### PR TITLE
fix: restore datasource SQL result factory compatibility

### DIFF
--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlResult.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlResult.java
@@ -28,6 +28,27 @@ public record DataSourceSqlResult(
     return new DataSourceSqlResult(false, List.of(), List.of(), affectedRows, false);
   }
 
+  /**
+   * Backward-compatible alias retained for datasource plugins compiled against the original SPI.
+   * New callers should use {@link #resultSet(List, List, boolean)}.
+   */
+  @Deprecated
+  public static DataSourceSqlResult query(
+      List<DataSourceSqlColumn> columns,
+      List<List<Object>> rows,
+      boolean truncated) {
+    return resultSet(columns, rows, truncated);
+  }
+
+  /**
+   * Backward-compatible alias retained for datasource plugins compiled against the original SPI.
+   * New callers should use {@link #updateCount(long)}.
+   */
+  @Deprecated
+  public static DataSourceSqlResult update(long affectedRows) {
+    return updateCount(affectedRows);
+  }
+
   private static List<List<Object>> immutableRows(List<List<Object>> values) {
     if (values == null || values.isEmpty()) return List.of();
     List<List<Object>> copied = new ArrayList<>(values.size());


### PR DESCRIPTION
## Summary

Fix the JDBC datasource module compilation regression caused by the Phase 1 `DataSourceSqlResult` factory rename.

`JdbcDataSourceSqlExecutor` still calls the original SPI factories:

```java
DataSourceSqlResult.update(...)
DataSourceSqlResult.query(...)
```

while the current datasource API exposes only:

```java
DataSourceSqlResult.updateCount(...)
DataSourceSqlResult.resultSet(...)
```

This causes the current compile error at `JdbcDataSourceSqlExecutor.java:216` and would expose the same issue on the result-set path after the first error is fixed.

## Fix

Restore `query(...)` and `update(...)` as deprecated source-compatibility aliases in the datasource plugin SPI:

```text
query(...)  -> resultSet(...)
update(...) -> updateCount(...)
```

The aliases contain no duplicate implementation logic; the current `resultSet` / `updateCount` factories remain the canonical API for new code.

## Why fix the SPI instead of only the JDBC implementation

`yak-ops-plugin-datasource-api` is a plugin SPI. Renaming/removing public factory methods caused a source compatibility break for existing datasource providers. The built-in JDBC provider is the first caller exposing it, but other providers or external plugins compiled from the earlier SPI can hit the same failure.

Keeping deprecated forwarding aliases provides a safe compatibility bridge while preserving the newer naming for future callers.

## Validation

- Branch is based on current `main` after Phase 4 merge.
- Final diff is one commit and one file; branch is one commit ahead and zero behind `main`.
- Java 21 `javac` smoke-tested a legacy caller using both `DataSourceSqlResult.update(1)` and `DataSourceSqlResult.query(...)`.
- The compiled smoke test executed successfully; only the expected deprecation warning is emitted.

No runtime SQL execution semantics are changed.