### PR TITLE
feat(bi): move chart editing into chart sheets (phase 3)

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -1,0 +1,112 @@
+import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
+import { Empty } from 'antd';
+import { BarChart3, Database } from 'lucide-react';
+import { ChartEditor } from './chart-editor';
+import type {
+  AnalysisAsset,
+  DashboardFilter,
+  DashboardGlobalFilter,
+  DashboardInlineAnalysisSpec,
+  DashboardInteraction,
+  DashboardWidget,
+  PublishedDataset,
+} from './model';
+
+export function DashboardChartSheetWorkspace({
+  currentDashboardId,
+  widget,
+  datasets,
+  analyses,
+  globalFilters,
+  interactions,
+  runtimeFilters,
+  updateWidget,
+  updateInlineAnalysis,
+  updateInteractions,
+  changeDataset,
+  detachAnalysis,
+  onDone,
+}: {
+  currentDashboardId: string;
+  widget: DashboardWidget;
+  datasets: PublishedDataset[];
+  analyses: AnalysisAsset[];
+  globalFilters: DashboardGlobalFilter[];
+  interactions: DashboardInteraction[];
+  runtimeFilters: DashboardFilter[];
+  updateWidget: (patch: Partial<DashboardWidget>) => void;
+  updateInlineAnalysis: (patch: Partial<DashboardInlineAnalysisSpec>) => void;
+  updateInteractions: (interactions: DashboardInteraction[]) => void;
+  changeDataset: (datasetId: string) => void;
+  detachAnalysis: () => void;
+  onDone: () => void;
+}) {
+  const analysis = widget.analysisId
+    ? analyses.find((item) => item.id === widget.analysisId)
+    : undefined;
+  const spec = widget.analysisId ? analysis : widget.inlineAnalysis;
+  const dataset = spec
+    ? datasets.find((item) => item.id === spec.datasetId)
+    : undefined;
+  const title = widget.analysisId
+    ? analysis?.name ?? '历史图表'
+    : widget.title?.trim() || '未命名图表';
+
+  return (
+    <div className="chart-sheet-workspace flex min-h-0 flex-1 overflow-hidden bg-[#f3f4f6]">
+      <ChartEditor
+        currentDashboardId={currentDashboardId}
+        widget={widget}
+        datasets={datasets}
+        analyses={analyses}
+        globalFilters={globalFilters}
+        interactions={interactions}
+        updateWidget={updateWidget}
+        updateInlineAnalysis={updateInlineAnalysis}
+        updateInteractions={updateInteractions}
+        changeDataset={changeDataset}
+        detachAnalysis={detachAnalysis}
+        close={onDone}
+      />
+
+      <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">
+        <div className="flex min-h-full p-5 2xl:p-6">
+          <div className="mx-auto flex min-h-[560px] w-full max-w-[1320px] flex-1 flex-col">
+            <div className="flex h-9 shrink-0 items-center justify-between gap-4 px-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <BarChart3 size={14} className="shrink-0 text-[#667085]" />
+                <span className="truncate text-[13px] font-semibold text-[#344054]">
+                  {title}
+                </span>
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5 text-[10px] text-[#98a2b3]">
+                <Database size={11} />
+                <span className="max-w-[220px] truncate">
+                  {dataset?.name ?? '数据来源不可用'}
+                </span>
+              </div>
+            </div>
+
+            <div className="mt-2 min-h-0 flex-1 overflow-hidden rounded-[10px] border border-[#e1e4e8] bg-white">
+              {spec && dataset ? (
+                <AnalysisPreview
+                  spec={spec}
+                  dataset={dataset}
+                  runtimeFilters={runtimeFilters}
+                  className="h-full min-h-[500px] p-4"
+                />
+              ) : (
+                <div className="flex min-h-[500px] items-center justify-center">
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description={spec ? '图表数据来源已失效' : '图表配置不可用'}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -6,7 +6,7 @@ import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ChartEditor } from './chart-editor';
+import { DashboardChartSheetWorkspace } from './chart-sheet-workspace';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
 import { DashboardSheetBar } from './sheet-bar';
@@ -96,18 +96,10 @@ export default function DashboardEditorPage() {
     designer.setSelectedId(undefined);
   };
 
-  const activateChartSheet = (widgetId: string, scrollIntoView = true) => {
+  const activateChartSheet = (widgetId: string) => {
     setActiveSheet('chart');
     setActiveSheetId(widgetId);
     designer.setSelectedId(widgetId);
-    if (!scrollIntoView) return;
-    window.requestAnimationFrame(() => {
-      document.getElementById(`dashboard-widget-${widgetId}`)?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-        inline: 'nearest',
-      });
-    });
   };
 
   const addChart = () => designer.addWidget('bar');
@@ -227,6 +219,8 @@ export default function DashboardEditorPage() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [designer, saveDashboard]);
 
+  const showDashboardWorkspace = designer.preview || activeSheet === 'dashboard';
+
   return (
     <div
       className="flex h-screen min-h-[640px] flex-col overflow-hidden bg-[#f3f4f6]"
@@ -276,116 +270,117 @@ export default function DashboardEditorPage() {
       ) : null}
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">
-          <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-4 2xl:p-0'}>
-            <div
-              ref={containerRef}
-              className={[
-                'min-w-[760px]',
-                canvasMinHeight,
-                designer.preview
-                  ? 'mx-auto max-w-[1480px] rounded-[10px] border border-[#e7e9ed] bg-white shadow-[0_6px_24px_rgba(16,24,40,.055)]'
-                  : 'dashboard-grid-canvas mx-auto max-w-[1540px] rounded-[10px] 2xl:mx-0 2xl:max-w-none 2xl:rounded-none',
-              ].join(' ')}
-              onMouseDown={(event) => {
-                if (event.target === event.currentTarget) designer.setSelectedId(undefined);
-              }}
-            >
-              {mounted && width > 0 ? (
-                <ReactGridLayout
-                  width={width}
-                  layout={layout}
-                  gridConfig={{
-                    cols: GRID_COLUMNS,
-                    rowHeight: GRID_ROW_HEIGHT,
-                    margin: [10, 10],
-                    containerPadding: [10, 10],
-                  }}
-                  dragConfig={{
-                    enabled: !designer.preview,
-                    handle: '.dashboard-widget__drag-handle',
-                  }}
-                  resizeConfig={{ enabled: !designer.preview }}
-                  onLayoutChange={designer.updateLayout}
-                >
-                  {designer.widgets.map((widget) => {
-                    const analysis = widget.analysisId
-                      ? designer.analyses.find((item) => item.id === widget.analysisId)
-                      : undefined;
-                    const runtimeSpec = designer.runtimeSpecForWidget(widget.id);
-                    const dataset = runtimeSpec
-                      ? designer.datasets.find((item) => item.id === runtimeSpec.datasetId)
-                      : undefined;
-                    const drillPath = designer.drillPathForWidget(widget.id);
+        {showDashboardWorkspace ? (
+          <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">
+            <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-4 2xl:p-0'}>
+              <div
+                ref={containerRef}
+                className={[
+                  'min-w-[760px]',
+                  canvasMinHeight,
+                  designer.preview
+                    ? 'mx-auto max-w-[1480px] rounded-[10px] border border-[#e7e9ed] bg-white shadow-[0_6px_24px_rgba(16,24,40,.055)]'
+                    : 'dashboard-grid-canvas mx-auto max-w-[1540px] rounded-[10px] 2xl:mx-0 2xl:max-w-none 2xl:rounded-none',
+                ].join(' ')}
+                onMouseDown={(event) => {
+                  if (event.target === event.currentTarget) designer.setSelectedId(undefined);
+                }}
+              >
+                {mounted && width > 0 ? (
+                  <ReactGridLayout
+                    width={width}
+                    layout={layout}
+                    gridConfig={{
+                      cols: GRID_COLUMNS,
+                      rowHeight: GRID_ROW_HEIGHT,
+                      margin: [10, 10],
+                      containerPadding: [10, 10],
+                    }}
+                    dragConfig={{
+                      enabled: !designer.preview,
+                      handle: '.dashboard-widget__drag-handle',
+                    }}
+                    resizeConfig={{ enabled: !designer.preview }}
+                    onLayoutChange={designer.updateLayout}
+                  >
+                    {designer.widgets.map((widget) => {
+                      const analysis = widget.analysisId
+                        ? designer.analyses.find((item) => item.id === widget.analysisId)
+                        : undefined;
+                      const runtimeSpec = designer.runtimeSpecForWidget(widget.id);
+                      const dataset = runtimeSpec
+                        ? designer.datasets.find((item) => item.id === runtimeSpec.datasetId)
+                        : undefined;
+                      const drillPath = designer.drillPathForWidget(widget.id);
 
-                    return (
-                      <div key={widget.id} id={`dashboard-widget-${widget.id}`}>
-                        <WidgetShell
-                          widget={widget}
-                          analysis={analysis}
-                          runtimeSpec={runtimeSpec}
-                          dataset={dataset}
-                          runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
-                          drillPath={drillPath}
-                          selected={designer.selectedId === widget.id}
-                          preview={designer.preview}
-                          onSelect={() => {
-                            if (!designer.preview) activateChartSheet(widget.id, false);
-                          }}
-                          onDataSelect={(selection) => {
-                            if (!designer.preview) return;
-                            const target = designer.handleWidgetSelection(widget.id, selection);
-                            if (target) history.push(target);
-                          }}
-                          onDrillBack={(depth) => designer.drillBack(widget.id, depth)}
-                          onDuplicate={() => designer.duplicateWidget(widget.id)}
-                          onDelete={() => designer.deleteWidget(widget.id)}
-                        />
+                      return (
+                        <div key={widget.id} id={`dashboard-widget-${widget.id}`}>
+                          <WidgetShell
+                            widget={widget}
+                            analysis={analysis}
+                            runtimeSpec={runtimeSpec}
+                            dataset={dataset}
+                            runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
+                            drillPath={drillPath}
+                            selected={designer.selectedId === widget.id}
+                            preview={designer.preview}
+                            onSelect={() => {
+                              if (!designer.preview) activateChartSheet(widget.id);
+                            }}
+                            onDataSelect={(selection) => {
+                              if (!designer.preview) return;
+                              const target = designer.handleWidgetSelection(widget.id, selection);
+                              if (target) history.push(target);
+                            }}
+                            onDrillBack={(depth) => designer.drillBack(widget.id, depth)}
+                            onDuplicate={() => designer.duplicateWidget(widget.id)}
+                            onDelete={() => designer.deleteWidget(widget.id)}
+                          />
+                        </div>
+                      );
+                    })}
+                  </ReactGridLayout>
+                ) : null}
+
+                {!designer.widgets.length && !designer.datasetsLoading ? (
+                  <div className="flex min-h-[420px] items-center justify-center px-6 text-center">
+                    <div className="max-w-[340px]">
+                      <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-[10px] bg-white text-[#7a818c] shadow-[0_1px_2px_rgba(16,24,40,.04)]">
+                        <BarChart3 size={18} />
                       </div>
-                    );
-                  })}
-                </ReactGridLayout>
-              ) : null}
-
-              {!designer.widgets.length && !designer.datasetsLoading ? (
-                <div className="flex min-h-[420px] items-center justify-center px-6 text-center">
-                  <div className="max-w-[340px]">
-                    <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-[10px] bg-white text-[#7a818c] shadow-[0_1px_2px_rgba(16,24,40,.04)]">
-                      <BarChart3 size={18} />
+                      <div className="mt-3 text-[14px] font-semibold text-[#344054]">
+                        {designer.activeDataset ? '从一个图表开始' : '暂无可用数据集'}
+                      </div>
+                      <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+                        {designer.activeDataset
+                          ? '添加图表后，进入对应图表 Sheet 完成数据与样式配置。'
+                          : '请先在数据开发发布中心发布并上线 Dataset。'}
+                      </div>
+                      {designer.activeDataset ? (
+                        <Button
+                          size="small"
+                          className="mt-4 !h-8 !rounded-[7px] !px-3"
+                          icon={<BarChart3 size={13} />}
+                          onClick={addChart}
+                        >
+                          添加图表
+                        </Button>
+                      ) : null}
                     </div>
-                    <div className="mt-3 text-[14px] font-semibold text-[#344054]">
-                      {designer.activeDataset ? '从一个图表开始' : '暂无可用数据集'}
-                    </div>
-                    <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-                      {designer.activeDataset
-                        ? '添加图表后，在右侧选择数据集、维度和指标即可完成配置。'
-                        : '请先在数据开发发布中心发布并上线 Dataset。'}
-                    </div>
-                    {designer.activeDataset ? (
-                      <Button
-                        size="small"
-                        className="mt-4 !h-8 !rounded-[7px] !px-3"
-                        icon={<BarChart3 size={13} />}
-                        onClick={addChart}
-                      >
-                        添加图表
-                      </Button>
-                    ) : null}
                   </div>
-                </div>
-              ) : null}
+                ) : null}
+              </div>
             </div>
-          </div>
-        </main>
-
-        {!designer.preview && designer.selectedWidget ? (
-          <ChartEditor
+          </main>
+        ) : designer.selectedWidget ? (
+          <DashboardChartSheetWorkspace
             currentDashboardId={designer.dashboard.id}
             widget={designer.selectedWidget}
             datasets={designer.datasets}
             analyses={designer.analyses}
             globalFilters={designer.dashboard.globalFilters}
             interactions={designer.dashboard.interactions}
+            runtimeFilters={designer.runtimeFiltersForWidget(designer.selectedWidget.id)}
             updateWidget={(patch) =>
               designer.updateWidget(designer.selectedWidget!.id, patch)}
             updateInlineAnalysis={(patch) =>
@@ -395,7 +390,7 @@ export default function DashboardEditorPage() {
               designer.changeWidgetDataset(designer.selectedWidget!.id, datasetId)}
             detachAnalysis={() =>
               designer.detachAnalysis(designer.selectedWidget!.id)}
-            close={() => designer.setSelectedId(undefined)}
+            onDone={activateDashboardSheet}
           />
         ) : null}
       </div>
@@ -406,7 +401,7 @@ export default function DashboardEditorPage() {
           activeSheet={activeSheet}
           activeSheetId={activeSheetId}
           onDashboard={activateDashboardSheet}
-          onChart={(widgetId) => activateChartSheet(widgetId)}
+          onChart={activateChartSheet}
           onReorder={setSheetOrder}
         />
       ) : null}
@@ -442,6 +437,10 @@ export default function DashboardEditorPage() {
           border-width: 0 1px 1px 0 !important;
           height: 6px !important;
           width: 6px !important;
+        }
+        .chart-sheet-workspace > aside {
+          border-left: 0 !important;
+          border-right: 1px solid #e3e6ea !important;
         }
         .chart-editor-more > .ant-collapse-item {
           border-bottom: 1px solid #eceef1 !important;


### PR DESCRIPTION
## What changed
- turn each chart Sheet into a dedicated chart editing workspace instead of keeping the Dashboard canvas visible behind the old right-side settings panel
- keep the `仪表盘` Sheet focused on layout / drag / resize only
- clicking a chart on the Dashboard canvas now enters that chart's Sheet directly
- reuse the existing `ChartEditor` capabilities inside the chart Sheet as a left-side configuration column
- add a large central chart preview that updates from the same inline Analysis spec and current runtime filters
- move the old settings panel visually from the right edge to the left side of the chart Sheet without duplicating chart configuration state
- keep legacy shared Analysis charts previewable and preserve the existing “复制为可编辑图表” migration flow
- return to the Dashboard Sheet via the existing close / 完成 action or the bottom `仪表盘` Sheet
- update the empty Dashboard hint so chart configuration points users to the corresponding chart Sheet

## Workspace responsibility after this PR

### 仪表盘 Sheet
- component layout
- drag / resize
- add / duplicate / delete chart widgets
- preview / save / publish lifecycle

### 图表 Sheet
- chart title
- dataset
- chart type
- dimensions / metrics / aggregation
- interaction settings
- style / query settings
- large live preview

## Compatibility
- no Dashboard document/schema changes
- no database/backend changes
- no Dataset / Analysis persistence changes
- chart Sheets still derive from existing Dashboard widgets
- existing `ChartEditor` logic is reused rather than rewritten
- existing save / publish / undo / redo flows stay on the current Dashboard model

## Out of scope (Phase 4)
- deleting/refactoring the old panel-oriented `ChartEditor` shell now that it is hosted inside chart Sheets
- Sheet rename / more advanced Sheet management polish
- filter model/API cleanup
- additional chart editor UX refinement after hands-on feedback

## Validation
- [x] Phase 2 PR #477 is merged into `main`; this branch is based directly on that merge commit
- [x] reviewed branch diff against `main` (2 frontend files changed)
- [x] no persisted Dashboard/backend model files changed
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] manual browser regression check

The current execution environment cannot resolve GitHub from the local container, so executable frontend validation is intentionally left unchecked rather than being claimed as completed.