### PR TITLE
feat: add api debug workspace

### DIFF
--- a/yak-ops-ui/src/config/navigation.test.ts
+++ b/yak-ops-ui/src/config/navigation.test.ts
@@ -77,20 +77,23 @@ describe('permission-aware navigation', () => {
     expect(getActiveNavigationId('/data-analysis/chart-analysis', [])).toBe('dashboard');
   });
 
-  it('registers api marketplace, runtime overview and call logs as data-service pages', () => {
+  it('registers api marketplace, debug, runtime overview and call logs as data-service pages', () => {
     const dataService = getMainNavigationGroups([]).find((group) => group.id === 'data-service');
     expect(dataService?.title).toBe('数据服务');
     expect(dataService?.routes.map((route) => route.id)).toEqual([
       'data-service-api',
+      'data-service-debug',
       'data-service-overview',
       'data-service-logs',
     ]);
     expect(dataService?.routes.map((route) => route.title)).toEqual([
       'API 集市',
+      'API 调试',
       '运行概览',
       '调用记录',
     ]);
     expect(getActiveNavigationId('/data-service', [])).toBe('data-service-api');
+    expect(getActiveNavigationId('/data-service/debug', [])).toBe('data-service-debug');
     expect(getActiveNavigationId('/data-service/overview', [])).toBe('data-service-overview');
     expect(getActiveNavigationId('/data-service/logs', [])).toBe('data-service-logs');
   });

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -47,8 +47,9 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'data-analysis-chart', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis-redirect', hidden: true, parentId: 'dashboard' },
   { id: 'data-service-api', mode: 'public', path: '/data-service', title: 'API 集市', component: './data-service', iconKey: 'api', menuGroup: 'data-service', order: 10 },
   { id: 'data-service-api-detail', path: '/data-service/api/:id', title: 'API 详情', component: './data-service/detail', hidden: true, parentId: 'data-service-api' },
-  { id: 'data-service-overview', mode: 'public', path: '/data-service/overview', title: '运行概览', component: './data-service/overview', iconKey: 'monitor', menuGroup: 'data-service', order: 20 },
-  { id: 'data-service-logs', mode: 'public', path: '/data-service/logs', title: '调用记录', component: './data-service/logs', iconKey: 'report', menuGroup: 'data-service', order: 30 },
+  { id: 'data-service-debug', mode: 'public', path: '/data-service/debug', title: 'API 调试', component: './data-service/debug', iconKey: 'api', menuGroup: 'data-service', order: 20 },
+  { id: 'data-service-overview', mode: 'public', path: '/data-service/overview', title: '运行概览', component: './data-service/overview', iconKey: 'monitor', menuGroup: 'data-service', order: 30 },
+  { id: 'data-service-logs', mode: 'public', path: '/data-service/logs', title: '调用记录', component: './data-service/logs', iconKey: 'report', menuGroup: 'data-service', order: 40 },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },
   {
     id: 'batch-link-up', mode: 'one', permission: 'task:batch:read',

--- a/yak-ops-ui/src/pages/data-service/debug/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/debug/index.tsx
@@ -1,0 +1,342 @@
+import { history, useLocation } from '@umijs/max';
+import { Button, Empty, Input, Select, Spin, message } from 'antd';
+import { ArrowLeft, Play } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  fetchDataServiceDocumentation,
+  fetchDataServices,
+  testDataService,
+  type DataServiceApi,
+  type DataServiceDocumentation,
+  type DataServiceQueryResult,
+} from '../service';
+
+const typeLabel: Record<string, string> = {
+  STRING: 'String',
+  INTEGER: 'Integer',
+  NUMBER: 'Number',
+  BOOLEAN: 'Boolean',
+  DATE: 'Date',
+  DATETIME: 'DateTime',
+};
+
+const prettyJson = (value: unknown) => JSON.stringify(value, null, 2);
+
+export default function DataServiceDebugPage() {
+  const location = useLocation();
+  const requestedApiId = Number(
+    new URLSearchParams(location.search).get('apiId') || 0,
+  );
+
+  const [services, setServices] = useState<DataServiceApi[]>([]);
+  const [selectedApiId, setSelectedApiId] = useState<number>();
+  const [documentation, setDocumentation] = useState<DataServiceDocumentation>();
+  const [debugValues, setDebugValues] = useState<Record<string, string>>({});
+  const [testResult, setTestResult] = useState<DataServiceQueryResult>();
+  const [loading, setLoading] = useState(true);
+  const [docLoading, setDocLoading] = useState(false);
+  const [testing, setTesting] = useState(false);
+
+  const selectedService = useMemo(
+    () => services.find((item) => Number(item.id) === Number(selectedApiId)),
+    [selectedApiId, services],
+  );
+
+  const apiOptions = useMemo(
+    () => services.map((item) => ({
+      value: item.id,
+      label: item.name,
+    })),
+    [services],
+  );
+
+  const loadServices = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetchDataServices();
+      const nextServices = response.data || [];
+      setServices(nextServices);
+
+      const requested = nextServices.find(
+        (item) => Number(item.id) === requestedApiId,
+      );
+      const preferred = requested
+        || nextServices.find((item) => item.enabled)
+        || nextServices[0];
+
+      if (preferred) {
+        setSelectedApiId(preferred.id);
+        if (Number(preferred.id) !== requestedApiId) {
+          history.replace(`/data-service/debug?apiId=${preferred.id}`);
+        }
+      }
+    } catch (error: any) {
+      message.error(error?.message || '加载 API 列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [requestedApiId]);
+
+  useEffect(() => {
+    void loadServices();
+  }, [loadServices]);
+
+  useEffect(() => {
+    if (!selectedApiId) {
+      setDocumentation(undefined);
+      setDebugValues({});
+      setTestResult(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    setDocLoading(true);
+    setTestResult(undefined);
+
+    void fetchDataServiceDocumentation(selectedApiId)
+      .then((response) => {
+        if (cancelled) return;
+        const doc = response.data;
+        setDocumentation(doc);
+        const nextValues: Record<string, string> = {};
+        for (const parameter of doc?.parameters || []) {
+          nextValues[parameter.name] = parameter.example || '';
+        }
+        setDebugValues(nextValues);
+      })
+      .catch((error: any) => {
+        if (!cancelled) {
+          setDocumentation(undefined);
+          setDebugValues({});
+          message.error(error?.message || '加载 API 参数失败');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setDocLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedApiId]);
+
+  const handleSelectApi = (value: number) => {
+    setSelectedApiId(value);
+    history.replace(`/data-service/debug?apiId=${value}`);
+  };
+
+  const runTest = async () => {
+    if (!selectedService) return;
+
+    const missing = (documentation?.parameters || []).find(
+      (item) => item.required && !String(debugValues[item.name] || '').trim(),
+    );
+    if (missing) {
+      message.warning(`请输入参数 ${missing.name}`);
+      return;
+    }
+
+    setTesting(true);
+    try {
+      const response = await testDataService(selectedService.id, debugValues);
+      if (!response.data) {
+        throw new Error(response.message || response.msg || '调试失败');
+      }
+      setTestResult(response.data);
+    } catch (error: any) {
+      message.error(error?.message || '调试失败');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const requestDetail = useMemo(() => {
+    if (!selectedService) return '';
+    return prettyJson({
+      method: 'GET',
+      endpoint: selectedService.runtimePath,
+      auth: selectedService.authMode === 'API_KEY' ? 'API Key' : 'Public',
+      parameters: debugValues,
+    });
+  }, [debugValues, selectedService]);
+
+  const responseContent = useMemo(() => {
+    if (!testResult) return '';
+    return prettyJson({
+      columns: testResult.columns,
+      rows: testResult.rows,
+      rowCount: testResult.rowCount,
+      truncated: testResult.truncated,
+    });
+  }, [testResult]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f7f8]">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[calc(100vh-64px)] overflow-hidden bg-[#f7f7f8] text-[#161823]">
+      <div className="flex h-14 items-center justify-between border-b border-[#eceef1] bg-white px-5">
+        <div className="flex items-center gap-3">
+          {selectedService ? (
+            <Button
+              type="text"
+              icon={<ArrowLeft size={15} />}
+              className="!px-1 !text-[#667085]"
+              onClick={() => history.push(`/data-service/api/${selectedService.id}`)}
+            />
+          ) : null}
+          <div>
+            <div className="text-[17px] font-semibold text-[#161823]">API 调试</div>
+            {selectedService ? (
+              <div className="mt-0.5 text-[11px] text-[#98a2b3]">
+                {selectedService.name}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="h-[calc(100%-56px)] p-4">
+        <div className="grid h-full min-h-0 overflow-hidden rounded-lg border border-[#e6e8eb] bg-white lg:grid-cols-[minmax(380px,0.86fr)_minmax(520px,1.14fr)]">
+          <section className="flex min-h-0 flex-col">
+            <div className="flex min-h-[52px] items-center border-b border-[#eef0f2] px-5 text-[14px] font-semibold">
+              请求配置
+            </div>
+
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-5">
+              <Select
+                showSearch
+                variant="filled"
+                value={selectedApiId}
+                options={apiOptions}
+                optionFilterProp="label"
+                placeholder="请选择或搜索 API"
+                className="w-full"
+                onChange={handleSelectApi}
+                notFoundContent="暂无 API"
+              />
+
+              {selectedService ? (
+                <div className="mt-3 flex items-center gap-2 text-[11px] text-[#8a8f98]">
+                  <span
+                    className={[
+                      'inline-block h-2 w-2 rounded-full',
+                      selectedService.enabled ? 'bg-[#20c77a]' : 'bg-[#b0b5bd]',
+                    ].join(' ')}
+                  />
+                  <span>{selectedService.enabled ? '运行中' : '已停用'}</span>
+                  <span className="text-[#d0d5dd]">·</span>
+                  <span className="truncate font-mono">GET {selectedService.runtimePath}</span>
+                </div>
+              ) : null}
+
+              <div className="mt-6 text-[13px] font-semibold text-[#344054]">请求参数</div>
+
+              <div className="mt-3 flex-1">
+                {docLoading ? (
+                  <div className="flex min-h-[180px] items-center justify-center">
+                    <Spin size="small" />
+                  </div>
+                ) : (documentation?.parameters || []).length ? (
+                  <div className="space-y-4">
+                    {(documentation?.parameters || []).map((parameter) => (
+                      <div key={parameter.name}>
+                        <div className="mb-1.5 flex items-center gap-2 text-[12px]">
+                          <span className="font-medium text-[#344054]">{parameter.name}</span>
+                          <span className="text-[#98a2b3]">{typeLabel[parameter.type] || parameter.type}</span>
+                          {parameter.required ? (
+                            <span className="text-[10px] text-[var(--yak-brand-color)]">必填</span>
+                          ) : null}
+                        </div>
+                        <Input
+                          value={debugValues[parameter.name] || ''}
+                          placeholder={parameter.example || `请输入 ${parameter.name}`}
+                          onChange={(event) => setDebugValues((current) => ({
+                            ...current,
+                            [parameter.name]: event.target.value,
+                          }))}
+                        />
+                        {parameter.description ? (
+                          <div className="mt-1 text-[11px] text-[#98a2b3]">
+                            {parameter.description}
+                          </div>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                ) : selectedService ? (
+                  <div className="rounded-md bg-[#f7f7f8] px-4 py-3 text-[12px] text-[#8a8f98]">
+                    当前 API 无请求参数
+                  </div>
+                ) : (
+                  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请选择 API" />
+                )}
+              </div>
+
+              <div className="mt-5 border-t border-[#eef0f2] pt-4">
+                <Button
+                  type="primary"
+                  icon={<Play size={14} />}
+                  disabled={!selectedService}
+                  loading={testing}
+                  onClick={() => void runTest()}
+                >
+                  开始调试
+                </Button>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid min-h-0 border-l border-[#eef0f2] lg:grid-rows-[minmax(220px,0.42fr)_minmax(280px,0.58fr)]">
+            <div className="flex min-h-0 flex-col border-b border-[#eef0f2]">
+              <div className="flex min-h-[52px] items-center border-b border-[#f2f3f5] px-5 text-[13px] font-semibold">
+                请求详情
+              </div>
+              <div className="min-h-0 flex-1 overflow-auto bg-[#fbfbfc] p-4">
+                {selectedService ? (
+                  <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[12px] leading-6 text-[#475467]">
+                    {requestDetail}
+                  </pre>
+                ) : (
+                  <div className="flex h-full items-center justify-center text-[12px] text-[#b0b5bd]">
+                    请选择 API
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex min-h-0 flex-col">
+              <div className="flex min-h-[52px] items-center justify-between border-b border-[#f2f3f5] px-5">
+                <div className="text-[13px] font-semibold">返回内容</div>
+                {testResult ? (
+                  <div className="flex items-center gap-4 text-[11px] text-[#667085]">
+                    <span className="font-medium text-[#20a66a]">200 OK</span>
+                    <span>{testResult.durationMs} ms</span>
+                    <span>{testResult.rowCount} 行</span>
+                  </div>
+                ) : null}
+              </div>
+              <div className="min-h-0 flex-1 overflow-auto bg-[#fafafa] p-4">
+                {testResult ? (
+                  <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[12px] leading-6 text-[#30343b]">
+                    {responseContent}
+                  </pre>
+                ) : (
+                  <div className="flex h-full items-center justify-center text-[12px] text-[#b0b5bd]">
+                    调试结果将在这里展示
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-service/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/detail/index.tsx
@@ -10,22 +10,11 @@ import {
   message,
   type TableColumnsType,
 } from 'antd';
-import {
-  ArrowLeft,
-  Copy,
-  FileText,
-  Gauge,
-  KeyRound,
-  RefreshCw,
-  ServerCog,
-} from 'lucide-react';
+import { ArrowLeft, PlayCircle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 
 import { BRAND_THEME } from '@/styles/brand';
 
-import DataServiceAccessModal from '../DataServiceAccessModal';
-import DataServiceDocsModal from '../DataServiceDocsModal';
-import DataServiceRuntimeModal from '../DataServiceRuntimeModal';
 import {
   DATA_SERVICE_NODE_SOURCE,
   LEGACY_DATA_DEVELOPMENT_RELEASE_SOURCE,
@@ -34,7 +23,6 @@ import {
   fetchDataServiceRuntime,
   fetchDataServices,
   fetchDataSourceOptions,
-  republishDataService,
   type DataServiceApi,
   type DataServiceApiKey,
   type DataServiceCallLog,
@@ -66,13 +54,7 @@ const latestActivity = (runtime?: DataServiceRuntimeStatus) => {
   );
 };
 
-const MetricTile = ({
-  label,
-  value,
-}: {
-  label: string;
-  value: ReactNode;
-}) => (
+const MetricTile = ({ label, value }: { label: string; value: ReactNode }) => (
   <div className="rounded-md bg-[#f7f7f8] px-4 py-4">
     <div className="text-[12px] leading-4 text-[#7c828c]">{label}</div>
     <div className="mt-2 truncate text-[20px] font-semibold leading-7 tracking-[-0.02em] text-[#161823]">
@@ -100,19 +82,16 @@ const InfoField = ({
 
 const SectionCard = ({
   title,
-  extra,
   children,
   className = '',
 }: {
   title: ReactNode;
-  extra?: ReactNode;
   children: ReactNode;
   className?: string;
 }) => (
   <section className={`min-w-0 rounded-lg bg-white ${className}`}>
-    <div className="flex min-h-[52px] items-center justify-between gap-4 px-5">
+    <div className="flex min-h-[52px] items-center px-5">
       <div className="text-[15px] font-semibold text-[#161823]">{title}</div>
-      {extra}
     </div>
     {children}
   </section>
@@ -133,33 +112,26 @@ const ApiIllustration = () => (
       <rect x="12" y="18" width="4" height="4" fill="#161823" />
       <rect x="20" y="18" width="4" height="4" fill="#161823" />
       <rect x="16" y="22" width="4" height="4" fill="#161823" />
-
       <rect x="58" y="18" width="4" height="4" fill="#FE2C55" />
       <rect x="54" y="22" width="4" height="4" fill="#FE2C55" />
       <rect x="62" y="22" width="4" height="4" fill="#FE2C55" />
       <rect x="58" y="26" width="4" height="4" fill="#FE2C55" />
-
       <rect x="23" y="29" width="32" height="4" fill="#161823" />
       <rect x="19" y="33" width="4" height="27" fill="#161823" />
       <rect x="55" y="33" width="4" height="27" fill="#161823" />
       <rect x="23" y="60" width="32" height="4" fill="#161823" />
-
       <rect x="23" y="33" width="32" height="27" fill="#F5F6F8" />
       <rect x="23" y="33" width="32" height="8" fill="#FFFFFF" />
       <rect x="23" y="41" width="32" height="4" fill="#E3E7EC" />
       <rect x="23" y="49" width="32" height="11" fill="#E8EBEF" />
-
       <rect x="27" y="36" width="4" height="4" fill="#FE2C55" />
       <rect x="34" y="36" width="4" height="4" fill="#AEB4BF" />
       <rect x="41" y="36" width="4" height="4" fill="#AEB4BF" />
-
       <rect x="29" y="52" width="20" height="4" fill="#161823" />
       <rect x="33" y="56" width="12" height="4" fill="#FE2C55" />
-
       <rect x="25" y="64" width="8" height="3" fill="#161823" />
       <rect x="45" y="64" width="8" height="3" fill="#161823" />
     </svg>
-
     <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-[46px] bg-gradient-to-b from-transparent via-black/10 to-black/25" />
   </div>
 );
@@ -174,39 +146,24 @@ export default function DataServiceDetailPage() {
   const [keys, setKeys] = useState<DataServiceApiKey[]>([]);
   const [logs, setLogs] = useState<DataServiceCallLog[]>([]);
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [updating, setUpdating] = useState(false);
   const [activeTab, setActiveTab] = useState<DetailTabKey>('overview');
-  const [docsOpen, setDocsOpen] = useState(false);
-  const [accessOpen, setAccessOpen] = useState(false);
-  const [runtimeOpen, setRuntimeOpen] = useState(false);
 
-  const load = useCallback(async (quiet = false) => {
+  const load = useCallback(async () => {
     if (!Number.isFinite(apiId) || apiId <= 0) {
       setLoading(false);
       return;
     }
 
-    quiet ? setRefreshing(true) : setLoading(true);
-
+    setLoading(true);
     try {
-      const [
-        servicesResponse,
-        dataSourceResponse,
-        runtimeResponse,
-        keyResponse,
-        logResponse,
-      ] = await Promise.all([
+      const [servicesResponse, dataSourceResponse, runtimeResponse, keyResponse, logResponse] = await Promise.all([
         fetchDataServices(),
         fetchDataSourceOptions(),
         fetchDataServiceRuntime(apiId),
         fetchDataServiceKeys(apiId),
         fetchDataServiceLogs(),
       ]);
-
-      setService(
-        (servicesResponse.data || []).find((item) => Number(item.id) === apiId),
-      );
+      setService((servicesResponse.data || []).find((item) => Number(item.id) === apiId));
       setDataSources(dataSourceResponse.data || []);
       setRuntime(runtimeResponse.data);
       setKeys(keyResponse.data || []);
@@ -215,7 +172,6 @@ export default function DataServiceDetailPage() {
       message.error(error?.message || '加载 API 详情失败');
     } finally {
       setLoading(false);
-      setRefreshing(false);
     }
   }, [apiId]);
 
@@ -228,15 +184,12 @@ export default function DataServiceDetailPage() {
 
   const dataSourceName = useMemo(() => {
     if (!service?.dataSourceId) return '-';
-    return dataSources.find(
-      (item) => String(item.value) === String(service.dataSourceId),
-    )?.label || `#${service.dataSourceId}`;
+    return dataSources.find((item) => String(item.value) === String(service.dataSourceId))?.label
+      || `#${service.dataSourceId}`;
   }, [dataSources, service?.dataSourceId]);
 
   const serviceLogs = useMemo(
-    () => logs
-      .filter((item) => Number(item.apiId) === apiId)
-      .slice(0, 50),
+    () => logs.filter((item) => Number(item.apiId) === apiId).slice(0, 50),
     [apiId, logs],
   );
 
@@ -244,35 +197,6 @@ export default function DataServiceDetailPage() {
     () => keys.filter((item) => item.enabled).length,
     [keys],
   );
-
-  const copyEndpoint = async () => {
-    if (!service?.runtimePath) return;
-
-    try {
-      await navigator.clipboard.writeText(service.runtimePath);
-      message.success('Endpoint 已复制');
-    } catch {
-      message.warning('复制失败，请手动复制');
-    }
-  };
-
-  const updateOnline = async () => {
-    if (!service || !sourceManaged) return;
-
-    setUpdating(true);
-    try {
-      const response = await republishDataService(service.id);
-      const revisionNo = response.data?.sourceRevisionNo;
-      message.success(
-        revisionNo ? `已更新上线到 DS R${revisionNo}` : '已更新上线',
-      );
-      await load(true);
-    } catch (error: any) {
-      message.error(error?.message || '更新上线失败');
-    } finally {
-      setUpdating(false);
-    }
-  };
 
   const logColumns: TableColumnsType<DataServiceCallLog> = [
     {
@@ -312,19 +236,10 @@ export default function DataServiceDetailPage() {
       dataIndex: 'errorMessage',
       ellipsis: true,
       render: (value) => value
-        ? (
-          <Tooltip title={value}>
-            <span className="text-[#b42318]">{value}</span>
-          </Tooltip>
-        )
+        ? <Tooltip title={value}><span className="text-[#b42318]">{value}</span></Tooltip>
         : <span className="text-black/20">-</span>,
     },
-    {
-      title: '时间',
-      dataIndex: 'createTime',
-      width: 150,
-      render: formatTime,
-    },
+    { title: '时间', dataIndex: 'createTime', width: 150, render: formatTime },
   ];
 
   if (loading) {
@@ -350,7 +265,6 @@ export default function DataServiceDetailPage() {
     : legacySqlRelease
       ? 'Legacy SQL Release'
       : 'Legacy';
-
   const sourceRevisionLabel = sourceManaged
     ? `DS R${service.sourceRevisionNo || '-'}`
     : legacySqlRelease
@@ -395,29 +309,12 @@ export default function DataServiceDetailPage() {
             </InfoField>
           ) : null}
         </div>
-
-        {legacySqlRelease ? (
-          <div className="mx-5 mb-5 rounded-md bg-[#fffaeb] px-4 py-3 text-[12px] text-[#93370d]">
-            历史来源已冻结
-          </div>
-        ) : null}
       </SectionCard>
     </div>
   );
 
   const accessContent = (
-    <SectionCard
-      title="API Key"
-      extra={(
-        <Button
-          size="small"
-          icon={<KeyRound size={13} />}
-          onClick={() => setAccessOpen(true)}
-        >
-          管理 API Key
-        </Button>
-      )}
-    >
+    <SectionCard title="API Key">
       <div className="grid grid-cols-1 gap-3 p-5 sm:grid-cols-3">
         <MetricTile
           label="访问模式"
@@ -431,18 +328,7 @@ export default function DataServiceDetailPage() {
 
   const runtimeContent = (
     <div className="grid gap-3 xl:grid-cols-2">
-      <SectionCard
-        title="运行指标"
-        extra={(
-          <Button
-            size="small"
-            icon={<Gauge size={13} />}
-            onClick={() => setRuntimeOpen(true)}
-          >
-            Runtime 配置
-          </Button>
-        )}
-      >
+      <SectionCard title="运行指标">
         <div className="grid grid-cols-2 gap-3 p-5">
           <MetricTile label="调用总数" value={runtime?.totalCalls || 0} />
           <MetricTile label="成功率" value={percent(runtime?.successRate)} />
@@ -454,21 +340,16 @@ export default function DataServiceDetailPage() {
       <SectionCard title="运行保护">
         <div className="grid grid-cols-1 gap-3 p-5 md:grid-cols-2">
           <div className="rounded-md bg-[#f7f7f8] px-4 py-4">
-            <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]">
-              <RefreshCw size={13} /> 结果缓存
-            </div>
-            <div className="mt-4 grid grid-cols-3 gap-3 text-[12px]">
+            <div className="text-[12px] font-medium text-[#344054]">结果缓存</div>
+            <div className="mt-4 grid grid-cols-3 gap-3">
               <InfoField label="状态">{runtime?.cacheEnabled ? '启用' : '关闭'}</InfoField>
               <InfoField label="命中率">{percent(runtime?.cacheHitRate)}</InfoField>
               <InfoField label="条目">{runtime?.cacheEntries || 0}</InfoField>
             </div>
           </div>
-
           <div className="rounded-md bg-[#f7f7f8] px-4 py-4">
-            <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]">
-              <ServerCog size={13} /> 熔断器
-            </div>
-            <div className="mt-4 grid grid-cols-3 gap-3 text-[12px]">
+            <div className="text-[12px] font-medium text-[#344054]">熔断器</div>
+            <div className="mt-4 grid grid-cols-3 gap-3">
               <InfoField label="状态">{runtime?.circuitState || 'DISABLED'}</InfoField>
               <InfoField label="拒绝">{runtime?.circuitRejected || 0}</InfoField>
               <InfoField label="最近失败">{formatTime(runtime?.lastFailureAt)}</InfoField>
@@ -480,21 +361,7 @@ export default function DataServiceDetailPage() {
   );
 
   const logsContent = (
-    <SectionCard
-      title="调用记录"
-      extra={(
-        <Button
-          size="small"
-          type="text"
-          icon={<RefreshCw size={13} />}
-          loading={refreshing}
-          className="!text-[#667085]"
-          onClick={() => void load(true)}
-        >
-          刷新
-        </Button>
-      )}
-    >
+    <SectionCard title="调用记录">
       <div className="p-5">
         {serviceLogs.length ? (
           <Table<DataServiceCallLog>
@@ -542,34 +409,27 @@ export default function DataServiceDetailPage() {
           </div>
 
           <section className="rounded-lg bg-white">
-            <div className="grid min-h-[176px] gap-6 px-5 py-6 lg:px-6 xl:grid-cols-[116px_minmax(0,1fr)_340px] xl:items-center">
+            <div className="grid min-h-[176px] gap-6 px-5 py-6 lg:px-6 xl:grid-cols-[116px_minmax(0,1fr)_180px] xl:items-center">
               <ApiIllustration />
-
               <div className="min-w-0">
                 <div className="max-w-[620px] truncate text-[14px] font-medium leading-5 text-[#161823]">
                   {service.name}
                 </div>
-
                 <div className="mt-1 text-[12px] leading-4 text-[#8a8f98]">
                   {formatTime(service.updateTime || service.createTime)}
                 </div>
-
                 <div className="mt-1 flex items-center gap-1 text-[11px] leading-4 text-[#667085]">
-                  <span
-                    className={[
-                      'inline-block h-[10px] w-[10px] rounded-full',
-                      service.enabled ? 'bg-[#20c77a]' : 'bg-[#b0b5bd]',
-                    ].join(' ')}
-                  />
+                  <span className={[
+                    'inline-block h-[10px] w-[10px] rounded-full',
+                    service.enabled ? 'bg-[#20c77a]' : 'bg-[#b0b5bd]',
+                  ].join(' ')} />
                   <span>{service.enabled ? '运行中' : '已停用'}</span>
                 </div>
-
                 <div className="mt-2 flex min-w-0 items-center gap-2 text-[11px] leading-4 text-[#8a8f98]">
                   <span className="font-mono">GET</span>
                   <span className="text-[#d0d5dd]">·</span>
                   <span className="truncate font-mono">{service.runtimePath}</span>
                 </div>
-
                 <div className="mt-1.5 flex min-w-0 items-center gap-1.5 text-[11px] leading-4 text-[#8a8f98]">
                   <span>{sourceTypeLabel}</span>
                   <span className="text-[#d0d5dd]">·</span>
@@ -578,41 +438,14 @@ export default function DataServiceDetailPage() {
                   <span className="truncate">{dataSourceName}</span>
                 </div>
               </div>
-
               <div className="min-w-0 xl:justify-self-end">
-                <div className="flex flex-wrap justify-end gap-2">
-                  <Button
-                    icon={<FileText size={14} />}
-                    onClick={() => setDocsOpen(true)}
-                  >
-                    OpenAPI / 调试
-                  </Button>
-                  <Button
-                    icon={<Copy size={14} />}
-                    onClick={() => void copyEndpoint()}
-                  >
-                    复制 Endpoint
-                  </Button>
-                  <Tooltip title="刷新">
-                    <Button
-                      icon={<RefreshCw size={14} />}
-                      loading={refreshing}
-                      onClick={() => void load(true)}
-                    />
-                  </Tooltip>
-                </div>
-
-                {sourceManaged ? (
-                  <div className="mt-2 flex justify-end">
-                    <Button
-                      type="primary"
-                      loading={updating}
-                      onClick={() => void updateOnline()}
-                    >
-                      更新上线
-                    </Button>
-                  </div>
-                ) : null}
+                <Button
+                  type="primary"
+                  icon={<PlayCircle size={14} />}
+                  onClick={() => history.push(`/data-service/debug?apiId=${service.id}`)}
+                >
+                  调试
+                </Button>
               </div>
             </div>
           </section>
@@ -631,31 +464,6 @@ export default function DataServiceDetailPage() {
           </div>
         </div>
       </div>
-
-      <DataServiceDocsModal
-        open={docsOpen}
-        service={service}
-        readOnly={sourceManaged}
-        onCancel={() => setDocsOpen(false)}
-      />
-
-      <DataServiceAccessModal
-        open={accessOpen}
-        service={service}
-        onCancel={() => setAccessOpen(false)}
-        onChanged={async () => {
-          await load(true);
-        }}
-      />
-
-      <DataServiceRuntimeModal
-        open={runtimeOpen}
-        service={service}
-        onCancel={() => {
-          setRuntimeOpen(false);
-          void load(true);
-        }}
-      />
     </ConfigProvider>
   );
 }


### PR DESCRIPTION
## 这次调整

- API 详情页继续做减法：只保留一个主操作「调试」
- API Key / Runtime / 调用记录改为只读展示，暂不暴露额外管理按钮
- 新增独立 `API 调试` 页面，并加入数据服务菜单
- API 详情点击「调试」直接跳转到 `/data-service/debug?apiId=...`
- API 调试页支持直接进入后选择 API
- 调试布局参考 DataWorks：左侧请求配置，右侧请求详情 / 返回内容
- 复用现有 `documentation` 与 `testDataService` 接口，不新增后端接口和数据库表
- 补充导航测试

## 变更范围

- `yak-ops-ui/src/pages/data-service/detail/index.tsx`
- `yak-ops-ui/src/pages/data-service/debug/index.tsx`
- `yak-ops-ui/src/config/navigation.ts`
- `yak-ops-ui/src/config/navigation.test.ts`

基于最新 main，1 commit。