### PR TITLE
feat: add phase 4 SQL execution observability

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/SqlExecutionAuditController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/SqlExecutionAuditController.java
@@ -1,0 +1,55 @@
+package io.yak.ops.business.datasource.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.PagingData;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.service.SqlExecutionAuditService;
+import io.yak.ops.common.bean.dto.observability.SqlExecutionAuditQueryDTO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditDetailVO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditSummaryVO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditVO;
+import io.yak.ops.common.constant.observability.SqlExecutionAuditConstants;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** SQL execution history and runtime observability API. */
+@Tag(name = "SQL 执行观测接口")
+@RestController
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+@RequestMapping(SqlExecutionAuditConstants.API_PREFIX)
+@RequiresPermission(SqlExecutionAuditConstants.READ_PERMISSION)
+public class SqlExecutionAuditController {
+
+  private final SqlExecutionAuditService auditService;
+
+  @Operation(summary = "分页查询 SQL 执行历史")
+  @PostMapping("/page")
+  public Result<PagingData<SqlExecutionAuditVO>> page(
+      @Valid @RequestBody(required = false) SqlExecutionAuditQueryDTO query) {
+    return Result.success(auditService.page(query));
+  }
+
+  @Operation(summary = "查询 SQL 执行详情")
+  @GetMapping("/{executionId}")
+  public Result<SqlExecutionAuditDetailVO> detail(
+      @PathVariable("executionId") String executionId) {
+    return Result.success(auditService.detail(executionId));
+  }
+
+  @Operation(summary = "查询 SQL 执行观测汇总")
+  @PostMapping("/summary")
+  public Result<SqlExecutionAuditSummaryVO> summary(
+      @Valid @RequestBody(required = false) SqlExecutionAuditQueryDTO query) {
+    return Result.success(auditService.summary(query));
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/SqlExecutionAuditDao.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/SqlExecutionAuditDao.java
@@ -1,0 +1,29 @@
+package io.yak.ops.business.datasource.dao;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditQuery;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditSummaryRow;
+import io.yak.ops.business.datasource.dao.model.SqlStatementExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlStatementTypeCountRow;
+import java.util.List;
+
+/** Persistence boundary for SQL execution observability. */
+public interface SqlExecutionAuditDao {
+
+  void insertExecution(SqlExecutionAuditPO execution);
+
+  void insertStatements(List<SqlStatementExecutionAuditPO> statements);
+
+  IPage<SqlExecutionAuditPO> selectPage(SqlExecutionAuditQuery query);
+
+  SqlExecutionAuditPO selectByExecutionId(String executionId);
+
+  List<SqlStatementExecutionAuditPO> selectStatements(String executionId);
+
+  SqlExecutionAuditSummaryRow selectSummary(SqlExecutionAuditQuery query);
+
+  long selectP95DurationMs(SqlExecutionAuditQuery query);
+
+  List<SqlStatementTypeCountRow> selectStatementTypeCounts(SqlExecutionAuditQuery query);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/SqlExecutionAuditDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/SqlExecutionAuditDaoImpl.java
@@ -1,0 +1,90 @@
+package io.yak.ops.business.datasource.dao.impl;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.dao.SqlExecutionAuditDao;
+import io.yak.ops.business.datasource.dao.mapper.SqlExecutionAuditMapper;
+import io.yak.ops.business.datasource.dao.mapper.SqlStatementExecutionAuditMapper;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditQuery;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditSummaryRow;
+import io.yak.ops.business.datasource.dao.model.SqlStatementExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlStatementTypeCountRow;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis-Plus implementation of the SQL execution audit DAO. */
+@Repository
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class SqlExecutionAuditDaoImpl implements SqlExecutionAuditDao {
+
+  private final SqlExecutionAuditMapper executionMapper;
+  private final SqlStatementExecutionAuditMapper statementMapper;
+
+  @Override
+  public void insertExecution(SqlExecutionAuditPO execution) {
+    executionMapper.insert(execution);
+  }
+
+  @Override
+  public void insertStatements(List<SqlStatementExecutionAuditPO> statements) {
+    if (statements == null || statements.isEmpty()) return;
+    for (SqlStatementExecutionAuditPO statement : statements) statementMapper.insert(statement);
+  }
+
+  @Override
+  public IPage<SqlExecutionAuditPO> selectPage(SqlExecutionAuditQuery query) {
+    SqlExecutionAuditQuery condition = requireQuery(query);
+    return executionMapper.selectAuditPage(
+        Page.of(condition.getPageNo(), condition.getPageSize()), condition);
+  }
+
+  @Override
+  public SqlExecutionAuditPO selectByExecutionId(String executionId) {
+    if (executionId == null || executionId.isBlank()) return null;
+    return executionMapper.selectOne(
+        Wrappers.<SqlExecutionAuditPO>lambdaQuery()
+            .eq(SqlExecutionAuditPO::getExecutionId, executionId.trim())
+            .last("LIMIT 1"));
+  }
+
+  @Override
+  public List<SqlStatementExecutionAuditPO> selectStatements(String executionId) {
+    if (executionId == null || executionId.isBlank()) return List.of();
+    return statementMapper.selectList(
+        Wrappers.<SqlStatementExecutionAuditPO>lambdaQuery()
+            .eq(SqlStatementExecutionAuditPO::getExecutionId, executionId.trim())
+            .orderByAsc(SqlStatementExecutionAuditPO::getStatementIndex)
+            .orderByAsc(SqlStatementExecutionAuditPO::getId));
+  }
+
+  @Override
+  public SqlExecutionAuditSummaryRow selectSummary(SqlExecutionAuditQuery query) {
+    SqlExecutionAuditSummaryRow row = executionMapper.selectAuditSummary(requireQuery(query));
+    return row == null ? new SqlExecutionAuditSummaryRow() : row;
+  }
+
+  @Override
+  public long selectP95DurationMs(SqlExecutionAuditQuery query) {
+    Long value = executionMapper.selectP95DurationMs(requireQuery(query));
+    return value == null ? 0L : Math.max(0L, value);
+  }
+
+  @Override
+  public List<SqlStatementTypeCountRow> selectStatementTypeCounts(SqlExecutionAuditQuery query) {
+    List<SqlStatementTypeCountRow> rows =
+        executionMapper.selectStatementTypeCounts(requireQuery(query));
+    return rows == null ? List.of() : List.copyOf(rows);
+  }
+
+  private static SqlExecutionAuditQuery requireQuery(SqlExecutionAuditQuery query) {
+    return query == null
+        ? new SqlExecutionAuditQuery(
+            1, 20, null, null, null, null, null, null, null, null, null, null, null, null)
+        : query;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/SqlExecutionAuditMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/SqlExecutionAuditMapper.java
@@ -1,0 +1,29 @@
+package io.yak.ops.business.datasource.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditQuery;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditSummaryRow;
+import io.yak.ops.business.datasource.dao.model.SqlStatementTypeCountRow;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/** MyBatis mapper for execution-level SQL audit records and aggregates. */
+@Mapper
+public interface SqlExecutionAuditMapper extends BaseMapper<SqlExecutionAuditPO> {
+
+  IPage<SqlExecutionAuditPO> selectAuditPage(
+      Page<SqlExecutionAuditPO> page,
+      @Param("query") SqlExecutionAuditQuery query);
+
+  SqlExecutionAuditSummaryRow selectAuditSummary(
+      @Param("query") SqlExecutionAuditQuery query);
+
+  Long selectP95DurationMs(@Param("query") SqlExecutionAuditQuery query);
+
+  List<SqlStatementTypeCountRow> selectStatementTypeCounts(
+      @Param("query") SqlExecutionAuditQuery query);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/SqlStatementExecutionAuditMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/SqlStatementExecutionAuditMapper.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.datasource.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.datasource.dao.model.SqlStatementExecutionAuditPO;
+import org.apache.ibatis.annotations.Mapper;
+
+/** MyBatis mapper for statement-level SQL audit records. */
+@Mapper
+public interface SqlStatementExecutionAuditMapper extends BaseMapper<SqlStatementExecutionAuditPO> {}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditPO.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.datasource.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** Persisted execution-level SQL audit metadata. */
+@Data
+@TableName("yak_ops_sql_execution")
+public class SqlExecutionAuditPO {
+
+  @TableId(type = IdType.AUTO)
+  private Long id;
+
+  private String executionId;
+  private String dataSourceId;
+  private SqlExecutionCaller caller;
+  private String callerReference;
+  private String operatorName;
+  private SqlTransactionMode transactionMode;
+  private SqlExecutionStatus status;
+  private Integer statementCount;
+  private Integer succeededStatementCount;
+  private Long returnedRows;
+  private Long affectedRows;
+  private LocalDateTime startedAt;
+  private LocalDateTime finishedAt;
+  private Long durationMs;
+  private String errorMessage;
+  private LocalDateTime createTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditQuery.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditQuery.java
@@ -1,0 +1,64 @@
+package io.yak.ops.business.datasource.dao.model;
+
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+/** DAO-level filters for SQL execution observability queries. */
+@Getter
+public final class SqlExecutionAuditQuery {
+
+  private final int pageNo;
+  private final int pageSize;
+  private final String executionId;
+  private final String dataSourceId;
+  private final SqlExecutionCaller caller;
+  private final String callerReference;
+  private final String operatorName;
+  private final SqlExecutionStatus status;
+  private final SqlTransactionMode transactionMode;
+  private final SqlStatementType statementType;
+  private final String sqlFingerprint;
+  private final Long minDurationMs;
+  private final LocalDateTime startedFrom;
+  private final LocalDateTime startedTo;
+
+  public SqlExecutionAuditQuery(
+      int pageNo,
+      int pageSize,
+      String executionId,
+      String dataSourceId,
+      SqlExecutionCaller caller,
+      String callerReference,
+      String operatorName,
+      SqlExecutionStatus status,
+      SqlTransactionMode transactionMode,
+      SqlStatementType statementType,
+      String sqlFingerprint,
+      Long minDurationMs,
+      LocalDateTime startedFrom,
+      LocalDateTime startedTo) {
+    this.pageNo = Math.max(1, pageNo);
+    this.pageSize = Math.min(200, Math.max(1, pageSize));
+    this.executionId = normalize(executionId);
+    this.dataSourceId = normalize(dataSourceId);
+    this.caller = caller;
+    this.callerReference = normalize(callerReference);
+    this.operatorName = normalize(operatorName);
+    this.status = status;
+    this.transactionMode = transactionMode;
+    this.statementType = statementType;
+    this.sqlFingerprint = normalize(sqlFingerprint);
+    this.minDurationMs = minDurationMs == null ? null : Math.max(0L, minDurationMs);
+    this.startedFrom = startedFrom;
+    this.startedTo = startedTo;
+  }
+
+  private static String normalize(String value) {
+    if (value == null || value.isBlank()) return null;
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditSummaryRow.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditSummaryRow.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.datasource.dao.model;
+
+import lombok.Data;
+
+/** Database aggregate for SQL execution observability. */
+@Data
+public class SqlExecutionAuditSummaryRow {
+  private long total;
+  private long succeeded;
+  private long failed;
+  private long cancelled;
+  private long timedOut;
+  private double avgDurationMs;
+  private long maxDurationMs;
+  private long returnedRows;
+  private long affectedRows;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlStatementExecutionAuditPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlStatementExecutionAuditPO.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.datasource.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import io.yak.ops.core.execution.sql.SqlExecutionResultType;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** Persisted statement-level SQL audit metadata. */
+@Data
+@TableName("yak_ops_sql_statement_execution")
+public class SqlStatementExecutionAuditPO {
+
+  @TableId(type = IdType.AUTO)
+  private Long id;
+
+  private String executionId;
+  private String statementId;
+  private Integer statementIndex;
+  private SqlStatementType statementType;
+  private String sqlFingerprint;
+  private String sqlPreview;
+  private SqlStatementStatus status;
+  private SqlExecutionResultType resultType;
+  private Long returnedRows;
+  private Long affectedRows;
+  private Boolean truncated;
+  private LocalDateTime startedAt;
+  private LocalDateTime finishedAt;
+  private Long durationMs;
+  private String errorMessage;
+  private LocalDateTime createTime;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlStatementTypeCountRow.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlStatementTypeCountRow.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.datasource.dao.model;
+
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import lombok.Data;
+
+/** Statement semantic distribution aggregate. */
+@Data
+public class SqlStatementTypeCountRow {
+  private SqlStatementType statementType;
+  private long count;
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntime.java
@@ -1,0 +1,195 @@
+package io.yak.ops.business.datasource.execution;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.execution.sql.LexicalSqlStatementClassifier;
+import io.yak.ops.core.execution.sql.SqlExecutionObserver;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionPolicyViolationException;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import jakarta.annotation.PreDestroy;
+import java.sql.SQLTimeoutException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * Primary SQL runtime facade that adds terminal observability without coupling persistence to the
+ * physical execution runtime.
+ */
+@Component
+@Primary
+@ConditionalOnDataSourceEnabled
+public final class ObservableSqlExecutionRuntime implements SqlExecutionRuntime {
+
+  private static final Logger log = LoggerFactory.getLogger(ObservableSqlExecutionRuntime.class);
+
+  private final DefaultSqlExecutionRuntime delegate;
+  private final List<SqlExecutionObserver> observers;
+  private final LexicalSqlStatementClassifier classifier = new LexicalSqlStatementClassifier();
+  private final ExecutorService tracker = Executors.newVirtualThreadPerTaskExecutor();
+
+  public ObservableSqlExecutionRuntime(
+      DefaultSqlExecutionRuntime delegate,
+      ObjectProvider<SqlExecutionObserver> observers) {
+    this(delegate, observers.orderedStream().toList());
+  }
+
+  ObservableSqlExecutionRuntime(
+      DefaultSqlExecutionRuntime delegate,
+      List<SqlExecutionObserver> observers) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.observers = observers == null ? List.of() : List.copyOf(observers);
+  }
+
+  @Override
+  public SqlExecutionResult execute(SqlExecutionRequest request) {
+    Objects.requireNonNull(request, "request");
+    SqlStatementType statementType = classifier.classify(request.sql()).primaryType();
+    String executionId = "sql-sync-" + UUID.randomUUID();
+    String statementId = executionId + ":stmt:1";
+    Instant startedAt = Instant.now();
+    try {
+      SqlExecutionResult result = delegate.execute(request);
+      Instant finishedAt = Instant.now();
+      notifyObservers(new SqlExecutionSnapshot(
+          executionId,
+          SqlExecutionStatus.SUCCEEDED,
+          request.dataSourceId(),
+          request.context(),
+          SqlTransactionMode.AUTO_COMMIT,
+          List.of(new SqlStatementSnapshot(
+              statementId,
+              0,
+              request.sql(),
+              statementType,
+              SqlStatementStatus.SUCCEEDED,
+              result,
+              null,
+              startedAt,
+              finishedAt)),
+          startedAt,
+          finishedAt,
+          null));
+      return result;
+    } catch (SqlExecutionPolicyViolationException exception) {
+      // Rejected SQL never reached a datasource and is not treated as a physical execution audit.
+      throw exception;
+    } catch (RuntimeException exception) {
+      Instant finishedAt = Instant.now();
+      boolean timedOut = causedBy(exception, SQLTimeoutException.class);
+      SqlExecutionStatus executionStatus =
+          timedOut ? SqlExecutionStatus.TIMED_OUT : SqlExecutionStatus.FAILED;
+      SqlStatementStatus statementStatus =
+          timedOut ? SqlStatementStatus.TIMED_OUT : SqlStatementStatus.FAILED;
+      String message = safeMessage(exception);
+      notifyObservers(new SqlExecutionSnapshot(
+          executionId,
+          executionStatus,
+          request.dataSourceId(),
+          request.context(),
+          SqlTransactionMode.AUTO_COMMIT,
+          List.of(new SqlStatementSnapshot(
+              statementId,
+              0,
+              request.sql(),
+              statementType,
+              statementStatus,
+              null,
+              message,
+              startedAt,
+              finishedAt)),
+          startedAt,
+          finishedAt,
+          message));
+      throw exception;
+    }
+  }
+
+  @Override
+  public SqlExecutionSnapshot start(SqlExecutionPlan plan) {
+    SqlExecutionSnapshot started = delegate.start(plan);
+    if (started.terminal()) {
+      notifyObservers(started);
+      return started;
+    }
+    try {
+      tracker.submit(() -> notifyObservers(delegate.await(started.executionId())));
+    } catch (RuntimeException exception) {
+      // Observability scheduling must not change the underlying execution lifecycle.
+      log.warn(
+          "Unable to schedule SQL execution observability: executionId={}",
+          started.executionId(),
+          exception);
+    }
+    return started;
+  }
+
+  @Override
+  public Optional<SqlExecutionSnapshot> find(String executionId) {
+    return delegate.find(executionId);
+  }
+
+  @Override
+  public SqlExecutionSnapshot await(String executionId) {
+    return delegate.await(executionId);
+  }
+
+  @Override
+  public boolean cancel(String executionId) {
+    return delegate.cancel(executionId);
+  }
+
+  @PreDestroy
+  void shutdown() {
+    tracker.shutdownNow();
+  }
+
+  private void notifyObservers(SqlExecutionSnapshot snapshot) {
+    if (snapshot == null || !snapshot.terminal()) return;
+    for (SqlExecutionObserver observer : observers) {
+      try {
+        observer.onExecutionCompleted(snapshot);
+      } catch (RuntimeException exception) {
+        log.warn(
+            "SQL execution observer failed: executionId={}, observer={}",
+            snapshot.executionId(),
+            observer.getClass().getName(),
+            exception);
+      }
+    }
+  }
+
+  private static boolean causedBy(Throwable throwable, Class<? extends Throwable> expected) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (expected.isInstance(current)) return true;
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private static String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "SQL execution failed" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 1000 ? message.substring(0, 1000) : message;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserver.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserver.java
@@ -1,0 +1,155 @@
+package io.yak.ops.business.datasource.execution.audit;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlStatementExecutionAuditPO;
+import io.yak.ops.core.execution.sql.SqlExecutionObserver;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlFingerprint;
+import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import jakarta.annotation.PreDestroy;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Persists completed SQL execution metadata without retaining result rows or bind parameters.
+ *
+ * <p>The bounded queue deliberately decouples audit I/O from user SQL latency. Saturation drops the
+ * audit item and emits a warning rather than changing the SQL execution outcome.
+ */
+@Component
+@ConditionalOnDataSourceEnabled
+public final class PersistentSqlExecutionObserver implements SqlExecutionObserver {
+
+  private static final Logger log = LoggerFactory.getLogger(PersistentSqlExecutionObserver.class);
+  private static final int QUEUE_CAPACITY = 2048;
+  private static final int SQL_PREVIEW_LIMIT = 2048;
+
+  private final SqlExecutionAuditStore store;
+  private final ThreadPoolExecutor executor;
+
+  public PersistentSqlExecutionObserver(SqlExecutionAuditStore store) {
+    this.store = store;
+    this.executor = new ThreadPoolExecutor(
+        2,
+        2,
+        0L,
+        TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+        Thread.ofPlatform().daemon(true).name("yak-sql-audit-", 0).factory(),
+        new ThreadPoolExecutor.AbortPolicy());
+  }
+
+  @Override
+  public void onExecutionCompleted(SqlExecutionSnapshot snapshot) {
+    if (snapshot == null || !snapshot.terminal()) return;
+    AuditBatch batch = map(snapshot);
+    try {
+      executor.execute(() -> persist(batch));
+    } catch (RejectedExecutionException exception) {
+      log.warn(
+          "SQL audit queue is full; dropping execution audit: executionId={}",
+          snapshot.executionId());
+    }
+  }
+
+  @PreDestroy
+  void shutdown() {
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(2, TimeUnit.SECONDS)) executor.shutdownNow();
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      executor.shutdownNow();
+    }
+  }
+
+  private void persist(AuditBatch batch) {
+    try {
+      store.save(batch.execution(), batch.statements());
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Failed to persist SQL execution audit: executionId={}",
+          batch.execution().getExecutionId(),
+          exception);
+    }
+  }
+
+  static AuditBatch map(SqlExecutionSnapshot snapshot) {
+    SqlExecutionAuditPO execution = new SqlExecutionAuditPO();
+    execution.setExecutionId(snapshot.executionId());
+    execution.setDataSourceId(snapshot.dataSourceId());
+    execution.setCaller(snapshot.context().caller());
+    execution.setCallerReference(snapshot.context().callerReference());
+    execution.setOperatorName(snapshot.context().operator());
+    execution.setTransactionMode(snapshot.transactionMode());
+    execution.setStatus(snapshot.status());
+    execution.setStatementCount(snapshot.statements().size());
+    execution.setSucceededStatementCount((int) snapshot.statements().stream()
+        .filter(statement -> statement.status() == SqlStatementStatus.SUCCEEDED)
+        .count());
+    execution.setReturnedRows(snapshot.statements().stream()
+        .map(SqlStatementSnapshot::result)
+        .filter(result -> result != null)
+        .mapToLong(SqlExecutionResult::returnedRows)
+        .sum());
+    execution.setAffectedRows(snapshot.statements().stream()
+        .map(SqlStatementSnapshot::result)
+        .filter(result -> result != null)
+        .mapToLong(SqlExecutionResult::affectedRows)
+        .sum());
+    execution.setStartedAt(local(snapshot.startedAt()));
+    execution.setFinishedAt(local(snapshot.finishedAt()));
+    execution.setDurationMs(snapshot.durationMillis());
+    execution.setErrorMessage(limit(snapshot.errorMessage(), 1000));
+
+    List<SqlStatementExecutionAuditPO> statements = new ArrayList<>(snapshot.statements().size());
+    for (SqlStatementSnapshot statement : snapshot.statements()) {
+      SqlStatementExecutionAuditPO row = new SqlStatementExecutionAuditPO();
+      row.setExecutionId(snapshot.executionId());
+      row.setStatementId(statement.statementId());
+      row.setStatementIndex(statement.index());
+      row.setStatementType(statement.statementType());
+      row.setSqlFingerprint(SqlFingerprint.sha256(statement.sql()));
+      row.setSqlPreview(SqlFingerprint.redactedPreview(statement.sql(), SQL_PREVIEW_LIMIT));
+      row.setStatus(statement.status());
+      SqlExecutionResult result = statement.result();
+      row.setResultType(result == null ? null : result.type());
+      row.setReturnedRows(result == null ? 0L : (long) result.returnedRows());
+      row.setAffectedRows(result == null ? 0L : result.affectedRows());
+      row.setTruncated(result != null && result.truncated());
+      row.setStartedAt(local(statement.startedAt()));
+      row.setFinishedAt(local(
+          statement.finishedAt() == null ? snapshot.finishedAt() : statement.finishedAt()));
+      row.setDurationMs(statement.durationMillis());
+      row.setErrorMessage(limit(statement.errorMessage(), 1000));
+      statements.add(row);
+    }
+    return new AuditBatch(execution, List.copyOf(statements));
+  }
+
+  private static LocalDateTime local(Instant value) {
+    return value == null ? null : LocalDateTime.ofInstant(value, ZoneId.systemDefault());
+  }
+
+  private static String limit(String value, int maxChars) {
+    if (value == null || value.length() <= maxChars) return value;
+    return value.substring(0, maxChars);
+  }
+
+  record AuditBatch(
+      SqlExecutionAuditPO execution,
+      List<SqlStatementExecutionAuditPO> statements) {}
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/SqlExecutionAuditStore.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/SqlExecutionAuditStore.java
@@ -1,0 +1,29 @@
+package io.yak.ops.business.datasource.execution.audit;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.dao.SqlExecutionAuditDao;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlStatementExecutionAuditPO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Transactional persistence boundary for one completed SQL execution audit batch. */
+@Service
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class SqlExecutionAuditStore {
+
+  private final SqlExecutionAuditDao auditDao;
+
+  @Transactional(
+      transactionManager = "opsDataSourceTransactionManager",
+      rollbackFor = Exception.class)
+  public void save(
+      SqlExecutionAuditPO execution,
+      List<SqlStatementExecutionAuditPO> statements) {
+    auditDao.insertExecution(execution);
+    auditDao.insertStatements(statements);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/SqlExecutionAuditService.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/SqlExecutionAuditService.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.datasource.service;
+
+import io.yak.framework.common.PagingData;
+import io.yak.ops.common.bean.dto.observability.SqlExecutionAuditQueryDTO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditDetailVO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditSummaryVO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditVO;
+
+/** Read-side service for SQL execution history and observability aggregates. */
+public interface SqlExecutionAuditService {
+
+  PagingData<SqlExecutionAuditVO> page(SqlExecutionAuditQueryDTO query);
+
+  SqlExecutionAuditDetailVO detail(String executionId);
+
+  SqlExecutionAuditSummaryVO summary(SqlExecutionAuditQueryDTO query);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/SqlExecutionAuditServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/SqlExecutionAuditServiceImpl.java
@@ -1,0 +1,181 @@
+package io.yak.ops.business.datasource.service.impl;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import io.yak.framework.common.PageData;
+import io.yak.framework.common.PagingData;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.dao.SqlExecutionAuditDao;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditQuery;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditSummaryRow;
+import io.yak.ops.business.datasource.dao.model.SqlStatementExecutionAuditPO;
+import io.yak.ops.business.datasource.service.SqlExecutionAuditService;
+import io.yak.ops.common.bean.dto.observability.SqlExecutionAuditQueryDTO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditDetailVO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditSummaryVO;
+import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditVO;
+import io.yak.ops.common.bean.vo.observability.SqlStatementExecutionAuditVO;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.stereotype.Service;
+
+/** SQL execution observability read service. */
+@Service
+@ConditionalOnDataSourceEnabled
+public class SqlExecutionAuditServiceImpl implements SqlExecutionAuditService {
+
+  private final SqlExecutionAuditDao auditDao;
+
+  public SqlExecutionAuditServiceImpl(SqlExecutionAuditDao auditDao) {
+    this.auditDao = auditDao;
+  }
+
+  @Override
+  public PagingData<SqlExecutionAuditVO> page(SqlExecutionAuditQueryDTO queryDTO) {
+    SqlExecutionAuditQuery query = toQuery(queryDTO);
+    IPage<SqlExecutionAuditPO> page = auditDao.selectPage(query);
+    List<SqlExecutionAuditVO> records = page.getRecords().stream().map(this::executionView).toList();
+    return PagingData.from(new PageData<>(
+        records,
+        page.getTotal(),
+        page.getPages(),
+        page.getCurrent(),
+        page.getSize()));
+  }
+
+  @Override
+  public SqlExecutionAuditDetailVO detail(String executionId) {
+    if (executionId == null || executionId.isBlank()) {
+      throw new IllegalArgumentException("executionId must not be blank");
+    }
+    SqlExecutionAuditPO execution = auditDao.selectByExecutionId(executionId.trim());
+    if (execution == null) {
+      throw new IllegalArgumentException("SQL execution audit not found: " + executionId.trim());
+    }
+    List<SqlStatementExecutionAuditVO> statements = auditDao.selectStatements(executionId).stream()
+        .map(this::statementView)
+        .toList();
+    return new SqlExecutionAuditDetailVO(executionView(execution), statements);
+  }
+
+  @Override
+  public SqlExecutionAuditSummaryVO summary(SqlExecutionAuditQueryDTO queryDTO) {
+    SqlExecutionAuditQuery query = toQuery(queryDTO);
+    SqlExecutionAuditSummaryRow summary = auditDao.selectSummary(query);
+    long p95 = auditDao.selectP95DurationMs(query);
+    List<SqlExecutionAuditSummaryVO.StatementTypeCountVO> statementTypes =
+        auditDao.selectStatementTypeCounts(query).stream()
+            .map(row -> new SqlExecutionAuditSummaryVO.StatementTypeCountVO(
+                row.getStatementType() == null ? "OTHER" : row.getStatementType().name(),
+                row.getCount()))
+            .toList();
+    double successRate = summary.getTotal() == 0L
+        ? 0D
+        : summary.getSucceeded() / (double) summary.getTotal();
+    return new SqlExecutionAuditSummaryVO(
+        summary.getTotal(),
+        summary.getSucceeded(),
+        summary.getFailed(),
+        summary.getCancelled(),
+        summary.getTimedOut(),
+        successRate,
+        summary.getAvgDurationMs(),
+        summary.getMaxDurationMs(),
+        p95,
+        summary.getReturnedRows(),
+        summary.getAffectedRows(),
+        statementTypes);
+  }
+
+  private SqlExecutionAuditQuery toQuery(SqlExecutionAuditQueryDTO dto) {
+    SqlExecutionAuditQueryDTO source = dto == null ? new SqlExecutionAuditQueryDTO() : dto;
+    if (source.getStartedFrom() != null
+        && source.getStartedTo() != null
+        && source.getStartedFrom().isAfter(source.getStartedTo())) {
+      throw new IllegalArgumentException("startedFrom must not be after startedTo");
+    }
+    return new SqlExecutionAuditQuery(
+        source.getPageNo() == null ? 1 : source.getPageNo(),
+        source.getPageSize() == null ? 20 : source.getPageSize(),
+        source.getExecutionId(),
+        source.getDataSourceId(),
+        parseEnum(SqlExecutionCaller.class, source.getCaller(), "caller"),
+        source.getCallerReference(),
+        source.getOperatorName(),
+        parseEnum(SqlExecutionStatus.class, source.getStatus(), "status"),
+        parseEnum(SqlTransactionMode.class, source.getTransactionMode(), "transactionMode"),
+        parseEnum(SqlStatementType.class, source.getStatementType(), "statementType"),
+        source.getSqlFingerprint(),
+        source.getMinDurationMs(),
+        source.getStartedFrom(),
+        source.getStartedTo());
+  }
+
+  private SqlExecutionAuditVO executionView(SqlExecutionAuditPO row) {
+    return new SqlExecutionAuditVO(
+        row.getExecutionId(),
+        row.getDataSourceId(),
+        name(row.getCaller()),
+        row.getCallerReference(),
+        row.getOperatorName(),
+        name(row.getTransactionMode()),
+        name(row.getStatus()),
+        value(row.getStatementCount()),
+        value(row.getSucceededStatementCount()),
+        value(row.getReturnedRows()),
+        value(row.getAffectedRows()),
+        row.getStartedAt(),
+        row.getFinishedAt(),
+        value(row.getDurationMs()),
+        row.getErrorMessage());
+  }
+
+  private SqlStatementExecutionAuditVO statementView(SqlStatementExecutionAuditPO row) {
+    return new SqlStatementExecutionAuditVO(
+        row.getStatementId(),
+        value(row.getStatementIndex()),
+        name(row.getStatementType()),
+        row.getSqlFingerprint(),
+        row.getSqlPreview(),
+        name(row.getStatus()),
+        name(row.getResultType()),
+        value(row.getReturnedRows()),
+        value(row.getAffectedRows()),
+        Boolean.TRUE.equals(row.getTruncated()),
+        row.getStartedAt(),
+        row.getFinishedAt(),
+        value(row.getDurationMs()),
+        row.getErrorMessage());
+  }
+
+  private static <E extends Enum<E>> E parseEnum(
+      Class<E> enumType,
+      String value,
+      String fieldName) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim().replace('-', '_').toUpperCase(Locale.ROOT);
+    try {
+      return Enum.valueOf(enumType, normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException(
+          "Invalid " + fieldName + ": " + value,
+          exception);
+    }
+  }
+
+  private static String name(Enum<?> value) {
+    return value == null ? null : value.name();
+  }
+
+  private static int value(Integer value) {
+    return value == null ? 0 : value;
+  }
+
+  private static long value(Long value) {
+    return value == null ? 0L : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V3__create_sql_execution_audit_tables.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V3__create_sql_execution_audit_tables.sql
@@ -1,0 +1,59 @@
+-- Shared SQL execution observability / audit tables.
+CREATE TABLE IF NOT EXISTS yak_ops_sql_execution (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+    execution_id VARCHAR(96) NOT NULL COMMENT 'SQL Runtime execution id',
+    data_source_id VARCHAR(128) NOT NULL COMMENT '数据源引用',
+    caller VARCHAR(32) NOT NULL COMMENT '调用方类型',
+    caller_reference VARCHAR(255) DEFAULT NULL COMMENT '调用方业务引用',
+    operator_name VARCHAR(128) DEFAULT NULL COMMENT '操作人标识，可为空',
+    transaction_mode VARCHAR(32) NOT NULL COMMENT '事务模式',
+    status VARCHAR(32) NOT NULL COMMENT '执行状态',
+    statement_count INT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Statement 数量',
+    succeeded_statement_count INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '成功 Statement 数量',
+    returned_rows BIGINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '累计返回行数',
+    affected_rows BIGINT NOT NULL DEFAULT 0 COMMENT '累计影响行数',
+    started_at DATETIME(3) NOT NULL COMMENT '开始时间',
+    finished_at DATETIME(3) NOT NULL COMMENT '结束时间',
+    duration_ms BIGINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '执行耗时毫秒',
+    error_message VARCHAR(1000) DEFAULT NULL COMMENT '终态错误摘要',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_ops_sql_execution_execution_id (execution_id),
+    KEY idx_yak_ops_sql_execution_started_at (started_at),
+    KEY idx_yak_ops_sql_execution_status_started (status, started_at),
+    KEY idx_yak_ops_sql_execution_caller_started (caller, started_at),
+    KEY idx_yak_ops_sql_execution_datasource_started (data_source_id, started_at),
+    KEY idx_yak_ops_sql_execution_duration (duration_ms)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops SQL Execution 执行审计';
+
+CREATE TABLE IF NOT EXISTS yak_ops_sql_statement_execution (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+    execution_id VARCHAR(96) NOT NULL COMMENT '所属 SQL execution id',
+    statement_id VARCHAR(128) NOT NULL COMMENT 'SQL Runtime statement id',
+    statement_index INT UNSIGNED NOT NULL COMMENT 'Statement 顺序，从 0 开始',
+    statement_type VARCHAR(32) NOT NULL COMMENT 'SQL 语义类型',
+    sql_fingerprint CHAR(64) NOT NULL COMMENT '字面量脱敏后的 SHA-256 指纹',
+    sql_preview VARCHAR(2048) NOT NULL COMMENT '字面量脱敏后的 SQL 预览',
+    status VARCHAR(32) NOT NULL COMMENT 'Statement 状态',
+    result_type VARCHAR(32) DEFAULT NULL COMMENT 'RESULT_SET / UPDATE_COUNT',
+    returned_rows BIGINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '返回行数',
+    affected_rows BIGINT NOT NULL DEFAULT 0 COMMENT '影响行数',
+    truncated TINYINT(1) NOT NULL DEFAULT 0 COMMENT '结果是否被 maxRows 截断',
+    started_at DATETIME(3) DEFAULT NULL COMMENT '开始时间；SKIPPED 可为空',
+    finished_at DATETIME(3) NOT NULL COMMENT '结束时间',
+    duration_ms BIGINT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Statement 耗时毫秒',
+    error_message VARCHAR(1000) DEFAULT NULL COMMENT 'Statement 错误摘要',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '记录创建时间',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_ops_sql_statement_statement_id (statement_id),
+    KEY idx_yak_ops_sql_statement_execution (execution_id, statement_index),
+    KEY idx_yak_ops_sql_statement_fingerprint (sql_fingerprint),
+    KEY idx_yak_ops_sql_statement_type_status (statement_type, status),
+    KEY idx_yak_ops_sql_statement_duration (duration_ms)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops SQL Statement 执行审计';

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/SqlExecutionAuditMapper.xml
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/SqlExecutionAuditMapper.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.yak.ops.business.datasource.dao.mapper.SqlExecutionAuditMapper">
+
+    <sql id="ExecutionBaseFilters">
+        <if test="query.executionId != null">
+            AND e.execution_id = #{query.executionId}
+        </if>
+        <if test="query.dataSourceId != null">
+            AND e.data_source_id = #{query.dataSourceId}
+        </if>
+        <if test="query.caller != null">
+            AND e.caller = #{query.caller}
+        </if>
+        <if test="query.callerReference != null">
+            AND e.caller_reference = #{query.callerReference}
+        </if>
+        <if test="query.operatorName != null">
+            AND e.operator_name LIKE CONCAT('%', #{query.operatorName}, '%')
+        </if>
+        <if test="query.status != null">
+            AND e.status = #{query.status}
+        </if>
+        <if test="query.transactionMode != null">
+            AND e.transaction_mode = #{query.transactionMode}
+        </if>
+        <if test="query.minDurationMs != null">
+            AND e.duration_ms &gt;= #{query.minDurationMs}
+        </if>
+        <if test="query.startedFrom != null">
+            AND e.started_at &gt;= #{query.startedFrom}
+        </if>
+        <if test="query.startedTo != null">
+            AND e.started_at &lt;= #{query.startedTo}
+        </if>
+    </sql>
+
+    <sql id="ExecutionStatementFilters">
+        <if test="query.statementType != null or query.sqlFingerprint != null">
+            AND EXISTS (
+                SELECT 1
+                FROM yak_ops_sql_statement_execution sf
+                WHERE sf.execution_id = e.execution_id
+                <if test="query.statementType != null">
+                    AND sf.statement_type = #{query.statementType}
+                </if>
+                <if test="query.sqlFingerprint != null">
+                    AND sf.sql_fingerprint = #{query.sqlFingerprint}
+                </if>
+            )
+        </if>
+    </sql>
+
+    <select id="selectAuditPage"
+            resultType="io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO">
+        SELECT e.*
+        FROM yak_ops_sql_execution e
+        <where>
+            1 = 1
+            <include refid="ExecutionBaseFilters"/>
+            <include refid="ExecutionStatementFilters"/>
+        </where>
+        ORDER BY e.started_at DESC, e.id DESC
+    </select>
+
+    <select id="selectAuditSummary"
+            resultType="io.yak.ops.business.datasource.dao.model.SqlExecutionAuditSummaryRow">
+        SELECT COUNT(*) AS total,
+               COALESCE(SUM(CASE WHEN e.status = 'SUCCEEDED' THEN 1 ELSE 0 END), 0) AS succeeded,
+               COALESCE(SUM(CASE WHEN e.status = 'FAILED' THEN 1 ELSE 0 END), 0) AS failed,
+               COALESCE(SUM(CASE WHEN e.status = 'CANCELLED' THEN 1 ELSE 0 END), 0) AS cancelled,
+               COALESCE(SUM(CASE WHEN e.status = 'TIMED_OUT' THEN 1 ELSE 0 END), 0) AS timed_out,
+               COALESCE(AVG(e.duration_ms), 0) AS avg_duration_ms,
+               COALESCE(MAX(e.duration_ms), 0) AS max_duration_ms,
+               COALESCE(SUM(e.returned_rows), 0) AS returned_rows,
+               COALESCE(SUM(e.affected_rows), 0) AS affected_rows
+        FROM yak_ops_sql_execution e
+        <where>
+            1 = 1
+            <include refid="ExecutionBaseFilters"/>
+            <include refid="ExecutionStatementFilters"/>
+        </where>
+    </select>
+
+    <select id="selectP95DurationMs" resultType="java.lang.Long">
+        SELECT ranked.duration_ms
+        FROM (
+            SELECT e.duration_ms,
+                   ROW_NUMBER() OVER (ORDER BY e.duration_ms) AS row_number_value,
+                   COUNT(*) OVER () AS total_count
+            FROM yak_ops_sql_execution e
+            <where>
+                1 = 1
+                <include refid="ExecutionBaseFilters"/>
+                <include refid="ExecutionStatementFilters"/>
+            </where>
+        ) ranked
+        WHERE ranked.row_number_value &gt;= CEIL(ranked.total_count * 0.95)
+        ORDER BY ranked.row_number_value
+        LIMIT 1
+    </select>
+
+    <select id="selectStatementTypeCounts"
+            resultType="io.yak.ops.business.datasource.dao.model.SqlStatementTypeCountRow">
+        SELECT s.statement_type AS statement_type,
+               COUNT(*) AS count
+        FROM yak_ops_sql_statement_execution s
+        INNER JOIN yak_ops_sql_execution e ON e.execution_id = s.execution_id
+        <where>
+            1 = 1
+            <include refid="ExecutionBaseFilters"/>
+            <if test="query.statementType != null">
+                AND s.statement_type = #{query.statementType}
+            </if>
+            <if test="query.sqlFingerprint != null">
+                AND s.sql_fingerprint = #{query.sqlFingerprint}
+            </if>
+        </where>
+        GROUP BY s.statement_type
+        ORDER BY count DESC, s.statement_type ASC
+    </select>
+
+</mapper>

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
@@ -1,0 +1,134 @@
+package io.yak.ops.business.datasource.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionObserver;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionPolicyViolationException;
+import io.yak.ops.core.execution.sql.SqlExecutionRequest;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementRequest;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class ObservableSqlExecutionRuntimeTest {
+
+  @Test
+  void observesSynchronousDatasetExecution() {
+    AtomicReference<SqlExecutionSnapshot> observed = new AtomicReference<>();
+    RuntimePair pair = runtime(observed::set);
+    try {
+      SqlExecutionResult result = pair.observable().execute(new SqlExecutionRequest(
+          "42",
+          "select * from demo where id = 7",
+          10,
+          5,
+          SqlExecutionContext.of(SqlExecutionCaller.DATASET, "dataset-1")));
+
+      assertTrue(result.resultSet());
+      SqlExecutionSnapshot snapshot = observed.get();
+      assertEquals(SqlExecutionStatus.SUCCEEDED, snapshot.status());
+      assertTrue(snapshot.executionId().startsWith("sql-sync-"));
+      assertEquals(SqlStatementType.SELECT, snapshot.statements().get(0).statementType());
+      assertEquals(SqlStatementStatus.SUCCEEDED, snapshot.statements().get(0).status());
+    } finally {
+      pair.close();
+    }
+  }
+
+  @Test
+  void observesTrackedExecutionOnceAtTerminalState() throws Exception {
+    AtomicInteger calls = new AtomicInteger();
+    AtomicReference<SqlExecutionSnapshot> observed = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    RuntimePair pair = runtime(snapshot -> {
+      calls.incrementAndGet();
+      observed.set(snapshot);
+      latch.countDown();
+    });
+    try {
+      SqlExecutionSnapshot started = pair.observable().start(new SqlExecutionPlan(
+          "42",
+          List.of(new SqlStatementRequest("update demo set enabled = 1", 10, 5)),
+          SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-1")));
+
+      SqlExecutionSnapshot completed = pair.observable().await(started.executionId());
+      assertEquals(SqlExecutionStatus.SUCCEEDED, completed.status());
+      assertTrue(latch.await(2, TimeUnit.SECONDS));
+      assertEquals(1, calls.get());
+      assertEquals(started.executionId(), observed.get().executionId());
+    } finally {
+      pair.close();
+    }
+  }
+
+  @Test
+  void observerFailureNeverChangesSqlOutcome() {
+    RuntimePair pair = runtime(snapshot -> {
+      throw new IllegalStateException("audit unavailable");
+    });
+    try {
+      SqlExecutionResult result = pair.observable().execute(new SqlExecutionRequest(
+          "42",
+          "select 1",
+          10,
+          5,
+          SqlExecutionContext.of(SqlExecutionCaller.CONSOLE, "console-1")));
+
+      assertTrue(result.resultSet());
+    } finally {
+      pair.close();
+    }
+  }
+
+  @Test
+  void policyRejectedSqlIsNotRecordedAsPhysicalExecution() {
+    AtomicInteger calls = new AtomicInteger();
+    RuntimePair pair = runtime(snapshot -> calls.incrementAndGet());
+    try {
+      assertThrows(
+          SqlExecutionPolicyViolationException.class,
+          () -> pair.observable().execute(new SqlExecutionRequest(
+              "42",
+              "update demo set enabled = 1",
+              10,
+              5,
+              SqlExecutionContext.of(SqlExecutionCaller.DATASET, "dataset-1"))));
+      assertEquals(0, calls.get());
+    } finally {
+      pair.close();
+    }
+  }
+
+  private static RuntimePair runtime(SqlExecutionObserver observer) {
+    DataSourceExecutionProvider provider = dataSourceId -> request ->
+        request.sql().trim().toLowerCase().startsWith("select")
+            ? DataSourceSqlResult.query(List.of(), List.of(), false)
+            : DataSourceSqlResult.updateCount(1L);
+    DefaultSqlExecutionRuntime delegate = new DefaultSqlExecutionRuntime(provider);
+    return new RuntimePair(delegate, new ObservableSqlExecutionRuntime(delegate, List.of(observer)));
+  }
+
+  private record RuntimePair(
+      DefaultSqlExecutionRuntime delegate,
+      ObservableSqlExecutionRuntime observable) {
+    void close() {
+      observable.shutdown();
+      delegate.shutdown();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserverTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserverTest.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.datasource.execution.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionResultType;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlExecutionTiming;
+import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PersistentSqlExecutionObserverTest {
+
+  @Test
+  void mapsOnlyObservabilityMetadataAndRedactsSqlLiterals() {
+    Instant started = Instant.parse("2026-08-18T10:00:00Z");
+    Instant finished = started.plusMillis(25);
+    SqlExecutionResult result = new SqlExecutionResult(
+        SqlExecutionResultType.RESULT_SET,
+        List.of(),
+        List.of(List.of("sensitive-result-value")),
+        0L,
+        false,
+        new SqlExecutionTiming(2L, 20L, 25L));
+    SqlExecutionSnapshot snapshot = new SqlExecutionSnapshot(
+        "sql-1",
+        SqlExecutionStatus.SUCCEEDED,
+        "42",
+        SqlExecutionContext.of(SqlExecutionCaller.CONSOLE, "console-1", "bruce"),
+        SqlTransactionMode.AUTO_COMMIT,
+        List.of(new SqlStatementSnapshot(
+            "sql-1:stmt:1",
+            0,
+            "select * from patient where name='Alice' and id=123",
+            SqlStatementType.SELECT,
+            SqlStatementStatus.SUCCEEDED,
+            result,
+            null,
+            started,
+            finished)),
+        started,
+        finished,
+        null);
+
+    PersistentSqlExecutionObserver.AuditBatch batch = PersistentSqlExecutionObserver.map(snapshot);
+
+    assertEquals("bruce", batch.execution().getOperatorName());
+    assertEquals(1L, batch.execution().getReturnedRows());
+    assertEquals(1, batch.execution().getSucceededStatementCount());
+    assertEquals(1, batch.statements().size());
+    String preview = batch.statements().get(0).getSqlPreview();
+    assertFalse(preview.contains("Alice"));
+    assertFalse(preview.contains("123"));
+    assertFalse(preview.contains("sensitive-result-value"));
+    assertTrue(preview.contains("?"));
+    assertEquals(64, batch.statements().get(0).getSqlFingerprint().length());
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/observability/SqlExecutionAuditQueryDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/observability/SqlExecutionAuditQueryDTO.java
@@ -1,0 +1,34 @@
+package io.yak.ops.common.bean.dto.observability;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** Filters for SQL execution history and observability aggregates. */
+@Data
+public class SqlExecutionAuditQueryDTO {
+
+  @Min(1)
+  private Integer pageNo = 1;
+
+  @Min(1)
+  @Max(200)
+  private Integer pageSize = 20;
+
+  private String executionId;
+  private String dataSourceId;
+  private String caller;
+  private String callerReference;
+  private String operatorName;
+  private String status;
+  private String transactionMode;
+  private String statementType;
+  private String sqlFingerprint;
+
+  @Min(0)
+  private Long minDurationMs;
+
+  private LocalDateTime startedFrom;
+  private LocalDateTime startedTo;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlExecutionAuditDetailVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlExecutionAuditDetailVO.java
@@ -1,0 +1,13 @@
+package io.yak.ops.common.bean.vo.observability;
+
+import java.util.List;
+
+/** Execution detail including ordered statement metadata. */
+public record SqlExecutionAuditDetailVO(
+    SqlExecutionAuditVO execution,
+    List<SqlStatementExecutionAuditVO> statements) {
+
+  public SqlExecutionAuditDetailVO {
+    statements = statements == null ? List.of() : List.copyOf(statements);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlExecutionAuditSummaryVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlExecutionAuditSummaryVO.java
@@ -1,0 +1,25 @@
+package io.yak.ops.common.bean.vo.observability;
+
+import java.util.List;
+
+/** Aggregate SQL execution observability summary. */
+public record SqlExecutionAuditSummaryVO(
+    long total,
+    long succeeded,
+    long failed,
+    long cancelled,
+    long timedOut,
+    double successRate,
+    double avgDurationMs,
+    long maxDurationMs,
+    long p95DurationMs,
+    long returnedRows,
+    long affectedRows,
+    List<StatementTypeCountVO> statementTypes) {
+
+  public SqlExecutionAuditSummaryVO {
+    statementTypes = statementTypes == null ? List.of() : List.copyOf(statementTypes);
+  }
+
+  public record StatementTypeCountVO(String statementType, long count) {}
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlExecutionAuditVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlExecutionAuditVO.java
@@ -1,0 +1,21 @@
+package io.yak.ops.common.bean.vo.observability;
+
+import java.time.LocalDateTime;
+
+/** Execution-level SQL observability view. */
+public record SqlExecutionAuditVO(
+    String executionId,
+    String dataSourceId,
+    String caller,
+    String callerReference,
+    String operatorName,
+    String transactionMode,
+    String status,
+    int statementCount,
+    int succeededStatementCount,
+    long returnedRows,
+    long affectedRows,
+    LocalDateTime startedAt,
+    LocalDateTime finishedAt,
+    long durationMs,
+    String errorMessage) {}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlStatementExecutionAuditVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/observability/SqlStatementExecutionAuditVO.java
@@ -1,0 +1,20 @@
+package io.yak.ops.common.bean.vo.observability;
+
+import java.time.LocalDateTime;
+
+/** Statement-level SQL observability view. */
+public record SqlStatementExecutionAuditVO(
+    String statementId,
+    int statementIndex,
+    String statementType,
+    String sqlFingerprint,
+    String sqlPreview,
+    String status,
+    String resultType,
+    long returnedRows,
+    long affectedRows,
+    boolean truncated,
+    LocalDateTime startedAt,
+    LocalDateTime finishedAt,
+    long durationMs,
+    String errorMessage) {}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/constant/observability/SqlExecutionAuditConstants.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/constant/observability/SqlExecutionAuditConstants.java
@@ -1,0 +1,10 @@
+package io.yak.ops.common.constant.observability;
+
+/** Stable API and permission constants for SQL execution observability. */
+public final class SqlExecutionAuditConstants {
+
+  public static final String API_PREFIX = "/api/v1/sql-executions";
+  public static final String READ_PERMISSION = "resource:sql-execution:read";
+
+  private SqlExecutionAuditConstants() {}
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionContext.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionContext.java
@@ -3,19 +3,39 @@ package io.yak.ops.core.execution.sql;
 import java.util.Objects;
 
 /** Identifies the platform caller without leaking domain-specific models into the SQL runtime. */
-public record SqlExecutionContext(SqlExecutionCaller caller, String callerReference) {
+public record SqlExecutionContext(
+    SqlExecutionCaller caller,
+    String callerReference,
+    String operator) {
 
   public SqlExecutionContext {
     caller = Objects.requireNonNull(caller, "caller");
     callerReference = normalize(callerReference);
+    operator = normalize(operator);
+  }
+
+  /** Backward-compatible constructor for callers that do not yet resolve an operator. */
+  public SqlExecutionContext(SqlExecutionCaller caller, String callerReference) {
+    this(caller, callerReference, null);
   }
 
   public static SqlExecutionContext of(SqlExecutionCaller caller, String callerReference) {
-    return new SqlExecutionContext(caller, callerReference);
+    return new SqlExecutionContext(caller, callerReference, null);
+  }
+
+  public static SqlExecutionContext of(
+      SqlExecutionCaller caller,
+      String callerReference,
+      String operator) {
+    return new SqlExecutionContext(caller, callerReference, operator);
+  }
+
+  public SqlExecutionContext withOperator(String resolvedOperator) {
+    return new SqlExecutionContext(caller, callerReference, resolvedOperator);
   }
 
   public static SqlExecutionContext system() {
-    return new SqlExecutionContext(SqlExecutionCaller.SYSTEM, null);
+    return new SqlExecutionContext(SqlExecutionCaller.SYSTEM, null, null);
   }
 
   private static String normalize(String value) {

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionObserver.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionObserver.java
@@ -1,0 +1,13 @@
+package io.yak.ops.core.execution.sql;
+
+/**
+ * Observer for terminal SQL execution snapshots.
+ *
+ * <p>Observers are side-effect boundaries such as audit persistence or metrics export. Runtime
+ * implementations must not let observer failures change the SQL execution outcome.
+ */
+@FunctionalInterface
+public interface SqlExecutionObserver {
+
+  void onExecutionCompleted(SqlExecutionSnapshot snapshot);
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlFingerprint.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlFingerprint.java
@@ -1,0 +1,222 @@
+package io.yak.ops.core.execution.sql;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+
+/** Stable, literal-redacted SQL normalization and SHA-256 fingerprinting. */
+public final class SqlFingerprint {
+
+  private SqlFingerprint() {}
+
+  public static String sha256(String sql) {
+    String normalized = normalize(sql);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] bytes = digest.digest(normalized.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(bytes.length * 2);
+      for (byte value : bytes) hex.append(String.format(Locale.ROOT, "%02x", value));
+      return hex.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+
+  /**
+   * Produces a deterministic SQL shape with comments removed and literal values redacted to '?'.
+   * It is intended for observability grouping, not SQL parsing or authorization.
+   *
+   * <p>Double-quoted content is conservatively redacted because dialects disagree on whether it is
+   * an identifier or a string literal. Backtick and bracket identifiers are retained.
+   */
+  public static String normalize(String sql) {
+    if (sql == null || sql.isBlank()) return "";
+    StringBuilder output = new StringBuilder(sql.length());
+    int index = 0;
+    while (index < sql.length()) {
+      char current = sql.charAt(index);
+
+      if (Character.isWhitespace(current)) {
+        index++;
+        continue;
+      }
+      if (current == '-' && index + 1 < sql.length() && sql.charAt(index + 1) == '-') {
+        index = skipLineComment(sql, index + 2);
+        continue;
+      }
+      if (current == '/' && index + 1 < sql.length() && sql.charAt(index + 1) == '*') {
+        index = skipBlockComment(sql, index + 2);
+        continue;
+      }
+      if (current == '\'') {
+        appendToken(output, "?");
+        index = skipQuoted(sql, index + 1, '\'', true);
+        continue;
+      }
+      if (current == '"') {
+        appendToken(output, "?");
+        index = skipQuoted(sql, index + 1, '"', true);
+        continue;
+      }
+      if (current == '$') {
+        int delimiterEnd = dollarQuoteDelimiterEnd(sql, index);
+        if (delimiterEnd > index) {
+          String delimiter = sql.substring(index, delimiterEnd);
+          int closing = sql.indexOf(delimiter, delimiterEnd);
+          if (closing >= 0) {
+            appendToken(output, "?");
+            index = closing + delimiter.length();
+            continue;
+          }
+        }
+      }
+      if (current == '`') {
+        int end = skipQuoted(sql, index + 1, current, true);
+        appendToken(output, sql.substring(index, Math.min(end, sql.length())));
+        index = end;
+        continue;
+      }
+      if (current == '[') {
+        int end = sql.indexOf(']', index + 1);
+        if (end >= 0) {
+          appendToken(output, sql.substring(index, end + 1));
+          index = end + 1;
+          continue;
+        }
+      }
+      if (isNumberStart(sql, index)) {
+        appendToken(output, "?");
+        index = skipNumber(sql, index);
+        continue;
+      }
+      if (Character.isLetter(current) || current == '_' || current == '$') {
+        int end = index + 1;
+        while (end < sql.length()) {
+          char value = sql.charAt(end);
+          if (!Character.isLetterOrDigit(value) && value != '_' && value != '$') break;
+          end++;
+        }
+        appendToken(output, sql.substring(index, end).toUpperCase(Locale.ROOT));
+        index = end;
+        continue;
+      }
+      if (current == '?') {
+        appendToken(output, "?");
+        index++;
+        continue;
+      }
+
+      appendToken(output, String.valueOf(current));
+      index++;
+    }
+    return output.toString();
+  }
+
+  public static String redactedPreview(String sql, int maxChars) {
+    int limit = Math.max(32, maxChars);
+    String normalized = normalize(sql);
+    return normalized.length() <= limit ? normalized : normalized.substring(0, limit) + "…";
+  }
+
+  private static void appendToken(StringBuilder output, String token) {
+    if (token == null || token.isEmpty()) return;
+    if (!output.isEmpty()) output.append(' ');
+    output.append(token);
+  }
+
+  private static int skipLineComment(String sql, int index) {
+    while (index < sql.length() && sql.charAt(index) != '\n' && sql.charAt(index) != '\r') index++;
+    return index;
+  }
+
+  private static int skipBlockComment(String sql, int index) {
+    int end = sql.indexOf("*/", index);
+    return end < 0 ? sql.length() : end + 2;
+  }
+
+  private static int skipQuoted(String sql, int index, char quote, boolean doubledEscape) {
+    while (index < sql.length()) {
+      char value = sql.charAt(index);
+      if (value == quote) {
+        if (doubledEscape && index + 1 < sql.length() && sql.charAt(index + 1) == quote) {
+          index += 2;
+          continue;
+        }
+        return index + 1;
+      }
+      if (value == '\\' && index + 1 < sql.length()) {
+        index += 2;
+        continue;
+      }
+      index++;
+    }
+    return sql.length();
+  }
+
+  private static int dollarQuoteDelimiterEnd(String sql, int index) {
+    if (sql.charAt(index) != '$') return -1;
+    int cursor = index + 1;
+    while (cursor < sql.length()) {
+      char value = sql.charAt(cursor);
+      if (value == '$') return cursor + 1;
+      if (!Character.isLetterOrDigit(value) && value != '_') return -1;
+      cursor++;
+    }
+    return -1;
+  }
+
+  private static boolean isNumberStart(String sql, int index) {
+    char value = sql.charAt(index);
+    if (Character.isDigit(value)) return true;
+    return value == '.'
+        && index + 1 < sql.length()
+        && Character.isDigit(sql.charAt(index + 1));
+  }
+
+  private static int skipNumber(String sql, int index) {
+    int cursor = index;
+    if (cursor + 1 < sql.length()
+        && sql.charAt(cursor) == '0'
+        && (sql.charAt(cursor + 1) == 'x' || sql.charAt(cursor + 1) == 'X')) {
+      cursor += 2;
+      while (cursor < sql.length()) {
+        char value = sql.charAt(cursor);
+        if (!isHexDigit(value) && value != '_') break;
+        cursor++;
+      }
+      return cursor;
+    }
+
+    boolean decimalPointSeen = false;
+    boolean exponentSeen = false;
+    while (cursor < sql.length()) {
+      char value = sql.charAt(cursor);
+      if (Character.isDigit(value) || value == '_') {
+        cursor++;
+        continue;
+      }
+      if (value == '.' && !decimalPointSeen && !exponentSeen) {
+        decimalPointSeen = true;
+        cursor++;
+        continue;
+      }
+      if ((value == 'e' || value == 'E') && !exponentSeen) {
+        exponentSeen = true;
+        cursor++;
+        if (cursor < sql.length() && (sql.charAt(cursor) == '+' || sql.charAt(cursor) == '-')) {
+          cursor++;
+        }
+        continue;
+      }
+      break;
+    }
+    return cursor;
+  }
+
+  private static boolean isHexDigit(char value) {
+    return Character.isDigit(value)
+        || (value >= 'a' && value <= 'f')
+        || (value >= 'A' && value <= 'F');
+  }
+}

--- a/yak-ops-core/src/test/java/io/yak/ops/core/execution/sql/SqlFingerprintTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/execution/sql/SqlFingerprintTest.java
@@ -1,0 +1,48 @@
+package io.yak.ops.core.execution.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SqlFingerprintTest {
+
+  @Test
+  void groupsEquivalentSqlShapesAcrossLiteralValuesAndComments() {
+    String left = "select * from users where id = 42 and name = 'Alice' -- comment";
+    String right = "SELECT * FROM users WHERE id=99 AND name='Bob'";
+
+    assertEquals(SqlFingerprint.sha256(left), SqlFingerprint.sha256(right));
+  }
+
+  @Test
+  void redactedPreviewDoesNotExposeCommonLiteralForms() {
+    String preview = SqlFingerprint.redactedPreview(
+        "select * from secret where token='my-token' and pin=123456 and note=\"private\"",
+        2048);
+
+    assertFalse(preview.contains("my-token"));
+    assertFalse(preview.contains("123456"));
+    assertFalse(preview.contains("private"));
+    assertTrue(preview.contains("?"));
+  }
+
+  @Test
+  void redactsPostgresDollarQuotedBodies() {
+    String preview = SqlFingerprint.redactedPreview(
+        "select $tag$patient-secret$tag$ as payload",
+        2048);
+
+    assertFalse(preview.contains("patient-secret"));
+    assertTrue(preview.contains("?"));
+  }
+
+  @Test
+  void keepsDifferentSqlStructuresDistinct() {
+    assertNotEquals(
+        SqlFingerprint.sha256("select id from users where id = 1"),
+        SqlFingerprint.sha256("delete from users where id = 1"));
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4 adds durable SQL execution observability on top of the Phase 1-3 runtime: terminal execution metadata is captured for both synchronous consumers (Dataset / Data Service) and tracked executions (SQL Task / future Console), persisted asynchronously, and exposed through protected history/detail/summary APIs.

The design deliberately treats observability as a side effect. Audit queue saturation, observer failures, or audit database write failures do **not** change the physical SQL execution outcome.

## Architecture

```text
Dataset / Data Service
        ↓
     execute()
        ↓
ObservableSqlExecutionRuntime (@Primary)
        ↓
DefaultSqlExecutionRuntime
        ↓
terminal synthetic snapshot (sql-sync-*)
        ↓
SqlExecutionObserver

SQL Task / future Console
        ↓
      start()
        ↓
ObservableSqlExecutionRuntime (@Primary)
        ↓
DefaultSqlExecutionRuntime
        ↓
original executionId reaches terminal state
        ↓
SqlExecutionObserver
```

Persistence path:

```text
Terminal SqlExecutionSnapshot
        ↓
map to metadata-only audit batch
        ↓
bounded async queue (2048)
        ↓
SqlExecutionAuditStore
        ↓
yak_ops_sql_execution
+ yak_ops_sql_statement_execution
```

## What changed

### 1. Observability contract and facade

- Added `SqlExecutionObserver` in `yak-ops-core`.
- Added `ObservableSqlExecutionRuntime` as the `@Primary` `SqlExecutionRuntime` facade.
- Kept `DefaultSqlExecutionRuntime` focused on physical execution/lifecycle/transactions from Phases 1-3.
- Synchronous `execute()` calls now receive synthetic `sql-sync-*` execution identities for audit persistence without changing the existing return contract.
- Tracked executions keep their original runtime `executionId` and are observed only after they reach a terminal state.
- Observer exceptions are caught and logged; they never turn successful SQL into failed SQL.
- SQL rejected by Phase 3 policy before datasource access is not recorded as a physical execution.

### 2. Optional operator context

`SqlExecutionContext` now supports an optional `operator` while preserving the existing two-argument constructor and `of(caller, reference)` factory.

Current callers may leave it null. This phase intentionally does not couple the core runtime to Web/Security internals; caller adapters can later supply an authenticated operator through `withOperator(...)` / the three-argument factory when a stable identity boundary is available.

### 3. Privacy-aware SQL fingerprinting

Added `SqlFingerprint`:

- removes comments
- normalizes keyword/token spacing and case
- replaces single-quoted literals with `?`
- replaces numeric literals with `?`
- redacts PostgreSQL dollar-quoted bodies
- conservatively redacts double-quoted content because dialects disagree on identifier vs string-literal semantics
- keeps backtick/bracket identifiers
- produces a SHA-256 fingerprint over the normalized SQL shape

The audit tables do **not** persist bind parameter values or result rows.

Example:

```sql
SELECT * FROM patient WHERE name = 'Alice' AND id = 123
```

is stored as a redacted preview shaped like:

```text
SELECT * FROM PATIENT WHERE NAME = ? AND ID = ?
```

### 4. Durable execution + statement audit schema

Added Flyway migration `V3__create_sql_execution_audit_tables.sql`:

- `yak_ops_sql_execution`
  - executionId
  - dataSourceId
  - caller / callerReference / optional operator
  - transactionMode
  - status
  - statement counts
  - returned/affected row aggregates
  - start / finish / duration
  - terminal error summary
- `yak_ops_sql_statement_execution`
  - statementId / order
  - statementType
  - SQL fingerprint
  - redacted SQL preview
  - status / resultType
  - returnedRows / affectedRows / truncated
  - timings
  - error summary

Indexes cover time, status, caller, datasource, duration, statement type, and SQL fingerprint discovery paths.

### 5. Best-effort asynchronous persistence

`PersistentSqlExecutionObserver` converts the terminal snapshot into a metadata-only batch **before** queueing it, so result rows are not retained in the audit queue.

- fixed 2-worker audit executor
- bounded queue of 2048 batches
- queue saturation logs and drops observability work rather than applying backpressure to SQL execution
- audit writes use a separate `opsDataSourceTransactionManager` transaction
- execution + statement rows are stored atomically per audit batch
- audit persistence failure is isolated from user SQL execution

This is operational observability / audit history, not a guarantee of regulatory-grade lossless event delivery.

### 6. History / detail / summary APIs

Added protected API prefix:

```text
/api/v1/sql-executions
```

with dedicated permission:

```text
resource:sql-execution:read
```

Endpoints:

```text
POST /api/v1/sql-executions/page
GET  /api/v1/sql-executions/{executionId}
POST /api/v1/sql-executions/summary
```

History filters include:

- executionId
- dataSourceId
- caller / callerReference
- operator
- status
- transactionMode
- statementType
- sqlFingerprint
- minimum duration (slow SQL)
- start time range

Summary includes:

- total executions
- succeeded / failed / cancelled / timed out
- success rate (0..1)
- average duration
- max duration
- P95 duration
- total returned rows
- total affected rows
- statement type distribution

P95 uses MySQL 8 window functions; the repository's default compose stack is MySQL 8.0.39.

## Security / data handling boundary

Phase 4 intentionally does **not** store:

- SQL bind parameter values
- query result rows
- raw literal-bearing SQL text

The detail API returns only the redacted SQL preview and fingerprint and uses a separate read permission rather than reusing datasource-read permission.

## Tests / validation

Added repository tests for:

- equivalent SQL shapes producing the same fingerprint across different literals/comments
- literal redaction including double quotes and PostgreSQL dollar quoting
- synchronous Dataset execution producing a terminal audit snapshot
- tracked SQL execution observation at terminal state
- observer failure isolation
- policy-rejected SQL not being misreported as a physical execution
- metadata mapping excluding sensitive result/literal values

Validation performed in this environment:

- Java 21 `javac` compiled the fingerprint implementation successfully.
- Executed a Java 21 fingerprint smoke test confirming equivalent query shapes share a fingerprint and single-quoted, numeric, and double-quoted literals are absent from the redacted preview.
- Verified the repository default compose database is MySQL 8.0.39, which supports the P95 window-function query.
- Final branch is one commit ahead of current `main` and zero commits behind.
- No GitHub commit status checks were reported before opening the PR.

Full Maven Wrapper execution could not be run here because the execution environment cannot resolve `github.com` to clone/materialize the repository locally. The repository unit tests are included for normal CI/local Maven execution.

## Intentionally not included in Phase 4

- frontend Ops Center / SQL history page
- audit retention / cleanup policy
- guaranteed/lossless event delivery (Kafka/outbox)
- OpenTelemetry / external metrics export
- automatic operator resolution from the security starter
- raw SQL or parameter/result persistence
- streaming execution events
- Statement Console UI

These can layer on top of the stable observer and persisted execution model without changing the SQL execution core.