### PR TITLE
style: refine dashboard toolbar colors

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -73,32 +73,32 @@ export function DashboardToolbar({
   })();
 
   return (
-    <header className="shrink-0 border-b border-[#e4e7ec] bg-white">
-      <div className="flex h-10 items-center justify-between px-3">
+    <header className="shrink-0 border-b border-[#172138] bg-[#eef3f8]">
+      <div className="flex h-10 items-center justify-between border-b border-[#dce4ee] bg-[#eef3f8] px-3">
         <div className="flex min-w-0 items-center gap-2.5">
           <Tooltip title="退出编辑器">
             <Button
               type="text"
-              className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[6px] !p-0 !text-[#667085] hover:!bg-[#f5f6f7] hover:!text-[#344054]"
+              className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[6px] !p-0 !text-[#526075] hover:!bg-[#e1e8f1] hover:!text-[#1f2a44]"
               icon={<ChevronLeft size={15} />}
               disabled={preview || busy}
               onClick={onBack}
             />
           </Tooltip>
-          <div className="h-5 w-px bg-[#eceef1]" />
+          <div className="h-5 w-px bg-[#ccd6e2]" />
           <Input
             variant="borderless"
             value={name}
             disabled={preview || busy}
             onChange={(event) => onName(event.target.value)}
-            className="!h-6 !w-[250px] !px-0 !text-[13px] !font-semibold !leading-6 !text-[#161823]"
+            className="!h-6 !w-[250px] !bg-transparent !px-0 !text-[13px] !font-semibold !leading-6 !text-[#172033]"
           />
-          <div className="hidden items-center gap-2 whitespace-nowrap text-[10px] text-[#8b929c] lg:flex">
+          <div className="hidden items-center gap-2 whitespace-nowrap text-[10px] text-[#6f7d91] lg:flex">
             <span>{lifecycleText}</span>
             {dirty ? (
               <>
-                <span className="h-1 w-1 rounded-full bg-[#c2c6cc]" />
-                <span className="text-[#667085]">有未保存修改</span>
+                <span className="h-1 w-1 rounded-full bg-[#9ca9ba]" />
+                <span className="text-[#526075]">有未保存修改</span>
               </>
             ) : null}
           </div>
@@ -110,7 +110,7 @@ export function DashboardToolbar({
               <span>
                 <Button
                   size="small"
-                  className="!h-7 !rounded-[6px] !border-[#e4e7ec] !px-2.5 !text-[11px]"
+                  className="!h-7 !rounded-[6px] !border-[#cfd8e4] !bg-[rgba(255,255,255,.72)] !px-2.5 !text-[11px] !text-[#344054] hover:!border-[#bfcad8] hover:!bg-white"
                   loading={saving}
                   disabled={saveDisabled || publishing}
                   icon={<Save size={12} />}
@@ -139,25 +139,25 @@ export function DashboardToolbar({
         ) : null}
       </div>
 
-      <div className="flex h-8 items-center justify-between border-t border-[#f0f1f3] bg-[#fbfcfd] px-3">
+      <div className="flex h-8 items-center justify-between bg-[#1f2a44] px-3">
         <div className="flex items-center gap-1">
           {!preview ? (
             <>
               <Button
                 type="text"
                 size="small"
-                className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f0f2f5]"
+                className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#dbe5f2] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
                 disabled={!canAddChart || busy}
                 icon={<BarChart3 size={12} />}
                 onClick={onAddChart}
               >
                 添加图表
               </Button>
-              <div className="mx-1 h-4 w-px bg-[#e4e7ec]" />
+              <div className="mx-1 h-4 w-px bg-[#43506a]" />
               <Tooltip title="撤销 Ctrl/Cmd + Z">
                 <Button
                   type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f0f2f5] hover:!text-[#344054]"
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#b8c5d8] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
                   icon={<Undo2 size={12} />}
                   disabled={!canUndo || busy}
                   onClick={onUndo}
@@ -166,7 +166,7 @@ export function DashboardToolbar({
               <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
                 <Button
                   type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f0f2f5] hover:!text-[#344054]"
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#b8c5d8] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
                   icon={<Redo2 size={12} />}
                   disabled={!canRedo || busy}
                   onClick={onRedo}
@@ -174,7 +174,7 @@ export function DashboardToolbar({
               </Tooltip>
             </>
           ) : (
-            <span className="text-[11px] font-medium text-[#667085]">预览模式</span>
+            <span className="text-[11px] font-medium text-[#c7d2e3]">预览模式</span>
           )}
         </div>
 
@@ -183,7 +183,7 @@ export function DashboardToolbar({
             <Tooltip title="历史版本">
               <Button
                 type="text"
-                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f0f2f5] hover:!text-[#344054]"
+                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#b8c5d8] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
                 disabled={busy}
                 icon={<History size={12} />}
                 onClick={onHistory}
@@ -193,7 +193,7 @@ export function DashboardToolbar({
           <Button
             type="text"
             size="small"
-            className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f0f2f5]"
+            className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#dbe5f2] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
             disabled={busy}
             icon={preview ? <X size={12} /> : <Eye size={12} />}
             onClick={onPreview}


### PR DESCRIPTION
## Overview

继续优化 Dashboard 编辑器顶部双层工具栏的视觉层级。参考 FineBI 的编辑器配色，将顶部从大面积白色调整为「浅灰蓝主栏 + 深蓝灰工具栏」，同时保留 Yak Ops 自己的品牌红作为发布主操作色。

本 PR 只调整 Toolbar 配色，不修改布局结构、按钮行为、Dashboard 数据模型或编辑逻辑。

## What changed

### 1. 主栏改为浅灰蓝

- 顶部主栏背景从白色调整为 `#eef3f8`
- 分隔线改为偏冷的蓝灰色
- 返回按钮 hover 使用更轻的蓝灰背景
- 仪表盘名称保持深色高对比
- 草稿 / 发布状态文字同步调整为蓝灰文字

### 2. 第二层工具栏改为深蓝灰

- 编辑工具栏背景调整为 `#1f2a44`
- 添加图表、撤销、重做、历史版本、预览使用浅蓝灰文字/图标
- hover 时使用轻量半透明白色背景，并提升到白色文字
- 工具组分隔线改为深色工具栏内的弱分隔
- Preview 模式文字同步适配深色背景

### 3. 保留 Yak Ops 品牌主操作

- 「发布 / 发布更新」继续使用 Yak Ops 品牌红
- 不直接复制 FineBI 的蓝色主按钮
- 「保存草稿」改为半透明白底，使其在浅灰蓝主栏上更协调

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/toolbar.tsx`

不修改：

- Dashboard Toolbar 双层布局结构
- 保存 / 发布逻辑
- Undo / Redo / Preview / History 行为
- Sheet Bar
- 图表 / Dataset / Widget
- Dashboard 数据模型

## Regression checklist

1. 返回编辑器正常
2. 仪表盘名称编辑正常
3. 生命周期状态可读
4. 保存草稿按钮状态正常
5. 发布按钮仍使用品牌色并正常工作
6. 添加图表正常
7. 撤销 / 重做正常
8. 历史版本正常
9. 预览 / 退出预览正常
10. disabled / loading 状态仍清晰可辨

## Validation

分支基于当前最新 `main`，compare 为 ahead 1 / behind 0，仅 `toolbar.tsx` 一个文件变化，共 17 additions / 17 deletions。当前 connector-only 环境未执行完整前端 build，建议以本地视觉回归或 PR CI 作为最终验证。