### PR TITLE
refactor(ui): simplify login form layout

### DIFF
--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -6,7 +6,6 @@ import { App, Button, Form, Input } from "antd";
 import { useForm } from "antd/es/form/Form";
 import { useState } from "react";
 import { flushSync } from "react-dom";
-import GoogleLoginButton from "./components/GoogleLoginButton";
 
 export default function LoginPanel() {
   const [loading, setLoading] = useState(false);
@@ -68,115 +67,63 @@ export default function LoginPanel() {
     }
   };
 
-  const handleGoogleSuccess = async () => {
-    const userInfo = await fetchUserInfo();
-
-    if (!userInfo) {
-      setLoading(false);
-      return;
-    }
-
-    redirectAfterLogin();
-  };
-
   return (
-    <div className="w-full">
-      <div className="rounded-[26px] border border-[#e4e4e1] bg-white p-5 shadow-[0_12px_40px_rgba(15,23,42,0.035)] sm:p-6">
-        <GoogleLoginButton
-          className="!h-11 !rounded-xl !border-[#dededb] !bg-white !font-medium !text-[#1b1b1b] !shadow-none hover:!border-[#bdbdb8] hover:!bg-[#fafafa] hover:!text-[#1b1b1b]"
+    <div className="w-full rounded-[24px] border border-[#e4e4e1] bg-white p-5 shadow-[0_12px_36px_rgba(15,23,42,0.035)] sm:p-6">
+      <Form
+        layout="vertical"
+        form={form}
+        requiredMark={false}
+        onFinish={handleAccountLogin}
+      >
+        <Form.Item
+          className="!mb-4"
+          label={
+            <span className="text-[13px] font-medium text-[#333]">
+              Username
+            </span>
+          }
+          name="userName"
+          rules={[{ required: true, message: "请输入用户名" }]}
+        >
+          <Input
+            className="!h-11 !rounded-xl !border-[#dededb] !bg-white !px-3.5 !text-[15px] !shadow-none placeholder:!text-[#aaa] hover:!border-[#bdbdb8] focus:!border-[#171717]"
+            placeholder="Enter your username"
+            autoComplete="username"
+          />
+        </Form.Item>
+
+        <Form.Item
+          className="!mb-5"
+          label={
+            <span className="text-[13px] font-medium text-[#333]">
+              Password
+            </span>
+          }
+          name="userPassword"
+          rules={[
+            {
+              required: true,
+              message: "Please enter your password",
+            },
+          ]}
+        >
+          <Input.Password
+            className="!h-11 !rounded-xl !border-[#dededb] !bg-white !px-3.5 !shadow-none hover:!border-[#bdbdb8] focus-within:!border-[#171717] [&>input.ant-input]:!bg-white [&>input.ant-input]:!text-[15px]"
+            placeholder="Enter your password"
+            autoComplete="current-password"
+          />
+        </Form.Item>
+
+        <Button
+          block
+          type="primary"
+          htmlType="submit"
           loading={loading}
-          onStart={() => setLoading(true)}
-          onSuccess={handleGoogleSuccess}
-          onError={() => setLoading(false)}
-        />
-
-        <div className="my-5 flex items-center gap-3" aria-hidden="true">
-          <span className="h-px flex-1 bg-[#ececea]" />
-          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-[#8a8a86]">
-            or
-          </span>
-          <span className="h-px flex-1 bg-[#ececea]" />
-        </div>
-
-        <Form
-          layout="vertical"
-          form={form}
-          requiredMark={false}
-          onFinish={handleAccountLogin}
+          className="!h-11 !rounded-xl !border-[#171717] !bg-[#171717] !font-medium !text-white !shadow-none hover:!border-[#292929] hover:!bg-[#292929]"
         >
-          <Form.Item
-            className="!mb-4"
-            label={
-              <span className="text-[13px] font-medium text-[#333]">
-                Username
-              </span>
-            }
-            name="userName"
-            rules={[{ required: true, message: "请输入用户名" }]}
-          >
-            <Input
-              className="!h-11 !rounded-xl !border-[#dededb] !bg-white !px-3.5 !text-[15px] !shadow-none placeholder:!text-[#aaa] hover:!border-[#bdbdb8] focus:!border-[#171717]"
-              placeholder="Enter your username"
-              autoComplete="username"
-            />
-          </Form.Item>
-
-          <Form.Item
-            className="!mb-2.5"
-            label={
-              <span className="text-[13px] font-medium text-[#333]">
-                Password
-              </span>
-            }
-            name="userPassword"
-            rules={[
-              {
-                required: true,
-                message: "Please enter your password",
-              },
-            ]}
-          >
-            <Input.Password
-              className="!h-11 !rounded-xl !border-[#dededb] !bg-white !px-3.5 !shadow-none hover:!border-[#bdbdb8] focus-within:!border-[#171717] [&>input.ant-input]:!bg-white [&>input.ant-input]:!text-[15px]"
-              placeholder="Enter your password"
-              autoComplete="current-password"
-            />
-          </Form.Item>
-
-          <div className="mb-5 flex justify-end">
-            <button
-              type="button"
-              className="border-0 bg-transparent p-0 text-[13px] text-[#666] transition-colors hover:text-[#171717]"
-            >
-              Forgot password?
-            </button>
-          </div>
-
-          <Button
-            block
-            type="primary"
-            htmlType="submit"
-            loading={loading}
-            className="!h-11 !rounded-xl !border-[#171717] !bg-[#171717] !font-medium !text-white !shadow-none hover:!border-[#292929] hover:!bg-[#292929]"
-          >
-            Log in
-          </Button>
-        </Form>
-
-        <p className="mb-0 mt-4 text-center text-[11px] leading-5 text-[#92928d]">
-          By continuing, you agree to use Yak Ops according to your organization&apos;s access policy.
-        </p>
-      </div>
-
-      <div className="mt-5 text-center text-[13px] text-[#73736f]">
-        Don&apos;t have an account?{" "}
-        <button
-          type="button"
-          className="border-0 bg-transparent p-0 font-semibold text-[#171717] hover:underline"
-        >
-          Sign up
-        </button>
-      </div>
+          Log in
+        </Button>
+      </Form>
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/login/index.tsx
+++ b/yak-ops-ui/src/pages/login/index.tsx
@@ -8,11 +8,14 @@ const LOGIN_VIDEO_URL =
 export default function LoginPage() {
   return (
     <main className="h-screen overflow-y-auto bg-[#fbfbfa] text-[#171717]">
-      <div className="mx-auto flex min-h-screen w-full max-w-[1540px] flex-col px-6 py-6 sm:px-10 lg:px-12 lg:py-10 xl:px-16">
+      <div className="mx-auto flex min-h-screen w-full max-w-[1540px] flex-col px-6 py-4 sm:px-10 lg:px-12 lg:pb-6 lg:pt-5 xl:px-16">
         <header className="flex h-10 shrink-0 items-center">
           <div className="inline-flex items-center gap-2.5">
             <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-[#fff0f3]">
-              <Sparkles className="h-[18px] w-[18px] text-[#fe2c55]" strokeWidth={2.2} />
+              <Sparkles
+                className="h-[18px] w-[18px] text-[#fe2c55]"
+                strokeWidth={2.2}
+              />
             </span>
             <span className="text-[21px] font-semibold tracking-[-0.03em] text-[#171717]">
               Yak Ops
@@ -20,10 +23,10 @@ export default function LoginPage() {
           </div>
         </header>
 
-        <div className="grid flex-1 grid-cols-1 gap-10 pt-8 lg:grid-cols-[minmax(0,0.88fr)_minmax(560px,1.12fr)] lg:items-center lg:gap-14 lg:pt-0 xl:gap-20">
-          <section className="flex min-w-0 items-center justify-center py-8 lg:py-12">
-            <div className="w-full max-w-[500px]">
-              <div className="mb-8 text-center sm:mb-9">
+        <div className="grid flex-1 grid-cols-1 gap-10 pt-6 lg:grid-cols-[minmax(0,0.88fr)_minmax(560px,1.12fr)] lg:items-center lg:gap-14 lg:pt-0 xl:gap-20">
+          <section className="flex min-w-0 items-center justify-center py-7 lg:py-10">
+            <div className="w-full max-w-[520px]">
+              <div className="mb-8 text-center">
                 <h1 className="m-0 text-[42px] font-normal leading-[1.02] tracking-[-0.045em] text-[#171717] sm:text-[54px] lg:text-[58px] [font-family:Georgia,'Times_New_Roman',serif]">
                   Operate what&apos;s next
                 </h1>
@@ -32,12 +35,14 @@ export default function LoginPage() {
                 </p>
               </div>
 
-              <LoginPanel />
+              <div className="mx-auto w-full max-w-[390px]">
+                <LoginPanel />
+              </div>
             </div>
           </section>
 
           <aside className="hidden min-w-0 justify-end lg:flex">
-            <div className="relative h-[min(760px,calc(100vh-128px))] min-h-[600px] w-full max-w-[690px] overflow-hidden rounded-[24px] bg-[#ecece9]">
+            <div className="relative h-[min(760px,calc(100vh-96px))] min-h-[600px] w-full max-w-[690px] overflow-hidden rounded-[24px] bg-[#ecece9]">
               <video
                 className="h-full w-full object-cover"
                 autoPlay


### PR DESCRIPTION
## Summary
- refine the Tailwind login page based on the latest annotated screenshot
- move the Yak Ops brand block slightly closer to the top edge
- narrow the left-side login form to a more compact width
- keep only username, password, and the primary login action
- remove Google login, OR divider, forgot-password link, access-policy copy, and sign-up copy
- preserve the existing account login, current-user refresh, and safe `returnTo` redirect flow

## Changed files
- `yak-ops-ui/src/pages/login/index.tsx`
- `yak-ops-ui/src/pages/login/LoginPanel.tsx`

## Notes
- the right-side reference video URL remains temporary and can be replaced later
- local build execution is not available in this tool environment, so CI/build verification is still recommended before merge