### PR TITLE
refactor: add compact dashboard editor toolbar

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -73,27 +73,27 @@ export function DashboardToolbar({
   })();
 
   return (
-    <header className="flex h-14 shrink-0 items-center justify-between border-b border-[#e8eaee] bg-white px-4">
-      <div className="flex min-w-0 items-center gap-3">
-        <Tooltip title="退出编辑器">
-          <Button
-            type="text"
-            className="!flex !h-8 !w-8 !min-w-0 !items-center !justify-center !rounded-[7px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7] hover:!text-[#344054]"
-            icon={<ChevronLeft size={16} />}
-            disabled={preview || busy}
-            onClick={onBack}
-          />
-        </Tooltip>
-        <div className="h-7 w-px bg-[#eceef1]" />
-        <div className="min-w-0">
+    <header className="shrink-0 border-b border-[#e4e7ec] bg-white">
+      <div className="flex h-10 items-center justify-between px-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <Tooltip title="退出编辑器">
+            <Button
+              type="text"
+              className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[6px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7] hover:!text-[#344054]"
+              icon={<ChevronLeft size={15} />}
+              disabled={preview || busy}
+              onClick={onBack}
+            />
+          </Tooltip>
+          <div className="h-5 w-px bg-[#eceef1]" />
           <Input
             variant="borderless"
             value={name}
             disabled={preview || busy}
             onChange={(event) => onName(event.target.value)}
-            className="!h-6 !w-[280px] !px-0 !text-[14px] !font-semibold !leading-6 !text-[#161823]"
+            className="!h-6 !w-[250px] !px-0 !text-[13px] !font-semibold !leading-6 !text-[#161823]"
           />
-          <div className="mt-0.5 flex h-4 items-center gap-2 text-[10px] leading-4 text-[#98a2b3]">
+          <div className="hidden items-center gap-2 whitespace-nowrap text-[10px] text-[#8b929c] lg:flex">
             <span>{lifecycleText}</span>
             {dirty ? (
               <>
@@ -103,53 +103,104 @@ export function DashboardToolbar({
             ) : null}
           </div>
         </div>
-      </div>
-
-      <div className="flex items-center gap-1.5">
-        {!preview ? (
-          <>
-            <div className="mr-1 flex items-center rounded-[7px] bg-[#f6f7f8] p-0.5">
-              <Tooltip title="撤销 Ctrl/Cmd + Z">
-                <Button type="text" className="!h-7 !w-7 !min-w-0 !rounded-[6px] !p-0" icon={<Undo2 size={13} />} disabled={!canUndo || busy} onClick={onUndo} />
-              </Tooltip>
-              <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
-                <Button type="text" className="!h-7 !w-7 !min-w-0 !rounded-[6px] !p-0" icon={<Redo2 size={13} />} disabled={!canRedo || busy} onClick={onRedo} />
-              </Tooltip>
-            </div>
-            <Button size="small" className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3" disabled={!canAddChart || busy} icon={<BarChart3 size={13} />} onClick={onAddChart}>
-              添加图表
-            </Button>
-          </>
-        ) : null}
-
-        {persisted && currentVersionNo ? (
-          <Tooltip title="历史版本">
-            <Button type="text" className="!flex !h-8 !w-8 !min-w-0 !items-center !justify-center !rounded-[7px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7]" disabled={busy} icon={<History size={14} />} onClick={onHistory} />
-          </Tooltip>
-        ) : null}
-
-        <Button size="small" className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3" disabled={busy} icon={preview ? <X size={13} /> : <Eye size={13} />} onClick={onPreview}>
-          {preview ? '退出预览' : '预览'}
-        </Button>
 
         {!preview ? (
-          <>
+          <div className="flex items-center gap-1.5">
             <Tooltip title={saveDisabled ? '当前没有需要保存到草稿的修改' : '保存草稿 Ctrl/Cmd + S'}>
               <span>
-                <Button size="small" className="!h-8 !rounded-[7px] !border-[#e4e7ec] !px-3" loading={saving} disabled={saveDisabled || publishing} icon={<Save size={13} />} onClick={onSaveDraft}>
+                <Button
+                  size="small"
+                  className="!h-7 !rounded-[6px] !border-[#e4e7ec] !px-2.5 !text-[11px]"
+                  loading={saving}
+                  disabled={saveDisabled || publishing}
+                  icon={<Save size={12} />}
+                  onClick={onSaveDraft}
+                >
                   保存草稿
                 </Button>
               </span>
             </Tooltip>
             <Tooltip title={!canPublish ? '当前草稿已经是已发布版本' : undefined}>
               <span>
-                <Button size="small" type="primary" className="!h-8 !rounded-[7px] !px-3.5 !shadow-none" loading={publishing} disabled={!canPublish || saving} icon={<Send size={13} />} onClick={onPublish}>
+                <Button
+                  size="small"
+                  type="primary"
+                  className="!h-7 !rounded-[6px] !px-3 !text-[11px] !shadow-none"
+                  loading={publishing}
+                  disabled={!canPublish || saving}
+                  icon={<Send size={12} />}
+                  onClick={onPublish}
+                >
                   {hasPublishedVersion ? '发布更新' : '发布'}
                 </Button>
               </span>
             </Tooltip>
-          </>
+          </div>
         ) : null}
+      </div>
+
+      <div className="flex h-8 items-center justify-between border-t border-[#f0f1f3] bg-[#fbfcfd] px-3">
+        <div className="flex items-center gap-1">
+          {!preview ? (
+            <>
+              <Button
+                type="text"
+                size="small"
+                className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f0f2f5]"
+                disabled={!canAddChart || busy}
+                icon={<BarChart3 size={12} />}
+                onClick={onAddChart}
+              >
+                添加图表
+              </Button>
+              <div className="mx-1 h-4 w-px bg-[#e4e7ec]" />
+              <Tooltip title="撤销 Ctrl/Cmd + Z">
+                <Button
+                  type="text"
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f0f2f5] hover:!text-[#344054]"
+                  icon={<Undo2 size={12} />}
+                  disabled={!canUndo || busy}
+                  onClick={onUndo}
+                />
+              </Tooltip>
+              <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
+                <Button
+                  type="text"
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f0f2f5] hover:!text-[#344054]"
+                  icon={<Redo2 size={12} />}
+                  disabled={!canRedo || busy}
+                  onClick={onRedo}
+                />
+              </Tooltip>
+            </>
+          ) : (
+            <span className="text-[11px] font-medium text-[#667085]">预览模式</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1">
+          {persisted && currentVersionNo && !preview ? (
+            <Tooltip title="历史版本">
+              <Button
+                type="text"
+                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f0f2f5] hover:!text-[#344054]"
+                disabled={busy}
+                icon={<History size={12} />}
+                onClick={onHistory}
+              />
+            </Tooltip>
+          ) : null}
+          <Button
+            type="text"
+            size="small"
+            className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f0f2f5]"
+            disabled={busy}
+            icon={preview ? <X size={12} /> : <Eye size={12} />}
+            onClick={onPreview}
+          >
+            {preview ? '退出预览' : '预览'}
+          </Button>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Overview

参考 FineBI 的 Dashboard 编辑器顶部结构，将原本挤在单层 Header 中的编辑操作拆成「主栏 + 工具栏」两层，并整体压缩高度与按钮尺寸。

本 PR 只调整 Dashboard 顶部编辑器 Toolbar，不修改图表、Dataset、Sheet、渲染配置或后端模型。

## What changed

### 1. 顶部改成双层结构

主栏（40px）：

- 返回
- 仪表盘名称
- 草稿 / 发布版本状态
- 保存草稿
- 发布 / 发布更新

第二层工具栏（32px）：

- 添加图表
- 撤销
- 重做
- 历史版本
- 预览 / 退出预览

### 2. 主操作与编辑操作分层

- 保存 / 发布继续保持在右上角，作为生命周期主操作
- 添加图表、撤销、重做统一下移到编辑工具栏
- 历史版本、预览移动到工具栏右侧
- 不再把所有操作挤在一排

### 3. 整体更紧凑

- 原 Header 高度 56px，主栏压缩为 40px
- 工具栏高度 32px
- 常规 Button 统一收敛到 26~28px
- 图标缩小到 12~15px
- 圆角从偏大的 7px 收到 5~6px
- 去掉原撤销/重做的独立灰色胶囊容器
- 第二层使用非常浅的 `#fbfcfd` 背景和分隔线，不增加阴影

### 4. 仪表盘状态改为单行

- 仪表盘名称、版本状态、未保存状态放到同一主栏
- 不再使用两行标题 + 状态，从而降低顶部视觉高度
- 小屏时版本状态自动隐藏，避免挤压右侧操作

### 5. Preview 行为保持兼容

- 预览模式仍可正常退出
- 预览时不显示编辑操作和保存 / 发布
- 第二层工具栏显示轻量 `预览模式` 状态

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/toolbar.tsx`

不修改：

- Dashboard 数据模型
- 图表与 Dataset
- Sheet Bar
- Widget 拖拽 / resize
- 图表编辑器
- 右侧渲染设置
- 保存 / 发布业务逻辑

## Regression checklist

1. 返回 Dashboard 列表正常
2. 仪表盘名称仍可编辑
3. 草稿 / 发布版本状态正常显示
4. 添加图表正常
5. 撤销 / 重做正常
6. 历史版本 Drawer 正常
7. 预览 / 退出预览正常
8. 保存草稿正常
9. 发布 / 发布更新正常
10. loading / disabled 状态正常
11. 1366 / 1440 / 1920 宽度下顶部不拥挤

## Validation

分支基于当前最新 `main`，compare 结果为 ahead 1 / behind 0，且只有 `toolbar.tsx` 一个文件变化。当前 connector-only 环境未运行完整前端 build，建议以本地页面视觉回归或 PR CI 作为最终验证。