### PR TITLE
feat: add dataset node authoring workbench

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -8,7 +8,6 @@ import type {
   DevelopmentId,
   DevelopmentResourceNode,
 } from '../types';
-import DatasetNodeEditor from './dataset/DatasetNodeEditor';
 import DevelopmentWorkbench from './workbench/DevelopmentWorkbench';
 
 interface DevelopmentEditorWorkspaceProps {
@@ -83,7 +82,10 @@ export default function DevelopmentEditorWorkspace({
     [nodes, selectedNodeId],
   );
   const workbenchNodes = useMemo(
-    () => nodes.filter((node) => isDevelopmentTaskNode(node) || node.type === 'DATA_SERVICE'),
+    () => nodes.filter((node) =>
+      isDevelopmentTaskNode(node)
+      || node.type === 'DATA_SERVICE'
+      || node.type === 'DATASET'),
     [nodes],
   );
 
@@ -96,24 +98,18 @@ export default function DevelopmentEditorWorkspace({
           </div>
           <div className="text-[13px] font-medium text-[#475467]">选择一个开发节点</div>
           <div className="mt-1 text-[11px] text-[#98a2b3]">
-            SQL、Shell、数据集和数据服务都是独立节点；执行关系请在工作流模块配置。
+            SQL、Shell、数据集和数据服务都在统一开发工作台中打开。
           </div>
         </div>
       </main>
     );
   }
 
-  if (selectedResource.type === 'DATASET') {
-    return (
-      <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-        <ResourceEditorBoundary resourceKey={selectedResource.id}>
-          <DatasetNodeEditor node={selectedResource} onSaved={onNodesChanged} />
-        </ResourceEditorBoundary>
-      </main>
-    );
-  }
-
-  if (isDevelopmentTaskNode(selectedResource) || selectedResource.type === 'DATA_SERVICE') {
+  if (
+    isDevelopmentTaskNode(selectedResource)
+    || selectedResource.type === 'DATA_SERVICE'
+    || selectedResource.type === 'DATASET'
+  ) {
     return (
       <ResourceEditorBoundary resourceKey={selectedResource.id}>
         <DevelopmentWorkbench

--- a/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
@@ -1,6 +1,24 @@
-import { Button, Input, Select, Spin, Table, Tag, message, type TableColumnsType } from 'antd';
-import { Database, RefreshCw, Save } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { BRAND_CSS_VARIABLES } from '@/styles/brand';
+import {
+  Button,
+  Input,
+  Select,
+  Spin,
+  Table,
+  Tooltip,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import {
+  FileStack,
+  LoaderCircle,
+  Play,
+  RefreshCw,
+  Save,
+  X,
+} from 'lucide-react';
+import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   getDevelopmentDatasetNode,
@@ -16,12 +34,70 @@ import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
 interface DatasetNodeEditorProps {
   node: DevelopmentResourceNode;
   onSaved?: () => void | Promise<void>;
+  onDirtyChange?: (dirty: boolean) => void;
 }
+
+type RightPanelKey = 'properties' | 'versions';
+
+const panelItems: Array<{ key: RightPanelKey; label: string }> = [
+  { key: 'properties', label: '属性' },
+  { key: 'versions', label: '版本' },
+];
 
 const roleOptions = [
   { label: '维度', value: 'DIMENSION' },
   { label: '指标', value: 'MEASURE' },
 ];
+
+const DEFAULT_PANEL_WIDTH = 380;
+const MIN_PANEL_WIDTH = 280;
+const MAX_PANEL_WIDTH = 640;
+const PANEL_WIDTH_STORAGE_KEY = 'yak-data-development.dataset-right-panel-width';
+
+const iconButtonClassName =
+  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
+
+interface ToolbarButtonProps {
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+}
+
+const ToolbarButton = ({ title, onClick, disabled, children }: ToolbarButtonProps) => (
+  <Tooltip title={title} mouseEnterDelay={0.35}>
+    <button
+      type="button"
+      aria-label={title}
+      disabled={disabled}
+      onClick={onClick}
+      className={iconButtonClassName}
+    >
+      {children}
+    </button>
+  </Tooltip>
+);
+
+const ToolbarDivider = () => <span className="mx-1 h-4 w-px shrink-0 bg-[#e5e7eb]" />;
+
+const clampPanelWidth = (value: number) =>
+  Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, value));
+
+const initialPanelWidth = () => {
+  if (typeof window === 'undefined') return DEFAULT_PANEL_WIDTH;
+  const stored = Number(window.localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
+  return Number.isFinite(stored) && stored > 0
+    ? clampPanelWidth(stored)
+    : DEFAULT_PANEL_WIDTH;
+};
+
+const formatTime = (value?: string | null) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value.replace('T', ' ').slice(0, 19)
+    : date.toLocaleString('zh-CN', { hour12: false });
+};
 
 const toFieldDrafts = (context?: DevelopmentDatasetNodeContext) =>
   (context?.dataset?.fields || []).map((field) => ({
@@ -34,32 +110,52 @@ const toFieldDrafts = (context?: DevelopmentDatasetNodeContext) =>
     defaultRole: field.defaultRole,
   }));
 
-const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
+const DatasetNodeEditor = ({ node, onSaved, onDirtyChange }: DatasetNodeEditorProps) => {
+  const dirtyChangeRef = useRef(onDirtyChange);
   const [context, setContext] = useState<DevelopmentDatasetNodeContext>();
   const [selectedSourceId, setSelectedSourceId] = useState<DevelopmentId>();
   const [description, setDescription] = useState('');
   const [fields, setFields] = useState<DevelopmentDatasetFieldDraft[]>([]);
+  const [dirty, setDirty] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string>();
   const [previewing, setPreviewing] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [activePanel, setActivePanel] = useState<RightPanelKey>();
+  const [panelWidth, setPanelWidth] = useState(initialPanelWidth);
+  const [resizing, setResizing] = useState(false);
+
+  useEffect(() => {
+    dirtyChangeRef.current = onDirtyChange;
+  }, [onDirtyChange]);
+
+  const setDirtyState = useCallback((next: boolean) => {
+    setDirty(next);
+    dirtyChangeRef.current?.(next);
+  }, []);
+
+  const markDirty = useCallback(() => setDirtyState(true), [setDirtyState]);
+
+  useEffect(() => () => dirtyChangeRef.current?.(false), []);
 
   const applyContext = useCallback((next: DevelopmentDatasetNodeContext) => {
     setContext(next);
     setSelectedSourceId(next.selectedSource?.taskAssetId);
     setDescription(next.dataset?.description || '');
     setFields(toFieldDrafts(next));
-  }, []);
+    setDirtyState(false);
+  }, [setDirtyState]);
 
   const load = useCallback(async () => {
     setLoading(true);
+    setLoadError(undefined);
     try {
       applyContext(await getDevelopmentDatasetNode(node.id));
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '加载 Dataset Node 失败');
+      const text = error instanceof Error ? error.message : '加载 Dataset Node 失败';
+      setLoadError(text);
       setContext(undefined);
-      setSelectedSourceId(undefined);
-      setDescription('');
-      setFields([]);
+      message.error(text);
     } finally {
       setLoading(false);
     }
@@ -69,6 +165,54 @@ const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
     void load();
   }, [load]);
 
+  const availableSources = context?.availableSources || [];
+  const currentVersion = context?.dataset?.currentVersion;
+  const selectableSourceIds = useMemo(
+    () => new Set(availableSources.map((source) => source.taskAssetId)),
+    [availableSources],
+  );
+
+  const sourceOptions = useMemo(() => {
+    const values: DevelopmentDatasetNodeSource[] = [...availableSources];
+    const selected = context?.selectedSource;
+    if (selected && !values.some((item) => item.taskAssetId === selected.taskAssetId)) {
+      values.unshift(selected);
+    }
+    return values.map((source) => ({
+      value: source.taskAssetId,
+      label: `${source.nodeName} · SQL R${source.revisionNo}`,
+      disabled: source.status !== 'ONLINE',
+    }));
+  }, [availableSources, context?.selectedSource]);
+
+  const activeSource = useMemo(
+    () => availableSources.find((source) => source.taskAssetId === selectedSourceId)
+      || (context?.selectedSource?.taskAssetId === selectedSourceId ? context.selectedSource : undefined),
+    [availableSources, context?.selectedSource, selectedSourceId],
+  );
+
+  const sourceSelectable = Boolean(selectedSourceId && selectableSourceIds.has(selectedSourceId));
+  const sourceChanged = Boolean(
+    selectedSourceId
+      && currentVersion?.sourceTaskAssetId
+      && selectedSourceId !== currentVersion.sourceTaskAssetId,
+  );
+  const sourceUpdated = Boolean(
+    activeSource
+      && currentVersion
+      && activeSource.taskAssetId === currentVersion.sourceTaskAssetId
+      && activeSource.revisionNo !== currentVersion.sourceTaskRevisionNo,
+  );
+
+  const changeSource = (value: DevelopmentId) => {
+    setSelectedSourceId(value);
+    const sameSnapshot = currentVersion
+      && value === currentVersion.sourceTaskAssetId
+      && activeSource?.revisionNo === currentVersion.sourceTaskRevisionNo;
+    if (!sameSnapshot) setFields([]);
+    markDirty();
+  };
+
   const updateField = useCallback((
     index: number,
     patch: Partial<DevelopmentDatasetFieldDraft>,
@@ -76,13 +220,14 @@ const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
     setFields((current) => current.map((field, fieldIndex) =>
       fieldIndex === index ? { ...field, ...patch } : field,
     ));
-  }, []);
+    markDirty();
+  }, [markDirty]);
 
   const columns = useMemo<TableColumnsType<DevelopmentDatasetFieldDraft>>(() => [
     {
       title: '字段',
       dataIndex: 'physicalName',
-      width: 180,
+      width: 190,
       render: (value: string) => (
         <span className="font-mono text-[12px] text-[#344054]">{value}</span>
       ),
@@ -104,7 +249,9 @@ const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
       title: '类型',
       dataIndex: 'dataType',
       width: 110,
-      render: (value: string) => <Tag className="!m-0">{value}</Tag>,
+      render: (value: string) => (
+        <span className="font-mono text-[11px] text-[#667085]">{value}</span>
+      ),
     },
     {
       title: '角色',
@@ -138,53 +285,12 @@ const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
           size="small"
           value={value || ''}
           maxLength={1000}
-          placeholder="可选"
+          placeholder="字段说明"
           onChange={(event) => updateField(index, { description: event.target.value })}
         />
       ),
     },
   ], [updateField]);
-
-  const availableSources = context?.availableSources || [];
-  const selectableSourceIds = useMemo(
-    () => new Set(availableSources.map((source) => source.taskAssetId)),
-    [availableSources],
-  );
-  const sourceOptions = useMemo(() => {
-    const values: DevelopmentDatasetNodeSource[] = [...availableSources];
-    const selected = context?.selectedSource;
-    if (selected && !values.some((item) => item.taskAssetId === selected.taskAssetId)) {
-      values.unshift(selected);
-    }
-    return values.map((source) => ({
-      value: source.taskAssetId,
-      label: `${source.nodeName} · SQL R${source.revisionNo} · ${source.status}`,
-      disabled: source.status !== 'ONLINE',
-    }));
-  }, [availableSources, context?.selectedSource]);
-  const activeSource = useMemo(
-    () => availableSources.find((source) => source.taskAssetId === selectedSourceId)
-      || (context?.selectedSource?.taskAssetId === selectedSourceId ? context.selectedSource : undefined),
-    [availableSources, context?.selectedSource, selectedSourceId],
-  );
-  const currentVersion = context?.dataset?.currentVersion;
-  const sourceChanged = Boolean(
-    selectedSourceId
-      && currentVersion?.sourceTaskAssetId
-      && selectedSourceId !== currentVersion.sourceTaskAssetId,
-  );
-  const sourceUpdated = Boolean(
-    activeSource
-      && currentVersion
-      && activeSource.taskAssetId === currentVersion.sourceTaskAssetId
-      && activeSource.revisionNo !== currentVersion.sourceTaskRevisionNo,
-  );
-  const sourceSelectable = Boolean(selectedSourceId && selectableSourceIds.has(selectedSourceId));
-
-  const changeSource = (value: DevelopmentId) => {
-    setSelectedSourceId(value);
-    if (value !== currentVersion?.sourceTaskAssetId) setFields([]);
-  };
 
   const preview = async () => {
     if (!selectedSourceId || !sourceSelectable || previewing) return;
@@ -205,7 +311,8 @@ const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
           defaultRole: previous.defaultRole,
         } : field;
       }));
-      message.success(`已发现 ${next.length} 个输出字段`);
+      markDirty();
+      message.success(`已发现 ${next.length} 个字段`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '发现 Dataset 字段失败');
     } finally {
@@ -228,12 +335,113 @@ const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
       });
       applyContext(next);
       await onSaved?.();
-      message.success(`Dataset 已保存 · DV${next.dataset?.currentVersion?.versionNo || 1}`);
+      message.success(`数据集已保存 · DV${next.dataset?.currentVersion?.versionNo || 1}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存 Dataset Node 失败');
     } finally {
       setSaving(false);
     }
+  };
+
+  const versions = useMemo(
+    () => [...(context?.dataset?.versions || [])].sort((left, right) => right.versionNo - left.versionNo),
+    [context?.dataset?.versions],
+  );
+
+  const propertiesPanel = (
+    <div className="text-[12px] leading-5">
+      <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-x-4 gap-y-4">
+        <div className="text-[#667085]">数据集名称：</div>
+        <Input size="small" value={node.name} disabled />
+        <div className="self-start pt-1 text-[#667085]">描述：</div>
+        <Input.TextArea
+          autoSize={{ minRows: 3, maxRows: 6 }}
+          maxLength={2000}
+          value={description}
+          placeholder="说明这个数据集提供什么数据"
+          onChange={(event) => {
+            setDescription(event.target.value);
+            markDirty();
+          }}
+        />
+      </div>
+
+      <dl className="m-0 mt-5 grid grid-cols-[88px_minmax(0,1fr)] gap-x-4 gap-y-3 border-t border-[#eef0f2] pt-4">
+        <dt className="text-[#667085]">Dataset：</dt>
+        <dd className="m-0 text-[#344054]">{context?.dataset ? `#${context.dataset.datasetId}` : '尚未创建'}</dd>
+        <dt className="text-[#667085]">当前版本：</dt>
+        <dd className="m-0 text-[#344054]">{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存'}</dd>
+        <dt className="text-[#667085]">来源 SQL：</dt>
+        <dd className="m-0 break-all text-[#344054]">
+          {activeSource ? `${activeSource.nodeName} · SQL R${activeSource.revisionNo}` : '未选择'}
+        </dd>
+        <dt className="text-[#667085]">字段：</dt>
+        <dd className="m-0 text-[#344054]">{fields.length} 个</dd>
+      </dl>
+    </div>
+  );
+
+  const versionsPanel = (
+    <div className="space-y-2 text-[12px]">
+      {versions.length ? versions.map((version, index) => (
+        <div
+          key={version.versionId}
+          className="flex items-center gap-2 rounded-[3px] border border-[#eaecf0] px-2.5 py-2"
+        >
+          <FileStack size={14} className="shrink-0 text-[#667085]" strokeWidth={1.7} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-[#344054]">DV{version.versionNo}</span>
+              {index === 0 ? (
+                <span className="rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[10px] text-[#667085]">当前</span>
+              ) : null}
+            </div>
+            <div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">
+              SQL R{version.sourceTaskRevisionNo} · {formatTime(version.createTime)}
+            </div>
+          </div>
+        </div>
+      )) : (
+        <div className="py-8 text-center text-[11px] text-[#98a2b3]">暂无数据集版本</div>
+      )}
+    </div>
+  );
+
+  const panelContent: Record<RightPanelKey, ReactNode> = {
+    properties: propertiesPanel,
+    versions: versionsPanel,
+  };
+
+  const handleResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!activePanel) return;
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = panelWidth;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    setResizing(true);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const resize = (moveEvent: PointerEvent) => {
+      setPanelWidth(clampPanelWidth(startWidth + startX - moveEvent.clientX));
+    };
+    const finish = (upEvent: PointerEvent) => {
+      const nextWidth = clampPanelWidth(startWidth + startX - upEvent.clientX);
+      setPanelWidth(nextWidth);
+      setResizing(false);
+      window.localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(nextWidth));
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener('pointermove', resize);
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', finish);
+    };
+
+    window.addEventListener('pointermove', resize);
+    window.addEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', finish);
   };
 
   if (loading) {
@@ -244,120 +452,197 @@ const DatasetNodeEditor = ({ node, onSaved }: DatasetNodeEditorProps) => {
     );
   }
 
-  return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
-      <div className="flex h-12 shrink-0 items-center justify-between border-b border-[#e4e7ec] px-4">
-        <div className="flex min-w-0 items-center gap-2.5">
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#f5f5f6] text-[#475467]">
-            <Database size={15} />
-          </span>
-          <div className="min-w-0">
-            <div className="truncate text-[13px] font-semibold text-[#161823]">{node.name}</div>
-            <div className="text-[10px] text-[#98a2b3]">
-              数据集节点{context?.dataset ? ` · Dataset #${context.dataset.datasetId}` : ' · 尚未创建资产'}
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            size="small"
-            icon={<RefreshCw size={13} />}
-            loading={previewing}
-            disabled={!sourceSelectable}
-            onClick={() => void preview()}
-          >
-            {fields.length ? '刷新字段' : '发现字段'}
-          </Button>
-          <Button
-            size="small"
-            type="primary"
-            icon={<Save size={13} />}
-            loading={saving}
-            disabled={!sourceSelectable || !fields.length}
-            onClick={() => void save()}
-          >
-            保存数据集
+  if (loadError || !context) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6">
+        <div className="max-w-[520px] text-center">
+          <div className="text-[14px] font-semibold text-[#344054]">Dataset Node 加载失败</div>
+          <div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">{loadError || '未返回有效编辑上下文'}</div>
+          <Button className="mt-4" size="small" icon={<RefreshCw size={13} />} onClick={() => void load()}>
+            重新加载
           </Button>
         </div>
       </div>
+    );
+  }
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <section className="border-b border-[#eef0f2] px-4 py-3">
-          <div className="mb-2 text-[11px] font-semibold text-[#344054]">来源 SQL</div>
-          <div className="grid max-w-[900px] grid-cols-[110px_minmax(0,1fr)] items-start gap-y-2">
-            <span className="pt-1.5 text-[11px] text-[#667085]">SQL 节点</span>
-            <Select
-              showSearch
-              optionFilterProp="label"
-              value={selectedSourceId}
-              options={sourceOptions}
-              placeholder="选择一个已发布的 SQL 节点"
-              className="w-full"
-              onChange={(value) => changeSource(String(value))}
-            />
-          </div>
-          <div className="ml-[110px] mt-1.5 text-[10px] leading-5 text-[#98a2b3]">
-            数据集只引用已发布 SQL 的不可变 Revision；节点之间的执行依赖请在“工作流”模块配置。
-          </div>
-          {!availableSources.length ? (
-            <div className="mt-2 rounded-md border border-[#f2d6a2] bg-[#fffbeb] px-2.5 py-2 text-[11px] text-[#8a6116]">
-              当前项目暂无可选的 ONLINE SQL，请先发布一个 SQL 节点。
-            </div>
+  const canPreview = sourceSelectable;
+  const canSave = sourceSelectable && fields.length > 0 && dirty;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2">
+        <div className="flex shrink-0 items-center gap-0.5">
+          <ToolbarButton
+            title={previewing ? '正在发现字段' : fields.length ? '刷新字段' : '发现字段'}
+            disabled={!canPreview || previewing}
+            onClick={() => void preview()}
+          >
+            {previewing ? <LoaderCircle size={15} className="animate-spin" /> : <Play size={15} strokeWidth={1.8} />}
+          </ToolbarButton>
+          <ToolbarDivider />
+          <ToolbarButton
+            title="保存数据集版本"
+            disabled={!canSave || saving}
+            onClick={() => void save()}
+          >
+            {saving ? <LoaderCircle size={15} className="animate-spin" /> : <Save size={15} strokeWidth={1.8} />}
+          </ToolbarButton>
+        </div>
+
+        <div className="flex min-w-0 items-center gap-2 pr-1">
+          <span className="shrink-0 text-[10px] text-[#98a2b3]">来源 SQL</span>
+          <Select
+            showSearch
+            optionFilterProp="label"
+            variant="borderless"
+            size="small"
+            value={selectedSourceId}
+            options={sourceOptions}
+            placeholder="选择已发布 SQL"
+            className="min-w-[260px] max-w-[360px]"
+            popupMatchSelectWidth={360}
+            onChange={(value) => changeSource(String(value))}
+          />
+          {sourceUpdated ? (
+            <span className="shrink-0 text-[10px] font-medium text-[#f79009]">有新 Revision</span>
+          ) : sourceChanged ? (
+            <span className="shrink-0 text-[10px] font-medium text-[#f79009]">来源已更换</span>
           ) : null}
-          {activeSource ? (
-            <div className="mt-2 flex items-center gap-2 text-[11px] text-[#667085]">
-              <span>{activeSource.nodeName}</span>
-              <span>·</span>
-              <span>SQL R{activeSource.revisionNo}</span>
-              <Tag className="!m-0">{activeSource.status}</Tag>
-              {currentVersion ? (
-                <span className="text-[#98a2b3]">
-                  当前数据集：DV{currentVersion.versionNo} / SQL R{currentVersion.sourceTaskRevisionNo}
-                </span>
-              ) : null}
-              {sourceChanged ? <span className="font-medium text-[#f79009]">来源已更换</span> : null}
-              {sourceUpdated ? <span className="font-medium text-[#f79009]">SQL 已有新 Revision</span> : null}
-            </div>
-          ) : null}
-        </section>
+        </div>
+      </div>
 
-        <section className="border-b border-[#eef0f2] px-4 py-3">
-          <div className="mb-2 text-[11px] font-semibold text-[#344054]">基本信息</div>
-          <div className="grid max-w-[900px] grid-cols-[110px_minmax(0,1fr)] items-start gap-y-2">
-            <span className="pt-1.5 text-[11px] text-[#667085]">名称</span>
-            <Input size="small" value={node.name} disabled />
-            <span className="pt-1.5 text-[11px] text-[#667085]">描述</span>
-            <Input.TextArea
-              value={description}
-              maxLength={2000}
-              autoSize={{ minRows: 2, maxRows: 4 }}
-              placeholder="说明这个数据集提供什么数据"
-              onChange={(event) => setDescription(event.target.value)}
-            />
-          </div>
-        </section>
-
-        <section className="px-4 py-3">
-          <div className="mb-2 flex items-center justify-between">
-            <div>
-              <div className="text-[11px] font-semibold text-[#344054]">字段结构</div>
-              <div className="mt-0.5 text-[10px] text-[#98a2b3]">
-                物理字段和类型来自选中的 SQL Revision；可调整显示名称、角色和描述。
-              </div>
-            </div>
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <section className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+          <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#eef0f2] px-3">
+            <span className="text-[12px] font-medium text-[#344054]">字段结构</span>
             <span className="text-[10px] text-[#98a2b3]">{fields.length} 个字段</span>
           </div>
-          <Table<DevelopmentDatasetFieldDraft>
-            size="small"
-            bordered={false}
-            pagination={false}
-            rowKey={(record) => record.fieldId || record.physicalName}
-            dataSource={fields}
-            columns={columns}
-            locale={{ emptyText: sourceSelectable ? '点击“发现字段”读取 SQL 输出结构' : '先选择一个已发布 SQL' }}
-            scroll={{ x: 880 }}
-          />
+
+          <div className="min-h-0 flex-1 overflow-hidden px-2 pt-2">
+            <Table<DevelopmentDatasetFieldDraft>
+              size="small"
+              bordered={false}
+              pagination={false}
+              rowKey={(record) => record.fieldId || record.physicalName}
+              dataSource={fields}
+              columns={columns}
+              locale={{
+                emptyText: sourceSelectable
+                  ? '点击顶部“发现字段”读取 SQL 输出结构'
+                  : '选择一个已发布 SQL',
+              }}
+              scroll={{ x: 900, y: 'calc(100vh - 220px)' }}
+            />
+          </div>
+
+          <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-2.5 text-[10px] text-[#7b808a]">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="font-medium text-[#667085]">DATASET</span>
+              <span className="truncate">{node.name}</span>
+              {dirty ? (
+                <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />
+                  未保存
+                </span>
+              ) : null}
+              <span className="max-w-[280px] truncate text-[#667085]">
+                {activeSource ? `${activeSource.nodeName} · SQL R${activeSource.revisionNo}` : '未选择来源 SQL'}
+              </span>
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+              <span>{fields.length} 个字段</span>
+              <span>{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存版本'}</span>
+            </div>
+          </div>
         </section>
+
+        <aside className="flex shrink-0 bg-white" style={BRAND_CSS_VARIABLES}>
+          <div
+            className={[
+              'relative h-full shrink-0',
+              resizing ? 'transition-none' : 'transition-[width] duration-200 ease-out',
+            ].join(' ')}
+            style={{ width: activePanel ? panelWidth : 0 }}
+          >
+            {activePanel ? (
+              <div
+                role="separator"
+                aria-label="调整右侧面板宽度"
+                aria-orientation="vertical"
+                onPointerDown={handleResizeStart}
+                className="group absolute inset-y-0 left-0 z-30 w-3 -translate-x-1/2 cursor-col-resize touch-none"
+              >
+                <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e5e7eb] transition-[width,background-color] duration-150 group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:w-[2px] group-active:bg-[rgba(254,44,85,1)]" />
+              </div>
+            ) : null}
+
+            <div className="h-full overflow-hidden">
+              <div className="flex h-full flex-col bg-white" style={{ width: panelWidth }}>
+                <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4">
+                  <span className="text-[13px] font-semibold text-[#30323b]">
+                    {panelItems.find((item) => item.key === activePanel)?.label}
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      title="刷新"
+                      onClick={() => {
+                        if (dirty) {
+                          message.warning('当前有未保存修改，请先保存');
+                          return;
+                        }
+                        void load();
+                      }}
+                      className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
+                    >
+                      <RefreshCw size={13} strokeWidth={1.8} />
+                      刷新
+                    </button>
+                    <button
+                      type="button"
+                      title="关闭"
+                      aria-label="关闭右侧面板"
+                      onClick={() => setActivePanel(undefined)}
+                      className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"
+                    >
+                      <X size={14} strokeWidth={1.8} />
+                    </button>
+                  </div>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+                  {activePanel ? panelContent[activePanel] : null}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex h-full w-9 shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
+            {panelItems.map((item, index) => {
+              const active = activePanel === item.key;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  title={item.label}
+                  aria-label={`${active ? '收起' : '展开'}${item.label}`}
+                  aria-expanded={active}
+                  onClick={() => setActivePanel((current) => current === item.key ? undefined : item.key)}
+                  className={[
+                    'relative flex min-h-[72px] w-9 shrink-0 items-center justify-center border-b border-[#e5e7eb] py-3 text-[12px] leading-5 transition-[color,background-color,opacity]',
+                    '[writing-mode:vertical-rl] [letter-spacing:3px]',
+                    index === 0 ? 'border-t' : '',
+                    active
+                      ? 'text-[var(--yak-brand-color)] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[var(--yak-brand-color)]'
+                      : 'text-[#475467] opacity-70 hover:bg-[#f7f8fa] hover:text-[#344054] hover:opacity-100',
+                  ].join(' ')}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+        </aside>
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -29,6 +29,7 @@ import type {
   DevelopmentTaskRunResult,
 } from '../../types';
 import DataServiceNodeEditor from '../data-service/DataServiceNodeEditor';
+import DatasetNodeEditor from '../dataset/DatasetNodeEditor';
 import EditorHost from './EditorHost';
 import EditorTabs, { type EditorTabAction } from './EditorTabs';
 import EditorToolbar from './EditorToolbar';
@@ -48,19 +49,18 @@ interface PendingCloseRequest {
   dirtyNodeIds: DevelopmentId[];
 }
 
-interface DataServiceWorkbenchEditorProps {
+interface StandaloneWorkbenchEditorProps {
   node: DevelopmentResourceNode;
   active: boolean;
   onSaved?: () => void | Promise<void>;
-  onOpenSourceNode: (nodeId: DevelopmentId) => void;
   onDirtyChange: (dirty: boolean) => void;
 }
 
-/**
- * Keep the authoring node identity stable while the directory tree refreshes. A save in another tab
- * may recreate the node list; that must not force a hidden Data Service editor to reload and discard
- * its unsaved local form state.
- */
+interface DataServiceWorkbenchEditorProps extends StandaloneWorkbenchEditorProps {
+  onOpenSourceNode: (nodeId: DevelopmentId) => void;
+}
+
+/** Keep standalone resource identity stable when the directory tree refreshes. */
 const DataServiceWorkbenchEditor = ({
   node,
   active,
@@ -68,10 +68,7 @@ const DataServiceWorkbenchEditor = ({
   onOpenSourceNode,
   onDirtyChange,
 }: DataServiceWorkbenchEditorProps) => {
-  const stableNode = useMemo(
-    () => node,
-    [node.id, node.name],
-  );
+  const stableNode = useMemo(() => node, [node.id, node.name]);
 
   return (
     <div
@@ -84,6 +81,30 @@ const DataServiceWorkbenchEditor = ({
         node={stableNode}
         onSaved={onSaved}
         onOpenSourceNode={onOpenSourceNode}
+        onDirtyChange={onDirtyChange}
+      />
+    </div>
+  );
+};
+
+const DatasetWorkbenchEditor = ({
+  node,
+  active,
+  onSaved,
+  onDirtyChange,
+}: StandaloneWorkbenchEditorProps) => {
+  const stableNode = useMemo(() => node, [node.id, node.name]);
+
+  return (
+    <div
+      className={[
+        'min-h-0 flex-1 overflow-hidden',
+        active ? 'flex' : 'hidden',
+      ].join(' ')}
+    >
+      <DatasetNodeEditor
+        node={stableNode}
+        onSaved={onSaved}
         onDirtyChange={onDirtyChange}
       />
     </div>
@@ -119,7 +140,7 @@ const DevelopmentWorkbench = ({
   const [publishing, setPublishing] = useState(false);
   const [closeSaving, setCloseSaving] = useState(false);
   const [versionsRefreshKey, setVersionsRefreshKey] = useState(0);
-  const [dataServiceDirtyNodeIds, setDataServiceDirtyNodeIds] = useState<DevelopmentId[]>([]);
+  const [resourceDirtyNodeIds, setResourceDirtyNodeIds] = useState<DevelopmentId[]>([]);
 
   const nodeMap = useMemo(
     () => new Map(nodes.map((node) => [node.id, node])),
@@ -143,7 +164,7 @@ const DevelopmentWorkbench = ({
     setActiveNodeId((current) =>
       current && nodeMap.has(current) ? current : undefined,
     );
-    setDataServiceDirtyNodeIds((current) => current.filter((nodeId) => nodeMap.has(nodeId)));
+    setResourceDirtyNodeIds((current) => current.filter((nodeId) => nodeMap.has(nodeId)));
   }, [nodeMap]);
 
   useEffect(() => {
@@ -184,18 +205,24 @@ const DevelopmentWorkbench = ({
       .filter((node): node is DevelopmentResourceNode => Boolean(node && node.type === 'DATA_SERVICE')),
     [nodeMap, openNodeIds],
   );
+  const openDatasetNodes = useMemo(
+    () => openNodeIds
+      .map((nodeId) => nodeMap.get(nodeId))
+      .filter((node): node is DevelopmentResourceNode => Boolean(node && node.type === 'DATASET')),
+    [nodeMap, openNodeIds],
+  );
 
   const focusNode = (nodeId: DevelopmentId) => {
     const target = nodeMap.get(nodeId);
     if (!target) return;
     setOpenNodeIds((current) => current.includes(nodeId) ? current : [...current, nodeId]);
     setActiveNodeId(nodeId);
-    if (target.type === 'DATA_SERVICE') setRunPanelOpen(false);
+    if (!isDevelopmentTaskNode(target)) setRunPanelOpen(false);
     onNodeFocus(nodeId);
   };
 
-  const updateDataServiceDirty = (nodeId: DevelopmentId, dirty: boolean) => {
-    setDataServiceDirtyNodeIds((current) => {
+  const updateResourceDirty = (nodeId: DevelopmentId, dirty: boolean) => {
+    setResourceDirtyNodeIds((current) => {
       if (dirty) return current.includes(nodeId) ? current : [...current, nodeId];
       return current.filter((id) => id !== nodeId);
     });
@@ -316,7 +343,7 @@ const DevelopmentWorkbench = ({
     const currentIndex = activeNodeId ? openNodeIds.indexOf(activeNodeId) : -1;
     const next = openNodeIds.filter((id) => !closeSet.has(id));
     setOpenNodeIds(next);
-    setDataServiceDirtyNodeIds((current) => current.filter((id) => !closeSet.has(id)));
+    setResourceDirtyNodeIds((current) => current.filter((id) => !closeSet.has(id)));
 
     if (!activeNodeId || !closeSet.has(activeNodeId)) return;
 
@@ -325,7 +352,8 @@ const DevelopmentWorkbench = ({
       next[next.length - 1];
     setActiveNodeId(nextActiveId);
     onNodeFocus(nextActiveId);
-    if (!nextActiveId || nodeMap.get(nextActiveId)?.type === 'DATA_SERVICE') {
+    const nextNode = nextActiveId ? nodeMap.get(nextActiveId) : undefined;
+    if (!nextNode || !isDevelopmentTaskNode(nextNode)) {
       setRunPanelOpen(false);
     }
   };
@@ -334,16 +362,16 @@ const DevelopmentWorkbench = ({
     const targetNodeIds = openNodeIds.filter((nodeId) => nodeIds.includes(nodeId));
     if (!targetNodeIds.length) return;
 
-    const dirtyDataServiceNodes = targetNodeIds
-      .filter((nodeId) => dataServiceDirtyNodeIds.includes(nodeId))
+    const dirtyResourceNodes = targetNodeIds
+      .filter((nodeId) => resourceDirtyNodeIds.includes(nodeId))
       .map((nodeId) => nodeMap.get(nodeId))
       .filter((node): node is DevelopmentResourceNode => Boolean(node));
-    if (dirtyDataServiceNodes.length) {
-      const firstName = dirtyDataServiceNodes[0]?.name || 'Data Service';
+    if (dirtyResourceNodes.length) {
+      const firstName = dirtyResourceNodes[0]?.name || '资源';
       message.warning(
-        dirtyDataServiceNodes.length === 1
-          ? `「${firstName}」有未保存修改，请先保存草稿后再关闭`
-          : `有 ${dirtyDataServiceNodes.length} 个 Data Service 编辑器尚未保存，请先保存草稿`,
+        dirtyResourceNodes.length === 1
+          ? `「${firstName}」有未保存修改，请先保存后再关闭`
+          : `有 ${dirtyResourceNodes.length} 个资源编辑器尚未保存，请先保存后再关闭`,
       );
       return;
     }
@@ -433,7 +461,7 @@ const DevelopmentWorkbench = ({
             选择左侧开发节点
           </div>
           <div className="mt-1 text-[12px] text-[#98a2b3]">
-            SQL、Shell 和 Data Service 会在同一个开发工作台中打开
+            SQL、Shell、Dataset 和 Data Service 会在同一个开发工作台中打开
           </div>
         </div>
       </main>
@@ -448,7 +476,7 @@ const DevelopmentWorkbench = ({
         nodeMap={nodeMap}
         openNodeIds={openNodeIds}
         activeNodeId={activeNodeId}
-        dirtyNodeIds={dataServiceDirtyNodeIds}
+        dirtyNodeIds={resourceDirtyNodeIds}
         onFocus={focusNode}
         onClose={(nodeId) => requestCloseNodes([nodeId])}
         onAction={handleTabAction}
@@ -505,7 +533,17 @@ const DevelopmentWorkbench = ({
             active={activeNodeId === dataServiceNode.id}
             onSaved={onNodesChanged}
             onOpenSourceNode={focusNode}
-            onDirtyChange={(dirty) => updateDataServiceDirty(dataServiceNode.id, dirty)}
+            onDirtyChange={(dirty) => updateResourceDirty(dataServiceNode.id, dirty)}
+          />
+        ))}
+
+        {openDatasetNodes.map((datasetNode) => (
+          <DatasetWorkbenchEditor
+            key={datasetNode.id}
+            node={datasetNode}
+            active={activeNodeId === datasetNode.id}
+            onSaved={onNodesChanged}
+            onDirtyChange={(dirty) => updateResourceDirty(datasetNode.id, dirty)}
           />
         ))}
       </div>


### PR DESCRIPTION
## 调整

- 数据集节点正式接入数据开发共享 Workbench，与 SQL / Data Service 共用编辑 Tab
- Dataset 编辑器改为统一的 36px Toolbar + 主编辑区 + 底部状态栏 + 右侧竖向面板
- Toolbar 仅保留 Dataset 核心动作：发现字段、保存数据集版本；右侧直接选择已发布 SQL 来源
- 中间字段结构支持显示名称、维度/指标角色、字段描述维护
- 右侧仅保留「属性 / 版本」，展示 Dataset ID、当前 DV、来源 SQL Revision 和版本历史
- 支持右侧面板收起、拖拽宽度并持久化宽度设置
- Dataset 未保存修改会同步到 Tab 脏点，并阻止误关闭导致修改丢失
- 继续复用现有 Dataset 后端能力：同项目 ONLINE SQL、字段发现、保存时冻结当前 SQL Revision、DatasetVersion 历史

不修改 Dataset 的领域边界：Dataset 仍是独立数据资产，不进入 Task Catalog / Workflow 任务生命周期；本次不新增数据库表或后端接口。