### PR TITLE
refactor: remove SQL execution compatibility APIs

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/QueryRevisionDatasetSourceAdapterTest.java
@@ -52,7 +52,7 @@ class QueryRevisionDatasetSourceAdapterTest {
         "checksum-v3");
     when(catalog.resolveRevision(11L, 71L)).thenReturn(new TaskAssetRevision(asset, revision));
     when(provider.open("9")).thenReturn(executor);
-    when(executor.execute(any())).thenReturn(DataSourceSqlResult.query(
+    when(executor.execute(any())).thenReturn(DataSourceSqlResult.resultSet(
         List.of(
             new DataSourceSqlColumn("region", "region", "VARCHAR", Types.VARCHAR, true),
             new DataSourceSqlColumn("amount", "amount", "DECIMAL", Types.DECIMAL, true)),

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
@@ -66,14 +66,6 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     this(executionProvider, new LexicalSqlStatementClassifier(), executionPolicy);
   }
 
-  /** Backward-compatible constructor used by existing tests and embedders. */
-  public DefaultSqlExecutionRuntime(DataSourceExecutionProvider executionProvider) {
-    this(
-        executionProvider,
-        new LexicalSqlStatementClassifier(),
-        new DefaultSqlExecutionPolicy());
-  }
-
   DefaultSqlExecutionRuntime(
       DataSourceExecutionProvider executionProvider,
       SqlStatementClassifier statementClassifier,

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
@@ -109,7 +109,7 @@ class DefaultSqlExecutionRuntimeTest {
       opened.incrementAndGet();
       return request -> DataSourceSqlResult.updateCount(1L);
     };
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime runtime = runtime(provider);
 
     SqlExecutionPolicyViolationException exception = assertThrows(
         SqlExecutionPolicyViolationException.class,
@@ -131,9 +131,9 @@ class DefaultSqlExecutionRuntimeTest {
     AtomicInteger opened = new AtomicInteger();
     DataSourceExecutionProvider provider = dataSourceId -> {
       opened.incrementAndGet();
-      return request -> DataSourceSqlResult.query(List.of(), List.of(), false);
+      return request -> DataSourceSqlResult.resultSet(List.of(), List.of(), false);
     };
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime runtime = runtime(provider);
     SqlExecutionPlan plan = new SqlExecutionPlan(
         "42",
         List.of(new SqlStatementRequest("""
@@ -161,7 +161,7 @@ class DefaultSqlExecutionRuntimeTest {
       opened.incrementAndGet();
       return request -> DataSourceSqlResult.updateCount(0L);
     };
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime runtime = runtime(provider);
 
     SqlExecutionPolicyViolationException exception = assertThrows(
         SqlExecutionPolicyViolationException.class,
@@ -181,13 +181,13 @@ class DefaultSqlExecutionRuntimeTest {
     DataSourceExecutionProvider provider = dataSourceId -> {
       int index = opened.getAndIncrement();
       return request -> index == 0
-          ? DataSourceSqlResult.query(
+          ? DataSourceSqlResult.resultSet(
               List.of(new DataSourceSqlColumn("VALUE", "value", "INTEGER", Types.INTEGER, true)),
               List.of(List.of(1)),
               false)
           : DataSourceSqlResult.updateCount(2L);
     };
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime runtime = runtime(provider);
     SqlExecutionPlan plan = new SqlExecutionPlan(
         "42",
         List.of(
@@ -221,7 +221,7 @@ class DefaultSqlExecutionRuntimeTest {
       opened.incrementAndGet();
       return executor;
     };
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime runtime = runtime(provider);
     SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionPlan(
         "42",
         List.of(
@@ -244,7 +244,7 @@ class DefaultSqlExecutionRuntimeTest {
   @Test
   void rollsBackSingleTransactionAndSkipsRemainingStatementOnFailure() {
     TransactionExecutor executor = new TransactionExecutor(2);
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(dataSourceId -> executor);
+    DefaultSqlExecutionRuntime runtime = runtime(dataSourceId -> executor);
     SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionPlan(
         "42",
         List.of(
@@ -272,7 +272,7 @@ class DefaultSqlExecutionRuntimeTest {
       executions.incrementAndGet();
       return DataSourceSqlResult.updateCount(1L);
     };
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(dataSourceId -> executor);
+    DefaultSqlExecutionRuntime runtime = runtime(dataSourceId -> executor);
     SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionPlan(
         "42",
         List.of(new SqlStatementRequest("update demo set enabled = 1", 10, 30)),
@@ -292,7 +292,7 @@ class DefaultSqlExecutionRuntimeTest {
     AtomicInteger opened = new AtomicInteger();
     DataSourceExecutionProvider provider = dataSourceId ->
         opened.getAndIncrement() == 0 ? blocking : request -> DataSourceSqlResult.updateCount(1L);
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime runtime = runtime(provider);
     SqlExecutionSnapshot started = runtime.start(new SqlExecutionPlan(
         "42",
         List.of(
@@ -318,7 +318,7 @@ class DefaultSqlExecutionRuntimeTest {
     DataSourceExecutionProvider provider = dataSourceId -> request -> {
       throw new IllegalStateException(new SQLTimeoutException("query timeout"));
     };
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime runtime = runtime(provider);
     SqlExecutionSnapshot completed = runtime.await(runtime.start(new SqlExecutionRequest(
         "42",
         "select slow_query",
@@ -338,7 +338,11 @@ class DefaultSqlExecutionRuntimeTest {
       executor.request = new CapturedRequest(dataSourceId, List.of());
       return executor;
     };
-    return new DefaultSqlExecutionRuntime(provider);
+    return runtime(provider);
+  }
+
+  private static DefaultSqlExecutionRuntime runtime(DataSourceExecutionProvider provider) {
+    return new DefaultSqlExecutionRuntime(provider, new DefaultSqlExecutionPolicy());
   }
 
   private record CapturedRequest(String dataSourceId, List<Object> parameters) {}
@@ -433,7 +437,7 @@ class DefaultSqlExecutionRuntimeTest {
         Thread.currentThread().interrupt();
       }
       if (cancelled.get()) throw new IllegalStateException("SQL execution cancelled");
-      return DataSourceSqlResult.query(List.of(), List.of(), false);
+      return DataSourceSqlResult.resultSet(List.of(), List.of(), false);
     }
 
     @Override

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionTransactionCancellationTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionTransactionCancellationTest.java
@@ -26,7 +26,9 @@ class DefaultSqlExecutionTransactionCancellationTest {
   @Test
   void rollsBackSingleTransactionWhenActiveStatementIsCancelled() throws Exception {
     BlockingTransactionExecutor executor = new BlockingTransactionExecutor();
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(dataSourceId -> executor);
+    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(
+        dataSourceId -> executor,
+        new DefaultSqlExecutionPolicy());
     SqlExecutionSnapshot started = runtime.start(new SqlExecutionPlan(
         "42",
         List.of(

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
@@ -117,9 +117,10 @@ class ObservableSqlExecutionRuntimeTest {
   private static RuntimePair runtime(SqlExecutionObserver observer) {
     DataSourceExecutionProvider provider = dataSourceId -> request ->
         request.sql().trim().toLowerCase().startsWith("select")
-            ? DataSourceSqlResult.query(List.of(), List.of(), false)
+            ? DataSourceSqlResult.resultSet(List.of(), List.of(), false)
             : DataSourceSqlResult.updateCount(1L);
-    DefaultSqlExecutionRuntime delegate = new DefaultSqlExecutionRuntime(provider);
+    DefaultSqlExecutionRuntime delegate =
+        new DefaultSqlExecutionRuntime(provider, new DefaultSqlExecutionPolicy());
     return new RuntimePair(delegate, new ObservableSqlExecutionRuntime(delegate, List.of(observer)));
   }
 

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionContext.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionContext.java
@@ -14,11 +14,6 @@ public record SqlExecutionContext(
     operator = normalize(operator);
   }
 
-  /** Backward-compatible constructor for callers that do not yet resolve an operator. */
-  public SqlExecutionContext(SqlExecutionCaller caller, String callerReference) {
-    this(caller, callerReference, null);
-  }
-
   public static SqlExecutionContext of(SqlExecutionCaller caller, String callerReference) {
     return new SqlExecutionContext(caller, callerReference, null);
   }

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPlan.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionPlan.java
@@ -33,7 +33,7 @@ public record SqlExecutionPlan(
         : transactionMode;
   }
 
-  /** Backward-compatible constructor; existing callers remain auto-commit by default. */
+  /** Convenience overload for the common auto-commit execution mode. */
   public SqlExecutionPlan(
       String dataSourceId,
       List<SqlStatementRequest> statements,

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRuntime.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionRuntime.java
@@ -18,22 +18,14 @@ public interface SqlExecutionRuntime {
   }
 
   /** Start one tracked execution whose statement boundaries are supplied explicitly by the caller. */
-  default SqlExecutionSnapshot start(SqlExecutionPlan plan) {
-    throw new UnsupportedOperationException("Tracked SQL execution is not supported");
-  }
+  SqlExecutionSnapshot start(SqlExecutionPlan plan);
 
   /** Find the latest immutable snapshot for a tracked execution. */
-  default Optional<SqlExecutionSnapshot> find(String executionId) {
-    return Optional.empty();
-  }
+  Optional<SqlExecutionSnapshot> find(String executionId);
 
   /** Wait until a tracked execution reaches a terminal state. */
-  default SqlExecutionSnapshot await(String executionId) {
-    throw new UnsupportedOperationException("Tracked SQL execution is not supported");
-  }
+  SqlExecutionSnapshot await(String executionId);
 
   /** Request cancellation. Returns false when the execution is absent or already terminal. */
-  default boolean cancel(String executionId) {
-    return false;
-  }
+  boolean cancel(String executionId);
 }

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionSnapshot.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlExecutionSnapshot.java
@@ -32,28 +32,6 @@ public record SqlExecutionSnapshot(
     statements = statements == null ? List.of() : List.copyOf(statements);
   }
 
-  /** Backward-compatible constructor; historical callers remain auto-commit by default. */
-  public SqlExecutionSnapshot(
-      String executionId,
-      SqlExecutionStatus status,
-      String dataSourceId,
-      SqlExecutionContext context,
-      List<SqlStatementSnapshot> statements,
-      Instant startedAt,
-      Instant finishedAt,
-      String errorMessage) {
-    this(
-        executionId,
-        status,
-        dataSourceId,
-        context,
-        SqlTransactionMode.AUTO_COMMIT,
-        statements,
-        startedAt,
-        finishedAt,
-        errorMessage);
-  }
-
   public boolean terminal() {
     return status.terminal();
   }

--- a/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementSnapshot.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/SqlStatementSnapshot.java
@@ -28,28 +28,6 @@ public record SqlStatementSnapshot(
     status = Objects.requireNonNull(status, "status");
   }
 
-  /** Backward-compatible constructor for callers created before statement semantics were exposed. */
-  public SqlStatementSnapshot(
-      String statementId,
-      int index,
-      String sql,
-      SqlStatementStatus status,
-      SqlExecutionResult result,
-      String errorMessage,
-      Instant startedAt,
-      Instant finishedAt) {
-    this(
-        statementId,
-        index,
-        sql,
-        SqlStatementType.OTHER,
-        status,
-        result,
-        errorMessage,
-        startedAt,
-        finishedAt);
-  }
-
   public boolean terminal() {
     return status.terminal();
   }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlResult.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/execution/DataSourceSqlResult.java
@@ -28,27 +28,6 @@ public record DataSourceSqlResult(
     return new DataSourceSqlResult(false, List.of(), List.of(), affectedRows, false);
   }
 
-  /**
-   * Backward-compatible alias retained for datasource plugins compiled against the original SPI.
-   * New callers should use {@link #resultSet(List, List, boolean)}.
-   */
-  @Deprecated
-  public static DataSourceSqlResult query(
-      List<DataSourceSqlColumn> columns,
-      List<List<Object>> rows,
-      boolean truncated) {
-    return resultSet(columns, rows, truncated);
-  }
-
-  /**
-   * Backward-compatible alias retained for datasource plugins compiled against the original SPI.
-   * New callers should use {@link #updateCount(long)}.
-   */
-  @Deprecated
-  public static DataSourceSqlResult update(long affectedRows) {
-    return updateCount(affectedRows);
-  }
-
   private static List<List<Object>> immutableRows(List<List<Object>> values) {
     if (values == null || values.isEmpty()) return List.of();
     List<List<Object>> copied = new ArrayList<>(values.size());

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcDataSourceSqlExecutor.java
@@ -213,7 +213,7 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
   private DataSourceSqlResult readStatementResult(
       Statement statement, boolean hasResultSet, int maxRows) throws Exception {
     if (!hasResultSet) {
-      return DataSourceSqlResult.update(statement.getUpdateCount());
+      return DataSourceSqlResult.updateCount(statement.getUpdateCount());
     }
     try (ResultSet resultSet = statement.getResultSet()) {
       return readResultSet(resultSet, maxRows);
@@ -282,7 +282,7 @@ public final class JdbcDataSourceSqlExecutor implements DataSourceSqlExecutor {
       }
       rows.add(row);
     }
-    return DataSourceSqlResult.query(columns, rows, truncated);
+    return DataSourceSqlResult.resultSet(columns, rows, truncated);
   }
 
   private List<DataSourceSqlColumn> columns(ResultSetMetaData metadata) throws Exception {

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskPluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskPluginTest.java
@@ -16,6 +16,7 @@ import io.yak.ops.core.execution.sql.SqlExecutionStatus;
 import io.yak.ops.core.execution.sql.SqlExecutionTiming;
 import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
 import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionResult;
 import io.yak.ops.plugin.task.api.TaskExecutor;
@@ -56,6 +57,7 @@ class SqlTaskPluginTest {
                 "sql-test:stmt:1",
                 0,
                 plan.statements().get(0).sql(),
+                SqlStatementType.SELECT,
                 SqlStatementStatus.SUCCEEDED,
                 new SqlExecutionResult(
                     SqlExecutionResultType.RESULT_SET,
@@ -73,6 +75,7 @@ class SqlTaskPluginTest {
                 SqlExecutionStatus.SUCCEEDED,
                 plan.dataSourceId(),
                 plan.context(),
+                plan.transactionMode(),
                 List.of(statement),
                 Instant.now(),
                 Instant.now(),
@@ -89,8 +92,21 @@ class SqlTaskPluginTest {
           }
 
           @Override
+          public Optional<SqlExecutionSnapshot> find(String executionId) {
+            SqlExecutionSnapshot snapshot = completed.get();
+            return snapshot != null && snapshot.executionId().equals(executionId)
+                ? Optional.of(snapshot)
+                : Optional.empty();
+          }
+
+          @Override
           public SqlExecutionSnapshot await(String executionId) {
             return completed.get();
+          }
+
+          @Override
+          public boolean cancel(String executionId) {
+            return false;
           }
         };
 


### PR DESCRIPTION
## Summary

This PR removes first-version compatibility layers from the unified SQL execution path and upgrades Yak Ops internal callers to the current API model.

### What changed

- remove deprecated `DataSourceSqlResult.query(...)` / `update(...)` aliases
  - keep only `resultSet(...)` and `updateCount(...)`
  - migrate JDBC execution and Dataset/runtime tests to the new factory names
- remove compatibility constructors from SQL execution models
  - `SqlExecutionContext`
  - `SqlExecutionSnapshot`
  - `SqlStatementSnapshot`
- make tracked lifecycle operations part of the required `SqlExecutionRuntime` contract
  - `start(SqlExecutionPlan)`
  - `find(...)`
  - `await(...)`
  - `cancel(...)`
  - keep `start(SqlExecutionRequest)` only as the normal single-statement convenience method
- remove the compatibility `DefaultSqlExecutionRuntime(DataSourceExecutionProvider)` constructor
  - runtime construction now explicitly supplies `SqlExecutionPolicy`
- update SQL Task fake runtime/tests to implement the complete lifecycle contract and use the current snapshot model
- keep the 3-argument `SqlExecutionPlan` constructor as an intentional AUTO_COMMIT convenience overload rather than a compatibility API

## Why

Yak Ops is still on the first version of this SQL execution architecture, so carrying compatibility bridges from Phase 1/2/3 only creates duplicate API surfaces and allows incomplete implementations to compile. This change makes the current SQL execution model the single contract before more callers and plugins depend on it.

## Validation

- reviewed the final diff against current `main`
- branch is based directly on current `main` and squashed to one commit
- verified JDBC/internal test call sites in the touched SQL execution path use the current result/runtime APIs
- GitHub currently reports no commit status checks for the branch
- full Maven test suite was not run because Maven is not installed in the available execution environment (`mvn: command not found`)

## Scope

13 files changed. No frontend, database migration, or unrelated business-domain changes.