### PR TITLE
feat(bi): add calculated fields and formula ast (phase 9)

### DIFF
--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -8,6 +8,12 @@ import {
   quickCalculationLabel,
   resolveAnalysisTopN,
 } from './analysis';
+import {
+  calculatedFieldFor,
+  isCalculatedFieldKey,
+  materializeCalculatedFields,
+  queryMetricsForAnalysis,
+} from './calculated-field';
 import { encodingMeetsChartRequirements, resolveAnalysisEncoding } from './encoding';
 import { queryAnalysisDataset } from './dataset-service';
 import type {
@@ -46,7 +52,10 @@ const metricAnalysisDisplayName = (
   dataset: PublishedDataset,
   metric: MetricBinding,
 ) => {
-  const base = metricDisplayName(dataset, metric);
+  const calculated = calculatedFieldFor(spec, metric.field);
+  const base = calculated
+    ? `${calculated.name} · 计算字段`
+    : metricDisplayName(dataset, metric);
   const calculation = spec.type === 'metric'
     ? 'none'
     : metricComputationFor(spec, metric.field).quickCalculation;
@@ -105,12 +114,13 @@ export const buildDatasetQueryPayload = (
   const sort = spec.sort;
   if (sort?.field) {
     const metric = spec.metrics.find((item) => item.field === sort.field);
-    const valid = Boolean(metric || spec.dimensions.includes(sort.field));
-    const duplicatedByTopN = Boolean(topN && metric?.field === topN.metric.field);
+    const physicalMetric = metric && !isCalculatedFieldKey(spec, metric.field) ? metric : undefined;
+    const valid = Boolean(physicalMetric || spec.dimensions.includes(sort.field));
+    const duplicatedByTopN = Boolean(topN && physicalMetric?.field === topN.metric.field);
     if (valid && !duplicatedByTopN) {
       sorts.push({
         fieldId: sort.field,
-        aggregation: metric?.aggregation,
+        aggregation: physicalMetric?.aggregation,
         direction: sort.direction === 'desc' ? 'DESC' : 'ASC',
       });
     }
@@ -119,7 +129,7 @@ export const buildDatasetQueryPayload = (
   const baseLimit = spec.limit ?? (spec.type === 'table' ? 200 : 500);
   return {
     dimensions: spec.type === 'metric' ? [] : spec.dimensions,
-    metrics: spec.metrics.map((metric) => ({ fieldId: metric.field, aggregation: metric.aggregation })),
+    metrics: queryMetricsForAnalysis(spec),
     filters,
     sorts,
     limit: topN ? Math.min(baseLimit, topN.count) : baseLimit,
@@ -162,7 +172,7 @@ function useAnalysisQuery(
       setError('');
       try {
         const value = await queryAnalysisDataset(dataset.id, payload);
-        if (requestId === sequence.current) setResult(value);
+        if (requestId === sequence.current) setResult(materializeCalculatedFields(spec, value));
       } catch (queryError) {
         if (requestId === sequence.current) {
           setResult(undefined);

--- a/yak-ops-ui/src/components/analysis/analysis.ts
+++ b/yak-ops-ui/src/components/analysis/analysis.ts
@@ -1,3 +1,4 @@
+import { isCalculatedFieldKey } from './calculated-field';
 import { resolveAnalysisEncoding } from './encoding';
 import type {
   AnalysisMetricComputation,
@@ -93,7 +94,8 @@ export const patchMetricComputation = (
 /**
  * Resolve an enabled Top/Bottom N definition against the active query projection. Grouped
  * color series are deliberately excluded because limiting grouped rows could truncate a
- * category before all of its series values are returned.
+ * category before all of its series values are returned. Calculated metrics stay client-side,
+ * so they cannot be used for a server-side Top N in Phase 9.
  */
 export const resolveAnalysisTopN = (spec: AnalysisSpec) => {
   const topN = spec.analysis?.topN;
@@ -101,7 +103,7 @@ export const resolveAnalysisTopN = (spec: AnalysisSpec) => {
   const colorField = resolveAnalysisEncoding(spec).color.find((item) => item.role === 'dimension')?.field;
   if (colorField) return undefined;
   const metric = spec.metrics.find((item) => item.field === topN.metricField);
-  if (!metric) return undefined;
+  if (!metric || isCalculatedFieldKey(spec, metric.field)) return undefined;
   const count = Math.min(100, Math.max(1, Math.round(Number(topN.count) || 10)));
   return {
     metric,

--- a/yak-ops-ui/src/components/analysis/calculated-field.test.ts
+++ b/yak-ops-ui/src/components/analysis/calculated-field.test.ts
@@ -1,0 +1,163 @@
+import {
+  calculatedFieldKey,
+  calculatedFieldMetric,
+  materializeCalculatedFields,
+  parseCalculatedFieldExpression,
+  queryMetricsForAnalysis,
+} from './calculated-field';
+import { rebindAnalysisEncoding } from './encoding';
+import type {
+  AnalysisCalculatedField,
+  AnalysisSpec,
+  DatasetQueryResult,
+  PublishedDataset,
+} from './model';
+
+const dataset: PublishedDataset = {
+  id: 'dataset-1',
+  name: '订单数据',
+  description: '',
+  status: 'ONLINE',
+  sourceTaskId: 'task-1',
+  sourceTaskName: '订单同步',
+  currentVersionNo: 1,
+  updatedAt: '2026-08-18T00:00:00Z',
+  fields: [
+    { key: 'category', label: '分类', physicalName: 'category', dataType: 'string', role: 'dimension', nullable: false },
+    { key: 'sales', label: '销售额', physicalName: 'sales', dataType: 'number', role: 'metric', nullable: false },
+    { key: 'profit', label: '利润', physicalName: 'profit', dataType: 'number', role: 'metric', nullable: true },
+    { key: 'order_id', label: '订单ID', physicalName: 'order_id', dataType: 'string', role: 'dimension', nullable: false },
+  ],
+};
+
+const calculated = (expression: string, id = 'average-order-value'): AnalysisCalculatedField => ({
+  id,
+  name: '客单价',
+  expression,
+  ast: parseCalculatedFieldExpression(expression, dataset).ast,
+});
+
+const specWith = (field: AnalysisCalculatedField): AnalysisSpec => {
+  const metric = calculatedFieldMetric(field);
+  return {
+    type: 'bar',
+    datasetId: dataset.id,
+    dimensions: ['category'],
+    metrics: [metric],
+    encoding: {
+      version: 1,
+      category: [{ field: 'category', role: 'dimension' }],
+      value: [{ field: metric.field, role: 'metric', aggregation: metric.aggregation }],
+      color: [],
+      size: [],
+      label: [],
+      detail: [],
+      tooltip: [],
+    },
+    filters: [],
+    style: {
+      showLegend: false,
+      showDataLabels: false,
+      smooth: false,
+      showGrid: true,
+    },
+    analysis: { version: 1, calculatedFields: [field] },
+  };
+};
+
+const result: DatasetQueryResult = {
+  datasetId: dataset.id,
+  datasetVersionId: 'version-1',
+  datasetVersionNo: 1,
+  bindings: [
+    { key: 'd0', fieldId: 'category', displayName: '分类', dataType: 'STRING', aggregation: null },
+    { key: 'm1', fieldId: 'sales', displayName: '销售额', dataType: 'NUMBER', aggregation: 'SUM' },
+    { key: 'm2', fieldId: 'order_id', displayName: '订单ID', dataType: 'NUMBER', aggregation: 'COUNT_DISTINCT' },
+  ],
+  columns: [],
+  rows: [
+    ['华东', 100, 4],
+    ['华南', 90, 3],
+  ],
+  returnedRows: 2,
+  truncated: false,
+  elapsedMillis: 1,
+};
+
+describe('parseCalculatedFieldExpression', () => {
+  it('parses aggregate arithmetic with precedence and dependencies', () => {
+    const parsed = parseCalculatedFieldExpression(
+      'SUM([sales]) / COUNT_DISTINCT([order_id]) + SUM([sales]) * 0.1',
+      dataset,
+    );
+    expect(parsed.dependencies).toEqual([
+      { field: 'sales', aggregation: 'SUM' },
+      { field: 'order_id', aggregation: 'COUNT_DISTINCT' },
+    ]);
+    expect(parsed.ast.kind).toBe('binary');
+  });
+
+  it('supports scalar functions without eval', () => {
+    const parsed = parseCalculatedFieldExpression(
+      'ROUND(ABS(SUM([profit])) / COALESCE(COUNT([order_id]), 1), 2)',
+      dataset,
+    );
+    expect(parsed.ast.kind).toBe('function');
+    expect(parsed.dependencies).toEqual([
+      { field: 'profit', aggregation: 'SUM' },
+      { field: 'order_id', aggregation: 'COUNT' },
+    ]);
+  });
+
+  it('rejects unknown fields and invalid numeric aggregations', () => {
+    expect(() => parseCalculatedFieldExpression('SUM([missing])', dataset)).toThrow('不存在字段');
+    expect(() => parseCalculatedFieldExpression('SUM([order_id])', dataset)).toThrow('仅支持数值字段');
+  });
+});
+
+describe('calculated metric query expansion', () => {
+  it('queries physical aggregate dependencies instead of virtual field ids', () => {
+    const field = calculated('SUM([sales]) / COUNT_DISTINCT([order_id])');
+    const spec = specWith(field);
+    expect(queryMetricsForAnalysis(spec)).toEqual([
+      { fieldId: 'sales', aggregation: 'SUM' },
+      { fieldId: 'order_id', aggregation: 'COUNT_DISTINCT' },
+    ]);
+    expect(queryMetricsForAnalysis(spec).some((metric) => metric.fieldId === calculatedFieldKey(field))).toBe(false);
+  });
+
+  it('deduplicates dependencies shared with physical metrics', () => {
+    const field = calculated('SUM([sales]) / COUNT_DISTINCT([order_id])');
+    const spec = specWith(field);
+    spec.metrics = [{ field: 'sales', aggregation: 'SUM' }, ...spec.metrics];
+    expect(queryMetricsForAnalysis(spec)).toHaveLength(2);
+  });
+});
+
+describe('materializeCalculatedFields', () => {
+  it('appends virtual metric values to the normal Dataset result', () => {
+    const field = calculated('SUM([sales]) / COUNT_DISTINCT([order_id])');
+    const spec = specWith(field);
+    const materialized = materializeCalculatedFields(spec, result);
+    const binding = materialized.bindings.at(-1);
+    expect(binding?.fieldId).toBe(calculatedFieldKey(field));
+    expect(materialized.rows.map((row) => row.at(-1))).toEqual([25, 30]);
+  });
+
+  it('returns null for division by zero rather than Infinity', () => {
+    const field = calculated('SUM([sales]) / (COUNT_DISTINCT([order_id]) - COUNT_DISTINCT([order_id]))');
+    const spec = specWith(field);
+    const materialized = materializeCalculatedFields(spec, result);
+    expect(materialized.rows.map((row) => row.at(-1))).toEqual([null, null]);
+  });
+});
+
+describe('encoding reconciliation', () => {
+  it('preserves chart-local calculated metric bindings on Dataset refresh', () => {
+    const field = calculated('SUM([sales]) / COUNT_DISTINCT([order_id])');
+    const spec = specWith(field);
+    const rebound = rebindAnalysisEncoding(spec, dataset);
+    expect(rebound.metrics).toEqual([calculatedFieldMetric(field)]);
+    expect(rebound.encoding?.value[0]?.field).toBe(calculatedFieldKey(field));
+  });
+});

--- a/yak-ops-ui/src/components/analysis/calculated-field.ts
+++ b/yak-ops-ui/src/components/analysis/calculated-field.ts
@@ -1,0 +1,376 @@
+import type {
+  Aggregation,
+  AnalysisCalculatedField,
+  AnalysisFormulaFunction,
+  AnalysisFormulaNode,
+  AnalysisSpec,
+  DatasetQueryMetric,
+  DatasetQueryResult,
+  MetricBinding,
+  PublishedDataset,
+} from './model';
+
+export const CALCULATED_FIELD_PREFIX = 'calc:';
+
+const AGGREGATIONS = new Set<Aggregation>([
+  'SUM',
+  'AVG',
+  'COUNT',
+  'COUNT_DISTINCT',
+  'MAX',
+  'MIN',
+]);
+const SCALAR_FUNCTIONS = new Set<AnalysisFormulaFunction>(['ABS', 'ROUND', 'COALESCE']);
+
+export const calculatedFieldKey = (field: Pick<AnalysisCalculatedField, 'id'> | string) => (
+  `${CALCULATED_FIELD_PREFIX}${typeof field === 'string' ? field : field.id}`
+);
+
+export const calculatedFieldFor = (
+  spec: Pick<AnalysisSpec, 'analysis'>,
+  key: string,
+) => spec.analysis?.calculatedFields?.find((field) => calculatedFieldKey(field) === key);
+
+export const isCalculatedFieldKey = (
+  spec: Pick<AnalysisSpec, 'analysis'>,
+  key: string,
+) => Boolean(calculatedFieldFor(spec, key));
+
+export const calculatedFieldMetric = (field: AnalysisCalculatedField): MetricBinding => ({
+  field: calculatedFieldKey(field),
+  // The formula itself owns aggregate semantics. SUM is a compatibility marker that lets
+  // the existing metric binding / encoding pipeline carry a virtual numeric field.
+  aggregation: 'SUM',
+});
+
+const metricKey = (field: string, aggregation: Aggregation) => `${field}|${aggregation}`;
+
+export const calculatedFieldDependencies = (ast: AnalysisFormulaNode) => {
+  const dependencies = new Map<string, MetricBinding>();
+  const visit = (node: AnalysisFormulaNode) => {
+    if (node.kind === 'metric') {
+      dependencies.set(metricKey(node.field, node.aggregation), {
+        field: node.field,
+        aggregation: node.aggregation,
+      });
+      return;
+    }
+    if (node.kind === 'unary') {
+      visit(node.value);
+      return;
+    }
+    if (node.kind === 'binary') {
+      visit(node.left);
+      visit(node.right);
+      return;
+    }
+    if (node.kind === 'function') node.args.forEach(visit);
+  };
+  visit(ast);
+  return [...dependencies.values()];
+};
+
+class FormulaParser {
+  private index = 0;
+
+  constructor(
+    private readonly expression: string,
+    private readonly dataset: PublishedDataset,
+  ) {}
+
+  parse(): AnalysisFormulaNode {
+    if (!this.expression.trim()) throw new Error('请输入计算公式');
+    const value = this.parseAdditive();
+    this.skipWhitespace();
+    if (!this.eof()) throw new Error(`公式第 ${this.index + 1} 个字符附近存在无法识别的内容`);
+    return value;
+  }
+
+  private parseAdditive(): AnalysisFormulaNode {
+    let left = this.parseMultiplicative();
+    while (true) {
+      this.skipWhitespace();
+      const operator = this.peek();
+      if (operator !== '+' && operator !== '-') return left;
+      this.index += 1;
+      left = { kind: 'binary', operator, left, right: this.parseMultiplicative() };
+    }
+  }
+
+  private parseMultiplicative(): AnalysisFormulaNode {
+    let left = this.parseUnary();
+    while (true) {
+      this.skipWhitespace();
+      const operator = this.peek();
+      if (operator !== '*' && operator !== '/') return left;
+      this.index += 1;
+      left = { kind: 'binary', operator, left, right: this.parseUnary() };
+    }
+  }
+
+  private parseUnary(): AnalysisFormulaNode {
+    this.skipWhitespace();
+    if (this.peek() === '-') {
+      this.index += 1;
+      return { kind: 'unary', operator: '-', value: this.parseUnary() };
+    }
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): AnalysisFormulaNode {
+    this.skipWhitespace();
+    const current = this.peek();
+    if (current === '(') {
+      this.index += 1;
+      const value = this.parseAdditive();
+      this.expect(')', '缺少右括号 )');
+      return value;
+    }
+    if (current && /[0-9.]/.test(current)) return this.parseNumber();
+    if (current && /[A-Za-z_]/.test(current)) return this.parseFunction();
+    throw new Error(`公式第 ${this.index + 1} 个字符附近需要数字、函数或括号`);
+  }
+
+  private parseNumber(): AnalysisFormulaNode {
+    this.skipWhitespace();
+    const start = this.index;
+    let dots = 0;
+    while (!this.eof()) {
+      const char = this.peek();
+      if (char === '.') {
+        dots += 1;
+        if (dots > 1) break;
+        this.index += 1;
+        continue;
+      }
+      if (!char || !/[0-9]/.test(char)) break;
+      this.index += 1;
+    }
+    const text = this.expression.slice(start, this.index);
+    const value = Number(text);
+    if (!text || text === '.' || !Number.isFinite(value)) throw new Error(`非法数值：${text || '.'}`);
+    return { kind: 'literal', value };
+  }
+
+  private parseFunction(): AnalysisFormulaNode {
+    const name = this.parseIdentifier().toUpperCase();
+    this.expect('(', `函数 ${name} 后需要 (`);
+    if (AGGREGATIONS.has(name as Aggregation)) {
+      const aggregation = name as Aggregation;
+      const field = this.parseFieldReference();
+      this.expect(')', `${aggregation} 缺少右括号 )`);
+      this.validateAggregateField(field, aggregation);
+      return { kind: 'metric', field, aggregation };
+    }
+    if (!SCALAR_FUNCTIONS.has(name as AnalysisFormulaFunction)) {
+      throw new Error(`暂不支持函数 ${name}`);
+    }
+
+    const args: AnalysisFormulaNode[] = [];
+    this.skipWhitespace();
+    if (this.peek() !== ')') {
+      while (true) {
+        args.push(this.parseAdditive());
+        this.skipWhitespace();
+        if (this.peek() !== ',') break;
+        this.index += 1;
+      }
+    }
+    this.expect(')', `${name} 缺少右括号 )`);
+    this.validateFunctionArity(name as AnalysisFormulaFunction, args.length);
+    return { kind: 'function', name: name as AnalysisFormulaFunction, args };
+  }
+
+  private parseFieldReference() {
+    this.skipWhitespace();
+    if (this.peek() !== '[') throw new Error('聚合函数中的字段必须使用 [字段] 写法');
+    this.index += 1;
+    const start = this.index;
+    while (!this.eof() && this.peek() !== ']') this.index += 1;
+    if (this.eof()) throw new Error('字段引用缺少右方括号 ]');
+    const raw = this.expression.slice(start, this.index).trim();
+    this.index += 1;
+    if (!raw) throw new Error('字段引用不能为空');
+
+    const direct = this.dataset.fields.find((field) => field.key === raw);
+    if (direct) return direct.key;
+    const aliases = this.dataset.fields.filter((field) => (
+      field.label === raw || field.physicalName === raw
+    ));
+    if (aliases.length === 1) return aliases[0].key;
+    if (aliases.length > 1) throw new Error(`字段 ${raw} 存在重名，请使用字段 key`);
+    throw new Error(`Dataset 中不存在字段 ${raw}`);
+  }
+
+  private validateAggregateField(fieldKey: string, aggregation: Aggregation) {
+    const field = this.dataset.fields.find((item) => item.key === fieldKey);
+    if (!field) throw new Error(`Dataset 中不存在字段 ${fieldKey}`);
+    if (
+      (aggregation === 'SUM' || aggregation === 'AVG' || aggregation === 'MAX' || aggregation === 'MIN')
+      && field.dataType !== 'number'
+    ) {
+      throw new Error(`${aggregation} 仅支持数值字段，${field.label} 当前为 ${field.dataType}`);
+    }
+  }
+
+  private validateFunctionArity(name: AnalysisFormulaFunction, count: number) {
+    if (name === 'ABS' && count !== 1) throw new Error('ABS 需要 1 个参数');
+    if (name === 'ROUND' && (count < 1 || count > 2)) throw new Error('ROUND 需要 1~2 个参数');
+    if (name === 'COALESCE' && count < 2) throw new Error('COALESCE 至少需要 2 个参数');
+  }
+
+  private parseIdentifier() {
+    this.skipWhitespace();
+    const start = this.index;
+    while (!this.eof() && /[A-Za-z0-9_]/.test(this.peek() || '')) this.index += 1;
+    return this.expression.slice(start, this.index);
+  }
+
+  private expect(char: string, error: string) {
+    this.skipWhitespace();
+    if (this.peek() !== char) throw new Error(error);
+    this.index += 1;
+  }
+
+  private skipWhitespace() {
+    while (!this.eof() && /\s/.test(this.peek() || '')) this.index += 1;
+  }
+
+  private peek() {
+    return this.expression[this.index];
+  }
+
+  private eof() {
+    return this.index >= this.expression.length;
+  }
+}
+
+export const parseCalculatedFieldExpression = (
+  expression: string,
+  dataset: PublishedDataset,
+) => {
+  const ast = new FormulaParser(expression, dataset).parse();
+  const dependencies = calculatedFieldDependencies(ast);
+  if (!dependencies.length) throw new Error('计算字段至少需要引用一个聚合字段');
+  return { ast, dependencies };
+};
+
+/** Expand virtual metrics into the physical aggregate metrics required by Dataset Runtime. */
+export const queryMetricsForAnalysis = (spec: AnalysisSpec): DatasetQueryMetric[] => {
+  const result = new Map<string, DatasetQueryMetric>();
+  spec.metrics.forEach((metric) => {
+    const calculated = calculatedFieldFor(spec, metric.field);
+    const dependencies = calculated
+      ? calculatedFieldDependencies(calculated.ast)
+      : [metric];
+    dependencies.forEach((dependency) => {
+      result.set(metricKey(dependency.field, dependency.aggregation), {
+        fieldId: dependency.field,
+        aggregation: dependency.aggregation,
+      });
+    });
+  });
+  return [...result.values()];
+};
+
+const bindingIndex = (
+  result: DatasetQueryResult,
+  field: string,
+  aggregation: Aggregation,
+) => result.bindings.findIndex((binding) => (
+  binding.fieldId === field && binding.aggregation === aggregation
+));
+
+const finiteOrNull = (value: number | null) => (
+  value !== null && Number.isFinite(value) ? value : null
+);
+
+const evaluateFormulaNode = (
+  node: AnalysisFormulaNode,
+  result: DatasetQueryResult,
+  rowIndex: number,
+): number | null => {
+  if (node.kind === 'literal') return node.value;
+  if (node.kind === 'metric') {
+    const index = bindingIndex(result, node.field, node.aggregation);
+    if (index < 0) return null;
+    const raw = result.rows[rowIndex]?.[index];
+    if (raw === null || raw === undefined) return null;
+    const number = Number(raw);
+    return Number.isFinite(number) ? number : null;
+  }
+  if (node.kind === 'unary') {
+    const value = evaluateFormulaNode(node.value, result, rowIndex);
+    return value === null ? null : finiteOrNull(-value);
+  }
+  if (node.kind === 'binary') {
+    const left = evaluateFormulaNode(node.left, result, rowIndex);
+    const right = evaluateFormulaNode(node.right, result, rowIndex);
+    if (left === null || right === null) return null;
+    if (node.operator === '/' && right === 0) return null;
+    const value = node.operator === '+'
+      ? left + right
+      : node.operator === '-'
+        ? left - right
+        : node.operator === '*'
+          ? left * right
+          : left / right;
+    return finiteOrNull(value);
+  }
+
+  const args = node.args.map((arg) => evaluateFormulaNode(arg, result, rowIndex));
+  if (node.name === 'COALESCE') return args.find((value) => value !== null) ?? null;
+  if (args[0] === null) return null;
+  if (node.name === 'ABS') return finiteOrNull(Math.abs(args[0]!));
+  const digits = args[1] === null || args[1] === undefined
+    ? 0
+    : Math.min(6, Math.max(0, Math.round(args[1])));
+  const factor = 10 ** digits;
+  return finiteOrNull(Math.round(args[0]! * factor) / factor);
+};
+
+/**
+ * Append active calculated metrics to a Dataset result so the existing chart/table and
+ * Phase 8 table-calculation renderers can consume them through the normal binding lookup.
+ */
+export const materializeCalculatedFields = (
+  spec: AnalysisSpec,
+  result: DatasetQueryResult,
+): DatasetQueryResult => {
+  const active = spec.metrics.flatMap((metric) => {
+    const calculated = calculatedFieldFor(spec, metric.field);
+    return calculated ? [{ metric, calculated }] : [];
+  });
+  if (!active.length) return result;
+
+  const bindings = [...result.bindings];
+  const columns = [...result.columns];
+  const valuesByField = active.map(({ metric, calculated }, index) => {
+    const key = calculatedFieldKey(calculated);
+    bindings.push({
+      key: `calc${index + result.bindings.length}`,
+      fieldId: key,
+      displayName: calculated.name,
+      dataType: 'NUMBER',
+      aggregation: metric.aggregation,
+    });
+    columns.push({
+      name: key,
+      label: calculated.name,
+      typeName: 'NUMBER',
+      jdbcType: 3,
+      nullable: true,
+    });
+    return result.rows.map((_, rowIndex) => evaluateFormulaNode(calculated.ast, result, rowIndex));
+  });
+
+  return {
+    ...result,
+    bindings,
+    columns,
+    rows: result.rows.map((row, rowIndex) => [
+      ...row,
+      ...valuesByField.map((values) => values[rowIndex]),
+    ]),
+  };
+};

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -1,3 +1,4 @@
+import { calculatedFieldKey } from './calculated-field';
 import type {
   Aggregation,
   AnalysisEncoding,
@@ -208,7 +209,11 @@ export const analysisEncodingFieldKeys = (
 const validBindingForDataset = (
   binding: AnalysisEncodingBinding,
   dataset: PublishedDataset,
+  calculatedFields: Set<string>,
 ) => {
+  if (binding.role === 'metric' && calculatedFields.has(binding.field)) {
+    return { ...binding, aggregation: binding.aggregation ?? 'SUM' } satisfies AnalysisEncodingBinding;
+  }
   const field = dataset.fields.find((item) => item.key === binding.field);
   if (!field || field.role !== binding.role) return undefined;
   return {
@@ -248,16 +253,19 @@ const fillRequiredBindings = (
   return next;
 };
 
-/** Dataset changes validate all channels, then seed only missing required slots. */
+/** Dataset changes validate all channels, preserve chart-local metrics, then seed required slots. */
 export const rebindAnalysisEncoding = <T extends AnalysisSpec>(
   spec: T,
   dataset: PublishedDataset,
 ): T => {
   const source = resolveAnalysisEncoding(spec);
   const next = cloneAnalysisEncoding(EMPTY_ANALYSIS_ENCODING);
+  const calculatedFields = new Set(
+    (spec.analysis?.calculatedFields ?? []).map((field) => calculatedFieldKey(field)),
+  );
   ENCODING_CHANNELS.forEach((channel) => {
     next[channel] = source[channel]
-      .map((binding) => validBindingForDataset(binding, dataset))
+      .map((binding) => validBindingForDataset(binding, dataset, calculatedFields))
       .filter((binding): binding is AnalysisEncodingBinding => Boolean(binding));
   });
   const seeded = fillRequiredBindings(next, spec.type, dataset);

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -137,6 +137,37 @@ export interface AnalysisTopNConfig {
   direction: AnalysisTopNDirection;
 }
 
+export type AnalysisFormulaBinaryOperator = '+' | '-' | '*' | '/';
+export type AnalysisFormulaFunction = 'ABS' | 'ROUND' | 'COALESCE';
+
+/**
+ * Safe calculated-field AST. Expressions are parsed once in the editor and evaluated
+ * without `eval`; aggregate references are the only nodes that read Dataset values.
+ */
+export type AnalysisFormulaNode =
+  | { kind: 'literal'; value: number }
+  | { kind: 'metric'; field: string; aggregation: Aggregation }
+  | { kind: 'unary'; operator: '-'; value: AnalysisFormulaNode }
+  | {
+    kind: 'binary';
+    operator: AnalysisFormulaBinaryOperator;
+    left: AnalysisFormulaNode;
+    right: AnalysisFormulaNode;
+  }
+  | {
+    kind: 'function';
+    name: AnalysisFormulaFunction;
+    args: AnalysisFormulaNode[];
+  };
+
+/** Chart-local virtual metric backed by a validated aggregate expression. */
+export interface AnalysisCalculatedField {
+  id: string;
+  name: string;
+  expression: string;
+  ast: AnalysisFormulaNode;
+}
+
 /**
  * Versioned analysis semantics layered on top of the Dataset query result. Quick
  * calculations are table calculations and therefore do not alter the Dataset SQL contract.
@@ -145,6 +176,8 @@ export interface AnalysisComputationConfig {
   version: 1;
   metrics?: Record<string, AnalysisMetricComputation>;
   topN?: AnalysisTopNConfig;
+  /** Optional Phase 9 chart-local calculated metrics. */
+  calculatedFields?: AnalysisCalculatedField[];
 }
 
 /** Query + visualization definition that can be reused outside a Dashboard. */
@@ -160,7 +193,7 @@ export interface AnalysisSpec {
   filters: AnalysisFilter[];
   sort?: AnalysisSort;
   style: AnalysisVisualConfig;
-  /** Optional Phase 8 analysis semantics. Legacy snapshots resolve to raw metric values. */
+  /** Optional Phase 8+ analysis semantics. Legacy snapshots resolve to raw metric values. */
   analysis?: AnalysisComputationConfig;
   limit?: number;
   timeoutSeconds?: number;

--- a/yak-ops-ui/src/pages/dashboard/calculated-field-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/calculated-field-editor.tsx
@@ -63,14 +63,14 @@ export function CalculatedFieldEditor({
       : '';
   const canSave = !nameError && 'value' in parsed;
 
-  const eligibleFields = dataset.fields.filter((item) => (
+  const eligibleFields = useMemo(() => dataset.fields.filter((item) => (
     aggregation === 'COUNT' || aggregation === 'COUNT_DISTINCT' || item.dataType === 'number'
-  ));
+  )), [aggregation, dataset.fields]);
 
   useEffect(() => {
     if (sourceField && eligibleFields.some((item) => item.key === sourceField)) return;
     setSourceField(eligibleFields[0]?.key);
-  }, [aggregation, eligibleFields, sourceField]);
+  }, [eligibleFields, sourceField]);
 
   const append = (snippet: string) => {
     setExpression((current) => `${current}${current && !/\s$/.test(current) ? ' ' : ''}${snippet}`);

--- a/yak-ops-ui/src/pages/dashboard/calculated-field-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/calculated-field-editor.tsx
@@ -1,0 +1,182 @@
+import { parseCalculatedFieldExpression } from '@/components/analysis/calculated-field';
+import type {
+  Aggregation,
+  AnalysisCalculatedField,
+  PublishedDataset,
+} from '@/components/analysis/model';
+import { Button, Input, Modal, Select } from 'antd';
+import { Braces, Plus } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { AGGREGATION_OPTIONS } from './helpers';
+
+const FUNCTION_SNIPPETS = [
+  { label: 'ABS', value: 'ABS()' },
+  { label: 'ROUND', value: 'ROUND(, 2)' },
+  { label: 'COALESCE', value: 'COALESCE(, 0)' },
+] as const;
+
+export function CalculatedFieldEditor({
+  open,
+  field,
+  dataset,
+  existingFields,
+  onCancel,
+  onSave,
+}: {
+  open: boolean;
+  field?: AnalysisCalculatedField;
+  dataset: PublishedDataset;
+  existingFields: AnalysisCalculatedField[];
+  onCancel: () => void;
+  onSave: (field: AnalysisCalculatedField) => void;
+}) {
+  const [name, setName] = useState('');
+  const [expression, setExpression] = useState('');
+  const [aggregation, setAggregation] = useState<Aggregation>('SUM');
+  const [sourceField, setSourceField] = useState<string>();
+
+  useEffect(() => {
+    if (!open) return;
+    setName(field?.name ?? '');
+    setExpression(field?.expression ?? '');
+    setAggregation('SUM');
+    setSourceField(dataset.fields.find((item) => item.dataType === 'number')?.key ?? dataset.fields[0]?.key);
+  }, [dataset.fields, field, open]);
+
+  const parsed = useMemo(() => {
+    if (!expression.trim()) return { error: '请输入计算公式' } as const;
+    try {
+      return { value: parseCalculatedFieldExpression(expression, dataset) } as const;
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : '公式不合法' } as const;
+    }
+  }, [dataset, expression]);
+
+  const trimmedName = name.trim();
+  const duplicateName = existingFields.some((item) => (
+    item.id !== field?.id && item.name.trim().toLowerCase() === trimmedName.toLowerCase()
+  ));
+  const nameError = !trimmedName
+    ? '请输入计算字段名称'
+    : duplicateName
+      ? '计算字段名称不能重复'
+      : '';
+  const canSave = !nameError && 'value' in parsed;
+
+  const eligibleFields = dataset.fields.filter((item) => (
+    aggregation === 'COUNT' || aggregation === 'COUNT_DISTINCT' || item.dataType === 'number'
+  ));
+
+  useEffect(() => {
+    if (sourceField && eligibleFields.some((item) => item.key === sourceField)) return;
+    setSourceField(eligibleFields[0]?.key);
+  }, [aggregation, eligibleFields, sourceField]);
+
+  const append = (snippet: string) => {
+    setExpression((current) => `${current}${current && !/\s$/.test(current) ? ' ' : ''}${snippet}`);
+  };
+
+  const insertAggregate = () => {
+    if (!sourceField) return;
+    append(`${aggregation}([${sourceField}])`);
+  };
+
+  return (
+    <Modal
+      open={open}
+      width={620}
+      title={field ? '编辑计算字段' : '新建计算字段'}
+      okText="保存计算字段"
+      cancelText="取消"
+      okButtonProps={{ disabled: !canSave }}
+      onCancel={onCancel}
+      onOk={() => {
+        if (!canSave || !('value' in parsed)) return;
+        onSave({
+          id: field?.id ?? `cf-${Date.now()}-${Math.round(Math.random() * 10000)}`,
+          name: trimmedName,
+          expression: expression.trim(),
+          ast: parsed.value.ast,
+        });
+      }}
+    >
+      <div className="space-y-4 pt-2">
+        <div>
+          <div className="mb-1.5 text-[11px] font-medium text-[#475467]">字段名称</div>
+          <Input
+            value={name}
+            maxLength={40}
+            placeholder="例如：客单价、利润率"
+            status={nameError ? 'error' : undefined}
+            onChange={(event) => setName(event.target.value)}
+          />
+          {nameError ? <div className="mt-1 text-[10px] text-[#b42318]">{nameError}</div> : null}
+        </div>
+
+        <div>
+          <div className="mb-1.5 flex items-center justify-between gap-3">
+            <span className="text-[11px] font-medium text-[#475467]">计算公式</span>
+            <span className="text-[9px] text-[#98a2b3]">安全 AST · 不执行任意脚本</span>
+          </div>
+          <Input.TextArea
+            value={expression}
+            rows={6}
+            maxLength={1000}
+            spellCheck={false}
+            className="font-mono text-[12px]"
+            placeholder="SUM([sales]) / COUNT_DISTINCT([order_id])"
+            status={'error' in parsed ? 'error' : undefined}
+            onChange={(event) => setExpression(event.target.value)}
+          />
+          <div className={`mt-1 text-[10px] ${'error' in parsed ? 'text-[#b42318]' : 'text-[#667085]'}`}>
+            {'error' in parsed
+              ? parsed.error
+              : `已识别 ${parsed.value.dependencies.length} 个聚合依赖`}
+          </div>
+        </div>
+
+        <div className="rounded-[9px] border border-[#e8eaee] bg-[#fafbfc] p-3">
+          <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold text-[#667085]">
+            <Braces size={12} />
+            插入聚合字段
+          </div>
+          <div className="grid grid-cols-[126px_1fr_auto] gap-2">
+            <Select
+              size="small"
+              value={aggregation}
+              options={AGGREGATION_OPTIONS}
+              onChange={(value: Aggregation) => setAggregation(value)}
+            />
+            <Select
+              showSearch
+              size="small"
+              value={sourceField}
+              optionFilterProp="label"
+              options={eligibleFields.map((item) => ({ label: item.label, value: item.key }))}
+              onChange={setSourceField}
+            />
+            <Button size="small" icon={<Plus size={12} />} disabled={!sourceField} onClick={insertAggregate}>
+              插入
+            </Button>
+          </div>
+
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {[' + ', ' - ', ' * ', ' / ', '(', ')'].map((value) => (
+              <Button key={value} size="small" onClick={() => append(value)}>{value.trim() || value}</Button>
+            ))}
+            {FUNCTION_SNIPPETS.map((item) => (
+              <Button key={item.label} size="small" onClick={() => append(item.value)}>{item.label}</Button>
+            ))}
+          </div>
+          <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
+            Phase 9 支持 SUM / AVG / COUNT / COUNT_DISTINCT / MAX / MIN、四则运算、ABS、ROUND、COALESCE。字段使用 [field_key] 引用。
+          </div>
+        </div>
+
+        <div className="rounded-[7px] bg-[#f7f8fa] px-3 py-2 text-[10px] leading-5 text-[#667085]">
+          示例：客单价 = SUM([sales]) / COUNT_DISTINCT([order_id])；利润率 = SUM([profit]) / SUM([sales])。
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -1,4 +1,8 @@
 import {
+  calculatedFieldKey,
+  isCalculatedFieldKey,
+} from '@/components/analysis/calculated-field';
+import {
   applyAnalysisEncoding,
   changeAnalysisEncodingType,
   updateEncodingMetricAggregation,
@@ -98,11 +102,20 @@ export function ChartSheetConfigPanel({
   const dataset = findDataset(datasets, spec.datasetId);
   if (!dataset) return null;
 
-  const fieldOptions = dataset.fields.map((field) => ({
-    label: field.label,
-    value: field.key,
-    role: field.role,
-  }));
+  const calculatedFields = spec.analysis?.calculatedFields ?? [];
+  const fieldOptions = [
+    ...dataset.fields.map((field) => ({
+      label: field.label,
+      value: field.key,
+      role: field.role,
+    })),
+    ...calculatedFields.map((field) => ({
+      label: field.name,
+      value: calculatedFieldKey(field),
+      role: 'metric' as const,
+      calculated: true,
+    })),
+  ];
   const filterOptions = dataset.fields.map((field) => ({
     label: field.label,
     value: field.key,
@@ -114,9 +127,11 @@ export function ChartSheetConfigPanel({
   const sortOptions = dataset.fields
     .filter((field) => selectedFields.has(field.key))
     .map((field) => ({ label: field.label, value: field.key }));
-  const metricLabels = Object.fromEntries(
-    dataset.fields.map((field) => [field.key, field.label]),
-  );
+  const metricLabels = Object.fromEntries([
+    ...dataset.fields.map((field) => [field.key, field.label]),
+    ...calculatedFields.map((field) => [calculatedFieldKey(field), field.name]),
+  ]);
+  const physicalMetrics = spec.metrics.filter((metric) => !isCalculatedFieldKey(spec, metric.field));
 
   const changeType = (type: ChartType) => {
     const next = changeAnalysisEncodingType(spec, type);
@@ -145,12 +160,13 @@ export function ChartSheetConfigPanel({
     const topNMetricStillActive = currentTopN
       ? next.metrics.some((metric) => metric.field === currentTopN.metricField)
       : true;
+    const topNFallback = next.metrics.find((metric) => !isCalculatedFieldKey(next, metric.field));
     const nextAnalysis = currentTopN && !topNMetricStillActive
       ? {
         ...spec.analysis,
         version: 1 as const,
-        topN: next.metrics[0]
-          ? { ...currentTopN, metricField: next.metrics[0].field }
+        topN: topNFallback
+          ? { ...currentTopN, metricField: topNFallback.field }
           : { ...currentTopN, enabled: false },
       }
       : spec.analysis;
@@ -243,7 +259,7 @@ export function ChartSheetConfigPanel({
             onEncodingChange={changeEncoding}
           />
           <MetricAggregations
-            metrics={spec.metrics}
+            metrics={physicalMetrics}
             labels={metricLabels}
             onChange={(field: string, aggregation: Aggregation) => {
               const next = updateEncodingMetricAggregation(spec, field, aggregation);
@@ -380,7 +396,7 @@ function ConfigPanelHeader({ onDone }: { onDone: () => void }) {
     <div className="flex h-14 shrink-0 items-center justify-between border-b border-[#eceef1] px-4">
       <div>
         <div className="text-[13px] font-semibold text-[#344054]">图表配置</div>
-        <div className="mt-0.5 text-[9px] text-[#98a2b3]">字段编码、分析、样式与交互配置</div>
+        <div className="mt-0.5 text-[9px] text-[#98a2b3]">字段编码、计算、分析、样式与交互</div>
       </div>
       <button
         type="button"

--- a/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
@@ -1,8 +1,30 @@
-import { analysisEncodingFieldKeys } from '@/components/analysis/encoding';
-import type { AnalysisSpec } from '@/components/analysis/model';
-import { Input } from 'antd';
-import { Database, GripVertical, Hash, Search, Type } from 'lucide-react';
+import {
+  calculatedFieldKey,
+  isCalculatedFieldKey,
+} from '@/components/analysis/calculated-field';
+import {
+  analysisEncodingFieldKeys,
+  applyAnalysisEncoding,
+  resolveAnalysisEncoding,
+} from '@/components/analysis/encoding';
+import type {
+  AnalysisCalculatedField,
+  AnalysisSpec,
+} from '@/components/analysis/model';
+import { Button, Input, Popconfirm } from 'antd';
+import {
+  Braces,
+  Database,
+  GripVertical,
+  Hash,
+  Pencil,
+  Plus,
+  Search,
+  Trash2,
+  Type,
+} from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { CalculatedFieldEditor } from './calculated-field-editor';
 import { writeChartFieldDragPayload } from './chart-field-drag';
 import type { DatasetField, PublishedDataset } from './model';
 
@@ -19,12 +41,16 @@ export function ChartFieldPanel({
   dataset,
   spec,
   editable,
+  onSpecPatch,
 }: {
   dataset?: PublishedDataset;
   spec?: AnalysisSpec;
   editable: boolean;
+  onSpecPatch?: (patch: Partial<AnalysisSpec>) => void;
 }) {
   const [keyword, setKeyword] = useState('');
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingField, setEditingField] = useState<AnalysisCalculatedField>();
   const normalizedKeyword = keyword.trim().toLowerCase();
   const fields = useMemo(() => {
     if (!dataset) return [];
@@ -37,10 +63,75 @@ export function ChartFieldPanel({
   }, [dataset, normalizedKeyword]);
   const dimensions = fields.filter((field) => field.role === 'dimension');
   const metrics = fields.filter((field) => field.role === 'metric');
+  const calculatedFields = spec?.analysis?.calculatedFields ?? [];
+  const visibleCalculatedFields = normalizedKeyword
+    ? calculatedFields.filter((field) => (
+      field.name.toLowerCase().includes(normalizedKeyword)
+      || field.expression.toLowerCase().includes(normalizedKeyword)
+    ))
+    : calculatedFields;
   const encodedFields = useMemo(
     () => spec ? analysisEncodingFieldKeys(spec) : new Set<string>(),
     [spec],
   );
+
+  const saveCalculatedField = (field: AnalysisCalculatedField) => {
+    if (!spec || !onSpecPatch) return;
+    const current = spec.analysis?.calculatedFields ?? [];
+    const exists = current.some((item) => item.id === field.id);
+    const next = exists
+      ? current.map((item) => item.id === field.id ? field : item)
+      : [...current, field];
+    onSpecPatch({
+      analysis: {
+        ...spec.analysis,
+        version: 1,
+        calculatedFields: next,
+      },
+    });
+    setEditorOpen(false);
+    setEditingField(undefined);
+  };
+
+  const deleteCalculatedField = (field: AnalysisCalculatedField) => {
+    if (!spec || !onSpecPatch) return;
+    const key = calculatedFieldKey(field);
+    const encoding = resolveAnalysisEncoding(spec);
+    const cleanedEncoding = {
+      ...encoding,
+      category: encoding.category.filter((item) => item.field !== key),
+      value: encoding.value.filter((item) => item.field !== key),
+      color: encoding.color.filter((item) => item.field !== key),
+      size: encoding.size.filter((item) => item.field !== key),
+      label: encoding.label.filter((item) => item.field !== key),
+      detail: encoding.detail.filter((item) => item.field !== key),
+      tooltip: encoding.tooltip.filter((item) => item.field !== key),
+    };
+    const metricConfig = { ...(spec.analysis?.metrics ?? {}) };
+    delete metricConfig[key];
+    const calculated = calculatedFields.filter((item) => item.id !== field.id);
+    const provisionalAnalysis = {
+      ...spec.analysis,
+      version: 1 as const,
+      metrics: metricConfig,
+      calculatedFields: calculated,
+    };
+    const rebound = applyAnalysisEncoding({ ...spec, analysis: provisionalAnalysis }, cleanedEncoding);
+    const topN = provisionalAnalysis.topN;
+    const physicalFallback = rebound.metrics.find((metric) => !isCalculatedFieldKey(rebound, metric.field));
+    const nextTopN = topN?.metricField === key
+      ? physicalFallback
+        ? { ...topN, metricField: physicalFallback.field }
+        : { ...topN, enabled: false }
+      : topN;
+    onSpecPatch({
+      encoding: rebound.encoding,
+      dimensions: rebound.dimensions,
+      metrics: rebound.metrics,
+      sort: spec.sort?.field === key ? undefined : spec.sort,
+      analysis: { ...provisionalAnalysis, topN: nextTopN },
+    });
+  };
 
   return (
     <section className="flex w-[244px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
@@ -64,8 +155,24 @@ export function ChartFieldPanel({
           className="!h-8 !rounded-[7px]"
           onChange={(event) => setKeyword(event.target.value)}
         />
-        <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
-          {editable ? '拖动字段到右侧可视化编码槽位' : '共享图表复制为可编辑图表后可拖拽配置'}
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <div className="text-[9px] leading-4 text-[#98a2b3]">
+            {editable ? '拖动字段到右侧编码槽位' : '复制为可编辑图表后可配置'}
+          </div>
+          {editable && dataset && spec && onSpecPatch ? (
+            <Button
+              type="text"
+              size="small"
+              className="!h-6 !px-1.5 !text-[9px]"
+              icon={<Plus size={10} />}
+              onClick={() => {
+                setEditingField(undefined);
+                setEditorOpen(true);
+              }}
+            >
+              计算字段
+            </Button>
+          ) : null}
         </div>
       </div>
 
@@ -86,9 +193,36 @@ export function ChartFieldPanel({
               encodedFields={encodedFields}
               editable={editable}
             />
+            {calculatedFields.length ? (
+              <CalculatedFieldGroup
+                fields={visibleCalculatedFields}
+                total={calculatedFields.length}
+                encodedFields={encodedFields}
+                editable={editable}
+                onEdit={(field) => {
+                  setEditingField(field);
+                  setEditorOpen(true);
+                }}
+                onDelete={deleteCalculatedField}
+              />
+            ) : null}
           </div>
         )}
       </div>
+
+      {dataset && spec ? (
+        <CalculatedFieldEditor
+          open={editorOpen}
+          field={editingField}
+          dataset={dataset}
+          existingFields={calculatedFields}
+          onCancel={() => {
+            setEditorOpen(false);
+            setEditingField(undefined);
+          }}
+          onSave={saveCalculatedField}
+        />
+      ) : null}
     </section>
   );
 }
@@ -144,6 +278,92 @@ function FieldGroup({
         })}
         {!fields.length ? (
           <div className="px-1.5 py-2 text-[9px] text-[#b0b5bd]">没有匹配字段</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CalculatedFieldGroup({
+  fields,
+  total,
+  encodedFields,
+  editable,
+  onEdit,
+  onDelete,
+}: {
+  fields: AnalysisCalculatedField[];
+  total: number;
+  encodedFields: Set<string>;
+  editable: boolean;
+  onEdit: (field: AnalysisCalculatedField) => void;
+  onDelete: (field: AnalysisCalculatedField) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between px-1.5">
+        <span className="text-[10px] font-semibold text-[#667085]">计算字段</span>
+        <span className="text-[9px] tabular-nums text-[#b0b5bd]">{total}</span>
+      </div>
+      <div className="space-y-0.5">
+        {fields.map((field) => {
+          const key = calculatedFieldKey(field);
+          const selected = encodedFields.has(key);
+          return (
+            <div
+              key={field.id}
+              draggable={editable}
+              title={`${field.name} · ${field.expression}`}
+              className={[
+                'group flex min-h-8 items-center gap-1.5 rounded-[6px] px-1.5 text-[10px] transition-colors',
+                editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',
+                selected
+                  ? 'bg-[#f4f5f7] font-medium text-[#344054]'
+                  : 'text-[#475467] hover:bg-[#f7f8fa]',
+              ].join(' ')}
+              onDragStart={(event) => {
+                if (!editable) return;
+                writeChartFieldDragPayload(event, { field: key, role: 'metric' });
+              }}
+            >
+              <GripVertical size={12} className="shrink-0 text-[#c2c6cc]" />
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[5px] bg-[#f2f4f7] text-[#7a818c]">
+                <Braces size={11} />
+              </span>
+              <span className="min-w-0 flex-1 truncate">{field.name}</span>
+              <span className="shrink-0 text-[8px] text-[#b0b5bd]">计算</span>
+              {editable ? (
+                <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex">
+                  <button
+                    type="button"
+                    className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[#98a2b3] hover:bg-[#e9ebef] hover:text-[#475467]"
+                    aria-label={`编辑${field.name}`}
+                    onClick={() => onEdit(field)}
+                  >
+                    <Pencil size={9} />
+                  </button>
+                  <Popconfirm
+                    title="删除计算字段？"
+                    description="已绑定到图表的该字段会同步移除。"
+                    okText="删除"
+                    cancelText="取消"
+                    onConfirm={() => onDelete(field)}
+                  >
+                    <button
+                      type="button"
+                      className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[#98a2b3] hover:bg-[#e9ebef] hover:text-[#b42318]"
+                      aria-label={`删除${field.name}`}
+                    >
+                      <Trash2 size={9} />
+                    </button>
+                  </Popconfirm>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+        {!fields.length ? (
+          <div className="px-1.5 py-2 text-[9px] text-[#b0b5bd]">没有匹配计算字段</div>
         ) : null}
       </div>
     </div>

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -61,6 +61,7 @@ export function DashboardChartSheetWorkspace({
         dataset={dataset}
         spec={spec}
         editable={!widget.analysisId && Boolean(widget.inlineAnalysis && dataset)}
+        onSpecPatch={!widget.analysisId ? updateInlineAnalysis : undefined}
       />
 
       <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">

--- a/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-analysis.tsx
@@ -4,6 +4,10 @@ import {
   patchMetricComputation,
   QUICK_CALCULATION_OPTIONS,
 } from '@/components/analysis/analysis';
+import {
+  calculatedFieldFor,
+  isCalculatedFieldKey,
+} from '@/components/analysis/calculated-field';
 import { resolveAnalysisEncoding } from '@/components/analysis/encoding';
 import type {
   AnalysisComputationConfig,
@@ -31,8 +35,9 @@ export function ChartAnalysisConfig({
   );
   const supportsSequentialCalculation = spec.type !== 'metric' && spec.dimensions.length > 0;
   const topN = spec.analysis?.topN;
-  const supportsTopN = spec.type !== 'metric' && spec.dimensions.length > 0 && spec.metrics.length > 0;
-  const topNMetricActive = !topN || spec.metrics.some((metric) => metric.field === topN.metricField);
+  const physicalMetrics = spec.metrics.filter((metric) => !isCalculatedFieldKey(spec, metric.field));
+  const supportsTopN = spec.type !== 'metric' && spec.dimensions.length > 0 && physicalMetrics.length > 0;
+  const topNMetricActive = !topN || physicalMetrics.some((metric) => metric.field === topN.metricField);
   const aggregationLabels = Object.fromEntries(
     AGGREGATION_OPTIONS.map((item) => [item.value, item.label]),
   );
@@ -42,14 +47,17 @@ export function ChartAnalysisConfig({
   };
 
   const patchTopN = (patch: Partial<NonNullable<AnalysisComputationConfig['topN']>>) => {
-    const fallbackMetric = spec.metrics[0];
+    const fallbackMetric = physicalMetrics[0];
     if (!fallbackMetric) return;
+    const currentMetric = topN && physicalMetrics.some((metric) => metric.field === topN.metricField)
+      ? topN.metricField
+      : fallbackMetric.field;
     onChange({
       ...spec.analysis,
       version: 1,
       topN: {
         enabled: topN?.enabled ?? false,
-        metricField: topN?.metricField ?? fallbackMetric.field,
+        metricField: currentMetric,
         count: topN?.count ?? 10,
         direction: topN?.direction ?? 'top',
         ...patch,
@@ -64,6 +72,7 @@ export function ChartAnalysisConfig({
         <div className="space-y-2.5">
           {spec.metrics.map((metric) => {
             const field = dataset.fields.find((item) => item.key === metric.field);
+            const calculated = calculatedFieldFor(spec, metric.field);
             const config = metricComputationFor(spec, metric.field);
             const stored = spec.analysis?.metrics?.[metric.field];
             return (
@@ -71,10 +80,10 @@ export function ChartAnalysisConfig({
                 <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
                     <div className="truncate text-[10px] font-medium text-[#344054]">
-                      {field?.label ?? metric.field}
+                      {calculated?.name ?? field?.label ?? metric.field}
                     </div>
                     <div className="mt-0.5 text-[9px] text-[#98a2b3]">
-                      {aggregationLabels[metric.aggregation] ?? metric.aggregation}
+                      {calculated ? '计算字段' : aggregationLabels[metric.aggregation] ?? metric.aggregation}
                     </div>
                   </div>
                   {supportsSequentialCalculation ? (
@@ -123,12 +132,17 @@ export function ChartAnalysisConfig({
                     onChange={(useGrouping) => patchMetric(metric.field, { useGrouping })}
                   />
                 </label>
+                {calculated ? (
+                  <div className="mt-2 truncate rounded-[5px] bg-white px-2 py-1 font-mono text-[8px] text-[#98a2b3]" title={calculated.expression}>
+                    {calculated.expression}
+                  </div>
+                ) : null}
               </div>
             );
           })}
         </div>
         <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
-          占比、累计、排名和较上期变化在当前查询结果上计算，不改变 Dataset SQL。
+          占比、累计、排名和较上期变化在当前查询结果上计算；计算字段也可继续叠加这些表计算。
         </div>
       </div>
 
@@ -137,7 +151,7 @@ export function ChartAnalysisConfig({
           <div className="mb-2.5 flex items-center justify-between">
             <div>
               <div className="text-[10px] font-semibold text-[#667085]">Top / Bottom N</div>
-              <div className="mt-0.5 text-[9px] text-[#98a2b3]">先按指标排序，再限制返回分类数量</div>
+              <div className="mt-0.5 text-[9px] text-[#98a2b3]">服务端排序仅支持物理聚合指标</div>
             </div>
             <Switch
               size="small"
@@ -154,7 +168,7 @@ export function ChartAnalysisConfig({
                 className="w-full"
                 placeholder="选择 Top N 指标"
                 value={topNMetricActive ? topN.metricField : undefined}
-                options={spec.metrics.map((metric) => ({
+                options={physicalMetrics.map((metric) => ({
                   label: `${dataset.fields.find((item) => item.key === metric.field)?.label ?? metric.field} · ${aggregationLabels[metric.aggregation] ?? metric.aggregation}`,
                   value: metric.field,
                 }))}
@@ -183,7 +197,7 @@ export function ChartAnalysisConfig({
               </div>
               {!topNMetricActive ? (
                 <div className="text-[9px] leading-4 text-[#98a2b3]">
-                  原 Top N 指标在当前图表类型中暂未激活；切回原图表类型可恢复，或在这里重新选择。
+                  原 Top N 指标当前不可用于服务端排序，请重新选择一个物理指标。
                 </div>
               ) : null}
             </div>

--- a/yak-ops-ui/src/pages/dashboard/config-data.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-data.tsx
@@ -19,6 +19,7 @@ interface FieldOption {
   label: string;
   value: string;
   role: DatasetFieldRole;
+  calculated?: boolean;
 }
 
 interface BoundField {
@@ -38,6 +39,9 @@ export function ConfigData({
 }) {
   const encoding = resolveAnalysisEncoding(spec);
   const fieldLabel = new Map(fieldOptions.map((option) => [option.value, option.label]));
+  const calculatedFields = new Set(
+    fieldOptions.filter((option) => option.calculated).map((option) => option.value),
+  );
   const aggregationLabel = new Map(AGGREGATION_OPTIONS.map((option) => [option.value, option.label]));
 
   return (
@@ -51,7 +55,9 @@ export function ConfigData({
           field: binding.field,
           label: fieldLabel.get(binding.field) ?? binding.field,
           suffix: binding.role === 'metric'
-            ? aggregationLabel.get(binding.aggregation ?? 'SUM') ?? binding.aggregation ?? 'SUM'
+            ? calculatedFields.has(binding.field)
+              ? '计算'
+              : aggregationLabel.get(binding.aggregation ?? 'SUM') ?? binding.aggregation ?? 'SUM'
             : undefined,
         }));
         const options = fieldOptions.filter((option) => rule.roles.includes(option.role));
@@ -157,6 +163,7 @@ function EncodingDropZone({
     setDragOver(false);
     const payload = readChartFieldDragPayload(event);
     if (!payload || !rule.roles.includes(payload.role)) return;
+    if (!options.some((option) => option.value === payload.field && option.role === payload.role)) return;
     onAdd(payload.field, payload.role);
   };
 


### PR DESCRIPTION
## What changed
- introduce chart-local calculated metrics under `AnalysisComputationConfig.calculatedFields`, persisted as both the user-facing formula text and a validated expression AST
- add a safe recursive-descent formula parser; expressions are never passed to `eval`, `Function`, SQL text, or another arbitrary-code execution path
- support aggregate references `SUM` / `AVG` / `COUNT` / `COUNT_DISTINCT` / `MAX` / `MIN`, arithmetic `+ - * /`, parentheses and unary minus
- support scalar calculation helpers `ABS` / `ROUND` / `COALESCE`
- validate field references against the current Dataset schema and restrict numeric aggregations to numeric fields
- add a calculated-field editor directly from the Chart Sheet field pane with live formula validation, aggregate/field insertion helpers, examples and duplicate-name checks
- expose calculated fields as virtual metric fields in the left field pane; they participate in search and can be dragged or click-selected into normal value encoding slots
- allow editing and deleting calculated fields; deleting an active field also cleans its encoding binding, metric calculation settings, sort state and Top N reference safely
- preserve calculated-field bindings during same-Dataset reconciliation / Dataset version refreshes

## Runtime architecture

```text
Calculated metric
  e.g. SUM([sales]) / COUNT_DISTINCT([order_id])
          ↓ parse once
Safe Formula AST
          ↓ collect aggregate dependencies
Dataset query
  SUM(sales) + COUNT_DISTINCT(order_id)
          ↓
Dataset result
          ↓ evaluate AST per result row
Virtual calculated metric binding
          ↓
Phase 8 table calculations / number formatting
          ↓
Metric / Bar / Line / Pie / Table renderer
```

The Dataset server still receives only its existing semantic aggregate bindings. Calculated field IDs never enter Dataset SQL compilation. The frontend expands active calculated metrics into their physical aggregate dependencies, evaluates the stored AST against the returned aggregate values, then materializes a virtual numeric metric into the normal result-binding pipeline.

## Editor behavior
- calculated fields live next to Dataset metrics in the field pane and use the same drag/drop encoding interaction
- value slots label them as `计算` instead of showing a misleading aggregate selector
- the normal aggregation selector remains available only for physical metrics because aggregate semantics are already encoded inside a calculated-field formula
- calculated metrics can still use Phase 8 `占比 / 累计值 / 排名 / 较上期变化` and number formatting after their formula has been evaluated
- chart-type switching remains non-destructive because calculated metrics travel through the existing Encoding v1 value channel
- editing a formula keeps the calculated-field ID stable, so an already-bound chart updates in place

## Top N / sorting boundary
- server-side Top / Bottom N remains restricted to physical aggregate metrics
- calculated metrics are intentionally excluded from server-side Top N because the Dataset Runtime cannot sort by a value that only exists after client-side formula evaluation
- calculated metrics are likewise not offered as server-side sort fields in Query Settings
- existing physical Top N behavior remains unchanged

## Compatibility
- `AnalysisComputationConfig.calculatedFields` is optional; existing Phase 8 and older Dashboard snapshots remain readable
- Dashboard document version remains `1`
- no database migration
- no backend DTO/domain change
- no Dataset query payload/API contract change
- no new npm dependency
- Dashboard inline Analysis JSON continues through the existing save / publish / restore / undo / redo pipeline
- reusable shared Analysis assets keep the existing backend contract and remain read-only until copied into the Dashboard-local chart flow
- changing to another Dataset keeps the existing Dashboard behavior of creating a fresh inline Analysis, so Dataset-specific calculated fields cannot accidentally leak across schemas

## Intentionally deferred
- row-level calculated dimensions
- calculated-field references to other calculated fields / dependency graph and cycle detection
- conditional `IF` / `CASE` and date functions such as `DATE_DIFF` / `DATE_FORMAT`; these need a broader typed expression grammar rather than being approximated as strings
- server-side calculated-field sorting / Top N / filtering
- persisting calculated fields into reusable shared Analysis assets

## Validation
- [x] Phase 8 PR #485 is merged into `main`
- [x] branch starts from the Phase 8 merge commit `f0682e5ebb81df8f7f31849ba8fc6c25280b1602`
- [x] branch compare is 0 commits behind `main`
- [x] reviewed final compare: 12 frontend files changed; no backend or DB migration files changed
- [x] added focused unit tests for parser validation, dependency deduplication, query expansion, formula materialization, division-by-zero safety and Encoding reconciliation
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm run jest -- calculated-field.test.ts`
- [ ] manual browser regression: create/edit/delete formula, drag calculated metric, chart-type round trips, Phase 8 calculations/formatting, save/reopen Dashboard

Executable frontend validation is intentionally left unchecked in the current environment rather than being claimed as completed. GitHub checks should be treated as the executable integration signal if/when workflows are configured.