### PR TITLE
feat: add custom dashboard theme controls

### DIFF
--- a/yak-ops-ui/src/components/analysis/analysis-theme.ts
+++ b/yak-ops-ui/src/components/analysis/analysis-theme.ts
@@ -9,8 +9,6 @@ export interface AnalysisThemeTokens {
   headerBackgroundColor: string;
   stripedBackgroundColor: string;
   hoverBackgroundColor: string;
-  tableTextColor: string;
-  tableBorderColor: string;
   tooltipBackgroundColor: string;
   tooltipTextColor: string;
   metricValueColor: string;
@@ -27,8 +25,6 @@ export const DEFAULT_ANALYSIS_THEME: AnalysisThemeTokens = {
   headerBackgroundColor: '#fafafa',
   stripedBackgroundColor: '#fafbfc',
   hoverBackgroundColor: '#f7f8fa',
-  tableTextColor: '#344054',
-  tableBorderColor: '#e7eaf0',
   tooltipBackgroundColor: 'rgba(17,24,39,.94)',
   tooltipTextColor: '#ffffff',
   metricValueColor: '#161823',

--- a/yak-ops-ui/src/components/analysis/analysis-theme.ts
+++ b/yak-ops-ui/src/components/analysis/analysis-theme.ts
@@ -9,6 +9,8 @@ export interface AnalysisThemeTokens {
   headerBackgroundColor: string;
   stripedBackgroundColor: string;
   hoverBackgroundColor: string;
+  tableTextColor: string;
+  tableBorderColor: string;
   tooltipBackgroundColor: string;
   tooltipTextColor: string;
   metricValueColor: string;
@@ -25,6 +27,8 @@ export const DEFAULT_ANALYSIS_THEME: AnalysisThemeTokens = {
   headerBackgroundColor: '#fafafa',
   stripedBackgroundColor: '#fafbfc',
   hoverBackgroundColor: '#f7f8fa',
+  tableTextColor: '#344054',
+  tableBorderColor: '#e7eaf0',
   tooltipBackgroundColor: 'rgba(17,24,39,.94)',
   tooltipTextColor: '#ffffff',
   metricValueColor: '#161823',

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme-drawer.tsx
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme-drawer.tsx
@@ -9,6 +9,7 @@ import {
   Sun,
   Table2,
 } from 'lucide-react';
+import type { ReactNode } from 'react';
 import {
   DASHBOARD_THEME_PRESETS,
   hasDashboardThemeOverrides,
@@ -119,8 +120,8 @@ const SectionLabel = ({
   icon,
   children,
 }: {
-  icon: React.ReactNode;
-  children: React.ReactNode;
+  icon: ReactNode;
+  children: ReactNode;
 }) => (
   <div className="flex items-center gap-2 text-[12px] font-semibold text-[#344054]">
     <span className="text-[#667085]">{icon}</span>
@@ -290,11 +291,6 @@ export function DashboardThemeDrawer({
                     ))}
                   </div>
                 </div>
-                <ColorSetting
-                  label="图表文字"
-                  value={resolved.chart.textColor}
-                  onChange={(textColor) => updateChart({ textColor })}
-                />
                 <ColorSetting
                   label="坐标轴"
                   value={resolved.chart.axisColor}

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme-drawer.tsx
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme-drawer.tsx
@@ -1,12 +1,30 @@
-import { Button, Drawer } from 'antd';
-import { Check, Moon, Sun } from 'lucide-react';
+import { Button, Collapse, ColorPicker, Drawer, Tabs } from 'antd';
+import {
+  BarChart3,
+  Box,
+  Check,
+  LayoutDashboard,
+  Moon,
+  RotateCcw,
+  Sun,
+  Table2,
+} from 'lucide-react';
 import {
   DASHBOARD_THEME_PRESETS,
+  hasDashboardThemeOverrides,
+  normalizeDashboardTheme,
   resolveDashboardTheme,
   themeFromPreset,
   type ResolvedDashboardTheme,
 } from './dashboard-theme';
-import type { DashboardTheme, DashboardThemePresetId } from './model';
+import type {
+  DashboardTheme,
+  DashboardThemeCanvas,
+  DashboardThemeChart,
+  DashboardThemeComponent,
+  DashboardThemePresetId,
+  DashboardThemeTable,
+} from './model';
 
 const ThemePreview = ({ preset }: { preset: ResolvedDashboardTheme }) => {
   const theme = resolveDashboardTheme(themeFromPreset(preset.presetId));
@@ -75,6 +93,41 @@ const ThemePreview = ({ preset }: { preset: ResolvedDashboardTheme }) => {
   );
 };
 
+const ColorSetting = ({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) => (
+  <div className="flex min-h-9 items-center justify-between gap-4 py-1">
+    <span className="text-[12px] text-[#344054]">{label}</span>
+    <div className="flex shrink-0 items-center gap-2">
+      <ColorPicker
+        size="small"
+        value={value}
+        onChange={(color) => onChange(color.toHexString())}
+      />
+      <span className="w-[68px] font-mono text-[10px] uppercase text-[#667085]">{value}</span>
+    </div>
+  </div>
+);
+
+const SectionLabel = ({
+  icon,
+  children,
+}: {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <div className="flex items-center gap-2 text-[12px] font-semibold text-[#344054]">
+    <span className="text-[#667085]">{icon}</span>
+    {children}
+  </div>
+);
+
 export function DashboardThemeDrawer({
   open,
   theme,
@@ -88,19 +141,217 @@ export function DashboardThemeDrawer({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
-  const selectedId = resolveDashboardTheme(theme).presetId;
+  const normalized = normalizeDashboardTheme(theme);
+  const resolved = resolveDashboardTheme(theme);
+  const selectedId = resolved.presetId;
+  const customized = hasDashboardThemeOverrides(theme);
+
+  const updateCanvas = (patch: DashboardThemeCanvas) => onChange({
+    ...normalized,
+    canvas: { ...normalized.canvas, ...patch },
+  });
+  const updateComponent = (patch: DashboardThemeComponent) => onChange({
+    ...normalized,
+    component: { ...normalized.component, ...patch },
+  });
+  const updateChart = (patch: DashboardThemeChart) => onChange({
+    ...normalized,
+    chart: { ...normalized.chart, ...patch },
+  });
+  const updateTable = (patch: DashboardThemeTable) => onChange({
+    ...normalized,
+    table: { ...normalized.table, ...patch },
+  });
+  const updatePalette = (index: number, color: string) => {
+    const palette = [...resolved.chart.palette];
+    palette[index] = color;
+    updateChart({ palette });
+  };
+
+  const presetContent = (
+    <div className="grid grid-cols-2 gap-3 pt-1">
+      {DASHBOARD_THEME_PRESETS.map((preset) => {
+        const selected = selectedId === preset.presetId;
+        const Icon = preset.tone === 'dark' ? Moon : Sun;
+        return (
+          <button
+            key={preset.presetId}
+            type="button"
+            className={[
+              'relative overflow-hidden border bg-white p-0 text-left transition-colors',
+              selected
+                ? 'border-[var(--yak-brand-color)]'
+                : 'border-[#e4e7ec] hover:border-[#c8ced8]',
+            ].join(' ')}
+            onClick={() => onChange(themeFromPreset(preset.presetId as DashboardThemePresetId))}
+          >
+            <ThemePreview preset={preset} />
+            <div className="flex h-9 items-center gap-1.5 px-2.5">
+              <Icon
+                size={13}
+                className={selected ? 'text-[var(--yak-brand-color)]' : 'text-[#667085]'}
+              />
+              <span className="text-[12px] font-medium text-[#344054]">{preset.name}</span>
+            </div>
+            {selected ? (
+              <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--yak-brand-color)] text-white">
+                <Check size={12} strokeWidth={2.4} />
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const customContent = (
+    <div className="pt-1">
+      <div className="mb-3 flex h-9 items-center justify-between bg-[#f7f8fa] px-3">
+        <div className="flex items-center gap-2 text-[11px] text-[#667085]">
+          <span>基于</span>
+          <span className="font-medium text-[#344054]">{resolved.name}</span>
+          {customized ? (
+            <span className="bg-[var(--yak-brand-color-soft)] px-1.5 py-0.5 text-[9px] text-[var(--yak-brand-color)]">
+              已自定义
+            </span>
+          ) : null}
+        </div>
+        <Button
+          type="text"
+          size="small"
+          className="!h-7 !px-1.5 !text-[10px] !text-[#667085] hover:!text-[#344054]"
+          icon={<RotateCcw size={11} />}
+          onClick={() => onChange(themeFromPreset(selectedId))}
+        >
+          恢复预设
+        </Button>
+      </div>
+
+      <Collapse
+        ghost
+        size="small"
+        defaultActiveKey={['canvas', 'component', 'chart', 'table']}
+        className="dashboard-theme-custom"
+        items={[
+          {
+            key: 'canvas',
+            label: <SectionLabel icon={<LayoutDashboard size={13} />}>仪表盘</SectionLabel>,
+            children: (
+              <ColorSetting
+                label="画布背景"
+                value={resolved.canvas.backgroundColor}
+                onChange={(backgroundColor) => updateCanvas({ backgroundColor })}
+              />
+            ),
+          },
+          {
+            key: 'component',
+            label: <SectionLabel icon={<Box size={13} />}>组件</SectionLabel>,
+            children: (
+              <div>
+                <ColorSetting
+                  label="组件背景"
+                  value={resolved.component.backgroundColor}
+                  onChange={(backgroundColor) => updateComponent({ backgroundColor })}
+                />
+                <ColorSetting
+                  label="主文字"
+                  value={resolved.component.textColor}
+                  onChange={(textColor) => updateComponent({ textColor })}
+                />
+                <ColorSetting
+                  label="次文字"
+                  value={resolved.component.mutedTextColor}
+                  onChange={(mutedTextColor) => updateComponent({ mutedTextColor })}
+                />
+                <ColorSetting
+                  label="组件边框"
+                  value={resolved.component.borderColor}
+                  onChange={(borderColor) => updateComponent({ borderColor })}
+                />
+              </div>
+            ),
+          },
+          {
+            key: 'chart',
+            label: <SectionLabel icon={<BarChart3 size={13} />}>图表</SectionLabel>,
+            children: (
+              <div>
+                <div className="flex min-h-10 items-center justify-between gap-4 py-1">
+                  <span className="text-[12px] text-[#344054]">图表色板</span>
+                  <div className="flex items-center gap-1.5">
+                    {resolved.chart.palette.slice(0, 6).map((color, index) => (
+                      <ColorPicker
+                        key={`${index}-${color}`}
+                        size="small"
+                        value={color}
+                        onChange={(nextColor) => updatePalette(index, nextColor.toHexString())}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <ColorSetting
+                  label="图表文字"
+                  value={resolved.chart.textColor}
+                  onChange={(textColor) => updateChart({ textColor })}
+                />
+                <ColorSetting
+                  label="坐标轴"
+                  value={resolved.chart.axisColor}
+                  onChange={(axisColor) => updateChart({ axisColor })}
+                />
+                <ColorSetting
+                  label="网格线"
+                  value={resolved.chart.gridColor}
+                  onChange={(gridColor) => updateChart({ gridColor })}
+                />
+                <ColorSetting
+                  label="指标值"
+                  value={resolved.chart.metricValueColor}
+                  onChange={(metricValueColor) => updateChart({ metricValueColor })}
+                />
+              </div>
+            ),
+          },
+          {
+            key: 'table',
+            label: <SectionLabel icon={<Table2 size={13} />}>表格</SectionLabel>,
+            children: (
+              <div>
+                <ColorSetting
+                  label="表头背景"
+                  value={resolved.table.headerBackgroundColor}
+                  onChange={(headerBackgroundColor) => updateTable({ headerBackgroundColor })}
+                />
+                <ColorSetting
+                  label="斑马行"
+                  value={resolved.table.stripedBackgroundColor}
+                  onChange={(stripedBackgroundColor) => updateTable({ stripedBackgroundColor })}
+                />
+                <ColorSetting
+                  label="悬停背景"
+                  value={resolved.table.hoverBackgroundColor}
+                  onChange={(hoverBackgroundColor) => updateTable({ hoverBackgroundColor })}
+                />
+              </div>
+            ),
+          },
+        ]}
+      />
+    </div>
+  );
 
   return (
     <Drawer
       title={<span className="text-[14px] font-semibold text-[#161823]">仪表盘样式</span>}
-      width={412}
+      width={420}
       open={open}
       onClose={onCancel}
       mask={false}
       destroyOnClose={false}
       styles={{
         header: { padding: '12px 16px', minHeight: 48 },
-        body: { padding: 16, background: '#fff' },
+        body: { padding: '0 16px 16px', background: '#fff' },
         footer: { padding: '10px 16px' },
       }}
       footer={(
@@ -112,40 +363,26 @@ export function DashboardThemeDrawer({
         </div>
       )}
     >
-      <div className="mb-3 text-[12px] font-semibold text-[#344054]">预设主题</div>
-      <div className="grid grid-cols-2 gap-3">
-        {DASHBOARD_THEME_PRESETS.map((preset) => {
-          const selected = selectedId === preset.presetId;
-          const Icon = preset.tone === 'dark' ? Moon : Sun;
-          return (
-            <button
-              key={preset.presetId}
-              type="button"
-              className={[
-                'relative overflow-hidden border bg-white p-0 text-left transition-colors',
-                selected
-                  ? 'border-[var(--yak-brand-color)]'
-                  : 'border-[#e4e7ec] hover:border-[#c8ced8]',
-              ].join(' ')}
-              onClick={() => onChange(themeFromPreset(preset.presetId as DashboardThemePresetId))}
-            >
-              <ThemePreview preset={preset} />
-              <div className="flex h-9 items-center gap-1.5 px-2.5">
-                <Icon
-                  size={13}
-                  className={selected ? 'text-[var(--yak-brand-color)]' : 'text-[#667085]'}
-                />
-                <span className="text-[12px] font-medium text-[#344054]">{preset.name}</span>
-              </div>
-              {selected ? (
-                <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--yak-brand-color)] text-white">
-                  <Check size={12} strokeWidth={2.4} />
-                </span>
-              ) : null}
-            </button>
-          );
-        })}
-      </div>
+      <Tabs
+        defaultActiveKey={customized ? 'custom' : 'preset'}
+        size="small"
+        items={[
+          { key: 'preset', label: '预设', children: presetContent },
+          { key: 'custom', label: '自定义', children: customContent },
+        ]}
+      />
+
+      <style>{`
+        .dashboard-theme-custom > .ant-collapse-item {
+          border-bottom: 1px solid #eef0f3 !important;
+        }
+        .dashboard-theme-custom > .ant-collapse-item > .ant-collapse-header {
+          padding: 10px 0 !important;
+        }
+        .dashboard-theme-custom .ant-collapse-content-box {
+          padding: 0 0 8px !important;
+        }
+      `}</style>
     </Drawer>
   );
 }

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme.test.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme.test.ts
@@ -1,6 +1,7 @@
 import {
   analysisThemeFromDashboardTheme,
   DASHBOARD_THEME_PRESETS,
+  hasDashboardThemeOverrides,
   normalizeDashboardTheme,
   resolveDashboardTheme,
   themeFromPreset,
@@ -19,6 +20,7 @@ describe('dashboard themes', () => {
       expect(preset.chart.palette.length).toBeGreaterThanOrEqual(5);
       expect(preset.component.backgroundColor).toBeTruthy();
       expect(preset.canvas.backgroundColor).toBeTruthy();
+      expect(preset.table.headerBackgroundColor).toBeTruthy();
     });
   });
 
@@ -28,10 +30,42 @@ describe('dashboard themes', () => {
     expect(normalizeDashboardTheme(themeFromPreset('mist-blue')).presetId).toBe('mist-blue');
   });
 
+  it('resolves sparse custom overrides on top of the selected preset', () => {
+    const base = resolveDashboardTheme(themeFromPreset('ocean-night'));
+    const theme = {
+      presetId: 'ocean-night' as const,
+      canvas: { backgroundColor: '#020617' },
+      component: { textColor: '#ffffff' },
+      chart: { palette: ['#111111', '#222222', '#333333'] },
+      table: { headerBackgroundColor: '#08192b' },
+    };
+    const resolved = resolveDashboardTheme(theme);
+
+    expect(resolved.canvas.backgroundColor).toBe('#020617');
+    expect(resolved.component.textColor).toBe('#ffffff');
+    expect(resolved.component.backgroundColor).toBe(base.component.backgroundColor);
+    expect(resolved.chart.palette).toEqual(['#111111', '#222222', '#333333']);
+    expect(resolved.chart.axisColor).toBe(base.chart.axisColor);
+    expect(resolved.table.headerBackgroundColor).toBe('#08192b');
+    expect(resolved.table.hoverBackgroundColor).toBe(base.table.hoverBackgroundColor);
+  });
+
+  it('detects custom overrides while a pure preset stays clean', () => {
+    expect(hasDashboardThemeOverrides(themeFromPreset('yak-dark'))).toBe(false);
+    expect(hasDashboardThemeOverrides({
+      presetId: 'yak-dark',
+      component: { backgroundColor: '#101010' },
+    })).toBe(true);
+  });
+
   it('turns dashboard tokens into renderer tokens without mutating the dashboard config', () => {
     const dashboardTheme = {
       presetId: 'ocean-night' as const,
       chart: { palette: ['#111111', '#222222'] },
+      table: {
+        headerBackgroundColor: '#091d30',
+        hoverBackgroundColor: '#123957',
+      },
     };
     const before = JSON.stringify(dashboardTheme);
     const rendererTheme = analysisThemeFromDashboardTheme(dashboardTheme);
@@ -39,6 +73,8 @@ describe('dashboard themes', () => {
     expect(rendererTheme.palette).toEqual(['#111111', '#222222']);
     expect(rendererTheme.backgroundColor).toBe(resolveDashboardTheme(dashboardTheme).component.backgroundColor);
     expect(rendererTheme.metricValueColor).toBe('#7dd3fc');
+    expect(rendererTheme.headerBackgroundColor).toBe('#091d30');
+    expect(rendererTheme.hoverBackgroundColor).toBe('#123957');
     expect(JSON.stringify(dashboardTheme)).toBe(before);
   });
 });

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
@@ -33,8 +33,6 @@ export interface ResolvedDashboardTheme {
   };
   table: {
     headerBackgroundColor: string;
-    textColor: string;
-    borderColor: string;
     stripedBackgroundColor: string;
     hoverBackgroundColor: string;
   };
@@ -68,8 +66,6 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
     },
     table: {
       headerBackgroundColor: '#fafafa',
-      textColor: '#344054',
-      borderColor: '#e7eaf0',
       stripedBackgroundColor: '#fafbfc',
       hoverBackgroundColor: '#f7f8fa',
     },
@@ -101,8 +97,6 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
     },
     table: {
       headerBackgroundColor: '#182230',
-      textColor: '#e7edf5',
-      borderColor: '#344054',
       stripedBackgroundColor: '#202b3a',
       hoverBackgroundColor: '#29384b',
     },
@@ -134,8 +128,6 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
     },
     table: {
       headerBackgroundColor: '#0b2944',
-      textColor: '#d8ecfa',
-      borderColor: '#163b59',
       stripedBackgroundColor: '#0c2841',
       hoverBackgroundColor: '#103553',
     },
@@ -167,8 +159,6 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
     },
     table: {
       headerBackgroundColor: '#2b2c30',
-      textColor: '#e4e4e7',
-      borderColor: '#3f3f46',
       stripedBackgroundColor: '#292a2e',
       hoverBackgroundColor: '#34353a',
     },
@@ -200,8 +190,6 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
     },
     table: {
       headerBackgroundColor: '#f1f6fb',
-      textColor: '#344a63',
-      borderColor: '#d6e0eb',
       stripedBackgroundColor: '#f5f9fc',
       hoverBackgroundColor: '#eaf2f9',
     },
@@ -276,8 +264,6 @@ export const analysisThemeFromDashboardTheme = (
     headerBackgroundColor: resolved.table.headerBackgroundColor,
     stripedBackgroundColor: resolved.table.stripedBackgroundColor,
     hoverBackgroundColor: resolved.table.hoverBackgroundColor,
-    tableTextColor: resolved.table.textColor,
-    tableBorderColor: resolved.table.borderColor,
     tooltipBackgroundColor: resolved.chart.tooltipBackgroundColor,
     tooltipTextColor: resolved.chart.tooltipTextColor,
     metricValueColor: resolved.chart.metricValueColor,

--- a/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
+++ b/yak-ops-ui/src/pages/dashboard/dashboard-theme.ts
@@ -31,6 +31,13 @@ export interface ResolvedDashboardTheme {
     tooltipTextColor: string;
     metricValueColor: string;
   };
+  table: {
+    headerBackgroundColor: string;
+    textColor: string;
+    borderColor: string;
+    stripedBackgroundColor: string;
+    hoverBackgroundColor: string;
+  };
 }
 
 export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
@@ -59,6 +66,13 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
       tooltipTextColor: '#ffffff',
       metricValueColor: '#161823',
     },
+    table: {
+      headerBackgroundColor: '#fafafa',
+      textColor: '#344054',
+      borderColor: '#e7eaf0',
+      stripedBackgroundColor: '#fafbfc',
+      hoverBackgroundColor: '#f7f8fa',
+    },
   },
   {
     presetId: 'yak-dark',
@@ -84,6 +98,13 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
       tooltipBackgroundColor: '#0b1220',
       tooltipTextColor: '#f8fafc',
       metricValueColor: '#f8fafc',
+    },
+    table: {
+      headerBackgroundColor: '#182230',
+      textColor: '#e7edf5',
+      borderColor: '#344054',
+      stripedBackgroundColor: '#202b3a',
+      hoverBackgroundColor: '#29384b',
     },
   },
   {
@@ -111,6 +132,13 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
       tooltipTextColor: '#edf8ff',
       metricValueColor: '#7dd3fc',
     },
+    table: {
+      headerBackgroundColor: '#0b2944',
+      textColor: '#d8ecfa',
+      borderColor: '#163b59',
+      stripedBackgroundColor: '#0c2841',
+      hoverBackgroundColor: '#103553',
+    },
   },
   {
     presetId: 'graphite',
@@ -136,6 +164,13 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
       tooltipBackgroundColor: '#0f0f10',
       tooltipTextColor: '#fafafa',
       metricValueColor: '#ffffff',
+    },
+    table: {
+      headerBackgroundColor: '#2b2c30',
+      textColor: '#e4e4e7',
+      borderColor: '#3f3f46',
+      stripedBackgroundColor: '#292a2e',
+      hoverBackgroundColor: '#34353a',
     },
   },
   {
@@ -163,12 +198,28 @@ export const DASHBOARD_THEME_PRESETS: ResolvedDashboardTheme[] = [
       tooltipTextColor: '#ffffff',
       metricValueColor: '#172b4d',
     },
+    table: {
+      headerBackgroundColor: '#f1f6fb',
+      textColor: '#344a63',
+      borderColor: '#d6e0eb',
+      stripedBackgroundColor: '#f5f9fc',
+      hoverBackgroundColor: '#eaf2f9',
+    },
   },
 ];
 
 const presetById = (presetId?: DashboardThemePresetId) => (
   DASHBOARD_THEME_PRESETS.find((item) => item.presetId === presetId)
   ?? DASHBOARD_THEME_PRESETS[0]
+);
+
+const hasKeys = (value?: Record<string, unknown>) => Boolean(value && Object.keys(value).length);
+
+export const hasDashboardThemeOverrides = (theme?: DashboardTheme) => (
+  hasKeys(theme?.canvas as Record<string, unknown> | undefined)
+  || hasKeys(theme?.component as Record<string, unknown> | undefined)
+  || hasKeys(theme?.chart as Record<string, unknown> | undefined)
+  || hasKeys(theme?.table as Record<string, unknown> | undefined)
 );
 
 export const normalizeDashboardTheme = (theme?: DashboardTheme): DashboardTheme => ({
@@ -179,6 +230,7 @@ export const normalizeDashboardTheme = (theme?: DashboardTheme): DashboardTheme 
     ...theme.chart,
     palette: theme.chart.palette ? [...theme.chart.palette] : undefined,
   } : undefined,
+  table: theme?.table ? { ...theme.table } : undefined,
 });
 
 export const resolveDashboardTheme = (theme?: DashboardTheme): ResolvedDashboardTheme => {
@@ -202,6 +254,10 @@ export const resolveDashboardTheme = (theme?: DashboardTheme): ResolvedDashboard
         ? [...normalized.chart.palette]
         : [...preset.chart.palette],
     },
+    table: {
+      ...preset.table,
+      ...normalized.table,
+    },
   };
 };
 
@@ -217,9 +273,11 @@ export const analysisThemeFromDashboardTheme = (
     axisColor: resolved.chart.axisColor,
     gridColor: resolved.chart.gridColor,
     borderColor: resolved.component.borderColor,
-    headerBackgroundColor: resolved.component.subtleBackgroundColor,
-    stripedBackgroundColor: resolved.component.subtleBackgroundColor,
-    hoverBackgroundColor: resolved.component.hoverBackgroundColor,
+    headerBackgroundColor: resolved.table.headerBackgroundColor,
+    stripedBackgroundColor: resolved.table.stripedBackgroundColor,
+    hoverBackgroundColor: resolved.table.hoverBackgroundColor,
+    tableTextColor: resolved.table.textColor,
+    tableBorderColor: resolved.table.borderColor,
     tooltipBackgroundColor: resolved.chart.tooltipBackgroundColor,
     tooltipTextColor: resolved.chart.tooltipTextColor,
     metricValueColor: resolved.chart.metricValueColor,

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -48,6 +48,8 @@ export interface DashboardThemeCanvas {
 export interface DashboardThemeComponent {
   backgroundColor?: string;
   textColor?: string;
+  mutedTextColor?: string;
+  borderColor?: string;
 }
 
 export interface DashboardThemeChart {
@@ -55,6 +57,15 @@ export interface DashboardThemeChart {
   textColor?: string;
   axisColor?: string;
   gridColor?: string;
+  metricValueColor?: string;
+}
+
+export interface DashboardThemeTable {
+  headerBackgroundColor?: string;
+  textColor?: string;
+  borderColor?: string;
+  stripedBackgroundColor?: string;
+  hoverBackgroundColor?: string;
 }
 
 /** Dashboard-level visual defaults. Preset values are resolved on the client; fields are explicit overrides. */
@@ -63,6 +74,7 @@ export interface DashboardTheme {
   canvas?: DashboardThemeCanvas;
   component?: DashboardThemeComponent;
   chart?: DashboardThemeChart;
+  table?: DashboardThemeTable;
 }
 
 /**

--- a/yak-ops-ui/src/pages/dashboard/model.ts
+++ b/yak-ops-ui/src/pages/dashboard/model.ts
@@ -62,8 +62,6 @@ export interface DashboardThemeChart {
 
 export interface DashboardThemeTable {
   headerBackgroundColor?: string;
-  textColor?: string;
-  borderColor?: string;
   stripedBackgroundColor?: string;
   hoverBackgroundColor?: string;
 }


### PR DESCRIPTION
## Overview

完成 Dashboard 仪表盘样式第三阶段：在 5 套预设主题和版本化 Theme 引擎之上，增加轻量的自定义主题能力。

本阶段继续保持产品边界：用户可以在预设基础上做高频视觉微调，但不引入企业主题市场、背景图管理或独立主题资产系统。

## Custom theme editor

Theme Drawer 现在提供：

- `预设`：继续保留第二阶段的 5 套精品主题
- `自定义`：在当前预设基础上保存稀疏 override

自定义设置按四组组织：

- 仪表盘：画布背景
- 组件：组件背景、主文字、次文字、组件边框
- 图表：6 色色板、坐标轴、网格线、指标值
- 表格：表头背景、斑马行、悬停背景

所有颜色使用 AntD ColorPicker，修改时继续走现有 `themePreview`，因此可以即时看到整个 Dashboard 的变化。

## Override model

自定义主题不是复制完整 preset，而是保存：

`presetId + sparse overrides`

例如用户基于 `ocean-night` 只修改画布背景和表头背景，`theme_json` 只保存这两个 override；未修改 token 继续从当前 preset 解析。

新增：

- `DashboardThemeComponent.mutedTextColor / borderColor`
- `DashboardThemeChart.metricValueColor`
- `DashboardThemeTable`
- `hasDashboardThemeOverrides()`

`normalizeDashboardTheme()` / `resolveDashboardTheme()` 已支持 table 和新增 override，并保持旧 Dashboard 向后兼容。

## Reset behavior

自定义页显示当前基础预设，并提供「恢复预设」：

- 清除所有 override
- 保留当前 presetId
- Dashboard 立即恢复到该预设默认视觉

取消 / 确定语义保持前两阶段一致：

- 取消：丢弃 themePreview，不产生 Dirty
- 确定：写入 Dashboard Document，进入 Dirty / Undo / Redo
- 保存草稿 / 发布 / 历史版本恢复继续复用现有 `theme_json` 版本链

## Persistence

本 PR 不需要后端迁移。

第一阶段的 `yak_dashboard_version.theme_json` 是通用 JSON 版本快照，可以直接保存新增 override 字段。

## Tests

扩展 `dashboard-theme.test.ts`，覆盖：

- preset table token 完整性
- sparse override 与 preset merge
- 未覆盖 token 保持 preset 默认值
- custom override 检测
- table theme token 映射
- Theme mapping 不修改原始配置

## Validation

- 分支基于最新 `main`，创建 PR 前 `behind=0`
- Diff 仅 4 个 Dashboard Theme 前端文件
- 不修改 Dashboard 保存 API、后端、Analysis 语义或图表自身配置
- 本地完整 `tsc` 因当前执行环境无法解析 `github.com` 而无法 clone 仓库；建议 CI / 本地重点回归 ColorPicker 类型、预设/自定义切换、取消/确定、保存刷新、发布与历史恢复
