### PR TITLE
refactor: unify home schedule center on Yak Schedule

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -163,13 +163,15 @@ yak-ops-boot
 
 三者都通过 `YakScheduleGateway -> ScheduleManager` 访问调度引擎，同时保留自己的执行模型和恢复逻辑。
 
+跨业务的只读调度视图（例如首页“调度中心”）应直接聚合这些 namespace 下的 `ScheduleSnapshot`，使用 `ScheduleDefinition.trigger` 中已经归一化的触发配置，不应再次查询各业务表并自行兼容 Linux Cron / Quartz Cron 或重新拼装 DAILY / WEEKLY Cron。
+
 ## 8. 新模块接入检查表
 
 新增 SQL Task、数据集刷新、报表刷新等调度能力时，提交前确认：
 
 - [ ] 业务表是调度定义事实来源；
 - [ ] 业务模块只依赖 `yak-schedule-api`；
-- [ ] 使用独立 namespace；
+- [ ] 使用独立 namespace，并优先在 `YakScheduleNamespaces` 中登记稳定 namespace；
 - [ ] 有 `EngineBridge + Handler + Lifecycle + Reconciler`；
 - [ ] 下线使用 pause，删除使用 delete；
 - [ ] `runNow` 和 missed trigger 进入统一 Handler；

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterService.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterService.java
@@ -1,18 +1,16 @@
 package io.yak.ops.boot.home;
 
-import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import io.yak.ops.business.quality.dao.mapper.QualityMonitorMapper;
-import io.yak.ops.business.quality.dao.mapper.QualityMonitorSettingMapper;
-import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
-import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
-import io.yak.ops.common.bean.po.quality.QualityMonitorPO;
-import io.yak.ops.common.bean.po.quality.QualityMonitorSettingPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import io.yak.framework.schedule.api.ScheduleStatus;
+import io.yak.framework.schedule.api.ScheduleTrigger;
+import io.yak.framework.schedule.api.TriggerType;
+import io.yak.ops.common.schedule.YakScheduleGateway;
+import io.yak.ops.common.schedule.YakScheduleNamespaces;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -23,30 +21,32 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.TimeZone;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import org.quartz.CronExpression;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
-/** 首页调度中心统一调度配置聚合服务。 */
+/** 首页调度中心：只读取 Yak Schedule 统一运行时快照，不再重复解释各业务调度配置。 */
 @Service
-@RequiredArgsConstructor
 public class HomeScheduleCenterService {
 
   private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
   private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-  private static final Set<String> WORKFLOW_ACTIVE_STATUS = Set.of("ONLINE");
+  private static final DateTimeFormatter ONE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
-  private final ObjectProvider<OfflineJobDefinitionMapper> offlineDefinitionMapperProvider;
-  private final ObjectProvider<WorkflowScheduleMapper> workflowScheduleMapperProvider;
-  private final ObjectProvider<QualityMonitorSettingMapper> qualitySettingMapperProvider;
-  private final ObjectProvider<QualityMonitorMapper> qualityMonitorMapperProvider;
+  private final YakScheduleGateway offlineSchedules;
+  private final YakScheduleGateway workflowSchedules;
+  private final YakScheduleGateway qualitySchedules;
+
+  public HomeScheduleCenterService(ObjectProvider<ScheduleManager> scheduleManagers) {
+    this.offlineSchedules = new YakScheduleGateway(
+        scheduleManagers::getIfAvailable, YakScheduleNamespaces.OFFLINE_SYNC);
+    this.workflowSchedules = new YakScheduleGateway(
+        scheduleManagers::getIfAvailable, YakScheduleNamespaces.WORKFLOW);
+    this.qualitySchedules = new YakScheduleGateway(
+        scheduleManagers::getIfAvailable, YakScheduleNamespaces.DATA_QUALITY);
+  }
 
   public CalendarResponse calendar(String monthValue) {
     YearMonth month = resolveMonth(monthValue);
@@ -54,9 +54,9 @@ public class HomeScheduleCenterService {
     LocalDate monthEnd = month.plusMonths(1).atDay(1);
 
     List<UnifiedScheduleTask> tasks = new ArrayList<>();
-    tasks.addAll(offlineTasks());
-    tasks.addAll(workflowTasks());
-    tasks.addAll(qualityTasks());
+    tasks.addAll(tasks(offlineSchedules, "OFFLINE_SYNC"));
+    tasks.addAll(tasks(workflowSchedules, "WORKFLOW"));
+    tasks.addAll(tasks(qualitySchedules, "DATA_QUALITY"));
 
     Map<LocalDate, List<ScheduleOccurrence>> occurrencesByDay = new LinkedHashMap<>();
     Map<String, ScheduleSummary> summariesByTask = new HashMap<>();
@@ -119,105 +119,40 @@ public class HomeScheduleCenterService {
         overview);
   }
 
-  private List<UnifiedScheduleTask> offlineTasks() {
-    OfflineJobDefinitionMapper mapper = offlineDefinitionMapperProvider.getIfAvailable();
-    if (mapper == null) return List.of();
-
-    return mapper.selectList(
-            new LambdaQueryWrapper<OfflineJobDefinitionPO>()
-                .eq(OfflineJobDefinitionPO::getScheduleEnabled, true)
-                .isNotNull(OfflineJobDefinitionPO::getCronExpression))
-        .stream()
-        .filter(item -> hasText(item.getCronExpression()))
-        .map(item -> new UnifiedScheduleTask(
-            String.valueOf(item.getId()),
-            "OFFLINE_SYNC",
-            defaultText(item.getJobName(), "离线同步任务 #" + item.getId()),
-            item.getCronExpression(),
-            ZoneId.systemDefault(),
-            null,
-            null,
-            item.getCronExpression(),
-            "/sync/batch-link-up/" + item.getId() + "/detail"))
+  private List<UnifiedScheduleTask> tasks(YakScheduleGateway gateway, String taskType) {
+    return gateway.list().stream()
+        .filter(snapshot -> snapshot.status() == ScheduleStatus.ENABLED)
+        .filter(snapshot -> snapshot.definition() != null && snapshot.definition().enabled())
+        .map(snapshot -> task(snapshot, taskType))
+        .filter(task -> task != null)
         .toList();
   }
 
-  private List<UnifiedScheduleTask> workflowTasks() {
-    WorkflowScheduleMapper mapper = workflowScheduleMapperProvider.getIfAvailable();
-    if (mapper == null) return List.of();
+  private UnifiedScheduleTask task(ScheduleSnapshot snapshot, String taskType) {
+    ScheduleDefinition definition = snapshot.definition();
+    ScheduleTrigger trigger = definition.trigger();
+    if (trigger == null) return null;
 
-    return mapper.selectList(
-            new LambdaQueryWrapper<WorkflowSchedulePO>()
-                .isNotNull(WorkflowSchedulePO::getCronExpression))
-        .stream()
-        .filter(item -> WORKFLOW_ACTIVE_STATUS.contains(normalize(item.getStatus())))
-        .filter(item -> hasText(item.getCronExpression()))
-        .map(item -> new UnifiedScheduleTask(
-            item.getId(),
-            "WORKFLOW",
-            defaultText(item.getName(), "工作流调度"),
-            item.getCronExpression(),
-            resolveZone(item.getTimezone()),
-            item.getStartTime(),
-            item.getEndTime(),
-            item.getCronExpression(),
-            "/workflow/schedules"))
-        .toList();
-  }
-
-  private List<UnifiedScheduleTask> qualityTasks() {
-    QualityMonitorSettingMapper settingMapper = qualitySettingMapperProvider.getIfAvailable();
-    QualityMonitorMapper monitorMapper = qualityMonitorMapperProvider.getIfAvailable();
-    if (settingMapper == null || monitorMapper == null) return List.of();
-
-    List<QualityMonitorSettingPO> settings = settingMapper.selectList(
-        new LambdaQueryWrapper<QualityMonitorSettingPO>()
-            .eq(QualityMonitorSettingPO::getRunMode, "SCHEDULE"));
-    if (settings.isEmpty()) return List.of();
-
-    Set<Long> monitorIds = settings.stream()
-        .map(QualityMonitorSettingPO::getMonitorId)
-        .filter(Objects::nonNull)
-        .collect(Collectors.toSet());
-    if (monitorIds.isEmpty()) return List.of();
-
-    Map<Long, QualityMonitorPO> monitors = monitorMapper.selectBatchIds(monitorIds).stream()
-        .filter(item -> Boolean.TRUE.equals(item.getEnabled()))
-        .filter(item -> !Boolean.TRUE.equals(item.getDeleted()))
-        .collect(Collectors.toMap(QualityMonitorPO::getId, item -> item, (left, right) -> left));
-
-    List<UnifiedScheduleTask> result = new ArrayList<>();
-    for (QualityMonitorSettingPO setting : settings) {
-      QualityMonitorPO monitor = monitors.get(setting.getMonitorId());
-      if (monitor == null) continue;
-      String cron = qualityCron(setting);
-      if (!hasText(cron)) continue;
-      result.add(new UnifiedScheduleTask(
-          String.valueOf(monitor.getId()),
-          "DATA_QUALITY",
-          defaultText(monitor.getMonitorName(), "数据质量任务 #" + monitor.getId()),
-          cron,
-          ZoneId.systemDefault(),
-          null,
-          null,
-          qualityScheduleText(setting),
-          "/data-quality/monitor/" + monitor.getId()));
-    }
-    return result;
+    String taskId = definition.key().name();
+    ZoneId zoneId = trigger.type() == TriggerType.CRON
+        ? trigger.zoneId()
+        : ZoneId.systemDefault();
+    return new UnifiedScheduleTask(
+        taskId,
+        taskType,
+        defaultText(definition.description(), fallbackName(taskType, taskId)),
+        trigger,
+        zoneId,
+        metadataInstant(definition.metadata(), "startTime"),
+        metadataInstant(definition.metadata(), "endTime"),
+        scheduleText(trigger, zoneId),
+        detailPath(taskType, taskId));
   }
 
   private List<ScheduleOccurrenceAt> occurrences(
       UnifiedScheduleTask task,
       LocalDate monthStart,
       LocalDate monthEnd) {
-    CronExpression cron;
-    try {
-      cron = new CronExpression(normalizeCron(task.cronExpression()));
-      cron.setTimeZone(TimeZone.getTimeZone(task.zoneId()));
-    } catch (Exception ignored) {
-      return List.of();
-    }
-
     Instant lowerBound = monthStart.atStartOfDay(task.zoneId()).toInstant();
     Instant upperBound = monthEnd.atStartOfDay(task.zoneId()).toInstant();
     if (task.startTime() != null && task.startTime().isAfter(lowerBound)) {
@@ -228,9 +163,27 @@ public class HomeScheduleCenterService {
     }
     if (!lowerBound.isBefore(upperBound)) return List.of();
 
+    return switch (task.trigger().type()) {
+      case CRON -> cronOccurrences(task, lowerBound, upperBound);
+      case ONE_TIME -> oneTimeOccurrences(task, lowerBound, upperBound);
+    };
+  }
+
+  private List<ScheduleOccurrenceAt> cronOccurrences(
+      UnifiedScheduleTask task,
+      Instant lowerBound,
+      Instant upperBound) {
+    CronExpression cron;
+    try {
+      // Cron 已在业务 Bridge -> ScheduleDefinition 阶段归一化，首页不再兼容或改写任何 Cron 方言。
+      cron = new CronExpression(task.trigger().expression());
+      cron.setTimeZone(TimeZone.getTimeZone(task.zoneId()));
+    } catch (Exception ignored) {
+      return List.of();
+    }
+
     List<ScheduleOccurrenceAt> result = new ArrayList<>();
     Date cursor = Date.from(lowerBound.minusMillis(1));
-
     while (true) {
       Date next = cron.getNextValidTimeAfter(cursor);
       if (next == null) break;
@@ -240,6 +193,7 @@ public class HomeScheduleCenterService {
       LocalDateTime dateTime = LocalDateTime.ofInstant(nextInstant, task.zoneId());
       result.add(new ScheduleOccurrenceAt(dateTime));
 
+      // 首页日历按“某天有哪些调度任务”展示，同一任务一天只投影一次。
       Instant nextDay = dateTime.toLocalDate().plusDays(1).atStartOfDay(task.zoneId()).toInstant();
       if (!nextDay.isBefore(upperBound)) break;
       cursor = Date.from(nextDay.minusMillis(1));
@@ -247,45 +201,49 @@ public class HomeScheduleCenterService {
     return result;
   }
 
-  private String qualityCron(QualityMonitorSettingPO setting) {
-    String frequency = normalize(setting.getScheduleFrequency());
-    return switch (frequency) {
-      case "DAILY" -> dailyCron(setting.getScheduleTime());
-      case "WEEKLY" -> weeklyCron(setting.getScheduleTime(), setting.getScheduleWeekday());
-      case "CRON" -> setting.getCronExpression();
-      default -> null;
+  private List<ScheduleOccurrenceAt> oneTimeOccurrences(
+      UnifiedScheduleTask task,
+      Instant lowerBound,
+      Instant upperBound) {
+    Instant executeAt = task.trigger().executeAt();
+    if (executeAt == null || executeAt.isBefore(lowerBound) || !executeAt.isBefore(upperBound)) {
+      return List.of();
+    }
+    return List.of(new ScheduleOccurrenceAt(LocalDateTime.ofInstant(executeAt, task.zoneId())));
+  }
+
+  private String scheduleText(ScheduleTrigger trigger, ZoneId zoneId) {
+    if (trigger.type() == TriggerType.CRON) return trigger.expression();
+    return "单次 " + LocalDateTime.ofInstant(trigger.executeAt(), zoneId).format(ONE_TIME_FORMATTER);
+  }
+
+  private Instant metadataInstant(Map<String, String> metadata, String key) {
+    if (metadata == null) return null;
+    String value = metadata.get(key);
+    if (!hasText(value)) return null;
+    try {
+      return Instant.parse(value.trim());
+    } catch (DateTimeParseException ignored) {
+      return null;
+    }
+  }
+
+  private String fallbackName(String taskType, String taskId) {
+    return switch (taskType) {
+      case "OFFLINE_SYNC" -> "离线同步任务 #" + taskId;
+      case "WORKFLOW" -> "工作流调度 #" + taskId;
+      case "DATA_QUALITY" -> "数据质量任务 #" + taskId;
+      default -> "调度任务 #" + taskId;
     };
   }
 
-  private String qualityScheduleText(QualityMonitorSettingPO setting) {
-    String frequency = normalize(setting.getScheduleFrequency());
-    return switch (frequency) {
-      case "DAILY" -> "每天 " + timeText(setting.getScheduleTime());
-      case "WEEKLY" -> "每周" + weekdayText(setting.getScheduleWeekday()) + " " + timeText(setting.getScheduleTime());
-      case "CRON" -> defaultText(setting.getCronExpression(), "Cron");
-      default -> "调度";
+  private String detailPath(String taskType, String taskId) {
+    return switch (taskType) {
+      case "OFFLINE_SYNC" -> "/sync/batch-link-up/" + taskId + "/detail";
+      case "WORKFLOW" -> "/workflow/schedules";
+      case "DATA_QUALITY" -> "/data-quality/monitor/" + taskId;
+      default -> "/";
     };
-  }
-
-  private String dailyCron(LocalTime time) {
-    if (time == null) return null;
-    return String.format("0 %d %d * * ?", time.getMinute(), time.getHour());
-  }
-
-  private String weeklyCron(LocalTime time, String weekday) {
-    if (time == null || !hasText(weekday)) return null;
-    return String.format(
-        "0 %d %d ? * %s",
-        time.getMinute(),
-        time.getHour(),
-        normalize(weekday));
-  }
-
-  private String normalizeCron(String expression) {
-    String normalized = expression == null ? "" : expression.trim().replaceAll("\\s+", " ");
-    int fields = normalized.isEmpty() ? 0 : normalized.split(" ").length;
-    if (fields == 5) return "0 " + normalized;
-    return normalized;
   }
 
   private YearMonth resolveMonth(String value) {
@@ -295,35 +253,6 @@ public class HomeScheduleCenterService {
     } catch (DateTimeParseException exception) {
       throw new IllegalArgumentException("month 格式必须为 yyyy-MM", exception);
     }
-  }
-
-  private ZoneId resolveZone(String value) {
-    try {
-      return hasText(value) ? ZoneId.of(value.trim()) : ZoneId.systemDefault();
-    } catch (Exception ignored) {
-      return ZoneId.systemDefault();
-    }
-  }
-
-  private String weekdayText(String value) {
-    return switch (normalize(value)) {
-      case "MON" -> "一";
-      case "TUE" -> "二";
-      case "WED" -> "三";
-      case "THU" -> "四";
-      case "FRI" -> "五";
-      case "SAT" -> "六";
-      case "SUN" -> "日";
-      default -> "";
-    };
-  }
-
-  private String timeText(LocalTime value) {
-    return value == null ? "--:--" : value.format(TIME_FORMATTER);
-  }
-
-  private String normalize(String value) {
-    return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
   }
 
   private boolean hasText(String value) {
@@ -368,7 +297,7 @@ public class HomeScheduleCenterService {
       String taskId,
       String taskType,
       String taskName,
-      String cronExpression,
+      ScheduleTrigger trigger,
       ZoneId zoneId,
       Instant startTime,
       Instant endTime,

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeScheduleCenterServiceTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeScheduleCenterServiceTest.java
@@ -1,0 +1,99 @@
+package io.yak.ops.boot.home;
+
+import static io.yak.ops.common.schedule.YakScheduleNamespaces.DATA_QUALITY;
+import static io.yak.ops.common.schedule.YakScheduleNamespaces.OFFLINE_SYNC;
+import static io.yak.ops.common.schedule.YakScheduleNamespaces.WORKFLOW;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.schedule.api.ScheduleDefinition;
+import io.yak.framework.schedule.api.ScheduleKey;
+import io.yak.framework.schedule.api.ScheduleManager;
+import io.yak.framework.schedule.api.SchedulePolicy;
+import io.yak.framework.schedule.api.ScheduleSnapshot;
+import io.yak.framework.schedule.api.ScheduleStatus;
+import io.yak.framework.schedule.api.ScheduleTarget;
+import io.yak.framework.schedule.api.ScheduleTrigger;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class HomeScheduleCenterServiceTest {
+
+  @Test
+  void shouldBuildCalendarFromUnifiedScheduleSnapshots() {
+    ScheduleManager manager = mock(ScheduleManager.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ScheduleManager> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(manager);
+    when(manager.list(OFFLINE_SYNC)).thenReturn(List.of(snapshot(
+        OFFLINE_SYNC, "11", "订单离线同步", "0 0 9 * * ?", ScheduleStatus.ENABLED, Map.of())));
+    when(manager.list(WORKFLOW)).thenReturn(List.of(snapshot(
+        WORKFLOW, "workflow-schedule-1", "每日加工工作流", "0 30 10 * * ?", ScheduleStatus.ENABLED,
+        Map.of("startTime", "2026-08-10T00:00:00Z"))));
+    when(manager.list(DATA_QUALITY)).thenReturn(List.of(snapshot(
+        DATA_QUALITY, "21", "订单完整性检查", "0 0 11 * * ?", ScheduleStatus.ENABLED, Map.of())));
+
+    HomeScheduleCenterService service = new HomeScheduleCenterService(provider);
+    HomeScheduleCenterService.CalendarResponse response = service.calendar("2026-08");
+
+    assertThat(response.totalSchedules()).isEqualTo(3);
+    assertThat(response.days()).isNotEmpty();
+    assertThat(response.overview()).hasSize(3);
+    assertThat(response.overview()).extracting(HomeScheduleCenterService.ScheduleSummary::taskType)
+        .containsExactlyInAnyOrder("OFFLINE_SYNC", "WORKFLOW", "DATA_QUALITY");
+    assertThat(response.overview()).extracting(HomeScheduleCenterService.ScheduleSummary::scheduleText)
+        .contains("0 0 9 * * ?", "0 30 10 * * ?", "0 0 11 * * ?");
+    verify(manager).list(OFFLINE_SYNC);
+    verify(manager).list(WORKFLOW);
+    verify(manager).list(DATA_QUALITY);
+  }
+
+  @Test
+  void shouldIgnorePausedSchedules() {
+    ScheduleManager manager = mock(ScheduleManager.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ScheduleManager> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(manager);
+    when(manager.list(OFFLINE_SYNC)).thenReturn(List.of(snapshot(
+        OFFLINE_SYNC, "11", "已暂停任务", "0 0 9 * * ?", ScheduleStatus.PAUSED, Map.of())));
+    when(manager.list(WORKFLOW)).thenReturn(List.of());
+    when(manager.list(DATA_QUALITY)).thenReturn(List.of());
+
+    HomeScheduleCenterService.CalendarResponse response =
+        new HomeScheduleCenterService(provider).calendar("2026-08");
+
+    assertThat(response.totalSchedules()).isZero();
+    assertThat(response.days()).isEmpty();
+    assertThat(response.overview()).isEmpty();
+  }
+
+  private ScheduleSnapshot snapshot(
+      String namespace,
+      String id,
+      String name,
+      String cron,
+      ScheduleStatus status,
+      Map<String, String> metadata) {
+    ScheduleDefinition definition = new ScheduleDefinition(
+        new ScheduleKey(namespace, id),
+        name,
+        ScheduleTrigger.cron(cron, ZoneId.of("Asia/Shanghai")),
+        new ScheduleTarget("testHandler", Map.of("id", id)),
+        SchedulePolicy.defaults(),
+        true,
+        metadata);
+    return new ScheduleSnapshot(
+        definition,
+        "quartz",
+        namespace + "/" + id,
+        status,
+        Instant.parse("2026-08-18T01:00:00Z"),
+        null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridge.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
 import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
 import io.yak.ops.common.schedule.YakScheduleGateway;
+import io.yak.ops.common.schedule.YakScheduleNamespaces;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -22,7 +23,7 @@ import org.springframework.stereotype.Component;
 /** Yak Ops 数据质量调度到 Yak Framework ScheduleManager 的适配层。 */
 @Component
 public class QualityScheduleEngineBridge {
-  static final String NAMESPACE = "yak-ops-quality";
+  static final String NAMESPACE = YakScheduleNamespaces.DATA_QUALITY;
   static final String HANDLER = "qualityScheduleHandler";
 
   private final YakScheduleGateway gateway;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleEngineBridge.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
 import io.yak.ops.common.schedule.YakScheduleGateway;
+import io.yak.ops.common.schedule.YakScheduleNamespaces;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,7 +25,7 @@ import org.springframework.util.StringUtils;
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineScheduleEngineBridge {
-  static final String NAMESPACE = "yak-ops-offline-sync";
+  static final String NAMESPACE = YakScheduleNamespaces.OFFLINE_SYNC;
   static final String HANDLER = "offlineSyncScheduleHandler";
 
   private final YakScheduleGateway gateway;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowScheduleEngineBridge.java
@@ -11,6 +11,7 @@ import io.yak.framework.schedule.api.ScheduleTarget;
 import io.yak.framework.schedule.api.ScheduleTrigger;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.schedule.YakScheduleGateway;
+import io.yak.ops.common.schedule.YakScheduleNamespaces;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,7 +27,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class WorkflowScheduleEngineBridge {
-  static final String NAMESPACE = "yak-ops-workflow";
+  static final String NAMESPACE = YakScheduleNamespaces.WORKFLOW;
   static final String HANDLER = "workflowScheduleHandler";
 
   private final YakScheduleGateway gateway;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/schedule/YakScheduleNamespaces.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/schedule/YakScheduleNamespaces.java
@@ -1,0 +1,10 @@
+package io.yak.ops.common.schedule;
+
+/** Yak Ops 已接入 Yak Schedule 的稳定业务 namespace。 */
+public final class YakScheduleNamespaces {
+  public static final String WORKFLOW = "yak-ops-workflow";
+  public static final String DATA_QUALITY = "yak-ops-quality";
+  public static final String OFFLINE_SYNC = "yak-ops-offline-sync";
+
+  private YakScheduleNamespaces() {}
+}


### PR DESCRIPTION
## What changed

- refactor the homepage Schedule Center to read unified `ScheduleSnapshot`s from Yak Schedule instead of querying Offline Sync / Workflow / Data Quality tables separately
- remove homepage-only Linux 5-field Cron -> Quartz 6-field compatibility and remove duplicated Data Quality DAILY / WEEKLY -> Cron reconstruction
- keep the existing homepage API and UI response contract unchanged
- filter calendar projection by Yak Schedule runtime status so paused schedules are not shown as active plans
- preserve Workflow start/end windows by reading the existing `ScheduleDefinition.metadata`
- support both `CRON` and `ONE_TIME` trigger projections from the unified `ScheduleTrigger` model
- add `YakScheduleNamespaces` as the single source for the three stable business namespaces and migrate the three Engine Bridges to it
- extend the scheduling standard to require cross-domain read-only views to consume `ScheduleSnapshot` rather than re-reading and re-interpreting business scheduling configuration

## Why

After Data Quality, Offline Sync and Workflow were unified on Yak Schedule, the homepage Schedule Center was still acting as a second scheduling adapter. It queried three business persistence models, rebuilt quality Cron expressions, and contained a compatibility branch that prefixed seconds for Linux-style 5-field Cron.

That duplicated the exact normalization work already completed before a schedule reaches Yak Schedule and made the homepage dependent on four business Mappers.

The homepage is a cross-domain read-only projection, so its source should be the unified runtime scheduling model:

```text
Business schedule tables
        -> EngineBridge
        -> Yak Schedule
        -> ScheduleSnapshot
        -> HomeScheduleCenterService
        -> existing calendar API / UI
```

## Behavior

- active Offline Sync / Workflow / Data Quality plans are read by namespace through `YakScheduleGateway`
- only `ScheduleStatus.ENABLED` + enabled definitions are projected into the calendar
- Cron expressions are consumed exactly as stored in `ScheduleDefinition.trigger`; the homepage no longer modifies Cron dialects
- the current Boot assembly uses its Quartz runtime to expand the already-normalized Cron into calendar dates; Linux/Quartz dialect compatibility is no longer implemented in the homepage aggregation layer
- Workflow `startTime` / `endTime` constraints continue to apply
- paused schedules remain excluded
- controller endpoint and frontend data shape remain unchanged, so no ScheduleCenter UI migration is required

## Validation

- added `HomeScheduleCenterServiceTest` covering three-namespace snapshot aggregation and paused-plan filtering
- reviewed the complete PR diff: 7 changed files, scoped to homepage schedule aggregation, shared namespace constants, tests and scheduling documentation
- branch is 1 commit ahead and 0 behind `main`
- verified the homepage service no longer imports the Offline / Workflow / Quality persistence Mappers or PO models
- verified `normalizeCron`, `qualityCron`, `dailyCron`, `weeklyCron`, and quality schedule-text reconstruction are removed from the homepage service
- GitHub reports the PR as mergeable
- no GitHub Actions workflow run or commit status check is configured/running for the current head SHA
- local Maven execution is not available in the current runtime, so this PR intentionally does not claim a successful local build
