### PR TITLE
feat: add digital screen template management

### DIFF
--- a/yak-ops-ui/src/pages/digital-screen/editor.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/editor.tsx
@@ -1,8 +1,6 @@
-import {
-  ScreenRenderer,
-  getScreenTemplateById,
-} from '@/components/screen-engine';
 import type { PublishedDataset } from '@/components/analysis/model';
+import { ScreenRenderer } from '@/components/screen-engine';
+import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import { history, useParams } from '@umijs/max';
 import { Button, Input, message } from 'antd';
 import { ArrowLeft, Database, Eye, Save, Send } from 'lucide-react';
@@ -37,7 +35,7 @@ export default function DigitalScreenEditorPage() {
   const [publishing, setPublishing] = useState(false);
 
   const template = useMemo(
-    () => (screen ? getScreenTemplateById(screen.templateId) : undefined),
+    () => (screen ? resolveScreenTemplateById(screen.templateId) : undefined),
     [screen],
   );
   const selectedComponent = useMemo(

--- a/yak-ops-ui/src/pages/digital-screen/index.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/index.tsx
@@ -1,4 +1,5 @@
-import { ScreenRenderer, getScreenTemplateById } from '@/components/screen-engine';
+import { ScreenRenderer } from '@/components/screen-engine';
+import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import { history } from '@umijs/max';
 import { Button, Input, Popconfirm, message } from 'antd';
 import { Copy, Eye, Monitor, Pencil, Plus, Search, Trash2 } from 'lucide-react';
@@ -40,7 +41,7 @@ export default function DigitalScreenListPage() {
     return screens.filter((screen) => {
       if (status !== 'all' && screen.status !== status) return false;
       if (!value) return true;
-      const template = getScreenTemplateById(screen.templateId);
+      const template = resolveScreenTemplateById(screen.templateId);
       return [screen.name, screen.description, template?.name]
         .some((field) => String(field || '').toLowerCase().includes(value));
     });
@@ -151,7 +152,7 @@ export default function DigitalScreenListPage() {
         ) : (
           <div className="grid grid-cols-1 gap-x-5 gap-y-6 pt-5 xl:grid-cols-2 2xl:grid-cols-3">
             {filteredScreens.map((screen) => {
-              const template = getScreenTemplateById(screen.templateId);
+              const template = resolveScreenTemplateById(screen.templateId);
               return (
                 <article
                   key={screen.id}

--- a/yak-ops-ui/src/pages/digital-screen/new.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/new.tsx
@@ -1,16 +1,11 @@
-import {
-  ScreenRenderer,
-  builtinScreenTemplates,
-  listScreenTemplateCategories,
-} from '@/components/screen-engine';
+import { ScreenRenderer } from '@/components/screen-engine';
 import type { ScreenTemplate } from '@/components/screen-engine';
+import { listAvailableScreenTemplates } from '@/services/screen-template-service';
 import { history } from '@umijs/max';
 import { Button, Input, Modal, message } from 'antd';
 import { ArrowLeft, Eye, Search } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { createDigitalScreen } from './screen-service';
-
-const categories = ['全部', ...listScreenTemplateCategories()];
 
 export default function DigitalScreenTemplatePage() {
   const [category, setCategory] = useState('全部');
@@ -21,15 +16,17 @@ export default function DigitalScreenTemplatePage() {
   const [description, setDescription] = useState('');
   const [creating, setCreating] = useState(false);
 
+  const availableTemplates = listAvailableScreenTemplates().map((record) => record.template);
+  const categories = ['全部', ...new Set(availableTemplates.map((template) => template.category))];
   const templates = useMemo(() => {
     const value = keyword.trim().toLowerCase();
-    return builtinScreenTemplates.filter((template) => {
+    return availableTemplates.filter((template) => {
       if (category !== '全部' && template.category !== category) return false;
       if (!value) return true;
       return [template.name, template.description, template.category]
         .some((field) => String(field || '').toLowerCase().includes(value));
     });
-  }, [category, keyword]);
+  }, [availableTemplates, category, keyword]);
 
   const openCreate = (template: ScreenTemplate) => {
     setSelectedTemplate(template);
@@ -110,7 +107,7 @@ export default function DigitalScreenTemplatePage() {
 
         {templates.length === 0 ? (
           <div className="flex h-[380px] items-center justify-center text-[13px] text-[#98a2b3]">
-            没有匹配的大屏模板
+            没有可用的大屏模板
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-x-5 gap-y-6 pt-5 xl:grid-cols-2 2xl:grid-cols-3">

--- a/yak-ops-ui/src/pages/digital-screen/screen-service.ts
+++ b/yak-ops-ui/src/pages/digital-screen/screen-service.ts
@@ -1,4 +1,4 @@
-import { getScreenTemplateById } from '@/components/screen-engine';
+import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import type {
   CreateDigitalScreenInput,
   DigitalScreenBindings,
@@ -67,7 +67,7 @@ export const fetchDigitalScreen = async (id: string) => {
 export const createDigitalScreen = async (input: CreateDigitalScreenInput) => {
   const name = input.name.trim();
   if (!name) throw new Error('请输入大屏名称');
-  if (!getScreenTemplateById(input.templateId)) throw new Error('所选大屏模板不存在');
+  if (!resolveScreenTemplateById(input.templateId)) throw new Error('所选大屏模板不存在');
 
   const timestamp = now();
   const screen: DigitalScreenInstance = {

--- a/yak-ops-ui/src/pages/digital-screen/viewer.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/viewer.tsx
@@ -1,5 +1,6 @@
-import { ScreenRenderer, getScreenTemplateById } from '@/components/screen-engine';
 import type { PublishedDataset } from '@/components/analysis/model';
+import { ScreenRenderer } from '@/components/screen-engine';
+import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import { history, useParams } from '@umijs/max';
 import { Button, message } from 'antd';
 import { ArrowLeft, Pencil } from 'lucide-react';
@@ -45,7 +46,7 @@ export default function DigitalScreenViewerPage() {
   }, []);
 
   const template = useMemo(
-    () => (screen ? getScreenTemplateById(screen.templateId) : undefined),
+    () => (screen ? resolveScreenTemplateById(screen.templateId) : undefined),
     [screen],
   );
   const runtime = useScreenRuntimeData(template, screen?.bindings ?? EMPTY_BINDINGS, datasets);

--- a/yak-ops-ui/src/pages/settings/components/ScreenTemplateSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ScreenTemplateSettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { ScreenRenderer } from '@/components/screen-engine';
 import type { ScreenTemplate } from '@/components/screen-engine';
+import { fetchDigitalScreens } from '@/pages/digital-screen/screen-service';
 import {
   copyManagedScreenTemplate,
   deleteCustomScreenTemplate,
@@ -17,7 +18,6 @@ import type {
 import { Button, Input, Modal, Popconfirm, Select, message } from 'antd';
 import { Copy, Eye, FileJson, Pencil, Plus, Search, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { fetchDigitalScreens } from '@/pages/digital-screen/screen-service';
 
 const statusLabel: Record<ManagedScreenTemplateStatus, string> = {
   draft: '草稿',
@@ -91,9 +91,23 @@ export default function ScreenTemplateSettingsPanel() {
     }
   };
 
-  const openEdit = (record: ManagedScreenTemplate) => {
-    setEditing(record);
-    setEditJson(stringifyScreenTemplate(record.template));
+  const usageCount = async (templateId: string) => {
+    const screens = await fetchDigitalScreens();
+    return screens.filter((screen) => screen.templateId === templateId).length;
+  };
+
+  const openEdit = async (record: ManagedScreenTemplate) => {
+    try {
+      const usage = await usageCount(record.id);
+      if (usage > 0) {
+        message.warning(`当前模板已被 ${usage} 个数字化大屏使用，请先复制模板后再修改`);
+        return;
+      }
+      setEditing(record);
+      setEditJson(stringifyScreenTemplate(record.template));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '检查模板使用情况失败');
+    }
   };
 
   const saveEdit = () => {
@@ -129,8 +143,7 @@ export default function ScreenTemplateSettingsPanel() {
 
   const removeTemplate = async (record: ManagedScreenTemplate) => {
     try {
-      const screens = await fetchDigitalScreens();
-      const usage = screens.filter((screen) => screen.templateId === record.id).length;
+      const usage = await usageCount(record.id);
       if (usage > 0) {
         message.warning(`当前模板已被 ${usage} 个数字化大屏使用，请先处理这些大屏`);
         return;
@@ -257,7 +270,7 @@ export default function ScreenTemplateSettingsPanel() {
                   复制
                 </Button>
                 {record.source === 'custom' ? (
-                  <Button type="text" size="small" icon={<Pencil size={13} />} onClick={() => openEdit(record)}>
+                  <Button type="text" size="small" icon={<Pencil size={13} />} onClick={() => void openEdit(record)}>
                     编辑
                   </Button>
                 ) : null}

--- a/yak-ops-ui/src/pages/settings/components/ScreenTemplateSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ScreenTemplateSettingsPanel.tsx
@@ -1,0 +1,351 @@
+import { ScreenRenderer } from '@/components/screen-engine';
+import type { ScreenTemplate } from '@/components/screen-engine';
+import {
+  copyManagedScreenTemplate,
+  deleteCustomScreenTemplate,
+  listManagedScreenTemplateCategories,
+  listManagedScreenTemplates,
+  parseAndImportManagedScreenTemplate,
+  setManagedScreenTemplateStatus,
+  stringifyScreenTemplate,
+  updateCustomScreenTemplate,
+} from '@/services/screen-template-service';
+import type {
+  ManagedScreenTemplate,
+  ManagedScreenTemplateStatus,
+} from '@/services/screen-template-service';
+import { Button, Input, Modal, Popconfirm, Select, message } from 'antd';
+import { Copy, Eye, FileJson, Pencil, Plus, Search, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { fetchDigitalScreens } from '@/pages/digital-screen/screen-service';
+
+const statusLabel: Record<ManagedScreenTemplateStatus, string> = {
+  draft: '草稿',
+  published: '已发布',
+  offline: '已下架',
+};
+
+const statusClass: Record<ManagedScreenTemplateStatus, string> = {
+  draft: 'bg-[#f3f4f6] text-[#667085]',
+  published: 'bg-[#edf8f2] text-[#27845a]',
+  offline: 'bg-[#fff4ed] text-[#b54708]',
+};
+
+const parseTemplate = (json: string): ScreenTemplate => {
+  try {
+    return JSON.parse(json) as ScreenTemplate;
+  } catch {
+    throw new Error('模板 JSON 格式不正确');
+  }
+};
+
+export default function ScreenTemplateSettingsPanel() {
+  const [revision, setRevision] = useState(0);
+  const [keyword, setKeyword] = useState('');
+  const [status, setStatus] = useState<'all' | ManagedScreenTemplateStatus>('all');
+  const [category, setCategory] = useState('全部');
+  const [preview, setPreview] = useState<ManagedScreenTemplate>();
+  const [editing, setEditing] = useState<ManagedScreenTemplate>();
+  const [editJson, setEditJson] = useState('');
+  const [importOpen, setImportOpen] = useState(false);
+  const [importJson, setImportJson] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const records = useMemo(() => listManagedScreenTemplates(), [revision]);
+  const categories = useMemo(() => ['全部', ...listManagedScreenTemplateCategories()], [revision]);
+  const filtered = useMemo(() => {
+    const value = keyword.trim().toLowerCase();
+    return records.filter((record) => {
+      if (status !== 'all' && record.status !== status) return false;
+      if (category !== '全部' && record.template.category !== category) return false;
+      if (!value) return true;
+      return [
+        record.template.name,
+        record.template.description,
+        record.template.category,
+        record.id,
+      ].some((field) => String(field || '').toLowerCase().includes(value));
+    });
+  }, [category, keyword, records, status]);
+
+  const refresh = () => setRevision((value) => value + 1);
+
+  const copyTemplate = (record: ManagedScreenTemplate) => {
+    try {
+      copyManagedScreenTemplate(record.id);
+      refresh();
+      message.success('已复制为自定义草稿模板');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '复制模板失败');
+    }
+  };
+
+  const toggleStatus = (record: ManagedScreenTemplate) => {
+    try {
+      const next: ManagedScreenTemplateStatus = record.status === 'published' ? 'offline' : 'published';
+      setManagedScreenTemplateStatus(record.id, next);
+      refresh();
+      message.success(next === 'published' ? '模板已发布' : '模板已下架');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '更新模板状态失败');
+    }
+  };
+
+  const openEdit = (record: ManagedScreenTemplate) => {
+    setEditing(record);
+    setEditJson(stringifyScreenTemplate(record.template));
+  };
+
+  const saveEdit = () => {
+    if (!editing) return;
+    setSaving(true);
+    try {
+      const template = parseTemplate(editJson);
+      updateCustomScreenTemplate(editing.id, template);
+      setEditing(undefined);
+      refresh();
+      message.success('模板已保存');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '保存模板失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const importTemplate = () => {
+    setSaving(true);
+    try {
+      parseAndImportManagedScreenTemplate(importJson);
+      setImportOpen(false);
+      setImportJson('');
+      refresh();
+      message.success('模板已导入为草稿');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '导入模板失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const removeTemplate = async (record: ManagedScreenTemplate) => {
+    try {
+      const screens = await fetchDigitalScreens();
+      const usage = screens.filter((screen) => screen.templateId === record.id).length;
+      if (usage > 0) {
+        message.warning(`当前模板已被 ${usage} 个数字化大屏使用，请先处理这些大屏`);
+        return;
+      }
+      deleteCustomScreenTemplate(record.id);
+      refresh();
+      message.success('模板已删除');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '删除模板失败');
+    }
+  };
+
+  const count = (target: ManagedScreenTemplateStatus) => records.filter((item) => item.status === target).length;
+
+  return (
+    <div>
+      <div className="flex items-start justify-between gap-6">
+        <div>
+          <div className="text-[18px] font-semibold leading-7 text-[#161823]">大屏模板</div>
+          <div className="mt-1 text-[12px] leading-5 text-[#8a9099]">
+            维护数字化大屏创建时可使用的模板
+          </div>
+        </div>
+        <Button
+          type="primary"
+          icon={<Plus size={14} />}
+          onClick={() => {
+            setImportJson('');
+            setImportOpen(true);
+          }}
+        >
+          导入模板
+        </Button>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-b border-[#eceef1] pb-3">
+        <div className="flex items-center gap-1">
+          {([
+            ['all', '全部', records.length],
+            ['published', '已发布', count('published')],
+            ['draft', '草稿', count('draft')],
+            ['offline', '已下架', count('offline')],
+          ] as const).map(([key, label, total]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setStatus(key)}
+              className={[
+                'h-8 rounded-[6px] border-0 px-3 text-[13px] transition-colors',
+                status === key
+                  ? 'bg-[#f0f1f2] font-semibold text-[#161823]'
+                  : 'bg-transparent text-[#8a9099] hover:bg-[#f7f8f9] hover:text-[#444950]',
+              ].join(' ')}
+            >
+              {label}<span className="ml-1 text-[11px] font-normal text-[#a3a8b0]">{total}</span>
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={category}
+            onChange={setCategory}
+            options={categories.map((item) => ({ label: item, value: item }))}
+            className="w-[130px]"
+            variant="filled"
+          />
+          <Input
+            allowClear
+            value={keyword}
+            onChange={(event) => setKeyword(event.target.value)}
+            prefix={<Search size={14} className="text-[#98a2b3]" />}
+            placeholder="搜索模板"
+            className="w-[200px]"
+            variant="filled"
+          />
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="flex h-[320px] items-center justify-center text-[13px] text-[#98a2b3]">
+          没有匹配的大屏模板
+        </div>
+      ) : (
+        <div className="mt-4 overflow-hidden rounded-[8px] border border-[#e7e9ec]">
+          <div className="grid grid-cols-[minmax(280px,1fr)_110px_90px_90px_210px] items-center bg-[#fafafa] px-4 py-2.5 text-[11px] font-medium text-[#8a9099]">
+            <div>模板</div>
+            <div>分类</div>
+            <div>来源</div>
+            <div>状态</div>
+            <div className="text-right">操作</div>
+          </div>
+          {filtered.map((record) => (
+            <div
+              key={record.id}
+              className="grid min-h-[96px] grid-cols-[minmax(280px,1fr)_110px_90px_90px_210px] items-center border-t border-[#eef0f2] px-4 py-3"
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <button
+                  type="button"
+                  className="w-[118px] shrink-0 overflow-hidden rounded-[5px] border border-[#e5e7ea] bg-[#111827] p-0"
+                  onClick={() => setPreview(record)}
+                >
+                  <ScreenRenderer template={record.template} className="pointer-events-none" />
+                </button>
+                <div className="min-w-0">
+                  <div className="truncate text-[13px] font-semibold text-[#161823]">{record.template.name}</div>
+                  <div className="mt-1 line-clamp-2 text-[11px] leading-[17px] text-[#98a2b3]">
+                    {record.template.description || `${record.template.width} × ${record.template.height}`}
+                  </div>
+                </div>
+              </div>
+              <div className="truncate text-[12px] text-[#667085]">{record.template.category}</div>
+              <div className="text-[12px] text-[#667085]">{record.source === 'builtin' ? '官方' : '自定义'}</div>
+              <div>
+                <span className={`rounded-[4px] px-2 py-1 text-[11px] font-medium ${statusClass[record.status]}`}>
+                  {statusLabel[record.status]}
+                </span>
+              </div>
+              <div className="flex items-center justify-end gap-1">
+                <Button type="text" size="small" icon={<Eye size={13} />} onClick={() => setPreview(record)}>
+                  预览
+                </Button>
+                <Button type="text" size="small" icon={<Copy size={13} />} onClick={() => copyTemplate(record)}>
+                  复制
+                </Button>
+                {record.source === 'custom' ? (
+                  <Button type="text" size="small" icon={<Pencil size={13} />} onClick={() => openEdit(record)}>
+                    编辑
+                  </Button>
+                ) : null}
+                <Button type="text" size="small" onClick={() => toggleStatus(record)}>
+                  {record.status === 'published' ? '下架' : '发布'}
+                </Button>
+                {record.source === 'custom' ? (
+                  <Popconfirm
+                    title="删除模板"
+                    description="删除后无法恢复，已被大屏使用的模板不会允许删除。"
+                    okText="删除"
+                    cancelText="取消"
+                    onConfirm={() => void removeTemplate(record)}
+                  >
+                    <Button type="text" size="small" danger icon={<Trash2 size={13} />} />
+                  </Popconfirm>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        open={Boolean(preview)}
+        title={preview ? `${preview.template.name} · 模板预览` : '模板预览'}
+        width="min(1200px, 92vw)"
+        footer={<Button onClick={() => setPreview(undefined)}>关闭</Button>}
+        onCancel={() => setPreview(undefined)}
+        destroyOnClose
+      >
+        {preview ? (
+          <div className="overflow-hidden rounded-[6px] border border-[#e6e8eb] bg-[#111827]">
+            <ScreenRenderer template={preview.template} />
+          </div>
+        ) : null}
+      </Modal>
+
+      <Modal
+        open={importOpen}
+        title="导入大屏模板"
+        okText="导入为草稿"
+        cancelText="取消"
+        width={760}
+        confirmLoading={saving}
+        onOk={importTemplate}
+        onCancel={() => setImportOpen(false)}
+        destroyOnClose
+      >
+        <div className="pt-2">
+          <div className="mb-3 flex items-center gap-2 text-[12px] text-[#667085]">
+            <FileJson size={14} /> 粘贴符合 ScreenTemplate 协议的 JSON；模板 ID 会自动生成，避免覆盖已有模板。
+          </div>
+          <Input.TextArea
+            value={importJson}
+            onChange={(event) => setImportJson(event.target.value)}
+            rows={18}
+            spellCheck={false}
+            placeholder={'{\n  "version": 1,\n  "name": "我的模板",\n  ...\n}'}
+            className="font-mono text-[12px]"
+          />
+        </div>
+      </Modal>
+
+      <Modal
+        open={Boolean(editing)}
+        title={editing ? `编辑模板 · ${editing.template.name}` : '编辑模板'}
+        okText="保存"
+        cancelText="取消"
+        width={820}
+        confirmLoading={saving}
+        onOk={saveEdit}
+        onCancel={() => setEditing(undefined)}
+        destroyOnClose
+      >
+        <div className="pt-2">
+          <div className="mb-3 text-[12px] leading-5 text-[#667085]">
+            当前阶段通过 JSON 维护模板布局和样式，不提供自由拖拽模板设计器。模板 ID 会保持不变。
+          </div>
+          <Input.TextArea
+            value={editJson}
+            onChange={(event) => setEditJson(event.target.value)}
+            rows={20}
+            spellCheck={false}
+            className="font-mono text-[12px]"
+          />
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/settings/index.tsx
+++ b/yak-ops-ui/src/pages/settings/index.tsx
@@ -1,20 +1,21 @@
-import { Braces, SlidersHorizontal } from 'lucide-react';
+import { Braces, LayoutTemplate, SlidersHorizontal } from 'lucide-react';
 import { history, useLocation } from '@umijs/max';
 
 import EditorSettingsPanel from './components/EditorSettingsPanel';
 import EnvironmentSettingsPanel from './components/EnvironmentSettingsPanel';
+import ScreenTemplateSettingsPanel from './components/ScreenTemplateSettingsPanel';
 
-type SettingsTab = 'editor' | 'environment';
+type SettingsTab = 'editor' | 'environment' | 'screen-template';
 
 const tabs: { key: SettingsTab; label: string; icon: React.ReactNode }[] = [
   { key: 'editor', label: '编辑器设置', icon: <SlidersHorizontal size={15} strokeWidth={1.8} /> },
   { key: 'environment', label: '环境变量', icon: <Braces size={15} strokeWidth={1.8} /> },
+  { key: 'screen-template', label: '大屏模板', icon: <LayoutTemplate size={15} strokeWidth={1.8} /> },
 ];
 
 const SettingsPage = () => {
   const location = useLocation();
 
-  // Determine active tab from URL hash or default to 'editor'
   const hash = location.hash.replace('#', '');
   const activeTab: SettingsTab = (tabs.some((t) => t.key === hash) ? hash : 'editor') as SettingsTab;
 
@@ -51,9 +52,13 @@ const SettingsPage = () => {
       </aside>
 
       <section className="min-w-0 flex-1 overflow-auto">
-        <div className="mx-auto w-full max-w-[920px] px-10 py-8 xl:px-14">
+        <div className={[
+          'mx-auto w-full px-10 py-8 xl:px-14',
+          activeTab === 'screen-template' ? 'max-w-[1220px]' : 'max-w-[920px]',
+        ].join(' ')}>
           {activeTab === 'editor' && <EditorSettingsPanel />}
           {activeTab === 'environment' && <EnvironmentSettingsPanel />}
+          {activeTab === 'screen-template' && <ScreenTemplateSettingsPanel />}
         </div>
       </section>
     </div>

--- a/yak-ops-ui/src/services/screen-template-service.ts
+++ b/yak-ops-ui/src/services/screen-template-service.ts
@@ -1,0 +1,268 @@
+import {
+  assertValidScreenTemplate,
+  builtinScreenTemplates,
+} from '@/components/screen-engine';
+import type { ScreenTemplate } from '@/components/screen-engine';
+
+const CUSTOM_STORAGE_KEY = 'yak-ops:screen-custom-templates:v1';
+const BUILTIN_SETTINGS_STORAGE_KEY = 'yak-ops:screen-builtin-template-settings:v1';
+
+export type ManagedScreenTemplateStatus = 'draft' | 'published' | 'offline';
+export type ManagedScreenTemplateSource = 'builtin' | 'custom';
+
+interface StoredCustomTemplate {
+  template: ScreenTemplate;
+  status: ManagedScreenTemplateStatus;
+  sort: number;
+  createdAt: string;
+  updatedAt: string;
+  derivedFrom?: string;
+}
+
+interface BuiltinTemplateSetting {
+  status: 'published' | 'offline';
+  sort: number;
+}
+
+export interface ManagedScreenTemplate {
+  id: string;
+  template: ScreenTemplate;
+  source: ManagedScreenTemplateSource;
+  status: ManagedScreenTemplateStatus;
+  sort: number;
+  createdAt?: string;
+  updatedAt?: string;
+  derivedFrom?: string;
+}
+
+const now = () => new Date().toISOString();
+
+const cloneTemplate = (template: ScreenTemplate): ScreenTemplate => (
+  JSON.parse(JSON.stringify(template)) as ScreenTemplate
+);
+
+const createCustomId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `custom-${crypto.randomUUID()}`;
+  }
+  return `custom-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+};
+
+const readJson = <T,>(key: string, fallback: T): T => {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) as T : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+const writeJson = (key: string, value: unknown) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(key, JSON.stringify(value));
+};
+
+const readBuiltinSettings = (): Record<string, BuiltinTemplateSetting> => {
+  const value = readJson<Record<string, BuiltinTemplateSetting>>(BUILTIN_SETTINGS_STORAGE_KEY, {});
+  return value && typeof value === 'object' ? value : {};
+};
+
+const writeBuiltinSettings = (settings: Record<string, BuiltinTemplateSetting>) => {
+  writeJson(BUILTIN_SETTINGS_STORAGE_KEY, settings);
+};
+
+const isStatus = (value: unknown): value is ManagedScreenTemplateStatus => (
+  value === 'draft' || value === 'published' || value === 'offline'
+);
+
+const readCustomTemplates = (): StoredCustomTemplate[] => {
+  const values = readJson<unknown>(CUSTOM_STORAGE_KEY, []);
+  if (!Array.isArray(values)) return [];
+
+  return values.flatMap((value) => {
+    if (!value || typeof value !== 'object') return [];
+    const candidate = value as Partial<StoredCustomTemplate>;
+    if (!candidate.template || !isStatus(candidate.status)) return [];
+    try {
+      assertValidScreenTemplate(candidate.template);
+    } catch {
+      return [];
+    }
+    return [{
+      template: candidate.template,
+      status: candidate.status,
+      sort: Number.isFinite(candidate.sort) ? Number(candidate.sort) : 1000,
+      createdAt: candidate.createdAt || now(),
+      updatedAt: candidate.updatedAt || candidate.createdAt || now(),
+      derivedFrom: candidate.derivedFrom,
+    }];
+  });
+};
+
+const writeCustomTemplates = (templates: StoredCustomTemplate[]) => {
+  writeJson(CUSTOM_STORAGE_KEY, templates);
+};
+
+const builtinRecords = (): ManagedScreenTemplate[] => {
+  const settings = readBuiltinSettings();
+  return builtinScreenTemplates.map((template, index) => {
+    const setting = settings[template.id];
+    return {
+      id: template.id,
+      template,
+      source: 'builtin' as const,
+      status: setting?.status ?? 'published',
+      sort: setting?.sort ?? (index + 1) * 10,
+    };
+  });
+};
+
+const customRecords = (): ManagedScreenTemplate[] => readCustomTemplates().map((item) => ({
+  id: item.template.id,
+  template: item.template,
+  source: 'custom',
+  status: item.status,
+  sort: item.sort,
+  createdAt: item.createdAt,
+  updatedAt: item.updatedAt,
+  derivedFrom: item.derivedFrom,
+}));
+
+const sortRecords = (left: ManagedScreenTemplate, right: ManagedScreenTemplate) => (
+  left.sort - right.sort
+  || left.template.name.localeCompare(right.template.name, 'zh-CN')
+);
+
+export const listManagedScreenTemplates = () => [
+  ...builtinRecords(),
+  ...customRecords(),
+].sort(sortRecords);
+
+export const listAvailableScreenTemplates = () => listManagedScreenTemplates()
+  .filter((record) => record.status === 'published')
+  .sort(sortRecords);
+
+export const resolveScreenTemplateById = (id: string) => (
+  listManagedScreenTemplates().find((record) => record.id === id)?.template
+);
+
+export const getManagedScreenTemplate = (id: string) => (
+  listManagedScreenTemplates().find((record) => record.id === id)
+);
+
+export const listManagedScreenTemplateCategories = (publishedOnly = false) => [
+  ...new Set(
+    (publishedOnly ? listAvailableScreenTemplates() : listManagedScreenTemplates())
+      .map((record) => record.template.category),
+  ),
+];
+
+const normalizeCustomTemplate = (template: ScreenTemplate, id: string): ScreenTemplate => {
+  const next = cloneTemplate(template);
+  next.id = id;
+  return assertValidScreenTemplate(next);
+};
+
+export const copyManagedScreenTemplate = (sourceId: string) => {
+  const source = getManagedScreenTemplate(sourceId);
+  if (!source) throw new Error('大屏模板不存在');
+
+  const id = createCustomId();
+  const timestamp = now();
+  const template = normalizeCustomTemplate({
+    ...cloneTemplate(source.template),
+    name: `${source.template.name} - 副本`,
+  }, id);
+  const customs = readCustomTemplates();
+  const record: StoredCustomTemplate = {
+    template,
+    status: 'draft',
+    sort: 1000 + customs.length * 10,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    derivedFrom: source.id,
+  };
+  writeCustomTemplates([...customs, record]);
+  return record;
+};
+
+export const importManagedScreenTemplate = (template: ScreenTemplate) => {
+  const id = createCustomId();
+  const timestamp = now();
+  const normalized = normalizeCustomTemplate(template, id);
+  const customs = readCustomTemplates();
+  const record: StoredCustomTemplate = {
+    template: normalized,
+    status: 'draft',
+    sort: 1000 + customs.length * 10,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  writeCustomTemplates([...customs, record]);
+  return record;
+};
+
+export const parseAndImportManagedScreenTemplate = (json: string) => {
+  let parsed: ScreenTemplate;
+  try {
+    parsed = JSON.parse(json) as ScreenTemplate;
+  } catch {
+    throw new Error('模板 JSON 格式不正确');
+  }
+  return importManagedScreenTemplate(parsed);
+};
+
+export const updateCustomScreenTemplate = (id: string, template: ScreenTemplate) => {
+  let updated: StoredCustomTemplate | undefined;
+  const nextTemplate = normalizeCustomTemplate(template, id);
+  const customs = readCustomTemplates().map((item) => {
+    if (item.template.id !== id) return item;
+    const next: StoredCustomTemplate = {
+      ...item,
+      template: nextTemplate,
+      updatedAt: now(),
+    };
+    updated = next;
+    return next;
+  });
+  if (!updated) throw new Error('自定义大屏模板不存在');
+  writeCustomTemplates(customs);
+  return updated;
+};
+
+export const setManagedScreenTemplateStatus = (
+  id: string,
+  status: ManagedScreenTemplateStatus,
+) => {
+  const builtin = builtinScreenTemplates.find((template) => template.id === id);
+  if (builtin) {
+    if (status === 'draft') throw new Error('内置模板不能设置为草稿');
+    const settings = readBuiltinSettings();
+    const current = settings[id];
+    settings[id] = {
+      status,
+      sort: current?.sort ?? (builtinScreenTemplates.findIndex((item) => item.id === id) + 1) * 10,
+    };
+    writeBuiltinSettings(settings);
+    return;
+  }
+
+  let found = false;
+  const customs = readCustomTemplates().map((item) => {
+    if (item.template.id !== id) return item;
+    found = true;
+    return { ...item, status, updatedAt: now() };
+  });
+  if (!found) throw new Error('大屏模板不存在');
+  writeCustomTemplates(customs);
+};
+
+export const deleteCustomScreenTemplate = (id: string) => {
+  const customs = readCustomTemplates();
+  const next = customs.filter((item) => item.template.id !== id);
+  if (next.length === customs.length) throw new Error('自定义大屏模板不存在');
+  writeCustomTemplates(next);
+};
+
+export const stringifyScreenTemplate = (template: ScreenTemplate) => JSON.stringify(template, null, 2);

--- a/yak-ops-ui/src/services/screen-template-service.ts
+++ b/yak-ops-ui/src/services/screen-template-service.ts
@@ -64,8 +64,20 @@ const writeJson = (key: string, value: unknown) => {
 };
 
 const readBuiltinSettings = (): Record<string, BuiltinTemplateSetting> => {
-  const value = readJson<Record<string, BuiltinTemplateSetting>>(BUILTIN_SETTINGS_STORAGE_KEY, {});
-  return value && typeof value === 'object' ? value : {};
+  const values = readJson<Record<string, unknown>>(BUILTIN_SETTINGS_STORAGE_KEY, {});
+  const settings: Record<string, BuiltinTemplateSetting> = {};
+  Object.entries(values || {}).forEach(([id, value]) => {
+    if (!value || typeof value !== 'object') return;
+    const candidate = value as Partial<BuiltinTemplateSetting>;
+    if (candidate.status !== 'published' && candidate.status !== 'offline') return;
+    settings[id] = {
+      status: candidate.status,
+      sort: typeof candidate.sort === 'number' && Number.isFinite(candidate.sort)
+        ? candidate.sort
+        : 1000,
+    };
+  });
+  return settings;
 };
 
 const writeBuiltinSettings = (settings: Record<string, BuiltinTemplateSetting>) => {
@@ -80,7 +92,7 @@ const readCustomTemplates = (): StoredCustomTemplate[] => {
   const values = readJson<unknown>(CUSTOM_STORAGE_KEY, []);
   if (!Array.isArray(values)) return [];
 
-  return values.flatMap((value) => {
+  return values.flatMap((value): StoredCustomTemplate[] => {
     if (!value || typeof value !== 'object') return [];
     const candidate = value as Partial<StoredCustomTemplate>;
     if (!candidate.template || !isStatus(candidate.status)) return [];
@@ -89,12 +101,15 @@ const readCustomTemplates = (): StoredCustomTemplate[] => {
     } catch {
       return [];
     }
+    const timestamp = now();
     return [{
       template: candidate.template,
       status: candidate.status,
-      sort: Number.isFinite(candidate.sort) ? Number(candidate.sort) : 1000,
-      createdAt: candidate.createdAt || now(),
-      updatedAt: candidate.updatedAt || candidate.createdAt || now(),
+      sort: typeof candidate.sort === 'number' && Number.isFinite(candidate.sort)
+        ? candidate.sort
+        : 1000,
+      createdAt: candidate.createdAt || timestamp,
+      updatedAt: candidate.updatedAt || candidate.createdAt || timestamp,
       derivedFrom: candidate.derivedFrom,
     }];
   });
@@ -216,7 +231,7 @@ export const parseAndImportManagedScreenTemplate = (json: string) => {
 export const updateCustomScreenTemplate = (id: string, template: ScreenTemplate) => {
   let updated: StoredCustomTemplate | undefined;
   const nextTemplate = normalizeCustomTemplate(template, id);
-  const customs = readCustomTemplates().map((item) => {
+  const customs = readCustomTemplates().map((item): StoredCustomTemplate => {
     if (item.template.id !== id) return item;
     const next: StoredCustomTemplate = {
       ...item,
@@ -249,7 +264,7 @@ export const setManagedScreenTemplateStatus = (
   }
 
   let found = false;
-  const customs = readCustomTemplates().map((item) => {
+  const customs = readCustomTemplates().map((item): StoredCustomTemplate => {
     if (item.template.id !== id) return item;
     found = true;
     return { ...item, status, updatedAt: now() };


### PR DESCRIPTION
## Overview

实现数字化大屏第四阶段：大屏模板管理。基于第三阶段的数据集绑定能力，把模板维护能力放到「设置 → 大屏模板」，并让模板的发布/下架状态真正影响“新建大屏”的模板选择。

> Stacked on Draft PR #486 (`feat/digital-screen-data-binding`). 本 PR 的 base 暂时指向第三阶段分支，确保 review 时只看到第四阶段“模板管理”的增量；第三阶段合并后可再 retarget 到 `main`。

## What changed

- 在「设置」中新增「大屏模板」入口
- 新增模板管理页面
  - 全部 / 已发布 / 草稿 / 已下架筛选
  - 分类筛选
  - 模板搜索
  - 真实模板缩略图与大图预览
- 区分官方模板和自定义模板
  - 官方模板：预览 / 复制 / 发布 / 下架
  - 官方模板不允许直接编辑和删除
  - 自定义模板：预览 / 复制 / JSON 编辑 / 发布 / 下架 / 删除
- 新增模板导入能力
  - 粘贴 `ScreenTemplate` JSON
  - 使用现有模板校验器校验布局和组件协议
  - 自动生成新的 custom template id，避免覆盖已有模板
  - 导入后默认进入草稿状态
- 新增模板复制能力
  - 官方/自定义模板都可以复制为新的自定义草稿
  - 记录 `derivedFrom` 来源
- 新增受管模板服务
  - 统一合并 builtin + custom 模板
  - `draft / published / offline` 状态
  - 内置模板只保存额外的状态/排序配置，不改写模板源文件
  - 自定义模板持久化到 localStorage
- 模板状态与创建流程联动
  - “新建大屏”只展示已发布模板
  - 下架模板不会再出现在模板选择页
  - 已有大屏仍可继续解析和展示被下架的模板
- 全面接入自定义模板解析
  - 数字化大屏列表
  - 大屏编辑器
  - 全屏 Viewer
  - 大屏实例创建校验
- 增加模板使用保护
  - 已经被数字化大屏使用的自定义模板不允许直接编辑或删除
  - 提示用户先复制模板再修改，避免维护模板时意外改变已有大屏布局

## Architecture

第四阶段新增应用层 `screen-template-service.ts`，模板引擎本身仍然只负责协议、校验和渲染：

`Screen Engine (builtin protocol/renderer)`
`        +`
`Managed Template Service (status/custom persistence)`
`        ↓`
`Settings Template Management / Screen Creation / Viewer`

这样模板引擎继续保持纯净，同时业务层可以动态管理模板生命周期。

## Persistence

本阶段继续沿用当前前端 MVP 的 localStorage 策略：

- 自定义模板：`yak-ops:screen-custom-templates:v1`
- 内置模板状态：`yak-ops:screen-builtin-template-settings:v1`

后续接后端模板表时，只需要替换 managed template service 的持久化实现，设置页面和数字化大屏页面不需要重构。

## Scope

本 PR 暂不包含：

- 自由拖拽模板设计器
- 模板版本历史 / 回滚
- 模板分类独立 CRUD
- 模板缩略图文件上传
- 服务端模板表和 API
- 模板市场

当前阶段继续坚持“模板通过 JSON/代码维护，不做另一个 DataV 设计器”。

## Verification

- 已确认相对第三阶段分支仅包含 8 个文件的第四阶段增量
- 已人工检查官方/自定义模板权限边界、状态切换、复制/导入/编辑/删除流程
- 已检查发布/下架和新建大屏模板选择之间的联动
- 已补充 localStorage 数据的运行时类型防御和 ScreenTemplate 校验
- 当前执行环境未提供可用的本地 `gh`/完整 checkout，无法在本地运行完整 `npm run tsc` / `npm run build`；建议以 PR CI 或本地工程校验作为最终验证

## User flow

`设置 -> 大屏模板 -> 复制/导入 -> 编辑 JSON -> 发布 -> 数字化大屏 -> 新建大屏 -> 使用已发布模板`
