### PR TITLE
refactor: simplify dashboard chart data binding workflow

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
@@ -27,7 +27,7 @@ export function ChartDataColumn({
           size="small"
           variant="filled"
           value={dataset?.id}
-          disabled={!editable || !dataset}
+          disabled={!editable}
           optionFilterProp="label"
           className="w-full"
           placeholder="选择数据集"
@@ -39,7 +39,7 @@ export function ChartDataColumn({
           onChange={onDatasetChange}
         />
         <div className="mt-1.5 truncate px-0.5 text-[9px] text-[#98a2b3]">
-          {dataset ? `数据目录 · ${dataset.name}` : '当前数据来源不可用'}
+          {dataset ? `数据目录 · ${dataset.name}` : '当前数据来源不可用，可重新选择'}
         </div>
       </div>
 
@@ -47,7 +47,7 @@ export function ChartDataColumn({
         <ChartFieldPanel
           dataset={dataset}
           spec={spec}
-          editable={editable}
+          editable={editable && Boolean(dataset)}
           onSpecPatch={onSpecPatch}
         />
       </div>

--- a/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
@@ -1,0 +1,66 @@
+import type { AnalysisSpec } from '@/components/analysis/model';
+import { Select } from 'antd';
+import { Database } from 'lucide-react';
+import { ChartFieldPanel } from './chart-field-panel';
+import type { PublishedDataset } from './model';
+
+export function ChartDataColumn({
+  dataset,
+  datasets,
+  spec,
+  editable,
+  onDatasetChange,
+  onSpecPatch,
+}: {
+  dataset?: PublishedDataset;
+  datasets: PublishedDataset[];
+  spec?: AnalysisSpec;
+  editable: boolean;
+  onDatasetChange?: (datasetId: string) => void;
+  onSpecPatch?: (patch: Partial<AnalysisSpec>) => void;
+}) {
+  return (
+    <section className="chart-data-column flex w-[244px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
+      <div className="shrink-0 border-b border-[#eceef1] px-3 py-3">
+        <Select
+          showSearch
+          size="small"
+          variant="filled"
+          value={dataset?.id}
+          disabled={!editable || !dataset}
+          optionFilterProp="label"
+          className="w-full"
+          placeholder="选择数据集"
+          suffixIcon={<Database size={12} className="text-[#8e95a0]" />}
+          options={datasets.map((item) => ({
+            label: item.name,
+            value: item.id,
+          }))}
+          onChange={onDatasetChange}
+        />
+        <div className="mt-1.5 truncate px-0.5 text-[9px] text-[#98a2b3]">
+          {dataset ? `数据目录 · ${dataset.name}` : '当前数据来源不可用'}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ChartFieldPanel
+          dataset={dataset}
+          spec={spec}
+          editable={editable}
+          onSpecPatch={onSpecPatch}
+        />
+      </div>
+
+      <style>{`
+        .chart-data-column > .min-h-0 > section {
+          height: 100%;
+          border-right: 0 !important;
+        }
+        .chart-data-column > .min-h-0 > section > div:first-child {
+          display: none;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/chart-encoding-shelf.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-encoding-shelf.tsx
@@ -1,0 +1,330 @@
+import {
+  calculatedFieldKey,
+  isCalculatedFieldKey,
+} from '@/components/analysis/calculated-field';
+import {
+  ANALYSIS_ENCODING_RULES,
+  applyAnalysisEncoding,
+  resolveAnalysisEncoding,
+  updateEncodingMetricAggregation,
+} from '@/components/analysis/encoding';
+import type {
+  AnalysisEncoding,
+  AnalysisEncodingBinding,
+  AnalysisSpec,
+  DatasetFieldRole,
+} from '@/components/analysis/model';
+import { Dropdown, Select } from 'antd';
+import { Plus, X } from 'lucide-react';
+import { useState, type DragEvent } from 'react';
+import { readChartFieldDragPayload } from './chart-field-drag';
+import { AGGREGATION_OPTIONS, FIELD_DRAG_MIME } from './helpers';
+import type { Aggregation, PublishedDataset } from './model';
+
+interface FieldOption {
+  label: string;
+  value: string;
+  role: DatasetFieldRole;
+  calculated?: boolean;
+}
+
+const AXIS_TYPES = new Set(['bar', 'stackedBar', 'line', 'area', 'scatter']);
+
+const shelfLabel = (spec: AnalysisSpec, channel: string, fallback: string) => {
+  if (channel === 'category') return AXIS_TYPES.has(spec.type) ? '横轴' : '维度';
+  if (channel === 'value') return AXIS_TYPES.has(spec.type) ? '纵轴' : '指标';
+  return fallback;
+};
+
+export function ChartEncodingShelf({
+  spec,
+  dataset,
+  editable,
+  onSpecPatch,
+}: {
+  spec?: AnalysisSpec;
+  dataset?: PublishedDataset;
+  editable: boolean;
+  onSpecPatch?: (patch: Partial<AnalysisSpec>) => void;
+}) {
+  if (!spec || !dataset) {
+    return (
+      <div className="shrink-0 border-b border-[#e4e7ec] bg-white px-4 py-2 text-[10px] text-[#98a2b3]">
+        选择可用数据集后配置图表字段
+      </div>
+    );
+  }
+
+  const calculatedFields = spec.analysis?.calculatedFields ?? [];
+  const fieldOptions: FieldOption[] = [
+    ...dataset.fields.map((field) => ({
+      label: field.label,
+      value: field.key,
+      role: field.role,
+    })),
+    ...calculatedFields.map((field) => ({
+      label: field.name,
+      value: calculatedFieldKey(field),
+      role: 'metric' as const,
+      calculated: true,
+    })),
+  ];
+  const fieldLabel = new Map(fieldOptions.map((option) => [option.value, option.label]));
+  const calculated = new Set(fieldOptions.filter((option) => option.calculated).map((option) => option.value));
+  const aggregationLabel = new Map(AGGREGATION_OPTIONS.map((option) => [option.value, option.label]));
+  const encoding = resolveAnalysisEncoding(spec);
+  const primaryRules = ANALYSIS_ENCODING_RULES[spec.type]
+    .filter((rule) => rule.channel === 'category' || rule.channel === 'value');
+
+  const changeEncoding = (nextEncoding: AnalysisEncoding) => {
+    if (!onSpecPatch) return;
+    const next = applyAnalysisEncoding(spec, nextEncoding);
+    const nextSort = spec.sort
+      && !next.dimensions.includes(spec.sort.field)
+      && !next.metrics.some((metric) => metric.field === spec.sort?.field)
+      ? undefined
+      : spec.sort;
+    const currentTopN = spec.analysis?.topN;
+    const topNMetricStillActive = currentTopN
+      ? next.metrics.some((metric) => metric.field === currentTopN.metricField)
+      : true;
+    const topNFallback = next.metrics.find((metric) => !isCalculatedFieldKey(next, metric.field));
+    const nextAnalysis = currentTopN && !topNMetricStillActive
+      ? {
+        ...spec.analysis,
+        version: 1 as const,
+        topN: topNFallback
+          ? { ...currentTopN, metricField: topNFallback.field }
+          : { ...currentTopN, enabled: false },
+      }
+      : spec.analysis;
+    const hadColor = Boolean(spec.encoding?.color?.length);
+    const hasColor = Boolean(next.encoding.color.length);
+    const shouldRevealLegend = !hadColor
+      && hasColor
+      && ['bar', 'stackedBar', 'line', 'area', 'scatter'].includes(spec.type);
+
+    onSpecPatch({
+      encoding: next.encoding,
+      dimensions: next.dimensions,
+      metrics: next.metrics,
+      sort: nextSort,
+      analysis: nextAnalysis,
+      ...(shouldRevealLegend
+        ? { style: { ...spec.style, showLegend: true, version: 1 as const } }
+        : {}),
+    });
+  };
+
+  const changeAggregation = (field: string, aggregation: Aggregation) => {
+    if (!onSpecPatch) return;
+    const next = updateEncodingMetricAggregation(spec, field, aggregation);
+    onSpecPatch({ encoding: next.encoding, metrics: next.metrics });
+  };
+
+  return (
+    <div className="shrink-0 border-b border-[#e3e6ea] bg-white">
+      {primaryRules.map((rule) => {
+        const bindings = encoding[rule.channel]
+          .filter((binding) => rule.roles.includes(binding.role))
+          .slice(0, rule.max);
+        const options = fieldOptions.filter((option) => rule.roles.includes(option.role));
+        return (
+          <ShelfRow
+            key={rule.channel}
+            label={shelfLabel(spec, rule.channel, rule.label)}
+            bindings={bindings}
+            allBindings={encoding[rule.channel]}
+            max={rule.max}
+            options={options}
+            editable={editable}
+            fieldLabel={fieldLabel}
+            calculated={calculated}
+            aggregationLabel={aggregationLabel}
+            onAdd={(field, role) => {
+              const nextBinding: AnalysisEncodingBinding = {
+                field,
+                role,
+                aggregation: role === 'metric' ? 'SUM' : undefined,
+              };
+              const current = encoding[rule.channel];
+              const existingIndex = current.findIndex((binding) => binding.field === field);
+              const existing = existingIndex >= 0 ? current[existingIndex] : undefined;
+              let nextChannel: AnalysisEncodingBinding[];
+
+              if (rule.max === 1) {
+                nextChannel = [
+                  existing ?? nextBinding,
+                  ...current.filter((_, index) => index !== existingIndex),
+                ];
+              } else if (existing) {
+                nextChannel = [
+                  existing,
+                  ...current.filter((_, index) => index !== existingIndex),
+                ];
+              } else {
+                const activeCount = current.filter((binding) => rule.roles.includes(binding.role)).length;
+                if (activeCount >= rule.max) return;
+                nextChannel = [...current, nextBinding];
+              }
+
+              changeEncoding({ ...encoding, [rule.channel]: nextChannel });
+            }}
+            onRemove={(field) => changeEncoding({
+              ...encoding,
+              [rule.channel]: encoding[rule.channel].filter((binding) => binding.field !== field),
+            })}
+            onAggregationChange={changeAggregation}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ShelfRow({
+  label,
+  bindings,
+  allBindings,
+  max,
+  options,
+  editable,
+  fieldLabel,
+  calculated,
+  aggregationLabel,
+  onAdd,
+  onRemove,
+  onAggregationChange,
+}: {
+  label: string;
+  bindings: AnalysisEncodingBinding[];
+  allBindings: AnalysisEncodingBinding[];
+  max: number;
+  options: FieldOption[];
+  editable: boolean;
+  fieldLabel: Map<string, string>;
+  calculated: Set<string>;
+  aggregationLabel: Map<string, string>;
+  onAdd: (field: string, role: DatasetFieldRole) => void;
+  onRemove: (field: string) => void;
+  onAggregationChange: (field: string, aggregation: Aggregation) => void;
+}) {
+  const [dragOver, setDragOver] = useState(false);
+  const visible = new Set(bindings.map((binding) => binding.field));
+  const allBound = new Set(allBindings.map((binding) => binding.field));
+  const available = options.filter((option) => (
+    max === 1 ? !visible.has(option.value) : !allBound.has(option.value)
+  ));
+  const full = bindings.length >= max;
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!editable) return;
+    if (
+      !event.dataTransfer.types.includes(FIELD_DRAG_MIME)
+      && !event.dataTransfer.types.includes('text/plain')
+    ) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDragOver(true);
+  };
+
+  return (
+    <div
+      className={[
+        'flex min-h-10 items-center gap-2 border-b border-[#f0f1f3] px-3 last:border-b-0 transition-colors',
+        dragOver ? 'bg-[var(--yak-brand-color-soft)]' : 'bg-white',
+      ].join(' ')}
+      onDragEnter={handleDragOver}
+      onDragOver={handleDragOver}
+      onDragLeave={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setDragOver(false);
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        setDragOver(false);
+        if (!editable) return;
+        const payload = readChartFieldDragPayload(event);
+        if (!payload || !options.some((option) => option.value === payload.field && option.role === payload.role)) return;
+        onAdd(payload.field, payload.role);
+      }}
+    >
+      <div className="w-12 shrink-0 text-[10px] font-medium text-[#667085]">{label}</div>
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 py-1">
+        {bindings.map((binding) => {
+          const metric = binding.role === 'metric';
+          const isCalculated = calculated.has(binding.field);
+          return (
+            <div
+              key={binding.field}
+              className={[
+                'flex h-7 max-w-[220px] items-center gap-1 rounded-[5px] px-2 text-[10px]',
+                metric
+                  ? 'bg-[#e4f5f0] text-[#2f7568]'
+                  : 'bg-[#e8f0fd] text-[#486b9d]',
+              ].join(' ')}
+            >
+              <span className="min-w-0 truncate font-medium">
+                {fieldLabel.get(binding.field) ?? binding.field}
+              </span>
+              {metric ? (
+                isCalculated ? (
+                  <span className="shrink-0 text-[8px] opacity-65">计算</span>
+                ) : (
+                  <Dropdown
+                    trigger={['click']}
+                    menu={{
+                      items: AGGREGATION_OPTIONS.map((option) => ({
+                        key: option.value,
+                        label: option.label,
+                      })),
+                      onClick: ({ key, domEvent }) => {
+                        domEvent.stopPropagation();
+                        onAggregationChange(binding.field, key as Aggregation);
+                      },
+                    }}
+                  >
+                    <button
+                      type="button"
+                      disabled={!editable}
+                      className="shrink-0 border-0 bg-transparent p-0 text-[8px] text-current opacity-65 hover:opacity-100 disabled:cursor-default"
+                    >
+                      {aggregationLabel.get(binding.aggregation ?? 'SUM') ?? '求和'}
+                    </button>
+                  </Dropdown>
+                )
+              ) : null}
+              {editable ? (
+                <button
+                  type="button"
+                  aria-label={`移除${fieldLabel.get(binding.field) ?? binding.field}`}
+                  className="flex h-4 w-4 shrink-0 items-center justify-center rounded-[3px] text-current opacity-45 hover:bg-white/60 hover:opacity-90"
+                  onClick={() => onRemove(binding.field)}
+                >
+                  <X size={9} />
+                </button>
+              ) : null}
+            </div>
+          );
+        })}
+
+        {editable && (max === 1 || !full) ? (
+          <Select
+            showSearch
+            size="small"
+            variant="borderless"
+            value={undefined}
+            className="min-w-[138px] max-w-[220px]"
+            optionFilterProp="label"
+            placeholder={bindings.length ? '+ 添加字段' : '拖入或选择字段'}
+            options={available.map((option) => ({ label: option.label, value: option.value }))}
+            suffixIcon={<Plus size={10} className="text-[#9aa1ab]" />}
+            onChange={(field) => {
+              const option = available.find((item) => item.value === field);
+              if (option) onAdd(option.value, option.role);
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -25,7 +25,6 @@ export function DashboardChartSheetWorkspace({
   globalFilters,
   interactions,
   runtimeFilters,
-  updateWidget,
   updateInlineAnalysis,
   updateInteractions,
   changeDataset,
@@ -58,7 +57,7 @@ export function DashboardChartSheetWorkspace({
     ? analysis?.name ?? '历史图表'
     : widget.title?.trim() || '未命名图表';
   const chartTypeLabel = spec ? CHART_META[spec.type]?.label : undefined;
-  const editable = !widget.analysisId && Boolean(widget.inlineAnalysis && dataset);
+  const editable = !widget.analysisId && Boolean(widget.inlineAnalysis);
 
   return (
     <div className="chart-sheet-workspace flex min-h-0 flex-1 overflow-hidden bg-[#f3f4f6]">
@@ -84,7 +83,7 @@ export function DashboardChartSheetWorkspace({
         <ChartEncodingShelf
           spec={spec}
           dataset={dataset}
-          editable={editable}
+          editable={editable && Boolean(dataset)}
           onSpecPatch={!widget.analysisId ? updateInlineAnalysis : undefined}
         />
 

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -1,11 +1,10 @@
 import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
 import { Empty } from 'antd';
-import { BarChart3, Database } from 'lucide-react';
-import {
-  ChartAppearanceConfigPanel,
-  ChartBuildConfigPanel,
-} from './chart-editor';
-import { ChartFieldPanel } from './chart-field-panel';
+import { BarChart3 } from 'lucide-react';
+import { ChartAppearanceConfigPanel } from './chart-editor';
+import { ChartDataColumn } from './chart-data-column';
+import { ChartEncodingShelf } from './chart-encoding-shelf';
+import { FineBiChartBuilderPanel } from './finebi-chart-builder';
 import { CHART_META } from './helpers';
 import type {
   AnalysisAsset,
@@ -59,67 +58,68 @@ export function DashboardChartSheetWorkspace({
     ? analysis?.name ?? '历史图表'
     : widget.title?.trim() || '未命名图表';
   const chartTypeLabel = spec ? CHART_META[spec.type]?.label : undefined;
+  const editable = !widget.analysisId && Boolean(widget.inlineAnalysis && dataset);
 
   return (
     <div className="chart-sheet-workspace flex min-h-0 flex-1 overflow-hidden bg-[#f3f4f6]">
       <div className="flex min-h-0 shrink-0 bg-white shadow-[1px_0_0_#e3e6ea]">
-        <ChartFieldPanel
+        <ChartDataColumn
           dataset={dataset}
+          datasets={datasets}
           spec={spec}
-          editable={!widget.analysisId && Boolean(widget.inlineAnalysis && dataset)}
+          editable={editable}
+          onDatasetChange={!widget.analysisId ? changeDataset : undefined}
           onSpecPatch={!widget.analysisId ? updateInlineAnalysis : undefined}
         />
-        <ChartBuildConfigPanel
+        <FineBiChartBuilderPanel
           widget={widget}
           datasets={datasets}
           analyses={analyses}
-          updateWidget={updateWidget}
           updateInlineAnalysis={updateInlineAnalysis}
-          changeDataset={changeDataset}
           detachAnalysis={detachAnalysis}
-          onDone={onDone}
         />
       </div>
 
-      <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">
-        <div className="flex min-h-full p-4 2xl:p-5">
-          <div className="mx-auto flex min-h-[560px] w-full max-w-[1320px] flex-1 flex-col">
-            <div className="flex h-10 shrink-0 items-center justify-between gap-4 px-1">
-              <div className="flex min-w-0 items-center gap-2">
-                <BarChart3 size={14} className="shrink-0 text-[#667085]" />
-                <span className="truncate text-[13px] font-semibold text-[#344054]">
+      <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-[#f3f4f6]">
+        <ChartEncodingShelf
+          spec={spec}
+          dataset={dataset}
+          editable={editable}
+          onSpecPatch={!widget.analysisId ? updateInlineAnalysis : undefined}
+        />
+
+        <div className="min-h-0 flex-1 overflow-auto">
+          <div className="flex min-h-full p-4 2xl:p-5">
+            <div className="mx-auto flex min-h-[560px] w-full max-w-[1320px] flex-1 flex-col">
+              <div className="flex h-9 shrink-0 items-center gap-2 px-1">
+                <BarChart3 size={13} className="shrink-0 text-[#667085]" />
+                <span className="truncate text-[12px] font-semibold text-[#344054]">
                   {title}
                 </span>
                 {chartTypeLabel ? (
-                  <span className="shrink-0 rounded-[5px] border border-[#e1e4e8] bg-[#f8f9fa] px-1.5 py-0.5 text-[9px] text-[#7a818c]">
+                  <span className="shrink-0 rounded-[5px] border border-[#e1e4e8] bg-[#f8f9fa] px-1.5 py-0.5 text-[8px] text-[#7a818c]">
                     {chartTypeLabel}
                   </span>
                 ) : null}
               </div>
-              <div className="flex shrink-0 items-center gap-1.5 text-[10px] text-[#98a2b3]">
-                <Database size={11} />
-                <span className="max-w-[220px] truncate">
-                  {dataset?.name ?? '数据来源不可用'}
-                </span>
-              </div>
-            </div>
 
-            <div className="mt-2 min-h-0 flex-1 overflow-hidden rounded-[10px] border border-[#e1e4e8] bg-white">
-              {spec && dataset ? (
-                <AnalysisPreview
-                  spec={spec}
-                  dataset={dataset}
-                  runtimeFilters={runtimeFilters}
-                  className="h-full min-h-[500px] p-4"
-                />
-              ) : (
-                <div className="flex min-h-[500px] items-center justify-center">
-                  <Empty
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    description={spec ? '图表数据来源已失效' : '图表配置不可用'}
+              <div className="mt-1 min-h-0 flex-1 overflow-hidden rounded-[8px] border border-[#e1e4e8] bg-white">
+                {spec && dataset ? (
+                  <AnalysisPreview
+                    spec={spec}
+                    dataset={dataset}
+                    runtimeFilters={runtimeFilters}
+                    className="h-full min-h-[500px] p-4"
                   />
-                </div>
-              )}
+                ) : (
+                  <div className="flex min-h-[500px] items-center justify-center">
+                    <Empty
+                      image={Empty.PRESENTED_IMAGE_SIMPLE}
+                      description={spec ? '图表数据来源已失效' : '图表配置不可用'}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/yak-ops-ui/src/pages/dashboard/finebi-chart-builder.tsx
+++ b/yak-ops-ui/src/pages/dashboard/finebi-chart-builder.tsx
@@ -1,0 +1,398 @@
+import {
+  calculatedFieldKey,
+  isCalculatedFieldKey,
+} from '@/components/analysis/calculated-field';
+import {
+  ANALYSIS_ENCODING_RULES,
+  applyAnalysisEncoding,
+  changeAnalysisEncodingType,
+  rebindAnalysisEncoding,
+  resolveAnalysisEncoding,
+} from '@/components/analysis/encoding';
+import type {
+  AnalysisEncoding,
+  AnalysisEncodingBinding,
+  DatasetFieldRole,
+} from '@/components/analysis/model';
+import { Button, Collapse, Select } from 'antd';
+import {
+  Calculator,
+  ChevronDown,
+  SlidersHorizontal,
+  X,
+} from 'lucide-react';
+import { useState, type DragEvent } from 'react';
+import { ChartAnalysisConfig } from './config-analysis';
+import { QueryControls } from './config-query';
+import { readChartFieldDragPayload } from './chart-field-drag';
+import { CHART_META, FIELD_DRAG_MIME, findDataset } from './helpers';
+import type {
+  AnalysisAsset,
+  ChartType,
+  DashboardInlineAnalysisSpec,
+  DashboardWidget,
+  PublishedDataset,
+  SortDirection,
+} from './model';
+
+interface FieldOption {
+  label: string;
+  value: string;
+  role: DatasetFieldRole;
+}
+
+export function FineBiChartBuilderPanel({
+  widget,
+  datasets,
+  analyses,
+  updateInlineAnalysis,
+  detachAnalysis,
+}: {
+  widget: DashboardWidget;
+  datasets: PublishedDataset[];
+  analyses: AnalysisAsset[];
+  updateInlineAnalysis: (patch: Partial<DashboardInlineAnalysisSpec>) => void;
+  detachAnalysis: () => void;
+}) {
+  if (widget.analysisId) {
+    const analysis = analyses.find((item) => item.id === widget.analysisId);
+    const dataset = analysis
+      ? datasets.find((item) => item.id === analysis.datasetId)
+      : undefined;
+
+    return (
+      <section className="flex w-[272px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white 2xl:w-[288px]">
+        <div className="p-3.5">
+          <div className="rounded-[7px] bg-[#f6f7f8] p-3">
+            <div className="truncate text-[11px] font-semibold text-[#344054]">
+              {analysis?.name ?? '历史图表'}
+            </div>
+            <div className="mt-1 truncate text-[9px] text-[#98a2b3]">
+              {dataset?.name ?? '数据来源不可用'}
+            </div>
+          </div>
+          <div className="mt-3 text-[10px] leading-5 text-[#667085]">
+            共享图表为只读状态。复制为当前仪表盘图表后，可继续调整字段与图表类型。
+          </div>
+          <Button
+            block
+            size="small"
+            className="mt-4 !h-8 !rounded-[7px]"
+            disabled={!analysis}
+            onClick={detachAnalysis}
+          >
+            复制为可编辑图表
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  const spec = widget.inlineAnalysis;
+  if (!spec) return null;
+  const dataset = findDataset(datasets, spec.datasetId);
+  if (!dataset) return null;
+
+  const calculatedFields = spec.analysis?.calculatedFields ?? [];
+  const fieldOptions: FieldOption[] = [
+    ...dataset.fields.map((field) => ({
+      label: field.label,
+      value: field.key,
+      role: field.role,
+    })),
+    ...calculatedFields.map((field) => ({
+      label: field.name,
+      value: calculatedFieldKey(field),
+      role: 'metric' as const,
+    })),
+  ];
+  const filterOptions = dataset.fields.map((field) => ({ label: field.label, value: field.key }));
+  const selectedFields = new Set([
+    ...spec.dimensions,
+    ...spec.metrics.map((metric) => metric.field),
+  ]);
+  const sortOptions = dataset.fields
+    .filter((field) => selectedFields.has(field.key))
+    .map((field) => ({ label: field.label, value: field.key }));
+  const encoding = resolveAnalysisEncoding(spec);
+  const secondaryRules = ANALYSIS_ENCODING_RULES[spec.type]
+    .filter((rule) => rule.channel !== 'category' && rule.channel !== 'value');
+
+  const changeType = (type: ChartType) => {
+    const changed = changeAnalysisEncodingType(spec, type);
+    const next = rebindAnalysisEncoding(changed, dataset);
+    updateInlineAnalysis({
+      type,
+      encoding: next.encoding,
+      dimensions: next.dimensions,
+      metrics: next.metrics,
+      sort: undefined,
+      style: { ...spec.style, version: 1 },
+      analysis: spec.analysis,
+      limit: type === 'table' ? 200 : 500,
+    });
+  };
+
+  const changeEncoding = (nextEncoding: AnalysisEncoding) => {
+    const next = applyAnalysisEncoding(spec, nextEncoding);
+    const nextSort = spec.sort
+      && !next.dimensions.includes(spec.sort.field)
+      && !next.metrics.some((metric) => metric.field === spec.sort?.field)
+      ? undefined
+      : spec.sort;
+    const currentTopN = spec.analysis?.topN;
+    const topNMetricStillActive = currentTopN
+      ? next.metrics.some((metric) => metric.field === currentTopN.metricField)
+      : true;
+    const topNFallback = next.metrics.find((metric) => !isCalculatedFieldKey(next, metric.field));
+    const nextAnalysis = currentTopN && !topNMetricStillActive
+      ? {
+        ...spec.analysis,
+        version: 1 as const,
+        topN: topNFallback
+          ? { ...currentTopN, metricField: topNFallback.field }
+          : { ...currentTopN, enabled: false },
+      }
+      : spec.analysis;
+    const hadColor = Boolean(spec.encoding?.color?.length);
+    const hasColor = Boolean(next.encoding.color.length);
+    const shouldRevealLegend = !hadColor
+      && hasColor
+      && ['bar', 'stackedBar', 'line', 'area', 'scatter'].includes(spec.type);
+
+    updateInlineAnalysis({
+      encoding: next.encoding,
+      dimensions: next.dimensions,
+      metrics: next.metrics,
+      sort: nextSort,
+      analysis: nextAnalysis,
+      ...(shouldRevealLegend
+        ? { style: { ...spec.style, showLegend: true, version: 1 as const } }
+        : {}),
+    });
+  };
+
+  return (
+    <section className="flex w-[272px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white 2xl:w-[288px]">
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3.5">
+        <div className="text-[10px] font-semibold text-[#667085]">图表类型</div>
+        <div className="mt-2 grid grid-cols-5 gap-1">
+          {(Object.keys(CHART_META) as ChartType[]).map((type) => {
+            const active = spec.type === type;
+            return (
+              <button
+                key={type}
+                type="button"
+                title={`${CHART_META[type].label} · ${CHART_META[type].description}`}
+                onClick={() => changeType(type)}
+                className={[
+                  'flex min-w-0 flex-col items-center justify-center gap-1 rounded-[6px] border px-0.5 py-2 text-[8px] transition-colors',
+                  active
+                    ? 'border-[var(--yak-brand-color-border)] bg-[var(--yak-brand-color-soft)] font-medium text-[var(--yak-brand-color)]'
+                    : 'border-transparent bg-white text-[#7f8792] hover:bg-[#f6f7f8] hover:text-[#475467]',
+                ].join(' ')}
+              >
+                <span className="text-[13px]">{CHART_META[type].icon}</span>
+                <span className="w-full truncate text-center">{CHART_META[type].label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {secondaryRules.length ? (
+          <div className="mt-4 border-t border-[#eceef1] pt-3.5">
+            <div className="mb-2 text-[10px] font-semibold text-[#667085]">图形属性</div>
+            <div className="space-y-1.5">
+              {secondaryRules.map((rule) => (
+                <SecondaryEncodingSlot
+                  key={rule.channel}
+                  label={rule.label}
+                  max={rule.max}
+                  roles={rule.roles}
+                  bindings={encoding[rule.channel]}
+                  options={fieldOptions}
+                  onChange={(bindings) => changeEncoding({
+                    ...encoding,
+                    [rule.channel]: bindings,
+                  })}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <Collapse
+          ghost
+          className="chart-editor-more mt-4 border-t border-[#eceef1]"
+          expandIconPosition="end"
+          expandIcon={({ isActive }) => (
+            <ChevronDown
+              size={13}
+              className={isActive ? 'rotate-180 text-[#667085]' : 'text-[#a0a6af]'}
+            />
+          )}
+          items={[
+            {
+              key: 'analysis',
+              label: (
+                <span className="flex items-center gap-1.5 text-[10px] font-medium text-[#667085]">
+                  <Calculator size={11} />
+                  分析设置
+                </span>
+              ),
+              children: (
+                <ChartAnalysisConfig
+                  spec={spec}
+                  dataset={dataset}
+                  onChange={(analysis) => updateInlineAnalysis({ analysis })}
+                />
+              ),
+            },
+            {
+              key: 'query',
+              label: (
+                <span className="flex items-center gap-1.5 text-[10px] font-medium text-[#667085]">
+                  <SlidersHorizontal size={11} />
+                  排序与过滤
+                </span>
+              ),
+              children: (
+                <QueryControls
+                  sortOptions={sortOptions}
+                  filterOptions={filterOptions}
+                  sortField={spec.sort?.field}
+                  sortDirection={spec.sort?.direction ?? 'asc'}
+                  filters={spec.filters}
+                  onSortField={(field?: string) => updateInlineAnalysis({
+                    sort: field
+                      ? { field, direction: spec.sort?.direction ?? 'asc' }
+                      : undefined,
+                  })}
+                  onSortDirection={(direction: SortDirection) =>
+                    spec.sort && updateInlineAnalysis({ sort: { ...spec.sort, direction } })}
+                  onFiltersChange={(filters) => updateInlineAnalysis({ filters })}
+                />
+              ),
+            },
+          ]}
+        />
+      </div>
+    </section>
+  );
+}
+
+function SecondaryEncodingSlot({
+  label,
+  max,
+  roles,
+  bindings,
+  options,
+  onChange,
+}: {
+  label: string;
+  max: number;
+  roles: DatasetFieldRole[];
+  bindings: AnalysisEncodingBinding[];
+  options: FieldOption[];
+  onChange: (bindings: AnalysisEncodingBinding[]) => void;
+}) {
+  const [dragOver, setDragOver] = useState(false);
+  const activeBindings = bindings.filter((binding) => roles.includes(binding.role)).slice(0, max);
+  const fieldLabel = new Map(options.map((option) => [option.value, option.label]));
+  const active = new Set(activeBindings.map((binding) => binding.field));
+  const allBound = new Set(bindings.map((binding) => binding.field));
+  const available = options.filter((option) => roles.includes(option.role) && (
+    max === 1 ? !active.has(option.value) : !allBound.has(option.value)
+  ));
+  const full = activeBindings.length >= max;
+
+  const addField = (field: string, role: DatasetFieldRole) => {
+    const nextBinding: AnalysisEncodingBinding = {
+      field,
+      role,
+      aggregation: role === 'metric' ? 'SUM' : undefined,
+    };
+    const existingIndex = bindings.findIndex((binding) => binding.field === field);
+    const existing = existingIndex >= 0 ? bindings[existingIndex] : undefined;
+    if (max === 1) {
+      onChange([
+        existing ?? nextBinding,
+        ...bindings.filter((_, index) => index !== existingIndex),
+      ]);
+      return;
+    }
+    if (existing) {
+      onChange([existing, ...bindings.filter((_, index) => index !== existingIndex)]);
+      return;
+    }
+    if (activeBindings.length < max) onChange([...bindings, nextBinding]);
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (
+      !event.dataTransfer.types.includes(FIELD_DRAG_MIME)
+      && !event.dataTransfer.types.includes('text/plain')
+    ) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setDragOver(true);
+  };
+
+  return (
+    <div
+      className={[
+        'flex min-h-9 items-center gap-2 rounded-[6px] px-2 transition-colors',
+        dragOver ? 'bg-[var(--yak-brand-color-soft)]' : 'bg-[#f7f8fa]',
+      ].join(' ')}
+      onDragEnter={handleDragOver}
+      onDragOver={handleDragOver}
+      onDragLeave={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setDragOver(false);
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        setDragOver(false);
+        const payload = readChartFieldDragPayload(event);
+        if (!payload || !roles.includes(payload.role)) return;
+        if (!options.some((option) => option.value === payload.field && option.role === payload.role)) return;
+        addField(payload.field, payload.role);
+      }}
+    >
+      <span className="w-10 shrink-0 text-[9px] text-[#667085]">{label}</span>
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1 py-1">
+        {activeBindings.map((binding) => (
+          <span
+            key={binding.field}
+            className="flex h-6 max-w-[150px] items-center gap-1 rounded-[4px] bg-white px-1.5 text-[9px] text-[#475467]"
+          >
+            <span className="min-w-0 truncate">{fieldLabel.get(binding.field) ?? binding.field}</span>
+            <button
+              type="button"
+              className="flex h-4 w-4 shrink-0 items-center justify-center rounded-[3px] text-[#a0a6af] hover:bg-[#f0f1f3] hover:text-[#667085]"
+              onClick={() => onChange(bindings.filter((item) => item.field !== binding.field))}
+              aria-label={`移除${fieldLabel.get(binding.field) ?? binding.field}`}
+            >
+              <X size={8} />
+            </button>
+          </span>
+        ))}
+        {(max === 1 || !full) ? (
+          <Select
+            showSearch
+            size="small"
+            variant="borderless"
+            value={undefined}
+            className="min-w-[106px] flex-1"
+            optionFilterProp="label"
+            placeholder={activeBindings.length ? '+ 字段' : '拖入一个字段'}
+            options={available.map((option) => ({ label: option.label, value: option.value }))}
+            onChange={(field) => {
+              const option = available.find((item) => item.value === field);
+              if (option) addField(option.value, option.role);
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview

参考 FineBI 的图表编辑信息架构，简化 Yak Ops Dashboard 图表的数据绑定与字段配置流程。重点不是复制视觉样式，而是把 Dataset、字段、主轴/指标和次要图形属性重新放到更直觉的位置，减少用户理解 `Encoding`、`数据字段`、`图表构建` 等内部概念的成本。

## What changed

### 1. 左上角直接绑定 Dataset

- 删除原来的「数据字段」标题
- 删除「图表构建」中的「数据集」表单项
- 当前图表 Dataset 统一放到左上角
- 使用 Ant Design `Select variant="filled"`
- Dataset 与下面字段目录保持在同一栏，用户能直接理解“这些字段来自哪个数据集”
- 如果原 Dataset 已失效，Select 仍可重新选择可用 Dataset 进行恢复

### 2. 删除多余的构建层级

不再显示：

- 「数据字段」
- 「图表构建」
- 「图表标题」编辑表单
- 「数据集」编辑表单
- 「可视化编码 / Encoding v1」面向用户的内部术语

图表名称仍按现有 Widget / Sheet 模型保留，不修改数据结构。

### 3. 主字段绑定移动到画布顶部

参考 FineBI，将主要字段槽位放到图表画布上方：

- 柱状图 / 折线图 / 面积图：横轴、纵轴
- 指标卡：指标
- 饼图 / 漏斗图 / 矩形树图 / 表格等：维度、指标
- 支持从左侧字段列表拖入
- 也支持直接点击 Select 选择字段
- 维度与指标使用轻量语义色区分

### 4. 聚合方式直接跟随指标

指标绑定后直接显示：

- 求和
- 平均
- 计数
- 去重计数
- 最大值
- 最小值

点击聚合文字即可切换，不再单独展示一块“指标聚合”配置。

### 5. 中间构建栏进一步收窄

中间左侧只保留：

- 图表类型
- 图形属性（颜色 / 分组 / 明细等次要 Encoding）
- 分析设置
- 排序与过滤

图表类型改成更紧凑的图标网格，整体宽度从原来的 320/336px 收窄到 272/288px。

### 6. 保持现有协议兼容

本 PR 不修改：

- `AnalysisSpec`
- `AnalysisEncoding`
- Dataset Query API
- Dashboard 后端模型
- 已保存图表 JSON

旧图表继续通过现有 `resolveAnalysisEncoding()` 读取，新的 UI 仍写回同一套 Encoding / dimensions / metrics 投影。

## Files

- `chart-data-column.tsx`：Dataset + 字段统一入口
- `chart-encoding-shelf.tsx`：画布顶部主字段架
- `finebi-chart-builder.tsx`：简化后的图表类型 / 次要属性 / 分析设置
- `chart-sheet-workspace.tsx`：新的 Chart Sheet 布局接线

## Regression checklist

1. 打开已有 Dashboard 图表，原字段绑定能够正常显示
2. 左上角 Dataset Select 能正确显示当前数据集
3. 切换 Dataset 后字段列表和图表配置正常重置/更新
4. 柱状图/折线图主字段在顶部以横轴/纵轴显示
5. 饼图/指标卡/表格主字段显示为维度/指标
6. 字段可从左侧拖入顶部槽位
7. 指标聚合方式可直接在字段 pill 上切换
8. 图表类型切换继续保留兼容字段和现有样式
9. 颜色/分组/明细等次要字段仍可配置
10. 分析设置、排序和过滤仍然可用
11. 样式/交互右侧面板保持原有能力
12. 共享历史图表仍保持只读，并可复制为可编辑图表

## Validation

当前执行容器无法解析 `github.com`，因此无法 clone 仓库执行完整 `npm run tsc` / `npm run build`。已按仓库现有 `AnalysisSpec`、`AnalysisEncoding`、`PublishedDataset`、`DashboardInlineAnalysisSpec` 类型和现有 Encoding 更新逻辑进行静态对齐。建议以本地工程回归或 PR CI 作为最终验证。