### PR TITLE
feat(bi): harden editor runtime and persistence (phase 12)

### DIFF
--- a/yak-ops-ui/docs/bi-editor-engineering.md
+++ b/yak-ops-ui/docs/bi-editor-engineering.md
@@ -1,0 +1,74 @@
+# BI Editor Engineering Boundary
+
+Phase 12 closes the first BI editor roadmap by making the runtime and persistence boundaries explicit. The goal is not to add another chart feature; it is to keep the editor predictable as the number of widgets, interactions and saved Dashboard versions grows.
+
+## Runtime query coordination
+
+`src/components/analysis/query-runtime.ts` is the shared Dataset query coordinator used by `AnalysisPreview`.
+
+- identical in-flight queries share one Promise;
+- successful raw Dataset results are kept for a short 1.5 second TTL;
+- Dataset id **and Dataset version** are part of the cache key;
+- failed queries are evicted immediately;
+- the cache is bounded to 64 entries;
+- calculated fields are still materialized after the shared raw result returns, so chart-local formulas do not contaminate another chart's result.
+
+The existing 180 ms editor debounce and request sequence guard stay in `AnalysisPreview`. Together the flow is:
+
+```text
+Spec / runtime filters change
+        ↓
+180 ms debounce
+        ↓
+Dataset + version + payload key
+        ↓
+shared in-flight / short TTL result
+        ↓
+calculated-field materialization
+        ↓
+latest-request sequence guard
+        ↓
+chart renderer
+```
+
+## Render failure isolation
+
+`AnalysisErrorBoundary` wraps each `AnalysisPreview`. Unexpected React/chart-option render failures are isolated to the current chart. Dataset query failures continue to use the normal query-error state and are not treated as render crashes.
+
+This matters on a Dashboard canvas: one malformed persisted chart should not blank the entire editor or viewer.
+
+## Dashboard document integrity
+
+`src/pages/dashboard/dashboard-integrity.ts` owns referential cleanup that is safe to perform without understanding business semantics.
+
+It removes:
+
+- duplicate/blank widget ids;
+- global-filter bindings that point to missing widgets;
+- duplicate filter bindings;
+- filter interactions whose source widget or target filter no longer exists;
+- direct chart links whose target widget no longer exists;
+- duplicate direct chart links.
+
+It deliberately does **not** rewrite Encoding, formulas, styling, aggregation choices, Top N, drill hierarchies or chart types.
+
+The normalizer runs when a server Dashboard becomes a `DashboardDocument` and again before the document is serialized for create/save. This makes old snapshots forward-tolerant without introducing a Dashboard document version migration.
+
+## Focused regression suite
+
+Run the BI-only logic regression suite from `yak-ops-ui`:
+
+```bash
+npm run test:bi
+```
+
+The command groups the focused tests for:
+
+- Phase 8 analysis calculations;
+- Phase 9 calculated fields;
+- Phase 10 chart options;
+- Phase 11 interaction runtime;
+- Phase 12 query coordination;
+- Phase 12 Dashboard integrity.
+
+Full release validation still includes `npm run lint`, `npm run build` and browser regression of editor/viewer behavior.

--- a/yak-ops-ui/package.json
+++ b/yak-ops-ui/package.json
@@ -28,6 +28,7 @@
     "start:pre": "cross-env REACT_APP_ENV=pre UMI_ENV=dev max dev",
     "start:test": "cross-env REACT_APP_ENV=test MOCK=none UMI_ENV=dev max dev",
     "test": "jest",
+    "test:bi": "jest src/components/analysis/analysis.test.ts src/components/analysis/calculated-field.test.ts src/components/analysis/chart-options.test.ts src/components/analysis/query-runtime.test.ts src/pages/dashboard/interaction-runtime.test.ts src/pages/dashboard/dashboard-integrity.test.ts",
     "test:coverage": "npm run jest -- --coverage",
     "test:update": "npm run jest -- -u",
     "tsc": "tsc --noEmit"

--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -1,4 +1,4 @@
-import { Empty, Spin } from 'antd';
+import { Button, Empty, Spin } from 'antd';
 import * as echarts from 'echarts';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AnalysisErrorBoundary } from './analysis-error-boundary';
@@ -124,9 +124,10 @@ function useAnalysisQuery(
   dataset?: PublishedDataset,
   runtimeFilters: AnalysisFilter[] = [],
 ) {
-  const [result, setResult] = useState<DatasetQueryResult>();
+  const [rawResult, setRawResult] = useState<DatasetQueryResult>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [retryVersion, setRetryVersion] = useState(0);
   const sequence = useRef(0);
   const runtimeFilterKey = useMemo(() => JSON.stringify(runtimeFilters), [runtimeFilters]);
   const payload = useMemo(
@@ -134,10 +135,14 @@ function useAnalysisQuery(
     [dataset, spec, runtimeFilterKey],
   );
   const payloadKey = useMemo(() => JSON.stringify(payload), [payload]);
+  const result = useMemo(
+    () => rawResult ? materializeCalculatedFields(spec, rawResult) : undefined,
+    [rawResult, spec],
+  );
 
   useEffect(() => {
     if (!dataset || !payload || !canQueryAnalysis(spec)) {
-      setResult(undefined);
+      setRawResult(undefined);
       setError('');
       setLoading(false);
       return undefined;
@@ -148,10 +153,10 @@ function useAnalysisQuery(
       setError('');
       try {
         const value = await queryAnalysisDatasetShared(dataset, payload);
-        if (requestId === sequence.current) setResult(materializeCalculatedFields(spec, value));
+        if (requestId === sequence.current) setRawResult(value);
       } catch (queryError) {
         if (requestId === sequence.current) {
-          setResult(undefined);
+          setRawResult(undefined);
           setError(queryError instanceof Error ? queryError.message : 'Dataset 查询失败');
         }
       } finally {
@@ -162,9 +167,14 @@ function useAnalysisQuery(
       window.clearTimeout(timer);
       if (sequence.current === requestId) sequence.current += 1;
     };
-  }, [dataset?.id, dataset?.currentVersionNo, payloadKey]);
+  }, [dataset?.id, dataset?.currentVersionNo, payloadKey, retryVersion]);
 
-  return { result, loading, error };
+  return {
+    result,
+    loading,
+    error,
+    retry: () => setRetryVersion((value) => value + 1),
+  };
 }
 
 const bindingIndex = (
@@ -377,7 +387,7 @@ function AnalysisPreviewContent({
   onSelect,
   className = 'h-full min-h-0',
 }: AnalysisPreviewProps) {
-  const { result, loading, error } = useAnalysisQuery(spec, dataset, runtimeFilters);
+  const { result, loading, error, retry } = useAnalysisQuery(spec, dataset, runtimeFilters);
   if (!dataset) {
     return <div className={className}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Dataset 不存在或已下线" className="mt-8" /></div>;
   }
@@ -388,7 +398,16 @@ function AnalysisPreviewContent({
     return <div className={`${className} flex items-center justify-center`}><Spin size="small" /></div>;
   }
   if (error) {
-    return <div className={`${className} flex items-center justify-center px-5 text-center text-[11px] text-[#b42318]`}>{error}</div>;
+    return (
+      <div className={`${className} flex items-center justify-center px-5 text-center`}>
+        <div>
+          <div className="text-[11px] text-[#b42318]">{error}</div>
+          <Button size="small" type="text" className="mt-2 !h-7 !text-[10px]" onClick={retry}>
+            重新查询
+          </Button>
+        </div>
+      </div>
+    );
   }
   if (!result) return <div className={className} />;
 
@@ -405,7 +424,12 @@ function AnalysisPreviewContent({
 }
 
 export function AnalysisPreview(props: AnalysisPreviewProps) {
-  const resetKey = `${props.dataset?.id ?? 'missing'}:${props.dataset?.currentVersionNo ?? 0}:${JSON.stringify(props.spec)}`;
+  const resetKey = [
+    props.dataset?.id ?? 'missing',
+    props.dataset?.currentVersionNo ?? 0,
+    JSON.stringify(props.spec),
+    JSON.stringify(props.runtimeFilters ?? []),
+  ].join(':');
   return (
     <AnalysisErrorBoundary key={resetKey}>
       <AnalysisPreviewContent {...props} />

--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -431,7 +431,7 @@ export function AnalysisPreview(props: AnalysisPreviewProps) {
     JSON.stringify(props.runtimeFilters ?? []),
   ].join(':');
   return (
-    <AnalysisErrorBoundary key={resetKey}>
+    <AnalysisErrorBoundary resetKey={resetKey}>
       <AnalysisPreviewContent {...props} />
     </AnalysisErrorBoundary>
   );

--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -1,6 +1,7 @@
 import { Empty, Spin } from 'antd';
 import * as echarts from 'echarts';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { AnalysisErrorBoundary } from './analysis-error-boundary';
 import {
   analysisMetricValues,
   formatAnalysisMetricValue,
@@ -17,7 +18,6 @@ import {
   metricAnalysisDisplayName,
 } from './display';
 import { encodingMeetsChartRequirements, resolveAnalysisEncoding } from './encoding';
-import { queryAnalysisDataset } from './dataset-service';
 import type {
   Aggregation,
   AnalysisFilter,
@@ -29,6 +29,7 @@ import type {
   PublishedDataset,
   Scalar,
 } from './model';
+import { queryAnalysisDatasetShared } from './query-runtime';
 import { resolveAnalysisStyle } from './style';
 
 export {
@@ -146,7 +147,7 @@ function useAnalysisQuery(
       setLoading(true);
       setError('');
       try {
-        const value = await queryAnalysisDataset(dataset.id, payload);
+        const value = await queryAnalysisDatasetShared(dataset, payload);
         if (requestId === sequence.current) setResult(materializeCalculatedFields(spec, value));
       } catch (queryError) {
         if (requestId === sequence.current) {
@@ -361,19 +362,21 @@ function TableAnalysis({
   );
 }
 
-export function AnalysisPreview({
-  spec,
-  dataset,
-  runtimeFilters = [],
-  onSelect,
-  className = 'h-full min-h-0',
-}: {
+interface AnalysisPreviewProps {
   spec: AnalysisSpec;
   dataset?: PublishedDataset;
   runtimeFilters?: AnalysisFilter[];
   onSelect?: (selection: AnalysisSelection) => void;
   className?: string;
-}) {
+}
+
+function AnalysisPreviewContent({
+  spec,
+  dataset,
+  runtimeFilters = [],
+  onSelect,
+  className = 'h-full min-h-0',
+}: AnalysisPreviewProps) {
   const { result, loading, error } = useAnalysisQuery(spec, dataset, runtimeFilters);
   if (!dataset) {
     return <div className={className}><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Dataset 不存在或已下线" className="mt-8" /></div>;
@@ -398,5 +401,14 @@ export function AnalysisPreview({
         ? <EChartAnalysis spec={spec} dataset={dataset} result={result} onSelect={onSelect} />
         : null}
     </div>
+  );
+}
+
+export function AnalysisPreview(props: AnalysisPreviewProps) {
+  const resetKey = `${props.dataset?.id ?? 'missing'}:${props.dataset?.currentVersionNo ?? 0}:${JSON.stringify(props.spec)}`;
+  return (
+    <AnalysisErrorBoundary key={resetKey}>
+      <AnalysisPreviewContent {...props} />
+    </AnalysisErrorBoundary>
   );
 }

--- a/yak-ops-ui/src/components/analysis/analysis-error-boundary.tsx
+++ b/yak-ops-ui/src/components/analysis/analysis-error-boundary.tsx
@@ -4,6 +4,8 @@ import { Component, type ErrorInfo, type ReactNode } from 'react';
 
 interface Props {
   children: ReactNode;
+  /** Changes clear a previous render failure without remounting healthy query state. */
+  resetKey?: string;
 }
 
 interface State {
@@ -25,6 +27,12 @@ export class AnalysisErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, info: ErrorInfo) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('[BI] Analysis render failed', error, info.componentStack);
+    }
+  }
+
+  componentDidUpdate(previous: Props) {
+    if (this.state.error && previous.resetKey !== this.props.resetKey) {
+      this.setState({ error: undefined });
     }
   }
 

--- a/yak-ops-ui/src/components/analysis/analysis-error-boundary.tsx
+++ b/yak-ops-ui/src/components/analysis/analysis-error-boundary.tsx
@@ -1,0 +1,57 @@
+import { Button } from 'antd';
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error?: Error;
+}
+
+/**
+ * Keep a single malformed chart option/spec from taking down the whole Dashboard canvas.
+ * Dataset/query errors continue to use the normal AnalysisPreview error state; this boundary
+ * is only for unexpected render-time failures.
+ */
+export class AnalysisErrorBoundary extends Component<Props, State> {
+  state: State = {};
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('[BI] Analysis render failed', error, info.componentStack);
+    }
+  }
+
+  private retry = () => this.setState({ error: undefined });
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div className="flex h-full min-h-[120px] items-center justify-center px-5 py-6 text-center">
+        <div className="max-w-[320px]">
+          <div className="mx-auto flex h-9 w-9 items-center justify-center rounded-[9px] bg-[#fff4f2] text-[#b42318]">
+            <AlertTriangle size={16} />
+          </div>
+          <div className="mt-2 text-[12px] font-medium text-[#344054]">图表渲染失败</div>
+          <div className="mt-1 text-[10px] leading-4 text-[#98a2b3]">
+            当前组件出现了未预期的渲染异常，其他图表不会受到影响。
+          </div>
+          <Button
+            size="small"
+            className="mt-3 !h-7 !rounded-[6px]"
+            icon={<RotateCcw size={11} />}
+            onClick={this.retry}
+          >
+            重试
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/yak-ops-ui/src/components/analysis/query-runtime.test.ts
+++ b/yak-ops-ui/src/components/analysis/query-runtime.test.ts
@@ -16,6 +16,7 @@ const payload: DatasetQueryPayload = {
 
 const result: DatasetQueryResult = {
   datasetId: '1',
+  datasetVersionId: 'version-3',
   datasetVersionNo: 3,
   columns: [],
   bindings: [],

--- a/yak-ops-ui/src/components/analysis/query-runtime.test.ts
+++ b/yak-ops-ui/src/components/analysis/query-runtime.test.ts
@@ -1,0 +1,69 @@
+import {
+  analysisQueryRuntimeSize,
+  clearAnalysisQueryRuntime,
+  queryAnalysisDatasetShared,
+} from './query-runtime';
+import type { DatasetQueryPayload, DatasetQueryResult } from './model';
+
+const payload: DatasetQueryPayload = {
+  dimensions: ['region'],
+  metrics: [{ fieldId: 'sales', aggregation: 'SUM' }],
+  filters: [],
+  sorts: [],
+  limit: 500,
+  timeoutSeconds: 30,
+};
+
+const result: DatasetQueryResult = {
+  datasetId: '1',
+  datasetVersionNo: 3,
+  columns: [],
+  bindings: [],
+  rows: [],
+  returnedRows: 0,
+  truncated: false,
+  elapsedMillis: 8,
+};
+
+describe('analysis query runtime', () => {
+  beforeEach(() => clearAnalysisQueryRuntime());
+
+  it('deduplicates identical in-flight requests', async () => {
+    let resolveRequest: (value: DatasetQueryResult) => void = () => undefined;
+    const loader = jest.fn(() => new Promise<DatasetQueryResult>((resolve) => {
+      resolveRequest = resolve;
+    }));
+    const dataset = { id: '1', currentVersionNo: 3 };
+
+    const first = queryAnalysisDatasetShared(dataset, payload, loader);
+    const second = queryAnalysisDatasetShared(dataset, payload, loader);
+
+    expect(first).toBe(second);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(analysisQueryRuntimeSize()).toBe(1);
+
+    resolveRequest(result);
+    await expect(first).resolves.toBe(result);
+  });
+
+  it('separates cache entries by Dataset version', async () => {
+    const loader = jest.fn(async () => result);
+
+    await queryAnalysisDatasetShared({ id: '1', currentVersionNo: 3 }, payload, loader);
+    await queryAnalysisDatasetShared({ id: '1', currentVersionNo: 4 }, payload, loader);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failed requests', async () => {
+    const loader = jest.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(result);
+    const dataset = { id: '1', currentVersionNo: 3 };
+
+    await expect(queryAnalysisDatasetShared(dataset, payload, loader)).rejects.toThrow('boom');
+    await expect(queryAnalysisDatasetShared(dataset, payload, loader)).resolves.toBe(result);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/yak-ops-ui/src/components/analysis/query-runtime.test.ts
+++ b/yak-ops-ui/src/components/analysis/query-runtime.test.ts
@@ -47,6 +47,16 @@ describe('analysis query runtime', () => {
     await expect(first).resolves.toBe(result);
   });
 
+  it('reuses a recently settled result', async () => {
+    const loader = jest.fn(async () => result);
+    const dataset = { id: '1', currentVersionNo: 3 };
+
+    await expect(queryAnalysisDatasetShared(dataset, payload, loader)).resolves.toBe(result);
+    await expect(queryAnalysisDatasetShared(dataset, payload, loader)).resolves.toBe(result);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
   it('separates cache entries by Dataset version', async () => {
     const loader = jest.fn(async () => result);
 

--- a/yak-ops-ui/src/components/analysis/query-runtime.ts
+++ b/yak-ops-ui/src/components/analysis/query-runtime.ts
@@ -61,11 +61,7 @@ export const queryAnalysisDatasetShared = (
   if (current) queryEntries.delete(key);
 
   pruneQueryEntries(now);
-  const entry: QueryEntry = {
-    promise: Promise.resolve(undefined as unknown as DatasetQueryResult),
-    settled: false,
-    expiresAt: Number.POSITIVE_INFINITY,
-  };
+  let entry: QueryEntry;
   const promise = loader(dataset.id, payload)
     .then((result) => {
       entry.settled = true;
@@ -76,7 +72,11 @@ export const queryAnalysisDatasetShared = (
       if (queryEntries.get(key) === entry) queryEntries.delete(key);
       throw error;
     });
-  entry.promise = promise;
+  entry = {
+    promise,
+    settled: false,
+    expiresAt: Number.POSITIVE_INFINITY,
+  };
   queryEntries.set(key, entry);
   return promise;
 };

--- a/yak-ops-ui/src/components/analysis/query-runtime.ts
+++ b/yak-ops-ui/src/components/analysis/query-runtime.ts
@@ -1,0 +1,86 @@
+import { queryAnalysisDataset } from './dataset-service';
+import type {
+  DatasetQueryPayload,
+  DatasetQueryResult,
+  PublishedDataset,
+} from './model';
+
+const QUERY_RESULT_TTL_MS = 1_500;
+const MAX_QUERY_ENTRIES = 64;
+
+type AnalysisQueryLoader = (
+  datasetId: string,
+  payload: DatasetQueryPayload,
+) => Promise<DatasetQueryResult>;
+
+interface QueryEntry {
+  promise: Promise<DatasetQueryResult>;
+  settled: boolean;
+  expiresAt: number;
+}
+
+const queryEntries = new Map<string, QueryEntry>();
+
+export const analysisQueryCacheKey = (
+  dataset: Pick<PublishedDataset, 'id' | 'currentVersionNo'>,
+  payload: DatasetQueryPayload,
+) => JSON.stringify({
+  datasetId: dataset.id,
+  datasetVersionNo: dataset.currentVersionNo ?? 0,
+  payload,
+});
+
+const pruneQueryEntries = (now: number) => {
+  queryEntries.forEach((entry, key) => {
+    if (entry.settled && entry.expiresAt <= now) queryEntries.delete(key);
+  });
+  while (queryEntries.size >= MAX_QUERY_ENTRIES) {
+    const oldest = queryEntries.keys().next().value as string | undefined;
+    if (!oldest) break;
+    queryEntries.delete(oldest);
+  }
+};
+
+/**
+ * Dashboard canvases frequently contain duplicated or closely related charts. Share an
+ * identical in-flight Dataset request and keep a very small success cache so mounting,
+ * resizing or switching Sheet state does not immediately issue the same query again.
+ *
+ * Dataset version is part of the key, so publishing a new Dataset version cannot reuse a
+ * result from the previous version. Failures are never cached.
+ */
+export const queryAnalysisDatasetShared = (
+  dataset: Pick<PublishedDataset, 'id' | 'currentVersionNo'>,
+  payload: DatasetQueryPayload,
+  loader: AnalysisQueryLoader = queryAnalysisDataset,
+): Promise<DatasetQueryResult> => {
+  const now = Date.now();
+  const key = analysisQueryCacheKey(dataset, payload);
+  const current = queryEntries.get(key);
+  if (current && (!current.settled || current.expiresAt > now)) return current.promise;
+  if (current) queryEntries.delete(key);
+
+  pruneQueryEntries(now);
+  const entry: QueryEntry = {
+    promise: Promise.resolve(undefined as unknown as DatasetQueryResult),
+    settled: false,
+    expiresAt: Number.POSITIVE_INFINITY,
+  };
+  const promise = loader(dataset.id, payload)
+    .then((result) => {
+      entry.settled = true;
+      entry.expiresAt = Date.now() + QUERY_RESULT_TTL_MS;
+      return result;
+    })
+    .catch((error) => {
+      if (queryEntries.get(key) === entry) queryEntries.delete(key);
+      throw error;
+    });
+  entry.promise = promise;
+  queryEntries.set(key, entry);
+  return promise;
+};
+
+export const clearAnalysisQueryRuntime = () => queryEntries.clear();
+
+export const analysisQueryRuntimeSize = () => queryEntries.size;

--- a/yak-ops-ui/src/pages/dashboard/dashboard-integrity.test.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-integrity.test.ts
@@ -1,0 +1,106 @@
+import {
+  normalizeDashboardDocument,
+  stripDashboardWidgetReferences,
+} from './dashboard-integrity';
+import type { DashboardDocument, DashboardWidget } from './model';
+
+const widget = (id: string): DashboardWidget => ({
+  id,
+  title: id,
+  x: 0,
+  y: 0,
+  w: 6,
+  h: 6,
+  inlineAnalysis: {
+    type: 'bar',
+    datasetId: `dataset-${id}`,
+    dimensions: ['region'],
+    metrics: [{ field: 'sales', aggregation: 'SUM' }],
+    filters: [],
+    style: {
+      showLegend: false,
+      showDataLabels: false,
+      smooth: false,
+      showGrid: true,
+    },
+  },
+});
+
+const baseDocument = (): DashboardDocument => ({
+  version: 1,
+  id: 'dashboard-1',
+  name: 'Dashboard',
+  activeDatasetId: 'dataset-a',
+  widgets: [widget('a'), widget('b')],
+  globalFilters: [{
+    id: 'filter-region',
+    name: '区域',
+    operator: 'eq',
+    bindings: [
+      { widgetId: 'a', field: 'region' },
+      { widgetId: 'b', field: 'region' },
+    ],
+  }],
+  interactions: [{
+    id: 'interaction-1',
+    event: 'select',
+    sourceWidgetId: 'a',
+    sourceField: 'region',
+    targetFilterId: 'filter-region',
+  }],
+});
+
+describe('dashboard integrity', () => {
+  it('drops stale references and duplicate semantic links', () => {
+    const document = baseDocument();
+    document.widgets[0].inlineAnalysis!.dashboardBehavior = {
+      crossFilters: [
+        { id: 'cross-1', sourceField: 'region', targetWidgetId: 'b', targetField: 'region' },
+        { id: 'cross-2', sourceField: 'region', targetWidgetId: 'b', targetField: 'region' },
+        { id: 'cross-stale', sourceField: 'region', targetWidgetId: 'missing', targetField: 'region' },
+      ],
+    };
+    document.globalFilters[0].bindings.push({ widgetId: 'missing', field: 'region' });
+    document.interactions.push({
+      id: 'interaction-stale',
+      event: 'select',
+      sourceWidgetId: 'missing',
+      sourceField: 'region',
+      targetFilterId: 'filter-region',
+    });
+
+    const normalized = normalizeDashboardDocument(document);
+
+    expect(normalized.widgets[0].inlineAnalysis?.dashboardBehavior?.crossFilters).toEqual([
+      { id: 'cross-1', sourceField: 'region', targetWidgetId: 'b', targetField: 'region' },
+    ]);
+    expect(normalized.globalFilters[0].bindings).toHaveLength(2);
+    expect(normalized.interactions).toHaveLength(1);
+  });
+
+  it('removes incoming and outgoing edges when a widget is rebound', () => {
+    const document = baseDocument();
+    document.widgets[0].inlineAnalysis!.dashboardBehavior = {
+      crossFilters: [{ id: 'a-b', sourceField: 'region', targetWidgetId: 'b', targetField: 'region' }],
+    };
+    document.widgets[1].inlineAnalysis!.dashboardBehavior = {
+      crossFilters: [{ id: 'b-a', sourceField: 'region', targetWidgetId: 'a', targetField: 'region' }],
+    };
+
+    const next = stripDashboardWidgetReferences(document, 'a', false);
+
+    expect(next.widgets).toHaveLength(2);
+    expect(next.widgets[0].inlineAnalysis?.dashboardBehavior?.crossFilters).toBeUndefined();
+    expect(next.widgets[1].inlineAnalysis?.dashboardBehavior?.crossFilters).toBeUndefined();
+    expect(next.globalFilters[0].bindings).toEqual([{ widgetId: 'b', field: 'region' }]);
+    expect(next.interactions).toEqual([]);
+  });
+
+  it('removes the widget itself when requested', () => {
+    const next = stripDashboardWidgetReferences(baseDocument(), 'a', true);
+
+    expect(next.widgets.map((item) => item.id)).toEqual(['b']);
+    expect(next.globalFilters[0].bindings).toEqual([{ widgetId: 'b', field: 'region' }]);
+    expect(next.interactions).toEqual([]);
+  });
+});

--- a/yak-ops-ui/src/pages/dashboard/dashboard-integrity.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-integrity.ts
@@ -52,7 +52,10 @@ const normalizeWidget = (widget: DashboardWidget, widgetIds: Set<string>): Dashb
   const spec = widget.inlineAnalysis;
   const behavior = spec?.dashboardBehavior;
   if (!spec || !behavior) return widget;
-  const crossFilters = normalizeCrossFilters(behavior.crossFilters ?? [], widgetIds);
+  const crossFilters = normalizeCrossFilters(
+    Array.isArray(behavior.crossFilters) ? behavior.crossFilters : [],
+    widgetIds,
+  );
   return {
     ...widget,
     inlineAnalysis: {
@@ -95,20 +98,24 @@ const normalizeInteractions = (
  */
 export const normalizeDashboardDocument = (document: DashboardDocument): DashboardDocument => {
   const widgets = uniqueBy(
-    document.widgets.filter((widget) => nonEmpty(widget.id)),
+    (document.widgets ?? []).filter((widget) => nonEmpty(widget.id)),
     (widget) => widget.id,
   );
   const widgetIds = new Set(widgets.map((widget) => widget.id));
   const normalizedWidgets = widgets.map((widget) => normalizeWidget(widget, widgetIds));
   const globalFilters = uniqueBy(
-    document.globalFilters.filter((filter) => nonEmpty(filter.id)),
+    (document.globalFilters ?? []).filter((filter) => nonEmpty(filter.id)),
     (filter) => filter.id,
   ).map((filter) => ({
     ...filter,
-    bindings: normalizeBindings(filter.bindings ?? [], widgetIds),
+    bindings: normalizeBindings(Array.isArray(filter.bindings) ? filter.bindings : [], widgetIds),
   }));
   const filterIds = new Set(globalFilters.map((filter) => filter.id));
-  const interactions = normalizeInteractions(document.interactions ?? [], widgetIds, filterIds);
+  const interactions = normalizeInteractions(
+    Array.isArray(document.interactions) ? document.interactions : [],
+    widgetIds,
+    filterIds,
+  );
 
   return {
     ...document,
@@ -129,14 +136,13 @@ export const stripDashboardWidgetReferences = (
   removeWidget: boolean,
 ): DashboardDocument => normalizeDashboardDocument({
   ...document,
-  widgets: document.widgets
+  widgets: (document.widgets ?? [])
     .filter((widget) => !removeWidget || widget.id !== widgetId)
     .map((widget) => {
       if (!widget.inlineAnalysis?.dashboardBehavior) return widget;
       const behavior = widget.inlineAnalysis.dashboardBehavior;
-      const crossFilters = (behavior.crossFilters ?? []).filter((rule) => (
-        widget.id !== widgetId && rule.targetWidgetId !== widgetId
-      ));
+      const crossFilters = (Array.isArray(behavior.crossFilters) ? behavior.crossFilters : [])
+        .filter((rule) => widget.id !== widgetId && rule.targetWidgetId !== widgetId);
       return {
         ...widget,
         inlineAnalysis: {
@@ -148,9 +154,9 @@ export const stripDashboardWidgetReferences = (
         },
       };
     }),
-  globalFilters: document.globalFilters.map((filter) => ({
+  globalFilters: (document.globalFilters ?? []).map((filter) => ({
     ...filter,
-    bindings: filter.bindings.filter((binding) => binding.widgetId !== widgetId),
+    bindings: (filter.bindings ?? []).filter((binding) => binding.widgetId !== widgetId),
   })),
-  interactions: document.interactions.filter((interaction) => interaction.sourceWidgetId !== widgetId),
+  interactions: (document.interactions ?? []).filter((interaction) => interaction.sourceWidgetId !== widgetId),
 });

--- a/yak-ops-ui/src/pages/dashboard/dashboard-integrity.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-integrity.ts
@@ -1,0 +1,156 @@
+import type {
+  DashboardCrossFilterRule,
+  DashboardDocument,
+  DashboardGlobalFilterBinding,
+  DashboardInteraction,
+  DashboardWidget,
+} from './model';
+
+const nonEmpty = (value: string | undefined) => Boolean(value?.trim());
+
+const uniqueBy = <T,>(items: T[], keyOf: (item: T) => string) => {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = keyOf(item);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+const normalizeBindings = (
+  bindings: DashboardGlobalFilterBinding[],
+  widgetIds: Set<string>,
+) => uniqueBy(
+  bindings.filter((binding) => widgetIds.has(binding.widgetId) && nonEmpty(binding.field)),
+  (binding) => `${binding.widgetId}\u0000${binding.field}`,
+);
+
+const normalizeCrossFilters = (
+  rules: DashboardCrossFilterRule[],
+  widgetIds: Set<string>,
+) => {
+  const ids = new Set<string>();
+  const pairs = new Set<string>();
+  return rules.filter((rule) => {
+    if (
+      !nonEmpty(rule.id)
+      || !nonEmpty(rule.sourceField)
+      || !widgetIds.has(rule.targetWidgetId)
+      || !nonEmpty(rule.targetField)
+      || ids.has(rule.id)
+    ) return false;
+    const pair = `${rule.sourceField}\u0000${rule.targetWidgetId}\u0000${rule.targetField}`;
+    if (pairs.has(pair)) return false;
+    ids.add(rule.id);
+    pairs.add(pair);
+    return true;
+  });
+};
+
+const normalizeWidget = (widget: DashboardWidget, widgetIds: Set<string>): DashboardWidget => {
+  const spec = widget.inlineAnalysis;
+  const behavior = spec?.dashboardBehavior;
+  if (!spec || !behavior) return widget;
+  const crossFilters = normalizeCrossFilters(behavior.crossFilters ?? [], widgetIds);
+  return {
+    ...widget,
+    inlineAnalysis: {
+      ...spec,
+      dashboardBehavior: {
+        ...behavior,
+        crossFilters: crossFilters.length ? crossFilters : undefined,
+      },
+    },
+  };
+};
+
+const normalizeInteractions = (
+  interactions: DashboardInteraction[],
+  widgetIds: Set<string>,
+  filterIds: Set<string>,
+) => {
+  const ids = new Set<string>();
+  const pairs = new Set<string>();
+  return interactions.filter((interaction) => {
+    if (
+      !nonEmpty(interaction.id)
+      || !widgetIds.has(interaction.sourceWidgetId)
+      || !nonEmpty(interaction.sourceField)
+      || !filterIds.has(interaction.targetFilterId)
+      || ids.has(interaction.id)
+    ) return false;
+    const pair = `${interaction.sourceWidgetId}\u0000${interaction.sourceField}\u0000${interaction.targetFilterId}`;
+    if (pairs.has(pair)) return false;
+    ids.add(interaction.id);
+    pairs.add(pair);
+    return true;
+  });
+};
+
+/**
+ * Repair only referential/integrity problems that cannot be meaningful to a user. The
+ * function deliberately does not rewrite chart semantics, Encoding, formulas or styling.
+ * It is safe to run on old persisted snapshots before editing or saving them again.
+ */
+export const normalizeDashboardDocument = (document: DashboardDocument): DashboardDocument => {
+  const widgets = uniqueBy(
+    document.widgets.filter((widget) => nonEmpty(widget.id)),
+    (widget) => widget.id,
+  );
+  const widgetIds = new Set(widgets.map((widget) => widget.id));
+  const normalizedWidgets = widgets.map((widget) => normalizeWidget(widget, widgetIds));
+  const globalFilters = uniqueBy(
+    document.globalFilters.filter((filter) => nonEmpty(filter.id)),
+    (filter) => filter.id,
+  ).map((filter) => ({
+    ...filter,
+    bindings: normalizeBindings(filter.bindings ?? [], widgetIds),
+  }));
+  const filterIds = new Set(globalFilters.map((filter) => filter.id));
+  const interactions = normalizeInteractions(document.interactions ?? [], widgetIds, filterIds);
+
+  return {
+    ...document,
+    version: 1,
+    widgets: normalizedWidgets,
+    globalFilters,
+    interactions,
+  };
+};
+
+/**
+ * Remove every persisted edge touching a widget. Use `removeWidget=false` before rebinding
+ * a widget to another Dataset, because incoming field mappings are no longer trustworthy.
+ */
+export const stripDashboardWidgetReferences = (
+  document: DashboardDocument,
+  widgetId: string,
+  removeWidget: boolean,
+): DashboardDocument => normalizeDashboardDocument({
+  ...document,
+  widgets: document.widgets
+    .filter((widget) => !removeWidget || widget.id !== widgetId)
+    .map((widget) => {
+      if (!widget.inlineAnalysis?.dashboardBehavior) return widget;
+      const behavior = widget.inlineAnalysis.dashboardBehavior;
+      const crossFilters = (behavior.crossFilters ?? []).filter((rule) => (
+        widget.id !== widgetId && rule.targetWidgetId !== widgetId
+      ));
+      return {
+        ...widget,
+        inlineAnalysis: {
+          ...widget.inlineAnalysis,
+          dashboardBehavior: {
+            ...behavior,
+            crossFilters: crossFilters.length ? crossFilters : undefined,
+          },
+        },
+      };
+    }),
+  globalFilters: document.globalFilters.map((filter) => ({
+    ...filter,
+    bindings: filter.bindings.filter((binding) => binding.widgetId !== widgetId),
+  })),
+  interactions: document.interactions.filter((interaction) => interaction.sourceWidgetId !== widgetId),
+});

--- a/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
@@ -182,13 +182,33 @@ export const toDashboardServerDetail = (value: DashboardDetailWire): DashboardSe
   interactions: (value.interactions || []).map(interaction),
 });
 
-const toDashboardVersionDetail = (value: DashboardVersionDetailWire): DashboardVersionDetail => ({
-  dashboard: summary(value.dashboard),
-  version: version(value.version),
-  widgets: (value.widgets || []).map(widget),
-  globalFilters: (value.globalFilters || []).map(globalFilter),
-  interactions: (value.interactions || []).map(interaction),
-});
+const toDashboardVersionDetail = (value: DashboardVersionDetailWire): DashboardVersionDetail => {
+  const dashboard = summary(value.dashboard);
+  const versionDetail = version(value.version);
+  const normalized = normalizeDashboardDocument({
+    version: 1,
+    id: dashboard.id,
+    name: versionDetail.name,
+    description: versionDetail.description,
+    activeDatasetId: versionDetail.activeDatasetId || '',
+    widgets: (value.widgets || []).map(widget),
+    globalFilters: (value.globalFilters || []).map(globalFilter),
+    interactions: (value.interactions || []).map(interaction),
+    currentVersionNo: versionDetail.versionNo,
+    currentVersionId: versionDetail.id,
+    publishedVersionNo: dashboard.publishedVersionNo,
+    publishedVersionId: dashboard.publishedVersionId,
+    publishedAt: dashboard.publishedTime,
+    updatedAt: dashboard.updateTime,
+  });
+  return {
+    dashboard,
+    version: versionDetail,
+    widgets: normalized.widgets,
+    globalFilters: normalized.globalFilters,
+    interactions: normalized.interactions,
+  };
+};
 
 export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDocument => normalizeDashboardDocument({
   version: 1,

--- a/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
@@ -2,6 +2,7 @@ import type { AnalysisSpec, Scalar } from '@/components/analysis/model';
 import type { ApiResponse } from '@/services/http/response';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
+import { normalizeDashboardDocument } from './dashboard-integrity';
 import type {
   DashboardDocument,
   DashboardGlobalFilter,
@@ -189,7 +190,7 @@ const toDashboardVersionDetail = (value: DashboardVersionDetailWire): DashboardV
   interactions: (value.interactions || []).map(interaction),
 });
 
-export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDocument => ({
+export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDocument => normalizeDashboardDocument({
   version: 1,
   id: detail.dashboard.id,
   name: detail.currentVersion?.name || detail.dashboard.name,
@@ -206,40 +207,43 @@ export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDoc
   updatedAt: detail.dashboard.updateTime,
 });
 
-const payload = (document: DashboardDocument) => ({
-  name: document.name,
-  description: document.description || undefined,
-  activeDatasetId: document.activeDatasetId || undefined,
-  widgets: document.widgets.map((item) => ({
-    widgetKey: item.id,
-    analysisId: item.analysisId,
-    title: item.title,
-    inlineAnalysis: item.inlineAnalysis,
-    x: item.x,
-    y: item.y,
-    w: item.w,
-    h: item.h,
-    minW: item.minW,
-    minH: item.minH,
-  })),
-  globalFilters: document.globalFilters.map((filter) => ({
-    filterKey: filter.id,
-    name: filter.name,
-    operator: operatorToWire(filter.operator),
-    defaultValue: filter.defaultValue,
-    bindings: filter.bindings.map((binding) => ({
-      widgetKey: binding.widgetId,
-      fieldId: binding.field,
+const payload = (document: DashboardDocument) => {
+  const normalized = normalizeDashboardDocument(document);
+  return {
+    name: normalized.name,
+    description: normalized.description || undefined,
+    activeDatasetId: normalized.activeDatasetId || undefined,
+    widgets: normalized.widgets.map((item) => ({
+      widgetKey: item.id,
+      analysisId: item.analysisId,
+      title: item.title,
+      inlineAnalysis: item.inlineAnalysis,
+      x: item.x,
+      y: item.y,
+      w: item.w,
+      h: item.h,
+      minW: item.minW,
+      minH: item.minH,
     })),
-  })),
-  interactions: document.interactions.map((item) => ({
-    interactionKey: item.id,
-    event: 'SELECT',
-    sourceWidgetKey: item.sourceWidgetId,
-    sourceFieldId: item.sourceField,
-    targetFilterKey: item.targetFilterId,
-  })),
-});
+    globalFilters: normalized.globalFilters.map((filter) => ({
+      filterKey: filter.id,
+      name: filter.name,
+      operator: operatorToWire(filter.operator),
+      defaultValue: filter.defaultValue,
+      bindings: filter.bindings.map((binding) => ({
+        widgetKey: binding.widgetId,
+        fieldId: binding.field,
+      })),
+    })),
+    interactions: normalized.interactions.map((item) => ({
+      interactionKey: item.id,
+      event: 'SELECT',
+      sourceWidgetKey: item.sourceWidgetId,
+      sourceFieldId: item.sourceField,
+      targetFilterKey: item.targetFilterId,
+    })),
+  };
+};
 
 export const fetchDashboards = async (): Promise<DashboardSummary[]> => {
   const values = unwrap(await HttpUtils.get<DashboardAssetWire[]>(DASHBOARD_API), '查询 Dashboard 列表失败');


### PR DESCRIPTION
## What changed
- add a shared Analysis query coordinator that deduplicates identical in-flight Dataset requests and keeps a very short version-aware success cache
- preserve the existing editor debounce/latest-request guard while separating raw Dataset query results from chart-local calculated-field materialization
- recompute calculated metrics immediately when formula/analysis configuration changes even when the physical aggregate query dependencies remain unchanged
- add an explicit retry path for Dataset query failures
- isolate unexpected chart render failures with a per-Analysis React error boundary so one malformed component does not blank the full Dashboard canvas
- add a Dashboard document integrity layer that removes stale/duplicate widget, global-filter, interaction and direct chart-link references at persistence boundaries
- normalize editable Dashboard snapshots, published/version snapshots and outgoing create/save payloads through the same integrity rules
- add a focused `npm run test:bi` regression command and engineering documentation for the BI module

## Query/runtime architecture

```text
AnalysisSpec / runtime filters
        ↓
existing 180 ms editor debounce
        ↓
Dataset id + Dataset version + query payload key
        ↓
shared in-flight query / 1.5s success cache
        ↓
raw DatasetQueryResult
        ↓
chart-local calculated-field materialization
        ↓
latest-request sequence guard
        ↓
metric / table / ECharts renderer
```

The shared cache is intentionally small and short-lived:
- maximum 64 entries
- 1.5 second success TTL
- Dataset version participates in the key
- failed requests are evicted immediately
- calculated-field materialization happens after the raw result is returned, so one chart's virtual fields cannot contaminate another chart's cached result

The raw-result separation also closes a correctness gap from Phase 9: editing a calculated-field formula can now recompute the virtual metric immediately even when the formula still depends on exactly the same physical aggregate query.

## Failure isolation
- Dataset query errors stay in the normal Analysis query state and expose `重新查询`
- unexpected React/render failures are contained by `AnalysisErrorBoundary`
- changing the chart spec/dataset/runtime filters clears a previous boundary failure without using a React `key`, so healthy query state is not remounted just to reset the boundary

## Dashboard document integrity
`dashboard-integrity.ts` repairs only referential problems that cannot represent valid user intent:
- blank/duplicate widget ids
- stale/duplicate global-filter bindings
- interactions whose source widget or target filter no longer exists
- stale/duplicate direct chart-to-chart cross-filter rules

It deliberately does **not** rewrite Encoding, calculated formulas, chart types, aggregation choices, Top N, drill hierarchies or visual styles.

The normalizer runs when server snapshots become Dashboard documents, for published/version snapshots, and again before create/save serialization. Existing Dashboard document version remains `1`; there is no migration step.

## Focused regression suite
A BI-only regression command is now available from `yak-ops-ui`:

```bash
npm run test:bi
```

It groups the focused suites for Phase 8 analysis calculations, Phase 9 calculated fields, Phase 10 chart options, Phase 11 interaction runtime, Phase 12 query coordination and Phase 12 Dashboard integrity.

## Compatibility
- Dashboard document version remains `1`
- no backend DTO/domain changes
- no database / Flyway migration
- no Dataset query payload/API changes
- no new npm dependency
- existing global filters, direct chart links, drill, Dashboard navigation and Yak navigation remain on their current contracts
- old Dashboard snapshots are normalized lazily at read/write boundaries rather than requiring a migration

## Validation
- [x] Phase 11 PR #491 is merged into `main`
- [x] branch starts from Phase 11 merge commit `98c7b32a891b6334b64a99001c166f863fb558fc`
- [x] branch compare is 0 commits behind `main`
- [x] final compare contains 9 UI/docs files only; no backend or Flyway files
- [x] added focused unit tests for in-flight query deduplication, short-lived result reuse, Dataset-version separation, failure eviction and Dashboard integrity cleanup
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm run test:bi`
- [ ] manual browser regression: formula edits with unchanged aggregate dependencies, duplicate charts, query retry, render fallback, save/reopen, published viewer and interaction flows

Executable frontend validation is intentionally left unchecked in the current connector-only environment rather than being claimed as completed. No GitHub Actions workflow run was associated with the branch head before opening this Draft PR.