### PR TITLE
feat(bi): add analysis calculations and top n (phase 8)

### DIFF
--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -47,7 +47,9 @@ const metricAnalysisDisplayName = (
   metric: MetricBinding,
 ) => {
   const base = metricDisplayName(dataset, metric);
-  const calculation = metricComputationFor(spec, metric.field).quickCalculation;
+  const calculation = spec.type === 'metric'
+    ? 'none'
+    : metricComputationFor(spec, metric.field).quickCalculation;
   return calculation === 'none' ? base : `${base} · ${quickCalculationLabel(calculation)}`;
 };
 

--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -1,6 +1,13 @@
 import { Empty, Spin } from 'antd';
 import * as echarts from 'echarts';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  analysisMetricValues,
+  formatAnalysisMetricValue,
+  metricComputationFor,
+  quickCalculationLabel,
+  resolveAnalysisTopN,
+} from './analysis';
 import { encodingMeetsChartRequirements, resolveAnalysisEncoding } from './encoding';
 import { queryAnalysisDataset } from './dataset-service';
 import type {
@@ -11,6 +18,7 @@ import type {
   DatasetField,
   DatasetQueryPayload,
   DatasetQueryResult,
+  MetricBinding,
   PublishedDataset,
   Scalar,
 } from './model';
@@ -33,9 +41,14 @@ export const metricDisplayName = (
   metric: AnalysisSpec['metrics'][number],
 ) => `${getAnalysisField(dataset, metric.field)?.label ?? metric.field} · ${AGGREGATION_LABELS[metric.aggregation]}`;
 
-const formatMetricValue = (value: number) => {
-  const maximumFractionDigits = Number.isInteger(value) ? 0 : 2;
-  return new Intl.NumberFormat('zh-CN', { maximumFractionDigits }).format(value);
+const metricAnalysisDisplayName = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  metric: MetricBinding,
+) => {
+  const base = metricDisplayName(dataset, metric);
+  const calculation = metricComputationFor(spec, metric.field).quickCalculation;
+  return calculation === 'none' ? base : `${base} · ${quickCalculationLabel(calculation)}`;
 };
 
 const filterValue = (field: DatasetField | undefined, value: string): Scalar => {
@@ -77,25 +90,37 @@ export const buildDatasetQueryPayload = (
       return { fieldId: filter.field, operator: operators[filter.operator], value };
     });
 
+  const sorts: DatasetQueryPayload['sorts'] = [];
+  const topN = resolveAnalysisTopN(spec);
+  if (topN) {
+    sorts.push({
+      fieldId: topN.metric.field,
+      aggregation: topN.metric.aggregation,
+      direction: topN.direction === 'top' ? 'DESC' : 'ASC',
+    });
+  }
+
   const sort = spec.sort;
-  let sorts: DatasetQueryPayload['sorts'] = [];
   if (sort?.field) {
     const metric = spec.metrics.find((item) => item.field === sort.field);
-    if (metric || spec.dimensions.includes(sort.field)) {
-      sorts = [{
+    const valid = Boolean(metric || spec.dimensions.includes(sort.field));
+    const duplicatedByTopN = Boolean(topN && metric?.field === topN.metric.field);
+    if (valid && !duplicatedByTopN) {
+      sorts.push({
         fieldId: sort.field,
         aggregation: metric?.aggregation,
         direction: sort.direction === 'desc' ? 'DESC' : 'ASC',
-      }];
+      });
     }
   }
 
+  const baseLimit = spec.limit ?? (spec.type === 'table' ? 200 : 500);
   return {
     dimensions: spec.type === 'metric' ? [] : spec.dimensions,
     metrics: spec.metrics.map((metric) => ({ fieldId: metric.field, aggregation: metric.aggregation })),
     filters,
     sorts,
-    limit: spec.limit ?? (spec.type === 'table' ? 200 : 500),
+    limit: topN ? Math.min(baseLimit, topN.count) : baseLimit,
     timeoutSeconds: spec.timeoutSeconds ?? 30,
   };
 };
@@ -173,16 +198,6 @@ const cell = (
   return index >= 0 ? row[index] : null;
 };
 
-const numericCell = (
-  result: DatasetQueryResult,
-  row: Scalar[],
-  fieldId: string,
-  aggregation: Aggregation,
-) => {
-  const value = Number(cell(result, row, fieldId, aggregation) ?? 0);
-  return Number.isFinite(value) ? value : 0;
-};
-
 const rowLabel = (result: DatasetQueryResult, row: Scalar[], dimensions: string[]) =>
   dimensions.map((fieldId) => String(cell(result, row, fieldId) ?? '')).join(' / ');
 
@@ -248,6 +263,17 @@ const chartOptionFor = (
   const colorDimension = encoding.color.find((binding) => binding.role === 'dimension')?.field;
   const dimension = getAnalysisField(dataset, firstDimension);
   const metrics = spec.metrics;
+  const computedValues = new Map(metrics.map((metric) => [
+    metric.field,
+    analysisMetricValues(spec, result, metric),
+  ]));
+  const metricValue = (metric: MetricBinding, rowIndex: number) =>
+    computedValues.get(metric.field)?.[rowIndex] ?? null;
+  const formatted = (metric: MetricBinding, value: unknown) => {
+    if (value === null || value === undefined) return '—';
+    const number = Number(value);
+    return formatAnalysisMetricValue(spec, metric, Number.isFinite(number) ? number : null);
+  };
   const axisText = '#667085';
   const axisLine = '#d8dde6';
   const splitLine = '#eef1f5';
@@ -256,6 +282,9 @@ const chartOptionFor = (
 
   if (spec.type === 'pie') {
     const metric = metrics[0];
+    const metricConfig = metricComputationFor(spec, metric.field);
+    const legacyPieLabel = metricConfig.quickCalculation === 'none'
+      && metricConfig.numberFormat === 'auto';
     const legendVisible = style.showLegend;
     const legendOnRight = legendVisible && style.legendPosition === 'right';
     const legendOnTop = legendVisible && style.legendPosition === 'top';
@@ -263,10 +292,13 @@ const chartOptionFor = (
     const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
     return {
       color: colors,
-      tooltip: { trigger: 'item' },
+      tooltip: {
+        trigger: 'item',
+        valueFormatter: (value: unknown) => formatted(metric, value),
+      },
       legend: legendOption(legendVisible, style.legendPosition, axisText),
       series: [{
-        name: metricDisplayName(dataset, metric),
+        name: metricAnalysisDisplayName(spec, dataset, metric),
         type: 'pie',
         radius: [`${style.pieInnerRadius}%`, '70%'],
         center: [
@@ -276,12 +308,16 @@ const chartOptionFor = (
         label: {
           show: style.showDataLabels,
           position: labelPosition,
-          formatter: labelPosition === 'inside' ? '{d}%' : '{b} {d}%',
+          formatter: legacyPieLabel
+            ? (labelPosition === 'inside' ? '{d}%' : '{b} {d}%')
+            : (params: any) => labelPosition === 'inside'
+              ? formatted(metric, params?.value)
+              : `${params?.name ?? ''} ${formatted(metric, params?.value)}`.trim(),
         },
         itemStyle: { borderColor: '#fff', borderWidth: 2 },
         data: result.rows.map((row, rowIndex) => ({
           name: rowLabel(result, row, [firstDimension]),
-          value: numericCell(result, row, metric.field, metric.aggregation),
+          value: metricValue(metric, rowIndex),
           __rowIndex: rowIndex,
         })),
       }],
@@ -302,40 +338,47 @@ const chartOptionFor = (
       && (!colorDimension || Object.is(cell(result, row, colorDimension), color))
     ));
 
-    const seriesStyle = {
+    const seriesStyleFor = (metric: MetricBinding) => ({
       smooth: isLine && style.smooth,
       symbolSize: isLine ? style.symbolSize : undefined,
       lineStyle: isLine ? { width: style.lineWidth } : undefined,
       barMaxWidth: !isLine ? style.barMaxWidth : undefined,
       itemStyle: !isLine ? { borderRadius: style.barRadius } : undefined,
-      label: { show: style.showDataLabels, position: labelPosition },
-    };
+      label: {
+        show: style.showDataLabels,
+        position: labelPosition,
+        formatter: (params: any) => formatted(metric, params?.value),
+      },
+      tooltip: {
+        valueFormatter: (value: unknown) => formatted(metric, value),
+      },
+    });
 
     const series = colorDimension
       ? metrics.flatMap((metric) => colorValues.map((color) => ({
         name: metrics.length > 1
-          ? `${color.label} · ${metricDisplayName(dataset, metric)}`
+          ? `${color.label} · ${metricAnalysisDisplayName(spec, dataset, metric)}`
           : color.label,
         type: spec.type,
-        ...seriesStyle,
+        ...seriesStyleFor(metric),
         data: categories.map((category) => {
           const rowIndex = rowIndexFor(category.value, color.value);
           if (rowIndex < 0) return null;
           return {
-            value: numericCell(result, result.rows[rowIndex], metric.field, metric.aggregation),
+            value: metricValue(metric, rowIndex),
             __rowIndex: rowIndex,
           };
         }),
       })))
       : metrics.map((metric) => ({
-        name: metricDisplayName(dataset, metric),
+        name: metricAnalysisDisplayName(spec, dataset, metric),
         type: spec.type,
-        ...seriesStyle,
+        ...seriesStyleFor(metric),
         data: categories.map((category) => {
           const rowIndex = rowIndexFor(category.value);
           if (rowIndex < 0) return null;
           return {
-            value: numericCell(result, result.rows[rowIndex], metric.field, metric.aggregation),
+            value: metricValue(metric, rowIndex),
             __rowIndex: rowIndex,
           };
         }),
@@ -369,7 +412,11 @@ const chartOptionFor = (
       yAxis: {
         type: 'value',
         splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
-        axisLabel: { color: axisText, fontSize: 11 },
+        axisLabel: {
+          color: axisText,
+          fontSize: 11,
+          formatter: (value: number) => formatAnalysisMetricValue(spec, metrics[0], value),
+        },
       },
       series,
     };
@@ -428,9 +475,7 @@ function MetricAnalysis({
 }) {
   const metric = spec.metrics[0];
   if (!metric) return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="请添加指标" className="mt-4" />;
-  const value = result.rows[0]
-    ? numericCell(result, result.rows[0], metric.field, metric.aggregation)
-    : 0;
+  const value = analysisMetricValues(spec, result, metric)[0] ?? null;
   const style = resolveAnalysisStyle(spec.style);
   const alignment = {
     left: { alignItems: 'flex-start' as const, textAlign: 'left' as const },
@@ -441,13 +486,13 @@ function MetricAnalysis({
   return (
     <div className="flex h-full flex-col justify-center px-5" style={{ alignItems: alignment.alignItems }}>
       <div className="text-[12px] font-medium text-[#667085]" style={{ textAlign: alignment.textAlign }}>
-        {metricDisplayName(dataset, metric)}
+        {metricAnalysisDisplayName(spec, dataset, metric)}
       </div>
       <div
         className="mt-2 font-semibold tracking-[-0.02em] text-[#161823]"
         style={{ fontSize: valueSize, lineHeight: 1.15, textAlign: alignment.textAlign }}
       >
-        {formatMetricValue(value)}
+        {formatAnalysisMetricValue(spec, metric, value)}
       </div>
       {style.showMetricMeta ? (
         <div className="mt-2 text-[11px] text-[#98a2b3]" style={{ textAlign: alignment.textAlign }}>
@@ -471,6 +516,10 @@ function TableAnalysis({
 }) {
   const style = resolveAnalysisStyle(spec.style);
   const dimensions = spec.dimensions.map((field) => getAnalysisField(dataset, field)).filter(Boolean);
+  const computedValues = new Map(spec.metrics.map((metric) => [
+    metric.field,
+    analysisMetricValues(spec, result, metric),
+  ]));
   const cellPadding = style.tableDensity === 'compact'
     ? 'px-3 py-1.5'
     : style.tableDensity === 'relaxed'
@@ -488,7 +537,7 @@ function TableAnalysis({
             ))}
             {spec.metrics.map((metric) => (
               <th key={`${metric.field}-${metric.aggregation}`} className={`whitespace-nowrap border-b border-[#e7eaf0] text-right font-medium ${cellPadding}`}>
-                {metricDisplayName(dataset, metric)}
+                {metricAnalysisDisplayName(spec, dataset, metric)}
               </th>
             ))}
           </tr>
@@ -513,7 +562,7 @@ function TableAnalysis({
                 ))}
                 {spec.metrics.map((metric) => (
                   <td key={`${metric.field}-${metric.aggregation}`} className={`border-b border-[#f0f2f5] text-right tabular-nums text-[#344054] ${cellPadding}`}>
-                    {formatMetricValue(numericCell(result, row, metric.field, metric.aggregation))}
+                    {formatAnalysisMetricValue(spec, metric, computedValues.get(metric.field)?.[rowIndex])}
                   </td>
                 ))}
               </tr>

--- a/yak-ops-ui/src/components/analysis/analysis.test.ts
+++ b/yak-ops-ui/src/components/analysis/analysis.test.ts
@@ -3,7 +3,12 @@ import {
   formatAnalysisMetricValue,
   resolveAnalysisTopN,
 } from './analysis';
-import type { AnalysisSpec, DatasetQueryResult, MetricBinding } from './model';
+import type {
+  AnalysisQuickCalculation,
+  AnalysisSpec,
+  DatasetQueryResult,
+  MetricBinding,
+} from './model';
 
 const metric: MetricBinding = { field: 'sales', aggregation: 'SUM' };
 
@@ -49,9 +54,7 @@ const result = (values: number[]): DatasetQueryResult => ({
   elapsedMillis: 1,
 });
 
-const withCalculation = (
-  quickCalculation: NonNullable<NonNullable<AnalysisSpec['analysis']>['metrics']>[string]['quickCalculation'],
-): AnalysisSpec => baseSpec({
+const withCalculation = (quickCalculation: AnalysisQuickCalculation): AnalysisSpec => baseSpec({
   version: 1,
   metrics: {
     sales: { quickCalculation },

--- a/yak-ops-ui/src/components/analysis/analysis.test.ts
+++ b/yak-ops-ui/src/components/analysis/analysis.test.ts
@@ -1,0 +1,139 @@
+import {
+  analysisMetricValues,
+  formatAnalysisMetricValue,
+  resolveAnalysisTopN,
+} from './analysis';
+import type { AnalysisSpec, DatasetQueryResult, MetricBinding } from './model';
+
+const metric: MetricBinding = { field: 'sales', aggregation: 'SUM' };
+
+const baseSpec = (calculation: AnalysisSpec['analysis'] = undefined): AnalysisSpec => ({
+  type: 'bar',
+  datasetId: 'dataset-1',
+  dimensions: ['category'],
+  metrics: [metric],
+  filters: [],
+  style: {
+    showLegend: false,
+    showDataLabels: false,
+    smooth: false,
+    showGrid: true,
+  },
+  analysis: calculation,
+});
+
+const result = (values: number[]): DatasetQueryResult => ({
+  datasetId: 'dataset-1',
+  datasetVersionId: 'version-1',
+  datasetVersionNo: 1,
+  bindings: [
+    {
+      key: 'd0',
+      fieldId: 'category',
+      displayName: '分类',
+      dataType: 'STRING',
+      aggregation: null,
+    },
+    {
+      key: 'm1',
+      fieldId: 'sales',
+      displayName: '销售额',
+      dataType: 'NUMBER',
+      aggregation: 'SUM',
+    },
+  ],
+  columns: [],
+  rows: values.map((value, index) => [`C${index + 1}`, value]),
+  returnedRows: values.length,
+  truncated: false,
+  elapsedMillis: 1,
+});
+
+const withCalculation = (
+  quickCalculation: NonNullable<NonNullable<AnalysisSpec['analysis']>['metrics']>[string]['quickCalculation'],
+): AnalysisSpec => baseSpec({
+  version: 1,
+  metrics: {
+    sales: { quickCalculation },
+  },
+});
+
+describe('analysisMetricValues', () => {
+  it('calculates percent of total inside the current result', () => {
+    expect(analysisMetricValues(withCalculation('percent_of_total'), result([10, 30]), metric))
+      .toEqual([0.25, 0.75]);
+  });
+
+  it('calculates a running total in current result order', () => {
+    expect(analysisMetricValues(withCalculation('running_total'), result([10, 30, 5]), metric))
+      .toEqual([10, 40, 45]);
+  });
+
+  it('uses competition ranking for tied values', () => {
+    expect(analysisMetricValues(withCalculation('rank'), result([10, 30, 30]), metric))
+      .toEqual([3, 1, 1]);
+  });
+
+  it('calculates previous change and leaves the first row empty', () => {
+    expect(analysisMetricValues(withCalculation('previous_change'), result([10, 30, 30]), metric))
+      .toEqual([null, 2, 0]);
+  });
+
+  it('keeps sequential calculations dormant on metric cards', () => {
+    const spec = { ...withCalculation('percent_of_total'), type: 'metric' as const, dimensions: [] };
+    expect(analysisMetricValues(spec, result([42]), metric)).toEqual([42]);
+  });
+});
+
+describe('resolveAnalysisTopN', () => {
+  it('resolves a server-side metric sort and clamps count', () => {
+    const spec = baseSpec({
+      version: 1,
+      topN: { enabled: true, metricField: 'sales', count: 999, direction: 'bottom' },
+    });
+    expect(resolveAnalysisTopN(spec)).toEqual({
+      metric,
+      count: 100,
+      direction: 'bottom',
+    });
+  });
+
+  it('suspends Top N while a color grouping is active', () => {
+    const spec: AnalysisSpec = {
+      ...baseSpec({
+        version: 1,
+        topN: { enabled: true, metricField: 'sales', count: 10, direction: 'top' },
+      }),
+      dimensions: ['category', 'region'],
+      encoding: {
+        version: 1,
+        category: [{ field: 'category', role: 'dimension' }],
+        value: [{ field: 'sales', role: 'metric', aggregation: 'SUM' }],
+        color: [{ field: 'region', role: 'dimension' }],
+        size: [],
+        label: [],
+        detail: [],
+        tooltip: [],
+      },
+    };
+    expect(resolveAnalysisTopN(spec)).toBeUndefined();
+  });
+});
+
+describe('formatAnalysisMetricValue', () => {
+  it('preserves legacy automatic decimals without trailing zeroes', () => {
+    expect(formatAnalysisMetricValue(baseSpec(), metric, 12.3)).toBe('12.3');
+  });
+
+  it('uses an explicitly configured decimal precision', () => {
+    const spec = baseSpec({
+      version: 1,
+      metrics: { sales: { decimalPlaces: 2 } },
+    });
+    expect(formatAnalysisMetricValue(spec, metric, 12.3)).toBe('12.30');
+  });
+
+  it('automatically formats percent calculations as percentages', () => {
+    expect(formatAnalysisMetricValue(withCalculation('percent_of_total'), metric, 0.125)).toBe('12.5%');
+  });
+});

--- a/yak-ops-ui/src/components/analysis/analysis.ts
+++ b/yak-ops-ui/src/components/analysis/analysis.ts
@@ -97,7 +97,7 @@ export const patchMetricComputation = (
  */
 export const resolveAnalysisTopN = (spec: AnalysisSpec) => {
   const topN = spec.analysis?.topN;
-  if (!topN?.enabled) return undefined;
+  if (!topN?.enabled || spec.type === 'metric' || !spec.dimensions.length) return undefined;
   const colorField = resolveAnalysisEncoding(spec).color.find((item) => item.role === 'dimension')?.field;
   if (colorField) return undefined;
   const metric = spec.metrics.find((item) => item.field === topN.metricField);

--- a/yak-ops-ui/src/components/analysis/analysis.ts
+++ b/yak-ops-ui/src/components/analysis/analysis.ts
@@ -1,0 +1,210 @@
+import { resolveAnalysisEncoding } from './encoding';
+import type {
+  AnalysisMetricComputation,
+  AnalysisNumberFormat,
+  AnalysisQuickCalculation,
+  AnalysisSpec,
+  DatasetQueryResult,
+  MetricBinding,
+  Scalar,
+} from './model';
+
+export const QUICK_CALCULATION_OPTIONS: Array<{
+  label: string;
+  value: AnalysisQuickCalculation;
+  description: string;
+}> = [
+  { label: '原始值', value: 'none', description: '直接展示聚合后的指标值' },
+  { label: '占比', value: 'percent_of_total', description: '当前结果范围内的指标占比' },
+  { label: '累计值', value: 'running_total', description: '按当前结果顺序累计指标值' },
+  { label: '排名', value: 'rank', description: '按指标值从高到低排名' },
+  { label: '较上期变化', value: 'previous_change', description: '与上一分类值相比的变化率' },
+];
+
+export const NUMBER_FORMAT_OPTIONS: Array<{ label: string; value: AnalysisNumberFormat }> = [
+  { label: '自动', value: 'auto' },
+  { label: '数值', value: 'number' },
+  { label: '百分比', value: 'percent' },
+];
+
+const DEFAULT_METRIC_COMPUTATION: Required<AnalysisMetricComputation> = {
+  quickCalculation: 'none',
+  numberFormat: 'auto',
+  decimalPlaces: 2,
+  useGrouping: true,
+};
+
+const bindingIndex = (
+  result: DatasetQueryResult,
+  fieldId: string,
+  aggregation?: MetricBinding['aggregation'],
+) => result.bindings.findIndex((binding) => (
+  binding.fieldId === fieldId
+    && (aggregation ? binding.aggregation === aggregation : !binding.aggregation)
+));
+
+const rawMetricValue = (
+  result: DatasetQueryResult,
+  rowIndex: number,
+  metric: MetricBinding,
+) => {
+  const index = bindingIndex(result, metric.field, metric.aggregation);
+  if (index < 0) return 0;
+  const value = Number(result.rows[rowIndex]?.[index] ?? 0);
+  return Number.isFinite(value) ? value : 0;
+};
+
+const dimensionValue = (
+  result: DatasetQueryResult,
+  rowIndex: number,
+  fieldId?: string,
+): Scalar => {
+  if (!fieldId) return null;
+  const index = bindingIndex(result, fieldId);
+  return index >= 0 ? result.rows[rowIndex]?.[index] ?? null : null;
+};
+
+const scalarKey = (value: Scalar) => `${typeof value}:${String(value)}`;
+
+export const metricComputationFor = (
+  spec: Pick<AnalysisSpec, 'analysis'>,
+  field: string,
+): Required<AnalysisMetricComputation> => ({
+  ...DEFAULT_METRIC_COMPUTATION,
+  ...(spec.analysis?.metrics?.[field] ?? {}),
+});
+
+export const patchMetricComputation = (
+  spec: AnalysisSpec,
+  field: string,
+  patch: Partial<AnalysisMetricComputation>,
+) => ({
+  version: 1 as const,
+  ...spec.analysis,
+  metrics: {
+    ...(spec.analysis?.metrics ?? {}),
+    [field]: {
+      ...(spec.analysis?.metrics?.[field] ?? {}),
+      ...patch,
+    },
+  },
+});
+
+/**
+ * Resolve an enabled Top/Bottom N definition against the active query projection. Grouped
+ * color series are deliberately excluded because limiting grouped rows could truncate a
+ * category before all of its series values are returned.
+ */
+export const resolveAnalysisTopN = (spec: AnalysisSpec) => {
+  const topN = spec.analysis?.topN;
+  if (!topN?.enabled) return undefined;
+  const colorField = resolveAnalysisEncoding(spec).color.find((item) => item.role === 'dimension')?.field;
+  if (colorField) return undefined;
+  const metric = spec.metrics.find((item) => item.field === topN.metricField);
+  if (!metric) return undefined;
+  const count = Math.min(100, Math.max(1, Math.round(Number(topN.count) || 10)));
+  return {
+    metric,
+    count,
+    direction: topN.direction === 'bottom' ? 'bottom' as const : 'top' as const,
+  };
+};
+
+/**
+ * Quick calculations intentionally run after the Dataset query. They are therefore
+ * portable across Dataset SQL dialects and leave the existing server query contract intact.
+ * When a color channel exists, sequential calculations are scoped to each color series.
+ */
+export const analysisMetricValues = (
+  spec: AnalysisSpec,
+  result: DatasetQueryResult,
+  metric: MetricBinding,
+): Array<number | null> => {
+  const config = metricComputationFor(spec, metric.field);
+  const raw = result.rows.map((_, rowIndex) => rawMetricValue(result, rowIndex, metric));
+  if (config.quickCalculation === 'none') return raw;
+
+  const colorField = resolveAnalysisEncoding(spec).color.find((item) => item.role === 'dimension')?.field;
+  const groupKeys = result.rows.map((_, rowIndex) => scalarKey(dimensionValue(result, rowIndex, colorField)));
+  const indexesByGroup = new Map<string, number[]>();
+  groupKeys.forEach((key, index) => {
+    const indexes = indexesByGroup.get(key) ?? [];
+    indexes.push(index);
+    indexesByGroup.set(key, indexes);
+  });
+
+  const values: Array<number | null> = Array.from({ length: raw.length }, () => null);
+  indexesByGroup.forEach((indexes) => {
+    if (config.quickCalculation === 'percent_of_total') {
+      const total = indexes.reduce((sum, index) => sum + raw[index], 0);
+      indexes.forEach((index) => {
+        values[index] = total === 0 ? 0 : raw[index] / total;
+      });
+      return;
+    }
+
+    if (config.quickCalculation === 'running_total') {
+      let total = 0;
+      indexes.forEach((index) => {
+        total += raw[index];
+        values[index] = total;
+      });
+      return;
+    }
+
+    if (config.quickCalculation === 'rank') {
+      const ordered = [...indexes].sort((left, right) => raw[right] - raw[left]);
+      let rank = 0;
+      let previous: number | undefined;
+      ordered.forEach((index, orderedIndex) => {
+        if (previous === undefined || raw[index] !== previous) rank = orderedIndex + 1;
+        values[index] = rank;
+        previous = raw[index];
+      });
+      return;
+    }
+
+    if (config.quickCalculation === 'previous_change') {
+      indexes.forEach((index, offset) => {
+        if (offset === 0) {
+          values[index] = null;
+          return;
+        }
+        const previous = raw[indexes[offset - 1]];
+        values[index] = previous === 0 ? null : (raw[index] - previous) / Math.abs(previous);
+      });
+    }
+  });
+  return values;
+};
+
+const effectiveNumberFormat = (
+  config: Required<AnalysisMetricComputation>,
+): Exclude<AnalysisNumberFormat, 'auto'> => {
+  if (config.numberFormat !== 'auto') return config.numberFormat;
+  return config.quickCalculation === 'percent_of_total' || config.quickCalculation === 'previous_change'
+    ? 'percent'
+    : 'number';
+};
+
+export const formatAnalysisMetricValue = (
+  spec: Pick<AnalysisSpec, 'analysis'>,
+  metric: MetricBinding,
+  value: number | null | undefined,
+) => {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+  const config = metricComputationFor(spec, metric.field);
+  const format = effectiveNumberFormat(config);
+  const decimalPlaces = Math.min(4, Math.max(0, Number(config.decimalPlaces)));
+  const options: Intl.NumberFormatOptions = {
+    useGrouping: config.useGrouping,
+    maximumFractionDigits: decimalPlaces,
+  };
+  if (format !== 'number' || !Number.isInteger(value)) options.minimumFractionDigits = decimalPlaces;
+  if (format === 'percent') options.style = 'percent';
+  return new Intl.NumberFormat('zh-CN', options).format(value);
+};
+
+export const quickCalculationLabel = (
+  calculation: AnalysisQuickCalculation,
+) => QUICK_CALCULATION_OPTIONS.find((item) => item.value === calculation)?.label ?? '原始值';

--- a/yak-ops-ui/src/components/analysis/analysis.ts
+++ b/yak-ops-ui/src/components/analysis/analysis.ts
@@ -122,7 +122,9 @@ export const analysisMetricValues = (
 ): Array<number | null> => {
   const config = metricComputationFor(spec, metric.field);
   const raw = result.rows.map((_, rowIndex) => rawMetricValue(result, rowIndex, metric));
-  if (config.quickCalculation === 'none') return raw;
+  // A metric card has no category sequence. Keep any calculation selected on another chart
+  // type parked in the persisted analysis config, but render the single aggregated value.
+  if (spec.type === 'metric' || config.quickCalculation === 'none') return raw;
 
   const colorField = resolveAnalysisEncoding(spec).color.find((item) => item.role === 'dimension')?.field;
   const groupKeys = result.rows.map((_, rowIndex) => scalarKey(dimensionValue(result, rowIndex, colorField)));
@@ -179,23 +181,25 @@ export const analysisMetricValues = (
 };
 
 const effectiveNumberFormat = (
+  type: AnalysisSpec['type'],
   config: Required<AnalysisMetricComputation>,
 ): Exclude<AnalysisNumberFormat, 'auto'> => {
   if (config.numberFormat !== 'auto') return config.numberFormat;
+  if (type === 'metric') return 'number';
   return config.quickCalculation === 'percent_of_total' || config.quickCalculation === 'previous_change'
     ? 'percent'
     : 'number';
 };
 
 export const formatAnalysisMetricValue = (
-  spec: Pick<AnalysisSpec, 'analysis'>,
+  spec: Pick<AnalysisSpec, 'analysis' | 'type'>,
   metric: MetricBinding,
   value: number | null | undefined,
 ) => {
   if (value === null || value === undefined || !Number.isFinite(value)) return '—';
   const stored = spec.analysis?.metrics?.[metric.field];
   const config = metricComputationFor(spec, metric.field);
-  const format = effectiveNumberFormat(config);
+  const format = effectiveNumberFormat(spec.type, config);
   const explicitDecimals = stored?.decimalPlaces;
   const options: Intl.NumberFormatOptions = {
     useGrouping: config.useGrouping,

--- a/yak-ops-ui/src/components/analysis/analysis.ts
+++ b/yak-ops-ui/src/components/analysis/analysis.ts
@@ -193,14 +193,24 @@ export const formatAnalysisMetricValue = (
   value: number | null | undefined,
 ) => {
   if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+  const stored = spec.analysis?.metrics?.[metric.field];
   const config = metricComputationFor(spec, metric.field);
   const format = effectiveNumberFormat(config);
-  const decimalPlaces = Math.min(4, Math.max(0, Number(config.decimalPlaces)));
+  const explicitDecimals = stored?.decimalPlaces;
   const options: Intl.NumberFormatOptions = {
     useGrouping: config.useGrouping,
-    maximumFractionDigits: decimalPlaces,
   };
-  if (format !== 'number' || !Number.isInteger(value)) options.minimumFractionDigits = decimalPlaces;
+
+  if (explicitDecimals !== undefined) {
+    const decimalPlaces = Math.min(4, Math.max(0, Number(explicitDecimals)));
+    options.minimumFractionDigits = decimalPlaces;
+    options.maximumFractionDigits = decimalPlaces;
+  } else {
+    // Preserve the pre-Phase-8 display contract for legacy/raw metrics: do not force
+    // trailing zeroes, but still cap noisy floating-point output at two decimals.
+    options.maximumFractionDigits = 2;
+  }
+
   if (format === 'percent') options.style = 'percent';
   return new Intl.NumberFormat('zh-CN', options).format(value);
 };

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -112,6 +112,41 @@ export interface AnalysisVisualConfig {
   stripedRows?: boolean;
 }
 
+export type AnalysisQuickCalculation =
+  | 'none'
+  | 'percent_of_total'
+  | 'running_total'
+  | 'rank'
+  | 'previous_change';
+export type AnalysisNumberFormat = 'auto' | 'number' | 'percent';
+export type AnalysisTopNDirection = 'top' | 'bottom';
+
+/** Per-metric table calculation and presentation choices. */
+export interface AnalysisMetricComputation {
+  quickCalculation?: AnalysisQuickCalculation;
+  numberFormat?: AnalysisNumberFormat;
+  decimalPlaces?: 0 | 1 | 2 | 3 | 4;
+  useGrouping?: boolean;
+}
+
+/** Server-side row reduction built from the current metric aggregation. */
+export interface AnalysisTopNConfig {
+  enabled: boolean;
+  metricField: string;
+  count: number;
+  direction: AnalysisTopNDirection;
+}
+
+/**
+ * Versioned analysis semantics layered on top of the Dataset query result. Quick
+ * calculations are table calculations and therefore do not alter the Dataset SQL contract.
+ */
+export interface AnalysisComputationConfig {
+  version: 1;
+  metrics?: Record<string, AnalysisMetricComputation>;
+  topN?: AnalysisTopNConfig;
+}
+
 /** Query + visualization definition that can be reused outside a Dashboard. */
 export interface AnalysisSpec {
   type: ChartType;
@@ -125,6 +160,8 @@ export interface AnalysisSpec {
   filters: AnalysisFilter[];
   sort?: AnalysisSort;
   style: AnalysisVisualConfig;
+  /** Optional Phase 8 analysis semantics. Legacy snapshots resolve to raw metric values. */
+  analysis?: AnalysisComputationConfig;
   limit?: number;
   timeoutSeconds?: number;
 }

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -141,6 +141,19 @@ export function ChartSheetConfigPanel({
       && !next.metrics.some((metric) => metric.field === spec.sort?.field)
       ? undefined
       : spec.sort;
+    const currentTopN = spec.analysis?.topN;
+    const topNMetricStillActive = currentTopN
+      ? next.metrics.some((metric) => metric.field === currentTopN.metricField)
+      : true;
+    const nextAnalysis = currentTopN && !topNMetricStillActive
+      ? {
+        ...spec.analysis,
+        version: 1 as const,
+        topN: next.metrics[0]
+          ? { ...currentTopN, metricField: next.metrics[0].field }
+          : { ...currentTopN, enabled: false },
+      }
+      : spec.analysis;
     const hadColor = Boolean(spec.encoding?.color?.length);
     const hasColor = Boolean(next.encoding.color.length);
     const shouldRevealLegend = !hadColor
@@ -151,6 +164,7 @@ export function ChartSheetConfigPanel({
       dimensions: next.dimensions,
       metrics: next.metrics,
       sort: nextSort,
+      analysis: nextAnalysis,
       ...(shouldRevealLegend
         ? { style: { ...spec.style, showLegend: true, version: 1 as const } }
         : {}),

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -5,7 +5,8 @@ import {
 } from '@/components/analysis/encoding';
 import type { AnalysisEncoding, AnalysisSpec } from '@/components/analysis/model';
 import { Button, Collapse, Input, Select } from 'antd';
-import { ChevronDown, MousePointerClick, Palette, SlidersHorizontal, X } from 'lucide-react';
+import { Calculator, ChevronDown, MousePointerClick, Palette, SlidersHorizontal, X } from 'lucide-react';
+import { ChartAnalysisConfig } from './config-analysis';
 import { ConfigData } from './config-data';
 import { MetricAggregations } from './config-metrics';
 import { QueryControls } from './config-query';
@@ -20,7 +21,6 @@ import type {
   DashboardInlineAnalysisSpec,
   DashboardInteraction,
   DashboardWidget,
-  FilterOperator,
   PublishedDataset,
   SortDirection,
 } from './model';
@@ -117,7 +117,6 @@ export function ChartSheetConfigPanel({
   const metricLabels = Object.fromEntries(
     dataset.fields.map((field) => [field.key, field.label]),
   );
-  const filter = spec.filters[0];
 
   const changeType = (type: ChartType) => {
     const next = changeAnalysisEncodingType(spec, type);
@@ -127,10 +126,10 @@ export function ChartSheetConfigPanel({
       dimensions: next.dimensions,
       metrics: next.metrics,
       sort: undefined,
-      // Keep style values non-destructive across chart type switches. Each renderer only
-      // consumes properties relevant to its type, so returning to a type restores the
-      // user's previous visual choices instead of resetting them.
+      // Keep style and analysis values non-destructive across chart type switches. Each
+      // renderer consumes only the options relevant to the currently active chart.
       style: { ...spec.style, version: 1 },
+      analysis: spec.analysis,
       limit: type === 'table' ? 200 : 500,
     });
   };
@@ -246,7 +245,7 @@ export function ChartSheetConfigPanel({
           ghost
           className="chart-editor-more mt-4 border-t border-[#eceef1]"
           expandIconPosition="end"
-          defaultActiveKey={['style']}
+          defaultActiveKey={['analysis']}
           expandIcon={({ isActive }) => (
             <ChevronDown
               size={13}
@@ -254,6 +253,22 @@ export function ChartSheetConfigPanel({
             />
           )}
           items={[
+            {
+              key: 'analysis',
+              label: (
+                <span className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+                  <Calculator size={12} />
+                  分析设置
+                </span>
+              ),
+              children: (
+                <ChartAnalysisConfig
+                  spec={spec}
+                  dataset={dataset}
+                  onChange={(analysis) => updateInlineAnalysis({ analysis })}
+                />
+              ),
+            },
             {
               key: 'style',
               label: (
@@ -310,9 +325,7 @@ export function ChartSheetConfigPanel({
                     filterOptions={filterOptions}
                     sortField={spec.sort?.field}
                     sortDirection={spec.sort?.direction ?? 'asc'}
-                    filterField={filter?.field}
-                    filterOperator={filter?.operator ?? 'eq'}
-                    filterValue={filter?.value ?? ''}
+                    filters={spec.filters}
                     onSortField={(field?: string) =>
                       updateInlineAnalysis({
                         sort: field
@@ -322,23 +335,7 @@ export function ChartSheetConfigPanel({
                     onSortDirection={(direction: SortDirection) =>
                       spec.sort
                       && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
-                    onFilterField={(field?: string) =>
-                      updateInlineAnalysis({
-                        filters: field
-                          ? [{
-                            id: filter?.id ?? 'filter-main',
-                            field,
-                            operator: filter?.operator ?? 'eq',
-                            value: filter?.value ?? '',
-                          }]
-                          : [],
-                      })}
-                    onFilterOperator={(operator: FilterOperator) =>
-                      filter
-                      && updateInlineAnalysis({ filters: [{ ...filter, operator }] })}
-                    onFilterValue={(value) =>
-                      filter
-                      && updateInlineAnalysis({ filters: [{ ...filter, value }] })}
+                    onFiltersChange={(filters) => updateInlineAnalysis({ filters })}
                   />
                 </div>
               ),
@@ -369,7 +366,7 @@ function ConfigPanelHeader({ onDone }: { onDone: () => void }) {
     <div className="flex h-14 shrink-0 items-center justify-between border-b border-[#eceef1] px-4">
       <div>
         <div className="text-[13px] font-semibold text-[#344054]">图表配置</div>
-        <div className="mt-0.5 text-[9px] text-[#98a2b3]">字段编码、样式与交互配置</div>
+        <div className="mt-0.5 text-[9px] text-[#98a2b3]">字段编码、分析、样式与交互配置</div>
       </div>
       <button
         type="button"

--- a/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
@@ -4,6 +4,7 @@ import {
   patchMetricComputation,
   QUICK_CALCULATION_OPTIONS,
 } from '@/components/analysis/analysis';
+import { resolveAnalysisEncoding } from '@/components/analysis/encoding';
 import type {
   AnalysisComputationConfig,
   AnalysisMetricComputation,
@@ -13,7 +14,6 @@ import type {
   AnalysisTopNDirection,
   PublishedDataset,
 } from '@/components/analysis/model';
-import { resolveAnalysisEncoding } from '@/components/analysis/encoding';
 import { InputNumber, Select, Switch } from 'antd';
 import { AGGREGATION_OPTIONS } from './helpers';
 
@@ -64,6 +64,7 @@ export function ChartAnalysisConfig({
           {spec.metrics.map((metric) => {
             const field = dataset.fields.find((item) => item.key === metric.field);
             const config = metricComputationFor(spec, metric.field);
+            const stored = spec.analysis?.metrics?.[metric.field];
             return (
               <div key={metric.field} className="rounded-[8px] border border-[#e8eaee] bg-[#fafbfc] p-2.5">
                 <div className="flex items-center justify-between gap-2">
@@ -83,7 +84,6 @@ export function ChartAnalysisConfig({
                       options={QUICK_CALCULATION_OPTIONS.map((item) => ({
                         label: item.label,
                         value: item.value,
-                        title: item.description,
                       }))}
                       onChange={(quickCalculation: AnalysisQuickCalculation) =>
                         patchMetric(metric.field, { quickCalculation })}
@@ -103,10 +103,15 @@ export function ChartAnalysisConfig({
                   />
                   <Select
                     size="small"
-                    value={config.decimalPlaces}
-                    options={[0, 1, 2, 3, 4].map((value) => ({ label: `${value} 位`, value }))}
-                    onChange={(decimalPlaces: 0 | 1 | 2 | 3 | 4) =>
-                      patchMetric(metric.field, { decimalPlaces })}
+                    value={stored?.decimalPlaces ?? 'auto'}
+                    options={[
+                      { label: '自动', value: 'auto' },
+                      ...([0, 1, 2, 3, 4] as const).map((value) => ({ label: `${value} 位`, value })),
+                    ]}
+                    onChange={(decimalPlaces: 'auto' | 0 | 1 | 2 | 3 | 4) =>
+                      patchMetric(metric.field, {
+                        decimalPlaces: decimalPlaces === 'auto' ? undefined : decimalPlaces,
+                      })}
                   />
                 </div>
                 <label className="mt-2.5 flex items-center justify-between">

--- a/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
@@ -1,0 +1,189 @@
+import {
+  metricComputationFor,
+  NUMBER_FORMAT_OPTIONS,
+  patchMetricComputation,
+  QUICK_CALCULATION_OPTIONS,
+} from '@/components/analysis/analysis';
+import type {
+  AnalysisComputationConfig,
+  AnalysisMetricComputation,
+  AnalysisNumberFormat,
+  AnalysisQuickCalculation,
+  AnalysisSpec,
+  AnalysisTopNDirection,
+  PublishedDataset,
+} from '@/components/analysis/model';
+import { resolveAnalysisEncoding } from '@/components/analysis/encoding';
+import { InputNumber, Select, Switch } from 'antd';
+import { AGGREGATION_OPTIONS } from './helpers';
+
+export function ChartAnalysisConfig({
+  spec,
+  dataset,
+  onChange,
+}: {
+  spec: AnalysisSpec;
+  dataset: PublishedDataset;
+  onChange: (analysis: AnalysisComputationConfig) => void;
+}) {
+  const colorActive = Boolean(
+    resolveAnalysisEncoding(spec).color.find((item) => item.role === 'dimension')?.field,
+  );
+  const supportsSequentialCalculation = spec.type !== 'metric' && spec.dimensions.length > 0;
+  const topN = spec.analysis?.topN;
+  const supportsTopN = spec.type !== 'metric' && spec.dimensions.length > 0 && spec.metrics.length > 0;
+  const aggregationLabels = Object.fromEntries(
+    AGGREGATION_OPTIONS.map((item) => [item.value, item.label]),
+  );
+
+  const patchMetric = (field: string, patch: Partial<AnalysisMetricComputation>) => {
+    onChange(patchMetricComputation(spec, field, patch));
+  };
+
+  const patchTopN = (patch: Partial<NonNullable<AnalysisComputationConfig['topN']>>) => {
+    const fallbackMetric = spec.metrics[0];
+    if (!fallbackMetric) return;
+    onChange({
+      ...spec.analysis,
+      version: 1,
+      topN: {
+        enabled: topN?.enabled ?? false,
+        metricField: topN?.metricField ?? fallbackMetric.field,
+        count: topN?.count ?? 10,
+        direction: topN?.direction ?? 'top',
+        ...patch,
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-4 pb-1 text-[11px] text-[#475467]">
+      <div>
+        <div className="mb-2.5 text-[10px] font-semibold text-[#667085]">指标计算</div>
+        <div className="space-y-2.5">
+          {spec.metrics.map((metric) => {
+            const field = dataset.fields.find((item) => item.key === metric.field);
+            const config = metricComputationFor(spec, metric.field);
+            return (
+              <div key={metric.field} className="rounded-[8px] border border-[#e8eaee] bg-[#fafbfc] p-2.5">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="truncate text-[10px] font-medium text-[#344054]">
+                      {field?.label ?? metric.field}
+                    </div>
+                    <div className="mt-0.5 text-[9px] text-[#98a2b3]">
+                      {aggregationLabels[metric.aggregation] ?? metric.aggregation}
+                    </div>
+                  </div>
+                  {supportsSequentialCalculation ? (
+                    <Select
+                      size="small"
+                      className="w-[126px]"
+                      value={config.quickCalculation}
+                      options={QUICK_CALCULATION_OPTIONS.map((item) => ({
+                        label: item.label,
+                        value: item.value,
+                        title: item.description,
+                      }))}
+                      onChange={(quickCalculation: AnalysisQuickCalculation) =>
+                        patchMetric(metric.field, { quickCalculation })}
+                    />
+                  ) : (
+                    <span className="text-[9px] text-[#98a2b3]">单值指标</span>
+                  )}
+                </div>
+
+                <div className="mt-2.5 grid grid-cols-[1fr_78px] gap-2">
+                  <Select
+                    size="small"
+                    value={config.numberFormat}
+                    options={NUMBER_FORMAT_OPTIONS}
+                    onChange={(numberFormat: AnalysisNumberFormat) =>
+                      patchMetric(metric.field, { numberFormat })}
+                  />
+                  <Select
+                    size="small"
+                    value={config.decimalPlaces}
+                    options={[0, 1, 2, 3, 4].map((value) => ({ label: `${value} 位`, value }))}
+                    onChange={(decimalPlaces: 0 | 1 | 2 | 3 | 4) =>
+                      patchMetric(metric.field, { decimalPlaces })}
+                  />
+                </div>
+                <label className="mt-2.5 flex items-center justify-between">
+                  <span className="text-[10px] text-[#667085]">千分位</span>
+                  <Switch
+                    size="small"
+                    checked={config.useGrouping}
+                    onChange={(useGrouping) => patchMetric(metric.field, { useGrouping })}
+                  />
+                </label>
+              </div>
+            );
+          })}
+        </div>
+        <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
+          占比、累计、排名和较上期变化在当前查询结果上计算，不改变 Dataset SQL。
+        </div>
+      </div>
+
+      {supportsTopN ? (
+        <div className="border-t border-[#f0f1f3] pt-4">
+          <div className="mb-2.5 flex items-center justify-between">
+            <div>
+              <div className="text-[10px] font-semibold text-[#667085]">Top / Bottom N</div>
+              <div className="mt-0.5 text-[9px] text-[#98a2b3]">先按指标排序，再限制返回分类数量</div>
+            </div>
+            <Switch
+              size="small"
+              checked={Boolean(topN?.enabled)}
+              disabled={colorActive && !topN?.enabled}
+              onChange={(enabled) => patchTopN({ enabled })}
+            />
+          </div>
+
+          {topN?.enabled ? (
+            <div className="space-y-2">
+              <Select
+                size="small"
+                className="w-full"
+                value={topN.metricField}
+                options={spec.metrics.map((metric) => ({
+                  label: `${dataset.fields.find((item) => item.key === metric.field)?.label ?? metric.field} · ${aggregationLabels[metric.aggregation] ?? metric.aggregation}`,
+                  value: metric.field,
+                }))}
+                onChange={(metricField: string) => patchTopN({ metricField })}
+              />
+              <div className="grid grid-cols-[1fr_92px] gap-2">
+                <Select
+                  size="small"
+                  value={topN.direction}
+                  options={[
+                    { label: 'Top N', value: 'top' },
+                    { label: 'Bottom N', value: 'bottom' },
+                  ]}
+                  onChange={(direction: AnalysisTopNDirection) => patchTopN({ direction })}
+                />
+                <InputNumber
+                  size="small"
+                  className="w-full"
+                  min={1}
+                  max={100}
+                  value={topN.count}
+                  onChange={(count) => {
+                    if (typeof count === 'number') patchTopN({ count });
+                  }}
+                />
+              </div>
+            </div>
+          ) : null}
+
+          {colorActive ? (
+            <div className="mt-2 rounded-[6px] bg-[#f7f8fa] px-2 py-1.5 text-[9px] leading-4 text-[#98a2b3]">
+              当前使用了颜色分组。为避免服务端截断某个分类的部分系列，Top N 暂不生效；移除颜色字段后会自动恢复。
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
@@ -32,6 +32,7 @@ export function ChartAnalysisConfig({
   const supportsSequentialCalculation = spec.type !== 'metric' && spec.dimensions.length > 0;
   const topN = spec.analysis?.topN;
   const supportsTopN = spec.type !== 'metric' && spec.dimensions.length > 0 && spec.metrics.length > 0;
+  const topNMetricActive = !topN || spec.metrics.some((metric) => metric.field === topN.metricField);
   const aggregationLabels = Object.fromEntries(
     AGGREGATION_OPTIONS.map((item) => [item.value, item.label]),
   );
@@ -151,7 +152,8 @@ export function ChartAnalysisConfig({
               <Select
                 size="small"
                 className="w-full"
-                value={topN.metricField}
+                placeholder="选择 Top N 指标"
+                value={topNMetricActive ? topN.metricField : undefined}
                 options={spec.metrics.map((metric) => ({
                   label: `${dataset.fields.find((item) => item.key === metric.field)?.label ?? metric.field} · ${aggregationLabels[metric.aggregation] ?? metric.aggregation}`,
                   value: metric.field,
@@ -179,6 +181,11 @@ export function ChartAnalysisConfig({
                   }}
                 />
               </div>
+              {!topNMetricActive ? (
+                <div className="text-[9px] leading-4 text-[#98a2b3]">
+                  原 Top N 指标在当前图表类型中暂未激活；切回原图表类型可恢复，或在这里重新选择。
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/yak-ops-ui/src/pages/dashboard/config-query.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-query.tsx
@@ -1,36 +1,52 @@
-import { Input, Select } from 'antd';
+import { Button, Input, Select } from 'antd';
+import { Plus, X } from 'lucide-react';
 import { FILTER_OPERATOR_OPTIONS } from './helpers';
-import type { FilterOperator, SortDirection } from './model';
+import type { DashboardFilter, FilterOperator, SortDirection } from './model';
 
 export function QueryControls({
   sortOptions,
   filterOptions,
   sortField,
   sortDirection,
-  filterField,
-  filterOperator,
-  filterValue,
+  filters,
   onSortField,
   onSortDirection,
-  onFilterField,
-  onFilterOperator,
-  onFilterValue,
+  onFiltersChange,
 }: {
   sortOptions: Array<{ label: string; value: string }>;
   filterOptions: Array<{ label: string; value: string }>;
   sortField?: string;
   sortDirection: SortDirection;
-  filterField?: string;
-  filterOperator: FilterOperator;
-  filterValue: string;
+  filters: DashboardFilter[];
   onSortField: (field?: string) => void;
   onSortDirection: (direction: SortDirection) => void;
-  onFilterField: (field?: string) => void;
-  onFilterOperator: (operator: FilterOperator) => void;
-  onFilterValue: (value: string) => void;
+  onFiltersChange: (filters: DashboardFilter[]) => void;
 }) {
+  const updateFilter = (id: string, patch: Partial<DashboardFilter>) => {
+    onFiltersChange(filters.map((filter) => filter.id === id ? { ...filter, ...patch } : filter));
+  };
+
+  const removeFilter = (id: string) => {
+    onFiltersChange(filters.filter((filter) => filter.id !== id));
+  };
+
+  const addFilter = () => {
+    if (filters.length >= 8) return;
+    const firstField = filterOptions[0]?.value;
+    if (!firstField) return;
+    onFiltersChange([
+      ...filters,
+      {
+        id: `filter-${Date.now()}-${filters.length}`,
+        field: firstField,
+        operator: 'eq',
+        value: '',
+      },
+    ]);
+  };
+
   return (
-    <div className="mt-4 space-y-4 border-t border-[#edf0f3] pt-4">
+    <div className="space-y-4">
       <div>
         <div className="mb-1 text-[11px] text-[#667085]">排序</div>
         <div className="flex gap-2">
@@ -53,33 +69,66 @@ export function QueryControls({
           />
         </div>
       </div>
-      <div>
-        <div className="mb-1 text-[11px] text-[#667085]">过滤</div>
-        <div className="grid grid-cols-[1fr_90px] gap-2">
-          <Select
-            allowClear
+
+      <div className="border-t border-[#edf0f3] pt-4">
+        <div className="mb-2 flex items-center justify-between">
+          <div>
+            <div className="text-[11px] text-[#667085]">过滤条件</div>
+            <div className="mt-0.5 text-[9px] text-[#98a2b3]">多个条件按 AND 组合</div>
+          </div>
+          <Button
             size="small"
-            placeholder="字段"
-            value={filterField}
-            options={filterOptions}
-            onChange={onFilterField}
-          />
-          <Select
-            size="small"
-            disabled={!filterField}
-            value={filterOperator}
-            options={FILTER_OPERATOR_OPTIONS}
-            onChange={onFilterOperator}
-          />
+            type="text"
+            className="!h-6 !px-1.5 !text-[10px]"
+            icon={<Plus size={11} />}
+            disabled={!filterOptions.length || filters.length >= 8}
+            onClick={addFilter}
+          >
+            添加
+          </Button>
         </div>
-        <Input
-          size="small"
-          className="mt-2"
-          disabled={!filterField}
-          placeholder="过滤值"
-          value={filterValue}
-          onChange={(event) => onFilterValue(event.target.value)}
-        />
+
+        {filters.length ? (
+          <div className="space-y-2.5">
+            {filters.map((filter) => (
+              <div key={filter.id} className="rounded-[7px] border border-[#e8eaee] bg-[#fafbfc] p-2.5">
+                <div className="grid grid-cols-[1fr_88px_24px] gap-1.5">
+                  <Select
+                    size="small"
+                    value={filter.field}
+                    options={filterOptions}
+                    onChange={(field: string) => updateFilter(filter.id, { field })}
+                  />
+                  <Select
+                    size="small"
+                    value={filter.operator}
+                    options={FILTER_OPERATOR_OPTIONS}
+                    onChange={(operator: FilterOperator) => updateFilter(filter.id, { operator })}
+                  />
+                  <button
+                    type="button"
+                    className="flex h-6 w-6 items-center justify-center rounded-[5px] text-[#98a2b3] hover:bg-[#f0f1f3] hover:text-[#475467]"
+                    aria-label="删除过滤条件"
+                    onClick={() => removeFilter(filter.id)}
+                  >
+                    <X size={11} />
+                  </button>
+                </div>
+                <Input
+                  size="small"
+                  className="mt-2"
+                  placeholder="过滤值"
+                  value={filter.value}
+                  onChange={(event) => updateFilter(filter.id, { value: event.target.value })}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-[6px] border border-dashed border-[#e2e5e9] px-2.5 py-3 text-center text-[9px] text-[#a0a6af]">
+            暂无过滤条件
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed
- introduce an optional versioned `AnalysisComputationConfig` on inline chart specs, separating analysis semantics from Encoding and Style
- add a first-class `分析设置` section in Chart Sheet for per-metric analytical calculations and number formatting
- support quick calculations on the current query result: `原始值` / `占比` / `累计值` / `排名` / `较上期变化`
- apply quick calculations consistently to bar, line, pie and table renderers; sequential calculations stay dormant on metric cards and are restored when switching back
- make color-grouped bar/line calculations run independently per color series
- add per-metric number format (`自动` / `数值` / `百分比`), automatic or fixed 0–4 decimal precision, and thousands grouping
- preserve legacy raw-number rendering when no Phase 8 precision is configured, so existing dashboards do not suddenly gain trailing zeroes
- add Top / Bottom N using the existing Dataset metric sort + limit contract rather than client-side row slicing
- automatically reconcile a Top N metric when the user removes that metric from the active Encoding; chart-type switches keep temporarily inactive Top N state dormant instead of destructively deleting it
- suspend Top N while a color grouping is active so the server cannot return only part of a category's grouped series
- upgrade chart query filters from one condition to up to 8 AND-combined conditions using the existing `filters[]` model
- add focused unit tests for percent-of-total, running total, rank ties, previous-change, dormant metric-card calculations, Top N safety and number formatting

## Phase 8 analysis semantics

```text
Dataset query
  ├─ aggregation                 existing server capability
  ├─ filters[]                   server, AND combined
  ├─ sort                        server
  └─ Top / Bottom N              server metric sort + limit
          ↓
Current query result
          ↓
Table calculations
  ├─ percent of total
  ├─ running total
  ├─ rank
  └─ previous change
          ↓
Number formatting
          ↓
Chart / Table renderer
```

Quick calculations deliberately run after the Dataset query. This keeps them portable across source SQL dialects and makes their scope explicit: they operate on the currently returned result/order. With a `color` Encoding, sequential calculations are scoped to each color series.

## Compatibility
- `AnalysisSpec.analysis` is optional, so existing Dashboard/Analysis snapshots remain readable
- Dashboard document version remains `1`
- no database schema migration
- no backend DTO/domain change
- no Dataset query payload/API contract change
- no new npm dependency
- existing Dashboard save / publish / restore / undo / redo keeps carrying inline analysis JSON transparently
- reusable shared Analysis assets remain on the existing backend contract; Dashboard-linked shared charts still use the existing “复制为可编辑图表” flow before Phase 8 settings become editable

## Intentionally deferred
- time grains such as year / quarter / month / week / day are **not** faked in this PR. The current Dataset query compiler has no dialect-aware date-bucket semantic, so implementing them correctly needs a real Dataset query-contract extension rather than client-side approximation.
-同比 / 环比 across calendar periods also depend on that time-grain foundation; `较上期变化` in this PR means previous row in the current result order.

## Validation
- [x] Phase 7 PR #482 is merged into `main`
- [x] branch starts from the latest `main` after the subsequently merged digital-screen work (#483)
- [x] branch compare is 0 commits behind `main`
- [x] reviewed final compare: 7 frontend files changed; no backend or DB migration files changed
- [x] added pure unit-test coverage for Phase 8 computation semantics
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm run jest -- analysis.test.ts`
- [ ] manual browser regression: quick calculations, formatting, Top/Bottom N, multi-filter AND behavior, chart-type round trips

Executable frontend validation is intentionally left unchecked in the current environment rather than being claimed as completed. GitHub checks should be treated as the executable integration signal if/when workflows are configured.