### PR TITLE
fix: prevent dataset node editor crash on initial render

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
@@ -187,7 +187,7 @@ const DatasetNodeEditor = ({ node, onSaved, onDirtyChange }: DatasetNodeEditorPr
 
   const activeSource = useMemo(
     () => availableSources.find((source) => source.taskAssetId === selectedSourceId)
-      || (context?.selectedSource?.taskAssetId === selectedSourceId ? context.selectedSource : undefined),
+      || (context?.selectedSource?.taskAssetId === selectedSourceId ? context?.selectedSource : undefined),
     [availableSources, context?.selectedSource, selectedSourceId],
   );
 


### PR DESCRIPTION
## Summary
- fix newly created DATASET nodes failing to render in the data development workbench
- safely handle the empty `selectedSource` state before the dataset context has loaded

## Root cause
On the first render, both `context` and `selectedSourceId` are `undefined`. The optional-chain comparison therefore evaluates as `undefined === undefined`, enters the true branch, and then dereferences `context.selectedSource`, which throws `Cannot read properties of undefined (reading 'selectedSource')` before the editor can finish mounting.

## Fix
Use optional chaining for the selected source returned from the fallback branch as well, so an unconfigured/new DATASET node remains in the valid empty state and can render the source selector normally.

## Verification
- reviewed the resulting diff: only the dataset editor null-safety guard changed (plus EOF newline metadata)
- GitHub Actions checks were not present for the branch commit before opening this PR