### PR TITLE
feat(bi): add dashboard sheet workspace (phase 2)

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChartEditor } from './chart-editor';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
+import { DashboardSheetBar } from './sheet-bar';
 import { DashboardToolbar } from './toolbar';
 import { useDashboardDesigner } from './use-dashboard';
 import { DashboardVersionHistoryDrawer } from './version-history-drawer';
@@ -28,6 +29,9 @@ export default function DashboardEditorPage() {
   const designer = useDashboardDesigner(dashboardId, initialPreview, false);
   const { width, containerRef, mounted } = useContainerWidth();
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [activeSheet, setActiveSheet] = useState<'dashboard' | 'chart'>('dashboard');
+  const [activeSheetId, setActiveSheetId] = useState<string>();
+  const [sheetOrder, setSheetOrder] = useState<string[]>([]);
   const layout = useMemo(() => designer.widgets.map((widget) => ({
     i: widget.id,
     x: widget.x,
@@ -37,14 +41,74 @@ export default function DashboardEditorPage() {
     minW: widget.minW,
     minH: widget.minH,
   })), [designer.widgets]);
+  const sheets = useMemo(() => sheetOrder.flatMap((widgetId) => {
+    const widget = designer.widgets.find((item) => item.id === widgetId);
+    if (!widget) return [];
+    const analysis = widget.analysisId
+      ? designer.analyses.find((item) => item.id === widget.analysisId)
+      : undefined;
+    return [{
+      id: widget.id,
+      title: widget.analysisId ? analysis?.name ?? '历史图表' : widget.title ?? '未命名图表',
+    }];
+  }), [designer.analyses, designer.widgets, sheetOrder]);
   const hasGlobalFilters = designer.dashboard.globalFilters.length > 0;
   const showRuntimeFilterBar = designer.preview && hasGlobalFilters;
-  let canvasMinHeight = 'min-h-[calc(100vh-88px)] 2xl:min-h-[calc(100vh-56px)]';
+  let canvasMinHeight = 'min-h-[calc(100vh-128px)] 2xl:min-h-[calc(100vh-96px)]';
   if (designer.preview) {
     canvasMinHeight = showRuntimeFilterBar
       ? 'min-h-[calc(100vh-140px)]'
       : 'min-h-[calc(100vh-96px)]';
   }
+
+  useEffect(() => {
+    setSheetOrder(designer.widgets.map((widget) => widget.id));
+    setActiveSheet('dashboard');
+    setActiveSheetId(undefined);
+  }, [designer.dashboard.id]);
+
+  useEffect(() => {
+    const widgetIds = designer.widgets.map((widget) => widget.id);
+    setSheetOrder((current) => {
+      const retained = current.filter((widgetId) => widgetIds.includes(widgetId));
+      const added = widgetIds.filter((widgetId) => !retained.includes(widgetId));
+      const next = [...retained, ...added];
+      return next.length === current.length && next.every((item, index) => item === current[index])
+        ? current
+        : next;
+    });
+  }, [designer.widgets]);
+
+  useEffect(() => {
+    if (designer.preview) return;
+    if (designer.selectedId) {
+      setActiveSheet('chart');
+      setActiveSheetId(designer.selectedId);
+      return;
+    }
+    setActiveSheet('dashboard');
+    setActiveSheetId(undefined);
+  }, [designer.preview, designer.selectedId]);
+
+  const activateDashboardSheet = () => {
+    setActiveSheet('dashboard');
+    setActiveSheetId(undefined);
+    designer.setSelectedId(undefined);
+  };
+
+  const activateChartSheet = (widgetId: string, scrollIntoView = true) => {
+    setActiveSheet('chart');
+    setActiveSheetId(widgetId);
+    designer.setSelectedId(widgetId);
+    if (!scrollIntoView) return;
+    window.requestAnimationFrame(() => {
+      document.getElementById(`dashboard-widget-${widgetId}`)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'nearest',
+      });
+    });
+  };
 
   const addChart = () => designer.addWidget('bar');
 
@@ -255,7 +319,7 @@ export default function DashboardEditorPage() {
                     const drillPath = designer.drillPathForWidget(widget.id);
 
                     return (
-                      <div key={widget.id}>
+                      <div key={widget.id} id={`dashboard-widget-${widget.id}`}>
                         <WidgetShell
                           widget={widget}
                           analysis={analysis}
@@ -266,7 +330,7 @@ export default function DashboardEditorPage() {
                           selected={designer.selectedId === widget.id}
                           preview={designer.preview}
                           onSelect={() => {
-                            if (!designer.preview) designer.setSelectedId(widget.id);
+                            if (!designer.preview) activateChartSheet(widget.id, false);
                           }}
                           onDataSelect={(selection) => {
                             if (!designer.preview) return;
@@ -335,6 +399,17 @@ export default function DashboardEditorPage() {
           />
         ) : null}
       </div>
+
+      {!designer.preview ? (
+        <DashboardSheetBar
+          sheets={sheets}
+          activeSheet={activeSheet}
+          activeSheetId={activeSheetId}
+          onDashboard={activateDashboardSheet}
+          onChart={(widgetId) => activateChartSheet(widgetId)}
+          onReorder={setSheetOrder}
+        />
+      ) : null}
 
       {designer.persisted ? (
         <DashboardVersionHistoryDrawer

--- a/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
@@ -1,0 +1,93 @@
+import { BarChart3, LayoutDashboard } from 'lucide-react';
+import { useState } from 'react';
+
+export type DashboardEditorSheet = {
+  id: string;
+  title: string;
+};
+
+export function DashboardSheetBar({
+  sheets,
+  activeSheet,
+  activeSheetId,
+  onDashboard,
+  onChart,
+  onReorder,
+}: {
+  sheets: DashboardEditorSheet[];
+  activeSheet: 'dashboard' | 'chart';
+  activeSheetId?: string;
+  onDashboard: () => void;
+  onChart: (sheetId: string) => void;
+  onReorder: (sheetIds: string[]) => void;
+}) {
+  const [draggingId, setDraggingId] = useState<string>();
+
+  const moveBefore = (targetId: string) => {
+    if (!draggingId || draggingId === targetId) return;
+    const ids = sheets.map((sheet) => sheet.id);
+    const from = ids.indexOf(draggingId);
+    const to = ids.indexOf(targetId);
+    if (from < 0 || to < 0) return;
+    ids.splice(from, 1);
+    ids.splice(to, 0, draggingId);
+    onReorder(ids);
+  };
+
+  const baseClass = 'flex h-full shrink-0 items-center gap-1.5 border-x px-3 text-[11px] transition-colors';
+  const inactiveClass = 'border-transparent text-[#667085] hover:bg-white/70 hover:text-[#344054]';
+  const activeClass = 'border-[#dfe3e8] bg-white font-medium text-[#161823] shadow-[inset_0_2px_0_var(--yak-brand-color)]';
+
+  return (
+    <div className="flex h-10 shrink-0 items-stretch border-t border-[#dfe3e8] bg-[#f7f8fa]">
+      <button
+        type="button"
+        className={`${baseClass} ${activeSheet === 'dashboard' ? activeClass : inactiveClass}`}
+        onClick={onDashboard}
+      >
+        <LayoutDashboard size={13} />
+        仪表盘
+      </button>
+
+      <div className="h-full w-px shrink-0 bg-[#e5e7eb]" />
+
+      <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden">
+        {sheets.map((sheet) => {
+          const active = activeSheet === 'chart' && activeSheetId === sheet.id;
+          return (
+            <button
+              key={sheet.id}
+              type="button"
+              draggable
+              title={`${sheet.title} · 拖动可调整 Sheet 顺序`}
+              className={`${baseClass} max-w-[220px] cursor-pointer ${active ? activeClass : inactiveClass} ${draggingId === sheet.id ? 'opacity-45' : ''}`}
+              onClick={() => onChart(sheet.id)}
+              onDragStart={(event) => {
+                setDraggingId(sheet.id);
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', sheet.id);
+              }}
+              onDragOver={(event) => {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = 'move';
+                moveBefore(sheet.id);
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                moveBefore(sheet.id);
+              }}
+              onDragEnd={() => setDraggingId(undefined)}
+            >
+              <BarChart3 size={12} className="shrink-0" />
+              <span className="truncate">{sheet.title}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex shrink-0 items-center border-l border-[#e5e7eb] px-3 text-[10px] text-[#98a2b3]">
+        {sheets.length} 个图表
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
@@ -67,15 +67,12 @@ export function DashboardSheetBar({
                 event.dataTransfer.effectAllowed = 'move';
                 event.dataTransfer.setData('text/plain', sheet.id);
               }}
+              onDragEnter={() => moveBefore(sheet.id)}
               onDragOver={(event) => {
                 event.preventDefault();
                 event.dataTransfer.dropEffect = 'move';
-                moveBefore(sheet.id);
               }}
-              onDrop={(event) => {
-                event.preventDefault();
-                moveBefore(sheet.id);
-              }}
+              onDrop={(event) => event.preventDefault()}
               onDragEnd={() => setDraggingId(undefined)}
             >
               <BarChart3 size={12} className="shrink-0" />


### PR DESCRIPTION
## What changed
- add an Excel-like bottom Sheet bar to the dashboard editor
- keep a fixed `仪表盘` Sheet plus one Sheet per existing dashboard chart/widget
- derive chart Sheets entirely from the existing Dashboard widgets; no new persisted Sheet model or backend/API changes
- introduce editor-only `activeSheet`, `activeSheetId`, and `sheetOrder` state as the foundation for the next chart-Sheet workspace phase
- keep Sheet selection synchronized with canvas widget selection and the existing right-side chart editor
- clicking a chart Sheet selects the matching widget and scrolls it into view
- clicking the dashboard Sheet clears chart selection and returns to the full-dashboard editing context
- keep Sheet order stable when charts are added/deleted and allow chart Sheets to be reordered by drag without changing Dashboard JSON
- hide the Sheet bar in preview mode and adjust editor canvas height for the new bottom workspace

## Compatibility
- no Dashboard document/schema changes
- no database/backend changes
- no dataset/analysis model changes
- existing add / duplicate / delete / undo / redo / save / publish flows remain on the current Dashboard widget model

## Out of scope (Phase 3)
- moving the right-side `ChartEditor` into a dedicated chart Sheet workspace
- left configuration + central chart preview layout inside chart Sheets
- removing the existing right-side chart settings panel
- filter model/API cleanup

## Validation
- [x] Phase 1 PR #476 is merged into `main`; this branch is based directly on that merged commit
- [x] reviewed branch diff against `main` (2 frontend files changed)
- [x] no persisted Dashboard model/backend files changed
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] manual browser regression check

Local validation could not be run from the current execution environment because outbound GitHub/network access is unavailable, so the lint/build/browser items are intentionally left unchecked.