### PR TITLE
feat(data-service): align node query UX with SQL editor

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
@@ -18,6 +18,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,7 +45,7 @@ public class DevelopmentDataServiceNodeController {
     return Result.success(service.get(nodeId));
   }
 
-  @Operation(summary = "基于当前数据源和查询 SQL 预览请求参数与响应字段 Contract")
+  @Operation(summary = "执行当前查询 SQL，并返回结果数据、请求参数与响应字段")
   @PostMapping("/{nodeId}/data-service/preview")
   public Result<PreviewResult> preview(
       @PathVariable("nodeId") long nodeId,
@@ -53,7 +54,9 @@ public class DevelopmentDataServiceNodeController {
         nodeId,
         request.dataSourceId(),
         request.sql(),
-        request.timeoutSeconds()));
+        request.maxRows(),
+        request.timeoutSeconds(),
+        request.parameterValues()));
   }
 
   @Operation(summary = "保存独立 Data Service Node 草稿")
@@ -82,6 +85,8 @@ public class DevelopmentDataServiceNodeController {
             request.maxRows(),
             request.timeoutSeconds(),
             request.description(),
+            request.paginationEnabled(),
+            request.autoParseParameters(),
             request.baseRevision())));
   }
 
@@ -121,7 +126,9 @@ public class DevelopmentDataServiceNodeController {
   public record PreviewRequest(
       @NotNull @Min(1) Long dataSourceId,
       @NotBlank @Size(max = 1_000_000) String sql,
-      @Min(1) @Max(3_600) Integer timeoutSeconds) {}
+      @Min(1) @Max(10_000) Integer maxRows,
+      @Min(1) @Max(3_600) Integer timeoutSeconds,
+      Map<String, Object> parameterValues) {}
 
   public record SaveDraftRequest(
       @NotNull @Min(1) Long dataSourceId,
@@ -134,6 +141,8 @@ public class DevelopmentDataServiceNodeController {
       @Min(1) @Max(10_000) Integer maxRows,
       @Min(1) @Max(3_600) Integer timeoutSeconds,
       @Size(max = 2_000) String description,
+      Boolean paginationEnabled,
+      Boolean autoParseParameters,
       @Min(0) Long baseRevision) {}
 
   public record ParameterRequest(

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentDataServiceDefinition.java
@@ -18,11 +18,48 @@ public record DevelopmentDataServiceDefinition(
     int timeoutSeconds,
     String description,
     @JsonSerialize(using = ToStringSerializer.class) long dataSourceId,
-    String sql) {
+    String sql,
+    boolean paginationEnabled,
+    Boolean autoParseParameters) {
 
   public DevelopmentDataServiceDefinition {
     parameters = parameters == null ? List.of() : List.copyOf(parameters);
     responseFields = responseFields == null ? List.of() : List.copyOf(responseFields);
+  }
+
+  /**
+   * Backward-compatible constructor for standalone revisions created before query options were added.
+   */
+  public DevelopmentDataServiceDefinition(
+      long sourceTaskAssetId,
+      long sourceTaskRevisionId,
+      int sourceTaskRevisionNo,
+      String serviceName,
+      String path,
+      String method,
+      List<ParameterContract> parameters,
+      List<ResponseFieldContract> responseFields,
+      int maxRows,
+      int timeoutSeconds,
+      String description,
+      long dataSourceId,
+      String sql) {
+    this(
+        sourceTaskAssetId,
+        sourceTaskRevisionId,
+        sourceTaskRevisionNo,
+        serviceName,
+        path,
+        method,
+        parameters,
+        responseFields,
+        maxRows,
+        timeoutSeconds,
+        description,
+        dataSourceId,
+        sql,
+        false,
+        Boolean.TRUE);
   }
 
   /**
@@ -57,11 +94,18 @@ public record DevelopmentDataServiceDefinition(
         timeoutSeconds,
         description,
         0L,
-        null);
+        null,
+        false,
+        Boolean.TRUE);
   }
 
   public boolean standaloneSql() {
     return dataSourceId > 0L && sql != null && !sql.isBlank();
+  }
+
+  /** Historical JSON has no autoParseParameters field; keep the previous auto-discovery behavior. */
+  public boolean autoParseParametersEnabled() {
+    return autoParseParameters == null || autoParseParameters;
   }
 
   /** A published v1 Data Service Revision must be directly deployable by Runtime. */
@@ -76,7 +120,7 @@ public record DevelopmentDataServiceDefinition(
       throw new IllegalArgumentException("发布前请填写查询 SQL");
     }
     if (responseFields.isEmpty()) {
-      throw new IllegalArgumentException("发布前请先预览并确认响应字段 Contract");
+      throw new IllegalArgumentException("发布前请先运行查询并确认响应字段");
     }
     for (ParameterContract parameter : parameters) {
       if (parameter == null) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeService.java
@@ -87,19 +87,29 @@ public class DevelopmentDataServiceNodeService {
     return context(node, draft);
   }
 
-  public PreviewResult preview(long nodeId, long dataSourceId, String sql, Integer timeoutSeconds) {
+  public PreviewResult preview(
+      long nodeId,
+      long dataSourceId,
+      String sql,
+      Integer maxRows,
+      Integer timeoutSeconds,
+      Map<String, Object> parameterValues) {
     requireDataServiceNode(nodeId);
     long normalizedDataSourceId = requireDataSourceId(dataSourceId);
     String normalizedSql = normalizeSql(sql);
     sqlCompiler.validateSelectOnly(normalizedSql);
-    ContractPreview contract = discoverContract(
+    ContractPreview preview = discoverContract(
         normalizedDataSourceId,
         normalizedSql,
-        range(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS, 1, 3_600, "超时时间"));
+        range(maxRows, DEFAULT_MAX_ROWS, 1, 10_000, "最大返回行数"),
+        range(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS, 1, 3_600, "超时时间"),
+        parameterValues);
     return new PreviewResult(
         String.valueOf(normalizedDataSourceId),
-        contract.parameters(),
-        contract.responseFields());
+        preview.parameters(),
+        preview.responseFields(),
+        preview.result(),
+        preview.durationMs());
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
@@ -119,6 +129,8 @@ public class DevelopmentDataServiceNodeService {
         command.maxRows(),
         command.timeoutSeconds(),
         command.description(),
+        command.paginationEnabled(),
+        command.autoParseParameters(),
         false);
 
     long expectedBaseRevision = command.baseRevision() == null ? 0L : command.baseRevision();
@@ -157,6 +169,8 @@ public class DevelopmentDataServiceNodeService {
         current.maxRows(),
         current.timeoutSeconds(),
         current.description(),
+        current.paginationEnabled(),
+        current.autoParseParametersEnabled(),
         true);
 
     String checksum = checksum(normalized);
@@ -224,6 +238,8 @@ public class DevelopmentDataServiceNodeService {
       Integer maxRows,
       Integer timeoutSeconds,
       String description,
+      Boolean paginationEnabled,
+      Boolean autoParseParameters,
       boolean requireResponseContract) {
     long normalizedDataSourceId = requireDataSourceId(dataSourceId);
     String normalizedSql = normalizeSql(sql);
@@ -241,7 +257,7 @@ public class DevelopmentDataServiceNodeService {
     List<ParameterContract> parameters = normalizeParameters(requestedParameters, sqlParameterNames);
     List<ResponseFieldContract> responseFields = normalizeResponseFields(requestedResponseFields);
     if (requireResponseContract && responseFields.isEmpty()) {
-      throw new IllegalArgumentException("发布前请先预览并确认响应字段 Contract");
+      throw new IllegalArgumentException("发布前请先运行查询并确认响应字段");
     }
 
     return new DevelopmentDataServiceDefinition(
@@ -257,7 +273,9 @@ public class DevelopmentDataServiceNodeService {
         range(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS, 1, 3_600, "超时时间"),
         optionalText(description, 2_000, "说明"),
         normalizedDataSourceId,
-        normalizedSql);
+        normalizedSql,
+        Boolean.TRUE.equals(paginationEnabled),
+        autoParseParameters == null ? Boolean.TRUE : autoParseParameters);
   }
 
   private List<ParameterContract> normalizeParameters(
@@ -318,26 +336,34 @@ public class DevelopmentDataServiceNodeService {
     return List.copyOf(normalized);
   }
 
-  private ContractPreview discoverContract(long dataSourceId, String sql, int timeoutSeconds) {
+  private ContractPreview discoverContract(
+      long dataSourceId,
+      String sql,
+      int maxRows,
+      int timeoutSeconds,
+      Map<String, Object> parameterValues) {
     List<String> parameterNames = sqlCompiler.parameterNames(sql);
     List<ParameterContract> parameters = parameterNames.stream()
         .map(name -> new ParameterContract(name, "STRING", true, null, null))
         .toList();
 
+    Map<String, Object> supplied = parameterValues == null ? Map.of() : parameterValues;
     Map<String, Object> previewParameters = new LinkedHashMap<>();
-    parameterNames.forEach(name -> previewParameters.put(name, null));
+    parameterNames.forEach(name -> previewParameters.put(name, supplied.get(name)));
     DevelopmentDataServiceSqlCompiler.CompiledSql compiled = sqlCompiler.compile(sql, previewParameters);
 
+    long started = System.nanoTime();
     DataSourceSqlResult result;
     try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(String.valueOf(dataSourceId))) {
       result = executor.execute(new DataSourceSqlRequest(
           compiled.sql(),
-          1,
+          maxRows,
           Math.min(timeoutSeconds, MAX_PREVIEW_TIMEOUT_SECONDS),
           compiled.parameters()));
     }
+    long durationMs = Math.max(0L, (System.nanoTime() - started) / 1_000_000L);
     if (!result.resultSet()) {
-      throw new IllegalStateException("Data Service Preview 没有返回结果集");
+      throw new IllegalStateException("Data Service 查询没有返回结果集");
     }
     if (result.columns().isEmpty()) {
       throw new IllegalArgumentException("查询 SQL 没有可发现的响应字段");
@@ -346,7 +372,20 @@ public class DevelopmentDataServiceNodeService {
     List<ResponseFieldContract> responseFields = result.columns().stream()
         .map(this::toResponseField)
         .toList();
-    return new ContractPreview(parameters, responseFields);
+    List<PreviewColumn> columns = result.columns().stream()
+        .map(column -> new PreviewColumn(
+            column.name(),
+            column.label(),
+            column.typeName(),
+            column.jdbcType(),
+            column.nullable()))
+        .toList();
+    PreviewSqlResult sqlResult = new PreviewSqlResult(
+        columns,
+        result.rows(),
+        result.rows().size(),
+        result.truncated());
+    return new ContractPreview(parameters, responseFields, sqlResult, durationMs);
   }
 
   private ResponseFieldContract toResponseField(DataSourceSqlColumn column) {
@@ -408,7 +447,9 @@ public class DevelopmentDataServiceNodeService {
           definition.timeoutSeconds(),
           definition.description(),
           Long.parseLong(sourceConfig.dataSourceId()),
-          sqlDefinition.content());
+          sqlDefinition.content(),
+          definition.paginationEnabled(),
+          definition.autoParseParametersEnabled());
     } catch (RuntimeException exception) {
       return definition;
     }
@@ -475,7 +516,9 @@ public class DevelopmentDataServiceNodeService {
             DEFAULT_TIMEOUT_SECONDS,
             null,
             0L,
-            ""),
+            "",
+            false,
+            Boolean.TRUE),
         0L,
         null,
         null);
@@ -582,12 +625,34 @@ public class DevelopmentDataServiceNodeService {
       Integer maxRows,
       Integer timeoutSeconds,
       String description,
+      Boolean paginationEnabled,
+      Boolean autoParseParameters,
       Long baseRevision) {}
+
+  public record PreviewColumn(
+      String name,
+      String label,
+      String typeName,
+      int jdbcType,
+      boolean nullable) {}
+
+  public record PreviewSqlResult(
+      List<PreviewColumn> columns,
+      List<List<Object>> rows,
+      int returnedRows,
+      boolean truncated) {
+    public PreviewSqlResult {
+      columns = columns == null ? List.of() : List.copyOf(columns);
+      rows = rows == null ? List.of() : List.copyOf(rows);
+    }
+  }
 
   public record PreviewResult(
       String dataSourceId,
       List<ParameterContract> parameters,
-      List<ResponseFieldContract> responseFields) {}
+      List<ResponseFieldContract> responseFields,
+      PreviewSqlResult result,
+      long durationMs) {}
 
   public record DataServiceNodeContext(
       String nodeId,
@@ -599,7 +664,9 @@ public class DevelopmentDataServiceNodeService {
 
   private record ContractPreview(
       List<ParameterContract> parameters,
-      List<ResponseFieldContract> responseFields) {}
+      List<ResponseFieldContract> responseFields,
+      PreviewSqlResult result,
+      long durationMs) {}
 
   private record SourceConfig(String dataSourceId) {}
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeSourceProvider.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeSourceProvider.java
@@ -129,17 +129,33 @@ public class DevelopmentDataServiceNodeSourceProvider implements DataServiceSour
         definition.timeoutSeconds(),
         definition.path(),
         definition.description(),
-        dataServiceRevision.createTime());
+        dataServiceRevision.createTime(),
+        definition.paginationEnabled());
 
-    SourceContract contract = new SourceContract(
-        definition.parameters().stream()
-            .map(item -> new ParameterContract(
-                item.name(), item.type(), item.required(), item.description(), item.example()))
-            .toList(),
-        definition.responseFields().stream()
-            .map(item -> new ResponseFieldContract(
-                item.name(), item.type(), item.nullable(), item.description(), item.example()))
-            .toList());
+    List<ParameterContract> parameters = new ArrayList<>(definition.parameters().stream()
+        .map(item -> new ParameterContract(
+            item.name(), item.type(), item.required(), item.description(), item.example()))
+        .toList());
+    List<ResponseFieldContract> responseFields = new ArrayList<>(definition.responseFields().stream()
+        .map(item -> new ResponseFieldContract(
+            item.name(), item.type(), item.nullable(), item.description(), item.example()))
+        .toList());
+    if (definition.paginationEnabled()) {
+      parameters.add(new ParameterContract(
+          "returnTotalNum", "BOOLEAN", false, "是否返回分页总数，默认 true", "true"));
+      parameters.add(new ParameterContract(
+          "pageNum", "INTEGER", false, "页码，从 1 开始，默认 1", "1"));
+      parameters.add(new ParameterContract(
+          "pageSize", "INTEGER", false, "每页条数，默认 20，不超过服务最大行数", "20"));
+      responseFields.add(new ResponseFieldContract(
+          "totalNum", "INTEGER", true, "分页结果总数；未请求总数时为空", null));
+      responseFields.add(new ResponseFieldContract(
+          "pageNum", "INTEGER", false, "当前页码", "1"));
+      responseFields.add(new ResponseFieldContract(
+          "pageSize", "INTEGER", false, "当前每页条数", "20"));
+    }
+
+    SourceContract contract = new SourceContract(parameters, responseFields);
     return new ResolvedSource(descriptor, resolvedSql.sql(), contract);
   }
 

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDataServiceNodeServiceTest.java
@@ -88,12 +88,16 @@ class DevelopmentDataServiceNodeServiceTest {
             1000,
             30,
             null,
+            true,
+            true,
             0L));
 
     assertEquals(42L, context.draft().definition().dataSourceId());
     assertEquals(sql, context.draft().definition().sql());
     assertEquals(0L, context.draft().definition().sourceTaskAssetId());
     assertEquals(0L, context.draft().definition().sourceTaskRevisionId());
+    assertTrue(context.draft().definition().paginationEnabled());
+    assertTrue(context.draft().definition().autoParseParametersEnabled());
     verify(taskCatalogService, never()).get(anyLong());
     verify(nodeRepository).updateConfigured(100L, true);
   }
@@ -170,6 +174,8 @@ class DevelopmentDataServiceNodeServiceTest {
                 1000,
                 30,
                 null,
+                false,
+                true,
                 0L)));
 
     assertTrue(error.getMessage().contains("数据源"));

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
@@ -19,6 +19,7 @@ public class DataServiceApiPO {
   private String sqlText;
   private Integer maxRows;
   private Integer timeoutSeconds;
+  private Boolean paginationEnabled;
   private Boolean enabled;
   private String authMode;
   private Boolean cacheEnabled;

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServicePublicationService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServicePublicationService.java
@@ -27,8 +27,8 @@ import org.springframework.util.StringUtils;
  * Single backend transition from an immutable upstream revision to a Data Service runtime snapshot.
  *
  * <p>Executable SQL and datasource identity are always resolved server-side. Sources that own their
- * service definition also make name/path/contracts/limits authoritative; Data Service then owns only
- * runtime concerns such as enablement, access control, resilience and observability.
+ * service definition also make name/path/contracts/limits/pagination authoritative; Data Service then
+ * owns only runtime concerns such as enablement, access control, resilience and observability.
  */
 @Service
 @ConditionalOnDataSourceEnabled
@@ -188,7 +188,8 @@ public class DataServicePublicationService {
         source.maxRows() == null ? DEFAULT_MAX_ROWS : source.maxRows(),
         source.timeoutSeconds() == null ? DEFAULT_TIMEOUT_SECONDS : source.timeoutSeconds(),
         enabled,
-        source.description());
+        source.description(),
+        Boolean.TRUE.equals(source.paginationEnabled()));
   }
 
   private ServiceSettingsInput legacySettings(
@@ -211,7 +212,10 @@ public class DataServicePublicationService {
     String description = request.description() != null
         ? request.description()
         : existing.map(ApiView::description).orElse(source.description());
-    return new ServiceSettingsInput(name, path, maxRows, timeoutSeconds, enabled, description);
+    Boolean paginationEnabled = existing.map(ApiView::paginationEnabled)
+        .orElse(Boolean.TRUE.equals(source.paginationEnabled()));
+    return new ServiceSettingsInput(
+        name, path, maxRows, timeoutSeconds, enabled, description, paginationEnabled);
   }
 
   private void syncSourceContract(Long apiId, SourceContract contract) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceRuntimeService.java
@@ -158,7 +158,14 @@ public class DataServiceRuntimeService {
 
   private QueryResponse copyWithDuration(QueryResponse response, long durationMs) {
     return new QueryResponse(
-        response.columns(), response.rows(), response.truncated(), response.rowCount(), durationMs);
+        response.columns(),
+        response.rows(),
+        response.truncated(),
+        response.rowCount(),
+        durationMs,
+        response.totalNum(),
+        response.pageNum(),
+        response.pageSize());
   }
 
   private long elapsedMs(long started) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/DataServiceService.java
@@ -35,6 +35,7 @@ public class DataServiceService {
 
   private static final int DEFAULT_MAX_ROWS = 1_000;
   private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int DEFAULT_PAGE_SIZE = 20;
   private static final int DEFAULT_CACHE_TTL_SECONDS = 60;
   private static final int DEFAULT_CACHE_MAX_ENTRIES = 200;
   private static final int DEFAULT_CIRCUIT_FAILURE_THRESHOLD = 5;
@@ -235,6 +236,7 @@ public class DataServiceService {
     api.setPath(input.path());
     api.setMaxRows(input.maxRows());
     api.setTimeoutSeconds(input.timeoutSeconds());
+    api.setPaginationEnabled(Boolean.TRUE.equals(input.paginationEnabled()));
     api.setEnabled(input.enabled());
     api.setDescription(input.description());
   }
@@ -256,9 +258,18 @@ public class DataServiceService {
     boolean enabled = input.enabled() == null
         ? existing != null && Boolean.TRUE.equals(existing.getEnabled())
         : input.enabled();
+    boolean paginationEnabled = input.paginationEnabled() == null
+        ? existing != null && Boolean.TRUE.equals(existing.getPaginationEnabled())
+        : input.paginationEnabled();
     String description = StringUtils.hasText(input.description()) ? input.description().trim() : null;
     return new ServiceSettingsInput(
-        input.name().trim(), path, maxRows, timeoutSeconds, enabled, description);
+        input.name().trim(),
+        path,
+        maxRows,
+        timeoutSeconds,
+        enabled,
+        description,
+        paginationEnabled);
   }
 
   private RuntimeDefinition normalizeRuntimeDefinition(RuntimeDefinition runtimeDefinition) {
@@ -281,13 +292,24 @@ public class DataServiceService {
       boolean resilientRuntime) {
     long started = System.nanoTime();
     try {
-      DataServiceSqlCompiler.CompiledSql compiled = sqlCompiler.compile(api.getSqlText(), parameters);
+      PaginationRequest pagination = paginationRequest(api, parameters);
+      Map<String, String> sqlParameters = sqlParameters(parameters, pagination != null);
+      DataServiceSqlCompiler.CompiledSql compiled = sqlCompiler.compile(api.getSqlText(), sqlParameters);
       QueryResponse response;
       if (resilientRuntime) {
-        String cacheKey = runtimeService.cacheKey(compiled.sql(), compiled.parameters());
-        response = runtimeService.execute(api, cacheKey, () -> executeDatabase(api, compiled));
+        List<Object> cacheBindings = new ArrayList<>(compiled.parameters());
+        if (pagination != null) {
+          cacheBindings.add("__yak_page_num=" + pagination.pageNum());
+          cacheBindings.add("__yak_page_size=" + pagination.pageSize());
+          cacheBindings.add("__yak_return_total=" + pagination.returnTotalNum());
+        }
+        String cacheKey = runtimeService.cacheKey(compiled.sql(), cacheBindings);
+        response = runtimeService.execute(
+            api,
+            cacheKey,
+            () -> executeDatabase(api, compiled, pagination));
       } else {
-        response = executeDatabase(api, compiled);
+        response = executeDatabase(api, compiled, pagination);
       }
       if (writeLog) {
         saveLog(api, parameters, true, response.durationMs(), response.rowCount(), null, access);
@@ -302,32 +324,105 @@ public class DataServiceService {
 
   private QueryResponse executeDatabase(
       DataServiceApiPO api,
-      DataServiceSqlCompiler.CompiledSql compiled) {
+      DataServiceSqlCompiler.CompiledSql compiled,
+      PaginationRequest pagination) {
+    int fetchRows = api.getMaxRows();
+    if (pagination != null && !pagination.returnTotalNum()) {
+      long requiredRows = pagination.offset() + pagination.pageSize();
+      fetchRows = (int) Math.min(api.getMaxRows(), Math.max(1L, requiredRows));
+    }
+
     SqlExecutionResult result = sqlExecutionRuntime.execute(new SqlExecutionRequest(
         String.valueOf(api.getDataSourceId()),
         compiled.sql(),
         compiled.parameters(),
-        api.getMaxRows(),
+        fetchRows,
         api.getTimeoutSeconds(),
         SqlExecutionContext.of(SqlExecutionCaller.DATA_SERVICE, String.valueOf(api.getId()))));
     if (!result.resultSet()) {
       throw new IllegalStateException("数据服务仅允许返回 SELECT 查询结果");
     }
-    return toResponse(result);
+    return toResponse(result, pagination);
   }
 
-  private QueryResponse toResponse(SqlExecutionResult result) {
+  private QueryResponse toResponse(SqlExecutionResult result, PaginationRequest pagination) {
     List<String> columns = result.columns().stream().map(SqlExecutionColumn::label).toList();
-    List<Map<String, Object>> rows = new ArrayList<>(result.rows().size());
+    List<Map<String, Object>> allRows = new ArrayList<>(result.rows().size());
     for (List<Object> values : result.rows()) {
       Map<String, Object> row = new LinkedHashMap<>();
       for (int index = 0; index < columns.size(); index++) {
         row.put(columns.get(index), index < values.size() ? values.get(index) : null);
       }
-      rows.add(row);
+      allRows.add(row);
     }
+
+    if (pagination == null) {
+      return new QueryResponse(
+          columns,
+          allRows,
+          result.truncated(),
+          allRows.size(),
+          result.timing().totalMillis());
+    }
+
+    int from = (int) Math.min(pagination.offset(), allRows.size());
+    int to = Math.min(allRows.size(), from + pagination.pageSize());
+    List<Map<String, Object>> pageRows = List.copyOf(allRows.subList(from, to));
+    Integer totalNum = pagination.returnTotalNum() ? allRows.size() : null;
     return new QueryResponse(
-        columns, rows, result.truncated(), rows.size(), result.timing().totalMillis());
+        columns,
+        pageRows,
+        result.truncated(),
+        pageRows.size(),
+        result.timing().totalMillis(),
+        totalNum,
+        pagination.pageNum(),
+        pagination.pageSize());
+  }
+
+  private PaginationRequest paginationRequest(
+      DataServiceApiPO api,
+      Map<String, String> parameters) {
+    if (!Boolean.TRUE.equals(api.getPaginationEnabled())) return null;
+    Map<String, String> values = parameters == null ? Map.of() : parameters;
+    int pageNum = positiveInt(values.get("pageNum"), 1, "pageNum");
+    int pageSize = positiveInt(values.get("pageSize"), DEFAULT_PAGE_SIZE, "pageSize");
+    if (pageSize > api.getMaxRows()) {
+      throw new IllegalArgumentException("pageSize 不能超过服务最大返回行数 " + api.getMaxRows());
+    }
+    boolean returnTotalNum = booleanValue(values.get("returnTotalNum"), true, "returnTotalNum");
+    long offset = (long) (pageNum - 1) * pageSize;
+    return new PaginationRequest(pageNum, pageSize, returnTotalNum, offset);
+  }
+
+  private Map<String, String> sqlParameters(
+      Map<String, String> parameters,
+      boolean paginationEnabled) {
+    if (parameters == null || parameters.isEmpty()) return Map.of();
+    if (!paginationEnabled) return parameters;
+    Map<String, String> result = new LinkedHashMap<>(parameters);
+    result.remove("pageNum");
+    result.remove("pageSize");
+    result.remove("returnTotalNum");
+    return result;
+  }
+
+  private int positiveInt(String raw, int fallback, String name) {
+    if (!StringUtils.hasText(raw)) return fallback;
+    try {
+      int value = Integer.parseInt(raw.trim());
+      if (value <= 0) throw new NumberFormatException("not positive");
+      return value;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException(name + " 必须是大于 0 的整数");
+    }
+  }
+
+  private boolean booleanValue(String raw, boolean fallback, String name) {
+    if (!StringUtils.hasText(raw)) return fallback;
+    if ("true".equalsIgnoreCase(raw) || "1".equals(raw)) return true;
+    if ("false".equalsIgnoreCase(raw) || "0".equals(raw)) return false;
+    throw new IllegalArgumentException(name + " 必须是 true/false 或 1/0");
   }
 
   private void saveLog(
@@ -359,12 +454,25 @@ public class DataServiceService {
   private ApiView toView(DataServiceApiPO api) {
     if (api == null) return null;
     return new ApiView(
-        api.getId(), api.getName(), api.getPath(), RUNTIME_PREFIX + api.getPath(),
-        api.getDataSourceId(), api.getSqlText(), sqlCompiler.parameterNames(api.getSqlText()),
-        api.getMaxRows(), api.getTimeoutSeconds(), Boolean.TRUE.equals(api.getEnabled()),
+        api.getId(),
+        api.getName(),
+        api.getPath(),
+        RUNTIME_PREFIX + api.getPath(),
+        api.getDataSourceId(),
+        api.getSqlText(),
+        sqlCompiler.parameterNames(api.getSqlText()),
+        api.getMaxRows(),
+        api.getTimeoutSeconds(),
+        Boolean.TRUE.equals(api.getEnabled()),
         StringUtils.hasText(api.getAuthMode()) ? api.getAuthMode() : "NONE",
-        api.getDescription(), api.getSourceType(), api.getSourceRef(), api.getSourceRevisionId(),
-        api.getSourceRevisionNo(), api.getCreateTime(), api.getUpdateTime());
+        api.getDescription(),
+        api.getSourceType(),
+        api.getSourceRef(),
+        api.getSourceRevisionId(),
+        api.getSourceRevisionNo(),
+        api.getCreateTime(),
+        api.getUpdateTime(),
+        Boolean.TRUE.equals(api.getPaginationEnabled()));
   }
 
   private DataServiceApiPO requireApi(Long id) {
@@ -374,6 +482,7 @@ public class DataServiceService {
   }
 
   private void initializeRuntimeDefaults(DataServiceApiPO api, boolean creating) {
+    if (api.getPaginationEnabled() == null) api.setPaginationEnabled(Boolean.FALSE);
     if (api.getCacheEnabled() == null) api.setCacheEnabled(Boolean.FALSE);
     if (api.getCacheTtlSeconds() == null) api.setCacheTtlSeconds(DEFAULT_CACHE_TTL_SECONDS);
     if (api.getCacheMaxEntries() == null) api.setCacheMaxEntries(DEFAULT_CACHE_MAX_ENTRIES);
@@ -483,7 +592,18 @@ public class DataServiceService {
       Integer maxRows,
       Integer timeoutSeconds,
       Boolean enabled,
-      String description) {}
+      String description,
+      Boolean paginationEnabled) {
+    public ServiceSettingsInput(
+        String name,
+        String path,
+        Integer maxRows,
+        Integer timeoutSeconds,
+        Boolean enabled,
+        String description) {
+      this(name, path, maxRows, timeoutSeconds, enabled, description, null);
+    }
+  }
 
   public record RuntimeDefinition(Long dataSourceId, String sql) {}
 
@@ -519,14 +639,33 @@ public class DataServiceService {
       Long sourceRevisionId,
       Integer sourceRevisionNo,
       LocalDateTime createTime,
-      LocalDateTime updateTime) {}
+      LocalDateTime updateTime,
+      Boolean paginationEnabled) {}
 
   public record QueryResponse(
       List<String> columns,
       List<Map<String, Object>> rows,
       boolean truncated,
       int rowCount,
-      long durationMs) {}
+      long durationMs,
+      Integer totalNum,
+      Integer pageNum,
+      Integer pageSize) {
+    public QueryResponse(
+        List<String> columns,
+        List<Map<String, Object>> rows,
+        boolean truncated,
+        int rowCount,
+        long durationMs) {
+      this(columns, rows, truncated, rowCount, durationMs, null, null, null);
+    }
+  }
+
+  private record PaginationRequest(
+      int pageNum,
+      int pageSize,
+      boolean returnTotalNum,
+      long offset) {}
 
   private record SourceKey(String sourceType, String sourceRef) {}
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/source/DataServiceSourceProvider.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/service/source/DataServiceSourceProvider.java
@@ -14,9 +14,9 @@ public interface DataServiceSourceProvider {
   /**
    * Whether service-facing definition fields are owned by the upstream authoring revision.
    *
-   * <p>When true, Data Service treats name/path/contracts/maxRows/timeout/description as immutable
-   * source definition and only owns runtime concerns such as enablement, auth, rate limits, cache,
-   * circuit breaking and observability.
+   * <p>When true, Data Service treats name/path/contracts/maxRows/timeout/description/pagination as
+   * immutable source definition and only owns runtime concerns such as enablement, auth, rate limits,
+   * cache, circuit breaking and observability.
    */
   default boolean managesServiceDefinition() {
     return false;
@@ -51,7 +51,40 @@ public interface DataServiceSourceProvider {
       Integer timeoutSeconds,
       String defaultPath,
       String description,
-      Instant updateTime) {
+      Instant updateTime,
+      Boolean paginationEnabled) {
+
+    /** Keeps existing full descriptors source-compatible while pagination ownership evolves. */
+    public SourceDescriptor(
+        String sourceType,
+        String sourceRef,
+        String name,
+        String sourceKind,
+        String status,
+        Long sourceRevisionId,
+        Integer sourceRevisionNo,
+        Long dataSourceId,
+        Integer maxRows,
+        Integer timeoutSeconds,
+        String defaultPath,
+        String description,
+        Instant updateTime) {
+      this(
+          sourceType,
+          sourceRef,
+          name,
+          sourceKind,
+          status,
+          sourceRevisionId,
+          sourceRevisionNo,
+          dataSourceId,
+          maxRows,
+          timeoutSeconds,
+          defaultPath,
+          description,
+          updateTime,
+          Boolean.FALSE);
+    }
 
     /** Keeps existing unmanaged providers source-compatible while definition ownership evolves. */
     public SourceDescriptor(
@@ -79,7 +112,8 @@ public interface DataServiceSourceProvider {
           timeoutSeconds,
           defaultPath,
           null,
-          updateTime);
+          updateTime,
+          Boolean.FALSE);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V8__add_data_service_pagination.sql
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V8__add_data_service_pagination.sql
@@ -1,0 +1,4 @@
+-- 数据服务：支持由数据开发 Data Service Node 控制返回结果分页。
+-- 历史服务保持关闭，避免升级后改变既有 Runtime 响应语义。
+ALTER TABLE yak_ops_data_service_api
+    ADD COLUMN pagination_enabled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用返回结果分页' AFTER timeout_seconds;

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationServiceTest.java
@@ -90,6 +90,7 @@ class DataServicePublicationServiceTest {
     assertThat(settingsCaptor.getValue().timeoutSeconds()).isEqualTo(20);
     assertThat(settingsCaptor.getValue().enabled()).isFalse();
     assertThat(settingsCaptor.getValue().description()).isEqualTo("DS Revision 定义");
+    assertThat(settingsCaptor.getValue().paginationEnabled()).isFalse();
     assertThat(result.id()).isEqualTo(9L);
 
     ArgumentCaptor<DocumentationInput> docsCaptor = ArgumentCaptor.forClass(DocumentationInput.class);
@@ -225,6 +226,7 @@ class DataServicePublicationServiceTest {
         source.sourceRevisionId(),
         source.sourceRevisionNo(),
         null,
-        null);
+        null,
+        Boolean.TRUE.equals(settings.paginationEnabled()));
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationStateTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/service/DataServicePublicationStateTest.java
@@ -91,6 +91,7 @@ class DataServicePublicationStateTest {
         revisionId,
         revisionNo,
         null,
-        null);
+        null,
+        false);
   }
 }

--- a/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/data-service/DataServiceNodeEditor.tsx
@@ -6,6 +6,7 @@ import {
   InputNumber,
   Select,
   Spin,
+  Switch,
   Table,
   Tag,
   Tooltip,
@@ -58,7 +59,12 @@ import {
   hydrateSqlTaskConfig,
   useSqlMetadataContext,
 } from '../../editors/sql/metadata/sqlMetadataContextStore';
-import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
+import type {
+  DevelopmentId,
+  DevelopmentResourceNode,
+  DevelopmentTaskRunResult,
+} from '../../types';
+import SqlResultWorkspace from '../sql-result/SqlResultWorkspace';
 
 interface DataServiceNodeEditorProps {
   node: DevelopmentResourceNode;
@@ -156,6 +162,45 @@ const normalizeId = (value: unknown): DevelopmentId => {
 const safeArray = <T,>(value: T[] | null | undefined): T[] =>
   Array.isArray(value) ? value.filter(Boolean) : [];
 
+const parseNamedParameters = (sql: string) => {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const matcher = /(^|[^:]):([A-Za-z_][A-Za-z0-9_]*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = matcher.exec(sql)) !== null) {
+    const name = match[2];
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    names.push(name);
+  }
+  return names;
+};
+
+const mergeParameters = (
+  names: string[],
+  current: DevelopmentDataServiceParameter[],
+) => {
+  const previous = new Map(
+    current.filter((item) => item?.name).map((item) => [item.name.toLowerCase(), item]),
+  );
+  return names.map((name) => {
+    const item = previous.get(name.toLowerCase());
+    return item
+      ? {
+          ...item,
+          name,
+          type: item.type === 'OBJECT' ? 'STRING' as const : item.type,
+          required: true,
+        }
+      : {
+          name,
+          type: 'STRING' as const,
+          required: true,
+        };
+  });
+};
+
 const normalizeContext = (
   raw: DevelopmentDataServiceNodeContext,
   node: DevelopmentResourceNode,
@@ -177,6 +222,8 @@ const normalizeContext = (
     maxRows: Number(rawDefinition?.maxRows || 1000),
     timeoutSeconds: Number(rawDefinition?.timeoutSeconds || 30),
     description: rawDefinition?.description || undefined,
+    paginationEnabled: Boolean(rawDefinition?.paginationEnabled),
+    autoParseParameters: rawDefinition?.autoParseParameters !== false,
   };
 
   return {
@@ -217,10 +264,13 @@ export default function DataServiceNodeEditor({
   const [description, setDescription] = useState('');
   const [parameters, setParameters] = useState<DevelopmentDataServiceParameter[]>([]);
   const [responseFields, setResponseFields] = useState<DevelopmentDataServiceResponseField[]>([]);
+  const [paginationEnabled, setPaginationEnabled] = useState(false);
+  const [autoParseParameters, setAutoParseParameters] = useState(true);
+  const [queryResult, setQueryResult] = useState<DevelopmentTaskRunResult>();
   const [dirty, setDirty] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string>();
-  const [previewing, setPreviewing] = useState(false);
+  const [running, setRunning] = useState(false);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [publicationState, setPublicationState] = useState<DataServicePublicationState>();
@@ -241,11 +291,6 @@ export default function DataServiceNodeEditor({
 
   useEffect(() => () => dirtyChangeRef.current?.(false), []);
 
-  const invalidateContract = useCallback(() => {
-    setParameters([]);
-    setResponseFields([]);
-  }, []);
-
   const applyContext = useCallback((raw: DevelopmentDataServiceNodeContext) => {
     const next = normalizeContext(raw, node);
     const definition = next.draft.definition;
@@ -263,6 +308,9 @@ export default function DataServiceNodeEditor({
     setDescription(definition.description || '');
     setParameters(safeArray(definition.parameters));
     setResponseFields(safeArray(definition.responseFields));
+    setPaginationEnabled(Boolean(definition.paginationEnabled));
+    setAutoParseParameters(definition.autoParseParameters !== false);
+    setQueryResult(undefined);
     hydrateSqlTaskConfig(
       node.id,
       JSON.stringify(nextDataSourceId ? { dataSourceId: nextDataSourceId } : {}),
@@ -320,9 +368,10 @@ export default function DataServiceNodeEditor({
   useEffect(() => {
     if (!context || loading) return;
     if (metadataContext.dataSourceId === savedDataSourceIdRef.current) return;
-    invalidateContract();
+    setResponseFields([]);
+    setQueryResult(undefined);
     markDirty();
-  }, [context, invalidateContract, loading, markDirty, metadataContext.dataSourceId]);
+  }, [context, loading, markDirty, metadataContext.dataSourceId]);
 
   const metadataPath = useMemo(
     () => [
@@ -346,62 +395,103 @@ export default function DataServiceNodeEditor({
 
   const changeSql = (value: string) => {
     setSqlText(value);
-    invalidateContract();
+    setQueryResult(undefined);
+    if (autoParseParameters) {
+      setParameters((current) => mergeParameters(parseNamedParameters(value), current));
+      setResponseFields([]);
+    }
     markDirty();
   };
 
-  const preview = async () => {
+  const runQuery = async (forceContractSync = false) => {
     const dataSourceId = metadataContext.dataSourceId;
-    if (!dataSourceId || !sqlText.trim() || previewing) return;
+    if (!dataSourceId || !sqlText.trim() || running) return;
 
-    setPreviewing(true);
+    setRunning(true);
+    setQueryResult({
+      status: 'RUNNING',
+      message: '正在执行 Data Service 查询',
+      durationMs: 0,
+      output: {},
+    });
     try {
+      const parameterValues = Object.fromEntries(
+        parameters
+          .filter((item) => item?.name)
+          .map((item) => [item.name, item.example?.trim() || null]),
+      );
       const result = await previewDevelopmentDataServiceNode(
         node.id,
         dataSourceId,
         sqlText,
+        maxRows,
         timeoutSeconds,
+        parameterValues,
       );
       const nextParameters = safeArray(result?.parameters);
       const nextResponses = safeArray(result?.responseFields);
-      const oldParameters = new Map(
-        parameters.filter((item) => item?.name).map((item) => [item.name.toLowerCase(), item]),
-      );
-      const oldResponses = new Map(
-        responseFields.filter((item) => item?.name).map((item) => [item.name.toLowerCase(), item]),
-      );
 
-      setParameters(nextParameters.map((item) => {
-        const previous = oldParameters.get(item.name.toLowerCase());
-        return previous
-          ? {
-              ...item,
-              type: previous.type === 'OBJECT' ? 'STRING' : previous.type,
-              required: true,
-              description: previous.description,
-              example: previous.example,
-            }
-          : { ...item, required: true };
-      }));
-      setResponseFields(nextResponses.map((item) => {
-        const previous = oldResponses.get(item.name.toLowerCase());
-        return previous
-          ? {
-              ...item,
-              type: previous.type,
-              description: previous.description,
-              example: previous.example,
-            }
-          : item;
-      }));
-      markDirty();
+      if (autoParseParameters || forceContractSync) {
+        const oldParameters = new Map(
+          parameters.filter((item) => item?.name).map((item) => [item.name.toLowerCase(), item]),
+        );
+        const oldResponses = new Map(
+          responseFields.filter((item) => item?.name).map((item) => [item.name.toLowerCase(), item]),
+        );
+
+        setParameters(nextParameters.map((item) => {
+          const previous = oldParameters.get(item.name.toLowerCase());
+          return previous
+            ? {
+                ...item,
+                type: previous.type === 'OBJECT' ? 'STRING' : previous.type,
+                required: true,
+                description: previous.description,
+                example: previous.example,
+              }
+            : { ...item, required: true };
+        }));
+        setResponseFields(nextResponses.map((item) => {
+          const previous = oldResponses.get(item.name.toLowerCase());
+          return previous
+            ? {
+                ...item,
+                type: previous.type,
+                description: previous.description,
+                example: previous.example,
+              }
+            : item;
+        }));
+        markDirty();
+      }
+
+      setQueryResult({
+        status: 'SUCCESS',
+        message: '查询成功',
+        durationMs: Number(result?.durationMs || 0),
+        output: {
+          kind: 'RESULT_SET',
+          columns: safeArray(result?.result?.columns),
+          rows: safeArray(result?.result?.rows),
+          returnedRows: Number(result?.result?.returnedRows || 0),
+          truncated: Boolean(result?.result?.truncated),
+          dataSourceId: result?.dataSourceId,
+        },
+      });
       message.success(
-        `Contract 已发现 · ${nextParameters.length} 个参数 / ${nextResponses.length} 个响应字段`,
+        `查询完成 · ${Number(result?.result?.returnedRows || 0)} 行 / ${nextResponses.length} 个字段`,
       );
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '预览 Data Service Contract 失败');
+      const text = error instanceof Error ? error.message : '运行 Data Service 查询失败';
+      setQueryResult({
+        status: 'FAILED',
+        message: text,
+        durationMs: 0,
+        output: {},
+      });
+      message.error(text);
     } finally {
-      setPreviewing(false);
+      setRunning(false);
     }
   };
 
@@ -431,6 +521,8 @@ export default function DataServiceNodeEditor({
         maxRows,
         timeoutSeconds,
         description: description.trim() || undefined,
+        paginationEnabled,
+        autoParseParameters,
         baseRevision: context?.draft?.draftRevision || 0,
       });
       applyContext(next);
@@ -586,7 +678,7 @@ export default function DataServiceNodeEditor({
         <Input
           size="small"
           value={value || ''}
-          placeholder="示例值"
+          placeholder="运行查询时作为参数值"
           onChange={(event) => updateParameter(index, { example: event.target.value })}
         />
       ),
@@ -704,6 +796,10 @@ export default function DataServiceNodeEditor({
         <dd className="m-0 break-all text-[#344054]">{metadataPath || '未选择数据源'}</dd>
         <dt className="text-[#667085]">查询 SQL：</dt>
         <dd className="m-0 text-[#344054]">{sqlText.trim() ? '已配置' : '未填写'}</dd>
+        <dt className="text-[#667085]">结果分页：</dt>
+        <dd className="m-0 text-[#344054]">{paginationEnabled ? '开启' : '关闭'}</dd>
+        <dt className="text-[#667085]">参数解析：</dt>
+        <dd className="m-0 text-[#344054]">{autoParseParameters ? '自动' : '手动维护'}</dd>
       </dl>
     </div>
   );
@@ -711,8 +807,18 @@ export default function DataServiceNodeEditor({
   const requestPanel = (
     <div>
       <div className="mb-4 text-[11px] leading-5 text-[#98a2b3]">
-        参数来自当前 SQL 中的 <span className="font-mono">:name</span> 命名参数，v1 统一为必填参数。
+        SQL 中的 <span className="font-mono">:name</span> 命名参数作为请求参数；示例值同时用于顶部“运行查询”。
       </div>
+      {paginationEnabled ? (
+        <div className="mb-4 rounded-[4px] border border-[#e6e9ef] bg-[#fafbfc] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+          <span className="font-medium text-[#475467]">分页系统参数</span>
+          <span className="ml-2 font-mono">returnTotalNum</span>
+          <span className="mx-1 text-[#c0c5ce]">·</span>
+          <span className="font-mono">pageNum</span>
+          <span className="mx-1 text-[#c0c5ce]">·</span>
+          <span className="font-mono">pageSize</span>
+        </div>
+      ) : null}
       <Table<DevelopmentDataServiceParameter>
         rowKey="name"
         size="small"
@@ -720,7 +826,7 @@ export default function DataServiceNodeEditor({
         dataSource={parameters}
         columns={parameterColumns}
         scroll={{ x: 610 }}
-        locale={{ emptyText: '预览 Contract 后自动发现请求参数' }}
+        locale={{ emptyText: autoParseParameters ? '运行查询后自动发现请求参数' : '当前 SQL 没有请求参数' }}
       />
     </div>
   );
@@ -728,8 +834,18 @@ export default function DataServiceNodeEditor({
   const responsePanel = (
     <div>
       <div className="mb-4 text-[11px] leading-5 text-[#98a2b3]">
-        通过当前数据源真实预览发现字段类型，可补充描述与示例后固化到 DS Revision。
+        运行当前 SQL 后从真实结果集发现字段类型，可补充描述与示例后固化到 DS Revision。
       </div>
+      {paginationEnabled ? (
+        <div className="mb-4 rounded-[4px] border border-[#e6e9ef] bg-[#fafbfc] px-3 py-2 text-[11px] leading-5 text-[#667085]">
+          <span className="font-medium text-[#475467]">分页返回信息</span>
+          <span className="ml-2 font-mono">totalNum</span>
+          <span className="mx-1 text-[#c0c5ce]">·</span>
+          <span className="font-mono">pageNum</span>
+          <span className="mx-1 text-[#c0c5ce]">·</span>
+          <span className="font-mono">pageSize</span>
+        </div>
+      ) : null}
       <Table<DevelopmentDataServiceResponseField>
         rowKey={(record) => record.name}
         size="small"
@@ -737,7 +853,7 @@ export default function DataServiceNodeEditor({
         dataSource={responseFields}
         columns={responseColumns}
         scroll={{ x: 610 }}
-        locale={{ emptyText: '预览 Contract 后自动发现返回字段' }}
+        locale={{ emptyText: '运行查询后自动发现返回字段' }}
       />
     </div>
   );
@@ -896,19 +1012,19 @@ export default function DataServiceNodeEditor({
     );
   }
 
-  const canPreview = Boolean(metadataContext.dataSourceId && sqlText.trim());
-  const canSave = canPreview && dirty;
+  const canRun = Boolean(metadataContext.dataSourceId && sqlText.trim());
+  const canSave = canRun && dirty;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2">
         <div className="flex shrink-0 items-center gap-0.5">
           <ToolbarButton
-            title={previewing ? '正在预览 Contract' : '预览 Contract'}
-            disabled={!canPreview || previewing}
-            onClick={() => void preview()}
+            title={running ? '正在运行查询' : '运行查询'}
+            disabled={!canRun || running}
+            onClick={() => void runQuery()}
           >
-            {previewing ? <LoaderCircle size={15} className="animate-spin" /> : <Play size={15} strokeWidth={1.8} />}
+            {running ? <LoaderCircle size={15} className="animate-spin" /> : <Play size={15} strokeWidth={1.8} />}
           </ToolbarButton>
           <ToolbarDivider />
           <ToolbarButton
@@ -944,12 +1060,55 @@ export default function DataServiceNodeEditor({
           </ToolbarButton>
         </div>
 
-        <SqlMetadataContextToolbar nodeId={node.id} />
+        <div className="flex min-w-0 items-center justify-end gap-3">
+          <div className="hidden shrink-0 items-center gap-4 border-r border-[#e5e7eb] pr-3 xl:flex">
+            <Tooltip
+              title="开启后，发布的数据服务使用分页请求参数 pageNum / pageSize / returnTotalNum，并返回分页信息。"
+              mouseEnterDelay={0.3}
+            >
+              <label className="flex cursor-pointer items-center gap-2 text-[11px] text-[#475467]">
+                <span>返回结果分页</span>
+                <Switch
+                  size="small"
+                  checked={paginationEnabled}
+                  onChange={(checked) => {
+                    setPaginationEnabled(checked);
+                    markDirty();
+                  }}
+                />
+              </label>
+            </Tooltip>
+            <Tooltip
+              title="开启后，运行查询会根据 SQL 命名参数和真实结果集同步请求参数、返回字段。"
+              mouseEnterDelay={0.3}
+            >
+              <label className="flex cursor-pointer items-center gap-2 text-[11px] text-[#475467]">
+                <span>自动解析参数</span>
+                <Switch
+                  size="small"
+                  checked={autoParseParameters}
+                  onChange={(checked) => {
+                    setAutoParseParameters(checked);
+                    if (checked) {
+                      setParameters((current) => mergeParameters(parseNamedParameters(sqlText), current));
+                      setResponseFields([]);
+                    }
+                    markDirty();
+                    if (checked && metadataContext.dataSourceId && sqlText.trim()) {
+                      window.setTimeout(() => void runQuery(true), 0);
+                    }
+                  }}
+                />
+              </label>
+            </Tooltip>
+          </div>
+          <SqlMetadataContextToolbar nodeId={node.id} />
+        </div>
       </div>
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <section className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-          <div className="min-h-0 flex-1">
+          <div className="min-h-[220px] min-w-0 flex-1">
             <SqlMonacoEditor
               id={String(node.id)}
               value={sqlText}
@@ -979,7 +1138,7 @@ export default function DataServiceNodeEditor({
               </span>
             </div>
             <div className="flex shrink-0 items-center gap-3">
-              <span>{responseFields.length ? `${responseFields.length} 个响应字段` : 'Contract 待预览'}</span>
+              <span>{responseFields.length ? `${responseFields.length} 个响应字段` : '运行查询以发现字段'}</span>
               <span>
                 Draft #{context.draft.draftRevision || 0}
                 {latestPublished ? ` · DS R${latestPublished.revisionNo}` : ''}
@@ -987,6 +1146,10 @@ export default function DataServiceNodeEditor({
               {position.selectionLength > 0 ? <span>已选择 {position.selectionLength} 字符</span> : null}
               <span>Ln {position.lineNumber}, Col {position.column}</span>
             </div>
+          </div>
+
+          <div className="h-[34%] min-h-[190px] max-h-[380px] shrink-0 border-t border-[#e7eaf0] bg-white">
+            <SqlResultWorkspace result={queryResult} />
           </div>
         </section>
 

--- a/yak-ops-ui/src/pages/data-development/data-service-node-service.ts
+++ b/yak-ops-ui/src/pages/data-development/data-service-node-service.ts
@@ -2,7 +2,7 @@ import type { ApiResponse } from '@/services/http/response';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 
-import type { DevelopmentId } from './types';
+import type { DevelopmentId, DevelopmentSqlResultColumn } from './types';
 
 const NODE_API = '/api/v1/data-development/nodes';
 
@@ -46,6 +46,8 @@ export interface DevelopmentDataServiceDefinition {
   maxRows: number;
   timeoutSeconds: number;
   description?: string | null;
+  paginationEnabled: boolean;
+  autoParseParameters: boolean;
 }
 
 export interface DevelopmentDataServiceDraft {
@@ -86,10 +88,19 @@ export interface DevelopmentDataServiceNodeContext {
   revisions: DevelopmentDataServiceRevisionSummary[];
 }
 
+export interface PreviewDevelopmentDataServiceSqlResult {
+  columns: DevelopmentSqlResultColumn[];
+  rows: unknown[][];
+  returnedRows: number;
+  truncated: boolean;
+}
+
 export interface PreviewDevelopmentDataServiceResult {
   dataSourceId: DevelopmentId;
   parameters: DevelopmentDataServiceParameter[];
   responseFields: DevelopmentDataServiceResponseField[];
+  result: PreviewDevelopmentDataServiceSqlResult;
+  durationMs: number;
 }
 
 export interface SaveDevelopmentDataServiceDraftPayload {
@@ -103,6 +114,8 @@ export interface SaveDevelopmentDataServiceDraftPayload {
   maxRows: number;
   timeoutSeconds: number;
   description?: string;
+  paginationEnabled: boolean;
+  autoParseParameters: boolean;
   baseRevision: number;
 }
 
@@ -124,13 +137,15 @@ export const previewDevelopmentDataServiceNode = async (
   nodeId: DevelopmentId,
   dataSourceId: DevelopmentId,
   sql: string,
+  maxRows = 1000,
   timeoutSeconds = 30,
+  parameterValues: Record<string, unknown> = {},
 ): Promise<PreviewDevelopmentDataServiceResult> => unwrap(
   await HttpUtils.post<PreviewDevelopmentDataServiceResult>(
     `${NODE_API}/${nodeId}/data-service/preview`,
-    { dataSourceId, sql, timeoutSeconds },
+    { dataSourceId, sql, maxRows, timeoutSeconds, parameterValues },
   ),
-  '预览 Data Service Contract 失败',
+  '运行 Data Service 查询失败',
 );
 
 export const saveDevelopmentDataServiceDraft = async (


### PR DESCRIPTION
## 背景

Data Service Node 当前使用“预览 Contract”作为主要验证入口，用户需要先理解 Contract 再判断 SQL 是否正确，和 SQL Node 的直接查询体验不一致。

这次把 Data Service Node 调整为以“运行查询”为主流程：先看真实 SQL Result，再由结果自动同步请求参数和返回字段；同时补上“返回结果分页”和“自动解析参数”两个数据服务侧配置。

## 主要改动

- 将顶部“预览 Contract”改为“运行查询”，直接执行当前 Data Service SQL。
- 复用数据开发现有 `SqlResultWorkspace`，在编辑器下方展示真实结果表格、字段类型、返回行数、耗时和截断状态。
- 将“返回结果分页 / 自动解析参数”放在 SQL 编辑器顶部工具栏、数据源上下文左侧，和运行/保存操作保持在同一工作区。
- 自动解析开启时：
  - SQL 编辑过程中识别 `:name` 命名参数；
  - 运行查询后根据真实 ResultSet 同步请求参数和响应字段；
  - 保留用户已经填写的参数说明、示例和字段说明。
- 请求参数示例值可直接作为“运行查询”的参数值，便于调试带参数 SQL。
- 分页配置随 Data Service Draft → Revision → Publication → Runtime 贯通，并同步到 API 文档 Contract。
- 分页 Runtime 提供系统参数 `pageNum` / `pageSize` / `returnTotalNum`，响应补充 `totalNum` / `pageNum` / `pageSize`。
- 新增 Flyway V8，历史 API 默认关闭分页，避免升级改变已有响应语义。
- Runtime cache key 纳入分页参数，避免不同页之间错误复用缓存。

## 交互取舍

两个开关没有放到右侧“属性”面板里，而是放在 SQL 顶部操作区。原因是它们直接影响“当前查询如何解释/返回”，和运行查询、数据源上下文的关系比普通 API 元数据更强；右侧属性面板仍会展示当前开关状态。

## 分页 v1 边界

当前 Data Service Runtime 仍坚持数据库方言无关和 `maxRows` 安全上限，因此 v1 分页采用 **受 `maxRows` 保护的结果窗口内分页**，暂不向用户 SQL 注入各数据库不同的 LIMIT/OFFSET/COUNT 语句。

因此：
- `pageSize` 不允许超过服务 `maxRows`；
- 分页只能访问 `maxRows` 保护窗口内的数据；
- `returnTotalNum=true` 时的 `totalNum` 是该保护窗口内可见的结果数，不代表超出 `maxRows` 后的全表精确 COUNT。

后续如果需要数据库级精确分页，建议在 datasource dialect 层增加统一的 page/count compiler，而不是在 Data Service Runtime 里直接拼接方言 SQL。

## 验证

- 更新 Data Service Node Service / Publication State 相关单测构造与新配置断言。
- 保留旧 `QueryResponse` / `ServiceSettingsInput` 构造兼容，避免既有 Runtime 单测受分页字段扩展影响。
- PR 创建后继续观察 CI，如有编译或前端检查问题会在本 Draft PR 内继续修正。