### PR TITLE
refactor(ui): use local login hero video

### DIFF
--- a/yak-ops-ui/src/pages/login/index.tsx
+++ b/yak-ops-ui/src/pages/login/index.tsx
@@ -1,9 +1,6 @@
+import loginHeroVideo from "@/assets/video/login-hero.mp4";
 import { Sparkles } from "lucide-react";
 import LoginPanel from "./LoginPanel";
-
-// Temporary demo media from the reference page. Replace with a Yak Ops-owned asset before production.
-const LOGIN_VIDEO_URL =
-  "https://claude.ai/images/homepage/claude-code-promo-loop@2x.mp4";
 
 export default function LoginPage() {
   return (
@@ -23,7 +20,7 @@ export default function LoginPage() {
           </div>
         </header>
 
-        <div className="grid flex-1 grid-cols-1 gap-10 pt-6 lg:grid-cols-[minmax(0,0.88fr)_minmax(560px,1.12fr)] lg:items-center lg:gap-14 lg:pt-0 xl:gap-20">
+        <div className="grid flex-1 grid-cols-1 gap-10 pt-6 lg:grid-cols-[minmax(0,0.92fr)_minmax(500px,1.08fr)] lg:items-center lg:gap-12 lg:pt-0 xl:gap-16">
           <section className="flex min-w-0 items-center justify-center py-7 lg:py-10">
             <div className="w-full max-w-[520px]">
               <div className="mb-8 text-center">
@@ -41,19 +38,18 @@ export default function LoginPage() {
             </div>
           </section>
 
-          <aside className="hidden min-w-0 justify-end lg:flex">
-            <div className="relative h-[min(760px,calc(100vh-96px))] min-h-[600px] w-full max-w-[690px] overflow-hidden rounded-[24px] bg-[#ecece9]">
+          <aside className="hidden min-w-0 items-center justify-center lg:flex xl:justify-end">
+            <div className="relative h-[clamp(560px,calc(100vh-132px),734px)] aspect-[4/5] flex-none overflow-hidden rounded-[22px] bg-[#ecece9]">
               <video
                 className="h-full w-full object-cover"
+                src={loginHeroVideo}
                 autoPlay
                 loop
                 muted
                 playsInline
                 preload="metadata"
                 aria-label="Yak Ops login visual"
-              >
-                <source src={LOGIN_VIDEO_URL} type="video/mp4" />
-              </video>
+              />
               <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/10 via-transparent to-white/5" />
             </div>
           </aside>


### PR DESCRIPTION
## Summary
- replace the temporary external Claude video URL with the checked-in `src/assets/video/login-hero.mp4`
- keep the login video fully local to Yak Ops so the page no longer depends on an external media host
- refine the desktop hero panel to a stable 4:5 portrait ratio, matching the reference layout more closely
- cap the panel at roughly 587×734 on large screens and let its height shrink with shorter viewports
- rebalance the desktop grid/gap so the right visual no longer feels oversized relative to the login content

## Changed files
- `yak-ops-ui/src/pages/login/index.tsx`

## Notes
- the existing `login-hero.mp4` already lives on `main` under `yak-ops-ui/src/assets/video/`
- the video remains hidden below the desktop breakpoint, preserving the current responsive behavior
- local build execution is not available in this tool environment, so CI/build verification is recommended before merge