### PR TITLE
style: align dashboard toolbar utility actions

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -3,7 +3,9 @@ import {
   BarChart3,
   ChevronLeft,
   Eye,
+  Gauge,
   History,
+  Palette,
   Redo2,
   Save,
   Send,
@@ -178,23 +180,25 @@ export function DashboardToolbar({
           )}
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1">
           {!preview ? (
             <>
-              <a
-                href="#"
-                className="text-[12px] font-medium text-[#161823] no-underline transition-colors hover:text-[var(--yak-brand-color)]"
-                onClick={(event) => event.preventDefault()}
+              <Button
+                type="text"
+                size="small"
+                className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+                icon={<Palette size={13} />}
               >
                 仪表盘样式
-              </a>
-              <a
-                href="#"
-                className="text-[12px] font-medium text-[#161823] no-underline transition-colors hover:text-[var(--yak-brand-color)]"
-                onClick={(event) => event.preventDefault()}
+              </Button>
+              <Button
+                type="text"
+                size="small"
+                className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+                icon={<Gauge size={13} />}
               >
                 性能分析
-              </a>
+              </Button>
             </>
           ) : null}
 


### PR DESCRIPTION
## Overview

继续收敛 Dashboard 第二层工具栏的视觉一致性：将 `仪表盘样式` 和 `性能分析` 从纯 `<a>` 文本入口改成与 `预览` 相同的轻量工具按钮，并补充对应图标。

## What changed

- 移除 `仪表盘样式` / `性能分析` 的 `<a>` 展示
- 两个入口改为 AntD `Button type="text"`
- 视觉样式与右侧 `预览` 保持一致：12px 字号、深色文字、浅灰 hover
- `仪表盘样式` 使用 `Palette` 图标
- `性能分析` 使用 `Gauge` 图标
- 保留 #510 已有的左侧品牌主色、字号和工具栏结构
- 两个入口暂时只完成视觉入口，不提前接业务功能

## Scope

仅修改：

- `yak-ops-ui/src/pages/dashboard/toolbar.tsx`

不修改 Dashboard 保存、发布、预览、历史版本、Undo/Redo 或其它业务逻辑。

## Validation

- 基于最新 `main`
- compare 为 ahead 1 / behind 0
- 仅 1 个文件变化