### PR TITLE
fix: restore dashboard widgets after sheet switch

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -34,7 +34,7 @@ export default function DashboardEditorPage() {
   const dashboardId = id && id !== 'new' ? id : undefined;
   const initialPreview = new URLSearchParams(window.location.search).get('preview') === '1';
   const designer = useDashboardDesigner(dashboardId, initialPreview, false);
-  const { width, containerRef, mounted } = useContainerWidth();
+  const { width, containerRef, mounted, measureWidth } = useContainerWidth();
   const [historyOpen, setHistoryOpen] = useState(false);
   const [activeSheet, setActiveSheet] = useState<'dashboard' | 'chart'>('dashboard');
   const [activeSheetId, setActiveSheetId] = useState<string>();
@@ -104,6 +104,14 @@ export default function DashboardEditorPage() {
     setActiveSheet('dashboard');
     setActiveSheetId(undefined);
   }, [designer.preview, designer.selectedId]);
+
+  useEffect(() => {
+    if (designer.preview || activeSheet !== 'dashboard') return undefined;
+    const frame = window.requestAnimationFrame(() => {
+      measureWidth();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [activeSheet, designer.preview, measureWidth]);
 
   const activateDashboardSheet = () => {
     setActiveSheet('dashboard');


### PR DESCRIPTION
## Bug

从图表 Sheet 切回「仪表盘」后，底部 Sheet 和画布背景仍然存在，但 ReactGridLayout 中的图表组件不再渲染，需要刷新页面才能恢复。

## Root cause

仪表盘与图表 Sheet 当前是条件挂载。切到图表时，承载 `useContainerWidth()` 的 Dashboard 容器会被卸载；切回仪表盘后容器重新挂载，但 react-grid-layout v2 的宽度测量状态没有主动重新测量新的容器节点，导致 GridLayout 没有重新拿到有效宽度。

## Fix

- 从 `useContainerWidth()` 取出官方提供的 `measureWidth()`
- 当活动 Sheet 切回 `dashboard` 时，在下一帧主动重新测量 Dashboard 容器
- 不修改 Dashboard 数据、Widget、Sheet 元数据或图表配置

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/editor.tsx`

Diff: `+9 / -1`。

## Verification

目标回归路径：

1. 打开仪表盘编辑器，确认仪表盘图表正常显示
2. 点击任意图表 Sheet
3. 再点击底部「仪表盘」
4. 仪表盘中的原图表应立即重新显示，无需刷新页面
5. 连续往返切换多个图表 Sheet，仪表盘内容保持正常

分支直接基于已合并 #495 后的最新 `main`，ahead 1 / behind 0。