### PR TITLE
feat: rebuild data service runtime overview

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceOverviewController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceOverviewController.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.dataservice.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.dataservice.service.DataServiceOverviewService;
+import io.yak.ops.business.dataservice.service.DataServiceOverviewService.Overview;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 数据服务运行概览聚合接口。 */
+@Tag(name = "数据服务")
+@RestController
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/data-service/overview")
+public class DataServiceOverviewController {
+
+  private final DataServiceOverviewService overviewService;
+
+  @Operation(summary = "查询数据服务运行概览")
+  @GetMapping
+  public Result<Overview> overview(
+      @RequestParam(value = "range", defaultValue = "24h") String range) {
+    return Result.success(overviewService.overview(range));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceOverviewService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceOverviewService.java
@@ -1,0 +1,307 @@
+package io.yak.ops.business.dataservice.service;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceApiMapper;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceCallLogMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
+import io.yak.ops.business.dataservice.dao.model.DataServiceCallLogPO;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Lightweight runtime overview aggregated from existing API definitions and invocation logs. */
+@Service
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataServiceOverviewService {
+
+  private static final int HOT_API_LIMIT = 8;
+  private static final int FAILURE_LIMIT = 8;
+
+  private final DataServiceApiMapper apiMapper;
+  private final DataServiceCallLogMapper callLogMapper;
+
+  public Overview overview(String range) {
+    return overviewAt(range, LocalDateTime.now());
+  }
+
+  Overview overviewAt(String range, LocalDateTime now) {
+    RangeWindow window = RangeWindow.of(range, now);
+    List<DataServiceApiPO> apis = apiMapper.selectList(
+        Wrappers.<DataServiceApiPO>lambdaQuery()
+            .select(
+                DataServiceApiPO::getId,
+                DataServiceApiPO::getName,
+                DataServiceApiPO::getPath,
+                DataServiceApiPO::getEnabled)
+            .orderByAsc(DataServiceApiPO::getId));
+
+    List<DataServiceCallLogPO> logs = callLogMapper.selectList(
+        Wrappers.<DataServiceCallLogPO>lambdaQuery()
+            .select(
+                DataServiceCallLogPO::getId,
+                DataServiceCallLogPO::getApiId,
+                DataServiceCallLogPO::getServiceName,
+                DataServiceCallLogPO::getServicePath,
+                DataServiceCallLogPO::getSuccess,
+                DataServiceCallLogPO::getDurationMs,
+                DataServiceCallLogPO::getRowCount,
+                DataServiceCallLogPO::getErrorMessage,
+                DataServiceCallLogPO::getCreateTime)
+            .ge(DataServiceCallLogPO::getCreateTime, window.startTime())
+            .le(DataServiceCallLogPO::getCreateTime, now)
+            .orderByAsc(DataServiceCallLogPO::getCreateTime)
+            .orderByAsc(DataServiceCallLogPO::getId));
+
+    long runningApis = apis.stream().filter(api -> Boolean.TRUE.equals(api.getEnabled())).count();
+    long totalCalls = logs.size();
+    long successCalls = 0;
+    long totalDuration = 0;
+    long totalRows = 0;
+
+    List<MutableTrendPoint> trend = createTrend(window);
+    Map<Long, MutableApiStats> apiStats = new LinkedHashMap<>();
+
+    for (DataServiceCallLogPO log : logs) {
+      boolean success = Boolean.TRUE.equals(log.getSuccess());
+      long duration = safeLong(log.getDurationMs());
+      int rows = safeInt(log.getRowCount());
+      if (success) successCalls++;
+      totalDuration += duration;
+      totalRows += rows;
+
+      int bucketIndex = window.bucketIndex(log.getCreateTime());
+      if (bucketIndex >= 0 && bucketIndex < trend.size()) {
+        trend.get(bucketIndex).accept(success, duration);
+      }
+
+      if (log.getApiId() != null) {
+        apiStats
+            .computeIfAbsent(log.getApiId(), ignored -> new MutableApiStats(log))
+            .accept(log, success, duration);
+      }
+    }
+
+    long failureCalls = totalCalls - successCalls;
+    long averageDurationMs = totalCalls == 0 ? 0 : Math.round((double) totalDuration / totalCalls);
+    double successRate = percent(successCalls, totalCalls);
+
+    Map<Long, DataServiceApiPO> apiById = new LinkedHashMap<>();
+    for (DataServiceApiPO api : apis) {
+      if (api.getId() != null) apiById.put(api.getId(), api);
+    }
+
+    List<HotApi> hotApis = apiStats.entrySet().stream()
+        .sorted((left, right) -> Long.compare(right.getValue().calls, left.getValue().calls))
+        .limit(HOT_API_LIMIT)
+        .map(entry -> entry.getValue().toHotApi(entry.getKey(), apiById.get(entry.getKey())))
+        .toList();
+
+    List<FailureItem> recentFailures = logs.stream()
+        .filter(log -> !Boolean.TRUE.equals(log.getSuccess()))
+        .sorted(Comparator
+            .comparing(DataServiceCallLogPO::getCreateTime, Comparator.nullsLast(Comparator.naturalOrder()))
+            .reversed())
+        .limit(FAILURE_LIMIT)
+        .map(FailureItem::from)
+        .toList();
+
+    return new Overview(
+        window.range(),
+        window.startTime(),
+        now,
+        apis.size(),
+        runningApis,
+        apis.size() - runningApis,
+        totalCalls,
+        successCalls,
+        failureCalls,
+        successRate,
+        averageDurationMs,
+        totalRows,
+        trend.stream().map(MutableTrendPoint::toView).toList(),
+        hotApis,
+        recentFailures);
+  }
+
+  private List<MutableTrendPoint> createTrend(RangeWindow window) {
+    List<MutableTrendPoint> points = new ArrayList<>(window.bucketCount());
+    for (int index = 0; index < window.bucketCount(); index++) {
+      LocalDateTime time = window.startTime().plusHours((long) index * window.bucketHours());
+      points.add(new MutableTrendPoint(window.label(time)));
+    }
+    return points;
+  }
+
+  private static long safeLong(Long value) {
+    return value == null ? 0L : Math.max(0L, value);
+  }
+
+  private static int safeInt(Integer value) {
+    return value == null ? 0 : Math.max(0, value);
+  }
+
+  private static double percent(long numerator, long denominator) {
+    if (denominator <= 0) return 0D;
+    return Math.round((numerator * 1000D) / denominator) / 10D;
+  }
+
+  public record Overview(
+      String range,
+      LocalDateTime startTime,
+      LocalDateTime endTime,
+      long apiTotal,
+      long runningApis,
+      long stoppedApis,
+      long totalCalls,
+      long successCalls,
+      long failureCalls,
+      double successRate,
+      long averageDurationMs,
+      long totalRows,
+      List<TrendPoint> trend,
+      List<HotApi> hotApis,
+      List<FailureItem> recentFailures) {}
+
+  public record TrendPoint(
+      String time,
+      long calls,
+      long successCalls,
+      long failureCalls,
+      long averageDurationMs) {}
+
+  public record HotApi(
+      Long apiId,
+      String name,
+      String path,
+      long calls,
+      double successRate,
+      long averageDurationMs) {}
+
+  public record FailureItem(
+      Long id,
+      Long apiId,
+      String serviceName,
+      String servicePath,
+      long durationMs,
+      String errorMessage,
+      LocalDateTime createTime) {
+
+    private static FailureItem from(DataServiceCallLogPO log) {
+      return new FailureItem(
+          log.getId(),
+          log.getApiId(),
+          log.getServiceName(),
+          log.getServicePath(),
+          safeLong(log.getDurationMs()),
+          log.getErrorMessage(),
+          log.getCreateTime());
+    }
+  }
+
+  private static final class MutableTrendPoint {
+    private final String time;
+    private long calls;
+    private long successCalls;
+    private long failureCalls;
+    private long totalDuration;
+
+    private MutableTrendPoint(String time) {
+      this.time = time;
+    }
+
+    private void accept(boolean success, long duration) {
+      calls++;
+      if (success) successCalls++;
+      else failureCalls++;
+      totalDuration += duration;
+    }
+
+    private TrendPoint toView() {
+      long average = calls == 0 ? 0 : Math.round((double) totalDuration / calls);
+      return new TrendPoint(time, calls, successCalls, failureCalls, average);
+    }
+  }
+
+  private static final class MutableApiStats {
+    private String name;
+    private String path;
+    private long calls;
+    private long successCalls;
+    private long totalDuration;
+
+    private MutableApiStats(DataServiceCallLogPO first) {
+      this.name = first.getServiceName();
+      this.path = first.getServicePath();
+    }
+
+    private void accept(DataServiceCallLogPO log, boolean success, long duration) {
+      calls++;
+      if (success) successCalls++;
+      totalDuration += duration;
+      if (log.getServiceName() != null) name = log.getServiceName();
+      if (log.getServicePath() != null) path = log.getServicePath();
+    }
+
+    private HotApi toHotApi(Long apiId, DataServiceApiPO current) {
+      String currentName = current != null && current.getName() != null ? current.getName() : name;
+      String currentPath = current != null && current.getPath() != null ? current.getPath() : path;
+      long average = calls == 0 ? 0 : Math.round((double) totalDuration / calls);
+      return new HotApi(apiId, currentName, currentPath, calls, percent(successCalls, calls), average);
+    }
+  }
+
+  private record RangeWindow(
+      String range,
+      LocalDateTime startTime,
+      int bucketHours,
+      int bucketCount,
+      DateTimeFormatter labelFormatter) {
+
+    private static RangeWindow of(String raw, LocalDateTime now) {
+      String range = raw == null || raw.isBlank() ? "24h" : raw.trim().toLowerCase();
+      return switch (range) {
+        case "24h" -> create("24h", now, 1, 24, DateTimeFormatter.ofPattern("HH:mm"));
+        case "7d" -> create("7d", now, 6, 28, DateTimeFormatter.ofPattern("MM-dd HH:mm"));
+        case "30d" -> create("30d", now, 24, 30, DateTimeFormatter.ofPattern("MM-dd"));
+        default -> throw new IllegalArgumentException("运行概览时间范围仅支持 24h、7d、30d");
+      };
+    }
+
+    private static RangeWindow create(
+        String range,
+        LocalDateTime now,
+        int bucketHours,
+        int bucketCount,
+        DateTimeFormatter formatter) {
+      LocalDateTime aligned;
+      if (bucketHours >= 24) {
+        aligned = now.toLocalDate().atStartOfDay();
+      } else {
+        int hour = (now.getHour() / bucketHours) * bucketHours;
+        aligned = now.withHour(hour).withMinute(0).withSecond(0).withNano(0);
+      }
+      LocalDateTime endBoundary = aligned.plusHours(bucketHours);
+      LocalDateTime start = endBoundary.minusHours((long) bucketHours * bucketCount);
+      return new RangeWindow(range, start, bucketHours, bucketCount, formatter);
+    }
+
+    private int bucketIndex(LocalDateTime time) {
+      if (time == null || time.isBefore(startTime)) return -1;
+      long minutes = Duration.between(startTime, time).toMinutes();
+      return (int) (minutes / (bucketHours * 60L));
+    }
+
+    private String label(LocalDateTime time) {
+      return labelFormatter.format(time);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServiceOverviewServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServiceOverviewServiceTest.java
@@ -1,0 +1,98 @@
+package io.yak.ops.business.dataservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceApiMapper;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceCallLogMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceApiPO;
+import io.yak.ops.business.dataservice.dao.model.DataServiceCallLogPO;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataServiceOverviewServiceTest {
+
+  @Test
+  void overviewAggregatesStatusTrendHotApiAndFailures() {
+    DataServiceApiMapper apiMapper = mock(DataServiceApiMapper.class);
+    DataServiceCallLogMapper logMapper = mock(DataServiceCallLogMapper.class);
+    DataServiceOverviewService service = new DataServiceOverviewService(apiMapper, logMapper);
+    LocalDateTime now = LocalDateTime.of(2026, 8, 16, 17, 30);
+
+    when(apiMapper.selectList(any())).thenReturn(List.of(
+        api(1L, "订单查询", "/orders", true),
+        api(2L, "用户查询", "/users", true),
+        api(3L, "历史查询", "/history", false)));
+    when(logMapper.selectList(any())).thenReturn(List.of(
+        log(1L, 1L, "订单查询", "/orders", true, 100L, 5, null, now.minusHours(1)),
+        log(2L, 1L, "订单查询", "/orders", false, 200L, 0, "datasource timeout", now.minusMinutes(55)),
+        log(3L, 2L, "用户查询", "/users", true, 300L, 10, null, now.minusMinutes(10))));
+
+    DataServiceOverviewService.Overview overview = service.overviewAt("24h", now);
+
+    assertThat(overview.apiTotal()).isEqualTo(3);
+    assertThat(overview.runningApis()).isEqualTo(2);
+    assertThat(overview.stoppedApis()).isEqualTo(1);
+    assertThat(overview.totalCalls()).isEqualTo(3);
+    assertThat(overview.successCalls()).isEqualTo(2);
+    assertThat(overview.failureCalls()).isEqualTo(1);
+    assertThat(overview.successRate()).isEqualTo(66.7D);
+    assertThat(overview.averageDurationMs()).isEqualTo(200);
+    assertThat(overview.totalRows()).isEqualTo(15);
+    assertThat(overview.trend()).hasSize(24);
+    assertThat(overview.trend().stream().mapToLong(DataServiceOverviewService.TrendPoint::calls).sum())
+        .isEqualTo(3);
+    assertThat(overview.hotApis()).hasSize(2);
+    assertThat(overview.hotApis().get(0).apiId()).isEqualTo(1L);
+    assertThat(overview.hotApis().get(0).calls()).isEqualTo(2);
+    assertThat(overview.recentFailures()).hasSize(1);
+    assertThat(overview.recentFailures().get(0).errorMessage()).isEqualTo("datasource timeout");
+  }
+
+  @Test
+  void overviewRejectsUnsupportedRange() {
+    DataServiceOverviewService service = new DataServiceOverviewService(
+        mock(DataServiceApiMapper.class),
+        mock(DataServiceCallLogMapper.class));
+
+    assertThatThrownBy(() -> service.overviewAt("90d", LocalDateTime.of(2026, 8, 16, 17, 30)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("24h、7d、30d");
+  }
+
+  private DataServiceApiPO api(Long id, String name, String path, boolean enabled) {
+    DataServiceApiPO api = new DataServiceApiPO();
+    api.setId(id);
+    api.setName(name);
+    api.setPath(path);
+    api.setEnabled(enabled);
+    return api;
+  }
+
+  private DataServiceCallLogPO log(
+      Long id,
+      Long apiId,
+      String name,
+      String path,
+      boolean success,
+      long duration,
+      int rows,
+      String error,
+      LocalDateTime time) {
+    DataServiceCallLogPO log = new DataServiceCallLogPO();
+    log.setId(id);
+    log.setApiId(apiId);
+    log.setServiceName(name);
+    log.setServicePath(path);
+    log.setSuccess(success);
+    log.setDurationMs(duration);
+    log.setRowCount(rows);
+    log.setErrorMessage(error);
+    log.setCreateTime(time);
+    return log;
+  }
+}

--- a/yak-ops-ui/src/pages/data-service/overview/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/overview/index.tsx
@@ -1,226 +1,436 @@
-import { Button, Empty, Table, Tag, Tooltip, message, type TableColumnsType } from 'antd';
-import {
-  Activity,
-  AlertCircle,
-  CheckCircle2,
-  Gauge,
-  RefreshCw,
-  Server,
-} from 'lucide-react';
+import { Button, Empty, Table, Tooltip, message, type TableColumnsType } from 'antd';
+import type { EChartsOption } from 'echarts';
+import ReactECharts from 'echarts-for-react';
+import { RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  fetchDataServiceLogs,
-  fetchDataServices,
-  type DataServiceApi,
-  type DataServiceCallLog,
-} from '../service';
+  fetchDataServiceOverview,
+  type DataServiceOverview,
+  type DataServiceOverviewFailure,
+  type DataServiceOverviewRange,
+} from './overview-service';
 
-const formatTime = (value?: string) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+const BRAND_COLOR = 'rgba(254,44,85,1)';
+const TEXT_PRIMARY = '#161823';
+const TEXT_SECONDARY = '#667085';
+const TEXT_WEAK = '#98a2b3';
+const BORDER = '#f0f0f0';
 
-const MetricCard = ({
-  label,
-  value,
-  note,
-  icon,
+const formatTime = (value?: string | null) => value ? value.replace('T', ' ').slice(0, 19) : '-';
+const formatNumber = (value?: number) => new Intl.NumberFormat('zh-CN').format(value || 0);
+
+const RANGE_ITEMS: Array<{ value: DataServiceOverviewRange; label: string }> = [
+  { value: '24h', label: '24 小时' },
+  { value: '7d', label: '7 天' },
+  { value: '30d', label: '30 天' },
+];
+
+const emptyOverview = (range: DataServiceOverviewRange): DataServiceOverview => ({
+  range,
+  startTime: '',
+  endTime: '',
+  apiTotal: 0,
+  runningApis: 0,
+  stoppedApis: 0,
+  totalCalls: 0,
+  successCalls: 0,
+  failureCalls: 0,
+  successRate: 0,
+  averageDurationMs: 0,
+  totalRows: 0,
+  trend: [],
+  hotApis: [],
+  recentFailures: [],
+});
+
+const Panel = ({
+  title,
+  subtitle,
+  children,
+  className = '',
 }: {
-  label: string;
-  value: string | number;
-  note: string;
-  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  className?: string;
 }) => (
-  <div className="rounded-[6px] border border-[#e6e8eb] bg-white px-4 py-4">
-    <div className="flex items-start justify-between gap-3">
-      <div>
-        <div className="text-[11px] text-[#98a2b3]">{label}</div>
-        <div className="mt-2 text-[24px] font-semibold tracking-[-.02em] text-[#1d2939]">{value}</div>
-      </div>
-      <div className="flex h-8 w-8 items-center justify-center rounded-[5px] bg-[#f6f7f8] text-[#667085]">
-        {icon}
+  <section className={`rounded-[8px] border border-[#f0f0f0] bg-white ${className}`}>
+    <div className="flex min-h-[48px] items-center justify-between border-b border-[#f3f4f5] px-4">
+      <div className="min-w-0">
+        <div className="text-[13px] font-semibold text-[#30323b]">{title}</div>
+        {subtitle ? <div className="mt-0.5 text-[10px] text-[#a0a5ad]">{subtitle}</div> : null}
       </div>
     </div>
-    <div className="mt-2 text-[11px] text-[#98a2b3]">{note}</div>
+    {children}
+  </section>
+);
+
+const DonutPanel = ({
+  title,
+  subtitle,
+  total,
+  items,
+}: {
+  title: string;
+  subtitle: string;
+  total: number;
+  items: Array<{ name: string; value: number; color: string }>;
+}) => {
+  const option: EChartsOption = {
+    animationDuration: 350,
+    tooltip: {
+      trigger: 'item',
+      backgroundColor: '#fff',
+      borderColor: '#e4e7ec',
+      textStyle: { color: '#475467', fontSize: 11 },
+      formatter: '{b}<br/>{c} ({d}%)',
+    },
+    series: [
+      {
+        type: 'pie',
+        radius: ['60%', '78%'],
+        center: ['50%', '49%'],
+        silent: false,
+        avoidLabelOverlap: true,
+        label: { show: false },
+        labelLine: { show: false },
+        emphasis: { scale: false },
+        itemStyle: { borderColor: '#fff', borderWidth: 2 },
+        data: items.map((item) => ({
+          name: item.name,
+          value: item.value,
+          itemStyle: { color: item.color },
+        })),
+      },
+    ],
+  };
+
+  return (
+    <Panel title={title} subtitle={subtitle}>
+      <div className="px-4 pb-3 pt-2">
+        <div className="relative h-[148px]">
+          <ReactECharts option={option} style={{ height: 148 }} notMerge lazyUpdate />
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center pt-1">
+            <div className="text-[22px] font-semibold tracking-[-.02em] text-[#161823]">{formatNumber(total)}</div>
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">总计</div>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-2 border-t border-[#f3f4f5] pt-3">
+          {items.map((item) => (
+            <div key={item.name} className="flex min-w-0 items-center justify-between gap-2 text-[11px]">
+              <div className="flex min-w-0 items-center gap-1.5 text-[#667085]">
+                <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: item.color }} />
+                <span className="truncate">{item.name}</span>
+              </div>
+              <span className="shrink-0 font-medium text-[#344054]">{formatNumber(item.value)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Panel>
+  );
+};
+
+const MetricCell = ({ label, value, note }: { label: string; value: string; note: string }) => (
+  <div className="min-w-0 px-4 py-4">
+    <div className="text-[10px] text-[#98a2b3]">{label}</div>
+    <div className="mt-1.5 truncate text-[22px] font-semibold tracking-[-.02em] text-[#161823]">{value}</div>
+    <div className="mt-1 truncate text-[10px] text-[#a0a5ad]">{note}</div>
   </div>
 );
 
 export default function DataServiceOverviewPage() {
-  const [services, setServices] = useState<DataServiceApi[]>([]);
-  const [logs, setLogs] = useState<DataServiceCallLog[]>([]);
+  const [range, setRange] = useState<DataServiceOverviewRange>('24h');
+  const [overview, setOverview] = useState<DataServiceOverview>(() => emptyOverview('24h'));
   const [loading, setLoading] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [serviceResponse, logResponse] = await Promise.all([
-        fetchDataServices(),
-        fetchDataServiceLogs(),
-      ]);
-      setServices(serviceResponse.data || []);
-      setLogs(logResponse.data || []);
+      const response = await fetchDataServiceOverview(range);
+      setOverview(response.data || emptyOverview(range));
     } catch (error: any) {
       message.error(error?.message || '加载数据服务运行概览失败');
+      setOverview(emptyOverview(range));
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [range]);
 
   useEffect(() => { void load(); }, [load]);
 
-  const successCalls = useMemo(() => logs.filter((item) => item.success).length, [logs]);
-  const failureCalls = logs.length - successCalls;
-  const successRate = logs.length ? Math.round((successCalls / logs.length) * 1000) / 10 : 0;
-  const averageDuration = logs.length
-    ? Math.round(logs.reduce((sum, item) => sum + (item.durationMs || 0), 0) / logs.length)
-    : 0;
-  const runningServices = services.filter((item) => item.enabled).length;
+  const trendOption = useMemo<EChartsOption>(() => ({
+    animationDuration: 350,
+    color: ['#344054', BRAND_COLOR, '#98a2b3'],
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#fff',
+      borderColor: '#e4e7ec',
+      padding: [8, 10],
+      textStyle: { color: '#475467', fontSize: 11 },
+    },
+    legend: {
+      top: 0,
+      right: 4,
+      itemWidth: 14,
+      itemHeight: 7,
+      textStyle: { color: TEXT_SECONDARY, fontSize: 10 },
+      data: ['总调用', '失败调用', '平均耗时'],
+    },
+    grid: { left: 44, right: 54, top: 44, bottom: 30, containLabel: false },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: overview.trend.map((item) => item.time),
+      axisTick: { show: false },
+      axisLine: { lineStyle: { color: '#e4e7ec' } },
+      axisLabel: { color: TEXT_WEAK, fontSize: 9, hideOverlap: true, margin: 11 },
+    },
+    yAxis: [
+      {
+        type: 'value',
+        minInterval: 1,
+        axisLabel: { color: TEXT_WEAK, fontSize: 9 },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: { lineStyle: { color: '#f2f4f7' } },
+      },
+      {
+        type: 'value',
+        axisLabel: { color: TEXT_WEAK, fontSize: 9, formatter: '{value} ms' },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: { show: false },
+      },
+    ],
+    series: [
+      {
+        name: '总调用',
+        type: 'line',
+        smooth: 0.25,
+        symbol: 'none',
+        lineStyle: { width: 2, color: '#344054' },
+        areaStyle: { color: 'rgba(52,64,84,.06)' },
+        data: overview.trend.map((item) => item.calls),
+      },
+      {
+        name: '失败调用',
+        type: 'line',
+        smooth: 0.25,
+        symbol: 'none',
+        lineStyle: { width: 1.6, color: BRAND_COLOR },
+        data: overview.trend.map((item) => item.failureCalls),
+      },
+      {
+        name: '平均耗时',
+        type: 'line',
+        yAxisIndex: 1,
+        smooth: 0.25,
+        symbol: 'none',
+        lineStyle: { width: 1.4, type: 'dashed', color: '#98a2b3' },
+        data: overview.trend.map((item) => item.averageDurationMs),
+      },
+    ],
+  }), [overview.trend]);
 
-  const hotApis = useMemo(() => {
-    const counts = new Map<number, { calls: number; success: number; duration: number }>();
-    logs.forEach((item) => {
-      const current = counts.get(item.apiId) || { calls: 0, success: 0, duration: 0 };
-      current.calls += 1;
-      current.success += item.success ? 1 : 0;
-      current.duration += item.durationMs || 0;
-      counts.set(item.apiId, current);
-    });
+  const hotApiOption = useMemo<EChartsOption>(() => {
+    const records = [...overview.hotApis].reverse();
+    return {
+      animationDuration: 350,
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        backgroundColor: '#fff',
+        borderColor: '#e4e7ec',
+        textStyle: { color: '#475467', fontSize: 11 },
+      },
+      grid: { left: 12, right: 42, top: 8, bottom: 8, containLabel: true },
+      xAxis: {
+        type: 'value',
+        minInterval: 1,
+        axisLabel: { show: false },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: 'category',
+        data: records.map((item) => item.name),
+        axisTick: { show: false },
+        axisLine: { show: false },
+        axisLabel: {
+          color: TEXT_SECONDARY,
+          fontSize: 10,
+          width: 110,
+          overflow: 'truncate',
+        },
+      },
+      series: [
+        {
+          type: 'bar',
+          barWidth: 10,
+          data: records.map((item) => item.calls),
+          itemStyle: { color: '#667085', borderRadius: [0, 3, 3, 0] },
+          label: {
+            show: true,
+            position: 'right',
+            color: TEXT_WEAK,
+            fontSize: 9,
+            formatter: '{c}',
+          },
+        },
+      ],
+    };
+  }, [overview.hotApis]);
 
-    return services
-      .map((service) => ({ service, stats: counts.get(service.id) }))
-      .filter((item): item is { service: DataServiceApi; stats: { calls: number; success: number; duration: number } } => Boolean(item.stats))
-      .sort((left, right) => right.stats.calls - left.stats.calls)
-      .slice(0, 8);
-  }, [logs, services]);
-
-  const maxCalls = hotApis[0]?.stats.calls || 1;
-  const recentFailures = useMemo(
-    () => logs.filter((item) => !item.success).slice(0, 8),
-    [logs],
-  );
-
-  const failureColumns: TableColumnsType<DataServiceCallLog> = [
+  const failureColumns: TableColumnsType<DataServiceOverviewFailure> = [
     {
       title: 'API',
       dataIndex: 'serviceName',
-      minWidth: 180,
+      minWidth: 170,
       render: (_, record) => (
-        <div>
-          <div className="font-medium text-[#344054]">{record.serviceName}</div>
+        <div className="min-w-0 py-0.5">
+          <div className="truncate text-[12px] font-medium text-[#344054]">{record.serviceName}</div>
           <div className="mt-0.5 truncate font-mono text-[10px] text-[#98a2b3]">{record.servicePath}</div>
         </div>
       ),
     },
-    { title: '耗时', dataIndex: 'durationMs', width: 90, render: (value) => `${value || 0} ms` },
     {
       title: '错误',
       dataIndex: 'errorMessage',
       ellipsis: true,
-      render: (value) => value
-        ? <Tooltip title={value}><span className="text-[#b42318]">{value}</span></Tooltip>
-        : <span className="text-[#98a2b3]">未知错误</span>,
+      render: (value?: string | null) => value
+        ? <Tooltip title={value}><span className="text-[11px] text-[#b42318]">{value}</span></Tooltip>
+        : <span className="text-[11px] text-[#98a2b3]">未知错误</span>,
     },
-    { title: '时间', dataIndex: 'createTime', width: 160, render: formatTime },
+    {
+      title: '耗时',
+      dataIndex: 'durationMs',
+      width: 82,
+      render: (value: number) => <span className="text-[11px] text-[#667085]">{value || 0} ms</span>,
+    },
+    {
+      title: '时间',
+      dataIndex: 'createTime',
+      width: 150,
+      render: (value?: string | null) => <span className="text-[10px] text-[#98a2b3]">{formatTime(value)}</span>,
+    },
   ];
 
   return (
-    <div className="h-full overflow-y-auto bg-[#fafafa] px-6 py-5">
-      <div className="mx-auto max-w-[1280px]">
-        <div className="mb-5 flex items-start justify-between gap-4">
+    <div className="h-full overflow-y-auto bg-[#f6f7f8] p-3">
+      <div className="min-h-full rounded-[10px] bg-white px-5 pb-5 pt-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="m-0 text-xl font-semibold text-[#161823]">运行概览</h1>
-            <p className="mb-0 mt-1 text-sm text-black/45">
-              基于当前 API 状态和最近 200 条调用记录做轻量统计，不额外引入计量平台。
-            </p>
-          </div>
-          <Button loading={loading} icon={<RefreshCw size={15} />} onClick={() => void load()}>刷新</Button>
-        </div>
-
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
-          <MetricCard
-            label="API 总数"
-            value={services.length}
-            note={`${runningServices} 个运行中`}
-            icon={<Server size={16} strokeWidth={1.8} />}
-          />
-          <MetricCard
-            label="近期调用"
-            value={logs.length}
-            note="最近调用记录窗口"
-            icon={<Activity size={16} strokeWidth={1.8} />}
-          />
-          <MetricCard
-            label="成功率"
-            value={`${successRate}%`}
-            note={`${successCalls} 成功 / ${failureCalls} 失败`}
-            icon={<CheckCircle2 size={16} strokeWidth={1.8} />}
-          />
-          <MetricCard
-            label="平均耗时"
-            value={`${averageDuration} ms`}
-            note="基于近期调用计算"
-            icon={<Gauge size={16} strokeWidth={1.8} />}
-          />
-          <MetricCard
-            label="失败调用"
-            value={failureCalls}
-            note="建议优先查看异常 API"
-            icon={<AlertCircle size={16} strokeWidth={1.8} />}
-          />
-        </div>
-
-        <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(480px,1.25fr)]">
-          <section className="rounded-[6px] border border-[#e6e8eb] bg-white p-5">
-            <div className="mb-4">
-              <div className="text-[14px] font-semibold text-[#30323b]">热门 API</div>
-              <div className="mt-1 text-[11px] text-[#98a2b3]">按最近调用次数排序</div>
+            <h1 className="m-0 text-[17px] font-semibold text-[#161823]">运行概览</h1>
+            <div className="mt-1 text-[12px] text-[#98a2b3]">
+              API 运行状态、调用趋势与近期异常
             </div>
+          </div>
 
-            {hotApis.length ? (
-              <div className="space-y-4">
-                {hotApis.map(({ service, stats }, index) => {
-                  const rate = stats.calls ? Math.round((stats.success / stats.calls) * 1000) / 10 : 0;
-                  const average = stats.calls ? Math.round(stats.duration / stats.calls) : 0;
-                  return (
-                    <div key={service.id}>
-                      <div className="flex items-center justify-between gap-4 text-[12px]">
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span className="w-4 shrink-0 text-[10px] text-[#98a2b3]">{index + 1}</span>
-                          <span className="truncate font-medium text-[#344054]">{service.name}</span>
-                          {!service.enabled ? <Tag bordered={false}>已停用</Tag> : null}
-                        </div>
-                        <div className="shrink-0 text-[11px] text-[#98a2b3]">
-                          {stats.calls} 次 · {rate}% · {average} ms
-                        </div>
-                      </div>
-                      <div className="ml-6 mt-2 h-1.5 overflow-hidden rounded-full bg-[#f0f2f4]">
-                        <div
-                          className="h-full rounded-full bg-[#667085]"
-                          style={{ width: `${Math.max(4, (stats.calls / maxCalls) * 100)}%` }}
-                        />
-                      </div>
-                    </div>
-                  );
-                })}
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1 rounded-[8px] bg-[#f5f5f6] p-1">
+              {RANGE_ITEMS.map((item) => {
+                const active = range === item.value;
+                return (
+                  <button
+                    key={item.value}
+                    type="button"
+                    onClick={() => setRange(item.value)}
+                    className={[
+                      'h-7 rounded-[6px] border-0 px-3 text-[12px] transition-all',
+                      active
+                        ? 'bg-white font-medium text-[#161823] shadow-[0_1px_3px_rgba(16,24,40,.06)]'
+                        : 'bg-transparent text-[#7b808a] hover:text-[#344054]',
+                    ].join(' ')}
+                  >
+                    {item.label}
+                  </button>
+                );
+              })}
+            </div>
+            <Button
+              type="text"
+              size="middle"
+              loading={loading}
+              icon={<RefreshCw size={14} />}
+              onClick={() => void load()}
+              className="bg-[#f5f6f7]"
+            >
+              刷新
+            </Button>
+          </div>
+        </div>
+
+        <div className="my-4 border-t border-[#f0f0f0]" />
+
+        <div className="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(360px,1.2fr)]">
+          <DonutPanel
+            title="API 状态分布"
+            subtitle="当前已上线的数据服务"
+            total={overview.apiTotal}
+            items={[
+              { name: '运行中', value: overview.runningApis, color: '#475467' },
+              { name: '已停用', value: overview.stoppedApis, color: '#d0d5dd' },
+            ]}
+          />
+          <DonutPanel
+            title="调用结果分布"
+            subtitle={`统计范围：${RANGE_ITEMS.find((item) => item.value === range)?.label || range}`}
+            total={overview.totalCalls}
+            items={[
+              { name: '成功', value: overview.successCalls, color: '#475467' },
+              { name: '失败', value: overview.failureCalls, color: BRAND_COLOR },
+            ]}
+          />
+          <Panel title="总体指标" subtitle="当前时间范围内的调用汇总">
+            <div className="grid grid-cols-2 divide-x divide-y divide-[#f3f4f5]">
+              <MetricCell label="调用次数" value={formatNumber(overview.totalCalls)} note="全部 API 调用" />
+              <MetricCell label="成功率" value={`${overview.successRate}%`} note={`${overview.failureCalls} 次失败`} />
+              <MetricCell label="平均耗时" value={`${formatNumber(overview.averageDurationMs)} ms`} note="按全部调用计算" />
+              <MetricCell label="返回行数" value={formatNumber(overview.totalRows)} note="成功查询返回数据量" />
+            </div>
+          </Panel>
+        </div>
+
+        <Panel
+          title="调用趋势"
+          subtitle="总调用、失败调用与平均耗时"
+          className="mt-3"
+        >
+          <div className="h-[330px] px-3 pb-2 pt-3">
+            <ReactECharts option={trendOption} style={{ height: 310 }} notMerge lazyUpdate />
+          </div>
+        </Panel>
+
+        <div className="mt-3 grid grid-cols-1 gap-3 xl:grid-cols-[minmax(360px,.8fr)_minmax(0,1.4fr)]">
+          <Panel title="热门 API" subtitle="按当前时间范围内调用次数排序">
+            {overview.hotApis.length ? (
+              <div className="h-[300px] px-2 py-3">
+                <ReactECharts option={hotApiOption} style={{ height: 276 }} notMerge lazyUpdate />
               </div>
             ) : (
-              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无调用数据" />
+              <div className="flex h-[300px] items-center justify-center">
+                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无调用数据" />
+              </div>
             )}
-          </section>
+          </Panel>
 
-          <section className="rounded-[6px] border border-[#e6e8eb] bg-white p-5">
-            <div className="mb-4">
-              <div className="text-[14px] font-semibold text-[#30323b]">最近失败</div>
-              <div className="mt-1 text-[11px] text-[#98a2b3]">快速发现需要处理的调用异常</div>
+          <Panel title="最近失败" subtitle="优先关注最近的异常调用">
+            <div className="p-3">
+              <Table<DataServiceOverviewFailure>
+                rowKey="id"
+                size="small"
+                bordered
+                loading={loading}
+                pagination={false}
+                dataSource={overview.recentFailures}
+                columns={failureColumns}
+                scroll={{ x: 700, y: 240 }}
+                locale={{ emptyText: '当前时间范围内没有失败调用' }}
+              />
             </div>
-            <Table<DataServiceCallLog>
-              rowKey="id"
-              size="small"
-              loading={loading}
-              pagination={false}
-              dataSource={recentFailures}
-              columns={failureColumns}
-              scroll={{ x: 680 }}
-              locale={{ emptyText: '近期没有失败调用' }}
-            />
-          </section>
+          </Panel>
         </div>
       </div>
     </div>

--- a/yak-ops-ui/src/pages/data-service/overview/overview-service.ts
+++ b/yak-ops-ui/src/pages/data-service/overview/overview-service.ts
@@ -1,0 +1,55 @@
+import HttpUtils from '@/utils/HttpUtils';
+import type { CommonApiResponse } from '../service';
+
+export type DataServiceOverviewRange = '24h' | '7d' | '30d';
+
+export interface DataServiceOverviewTrendPoint {
+  time: string;
+  calls: number;
+  successCalls: number;
+  failureCalls: number;
+  averageDurationMs: number;
+}
+
+export interface DataServiceOverviewHotApi {
+  apiId: number;
+  name: string;
+  path: string;
+  calls: number;
+  successRate: number;
+  averageDurationMs: number;
+}
+
+export interface DataServiceOverviewFailure {
+  id: number;
+  apiId: number;
+  serviceName: string;
+  servicePath: string;
+  durationMs: number;
+  errorMessage?: string | null;
+  createTime?: string | null;
+}
+
+export interface DataServiceOverview {
+  range: DataServiceOverviewRange;
+  startTime: string;
+  endTime: string;
+  apiTotal: number;
+  runningApis: number;
+  stoppedApis: number;
+  totalCalls: number;
+  successCalls: number;
+  failureCalls: number;
+  successRate: number;
+  averageDurationMs: number;
+  totalRows: number;
+  trend: DataServiceOverviewTrendPoint[];
+  hotApis: DataServiceOverviewHotApi[];
+  recentFailures: DataServiceOverviewFailure[];
+}
+
+const PREFIX = '/api/v1/data-service/overview';
+
+export const fetchDataServiceOverview = (range: DataServiceOverviewRange) =>
+  HttpUtils.get<DataServiceOverview>(`${PREFIX}?range=${encodeURIComponent(range)}`)
+    as Promise<CommonApiResponse<DataServiceOverview>>;


### PR DESCRIPTION
## 背景

当前「运行概览」只是 5 个统计卡片 + 热门 API / 最近失败列表，信息是有的，但缺少真正的运行趋势与结构分布，视觉也和 Yak Ops 现有白底、高密度、浅灰边框的工具型页面不一致。

本 PR 参考 DataWorks 计量大屏的**信息布局**，但不照搬深色大屏风格；继续使用 Yak Ops 自己的视觉语言，并补一个轻量后端 overview 聚合接口，让趋势图有真实时间范围数据。

## 页面结构

新版运行概览收成四层：

```text
运行概览                         [24小时] [7天] [30天]  刷新
────────────────────────────────────────────────────────

┌ API 状态分布 ┐ ┌ 调用结果分布 ┐ ┌ 总体指标 ─────────┐
│    环形图     │ │    环形图     │ │ 调用 / 成功率      │
│ 运行 / 停用   │ │ 成功 / 失败   │ │ 平均耗时 / 返回行数 │
└──────────────┘ └──────────────┘ └──────────────────┘

┌──────────────────── 调用趋势 ──────────────────────┐
│  总调用 ────────      失败调用 ───      平均耗时 --- │
│                    折线 / 面积趋势                   │
└────────────────────────────────────────────────────┘

┌──────── 热门 API Top 8 ────────┐ ┌──── 最近失败 ────┐
│       横向调用排行图             │ │ API / 错误 / 耗时 │
└─────────────────────────────────┘ └──────────────────┘
```

## 1. 视觉统一到 Yak Ops

- 页面背景使用 Yak Ops 常见的 `#f6f7f8` + 白色圆角主容器
- 17px 页面标题，12px 弱说明
- 面板统一 8px 圆角、`#f0f0f0` 边框
- 不做深色大屏、不做渐变背景、不做重阴影
- 正常数据全部使用黑灰色系
- 只有失败 / 异常使用 Yak 品牌红

## 2. 新增真实时间范围

顶部提供：

- 24 小时
- 7 天
- 30 天

后端按范围从已有 `yak_ops_data_service_call_log.create_time` 时间索引读取并聚合：

- 24h：1 小时一个桶，24 个趋势点
- 7d：6 小时一个桶，28 个趋势点
- 30d：1 天一个桶，30 个趋势点

不会用「最近 200 条日志」冒充完整时间趋势。

## 3. API 状态与调用结果分布

新增两个轻量环形图：

### API 状态

- API 总数
- 运行中
- 已停用

### 调用结果

- 总调用
- 成功
- 失败

使用已有 `echarts / echarts-for-react`，不新增前端依赖。

## 4. 总体指标

不再使用 5 张独立 Metric Card，而是在一个高密度区域展示：

- 调用次数
- 成功率
- 平均耗时
- 返回行数

整体更接近 Yak Ops 的管理页面信息密度。

## 5. 调用趋势曲线

新增真实趋势图：

- 总调用：黑灰实线 + 极浅面积
- 失败调用：品牌红曲线
- 平均耗时：灰色虚线，独立 ms Y 轴

避免五颜六色，同时把 Runtime 最重要的三个变化放在一个时间轴上。

## 6. 热门 API + 最近失败

### 热门 API

按选定时间范围内调用次数排序 Top 8，使用横向条形图。

### 最近失败

保留真实失败调用表格，展示：

- API
- Endpoint
- 错误信息
- 耗时
- 时间

## 7. 新增轻量 overview 后端接口

新增：

```text
GET /api/v1/data-service/overview?range=24h|7d|30d
```

返回：

- API 总数 / 运行中 / 停用
- 总调用 / 成功 / 失败
- 成功率
- 平均耗时
- 返回总行数
- 时间趋势点
- 热门 API Top 8
- 最近失败 Top 8

实现直接聚合现有 API 表和调用日志表，不新增数据库表，也不改变 Runtime 调用链。

## 8. 测试

新增 `DataServiceOverviewServiceTest`，覆盖：

- API 状态统计
- 调用成功 / 失败统计
- 成功率 / 平均耗时 / 返回行数
- 24 小时时间桶
- 热门 API 排序
- 最近失败
- 非法 range 拒绝

## 变更范围

最终 diff：**1 commit / 5 files**

- `DataServiceOverviewController.java`（新增）
- `DataServiceOverviewService.java`（新增）
- `DataServiceOverviewServiceTest.java`（新增）
- `overview/index.tsx`（重构）
- `overview/overview-service.ts`（新增）

没有数据库迁移，没有新增前端依赖，没有修改 Data Service 发布 / 上线 / Runtime 执行逻辑。

## 检查说明

- 分支基于已合并 #438 的最新 `main`
- compare 已确认 `ahead=1 / behind=0`
- 复用仓库已有 `echarts@5.6.0` 与 `echarts-for-react@3.0.6`
- 调用日志表已有 `create_time` 索引，可直接支撑当前 v1 的范围查询
- 已补聚合逻辑单元测试
- 当前执行环境仍无法通过 DNS clone GitHub，因此未声称本地 Maven / npm 全量构建已通过；继续以 GitHub reported checks 为准

核心目标：**运行概览要像一个真正可用的 Runtime Overview，但仍然保持 Yak Ops v1 的轻量。**