### PR TITLE
feat: add dashboard query performance analysis

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
@@ -8,12 +8,15 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "BI 数据集接口")
@@ -33,6 +36,15 @@ public class DatasetController {
   @GetMapping
   public Result<List<Dataset>> list() {
     return Result.success(service.list());
+  }
+
+  @Operation(summary = "查询最近的 Dataset SQL 性能诊断记录")
+  @GetMapping("/query-performance")
+  public Result<List<DatasetQueryPerformance>> queryPerformance(
+      @RequestParam(value = "datasetIds", required = false) List<Long> datasetIds,
+      @RequestParam(value = "limit", defaultValue = "100") int limit) {
+    Set<Long> filters = datasetIds == null ? Set.of() : new HashSet<>(datasetIds);
+    return Result.success(queryService.recentPerformance(filters, limit));
   }
 
   @Operation(summary = "查询 Dataset 详情、当前版本与版本历史")

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformance.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformance.java
@@ -11,7 +11,7 @@ public record DatasetQueryPerformance(
     String datasetName,
     @JsonSerialize(using = ToStringSerializer.class) long datasetVersionId,
     int datasetVersionNo,
-    DatasetSourceType sourceType,
+    String sourceType,
     String dataSourceId,
     String sql,
     long waitMillis,

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformance.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformance.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+
+/** Diagnostic trace for one Dataset Query Runtime execution. */
+public record DatasetQueryPerformance(
+    String queryId,
+    @JsonSerialize(using = ToStringSerializer.class) long datasetId,
+    String datasetName,
+    @JsonSerialize(using = ToStringSerializer.class) long datasetVersionId,
+    int datasetVersionNo,
+    DatasetSourceType sourceType,
+    String dataSourceId,
+    String sql,
+    long waitMillis,
+    long prepareMillis,
+    long executeMillis,
+    long transferMillis,
+    long totalMillis,
+    int returnedRows,
+    boolean truncated,
+    Instant startedAt) {
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformanceService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformanceService.java
@@ -1,0 +1,40 @@
+package io.yak.ops.business.dataset;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import org.springframework.stereotype.Service;
+
+/**
+ * Keeps a small in-memory diagnostic window so performance tracing does not add database I/O
+ * to the Dataset query that is being measured.
+ */
+@Service
+public class DatasetQueryPerformanceService {
+
+  static final int MAX_TRACES = 500;
+  static final int MAX_QUERY_LIMIT = 200;
+
+  private final ConcurrentLinkedDeque<DatasetQueryPerformance> traces = new ConcurrentLinkedDeque<>();
+
+  void record(DatasetQueryPerformance trace) {
+    if (trace == null) return;
+    traces.addFirst(trace);
+    while (traces.size() > MAX_TRACES) {
+      traces.pollLast();
+    }
+  }
+
+  public List<DatasetQueryPerformance> recent(Set<Long> datasetIds, int requestedLimit) {
+    int limit = Math.max(1, Math.min(requestedLimit, MAX_QUERY_LIMIT));
+    boolean filterDatasets = datasetIds != null && !datasetIds.isEmpty();
+    List<DatasetQueryPerformance> result = new ArrayList<>(Math.min(limit, traces.size()));
+    for (DatasetQueryPerformance trace : traces) {
+      if (filterDatasets && !datasetIds.contains(trace.datasetId())) continue;
+      result.add(trace);
+      if (result.size() >= limit) break;
+    }
+    return List.copyOf(result);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
@@ -59,7 +59,7 @@ public class DatasetQueryService {
         dataset.name(),
         version.id(),
         version.versionNo(),
-        version.sourceType(),
+        version.sourceType().name(),
         execution.dataSourceId(),
         execution.sql(),
         execution.waitMillis(),

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
@@ -1,8 +1,11 @@
 package io.yak.ops.business.dataset;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 /** Application entry point used by Dashboard/Chart consumers. */
@@ -11,11 +14,14 @@ public class DatasetQueryService {
 
   private final DatasetRepository repository;
   private final Map<DatasetSourceType, DatasetSourceQueryAdapter> adapters;
+  private final DatasetQueryPerformanceService performanceService;
 
   DatasetQueryService(
       DatasetRepository repository,
-      List<DatasetSourceQueryAdapter> adapters) {
+      List<DatasetSourceQueryAdapter> adapters,
+      DatasetQueryPerformanceService performanceService) {
     this.repository = repository;
+    this.performanceService = performanceService;
     Map<DatasetSourceType, DatasetSourceQueryAdapter> discovered = new LinkedHashMap<>();
     for (DatasetSourceQueryAdapter adapter : adapters) {
       DatasetSourceQueryAdapter existing = discovered.putIfAbsent(adapter.sourceType(), adapter);
@@ -27,6 +33,8 @@ public class DatasetQueryService {
   }
 
   public DatasetQueryResult query(long datasetId, DatasetQueryRequest request) {
+    Instant startedAt = Instant.now();
+    long queryStartedAt = System.nanoTime();
     if (datasetId <= 0L) throw new IllegalArgumentException("datasetId 必须大于 0");
     Dataset dataset = repository.findDataset(datasetId)
         .orElseThrow(() -> new IllegalArgumentException("Dataset 不存在：" + datasetId));
@@ -40,7 +48,33 @@ public class DatasetQueryService {
     if (adapter == null) {
       throw new IllegalStateException("Dataset sourceType 尚未接入 Query Runtime：" + version.sourceType());
     }
-    return adapter.execute(dataset, version, fields, request);
+    long servicePrepareMillis = elapsedMillis(queryStartedAt);
+
+    DatasetQueryExecution execution = adapter.execute(dataset, version, fields, request);
+    long totalMillis = elapsedMillis(queryStartedAt);
+    DatasetQueryResult result = execution.result();
+    performanceService.record(new DatasetQueryPerformance(
+        UUID.randomUUID().toString().replace("-", ""),
+        dataset.id(),
+        dataset.name(),
+        version.id(),
+        version.versionNo(),
+        version.sourceType(),
+        execution.dataSourceId(),
+        execution.sql(),
+        execution.waitMillis(),
+        servicePrepareMillis + execution.prepareMillis(),
+        execution.executeMillis(),
+        execution.transferMillis(),
+        totalMillis,
+        result.returnedRows(),
+        result.truncated(),
+        startedAt));
+    return result;
+  }
+
+  public List<DatasetQueryPerformance> recentPerformance(Set<Long> datasetIds, int limit) {
+    return performanceService.recent(datasetIds, limit);
   }
 
   private DatasetVersion resolveVersion(Dataset dataset, Integer versionNo) {
@@ -57,5 +91,9 @@ public class DatasetQueryService {
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException(
             "DatasetVersion 不存在：datasetId=" + dataset.id() + ", versionNo=" + versionNo));
+  }
+
+  private static long elapsedMillis(long startedAt) {
+    return Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSourceQueryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSourceQueryAdapter.java
@@ -7,9 +7,20 @@ interface DatasetSourceQueryAdapter {
 
   DatasetSourceType sourceType();
 
-  DatasetQueryResult execute(
+  DatasetQueryExecution execute(
       Dataset dataset,
       DatasetVersion version,
       List<DatasetField> fields,
       DatasetQueryRequest request);
+}
+
+/** Adapter result plus execution-only diagnostics used by the Dataset performance analyzer. */
+record DatasetQueryExecution(
+    DatasetQueryResult result,
+    String dataSourceId,
+    String sql,
+    long prepareMillis,
+    long waitMillis,
+    long executeMillis,
+    long transferMillis) {
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapter.java
@@ -41,11 +41,13 @@ final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapt
   }
 
   @Override
-  public DatasetQueryResult execute(
+  public DatasetQueryExecution execute(
       Dataset dataset,
       DatasetVersion version,
       List<DatasetField> fields,
       DatasetQueryRequest request) {
+    long adapterStartedAt = System.nanoTime();
+    long prepareStartedAt = System.nanoTime();
     TaskAssetRevision resolved = taskCatalogService.resolveRevision(
         version.sourceTaskAssetId(), version.sourceTaskRevisionId());
     if (resolved.revision().revisionId() != version.sourceTaskRevisionId()
@@ -61,23 +63,32 @@ final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapt
     SourceConfig sourceConfig = sourceConfig(definition.configJson());
     DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(definition.content(), fields, request);
     int timeoutSeconds = queryTimeout(request, sourceConfig.timeoutSeconds());
-    long startedAt = System.nanoTime();
+    long prepareMillis = elapsedMillis(prepareStartedAt);
+
+    long waitStartedAt = System.nanoTime();
+    DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(sourceConfig.dataSourceId());
+    long waitMillis = elapsedMillis(waitStartedAt);
 
     DataSourceSqlResult result;
-    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(sourceConfig.dataSourceId())) {
+    long executeStartedAt = System.nanoTime();
+    try (executor) {
       result = executor.execute(new DataSourceSqlRequest(
           compiled.sql(), compiled.fetchRows(), timeoutSeconds));
     }
+    long executeMillis = elapsedMillis(executeStartedAt);
+
+    long transferStartedAt = System.nanoTime();
     if (!result.resultSet()) {
       throw new IllegalStateException("Dataset Query Runtime 只接受结果集查询");
     }
-
     boolean overflow = result.rows().size() > compiled.limit();
     List<List<Object>> rows = overflow
         ? result.rows().subList(0, compiled.limit())
         : result.rows();
-    long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
-    return new DatasetQueryResult(
+    long transferMillis = elapsedMillis(transferStartedAt);
+    long elapsedMillis = elapsedMillis(adapterStartedAt);
+
+    DatasetQueryResult queryResult = new DatasetQueryResult(
         dataset.id(),
         version.id(),
         version.versionNo(),
@@ -87,6 +98,14 @@ final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapt
         rows.size(),
         result.truncated() || overflow,
         elapsedMillis);
+    return new DatasetQueryExecution(
+        queryResult,
+        sourceConfig.dataSourceId(),
+        compiled.sql(),
+        prepareMillis,
+        waitMillis,
+        executeMillis,
+        transferMillis);
   }
 
   private SourceConfig sourceConfig(String configJson) {
@@ -117,6 +136,10 @@ final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapt
       throw new IllegalArgumentException("timeoutSeconds 必须在 1~120 之间");
     }
     return requested;
+  }
+
+  private static long elapsedMillis(long startedAt) {
+    return Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
   }
 
   private record SourceConfig(String dataSourceId, int timeoutSeconds) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapter.java
@@ -46,7 +46,6 @@ final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapt
       DatasetVersion version,
       List<DatasetField> fields,
       DatasetQueryRequest request) {
-    long adapterStartedAt = System.nanoTime();
     long prepareStartedAt = System.nanoTime();
     TaskAssetRevision resolved = taskCatalogService.resolveRevision(
         version.sourceTaskAssetId(), version.sourceTaskRevisionId());
@@ -64,6 +63,7 @@ final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapt
     DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(definition.content(), fields, request);
     int timeoutSeconds = queryTimeout(request, sourceConfig.timeoutSeconds());
     long prepareMillis = elapsedMillis(prepareStartedAt);
+    long runtimeStartedAt = System.nanoTime();
 
     long waitStartedAt = System.nanoTime();
     DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(sourceConfig.dataSourceId());
@@ -86,7 +86,7 @@ final class QueryRevisionDatasetSourceAdapter implements DatasetSourceQueryAdapt
         ? result.rows().subList(0, compiled.limit())
         : result.rows();
     long transferMillis = elapsedMillis(transferStartedAt);
-    long elapsedMillis = elapsedMillis(adapterStartedAt);
+    long elapsedMillis = elapsedMillis(runtimeStartedAt);
 
     DatasetQueryResult queryResult = new DatasetQueryResult(
         dataset.id(),

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
@@ -35,7 +35,6 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
       DatasetVersion version,
       List<DatasetField> fields,
       DatasetQueryRequest request) {
-    long adapterStartedAt = System.nanoTime();
     long prepareStartedAt = System.nanoTime();
     if (version.dataSourceId() == null || version.dataSourceId().isBlank()) {
       throw new IllegalStateException("SQL_QUERY DatasetVersion 缺少 dataSourceId");
@@ -47,6 +46,7 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
     DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(version.sql(), fields, request);
     int timeoutSeconds = queryTimeout(request);
     long prepareMillis = elapsedMillis(prepareStartedAt);
+    long runtimeStartedAt = System.nanoTime();
 
     long waitStartedAt = System.nanoTime();
     DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(version.dataSourceId());
@@ -69,7 +69,7 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
         ? result.rows().subList(0, compiled.limit())
         : result.rows();
     long transferMillis = elapsedMillis(transferStartedAt);
-    long elapsedMillis = elapsedMillis(adapterStartedAt);
+    long elapsedMillis = elapsedMillis(runtimeStartedAt);
 
     DatasetQueryResult queryResult = new DatasetQueryResult(
         dataset.id(), version.id(), version.versionNo(), compiled.bindings(), result.columns(),

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
@@ -30,11 +30,13 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
   }
 
   @Override
-  public DatasetQueryResult execute(
+  public DatasetQueryExecution execute(
       Dataset dataset,
       DatasetVersion version,
       List<DatasetField> fields,
       DatasetQueryRequest request) {
+    long adapterStartedAt = System.nanoTime();
+    long prepareStartedAt = System.nanoTime();
     if (version.dataSourceId() == null || version.dataSourceId().isBlank()) {
       throw new IllegalStateException("SQL_QUERY DatasetVersion 缺少 dataSourceId");
     }
@@ -44,24 +46,42 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
 
     DatasetQueryCompiler.CompiledQuery compiled = compiler.compile(version.sql(), fields, request);
     int timeoutSeconds = queryTimeout(request);
-    long startedAt = System.nanoTime();
+    long prepareMillis = elapsedMillis(prepareStartedAt);
+
+    long waitStartedAt = System.nanoTime();
+    DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(version.dataSourceId());
+    long waitMillis = elapsedMillis(waitStartedAt);
+
     DataSourceSqlResult result;
-    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(version.dataSourceId())) {
+    long executeStartedAt = System.nanoTime();
+    try (executor) {
       result = executor.execute(new DataSourceSqlRequest(
           compiled.sql(), compiled.fetchRows(), timeoutSeconds));
     }
+    long executeMillis = elapsedMillis(executeStartedAt);
+
+    long transferStartedAt = System.nanoTime();
     if (!result.resultSet()) {
       throw new IllegalStateException("Dataset Query Runtime 只接受结果集查询");
     }
-
     boolean overflow = result.rows().size() > compiled.limit();
     List<List<Object>> rows = overflow
         ? result.rows().subList(0, compiled.limit())
         : result.rows();
-    long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
-    return new DatasetQueryResult(
+    long transferMillis = elapsedMillis(transferStartedAt);
+    long elapsedMillis = elapsedMillis(adapterStartedAt);
+
+    DatasetQueryResult queryResult = new DatasetQueryResult(
         dataset.id(), version.id(), version.versionNo(), compiled.bindings(), result.columns(),
         rows, rows.size(), result.truncated() || overflow, elapsedMillis);
+    return new DatasetQueryExecution(
+        queryResult,
+        version.dataSourceId(),
+        compiled.sql(),
+        prepareMillis,
+        waitMillis,
+        executeMillis,
+        transferMillis);
   }
 
   private int queryTimeout(DatasetQueryRequest request) {
@@ -71,5 +91,9 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
       throw new IllegalArgumentException("timeoutSeconds 必须在 1~120 之间");
     }
     return requested;
+  }
+
+  private static long elapsedMillis(long startedAt) {
+    return Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryPerformanceServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryPerformanceServiceTest.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DatasetQueryPerformanceServiceTest {
+
+  @Test
+  void filtersRecentTracesByDatasetAndKeepsNewestFirst() {
+    DatasetQueryPerformanceService service = new DatasetQueryPerformanceService();
+    service.record(trace("q1", 1L, 10L));
+    service.record(trace("q2", 2L, 20L));
+    service.record(trace("q3", 1L, 30L));
+
+    var traces = service.recent(Set.of(1L), 10);
+
+    assertEquals(2, traces.size());
+    assertEquals("q3", traces.get(0).queryId());
+    assertEquals("q1", traces.get(1).queryId());
+  }
+
+  @Test
+  void capsTheDiagnosticWindow() {
+    DatasetQueryPerformanceService service = new DatasetQueryPerformanceService();
+    for (int index = 0; index < DatasetQueryPerformanceService.MAX_TRACES + 5; index++) {
+      service.record(trace("q" + index, 1L, index));
+    }
+
+    var traces = service.recent(Set.of(), DatasetQueryPerformanceService.MAX_QUERY_LIMIT);
+
+    assertEquals(DatasetQueryPerformanceService.MAX_QUERY_LIMIT, traces.size());
+    assertEquals("q504", traces.get(0).queryId());
+  }
+
+  private static DatasetQueryPerformance trace(String queryId, long datasetId, long totalMillis) {
+    return new DatasetQueryPerformance(
+        queryId,
+        datasetId,
+        "dataset-" + datasetId,
+        datasetId * 10,
+        1,
+        DatasetSourceType.SQL_QUERY,
+        "ds-1",
+        "select 1",
+        1,
+        2,
+        3,
+        4,
+        totalMillis,
+        1,
+        false,
+        Instant.parse("2026-08-18T10:00:00Z"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryPerformanceServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryPerformanceServiceTest.java
@@ -42,7 +42,7 @@ class DatasetQueryPerformanceServiceTest {
         "dataset-" + datasetId,
         datasetId * 10,
         1,
-        DatasetSourceType.SQL_QUERY,
+        "SQL_QUERY",
         "ds-1",
         "select 1",
         1,

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapterTest.java
@@ -73,7 +73,8 @@ class QueryRevisionDatasetSourceAdapterTest {
     DatasetQueryRequest request = new DatasetQueryRequest(
         null, List.of(), List.of(), List.of(), List.of(), 2, 15);
 
-    DatasetQueryResult result = adapter.execute(dataset, version, fields, request);
+    DatasetQueryExecution execution = adapter.execute(dataset, version, fields, request);
+    DatasetQueryResult result = execution.result();
 
     verify(catalog).resolveRevision(11L, 71L);
     ArgumentCaptor<DataSourceSqlRequest> captor = ArgumentCaptor.forClass(DataSourceSqlRequest.class);
@@ -84,5 +85,11 @@ class QueryRevisionDatasetSourceAdapterTest {
     assertEquals(2, result.returnedRows());
     assertTrue(result.truncated());
     assertEquals(1, result.datasetVersionNo());
+    assertEquals("9", execution.dataSourceId());
+    assertEquals(captor.getValue().sql(), execution.sql());
+    assertTrue(execution.prepareMillis() >= 0L);
+    assertTrue(execution.waitMillis() >= 0L);
+    assertTrue(execution.executeMillis() >= 0L);
+    assertTrue(execution.transferMillis() >= 0L);
   }
 }

--- a/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
+++ b/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
@@ -1,3 +1,5 @@
+import { fetchAnalyses } from '@/components/analysis/analysis-service';
+import { fetchAnalysisDatasets } from '@/components/analysis/dataset-service';
 import {
   Alert,
   Button,
@@ -10,6 +12,7 @@ import {
 } from 'antd';
 import { Download, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchDashboard } from './dashboard-service';
 import type { AnalysisAsset, DashboardWidget, PublishedDataset } from './model';
 import {
   fetchDashboardQueryPerformance,
@@ -37,27 +40,22 @@ const widgetTitle = (widget: DashboardWidget, analyses: AnalysisAsset[]) => (
 
 export function DashboardPerformanceModal({
   open,
+  dashboardId,
   dashboardName,
-  widgets,
-  analyses,
-  datasets,
   onClose,
 }: {
   open: boolean;
+  dashboardId: string;
   dashboardName: string;
-  widgets: DashboardWidget[];
-  analyses: AnalysisAsset[];
-  datasets: PublishedDataset[];
   onClose: () => void;
 }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [records, setRecords] = useState<DashboardQueryPerformance[]>([]);
   const [detail, setDetail] = useState<DashboardQueryPerformance>();
-
-  const datasetIds = useMemo(() => Array.from(new Set(widgets
-    .map((widget) => widgetDatasetId(widget, analyses))
-    .filter((value): value is string => Boolean(value)))), [analyses, widgets]);
+  const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
+  const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
+  const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
 
   const widgetNamesByDataset = useMemo(() => {
     const result = new Map<string, string[]>();
@@ -77,21 +75,28 @@ export function DashboardPerformanceModal({
   ), [datasets]);
 
   const load = useCallback(async () => {
-    if (!datasetIds.length) {
-      setRecords([]);
-      setError(undefined);
-      return;
-    }
+    if (!/^\d+$/.test(dashboardId)) return;
     setLoading(true);
     setError(undefined);
     try {
+      const [dashboard, nextAnalyses, nextDatasets] = await Promise.all([
+        fetchDashboard(dashboardId),
+        fetchAnalyses(),
+        fetchAnalysisDatasets(),
+      ]);
+      setWidgets(dashboard.widgets);
+      setAnalyses(nextAnalyses);
+      setDatasets(nextDatasets);
+      const datasetIds = Array.from(new Set(dashboard.widgets
+        .map((widget) => widgetDatasetId(widget, nextAnalyses))
+        .filter((value): value is string => Boolean(value))));
       setRecords(await fetchDashboardQueryPerformance(datasetIds, 100));
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : '读取性能分析记录失败');
     } finally {
       setLoading(false);
     }
-  }, [datasetIds]);
+  }, [dashboardId]);
 
   useEffect(() => {
     if (open) void load();
@@ -220,9 +225,7 @@ export function DashboardPerformanceModal({
             emptyText: (
               <Empty
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
-                description={datasetIds.length
-                  ? '当前进程尚未采集到这些数据集的查询记录，请操作或刷新图表后再查看'
-                  : '当前仪表盘还没有可分析的数据集组件'}
+                description="当前进程尚未采集到该仪表盘的查询记录，请操作或刷新图表后再查看"
               />
             ),
           }}

--- a/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
+++ b/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
@@ -1,0 +1,270 @@
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Empty,
+  Modal,
+  Table,
+  Tooltip,
+  type TableColumnsType,
+} from 'antd';
+import { Download, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AnalysisAsset, DashboardWidget, PublishedDataset } from './model';
+import {
+  fetchDashboardQueryPerformance,
+  type DashboardQueryPerformance,
+} from './performance-service';
+
+const formatTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false });
+};
+
+const escapeCsv = (value: unknown) => `"${String(value ?? '').replaceAll('"', '""')}"`;
+
+const widgetDatasetId = (widget: DashboardWidget, analyses: AnalysisAsset[]) => (
+  widget.inlineAnalysis?.datasetId
+  ?? (widget.analysisId ? analyses.find((item) => item.id === widget.analysisId)?.datasetId : undefined)
+);
+
+const widgetTitle = (widget: DashboardWidget, analyses: AnalysisAsset[]) => (
+  widget.title?.trim()
+  || (widget.analysisId ? analyses.find((item) => item.id === widget.analysisId)?.name : undefined)
+  || '未命名组件'
+);
+
+export function DashboardPerformanceModal({
+  open,
+  dashboardName,
+  widgets,
+  analyses,
+  datasets,
+  onClose,
+}: {
+  open: boolean;
+  dashboardName: string;
+  widgets: DashboardWidget[];
+  analyses: AnalysisAsset[];
+  datasets: PublishedDataset[];
+  onClose: () => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [records, setRecords] = useState<DashboardQueryPerformance[]>([]);
+  const [detail, setDetail] = useState<DashboardQueryPerformance>();
+
+  const datasetIds = useMemo(() => Array.from(new Set(widgets
+    .map((widget) => widgetDatasetId(widget, analyses))
+    .filter((value): value is string => Boolean(value)))), [analyses, widgets]);
+
+  const widgetNamesByDataset = useMemo(() => {
+    const result = new Map<string, string[]>();
+    widgets.forEach((widget) => {
+      const datasetId = widgetDatasetId(widget, analyses);
+      if (!datasetId) return;
+      const current = result.get(datasetId) ?? [];
+      const title = widgetTitle(widget, analyses);
+      if (!current.includes(title)) current.push(title);
+      result.set(datasetId, current);
+    });
+    return result;
+  }, [analyses, widgets]);
+
+  const datasetNameById = useMemo(() => new Map(
+    datasets.map((dataset) => [dataset.id, dataset.name]),
+  ), [datasets]);
+
+  const load = useCallback(async () => {
+    if (!datasetIds.length) {
+      setRecords([]);
+      setError(undefined);
+      return;
+    }
+    setLoading(true);
+    setError(undefined);
+    try {
+      setRecords(await fetchDashboardQueryPerformance(datasetIds, 100));
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : '读取性能分析记录失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [datasetIds]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [load, open]);
+
+  const exportDetails = () => {
+    const header = [
+      '一级资源名称', '二级资源名称', '数据集', '查询ID', '数据源等待(ms)', '查询准备阶段(ms)',
+      'SQL执行时间(ms)', '结果处理时间(ms)', '总查询时间(ms)', '返回行数', '查询开始时间', '数据源ID', 'SQL',
+    ];
+    const rows = records.map((record) => [
+      dashboardName,
+      (widgetNamesByDataset.get(record.datasetId) ?? []).join(' / '),
+      record.datasetName || datasetNameById.get(record.datasetId) || record.datasetId,
+      record.queryId,
+      record.waitMillis,
+      record.prepareMillis,
+      record.executeMillis,
+      record.transferMillis,
+      record.totalMillis,
+      record.returnedRows,
+      formatTime(record.startedAt),
+      record.dataSourceId ?? '',
+      record.sql,
+    ]);
+    const csv = `\uFEFF${[header, ...rows].map((row) => row.map(escapeCsv).join(',')).join('\r\n')}`;
+    const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }));
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${dashboardName || 'dashboard'}-performance.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const columns: TableColumnsType<DashboardQueryPerformance> = [
+    {
+      title: '一级资源名称',
+      width: 130,
+      render: () => <span className="text-[#344054]">{dashboardName || '仪表盘'}</span>,
+    },
+    {
+      title: '二级资源名称',
+      width: 180,
+      render: (_, record) => {
+        const names = widgetNamesByDataset.get(record.datasetId) ?? [];
+        const value = names.length ? names.join(' / ') : '-';
+        return <Tooltip title={value}><span className="block max-w-[160px] truncate">{value}</span></Tooltip>;
+      },
+    },
+    {
+      title: '数据集',
+      width: 150,
+      render: (_, record) => record.datasetName || datasetNameById.get(record.datasetId) || record.datasetId,
+    },
+    {
+      title: '查询ID',
+      dataIndex: 'queryId',
+      width: 150,
+      render: (value: string, record) => (
+        <Button type="link" className="!h-auto !p-0 !text-[11px]" onClick={() => setDetail(record)}>
+          {value.slice(0, 12)}…
+        </Button>
+      ),
+    },
+    { title: '查询等待时间 (ms)', dataIndex: 'waitMillis', width: 135, align: 'right' },
+    { title: '查询准备阶段 (ms)', dataIndex: 'prepareMillis', width: 135, align: 'right' },
+    { title: 'SQL执行时间 (ms)', dataIndex: 'executeMillis', width: 125, align: 'right' },
+    { title: '结果处理时间 (ms)', dataIndex: 'transferMillis', width: 130, align: 'right' },
+    {
+      title: '总查询时间 (ms)',
+      dataIndex: 'totalMillis',
+      width: 125,
+      align: 'right',
+      render: (value: number) => (
+        <span className={value >= 1000 ? 'font-semibold text-[var(--yak-brand-color)]' : 'font-medium text-[#161823]'}>
+          {value}
+        </span>
+      ),
+    },
+    { title: '返回行数', dataIndex: 'returnedRows', width: 90, align: 'right' },
+    {
+      title: '查询开始时间',
+      dataIndex: 'startedAt',
+      width: 170,
+      render: (value: string) => formatTime(value),
+    },
+  ];
+
+  return (
+    <>
+      <Modal
+        title={<span className="text-[14px] font-semibold text-[#161823]">{dashboardName || '仪表盘'} · 性能分析</span>}
+        width="min(1240px, calc(100vw - 48px))"
+        open={open}
+        onCancel={onClose}
+        footer={null}
+        destroyOnClose={false}
+        styles={{ body: { paddingTop: 8 } }}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <div>
+            <div className="text-[12px] font-semibold text-[#344054]">核心信息</div>
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">最近 100 条当前仪表盘 Dataset SQL 查询记录</div>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button type="text" size="small" icon={<RefreshCw size={12} />} loading={loading} onClick={() => void load()}>
+              刷新
+            </Button>
+            <Button size="small" icon={<Download size={12} />} disabled={!records.length} onClick={exportDetails}>
+              导出详细信息
+            </Button>
+          </div>
+        </div>
+
+        {error ? <Alert className="mb-3" type="error" showIcon message={error} /> : null}
+
+        <Table<DashboardQueryPerformance>
+          rowKey="queryId"
+          size="small"
+          loading={loading}
+          columns={columns}
+          dataSource={records}
+          pagination={false}
+          scroll={{ x: 1500, y: 430 }}
+          locale={{
+            emptyText: (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={datasetIds.length
+                  ? '当前进程尚未采集到这些数据集的查询记录，请操作或刷新图表后再查看'
+                  : '当前仪表盘还没有可分析的数据集组件'}
+              />
+            ),
+          }}
+        />
+      </Modal>
+
+      <Modal
+        title="查询详情"
+        width={820}
+        open={Boolean(detail)}
+        onCancel={() => setDetail(undefined)}
+        footer={<Button onClick={() => setDetail(undefined)}>关闭</Button>}
+      >
+        {detail ? (
+          <div>
+            <Descriptions
+              size="small"
+              bordered
+              column={3}
+              items={[
+                { key: 'queryId', label: '查询 ID', children: detail.queryId, span: 3 },
+                { key: 'dataset', label: '数据集', children: detail.datasetName },
+                { key: 'version', label: '版本', children: `V${detail.datasetVersionNo}` },
+                { key: 'rows', label: '返回行数', children: detail.returnedRows },
+                { key: 'wait', label: '数据源等待', children: `${detail.waitMillis} ms` },
+                { key: 'prepare', label: '准备阶段', children: `${detail.prepareMillis} ms` },
+                { key: 'execute', label: 'SQL 执行', children: `${detail.executeMillis} ms` },
+                { key: 'transfer', label: '结果处理', children: `${detail.transferMillis} ms` },
+                { key: 'total', label: '总耗时', children: `${detail.totalMillis} ms` },
+                { key: 'start', label: '开始时间', children: formatTime(detail.startedAt) },
+              ]}
+            />
+            <div className="mt-4 text-[12px] font-semibold text-[#344054]">最终执行 SQL</div>
+            <pre className="mt-2 max-h-[320px] overflow-auto whitespace-pre-wrap break-all border border-[#e4e7ec] bg-[#f7f8fa] p-3 font-mono text-[11px] leading-5 text-[#344054]">
+              {detail.sql || '-- SQL 不可用'}
+            </pre>
+            <div className="mt-2 text-[10px] leading-5 text-[#98a2b3]">
+              SQL 执行时间包含 JDBC 驱动取数；结果处理时间仅统计 Query Runtime 对返回结果的截断与整理。
+            </div>
+          </div>
+        ) : null}
+      </Modal>
+    </>
+  );
+}

--- a/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
+++ b/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
@@ -1,5 +1,4 @@
 import { fetchAnalyses } from '@/components/analysis/analysis-service';
-import { fetchAnalysisDatasets } from '@/components/analysis/dataset-service';
 import {
   Alert,
   Button,
@@ -13,7 +12,7 @@ import {
 import { Download, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchDashboard } from './dashboard-service';
-import type { AnalysisAsset, DashboardWidget, PublishedDataset } from './model';
+import type { AnalysisAsset, DashboardWidget } from './model';
 import {
   fetchDashboardQueryPerformance,
   type DashboardQueryPerformance,
@@ -25,7 +24,7 @@ const formatTime = (value?: string) => {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false });
 };
 
-const escapeCsv = (value: unknown) => `"${String(value ?? '').replaceAll('"', '""')}"`;
+const escapeCsv = (value: unknown) => `"${String(value ?? '').replace(/"/g, '""')}"`;
 
 const widgetDatasetId = (widget: DashboardWidget, analyses: AnalysisAsset[]) => (
   widget.inlineAnalysis?.datasetId
@@ -55,7 +54,6 @@ export function DashboardPerformanceModal({
   const [detail, setDetail] = useState<DashboardQueryPerformance>();
   const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
   const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
-  const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
 
   const widgetNamesByDataset = useMemo(() => {
     const result = new Map<string, string[]>();
@@ -70,23 +68,17 @@ export function DashboardPerformanceModal({
     return result;
   }, [analyses, widgets]);
 
-  const datasetNameById = useMemo(() => new Map(
-    datasets.map((dataset) => [dataset.id, dataset.name]),
-  ), [datasets]);
-
   const load = useCallback(async () => {
     if (!/^\d+$/.test(dashboardId)) return;
     setLoading(true);
     setError(undefined);
     try {
-      const [dashboard, nextAnalyses, nextDatasets] = await Promise.all([
+      const [dashboard, nextAnalyses] = await Promise.all([
         fetchDashboard(dashboardId),
         fetchAnalyses(),
-        fetchAnalysisDatasets(),
       ]);
       setWidgets(dashboard.widgets);
       setAnalyses(nextAnalyses);
-      setDatasets(nextDatasets);
       const datasetIds = Array.from(new Set(dashboard.widgets
         .map((widget) => widgetDatasetId(widget, nextAnalyses))
         .filter((value): value is string => Boolean(value))));
@@ -110,7 +102,7 @@ export function DashboardPerformanceModal({
     const rows = records.map((record) => [
       dashboardName,
       (widgetNamesByDataset.get(record.datasetId) ?? []).join(' / '),
-      record.datasetName || datasetNameById.get(record.datasetId) || record.datasetId,
+      record.datasetName || record.datasetId,
       record.queryId,
       record.waitMillis,
       record.prepareMillis,
@@ -149,7 +141,7 @@ export function DashboardPerformanceModal({
     {
       title: '数据集',
       width: 150,
-      render: (_, record) => record.datasetName || datasetNameById.get(record.datasetId) || record.datasetId,
+      render: (_, record) => record.datasetName || record.datasetId,
     },
     {
       title: '查询ID',
@@ -199,7 +191,7 @@ export function DashboardPerformanceModal({
         <div className="mb-3 flex items-center justify-between">
           <div>
             <div className="text-[12px] font-semibold text-[#344054]">核心信息</div>
-            <div className="mt-0.5 text-[10px] text-[#98a2b3]">最近 100 条当前仪表盘 Dataset SQL 查询记录</div>
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">最近 100 条当前已保存仪表盘的 Dataset SQL 查询记录</div>
           </div>
           <div className="flex items-center gap-1">
             <Button type="text" size="small" icon={<RefreshCw size={12} />} loading={loading} onClick={() => void load()}>

--- a/yak-ops-ui/src/pages/dashboard/performance-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/performance-service.ts
@@ -1,0 +1,45 @@
+import type { ApiResponse } from '@/services/http/response';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+
+const PERFORMANCE_API = '/api/v1/datasets/query-performance';
+
+export interface DashboardQueryPerformance {
+  queryId: string;
+  datasetId: string;
+  datasetName: string;
+  datasetVersionId: string;
+  datasetVersionNo: number;
+  sourceType: 'QUERY_REVISION' | 'SQL_QUERY' | 'TABLE' | 'VIEW';
+  dataSourceId?: string | null;
+  sql: string;
+  waitMillis: number;
+  prepareMillis: number;
+  executeMillis: number;
+  transferMillis: number;
+  totalMillis: number;
+  returnedRows: number;
+  truncated: boolean;
+  startedAt: string;
+}
+
+const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+export const fetchDashboardQueryPerformance = async (
+  datasetIds: string[],
+  limit = 100,
+): Promise<DashboardQueryPerformance[]> => {
+  if (!datasetIds.length) return [];
+  const params = new URLSearchParams();
+  datasetIds.forEach((datasetId) => params.append('datasetIds', datasetId));
+  params.set('limit', String(limit));
+  return unwrap(
+    await HttpUtils.get<DashboardQueryPerformance[]>(`${PERFORMANCE_API}?${params.toString()}`),
+    '查询 Dataset 性能分析记录失败',
+  );
+};

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -34,6 +34,7 @@ export function DashboardToolbar({
   onRedo,
   onAddChart,
   onDashboardStyle,
+  onPerformance,
   onHistory,
   onPreview,
   onSaveDraft,
@@ -59,6 +60,7 @@ export function DashboardToolbar({
   onRedo: () => void;
   onAddChart: () => void;
   onDashboardStyle: () => void;
+  onPerformance: () => void;
   onHistory: () => void;
   onPreview: () => void;
   onSaveDraft: () => void;
@@ -199,6 +201,7 @@ export function DashboardToolbar({
                 size="small"
                 className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
                 icon={<Gauge size={13} />}
+                onClick={onPerformance}
               >
                 性能分析
               </Button>

--- a/yak-ops-ui/src/pages/dashboard/toolbar.tsx
+++ b/yak-ops-ui/src/pages/dashboard/toolbar.tsx
@@ -12,6 +12,8 @@ import {
   Undo2,
   X,
 } from 'lucide-react';
+import { useState } from 'react';
+import { DashboardPerformanceModal } from './performance-modal';
 
 export function DashboardToolbar({
   name,
@@ -34,7 +36,6 @@ export function DashboardToolbar({
   onRedo,
   onAddChart,
   onDashboardStyle,
-  onPerformance,
   onHistory,
   onPreview,
   onSaveDraft,
@@ -60,12 +61,12 @@ export function DashboardToolbar({
   onRedo: () => void;
   onAddChart: () => void;
   onDashboardStyle: () => void;
-  onPerformance: () => void;
   onHistory: () => void;
   onPreview: () => void;
   onSaveDraft: () => void;
   onPublish: () => void;
 }) {
+  const [performanceOpen, setPerformanceOpen] = useState(false);
   const persisted = /^\d+$/.test(dashboardId);
   const saveDisabled = persisted && !dirty;
   const busy = saving || publishing;
@@ -79,158 +80,174 @@ export function DashboardToolbar({
   })();
 
   return (
-    <header className="shrink-0 border-b border-[#dce3ea] bg-[#eef3f8]">
-      <div className="flex h-10 items-center justify-between border-b border-[#dce4ee] bg-[#eef3f8] px-3">
-        <div className="flex min-w-0 items-center gap-2.5">
-          <Tooltip title="退出编辑器">
-            <Button
-              type="text"
-              className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[6px] !p-0 !text-[#526075] hover:!bg-[#e1e8f1] hover:!text-[#1f2a44]"
-              icon={<ChevronLeft size={15} />}
-              disabled={preview || busy}
-              onClick={onBack}
-            />
-          </Tooltip>
-          <div className="h-5 w-px bg-[#ccd6e2]" />
-          <Input
-            variant="borderless"
-            value={name}
-            disabled={preview || busy}
-            onChange={(event) => onName(event.target.value)}
-            className="!h-6 !w-[250px] !bg-transparent !px-0 !text-[13px] !font-semibold !leading-6 !text-[#172033]"
-          />
-          <div className="hidden items-center gap-2 whitespace-nowrap text-[10px] text-[#6f7d91] lg:flex">
-            <span>{lifecycleText}</span>
-            {dirty ? (
-              <>
-                <span className="h-1 w-1 rounded-full bg-[#9ca9ba]" />
-                <span className="text-[#526075]">有未保存修改</span>
-              </>
-            ) : null}
-          </div>
-        </div>
-
-        {!preview ? (
-          <div className="flex items-center gap-1.5">
-            <Tooltip title={saveDisabled ? '当前没有需要保存到草稿的修改' : '保存草稿 Ctrl/Cmd + S'}>
-              <span>
-                <Button
-                  size="small"
-                  className="!h-7 !rounded-[6px] !border-[#cfd8e4] !bg-[rgba(255,255,255,.72)] !px-2.5 !text-[11px] !text-[#344054] hover:!border-[#bfcad8] hover:!bg-white"
-                  loading={saving}
-                  disabled={saveDisabled || publishing}
-                  icon={<Save size={12} />}
-                  onClick={onSaveDraft}
-                >
-                  保存草稿
-                </Button>
-              </span>
-            </Tooltip>
-            <Tooltip title={!canPublish ? '当前草稿已经是已发布版本' : undefined}>
-              <span>
-                <Button
-                  size="small"
-                  type="primary"
-                  className="!h-7 !rounded-[6px] !px-3 !text-[11px] !shadow-none"
-                  loading={publishing}
-                  disabled={!canPublish || saving}
-                  icon={<Send size={12} />}
-                  onClick={onPublish}
-                >
-                  {hasPublishedVersion ? '发布更新' : '发布'}
-                </Button>
-              </span>
-            </Tooltip>
-          </div>
-        ) : null}
-      </div>
-
-      <div className="flex h-8 items-center justify-between bg-white px-3">
-        <div className="flex items-center gap-1">
-          {!preview ? (
-            <>
+    <>
+      <header className="shrink-0 border-b border-[#dce3ea] bg-[#eef3f8]">
+        <div className="flex h-10 items-center justify-between border-b border-[#dce4ee] bg-[#eef3f8] px-3">
+          <div className="flex min-w-0 items-center gap-2.5">
+            <Tooltip title="退出编辑器">
               <Button
                 type="text"
-                size="small"
-                className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
-                disabled={!canAddChart || busy}
-                icon={<BarChart3 size={13} />}
-                onClick={onAddChart}
-              >
-                添加图表
-              </Button>
-              <div className="mx-1 h-4 w-px bg-[#e1e5ea]" />
-              <Tooltip title="撤销 Ctrl/Cmd + Z">
-                <Button
-                  type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
-                  icon={<Undo2 size={13} />}
-                  disabled={!canUndo || busy}
-                  onClick={onUndo}
-                />
-              </Tooltip>
-              <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
-                <Button
-                  type="text"
-                  className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
-                  icon={<Redo2 size={13} />}
-                  disabled={!canRedo || busy}
-                  onClick={onRedo}
-                />
-              </Tooltip>
-            </>
-          ) : (
-            <span className="text-[12px] font-medium text-[#161823]">预览模式</span>
-          )}
-        </div>
-
-        <div className="flex items-center gap-1">
-          {!preview ? (
-            <>
-              <Button
-                type="text"
-                size="small"
-                className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
-                icon={<Palette size={13} />}
-                onClick={onDashboardStyle}
-              >
-                仪表盘样式
-              </Button>
-              <Button
-                type="text"
-                size="small"
-                className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
-                icon={<Gauge size={13} />}
-                onClick={onPerformance}
-              >
-                性能分析
-              </Button>
-            </>
-          ) : null}
-
-          {persisted && currentVersionNo && !preview ? (
-            <Tooltip title="历史版本">
-              <Button
-                type="text"
-                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#344054] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
-                disabled={busy}
-                icon={<History size={13} />}
-                onClick={onHistory}
+                className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[6px] !p-0 !text-[#526075] hover:!bg-[#e1e8f1] hover:!text-[#1f2a44]"
+                icon={<ChevronLeft size={15} />}
+                disabled={preview || busy}
+                onClick={onBack}
               />
             </Tooltip>
+            <div className="h-5 w-px bg-[#ccd6e2]" />
+            <Input
+              variant="borderless"
+              value={name}
+              disabled={preview || busy}
+              onChange={(event) => onName(event.target.value)}
+              className="!h-6 !w-[250px] !bg-transparent !px-0 !text-[13px] !font-semibold !leading-6 !text-[#172033]"
+            />
+            <div className="hidden items-center gap-2 whitespace-nowrap text-[10px] text-[#6f7d91] lg:flex">
+              <span>{lifecycleText}</span>
+              {dirty ? (
+                <>
+                  <span className="h-1 w-1 rounded-full bg-[#9ca9ba]" />
+                  <span className="text-[#526075]">有未保存修改</span>
+                </>
+              ) : null}
+            </div>
+          </div>
+
+          {!preview ? (
+            <div className="flex items-center gap-1.5">
+              <Tooltip title={saveDisabled ? '当前没有需要保存到草稿的修改' : '保存草稿 Ctrl/Cmd + S'}>
+                <span>
+                  <Button
+                    size="small"
+                    className="!h-7 !rounded-[6px] !border-[#cfd8e4] !bg-[rgba(255,255,255,.72)] !px-2.5 !text-[11px] !text-[#344054] hover:!border-[#bfcad8] hover:!bg-white"
+                    loading={saving}
+                    disabled={saveDisabled || publishing}
+                    icon={<Save size={12} />}
+                    onClick={onSaveDraft}
+                  >
+                    保存草稿
+                  </Button>
+                </span>
+              </Tooltip>
+              <Tooltip title={!canPublish ? '当前草稿已经是已发布版本' : undefined}>
+                <span>
+                  <Button
+                    size="small"
+                    type="primary"
+                    className="!h-7 !rounded-[6px] !px-3 !text-[11px] !shadow-none"
+                    loading={publishing}
+                    disabled={!canPublish || saving}
+                    icon={<Send size={12} />}
+                    onClick={onPublish}
+                  >
+                    {hasPublishedVersion ? '发布更新' : '发布'}
+                  </Button>
+                </span>
+              </Tooltip>
+            </div>
           ) : null}
-          <Button
-            type="text"
-            size="small"
-            className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
-            disabled={busy}
-            icon={preview ? <X size={13} /> : <Eye size={13} />}
-            onClick={onPreview}
-          >
-            {preview ? '退出预览' : '预览'}
-          </Button>
         </div>
-      </div>
-    </header>
+
+        <div className="flex h-8 items-center justify-between bg-white px-3">
+          <div className="flex items-center gap-1">
+            {!preview ? (
+              <>
+                <Button
+                  type="text"
+                  size="small"
+                  className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
+                  disabled={!canAddChart || busy}
+                  icon={<BarChart3 size={13} />}
+                  onClick={onAddChart}
+                >
+                  添加图表
+                </Button>
+                <div className="mx-1 h-4 w-px bg-[#e1e5ea]" />
+                <Tooltip title="撤销 Ctrl/Cmd + Z">
+                  <Button
+                    type="text"
+                    className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
+                    icon={<Undo2 size={13} />}
+                    disabled={!canUndo || busy}
+                    onClick={onUndo}
+                  />
+                </Tooltip>
+                <Tooltip title="重做 Ctrl/Cmd + Shift + Z">
+                  <Button
+                    type="text"
+                    className="!h-7 !w-7 !min-w-0 !rounded-[5px] !p-0 !text-[var(--yak-brand-color)] hover:!bg-[var(--yak-brand-color-soft)] hover:!text-[var(--yak-brand-color)]"
+                    icon={<Redo2 size={13} />}
+                    disabled={!canRedo || busy}
+                    onClick={onRedo}
+                  />
+                </Tooltip>
+              </>
+            ) : (
+              <span className="text-[12px] font-medium text-[#161823]">预览模式</span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-1">
+            {!preview ? (
+              <>
+                <Button
+                  type="text"
+                  size="small"
+                  className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+                  icon={<Palette size={13} />}
+                  onClick={onDashboardStyle}
+                >
+                  仪表盘样式
+                </Button>
+                <Tooltip title={persisted ? undefined : '请先保存仪表盘，再查看 Dataset 查询性能'}>
+                  <span>
+                    <Button
+                      type="text"
+                      size="small"
+                      className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+                      icon={<Gauge size={13} />}
+                      disabled={!persisted}
+                      onClick={() => setPerformanceOpen(true)}
+                    >
+                      性能分析
+                    </Button>
+                  </span>
+                </Tooltip>
+              </>
+            ) : null}
+
+            {persisted && currentVersionNo && !preview ? (
+              <Tooltip title="历史版本">
+                <Button
+                  type="text"
+                  className="!flex !h-7 !w-7 !min-w-0 !items-center !justify-center !rounded-[5px] !p-0 !text-[#344054] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+                  disabled={busy}
+                  icon={<History size={13} />}
+                  onClick={onHistory}
+                />
+              </Tooltip>
+            ) : null}
+            <Button
+              type="text"
+              size="small"
+              className="!h-7 !rounded-[5px] !px-2 !text-[12px] !font-medium !text-[#161823] hover:!bg-[#f3f5f7] hover:!text-[#161823]"
+              disabled={busy}
+              icon={preview ? <X size={13} /> : <Eye size={13} />}
+              onClick={onPreview}
+            >
+              {preview ? '退出预览' : '预览'}
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {persisted ? (
+        <DashboardPerformanceModal
+          open={performanceOpen}
+          dashboardId={dashboardId}
+          dashboardName={name}
+          onClose={() => setPerformanceOpen(false)}
+        />
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
## Overview

新增 Dashboard「性能分析」能力，参考 FineBI 的操作流程，但第一阶段只展示 Yak Ops 能真实采集的 Dataset SQL 查询链路，不伪造内存计算或前端渲染耗时。

用户在 Dashboard 编辑器顶部点击「性能分析」后，会打开性能分析 Modal，查看当前已保存仪表盘涉及的数据集最近查询情况，并可进一步查看最终执行 SQL 或导出 CSV。

## Backend query tracing

Dataset Query Runtime 现在会在真实执行路径上采集：

- Query ID
- Dataset / DatasetVersion
- sourceType / dataSourceId
- 最终编译后的 SQL
- 数据源等待时间：`DataSourceExecutionProvider.open(...)`
- 查询准备阶段：Dataset/version/fields 解析 + TaskRevision/source config + SQL compile
- SQL 执行时间：`DataSourceSqlExecutor.execute(...)`
- 结果处理时间：结果集校验、limit/truncated 整理
- 总查询时间：DatasetQueryService 从接收查询到完成结果的完整时间
- 返回行数 / truncated
- 查询开始时间

原有 `DatasetQueryResult.elapsedMillis` 的语义保持兼容，仍表示进入数据源运行阶段后的耗时；新的完整总耗时只存在 performance trace 中，不改变现有 Dataset Query 返回协议。

## Performance trace storage

新增 `DatasetQueryPerformanceService`，在进程内保留最近 500 条 trace，查询接口最多返回 200 条。

这里刻意不把诊断 trace 同步写数据库：性能分析本身不应该给正在测量的 SQL 增加额外数据库 I/O。服务重启后 trace 会清空，这是当前诊断窗口的明确边界。

新增接口：

`GET /api/v1/datasets/query-performance?datasetIds=...&limit=100`

支持按 Dataset ID 过滤，Dashboard 只读取自己涉及的数据集记录。

## Dashboard UI

顶部原有「性能分析」入口现在接入真实功能：

- 未保存 Dashboard 禁用，并提示先保存
- 打开 Modal 自动读取当前已保存 Dashboard 快照
- 根据 inline Analysis / AnalysisAsset 解析当前 Dashboard 使用的 Dataset
- 仅查询这些 Dataset 的性能记录
- 表格展示：一级资源、二级资源、Dataset、Query ID、等待/准备/执行/结果处理/总耗时、返回行数、开始时间
- Query ID 可点击打开查询详情
- 查询详情展示完整 Query ID、各阶段耗时和最终编译 SQL
- 支持刷新
- 支持导出 CSV 详细信息
- 总耗时 >= 1000ms 时使用 Yak 主色强调

如果同一 Dataset 被多个 Dashboard 组件消费，二级资源名称会展示这些组件名称；Dataset Query Runtime 仍保持 Dashboard 无关，不在后端耦合 widget id。

## Why some FineBI fields are not included yet

参考截图中还有「内存计算时间 / 前端渲染时间」。本阶段没有填充这些字段，因为当前 Query Runtime 无法真实测量它们。

后续如果需要，可以让 Query ID 从 Dataset response 继续贯穿 AnalysisPreview / ECharts render，再补浏览器端 profiling；本 PR 不用 0ms 伪装这些指标。

## Tests

- 新增 `DatasetQueryPerformanceServiceTest`
  - Dataset 过滤
  - newest-first 顺序
  - 查询窗口限制
- 更新 `QueryRevisionDatasetSourceAdapterTest`
  - 兼容新的 execution diagnostics wrapper
  - 校验最终 SQL / datasourceId
  - 校验四个阶段耗时非负

## Validation

- 分支创建 PR 前 compare：`behind=0`
- Diff 仅涉及 Dataset Query Runtime、性能分析 API/测试，以及 Dashboard 性能分析 Modal/toolbar
- 无 Flyway / 数据库 schema 改动
- 不修改 Dataset Query JSON response contract
- 当前执行环境无法稳定 clone github.com，因此未运行完整 Maven / TypeScript build；建议本地或 CI 重点回归 Dataset 模块测试、Dashboard Modal 表格横向滚动、SQL 详情与 CSV 导出
