### PR TITLE
feat(bi): add direct cross-filter interactions (phase 11)

### DIFF
--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -4,16 +4,18 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   analysisMetricValues,
   formatAnalysisMetricValue,
-  metricComputationFor,
-  quickCalculationLabel,
   resolveAnalysisTopN,
 } from './analysis';
 import {
-  calculatedFieldFor,
   isCalculatedFieldKey,
   materializeCalculatedFields,
   queryMetricsForAnalysis,
 } from './calculated-field';
+import { buildAnalysisChartOption } from './chart-options';
+import {
+  getAnalysisField,
+  metricAnalysisDisplayName,
+} from './display';
 import { encodingMeetsChartRequirements, resolveAnalysisEncoding } from './encoding';
 import { queryAnalysisDataset } from './dataset-service';
 import type {
@@ -24,43 +26,16 @@ import type {
   DatasetField,
   DatasetQueryPayload,
   DatasetQueryResult,
-  MetricBinding,
   PublishedDataset,
   Scalar,
 } from './model';
-import { paletteColors, resolveAnalysisStyle } from './style';
+import { resolveAnalysisStyle } from './style';
 
-export const AGGREGATION_LABELS: Record<Aggregation, string> = {
-  SUM: '求和',
-  AVG: '平均',
-  COUNT: '计数',
-  COUNT_DISTINCT: '去重计数',
-  MAX: '最大值',
-  MIN: '最小值',
-};
-
-export const getAnalysisField = (dataset: PublishedDataset, fieldKey?: string) =>
-  dataset.fields.find((field) => field.key === fieldKey);
-
-export const metricDisplayName = (
-  dataset: PublishedDataset,
-  metric: AnalysisSpec['metrics'][number],
-) => `${getAnalysisField(dataset, metric.field)?.label ?? metric.field} · ${AGGREGATION_LABELS[metric.aggregation]}`;
-
-const metricAnalysisDisplayName = (
-  spec: AnalysisSpec,
-  dataset: PublishedDataset,
-  metric: MetricBinding,
-) => {
-  const calculated = calculatedFieldFor(spec, metric.field);
-  const base = calculated
-    ? `${calculated.name} · 计算字段`
-    : metricDisplayName(dataset, metric);
-  const calculation = spec.type === 'metric'
-    ? 'none'
-    : metricComputationFor(spec, metric.field).quickCalculation;
-  return calculation === 'none' ? base : `${base} · ${quickCalculationLabel(calculation)}`;
-};
+export {
+  AGGREGATION_LABELS,
+  getAnalysisField,
+  metricDisplayName,
+} from './display';
 
 const filterValue = (field: DatasetField | undefined, value: string): Scalar => {
   if (field?.dataType === 'number') {
@@ -210,25 +185,6 @@ const cell = (
   return index >= 0 ? row[index] : null;
 };
 
-const rowLabel = (result: DatasetQueryResult, row: Scalar[], dimensions: string[]) =>
-  dimensions.map((fieldId) => String(cell(result, row, fieldId) ?? '')).join(' / ');
-
-const scalarKey = (value: Scalar) => `${typeof value}:${String(value)}`;
-
-const uniqueDimensionValues = (
-  result: DatasetQueryResult,
-  fieldId: string,
-) => {
-  const seen = new Set<string>();
-  return result.rows.flatMap((row) => {
-    const value = cell(result, row, fieldId);
-    const key = scalarKey(value);
-    if (seen.has(key)) return [];
-    seen.add(key);
-    return [{ key, value, label: String(value ?? '') }];
-  });
-};
-
 const selectionForRow = (
   spec: AnalysisSpec,
   dataset: PublishedDataset,
@@ -250,193 +206,6 @@ const selectionForRow = (
   };
 };
 
-const legendOption = (
-  visible: boolean,
-  position: 'top' | 'right' | 'bottom',
-  axisText: string,
-) => {
-  if (!visible) return { show: false };
-  const base = { textStyle: { color: axisText, fontSize: 11 } };
-  if (position === 'right') return { ...base, orient: 'vertical', right: 0, top: 'middle' };
-  if (position === 'bottom') return { ...base, orient: 'horizontal', left: 'center', bottom: 0 };
-  return { ...base, orient: 'horizontal', right: 4, top: 0 };
-};
-
-const chartOptionFor = (
-  spec: AnalysisSpec,
-  dataset: PublishedDataset,
-  result: DatasetQueryResult,
-) => {
-  const encoding = resolveAnalysisEncoding(spec);
-  const style = resolveAnalysisStyle(spec.style);
-  const colors = paletteColors(spec.style);
-  const firstDimension = encoding.category.find((binding) => binding.role === 'dimension')?.field
-    ?? spec.dimensions[0];
-  const colorDimension = encoding.color.find((binding) => binding.role === 'dimension')?.field;
-  const dimension = getAnalysisField(dataset, firstDimension);
-  const metrics = spec.metrics;
-  const computedValues = new Map(metrics.map((metric) => [
-    metric.field,
-    analysisMetricValues(spec, result, metric),
-  ]));
-  const metricValue = (metric: MetricBinding, rowIndex: number) =>
-    computedValues.get(metric.field)?.[rowIndex] ?? null;
-  const formatted = (metric: MetricBinding, value: unknown) => {
-    if (value === null || value === undefined) return '—';
-    const number = Number(value);
-    return formatAnalysisMetricValue(spec, metric, Number.isFinite(number) ? number : null);
-  };
-  const axisText = '#667085';
-  const axisLine = '#d8dde6';
-  const splitLine = '#eef1f5';
-
-  if (!firstDimension || !metrics.length) return undefined;
-
-  if (spec.type === 'pie') {
-    const metric = metrics[0];
-    const metricConfig = metricComputationFor(spec, metric.field);
-    const legacyPieLabel = metricConfig.quickCalculation === 'none'
-      && metricConfig.numberFormat === 'auto';
-    const legendVisible = style.showLegend;
-    const legendOnRight = legendVisible && style.legendPosition === 'right';
-    const legendOnTop = legendVisible && style.legendPosition === 'top';
-    const legendOnBottom = legendVisible && style.legendPosition === 'bottom';
-    const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
-    return {
-      color: colors,
-      tooltip: {
-        trigger: 'item',
-        valueFormatter: (value: unknown) => formatted(metric, value),
-      },
-      legend: legendOption(legendVisible, style.legendPosition, axisText),
-      series: [{
-        name: metricAnalysisDisplayName(spec, dataset, metric),
-        type: 'pie',
-        radius: [`${style.pieInnerRadius}%`, '70%'],
-        center: [
-          legendOnRight ? '38%' : '50%',
-          legendOnTop ? '56%' : legendOnBottom ? '45%' : '52%',
-        ],
-        label: {
-          show: style.showDataLabels,
-          position: labelPosition,
-          formatter: legacyPieLabel
-            ? (labelPosition === 'inside' ? '{d}%' : '{b} {d}%')
-            : (params: any) => labelPosition === 'inside'
-              ? formatted(metric, params?.value)
-              : `${params?.name ?? ''} ${formatted(metric, params?.value)}`.trim(),
-        },
-        itemStyle: { borderColor: '#fff', borderWidth: 2 },
-        data: result.rows.map((row, rowIndex) => ({
-          name: rowLabel(result, row, [firstDimension]),
-          value: metricValue(metric, rowIndex),
-          __rowIndex: rowIndex,
-        })),
-      }],
-    };
-  }
-
-  if (spec.type === 'bar' || spec.type === 'line') {
-    const isLine = spec.type === 'line';
-    const categories = uniqueDimensionValues(result, firstDimension);
-    const colorValues = colorDimension
-      ? uniqueDimensionValues(result, colorDimension)
-      : [];
-    const legendVisible = style.showLegend;
-    const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'top';
-
-    const rowIndexFor = (category: Scalar, color?: Scalar) => result.rows.findIndex((row) => (
-      Object.is(cell(result, row, firstDimension), category)
-      && (!colorDimension || Object.is(cell(result, row, colorDimension), color))
-    ));
-
-    const seriesStyleFor = (metric: MetricBinding) => ({
-      smooth: isLine && style.smooth,
-      symbolSize: isLine ? style.symbolSize : undefined,
-      lineStyle: isLine ? { width: style.lineWidth } : undefined,
-      barMaxWidth: !isLine ? style.barMaxWidth : undefined,
-      itemStyle: !isLine ? { borderRadius: style.barRadius } : undefined,
-      label: {
-        show: style.showDataLabels,
-        position: labelPosition,
-        formatter: (params: any) => formatted(metric, params?.value),
-      },
-      tooltip: {
-        valueFormatter: (value: unknown) => formatted(metric, value),
-      },
-    });
-
-    const series = colorDimension
-      ? metrics.flatMap((metric) => colorValues.map((color) => ({
-        name: metrics.length > 1
-          ? `${color.label} · ${metricAnalysisDisplayName(spec, dataset, metric)}`
-          : color.label,
-        type: spec.type,
-        ...seriesStyleFor(metric),
-        data: categories.map((category) => {
-          const rowIndex = rowIndexFor(category.value, color.value);
-          if (rowIndex < 0) return null;
-          return {
-            value: metricValue(metric, rowIndex),
-            __rowIndex: rowIndex,
-          };
-        }),
-      })))
-      : metrics.map((metric) => ({
-        name: metricAnalysisDisplayName(spec, dataset, metric),
-        type: spec.type,
-        ...seriesStyleFor(metric),
-        data: categories.map((category) => {
-          const rowIndex = rowIndexFor(category.value);
-          if (rowIndex < 0) return null;
-          return {
-            value: metricValue(metric, rowIndex),
-            __rowIndex: rowIndex,
-          };
-        }),
-      }));
-
-    return {
-      color: colors,
-      grid: {
-        left: 22,
-        right: legendVisible && style.legendPosition === 'right' ? 112 : 16,
-        top: legendVisible && style.legendPosition === 'top' ? 34 : 14,
-        bottom: legendVisible && style.legendPosition === 'bottom' ? 40 : 22,
-        containLabel: true,
-      },
-      tooltip: { trigger: 'axis' },
-      legend: legendOption(legendVisible, style.legendPosition, axisText),
-      xAxis: {
-        type: 'category',
-        boundaryGap: !isLine,
-        name: dimension?.label,
-        nameTextStyle: { color: '#98a2b3', fontSize: 10 },
-        data: categories.map((item) => item.label),
-        axisLine: { lineStyle: { color: axisLine } },
-        axisTick: { show: false },
-        axisLabel: {
-          color: axisText,
-          fontSize: 11,
-          rotate: style.axisLabelRotation,
-        },
-      },
-      yAxis: {
-        type: 'value',
-        splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
-        axisLabel: {
-          color: axisText,
-          fontSize: 11,
-          formatter: (value: number) => formatAnalysisMetricValue(spec, metrics[0], value),
-        },
-      },
-      series,
-    };
-  }
-
-  return undefined;
-};
-
 function EChartAnalysis({
   spec,
   dataset,
@@ -449,7 +218,10 @@ function EChartAnalysis({
   onSelect?: (selection: AnalysisSelection) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const option = useMemo(() => chartOptionFor(spec, dataset, result), [spec, dataset, result]);
+  const option = useMemo(
+    () => buildAnalysisChartOption(spec, dataset, result),
+    [spec, dataset, result],
+  );
 
   useEffect(() => {
     if (!containerRef.current || !option) return undefined;

--- a/yak-ops-ui/src/components/analysis/analysis-service.ts
+++ b/yak-ops-ui/src/components/analysis/analysis-service.ts
@@ -11,6 +11,7 @@ import type {
 } from './model';
 
 const ANALYSIS_API = '/api/v1/analyses';
+const SHARED_ANALYSIS_CHART_TYPES = new Set<ChartType>(['metric', 'bar', 'line', 'pie', 'table']);
 
 type AnalysisFilterWireOperator = 'EQ' | 'NE' | 'GT' | 'GTE' | 'LT' | 'LTE' | 'CONTAINS';
 
@@ -118,6 +119,9 @@ const filterOperatorWire = (operator: FilterOperator): AnalysisFilterWireOperato
 };
 
 const payload = (name: string, description: string, spec: AnalysisSpec) => {
+  if (!SHARED_ANALYSIS_CHART_TYPES.has(spec.type)) {
+    throw new Error('高级图表当前仅支持 Dashboard 本地图表；共享 Analysis 暂未扩展后端 chartType 协议');
+  }
   const metric = spec.sort
     ? spec.metrics.find((candidate) => candidate.field === spec.sort?.field)
     : undefined;

--- a/yak-ops-ui/src/components/analysis/chart-options.test.ts
+++ b/yak-ops-ui/src/components/analysis/chart-options.test.ts
@@ -1,0 +1,142 @@
+import { buildAnalysisChartOption } from './chart-options';
+import {
+  ANALYSIS_ENCODING_RULES,
+  rebindAnalysisEncoding,
+} from './encoding';
+import type {
+  AnalysisSpec,
+  ChartType,
+  DatasetQueryResult,
+  PublishedDataset,
+} from './model';
+
+const dataset: PublishedDataset = {
+  id: 'dataset-1',
+  name: '订单分析',
+  description: '',
+  status: 'ONLINE',
+  sourceTaskId: 'task-1',
+  sourceTaskName: '订单同步',
+  currentVersionNo: 1,
+  updatedAt: '2026-08-18T00:00:00Z',
+  fields: [
+    { key: 'category', label: '区域', physicalName: 'category', dataType: 'string', role: 'dimension', nullable: false },
+    { key: 'segment', label: '客群', physicalName: 'segment', dataType: 'string', role: 'dimension', nullable: false },
+    { key: 'sales', label: '销售额', physicalName: 'sales', dataType: 'number', role: 'metric', nullable: false },
+    { key: 'profit', label: '利润', physicalName: 'profit', dataType: 'number', role: 'metric', nullable: false },
+    { key: 'orders', label: '订单数', physicalName: 'orders', dataType: 'number', role: 'metric', nullable: false },
+  ],
+};
+
+const result: DatasetQueryResult = {
+  datasetId: dataset.id,
+  datasetVersionId: 'version-1',
+  datasetVersionNo: 1,
+  bindings: [
+    { key: 'd0', fieldId: 'category', displayName: '区域', dataType: 'STRING', aggregation: null },
+    { key: 'd1', fieldId: 'segment', displayName: '客群', dataType: 'STRING', aggregation: null },
+    { key: 'm0', fieldId: 'sales', displayName: '销售额', dataType: 'NUMBER', aggregation: 'SUM' },
+    { key: 'm1', fieldId: 'profit', displayName: '利润', dataType: 'NUMBER', aggregation: 'SUM' },
+    { key: 'm2', fieldId: 'orders', displayName: '订单数', dataType: 'NUMBER', aggregation: 'SUM' },
+  ],
+  columns: [],
+  rows: [
+    ['华东', 'A', 100, 20, 5],
+    ['华东', 'B', 80, 16, 4],
+    ['华南', 'A', 60, 18, 3],
+    ['华南', 'B', 40, 12, 2],
+  ],
+  returnedRows: 4,
+  truncated: false,
+  elapsedMillis: 1,
+};
+
+const specFor = (
+  type: ChartType,
+  metrics = ['sales'],
+  color = false,
+): AnalysisSpec => ({
+  type,
+  datasetId: dataset.id,
+  dimensions: color ? ['category', 'segment'] : ['category'],
+  metrics: metrics.map((field) => ({ field, aggregation: 'SUM' as const })),
+  encoding: {
+    version: 1,
+    category: [{ field: 'category', role: 'dimension' }],
+    value: metrics.map((field) => ({ field, role: 'metric' as const, aggregation: 'SUM' as const })),
+    color: color ? [{ field: 'segment', role: 'dimension' }] : [],
+    size: [],
+    label: [],
+    detail: [],
+    tooltip: [],
+  },
+  filters: [],
+  style: {
+    showLegend: true,
+    showDataLabels: false,
+    smooth: true,
+    showGrid: true,
+  },
+});
+
+describe('advanced chart encoding contracts', () => {
+  it('requires exactly two value metrics for scatter', () => {
+    const value = ANALYSIS_ENCODING_RULES.scatter.find((rule) => rule.channel === 'value');
+    expect(value).toMatchObject({ min: 2, max: 2, roles: ['metric'] });
+  });
+
+  it('seeds a missing second metric when switching to scatter', () => {
+    const rebound = rebindAnalysisEncoding(specFor('scatter', ['sales']), dataset);
+    expect(rebound.metrics.map((metric) => metric.field)).toEqual(['sales', 'profit']);
+  });
+
+  it('supports multiple radar metric axes', () => {
+    const value = ANALYSIS_ENCODING_RULES.radar.find((rule) => rule.channel === 'value');
+    expect(value).toMatchObject({ min: 2, max: 5 });
+  });
+});
+
+describe('advanced chart options', () => {
+  it('renders stacked bars with a shared stack', () => {
+    const option = buildAnalysisChartOption(specFor('stackedBar', ['sales', 'profit']), dataset, result) as any;
+    expect(option.series).toHaveLength(2);
+    expect(option.series.every((series: any) => series.type === 'bar')).toBe(true);
+    expect(option.series.map((series: any) => series.stack)).toEqual(['total', 'total']);
+  });
+
+  it('renders an area chart using line series with areaStyle', () => {
+    const option = buildAnalysisChartOption(specFor('area', ['sales']), dataset, result) as any;
+    expect(option.series[0].type).toBe('line');
+    expect(option.series[0].areaStyle).toEqual({ opacity: 0.18 });
+  });
+
+  it('maps two scatter metrics to x/y and preserves color groups', () => {
+    const option = buildAnalysisChartOption(specFor('scatter', ['sales', 'profit'], true), dataset, result) as any;
+    expect(option.series).toHaveLength(2);
+    expect(option.series[0].type).toBe('scatter');
+    expect(option.series[0].data[0]).toMatchObject({ name: '华东', value: [100, 20], __rowIndex: 0 });
+    expect(option.series[1].data[0]).toMatchObject({ name: '华东', value: [80, 16], __rowIndex: 1 });
+  });
+
+  it('maps radar metrics to indicator axes and category rows to polygons', () => {
+    const option = buildAnalysisChartOption(specFor('radar', ['sales', 'profit']), dataset, result) as any;
+    expect(option.radar.indicator.map((item: any) => item.name)).toEqual(['销售额', '利润']);
+    expect(option.series[0].type).toBe('radar');
+    expect(option.series[0].data[0]).toMatchObject({ name: '华东', value: [100, 20], __rowIndex: 0 });
+  });
+
+  it('renders funnel and treemap from category + metric semantics', () => {
+    const funnel = buildAnalysisChartOption(specFor('funnel', ['sales']), dataset, result) as any;
+    const treemap = buildAnalysisChartOption(specFor('treemap', ['sales']), dataset, result) as any;
+    expect(funnel.series[0].type).toBe('funnel');
+    expect(funnel.series[0].data[0]).toMatchObject({ name: '华东', value: 100, __rowIndex: 0 });
+    expect(treemap.series[0].type).toBe('treemap');
+    expect(treemap.series[0].data[0]).toMatchObject({ name: '华东', value: 100, __rowIndex: 0 });
+  });
+
+  it('stacks color groups per metric in stacked bar mode', () => {
+    const option = buildAnalysisChartOption(specFor('stackedBar', ['sales'], true), dataset, result) as any;
+    expect(option.series.map((series: any) => series.name)).toEqual(['A', 'B']);
+    expect(option.series.map((series: any) => series.stack)).toEqual(['sales', 'sales']);
+  });
+});

--- a/yak-ops-ui/src/components/analysis/chart-options.ts
+++ b/yak-ops-ui/src/components/analysis/chart-options.ts
@@ -1,0 +1,541 @@
+import {
+  analysisMetricValues,
+  formatAnalysisMetricValue,
+  metricComputationFor,
+} from './analysis';
+import {
+  getAnalysisField,
+  metricAnalysisDisplayName,
+  metricFieldLabel,
+} from './display';
+import { resolveAnalysisEncoding } from './encoding';
+import type {
+  AnalysisSpec,
+  DatasetQueryResult,
+  MetricBinding,
+  PublishedDataset,
+  Scalar,
+} from './model';
+import { paletteColors, resolveAnalysisStyle } from './style';
+
+const bindingIndex = (
+  result: DatasetQueryResult,
+  fieldId: string,
+  aggregation?: MetricBinding['aggregation'],
+) => result.bindings.findIndex((binding) => (
+  binding.fieldId === fieldId
+    && (aggregation ? binding.aggregation === aggregation : !binding.aggregation)
+));
+
+const cell = (
+  result: DatasetQueryResult,
+  row: Scalar[],
+  fieldId: string,
+  aggregation?: MetricBinding['aggregation'],
+) => {
+  const index = bindingIndex(result, fieldId, aggregation);
+  return index >= 0 ? row[index] : null;
+};
+
+const rowLabel = (result: DatasetQueryResult, row: Scalar[], dimensions: string[]) =>
+  dimensions.map((fieldId) => String(cell(result, row, fieldId) ?? '')).join(' / ');
+
+const scalarKey = (value: Scalar) => `${typeof value}:${String(value)}`;
+
+const uniqueDimensionValues = (
+  result: DatasetQueryResult,
+  fieldId: string,
+) => {
+  const seen = new Set<string>();
+  return result.rows.flatMap((row) => {
+    const value = cell(result, row, fieldId);
+    const key = scalarKey(value);
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{ key, value, label: String(value ?? '') }];
+  });
+};
+
+const legendOption = (
+  visible: boolean,
+  position: 'top' | 'right' | 'bottom',
+  axisText: string,
+) => {
+  if (!visible) return { show: false };
+  const base = { textStyle: { color: axisText, fontSize: 11 } };
+  if (position === 'right') return { ...base, orient: 'vertical', right: 0, top: 'middle' };
+  if (position === 'bottom') return { ...base, orient: 'horizontal', left: 'center', bottom: 0 };
+  return { ...base, orient: 'horizontal', right: 4, top: 0 };
+};
+
+const chartRuntime = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const encoding = resolveAnalysisEncoding(spec);
+  const style = resolveAnalysisStyle(spec.style);
+  const colors = paletteColors(spec.style);
+  const firstDimension = encoding.category.find((binding) => binding.role === 'dimension')?.field
+    ?? spec.dimensions[0];
+  const colorDimension = encoding.color.find((binding) => binding.role === 'dimension')?.field;
+  const metrics = spec.metrics;
+  const computedValues = new Map(metrics.map((metric) => [
+    metric.field,
+    analysisMetricValues(spec, result, metric),
+  ]));
+  const metricValue = (metric: MetricBinding, rowIndex: number) =>
+    computedValues.get(metric.field)?.[rowIndex] ?? null;
+  const formatted = (metric: MetricBinding, value: unknown) => {
+    if (value === null || value === undefined) return '—';
+    const number = Number(value);
+    return formatAnalysisMetricValue(spec, metric, Number.isFinite(number) ? number : null);
+  };
+  return {
+    encoding,
+    style,
+    colors,
+    firstDimension,
+    colorDimension,
+    metrics,
+    computedValues,
+    metricValue,
+    formatted,
+  };
+};
+
+const axisText = '#667085';
+const axisLine = '#d8dde6';
+const splitLine = '#eef1f5';
+
+const cartesianSeriesOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const {
+    style,
+    colors,
+    firstDimension,
+    colorDimension,
+    metrics,
+    metricValue,
+    formatted,
+  } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+
+  const isLine = spec.type === 'line' || spec.type === 'area';
+  const isArea = spec.type === 'area';
+  const isStacked = spec.type === 'stackedBar';
+  const categories = uniqueDimensionValues(result, firstDimension);
+  const colorValues = colorDimension
+    ? uniqueDimensionValues(result, colorDimension)
+    : [];
+  const legendVisible = style.showLegend;
+  const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'top';
+  const dimension = getAnalysisField(dataset, firstDimension);
+
+  const rowIndexFor = (category: Scalar, color?: Scalar) => result.rows.findIndex((row) => (
+    Object.is(cell(result, row, firstDimension), category)
+    && (!colorDimension || Object.is(cell(result, row, colorDimension), color))
+  ));
+
+  const seriesStyleFor = (metric: MetricBinding, stack?: string) => ({
+    type: isLine ? 'line' : 'bar',
+    stack,
+    smooth: isLine && style.smooth,
+    symbolSize: isLine ? style.symbolSize : undefined,
+    lineStyle: isLine ? { width: style.lineWidth } : undefined,
+    areaStyle: isArea ? { opacity: 0.18 } : undefined,
+    barMaxWidth: !isLine ? style.barMaxWidth : undefined,
+    itemStyle: !isLine ? { borderRadius: style.barRadius } : undefined,
+    label: {
+      show: style.showDataLabels,
+      position: labelPosition,
+      formatter: (params: any) => formatted(metric, params?.value),
+    },
+    tooltip: {
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+  });
+
+  const series = colorDimension
+    ? metrics.flatMap((metric) => colorValues.map((color) => ({
+      name: metrics.length > 1
+        ? `${color.label} · ${metricAnalysisDisplayName(spec, dataset, metric)}`
+        : color.label,
+      ...seriesStyleFor(metric, isStacked ? metric.field : undefined),
+      data: categories.map((category) => {
+        const rowIndex = rowIndexFor(category.value, color.value);
+        if (rowIndex < 0) return null;
+        return {
+          value: metricValue(metric, rowIndex),
+          __rowIndex: rowIndex,
+        };
+      }),
+    })))
+    : metrics.map((metric) => ({
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      ...seriesStyleFor(metric, isStacked ? 'total' : undefined),
+      data: categories.map((category) => {
+        const rowIndex = rowIndexFor(category.value);
+        if (rowIndex < 0) return null;
+        return {
+          value: metricValue(metric, rowIndex),
+          __rowIndex: rowIndex,
+        };
+      }),
+    }));
+
+  return {
+    color: colors,
+    grid: {
+      left: 22,
+      right: legendVisible && style.legendPosition === 'right' ? 112 : 16,
+      top: legendVisible && style.legendPosition === 'top' ? 34 : 14,
+      bottom: legendVisible && style.legendPosition === 'bottom' ? 40 : 22,
+      containLabel: true,
+    },
+    tooltip: { trigger: 'axis' },
+    legend: legendOption(legendVisible, style.legendPosition, axisText),
+    xAxis: {
+      type: 'category',
+      boundaryGap: !isLine,
+      name: dimension?.label,
+      nameTextStyle: { color: '#98a2b3', fontSize: 10 },
+      data: categories.map((item) => item.label),
+      axisLine: { lineStyle: { color: axisLine } },
+      axisTick: { show: false },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        rotate: style.axisLabelRotation,
+      },
+    },
+    yAxis: {
+      type: 'value',
+      splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        formatter: (value: number) => formatAnalysisMetricValue(spec, metrics[0], value),
+      },
+    },
+    series,
+  };
+};
+
+const pieOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, metricValue, formatted } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+  const metric = metrics[0];
+  const metricConfig = metricComputationFor(spec, metric.field);
+  const legacyPieLabel = metricConfig.quickCalculation === 'none'
+    && metricConfig.numberFormat === 'auto';
+  const legendVisible = style.showLegend;
+  const legendOnRight = legendVisible && style.legendPosition === 'right';
+  const legendOnTop = legendVisible && style.legendPosition === 'top';
+  const legendOnBottom = legendVisible && style.legendPosition === 'bottom';
+  const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
+
+  return {
+    color: colors,
+    tooltip: {
+      trigger: 'item',
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+    legend: legendOption(legendVisible, style.legendPosition, axisText),
+    series: [{
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      type: 'pie',
+      radius: [`${style.pieInnerRadius}%`, '70%'],
+      center: [
+        legendOnRight ? '38%' : '50%',
+        legendOnTop ? '56%' : legendOnBottom ? '45%' : '52%',
+      ],
+      label: {
+        show: style.showDataLabels,
+        position: labelPosition,
+        formatter: legacyPieLabel
+          ? (labelPosition === 'inside' ? '{d}%' : '{b} {d}%')
+          : (params: any) => labelPosition === 'inside'
+            ? formatted(metric, params?.value)
+            : `${params?.name ?? ''} ${formatted(metric, params?.value)}`.trim(),
+      },
+      itemStyle: { borderColor: '#fff', borderWidth: 2 },
+      data: result.rows.map((row, rowIndex) => ({
+        name: rowLabel(result, row, [firstDimension]),
+        value: metricValue(metric, rowIndex),
+        __rowIndex: rowIndex,
+      })),
+    }],
+  };
+};
+
+const scatterOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const {
+    style,
+    colors,
+    firstDimension,
+    colorDimension,
+    metrics,
+    metricValue,
+  } = runtime;
+  if (!firstDimension || metrics.length < 2) return undefined;
+  const [xMetric, yMetric] = metrics;
+  const colorValues = colorDimension
+    ? uniqueDimensionValues(result, colorDimension)
+    : [{ key: 'all', value: undefined as Scalar | undefined, label: metricFieldLabel(spec, dataset, yMetric) }];
+  const pointSize = Math.max(6, style.symbolSize);
+
+  const series = colorValues.map((color) => ({
+    name: color.label,
+    type: 'scatter',
+    symbolSize: pointSize,
+    label: {
+      show: style.showDataLabels,
+      position: style.dataLabelPosition === 'inside' ? 'inside' : 'top',
+      formatter: (params: any) => params?.name ?? '',
+    },
+    data: result.rows.flatMap((row, rowIndex) => {
+      if (
+        colorDimension
+        && !Object.is(cell(result, row, colorDimension), color.value)
+      ) return [];
+      const x = metricValue(xMetric, rowIndex);
+      const y = metricValue(yMetric, rowIndex);
+      if (x === null || y === null) return [];
+      return [{
+        name: rowLabel(result, row, [firstDimension]),
+        value: [x, y],
+        __rowIndex: rowIndex,
+      }];
+    }),
+  }));
+
+  return {
+    color: colors,
+    grid: {
+      left: 24,
+      right: colorDimension && style.showLegend && style.legendPosition === 'right' ? 112 : 20,
+      top: colorDimension && style.showLegend && style.legendPosition === 'top' ? 34 : 18,
+      bottom: colorDimension && style.showLegend && style.legendPosition === 'bottom' ? 46 : 34,
+      containLabel: true,
+    },
+    tooltip: { trigger: 'item' },
+    legend: legendOption(Boolean(colorDimension) && style.showLegend, style.legendPosition, axisText),
+    xAxis: {
+      type: 'value',
+      name: metricFieldLabel(spec, dataset, xMetric),
+      nameLocation: 'middle',
+      nameGap: 28,
+      nameTextStyle: { color: '#98a2b3', fontSize: 10 },
+      axisLine: { lineStyle: { color: axisLine } },
+      splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        formatter: (value: number) => formatAnalysisMetricValue(spec, xMetric, value),
+      },
+    },
+    yAxis: {
+      type: 'value',
+      name: metricFieldLabel(spec, dataset, yMetric),
+      nameTextStyle: { color: '#98a2b3', fontSize: 10 },
+      axisLine: { lineStyle: { color: axisLine } },
+      splitLine: { show: style.showGrid, lineStyle: { color: splitLine } },
+      axisLabel: {
+        color: axisText,
+        fontSize: 11,
+        formatter: (value: number) => formatAnalysisMetricValue(spec, yMetric, value),
+      },
+    },
+    series,
+  };
+};
+
+const radarOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, computedValues } = runtime;
+  if (!firstDimension || metrics.length < 2) return undefined;
+
+  const indicator = metrics.map((metric) => {
+    const values = (computedValues.get(metric.field) ?? [])
+      .filter((value): value is number => value !== null && Number.isFinite(value));
+    const minValue = values.length ? Math.min(...values) : 0;
+    const maxValue = values.length ? Math.max(...values) : 0;
+    const low = Math.min(0, minValue);
+    const high = Math.max(0, maxValue);
+    const span = Math.max(1, high - low, Math.abs(high), Math.abs(low));
+    return {
+      name: metricFieldLabel(spec, dataset, metric),
+      min: low < 0 ? low - span * 0.1 : 0,
+      max: high + span * 0.1,
+    };
+  });
+
+  const data = result.rows.flatMap((row, rowIndex) => {
+    const values = metrics.map((metric) => computedValues.get(metric.field)?.[rowIndex] ?? null);
+    if (values.some((value) => value === null)) return [];
+    return [{
+      name: rowLabel(result, row, [firstDimension]),
+      value: values,
+      __rowIndex: rowIndex,
+    }];
+  });
+
+  return {
+    color: colors,
+    tooltip: { trigger: 'item' },
+    legend: legendOption(style.showLegend, style.legendPosition, axisText),
+    radar: {
+      indicator,
+      radius: '62%',
+      center: [style.showLegend && style.legendPosition === 'right' ? '42%' : '50%', '53%'],
+      splitNumber: 4,
+      axisName: { color: axisText, fontSize: 10 },
+      axisLine: { lineStyle: { color: axisLine } },
+      splitLine: { lineStyle: { color: splitLine } },
+      splitArea: { show: false },
+    },
+    series: [{
+      type: 'radar',
+      symbolSize: Math.max(4, style.symbolSize),
+      lineStyle: { width: style.lineWidth },
+      areaStyle: { opacity: 0.08 },
+      data,
+    }],
+  };
+};
+
+const funnelOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, metricValue, formatted } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+  const metric = metrics[0];
+  const labelPosition = style.dataLabelPosition === 'inside' ? 'inside' : 'outside';
+
+  return {
+    color: colors,
+    tooltip: {
+      trigger: 'item',
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+    legend: legendOption(style.showLegend, style.legendPosition, axisText),
+    series: [{
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      type: 'funnel',
+      left: '10%',
+      top: style.showLegend && style.legendPosition === 'top' ? 38 : 18,
+      bottom: style.showLegend && style.legendPosition === 'bottom' ? 42 : 18,
+      width: style.showLegend && style.legendPosition === 'right' ? '68%' : '80%',
+      minSize: '10%',
+      maxSize: '100%',
+      sort: 'descending',
+      gap: 2,
+      label: {
+        show: style.showDataLabels,
+        position: labelPosition,
+        formatter: (params: any) => `${params?.name ?? ''} ${formatted(metric, params?.value)}`.trim(),
+      },
+      itemStyle: { borderColor: '#fff', borderWidth: 1 },
+      data: result.rows.flatMap((row, rowIndex) => {
+        const value = metricValue(metric, rowIndex);
+        if (value === null) return [];
+        return [{
+          name: rowLabel(result, row, [firstDimension]),
+          value,
+          __rowIndex: rowIndex,
+        }];
+      }),
+    }],
+  };
+};
+
+const treemapOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  const runtime = chartRuntime(spec, dataset, result);
+  const { style, colors, firstDimension, metrics, metricValue, formatted } = runtime;
+  if (!firstDimension || !metrics.length) return undefined;
+  const metric = metrics[0];
+
+  return {
+    color: colors,
+    tooltip: {
+      trigger: 'item',
+      valueFormatter: (value: unknown) => formatted(metric, value),
+    },
+    series: [{
+      name: metricAnalysisDisplayName(spec, dataset, metric),
+      type: 'treemap',
+      roam: false,
+      nodeClick: false,
+      breadcrumb: { show: false },
+      label: {
+        show: true,
+        color: '#fff',
+        fontSize: 11,
+        lineHeight: 16,
+        formatter: (params: any) => style.showDataLabels
+          ? `${params?.name ?? ''}\n${formatted(metric, params?.value)}`
+          : params?.name ?? '',
+      },
+      itemStyle: {
+        borderColor: '#fff',
+        borderWidth: 2,
+        gapWidth: 2,
+      },
+      data: result.rows.flatMap((row, rowIndex) => {
+        const value = metricValue(metric, rowIndex);
+        if (value === null) return [];
+        return [{
+          name: rowLabel(result, row, [firstDimension]),
+          value,
+          __rowIndex: rowIndex,
+        }];
+      }),
+    }],
+  };
+};
+
+/** Build the ECharts option for every non-table/non-metric Analysis chart type. */
+export const buildAnalysisChartOption = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  result: DatasetQueryResult,
+) => {
+  if (
+    spec.type === 'bar'
+    || spec.type === 'stackedBar'
+    || spec.type === 'line'
+    || spec.type === 'area'
+  ) return cartesianSeriesOption(spec, dataset, result);
+  if (spec.type === 'pie') return pieOption(spec, dataset, result);
+  if (spec.type === 'scatter') return scatterOption(spec, dataset, result);
+  if (spec.type === 'radar') return radarOption(spec, dataset, result);
+  if (spec.type === 'funnel') return funnelOption(spec, dataset, result);
+  if (spec.type === 'treemap') return treemapOption(spec, dataset, result);
+  return undefined;
+};

--- a/yak-ops-ui/src/components/analysis/display.ts
+++ b/yak-ops-ui/src/components/analysis/display.ts
@@ -1,0 +1,51 @@
+import {
+  metricComputationFor,
+  quickCalculationLabel,
+} from './analysis';
+import { calculatedFieldFor } from './calculated-field';
+import type {
+  Aggregation,
+  AnalysisSpec,
+  MetricBinding,
+  PublishedDataset,
+} from './model';
+
+export const AGGREGATION_LABELS: Record<Aggregation, string> = {
+  SUM: '求和',
+  AVG: '平均',
+  COUNT: '计数',
+  COUNT_DISTINCT: '去重计数',
+  MAX: '最大值',
+  MIN: '最小值',
+};
+
+export const getAnalysisField = (dataset: PublishedDataset, fieldKey?: string) =>
+  dataset.fields.find((field) => field.key === fieldKey);
+
+export const metricFieldLabel = (
+  spec: Pick<AnalysisSpec, 'analysis'>,
+  dataset: PublishedDataset,
+  metric: MetricBinding,
+) => calculatedFieldFor(spec, metric.field)?.name
+  ?? getAnalysisField(dataset, metric.field)?.label
+  ?? metric.field;
+
+export const metricDisplayName = (
+  dataset: PublishedDataset,
+  metric: MetricBinding,
+) => `${getAnalysisField(dataset, metric.field)?.label ?? metric.field} · ${AGGREGATION_LABELS[metric.aggregation]}`;
+
+export const metricAnalysisDisplayName = (
+  spec: AnalysisSpec,
+  dataset: PublishedDataset,
+  metric: MetricBinding,
+) => {
+  const calculated = calculatedFieldFor(spec, metric.field);
+  const base = calculated
+    ? `${calculated.name} · 计算字段`
+    : metricDisplayName(dataset, metric);
+  const calculation = spec.type === 'metric'
+    ? 'none'
+    : metricComputationFor(spec, metric.field).quickCalculation;
+  return calculation === 'none' ? base : `${base} · ${quickCalculationLabel(calculation)}`;
+};

--- a/yak-ops-ui/src/components/analysis/encoding.ts
+++ b/yak-ops-ui/src/components/analysis/encoding.ts
@@ -39,11 +39,7 @@ const slot = (
   hint?: string,
 ): AnalysisEncodingSlotRule => ({ channel, label, roles, min, max, hint });
 
-/**
- * Semantic channel contracts for the chart renderers currently shipped by Yak Ops.
- * size / label / tooltip already exist in the versioned grammar and can be activated by
- * later renderers without another persistence migration.
- */
+/** Semantic channel contracts for every chart renderer currently shipped by Yak Ops. */
 export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule[]> = {
   metric: [
     slot('value', '值', ['metric'], 1, 1, '指标卡需要 1 个指标'),
@@ -53,14 +49,41 @@ export const ANALYSIS_ENCODING_RULES: Record<ChartType, AnalysisEncodingSlotRule
     slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
     slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
   ],
+  stackedBar: [
+    slot('category', '分类', ['dimension'], 1, 1, '堆叠柱状图需要 1 个分类字段'),
+    slot('value', '值', ['metric'], 1, 3, '最多 3 个指标；多个指标会自动堆叠'),
+    slot('color', '堆叠分组', ['dimension'], 0, 1, '可按 1 个维度拆分堆叠系列'),
+  ],
   line: [
     slot('category', '分类', ['dimension'], 1, 1, '折线图需要 1 个分类字段'),
+    slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
+    slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
+  ],
+  area: [
+    slot('category', '分类', ['dimension'], 1, 1, '面积图需要 1 个分类字段'),
     slot('value', '值', ['metric'], 1, 3, '最多 3 个指标'),
     slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分系列'),
   ],
   pie: [
     slot('category', '分类', ['dimension'], 1, 1, '饼图需要 1 个分类字段'),
     slot('value', '值', ['metric'], 1, 1, '饼图需要 1 个指标'),
+  ],
+  scatter: [
+    slot('category', '点标签', ['dimension'], 1, 1, '散点图需要 1 个维度标识每个点'),
+    slot('value', '坐标值', ['metric'], 2, 2, '前两个指标分别作为 X / Y 轴'),
+    slot('color', '颜色', ['dimension'], 0, 1, '可按 1 个维度拆分点系列'),
+  ],
+  radar: [
+    slot('category', '对象', ['dimension'], 1, 1, '雷达图按 1 个维度生成对象'),
+    slot('value', '指标轴', ['metric'], 2, 5, '配置 2~5 个指标作为雷达轴'),
+  ],
+  funnel: [
+    slot('category', '阶段', ['dimension'], 1, 1, '漏斗图需要 1 个阶段字段'),
+    slot('value', '值', ['metric'], 1, 1, '漏斗图需要 1 个指标'),
+  ],
+  treemap: [
+    slot('category', '分类', ['dimension'], 1, 1, '矩形树图需要 1 个分类字段'),
+    slot('value', '面积值', ['metric'], 1, 1, '矩形面积由 1 个指标决定'),
   ],
   table: [
     slot('category', '维度', ['dimension'], 0, 3, '最多 3 个维度'),
@@ -98,15 +121,17 @@ export const cloneAnalysisEncoding = (encoding: AnalysisEncoding): AnalysisEncod
 });
 
 /**
- * Legacy snapshots have only the query projection. For bar/line we can safely infer
- * category + color from the first two projected dimensions because Encoding v1 is the
- * first editor version that intentionally produces that shape. Other charts keep their
- * historical dimensions in category to avoid inventing semantics that were never stored.
+ * Legacy snapshots have only the query projection. Cartesian grouped charts can safely
+ * infer category + color from the first two projected dimensions because Encoding v1 is
+ * the first editor version that intentionally produces that shape.
  */
 export const legacyAnalysisEncoding = (
   spec: Pick<AnalysisSpec, 'type' | 'dimensions' | 'metrics'>,
 ): AnalysisEncoding => {
-  const groupedSeries = spec.type === 'bar' || spec.type === 'line';
+  const groupedSeries = spec.type === 'bar'
+    || spec.type === 'line'
+    || spec.type === 'stackedBar'
+    || spec.type === 'area';
   const categoryDimensions = groupedSeries ? spec.dimensions.slice(0, 1) : spec.dimensions;
   const colorDimensions = groupedSeries ? spec.dimensions.slice(1, 2) : [];
   return {

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -24,7 +24,15 @@ export interface PublishedDataset {
   fields: DatasetField[];
 }
 
-export type ChartType = 'metric' | 'bar' | 'line' | 'pie' | 'table';
+export type BasicChartType = 'metric' | 'bar' | 'line' | 'pie' | 'table';
+export type AdvancedChartType =
+  | 'stackedBar'
+  | 'area'
+  | 'scatter'
+  | 'radar'
+  | 'funnel'
+  | 'treemap';
+export type ChartType = BasicChartType | AdvancedChartType;
 export type Aggregation = 'SUM' | 'AVG' | 'COUNT' | 'COUNT_DISTINCT' | 'MAX' | 'MIN';
 export type SortDirection = 'asc' | 'desc';
 export type FilterOperator = 'eq' | 'neq' | 'contains' | 'gt' | 'gte' | 'lt' | 'lte';

--- a/yak-ops-ui/src/components/analysis/style.ts
+++ b/yak-ops-ui/src/components/analysis/style.ts
@@ -81,11 +81,15 @@ export const resolveAnalysisStyle = (
   stripedRows: style?.stripedRows ?? DEFAULT_ANALYSIS_VISUAL_CONFIG.stripedRows,
 });
 
+const defaultLegendTypes = new Set<ChartType>(['pie', 'stackedBar', 'area', 'radar']);
+const smoothTypes = new Set<ChartType>(['line', 'area']);
+const gridTypes = new Set<ChartType>(['bar', 'stackedBar', 'line', 'area', 'scatter']);
+
 export const createAnalysisVisualConfig = (type: ChartType): AnalysisVisualConfig => ({
   ...DEFAULT_ANALYSIS_VISUAL_CONFIG,
-  showLegend: type === 'pie',
-  smooth: type === 'line',
-  showGrid: type === 'bar' || type === 'line',
+  showLegend: defaultLegendTypes.has(type),
+  smooth: smoothTypes.has(type),
+  showGrid: gridTypes.has(type),
 });
 
 export const paletteColors = (style?: AnalysisVisualConfig) => {

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -5,6 +5,7 @@ import {
 import {
   applyAnalysisEncoding,
   changeAnalysisEncodingType,
+  rebindAnalysisEncoding,
   updateEncodingMetricAggregation,
 } from '@/components/analysis/encoding';
 import type { AnalysisEncoding, AnalysisSpec } from '@/components/analysis/model';
@@ -134,7 +135,8 @@ export function ChartSheetConfigPanel({
   const physicalMetrics = spec.metrics.filter((metric) => !isCalculatedFieldKey(spec, metric.field));
 
   const changeType = (type: ChartType) => {
-    const next = changeAnalysisEncodingType(spec, type);
+    const changed = changeAnalysisEncodingType(spec, type);
+    const next = rebindAnalysisEncoding(changed, dataset);
     updateInlineAnalysis({
       type,
       encoding: next.encoding,
@@ -174,7 +176,7 @@ export function ChartSheetConfigPanel({
     const hasColor = Boolean(next.encoding.color.length);
     const shouldRevealLegend = !hadColor
       && hasColor
-      && (spec.type === 'bar' || spec.type === 'line');
+      && ['bar', 'stackedBar', 'line', 'area', 'scatter'].includes(spec.type);
     updateInlineAnalysis({
       encoding: next.encoding,
       dimensions: next.dimensions,
@@ -221,13 +223,14 @@ export function ChartSheetConfigPanel({
 
         <div className="mt-5">
           <SectionLabel>图表类型</SectionLabel>
-          <div className="grid grid-cols-5 gap-1.5">
+          <div className="grid grid-cols-4 gap-1.5">
             {(Object.keys(CHART_META) as ChartType[]).map((type) => {
               const active = spec.type === type;
               return (
                 <button
                   key={type}
                   type="button"
+                  title={CHART_META[type].description}
                   onClick={() => changeType(type)}
                   className={[
                     'flex min-w-0 flex-col items-center justify-center gap-1.5 rounded-[7px] border px-1 py-2.5 text-[10px] transition-[background-color,border-color,color]',
@@ -239,10 +242,13 @@ export function ChartSheetConfigPanel({
                   <span className={active ? 'text-[#344054]' : 'text-[#a0a6af]'}>
                     {CHART_META[type].icon}
                   </span>
-                  <span className="truncate">{CHART_META[type].label}</span>
+                  <span className="w-full truncate text-center">{CHART_META[type].label}</span>
                 </button>
               );
             })}
+          </div>
+          <div className="mt-2 text-[9px] leading-4 text-[#98a2b3]">
+            高级图表沿用 Encoding v1；切换类型时会保留可兼容字段，并自动补齐必填槽位。
           </div>
         </div>
 

--- a/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-editor.tsx
@@ -16,6 +16,7 @@ import { ConfigData } from './config-data';
 import { MetricAggregations } from './config-metrics';
 import { QueryControls } from './config-query';
 import { ChartStyleConfig } from './config-style';
+import { DashboardDirectCrossFilterEditor } from './direct-link-editor';
 import { CHART_META, findDataset } from './helpers';
 import { DashboardInteractionEditor } from './interaction-editor';
 import type {
@@ -34,6 +35,7 @@ import { DashboardWidgetActionEditor } from './widget-action-editor';
 export function ChartSheetConfigPanel({
   currentDashboardId,
   widget,
+  widgets,
   datasets,
   analyses,
   globalFilters,
@@ -47,6 +49,7 @@ export function ChartSheetConfigPanel({
 }: {
   currentDashboardId: string;
   widget: DashboardWidget;
+  widgets: DashboardWidget[];
   datasets: PublishedDataset[];
   analyses: AnalysisAsset[];
   globalFilters: DashboardGlobalFilter[];
@@ -327,14 +330,25 @@ export function ChartSheetConfigPanel({
               ),
               children: (
                 <div className="space-y-4 pb-2">
-                  <DashboardInteractionEditor
+                  <DashboardDirectCrossFilterEditor
                     widget={widget}
+                    widgets={widgets}
                     spec={spec}
                     dataset={dataset}
-                    filters={globalFilters}
-                    interactions={interactions}
-                    onChange={updateInteractions}
+                    datasets={datasets}
+                    analyses={analyses}
+                    onChange={(dashboardBehavior) => updateInlineAnalysis({ dashboardBehavior })}
                   />
+                  <div className="border-t border-[#eceef1] pt-4">
+                    <DashboardInteractionEditor
+                      widget={widget}
+                      spec={spec}
+                      dataset={dataset}
+                      filters={globalFilters}
+                      interactions={interactions}
+                      onChange={updateInteractions}
+                    />
+                  </div>
                   <div className="border-t border-[#eceef1] pt-4">
                     <DashboardWidgetActionEditor
                       currentDashboardId={currentDashboardId}

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -17,6 +17,7 @@ import type {
 export function DashboardChartSheetWorkspace({
   currentDashboardId,
   widget,
+  widgets,
   datasets,
   analyses,
   globalFilters,
@@ -31,6 +32,7 @@ export function DashboardChartSheetWorkspace({
 }: {
   currentDashboardId: string;
   widget: DashboardWidget;
+  widgets: DashboardWidget[];
   datasets: PublishedDataset[];
   analyses: AnalysisAsset[];
   globalFilters: DashboardGlobalFilter[];
@@ -112,6 +114,7 @@ export function DashboardChartSheetWorkspace({
         <ChartSheetConfigPanel
           currentDashboardId={currentDashboardId}
           widget={widget}
+          widgets={widgets}
           datasets={datasets}
           analyses={analyses}
           globalFilters={globalFilters}

--- a/yak-ops-ui/src/pages/dashboard/config-style.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-style.tsx
@@ -18,11 +18,32 @@ export function ChartStyleConfig({
   onChange: (patch: Partial<AnalysisVisualConfig>) => void;
 }) {
   const style = resolveAnalysisStyle(spec.style);
-  const hasCartesianAxes = spec.type === 'bar' || spec.type === 'line';
-  const supportsLegend = spec.type === 'bar' || spec.type === 'line' || spec.type === 'pie';
-  const supportsLabels = supportsLegend;
-  const supportsPalette = supportsLegend;
-  const activeLabelPosition: AnalysisDataLabelPosition = spec.type === 'pie'
+  const hasCartesianAxes = ['bar', 'stackedBar', 'line', 'area', 'scatter'].includes(spec.type);
+  const hasCategoricalAxis = ['bar', 'stackedBar', 'line', 'area'].includes(spec.type);
+  const supportsLegend = [
+    'bar',
+    'stackedBar',
+    'line',
+    'area',
+    'pie',
+    'scatter',
+    'radar',
+    'funnel',
+  ].includes(spec.type);
+  const supportsLabels = [
+    'bar',
+    'stackedBar',
+    'line',
+    'area',
+    'pie',
+    'scatter',
+    'funnel',
+    'treemap',
+  ].includes(spec.type);
+  const supportsPalette = !['metric', 'table'].includes(spec.type);
+  const supportsLabelPosition = supportsLabels && spec.type !== 'treemap';
+  const radialLabelPosition = spec.type === 'pie' || spec.type === 'funnel';
+  const activeLabelPosition: AnalysisDataLabelPosition = radialLabelPosition
     ? style.dataLabelPosition === 'inside' ? 'inside' : 'outside'
     : style.dataLabelPosition === 'inside' ? 'inside' : 'top';
 
@@ -90,17 +111,17 @@ export function ChartStyleConfig({
             {supportsLabels ? (
               <>
                 <ToggleRow
-                  label="显示数据标签"
+                  label={spec.type === 'treemap' ? '显示数值' : '显示数据标签'}
                   checked={style.showDataLabels}
                   onChange={(showDataLabels) => onChange({ showDataLabels })}
                 />
-                {style.showDataLabels ? (
+                {style.showDataLabels && supportsLabelPosition ? (
                   <ControlRow label="标签位置">
                     <Select
                       size="small"
                       className="w-[116px]"
                       value={activeLabelPosition}
-                      options={spec.type === 'pie'
+                      options={radialLabelPosition
                         ? [
                           { label: '外侧', value: 'outside' },
                           { label: '内部', value: 'inside' },
@@ -127,25 +148,27 @@ export function ChartStyleConfig({
               checked={style.showGrid}
               onChange={(showGrid) => onChange({ showGrid })}
             />
-            <ControlRow label="标签旋转">
-              <Select
-                size="small"
-                className="w-[116px]"
-                value={style.axisLabelRotation}
-                options={[
-                  { label: '不旋转', value: 0 },
-                  { label: '30°', value: 30 },
-                  { label: '45°', value: 45 },
-                ]}
-                onChange={(axisLabelRotation: 0 | 30 | 45) => onChange({ axisLabelRotation })}
-              />
-            </ControlRow>
+            {hasCategoricalAxis ? (
+              <ControlRow label="标签旋转">
+                <Select
+                  size="small"
+                  className="w-[116px]"
+                  value={style.axisLabelRotation}
+                  options={[
+                    { label: '不旋转', value: 0 },
+                    { label: '30°', value: 30 },
+                    { label: '45°', value: 45 },
+                  ]}
+                  onChange={(axisLabelRotation: 0 | 30 | 45) => onChange({ axisLabelRotation })}
+                />
+              </ControlRow>
+            ) : null}
           </div>
         </StyleGroup>
       ) : null}
 
-      {spec.type === 'bar' ? (
-        <StyleGroup title="柱形">
+      {spec.type === 'bar' || spec.type === 'stackedBar' ? (
+        <StyleGroup title={spec.type === 'stackedBar' ? '堆叠柱形' : '柱形'}>
           <div className="space-y-3">
             <NumberRow
               label="最大宽度"
@@ -167,8 +190,8 @@ export function ChartStyleConfig({
         </StyleGroup>
       ) : null}
 
-      {spec.type === 'line' ? (
-        <StyleGroup title="折线">
+      {spec.type === 'line' || spec.type === 'area' ? (
+        <StyleGroup title={spec.type === 'area' ? '面积线' : '折线'}>
           <div className="space-y-3">
             <ToggleRow
               label="平滑曲线"
@@ -192,6 +215,19 @@ export function ChartStyleConfig({
               onChange={(symbolSize) => onChange({ symbolSize })}
             />
           </div>
+        </StyleGroup>
+      ) : null}
+
+      {spec.type === 'scatter' ? (
+        <StyleGroup title="散点">
+          <NumberRow
+            label="点大小"
+            value={style.symbolSize}
+            min={0}
+            max={14}
+            suffix="px"
+            onChange={(symbolSize) => onChange({ symbolSize })}
+          />
         </StyleGroup>
       ) : null}
 

--- a/yak-ops-ui/src/pages/dashboard/direct-link-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/direct-link-editor.tsx
@@ -1,0 +1,212 @@
+import { Button, Select, Tooltip } from 'antd';
+import { Link2, Plus, Trash2 } from 'lucide-react';
+import type {
+  AnalysisAsset,
+  DashboardCrossFilterRule,
+  DashboardInlineAnalysisSpec,
+  DashboardWidget,
+  DashboardWidgetBehavior,
+  PublishedDataset,
+} from './model';
+
+const createRuleId = () => `cross-${Date.now()}-${Math.round(Math.random() * 1000)}`;
+
+const behaviorHasMeaning = (behavior: DashboardWidgetBehavior) => Boolean(
+  behavior.crossFilters?.length
+  || (behavior.clickAction && behavior.clickAction !== 'none'),
+);
+
+export function DashboardDirectCrossFilterEditor({
+  widget,
+  widgets,
+  spec,
+  dataset,
+  datasets,
+  analyses,
+  onChange,
+}: {
+  widget: DashboardWidget;
+  widgets: DashboardWidget[];
+  spec: DashboardInlineAnalysisSpec;
+  dataset: PublishedDataset;
+  datasets: PublishedDataset[];
+  analyses: AnalysisAsset[];
+  onChange: (behavior: DashboardWidgetBehavior | undefined) => void;
+}) {
+  const behavior = spec.dashboardBehavior || {};
+  const rules = behavior.crossFilters || [];
+  // AnalysisSelection currently emits the primary category dimension. Keep the editor
+  // honest by only offering that field as a direct-link source.
+  const sourceFields = spec.dimensions.slice(0, 1);
+  const sourceOptions = sourceFields.map((fieldId) => {
+    const field = dataset.fields.find((item) => item.key === fieldId);
+    return { label: field?.label || fieldId, value: fieldId };
+  });
+
+  const targetDescriptors = widgets.flatMap((targetWidget) => {
+    if (targetWidget.id === widget.id) return [];
+    const targetSpec = targetWidget.analysisId
+      ? analyses.find((item) => item.id === targetWidget.analysisId)
+      : targetWidget.inlineAnalysis;
+    if (!targetSpec) return [];
+    const targetDataset = datasets.find((item) => item.id === targetSpec.datasetId);
+    if (!targetDataset) return [];
+    const targetFields = targetDataset.fields.filter((field) => field.role === 'dimension');
+    if (!targetFields.length) return [];
+    const targetAnalysis = targetWidget.analysisId
+      ? analyses.find((item) => item.id === targetWidget.analysisId)
+      : undefined;
+    return [{
+      widget: targetWidget,
+      title: targetWidget.analysisId
+        ? targetAnalysis?.name ?? '历史图表'
+        : targetWidget.title?.trim() || '未命名图表',
+      dataset: targetDataset,
+      fields: targetFields,
+    }];
+  });
+
+  const targetOptions = targetDescriptors.map((item) => ({
+    label: `${item.title} · ${item.dataset.name}`,
+    value: item.widget.id,
+  }));
+
+  const patchRules = (nextRules: DashboardCrossFilterRule[]) => {
+    const nextBehavior: DashboardWidgetBehavior = {
+      ...behavior,
+      crossFilters: nextRules.length ? nextRules : undefined,
+    };
+    onChange(behaviorHasMeaning(nextBehavior) ? nextBehavior : undefined);
+  };
+
+  const addRule = () => {
+    const sourceField = sourceFields[0];
+    const target = targetDescriptors[0];
+    if (!sourceField || !target) return;
+    const targetField = target.fields.find((field) => field.key === sourceField)?.key
+      || target.fields[0]?.key;
+    if (!targetField) return;
+    patchRules([
+      ...rules,
+      {
+        id: createRuleId(),
+        sourceField,
+        targetWidgetId: target.widget.id,
+        targetField,
+      },
+    ]);
+  };
+
+  const updateRule = (id: string, patch: Partial<DashboardCrossFilterRule>) => {
+    patchRules(rules.map((rule) => rule.id === id ? { ...rule, ...patch } : rule));
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <div className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+            <Link2 size={12} />
+            直接图表联动
+          </div>
+          <div className="mt-1 text-[9px] leading-4 text-[#98a2b3]">
+            点击当前图表分类后，直接把值映射为目标图表的运行时筛选，不需要先创建全局筛选器。
+          </div>
+        </div>
+        <Button
+          size="small"
+          type="text"
+          icon={<Plus size={12} />}
+          disabled={!sourceOptions.length || !targetOptions.length}
+          onClick={addRule}
+        >
+          添加
+        </Button>
+      </div>
+
+      {!sourceOptions.length ? (
+        <div className="mt-2 rounded-[6px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
+          当前图表没有可点击的主分类维度，暂时不能作为直接联动来源。
+        </div>
+      ) : !targetOptions.length ? (
+        <div className="mt-2 rounded-[6px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
+          当前仪表盘没有其他可映射的维度图表。
+        </div>
+      ) : rules.length ? (
+        <div className="mt-2 space-y-2">
+          {rules.map((rule) => {
+            const target = targetDescriptors.find((item) => item.widget.id === rule.targetWidgetId);
+            const targetFieldOptions = target?.fields.map((field) => ({
+              label: `${field.label} · ${field.dataType}`,
+              value: field.key,
+            })) ?? [];
+            const targetStillAvailable = Boolean(target);
+            return (
+              <div key={rule.id} className="rounded-[7px] border border-[#edf0f3] bg-[#fafbfc] p-2.5">
+                <div className="grid grid-cols-[1fr_28px] items-end gap-2">
+                  <div>
+                    <div className="mb-1 text-[9px] text-[#98a2b3]">点击字段</div>
+                    <Select
+                      size="small"
+                      className="w-full"
+                      value={rule.sourceField}
+                      options={sourceOptions}
+                      onChange={(sourceField) => updateRule(rule.id, { sourceField })}
+                    />
+                  </div>
+                  <Tooltip title="删除联动">
+                    <Button
+                      size="small"
+                      type="text"
+                      danger
+                      className="w-7 px-0"
+                      icon={<Trash2 size={12} />}
+                      onClick={() => patchRules(rules.filter((item) => item.id !== rule.id))}
+                    />
+                  </Tooltip>
+                </div>
+
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  <div>
+                    <div className="mb-1 text-[9px] text-[#98a2b3]">目标图表</div>
+                    <Select
+                      size="small"
+                      className="w-full"
+                      status={targetStillAvailable ? undefined : 'error'}
+                      value={targetStillAvailable ? rule.targetWidgetId : undefined}
+                      placeholder={targetStillAvailable ? '选择目标图表' : '目标已失效'}
+                      options={targetOptions}
+                      onChange={(targetWidgetId) => {
+                        const nextTarget = targetDescriptors.find((item) => item.widget.id === targetWidgetId);
+                        if (!nextTarget) return;
+                        const targetField = nextTarget.fields.find((field) => field.key === rule.sourceField)?.key
+                          || nextTarget.fields[0]?.key;
+                        if (!targetField) return;
+                        updateRule(rule.id, { targetWidgetId, targetField });
+                      }}
+                    />
+                  </div>
+                  <div>
+                    <div className="mb-1 text-[9px] text-[#98a2b3]">映射字段</div>
+                    <Select
+                      size="small"
+                      className="w-full"
+                      disabled={!targetStillAvailable}
+                      value={targetStillAvailable ? rule.targetField : undefined}
+                      options={targetFieldOptions}
+                      onChange={(targetField) => updateRule(rule.id, { targetField })}
+                    />
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-2 rounded-[6px] bg-[#fafbfc] px-2.5 py-2 text-[10px] leading-4 text-[#98a2b3]">
+          暂无直接联动。添加后，来源和目标可以使用不同 Dataset，只要显式选择对应的目标维度字段即可。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -9,6 +9,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DashboardChartSheetWorkspace } from './chart-sheet-workspace';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
+import {
+  directCrossFiltersForWidget,
+  pruneRuntimeSelections,
+  sameDashboardSelection,
+  type DashboardRuntimeSelections,
+} from './interaction-runtime';
+import type { AnalysisSelection } from './model';
 import { DashboardSheetBar } from './sheet-bar';
 import { DashboardToolbar } from './toolbar';
 import { useDashboardDesigner } from './use-dashboard';
@@ -32,6 +39,7 @@ export default function DashboardEditorPage() {
   const [activeSheet, setActiveSheet] = useState<'dashboard' | 'chart'>('dashboard');
   const [activeSheetId, setActiveSheetId] = useState<string>();
   const [sheetOrder, setSheetOrder] = useState<string[]>([]);
+  const [runtimeSelections, setRuntimeSelections] = useState<DashboardRuntimeSelections>({});
   const layout = useMemo(() => designer.widgets.map((widget) => ({
     i: widget.id,
     x: widget.x,
@@ -65,7 +73,12 @@ export default function DashboardEditorPage() {
     setSheetOrder(designer.widgets.map((widget) => widget.id));
     setActiveSheet('dashboard');
     setActiveSheetId(undefined);
+    setRuntimeSelections({});
   }, [designer.dashboard.id]);
+
+  useEffect(() => {
+    setRuntimeSelections({});
+  }, [designer.dashboard.currentVersionId]);
 
   useEffect(() => {
     const widgetIds = designer.widgets.map((widget) => widget.id);
@@ -77,6 +90,7 @@ export default function DashboardEditorPage() {
         ? current
         : next;
     });
+    setRuntimeSelections((current) => pruneRuntimeSelections(designer.widgets, current));
   }, [designer.widgets]);
 
   useEffect(() => {
@@ -103,6 +117,55 @@ export default function DashboardEditorPage() {
   };
 
   const addChart = () => designer.addWidget('bar');
+
+  const clearWidgetSelection = useCallback((widgetId: string) => {
+    const nextSelections = { ...runtimeSelections };
+    delete nextSelections[widgetId];
+    setRuntimeSelections(nextSelections);
+
+    const targetFilterIds = new Set(designer.dashboard.interactions
+      .filter((interaction) => interaction.sourceWidgetId === widgetId)
+      .map((interaction) => interaction.targetFilterId));
+    targetFilterIds.forEach((filterId) => {
+      const replacement = designer.dashboard.interactions.find((interaction) => {
+        if (interaction.targetFilterId !== filterId || interaction.sourceWidgetId === widgetId) return false;
+        const selection = nextSelections[interaction.sourceWidgetId];
+        return selection?.fieldId === interaction.sourceField;
+      });
+      const replacementSelection = replacement
+        ? nextSelections[replacement.sourceWidgetId]
+        : undefined;
+      const defaultValue = designer.dashboard.globalFilters.find((filter) => filter.id === filterId)?.defaultValue;
+      designer.setRuntimeFilterValue(filterId, replacementSelection?.value ?? defaultValue);
+    });
+  }, [designer, runtimeSelections]);
+
+  const handleRuntimeSelection = useCallback((widgetId: string, selection: AnalysisSelection) => {
+    const current = runtimeSelections[widgetId];
+    if (sameDashboardSelection(current, selection)) {
+      clearWidgetSelection(widgetId);
+      return;
+    }
+
+    const widget = designer.widgets.find((item) => item.id === widgetId);
+    const behavior = widget?.inlineAnalysis?.dashboardBehavior;
+    const hasDirectLink = Boolean(behavior?.crossFilters?.some((rule) => rule.sourceField === selection.fieldId));
+    const hasGlobalLink = designer.dashboard.interactions.some((interaction) => (
+      interaction.sourceWidgetId === widgetId && interaction.sourceField === selection.fieldId
+    ));
+    const hasClickAction = Boolean(behavior?.clickAction && behavior.clickAction !== 'none');
+    if (hasDirectLink || hasGlobalLink || hasClickAction) {
+      setRuntimeSelections((items) => ({ ...items, [widgetId]: selection }));
+    }
+
+    const target = designer.handleWidgetSelection(widgetId, selection);
+    if (target) history.push(target);
+  }, [clearWidgetSelection, designer, runtimeSelections]);
+
+  const resetRuntimeInteractions = useCallback(() => {
+    setRuntimeSelections({});
+    designer.resetRuntimeFilters();
+  }, [designer]);
 
   const saveDashboard = useCallback(async () => {
     const persisted = /^\d+$/.test(designer.dashboard.id);
@@ -150,6 +213,7 @@ export default function DashboardEditorPage() {
     const restore = async () => {
       await designer.restoreVersion(versionNo);
       setHistoryOpen(false);
+      setRuntimeSelections({});
     };
     if (!designer.dirty) {
       void restore();
@@ -166,7 +230,13 @@ export default function DashboardEditorPage() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (designer.preview) return;
+      if (designer.preview) {
+        if (event.key === 'Escape' && Object.keys(runtimeSelections).length) {
+          event.preventDefault();
+          resetRuntimeInteractions();
+        }
+        return;
+      }
       const key = event.key.toLowerCase();
       const modifier = event.metaKey || event.ctrlKey;
 
@@ -217,7 +287,7 @@ export default function DashboardEditorPage() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [designer, saveDashboard]);
+  }, [designer, resetRuntimeInteractions, runtimeSelections, saveDashboard]);
 
   const showDashboardWorkspace = designer.preview || activeSheet === 'dashboard';
 
@@ -250,6 +320,7 @@ export default function DashboardEditorPage() {
         onPreview={() => {
           designer.setPreview((current) => !current);
           designer.setSelectedId(undefined);
+          setRuntimeSelections({});
         }}
         onSaveDraft={() => void saveDashboard()}
         onPublish={publishDashboard}
@@ -264,7 +335,7 @@ export default function DashboardEditorPage() {
           analyses={designer.analyses}
           editable={false}
           onRuntimeValue={designer.setRuntimeFilterValue}
-          onReset={designer.resetRuntimeFilters}
+          onReset={resetRuntimeInteractions}
           onManage={() => undefined}
         />
       ) : null}
@@ -312,6 +383,11 @@ export default function DashboardEditorPage() {
                         ? designer.datasets.find((item) => item.id === runtimeSpec.datasetId)
                         : undefined;
                       const drillPath = designer.drillPathForWidget(widget.id);
+                      const directFilters = directCrossFiltersForWidget(
+                        designer.widgets,
+                        runtimeSelections,
+                        widget.id,
+                      );
 
                       return (
                         <div key={widget.id} id={`dashboard-widget-${widget.id}`}>
@@ -320,8 +396,12 @@ export default function DashboardEditorPage() {
                             analysis={analysis}
                             runtimeSpec={runtimeSpec}
                             dataset={dataset}
-                            runtimeFilters={designer.runtimeFiltersForWidget(widget.id)}
+                            runtimeFilters={[
+                              ...designer.runtimeFiltersForWidget(widget.id),
+                              ...directFilters,
+                            ]}
                             drillPath={drillPath}
+                            activeSelection={runtimeSelections[widget.id]}
                             selected={designer.selectedId === widget.id}
                             preview={designer.preview}
                             onSelect={() => {
@@ -329,10 +409,13 @@ export default function DashboardEditorPage() {
                             }}
                             onDataSelect={(selection) => {
                               if (!designer.preview) return;
-                              const target = designer.handleWidgetSelection(widget.id, selection);
-                              if (target) history.push(target);
+                              handleRuntimeSelection(widget.id, selection);
                             }}
-                            onDrillBack={(depth) => designer.drillBack(widget.id, depth)}
+                            onClearSelection={() => clearWidgetSelection(widget.id)}
+                            onDrillBack={(depth) => {
+                              clearWidgetSelection(widget.id);
+                              designer.drillBack(widget.id, depth);
+                            }}
                             onDuplicate={() => designer.duplicateWidget(widget.id)}
                             onDelete={() => designer.deleteWidget(widget.id)}
                           />
@@ -376,6 +459,7 @@ export default function DashboardEditorPage() {
           <DashboardChartSheetWorkspace
             currentDashboardId={designer.dashboard.id}
             widget={designer.selectedWidget}
+            widgets={designer.widgets}
             datasets={designer.datasets}
             analyses={designer.analyses}
             globalFilters={designer.dashboard.globalFilters}
@@ -437,10 +521,6 @@ export default function DashboardEditorPage() {
           border-width: 0 1px 1px 0 !important;
           height: 6px !important;
           width: 6px !important;
-        }
-        .chart-sheet-workspace > aside {
-          border-left: 0 !important;
-          border-right: 1px solid #e3e6ea !important;
         }
         .chart-editor-more > .ant-collapse-item {
           border-bottom: 1px solid #eceef1 !important;

--- a/yak-ops-ui/src/pages/dashboard/helpers.tsx
+++ b/yak-ops-ui/src/pages/dashboard/helpers.tsx
@@ -26,8 +26,14 @@ export const FIELD_DRAG_MIME = 'application/x-yak-dashboard-field';
 export const CHART_META: Record<ChartType, { label: string; description: string; icon: ReactNode }> = {
   metric: { label: '指标卡', description: '展示单个核心指标', icon: <Sigma size={15} /> },
   bar: { label: '柱状图', description: '分类对比与排行', icon: <BarChart3 size={15} /> },
+  stackedBar: { label: '堆叠柱状图', description: '堆叠比较整体与构成', icon: <BarChart3 size={15} /> },
   line: { label: '折线图', description: '趋势与时间序列', icon: <ChartLine size={15} /> },
+  area: { label: '面积图', description: '趋势变化与区间体量', icon: <ChartLine size={15} /> },
   pie: { label: '饼图', description: '占比与构成分析', icon: <ChartPie size={15} /> },
+  scatter: { label: '散点图', description: '双指标相关性与离群点', icon: <Sigma size={15} /> },
+  radar: { label: '雷达图', description: '多指标对象对比', icon: <ChartPie size={15} /> },
+  funnel: { label: '漏斗图', description: '阶段转化与逐层收敛', icon: <BarChart3 size={15} /> },
+  treemap: { label: '矩形树图', description: '按面积呈现分类贡献', icon: <Table2 size={15} /> },
   table: { label: '明细表', description: '多维度数据查看', icon: <Table2 size={15} /> },
 };
 
@@ -122,7 +128,7 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
     datasetId: dataset.id,
     // Seed semantic category even for metric cards. `applyAnalysisEncoding` keeps the
     // metric query dimensionless while preserving a useful category if the user later
-    // switches this chart to bar / line / pie.
+    // switches chart type.
     dimensions: bindings.dimensions,
     metrics: bindings.metrics,
     filters: [],
@@ -130,7 +136,17 @@ export const createInlineAnalysis = (type: ChartType, dataset: PublishedDataset)
     limit: type === 'table' ? 200 : 500,
     timeoutSeconds: 30,
   };
-  return applyAnalysisEncoding(base, legacyAnalysisEncoding(base));
+  const encoded = applyAnalysisEncoding(base, legacyAnalysisEncoding(base));
+  // Advanced charts such as scatter / radar have a larger minimum metric cardinality.
+  // Rebinding seeds only required slots when the Dataset has enough compatible fields.
+  return rebindAnalysisEncoding(encoded, dataset);
+};
+
+const widgetShapeFor = (type: ChartType) => {
+  if (type === 'metric') return { w: 6, h: 4, minW: 4, minH: 3 };
+  if (type === 'table') return { w: 16, h: 8, minW: 8, minH: 6 };
+  if (type === 'radar' || type === 'treemap') return { w: 12, h: 8, minW: 7, minH: 6 };
+  return { w: 10, h: 7, minW: 6, minH: 5 };
 };
 
 export const createWidget = (type: ChartType, dataset: PublishedDataset, y: number): DashboardWidget => ({
@@ -139,10 +155,7 @@ export const createWidget = (type: ChartType, dataset: PublishedDataset, y: numb
   inlineAnalysis: createInlineAnalysis(type, dataset),
   x: 0,
   y,
-  w: type === 'metric' ? 6 : type === 'table' ? 16 : 10,
-  h: type === 'metric' ? 4 : type === 'table' ? 8 : 7,
-  minW: type === 'metric' ? 4 : type === 'table' ? 8 : 6,
-  minH: type === 'metric' ? 3 : type === 'table' ? 6 : 5,
+  ...widgetShapeFor(type),
 });
 
 const rebindInlineAnalysis = (spec: AnalysisSpec, dataset: PublishedDataset): AnalysisSpec => {

--- a/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/interaction-editor.tsx
@@ -26,7 +26,9 @@ export function DashboardInteractionEditor({
   onChange: (interactions: DashboardInteraction[]) => void;
 }) {
   const rules = interactions.filter((item) => item.sourceWidgetId === widget.id);
-  const sourceOptions = spec.dimensions.map((fieldId) => {
+  // AnalysisSelection currently emits the primary category dimension. Keep configured
+  // interaction sources aligned with the actual runtime event contract.
+  const sourceOptions = spec.dimensions.slice(0, 1).map((fieldId) => {
     const field = dataset.fields.find((item) => item.key === fieldId);
     return {
       label: field?.label || fieldId,
@@ -76,10 +78,10 @@ export function DashboardInteractionEditor({
         <div>
           <div className="flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
             <Link2 size={12} />
-            图表联动
+            筛选器联动
           </div>
           <div className="mt-1 text-[9px] leading-4 text-[#98a2b3]">
-            点击当前图表的分类值后，写入目标筛选器并刷新它绑定的图表。
+            点击当前图表的主分类值后，写入目标全局筛选器并刷新它绑定的图表。
           </div>
         </div>
         <Button
@@ -95,11 +97,11 @@ export function DashboardInteractionEditor({
 
       {!filters.length ? (
         <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
-          先在画布顶部添加全局筛选器，再配置图表联动。
+          先创建全局筛选器，再配置筛选器联动。
         </div>
       ) : !sourceOptions.length ? (
         <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
-          当前图表没有维度字段，暂时不能作为联动来源。
+          当前图表没有可点击的主分类维度，暂时不能作为联动来源。
         </div>
       ) : !targetOptions.length ? (
         <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
@@ -146,7 +148,7 @@ export function DashboardInteractionEditor({
         </div>
       ) : (
         <div className="mt-2 rounded-[5px] bg-[#fafbfc] px-2.5 py-2 text-[10px] text-[#98a2b3]">
-          暂无联动。点击“添加”后选择来源维度和目标筛选器。
+          暂无筛选器联动。添加后选择来源维度和目标全局筛选器。
         </div>
       )}
     </div>

--- a/yak-ops-ui/src/pages/dashboard/interaction-runtime.test.ts
+++ b/yak-ops-ui/src/pages/dashboard/interaction-runtime.test.ts
@@ -1,0 +1,78 @@
+import {
+  directCrossFiltersForWidget,
+  pruneRuntimeSelections,
+  sameDashboardSelection,
+} from './interaction-runtime';
+import type { AnalysisSelection, DashboardWidget } from './model';
+
+const selection = (fieldId: string, value: string): AnalysisSelection => ({
+  fieldId,
+  value,
+  label: `${fieldId}: ${value}`,
+  rowIndex: 0,
+});
+
+const widgets = [
+  {
+    id: 'source',
+    inlineAnalysis: {
+      dashboardBehavior: {
+        crossFilters: [
+          {
+            id: 'link-1',
+            sourceField: 'province',
+            targetWidgetId: 'target',
+            targetField: 'region',
+          },
+        ],
+      },
+    },
+  },
+  { id: 'target' },
+] as DashboardWidget[];
+
+describe('dashboard direct cross-filter runtime', () => {
+  it('maps an active source selection into the target field', () => {
+    expect(directCrossFiltersForWidget(
+      widgets,
+      { source: selection('province', '广东') },
+      'target',
+    )).toEqual([
+      {
+        id: 'dashboard-cross-source-link-1',
+        field: 'region',
+        operator: 'eq',
+        value: '广东',
+      },
+    ]);
+  });
+
+  it('ignores rules when the emitted source field does not match', () => {
+    expect(directCrossFiltersForWidget(
+      widgets,
+      { source: selection('city', '深圳') },
+      'target',
+    )).toEqual([]);
+  });
+
+  it('compares semantic selections for click-to-clear behavior', () => {
+    expect(sameDashboardSelection(
+      selection('province', '广东'),
+      selection('province', '广东'),
+    )).toBe(true);
+    expect(sameDashboardSelection(
+      selection('province', '广东'),
+      selection('province', '浙江'),
+    )).toBe(false);
+  });
+
+  it('removes runtime selections for widgets that no longer exist', () => {
+    expect(pruneRuntimeSelections(
+      widgets,
+      {
+        source: selection('province', '广东'),
+        removed: selection('province', '浙江'),
+      },
+    )).toEqual({ source: selection('province', '广东') });
+  });
+});

--- a/yak-ops-ui/src/pages/dashboard/interaction-runtime.ts
+++ b/yak-ops-ui/src/pages/dashboard/interaction-runtime.ts
@@ -52,5 +52,5 @@ export const pruneRuntimeSelections = (
   const widgetIds = new Set(widgets.map((widget) => widget.id));
   return Object.fromEntries(
     Object.entries(selections).filter(([widgetId, selection]) => widgetIds.has(widgetId) && selection),
-  );
+  ) as DashboardRuntimeSelections;
 };

--- a/yak-ops-ui/src/pages/dashboard/interaction-runtime.ts
+++ b/yak-ops-ui/src/pages/dashboard/interaction-runtime.ts
@@ -1,0 +1,56 @@
+import type {
+  AnalysisSelection,
+  DashboardFilter,
+  DashboardWidget,
+} from './model';
+
+export type DashboardRuntimeSelections = Record<string, AnalysisSelection | undefined>;
+
+export const sameDashboardSelection = (
+  left?: AnalysisSelection,
+  right?: AnalysisSelection,
+) => Boolean(
+  left
+  && right
+  && left.fieldId === right.fieldId
+  && Object.is(left.value, right.value),
+);
+
+/**
+ * Materialize chart-to-chart links as ordinary runtime Analysis filters. This deliberately
+ * stays outside the persisted AnalysisSpec: a click is session state, not Dashboard dirty state.
+ */
+export const directCrossFiltersForWidget = (
+  widgets: DashboardWidget[],
+  selections: DashboardRuntimeSelections,
+  targetWidgetId: string,
+): DashboardFilter[] => widgets.flatMap((sourceWidget) => {
+  const selection = selections[sourceWidget.id];
+  if (!selection || !sourceWidget.inlineAnalysis) return [];
+  const rules = sourceWidget.inlineAnalysis.dashboardBehavior?.crossFilters ?? [];
+  return rules.flatMap((rule) => {
+    if (
+      rule.targetWidgetId !== targetWidgetId
+      || rule.sourceField !== selection.fieldId
+      || selection.value === undefined
+      || selection.value === null
+      || selection.value === ''
+    ) return [];
+    return [{
+      id: `dashboard-cross-${sourceWidget.id}-${rule.id}`,
+      field: rule.targetField,
+      operator: 'eq' as const,
+      value: String(selection.value),
+    }];
+  });
+});
+
+export const pruneRuntimeSelections = (
+  widgets: DashboardWidget[],
+  selections: DashboardRuntimeSelections,
+): DashboardRuntimeSelections => {
+  const widgetIds = new Set(widgets.map((widget) => widget.id));
+  return Object.fromEntries(
+    Object.entries(selections).filter(([widgetId, selection]) => widgetIds.has(widgetId) && selection),
+  );
+};

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -34,8 +34,21 @@ export type {
 
 export type DashboardWidgetClickAction = 'none' | 'drill' | 'dashboard' | 'yak';
 
+/**
+ * Dashboard-local direct chart linkage. The source widget owns the rule; selecting its
+ * source field creates a runtime EQ filter on the mapped target widget field.
+ */
+export interface DashboardCrossFilterRule {
+  id: string;
+  sourceField: string;
+  targetWidgetId: string;
+  targetField: string;
+}
+
 /** Dashboard-only behavior persisted together with the inline Analysis snapshot. */
 export interface DashboardWidgetBehavior {
+  /** Direct chart-to-chart filters introduced in BI Phase 11. */
+  crossFilters?: DashboardCrossFilterRule[];
   clickAction?: DashboardWidgetClickAction;
   /** Ordered hierarchy, e.g. province -> city -> store. */
   drillFields?: string[];

--- a/yak-ops-ui/src/pages/dashboard/widget-action-editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget-action-editor.tsx
@@ -38,6 +38,11 @@ const ACTION_OPTIONS: Array<{
   { label: '跳转 Yak 页面', value: 'yak' },
 ];
 
+const hasBehavior = (behavior: DashboardWidgetBehavior) => Boolean(
+  behavior.crossFilters?.length
+  || (behavior.clickAction && behavior.clickAction !== 'none'),
+);
+
 export function DashboardWidgetActionEditor({
   currentDashboardId,
   spec,
@@ -85,14 +90,24 @@ export function DashboardWidgetActionEditor({
     .filter((route) => YAK_TARGET_IDS.has(route.id))
     .map((route) => ({ label: route.title, value: route.path })), []);
 
+  const emit = (next: DashboardWidgetBehavior) => {
+    onChange(hasBehavior(next) ? next : undefined);
+  };
+
   const patch = (next: Partial<DashboardWidgetBehavior>) => {
-    const value: DashboardWidgetBehavior = { ...behavior, ...next };
-    onChange(value.clickAction && value.clickAction !== 'none' ? value : undefined);
+    emit({ ...behavior, ...next });
   };
 
   const changeAction = (clickAction: DashboardWidgetClickAction) => {
     if (clickAction === 'none') {
-      onChange(undefined);
+      emit({
+        ...behavior,
+        clickAction: undefined,
+        drillFields: undefined,
+        targetDashboardId: undefined,
+        targetPath: undefined,
+        queryParam: undefined,
+      });
       return;
     }
     if (clickAction === 'drill') {
@@ -130,7 +145,7 @@ export function DashboardWidgetActionEditor({
         点击行为
       </div>
       <div className="mt-1 text-[9px] leading-4 text-[#98a2b3]">
-        这是图表的主要点击动作；Stage 3 的筛选联动仍可同时执行。
+        这是图表的主要点击动作；直接图表联动和筛选器联动仍可同时执行。
       </div>
 
       <Select

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -7,6 +7,7 @@ import {
   MoreHorizontal,
   RotateCcw,
   Trash2,
+  X,
 } from 'lucide-react';
 import type {
   AnalysisAsset,
@@ -25,10 +26,12 @@ export function WidgetShell({
   dataset,
   runtimeFilters,
   drillPath,
+  activeSelection,
   selected,
   preview,
   onSelect,
   onDataSelect,
+  onClearSelection,
   onDrillBack,
   onDuplicate,
   onDelete,
@@ -39,10 +42,12 @@ export function WidgetShell({
   dataset?: PublishedDataset;
   runtimeFilters: DashboardFilter[];
   drillPath: DashboardDrillStep[];
+  activeSelection?: AnalysisSelection;
   selected: boolean;
   preview: boolean;
   onSelect: () => void;
   onDataSelect: (selection: AnalysisSelection) => void;
+  onClearSelection: () => void;
   onDrillBack: (depth: number) => void;
   onDuplicate: () => void;
   onDelete: () => void;
@@ -58,7 +63,9 @@ export function WidgetShell({
       className={[
         'group relative flex h-full min-h-0 flex-col overflow-hidden rounded-[9px] bg-white transition-[border-color,box-shadow,transform] duration-150',
         preview
-          ? 'border border-[#e7e9ed] shadow-[0_1px_2px_rgba(16,24,40,.03)]'
+          ? activeSelection
+            ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
+            : 'border border-[#e7e9ed] shadow-[0_1px_2px_rgba(16,24,40,.03)]'
           : selected
             ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
             : 'border border-[#e4e7ec] shadow-[0_1px_2px_rgba(16,24,40,.025)] hover:border-[#d6dae0] hover:shadow-[0_4px_12px_rgba(16,24,40,.055)]',
@@ -77,6 +84,22 @@ export function WidgetShell({
         <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-[#344054]">
           {title}
         </span>
+
+        {preview && activeSelection ? (
+          <button
+            type="button"
+            title={activeSelection.label}
+            className="ml-2 flex max-w-[190px] shrink-0 items-center gap-1 rounded-[5px] border border-[var(--yak-brand-color-border)] bg-[var(--yak-brand-color-soft)] px-1.5 py-1 text-[9px] text-[#475467]"
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              onClearSelection();
+            }}
+          >
+            <span className="truncate">已选 · {String(activeSelection.value)}</span>
+            <X size={9} className="shrink-0 text-[#7a818c]" />
+          </button>
+        ) : null}
 
         {!preview ? (
           <div


### PR DESCRIPTION
## What changed
- add **direct chart-to-chart cross-filtering** to Dashboard preview: selecting a source chart category can now apply a runtime `EQ` filter directly to one or more target charts without first creating a global filter
- support explicit source-field -> target-field mapping, including targets backed by a different Dataset
- persist direct-link rules as Dashboard-local `inlineAnalysis.dashboardBehavior.crossFilters`; the selected value itself remains runtime-only session state and does not make the Dashboard dirty
- add a dedicated **直接图表联动** editor in the Chart Sheet interaction section
- keep the existing global-filter routing model and rename its editor presentation to **筛选器联动** so the two interaction mechanisms are clearly separated
- keep existing drill-down, Dashboard navigation and Yak page navigation compatible with both direct links and global-filter links
- surface the active source selection in preview with a lightweight selected border/chip and support click-the-same-value / chip X to clear it
- make runtime reset clear both global-filter values and direct chart selections; `Escape` in preview also clears active interaction selections
- preserve cross-filter rules when the primary click action is changed or disabled
- prune runtime selections when widgets disappear and add focused runtime tests for direct-field mapping, source-field mismatch, semantic click-to-clear and stale selection cleanup

## Runtime flow

```text
source chart click
      ↓
AnalysisSelection
      ↓
Dashboard runtime selection state
      ├─ direct cross-filter rule
      │      ↓
      │  target field mapping
      │      ↓
      │  runtime AnalysisFilter (EQ)
      │      ↓
      │  target Dataset query refresh
      │
      ├─ existing global-filter interaction
      ├─ existing drill hierarchy
      ├─ Dashboard navigation
      └─ Yak page navigation
```

Direct selection values are deliberately not written back into `AnalysisSpec`, `DashboardDocument` or the history stack. Only the reusable interaction rule is persisted; the current click selection belongs to the viewer session.

## Interaction model

A source chart can now combine three independent behaviors:

1. **直接图表联动** — source field -> target widget + target Dataset field
2. **筛选器联动** — source field -> existing Dashboard global filter -> all filter bindings
3. **主要点击动作** — drill / Dashboard jump / Yak page jump

The three routes can execute from the same selection instead of being mutually exclusive.

## Phase 10 integration note

Phase 10 PR #489 was created as a stacked PR against the Phase 9 feature branch. It was merged there after Phase 9 had already landed on `main`, so the six Phase 10 advanced chart types were not actually present in current `main`.

This Phase 11 branch therefore first integrates the Phase 10 head onto the current `main` (which also contains the digital-screen work from PR #490) with merge commit `7379c52b142e2af4337db6172fc1bc04ac1ea2cf`, and then layers Phase 11 interactions on top. As a result this PR intentionally contains the missing Phase 10 frontend delta plus the Phase 11 changes.

## Compatibility
- Dashboard document version remains `1`
- no backend DTO/domain changes
- no database / Flyway migration
- no Dataset query payload/API changes
- no new npm dependency
- existing global filters and `DashboardInteraction[]` remain supported unchanged
- direct links are stored only in Dashboard-local inline Analysis JSON; legacy shared Analysis assets remain read-only until copied into a Dashboard-local chart
- Phase 8 table calculations, Phase 9 calculated fields and Phase 10 advanced charts continue through the same query/render pipeline

## Validation
- [x] branch is based on current `main` and is 0 commits behind
- [x] current `main` + the previously missing Phase 10 chart delta are integrated without replacing the digital-screen changes
- [x] final compare contains 20 frontend files only; no backend / Flyway files
- [x] added focused unit tests for direct runtime cross-filter mapping and selection lifecycle
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm run jest -- interaction-runtime.test.ts chart-options.test.ts calculated-field.test.ts`
- [ ] manual browser regression: same-Dataset direct link, cross-Dataset mapping, click-to-clear, global-filter linkage, drill/back, Dashboard/Yak navigation, preview reset and save/reopen

Executable validation is intentionally left unchecked in the current connector-only environment rather than being claimed as completed. No GitHub Actions workflow run is currently associated with the branch head.