### PR TITLE
refactor: clean up scheduling legacy and document standard

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,179 @@
+# Yak Ops 调度接入规范
+
+Yak Ops 业务模块统一通过 Yak Framework Schedule 接入时间调度。本文定义业务调度的职责边界、生命周期、依赖规则和新增模块的标准接入方式。
+
+## 1. 核心原则
+
+调度系统只回答一个问题：**什么时候触发**。
+
+业务模块继续负责：**执行什么、是否允许执行、如何执行、执行结果是什么**。
+
+```text
+Business Schedule / Definition   <- 业务事实来源
+              |
+              v
+      XxxScheduleEngineBridge    <- 业务对象 -> ScheduleDefinition
+              |
+              v
+        YakScheduleGateway       <- Yak Ops 统一引擎访问层
+              |
+              v
+          ScheduleManager
+              |
+              v
+       Schedule Provider         <- Quartz / XXL-JOB / ...
+              |
+              v
+       XxxScheduleHandler
+              |
+              v
+        Business Execution
+```
+
+业务表始终是事实来源。Yak Schedule 不替代业务定义表，也不引入一个新的通用业务任务表。
+
+## 2. 职责边界
+
+### Yak Schedule 负责
+
+- Cron / One-Time 等时间触发
+- Provider 路由
+- pause / resume / delete / runNow
+- 调度器级并发策略
+- Misfire 策略
+- 调度入口日志与操作审计
+- `ScheduleSnapshot` 中的运行时调度状态
+
+### 业务模块负责
+
+- 业务定义及启停状态
+- 执行实例和执行状态机
+- 幂等、资源锁、业务并发准入
+- 业务失败后的重试语义
+- 业务运行日志、结果、告警
+- 领域特有的恢复机制
+
+例如：Workflow 的 Trigger Ledger、Offline Sync 的 Link-Up 对账与失败重试，都属于业务执行生命周期，不应塞进 Yak Schedule。
+
+## 3. 标准组件
+
+任何需要时间调度的业务模块，优先使用下面四个组件。
+
+### `XxxScheduleEngineBridge`
+
+只做两件事：
+
+1. 把业务对象映射成 `ScheduleDefinition`；
+2. 通过 `YakScheduleGateway` 操作当前 namespace 下的计划。
+
+Bridge 不直接依赖 Quartz、XXL-JOB，也不维护业务执行状态。
+
+### `XxxScheduleHandler`
+
+实现 `ScheduleHandler`，作为所有时间触发的统一业务入口。
+
+正常 Cron、`runNow`、启动后的 missed-trigger 恢复，都应尽量进入同一个 Handler，再由 Handler 调用业务执行 Service。
+
+### `XxxScheduleLifecycle`
+
+负责业务状态与调度引擎状态同步，并遵循统一语义：
+
+| 业务动作 | Yak Schedule 动作 | 业务运行时状态 |
+| --- | --- | --- |
+| 保存 / 上线 | `save` | 回写 snapshot 的 `nextFireTime` |
+| 下线 / 停用 | `pause` | 清空 `nextFireTime` |
+| 删除 | `delete` | 清理业务调度运行时状态 |
+| 立即执行 | `runNow` | 仍从 Handler 进入业务执行 |
+
+业务删除与业务停用必须区分：**停用是 pause，删除才是 delete**。
+
+### `XxxScheduleReconciler`
+
+应用启动后，以业务表为事实来源完成恢复：
+
+1. 加载业务侧有效计划；
+2. 清理 namespace 下已经失效的引擎计划；
+3. 对有效计划重新 `save`；
+4. 从 `ScheduleSnapshot` 同步运行时状态；
+5. 按业务策略恢复持久化的 missed trigger；
+6. 恢复业务特有的等待队列、Trigger Ledger 等状态。
+
+当前 Yak Schedule 可以使用内存型 Provider 状态，因此启动对账是业务可恢复性的必要组成部分。
+
+## 4. `nextFireTime` 规则
+
+`nextFireTime` 的运行时事实来源必须是 Yak Schedule 的 `ScheduleSnapshot`。
+
+业务模块可以保存 Cron 和前端友好的调度配置，但不应再维护另一套运行时“下一次执行时间”计算器，也不应通过扫描 `nextFireTime <= now` 来驱动业务任务。
+
+允许业务代码使用 Cron 工具做：
+
+- 输入校验；
+- DAILY / WEEKLY 等友好配置转 Cron；
+- Provider 兼容格式规范化。
+
+不允许业务代码使用 Cron 工具重新实现调度时钟。
+
+## 5. 依赖规则
+
+业务模块只允许依赖：
+
+```xml
+<dependency>
+  <groupId>io.yak.framework</groupId>
+  <artifactId>yak-schedule-api</artifactId>
+</dependency>
+```
+
+Provider 只能由 Boot / 组装层引入，例如：
+
+```text
+yak-ops-boot
+  -> yak-schedule-core
+  -> yak-schedule-plugin-quartz
+```
+
+业务模块禁止直接依赖：
+
+- `org.quartz-scheduler:quartz`
+- XXL-JOB Provider SDK
+- 其他具体调度 Provider
+
+这样 Provider 替换不会影响业务模块。
+
+## 6. `@Scheduled` 使用边界
+
+业务任务的 Cron 时间触发禁止使用 Spring `@Scheduled` 自建轮询调度器。
+
+以下场景可以保留独立短周期 `@Scheduled`：
+
+- 外部执行引擎状态对账；
+- 运行实例心跳 / 超时回收；
+- 与“任务什么时候触发”无关的业务执行生命周期维护。
+
+例如 Offline Sync 的 `OfflineExecutionReconciler` 负责 Link-Up 运行状态对账和业务失败重试，它不是任务 Cron Scheduler，因此可以保留。
+
+## 7. 当前实现
+
+| 业务域 | Namespace | Handler | 业务事实来源 |
+| --- | --- | --- | --- |
+| Workflow | `yak-ops-workflow` | `workflowScheduleHandler` | `yak_workflow_schedule` |
+| Data Quality | `yak-ops-quality` | `qualityScheduleHandler` | 质量 Monitor / Settings |
+| Offline Sync | `yak-ops-offline-sync` | `offlineSyncScheduleHandler` | `yak_offline_job_definition` |
+
+三者都通过 `YakScheduleGateway -> ScheduleManager` 访问调度引擎，同时保留自己的执行模型和恢复逻辑。
+
+## 8. 新模块接入检查表
+
+新增 SQL Task、数据集刷新、报表刷新等调度能力时，提交前确认：
+
+- [ ] 业务表是调度定义事实来源；
+- [ ] 业务模块只依赖 `yak-schedule-api`；
+- [ ] 使用独立 namespace；
+- [ ] 有 `EngineBridge + Handler + Lifecycle + Reconciler`；
+- [ ] 下线使用 pause，删除使用 delete；
+- [ ] `runNow` 和 missed trigger 进入统一 Handler；
+- [ ] `nextFireTime` 来自 `ScheduleSnapshot`；
+- [ ] 没有 `@Scheduled` 扫描业务任务到期时间；
+- [ ] 没有直接依赖 Quartz / XXL-JOB；
+- [ ] 业务并发、重试、日志和告警仍保留在业务执行层。

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityProperties.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityProperties.java
@@ -7,7 +7,6 @@ public class QualityProperties {
 
   private boolean enabled = true;
   private final Executor executor = new Executor();
-  private final Scheduler scheduler = new Scheduler();
 
   public boolean isEnabled() {
     return enabled;
@@ -19,10 +18,6 @@ public class QualityProperties {
 
   public Executor getExecutor() {
     return executor;
-  }
-
-  public Scheduler getScheduler() {
-    return scheduler;
   }
 
   public static class Executor {
@@ -61,27 +56,6 @@ public class QualityProperties {
 
     public void setShutdownWaitSeconds(int shutdownWaitSeconds) {
       this.shutdownWaitSeconds = shutdownWaitSeconds;
-    }
-  }
-
-  public static class Scheduler {
-    private long pollIntervalMs = 30000L;
-    private int batchSize = 50;
-
-    public long getPollIntervalMs() {
-      return pollIntervalMs;
-    }
-
-    public void setPollIntervalMs(long pollIntervalMs) {
-      this.pollIntervalMs = pollIntervalMs;
-    }
-
-    public int getBatchSize() {
-      return batchSize;
-    }
-
-    public void setBatchSize(int batchSize) {
-      this.batchSize = batchSize;
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/QualityMonitorDao.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/QualityMonitorDao.java
@@ -30,8 +30,6 @@ public interface QualityMonitorDao {
 
   QualityMonitorSettingPO selectSetting(long monitorId);
   void upsertSetting(QualityMonitorSettingPO setting);
-  List<QualityMonitorSettingPO> selectDue(LocalDateTime now, int limit);
-  boolean claimSchedule(long monitorId, LocalDateTime expectedRunTime, LocalDateTime nextRunTime);
   void insertAlert(QualityAlertEventPO alert);
 
   long countTableAssets(Map<String, Object> params);

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityMonitorDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityMonitorDaoImpl.java
@@ -133,8 +133,6 @@ public class QualityMonitorDaoImpl implements QualityMonitorDao {
 
   @Override public QualityMonitorSettingPO selectSetting(long monitorId) { return settingMapper.selectById(monitorId); }
   @Override public void upsertSetting(QualityMonitorSettingPO setting) { writeMapper.upsertMonitorSetting(setting); }
-  @Override public List<QualityMonitorSettingPO> selectDue(LocalDateTime now, int limit) { return queryMapper.selectDueMonitors(now, Math.max(1, limit)); }
-  @Override public boolean claimSchedule(long monitorId, LocalDateTime expectedRunTime, LocalDateTime nextRunTime) { return writeMapper.claimMonitorSchedule(monitorId, expectedRunTime, nextRunTime) == 1; }
   @Override public void insertAlert(QualityAlertEventPO alert) { alertEventMapper.insert(alert); }
 
   @Override public long countTableAssets(Map<String, Object> params) { return queryMapper.countTableAssets(params); }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityQueryMapper.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityQueryMapper.java
@@ -1,7 +1,6 @@
 package io.yak.ops.business.quality.dao.mapper;
 
 import io.yak.ops.common.bean.po.quality.QualityExecutionPO;
-import io.yak.ops.common.bean.po.quality.QualityMonitorSettingPO;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.ColumnReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.DimensionReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.FolderRow;
@@ -14,7 +13,6 @@ import io.yak.ops.common.bean.po.quality.QualityQueryPO.TableMonitorSummaryRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.TemplateRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.TrendPointRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.WorkspaceStatsRow;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.apache.ibatis.annotations.Mapper;
@@ -36,10 +34,6 @@ public interface QualityQueryMapper {
   long countTableAssets(Map<String, Object> params);
   List<TableAssetRow> selectTableAssets(Map<String, Object> params);
   int countMonitorsForAsset(@Param("assetId") long assetId);
-
-  List<QualityMonitorSettingPO> selectDueMonitors(
-      @Param("now") LocalDateTime now,
-      @Param("limit") int limit);
 
   long countExecutions(Map<String, Object> params);
   List<QualityExecutionPO> selectExecutions(Map<String, Object> params);

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityWriteMapper.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityWriteMapper.java
@@ -2,7 +2,6 @@ package io.yak.ops.business.quality.dao.mapper;
 
 import io.yak.ops.common.bean.po.quality.QualityMonitorSettingPO;
 import io.yak.ops.common.bean.po.quality.QualityTableAssetPO;
-import java.time.LocalDateTime;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -14,9 +13,4 @@ public interface QualityWriteMapper {
   int upsertTableAsset(QualityTableAssetPO asset);
 
   int upsertMonitorSetting(QualityMonitorSettingPO setting);
-
-  int claimMonitorSchedule(
-      @Param("monitorId") long monitorId,
-      @Param("expectedRunTime") LocalDateTime expectedRunTime,
-      @Param("nextRunTime") LocalDateTime nextRunTime);
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/QualityDomain.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/QualityDomain.java
@@ -120,11 +120,6 @@ public final class QualityDomain {
       RuleFailureAction ruleFailureAction, boolean notifyEnabled, NotifyChannel notifyChannel,
       String notifyTarget, AlertLevel alertLevel) {}
 
-  public record ScheduledMonitor(
-      long monitorId, RunMode runMode, ScheduleFrequency scheduleFrequency,
-      String scheduleTime, ScheduleWeekday scheduleWeekday, String cronExpression,
-      LocalDateTime expectedRunTime) {}
-
   public record RuleSpec(
       long templateId, String templateCode, String name, RuleType ruleType,
       RuleScope scope, String dimension, String columnName, ComparisonOperator operator,

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepository.java
@@ -9,7 +9,6 @@ import io.yak.ops.business.quality.domain.QualityDomain.MonitorSpec;
 import io.yak.ops.business.quality.domain.QualityDomain.Rule;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecutionSpec;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleSpec;
-import io.yak.ops.business.quality.domain.QualityDomain.ScheduledMonitor;
 import io.yak.ops.business.quality.domain.QualityDomain.TableAsset;
 import io.yak.ops.business.quality.domain.QualityDomain.TableAssetSpec;
 import io.yak.ops.business.quality.domain.QualityDomain.TableAssetTarget;
@@ -45,8 +44,6 @@ public interface QualityRepository {
   boolean deleteMonitor(long id);
   MonitorSettings findMonitorSettings(long monitorId);
   void upsertMonitorSettings(long monitorId, MonitorSettingsSpec settings);
-  List<ScheduledMonitor> listDueMonitors(LocalDateTime now, int limit);
-  boolean claimMonitorSchedule(long monitorId, LocalDateTime expectedRunTime, LocalDateTime nextRunTime);
   void insertAlertEvent(AlertEventSpec alert);
   void replaceRules(long monitorId, List<RuleSpec> rules);
   List<Rule> listRules(long monitorId);

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityRepositoryAdapter.java
@@ -18,7 +18,6 @@ import io.yak.ops.business.quality.domain.QualityDomain.Rule;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecution;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecutionSpec;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleSpec;
-import io.yak.ops.business.quality.domain.QualityDomain.ScheduledMonitor;
 import io.yak.ops.business.quality.domain.QualityDomain.TableAsset;
 import io.yak.ops.business.quality.domain.QualityDomain.TableAssetSpec;
 import io.yak.ops.business.quality.domain.QualityDomain.TableAssetTarget;
@@ -165,18 +164,6 @@ public class QualityRepositoryAdapter implements QualityRepository {
   }
 
   @Override public void upsertMonitorSettings(long monitorId, MonitorSettingsSpec settings) { monitorDao.upsertSetting(settingPO(monitorId, settings)); }
-
-  @Override
-  public List<ScheduledMonitor> listDueMonitors(LocalDateTime now, int limit) {
-    return monitorDao.selectDue(now, limit).stream().map(po -> new ScheduledMonitor(
-        po.getMonitorId(), enumValue(RunMode.class, po.getRunMode(), RunMode.MANUAL),
-        enumValue(ScheduleFrequency.class, po.getScheduleFrequency()),
-        po.getScheduleTime() == null ? null : po.getScheduleTime().format(TIME_FORMATTER),
-        enumValue(ScheduleWeekday.class, po.getScheduleWeekday()), po.getCronExpression(),
-        po.getNextRunTime())).toList();
-  }
-
-  @Override public boolean claimMonitorSchedule(long monitorId, LocalDateTime expectedRunTime, LocalDateTime nextRunTime) { return monitorDao.claimSchedule(monitorId, expectedRunTime, nextRunTime); }
   @Override public void insertAlertEvent(AlertEventSpec alert) { monitorDao.insertAlert(alertPO(alert)); }
 
   @Override

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleCalculator.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleCalculator.java
@@ -1,10 +1,7 @@
 package io.yak.ops.business.quality.schedule;
 
-import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
 import io.yak.ops.common.enums.quality.QualityEnums.ScheduleFrequency;
 import io.yak.ops.common.enums.quality.QualityEnums.ScheduleWeekday;
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -15,23 +12,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class QualityScheduleCalculator {
   private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-
-  public LocalDateTime nextRun(
-      RunMode runMode,
-      ScheduleFrequency frequency,
-      String scheduleTime,
-      ScheduleWeekday weekday,
-      String cronExpression,
-      LocalDateTime from) {
-    if (runMode != RunMode.SCHEDULE) return null;
-    if (frequency == null) throw new IllegalArgumentException("调度触发必须选择调度周期");
-    LocalDateTime base = from == null ? LocalDateTime.now() : from;
-    return switch (frequency) {
-      case DAILY -> nextDaily(parseTime(scheduleTime), base);
-      case WEEKLY -> nextWeekly(parseTime(scheduleTime), requiredWeekday(weekday), base);
-      case CRON -> nextCron(cronExpression, base);
-    };
-  }
 
   /** 将数据质量的友好调度配置统一转换成 Yak Schedule/Quartz 使用的 Cron。 */
   public String cronExpression(
@@ -48,25 +28,6 @@ public class QualityScheduleCalculator {
   }
 
   public void validateCron(String expression) { parseCron(expression); }
-
-  private LocalDateTime nextDaily(LocalTime time, LocalDateTime from) {
-    LocalDateTime candidate = from.toLocalDate().atTime(time);
-    return candidate.isAfter(from) ? candidate : candidate.plusDays(1);
-  }
-
-  private LocalDateTime nextWeekly(LocalTime time, ScheduleWeekday weekday, LocalDateTime from) {
-    DayOfWeek target = DayOfWeek.valueOf(weekday.name());
-    int days = Math.floorMod(target.getValue() - from.getDayOfWeek().getValue(), 7);
-    LocalDateTime candidate = from.toLocalDate().plusDays(days).atTime(time);
-    if (!candidate.isAfter(from)) candidate = candidate.plusWeeks(1);
-    return candidate;
-  }
-
-  private LocalDateTime nextCron(String expression, LocalDateTime from) {
-    LocalDateTime next = parseCron(expression).next(from);
-    if (next == null) throw new IllegalArgumentException("Cron 表达式无法计算下一次执行时间");
-    return next;
-  }
 
   private String dailyCron(LocalTime time) {
     return "0 " + time.getMinute() + " " + time.getHour() + " * * ?";

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityQueryMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityQueryMapper.xml
@@ -191,18 +191,6 @@
     WHERE asset.id = #{assetId} AND asset.deleted = 0
   </select>
 
-  <select id="selectDueMonitors" resultType="io.yak.ops.common.bean.po.quality.QualityMonitorSettingPO">
-    SELECT s.monitor_id, s.run_mode, s.schedule_frequency, s.schedule_time,
-      s.schedule_weekday, s.cron_expression, s.next_run_time,
-      s.rule_failure_action, s.notify_enabled, s.notify_channel,
-      s.notify_target, s.alert_level, s.created_at, s.updated_at
-    FROM yak_quality_monitor_setting s
-    JOIN yak_quality_monitor m ON m.id = s.monitor_id
-    WHERE m.deleted = 0 AND m.enabled = 1
-      AND s.run_mode = 'SCHEDULE' AND s.next_run_time IS NOT NULL AND s.next_run_time &lt;= #{now}
-    ORDER BY s.next_run_time ASC, s.monitor_id ASC LIMIT #{limit}
-  </select>
-
   <sql id="ExecutionColumns">
     e.id, e.execution_no, e.monitor_id, e.monitor_name, e.data_source_id,
     e.data_source_name, e.database_name, e.schema_name, e.table_name, e.object_name,

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityWriteMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityWriteMapper.xml
@@ -49,15 +49,4 @@
       notify_target = VALUES(notify_target),
       alert_level = VALUES(alert_level)
   </insert>
-
-  <update id="claimMonitorSchedule">
-    UPDATE yak_quality_monitor_setting s
-    JOIN yak_quality_monitor m ON m.id = s.monitor_id
-    SET s.next_run_time = #{nextRunTime}
-    WHERE s.monitor_id = #{monitorId}
-      AND s.run_mode = 'SCHEDULE'
-      AND s.next_run_time = #{expectedRunTime}
-      AND m.deleted = 0
-      AND m.enabled = 1
-  </update>
 </mapper>

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/schedule/QualityScheduleCalculatorTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/schedule/QualityScheduleCalculatorTest.java
@@ -3,47 +3,12 @@ package io.yak.ops.business.quality.schedule;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
 import io.yak.ops.common.enums.quality.QualityEnums.ScheduleFrequency;
 import io.yak.ops.common.enums.quality.QualityEnums.ScheduleWeekday;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 class QualityScheduleCalculatorTest {
   private final QualityScheduleCalculator calculator = new QualityScheduleCalculator();
-
-  @Test
-  void shouldCalculateNextDailyTime() {
-    LocalDateTime from = LocalDateTime.of(2026, 8, 6, 10, 0);
-    assertEquals(LocalDateTime.of(2026, 8, 7, 9, 0),
-        calculator.nextRun(RunMode.SCHEDULE, ScheduleFrequency.DAILY, "09:00", null, null, from));
-  }
-
-  @Test
-  void shouldCalculateNextWeeklyTime() {
-    LocalDateTime from = LocalDateTime.of(2026, 8, 6, 10, 0);
-    assertEquals(LocalDateTime.of(2026, 8, 10, 9, 30),
-        calculator.nextRun(
-            RunMode.SCHEDULE,
-            ScheduleFrequency.WEEKLY,
-            "09:30",
-            ScheduleWeekday.MON,
-            null,
-            from));
-  }
-
-  @Test
-  void shouldCalculateCronTime() {
-    LocalDateTime from = LocalDateTime.of(2026, 8, 6, 10, 0);
-    assertEquals(LocalDateTime.of(2026, 8, 7, 9, 0),
-        calculator.nextRun(
-            RunMode.SCHEDULE,
-            ScheduleFrequency.CRON,
-            null,
-            null,
-            "0 0 9 * * *",
-            from));
-  }
 
   @Test
   void shouldConvertFriendlySchedulesToQuartzCron() {

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -43,10 +43,6 @@
             <version>${yak-framework.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>


### PR DESCRIPTION
## What changed

- remove the retired data-quality polling scheduler persistence path: `ScheduledMonitor`, due scanning, schedule claiming, DAO/Repository methods, and their MyBatis SQL
- remove obsolete `yak.quality.scheduler.poll-interval-ms` / `batch-size` configuration model
- trim `QualityScheduleCalculator` so it only validates and normalizes friendly schedule configuration into provider-compatible Cron; it no longer calculates runtime next-fire times
- remove the workflow module's direct `org.quartz-scheduler:quartz` dependency; business modules now stay provider-neutral and depend only on `yak-schedule-api`
- add `docs/scheduling.md` as the canonical Yak Ops scheduling integration standard

## Why

Stages 1-3 moved data quality, offline sync, and workflow onto Yak Schedule and unified their lifecycle. A few pre-migration polling APIs and provider-specific dependencies were still left behind. Keeping them would make it unclear which layer owns the clock and would encourage future modules to copy obsolete patterns.

This cleanup makes the boundary explicit: Yak Schedule owns **when to trigger**, while each business module owns **what/how to execute**.

## Scheduling standard

The new `docs/scheduling.md` defines:

- business tables are the source of truth
- `EngineBridge + Handler + Lifecycle + Reconciler` as the standard integration pattern
- `YakScheduleGateway -> ScheduleManager` as the common engine access path
- save/online = `save`, offline/disabled = `pause`, delete = `delete`, immediate/missed trigger = `runNow`
- runtime `nextFireTime` must come from `ScheduleSnapshot`
- business modules may validate/normalize Cron but must not implement their own scheduling clock
- business modules depend only on `yak-schedule-api`; provider plugins belong to the Boot/assembly layer
- Spring `@Scheduled` must not be used to scan business task due times, while execution-state reconciliation such as `OfflineExecutionReconciler` remains valid

## Scope boundary

No execution behavior is redesigned here:

- Workflow keeps Trigger Ledger, business concurrency/misfire semantics, windows, and recovery
- Offline Sync keeps Link-Up status reconciliation and business retry handling
- Data Quality keeps monitor/execution admission and quality result handling

`OfflineExecutionReconciler` is intentionally retained because it reconciles external execution state; it is not a task Cron scheduler.

## Validation

- reviewed the full diff against current `main`: 14 files, all limited to scheduling cleanup and the new standard document
- branch is 1 commit ahead and 0 behind `main`
- verified the old quality `ScheduledMonitor / selectDue / claimSchedule / scheduler` path is removed from the affected Repository/DAO/Mapper/config layers
- verified `QualityScheduleCalculator` no longer implements runtime next-run calculation
- verified workflow no longer directly declares Quartz
- GitHub reports this PR as mergeable
- no GitHub Actions workflow run or commit status check is configured/running for the current head SHA
- local Maven execution is not available in the current runtime, so this PR intentionally does not claim a successful local build
