### PR TITLE
fix: make observable SQL runtime Spring-constructible

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntime.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -45,6 +46,7 @@ public final class ObservableSqlExecutionRuntime implements SqlExecutionRuntime 
   private final LexicalSqlStatementClassifier classifier = new LexicalSqlStatementClassifier();
   private final ExecutorService tracker = Executors.newVirtualThreadPerTaskExecutor();
 
+  @Autowired
   public ObservableSqlExecutionRuntime(
       DefaultSqlExecutionRuntime delegate,
       ObjectProvider<SqlExecutionObserver> observers) {

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
@@ -24,8 +24,27 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 class ObservableSqlExecutionRuntimeTest {
+
+  @Test
+  void springUsesExplicitInjectionConstructorWhenTestConstructorAlsoExists() {
+    DataSourceExecutionProvider provider = dataSourceId -> request ->
+        DataSourceSqlResult.resultSet(List.of(), List.of(), false);
+    DefaultSqlExecutionRuntime delegate =
+        new DefaultSqlExecutionRuntime(provider, new DefaultSqlExecutionPolicy());
+
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+      context.getBeanFactory().registerSingleton("defaultSqlExecutionRuntime", delegate);
+      context.registerBean(ObservableSqlExecutionRuntime.class);
+      context.refresh();
+
+      assertTrue(context.getBean(ObservableSqlExecutionRuntime.class) instanceof SqlExecutionRuntime);
+    } finally {
+      delegate.shutdown();
+    }
+  }
 
   @Test
   void observesSynchronousDatasetExecution() {


### PR DESCRIPTION
## Summary

Fix application startup failure when Spring creates `ObservableSqlExecutionRuntime`.

## Root cause

`ObservableSqlExecutionRuntime` has two constructors:

- the production constructor: `(DefaultSqlExecutionRuntime, ObjectProvider<SqlExecutionObserver>)`
- a package-private test constructor: `(DefaultSqlExecutionRuntime, List<SqlExecutionObserver>)`

With multiple constructors and no explicit injection annotation, Spring cannot uniquely select the production constructor and falls back to ordinary instantiation, eventually attempting a non-existent no-arg constructor. This matches the startup failure:

`No default constructor found` / `NoSuchMethodException: ObservableSqlExecutionRuntime.<init>()`.

## What changed

- mark the production `ObservableSqlExecutionRuntime` constructor with `@Autowired`
- keep the package-private test constructor unchanged
- add a focused Spring `AnnotationConfigApplicationContext` regression test that creates the runtime through Spring with the test constructor still present

## Why this approach

Do not add a no-arg constructor and do not remove the useful test constructor. The correct boundary is to make the Spring injection constructor explicit so production construction is deterministic while tests retain their lightweight entry point.

## Validation

- final branch is based on current `main`
- squashed to one commit
- 2 files changed
- ahead 1 / behind 0
- regression test exercises actual Spring constructor resolution rather than only reflecting on annotations

Full Maven tests were not run in the available execution environment.