### PR TITLE
fix: restore startup for standalone Dataset service

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentStandaloneDatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentStandaloneDatasetService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** Lifecycle for data-development Dataset nodes that own datasource + SQL directly. */
 @Service
-final class DevelopmentStandaloneDatasetService {
+class DevelopmentStandaloneDatasetService {
 
   private final DatasetRepository repository;
   private final DatasetSchemaDiscoveryService discoveryService;


### PR DESCRIPTION
## What changed

- remove the `final` modifier from `DevelopmentStandaloneDatasetService`
- keep the existing `@Transactional("yakBusinessTransactionManager")` behavior unchanged

## Root cause

`DevelopmentStandaloneDatasetService` is a Spring `@Service` with a transactional method. Spring creates a class-based CGLIB proxy for the bean, but the service was introduced as a `final` class, so CGLIB could not subclass it during ApplicationContext initialization.

This caused startup to fail with:

`Cannot subclass final class io.yak.ops.business.dataset.DevelopmentStandaloneDatasetService`

## Impact

The application can create the transactional proxy for the standalone Dataset service again, allowing Spring Boot startup to proceed past this bean initialization step.

## Validation

- compared the branch against `main`
- confirmed the PR contains only one semantic change in one file (`final class` -> `class`)
- no Dataset business logic or transaction configuration changed
