### PR TITLE
feat(bi): introduce visualization encoding model (phase 6)

### DIFF
--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -1,6 +1,7 @@
 import { Empty, Spin } from 'antd';
 import * as echarts from 'echarts';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { encodingMeetsChartRequirements, resolveAnalysisEncoding } from './encoding';
 import { queryAnalysisDataset } from './dataset-service';
 import type {
   Aggregation,
@@ -99,9 +100,9 @@ export const buildDatasetQueryPayload = (
 };
 
 export const canQueryAnalysis = (spec: AnalysisSpec) => {
-  if (spec.type === 'metric') return spec.metrics.length === 1;
+  if (!encodingMeetsChartRequirements(spec)) return false;
   if (spec.type === 'table') return spec.dimensions.length > 0 || spec.metrics.length > 0;
-  return spec.dimensions.length > 0 && spec.metrics.length > 0;
+  return true;
 };
 
 function useAnalysisQuery(
@@ -184,13 +185,31 @@ const numericCell = (
 const rowLabel = (result: DatasetQueryResult, row: Scalar[], dimensions: string[]) =>
   dimensions.map((fieldId) => String(cell(result, row, fieldId) ?? '')).join(' / ');
 
+const scalarKey = (value: Scalar) => `${typeof value}:${String(value)}`;
+
+const uniqueDimensionValues = (
+  result: DatasetQueryResult,
+  fieldId: string,
+) => {
+  const seen = new Set<string>();
+  return result.rows.flatMap((row) => {
+    const value = cell(result, row, fieldId);
+    const key = scalarKey(value);
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{ key, value, label: String(value ?? '') }];
+  });
+};
+
 const selectionForRow = (
   spec: AnalysisSpec,
   dataset: PublishedDataset,
   result: DatasetQueryResult,
   rowIndex: number,
 ): AnalysisSelection | undefined => {
-  const fieldId = spec.dimensions[0];
+  const encoding = resolveAnalysisEncoding(spec);
+  const fieldId = encoding.category.find((binding) => binding.role === 'dimension')?.field
+    ?? spec.dimensions[0];
   const row = result.rows[rowIndex];
   if (!fieldId || !row) return undefined;
   const value = cell(result, row, fieldId);
@@ -208,7 +227,10 @@ const chartOptionFor = (
   dataset: PublishedDataset,
   result: DatasetQueryResult,
 ) => {
-  const firstDimension = spec.dimensions[0];
+  const encoding = resolveAnalysisEncoding(spec);
+  const firstDimension = encoding.category.find((binding) => binding.role === 'dimension')?.field
+    ?? spec.dimensions[0];
+  const colorDimension = encoding.color.find((binding) => binding.role === 'dimension')?.field;
   const dimension = getAnalysisField(dataset, firstDimension);
   const metrics = spec.metrics;
   const axisText = '#667085';
@@ -231,9 +253,10 @@ const chartOptionFor = (
         center: [spec.style.showLegend ? '38%' : '50%', '52%'],
         label: { show: spec.style.showDataLabels, formatter: '{b} {d}%' },
         itemStyle: { borderColor: '#fff', borderWidth: 2 },
-        data: result.rows.map((row) => ({
-          name: rowLabel(result, row, spec.dimensions),
+        data: result.rows.map((row, rowIndex) => ({
+          name: rowLabel(result, row, [firstDimension]),
           value: numericCell(result, row, metric.field, metric.aggregation),
+          __rowIndex: rowIndex,
         })),
       }],
     };
@@ -241,10 +264,57 @@ const chartOptionFor = (
 
   if (spec.type === 'bar' || spec.type === 'line') {
     const isLine = spec.type === 'line';
+    const categories = uniqueDimensionValues(result, firstDimension);
+    const colorValues = colorDimension
+      ? uniqueDimensionValues(result, colorDimension)
+      : [];
+    const legendVisible = spec.style.showLegend || Boolean(colorDimension);
+
+    const rowIndexFor = (category: Scalar, color?: Scalar) => result.rows.findIndex((row) => (
+      Object.is(cell(result, row, firstDimension), category)
+      && (!colorDimension || Object.is(cell(result, row, colorDimension), color))
+    ));
+
+    const series = colorDimension
+      ? metrics.flatMap((metric) => colorValues.map((color) => ({
+        name: metrics.length > 1
+          ? `${color.label} · ${metricDisplayName(dataset, metric)}`
+          : color.label,
+        type: spec.type,
+        smooth: isLine && spec.style.smooth,
+        symbolSize: 5,
+        barMaxWidth: 34,
+        label: { show: spec.style.showDataLabels, position: 'top' },
+        data: categories.map((category) => {
+          const rowIndex = rowIndexFor(category.value, color.value);
+          if (rowIndex < 0) return null;
+          return {
+            value: numericCell(result, result.rows[rowIndex], metric.field, metric.aggregation),
+            __rowIndex: rowIndex,
+          };
+        }),
+      })))
+      : metrics.map((metric) => ({
+        name: metricDisplayName(dataset, metric),
+        type: spec.type,
+        smooth: isLine && spec.style.smooth,
+        symbolSize: 5,
+        barMaxWidth: 34,
+        label: { show: spec.style.showDataLabels, position: 'top' },
+        data: categories.map((category) => {
+          const rowIndex = rowIndexFor(category.value);
+          if (rowIndex < 0) return null;
+          return {
+            value: numericCell(result, result.rows[rowIndex], metric.field, metric.aggregation),
+            __rowIndex: rowIndex,
+          };
+        }),
+      }));
+
     return {
-      grid: { left: 22, right: 16, top: spec.style.showLegend ? 30 : 14, bottom: 22, containLabel: true },
+      grid: { left: 22, right: 16, top: legendVisible ? 30 : 14, bottom: 22, containLabel: true },
       tooltip: { trigger: 'axis' },
-      legend: spec.style.showLegend
+      legend: legendVisible
         ? { top: 0, right: 4, textStyle: { color: axisText, fontSize: 11 } }
         : { show: false },
       xAxis: {
@@ -252,7 +322,7 @@ const chartOptionFor = (
         boundaryGap: !isLine,
         name: dimension?.label,
         nameTextStyle: { color: '#98a2b3', fontSize: 10 },
-        data: result.rows.map((row) => rowLabel(result, row, spec.dimensions)),
+        data: categories.map((item) => item.label),
         axisLine: { lineStyle: { color: axisLine } },
         axisTick: { show: false },
         axisLabel: { color: axisText, fontSize: 11 },
@@ -262,15 +332,7 @@ const chartOptionFor = (
         splitLine: { show: spec.style.showGrid, lineStyle: { color: splitLine } },
         axisLabel: { color: axisText, fontSize: 11 },
       },
-      series: metrics.map((metric) => ({
-        name: metricDisplayName(dataset, metric),
-        type: spec.type,
-        smooth: isLine && spec.style.smooth,
-        symbolSize: 5,
-        barMaxWidth: 34,
-        label: { show: spec.style.showDataLabels, position: 'top' },
-        data: result.rows.map((row) => numericCell(result, row, metric.field, metric.aggregation)),
-      })),
+      series,
     };
   }
 
@@ -296,7 +358,8 @@ function EChartAnalysis({
     const chart = echarts.init(containerRef.current);
     chart.setOption(option, true);
     const click = (params: any) => {
-      const selection = selectionForRow(spec, dataset, result, Number(params?.dataIndex));
+      const rowIndex = Number(params?.data?.__rowIndex ?? params?.dataIndex);
+      const selection = selectionForRow(spec, dataset, result, rowIndex);
       if (selection) onSelect?.(selection);
     };
     chart.on('click', click);
@@ -310,7 +373,7 @@ function EChartAnalysis({
   }, [option, onSelect, spec, dataset, result]);
 
   if (!option) {
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请配置维度和指标" className="mt-8" />;
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请配置必填编码" className="mt-8" />;
   }
   return <div ref={containerRef} className="h-full min-h-0 w-full" />;
 }
@@ -420,7 +483,7 @@ export function AnalysisPreview({
     return <div className={className}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Dataset 不存在或已下线" className="mt-8" /></div>;
   }
   if (!canQueryAnalysis(spec)) {
-    return <div className={className}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请配置维度和指标" className="mt-8" /></div>;
+    return <div className={className}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请配置必填编码" className="mt-8" /></div>;
   }
   if (loading && !result) {
     return <div className={`${className} flex items-center justify-center`}><Spin size="small" /></div>;

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -1,0 +1,243 @@
+import type {
+  Aggregation,
+  AnalysisEncoding,
+  AnalysisEncodingBinding,
+  AnalysisEncodingChannel,
+  AnalysisSpec,
+  ChartType,
+  DatasetFieldRole,
+  MetricBinding,
+  PublishedDataset,
+} from './model';
+
+export interface AnalysisEncodingSlotRule {
+  channel: AnalysisEncodingChannel;
+  label: string;
+  roles: DatasetFieldRole[];
+  min: number;
+  max: number;
+  hint?: string;
+}
+
+const slot = (
+  channel: AnalysisEncodingChannel,
+  label: string,
+  roles: DatasetFieldRole[],
+  min: number,
+  max: number,
+  hint?: string,
+): AnalysisEncodingSlotRule => ({ channel, label, roles, min, max, hint });
+
+/**
+ * Active visual channels for the chart types currently shipped by Yak Ops.
+ * The encoding model already defines color / size / label / detail / tooltip so
+ * future chart renderers can enable them without another persistence migration.
+ */
+export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule[]> = {
+  metric: [
+    slot('value', '值', ['metric'], 1, 1, '指标卡需要 1 个指标'),
+  ],
+  bar: [
+    slot('category', '分类', ['dimension'], 1, 1, '柱状图需要 1 个分类字段'),
+    slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
+  ],
+  line: [
+    slot('category', '分类', ['dimension'], 1, 1, '折线图需要 1 个分类字段'),
+    slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
+  ],
+  pie: [
+    slot('category', '分类', ['dimension'], 1, 1, '饼图需要 1 个分类字段'),
+    slot('value', '值', ['metric'], 1, 1, '饼图需要 1 个指标'),
+  ],
+  table: [
+    slot('category', '维度', ['dimension'], 0, 3, '最多 3 个维度'),
+    slot('value', '指标', ['metric'], 0, 3, '最多 3 个指标'),
+  ],
+};
+
+export const EMPTY_ANALYSIS_ENCODING: AnalysisEncoding = {
+  version: 1,
+  category: [],
+  value: [],
+  color: [],
+  size: [],
+  label: [],
+  detail: [],
+  tooltip: [],
+};
+
+const cloneBinding = (binding: AnalysisEncodingBinding): AnalysisEncodingBinding => ({
+  field: binding.field,
+  role: binding.role,
+  aggregation: binding.aggregation,
+});
+
+export const cloneAnalysisEncoding = (encoding: AnalysisEncoding): AnalysisEncoding => ({
+  version: 1,
+  category: encoding.category.map(cloneBinding),
+  value: encoding.value.map(cloneBinding),
+  color: encoding.color.map(cloneBinding),
+  size: encoding.size.map(cloneBinding),
+  label: encoding.label.map(cloneBinding),
+  detail: encoding.detail.map(cloneBinding),
+  tooltip: encoding.tooltip.map(cloneBinding),
+});
+
+export const legacyAnalysisEncoding = (spec: Pick<AnalysisSpec, 'dimensions' | 'metrics'>): AnalysisEncoding => ({
+  ...cloneAnalysisEncoding(EMPTY_ANALYSIS_ENCODING),
+  category: spec.dimensions.map((field) => ({ field, role: 'dimension' as const })),
+  value: spec.metrics.map((metric) => ({
+    field: metric.field,
+    role: 'metric' as const,
+    aggregation: metric.aggregation,
+  })),
+});
+
+/** Existing snapshots without `encoding` are upgraded lazily and losslessly in memory. */
+export const resolveAnalysisEncoding = (spec: Pick<AnalysisSpec, 'encoding' | 'dimensions' | 'metrics'>): AnalysisEncoding => (
+  spec.encoding?.version === 1
+    ? cloneAnalysisEncoding(spec.encoding)
+    : legacyAnalysisEncoding(spec)
+);
+
+const activeRuleMap = (type: ChartType) => new Map(
+  ANALYSIS_ENCODING_RULES[type].map((rule) => [rule.channel, rule]),
+);
+
+const metricProjection = (bindings: AnalysisEncodingBinding[]): MetricBinding[] => bindings
+  .filter((binding) => binding.role === 'metric')
+  .map((binding) => ({
+    field: binding.field,
+    aggregation: binding.aggregation ?? 'SUM',
+  }));
+
+/**
+ * Keeps the existing query/render contract alive while encoding becomes the editor's
+ * semantic source of truth. Inactive channels remain persisted in `encoding`, but do
+ * not leak into the legacy query projection for a chart type that cannot render them.
+ */
+export const applyAnalysisEncoding = <T extends AnalysisSpec>(
+  spec: T,
+  encoding: AnalysisEncoding,
+): T => {
+  const rules = activeRuleMap(spec.type);
+  const categoryRule = rules.get('category');
+  const valueRule = rules.get('value');
+  return {
+    ...spec,
+    encoding: cloneAnalysisEncoding(encoding),
+    dimensions: categoryRule
+      ? encoding.category
+        .filter((binding) => binding.role === 'dimension')
+        .slice(0, categoryRule.max)
+        .map((binding) => binding.field)
+      : [],
+    metrics: valueRule
+      ? metricProjection(encoding.value).slice(0, valueRule.max)
+      : [],
+  };
+};
+
+const sanitizeChannel = (
+  bindings: AnalysisEncodingBinding[],
+  rule: AnalysisEncodingSlotRule,
+) => bindings
+  .filter((binding) => rule.roles.includes(binding.role))
+  .slice(0, rule.max)
+  .map(cloneBinding);
+
+/**
+ * Chart switching preserves every inactive semantic channel, while active channels are
+ * validated and trimmed to the target chart's capacity. This is what makes switching
+ * metric -> bar -> metric reversible instead of destructively clearing field choices.
+ */
+export const changeAnalysisEncodingType = <T extends AnalysisSpec>(
+  spec: T,
+  type: ChartType,
+): T => {
+  const encoding = resolveAnalysisEncoding(spec);
+  const nextRules = ANALYSIS_ENCODING_RULES[type];
+  const next = cloneAnalysisEncoding(encoding);
+  nextRules.forEach((rule) => {
+    next[rule.channel] = sanitizeChannel(next[rule.channel], rule);
+  });
+  return applyAnalysisEncoding({ ...spec, type } as T, next);
+};
+
+export const analysisEncodingFieldKeys = (
+  spec: Pick<AnalysisSpec, 'encoding' | 'dimensions' | 'metrics'>,
+) => {
+  const encoding = resolveAnalysisEncoding(spec);
+  return new Set< string >([
+    ...encoding.category.map((binding) => binding.field),
+    ...encoding.value.map((binding) => binding.field),
+    ...encoding.color.map((binding) => binding.field),
+    ...encoding.size.map((binding) => binding.field),
+    ...encoding.label.map((binding) => binding.field),
+    ...encoding.detail.map((binding) => binding.field),
+    ...encoding.tooltip.map((binding) => binding.field),
+  ]);
+};
+
+const validBindingForDataset = (
+  binding: AnalysisEncodingBinding,
+  dataset: PublishedDataset,
+) => {
+  const field = dataset.fields.find((item) => item.key === binding.field);
+  if (!field || field.role !== binding.role) return undefined;
+  return {
+    ...binding,
+    aggregation: binding.role === 'metric'
+      ? (binding.aggregation ?? 'SUM')
+      : undefined,
+  } satisfies AnalysisEncodingBinding;
+};
+
+/** Dataset changes remove invalid bindings from every semantic channel in one place. */
+export const rebindAnalysisEncoding = <T extends AnalysisSpec>(
+  spec: T,
+  dataset: PublishedDataset,
+): T => {
+  const source = resolveAnalysisEncoding(spec);
+  const next = cloneAnalysisEncoding(EMPTY_ANALYSIS_ENCODING);
+  (Object.keys(next) as Array<keyof AnalysisEncoding>).forEach((key) => {
+    if (key === 'version') return;
+    next[key] = source[key]
+      .map((binding) => validBindingForDataset(binding, dataset))
+      .filter(Boolean) as AnalysisEncodingBinding[];
+  });
+  return applyAnalysisEncoding({ ...spec, datasetId: dataset.id } as T, next);
+};
+
+export const updateEncodingMetricAggregation = <T extends AnalysisSpec>(
+  spec: T,
+  field: string,
+  aggregation: Aggregation,
+): T => {
+  const encoding = resolveAnalysisEncoding(spec);
+  const patchChannel = (bindings: AnalysisEncodingBinding[]) => bindings.map((binding) => (
+    binding.field === field && binding.role === 'metric'
+      ? { ...binding, aggregation }
+      : binding
+  ));
+  const next: AnalysisEncoding = {
+    ...encoding,
+    value: patchChannel(encoding.value),
+    color: patchChannel(encoding.color),
+    size: patchChannel(encoding.size),
+    label: patchChannel(encoding.label),
+    detail: patchChannel(encoding.detail),
+    tooltip: patchChannel(encoding.tooltip),
+  };
+  return applyAnalysisEncoding(spec, next);
+};
+
+export const encodingMeetsChartRequirements = (spec: AnalysisSpec) => {
+  const encoding = resolveAnalysisEncoding(spec);
+  return ANALYSIS_ENCODING_RULES[spec.type].every((rule) => {
+    const validCount = encoding[rule.channel]
+      .filter((binding) => rule.roles.includes(binding.role))
+      .length;
+    return validCount >= rule.min && validCount <= rule.max;
+  });
+};

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -123,8 +123,8 @@ const metricProjection = (bindings: AnalysisEncodingBinding[]): MetricBinding[] 
 
 /**
  * Keeps the existing query/render contract alive while encoding becomes the editor's
- * semantic source of truth. Inactive channels remain persisted in `encoding`, but do
- * not leak into the legacy query projection for a chart type that cannot render them.
+ * semantic source of truth. Inactive and overflow bindings stay persisted in
+ * `encoding`; only the active chart slots are projected into dimensions / metrics.
  */
 export const applyAnalysisEncoding = <T extends AnalysisSpec>(
   spec: T,
@@ -138,38 +138,40 @@ export const applyAnalysisEncoding = <T extends AnalysisSpec>(
     encoding: cloneAnalysisEncoding(encoding),
     dimensions: categoryRule
       ? encoding.category
-        .filter((binding) => binding.role === 'dimension')
+        .filter((binding) => categoryRule.roles.includes(binding.role) && binding.role === 'dimension')
         .slice(0, categoryRule.max)
         .map((binding) => binding.field)
       : [],
     metrics: valueRule
-      ? metricProjection(encoding.value).slice(0, valueRule.max)
+      ? metricProjection(
+        encoding.value.filter((binding) => valueRule.roles.includes(binding.role)),
+      ).slice(0, valueRule.max)
       : [],
   };
 };
 
-const sanitizeChannel = (
+const compatibleChannel = (
   bindings: AnalysisEncodingBinding[],
   rule: AnalysisEncodingSlotRule,
 ) => bindings
   .filter((binding) => rule.roles.includes(binding.role))
-  .slice(0, rule.max)
   .map(cloneBinding);
 
 /**
- * Chart switching preserves every inactive semantic channel, while active channels are
- * validated and trimmed to the target chart's capacity. This is what makes switching
- * metric -> bar -> metric reversible instead of destructively clearing field choices.
+ * Chart switching is non-destructive: incompatible roles are discarded for channels
+ * activated by the target chart, but bindings beyond the target slot capacity remain
+ * parked in the semantic channel. Switching back can therefore restore them.
  */
 export const changeAnalysisEncodingType = <T extends AnalysisSpec>(
   spec: T,
   type: ChartType,
 ): T => {
   const encoding = resolveAnalysisEncoding(spec);
-  const nextRules = ANALYSIS_ENCODING_RULES[type];
   const next = cloneAnalysisEncoding(encoding);
-  nextRules.forEach((rule) => {
-    next[rule.channel] = sanitizeChannel(next[rule.channel], rule);
+  ANALYSIS_ENCODING_RULES[type].forEach((rule) => {
+    const compatible = compatibleChannel(next[rule.channel], rule);
+    const incompatible = next[rule.channel].filter((binding) => !rule.roles.includes(binding.role));
+    next[rule.channel] = [...compatible, ...incompatible];
   });
   return applyAnalysisEncoding({ ...spec, type } as T, next);
 };
@@ -204,24 +206,24 @@ const fillRequiredBindings = (
 ) => {
   const next = cloneAnalysisEncoding(encoding);
   ANALYSIS_ENCODING_RULES[type].forEach((rule) => {
-    const sanitized = sanitizeChannel(next[rule.channel], rule);
-    if (sanitized.length >= rule.min) {
-      next[rule.channel] = sanitized;
-      return;
-    }
-    const used = new Set(sanitized.map((binding) => binding.field));
+    const compatible = next[rule.channel].filter((binding) => rule.roles.includes(binding.role));
+    const active = compatible.slice(0, rule.max);
+    if (active.length >= rule.min) return;
+
+    const used = new Set(next[rule.channel].map((binding) => binding.field));
     const candidates = dataset.fields.filter((field) => (
       rule.roles.includes(field.role) && !used.has(field.key)
     ));
-    const missing = Math.max(0, rule.min - sanitized.length);
+    const missing = Math.max(0, rule.min - active.length);
     next[rule.channel] = [
-      ...sanitized,
+      ...compatible,
       ...candidates.slice(0, missing).map((field) => ({
         field: field.key,
         role: field.role,
         aggregation: field.role === 'metric' ? 'SUM' as Aggregation : undefined,
       })),
-    ].slice(0, rule.max);
+      ...next[rule.channel].filter((binding) => !rule.roles.includes(binding.role)),
+    ];
   });
   return next;
 };
@@ -268,9 +270,10 @@ export const updateEncodingMetricAggregation = <T extends AnalysisSpec>(
 export const encodingMeetsChartRequirements = (spec: AnalysisSpec) => {
   const encoding = resolveAnalysisEncoding(spec);
   return ANALYSIS_ENCODING_RULES[spec.type].every((rule) => {
-    const validCount = encoding[rule.channel]
+    const activeCount = encoding[rule.channel]
       .filter((binding) => rule.roles.includes(binding.role))
+      .slice(0, rule.max)
       .length;
-    return validCount >= rule.min && validCount <= rule.max;
+    return activeCount >= rule.min;
   });
 };

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -96,18 +96,34 @@ export const cloneAnalysisEncoding = (encoding: AnalysisEncoding): AnalysisEncod
   tooltip: (encoding.tooltip || []).map(cloneBinding),
 });
 
-export const legacyAnalysisEncoding = (spec: Pick<AnalysisSpec, 'dimensions' | 'metrics'>): AnalysisEncoding => ({
-  ...cloneAnalysisEncoding(EMPTY_ANALYSIS_ENCODING),
-  category: spec.dimensions.map((field) => ({ field, role: 'dimension' as const })),
-  value: spec.metrics.map((metric) => ({
-    field: metric.field,
-    role: 'metric' as const,
-    aggregation: metric.aggregation,
-  })),
-});
+/**
+ * Legacy snapshots have only the query projection. For bar/line we can safely infer
+ * category + color from the first two projected dimensions because Encoding v1 is the
+ * first editor version that intentionally produces that shape. Other charts keep their
+ * historical dimensions in category to avoid inventing semantics that were never stored.
+ */
+export const legacyAnalysisEncoding = (
+  spec: Pick<AnalysisSpec, 'type' | 'dimensions' | 'metrics'>,
+): AnalysisEncoding => {
+  const groupedSeries = spec.type === 'bar' || spec.type === 'line';
+  const categoryDimensions = groupedSeries ? spec.dimensions.slice(0, 1) : spec.dimensions;
+  const colorDimensions = groupedSeries ? spec.dimensions.slice(1, 2) : [];
+  return {
+    ...cloneAnalysisEncoding(EMPTY_ANALYSIS_ENCODING),
+    category: categoryDimensions.map((field) => ({ field, role: 'dimension' as const })),
+    color: colorDimensions.map((field) => ({ field, role: 'dimension' as const })),
+    value: spec.metrics.map((metric) => ({
+      field: metric.field,
+      role: 'metric' as const,
+      aggregation: metric.aggregation,
+    })),
+  };
+};
 
 /** Existing snapshots without `encoding` are upgraded lazily and losslessly in memory. */
-export const resolveAnalysisEncoding = (spec: Pick<AnalysisSpec, 'encoding' | 'dimensions' | 'metrics'>): AnalysisEncoding => (
+export const resolveAnalysisEncoding = (
+  spec: Pick<AnalysisSpec, 'type' | 'encoding' | 'dimensions' | 'metrics'>,
+): AnalysisEncoding => (
   spec.encoding?.version === 1
     ? cloneAnalysisEncoding(spec.encoding)
     : legacyAnalysisEncoding(spec)
@@ -181,7 +197,7 @@ export const changeAnalysisEncodingType = <T extends AnalysisSpec>(
 };
 
 export const analysisEncodingFieldKeys = (
-  spec: Pick<AnalysisSpec, 'encoding' | 'dimensions' | 'metrics'>,
+  spec: Pick<AnalysisSpec, 'type' | 'encoding' | 'dimensions' | 'metrics'>,
 ) => {
   const encoding = resolveAnalysisEncoding(spec);
   return new Set<string>(ENCODING_CHANNELS.flatMap(

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -39,9 +39,9 @@ const slot = (
 ): AnalysisEncodingSlotRule => ({ channel, label, roles, min, max, hint });
 
 /**
- * Active visual channels for the chart types currently shipped by Yak Ops.
- * The encoding model already defines color / size / label / detail / tooltip so
- * future chart renderers can enable them without another persistence migration.
+ * Semantic channel contracts for the chart renderers currently shipped by Yak Ops.
+ * size / label / tooltip already exist in the versioned grammar and can be activated by
+ * later renderers without another persistence migration.
  */
 export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule[]> = {
   metric: [
@@ -50,10 +50,12 @@ export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule
   bar: [
     slot('category', '分类', ['dimension'], 1, 1, '柱状图需要 1 个分类字段'),
     slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
+    slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
   ],
   line: [
     slot('category', '分类', ['dimension'], 1, 1, '折线图需要 1 个分类字段'),
     slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
+    slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
   ],
   pie: [
     slot('category', '分类', ['dimension'], 1, 1, '饼图需要 1 个分类字段'),
@@ -62,6 +64,7 @@ export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule
   table: [
     slot('category', '维度', ['dimension'], 0, 3, '最多 3 个维度'),
     slot('value', '指标', ['metric'], 0, 3, '最多 3 个指标'),
+    slot('detail', '明细', ['dimension'], 0, 3, '追加明细维度，不改变指标定义'),
   ],
 };
 
@@ -84,13 +87,13 @@ const cloneBinding = (binding: AnalysisEncodingBinding): AnalysisEncodingBinding
 
 export const cloneAnalysisEncoding = (encoding: AnalysisEncoding): AnalysisEncoding => ({
   version: 1,
-  category: encoding.category.map(cloneBinding),
-  value: encoding.value.map(cloneBinding),
-  color: encoding.color.map(cloneBinding),
-  size: encoding.size.map(cloneBinding),
-  label: encoding.label.map(cloneBinding),
-  detail: encoding.detail.map(cloneBinding),
-  tooltip: encoding.tooltip.map(cloneBinding),
+  category: (encoding.category || []).map(cloneBinding),
+  value: (encoding.value || []).map(cloneBinding),
+  color: (encoding.color || []).map(cloneBinding),
+  size: (encoding.size || []).map(cloneBinding),
+  label: (encoding.label || []).map(cloneBinding),
+  detail: (encoding.detail || []).map(cloneBinding),
+  tooltip: (encoding.tooltip || []).map(cloneBinding),
 });
 
 export const legacyAnalysisEncoding = (spec: Pick<AnalysisSpec, 'dimensions' | 'metrics'>): AnalysisEncoding => ({
@@ -110,10 +113,6 @@ export const resolveAnalysisEncoding = (spec: Pick<AnalysisSpec, 'encoding' | 'd
     : legacyAnalysisEncoding(spec)
 );
 
-const activeRuleMap = (type: ChartType) => new Map(
-  ANALYSIS_ENCODING_RULES[type].map((rule) => [rule.channel, rule]),
-);
-
 const metricProjection = (bindings: AnalysisEncodingBinding[]): MetricBinding[] => bindings
   .filter((binding) => binding.role === 'metric')
   .map((binding) => ({
@@ -121,27 +120,32 @@ const metricProjection = (bindings: AnalysisEncodingBinding[]): MetricBinding[] 
     aggregation: binding.aggregation ?? 'SUM',
   }));
 
+const unique = <T,>(values: T[]) => [...new Set(values)];
+
 /**
  * Keeps the existing query/render contract alive while encoding becomes the editor's
  * semantic source of truth. Inactive and overflow bindings stay persisted in
- * `encoding`; only the active chart slots are projected into dimensions / metrics.
+ * `encoding`; only active chart slots are projected into dimensions / metrics.
  */
 export const applyAnalysisEncoding = <T extends AnalysisSpec>(
   spec: T,
   encoding: AnalysisEncoding,
 ): T => {
-  const rules = activeRuleMap(spec.type);
-  const categoryRule = rules.get('category');
-  const valueRule = rules.get('value');
+  const rules = ANALYSIS_ENCODING_RULES[spec.type];
+  const valueRule = rules.find((rule) => rule.channel === 'value');
+  const dimensions = unique(rules.flatMap((rule) => (
+    rule.roles.includes('dimension')
+      ? encoding[rule.channel]
+        .filter((binding) => binding.role === 'dimension')
+        .slice(0, rule.max)
+        .map((binding) => binding.field)
+      : []
+  )));
+
   return {
     ...spec,
     encoding: cloneAnalysisEncoding(encoding),
-    dimensions: categoryRule
-      ? encoding.category
-        .filter((binding) => categoryRule.roles.includes(binding.role) && binding.role === 'dimension')
-        .slice(0, categoryRule.max)
-        .map((binding) => binding.field)
-      : [],
+    dimensions: spec.type === 'metric' ? [] : dimensions,
     metrics: valueRule
       ? metricProjection(
         encoding.value.filter((binding) => valueRule.roles.includes(binding.role)),
@@ -158,9 +162,9 @@ const compatibleChannel = (
   .map(cloneBinding);
 
 /**
- * Chart switching is non-destructive: incompatible roles are discarded for channels
- * activated by the target chart, but bindings beyond the target slot capacity remain
- * parked in the semantic channel. Switching back can therefore restore them.
+ * Chart switching is non-destructive: incompatible roles are moved behind compatible
+ * bindings for target-active channels, while overflow bindings remain parked. Switching
+ * back can therefore restore previous field choices.
  */
 export const changeAnalysisEncodingType = <T extends AnalysisSpec>(
   spec: T,

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -19,6 +19,16 @@ export interface AnalysisEncodingSlotRule {
   hint?: string;
 }
 
+const ENCODING_CHANNELS: AnalysisEncodingChannel[] = [
+  'category',
+  'value',
+  'color',
+  'size',
+  'label',
+  'detail',
+  'tooltip',
+];
+
 const slot = (
   channel: AnalysisEncodingChannel,
   label: string,
@@ -168,15 +178,9 @@ export const analysisEncodingFieldKeys = (
   spec: Pick<AnalysisSpec, 'encoding' | 'dimensions' | 'metrics'>,
 ) => {
   const encoding = resolveAnalysisEncoding(spec);
-  return new Set< string >([
-    ...encoding.category.map((binding) => binding.field),
-    ...encoding.value.map((binding) => binding.field),
-    ...encoding.color.map((binding) => binding.field),
-    ...encoding.size.map((binding) => binding.field),
-    ...encoding.label.map((binding) => binding.field),
-    ...encoding.detail.map((binding) => binding.field),
-    ...encoding.tooltip.map((binding) => binding.field),
-  ]);
+  return new Set<string>(ENCODING_CHANNELS.flatMap(
+    (channel) => encoding[channel].map((binding) => binding.field),
+  ));
 };
 
 const validBindingForDataset = (
@@ -193,20 +197,49 @@ const validBindingForDataset = (
   } satisfies AnalysisEncodingBinding;
 };
 
-/** Dataset changes remove invalid bindings from every semantic channel in one place. */
+const fillRequiredBindings = (
+  encoding: AnalysisEncoding,
+  type: ChartType,
+  dataset: PublishedDataset,
+) => {
+  const next = cloneAnalysisEncoding(encoding);
+  ANALYSIS_ENCODING_RULES[type].forEach((rule) => {
+    const sanitized = sanitizeChannel(next[rule.channel], rule);
+    if (sanitized.length >= rule.min) {
+      next[rule.channel] = sanitized;
+      return;
+    }
+    const used = new Set(sanitized.map((binding) => binding.field));
+    const candidates = dataset.fields.filter((field) => (
+      rule.roles.includes(field.role) && !used.has(field.key)
+    ));
+    const missing = Math.max(0, rule.min - sanitized.length);
+    next[rule.channel] = [
+      ...sanitized,
+      ...candidates.slice(0, missing).map((field) => ({
+        field: field.key,
+        role: field.role,
+        aggregation: field.role === 'metric' ? 'SUM' as Aggregation : undefined,
+      })),
+    ].slice(0, rule.max);
+  });
+  return next;
+};
+
+/** Dataset changes validate all channels, then seed only missing required slots. */
 export const rebindAnalysisEncoding = <T extends AnalysisSpec>(
   spec: T,
   dataset: PublishedDataset,
 ): T => {
   const source = resolveAnalysisEncoding(spec);
   const next = cloneAnalysisEncoding(EMPTY_ANALYSIS_ENCODING);
-  (Object.keys(next) as Array<keyof AnalysisEncoding>).forEach((key) => {
-    if (key === 'version') return;
-    next[key] = source[key]
+  ENCODING_CHANNELS.forEach((channel) => {
+    next[channel] = source[channel]
       .map((binding) => validBindingForDataset(binding, dataset))
-      .filter(Boolean) as AnalysisEncodingBinding[];
+      .filter((binding): binding is AnalysisEncodingBinding => Boolean(binding));
   });
-  return applyAnalysisEncoding({ ...spec, datasetId: dataset.id } as T, next);
+  const seeded = fillRequiredBindings(next, spec.type, dataset);
+  return applyAnalysisEncoding({ ...spec, datasetId: dataset.id } as T, seeded);
 };
 
 export const updateEncodingMetricAggregation = <T extends AnalysisSpec>(

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -34,6 +34,38 @@ export interface MetricBinding {
   aggregation: Aggregation;
 }
 
+export type AnalysisEncodingChannel =
+  | 'category'
+  | 'value'
+  | 'color'
+  | 'size'
+  | 'label'
+  | 'detail'
+  | 'tooltip';
+
+/** Semantic field binding used by the visual editor, independent from a concrete chart renderer. */
+export interface AnalysisEncodingBinding {
+  field: string;
+  role: DatasetFieldRole;
+  aggregation?: Aggregation;
+}
+
+/**
+ * Versioned visualization grammar. `dimensions` / `metrics` remain as a compatibility
+ * projection for the existing query/render pipeline while the editor evolves around
+ * semantic encoding channels.
+ */
+export interface AnalysisEncoding {
+  version: 1;
+  category: AnalysisEncodingBinding[];
+  value: AnalysisEncodingBinding[];
+  color: AnalysisEncodingBinding[];
+  size: AnalysisEncodingBinding[];
+  label: AnalysisEncodingBinding[];
+  detail: AnalysisEncodingBinding[];
+  tooltip: AnalysisEncodingBinding[];
+}
+
 export interface AnalysisFilter {
   id: string;
   field: string;
@@ -57,8 +89,12 @@ export interface AnalysisVisualConfig {
 export interface AnalysisSpec {
   type: ChartType;
   datasetId: string;
+  /** Compatibility projection of the active category encoding. */
   dimensions: string[];
+  /** Compatibility projection of the active value encoding. */
   metrics: MetricBinding[];
+  /** Optional for backwards compatibility with existing Analysis / Dashboard snapshots. */
+  encoding?: AnalysisEncoding;
   filters: AnalysisFilter[];
   sort?: AnalysisSort;
   style: AnalysisVisualConfig;

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -1,4 +1,9 @@
-import type { AnalysisSpec } from '@/components/analysis/model';
+import {
+  applyAnalysisEncoding,
+  changeAnalysisEncodingType,
+  updateEncodingMetricAggregation,
+} from '@/components/analysis/encoding';
+import type { AnalysisEncoding, AnalysisSpec } from '@/components/analysis/model';
 import { Button, Collapse, Input, Select, Switch } from 'antd';
 import { ChevronDown, MousePointerClick, SlidersHorizontal, X } from 'lucide-react';
 import { ConfigData } from './config-data';
@@ -15,7 +20,6 @@ import type {
   DashboardInteraction,
   DashboardWidget,
   FilterOperator,
-  MetricBinding,
   PublishedDataset,
   SortDirection,
 } from './model';
@@ -93,12 +97,11 @@ export function ChartSheetConfigPanel({
   const dataset = findDataset(datasets, spec.datasetId);
   if (!dataset) return null;
 
-  const dimensionOptions = dataset.fields
-    .filter((field) => field.role === 'dimension')
-    .map((field) => ({ label: field.label, value: field.key }));
-  const metricOptions = dataset.fields
-    .filter((field) => field.role === 'metric')
-    .map((field) => ({ label: field.label, value: field.key }));
+  const fieldOptions = dataset.fields.map((field) => ({
+    label: field.label,
+    value: field.key,
+    role: field.role,
+  }));
   const filterOptions = dataset.fields.map((field) => ({
     label: field.label,
     value: field.key,
@@ -116,12 +119,12 @@ export function ChartSheetConfigPanel({
   const filter = spec.filters[0];
 
   const changeType = (type: ChartType) => {
-    const dimensionLimit = type === 'table' ? 3 : 1;
-    const metricLimit = ['bar', 'line', 'table'].includes(type) ? 3 : 1;
+    const next = changeAnalysisEncodingType(spec, type);
     updateInlineAnalysis({
       type,
-      dimensions: type === 'metric' ? [] : spec.dimensions.slice(0, dimensionLimit),
-      metrics: spec.metrics.slice(0, metricLimit),
+      encoding: next.encoding,
+      dimensions: next.dimensions,
+      metrics: next.metrics,
       sort: undefined,
       style: {
         ...spec.style,
@@ -133,26 +136,19 @@ export function ChartSheetConfigPanel({
     });
   };
 
-  const onDimensions = (dimensions: string[]) => {
+  const changeEncoding = (encoding: AnalysisEncoding) => {
+    const next = applyAnalysisEncoding(spec, encoding);
     const nextSort = spec.sort
-      && !dimensions.includes(spec.sort.field)
-      && !spec.metrics.some((metric) => metric.field === spec.sort?.field)
+      && !next.dimensions.includes(spec.sort.field)
+      && !next.metrics.some((metric) => metric.field === spec.sort?.field)
       ? undefined
       : spec.sort;
-    updateInlineAnalysis({ dimensions, sort: nextSort });
-  };
-
-  const onMetrics = (fields: string[]) => {
-    const previous = new Map(spec.metrics.map((metric) => [metric.field, metric]));
-    const metrics: MetricBinding[] = fields.map(
-      (field) => previous.get(field) ?? { field, aggregation: 'SUM' },
-    );
-    const nextSort = spec.sort
-      && !spec.dimensions.includes(spec.sort.field)
-      && !metrics.some((metric) => metric.field === spec.sort?.field)
-      ? undefined
-      : spec.sort;
-    updateInlineAnalysis({ metrics, sort: nextSort });
+    updateInlineAnalysis({
+      encoding: next.encoding,
+      dimensions: next.dimensions,
+      metrics: next.metrics,
+      sort: nextSort,
+    });
   };
 
   const updateStyle = (patch: Partial<AnalysisSpec['style']>) =>
@@ -215,22 +211,27 @@ export function ChartSheetConfigPanel({
         </div>
 
         <div className="mt-5 rounded-[9px] bg-[#f8f9fa] p-3.5">
-          <div className="mb-3 text-[11px] font-semibold text-[#475467]">数据配置</div>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="text-[11px] font-semibold text-[#475467]">可视化编码</div>
+            <span className="rounded-[4px] border border-[#e1e4e8] bg-white px-1.5 py-0.5 text-[8px] text-[#98a2b3]">
+              Encoding v1
+            </span>
+          </div>
           <ConfigData
             spec={spec}
-            dimensionOptions={dimensionOptions}
-            metricOptions={metricOptions}
-            onDimensions={onDimensions}
-            onMetrics={onMetrics}
+            fieldOptions={fieldOptions}
+            onEncodingChange={changeEncoding}
           />
           <MetricAggregations
             metrics={spec.metrics}
             labels={metricLabels}
-            onChange={(field: string, aggregation: Aggregation) =>
+            onChange={(field: string, aggregation: Aggregation) => {
+              const next = updateEncodingMetricAggregation(spec, field, aggregation);
               updateInlineAnalysis({
-                metrics: spec.metrics.map((metric) =>
-                  metric.field === field ? { ...metric, aggregation } : metric),
-              })}
+                encoding: next.encoding,
+                metrics: next.metrics,
+              });
+            }}
           />
         </div>
 
@@ -377,7 +378,7 @@ function ConfigPanelHeader({ onDone }: { onDone: () => void }) {
     <div className="flex h-14 shrink-0 items-center justify-between border-b border-[#eceef1] px-4">
       <div>
         <div className="text-[13px] font-semibold text-[#344054]">图表配置</div>
-        <div className="mt-0.5 text-[9px] text-[#98a2b3]">数据、展示与交互配置</div>
+        <div className="mt-0.5 text-[9px] text-[#98a2b3]">字段编码、展示与交互配置</div>
       </div>
       <button
         type="button"

--- a/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
@@ -1,3 +1,4 @@
+import { analysisEncodingFieldKeys } from '@/components/analysis/encoding';
 import type { AnalysisSpec } from '@/components/analysis/model';
 import { Input } from 'antd';
 import { Database, GripVertical, Hash, Search, Type } from 'lucide-react';
@@ -36,6 +37,10 @@ export function ChartFieldPanel({
   }, [dataset, normalizedKeyword]);
   const dimensions = fields.filter((field) => field.role === 'dimension');
   const metrics = fields.filter((field) => field.role === 'metric');
+  const encodedFields = useMemo(
+    () => spec ? analysisEncodingFieldKeys(spec) : new Set<string>(),
+    [spec],
+  );
 
   return (
     <section className="flex w-[244px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
@@ -60,7 +65,7 @@ export function ChartFieldPanel({
           onChange={(event) => setKeyword(event.target.value)}
         />
         <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
-          {editable ? '拖动字段到右侧维度 / 指标槽位' : '共享图表复制为可编辑图表后可拖拽配置'}
+          {editable ? '拖动字段到右侧分类 / 值编码槽位' : '共享图表复制为可编辑图表后可拖拽配置'}
         </div>
       </div>
 
@@ -72,13 +77,13 @@ export function ChartFieldPanel({
             <FieldGroup
               title="维度"
               fields={dimensions}
-              spec={spec}
+              encodedFields={encodedFields}
               editable={editable}
             />
             <FieldGroup
               title="指标"
               fields={metrics}
-              spec={spec}
+              encodedFields={encodedFields}
               editable={editable}
             />
           </div>
@@ -91,12 +96,12 @@ export function ChartFieldPanel({
 function FieldGroup({
   title,
   fields,
-  spec,
+  encodedFields,
   editable,
 }: {
   title: string;
   fields: DatasetField[];
-  spec?: AnalysisSpec;
+  encodedFields: Set<string>;
   editable: boolean;
 }) {
   return (
@@ -107,14 +112,12 @@ function FieldGroup({
       </div>
       <div className="space-y-0.5">
         {fields.map((field) => {
-          const selected = field.role === 'dimension'
-            ? Boolean(spec?.dimensions.includes(field.key))
-            : Boolean(spec?.metrics.some((metric) => metric.field === field.key));
+          const selected = encodedFields.has(field.key);
           return (
             <div
               key={field.key}
               draggable={editable}
-              title={editable ? `${field.label} · 拖动到图表配置` : field.label}
+              title={editable ? `${field.label} · 拖动到图表编码槽位` : field.label}
               className={[
                 'group flex h-8 items-center gap-1.5 rounded-[6px] px-1.5 text-[10px] transition-colors',
                 editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',

--- a/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
@@ -65,7 +65,7 @@ export function ChartFieldPanel({
           onChange={(event) => setKeyword(event.target.value)}
         />
         <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
-          {editable ? '拖动字段到右侧分类 / 值编码槽位' : '共享图表复制为可编辑图表后可拖拽配置'}
+          {editable ? '拖动字段到右侧可视化编码槽位' : '共享图表复制为可编辑图表后可拖拽配置'}
         </div>
       </div>
 

--- a/yak-ops-ui/src/pages/dashboard/config-data.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-data.tsx
@@ -44,7 +44,10 @@ export function ConfigData({
     <div className="space-y-3">
       {ANALYSIS_ENCODING_RULES[spec.type].map((rule) => {
         const bindings = encoding[rule.channel];
-        const values: BoundField[] = bindings.map((binding) => ({
+        const activeBindings = bindings
+          .filter((binding) => rule.roles.includes(binding.role))
+          .slice(0, rule.max);
+        const values: BoundField[] = activeBindings.map((binding) => ({
           field: binding.field,
           label: fieldLabel.get(binding.field) ?? binding.field,
           suffix: binding.role === 'metric'
@@ -67,9 +70,23 @@ export function ConfigData({
               };
               const current = encoding[rule.channel];
               if (current.some((binding) => binding.field === field)) return;
-              const nextChannel = rule.max === 1
-                ? [nextBinding]
-                : [...current, nextBinding].slice(0, rule.max);
+
+              let nextChannel: AnalysisEncodingBinding[];
+              if (rule.max === 1) {
+                const firstActiveIndex = current.findIndex((binding) => rule.roles.includes(binding.role));
+                if (firstActiveIndex < 0) {
+                  nextChannel = [nextBinding, ...current];
+                } else {
+                  nextChannel = current.map((binding, index) => (
+                    index === firstActiveIndex ? nextBinding : binding
+                  ));
+                }
+              } else {
+                const activeCount = current.filter((binding) => rule.roles.includes(binding.role)).length;
+                if (activeCount >= rule.max) return;
+                nextChannel = [...current, nextBinding];
+              }
+
               onEncodingChange({
                 ...encoding,
                 [rule.channel]: nextChannel,

--- a/yak-ops-ui/src/pages/dashboard/config-data.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-data.tsx
@@ -61,6 +61,7 @@ export function ConfigData({
             key={rule.channel}
             rule={rule}
             values={values}
+            boundFields={bindings.map((binding) => binding.field)}
             options={options}
             onAdd={(field, role) => {
               const nextBinding: AnalysisEncodingBinding = {
@@ -69,18 +70,25 @@ export function ConfigData({
                 aggregation: role === 'metric' ? 'SUM' : undefined,
               };
               const current = encoding[rule.channel];
-              if (current.some((binding) => binding.field === field)) return;
+              const existingIndex = current.findIndex((binding) => binding.field === field);
+              const existing = existingIndex >= 0 ? current[existingIndex] : undefined;
 
               let nextChannel: AnalysisEncodingBinding[];
               if (rule.max === 1) {
-                const firstActiveIndex = current.findIndex((binding) => rule.roles.includes(binding.role));
-                if (firstActiveIndex < 0) {
-                  nextChannel = [nextBinding, ...current];
-                } else {
-                  nextChannel = current.map((binding, index) => (
-                    index === firstActiveIndex ? nextBinding : binding
-                  ));
-                }
+                // Replacing a single visual slot parks the previous binding behind the
+                // new active binding instead of destroying it. Switching chart types can
+                // therefore restore the user's earlier configuration.
+                nextChannel = [
+                  existing ?? nextBinding,
+                  ...current.filter((_, index) => index !== existingIndex),
+                ];
+              } else if (existing) {
+                // A previously parked overflow binding can be promoted into the active
+                // range without creating a duplicate.
+                nextChannel = [
+                  existing,
+                  ...current.filter((_, index) => index !== existingIndex),
+                ];
               } else {
                 const activeCount = current.filter((binding) => rule.roles.includes(binding.role)).length;
                 if (activeCount >= rule.max) return;
@@ -106,19 +114,33 @@ export function ConfigData({
 function EncodingDropZone({
   rule,
   values,
+  boundFields,
   options,
   onAdd,
   onRemove,
 }: {
   rule: AnalysisEncodingSlotRule;
   values: BoundField[];
+  boundFields: string[];
   options: FieldOption[];
   onAdd: (field: string, role: DatasetFieldRole) => void;
   onRemove: (field: string) => void;
 }) {
   const [dragOver, setDragOver] = useState(false);
-  const availableOptions = options.filter((option) => !values.some((item) => item.field === option.value));
+  const visibleFields = new Set(values.map((item) => item.field));
+  const allBoundFields = new Set(boundFields);
+  const availableOptions = options.filter((option) => (
+    rule.max === 1
+      ? !visibleFields.has(option.value)
+      : !allBoundFields.has(option.value)
+  ));
   const full = values.length >= rule.max;
+  const selectDisabled = (rule.max > 1 && full) || !availableOptions.length;
+  const selectPlaceholder = rule.max === 1 && full
+    ? `选择字段替换当前${rule.label}`
+    : full
+      ? `最多 ${rule.max} 个字段`
+      : '+ 点击选择字段';
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
     if (
@@ -194,11 +216,11 @@ function EncodingDropZone({
           showSearch
           size="small"
           value={undefined}
-          disabled={full || !availableOptions.length}
+          disabled={selectDisabled}
           className="mt-2 w-full"
           options={availableOptions.map((option) => ({ label: option.label, value: option.value }))}
           optionFilterProp="label"
-          placeholder={full ? `最多 ${rule.max} 个字段` : '+ 点击选择字段'}
+          placeholder={selectPlaceholder}
           onChange={(field) => {
             const option = availableOptions.find((item) => item.value === field);
             if (option) onAdd(option.value, option.role);

--- a/yak-ops-ui/src/pages/dashboard/config-data.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-data.tsx
@@ -1,4 +1,14 @@
-import type { AnalysisSpec } from '@/components/analysis/model';
+import {
+  ANALYSIS_ENCODING_RULES,
+  resolveAnalysisEncoding,
+  type AnalysisEncodingSlotRule,
+} from '@/components/analysis/encoding';
+import type {
+  AnalysisEncoding,
+  AnalysisEncodingBinding,
+  AnalysisSpec,
+  DatasetFieldRole,
+} from '@/components/analysis/model';
 import { Select } from 'antd';
 import { Plus, X } from 'lucide-react';
 import { useState, type DragEvent } from 'react';
@@ -8,6 +18,7 @@ import { AGGREGATION_OPTIONS, FIELD_DRAG_MIME } from './helpers';
 interface FieldOption {
   label: string;
   value: string;
+  role: DatasetFieldRole;
 }
 
 interface BoundField {
@@ -18,108 +29,79 @@ interface BoundField {
 
 export function ConfigData({
   spec,
-  dimensionOptions,
-  metricOptions,
-  onDimensions,
-  onMetrics,
+  fieldOptions,
+  onEncodingChange,
 }: {
   spec: AnalysisSpec;
-  dimensionOptions: FieldOption[];
-  metricOptions: FieldOption[];
-  onDimensions: (value: string[]) => void;
-  onMetrics: (value: string[]) => void;
+  fieldOptions: FieldOption[];
+  onEncodingChange: (encoding: AnalysisEncoding) => void;
 }) {
-  const dimensionLimit = spec.type === 'table' ? 3 : 1;
-  const metricLimit = ['bar', 'line', 'table'].includes(spec.type) ? 3 : 1;
-  const dimensionLabel = new Map(dimensionOptions.map((option) => [option.value, option.label]));
-  const metricLabel = new Map(metricOptions.map((option) => [option.value, option.label]));
+  const encoding = resolveAnalysisEncoding(spec);
+  const fieldLabel = new Map(fieldOptions.map((option) => [option.value, option.label]));
   const aggregationLabel = new Map(AGGREGATION_OPTIONS.map((option) => [option.value, option.label]));
-
-  const addDimension = (field: string) => {
-    if (!dimensionOptions.some((option) => option.value === field)) return;
-    if (spec.dimensions.includes(field)) return;
-    if (dimensionLimit === 1) {
-      onDimensions([field]);
-      return;
-    }
-    if (spec.dimensions.length >= dimensionLimit) return;
-    onDimensions([...spec.dimensions, field]);
-  };
-
-  const addMetric = (field: string) => {
-    if (!metricOptions.some((option) => option.value === field)) return;
-    const fields = spec.metrics.map((metric) => metric.field);
-    if (fields.includes(field)) return;
-    if (metricLimit === 1) {
-      onMetrics([field]);
-      return;
-    }
-    if (fields.length >= metricLimit) return;
-    onMetrics([...fields, field]);
-  };
-
-  const dimensions: BoundField[] = spec.dimensions.map((field) => ({
-    field,
-    label: dimensionLabel.get(field) ?? field,
-  }));
-  const metrics: BoundField[] = spec.metrics.map((metric) => ({
-    field: metric.field,
-    label: metricLabel.get(metric.field) ?? metric.field,
-    suffix: aggregationLabel.get(metric.aggregation) ?? metric.aggregation,
-  }));
 
   return (
     <div className="space-y-3">
-      {spec.type !== 'metric' ? (
-        <BindingDropZone
-          role="dimension"
-          label="维度"
-          emptyText="拖入维度字段"
-          values={dimensions}
-          options={dimensionOptions}
-          limit={dimensionLimit}
-          onAdd={addDimension}
-          onRemove={(field) => onDimensions(spec.dimensions.filter((item) => item !== field))}
-        />
-      ) : null}
-      <BindingDropZone
-        role="metric"
-        label="指标"
-        emptyText="拖入指标字段"
-        values={metrics}
-        options={metricOptions}
-        limit={metricLimit}
-        onAdd={addMetric}
-        onRemove={(field) => onMetrics(spec.metrics
-          .map((metric) => metric.field)
-          .filter((item) => item !== field))}
-      />
+      {ANALYSIS_ENCODING_RULES[spec.type].map((rule) => {
+        const bindings = encoding[rule.channel];
+        const values: BoundField[] = bindings.map((binding) => ({
+          field: binding.field,
+          label: fieldLabel.get(binding.field) ?? binding.field,
+          suffix: binding.role === 'metric'
+            ? aggregationLabel.get(binding.aggregation ?? 'SUM') ?? binding.aggregation ?? 'SUM'
+            : undefined,
+        }));
+        const options = fieldOptions.filter((option) => rule.roles.includes(option.role));
+
+        return (
+          <EncodingDropZone
+            key={rule.channel}
+            rule={rule}
+            values={values}
+            options={options}
+            onAdd={(field, role) => {
+              const nextBinding: AnalysisEncodingBinding = {
+                field,
+                role,
+                aggregation: role === 'metric' ? 'SUM' : undefined,
+              };
+              const current = encoding[rule.channel];
+              if (current.some((binding) => binding.field === field)) return;
+              const nextChannel = rule.max === 1
+                ? [nextBinding]
+                : [...current, nextBinding].slice(0, rule.max);
+              onEncodingChange({
+                ...encoding,
+                [rule.channel]: nextChannel,
+              });
+            }}
+            onRemove={(field) => onEncodingChange({
+              ...encoding,
+              [rule.channel]: bindings.filter((binding) => binding.field !== field),
+            })}
+          />
+        );
+      })}
     </div>
   );
 }
 
-function BindingDropZone({
-  role,
-  label,
-  emptyText,
+function EncodingDropZone({
+  rule,
   values,
   options,
-  limit,
   onAdd,
   onRemove,
 }: {
-  role: 'dimension' | 'metric';
-  label: string;
-  emptyText: string;
+  rule: AnalysisEncodingSlotRule;
   values: BoundField[];
   options: FieldOption[];
-  limit: number;
-  onAdd: (field: string) => void;
+  onAdd: (field: string, role: DatasetFieldRole) => void;
   onRemove: (field: string) => void;
 }) {
   const [dragOver, setDragOver] = useState(false);
   const availableOptions = options.filter((option) => !values.some((item) => item.field === option.value));
-  const full = values.length >= limit;
+  const full = values.length >= rule.max;
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
     if (
@@ -135,15 +117,18 @@ function BindingDropZone({
     event.preventDefault();
     setDragOver(false);
     const payload = readChartFieldDragPayload(event);
-    if (!payload || payload.role !== role) return;
-    onAdd(payload.field);
+    if (!payload || !rule.roles.includes(payload.role)) return;
+    onAdd(payload.field, payload.role);
   };
 
   return (
     <div>
-      <div className="mb-1.5 flex items-center justify-between text-[10px] text-[#667085]">
-        <span>{label}</span>
-        <span className="text-[9px] text-[#a0a6af]">{values.length}/{limit}</span>
+      <div className="mb-1.5 flex items-center justify-between gap-3 text-[10px] text-[#667085]">
+        <div className="min-w-0">
+          <span>{rule.label}</span>
+          {rule.min > 0 ? <span className="ml-1 text-[8px] text-[#b42318]">必填</span> : null}
+        </div>
+        <span className="shrink-0 text-[9px] text-[#a0a6af]">{values.length}/{rule.max}</span>
       </div>
       <div
         className={[
@@ -184,7 +169,7 @@ function BindingDropZone({
         {!values.length ? (
           <div className="flex h-9 items-center justify-center gap-1 text-[9px] text-[#a0a6af]">
             <Plus size={10} />
-            {emptyText}
+            拖入{rule.label}字段
           </div>
         ) : null}
 
@@ -194,11 +179,17 @@ function BindingDropZone({
           value={undefined}
           disabled={full || !availableOptions.length}
           className="mt-2 w-full"
-          options={availableOptions}
+          options={availableOptions.map((option) => ({ label: option.label, value: option.value }))}
           optionFilterProp="label"
-          placeholder={full ? `最多 ${limit} 个字段` : '+ 点击选择字段'}
-          onChange={onAdd}
+          placeholder={full ? `最多 ${rule.max} 个字段` : '+ 点击选择字段'}
+          onChange={(field) => {
+            const option = availableOptions.find((item) => item.value === field);
+            if (option) onAdd(option.value, option.role);
+          }}
         />
+        {rule.hint ? (
+          <div className="mt-1.5 text-[8px] leading-4 text-[#a0a6af]">{rule.hint}</div>
+        ) : null}
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/dashboard/helpers.tsx
+++ b/yak-ops-ui/src/pages/dashboard/helpers.tsx
@@ -119,7 +119,10 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
   const base: AnalysisSpec = {
     type,
     datasetId: dataset.id,
-    dimensions: type === 'metric' ? [] : bindings.dimensions,
+    // Seed semantic category even for metric cards. `applyAnalysisEncoding` keeps the
+    // metric query dimensionless while preserving a useful category if the user later
+    // switches this chart to bar / line / pie.
+    dimensions: bindings.dimensions,
     metrics: bindings.metrics,
     filters: [],
     style: {

--- a/yak-ops-ui/src/pages/dashboard/helpers.tsx
+++ b/yak-ops-ui/src/pages/dashboard/helpers.tsx
@@ -1,3 +1,8 @@
+import {
+  applyAnalysisEncoding,
+  legacyAnalysisEncoding,
+  rebindAnalysisEncoding,
+} from '@/components/analysis/encoding';
 import type { AnalysisSpec } from '@/components/analysis/model';
 import { BarChart3, ChartLine, ChartPie, Sigma, Table2 } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -111,7 +116,7 @@ export const defaultBindings = (dataset: PublishedDataset) => ({
 
 export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset): AnalysisSpec => {
   const bindings = defaultBindings(dataset);
-  return {
+  const base: AnalysisSpec = {
     type,
     datasetId: dataset.id,
     dimensions: type === 'metric' ? [] : bindings.dimensions,
@@ -126,6 +131,7 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
     limit: type === 'table' ? 200 : 500,
     timeoutSeconds: 30,
   };
+  return applyAnalysisEncoding(base, legacyAnalysisEncoding(base));
 };
 
 export const createWidget = (type: ChartType, dataset: PublishedDataset, y: number): DashboardWidget => ({
@@ -141,16 +147,28 @@ export const createWidget = (type: ChartType, dataset: PublishedDataset, y: numb
 });
 
 const rebindInlineAnalysis = (spec: AnalysisSpec, dataset: PublishedDataset): AnalysisSpec => {
-  const bindings = defaultBindings(dataset);
-  const fieldMap = new Map(dataset.fields.map((field) => [field.key, field]));
   const sameDataset = spec.datasetId === dataset.id;
-  const validDimensions = sameDataset ? spec.dimensions.filter((field) => fieldMap.get(field)?.role === 'dimension') : [];
-  const validMetrics = sameDataset ? spec.metrics.filter((metric) => fieldMap.get(metric.field)?.role === 'metric') : [];
-  const dimensions = spec.type === 'metric' ? [] : validDimensions.length ? validDimensions : bindings.dimensions;
-  const metrics = validMetrics.length ? validMetrics : bindings.metrics;
-  const filters = sameDataset ? spec.filters.filter((filter) => fieldMap.has(filter.field)) : [];
-  const sort = sameDataset && spec.sort && fieldMap.has(spec.sort.field) ? spec.sort : undefined;
-  return { ...spec, datasetId: dataset.id, dimensions, metrics, filters, sort };
+  const filters = sameDataset
+    ? spec.filters.filter((filter) => dataset.fields.some((field) => field.key === filter.field))
+    : [];
+  const sort = sameDataset && spec.sort && dataset.fields.some((field) => field.key === spec.sort?.field)
+    ? spec.sort
+    : undefined;
+
+  if (!sameDataset) {
+    const fresh = createInlineAnalysis(spec.type, dataset);
+    return {
+      ...fresh,
+      style: { ...spec.style },
+      filters,
+      sort,
+      limit: spec.type === 'table' ? 200 : spec.limit,
+      timeoutSeconds: spec.timeoutSeconds,
+    };
+  }
+
+  const rebound = rebindAnalysisEncoding(spec, dataset);
+  return { ...rebound, filters, sort };
 };
 
 export const reconcileDashboard = (

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -7,6 +7,9 @@ import type {
 export type {
   Aggregation,
   AnalysisAsset,
+  AnalysisEncoding,
+  AnalysisEncodingBinding,
+  AnalysisEncodingChannel,
   AnalysisFilter as DashboardFilter,
   AnalysisSelection,
   AnalysisSort as DashboardSort,


### PR DESCRIPTION
## What changed
- introduce a versioned `AnalysisEncoding` grammar with semantic channels: `category` / `value` / `color` / `size` / `label` / `detail` / `tooltip`
- keep the existing `dimensions` / `metrics` fields as materialized compatibility projections so the current query/render contract remains available while the editor moves to semantic encodings
- add chart-specific encoding rules for field role, required count, slot capacity and type migration
- migrate the chart editor from hard-coded dimension/metric slot logic to rule-driven visualization encoding slots
- preserve inactive and overflow bindings when switching chart types, so temporary chart-type constraints do not destructively discard field choices
- seed useful inactive category state for new metric cards, allowing metric -> bar/line/pie switches to recover a sensible category without another manual binding
- activate `color` encoding for bar/line charts: a dragged dimension becomes a grouped series dimension and renders as separate ECharts series with legend
- activate `detail` encoding for tables: detail dimensions participate in the query/table projection without changing metric definitions
- make field-panel bound-state highlighting encoding-aware across all semantic channels
- keep metric aggregation synchronized with value-channel bindings
- lazily upgrade legacy Dashboard/Analysis snapshots that do not contain `encoding`
- validate/reconcile semantic bindings when a Dataset changes and seed only missing required slots

## Encoding v1

```text
encoding
├─ category[]
├─ value[]
├─ color[]
├─ size[]
├─ label[]
├─ detail[]
└─ tooltip[]
```

Current renderer support in this PR:
- `category` + `value`: metric / bar / line / pie / table as applicable
- `color`: bar / line
- `detail`: table
- `size` / `label` / `tooltip`: reserved in Encoding v1 but intentionally not exposed until a renderer can consume them honestly

## Compatibility
- `AnalysisSpec.encoding` is optional, so existing saved Analysis/Dashboard snapshots remain readable
- Dashboard document version remains `1`
- no database schema migration is required
- no backend DTO/domain change is required: Dashboard `inlineAnalysis` is accepted as `Object`, serialized as arbitrary JSON, stored in `inline_analysis_json`, and parsed back as an object, so Encoding v1 is preserved transparently
- no new npm dependency
- existing Dashboard save / publish / restore / undo / redo flows keep the same document pipeline
- legacy shared Analysis assets continue through the existing “复制为可编辑图表” flow

## Validation
- [x] Phase 5 PR #480 is merged into `main`; this branch starts from its merge commit
- [x] branch compare is 0 commits behind `main`
- [x] reviewed final compare: 8 frontend files changed; no backend or DB migration files changed
- [x] verified Dashboard backend persists `inlineAnalysis` as arbitrary JSON without whitelisting fields
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] manual browser regression: drag fields, type-switch restoration, grouped color series, table detail

Executable frontend validation is intentionally left unchecked in the current environment rather than being claimed as completed. GitHub checks should be treated as the executable integration signal if/when workflows are configured.