### PR TITLE
fix: remove Quartz dependency from workflow backfill planner

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlanner.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlanner.java
@@ -1,6 +1,5 @@
 package io.yak.ops.business.workflow.service;
 
-import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -8,17 +7,19 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.Arrays;
 import java.util.List;
-import java.util.TimeZone;
-import org.quartz.CronExpression;
+import java.util.Locale;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Component;
 
-/** 使用与 Stage 3 Quartz 相同的 Cron 语义生成历史补数逻辑计划时间。 */
+/** 无 Quartz 业务依赖地生成 Workflow 历史补数逻辑计划时间。 */
 @Component
 public class WorkflowBackfillPlanner {
   public static final int MAX_OCCURRENCES = 1000;
   private static final long MAX_RANGE_DAYS = 3660L;
+  private static final int QUARTZ_MIN_YEAR = 1970;
+  private static final int QUARTZ_MAX_YEAR = 2199;
 
   public Plan plan(
       String cronExpression,
@@ -37,24 +38,33 @@ public class WorkflowBackfillPlanner {
     }
 
     ZoneId zone = ZoneId.of(required(timezone, "补数时区不能为空"));
-    String normalizedCron = normalizeCron(cronExpression);
-    CronExpression cron = parseCron(normalizedCron, zone);
+    NormalizedCron normalizedCron = normalizeCron(cronExpression);
+    ParsedCron cron = parseCron(normalizedCron);
     Instant rangeStart = startBusinessDate.atStartOfDay(zone).toInstant();
     Instant rangeEndExclusive = endBusinessDate.plusDays(1).atStartOfDay(zone).toInstant();
 
     List<Occurrence> occurrences = new ArrayList<>();
-    Date cursor = Date.from(rangeStart.minusMillis(1));
+    ZonedDateTime cursor = rangeStart.atZone(zone).minusNanos(1L);
     while (true) {
-      Date next = cron.getNextValidTimeAfter(cursor);
+      ZonedDateTime next = cron.expression().next(cursor);
       if (next == null) break;
       Instant instant = next.toInstant();
       if (!instant.isBefore(rangeEndExclusive)) break;
+
+      if (!cron.yearConstraint().matches(next.getYear())) {
+        Integer nextYear = cron.yearConstraint().nextAllowedYear(next.getYear() + 1);
+        if (nextYear == null) break;
+        ZonedDateTime jump = LocalDate.of(nextYear, 1, 1).atStartOfDay(zone).minusNanos(1L);
+        if (!jump.toInstant().isBefore(rangeEndExclusive)) break;
+        cursor = jump;
+        continue;
+      }
+
       if (!instant.isBefore(rangeStart)) {
-        ZonedDateTime local = instant.atZone(zone);
         occurrences.add(new Occurrence(
-            local.toLocalDate(),
+            next.toLocalDate(),
             instant,
-            DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(local)));
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(next)));
         if (occurrences.size() > MAX_OCCURRENCES) {
           throw new IllegalArgumentException(
               "单次补数最多生成 " + MAX_OCCURRENCES + " 个计划实例，请缩小日期范围");
@@ -66,20 +76,29 @@ public class WorkflowBackfillPlanner {
     if (occurrences.isEmpty()) {
       throw new IllegalArgumentException("当前 Cron 在所选业务日期范围内没有可执行计划时间");
     }
-    return new Plan(zone.getId(), normalizedCron, List.copyOf(occurrences));
+    return new Plan(zone.getId(), normalizedCron.expression(), List.copyOf(occurrences));
   }
 
-  private CronExpression parseCron(String normalized, ZoneId zone) {
+  private ParsedCron parseCron(NormalizedCron normalized) {
+    String[] fields = normalized.expression().split(" ");
+    String[] springFields = Arrays.copyOf(fields, 6);
+    if (!normalized.fromFiveFields()) {
+      springFields[5] = quartzDayOfWeekToSpring(springFields[5]);
+    }
+
     try {
-      CronExpression cron = new CronExpression(normalized);
-      cron.setTimeZone(TimeZone.getTimeZone(zone));
-      return cron;
-    } catch (ParseException exception) {
-      throw new IllegalArgumentException("补数无法解析 Cron 表达式：" + normalized, exception);
+      CronExpression expression = CronExpression.parse(String.join(" ", springFields));
+      YearConstraint years = fields.length == 7
+          ? parseYearConstraint(fields[6])
+          : YearConstraint.unrestricted();
+      return new ParsedCron(expression, years);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException(
+          "补数无法解析 Cron 表达式：" + normalized.expression(), exception);
     }
   }
 
-  private String normalizeCron(String expression) {
+  private NormalizedCron normalizeCron(String expression) {
     String cron = required(expression, "Cron 表达式不能为空").replaceAll("\\s+", " ");
     String[] fields = cron.split(" ");
     if (fields.length == 5) {
@@ -96,15 +115,179 @@ public class WorkflowBackfillPlanner {
       }
       if (weekDaySpecified) dayOfMonth = "?";
       else dayOfWeek = "?";
-      return String.join(" ", "0", minute, hour, dayOfMonth, month, dayOfWeek);
+      return new NormalizedCron(
+          String.join(" ", "0", minute, hour, dayOfMonth, month, dayOfWeek),
+          true);
     }
-    if (fields.length == 6 || fields.length == 7) return cron;
+    if (fields.length == 6 || fields.length == 7) {
+      return new NormalizedCron(cron, false);
+    }
     throw new IllegalArgumentException("Backfill 仅支持 5、6 或 7 字段 Cron 表达式");
+  }
+
+  /**
+   * Spring Cron 使用 0-6 表示 SUN-SAT，而 Quartz 使用 1-7。
+   * 这里只转换 6/7 字段 Quartz-style Cron 的星期字段，英文星期名无需转换。
+   */
+  private String quartzDayOfWeekToSpring(String field) {
+    if ("?".equals(field) || "*".equals(field)) return field;
+    String[] parts = field.split(",");
+    List<String> converted = new ArrayList<>(parts.length);
+    for (String part : parts) {
+      converted.add(convertQuartzDayOfWeekPart(part));
+    }
+    return String.join(",", converted);
+  }
+
+  private String convertQuartzDayOfWeekPart(String value) {
+    String part = value.trim().toUpperCase(Locale.ROOT);
+    if (part.isEmpty()) {
+      throw new IllegalArgumentException("星期字段不能为空");
+    }
+    if ("L".equals(part)) {
+      // Quartz 在 day-of-week 中单独的 L 等价于 7/SAT。
+      return "6";
+    }
+
+    int hashIndex = part.indexOf('#');
+    if (hashIndex > 0) {
+      return convertQuartzDayOfWeekBase(part.substring(0, hashIndex))
+          + part.substring(hashIndex);
+    }
+    if (part.endsWith("L") && part.length() > 1) {
+      return convertQuartzDayOfWeekBase(part.substring(0, part.length() - 1)) + "L";
+    }
+
+    int slashIndex = part.indexOf('/');
+    if (slashIndex > 0) {
+      return convertQuartzDayOfWeekBase(part.substring(0, slashIndex))
+          + part.substring(slashIndex);
+    }
+    return convertQuartzDayOfWeekBase(part);
+  }
+
+  private String convertQuartzDayOfWeekBase(String value) {
+    if ("*".equals(value) || "?".equals(value)) return value;
+    int rangeIndex = value.indexOf('-');
+    if (rangeIndex > 0) {
+      return convertQuartzDayOfWeekValue(value.substring(0, rangeIndex))
+          + "-"
+          + convertQuartzDayOfWeekValue(value.substring(rangeIndex + 1));
+    }
+    return convertQuartzDayOfWeekValue(value);
+  }
+
+  private String convertQuartzDayOfWeekValue(String value) {
+    try {
+      int day = Integer.parseInt(value);
+      if (day < 1 || day > 7) {
+        throw new IllegalArgumentException("Quartz 星期数字必须在 1 到 7 之间：" + value);
+      }
+      return Integer.toString(day - 1);
+    } catch (NumberFormatException ignored) {
+      return value;
+    }
+  }
+
+  private YearConstraint parseYearConstraint(String expression) {
+    String field = required(expression, "Cron 年份字段不能为空");
+    List<Integer> allowedYears = new ArrayList<>();
+    for (int year = QUARTZ_MIN_YEAR; year <= QUARTZ_MAX_YEAR; year++) {
+      if (matchesYearExpression(field, year)) {
+        allowedYears.add(year);
+      }
+    }
+    if (allowedYears.isEmpty()) {
+      throw new IllegalArgumentException("Cron 年份字段没有可执行年份：" + expression);
+    }
+    return new YearConstraint(false, List.copyOf(allowedYears));
+  }
+
+  private boolean matchesYearExpression(String expression, int year) {
+    for (String part : expression.split(",")) {
+      if (matchesYearPart(part.trim(), year)) return true;
+    }
+    return false;
+  }
+
+  private boolean matchesYearPart(String part, int year) {
+    if (part.isEmpty()) {
+      throw new IllegalArgumentException("Cron 年份字段格式不正确");
+    }
+    String[] stepParts = part.split("/", -1);
+    if (stepParts.length > 2 || stepParts[0].isEmpty()) {
+      throw new IllegalArgumentException("Cron 年份字段格式不正确：" + part);
+    }
+    int step = stepParts.length == 2 ? positiveInt(stepParts[1], "Cron 年份步长") : 1;
+
+    int start;
+    int end;
+    String base = stepParts[0];
+    if ("*".equals(base)) {
+      start = QUARTZ_MIN_YEAR;
+      end = QUARTZ_MAX_YEAR;
+    } else {
+      int rangeIndex = base.indexOf('-');
+      if (rangeIndex > 0) {
+        start = quartzYear(base.substring(0, rangeIndex));
+        end = quartzYear(base.substring(rangeIndex + 1));
+      } else {
+        start = quartzYear(base);
+        end = stepParts.length == 2 ? QUARTZ_MAX_YEAR : start;
+      }
+    }
+    if (end < start) {
+      throw new IllegalArgumentException("Cron 年份范围不正确：" + part);
+    }
+    return year >= start && year <= end && (year - start) % step == 0;
+  }
+
+  private int quartzYear(String value) {
+    int year = positiveInt(value, "Cron 年份");
+    if (year < QUARTZ_MIN_YEAR || year > QUARTZ_MAX_YEAR) {
+      throw new IllegalArgumentException(
+          "Cron 年份必须在 " + QUARTZ_MIN_YEAR + " 到 " + QUARTZ_MAX_YEAR + " 之间：" + value);
+    }
+    return year;
+  }
+
+  private int positiveInt(String value, String label) {
+    try {
+      int parsed = Integer.parseInt(value);
+      if (parsed <= 0) throw new NumberFormatException(value);
+      return parsed;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException(label + "必须是正整数：" + value, exception);
+    }
   }
 
   private String required(String value, String message) {
     if (value == null || value.isBlank()) throw new IllegalArgumentException(message);
     return value.trim();
+  }
+
+  private record NormalizedCron(String expression, boolean fromFiveFields) {
+  }
+
+  private record ParsedCron(CronExpression expression, YearConstraint yearConstraint) {
+  }
+
+  private record YearConstraint(boolean any, List<Integer> allowedYears) {
+    static YearConstraint unrestricted() {
+      return new YearConstraint(true, List.of());
+    }
+
+    boolean matches(int year) {
+      return any || allowedYears.contains(year);
+    }
+
+    Integer nextAllowedYear(int lowerBound) {
+      if (any) return lowerBound;
+      for (Integer year : allowedYears) {
+        if (year >= lowerBound) return year;
+      }
+      return null;
+    }
   }
 
   public record Plan(

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlannerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowBackfillPlannerTest.java
@@ -41,6 +41,42 @@ class WorkflowBackfillPlannerTest {
   }
 
   @Test
+  void shouldKeepStandardFiveFieldNumericWeekdaySemantics() {
+    var plan = planner.plan(
+        "0 2 * * 0",
+        "UTC",
+        LocalDate.of(2026, 8, 2),
+        LocalDate.of(2026, 8, 2));
+
+    assertThat(plan.occurrences()).hasSize(1);
+    assertThat(plan.occurrences().get(0).businessDate()).isEqualTo(LocalDate.of(2026, 8, 2));
+  }
+
+  @Test
+  void shouldTranslateQuartzNumericWeekdayToSpringSemantics() {
+    var plan = planner.plan(
+        "0 0 2 ? * 1",
+        "UTC",
+        LocalDate.of(2026, 8, 2),
+        LocalDate.of(2026, 8, 2));
+
+    assertThat(plan.occurrences()).hasSize(1);
+    assertThat(plan.occurrences().get(0).businessDate()).isEqualTo(LocalDate.of(2026, 8, 2));
+  }
+
+  @Test
+  void shouldApplyQuartzYearFieldWithoutQuartzDependency() {
+    var plan = planner.plan(
+        "0 0 2 * * ? 2027",
+        "UTC",
+        LocalDate.of(2026, 12, 31),
+        LocalDate.of(2027, 1, 1));
+
+    assertThat(plan.occurrences()).hasSize(1);
+    assertThat(plan.occurrences().get(0).businessDate()).isEqualTo(LocalDate.of(2027, 1, 1));
+  }
+
+  @Test
   void shouldRejectAmbiguousFiveFieldDayAndWeekCombination() {
     assertThatThrownBy(() -> planner.plan(
         "0 2 1 * MON",


### PR DESCRIPTION
## 问题

`WorkflowBackfillPlanner` 仍直接引用 `org.quartz.CronExpression`，但 Workflow 模块已经移除了 Quartz 直接依赖，导致编译报错：

```text
WorkflowBackfillPlanner.java:72:11
java: 找不到符号
  符号: 类 CronExpression
```

## 修复

- 将补数 Cron 计算改为 Spring `org.springframework.scheduling.support.CronExpression`
- 不恢复 Workflow -> Quartz 的直接依赖，继续遵守 Yak Ops 调度依赖边界
- 5 字段标准 Cron 使用 Spring/标准星期语义
- 6/7 字段 Quartz-style Cron 在补数计算前转换数字星期语义：Quartz `1-7=SUN-SAT` -> Spring `0-6=SUN-SAT`
- 7 字段 Cron 的年份约束由补数规划器单独保留并过滤，避免因为 Spring 只支持 6 字段而丢失语义
- 保留原有时区、补数范围、最多 1000 个实例等限制

## 测试补充

`WorkflowBackfillPlannerTest` 新增覆盖：

- 5 字段数字星期语义
- 6 字段 Quartz 数字星期转换
- 7 字段年份约束
- 原有时区、5 字段规范化、歧义日/周、最大实例数测试继续保留

## Scope

本 PR 只修改：

- `WorkflowBackfillPlanner.java`
- `WorkflowBackfillPlannerTest.java`

不修改 Workflow Schedule EngineBridge / Lifecycle / Handler，也不增加 Quartz 依赖。

## Validation

- branch 基于最新 `main` (`94fcb96819b3bd9f3e46360707d194950dd9f62a`，已包含 PR #469)
- 1 commit ahead / 0 behind
- repository code search 未发现剩余 `org.quartz` 直接引用
- 当前运行环境无法执行本地 Maven/IDEA 编译，因此不虚报本地构建结果
