### PR TITLE
feat: connect offline sync scheduling to Yak Schedule

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -21,6 +21,23 @@ yak:
 
 不再提供客户端管理、Connector 管理、多 Worker 调度、能力匹配、Preflight、动态注册和告警投递。
 
+## 调度边界
+
+任务级 Cron 时间触发统一交给 Yak Framework Schedule：
+
+```text
+Offline Job Definition
+  -> OfflineScheduleEngineBridge
+  -> Yak Schedule / Quartz
+  -> OfflineScheduleHandler
+  -> OfflineExecutionOrchestrator
+  -> Link-Up
+```
+
+`yak_offline_job_definition` 仍是调度配置的事实来源；Yak Schedule 只负责“什么时候触发”。应用启动后会根据业务表恢复计划，并处理一次持久化的 missed trigger。
+
+Link-Up 运行状态对账和业务失败重试仍由 `OfflineExecutionReconciler` 负责。这属于执行生命周期，不属于任务 Cron 调度，因此继续保留独立的短周期对账。
+
 ## 工程分层
 
 离线同步遵循 Yak Ops 统一业务模块边界：

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-schedule-api</artifactId>
+            <version>${yak-framework.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridge.java
@@ -1,0 +1,120 @@
+package io.yak.ops.business.sync.offline.schedule;
+
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleKey;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.framework.schedule.api.SchedulePolicy;
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import io.yak.framework.schedule.api.ScheduleTarget;
+import io.yak.framework.schedule.api.ScheduleTrigger;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 离线同步业务调度到 Yak Framework ScheduleManager 的适配层。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineScheduleEngineBridge {
+  static final String NAMESPACE = "yak-ops-offline-sync";
+  static final String HANDLER = "offlineSyncScheduleHandler";
+
+  private final ObjectProvider<ScheduleManager> scheduleManagers;
+
+  public OfflineScheduleEngineBridge(ObjectProvider<ScheduleManager> scheduleManagers) {
+    this.scheduleManagers = scheduleManagers;
+  }
+
+  public boolean available() {
+    return scheduleManagers.getIfAvailable() != null;
+  }
+
+  public ScheduleSnapshot save(OfflineJobDefinition definition, OfflineSchedule schedule) {
+    return manager().save(toDefinition(definition, schedule));
+  }
+
+  public Optional<ScheduleSnapshot> snapshot(long definitionId) {
+    ScheduleManager manager = scheduleManagers.getIfAvailable();
+    return manager == null ? Optional.empty() : manager.get(key(definitionId));
+  }
+
+  public List<ScheduleSnapshot> list() {
+    ScheduleManager manager = scheduleManagers.getIfAvailable();
+    return manager == null ? List.of() : manager.list(NAMESPACE);
+  }
+
+  public void pauseIfPresent(long definitionId) {
+    ScheduleManager manager = scheduleManagers.getIfAvailable();
+    if (manager == null) return;
+    ScheduleKey key = key(definitionId);
+    if (manager.get(key).isPresent()) manager.pause(key);
+  }
+
+  public void deleteIfPresent(long definitionId) {
+    ScheduleManager manager = scheduleManagers.getIfAvailable();
+    if (manager == null) return;
+    ScheduleKey key = key(definitionId);
+    if (manager.get(key).isPresent()) manager.delete(key);
+  }
+
+  public void runNowIfPresent(long definitionId) {
+    ScheduleManager manager = scheduleManagers.getIfAvailable();
+    if (manager == null) return;
+    ScheduleKey key = key(definitionId);
+    if (manager.get(key).isPresent()) manager.runNow(key);
+  }
+
+  ScheduleDefinition toDefinition(OfflineJobDefinition definition, OfflineSchedule schedule) {
+    if (definition == null || definition.getId() == null || definition.getId() <= 0L) {
+      throw new IllegalArgumentException("离线同步任务不能为空");
+    }
+    if (schedule == null || !StringUtils.hasText(schedule.cronExpression())) {
+      throw new IllegalArgumentException("离线同步任务未配置 Cron 调度");
+    }
+
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("definitionId", definition.getId());
+
+    Map<String, String> metadata = new LinkedHashMap<>();
+    metadata.put("source", "yak-ops");
+    metadata.put("definitionId", String.valueOf(definition.getId()));
+    put(metadata, "mode", definition.getMode());
+    put(metadata, "sourceType", definition.getSourceType());
+    put(metadata, "sinkType", definition.getSinkType());
+
+    boolean enabled = "ONLINE".equalsIgnoreCase(definition.getReleaseState()) && schedule.enabled();
+    return new ScheduleDefinition(
+        key(definition.getId()),
+        definition.getJobName(),
+        ScheduleTrigger.cron(schedule.cronExpression(), ZoneId.systemDefault()),
+        new ScheduleTarget(HANDLER, payload),
+        SchedulePolicy.defaults(),
+        enabled,
+        metadata);
+  }
+
+  private ScheduleKey key(long definitionId) {
+    if (definitionId <= 0L) throw new IllegalArgumentException("离线同步任务 ID 不合法");
+    return new ScheduleKey(NAMESPACE, String.valueOf(definitionId));
+  }
+
+  private ScheduleManager manager() {
+    ScheduleManager manager = scheduleManagers.getIfAvailable();
+    if (manager == null) {
+      throw new IllegalStateException(
+          "Yak ScheduleManager 不可用，请确认 yak-schedule-core、调度引擎插件与 yak.schedule.enabled 配置");
+    }
+    return manager;
+  }
+
+  private void put(Map<String, String> metadata, String key, String value) {
+    if (StringUtils.hasText(value)) metadata.put(key, value);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
@@ -1,0 +1,73 @@
+package io.yak.ops.business.sync.offline.schedule;
+
+import io.yak.framework.schedule.api.ScheduleExecutionContext;
+import io.yak.framework.schedule.api.ScheduleExecutionResult;
+import io.yak.framework.schedule.api.ScheduleHandler;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.service.OfflineExecutionOrchestrator;
+import org.springframework.stereotype.Component;
+
+/** Yak Schedule 离线同步 Handler：到点后统一进入现有 Offline Execution 执行链。 */
+@ConditionalOnOfflineSyncEnabled
+@Component(OfflineScheduleEngineBridge.HANDLER)
+public class OfflineScheduleHandler implements ScheduleHandler {
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineScheduleRepository scheduleRepository;
+  private final OfflineExecutionOrchestrator orchestrator;
+  private final OfflineScheduleEngineBridge engine;
+  private final OfflineScheduleLifecycle lifecycle;
+
+  public OfflineScheduleHandler(
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineJobExecutionRepository executionRepository,
+      OfflineScheduleRepository scheduleRepository,
+      OfflineExecutionOrchestrator orchestrator,
+      OfflineScheduleEngineBridge engine,
+      OfflineScheduleLifecycle lifecycle) {
+    this.definitionRepository = definitionRepository;
+    this.executionRepository = executionRepository;
+    this.scheduleRepository = scheduleRepository;
+    this.orchestrator = orchestrator;
+    this.engine = engine;
+    this.lifecycle = lifecycle;
+  }
+
+  @Override
+  public ScheduleExecutionResult execute(ScheduleExecutionContext context) {
+    long definitionId = context.requiredLong("definitionId");
+    OfflineJobDefinition definition = definitionRepository.findById(definitionId).orElse(null);
+    if (definition == null) {
+      engine.deleteIfPresent(definitionId);
+      return ScheduleExecutionResult.accepted(null, "离线同步任务已删除，清理残留调度计划");
+    }
+
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
+    if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())
+        || schedule == null
+        || !schedule.enabled()) {
+      lifecycle.sync(definitionId);
+      return ScheduleExecutionResult.accepted(null, "离线同步任务未启用调度，本次触发忽略");
+    }
+
+    if (executionRepository.hasActiveExecution(definitionId)) {
+      lifecycle.refreshRuntimeState(definitionId, context.actualFireTime());
+      return ScheduleExecutionResult.accepted(null, "任务已有运行实例，本次调度触发跳过");
+    }
+
+    try {
+      OfflineJobExecution execution = orchestrator.execute(definitionId, "SCHEDULE", null, 1);
+      return ScheduleExecutionResult.accepted(
+          execution.getId() == null ? null : String.valueOf(execution.getId()),
+          "离线同步任务已提交 Link-Up 执行");
+    } finally {
+      lifecycle.refreshRuntimeState(definitionId, context.actualFireTime());
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleLifecycle.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleLifecycle.java
@@ -1,0 +1,87 @@
+package io.yak.ops.business.sync.offline.schedule;
+
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import io.yak.framework.schedule.api.ScheduleStatus;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** 离线同步调度生命周期：业务定义表为事实来源，Yak Schedule 只负责时间触发。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineScheduleLifecycle {
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineScheduleRepository scheduleRepository;
+  private final OfflineScheduleEngineBridge engine;
+
+  public OfflineScheduleLifecycle(
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineScheduleRepository scheduleRepository,
+      OfflineScheduleEngineBridge engine) {
+    this.definitionRepository = definitionRepository;
+    this.scheduleRepository = scheduleRepository;
+    this.engine = engine;
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public void sync(long definitionId) {
+    OfflineJobDefinition definition = definitionRepository.findById(definitionId).orElse(null);
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
+    if (definition == null) {
+      engine.deleteIfPresent(definitionId);
+      return;
+    }
+
+    if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())
+        || schedule == null
+        || !schedule.enabled()
+        || !StringUtils.hasText(schedule.cronExpression())) {
+      engine.deleteIfPresent(definitionId);
+      if (schedule != null) {
+        scheduleRepository.updateRuntimeState(definitionId, schedule.lastFireTime(), null);
+      }
+      return;
+    }
+
+    ScheduleSnapshot snapshot = engine.save(definition, schedule);
+    scheduleRepository.updateRuntimeState(
+        definitionId,
+        schedule.lastFireTime(),
+        local(snapshot.nextFireTime()));
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public void refreshRuntimeState(long definitionId, Instant actualFireTime) {
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
+    if (schedule == null) return;
+
+    LocalDateTime last = actualFireTime == null ? schedule.lastFireTime() : local(actualFireTime);
+    LocalDateTime next = engine.snapshot(definitionId)
+        .filter(snapshot -> snapshot.status() == ScheduleStatus.ENABLED)
+        .map(ScheduleSnapshot::nextFireTime)
+        .map(this::local)
+        .orElse(null);
+    scheduleRepository.updateRuntimeState(definitionId, last, next);
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public void remove(long definitionId) {
+    engine.deleteIfPresent(definitionId);
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
+    if (schedule != null) {
+      scheduleRepository.updateRuntimeState(definitionId, schedule.lastFireTime(), null);
+    }
+  }
+
+  private LocalDateTime local(Instant instant) {
+    return instant == null ? null : LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleReconciler.java
@@ -1,0 +1,118 @@
+package io.yak.ops.business.sync.offline.schedule;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 应用启动后以离线同步业务表为事实来源恢复 Yak Schedule 计划。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineScheduleReconciler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OfflineScheduleReconciler.class);
+
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineScheduleRepository scheduleRepository;
+  private final OfflineScheduleEngineBridge engine;
+  private final OfflineScheduleLifecycle lifecycle;
+
+  public OfflineScheduleReconciler(
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineScheduleRepository scheduleRepository,
+      OfflineScheduleEngineBridge engine,
+      OfflineScheduleLifecycle lifecycle) {
+    this.definitionRepository = definitionRepository;
+    this.scheduleRepository = scheduleRepository;
+    this.engine = engine;
+    this.lifecycle = lifecycle;
+  }
+
+  @Order(40)
+  @EventListener(ApplicationReadyEvent.class)
+  public void reconcile() {
+    if (!engine.available()) {
+      LOGGER.warn("[offline-schedule] Yak ScheduleManager unavailable, skip startup reconcile");
+      return;
+    }
+
+    Map<Long, OfflineSchedule> active = activeSchedules();
+    engine.list().forEach(snapshot -> {
+      long definitionId;
+      try {
+        definitionId = Long.parseLong(snapshot.definition().key().name());
+      } catch (NumberFormatException exception) {
+        return;
+      }
+      if (!active.containsKey(definitionId)) {
+        try {
+          engine.deleteIfPresent(definitionId);
+        } catch (RuntimeException exception) {
+          LOGGER.warn(
+              "[offline-schedule] stale schedule cleanup failed definition={}, message={}",
+              definitionId,
+              exception.getMessage());
+        }
+      }
+    });
+
+    LocalDateTime now = LocalDateTime.now();
+    active.forEach((definitionId, schedule) -> {
+      LocalDateTime persistedNextFireTime = schedule.nextFireTime();
+      try {
+        lifecycle.sync(definitionId);
+        LOGGER.info("[offline-schedule] reconciled definition={}", definitionId);
+      } catch (RuntimeException exception) {
+        LOGGER.error(
+            "[offline-schedule] reconcile failed definition={}, message={}",
+            definitionId,
+            exception.getMessage(),
+            exception);
+        return;
+      }
+
+      if (persistedNextFireTime != null && !persistedNextFireTime.isAfter(now)) {
+        try {
+          engine.runNowIfPresent(definitionId);
+          LOGGER.info(
+              "[offline-schedule] recovered missed trigger definition={}, planned={}",
+              definitionId,
+              persistedNextFireTime);
+        } catch (RuntimeException exception) {
+          LOGGER.warn(
+              "[offline-schedule] missed trigger recovery skipped definition={}, planned={}, message={}",
+              definitionId,
+              persistedNextFireTime,
+              exception.getMessage());
+        }
+      }
+    });
+  }
+
+  private Map<Long, OfflineSchedule> activeSchedules() {
+    Map<Long, OfflineSchedule> result = new LinkedHashMap<>();
+    for (OfflineSchedule schedule : scheduleRepository.findAllSchedules()) {
+      if (schedule == null
+          || schedule.jobDefinitionId() == null
+          || !schedule.enabled()
+          || !StringUtils.hasText(schedule.cronExpression())) {
+        continue;
+      }
+      OfflineJobDefinition definition = definitionRepository.findById(schedule.jobDefinitionId()).orElse(null);
+      if (definition != null && "ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
+        result.put(schedule.jobDefinitionId(), schedule);
+      }
+    }
+    return result;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleLifecycle;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.DraftDefinition;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.PreparedDefinition;
 import io.yak.ops.business.sync.offline.service.support.OfflineScheduleSupport;
@@ -34,6 +35,7 @@ public class OfflineJobDefinitionService {
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineDefinitionSupport support;
   private final OfflineScheduleSupport scheduleSupport;
+  private final OfflineScheduleLifecycle scheduleLifecycle;
   private final OfflineSyncViewMapper viewMapper;
   private final AtomicLong idSequence = new AtomicLong(System.currentTimeMillis() * 1000L);
 
@@ -83,6 +85,7 @@ public class OfflineJobDefinitionService {
     if (existing == null) definitionRepository.insert(definition); else definitionRepository.update(definition);
     scheduleRepository.saveSchedule(
         scheduleSupport.prepare(id, draft.getRequest().get("schedule")));
+    scheduleLifecycle.sync(id);
     return id;
   }
 
@@ -122,6 +125,7 @@ public class OfflineJobDefinitionService {
     if (existing == null) definitionRepository.insert(definition); else definitionRepository.update(definition);
     scheduleRepository.saveSchedule(
         scheduleSupport.prepare(id, prepared.getRequest().get("schedule")));
+    scheduleLifecycle.sync(id);
     return id;
   }
 
@@ -180,7 +184,9 @@ public class OfflineJobDefinitionService {
     resolveLogicalJobSpec(definition);
     definition.setReleaseState("ONLINE");
     definition.setUpdateTime(LocalDateTime.now());
-    return definitionRepository.update(definition);
+    boolean updated = definitionRepository.update(definition);
+    if (updated) scheduleLifecycle.sync(id);
+    return updated;
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
@@ -191,7 +197,9 @@ public class OfflineJobDefinitionService {
     }
     definition.setReleaseState("OFFLINE");
     definition.setUpdateTime(LocalDateTime.now());
-    return definitionRepository.update(definition);
+    boolean updated = definitionRepository.update(definition);
+    if (updated) scheduleLifecycle.sync(id);
+    return updated;
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
@@ -203,6 +211,7 @@ public class OfflineJobDefinitionService {
     if (executionRepository.hasActiveExecution(id)) {
       throw new IllegalStateException("运行中的任务不能删除");
     }
+    scheduleLifecycle.remove(id);
     return definitionRepository.delete(id);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineScheduleSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineScheduleSupport.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
-import java.time.LocalDateTime;
+import java.util.Arrays;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** 解析和校验任务级调度配置，不承担数据库访问。 */
+/** 解析和校验任务级调度配置，不承担数据库访问和运行时触发。 */
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineScheduleSupport {
@@ -26,12 +26,25 @@ public class OfflineScheduleSupport {
     if (enabled && !StringUtils.hasText(cron)) {
       throw new IllegalArgumentException("启用调度时必须填写 Cron 表达式");
     }
-    if (StringUtils.hasText(cron)) CronExpression.parse(cron);
+    if (StringUtils.hasText(cron)) cron = normalizeQuartzCron(cron);
     int attempts = Math.max(1, maxAttempts(schedule));
     int backoff = Math.max(1, backoffSeconds(schedule));
-    LocalDateTime next = enabled ? CronExpression.parse(cron).next(LocalDateTime.now()) : null;
     return new OfflineSchedule(
-        definitionId, cron, enabled, attempts, backoff, next, null, writeNullable(schedule));
+        definitionId, cron, enabled, attempts, backoff, null, null, writeNullable(schedule));
+  }
+
+  /** Spring Cron 负责输入校验，最终统一为当前 Quartz Provider 可消费的六段表达式。 */
+  String normalizeQuartzCron(String value) {
+    CronExpression.parse(value);
+    String[] fields = value.trim().replaceAll("\\s+", " ").split(" ");
+    if (fields.length >= 6) {
+      if ("*".equals(fields[3]) && !"?".equals(fields[5])) {
+        fields[3] = "?";
+      } else if (!"?".equals(fields[3]) && "*".equals(fields[5])) {
+        fields[5] = "?";
+      }
+    }
+    return String.join(" ", Arrays.asList(fields));
   }
 
   private boolean enabled(JsonNode node, String cron) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridgeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridgeTest.java
@@ -1,0 +1,75 @@
+package io.yak.ops.business.sync.offline.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.yak.framework.schedule.api.ConcurrencyPolicy;
+import io.yak.framework.schedule.api.MisfirePolicy;
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class OfflineScheduleEngineBridgeTest {
+
+  @Test
+  void shouldMapOnlineOfflineJobToYakScheduleDefinition() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ScheduleManager> provider = mock(ObjectProvider.class);
+    OfflineScheduleEngineBridge bridge = new OfflineScheduleEngineBridge(provider);
+
+    ScheduleDefinition definition = bridge.toDefinition(
+        definition("ONLINE"),
+        schedule(true));
+
+    assertThat(definition.key().namespace()).isEqualTo("yak-ops-offline-sync");
+    assertThat(definition.key().name()).isEqualTo("42");
+    assertThat(definition.trigger().expression()).isEqualTo("0 5 9 ? * *");
+    assertThat(definition.trigger().zoneId()).isEqualTo(ZoneId.systemDefault());
+    assertThat(definition.target().handler()).isEqualTo("offlineSyncScheduleHandler");
+    assertThat(definition.target().payload()).containsEntry("definitionId", 42L);
+    assertThat(definition.policy().concurrencyPolicy()).isEqualTo(ConcurrencyPolicy.FORBID);
+    assertThat(definition.policy().misfirePolicy()).isEqualTo(MisfirePolicy.FIRE_ONCE_NOW);
+    assertThat(definition.policy().triggerRetries()).isZero();
+    assertThat(definition.enabled()).isTrue();
+  }
+
+  @Test
+  void shouldKeepOfflineDefinitionDisabledInScheduleDefinition() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ScheduleManager> provider = mock(ObjectProvider.class);
+    OfflineScheduleEngineBridge bridge = new OfflineScheduleEngineBridge(provider);
+
+    ScheduleDefinition definition = bridge.toDefinition(
+        definition("OFFLINE"),
+        schedule(true));
+
+    assertThat(definition.enabled()).isFalse();
+  }
+
+  private OfflineJobDefinition definition(String state) {
+    return OfflineJobDefinition.builder()
+        .id(42L)
+        .jobName("订单离线同步")
+        .mode("FULL")
+        .sourceType("MYSQL")
+        .sinkType("MYSQL")
+        .releaseState(state)
+        .build();
+  }
+
+  private OfflineSchedule schedule(boolean enabled) {
+    return new OfflineSchedule(
+        42L,
+        "0 5 9 ? * *",
+        enabled,
+        2,
+        60,
+        null,
+        null,
+        "{}");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/support/OfflineScheduleSupportTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/support/OfflineScheduleSupportTest.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.sync.offline.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import org.junit.jupiter.api.Test;
+
+class OfflineScheduleSupportTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final OfflineScheduleSupport support = new OfflineScheduleSupport(objectMapper);
+
+  @Test
+  void shouldNormalizeCronAndLeaveNextFireTimeToYakSchedule() {
+    ObjectNode config = objectMapper.createObjectNode();
+    config.put("enabled", true);
+    config.put("cron", "0 5 9 * * *");
+    config.put("retryTimes", 2);
+    config.put("retryIntervalSeconds", 30);
+
+    OfflineSchedule schedule = support.prepare(42L, config);
+
+    assertThat(schedule.cronExpression()).isEqualTo("0 5 9 ? * *");
+    assertThat(schedule.enabled()).isTrue();
+    assertThat(schedule.retryMaxAttempts()).isEqualTo(3);
+    assertThat(schedule.retryBackoffSeconds()).isEqualTo(30);
+    assertThat(schedule.nextFireTime()).isNull();
+  }
+
+  @Test
+  void shouldNormalizeDayOfWeekCronForQuartz() {
+    ObjectNode config = objectMapper.createObjectNode();
+    config.put("enabled", true);
+    config.put("cronExpression", "0 0 12 * * MON");
+
+    OfflineSchedule schedule = support.prepare(42L, config);
+
+    assertThat(schedule.cronExpression()).isEqualTo("0 0 12 ? * MON");
+  }
+}


### PR DESCRIPTION
## What changed

- add `yak-schedule-api` to the offline-sync business module
- add `OfflineScheduleEngineBridge` to map offline job schedules into Yak Framework `ScheduleDefinition`
- add `OfflineScheduleHandler` so Cron triggers enter the existing `OfflineExecutionOrchestrator` and Link-Up execution chain
- add `OfflineScheduleLifecycle` to register schedules on task online, remove them on offline/delete, and persist engine-provided `lastFireTime` / `nextFireTime`
- add `OfflineScheduleReconciler` to rebuild in-memory Yak Schedule plans from `yak_offline_job_definition` after application startup and recover one persisted missed trigger through `ScheduleManager.runNow`
- normalize stored Cron expressions to the Quartz-compatible form consumed by the current Yak Schedule provider
- stop calculating runtime `nextFireTime` inside `OfflineScheduleSupport`; Yak Schedule snapshot is now the runtime source
- keep the existing Link-Up execution reconciliation and business retry loop unchanged
- document the boundary between task Cron scheduling and Link-Up execution reconciliation

## Why

Offline sync already persisted Cron, retry settings, `lastFireTime`, and `nextFireTime`, but there was no complete `Cron -> scheduler -> Offline Execution -> Link-Up` automatic trigger path. Yak Ops already assembles Yak Schedule and the Quartz provider, and data-quality/workflow scheduling now follow the same framework abstraction.

This change makes Yak Schedule the single task-level time-triggering layer while keeping `yak_offline_job_definition` as the business source of truth and preserving the existing offline execution state machine, active-execution admission, Link-Up reconciliation, and retry semantics.

## Behavior

```text
Offline Job Definition
  -> OfflineScheduleEngineBridge
  -> Yak Schedule / Quartz
  -> OfflineScheduleHandler
  -> OfflineExecutionOrchestrator
  -> Link-Up
```

Task lifecycle now behaves as follows:

- save draft/config: persist schedule projection and clear stale runtime scheduling when the task is offline
- online: register an enabled Cron plan and persist the engine-provided next fire time
- scheduled fire: create the existing `SCHEDULE` execution and submit it to Link-Up
- active execution: skip overlapping Cron fire using the existing business execution guard
- offline/delete: remove the engine plan and clear the next fire time
- startup: rebuild online schedules from the business table and recover one persisted overdue fire

## Scope boundary

`OfflineExecutionReconciler` intentionally keeps its Spring `@Scheduled` loop. It reconciles Link-Up execution state and creates business retries; it is not the task Cron scheduler and therefore remains part of the execution lifecycle.

No new scheduling table is introduced. The existing three-table offline-sync persistence model remains unchanged.

## Validation

- added coverage for offline job -> Yak `ScheduleDefinition` mapping, namespace, handler, concurrency and misfire policy
- added coverage for Cron normalization and for leaving runtime `nextFireTime` to Yak Schedule
- reviewed the complete PR diff against `main`; all 10 changed files are scoped to the offline-sync module
- GitHub reports the PR as mergeable; the branch is 0 commits behind `main`
- no GitHub Actions workflow run or commit status check is configured/running for the current head SHA
- local Maven execution is unavailable in the current runtime, so this PR intentionally does not claim a successful local build
