### PR TITLE
style: refine dashboard resize handles

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -215,7 +215,7 @@ export function WidgetShell({
       <style>{`
         .dashboard-widget__surface {
           outline: 1px solid transparent;
-          outline-offset: -1px;
+          outline-offset: 0;
           transition: outline-color 120ms ease;
         }
         .dashboard-widget--editable:not(.dashboard-widget--selected):hover .dashboard-widget__surface {
@@ -237,10 +237,48 @@ export function WidgetShell({
           border-radius: 0 !important;
         }
         .dashboard-grid-canvas .react-grid-item > .react-resizable-handle {
+          width: 18px !important;
+          height: 18px !important;
           background-image: none !important;
           opacity: 0;
           transition: opacity 120ms ease;
           z-index: 25;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-n {
+          top: -9px !important;
+          left: 50% !important;
+          margin-left: -9px !important;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-s {
+          bottom: -9px !important;
+          left: 50% !important;
+          margin-left: -9px !important;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-e {
+          right: -9px !important;
+          top: 50% !important;
+          margin-top: -9px !important;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-w {
+          left: -9px !important;
+          top: 50% !important;
+          margin-top: -9px !important;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-ne {
+          right: -9px !important;
+          top: -9px !important;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-nw {
+          left: -9px !important;
+          top: -9px !important;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-se {
+          right: -9px !important;
+          bottom: -9px !important;
+        }
+        .dashboard-grid-canvas .react-grid-item > .react-resizable-handle-sw {
+          left: -9px !important;
+          bottom: -9px !important;
         }
         .dashboard-grid-canvas .react-grid-item:has(> .dashboard-widget--selected) > .react-resizable-handle {
           opacity: 1;
@@ -248,13 +286,13 @@ export function WidgetShell({
         .dashboard-grid-canvas .react-grid-item > .react-resizable-handle::after {
           content: '' !important;
           position: absolute !important;
-          left: 7px !important;
-          top: 7px !important;
+          left: 6px !important;
+          top: 6px !important;
           width: 6px !important;
           height: 6px !important;
-          box-sizing: border-box !important;
-          border: 1px solid var(--yak-brand-color) !important;
-          background: #fff !important;
+          border: 0 !important;
+          border-radius: 9999px !important;
+          background: var(--yak-brand-color) !important;
           transform: none !important;
         }
       `}</style>


### PR DESCRIPTION
## Overview

继续优化 Dashboard 组件选中态的 resize 控制点视觉，使其更接近 FineBI：选中边框是一条连续实线，8 个 resize 控制点改为实心圆，并准确压在线上。

本 PR 只调整 `WidgetShell` 中 resize handle 的视觉和定位，不修改八方向 resize 能力、拖拽逻辑、布局持久化或其它 Dashboard 功能。

## What changed

- 选中轮廓移动到组件真实边界，不再向内缩 1px
- 8 个 resize handle 继续保留较大的透明命中区域
- 视觉控制点改为 6px 实心品牌色圆点
- 去掉白底与描边，不再呈现空心小方块/菱形感
- 分别校准 `n / s / e / w / ne / nw / se / sw` 的位置，让圆点中心与选中实线重合
- Hover 虚线、右侧编辑/复制/删除工具条、八方向 resize 行为保持不变

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/widget.tsx`

不修改：

- `editor.tsx` 中八方向 resize 配置
- Dashboard 数据模型
- Widget 布局保存协议
- Dataset / 图表编辑器 / Sheet / Toolbar

## Validation

- 基于当前最新 `main`
- compare 为 ahead 1 / behind 0
- 仅 1 个文件变化
- 建议本地重点回归选中态 8 个控制点的位置，以及四边/四角 resize 命中区域