### PR TITLE
style: improve dashboard toolbar readability

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -146,9 +146,9 @@ export function DashboardToolbar({
               <Button
                 type="text"
                 size="small"
-                className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+                className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
                 disabled={!canAddChart || busy}
-                icon={<BarChart3 size={12} />}
+                icon={<BarChart3 size={13} />}
                 onClick={onAddChart}
               >
                 添加图表
@@ -157,8 +157,8 @@ export function DashboardToolbar({
               <Tooltip title="撤销 Ctrl/Cmd + Z">
                 <Button
                   type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
-                  icon={<Undo2 size={12} />}
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
+                  icon={<Undo2 size={13} />}
                   disabled={!canUndo || busy}
                   onClick={onUndo}
                 />
@@ -166,26 +166,45 @@ export function DashboardToolbar({
               <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
                 <Button
                   type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
-                  icon={<Redo2 size={12} />}
+                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
+                  icon={<Redo2 size={13} />}
                   disabled={!canRedo || busy}
                   onClick={onRedo}
                 />
               </Tooltip>
             </>
           ) : (
-            <span className="text-[11px] font-medium text-[#667085]">预览模式</span>
+            <span className="text-[12px] font-medium text-[#161823]">预览模式</span>
           )}
         </div>
 
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-3">
+          {!preview ? (
+            <>
+              <a
+                href="#"
+                className="text-[12px] font-medium text-[#161823] no-underline transition-colors hover:text-[var(--yak-brand-color)]"
+                onClick={(event) => event.preventDefault()}
+              >
+                仪表盘样式
+              </a>
+              <a
+                href="#"
+                className="text-[12px] font-medium text-[#161823] no-underline transition-colors hover:text-[var(--yak-brand-color)]"
+                onClick={(event) => event.preventDefault()}
+              >
+                性能分析
+              </a>
+            </>
+          ) : null}
+
           {persisted && currentVersionNo && !preview ? (
             <Tooltip title="历史版本">
               <Button
                 type="text"
-                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#667085] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#344054] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
                 disabled={busy}
-                icon={<History size={12} />}
+                icon={<History size={13} />}
                 onClick={onHistory}
               />
             </Tooltip>
@@ -193,9 +212,9 @@ export function DashboardToolbar({
           <Button
             type="text"
             size="small"
-            className="!h-7 !rounded-[5px] !px-2 !text-[11px] !text-[#344054] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+            className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
             disabled={busy}
-            icon={preview ? <X size={12} /> : <Eye size={12} />}
+            icon={preview ? <X size={13} /> : <Eye size={13} />}
             onClick={onPreview}
           >
             {preview ? '退出预览' : '预览'}


### PR DESCRIPTION
## Overview

继续优化 Dashboard 第二层工具栏的可读性与信息层级。本 PR 只调整工具栏字号、颜色与右侧轻量入口，不修改任何 Dashboard 业务逻辑。

## What changed

- 第二层工具栏主要文字从 11px 提升到 12px
- 添加图表 / 撤销 / 重做改用 Yak Ops 品牌主色
- 左侧图标同步从 12px 提升到 13px
- 右侧预览与历史入口颜色加深，更接近 `#161823 / #344054`
- Preview 模式文字同步提升到 12px 并加深
- 右侧新增两个纯 `<a>` 文本入口：`仪表盘样式`、`性能分析`
- 两个新入口不使用 Button，不显示边框或背景；hover 时仅切换为品牌主色
- 新入口当前仅作为第一期视觉入口，不提前接业务功能

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/toolbar.tsx`

不修改：

- Dashboard 数据模型
- 保存 / 发布 / Undo / Redo / Preview / History 行为
- Widget / Sheet / Dataset / 图表编辑器
- 顶部第一层主栏布局

## Validation

- 基于最新 `main`
- compare 为 ahead 1 / behind 0
- 仅 1 个文件变化
- 建议本地重点回归第二层工具栏在普通编辑态、禁用态和 Preview 模式下的可读性