### PR TITLE
refactor: move dashboard widget actions to side toolbar

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -1,10 +1,9 @@
 import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
-import { Dropdown, Empty, Tooltip } from 'antd';
+import { Empty, Tooltip } from 'antd';
 import {
   ChevronRight,
   Copy,
   GripVertical,
-  MoreHorizontal,
   Pencil,
   RotateCcw,
   Trash2,
@@ -62,165 +61,169 @@ export function WidgetShell({
 
   return (
     <div
-      onMouseDown={onSelect}
       className={[
-        'group relative flex h-full min-h-0 flex-col overflow-hidden rounded-[9px] bg-white transition-[border-color,box-shadow] duration-150',
-        preview
-          ? activeSelection
-            ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
-            : 'border border-[#e7e9ed] shadow-[0_1px_2px_rgba(16,24,40,.03)]'
-          : selected
-            ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
-            : 'border border-[#e4e7ec] shadow-[0_1px_2px_rgba(16,24,40,.025)] hover:border-[#d6dae0] hover:shadow-[0_4px_12px_rgba(16,24,40,.055)]',
+        'group relative h-full min-h-0 overflow-visible',
+        !preview && selected ? 'dashboard-widget--selected' : '',
       ].join(' ')}
     >
-      <div className="dashboard-widget__drag-handle flex h-10 shrink-0 cursor-move items-center px-3.5">
-        {!preview ? (
-          <GripVertical
-            size={13}
-            className={[
-              'mr-1.5 text-[#a8adb5] transition-opacity duration-150',
-              selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-            ].join(' ')}
-          />
-        ) : null}
-        <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-[#344054]">
-          {title}
-        </span>
+      <div
+        onMouseDown={onSelect}
+        className={[
+          'relative flex h-full min-h-0 flex-col overflow-hidden rounded-[9px] bg-white transition-[border-color,box-shadow] duration-150',
+          preview
+            ? activeSelection
+              ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
+              : 'border border-[#e7e9ed] shadow-[0_1px_2px_rgba(16,24,40,.03)]'
+            : selected
+              ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
+              : 'border border-[#e4e7ec] shadow-[0_1px_2px_rgba(16,24,40,.025)] hover:border-[#d6dae0] hover:shadow-[0_4px_12px_rgba(16,24,40,.055)]',
+        ].join(' ')}
+      >
+        <div className="dashboard-widget__drag-handle flex h-10 shrink-0 cursor-move items-center px-3.5">
+          {!preview ? (
+            <GripVertical
+              size={13}
+              className={[
+                'mr-1.5 text-[#a8adb5] transition-opacity duration-150',
+                selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+              ].join(' ')}
+            />
+          ) : null}
+          <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-[#344054]">
+            {title}
+          </span>
 
-        {preview && activeSelection ? (
-          <button
-            type="button"
-            title={activeSelection.label}
-            className="ml-2 flex max-w-[190px] shrink-0 items-center gap-1 rounded-[5px] border border-[var(--yak-brand-color-border)] bg-[var(--yak-brand-color-soft)] px-1.5 py-1 text-[9px] text-[#475467]"
-            onMouseDown={(event) => event.stopPropagation()}
-            onClick={(event) => {
-              event.stopPropagation();
-              onClearSelection();
-            }}
-          >
-            <span className="truncate">已选 · {String(activeSelection.value)}</span>
-            <X size={9} className="shrink-0 text-[#7a818c]" />
-          </button>
-        ) : null}
-
-        {!preview ? (
-          <div
-            className={[
-              'flex items-center gap-1 transition-opacity duration-150',
-              selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-            ].join(' ')}
-          >
-            {selected ? (
-              <Tooltip title="编辑图表">
-                <button
-                  type="button"
-                  aria-label="编辑图表"
-                  onMouseDown={(event) => event.stopPropagation()}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onEdit();
-                  }}
-                  className="flex h-7 items-center gap-1 rounded-[6px] border border-[var(--yak-brand-color-border)] bg-[var(--yak-brand-color-soft)] px-2 text-[10px] font-medium text-[var(--yak-brand-color)] transition-colors hover:bg-[rgba(254,44,85,.1)]"
-                >
-                  <Pencil size={11} />
-                  编辑
-                </button>
-              </Tooltip>
-            ) : null}
-
-            <Dropdown
-              trigger={['click']}
-              placement="bottomRight"
-              menu={{
-                items: [
-                  {
-                    key: 'duplicate',
-                    label: '复制组件',
-                    icon: <Copy size={13} />,
-                  },
-                  { type: 'divider' },
-                  {
-                    key: 'delete',
-                    label: '删除组件',
-                    icon: <Trash2 size={13} />,
-                    danger: true,
-                  },
-                ],
-                onClick: ({ key, domEvent }) => {
-                  domEvent.stopPropagation();
-                  if (key === 'duplicate') onDuplicate();
-                  if (key === 'delete') onDelete();
-                },
+          {preview && activeSelection ? (
+            <button
+              type="button"
+              title={activeSelection.label}
+              className="ml-2 flex max-w-[190px] shrink-0 items-center gap-1 rounded-[5px] border border-[var(--yak-brand-color-border)] bg-[var(--yak-brand-color-soft)] px-1.5 py-1 text-[9px] text-[#475467]"
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onClearSelection();
               }}
             >
-              <Tooltip title="更多操作">
+              <span className="truncate">已选 · {String(activeSelection.value)}</span>
+              <X size={9} className="shrink-0 text-[#7a818c]" />
+            </button>
+          ) : null}
+        </div>
+
+        {drillPath.length ? (
+          <div
+            className="mx-3 flex h-7 shrink-0 items-center gap-0.5 rounded-[6px] bg-[#f7f8fa] px-2 text-[9px] text-[#667085]"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="flex h-5 items-center gap-1 rounded-[4px] border-0 bg-transparent px-1 text-[#667085] hover:bg-[#eceef1] hover:text-[#344054]"
+              onClick={(event) => {
+                event.stopPropagation();
+                onDrillBack(0);
+              }}
+            >
+              <RotateCcw size={9} />
+              全部
+            </button>
+            {drillPath.map((step, index) => (
+              <span key={`${step.field}-${index}`} className="flex min-w-0 items-center gap-0.5">
+                <ChevronRight size={9} className="shrink-0 text-[#b1b6bf]" />
                 <button
                   type="button"
-                  aria-label="组件操作"
-                  onMouseDown={(event) => event.stopPropagation()}
-                  onClick={(event) => event.stopPropagation()}
-                  className="flex h-7 w-7 items-center justify-center rounded-[6px] border-0 bg-transparent text-[#7a818c] transition-colors hover:bg-[#f5f6f7] hover:text-[#344054]"
+                  className="max-w-[120px] truncate rounded-[4px] border-0 bg-transparent px-1 py-0.5 text-[#475467] hover:bg-[#eceef1]"
+                  title={step.label}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDrillBack(index + 1);
+                  }}
                 >
-                  <MoreHorizontal size={14} />
+                  {step.label}
                 </button>
-              </Tooltip>
-            </Dropdown>
+              </span>
+            ))}
           </div>
         ) : null}
+
+        <div className="min-h-0 flex-1 overflow-hidden px-1 pb-1">
+          {spec ? (
+            <AnalysisPreview
+              spec={spec}
+              dataset={dataset}
+              runtimeFilters={runtimeFilters}
+              onSelect={onDataSelect}
+            />
+          ) : (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="图表数据来源已失效"
+              className="mt-8"
+            />
+          )}
+        </div>
       </div>
 
-      {drillPath.length ? (
+      {!preview && selected ? (
         <div
-          className="mx-3 flex h-7 shrink-0 items-center gap-0.5 rounded-[6px] bg-[#f7f8fa] px-2 text-[9px] text-[#667085]"
+          className="absolute left-full top-0 z-30 ml-1.5 flex w-8 flex-col overflow-hidden rounded-[7px] border border-[#e4e7ec] bg-white shadow-[0_6px_18px_rgba(16,24,40,.12)]"
           onMouseDown={(event) => event.stopPropagation()}
         >
-          <button
-            type="button"
-            className="flex h-5 items-center gap-1 rounded-[4px] border-0 bg-transparent px-1 text-[#667085] hover:bg-[#eceef1] hover:text-[#344054]"
-            onClick={(event) => {
-              event.stopPropagation();
-              onDrillBack(0);
-            }}
-          >
-            <RotateCcw size={9} />
-            全部
-          </button>
-          {drillPath.map((step, index) => (
-            <span key={`${step.field}-${index}`} className="flex min-w-0 items-center gap-0.5">
-              <ChevronRight size={9} className="shrink-0 text-[#b1b6bf]" />
-              <button
-                type="button"
-                className="max-w-[120px] truncate rounded-[4px] border-0 bg-transparent px-1 py-0.5 text-[#475467] hover:bg-[#eceef1]"
-                title={step.label}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onDrillBack(index + 1);
-                }}
-              >
-                {step.label}
-              </button>
-            </span>
-          ))}
+          <Tooltip title="编辑图表" placement="right">
+            <button
+              type="button"
+              aria-label="编辑图表"
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onEdit();
+              }}
+              className="flex h-8 w-8 items-center justify-center border-0 bg-transparent text-[#667085] transition-colors hover:bg-[var(--yak-brand-color-soft)] hover:text-[var(--yak-brand-color)]"
+            >
+              <Pencil size={14} />
+            </button>
+          </Tooltip>
+
+          <div className="h-px bg-[#eef0f3]" />
+
+          <Tooltip title="复制组件" placement="right">
+            <button
+              type="button"
+              aria-label="复制组件"
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onDuplicate();
+              }}
+              className="flex h-8 w-8 items-center justify-center border-0 bg-transparent text-[#667085] transition-colors hover:bg-[#f5f6f7] hover:text-[#344054]"
+            >
+              <Copy size={14} />
+            </button>
+          </Tooltip>
+
+          <div className="h-px bg-[#eef0f3]" />
+
+          <Tooltip title="删除组件" placement="right">
+            <button
+              type="button"
+              aria-label="删除组件"
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete();
+              }}
+              className="flex h-8 w-8 items-center justify-center border-0 bg-transparent text-[#98a2b3] transition-colors hover:bg-[rgba(254,44,85,.06)] hover:text-[var(--yak-brand-color)]"
+            >
+              <Trash2 size={14} />
+            </button>
+          </Tooltip>
         </div>
       ) : null}
 
-      <div className="min-h-0 flex-1 overflow-hidden px-1 pb-1">
-        {spec ? (
-          <AnalysisPreview
-            spec={spec}
-            dataset={dataset}
-            runtimeFilters={runtimeFilters}
-            onSelect={onDataSelect}
-          />
-        ) : (
-          <Empty
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description="图表数据来源已失效"
-            className="mt-8"
-          />
-        )}
-      </div>
+      <style>{`
+        .react-grid-item:has(> .dashboard-widget--selected) {
+          z-index: 20;
+        }
+      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Overview

参考 FineBI 的画布组件交互，将 Dashboard 选中图表后的操作区从图表标题栏移到组件右侧外边缘，减少图表内部干扰，让选中态更接近真正的可视化布局编辑器。

## What changed

- 选中图表后，右侧外边缘显示竖向悬浮工具条
- 当前只保留现有 3 个动作：
  - 编辑图表
  - 复制组件
  - 删除组件
- 移除标题栏里的「编辑」按钮和 `...` 下拉菜单
- 图表标题栏恢复为标题 + 拖拽把手，减少视觉干扰
- 工具条只在选中状态显示，预览模式不显示
- 工具条点击会阻止 mousedown 冒泡，不会触发 react-grid-layout 拖拽
- 选中组件会提升层级，避免右侧工具条被相邻图表覆盖
- 保留 #498 的交互边界：单击只选中，点击编辑才进入图表 Sheet

## Visual behavior

```text
┌────────────────────────────┐  ┌──┐
│                            │  │✎ │ 编辑
│        图表内容             │  ├──┤
│                            │  │⧉ │ 复制
│                            │  ├──┤
│                            │  │🗑│ 删除
└────────────────────────────┘  └──┘
```

## Scope

本 PR 只调整 Dashboard Widget 的选中操作条，不修改：

- Sheet Bar
- 图表编辑器
- Dataset / Query
- Dashboard 数据模型
- 数字化大屏

## Diff

仅修改：

- `yak-ops-ui/src/pages/dashboard/widget.tsx`

分支重新基于最新 `main` 创建，当前 ahead 1 / behind 0。

## Regression checklist

1. 单击图表只选中，不进入图表编辑
2. 选中后右侧显示编辑 / 复制 / 删除工具条
3. 标题栏不再显示编辑和更多菜单
4. 标题栏仍可正常拖拽组件
5. resize 仍然正常
6. 点击编辑进入对应图表 Sheet
7. 复制 / 删除操作正常
8. 相邻图表不会遮住选中组件的侧边工具条
9. 预览模式不显示编辑工具条

当前 connector-only 环境无法执行完整本地 `npm run tsc` / `npm run build`，建议以 PR CI 或本地工程回归作为最终验证。