### PR TITLE
feat(ui): apply Yak Ops font globally

### DIFF
--- a/yak-ops-ui/config/config.ts
+++ b/yak-ops-ui/config/config.ts
@@ -136,7 +136,7 @@ antd: {
         colorInfo: BRAND_COLOR,
         colorLink: BRAND_COLOR,
 
-        fontFamily: 'AlibabaSans, sans-serif',
+        fontFamily: 'YakOps, Inter, "PingFang SC", "Microsoft YaHei", sans-serif',
       },
     },
   },

--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -1,12 +1,18 @@
 @font-face {
+  font-family: 'YakOps';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('@/assets/yak-ops.woff2') format('woff2');
+}
+
+@font-face {
   font-family: st-web;
   font-style: normal;
   font-weight: 400;
   font-display: swap;
   src: url("@/assets/web.woff2") format("woff2");
 }
-
-
 
 html,
 body,
@@ -15,7 +21,7 @@ body,
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: Inter, sans-serif, st-web;
+  font-family: 'YakOps', Inter, 'PingFang SC', 'Microsoft YaHei', sans-serif;
 }
 
 .st-web-font {

--- a/yak-ops-ui/src/pages/login/index.tsx
+++ b/yak-ops-ui/src/pages/login/index.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
           <section className="flex min-w-0 items-center justify-center py-7 lg:py-10">
             <div className="w-full max-w-[520px]">
               <div className="mb-8 text-center">
-                <h1 className="m-0 text-[42px] font-normal leading-[1.02] tracking-[-0.045em] text-[#171717] sm:text-[54px] lg:text-[58px] [font-family:Georgia,'Times_New_Roman',serif]">
+                <h1 className="m-0 text-[42px] font-normal leading-[1.02] tracking-[-0.045em] text-[#171717] sm:text-[54px] lg:text-[58px]">
                   Operate what&apos;s next
                 </h1>
                 <p className="mt-4 text-[15px] leading-6 text-[#555] sm:text-base">


### PR DESCRIPTION
## Summary
- register `src/assets/yak-ops.woff2` as the `YakOps` web font in `src/global.less`
- make `YakOps` the default application font with sensible system fallbacks
- align Ant Design's global `fontFamily` token with the same font stack so form controls, tables, menus, buttons, and other AntD components inherit the brand font consistently
- remove the login heading's explicit Georgia/Times override so the login page also follows the global Yak Ops typography
- keep the existing `st-web` font registration and utility class intact for any explicit legacy usage

## Changed files
- `yak-ops-ui/src/global.less`
- `yak-ops-ui/config/config.ts`
- `yak-ops-ui/src/pages/login/index.tsx`

## Notes
- `yak-ops.woff2` already exists on `main`; this PR only wires it into the global typography stack
- code/editor-specific fonts are not overridden with a blanket `* { font-family: ... }`, so Monaco/code surfaces can continue to use their own typography
- local build execution is not available in this tool environment, so CI/build verification is recommended before merge