### PR TITLE
refactor: unify schedule lifecycle across business domains

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridge.java
@@ -10,6 +10,7 @@ import io.yak.framework.schedule.api.ScheduleTrigger;
 import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
 import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
+import io.yak.ops.common.schedule.YakScheduleGateway;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,46 +25,42 @@ public class QualityScheduleEngineBridge {
   static final String NAMESPACE = "yak-ops-quality";
   static final String HANDLER = "qualityScheduleHandler";
 
-  private final ObjectProvider<ScheduleManager> scheduleManagers;
+  private final YakScheduleGateway gateway;
   private final QualityScheduleCalculator calculator;
 
   public QualityScheduleEngineBridge(
       ObjectProvider<ScheduleManager> scheduleManagers,
       QualityScheduleCalculator calculator) {
-    this.scheduleManagers = scheduleManagers;
+    this.gateway = new YakScheduleGateway(scheduleManagers::getIfAvailable, NAMESPACE);
     this.calculator = calculator;
   }
 
   public boolean available() {
-    return scheduleManagers.getIfAvailable() != null;
+    return gateway.available();
   }
 
   public ScheduleSnapshot save(Monitor monitor, MonitorSettings settings) {
-    return manager().save(toDefinition(monitor, settings));
+    return gateway.save(toDefinition(monitor, settings));
   }
 
   public Optional<ScheduleSnapshot> snapshot(long monitorId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    return manager == null ? Optional.empty() : manager.get(key(monitorId));
+    return gateway.snapshot(name(monitorId));
   }
 
   public List<ScheduleSnapshot> list() {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    return manager == null ? List.of() : manager.list(NAMESPACE);
+    return gateway.list();
   }
 
   public void pauseIfPresent(long monitorId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) return;
-    ScheduleKey key = key(monitorId);
-    if (manager.get(key).isPresent()) manager.pause(key);
+    gateway.pauseIfPresent(name(monitorId));
   }
 
   public void deleteIfPresent(long monitorId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) return;
-    ScheduleKey key = key(monitorId);
-    if (manager.get(key).isPresent()) manager.delete(key);
+    gateway.deleteIfPresent(name(monitorId));
+  }
+
+  public void runNowIfPresent(long monitorId) {
+    gateway.runNowIfPresent(name(monitorId));
   }
 
   ScheduleDefinition toDefinition(Monitor monitor, MonitorSettings settings) {
@@ -100,16 +97,11 @@ public class QualityScheduleEngineBridge {
   }
 
   private ScheduleKey key(long monitorId) {
-    if (monitorId <= 0L) throw new IllegalArgumentException("质量监控 ID 不合法");
-    return new ScheduleKey(NAMESPACE, String.valueOf(monitorId));
+    return gateway.key(name(monitorId));
   }
 
-  private ScheduleManager manager() {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) {
-      throw new IllegalStateException(
-          "Yak ScheduleManager 不可用，请确认 yak-schedule-core、调度引擎插件与 yak.schedule.enabled 配置");
-    }
-    return manager;
+  private String name(long monitorId) {
+    if (monitorId <= 0L) throw new IllegalArgumentException("质量监控 ID 不合法");
+    return String.valueOf(monitorId);
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleLifecycle.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleLifecycle.java
@@ -38,7 +38,7 @@ public class QualityScheduleLifecycle {
 
     MonitorSettings settings = repository.findMonitorSettings(monitorId);
     if (!monitor.enabled() || settings.runMode() != RunMode.SCHEDULE) {
-      engine.deleteIfPresent(monitorId);
+      engine.pauseIfPresent(monitorId);
       updateNextRunTime(monitorId, settings, null);
       return;
     }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleReconciler.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleReconciler.java
@@ -5,7 +5,6 @@ import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
 import io.yak.ops.business.quality.domain.QualityQuery;
 import io.yak.ops.business.quality.repository.QualityRepository;
-import io.yak.ops.business.quality.service.QualityExecutionService;
 import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
@@ -27,17 +26,14 @@ public class QualityScheduleReconciler {
   private final QualityRepository repository;
   private final QualityScheduleEngineBridge engine;
   private final QualityScheduleLifecycle lifecycle;
-  private final QualityExecutionService executionService;
 
   public QualityScheduleReconciler(
       QualityRepository repository,
       QualityScheduleEngineBridge engine,
-      QualityScheduleLifecycle lifecycle,
-      QualityExecutionService executionService) {
+      QualityScheduleLifecycle lifecycle) {
     this.repository = repository;
     this.engine = engine;
     this.lifecycle = lifecycle;
-    this.executionService = executionService;
   }
 
   @Order(30)
@@ -93,7 +89,7 @@ public class QualityScheduleReconciler {
 
       if (persistedNextRunTime != null && !persistedNextRunTime.isAfter(now)) {
         try {
-          executionService.runScheduled(monitorId);
+          engine.runNowIfPresent(monitorId);
           LOGGER.info(
               "[quality-schedule] recovered missed trigger monitor={}, planned={}",
               monitorId,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridge.java
@@ -10,6 +10,7 @@ import io.yak.framework.schedule.api.ScheduleTrigger;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.common.schedule.YakScheduleGateway;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,49 +27,38 @@ public class OfflineScheduleEngineBridge {
   static final String NAMESPACE = "yak-ops-offline-sync";
   static final String HANDLER = "offlineSyncScheduleHandler";
 
-  private final ObjectProvider<ScheduleManager> scheduleManagers;
+  private final YakScheduleGateway gateway;
 
   public OfflineScheduleEngineBridge(ObjectProvider<ScheduleManager> scheduleManagers) {
-    this.scheduleManagers = scheduleManagers;
+    this.gateway = new YakScheduleGateway(scheduleManagers::getIfAvailable, NAMESPACE);
   }
 
   public boolean available() {
-    return scheduleManagers.getIfAvailable() != null;
+    return gateway.available();
   }
 
   public ScheduleSnapshot save(OfflineJobDefinition definition, OfflineSchedule schedule) {
-    return manager().save(toDefinition(definition, schedule));
+    return gateway.save(toDefinition(definition, schedule));
   }
 
   public Optional<ScheduleSnapshot> snapshot(long definitionId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    return manager == null ? Optional.empty() : manager.get(key(definitionId));
+    return gateway.snapshot(name(definitionId));
   }
 
   public List<ScheduleSnapshot> list() {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    return manager == null ? List.of() : manager.list(NAMESPACE);
+    return gateway.list();
   }
 
   public void pauseIfPresent(long definitionId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) return;
-    ScheduleKey key = key(definitionId);
-    if (manager.get(key).isPresent()) manager.pause(key);
+    gateway.pauseIfPresent(name(definitionId));
   }
 
   public void deleteIfPresent(long definitionId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) return;
-    ScheduleKey key = key(definitionId);
-    if (manager.get(key).isPresent()) manager.delete(key);
+    gateway.deleteIfPresent(name(definitionId));
   }
 
   public void runNowIfPresent(long definitionId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) return;
-    ScheduleKey key = key(definitionId);
-    if (manager.get(key).isPresent()) manager.runNow(key);
+    gateway.runNowIfPresent(name(definitionId));
   }
 
   ScheduleDefinition toDefinition(OfflineJobDefinition definition, OfflineSchedule schedule) {
@@ -101,17 +91,12 @@ public class OfflineScheduleEngineBridge {
   }
 
   private ScheduleKey key(long definitionId) {
-    if (definitionId <= 0L) throw new IllegalArgumentException("离线同步任务 ID 不合法");
-    return new ScheduleKey(NAMESPACE, String.valueOf(definitionId));
+    return gateway.key(name(definitionId));
   }
 
-  private ScheduleManager manager() {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) {
-      throw new IllegalStateException(
-          "Yak ScheduleManager 不可用，请确认 yak-schedule-core、调度引擎插件与 yak.schedule.enabled 配置");
-    }
-    return manager;
+  private String name(long definitionId) {
+    if (definitionId <= 0L) throw new IllegalArgumentException("离线同步任务 ID 不合法");
+    return String.valueOf(definitionId);
   }
 
   private void put(Map<String, String> metadata, String key, String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleLifecycle.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleLifecycle.java
@@ -44,7 +44,7 @@ public class OfflineScheduleLifecycle {
         || schedule == null
         || !schedule.enabled()
         || !StringUtils.hasText(schedule.cronExpression())) {
-      engine.deleteIfPresent(definitionId);
+      engine.pauseIfPresent(definitionId);
       if (schedule != null) {
         scheduleRepository.updateRuntimeState(definitionId, schedule.lastFireTime(), null);
       }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleEngineBridge.java
@@ -10,6 +10,7 @@ import io.yak.framework.schedule.api.ScheduleSnapshot;
 import io.yak.framework.schedule.api.ScheduleTarget;
 import io.yak.framework.schedule.api.ScheduleTrigger;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.common.schedule.YakScheduleGateway;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,42 +29,38 @@ public class WorkflowScheduleEngineBridge {
   static final String NAMESPACE = "yak-ops-workflow";
   static final String HANDLER = "workflowScheduleHandler";
 
-  private final ObjectProvider<ScheduleManager> scheduleManagers;
+  private final YakScheduleGateway gateway;
 
   public WorkflowScheduleEngineBridge(ObjectProvider<ScheduleManager> scheduleManagers) {
-    this.scheduleManagers = scheduleManagers;
+    this.gateway = new YakScheduleGateway(scheduleManagers::getIfAvailable, NAMESPACE);
   }
 
   public boolean available() {
-    return scheduleManagers.getIfAvailable() != null;
+    return gateway.available();
   }
 
   public ScheduleSnapshot save(WorkflowSchedulePO schedule) {
-    return manager().save(toDefinition(schedule));
+    return gateway.save(toDefinition(schedule));
   }
 
   public Optional<ScheduleSnapshot> snapshot(String scheduleId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    return manager == null ? Optional.empty() : manager.get(key(scheduleId));
+    return gateway.snapshot(name(scheduleId));
   }
 
   public List<ScheduleSnapshot> list() {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    return manager == null ? List.of() : manager.list(NAMESPACE);
+    return gateway.list();
   }
 
   public void pauseIfPresent(String scheduleId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) return;
-    ScheduleKey key = key(scheduleId);
-    if (manager.get(key).isPresent()) manager.pause(key);
+    gateway.pauseIfPresent(name(scheduleId));
   }
 
   public void deleteIfPresent(String scheduleId) {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) return;
-    ScheduleKey key = key(scheduleId);
-    if (manager.get(key).isPresent()) manager.delete(key);
+    gateway.deleteIfPresent(name(scheduleId));
+  }
+
+  public void runNowIfPresent(String scheduleId) {
+    gateway.runNowIfPresent(name(scheduleId));
   }
 
   ScheduleDefinition toDefinition(WorkflowSchedulePO schedule) {
@@ -93,19 +90,14 @@ public class WorkflowScheduleEngineBridge {
   }
 
   ScheduleKey key(String scheduleId) {
+    return gateway.key(name(scheduleId));
+  }
+
+  private String name(String scheduleId) {
     if (scheduleId == null || scheduleId.isBlank()) {
       throw new IllegalArgumentException("调度 ID 不能为空");
     }
-    return new ScheduleKey(NAMESPACE, scheduleId.trim());
-  }
-
-  private ScheduleManager manager() {
-    ScheduleManager manager = scheduleManagers.getIfAvailable();
-    if (manager == null) {
-      throw new IllegalStateException(
-          "Yak ScheduleManager 不可用，请确认 yak-schedule-core、Quartz 插件与 yak.schedule.enabled 配置");
-    }
-    return manager;
+    return scheduleId.trim();
   }
 
   private ConcurrencyPolicy concurrency(String strategy) {

--- a/yak-ops-common/pom.xml
+++ b/yak-ops-common/pom.xml
@@ -17,6 +17,11 @@
             <artifactId>yak-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-schedule-api</artifactId>
+            <version>${yak-framework.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/yak-ops-common/src/main/java/io/yak/ops/common/schedule/YakScheduleGateway.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/schedule/YakScheduleGateway.java
@@ -1,0 +1,101 @@
+package io.yak.ops.common.schedule;
+
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleKey;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Yak Ops 业务模块访问 Yak Schedule 的轻量网关。
+ *
+ * <p>这里只统一引擎操作语义，不承载任何业务状态、重试、并发准入或运行记录。</p>
+ */
+public final class YakScheduleGateway {
+  private final Supplier<ScheduleManager> managerSupplier;
+  private final String namespace;
+
+  public YakScheduleGateway(Supplier<ScheduleManager> managerSupplier, String namespace) {
+    if (managerSupplier == null) throw new IllegalArgumentException("ScheduleManager supplier 不能为空");
+    if (namespace == null || namespace.isBlank()) throw new IllegalArgumentException("调度 namespace 不能为空");
+    this.managerSupplier = managerSupplier;
+    this.namespace = namespace.trim();
+  }
+
+  public String namespace() {
+    return namespace;
+  }
+
+  public boolean available() {
+    return current() != null;
+  }
+
+  public ScheduleSnapshot save(ScheduleDefinition definition) {
+    if (definition == null) throw new IllegalArgumentException("调度定义不能为空");
+    if (!namespace.equals(definition.key().namespace())) {
+      throw new IllegalArgumentException(
+          "调度定义 namespace 不匹配，expected=" + namespace + ", actual=" + definition.key().namespace());
+    }
+    return required().save(definition);
+  }
+
+  public Optional<ScheduleSnapshot> snapshot(String name) {
+    ScheduleManager manager = current();
+    return manager == null ? Optional.empty() : manager.get(key(name));
+  }
+
+  public List<ScheduleSnapshot> list() {
+    ScheduleManager manager = current();
+    return manager == null ? List.of() : manager.list(namespace);
+  }
+
+  public void pauseIfPresent(String name) {
+    ScheduleManager manager = current();
+    if (manager == null) return;
+    ScheduleKey key = key(name);
+    if (manager.get(key).isPresent()) manager.pause(key);
+  }
+
+  public void resumeIfPresent(String name) {
+    ScheduleManager manager = current();
+    if (manager == null) return;
+    ScheduleKey key = key(name);
+    if (manager.get(key).isPresent()) manager.resume(key);
+  }
+
+  public void deleteIfPresent(String name) {
+    ScheduleManager manager = current();
+    if (manager == null) return;
+    ScheduleKey key = key(name);
+    if (manager.get(key).isPresent()) manager.delete(key);
+  }
+
+  public boolean runNowIfPresent(String name) {
+    ScheduleManager manager = current();
+    if (manager == null) return false;
+    ScheduleKey key = key(name);
+    if (manager.get(key).isEmpty()) return false;
+    manager.runNow(key);
+    return true;
+  }
+
+  public ScheduleKey key(String name) {
+    if (name == null || name.isBlank()) throw new IllegalArgumentException("调度业务 ID 不能为空");
+    return new ScheduleKey(namespace, name.trim());
+  }
+
+  private ScheduleManager current() {
+    return managerSupplier.get();
+  }
+
+  private ScheduleManager required() {
+    ScheduleManager manager = current();
+    if (manager == null) {
+      throw new IllegalStateException(
+          "Yak ScheduleManager 不可用，请确认 yak-schedule-core、调度引擎插件与 yak.schedule.enabled 配置");
+    }
+    return manager;
+  }
+}

--- a/yak-ops-common/src/test/java/io/yak/ops/common/schedule/YakScheduleGatewayTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/schedule/YakScheduleGatewayTest.java
@@ -1,0 +1,56 @@
+package io.yak.ops.common.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleKey;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class YakScheduleGatewayTest {
+
+  @Test
+  void shouldUnifyPresentScheduleOperationsWithinNamespace() {
+    ScheduleManager manager = mock(ScheduleManager.class);
+    YakScheduleGateway gateway = new YakScheduleGateway(() -> manager, "yak-ops-test");
+    ScheduleKey key = gateway.key("42");
+    when(manager.get(key)).thenReturn(Optional.of(mock(ScheduleSnapshot.class)));
+
+    gateway.pauseIfPresent("42");
+    gateway.resumeIfPresent("42");
+    assertThat(gateway.runNowIfPresent("42")).isTrue();
+    gateway.deleteIfPresent("42");
+
+    verify(manager).pause(key);
+    verify(manager).resume(key);
+    verify(manager).runNow(key);
+    verify(manager).delete(key);
+  }
+
+  @Test
+  void shouldBeSafeWhenScheduleManagerIsUnavailable() {
+    YakScheduleGateway gateway = new YakScheduleGateway(() -> null, "yak-ops-test");
+
+    assertThat(gateway.available()).isFalse();
+    assertThat(gateway.snapshot("42")).isEmpty();
+    assertThat(gateway.list()).isEmpty();
+    assertThat(gateway.runNowIfPresent("42")).isFalse();
+  }
+
+  @Test
+  void shouldRejectDefinitionFromAnotherNamespace() {
+    ScheduleDefinition definition = mock(ScheduleDefinition.class);
+    when(definition.key()).thenReturn(new ScheduleKey("other", "42"));
+    YakScheduleGateway gateway = new YakScheduleGateway(() -> mock(ScheduleManager.class), "yak-ops-test");
+
+    assertThatThrownBy(() -> gateway.save(definition))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("namespace");
+  }
+}


### PR DESCRIPTION
## What changed

- add a small shared `YakScheduleGateway` in `yak-ops-common` for namespace-scoped `save / snapshot / list / pause / resume / delete / runNow` operations
- keep Spring wiring and `ScheduleDefinition` mapping inside each business Bridge; common remains pure Java and only depends on `yak-schedule-api`
- migrate quality, offline sync, and workflow schedule bridges to the shared gateway
- align business lifecycle semantics so **disable/offline pauses an existing schedule** while **business deletion removes it**
- route data-quality startup missed-trigger recovery through `ScheduleManager.runNow` instead of calling `QualityExecutionService` directly
- preserve business-specific runtime behavior: workflow Trigger Ledger and configurable misfire recovery remain workflow-owned; offline Link-Up reconciliation/retries remain offline-owned; quality execution admission remains quality-owned

## Why

After the first two scheduling phases, all three domains used Yak Schedule but still carried nearly identical `ScheduleManager` plumbing and slightly different lifecycle semantics. That duplication made future scheduled domains likely to drift again.

This refactor deliberately extracts only the stable engine-facing operations. It does **not** introduce a generic business schedule table, a large base lifecycle class, or a shared execution model.

## Unified lifecycle convention

```text
Business schedule is source of truth
        ↓
Business EngineBridge builds ScheduleDefinition
        ↓
YakScheduleGateway
        ↓
Yak Schedule / provider
```

- save / online: `ScheduleManager.save`
- offline / disabled: `ScheduleManager.pause` when a plan exists; clear business `nextFireTime`
- delete: `ScheduleManager.delete`
- immediate/missed trigger: `ScheduleManager.runNow`
- runtime next fire: read `ScheduleSnapshot.nextFireTime` and persist to the business table
- startup: each business Reconciler rebuilds active plans from its own business table and removes stale engine plans

## Business boundaries kept intentionally separate

- **workflow** keeps its own concurrency strategy, misfire strategy, Trigger Ledger, start/end windows, and pending-trigger recovery
- **offline sync** keeps Link-Up execution reconciliation, active-execution admission, and business retry semantics
- **data quality** keeps monitor settings and quality execution state; only missed-trigger entry now goes through Yak Schedule

## Validation

- added unit coverage for the shared gateway: namespace isolation, no-op behavior when `ScheduleManager` is unavailable, and pause/resume/delete/runNow delegation
- existing quality/offline/workflow bridge tests keep their constructor signatures and continue exercising business-to-`ScheduleDefinition` mapping through the gateway
- reviewed the complete branch diff against `main`; changes are limited to `yak-ops-common` and the three scheduling domains
- GitHub reports the PR as mergeable; the branch is 1 commit ahead and 0 behind `main`
- no GitHub Actions workflow run or commit status check is configured/running for the current head SHA
- local Maven execution is unavailable in the current runtime because `gh`/local repository tooling is not installed, so this PR intentionally does not claim a successful local build
