### PR TITLE
feat(bi): add visualization style system (phase 7)

### DIFF
--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -14,6 +14,7 @@ import type {
   PublishedDataset,
   Scalar,
 } from './model';
+import { paletteColors, resolveAnalysisStyle } from './style';
 
 export const AGGREGATION_LABELS: Record<Aggregation, string> = {
   SUM: '求和',
@@ -222,12 +223,26 @@ const selectionForRow = (
   };
 };
 
+const legendOption = (
+  visible: boolean,
+  position: 'top' | 'right' | 'bottom',
+  axisText: string,
+) => {
+  if (!visible) return { show: false };
+  const base = { textStyle: { color: axisText, fontSize: 11 } };
+  if (position === 'right') return { ...base, orient: 'vertical', right: 0, top: 'middle' };
+  if (position === 'bottom') return { ...base, orient: 'horizontal', left: 'center', bottom: 0 };
+  return { ...base, orient: 'horizontal', right: 4, top: 0 };
+};
+
 const chartOptionFor = (
   spec: AnalysisSpec,
   dataset: PublishedDataset,
   result: DatasetQueryResult,
 ) => {
   const encoding = resolveAnalysisEncoding(spec);
+  const style = resolveAnalysisStyle(spec.style);
+  const colors = paletteColors(spec.style);
   const firstDimension = encoding.category.find((binding) => binding.role === 'dimension')?.field
     ?? spec.dimensions[0];
   const colorDimension = encoding.color.find((binding) => binding.role === 'dimension')?.field;
@@ -241,17 +256,28 @@ const chartOptionFor = (
 
   if (spec.type === 'pie') {
     const metric = metrics[0];
+    const legendVisible = style.showLegend;
+    const legendOnRight = legendVisible && style.legendPosition === 'right';
+    const legendOnTop = legendVisible && style.legendPosition === 'top';
+    const legendOnBottom = legendVisible && style.legendPosition === 'bottom';
+    const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
     return {
+      color: colors,
       tooltip: { trigger: 'item' },
-      legend: spec.style.showLegend
-        ? { orient: 'vertical', right: 8, top: 'middle', textStyle: { color: axisText, fontSize: 11 } }
-        : { show: false },
+      legend: legendOption(legendVisible, style.legendPosition, axisText),
       series: [{
         name: metricDisplayName(dataset, metric),
         type: 'pie',
-        radius: ['42%', '70%'],
-        center: [spec.style.showLegend ? '38%' : '50%', '52%'],
-        label: { show: spec.style.showDataLabels, formatter: '{b} {d}%' },
+        radius: [`${style.pieInnerRadius}%`, '70%'],
+        center: [
+          legendOnRight ? '38%' : '50%',
+          legendOnTop ? '56%' : legendOnBottom ? '45%' : '52%',
+        ],
+        label: {
+          show: style.showDataLabels,
+          position: labelPosition,
+          formatter: labelPosition === 'inside' ? '{d}%' : '{b} {d}%',
+        },
         itemStyle: { borderColor: '#fff', borderWidth: 2 },
         data: result.rows.map((row, rowIndex) => ({
           name: rowLabel(result, row, [firstDimension]),
@@ -268,12 +294,22 @@ const chartOptionFor = (
     const colorValues = colorDimension
       ? uniqueDimensionValues(result, colorDimension)
       : [];
-    const legendVisible = spec.style.showLegend || Boolean(colorDimension);
+    const legendVisible = style.showLegend;
+    const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'top';
 
     const rowIndexFor = (category: Scalar, color?: Scalar) => result.rows.findIndex((row) => (
       Object.is(cell(result, row, firstDimension), category)
       && (!colorDimension || Object.is(cell(result, row, colorDimension), color))
     ));
+
+    const seriesStyle = {
+      smooth: isLine && style.smooth,
+      symbolSize: isLine ? style.symbolSize : undefined,
+      lineStyle: isLine ? { width: style.lineWidth } : undefined,
+      barMaxWidth: !isLine ? style.barMaxWidth : undefined,
+      itemStyle: !isLine ? { borderRadius: style.barRadius } : undefined,
+      label: { show: style.showDataLabels, position: labelPosition },
+    };
 
     const series = colorDimension
       ? metrics.flatMap((metric) => colorValues.map((color) => ({
@@ -281,10 +317,7 @@ const chartOptionFor = (
           ? `${color.label} · ${metricDisplayName(dataset, metric)}`
           : color.label,
         type: spec.type,
-        smooth: isLine && spec.style.smooth,
-        symbolSize: 5,
-        barMaxWidth: 34,
-        label: { show: spec.style.showDataLabels, position: 'top' },
+        ...seriesStyle,
         data: categories.map((category) => {
           const rowIndex = rowIndexFor(category.value, color.value);
           if (rowIndex < 0) return null;
@@ -297,10 +330,7 @@ const chartOptionFor = (
       : metrics.map((metric) => ({
         name: metricDisplayName(dataset, metric),
         type: spec.type,
-        smooth: isLine && spec.style.smooth,
-        symbolSize: 5,
-        barMaxWidth: 34,
-        label: { show: spec.style.showDataLabels, position: 'top' },
+        ...seriesStyle,
         data: categories.map((category) => {
           const rowIndex = rowIndexFor(category.value);
           if (rowIndex < 0) return null;
@@ -312,11 +342,16 @@ const chartOptionFor = (
       }));
 
     return {
-      grid: { left: 22, right: 16, top: legendVisible ? 30 : 14, bottom: 22, containLabel: true },
+      color: colors,
+      grid: {
+        left: 22,
+        right: legendVisible && style.legendPosition === 'right' ? 112 : 16,
+        top: legendVisible && style.legendPosition === 'top' ? 34 : 14,
+        bottom: legendVisible && style.legendPosition === 'bottom' ? 40 : 22,
+        containLabel: true,
+      },
       tooltip: { trigger: 'axis' },
-      legend: legendVisible
-        ? { top: 0, right: 4, textStyle: { color: axisText, fontSize: 11 } }
-        : { show: false },
+      legend: legendOption(legendVisible, style.legendPosition, axisText),
       xAxis: {
         type: 'category',
         boundaryGap: !isLine,
@@ -325,11 +360,15 @@ const chartOptionFor = (
         data: categories.map((item) => item.label),
         axisLine: { lineStyle: { color: axisLine } },
         axisTick: { show: false },
-        axisLabel: { color: axisText, fontSize: 11 },
+        axisLabel: {
+          color: axisText,
+          fontSize: 11,
+          rotate: style.axisLabelRotation,
+        },
       },
       yAxis: {
         type: 'value',
-        splitLine: { show: spec.style.showGrid, lineStyle: { color: splitLine } },
+        splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
         axisLabel: { color: axisText, fontSize: 11 },
       },
       series,
@@ -392,15 +431,29 @@ function MetricAnalysis({
   const value = result.rows[0]
     ? numericCell(result, result.rows[0], metric.field, metric.aggregation)
     : 0;
+  const style = resolveAnalysisStyle(spec.style);
+  const alignment = {
+    left: { alignItems: 'flex-start', textAlign: 'left' as const },
+    center: { alignItems: 'center', textAlign: 'center' as const },
+    right: { alignItems: 'flex-end', textAlign: 'right' as const },
+  }[style.metricAlign];
+  const valueSize = { sm: 24, md: 28, lg: 36 }[style.metricValueSize];
   return (
-    <div className="flex h-full flex-col justify-center px-5">
-      <div className="text-[12px] font-medium text-[#667085]">{metricDisplayName(dataset, metric)}</div>
-      <div className="mt-2 text-[28px] font-semibold tracking-[-0.02em] text-[#161823]">
+    <div className="flex h-full flex-col justify-center px-5" style={{ alignItems: alignment.alignItems }}>
+      <div className="text-[12px] font-medium text-[#667085]" style={{ textAlign: alignment.textAlign }}>
+        {metricDisplayName(dataset, metric)}
+      </div>
+      <div
+        className="mt-2 font-semibold tracking-[-0.02em] text-[#161823]"
+        style={{ fontSize: valueSize, lineHeight: 1.15, textAlign: alignment.textAlign }}
+      >
         {formatMetricValue(value)}
       </div>
-      <div className="mt-2 text-[11px] text-[#98a2b3]">
-        {dataset.name} · DV{result.datasetVersionNo} · {result.elapsedMillis}ms
-      </div>
+      {style.showMetricMeta ? (
+        <div className="mt-2 text-[11px] text-[#98a2b3]" style={{ textAlign: alignment.textAlign }}>
+          {dataset.name} · DV{result.datasetVersionNo} · {result.elapsedMillis}ms
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -416,46 +469,56 @@ function TableAnalysis({
   result: DatasetQueryResult;
   onSelect?: (selection: AnalysisSelection) => void;
 }) {
+  const style = resolveAnalysisStyle(spec.style);
   const dimensions = spec.dimensions.map((field) => getAnalysisField(dataset, field)).filter(Boolean);
+  const cellPadding = style.tableDensity === 'compact'
+    ? 'px-3 py-1.5'
+    : style.tableDensity === 'relaxed'
+      ? 'px-3 py-3'
+      : 'px-3 py-2';
   return (
     <div className="h-full overflow-auto">
       <table className="w-full border-collapse text-[11px]">
         <thead className="sticky top-0 z-10 bg-[#fafafa] text-[#475467]">
           <tr>
             {dimensions.map((field) => (
-              <th key={field?.key} className="whitespace-nowrap border-b border-[#e7eaf0] px-3 py-2 text-left font-medium">
+              <th key={field?.key} className={`whitespace-nowrap border-b border-[#e7eaf0] text-left font-medium ${cellPadding}`}>
                 {field?.label}
               </th>
             ))}
             {spec.metrics.map((metric) => (
-              <th key={`${metric.field}-${metric.aggregation}`} className="whitespace-nowrap border-b border-[#e7eaf0] px-3 py-2 text-right font-medium">
+              <th key={`${metric.field}-${metric.aggregation}`} className={`whitespace-nowrap border-b border-[#e7eaf0] text-right font-medium ${cellPadding}`}>
                 {metricDisplayName(dataset, metric)}
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {result.rows.map((row, rowIndex) => (
-            <tr
-              key={rowIndex}
-              className={onSelect && spec.dimensions.length ? 'cursor-pointer hover:bg-[#f7f8fa]' : 'hover:bg-[#fafbfc]'}
-              onClick={() => {
-                const selection = selectionForRow(spec, dataset, result, rowIndex);
-                if (selection) onSelect?.(selection);
-              }}
-            >
-              {spec.dimensions.map((field) => (
-                <td key={field} className="border-b border-[#f0f2f5] px-3 py-2 text-[#344054]">
-                  {String(cell(result, row, field) ?? '')}
-                </td>
-              ))}
-              {spec.metrics.map((metric) => (
-                <td key={`${metric.field}-${metric.aggregation}`} className="border-b border-[#f0f2f5] px-3 py-2 text-right tabular-nums text-[#344054]">
-                  {formatMetricValue(numericCell(result, row, metric.field, metric.aggregation))}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {result.rows.map((row, rowIndex) => {
+            const striped = style.stripedRows && rowIndex % 2 === 1;
+            const hover = onSelect && spec.dimensions.length ? 'cursor-pointer hover:bg-[#f7f8fa]' : 'hover:bg-[#fafbfc]';
+            return (
+              <tr
+                key={rowIndex}
+                className={`${striped ? 'bg-[#fafbfc]' : ''} ${hover}`}
+                onClick={() => {
+                  const selection = selectionForRow(spec, dataset, result, rowIndex);
+                  if (selection) onSelect?.(selection);
+                }}
+              >
+                {spec.dimensions.map((field) => (
+                  <td key={field} className={`border-b border-[#f0f2f5] text-[#344054] ${cellPadding}`}>
+                    {String(cell(result, row, field) ?? '')}
+                  </td>
+                ))}
+                {spec.metrics.map((metric) => (
+                  <td key={`${metric.field}-${metric.aggregation}`} className={`border-b border-[#f0f2f5] text-right tabular-nums text-[#344054] ${cellPadding}`}>
+                    {formatMetricValue(numericCell(result, row, metric.field, metric.aggregation))}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       {result.truncated ? (

--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -433,9 +433,9 @@ function MetricAnalysis({
     : 0;
   const style = resolveAnalysisStyle(spec.style);
   const alignment = {
-    left: { alignItems: 'flex-start', textAlign: 'left' as const },
-    center: { alignItems: 'center', textAlign: 'center' as const },
-    right: { alignItems: 'flex-end', textAlign: 'right' as const },
+    left: { alignItems: 'flex-start' as const, textAlign: 'left' as const },
+    center: { alignItems: 'center' as const, textAlign: 'center' as const },
+    right: { alignItems: 'flex-end' as const, textAlign: 'right' as const },
   }[style.metricAlign];
   const valueSize = { sm: 24, md: 28, lg: 36 }[style.metricValueSize];
   return (

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -78,11 +78,38 @@ export interface AnalysisSort {
   direction: SortDirection;
 }
 
+export type AnalysisColorPalette = 'yak' | 'ocean' | 'sunset' | 'violet' | 'mono';
+export type AnalysisLegendPosition = 'top' | 'right' | 'bottom';
+export type AnalysisDataLabelPosition = 'top' | 'inside' | 'outside';
+export type AnalysisMetricAlign = 'left' | 'center' | 'right';
+export type AnalysisMetricValueSize = 'sm' | 'md' | 'lg';
+export type AnalysisTableDensity = 'compact' | 'comfortable' | 'relaxed';
+
+/**
+ * Versioned visual appearance grammar. The original four booleans stay required for
+ * backwards source compatibility; Phase 7 properties are optional so old persisted
+ * Analysis / Dashboard snapshots continue to deserialize without migration.
+ */
 export interface AnalysisVisualConfig {
+  version?: 1;
   showLegend: boolean;
   showDataLabels: boolean;
   smooth: boolean;
   showGrid: boolean;
+  palette?: AnalysisColorPalette;
+  legendPosition?: AnalysisLegendPosition;
+  dataLabelPosition?: AnalysisDataLabelPosition;
+  axisLabelRotation?: 0 | 30 | 45;
+  lineWidth?: number;
+  symbolSize?: number;
+  barMaxWidth?: number;
+  barRadius?: number;
+  pieInnerRadius?: number;
+  metricAlign?: AnalysisMetricAlign;
+  metricValueSize?: AnalysisMetricValueSize;
+  showMetricMeta?: boolean;
+  tableDensity?: AnalysisTableDensity;
+  stripedRows?: boolean;
 }
 
 /** Query + visualization definition that can be reused outside a Dashboard. */

--- a/yak-ops-ui/src/components/analysis/style.ts
+++ b/yak-ops-ui/src/components/analysis/style.ts
@@ -73,7 +73,7 @@ export const resolveAnalysisStyle = (
   symbolSize: clamp(style?.symbolSize, 0, 14, DEFAULT_ANALYSIS_VISUAL_CONFIG.symbolSize),
   barMaxWidth: clamp(style?.barMaxWidth, 12, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.barMaxWidth),
   barRadius: clamp(style?.barRadius, 0, 16, DEFAULT_ANALYSIS_VISUAL_CONFIG.barRadius),
-  pieInnerRadius: clamp(style?.pieInnerRadius, 0, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.pieInnerRadius),
+  pieInnerRadius: clamp(style?.pieInnerRadius, 0, 64, DEFAULT_ANALYSIS_VISUAL_CONFIG.pieInnerRadius),
   metricAlign: style?.metricAlign ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.metricAlign,
   metricValueSize: style?.metricValueSize ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.metricValueSize,
   showMetricMeta: style?.showMetricMeta ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.showMetricMeta,

--- a/yak-ops-ui/src/components/analysis/style.ts
+++ b/yak-ops-ui/src/components/analysis/style.ts
@@ -30,7 +30,7 @@ export const ANALYSIS_PALETTES: Record<
   },
 };
 
-export const DEFAULT_ANALYSIS_VISUAL_CONFIG: AnalysisVisualConfig = {
+export const DEFAULT_ANALYSIS_VISUAL_CONFIG: Required<AnalysisVisualConfig> = {
   version: 1,
   showLegend: false,
   showDataLabels: false,
@@ -65,11 +65,20 @@ export const resolveAnalysisStyle = (
   ...DEFAULT_ANALYSIS_VISUAL_CONFIG,
   ...style,
   version: 1,
-  lineWidth: clamp(style?.lineWidth, 1, 6, DEFAULT_ANALYSIS_VISUAL_CONFIG.lineWidth!),
-  symbolSize: clamp(style?.symbolSize, 0, 14, DEFAULT_ANALYSIS_VISUAL_CONFIG.symbolSize!),
-  barMaxWidth: clamp(style?.barMaxWidth, 12, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.barMaxWidth!),
-  barRadius: clamp(style?.barRadius, 0, 16, DEFAULT_ANALYSIS_VISUAL_CONFIG.barRadius!),
-  pieInnerRadius: clamp(style?.pieInnerRadius, 0, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.pieInnerRadius!),
+  palette: style?.palette ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.palette,
+  legendPosition: style?.legendPosition ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.legendPosition,
+  dataLabelPosition: style?.dataLabelPosition ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.dataLabelPosition,
+  axisLabelRotation: style?.axisLabelRotation ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.axisLabelRotation,
+  lineWidth: clamp(style?.lineWidth, 1, 6, DEFAULT_ANALYSIS_VISUAL_CONFIG.lineWidth),
+  symbolSize: clamp(style?.symbolSize, 0, 14, DEFAULT_ANALYSIS_VISUAL_CONFIG.symbolSize),
+  barMaxWidth: clamp(style?.barMaxWidth, 12, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.barMaxWidth),
+  barRadius: clamp(style?.barRadius, 0, 16, DEFAULT_ANALYSIS_VISUAL_CONFIG.barRadius),
+  pieInnerRadius: clamp(style?.pieInnerRadius, 0, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.pieInnerRadius),
+  metricAlign: style?.metricAlign ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.metricAlign,
+  metricValueSize: style?.metricValueSize ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.metricValueSize,
+  showMetricMeta: style?.showMetricMeta ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.showMetricMeta,
+  tableDensity: style?.tableDensity ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.tableDensity,
+  stripedRows: style?.stripedRows ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.stripedRows,
 });
 
 export const createAnalysisVisualConfig = (type: ChartType): AnalysisVisualConfig => ({

--- a/yak-ops-ui/src/components/analysis/style.ts
+++ b/yak-ops-ui/src/components/analysis/style.ts
@@ -1,0 +1,85 @@
+import type {
+  AnalysisColorPalette,
+  AnalysisVisualConfig,
+  ChartType,
+} from './model';
+
+export const ANALYSIS_PALETTES: Record<
+  AnalysisColorPalette,
+  { label: string; colors: string[] }
+> = {
+  yak: {
+    label: 'Yak',
+    colors: ['#fe2c55', '#5b6df8', '#8b5cf6', '#f59e0b', '#0ea5e9', '#64748b'],
+  },
+  ocean: {
+    label: '海洋',
+    colors: ['#2563eb', '#0ea5e9', '#06b6d4', '#14b8a6', '#6366f1', '#3b82f6'],
+  },
+  sunset: {
+    label: '日落',
+    colors: ['#f97316', '#ef4444', '#f59e0b', '#ec4899', '#8b5cf6', '#fb7185'],
+  },
+  violet: {
+    label: '紫罗兰',
+    colors: ['#7c3aed', '#a855f7', '#c026d3', '#6366f1', '#8b5cf6', '#d946ef'],
+  },
+  mono: {
+    label: '灰阶',
+    colors: ['#111827', '#374151', '#6b7280', '#9ca3af', '#cbd5e1', '#e2e8f0'],
+  },
+};
+
+export const DEFAULT_ANALYSIS_VISUAL_CONFIG: AnalysisVisualConfig = {
+  version: 1,
+  showLegend: false,
+  showDataLabels: false,
+  smooth: false,
+  showGrid: true,
+  palette: 'yak',
+  legendPosition: 'top',
+  dataLabelPosition: 'top',
+  axisLabelRotation: 0,
+  lineWidth: 2,
+  symbolSize: 5,
+  barMaxWidth: 34,
+  barRadius: 3,
+  pieInnerRadius: 42,
+  metricAlign: 'left',
+  metricValueSize: 'md',
+  showMetricMeta: true,
+  tableDensity: 'comfortable',
+  stripedRows: false,
+};
+
+const clamp = (value: number | undefined, min: number, max: number, fallback: number) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.min(max, Math.max(min, numeric));
+};
+
+/** Resolve legacy / partial style snapshots to one stable renderer contract. */
+export const resolveAnalysisStyle = (
+  style?: AnalysisVisualConfig,
+): Required<AnalysisVisualConfig> => ({
+  ...DEFAULT_ANALYSIS_VISUAL_CONFIG,
+  ...style,
+  version: 1,
+  lineWidth: clamp(style?.lineWidth, 1, 6, DEFAULT_ANALYSIS_VISUAL_CONFIG.lineWidth!),
+  symbolSize: clamp(style?.symbolSize, 0, 14, DEFAULT_ANALYSIS_VISUAL_CONFIG.symbolSize!),
+  barMaxWidth: clamp(style?.barMaxWidth, 12, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.barMaxWidth!),
+  barRadius: clamp(style?.barRadius, 0, 16, DEFAULT_ANALYSIS_VISUAL_CONFIG.barRadius!),
+  pieInnerRadius: clamp(style?.pieInnerRadius, 0, 72, DEFAULT_ANALYSIS_VISUAL_CONFIG.pieInnerRadius!),
+});
+
+export const createAnalysisVisualConfig = (type: ChartType): AnalysisVisualConfig => ({
+  ...DEFAULT_ANALYSIS_VISUAL_CONFIG,
+  showLegend: type === 'pie',
+  smooth: type === 'line',
+  showGrid: type === 'bar' || type === 'line',
+});
+
+export const paletteColors = (style?: AnalysisVisualConfig) => {
+  const resolved = resolveAnalysisStyle(style);
+  return ANALYSIS_PALETTES[resolved.palette].colors;
+};

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -4,11 +4,12 @@ import {
   updateEncodingMetricAggregation,
 } from '@/components/analysis/encoding';
 import type { AnalysisEncoding, AnalysisSpec } from '@/components/analysis/model';
-import { Button, Collapse, Input, Select, Switch } from 'antd';
-import { ChevronDown, MousePointerClick, SlidersHorizontal, X } from 'lucide-react';
+import { Button, Collapse, Input, Select } from 'antd';
+import { ChevronDown, MousePointerClick, Palette, SlidersHorizontal, X } from 'lucide-react';
 import { ConfigData } from './config-data';
 import { MetricAggregations } from './config-metrics';
 import { QueryControls } from './config-query';
+import { ChartStyleConfig } from './config-style';
 import { CHART_META, findDataset } from './helpers';
 import { DashboardInteractionEditor } from './interaction-editor';
 import type {
@@ -126,12 +127,10 @@ export function ChartSheetConfigPanel({
       dimensions: next.dimensions,
       metrics: next.metrics,
       sort: undefined,
-      style: {
-        ...spec.style,
-        showLegend: type === 'pie' ? true : spec.style.showLegend,
-        smooth: type === 'line' ? spec.style.smooth : false,
-        showGrid: type === 'line' || type === 'bar' ? spec.style.showGrid : false,
-      },
+      // Keep style values non-destructive across chart type switches. Each renderer only
+      // consumes properties relevant to its type, so returning to a type restores the
+      // user's previous visual choices instead of resetting them.
+      style: { ...spec.style, version: 1 },
       limit: type === 'table' ? 200 : 500,
     });
   };
@@ -152,7 +151,7 @@ export function ChartSheetConfigPanel({
   };
 
   const updateStyle = (patch: Partial<AnalysisSpec['style']>) =>
-    updateInlineAnalysis({ style: { ...spec.style, ...patch } });
+    updateInlineAnalysis({ style: { ...spec.style, ...patch, version: 1 } });
 
   return (
     <section className="chart-sheet-config-panel flex w-[360px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
@@ -239,6 +238,7 @@ export function ChartSheetConfigPanel({
           ghost
           className="chart-editor-more mt-4 border-t border-[#eceef1]"
           expandIconPosition="end"
+          defaultActiveKey={['style']}
           expandIcon={({ isActive }) => (
             <ChevronDown
               size={13}
@@ -246,6 +246,18 @@ export function ChartSheetConfigPanel({
             />
           )}
           items={[
+            {
+              key: 'style',
+              label: (
+                <span className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+                  <Palette size={12} />
+                  样式设置
+                </span>
+              ),
+              children: (
+                <ChartStyleConfig spec={spec} onChange={updateStyle} />
+              ),
+            },
             {
               key: 'interaction',
               label: (
@@ -276,79 +288,50 @@ export function ChartSheetConfigPanel({
               ),
             },
             {
-              key: 'advanced',
+              key: 'query',
               label: (
                 <span className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
                   <SlidersHorizontal size={12} />
-                  样式与查询
+                  查询设置
                 </span>
               ),
               children: (
                 <div className="pb-2">
-                  <div className="space-y-3 text-[11px] text-[#475467]">
-                    {spec.type !== 'metric' && spec.type !== 'table' ? (
-                      <label className="flex items-center justify-between">
-                        <span>显示图例</span>
-                        <Switch size="small" checked={spec.style.showLegend} onChange={(showLegend) => updateStyle({ showLegend })} />
-                      </label>
-                    ) : null}
-                    {spec.type !== 'metric' && spec.type !== 'table' ? (
-                      <label className="flex items-center justify-between">
-                        <span>显示数据标签</span>
-                        <Switch size="small" checked={spec.style.showDataLabels} onChange={(showDataLabels) => updateStyle({ showDataLabels })} />
-                      </label>
-                    ) : null}
-                    {spec.type === 'line' ? (
-                      <label className="flex items-center justify-between">
-                        <span>平滑曲线</span>
-                        <Switch size="small" checked={spec.style.smooth} onChange={(smooth) => updateStyle({ smooth })} />
-                      </label>
-                    ) : null}
-                    {spec.type === 'line' || spec.type === 'bar' ? (
-                      <label className="flex items-center justify-between">
-                        <span>显示网格线</span>
-                        <Switch size="small" checked={spec.style.showGrid} onChange={(showGrid) => updateStyle({ showGrid })} />
-                      </label>
-                    ) : null}
-                  </div>
-
-                  <div className="mt-4 border-t border-[#eceef1] pt-4">
-                    <QueryControls
-                      sortOptions={sortOptions}
-                      filterOptions={filterOptions}
-                      sortField={spec.sort?.field}
-                      sortDirection={spec.sort?.direction ?? 'asc'}
-                      filterField={filter?.field}
-                      filterOperator={filter?.operator ?? 'eq'}
-                      filterValue={filter?.value ?? ''}
-                      onSortField={(field?: string) =>
-                        updateInlineAnalysis({
-                          sort: field
-                            ? { field, direction: spec.sort?.direction ?? 'asc' }
-                            : undefined,
-                        })}
-                      onSortDirection={(direction: SortDirection) =>
-                        spec.sort
-                        && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
-                      onFilterField={(field?: string) =>
-                        updateInlineAnalysis({
-                          filters: field
-                            ? [{
-                              id: filter?.id ?? 'filter-main',
-                              field,
-                              operator: filter?.operator ?? 'eq',
-                              value: filter?.value ?? '',
-                            }]
-                            : [],
-                        })}
-                      onFilterOperator={(operator: FilterOperator) =>
-                        filter
-                        && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
-                      onFilterValue={(value) =>
-                        filter
-                        && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
-                    />
-                  </div>
+                  <QueryControls
+                    sortOptions={sortOptions}
+                    filterOptions={filterOptions}
+                    sortField={spec.sort?.field}
+                    sortDirection={spec.sort?.direction ?? 'asc'}
+                    filterField={filter?.field}
+                    filterOperator={filter?.operator ?? 'eq'}
+                    filterValue={filter?.value ?? ''}
+                    onSortField={(field?: string) =>
+                      updateInlineAnalysis({
+                        sort: field
+                          ? { field, direction: spec.sort?.direction ?? 'asc' }
+                          : undefined,
+                      })}
+                    onSortDirection={(direction: SortDirection) =>
+                      spec.sort
+                      && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
+                    onFilterField={(field?: string) =>
+                      updateInlineAnalysis({
+                        filters: field
+                          ? [{
+                            id: filter?.id ?? 'filter-main',
+                            field,
+                            operator: filter?.operator ?? 'eq',
+                            value: filter?.value ?? '',
+                          }]
+                          : [],
+                      })}
+                    onFilterOperator={(operator: FilterOperator) =>
+                      filter
+                      && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
+                    onFilterValue={(value) =>
+                      filter
+                      && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
+                  />
                 </div>
               ),
             },
@@ -378,7 +361,7 @@ function ConfigPanelHeader({ onDone }: { onDone: () => void }) {
     <div className="flex h-14 shrink-0 items-center justify-between border-b border-[#eceef1] px-4">
       <div>
         <div className="text-[13px] font-semibold text-[#344054]">图表配置</div>
-        <div className="mt-0.5 text-[9px] text-[#98a2b3]">字段编码、展示与交互配置</div>
+        <div className="mt-0.5 text-[9px] text-[#98a2b3]">字段编码、样式与交互配置</div>
       </div>
       <button
         type="button"

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -142,11 +142,19 @@ export function ChartSheetConfigPanel({
       && !next.metrics.some((metric) => metric.field === spec.sort?.field)
       ? undefined
       : spec.sort;
+    const hadColor = Boolean(spec.encoding?.color?.length);
+    const hasColor = Boolean(next.encoding.color.length);
+    const shouldRevealLegend = !hadColor
+      && hasColor
+      && (spec.type === 'bar' || spec.type === 'line');
     updateInlineAnalysis({
       encoding: next.encoding,
       dimensions: next.dimensions,
       metrics: next.metrics,
       sort: nextSort,
+      ...(shouldRevealLegend
+        ? { style: { ...spec.style, showLegend: true, version: 1 as const } }
+        : {}),
     });
   };
 

--- a/yak-ops-ui/src/pages/dashboard/config-style.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-style.tsx
@@ -22,6 +22,9 @@ export function ChartStyleConfig({
   const supportsLegend = spec.type === 'bar' || spec.type === 'line' || spec.type === 'pie';
   const supportsLabels = supportsLegend;
   const supportsPalette = supportsLegend;
+  const activeLabelPosition: AnalysisDataLabelPosition = spec.type === 'pie'
+    ? style.dataLabelPosition === 'inside' ? 'inside' : 'outside'
+    : style.dataLabelPosition === 'inside' ? 'inside' : 'top';
 
   return (
     <div className="space-y-4 pb-1 text-[11px] text-[#475467]">
@@ -96,7 +99,7 @@ export function ChartStyleConfig({
                     <Select
                       size="small"
                       className="w-[116px]"
-                      value={style.dataLabelPosition}
+                      value={activeLabelPosition}
                       options={spec.type === 'pie'
                         ? [
                           { label: '外侧', value: 'outside' },

--- a/yak-ops-ui/src/pages/dashboard/config-style.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-style.tsx
@@ -204,7 +204,7 @@ export function ChartStyleConfig({
             </div>
             <Slider
               min={0}
-              max={72}
+              max={64}
               step={2}
               value={style.pieInnerRadius}
               onChange={(pieInnerRadius) => onChange({ pieInnerRadius })}

--- a/yak-ops-ui/src/pages/dashboard/config-style.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-style.tsx
@@ -1,0 +1,344 @@
+import type {
+  AnalysisDataLabelPosition,
+  AnalysisLegendPosition,
+  AnalysisMetricAlign,
+  AnalysisMetricValueSize,
+  AnalysisSpec,
+  AnalysisTableDensity,
+  AnalysisVisualConfig,
+} from '@/components/analysis/model';
+import { ANALYSIS_PALETTES, resolveAnalysisStyle } from '@/components/analysis/style';
+import { InputNumber, Select, Slider, Switch } from 'antd';
+
+export function ChartStyleConfig({
+  spec,
+  onChange,
+}: {
+  spec: AnalysisSpec;
+  onChange: (patch: Partial<AnalysisVisualConfig>) => void;
+}) {
+  const style = resolveAnalysisStyle(spec.style);
+  const hasCartesianAxes = spec.type === 'bar' || spec.type === 'line';
+  const supportsLegend = spec.type === 'bar' || spec.type === 'line' || spec.type === 'pie';
+  const supportsLabels = supportsLegend;
+  const supportsPalette = supportsLegend;
+
+  return (
+    <div className="space-y-4 pb-1 text-[11px] text-[#475467]">
+      {supportsPalette ? (
+        <StyleGroup title="配色">
+          <div className="grid grid-cols-5 gap-1.5">
+            {(Object.entries(ANALYSIS_PALETTES) as Array<
+              [keyof typeof ANALYSIS_PALETTES, (typeof ANALYSIS_PALETTES)[keyof typeof ANALYSIS_PALETTES]]
+            >).map(([key, palette]) => {
+              const active = style.palette === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  title={palette.label}
+                  onClick={() => onChange({ palette: key })}
+                  className={[
+                    'rounded-[7px] border px-1.5 py-2 transition-[background-color,border-color]',
+                    active
+                      ? 'border-[#cbd1da] bg-[#f5f6f7]'
+                      : 'border-[#e8eaee] bg-white hover:border-[#d9dde4] hover:bg-[#fafbfc]',
+                  ].join(' ')}
+                >
+                  <div className="flex h-3 overflow-hidden rounded-[3px]">
+                    {palette.colors.slice(0, 4).map((color) => (
+                      <span key={color} className="flex-1" style={{ backgroundColor: color }} />
+                    ))}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </StyleGroup>
+      ) : null}
+
+      {supportsLegend || supportsLabels ? (
+        <StyleGroup title="展示">
+          <div className="space-y-3">
+            {supportsLegend ? (
+              <>
+                <ToggleRow
+                  label="显示图例"
+                  checked={style.showLegend}
+                  onChange={(showLegend) => onChange({ showLegend })}
+                />
+                {style.showLegend ? (
+                  <ControlRow label="图例位置">
+                    <Select
+                      size="small"
+                      className="w-[116px]"
+                      value={style.legendPosition}
+                      options={[
+                        { label: '顶部', value: 'top' },
+                        { label: '右侧', value: 'right' },
+                        { label: '底部', value: 'bottom' },
+                      ]}
+                      onChange={(legendPosition: AnalysisLegendPosition) => onChange({ legendPosition })}
+                    />
+                  </ControlRow>
+                ) : null}
+              </>
+            ) : null}
+            {supportsLabels ? (
+              <>
+                <ToggleRow
+                  label="显示数据标签"
+                  checked={style.showDataLabels}
+                  onChange={(showDataLabels) => onChange({ showDataLabels })}
+                />
+                {style.showDataLabels ? (
+                  <ControlRow label="标签位置">
+                    <Select
+                      size="small"
+                      className="w-[116px]"
+                      value={style.dataLabelPosition}
+                      options={spec.type === 'pie'
+                        ? [
+                          { label: '外侧', value: 'outside' },
+                          { label: '内部', value: 'inside' },
+                        ]
+                        : [
+                          { label: '顶部', value: 'top' },
+                          { label: '内部', value: 'inside' },
+                        ]}
+                      onChange={(dataLabelPosition: AnalysisDataLabelPosition) => onChange({ dataLabelPosition })}
+                    />
+                  </ControlRow>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        </StyleGroup>
+      ) : null}
+
+      {hasCartesianAxes ? (
+        <StyleGroup title="坐标轴">
+          <div className="space-y-3">
+            <ToggleRow
+              label="显示网格线"
+              checked={style.showGrid}
+              onChange={(showGrid) => onChange({ showGrid })}
+            />
+            <ControlRow label="标签旋转">
+              <Select
+                size="small"
+                className="w-[116px]"
+                value={style.axisLabelRotation}
+                options={[
+                  { label: '不旋转', value: 0 },
+                  { label: '30°', value: 30 },
+                  { label: '45°', value: 45 },
+                ]}
+                onChange={(axisLabelRotation: 0 | 30 | 45) => onChange({ axisLabelRotation })}
+              />
+            </ControlRow>
+          </div>
+        </StyleGroup>
+      ) : null}
+
+      {spec.type === 'bar' ? (
+        <StyleGroup title="柱形">
+          <div className="space-y-3">
+            <NumberRow
+              label="最大宽度"
+              value={style.barMaxWidth}
+              min={12}
+              max={72}
+              suffix="px"
+              onChange={(barMaxWidth) => onChange({ barMaxWidth })}
+            />
+            <NumberRow
+              label="圆角"
+              value={style.barRadius}
+              min={0}
+              max={16}
+              suffix="px"
+              onChange={(barRadius) => onChange({ barRadius })}
+            />
+          </div>
+        </StyleGroup>
+      ) : null}
+
+      {spec.type === 'line' ? (
+        <StyleGroup title="折线">
+          <div className="space-y-3">
+            <ToggleRow
+              label="平滑曲线"
+              checked={style.smooth}
+              onChange={(smooth) => onChange({ smooth })}
+            />
+            <NumberRow
+              label="线宽"
+              value={style.lineWidth}
+              min={1}
+              max={6}
+              suffix="px"
+              onChange={(lineWidth) => onChange({ lineWidth })}
+            />
+            <NumberRow
+              label="数据点"
+              value={style.symbolSize}
+              min={0}
+              max={14}
+              suffix="px"
+              onChange={(symbolSize) => onChange({ symbolSize })}
+            />
+          </div>
+        </StyleGroup>
+      ) : null}
+
+      {spec.type === 'pie' ? (
+        <StyleGroup title="饼图">
+          <div>
+            <div className="mb-1.5 flex items-center justify-between text-[10px] text-[#667085]">
+              <span>内径</span>
+              <span className="tabular-nums text-[#98a2b3]">{style.pieInnerRadius}%</span>
+            </div>
+            <Slider
+              min={0}
+              max={72}
+              step={2}
+              value={style.pieInnerRadius}
+              onChange={(pieInnerRadius) => onChange({ pieInnerRadius })}
+            />
+          </div>
+        </StyleGroup>
+      ) : null}
+
+      {spec.type === 'metric' ? (
+        <StyleGroup title="指标卡">
+          <div className="space-y-3">
+            <ControlRow label="对齐方式">
+              <Select
+                size="small"
+                className="w-[116px]"
+                value={style.metricAlign}
+                options={[
+                  { label: '左对齐', value: 'left' },
+                  { label: '居中', value: 'center' },
+                  { label: '右对齐', value: 'right' },
+                ]}
+                onChange={(metricAlign: AnalysisMetricAlign) => onChange({ metricAlign })}
+              />
+            </ControlRow>
+            <ControlRow label="数值字号">
+              <Select
+                size="small"
+                className="w-[116px]"
+                value={style.metricValueSize}
+                options={[
+                  { label: '紧凑', value: 'sm' },
+                  { label: '标准', value: 'md' },
+                  { label: '突出', value: 'lg' },
+                ]}
+                onChange={(metricValueSize: AnalysisMetricValueSize) => onChange({ metricValueSize })}
+              />
+            </ControlRow>
+            <ToggleRow
+              label="显示数据来源"
+              checked={style.showMetricMeta}
+              onChange={(showMetricMeta) => onChange({ showMetricMeta })}
+            />
+          </div>
+        </StyleGroup>
+      ) : null}
+
+      {spec.type === 'table' ? (
+        <StyleGroup title="表格">
+          <div className="space-y-3">
+            <ControlRow label="行高密度">
+              <Select
+                size="small"
+                className="w-[116px]"
+                value={style.tableDensity}
+                options={[
+                  { label: '紧凑', value: 'compact' },
+                  { label: '标准', value: 'comfortable' },
+                  { label: '宽松', value: 'relaxed' },
+                ]}
+                onChange={(tableDensity: AnalysisTableDensity) => onChange({ tableDensity })}
+              />
+            </ControlRow>
+            <ToggleRow
+              label="斑马纹"
+              checked={style.stripedRows}
+              onChange={(stripedRows) => onChange({ stripedRows })}
+            />
+          </div>
+        </StyleGroup>
+      ) : null}
+    </div>
+  );
+}
+
+function StyleGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="border-b border-[#f0f1f3] pb-4 last:border-b-0 last:pb-0">
+      <div className="mb-2.5 text-[10px] font-semibold text-[#667085]">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function ToggleRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3">
+      <span>{label}</span>
+      <Switch size="small" checked={checked} onChange={onChange} />
+    </label>
+  );
+}
+
+function ControlRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function NumberRow({
+  label,
+  value,
+  min,
+  max,
+  suffix,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  suffix: string;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <ControlRow label={label}>
+      <InputNumber
+        size="small"
+        className="w-[116px]"
+        min={min}
+        max={max}
+        value={value}
+        addonAfter={suffix}
+        onChange={(next) => {
+          if (typeof next === 'number') onChange(next);
+        }}
+      />
+    </ControlRow>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/helpers.tsx
+++ b/yak-ops-ui/src/pages/dashboard/helpers.tsx
@@ -4,6 +4,7 @@ import {
   rebindAnalysisEncoding,
 } from '@/components/analysis/encoding';
 import type { AnalysisSpec } from '@/components/analysis/model';
+import { createAnalysisVisualConfig } from '@/components/analysis/style';
 import { BarChart3, ChartLine, ChartPie, Sigma, Table2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { DEFAULT_DASHBOARD } from './defaults';
@@ -62,7 +63,7 @@ const legacyWidgetToCurrent = (value: any): DashboardWidget => {
     metrics: Array.isArray(value.metrics) ? value.metrics : [],
     filters: Array.isArray(value.filters) ? value.filters : [],
     sort: value.sort,
-    style: value.style ?? { showLegend: false, showDataLabels: false, smooth: false, showGrid: false },
+    style: value.style ?? createAnalysisVisualConfig(value.type),
     limit: value.limit,
     timeoutSeconds: value.timeoutSeconds,
   };
@@ -125,12 +126,7 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
     dimensions: bindings.dimensions,
     metrics: bindings.metrics,
     filters: [],
-    style: {
-      showLegend: type === 'pie',
-      showDataLabels: false,
-      smooth: type === 'line',
-      showGrid: type === 'bar' || type === 'line',
-    },
+    style: createAnalysisVisualConfig(type),
     limit: type === 'table' ? 200 : 500,
     timeoutSeconds: 30,
   };


### PR DESCRIPTION
## What changed
- promote chart appearance from four ad-hoc booleans into a versioned `AnalysisVisualConfig` style system while keeping old snapshots readable
- add a centralized style resolver so missing / legacy style fields receive stable defaults at render time without a migration
- add five built-in palettes (`Yak`, `海洋`, `日落`, `紫罗兰`, `灰阶`) and apply them through the shared Analysis/ECharts renderer
- move style configuration into its own first-class `样式设置` section in the Chart Sheet instead of mixing it with query controls
- keep style state non-destructive across chart-type switches; irrelevant properties stay dormant and are restored when the user returns to that chart type
- split the previous `样式与查询` accordion into `样式设置` and `查询设置`

## Style controls by chart type

### 柱状图
- palette
- legend show/hide + top/right/bottom placement
- data labels + top/inside placement
- grid lines
- X-axis label rotation (0 / 30 / 45 degrees)
- max bar width
- bar corner radius

### 折线图
- palette
- legend show/hide + placement
- data labels + placement
- grid lines
- X-axis label rotation
- smooth curve
- line width
- point size

### 饼图
- palette
- legend show/hide + placement
- data labels + outside/inside placement
- configurable donut inner radius

### 指标卡
- left / center / right alignment
- compact / standard / prominent value size
- show/hide Dataset/version/runtime metadata

### 明细表
- compact / standard / relaxed row density
- optional striped rows

## Renderer behavior
- ECharts receives the selected palette as its top-level color sequence
- legend placement updates both legend layout and chart grid/center geometry so it does not simply overlay the chart
- bar radius/width, line width/point size/smoothing, label position and axis rotation are applied by the shared Analysis renderer
- metric and table styles are rendered by their existing React renderers
- when a color encoding is added to bar/line for the first time, the legend is revealed automatically for discoverability; the user can still turn it off afterwards

## Compatibility
- existing `showLegend` / `showDataLabels` / `smooth` / `showGrid` fields remain supported
- new style fields are optional on the TypeScript model so existing persisted Analysis/Dashboard snapshots remain readable
- legacy/partial styles are resolved lazily by `resolveAnalysisStyle`
- no Dashboard document version change
- no database schema migration
- no backend DTO/domain change
- no Dataset query contract change
- no new npm dependency

## Validation
- [x] Phase 6 PR #481 is merged into `main`; this branch starts from that merge commit
- [x] branch compare is 0 commits behind `main`
- [x] reviewed final compare: 6 frontend files changed; no backend or DB migration files changed
- [x] style renderer keeps legacy fields compatible and clamps numeric style values before rendering
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] manual browser regression: palettes, legend positions, label positions, chart-type round trips, metric alignment, table density

Executable frontend validation is intentionally left unchecked in the current environment rather than being claimed as completed. GitHub checks should be treated as the executable integration signal if/when workflows are configured.