### PR TITLE
feat: add phase 3 SQL policy and transactions

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionPolicy.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionPolicy.java
@@ -1,0 +1,56 @@
+package io.yak.ops.business.datasource.execution;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionPolicy;
+import io.yak.ops.core.execution.sql.SqlExecutionPolicyViolationException;
+import io.yak.ops.core.execution.sql.SqlStatementClassification;
+import org.springframework.stereotype.Component;
+
+/** Default caller-aware SQL policy for the shared execution runtime. */
+@Component
+@ConditionalOnDataSourceEnabled
+public final class DefaultSqlExecutionPolicy implements SqlExecutionPolicy {
+
+  @Override
+  public void validate(
+      SqlExecutionContext context,
+      SqlStatementClassification classification) {
+    if (context == null) throw new IllegalArgumentException("context must not be null");
+    if (classification == null) {
+      throw new IllegalArgumentException("classification must not be null");
+    }
+
+    SqlExecutionCaller caller = context.caller();
+    if (classification.containsTransactionControl()) {
+      throw violation(
+          caller,
+          classification,
+          "Transaction control SQL is runtime-owned; use SqlTransactionMode instead");
+    }
+
+    switch (caller) {
+      case DATASET, DATA_SERVICE, ANALYSIS -> {
+        if (!classification.readOnly()) {
+          throw violation(
+              caller,
+              classification,
+              caller + " only allows strictly read-only SQL");
+        }
+      }
+      case CONSOLE, SQL_TASK, SYSTEM -> {
+        // These callers may execute write/DDL/vendor-specific SQL. Product-level confirmation,
+        // authorization, and dangerous-SQL controls can layer on top without weakening the
+        // read-only guarantee for data-consumption callers.
+      }
+    }
+  }
+
+  private static SqlExecutionPolicyViolationException violation(
+      SqlExecutionCaller caller,
+      SqlStatementClassification classification,
+      String message) {
+    return new SqlExecutionPolicyViolationException(caller, classification, message);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
@@ -1,9 +1,11 @@
 package io.yak.ops.business.datasource.execution;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.execution.sql.LexicalSqlStatementClassifier;
 import io.yak.ops.core.execution.sql.SqlExecutionColumn;
 import io.yak.ops.core.execution.sql.SqlExecutionException;
 import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionPolicy;
 import io.yak.ops.core.execution.sql.SqlExecutionRequest;
 import io.yak.ops.core.execution.sql.SqlExecutionResult;
 import io.yak.ops.core.execution.sql.SqlExecutionResultType;
@@ -11,9 +13,13 @@ import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
 import io.yak.ops.core.execution.sql.SqlExecutionStatus;
 import io.yak.ops.core.execution.sql.SqlExecutionTiming;
+import io.yak.ops.core.execution.sql.SqlStatementClassification;
+import io.yak.ops.core.execution.sql.SqlStatementClassifier;
 import io.yak.ops.core.execution.sql.SqlStatementRequest;
 import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
 import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
@@ -24,6 +30,7 @@ import java.sql.SQLTimeoutException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -34,6 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Default SQL runtime backed by the existing datasource execution SPI. */
@@ -44,24 +52,55 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
   private static final int MAX_COMPLETED_EXECUTIONS = 512;
 
   private final DataSourceExecutionProvider executionProvider;
+  private final SqlStatementClassifier statementClassifier;
+  private final SqlExecutionPolicy executionPolicy;
   private final ExecutorService lifecycleExecutor;
   private final ConcurrentMap<String, ManagedExecution> executions = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> completedOrder = new ConcurrentLinkedDeque<>();
 
+  /** Spring entry point: policy remains replaceable while the standard classifier is deterministic. */
+  @Autowired
+  public DefaultSqlExecutionRuntime(
+      DataSourceExecutionProvider executionProvider,
+      SqlExecutionPolicy executionPolicy) {
+    this(executionProvider, new LexicalSqlStatementClassifier(), executionPolicy);
+  }
+
+  /** Backward-compatible constructor used by existing tests and embedders. */
   public DefaultSqlExecutionRuntime(DataSourceExecutionProvider executionProvider) {
-    this.executionProvider = executionProvider;
+    this(
+        executionProvider,
+        new LexicalSqlStatementClassifier(),
+        new DefaultSqlExecutionPolicy());
+  }
+
+  DefaultSqlExecutionRuntime(
+      DataSourceExecutionProvider executionProvider,
+      SqlStatementClassifier statementClassifier,
+      SqlExecutionPolicy executionPolicy) {
+    this.executionProvider = Objects.requireNonNull(executionProvider, "executionProvider");
+    this.statementClassifier = Objects.requireNonNull(statementClassifier, "statementClassifier");
+    this.executionPolicy = Objects.requireNonNull(executionPolicy, "executionPolicy");
     this.lifecycleExecutor = Executors.newVirtualThreadPerTaskExecutor();
   }
 
   @Override
   public SqlExecutionResult execute(SqlExecutionRequest request) {
-    return executeOne(request, null);
+    Objects.requireNonNull(request, "request");
+    classifyAndValidate(request.context(), request.sql());
+    return executeFresh(request, null, null);
   }
 
   @Override
   public SqlExecutionSnapshot start(SqlExecutionPlan plan) {
+    Objects.requireNonNull(plan, "plan");
+    List<SqlStatementClassification> classifications = new ArrayList<>(plan.statements().size());
+    for (SqlStatementRequest statement : plan.statements()) {
+      classifications.add(classifyAndValidate(plan.context(), statement.sql()));
+    }
+
     String executionId = "sql-" + UUID.randomUUID();
-    ManagedExecution execution = new ManagedExecution(executionId, plan);
+    ManagedExecution execution = new ManagedExecution(executionId, plan, classifications);
     executions.put(executionId, execution);
     try {
       lifecycleExecutor.submit(() -> run(execution));
@@ -98,7 +137,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       try {
         active.cancel();
       } catch (RuntimeException ignored) {
-        // Cancellation is best-effort. The worker will still observe cancelRequested.
+        // Cancellation is best-effort. The worker still observes cancelRequested.
       }
     }
     return true;
@@ -109,40 +148,49 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     lifecycleExecutor.shutdownNow();
   }
 
+  private SqlStatementClassification classifyAndValidate(
+      io.yak.ops.core.execution.sql.SqlExecutionContext context,
+      String sql) {
+    SqlStatementClassification classification = statementClassifier.classify(sql);
+    executionPolicy.validate(context, classification);
+    return classification;
+  }
+
   private void run(ManagedExecution execution) {
     execution.markRunning();
+    try {
+      if (execution.plan().transactionMode() == SqlTransactionMode.SINGLE_TRANSACTION) {
+        runSingleTransaction(execution);
+      } else {
+        runAutoCommit(execution);
+      }
+    } catch (RuntimeException exception) {
+      execution.finishUnexpectedFailure(safeMessage(exception));
+    } finally {
+      if (!execution.snapshot().terminal()) {
+        execution.finishUnexpectedFailure("SQL execution ended without a terminal state");
+      }
+      retainCompleted(execution.executionId());
+    }
+  }
+
+  private void runAutoCommit(ManagedExecution execution) {
     List<SqlStatementRequest> statements = execution.plan().statements();
     for (int index = 0; index < statements.size(); index++) {
       if (execution.cancelRequested()) {
         execution.finishCancelled(index, "SQL execution cancelled");
-        retainCompleted(execution.executionId());
         return;
       }
 
       SqlStatementRequest statement = statements.get(index);
       execution.markStatementRunning(index);
-      SqlExecutionRequest request = new SqlExecutionRequest(
-          execution.plan().dataSourceId(),
-          statement.sql(),
-          statement.parameters(),
-          statement.maxRows(),
-          statement.timeoutSeconds(),
-          execution.plan().context());
+      SqlExecutionRequest request = request(execution, statement);
       try {
-        SqlExecutionResult result = executeOne(request, execution.activeExecutor());
+        SqlExecutionResult result =
+            executeFresh(request, execution.activeExecutor(), execution);
         execution.markStatementSucceeded(index, result);
       } catch (RuntimeException exception) {
-        if (execution.cancelRequested()) {
-          execution.markStatementCancelled(index, safeMessage(exception));
-          execution.finishCancelled(index + 1, safeMessage(exception));
-        } else if (causedBy(exception, SQLTimeoutException.class)) {
-          execution.markStatementTimedOut(index, safeMessage(exception));
-          execution.finishTimedOut(index + 1, safeMessage(exception));
-        } else {
-          execution.markStatementFailed(index, safeMessage(exception));
-          execution.finishFailed(index + 1, safeMessage(exception));
-        }
-        retainCompleted(execution.executionId());
+        finishStatementException(execution, index, exception);
         return;
       }
     }
@@ -152,23 +200,166 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     } else {
       execution.finishSucceeded();
     }
-    retainCompleted(execution.executionId());
   }
 
-  private SqlExecutionResult executeOne(
+  private void runSingleTransaction(ManagedExecution execution) {
+    if (execution.cancelRequested()) {
+      execution.finishCancelled(0, "SQL execution cancelled");
+      return;
+    }
+
+    DataSourceSqlExecutor executor = null;
+    boolean transactionStarted = false;
+    try {
+      executor = executionProvider.open(execution.plan().dataSourceId());
+      execution.activeExecutor().set(executor);
+
+      if (execution.cancelRequested()) {
+        cancelSafely(executor);
+        execution.finishCancelled(0, "SQL execution cancelled");
+        return;
+      }
+      if (!executor.supportsTransactions()) {
+        execution.finishFailed(
+            0,
+            "Datasource SQL executor does not support SINGLE_TRANSACTION");
+        return;
+      }
+
+      executor.beginTransaction();
+      transactionStarted = true;
+      if (execution.cancelRequested()) {
+        String rollbackError = rollbackSafely(executor);
+        transactionStarted = false;
+        execution.finishCancelled(
+            0,
+            appendRollbackError("SQL execution cancelled", rollbackError));
+        return;
+      }
+
+      List<SqlStatementRequest> statements = execution.plan().statements();
+      for (int index = 0; index < statements.size(); index++) {
+        if (execution.cancelRequested()) {
+          String rollbackError = rollbackSafely(executor);
+          transactionStarted = false;
+          execution.finishCancelled(
+              index,
+              appendRollbackError("SQL execution cancelled", rollbackError));
+          return;
+        }
+
+        SqlStatementRequest statement = statements.get(index);
+        execution.markStatementRunning(index);
+        SqlExecutionRequest request = request(execution, statement);
+        try {
+          SqlExecutionResult result = executeExisting(request, executor);
+          execution.markStatementSucceeded(index, result);
+        } catch (RuntimeException exception) {
+          String rollbackError = rollbackSafely(executor);
+          transactionStarted = false;
+          finishStatementException(execution, index, exception, rollbackError);
+          return;
+        }
+      }
+
+      if (execution.cancelRequested()) {
+        String rollbackError = rollbackSafely(executor);
+        transactionStarted = false;
+        execution.finishCancelled(
+            statements.size(),
+            appendRollbackError("SQL execution cancelled", rollbackError));
+        return;
+      }
+
+      try {
+        executor.commitTransaction();
+        transactionStarted = false;
+        execution.finishSucceeded();
+      } catch (RuntimeException exception) {
+        String rollbackError = rollbackSafely(executor);
+        transactionStarted = false;
+        execution.finishFailed(
+            statements.size(),
+            appendRollbackError(safeMessage(exception), rollbackError));
+      }
+    } catch (RuntimeException exception) {
+      String rollbackError = transactionStarted && executor != null
+          ? rollbackSafely(executor)
+          : null;
+      if (execution.cancelRequested()) {
+        execution.finishCancelled(
+            0,
+            appendRollbackError("SQL execution cancelled", rollbackError));
+      } else {
+        execution.finishFailed(
+            0,
+            appendRollbackError(safeMessage(exception), rollbackError));
+      }
+    } finally {
+      execution.activeExecutor().compareAndSet(executor, null);
+      if (executor != null) {
+        try {
+          executor.close();
+        } catch (RuntimeException ignored) {
+          // Transaction outcome is already reflected above; close is best-effort cleanup.
+        }
+      }
+    }
+  }
+
+  private SqlExecutionRequest request(
+      ManagedExecution execution,
+      SqlStatementRequest statement) {
+    return new SqlExecutionRequest(
+        execution.plan().dataSourceId(),
+        statement.sql(),
+        statement.parameters(),
+        statement.maxRows(),
+        statement.timeoutSeconds(),
+        execution.plan().context());
+  }
+
+  private void finishStatementException(
+      ManagedExecution execution,
+      int index,
+      RuntimeException exception) {
+    finishStatementException(execution, index, exception, null);
+  }
+
+  private void finishStatementException(
+      ManagedExecution execution,
+      int index,
+      RuntimeException exception,
+      String rollbackError) {
+    String message = appendRollbackError(safeMessage(exception), rollbackError);
+    if (execution.cancelRequested()) {
+      execution.markStatementCancelled(index, message);
+      execution.finishCancelled(index + 1, message);
+    } else if (causedBy(exception, SQLTimeoutException.class)) {
+      execution.markStatementTimedOut(index, message);
+      execution.finishTimedOut(index + 1, message);
+    } else {
+      execution.markStatementFailed(index, message);
+      execution.finishFailed(index + 1, message);
+    }
+  }
+
+  private SqlExecutionResult executeFresh(
       SqlExecutionRequest request,
-      AtomicReference<DataSourceSqlExecutor> activeExecutor) {
+      AtomicReference<DataSourceSqlExecutor> activeExecutor,
+      ManagedExecution managedExecution) {
     long totalStartedAt = System.nanoTime();
     long openStartedAt = System.nanoTime();
     DataSourceSqlExecutor executor = executionProvider.open(request.dataSourceId());
     long openMillis = elapsedMillis(openStartedAt);
     if (activeExecutor != null) activeExecutor.set(executor);
 
-    long executeStartedAt = System.nanoTime();
-    DataSourceSqlResult result;
     try (executor) {
-      result = executor.execute(new DataSourceSqlRequest(
-          request.sql(), request.maxRows(), request.timeoutSeconds(), request.parameters()));
+      if (managedExecution != null && managedExecution.cancelRequested()) {
+        cancelSafely(executor);
+        throw new IllegalStateException("SQL execution cancelled");
+      }
+      return executeOnExecutor(request, executor, openMillis, totalStartedAt);
     } catch (RuntimeException exception) {
       throw exception;
     } catch (Exception exception) {
@@ -176,6 +367,23 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     } finally {
       if (activeExecutor != null) activeExecutor.compareAndSet(executor, null);
     }
+  }
+
+  private SqlExecutionResult executeExisting(
+      SqlExecutionRequest request,
+      DataSourceSqlExecutor executor) {
+    long totalStartedAt = System.nanoTime();
+    return executeOnExecutor(request, executor, 0L, totalStartedAt);
+  }
+
+  private SqlExecutionResult executeOnExecutor(
+      SqlExecutionRequest request,
+      DataSourceSqlExecutor executor,
+      long openMillis,
+      long totalStartedAt) {
+    long executeStartedAt = System.nanoTime();
+    DataSourceSqlResult result = executor.execute(new DataSourceSqlRequest(
+        request.sql(), request.maxRows(), request.timeoutSeconds(), request.parameters()));
     long executeMillis = elapsedMillis(executeStartedAt);
     long totalMillis = elapsedMillis(totalStartedAt);
 
@@ -186,6 +394,28 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
         result.affectedRows(),
         result.truncated(),
         new SqlExecutionTiming(openMillis, executeMillis, totalMillis));
+  }
+
+  private static void cancelSafely(DataSourceSqlExecutor executor) {
+    try {
+      executor.cancel();
+    } catch (RuntimeException ignored) {
+      // Best effort cancellation.
+    }
+  }
+
+  private String rollbackSafely(DataSourceSqlExecutor executor) {
+    try {
+      executor.rollbackTransaction();
+      return null;
+    } catch (RuntimeException exception) {
+      return safeMessage(exception);
+    }
+  }
+
+  private static String appendRollbackError(String message, String rollbackError) {
+    if (rollbackError == null || rollbackError.isBlank()) return message;
+    return message + "; rollback failed: " + rollbackError;
   }
 
   private ManagedExecution requireExecution(String executionId) {
@@ -257,7 +487,10 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     private Instant finishedAt;
     private String errorMessage;
 
-    private ManagedExecution(String executionId, SqlExecutionPlan plan) {
+    private ManagedExecution(
+        String executionId,
+        SqlExecutionPlan plan,
+        List<SqlStatementClassification> classifications) {
       this.executionId = executionId;
       this.plan = plan;
       this.statements = new ArrayList<>(plan.statements().size());
@@ -265,7 +498,8 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
         this.statements.add(new MutableStatement(
             executionId + ":stmt:" + (index + 1),
             index,
-            plan.statements().get(index).sql()));
+            plan.statements().get(index).sql(),
+            classifications.get(index).primaryType()));
       }
     }
 
@@ -350,6 +584,28 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       complete(SqlExecutionStatus.CANCELLED, message, skipFrom);
     }
 
+    synchronized void finishUnexpectedFailure(String message) {
+      if (status.terminal()) return;
+      int skipFrom = 0;
+      for (int index = 0; index < statements.size(); index++) {
+        MutableStatement statement = statements.get(index);
+        if (statement.status == SqlStatementStatus.RUNNING) {
+          statement.status = SqlStatementStatus.FAILED;
+          statement.errorMessage = message;
+          statement.finishedAt = Instant.now();
+          skipFrom = index + 1;
+          break;
+        }
+        if (statement.status == SqlStatementStatus.SUCCEEDED) {
+          skipFrom = index + 1;
+          continue;
+        }
+        skipFrom = index;
+        break;
+      }
+      complete(SqlExecutionStatus.FAILED, message, skipFrom);
+    }
+
     synchronized void failBeforeStart(Throwable throwable) {
       startedAt = Instant.now();
       complete(SqlExecutionStatus.FAILED, safeMessage(throwable), 0);
@@ -382,6 +638,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
           status,
           plan.dataSourceId(),
           plan.context(),
+          plan.transactionMode(),
           snapshots,
           startedAt,
           finishedAt,
@@ -393,16 +650,22 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     private final String statementId;
     private final int index;
     private final String sql;
+    private final SqlStatementType statementType;
     private SqlStatementStatus status = SqlStatementStatus.PENDING;
     private SqlExecutionResult result;
     private String errorMessage;
     private Instant startedAt;
     private Instant finishedAt;
 
-    private MutableStatement(String statementId, int index, String sql) {
+    private MutableStatement(
+        String statementId,
+        int index,
+        String sql,
+        SqlStatementType statementType) {
       this.statementId = statementId;
       this.index = index;
       this.sql = sql;
+      this.statementType = statementType;
     }
 
     private SqlStatementSnapshot snapshot() {
@@ -410,6 +673,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
           statementId,
           index,
           sql,
+          statementType,
           status,
           result,
           errorMessage,

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.yak.ops.core.execution.sql.SqlExecutionCaller;
 import io.yak.ops.core.execution.sql.SqlExecutionContext;
 import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionPolicyViolationException;
 import io.yak.ops.core.execution.sql.SqlExecutionRequest;
 import io.yak.ops.core.execution.sql.SqlExecutionResult;
 import io.yak.ops.core.execution.sql.SqlExecutionResultType;
@@ -16,6 +17,8 @@ import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
 import io.yak.ops.core.execution.sql.SqlExecutionStatus;
 import io.yak.ops.core.execution.sql.SqlStatementRequest;
 import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
@@ -23,6 +26,7 @@ import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
 import java.sql.SQLTimeoutException;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -99,6 +103,79 @@ class DefaultSqlExecutionRuntimeTest {
   }
 
   @Test
+  void rejectsDatasetWriteBeforeOpeningDatasource() {
+    AtomicInteger opened = new AtomicInteger();
+    DataSourceExecutionProvider provider = dataSourceId -> {
+      opened.incrementAndGet();
+      return request -> DataSourceSqlResult.updateCount(1L);
+    };
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+
+    SqlExecutionPolicyViolationException exception = assertThrows(
+        SqlExecutionPolicyViolationException.class,
+        () -> runtime.execute(new SqlExecutionRequest(
+            "42",
+            "update orders set status = 'DONE'",
+            10,
+            30,
+            SqlExecutionContext.of(SqlExecutionCaller.DATASET, "dataset-1"))));
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionCaller.DATASET, exception.caller());
+    assertEquals(SqlStatementType.UPDATE, exception.classification().primaryType());
+    assertEquals(0, opened.get());
+  }
+
+  @Test
+  void rejectsMutatingCteForReadOnlyDataService() {
+    AtomicInteger opened = new AtomicInteger();
+    DataSourceExecutionProvider provider = dataSourceId -> {
+      opened.incrementAndGet();
+      return request -> DataSourceSqlResult.query(List.of(), List.of(), false);
+    };
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    SqlExecutionPlan plan = new SqlExecutionPlan(
+        "42",
+        List.of(new SqlStatementRequest("""
+            WITH deleted AS (
+              DELETE FROM orders WHERE expired = true RETURNING *
+            )
+            SELECT * FROM deleted
+            """, 10, 30)),
+        SqlExecutionContext.of(SqlExecutionCaller.DATA_SERVICE, "service-1"));
+
+    SqlExecutionPolicyViolationException exception = assertThrows(
+        SqlExecutionPolicyViolationException.class,
+        () -> runtime.start(plan));
+    runtime.shutdown();
+
+    assertEquals(SqlStatementType.SELECT, exception.classification().primaryType());
+    assertTrue(exception.classification().potentiallyMutating());
+    assertEquals(0, opened.get());
+  }
+
+  @Test
+  void rejectsEmbeddedTransactionControlForTask() {
+    AtomicInteger opened = new AtomicInteger();
+    DataSourceExecutionProvider provider = dataSourceId -> {
+      opened.incrementAndGet();
+      return request -> DataSourceSqlResult.updateCount(0L);
+    };
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+
+    SqlExecutionPolicyViolationException exception = assertThrows(
+        SqlExecutionPolicyViolationException.class,
+        () -> runtime.start(new SqlExecutionPlan(
+            "42",
+            List.of(new SqlStatementRequest("begin", 10, 30)),
+            SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-1"))));
+    runtime.shutdown();
+
+    assertEquals(SqlStatementType.BEGIN, exception.classification().primaryType());
+    assertEquals(0, opened.get());
+  }
+
+  @Test
   void tracksExplicitMultiStatementLifecycleAndResults() {
     AtomicInteger opened = new AtomicInteger();
     DataSourceExecutionProvider provider = dataSourceId -> {
@@ -116,7 +193,7 @@ class DefaultSqlExecutionRuntimeTest {
         List.of(
             new SqlStatementRequest("select 1 as value", 10, 5),
             new SqlStatementRequest("update demo set enabled = 1", 10, 5)),
-        SqlExecutionContext.of(SqlExecutionCaller.STATEMENT, "console-1"));
+        SqlExecutionContext.of(SqlExecutionCaller.CONSOLE, "console-1"));
 
     SqlExecutionSnapshot started = runtime.start(plan);
     assertTrue(runtime.find(started.executionId()).isPresent());
@@ -125,12 +202,88 @@ class DefaultSqlExecutionRuntimeTest {
     runtime.shutdown();
 
     assertEquals(SqlExecutionStatus.SUCCEEDED, completed.status());
+    assertEquals(SqlTransactionMode.AUTO_COMMIT, completed.transactionMode());
     assertEquals(2, completed.statements().size());
+    assertEquals(SqlStatementType.SELECT, completed.statements().get(0).statementType());
+    assertEquals(SqlStatementType.UPDATE, completed.statements().get(1).statementType());
     assertEquals(SqlStatementStatus.SUCCEEDED, completed.statements().get(0).status());
     assertEquals(SqlExecutionResultType.RESULT_SET, completed.statements().get(0).result().type());
     assertEquals(SqlExecutionResultType.UPDATE_COUNT, completed.statements().get(1).result().type());
     assertEquals(2L, completed.statements().get(1).result().affectedRows());
     assertTrue(completed.statements().get(0).statementId().contains(completed.executionId()));
+  }
+
+  @Test
+  void commitsSingleTransactionAfterAllStatementsSucceed() {
+    TransactionExecutor executor = new TransactionExecutor(-1);
+    AtomicInteger opened = new AtomicInteger();
+    DataSourceExecutionProvider provider = dataSourceId -> {
+      opened.incrementAndGet();
+      return executor;
+    };
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionPlan(
+        "42",
+        List.of(
+            new SqlStatementRequest("update orders set status = 'DONE' where id = 1", 10, 30),
+            new SqlStatementRequest("insert into audit_log(id) values (1)", 10, 30)),
+        SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-1"),
+        SqlTransactionMode.SINGLE_TRANSACTION)).executionId());
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.SUCCEEDED, completed.status());
+    assertEquals(SqlTransactionMode.SINGLE_TRANSACTION, completed.transactionMode());
+    assertEquals(1, opened.get());
+    assertTrue(executor.begun.get());
+    assertTrue(executor.committed.get());
+    assertFalse(executor.rolledBack.get());
+    assertEquals(2, executor.sql.size());
+    assertTrue(executor.closed.get());
+  }
+
+  @Test
+  void rollsBackSingleTransactionAndSkipsRemainingStatementOnFailure() {
+    TransactionExecutor executor = new TransactionExecutor(2);
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(dataSourceId -> executor);
+    SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionPlan(
+        "42",
+        List.of(
+            new SqlStatementRequest("update orders set status = 'DONE' where id = 1", 10, 30),
+            new SqlStatementRequest("delete from audit_log where id = 1", 10, 30),
+            new SqlStatementRequest("insert into audit_log(id) values (2)", 10, 30)),
+        SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-2"),
+        SqlTransactionMode.SINGLE_TRANSACTION)).executionId());
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.FAILED, completed.status());
+    assertTrue(executor.begun.get());
+    assertFalse(executor.committed.get());
+    assertTrue(executor.rolledBack.get());
+    assertEquals(SqlStatementStatus.SUCCEEDED, completed.statements().get(0).status());
+    assertEquals(SqlStatementStatus.FAILED, completed.statements().get(1).status());
+    assertEquals(SqlStatementStatus.SKIPPED, completed.statements().get(2).status());
+    assertEquals(SqlStatementType.DELETE, completed.statements().get(1).statementType());
+  }
+
+  @Test
+  void failsFastWhenDatasourceDoesNotSupportSingleTransaction() {
+    AtomicInteger executions = new AtomicInteger();
+    DataSourceSqlExecutor executor = request -> {
+      executions.incrementAndGet();
+      return DataSourceSqlResult.updateCount(1L);
+    };
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(dataSourceId -> executor);
+    SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionPlan(
+        "42",
+        List.of(new SqlStatementRequest("update demo set enabled = 1", 10, 30)),
+        SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-3"),
+        SqlTransactionMode.SINGLE_TRANSACTION)).executionId());
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.FAILED, completed.status());
+    assertEquals(0, executions.get());
+    assertEquals(SqlStatementStatus.SKIPPED, completed.statements().get(0).status());
+    assertTrue(completed.errorMessage().contains("does not support SINGLE_TRANSACTION"));
   }
 
   @Test
@@ -171,7 +324,7 @@ class DefaultSqlExecutionRuntimeTest {
         "select slow_query",
         10,
         1,
-        SqlExecutionContext.of(SqlExecutionCaller.STATEMENT, "console-2"))).executionId());
+        SqlExecutionContext.of(SqlExecutionCaller.CONSOLE, "console-2"))).executionId());
     runtime.shutdown();
 
     assertEquals(SqlExecutionStatus.TIMED_OUT, completed.status());
@@ -216,6 +369,53 @@ class DefaultSqlExecutionRuntimeTest {
     @Override
     public void close() {
       closed = true;
+    }
+  }
+
+  private static final class TransactionExecutor implements DataSourceSqlExecutor {
+    private final int failOnCall;
+    private final AtomicInteger calls = new AtomicInteger();
+    private final AtomicBoolean begun = new AtomicBoolean(false);
+    private final AtomicBoolean committed = new AtomicBoolean(false);
+    private final AtomicBoolean rolledBack = new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final List<String> sql = new ArrayList<>();
+
+    private TransactionExecutor(int failOnCall) {
+      this.failOnCall = failOnCall;
+    }
+
+    @Override
+    public boolean supportsTransactions() {
+      return true;
+    }
+
+    @Override
+    public void beginTransaction() {
+      begun.set(true);
+    }
+
+    @Override
+    public DataSourceSqlResult execute(DataSourceSqlRequest request) {
+      sql.add(request.sql());
+      int call = calls.incrementAndGet();
+      if (call == failOnCall) throw new IllegalStateException("statement failed");
+      return DataSourceSqlResult.updateCount(1L);
+    }
+
+    @Override
+    public void commitTransaction() {
+      committed.set(true);
+    }
+
+    @Override
+    public void rollbackTransaction() {
+      rolledBack.set(true);
+    }
+
+    @Override
+    public void close() {
+      closed.set(true);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionTransactionCancellationTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionTransactionCancellationTest.java
@@ -1,0 +1,95 @@
+package io.yak.ops.business.datasource.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementRequest;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class DefaultSqlExecutionTransactionCancellationTest {
+
+  @Test
+  void rollsBackSingleTransactionWhenActiveStatementIsCancelled() throws Exception {
+    BlockingTransactionExecutor executor = new BlockingTransactionExecutor();
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(dataSourceId -> executor);
+    SqlExecutionSnapshot started = runtime.start(new SqlExecutionPlan(
+        "42",
+        List.of(
+            new SqlStatementRequest("update orders set status = 'RUNNING'", 10, 30),
+            new SqlStatementRequest("insert into audit_log(id) values (1)", 10, 30)),
+        SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-cancel"),
+        SqlTransactionMode.SINGLE_TRANSACTION));
+
+    assertTrue(executor.started.await(2, TimeUnit.SECONDS));
+    assertTrue(runtime.cancel(started.executionId()));
+    SqlExecutionSnapshot completed = runtime.await(started.executionId());
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.CANCELLED, completed.status());
+    assertEquals(SqlStatementStatus.CANCELLED, completed.statements().get(0).status());
+    assertEquals(SqlStatementStatus.SKIPPED, completed.statements().get(1).status());
+    assertTrue(executor.rolledBack.get());
+    assertFalse(executor.committed.get());
+  }
+
+  private static final class BlockingTransactionExecutor implements DataSourceSqlExecutor {
+    private final CountDownLatch started = new CountDownLatch(1);
+    private final CountDownLatch released = new CountDownLatch(1);
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private final AtomicBoolean committed = new AtomicBoolean(false);
+    private final AtomicBoolean rolledBack = new AtomicBoolean(false);
+
+    @Override
+    public boolean supportsTransactions() {
+      return true;
+    }
+
+    @Override
+    public void beginTransaction() {
+      // No-op test transaction.
+    }
+
+    @Override
+    public DataSourceSqlResult execute(DataSourceSqlRequest request) {
+      started.countDown();
+      try {
+        released.await(2, TimeUnit.SECONDS);
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+      }
+      if (cancelled.get()) throw new IllegalStateException("cancelled");
+      return DataSourceSqlResult.updateCount(1L);
+    }
+
+    @Override
+    public void cancel() {
+      cancelled.set(true);
+      released.countDown();
+    }
+
+    @Override
+    public void commitTransaction() {
+      committed.set(true);
+    }
+
+    @Override
+    public void rollbackTransaction() {
+      rolledBack.set(true);
+    }
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/LexicalSqlStatementClassifier.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/LexicalSqlStatementClassifier.java
@@ -1,0 +1,206 @@
+package io.yak.ops.core.execution.sql;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Dependency-free conservative SQL lexer used for platform policy decisions.
+ *
+ * <p>This is intentionally not a dialect parser. It skips comments and quoted content, tracks
+ * parenthesis depth, identifies the first known top-level statement semantic, and records known
+ * semantics observed anywhere in the SQL. That lets read-only policy reject cases such as a
+ * data-modifying CTE even when the outer statement is SELECT.
+ */
+public final class LexicalSqlStatementClassifier implements SqlStatementClassifier {
+
+  private static final Map<String, SqlStatementType> KEYWORDS = Map.ofEntries(
+      Map.entry("SELECT", SqlStatementType.SELECT),
+      Map.entry("VALUES", SqlStatementType.VALUES),
+      Map.entry("SHOW", SqlStatementType.SHOW),
+      Map.entry("DESCRIBE", SqlStatementType.DESCRIBE),
+      Map.entry("DESC", SqlStatementType.DESCRIBE),
+      Map.entry("INSERT", SqlStatementType.INSERT),
+      Map.entry("UPDATE", SqlStatementType.UPDATE),
+      Map.entry("DELETE", SqlStatementType.DELETE),
+      Map.entry("MERGE", SqlStatementType.MERGE),
+      Map.entry("REPLACE", SqlStatementType.REPLACE),
+      Map.entry("UPSERT", SqlStatementType.MERGE),
+      Map.entry("CREATE", SqlStatementType.CREATE),
+      Map.entry("ALTER", SqlStatementType.ALTER),
+      Map.entry("DROP", SqlStatementType.DROP),
+      Map.entry("TRUNCATE", SqlStatementType.TRUNCATE),
+      Map.entry("GRANT", SqlStatementType.GRANT),
+      Map.entry("REVOKE", SqlStatementType.REVOKE),
+      Map.entry("CALL", SqlStatementType.CALL),
+      Map.entry("EXEC", SqlStatementType.CALL),
+      Map.entry("EXECUTE", SqlStatementType.CALL),
+      Map.entry("EXPLAIN", SqlStatementType.EXPLAIN),
+      Map.entry("SET", SqlStatementType.SET),
+      Map.entry("BEGIN", SqlStatementType.BEGIN),
+      Map.entry("START", SqlStatementType.BEGIN),
+      Map.entry("COMMIT", SqlStatementType.COMMIT),
+      Map.entry("ROLLBACK", SqlStatementType.ROLLBACK));
+
+  @Override
+  public SqlStatementClassification classify(String sql) {
+    if (sql == null || sql.isBlank()) return SqlStatementClassification.other();
+
+    List<Token> tokens = scan(sql);
+    EnumSet<SqlStatementType> observed = EnumSet.noneOf(SqlStatementType.class);
+    SqlStatementType primary = SqlStatementType.OTHER;
+
+    for (Token token : tokens) {
+      SqlStatementType type = KEYWORDS.get(token.word());
+      if (type == null) continue;
+      observed.add(type);
+      if (primary == SqlStatementType.OTHER && token.depth() == 0) {
+        primary = type;
+      }
+    }
+    return new SqlStatementClassification(primary, observed);
+  }
+
+  private static List<Token> scan(String sql) {
+    List<Token> tokens = new ArrayList<>();
+    int depth = 0;
+    int index = 0;
+    while (index < sql.length()) {
+      char current = sql.charAt(index);
+
+      if (Character.isWhitespace(current) || current == ';' || current == ',') {
+        index++;
+        continue;
+      }
+      if (current == '-' && hasNext(sql, index, '-')) {
+        index = skipLine(sql, index + 2);
+        continue;
+      }
+      if (current == '#') {
+        index = skipLine(sql, index + 1);
+        continue;
+      }
+      if (current == '/' && hasNext(sql, index, '*')) {
+        index = skipBlockComment(sql, index + 2);
+        continue;
+      }
+      if (current == '\'' || current == '"' || current == '`') {
+        index = skipQuoted(sql, index, current);
+        continue;
+      }
+      if (current == '[') {
+        index = skipBracketIdentifier(sql, index + 1);
+        continue;
+      }
+      if (current == '$') {
+        int afterDollarQuote = skipDollarQuoted(sql, index);
+        if (afterDollarQuote > index) {
+          index = afterDollarQuote;
+          continue;
+        }
+      }
+      if (current == '(') {
+        depth++;
+        index++;
+        continue;
+      }
+      if (current == ')') {
+        depth = Math.max(0, depth - 1);
+        index++;
+        continue;
+      }
+      if (isWordStart(current)) {
+        int end = index + 1;
+        while (end < sql.length() && isWordPart(sql.charAt(end))) end++;
+        String word = sql.substring(index, end).toUpperCase(Locale.ROOT);
+        tokens.add(new Token(word, depth));
+        index = end;
+        continue;
+      }
+      index++;
+    }
+    return tokens;
+  }
+
+  private static boolean hasNext(String sql, int index, char expected) {
+    return index + 1 < sql.length() && sql.charAt(index + 1) == expected;
+  }
+
+  private static int skipLine(String sql, int index) {
+    int current = index;
+    while (current < sql.length()) {
+      char value = sql.charAt(current++);
+      if (value == '\n' || value == '\r') break;
+    }
+    return current;
+  }
+
+  private static int skipBlockComment(String sql, int index) {
+    int current = index;
+    while (current + 1 < sql.length()) {
+      if (sql.charAt(current) == '*' && sql.charAt(current + 1) == '/') return current + 2;
+      current++;
+    }
+    return sql.length();
+  }
+
+  private static int skipQuoted(String sql, int index, char quote) {
+    int current = index + 1;
+    while (current < sql.length()) {
+      char value = sql.charAt(current);
+      if (value == quote) {
+        if (current + 1 < sql.length() && sql.charAt(current + 1) == quote) {
+          current += 2;
+          continue;
+        }
+        return current + 1;
+      }
+      if (value == '\\' && current + 1 < sql.length()) {
+        current += 2;
+      } else {
+        current++;
+      }
+    }
+    return sql.length();
+  }
+
+  private static int skipBracketIdentifier(String sql, int index) {
+    int current = index;
+    while (current < sql.length()) {
+      if (sql.charAt(current) == ']') {
+        if (current + 1 < sql.length() && sql.charAt(current + 1) == ']') {
+          current += 2;
+          continue;
+        }
+        return current + 1;
+      }
+      current++;
+    }
+    return sql.length();
+  }
+
+  private static int skipDollarQuoted(String sql, int index) {
+    int tagEnd = index + 1;
+    while (tagEnd < sql.length() && isDollarTagPart(sql.charAt(tagEnd))) tagEnd++;
+    if (tagEnd >= sql.length() || sql.charAt(tagEnd) != '$') return index;
+    String tag = sql.substring(index, tagEnd + 1);
+    int closing = sql.indexOf(tag, tagEnd + 1);
+    return closing < 0 ? sql.length() : closing + tag.length();
+  }
+
+  private static boolean isWordStart(char value) {
+    return Character.isLetter(value) || value == '_';
+  }
+
+  private static boolean isWordPart(char value) {
+    return Character.isLetterOrDigit(value) || value == '_' || value == '$';
+  }
+
+  private static boolean isDollarTagPart(char value) {
+    return Character.isLetterOrDigit(value) || value == '_';
+  }
+
+  private record Token(String word, int depth) {}
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPlan.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPlan.java
@@ -12,7 +12,8 @@ import java.util.Objects;
 public record SqlExecutionPlan(
     String dataSourceId,
     List<SqlStatementRequest> statements,
-    SqlExecutionContext context) {
+    SqlExecutionContext context,
+    SqlTransactionMode transactionMode) {
 
   public SqlExecutionPlan {
     if (dataSourceId == null || dataSourceId.isBlank()) {
@@ -27,6 +28,17 @@ public record SqlExecutionPlan(
       throw new IllegalArgumentException("statements must not contain null");
     }
     context = Objects.requireNonNull(context, "context");
+    transactionMode = transactionMode == null
+        ? SqlTransactionMode.AUTO_COMMIT
+        : transactionMode;
+  }
+
+  /** Backward-compatible constructor; existing callers remain auto-commit by default. */
+  public SqlExecutionPlan(
+      String dataSourceId,
+      List<SqlStatementRequest> statements,
+      SqlExecutionContext context) {
+    this(dataSourceId, statements, context, SqlTransactionMode.AUTO_COMMIT);
   }
 
   public static SqlExecutionPlan single(SqlExecutionRequest request) {
@@ -34,6 +46,7 @@ public record SqlExecutionPlan(
     return new SqlExecutionPlan(
         request.dataSourceId(),
         List.of(SqlStatementRequest.from(request)),
-        request.context());
+        request.context(),
+        SqlTransactionMode.AUTO_COMMIT);
   }
 }

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPolicy.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPolicy.java
@@ -1,0 +1,8 @@
+package io.yak.ops.core.execution.sql;
+
+/** Policy boundary that decides whether a classified SQL statement may execute for a caller. */
+@FunctionalInterface
+public interface SqlExecutionPolicy {
+
+  void validate(SqlExecutionContext context, SqlStatementClassification classification);
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPolicyViolationException.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPolicyViolationException.java
@@ -1,0 +1,25 @@
+package io.yak.ops.core.execution.sql;
+
+/** Raised before datasource access when SQL violates the platform execution policy. */
+public final class SqlExecutionPolicyViolationException extends RuntimeException {
+
+  private final SqlExecutionCaller caller;
+  private final SqlStatementClassification classification;
+
+  public SqlExecutionPolicyViolationException(
+      SqlExecutionCaller caller,
+      SqlStatementClassification classification,
+      String message) {
+    super(message);
+    this.caller = caller;
+    this.classification = classification;
+  }
+
+  public SqlExecutionCaller caller() {
+    return caller;
+  }
+
+  public SqlStatementClassification classification() {
+    return classification;
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionSnapshot.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionSnapshot.java
@@ -11,6 +11,7 @@ public record SqlExecutionSnapshot(
     SqlExecutionStatus status,
     String dataSourceId,
     SqlExecutionContext context,
+    SqlTransactionMode transactionMode,
     List<SqlStatementSnapshot> statements,
     Instant startedAt,
     Instant finishedAt,
@@ -27,7 +28,30 @@ public record SqlExecutionSnapshot(
     }
     dataSourceId = dataSourceId.trim();
     context = Objects.requireNonNull(context, "context");
+    transactionMode = transactionMode == null ? SqlTransactionMode.AUTO_COMMIT : transactionMode;
     statements = statements == null ? List.of() : List.copyOf(statements);
+  }
+
+  /** Backward-compatible constructor; historical callers remain auto-commit by default. */
+  public SqlExecutionSnapshot(
+      String executionId,
+      SqlExecutionStatus status,
+      String dataSourceId,
+      SqlExecutionContext context,
+      List<SqlStatementSnapshot> statements,
+      Instant startedAt,
+      Instant finishedAt,
+      String errorMessage) {
+    this(
+        executionId,
+        status,
+        dataSourceId,
+        context,
+        SqlTransactionMode.AUTO_COMMIT,
+        statements,
+        startedAt,
+        finishedAt,
+        errorMessage);
   }
 
   public boolean terminal() {

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementClassification.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementClassification.java
@@ -1,0 +1,45 @@
+package io.yak.ops.core.execution.sql;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Conservative semantic classification for one SQL statement. */
+public record SqlStatementClassification(
+    SqlStatementType primaryType,
+    Set<SqlStatementType> observedTypes) {
+
+  public SqlStatementClassification {
+    primaryType = Objects.requireNonNull(primaryType, "primaryType");
+    EnumSet<SqlStatementType> copy = observedTypes == null || observedTypes.isEmpty()
+        ? EnumSet.noneOf(SqlStatementType.class)
+        : EnumSet.copyOf(observedTypes);
+    if (primaryType != SqlStatementType.OTHER) copy.add(primaryType);
+    observedTypes = Collections.unmodifiableSet(copy);
+  }
+
+  public static SqlStatementClassification other() {
+    return new SqlStatementClassification(SqlStatementType.OTHER, Set.of());
+  }
+
+  /**
+   * Strict read-only means both the primary statement and every observed nested semantic are
+   * explicitly known to be read-only. This intentionally rejects EXPLAIN, CALL, SET, and unknown
+   * vendor-specific syntax for read-only callers.
+   */
+  public boolean readOnly() {
+    return primaryType.readOnlySafe()
+        && !observedTypes.isEmpty()
+        && observedTypes.stream().allMatch(SqlStatementType::readOnlySafe);
+  }
+
+  public boolean potentiallyMutating() {
+    return observedTypes.stream().anyMatch(SqlStatementType::potentiallyMutating);
+  }
+
+  /** Any observed transaction control is rejected so it cannot bypass runtime transaction modes. */
+  public boolean containsTransactionControl() {
+    return observedTypes.stream().anyMatch(SqlStatementType::transactionControl);
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementClassifier.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementClassifier.java
@@ -1,0 +1,8 @@
+package io.yak.ops.core.execution.sql;
+
+/** Classifies SQL without depending on datasource-specific driver implementations. */
+@FunctionalInterface
+public interface SqlStatementClassifier {
+
+  SqlStatementClassification classify(String sql);
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementSnapshot.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementSnapshot.java
@@ -9,6 +9,7 @@ public record SqlStatementSnapshot(
     String statementId,
     int index,
     String sql,
+    SqlStatementType statementType,
     SqlStatementStatus status,
     SqlExecutionResult result,
     String errorMessage,
@@ -23,7 +24,30 @@ public record SqlStatementSnapshot(
     if (index < 0) throw new IllegalArgumentException("index must not be negative");
     if (sql == null || sql.isBlank()) throw new IllegalArgumentException("sql must not be blank");
     sql = sql.trim();
+    statementType = statementType == null ? SqlStatementType.OTHER : statementType;
     status = Objects.requireNonNull(status, "status");
+  }
+
+  /** Backward-compatible constructor for callers created before statement semantics were exposed. */
+  public SqlStatementSnapshot(
+      String statementId,
+      int index,
+      String sql,
+      SqlStatementStatus status,
+      SqlExecutionResult result,
+      String errorMessage,
+      Instant startedAt,
+      Instant finishedAt) {
+    this(
+        statementId,
+        index,
+        sql,
+        SqlStatementType.OTHER,
+        status,
+        result,
+        errorMessage,
+        startedAt,
+        finishedAt);
   }
 
   public boolean terminal() {

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementType.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementType.java
@@ -1,0 +1,60 @@
+package io.yak.ops.core.execution.sql;
+
+/** Semantic SQL statement type used by execution policy and observability. */
+public enum SqlStatementType {
+  SELECT(true, false, false),
+  VALUES(true, false, false),
+  SHOW(true, false, false),
+  DESCRIBE(true, false, false),
+
+  INSERT(false, true, false),
+  UPDATE(false, true, false),
+  DELETE(false, true, false),
+  MERGE(false, true, false),
+  REPLACE(false, true, false),
+
+  CREATE(false, true, false),
+  ALTER(false, true, false),
+  DROP(false, true, false),
+  TRUNCATE(false, true, false),
+  GRANT(false, true, false),
+  REVOKE(false, true, false),
+
+  CALL(false, true, false),
+  EXPLAIN(false, false, false),
+  SET(false, false, false),
+
+  BEGIN(false, false, true),
+  COMMIT(false, false, true),
+  ROLLBACK(false, false, true),
+
+  OTHER(false, false, false);
+
+  private final boolean readOnlySafe;
+  private final boolean potentiallyMutating;
+  private final boolean transactionControl;
+
+  SqlStatementType(
+      boolean readOnlySafe,
+      boolean potentiallyMutating,
+      boolean transactionControl) {
+    this.readOnlySafe = readOnlySafe;
+    this.potentiallyMutating = potentiallyMutating;
+    this.transactionControl = transactionControl;
+  }
+
+  /** True only for statement kinds that are safe for strict read-only product callers. */
+  public boolean readOnlySafe() {
+    return readOnlySafe;
+  }
+
+  /** True when the statement can modify data, schema, privileges, or invoke mutating procedures. */
+  public boolean potentiallyMutating() {
+    return potentiallyMutating;
+  }
+
+  /** Transaction control is owned by the runtime, not embedded SQL text. */
+  public boolean transactionControl() {
+    return transactionControl;
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlTransactionMode.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlTransactionMode.java
@@ -1,0 +1,10 @@
+package io.yak.ops.core.execution.sql;
+
+/** Transaction boundary for a tracked SQL execution plan. */
+public enum SqlTransactionMode {
+  /** Each statement uses the datasource executor's normal auto-commit behavior. */
+  AUTO_COMMIT,
+
+  /** All statements execute on one datasource executor transaction and commit atomically. */
+  SINGLE_TRANSACTION
+}

--- a/yak-ops-core/src/test/java/io/yak/ops/core/execution/sql/LexicalSqlStatementClassifierTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/execution/sql/LexicalSqlStatementClassifierTest.java
@@ -1,0 +1,95 @@
+package io.yak.ops.core.execution.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LexicalSqlStatementClassifierTest {
+
+  private final SqlStatementClassifier classifier = new LexicalSqlStatementClassifier();
+
+  @Test
+  void classifiesSelectAndIgnoresCommentsAndQuotedKeywords() {
+    SqlStatementClassification classification = classifier.classify("""
+        -- DELETE FROM hidden
+        SELECT 'update', "delete", `insert`
+        FROM demo
+        """);
+
+    assertEquals(SqlStatementType.SELECT, classification.primaryType());
+    assertTrue(classification.readOnly());
+    assertEquals(1, classification.observedTypes().size());
+  }
+
+  @Test
+  void classifiesReadOnlyCteByOuterStatement() {
+    SqlStatementClassification classification = classifier.classify("""
+        WITH recent AS (
+          SELECT id FROM orders WHERE created_at > ?
+        )
+        SELECT * FROM recent
+        """);
+
+    assertEquals(SqlStatementType.SELECT, classification.primaryType());
+    assertTrue(classification.readOnly());
+  }
+
+  @Test
+  void detectsMutatingCteEvenWhenOuterStatementIsSelect() {
+    SqlStatementClassification classification = classifier.classify("""
+        WITH deleted AS (
+          DELETE FROM orders WHERE expired = true RETURNING *
+        )
+        SELECT * FROM deleted
+        """);
+
+    assertEquals(SqlStatementType.SELECT, classification.primaryType());
+    assertTrue(classification.observedTypes().contains(SqlStatementType.DELETE));
+    assertTrue(classification.potentiallyMutating());
+    assertFalse(classification.readOnly());
+  }
+
+  @Test
+  void treatsSelectForUpdateAsNotStrictlyReadOnly() {
+    SqlStatementClassification classification =
+        classifier.classify("select * from orders where id = ? for update");
+
+    assertEquals(SqlStatementType.SELECT, classification.primaryType());
+    assertTrue(classification.observedTypes().contains(SqlStatementType.UPDATE));
+    assertFalse(classification.readOnly());
+  }
+
+  @Test
+  void keepsExplainConservativeForReadOnlyPolicy() {
+    SqlStatementClassification classification =
+        classifier.classify("explain analyze select * from orders");
+
+    assertEquals(SqlStatementType.EXPLAIN, classification.primaryType());
+    assertFalse(classification.readOnly());
+  }
+
+  @Test
+  void skipsPostgresDollarQuotedProcedureBody() {
+    SqlStatementClassification classification = classifier.classify("""
+        CREATE FUNCTION cleanup_orders() RETURNS void AS $$
+        BEGIN
+          DELETE FROM orders WHERE expired = true;
+        END;
+        $$ LANGUAGE plpgsql
+        """);
+
+    assertEquals(SqlStatementType.CREATE, classification.primaryType());
+    assertTrue(classification.observedTypes().contains(SqlStatementType.CREATE));
+    assertFalse(classification.containsTransactionControl());
+  }
+
+  @Test
+  void recognizesRuntimeOwnedTransactionControl() {
+    assertEquals(SqlStatementType.BEGIN, classifier.classify("begin").primaryType());
+    assertEquals(SqlStatementType.BEGIN, classifier.classify("start transaction").primaryType());
+    assertEquals(SqlStatementType.COMMIT, classifier.classify("commit").primaryType());
+    assertEquals(SqlStatementType.ROLLBACK, classifier.classify("rollback").primaryType());
+  }
+}

--- a/yak-ops-core/src/test/java/io/yak/ops/core/execution/sql/SqlTransactionControlClassificationTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/execution/sql/SqlTransactionControlClassificationTest.java
@@ -1,0 +1,19 @@
+package io.yak.ops.core.execution.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SqlTransactionControlClassificationTest {
+
+  @Test
+  void detectsTransactionControlAppendedAfterDml() {
+    SqlStatementClassification classification =
+        new LexicalSqlStatementClassifier().classify("update demo set enabled = 1; commit;");
+
+    assertEquals(SqlStatementType.UPDATE, classification.primaryType());
+    assertTrue(classification.observedTypes().contains(SqlStatementType.COMMIT));
+    assertTrue(classification.containsTransactionControl());
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlExecutor.java
@@ -1,9 +1,29 @@
 package io.yak.ops.spi.datasource.execution;
 
-/** Fresh datasource SQL executor used by one task execution attempt. */
+/** Fresh datasource SQL executor used by one execution attempt. */
 public interface DataSourceSqlExecutor extends AutoCloseable {
 
   DataSourceSqlResult execute(DataSourceSqlRequest request);
+
+  /** Whether this executor can keep one datasource transaction across multiple execute calls. */
+  default boolean supportsTransactions() {
+    return false;
+  }
+
+  /** Begin a transaction that remains active across subsequent execute calls. */
+  default void beginTransaction() {
+    throw new UnsupportedOperationException("Datasource SQL executor does not support transactions");
+  }
+
+  /** Commit the active transaction. */
+  default void commitTransaction() {
+    throw new UnsupportedOperationException("Datasource SQL executor does not support transactions");
+  }
+
+  /** Roll back the active transaction. */
+  default void rollbackTransaction() {
+    throw new UnsupportedOperationException("Datasource SQL executor does not support transactions");
+  }
 
   /** Best-effort cancellation for a currently running statement. */
   default void cancel() {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
@@ -34,6 +34,7 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
   private final JdbcConnectionProvider connectionProvider;
   private final AtomicBoolean cancelled = new AtomicBoolean(false);
   private final AtomicReference<Connection> activeConnection = new AtomicReference<>();
+  private final AtomicReference<Connection> transactionConnection = new AtomicReference<>();
   private final AtomicReference<Statement> activeStatement = new AtomicReference<>();
 
   public JdbcDataSourceSqlExecutor(
@@ -57,17 +58,20 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
       throw executionError("SQL 执行已取消", null);
     }
 
+    Connection transactional = transactionConnection.get();
+    if (transactional != null) {
+      try {
+        return executeOnConnection(transactional, request);
+      } catch (DataSourcePluginException exception) {
+        throw exception;
+      } catch (Exception exception) {
+        throw executionError(safeMessage(exception), exception);
+      }
+    }
+
     try {
       try (Connection opened = connectionProvider.open(connection, connectionTimeoutSeconds)) {
-        activeConnection.set(opened);
-        if (cancelled.get()) {
-          throw executionError("SQL 执行已取消", null);
-        }
-        return request.parameters().isEmpty()
-            ? executePlain(opened, request)
-            : executePrepared(opened, request);
-      } finally {
-        activeConnection.set(null);
+        return executeOnConnection(opened, request);
       }
     } catch (DataSourcePluginException exception) {
       throw exception;
@@ -75,6 +79,97 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
       throw executionError("数据库驱动未安装：" + connection.driverClassName(), exception);
     } catch (Exception exception) {
       throw executionError(safeMessage(exception), exception);
+    }
+  }
+
+  @Override
+  public boolean supportsTransactions() {
+    return true;
+  }
+
+  @Override
+  public synchronized void beginTransaction() {
+    if (cancelled.get()) {
+      throw executionError("SQL 执行已取消", null);
+    }
+    if (transactionConnection.get() != null) {
+      throw executionError("SQL 事务已经开启", null);
+    }
+
+    Connection opened = null;
+    try {
+      opened = connectionProvider.open(connection, connectionTimeoutSeconds);
+      if (cancelled.get()) {
+        closeQuietly(opened);
+        throw executionError("SQL 执行已取消", null);
+      }
+      opened.setAutoCommit(false);
+      transactionConnection.set(opened);
+    } catch (DataSourcePluginException exception) {
+      closeQuietly(opened);
+      throw exception;
+    } catch (ClassNotFoundException exception) {
+      closeQuietly(opened);
+      throw executionError("数据库驱动未安装：" + connection.driverClassName(), exception);
+    } catch (Exception exception) {
+      closeQuietly(opened);
+      throw executionError("开启 SQL 事务失败：" + safeMessage(exception), exception);
+    }
+  }
+
+  @Override
+  public synchronized void commitTransaction() {
+    Connection transactional = requireTransaction();
+    try {
+      transactional.commit();
+    } catch (Exception exception) {
+      try {
+        transactional.rollback();
+      } catch (Exception ignored) {
+        // Best effort: closing the connection below is the final cleanup path.
+      }
+      throw executionError("提交 SQL 事务失败：" + safeMessage(exception), exception);
+    } finally {
+      transactionConnection.compareAndSet(transactional, null);
+      closeQuietly(transactional);
+    }
+  }
+
+  @Override
+  public synchronized void rollbackTransaction() {
+    Connection transactional = transactionConnection.getAndSet(null);
+    if (transactional == null) return;
+    try {
+      if (!transactional.isClosed()) transactional.rollback();
+    } catch (Exception exception) {
+      throw executionError("回滚 SQL 事务失败：" + safeMessage(exception), exception);
+    } finally {
+      closeQuietly(transactional);
+    }
+  }
+
+  private Connection requireTransaction() {
+    Connection transactional = transactionConnection.get();
+    if (transactional == null) {
+      throw executionError("SQL 事务尚未开启", null);
+    }
+    return transactional;
+  }
+
+  private DataSourceSqlResult executeOnConnection(
+      Connection opened,
+      DataSourceSqlRequest request)
+      throws Exception {
+    activeConnection.set(opened);
+    try {
+      if (cancelled.get()) {
+        throw executionError("SQL 执行已取消", null);
+      }
+      return request.parameters().isEmpty()
+          ? executePlain(opened, request)
+          : executePrepared(opened, request);
+    } finally {
+      activeConnection.compareAndSet(opened, null);
     }
   }
 
@@ -133,25 +228,41 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
       try {
         statement.cancel();
       } catch (Exception ignored) {
-        // Best effort; closing the connection below is the fallback.
+        // Best effort; transaction rollback or connection close remains the cleanup path.
       }
     }
+
+    // In transaction mode keep the connection open so the runtime can explicitly roll it back.
+    Connection transactional = transactionConnection.get();
     Connection opened = activeConnection.get();
-    if (opened != null) {
-      try {
-        opened.close();
-      } catch (Exception ignored) {
-        // Best effort cancellation. SSH tunnel is also released by Connection.close().
-      }
+    if (opened != null && opened != transactional) {
+      closeQuietly(opened);
     }
   }
 
   @Override
-  public void close() {
-    Statement statement = activeStatement.get();
-    Connection opened = activeConnection.get();
-    if (statement == null && opened == null) return;
-    cancel();
+  public synchronized void close() {
+    Connection transactional = transactionConnection.getAndSet(null);
+    if (transactional != null) {
+      try {
+        if (!transactional.isClosed()) transactional.rollback();
+      } catch (Exception ignored) {
+        // Best effort cleanup on close.
+      } finally {
+        closeQuietly(transactional);
+      }
+    }
+
+    Statement statement = activeStatement.getAndSet(null);
+    if (statement != null) {
+      try {
+        statement.close();
+      } catch (Exception ignored) {
+        // Best effort cleanup.
+      }
+    }
+    Connection opened = activeConnection.getAndSet(null);
+    if (opened != null && opened != transactional) closeQuietly(opened);
   }
 
   private DataSourceSqlResult readResultSet(ResultSet resultSet, int maxRows) throws Exception {
@@ -252,6 +363,15 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
       properties.setProperty("password", connection.password());
     }
     return properties;
+  }
+
+  private static void closeQuietly(Connection connection) {
+    if (connection == null) return;
+    try {
+      connection.close();
+    } catch (Exception ignored) {
+      // Best effort cleanup.
+    }
   }
 
   private DataSourcePluginException executionError(String message, Throwable cause) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutorTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutorTest.java
@@ -1,0 +1,120 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class JdbcDataSourceSqlExecutorTest {
+
+  @Test
+  void reusesOneConnectionAndCommitsExplicitTransaction() throws Exception {
+    Connection connection = mock(Connection.class);
+    Statement first = updateStatement(1);
+    Statement second = updateStatement(2);
+    when(connection.createStatement()).thenReturn(first, second);
+    AtomicInteger opened = new AtomicInteger();
+
+    JdbcDataSourceSqlExecutor executor = new JdbcDataSourceSqlExecutor(
+        properties(),
+        5,
+        (ignored, timeout) -> {
+          opened.incrementAndGet();
+          return connection;
+        });
+
+    assertTrue(executor.supportsTransactions());
+    executor.beginTransaction();
+    assertEquals(1L, executor.execute(new DataSourceSqlRequest("update a set v = 1", 10, 30)).affectedRows());
+    assertEquals(2L, executor.execute(new DataSourceSqlRequest("update b set v = 2", 10, 30)).affectedRows());
+    executor.commitTransaction();
+
+    assertEquals(1, opened.get());
+    verify(connection).setAutoCommit(false);
+    verify(connection).commit();
+    verify(connection, never()).rollback();
+    verify(connection).close();
+    verify(first).close();
+    verify(second).close();
+  }
+
+  @Test
+  void rollsBackAndClosesExplicitTransaction() throws Exception {
+    Connection connection = mock(Connection.class);
+    Statement statement = updateStatement(1);
+    when(connection.createStatement()).thenReturn(statement);
+    AtomicInteger opened = new AtomicInteger();
+
+    JdbcDataSourceSqlExecutor executor = new JdbcDataSourceSqlExecutor(
+        properties(),
+        5,
+        (ignored, timeout) -> {
+          opened.incrementAndGet();
+          return connection;
+        });
+
+    executor.beginTransaction();
+    executor.execute(new DataSourceSqlRequest("delete from demo", 10, 30));
+    executor.rollbackTransaction();
+
+    assertEquals(1, opened.get());
+    verify(connection).setAutoCommit(false);
+    verify(connection).rollback();
+    verify(connection, never()).commit();
+    verify(connection).close();
+  }
+
+  @Test
+  void keepsAutoCommitExecutionsOnFreshConnections() throws Exception {
+    Connection firstConnection = mock(Connection.class);
+    Connection secondConnection = mock(Connection.class);
+    when(firstConnection.createStatement()).thenReturn(updateStatement(1));
+    when(secondConnection.createStatement()).thenReturn(updateStatement(1));
+    AtomicInteger opened = new AtomicInteger();
+
+    JdbcDataSourceSqlExecutor executor = new JdbcDataSourceSqlExecutor(
+        properties(),
+        5,
+        (ignored, timeout) -> opened.getAndIncrement() == 0 ? firstConnection : secondConnection);
+
+    executor.execute(new DataSourceSqlRequest("update a set v = 1", 10, 30));
+    executor.execute(new DataSourceSqlRequest("update b set v = 2", 10, 30));
+
+    assertEquals(2, opened.get());
+    verify(firstConnection, never()).setAutoCommit(false);
+    verify(secondConnection, never()).setAutoCommit(false);
+    verify(firstConnection).close();
+    verify(secondConnection).close();
+  }
+
+  private static Statement updateStatement(int affectedRows) throws Exception {
+    Statement statement = mock(Statement.class);
+    when(statement.execute(anyString())).thenReturn(false);
+    when(statement.getUpdateCount()).thenReturn(affectedRows);
+    return statement;
+  }
+
+  private static JdbcConnectionProperties properties() {
+    return new JdbcConnectionProperties(
+        null,
+        "jdbc:test",
+        "example.Driver",
+        null,
+        null,
+        null,
+        null,
+        Map.of(),
+        "{}");
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3 adds SQL semantic classification, caller-aware execution policy, and real transaction boundaries on top of the Phase 2 `Execution -> Statement -> Result` lifecycle.

The goal is to make SQL meaning and execution intent explicit before Yak Ops adds richer Statement Console, audit, and analysis capabilities.

## What changed

### SQL semantics

- Added `SqlStatementType` covering query, DML, DDL, procedure, session, and transaction-control semantics.
- Added `SqlStatementClassification` with:
  - primary statement type
  - all observed semantic types
  - strict read-only detection
  - potentially-mutating detection
  - transaction-control detection
- Added a dependency-free conservative `LexicalSqlStatementClassifier`.
  - skips comments and quoted literals/identifiers
  - handles PostgreSQL dollar-quoted bodies
  - tracks parenthesis depth
  - identifies the outer/top-level statement
  - also records nested semantics so data-modifying CTEs are not mistaken for read-only SELECTs
- `SqlStatementSnapshot` now exposes `statementType` for future audit/metrics without re-parsing SQL.

Examples intentionally treated as not strictly read-only:

```sql
WITH deleted AS (
  DELETE FROM orders WHERE expired = true RETURNING *
)
SELECT * FROM deleted;
```

```sql
SELECT * FROM orders WHERE id = ? FOR UPDATE;
```

### Caller-aware SQL policy

Added `SqlExecutionPolicy` and a default platform policy:

| Caller | Default policy |
| --- | --- |
| Dataset | strict read-only |
| Data Service | strict read-only |
| Analysis | strict read-only |
| Console | write / DDL / vendor-specific SQL allowed |
| SQL Task | write / DDL / vendor-specific SQL allowed |
| System | write / DDL / vendor-specific SQL allowed |

Policy validation happens before datasource access.

Transaction-control SQL such as `BEGIN`, `COMMIT`, or `ROLLBACK` is runtime-owned and rejected for every caller. This also blocks transaction control appended inside one request such as:

```sql
UPDATE demo SET enabled = 1;
COMMIT;
```

Callers must use `SqlTransactionMode` instead.

### Real transaction execution

Added:

```text
SqlTransactionMode
  ├─ AUTO_COMMIT
  └─ SINGLE_TRANSACTION
```

`SqlExecutionPlan` now carries `transactionMode`, defaulting to `AUTO_COMMIT` for compatibility. `SqlExecutionSnapshot` exposes it as lifecycle metadata.

`SINGLE_TRANSACTION` is a real datasource transaction, not just metadata:

```text
ExecutionPlan
  ↓
open one DataSourceSqlExecutor
  ↓
beginTransaction()
  ↓
Statement 1
Statement 2
...
  ↓
commitTransaction()

failure / timeout / cancellation
  ↓
rollbackTransaction()
```

- Added optional transaction capability to `DataSourceSqlExecutor` through backward-compatible default methods.
- Datasource implementations that do not support transactions fail fast for `SINGLE_TRANSACTION`; the runtime does not silently degrade to auto-commit.
- JDBC executor now keeps one Connection across the full explicit transaction and sets `autoCommit=false`.
- Statement failure, timeout, or cancellation rolls the transaction back.
- Commit failure makes the execution fail even when all statement executions individually succeeded.
- Closing an executor with an active JDBC transaction performs best-effort rollback cleanup.

### Lifecycle hardening

Phase 3 also closes cancellation races around datasource setup:

- cancellation is re-checked after datasource open and before physical execution
- transaction setup re-checks cancellation before and after `beginTransaction()`
- active transactional cancellation is followed by explicit rollback
- unexpected runtime failures no longer leave a statement snapshot stuck in `RUNNING`

### Tests

Added / expanded tests for:

- comment and quoted-keyword handling
- read-only CTE classification
- data-modifying CTE classification
- `SELECT ... FOR UPDATE`
- conservative `EXPLAIN` handling
- PostgreSQL dollar-quoted body handling
- embedded transaction control (`UPDATE ...; COMMIT`)
- Dataset write rejection before datasource open
- Data Service mutating-CTE rejection
- SQL Task transaction-control rejection
- statement type / transaction mode snapshot metadata
- single-transaction commit
- rollback and remaining-statement skip on failure
- unsupported transaction fail-fast
- active transaction cancellation + rollback
- timeout lifecycle propagation
- JDBC one-Connection transaction reuse
- JDBC commit / rollback / auto-commit behavior

Also corrected a Phase 2 test drift that referenced `SqlExecutionCaller.STATEMENT`; the current execution caller is `CONSOLE`.

## Architecture

```text
SQL
 ↓
SqlStatementClassifier
 ↓
SqlStatementClassification
 ↓
SqlExecutionPolicy
 ↓
Execution Runtime
 ├─ AUTO_COMMIT
 └─ SINGLE_TRANSACTION
       ↓
DataSourceSqlExecutor
       ↓
JDBC / future datasource plugins
```

Read-only consumption path:

```text
Dataset / Data Service / Analysis
           ↓
     strict read-only policy
           ↓
      SqlExecutionRuntime
```

Write-capable path:

```text
Console / SQL Task / System
           ↓
 write / DDL allowed by platform policy
           ↓
      SqlExecutionRuntime
```

Product-level authorization, dangerous-SQL confirmation, and finer project/user policy can layer on top without weakening the read-only guarantee for consumption callers.

## Conservative boundary

`LexicalSqlStatementClassifier` is deliberately a platform semantic guard, not a complete dialect AST parser or security sandbox.

- Unknown/vendor-specific SQL is denied for strict read-only callers.
- Console / SQL Task / System may execute unknown vendor-specific SQL under the default platform policy.
- Transaction keywords observed outside skipped comments/quoted bodies are conservatively rejected so they cannot bypass runtime transaction modes.
- A future dialect-aware parser can implement the `SqlStatementClassifier` contract without changing the execution-policy boundary.

## Intentionally not included in Phase 3

- persisted SQL execution / audit tables
- SQL fingerprint persistence
- per-user / per-project configurable execution ACLs
- DML / DDL confirmation UI
- a full dialect AST parser
- savepoints or nested transactions
- distributed transactions
- streaming execution events
- Statement Console frontend integration

These belong in later phases once the execution semantics and transaction boundary are stable.

## Validation

- Java 21 `javac` checks passed for the new semantic/classification/policy contracts.
- Executed classifier smoke cases for mutating CTEs, quoted/comment keywords, `SELECT ... FOR UPDATE`, and embedded `COMMIT`; observed classifications matched the intended policy behavior.
- Added / updated repository unit tests covering the runtime and JDBC transaction semantics described above.
- Full Maven test execution was not available in this environment because Maven is not installed.
- Final branch is one commit ahead of current `main` and zero commits behind.
- No commit status checks were reported before opening this PR.
