### PR TITLE
feat: add phase 1 unified SQL execution runtime

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-service/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-datasource-api</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
@@ -10,11 +10,12 @@ import io.yak.ops.business.dataservice.service.DataServiceAccessService.AccessCo
 import io.yak.ops.business.dataservice.service.DataServiceRuntimeService.RuntimeSnapshot;
 import io.yak.ops.business.dataservice.service.support.DataServiceSqlCompiler;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
-import io.yak.ops.business.datasource.service.support.BusinessDataSourceExecutionProvider;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionColumn;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -42,7 +43,7 @@ public class DataServiceService {
 
   private final DataServiceApiMapper apiMapper;
   private final DataServiceCallLogMapper callLogMapper;
-  private final BusinessDataSourceExecutionProvider executionProvider;
+  private final SqlExecutionRuntime sqlExecutionRuntime;
   private final DataServiceSqlCompiler sqlCompiler;
   private final ObjectMapper objectMapper;
   private final DataServiceAccessService accessService;
@@ -302,21 +303,21 @@ public class DataServiceService {
   private QueryResponse executeDatabase(
       DataServiceApiPO api,
       DataServiceSqlCompiler.CompiledSql compiled) {
-    long started = System.nanoTime();
-    DataSourceSqlResult result;
-    try (DataSourceSqlExecutor executor = executionProvider.open(String.valueOf(api.getDataSourceId()))) {
-      result = executor.execute(
-          new DataSourceSqlRequest(
-              compiled.sql(), api.getMaxRows(), api.getTimeoutSeconds(), compiled.parameters()));
-    }
+    SqlExecutionResult result = sqlExecutionRuntime.execute(new SqlExecutionRequest(
+        String.valueOf(api.getDataSourceId()),
+        compiled.sql(),
+        compiled.parameters(),
+        api.getMaxRows(),
+        api.getTimeoutSeconds(),
+        SqlExecutionContext.of(SqlExecutionCaller.DATA_SERVICE, String.valueOf(api.getId()))));
     if (!result.resultSet()) {
       throw new IllegalStateException("数据服务仅允许返回 SELECT 查询结果");
     }
-    return toResponse(result, elapsedMs(started));
+    return toResponse(result);
   }
 
-  private QueryResponse toResponse(DataSourceSqlResult result, long durationMs) {
-    List<String> columns = result.columns().stream().map(DataSourceSqlColumn::label).toList();
+  private QueryResponse toResponse(SqlExecutionResult result) {
+    List<String> columns = result.columns().stream().map(SqlExecutionColumn::label).toList();
     List<Map<String, Object>> rows = new ArrayList<>(result.rows().size());
     for (List<Object> values : result.rows()) {
       Map<String, Object> row = new LinkedHashMap<>();
@@ -325,7 +326,8 @@ public class DataServiceService {
       }
       rows.add(row);
     }
-    return new QueryResponse(columns, rows, result.truncated(), rows.size(), durationMs);
+    return new QueryResponse(
+        columns, rows, result.truncated(), rows.size(), result.timing().totalMillis());
   }
 
   private void saveLog(

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServiceServiceSourceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServiceServiceSourceTest.java
@@ -15,7 +15,7 @@ import io.yak.ops.business.dataservice.service.DataServiceService.RuntimeDefinit
 import io.yak.ops.business.dataservice.service.DataServiceService.ServiceSettingsInput;
 import io.yak.ops.business.dataservice.service.DataServiceService.SourceSnapshot;
 import io.yak.ops.business.dataservice.service.support.DataServiceSqlCompiler;
-import io.yak.ops.business.datasource.service.support.BusinessDataSourceExecutionProvider;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ class DataServiceServiceSourceTest {
     service = new DataServiceService(
         apiMapper,
         mock(DataServiceCallLogMapper.class),
-        mock(BusinessDataSourceExecutionProvider.class),
+        mock(SqlExecutionRuntime.class),
         new DataServiceSqlCompiler(),
         new ObjectMapper(),
         mock(DataServiceAccessService.class),

--- a/yak-ops-business/yak-ops-business-dataset/pom.xml
+++ b/yak-ops-business/yak-ops-business-dataset/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
@@ -2,7 +2,7 @@ package io.yak.ops.business.dataset;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.core.execution.sql.SqlExecutionColumn;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,7 +13,7 @@ public record DatasetQueryResult(
     @JsonSerialize(using = ToStringSerializer.class) long datasetVersionId,
     int datasetVersionNo,
     List<DatasetQueryColumnBinding> bindings,
-    List<DataSourceSqlColumn> columns,
+    List<SqlExecutionColumn> columns,
     List<List<Object>> rows,
     int returnedRows,
     boolean truncated,

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/SqlQueryDatasetSourceAdapter.java
@@ -1,9 +1,10 @@
 package io.yak.ops.business.dataset;
 
-import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -14,13 +15,13 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
   private static final int DEFAULT_TIMEOUT_SECONDS = 30;
   private static final int MAX_TIMEOUT_SECONDS = 120;
 
-  private final DataSourceExecutionProvider dataSourceExecutionProvider;
+  private final SqlExecutionRuntime sqlExecutionRuntime;
   private final DatasetQueryCompiler compiler;
 
   SqlQueryDatasetSourceAdapter(
-      DataSourceExecutionProvider dataSourceExecutionProvider,
+      SqlExecutionRuntime sqlExecutionRuntime,
       DatasetQueryCompiler compiler) {
-    this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.sqlExecutionRuntime = sqlExecutionRuntime;
     this.compiler = compiler;
   }
 
@@ -48,17 +49,14 @@ final class SqlQueryDatasetSourceAdapter implements DatasetSourceQueryAdapter {
     long prepareMillis = elapsedMillis(prepareStartedAt);
     long runtimeStartedAt = System.nanoTime();
 
-    long waitStartedAt = System.nanoTime();
-    DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(version.dataSourceId());
-    long waitMillis = elapsedMillis(waitStartedAt);
-
-    DataSourceSqlResult result;
-    long executeStartedAt = System.nanoTime();
-    try (executor) {
-      result = executor.execute(new DataSourceSqlRequest(
-          compiled.sql(), compiled.fetchRows(), timeoutSeconds));
-    }
-    long executeMillis = elapsedMillis(executeStartedAt);
+    SqlExecutionResult result = sqlExecutionRuntime.execute(new SqlExecutionRequest(
+        version.dataSourceId(),
+        compiled.sql(),
+        compiled.fetchRows(),
+        timeoutSeconds,
+        SqlExecutionContext.of(SqlExecutionCaller.DATASET, String.valueOf(dataset.id()))));
+    long waitMillis = result.timing().openMillis();
+    long executeMillis = result.timing().executeMillis();
 
     long transferStartedAt = System.nanoTime();
     if (!result.resultSet()) {

--- a/yak-ops-business/yak-ops-business-datasource/pom.xml
+++ b/yak-ops-business/yak-ops-business-datasource/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-plugin-datasource-api</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
@@ -1,0 +1,73 @@
+package io.yak.ops.business.datasource.execution;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.execution.sql.SqlExecutionColumn;
+import io.yak.ops.core.execution.sql.SqlExecutionException;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionResultType;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
+import io.yak.ops.core.execution.sql.SqlExecutionTiming;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Default SQL runtime backed by the existing datasource execution SPI. */
+@Component
+@ConditionalOnDataSourceEnabled
+public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
+
+  private final DataSourceExecutionProvider executionProvider;
+
+  public DefaultSqlExecutionRuntime(DataSourceExecutionProvider executionProvider) {
+    this.executionProvider = executionProvider;
+  }
+
+  @Override
+  public SqlExecutionResult execute(SqlExecutionRequest request) {
+    long totalStartedAt = System.nanoTime();
+    long openStartedAt = System.nanoTime();
+    DataSourceSqlExecutor executor = executionProvider.open(request.dataSourceId());
+    long openMillis = elapsedMillis(openStartedAt);
+
+    long executeStartedAt = System.nanoTime();
+    DataSourceSqlResult result;
+    try (executor) {
+      result = executor.execute(new DataSourceSqlRequest(
+          request.sql(), request.maxRows(), request.timeoutSeconds(), request.parameters()));
+    } catch (RuntimeException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new SqlExecutionException(request.dataSourceId(), request.context(), exception);
+    }
+    long executeMillis = elapsedMillis(executeStartedAt);
+    long totalMillis = elapsedMillis(totalStartedAt);
+
+    return new SqlExecutionResult(
+        result.resultSet() ? SqlExecutionResultType.RESULT_SET : SqlExecutionResultType.UPDATE_COUNT,
+        mapColumns(result.columns()),
+        result.rows(),
+        result.affectedRows(),
+        result.truncated(),
+        new SqlExecutionTiming(openMillis, executeMillis, totalMillis));
+  }
+
+  private static List<SqlExecutionColumn> mapColumns(List<DataSourceSqlColumn> columns) {
+    return columns.stream()
+        .map(column -> new SqlExecutionColumn(
+            column.name(),
+            column.label(),
+            column.typeName(),
+            column.jdbcType(),
+            column.nullable()))
+        .toList();
+  }
+
+  private static long elapsedMillis(long startedAt) {
+    return Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
@@ -1,0 +1,128 @@
+package io.yak.ops.business.datasource.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionException;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionResultType;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DefaultSqlExecutionRuntimeTest {
+
+  @Test
+  void mapsResultSetAndPreservesNullableSqlValues() {
+    CapturingExecutor executor = new CapturingExecutor(new DataSourceSqlResult(
+        true,
+        List.of(new DataSourceSqlColumn("name", "name", "VARCHAR", Types.VARCHAR, true)),
+        List.of(Arrays.asList("Yak", null)),
+        0L,
+        false));
+    SqlExecutionRequest request = new SqlExecutionRequest(
+        " 12 ",
+        " select name from demo where id = ? and deleted_at is ? ",
+        Arrays.asList(7L, null),
+        100,
+        30,
+        SqlExecutionContext.of(SqlExecutionCaller.DATASET, "42"));
+
+    SqlExecutionResult result = runtime(executor).execute(request);
+
+    assertEquals(SqlExecutionResultType.RESULT_SET, result.type());
+    assertTrue(result.resultSet());
+    assertEquals(1, result.returnedRows());
+    assertEquals("name", result.columns().get(0).label());
+    assertNull(result.rows().get(0).get(1));
+    assertEquals("12", executor.request.dataSourceId());
+    assertNull(executor.request.parameters().get(1));
+    assertTrue(executor.closed);
+  }
+
+  @Test
+  void mapsUpdateCountWithoutPretendingItIsAQueryResult() {
+    CapturingExecutor executor = new CapturingExecutor(DataSourceSqlResult.updateCount(3L));
+    SqlExecutionResult result = runtime(executor).execute(new SqlExecutionRequest(
+        "9",
+        "update demo set enabled = 1",
+        10,
+        30,
+        SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-1")));
+
+    assertEquals(SqlExecutionResultType.UPDATE_COUNT, result.type());
+    assertFalse(result.resultSet());
+    assertEquals(3L, result.affectedRows());
+    assertEquals(0, result.returnedRows());
+  }
+
+  @Test
+  void wrapsCheckedDatasourceFailuresAndKeepsTheCause() {
+    CapturingExecutor executor = new CapturingExecutor(new Exception("driver failed"));
+    SqlExecutionException exception = assertThrows(
+        SqlExecutionException.class,
+        () -> runtime(executor).execute(new SqlExecutionRequest(
+            "9",
+            "select 1",
+            10,
+            30,
+            SqlExecutionContext.of(SqlExecutionCaller.DATA_SERVICE, "service-2"))));
+
+    assertEquals("9", exception.dataSourceId());
+    assertEquals(SqlExecutionCaller.DATA_SERVICE, exception.context().caller());
+    assertInstanceOf(Exception.class, exception.getCause());
+    assertEquals("driver failed", exception.getCause().getMessage());
+  }
+
+  private static DefaultSqlExecutionRuntime runtime(CapturingExecutor executor) {
+    DataSourceExecutionProvider provider = dataSourceId -> {
+      executor.request = new CapturedRequest(dataSourceId, List.of());
+      return executor;
+    };
+    return new DefaultSqlExecutionRuntime(provider);
+  }
+
+  private record CapturedRequest(String dataSourceId, List<Object> parameters) {}
+
+  private static final class CapturingExecutor implements DataSourceSqlExecutor {
+    private final DataSourceSqlResult result;
+    private final Exception failure;
+    private CapturedRequest request;
+    private boolean closed;
+
+    private CapturingExecutor(DataSourceSqlResult result) {
+      this.result = result;
+      this.failure = null;
+    }
+
+    private CapturingExecutor(Exception failure) {
+      this.result = null;
+      this.failure = failure;
+    }
+
+    @Override
+    public DataSourceSqlResult execute(DataSourceSqlRequest request) throws Exception {
+      this.request = new CapturedRequest(this.request.dataSourceId(), request.parameters());
+      if (failure != null) throw failure;
+      return result;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/package-info.java
@@ -1,2 +1,2 @@
-/** Generic execution context, lifecycle and listener mechanisms. */
+/** Shared execution contracts and runtime coordination primitives. */
 package io.yak.ops.core.execution;

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionCaller.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionCaller.java
@@ -1,0 +1,11 @@
+package io.yak.ops.core.execution.sql;
+
+/** Product/runtime origin that initiated a SQL execution. */
+public enum SqlExecutionCaller {
+  CONSOLE,
+  SQL_TASK,
+  DATASET,
+  DATA_SERVICE,
+  ANALYSIS,
+  SYSTEM
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionColumn.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionColumn.java
@@ -1,0 +1,10 @@
+package io.yak.ops.core.execution.sql;
+
+/** JDBC-neutral column metadata exposed by the platform SQL execution contract. */
+public record SqlExecutionColumn(
+    String name,
+    String label,
+    String typeName,
+    int jdbcType,
+    boolean nullable) {
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionContext.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionContext.java
@@ -1,0 +1,25 @@
+package io.yak.ops.core.execution.sql;
+
+import java.util.Objects;
+
+/** Identifies the platform caller without leaking domain-specific models into the SQL runtime. */
+public record SqlExecutionContext(SqlExecutionCaller caller, String callerReference) {
+
+  public SqlExecutionContext {
+    caller = Objects.requireNonNull(caller, "caller");
+    callerReference = normalize(callerReference);
+  }
+
+  public static SqlExecutionContext of(SqlExecutionCaller caller, String callerReference) {
+    return new SqlExecutionContext(caller, callerReference);
+  }
+
+  public static SqlExecutionContext system() {
+    return new SqlExecutionContext(SqlExecutionCaller.SYSTEM, null);
+  }
+
+  private static String normalize(String value) {
+    if (value == null || value.isBlank()) return null;
+    return value.trim();
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionException.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionException.java
@@ -1,0 +1,30 @@
+package io.yak.ops.core.execution.sql;
+
+/** Wraps checked datasource execution failures without exposing driver-specific contracts upstream. */
+public final class SqlExecutionException extends RuntimeException {
+
+  private final String dataSourceId;
+  private final SqlExecutionContext context;
+
+  public SqlExecutionException(
+      String dataSourceId,
+      SqlExecutionContext context,
+      Throwable cause) {
+    super(message(dataSourceId, context), cause);
+    this.dataSourceId = dataSourceId;
+    this.context = context;
+  }
+
+  public String dataSourceId() {
+    return dataSourceId;
+  }
+
+  public SqlExecutionContext context() {
+    return context;
+  }
+
+  private static String message(String dataSourceId, SqlExecutionContext context) {
+    String caller = context == null ? "UNKNOWN" : context.caller().name();
+    return "SQL execution failed for datasource " + dataSourceId + " (caller=" + caller + ")";
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRequest.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRequest.java
@@ -1,0 +1,48 @@
+package io.yak.ops.core.execution.sql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Platform-neutral request for one synchronous SQL execution. */
+public record SqlExecutionRequest(
+    String dataSourceId,
+    String sql,
+    List<Object> parameters,
+    int maxRows,
+    int timeoutSeconds,
+    SqlExecutionContext context) {
+
+  public SqlExecutionRequest {
+    dataSourceId = requireText(dataSourceId, "dataSourceId");
+    sql = requireText(sql, "sql");
+    if (maxRows <= 0) throw new IllegalArgumentException("maxRows must be greater than zero");
+    if (timeoutSeconds <= 0) {
+      throw new IllegalArgumentException("timeoutSeconds must be greater than zero");
+    }
+    parameters = immutableNullableList(parameters);
+    context = Objects.requireNonNull(context, "context");
+  }
+
+  public SqlExecutionRequest(
+      String dataSourceId,
+      String sql,
+      int maxRows,
+      int timeoutSeconds,
+      SqlExecutionContext context) {
+    this(dataSourceId, sql, List.of(), maxRows, timeoutSeconds, context);
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static List<Object> immutableNullableList(List<Object> values) {
+    if (values == null || values.isEmpty()) return List.of();
+    return Collections.unmodifiableList(new ArrayList<>(values));
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionResult.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionResult.java
@@ -1,31 +1,32 @@
-package io.yak.ops.spi.datasource.execution;
+package io.yak.ops.core.execution.sql;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-/** JDBC-neutral SQL execution result. */
-public record DataSourceSqlResult(
-    boolean resultSet,
-    List<DataSourceSqlColumn> columns,
+/** Result of one synchronous SQL execution. SQL semantics remain a caller/policy concern. */
+public record SqlExecutionResult(
+    SqlExecutionResultType type,
+    List<SqlExecutionColumn> columns,
     List<List<Object>> rows,
     long affectedRows,
-    boolean truncated) {
+    boolean truncated,
+    SqlExecutionTiming timing) {
 
-  public DataSourceSqlResult {
+  public SqlExecutionResult {
+    type = Objects.requireNonNull(type, "type");
     columns = columns == null ? List.of() : List.copyOf(columns);
     rows = immutableRows(rows);
+    timing = Objects.requireNonNull(timing, "timing");
   }
 
-  public static DataSourceSqlResult resultSet(
-      List<DataSourceSqlColumn> columns,
-      List<List<Object>> rows,
-      boolean truncated) {
-    return new DataSourceSqlResult(true, columns, rows, 0L, truncated);
+  public boolean resultSet() {
+    return type == SqlExecutionResultType.RESULT_SET;
   }
 
-  public static DataSourceSqlResult updateCount(long affectedRows) {
-    return new DataSourceSqlResult(false, List.of(), List.of(), affectedRows, false);
+  public int returnedRows() {
+    return rows.size();
   }
 
   private static List<List<Object>> immutableRows(List<List<Object>> values) {

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionResultType.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionResultType.java
@@ -1,0 +1,7 @@
+package io.yak.ops.core.execution.sql;
+
+/** Shape of the result produced by the current synchronous execution contract. */
+public enum SqlExecutionResultType {
+  RESULT_SET,
+  UPDATE_COUNT
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRuntime.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRuntime.java
@@ -1,0 +1,7 @@
+package io.yak.ops.core.execution.sql;
+
+/** Shared SQL execution boundary used by product and domain adapters. */
+public interface SqlExecutionRuntime {
+
+  SqlExecutionResult execute(SqlExecutionRequest request);
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionTiming.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionTiming.java
@@ -1,0 +1,11 @@
+package io.yak.ops.core.execution.sql;
+
+/** Basic synchronous timing retained while callers migrate to the shared runtime. */
+public record SqlExecutionTiming(long openMillis, long executeMillis, long totalMillis) {
+
+  public SqlExecutionTiming {
+    if (openMillis < 0 || executeMillis < 0 || totalMillis < 0) {
+      throw new IllegalArgumentException("SQL execution timings must not be negative");
+    }
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/package-info.java
@@ -1,0 +1,2 @@
+/** Platform-neutral SQL execution contracts shared by product and domain adapters. */
+package io.yak.ops.core.execution.sql;

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlRequest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlRequest.java
@@ -1,30 +1,37 @@
 package io.yak.ops.spi.datasource.execution;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-/** Immutable SQL execution request shared by task plugins and datasource plugins. */
+/** JDBC-neutral request used by SQL-capable datasource plugins. */
 public record DataSourceSqlRequest(
     String sql,
     int maxRows,
     int timeoutSeconds,
     List<Object> parameters) {
 
-  /** Backward-compatible constructor for callers that execute SQL without bind parameters. */
+  public DataSourceSqlRequest {
+    sql = Objects.requireNonNull(sql, "sql").trim();
+    if (sql.isEmpty()) {
+      throw new IllegalArgumentException("sql must not be blank");
+    }
+    if (maxRows <= 0) {
+      throw new IllegalArgumentException("maxRows must be greater than zero");
+    }
+    if (timeoutSeconds <= 0) {
+      throw new IllegalArgumentException("timeoutSeconds must be greater than zero");
+    }
+    parameters = immutableNullableList(parameters);
+  }
+
   public DataSourceSqlRequest(String sql, int maxRows, int timeoutSeconds) {
     this(sql, maxRows, timeoutSeconds, List.of());
   }
 
-  public DataSourceSqlRequest {
-    if (sql == null || sql.isBlank()) {
-      throw new IllegalArgumentException("sql must not be blank");
-    }
-    sql = sql.trim();
-    if (maxRows < 1 || maxRows > 10_000) {
-      throw new IllegalArgumentException("maxRows must be between 1 and 10000");
-    }
-    if (timeoutSeconds < 1 || timeoutSeconds > 3_600) {
-      throw new IllegalArgumentException("timeoutSeconds must be between 1 and 3600");
-    }
-    parameters = parameters == null ? List.of() : List.copyOf(parameters);
+  private static List<Object> immutableNullableList(List<Object> values) {
+    if (values == null || values.isEmpty()) return List.of();
+    return Collections.unmodifiableList(new ArrayList<>(values));
   }
 }


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of the Yak Ops SQL execution unification plan: establish a platform-level SQL execution contract above the existing datasource execution SPI.

### What changed

- Added platform-neutral SQL execution contracts under `yak-ops-core`:
  - `SqlExecutionRuntime`
  - `SqlExecutionRequest`
  - `SqlExecutionContext` / `SqlExecutionCaller`
  - `SqlExecutionResult` / `SqlExecutionResultType`
  - `SqlExecutionColumn`
  - `SqlExecutionTiming`
  - `SqlExecutionException`
- Added `DefaultSqlExecutionRuntime` in `yak-ops-business-datasource` as the adapter to the existing `DataSourceExecutionProvider` / `DataSourceSqlExecutor` SPI.
- Migrated Dataset SQL execution to the shared runtime while preserving its prepare / datasource-open / execute / transfer performance diagnostics.
- Migrated Data Service database execution to the shared runtime while keeping Data Service SQL compilation, read-only validation, cache, circuit breaker, access control, and invocation logs in the Data Service domain.
- Kept result semantics execution-oriented rather than query-only: the shared result explicitly supports both `RESULT_SET` and `UPDATE_COUNT`, leaving room for DML without redesigning the contract.
- Fixed datasource request/result immutability handling so SQL `NULL` bound parameters and `NULL` result cells are preserved instead of being rejected by `List.copyOf`.
- Added focused tests for result-set mapping, update-count mapping, nullable SQL values, executor closing, and checked datasource failure wrapping.
- Updated the existing Data Service source-management test to use the new shared runtime dependency.

## Architecture boundary

```text
Dataset / Data Service / future Console / SQL Task
                    ↓
             SqlExecutionRuntime
                    ↓
        DataSourceExecutionProvider
                    ↓
          DataSourceSqlExecutor
```

`yak-ops-core` owns only the execution contract. It does not depend on JDBC or datasource plugin implementation details. The concrete adapter lives in `yak-ops-business-datasource`.

## Intentionally not included in Phase 1

- executionId / persisted execution lifecycle
- multi-statement execution model
- cancellation orchestration in the shared runtime
- SQL statement classification and execution policy
- transaction modes
- execution events / streaming
- SQL Task migration

SQL Task is intentionally left on its current executor path for now because its cancellation behavior holds the active `DataSourceSqlExecutor`; moving it before the execution lifecycle is designed would prematurely couple Phase 1 to Phase 2.

## Validation

- The execution contract/default adapter shape was syntax-checked against the current datasource SPI with Java 21.
- Added unit coverage for the new default runtime and updated the affected existing Data Service constructor test.
- The branch is one commit ahead of the current `main` and zero commits behind.
- Full Maven test execution was not available in this environment because Maven is not installed; the repository currently has no `.github/workflows` GitHub Actions workflow to provide an automatic CI result.
