### PR TITLE
refactor: polish api marketplace search entrance

### DIFF
--- a/yak-ops-ui/src/pages/data-service/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/index.tsx
@@ -54,6 +54,59 @@ const ApiMethod = () => (
   </span>
 );
 
+const ApiMarketplaceIllustration = () => (
+  <svg
+    viewBox="0 0 240 150"
+    className="h-[132px] w-[210px]"
+    fill="none"
+    aria-hidden="true"
+  >
+    <defs>
+      <linearGradient id="api-marketplace-node-fill" x1="0" y1="0" x2="1" y2="1">
+        <stop stopColor="#fff" />
+        <stop offset="1" stopColor="#fff4f6" />
+      </linearGradient>
+    </defs>
+
+    <path
+      d="M40 76C64 76 68 42 93 42H120C143 42 146 72 169 72H199"
+      stroke="#d9dde4"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M40 76C64 76 68 111 93 111H121C144 111 148 87 170 87H199"
+      stroke="#f5a2b5"
+      strokeOpacity=".72"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path d="M112 42V111" stroke="#e8eaee" strokeWidth="1.2" strokeDasharray="3 5" />
+
+    <rect x="22" y="58" width="38" height="36" rx="9" fill="url(#api-marketplace-node-fill)" stroke="#f0c8d2" />
+    <path d="M33 70L28 76L33 82" stroke="#fe2c55" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M49 70L54 76L49 82" stroke="#fe2c55" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M44 67L38 85" stroke="#98a2b3" strokeWidth="1.5" strokeLinecap="round" />
+
+    <rect x="92" y="25" width="42" height="34" rx="9" fill="#fff" stroke="#dfe3e8" />
+    <circle cx="106" cy="42" r="4" fill="#f8d1da" stroke="#fe2c55" strokeWidth="1.2" />
+    <path d="M114 38H125M114 43H125M104 50H125" stroke="#98a2b3" strokeWidth="1.3" strokeLinecap="round" />
+
+    <rect x="92" y="94" width="42" height="34" rx="9" fill="#fff" stroke="#dfe3e8" />
+    <path d="M103 106H123M103 112H118M103 118H125" stroke="#98a2b3" strokeWidth="1.3" strokeLinecap="round" />
+    <circle cx="126" cy="106" r="2.5" fill="#fe2c55" fillOpacity=".65" />
+
+    <rect x="180" y="57" width="38" height="44" rx="10" fill="url(#api-marketplace-node-fill)" stroke="#f0c8d2" />
+    <rect x="189" y="67" width="20" height="5" rx="2.5" fill="#d9dde4" />
+    <rect x="189" y="76" width="20" height="5" rx="2.5" fill="#f6b8c6" />
+    <rect x="189" y="85" width="14" height="5" rx="2.5" fill="#d9dde4" />
+
+    <circle cx="40" cy="76" r="3" fill="#fe2c55" />
+    <circle cx="199" cy="72" r="3" fill="#667085" />
+    <circle cx="199" cy="87" r="3" fill="#fe2c55" fillOpacity=".72" />
+  </svg>
+);
+
 const ApiListItem = ({
   service,
   dataSourceName,
@@ -91,7 +144,10 @@ const ApiListItem = ({
     </div>
 
     <div className="w-[118px] shrink-0 text-right">
-      <div className="truncate text-[11px] font-medium text-[#667085]" title={calls !== undefined ? undefined : dataSourceName}>
+      <div
+        className="truncate text-[11px] font-medium text-[#667085]"
+        title={calls !== undefined ? undefined : dataSourceName}
+      >
         {calls !== undefined ? `${calls} 次调用` : dataSourceName}
       </div>
       <div className="mt-1 text-[10px] text-[#b0b5bd]">
@@ -359,28 +415,52 @@ export default function DataServicePage() {
   const searchControls = (compact = false) => (
     <div className={compact
       ? 'flex min-w-0 flex-1 items-center gap-2'
-      : 'flex w-full max-w-[640px] items-center gap-2'}>
-      <Input
-        allowClear
-        variant="filled"
-        value={keyword}
-        prefix={<Search size={15} className="text-[#98a2b3]" />}
-        placeholder="搜索 API 名称、Endpoint、描述或数据源"
-        className={compact ? '!h-9' : '!h-10'}
-        onChange={(event) => {
-          setKeyword(event.target.value);
-          if (!event.target.value) setSubmittedKeyword('');
-        }}
-        onPressEnter={submitSearch}
-      />
-      <Button
-        type="primary"
-        loading={loading}
-        className={compact ? '!h-9 !px-4' : '!h-10 !px-5'}
-        onClick={submitSearch}
-      >
-        搜索
-      </Button>
+      : 'w-full max-w-[760px] rounded-[10px] border border-[#dfe3e8] bg-white px-3 pb-2.5 pt-2 shadow-[0_8px_30px_rgba(16,24,40,.03)]'}>
+      {compact ? (
+        <>
+          <Input
+            allowClear
+            variant="filled"
+            value={keyword}
+            prefix={<Search size={15} className="text-[#98a2b3]" />}
+            placeholder="搜索 API 名称、Endpoint、描述或数据源"
+            className="!h-9"
+            onChange={(event) => {
+              setKeyword(event.target.value);
+              if (!event.target.value) setSubmittedKeyword('');
+            }}
+            onPressEnter={submitSearch}
+          />
+          <Button type="primary" loading={loading} className="!h-9 !px-4" onClick={submitSearch}>
+            搜索
+          </Button>
+        </>
+      ) : (
+        <>
+          <Input
+            allowClear
+            variant="borderless"
+            value={keyword}
+            placeholder="输入 API 名称、Endpoint、描述或数据源，按 Enter 搜索"
+            className="!h-10 !px-1 !text-[13px]"
+            onChange={(event) => {
+              setKeyword(event.target.value);
+              if (!event.target.value) setSubmittedKeyword('');
+            }}
+            onPressEnter={submitSearch}
+          />
+          <div className="mt-1 flex min-h-9 items-center justify-between gap-4 border-t border-[#f0f1f2] pt-2">
+            <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-[#98a2b3]">
+              <span className="rounded-[5px] bg-[#f6f7f8] px-2 py-1">API 名称</span>
+              <span className="rounded-[5px] bg-[#f6f7f8] px-2 py-1">Endpoint</span>
+              <span className="rounded-[5px] bg-[#f6f7f8] px-2 py-1">数据源</span>
+            </div>
+            <Button type="primary" loading={loading} className="!h-8 !px-5" onClick={submitSearch}>
+              搜索
+            </Button>
+          </div>
+        </>
+      )}
     </div>
   );
 
@@ -436,77 +516,103 @@ export default function DataServicePage() {
           </div>
         </div>
       ) : (
-        <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h1 className="m-0 text-[17px] font-semibold text-[#161823]">API 集市</h1>
-              <div className="mt-1 text-[12px] text-[#98a2b3]">
-                共 {services.length} 个 API · {runningServices.length} 个运行中
-              </div>
+        <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white">
+          <div
+            className="relative overflow-hidden border-b border-[#eef0f3] px-5 py-7"
+            style={{
+              background: 'linear-gradient(180deg, #f7f9fc 0%, #fbfcfd 72%, #ffffff 100%)',
+            }}
+          >
+            <div className="pointer-events-none absolute left-[4%] top-1/2 hidden -translate-y-1/2 opacity-90 lg:block">
+              <ApiMarketplaceIllustration />
             </div>
+            <div className="pointer-events-none absolute -left-12 bottom-[-82px] h-[180px] w-[180px] rounded-full bg-[rgba(254,44,85,.035)]" />
+            <div className="pointer-events-none absolute left-[18%] top-[-78px] h-[150px] w-[150px] rounded-full border border-[rgba(254,44,85,.055)]" />
+
+            <div className="relative mx-auto flex max-w-[840px] flex-col items-center">
+              <div className="mb-4 flex items-center gap-2">
+                <span className="flex h-7 w-7 items-center justify-center rounded-[7px] border border-[#e3e6eb] bg-white shadow-[0_2px_8px_rgba(16,24,40,.04)]">
+                  <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" aria-hidden="true">
+                    <path d="M6 8.5L3.5 12L6 15.5" stroke="#fe2c55" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M18 8.5L20.5 12L18 15.5" stroke="#fe2c55" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M14.5 5.5L9.5 18.5" stroke="#667085" strokeWidth="1.7" strokeLinecap="round" />
+                  </svg>
+                </span>
+                <h1 className="m-0 text-[19px] font-semibold tracking-[-.01em] text-[#161823]">API 集市</h1>
+              </div>
+              {searchControls()}
+            </div>
+
             <Button
               type="text"
               icon={<RefreshCw size={14} />}
               loading={loading}
               onClick={() => void load()}
-              className="bg-[#f5f6f7]"
+              className="!absolute !right-5 !top-4 !bg-white/70 !text-[#667085]"
             >
               刷新
             </Button>
           </div>
 
-          <div className="mt-4 flex min-h-[76px] items-center justify-center rounded-[8px] border border-[#f0f0f0] bg-[#fafafa] px-6 py-4">
-            {searchControls()}
-          </div>
-
-          <div className="mt-6 grid min-h-0 grid-cols-1 gap-x-8 gap-y-8 xl:grid-cols-2">
-            <section className="min-w-0">
-              <div className="flex h-9 items-center justify-between border-b border-[#e9ebee]">
-                <div className="text-[13px] font-semibold text-[#30323b]">推荐 API</div>
-                <div className="text-[11px] text-[#98a2b3]">最近更新</div>
+          <div className="px-5 pb-6 pt-4">
+            <div className="flex items-center justify-between border-b border-[#f0f0f0] pb-3">
+              <div className="text-[12px] text-[#98a2b3]">
+                共 <span className="font-medium text-[#667085]">{services.length}</span> 个 API
+                <span className="mx-2 text-[#d0d5dd]">·</span>
+                <span className="font-medium text-[#667085]">{runningServices.length}</span> 个运行中
               </div>
-              {recommendedServices.length ? (
-                <div>
-                  {recommendedServices.map((service) => (
-                    <ApiListItem
-                      key={service.id}
-                      service={service}
-                      dataSourceName={dataSourceName(service.dataSourceId)}
-                      onOpen={() => setDetailTarget(service)}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div className="flex h-[260px] items-center justify-center">
-                  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无已上线 API" />
-                </div>
-              )}
-            </section>
+              <div className="text-[11px] text-[#b0b5bd]">点击 API 可查看文档、密钥和调用信息</div>
+            </div>
 
-            <section className="min-w-0">
-              <div className="flex h-9 items-center justify-between border-b border-[#e9ebee]">
-                <div className="text-[13px] font-semibold text-[#30323b]">热门调用</div>
-                <div className="text-[11px] text-[#98a2b3]">最近调用</div>
-              </div>
-              {hotServices.length ? (
-                <div>
-                  {hotServices.map((service, index) => (
-                    <ApiListItem
-                      key={service.id}
-                      rank={index + 1}
-                      service={service}
-                      dataSourceName={dataSourceName(service.dataSourceId)}
-                      calls={callsByApiId.get(service.id) || 0}
-                      onOpen={() => setDetailTarget(service)}
-                    />
-                  ))}
+            <div className="mt-4 grid min-h-0 grid-cols-1 gap-x-8 gap-y-8 xl:grid-cols-2">
+              <section className="min-w-0">
+                <div className="flex h-9 items-center justify-between border-b border-[#e9ebee]">
+                  <div className="text-[13px] font-semibold text-[#30323b]">推荐 API</div>
+                  <div className="text-[11px] text-[#98a2b3]">最近更新</div>
                 </div>
-              ) : (
-                <div className="flex h-[260px] items-center justify-center">
-                  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无调用记录" />
+                {recommendedServices.length ? (
+                  <div>
+                    {recommendedServices.map((service) => (
+                      <ApiListItem
+                        key={service.id}
+                        service={service}
+                        dataSourceName={dataSourceName(service.dataSourceId)}
+                        onOpen={() => setDetailTarget(service)}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex h-[260px] items-center justify-center">
+                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无已上线 API" />
+                  </div>
+                )}
+              </section>
+
+              <section className="min-w-0">
+                <div className="flex h-9 items-center justify-between border-b border-[#e9ebee]">
+                  <div className="text-[13px] font-semibold text-[#30323b]">热门调用</div>
+                  <div className="text-[11px] text-[#98a2b3]">最近调用</div>
                 </div>
-              )}
-            </section>
+                {hotServices.length ? (
+                  <div>
+                    {hotServices.map((service, index) => (
+                      <ApiListItem
+                        key={service.id}
+                        rank={index + 1}
+                        service={service}
+                        dataSourceName={dataSourceName(service.dataSourceId)}
+                        calls={callsByApiId.get(service.id) || 0}
+                        onOpen={() => setDetailTarget(service)}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex h-[260px] items-center justify-center">
+                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无调用记录" />
+                  </div>
+                )}
+              </section>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## 背景

API 集市当前顶部仍然是「标题 + 一条浅灰搜索栏」，信息是对的，但缺少一个真正像“能力入口”的视觉焦点。用户给出的参考图里，搜索区域有轻背景、居中标题和一体化搜索框，整体更像一个搜索门户。

本 PR 只精修 API 集市默认首页，不改变搜索结果、推荐/热门计算、API 管理和详情能力。

## 主要调整

### 1. 顶部改成轻量搜索门户

默认页顶部改为：

```text
┌──────────── 浅灰 / 极淡品牌色背景 ─────────────────────────┐
│                                                            │
│   [API 数据流 SVG]              API 集市                    │
│                              ┌──────────────────────┐       │
│                              │ 搜索 API 能力...      │       │
│                              │                      │       │
│                              │ API名 Endpoint 数据源  [搜索] │
│                              └──────────────────────┘       │
│                                                            │
└────────────────────────────────────────────────────────────┘
```

- 采用 `#f7f9fc → #fff` 的非常轻背景
- 保持白底产品风格，不做深色 Banner
- 标题居中，不再单独占页面左上角
- 刷新动作仍保留在右上角

### 2. 自绘左侧 SVG

新增内联 `ApiMarketplaceIllustration`：

- API 代码节点
- 数据节点
- Runtime / 服务节点
- 两条连接路径

配色仅使用黑灰 + 极淡品牌红，不使用机器人、星星、魔法棒等 AI 装饰元素，也不增加外部图片资源。

### 3. 搜索框参考门户式结构

默认状态不再使用一条 filled Input，而是改成一个白色有边界的搜索容器：

- 第一行：borderless 搜索输入
- 第二行：API 名称 / Endpoint / 数据源搜索提示 + 搜索按钮
- 支持 Enter 搜索
- 最大宽度约 760px

搜索进入结果状态后，仍复用原来的 compact 搜索框 + Table，不改变已有交互。

### 4. 推荐 / 热门区域保持 Yak Ops 高密度风格

搜索门户下方继续保留：

- API 总数 / 运行中数量
- 推荐 API
- 热门调用

仍然使用当前的紧凑列表，不重新做大卡片墙。

## 不改变的能力

本 PR 不修改：

- 推荐 API 排序
- 热门调用统计
- 搜索字段与匹配逻辑
- 搜索后 Table 结果页
- API 启停
- API 删除
- API Detail Drawer
- OpenAPI / API Key / Runtime
- 后端接口与数据库

## 变更范围

最终 diff：**1 commit / 1 frontend file**

- `yak-ops-ui/src/pages/data-service/index.tsx`

## 检查

- 基于最新 `main`（包含 #439）创建
- compare：`ahead=1 / behind=0`
- 本地使用 TypeScript `transpileModule` 做 parser-level 检查，无语法错误
- 当前仓库若没有 GitHub Actions/status checks，则不将其表述为 CI 已通过

核心目标：**让 API 集市第一眼更像一个数据 API 搜索入口，同时仍然保持 Yak Ops 的克制和工具感。**