### PR TITLE
feat(home): wire data center to runtime statistics

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterController.java
@@ -1,0 +1,37 @@
+package io.yak.ops.boot.home;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.boot.home.HomeDataCenterService.OverviewResponse;
+import io.yak.ops.boot.home.HomeDataCenterService.RecentResponse;
+import io.yak.ops.boot.home.HomeDataCenterService.ScheduleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 首页数据中心接口。 */
+@RestController
+@RequestMapping("/api/v1/home/data-center")
+@RequiredArgsConstructor
+public class HomeDataCenterController {
+
+  private final HomeDataCenterService service;
+
+  @GetMapping("/overview")
+  public Result<OverviewResponse> overview(
+      @RequestParam(defaultValue = "7d") String period) {
+    return Result.success(service.overview(period));
+  }
+
+  @GetMapping("/recent")
+  public Result<RecentResponse> recent() {
+    return Result.success(service.recent());
+  }
+
+  @GetMapping("/schedule")
+  public Result<ScheduleResponse> schedules(
+      @RequestParam(defaultValue = "7d") String period) {
+    return Result.success(service.schedules(period));
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterService.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterService.java
@@ -1,0 +1,548 @@
+package io.yak.ops.boot.home;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.yak.ops.business.quality.dao.mapper.QualityExecutionMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowExecutionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
+import io.yak.ops.common.bean.po.quality.QualityExecutionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** 首页数据中心运行统计聚合服务。 */
+@Service
+@RequiredArgsConstructor
+public class HomeDataCenterService {
+
+  private static final DateTimeFormatter DAY_LABEL = DateTimeFormatter.ofPattern("MM-dd");
+  private static final Set<String> WORKFLOW_RUNNING =
+      Set.of("CREATED", "RUNNING", "PAUSING", "PAUSED", "RESUMING");
+  private static final Set<String> WORKFLOW_SUCCESS =
+      Set.of("SUCCESS", "SUCCESS_WITH_WARNINGS", "WARNING");
+  private static final Set<String> WORKFLOW_FAILED = Set.of("FAILED", "TIMED_OUT");
+  private static final Set<String> QUALITY_RUNNING = Set.of("QUEUED", "RUNNING");
+  private static final Set<String> QUALITY_SUCCESS = Set.of("SUCCESS", "SUCCEEDED", "COMPLETED");
+  private static final Set<String> QUALITY_FAILED = Set.of("FAILED", "ERROR", "TIMED_OUT");
+  private static final Set<String> OFFLINE_RUNNING = Set.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING");
+  private static final Set<String> OFFLINE_SUCCESS = Set.of("SUCCEEDED", "SUCCESS", "FINISHED", "COMPLETED");
+  private static final Set<String> OFFLINE_FAILED = Set.of("FAILED", "LOST");
+
+  private final ObjectProvider<OfflineJobExecutionMapper> offlineExecutionMapperProvider;
+  private final ObjectProvider<OfflineJobDefinitionMapper> offlineDefinitionMapperProvider;
+  private final ObjectProvider<WorkflowExecutionMapper> workflowExecutionMapperProvider;
+  private final ObjectProvider<WorkflowScheduleMapper> workflowScheduleMapperProvider;
+  private final ObjectProvider<QualityExecutionMapper> qualityExecutionMapperProvider;
+
+  public OverviewResponse overview(String periodValue) {
+    PeriodRange range = PeriodRange.resolve(periodValue);
+    PeriodRange previous = range.previous();
+
+    List<RuntimeExecution> current = executions(range.start(), range.end());
+    List<RuntimeExecution> previousExecutions = executions(previous.start(), previous.end());
+
+    Metrics currentMetrics = metrics(current, range.end());
+    Metrics previousMetrics = metrics(previousExecutions, previous.end());
+    LatestTask latestTask = latestTask(current);
+
+    return new OverviewResponse(
+        new PeriodView(range.start().toLocalDate().toString(), range.end().minusNanos(1).toLocalDate().toString()),
+        latestTask,
+        trend(range, current),
+        currentMetrics,
+        compare(currentMetrics, previousMetrics));
+  }
+
+  public RecentResponse recent() {
+    LocalDateTime end = LocalDateTime.now().plusNanos(1);
+    LocalDateTime start = end.minusDays(7);
+    List<RuntimeExecution> all = executions(start, end);
+
+    Map<String, List<RuntimeExecution>> grouped =
+        all.stream().collect(Collectors.groupingBy(RuntimeExecution::taskKey));
+
+    List<RecentTask> items = new ArrayList<>();
+    grouped.values().forEach(group -> {
+      RuntimeExecution latest = group.stream().max(Comparator.comparing(RuntimeExecution::occurredAt)).orElse(null);
+      if (latest == null) return;
+      long success = group.stream().filter(RuntimeExecution::success).count();
+      long failed = group.stream().filter(RuntimeExecution::failed).count();
+      items.add(new RecentTask(
+          latest.taskId(),
+          latest.taskType(),
+          latest.taskName(),
+          latest.occurredAt().toString(),
+          group.size(),
+          success,
+          failed,
+          latest.durationMs(),
+          latest.status(),
+          detailPath(latest)));
+    });
+
+    items.sort(Comparator.comparing(RecentTask::lastRunTime).reversed());
+    if (items.size() > 5) items = new ArrayList<>(items.subList(0, 5));
+    return new RecentResponse(items);
+  }
+
+  public ScheduleResponse schedules(String periodValue) {
+    PeriodRange range = PeriodRange.resolve(periodValue);
+    List<ScheduleItem> items = new ArrayList<>();
+
+    OfflineJobDefinitionMapper offlineMapper = offlineDefinitionMapperProvider.getIfAvailable();
+    if (offlineMapper != null) {
+      List<OfflineJobDefinitionPO> definitions = offlineMapper.selectList(
+          new LambdaQueryWrapper<OfflineJobDefinitionPO>()
+              .eq(OfflineJobDefinitionPO::getScheduleEnabled, true)
+              .orderByDesc(OfflineJobDefinitionPO::getScheduleNextFireTime)
+              .last("LIMIT 20"));
+      for (OfflineJobDefinitionPO definition : definitions) {
+        items.add(new ScheduleItem(
+            String.valueOf(definition.getId()),
+            "OFFLINE_SYNC",
+            defaultText(definition.getJobName(), "离线同步任务"),
+            definition.getCronExpression(),
+            "ENABLED",
+            toText(definition.getScheduleLastFireTime()),
+            toText(definition.getScheduleNextFireTime()),
+            "/sync/batch-link-up/" + definition.getId() + "/detail"));
+      }
+    }
+
+    WorkflowScheduleMapper workflowMapper = workflowScheduleMapperProvider.getIfAvailable();
+    if (workflowMapper != null) {
+      List<WorkflowSchedulePO> schedules = workflowMapper.selectList(
+          new LambdaQueryWrapper<WorkflowSchedulePO>()
+              .orderByDesc(WorkflowSchedulePO::getNextFireTime)
+              .last("LIMIT 20"));
+      for (WorkflowSchedulePO schedule : schedules) {
+        items.add(new ScheduleItem(
+            schedule.getId(),
+            "WORKFLOW",
+            defaultText(schedule.getName(), "工作流调度"),
+            schedule.getCronExpression(),
+            defaultText(schedule.getStatus(), "UNKNOWN"),
+            toText(schedule.getLastFireTime()),
+            toText(schedule.getNextFireTime()),
+            "/workflow/schedules"));
+      }
+    }
+
+    items.sort(Comparator.comparing(
+        ScheduleItem::nextScheduleTime,
+        Comparator.nullsLast(Comparator.naturalOrder())));
+    if (items.size() > 8) items = new ArrayList<>(items.subList(0, 8));
+    return new ScheduleResponse(
+        new PeriodView(range.start().toLocalDate().toString(), range.end().minusNanos(1).toLocalDate().toString()),
+        items.size(),
+        items);
+  }
+
+  private List<RuntimeExecution> executions(LocalDateTime start, LocalDateTime end) {
+    List<RuntimeExecution> result = new ArrayList<>();
+    result.addAll(offlineExecutions(start, end));
+    result.addAll(workflowExecutions(start, end));
+    result.addAll(qualityExecutions(start, end));
+    result.sort(Comparator.comparing(RuntimeExecution::occurredAt));
+    return result;
+  }
+
+  private List<RuntimeExecution> offlineExecutions(LocalDateTime start, LocalDateTime end) {
+    OfflineJobExecutionMapper mapper = offlineExecutionMapperProvider.getIfAvailable();
+    if (mapper == null) return List.of();
+
+    List<OfflineJobExecutionPO> rows = mapper.selectList(
+        new LambdaQueryWrapper<OfflineJobExecutionPO>()
+            .ge(OfflineJobExecutionPO::getCreateTime, start)
+            .lt(OfflineJobExecutionPO::getCreateTime, end)
+            .orderByAsc(OfflineJobExecutionPO::getCreateTime));
+
+    OfflineJobDefinitionMapper definitionMapper = offlineDefinitionMapperProvider.getIfAvailable();
+    Map<Long, String> names = new HashMap<>();
+    if (definitionMapper != null) {
+      Set<Long> ids = rows.stream()
+          .map(OfflineJobExecutionPO::getJobDefinitionId)
+          .filter(Objects::nonNull)
+          .collect(Collectors.toSet());
+      if (!ids.isEmpty()) {
+        names = definitionMapper.selectBatchIds(ids).stream()
+            .collect(Collectors.toMap(OfflineJobDefinitionPO::getId, OfflineJobDefinitionPO::getJobName, (a, b) -> a));
+      }
+    }
+
+    Map<Long, String> finalNames = names;
+    return rows.stream().map(row -> {
+      String status = normalize(row.getStatus());
+      LocalDateTime occurredAt = firstNonNull(row.getStartTime(), row.getCreateTime(), row.getUpdateTime());
+      return new RuntimeExecution(
+          "OFFLINE_SYNC",
+          String.valueOf(row.getJobDefinitionId()),
+          defaultText(finalNames.get(row.getJobDefinitionId()), "离线同步任务 #" + row.getJobDefinitionId()),
+          status,
+          occurredAt,
+          row.getEndTime(),
+          zero(row.getDurationMillis()),
+          zero(row.getSinkSuccessRecordCount()),
+          "SCHEDULE".equalsIgnoreCase(row.getTriggerType()),
+          OFFLINE_SUCCESS.contains(status),
+          OFFLINE_FAILED.contains(status),
+          OFFLINE_RUNNING.contains(status),
+          row.getErrorMessage(),
+          String.valueOf(row.getId()));
+    }).toList();
+  }
+
+  private List<RuntimeExecution> workflowExecutions(LocalDateTime start, LocalDateTime end) {
+    WorkflowExecutionMapper mapper = workflowExecutionMapperProvider.getIfAvailable();
+    if (mapper == null) return List.of();
+    ZoneId zone = ZoneId.systemDefault();
+    Instant startInstant = start.atZone(zone).toInstant();
+    Instant endInstant = end.atZone(zone).toInstant();
+
+    List<WorkflowExecutionPO> rows = mapper.selectList(
+        new LambdaQueryWrapper<WorkflowExecutionPO>()
+            .ge(WorkflowExecutionPO::getCreatedAt, startInstant)
+            .lt(WorkflowExecutionPO::getCreatedAt, endInstant)
+            .orderByAsc(WorkflowExecutionPO::getCreatedAt));
+
+    return rows.stream().map(row -> {
+      String status = normalize(row.getStatus());
+      Instant started = firstNonNull(row.getRunStartedAt(), row.getCreatedAt(), row.getUpdatedAt());
+      long duration = row.getEndedAt() == null || started == null
+          ? 0L
+          : Math.max(0L, Duration.between(started, row.getEndedAt()).toMillis());
+      return new RuntimeExecution(
+          "WORKFLOW",
+          defaultText(row.getDefinitionId(), row.getId()),
+          defaultText(row.getWorkflowName(), "工作流 #" + row.getDefinitionId()),
+          status,
+          LocalDateTime.ofInstant(started == null ? Instant.EPOCH : started, zone),
+          row.getEndedAt() == null ? null : LocalDateTime.ofInstant(row.getEndedAt(), zone),
+          duration,
+          0L,
+          false,
+          WORKFLOW_SUCCESS.contains(status),
+          WORKFLOW_FAILED.contains(status),
+          WORKFLOW_RUNNING.contains(status),
+          null,
+          row.getId());
+    }).toList();
+  }
+
+  private List<RuntimeExecution> qualityExecutions(LocalDateTime start, LocalDateTime end) {
+    QualityExecutionMapper mapper = qualityExecutionMapperProvider.getIfAvailable();
+    if (mapper == null) return List.of();
+
+    List<QualityExecutionPO> rows = mapper.selectList(
+        new LambdaQueryWrapper<QualityExecutionPO>()
+            .ge(QualityExecutionPO::getQueuedAt, start)
+            .lt(QualityExecutionPO::getQueuedAt, end)
+            .orderByAsc(QualityExecutionPO::getQueuedAt));
+
+    return rows.stream().map(row -> {
+      String status = normalize(row.getExecutionStatus());
+      LocalDateTime occurredAt = firstNonNull(row.getStartedAt(), row.getQueuedAt(), row.getCreatedAt());
+      // 质量检查结果 FAIL 仅表示发现质量问题；技术执行成功仍计入成功任务。
+      boolean success = QUALITY_SUCCESS.contains(status);
+      return new RuntimeExecution(
+          "DATA_QUALITY",
+          String.valueOf(row.getMonitorId()),
+          defaultText(row.getMonitorName(), "数据质量任务 #" + row.getMonitorId()),
+          status,
+          occurredAt,
+          row.getFinishedAt(),
+          zero(row.getDurationMs()),
+          0L,
+          "SCHEDULE".equalsIgnoreCase(row.getTriggerType()),
+          success,
+          QUALITY_FAILED.contains(status),
+          QUALITY_RUNNING.contains(status),
+          row.getErrorMessage(),
+          row.getExecutionNo());
+    }).toList();
+  }
+
+  private Metrics metrics(List<RuntimeExecution> executions, LocalDateTime end) {
+    long success = executions.stream().filter(RuntimeExecution::success).count();
+    long failed = executions.stream().filter(RuntimeExecution::failed).count();
+    long schedule = executions.stream().filter(RuntimeExecution::scheduled).count();
+    long processed = executions.stream()
+        .filter(item -> "OFFLINE_SYNC".equals(item.taskType()))
+        .mapToLong(RuntimeExecution::processedRecords)
+        .sum();
+    List<Long> durations = executions.stream()
+        .filter(item -> !item.running() && item.durationMs() > 0)
+        .map(RuntimeExecution::durationMs)
+        .toList();
+    long avgDuration = durations.isEmpty()
+        ? 0L
+        : Math.round(durations.stream().mapToLong(Long::longValue).average().orElse(0D));
+    long running = runningAt(end);
+    return new Metrics(success, running, failed, schedule, processed, avgDuration);
+  }
+
+  private long runningAt(LocalDateTime point) {
+    long count = 0L;
+
+    OfflineJobExecutionMapper offline = offlineExecutionMapperProvider.getIfAvailable();
+    if (offline != null) {
+      count += offline.selectCount(
+          new LambdaQueryWrapper<OfflineJobExecutionPO>()
+              .le(OfflineJobExecutionPO::getCreateTime, point)
+              .and(wrapper -> wrapper.isNull(OfflineJobExecutionPO::getEndTime)
+                  .or().gt(OfflineJobExecutionPO::getEndTime, point)));
+    }
+
+    WorkflowExecutionMapper workflow = workflowExecutionMapperProvider.getIfAvailable();
+    if (workflow != null) {
+      Instant instant = point.atZone(ZoneId.systemDefault()).toInstant();
+      count += workflow.selectCount(
+          new LambdaQueryWrapper<WorkflowExecutionPO>()
+              .le(WorkflowExecutionPO::getCreatedAt, instant)
+              .and(wrapper -> wrapper.isNull(WorkflowExecutionPO::getEndedAt)
+                  .or().gt(WorkflowExecutionPO::getEndedAt, instant)));
+    }
+
+    QualityExecutionMapper quality = qualityExecutionMapperProvider.getIfAvailable();
+    if (quality != null) {
+      count += quality.selectCount(
+          new LambdaQueryWrapper<QualityExecutionPO>()
+              .le(QualityExecutionPO::getQueuedAt, point)
+              .and(wrapper -> wrapper.isNull(QualityExecutionPO::getFinishedAt)
+                  .or().gt(QualityExecutionPO::getFinishedAt, point)));
+    }
+    return count;
+  }
+
+  private Trend trend(PeriodRange range, List<RuntimeExecution> executions) {
+    if (range.days() == 1) {
+      List<String> labels = List.of("00:00", "04:00", "08:00", "12:00", "16:00", "20:00", "24:00");
+      long[] buckets = new long[7];
+      for (RuntimeExecution execution : executions) {
+        int index = Math.min(5, Math.max(0, execution.occurredAt().getHour() / 4));
+        buckets[index]++;
+      }
+      // 最后一个点保持 0，用于保留现有 24:00 坐标与折线收尾。
+      List<Long> values = new ArrayList<>();
+      for (long bucket : buckets) values.add(bucket);
+      return new Trend(labels, values);
+    }
+
+    Map<LocalDate, Long> counts = executions.stream().collect(Collectors.groupingBy(
+        item -> item.occurredAt().toLocalDate(), LinkedHashMap::new, Collectors.counting()));
+    List<String> labels = new ArrayList<>();
+    List<Long> values = new ArrayList<>();
+    for (int i = 0; i < range.days(); i++) {
+      LocalDate day = range.start().toLocalDate().plusDays(i);
+      labels.add(DAY_LABEL.format(day));
+      values.add(counts.getOrDefault(day, 0L));
+    }
+    return new Trend(labels, values);
+  }
+
+  private LatestTask latestTask(List<RuntimeExecution> current) {
+    RuntimeExecution latest = current.stream()
+        .max(Comparator.comparing(RuntimeExecution::occurredAt))
+        .orElseGet(this::latestExecutionAcrossAll);
+    if (latest == null) return null;
+
+    LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+    List<RuntimeExecution> recentRuns = executions(sevenDaysAgo, LocalDateTime.now().plusNanos(1)).stream()
+        .filter(item -> item.taskKey().equals(latest.taskKey()))
+        .toList();
+    long exceptions = recentRuns.stream().filter(RuntimeExecution::failed).count();
+    return new LatestTask(
+        latest.taskId(),
+        latest.taskType(),
+        latest.taskName(),
+        latest.durationMs(),
+        recentRuns.size(),
+        exceptions,
+        latest.status(),
+        detailPath(latest));
+  }
+
+  private RuntimeExecution latestExecutionAcrossAll() {
+    LocalDateTime end = LocalDateTime.now().plusNanos(1);
+    List<RuntimeExecution> candidates = executions(end.minusDays(90), end);
+    return candidates.stream().max(Comparator.comparing(RuntimeExecution::occurredAt)).orElse(null);
+  }
+
+  private MetricCompare compare(Metrics current, Metrics previous) {
+    return new MetricCompare(
+        current.successCount() - previous.successCount(),
+        current.runningCount() - previous.runningCount(),
+        current.failedCount() - previous.failedCount(),
+        current.scheduleCount() - previous.scheduleCount(),
+        rateChange(current.processedRecords(), previous.processedRecords()),
+        current.avgDurationMs() - previous.avgDurationMs());
+  }
+
+  private BigDecimal rateChange(long current, long previous) {
+    if (previous <= 0L) return current <= 0L ? BigDecimal.ZERO : BigDecimal.valueOf(100);
+    return BigDecimal.valueOf(current - previous)
+        .multiply(BigDecimal.valueOf(100))
+        .divide(BigDecimal.valueOf(previous), 1, RoundingMode.HALF_UP);
+  }
+
+  private String detailPath(RuntimeExecution execution) {
+    return switch (execution.taskType()) {
+      case "OFFLINE_SYNC" -> "/sync/batch-link-up/" + execution.taskId() + "/detail";
+      case "WORKFLOW" -> "/workflow/instances";
+      case "DATA_QUALITY" -> "/data-quality/execution/" + execution.executionId();
+      default -> "/home";
+    };
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static long zero(Long value) {
+    return value == null ? 0L : value;
+  }
+
+  private static String defaultText(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private static String toText(LocalDateTime value) {
+    return value == null ? null : value.toString();
+  }
+
+  private static String toText(Instant value) {
+    return value == null ? null : LocalDateTime.ofInstant(value, ZoneId.systemDefault()).toString();
+  }
+
+  @SafeVarargs
+  private static <T> T firstNonNull(T... values) {
+    for (T value : values) if (value != null) return value;
+    return null;
+  }
+
+  public record OverviewResponse(
+      PeriodView period,
+      LatestTask latestTask,
+      Trend trend,
+      Metrics metrics,
+      MetricCompare compare) {}
+
+  public record PeriodView(String start, String end) {}
+
+  public record Trend(List<String> labels, List<Long> values) {}
+
+  public record Metrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long avgDurationMs) {}
+
+  public record MetricCompare(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      BigDecimal processedRecordsRate,
+      long avgDurationMs) {}
+
+  public record LatestTask(
+      String taskId,
+      String taskType,
+      String taskName,
+      long durationMs,
+      long runCount,
+      long exceptionCount,
+      String status,
+      String detailPath) {}
+
+  public record RecentResponse(List<RecentTask> items) {}
+
+  public record RecentTask(
+      String taskId,
+      String taskType,
+      String taskName,
+      String lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String detailPath) {}
+
+  public record ScheduleResponse(PeriodView period, long total, List<ScheduleItem> items) {}
+
+  public record ScheduleItem(
+      String taskId,
+      String taskType,
+      String taskName,
+      String cronExpression,
+      String status,
+      String lastScheduleTime,
+      String nextScheduleTime,
+      String detailPath) {}
+
+  private record RuntimeExecution(
+      String taskType,
+      String taskId,
+      String taskName,
+      String status,
+      LocalDateTime occurredAt,
+      LocalDateTime endedAt,
+      long durationMs,
+      long processedRecords,
+      boolean scheduled,
+      boolean success,
+      boolean failed,
+      boolean running,
+      String errorMessage,
+      String executionId) {
+    String taskKey() {
+      return taskType + ":" + taskId;
+    }
+  }
+
+  private record PeriodRange(LocalDateTime start, LocalDateTime end, int days) {
+    static PeriodRange resolve(String value) {
+      String normalized = value == null ? "7d" : value.trim().toLowerCase(Locale.ROOT);
+      int days = switch (normalized) {
+        case "yesterday" -> 1;
+        case "30d" -> 30;
+        default -> 7;
+      };
+      LocalDate yesterday = LocalDate.now().minusDays(1);
+      LocalDate startDay = yesterday.minusDays(days - 1L);
+      return new PeriodRange(startDay.atStartOfDay(), yesterday.plusDays(1).atStartOfDay(), days);
+    }
+
+    PeriodRange previous() {
+      return new PeriodRange(start.minusDays(days), start, days);
+    }
+  }
+}

--- a/yak-ops-ui/src/pages/home/DataCenter.tsx
+++ b/yak-ops-ui/src/pages/home/DataCenter.tsx
@@ -1,0 +1,782 @@
+import { history } from '@umijs/max';
+import type { EChartsOption } from 'echarts';
+import ReactECharts from 'echarts-for-react';
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  CircleHelp,
+  Clock3,
+  Copy,
+  Database,
+  RadioTower,
+} from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  homeDataCenterApi,
+  type HomeDataCenterOverview,
+  type HomeDataCenterPeriod,
+  type HomeLatestTask,
+  type HomeRecentTask,
+  type HomeScheduleItem,
+} from './service';
+
+type OverviewTabKey = 'overview' | 'recent' | 'schedule';
+type PeriodKey = HomeDataCenterPeriod;
+
+interface OverviewMetric {
+  label: string;
+  value: string;
+  compareLabel: string;
+  compareValue: string;
+  tone?: 'positive' | 'negative' | 'neutral';
+}
+
+const overviewTabs: Array<{ key: OverviewTabKey; label: string }> = [
+  { key: 'overview', label: '运行总览' },
+  { key: 'recent', label: '近期任务' },
+  { key: 'schedule', label: '调度数据' },
+];
+
+const periodOptions: Array<{ key: PeriodKey; label: string }> = [
+  { key: 'yesterday', label: '昨天' },
+  { key: '7d', label: '近7日' },
+  { key: '30d', label: '近30日' },
+];
+
+const pad2 = (value: number) => String(value).padStart(2, '0');
+
+const formatDate = (date: Date) =>
+  `${date.getFullYear()}.${pad2(date.getMonth() + 1)}.${pad2(date.getDate())}`;
+
+const formatIsoDate = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? value.replaceAll('-', '.') : formatDate(date);
+};
+
+function buildPeriod(periodKey: PeriodKey, reference = new Date()) {
+  const today = new Date(
+    reference.getFullYear(),
+    reference.getMonth(),
+    reference.getDate(),
+  );
+  const end = new Date(today);
+  end.setDate(today.getDate() - 1);
+  const count = periodKey === '30d' ? 30 : periodKey === 'yesterday' ? 1 : 7;
+  const start = new Date(end);
+  start.setDate(end.getDate() - (count - 1));
+  return { start, end };
+}
+
+const formatCount = (value: number) => {
+  if (value >= 100000000) return `${(value / 100000000).toFixed(1).replace(/\.0$/, '')}亿`;
+  if (value >= 10000) return `${(value / 10000).toFixed(1).replace(/\.0$/, '')}万`;
+  return String(value);
+};
+
+const formatDuration = (millis?: number) => {
+  const seconds = Math.max(0, Math.round((millis || 0) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+};
+
+const formatCardDuration = (millis?: number) => {
+  const totalSeconds = Math.max(0, Math.round((millis || 0) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  return `${pad2(minutes)}:${pad2(totalSeconds % 60)}`;
+};
+
+const signedNumber = (value: number) => `${value > 0 ? '+' : ''}${value}`;
+const signedDuration = (value: number) => `${value > 0 ? '+' : value < 0 ? '-' : ''}${formatDuration(Math.abs(value))}`;
+const signedRate = (value: number) => `${value > 0 ? '+' : ''}${Number(value || 0).toFixed(1)}%`;
+
+const compareLabelFor = (periodKey: PeriodKey) =>
+  periodKey === 'yesterday' ? '较前1日' : periodKey === '30d' ? '较前30日' : '较前7日';
+
+const positiveWhenUp = (value: number): OverviewMetric['tone'] =>
+  value > 0 ? 'positive' : value < 0 ? 'negative' : 'neutral';
+
+const positiveWhenDown = (value: number): OverviewMetric['tone'] =>
+  value < 0 ? 'positive' : value > 0 ? 'negative' : 'neutral';
+
+const toOverviewMetrics = (
+  overview: HomeDataCenterOverview | undefined,
+  periodKey: PeriodKey,
+): OverviewMetric[] => {
+  const metrics = overview?.metrics;
+  const compare = overview?.compare;
+  const compareLabel = compareLabelFor(periodKey);
+  return [
+    {
+      label: '成功任务',
+      value: String(metrics?.successCount ?? 0),
+      compareLabel,
+      compareValue: signedNumber(compare?.successCount ?? 0),
+      tone: positiveWhenUp(compare?.successCount ?? 0),
+    },
+    {
+      label: '运行中',
+      value: String(metrics?.runningCount ?? 0),
+      compareLabel,
+      compareValue: signedNumber(compare?.runningCount ?? 0),
+      tone: positiveWhenDown(compare?.runningCount ?? 0),
+    },
+    {
+      label: '失败任务',
+      value: String(metrics?.failedCount ?? 0),
+      compareLabel,
+      compareValue: signedNumber(compare?.failedCount ?? 0),
+      tone: positiveWhenDown(compare?.failedCount ?? 0),
+    },
+    {
+      label: '调度次数',
+      value: String(metrics?.scheduleCount ?? 0),
+      compareLabel,
+      compareValue: signedNumber(compare?.scheduleCount ?? 0),
+      tone: 'neutral',
+    },
+    {
+      label: '处理记录',
+      value: formatCount(metrics?.processedRecords ?? 0),
+      compareLabel,
+      compareValue: signedRate(compare?.processedRecordsRate ?? 0),
+      tone: positiveWhenUp(compare?.processedRecordsRate ?? 0),
+    },
+    {
+      label: '平均耗时',
+      value: formatDuration(metrics?.avgDurationMs ?? 0),
+      compareLabel,
+      compareValue: signedDuration(compare?.avgDurationMs ?? 0),
+      tone: positiveWhenDown(compare?.avgDurationMs ?? 0),
+    },
+  ];
+};
+
+const taskTypeLabel = (taskType?: string) => {
+  if (taskType === 'OFFLINE_SYNC') return '离线同步';
+  if (taskType === 'WORKFLOW') return '工作流';
+  if (taskType === 'DATA_QUALITY') return '数据质量';
+  return '任务';
+};
+
+const statusLabel = (status?: string) => {
+  const normalized = status?.toUpperCase();
+  if (['SUCCEEDED', 'SUCCESS', 'SUCCESS_WITH_WARNINGS', 'COMPLETED', 'FINISHED', 'WARNING'].includes(normalized || '')) return '成功';
+  if (['FAILED', 'ERROR', 'TIMED_OUT', 'LOST'].includes(normalized || '')) return '失败';
+  if (['CREATED', 'SUBMITTED', 'QUEUED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING'].includes(normalized || '')) return '运行中';
+  if (['CANCELED', 'CANCELLED'].includes(normalized || '')) return '已取消';
+  return status || '-';
+};
+
+const statusClassName = (status?: string) => {
+  const label = statusLabel(status);
+  if (label === '成功') return 'text-[#20a464]';
+  if (label === '失败') return 'text-[#f04c5a]';
+  return 'text-[#7b8089]';
+};
+
+const formatRunTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.replace('T', ' ').slice(0, 16);
+  const now = new Date();
+  const time = `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+  if (
+    date.getFullYear() === now.getFullYear()
+    && date.getMonth() === now.getMonth()
+    && date.getDate() === now.getDate()
+  ) return `今日 ${time}`;
+  return `${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${time}`;
+};
+
+const goToDetail = (path?: string) => {
+  if (path) history.push(path);
+};
+
+interface TrendChartProps {
+  values: number[];
+  labels: string[];
+  name: string;
+}
+
+function TrendChart({ values, labels, name }: TrendChartProps) {
+  const option = useMemo<EChartsOption>(
+    () => ({
+      animation: true,
+      animationDuration: 720,
+      animationDurationUpdate: 620,
+      animationEasing: 'cubicOut',
+      animationEasingUpdate: 'cubicOut',
+      grid: {
+        left: 0,
+        right: 2,
+        top: 18,
+        bottom: 26,
+        containLabel: false,
+      },
+      tooltip: {
+        trigger: 'axis',
+        confine: true,
+        appendToBody: false,
+        backgroundColor: 'rgba(255,255,255,0.98)',
+        borderColor: '#edf0f4',
+        borderWidth: 1,
+        padding: [10, 12],
+        textStyle: {
+          color: '#30333b',
+          fontSize: 12,
+        },
+        extraCssText:
+          'box-shadow:0 8px 28px rgba(31,35,41,.10);border-radius:8px;',
+        axisPointer: {
+          type: 'line',
+          lineStyle: {
+            color: '#dfe6f4',
+            width: 1,
+          },
+        },
+        formatter: (params: any) => {
+          const item = Array.isArray(params) ? params[0] : params;
+          if (!item) return '';
+          return `
+            <div style="min-width:120px">
+              <div style="font-size:12px;color:#555a64;margin-bottom:8px">${item.axisValue}</div>
+              <div style="display:flex;align-items:center;justify-content:space-between;gap:20px">
+                <span style="display:flex;align-items:center;color:#30333b;font-weight:600">
+                  <i style="display:inline-block;width:7px;height:7px;border-radius:999px;background:#5b8cff;margin-right:6px"></i>
+                  ${name}
+                </span>
+                <b style="font-size:12px;color:#30333b">${item.data}</b>
+              </div>
+            </div>
+          `;
+        },
+      },
+      xAxis: {
+        type: 'category',
+        boundaryGap: false,
+        data: labels,
+        axisTick: { show: false },
+        axisLine: { show: false },
+        axisLabel: {
+          color: '#8d929b',
+          fontSize: 11,
+          margin: 9,
+          interval: labels.length > 10 ? 4 : 0,
+          showMinLabel: true,
+          showMaxLabel: true,
+        },
+      },
+      yAxis: {
+        type: 'value',
+        min: 0,
+        max: Math.max(...values, 1) * 1.2,
+        axisTick: { show: false },
+        axisLine: { show: false },
+        axisLabel: { show: false },
+        splitLine: { show: false },
+      },
+      series: [
+        {
+          name,
+          type: 'line',
+          data: values,
+          smooth: 0.42,
+          showSymbol: false,
+          symbol: 'circle',
+          symbolSize: 6,
+          lineStyle: {
+            color: '#5b8cff',
+            width: 1.5,
+          },
+          itemStyle: {
+            color: '#5b8cff',
+            borderColor: '#ffffff',
+            borderWidth: 2,
+          },
+          areaStyle: {
+            color: {
+              type: 'linear',
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: 'rgba(91,140,255,0.18)' },
+                { offset: 1, color: 'rgba(91,140,255,0.00)' },
+              ],
+            },
+          },
+          emphasis: {
+            focus: 'series',
+            scale: true,
+          },
+        },
+      ],
+    }),
+    [labels, name, values],
+  );
+
+  return (
+    <ReactECharts
+      option={option}
+      notMerge
+      lazyUpdate
+      style={{ height: 152, width: '100%' }}
+    />
+  );
+}
+
+function LatestTaskCard({ task }: { task?: HomeLatestTask }) {
+  return (
+    <aside className="w-full shrink-0 lg:w-[220px] lg:border-r lg:border-[#edf0f3] lg:pr-5">
+      <div className="mb-2 text-[13px] font-semibold leading-5 text-[#353842]">
+        最新任务
+      </div>
+
+      <button
+        type="button"
+        onClick={() => goToDetail(task?.detailPath)}
+        className="group relative h-[266px] w-full overflow-hidden rounded-[10px] border border-[#e8ebef] bg-[linear-gradient(150deg,#6c737d_0%,#9197a0_48%,#c0c4ca_100%)] text-left text-white transition-[border-color,transform] duration-200 hover:-translate-y-px hover:border-[#dfe3e8] lg:w-[198px]"
+      >
+        <div className="pointer-events-none absolute inset-0 opacity-[0.18] [background-image:linear-gradient(rgba(255,255,255,.28)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.22)_1px,transparent_1px)] [background-size:22px_22px]" />
+        <div className="pointer-events-none absolute -right-9 top-10 h-32 w-32 rounded-full border border-white/20" />
+        <div className="pointer-events-none absolute -right-2 top-16 h-24 w-24 rounded-full border border-white/20" />
+
+        <div className="absolute left-4 top-3 z-10">
+          <div className="text-[12px] font-semibold text-white/95">{taskTypeLabel(task?.taskType)}</div>
+          <div className="mt-0.5 text-[11px] text-white/80">{formatCardDuration(task?.durationMs)}</div>
+        </div>
+
+        <Copy
+          size={14}
+          strokeWidth={1.8}
+          className="absolute right-3 top-3 z-10 text-white/90"
+        />
+
+        <div className="absolute inset-x-0 top-[50px] z-10 flex justify-center">
+          <div className="relative flex h-[122px] w-[122px] items-center justify-center">
+            <span className="absolute h-[112px] w-[112px] rounded-full border border-white/25" />
+            <span className="absolute h-[82px] w-[82px] rounded-full border border-white/18" />
+            <span className="absolute h-[52px] w-[52px] rounded-full bg-white/12 backdrop-blur-[2px]" />
+            <Database size={52} strokeWidth={1.15} className="relative text-white/95" />
+          </div>
+        </div>
+
+        <div className="absolute inset-x-0 bottom-[70px] z-10 px-4">
+          <div className="truncate text-[12px] font-medium text-white/95">
+            {task?.taskName || '暂无运行任务'}
+          </div>
+        </div>
+
+        <div className="absolute inset-x-0 bottom-0 z-10 h-[70px] bg-black/20 px-4 backdrop-blur-[12px]">
+          <div className="flex h-1/2 items-center justify-between border-b border-white/12">
+            <span className="text-[11px] text-white/78">运行次数</span>
+            <strong className="text-[12px] font-semibold">{task?.runCount ?? 0}</strong>
+          </div>
+          <div className="flex h-1/2 items-center justify-between">
+            <span className="text-[11px] text-white/78">异常</span>
+            <strong className="text-[12px] font-semibold">{task?.exceptionCount ?? 0}</strong>
+          </div>
+        </div>
+      </button>
+    </aside>
+  );
+}
+
+function PeriodSelect({
+  value,
+  onChange,
+}: {
+  value: PeriodKey;
+  onChange: (value: PeriodKey) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const current = periodOptions.find((option) => option.key === value)!;
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, []);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((currentOpen) => !currentOpen)}
+        className={`
+          flex h-[27px] items-center rounded-[7px] border px-2.5 text-[12px]
+          transition-colors
+          ${
+            open
+              ? 'border-[#9db7ef] bg-[#f7f9fd] text-[#454a54]'
+              : 'border-transparent bg-[#f4f5f7] text-[#5f646e] hover:bg-[#eceef2]'
+          }
+        `}
+      >
+        <span className="pr-2 text-[#727781]">时间</span>
+        <span className="mr-1.5 h-[12px] w-px bg-[#dcdfe4]" />
+        <span className="min-w-[34px] text-left font-medium text-[#4d525c]">
+          {current.label}
+        </span>
+        <ChevronDown
+          size={13}
+          strokeWidth={1.8}
+          className={`ml-1 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-[31px] z-30 w-[116px] overflow-hidden rounded-[8px] border border-[#eceef2] bg-white py-1 shadow-[0_8px_22px_rgba(31,35,41,0.10)]">
+          {periodOptions.map((option) => {
+            const selected = option.key === value;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => {
+                  onChange(option.key);
+                  setOpen(false);
+                }}
+                className="flex h-[34px] w-full items-center px-3 text-left text-[12px] text-[#444952] transition-colors hover:bg-[#f6f7f9]"
+              >
+                <span className="flex w-5 items-center">
+                  {selected && <Check size={14} strokeWidth={2} />}
+                </span>
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OverviewMetrics({ metrics }: { metrics: OverviewMetric[] }) {
+  return (
+    <div className="mt-1 grid grid-cols-2 gap-x-2 gap-y-1 sm:grid-cols-3">
+      {metrics.map((metric) => (
+        <div
+          key={metric.label}
+          className="group min-w-0 rounded-[6px] px-3 py-2 transition-colors duration-150 hover:bg-[#f7f8fa]"
+        >
+          <div className="text-[12px] font-semibold leading-5 text-[#454951]">
+            {metric.label}
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <strong className="text-[20px] font-semibold leading-7 tracking-[-0.4px] text-[#272a33]">
+              {metric.value}
+            </strong>
+            <span className="text-[11px] text-[#989ca4]">
+              {metric.compareLabel}
+              <span
+                className={`ml-0.5 font-medium ${
+                  metric.tone === 'positive'
+                    ? 'text-[#20a464]'
+                    : metric.tone === 'negative'
+                      ? 'text-[#f04c5a]'
+                      : 'text-[#7b8089]'
+                }`}
+              >
+                {metric.compareValue}
+              </span>
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RecentTasksPanel({ items }: { items: HomeRecentTask[] }) {
+  return (
+    <div className="min-h-[263px] pt-2">
+      {items.length === 0 && (
+        <div className="flex min-h-[240px] items-center justify-center text-[12px] text-[#9da1a8]">
+          暂无近期任务
+        </div>
+      )}
+      {items.map((item) => (
+        <button
+          key={`${item.taskType}-${item.taskId}`}
+          type="button"
+          onClick={() => goToDetail(item.detailPath)}
+          className="group grid w-full grid-cols-[minmax(230px,1.5fr)_repeat(4,minmax(72px,.55fr))_150px] items-center gap-3 rounded-[8px] px-3 py-3 text-left transition-colors hover:bg-[#f7f8fa]"
+        >
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#edf4ff] text-[#5b8cff]">
+              <Database size={16} strokeWidth={1.9} />
+            </div>
+            <div className="min-w-0">
+              <div className="truncate text-[12px] font-medium text-[#363a43]">
+                {item.taskName}
+              </div>
+              <div className="mt-1 flex items-center gap-1 text-[11px] text-[#969aa3]">
+                <Clock3 size={11} strokeWidth={1.8} />
+                {formatRunTime(item.lastRunTime)}
+              </div>
+            </div>
+          </div>
+
+          {[
+            ['运行', String(item.runCount)],
+            ['成功', String(item.successCount)],
+            ['失败', String(item.failedCount)],
+            ['耗时', formatDuration(item.lastDurationMs)],
+          ].map(([label, value]) => (
+            <div key={label} className="min-w-0">
+              <span className="text-[11px] text-[#969aa3]">{label}</span>
+              <strong className="ml-2 text-[12px] font-semibold text-[#3b3f48]">
+                {value}
+              </strong>
+            </div>
+          ))}
+
+          <div className="flex items-center justify-end gap-4">
+            <span className={`text-[11px] font-medium ${statusClassName(item.lastStatus)}`}>
+              {statusLabel(item.lastStatus)}
+            </span>
+            <span className="text-[12px] font-semibold text-[#323640] transition-colors group-hover:text-[#5b8cff]">
+              查看详情
+            </span>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function EmptySchedulePanel({ periodLabel }: { periodLabel: string }) {
+  return (
+    <div className="flex min-h-[263px] items-center justify-center pb-4">
+      <div className="text-center">
+        <div className="relative mx-auto flex h-[78px] w-[112px] items-center justify-center">
+          <span className="absolute left-[19px] top-[5px] flex h-7 w-7 items-center justify-center rounded-full bg-[#d9e7ff] text-[#4b7df3]">
+            <CircleHelp size={18} strokeWidth={2.1} />
+          </span>
+          <span className="absolute bottom-2 left-[38px] h-[40px] w-[54px] rounded-[12px] border border-[#dfe3e9] bg-[#fafbfc]" />
+          <RadioTower
+            size={45}
+            strokeWidth={1.25}
+            className="absolute bottom-[7px] right-[22px] text-[#9ba2ad]"
+          />
+        </div>
+        <div className="mt-1 text-[12px] text-[#8a8f98]">
+          {periodLabel}暂无调度数据
+        </div>
+        <div className="mt-1 text-[11px] text-[#b0b4bb]">
+          当前周期内没有可展示的调度记录
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SchedulePanel({ items, periodLabel }: { items: HomeScheduleItem[]; periodLabel: string }) {
+  if (items.length === 0) return <EmptySchedulePanel periodLabel={periodLabel} />;
+  return (
+    <div className="min-h-[263px] pt-2">
+      {items.map((item) => (
+        <button
+          key={`${item.taskType}-${item.taskId}`}
+          type="button"
+          onClick={() => goToDetail(item.detailPath)}
+          className="group grid w-full grid-cols-[minmax(230px,1.5fr)_repeat(4,minmax(72px,.55fr))_150px] items-center gap-3 rounded-[8px] px-3 py-3 text-left transition-colors hover:bg-[#f7f8fa]"
+        >
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#edf4ff] text-[#5b8cff]">
+              <RadioTower size={16} strokeWidth={1.9} />
+            </div>
+            <div className="min-w-0">
+              <div className="truncate text-[12px] font-medium text-[#363a43]">
+                {item.taskName}
+              </div>
+              <div className="mt-1 flex items-center gap-1 text-[11px] text-[#969aa3]">
+                <Clock3 size={11} strokeWidth={1.8} />
+                {taskTypeLabel(item.taskType)}
+              </div>
+            </div>
+          </div>
+
+          {[
+            ['周期', item.cronExpression || '-'],
+            ['上次', formatRunTime(item.lastScheduleTime)],
+            ['下次', formatRunTime(item.nextScheduleTime)],
+            ['状态', statusLabel(item.status)],
+          ].map(([label, value]) => (
+            <div key={label} className="min-w-0">
+              <span className="text-[11px] text-[#969aa3]">{label}</span>
+              <strong className="ml-2 truncate text-[12px] font-semibold text-[#3b3f48]">
+                {value}
+              </strong>
+            </div>
+          ))}
+
+          <div className="flex items-center justify-end gap-4">
+            <span className={`text-[11px] font-medium ${statusClassName(item.status)}`}>
+              {item.status || '-'}
+            </span>
+            <span className="text-[12px] font-semibold text-[#323640] transition-colors group-hover:text-[#5b8cff]">
+              查看详情
+            </span>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default function DataCenter() {
+  const [activeTab, setActiveTab] = useState<OverviewTabKey>('overview');
+  const [periodKey, setPeriodKey] = useState<PeriodKey>('7d');
+  const [overview, setOverview] = useState<HomeDataCenterOverview>();
+  const [recentTasks, setRecentTasks] = useState<HomeRecentTask[]>([]);
+  const [scheduleItems, setScheduleItems] = useState<HomeScheduleItem[]>([]);
+  const fallbackPeriod = useMemo(() => buildPeriod(periodKey), [periodKey]);
+  const periodLabel = periodOptions.find((item) => item.key === periodKey)!.label;
+  const overviewMetrics = useMemo(
+    () => toOverviewMetrics(overview, periodKey),
+    [overview, periodKey],
+  );
+
+  useEffect(() => {
+    let active = true;
+    void homeDataCenterApi.overview(periodKey).then((response) => {
+      if (active) setOverview(response.data);
+    }).catch(() => {
+      if (active) setOverview(undefined);
+    });
+    return () => { active = false; };
+  }, [periodKey]);
+
+  useEffect(() => {
+    if (activeTab !== 'recent') return undefined;
+    let active = true;
+    void homeDataCenterApi.recent().then((response) => {
+      if (active) setRecentTasks(response.data?.items || []);
+    }).catch(() => {
+      if (active) setRecentTasks([]);
+    });
+    return () => { active = false; };
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (activeTab !== 'schedule') return undefined;
+    let active = true;
+    void homeDataCenterApi.schedule(periodKey).then((response) => {
+      if (active) setScheduleItems(response.data?.items || []);
+    }).catch(() => {
+      if (active) setScheduleItems([]);
+    });
+    return () => { active = false; };
+  }, [activeTab, periodKey]);
+
+  const periodStart = overview?.period?.start
+    ? formatIsoDate(overview.period.start)
+    : formatDate(fallbackPeriod.start);
+  const periodEnd = overview?.period?.end
+    ? formatIsoDate(overview.period.end)
+    : formatDate(fallbackPeriod.end);
+  const trendLabels = overview?.trend?.labels || [];
+  const trendValues = overview?.trend?.values || [];
+
+  return (
+    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <header className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <h2 className="shrink-0 text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+            数据中心
+          </h2>
+          <CircleHelp size={14} strokeWidth={1.9} className="shrink-0 text-[#a0a4ac]" />
+          <span className="ml-0.5 hidden text-[12px] leading-5 text-[#8d929b] sm:inline">
+            统计周期：{periodStart}-{periodEnd}（每天12点更新）
+          </span>
+        </div>
+
+        <button
+          type="button"
+          className="flex items-center gap-0.5 text-[12px] text-[#666b75] transition-colors hover:text-[#252832]"
+        >
+          查看更多
+          <ChevronRight size={14} strokeWidth={1.8} />
+        </button>
+      </header>
+
+      <div className="mt-4 flex flex-col gap-5 lg:flex-row lg:gap-6">
+        <LatestTaskCard task={overview?.latestTask} />
+
+        <div className="min-w-0 flex-1">
+          <div className="flex min-h-[35px] items-end justify-between border-b border-[#eceef2]">
+            <div className="flex items-center gap-5 sm:gap-7">
+              {overviewTabs.map((tab) => {
+                const active = activeTab === tab.key;
+                return (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => setActiveTab(tab.key)}
+                    className={`
+                      relative h-[35px] pb-2 text-[13px] transition-colors
+                      ${
+                        active
+                          ? 'font-semibold text-[#292c35]'
+                          : 'font-normal text-[#858a93] hover:text-[#4a4f59]'
+                      }
+                    `}
+                  >
+                    {tab.label}
+                    <span
+                      className={`absolute inset-x-0 -bottom-px h-[2px] origin-center rounded-full bg-[#252832] transition-transform duration-200 ${
+                        active ? 'scale-x-100' : 'scale-x-0'
+                      }`}
+                    />
+                  </button>
+                );
+              })}
+            </div>
+
+            {activeTab !== 'recent' && (
+              <div className="mb-1.5">
+                <PeriodSelect value={periodKey} onChange={setPeriodKey} />
+              </div>
+            )}
+          </div>
+
+          {activeTab === 'overview' && (
+            <div>
+              <div className="mt-2 flex items-center justify-end gap-1.5 text-[12px] text-[#7f848e]">
+                <span className="h-2 w-2 rounded-full bg-[#5b8cff]" />
+                运行次数
+              </div>
+              <TrendChart
+                key={`trend-${periodKey}`}
+                values={trendValues}
+                labels={trendLabels}
+                name="运行次数"
+              />
+              <OverviewMetrics metrics={overviewMetrics} />
+            </div>
+          )}
+
+          {activeTab === 'recent' && <RecentTasksPanel items={recentTasks} />}
+
+          {activeTab === 'schedule' && (
+            <SchedulePanel items={scheduleItems} periodLabel={periodLabel} />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/index.tsx
+++ b/yak-ops-ui/src/pages/home/index.tsx
@@ -1,22 +1,15 @@
 import {
   ArrowRightLeft,
   BarChart3,
-  Check,
-  ChevronDown,
   ChevronLeft,
   ChevronRight,
-  CircleHelp,
-  Clock3,
   Code2,
-  Copy,
   Database,
-  RadioTower,
   ShieldCheck,
   Workflow,
 } from 'lucide-react';
-import ReactECharts from 'echarts-for-react';
-import type { EChartsOption } from 'echarts';
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
+import DataCenter from './DataCenter';
 
 /* =========================================================
  * Types
@@ -109,16 +102,13 @@ const themeStyles: Record<
     glow: 'bg-[#ff58a9]',
     iconHover: 'group-hover:rotate-[360deg]',
   },
-
   image: {
     panel: 'bg-gradient-to-b from-[#79c8ff] to-[#e4f5ff]',
     core:
       'bg-gradient-to-br from-[#28b8ff] to-[#168cf4] shadow-[inset_0_-2px_2px_rgba(0,93,231,0.28)]',
     glow: 'bg-[#63e3ff]',
-    iconHover:
-      'group-hover:-translate-y-[1px] group-hover:rotate-[8deg]',
+    iconHover: 'group-hover:-translate-y-[1px] group-hover:rotate-[8deg]',
   },
-
   panorama: {
     panel: 'bg-gradient-to-b from-[#aaa1ff] to-[#eeebff]',
     core:
@@ -126,16 +116,13 @@ const themeStyles: Record<
     glow: 'bg-[#c677ff]',
     iconHover: 'group-hover:rotate-[360deg]',
   },
-
   article: {
     panel: 'bg-gradient-to-b from-[#ffd65c] to-[#fff3c9]',
     core:
       'bg-gradient-to-br from-[#ffcb24] to-[#ffb900] shadow-[inset_0_-2px_2px_rgba(225,152,0,0.25)]',
     glow: 'bg-[#fff27d]',
-    iconHover:
-      'group-hover:-translate-y-[2px] group-hover:rotate-[-4deg]',
+    iconHover: 'group-hover:-translate-y-[2px] group-hover:rotate-[-4deg]',
   },
-
   avatar: {
     panel: 'bg-gradient-to-b from-[#89d6f6] to-[#e6f7fe]',
     core:
@@ -143,7 +130,6 @@ const themeStyles: Record<
     glow: 'bg-[#84eeff]',
     iconHover: 'group-hover:rotate-[12deg]',
   },
-
   workshop: {
     panel: 'bg-gradient-to-b from-[#a5ccff] to-[#eef6ff]',
     core:
@@ -155,13 +141,6 @@ const themeStyles: Record<
 
 /* =========================================================
  * Layered Icon
- *
- * 对应原页面：
- *
- * 77 × 84 icon layer
- * ├── 60 × 75 后置倾斜玻璃板
- * └── 60 × 75 前置渐变玻璃板
- *      └── 32 × 32 核心 icon
  * ========================================================= */
 
 interface LayeredIconProps {
@@ -171,126 +150,53 @@ interface LayeredIconProps {
 
 function LayeredIcon({ theme, icon }: LayeredIconProps) {
   const styles = themeStyles[theme];
-
   return (
     <div
       className="
-        pointer-events-none
-        absolute
-        -left-px
-        -top-[5px]
-        z-[1]
-        h-[84px]
-        w-[77px]
+        pointer-events-none absolute -left-px -top-[5px] z-[1]
+        h-[84px] w-[77px]
       "
     >
-      {/* 后置倾斜玻璃层 */}
       <div
         className="
-          absolute
-          left-[3px]
-          top-0
-          h-[75px]
-          w-[60px]
-          rotate-[10deg]
-          skew-x-[-1.54deg]
-          rounded-[12px]
-          border
-          border-white
-          bg-[#d6d7d9]/40
-          backdrop-blur-[6px]
+          absolute left-[3px] top-0 h-[75px] w-[60px]
+          rotate-[10deg] skew-x-[-1.54deg] rounded-[12px]
+          border border-white bg-[#d6d7d9]/40 backdrop-blur-[6px]
         "
       />
-
-      {/* 前置渐变玻璃层 */}
       <div
         className={`
-          absolute
-          left-0
-          top-[5px]
-          flex
-          h-[75px]
-          w-[60px]
-          items-center
-          justify-center
-          overflow-hidden
-          rounded-[12px]
-          border
-          border-white
-          backdrop-blur-[6px]
-          ${styles.panel}
+          absolute left-0 top-[5px] flex h-[75px] w-[60px]
+          items-center justify-center overflow-hidden rounded-[12px]
+          border border-white backdrop-blur-[6px] ${styles.panel}
         `}
       >
-        {/* 核心 32 × 32 */}
         <div
           className={`
-            relative
-            flex
-            h-8
-            w-8
-            shrink-0
-            items-center
-            justify-center
-            overflow-hidden
-            rounded-lg
-            text-white
-            ${styles.core}
+            relative flex h-8 w-8 shrink-0 items-center justify-center
+            overflow-hidden rounded-lg text-white ${styles.core}
           `}
         >
-          {/* 左上光斑 */}
           <span
             className={`
-              absolute
-              -left-[7px]
-              -top-2
-              h-[23px]
-              w-[23px]
-              rounded-full
-              blur-[5px]
-              transition-all
-              duration-500
-              ease-in-out
-              group-hover:translate-x-[5px]
-              group-hover:translate-y-[3px]
+              absolute -left-[7px] -top-2 h-[23px] w-[23px] rounded-full
+              blur-[5px] transition-all duration-500 ease-in-out
+              group-hover:translate-x-[5px] group-hover:translate-y-[3px]
               ${styles.glow}
             `}
           />
-
-          {/* 右下白色光斑 */}
           <span
             className="
-              absolute
-              left-[18px]
-              top-[21px]
-              h-[18px]
-              w-[18px]
-              rounded-full
-              bg-white/50
-              blur-[5px]
-              transition-all
-              duration-500
-              ease-in-out
-              group-hover:-translate-x-[4px]
-              group-hover:-translate-y-[4px]
+              absolute left-[18px] top-[21px] h-[18px] w-[18px] rounded-full
+              bg-white/50 blur-[5px] transition-all duration-500 ease-in-out
+              group-hover:-translate-x-[4px] group-hover:-translate-y-[4px]
             "
           />
-
-          {/* 白色图形 */}
           <span
             className={`
-              relative
-              z-[3]
-              flex
-              h-5
-              w-5
-              items-center
-              justify-center
-              text-white
-              drop-shadow-[0_1px_1px_rgba(0,0,0,0.05)]
-              transition-transform
-              duration-500
-              ease-in-out
-              ${styles.iconHover}
+              relative z-[3] flex h-5 w-5 items-center justify-center text-white
+              drop-shadow-[0_1px_1px_rgba(0,0,0,0.05)] transition-transform
+              duration-500 ease-in-out ${styles.iconHover}
             `}
           >
             {icon}
@@ -316,57 +222,22 @@ function ActionCard({ item, onClick }: ActionCardProps) {
       type="button"
       onClick={onClick}
       className="
-        group
-        relative
-        flex
-        h-[75px]
-        w-full
-        items-center
-        overflow-visible
-        rounded-[18px]
-        border
-        border-[rgba(31,35,41,0.075)]
-        bg-white/[0.96]
-        pr-4
-        text-left
-        shadow-[0_5px_12px_rgba(31,35,41,0.055),0_1px_2px_rgba(31,35,41,0.025)]
-        transition-[background-color,border-color,box-shadow]
-        duration-200
-        ease-out
-        hover:border-[rgba(31,35,41,0.10)]
-        hover:bg-white
+        group relative flex h-[75px] w-full items-center overflow-visible
+        rounded-[18px] border border-[rgba(31,35,41,0.075)] bg-white/[0.96]
+        pr-4 text-left shadow-[0_5px_12px_rgba(31,35,41,0.055),0_1px_2px_rgba(31,35,41,0.025)]
+        transition-[background-color,border-color,box-shadow] duration-200 ease-out
+        hover:border-[rgba(31,35,41,0.10)] hover:bg-white
         hover:shadow-[0_6px_15px_rgba(31,35,41,0.065),0_1px_2px_rgba(31,35,41,0.025)]
       "
     >
-      {/* Icon 占位 */}
       <div className="relative h-[75px] w-[77px] shrink-0">
         <LayeredIcon theme={item.theme} icon={item.icon} />
       </div>
-
-      {/* Text */}
       <div className="ml-2 min-w-0">
-        <div
-          className="
-            truncate
-            text-[15px]
-            font-semibold
-            leading-[22px]
-            text-[#292c35]
-          "
-        >
+        <div className="truncate text-[15px] font-semibold leading-[22px] text-[#292c35]">
           {item.title}
         </div>
-
-        <div
-          className="
-            mt-0.5
-            truncate
-            text-[13px]
-            font-normal
-            leading-5
-            text-[#9498a1]
-          "
-        >
+        <div className="mt-0.5 truncate text-[13px] font-normal leading-5 text-[#9498a1]">
           {item.description}
         </div>
       </div>
@@ -384,40 +255,19 @@ interface ProfileStatProps {
   arrow?: boolean;
 }
 
-function ProfileStat({
-  label,
-  value,
-  arrow = false,
-}: ProfileStatProps) {
+function ProfileStat({ label, value, arrow = false }: ProfileStatProps) {
   return (
     <button
       type="button"
       className="
-        flex
-        items-center
-        border-0
-        bg-transparent
-        p-0
-        text-sm
-        leading-[22px]
-        text-[#747983]
-        transition-colors
-        duration-200
-        hover:text-[#292c35]
+        flex items-center border-0 bg-transparent p-0 text-sm leading-[22px]
+        text-[#747983] transition-colors duration-200 hover:text-[#292c35]
       "
     >
       <span>{label}</span>
-
-      <strong className="ml-[5px] font-semibold text-[#282b34]">
-        {value}
-      </strong>
-
+      <strong className="ml-[5px] font-semibold text-[#282b34]">{value}</strong>
       {arrow && (
-        <ChevronRight
-          size={14}
-          strokeWidth={1.8}
-          className="ml-[3px] text-[#9599a2]"
-        />
+        <ChevronRight size={14} strokeWidth={1.8} className="ml-[3px] text-[#9599a2]" />
       )}
     </button>
   );
@@ -433,121 +283,35 @@ interface SectionProps {
   className?: string;
 }
 
-function Section({
-  title,
-  children,
-  className = '',
-}: SectionProps) {
+function Section({ title, children, className = '' }: SectionProps) {
   return (
     <section
       className={`
-        min-h-[258px]
-        rounded-[22px]
-        border
-        border-[#f1f1f1]
-        bg-white/[0.68]
-        px-[22px]
-        pb-6
-        pt-6
-        backdrop-blur-[8px]
-        ${className}
+        min-h-[258px] rounded-[22px] border border-[#f1f1f1] bg-white/[0.68]
+        px-[22px] pb-6 pt-6 backdrop-blur-[8px] ${className}
       `}
     >
       <h2
         className="
-          mb-5
-          text-xl
-          font-semibold
-          leading-7
-          tracking-[-0.35px]
-          text-[#252832]
+          mb-5 text-xl font-semibold leading-7 tracking-[-0.35px] text-[#252832]
         "
       >
         {title}
       </h2>
-
       {children}
     </section>
   );
 }
 
 /* =========================================================
- * Data Center
+ * Activity Center
  * ========================================================= */
-
-type OverviewTabKey = 'overview' | 'recent' | 'schedule';
-type PeriodKey = 'yesterday' | '7d' | '30d';
-
-interface OverviewMetric {
-  label: string;
-  value: string;
-  compareLabel: string;
-  compareValue: string;
-  tone?: 'positive' | 'negative' | 'neutral';
-}
 
 interface ActivityOverviewItem {
   title: string;
   type: string;
   date: string;
 }
-
-const overviewTabs: Array<{ key: OverviewTabKey; label: string }> = [
-  { key: 'overview', label: '运行总览' },
-  { key: 'recent', label: '近期任务' },
-  { key: 'schedule', label: '调度数据' },
-];
-
-const periodOptions: Array<{ key: PeriodKey; label: string }> = [
-  { key: 'yesterday', label: '昨天' },
-  { key: '7d', label: '近7日' },
-  { key: '30d', label: '近30日' },
-];
-
-const overviewMetrics: OverviewMetric[] = [
-  {
-    label: '成功任务',
-    value: '128',
-    compareLabel: '较前7日',
-    compareValue: '+12',
-    tone: 'positive',
-  },
-  {
-    label: '运行中',
-    value: '3',
-    compareLabel: '较前7日',
-    compareValue: '+1',
-    tone: 'negative',
-  },
-  {
-    label: '失败任务',
-    value: '1',
-    compareLabel: '较前7日',
-    compareValue: '-2',
-    tone: 'positive',
-  },
-  {
-    label: '调度次数',
-    value: '162',
-    compareLabel: '较前7日',
-    compareValue: '+8',
-    tone: 'neutral',
-  },
-  {
-    label: '处理记录',
-    value: '24.8万',
-    compareLabel: '较前7日',
-    compareValue: '+6.4%',
-    tone: 'positive',
-  },
-  {
-    label: '平均耗时',
-    value: '42s',
-    compareLabel: '较前7日',
-    compareValue: '-5s',
-    tone: 'positive',
-  },
-];
 
 const activityOverviewItems: ActivityOverviewItem[] = [
   {
@@ -569,532 +333,6 @@ const activityOverviewItems: ActivityOverviewItem[] = [
 
 const pad2 = (value: number) => String(value).padStart(2, '0');
 
-const formatDate = (date: Date) =>
-  `${date.getFullYear()}.${pad2(date.getMonth() + 1)}.${pad2(date.getDate())}`;
-
-const formatAxisDate = (date: Date) =>
-  `${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
-
-function buildPeriod(periodKey: PeriodKey, reference = new Date()) {
-  const today = new Date(
-    reference.getFullYear(),
-    reference.getMonth(),
-    reference.getDate(),
-  );
-  const end = new Date(today);
-  end.setDate(today.getDate() - 1);
-
-  if (periodKey === 'yesterday') {
-    const hours = ['00:00', '04:00', '08:00', '12:00', '16:00', '20:00', '24:00'];
-    return {
-      start: end,
-      end,
-      labels: hours,
-      values: [8, 14, 11, 18, 15, 22, 17],
-    };
-  }
-
-  const count = periodKey === '30d' ? 30 : 7;
-  const start = new Date(end);
-  start.setDate(end.getDate() - (count - 1));
-
-  const days = Array.from({ length: count }, (_, index) => {
-    const current = new Date(start);
-    current.setDate(start.getDate() + index);
-    return current;
-  });
-
-  const values =
-    periodKey === '30d'
-      ? [
-          12, 13, 15, 14, 16, 18, 17, 19, 18, 21,
-          20, 22, 24, 23, 25, 24, 26, 28, 27, 29,
-          30, 28, 31, 34, 36, 35, 33, 31, 29, 27,
-        ]
-      : [18, 18, 18, 18, 20, 36, 22];
-
-  return {
-    start,
-    end,
-    labels: days.map(formatAxisDate),
-    values,
-  };
-}
-
-interface TrendChartProps {
-  values: number[];
-  labels: string[];
-  name: string;
-}
-
-function TrendChart({ values, labels, name }: TrendChartProps) {
-  const option = useMemo<EChartsOption>(
-    () => ({
-      animation: true,
-      animationDuration: 720,
-      animationDurationUpdate: 620,
-      animationEasing: 'cubicOut',
-      animationEasingUpdate: 'cubicOut',
-      grid: {
-        left: 0,
-        right: 2,
-        top: 18,
-        bottom: 26,
-        containLabel: false,
-      },
-      tooltip: {
-        trigger: 'axis',
-        confine: true,
-        appendToBody: false,
-        backgroundColor: 'rgba(255,255,255,0.98)',
-        borderColor: '#edf0f4',
-        borderWidth: 1,
-        padding: [10, 12],
-        textStyle: {
-          color: '#30333b',
-          fontSize: 12,
-        },
-        extraCssText:
-          'box-shadow:0 8px 28px rgba(31,35,41,.10);border-radius:8px;',
-        axisPointer: {
-          type: 'line',
-          lineStyle: {
-            color: '#dfe6f4',
-            width: 1,
-          },
-        },
-        formatter: (params: any) => {
-          const item = Array.isArray(params) ? params[0] : params;
-          if (!item) return '';
-          return `
-            <div style="min-width:120px">
-              <div style="font-size:12px;color:#555a64;margin-bottom:8px">${item.axisValue}</div>
-              <div style="display:flex;align-items:center;justify-content:space-between;gap:20px">
-                <span style="display:flex;align-items:center;color:#30333b;font-weight:600">
-                  <i style="display:inline-block;width:7px;height:7px;border-radius:999px;background:#5b8cff;margin-right:6px"></i>
-                  ${name}
-                </span>
-                <b style="font-size:12px;color:#30333b">${item.data}</b>
-              </div>
-            </div>
-          `;
-        },
-      },
-      xAxis: {
-        type: 'category',
-        boundaryGap: false,
-        data: labels,
-        axisTick: { show: false },
-        axisLine: { show: false },
-        axisLabel: {
-          color: '#8d929b',
-          fontSize: 11,
-          margin: 9,
-          interval: labels.length > 10 ? 4 : 0,
-          showMinLabel: true,
-          showMaxLabel: true,
-        },
-      },
-      yAxis: {
-        type: 'value',
-        min: 0,
-        max: Math.max(...values, 1) * 1.2,
-        axisTick: { show: false },
-        axisLine: { show: false },
-        axisLabel: { show: false },
-        splitLine: { show: false },
-      },
-      series: [
-        {
-          name,
-          type: 'line',
-          data: values,
-          smooth: 0.42,
-          showSymbol: false,
-          symbol: 'circle',
-          symbolSize: 6,
-          lineStyle: {
-            color: '#5b8cff',
-            width: 1.5,
-          },
-          itemStyle: {
-            color: '#5b8cff',
-            borderColor: '#ffffff',
-            borderWidth: 2,
-          },
-          areaStyle: {
-            color: {
-              type: 'linear',
-              x: 0,
-              y: 0,
-              x2: 0,
-              y2: 1,
-              colorStops: [
-                { offset: 0, color: 'rgba(91,140,255,0.18)' },
-                { offset: 1, color: 'rgba(91,140,255,0.00)' },
-              ],
-            },
-          },
-          emphasis: {
-            focus: 'series',
-            scale: true,
-          },
-        },
-      ],
-    }),
-    [labels, name, values],
-  );
-
-  return (
-    <ReactECharts
-      option={option}
-      notMerge
-      lazyUpdate
-      style={{ height: 152, width: '100%' }}
-    />
-  );
-}
-
-function LatestTaskCard() {
-  return (
-    <aside className="w-full shrink-0 lg:w-[220px] lg:border-r lg:border-[#edf0f3] lg:pr-5">
-      <div className="mb-2 text-[13px] font-semibold leading-5 text-[#353842]">
-        最新任务
-      </div>
-
-      <button
-        type="button"
-        className="group relative h-[266px] w-full overflow-hidden rounded-[10px] border border-[#e8ebef] bg-[linear-gradient(150deg,#6c737d_0%,#9197a0_48%,#c0c4ca_100%)] text-left text-white transition-[border-color,transform] duration-200 hover:-translate-y-px hover:border-[#dfe3e8] lg:w-[198px]"
-      >
-        <div className="pointer-events-none absolute inset-0 opacity-[0.18] [background-image:linear-gradient(rgba(255,255,255,.28)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.22)_1px,transparent_1px)] [background-size:22px_22px]" />
-        <div className="pointer-events-none absolute -right-9 top-10 h-32 w-32 rounded-full border border-white/20" />
-        <div className="pointer-events-none absolute -right-2 top-16 h-24 w-24 rounded-full border border-white/20" />
-
-        <div className="absolute left-4 top-3 z-10">
-          <div className="text-[12px] font-semibold text-white/95">SQL</div>
-          <div className="mt-0.5 text-[11px] text-white/80">00:42</div>
-        </div>
-
-        <Copy
-          size={14}
-          strokeWidth={1.8}
-          className="absolute right-3 top-3 z-10 text-white/90"
-        />
-
-        <div className="absolute inset-x-0 top-[50px] z-10 flex justify-center">
-          <div className="relative flex h-[122px] w-[122px] items-center justify-center">
-            <span className="absolute h-[112px] w-[112px] rounded-full border border-white/25" />
-            <span className="absolute h-[82px] w-[82px] rounded-full border border-white/18" />
-            <span className="absolute h-[52px] w-[52px] rounded-full bg-white/12 backdrop-blur-[2px]" />
-            <Database size={52} strokeWidth={1.15} className="relative text-white/95" />
-          </div>
-        </div>
-
-        <div className="absolute inset-x-0 bottom-[70px] z-10 px-4">
-          <div className="truncate text-[12px] font-medium text-white/95">
-            ods_user_profile_sync
-          </div>
-        </div>
-
-        <div className="absolute inset-x-0 bottom-0 z-10 h-[70px] bg-black/20 px-4 backdrop-blur-[12px]">
-          <div className="flex h-1/2 items-center justify-between border-b border-white/12">
-            <span className="text-[11px] text-white/78">运行次数</span>
-            <strong className="text-[12px] font-semibold">17</strong>
-          </div>
-          <div className="flex h-1/2 items-center justify-between">
-            <span className="text-[11px] text-white/78">异常</span>
-            <strong className="text-[12px] font-semibold">1</strong>
-          </div>
-        </div>
-      </button>
-    </aside>
-  );
-}
-
-function PeriodSelect({
-  value,
-  onChange,
-}: {
-  value: PeriodKey;
-  onChange: (value: PeriodKey) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const current = periodOptions.find((option) => option.key === value)!;
-
-  useEffect(() => {
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handlePointerDown);
-    return () => document.removeEventListener('mousedown', handlePointerDown);
-  }, []);
-
-  return (
-    <div ref={rootRef} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((currentOpen) => !currentOpen)}
-        className={`
-          flex h-[27px] items-center rounded-[7px] border px-2.5 text-[12px]
-          transition-colors
-          ${
-            open
-              ? 'border-[#9db7ef] bg-[#f7f9fd] text-[#454a54]'
-              : 'border-transparent bg-[#f4f5f7] text-[#5f646e] hover:bg-[#eceef2]'
-          }
-        `}
-      >
-        <span className="pr-2 text-[#727781]">时间</span>
-        <span className="mr-1.5 h-[12px] w-px bg-[#dcdfe4]" />
-        <span className="min-w-[34px] text-left font-medium text-[#4d525c]">
-          {current.label}
-        </span>
-        <ChevronDown
-          size={13}
-          strokeWidth={1.8}
-          className={`ml-1 transition-transform ${open ? 'rotate-180' : ''}`}
-        />
-      </button>
-
-      {open && (
-        <div className="absolute right-0 top-[31px] z-30 w-[116px] overflow-hidden rounded-[8px] border border-[#eceef2] bg-white py-1 shadow-[0_8px_22px_rgba(31,35,41,0.10)]">
-          {periodOptions.map((option) => {
-            const selected = option.key === value;
-            return (
-              <button
-                key={option.key}
-                type="button"
-                onClick={() => {
-                  onChange(option.key);
-                  setOpen(false);
-                }}
-                className="flex h-[34px] w-full items-center px-3 text-left text-[12px] text-[#444952] transition-colors hover:bg-[#f6f7f9]"
-              >
-                <span className="flex w-5 items-center">
-                  {selected && <Check size={14} strokeWidth={2} />}
-                </span>
-                {option.label}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function OverviewMetrics() {
-  return (
-    <div className="mt-1 grid grid-cols-2 gap-x-2 gap-y-1 sm:grid-cols-3">
-      {overviewMetrics.map((metric) => (
-        <div
-          key={metric.label}
-          className="group min-w-0 rounded-[6px] px-3 py-2 transition-colors duration-150 hover:bg-[#f7f8fa]"
-        >
-          <div className="text-[12px] font-semibold leading-5 text-[#454951]">
-            {metric.label}
-          </div>
-          <div className="mt-0.5 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-            <strong className="text-[20px] font-semibold leading-7 tracking-[-0.4px] text-[#272a33]">
-              {metric.value}
-            </strong>
-            <span className="text-[11px] text-[#989ca4]">
-              {metric.compareLabel}
-              <span
-                className={`ml-0.5 font-medium ${
-                  metric.tone === 'positive'
-                    ? 'text-[#20a464]'
-                    : metric.tone === 'negative'
-                      ? 'text-[#f04c5a]'
-                      : 'text-[#7b8089]'
-                }`}
-              >
-                {metric.compareValue}
-              </span>
-            </span>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function RecentTasksPanel() {
-  return (
-    <div className="min-h-[263px] pt-2">
-      <button
-        type="button"
-        className="group grid w-full grid-cols-[minmax(230px,1.5fr)_repeat(4,minmax(72px,.55fr))_150px] items-center gap-3 rounded-[8px] px-3 py-3 text-left transition-colors hover:bg-[#f7f8fa]"
-      >
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#edf4ff] text-[#5b8cff]">
-            <Database size={16} strokeWidth={1.9} />
-          </div>
-          <div className="min-w-0">
-            <div className="truncate text-[12px] font-medium text-[#363a43]">
-              ods_user_profile_sync
-            </div>
-            <div className="mt-1 flex items-center gap-1 text-[11px] text-[#969aa3]">
-              <Clock3 size={11} strokeWidth={1.8} />
-              今日 10:42
-            </div>
-          </div>
-        </div>
-
-        {[
-          ['运行', '17'],
-          ['成功', '16'],
-          ['失败', '1'],
-          ['耗时', '42s'],
-        ].map(([label, value]) => (
-          <div key={label} className="min-w-0">
-            <span className="text-[11px] text-[#969aa3]">{label}</span>
-            <strong className="ml-2 text-[12px] font-semibold text-[#3b3f48]">
-              {value}
-            </strong>
-          </div>
-        ))}
-
-        <div className="flex items-center justify-end gap-4">
-          <span className="text-[11px] font-medium text-[#20a464]">成功</span>
-          <span className="text-[12px] font-semibold text-[#323640] transition-colors group-hover:text-[#5b8cff]">
-            查看详情
-          </span>
-        </div>
-      </button>
-    </div>
-  );
-}
-
-function EmptySchedulePanel({ periodLabel }: { periodLabel: string }) {
-  return (
-    <div className="flex min-h-[263px] items-center justify-center pb-4">
-      <div className="text-center">
-        <div className="relative mx-auto flex h-[78px] w-[112px] items-center justify-center">
-          <span className="absolute left-[19px] top-[5px] flex h-7 w-7 items-center justify-center rounded-full bg-[#d9e7ff] text-[#4b7df3]">
-            <CircleHelp size={18} strokeWidth={2.1} />
-          </span>
-          <span className="absolute bottom-2 left-[38px] h-[40px] w-[54px] rounded-[12px] border border-[#dfe3e9] bg-[#fafbfc]" />
-          <RadioTower
-            size={45}
-            strokeWidth={1.25}
-            className="absolute bottom-[7px] right-[22px] text-[#9ba2ad]"
-          />
-        </div>
-        <div className="mt-1 text-[12px] text-[#8a8f98]">
-          {periodLabel}暂无调度数据
-        </div>
-        <div className="mt-1 text-[11px] text-[#b0b4bb]">
-          当前周期内没有可展示的调度记录
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function DataCenter() {
-  const [activeTab, setActiveTab] = useState<OverviewTabKey>('overview');
-  const [periodKey, setPeriodKey] = useState<PeriodKey>('7d');
-  const period = useMemo(() => buildPeriod(periodKey), [periodKey]);
-  const periodLabel = periodOptions.find((item) => item.key === periodKey)!.label;
-
-  return (
-    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
-      <header className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <h2 className="shrink-0 text-xl font-semibold tracking-[-0.35px] text-[#252832]">
-            数据中心
-          </h2>
-          <CircleHelp size={14} strokeWidth={1.9} className="shrink-0 text-[#a0a4ac]" />
-          <span className="ml-0.5 hidden text-[12px] leading-5 text-[#8d929b] sm:inline">
-            统计周期：{formatDate(period.start)}-{formatDate(period.end)}（每天12点更新）
-          </span>
-        </div>
-
-        <button
-          type="button"
-          className="flex items-center gap-0.5 text-[12px] text-[#666b75] transition-colors hover:text-[#252832]"
-        >
-          查看更多
-          <ChevronRight size={14} strokeWidth={1.8} />
-        </button>
-      </header>
-
-      <div className="mt-4 flex flex-col gap-5 lg:flex-row lg:gap-6">
-        <LatestTaskCard />
-
-        <div className="min-w-0 flex-1">
-          <div className="flex min-h-[35px] items-end justify-between border-b border-[#eceef2]">
-            <div className="flex items-center gap-5 sm:gap-7">
-              {overviewTabs.map((tab) => {
-                const active = activeTab === tab.key;
-                return (
-                  <button
-                    key={tab.key}
-                    type="button"
-                    onClick={() => setActiveTab(tab.key)}
-                    className={`
-                      relative h-[35px] pb-2 text-[13px] transition-colors
-                      ${
-                        active
-                          ? 'font-semibold text-[#292c35]'
-                          : 'font-normal text-[#858a93] hover:text-[#4a4f59]'
-                      }
-                    `}
-                  >
-                    {tab.label}
-                    <span
-                      className={`absolute inset-x-0 -bottom-px h-[2px] origin-center rounded-full bg-[#252832] transition-transform duration-200 ${
-                        active ? 'scale-x-100' : 'scale-x-0'
-                      }`}
-                    />
-                  </button>
-                );
-              })}
-            </div>
-
-            {activeTab !== 'recent' && (
-              <div className="mb-1.5">
-                <PeriodSelect value={periodKey} onChange={setPeriodKey} />
-              </div>
-            )}
-          </div>
-
-          {activeTab === 'overview' && (
-            <div>
-              <div className="mt-2 flex items-center justify-end gap-1.5 text-[12px] text-[#7f848e]">
-                <span className="h-2 w-2 rounded-full bg-[#5b8cff]" />
-                运行次数
-              </div>
-              <TrendChart
-                key={`trend-${periodKey}`}
-                values={period.values}
-                labels={period.labels}
-                name="运行次数"
-              />
-              <OverviewMetrics />
-            </div>
-          )}
-
-          {activeTab === 'recent' && <RecentTasksPanel />}
-
-          {activeTab === 'schedule' && (
-            <EmptySchedulePanel periodLabel={periodLabel} />
-          )}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* =========================================================
- * Activity Center
- * ========================================================= */
-
 interface CalendarCell {
   day: number | null;
   date: Date | null;
@@ -1110,26 +348,15 @@ function buildCalendarWeeks(cursor: Date): CalendarCell[][] {
 
   const cells: CalendarCell[] = Array.from({ length: 42 }, (_, index) => {
     const day = index - firstDay + 1;
-
     if (day < 1 || day > daysInMonth) {
-      return {
-        day: null,
-        date: null,
-        isToday: false,
-      };
+      return { day: null, date: null, isToday: false };
     }
-
     const date = new Date(year, month, day);
     const isToday =
-      today.getFullYear() === year &&
-      today.getMonth() === month &&
-      today.getDate() === day;
-
-    return {
-      day,
-      date,
-      isToday,
-    };
+      today.getFullYear() === year
+      && today.getMonth() === month
+      && today.getDate() === day;
+    return { day, date, isToday };
   });
 
   return Array.from({ length: 6 }, (_, weekIndex) =>
@@ -1298,7 +525,6 @@ function HomeSecondaryPanels() {
   );
 }
 
-
 /* =========================================================
  * Page
  * ========================================================= */
@@ -1311,27 +537,21 @@ export default function CreatorWorkbenchPage() {
       case 'data-source':
         // TODO 数据源管理
         break;
-
       case 'offline-sync':
         // TODO 离线同步
         break;
-
       case 'development':
         // TODO 数据开发
         break;
-
       case 'workflow':
         // TODO 工作流
         break;
-
       case 'quality':
         // TODO 数据质量
         break;
-
       case 'application':
         // TODO 数据应用
         break;
-
       default:
         break;
     }
@@ -1340,194 +560,84 @@ export default function CreatorWorkbenchPage() {
   return (
     <div
       className="
-        relative
-        min-h-screen
-        w-full
-        overflow-hidden
-        bg-[#f7f8fa]
-        text-[#242731]
+        relative min-h-screen w-full overflow-hidden bg-[#f7f8fa] text-[#242731]
       "
     >
-      {/* =====================================================
-          背景
-      ====================================================== */}
-
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        {/* 顶部基础背景 */}
         <div
           className="
-            absolute
-            inset-x-0
-            top-0
-            h-[170px]
-            bg-gradient-to-b
-            from-[#f9fafb]
-            to-transparent
+            absolute inset-x-0 top-0 h-[170px]
+            bg-gradient-to-b from-[#f9fafb] to-transparent
           "
         />
-
-        {/* 右上浅蓝 */}
         <div
           className="
-            absolute
-            -right-[60px]
-            -top-[180px]
-            h-[420px]
-            w-[76%]
+            absolute -right-[60px] -top-[180px] h-[420px] w-[76%]
             bg-[radial-gradient(ellipse_at_center,rgba(159,215,239,0.48)_0%,rgba(187,224,240,0.23)_45%,rgba(255,255,255,0)_74%)]
             blur-[12px]
           "
         />
-
-        {/* 右下浅黄 */}
         <div
           className="
-            absolute
-            -bottom-[180px]
-            -right-[160px]
-            h-[420px]
-            w-[620px]
+            absolute -bottom-[180px] -right-[160px] h-[420px] w-[620px]
             bg-[radial-gradient(circle_at_center,rgba(231,238,178,0.47),rgba(255,255,255,0)_70%)]
             blur-[16px]
           "
         />
-
-        {/* 顶部细纹理 */}
         <div
           className="
-            absolute
-            right-0
-            top-0
-            h-[118px]
-            w-[73%]
-            opacity-[0.16]
+            absolute right-0 top-0 h-[118px] w-[73%] opacity-[0.16]
             [background-image:repeating-linear-gradient(90deg,rgba(255,255,255,0.95)_0px,rgba(255,255,255,0.95)_1px,transparent_1px,transparent_5px)]
             [mask-image:linear-gradient(90deg,transparent_0%,rgba(0,0,0,0.2)_20%,rgba(0,0,0,1)_100%)]
           "
         />
       </div>
 
-      {/* =====================================================
-          Content
-      ====================================================== */}
-
       <div className="relative z-10">
-        {/* ===================================================
-            Header
-        ==================================================== */}
-
         <header className="flex h-[116px] items-center px-4">
           <div className="flex items-center">
-            {/* Avatar */}
             <div
               className="
-                flex
-                h-[66px]
-                w-[66px]
-                shrink-0
-                items-center
-                justify-center
-                overflow-hidden
-                rounded-full
-                border
-                border-white/90
-                bg-gradient-to-br
-                from-[#dde6ef]
-                via-[#a6c8e2]
-                to-[#5e93d4]
-                text-white/95
+                flex h-[66px] w-[66px] shrink-0 items-center justify-center overflow-hidden
+                rounded-full border border-white/90 bg-gradient-to-br from-[#dde6ef]
+                via-[#a6c8e2] to-[#5e93d4] text-white/95
                 shadow-[0_2px_4px_rgba(31,35,41,0.04)]
               "
             >
               <Database size={30} strokeWidth={1.5} />
             </div>
 
-            {/* Info */}
             <div className="ml-4 min-w-0">
-              {/* 第一行 */}
               <div className="flex min-h-[22px] items-center">
-                <span
-                  className="
-                    whitespace-nowrap
-                    text-sm
-                    font-medium
-                    leading-[22px]
-                    text-[#252830]
-                  "
-                >
+                <span className="whitespace-nowrap text-sm font-medium leading-[22px] text-[#252830]">
                   Yak Ops
                 </span>
-
                 <span className="mx-3 h-[14px] w-px shrink-0 bg-black/[0.14]" />
-
-                <span
-                  className="
-                    whitespace-nowrap
-                    text-sm
-                    font-normal
-                    leading-[22px]
-                    text-[#777b84]
-                  "
-                >
+                <span className="whitespace-nowrap text-sm font-normal leading-[22px] text-[#777b84]">
                   Data Operations Platform
                 </span>
-
                 <span className="mx-3 h-[14px] w-px shrink-0 bg-black/[0.14]" />
-
-                <span
-                  className="
-                    whitespace-nowrap
-                    text-sm
-                    font-normal
-                    leading-[22px]
-                    text-[#777b84]
-                  "
-                >
+                <span className="whitespace-nowrap text-sm font-normal leading-[22px] text-[#777b84]">
                   让数据接入、开发、编排、质量与消费变得更简单
                 </span>
               </div>
 
-              {/* 第二行 */}
               <div className="mt-2.5 flex items-center gap-[27px]">
-                <ProfileStat
-                  label="数据源"
-                  value={0}
-                  arrow
-                />
-
-                <ProfileStat
-                  label="运行中"
-                  value={0}
-                  arrow
-                />
-
-                <ProfileStat
-                  label="今日异常"
-                  value={0}
-                />
+                <ProfileStat label="数据源" value={0} arrow />
+                <ProfileStat label="运行中" value={0} arrow />
+                <ProfileStat label="今日异常" value={0} />
               </div>
             </div>
           </div>
         </header>
 
-        {/* ===================================================
-            Main
-        ==================================================== */}
-
         <main className="px-4 pb-4">
           <div
             className="
-              grid
-              grid-cols-1
-              gap-4
-              min-[901px]:grid-cols-[330px_minmax(0,1fr)]
+              grid grid-cols-1 gap-4 min-[901px]:grid-cols-[330px_minmax(0,1fr)]
               min-[1101px]:grid-cols-[398px_minmax(0,1fr)]
             "
           >
-            {/* =================================================
-                数据接入
-            ================================================== */}
-
             <Section title="数据接入">
               <div className="grid gap-[13px]">
                 {createItems.map((item) => (
@@ -1540,21 +650,10 @@ export default function CreatorWorkbenchPage() {
               </div>
             </Section>
 
-            {/* =================================================
-                数据工作
-            ================================================== */}
-
-            <Section
-              title="数据工作"
-              className="bg-white/[0.74]"
-            >
+            <Section title="数据工作" className="bg-white/[0.74]">
               <div
                 className="
-                  grid
-                  grid-cols-1
-                  gap-x-[14px]
-                  gap-y-[13px]
-                  sm:grid-cols-2
+                  grid grid-cols-1 gap-x-[14px] gap-y-[13px] sm:grid-cols-2
                 "
               >
                 {publishItems.map((item) => (

--- a/yak-ops-ui/src/pages/home/service.ts
+++ b/yak-ops-ui/src/pages/home/service.ts
@@ -1,0 +1,103 @@
+import type { ApiResponse } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+export type HomeDataCenterPeriod = 'yesterday' | '7d' | '30d';
+export type HomeTaskType = 'OFFLINE_SYNC' | 'WORKFLOW' | 'DATA_QUALITY';
+
+export interface HomeDataCenterPeriodView {
+  start: string;
+  end: string;
+}
+
+export interface HomeLatestTask {
+  taskId: string;
+  taskType: HomeTaskType;
+  taskName: string;
+  durationMs: number;
+  runCount: number;
+  exceptionCount: number;
+  status: string;
+  detailPath: string;
+}
+
+export interface HomeDataCenterMetrics {
+  successCount: number;
+  runningCount: number;
+  failedCount: number;
+  scheduleCount: number;
+  processedRecords: number;
+  avgDurationMs: number;
+}
+
+export interface HomeDataCenterMetricCompare {
+  successCount: number;
+  runningCount: number;
+  failedCount: number;
+  scheduleCount: number;
+  processedRecordsRate: number;
+  avgDurationMs: number;
+}
+
+export interface HomeDataCenterOverview {
+  period: HomeDataCenterPeriodView;
+  latestTask?: HomeLatestTask;
+  trend: {
+    labels: string[];
+    values: number[];
+  };
+  metrics: HomeDataCenterMetrics;
+  compare: HomeDataCenterMetricCompare;
+}
+
+export interface HomeRecentTask {
+  taskId: string;
+  taskType: HomeTaskType;
+  taskName: string;
+  lastRunTime: string;
+  runCount: number;
+  successCount: number;
+  failedCount: number;
+  lastDurationMs: number;
+  lastStatus: string;
+  detailPath: string;
+}
+
+export interface HomeRecentResponse {
+  items: HomeRecentTask[];
+}
+
+export interface HomeScheduleItem {
+  taskId: string;
+  taskType: HomeTaskType | string;
+  taskName: string;
+  cronExpression?: string;
+  status: string;
+  lastScheduleTime?: string;
+  nextScheduleTime?: string;
+  detailPath: string;
+}
+
+export interface HomeScheduleResponse {
+  period: HomeDataCenterPeriodView;
+  total: number;
+  items: HomeScheduleItem[];
+}
+
+const PREFIX = '/api/v1/home/data-center';
+
+export const homeDataCenterApi = {
+  overview: (
+    period: HomeDataCenterPeriod,
+  ): Promise<ApiResponse<HomeDataCenterOverview>> =>
+    HttpUtils.get<HomeDataCenterOverview>(
+      `${PREFIX}/overview?period=${encodeURIComponent(period)}`,
+    ),
+  recent: (): Promise<ApiResponse<HomeRecentResponse>> =>
+    HttpUtils.get<HomeRecentResponse>(`${PREFIX}/recent`),
+  schedule: (
+    period: HomeDataCenterPeriod,
+  ): Promise<ApiResponse<HomeScheduleResponse>> =>
+    HttpUtils.get<HomeScheduleResponse>(
+      `${PREFIX}/schedule?period=${encodeURIComponent(period)}`,
+    ),
+};


### PR DESCRIPTION
## Summary

- add homepage Data Center aggregation APIs for overview, recent tasks, and schedule data
- aggregate runtime data from offline sync, workflow, and data quality executions
- replace hardcoded homepage Data Center statistics with real backend data
- preserve the existing three-tab layout, ECharts trend, latest-task card, dimensions, and visual styling
- keep data-quality execution status separate from quality check result, so a completed check with failed rules is not counted as a technical task failure

## API

- `GET /api/v1/home/data-center/overview?period=7d`
- `GET /api/v1/home/data-center/recent`
- `GET /api/v1/home/data-center/schedule?period=7d`

## Metrics

- 成功任务：三类任务技术执行成功次数
- 运行中：统计周期结束时仍处于运行中的执行
- 失败任务：技术执行失败次数
- 调度次数：调度触发的执行次数
- 处理记录：离线同步成功写入记录数
- 平均耗时：已结束执行的平均耗时

## Notes

- period comparisons use the equal-sized previous period and keep the current homepage behavior of ending the statistics window at yesterday
- the Data Center implementation was extracted to `DataCenter.tsx` only to isolate data binding; the existing visual layout and three tabs are intentionally preserved
- no new execution tables were introduced; statistics are aggregated from the existing execution records

## Validation

- API contracts and existing execution-field mappings were statically reviewed end-to-end
- full Maven/TypeScript CI was not available in the connector-only execution environment, so this PR is intentionally opened as Draft for CI/review validation