### PR TITLE
feat: add dashboard theme foundation

### DIFF
--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
@@ -91,6 +91,16 @@ record DashboardDetail(
     List<DashboardWidgetSnapshot> widgets,
     List<DashboardGlobalFilterSnapshot> globalFilters,
     List<DashboardInteractionSnapshot> interactions) {
+
+  DashboardDetail(
+      DashboardAsset dashboard,
+      DashboardVersion currentVersion,
+      List<DashboardVersion> versions,
+      List<DashboardWidgetSnapshot> widgets,
+      List<DashboardGlobalFilterSnapshot> globalFilters,
+      List<DashboardInteractionSnapshot> interactions) {
+    this(dashboard, currentVersion, null, versions, widgets, globalFilters, interactions);
+  }
 }
 
 /** Exact immutable version snapshot, used for history preview and published reads. */
@@ -101,4 +111,13 @@ record DashboardVersionDetail(
     List<DashboardWidgetSnapshot> widgets,
     List<DashboardGlobalFilterSnapshot> globalFilters,
     List<DashboardInteractionSnapshot> interactions) {
+
+  DashboardVersionDetail(
+      DashboardAsset dashboard,
+      DashboardVersion version,
+      List<DashboardWidgetSnapshot> widgets,
+      List<DashboardGlobalFilterSnapshot> globalFilters,
+      List<DashboardInteractionSnapshot> interactions) {
+    this(dashboard, version, null, widgets, globalFilters, interactions);
+  }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardAsset.java
@@ -86,6 +86,7 @@ record DashboardInteractionSnapshot(
 record DashboardDetail(
     DashboardAsset dashboard,
     DashboardVersion currentVersion,
+    Object theme,
     List<DashboardVersion> versions,
     List<DashboardWidgetSnapshot> widgets,
     List<DashboardGlobalFilterSnapshot> globalFilters,
@@ -96,6 +97,7 @@ record DashboardDetail(
 record DashboardVersionDetail(
     DashboardAsset dashboard,
     DashboardVersion version,
+    Object theme,
     List<DashboardWidgetSnapshot> widgets,
     List<DashboardGlobalFilterSnapshot> globalFilters,
     List<DashboardInteractionSnapshot> interactions) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardController.java
@@ -1,5 +1,8 @@
 package io.yak.ops.business.dashboard;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
@@ -10,6 +13,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,10 +27,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/dashboards")
 public class DashboardController {
 
-  private final DashboardService service;
+  private static final int MAX_THEME_JSON = 16000;
 
-  public DashboardController(DashboardService service) {
+  private final DashboardService service;
+  private final DashboardThemeRepository themeRepository;
+  private final ObjectMapper objectMapper;
+
+  public DashboardController(
+      DashboardService service,
+      DashboardThemeRepository themeRepository,
+      ObjectMapper objectMapper) {
     this.service = service;
+    this.themeRepository = themeRepository;
+    this.objectMapper = objectMapper;
   }
 
   @Operation(summary = "查询 Dashboard 列表")
@@ -38,7 +51,7 @@ public class DashboardController {
   @Operation(summary = "查询 Dashboard 当前草稿和历史版本")
   @GetMapping("/{dashboardId}")
   public Result<DashboardDetail> get(@PathVariable("dashboardId") long dashboardId) {
-    return Result.success(service.get(dashboardId));
+    return Result.success(withTheme(service.get(dashboardId)));
   }
 
   @Operation(summary = "查询 Dashboard 版本历史")
@@ -52,50 +65,62 @@ public class DashboardController {
   public Result<DashboardVersionDetail> version(
       @PathVariable("dashboardId") long dashboardId,
       @PathVariable("versionNo") int versionNo) {
-    return Result.success(service.version(dashboardId, versionNo));
+    return Result.success(withTheme(service.version(dashboardId, versionNo)));
   }
 
   @Operation(summary = "查询 Dashboard 当前已发布快照")
   @GetMapping("/{dashboardId}/published")
   public Result<DashboardVersionDetail> published(@PathVariable("dashboardId") long dashboardId) {
-    return Result.success(service.published(dashboardId));
+    return Result.success(withTheme(service.published(dashboardId)));
   }
 
   @Operation(summary = "创建 Dashboard，并保存草稿 V1")
   @PostMapping
+  @Transactional("yakBusinessTransactionManager")
   public Result<DashboardDetail> create(@Valid @RequestBody SaveDashboardRequest request) {
-    return Result.success(service.create(toCommand(request)));
+    DashboardDetail detail = service.create(toCommand(request));
+    persistTheme(detail.dashboard().currentVersionId(), request.theme());
+    return Result.success(withTheme(detail));
   }
 
   @Operation(summary = "保存 Dashboard 新草稿版本")
   @PostMapping("/{dashboardId}/versions")
+  @Transactional("yakBusinessTransactionManager")
   public Result<DashboardDetail> saveVersion(
       @PathVariable("dashboardId") long dashboardId,
       @Valid @RequestBody SaveDashboardRequest request) {
-    return Result.success(service.saveVersion(dashboardId, toCommand(request)));
+    DashboardDetail detail = service.saveVersion(dashboardId, toCommand(request));
+    persistTheme(detail.dashboard().currentVersionId(), request.theme());
+    return Result.success(withTheme(detail));
   }
 
   @Operation(summary = "发布当前 Dashboard 草稿")
   @PostMapping("/{dashboardId}/publish")
   public Result<DashboardDetail> publish(@PathVariable("dashboardId") long dashboardId) {
-    return Result.success(service.publish(dashboardId));
+    return Result.success(withTheme(service.publish(dashboardId)));
   }
 
   @Operation(summary = "将历史 DashboardVersion 恢复为新的草稿版本")
   @PostMapping("/{dashboardId}/restore/{versionNo}")
+  @Transactional("yakBusinessTransactionManager")
   public Result<DashboardDetail> restoreVersion(
       @PathVariable("dashboardId") long dashboardId,
       @PathVariable("versionNo") int versionNo) {
-    return Result.success(service.restoreVersion(dashboardId, versionNo));
+    DashboardVersionDetail source = service.version(dashboardId, versionNo);
+    Object sourceTheme = themeRepository.find(source.version().id());
+    DashboardDetail restored = service.restoreVersion(dashboardId, versionNo);
+    persistTheme(restored.dashboard().currentVersionId(), sourceTheme);
+    return Result.success(withTheme(restored));
   }
 
   @Deprecated
   @Operation(summary = "兼容旧版激活接口：恢复历史版本为新草稿")
   @PostMapping("/{dashboardId}/activate/{versionNo}")
+  @Transactional("yakBusinessTransactionManager")
   public Result<DashboardDetail> activateVersion(
       @PathVariable("dashboardId") long dashboardId,
       @PathVariable("versionNo") int versionNo) {
-    return Result.success(service.activateVersion(dashboardId, versionNo));
+    return restoreVersion(dashboardId, versionNo);
   }
 
   @Operation(summary = "删除 Dashboard 及其历史版本")
@@ -103,6 +128,46 @@ public class DashboardController {
   public Result<Boolean> delete(@PathVariable("dashboardId") long dashboardId) {
     service.delete(dashboardId);
     return Result.success(Boolean.TRUE);
+  }
+
+  private DashboardDetail withTheme(DashboardDetail detail) {
+    Object theme = detail.currentVersion() == null ? null : themeRepository.find(detail.currentVersion().id());
+    return new DashboardDetail(
+        detail.dashboard(),
+        detail.currentVersion(),
+        theme,
+        detail.versions(),
+        detail.widgets(),
+        detail.globalFilters(),
+        detail.interactions());
+  }
+
+  private DashboardVersionDetail withTheme(DashboardVersionDetail detail) {
+    return new DashboardVersionDetail(
+        detail.dashboard(),
+        detail.version(),
+        themeRepository.find(detail.version().id()),
+        detail.widgets(),
+        detail.globalFilters(),
+        detail.interactions());
+  }
+
+  private void persistTheme(Long versionId, Object theme) {
+    if (versionId == null) throw new IllegalStateException("Dashboard 当前草稿版本不存在");
+    themeRepository.save(versionId, themeJson(theme));
+  }
+
+  private String themeJson(Object theme) {
+    if (theme == null) return null;
+    JsonNode node = objectMapper.valueToTree(theme);
+    if (!node.isObject()) throw new IllegalArgumentException("Dashboard Theme 必须是 JSON 对象");
+    try {
+      String json = objectMapper.writeValueAsString(theme);
+      if (json.length() > MAX_THEME_JSON) throw new IllegalArgumentException("Dashboard Theme 配置过大");
+      return json;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("Dashboard Theme 无法序列化", exception);
+    }
   }
 
   private DashboardService.SaveCommand toCommand(SaveDashboardRequest request) {
@@ -133,6 +198,7 @@ public class DashboardController {
       @NotBlank @Size(max = 200) String name,
       @Size(max = 2000) String description,
       @Min(1) Long activeDatasetId,
+      Object theme,
       @Size(max = 200) List<@Valid WidgetRequest> widgets,
       @Size(max = 20) List<@Valid GlobalFilterRequest> globalFilters,
       @Size(max = 100) List<@Valid InteractionRequest> interactions) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardThemeRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardThemeRepository.java
@@ -1,0 +1,6 @@
+package io.yak.ops.business.dashboard;
+
+interface DashboardThemeRepository {
+  void save(long versionId, String themeJson);
+  Object find(long versionId);
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardThemeRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardThemeRepository.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.dashboard;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@DependsOn("yakDashboardFlyway")
+@ConditionalOnDataSourceEnabled
+class JdbcDashboardThemeRepository implements DashboardThemeRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+
+  JdbcDashboardThemeRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ObjectMapper objectMapper) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void save(long versionId, String themeJson) {
+    int updated = jdbcTemplate.update(
+        "UPDATE yak_dashboard_version SET theme_json = ? WHERE id = ?",
+        themeJson,
+        versionId);
+    if (updated != 1) throw new IllegalArgumentException("DashboardVersion 不存在：" + versionId);
+  }
+
+  @Override
+  public Object find(long versionId) {
+    String json = jdbcTemplate.query(
+        "SELECT theme_json FROM yak_dashboard_version WHERE id = ? LIMIT 1",
+        rs -> rs.next() ? rs.getString("theme_json") : null,
+        versionId);
+    if (json == null || json.isBlank()) return null;
+    try {
+      return objectMapper.readValue(json, Object.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Dashboard Theme JSON 反序列化失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V4__dashboard_theme_snapshot.sql
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V4__dashboard_theme_snapshot.sql
@@ -1,0 +1,3 @@
+-- Dashboard theme is part of the immutable version snapshot so draft, publish and restore stay consistent.
+ALTER TABLE yak_dashboard_version
+    ADD COLUMN theme_json JSON NULL AFTER active_dataset_id;

--- a/yak-ops-ui/src/pages/dashboard/dashboard-integrity.test.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-integrity.test.ts
@@ -51,6 +51,32 @@ const baseDocument = (): DashboardDocument => ({
 });
 
 describe('dashboard integrity', () => {
+  it('defaults legacy snapshots to the light dashboard theme', () => {
+    const normalized = normalizeDashboardDocument(baseDocument());
+
+    expect(normalized.theme).toEqual({
+      presetId: 'yak-light',
+      canvas: undefined,
+      component: undefined,
+      chart: undefined,
+    });
+  });
+
+  it('preserves supported dashboard theme overrides', () => {
+    const document = baseDocument();
+    document.theme = {
+      presetId: 'yak-dark',
+      canvas: { backgroundColor: '#101828' },
+      chart: { palette: ['#35d0ff', '#8b5cf6'] },
+    };
+
+    const normalized = normalizeDashboardDocument(document);
+
+    expect(normalized.theme?.presetId).toBe('yak-dark');
+    expect(normalized.theme?.canvas?.backgroundColor).toBe('#101828');
+    expect(normalized.theme?.chart?.palette).toEqual(['#35d0ff', '#8b5cf6']);
+  });
+
   it('drops stale references and duplicate semantic links', () => {
     const document = baseDocument();
     document.widgets[0].inlineAnalysis!.dashboardBehavior = {

--- a/yak-ops-ui/src/pages/dashboard/dashboard-integrity.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-integrity.ts
@@ -1,3 +1,4 @@
+import { normalizeDashboardTheme } from './dashboard-theme';
 import type {
   DashboardCrossFilterRule,
   DashboardDocument,
@@ -120,6 +121,7 @@ export const normalizeDashboardDocument = (document: DashboardDocument): Dashboa
   return {
     ...document,
     version: 1,
+    theme: normalizeDashboardTheme(document.theme),
     widgets: normalizedWidgets,
     globalFilters,
     interactions,

--- a/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-service.ts
@@ -9,6 +9,7 @@ import type {
   DashboardInteraction,
   DashboardServerDetail,
   DashboardSummary,
+  DashboardTheme,
   DashboardVersionDetail,
   DashboardVersionSummary,
   DashboardWidget,
@@ -77,6 +78,7 @@ interface DashboardInteractionWire {
 interface DashboardDetailWire {
   dashboard: DashboardAssetWire;
   currentVersion?: DashboardVersionWire | null;
+  theme?: DashboardTheme | null;
   versions: DashboardVersionWire[];
   widgets: DashboardWidgetWire[];
   globalFilters?: DashboardGlobalFilterWire[];
@@ -86,6 +88,7 @@ interface DashboardDetailWire {
 interface DashboardVersionDetailWire {
   dashboard: DashboardAssetWire;
   version: DashboardVersionWire;
+  theme?: DashboardTheme | null;
   widgets: DashboardWidgetWire[];
   globalFilters?: DashboardGlobalFilterWire[];
   interactions?: DashboardInteractionWire[];
@@ -176,6 +179,7 @@ const interaction = (value: DashboardInteractionWire): DashboardInteraction => (
 export const toDashboardServerDetail = (value: DashboardDetailWire): DashboardServerDetail => ({
   dashboard: summary(value.dashboard),
   currentVersion: value.currentVersion ? version(value.currentVersion) : undefined,
+  theme: value.theme || undefined,
   versions: (value.versions || []).map(version),
   widgets: (value.widgets || []).map(widget),
   globalFilters: (value.globalFilters || []).map(globalFilter),
@@ -191,6 +195,7 @@ const toDashboardVersionDetail = (value: DashboardVersionDetailWire): DashboardV
     name: versionDetail.name,
     description: versionDetail.description,
     activeDatasetId: versionDetail.activeDatasetId || '',
+    theme: value.theme || undefined,
     widgets: (value.widgets || []).map(widget),
     globalFilters: (value.globalFilters || []).map(globalFilter),
     interactions: (value.interactions || []).map(interaction),
@@ -204,6 +209,7 @@ const toDashboardVersionDetail = (value: DashboardVersionDetailWire): DashboardV
   return {
     dashboard,
     version: versionDetail,
+    theme: normalized.theme,
     widgets: normalized.widgets,
     globalFilters: normalized.globalFilters,
     interactions: normalized.interactions,
@@ -216,6 +222,7 @@ export const toDashboardDocument = (detail: DashboardServerDetail): DashboardDoc
   name: detail.currentVersion?.name || detail.dashboard.name,
   description: detail.currentVersion?.description || detail.dashboard.description,
   activeDatasetId: detail.currentVersion?.activeDatasetId || '',
+  theme: detail.theme,
   widgets: detail.widgets,
   globalFilters: detail.globalFilters,
   interactions: detail.interactions,
@@ -233,6 +240,7 @@ const payload = (document: DashboardDocument) => {
     name: normalized.name,
     description: normalized.description || undefined,
     activeDatasetId: normalized.activeDatasetId || undefined,
+    theme: normalized.theme,
     widgets: normalized.widgets.map((item) => ({
       widgetKey: item.id,
       analysisId: item.analysisId,

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme-drawer.tsx
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme-drawer.tsx
@@ -1,0 +1,138 @@
+import { Button, Drawer } from 'antd';
+import { Check, Moon, Sun } from 'lucide-react';
+import {
+  DASHBOARD_THEME_PRESETS,
+  resolveDashboardTheme,
+  themeFromPreset,
+} from './dashboard-theme';
+import type { DashboardTheme, DashboardThemePresetId } from './model';
+
+const ThemePreview = ({ presetId }: { presetId: DashboardThemePresetId }) => {
+  const theme = resolveDashboardTheme(themeFromPreset(presetId));
+  const dark = presetId === 'yak-dark';
+  return (
+    <div
+      className="h-[86px] overflow-hidden border border-[#e5e7eb]"
+      style={{ backgroundColor: theme.canvas.backgroundColor }}
+    >
+      <div className="grid h-full grid-cols-[1.15fr_.85fr] gap-2 p-2.5">
+        <div className="flex flex-col gap-2">
+          <div
+            className="h-6 border border-black/[.04]"
+            style={{ backgroundColor: theme.component.backgroundColor }}
+          >
+            <div className="flex h-full items-end gap-1 px-2 pb-1.5">
+              {[14, 20, 10, 24, 17].map((height, index) => (
+                <span
+                  key={index}
+                  className="w-2"
+                  style={{
+                    height,
+                    backgroundColor: theme.chart.palette[index % theme.chart.palette.length],
+                    opacity: dark ? 0.9 : 0.78,
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+          <div
+            className="flex min-h-0 flex-1 items-center px-2"
+            style={{ backgroundColor: theme.component.backgroundColor }}
+          >
+            <div className="w-full space-y-1.5">
+              <div className="h-1 w-[78%] bg-[#d8dde5]" />
+              <div className="h-1 w-[56%] bg-[#e5e9ef]" />
+            </div>
+          </div>
+        </div>
+        <div
+          className="flex flex-col justify-between p-2"
+          style={{ backgroundColor: theme.component.backgroundColor }}
+        >
+          <div className="h-1 w-10 bg-[#d8dde5]" />
+          <div>
+            <div
+              className="text-[14px] font-semibold leading-none"
+              style={{ color: theme.component.textColor }}
+            >
+              86.4%
+            </div>
+            <div className="mt-1.5 h-1 w-8 bg-[#e5e9ef]" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export function DashboardThemeDrawer({
+  open,
+  theme,
+  onChange,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean;
+  theme?: DashboardTheme;
+  onChange: (theme: DashboardTheme) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const selectedId = resolveDashboardTheme(theme).presetId;
+
+  return (
+    <Drawer
+      title={<span className="text-[14px] font-semibold text-[#161823]">仪表盘样式</span>}
+      width={376}
+      open={open}
+      onClose={onCancel}
+      mask={false}
+      destroyOnClose={false}
+      styles={{
+        header: { padding: '12px 16px', minHeight: 48 },
+        body: { padding: 16, background: '#fff' },
+        footer: { padding: '10px 16px' },
+      }}
+      footer={(
+        <div className="flex justify-end gap-2">
+          <Button size="small" className="!h-8 !px-4" onClick={onCancel}>取消</Button>
+          <Button size="small" type="primary" className="!h-8 !px-4 !shadow-none" onClick={onConfirm}>
+            确定
+          </Button>
+        </div>
+      )}
+    >
+      <div className="mb-3 text-[12px] font-semibold text-[#344054]">预设主题</div>
+      <div className="grid grid-cols-2 gap-3">
+        {DASHBOARD_THEME_PRESETS.map((preset) => {
+          const selected = selectedId === preset.presetId;
+          const Icon = preset.presetId === 'yak-dark' ? Moon : Sun;
+          return (
+            <button
+              key={preset.presetId}
+              type="button"
+              className={[
+                'relative overflow-hidden border bg-white p-0 text-left transition-colors',
+                selected
+                  ? 'border-[var(--yak-brand-color)]'
+                  : 'border-[#e4e7ec] hover:border-[#c8ced8]',
+              ].join(' ')}
+              onClick={() => onChange(themeFromPreset(preset.presetId))}
+            >
+              <ThemePreview presetId={preset.presetId} />
+              <div className="flex h-9 items-center gap-1.5 px-2.5">
+                <Icon size={13} className={selected ? 'text-[var(--yak-brand-color)]' : 'text-[#667085]'} />
+                <span className="text-[12px] font-medium text-[#344054]">{preset.name}</span>
+              </div>
+              {selected ? (
+                <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--yak-brand-color)] text-white">
+                  <Check size={12} strokeWidth={2.4} />
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
@@ -41,11 +41,9 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
     presetId: 'yak-dark',
     name: '深色主题',
     canvas: { backgroundColor: '#161d2b' },
-    // Phase 1 deliberately keeps chart cards light. Phase 2 will make charts/tables consume
-    // the full dashboard palette so the entire component surface can become dark safely.
     component: {
-      backgroundColor: '#ffffff',
-      textColor: '#273142',
+      backgroundColor: '#222b3a',
+      textColor: '#f1f5f9',
     },
     chart: {
       palette: ['#35d0ff', '#5b8cff', '#8b5cf6', '#2dd4bf', '#fbbf24'],

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
@@ -1,0 +1,100 @@
+import type {
+  DashboardTheme,
+  DashboardThemePresetId,
+} from './model';
+
+export interface ResolvedDashboardTheme {
+  presetId: DashboardThemePresetId;
+  name: string;
+  canvas: {
+    backgroundColor: string;
+  };
+  component: {
+    backgroundColor: string;
+    textColor: string;
+  };
+  chart: {
+    palette: string[];
+    textColor: string;
+    axisColor: string;
+    gridColor: string;
+  };
+}
+
+export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
+  {
+    presetId: 'yak-light',
+    name: '默认亮色',
+    canvas: { backgroundColor: '#f3f4f6' },
+    component: {
+      backgroundColor: '#ffffff',
+      textColor: '#344054',
+    },
+    chart: {
+      palette: ['#fe2c55', '#5b8ff9', '#61d9a5', '#f6bd16', '#7262fd'],
+      textColor: '#475467',
+      axisColor: '#98a2b3',
+      gridColor: '#eaecf0',
+    },
+  },
+  {
+    presetId: 'yak-dark',
+    name: '深色主题',
+    canvas: { backgroundColor: '#161d2b' },
+    // Phase 1 deliberately keeps chart cards light. Phase 2 will make charts/tables consume
+    // the full dashboard palette so the entire component surface can become dark safely.
+    component: {
+      backgroundColor: '#ffffff',
+      textColor: '#273142',
+    },
+    chart: {
+      palette: ['#35d0ff', '#5b8cff', '#8b5cf6', '#2dd4bf', '#fbbf24'],
+      textColor: '#d6deea',
+      axisColor: '#718096',
+      gridColor: '#2b364a',
+    },
+  },
+];
+
+const presetById = (presetId?: DashboardThemePresetId) => (
+  DASHBOARD_THEME_PRESETS.find((item) => item.presetId === presetId)
+  ?? DASHBOARD_THEME_PRESETS[0]
+);
+
+export const normalizeDashboardTheme = (theme?: DashboardTheme): DashboardTheme => ({
+  presetId: theme?.presetId === 'yak-dark' ? 'yak-dark' : 'yak-light',
+  canvas: theme?.canvas ? { ...theme.canvas } : undefined,
+  component: theme?.component ? { ...theme.component } : undefined,
+  chart: theme?.chart ? {
+    ...theme.chart,
+    palette: theme.chart.palette ? [...theme.chart.palette] : undefined,
+  } : undefined,
+});
+
+export const resolveDashboardTheme = (theme?: DashboardTheme): ResolvedDashboardTheme => {
+  const normalized = normalizeDashboardTheme(theme);
+  const preset = presetById(normalized.presetId);
+  return {
+    ...preset,
+    presetId: normalized.presetId || preset.presetId,
+    canvas: {
+      ...preset.canvas,
+      ...normalized.canvas,
+    },
+    component: {
+      ...preset.component,
+      ...normalized.component,
+    },
+    chart: {
+      ...preset.chart,
+      ...normalized.chart,
+      palette: normalized.chart?.palette?.length
+        ? [...normalized.chart.palette]
+        : [...preset.chart.palette],
+    },
+  };
+};
+
+export const themeFromPreset = (presetId: DashboardThemePresetId): DashboardTheme => ({
+  presetId,
+});

--- a/yak-ops-ui/src/pages/dashboard/defaults.ts
+++ b/yak-ops-ui/src/pages/dashboard/defaults.ts
@@ -7,6 +7,7 @@ export const DEFAULT_DASHBOARD: DashboardDocument = {
   name: '未命名仪表盘',
   description: '',
   activeDatasetId: '',
+  theme: { presetId: 'yak-light' },
   widgets: [],
   globalFilters: [],
   interactions: [],

--- a/yak-ops-ui/src/pages/dashboard/editor.tsx
+++ b/yak-ops-ui/src/pages/dashboard/editor.tsx
@@ -5,9 +5,11 @@ import { BarChart3 } from 'lucide-react';
 import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { DashboardChartSheetWorkspace } from './chart-sheet-workspace';
 import { DashboardGlobalFilterBar } from './global-filter-bar';
+import { DashboardThemeDrawer } from './dashboard-theme-drawer';
+import { resolveDashboardTheme, themeFromPreset } from './dashboard-theme';
 import { GRID_COLUMNS, GRID_ROW_HEIGHT } from './helpers';
 import {
   directCrossFiltersForWidget,
@@ -15,7 +17,7 @@ import {
   sameDashboardSelection,
   type DashboardRuntimeSelections,
 } from './interaction-runtime';
-import type { AnalysisSelection } from './model';
+import type { AnalysisSelection, DashboardTheme } from './model';
 import { DashboardSheetBar } from './sheet-bar';
 import { DashboardToolbar } from './toolbar';
 import { useDashboardDesigner } from './use-dashboard';
@@ -36,10 +38,16 @@ export default function DashboardEditorPage() {
   const designer = useDashboardDesigner(dashboardId, initialPreview, false);
   const { width, containerRef, mounted, measureWidth } = useContainerWidth();
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [themeOpen, setThemeOpen] = useState(false);
+  const [themePreview, setThemePreview] = useState<DashboardTheme>();
   const [activeSheet, setActiveSheet] = useState<'dashboard' | 'chart'>('dashboard');
   const [activeSheetId, setActiveSheetId] = useState<string>();
   const [sheetOrder, setSheetOrder] = useState<string[]>([]);
   const [runtimeSelections, setRuntimeSelections] = useState<DashboardRuntimeSelections>({});
+  const resolvedTheme = useMemo(
+    () => resolveDashboardTheme(themePreview ?? designer.dashboard.theme),
+    [designer.dashboard.theme, themePreview],
+  );
   const layout = useMemo(() => designer.widgets.map((widget) => ({
     i: widget.id,
     x: widget.x,
@@ -75,10 +83,14 @@ export default function DashboardEditorPage() {
     setActiveSheet('dashboard');
     setActiveSheetId(undefined);
     setRuntimeSelections({});
+    setThemeOpen(false);
+    setThemePreview(undefined);
   }, [designer.dashboard.id]);
 
   useEffect(() => {
     setRuntimeSelections({});
+    setThemeOpen(false);
+    setThemePreview(undefined);
   }, [designer.dashboard.currentVersionId]);
 
   useEffect(() => {
@@ -298,11 +310,20 @@ export default function DashboardEditorPage() {
   }, [designer, resetRuntimeInteractions, runtimeSelections, saveDashboard]);
 
   const showDashboardWorkspace = designer.preview || activeSheet === 'dashboard';
+  const themeStyle = {
+    ...BRAND_CSS_VARIABLES,
+    '--dashboard-canvas-bg': resolvedTheme.canvas.backgroundColor,
+    '--dashboard-component-bg': resolvedTheme.component.backgroundColor,
+    '--dashboard-component-text': resolvedTheme.component.textColor,
+    '--dashboard-grid-dot': resolvedTheme.presetId === 'yak-dark'
+      ? 'rgba(255,255,255,.065)'
+      : 'rgba(15,23,42,.035)',
+  } as CSSProperties;
 
   return (
     <div
-      className="flex h-screen min-h-[640px] flex-col overflow-hidden bg-[#f3f4f6]"
-      style={BRAND_CSS_VARIABLES}
+      className="flex h-screen min-h-[640px] flex-col overflow-hidden"
+      style={themeStyle}
     >
       <DashboardToolbar
         name={designer.dashboard.name}
@@ -324,6 +345,10 @@ export default function DashboardEditorPage() {
         onUndo={designer.undo}
         onRedo={designer.redo}
         onAddChart={addChart}
+        onDashboardStyle={() => {
+          setThemePreview(designer.dashboard.theme ?? themeFromPreset('yak-light'));
+          setThemeOpen(true);
+        }}
         onHistory={() => setHistoryOpen(true)}
         onPreview={() => {
           designer.setPreview((current) => !current);
@@ -350,7 +375,10 @@ export default function DashboardEditorPage() {
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {showDashboardWorkspace ? (
-          <main className="min-w-0 flex-1 overflow-auto bg-[#f3f4f6]">
+          <main
+            className="min-w-0 flex-1 overflow-auto"
+            style={{ backgroundColor: resolvedTheme.canvas.backgroundColor }}
+          >
             <div className={designer.preview ? 'min-h-full p-5' : 'min-h-full p-4 2xl:p-0'}>
               <div
                 ref={containerRef}
@@ -358,9 +386,10 @@ export default function DashboardEditorPage() {
                   'min-w-[760px]',
                   canvasMinHeight,
                   designer.preview
-                    ? 'mx-auto max-w-[1480px] rounded-[10px] border border-[#e7e9ed] bg-white shadow-[0_6px_24px_rgba(16,24,40,.055)]'
-                    : 'dashboard-grid-canvas mx-auto max-w-[1540px] rounded-[10px] 2xl:mx-0 2xl:max-w-none 2xl:rounded-none',
+                    ? 'mx-auto max-w-[1480px] border border-[#e7e9ed] shadow-[0_6px_24px_rgba(16,24,40,.055)]'
+                    : 'dashboard-grid-canvas mx-auto max-w-[1540px] 2xl:mx-0 2xl:max-w-none',
                 ].join(' ')}
+                style={{ backgroundColor: resolvedTheme.canvas.backgroundColor }}
                 onMouseDown={(event) => {
                   if (event.target === event.currentTarget) designer.setSelectedId(undefined);
                 }}
@@ -440,7 +469,7 @@ export default function DashboardEditorPage() {
                 {!designer.widgets.length && !designer.datasetsLoading ? (
                   <div className="flex min-h-[420px] items-center justify-center px-6 text-center">
                     <div className="max-w-[340px]">
-                      <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-[10px] bg-white text-[#7a818c] shadow-[0_1px_2px_rgba(16,24,40,.04)]">
+                      <div className="mx-auto flex h-11 w-11 items-center justify-center bg-white text-[#7a818c] shadow-[0_1px_2px_rgba(16,24,40,.04)]">
                         <BarChart3 size={18} />
                       </div>
                       <div className="mt-3 text-[14px] font-semibold text-[#344054]">
@@ -521,17 +550,32 @@ export default function DashboardEditorPage() {
         />
       ) : null}
 
+      <DashboardThemeDrawer
+        open={themeOpen}
+        theme={themePreview ?? designer.dashboard.theme}
+        onChange={setThemePreview}
+        onCancel={() => {
+          setThemeOpen(false);
+          setThemePreview(undefined);
+        }}
+        onConfirm={() => {
+          designer.updateDashboardTheme(themePreview ?? designer.dashboard.theme ?? themeFromPreset('yak-light'));
+          setThemeOpen(false);
+          setThemePreview(undefined);
+        }}
+      />
+
       <style>{`
         .dashboard-grid-canvas {
-          background-color: #f3f4f6;
-          background-image: radial-gradient(circle, rgba(15, 23, 42, .035) 1px, transparent 1px);
+          background-color: var(--dashboard-canvas-bg);
+          background-image: radial-gradient(circle, var(--dashboard-grid-dot) 1px, transparent 1px);
           background-size: calc(100% / 24) 36px;
           background-position: 10px 10px;
         }
         .react-grid-item.react-grid-placeholder {
           background: var(--yak-brand-color-soft) !important;
           border: 1px dashed var(--yak-brand-color) !important;
-          border-radius: 9px !important;
+          border-radius: 0 !important;
           opacity: 1 !important;
         }
         .react-grid-item > .react-resizable-handle::after {

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -33,6 +33,31 @@ export type {
 } from '@/components/analysis/model';
 
 export type DashboardWidgetClickAction = 'none' | 'drill' | 'dashboard' | 'yak';
+export type DashboardThemePresetId = 'yak-light' | 'yak-dark';
+
+export interface DashboardThemeCanvas {
+  backgroundColor?: string;
+}
+
+export interface DashboardThemeComponent {
+  backgroundColor?: string;
+  textColor?: string;
+}
+
+export interface DashboardThemeChart {
+  palette?: string[];
+  textColor?: string;
+  axisColor?: string;
+  gridColor?: string;
+}
+
+/** Dashboard-level visual defaults. Preset values are resolved on the client; fields are explicit overrides. */
+export interface DashboardTheme {
+  presetId?: DashboardThemePresetId;
+  canvas?: DashboardThemeCanvas;
+  component?: DashboardThemeComponent;
+  chart?: DashboardThemeChart;
+}
 
 /**
  * Dashboard-local direct chart linkage. The source widget owns the rule; selecting its
@@ -121,6 +146,7 @@ export interface DashboardDocument {
   name: string;
   description?: string;
   activeDatasetId: string;
+  theme?: DashboardTheme;
   widgets: DashboardWidget[];
   globalFilters: DashboardGlobalFilter[];
   interactions: DashboardInteraction[];
@@ -160,6 +186,7 @@ export interface DashboardVersionSummary {
 export interface DashboardServerDetail {
   dashboard: DashboardSummary;
   currentVersion?: DashboardVersionSummary;
+  theme?: DashboardTheme;
   versions: DashboardVersionSummary[];
   widgets: DashboardWidget[];
   globalFilters: DashboardGlobalFilter[];
@@ -169,6 +196,7 @@ export interface DashboardServerDetail {
 export interface DashboardVersionDetail {
   dashboard: DashboardSummary;
   version: DashboardVersionSummary;
+  theme?: DashboardTheme;
   widgets: DashboardWidget[];
   globalFilters: DashboardGlobalFilter[];
   interactions: DashboardInteraction[];

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -33,6 +33,7 @@ export function DashboardToolbar({
   onUndo,
   onRedo,
   onAddChart,
+  onDashboardStyle,
   onHistory,
   onPreview,
   onSaveDraft,
@@ -57,6 +58,7 @@ export function DashboardToolbar({
   onUndo: () => void;
   onRedo: () => void;
   onAddChart: () => void;
+  onDashboardStyle: () => void;
   onHistory: () => void;
   onPreview: () => void;
   onSaveDraft: () => void;
@@ -188,6 +190,7 @@ export function DashboardToolbar({
                 size="small"
                 className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
                 icon={<Palette size={13} />}
+                onClick={onDashboardStyle}
               >
                 仪表盘样式
               </Button>

--- a/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
+++ b/yak-ops-ui/src/pages/dashboard/use-dashboard.ts
@@ -34,6 +34,7 @@ import type {
   DashboardInlineAnalysisSpec,
   DashboardInteraction,
   DashboardServerDetail,
+  DashboardTheme,
   DashboardVersionDetail,
   DashboardVersionSummary,
   DashboardWidget,
@@ -70,6 +71,7 @@ const dashboardFingerprint = (dashboard: DashboardDocument) => JSON.stringify({
   name: dashboard.name,
   description: dashboard.description,
   activeDatasetId: dashboard.activeDatasetId,
+  theme: dashboard.theme,
   widgets: dashboard.widgets,
   globalFilters: dashboard.globalFilters,
   interactions: dashboard.interactions,
@@ -85,6 +87,7 @@ const publishedDocument = (detail: DashboardVersionDetail): DashboardDocument =>
   name: detail.version.name,
   description: detail.version.description,
   activeDatasetId: detail.version.activeDatasetId || '',
+  theme: detail.theme,
   widgets: detail.widgets,
   globalFilters: detail.globalFilters,
   interactions: detail.interactions,
@@ -314,6 +317,11 @@ export function useDashboardDesigner(
   const updateDashboardName = (name: string) => commitDashboard(
     (current) => ({ ...current, name }),
     'dashboard:name',
+  );
+
+  const updateDashboardTheme = (theme: DashboardTheme) => commitDashboard(
+    (current) => ({ ...current, theme }),
+    'dashboard:theme',
   );
 
   const updateLayout = (
@@ -678,6 +686,7 @@ export function useDashboardDesigner(
     setSelectedId,
     setPreview,
     updateDashboardName,
+    updateDashboardTheme,
     updateLayout,
     updateWidget,
     updateInlineAnalysis,

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -70,7 +70,8 @@ export function WidgetShell({
     >
       <div
         onMouseDown={onSelect}
-        className="dashboard-widget__surface relative flex h-full min-h-0 flex-col overflow-hidden bg-white"
+        className="dashboard-widget__surface relative flex h-full min-h-0 flex-col overflow-hidden"
+        style={{ backgroundColor: 'var(--dashboard-component-bg)' }}
       >
         <div className="dashboard-widget__drag-handle flex h-10 shrink-0 cursor-move items-center px-3.5">
           {!preview ? (
@@ -82,7 +83,10 @@ export function WidgetShell({
               ].join(' ')}
             />
           ) : null}
-          <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-[#344054]">
+          <span
+            className="min-w-0 flex-1 truncate text-[12px] font-semibold"
+            style={{ color: 'var(--dashboard-component-text)' }}
+          >
             {title}
           </span>
 
@@ -138,7 +142,7 @@ export function WidgetShell({
           </div>
         ) : null}
 
-        <div className="min-h-0 flex-1 overflow-hidden px-1 pb-1">
+        <div className="min-h-0 flex-1 overflow-hidden bg-white px-1 pb-1">
           {spec ? (
             <AnalysisPreview
               spec={spec}
@@ -216,7 +220,7 @@ export function WidgetShell({
         .dashboard-widget__surface {
           outline: 1px solid transparent;
           outline-offset: 0;
-          transition: outline-color 120ms ease;
+          transition: outline-color 120ms ease, background-color 160ms ease;
         }
         .dashboard-widget--editable:not(.dashboard-widget--selected):hover .dashboard-widget__surface {
           outline-color: #9aa7b8;


### PR DESCRIPTION
## Overview

实现 Dashboard 仪表盘样式第一阶段：建立版本化 Theme 基础能力，并打通前端实时预览、草稿保存、发布与历史恢复链路。

本阶段刻意保持小范围，只提供 `默认亮色` / `深色主题` 两个预设，不提前实现第二阶段的完整主题库和图表/表格深度换肤。

## Frontend

- 新增 `DashboardTheme` / `DashboardThemePresetId` 模型
- 新增 Theme preset resolver，内置：
  - `yak-light` / 默认亮色
  - `yak-dark` / 深色主题
- 顶部 `仪表盘样式` 工具按钮接入真实功能
- 新增右侧 `DashboardThemeDrawer`
- 点击主题卡片立即实时预览画布主题
- `取消` 丢弃临时预览，不产生 Dashboard Dirty
- `确定` 才写入 Dashboard Document，并进入 Undo/Redo + Dirty 链路
- Theme 纳入 Dashboard fingerprint，支持撤销/重做
- 新 Dashboard 默认使用 `yak-light`
- 老 Dashboard 没有 theme 时自动归一为亮色，保持向后兼容
- Dashboard API create/save/get/published/version 映射 theme
- Published view 同样读取已发布版本的 theme

## Backend

- Flyway `V4` 为 `yak_dashboard_version` 增加 `theme_json`
- Theme 与 immutable DashboardVersion 绑定，而不是放在 Dashboard asset 顶层
- 创建 / 保存草稿时同步保存 theme snapshot
- 查询当前草稿、指定历史版本、已发布版本时返回对应 theme
- 发布仍只移动 published pointer，因此天然发布同一个 theme snapshot
- 恢复历史版本时把历史 theme 一并复制到新的草稿版本
- Theme JSON 做对象类型校验和 16KB 上限校验
- 不新增 theme preset 数据表；预设仍由前端内置，后端只保存 Dashboard 的主题选择/override

## Phase 1 boundary

本 PR 不包含：

- 多套精品主题
- 自定义颜色/背景图片
- 企业主题管理
- Theme preset 市场
- 完整的 ECharts / Table 主题 token 消费

这些留到第二、第三阶段。当前深色预设主要建立 Dashboard 级主题切换和版本持久化能力。

## Validation

- 新增 Dashboard integrity theme compatibility tests
- 分支基于最新 `main`，创建 PR 前 compare 为 behind 0
- 后端沿用现有 DashboardVersion 生命周期，发布与恢复逻辑未重写
- 建议 CI / 本地重点回归：亮暗主题实时预览、取消、确定、保存刷新、发布读取、历史版本恢复