### PR TITLE
feat(home): add real schedule overview

### DIFF
--- a/yak-ops-ui/src/pages/home/index.tsx
+++ b/yak-ops-ui/src/pages/home/index.tsx
@@ -1,13 +1,17 @@
 import { history } from '@umijs/max';
 import { Button, Skeleton, Tooltip } from 'antd';
+import dayjs from 'dayjs';
 import {
   Activity,
   Bell,
   Cable,
+  CalendarClock,
   CheckCircle2,
   ChevronRight,
   Clock3,
   Database,
+  PauseCircle,
+  PlayCircle,
   RefreshCw,
   Server,
   Sparkles,
@@ -20,6 +24,7 @@ import type {
   HomeDataSourceKey,
   HomeOverview,
   HomeRunItem,
+  HomeScheduleItem,
 } from './model';
 import { fetchHomeOverview } from './service';
 
@@ -34,7 +39,7 @@ interface QuickAction {
 }
 
 const HOME_CARD_CLASS =
-  'rounded-[10px] border border-[rgba(22,24,35,0.045)] bg-white shadow-[0_2px_12px_rgba(31,35,41,0.025)]';
+  'rounded-[10px] border border-[rgba(22,24,35,0.055)] bg-white';
 
 const actionToneClasses: Record<ActionTone, string> = {
   sync: 'bg-[#fff1f3] text-[#fe2c55]',
@@ -79,6 +84,7 @@ const sourceLabels: Record<HomeDataSourceKey, string> = {
   client: '客户端',
   alarm: '告警',
   execution: '运行实例',
+  schedule: '调度计划',
 };
 
 const navigate = (path: string) => history.push(path);
@@ -88,7 +94,18 @@ const formatCount = (value?: number) =>
 
 const formatTime = (value?: string) => {
   if (!value) return '-';
-  return value.replace('T', ' ').slice(0, 19);
+  const time = dayjs(value);
+  return time.isValid() ? time.format('YYYY-MM-DD HH:mm:ss') : value;
+};
+
+const formatPlanTime = (value?: string) => {
+  if (!value) return '-';
+  const time = dayjs(value);
+  if (!time.isValid()) return value;
+  const today = dayjs();
+  if (time.isSame(today, 'day')) return `今天 ${time.format('HH:mm')}`;
+  if (time.isSame(today.add(1, 'day'), 'day')) return `明天 ${time.format('HH:mm')}`;
+  return time.format('MM-DD HH:mm');
 };
 
 const formatDuration = (value?: number) => {
@@ -113,7 +130,10 @@ const getRunStatusMeta = (status?: string) => {
     return { label: '失败', className: 'bg-[#fff1f3] text-[#d92d50]' };
   }
   if (['RUNNING', 'STARTING', 'SUBMITTED', 'DISPATCHING', 'QUEUED', 'PENDING', 'WAITING', 'RETRYING', 'PAUSED'].includes(normalized)) {
-    return { label: normalized === 'PAUSED' ? '已暂停' : '运行中', className: 'bg-[#eef7ff] text-[#175cd3]' };
+    return {
+      label: normalized === 'PAUSED' ? '已暂停' : '运行中',
+      className: 'bg-[#eef7ff] text-[#175cd3]',
+    };
   }
   if (['CANCELED', 'CANCELLED'].includes(normalized)) {
     return { label: '已取消', className: 'bg-[#f5f5f6] text-[rgba(22,24,35,0.55)]' };
@@ -136,13 +156,9 @@ function SectionHeader({
   return (
     <div className="flex min-h-8 items-center justify-between gap-4">
       <div className="min-w-0">
-        <h2 className="m-0 text-lg font-[650] tracking-[-0.2px] text-[#161823]">
-          {title}
-        </h2>
+        <h2 className="m-0 text-lg font-[650] tracking-[-0.2px] text-[#161823]">{title}</h2>
         {description ? (
-          <p className="mb-0 mt-1 text-xs leading-5 text-[rgba(22,24,35,0.46)]">
-            {description}
-          </p>
+          <p className="mb-0 mt-1 text-xs leading-5 text-[rgba(22,24,35,0.46)]">{description}</p>
         ) : null}
       </div>
       {extra}
@@ -159,20 +175,14 @@ function DataState({
   loading: boolean;
   children: ReactNode;
 }) {
-  if (loading) {
-    return <Skeleton.Input active size="small" style={{ width: 72 }} />;
-  }
-
+  if (loading) return <Skeleton.Input active size="small" style={{ width: 72 }} />;
   if (unavailable) {
     return (
       <Tooltip title="当前接口未能返回有效数据">
-        <span className="text-[13px] font-medium text-[rgba(22,24,35,0.38)]">
-          暂不可用
-        </span>
+        <span className="text-[13px] font-medium text-[rgba(22,24,35,0.38)]">暂不可用</span>
       </Tooltip>
     );
   }
-
   return <>{children}</>;
 }
 
@@ -196,70 +206,57 @@ function MetricCard({
   return (
     <button
       type="button"
-      className={`${HOME_CARD_CLASS} group flex min-h-[112px] min-w-0 cursor-pointer items-center border-[rgba(22,24,35,0.045)] px-5 py-4 text-left transition duration-150 hover:-translate-y-px hover:border-[rgba(22,24,35,0.08)] hover:shadow-[0_8px_24px_rgba(22,24,35,0.055)]`}
+      className={`${HOME_CARD_CLASS} group flex min-h-[108px] min-w-0 cursor-pointer items-center px-4 py-4 text-left transition hover:border-[rgba(22,24,35,0.11)]`}
       onClick={onClick}
     >
-      <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[10px] bg-[#f5f5f6] text-[#161823] transition-colors group-hover:bg-[#f0f0f1]">
-        <Icon size={22} strokeWidth={1.9} />
+      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[9px] bg-[#f5f5f6] text-[#161823]">
+        <Icon size={20} strokeWidth={1.9} />
       </span>
-      <span className="ml-4 min-w-0 flex-1">
+      <span className="ml-3 min-w-0 flex-1">
         <span className="block text-xs text-[rgba(22,24,35,0.48)]">{label}</span>
-        <span className="mt-1.5 flex min-h-8 items-center">
+        <span className="mt-1 flex min-h-8 items-center">
           <DataState unavailable={unavailable} loading={loading}>
-            <strong className="text-[26px] font-[650] leading-8 tracking-[-0.5px] text-[#161823]">
-              {formatCount(value)}
-            </strong>
+            <strong className="text-[25px] font-[650] leading-8 tracking-[-0.5px] text-[#161823]">{formatCount(value)}</strong>
           </DataState>
         </span>
-        <span className="mt-1 block truncate text-[11px] text-[rgba(22,24,35,0.42)]">
+        <span className="mt-0.5 block truncate text-[11px] text-[rgba(22,24,35,0.42)]">
           {loading || unavailable ? '来自 Yak Ops 实际接口' : detail}
         </span>
       </span>
-      <ChevronRight
-        className="ml-2 shrink-0 text-[rgba(22,24,35,0.2)] transition group-hover:translate-x-0.5 group-hover:text-[rgba(22,24,35,0.48)]"
-        size={16}
-      />
+      <ChevronRight size={15} className="ml-1 shrink-0 text-[rgba(22,24,35,0.2)]" />
     </button>
   );
 }
 
 function QuickActionCard({ action }: { action: QuickAction }) {
   const Icon = action.icon;
-
   return (
     <button
       type="button"
-      className={`relative flex h-[66px] min-w-0 cursor-pointer items-center overflow-hidden rounded-[9px] border-0 px-4 text-left transition duration-150 hover:-translate-y-px hover:shadow-[0_7px_20px_rgba(22,24,35,0.08)] ${actionToneClasses[action.tone]}`}
+      className={`relative flex h-[66px] min-w-0 cursor-pointer items-center overflow-hidden rounded-[9px] border-0 px-4 text-left transition hover:-translate-y-px ${actionToneClasses[action.tone]}`}
       onClick={() => navigate(action.path)}
     >
-      <span className="relative z-[1] flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-current text-white shadow-[0_4px_10px_rgba(22,24,35,0.09)]">
+      <span className="relative z-[1] flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-current text-white">
         <Icon className="text-white" size={20} strokeWidth={2.1} />
       </span>
-      <span className="relative z-[1] ml-2.5 flex min-w-0 flex-col">
-        <strong className="truncate text-sm font-[650] text-[#161823]">
-          {action.title}
-        </strong>
-        <span className="mt-[3px] truncate text-[11px] text-[rgba(22,24,35,0.5)]">
-          {action.description}
-        </span>
+      <span className="relative z-[1] ml-2.5 min-w-0">
+        <strong className="block truncate text-sm font-[650] text-[#161823]">{action.title}</strong>
+        <span className="mt-[3px] block truncate text-[11px] text-[rgba(22,24,35,0.5)]">{action.description}</span>
       </span>
-      <span className="absolute -right-2 -top-6 h-[92px] w-[68px] -rotate-[28deg] rounded-[22px] border-[12px] border-current opacity-[0.08]" />
     </button>
   );
 }
 
-function ResourceValue({ label, value }: { label: string; value?: number }) {
+function SmallValue({ label, value }: { label: string; value?: number }) {
   return (
     <div className="min-w-0 rounded-lg bg-[#f8f8f9] px-3 py-3">
       <div className="text-[11px] text-[rgba(22,24,35,0.42)]">{label}</div>
-      <div className="mt-1 text-[15px] font-[650] text-[#161823]">
-        {formatCount(value)}
-      </div>
+      <div className="mt-1 text-[15px] font-[650] text-[#161823]">{formatCount(value)}</div>
     </div>
   );
 }
 
-function RuntimeValue({
+function OverviewValue({
   icon: Icon,
   label,
   value,
@@ -280,9 +277,7 @@ function RuntimeValue({
       </div>
       <div className="mt-2 flex min-h-7 items-center">
         <DataState loading={loading} unavailable={unavailable}>
-          <strong className="text-[22px] font-[650] leading-7 tracking-[-0.4px] text-[#161823]">
-            {formatCount(value)}
-          </strong>
+          <strong className="text-[22px] font-[650] leading-7 tracking-[-0.4px] text-[#161823]">{formatCount(value)}</strong>
         </DataState>
       </div>
     </div>
@@ -302,40 +297,59 @@ function RecentRunRow({ item }: { item: HomeRunItem }) {
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-center gap-2">
-          <strong className="truncate text-[12px] font-[650] text-[#161823]">
-            {item.name}
-          </strong>
+          <strong className="truncate text-[12px] font-[650] text-[#161823]">{item.name}</strong>
           <span className="shrink-0 rounded bg-[#f5f5f6] px-1.5 py-0.5 text-[9px] text-[rgba(22,24,35,0.5)]">
             {item.type === 'batch' ? '离线同步' : '工作流'}
           </span>
-          <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] ${status.className}`}>
-            {status.label}
-          </span>
+          <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] ${status.className}`}>{status.label}</span>
         </span>
-        <span className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[rgba(22,24,35,0.4)]">
+        <span className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[rgba(22,24,35,0.4)]">
           <span>{formatTime(item.startedAt)}</span>
           <span>耗时 {formatDuration(item.durationMillis)}</span>
         </span>
       </span>
-      <ChevronRight
-        size={14}
-        className="shrink-0 text-[rgba(22,24,35,0.18)] transition group-hover:translate-x-0.5 group-hover:text-[rgba(22,24,35,0.46)]"
-      />
+      <ChevronRight size={14} className="shrink-0 text-[rgba(22,24,35,0.18)]" />
     </button>
   );
 }
 
-function DeferredSection({ title, description }: { title: string; description: string }) {
+function ScheduleRow({ item }: { item: HomeScheduleItem }) {
   return (
-    <section className={`${HOME_CARD_CLASS} mt-4 min-h-[150px] p-[22px]`}>
-      <SectionHeader title={title} />
-      <div className="mt-4 flex min-h-[70px] items-center rounded-lg border border-dashed border-[rgba(22,24,35,0.09)] bg-[#fafafa] px-5">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white text-[rgba(22,24,35,0.4)] shadow-[0_2px_8px_rgba(22,24,35,0.04)]">
-          <Activity size={18} />
+    <button
+      type="button"
+      className="group flex w-full min-w-0 cursor-pointer items-center gap-3 border-0 bg-transparent py-3 text-left first:pt-0 last:pb-0"
+      onClick={() => navigate(item.path)}
+    >
+      <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${item.type === 'batch' ? 'bg-[#fff1f3] text-[#fe2c55]' : 'bg-[#f3f0ff] text-[#7652ff]'}`}>
+        {item.type === 'batch' ? <Database size={17} /> : <Workflow size={17} />}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <strong className="truncate text-[12px] font-[650] text-[#161823]">{item.name}</strong>
+          <span className="shrink-0 rounded bg-[#f5f5f6] px-1.5 py-0.5 text-[9px] text-[rgba(22,24,35,0.5)]">
+            {item.type === 'batch' ? '离线同步' : '工作流'}
+          </span>
         </span>
+        <span className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[rgba(22,24,35,0.4)]">
+          <span className="font-medium text-[rgba(22,24,35,0.62)]">{formatPlanTime(item.nextRunAt)}</span>
+          {item.cronExpression ? <span className="max-w-[180px] truncate font-mono">{item.cronExpression}</span> : null}
+          {item.timezone ? <span>{item.timezone}</span> : null}
+        </span>
+      </span>
+      <ChevronRight size={14} className="shrink-0 text-[rgba(22,24,35,0.18)]" />
+    </button>
+  );
+}
+
+function DeferredSection() {
+  return (
+    <section className={`${HOME_CARD_CLASS} mt-4 p-[22px]`}>
+      <SectionHeader title="趋势与 SLA" />
+      <div className="mt-4 flex min-h-[68px] items-center rounded-lg border border-dashed border-[rgba(22,24,35,0.09)] bg-[#fafafa] px-5">
+        <Activity size={18} className="shrink-0 text-[rgba(22,24,35,0.36)]" />
         <div className="ml-3 min-w-0">
-          <div className="text-[13px] font-[650] text-[rgba(22,24,35,0.74)]">等待统一统计口径</div>
-          <div className="mt-1 text-[11px] leading-5 text-[rgba(22,24,35,0.42)]">{description}</div>
+          <div className="text-[13px] font-[650] text-[rgba(22,24,35,0.72)]">等待统一统计口径</div>
+          <div className="mt-1 text-[11px] text-[rgba(22,24,35,0.42)]">运行趋势、成功率、SLA 与吞吐量将在统一历史统计口径后接入。</div>
         </div>
       </div>
     </section>
@@ -351,13 +365,14 @@ const HomePage = () => {
   const loadOverview = useCallback(async () => {
     setLoading(true);
     setLoadError(false);
-
     try {
       const nextOverview = await fetchHomeOverview();
       setOverview(nextOverview);
       setLastUpdatedAt(new Date());
     } catch {
-      setOverview({ unavailable: ['dataSource', 'client', 'alarm', 'execution'] });
+      setOverview({
+        unavailable: ['dataSource', 'client', 'alarm', 'execution', 'schedule'],
+      });
       setLoadError(true);
     } finally {
       setLoading(false);
@@ -388,47 +403,40 @@ const HomePage = () => {
     return '来自客户端统计接口';
   }, [overview?.client]);
 
-  const scrollToRuntime = () => {
-    document.getElementById('home-runtime')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  const scrollTo = (id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
   const dataSource = overview?.dataSource;
   const client = overview?.client;
   const alarm = overview?.alarm;
   const execution = overview?.execution;
+  const schedule = overview?.schedule;
   const executionUnavailable = unavailableSet.has('execution');
+  const scheduleUnavailable = unavailableSet.has('schedule');
 
   return (
     <div className="min-h-full bg-[#f7f8fa] p-4 font-sans text-[#161823] min-[1041px]:p-5">
-      <section className="relative flex min-h-[126px] items-center overflow-hidden rounded-[10px] bg-[linear-gradient(100deg,rgba(255,255,255,0.96)_0%,rgba(247,247,255,0.88)_42%),linear-gradient(115deg,#f9fbff_0%,#e7e7ff_62%,#d8dbff_100%)] px-[30px] py-6">
-        <div className="absolute -top-[180px] right-[45px] h-[470px] w-[470px] rounded-full border border-[rgba(126,133,255,0.14)] shadow-[inset_0_0_0_28px_rgba(255,255,255,0.08),inset_0_0_0_76px_rgba(255,255,255,0.07)]" />
-        <div className="absolute -top-[116px] right-[230px] h-[280px] w-[280px] rounded-full border border-[rgba(126,133,255,0.12)]" />
-
-        <div className="relative z-[1] flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-full border-2 border-white/90 bg-[#161823] text-white shadow-[0_5px_20px_rgba(53,63,110,0.12)]">
-          <Sparkles size={25} strokeWidth={1.8} />
+      <section className="relative flex min-h-[122px] items-center overflow-hidden rounded-[10px] bg-[linear-gradient(100deg,rgba(255,255,255,0.96)_0%,rgba(247,247,255,0.88)_42%),linear-gradient(115deg,#f9fbff_0%,#e7e7ff_62%,#d8dbff_100%)] px-[30px] py-6">
+        <div className="absolute -top-[180px] right-[45px] h-[470px] w-[470px] rounded-full border border-[rgba(126,133,255,0.12)]" />
+        <div className="relative z-[1] flex h-[56px] w-[56px] shrink-0 items-center justify-center rounded-full bg-[#161823] text-white">
+          <Sparkles size={24} strokeWidth={1.8} />
         </div>
-
         <div className="relative z-[1] ml-[18px] min-w-0">
           <h1 className="m-0 text-[18px] font-[650] tracking-[-0.3px] text-[#161823]">Yak Ops 一体化数据平台</h1>
-          <p className="mb-0 mt-2 max-w-[760px] text-xs leading-5 text-[rgba(22,24,35,0.5)]">
-            汇总平台资源、告警与运行实例，优先回答“现在有什么、运行怎么样、哪里出了问题”。
-          </p>
+          <p className="mb-0 mt-2 max-w-[760px] text-xs leading-5 text-[rgba(22,24,35,0.5)]">资源、运行、告警与后续调度统一汇总。</p>
           <div className="mt-2 flex items-center gap-2 text-[11px] text-[rgba(22,24,35,0.38)]">
             {lastUpdatedAt ? (
               <span>最近更新 {lastUpdatedAt.toLocaleTimeString('zh-CN', { hour12: false })}</span>
             ) : (
               <span>正在读取平台实时数据</span>
             )}
-            {unavailableText ? (
-              <span className="rounded bg-[#fff1f3] px-1.5 py-0.5 text-[#d92d50]">{unavailableText}</span>
-            ) : null}
+            {unavailableText ? <span className="rounded bg-[#fff1f3] px-1.5 py-0.5 text-[#d92d50]">{unavailableText}</span> : null}
           </div>
         </div>
-
         <div className="relative z-[1] ml-auto pl-5">
           <Button
             icon={<RefreshCw size={14} className={loading ? 'animate-spin' : ''} />}
-            loading={false}
             disabled={loading}
             onClick={() => void loadOverview()}
           >
@@ -437,7 +445,7 @@ const HomePage = () => {
         </div>
       </section>
 
-      <section className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <section className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-5">
         <MetricCard
           icon={Database}
           label="数据源"
@@ -460,10 +468,19 @@ const HomePage = () => {
           icon={Activity}
           label="今日运行"
           value={execution?.todayTotal}
-          detail={`当前运行 ${formatCount(execution?.running)} / 今日失败 ${formatCount(execution?.failed)}`}
+          detail={`运行中 ${formatCount(execution?.running)} / 失败 ${formatCount(execution?.failed)}`}
           loading={loading}
           unavailable={executionUnavailable}
-          onClick={scrollToRuntime}
+          onClick={() => scrollTo('home-runtime')}
+        />
+        <MetricCard
+          icon={CalendarClock}
+          label="今日计划"
+          value={schedule?.today}
+          detail={`24h 内 ${formatCount(schedule?.next24h)} / 已启用 ${formatCount(schedule?.enabled)}`}
+          loading={loading}
+          unavailable={scheduleUnavailable}
+          onClick={() => scrollTo('home-schedule')}
         />
         <MetricCard
           icon={Bell}
@@ -477,98 +494,71 @@ const HomePage = () => {
       </section>
 
       <section className={`${HOME_CARD_CLASS} mt-4 px-[22px] pb-[22px] pt-5`}>
-        <SectionHeader title="快速创建" description="保留高频入口，创建后进入各业务模块完成配置与运行。" />
+        <SectionHeader title="快速创建" />
         <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {quickActions.map((action) => <QuickActionCard action={action} key={action.title} />)}
         </div>
       </section>
 
       <div className="mt-4 grid grid-cols-1 gap-4 min-[1041px]:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.8fr)]">
-        <section className={`${HOME_CARD_CLASS} min-h-[276px] p-[22px]`}>
+        <section className={`${HOME_CARD_CLASS} min-h-[270px] p-[22px]`}>
           <SectionHeader
             title="资源概览"
-            description="资源状态直接来自数据源与客户端现有接口。"
             extra={
-              <button
-                type="button"
-                className="inline-flex cursor-pointer items-center border-0 bg-transparent p-0 text-xs text-[rgba(22,24,35,0.5)] transition-colors hover:text-[#161823]"
-                onClick={() => navigate('/data-source')}
-              >
+              <button type="button" className="inline-flex items-center border-0 bg-transparent p-0 text-xs text-[rgba(22,24,35,0.5)] hover:text-[#161823]" onClick={() => navigate('/data-source')}>
                 资源管理<ChevronRight size={14} />
               </button>
             }
           />
-
           <div className="mt-5 grid grid-cols-1 gap-4 xl:grid-cols-2">
-            <button
-              type="button"
-              className="min-w-0 cursor-pointer rounded-[10px] border border-[rgba(22,24,35,0.06)] bg-white p-4 text-left transition hover:border-[rgba(22,24,35,0.1)] hover:shadow-[0_6px_18px_rgba(22,24,35,0.04)]"
-              onClick={() => navigate('/data-source')}
-            >
+            <button type="button" className="min-w-0 rounded-[10px] border border-[rgba(22,24,35,0.06)] bg-white p-4 text-left" onClick={() => navigate('/data-source')}>
               <div className="flex items-center justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-2.5">
-                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#fff1f3] text-[#fe2c55]"><Database size={19} /></span>
-                  <div className="min-w-0">
-                    <strong className="block truncate text-[13px] font-[650]">数据源</strong>
-                    <span className="mt-0.5 block text-[11px] text-[rgba(22,24,35,0.42)]">连接状态与环境统计</span>
-                  </div>
+                <div className="flex items-center gap-2.5">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#fff1f3] text-[#fe2c55]"><Database size={19} /></span>
+                  <strong className="text-[13px] font-[650]">数据源</strong>
                 </div>
                 <DataState unavailable={unavailableSet.has('dataSource')} loading={loading}>
                   <strong className="text-xl font-[650]">{formatCount(dataSource?.total)}</strong>
                 </DataState>
               </div>
               <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-2 2xl:grid-cols-4">
-                <ResourceValue label="连接正常" value={dataSource?.connected} />
-                <ResourceValue label="连接异常" value={dataSource?.disconnected} />
-                <ResourceValue label="状态未知" value={dataSource?.unknown} />
-                <ResourceValue label="环境数量" value={dataSource?.environmentCount} />
+                <SmallValue label="连接正常" value={dataSource?.connected} />
+                <SmallValue label="连接异常" value={dataSource?.disconnected} />
+                <SmallValue label="状态未知" value={dataSource?.unknown} />
+                <SmallValue label="环境数量" value={dataSource?.environmentCount} />
               </div>
             </button>
 
-            <button
-              type="button"
-              className="min-w-0 cursor-pointer rounded-[10px] border border-[rgba(22,24,35,0.06)] bg-white p-4 text-left transition hover:border-[rgba(22,24,35,0.1)] hover:shadow-[0_6px_18px_rgba(22,24,35,0.04)]"
-              onClick={() => navigate('/client')}
-            >
+            <button type="button" className="min-w-0 rounded-[10px] border border-[rgba(22,24,35,0.06)] bg-white p-4 text-left" onClick={() => navigate('/client')}>
               <div className="flex items-center justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-2.5">
-                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#f2f4f7] text-[#344054]"><Server size={19} /></span>
-                  <div className="min-w-0">
-                    <strong className="block truncate text-[13px] font-[650]">客户端</strong>
-                    <span className="mt-0.5 block text-[11px] text-[rgba(22,24,35,0.42)]">执行器服务实时统计</span>
-                  </div>
+                <div className="flex items-center gap-2.5">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#f2f4f7] text-[#344054]"><Server size={19} /></span>
+                  <strong className="text-[13px] font-[650]">客户端</strong>
                 </div>
                 <DataState unavailable={unavailableSet.has('client')} loading={loading}>
                   <strong className="text-xl font-[650]">{formatCount(client?.total)}</strong>
                 </DataState>
               </div>
               <div className="mt-4 grid grid-cols-2 gap-2">
-                <ResourceValue label="客户端总数" value={client?.total} />
+                <SmallValue label="客户端总数" value={client?.total} />
                 {client?.online !== undefined || client?.offline !== undefined ? (
                   <>
-                    <ResourceValue label="在线" value={client?.online} />
-                    <ResourceValue label="离线" value={client?.offline} />
+                    <SmallValue label="在线" value={client?.online} />
+                    <SmallValue label="离线" value={client?.offline} />
                   </>
                 ) : (
-                  <div className="flex min-h-[60px] items-center rounded-lg bg-[#f8f8f9] px-3 text-[11px] leading-5 text-[rgba(22,24,35,0.42)]">
-                    当前接口未明确返回在线/离线拆分，首页不做推算。
-                  </div>
+                  <div className="flex min-h-[60px] items-center rounded-lg bg-[#f8f8f9] px-3 text-[11px] leading-5 text-[rgba(22,24,35,0.42)]">当前接口未明确返回在线/离线拆分。</div>
                 )}
               </div>
             </button>
           </div>
         </section>
 
-        <aside className={`${HOME_CARD_CLASS} min-h-[276px] p-[22px]`}>
+        <aside className={`${HOME_CARD_CLASS} min-h-[270px] p-[22px]`}>
           <SectionHeader
             title="最近告警"
-            description="展示告警记录接口返回的最近数据。"
             extra={
-              <button
-                type="button"
-                className="inline-flex cursor-pointer items-center border-0 bg-transparent p-0 text-xs text-[rgba(22,24,35,0.5)] transition-colors hover:text-[#161823]"
-                onClick={() => navigate('/alarm')}
-              >
+              <button type="button" className="inline-flex items-center border-0 bg-transparent p-0 text-xs text-[rgba(22,24,35,0.5)] hover:text-[#161823]" onClick={() => navigate('/alarm')}>
                 查看全部<ChevronRight size={14} />
               </button>
             }
@@ -581,21 +571,11 @@ const HomePage = () => {
             ) : alarm?.recent.length ? (
               <div className="divide-y divide-[rgba(22,24,35,0.06)]">
                 {alarm.recent.map((item, index) => (
-                  <button
-                    type="button"
-                    className="flex w-full min-w-0 cursor-pointer items-center gap-3 border-0 bg-transparent py-3 text-left first:pt-0 last:pb-0"
-                    key={item.id ?? `${item.jobName}-${item.time}-${index}`}
-                    onClick={() => navigate('/alarm')}
-                  >
+                  <button type="button" className="flex w-full min-w-0 items-center gap-3 border-0 bg-transparent py-3 text-left first:pt-0 last:pb-0" key={item.id ?? `${item.jobName}-${item.time}-${index}`} onClick={() => navigate('/alarm')}>
                     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#fff1f3] text-[#fe2c55]"><Bell size={16} /></span>
                     <span className="min-w-0 flex-1">
-                      <span className="flex min-w-0 items-center gap-2">
-                        <strong className="truncate text-[12px] font-[650] text-[#161823]">{item.jobName || '未命名任务'}</strong>
-                        {item.severity ? <span className="shrink-0 rounded bg-[#f5f5f6] px-1.5 py-0.5 text-[9px] text-[rgba(22,24,35,0.55)]">{item.severity}</span> : null}
-                      </span>
-                      <span className="mt-1 flex items-center gap-2 text-[10px] text-[rgba(22,24,35,0.4)]">
-                        <span>{item.status || '状态未知'}</span><span>{formatTime(item.time)}</span>
-                      </span>
+                      <strong className="block truncate text-[12px] font-[650] text-[#161823]">{item.jobName || '未命名任务'}</strong>
+                      <span className="mt-1 flex items-center gap-2 text-[10px] text-[rgba(22,24,35,0.4)]"><span>{item.status || '状态未知'}</span><span>{formatTime(item.time)}</span></span>
                     </span>
                     <ChevronRight size={14} className="shrink-0 text-[rgba(22,24,35,0.2)]" />
                   </button>
@@ -615,7 +595,6 @@ const HomePage = () => {
         <section className={`${HOME_CARD_CLASS} min-h-[286px] p-[22px]`}>
           <SectionHeader
             title="运行概览"
-            description="今日统计按运行开始时间计算；当前运行统计离线同步与工作流的活跃实例。"
             extra={
               <div className="flex items-center gap-3">
                 <button type="button" className="border-0 bg-transparent p-0 text-xs text-[rgba(22,24,35,0.5)] hover:text-[#161823]" onClick={() => navigate('/sync/batch-link-up')}>离线同步</button>
@@ -624,30 +603,22 @@ const HomePage = () => {
             }
           />
           <div className="mt-5 grid grid-cols-2 gap-3">
-            <RuntimeValue icon={Clock3} label="今日运行" value={execution?.todayTotal} loading={loading} unavailable={executionUnavailable} />
-            <RuntimeValue icon={Activity} label="当前运行" value={execution?.running} loading={loading} unavailable={executionUnavailable} />
-            <RuntimeValue icon={CheckCircle2} label="今日成功" value={execution?.success} loading={loading} unavailable={executionUnavailable} />
-            <RuntimeValue icon={XCircle} label="今日失败" value={execution?.failed} loading={loading} unavailable={executionUnavailable} />
+            <OverviewValue icon={Clock3} label="今日运行" value={execution?.todayTotal} loading={loading} unavailable={executionUnavailable} />
+            <OverviewValue icon={Activity} label="当前运行" value={execution?.running} loading={loading} unavailable={executionUnavailable} />
+            <OverviewValue icon={CheckCircle2} label="今日成功" value={execution?.success} loading={loading} unavailable={executionUnavailable} />
+            <OverviewValue icon={XCircle} label="今日失败" value={execution?.failed} loading={loading} unavailable={executionUnavailable} />
           </div>
           {!loading && !executionUnavailable && execution ? (
-            <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] leading-5 text-[rgba(22,24,35,0.38)]">
-              <span>已读取离线实例 {formatCount(execution.batchObserved)} 条</span>
+            <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-[rgba(22,24,35,0.38)]">
+              <span>离线实例 {formatCount(execution.batchObserved)} 条</span>
               <span>工作流实例 {formatCount(execution.workflowObserved)} 条</span>
-              {execution.limited ? <span className="text-[#b54708]">离线实例超过首页读取上限，统计基于最近 200 条实例</span> : null}
+              {execution.limited ? <span className="text-[#b54708]">离线统计基于最近 200 条实例</span> : null}
             </div>
           ) : null}
         </section>
 
         <section className={`${HOME_CARD_CLASS} min-h-[286px] p-[22px]`}>
-          <SectionHeader
-            title="最近运行"
-            description="离线同步和工作流实例统一按开始时间排序。"
-            extra={
-              <button type="button" className="inline-flex items-center border-0 bg-transparent p-0 text-xs text-[rgba(22,24,35,0.5)] hover:text-[#161823]" onClick={() => navigate('/workflow/instances')}>
-                工作流实例<ChevronRight size={14} />
-              </button>
-            }
-          />
+          <SectionHeader title="最近运行" />
           <div className="mt-4">
             {loading ? (
               <Skeleton active paragraph={{ rows: 4 }} title={false} />
@@ -658,19 +629,59 @@ const HomePage = () => {
                 {execution.recent.map((item) => <RecentRunRow item={item} key={`${item.type}-${item.id}`} />)}
               </div>
             ) : (
+              <div className="flex min-h-[190px] items-center justify-center rounded-lg bg-[#fafafa] text-xs text-[rgba(22,24,35,0.42)]">暂无运行实例</div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <div id="home-schedule" className="mt-4 grid scroll-mt-4 grid-cols-1 gap-4 min-[1100px]:grid-cols-[minmax(330px,0.82fr)_minmax(0,1.18fr)]">
+        <section className={`${HOME_CARD_CLASS} min-h-[286px] p-[22px]`}>
+          <SectionHeader
+            title="调度概览"
+            extra={
+              <button type="button" className="inline-flex items-center border-0 bg-transparent p-0 text-xs text-[rgba(22,24,35,0.5)] hover:text-[#161823]" onClick={() => navigate('/workflow/schedules')}>
+                调度管理<ChevronRight size={14} />
+              </button>
+            }
+          />
+          <div className="mt-5 grid grid-cols-2 gap-3">
+            <OverviewValue icon={CalendarClock} label="已配置" value={schedule?.total} loading={loading} unavailable={scheduleUnavailable} />
+            <OverviewValue icon={PlayCircle} label="已启用" value={schedule?.enabled} loading={loading} unavailable={scheduleUnavailable} />
+            <OverviewValue icon={PauseCircle} label="已暂停" value={schedule?.paused} loading={loading} unavailable={scheduleUnavailable} />
+            <OverviewValue icon={Clock3} label="24h 内" value={schedule?.next24h} loading={loading} unavailable={scheduleUnavailable} />
+          </div>
+          {!loading && !scheduleUnavailable && schedule ? (
+            <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-[rgba(22,24,35,0.38)]">
+              <span>离线调度 {formatCount(schedule.batchObserved)} 个</span>
+              <span>工作流调度 {formatCount(schedule.workflowObserved)} 个</span>
+              {schedule.limited ? <span className="text-[#b54708]">离线调度统计基于最近 200 个任务定义</span> : null}
+            </div>
+          ) : null}
+        </section>
+
+        <section className={`${HOME_CARD_CLASS} min-h-[286px] p-[22px]`}>
+          <SectionHeader title="近期计划" description="仅展示接口明确返回下次执行时间且当前已启用的计划。" />
+          <div className="mt-4">
+            {loading ? (
+              <Skeleton active paragraph={{ rows: 4 }} title={false} />
+            ) : scheduleUnavailable ? (
+              <div className="flex min-h-[190px] items-center justify-center rounded-lg bg-[#fafafa] text-xs text-[rgba(22,24,35,0.4)]">调度计划数据暂不可用</div>
+            ) : schedule?.upcoming.length ? (
+              <div className="divide-y divide-[rgba(22,24,35,0.06)]">
+                {schedule.upcoming.map((item) => <ScheduleRow item={item} key={`${item.type}-${item.id}`} />)}
+              </div>
+            ) : (
               <div className="flex min-h-[190px] flex-col items-center justify-center rounded-lg bg-[#fafafa] text-center">
-                <Activity size={24} className="text-[rgba(22,24,35,0.24)]" />
-                <span className="mt-2 text-xs text-[rgba(22,24,35,0.42)]">暂无运行实例</span>
+                <CalendarClock size={24} className="text-[rgba(22,24,35,0.24)]" />
+                <span className="mt-2 text-xs text-[rgba(22,24,35,0.42)]">暂无明确的后续执行计划</span>
               </div>
             )}
           </div>
         </section>
       </div>
 
-      <DeferredSection
-        title="调度与趋势"
-        description="下一阶段再统一调度事件、运行趋势、SLA 与吞吐量口径；当前继续不展示任何演示统计。"
-      />
+      <DeferredSection />
     </div>
   );
 };

--- a/yak-ops-ui/src/pages/home/model.ts
+++ b/yak-ops-ui/src/pages/home/model.ts
@@ -1,4 +1,9 @@
-export type HomeDataSourceKey = 'dataSource' | 'client' | 'alarm' | 'execution';
+export type HomeDataSourceKey =
+  | 'dataSource'
+  | 'client'
+  | 'alarm'
+  | 'execution'
+  | 'schedule';
 
 export interface HomeDataSourceOverview {
   total: number;
@@ -51,10 +56,37 @@ export interface HomeExecutionOverview {
   limited: boolean;
 }
 
+export type HomeScheduleType = 'batch' | 'workflow';
+
+export interface HomeScheduleItem {
+  id: string | number;
+  type: HomeScheduleType;
+  name: string;
+  status: string;
+  cronExpression?: string;
+  nextRunAt: string;
+  lastRunAt?: string;
+  timezone?: string;
+  path: string;
+}
+
+export interface HomeScheduleOverview {
+  total: number;
+  enabled: number;
+  paused: number;
+  today: number;
+  next24h: number;
+  upcoming: HomeScheduleItem[];
+  batchObserved: number;
+  workflowObserved: number;
+  limited: boolean;
+}
+
 export interface HomeOverview {
   dataSource?: HomeDataSourceOverview;
   client?: HomeClientOverview;
   alarm?: HomeAlarmOverview;
   execution?: HomeExecutionOverview;
+  schedule?: HomeScheduleOverview;
   unavailable: HomeDataSourceKey[];
 }

--- a/yak-ops-ui/src/pages/home/service.ts
+++ b/yak-ops-ui/src/pages/home/service.ts
@@ -2,6 +2,10 @@ import {
   getWorkflowInstances,
   type WorkflowInstance,
 } from '@/services/workflow';
+import {
+  listWorkflowSchedules,
+  type WorkflowSchedule,
+} from '@/services/workflow/schedules';
 import HttpUtils from '@/utils/HttpUtils';
 import dayjs from 'dayjs';
 import { fetchAlarmRecords } from '../alarm/service';
@@ -20,12 +24,15 @@ import type {
   HomeExecutionOverview,
   HomeOverview,
   HomeRunItem,
+  HomeScheduleItem,
+  HomeScheduleOverview,
 } from './model';
 
 const CLIENT_COUNT_API = '/api/v1/datax/executor/count';
 const HOME_BATCH_INSTANCE_LIMIT = 200;
 const HOME_BATCH_DEFINITION_LIMIT = 200;
 const HOME_RECENT_RUN_LIMIT = 6;
+const HOME_UPCOMING_SCHEDULE_LIMIT = 6;
 
 const SUCCESS_STATUSES = new Set([
   'SUCCESS',
@@ -61,10 +68,13 @@ type ClientCountPayload =
       offlineCount?: number;
     };
 
+interface BatchDefinitionSnapshot {
+  definitions: OfflineJobDefinitionVO[];
+  total: number;
+}
+
 const asFiniteNumber = (value: unknown): number | undefined => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return undefined;
-  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
   return value;
 };
 
@@ -74,9 +84,7 @@ const firstNumber = (
 ): number | undefined => {
   for (const key of keys) {
     const value = asFiniteNumber(payload[key]);
-    if (value !== undefined) {
-      return value;
-    }
+    if (value !== undefined) return value;
   }
   return undefined;
 };
@@ -110,10 +118,7 @@ export const normalizeClientCount = (
   if (typeof payload === 'number') {
     return Number.isFinite(payload) ? { total: payload } : undefined;
   }
-
-  if (!payload || typeof payload !== 'object') {
-    return undefined;
-  }
+  if (!payload || typeof payload !== 'object') return undefined;
 
   const record = payload as Record<string, unknown>;
   const online = firstNumber(record, [
@@ -127,10 +132,7 @@ export const normalizeClientCount = (
     firstNumber(record, ['total', 'count', 'executorCount']) ??
     (online !== undefined && offline !== undefined ? online + offline : undefined);
 
-  if (total === undefined) {
-    return undefined;
-  }
-
+  if (total === undefined) return undefined;
   return {
     total,
     ...(online === undefined ? {} : { online }),
@@ -141,33 +143,25 @@ export const normalizeClientCount = (
 const fetchHomeDataSourceOverview = async (): Promise<HomeDataSourceOverview> => {
   const response = await fetchDataSourceSummary();
   const data = response?.data;
-
   if (!data || typeof data.total !== 'number') {
     throw new Error('数据源汇总接口未返回有效数据');
   }
-
   return data;
 };
 
 const fetchHomeClientOverview = async (): Promise<HomeClientOverview> => {
   const response = await HttpUtils.get<ClientCountPayload>(CLIENT_COUNT_API);
   const data = normalizeClientCount(response?.data);
-
-  if (!data) {
-    throw new Error('客户端统计接口未返回有效数据');
-  }
-
+  if (!data) throw new Error('客户端统计接口未返回有效数据');
   return data;
 };
 
 const fetchHomeAlarmOverview = async (): Promise<HomeAlarmOverview> => {
   const response = await fetchAlarmRecords({ pageNo: 1, pageSize: 3 });
   const data = response?.data;
-
   if (!data || typeof data.total !== 'number' || !Array.isArray(data.list)) {
     throw new Error('告警记录接口未返回有效数据');
   }
-
   return {
     total: data.total,
     recent: data.list.map((item) => ({
@@ -178,6 +172,19 @@ const fetchHomeAlarmOverview = async (): Promise<HomeAlarmOverview> => {
       time: item.sentTime || item.createTime,
     })),
   };
+};
+
+const fetchBatchDefinitionSnapshot = async (): Promise<BatchDefinitionSnapshot> => {
+  const response = await linkupJobDefinitionApi.page({
+    current: 1,
+    pageSize: HOME_BATCH_DEFINITION_LIMIT,
+  });
+  const definitions = response?.data?.bizData;
+  const total = response?.data?.pagination?.total;
+  if (!Array.isArray(definitions) || typeof total !== 'number') {
+    throw new Error('离线同步任务定义接口未返回有效数据');
+  }
+  return { definitions, total };
 };
 
 const toBatchRunItem = (
@@ -220,9 +227,7 @@ export const buildExecutionOverview = (
   const definitionMap = new Map<string, OfflineJobDefinitionVO>(
     definitions
       .filter((item) => item.id !== undefined && item.id !== null)
-      .map(
-        (item): [string, OfflineJobDefinitionVO] => [String(item.id), item],
-      ),
+      .map((item): [string, OfflineJobDefinitionVO] => [String(item.id), item]),
   );
   const runs = [
     ...batchExecutions.map((item) => toBatchRunItem(item, definitionMap)),
@@ -251,12 +256,14 @@ export const buildExecutionOverview = (
   };
 };
 
-const fetchHomeExecutionOverview = async (): Promise<HomeExecutionOverview> => {
-  const definitionPromise = linkupJobDefinitionApi
-    .page({ current: 1, pageSize: HOME_BATCH_DEFINITION_LIMIT })
-    .catch(() => undefined);
+const fetchHomeExecutionOverview = async (
+  batchDefinitionPromise: Promise<BatchDefinitionSnapshot>,
+): Promise<HomeExecutionOverview> => {
+  const definitionPromise = batchDefinitionPromise
+    .then((snapshot) => snapshot.definitions)
+    .catch(() => [] as OfflineJobDefinitionVO[]);
 
-  const [batchResponse, workflowInstances, definitionResponse] = await Promise.all([
+  const [batchResponse, workflowInstances, definitions] = await Promise.all([
     batchJobInstanceApi.page({ current: 1, pageSize: HOME_BATCH_INSTANCE_LIMIT }),
     getWorkflowInstances(),
     definitionPromise,
@@ -271,30 +278,150 @@ const fetchHomeExecutionOverview = async (): Promise<HomeExecutionOverview> => {
     throw new Error('工作流实例接口未返回有效数据');
   }
 
-  const definitions = definitionResponse?.data?.bizData;
   return buildExecutionOverview(
     batchExecutions,
     workflowInstances,
-    Array.isArray(definitions) ? definitions : [],
+    definitions,
     batchTotal,
   );
 };
 
+const isBatchSchedule = (definition: OfflineJobDefinitionVO) =>
+  Boolean(
+    definition.cronExpression ||
+      definition.scheduleStatus ||
+      definition.nextScheduleTime ||
+      definition.lastScheduleTime,
+  );
+
+const toBatchScheduleItem = (
+  definition: OfflineJobDefinitionVO,
+): HomeScheduleItem | undefined => {
+  if (
+    definition.id === undefined ||
+    definition.id === null ||
+    definition.scheduleStatus !== 'NORMAL' ||
+    !definition.nextScheduleTime
+  ) {
+    return undefined;
+  }
+  return {
+    id: definition.id,
+    type: 'batch',
+    name: definition.jobName || `离线同步 #${definition.id}`,
+    status: definition.scheduleStatus,
+    cronExpression: definition.cronExpression,
+    nextRunAt: definition.nextScheduleTime,
+    lastRunAt: definition.lastScheduleTime,
+    path: `/sync/batch-link-up/${definition.id}/detail`,
+  };
+};
+
+const toWorkflowScheduleItem = (
+  schedule: WorkflowSchedule,
+): HomeScheduleItem | undefined => {
+  if (schedule.status !== 'ONLINE' || !schedule.nextFireTime) return undefined;
+  return {
+    id: schedule.id,
+    type: 'workflow',
+    name: schedule.name || `工作流调度 #${schedule.id}`,
+    status: schedule.status,
+    cronExpression: schedule.cronExpression,
+    nextRunAt: schedule.nextFireTime,
+    lastRunAt: schedule.lastFireTime,
+    timezone: schedule.timezone,
+    path: '/workflow/schedules',
+  };
+};
+
+const isFutureSchedule = (item: HomeScheduleItem, now: dayjs.Dayjs) => {
+  const time = dayjs(item.nextRunAt);
+  return time.isValid() && time.isAfter(now);
+};
+
+export const buildScheduleOverview = (
+  definitions: OfflineJobDefinitionVO[],
+  batchTotal: number,
+  workflowSchedules: WorkflowSchedule[],
+): HomeScheduleOverview => {
+  const batchSchedules = definitions.filter(isBatchSchedule);
+  const enabledBatch = batchSchedules.filter(
+    (item) => item.scheduleStatus === 'NORMAL',
+  ).length;
+  const enabledWorkflow = workflowSchedules.filter(
+    (item) => item.status === 'ONLINE',
+  ).length;
+  const total = batchSchedules.length + workflowSchedules.length;
+  const enabled = enabledBatch + enabledWorkflow;
+  const now = dayjs();
+  const next24Hours = now.add(24, 'hour');
+
+  const futureSchedules = [
+    ...batchSchedules
+      .map(toBatchScheduleItem)
+      .filter((item): item is HomeScheduleItem => Boolean(item)),
+    ...workflowSchedules
+      .map(toWorkflowScheduleItem)
+      .filter((item): item is HomeScheduleItem => Boolean(item)),
+  ]
+    .filter((item) => isFutureSchedule(item, now))
+    .sort((left, right) => timeValue(left.nextRunAt) - timeValue(right.nextRunAt));
+
+  return {
+    total,
+    enabled,
+    paused: Math.max(total - enabled, 0),
+    today: futureSchedules.filter((item) => isToday(item.nextRunAt)).length,
+    next24h: futureSchedules.filter((item) => {
+      const time = dayjs(item.nextRunAt);
+      return time.isValid() && !time.isAfter(next24Hours);
+    }).length,
+    upcoming: futureSchedules.slice(0, HOME_UPCOMING_SCHEDULE_LIMIT),
+    batchObserved: batchSchedules.length,
+    workflowObserved: workflowSchedules.length,
+    limited: batchTotal > definitions.length,
+  };
+};
+
+const fetchHomeScheduleOverview = async (
+  batchDefinitionPromise: Promise<BatchDefinitionSnapshot>,
+): Promise<HomeScheduleOverview> => {
+  const [batchSnapshot, workflowSchedules] = await Promise.all([
+    batchDefinitionPromise,
+    listWorkflowSchedules(),
+  ]);
+  if (!Array.isArray(workflowSchedules)) {
+    throw new Error('工作流调度接口未返回有效数据');
+  }
+  return buildScheduleOverview(
+    batchSnapshot.definitions,
+    batchSnapshot.total,
+    workflowSchedules,
+  );
+};
+
 export async function fetchHomeOverview(): Promise<HomeOverview> {
-  const [dataSourceResult, clientResult, alarmResult, executionResult] =
-    await Promise.allSettled([
-      fetchHomeDataSourceOverview(),
-      fetchHomeClientOverview(),
-      fetchHomeAlarmOverview(),
-      fetchHomeExecutionOverview(),
-    ]);
+  const batchDefinitionPromise = fetchBatchDefinitionSnapshot();
+  const [
+    dataSourceResult,
+    clientResult,
+    alarmResult,
+    executionResult,
+    scheduleResult,
+  ] = await Promise.allSettled([
+    fetchHomeDataSourceOverview(),
+    fetchHomeClientOverview(),
+    fetchHomeAlarmOverview(),
+    fetchHomeExecutionOverview(batchDefinitionPromise),
+    fetchHomeScheduleOverview(batchDefinitionPromise),
+  ]);
 
   const unavailable: HomeDataSourceKey[] = [];
-
   if (dataSourceResult.status === 'rejected') unavailable.push('dataSource');
   if (clientResult.status === 'rejected') unavailable.push('client');
   if (alarmResult.status === 'rejected') unavailable.push('alarm');
   if (executionResult.status === 'rejected') unavailable.push('execution');
+  if (scheduleResult.status === 'rejected') unavailable.push('schedule');
 
   return {
     dataSource:
@@ -303,6 +430,8 @@ export async function fetchHomeOverview(): Promise<HomeOverview> {
     alarm: alarmResult.status === 'fulfilled' ? alarmResult.value : undefined,
     execution:
       executionResult.status === 'fulfilled' ? executionResult.value : undefined,
+    schedule:
+      scheduleResult.status === 'fulfilled' ? scheduleResult.value : undefined,
     unavailable,
   };
 }


### PR DESCRIPTION
## What changed

- Added the third-stage real scheduling view to `/home`.
- Unified existing offline-sync scheduling data and workflow schedules into a shared Home schedule model.
- Added real schedule metrics for:
  - 今日计划
  - 已配置
  - 已启用
  - 已暂停
  - 24h 内计划
- Added a mixed “近期计划” list that combines offline sync and workflow schedules and sorts them by their real next-run time.
- Only schedules whose backend response explicitly provides a future `nextScheduleTime` / `nextFireTime` are shown as upcoming; the Home page does not calculate future executions from cron expressions itself.
- Reused the same offline task-definition request for runtime name resolution and schedule aggregation, avoiding a duplicate Home request.
- Preserved partial-failure semantics: if schedule data cannot be assembled completely, the schedule area shows `暂不可用` rather than misleading partial totals.
- Keeps trend, SLA, success-rate history, and throughput metrics deferred until a unified historical statistics contract is available.

## Schedule semantics

- Offline sync is treated as enabled only when `scheduleStatus === NORMAL`, matching the existing batch schedule UI.
- Workflow schedules use the existing `ONLINE / OFFLINE` status.
- `今日计划` counts enabled schedules whose real next-run time is later today.
- `24h 内` counts enabled schedules whose real next-run time falls within the next 24 hours.
- Paused schedules remain visible in aggregate counts but are not included in upcoming plans.

## Scope

Only Home files are changed:

- `yak-ops-ui/src/pages/home/index.tsx`
- `yak-ops-ui/src/pages/home/model.ts`
- `yak-ops-ui/src/pages/home/service.ts`

## Validation

- Compared `agent/home-schedule-phase3` against current `main`; the branch is directly based on the phase-two merge and only changes the three Home files.
- Verified the existing offline schedule fields (`scheduleStatus`, `nextScheduleTime`) and workflow schedule contract (`ONLINE/OFFLINE`, `nextFireTime`) before wiring the aggregation.
- Added explicit warning text when offline task definitions exceed the Home 200-item read limit.
- Local `npm run lint` / build is not available in this connector-only runtime, so GitHub CI, if configured, should be treated as the authoritative build check.
