### PR TITLE
style: simplify dashboard field role icons

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-data-column.tsx
@@ -72,6 +72,11 @@ export function ChartDataColumn({
           font-weight: 600 !important;
           color: #344054 !important;
         }
+        .chart-data-column > .min-h-0 > section > div:nth-child(3) span[class*="rounded-[5px]"][class*="border"] {
+          border: 0 !important;
+          background: transparent !important;
+          border-radius: 0 !important;
+        }
       `}</style>
     </section>
   );


### PR DESCRIPTION
## Overview

进一步收敛 Dashboard 图表编辑器左侧字段区的视觉样式，使维度 / 指标 / 计算字段更接近 FineBI 的轻量字段标识方式。

本 PR 只处理字段角色图标的视觉表达，不改字段绑定、拖拽、Dataset、Encoding 或查询逻辑。

## What changed

- 去掉维度 `T` 图标外层的浅蓝背景、border 和圆角方块
- 去掉指标 `#` 图标外层的浅青背景、border 和圆角方块
- 去掉计算字段 `{}` 图标外层的浅橙背景、border 和圆角方块
- 保留原有语义颜色：
  - 维度：蓝色
  - 指标：青色
  - 计算字段：橙色
- 继续保留 #502 已完成的字号、字段行高、Dataset Select 和字段可读性优化

## Visual direction

从：

```text
[ T ] 合同类型名称
[ # ] 合同总价
```

调整为：

```text
T   合同类型名称
#   合同总价
```

颜色仍保留，但不再额外包一层视觉容器。

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/chart-data-column.tsx`

Diff 为 1 个文件、5 行新增；分支基于最新 `main`，ahead 1 / behind 0。

## Regression checklist

1. 维度 / 指标 / 计算字段语义颜色仍正常
2. 字段拖拽不受影响
3. 已绑定字段选中态不受影响
4. 字段 hover 不受影响
5. 计算字段编辑 / 删除不受影响
6. Dataset Select 不受影响

## Validation

本次仅增加 scoped CSS 覆盖字段角色 icon 外层容器的 border / background / radius，不涉及业务逻辑。建议以本地页面视觉回归为最终确认。