### PR TITLE
refactor: refine dashboard widget selection and resizing

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -379,7 +379,10 @@ export default function DashboardEditorPage() {
                       enabled: !designer.preview,
                       handle: '.dashboard-widget__drag-handle',
                     }}
-                    resizeConfig={{ enabled: !designer.preview }}
+                    resizeConfig={{
+                      enabled: !designer.preview,
+                      handles: ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'],
+                    }}
                     onLayoutChange={designer.updateLayout}
                   >
                     {designer.widgets.map((widget) => {

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -62,22 +62,15 @@ export function WidgetShell({
   return (
     <div
       className={[
-        'group relative h-full min-h-0 overflow-visible',
+        'group dashboard-widget relative h-full min-h-0 overflow-visible',
+        preview ? 'dashboard-widget--preview' : 'dashboard-widget--editable',
         !preview && selected ? 'dashboard-widget--selected' : '',
+        preview && activeSelection ? 'dashboard-widget--active' : '',
       ].join(' ')}
     >
       <div
         onMouseDown={onSelect}
-        className={[
-          'relative flex h-full min-h-0 flex-col overflow-hidden rounded-[9px] bg-white transition-[border-color,box-shadow] duration-150',
-          preview
-            ? activeSelection
-              ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
-              : 'border border-[#e7e9ed] shadow-[0_1px_2px_rgba(16,24,40,.03)]'
-            : selected
-              ? 'border border-[var(--yak-brand-color)] shadow-[0_0_0_2px_var(--yak-brand-color-soft),0_4px_12px_rgba(16,24,40,.05)]'
-              : 'border border-[#e4e7ec] shadow-[0_1px_2px_rgba(16,24,40,.025)] hover:border-[#d6dae0] hover:shadow-[0_4px_12px_rgba(16,24,40,.055)]',
-        ].join(' ')}
+        className="dashboard-widget__surface relative flex h-full min-h-0 flex-col overflow-hidden bg-white"
       >
         <div className="dashboard-widget__drag-handle flex h-10 shrink-0 cursor-move items-center px-3.5">
           {!preview ? (
@@ -220,8 +213,46 @@ export function WidgetShell({
       ) : null}
 
       <style>{`
+        .dashboard-widget__surface {
+          outline: 1px solid transparent;
+          outline-offset: -1px;
+          transition: outline-color 120ms ease;
+        }
+        .dashboard-widget--editable:not(.dashboard-widget--selected):hover .dashboard-widget__surface {
+          outline-color: #9aa7b8;
+          outline-style: dashed;
+        }
+        .dashboard-widget--selected .dashboard-widget__surface {
+          outline-color: var(--yak-brand-color);
+          outline-style: solid;
+        }
+        .dashboard-widget--preview.dashboard-widget--active .dashboard-widget__surface {
+          outline-color: var(--yak-brand-color);
+          outline-style: solid;
+        }
         .react-grid-item:has(> .dashboard-widget--selected) {
           z-index: 20;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle {
+          background-image: none !important;
+          opacity: 0;
+          transition: opacity 120ms ease;
+          z-index: 25;
+        }
+        .dashboard-grid-canvas .react-grid-item:has(> .dashboard-widget--selected) > .react-resizable-handle {
+          opacity: 1;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle::after {
+          content: '' !important;
+          position: absolute !important;
+          left: 7px !important;
+          top: 7px !important;
+          width: 6px !important;
+          height: 6px !important;
+          box-sizing: border-box !important;
+          border: 1px solid var(--yak-brand-color) !important;
+          background: #fff !important;
+          transform: none !important;
         }
       `}</style>
     </div>

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -158,7 +158,7 @@ export function WidgetShell({
 
       {!preview && selected ? (
         <div
-          className="absolute left-full top-0 z-30 ml-1.5 flex w-8 flex-col overflow-hidden rounded-[7px] border border-[#e4e7ec] bg-white shadow-[0_6px_18px_rgba(16,24,40,.12)]"
+          className="absolute left-full top-0 z-30 ml-3 flex w-8 flex-col overflow-hidden rounded-[7px] border border-[#e4e7ec] bg-white shadow-[0_6px_18px_rgba(16,24,40,.12)]"
           onMouseDown={(event) => event.stopPropagation()}
         >
           <Tooltip title="编辑图表" placement="right">
@@ -232,6 +232,9 @@ export function WidgetShell({
         }
         .react-grid-item:has(> .dashboard-widget--selected) {
           z-index: 20;
+        }
+        .dashboard-grid-canvas .react-grid-item.react-grid-placeholder {
+          border-radius: 0 !important;
         }
         .dashboard-grid-canvas .react-grid-item > .react-resizable-handle {
           background-image: none !important;


### PR DESCRIPTION
## Overview

参考 FineBI 的 Dashboard 组件编辑交互，收敛 Yak Ops 仪表盘组件的“卡片感”，并把 resize 从单一方向升级为四边与四角均可调整。

本 PR 只聚焦 Dashboard 画布组件的容器视觉、hover/选中反馈和 resize 交互，不修改图表数据、Dataset、Sheet、渲染设置或后端模型。

## What changed

### 1. 去掉组件默认卡片边框

- 默认状态不再显示 border
- 去掉组件 border-radius
- 去掉默认 shadow
- 图表以更直接的白色画布块呈现，减少卡片感

### 2. Hover / Selected 两层反馈

- 鼠标移入未选中组件：显示轻量灰蓝虚线轮廓
- 点击选中组件：切换为 Yak Ops 品牌色实线轮廓
- Preview 模式不显示编辑 hover 轮廓
- Preview 中已有数据选中态仍保留品牌色轮廓

### 3. 八方向 Resize

基于现有 `react-grid-layout` v2 API，启用：

- 上 / 下 / 左 / 右
- 左上 / 右上 / 左下 / 右下

即 `n / ne / e / se / s / sw / w / nw` 八个 resize handle。

用户选中图表后，可以从四周和四角直接拉长或缩短，不再只依赖右下角。

### 4. Resize 控制点视觉

- 未选中时隐藏 resize handle
- 选中后显示 8 个小型控制点
- 控制点采用白底 + Yak 品牌色描边
- 保留较大的透明命中区域，避免控制点视觉变小后难以拖动
- 拖拽 / resize 占位框同步取消圆角

### 5. 侧边工具条避让 Resize

- 现有编辑 / 复制 / 删除侧边工具条继续保留
- 将工具条与组件右侧的间距从 6px 调整到 12px
- 避免与右侧 / 右上 / 右下 resize handle 的鼠标命中区域重叠

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/editor.tsx`
- `yak-ops-ui/src/pages/dashboard/widget.tsx`

不修改：

- Dashboard 数据模型
- Widget 布局持久化协议
- Dataset / Query
- 图表编辑器
- Sheet Bar
- 顶部 Toolbar
- 右侧渲染设置

## Regression checklist

1. 默认组件无可见 border / radius / shadow
2. Hover 未选中组件显示虚线轮廓
3. 点击后显示实线选中轮廓
4. 选中组件显示 8 个 resize 控制点
5. 从上 / 下 / 左 / 右均可 resize
6. 从四个角均可 resize
7. resize 后布局仍通过现有 `onLayoutChange` 保存
8. 标题区拖拽移动仍正常
9. 编辑 / 复制 / 删除侧边工具条仍正常
10. 工具条不会遮挡右侧 resize handle
11. Preview 模式不出现编辑控制点
12. 图表内部交互与 Drill 行为不受影响

## Validation

- 分支基于当前 `main`，compare 为 `behind 0`
- 仅 2 个文件变化
- `editor.tsx` 仅增加八方向 resize 配置
- `widget.tsx` 仅调整组件容器状态和 resize handle 样式
- 当前 connector-only 环境无法运行完整前端 build，建议以本地拖拽/resize 视觉回归或 PR CI 作为最终确认

技术实现使用项目当前的 `react-grid-layout ^2.2.3` / `react-resizable ^4.0.1` 原生多方向 resize 能力，没有新增依赖。