### PR TITLE
优化仪表盘编辑区的大屏布局

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -215,15 +215,15 @@ export default function DashboardEditorPage() {
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <main className="min-w-0 flex-1 overflow-auto bg-[#f6f7f9]">
-          <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-4'}>
+          <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-4 2xl:p-0'}>
             <div
               ref={containerRef}
               className={[
-                'mx-auto min-w-[760px] rounded-[10px] bg-white',
+                'min-w-[760px] bg-white',
                 canvasMinHeight,
                 designer.preview
-                  ? 'max-w-[1480px] border border-[#e7e9ed] shadow-[0_6px_24px_rgba(16,24,40,.055)]'
-                  : 'dashboard-grid-canvas max-w-[1540px] border border-[#e3e6ea] shadow-[0_2px_8px_rgba(16,24,40,.035)]',
+                  ? 'mx-auto max-w-[1480px] rounded-[10px] border border-[#e7e9ed] shadow-[0_6px_24px_rgba(16,24,40,.055)]'
+                  : 'dashboard-grid-canvas mx-auto max-w-[1540px] rounded-[10px] border border-[#e3e6ea] shadow-[0_2px_8px_rgba(16,24,40,.035)] 2xl:mx-0 2xl:max-w-none 2xl:rounded-none 2xl:border-0 2xl:shadow-none',
               ].join(' ')}
               onMouseDown={(event) => {
                 if (event.target === event.currentTarget) designer.setSelectedId(undefined);


### PR DESCRIPTION
## 调整内容

- 大屏（`2xl` / ≥1536px）下移除仪表盘编辑内容区外围 padding，让画布直接使用可用宽度
- 大屏下取消编辑画布 `max-width` 限制、左右居中留白、外层 border、圆角和阴影
- 中小屏继续保留原有留白、边框和圆角，避免普通笔记本尺寸下内容贴边
- 预览模式保持原样，本次只调整编辑态
- 图表组件自身的网格间距和卡片边界不变，避免影响拖拽/缩放体验

## 说明

本次修改针对宽屏下“内容区套在一个居中的白色容器里”造成的大面积无效留白。编辑态更接近真正的大屏工作区，画布会随着可用区域铺开。

## 验证

- 已检查 diff，仅修改 `yak-ops-ui/src/pages/dashboard/editor.tsx`
- 当前执行环境无法直接启动仓库前端，因此未做浏览器运行截图验证