### PR TITLE
feat(bi): add advanced chart types (phase 10)

### DIFF
--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -4,16 +4,18 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   analysisMetricValues,
   formatAnalysisMetricValue,
-  metricComputationFor,
-  quickCalculationLabel,
   resolveAnalysisTopN,
 } from './analysis';
 import {
-  calculatedFieldFor,
   isCalculatedFieldKey,
   materializeCalculatedFields,
   queryMetricsForAnalysis,
 } from './calculated-field';
+import { buildAnalysisChartOption } from './chart-options';
+import {
+  getAnalysisField,
+  metricAnalysisDisplayName,
+} from './display';
 import { encodingMeetsChartRequirements, resolveAnalysisEncoding } from './encoding';
 import { queryAnalysisDataset } from './dataset-service';
 import type {
@@ -24,43 +26,16 @@ import type {
   DatasetField,
   DatasetQueryPayload,
   DatasetQueryResult,
-  MetricBinding,
   PublishedDataset,
   Scalar,
 } from './model';
-import { paletteColors, resolveAnalysisStyle } from './style';
+import { resolveAnalysisStyle } from './style';
 
-export const AGGREGATION_LABELS: Record<Aggregation, string> = {
-  SUM: '求和',
-  AVG: '平均',
-  COUNT: '计数',
-  COUNT_DISTINCT: '去重计数',
-  MAX: '最大值',
-  MIN: '最小值',
-};
-
-export const getAnalysisField = (dataset: PublishedDataset, fieldKey?: string) =>
-  dataset.fields.find((field) => field.key === fieldKey);
-
-export const metricDisplayName = (
-  dataset: PublishedDataset,
-  metric: AnalysisSpec['metrics'][number],
-) => `${getAnalysisField(dataset, metric.field)?.label ?? metric.field} · ${AGGREGATION_LABELS[metric.aggregation]}`;
-
-const metricAnalysisDisplayName = (
-  spec: AnalysisSpec,
-  dataset: PublishedDataset,
-  metric: MetricBinding,
-) => {
-  const calculated = calculatedFieldFor(spec, metric.field);
-  const base = calculated
-    ? `${calculated.name} · 计算字段`
-    : metricDisplayName(dataset, metric);
-  const calculation = spec.type === 'metric'
-    ? 'none'
-    : metricComputationFor(spec, metric.field).quickCalculation;
-  return calculation === 'none' ? base : `${base} · ${quickCalculationLabel(calculation)}`;
-};
+export {
+  AGGREGATION_LABELS,
+  getAnalysisField,
+  metricDisplayName,
+} from './display';
 
 const filterValue = (field: DatasetField | undefined, value: string): Scalar => {
   if (field?.dataType === 'number') {
@@ -210,25 +185,6 @@ const cell = (
   return index >= 0 ? row[index] : null;
 };
 
-const rowLabel = (result: DatasetQueryResult, row: Scalar[], dimensions: string[]) =>
-  dimensions.map((fieldId) => String(cell(result, row, fieldId) ?? '')).join(' / ');
-
-const scalarKey = (value: Scalar) => `${typeof value}:${String(value)}`;
-
-const uniqueDimensionValues = (
-  result: DatasetQueryResult,
-  fieldId: string,
-) => {
-  const seen = new Set<string>();
-  return result.rows.flatMap((row) => {
-    const value = cell(result, row, fieldId);
-    const key = scalarKey(value);
-    if (seen.has(key)) return [];
-    seen.add(key);
-    return [{ key, value, label: String(value ?? '') }];
-  });
-};
-
 const selectionForRow = (
   spec: AnalysisSpec,
   dataset: PublishedDataset,
@@ -250,193 +206,6 @@ const selectionForRow = (
   };
 };
 
-const legendOption = (
-  visible: boolean,
-  position: 'top' | 'right' | 'bottom',
-  axisText: string,
-) => {
-  if (!visible) return { show: false };
-  const base = { textStyle: { color: axisText, fontSize: 11 } };
-  if (position === 'right') return { ...base, orient: 'vertical', right: 0, top: 'middle' };
-  if (position === 'bottom') return { ...base, orient: 'horizontal', left: 'center', bottom: 0 };
-  return { ...base, orient: 'horizontal', right: 4, top: 0 };
-};
-
-const chartOptionFor = (
-  spec: AnalysisSpec,
-  dataset: PublishedDataset,
-  result: DatasetQueryResult,
-) => {
-  const encoding = resolveAnalysisEncoding(spec);
-  const style = resolveAnalysisStyle(spec.style);
-  const colors = paletteColors(spec.style);
-  const firstDimension = encoding.category.find((binding) => binding.role === 'dimension')?.field
-    ?? spec.dimensions[0];
-  const colorDimension = encoding.color.find((binding) => binding.role === 'dimension')?.field;
-  const dimension = getAnalysisField(dataset, firstDimension);
-  const metrics = spec.metrics;
-  const computedValues = new Map(metrics.map((metric) => [
-    metric.field,
-    analysisMetricValues(spec, result, metric),
-  ]));
-  const metricValue = (metric: MetricBinding, rowIndex: number) =>
-    computedValues.get(metric.field)?.[rowIndex] ?? null;
-  const formatted = (metric: MetricBinding, value: unknown) => {
-    if (value === null || value === undefined) return '—';
-    const number = Number(value);
-    return formatAnalysisMetricValue(spec, metric, Number.isFinite(number) ? number : null);
-  };
-  const axisText = '#667085';
-  const axisLine = '#d8dde6';
-  const splitLine = '#eef1f5';
-
-  if (!firstDimension || !metrics.length) return undefined;
-
-  if (spec.type === 'pie') {
-    const metric = metrics[0];
-    const metricConfig = metricComputationFor(spec, metric.field);
-    const legacyPieLabel = metricConfig.quickCalculation === 'none'
-      && metricConfig.numberFormat === 'auto';
-    const legendVisible = style.showLegend;
-    const legendOnRight = legendVisible && style.legendPosition === 'right';
-    const legendOnTop = legendVisible && style.legendPosition === 'top';
-    const legendOnBottom = legendVisible && style.legendPosition === 'bottom';
-    const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
-    return {
-      color: colors,
-      tooltip: {
-        trigger: 'item',
-        valueFormatter: (value: unknown) => formatted(metric, value),
-      },
-      legend: legendOption(legendVisible, style.legendPosition, axisText),
-      series: [{
-        name: metricAnalysisDisplayName(spec, dataset, metric),
-        type: 'pie',
-        radius: [`${style.pieInnerRadius}%`, '70%'],
-        center: [
-          legendOnRight ? '38%' : '50%',
-          legendOnTop ? '56%' : legendOnBottom ? '45%' : '52%',
-        ],
-        label: {
-          show: style.showDataLabels,
-          position: labelPosition,
-          formatter: legacyPieLabel
-            ? (labelPosition === 'inside' ? '{d}%' : '{b} {d}%')
-            : (params: any) => labelPosition === 'inside'
-              ? formatted(metric, params?.value)
-              : `${params?.name ?? ''} ${formatted(metric, params?.value)}`.trim(),
-        },
-        itemStyle: { borderColor: '#fff', borderWidth: 2 },
-        data: result.rows.map((row, rowIndex) => ({
-          name: rowLabel(result, row, [firstDimension]),
-          value: metricValue(metric, rowIndex),
-          __rowIndex: rowIndex,
-        })),
-      }],
-    };
-  }
-
-  if (spec.type === 'bar' || spec.type === 'line') {
-    const isLine = spec.type === 'line';
-    const categories = uniqueDimensionValues(result, firstDimension);
-    const colorValues = colorDimension
-      ? uniqueDimensionValues(result, colorDimension)
-      : [];
-    const legendVisible = style.showLegend;
-    const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'top';
-
-    const rowIndexFor = (category: Scalar, color?: Scalar) => result.rows.findIndex((row) => (
-      Object.is(cell(result, row, firstDimension), category)
-      && (!colorDimension || Object.is(cell(result, row, colorDimension), color))
-    ));
-
-    const seriesStyleFor = (metric: MetricBinding) => ({
-      smooth: isLine && style.smooth,
-      symbolSize: isLine ? style.symbolSize : undefined,
-      lineStyle: isLine ? { width: style.lineWidth } : undefined,
-      barMaxWidth: !isLine ? style.barMaxWidth : undefined,
-      itemStyle: !isLine ? { borderRadius: style.barRadius } : undefined,
-      label: {
-        show: style.showDataLabels,
-        position: labelPosition,
-        formatter: (params: any) => formatted(metric, params?.value),
-      },
-      tooltip: {
-        valueFormatter: (value: unknown) => formatted(metric, value),
-      },
-    });
-
-    const series = colorDimension
-      ? metrics.flatMap((metric) => colorValues.map((color) => ({
-        name: metrics.length > 1
-          ? `${color.label} · ${metricAnalysisDisplayName(spec, dataset, metric)}`
-          : color.label,
-        type: spec.type,
-        ...seriesStyleFor(metric),
-        data: categories.map((category) => {
-          const rowIndex = rowIndexFor(category.value, color.value);
-          if (rowIndex < 0) return null;
-          return {
-            value: metricValue(metric, rowIndex),
-            __rowIndex: rowIndex,
-          };
-        }),
-      })))
-      : metrics.map((metric) => ({
-        name: metricAnalysisDisplayName(spec, dataset, metric),
-        type: spec.type,
-        ...seriesStyleFor(metric),
-        data: categories.map((category) => {
-          const rowIndex = rowIndexFor(category.value);
-          if (rowIndex < 0) return null;
-          return {
-            value: metricValue(metric, rowIndex),
-            __rowIndex: rowIndex,
-          };
-        }),
-      }));
-
-    return {
-      color: colors,
-      grid: {
-        left: 22,
-        right: legendVisible && style.legendPosition === 'right' ? 112 : 16,
-        top: legendVisible && style.legendPosition === 'top' ? 34 : 14,
-        bottom: legendVisible && style.legendPosition === 'bottom' ? 40 : 22,
-        containLabel: true,
-      },
-      tooltip: { trigger: 'axis' },
-      legend: legendOption(legendVisible, style.legendPosition, axisText),
-      xAxis: {
-        type: 'category',
-        boundaryGap: !isLine,
-        name: dimension?.label,
-        nameTextStyle: { color: '#98a2b3', fontSize: 10 },
-        data: categories.map((item) => item.label),
-        axisLine: { lineStyle: { color: axisLine } },
-        axisTick: { show: false },
-        axisLabel: {
-          color: axisText,
-          fontSize: 11,
-          rotate: style.axisLabelRotation,
-        },
-      },
-      yAxis: {
-        type: 'value',
-        splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
-        axisLabel: {
-          color: axisText,
-          fontSize: 11,
-          formatter: (value: number) => formatAnalysisMetricValue(spec, metrics[0], value),
-        },
-      },
-      series,
-    };
-  }
-
-  return undefined;
-};
-
 function EChartAnalysis({
   spec,
   dataset,
@@ -449,7 +218,10 @@ function EChartAnalysis({
   onSelect?: (selection: AnalysisSelection) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const option = useMemo(() => chartOptionFor(spec, dataset, result), [spec, dataset, result]);
+  const option = useMemo(
+    () => buildAnalysisChartOption(spec, dataset, result),
+    [spec, dataset, result],
+  );
 
   useEffect(() => {
     if (!containerRef.current || !option) return undefined;

--- a/yak-ops-ui/src/components/analysis/analysis-service.ts
+++ b/yak-ops-ui/src/components/analysis/analysis-service.ts
@@ -11,6 +11,7 @@ import type {
 } from './model';
 
 const ANALYSIS_API = '/api/v1/analyses';
+const SHARED_ANALYSIS_CHART_TYPES = new Set<ChartType>(['metric', 'bar', 'line', 'pie', 'table']);
 
 type AnalysisFilterWireOperator = 'EQ' | 'NE' | 'GT' | 'GTE' | 'LT' | 'LTE' | 'CONTAINS';
 
@@ -118,6 +119,9 @@ const filterOperatorWire = (operator: FilterOperator): AnalysisFilterWireOperato
 };
 
 const payload = (name: string, description: string, spec: AnalysisSpec) => {
+  if (!SHARED_ANALYSIS_CHART_TYPES.has(spec.type)) {
+    throw new Error('高级图表当前仅支持 Dashboard 本地图表；共享 Analysis 暂未扩展后端 chartType 协议');
+  }
   const metric = spec.sort
     ? spec.metrics.find((candidate) => candidate.field === spec.sort?.field)
     : undefined;

--- a/yak-ops-ui/src/components/analysis/chart-options.test.ts
+++ b/yak-ops-ui/src/components/analysis/chart-options.test.ts
@@ -1,0 +1,142 @@
+import { buildAnalysisChartOption } from './chart-options';
+import {
+  ANALYSIS_ENCODING_RULES,
+  rebindAnalysisEncoding,
+} from './encoding';
+import type {
+  AnalysisSpec,
+  ChartType,
+  DatasetQueryResult,
+  PublishedDataset,
+} from './model';
+
+const dataset: PublishedDataset = {
+  id: 'dataset-1',
+  name: '订单分析',
+  description: '',
+  status: 'ONLINE',
+  sourceTaskId: 'task-1',
+  sourceTaskName: '订单同步',
+  currentVersionNo: 1,
+  updatedAt: '2026-08-18T00:00:00Z',
+  fields: [
+    { key: 'category', label: '区域', physicalName: 'category', dataType: 'string', role: 'dimension', nullable: false },
+    { key: 'segment', label: '客群', physicalName: 'segment', dataType: 'string', role: 'dimension', nullable: false },
+    { key: 'sales', label: '销售额', physicalName: 'sales', dataType: 'number', role: 'metric', nullable: false },
+    { key: 'profit', label: '利润', physicalName: 'profit', dataType: 'number', role: 'metric', nullable: false },
+    { key: 'orders', label: '订单数', physicalName: 'orders', dataType: 'number', role: 'metric', nullable: false },
+  ],
+};
+
+const result: DatasetQueryResult = {
+  datasetId: dataset.id,
+  datasetVersionId: 'version-1',
+  datasetVersionNo: 1,
+  bindings: [
+    { key: 'd0', fieldId: 'category', displayName: '区域', dataType: 'STRING', aggregation: null },
+    { key: 'd1', fieldId: 'segment', displayName: '客群', dataType: 'STRING', aggregation: null },
+    { key: 'm0', fieldId: 'sales', displayName: '销售额', dataType: 'NUMBER', aggregation: 'SUM' },
+    { key: 'm1', fieldId: 'profit', displayName: '利润', dataType: 'NUMBER', aggregation: 'SUM' },
+    { key: 'm2', fieldId: 'orders', displayName: '订单数', dataType: 'NUMBER', aggregation: 'SUM' },
+  ],
+  columns: [],
+  rows: [
+    ['华东', 'A', 100, 20, 5],
+    ['华东', 'B', 80, 16, 4],
+    ['华南', 'A', 60, 18, 3],
+    ['华南', 'B', 40, 12, 2],
+  ],
+  returnedRows: 4,
+  truncated: false,
+  elapsedMillis: 1,
+};
+
+const specFor = (
+  type: ChartType,
+  metrics = ['sales'],
+  color = false,
+): AnalysisSpec => ({
+  type,
+  datasetId: dataset.id,
+  dimensions: color ? ['category', 'segment'] : ['category'],
+  metrics: metrics.map((field) => ({ field, aggregation: 'SUM' as const })),
+  encoding: {
+    version: 1,
+    category: [{ field: 'category', role: 'dimension' }],
+    value: metrics.map((field) => ({ field, role: 'metric' as const, aggregation: 'SUM' as const })),
+    color: color ? [{ field: 'segment', role: 'dimension' }] : [],
+    size: [],
+    label: [],
+    detail: [],
+    tooltip: [],
+  },
+  filters: [],
+  style: {
+    showLegend: true,
+    showDataLabels: false,
+    smooth: true,
+    showGrid: true,
+  },
+});
+
+describe('advanced chart encoding contracts', () => {
+  it('requires exactly two value metrics for scatter', () => {
+    const value = ANALYSIS_ENCODING_RULES.scatter.find((rule) => rule.channel === 'value');
+    expect(value).toMatchObject({ min: 2, max: 2, roles: ['metric'] });
+  });
+
+  it('seeds a missing second metric when switching to scatter', () => {
+    const rebound = rebindAnalysisEncoding(specFor('scatter', ['sales']), dataset);
+    expect(rebound.metrics.map((metric) => metric.field)).toEqual(['sales', 'profit']);
+  });
+
+  it('supports multiple radar metric axes', () => {
+    const value = ANALYSIS_ENCODING_RULES.radar.find((rule) => rule.channel === 'value');
+    expect(value).toMatchObject({ min: 2, max: 5 });
+  });
+});
+
+describe('advanced chart options', () => {
+  it('renders stacked bars with a shared stack', () => {
+    const option = buildAnalysisChartOption(specFor('stackedBar', ['sales', 'profit']), dataset, result) as any;
+    expect(option.series).toHaveLength(2);
+    expect(option.series.every((series: any) => series.type === 'bar')).toBe(true);
+    expect(option.series.map((series: any) => series.stack)).toEqual(['total', 'total']);
+  });
+
+  it('renders an area chart using line series with areaStyle', () => {
+    const option = buildAnalysisChartOption(specFor('area', ['sales']), dataset, result) as any;
+    expect(option.series[0].type).toBe('line');
+    expect(option.series[0].areaStyle).toEqual({ opacity: 0.18 });
+  });
+
+  it('maps two scatter metrics to x/y and preserves color groups', () => {
+    const option = buildAnalysisChartOption(specFor('scatter', ['sales', 'profit'], true), dataset, result) as any;
+    expect(option.series).toHaveLength(2);
+    expect(option.series[0].type).toBe('scatter');
+    expect(option.series[0].data[0]).toMatchObject({ name: '华东', value: [100, 20], __rowIndex: 0 });
+    expect(option.series[1].data[0]).toMatchObject({ name: '华东', value: [80, 16], __rowIndex: 1 });
+  });
+
+  it('maps radar metrics to indicator axes and category rows to polygons', () => {
+    const option = buildAnalysisChartOption(specFor('radar', ['sales', 'profit']), dataset, result) as any;
+    expect(option.radar.indicator.map((item: any) => item.name)).toEqual(['销售额', '利润']);
+    expect(option.series[0].type).toBe('radar');
+    expect(option.series[0].data[0]).toMatchObject({ name: '华东', value: [100, 20], __rowIndex: 0 });
+  });
+
+  it('renders funnel and treemap from category + metric semantics', () => {
+    const funnel = buildAnalysisChartOption(specFor('funnel', ['sales']), dataset, result) as any;
+    const treemap = buildAnalysisChartOption(specFor('treemap', ['sales']), dataset, result) as any;
+    expect(funnel.series[0].type).toBe('funnel');
+    expect(funnel.series[0].data[0]).toMatchObject({ name: '华东', value: 100, __rowIndex: 0 });
+    expect(treemap.series[0].type).toBe('treemap');
+    expect(treemap.series[0].data[0]).toMatchObject({ name: '华东', value: 100, __rowIndex: 0 });
+  });
+
+  it('stacks color groups per metric in stacked bar mode', () => {
+    const option = buildAnalysisChartOption(specFor('stackedBar', ['sales'], true), dataset, result) as any;
+    expect(option.series.map((series: any) => series.name)).toEqual(['A', 'B']);
+    expect(option.series.map((series: any) => series.stack)).toEqual(['sales', 'sales']);
+  });
+});

--- a/yak-ops-ui/src/components/analysis/chart-options.ts
+++ b/yak-ops-ui/src/components/analysis/chart-options.ts
@@ -1,0 +1,541 @@
+import {
+  analysisMetricValues,
+  formatAnalysisMetricValue,
+  metricComputationFor,
+} from './analysis';
+import {
+  getAnalysisField,
+  metricAnalysisDisplayName,
+  metricFieldLabel,
+} from './display';
+import { resolveAnalysisEncoding } from './encoding';
+import type {
+  AnalysisSpec,
+  DatasetQueryResult,
+  MetricBinding,
+  PublishedDataset,
+  Scalar,
+} from './model';
+import { paletteColors, resolveAnalysisStyle } from './style';
+
+const bindingIndex = (
+  result: DatasetQueryResult,
+  fieldId: string,
+  aggregation?: MetricBinding['aggregation'],
+) => result.bindings.findIndex((binding) => (
+  binding.fieldId === fieldId
+    && (aggregation ? binding.aggregation === aggregation : !binding.aggregation)
+));
+
+const cell = (
+  result: DatasetQueryResult,
+  row: Scalar[],
+  fieldId: string,
+  aggregation?: MetricBinding['aggregation'],
+) => {
+  const index = bindingIndex(result, fieldId, aggregation);
+  return index >= 0 ? row[index] : null;
+};
+
+const rowLabel = (result: DatasetQueryResult, row: Scalar[], dimensions: string[]) =>
+  dimensions.map((fieldId) => String(cell(result, row, fieldId) ?? '')).join(' / ');
+
+const scalarKey = (value: Scalar) => `${typeof value}:${String(value)}`;
+
+const uniqueDimensionValues = (
+  result: DatasetQueryResult,
+  fieldId: string,
+) => {
+  const seen = new Set<string>();
+  return result.rows.flatMap((row) => {
+    const value = cell(result, row, fieldId);
+    const key = scalarKey(value);
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{ key, value, label: String(value ?? '') }];
+  });
+};
+
+const legendOption = (
+  visible: boolean,
+  position: 'top' | 'right' | 'bottom',
+  axisText: string,
+) => {
+  if (!visible) return { show: false };
+  const base = { textStyle: { color: axisText, fontSize: 11 } };
+  if (position === 'right') return { ...base, orient: 'vertical', right: 0, top: 'middle' };
+  if (position === 'bottom') return { ...base, orient: 'horizontal', left: 'center', bottom: 0 };
+  return { ...base, orient: 'horizontal', right: 4, top: 0 };
+};
+
+const chartRuntime = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const encoding = resolveAnalysisEncoding(spec);
+  const style = resolveAnalysisStyle(spec.style);
+  const colors = paletteColors(spec.style);
+  const firstDimension = encoding.category.find((binding) => binding.role === 'dimension')?.field
+    ?? spec.dimensions[0];
+  const colorDimension = encoding.color.find((binding) => binding.role === 'dimension')?.field;
+  const metrics = spec.metrics;
+  const computedValues = new Map(metrics.map((metric) => [
+    metric.field,
+    analysisMetricValues(spec, result, metric),
+  ]));
+  const metricValue = (metric: MetricBinding, rowIndex: number) =>
+    computedValues.get(metric.field)?.[rowIndex] ?? null;
+  const formatted = (metric: MetricBinding, value: unknown) => {
+    if (value === null || value === undefined) return '—';
+    const number = Number(value);
+    return formatAnalysisMetricValue(spec, metric, Number.isFinite(number) ? number : null);
+  };
+  return {
+    encoding,
+    style,
+    colors,
+    firstDimension,
+    colorDimension,
+    metrics,
+    computedValues,
+    metricValue,
+    formatted,
+  };
+};
+
+const axisText = '#667085';
+const axisLine = '#d8dde6';
+const splitLine = '#eef1f5';
+
+const cartesianSeriesOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const {
+    style,
+    colors,
+    firstDimension,
+    colorDimension,
+    metrics,
+    metricValue,
+    formatted,
+  } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+
+  const isLine = spec.type === 'line' || spec.type === 'area';
+  const isArea = spec.type === 'area';
+  const isStacked = spec.type === 'stackedBar';
+  const categories = uniqueDimensionValues(result, firstDimension);
+  const colorValues = colorDimension
+    ? uniqueDimensionValues(result, colorDimension)
+    : [];
+  const legendVisible = style.showLegend;
+  const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'top';
+  const dimension = getAnalysisField(dataset, firstDimension);
+
+  const rowIndexFor = (category: Scalar, color?: Scalar) => result.rows.findIndex((row) => (
+    Object.is(cell(result, row, firstDimension), category)
+    && (!colorDimension || Object.is(cell(result, row, colorDimension), color))
+  ));
+
+  const seriesStyleFor = (metric: MetricBinding, stack?: string) => ({
+    type: isLine ? 'line' : 'bar',
+    stack,
+    smooth: isLine && style.smooth,
+    symbolSize: isLine ? style.symbolSize : undefined,
+    lineStyle: isLine ? { width: style.lineWidth } : undefined,
+    areaStyle: isArea ? { opacity: 0.18 } : undefined,
+    barMaxWidth: !isLine ? style.barMaxWidth : undefined,
+    itemStyle: !isLine ? { borderRadius: style.barRadius } : undefined,
+    label: {
+      show: style.showDataLabels,
+      position: labelPosition,
+      formatter: (params: any) => formatted(metric, params?.value),
+    },
+    tooltip: {
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+  });
+
+  const series = colorDimension
+    ? metrics.flatMap((metric) => colorValues.map((color) => ({
+      name: metrics.length > 1
+        ? `${color.label} · ${metricAnalysisDisplayName(spec, dataset, metric)}`
+        : color.label,
+      ...seriesStyleFor(metric, isStacked ? metric.field : undefined),
+      data: categories.map((category) => {
+        const rowIndex = rowIndexFor(category.value, color.value);
+        if (rowIndex < 0) return null;
+        return {
+          value: metricValue(metric, rowIndex),
+          __rowIndex: rowIndex,
+        };
+      }),
+    })))
+    : metrics.map((metric) => ({
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      ...seriesStyleFor(metric, isStacked ? 'total' : undefined),
+      data: categories.map((category) => {
+        const rowIndex = rowIndexFor(category.value);
+        if (rowIndex < 0) return null;
+        return {
+          value: metricValue(metric, rowIndex),
+          __rowIndex: rowIndex,
+        };
+      }),
+    }));
+
+  return {
+    color: colors,
+    grid: {
+      left: 22,
+      right: legendVisible && style.legendPosition === 'right' ? 112 : 16,
+      top: legendVisible && style.legendPosition === 'top' ? 34 : 14,
+      bottom: legendVisible && style.legendPosition === 'bottom' ? 40 : 22,
+      containLabel: true,
+    },
+    tooltip: { trigger: 'axis' },
+    legend: legendOption(legendVisible, style.legendPosition, axisText),
+    xAxis: {
+      type: 'category',
+      boundaryGap: !isLine,
+      name: dimension?.label,
+      nameTextStyle: { color: '#98a2b3', fontSize: 10 },
+      data: categories.map((item) => item.label),
+      axisLine: { lineStyle: { color: axisLine } },
+      axisTick: { show: false },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        rotate: style.axisLabelRotation,
+      },
+    },
+    yAxis: {
+      type: 'value',
+      splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        formatter: (value: number) => formatAnalysisMetricValue(spec, metrics[0], value),
+      },
+    },
+    series,
+  };
+};
+
+const pieOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, metricValue, formatted } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+  const metric = metrics[0];
+  const metricConfig = metricComputationFor(spec, metric.field);
+  const legacyPieLabel = metricConfig.quickCalculation === 'none'
+    && metricConfig.numberFormat === 'auto';
+  const legendVisible = style.showLegend;
+  const legendOnRight = legendVisible && style.legendPosition === 'right';
+  const legendOnTop = legendVisible && style.legendPosition === 'top';
+  const legendOnBottom = legendVisible && style.legendPosition === 'bottom';
+  const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
+
+  return {
+    color: colors,
+    tooltip: {
+      trigger: 'item',
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+    legend: legendOption(legendVisible, style.legendPosition, axisText),
+    series: [{
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      type: 'pie',
+      radius: [`${style.pieInnerRadius}%`, '70%'],
+      center: [
+        legendOnRight ? '38%' : '50%',
+        legendOnTop ? '56%' : legendOnBottom ? '45%' : '52%',
+      ],
+      label: {
+        show: style.showDataLabels,
+        position: labelPosition,
+        formatter: legacyPieLabel
+          ? (labelPosition === 'inside' ? '{d}%' : '{b} {d}%')
+          : (params: any) => labelPosition === 'inside'
+            ? formatted(metric, params?.value)
+            : `${params?.name ?? ''} ${formatted(metric, params?.value)}`.trim(),
+      },
+      itemStyle: { borderColor: '#fff', borderWidth: 2 },
+      data: result.rows.map((row, rowIndex) => ({
+        name: rowLabel(result, row, [firstDimension]),
+        value: metricValue(metric, rowIndex),
+        __rowIndex: rowIndex,
+      })),
+    }],
+  };
+};
+
+const scatterOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const {
+    style,
+    colors,
+    firstDimension,
+    colorDimension,
+    metrics,
+    metricValue,
+  } = runtime;
+  if (!firstDimension || metrics.length < 2) return undefined;
+  const [xMetric, yMetric] = metrics;
+  const colorValues = colorDimension
+    ? uniqueDimensionValues(result, colorDimension)
+    : [{ key: 'all', value: undefined as Scalar | undefined, label: metricFieldLabel(spec, dataset, yMetric) }];
+  const pointSize = Math.max(6, style.symbolSize);
+
+  const series = colorValues.map((color) => ({
+    name: color.label,
+    type: 'scatter',
+    symbolSize: pointSize,
+    label: {
+      show: style.showDataLabels,
+      position: style.dataLabelPosition === 'inside' ? 'inside' : 'top',
+      formatter: (params: any) => params?.name ?? '',
+    },
+    data: result.rows.flatMap((row, rowIndex) => {
+      if (
+        colorDimension
+        && !Object.is(cell(result, row, colorDimension), color.value)
+      ) return [];
+      const x = metricValue(xMetric, rowIndex);
+      const y = metricValue(yMetric, rowIndex);
+      if (x === null || y === null) return [];
+      return [{
+        name: rowLabel(result, row, [firstDimension]),
+        value: [x, y],
+        __rowIndex: rowIndex,
+      }];
+    }),
+  }));
+
+  return {
+    color: colors,
+    grid: {
+      left: 24,
+      right: colorDimension && style.showLegend && style.legendPosition === 'right' ? 112 : 20,
+      top: colorDimension && style.showLegend && style.legendPosition === 'top' ? 34 : 18,
+      bottom: colorDimension && style.showLegend && style.legendPosition === 'bottom' ? 46 : 34,
+      containLabel: true,
+    },
+    tooltip: { trigger: 'item' },
+    legend: legendOption(Boolean(colorDimension) && style.showLegend, style.legendPosition, axisText),
+    xAxis: {
+      type: 'value',
+      name: metricFieldLabel(spec, dataset, xMetric),
+      nameLocation: 'middle',
+      nameGap: 28,
+      nameTextStyle: { color: '#98a2b3', fontSize: 10 },
+      axisLine: { lineStyle: { color: axisLine } },
+      splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        formatter: (value: number) => formatAnalysisMetricValue(spec, xMetric, value),
+      },
+    },
+    yAxis: {
+      type: 'value',
+      name: metricFieldLabel(spec, dataset, yMetric),
+      nameTextStyle: { color: '#98a2b3', fontSize: 10 },
+      axisLine: { lineStyle: { color: axisLine } },
+      splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        formatter: (value: number) => formatAnalysisMetricValue(spec, yMetric, value),
+      },
+    },
+    series,
+  };
+};
+
+const radarOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, computedValues } = runtime;
+  if (!firstDimension || metrics.length < 2) return undefined;
+
+  const indicator = metrics.map((metric) => {
+    const values = (computedValues.get(metric.field) ?? [])
+      .filter((value): value is number => value !== null && Number.isFinite(value));
+    const minValue = values.length ? Math.min(...values) : 0;
+    const maxValue = values.length ? Math.max(...values) : 0;
+    const low = Math.min(0, minValue);
+    const high = Math.max(0, maxValue);
+    const span = Math.max(1, high - low, Math.abs(high), Math.abs(low));
+    return {
+      name: metricFieldLabel(spec, dataset, metric),
+      min: low < 0 ? low - span * 0.1 : 0,
+      max: high + span * 0.1,
+    };
+  });
+
+  const data = result.rows.flatMap((row, rowIndex) => {
+    const values = metrics.map((metric) => computedValues.get(metric.field)?.[rowIndex] ?? null);
+    if (values.some((value) => value === null)) return [];
+    return [{
+      name: rowLabel(result, row, [firstDimension]),
+      value: values,
+      __rowIndex: rowIndex,
+    }];
+  });
+
+  return {
+    color: colors,
+    tooltip: { trigger: 'item' },
+    legend: legendOption(style.showLegend, style.legendPosition, axisText),
+    radar: {
+      indicator,
+      radius: '62%',
+      center: [style.showLegend && style.legendPosition === 'right' ? '42%' : '50%', '53%'],
+      splitNumber: 4,
+      axisName: { color: axisText, fontSize: 10 },
+      axisLine: { lineStyle: { color: axisLine } },
+      splitLine: { lineStyle: { color: splitLine } },
+      splitArea: { show: false },
+    },
+    series: [{
+      type: 'radar',
+      symbolSize: Math.max(4, style.symbolSize),
+      lineStyle: { width: style.lineWidth },
+      areaStyle: { opacity: 0.08 },
+      data,
+    }],
+  };
+};
+
+const funnelOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, metricValue, formatted } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+  const metric = metrics[0];
+  const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
+
+  return {
+    color: colors,
+    tooltip: {
+      trigger: 'item',
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+    legend: legendOption(style.showLegend, style.legendPosition, axisText),
+    series: [{
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      type: 'funnel',
+      left: '10%',
+      top: style.showLegend && style.legendPosition === 'top' ? 38 : 18,
+      bottom: style.showLegend && style.legendPosition === 'bottom' ? 42 : 18,
+      width: style.showLegend && style.legendPosition === 'right' ? '68%' : '80%',
+      minSize: '10%',
+      maxSize: '100%',
+      sort: 'descending',
+      gap: 2,
+      label: {
+        show: style.showDataLabels,
+        position: labelPosition,
+        formatter: (params: any) => `${params?.name ?? ''} ${formatted(metric, params?.value)}`.trim(),
+      },
+      itemStyle: { borderColor: '#fff', borderWidth: 1 },
+      data: result.rows.flatMap((row, rowIndex) => {
+        const value = metricValue(metric, rowIndex);
+        if (value === null) return [];
+        return [{
+          name: rowLabel(result, row, [firstDimension]),
+          value,
+          __rowIndex: rowIndex,
+        }];
+      }),
+    }],
+  };
+};
+
+const treemapOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, metricValue, formatted } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+  const metric = metrics[0];
+
+  return {
+    color: colors,
+    tooltip: {
+      trigger: 'item',
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+    series: [{
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      type: 'treemap',
+      roam: false,
+      nodeClick: false,
+      breadcrumb: { show: false },
+      label: {
+        show: true,
+        color: '#fff',
+        fontSize: 11,
+        lineHeight: 16,
+        formatter: (params: any) => style.showDataLabels
+          ? `${params?.name ?? ''}\n${formatted(metric, params?.value)}`
+          : params?.name ?? '',
+      },
+      itemStyle: {
+        borderColor: '#fff',
+        borderWidth: 2,
+        gapWidth: 2,
+      },
+      data: result.rows.flatMap((row, rowIndex) => {
+        const value = metricValue(metric, rowIndex);
+        if (value === null) return [];
+        return [{
+          name: rowLabel(result, row, [firstDimension]),
+          value,
+          __rowIndex: rowIndex,
+        }];
+      }),
+    }],
+  };
+};
+
+/** Build the ECharts option for every non-table/non-metric Analysis chart type. */
+export const buildAnalysisChartOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  if (
+    spec.type === 'bar'
+    || spec.type === 'stackedBar'
+    || spec.type === 'line'
+    || spec.type === 'area'
+  ) return cartesianSeriesOption(spec, dataset, result);
+  if (spec.type === 'pie') return pieOption(spec, dataset, result);
+  if (spec.type === 'scatter') return scatterOption(spec, dataset, result);
+  if (spec.type === 'radar') return radarOption(spec, dataset, result);
+  if (spec.type === 'funnel') return funnelOption(spec, dataset, result);
+  if (spec.type === 'treemap') return treemapOption(spec, dataset, result);
+  return undefined;
+};

--- a/yak-ops-ui/src/components/analysis/display.ts
+++ b/yak-ops-ui/src/components/analysis/display.ts
@@ -1,0 +1,51 @@
+import {
+  metricComputationFor,
+  quickCalculationLabel,
+} from './analysis';
+import { calculatedFieldFor } from './calculated-field';
+import type {
+  Aggregation,
+  AnalysisSpec,
+  MetricBinding,
+  PublishedDataset,
+} from './model';
+
+export const AGGREGATION_LABELS: Record<Aggregation, string> = {
+  SUM: '求和',
+  AVG: '平均',
+  COUNT: '计数',
+  COUNT_DISTINCT: '去重计数',
+  MAX: '最大值',
+  MIN: '最小值',
+};
+
+export const getAnalysisField = (dataset: PublishedDataset, fieldKey?: string) =>
+  dataset.fields.find((field) => field.key === fieldKey);
+
+export const metricFieldLabel = (
+  spec: Pick<AnalysisSpec, 'analysis'>,
+  dataset: PublishedDataset,
+  metric: MetricBinding,
+) => calculatedFieldFor(spec, metric.field)?.name
+  ?? getAnalysisField(dataset, metric.field)?.label
+  ?? metric.field;
+
+export const metricDisplayName = (
+  dataset: PublishedDataset,
+  metric: MetricBinding,
+) => `${getAnalysisField(dataset, metric.field)?.label ?? metric.field} · ${AGGREGATION_LABELS[metric.aggregation]}`;
+
+export const metricAnalysisDisplayName = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  metric: MetricBinding,
+) => {
+  const calculated = calculatedFieldFor(spec, metric.field);
+  const base = calculated
+    ? `${calculated.name} · 计算字段`
+    : metricDisplayName(dataset, metric);
+  const calculation = spec.type === 'metric'
+    ? 'none'
+    : metricComputationFor(spec, metric.field).quickCalculation;
+  return calculation === 'none' ? base : `${base} · ${quickCalculationLabel(calculation)}`;
+};

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -39,11 +39,7 @@ const slot = (
   hint?: string,
 ): AnalysisEncodingSlotRule => ({ channel, label, roles, min, max, hint });
 
-/**
- * Semantic channel contracts for the chart renderers currently shipped by Yak Ops.
- * size / label / tooltip already exist in the versioned grammar and can be activated by
- * later renderers without another persistence migration.
- */
+/** Semantic channel contracts for every chart renderer currently shipped by Yak Ops. */
 export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule[]> = {
   metric: [
     slot('value', '值', ['metric'], 1, 1, '指标卡需要 1 个指标'),
@@ -53,14 +49,41 @@ export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule
     slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
     slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
   ],
+  stackedBar: [
+    slot('category', '分类', ['dimension'], 1, 1, '堆叠柱状图需要 1 个分类字段'),
+    slot('value', '值', ['metric'], 1, 3, '最多 3 个指标；多个指标会自动堆叠'),
+    slot('color', '堆叠分组', ['dimension'], 0, 1, '可按 1 个维度拆分堆叠系列'),
+  ],
   line: [
     slot('category', '分类', ['dimension'], 1, 1, '折线图需要 1 个分类字段'),
+    slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
+    slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
+  ],
+  area: [
+    slot('category', '分类', ['dimension'], 1, 1, '面积图需要 1 个分类字段'),
     slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
     slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
   ],
   pie: [
     slot('category', '分类', ['dimension'], 1, 1, '饼图需要 1 个分类字段'),
     slot('value', '值', ['metric'], 1, 1, '饼图需要 1 个指标'),
+  ],
+  scatter: [
+    slot('category', '点标签', ['dimension'], 1, 1, '散点图需要 1 个维度标识每个点'),
+    slot('value', '坐标值', ['metric'], 2, 2, '前两个指标分别作为 X / Y 轴'),
+    slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分点系列'),
+  ],
+  radar: [
+    slot('category', '对象', ['dimension'], 1, 1, '雷达图按 1 个维度生成对象'),
+    slot('value', '指标轴', ['metric'], 2, 5, '配置 2~5 个指标作为雷达轴'),
+  ],
+  funnel: [
+    slot('category', '阶段', ['dimension'], 1, 1, '漏斗图需要 1 个阶段字段'),
+    slot('value', '值', ['metric'], 1, 1, '漏斗图需要 1 个指标'),
+  ],
+  treemap: [
+    slot('category', '分类', ['dimension'], 1, 1, '矩形树图需要 1 个分类字段'),
+    slot('value', '面积值', ['metric'], 1, 1, '矩形面积由 1 个指标决定'),
   ],
   table: [
     slot('category', '维度', ['dimension'], 0, 3, '最多 3 个维度'),
@@ -98,15 +121,17 @@ export const cloneAnalysisEncoding = (encoding: AnalysisEncoding): AnalysisEncod
 });
 
 /**
- * Legacy snapshots have only the query projection. For bar/line we can safely infer
- * category + color from the first two projected dimensions because Encoding v1 is the
- * first editor version that intentionally produces that shape. Other charts keep their
- * historical dimensions in category to avoid inventing semantics that were never stored.
+ * Legacy snapshots have only the query projection. Cartesian grouped charts can safely
+ * infer category + color from the first two projected dimensions because Encoding v1 is
+ * the first editor version that intentionally produces that shape.
  */
 export const legacyAnalysisEncoding = (
   spec: Pick<AnalysisSpec, 'type' | 'dimensions' | 'metrics'>,
 ): AnalysisEncoding => {
-  const groupedSeries = spec.type === 'bar' || spec.type === 'line';
+  const groupedSeries = spec.type === 'bar'
+    || spec.type === 'line'
+    || spec.type === 'stackedBar'
+    || spec.type === 'area';
   const categoryDimensions = groupedSeries ? spec.dimensions.slice(0, 1) : spec.dimensions;
   const colorDimensions = groupedSeries ? spec.dimensions.slice(1, 2) : [];
   return {

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -24,7 +24,15 @@ export interface PublishedDataset {
   fields: DatasetField[];
 }
 
-export type ChartType = 'metric' | 'bar' | 'line' | 'pie' | 'table';
+export type BasicChartType = 'metric' | 'bar' | 'line' | 'pie' | 'table';
+export type AdvancedChartType =
+  | 'stackedBar'
+  | 'area'
+  | 'scatter'
+  | 'radar'
+  | 'funnel'
+  | 'treemap';
+export type ChartType = BasicChartType | AdvancedChartType;
 export type Aggregation = 'SUM' | 'AVG' | 'COUNT' | 'COUNT_DISTINCT' | 'MAX' | 'MIN';
 export type SortDirection = 'asc' | 'desc';
 export type FilterOperator = 'eq' | 'neq' | 'contains' | 'gt' | 'gte' | 'lt' | 'lte';

--- a/yak-ops-ui/src/components/analysis/style.ts
+++ b/yak-ops-ui/src/components/analysis/style.ts
@@ -81,11 +81,15 @@ export const resolveAnalysisStyle = (
   stripedRows: style?.stripedRows ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.stripedRows,
 });
 
+const defaultLegendTypes = new Set<ChartType>(['pie', 'stackedBar', 'area', 'radar']);
+const smoothTypes = new Set<ChartType>(['line', 'area']);
+const gridTypes = new Set<ChartType>(['bar', 'stackedBar', 'line', 'area', 'scatter']);
+
 export const createAnalysisVisualConfig = (type: ChartType): AnalysisVisualConfig => ({
   ...DEFAULT_ANALYSIS_VISUAL_CONFIG,
-  showLegend: type === 'pie',
-  smooth: type === 'line',
-  showGrid: type === 'bar' || type === 'line',
+  showLegend: defaultLegendTypes.has(type),
+  smooth: smoothTypes.has(type),
+  showGrid: gridTypes.has(type),
 });
 
 export const paletteColors = (style?: AnalysisVisualConfig) => {

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -5,6 +5,7 @@ import {
 import {
   applyAnalysisEncoding,
   changeAnalysisEncodingType,
+  rebindAnalysisEncoding,
   updateEncodingMetricAggregation,
 } from '@/components/analysis/encoding';
 import type { AnalysisEncoding, AnalysisSpec } from '@/components/analysis/model';
@@ -134,7 +135,8 @@ export function ChartSheetConfigPanel({
   const physicalMetrics = spec.metrics.filter((metric) => !isCalculatedFieldKey(spec, metric.field));
 
   const changeType = (type: ChartType) => {
-    const next = changeAnalysisEncodingType(spec, type);
+    const changed = changeAnalysisEncodingType(spec, type);
+    const next = rebindAnalysisEncoding(changed, dataset);
     updateInlineAnalysis({
       type,
       encoding: next.encoding,
@@ -174,7 +176,7 @@ export function ChartSheetConfigPanel({
     const hasColor = Boolean(next.encoding.color.length);
     const shouldRevealLegend = !hadColor
       && hasColor
-      && (spec.type === 'bar' || spec.type === 'line');
+      && ['bar', 'stackedBar', 'line', 'area', 'scatter'].includes(spec.type);
     updateInlineAnalysis({
       encoding: next.encoding,
       dimensions: next.dimensions,
@@ -221,13 +223,14 @@ export function ChartSheetConfigPanel({
 
         <div className="mt-5">
           <SectionLabel>图表类型</SectionLabel>
-          <div className="grid grid-cols-5 gap-1.5">
+          <div className="grid grid-cols-4 gap-1.5">
             {(Object.keys(CHART_META) as ChartType[]).map((type) => {
               const active = spec.type === type;
               return (
                 <button
                   key={type}
                   type="button"
+                  title={CHART_META[type].description}
                   onClick={() => changeType(type)}
                   className={[
                     'flex min-w-0 flex-col items-center justify-center gap-1.5 rounded-[7px] border px-1 py-2.5 text-[10px] transition-[background-color,border-color,color]',
@@ -239,10 +242,13 @@ export function ChartSheetConfigPanel({
                   <span className={active ? 'text-[#344054]' : 'text-[#a0a6af]'}>
                     {CHART_META[type].icon}
                   </span>
-                  <span className="truncate">{CHART_META[type].label}</span>
+                  <span className="w-full truncate text-center">{CHART_META[type].label}</span>
                 </button>
               );
             })}
+          </div>
+          <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
+            高级图表沿用 Encoding v1；切换类型时会保留可兼容字段，并自动补齐必填槽位。
           </div>
         </div>
 

--- a/yak-ops-ui/src/pages/dashboard/config-style.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-style.tsx
@@ -18,11 +18,32 @@ export function ChartStyleConfig({
   onChange: (patch: Partial<AnalysisVisualConfig>) => void;
 }) {
   const style = resolveAnalysisStyle(spec.style);
-  const hasCartesianAxes = spec.type === 'bar' || spec.type === 'line';
-  const supportsLegend = spec.type === 'bar' || spec.type === 'line' || spec.type === 'pie';
-  const supportsLabels = supportsLegend;
-  const supportsPalette = supportsLegend;
-  const activeLabelPosition: AnalysisDataLabelPosition = spec.type === 'pie'
+  const hasCartesianAxes = ['bar', 'stackedBar', 'line', 'area', 'scatter'].includes(spec.type);
+  const hasCategoricalAxis = ['bar', 'stackedBar', 'line', 'area'].includes(spec.type);
+  const supportsLegend = [
+    'bar',
+    'stackedBar',
+    'line',
+    'area',
+    'pie',
+    'scatter',
+    'radar',
+    'funnel',
+  ].includes(spec.type);
+  const supportsLabels = [
+    'bar',
+    'stackedBar',
+    'line',
+    'area',
+    'pie',
+    'scatter',
+    'funnel',
+    'treemap',
+  ].includes(spec.type);
+  const supportsPalette = !['metric', 'table'].includes(spec.type);
+  const supportsLabelPosition = supportsLabels && spec.type !== 'treemap';
+  const radialLabelPosition = spec.type === 'pie' || spec.type === 'funnel';
+  const activeLabelPosition: AnalysisDataLabelPosition = radialLabelPosition
     ? style.dataLabelPosition === 'inside' ? 'inside' : 'outside'
     : style.dataLabelPosition === 'inside' ? 'inside' : 'top';
 
@@ -90,17 +111,17 @@ export function ChartStyleConfig({
             {supportsLabels ? (
               <>
                 <ToggleRow
-                  label="显示数据标签"
+                  label={spec.type === 'treemap' ? '显示数值' : '显示数据标签'}
                   checked={style.showDataLabels}
                   onChange={(showDataLabels) => onChange({ showDataLabels })}
                 />
-                {style.showDataLabels ? (
+                {style.showDataLabels && supportsLabelPosition ? (
                   <ControlRow label="标签位置">
                     <Select
                       size="small"
                       className="w-[116px]"
                       value={activeLabelPosition}
-                      options={spec.type === 'pie'
+                      options={radialLabelPosition
                         ? [
                           { label: '外侧', value: 'outside' },
                           { label: '内部', value: 'inside' },
@@ -127,25 +148,27 @@ export function ChartStyleConfig({
               checked={style.showGrid}
               onChange={(showGrid) => onChange({ showGrid })}
             />
-            <ControlRow label="标签旋转">
-              <Select
-                size="small"
-                className="w-[116px]"
-                value={style.axisLabelRotation}
-                options={[
-                  { label: '不旋转', value: 0 },
-                  { label: '30°', value: 30 },
-                  { label: '45°', value: 45 },
-                ]}
-                onChange={(axisLabelRotation: 0 | 30 | 45) => onChange({ axisLabelRotation })}
-              />
-            </ControlRow>
+            {hasCategoricalAxis ? (
+              <ControlRow label="标签旋转">
+                <Select
+                  size="small"
+                  className="w-[116px]"
+                  value={style.axisLabelRotation}
+                  options={[
+                    { label: '不旋转', value: 0 },
+                    { label: '30°', value: 30 },
+                    { label: '45°', value: 45 },
+                  ]}
+                  onChange={(axisLabelRotation: 0 | 30 | 45) => onChange({ axisLabelRotation })}
+                />
+              </ControlRow>
+            ) : null}
           </div>
         </StyleGroup>
       ) : null}
 
-      {spec.type === 'bar' ? (
-        <StyleGroup title="柱形">
+      {spec.type === 'bar' || spec.type === 'stackedBar' ? (
+        <StyleGroup title={spec.type === 'stackedBar' ? '堆叠柱形' : '柱形'}>
           <div className="space-y-3">
             <NumberRow
               label="最大宽度"
@@ -167,8 +190,8 @@ export function ChartStyleConfig({
         </StyleGroup>
       ) : null}
 
-      {spec.type === 'line' ? (
-        <StyleGroup title="折线">
+      {spec.type === 'line' || spec.type === 'area' ? (
+        <StyleGroup title={spec.type === 'area' ? '面积线' : '折线'}>
           <div className="space-y-3">
             <ToggleRow
               label="平滑曲线"
@@ -192,6 +215,19 @@ export function ChartStyleConfig({
               onChange={(symbolSize) => onChange({ symbolSize })}
             />
           </div>
+        </StyleGroup>
+      ) : null}
+
+      {spec.type === 'scatter' ? (
+        <StyleGroup title="散点">
+          <NumberRow
+            label="点大小"
+            value={style.symbolSize}
+            min={0}
+            max={14}
+            suffix="px"
+            onChange={(symbolSize) => onChange({ symbolSize })}
+          />
         </StyleGroup>
       ) : null}
 

--- a/yak-ops-ui/src/pages/dashboard/helpers.tsx
+++ b/yak-ops-ui/src/pages/dashboard/helpers.tsx
@@ -26,8 +26,14 @@ export const FIELD_DRAG_MIME = 'application/x-yak-dashboard-field';
 export const CHART_META: Record<ChartType, { label: string; description: string; icon: ReactNode }> = {
   metric: { label: '指标卡', description: '展示单个核心指标', icon: <Sigma size={15} /> },
   bar: { label: '柱状图', description: '分类对比与排行', icon: <BarChart3 size={15} /> },
+  stackedBar: { label: '堆叠柱状图', description: '堆叠比较整体与构成', icon: <BarChart3 size={15} /> },
   line: { label: '折线图', description: '趋势与时间序列', icon: <ChartLine size={15} /> },
+  area: { label: '面积图', description: '趋势变化与区间体量', icon: <ChartLine size={15} /> },
   pie: { label: '饼图', description: '占比与构成分析', icon: <ChartPie size={15} /> },
+  scatter: { label: '散点图', description: '双指标相关性与离群点', icon: <Sigma size={15} /> },
+  radar: { label: '雷达图', description: '多指标对象对比', icon: <ChartPie size={15} /> },
+  funnel: { label: '漏斗图', description: '阶段转化与逐层收敛', icon: <BarChart3 size={15} /> },
+  treemap: { label: '矩形树图', description: '按面积呈现分类贡献', icon: <Table2 size={15} /> },
   table: { label: '明细表', description: '多维度数据查看', icon: <Table2 size={15} /> },
 };
 
@@ -122,7 +128,7 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
     datasetId: dataset.id,
     // Seed semantic category even for metric cards. `applyAnalysisEncoding` keeps the
     // metric query dimensionless while preserving a useful category if the user later
-    // switches this chart to bar / line / pie.
+    // switches chart type.
     dimensions: bindings.dimensions,
     metrics: bindings.metrics,
     filters: [],
@@ -130,7 +136,17 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
     limit: type === 'table' ? 200 : 500,
     timeoutSeconds: 30,
   };
-  return applyAnalysisEncoding(base, legacyAnalysisEncoding(base));
+  const encoded = applyAnalysisEncoding(base, legacyAnalysisEncoding(base));
+  // Advanced charts such as scatter / radar have a larger minimum metric cardinality.
+  // Rebinding seeds only required slots when the Dataset has enough compatible fields.
+  return rebindAnalysisEncoding(encoded, dataset);
+};
+
+const widgetShapeFor = (type: ChartType) => {
+  if (type === 'metric') return { w: 6, h: 4, minW: 4, minH: 3 };
+  if (type === 'table') return { w: 16, h: 8, minW: 8, minH: 6 };
+  if (type === 'radar' || type === 'treemap') return { w: 12, h: 8, minW: 7, minH: 6 };
+  return { w: 10, h: 7, minW: 6, minH: 5 };
 };
 
 export const createWidget = (type: ChartType, dataset: PublishedDataset, y: number): DashboardWidget => ({
@@ -139,10 +155,7 @@ export const createWidget = (type: ChartType, dataset: PublishedDataset, y: numb
   inlineAnalysis: createInlineAnalysis(type, dataset),
   x: 0,
   y,
-  w: type === 'metric' ? 6 : type === 'table' ? 16 : 10,
-  h: type === 'metric' ? 4 : type === 'table' ? 8 : 7,
-  minW: type === 'metric' ? 4 : type === 'table' ? 8 : 6,
-  minH: type === 'metric' ? 3 : type === 'table' ? 6 : 5,
+  ...widgetShapeFor(type),
 });
 
 const rebindInlineAnalysis = (spec: AnalysisSpec, dataset: PublishedDataset): AnalysisSpec => {


### PR DESCRIPTION
## What changed
- expand the Dashboard-local `ChartType` grammar from the original 5 chart types to 11 chart types
- add **堆叠柱状图 / 面积图 / 散点图 / 雷达图 / 漏斗图 / 矩形树图** while keeping 指标卡 / 柱状图 / 折线图 / 饼图 / 明细表 intact
- give every advanced chart an explicit Encoding v1 contract instead of adding renderer-specific ad-hoc fields
- extract ECharts option construction from `AnalysisPreview` into a dedicated `chart-options.ts` renderer layer
- keep Phase 8 quick calculations / number formatting in the metric value pipeline used by the new charts
- keep Phase 9 calculated metrics in the same value encoding pipeline, including query dependency expansion + virtual metric materialization
- auto-seed missing required metric slots when creating or switching to scatter/radar if the Dataset has enough compatible metrics
- extend the chart picker and style controls for the new chart families
- preserve Dashboard click-selection row indexes so the new ECharts renderers remain compatible with the existing interaction route

## Advanced chart contracts

| Chart | Encoding contract | Renderer behavior |
| --- | --- | --- |
| 堆叠柱状图 | category 1 / value 1-3 / color 0-1 | multiple metrics stack together; a color dimension creates grouped stack series |
| 面积图 | category 1 / value 1-3 / color 0-1 | line renderer with area fill; keeps line smoothing / point / width controls |
| 散点图 | category 1 / value **2** / color 0-1 | first metric = X, second metric = Y; optional color dimension creates series |
| 雷达图 | category 1 / value 2-5 | metric bindings become radar axes; category rows become radar polygons |
| 漏斗图 | category 1 / value 1 | category rows become funnel stages, rendered descending by value |
| 矩形树图 | category 1 / value 1 | category rows become treemap nodes sized by the metric |

## Renderer architecture

```text
Dashboard AnalysisSpec
        ↓
Encoding v1 contract
        ↓
Dataset query projection
        ↓
Phase 9 calculated-field materialization
        ↓
Phase 8 quick calculations / number formatting
        ↓
chart-options.ts
        ↓
ECharts
```

`AnalysisPreview` now owns querying, loading/error states, metric cards, tables and selection routing. The chart-specific ECharts option logic lives in `chart-options.ts`, which reduces the pressure to keep growing one monolithic preview component as later chart types are added.

## Shared Analysis boundary
The existing `/api/v1/analyses` backend wire contract currently exposes only `METRIC / BAR / LINE / PIE / TABLE`. Phase 10 therefore keeps the six advanced types **Dashboard-local** and adds a client guard so an unsupported advanced chart cannot accidentally be POSTed/PUT to the shared Analysis API.

This PR does **not** change backend enums, DTOs, database schemas, Dataset query payloads or the Dashboard document version.

## Compatibility
- existing 5 chart types keep their current query and render semantics
- Encoding v1 remains the persisted visualization grammar
- advanced chart switching remains non-destructive: parked/overflow bindings stay in Encoding v1 and compatible fields are restored when switching back
- existing Dashboard save / publish / restore / undo / redo continues to persist the inline Analysis JSON
- no new npm dependency
- calculated fields remain frontend virtual metrics and never enter Dataset SQL as `calc:*` identifiers

## Stack note
Phase 9 PR #488 is still open as a Draft, so this PR intentionally targets `feat/bi-editor-phase9-calculated-fields` and contains only the Phase 10 delta. Once #488 lands, this PR can be retargeted to `main`.

## Validation
- [x] Phase 10 branch starts exactly from Phase 9 head `1fa88cfc5b2452acb3cd1bf58c3084636cd7e1eb`
- [x] branch is 0 commits behind the Phase 9 branch and 2 commits ahead
- [x] final stacked compare contains 11 frontend files only; no backend / Flyway files
- [x] added focused tests for advanced encoding cardinality, scatter/radar auto-seeding, stacked bars, area, scatter grouping, radar axes, funnel and treemap options
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm run jest -- chart-options.test.ts`
- [ ] manual browser regression across all 11 chart types, chart-type round trips, Phase 8 calculations, Phase 9 calculated metrics and Dashboard save/reopen

Executable validation is intentionally left unchecked in the current connector-only environment rather than being claimed as completed. GitHub checks should be treated as the executable integration signal if/when workflows are configured.