### PR TITLE
style: simplify dashboard render settings panel

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/config-style.tsx
+++ b/yak-ops-ui/src/pages/dashboard/config-style.tsx
@@ -48,277 +48,318 @@ export function ChartStyleConfig({
     : style.dataLabelPosition === 'inside' ? 'inside' : 'top';
 
   return (
-    <div className="space-y-4 pb-1 text-[11px] text-[#475467]">
-      {supportsPalette ? (
-        <StyleGroup title="配色">
-          <div className="grid grid-cols-5 gap-1.5">
-            {(Object.entries(ANALYSIS_PALETTES) as Array<
-              [keyof typeof ANALYSIS_PALETTES, (typeof ANALYSIS_PALETTES)[keyof typeof ANALYSIS_PALETTES]]
-            >).map(([key, palette]) => {
-              const active = style.palette === key;
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  title={palette.label}
-                  onClick={() => onChange({ palette: key })}
-                  className={[
-                    'rounded-[7px] border px-1.5 py-2 transition-[background-color,border-color]',
-                    active
-                      ? 'border-[#cbd1da] bg-[#f5f6f7]'
-                      : 'border-[#e8eaee] bg-white hover:border-[#d9dde4] hover:bg-[#fafbfc]',
-                  ].join(' ')}
-                >
-                  <div className="flex h-3 overflow-hidden rounded-[3px]">
-                    {palette.colors.slice(0, 4).map((color) => (
-                      <span key={color} className="flex-1" style={{ backgroundColor: color }} />
-                    ))}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </StyleGroup>
-      ) : null}
+    <>
+      <div className="chart-style-config space-y-5 pb-1 text-[12px] font-medium text-[#344054]">
+        {supportsPalette ? (
+          <StyleGroup title="配色">
+            <div className="grid grid-cols-5 gap-1.5">
+              {(Object.entries(ANALYSIS_PALETTES) as Array<
+                [keyof typeof ANALYSIS_PALETTES, (typeof ANALYSIS_PALETTES)[keyof typeof ANALYSIS_PALETTES]]
+              >).map(([key, palette]) => {
+                const active = style.palette === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    title={palette.label}
+                    onClick={() => onChange({ palette: key })}
+                    className={[
+                      'rounded-[7px] border px-1.5 py-2 transition-[background-color,border-color]',
+                      active
+                        ? 'border-[#bfc6d0] bg-[#f4f5f7]'
+                        : 'border-[#e4e7ec] bg-white hover:border-[#cfd4dc] hover:bg-[#fafbfc]',
+                    ].join(' ')}
+                  >
+                    <div className="flex h-3.5 overflow-hidden rounded-[3px]">
+                      {palette.colors.slice(0, 4).map((color) => (
+                        <span key={color} className="flex-1" style={{ backgroundColor: color }} />
+                      ))}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </StyleGroup>
+        ) : null}
 
-      {supportsLegend || supportsLabels ? (
-        <StyleGroup title="展示">
-          <div className="space-y-3">
-            {supportsLegend ? (
-              <>
-                <ToggleRow
-                  label="显示图例"
-                  checked={style.showLegend}
-                  onChange={(showLegend) => onChange({ showLegend })}
-                />
-                {style.showLegend ? (
-                  <ControlRow label="图例位置">
-                    <Select
-                      size="small"
-                      className="w-[116px]"
-                      value={style.legendPosition}
-                      options={[
-                        { label: '顶部', value: 'top' },
-                        { label: '右侧', value: 'right' },
-                        { label: '底部', value: 'bottom' },
-                      ]}
-                      onChange={(legendPosition: AnalysisLegendPosition) => onChange({ legendPosition })}
-                    />
-                  </ControlRow>
-                ) : null}
-              </>
-            ) : null}
-            {supportsLabels ? (
-              <>
-                <ToggleRow
-                  label={spec.type === 'treemap' ? '显示数值' : '显示数据标签'}
-                  checked={style.showDataLabels}
-                  onChange={(showDataLabels) => onChange({ showDataLabels })}
-                />
-                {style.showDataLabels && supportsLabelPosition ? (
-                  <ControlRow label="标签位置">
-                    <Select
-                      size="small"
-                      className="w-[116px]"
-                      value={activeLabelPosition}
-                      options={radialLabelPosition
-                        ? [
-                          { label: '外侧', value: 'outside' },
-                          { label: '内部', value: 'inside' },
-                        ]
-                        : [
+        {supportsLegend || supportsLabels ? (
+          <StyleGroup title="展示">
+            <div className="space-y-3.5">
+              {supportsLegend ? (
+                <>
+                  <ToggleRow
+                    label="显示图例"
+                    checked={style.showLegend}
+                    onChange={(showLegend) => onChange({ showLegend })}
+                  />
+                  {style.showLegend ? (
+                    <ControlRow label="图例位置">
+                      <Select
+                        size="small"
+                        className="chart-style-control w-[120px]"
+                        value={style.legendPosition}
+                        options={[
                           { label: '顶部', value: 'top' },
-                          { label: '内部', value: 'inside' },
+                          { label: '右侧', value: 'right' },
+                          { label: '底部', value: 'bottom' },
                         ]}
-                      onChange={(dataLabelPosition: AnalysisDataLabelPosition) => onChange({ dataLabelPosition })}
-                    />
-                  </ControlRow>
-                ) : null}
-              </>
-            ) : null}
-          </div>
-        </StyleGroup>
-      ) : null}
+                        onChange={(legendPosition: AnalysisLegendPosition) => onChange({ legendPosition })}
+                      />
+                    </ControlRow>
+                  ) : null}
+                </>
+              ) : null}
+              {supportsLabels ? (
+                <>
+                  <ToggleRow
+                    label={spec.type === 'treemap' ? '显示数值' : '显示数据标签'}
+                    checked={style.showDataLabels}
+                    onChange={(showDataLabels) => onChange({ showDataLabels })}
+                  />
+                  {style.showDataLabels && supportsLabelPosition ? (
+                    <ControlRow label="标签位置">
+                      <Select
+                        size="small"
+                        className="chart-style-control w-[120px]"
+                        value={activeLabelPosition}
+                        options={radialLabelPosition
+                          ? [
+                            { label: '外侧', value: 'outside' },
+                            { label: '内部', value: 'inside' },
+                          ]
+                          : [
+                            { label: '顶部', value: 'top' },
+                            { label: '内部', value: 'inside' },
+                          ]}
+                        onChange={(dataLabelPosition: AnalysisDataLabelPosition) => onChange({ dataLabelPosition })}
+                      />
+                    </ControlRow>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          </StyleGroup>
+        ) : null}
 
-      {hasCartesianAxes ? (
-        <StyleGroup title="坐标轴">
-          <div className="space-y-3">
-            <ToggleRow
-              label="显示网格线"
-              checked={style.showGrid}
-              onChange={(showGrid) => onChange({ showGrid })}
-            />
-            {hasCategoricalAxis ? (
-              <ControlRow label="标签旋转">
-                <Select
-                  size="small"
-                  className="w-[116px]"
-                  value={style.axisLabelRotation}
-                  options={[
-                    { label: '不旋转', value: 0 },
-                    { label: '30°', value: 30 },
-                    { label: '45°', value: 45 },
-                  ]}
-                  onChange={(axisLabelRotation: 0 | 30 | 45) => onChange({ axisLabelRotation })}
-                />
-              </ControlRow>
-            ) : null}
-          </div>
-        </StyleGroup>
-      ) : null}
+        {hasCartesianAxes ? (
+          <StyleGroup title="坐标轴">
+            <div className="space-y-3.5">
+              <ToggleRow
+                label="显示网格线"
+                checked={style.showGrid}
+                onChange={(showGrid) => onChange({ showGrid })}
+              />
+              {hasCategoricalAxis ? (
+                <ControlRow label="标签旋转">
+                  <Select
+                    size="small"
+                    className="chart-style-control w-[120px]"
+                    value={style.axisLabelRotation}
+                    options={[
+                      { label: '不旋转', value: 0 },
+                      { label: '30°', value: 30 },
+                      { label: '45°', value: 45 },
+                    ]}
+                    onChange={(axisLabelRotation: 0 | 30 | 45) => onChange({ axisLabelRotation })}
+                  />
+                </ControlRow>
+              ) : null}
+            </div>
+          </StyleGroup>
+        ) : null}
 
-      {spec.type === 'bar' || spec.type === 'stackedBar' ? (
-        <StyleGroup title={spec.type === 'stackedBar' ? '堆叠柱形' : '柱形'}>
-          <div className="space-y-3">
-            <NumberRow
-              label="最大宽度"
-              value={style.barMaxWidth}
-              min={12}
-              max={72}
-              suffix="px"
-              onChange={(barMaxWidth) => onChange({ barMaxWidth })}
-            />
-            <NumberRow
-              label="圆角"
-              value={style.barRadius}
-              min={0}
-              max={16}
-              suffix="px"
-              onChange={(barRadius) => onChange({ barRadius })}
-            />
-          </div>
-        </StyleGroup>
-      ) : null}
+        {spec.type === 'bar' || spec.type === 'stackedBar' ? (
+          <StyleGroup title={spec.type === 'stackedBar' ? '堆叠柱形' : '柱形'}>
+            <div className="space-y-3.5">
+              <NumberRow
+                label="最大宽度"
+                value={style.barMaxWidth}
+                min={12}
+                max={72}
+                suffix="px"
+                onChange={(barMaxWidth) => onChange({ barMaxWidth })}
+              />
+              <NumberRow
+                label="圆角"
+                value={style.barRadius}
+                min={0}
+                max={16}
+                suffix="px"
+                onChange={(barRadius) => onChange({ barRadius })}
+              />
+            </div>
+          </StyleGroup>
+        ) : null}
 
-      {spec.type === 'line' || spec.type === 'area' ? (
-        <StyleGroup title={spec.type === 'area' ? '面积线' : '折线'}>
-          <div className="space-y-3">
-            <ToggleRow
-              label="平滑曲线"
-              checked={style.smooth}
-              onChange={(smooth) => onChange({ smooth })}
-            />
+        {spec.type === 'line' || spec.type === 'area' ? (
+          <StyleGroup title={spec.type === 'area' ? '面积线' : '折线'}>
+            <div className="space-y-3.5">
+              <ToggleRow
+                label="平滑曲线"
+                checked={style.smooth}
+                onChange={(smooth) => onChange({ smooth })}
+              />
+              <NumberRow
+                label="线宽"
+                value={style.lineWidth}
+                min={1}
+                max={6}
+                suffix="px"
+                onChange={(lineWidth) => onChange({ lineWidth })}
+              />
+              <NumberRow
+                label="数据点"
+                value={style.symbolSize}
+                min={0}
+                max={14}
+                suffix="px"
+                onChange={(symbolSize) => onChange({ symbolSize })}
+              />
+            </div>
+          </StyleGroup>
+        ) : null}
+
+        {spec.type === 'scatter' ? (
+          <StyleGroup title="散点">
             <NumberRow
-              label="线宽"
-              value={style.lineWidth}
-              min={1}
-              max={6}
-              suffix="px"
-              onChange={(lineWidth) => onChange({ lineWidth })}
-            />
-            <NumberRow
-              label="数据点"
+              label="点大小"
               value={style.symbolSize}
               min={0}
               max={14}
               suffix="px"
               onChange={(symbolSize) => onChange({ symbolSize })}
             />
-          </div>
-        </StyleGroup>
-      ) : null}
+          </StyleGroup>
+        ) : null}
 
-      {spec.type === 'scatter' ? (
-        <StyleGroup title="散点">
-          <NumberRow
-            label="点大小"
-            value={style.symbolSize}
-            min={0}
-            max={14}
-            suffix="px"
-            onChange={(symbolSize) => onChange({ symbolSize })}
-          />
-        </StyleGroup>
-      ) : null}
-
-      {spec.type === 'pie' ? (
-        <StyleGroup title="饼图">
-          <div>
-            <div className="mb-1.5 flex items-center justify-between text-[10px] text-[#667085]">
-              <span>内径</span>
-              <span className="tabular-nums text-[#98a2b3]">{style.pieInnerRadius}%</span>
+        {spec.type === 'pie' ? (
+          <StyleGroup title="饼图">
+            <div>
+              <div className="mb-2 flex items-center justify-between text-[12px] text-[#344054]">
+                <span>内径</span>
+                <span className="tabular-nums font-normal text-[#667085]">{style.pieInnerRadius}%</span>
+              </div>
+              <Slider
+                min={0}
+                max={64}
+                step={2}
+                value={style.pieInnerRadius}
+                onChange={(pieInnerRadius) => onChange({ pieInnerRadius })}
+              />
             </div>
-            <Slider
-              min={0}
-              max={64}
-              step={2}
-              value={style.pieInnerRadius}
-              onChange={(pieInnerRadius) => onChange({ pieInnerRadius })}
-            />
-          </div>
-        </StyleGroup>
-      ) : null}
+          </StyleGroup>
+        ) : null}
 
-      {spec.type === 'metric' ? (
-        <StyleGroup title="指标卡">
-          <div className="space-y-3">
-            <ControlRow label="对齐方式">
-              <Select
-                size="small"
-                className="w-[116px]"
-                value={style.metricAlign}
-                options={[
-                  { label: '左对齐', value: 'left' },
-                  { label: '居中', value: 'center' },
-                  { label: '右对齐', value: 'right' },
-                ]}
-                onChange={(metricAlign: AnalysisMetricAlign) => onChange({ metricAlign })}
+        {spec.type === 'metric' ? (
+          <StyleGroup title="指标卡">
+            <div className="space-y-3.5">
+              <ControlRow label="对齐方式">
+                <Select
+                  size="small"
+                  className="chart-style-control w-[120px]"
+                  value={style.metricAlign}
+                  options={[
+                    { label: '左对齐', value: 'left' },
+                    { label: '居中', value: 'center' },
+                    { label: '右对齐', value: 'right' },
+                  ]}
+                  onChange={(metricAlign: AnalysisMetricAlign) => onChange({ metricAlign })}
+                />
+              </ControlRow>
+              <ControlRow label="数值字号">
+                <Select
+                  size="small"
+                  className="chart-style-control w-[120px]"
+                  value={style.metricValueSize}
+                  options={[
+                    { label: '紧凑', value: 'sm' },
+                    { label: '标准', value: 'md' },
+                    { label: '突出', value: 'lg' },
+                  ]}
+                  onChange={(metricValueSize: AnalysisMetricValueSize) => onChange({ metricValueSize })}
+                />
+              </ControlRow>
+              <ToggleRow
+                label="显示数据来源"
+                checked={style.showMetricMeta}
+                onChange={(showMetricMeta) => onChange({ showMetricMeta })}
               />
-            </ControlRow>
-            <ControlRow label="数值字号">
-              <Select
-                size="small"
-                className="w-[116px]"
-                value={style.metricValueSize}
-                options={[
-                  { label: '紧凑', value: 'sm' },
-                  { label: '标准', value: 'md' },
-                  { label: '突出', value: 'lg' },
-                ]}
-                onChange={(metricValueSize: AnalysisMetricValueSize) => onChange({ metricValueSize })}
-              />
-            </ControlRow>
-            <ToggleRow
-              label="显示数据来源"
-              checked={style.showMetricMeta}
-              onChange={(showMetricMeta) => onChange({ showMetricMeta })}
-            />
-          </div>
-        </StyleGroup>
-      ) : null}
+            </div>
+          </StyleGroup>
+        ) : null}
 
-      {spec.type === 'table' ? (
-        <StyleGroup title="表格">
-          <div className="space-y-3">
-            <ControlRow label="行高密度">
-              <Select
-                size="small"
-                className="w-[116px]"
-                value={style.tableDensity}
-                options={[
-                  { label: '紧凑', value: 'compact' },
-                  { label: '标准', value: 'comfortable' },
-                  { label: '宽松', value: 'relaxed' },
-                ]}
-                onChange={(tableDensity: AnalysisTableDensity) => onChange({ tableDensity })}
+        {spec.type === 'table' ? (
+          <StyleGroup title="表格">
+            <div className="space-y-3.5">
+              <ControlRow label="行高密度">
+                <Select
+                  size="small"
+                  className="chart-style-control w-[120px]"
+                  value={style.tableDensity}
+                  options={[
+                    { label: '紧凑', value: 'compact' },
+                    { label: '标准', value: 'comfortable' },
+                    { label: '宽松', value: 'relaxed' },
+                  ]}
+                  onChange={(tableDensity: AnalysisTableDensity) => onChange({ tableDensity })}
+                />
+              </ControlRow>
+              <ToggleRow
+                label="斑马纹"
+                checked={style.stripedRows}
+                onChange={(stripedRows) => onChange({ stripedRows })}
               />
-            </ControlRow>
-            <ToggleRow
-              label="斑马纹"
-              checked={style.stripedRows}
-              onChange={(stripedRows) => onChange({ stripedRows })}
-            />
-          </div>
-        </StyleGroup>
-      ) : null}
-    </div>
+            </div>
+          </StyleGroup>
+        ) : null}
+      </div>
+
+      <style>{`
+        /* Phase 1 keeps interaction data compatibility, but does not expose interaction editing. */
+        .chart-appearance-config-panel > div:first-child {
+          height: 52px !important;
+        }
+        .chart-appearance-config-panel > div:first-child > div > div:first-child {
+          font-size: 14px !important;
+          font-weight: 600 !important;
+          color: #161823 !important;
+        }
+        .chart-appearance-config-panel > div:first-child > div > div:last-child:not(:first-child) {
+          display: none !important;
+        }
+        .chart-appearance-tabs .ant-tabs-nav {
+          display: none !important;
+        }
+        .chart-appearance-tabs .ant-tabs-tabpane-active > div > div:first-child {
+          display: none !important;
+        }
+        .chart-appearance-tabs .ant-tabs-tabpane-active > div {
+          padding-top: 16px !important;
+        }
+        .chart-appearance-config-panel .ant-select-selection-item,
+        .chart-appearance-config-panel .ant-select-selection-placeholder,
+        .chart-appearance-config-panel .ant-input-number-input,
+        .chart-appearance-config-panel .ant-input-number-group-addon {
+          font-size: 12px !important;
+          color: #344054 !important;
+        }
+        .chart-appearance-config-panel .ant-select-selector,
+        .chart-appearance-config-panel .ant-input-number {
+          min-height: 30px !important;
+        }
+        .chart-appearance-config-panel > div:last-child .ant-btn {
+          font-size: 12px !important;
+          color: #344054 !important;
+        }
+      `}</style>
+    </>
   );
 }
 
 function StyleGroup({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="border-b border-[#f0f1f3] pb-4 last:border-b-0 last:pb-0">
-      <div className="mb-2.5 text-[10px] font-semibold text-[#667085]">{title}</div>
+    <div className="border-b border-[#eceef1] pb-5 last:border-b-0 last:pb-0">
+      <div className="mb-3 text-[12px] font-semibold text-[#161823]">{title}</div>
       {children}
     </div>
   );
@@ -334,7 +375,7 @@ function ToggleRow({
   onChange: (checked: boolean) => void;
 }) {
   return (
-    <label className="flex items-center justify-between gap-3">
+    <label className="flex min-h-8 items-center justify-between gap-3 text-[#344054]">
       <span>{label}</span>
       <Switch size="small" checked={checked} onChange={onChange} />
     </label>
@@ -343,7 +384,7 @@ function ToggleRow({
 
 function ControlRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-3">
+    <div className="flex min-h-8 items-center justify-between gap-3 text-[#344054]">
       <span>{label}</span>
       {children}
     </div>
@@ -369,7 +410,7 @@ function NumberRow({
     <ControlRow label={label}>
       <InputNumber
         size="small"
-        className="w-[116px]"
+        className="w-[120px]"
         min={min}
         max={max}
         value={value}


### PR DESCRIPTION
## Overview

简化 Dashboard 图表编辑器右侧「渲染设置」面板。第一期不再对用户暴露图表交互配置，右侧只聚焦图表样式，并提升字号、文字对比度和配置可读性。

## What changed

### 1. 第一阶段隐藏「交互」入口

- 不再显示「样式 / 交互」Tabs
- 右侧进入后直接展示样式配置
- 交互底层模型与历史配置暂时保留，避免影响已有 Dashboard JSON
- 本 PR 不删除交互数据结构，只是不在第一期 Dashboard 编辑 UI 暴露

### 2. 删除不必要的解释

删除右侧顶部这些说明性内容：

- `外观样式与图表交互`
- `这里只控制当前图表的视觉表现；字段、图表类型与分析逻辑统一在左侧完成。`

最终右侧直接以「渲染设置」作为标题，下面立即进入具体配置。

### 3. 提升字体和文字对比度

- 面板标题：14px / semibold / `#161823`
- 配置分组标题：12px / semibold / `#161823`
- 配置项：12px / `#344054`
- Select / InputNumber 文本统一提升到 12px
- 仅数值提示等次要信息保留较弱灰色

### 4. 调整右侧配置密度

- 配色块稍增高，提高辨识度
- 展示 / 坐标轴 / 柱形 / 折线等配置行增加轻微高度
- Select / InputNumber 最小高度统一为 30px
- 分组之间增加更稳定的纵向留白
- 底部「完成」按钮文字同步提升

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/config-style.tsx`

不修改：

- Dataset / Query
- AnalysisSpec / AnalysisEncoding
- Dashboard 数据模型
- 左侧字段与图表构建
- 图表渲染逻辑
- 交互历史数据结构

## Regression checklist

1. 右侧不再显示「交互」Tab
2. 右侧不再显示「样式」Tab 导航，直接进入样式配置
3. 顶部只显示「渲染设置」
4. 配色切换正常
5. 图例 / 标签配置正常
6. 坐标轴配置正常
7. 柱形 / 折线 / 饼图 / 指标卡 / 表格专属配置正常
8. Select / InputNumber / Switch 正常工作
9. 底部「完成」按钮正常
10. 已有交互数据不会因打开或保存图表而被清理

## Validation

当前执行容器无法解析 `github.com`，无法 clone 仓库运行完整 `npm run tsc` / `npm run build`。本次仅调整现有样式面板组件和 scoped CSS，没有修改业务协议；建议以本地页面视觉回归或 PR CI 作为最终验证。