### PR TITLE
refactor: separate dashboard widget selection and editing

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -95,15 +95,14 @@ export default function DashboardEditorPage() {
   }, [designer.widgets]);
 
   useEffect(() => {
-    if (designer.preview) return;
+    if (designer.preview || activeSheet !== 'chart') return;
     if (designer.selectedId) {
-      setActiveSheet('chart');
       setActiveSheetId(designer.selectedId);
       return;
     }
     setActiveSheet('dashboard');
     setActiveSheetId(undefined);
-  }, [designer.preview, designer.selectedId]);
+  }, [activeSheet, designer.preview, designer.selectedId]);
 
   useEffect(() => {
     if (designer.preview || activeSheet !== 'dashboard') return undefined;
@@ -414,8 +413,9 @@ export default function DashboardEditorPage() {
                             selected={designer.selectedId === widget.id}
                             preview={designer.preview}
                             onSelect={() => {
-                              if (!designer.preview) activateChartSheet(widget.id);
+                              if (!designer.preview) designer.setSelectedId(widget.id);
                             }}
+                            onEdit={() => activateChartSheet(widget.id)}
                             onDataSelect={(selection) => {
                               if (!designer.preview) return;
                               handleRuntimeSelection(widget.id, selection);

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -5,6 +5,7 @@ import {
   Copy,
   GripVertical,
   MoreHorizontal,
+  Pencil,
   RotateCcw,
   Trash2,
   X,
@@ -30,6 +31,7 @@ export function WidgetShell({
   selected,
   preview,
   onSelect,
+  onEdit,
   onDataSelect,
   onClearSelection,
   onDrillBack,
@@ -46,6 +48,7 @@ export function WidgetShell({
   selected: boolean;
   preview: boolean;
   onSelect: () => void;
+  onEdit: () => void;
   onDataSelect: (selection: AnalysisSelection) => void;
   onClearSelection: () => void;
   onDrillBack: (depth: number) => void;
@@ -61,7 +64,7 @@ export function WidgetShell({
     <div
       onMouseDown={onSelect}
       className={[
-        'group relative flex h-full min-h-0 flex-col overflow-hidden rounded-[9px] bg-white transition-[border-color,box-shadow,transform] duration-150',
+        'group relative flex h-full min-h-0 flex-col overflow-hidden rounded-[9px] bg-white transition-[border-color,box-shadow] duration-150',
         preview
           ? activeSelection
             ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
@@ -104,10 +107,28 @@ export function WidgetShell({
         {!preview ? (
           <div
             className={[
-              'flex items-center transition-opacity duration-150',
+              'flex items-center gap-1 transition-opacity duration-150',
               selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
             ].join(' ')}
           >
+            {selected ? (
+              <Tooltip title="编辑图表">
+                <button
+                  type="button"
+                  aria-label="编辑图表"
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onEdit();
+                  }}
+                  className="flex h-7 items-center gap-1 rounded-[6px] border border-[var(--yak-brand-color-border)] bg-[var(--yak-brand-color-soft)] px-2 text-[10px] font-medium text-[var(--yak-brand-color)] transition-colors hover:bg-[rgba(254,44,85,.1)]"
+                >
+                  <Pencil size={11} />
+                  编辑
+                </button>
+              </Tooltip>
+            ) : null}
+
             <Dropdown
               trigger={['click']}
               placement="bottomRight"


### PR DESCRIPTION
## Overview

优化 Dashboard 画布中的图表交互，参考帆软的组件选中/编辑模式，将“选中组件”和“进入图表编辑”拆成两个明确动作。

## Problem

当前 Dashboard 中单击图表会立即切换到对应图表 Sheet，导致：

- 用户无法先选中组件再调整布局
- 单击和拖拽操作语义冲突
- 组件的移动、缩放、复制、删除等画布操作体验不自然
- Dashboard 编辑器更像“点击即跳转”，而不是可视化布局编辑器

## New interaction

- **单击图表**：仅选中当前组件，仍停留在 Dashboard 画布
- **选中状态**：保持 Yak 品牌色 Border，并显示拖拽把手和右上角操作区
- **点击右上角「编辑」**：才进入对应图表 Sheet / 图表配置页
- **拖拽标题栏**：继续移动组件，不再因为单击而跳转
- **缩放组件**：保持 react-grid-layout 原有 resize 能力
- **底部 Sheet**：仍然可以直接点击进入对应图表编辑
- **点击画布空白处 / Esc**：取消组件选中
- **复制 / 删除快捷键与更多菜单**：继续基于当前选中组件工作

## Implementation

### `editor.tsx`

- 移除 `selectedId` 自动驱动 `activeSheet=chart` 的行为
- `selectedId` 只表示 Dashboard 画布选中状态
- `activeSheet` 只表示当前工作区是 Dashboard 还是图表编辑
- 仅当已经处于 `chart` Sheet 时，同步 `activeSheetId` 与 `selectedId`
- Widget `onSelect` 改为只调用 `designer.setSelectedId(widget.id)`
- 新增显式 `onEdit`，调用 `activateChartSheet(widget.id)`

### `widget.tsx`

- 选中图表后右上角显示「编辑」按钮
- 「编辑」按钮使用明确的 Pencil 图标与 Yak 品牌色轻背景
- 编辑按钮阻止 mousedown 冒泡，不会误触 react-grid-layout 拖拽
- 保留现有更多菜单、复制、删除和 drag handle

## Scope

本 PR 只调整 Dashboard 画布的组件选中/编辑交互，不修改：

- 图表配置能力
- Dataset / Query
- Dashboard 后端模型
- Sheet Bar 数据模型
- 数字化大屏

## Diff

仅修改 2 个文件：

- `yak-ops-ui/src/pages/dashboard/editor.tsx`
- `yak-ops-ui/src/pages/dashboard/widget.tsx`

## Regression checklist

1. 在 Dashboard 中单击图表，只出现选中 Border，不跳转
2. 选中后可从标题栏正常拖拽图表
3. 选中后可正常 resize
4. 点击右上角「编辑」进入对应图表 Sheet
5. 点击底部图表 Sheet 仍可直接进入图表编辑
6. 从图表 Sheet 返回 Dashboard 后内容正常显示
7. Esc / 点击空白处可取消选中
8. Ctrl/Cmd+D、Delete/Backspace 和更多菜单继续对当前选中图表生效

当前 connector-only 环境无法执行完整本地 `npm run tsc` / `npm run build`，建议以 PR CI 或本地工程回归作为最终验证。