### PR TITLE
feat: add phase 2 SQL execution lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
@@ -3,17 +3,37 @@ package io.yak.ops.business.datasource.execution;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.core.execution.sql.SqlExecutionColumn;
 import io.yak.ops.core.execution.sql.SqlExecutionException;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
 import io.yak.ops.core.execution.sql.SqlExecutionRequest;
 import io.yak.ops.core.execution.sql.SqlExecutionResult;
 import io.yak.ops.core.execution.sql.SqlExecutionResultType;
 import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
 import io.yak.ops.core.execution.sql.SqlExecutionTiming;
+import io.yak.ops.core.execution.sql.SqlStatementRequest;
+import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import jakarta.annotation.PreDestroy;
+import java.sql.SQLTimeoutException;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.stereotype.Component;
 
 /** Default SQL runtime backed by the existing datasource execution SPI. */
@@ -21,18 +41,128 @@ import org.springframework.stereotype.Component;
 @ConditionalOnDataSourceEnabled
 public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
 
+  private static final int MAX_COMPLETED_EXECUTIONS = 512;
+
   private final DataSourceExecutionProvider executionProvider;
+  private final ExecutorService lifecycleExecutor;
+  private final ConcurrentMap<String, ManagedExecution> executions = new ConcurrentHashMap<>();
+  private final ConcurrentLinkedDeque<String> completedOrder = new ConcurrentLinkedDeque<>();
 
   public DefaultSqlExecutionRuntime(DataSourceExecutionProvider executionProvider) {
     this.executionProvider = executionProvider;
+    this.lifecycleExecutor = Executors.newVirtualThreadPerTaskExecutor();
   }
 
   @Override
   public SqlExecutionResult execute(SqlExecutionRequest request) {
+    return executeOne(request, null);
+  }
+
+  @Override
+  public SqlExecutionSnapshot start(SqlExecutionPlan plan) {
+    String executionId = "sql-" + UUID.randomUUID();
+    ManagedExecution execution = new ManagedExecution(executionId, plan);
+    executions.put(executionId, execution);
+    try {
+      lifecycleExecutor.submit(() -> run(execution));
+    } catch (RuntimeException exception) {
+      execution.failBeforeStart(exception);
+      retainCompleted(executionId);
+    }
+    return execution.snapshot();
+  }
+
+  @Override
+  public Optional<SqlExecutionSnapshot> find(String executionId) {
+    if (executionId == null || executionId.isBlank()) return Optional.empty();
+    ManagedExecution execution = executions.get(executionId.trim());
+    return execution == null ? Optional.empty() : Optional.of(execution.snapshot());
+  }
+
+  @Override
+  public SqlExecutionSnapshot await(String executionId) {
+    ManagedExecution execution = requireExecution(executionId);
+    try {
+      return execution.completion().join();
+    } catch (RuntimeException exception) {
+      return execution.snapshot();
+    }
+  }
+
+  @Override
+  public boolean cancel(String executionId) {
+    ManagedExecution execution = executions.get(normalizeExecutionId(executionId));
+    if (execution == null || !execution.requestCancel()) return false;
+    DataSourceSqlExecutor active = execution.activeExecutor().get();
+    if (active != null) {
+      try {
+        active.cancel();
+      } catch (RuntimeException ignored) {
+        // Cancellation is best-effort. The worker will still observe cancelRequested.
+      }
+    }
+    return true;
+  }
+
+  @PreDestroy
+  void shutdown() {
+    lifecycleExecutor.shutdownNow();
+  }
+
+  private void run(ManagedExecution execution) {
+    execution.markRunning();
+    List<SqlStatementRequest> statements = execution.plan().statements();
+    for (int index = 0; index < statements.size(); index++) {
+      if (execution.cancelRequested()) {
+        execution.finishCancelled(index, "SQL execution cancelled");
+        retainCompleted(execution.executionId());
+        return;
+      }
+
+      SqlStatementRequest statement = statements.get(index);
+      execution.markStatementRunning(index);
+      SqlExecutionRequest request = new SqlExecutionRequest(
+          execution.plan().dataSourceId(),
+          statement.sql(),
+          statement.parameters(),
+          statement.maxRows(),
+          statement.timeoutSeconds(),
+          execution.plan().context());
+      try {
+        SqlExecutionResult result = executeOne(request, execution.activeExecutor());
+        execution.markStatementSucceeded(index, result);
+      } catch (RuntimeException exception) {
+        if (execution.cancelRequested()) {
+          execution.markStatementCancelled(index, safeMessage(exception));
+          execution.finishCancelled(index + 1, safeMessage(exception));
+        } else if (causedBy(exception, SQLTimeoutException.class)) {
+          execution.markStatementTimedOut(index, safeMessage(exception));
+          execution.finishTimedOut(index + 1, safeMessage(exception));
+        } else {
+          execution.markStatementFailed(index, safeMessage(exception));
+          execution.finishFailed(index + 1, safeMessage(exception));
+        }
+        retainCompleted(execution.executionId());
+        return;
+      }
+    }
+
+    if (execution.cancelRequested()) {
+      execution.finishCancelled(statements.size(), "SQL execution cancelled");
+    } else {
+      execution.finishSucceeded();
+    }
+    retainCompleted(execution.executionId());
+  }
+
+  private SqlExecutionResult executeOne(
+      SqlExecutionRequest request,
+      AtomicReference<DataSourceSqlExecutor> activeExecutor) {
     long totalStartedAt = System.nanoTime();
     long openStartedAt = System.nanoTime();
     DataSourceSqlExecutor executor = executionProvider.open(request.dataSourceId());
     long openMillis = elapsedMillis(openStartedAt);
+    if (activeExecutor != null) activeExecutor.set(executor);
 
     long executeStartedAt = System.nanoTime();
     DataSourceSqlResult result;
@@ -43,6 +173,8 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       throw exception;
     } catch (Exception exception) {
       throw new SqlExecutionException(request.dataSourceId(), request.context(), exception);
+    } finally {
+      if (activeExecutor != null) activeExecutor.compareAndSet(executor, null);
     }
     long executeMillis = elapsedMillis(executeStartedAt);
     long totalMillis = elapsedMillis(totalStartedAt);
@@ -56,6 +188,30 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
         new SqlExecutionTiming(openMillis, executeMillis, totalMillis));
   }
 
+  private ManagedExecution requireExecution(String executionId) {
+    String normalized = normalizeExecutionId(executionId);
+    ManagedExecution execution = executions.get(normalized);
+    if (execution == null) {
+      throw new IllegalArgumentException("SQL execution not found: " + normalized);
+    }
+    return execution;
+  }
+
+  private String normalizeExecutionId(String executionId) {
+    if (executionId == null || executionId.isBlank()) {
+      throw new IllegalArgumentException("executionId must not be blank");
+    }
+    return executionId.trim();
+  }
+
+  private void retainCompleted(String executionId) {
+    completedOrder.addLast(executionId);
+    while (completedOrder.size() > MAX_COMPLETED_EXECUTIONS) {
+      String expired = completedOrder.pollFirst();
+      if (expired != null) executions.remove(expired);
+    }
+  }
+
   private static List<SqlExecutionColumn> mapColumns(List<DataSourceSqlColumn> columns) {
     return columns.stream()
         .map(column -> new SqlExecutionColumn(
@@ -67,7 +223,198 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
         .toList();
   }
 
+  private static boolean causedBy(Throwable throwable, Class<? extends Throwable> expected) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (expected.isInstance(current)) return true;
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private static String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "SQL execution failed" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 500 ? message.substring(0, 500) : message;
+  }
+
   private static long elapsedMillis(long startedAt) {
     return Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
+  }
+
+  private static final class ManagedExecution {
+
+    private final String executionId;
+    private final SqlExecutionPlan plan;
+    private final List<MutableStatement> statements;
+    private final AtomicBoolean cancelRequested = new AtomicBoolean(false);
+    private final AtomicReference<DataSourceSqlExecutor> activeExecutor = new AtomicReference<>();
+    private final CompletableFuture<SqlExecutionSnapshot> completion = new CompletableFuture<>();
+    private SqlExecutionStatus status = SqlExecutionStatus.PENDING;
+    private Instant startedAt;
+    private Instant finishedAt;
+    private String errorMessage;
+
+    private ManagedExecution(String executionId, SqlExecutionPlan plan) {
+      this.executionId = executionId;
+      this.plan = plan;
+      this.statements = new ArrayList<>(plan.statements().size());
+      for (int index = 0; index < plan.statements().size(); index++) {
+        this.statements.add(new MutableStatement(
+            executionId + ":stmt:" + (index + 1),
+            index,
+            plan.statements().get(index).sql()));
+      }
+    }
+
+    String executionId() {
+      return executionId;
+    }
+
+    SqlExecutionPlan plan() {
+      return plan;
+    }
+
+    AtomicReference<DataSourceSqlExecutor> activeExecutor() {
+      return activeExecutor;
+    }
+
+    CompletableFuture<SqlExecutionSnapshot> completion() {
+      return completion;
+    }
+
+    boolean cancelRequested() {
+      return cancelRequested.get();
+    }
+
+    synchronized void markRunning() {
+      if (status.terminal()) return;
+      startedAt = Instant.now();
+      status = cancelRequested.get() ? SqlExecutionStatus.CANCELLING : SqlExecutionStatus.RUNNING;
+    }
+
+    synchronized void markStatementRunning(int index) {
+      MutableStatement statement = statements.get(index);
+      statement.status = SqlStatementStatus.RUNNING;
+      statement.startedAt = Instant.now();
+    }
+
+    synchronized void markStatementSucceeded(int index, SqlExecutionResult result) {
+      MutableStatement statement = statements.get(index);
+      statement.result = result;
+      statement.status = SqlStatementStatus.SUCCEEDED;
+      statement.finishedAt = Instant.now();
+    }
+
+    synchronized void markStatementFailed(int index, String message) {
+      finishStatement(index, SqlStatementStatus.FAILED, message);
+    }
+
+    synchronized void markStatementTimedOut(int index, String message) {
+      finishStatement(index, SqlStatementStatus.TIMED_OUT, message);
+    }
+
+    synchronized void markStatementCancelled(int index, String message) {
+      finishStatement(index, SqlStatementStatus.CANCELLED, message);
+    }
+
+    private void finishStatement(int index, SqlStatementStatus statementStatus, String message) {
+      MutableStatement statement = statements.get(index);
+      statement.status = statementStatus;
+      statement.errorMessage = message;
+      statement.finishedAt = Instant.now();
+    }
+
+    synchronized boolean requestCancel() {
+      if (status.terminal()) return false;
+      cancelRequested.set(true);
+      status = SqlExecutionStatus.CANCELLING;
+      return true;
+    }
+
+    synchronized void finishSucceeded() {
+      complete(SqlExecutionStatus.SUCCEEDED, null, statements.size());
+    }
+
+    synchronized void finishFailed(int skipFrom, String message) {
+      complete(SqlExecutionStatus.FAILED, message, skipFrom);
+    }
+
+    synchronized void finishTimedOut(int skipFrom, String message) {
+      complete(SqlExecutionStatus.TIMED_OUT, message, skipFrom);
+    }
+
+    synchronized void finishCancelled(int skipFrom, String message) {
+      complete(SqlExecutionStatus.CANCELLED, message, skipFrom);
+    }
+
+    synchronized void failBeforeStart(Throwable throwable) {
+      startedAt = Instant.now();
+      complete(SqlExecutionStatus.FAILED, safeMessage(throwable), 0);
+    }
+
+    private void complete(SqlExecutionStatus finalStatus, String message, int skipFrom) {
+      if (status.terminal()) return;
+      Instant now = Instant.now();
+      for (int index = Math.max(0, skipFrom); index < statements.size(); index++) {
+        MutableStatement statement = statements.get(index);
+        if (statement.status == SqlStatementStatus.PENDING) {
+          statement.status = SqlStatementStatus.SKIPPED;
+          statement.finishedAt = now;
+          statement.errorMessage = message;
+        }
+      }
+      status = finalStatus;
+      errorMessage = message;
+      finishedAt = now;
+      SqlExecutionSnapshot snapshot = snapshot();
+      completion.complete(snapshot);
+    }
+
+    synchronized SqlExecutionSnapshot snapshot() {
+      List<SqlStatementSnapshot> snapshots = statements.stream()
+          .map(MutableStatement::snapshot)
+          .toList();
+      return new SqlExecutionSnapshot(
+          executionId,
+          status,
+          plan.dataSourceId(),
+          plan.context(),
+          snapshots,
+          startedAt,
+          finishedAt,
+          errorMessage);
+    }
+  }
+
+  private static final class MutableStatement {
+    private final String statementId;
+    private final int index;
+    private final String sql;
+    private SqlStatementStatus status = SqlStatementStatus.PENDING;
+    private SqlExecutionResult result;
+    private String errorMessage;
+    private Instant startedAt;
+    private Instant finishedAt;
+
+    private MutableStatement(String statementId, int index, String sql) {
+      this.statementId = statementId;
+      this.index = index;
+      this.sql = sql;
+    }
+
+    private SqlStatementSnapshot snapshot() {
+      return new SqlStatementSnapshot(
+          statementId,
+          index,
+          sql,
+          status,
+          result,
+          errorMessage,
+          startedAt,
+          finishedAt);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
@@ -2,25 +2,33 @@ package io.yak.ops.business.datasource.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.yak.ops.core.execution.sql.SqlExecutionCaller;
 import io.yak.ops.core.execution.sql.SqlExecutionContext;
-import io.yak.ops.core.execution.sql.SqlExecutionException;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
 import io.yak.ops.core.execution.sql.SqlExecutionRequest;
 import io.yak.ops.core.execution.sql.SqlExecutionResult;
 import io.yak.ops.core.execution.sql.SqlExecutionResultType;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementRequest;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.sql.SQLTimeoutException;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class DefaultSqlExecutionRuntimeTest {
@@ -41,7 +49,9 @@ class DefaultSqlExecutionRuntimeTest {
         30,
         SqlExecutionContext.of(SqlExecutionCaller.DATASET, "42"));
 
-    SqlExecutionResult result = runtime(executor).execute(request);
+    DefaultSqlExecutionRuntime runtime = runtime(executor);
+    SqlExecutionResult result = runtime.execute(request);
+    runtime.shutdown();
 
     assertEquals(SqlExecutionResultType.RESULT_SET, result.type());
     assertTrue(result.resultSet());
@@ -56,12 +66,14 @@ class DefaultSqlExecutionRuntimeTest {
   @Test
   void mapsUpdateCountWithoutPretendingItIsAQueryResult() {
     CapturingExecutor executor = new CapturingExecutor(DataSourceSqlResult.updateCount(3L));
-    SqlExecutionResult result = runtime(executor).execute(new SqlExecutionRequest(
+    DefaultSqlExecutionRuntime runtime = runtime(executor);
+    SqlExecutionResult result = runtime.execute(new SqlExecutionRequest(
         "9",
         "update demo set enabled = 1",
         10,
         30,
         SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-1")));
+    runtime.shutdown();
 
     assertEquals(SqlExecutionResultType.UPDATE_COUNT, result.type());
     assertFalse(result.resultSet());
@@ -70,21 +82,102 @@ class DefaultSqlExecutionRuntimeTest {
   }
 
   @Test
-  void wrapsCheckedDatasourceFailuresAndKeepsTheCause() {
-    CapturingExecutor executor = new CapturingExecutor(new Exception("driver failed"));
-    SqlExecutionException exception = assertThrows(
-        SqlExecutionException.class,
-        () -> runtime(executor).execute(new SqlExecutionRequest(
+  void propagatesRuntimeDatasourceFailures() {
+    CapturingExecutor executor = new CapturingExecutor(new IllegalStateException("driver failed"));
+    DefaultSqlExecutionRuntime runtime = runtime(executor);
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> runtime.execute(new SqlExecutionRequest(
             "9",
             "select 1",
             10,
             30,
             SqlExecutionContext.of(SqlExecutionCaller.DATA_SERVICE, "service-2"))));
+    runtime.shutdown();
 
-    assertEquals("9", exception.dataSourceId());
-    assertEquals(SqlExecutionCaller.DATA_SERVICE, exception.context().caller());
-    assertInstanceOf(Exception.class, exception.getCause());
-    assertEquals("driver failed", exception.getCause().getMessage());
+    assertEquals("driver failed", exception.getMessage());
+  }
+
+  @Test
+  void tracksExplicitMultiStatementLifecycleAndResults() {
+    AtomicInteger opened = new AtomicInteger();
+    DataSourceExecutionProvider provider = dataSourceId -> {
+      int index = opened.getAndIncrement();
+      return request -> index == 0
+          ? DataSourceSqlResult.query(
+              List.of(new DataSourceSqlColumn("VALUE", "value", "INTEGER", Types.INTEGER, true)),
+              List.of(List.of(1)),
+              false)
+          : DataSourceSqlResult.updateCount(2L);
+    };
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    SqlExecutionPlan plan = new SqlExecutionPlan(
+        "42",
+        List.of(
+            new SqlStatementRequest("select 1 as value", 10, 5),
+            new SqlStatementRequest("update demo set enabled = 1", 10, 5)),
+        SqlExecutionContext.of(SqlExecutionCaller.STATEMENT, "console-1"));
+
+    SqlExecutionSnapshot started = runtime.start(plan);
+    assertTrue(runtime.find(started.executionId()).isPresent());
+
+    SqlExecutionSnapshot completed = runtime.await(started.executionId());
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.SUCCEEDED, completed.status());
+    assertEquals(2, completed.statements().size());
+    assertEquals(SqlStatementStatus.SUCCEEDED, completed.statements().get(0).status());
+    assertEquals(SqlExecutionResultType.RESULT_SET, completed.statements().get(0).result().type());
+    assertEquals(SqlExecutionResultType.UPDATE_COUNT, completed.statements().get(1).result().type());
+    assertEquals(2L, completed.statements().get(1).result().affectedRows());
+    assertTrue(completed.statements().get(0).statementId().contains(completed.executionId()));
+  }
+
+  @Test
+  void cancelsActiveStatementAndSkipsRemainingStatements() throws Exception {
+    BlockingExecutor blocking = new BlockingExecutor();
+    AtomicInteger opened = new AtomicInteger();
+    DataSourceExecutionProvider provider = dataSourceId ->
+        opened.getAndIncrement() == 0 ? blocking : request -> DataSourceSqlResult.updateCount(1L);
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    SqlExecutionSnapshot started = runtime.start(new SqlExecutionPlan(
+        "42",
+        List.of(
+            new SqlStatementRequest("select sleep", 10, 30),
+            new SqlStatementRequest("update should_not_run set value = 1", 10, 30)),
+        SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-1")));
+
+    assertTrue(blocking.started.await(2, TimeUnit.SECONDS));
+    assertTrue(runtime.cancel(started.executionId()));
+    SqlExecutionSnapshot cancelled = runtime.await(started.executionId());
+    assertFalse(runtime.cancel(started.executionId()));
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.CANCELLED, cancelled.status());
+    assertEquals(SqlStatementStatus.CANCELLED, cancelled.statements().get(0).status());
+    assertEquals(SqlStatementStatus.SKIPPED, cancelled.statements().get(1).status());
+    assertTrue(blocking.cancelled.get());
+    assertEquals(1, opened.get());
+  }
+
+  @Test
+  void promotesStatementTimeoutToExecutionTimeout() {
+    DataSourceExecutionProvider provider = dataSourceId -> request -> {
+      throw new IllegalStateException(new SQLTimeoutException("query timeout"));
+    };
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionRequest(
+        "42",
+        "select slow_query",
+        10,
+        1,
+        SqlExecutionContext.of(SqlExecutionCaller.STATEMENT, "console-2"))).executionId());
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.TIMED_OUT, completed.status());
+    assertEquals(SqlStatementStatus.TIMED_OUT, completed.statements().get(0).status());
+    assertTrue(completed.errorMessage().contains("SQLTimeoutException")
+        || completed.errorMessage().contains("query timeout"));
   }
 
   private static DefaultSqlExecutionRuntime runtime(CapturingExecutor executor) {
@@ -99,7 +192,7 @@ class DefaultSqlExecutionRuntimeTest {
 
   private static final class CapturingExecutor implements DataSourceSqlExecutor {
     private final DataSourceSqlResult result;
-    private final Exception failure;
+    private final RuntimeException failure;
     private CapturedRequest request;
     private boolean closed;
 
@@ -108,13 +201,13 @@ class DefaultSqlExecutionRuntimeTest {
       this.failure = null;
     }
 
-    private CapturingExecutor(Exception failure) {
+    private CapturingExecutor(RuntimeException failure) {
       this.result = null;
       this.failure = failure;
     }
 
     @Override
-    public DataSourceSqlResult execute(DataSourceSqlRequest request) throws Exception {
+    public DataSourceSqlResult execute(DataSourceSqlRequest request) {
       this.request = new CapturedRequest(this.request.dataSourceId(), request.parameters());
       if (failure != null) throw failure;
       return result;
@@ -123,6 +216,30 @@ class DefaultSqlExecutionRuntimeTest {
     @Override
     public void close() {
       closed = true;
+    }
+  }
+
+  private static final class BlockingExecutor implements DataSourceSqlExecutor {
+    private final CountDownLatch started = new CountDownLatch(1);
+    private final CountDownLatch released = new CountDownLatch(1);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    @Override
+    public DataSourceSqlResult execute(DataSourceSqlRequest request) {
+      started.countDown();
+      try {
+        released.await(2, TimeUnit.SECONDS);
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+      }
+      if (cancelled.get()) throw new IllegalStateException("SQL execution cancelled");
+      return DataSourceSqlResult.query(List.of(), List.of(), false);
+    }
+
+    @Override
+    public void cancel() {
+      cancelled.set(true);
+      released.countDown();
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.job.task;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionResult;
@@ -21,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Executes SQL revisions through the shared Task Runtime and TaskPlugin contract. */
@@ -29,22 +31,40 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
 
   private final TaskPluginRegistry pluginRegistry;
   private final ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider;
+  private final ObjectProvider<SqlExecutionRuntime> sqlExecutionRuntime;
   private final ObjectMapper objectMapper;
   private final TaskExecutionContextFactory contextFactory;
   private final ExecutorService workerExecutor;
   private final ConcurrentMap<String, ExecutionHandle> executions = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, String> idempotencyIndex = new ConcurrentHashMap<>();
 
+  @Autowired
   public SqlTaskExecutorAdapter(
       TaskPluginRegistry pluginRegistry,
       ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider,
+      ObjectProvider<SqlExecutionRuntime> sqlExecutionRuntime,
       ObjectMapper objectMapper,
       TaskExecutionContextFactory contextFactory) {
     this.pluginRegistry = pluginRegistry;
     this.dataSourceExecutionProvider = dataSourceExecutionProvider;
+    this.sqlExecutionRuntime = sqlExecutionRuntime;
     this.objectMapper = objectMapper;
     this.contextFactory = contextFactory;
     this.workerExecutor = Executors.newVirtualThreadPerTaskExecutor();
+  }
+
+  /** Backward-compatible constructor for existing adapter-level tests and embedders. */
+  SqlTaskExecutorAdapter(
+      TaskPluginRegistry pluginRegistry,
+      ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider,
+      ObjectMapper objectMapper,
+      TaskExecutionContextFactory contextFactory) {
+    this(
+        pluginRegistry,
+        dataSourceExecutionProvider,
+        null,
+        objectMapper,
+        contextFactory);
   }
 
   @Override
@@ -85,10 +105,15 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
     validate(plugin, definition);
 
     DataSourceExecutionProvider provider = dataSourceExecutionProvider.getIfAvailable();
+    SqlExecutionRuntime runtime =
+        sqlExecutionRuntime == null ? null : sqlExecutionRuntime.getIfAvailable();
     TaskExecutionContext context = contextFactory.create(safeTrigger, input,
         builder -> {
           if (provider != null) {
             builder.capability(DataSourceExecutionProvider.class, provider);
+          }
+          if (runtime != null) {
+            builder.capability(SqlExecutionRuntime.class, runtime);
           }
         });
     io.yak.ops.plugin.task.api.TaskExecutor pluginExecutor =

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPlan.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPlan.java
@@ -1,0 +1,39 @@
+package io.yak.ops.core.execution.sql;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Explicit sequence of statements for one tracked execution.
+ *
+ * <p>The runtime intentionally does not split SQL text on semicolons. Callers that want multiple
+ * statements must provide the statement boundaries explicitly.
+ */
+public record SqlExecutionPlan(
+    String dataSourceId,
+    List<SqlStatementRequest> statements,
+    SqlExecutionContext context) {
+
+  public SqlExecutionPlan {
+    if (dataSourceId == null || dataSourceId.isBlank()) {
+      throw new IllegalArgumentException("dataSourceId must not be blank");
+    }
+    dataSourceId = dataSourceId.trim();
+    statements = statements == null ? List.of() : List.copyOf(statements);
+    if (statements.isEmpty()) {
+      throw new IllegalArgumentException("statements must not be empty");
+    }
+    if (statements.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("statements must not contain null");
+    }
+    context = Objects.requireNonNull(context, "context");
+  }
+
+  public static SqlExecutionPlan single(SqlExecutionRequest request) {
+    Objects.requireNonNull(request, "request");
+    return new SqlExecutionPlan(
+        request.dataSourceId(),
+        List.of(SqlStatementRequest.from(request)),
+        request.context());
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRuntime.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRuntime.java
@@ -1,7 +1,39 @@
 package io.yak.ops.core.execution.sql;
 
-/** Shared SQL execution boundary used by product and domain adapters. */
+import java.util.Optional;
+
+/** Platform-level SQL execution boundary shared by product domains. */
 public interface SqlExecutionRuntime {
 
+  /**
+   * Execute one SQL request synchronously without registering it in the tracked lifecycle registry.
+   *
+   * <p>This remains the lightweight path for Dataset and Data Service queries.
+   */
   SqlExecutionResult execute(SqlExecutionRequest request);
+
+  /** Start one tracked single-statement execution and return its initial snapshot. */
+  default SqlExecutionSnapshot start(SqlExecutionRequest request) {
+    return start(SqlExecutionPlan.single(request));
+  }
+
+  /** Start one tracked execution whose statement boundaries are supplied explicitly by the caller. */
+  default SqlExecutionSnapshot start(SqlExecutionPlan plan) {
+    throw new UnsupportedOperationException("Tracked SQL execution is not supported");
+  }
+
+  /** Find the latest immutable snapshot for a tracked execution. */
+  default Optional<SqlExecutionSnapshot> find(String executionId) {
+    return Optional.empty();
+  }
+
+  /** Wait until a tracked execution reaches a terminal state. */
+  default SqlExecutionSnapshot await(String executionId) {
+    throw new UnsupportedOperationException("Tracked SQL execution is not supported");
+  }
+
+  /** Request cancellation. Returns false when the execution is absent or already terminal. */
+  default boolean cancel(String executionId) {
+    return false;
+  }
 }

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionSnapshot.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionSnapshot.java
@@ -1,0 +1,46 @@
+package io.yak.ops.core.execution.sql;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable point-in-time view of one tracked SQL execution. */
+public record SqlExecutionSnapshot(
+    String executionId,
+    SqlExecutionStatus status,
+    String dataSourceId,
+    SqlExecutionContext context,
+    List<SqlStatementSnapshot> statements,
+    Instant startedAt,
+    Instant finishedAt,
+    String errorMessage) {
+
+  public SqlExecutionSnapshot {
+    if (executionId == null || executionId.isBlank()) {
+      throw new IllegalArgumentException("executionId must not be blank");
+    }
+    executionId = executionId.trim();
+    status = Objects.requireNonNull(status, "status");
+    if (dataSourceId == null || dataSourceId.isBlank()) {
+      throw new IllegalArgumentException("dataSourceId must not be blank");
+    }
+    dataSourceId = dataSourceId.trim();
+    context = Objects.requireNonNull(context, "context");
+    statements = statements == null ? List.of() : List.copyOf(statements);
+  }
+
+  public boolean terminal() {
+    return status.terminal();
+  }
+
+  public boolean successful() {
+    return status == SqlExecutionStatus.SUCCEEDED;
+  }
+
+  public long durationMillis() {
+    if (startedAt == null) return 0L;
+    Instant end = finishedAt == null ? Instant.now() : finishedAt;
+    return Math.max(0L, Duration.between(startedAt, end).toMillis());
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionStatus.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionStatus.java
@@ -1,0 +1,16 @@
+package io.yak.ops.core.execution.sql;
+
+/** Lifecycle status of one tracked SQL execution. */
+public enum SqlExecutionStatus {
+  PENDING,
+  RUNNING,
+  CANCELLING,
+  SUCCEEDED,
+  FAILED,
+  CANCELLED,
+  TIMED_OUT;
+
+  public boolean terminal() {
+    return this == SUCCEEDED || this == FAILED || this == CANCELLED || this == TIMED_OUT;
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementRequest.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementRequest.java
@@ -1,0 +1,39 @@
+package io.yak.ops.core.execution.sql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Explicit statement request used by a tracked SQL execution plan. */
+public record SqlStatementRequest(
+    String sql,
+    List<Object> parameters,
+    int maxRows,
+    int timeoutSeconds) {
+
+  public SqlStatementRequest {
+    if (sql == null || sql.isBlank()) {
+      throw new IllegalArgumentException("sql must not be blank");
+    }
+    sql = sql.trim();
+    if (maxRows <= 0) throw new IllegalArgumentException("maxRows must be greater than zero");
+    if (timeoutSeconds <= 0) {
+      throw new IllegalArgumentException("timeoutSeconds must be greater than zero");
+    }
+    parameters = immutableNullableList(parameters);
+  }
+
+  public SqlStatementRequest(String sql, int maxRows, int timeoutSeconds) {
+    this(sql, List.of(), maxRows, timeoutSeconds);
+  }
+
+  static SqlStatementRequest from(SqlExecutionRequest request) {
+    return new SqlStatementRequest(
+        request.sql(), request.parameters(), request.maxRows(), request.timeoutSeconds());
+  }
+
+  private static List<Object> immutableNullableList(List<Object> values) {
+    if (values == null || values.isEmpty()) return List.of();
+    return Collections.unmodifiableList(new ArrayList<>(values));
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementSnapshot.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementSnapshot.java
@@ -1,0 +1,38 @@
+package io.yak.ops.core.execution.sql;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/** Immutable lifecycle snapshot for one statement in a tracked execution. */
+public record SqlStatementSnapshot(
+    String statementId,
+    int index,
+    String sql,
+    SqlStatementStatus status,
+    SqlExecutionResult result,
+    String errorMessage,
+    Instant startedAt,
+    Instant finishedAt) {
+
+  public SqlStatementSnapshot {
+    if (statementId == null || statementId.isBlank()) {
+      throw new IllegalArgumentException("statementId must not be blank");
+    }
+    statementId = statementId.trim();
+    if (index < 0) throw new IllegalArgumentException("index must not be negative");
+    if (sql == null || sql.isBlank()) throw new IllegalArgumentException("sql must not be blank");
+    sql = sql.trim();
+    status = Objects.requireNonNull(status, "status");
+  }
+
+  public boolean terminal() {
+    return status.terminal();
+  }
+
+  public long durationMillis() {
+    if (startedAt == null) return 0L;
+    Instant end = finishedAt == null ? Instant.now() : finishedAt;
+    return Math.max(0L, Duration.between(startedAt, end).toMillis());
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementStatus.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementStatus.java
@@ -1,0 +1,16 @@
+package io.yak.ops.core.execution.sql;
+
+/** Lifecycle status of one statement inside a tracked SQL execution. */
+public enum SqlStatementStatus {
+  PENDING,
+  RUNNING,
+  SUCCEEDED,
+  FAILED,
+  CANCELLED,
+  TIMED_OUT,
+  SKIPPED;
+
+  public boolean terminal() {
+    return this != PENDING && this != RUNNING;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-api</artifactId>
+            <artifactId>yak-ops-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskExecutor.java
@@ -1,35 +1,38 @@
 package io.yak.ops.plugin.task.sql;
 
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
 import io.yak.ops.plugin.task.api.TaskExecutionResult;
 import io.yak.ops.plugin.task.api.TaskExecutor;
-import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import io.yak.ops.spi.task.model.TaskExecutionStatus;
-import java.sql.SQLTimeoutException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-/** One physical SQL task execution attempt. */
+/** One SQL task attempt delegated to the shared SQL execution lifecycle. */
 final class SqlTaskExecutor implements TaskExecutor {
 
   private final TaskDefinition definition;
   private final SqlTaskConfig config;
-  private final DataSourceExecutionProvider dataSourceProvider;
+  private final SqlExecutionRuntime runtime;
   private final AtomicBoolean cancelled = new AtomicBoolean(false);
-  private final AtomicReference<DataSourceSqlExecutor> activeExecutor = new AtomicReference<>();
+  private final AtomicReference<String> executionId = new AtomicReference<>();
 
   SqlTaskExecutor(
       TaskDefinition definition,
       SqlTaskConfig config,
-      DataSourceExecutionProvider dataSourceProvider) {
+      SqlExecutionRuntime runtime) {
     this.definition = definition;
     this.config = config;
-    this.dataSourceProvider = dataSourceProvider;
+    this.runtime = runtime;
   }
 
   @Override
@@ -38,66 +41,102 @@ final class SqlTaskExecutor implements TaskExecutor {
       return cancelledResult("SQL execution was cancelled before start");
     }
 
-    try (DataSourceSqlExecutor executor = dataSourceProvider.open(config.dataSourceId())) {
-      activeExecutor.set(executor);
+    try {
+      SqlExecutionSnapshot started = runtime.start(new SqlExecutionRequest(
+          config.dataSourceId(),
+          definition.content(),
+          config.maxRows(),
+          config.timeoutSeconds(),
+          SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, null)));
+      executionId.set(started.executionId());
+
       if (cancelled.get()) {
-        executor.cancel();
-        return cancelledResult("SQL execution was cancelled before statement execution");
+        runtime.cancel(started.executionId());
       }
 
-      DataSourceSqlResult result =
-          executor.execute(
-              new DataSourceSqlRequest(
-                  definition.content(),
-                  config.maxRows(),
-                  config.timeoutSeconds()));
-      Map<String, Object> output = new LinkedHashMap<>();
-      output.put("kind", result.resultSet() ? "RESULT_SET" : "UPDATE_COUNT");
-      output.put("columns", result.columns());
-      output.put("rows", result.rows());
-      output.put("returnedRows", result.returnedRows());
-      output.put("affectedRows", result.affectedRows());
-      output.put("truncated", result.truncated());
-      output.put("dataSourceId", config.dataSourceId());
-      return TaskExecutionResult.success(output);
-    } catch (Exception exception) {
+      SqlExecutionSnapshot completed = runtime.await(started.executionId());
+      return toTaskResult(completed);
+    } catch (RuntimeException exception) {
       if (cancelled.get()) {
         return cancelledResult(safeMessage(exception));
       }
-      TaskExecutionStatus status =
-          causedBy(exception, SQLTimeoutException.class)
-              ? TaskExecutionStatus.TIMEOUT
-              : TaskExecutionStatus.FAILED;
       return new TaskExecutionResult(
-          status,
+          TaskExecutionStatus.FAILED,
           safeMessage(exception),
-          Map.of("dataSourceId", config.dataSourceId()));
-    } finally {
-      activeExecutor.set(null);
+          failureOutput());
     }
   }
 
   @Override
   public void cancel() {
     cancelled.set(true);
-    DataSourceSqlExecutor executor = activeExecutor.get();
-    if (executor != null) executor.cancel();
+    String currentExecutionId = executionId.get();
+    if (currentExecutionId != null) {
+      runtime.cancel(currentExecutionId);
+    }
+  }
+
+  private TaskExecutionResult toTaskResult(SqlExecutionSnapshot execution) {
+    if (execution.status() == SqlExecutionStatus.CANCELLED) {
+      return new TaskExecutionResult(
+          TaskExecutionStatus.CANCELLED,
+          defaultMessage(execution.errorMessage(), "SQL execution cancelled"),
+          failureOutput(execution.executionId()));
+    }
+    if (execution.status() == SqlExecutionStatus.TIMED_OUT) {
+      return new TaskExecutionResult(
+          TaskExecutionStatus.TIMEOUT,
+          defaultMessage(execution.errorMessage(), "SQL execution timed out"),
+          failureOutput(execution.executionId()));
+    }
+    if (execution.status() != SqlExecutionStatus.SUCCEEDED) {
+      return new TaskExecutionResult(
+          TaskExecutionStatus.FAILED,
+          defaultMessage(execution.errorMessage(), "SQL execution failed"),
+          failureOutput(execution.executionId()));
+    }
+
+    SqlStatementSnapshot statement = execution.statements().stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("SQL execution completed without a statement"));
+    SqlExecutionResult result = statement.result();
+    if (result == null) {
+      throw new IllegalStateException("SQL execution completed without a statement result");
+    }
+
+    Map<String, Object> output = new LinkedHashMap<>();
+    output.put("kind", result.type().name());
+    output.put("columns", result.columns());
+    output.put("rows", result.rows());
+    output.put("returnedRows", result.returnedRows());
+    output.put("affectedRows", result.affectedRows());
+    output.put("truncated", result.truncated());
+    output.put("dataSourceId", config.dataSourceId());
+    output.put("sqlExecutionId", execution.executionId());
+    output.put("statementId", statement.statementId());
+    return TaskExecutionResult.success(output);
   }
 
   private TaskExecutionResult cancelledResult(String message) {
     return new TaskExecutionResult(
         TaskExecutionStatus.CANCELLED,
-        message == null ? "SQL execution cancelled" : message,
-        Map.of("dataSourceId", config.dataSourceId()));
+        defaultMessage(message, "SQL execution cancelled"),
+        failureOutput());
   }
 
-  private boolean causedBy(Throwable throwable, Class<? extends Throwable> expected) {
-    Throwable current = throwable;
-    while (current != null) {
-      if (expected.isInstance(current)) return true;
-      current = current.getCause();
-    }
-    return false;
+  private Map<String, Object> failureOutput() {
+    return failureOutput(executionId.get());
+  }
+
+  private Map<String, Object> failureOutput(String currentExecutionId) {
+    Map<String, Object> output = new LinkedHashMap<>();
+    output.put("dataSourceId", config.dataSourceId());
+    if (currentExecutionId != null) output.put("sqlExecutionId", currentExecutionId);
+    return output;
+  }
+
+  private String defaultMessage(String message, String fallback) {
+    return message == null || message.isBlank() ? fallback : message;
   }
 
   private String safeMessage(Throwable throwable) {

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskPlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskPlugin.java
@@ -1,17 +1,17 @@
 package io.yak.ops.plugin.task.sql;
 
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutor;
 import io.yak.ops.plugin.task.api.TaskPlugin;
 import io.yak.ops.plugin.task.api.TaskPluginDescriptor;
 import io.yak.ops.plugin.task.api.TaskValidationIssue;
 import io.yak.ops.plugin.task.api.TaskValidationResult;
-import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Datasource-backed SQL Task Plugin. */
+/** SQL Task Plugin backed by the platform-level SQL execution lifecycle. */
 public final class SqlTaskPlugin implements TaskPlugin {
 
   public static final String TYPE = "SQL";
@@ -21,8 +21,8 @@ public final class SqlTaskPlugin implements TaskPlugin {
       new TaskPluginDescriptor(
           TYPE,
           "SQL",
-          "Execute SQL against a Yak Ops datasource reference",
-          "1.1.0",
+          "Execute SQL through the Yak Ops shared SQL execution runtime",
+          "1.2.0",
           SCHEMA_VERSION,
           true,
           true);
@@ -100,8 +100,7 @@ public final class SqlTaskPlugin implements TaskPlugin {
       throw new IllegalArgumentException(summary);
     }
     SqlTaskConfig config = SqlTaskConfig.parse(definition.configJson());
-    DataSourceExecutionProvider provider =
-        context.requireCapability(DataSourceExecutionProvider.class);
-    return new SqlTaskExecutor(definition, config, provider);
+    SqlExecutionRuntime runtime = context.requireCapability(SqlExecutionRuntime.class);
+    return new SqlTaskExecutor(definition, config, runtime);
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskPluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskPluginTest.java
@@ -4,18 +4,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionColumn;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionResultType;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlExecutionTiming;
+import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionResult;
 import io.yak.ops.plugin.task.api.TaskExecutor;
-import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import io.yak.ops.spi.task.model.TaskExecutionStatus;
 import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.sql.Types;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,7 +33,7 @@ import org.junit.jupiter.api.Test;
 class SqlTaskPluginTest {
 
   @Test
-  void validatesDatasourceAndExecutesThroughRuntimeCapability() throws Exception {
+  void validatesDatasourceAndExecutesThroughSharedLifecycleCapability() throws Exception {
     SqlTaskPlugin plugin = new SqlTaskPlugin();
     TaskDefinition definition =
         new TaskDefinition(
@@ -33,19 +41,58 @@ class SqlTaskPluginTest {
             1,
             "select 1 as value",
             "{\"dataSourceId\":\"42\",\"maxRows\":10,\"timeoutSeconds\":5}");
-    AtomicReference<DataSourceSqlRequest> captured = new AtomicReference<>();
-    DataSourceExecutionProvider provider =
-        reference ->
-            new DataSourceSqlExecutor() {
-              @Override
-              public DataSourceSqlResult execute(DataSourceSqlRequest request) {
-                captured.set(request);
-                return DataSourceSqlResult.query(
-                    List.of(new DataSourceSqlColumn("VALUE", "value", "INTEGER", Types.INTEGER, true)),
+    AtomicReference<SqlExecutionRequest> captured = new AtomicReference<>();
+    AtomicReference<SqlExecutionSnapshot> completed = new AtomicReference<>();
+    SqlExecutionRuntime runtime =
+        new SqlExecutionRuntime() {
+          @Override
+          public SqlExecutionResult execute(SqlExecutionRequest request) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public SqlExecutionSnapshot start(SqlExecutionPlan plan) {
+            SqlStatementSnapshot statement = new SqlStatementSnapshot(
+                "sql-test:stmt:1",
+                0,
+                plan.statements().get(0).sql(),
+                SqlStatementStatus.SUCCEEDED,
+                new SqlExecutionResult(
+                    SqlExecutionResultType.RESULT_SET,
+                    List.of(new SqlExecutionColumn(
+                        "VALUE", "value", "INTEGER", Types.INTEGER, true)),
                     List.of(List.of(1)),
-                    false);
-              }
-            };
+                    0L,
+                    false,
+                    new SqlExecutionTiming(1L, 2L, 3L)),
+                null,
+                Instant.now(),
+                Instant.now());
+            SqlExecutionSnapshot snapshot = new SqlExecutionSnapshot(
+                "sql-test",
+                SqlExecutionStatus.SUCCEEDED,
+                plan.dataSourceId(),
+                plan.context(),
+                List.of(statement),
+                Instant.now(),
+                Instant.now(),
+                null);
+            captured.set(new SqlExecutionRequest(
+                plan.dataSourceId(),
+                plan.statements().get(0).sql(),
+                plan.statements().get(0).parameters(),
+                plan.statements().get(0).maxRows(),
+                plan.statements().get(0).timeoutSeconds(),
+                plan.context()));
+            completed.set(snapshot);
+            return snapshot;
+          }
+
+          @Override
+          public SqlExecutionSnapshot await(String executionId) {
+            return completed.get();
+          }
+        };
 
     TaskExecutionContext context =
         new TaskExecutionContext() {
@@ -61,8 +108,8 @@ class SqlTaskPluginTest {
 
           @Override
           public <T> Optional<T> capability(Class<T> capabilityType) {
-            return capabilityType.isInstance(provider)
-                ? Optional.of(capabilityType.cast(provider))
+            return capabilityType.isInstance(runtime)
+                ? Optional.of(capabilityType.cast(runtime))
                 : Optional.empty();
           }
         };
@@ -76,8 +123,10 @@ class SqlTaskPluginTest {
 
     assertEquals(TaskExecutionStatus.SUCCESS, result.status());
     assertEquals("RESULT_SET", result.output().get("kind"));
+    assertEquals("sql-test", result.output().get("sqlExecutionId"));
     assertEquals(10, captured.get().maxRows());
     assertEquals(5, captured.get().timeoutSeconds());
+    assertEquals(SqlExecutionCaller.SQL_TASK, captured.get().context().caller());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Phase 2 turns the shared SQL execution contract from a synchronous call into an opt-in tracked `Execution -> Statement -> Result` lifecycle, while keeping Dataset and Data Service on the lightweight synchronous path.

### What changed

- Added tracked execution model in `yak-ops-core`:
  - `SqlExecutionStatus`
  - `SqlStatementStatus`
  - `SqlStatementRequest`
  - `SqlExecutionPlan`
  - `SqlStatementSnapshot`
  - `SqlExecutionSnapshot`
- Extended `SqlExecutionRuntime` with backward-compatible lifecycle methods:
  - `start(...)`
  - `find(...)`
  - `await(...)`
  - `cancel(...)`
- Implemented lifecycle orchestration in `DefaultSqlExecutionRuntime`:
  - execution IDs
  - statement IDs
  - virtual-thread execution
  - explicit sequential multi-statement plans
  - active executor cancellation
  - timeout / failure / cancellation propagation
  - remaining statements marked `SKIPPED`
  - bounded retention of 512 completed executions
- Kept `execute(SqlExecutionRequest)` synchronous and untracked for Dataset and Data Service.
- Migrated the built-in SQL Task plugin onto the shared `SqlExecutionRuntime` capability.
- SQL Task success output now includes `sqlExecutionId` and `statementId` while preserving the current result fields.
- Preserved `DataSourceExecutionProvider` capability injection in the Task adapter for existing / third-party plugin compatibility.
- Corrected an existing Phase 1 test that declared a checked exception not allowed by the current `DataSourceSqlExecutor` SPI.
- Added lifecycle-focused tests for multi-statement results, cancellation, skipped statements, timeout propagation, and plugin lifecycle usage.

## Architecture

```text
Dataset / Data Service
        │
        └── execute() ──────────────> SqlExecutionRuntime
                                      (synchronous, untracked)

Statement / SQL Task
        │
        └── start() ──> executionId
                         ├─ find()
                         ├─ await()
                         └─ cancel()
                              │
                              ↓
                    DataSourceExecutionProvider
                              ↓
                    DataSourceSqlExecutor
```

Tracked execution:

```text
SqlExecution
  ├─ statement-1 -> result / error
  ├─ statement-2 -> result / error
  └─ statement-N -> result / error
```

Statement boundaries are explicit. The runtime intentionally does not split SQL text on semicolons.

## SQL Task boundary

Task Runtime still owns task-level execution state, scheduling, idempotency, and history. The SQL Task plugin now delegates the physical SQL lifecycle to `SqlExecutionRuntime` and exposes the underlying `sqlExecutionId` in task output.

## Intentionally not included in Phase 2

- persisted SQL execution history / database tables
- REST Statement / SQL console API
- SQL parsing / statement classification
- read / write execution policy
- transaction modes across statements
- streaming result events / SSE / WebSocket
- frontend Statement console lifecycle integration

These remain follow-up work after the lifecycle contract is stable.

## Validation

- Java 21 `javac` compilation was run for the new core lifecycle and default runtime against the current datasource SPI shape using matching local stubs.
- Java 21 compilation checks were also run for the SQL Task plugin and Task adapter signatures.
- Added / updated repository unit tests for lifecycle states, explicit multi-statement execution, cancellation, timeout propagation, and SQL Task lifecycle capability usage.
- Full Maven test execution is not available in this environment because Maven is not installed.
- The branch is one commit ahead of current `main` and zero commits behind.
- No commit status checks are currently reported for the branch.
