### PR TITLE
refactor: make Dataset a standalone SQL-backed asset

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDatasetNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDatasetNodeController.java
@@ -7,9 +7,7 @@ import io.yak.ops.business.dataset.DevelopmentDatasetFacade.FieldDraft;
 import io.yak.ops.business.development.service.DevelopmentDatasetNodeService;
 import io.yak.ops.business.development.service.DevelopmentDatasetNodeService.DatasetNodeContext;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Dataset Node editor API. Workflow topology remains owned by the workflow module. */
+/** Dataset Node editor API. Dataset owns datasource + SQL; SQL development tasks are independent. */
 @Tag(name = "数据开发 Dataset Node 接口")
 @RestController
 @RequestMapping("/api/v1/data-development/nodes")
@@ -32,21 +30,21 @@ public class DevelopmentDatasetNodeController {
     this.service = service;
   }
 
-  @Operation(summary = "查询 Dataset Node、可选 SQL 来源与 Dataset 资产")
+  @Operation(summary = "查询 Dataset Node 与 Dataset 资产")
   @GetMapping("/{nodeId}/dataset")
   public Result<DatasetNodeContext> get(@PathVariable("nodeId") long nodeId) {
     return Result.success(service.get(nodeId));
   }
 
-  @Operation(summary = "基于选中的已发布 SQL Revision 发现 Dataset 字段")
+  @Operation(summary = "基于 Dataset 自有 SQL 发现输出字段")
   @PostMapping("/{nodeId}/dataset/preview")
   public Result<List<FieldDraft>> preview(
       @PathVariable("nodeId") long nodeId,
-      @Valid @RequestBody DatasetSourceRequest request) {
-    return Result.success(service.preview(nodeId, request.sourceTaskAssetId()));
+      @Valid @RequestBody DatasetSqlRequest request) {
+    return Result.success(service.preview(nodeId, request.dataSourceId(), request.sql()));
   }
 
-  @Operation(summary = "保存 Dataset Node 并冻结选中 SQL 的当前 Revision")
+  @Operation(summary = "保存 Dataset Node 并冻结数据源、SQL 与字段契约")
   @PutMapping("/{nodeId}/dataset")
   public Result<DatasetNodeContext> save(
       @PathVariable("nodeId") long nodeId,
@@ -56,28 +54,26 @@ public class DevelopmentDatasetNodeController {
         : request.fields().stream().map(DevelopmentDatasetNodeController::toFieldDraft).toList();
     return Result.success(service.save(
         nodeId,
-        request.sourceTaskAssetId(),
+        request.dataSourceId(),
+        request.sql(),
         request.description(),
         fields));
   }
 
   private static FieldDraft toFieldDraft(DatasetFieldRequest field) {
     return new FieldDraft(
-        field.fieldId(),
-        field.physicalName(),
-        field.displayName(),
-        field.dataType(),
-        field.nullable(),
-        field.description(),
-        field.defaultRole());
+        field.fieldId(), field.physicalName(), field.displayName(), field.dataType(),
+        field.nullable(), field.description(), field.defaultRole());
   }
 
-  public record DatasetSourceRequest(
-      @NotNull @Min(1) Long sourceTaskAssetId) {
+  public record DatasetSqlRequest(
+      @NotBlank @Size(max = 128) String dataSourceId,
+      @NotBlank @Size(max = 200000) String sql) {
   }
 
   public record SaveDatasetNodeRequest(
-      @NotNull @Min(1) Long sourceTaskAssetId,
+      @NotBlank @Size(max = 128) String dataSourceId,
+      @NotBlank @Size(max = 200000) String sql,
       @Size(max = 2000) String description,
       List<@Valid DatasetFieldRequest> fields) {
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDatasetNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDatasetNodeService.java
@@ -17,13 +17,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Turns a standalone DATASET node into a stable Dataset asset.
- *
- * <p>Source selection belongs to the Dataset node itself. Workflow topology is intentionally not
- * consulted here: orchestration relationships are owned by the dedicated workflow module. Saving the
- * Dataset snapshots the selected SQL TaskAsset's current immutable TaskRevision.
- */
+/** Dataset node application service. New editors own datasource + SQL directly. */
 @Service
 public class DevelopmentDatasetNodeService {
 
@@ -46,12 +40,36 @@ public class DevelopmentDatasetNodeService {
     return context(datasetNode, dataset, selectedSource(dataset));
   }
 
+  /** Standalone editor preview; no SQL TaskAsset is required. */
+  public List<FieldDraft> preview(long nodeId, String dataSourceId, String sql) {
+    requireDatasetNode(nodeId);
+    return datasetFacade.preview(dataSourceId, sql);
+  }
+
+  /** Standalone editor save; DatasetVersion freezes datasource + SQL + field contract. */
+  @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
+  public DatasetNodeContext save(
+      long nodeId,
+      String dataSourceId,
+      String sql,
+      String description,
+      List<FieldDraft> fields) {
+    DevelopmentNode datasetNode = requireDatasetNode(nodeId);
+    NodeDataset saved = datasetFacade.save(
+        nodeId, dataSourceId, sql, datasetNode.name(), description, fields);
+    markConfigured(datasetNode);
+    DevelopmentNode refreshed = nodeRepository.findById(nodeId).orElse(datasetNode);
+    return context(refreshed, saved, null);
+  }
+
+  /** Legacy TaskAsset preview retained for compatibility during migration. */
   public List<FieldDraft> preview(long nodeId, long sourceTaskAssetId) {
     DevelopmentNode datasetNode = requireDatasetNode(nodeId);
     TaskAsset source = requireSelectableSqlAsset(datasetNode, sourceTaskAssetId);
     return datasetFacade.preview(source.id());
   }
 
+  /** Legacy TaskAsset save retained for compatibility during migration. */
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public DatasetNodeContext save(
       long nodeId,
@@ -61,16 +79,16 @@ public class DevelopmentDatasetNodeService {
     DevelopmentNode datasetNode = requireDatasetNode(nodeId);
     TaskAsset source = requireSelectableSqlAsset(datasetNode, sourceTaskAssetId);
     NodeDataset saved = datasetFacade.save(
-        nodeId,
-        source.id(),
-        datasetNode.name(),
-        description,
-        fields);
-    if (!datasetNode.configured() && !nodeRepository.updateConfigured(nodeId, true)) {
-      throw new IllegalStateException("Dataset Node 配置状态更新失败：" + nodeId);
-    }
+        nodeId, source.id(), datasetNode.name(), description, fields);
+    markConfigured(datasetNode);
     DevelopmentNode refreshed = nodeRepository.findById(nodeId).orElse(datasetNode);
     return context(refreshed, saved, toSnapshot(source));
+  }
+
+  private void markConfigured(DevelopmentNode datasetNode) {
+    if (!datasetNode.configured() && !nodeRepository.updateConfigured(datasetNode.id(), true)) {
+      throw new IllegalStateException("Dataset Node 配置状态更新失败：" + datasetNode.id());
+    }
   }
 
   private DatasetNodeContext context(
@@ -86,6 +104,7 @@ public class DevelopmentDatasetNodeService {
         dataset);
   }
 
+  /** Legacy source list remains in the response temporarily; the new UI no longer consumes it. */
   private List<SourceSnapshot> availableSources(DevelopmentNode datasetNode) {
     return taskCatalogService.list("DATA_DEVELOPMENT", "ONLINE", null).stream()
         .filter(asset -> "SQL".equalsIgnoreCase(asset.taskType()))
@@ -100,21 +119,17 @@ public class DevelopmentDatasetNodeService {
 
   private SourceSnapshot selectedSource(NodeDataset dataset) {
     if (dataset == null || dataset.currentVersion() == null) return null;
+    String assetId = dataset.currentVersion().sourceTaskAssetId();
+    if (assetId == null || assetId.isBlank() || "0".equals(assetId)) return null;
     try {
-      TaskAsset asset = taskCatalogService.get(
-          Long.parseLong(dataset.currentVersion().sourceTaskAssetId()));
-      return toSnapshot(asset);
+      return toSnapshot(taskCatalogService.get(Long.parseLong(assetId)));
     } catch (RuntimeException exception) {
       return null;
     }
   }
 
-  private TaskAsset requireSelectableSqlAsset(
-      DevelopmentNode datasetNode,
-      long sourceTaskAssetId) {
-    if (sourceTaskAssetId <= 0L) {
-      throw new IllegalArgumentException("sourceTaskAssetId 必须大于 0");
-    }
+  private TaskAsset requireSelectableSqlAsset(DevelopmentNode datasetNode, long sourceTaskAssetId) {
+    if (sourceTaskAssetId <= 0L) throw new IllegalArgumentException("sourceTaskAssetId 必须大于 0");
     TaskAsset asset = taskCatalogService.get(sourceTaskAssetId);
     if (asset.source() != TaskAssetSource.DATA_DEVELOPMENT) {
       throw new IllegalArgumentException("Dataset 只能选择数据开发 SQL 来源");
@@ -152,8 +167,7 @@ public class DevelopmentDatasetNodeService {
 
   private Optional<SourceSnapshot> toSnapshotIfValidSqlNode(TaskAsset asset) {
     try {
-      DevelopmentNode sourceNode = requireSourceSqlNode(asset);
-      return Optional.of(toSnapshot(asset, sourceNode));
+      return Optional.of(toSnapshot(asset, requireSourceSqlNode(asset)));
     } catch (RuntimeException exception) {
       return Optional.empty();
     }
@@ -163,22 +177,15 @@ public class DevelopmentDatasetNodeService {
     DevelopmentNode sourceNode = nodeRepository.findById(parseSourceNodeId(asset)).orElse(null);
     return sourceNode == null
         ? new SourceSnapshot(
-            asset.sourceRef(),
-            asset.name(),
-            String.valueOf(asset.id()),
-            asset.status().name(),
-            String.valueOf(asset.currentRevision().taskRevisionId()),
-            asset.currentRevision().revisionNo())
+            asset.sourceRef(), asset.name(), String.valueOf(asset.id()), asset.status().name(),
+            String.valueOf(asset.currentRevision().taskRevisionId()), asset.currentRevision().revisionNo())
         : toSnapshot(asset, sourceNode);
   }
 
   private SourceSnapshot toSnapshot(TaskAsset asset, DevelopmentNode sourceNode) {
     return new SourceSnapshot(
-        String.valueOf(sourceNode.id()),
-        sourceNode.name(),
-        String.valueOf(asset.id()),
-        asset.status().name(),
-        String.valueOf(asset.currentRevision().taskRevisionId()),
+        String.valueOf(sourceNode.id()), sourceNode.name(), String.valueOf(asset.id()),
+        asset.status().name(), String.valueOf(asset.currentRevision().taskRevisionId()),
         asset.currentRevision().revisionNo());
   }
 

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/Dataset.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/Dataset.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 import java.util.List;
 
-/** Stable BI-consumption asset. Task execution remains owned by the upstream source domain. */
+/** Stable BI-consumption asset. Dataset versions freeze their own executable source contract. */
 public record Dataset(
     @JsonSerialize(using = ToStringSerializer.class) long id,
     String name,
@@ -23,6 +23,7 @@ enum DatasetStatus {
 
 enum DatasetSourceType {
   QUERY_REVISION,
+  SQL_QUERY,
   TABLE,
   VIEW
 }
@@ -49,8 +50,35 @@ record DatasetVersion(
     @JsonSerialize(using = ToStringSerializer.class) long sourceTaskAssetId,
     @JsonSerialize(using = ToStringSerializer.class) long sourceTaskRevisionId,
     int sourceTaskRevisionNo,
+    String dataSourceId,
+    String sql,
     String schemaSnapshot,
     Instant createTime) {
+
+  /** Keeps existing QUERY_REVISION-focused tests/callers source compatible. */
+  DatasetVersion(
+      long id,
+      long datasetId,
+      int versionNo,
+      DatasetSourceType sourceType,
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId,
+      int sourceTaskRevisionNo,
+      String schemaSnapshot,
+      Instant createTime) {
+    this(
+        id,
+        datasetId,
+        versionNo,
+        sourceType,
+        sourceTaskAssetId,
+        sourceTaskRevisionId,
+        sourceTaskRevisionNo,
+        null,
+        null,
+        schemaSnapshot,
+        createTime);
+  }
 }
 
 record DatasetField(

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetRepository.java
@@ -24,6 +24,16 @@ interface DatasetRepository {
       int sourceTaskRevisionNo,
       String schemaSnapshot);
 
+  /** Persists a Dataset-owned SQL snapshot without depending on a data-development TaskAsset. */
+  default long insertStandaloneVersion(
+      long datasetId,
+      int versionNo,
+      String dataSourceId,
+      String sql,
+      String schemaSnapshot) {
+    throw new UnsupportedOperationException("Standalone Dataset SQL is not supported");
+  }
+
   void insertFields(long versionId, List<DatasetService.FieldSpec> fields);
 
   void updateCurrentVersion(long datasetId, long versionId);

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Service;
 
-/** Discovers and freezes QUERY_REVISION output schema while a DatasetVersion is being created. */
+/** Discovers Dataset output schema from either legacy TaskRevision or Dataset-owned SQL. */
 @Service
 final class DatasetSchemaDiscoveryService {
 
@@ -47,9 +47,17 @@ final class DatasetSchemaDiscoveryService {
     return toFields(datasetId, discoverColumns(asset));
   }
 
-  /** Preview uses no persistent fieldId; DatasetService assigns stable ids when the version is saved. */
   List<DatasetService.FieldSpec> preview(TaskAsset asset) {
     return toPreviewFields(discoverColumns(asset));
+  }
+
+  List<DatasetService.FieldSpec> discover(long datasetId, String dataSourceId, String sql) {
+    return toFields(datasetId, discoverColumns(dataSourceId, sql, DEFAULT_TIMEOUT_SECONDS));
+  }
+
+  /** Preview owns no persistent fieldId; stable ids are assigned when a version is saved. */
+  List<DatasetService.FieldSpec> preview(String dataSourceId, String sql) {
+    return toPreviewFields(discoverColumns(dataSourceId, sql, DEFAULT_TIMEOUT_SECONDS));
   }
 
   private List<DataSourceSqlColumn> discoverColumns(TaskAsset asset) {
@@ -59,23 +67,29 @@ final class DatasetSchemaDiscoveryService {
         || resolved.revision().revisionNo() != asset.currentRevision().revisionNo()) {
       throw new IllegalStateException("Schema discovery 解析到的 TaskRevision 与发布快照不一致");
     }
-
     TaskDefinition definition = resolved.revision().definition();
     if (!"SQL".equalsIgnoreCase(definition.taskType())) {
       throw new IllegalArgumentException("Schema discovery 仅支持 SQL TaskRevision");
     }
-    String baseSql = DatasetSqlSafety.requireReadOnlyQuery(definition.content());
     SourceConfig config = sourceConfig(definition.configJson());
+    return discoverColumns(config.dataSourceId(), definition.content(), config.timeoutSeconds());
+  }
+
+  private List<DataSourceSqlColumn> discoverColumns(
+      String dataSourceId,
+      String sql,
+      int timeoutSeconds) {
+    String normalizedDataSourceId = requireDataSourceId(dataSourceId);
+    String baseSql = DatasetSqlSafety.requireReadOnlyQuery(sql);
     String discoverySql = "SELECT yak_dataset_source.* FROM (" + baseSql
         + ") yak_dataset_source LIMIT 1";
 
     DataSourceSqlResult result;
-    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(config.dataSourceId())) {
-      result = executor.execute(new DataSourceSqlRequest(discoverySql, 1, config.timeoutSeconds()));
+    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(normalizedDataSourceId)) {
+      result = executor.execute(new DataSourceSqlRequest(
+          discoverySql, 1, Math.min(Math.max(timeoutSeconds, 1), MAX_DISCOVERY_TIMEOUT_SECONDS)));
     }
-    if (!result.resultSet()) {
-      throw new IllegalStateException("Dataset schema discovery 没有返回结果集");
-    }
+    if (!result.resultSet()) throw new IllegalStateException("Dataset schema discovery 没有返回结果集");
     if (result.columns().isEmpty()) {
       throw new IllegalArgumentException("Dataset 来源查询没有可发现的输出字段");
     }
@@ -83,16 +97,11 @@ final class DatasetSchemaDiscoveryService {
   }
 
   private List<DatasetService.FieldSpec> toFields(long datasetId, List<DataSourceSqlColumn> columns) {
-    List<DatasetService.FieldSpec> preview = toPreviewFields(columns);
-    return preview.stream()
+    return toPreviewFields(columns).stream()
         .map(field -> new DatasetService.FieldSpec(
             stableFieldId(datasetId, field.physicalName()),
-            field.physicalName(),
-            field.displayName(),
-            field.dataType(),
-            field.nullable(),
-            field.description(),
-            field.defaultRole()))
+            field.physicalName(), field.displayName(), field.dataType(), field.nullable(),
+            field.description(), field.defaultRole()))
         .toList();
   }
 
@@ -110,22 +119,14 @@ final class DatasetSchemaDiscoveryService {
         throw new IllegalArgumentException(
             "Dataset 输出字段必须使用简单安全别名 [A-Za-z_][A-Za-z0-9_$]*：" + physicalName);
       }
-      String normalized = physicalName.toLowerCase(Locale.ROOT);
-      if (!names.add(normalized)) {
+      if (!names.add(physicalName.toLowerCase(Locale.ROOT))) {
         throw new IllegalArgumentException("Dataset 来源查询存在重复输出字段：" + physicalName);
       }
-
       DatasetFieldDataType dataType = dataType(column.jdbcType());
       DatasetFieldRole role = dataType == DatasetFieldDataType.NUMBER
           ? DatasetFieldRole.MEASURE : DatasetFieldRole.DIMENSION;
       fields.add(new DatasetService.FieldSpec(
-          null,
-          physicalName,
-          physicalName,
-          dataType,
-          column.nullable(),
-          null,
-          role));
+          null, physicalName, physicalName, dataType, column.nullable(), null, role));
     }
     return List.copyOf(fields);
   }
@@ -155,22 +156,22 @@ final class DatasetSchemaDiscoveryService {
     try {
       JsonNode root = objectMapper.readTree(raw);
       if (root == null || !root.isObject()) throw new IllegalArgumentException("SQL configJson 必须是 JSON 对象");
-      JsonNode dataSourceNode = root.get("dataSourceId");
-      String dataSourceId = dataSourceNode == null || dataSourceNode.isNull()
-          ? null : dataSourceNode.asText();
-      if (dataSourceId == null || dataSourceId.isBlank()) {
-        throw new IllegalArgumentException("SQL TaskRevision 缺少 dataSourceId，无法发现 Dataset schema");
-      }
+      String dataSourceId = root.path("dataSourceId").asText(null);
       int sourceTimeout = root.path("timeoutSeconds").asInt(DEFAULT_TIMEOUT_SECONDS);
       if (sourceTimeout < 1) sourceTimeout = DEFAULT_TIMEOUT_SECONDS;
       return new SourceConfig(
-          dataSourceId.trim(),
+          requireDataSourceId(dataSourceId),
           Math.min(sourceTimeout, MAX_DISCOVERY_TIMEOUT_SECONDS));
     } catch (IllegalArgumentException exception) {
       throw exception;
     } catch (Exception exception) {
       throw new IllegalArgumentException("SQL TaskRevision configJson 非法", exception);
     }
+  }
+
+  private String requireDataSourceId(String value) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException("Dataset 必须选择数据源");
+    return value.trim();
   }
 
   private record SourceConfig(String dataSourceId, int timeoutSeconds) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
@@ -6,19 +6,18 @@ import java.util.Locale;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
-/**
- * Public boundary used by data-development Dataset nodes.
- *
- * <p>It deliberately exposes DTOs made only of public Java types so the data-development module does
- * not depend on Dataset's internal persistence records or enums.
- */
+/** Public boundary used by data-development Dataset nodes. */
 @Service
 public class DevelopmentDatasetFacade {
 
   private final DatasetService service;
+  private final DevelopmentStandaloneDatasetService standaloneService;
 
-  public DevelopmentDatasetFacade(DatasetService service) {
+  public DevelopmentDatasetFacade(
+      DatasetService service,
+      DevelopmentStandaloneDatasetService standaloneService) {
     this.service = service;
+    this.standaloneService = standaloneService;
   }
 
   public Optional<NodeDataset> findByDevelopmentNodeId(long developmentNodeId) {
@@ -26,12 +25,36 @@ public class DevelopmentDatasetFacade {
         .map(detail -> toNodeDataset(developmentNodeId, detail));
   }
 
+  /** Standalone Dataset editor preview: datasource + SQL belong to Dataset itself. */
+  public List<FieldDraft> preview(String dataSourceId, String sql) {
+    return standaloneService.preview(dataSourceId, sql).stream()
+        .map(DevelopmentDatasetFacade::toFieldDraft)
+        .toList();
+  }
+
+  public NodeDataset save(
+      long developmentNodeId,
+      String dataSourceId,
+      String sql,
+      String name,
+      String description,
+      List<FieldDraft> fields) {
+    List<DatasetService.FieldSpec> specs = fields == null
+        ? List.of()
+        : fields.stream().map(DevelopmentDatasetFacade::toFieldSpec).toList();
+    DatasetDetail detail = standaloneService.save(
+        developmentNodeId, dataSourceId, sql, name, description, specs);
+    return toNodeDataset(developmentNodeId, detail);
+  }
+
+  /** Legacy TaskAsset API retained for release flows/tests outside the Dataset node editor. */
   public List<FieldDraft> preview(long sourceTaskAssetId) {
     return service.previewReleaseFields(sourceTaskAssetId).stream()
         .map(DevelopmentDatasetFacade::toFieldDraft)
         .toList();
   }
 
+  /** Legacy TaskAsset API retained for source compatibility. */
   public NodeDataset save(
       long developmentNodeId,
       long sourceTaskAssetId,
@@ -50,8 +73,7 @@ public class DevelopmentDatasetFacade {
   private static NodeDataset toNodeDataset(long developmentNodeId, DatasetDetail detail) {
     Dataset dataset = detail.dataset();
     VersionSnapshot currentVersion = detail.currentVersion() == null
-        ? null
-        : toVersion(detail.currentVersion());
+        ? null : toVersion(detail.currentVersion());
     return new NodeDataset(
         String.valueOf(developmentNodeId),
         String.valueOf(dataset.id()),
@@ -73,42 +95,28 @@ public class DevelopmentDatasetFacade {
         String.valueOf(version.sourceTaskAssetId()),
         String.valueOf(version.sourceTaskRevisionId()),
         version.sourceTaskRevisionNo(),
+        version.dataSourceId(),
+        version.sql(),
         version.createTime());
   }
 
   private static FieldSnapshot toField(DatasetField field) {
     return new FieldSnapshot(
-        field.fieldId(),
-        field.physicalName(),
-        field.displayName(),
-        field.dataType().name(),
-        field.nullable(),
-        field.description(),
-        field.defaultRole().name(),
-        field.sortOrder());
+        field.fieldId(), field.physicalName(), field.displayName(), field.dataType().name(),
+        field.nullable(), field.description(), field.defaultRole().name(), field.sortOrder());
   }
 
   private static FieldDraft toFieldDraft(DatasetService.FieldSpec field) {
     return new FieldDraft(
-        field.fieldId(),
-        field.physicalName(),
-        field.displayName(),
-        field.dataType().name(),
-        field.nullable(),
-        field.description(),
-        field.defaultRole().name());
+        field.fieldId(), field.physicalName(), field.displayName(), field.dataType().name(),
+        field.nullable(), field.description(), field.defaultRole().name());
   }
 
   private static DatasetService.FieldSpec toFieldSpec(FieldDraft field) {
     if (field == null) throw new IllegalArgumentException("Dataset 字段不能为空");
     return new DatasetService.FieldSpec(
-        field.fieldId(),
-        field.physicalName(),
-        field.displayName(),
-        parseDataType(field.dataType()),
-        field.nullable(),
-        field.description(),
-        parseRole(field.defaultRole()));
+        field.fieldId(), field.physicalName(), field.displayName(), parseDataType(field.dataType()),
+        field.nullable(), field.description(), parseRole(field.defaultRole()));
   }
 
   private static DatasetFieldDataType parseDataType(String value) {
@@ -149,7 +157,21 @@ public class DevelopmentDatasetFacade {
       String sourceTaskAssetId,
       String sourceTaskRevisionId,
       int sourceTaskRevisionNo,
+      String dataSourceId,
+      String sql,
       Instant createTime) {
+
+    public VersionSnapshot(
+        String versionId,
+        int versionNo,
+        String sourceType,
+        String sourceTaskAssetId,
+        String sourceTaskRevisionId,
+        int sourceTaskRevisionNo,
+        Instant createTime) {
+      this(versionId, versionNo, sourceType, sourceTaskAssetId, sourceTaskRevisionId,
+          sourceTaskRevisionNo, null, null, createTime);
+    }
   }
 
   public record FieldSnapshot(

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentStandaloneDatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentStandaloneDatasetService.java
@@ -1,0 +1,203 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Lifecycle for data-development Dataset nodes that own datasource + SQL directly. */
+@Service
+final class DevelopmentStandaloneDatasetService {
+
+  private final DatasetRepository repository;
+  private final DatasetSchemaDiscoveryService discoveryService;
+  private final ObjectMapper objectMapper;
+
+  DevelopmentStandaloneDatasetService(
+      DatasetRepository repository,
+      DatasetSchemaDiscoveryService discoveryService,
+      ObjectMapper objectMapper) {
+    this.repository = repository;
+    this.discoveryService = discoveryService;
+    this.objectMapper = objectMapper;
+  }
+
+  List<DatasetService.FieldSpec> preview(String dataSourceId, String sql) {
+    return discoveryService.preview(requireDataSourceId(dataSourceId), requireSql(sql));
+  }
+
+  @Transactional("yakBusinessTransactionManager")
+  DatasetDetail save(
+      long developmentNodeId,
+      String dataSourceId,
+      String sql,
+      String name,
+      String description,
+      List<DatasetService.FieldSpec> requestedFields) {
+    if (developmentNodeId <= 0L) throw new IllegalArgumentException("developmentNodeId 必须大于 0");
+    String sourceId = requireDataSourceId(dataSourceId);
+    String sourceSql = requireSql(sql);
+    String normalizedName = normalizeName(name);
+    String normalizedDescription = normalizeDescription(description);
+
+    Dataset dataset = repository.findDatasetByDevelopmentNodeId(developmentNodeId).orElse(null);
+    long datasetId;
+    if (dataset == null) {
+      datasetId = repository.insertDevelopmentNodeDataset(
+          developmentNodeId, normalizedName, normalizedDescription);
+    } else {
+      datasetId = dataset.id();
+      repository.updateMetadata(datasetId, normalizedName, normalizedDescription);
+    }
+
+    List<DatasetService.FieldSpec> fields = requestedFields == null || requestedFields.isEmpty()
+        ? discoveryService.discover(datasetId, sourceId, sourceSql)
+        : normalizeFields(datasetId, requestedFields);
+    DatasetDetail current = get(datasetId);
+    DatasetVersion version = current.currentVersion();
+    if (version != null
+        && version.sourceType() == DatasetSourceType.SQL_QUERY
+        && Objects.equals(version.dataSourceId(), sourceId)
+        && Objects.equals(version.sql(), sourceSql)
+        && sameFields(current.fields(), fields)) {
+      return current;
+    }
+
+    int versionNo = repository.nextVersionNo(datasetId);
+    long versionId = repository.insertStandaloneVersion(
+        datasetId, versionNo, sourceId, sourceSql, schemaSnapshot(fields));
+    repository.insertFields(versionId, fields);
+    repository.updateCurrentVersion(datasetId, versionId);
+    return get(datasetId);
+  }
+
+  private DatasetDetail get(long datasetId) {
+    Dataset dataset = repository.findDataset(datasetId)
+        .orElseThrow(() -> new IllegalArgumentException("Dataset 不存在：" + datasetId));
+    DatasetVersion currentVersion = dataset.currentVersionId() == null
+        ? null
+        : repository.findVersion(dataset.currentVersionId())
+            .orElseThrow(() -> new IllegalStateException("Dataset 当前版本不存在：" + dataset.currentVersionId()));
+    List<DatasetField> fields = currentVersion == null ? List.of() : repository.listFields(currentVersion.id());
+    return new DatasetDetail(dataset, currentVersion, repository.listVersions(datasetId), fields);
+  }
+
+  private List<DatasetService.FieldSpec> normalizeFields(
+      long datasetId,
+      List<DatasetService.FieldSpec> values) {
+    Map<String, String> existingIds = existingFieldIds(datasetId);
+    List<DatasetService.FieldSpec> result = new ArrayList<>(values.size());
+    Set<String> names = new HashSet<>();
+    Set<String> ids = new HashSet<>();
+    for (DatasetService.FieldSpec value : values) {
+      if (value == null) throw new IllegalArgumentException("Dataset 字段不能为空");
+      String physicalName = required(value.physicalName(), "physicalName", 128);
+      String key = physicalName.toLowerCase(Locale.ROOT);
+      if (!names.add(key)) throw new IllegalArgumentException("Dataset 字段重复：" + physicalName);
+      String fieldId = value.fieldId();
+      if (fieldId == null || fieldId.isBlank()) {
+        fieldId = existingIds.getOrDefault(key, stableFieldId(datasetId, key));
+      }
+      fieldId = required(fieldId, "fieldId", 64);
+      if (!ids.add(fieldId)) throw new IllegalArgumentException("fieldId 重复：" + fieldId);
+      String displayName = value.displayName();
+      if (displayName == null || displayName.isBlank()) displayName = physicalName;
+      displayName = required(displayName, "displayName", 200);
+      String fieldDescription = normalizeFieldDescription(value.description());
+      result.add(new DatasetService.FieldSpec(
+          fieldId,
+          physicalName,
+          displayName,
+          value.dataType() == null ? DatasetFieldDataType.UNKNOWN : value.dataType(),
+          value.nullable(),
+          fieldDescription,
+          value.defaultRole() == null ? DatasetFieldRole.DIMENSION : value.defaultRole()));
+    }
+    return List.copyOf(result);
+  }
+
+  private Map<String, String> existingFieldIds(long datasetId) {
+    Map<String, String> result = new HashMap<>();
+    repository.findDataset(datasetId).ifPresent(dataset -> {
+      if (dataset.currentVersionId() == null) return;
+      repository.listFields(dataset.currentVersionId()).forEach(field ->
+          result.put(field.physicalName().toLowerCase(Locale.ROOT), field.fieldId()));
+    });
+    return result;
+  }
+
+  private boolean sameFields(List<DatasetField> current, List<DatasetService.FieldSpec> requested) {
+    if (current.size() != requested.size()) return false;
+    for (int i = 0; i < current.size(); i++) {
+      DatasetField left = current.get(i);
+      DatasetService.FieldSpec right = requested.get(i);
+      if (!Objects.equals(left.fieldId(), right.fieldId())
+          || !Objects.equals(left.physicalName(), right.physicalName())
+          || !Objects.equals(left.displayName(), right.displayName())
+          || left.dataType() != right.dataType()
+          || left.nullable() != right.nullable()
+          || !Objects.equals(left.description(), right.description())
+          || left.defaultRole() != right.defaultRole()) return false;
+    }
+    return true;
+  }
+
+  private String requireDataSourceId(String value) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException("Dataset 必须选择数据源");
+    String normalized = value.trim();
+    if (normalized.length() > 128) throw new IllegalArgumentException("dataSourceId 不能超过 128 个字符");
+    return normalized;
+  }
+
+  private String requireSql(String value) {
+    return DatasetSqlSafety.requireReadOnlyQuery(value);
+  }
+
+  private String normalizeName(String value) {
+    return required(value, "Dataset 名称", 200);
+  }
+
+  private String normalizeDescription(String value) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim();
+    if (normalized.length() > 2000) throw new IllegalArgumentException("Dataset 描述不能超过 2000 个字符");
+    return normalized;
+  }
+
+  private String normalizeFieldDescription(String value) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim();
+    if (normalized.length() > 1000) throw new IllegalArgumentException("字段描述不能超过 1000 个字符");
+    return normalized;
+  }
+
+  private String required(String value, String field, int maxLength) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " 不能为空");
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) throw new IllegalArgumentException(field + " 不能超过 " + maxLength + " 个字符");
+    return normalized;
+  }
+
+  private String stableFieldId(long datasetId, String physicalKey) {
+    return UUID.nameUUIDFromBytes(
+        ("dataset:" + datasetId + ":" + physicalKey).getBytes(StandardCharsets.UTF_8)).toString();
+  }
+
+  private String schemaSnapshot(List<DatasetService.FieldSpec> fields) {
+    try {
+      return objectMapper.writeValueAsString(fields);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Dataset schemaSnapshot 序列化失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
@@ -28,8 +28,8 @@ class JdbcDatasetRepository implements DatasetRepository {
 
   private static final String VERSION_COLUMNS =
       "SELECT id, dataset_id, version_no, source_type, source_task_asset_id, "
-          + "source_task_revision_id, source_task_revision_no, schema_snapshot, create_time "
-          + "FROM yak_dataset_version";
+          + "source_task_revision_id, source_task_revision_no, data_source_id, sql_content, "
+          + "schema_snapshot, create_time FROM yak_dataset_version";
 
   private final JdbcTemplate jdbcTemplate;
 
@@ -43,13 +43,8 @@ class JdbcDatasetRepository implements DatasetRepository {
   }
 
   @Override
-  public long insertDevelopmentNodeDataset(
-      long developmentNodeId,
-      String name,
-      String description) {
-    if (developmentNodeId <= 0L) {
-      throw new IllegalArgumentException("developmentNodeId 必须大于 0");
-    }
+  public long insertDevelopmentNodeDataset(long developmentNodeId, String name, String description) {
+    if (developmentNodeId <= 0L) throw new IllegalArgumentException("developmentNodeId 必须大于 0");
     return insertDatasetInternal(developmentNodeId, name, description);
   }
 
@@ -63,11 +58,8 @@ class JdbcDatasetRepository implements DatasetRepository {
           VALUES (?, ?, ?, 'ONLINE', NULL, NOW(6), NOW(6))
           """,
           Statement.RETURN_GENERATED_KEYS);
-      if (developmentNodeId == null) {
-        statement.setNull(1, java.sql.Types.BIGINT);
-      } else {
-        statement.setLong(1, developmentNodeId);
-      }
+      if (developmentNodeId == null) statement.setNull(1, java.sql.Types.BIGINT);
+      else statement.setLong(1, developmentNodeId);
       statement.setString(2, name);
       statement.setString(3, description);
       return statement;
@@ -86,14 +78,42 @@ class JdbcDatasetRepository implements DatasetRepository {
       long sourceTaskRevisionId,
       int sourceTaskRevisionNo,
       String schemaSnapshot) {
+    return insertVersionInternal(
+        datasetId, versionNo, sourceType, sourceTaskAssetId, sourceTaskRevisionId,
+        sourceTaskRevisionNo, null, null, schemaSnapshot);
+  }
+
+  @Override
+  public long insertStandaloneVersion(
+      long datasetId,
+      int versionNo,
+      String dataSourceId,
+      String sql,
+      String schemaSnapshot) {
+    return insertVersionInternal(
+        datasetId, versionNo, DatasetSourceType.SQL_QUERY, 0L, 0L, 0,
+        dataSourceId, sql, schemaSnapshot);
+  }
+
+  private long insertVersionInternal(
+      long datasetId,
+      int versionNo,
+      DatasetSourceType sourceType,
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId,
+      int sourceTaskRevisionNo,
+      String dataSourceId,
+      String sql,
+      String schemaSnapshot) {
     KeyHolder keyHolder = new GeneratedKeyHolder();
     jdbcTemplate.update(connection -> {
       PreparedStatement statement = connection.prepareStatement(
           """
           INSERT INTO yak_dataset_version
             (dataset_id, version_no, source_type, source_task_asset_id,
-             source_task_revision_id, source_task_revision_no, schema_snapshot, create_time)
-          VALUES (?, ?, ?, ?, ?, ?, ?, NOW(6))
+             source_task_revision_id, source_task_revision_no, data_source_id, sql_content,
+             schema_snapshot, create_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6))
           """,
           Statement.RETURN_GENERATED_KEYS);
       statement.setLong(1, datasetId);
@@ -102,7 +122,9 @@ class JdbcDatasetRepository implements DatasetRepository {
       statement.setLong(4, sourceTaskAssetId);
       statement.setLong(5, sourceTaskRevisionId);
       statement.setInt(6, sourceTaskRevisionNo);
-      statement.setString(7, schemaSnapshot);
+      statement.setString(7, dataSourceId);
+      statement.setString(8, sql);
+      statement.setString(9, schemaSnapshot);
       return statement;
     }, keyHolder);
     Number key = keyHolder.getKey();
@@ -121,15 +143,9 @@ class JdbcDatasetRepository implements DatasetRepository {
              description, default_role, sort_order)
           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
           """,
-          field.fieldId(),
-          versionId,
-          field.physicalName(),
-          field.displayName(),
-          field.dataType().name(),
-          field.nullable(),
-          field.description(),
-          field.defaultRole().name(),
-          index + 1);
+          field.fieldId(), versionId, field.physicalName(), field.displayName(),
+          field.dataType().name(), field.nullable(), field.description(),
+          field.defaultRole().name(), index + 1);
     }
   }
 
@@ -137,8 +153,7 @@ class JdbcDatasetRepository implements DatasetRepository {
   public void updateCurrentVersion(long datasetId, long versionId) {
     int updated = jdbcTemplate.update(
         "UPDATE yak_dataset SET current_version_id = ?, update_time = NOW(6) WHERE id = ?",
-        versionId,
-        datasetId);
+        versionId, datasetId);
     if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
   }
 
@@ -146,8 +161,7 @@ class JdbcDatasetRepository implements DatasetRepository {
   public void updateStatus(long datasetId, DatasetStatus status) {
     int updated = jdbcTemplate.update(
         "UPDATE yak_dataset SET status = ?, update_time = NOW(6) WHERE id = ?",
-        status.name(),
-        datasetId);
+        status.name(), datasetId);
     if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
   }
 
@@ -155,18 +169,15 @@ class JdbcDatasetRepository implements DatasetRepository {
   public void updateMetadata(long datasetId, String name, String description) {
     int updated = jdbcTemplate.update(
         "UPDATE yak_dataset SET name = ?, description = ?, update_time = NOW(6) WHERE id = ?",
-        name,
-        description,
-        datasetId);
+        name, description, datasetId);
     if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
   }
 
   @Override
   public Optional<Dataset> findDataset(long datasetId) {
     return jdbcTemplate.query(
-        DATASET_COLUMNS + " WHERE id = ? LIMIT 1",
-        JdbcDatasetRepository::mapDataset,
-        datasetId).stream().findFirst();
+        DATASET_COLUMNS + " WHERE id = ? LIMIT 1", JdbcDatasetRepository::mapDataset, datasetId)
+        .stream().findFirst();
   }
 
   @Override
@@ -182,39 +193,34 @@ class JdbcDatasetRepository implements DatasetRepository {
         ORDER BY d.update_time DESC, d.id DESC
         LIMIT 1
         """,
-        JdbcDatasetRepository::mapDataset,
-        sourceTaskAssetId).stream().findFirst();
+        JdbcDatasetRepository::mapDataset, sourceTaskAssetId).stream().findFirst();
   }
 
   @Override
   public Optional<Dataset> findDatasetByDevelopmentNodeId(long developmentNodeId) {
     return jdbcTemplate.query(
         DATASET_COLUMNS + " WHERE development_node_id = ? LIMIT 1",
-        JdbcDatasetRepository::mapDataset,
-        developmentNodeId).stream().findFirst();
+        JdbcDatasetRepository::mapDataset, developmentNodeId).stream().findFirst();
   }
 
   @Override
   public List<Dataset> listDatasets() {
     return jdbcTemplate.query(
-        DATASET_COLUMNS + " ORDER BY update_time DESC, id DESC",
-        JdbcDatasetRepository::mapDataset);
+        DATASET_COLUMNS + " ORDER BY update_time DESC, id DESC", JdbcDatasetRepository::mapDataset);
   }
 
   @Override
   public Optional<DatasetVersion> findVersion(long versionId) {
     return jdbcTemplate.query(
-        VERSION_COLUMNS + " WHERE id = ? LIMIT 1",
-        JdbcDatasetRepository::mapVersion,
-        versionId).stream().findFirst();
+        VERSION_COLUMNS + " WHERE id = ? LIMIT 1", JdbcDatasetRepository::mapVersion, versionId)
+        .stream().findFirst();
   }
 
   @Override
   public List<DatasetVersion> listVersions(long datasetId) {
     return jdbcTemplate.query(
         VERSION_COLUMNS + " WHERE dataset_id = ? ORDER BY version_no DESC",
-        JdbcDatasetRepository::mapVersion,
-        datasetId);
+        JdbcDatasetRepository::mapVersion, datasetId);
   }
 
   @Override
@@ -227,16 +233,14 @@ class JdbcDatasetRepository implements DatasetRepository {
         WHERE version_id = ?
         ORDER BY sort_order ASC, physical_name ASC
         """,
-        JdbcDatasetRepository::mapField,
-        versionId);
+        JdbcDatasetRepository::mapField, versionId);
   }
 
   @Override
   public int nextVersionNo(long datasetId) {
     Integer value = jdbcTemplate.queryForObject(
         "SELECT COALESCE(MAX(version_no), 0) + 1 FROM yak_dataset_version WHERE dataset_id = ?",
-        Integer.class,
-        datasetId);
+        Integer.class, datasetId);
     return value == null ? 1 : value;
   }
 
@@ -244,13 +248,9 @@ class JdbcDatasetRepository implements DatasetRepository {
     Object currentValue = rs.getObject("current_version_id");
     Long currentVersionId = currentValue == null ? null : rs.getLong("current_version_id");
     return new Dataset(
-        rs.getLong("id"),
-        rs.getString("name"),
-        rs.getString("description"),
-        DatasetStatus.valueOf(rs.getString("status")),
-        currentVersionId,
-        instant(rs.getTimestamp("create_time")),
-        instant(rs.getTimestamp("update_time")));
+        rs.getLong("id"), rs.getString("name"), rs.getString("description"),
+        DatasetStatus.valueOf(rs.getString("status")), currentVersionId,
+        instant(rs.getTimestamp("create_time")), instant(rs.getTimestamp("update_time")));
   }
 
   private static DatasetVersion mapVersion(ResultSet rs, int rowNum) throws SQLException {
@@ -262,21 +262,18 @@ class JdbcDatasetRepository implements DatasetRepository {
         rs.getLong("source_task_asset_id"),
         rs.getLong("source_task_revision_id"),
         rs.getInt("source_task_revision_no"),
+        rs.getString("data_source_id"),
+        rs.getString("sql_content"),
         rs.getString("schema_snapshot"),
         instant(rs.getTimestamp("create_time")));
   }
 
   private static DatasetField mapField(ResultSet rs, int rowNum) throws SQLException {
     return new DatasetField(
-        rs.getString("field_id"),
-        rs.getLong("version_id"),
-        rs.getString("physical_name"),
-        rs.getString("display_name"),
-        DatasetFieldDataType.valueOf(rs.getString("data_type")),
-        rs.getBoolean("nullable"),
-        rs.getString("description"),
-        DatasetFieldRole.valueOf(rs.getString("default_role")),
-        rs.getInt("sort_order"));
+        rs.getString("field_id"), rs.getLong("version_id"), rs.getString("physical_name"),
+        rs.getString("display_name"), DatasetFieldDataType.valueOf(rs.getString("data_type")),
+        rs.getBoolean("nullable"), rs.getString("description"),
+        DatasetFieldRole.valueOf(rs.getString("default_role")), rs.getInt("sort_order"));
   }
 
   private static Instant instant(Timestamp value) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
@@ -1,0 +1,75 @@
+package io.yak.ops.business.dataset;
+
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Query runtime for Dataset versions that own datasource + SQL directly. */
+@Component
+final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
+
+  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int MAX_TIMEOUT_SECONDS = 120;
+
+  private final DataSourceExecutionProvider dataSourceExecutionProvider;
+  private final DatasetQueryCompiler compiler;
+
+  SqlQueryDatasetSourceAdapter(
+      DataSourceExecutionProvider dataSourceExecutionProvider,
+      DatasetQueryCompiler compiler) {
+    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.compiler = compiler;
+  }
+
+  @Override
+  public DatasetSourceType sourceType() {
+    return DatasetSourceType.SQL_QUERY;
+  }
+
+  @Override
+  public DatasetQueryResult execute(
+      Dataset dataset,
+      DatasetVersion version,
+      List<DatasetField> fields,
+      DatasetQueryRequest request) {
+    if (version.dataSourceId() == null || version.dataSourceId().isBlank()) {
+      throw new IllegalStateException("SQL_QUERY DatasetVersion 缺少 dataSourceId");
+    }
+    if (version.sql() == null || version.sql().isBlank()) {
+      throw new IllegalStateException("SQL_QUERY DatasetVersion 缺少 SQL");
+    }
+
+    DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(version.sql(), fields, request);
+    int timeoutSeconds = queryTimeout(request);
+    long startedAt = System.nanoTime();
+    DataSourceSqlResult result;
+    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(version.dataSourceId())) {
+      result = executor.execute(new DataSourceSqlRequest(
+          compiled.sql(), compiled.fetchRows(), timeoutSeconds));
+    }
+    if (!result.resultSet()) {
+      throw new IllegalStateException("Dataset Query Runtime 只接受结果集查询");
+    }
+
+    boolean overflow = result.rows().size() > compiled.limit();
+    List<List<Object>> rows = overflow
+        ? result.rows().subList(0, compiled.limit())
+        : result.rows();
+    long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
+    return new DatasetQueryResult(
+        dataset.id(), version.id(), version.versionNo(), compiled.bindings(), result.columns(),
+        rows, rows.size(), result.truncated() || overflow, elapsedMillis);
+  }
+
+  private int queryTimeout(DatasetQueryRequest request) {
+    Integer requested = request == null ? null : request.timeoutSeconds();
+    if (requested == null) return DEFAULT_TIMEOUT_SECONDS;
+    if (requested < 1 || requested > MAX_TIMEOUT_SECONDS) {
+      throw new IllegalArgumentException("timeoutSeconds 必须在 1~120 之间");
+    }
+    return requested;
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V3__add_standalone_sql_source.sql
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V3__add_standalone_sql_source.sql
@@ -1,0 +1,7 @@
+-- Dataset nodes own their SQL directly instead of binding to published SQL TaskAssets.
+ALTER TABLE yak_dataset_version
+    ADD COLUMN data_source_id VARCHAR(128) NULL AFTER source_task_revision_no,
+    ADD COLUMN sql_content LONGTEXT NULL AFTER data_source_id;
+
+CREATE INDEX idx_yak_dataset_version_datasource
+    ON yak_dataset_version (data_source_id);

--- a/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
@@ -1,22 +1,6 @@
 import { BRAND_CSS_VARIABLES } from '@/styles/brand';
-import {
-  Button,
-  Input,
-  Select,
-  Spin,
-  Table,
-  Tooltip,
-  message,
-  type TableColumnsType,
-} from 'antd';
-import {
-  FileStack,
-  LoaderCircle,
-  Play,
-  RefreshCw,
-  Save,
-  X,
-} from 'lucide-react';
+import { Button, Input, Select, Spin, Table, Tooltip, message, type TableColumnsType } from 'antd';
+import { FileStack, LoaderCircle, Play, Redo2, RefreshCw, Save, Search, Sparkles, Undo2, Wand2, X } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -27,8 +11,11 @@ import {
   type DevelopmentDatasetFieldDraft,
   type DevelopmentDatasetFieldRole,
   type DevelopmentDatasetNodeContext,
-  type DevelopmentDatasetNodeSource,
 } from '../../dataset-service';
+import { executeSqlEditorCommand, type SqlEditorCommand } from '../../editors/sql/commands/sqlEditorCommandBus';
+import SqlMonacoEditor, { type SqlEditorPosition } from '../../editors/sql/components/SqlMonacoEditor';
+import SqlMetadataContextToolbar from '../../editors/sql/metadata/SqlMetadataContextToolbar';
+import { hydrateSqlTaskConfig, useSqlMetadataContext } from '../../editors/sql/metadata/sqlMetadataContextStore';
 import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
 
 interface DatasetNodeEditorProps {
@@ -37,69 +24,42 @@ interface DatasetNodeEditorProps {
   onDirtyChange?: (dirty: boolean) => void;
 }
 
-type RightPanelKey = 'properties' | 'versions';
+type RightPanelKey = 'properties' | 'fields' | 'versions';
 
 const panelItems: Array<{ key: RightPanelKey; label: string }> = [
   { key: 'properties', label: '属性' },
+  { key: 'fields', label: '字段' },
   { key: 'versions', label: '版本' },
 ];
-
 const roleOptions = [
   { label: '维度', value: 'DIMENSION' },
   { label: '指标', value: 'MEASURE' },
 ];
-
-const DEFAULT_PANEL_WIDTH = 380;
-const MIN_PANEL_WIDTH = 280;
-const MAX_PANEL_WIDTH = 640;
+const DEFAULT_PANEL_WIDTH = 420;
+const MIN_PANEL_WIDTH = 320;
+const MAX_PANEL_WIDTH = 720;
 const PANEL_WIDTH_STORAGE_KEY = 'yak-data-development.dataset-right-panel-width';
+const defaultPosition: SqlEditorPosition = { lineNumber: 1, column: 1, selectionLength: 0 };
+const iconButtonClassName = 'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
 
-const iconButtonClassName =
-  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
-
-interface ToolbarButtonProps {
-  title: string;
-  onClick: () => void;
-  disabled?: boolean;
-  children: ReactNode;
-}
-
-const ToolbarButton = ({ title, onClick, disabled, children }: ToolbarButtonProps) => (
+const ToolbarButton = ({ title, onClick, disabled, children }: { title: string; onClick: () => void; disabled?: boolean; children: ReactNode }) => (
   <Tooltip title={title} mouseEnterDelay={0.35}>
-    <button
-      type="button"
-      aria-label={title}
-      disabled={disabled}
-      onClick={onClick}
-      className={iconButtonClassName}
-    >
-      {children}
-    </button>
+    <button type="button" aria-label={title} disabled={disabled} onClick={onClick} className={iconButtonClassName}>{children}</button>
   </Tooltip>
 );
-
 const ToolbarDivider = () => <span className="mx-1 h-4 w-px shrink-0 bg-[#e5e7eb]" />;
-
-const clampPanelWidth = (value: number) =>
-  Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, value));
-
+const clampPanelWidth = (value: number) => Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, value));
 const initialPanelWidth = () => {
   if (typeof window === 'undefined') return DEFAULT_PANEL_WIDTH;
   const stored = Number(window.localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
-  return Number.isFinite(stored) && stored > 0
-    ? clampPanelWidth(stored)
-    : DEFAULT_PANEL_WIDTH;
+  return Number.isFinite(stored) && stored > 0 ? clampPanelWidth(stored) : DEFAULT_PANEL_WIDTH;
 };
-
 const formatTime = (value?: string | null) => {
   if (!value) return '-';
   const date = new Date(value);
-  return Number.isNaN(date.getTime())
-    ? value.replace('T', ' ').slice(0, 19)
-    : date.toLocaleString('zh-CN', { hour12: false });
+  return Number.isNaN(date.getTime()) ? value.replace('T', ' ').slice(0, 19) : date.toLocaleString('zh-CN', { hour12: false });
 };
-
-const toFieldDrafts = (context?: DevelopmentDatasetNodeContext) =>
+const toFieldDrafts = (context?: DevelopmentDatasetNodeContext): DevelopmentDatasetFieldDraft[] =>
   (context?.dataset?.fields || []).map((field) => ({
     fieldId: field.fieldId,
     physicalName: field.physicalName,
@@ -110,10 +70,12 @@ const toFieldDrafts = (context?: DevelopmentDatasetNodeContext) =>
     defaultRole: field.defaultRole,
   }));
 
-const DatasetNodeEditor = ({ node, onSaved, onDirtyChange }: DatasetNodeEditorProps) => {
+export default function DatasetNodeEditor({ node, onSaved, onDirtyChange }: DatasetNodeEditorProps) {
+  const metadataContext = useSqlMetadataContext(node.id);
   const dirtyChangeRef = useRef(onDirtyChange);
+  const savedDataSourceIdRef = useRef<DevelopmentId>();
   const [context, setContext] = useState<DevelopmentDatasetNodeContext>();
-  const [selectedSourceId, setSelectedSourceId] = useState<DevelopmentId>();
+  const [sqlText, setSqlText] = useState('');
   const [description, setDescription] = useState('');
   const [fields, setFields] = useState<DevelopmentDatasetFieldDraft[]>([]);
   const [dirty, setDirty] = useState(false);
@@ -124,27 +86,24 @@ const DatasetNodeEditor = ({ node, onSaved, onDirtyChange }: DatasetNodeEditorPr
   const [activePanel, setActivePanel] = useState<RightPanelKey>();
   const [panelWidth, setPanelWidth] = useState(initialPanelWidth);
   const [resizing, setResizing] = useState(false);
+  const [position, setPosition] = useState<SqlEditorPosition>(defaultPosition);
 
-  useEffect(() => {
-    dirtyChangeRef.current = onDirtyChange;
-  }, [onDirtyChange]);
-
-  const setDirtyState = useCallback((next: boolean) => {
-    setDirty(next);
-    dirtyChangeRef.current?.(next);
-  }, []);
-
+  useEffect(() => { dirtyChangeRef.current = onDirtyChange; }, [onDirtyChange]);
+  const setDirtyState = useCallback((next: boolean) => { setDirty(next); dirtyChangeRef.current?.(next); }, []);
   const markDirty = useCallback(() => setDirtyState(true), [setDirtyState]);
-
   useEffect(() => () => dirtyChangeRef.current?.(false), []);
 
   const applyContext = useCallback((next: DevelopmentDatasetNodeContext) => {
+    const currentVersion = next.dataset?.currentVersion;
+    const dataSourceId = currentVersion?.dataSourceId || undefined;
+    savedDataSourceIdRef.current = dataSourceId;
     setContext(next);
-    setSelectedSourceId(next.selectedSource?.taskAssetId);
+    setSqlText(currentVersion?.sql || '');
     setDescription(next.dataset?.description || '');
     setFields(toFieldDrafts(next));
+    hydrateSqlTaskConfig(node.id, JSON.stringify(dataSourceId ? { dataSourceId } : {}));
     setDirtyState(false);
-  }, [setDirtyState]);
+  }, [node.id, setDirtyState]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -160,257 +119,108 @@ const DatasetNodeEditor = ({ node, onSaved, onDirtyChange }: DatasetNodeEditorPr
       setLoading(false);
     }
   }, [applyContext, node.id]);
-
+  useEffect(() => { void load(); }, [load]);
   useEffect(() => {
-    void load();
-  }, [load]);
-
-  const availableSources = context?.availableSources || [];
-  const currentVersion = context?.dataset?.currentVersion;
-  const selectableSourceIds = useMemo(
-    () => new Set(availableSources.map((source) => source.taskAssetId)),
-    [availableSources],
-  );
-
-  const sourceOptions = useMemo(() => {
-    const values: DevelopmentDatasetNodeSource[] = [...availableSources];
-    const selected = context?.selectedSource;
-    if (selected && !values.some((item) => item.taskAssetId === selected.taskAssetId)) {
-      values.unshift(selected);
-    }
-    return values.map((source) => ({
-      value: source.taskAssetId,
-      label: `${source.nodeName} · SQL R${source.revisionNo}`,
-      disabled: source.status !== 'ONLINE',
-    }));
-  }, [availableSources, context?.selectedSource]);
-
-  const activeSource = useMemo(
-    () => availableSources.find((source) => source.taskAssetId === selectedSourceId)
-      || (context?.selectedSource?.taskAssetId === selectedSourceId ? context?.selectedSource : undefined),
-    [availableSources, context?.selectedSource, selectedSourceId],
-  );
-
-  const sourceSelectable = Boolean(selectedSourceId && selectableSourceIds.has(selectedSourceId));
-  const sourceChanged = Boolean(
-    selectedSourceId
-      && currentVersion?.sourceTaskAssetId
-      && selectedSourceId !== currentVersion.sourceTaskAssetId,
-  );
-  const sourceUpdated = Boolean(
-    activeSource
-      && currentVersion
-      && activeSource.taskAssetId === currentVersion.sourceTaskAssetId
-      && activeSource.revisionNo !== currentVersion.sourceTaskRevisionNo,
-  );
-
-  const changeSource = (value: DevelopmentId) => {
-    setSelectedSourceId(value);
-    const sameSnapshot = currentVersion
-      && value === currentVersion.sourceTaskAssetId
-      && activeSource?.revisionNo === currentVersion.sourceTaskRevisionNo;
-    if (!sameSnapshot) setFields([]);
+    if (!context || loading || metadataContext.dataSourceId === savedDataSourceIdRef.current) return;
+    setFields([]);
     markDirty();
-  };
+  }, [context, loading, markDirty, metadataContext.dataSourceId]);
 
-  const updateField = useCallback((
-    index: number,
-    patch: Partial<DevelopmentDatasetFieldDraft>,
-  ) => {
-    setFields((current) => current.map((field, fieldIndex) =>
-      fieldIndex === index ? { ...field, ...patch } : field,
-    ));
+  const currentVersion = context?.dataset?.currentVersion;
+  const versions = useMemo(() => [...(context?.dataset?.versions || [])].sort((a, b) => b.versionNo - a.versionNo), [context?.dataset?.versions]);
+  const metadataPath = useMemo(() => [
+    metadataContext.dataSourceName || (metadataContext.dataSourceId ? `DS ${metadataContext.dataSourceId}` : undefined),
+    metadataContext.database,
+    metadataContext.schema,
+  ].filter(Boolean).join(' / '), [metadataContext.dataSourceId, metadataContext.dataSourceName, metadataContext.database, metadataContext.schema]);
+  const execute = (command: SqlEditorCommand, fallback: string) => {
+    if (!executeSqlEditorCommand(node.id, command)) message.info(fallback);
+  };
+  const changeSql = (value: string) => { setSqlText(value); setFields([]); markDirty(); };
+  const updateField = useCallback((index: number, patch: Partial<DevelopmentDatasetFieldDraft>) => {
+    setFields((current) => current.map((field, fieldIndex) => fieldIndex === index ? { ...field, ...patch } : field));
     markDirty();
   }, [markDirty]);
 
   const columns = useMemo<TableColumnsType<DevelopmentDatasetFieldDraft>>(() => [
-    {
-      title: '字段',
-      dataIndex: 'physicalName',
-      width: 190,
-      render: (value: string) => (
-        <span className="font-mono text-[12px] text-[#344054]">{value}</span>
-      ),
-    },
-    {
-      title: '显示名称',
-      dataIndex: 'displayName',
-      width: 180,
-      render: (value: string, _record, index) => (
-        <Input
-          size="small"
-          value={value}
-          maxLength={200}
-          onChange={(event) => updateField(index, { displayName: event.target.value })}
-        />
-      ),
-    },
-    {
-      title: '类型',
-      dataIndex: 'dataType',
-      width: 110,
-      render: (value: string) => (
-        <span className="font-mono text-[11px] text-[#667085]">{value}</span>
-      ),
-    },
-    {
-      title: '角色',
-      dataIndex: 'defaultRole',
-      width: 120,
-      render: (value: DevelopmentDatasetFieldRole, _record, index) => (
-        <Select
-          size="small"
-          value={value}
-          options={roleOptions}
-          className="w-full"
-          onChange={(next) => updateField(index, {
-            defaultRole: next as DevelopmentDatasetFieldRole,
-          })}
-        />
-      ),
-    },
-    {
-      title: '可空',
-      dataIndex: 'nullable',
-      width: 72,
-      render: (value: boolean) => (
-        <span className="text-[12px] text-[#667085]">{value ? '是' : '否'}</span>
-      ),
-    },
-    {
-      title: '描述',
-      dataIndex: 'description',
-      render: (value: string | null | undefined, _record, index) => (
-        <Input
-          size="small"
-          value={value || ''}
-          maxLength={1000}
-          placeholder="字段说明"
-          onChange={(event) => updateField(index, { description: event.target.value })}
-        />
-      ),
-    },
+    { title: '字段', dataIndex: 'physicalName', width: 150, render: (value: string) => <span className="font-mono text-[11px] text-[#344054]">{value}</span> },
+    { title: '显示名称', dataIndex: 'displayName', width: 150, render: (value: string, _record, index) => <Input size="small" value={value} maxLength={200} onChange={(event) => updateField(index, { displayName: event.target.value })} /> },
+    { title: '类型', dataIndex: 'dataType', width: 92, render: (value: string) => <span className="font-mono text-[10px] text-[#667085]">{value}</span> },
+    { title: '角色', dataIndex: 'defaultRole', width: 105, render: (value: DevelopmentDatasetFieldRole, _record, index) => <Select size="small" value={value} options={roleOptions} className="w-[94px]" onChange={(next) => updateField(index, { defaultRole: next as DevelopmentDatasetFieldRole })} /> },
+    { title: '可空', dataIndex: 'nullable', width: 54, render: (value: boolean) => <span className="text-[11px] text-[#667085]">{value ? '是' : '否'}</span> },
+    { title: '描述', dataIndex: 'description', width: 180, render: (value: string | null | undefined, _record, index) => <Input size="small" value={value || ''} maxLength={1000} placeholder="字段说明" onChange={(event) => updateField(index, { description: event.target.value })} /> },
   ], [updateField]);
 
   const preview = async () => {
-    if (!selectedSourceId || !sourceSelectable || previewing) return;
+    const dataSourceId = metadataContext.dataSourceId;
+    if (!dataSourceId || !sqlText.trim() || previewing) return;
     setPreviewing(true);
     try {
-      const next = await previewDevelopmentDatasetNode(node.id, selectedSourceId);
-      const existing = new Map(fields.map((field) => [
-        field.physicalName.toLowerCase(),
-        field,
-      ]));
-      setFields(next.map((field) => {
+      const existing = new Map(fields.map((field) => [field.physicalName.toLowerCase(), field]));
+      const discovered = await previewDevelopmentDatasetNode(node.id, dataSourceId, sqlText);
+      setFields(discovered.map((field) => {
         const previous = existing.get(field.physicalName.toLowerCase());
-        return previous ? {
-          ...field,
-          fieldId: previous.fieldId || field.fieldId,
-          displayName: previous.displayName || field.displayName,
-          description: previous.description,
-          defaultRole: previous.defaultRole,
-        } : field;
+        return previous ? { ...field, fieldId: previous.fieldId || field.fieldId, displayName: previous.displayName || field.displayName, description: previous.description, defaultRole: previous.defaultRole } : field;
       }));
       markDirty();
-      message.success(`已发现 ${next.length} 个字段`);
+      message.success(`已发现 ${discovered.length} 个字段`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '发现 Dataset 字段失败');
-    } finally {
-      setPreviewing(false);
-    }
+    } finally { setPreviewing(false); }
   };
 
   const save = async () => {
-    if (!selectedSourceId || !sourceSelectable || !fields.length || saving) return;
+    const dataSourceId = metadataContext.dataSourceId;
+    if (!dataSourceId || !sqlText.trim() || !fields.length || saving) return;
     setSaving(true);
     try {
       const next = await saveDevelopmentDatasetNode(node.id, {
-        sourceTaskAssetId: selectedSourceId,
+        dataSourceId,
+        sql: sqlText,
         description: description.trim() || undefined,
-        fields: fields.map((field) => ({
-          ...field,
-          displayName: field.displayName.trim() || field.physicalName,
-          description: field.description?.trim() || undefined,
-        })),
+        fields: fields.map((field) => ({ ...field, displayName: field.displayName.trim() || field.physicalName, description: field.description?.trim() || undefined })),
       });
       applyContext(next);
       await onSaved?.();
       message.success(`数据集已保存 · DV${next.dataset?.currentVersion?.versionNo || 1}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存 Dataset Node 失败');
-    } finally {
-      setSaving(false);
-    }
+    } finally { setSaving(false); }
   };
-
-  const versions = useMemo(
-    () => [...(context?.dataset?.versions || [])].sort((left, right) => right.versionNo - left.versionNo),
-    [context?.dataset?.versions],
-  );
 
   const propertiesPanel = (
     <div className="text-[12px] leading-5">
       <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-x-4 gap-y-4">
-        <div className="text-[#667085]">数据集名称：</div>
-        <Input size="small" value={node.name} disabled />
+        <div className="text-[#667085]">数据集名称：</div><Input size="small" value={node.name} disabled />
+        <div className="text-[#667085]">数据源：</div><div className="break-all text-[#344054]">{metadataPath || '未选择数据源'}</div>
         <div className="self-start pt-1 text-[#667085]">描述：</div>
-        <Input.TextArea
-          autoSize={{ minRows: 3, maxRows: 6 }}
-          maxLength={2000}
-          value={description}
-          placeholder="说明这个数据集提供什么数据"
-          onChange={(event) => {
-            setDescription(event.target.value);
-            markDirty();
-          }}
-        />
+        <Input.TextArea autoSize={{ minRows: 3, maxRows: 6 }} maxLength={2000} value={description} placeholder="说明这个数据集提供什么数据" onChange={(event) => { setDescription(event.target.value); markDirty(); }} />
       </div>
-
       <dl className="m-0 mt-5 grid grid-cols-[88px_minmax(0,1fr)] gap-x-4 gap-y-3 border-t border-[#eef0f2] pt-4">
-        <dt className="text-[#667085]">Dataset：</dt>
-        <dd className="m-0 text-[#344054]">{context?.dataset ? `#${context.dataset.datasetId}` : '尚未创建'}</dd>
-        <dt className="text-[#667085]">当前版本：</dt>
-        <dd className="m-0 text-[#344054]">{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存'}</dd>
-        <dt className="text-[#667085]">来源 SQL：</dt>
-        <dd className="m-0 break-all text-[#344054]">
-          {activeSource ? `${activeSource.nodeName} · SQL R${activeSource.revisionNo}` : '未选择'}
-        </dd>
-        <dt className="text-[#667085]">字段：</dt>
-        <dd className="m-0 text-[#344054]">{fields.length} 个</dd>
+        <dt className="text-[#667085]">Dataset：</dt><dd className="m-0 text-[#344054]">{context?.dataset ? `#${context.dataset.datasetId}` : '尚未创建'}</dd>
+        <dt className="text-[#667085]">当前版本：</dt><dd className="m-0 text-[#344054]">{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存'}</dd>
+        <dt className="text-[#667085]">查询 SQL：</dt><dd className="m-0 text-[#344054]">{sqlText.trim() ? '已配置' : '未填写'}</dd>
+        <dt className="text-[#667085]">字段：</dt><dd className="m-0 text-[#344054]">{fields.length} 个</dd>
       </dl>
     </div>
   );
-
+  const fieldsPanel = (
+    <div>
+      <div className="mb-3 text-[11px] leading-5 text-[#98a2b3]">字段来自当前 SQL 输出结构。修改 SQL 后请重新发现字段，再调整显示名称、角色和描述。</div>
+      <Table<DevelopmentDatasetFieldDraft> size="small" pagination={false} rowKey={(record) => record.fieldId || record.physicalName} dataSource={fields} columns={columns} scroll={{ x: 730 }} locale={{ emptyText: '运行“发现字段”后生成字段结构' }} />
+    </div>
+  );
   const versionsPanel = (
     <div className="space-y-2 text-[12px]">
       {versions.length ? versions.map((version, index) => (
-        <div
-          key={version.versionId}
-          className="flex items-center gap-2 rounded-[3px] border border-[#eaecf0] px-2.5 py-2"
-        >
+        <div key={version.versionId} className="flex items-center gap-2 rounded-[3px] border border-[#eaecf0] px-2.5 py-2">
           <FileStack size={14} className="shrink-0 text-[#667085]" strokeWidth={1.7} />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-[#344054]">DV{version.versionNo}</span>
-              {index === 0 ? (
-                <span className="rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[10px] text-[#667085]">当前</span>
-              ) : null}
-            </div>
-            <div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">
-              SQL R{version.sourceTaskRevisionNo} · {formatTime(version.createTime)}
-            </div>
-          </div>
+          <div className="min-w-0 flex-1"><div className="flex items-center gap-2"><span className="font-medium text-[#344054]">DV{version.versionNo}</span>{index === 0 ? <span className="rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[10px] text-[#667085]">当前</span> : null}</div><div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">{version.sourceType === 'SQL_QUERY' ? '独立 SQL' : version.sourceType} · {formatTime(version.createTime)}</div></div>
         </div>
-      )) : (
-        <div className="py-8 text-center text-[11px] text-[#98a2b3]">暂无数据集版本</div>
-      )}
+      )) : <div className="py-8 text-center text-[11px] text-[#98a2b3]">暂无数据集版本</div>}
     </div>
   );
-
-  const panelContent: Record<RightPanelKey, ReactNode> = {
-    properties: propertiesPanel,
-    versions: versionsPanel,
-  };
+  const panelContent: Record<RightPanelKey, ReactNode> = { properties: propertiesPanel, fields: fieldsPanel, versions: versionsPanel };
 
   const handleResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!activePanel) return;
@@ -419,14 +229,10 @@ const DatasetNodeEditor = ({ node, onSaved, onDirtyChange }: DatasetNodeEditorPr
     const startWidth = panelWidth;
     const previousCursor = document.body.style.cursor;
     const previousUserSelect = document.body.style.userSelect;
-
     setResizing(true);
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
-
-    const resize = (moveEvent: PointerEvent) => {
-      setPanelWidth(clampPanelWidth(startWidth + startX - moveEvent.clientX));
-    };
+    const resize = (moveEvent: PointerEvent) => setPanelWidth(clampPanelWidth(startWidth + startX - moveEvent.clientX));
     const finish = (upEvent: PointerEvent) => {
       const nextWidth = clampPanelWidth(startWidth + startX - upEvent.clientX);
       setPanelWidth(nextWidth);
@@ -438,214 +244,56 @@ const DatasetNodeEditor = ({ node, onSaved, onDirtyChange }: DatasetNodeEditorPr
       window.removeEventListener('pointerup', finish);
       window.removeEventListener('pointercancel', finish);
     };
-
     window.addEventListener('pointermove', resize);
     window.addEventListener('pointerup', finish);
     window.addEventListener('pointercancel', finish);
   };
 
-  if (loading) {
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center bg-white">
-        <Spin size="small" />
-      </div>
-    );
-  }
-
-  if (loadError || !context) {
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6">
-        <div className="max-w-[520px] text-center">
-          <div className="text-[14px] font-semibold text-[#344054]">Dataset Node 加载失败</div>
-          <div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">{loadError || '未返回有效编辑上下文'}</div>
-          <Button className="mt-4" size="small" icon={<RefreshCw size={13} />} onClick={() => void load()}>
-            重新加载
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  const canPreview = sourceSelectable;
-  const canSave = sourceSelectable && fields.length > 0 && dirty;
+  if (loading) return <div className="flex min-h-0 flex-1 items-center justify-center bg-white"><Spin size="small" /></div>;
+  if (loadError || !context) return (
+    <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6"><div className="max-w-[520px] text-center"><div className="text-[14px] font-semibold text-[#344054]">Dataset Node 加载失败</div><div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">{loadError || '未返回有效编辑上下文'}</div><Button className="mt-4" size="small" icon={<RefreshCw size={13} />} onClick={() => void load()}>重新加载</Button></div></div>
+  );
+  const canPreview = Boolean(metadataContext.dataSourceId && sqlText.trim());
+  const canSave = canPreview && fields.length > 0 && dirty;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2">
         <div className="flex shrink-0 items-center gap-0.5">
-          <ToolbarButton
-            title={previewing ? '正在发现字段' : fields.length ? '刷新字段' : '发现字段'}
-            disabled={!canPreview || previewing}
-            onClick={() => void preview()}
-          >
-            {previewing ? <LoaderCircle size={15} className="animate-spin" /> : <Play size={15} strokeWidth={1.8} />}
-          </ToolbarButton>
+          <ToolbarButton title={previewing ? '正在发现字段' : '发现字段'} disabled={!canPreview || previewing} onClick={() => void preview()}>{previewing ? <LoaderCircle size={15} className="animate-spin" /> : <Play size={15} strokeWidth={1.8} />}</ToolbarButton>
           <ToolbarDivider />
-          <ToolbarButton
-            title="保存数据集版本"
-            disabled={!canSave || saving}
-            onClick={() => void save()}
-          >
-            {saving ? <LoaderCircle size={15} className="animate-spin" /> : <Save size={15} strokeWidth={1.8} />}
-          </ToolbarButton>
+          <ToolbarButton title="保存数据集版本" disabled={!canSave || saving} onClick={() => void save()}>{saving ? <LoaderCircle size={15} className="animate-spin" /> : <Save size={15} strokeWidth={1.8} />}</ToolbarButton>
+          <ToolbarDivider />
+          <ToolbarButton title="撤销" onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}><Undo2 size={15} strokeWidth={1.8} /></ToolbarButton>
+          <ToolbarButton title="重做" onClick={() => execute('redo', 'SQL 编辑器尚未就绪')}><Redo2 size={15} strokeWidth={1.8} /></ToolbarButton>
+          <ToolbarButton title="查找" onClick={() => execute('find', 'SQL 编辑器尚未就绪')}><Search size={15} strokeWidth={1.8} /></ToolbarButton>
+          <ToolbarDivider />
+          <ToolbarButton title="格式化 SQL" onClick={() => execute('format', 'SQL 编辑器尚未就绪')}><Wand2 size={15} strokeWidth={1.8} /></ToolbarButton>
+          <ToolbarButton title="触发智能提示" onClick={() => execute('suggest', 'SQL 编辑器尚未就绪')}><Sparkles size={15} strokeWidth={1.8} /></ToolbarButton>
         </div>
-
-        <div className="flex min-w-0 items-center gap-2 pr-1">
-          <span className="shrink-0 text-[10px] text-[#98a2b3]">来源 SQL</span>
-          <Select
-            showSearch
-            optionFilterProp="label"
-            variant="borderless"
-            size="small"
-            value={selectedSourceId}
-            options={sourceOptions}
-            placeholder="选择已发布 SQL"
-            className="min-w-[260px] max-w-[360px]"
-            popupMatchSelectWidth={360}
-            onChange={(value) => changeSource(String(value))}
-          />
-          {sourceUpdated ? (
-            <span className="shrink-0 text-[10px] font-medium text-[#f79009]">有新 Revision</span>
-          ) : sourceChanged ? (
-            <span className="shrink-0 text-[10px] font-medium text-[#f79009]">来源已更换</span>
-          ) : null}
-        </div>
+        <SqlMetadataContextToolbar nodeId={node.id} />
       </div>
-
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <section className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-          <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#eef0f2] px-3">
-            <span className="text-[12px] font-medium text-[#344054]">字段结构</span>
-            <span className="text-[10px] text-[#98a2b3]">{fields.length} 个字段</span>
-          </div>
-
-          <div className="min-h-0 flex-1 overflow-hidden px-2 pt-2">
-            <Table<DevelopmentDatasetFieldDraft>
-              size="small"
-              bordered={false}
-              pagination={false}
-              rowKey={(record) => record.fieldId || record.physicalName}
-              dataSource={fields}
-              columns={columns}
-              locale={{
-                emptyText: sourceSelectable
-                  ? '点击顶部“发现字段”读取 SQL 输出结构'
-                  : '选择一个已发布 SQL',
-              }}
-              scroll={{ x: 900, y: 'calc(100vh - 220px)' }}
-            />
-          </div>
-
+          <div className="min-h-0 flex-1"><SqlMonacoEditor id={String(node.id)} value={sqlText} onChange={changeSql} onPositionChange={setPosition} /></div>
           <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-2.5 text-[10px] text-[#7b808a]">
-            <div className="flex min-w-0 items-center gap-3">
-              <span className="font-medium text-[#667085]">DATASET</span>
-              <span className="truncate">{node.name}</span>
-              {dirty ? (
-                <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]">
-                  <span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />
-                  未保存
-                </span>
-              ) : null}
-              <span className="max-w-[280px] truncate text-[#667085]">
-                {activeSource ? `${activeSource.nodeName} · SQL R${activeSource.revisionNo}` : '未选择来源 SQL'}
-              </span>
-            </div>
-            <div className="flex shrink-0 items-center gap-3">
-              <span>{fields.length} 个字段</span>
-              <span>{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存版本'}</span>
-            </div>
+            <div className="flex min-w-0 items-center gap-3"><span className="font-medium text-[#667085]">DATASET</span><span className="truncate">{node.name}</span>{dirty ? <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]"><span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />未保存</span> : null}<span className="max-w-[280px] truncate text-[#667085]" title={metadataPath || '未选择数据源'}>{metadataPath || '未选择数据源'}</span></div>
+            <div className="flex shrink-0 items-center gap-3"><span>{fields.length ? `${fields.length} 个字段` : '字段待发现'}</span><span>{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存版本'}</span>{position.selectionLength > 0 ? <span>已选择 {position.selectionLength} 字符</span> : null}<span>Ln {position.lineNumber}, Col {position.column}</span></div>
           </div>
         </section>
-
         <aside className="flex shrink-0 bg-white" style={BRAND_CSS_VARIABLES}>
-          <div
-            className={[
-              'relative h-full shrink-0',
-              resizing ? 'transition-none' : 'transition-[width] duration-200 ease-out',
-            ].join(' ')}
-            style={{ width: activePanel ? panelWidth : 0 }}
-          >
-            {activePanel ? (
-              <div
-                role="separator"
-                aria-label="调整右侧面板宽度"
-                aria-orientation="vertical"
-                onPointerDown={handleResizeStart}
-                className="group absolute inset-y-0 left-0 z-30 w-3 -translate-x-1/2 cursor-col-resize touch-none"
-              >
-                <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e5e7eb] transition-[width,background-color] duration-150 group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:w-[2px] group-active:bg-[rgba(254,44,85,1)]" />
-              </div>
-            ) : null}
-
-            <div className="h-full overflow-hidden">
-              <div className="flex h-full flex-col bg-white" style={{ width: panelWidth }}>
-                <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4">
-                  <span className="text-[13px] font-semibold text-[#30323b]">
-                    {panelItems.find((item) => item.key === activePanel)?.label}
-                  </span>
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      title="刷新"
-                      onClick={() => {
-                        if (dirty) {
-                          message.warning('当前有未保存修改，请先保存');
-                          return;
-                        }
-                        void load();
-                      }}
-                      className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
-                    >
-                      <RefreshCw size={13} strokeWidth={1.8} />
-                      刷新
-                    </button>
-                    <button
-                      type="button"
-                      title="关闭"
-                      aria-label="关闭右侧面板"
-                      onClick={() => setActivePanel(undefined)}
-                      className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"
-                    >
-                      <X size={14} strokeWidth={1.8} />
-                    </button>
-                  </div>
-                </div>
-                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
-                  {activePanel ? panelContent[activePanel] : null}
-                </div>
-              </div>
-            </div>
+          <div className={['relative h-full shrink-0', resizing ? 'transition-none' : 'transition-[width] duration-200 ease-out'].join(' ')} style={{ width: activePanel ? panelWidth : 0 }}>
+            {activePanel ? <div role="separator" aria-label="调整右侧面板宽度" aria-orientation="vertical" onPointerDown={handleResizeStart} className="group absolute inset-y-0 left-0 z-30 w-3 -translate-x-1/2 cursor-col-resize touch-none"><div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e5e7eb] transition-[width,background-color] duration-150 group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:w-[2px] group-active:bg-[rgba(254,44,85,1)]" /></div> : null}
+            <div className="h-full overflow-hidden"><div className="flex h-full flex-col bg-white" style={{ width: panelWidth }}><div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4"><span className="text-[13px] font-semibold text-[#30323b]">{panelItems.find((item) => item.key === activePanel)?.label}</span><div className="flex items-center gap-1"><button type="button" title="刷新" onClick={() => { if (dirty) { message.warning('当前有未保存修改，请先保存'); return; } void load(); }} className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"><RefreshCw size={13} strokeWidth={1.8} />刷新</button><button type="button" title="关闭" aria-label="关闭右侧面板" onClick={() => setActivePanel(undefined)} className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"><X size={14} strokeWidth={1.8} /></button></div></div><div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">{activePanel ? panelContent[activePanel] : null}</div></div></div>
           </div>
-
           <div className="flex h-full w-9 shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
             {panelItems.map((item, index) => {
               const active = activePanel === item.key;
-              return (
-                <button
-                  key={item.key}
-                  type="button"
-                  title={item.label}
-                  aria-label={`${active ? '收起' : '展开'}${item.label}`}
-                  aria-expanded={active}
-                  onClick={() => setActivePanel((current) => current === item.key ? undefined : item.key)}
-                  className={[
-                    'relative flex min-h-[72px] w-9 shrink-0 items-center justify-center border-b border-[#e5e7eb] py-3 text-[12px] leading-5 transition-[color,background-color,opacity]',
-                    '[writing-mode:vertical-rl] [letter-spacing:3px]',
-                    index === 0 ? 'border-t' : '',
-                    active
-                      ? 'text-[var(--yak-brand-color)] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[var(--yak-brand-color)]'
-                      : 'text-[#475467] opacity-70 hover:bg-[#f7f8fa] hover:text-[#344054] hover:opacity-100',
-                  ].join(' ')}
-                >
-                  {item.label}
-                </button>
-              );
+              return <button key={item.key} type="button" title={item.label} aria-label={`${active ? '收起' : '展开'}${item.label}`} aria-expanded={active} onClick={() => setActivePanel((current) => current === item.key ? undefined : item.key)} className={['relative flex min-h-[72px] w-9 shrink-0 items-center justify-center border-b border-[#e5e7eb] py-3 text-[12px] leading-5 transition-[color,background-color,opacity]', '[writing-mode:vertical-rl] [letter-spacing:3px]', index === 0 ? 'border-t' : '', active ? 'text-[var(--yak-brand-color)] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[var(--yak-brand-color)]' : 'text-[#475467] opacity-70 hover:bg-[#f7f8fa] hover:text-[#344054] hover:opacity-100'].join(' ')}>{item.label}</button>;
             })}
           </div>
         </aside>
       </div>
     </div>
   );
-};
-
-export default DatasetNodeEditor;
+}

--- a/yak-ops-ui/src/pages/data-development/dataset-service.ts
+++ b/yak-ops-ui/src/pages/data-development/dataset-service.ts
@@ -26,22 +26,15 @@ export interface DevelopmentDatasetFieldDraft {
   defaultRole: DevelopmentDatasetFieldRole;
 }
 
-export interface DevelopmentDatasetNodeSource {
-  nodeId: DevelopmentId;
-  nodeName: string;
-  taskAssetId: DevelopmentId;
-  status: string;
-  revisionId: DevelopmentId;
-  revisionNo: number;
-}
-
 export interface DevelopmentDatasetNodeVersion {
   versionId: DevelopmentId;
   versionNo: number;
   sourceType: string;
-  sourceTaskAssetId: DevelopmentId;
-  sourceTaskRevisionId: DevelopmentId;
-  sourceTaskRevisionNo: number;
+  sourceTaskAssetId?: DevelopmentId;
+  sourceTaskRevisionId?: DevelopmentId;
+  sourceTaskRevisionNo?: number;
+  dataSourceId?: DevelopmentId | null;
+  sql?: string | null;
   createTime?: string;
 }
 
@@ -73,13 +66,12 @@ export interface DevelopmentDatasetNodeContext {
   nodeId: DevelopmentId;
   nodeName: string;
   configured: boolean;
-  availableSources: DevelopmentDatasetNodeSource[];
-  selectedSource?: DevelopmentDatasetNodeSource | null;
   dataset?: DevelopmentDatasetNodeAsset | null;
 }
 
 export interface SaveDevelopmentDatasetNodePayload {
-  sourceTaskAssetId: DevelopmentId;
+  dataSourceId: DevelopmentId;
+  sql: string;
   description?: string;
   fields?: DevelopmentDatasetFieldDraft[];
 }
@@ -100,11 +92,12 @@ export const getDevelopmentDatasetNode = async (
 
 export const previewDevelopmentDatasetNode = async (
   nodeId: DevelopmentId,
-  sourceTaskAssetId: DevelopmentId,
+  dataSourceId: DevelopmentId,
+  sql: string,
 ): Promise<DevelopmentDatasetFieldDraft[]> => unwrap(
   await HttpUtils.post<DevelopmentDatasetFieldDraft[]>(
     `${NODE_API}/${nodeId}/dataset/preview`,
-    { sourceTaskAssetId },
+    { dataSourceId, sql },
   ),
   '发现 Dataset Node 字段失败',
 );


### PR DESCRIPTION
## 背景

Dataset 不应该依赖已经上线的 SQL 开发任务。它应该像数据服务一样，拥有自己的 SQL 编辑能力、数据源上下文和独立生命周期。

本 PR 将 Dataset 从“引用已发布 SQL TaskAsset”重构为“自带 SQL 的独立数据资产”，并同步重构前端编辑体验。

## 主要改动

### 前端

- Dataset Node 改为独立 SQL 编辑器，不再选择已上线 SQL 开发任务
- 复用现有 SQL Monaco Editor 与数据源上下文能力
- 顶部 Toolbar 对齐其他 SQL / Data Service 节点风格
- 中间区域专注 SQL 编辑
- 右侧使用可收起属性面板，承载属性、字段、版本等信息
- SQL / 数据源变化后可重新预览并发现 Dataset 字段
- 保持现有 Yak Ops 白底、轻边框、高密度工作台风格

### 后端

- DatasetVersion 新增独立 SQL 来源模型
- 新增 SQL_QUERY source type
- DatasetVersion 冻结 dataSourceId + SQL + schema snapshot
- Dataset 查询 Runtime 可直接执行 Dataset 自己的 SQL
- Schema discovery 支持直接基于 Dataset SQL 发现字段
- 保留 QUERY_REVISION 兼容路径，避免影响已有 Dataset
- 增加数据库迁移，保存 Dataset 独立 SQL 来源信息

## 设计结果

重构后关系变为：

`Dataset = DataSource + SQL + Field Contract + DatasetVersion`

而不再是：

`Dataset -> ONLINE SQL Development Task`

这样数据开发负责开发任务，Dataset 负责 BI/消费侧的数据语义和稳定契约，两者生命周期彻底分开。

## 备注

当前分支在开发过程中 main 又有新的提交，因此此 PR 先以 Draft 方式提交，后续合并前再同步 main 并处理可能的冲突。