### PR TITLE
feat(bi): add draggable chart field bindings (phase 5)

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-field-drag.ts
+++ b/yak-ops-ui/src/pages/dashboard/chart-field-drag.ts
@@ -1,0 +1,36 @@
+import type { DragEvent } from 'react';
+import { FIELD_DRAG_MIME } from './helpers';
+import type { DatasetFieldRole } from './model';
+
+export interface ChartFieldDragPayload {
+  field: string;
+  role: DatasetFieldRole;
+}
+
+export const writeChartFieldDragPayload = (
+  event: DragEvent<HTMLElement>,
+  payload: ChartFieldDragPayload,
+) => {
+  const serialized = JSON.stringify(payload);
+  event.dataTransfer.effectAllowed = 'copy';
+  event.dataTransfer.setData(FIELD_DRAG_MIME, serialized);
+  event.dataTransfer.setData('text/plain', serialized);
+};
+
+export const readChartFieldDragPayload = (
+  event: DragEvent<HTMLElement>,
+): ChartFieldDragPayload | undefined => {
+  const raw = event.dataTransfer.getData(FIELD_DRAG_MIME)
+    || event.dataTransfer.getData('text/plain');
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as Partial<ChartFieldDragPayload>;
+    if (
+      typeof parsed.field !== 'string'
+      || (parsed.role !== 'dimension' && parsed.role !== 'metric')
+    ) return undefined;
+    return { field: parsed.field, role: parsed.role };
+  } catch {
+    return undefined;
+  }
+};

--- a/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
@@ -1,0 +1,148 @@
+import type { AnalysisSpec } from '@/components/analysis/model';
+import { Input } from 'antd';
+import { Database, GripVertical, Hash, Search, Type } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { writeChartFieldDragPayload } from './chart-field-drag';
+import type { DatasetField, PublishedDataset } from './model';
+
+const fieldTypeLabel: Record<DatasetField['dataType'], string> = {
+  string: '文本',
+  number: '数值',
+  date: '日期',
+  datetime: '日期时间',
+  boolean: '布尔',
+  unknown: '未知',
+};
+
+export function ChartFieldPanel({
+  dataset,
+  spec,
+  editable,
+}: {
+  dataset?: PublishedDataset;
+  spec?: AnalysisSpec;
+  editable: boolean;
+}) {
+  const [keyword, setKeyword] = useState('');
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  const fields = useMemo(() => {
+    if (!dataset) return [];
+    if (!normalizedKeyword) return dataset.fields;
+    return dataset.fields.filter((field) => (
+      field.label.toLowerCase().includes(normalizedKeyword)
+      || field.key.toLowerCase().includes(normalizedKeyword)
+      || field.physicalName.toLowerCase().includes(normalizedKeyword)
+    ));
+  }, [dataset, normalizedKeyword]);
+  const dimensions = fields.filter((field) => field.role === 'dimension');
+  const metrics = fields.filter((field) => field.role === 'metric');
+
+  return (
+    <section className="flex w-[244px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
+      <div className="flex h-14 shrink-0 items-center border-b border-[#eceef1] px-3.5">
+        <div className="min-w-0">
+          <div className="text-[13px] font-semibold text-[#344054]">数据字段</div>
+          <div className="mt-0.5 flex items-center gap-1 text-[9px] text-[#98a2b3]">
+            <Database size={9} className="shrink-0" />
+            <span className="truncate">{dataset?.name ?? '数据来源不可用'}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="shrink-0 border-b border-[#f0f1f3] p-3">
+        <Input
+          allowClear
+          size="small"
+          value={keyword}
+          prefix={<Search size={12} className="text-[#a0a6af]" />}
+          placeholder="搜索字段"
+          className="!h-8 !rounded-[7px]"
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+        <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
+          {editable ? '拖动字段到右侧维度 / 指标槽位' : '共享图表复制为可编辑图表后可拖拽配置'}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2.5 py-3">
+        {!dataset ? (
+          <div className="px-2 py-6 text-center text-[10px] text-[#98a2b3]">暂无可用字段</div>
+        ) : (
+          <div className="space-y-4">
+            <FieldGroup
+              title="维度"
+              fields={dimensions}
+              spec={spec}
+              editable={editable}
+            />
+            <FieldGroup
+              title="指标"
+              fields={metrics}
+              spec={spec}
+              editable={editable}
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function FieldGroup({
+  title,
+  fields,
+  spec,
+  editable,
+}: {
+  title: string;
+  fields: DatasetField[];
+  spec?: AnalysisSpec;
+  editable: boolean;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between px-1.5">
+        <span className="text-[10px] font-semibold text-[#667085]">{title}</span>
+        <span className="text-[9px] tabular-nums text-[#b0b5bd]">{fields.length}</span>
+      </div>
+      <div className="space-y-0.5">
+        {fields.map((field) => {
+          const selected = field.role === 'dimension'
+            ? Boolean(spec?.dimensions.includes(field.key))
+            : Boolean(spec?.metrics.some((metric) => metric.field === field.key));
+          return (
+            <div
+              key={field.key}
+              draggable={editable}
+              title={editable ? `${field.label} · 拖动到图表配置` : field.label}
+              className={[
+                'group flex h-8 items-center gap-1.5 rounded-[6px] px-1.5 text-[10px] transition-colors',
+                editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',
+                selected
+                  ? 'bg-[#f4f5f7] font-medium text-[#344054]'
+                  : 'text-[#475467] hover:bg-[#f7f8fa]',
+              ].join(' ')}
+              onDragStart={(event) => {
+                if (!editable) return;
+                writeChartFieldDragPayload(event, { field: field.key, role: field.role });
+              }}
+            >
+              <GripVertical
+                size={12}
+                className={editable ? 'shrink-0 text-[#c2c6cc] group-hover:text-[#8b929c]' : 'shrink-0 text-[#e0e2e6]'}
+              />
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[5px] bg-[#f2f4f7] text-[#7a818c]">
+                {field.dataType === 'number' ? <Hash size={11} /> : <Type size={11} />}
+              </span>
+              <span className="min-w-0 flex-1 truncate">{field.label}</span>
+              <span className="shrink-0 text-[8px] text-[#b0b5bd]">{fieldTypeLabel[field.dataType]}</span>
+            </div>
+          );
+        })}
+        {!fields.length ? (
+          <div className="px-1.5 py-2 text-[9px] text-[#b0b5bd]">没有匹配字段</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -107,20 +107,22 @@ export function DashboardChartSheetWorkspace({
         </div>
       </main>
 
-      <ChartSheetConfigPanel
-        currentDashboardId={currentDashboardId}
-        widget={widget}
-        datasets={datasets}
-        analyses={analyses}
-        globalFilters={globalFilters}
-        interactions={interactions}
-        updateWidget={updateWidget}
-        updateInlineAnalysis={updateInlineAnalysis}
-        updateInteractions={updateInteractions}
-        changeDataset={changeDataset}
-        detachAnalysis={detachAnalysis}
-        onDone={onDone}
-      />
+      <div className="flex shrink-0 border-l border-[#e3e6ea]">
+        <ChartSheetConfigPanel
+          currentDashboardId={currentDashboardId}
+          widget={widget}
+          datasets={datasets}
+          analyses={analyses}
+          globalFilters={globalFilters}
+          interactions={interactions}
+          updateWidget={updateWidget}
+          updateInlineAnalysis={updateInlineAnalysis}
+          updateInteractions={updateInteractions}
+          changeDataset={changeDataset}
+          detachAnalysis={detachAnalysis}
+          onDone={onDone}
+        />
+      </div>
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -2,6 +2,7 @@ import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
 import { Empty } from 'antd';
 import { BarChart3, Database } from 'lucide-react';
 import { ChartSheetConfigPanel } from './chart-editor';
+import { ChartFieldPanel } from './chart-field-panel';
 import { CHART_META } from './helpers';
 import type {
   AnalysisAsset,
@@ -56,19 +57,10 @@ export function DashboardChartSheetWorkspace({
 
   return (
     <div className="chart-sheet-workspace flex min-h-0 flex-1 overflow-hidden bg-[#f3f4f6]">
-      <ChartSheetConfigPanel
-        currentDashboardId={currentDashboardId}
-        widget={widget}
-        datasets={datasets}
-        analyses={analyses}
-        globalFilters={globalFilters}
-        interactions={interactions}
-        updateWidget={updateWidget}
-        updateInlineAnalysis={updateInlineAnalysis}
-        updateInteractions={updateInteractions}
-        changeDataset={changeDataset}
-        detachAnalysis={detachAnalysis}
-        onDone={onDone}
+      <ChartFieldPanel
+        dataset={dataset}
+        spec={spec}
+        editable={!widget.analysisId && Boolean(widget.inlineAnalysis && dataset)}
       />
 
       <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">
@@ -114,6 +106,21 @@ export function DashboardChartSheetWorkspace({
           </div>
         </div>
       </main>
+
+      <ChartSheetConfigPanel
+        currentDashboardId={currentDashboardId}
+        widget={widget}
+        datasets={datasets}
+        analyses={analyses}
+        globalFilters={globalFilters}
+        interactions={interactions}
+        updateWidget={updateWidget}
+        updateInlineAnalysis={updateInlineAnalysis}
+        updateInteractions={updateInteractions}
+        changeDataset={changeDataset}
+        detachAnalysis={detachAnalysis}
+        onDone={onDone}
+      />
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/dashboard/config-data.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-data.tsx
@@ -1,5 +1,20 @@
 import type { AnalysisSpec } from '@/components/analysis/model';
 import { Select } from 'antd';
+import { Plus, X } from 'lucide-react';
+import { useState, type DragEvent } from 'react';
+import { readChartFieldDragPayload } from './chart-field-drag';
+import { AGGREGATION_OPTIONS, FIELD_DRAG_MIME } from './helpers';
+
+interface FieldOption {
+  label: string;
+  value: string;
+}
+
+interface BoundField {
+  field: string;
+  label: string;
+  suffix?: string;
+}
 
 export function ConfigData({
   spec,
@@ -9,24 +24,181 @@ export function ConfigData({
   onMetrics,
 }: {
   spec: AnalysisSpec;
-  dimensionOptions: Array<{ label: string; value: string }>;
-  metricOptions: Array<{ label: string; value: string }>;
+  dimensionOptions: FieldOption[];
+  metricOptions: FieldOption[];
   onDimensions: (value: string[]) => void;
   onMetrics: (value: string[]) => void;
 }) {
   const dimensionLimit = spec.type === 'table' ? 3 : 1;
   const metricLimit = ['bar', 'line', 'table'].includes(spec.type) ? 3 : 1;
+  const dimensionLabel = new Map(dimensionOptions.map((option) => [option.value, option.label]));
+  const metricLabel = new Map(metricOptions.map((option) => [option.value, option.label]));
+  const aggregationLabel = new Map(AGGREGATION_OPTIONS.map((option) => [option.value, option.label]));
+
+  const addDimension = (field: string) => {
+    if (!dimensionOptions.some((option) => option.value === field)) return;
+    if (spec.dimensions.includes(field)) return;
+    if (dimensionLimit === 1) {
+      onDimensions([field]);
+      return;
+    }
+    if (spec.dimensions.length >= dimensionLimit) return;
+    onDimensions([...spec.dimensions, field]);
+  };
+
+  const addMetric = (field: string) => {
+    if (!metricOptions.some((option) => option.value === field)) return;
+    const fields = spec.metrics.map((metric) => metric.field);
+    if (fields.includes(field)) return;
+    if (metricLimit === 1) {
+      onMetrics([field]);
+      return;
+    }
+    if (fields.length >= metricLimit) return;
+    onMetrics([...fields, field]);
+  };
+
+  const dimensions: BoundField[] = spec.dimensions.map((field) => ({
+    field,
+    label: dimensionLabel.get(field) ?? field,
+  }));
+  const metrics: BoundField[] = spec.metrics.map((metric) => ({
+    field: metric.field,
+    label: metricLabel.get(metric.field) ?? metric.field,
+    suffix: aggregationLabel.get(metric.aggregation) ?? metric.aggregation,
+  }));
+
   return (
     <div className="space-y-3">
       {spec.type !== 'metric' ? (
-        <div>
-          <div className="mb-1 text-[11px] text-[#667085]">维度</div>
-          <Select mode="multiple" size="small" maxCount={dimensionLimit} className="w-full" value={spec.dimensions} options={dimensionOptions} onChange={onDimensions} />
-        </div>
+        <BindingDropZone
+          role="dimension"
+          label="维度"
+          emptyText="拖入维度字段"
+          values={dimensions}
+          options={dimensionOptions}
+          limit={dimensionLimit}
+          onAdd={addDimension}
+          onRemove={(field) => onDimensions(spec.dimensions.filter((item) => item !== field))}
+        />
       ) : null}
-      <div>
-        <div className="mb-1 text-[11px] text-[#667085]">指标</div>
-        <Select mode="multiple" size="small" maxCount={metricLimit} className="w-full" value={spec.metrics.map((item) => item.field)} options={metricOptions} onChange={onMetrics} />
+      <BindingDropZone
+        role="metric"
+        label="指标"
+        emptyText="拖入指标字段"
+        values={metrics}
+        options={metricOptions}
+        limit={metricLimit}
+        onAdd={addMetric}
+        onRemove={(field) => onMetrics(spec.metrics
+          .map((metric) => metric.field)
+          .filter((item) => item !== field))}
+      />
+    </div>
+  );
+}
+
+function BindingDropZone({
+  role,
+  label,
+  emptyText,
+  values,
+  options,
+  limit,
+  onAdd,
+  onRemove,
+}: {
+  role: 'dimension' | 'metric';
+  label: string;
+  emptyText: string;
+  values: BoundField[];
+  options: FieldOption[];
+  limit: number;
+  onAdd: (field: string) => void;
+  onRemove: (field: string) => void;
+}) {
+  const [dragOver, setDragOver] = useState(false);
+  const availableOptions = options.filter((option) => !values.some((item) => item.field === option.value));
+  const full = values.length >= limit;
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (
+      !event.dataTransfer.types.includes(FIELD_DRAG_MIME)
+      && !event.dataTransfer.types.includes('text/plain')
+    ) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDragOver(true);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragOver(false);
+    const payload = readChartFieldDragPayload(event);
+    if (!payload || payload.role !== role) return;
+    onAdd(payload.field);
+  };
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between text-[10px] text-[#667085]">
+        <span>{label}</span>
+        <span className="text-[9px] text-[#a0a6af]">{values.length}/{limit}</span>
+      </div>
+      <div
+        className={[
+          'rounded-[8px] border border-dashed p-2 transition-[border-color,background-color]',
+          dragOver
+            ? 'border-[var(--yak-brand-color)] bg-[var(--yak-brand-color-soft)]'
+            : 'border-[#dfe3e8] bg-white',
+        ].join(' ')}
+        onDragEnter={handleDragOver}
+        onDragOver={handleDragOver}
+        onDragLeave={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setDragOver(false);
+        }}
+        onDrop={handleDrop}
+      >
+        <div className="space-y-1.5">
+          {values.map((value) => (
+            <div
+              key={value.field}
+              className="flex min-h-7 items-center gap-1.5 rounded-[6px] border border-[#e4e7ec] bg-[#f8f9fa] px-2 text-[10px] text-[#344054]"
+            >
+              <span className="min-w-0 flex-1 truncate font-medium">{value.label}</span>
+              {value.suffix ? (
+                <span className="shrink-0 text-[8px] text-[#98a2b3]">{value.suffix}</span>
+              ) : null}
+              <button
+                type="button"
+                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] text-[#a0a6af] hover:bg-[#eceef1] hover:text-[#667085]"
+                aria-label={`移除${value.label}`}
+                onClick={() => onRemove(value.field)}
+              >
+                <X size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {!values.length ? (
+          <div className="flex h-9 items-center justify-center gap-1 text-[9px] text-[#a0a6af]">
+            <Plus size={10} />
+            {emptyText}
+          </div>
+        ) : null}
+
+        <Select
+          showSearch
+          size="small"
+          value={undefined}
+          disabled={full || !availableOptions.length}
+          className="mt-2 w-full"
+          options={availableOptions}
+          optionFilterProp="label"
+          placeholder={full ? `最多 ${limit} 个字段` : '+ 点击选择字段'}
+          onChange={onAdd}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed
- add a dedicated Dataset field panel to every chart Sheet, grouped into dimensions and metrics with field search
- make editable Dataset fields draggable using a small Dashboard-local drag payload; legacy shared Analysis charts remain read-only until copied into the Dashboard
- reshape the chart Sheet into a FineBI-style three-area workspace: **fields on the left / live chart preview in the center / chart configuration on the right**
- replace the old multi-select-only dimension / metric bindings with visible drop zones and bound-field chips
- support dropping dimension fields into the dimension slot and metric fields into the metric slot while keeping the existing chart-specific field-count limits
- preserve current single-slot behavior by replacing the existing binding when a new field is dropped onto metric/pie/single-dimension charts
- keep multi-field bar / line / table limits and prevent duplicate bindings
- show metric aggregation directly on bound metric chips and keep the existing aggregation editor below the slots
- allow removing a bound field directly from its chip
- keep a compact click-to-select fallback inside each slot so keyboard/mouse users are not forced to use drag and drop
- visually highlight fields that are already bound to the current chart

## Phase 5 scope
This PR intentionally implements drag-and-drop on top of the **existing** `dimensions` / `metrics` Analysis model. It does **not** introduce the Phase 6 visualization encoding model yet (`color`, `size`, `label`, `detail`, `tooltip`, etc.).

The current persisted shape therefore stays compatible:

```text
AnalysisSpec
├─ dimensions[]
├─ metrics[]
├─ filters[]
├─ sort
└─ style
```

## Compatibility
- no Dashboard document/schema changes
- no backend/database changes
- no Dataset or Analysis persistence changes
- no new npm dependency; drag/drop uses the browser DataTransfer API
- existing dataset switching, chart type switching, metric aggregation, style/query, interactions, save/publish, undo/redo continue to use the current Dashboard model
- shared Analysis charts keep the existing “复制为可编辑图表” migration flow

## Validation
- [x] Phase 4 PR #479 is merged into `main`; this branch is based directly on that merge commit
- [x] branch compare is 0 commits behind `main`
- [x] reviewed final diff: 4 frontend files changed, no persisted model/backend files changed
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] manual browser drag/drop regression check

Executable frontend validation is intentionally left unchecked because the current execution environment does not provide a usable local checkout/network path for installing/running this repository. GitHub checks should be treated as the executable integration signal if/when workflows are configured.