### PR TITLE
feat(home): add unified schedule center

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterController.java
@@ -1,0 +1,24 @@
+package io.yak.ops.boot.home;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.boot.home.HomeScheduleCenterService.CalendarResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 首页调度中心接口。 */
+@RestController
+@RequestMapping("/api/v1/home/schedule-center")
+@RequiredArgsConstructor
+public class HomeScheduleCenterController {
+
+  private final HomeScheduleCenterService service;
+
+  @GetMapping("/calendar")
+  public Result<CalendarResponse> calendar(
+      @RequestParam(required = false) String month) {
+    return Result.success(service.calendar(month));
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterService.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterService.java
@@ -1,0 +1,381 @@
+package io.yak.ops.boot.home;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import io.yak.ops.business.quality.dao.mapper.QualityMonitorMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityMonitorSettingMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
+import io.yak.ops.common.bean.po.quality.QualityMonitorPO;
+import io.yak.ops.common.bean.po.quality.QualityMonitorSettingPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.quartz.CronExpression;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** 首页调度中心统一调度配置聚合服务。 */
+@Service
+@RequiredArgsConstructor
+public class HomeScheduleCenterService {
+
+  private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
+  private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+  private static final Set<String> WORKFLOW_ACTIVE_STATUS = Set.of("ONLINE");
+
+  private final ObjectProvider<OfflineJobDefinitionMapper> offlineDefinitionMapperProvider;
+  private final ObjectProvider<WorkflowScheduleMapper> workflowScheduleMapperProvider;
+  private final ObjectProvider<QualityMonitorSettingMapper> qualitySettingMapperProvider;
+  private final ObjectProvider<QualityMonitorMapper> qualityMonitorMapperProvider;
+
+  public CalendarResponse calendar(String monthValue) {
+    YearMonth month = resolveMonth(monthValue);
+    LocalDate monthStart = month.atDay(1);
+    LocalDate monthEnd = month.plusMonths(1).atDay(1);
+
+    List<UnifiedScheduleTask> tasks = new ArrayList<>();
+    tasks.addAll(offlineTasks());
+    tasks.addAll(workflowTasks());
+    tasks.addAll(qualityTasks());
+
+    Map<LocalDate, List<ScheduleOccurrence>> occurrencesByDay = new LinkedHashMap<>();
+    Map<String, ScheduleSummary> summariesByTask = new HashMap<>();
+
+    for (UnifiedScheduleTask task : tasks) {
+      List<ScheduleOccurrenceAt> occurrences = occurrences(task, monthStart, monthEnd);
+      if (occurrences.isEmpty()) continue;
+
+      ScheduleOccurrenceAt first = occurrences.get(0);
+      summariesByTask.put(
+          task.key(),
+          new ScheduleSummary(
+              task.taskId(),
+              task.taskType(),
+              task.taskName(),
+              task.scheduleText(),
+              first.dateTime().toLocalDate().toString(),
+              first.dateTime().format(TIME_FORMATTER),
+              task.detailPath()));
+
+      for (ScheduleOccurrenceAt occurrence : occurrences) {
+        ScheduleOccurrence item = new ScheduleOccurrence(
+            task.taskId(),
+            task.taskType(),
+            task.taskName(),
+            occurrence.dateTime().format(TIME_FORMATTER),
+            task.scheduleText(),
+            task.detailPath());
+        occurrencesByDay.computeIfAbsent(occurrence.dateTime().toLocalDate(), ignored -> new ArrayList<>())
+            .add(item);
+      }
+    }
+
+    List<DaySchedule> days = occurrencesByDay.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .map(entry -> {
+          List<ScheduleOccurrence> sorted = entry.getValue().stream()
+              .sorted(Comparator
+                  .comparing(ScheduleOccurrence::time)
+                  .thenComparing(ScheduleOccurrence::taskType)
+                  .thenComparing(ScheduleOccurrence::taskName))
+              .toList();
+          List<ScheduleOccurrence> preview = sorted.size() > 3 ? sorted.subList(0, 3) : sorted;
+          return new DaySchedule(entry.getKey().toString(), sorted.size(), preview);
+        })
+        .toList();
+
+    List<ScheduleSummary> overview = summariesByTask.values().stream()
+        .sorted(Comparator
+            .comparing(ScheduleSummary::nextRunDate)
+            .thenComparing(ScheduleSummary::nextRunTime)
+            .thenComparing(ScheduleSummary::taskName))
+        .limit(3)
+        .toList();
+
+    return new CalendarResponse(
+        month.format(MONTH_FORMATTER),
+        summariesByTask.size(),
+        days,
+        overview);
+  }
+
+  private List<UnifiedScheduleTask> offlineTasks() {
+    OfflineJobDefinitionMapper mapper = offlineDefinitionMapperProvider.getIfAvailable();
+    if (mapper == null) return List.of();
+
+    return mapper.selectList(
+            new LambdaQueryWrapper<OfflineJobDefinitionPO>()
+                .eq(OfflineJobDefinitionPO::getScheduleEnabled, true)
+                .isNotNull(OfflineJobDefinitionPO::getCronExpression))
+        .stream()
+        .filter(item -> hasText(item.getCronExpression()))
+        .map(item -> new UnifiedScheduleTask(
+            String.valueOf(item.getId()),
+            "OFFLINE_SYNC",
+            defaultText(item.getJobName(), "离线同步任务 #" + item.getId()),
+            item.getCronExpression(),
+            ZoneId.systemDefault(),
+            null,
+            null,
+            item.getCronExpression(),
+            "/sync/batch-link-up/" + item.getId() + "/detail"))
+        .toList();
+  }
+
+  private List<UnifiedScheduleTask> workflowTasks() {
+    WorkflowScheduleMapper mapper = workflowScheduleMapperProvider.getIfAvailable();
+    if (mapper == null) return List.of();
+
+    return mapper.selectList(
+            new LambdaQueryWrapper<WorkflowSchedulePO>()
+                .isNotNull(WorkflowSchedulePO::getCronExpression))
+        .stream()
+        .filter(item -> WORKFLOW_ACTIVE_STATUS.contains(normalize(item.getStatus())))
+        .filter(item -> hasText(item.getCronExpression()))
+        .map(item -> new UnifiedScheduleTask(
+            item.getId(),
+            "WORKFLOW",
+            defaultText(item.getName(), "工作流调度"),
+            item.getCronExpression(),
+            resolveZone(item.getTimezone()),
+            item.getStartTime(),
+            item.getEndTime(),
+            item.getCronExpression(),
+            "/workflow/schedules"))
+        .toList();
+  }
+
+  private List<UnifiedScheduleTask> qualityTasks() {
+    QualityMonitorSettingMapper settingMapper = qualitySettingMapperProvider.getIfAvailable();
+    QualityMonitorMapper monitorMapper = qualityMonitorMapperProvider.getIfAvailable();
+    if (settingMapper == null || monitorMapper == null) return List.of();
+
+    List<QualityMonitorSettingPO> settings = settingMapper.selectList(
+        new LambdaQueryWrapper<QualityMonitorSettingPO>()
+            .eq(QualityMonitorSettingPO::getRunMode, "SCHEDULE"));
+    if (settings.isEmpty()) return List.of();
+
+    Set<Long> monitorIds = settings.stream()
+        .map(QualityMonitorSettingPO::getMonitorId)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+    if (monitorIds.isEmpty()) return List.of();
+
+    Map<Long, QualityMonitorPO> monitors = monitorMapper.selectBatchIds(monitorIds).stream()
+        .filter(item -> Boolean.TRUE.equals(item.getEnabled()))
+        .filter(item -> !Boolean.TRUE.equals(item.getDeleted()))
+        .collect(Collectors.toMap(QualityMonitorPO::getId, item -> item, (left, right) -> left));
+
+    List<UnifiedScheduleTask> result = new ArrayList<>();
+    for (QualityMonitorSettingPO setting : settings) {
+      QualityMonitorPO monitor = monitors.get(setting.getMonitorId());
+      if (monitor == null) continue;
+      String cron = qualityCron(setting);
+      if (!hasText(cron)) continue;
+      result.add(new UnifiedScheduleTask(
+          String.valueOf(monitor.getId()),
+          "DATA_QUALITY",
+          defaultText(monitor.getMonitorName(), "数据质量任务 #" + monitor.getId()),
+          cron,
+          ZoneId.systemDefault(),
+          null,
+          null,
+          qualityScheduleText(setting),
+          "/data-quality/monitor/" + monitor.getId()));
+    }
+    return result;
+  }
+
+  private List<ScheduleOccurrenceAt> occurrences(
+      UnifiedScheduleTask task,
+      LocalDate monthStart,
+      LocalDate monthEnd) {
+    CronExpression cron;
+    try {
+      cron = new CronExpression(normalizeCron(task.cronExpression()));
+      cron.setTimeZone(TimeZone.getTimeZone(task.zoneId()));
+    } catch (Exception ignored) {
+      return List.of();
+    }
+
+    Instant lowerBound = monthStart.atStartOfDay(task.zoneId()).toInstant();
+    Instant upperBound = monthEnd.atStartOfDay(task.zoneId()).toInstant();
+    if (task.startTime() != null && task.startTime().isAfter(lowerBound)) {
+      lowerBound = task.startTime();
+    }
+    if (task.endTime() != null && task.endTime().isBefore(upperBound)) {
+      upperBound = task.endTime();
+    }
+    if (!lowerBound.isBefore(upperBound)) return List.of();
+
+    List<ScheduleOccurrenceAt> result = new ArrayList<>();
+    Date cursor = Date.from(lowerBound.minusMillis(1));
+
+    while (true) {
+      Date next = cron.getNextValidTimeAfter(cursor);
+      if (next == null) break;
+      Instant nextInstant = next.toInstant();
+      if (!nextInstant.isBefore(upperBound)) break;
+
+      LocalDateTime dateTime = LocalDateTime.ofInstant(nextInstant, task.zoneId());
+      result.add(new ScheduleOccurrenceAt(dateTime));
+
+      Instant nextDay = dateTime.toLocalDate().plusDays(1).atStartOfDay(task.zoneId()).toInstant();
+      if (!nextDay.isBefore(upperBound)) break;
+      cursor = Date.from(nextDay.minusMillis(1));
+    }
+    return result;
+  }
+
+  private String qualityCron(QualityMonitorSettingPO setting) {
+    String frequency = normalize(setting.getScheduleFrequency());
+    return switch (frequency) {
+      case "DAILY" -> dailyCron(setting.getScheduleTime());
+      case "WEEKLY" -> weeklyCron(setting.getScheduleTime(), setting.getScheduleWeekday());
+      case "CRON" -> setting.getCronExpression();
+      default -> null;
+    };
+  }
+
+  private String qualityScheduleText(QualityMonitorSettingPO setting) {
+    String frequency = normalize(setting.getScheduleFrequency());
+    return switch (frequency) {
+      case "DAILY" -> "每天 " + timeText(setting.getScheduleTime());
+      case "WEEKLY" -> "每周" + weekdayText(setting.getScheduleWeekday()) + " " + timeText(setting.getScheduleTime());
+      case "CRON" -> defaultText(setting.getCronExpression(), "Cron");
+      default -> "调度";
+    };
+  }
+
+  private String dailyCron(LocalTime time) {
+    if (time == null) return null;
+    return String.format("0 %d %d * * ?", time.getMinute(), time.getHour());
+  }
+
+  private String weeklyCron(LocalTime time, String weekday) {
+    if (time == null || !hasText(weekday)) return null;
+    return String.format(
+        "0 %d %d ? * %s",
+        time.getMinute(),
+        time.getHour(),
+        normalize(weekday));
+  }
+
+  private String normalizeCron(String expression) {
+    String normalized = expression == null ? "" : expression.trim().replaceAll("\\s+", " ");
+    int fields = normalized.isEmpty() ? 0 : normalized.split(" ").length;
+    if (fields == 5) return "0 " + normalized;
+    return normalized;
+  }
+
+  private YearMonth resolveMonth(String value) {
+    if (!hasText(value)) return YearMonth.now();
+    try {
+      return YearMonth.parse(value.trim(), MONTH_FORMATTER);
+    } catch (DateTimeParseException exception) {
+      throw new IllegalArgumentException("month 格式必须为 yyyy-MM", exception);
+    }
+  }
+
+  private ZoneId resolveZone(String value) {
+    try {
+      return hasText(value) ? ZoneId.of(value.trim()) : ZoneId.systemDefault();
+    } catch (Exception ignored) {
+      return ZoneId.systemDefault();
+    }
+  }
+
+  private String weekdayText(String value) {
+    return switch (normalize(value)) {
+      case "MON" -> "一";
+      case "TUE" -> "二";
+      case "WED" -> "三";
+      case "THU" -> "四";
+      case "FRI" -> "五";
+      case "SAT" -> "六";
+      case "SUN" -> "日";
+      default -> "";
+    };
+  }
+
+  private String timeText(LocalTime value) {
+    return value == null ? "--:--" : value.format(TIME_FORMATTER);
+  }
+
+  private String normalize(String value) {
+    return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+
+  private String defaultText(String value, String fallback) {
+    return hasText(value) ? value : fallback;
+  }
+
+  public record CalendarResponse(
+      String month,
+      long totalSchedules,
+      List<DaySchedule> days,
+      List<ScheduleSummary> overview) {}
+
+  public record DaySchedule(
+      String date,
+      int count,
+      List<ScheduleOccurrence> items) {}
+
+  public record ScheduleOccurrence(
+      String taskId,
+      String taskType,
+      String taskName,
+      String time,
+      String scheduleText,
+      String detailPath) {}
+
+  public record ScheduleSummary(
+      String taskId,
+      String taskType,
+      String taskName,
+      String scheduleText,
+      String nextRunDate,
+      String nextRunTime,
+      String detailPath) {}
+
+  private record ScheduleOccurrenceAt(LocalDateTime dateTime) {}
+
+  private record UnifiedScheduleTask(
+      String taskId,
+      String taskType,
+      String taskName,
+      String cronExpression,
+      ZoneId zoneId,
+      Instant startTime,
+      Instant endTime,
+      String scheduleText,
+      String detailPath) {
+    String key() {
+      return taskType + ":" + taskId;
+    }
+  }
+}

--- a/yak-ops-ui/src/pages/home/ScheduleCenter.tsx
+++ b/yak-ops-ui/src/pages/home/ScheduleCenter.tsx
@@ -1,0 +1,276 @@
+import { history } from '@umijs/max';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  homeScheduleCenterApi,
+  type HomeScheduleCalendar,
+  type HomeScheduleDay,
+} from './schedule-service';
+
+const pad2 = (value: number) => String(value).padStart(2, '0');
+
+interface CalendarCell {
+  day: number | null;
+  date: Date | null;
+  isToday: boolean;
+}
+
+function buildCalendarWeeks(cursor: Date): CalendarCell[][] {
+  const year = cursor.getFullYear();
+  const month = cursor.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const today = new Date();
+
+  const cells: CalendarCell[] = Array.from({ length: 42 }, (_, index) => {
+    const day = index - firstDay + 1;
+    if (day < 1 || day > daysInMonth) {
+      return { day: null, date: null, isToday: false };
+    }
+    const date = new Date(year, month, day);
+    const isToday =
+      today.getFullYear() === year
+      && today.getMonth() === month
+      && today.getDate() === day;
+    return { day, date, isToday };
+  });
+
+  return Array.from({ length: 6 }, (_, weekIndex) =>
+    cells.slice(weekIndex * 7, weekIndex * 7 + 7),
+  );
+}
+
+const formatDateKey = (date: Date) =>
+  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+
+const taskTypeLabel = (taskType: string) => {
+  if (taskType === 'OFFLINE_SYNC') return '同步';
+  if (taskType === 'WORKFLOW') return '工作流';
+  if (taskType === 'DATA_QUALITY') return '质量';
+  return '任务';
+};
+
+const tooltipPosition = (index: number) => {
+  if (index <= 1) return 'left-0';
+  if (index >= 5) return 'right-0';
+  return 'left-1/2 -translate-x-1/2';
+};
+
+function CalendarWeek({
+  cells,
+  scheduleMap,
+}: {
+  cells: CalendarCell[];
+  scheduleMap: Map<string, HomeScheduleDay>;
+}) {
+  return (
+    <div className="relative grid h-[39px] grid-cols-7 items-center">
+      {cells.map((cell, index) => {
+        const schedule = cell.date ? scheduleMap.get(formatDateKey(cell.date)) : undefined;
+        return (
+          <div
+            key={`${cell.day ?? 'empty'}-${index}`}
+            className="group relative flex h-full items-center justify-center text-[12px] text-[#353943]"
+          >
+            {cell.day && (
+              <>
+                <span
+                  className={`
+                    flex h-7 min-w-7 items-center justify-center rounded-full px-1
+                    ${cell.isToday ? 'bg-[#eef4ff] font-semibold text-[#356fe8]' : ''}
+                  `}
+                >
+                  {pad2(cell.day)}
+                </span>
+
+                {schedule && schedule.count > 0 && (
+                  <>
+                    <span className="pointer-events-none absolute bottom-0 h-[3px] w-4 rounded-full bg-[#bfd3ff]" />
+                    <div
+                      className={`
+                        absolute top-[36px] z-40 hidden w-[214px] rounded-[9px]
+                        border border-[#eceef2] bg-white px-3 py-2.5 text-left
+                        shadow-[0_10px_28px_rgba(31,35,41,0.12)] group-hover:block
+                        ${tooltipPosition(index)}
+                      `}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <strong className="text-[12px] font-semibold text-[#343842]">
+                          {cell.date ? `${cell.date.getMonth() + 1}月${cell.day}日` : ''}
+                        </strong>
+                        <span className="text-[11px] text-[#8f949d]">
+                          {schedule.count} 个任务
+                        </span>
+                      </div>
+
+                      <div className="mt-2 space-y-1.5">
+                        {schedule.items.map((item) => (
+                          <div
+                            key={`${item.taskType}-${item.taskId}`}
+                            className="flex min-w-0 items-center gap-2"
+                          >
+                            <span className="w-[36px] shrink-0 text-[10px] font-medium text-[#6e7480]">
+                              {item.time}
+                            </span>
+                            <span className="min-w-0 flex-1 truncate text-[11px] text-[#454a54]">
+                              {item.taskName}
+                            </span>
+                            <span className="shrink-0 text-[10px] text-[#969ba4]">
+                              {taskTypeLabel(item.taskType)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+
+                      {schedule.count > schedule.items.length && (
+                        <div className="mt-2 border-t border-[#f0f1f3] pt-2 text-[10px] text-[#9ca1a9]">
+                          还有 {schedule.count - schedule.items.length} 个任务
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function ScheduleCenter() {
+  const now = useMemo(() => new Date(), []);
+  const [cursor, setCursor] = useState(
+    () => new Date(now.getFullYear(), now.getMonth(), 1),
+  );
+  const [calendar, setCalendar] = useState<HomeScheduleCalendar>();
+
+  const weeks = useMemo(() => buildCalendarWeeks(cursor), [cursor]);
+  const monthKey = `${cursor.getFullYear()}-${pad2(cursor.getMonth() + 1)}`;
+  const monthLabel = `${cursor.getFullYear()}年${pad2(cursor.getMonth() + 1)}月`;
+  const scheduleMap = useMemo(
+    () => new Map((calendar?.days || []).map((item) => [item.date, item])),
+    [calendar?.days],
+  );
+
+  useEffect(() => {
+    let active = true;
+    homeScheduleCenterApi.calendar(monthKey)
+      .then((response) => {
+        if (active) setCalendar(response.data);
+      })
+      .catch(() => {
+        if (active) setCalendar(undefined);
+      });
+    return () => {
+      active = false;
+    };
+  }, [monthKey]);
+
+  const moveMonth = (offset: number) => {
+    setCursor(
+      (current) =>
+        new Date(current.getFullYear(), current.getMonth() + offset, 1),
+    );
+  };
+
+  return (
+    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <header className="flex items-start justify-between gap-4">
+        <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+          调度中心
+        </h2>
+
+        <div className="flex flex-col items-end gap-2">
+          <button
+            type="button"
+            className="flex items-center gap-0.5 text-[12px] text-[#666b75] transition-colors hover:text-[#252832]"
+          >
+            查看更多
+            <ChevronRight size={14} strokeWidth={1.8} />
+          </button>
+          <span className="flex items-center gap-1.5 text-[11px] text-[#8b9099]">
+            <span className="h-2 w-2 rounded-full bg-[#5b8cff]" />
+            已配置调度
+          </span>
+        </div>
+      </header>
+
+      <div className="mt-4">
+        <div className="flex items-center justify-center gap-2">
+          <button
+            type="button"
+            onClick={() => moveMonth(-1)}
+            className="flex h-7 w-7 items-center justify-center rounded-full text-[#91959d] transition-colors hover:bg-[#f5f6f8] hover:text-[#4a4f58]"
+            aria-label="上个月"
+          >
+            <ChevronLeft size={16} strokeWidth={1.8} />
+          </button>
+
+          <div className="min-w-[112px] text-center text-[14px] font-semibold text-[#333741]">
+            {monthLabel}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => moveMonth(1)}
+            className="flex h-7 w-7 items-center justify-center rounded-full text-[#91959d] transition-colors hover:bg-[#f5f6f8] hover:text-[#4a4f58]"
+            aria-label="下个月"
+          >
+            <ChevronRight size={16} strokeWidth={1.8} />
+          </button>
+        </div>
+
+        <div className="mt-2 grid grid-cols-7 text-center text-[11px] text-[#6d727c]">
+          {['日', '一', '二', '三', '四', '五', '六'].map((day) => (
+            <span key={day}>{day}</span>
+          ))}
+        </div>
+
+        <div className="mt-1">
+          {weeks.map((week, index) => (
+            <CalendarWeek key={index} cells={week} scheduleMap={scheduleMap} />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 border-t border-[#eef0f3] pt-4">
+        <div className="flex items-center justify-between">
+          <strong className="text-[13px] font-semibold text-[#3c4049]">
+            {cursor.getMonth() + 1}月调度总览
+          </strong>
+          <span className="text-[11px] text-[#999da5]">
+            共{calendar?.totalSchedules ?? 0}个调度配置
+          </span>
+        </div>
+
+        <div className="mt-2.5 space-y-2">
+          {(calendar?.overview || []).map((item) => (
+            <button
+              key={`${item.taskType}-${item.taskId}`}
+              type="button"
+              onClick={() => item.detailPath && history.push(item.detailPath)}
+              className="group flex w-full items-center gap-2 text-left"
+            >
+              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#5b8cff]" />
+              <span className="min-w-0 flex-1 truncate text-[12px] text-[#464a53] transition-colors group-hover:text-[#252832]">
+                {item.taskName}
+              </span>
+              <span className="shrink-0 rounded border border-[#eceef2] px-1.5 py-0.5 text-[10px] leading-4 text-[#8d929a]">
+                {taskTypeLabel(item.taskType)}
+              </span>
+              <span className="w-[74px] shrink-0 text-right text-[10px] text-[#9da1a8]">
+                {item.nextRunDate.slice(5)} {item.nextRunTime}
+              </span>
+            </button>
+          ))}
+
+          {calendar && calendar.overview.length === 0 && (
+            <div className="py-1 text-[11px] text-[#a0a4ac]">本月暂无调度配置</div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/index.tsx
+++ b/yak-ops-ui/src/pages/home/index.tsx
@@ -1,15 +1,15 @@
 import {
   ArrowRightLeft,
   BarChart3,
-  ChevronLeft,
   ChevronRight,
   Code2,
   Database,
   ShieldCheck,
   Workflow,
 } from 'lucide-react';
-import { useMemo, useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import DataCenter from './DataCenter';
+import ScheduleCenter from './ScheduleCenter';
 
 /* =========================================================
  * Types
@@ -304,215 +304,6 @@ function Section({ title, children, className = '' }: SectionProps) {
 }
 
 /* =========================================================
- * Activity Center
- * ========================================================= */
-
-interface ActivityOverviewItem {
-  title: string;
-  type: string;
-  date: string;
-}
-
-const activityOverviewItems: ActivityOverviewItem[] = [
-  {
-    title: '数据源连接巡检',
-    type: '数据源',
-    date: '08-01~08-31',
-  },
-  {
-    title: '离线同步任务周巡检',
-    type: '集成',
-    date: '08-10~08-16',
-  },
-  {
-    title: '数据质量规则扫描',
-    type: '质量',
-    date: '08-17~08-23',
-  },
-];
-
-const pad2 = (value: number) => String(value).padStart(2, '0');
-
-interface CalendarCell {
-  day: number | null;
-  date: Date | null;
-  isToday: boolean;
-}
-
-function buildCalendarWeeks(cursor: Date): CalendarCell[][] {
-  const year = cursor.getFullYear();
-  const month = cursor.getMonth();
-  const firstDay = new Date(year, month, 1).getDay();
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  const today = new Date();
-
-  const cells: CalendarCell[] = Array.from({ length: 42 }, (_, index) => {
-    const day = index - firstDay + 1;
-    if (day < 1 || day > daysInMonth) {
-      return { day: null, date: null, isToday: false };
-    }
-    const date = new Date(year, month, day);
-    const isToday =
-      today.getFullYear() === year
-      && today.getMonth() === month
-      && today.getDate() === day;
-    return { day, date, isToday };
-  });
-
-  return Array.from({ length: 6 }, (_, weekIndex) =>
-    cells.slice(weekIndex * 7, weekIndex * 7 + 7),
-  );
-}
-
-function CalendarWeek({ cells }: { cells: CalendarCell[] }) {
-  const activeIndexes = cells
-    .map((cell, index) => (cell.day ? index : -1))
-    .filter((index) => index >= 0);
-  const start = activeIndexes[0];
-  const end = activeIndexes[activeIndexes.length - 1];
-
-  return (
-    <div className="relative grid h-[39px] grid-cols-7 items-center">
-      {cells.map((cell, index) => (
-        <div
-          key={`${cell.day ?? 'empty'}-${index}`}
-          className="relative flex h-full items-center justify-center text-[12px] text-[#353943]"
-        >
-          {cell.day && (
-            <span
-              className={`
-                flex h-7 min-w-7 items-center justify-center rounded-full px-1
-                ${cell.isToday ? 'bg-[#eef4ff] font-semibold text-[#356fe8]' : ''}
-              `}
-            >
-              {pad2(cell.day)}
-            </span>
-          )}
-        </div>
-      ))}
-
-      {start !== undefined && end !== undefined && (
-        <span
-          className="pointer-events-none absolute bottom-0 h-[3px] rounded-full bg-[#bfd3ff]"
-          style={{
-            left: `calc(${(start / 7) * 100}% + 8px)`,
-            width: `calc(${((end - start + 1) / 7) * 100}% - 16px)`,
-          }}
-        />
-      )}
-    </div>
-  );
-}
-
-function ActivityCenter() {
-  const now = useMemo(() => new Date(), []);
-  const [cursor, setCursor] = useState(
-    () => new Date(now.getFullYear(), now.getMonth(), 1),
-  );
-  const weeks = useMemo(() => buildCalendarWeeks(cursor), [cursor]);
-  const monthLabel = `${cursor.getFullYear()}年${pad2(cursor.getMonth() + 1)}月`;
-
-  const moveMonth = (offset: number) => {
-    setCursor(
-      (current) =>
-        new Date(current.getFullYear(), current.getMonth() + offset, 1),
-    );
-  };
-
-  return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
-      <header className="flex items-start justify-between gap-4">
-        <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
-          活动中心
-        </h2>
-
-        <div className="flex flex-col items-end gap-2">
-          <button
-            type="button"
-            className="flex items-center gap-0.5 text-[12px] text-[#666b75] transition-colors hover:text-[#252832]"
-          >
-            查看更多
-            <ChevronRight size={14} strokeWidth={1.8} />
-          </button>
-          <span className="flex items-center gap-1.5 text-[11px] text-[#8b9099]">
-            <span className="h-2 w-2 rounded-full bg-[#5b8cff]" />
-            进行中
-          </span>
-        </div>
-      </header>
-
-      <div className="mt-4">
-        <div className="flex items-center justify-center gap-2">
-          <button
-            type="button"
-            onClick={() => moveMonth(-1)}
-            className="flex h-7 w-7 items-center justify-center rounded-full text-[#91959d] transition-colors hover:bg-[#f5f6f8] hover:text-[#4a4f58]"
-            aria-label="上个月"
-          >
-            <ChevronLeft size={16} strokeWidth={1.8} />
-          </button>
-
-          <div className="min-w-[112px] text-center text-[14px] font-semibold text-[#333741]">
-            {monthLabel}
-          </div>
-
-          <button
-            type="button"
-            onClick={() => moveMonth(1)}
-            className="flex h-7 w-7 items-center justify-center rounded-full text-[#91959d] transition-colors hover:bg-[#f5f6f8] hover:text-[#4a4f58]"
-            aria-label="下个月"
-          >
-            <ChevronRight size={16} strokeWidth={1.8} />
-          </button>
-        </div>
-
-        <div className="mt-2 grid grid-cols-7 text-center text-[11px] text-[#6d727c]">
-          {['日', '一', '二', '三', '四', '五', '六'].map((day) => (
-            <span key={day}>{day}</span>
-          ))}
-        </div>
-
-        <div className="mt-1">
-          {weeks.map((week, index) => (
-            <CalendarWeek key={index} cells={week} />
-          ))}
-        </div>
-      </div>
-
-      <div className="mt-4 border-t border-[#eef0f3] pt-4">
-        <div className="flex items-center justify-between">
-          <strong className="text-[13px] font-semibold text-[#3c4049]">
-            {cursor.getMonth() + 1}月活动总览
-          </strong>
-          <span className="text-[11px] text-[#999da5]">共9个进行中</span>
-        </div>
-
-        <div className="mt-2.5 space-y-2">
-          {activityOverviewItems.map((item) => (
-            <button
-              key={item.title}
-              type="button"
-              className="group flex w-full items-center gap-2 text-left"
-            >
-              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#5b8cff]" />
-              <span className="min-w-0 flex-1 truncate text-[12px] text-[#464a53] transition-colors group-hover:text-[#252832]">
-                {item.title}
-              </span>
-              <span className="shrink-0 rounded border border-[#eceef2] px-1.5 py-0.5 text-[10px] leading-4 text-[#8d929a]">
-                {item.type}
-              </span>
-              <span className="w-[74px] shrink-0 text-right text-[10px] text-[#9da1a8]">
-                {item.date}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* =========================================================
  * Home secondary panels
  * ========================================================= */
 
@@ -520,7 +311,7 @@ function HomeSecondaryPanels() {
   return (
     <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_410px]">
       <DataCenter />
-      <ActivityCenter />
+      <ScheduleCenter />
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/home/schedule-service.ts
+++ b/yak-ops-ui/src/pages/home/schedule-service.ts
@@ -1,0 +1,44 @@
+import type { ApiResponse } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+import type { HomeTaskType } from './service';
+
+export interface HomeScheduleOccurrence {
+  taskId: string;
+  taskType: HomeTaskType;
+  taskName: string;
+  time: string;
+  scheduleText: string;
+  detailPath: string;
+}
+
+export interface HomeScheduleDay {
+  date: string;
+  count: number;
+  items: HomeScheduleOccurrence[];
+}
+
+export interface HomeScheduleSummary {
+  taskId: string;
+  taskType: HomeTaskType;
+  taskName: string;
+  scheduleText: string;
+  nextRunDate: string;
+  nextRunTime: string;
+  detailPath: string;
+}
+
+export interface HomeScheduleCalendar {
+  month: string;
+  totalSchedules: number;
+  days: HomeScheduleDay[];
+  overview: HomeScheduleSummary[];
+}
+
+const PREFIX = '/api/v1/home/schedule-center';
+
+export const homeScheduleCenterApi = {
+  calendar: (month: string): Promise<ApiResponse<HomeScheduleCalendar>> =>
+    HttpUtils.get<HomeScheduleCalendar>(
+      `${PREFIX}/calendar?month=${encodeURIComponent(month)}`,
+    ),
+};


### PR DESCRIPTION
## Summary

- rename the homepage Activity Center to Schedule Center without changing the existing card/grid layout
- aggregate schedule configurations from offline sync, workflow, and data quality into one calendar API
- mark dates that contain scheduled tasks and show a hover preview with the task count and first 3 tasks
- replace the hardcoded monthly activity overview with a real unified schedule overview
- keep the current month navigation, calendar dimensions, bottom summary layout, spacing, and visual style intact

## API

- `GET /api/v1/home/schedule-center/calendar?month=2026-08`

## Unified schedule sources

- Offline sync: enabled job definitions with schedule configuration
- Workflow: `ONLINE` workflow schedules
- Data quality: enabled monitors with `runMode=SCHEDULE`

## Calendar semantics

- each date counts distinct scheduled task configurations, not the raw number of cron trigger occurrences
- if one task triggers multiple times on the same day, it counts as one task and the preview shows its first trigger time for that day
- hover preview returns the total task count and up to the first 3 tasks for the date
- the monthly overview shows the first 3 configured tasks ordered by their first run in the selected month

## UI scope

- no homepage column/layout redesign
- no calendar size changes
- no changes to the Data Center three-tab design
- the hover panel is an absolute overlay, so it does not expand the card or shift surrounding content

## Validation

- rebased directly onto the merged Data Center PR state on `main`
- branch contains one focused functional commit and 5 expected changed files
- statically reviewed schedule status/field mappings and frontend API binding
- no commit status checks are currently reported for the branch, so this PR remains Draft for review/CI validation