### PR TITLE
feat: bind datasets to digital screen components

### DIFF
--- a/yak-ops-ui/src/components/screen-engine/ScreenRenderer.tsx
+++ b/yak-ops-ui/src/components/screen-engine/ScreenRenderer.tsx
@@ -15,6 +15,11 @@ import type {
 
 type ScreenChartComponent = ScreenLineComponent | ScreenBarComponent | ScreenPieComponent;
 
+interface ComponentInteraction {
+  selected?: boolean;
+  onSelect?: () => void;
+}
+
 const CHART_COLORS = ['#38bdf8', '#22c55e', '#f59e0b', '#a78bfa', '#fb7185', '#2dd4bf'];
 
 const formatValue = (value: string | number) => {
@@ -131,17 +136,24 @@ function ComponentFrame({
   component,
   theme,
   children,
+  selected = false,
+  onSelect,
 }: {
   component: ScreenComponent;
   theme: ScreenTheme;
   children: ReactNode;
-}) {
+} & ComponentInteraction) {
   const style = component.style;
   const transparent = component.type === 'text';
   return (
     <div
       data-screen-component={component.id}
-      className="absolute box-border flex min-h-0 flex-col overflow-hidden"
+      data-screen-selected={selected || undefined}
+      onClick={onSelect}
+      className={[
+        'absolute box-border flex min-h-0 flex-col overflow-hidden transition-[outline,filter] duration-150',
+        onSelect ? 'cursor-pointer hover:brightness-[1.04]' : '',
+      ].join(' ')}
       style={{
         left: component.x,
         top: component.y,
@@ -153,6 +165,8 @@ function ComponentFrame({
         borderRadius: style?.borderRadius ?? (transparent ? 0 : 12),
         boxShadow: style?.shadow,
         color: style?.color ?? theme.textColor,
+        outline: selected ? '3px solid rgba(254, 44, 85, 0.92)' : undefined,
+        outlineOffset: selected ? -3 : undefined,
       }}
     >
       {component.title ? (
@@ -175,14 +189,21 @@ function ComponentFrame({
   );
 }
 
-function MetricComponent({ component, theme }: { component: Extract<ScreenComponent, { type: 'metric' }>; theme: ScreenTheme }) {
+function MetricComponent({
+  component,
+  theme,
+  ...interaction
+}: {
+  component: Extract<ScreenComponent, { type: 'metric' }>;
+  theme: ScreenTheme;
+} & ComponentInteraction) {
   const data = component.data;
   const direction = data?.trendDirection ?? 'flat';
   const trendColor = direction === 'up' ? '#22c55e' : direction === 'down' ? '#f43f5e' : theme.mutedTextColor;
   const trendPrefix = direction === 'up' ? '↑' : direction === 'down' ? '↓' : '→';
 
   return (
-    <ComponentFrame component={component} theme={theme}>
+    <ComponentFrame component={component} theme={theme} {...interaction}>
       <div className="flex h-full min-h-0 flex-col justify-center">
         <div className="flex items-end gap-2">
           <span
@@ -208,10 +229,17 @@ function MetricComponent({ component, theme }: { component: Extract<ScreenCompon
   );
 }
 
-function TableComponent({ component, theme }: { component: ScreenTableComponent; theme: ScreenTheme }) {
+function TableComponent({
+  component,
+  theme,
+  ...interaction
+}: {
+  component: ScreenTableComponent;
+  theme: ScreenTheme;
+} & ComponentInteraction) {
   const data = component.data;
   return (
-    <ComponentFrame component={component} theme={theme}>
+    <ComponentFrame component={component} theme={theme} {...interaction}>
       {!data ? (
         <div className="flex h-full items-center justify-center text-[13px]" style={{ color: theme.mutedTextColor }}>
           暂无预览数据
@@ -262,23 +290,27 @@ function TableComponent({ component, theme }: { component: ScreenTableComponent;
   );
 }
 
-function renderScreenComponent(component: ScreenComponent, theme: ScreenTheme) {
+function renderScreenComponent(
+  component: ScreenComponent,
+  theme: ScreenTheme,
+  interaction: ComponentInteraction,
+) {
   switch (component.type) {
     case 'metric':
-      return <MetricComponent component={component} theme={theme} />;
+      return <MetricComponent component={component} theme={theme} {...interaction} />;
     case 'line':
     case 'bar':
     case 'pie':
       return (
-        <ComponentFrame component={component} theme={theme}>
+        <ComponentFrame component={component} theme={theme} {...interaction}>
           <ScreenChart component={component} theme={theme} />
         </ComponentFrame>
       );
     case 'table':
-      return <TableComponent component={component} theme={theme} />;
+      return <TableComponent component={component} theme={theme} {...interaction} />;
     case 'text':
       return (
-        <ComponentFrame component={component} theme={theme}>
+        <ComponentFrame component={component} theme={theme} {...interaction}>
           <div
             className="flex h-full items-center"
             style={{
@@ -309,21 +341,37 @@ const withRuntimeData = (component: ScreenComponent, overrides?: ScreenDataOverr
   return data ? ({ ...component, data } as ScreenComponent) : component;
 };
 
-function RuntimeScreenComponent({ component, theme }: { component: ScreenComponent; theme: ScreenTheme }) {
-  return renderScreenComponent(component, theme);
+function RuntimeScreenComponent({
+  component,
+  theme,
+  selected,
+  onSelect,
+}: {
+  component: ScreenComponent;
+  theme: ScreenTheme;
+} & ComponentInteraction) {
+  return renderScreenComponent(component, theme, { selected, onSelect });
 }
 
 export interface ScreenRendererProps {
   template: ScreenTemplate;
   data?: ScreenDataOverrides;
   className?: string;
+  selectedComponentId?: string;
+  onComponentClick?: (component: ScreenComponent) => void;
 }
 
 /**
  * Renders the fixed design canvas and scales it to the available width. Layout,
  * visual style and preview data all come from the template document.
  */
-export function ScreenRenderer({ template, data, className = '' }: ScreenRendererProps) {
+export function ScreenRenderer({
+  template,
+  data,
+  className = '',
+  selectedComponentId,
+  onComponentClick,
+}: ScreenRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
 
@@ -360,13 +408,18 @@ export function ScreenRenderer({ template, data, className = '' }: ScreenRendere
           fontFamily: template.theme.fontFamily,
         }}
       >
-        {template.components.map((component) => (
-          <RuntimeScreenComponent
-            key={component.id}
-            component={withRuntimeData(component, data)}
-            theme={template.theme}
-          />
-        ))}
+        {template.components.map((component) => {
+          const runtimeComponent = withRuntimeData(component, data);
+          return (
+            <RuntimeScreenComponent
+              key={component.id}
+              component={runtimeComponent}
+              theme={template.theme}
+              selected={component.id === selectedComponentId}
+              onSelect={onComponentClick ? () => onComponentClick(runtimeComponent) : undefined}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/digital-screen/DataBindingPanel.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/DataBindingPanel.tsx
@@ -1,0 +1,300 @@
+import type { ScreenAggregation, ScreenComponent } from '@/components/screen-engine';
+import type { DatasetField, PublishedDataset } from '@/components/analysis/model';
+import { Button, Select, Spin } from 'antd';
+import { Database, Plus, Trash2, Unlink } from 'lucide-react';
+import type { DigitalScreenComponentBinding } from './model';
+import {
+  SCREEN_AGGREGATION_LABELS,
+  isBindableScreenComponent,
+} from './screen-data-service';
+
+const COMPONENT_LABELS: Record<ScreenComponent['type'], string> = {
+  metric: '指标卡',
+  line: '折线图',
+  bar: '柱状图',
+  pie: '饼图',
+  table: '表格',
+  text: '文本',
+};
+
+const aggregationOptions = Object.entries(SCREEN_AGGREGATION_LABELS).map(([value, label]) => ({
+  value: value as ScreenAggregation,
+  label,
+}));
+
+const defaultAggregation = (field?: DatasetField): ScreenAggregation => (
+  field?.dataType === 'number' ? 'SUM' : 'COUNT'
+);
+
+export interface DataBindingPanelProps {
+  component?: ScreenComponent;
+  binding?: DigitalScreenComponentBinding;
+  datasets: PublishedDataset[];
+  datasetsLoading?: boolean;
+  datasetsError?: string;
+  querying?: boolean;
+  queryError?: string;
+  onChange: (binding?: DigitalScreenComponentBinding) => void;
+}
+
+export function DataBindingPanel({
+  component,
+  binding,
+  datasets,
+  datasetsLoading = false,
+  datasetsError,
+  querying = false,
+  queryError,
+  onChange,
+}: DataBindingPanelProps) {
+  if (!component) {
+    return (
+      <div className="rounded-[7px] border border-dashed border-[#dfe2e6] px-4 py-5 text-center">
+        <div className="text-[12px] font-medium text-[#667085]">请选择一个组件</div>
+        <div className="mt-1 text-[11px] leading-[18px] text-[#a3a8b0]">
+          点击左侧大屏中的图表或指标卡进行数据绑定。
+        </div>
+      </div>
+    );
+  }
+
+  if (!isBindableScreenComponent(component)) {
+    return (
+      <div className="rounded-[7px] bg-[#f6f7f8] px-4 py-4 text-[12px] leading-5 text-[#8a9099]">
+        文本组件由模板负责展示，不需要绑定数据集。
+      </div>
+    );
+  }
+
+  const dataset = datasets.find((item) => item.id === binding?.datasetId);
+  const fields = dataset?.fields ?? [];
+  const dimensionLimit = component.type === 'table' ? undefined : 1;
+  const metricLimit = component.type === 'line' || component.type === 'bar' || component.type === 'table'
+    ? 4
+    : 1;
+  const dimensionOptions = fields.map((field) => ({
+    value: field.key,
+    label: `${field.label} · ${field.dataType}`,
+  }));
+
+  const updateDimensions = (values: string[]) => {
+    if (!binding) return;
+    onChange({
+      ...binding,
+      dimensions: dimensionLimit ? values.slice(0, dimensionLimit) : values,
+    });
+  };
+
+  const updateMetric = (
+    index: number,
+    patch: Partial<DigitalScreenComponentBinding['metrics'][number]>,
+  ) => {
+    if (!binding) return;
+    onChange({
+      ...binding,
+      metrics: binding.metrics.map((metric, metricIndex) => (
+        metricIndex === index ? { ...metric, ...patch } : metric
+      )),
+    });
+  };
+
+  const addMetric = () => {
+    if (!binding || binding.metrics.length >= metricLimit) return;
+    const used = new Set(binding.metrics.map((metric) => metric.field));
+    const candidate = fields.find((field) => field.role === 'metric' && !used.has(field.key))
+      || fields.find((field) => !used.has(field.key));
+    if (!candidate) return;
+    onChange({
+      ...binding,
+      metrics: [...binding.metrics, {
+        field: candidate.key,
+        aggregation: defaultAggregation(candidate),
+      }],
+    });
+  };
+
+  const removeMetric = (index: number) => {
+    if (!binding) return;
+    onChange({
+      ...binding,
+      metrics: binding.metrics.filter((_, metricIndex) => metricIndex !== index),
+    });
+  };
+
+  return (
+    <div>
+      <div className="rounded-[7px] bg-[#f6f7f8] px-3 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-[12px] font-medium text-[#444950]">
+              {component.title || component.id}
+            </div>
+            <div className="mt-1 text-[11px] text-[#98a2b3]">
+              {COMPONENT_LABELS[component.type]} · {component.id}
+            </div>
+          </div>
+          {querying ? <Spin size="small" /> : null}
+        </div>
+      </div>
+
+      <label className="mt-4 block text-[12px] text-[#667085]">
+        数据集
+        <Select
+          allowClear
+          showSearch
+          loading={datasetsLoading}
+          value={binding?.datasetId}
+          className="mt-2 w-full"
+          variant="filled"
+          placeholder="选择已上线数据集"
+          optionFilterProp="label"
+          options={datasets.map((item) => ({
+            value: item.id,
+            label: item.name,
+          }))}
+          onChange={(datasetId?: string) => {
+            if (!datasetId) {
+              onChange(undefined);
+              return;
+            }
+            onChange({ datasetId, dimensions: [], metrics: [] });
+          }}
+        />
+      </label>
+
+      {datasetsError ? (
+        <div className="mt-2 rounded-[6px] bg-[#fff4f4] px-3 py-2 text-[11px] leading-5 text-[#c93b3b]">
+          {datasetsError}
+        </div>
+      ) : null}
+
+      {binding && dataset ? (
+        <>
+          {component.type !== 'metric' ? (
+            <label className="mt-4 block text-[12px] text-[#667085]">
+              {component.type === 'table' ? '维度' : '维度（最多 1 个）'}
+              <Select
+                mode="multiple"
+                allowClear
+                showSearch
+                value={binding.dimensions}
+                className="mt-2 w-full"
+                variant="filled"
+                placeholder="选择维度字段"
+                optionFilterProp="label"
+                options={dimensionOptions}
+                onChange={updateDimensions}
+              />
+            </label>
+          ) : null}
+
+          <div className="mt-4">
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] text-[#667085]">指标</span>
+              <Button
+                type="text"
+                size="small"
+                icon={<Plus size={13} />}
+                disabled={!fields.length || binding.metrics.length >= metricLimit}
+                onClick={addMetric}
+                className="px-1 text-[11px]"
+              >
+                添加
+              </Button>
+            </div>
+
+            <div className="mt-2 space-y-2">
+              {binding.metrics.map((metric, index) => {
+                const currentField = fields.find((field) => field.key === metric.field);
+                const used = new Set(binding.metrics
+                  .filter((_, metricIndex) => metricIndex !== index)
+                  .map((item) => item.field));
+                return (
+                  <div key={`${index}-${metric.field}`} className="rounded-[7px] border border-[#eceef1] p-2">
+                    <div className="flex items-center gap-2">
+                      <Select
+                        showSearch
+                        value={metric.field}
+                        className="min-w-0 flex-1"
+                        variant="filled"
+                        optionFilterProp="label"
+                        options={fields.map((field) => ({
+                          value: field.key,
+                          label: `${field.label} · ${field.dataType}`,
+                          disabled: used.has(field.key),
+                        }))}
+                        onChange={(fieldId: string) => {
+                          const field = fields.find((item) => item.key === fieldId);
+                          updateMetric(index, {
+                            field: fieldId,
+                            aggregation: defaultAggregation(field),
+                          });
+                        }}
+                      />
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<Trash2 size={13} />}
+                        onClick={() => removeMetric(index)}
+                      />
+                    </div>
+                    <Select
+                      value={metric.aggregation}
+                      className="mt-2 w-full"
+                      variant="filled"
+                      options={aggregationOptions}
+                      onChange={(aggregation: ScreenAggregation) => updateMetric(index, { aggregation })}
+                    />
+                    {currentField && currentField.dataType !== 'number' && metric.aggregation !== 'COUNT' && metric.aggregation !== 'COUNT_DISTINCT' ? (
+                      <div className="mt-1 text-[10px] leading-4 text-[#c27b2b]">
+                        非数值字段建议使用计数或去重计数。
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+
+              {!binding.metrics.length ? (
+                <button
+                  type="button"
+                  onClick={addMetric}
+                  className="flex w-full items-center justify-center gap-1 rounded-[7px] border border-dashed border-[#dfe2e6] bg-white py-3 text-[11px] text-[#8a9099] hover:bg-[#fafafa]"
+                >
+                  <Plus size={13} /> 添加指标
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="mt-4 flex items-center justify-between rounded-[7px] bg-[#f8f9fa] px-3 py-2.5">
+            <div className="flex min-w-0 items-center gap-2 text-[11px] text-[#667085]">
+              <Database size={13} />
+              <span className="truncate">{dataset.name}</span>
+            </div>
+            <Button
+              type="text"
+              size="small"
+              icon={<Unlink size={12} />}
+              className="px-1 text-[11px] text-[#8a9099]"
+              onClick={() => onChange(undefined)}
+            >
+              清除
+            </Button>
+          </div>
+
+          {queryError ? (
+            <div className="mt-2 rounded-[6px] bg-[#fff4f4] px-3 py-2 text-[11px] leading-5 text-[#c93b3b]">
+              {queryError}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+
+      {binding && !dataset && !datasetsLoading ? (
+        <div className="mt-3 rounded-[6px] bg-[#fff8eb] px-3 py-2 text-[11px] leading-5 text-[#a66a16]">
+          原绑定的数据集已下线或不存在，请重新选择数据集。
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/digital-screen/editor.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/editor.tsx
@@ -1,24 +1,50 @@
-import { ScreenRenderer, getScreenTemplateById } from '@/components/screen-engine';
+import {
+  ScreenRenderer,
+  getScreenTemplateById,
+} from '@/components/screen-engine';
+import type { PublishedDataset } from '@/components/analysis/model';
 import { history, useParams } from '@umijs/max';
 import { Button, Input, message } from 'antd';
 import { ArrowLeft, Database, Eye, Save, Send } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
-import type { DigitalScreenInstance } from './model';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { DataBindingPanel } from './DataBindingPanel';
+import type {
+  DigitalScreenBindings,
+  DigitalScreenComponentBinding,
+  DigitalScreenInstance,
+} from './model';
+import { fetchDigitalScreenDatasets } from './screen-data-service';
 import {
   fetchDigitalScreen,
   publishDigitalScreen,
   unpublishDigitalScreen,
   updateDigitalScreen,
 } from './screen-service';
+import { useScreenRuntimeData } from './use-screen-data';
 
 export default function DigitalScreenEditorPage() {
   const { id } = useParams<{ id: string }>();
   const [screen, setScreen] = useState<DigitalScreenInstance>();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [bindings, setBindings] = useState<DigitalScreenBindings>({});
+  const [selectedComponentId, setSelectedComponentId] = useState<string>();
+  const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
+  const [datasetsLoading, setDatasetsLoading] = useState(true);
+  const [datasetsError, setDatasetsError] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
+
+  const template = useMemo(
+    () => (screen ? getScreenTemplateById(screen.templateId) : undefined),
+    [screen],
+  );
+  const selectedComponent = useMemo(
+    () => template?.components.find((component) => component.id === selectedComponentId),
+    [template, selectedComponentId],
+  );
+  const runtime = useScreenRuntimeData(template, bindings, datasets);
 
   const loadScreen = useCallback(async () => {
     if (!id) return;
@@ -28,6 +54,7 @@ export default function DigitalScreenEditorPage() {
       setScreen(detail);
       setName(detail.name);
       setDescription(detail.description || '');
+      setBindings(detail.bindings || {});
     } catch (error) {
       message.error(error instanceof Error ? error.message : '加载数字化大屏失败');
     } finally {
@@ -39,6 +66,35 @@ export default function DigitalScreenEditorPage() {
     void loadScreen();
   }, [loadScreen]);
 
+  useEffect(() => {
+    let active = true;
+    setDatasetsLoading(true);
+    setDatasetsError('');
+    void fetchDigitalScreenDatasets()
+      .then((values) => {
+        if (active) setDatasets(values);
+      })
+      .catch((error) => {
+        if (!active) return;
+        setDatasets([]);
+        setDatasetsError(error instanceof Error ? error.message : '加载 Dataset 失败');
+      })
+      .finally(() => {
+        if (active) setDatasetsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!template) return;
+    if (selectedComponentId && template.components.some((component) => component.id === selectedComponentId)) return;
+    const preferred = template.components.find((component) => component.type !== 'text')
+      || template.components[0];
+    setSelectedComponentId(preferred?.id);
+  }, [template?.id, selectedComponentId]);
+
   const save = async (showMessage = true) => {
     if (!id) return undefined;
     if (!name.trim()) {
@@ -48,8 +104,9 @@ export default function DigitalScreenEditorPage() {
 
     setSaving(true);
     try {
-      const updated = await updateDigitalScreen(id, { name, description });
+      const updated = await updateDigitalScreen(id, { name, description, bindings });
       setScreen(updated);
+      setBindings(updated.bindings);
       if (showMessage) message.success('大屏已保存');
       return updated;
     } catch (error) {
@@ -78,6 +135,16 @@ export default function DigitalScreenEditorPage() {
     }
   };
 
+  const updateSelectedBinding = (next?: DigitalScreenComponentBinding) => {
+    if (!selectedComponent) return;
+    setBindings((current) => {
+      const result = { ...current };
+      if (next) result[selectedComponent.id] = next;
+      else delete result[selectedComponent.id];
+      return result;
+    });
+  };
+
   if (loading) {
     return (
       <div className="flex h-screen items-center justify-center bg-[#f4f5f6] text-[13px] text-[#98a2b3]">
@@ -95,10 +162,16 @@ export default function DigitalScreenEditorPage() {
     );
   }
 
-  const template = getScreenTemplateById(screen.templateId);
+  const bindableCount = template?.components.filter((component) => component.type !== 'text').length ?? 0;
+  const selectedQuerying = selectedComponent
+    ? runtime.loadingIds.includes(selectedComponent.id)
+    : false;
+  const selectedQueryError = selectedComponent
+    ? runtime.errors[selectedComponent.id]
+    : undefined;
 
   return (
-    <div className="flex h-screen min-w-[1100px] flex-col overflow-hidden bg-[#f4f5f6] text-[#161823]">
+    <div className="flex h-screen min-w-[1180px] flex-col overflow-hidden bg-[#f4f5f6] text-[#161823]">
       <header className="flex h-14 shrink-0 items-center justify-between border-b border-[#e5e7ea] bg-white px-4">
         <div className="flex min-w-0 items-center gap-2">
           <Button
@@ -122,6 +195,12 @@ export default function DigitalScreenEditorPage() {
           ].join(' ')}>
             {screen.status === 'published' ? '已发布' : '草稿'}
           </span>
+          <span className="ml-1 text-[11px] text-[#98a2b3]">
+            已绑定 {runtime.boundCount}/{bindableCount}
+          </span>
+          {runtime.loadingCount ? (
+            <span className="text-[11px] text-[#8a9099]">正在刷新数据...</span>
+          ) : null}
         </div>
 
         <div className="flex items-center gap-2">
@@ -150,7 +229,12 @@ export default function DigitalScreenEditorPage() {
           <div className="mx-auto flex min-h-full max-w-[1400px] items-center justify-center">
             {template ? (
               <div className="w-full overflow-hidden border border-[#dfe2e6] bg-[#111827]">
-                <ScreenRenderer template={template} />
+                <ScreenRenderer
+                  template={template}
+                  data={runtime.data}
+                  selectedComponentId={selectedComponentId}
+                  onComponentClick={(component) => setSelectedComponentId(component.id)}
+                />
               </div>
             ) : (
               <div className="flex h-[420px] w-full items-center justify-center border border-[#e0e3e7] bg-white text-[13px] text-[#98a2b3]">
@@ -160,7 +244,7 @@ export default function DigitalScreenEditorPage() {
           </div>
         </main>
 
-        <aside className="w-[320px] shrink-0 overflow-y-auto border-l border-[#e5e7ea] bg-white">
+        <aside className="w-[360px] shrink-0 overflow-y-auto border-l border-[#e5e7ea] bg-white">
           <section className="border-b border-[#eceef1] px-5 py-5">
             <div className="text-[13px] font-semibold text-[#161823]">大屏设置</div>
             <label className="mt-4 block text-[12px] text-[#667085]">
@@ -196,19 +280,28 @@ export default function DigitalScreenEditorPage() {
               </div>
             </div>
             <div className="mt-2 text-[11px] leading-[18px] text-[#a3a8b0]">
-              创建后固定模板布局，避免数据配置阶段意外改变整体设计。
+              布局由模板固定。点击左侧组件后，只配置它消费的数据，不修改模板设计。
             </div>
           </section>
 
           <section className="px-5 py-5">
-            <div className="flex items-center gap-2 text-[13px] font-semibold text-[#161823]">
-              <Database size={14} /> 数据绑定
-            </div>
-            <div className="mt-4 rounded-[7px] border border-dashed border-[#dfe2e6] px-4 py-5 text-center">
-              <div className="text-[12px] font-medium text-[#667085]">暂未绑定数据集</div>
-              <div className="mt-1 text-[11px] leading-[18px] text-[#a3a8b0]">
-                下一阶段将在这里为模板组件选择数据集、维度和指标。
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 text-[13px] font-semibold text-[#161823]">
+                <Database size={14} /> 数据绑定
               </div>
+              <span className="text-[10px] text-[#a3a8b0]">{datasets.length} 个可用 Dataset</span>
+            </div>
+            <div className="mt-4">
+              <DataBindingPanel
+                component={selectedComponent}
+                binding={selectedComponent ? bindings[selectedComponent.id] : undefined}
+                datasets={datasets}
+                datasetsLoading={datasetsLoading}
+                datasetsError={datasetsError}
+                querying={selectedQuerying}
+                queryError={selectedQueryError}
+                onChange={updateSelectedBinding}
+              />
             </div>
           </section>
         </aside>

--- a/yak-ops-ui/src/pages/digital-screen/model.ts
+++ b/yak-ops-ui/src/pages/digital-screen/model.ts
@@ -1,4 +1,19 @@
+import type { ScreenAggregation } from '@/components/screen-engine';
+
 export type DigitalScreenStatus = 'draft' | 'published';
+
+export interface DigitalScreenMetricBinding {
+  field: string;
+  aggregation: ScreenAggregation;
+}
+
+export interface DigitalScreenComponentBinding {
+  datasetId: string;
+  dimensions: string[];
+  metrics: DigitalScreenMetricBinding[];
+}
+
+export type DigitalScreenBindings = Record<string, DigitalScreenComponentBinding>;
 
 export interface DigitalScreenInstance {
   id: string;
@@ -7,6 +22,7 @@ export interface DigitalScreenInstance {
   templateId: string;
   templateVersion: 1;
   status: DigitalScreenStatus;
+  bindings: DigitalScreenBindings;
   createdAt: string;
   updatedAt: string;
   publishedAt?: string;
@@ -16,9 +32,11 @@ export interface CreateDigitalScreenInput {
   name: string;
   description?: string;
   templateId: string;
+  bindings?: DigitalScreenBindings;
 }
 
 export interface UpdateDigitalScreenInput {
   name?: string;
   description?: string;
+  bindings?: DigitalScreenBindings;
 }

--- a/yak-ops-ui/src/pages/digital-screen/screen-data-service.ts
+++ b/yak-ops-ui/src/pages/digital-screen/screen-data-service.ts
@@ -1,0 +1,194 @@
+import type {
+  ScreenComponent,
+  ScreenComponentData,
+} from '@/components/screen-engine';
+import {
+  fetchAnalysisDatasets,
+  queryAnalysisDataset,
+} from '@/components/analysis/dataset-service';
+import type {
+  Aggregation,
+  DatasetQueryPayload,
+  DatasetQueryResult,
+  PublishedDataset,
+  Scalar,
+} from '@/components/analysis/model';
+import type { DigitalScreenComponentBinding } from './model';
+
+export const fetchDigitalScreenDatasets = fetchAnalysisDatasets;
+
+export const SCREEN_AGGREGATION_LABELS: Record<Aggregation, string> = {
+  SUM: '求和',
+  AVG: '平均',
+  COUNT: '计数',
+  COUNT_DISTINCT: '去重计数',
+  MAX: '最大值',
+  MIN: '最小值',
+};
+
+export const isBindableScreenComponent = (component?: ScreenComponent) => Boolean(
+  component && component.type !== 'text',
+);
+
+export const canQueryScreenComponent = (
+  component: ScreenComponent,
+  binding?: DigitalScreenComponentBinding,
+) => {
+  if (!binding?.datasetId) return false;
+  if (component.type === 'text') return false;
+  if (component.type === 'metric') return binding.metrics.length === 1;
+  if (component.type === 'table') return binding.dimensions.length > 0 || binding.metrics.length > 0;
+  return binding.dimensions.length > 0 && binding.metrics.length > 0;
+};
+
+export const buildScreenDatasetQueryPayload = (
+  component: ScreenComponent,
+  binding: DigitalScreenComponentBinding,
+): DatasetQueryPayload => ({
+  dimensions: component.type === 'metric' ? [] : binding.dimensions,
+  metrics: binding.metrics.map((metric) => ({
+    fieldId: metric.field,
+    aggregation: metric.aggregation,
+  })),
+  filters: [],
+  sorts: [],
+  limit: component.type === 'table' ? 100 : 200,
+  timeoutSeconds: 30,
+});
+
+const bindingIndex = (
+  result: DatasetQueryResult,
+  fieldId: string,
+  aggregation?: Aggregation,
+) => result.bindings.findIndex((item) => (
+  item.fieldId === fieldId
+  && (aggregation ? item.aggregation === aggregation : !item.aggregation)
+));
+
+const cell = (
+  result: DatasetQueryResult,
+  row: Scalar[],
+  fieldId: string,
+  aggregation?: Aggregation,
+) => {
+  const index = bindingIndex(result, fieldId, aggregation);
+  return index >= 0 ? row[index] : null;
+};
+
+const numericCell = (
+  result: DatasetQueryResult,
+  row: Scalar[],
+  fieldId: string,
+  aggregation: Aggregation,
+) => {
+  const value = Number(cell(result, row, fieldId, aggregation) ?? 0);
+  return Number.isFinite(value) ? value : 0;
+};
+
+const fieldLabel = (dataset: PublishedDataset, fieldId: string) => (
+  dataset.fields.find((field) => field.key === fieldId)?.label || fieldId
+);
+
+const metricLabel = (
+  dataset: PublishedDataset,
+  metric: DigitalScreenComponentBinding['metrics'][number],
+) => `${fieldLabel(dataset, metric.field)} · ${SCREEN_AGGREGATION_LABELS[metric.aggregation]}`;
+
+const rowLabel = (
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+  row: Scalar[],
+  dimensions: string[],
+) => dimensions.map((fieldId) => {
+  const value = cell(result, row, fieldId);
+  return value == null ? fieldLabel(dataset, fieldId) : String(value);
+}).join(' / ');
+
+export const toScreenComponentData = (
+  component: ScreenComponent,
+  binding: DigitalScreenComponentBinding,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+): ScreenComponentData | undefined => {
+  if (component.type === 'metric') {
+    const metric = binding.metrics[0];
+    if (!metric) return undefined;
+    const row = result.rows[0];
+    return {
+      value: row ? numericCell(result, row, metric.field, metric.aggregation) : 0,
+      trendLabel: `${dataset.name} · DV${result.datasetVersionNo}`,
+    };
+  }
+
+  if (component.type === 'line' || component.type === 'bar') {
+    return {
+      categories: result.rows.map((row) => rowLabel(dataset, result, row, binding.dimensions)),
+      series: binding.metrics.map((metric) => ({
+        name: metricLabel(dataset, metric),
+        values: result.rows.map((row) => numericCell(
+          result,
+          row,
+          metric.field,
+          metric.aggregation,
+        )),
+      })),
+    };
+  }
+
+  if (component.type === 'pie') {
+    const metric = binding.metrics[0];
+    if (!metric) return undefined;
+    return {
+      items: result.rows.map((row) => ({
+        name: rowLabel(dataset, result, row, binding.dimensions),
+        value: numericCell(result, row, metric.field, metric.aggregation),
+      })),
+    };
+  }
+
+  if (component.type === 'table') {
+    const dimensionColumns = binding.dimensions.map((fieldId) => ({
+      key: `dimension:${fieldId}`,
+      title: fieldLabel(dataset, fieldId),
+      align: 'left' as const,
+    }));
+    const metricColumns = binding.metrics.map((metric) => ({
+      key: `metric:${metric.field}:${metric.aggregation}`,
+      title: metricLabel(dataset, metric),
+      align: 'right' as const,
+    }));
+    return {
+      columns: [...dimensionColumns, ...metricColumns],
+      rows: result.rows.map((row) => {
+        const record: Record<string, Scalar> = {};
+        binding.dimensions.forEach((fieldId) => {
+          record[`dimension:${fieldId}`] = cell(result, row, fieldId);
+        });
+        binding.metrics.forEach((metric) => {
+          record[`metric:${metric.field}:${metric.aggregation}`] = cell(
+            result,
+            row,
+            metric.field,
+            metric.aggregation,
+          );
+        });
+        return record;
+      }),
+    };
+  }
+
+  return undefined;
+};
+
+export const queryScreenComponentData = async (
+  component: ScreenComponent,
+  binding: DigitalScreenComponentBinding,
+  dataset: PublishedDataset,
+) => {
+  if (!canQueryScreenComponent(component, binding)) return undefined;
+  const result = await queryAnalysisDataset(
+    dataset.id,
+    buildScreenDatasetQueryPayload(component, binding),
+  );
+  return toScreenComponentData(component, binding, dataset, result);
+};

--- a/yak-ops-ui/src/pages/digital-screen/screen-service.ts
+++ b/yak-ops-ui/src/pages/digital-screen/screen-service.ts
@@ -1,6 +1,7 @@
 import { getScreenTemplateById } from '@/components/screen-engine';
 import type {
   CreateDigitalScreenInput,
+  DigitalScreenBindings,
   DigitalScreenInstance,
   UpdateDigitalScreenInput,
 } from './model';
@@ -16,6 +17,11 @@ const createId = () => {
   return `screen-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 };
 
+const normalizeBindings = (value: unknown): DigitalScreenBindings => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as DigitalScreenBindings;
+};
+
 const readScreens = (): DigitalScreenInstance[] => {
   if (typeof window === 'undefined') return [];
   try {
@@ -23,13 +29,19 @@ const readScreens = (): DigitalScreenInstance[] => {
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter((item): item is DigitalScreenInstance => Boolean(
-      item
-      && typeof item === 'object'
-      && typeof (item as DigitalScreenInstance).id === 'string'
-      && typeof (item as DigitalScreenInstance).name === 'string'
-      && typeof (item as DigitalScreenInstance).templateId === 'string',
-    ));
+    return parsed.flatMap((item) => {
+      if (!item || typeof item !== 'object') return [];
+      const candidate = item as Partial<DigitalScreenInstance>;
+      if (
+        typeof candidate.id !== 'string'
+        || typeof candidate.name !== 'string'
+        || typeof candidate.templateId !== 'string'
+      ) return [];
+      return [{
+        ...candidate,
+        bindings: normalizeBindings(candidate.bindings),
+      } as DigitalScreenInstance];
+    });
   } catch {
     return [];
   }
@@ -65,6 +77,7 @@ export const createDigitalScreen = async (input: CreateDigitalScreenInput) => {
     templateId: input.templateId,
     templateVersion: 1,
     status: 'draft',
+    bindings: input.bindings ?? {},
     createdAt: timestamp,
     updatedAt: timestamp,
   };
@@ -85,6 +98,7 @@ export const updateDigitalScreen = async (id: string, input: UpdateDigitalScreen
       description: input.description === undefined
         ? screen.description
         : input.description.trim() || undefined,
+      bindings: input.bindings === undefined ? screen.bindings : input.bindings,
       updatedAt: now(),
     };
     updated = next;
@@ -141,6 +155,7 @@ export const duplicateDigitalScreen = async (id: string) => {
     name: `${source.name} - 副本`,
     description: source.description,
     templateId: source.templateId,
+    bindings: source.bindings,
   });
 };
 

--- a/yak-ops-ui/src/pages/digital-screen/use-screen-data.ts
+++ b/yak-ops-ui/src/pages/digital-screen/use-screen-data.ts
@@ -1,0 +1,91 @@
+import type { ScreenDataOverrides, ScreenTemplate } from '@/components/screen-engine';
+import type { PublishedDataset } from '@/components/analysis/model';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { DigitalScreenBindings } from './model';
+import {
+  canQueryScreenComponent,
+  queryScreenComponentData,
+} from './screen-data-service';
+
+interface ScreenRuntimeDataState {
+  data: ScreenDataOverrides;
+  loadingIds: string[];
+  errors: Record<string, string>;
+}
+
+const EMPTY_STATE: ScreenRuntimeDataState = {
+  data: {},
+  loadingIds: [],
+  errors: {},
+};
+
+export const useScreenRuntimeData = (
+  template: ScreenTemplate | undefined,
+  bindings: DigitalScreenBindings,
+  datasets: PublishedDataset[],
+) => {
+  const [state, setState] = useState<ScreenRuntimeDataState>(EMPTY_STATE);
+  const sequence = useRef(0);
+  const bindingKey = useMemo(() => JSON.stringify(bindings), [bindings]);
+  const datasetKey = useMemo(
+    () => datasets.map((dataset) => `${dataset.id}:${dataset.currentVersionNo ?? ''}`).join('|'),
+    [datasets],
+  );
+
+  useEffect(() => {
+    if (!template) {
+      setState(EMPTY_STATE);
+      return undefined;
+    }
+
+    const candidates = template.components.flatMap((component) => {
+      const binding = bindings[component.id];
+      if (!binding || !canQueryScreenComponent(component, binding)) return [];
+      const dataset = datasets.find((item) => item.id === binding.datasetId);
+      if (!dataset) return [];
+      return [{ component, binding, dataset }];
+    });
+
+    if (!candidates.length) {
+      setState(EMPTY_STATE);
+      return undefined;
+    }
+
+    const requestId = ++sequence.current;
+    const loadingIds = candidates.map(({ component }) => component.id);
+    setState({ data: {}, loadingIds, errors: {} });
+
+    const timer = window.setTimeout(async () => {
+      const results = await Promise.allSettled(candidates.map(async ({ component, binding, dataset }) => ({
+        componentId: component.id,
+        data: await queryScreenComponentData(component, binding, dataset),
+      })));
+      if (requestId !== sequence.current) return;
+
+      const data: ScreenDataOverrides = {};
+      const errors: Record<string, string> = {};
+      results.forEach((result, index) => {
+        const componentId = candidates[index].component.id;
+        if (result.status === 'fulfilled') {
+          if (result.value.data) data[result.value.componentId] = result.value.data;
+          return;
+        }
+        errors[componentId] = result.reason instanceof Error
+          ? result.reason.message
+          : 'Dataset 查询失败';
+      });
+      setState({ data, loadingIds: [], errors });
+    }, 180);
+
+    return () => {
+      window.clearTimeout(timer);
+      if (sequence.current === requestId) sequence.current += 1;
+    };
+  }, [template?.id, bindingKey, datasetKey]);
+
+  return {
+    ...state,
+    loadingCount: state.loadingIds.length,
+    boundCount: template?.components.filter((component) => Boolean(bindings[component.id])).length ?? 0,
+  };
+};

--- a/yak-ops-ui/src/pages/digital-screen/viewer.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/viewer.tsx
@@ -1,14 +1,21 @@
 import { ScreenRenderer, getScreenTemplateById } from '@/components/screen-engine';
+import type { PublishedDataset } from '@/components/analysis/model';
 import { history, useParams } from '@umijs/max';
 import { Button, message } from 'antd';
 import { ArrowLeft, Pencil } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import type { DigitalScreenInstance } from './model';
+import type { DigitalScreenBindings, DigitalScreenInstance } from './model';
+import { fetchDigitalScreenDatasets } from './screen-data-service';
 import { fetchDigitalScreen } from './screen-service';
+import { useScreenRuntimeData } from './use-screen-data';
+
+const EMPTY_BINDINGS: DigitalScreenBindings = {};
 
 export default function DigitalScreenViewerPage() {
   const { id } = useParams<{ id: string }>();
   const [screen, setScreen] = useState<DigitalScreenInstance>();
+  const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
+  const [dataError, setDataError] = useState('');
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -20,10 +27,28 @@ export default function DigitalScreenViewerPage() {
       .finally(() => setLoading(false));
   }, [id]);
 
+  useEffect(() => {
+    let active = true;
+    setDataError('');
+    void fetchDigitalScreenDatasets()
+      .then((values) => {
+        if (active) setDatasets(values);
+      })
+      .catch((error) => {
+        if (!active) return;
+        setDatasets([]);
+        setDataError(error instanceof Error ? error.message : '加载 Dataset 失败');
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const template = useMemo(
     () => (screen ? getScreenTemplateById(screen.templateId) : undefined),
     [screen],
   );
+  const runtime = useScreenRuntimeData(template, screen?.bindings ?? EMPTY_BINDINGS, datasets);
 
   if (loading) {
     return (
@@ -43,6 +68,7 @@ export default function DigitalScreenViewerPage() {
   }
 
   const ratio = template.width / template.height;
+  const runtimeErrors = Object.values(runtime.errors);
 
   return (
     <div className="group relative flex h-screen w-screen items-center justify-center overflow-hidden bg-[#070b13]">
@@ -50,7 +76,7 @@ export default function DigitalScreenViewerPage() {
         className="max-h-screen max-w-screen"
         style={{ width: `min(100vw, calc(100vh * ${ratio}))` }}
       >
-        <ScreenRenderer template={template} />
+        <ScreenRenderer template={template} data={runtime.data} />
       </div>
 
       <div className="absolute left-4 top-4 flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100">
@@ -69,6 +95,18 @@ export default function DigitalScreenViewerPage() {
           编辑
         </Button>
       </div>
+
+      {runtime.loadingCount ? (
+        <div className="absolute right-4 top-4 rounded-[4px] bg-black/40 px-2.5 py-1.5 text-[10px] text-white/55 backdrop-blur">
+          正在刷新 {runtime.loadingCount} 个组件的数据...
+        </div>
+      ) : null}
+
+      {dataError || runtimeErrors.length ? (
+        <div className="absolute bottom-4 left-1/2 max-w-[560px] -translate-x-1/2 rounded-[6px] bg-black/55 px-3 py-2 text-[10px] leading-5 text-white/65 opacity-0 backdrop-blur transition-opacity group-hover:opacity-100">
+          {dataError || `${runtimeErrors.length} 个组件的数据查询失败：${runtimeErrors[0]}`}
+        </div>
+      ) : null}
 
       <div className="absolute bottom-3 right-4 rounded-[4px] bg-black/35 px-2 py-1 text-[10px] text-white/35 opacity-0 transition-opacity group-hover:opacity-100">
         {screen.name}


### PR DESCRIPTION
## Overview

实现数字化大屏第三阶段：数据集绑定。基于第二阶段的大屏创建/编辑流程，直接复用 Yak Ops 已有 Dataset 查询能力，让模板组件可以绑定真实数据并在编辑器和全屏预览中实时渲染。

> Stacked on Draft PR #484 (`feat/digital-screen-phase-2`). 本 PR 的 base 暂时指向第二阶段分支，确保 review 时只看到第三阶段“数据集绑定”的增量；第二阶段合并后可再 retarget 到 `main`。

## What changed

- 大屏实例新增组件级 `bindings`
  - 绑定关系按 `componentId` 保存
  - 模板本身不保存真实 Dataset ID，保持模板可复用
  - 兼容第二阶段已创建的旧大屏，自动补齐空绑定
  - 复制大屏时同步复制绑定关系
- 直接复用现有 Dataset 能力
  - `fetchAnalysisDatasets()` 获取已上线 Dataset 和字段
  - `/api/v1/datasets/{id}/query` 执行维度/指标/聚合查询
- 新增组件数据绑定面板
  - 选择 Dataset
  - 选择维度
  - 添加指标
  - 为每个指标设置 SUM / AVG / COUNT / COUNT_DISTINCT / MAX / MIN
  - 支持清除绑定
  - Dataset / Query 错误提示
- 按组件类型生成查询
  - 指标卡：1 个指标
  - 折线图 / 柱状图：1 个维度 + 多个指标
  - 饼图：1 个维度 + 1 个指标
  - 表格：多个维度 + 多个指标
- 新增 Dataset Query -> ScreenRenderer 数据转换
  - metric -> value
  - line / bar -> categories + series
  - pie -> items
  - table -> columns + rows
- ScreenRenderer 增加组件点击选中能力
  - 编辑模式下点击画布组件即可切换右侧绑定配置
  - 当前组件使用 Yak 品牌红描边标识
- 编辑器实时刷新
  - 绑定配置变更后自动查询 Dataset
  - 查询结果直接覆盖模板预览数据
  - 顶部展示已绑定组件数和刷新状态
- 全屏 Viewer 使用真实绑定数据
  - 打开大屏时自动加载 Dataset 并查询所有已配置组件
  - 查询失败时保留页面并提供轻量错误提示

## Architecture

`ScreenTemplate` 继续只负责布局和视觉；真实数据关系保存在 `DigitalScreenInstance.bindings`：

`Template + Component Binding + Dataset Query Result -> ScreenRenderer`

这样同一份官方模板可以被多张大屏重复使用，每个实例绑定完全不同的数据集，同时不会污染模板定义。

## Persistence

第三阶段仍沿用第二阶段的 `localStorage` 大屏实例持久化，但 `bindings` 已纳入实例模型。后续切换服务端持久化时，只需要替换 `screen-service.ts`，组件绑定协议和页面交互可以保持不变。

## Scope

本 PR 暂不包含：

- 组件过滤条件
- 排序 / Top N 配置
- 数据刷新周期配置
- Dataset 参数 / 联动筛选
- 服务端大屏实例表与 API
- 模板管理后台

这些可以作为后续增强阶段逐步补充。

## Verification

- 已确认相对第二阶段分支仅包含 8 个文件的第三阶段增量
- 已对齐仓库现有 `PublishedDataset` / `DatasetQueryPayload` / `DatasetQueryResult` 类型和 Dataset Query API
- 已人工检查旧实例迁移、绑定持久化、查询条件生成、查询结果转换、编辑器实时刷新和 Viewer 数据加载路径
- 当前执行容器无法解析 `github.com`，无法 clone 仓库执行完整 `npm run tsc` / `npm run build`；建议以 PR CI 或本地工程校验作为最终验证

## User flow

`数字化大屏 -> 编辑 -> 点击组件 -> 选择 Dataset -> 配置维度/指标/聚合 -> 实时预览 -> 保存/发布 -> 全屏展示真实数据`
