### PR TITLE
refactor(bi): polish chart sheet editing experience (phase 4)

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -21,7 +21,7 @@ import type {
 } from './model';
 import { DashboardWidgetActionEditor } from './widget-action-editor';
 
-export function ChartEditor({
+export function ChartSheetConfigPanel({
   currentDashboardId,
   widget,
   datasets,
@@ -33,7 +33,7 @@ export function ChartEditor({
   updateInteractions,
   changeDataset,
   detachAnalysis,
-  close,
+  onDone,
 }: {
   currentDashboardId: string;
   widget: DashboardWidget;
@@ -46,7 +46,7 @@ export function ChartEditor({
   updateInteractions: (interactions: DashboardInteraction[]) => void;
   changeDataset: (datasetId: string) => void;
   detachAnalysis: () => void;
-  close: () => void;
+  onDone: () => void;
 }) {
   if (widget.analysisId) {
     const analysis = analyses.find((item) => item.id === widget.analysisId);
@@ -55,8 +55,8 @@ export function ChartEditor({
       : undefined;
 
     return (
-      <aside className="flex w-[344px] shrink-0 flex-col border-l border-[#e8eaee] bg-white">
-        <EditorHeader onClose={close} />
+      <section className="chart-sheet-config-panel flex w-[360px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
+        <ConfigPanelHeader onDone={onDone} />
         <div className="p-4">
           <div className="rounded-[8px] border border-[#e7e9ed] bg-[#fafbfc] p-3.5">
             <div className="truncate text-[12px] font-semibold text-[#344054]">
@@ -84,7 +84,7 @@ export function ChartEditor({
             复制为可编辑图表
           </Button>
         </div>
-      </aside>
+      </section>
     );
   }
 
@@ -159,8 +159,8 @@ export function ChartEditor({
     updateInlineAnalysis({ style: { ...spec.style, ...patch } });
 
   return (
-    <aside className="flex w-[344px] shrink-0 flex-col border-l border-[#e8eaee] bg-white">
-      <EditorHeader onClose={close} />
+    <section className="chart-sheet-config-panel flex w-[360px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
+      <ConfigPanelHeader onDone={onDone} />
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
         <div className="space-y-4">
@@ -356,11 +356,11 @@ export function ChartEditor({
       </div>
 
       <div className="shrink-0 border-t border-[#eceef1] bg-[#fbfcfd] p-3">
-        <Button block size="small" className="!h-8 !rounded-[7px]" onClick={close}>
+        <Button block size="small" className="!h-8 !rounded-[7px]" onClick={onDone}>
           完成
         </Button>
       </div>
-    </aside>
+    </section>
   );
 }
 
@@ -372,18 +372,18 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-function EditorHeader({ onClose }: { onClose: () => void }) {
+function ConfigPanelHeader({ onDone }: { onDone: () => void }) {
   return (
     <div className="flex h-14 shrink-0 items-center justify-between border-b border-[#eceef1] px-4">
       <div>
-        <div className="text-[13px] font-semibold text-[#344054]">图表设置</div>
+        <div className="text-[13px] font-semibold text-[#344054]">图表配置</div>
         <div className="mt-0.5 text-[9px] text-[#98a2b3]">数据、展示与交互配置</div>
       </div>
       <button
         type="button"
-        onClick={onClose}
+        onClick={onDone}
         className="flex h-7 w-7 items-center justify-center rounded-[6px] border-0 bg-transparent text-[#7a818c] hover:bg-[#f5f6f7] hover:text-[#344054]"
-        aria-label="关闭图表编辑"
+        aria-label="返回仪表盘 Sheet"
       >
         <X size={14} />
       </button>

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -1,7 +1,8 @@
 import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
 import { Empty } from 'antd';
 import { BarChart3, Database } from 'lucide-react';
-import { ChartEditor } from './chart-editor';
+import { ChartSheetConfigPanel } from './chart-editor';
+import { CHART_META } from './helpers';
 import type {
   AnalysisAsset,
   DashboardFilter,
@@ -51,10 +52,11 @@ export function DashboardChartSheetWorkspace({
   const title = widget.analysisId
     ? analysis?.name ?? '历史图表'
     : widget.title?.trim() || '未命名图表';
+  const chartTypeLabel = spec ? CHART_META[spec.type]?.label : undefined;
 
   return (
     <div className="chart-sheet-workspace flex min-h-0 flex-1 overflow-hidden bg-[#f3f4f6]">
-      <ChartEditor
+      <ChartSheetConfigPanel
         currentDashboardId={currentDashboardId}
         widget={widget}
         datasets={datasets}
@@ -66,18 +68,23 @@ export function DashboardChartSheetWorkspace({
         updateInteractions={updateInteractions}
         changeDataset={changeDataset}
         detachAnalysis={detachAnalysis}
-        close={onDone}
+        onDone={onDone}
       />
 
       <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">
         <div className="flex min-h-full p-5 2xl:p-6">
           <div className="mx-auto flex min-h-[560px] w-full max-w-[1320px] flex-1 flex-col">
-            <div className="flex h-9 shrink-0 items-center justify-between gap-4 px-1">
+            <div className="flex h-10 shrink-0 items-center justify-between gap-4 px-1">
               <div className="flex min-w-0 items-center gap-2">
                 <BarChart3 size={14} className="shrink-0 text-[#667085]" />
                 <span className="truncate text-[13px] font-semibold text-[#344054]">
                   {title}
                 </span>
+                {chartTypeLabel ? (
+                  <span className="shrink-0 rounded-[5px] border border-[#e1e4e8] bg-[#f8f9fa] px-1.5 py-0.5 text-[9px] text-[#7a818c]">
+                    {chartTypeLabel}
+                  </span>
+                ) : null}
               </div>
               <div className="flex shrink-0 items-center gap-1.5 text-[10px] text-[#98a2b3]">
                 <Database size={11} />

--- a/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
@@ -1,5 +1,5 @@
-import { BarChart3, LayoutDashboard } from 'lucide-react';
-import { useState } from 'react';
+import { BarChart3, ChevronLeft, ChevronRight, LayoutDashboard } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 
 export type DashboardEditorSheet = {
   id: string;
@@ -22,6 +22,42 @@ export function DashboardSheetBar({
   onReorder: (sheetIds: string[]) => void;
 }) {
   const [draggingId, setDraggingId] = useState<string>();
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const dashboardRef = useRef<HTMLButtonElement>(null);
+  const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  const updateScrollState = () => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const maximum = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+    setCanScrollLeft(viewport.scrollLeft > 1);
+    setCanScrollRight(viewport.scrollLeft < maximum - 1);
+  };
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return undefined;
+    updateScrollState();
+    const observer = new ResizeObserver(updateScrollState);
+    observer.observe(viewport);
+    viewport.addEventListener('scroll', updateScrollState, { passive: true });
+    return () => {
+      observer.disconnect();
+      viewport.removeEventListener('scroll', updateScrollState);
+    };
+  }, [sheets.length]);
+
+  useEffect(() => {
+    if (activeSheet !== 'chart' || !activeSheetId) return;
+    tabRefs.current.get(activeSheetId)?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+    window.requestAnimationFrame(updateScrollState);
+  }, [activeSheet, activeSheetId]);
 
   const moveBefore = (targetId: string) => {
     if (!draggingId || draggingId === targetId) return;
@@ -34,16 +70,56 @@ export function DashboardSheetBar({
     onReorder(ids);
   };
 
-  const baseClass = 'flex h-full shrink-0 items-center gap-1.5 border-x px-3 text-[11px] transition-colors';
+  const focusSheet = (id: 'dashboard' | string) => {
+    window.requestAnimationFrame(() => {
+      if (id === 'dashboard') dashboardRef.current?.focus();
+      else tabRefs.current.get(id)?.focus();
+    });
+  };
+
+  const handleNavigation = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    currentId: 'dashboard' | string,
+  ) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+    const ids = ['dashboard', ...sheets.map((sheet) => sheet.id)];
+    const currentIndex = Math.max(0, ids.indexOf(currentId));
+    let nextIndex = currentIndex;
+    if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = ids.length - 1;
+    else if (event.key === 'ArrowLeft') nextIndex = Math.max(0, currentIndex - 1);
+    else if (event.key === 'ArrowRight') nextIndex = Math.min(ids.length - 1, currentIndex + 1);
+    const nextId = ids[nextIndex];
+    if (!nextId || nextId === currentId) return;
+    if (nextId === 'dashboard') onDashboard();
+    else onChart(nextId);
+    focusSheet(nextId);
+  };
+
+  const scrollSheets = (direction: -1 | 1) => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    viewport.scrollBy({
+      left: direction * Math.max(180, Math.round(viewport.clientWidth * 0.65)),
+      behavior: 'smooth',
+    });
+  };
+
+  const baseClass = 'flex h-full shrink-0 items-center gap-1.5 border-x px-3 text-[11px] transition-colors focus-visible:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--yak-brand-color)]';
   const inactiveClass = 'border-transparent text-[#667085] hover:bg-white/70 hover:text-[#344054]';
   const activeClass = 'border-[#dfe3e8] bg-white font-medium text-[#161823] shadow-[inset_0_2px_0_var(--yak-brand-color)]';
 
   return (
-    <div className="flex h-10 shrink-0 items-stretch border-t border-[#dfe3e8] bg-[#f7f8fa]">
+    <div className="flex h-10 shrink-0 items-stretch border-t border-[#dfe3e8] bg-[#f7f8fa]" role="tablist" aria-label="仪表盘编辑 Sheet">
       <button
+        ref={dashboardRef}
         type="button"
+        role="tab"
+        aria-selected={activeSheet === 'dashboard'}
         className={`${baseClass} ${activeSheet === 'dashboard' ? activeClass : inactiveClass}`}
         onClick={onDashboard}
+        onKeyDown={(event) => handleNavigation(event, 'dashboard')}
       >
         <LayoutDashboard size={13} />
         仪表盘
@@ -51,17 +127,37 @@ export function DashboardSheetBar({
 
       <div className="h-full w-px shrink-0 bg-[#e5e7eb]" />
 
-      <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden">
-        {sheets.map((sheet) => {
+      <button
+        type="button"
+        aria-label="向左滚动图表 Sheet"
+        disabled={!canScrollLeft}
+        className="flex w-7 shrink-0 items-center justify-center border-0 border-r border-[#e5e7eb] bg-transparent text-[#667085] hover:bg-white disabled:cursor-default disabled:text-[#c7ccd4]"
+        onClick={() => scrollSheets(-1)}
+      >
+        <ChevronLeft size={13} />
+      </button>
+
+      <div
+        ref={viewportRef}
+        className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {sheets.length ? sheets.map((sheet) => {
           const active = activeSheet === 'chart' && activeSheetId === sheet.id;
           return (
             <button
               key={sheet.id}
+              ref={(node) => {
+                if (node) tabRefs.current.set(sheet.id, node);
+                else tabRefs.current.delete(sheet.id);
+              }}
               type="button"
+              role="tab"
+              aria-selected={active}
               draggable
               title={`${sheet.title} · 拖动可调整 Sheet 顺序`}
               className={`${baseClass} max-w-[220px] cursor-pointer ${active ? activeClass : inactiveClass} ${draggingId === sheet.id ? 'opacity-45' : ''}`}
               onClick={() => onChart(sheet.id)}
+              onKeyDown={(event) => handleNavigation(event, sheet.id)}
               onDragStart={(event) => {
                 setDraggingId(sheet.id);
                 event.dataTransfer.effectAllowed = 'move';
@@ -79,8 +175,22 @@ export function DashboardSheetBar({
               <span className="truncate">{sheet.title}</span>
             </button>
           );
-        })}
+        }) : (
+          <div className="flex h-full items-center px-3 text-[10px] text-[#98a2b3]">
+            暂无图表 Sheet
+          </div>
+        )}
       </div>
+
+      <button
+        type="button"
+        aria-label="向右滚动图表 Sheet"
+        disabled={!canScrollRight}
+        className="flex w-7 shrink-0 items-center justify-center border-0 border-l border-[#e5e7eb] bg-transparent text-[#667085] hover:bg-white disabled:cursor-default disabled:text-[#c7ccd4]"
+        onClick={() => scrollSheets(1)}
+      >
+        <ChevronRight size={13} />
+      </button>
 
       <div className="flex shrink-0 items-center border-l border-[#e5e7eb] px-3 text-[10px] text-[#98a2b3]">
         {sheets.length} 个图表

--- a/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
@@ -1,5 +1,5 @@
 import { BarChart3, ChevronLeft, ChevronRight, LayoutDashboard } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type DashboardEditorSheet = {
   id: string;
@@ -28,13 +28,13 @@ export function DashboardSheetBar({
   const dashboardRef = useRef<HTMLButtonElement>(null);
   const tabRefs = useRef(new Map<string, HTMLButtonElement>());
 
-  const updateScrollState = () => {
+  const updateScrollState = useCallback(() => {
     const viewport = viewportRef.current;
     if (!viewport) return;
     const maximum = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
     setCanScrollLeft(viewport.scrollLeft > 1);
     setCanScrollRight(viewport.scrollLeft < maximum - 1);
-  };
+  }, []);
 
   useEffect(() => {
     const viewport = viewportRef.current;
@@ -47,7 +47,7 @@ export function DashboardSheetBar({
       observer.disconnect();
       viewport.removeEventListener('scroll', updateScrollState);
     };
-  }, [sheets.length]);
+  }, [sheets.length, updateScrollState]);
 
   useEffect(() => {
     if (activeSheet !== 'chart' || !activeSheetId) return;
@@ -57,7 +57,7 @@ export function DashboardSheetBar({
       inline: 'nearest',
     });
     window.requestAnimationFrame(updateScrollState);
-  }, [activeSheet, activeSheetId]);
+  }, [activeSheet, activeSheetId, updateScrollState]);
 
   const moveBefore = (targetId: string) => {
     if (!draggingId || draggingId === targetId) return;
@@ -70,7 +70,7 @@ export function DashboardSheetBar({
     onReorder(ids);
   };
 
-  const focusSheet = (id: 'dashboard' | string) => {
+  const focusSheet = (id: string) => {
     window.requestAnimationFrame(() => {
       if (id === 'dashboard') dashboardRef.current?.focus();
       else tabRefs.current.get(id)?.focus();
@@ -79,7 +79,7 @@ export function DashboardSheetBar({
 
   const handleNavigation = (
     event: React.KeyboardEvent<HTMLButtonElement>,
-    currentId: 'dashboard' | string,
+    currentId: string,
   ) => {
     if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
     event.preventDefault();


### PR DESCRIPTION
## What changed
- refactor the old panel-oriented `ChartEditor` shell into a Sheet-native `ChartSheetConfigPanel` contract
- switch the chart configuration column from a right-panel semantic (`aside` + left border) to an explicit left configuration section with its own right divider
- rename the completion callback from `close` to `onDone` so the action means returning to the Dashboard Sheet rather than closing a drawer/panel
- keep all existing dataset / chart type / dimension / metric / aggregation / interaction / style / query behavior unchanged
- polish the chart Sheet preview header with chart type and dataset context
- improve the bottom Sheet bar for larger dashboards: hidden native scrollbar, explicit left/right paging controls, automatic reveal of the active chart Sheet, and an empty Sheet state
- add keyboard navigation across Dashboard / chart Sheets with ArrowLeft / ArrowRight / Home / End
- add tab semantics (`tablist` / `tab` / `aria-selected`) and visible keyboard focus treatment
- preserve drag-to-reorder behavior and the existing editor-only Sheet order model

## Compatibility
- no Dashboard document/schema changes
- no database/backend changes
- no Dataset / Analysis persistence changes
- no change to Dashboard save / publish / undo / redo behavior
- no persisted Sheet entity introduced
- legacy shared Analysis charts keep the existing “复制为可编辑图表” flow

## Intentionally deferred
- global filter model/API cleanup (the hidden editor filter UI remains compatibility data for existing dashboards)
- persistent custom Sheet ordering or a separate Sheet backend model
- treating “close Sheet” as chart deletion; chart deletion continues to use the existing widget actions to avoid ambiguous destructive behavior
- additional visual tuning that depends on hands-on browser feedback

## Validation
- [x] Phase 3 PR #478 is merged into `main`; this branch starts from that merge commit
- [x] reviewed branch compare against `main` (3 frontend files changed)
- [x] no persisted Dashboard/backend model files changed
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] manual browser regression check

The current execution environment still cannot resolve GitHub from the local container, so executable frontend validation is intentionally left unchecked rather than being claimed as completed.