### PR TITLE
feat: add lightweight data service api marketplace

### DIFF
--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -25,12 +25,14 @@ describe('permission-aware navigation', () => {
       'development',
       'workflow',
       'data-analysis',
+      'data-service',
     ]);
     expect(getMainNavigationGroups(batchRead).map((group) => group.id)).toEqual([
       'integration',
       'development',
       'workflow',
       'data-analysis',
+      'data-service',
     ]);
     expect(getQuickCreateRoutes(batchRead)).toEqual([]);
     expect(getQuickCreateRoutes([...batchRead, 'task:batch:create']).map((route) => route.id)).toEqual(['batch-link-up']);
@@ -45,12 +47,14 @@ describe('permission-aware navigation', () => {
       'resources',
       'data-quality',
       'data-analysis',
+      'data-service',
       'system',
     ]);
     expect(groups.map((group) => group.section)).toEqual([
       'task',
       'task',
       'task',
+      'management',
       'management',
       'management',
       'management',
@@ -71,6 +75,24 @@ describe('permission-aware navigation', () => {
     expect(getActiveNavigationId('/dashboard/new', [])).toBe('dashboard');
     expect(getActiveNavigationId('/dashboard/42', [])).toBe('dashboard');
     expect(getActiveNavigationId('/data-analysis/chart-analysis', [])).toBe('dashboard');
+  });
+
+  it('registers api marketplace, runtime overview and call logs as data-service pages', () => {
+    const dataService = getMainNavigationGroups([]).find((group) => group.id === 'data-service');
+    expect(dataService?.title).toBe('数据服务');
+    expect(dataService?.routes.map((route) => route.id)).toEqual([
+      'data-service-api',
+      'data-service-overview',
+      'data-service-logs',
+    ]);
+    expect(dataService?.routes.map((route) => route.title)).toEqual([
+      'API 集市',
+      '运行概览',
+      '调用记录',
+    ]);
+    expect(getActiveNavigationId('/data-service', [])).toBe('data-service-api');
+    expect(getActiveNavigationId('/data-service/overview', [])).toBe('data-service-overview');
+    expect(getActiveNavigationId('/data-service/logs', [])).toBe('data-service-logs');
   });
 
   it('registers home before other standalone navigation', () => {

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -45,8 +45,9 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'dashboard-viewer', path: '/dashboard/:id', title: '仪表盘查看', component: './dashboard/viewer', hidden: true, parentId: 'dashboard' },
   { id: 'data-analysis-catalog', mode: 'public', path: '/data-analysis/data-catalog', title: '数据目录', component: './data-analysis/data-catalog', iconKey: 'database', menuGroup: 'data-analysis', order: 20 },
   { id: 'data-analysis-chart', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis-redirect', hidden: true, parentId: 'dashboard' },
-  { id: 'data-service-api', mode: 'public', path: '/data-service', title: 'API 服务', component: './data-service', iconKey: 'api', menuGroup: 'data-service', order: 10 },
-  { id: 'data-service-logs', mode: 'public', path: '/data-service/logs', title: '调用记录', component: './data-service/logs', iconKey: 'report', menuGroup: 'data-service', order: 20 },
+  { id: 'data-service-api', mode: 'public', path: '/data-service', title: 'API 集市', component: './data-service', iconKey: 'api', menuGroup: 'data-service', order: 10 },
+  { id: 'data-service-overview', mode: 'public', path: '/data-service/overview', title: '运行概览', component: './data-service/overview', iconKey: 'monitor', menuGroup: 'data-service', order: 20 },
+  { id: 'data-service-logs', mode: 'public', path: '/data-service/logs', title: '调用记录', component: './data-service/logs', iconKey: 'report', menuGroup: 'data-service', order: 30 },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },
   {
     id: 'batch-link-up', mode: 'one', permission: 'task:batch:read',

--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Dropdown,
+  Empty,
   Input,
   Modal,
   Space,
@@ -12,11 +13,14 @@ import {
   type TableColumnsType,
 } from 'antd';
 import {
+  ArrowLeft,
   Copy,
   Eye,
+  Flame,
   MoreHorizontal,
   RefreshCw,
   Search,
+  Sparkles,
   Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -25,35 +29,91 @@ import {
   DATA_SERVICE_NODE_SOURCE,
   LEGACY_DATA_DEVELOPMENT_RELEASE_SOURCE,
   deleteDataService,
+  fetchDataServiceLogs,
   fetchDataServices,
   fetchDataSourceOptions,
   setDataServiceEnabled,
   type DataServiceApi,
+  type DataServiceCallLog,
   type DataSourceOption,
 } from './service';
+
+const timeValue = (value?: string) => {
+  if (!value) return 0;
+  const result = new Date(value).getTime();
+  return Number.isNaN(result) ? 0 : result;
+};
+
+interface ApiCardProps {
+  service: DataServiceApi;
+  dataSourceName: string;
+  calls?: number;
+  hot?: boolean;
+  onOpen: () => void;
+}
+
+const ApiCard = ({ service, dataSourceName, calls, hot, onOpen }: ApiCardProps) => (
+  <button
+    type="button"
+    onClick={onOpen}
+    className="group min-h-[148px] rounded-[6px] border border-[#e6e8eb] bg-white p-4 text-left transition-all hover:-translate-y-px hover:border-[#d9dde3] hover:shadow-[0_5px_18px_rgba(16,24,40,.06)]"
+  >
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-[14px] font-semibold text-[#161823]">{service.name}</span>
+          <Tag bordered={false}>GET</Tag>
+        </div>
+        <div className="mt-1.5 line-clamp-2 min-h-[36px] text-[12px] leading-[18px] text-[#7b808a]">
+          {service.description || '暂无能力说明'}
+        </div>
+      </div>
+      {hot ? (
+        <Flame size={16} strokeWidth={1.8} className="mt-0.5 shrink-0 text-[#98a2b3]" />
+      ) : (
+        <Sparkles size={16} strokeWidth={1.8} className="mt-0.5 shrink-0 text-[#98a2b3]" />
+      )}
+    </div>
+
+    <div className="mt-4 flex items-center justify-between gap-3 border-t border-[#f0f1f3] pt-3 text-[11px] text-[#98a2b3]">
+      <span className="min-w-0 flex-1 truncate font-mono" title={service.runtimePath}>
+        {service.runtimePath}
+      </span>
+      {calls !== undefined ? (
+        <span className="shrink-0">{calls} 次调用</span>
+      ) : (
+        <span className="max-w-[120px] shrink-0 truncate" title={dataSourceName}>{dataSourceName}</span>
+      )}
+    </div>
+  </button>
+);
 
 export default function DataServicePage() {
   const [services, setServices] = useState<DataServiceApi[]>([]);
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
+  const [logs, setLogs] = useState<DataServiceCallLog[]>([]);
   const [loading, setLoading] = useState(false);
   const [keyword, setKeyword] = useState('');
+  const [submittedKeyword, setSubmittedKeyword] = useState('');
   const [detailTarget, setDetailTarget] = useState<DataServiceApi>();
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [serviceResponse, dataSourceResponse] = await Promise.all([
+      const [serviceResponse, dataSourceResponse, logResponse] = await Promise.all([
         fetchDataServices(),
         fetchDataSourceOptions(),
+        fetchDataServiceLogs(),
       ]);
       const nextServices = serviceResponse.data || [];
       setServices(nextServices);
       setDataSources(dataSourceResponse.data || []);
+      setLogs(logResponse.data || []);
       setDetailTarget((current) => current
         ? nextServices.find((item) => item.id === current.id)
         : undefined);
     } catch (error: any) {
-      message.error(error?.message || '加载数据服务失败');
+      message.error(error?.message || '加载 API 集市失败');
     } finally {
       setLoading(false);
     }
@@ -61,20 +121,51 @@ export default function DataServicePage() {
 
   useEffect(() => { void load(); }, [load]);
 
-  const filtered = useMemo(() => {
-    const value = keyword.trim().toLowerCase();
-    if (!value) return services;
-    return services.filter((item) =>
-      [item.name, item.path, item.runtimePath, item.description, item.sourceRef]
-        .filter(Boolean)
-        .some((text) => String(text).toLowerCase().includes(value)));
-  }, [keyword, services]);
-
   const dataSourceName = useCallback((dataSourceId?: number) => {
     if (!dataSourceId) return '-';
     return dataSources.find((item) => String(item.value) === String(dataSourceId))?.label
       || `#${dataSourceId}`;
   }, [dataSources]);
+
+  const callsByApiId = useMemo(() => {
+    const result = new Map<number, number>();
+    logs.forEach((item) => result.set(item.apiId, (result.get(item.apiId) || 0) + 1));
+    return result;
+  }, [logs]);
+
+  const runningServices = useMemo(
+    () => services.filter((item) => item.enabled),
+    [services],
+  );
+
+  const recommendedServices = useMemo(() => {
+    const source = runningServices.length ? runningServices : services;
+    return [...source]
+      .sort((left, right) => timeValue(right.updateTime || right.createTime)
+        - timeValue(left.updateTime || left.createTime))
+      .slice(0, 6);
+  }, [runningServices, services]);
+
+  const hotServices = useMemo(() => services
+    .filter((item) => (callsByApiId.get(item.id) || 0) > 0)
+    .sort((left, right) => (callsByApiId.get(right.id) || 0) - (callsByApiId.get(left.id) || 0))
+    .slice(0, 6), [callsByApiId, services]);
+
+  const searchResults = useMemo(() => {
+    const value = submittedKeyword.trim().toLowerCase();
+    if (!value) return [];
+    return services.filter((item) =>
+      [
+        item.name,
+        item.path,
+        item.runtimePath,
+        item.description,
+        item.sourceRef,
+        dataSourceName(item.dataSourceId),
+      ]
+        .filter(Boolean)
+        .some((text) => String(text).toLowerCase().includes(value)));
+  }, [dataSourceName, services, submittedKeyword]);
 
   const remove = async (record: DataServiceApi) => {
     try {
@@ -90,7 +181,7 @@ export default function DataServicePage() {
   const confirmRemove = (record: DataServiceApi) => {
     Modal.confirm({
       title: '删除 API',
-      content: `确认删除「${record.name}」？API Key、Runtime 状态和相关文档也会一起移除。`,
+      content: `确认删除「${record.name}」？API Key、运行状态和相关文档也会一起移除。`,
       okText: '删除',
       okButtonProps: { danger: true },
       cancelText: '取消',
@@ -117,6 +208,20 @@ export default function DataServicePage() {
     }
   };
 
+  const submitSearch = () => {
+    const value = keyword.trim();
+    if (!value) {
+      setSubmittedKeyword('');
+      return;
+    }
+    setSubmittedKeyword(value);
+  };
+
+  const resetSearch = () => {
+    setKeyword('');
+    setSubmittedKeyword('');
+  };
+
   const columns: TableColumnsType<DataServiceApi> = [
     {
       title: 'API',
@@ -137,7 +242,7 @@ export default function DataServicePage() {
     {
       title: 'Endpoint',
       dataIndex: 'runtimePath',
-      minWidth: 300,
+      minWidth: 280,
       render: (value: string) => (
         <div className="flex items-center gap-1">
           <span className="truncate font-mono text-xs text-black/55">{value}</span>
@@ -155,15 +260,13 @@ export default function DataServicePage() {
     {
       title: '来源',
       key: 'source',
-      width: 220,
+      width: 210,
       render: (_, record) => {
         if (record.sourceType === DATA_SERVICE_NODE_SOURCE) {
           return (
             <div>
               <div className="font-medium text-[#475467]">Data Service · DS R{record.sourceRevisionNo || '-'}</div>
-              <div className="mt-1 text-[11px] text-black/35">
-                {dataSourceName(record.dataSourceId)} · Node #{record.sourceRef}
-              </div>
+              <div className="mt-1 text-[11px] text-black/35">{dataSourceName(record.dataSourceId)}</div>
             </div>
           );
         }
@@ -175,18 +278,19 @@ export default function DataServicePage() {
             </div>
           );
         }
-        return (
-          <div>
-            <Tag bordered={false}>Legacy</Tag>
-            <div className="mt-1 text-[11px] text-black/35">{dataSourceName(record.dataSourceId)}</div>
-          </div>
-        );
+        return <span className="text-black/45">{dataSourceName(record.dataSourceId)}</span>;
       },
+    },
+    {
+      title: '近期调用',
+      key: 'calls',
+      width: 100,
+      render: (_, record) => <span className="text-[#475467]">{callsByApiId.get(record.id) || 0}</span>,
     },
     {
       title: '状态',
       dataIndex: 'enabled',
-      width: 145,
+      width: 135,
       render: (enabled: boolean, record) => (
         <div className="flex items-center gap-2">
           <Switch
@@ -233,36 +337,135 @@ export default function DataServicePage() {
     },
   ];
 
+  const searchBox = (compact = false) => (
+    <Input.Search
+      allowClear
+      value={keyword}
+      loading={loading}
+      enterButton="搜索"
+      size={compact ? 'middle' : 'large'}
+      prefix={<Search size={compact ? 15 : 17} className="text-black/25" />}
+      placeholder="搜索 API 名称、Endpoint、能力描述或数据源"
+      onChange={(event) => {
+        setKeyword(event.target.value);
+        if (!event.target.value) setSubmittedKeyword('');
+      }}
+      onSearch={submitSearch}
+      className={compact ? 'max-w-[620px]' : 'w-full max-w-[680px]'}
+    />
+  );
+
+  const searching = Boolean(submittedKeyword.trim());
+
   return (
-    <div className="h-full bg-white px-6 py-5">
-      <div className="mb-5">
-        <h1 className="m-0 text-xl font-semibold text-[#161823]">API 服务</h1>
-        <p className="mb-0 mt-1 text-sm text-black/45">
-          管理已上线的 Data Service，查看启停、API Key、Runtime、OpenAPI 和调用记录。
-        </p>
-      </div>
+    <div className="h-full overflow-y-auto bg-white">
+      {searching ? (
+        <div className="px-6 py-5">
+          <div className="flex items-center gap-3 border-b border-[#eef0f2] pb-5">
+            <Button
+              type="text"
+              icon={<ArrowLeft size={16} />}
+              onClick={resetSearch}
+            >
+              API 集市
+            </Button>
+            <div className="min-w-0 flex-1">{searchBox(true)}</div>
+            <Button icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
+          </div>
 
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <Input
-          allowClear
-          value={keyword}
-          onChange={(event) => setKeyword(event.target.value)}
-          prefix={<Search size={15} className="text-black/30" />}
-          placeholder="搜索 API、Endpoint 或来源"
-          className="max-w-[340px]"
-        />
-        <Button icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
-      </div>
+          <div className="mb-3 mt-5 flex items-center justify-between gap-3">
+            <div>
+              <h1 className="m-0 text-[18px] font-semibold text-[#161823]">搜索结果</h1>
+              <div className="mt-1 text-[12px] text-[#98a2b3]">
+                “{submittedKeyword}” · 找到 {searchResults.length} 个 API
+              </div>
+            </div>
+          </div>
 
-      <Table<DataServiceApi>
-        rowKey="id"
-        size="small"
-        loading={loading}
-        dataSource={filtered}
-        columns={columns}
-        pagination={false}
-        scroll={{ x: 1050 }}
-      />
+          <Table<DataServiceApi>
+            rowKey="id"
+            size="small"
+            loading={loading}
+            dataSource={searchResults}
+            columns={columns}
+            pagination={false}
+            scroll={{ x: 1080 }}
+            locale={{ emptyText: '没有找到匹配的 API' }}
+          />
+        </div>
+      ) : (
+        <div className="mx-auto w-full max-w-[1240px] px-8 pb-12 pt-[9vh]">
+          <section className="flex flex-col items-center text-center">
+            <div className="text-[12px] font-medium tracking-[.18em] text-[#98a2b3]">YAK DATA SERVICE</div>
+            <h1 className="mb-0 mt-3 text-[28px] font-semibold tracking-[-.02em] text-[#161823]">API 集市</h1>
+            <p className="mb-0 mt-2 max-w-[560px] text-[13px] leading-6 text-[#7b808a]">
+              发现已经上线的数据 API，搜索能力、查看契约，并快速进入调试与调用配置。
+            </p>
+            <div className="mt-7 flex w-full justify-center">{searchBox()}</div>
+            <div className="mt-3 flex items-center gap-4 text-[11px] text-[#98a2b3]">
+              <span>{services.length} 个 API</span>
+              <span className="h-3 w-px bg-[#e4e7ec]" />
+              <span>{runningServices.length} 个运行中</span>
+              <span className="h-3 w-px bg-[#e4e7ec]" />
+              <button type="button" onClick={() => void load()} className="hover:text-[#475467]">刷新集市</button>
+            </div>
+          </section>
+
+          <section className="mt-14">
+            <div className="mb-4 flex items-center justify-between">
+              <div>
+                <div className="flex items-center gap-2 text-[14px] font-semibold text-[#30323b]">
+                  <Sparkles size={15} strokeWidth={1.8} className="text-[#667085]" />
+                  推荐 API
+                </div>
+                <div className="mt-1 text-[11px] text-[#98a2b3]">优先展示当前运行中的近期服务</div>
+              </div>
+            </div>
+            {recommendedServices.length ? (
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {recommendedServices.map((service) => (
+                  <ApiCard
+                    key={service.id}
+                    service={service}
+                    dataSourceName={dataSourceName(service.dataSourceId)}
+                    onOpen={() => setDetailTarget(service)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无已上线 API" />
+            )}
+          </section>
+
+          <section className="mt-12">
+            <div className="mb-4">
+              <div className="flex items-center gap-2 text-[14px] font-semibold text-[#30323b]">
+                <Flame size={15} strokeWidth={1.8} className="text-[#667085]" />
+                热门调用
+              </div>
+              <div className="mt-1 text-[11px] text-[#98a2b3]">基于最近调用记录统计，不额外引入计量服务</div>
+            </div>
+            {hotServices.length ? (
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {hotServices.map((service) => (
+                  <ApiCard
+                    key={service.id}
+                    hot
+                    service={service}
+                    dataSourceName={dataSourceName(service.dataSourceId)}
+                    calls={callsByApiId.get(service.id) || 0}
+                    onOpen={() => setDetailTarget(service)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-[6px] border border-dashed border-[#e4e7ec] px-5 py-8 text-center text-[12px] text-[#98a2b3]">
+                暂无调用数据，API 被调用后这里会自动形成热门排行
+              </div>
+            )}
+          </section>
+        </div>
+      )}
 
       <DataServiceDetailDrawer
         open={Boolean(detailTarget)}

--- a/yak-ops-ui/src/pages/data-service/overview/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/overview/index.tsx
@@ -1,0 +1,228 @@
+import { Button, Empty, Table, Tag, Tooltip, message, type TableColumnsType } from 'antd';
+import {
+  Activity,
+  AlertCircle,
+  CheckCircle2,
+  Gauge,
+  RefreshCw,
+  Server,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  fetchDataServiceLogs,
+  fetchDataServices,
+  type DataServiceApi,
+  type DataServiceCallLog,
+} from '../service';
+
+const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+
+const MetricCard = ({
+  label,
+  value,
+  note,
+  icon,
+}: {
+  label: string;
+  value: string | number;
+  note: string;
+  icon: React.ReactNode;
+}) => (
+  <div className="rounded-[6px] border border-[#e6e8eb] bg-white px-4 py-4">
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <div className="text-[11px] text-[#98a2b3]">{label}</div>
+        <div className="mt-2 text-[24px] font-semibold tracking-[-.02em] text-[#1d2939]">{value}</div>
+      </div>
+      <div className="flex h-8 w-8 items-center justify-center rounded-[5px] bg-[#f6f7f8] text-[#667085]">
+        {icon}
+      </div>
+    </div>
+    <div className="mt-2 text-[11px] text-[#98a2b3]">{note}</div>
+  </div>
+);
+
+export default function DataServiceOverviewPage() {
+  const [services, setServices] = useState<DataServiceApi[]>([]);
+  const [logs, setLogs] = useState<DataServiceCallLog[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [serviceResponse, logResponse] = await Promise.all([
+        fetchDataServices(),
+        fetchDataServiceLogs(),
+      ]);
+      setServices(serviceResponse.data || []);
+      setLogs(logResponse.data || []);
+    } catch (error: any) {
+      message.error(error?.message || '加载数据服务运行概览失败');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const successCalls = useMemo(() => logs.filter((item) => item.success).length, [logs]);
+  const failureCalls = logs.length - successCalls;
+  const successRate = logs.length ? Math.round((successCalls / logs.length) * 1000) / 10 : 0;
+  const averageDuration = logs.length
+    ? Math.round(logs.reduce((sum, item) => sum + (item.durationMs || 0), 0) / logs.length)
+    : 0;
+  const runningServices = services.filter((item) => item.enabled).length;
+
+  const hotApis = useMemo(() => {
+    const counts = new Map<number, { calls: number; success: number; duration: number }>();
+    logs.forEach((item) => {
+      const current = counts.get(item.apiId) || { calls: 0, success: 0, duration: 0 };
+      current.calls += 1;
+      current.success += item.success ? 1 : 0;
+      current.duration += item.durationMs || 0;
+      counts.set(item.apiId, current);
+    });
+
+    return services
+      .map((service) => ({ service, stats: counts.get(service.id) }))
+      .filter((item): item is { service: DataServiceApi; stats: { calls: number; success: number; duration: number } } => Boolean(item.stats))
+      .sort((left, right) => right.stats.calls - left.stats.calls)
+      .slice(0, 8);
+  }, [logs, services]);
+
+  const maxCalls = hotApis[0]?.stats.calls || 1;
+  const recentFailures = useMemo(
+    () => logs.filter((item) => !item.success).slice(0, 8),
+    [logs],
+  );
+
+  const failureColumns: TableColumnsType<DataServiceCallLog> = [
+    {
+      title: 'API',
+      dataIndex: 'serviceName',
+      minWidth: 180,
+      render: (_, record) => (
+        <div>
+          <div className="font-medium text-[#344054]">{record.serviceName}</div>
+          <div className="mt-0.5 truncate font-mono text-[10px] text-[#98a2b3]">{record.servicePath}</div>
+        </div>
+      ),
+    },
+    { title: '耗时', dataIndex: 'durationMs', width: 90, render: (value) => `${value || 0} ms` },
+    {
+      title: '错误',
+      dataIndex: 'errorMessage',
+      ellipsis: true,
+      render: (value) => value
+        ? <Tooltip title={value}><span className="text-[#b42318]">{value}</span></Tooltip>
+        : <span className="text-[#98a2b3]">未知错误</span>,
+    },
+    { title: '时间', dataIndex: 'createTime', width: 160, render: formatTime },
+  ];
+
+  return (
+    <div className="h-full overflow-y-auto bg-[#fafafa] px-6 py-5">
+      <div className="mx-auto max-w-[1280px]">
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="m-0 text-xl font-semibold text-[#161823]">运行概览</h1>
+            <p className="mb-0 mt-1 text-sm text-black/45">
+              基于当前 API 状态和最近 200 条调用记录做轻量统计，不额外引入计量平台。
+            </p>
+          </div>
+          <Button loading={loading} icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
+          <MetricCard
+            label="API 总数"
+            value={services.length}
+            note={`${runningServices} 个运行中`}
+            icon={<Server size={16} strokeWidth={1.8} />}
+          />
+          <MetricCard
+            label="近期调用"
+            value={logs.length}
+            note="最近调用记录窗口"
+            icon={<Activity size={16} strokeWidth={1.8} />}
+          />
+          <MetricCard
+            label="成功率"
+            value={`${successRate}%`}
+            note={`${successCalls} 成功 / ${failureCalls} 失败`}
+            icon={<CheckCircle2 size={16} strokeWidth={1.8} />}
+          />
+          <MetricCard
+            label="平均耗时"
+            value={`${averageDuration} ms`}
+            note="基于近期调用计算"
+            icon={<Gauge size={16} strokeWidth={1.8} />}
+          />
+          <MetricCard
+            label="失败调用"
+            value={failureCalls}
+            note="建议优先查看异常 API"
+            icon={<AlertCircle size={16} strokeWidth={1.8} />}
+          />
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(480px,1.25fr)]">
+          <section className="rounded-[6px] border border-[#e6e8eb] bg-white p-5">
+            <div className="mb-4">
+              <div className="text-[14px] font-semibold text-[#30323b]">热门 API</div>
+              <div className="mt-1 text-[11px] text-[#98a2b3]">按最近调用次数排序</div>
+            </div>
+
+            {hotApis.length ? (
+              <div className="space-y-4">
+                {hotApis.map(({ service, stats }, index) => {
+                  const rate = stats.calls ? Math.round((stats.success / stats.calls) * 1000) / 10 : 0;
+                  const average = stats.calls ? Math.round(stats.duration / stats.calls) : 0;
+                  return (
+                    <div key={service.id}>
+                      <div className="flex items-center justify-between gap-4 text-[12px]">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <span className="w-4 shrink-0 text-[10px] text-[#98a2b3]">{index + 1}</span>
+                          <span className="truncate font-medium text-[#344054]">{service.name}</span>
+                          {!service.enabled ? <Tag bordered={false}>已停用</Tag> : null}
+                        </div>
+                        <div className="shrink-0 text-[11px] text-[#98a2b3]">
+                          {stats.calls} 次 · {rate}% · {average} ms
+                        </div>
+                      </div>
+                      <div className="ml-6 mt-2 h-1.5 overflow-hidden rounded-full bg-[#f0f2f4]">
+                        <div
+                          className="h-full rounded-full bg-[#667085]"
+                          style={{ width: `${Math.max(4, (stats.calls / maxCalls) * 100)}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无调用数据" />
+            )}
+          </section>
+
+          <section className="rounded-[6px] border border-[#e6e8eb] bg-white p-5">
+            <div className="mb-4">
+              <div className="text-[14px] font-semibold text-[#30323b]">最近失败</div>
+              <div className="mt-1 text-[11px] text-[#98a2b3]">快速发现需要处理的调用异常</div>
+            </div>
+            <Table<DataServiceCallLog>
+              rowKey="id"
+              size="small"
+              loading={loading}
+              pagination={false}
+              dataSource={recentFailures}
+              columns={failureColumns}
+              scroll={{ x: 680 }}
+              locale={{ emptyText: '近期没有失败调用' }}
+            />
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 背景

参考 DataWorks 的数据服务管理能力重新梳理 Yak Ops v1 后，这一轮不照搬完整的 API 管理 / API 测试 / API 调用 / 计量体系，而是只补当前已有底座能够真实支撑的能力。

最终将数据服务收成三个入口：

```text
API 集市
运行概览
调用记录
```

其中：

- API 测试继续使用现有 API 详情里的 OpenAPI / 在线调试
- API 调用认证继续使用现有 API Key
- 不单独造 API 测试、API 调用认证页面
- 不新增复杂计量、网关、SDK 或 Metrics 基础设施

## 1. API 服务改为 API 集市

`/data-service` 从管理表格首页改成 API discovery 首页。

默认状态：

```text
              API 集市

       [ 搜索 API 能力................ ]

推荐 API
┌────────┐ ┌────────┐ ┌────────┐
│ API A  │ │ API B  │ │ API C  │
└────────┘ └────────┘ └────────┘

热门调用
┌────────┐ ┌────────┐ ┌────────┐
│ API D  │ │ API E  │ │ API F  │
└────────┘ └────────┘ └────────┘
```

### 推荐 API

- 优先展示当前运行中的 API
- 按最近更新时间排序
- 展示 API 名称、能力说明、Endpoint、数据源
- 点击卡片直接打开现有 API Detail Drawer

### 热门调用

- 直接基于现有 `logs/recent` 调用记录统计
- 按最近调用次数排序
- 不引入假的计量数据和新的 Metrics 后端

## 2. 搜索后搜索框上移 + 结果列表

默认大搜索框提交后，页面切换成结果模式：

```text
← API 集市    [ 搜索框........................ ]   刷新
────────────────────────────────────────────────
搜索结果 · N 个 API

API | Endpoint | 来源 | 近期调用 | 状态 | 操作
```

搜索范围包括：

- API 名称
- Endpoint / Path
- 描述
- 来源
- 数据源名称

清空搜索或点击「API 集市」返回 discovery 首页。

## 3. 新增轻量运行概览

新增 `/data-service/overview`。

第一版不做 DataWorks 那种完整计量中心，只使用已有 API 状态与最近 200 条调用记录形成真实轻量统计：

- API 总数 / 运行中数量
- 近期调用数
- 成功率
- 平均耗时
- 失败调用数
- 热门 API Top 8
- 最近失败调用

热门 API 同时展示：

- 最近调用次数
- 成功率
- 平均耗时

这样先把“整体运行情况”做出来，将来有正式 Metrics API 时只替换数据来源即可，不需要推翻页面结构。

## 4. 数据服务导航收口

菜单调整为：

```text
数据服务
├── API 集市
├── 运行概览
└── 调用记录
```

并补充 navigation test 覆盖路由顺序和 active route。

## 5. 当前不做的 DataWorks 能力

这一版明确不新增：

- 独立 API 测试页面（现有 OpenAPI / 在线调试已覆盖）
- 独立 API 调用认证页（现有 API Key 已覆盖）
- 计量大屏完整体系
- 计费 / 资源组计量
- API Gateway 管理
- AppCode / AppKey / AppSecret 新认证模型
- SDK 生成
- 新 Metrics / Observability 后端

保持 Yak Ops v1 轻量。

## 变更范围

最终 diff：**1 commit / 4 frontend files**

- `yak-ops-ui/src/pages/data-service/index.tsx`
- `yak-ops-ui/src/pages/data-service/overview/index.tsx`（新增）
- `yak-ops-ui/src/config/navigation.ts`
- `yak-ops-ui/src/config/navigation.test.ts`

不修改后端、数据库、Data Service Runtime 或发布生命周期。

## 检查

- 分支基于已合并 #436 的最新 `main`
- compare 已确认 `ahead=1 / behind=0`
- 已核对现有 `fetchDataServices()`、`fetchDataServiceLogs()` 和数据源 Option API，可直接支撑集市与轻量概览
- 已补导航测试
- 当前执行环境 DNS 无法 clone GitHub，因此未声称完整 npm / TypeScript project build 已通过；继续以 GitHub reported checks 为准

核心目标：**数据开发负责把 API 做出来；数据服务负责让 API 更容易被发现、使用和观察。**