### PR TITLE
refactor: redesign dashboard sheet bar

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -57,7 +57,8 @@ export default function DashboardEditorPage() {
       : undefined;
     return [{
       id: widget.id,
-      title: widget.analysisId ? analysis?.name ?? '历史图表' : widget.title ?? '未命名图表',
+      title: widget.title?.trim()
+        || (widget.analysisId ? analysis?.name ?? '历史图表' : '未命名图表'),
     }];
   }), [designer.analyses, designer.widgets, sheetOrder]);
   const hasGlobalFilters = designer.dashboard.globalFilters.length > 0;
@@ -481,12 +482,18 @@ export default function DashboardEditorPage() {
 
       {!designer.preview ? (
         <DashboardSheetBar
+          dashboardKey={designer.dashboard.id}
           sheets={sheets}
           activeSheet={activeSheet}
           activeSheetId={activeSheetId}
+          canAddChart={Boolean(designer.activeDataset) && !designer.datasetsLoading}
           onDashboard={activateDashboardSheet}
           onChart={activateChartSheet}
           onReorder={setSheetOrder}
+          onAddChart={addChart}
+          onRename={(sheetId, title) => designer.updateWidget(sheetId, { title })}
+          onDuplicate={designer.duplicateWidget}
+          onDelete={designer.deleteWidget}
         />
       ) : null}
 

--- a/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
@@ -1,32 +1,120 @@
-import { BarChart3, ChevronLeft, ChevronRight, LayoutDashboard } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Dropdown, Input, Modal, Tooltip } from 'antd';
+import type { MenuProps } from 'antd';
+import {
+  BarChart3,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Eye,
+  EyeOff,
+  FilePenLine,
+  LayoutDashboard,
+  MessageSquareText,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export type DashboardEditorSheet = {
   id: string;
   title: string;
 };
 
+type DashboardSheetMeta = {
+  note?: string;
+  hidden?: boolean;
+};
+
+type DashboardSheetMetaMap = Record<string, DashboardSheetMeta>;
+
+const SHEET_META_STORAGE_PREFIX = 'yak.dashboard.sheet-meta';
+
+const readSheetMeta = (dashboardKey: string): DashboardSheetMetaMap => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(`${SHEET_META_STORAGE_PREFIX}:${dashboardKey}`);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
 export function DashboardSheetBar({
+  dashboardKey,
   sheets,
   activeSheet,
   activeSheetId,
+  canAddChart = true,
   onDashboard,
   onChart,
   onReorder,
+  onAddChart,
+  onRename,
+  onDuplicate,
+  onDelete,
 }: {
+  dashboardKey: string;
   sheets: DashboardEditorSheet[];
   activeSheet: 'dashboard' | 'chart';
   activeSheetId?: string;
+  canAddChart?: boolean;
   onDashboard: () => void;
   onChart: (sheetId: string) => void;
   onReorder: (sheetIds: string[]) => void;
+  onAddChart?: () => void;
+  onRename?: (sheetId: string, title: string) => void;
+  onDuplicate?: (sheetId: string) => void;
+  onDelete?: (sheetId: string) => void;
 }) {
   const [draggingId, setDraggingId] = useState<string>();
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
+  const [sheetMeta, setSheetMeta] = useState<DashboardSheetMetaMap>({});
+  const [metaReady, setMetaReady] = useState(false);
+  const [renameSheet, setRenameSheet] = useState<DashboardEditorSheet>();
+  const [renameDraft, setRenameDraft] = useState('');
+  const [noteSheet, setNoteSheet] = useState<DashboardEditorSheet>();
+  const [noteDraft, setNoteDraft] = useState('');
   const viewportRef = useRef<HTMLDivElement>(null);
   const dashboardRef = useRef<HTMLButtonElement>(null);
   const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  useEffect(() => {
+    setMetaReady(false);
+    setSheetMeta(readSheetMeta(dashboardKey));
+    setMetaReady(true);
+  }, [dashboardKey]);
+
+  useEffect(() => {
+    if (!metaReady || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(
+        `${SHEET_META_STORAGE_PREFIX}:${dashboardKey}`,
+        JSON.stringify(sheetMeta),
+      );
+    } catch {
+      // Sheet notes and visibility are editor conveniences. Storage failure must not block editing.
+    }
+  }, [dashboardKey, metaReady, sheetMeta]);
+
+  const visibleSheets = useMemo(
+    () => sheets.filter((sheet) => !sheetMeta[sheet.id]?.hidden),
+    [sheetMeta, sheets],
+  );
+  const hiddenSheets = useMemo(
+    () => sheets.filter((sheet) => sheetMeta[sheet.id]?.hidden),
+    [sheetMeta, sheets],
+  );
+
+  const patchSheetMeta = useCallback((sheetId: string, patch: DashboardSheetMeta) => {
+    setSheetMeta((current) => ({
+      ...current,
+      [sheetId]: { ...current[sheetId], ...patch },
+    }));
+  }, []);
 
   const updateScrollState = useCallback(() => {
     const viewport = viewportRef.current;
@@ -47,17 +135,17 @@ export function DashboardSheetBar({
       observer.disconnect();
       viewport.removeEventListener('scroll', updateScrollState);
     };
-  }, [sheets.length, updateScrollState]);
+  }, [visibleSheets.length, updateScrollState]);
 
   useEffect(() => {
-    if (activeSheet !== 'chart' || !activeSheetId) return;
+    if (activeSheet !== 'chart' || !activeSheetId || sheetMeta[activeSheetId]?.hidden) return;
     tabRefs.current.get(activeSheetId)?.scrollIntoView({
       behavior: 'smooth',
       block: 'nearest',
       inline: 'nearest',
     });
     window.requestAnimationFrame(updateScrollState);
-  }, [activeSheet, activeSheetId, updateScrollState]);
+  }, [activeSheet, activeSheetId, sheetMeta, updateScrollState]);
 
   const moveBefore = (targetId: string) => {
     if (!draggingId || draggingId === targetId) return;
@@ -83,7 +171,7 @@ export function DashboardSheetBar({
   ) => {
     if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
     event.preventDefault();
-    const ids = ['dashboard', ...sheets.map((sheet) => sheet.id)];
+    const ids = ['dashboard', ...visibleSheets.map((sheet) => sheet.id)];
     const currentIndex = Math.max(0, ids.indexOf(currentId));
     let nextIndex = currentIndex;
     if (event.key === 'Home') nextIndex = 0;
@@ -106,95 +194,316 @@ export function DashboardSheetBar({
     });
   };
 
-  const baseClass = 'flex h-full shrink-0 items-center gap-1.5 border-x px-3 text-[11px] transition-colors focus-visible:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--yak-brand-color)]';
-  const inactiveClass = 'border-transparent text-[#667085] hover:bg-white/70 hover:text-[#344054]';
-  const activeClass = 'border-[#dfe3e8] bg-white font-medium text-[#161823] shadow-[inset_0_2px_0_var(--yak-brand-color)]';
+  const openRename = (sheet: DashboardEditorSheet) => {
+    setRenameSheet(sheet);
+    setRenameDraft(sheet.title);
+  };
+
+  const openNote = (sheet: DashboardEditorSheet) => {
+    setNoteSheet(sheet);
+    setNoteDraft(sheetMeta[sheet.id]?.note ?? '');
+  };
+
+  const hideSheet = (sheet: DashboardEditorSheet) => {
+    patchSheetMeta(sheet.id, { hidden: true });
+    if (activeSheet === 'chart' && activeSheetId === sheet.id) onDashboard();
+  };
+
+  const restoreSheet = (sheetId: string) => {
+    patchSheetMeta(sheetId, { hidden: false });
+    onChart(sheetId);
+  };
+
+  const confirmDelete = (sheet: DashboardEditorSheet) => {
+    Modal.confirm({
+      title: '删除 Sheet？',
+      content: `“${sheet.title}”对应的图表组件也会从当前仪表盘中删除。`,
+      okText: '删除',
+      cancelText: '取消',
+      okButtonProps: { danger: true },
+      onOk: () => {
+        if (activeSheet === 'chart' && activeSheetId === sheet.id) onDashboard();
+        onDelete?.(sheet.id);
+      },
+    });
+  };
+
+  const menuFor = (sheet: DashboardEditorSheet): MenuProps => ({
+    items: [
+      {
+        key: 'rename',
+        icon: <FilePenLine size={14} />,
+        label: '重命名',
+        disabled: !onRename,
+      },
+      {
+        key: 'duplicate',
+        icon: <Copy size={14} />,
+        label: '复制',
+        disabled: !onDuplicate,
+      },
+      {
+        key: 'note',
+        icon: <MessageSquareText size={14} />,
+        label: '备注',
+      },
+      { type: 'divider' },
+      {
+        key: 'hide',
+        icon: <EyeOff size={14} />,
+        label: '隐藏',
+      },
+      {
+        key: 'delete',
+        icon: <Trash2 size={14} />,
+        label: '删除',
+        danger: true,
+        disabled: !onDelete,
+      },
+    ],
+    onClick: ({ key, domEvent }) => {
+      domEvent.stopPropagation();
+      if (key === 'rename') openRename(sheet);
+      else if (key === 'duplicate') onDuplicate?.(sheet.id);
+      else if (key === 'note') openNote(sheet);
+      else if (key === 'hide') hideSheet(sheet);
+      else if (key === 'delete') confirmDelete(sheet);
+    },
+  });
+
+  const hiddenMenu: MenuProps = {
+    items: hiddenSheets.map((sheet) => ({
+      key: sheet.id,
+      icon: <Eye size={14} />,
+      label: (
+        <div className="flex min-w-[150px] items-center justify-between gap-4">
+          <span className="max-w-[190px] truncate">{sheet.title}</span>
+          <span className="text-[10px] text-[#98a2b3]">恢复</span>
+        </div>
+      ),
+    })),
+    onClick: ({ key }) => restoreSheet(String(key)),
+  };
+
+  const dashboardActive = activeSheet === 'dashboard';
 
   return (
-    <div className="flex h-10 shrink-0 items-stretch border-t border-[#dfe3e8] bg-[#f7f8fa]" role="tablist" aria-label="仪表盘编辑 Sheet">
-      <button
-        ref={dashboardRef}
-        type="button"
-        role="tab"
-        aria-selected={activeSheet === 'dashboard'}
-        className={`${baseClass} ${activeSheet === 'dashboard' ? activeClass : inactiveClass}`}
-        onClick={onDashboard}
-        onKeyDown={(event) => handleNavigation(event, 'dashboard')}
-      >
-        <LayoutDashboard size={13} />
-        仪表盘
-      </button>
-
-      <div className="h-full w-px shrink-0 bg-[#e5e7eb]" />
-
-      <button
-        type="button"
-        aria-label="向左滚动图表 Sheet"
-        disabled={!canScrollLeft}
-        className="flex w-7 shrink-0 items-center justify-center border-0 border-r border-[#e5e7eb] bg-transparent text-[#667085] hover:bg-white disabled:cursor-default disabled:text-[#c7ccd4]"
-        onClick={() => scrollSheets(-1)}
-      >
-        <ChevronLeft size={13} />
-      </button>
-
+    <>
       <div
-        ref={viewportRef}
-        className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex h-9 shrink-0 items-stretch border-t border-[#d9dde3] bg-[#f4f6f8] shadow-[0_-1px_0_rgba(16,24,40,.02)]"
+        aria-label="仪表盘编辑 Sheet"
       >
-        {sheets.length ? sheets.map((sheet) => {
-          const active = activeSheet === 'chart' && activeSheetId === sheet.id;
-          return (
+        <button
+          ref={dashboardRef}
+          type="button"
+          role="tab"
+          aria-selected={dashboardActive}
+          className={[
+            'relative flex h-full shrink-0 items-center gap-1.5 border-r border-[#dfe3e8] px-3.5 text-[11px] outline-none transition-colors',
+            'focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--yak-brand-color)]',
+            dashboardActive
+              ? 'bg-white font-medium text-[#161823] after:absolute after:inset-x-0 after:top-0 after:h-[2px] after:bg-[var(--yak-brand-color)]'
+              : 'text-[#626b78] hover:bg-white/80 hover:text-[#344054]',
+          ].join(' ')}
+          onClick={onDashboard}
+          onKeyDown={(event) => handleNavigation(event, 'dashboard')}
+        >
+          <LayoutDashboard size={13} className={dashboardActive ? 'text-[var(--yak-brand-color)]' : ''} />
+          <span>仪表盘</span>
+        </button>
+
+        <div
+          ref={viewportRef}
+          className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          role="tablist"
+        >
+          {visibleSheets.length ? visibleSheets.map((sheet) => {
+            const active = activeSheet === 'chart' && activeSheetId === sheet.id;
+            const note = sheetMeta[sheet.id]?.note?.trim();
+            return (
+              <div
+                key={sheet.id}
+                draggable
+                title={note ? `${sheet.title}\n备注：${note}` : `${sheet.title} · 拖动可调整 Sheet 顺序`}
+                className={[
+                  'group relative flex h-full min-w-[116px] max-w-[210px] shrink-0 items-stretch border-r border-[#dfe3e8] transition-colors',
+                  active
+                    ? 'bg-white text-[#161823] after:absolute after:inset-x-0 after:top-0 after:h-[2px] after:bg-[var(--yak-brand-color)]'
+                    : 'bg-transparent text-[#626b78] hover:bg-white/80 hover:text-[#344054]',
+                  draggingId === sheet.id ? 'opacity-45' : '',
+                ].join(' ')}
+                onDragStart={(event) => {
+                  setDraggingId(sheet.id);
+                  event.dataTransfer.effectAllowed = 'move';
+                  event.dataTransfer.setData('text/plain', sheet.id);
+                }}
+                onDragEnter={() => moveBefore(sheet.id)}
+                onDragOver={(event) => {
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = 'move';
+                }}
+                onDrop={(event) => event.preventDefault()}
+                onDragEnd={() => setDraggingId(undefined)}
+              >
+                <button
+                  ref={(node) => {
+                    if (node) tabRefs.current.set(sheet.id, node);
+                    else tabRefs.current.delete(sheet.id);
+                  }}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  className="flex min-w-0 flex-1 items-center gap-1.5 bg-transparent py-0 pl-3 pr-1 text-left text-[11px] outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--yak-brand-color)]"
+                  onClick={() => onChart(sheet.id)}
+                  onKeyDown={(event) => handleNavigation(event, sheet.id)}
+                >
+                  <BarChart3
+                    size={12}
+                    className={active ? 'shrink-0 text-[var(--yak-brand-color)]' : 'shrink-0 text-[#7d8591]'}
+                  />
+                  <span className={active ? 'truncate font-medium' : 'truncate'}>{sheet.title}</span>
+                  {note ? (
+                    <span
+                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#aeb5bf]"
+                      aria-label="已有备注"
+                    />
+                  ) : null}
+                </button>
+
+                <Dropdown menu={menuFor(sheet)} trigger={['click']} placement="topLeft">
+                  <button
+                    type="button"
+                    aria-label={`${sheet.title} Sheet 操作`}
+                    draggable={false}
+                    className={[
+                      'mr-1 flex w-6 shrink-0 items-center justify-center self-center rounded-[4px] text-[#818995] transition-all',
+                      'opacity-0 hover:bg-[#eef0f3] hover:text-[#344054] focus:opacity-100 focus:outline-none group-hover:opacity-100',
+                    ].join(' ')}
+                    onClick={(event) => event.stopPropagation()}
+                    onMouseDown={(event) => event.stopPropagation()}
+                  >
+                    <MoreHorizontal size={14} />
+                  </button>
+                </Dropdown>
+              </div>
+            );
+          }) : (
+            <div className="flex h-full items-center px-3 text-[10px] text-[#98a2b3]">
+              暂无图表 Sheet
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-stretch border-l border-[#dfe3e8] bg-[#f4f6f8]">
+          <Tooltip title="向左滚动">
             <button
-              key={sheet.id}
-              ref={(node) => {
-                if (node) tabRefs.current.set(sheet.id, node);
-                else tabRefs.current.delete(sheet.id);
-              }}
               type="button"
-              role="tab"
-              aria-selected={active}
-              draggable
-              title={`${sheet.title} · 拖动可调整 Sheet 顺序`}
-              className={`${baseClass} max-w-[220px] cursor-pointer ${active ? activeClass : inactiveClass} ${draggingId === sheet.id ? 'opacity-45' : ''}`}
-              onClick={() => onChart(sheet.id)}
-              onKeyDown={(event) => handleNavigation(event, sheet.id)}
-              onDragStart={(event) => {
-                setDraggingId(sheet.id);
-                event.dataTransfer.effectAllowed = 'move';
-                event.dataTransfer.setData('text/plain', sheet.id);
-              }}
-              onDragEnter={() => moveBefore(sheet.id)}
-              onDragOver={(event) => {
-                event.preventDefault();
-                event.dataTransfer.dropEffect = 'move';
-              }}
-              onDrop={(event) => event.preventDefault()}
-              onDragEnd={() => setDraggingId(undefined)}
+              aria-label="向左滚动图表 Sheet"
+              disabled={!canScrollLeft}
+              className="flex w-7 items-center justify-center bg-transparent text-[#687180] transition-colors hover:bg-white disabled:cursor-default disabled:text-[#c7ccd4]"
+              onClick={() => scrollSheets(-1)}
             >
-              <BarChart3 size={12} className="shrink-0" />
-              <span className="truncate">{sheet.title}</span>
+              <ChevronLeft size={13} />
             </button>
-          );
-        }) : (
-          <div className="flex h-full items-center px-3 text-[10px] text-[#98a2b3]">
-            暂无图表 Sheet
-          </div>
-        )}
+          </Tooltip>
+          <Tooltip title="向右滚动">
+            <button
+              type="button"
+              aria-label="向右滚动图表 Sheet"
+              disabled={!canScrollRight}
+              className="flex w-7 items-center justify-center bg-transparent text-[#687180] transition-colors hover:bg-white disabled:cursor-default disabled:text-[#c7ccd4]"
+              onClick={() => scrollSheets(1)}
+            >
+              <ChevronRight size={13} />
+            </button>
+          </Tooltip>
+
+          {hiddenSheets.length ? (
+            <Dropdown menu={hiddenMenu} trigger={['click']} placement="topRight">
+              <Tooltip title={`${hiddenSheets.length} 个隐藏 Sheet`}>
+                <button
+                  type="button"
+                  aria-label="显示隐藏 Sheet"
+                  className="relative flex w-8 items-center justify-center border-l border-[#dfe3e8] bg-transparent text-[#687180] transition-colors hover:bg-white"
+                >
+                  <EyeOff size={13} />
+                  <span className="absolute right-0.5 top-0.5 min-w-[12px] rounded-full bg-[#8d95a1] px-0.5 text-center text-[8px] leading-[12px] text-white">
+                    {hiddenSheets.length}
+                  </span>
+                </button>
+              </Tooltip>
+            </Dropdown>
+          ) : null}
+
+          <Tooltip title="新建图表 Sheet">
+            <button
+              type="button"
+              aria-label="新建图表 Sheet"
+              disabled={!onAddChart || !canAddChart}
+              className="flex w-9 items-center justify-center border-l border-[#dfe3e8] bg-transparent text-[#596271] transition-colors hover:bg-white hover:text-[var(--yak-brand-color)] disabled:cursor-not-allowed disabled:text-[#c7ccd4]"
+              onClick={onAddChart}
+            >
+              <Plus size={14} />
+            </button>
+          </Tooltip>
+        </div>
       </div>
 
-      <button
-        type="button"
-        aria-label="向右滚动图表 Sheet"
-        disabled={!canScrollRight}
-        className="flex w-7 shrink-0 items-center justify-center border-0 border-l border-[#e5e7eb] bg-transparent text-[#667085] hover:bg-white disabled:cursor-default disabled:text-[#c7ccd4]"
-        onClick={() => scrollSheets(1)}
+      <Modal
+        open={Boolean(renameSheet)}
+        title="重命名 Sheet"
+        okText="确定"
+        cancelText="取消"
+        width={400}
+        okButtonProps={{ disabled: !renameDraft.trim() }}
+        onCancel={() => setRenameSheet(undefined)}
+        onOk={() => {
+          const value = renameDraft.trim();
+          if (!renameSheet || !value) return;
+          onRename?.(renameSheet.id, value);
+          setRenameSheet(undefined);
+        }}
       >
-        <ChevronRight size={13} />
-      </button>
+        <Input
+          autoFocus
+          value={renameDraft}
+          maxLength={60}
+          placeholder="输入 Sheet 名称"
+          onChange={(event) => setRenameDraft(event.target.value)}
+          onPressEnter={() => {
+            const value = renameDraft.trim();
+            if (!renameSheet || !value) return;
+            onRename?.(renameSheet.id, value);
+            setRenameSheet(undefined);
+          }}
+        />
+      </Modal>
 
-      <div className="flex shrink-0 items-center border-l border-[#e5e7eb] px-3 text-[10px] text-[#98a2b3]">
-        {sheets.length} 个图表
-      </div>
-    </div>
+      <Modal
+        open={Boolean(noteSheet)}
+        title={noteSheet ? `备注 · ${noteSheet.title}` : 'Sheet 备注'}
+        okText="保存"
+        cancelText="取消"
+        width={440}
+        onCancel={() => setNoteSheet(undefined)}
+        onOk={() => {
+          if (!noteSheet) return;
+          patchSheetMeta(noteSheet.id, { note: noteDraft.trim() });
+          setNoteSheet(undefined);
+        }}
+      >
+        <Input.TextArea
+          autoFocus
+          value={noteDraft}
+          maxLength={300}
+          autoSize={{ minRows: 4, maxRows: 8 }}
+          placeholder="记录这个 Sheet 的用途、口径或待办事项"
+          onChange={(event) => setNoteDraft(event.target.value)}
+        />
+        <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
+          Sheet 备注仅保存在当前浏览器，不进入仪表盘服务端版本。
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/sheet-bar.tsx
@@ -73,7 +73,7 @@ export function DashboardSheetBar({
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const [sheetMeta, setSheetMeta] = useState<DashboardSheetMetaMap>({});
-  const [metaReady, setMetaReady] = useState(false);
+  const [loadedMetaKey, setLoadedMetaKey] = useState<string>();
   const [renameSheet, setRenameSheet] = useState<DashboardEditorSheet>();
   const [renameDraft, setRenameDraft] = useState('');
   const [noteSheet, setNoteSheet] = useState<DashboardEditorSheet>();
@@ -83,13 +83,13 @@ export function DashboardSheetBar({
   const tabRefs = useRef(new Map<string, HTMLButtonElement>());
 
   useEffect(() => {
-    setMetaReady(false);
+    setLoadedMetaKey(undefined);
     setSheetMeta(readSheetMeta(dashboardKey));
-    setMetaReady(true);
+    setLoadedMetaKey(dashboardKey);
   }, [dashboardKey]);
 
   useEffect(() => {
-    if (!metaReady || typeof window === 'undefined') return;
+    if (loadedMetaKey !== dashboardKey || typeof window === 'undefined') return;
     try {
       window.localStorage.setItem(
         `${SHEET_META_STORAGE_PREFIX}:${dashboardKey}`,
@@ -98,7 +98,7 @@ export function DashboardSheetBar({
     } catch {
       // Sheet notes and visibility are editor conveniences. Storage failure must not block editing.
     }
-  }, [dashboardKey, metaReady, sheetMeta]);
+  }, [dashboardKey, loadedMetaKey, sheetMeta]);
 
   const visibleSheets = useMemo(
     () => sheets.filter((sheet) => !sheetMeta[sheet.id]?.hidden),


### PR DESCRIPTION
## Overview

将仪表盘编辑器底部 Sheet 区域重构为更接近 FineBI / Excel 的紧凑 Sheet 标签交互。本 PR 只聚焦底部 Sheet Bar，不调整图表编辑器、Dataset、Dashboard 服务端模型或数字化大屏。

## What changed

- 底部 Sheet Bar 改为 36px 紧凑标签栏
- 当前 Sheet 使用白底 + Yak 品牌色顶部高亮
- Sheet hover 时显示 `...` 操作入口
- 操作菜单从 Sheet 上方弹出，包含：
  - 重命名
  - 复制
  - 备注
  - 隐藏
  - 删除
- 重命名直接更新当前 Dashboard Widget 的 `title`
- 复制 / 删除复用现有 Dashboard Designer 能力
- Sheet 备注支持编辑并用小圆点提示
- Sheet 隐藏后不再出现在底栏，右侧提供隐藏 Sheet 恢复入口
- 右侧保留左右滚动，并新增 `+` 新建图表 Sheet
- 保留现有拖拽排序
- 保留 Home / End / 左右方向键 Sheet 导航

## Sheet metadata boundary

为保持本 PR 只做 Sheet UI，不扩张后端模型：

- `重命名 / 复制 / 删除` 会作用于 Dashboard 当前草稿
- `备注 / 隐藏` 作为编辑器 Sheet 层本地元数据，按 Dashboard ID 保存到 `localStorage`
- 隐藏 Sheet 不会删除或隐藏 Dashboard 中的图表组件，只控制编辑器底部 Sheet 是否显示
- 隐藏状态可通过底栏右侧入口恢复

## Scope

本 PR 不包含：

- 图表类型或图表渲染调整
- Dataset / Query 改造
- Dashboard 后端字段或数据库变更
- Sheet 服务端持久化
- 数字化大屏相关修改

## Verification

- 分支基于当前最新 `main`
- `behind: 0`
- 最终 diff 仅包含 2 个文件：
  - `yak-ops-ui/src/pages/dashboard/sheet-bar.tsx`
  - `yak-ops-ui/src/pages/dashboard/editor.tsx`
- 现有拖拽排序、横向滚动和键盘导航继续保留
- 当前 connector-only 环境无法运行完整本地 `npm run tsc` / `npm run build`，建议以 PR CI 或本地工程校验作为最终验证
