### PR TITLE
feat: 整合工作流调度并约束生命周期

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.service.WorkflowDefinitionScheduleGuard;
 import io.yak.ops.business.workflow.service.WorkflowDefinitionService;
 import io.yak.ops.business.workflow.service.WorkflowLaunchService;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
@@ -30,12 +31,15 @@ public class WorkflowDefinitionController {
 
   private final WorkflowDefinitionService definitionService;
   private final WorkflowLaunchService launchService;
+  private final WorkflowDefinitionScheduleGuard scheduleGuard;
 
   public WorkflowDefinitionController(
       WorkflowDefinitionService definitionService,
-      WorkflowLaunchService launchService) {
+      WorkflowLaunchService launchService,
+      WorkflowDefinitionScheduleGuard scheduleGuard) {
     this.definitionService = definitionService;
     this.launchService = launchService;
+    this.scheduleGuard = scheduleGuard;
   }
 
   @Operation(summary = "查询工作流定义")
@@ -91,6 +95,7 @@ public class WorkflowDefinitionController {
   @Operation(summary = "停用工作流正式运行入口")
   @PostMapping("/{id}/offline")
   public Result<WorkflowDefinitionVO> offline(@PathVariable("id") String id) {
+    scheduleGuard.ensureCanOffline(id);
     return Result.success(definitionService.offline(id));
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuard.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuard.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.workflow.service;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleDao;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/** 工作流定义生命周期与调度生命周期之间的约束。 */
+@Component
+public class WorkflowDefinitionScheduleGuard {
+  private final ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider;
+
+  public WorkflowDefinitionScheduleGuard(ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider) {
+    this.scheduleDaoProvider = scheduleDaoProvider;
+  }
+
+  /**
+   * 工作流下线前必须先停用所有在线调度。
+   * database-disabled 的 focused development/test 环境没有调度 DAO，此时保持原有轻量行为。
+   */
+  public void ensureCanOffline(String workflowId) {
+    if (workflowId == null || workflowId.isBlank()) {
+      throw new IllegalArgumentException("工作流 ID 不能为空");
+    }
+
+    WorkflowScheduleDao scheduleDao = scheduleDaoProvider.getIfAvailable();
+    if (scheduleDao == null) return;
+
+    if (!scheduleDao.selectSchedules(workflowId.trim(), "ONLINE").isEmpty()) {
+      throw new IllegalStateException("工作流存在已启用调度，请先停用调度后再下线工作流");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuardTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuardTest.java
@@ -1,0 +1,59 @@
+package io.yak.ops.business.workflow.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowScheduleDao;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowDefinitionScheduleGuardTest {
+
+  @Mock private ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider;
+  @Mock private WorkflowScheduleDao scheduleDao;
+
+  private WorkflowDefinitionScheduleGuard guard;
+
+  @BeforeEach
+  void setUp() {
+    guard = new WorkflowDefinitionScheduleGuard(scheduleDaoProvider);
+  }
+
+  @Test
+  void shouldAllowOfflineWhenSchedulePersistenceIsUnavailable() {
+    when(scheduleDaoProvider.getIfAvailable()).thenReturn(null);
+
+    assertThatCode(() -> guard.ensureCanOffline("workflow-1")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAllowOfflineWhenNoOnlineScheduleExists() {
+    when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
+    when(scheduleDao.selectSchedules("workflow-1", "ONLINE")).thenReturn(List.of());
+
+    assertThatCode(() -> guard.ensureCanOffline("workflow-1")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectOfflineWhenOnlineScheduleExists() {
+    WorkflowSchedulePO schedule = new WorkflowSchedulePO();
+    schedule.setId("schedule-1");
+    schedule.setWorkflowId("workflow-1");
+    schedule.setStatus("ONLINE");
+
+    when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
+    when(scheduleDao.selectSchedules("workflow-1", "ONLINE")).thenReturn(List.of(schedule));
+
+    assertThatThrownBy(() -> guard.ensureCanOffline("workflow-1"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请先停用调度");
+  }
+}

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -69,7 +69,7 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'data-development-task', path: '/data-development/task/:id', title: '开发任务配置', component: './data-development/task', hidden: true, parentId: 'data-development' },
   { id: 'workflow-definition', mode: 'public', path: '/workflow/definitions', title: '工作流定义', component: './workflow/management', iconKey: 'workflow', menuGroup: 'workflow', order: 10 },
   { id: 'workflow-definition-editor', path: '/workflow/definition/:id', title: '工作流配置', component: './workflow/definition', hidden: true, parentId: 'workflow-definition' },
-  { id: 'workflow-schedules', mode: 'public', path: '/workflow/schedules', title: '调度管理', component: './workflow/schedules', iconKey: 'monitor', menuGroup: 'workflow', order: 20 },
+  { id: 'workflow-schedules', path: '/workflow/schedules', title: '调度配置', component: './workflow/schedules', hidden: true, parentId: 'workflow-definition' },
   { id: 'workflow-instances', mode: 'public', path: '/workflow/instances', title: '工作流实例', component: './workflow/instances', iconKey: 'instance', menuGroup: 'workflow', order: 30 },
   { id: 'workflow-instance-detail', path: '/workflow/instances/:executionId', title: '工作流实例详情', component: './workflow/instances/detail', hidden: true, parentId: 'workflow-instances' },
   { id: 'resource-management', mode: 'one', permission: 'resource:view', path: '/resource-management', title: '文件资源', component: './resource-management', iconKey: 'database', menuGroup: 'resources', order: 10 },

--- a/yak-ops-ui/src/pages/workflow/management/WorkflowDefinitionList.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/WorkflowDefinitionList.tsx
@@ -10,7 +10,9 @@ import {
   type WorkflowDefinition,
   type WorkflowDefinitionStatus,
 } from '@/services/workflow/definitions';
+import { listWorkflowSchedules } from '@/services/workflow/schedules';
 import {
+  CalendarOutlined,
   CloudDownloadOutlined,
   CloudUploadOutlined,
   DeleteOutlined,
@@ -341,6 +343,10 @@ export default function WorkflowDefinitionList() {
     history.push(`/workflow/definition/${record.id}?scene=edit`);
   };
 
+  const goToSchedules = (record: WorkflowDefinition) => {
+    history.push(`/workflow/schedules?workflowId=${encodeURIComponent(record.id)}`);
+  };
+
   const handleDelete = (record: WorkflowDefinition) => {
     Modal.confirm({
       centered: true,
@@ -430,9 +436,31 @@ export default function WorkflowDefinitionList() {
     });
   };
 
-  const confirmOffline = (record: WorkflowDefinition) => {
+  const confirmOffline = async (record: WorkflowDefinition) => {
     if (isActiveRuntime(record.latestExecutionStatus)) {
       message.warning('工作流存在活动执行，请先暂停或等待执行结束后再下线');
+      return;
+    }
+
+    try {
+      const onlineSchedules = await listWorkflowSchedules({
+        workflowId: record.id,
+        status: 'ONLINE',
+      });
+      if (onlineSchedules.length > 0) {
+        Modal.warning({
+          centered: true,
+          title: '请先停用工作流调度',
+          content: `当前工作流仍有 ${onlineSchedules.length} 个已启用调度。停用全部调度后才能下线工作流。`,
+          okText: '前往调度配置',
+          onOk: () => goToSchedules(record),
+        });
+        return;
+      }
+    } catch (error) {
+      message.error(
+        error instanceof Error ? error.message : '检查工作流调度状态失败',
+      );
       return;
     }
 
@@ -458,11 +486,14 @@ export default function WorkflowDefinitionList() {
       case 'edit':
         goToDefinition(record);
         break;
+      case 'schedule':
+        goToSchedules(record);
+        break;
       case 'online':
         confirmOnline(record);
         break;
       case 'offline':
-        confirmOffline(record);
+        void confirmOffline(record);
         break;
       case 'delete':
         handleDelete(record);
@@ -488,6 +519,11 @@ export default function WorkflowDefinitionList() {
         icon: <EditOutlined />,
         label: '编辑配置',
         disabled: !canEdit,
+      },
+      {
+        key: 'schedule',
+        icon: <CalendarOutlined />,
+        label: '调度配置',
       },
       { type: 'divider' },
       {
@@ -890,7 +926,7 @@ export default function WorkflowDefinitionList() {
               <span className="mr-2 text-[14px] text-[#faad14]">▲</span>
               <span className="font-medium text-[#344054]">【提示】</span>
               <span>
-                工作流完成节点编排并上线后即可运行；存在活动执行时不可直接下线。
+                工作流完成节点编排并上线后即可运行或启用调度；存在活动执行或已启用调度时不可直接下线。
               </span>
             </div>
           </div>

--- a/yak-ops-ui/src/pages/workflow/schedules/ScheduleEditorDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/ScheduleEditorDrawer.tsx
@@ -27,6 +27,7 @@ interface Props {
   definitions: WorkflowDefinition[];
   workflowId?: string;
   schedule?: WorkflowSchedule;
+  lockWorkflow?: boolean;
   onClose: () => void;
   onSaved: () => Promise<void> | void;
 }
@@ -36,6 +37,7 @@ const ScheduleEditorDrawer = ({
   definitions,
   workflowId,
   schedule,
+  lockWorkflow = false,
   onClose,
   onSaved,
 }: Props) => {
@@ -115,7 +117,7 @@ const ScheduleEditorDrawer = ({
         <Form.Item name="workflowId" label="工作流" rules={[{ required: true, message: '请选择工作流' }]}>
           <Select
             showSearch
-            disabled={Boolean(schedule)}
+            disabled={Boolean(schedule || lockWorkflow)}
             optionFilterProp="label"
             placeholder="选择要配置调度的工作流"
             options={definitions.map((item) => ({

--- a/yak-ops-ui/src/pages/workflow/schedules/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/index.tsx
@@ -8,8 +8,9 @@ import {
   type WorkflowSchedule,
 } from '@/services/workflow/schedules';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
+import { history } from '@umijs/max';
 import { Button, ConfigProvider, Input, Modal, Select, Table, Tooltip, message } from 'antd';
-import { CalendarClock, DatabaseBackup, History, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
+import { ArrowLeft, CalendarClock, DatabaseBackup, History, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import BackfillDrawer from './BackfillDrawer';
 import BackfillHistoryDrawer from './BackfillHistoryDrawer';
@@ -31,11 +32,17 @@ const STRATEGY_LABEL: Record<string, string> = {
 };
 
 const WorkflowSchedulesPage = () => {
+  const scopedWorkflowId = useMemo(() => {
+    const params = new URLSearchParams(history.location.search);
+    return params.get('workflowId') || undefined;
+  }, []);
+  const scoped = Boolean(scopedWorkflowId);
+
   const [definitions, setDefinitions] = useState<WorkflowDefinition[]>([]);
   const [schedules, setSchedules] = useState<WorkflowSchedule[]>([]);
   const [loading, setLoading] = useState(false);
   const [keyword, setKeyword] = useState('');
-  const [workflowId, setWorkflowId] = useState<string>();
+  const [workflowId, setWorkflowId] = useState<string | undefined>(() => scopedWorkflowId);
   const [status, setStatus] = useState<StatusFilter>('ALL');
   const [editorOpen, setEditorOpen] = useState(false);
   const [editing, setEditing] = useState<WorkflowSchedule>();
@@ -51,7 +58,7 @@ const WorkflowSchedulesPage = () => {
     try {
       const [workflowData, scheduleData] = await Promise.all([
         listWorkflowDefinitions(),
-        listWorkflowSchedules(),
+        listWorkflowSchedules(scopedWorkflowId ? { workflowId: scopedWorkflowId } : undefined),
       ]);
       setDefinitions(workflowData || []);
       setSchedules(scheduleData || []);
@@ -60,7 +67,7 @@ const WorkflowSchedulesPage = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [scopedWorkflowId]);
 
   useEffect(() => {
     void load();
@@ -70,6 +77,10 @@ const WorkflowSchedulesPage = () => {
     () => new Map(definitions.map((item) => [item.id, item])),
     [definitions],
   );
+
+  const scopedWorkflow = scopedWorkflowId
+    ? workflowMap.get(scopedWorkflowId)
+    : undefined;
 
   const filtered = useMemo(() => {
     const q = keyword.trim().toLowerCase();
@@ -254,10 +265,29 @@ const WorkflowSchedulesPage = () => {
   return (
     <ConfigProvider theme={{ token: { borderRadius: 9, colorBorder: '#eaecf0' }, components: { Input: { activeShadow: 'none' } } }}>
       <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4 text-[#161823]">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="m-0 text-[17px] font-semibold leading-8">调度管理</h1>
-            <div className="text-[11px] text-[#98a2b3]">Yak Schedule / Quartz · Trigger Ledger、Backfill、调度参数与恢复</div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-2.5">
+            {scoped && (
+              <Tooltip title="返回工作流定义">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<ArrowLeft size={15} />}
+                  className="!h-8 !w-8 !px-0"
+                  onClick={() => history.push('/workflow/definitions')}
+                />
+              </Tooltip>
+            )}
+            <div className="min-w-0">
+              <h1 className="m-0 truncate text-[17px] font-semibold leading-8">
+                {scoped ? '调度配置' : '调度管理'}
+              </h1>
+              <div className="truncate text-[11px] text-[#98a2b3]">
+                {scoped
+                  ? `${scopedWorkflow?.name || scopedWorkflowId} · ${scopedWorkflow?.status === 'ONLINE' ? '工作流已上线，可启用调度' : '工作流未上线，调度可配置但不能启用'}`
+                  : 'Yak Schedule / Quartz · Trigger Ledger、Backfill、调度参数与恢复'}
+              </div>
+            </div>
           </div>
           <div className="flex items-center gap-2">
             <Button size="small" icon={<History size={14} />} onClick={() => setBackfillHistoryOpen(true)}>
@@ -272,8 +302,9 @@ const WorkflowSchedulesPage = () => {
         <div className="mt-4 flex min-h-[52px] items-center justify-between gap-3 border-y border-[#f0f0f0]">
           <div className="flex items-center gap-2">
             <Select
-              allowClear
+              allowClear={!scoped}
               showSearch
+              disabled={scoped}
               optionFilterProp="label"
               placeholder="全部工作流"
               className="w-[220px]"
@@ -297,7 +328,7 @@ const WorkflowSchedulesPage = () => {
         </div>
 
         <div className="mt-3 flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
-          <span><b>【调度参数】</b> Cron 与 Backfill 均按逻辑计划时间注入 businessDate / scheduleTime；历史补数复用 Trigger Ledger 幂等、串行等待与并行执行。</span>
+          <span><b>【调度参数】</b> 工作流上线后才能启用调度；Cron 与 Backfill 均按逻辑计划时间注入 businessDate / scheduleTime。</span>
         </div>
 
         <div className="mt-4 flex-1">
@@ -318,7 +349,8 @@ const WorkflowSchedulesPage = () => {
           open={editorOpen}
           definitions={definitions}
           schedule={editing}
-          workflowId={workflowId}
+          workflowId={scopedWorkflowId || workflowId}
+          lockWorkflow={scoped}
           onClose={() => { setEditorOpen(false); setEditing(undefined); }}
           onSaved={load}
         />


### PR DESCRIPTION
## Summary
- 从工作流定义列表直接进入当前工作流的调度配置，调度页支持 `workflowId` 上下文并锁定工作流选择
- 将独立“调度管理”从主菜单中移除，保留 `/workflow/schedules` 作为工作流定义下的深链配置页面
- 工作流下线前检查是否仍有 ONLINE 调度；前端提前提示并引导停用，后端再次做强制校验
- 保留现有“工作流必须先上线并有生效版本，调度才能启用”的后端约束
- 新增工作流下线调度 Guard 单元测试

## Lifecycle
1. 工作流草稿完成编排并上线
2. 创建调度；只有工作流 ONLINE 时才能启用调度
3. 若工作流存在 ONLINE 调度，禁止直接下线工作流
4. 先停用全部调度后，才允许下线工作流

## Test Plan
- [x] 新增 `WorkflowDefinitionScheduleGuardTest`，覆盖无 DAO、无在线调度、存在在线调度三种情况
- [ ] 本环境未执行本地 Maven / UI 构建，等待 PR CI 验证
