### PR TITLE
style: improve dashboard field panel readability

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
@@ -21,24 +21,24 @@ export function ChartDataColumn({
 }) {
   return (
     <section className="chart-data-column flex w-[244px] shrink-0 flex-col border-r border-[#e3e6ea] bg-white">
-      <div className="shrink-0 border-b border-[#eceef1] px-3 py-3">
+      <div className="shrink-0 border-b border-[#eceef1] px-3 py-3.5">
         <Select
           showSearch
-          size="small"
+          size="middle"
           variant="filled"
           value={dataset?.id}
           disabled={!editable}
           optionFilterProp="label"
-          className="w-full"
+          className="chart-dataset-select w-full"
           placeholder="选择数据集"
-          suffixIcon={<Database size={12} className="text-[#8e95a0]" />}
+          suffixIcon={<Database size={13} className="text-[#667085]" />}
           options={datasets.map((item) => ({
             label: item.name,
             value: item.id,
           }))}
           onChange={onDatasetChange}
         />
-        <div className="mt-1.5 truncate px-0.5 text-[9px] text-[#98a2b3]">
+        <div className="mt-2 truncate px-0.5 text-[10px] font-medium text-[#7a818c]">
           {dataset ? `数据目录 · ${dataset.name}` : '当前数据来源不可用，可重新选择'}
         </div>
       </div>
@@ -59,6 +59,18 @@ export function ChartDataColumn({
         }
         .chart-data-column > .min-h-0 > section > div:first-child {
           display: none;
+        }
+        .chart-data-column .chart-dataset-select .ant-select-selector {
+          min-height: 34px !important;
+          border-radius: 7px !important;
+        }
+        .chart-data-column .chart-dataset-select .ant-select-selection-item,
+        .chart-data-column .chart-dataset-select .ant-select-selection-placeholder {
+          font-size: 12px !important;
+        }
+        .chart-data-column .chart-dataset-select .ant-select-selection-item {
+          font-weight: 600 !important;
+          color: #344054 !important;
         }
       `}</style>
     </section>

--- a/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
@@ -180,7 +180,7 @@ export function ChartFieldPanel({
         {!dataset ? (
           <div className="px-2 py-6 text-center text-[11px] text-[#8b929c]">暂无可用字段</div>
         ) : (
-          <div className="space-y-4.5">
+          <div className="space-y-4">
             <FieldGroup
               title="维度"
               role="dimension"

--- a/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx
@@ -138,8 +138,8 @@ export function ChartFieldPanel({
       <div className="flex h-14 shrink-0 items-center border-b border-[#eceef1] px-3.5">
         <div className="min-w-0">
           <div className="text-[13px] font-semibold text-[#344054]">数据字段</div>
-          <div className="mt-0.5 flex items-center gap-1 text-[9px] text-[#98a2b3]">
-            <Database size={9} className="shrink-0" />
+          <div className="mt-0.5 flex items-center gap-1 text-[10px] font-medium text-[#7a818c]">
+            <Database size={10} className="shrink-0" />
             <span className="truncate">{dataset?.name ?? '数据来源不可用'}</span>
           </div>
         </div>
@@ -150,21 +150,21 @@ export function ChartFieldPanel({
           allowClear
           size="small"
           value={keyword}
-          prefix={<Search size={12} className="text-[#a0a6af]" />}
+          prefix={<Search size={13} className="text-[#7a818c]" />}
           placeholder="搜索字段"
-          className="!h-8 !rounded-[7px]"
+          className="!h-9 !rounded-[7px] !text-[11px]"
           onChange={(event) => setKeyword(event.target.value)}
         />
         <div className="mt-2 flex items-center justify-between gap-2">
-          <div className="text-[9px] leading-4 text-[#98a2b3]">
-            {editable ? '拖动字段到右侧编码槽位' : '复制为可编辑图表后可配置'}
+          <div className="text-[10px] leading-4 text-[#8b929c]">
+            {editable ? '拖动字段到上方字段槽位' : '复制为可编辑图表后可配置'}
           </div>
           {editable && dataset && spec && onSpecPatch ? (
             <Button
               type="text"
               size="small"
-              className="!h-6 !px-1.5 !text-[9px]"
-              icon={<Plus size={10} />}
+              className="!h-7 !px-1.5 !text-[10px]"
+              icon={<Plus size={11} />}
               onClick={() => {
                 setEditingField(undefined);
                 setEditorOpen(true);
@@ -176,19 +176,21 @@ export function ChartFieldPanel({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-2.5 py-3">
+      <div className="min-h-0 flex-1 overflow-y-auto px-2.5 py-3.5">
         {!dataset ? (
-          <div className="px-2 py-6 text-center text-[10px] text-[#98a2b3]">暂无可用字段</div>
+          <div className="px-2 py-6 text-center text-[11px] text-[#8b929c]">暂无可用字段</div>
         ) : (
-          <div className="space-y-4">
+          <div className="space-y-4.5">
             <FieldGroup
               title="维度"
+              role="dimension"
               fields={dimensions}
               encodedFields={encodedFields}
               editable={editable}
             />
             <FieldGroup
               title="指标"
+              role="metric"
               fields={metrics}
               encodedFields={encodedFields}
               editable={editable}
@@ -229,35 +231,56 @@ export function ChartFieldPanel({
 
 function FieldGroup({
   title,
+  role,
   fields,
   encodedFields,
   editable,
 }: {
   title: string;
+  role: DatasetField['role'];
   fields: DatasetField[];
   encodedFields: Set<string>;
   editable: boolean;
 }) {
+  const dimension = role === 'dimension';
+
   return (
     <div>
       <div className="mb-1.5 flex items-center justify-between px-1.5">
-        <span className="text-[10px] font-semibold text-[#667085]">{title}</span>
-        <span className="text-[9px] tabular-nums text-[#b0b5bd]">{fields.length}</span>
+        <div className="flex items-center gap-1.5">
+          <span
+            className={[
+              'flex h-5 w-5 items-center justify-center rounded-[5px] border',
+              dimension
+                ? 'border-[#dce6ff] bg-[#eef3ff] text-[#5674e8]'
+                : 'border-[#d5eeee] bg-[#edf9f9] text-[#169c9c]',
+            ].join(' ')}
+          >
+            {dimension ? <Type size={10} /> : <Hash size={10} />}
+          </span>
+          <span className="text-[11px] font-semibold text-[#344054]">{title}</span>
+        </div>
+        <span className="rounded-[4px] bg-[#f2f4f7] px-1.5 py-0.5 text-[9px] font-medium tabular-nums text-[#667085]">
+          {fields.length}
+        </span>
       </div>
       <div className="space-y-0.5">
         {fields.map((field) => {
           const selected = encodedFields.has(field.key);
+          const isDimension = field.role === 'dimension';
           return (
             <div
               key={field.key}
               draggable={editable}
-              title={editable ? `${field.label} · 拖动到图表编码槽位` : field.label}
+              title={editable ? `${field.label} · 拖动到上方字段槽位` : field.label}
               className={[
-                'group flex h-8 items-center gap-1.5 rounded-[6px] px-1.5 text-[10px] transition-colors',
+                'group flex h-9 items-center gap-2 rounded-[6px] px-1.5 text-[11px] transition-colors',
                 editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',
                 selected
-                  ? 'bg-[#f4f5f7] font-medium text-[#344054]'
-                  : 'text-[#475467] hover:bg-[#f7f8fa]',
+                  ? isDimension
+                    ? 'bg-[#f4f7ff] font-medium text-[#263244]'
+                    : 'bg-[#f0fafa] font-medium text-[#263244]'
+                  : 'text-[#344054] hover:bg-[#f7f8fa]',
               ].join(' ')}
               onDragStart={(event) => {
                 if (!editable) return;
@@ -266,18 +289,25 @@ function FieldGroup({
             >
               <GripVertical
                 size={12}
-                className={editable ? 'shrink-0 text-[#c2c6cc] group-hover:text-[#8b929c]' : 'shrink-0 text-[#e0e2e6]'}
+                className={editable ? 'shrink-0 text-[#c2c6cc] group-hover:text-[#8b929c]' : 'shrink-0 text-[#d9dde2]'}
               />
-              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[5px] bg-[#f2f4f7] text-[#7a818c]">
-                {field.dataType === 'number' ? <Hash size={11} /> : <Type size={11} />}
+              <span
+                className={[
+                  'flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[5px] border',
+                  isDimension
+                    ? 'border-[#dce6ff] bg-[#eef3ff] text-[#5674e8]'
+                    : 'border-[#d5eeee] bg-[#edf9f9] text-[#169c9c]',
+                ].join(' ')}
+              >
+                {isDimension ? <Type size={11} /> : <Hash size={11} />}
               </span>
-              <span className="min-w-0 flex-1 truncate">{field.label}</span>
-              <span className="shrink-0 text-[8px] text-[#b0b5bd]">{fieldTypeLabel[field.dataType]}</span>
+              <span className="min-w-0 flex-1 truncate font-medium">{field.label}</span>
+              <span className="shrink-0 text-[9px] text-[#8e95a0]">{fieldTypeLabel[field.dataType]}</span>
             </div>
           );
         })}
         {!fields.length ? (
-          <div className="px-1.5 py-2 text-[9px] text-[#b0b5bd]">没有匹配字段</div>
+          <div className="px-1.5 py-2.5 text-[10px] text-[#98a2b3]">没有匹配字段</div>
         ) : null}
       </div>
     </div>
@@ -302,8 +332,15 @@ function CalculatedFieldGroup({
   return (
     <div>
       <div className="mb-1.5 flex items-center justify-between px-1.5">
-        <span className="text-[10px] font-semibold text-[#667085]">计算字段</span>
-        <span className="text-[9px] tabular-nums text-[#b0b5bd]">{total}</span>
+        <div className="flex items-center gap-1.5">
+          <span className="flex h-5 w-5 items-center justify-center rounded-[5px] border border-[#fee1c7] bg-[#fff6ed] text-[#f79009]">
+            <Braces size={10} />
+          </span>
+          <span className="text-[11px] font-semibold text-[#344054]">计算字段</span>
+        </div>
+        <span className="rounded-[4px] bg-[#f2f4f7] px-1.5 py-0.5 text-[9px] font-medium tabular-nums text-[#667085]">
+          {total}
+        </span>
       </div>
       <div className="space-y-0.5">
         {fields.map((field) => {
@@ -315,28 +352,28 @@ function CalculatedFieldGroup({
               draggable={editable}
               title={`${field.name} · ${field.expression}`}
               className={[
-                'group flex min-h-8 items-center gap-1.5 rounded-[6px] px-1.5 text-[10px] transition-colors',
+                'group flex min-h-9 items-center gap-2 rounded-[6px] px-1.5 text-[11px] transition-colors',
                 editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',
                 selected
-                  ? 'bg-[#f4f5f7] font-medium text-[#344054]'
-                  : 'text-[#475467] hover:bg-[#f7f8fa]',
+                  ? 'bg-[#fff8f0] font-medium text-[#263244]'
+                  : 'text-[#344054] hover:bg-[#f7f8fa]',
               ].join(' ')}
               onDragStart={(event) => {
                 if (!editable) return;
                 writeChartFieldDragPayload(event, { field: key, role: 'metric' });
               }}
             >
-              <GripVertical size={12} className="shrink-0 text-[#c2c6cc]" />
-              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[5px] bg-[#f2f4f7] text-[#7a818c]">
+              <GripVertical size={12} className="shrink-0 text-[#c2c6cc] group-hover:text-[#8b929c]" />
+              <span className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[5px] border border-[#fee1c7] bg-[#fff6ed] text-[#f79009]">
                 <Braces size={11} />
               </span>
-              <span className="min-w-0 flex-1 truncate">{field.name}</span>
-              <span className="shrink-0 text-[8px] text-[#b0b5bd]">计算</span>
+              <span className="min-w-0 flex-1 truncate font-medium">{field.name}</span>
+              <span className="shrink-0 text-[9px] text-[#8e95a0]">计算</span>
               {editable ? (
                 <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex">
                   <button
                     type="button"
-                    className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[#98a2b3] hover:bg-[#e9ebef] hover:text-[#475467]"
+                    className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[#8e95a0] hover:bg-[#e9ebef] hover:text-[#475467]"
                     aria-label={`编辑${field.name}`}
                     onClick={() => onEdit(field)}
                   >
@@ -351,7 +388,7 @@ function CalculatedFieldGroup({
                   >
                     <button
                       type="button"
-                      className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[#98a2b3] hover:bg-[#e9ebef] hover:text-[#b42318]"
+                      className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[#8e95a0] hover:bg-[#e9ebef] hover:text-[#b42318]"
                       aria-label={`删除${field.name}`}
                     >
                       <Trash2 size={9} />
@@ -363,7 +400,7 @@ function CalculatedFieldGroup({
           );
         })}
         {!fields.length ? (
-          <div className="px-1.5 py-2 text-[9px] text-[#b0b5bd]">没有匹配计算字段</div>
+          <div className="px-1.5 py-2.5 text-[10px] text-[#98a2b3]">没有匹配计算字段</div>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Overview

优化 Dashboard 图表编辑器左侧数据区域的可读性和字段角色识别。当前 Dataset / 字段区域整体字体偏小、颜色偏淡，维度与指标使用相同的灰色图标，字段较多时不容易快速扫描。

本 PR 只调整左侧数据面板视觉层级，不修改 Dataset、字段拖拽、图表 Encoding、查询或 Dashboard 数据模型。

## What changed

### Dataset 入口

- Dataset Select 从偏小的 small 尺寸调整为更舒适的 34px 高度
- Dataset 名称提升到 12px / semibold
- `数据目录 · xxx` 辅助信息从 9px 提升到 10px，并提高文字对比度
- Database 图标同步提高可见度
- 继续保留 Ant Design `variant="filled"`

### 字段搜索与辅助信息

- 搜索框提升到 36px 高度
- 搜索文字提升为 11px
- 搜索图标和辅助提示不再使用过淡灰色
- 将旧文案“拖动字段到右侧编码槽位”更新为符合当前布局的“拖动字段到上方字段槽位”

### 维度 / 指标语义颜色

参考 FineBI 的字段识别方式，但保持 Yak Ops 的克制视觉：

- 维度：蓝色 `T` 图标 + 浅蓝背景
- 指标：青色 `#` 图标 + 浅青背景
- 计算字段：橙色 `{}` 图标 + 浅橙背景

颜色只用于图标和非常轻的选中底色，不扩大到整块高饱和区域。

### 字段列表层级

- 分组标题提升到 11px / semibold
- 字段名称提升到 11px / medium
- 字段类型说明从 8px 提升到 9px
- 字段行高度从 32px 提升到 36px
- 分组数量改成轻量 badge，提高扫视效率
- 已绑定字段按角色使用轻量蓝 / 青 / 橙背景
- 拖拽把手仍保持弱化，仅 hover 时增强

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/chart-data-column.tsx`
- `yak-ops-ui/src/pages/dashboard/chart-field-panel.tsx`

不修改：

- Dataset API / Query
- AnalysisSpec / AnalysisEncoding
- 图表类型与字段绑定逻辑
- Dashboard 数据模型
- 右侧渲染设置
- 底部 Sheet

## Regression checklist

1. Dataset Select 能正常切换数据集
2. 字段搜索正常
3. 维度字段仍可拖到上方维度/横轴槽位
4. 指标字段仍可拖到上方指标/纵轴槽位
5. 已绑定字段状态正常显示
6. 计算字段新增 / 编辑 / 删除正常
7. 计算字段拖拽正常
8. 只读共享图表仍保持不可编辑状态
9. 长字段名称仍然正确 truncate
10. 左侧滚动区域正常

## Validation

本次为纯前端视觉层级调整，未修改业务协议。当前 connector-only 环境无法执行完整本地 `npm run tsc` / `npm run build`，建议以本地工程回归或 PR CI 作为最终验证。