### PR TITLE
style: use white dashboard editor toolbar

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -73,7 +73,7 @@ export function DashboardToolbar({
   })();
 
   return (
-    <header className="shrink-0 border-b border-[#172138] bg-[#eef3f8]">
+    <header className="shrink-0 border-b border-[#dce3ea] bg-[#eef3f8]">
       <div className="flex h-10 items-center justify-between border-b border-[#dce4ee] bg-[#eef3f8] px-3">
         <div className="flex min-w-0 items-center gap-2.5">
           <Tooltip title="退出编辑器">
@@ -139,25 +139,25 @@ export function DashboardToolbar({
         ) : null}
       </div>
 
-      <div className="flex h-8 items-center justify-between bg-[#1f2a44] px-3">
+      <div className="flex h-8 items-center justify-between bg-white px-3">
         <div className="flex items-center gap-1">
           {!preview ? (
             <>
               <Button
                 type="text"
                 size="small"
-                className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#dbe5f2] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
+                className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
                 disabled={!canAddChart || busy}
                 icon={<BarChart3 size={12} />}
                 onClick={onAddChart}
               >
                 添加图表
               </Button>
-              <div className="mx-1 h-4 w-px bg-[#43506a]" />
+              <div className="mx-1 h-4 w-px bg-[#e1e5ea]" />
               <Tooltip title="撤销 Ctrl/Cmd + Z">
                 <Button
                   type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#b8c5d8] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
                   icon={<Undo2 size={12} />}
                   disabled={!canUndo || busy}
                   onClick={onUndo}
@@ -166,7 +166,7 @@ export function DashboardToolbar({
               <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
                 <Button
                   type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#b8c5d8] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
                   icon={<Redo2 size={12} />}
                   disabled={!canRedo || busy}
                   onClick={onRedo}
@@ -174,7 +174,7 @@ export function DashboardToolbar({
               </Tooltip>
             </>
           ) : (
-            <span className="text-[11px] font-medium text-[#c7d2e3]">预览模式</span>
+            <span className="text-[11px] font-medium text-[#667085]">预览模式</span>
           )}
         </div>
 
@@ -183,7 +183,7 @@ export function DashboardToolbar({
             <Tooltip title="历史版本">
               <Button
                 type="text"
-                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#b8c5d8] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
+                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
                 disabled={busy}
                 icon={<History size={12} />}
                 onClick={onHistory}
@@ -193,7 +193,7 @@ export function DashboardToolbar({
           <Button
             type="text"
             size="small"
-            className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#dbe5f2] hover:!bg-[rgba(255,255,255,.09)] hover:!text-white"
+            className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
             disabled={busy}
             icon={preview ? <X size={12} /> : <Eye size={12} />}
             onClick={onPreview}


### PR DESCRIPTION
## Overview

继续收敛 Dashboard 编辑器顶部视觉，参考 FineBI 当前编辑器的层级：保留第一层浅灰蓝主栏，同时将第二层编辑工具栏调整为白色。

本 PR 只调整第二层工具栏的配色，不修改布局、按钮行为或 Dashboard 业务逻辑。

## What changed

- 第二层工具栏背景从深蓝灰改为白色
- 添加图表 / 撤销 / 重做 / 历史版本 / 预览恢复为深灰文字与图标
- hover 使用浅灰背景 `#f3f5f7`
- 工具组分隔线调整为轻量灰色
- Preview 模式文字同步恢复为深灰
- 顶部第一层浅灰蓝主栏继续保留
- 修正 Header 底部分隔线，去掉之前为深色工具栏准备的深色边框
- Yak Ops 品牌红发布按钮保持不变

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/toolbar.tsx`

不修改：

- 双层 Toolbar 布局
- Dashboard 数据模型
- 保存 / 发布逻辑
- Undo / Redo / Preview / History 行为
- Sheet Bar
- Widget / Dataset / 图表编辑器

## Validation

分支基于最新 `main`，compare 为 ahead 1 / behind 0，仅 1 个文件变化，共 9 additions / 9 deletions。建议以本地页面视觉回归或 PR CI 作为最终确认。