### PR TITLE
feat(dataset): add SQL result workspace to dataset editor

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDatasetNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDatasetNodeController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade.FieldDraft;
+import io.yak.ops.business.dataset.DevelopmentDatasetFacade.PreviewResult;
 import io.yak.ops.business.development.service.DevelopmentDatasetNodeService;
 import io.yak.ops.business.development.service.DevelopmentDatasetNodeService.DatasetNodeContext;
 import jakarta.validation.Valid;
@@ -42,6 +43,14 @@ public class DevelopmentDatasetNodeController {
       @PathVariable("nodeId") long nodeId,
       @Valid @RequestBody DatasetSqlRequest request) {
     return Result.success(service.preview(nodeId, request.dataSourceId(), request.sql()));
+  }
+
+  @Operation(summary = "执行 Dataset 自有 SQL，并返回结果数据与输出字段")
+  @PostMapping("/{nodeId}/dataset/query")
+  public Result<PreviewResult> query(
+      @PathVariable("nodeId") long nodeId,
+      @Valid @RequestBody DatasetSqlRequest request) {
+    return Result.success(service.query(nodeId, request.dataSourceId(), request.sql()));
   }
 
   @Operation(summary = "保存 Dataset Node 并冻结数据源、SQL 与字段契约")

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDatasetNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentDatasetNodeService.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.development.service;
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade;
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade.FieldDraft;
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade.NodeDataset;
+import io.yak.ops.business.dataset.DevelopmentDatasetFacade.PreviewResult;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentNodeType;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
@@ -44,6 +45,12 @@ public class DevelopmentDatasetNodeService {
   public List<FieldDraft> preview(long nodeId, String dataSourceId, String sql) {
     requireDatasetNode(nodeId);
     return datasetFacade.preview(dataSourceId, sql);
+  }
+
+  /** Execute Dataset-owned SQL and return both field contract and actual result rows. */
+  public PreviewResult query(long nodeId, String dataSourceId, String sql) {
+    requireDatasetNode(nodeId);
+    return datasetFacade.previewQuery(dataSourceId, sql);
   }
 
   /** Standalone editor save; DatasetVersion freezes datasource + SQL + field contract. */

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetSchemaDiscoveryService.java
@@ -28,6 +28,7 @@ final class DatasetSchemaDiscoveryService {
 
   private static final int DEFAULT_TIMEOUT_SECONDS = 30;
   private static final int MAX_DISCOVERY_TIMEOUT_SECONDS = 30;
+  private static final int DEFAULT_PREVIEW_MAX_ROWS = 1_000;
   private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*");
 
   private final TaskCatalogService taskCatalogService;
@@ -58,6 +59,26 @@ final class DatasetSchemaDiscoveryService {
   /** Preview owns no persistent fieldId; stable ids are assigned when a version is saved. */
   List<DatasetService.FieldSpec> preview(String dataSourceId, String sql) {
     return toPreviewFields(discoverColumns(dataSourceId, sql, DEFAULT_TIMEOUT_SECONDS));
+  }
+
+  /** Editor query preview returns real rows and derives the field contract from the same result set. */
+  QueryPreview previewQuery(String dataSourceId, String sql) {
+    String normalizedDataSourceId = requireDataSourceId(dataSourceId);
+    String baseSql = DatasetSqlSafety.requireReadOnlyQuery(sql);
+    long started = System.nanoTime();
+    DataSourceSqlResult result;
+    try (DataSourceSqlExecutor executor = dataSourceExecutionProvider.open(normalizedDataSourceId)) {
+      result = executor.execute(new DataSourceSqlRequest(
+          baseSql,
+          DEFAULT_PREVIEW_MAX_ROWS,
+          DEFAULT_TIMEOUT_SECONDS));
+    }
+    long durationMs = Math.max(0L, (System.nanoTime() - started) / 1_000_000L);
+    if (!result.resultSet()) throw new IllegalStateException("Dataset 查询没有返回结果集");
+    if (result.columns().isEmpty()) {
+      throw new IllegalArgumentException("Dataset 来源查询没有可发现的输出字段");
+    }
+    return new QueryPreview(toPreviewFields(result.columns()), result, durationMs);
   }
 
   private List<DataSourceSqlColumn> discoverColumns(TaskAsset asset) {
@@ -172,6 +193,12 @@ final class DatasetSchemaDiscoveryService {
   private String requireDataSourceId(String value) {
     if (value == null || value.isBlank()) throw new IllegalArgumentException("Dataset 必须选择数据源");
     return value.trim();
+  }
+
+  record QueryPreview(
+      List<DatasetService.FieldSpec> fields,
+      DataSourceSqlResult result,
+      long durationMs) {
   }
 
   private record SourceConfig(String dataSourceId, int timeoutSeconds) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
@@ -32,6 +32,25 @@ public class DevelopmentDatasetFacade {
         .toList();
   }
 
+  /** Execute Dataset-owned SQL for the editor and expose both field metadata and real rows. */
+  public PreviewResult previewQuery(String dataSourceId, String sql) {
+    DatasetSchemaDiscoveryService.QueryPreview preview = standaloneService.previewQuery(dataSourceId, sql);
+    return new PreviewResult(
+        preview.fields().stream().map(DevelopmentDatasetFacade::toFieldDraft).toList(),
+        preview.result().columns().stream()
+            .map(column -> new PreviewColumn(
+                column.name(),
+                column.label(),
+                column.typeName(),
+                column.jdbcType(),
+                column.nullable()))
+            .toList(),
+        preview.result().rows(),
+        preview.result().rows().size(),
+        preview.result().truncated(),
+        preview.durationMs());
+  }
+
   public NodeDataset save(
       long developmentNodeId,
       String dataSourceId,
@@ -193,5 +212,27 @@ public class DevelopmentDatasetFacade {
       boolean nullable,
       String description,
       String defaultRole) {
+  }
+
+  public record PreviewColumn(
+      String name,
+      String label,
+      String typeName,
+      int jdbcType,
+      boolean nullable) {
+  }
+
+  public record PreviewResult(
+      List<FieldDraft> fields,
+      List<PreviewColumn> columns,
+      List<List<Object>> rows,
+      int returnedRows,
+      boolean truncated,
+      long durationMs) {
+    public PreviewResult {
+      fields = fields == null ? List.of() : List.copyOf(fields);
+      columns = columns == null ? List.of() : List.copyOf(columns);
+      rows = rows == null ? List.of() : List.copyOf(rows);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentStandaloneDatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentStandaloneDatasetService.java
@@ -36,6 +36,10 @@ class DevelopmentStandaloneDatasetService {
     return discoveryService.preview(requireDataSourceId(dataSourceId), requireSql(sql));
   }
 
+  DatasetSchemaDiscoveryService.QueryPreview previewQuery(String dataSourceId, String sql) {
+    return discoveryService.previewQuery(requireDataSourceId(dataSourceId), requireSql(sql));
+  }
+
   @Transactional("yakBusinessTransactionManager")
   DatasetDetail save(
       long developmentNodeId,

--- a/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/dataset/DatasetNodeEditor.tsx
@@ -1,22 +1,56 @@
 import { BRAND_CSS_VARIABLES } from '@/styles/brand';
-import { Button, Input, Select, Spin, Table, Tooltip, message, type TableColumnsType } from 'antd';
-import { FileStack, LoaderCircle, Play, Redo2, RefreshCw, Save, Search, Sparkles, Undo2, Wand2, X } from 'lucide-react';
+import {
+  Button,
+  Input,
+  Select,
+  Spin,
+  Table,
+  Tooltip,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import {
+  FileStack,
+  LoaderCircle,
+  Play,
+  Redo2,
+  RefreshCw,
+  Save,
+  Search,
+  Sparkles,
+  Undo2,
+  Wand2,
+  X,
+} from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   getDevelopmentDatasetNode,
-  previewDevelopmentDatasetNode,
+  runDevelopmentDatasetNode,
   saveDevelopmentDatasetNode,
   type DevelopmentDatasetFieldDraft,
   type DevelopmentDatasetFieldRole,
   type DevelopmentDatasetNodeContext,
 } from '../../dataset-service';
-import { executeSqlEditorCommand, type SqlEditorCommand } from '../../editors/sql/commands/sqlEditorCommandBus';
-import SqlMonacoEditor, { type SqlEditorPosition } from '../../editors/sql/components/SqlMonacoEditor';
+import {
+  executeSqlEditorCommand,
+  type SqlEditorCommand,
+} from '../../editors/sql/commands/sqlEditorCommandBus';
+import SqlMonacoEditor, {
+  type SqlEditorPosition,
+} from '../../editors/sql/components/SqlMonacoEditor';
 import SqlMetadataContextToolbar from '../../editors/sql/metadata/SqlMetadataContextToolbar';
-import { hydrateSqlTaskConfig, useSqlMetadataContext } from '../../editors/sql/metadata/sqlMetadataContextStore';
-import type { DevelopmentId, DevelopmentResourceNode } from '../../types';
+import {
+  hydrateSqlTaskConfig,
+  useSqlMetadataContext,
+} from '../../editors/sql/metadata/sqlMetadataContextStore';
+import type {
+  DevelopmentId,
+  DevelopmentResourceNode,
+  DevelopmentTaskRunResult,
+} from '../../types';
+import SqlResultWorkspace from '../sql-result/SqlResultWorkspace';
 
 interface DatasetNodeEditorProps {
   node: DevelopmentResourceNode;
@@ -31,35 +65,89 @@ const panelItems: Array<{ key: RightPanelKey; label: string }> = [
   { key: 'fields', label: '字段' },
   { key: 'versions', label: '版本' },
 ];
+
 const roleOptions = [
   { label: '维度', value: 'DIMENSION' },
   { label: '指标', value: 'MEASURE' },
 ];
+
 const DEFAULT_PANEL_WIDTH = 420;
 const MIN_PANEL_WIDTH = 320;
 const MAX_PANEL_WIDTH = 720;
 const PANEL_WIDTH_STORAGE_KEY = 'yak-data-development.dataset-right-panel-width';
-const defaultPosition: SqlEditorPosition = { lineNumber: 1, column: 1, selectionLength: 0 };
-const iconButtonClassName = 'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
+const DEFAULT_RESULT_HEIGHT = 280;
+const MIN_RESULT_HEIGHT = 160;
+const MAX_RESULT_HEIGHT = 520;
+const RESULT_HEIGHT_STORAGE_KEY = 'yak-data-development.bottom-panel-height';
 
-const ToolbarButton = ({ title, onClick, disabled, children }: { title: string; onClick: () => void; disabled?: boolean; children: ReactNode }) => (
+const defaultPosition: SqlEditorPosition = {
+  lineNumber: 1,
+  column: 1,
+  selectionLength: 0,
+};
+
+const iconButtonClassName =
+  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#475467] outline-none transition-colors hover:bg-[#f5f5f6] hover:text-[#1f2937] focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,.16)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent';
+
+const ToolbarButton = ({
+  title,
+  onClick,
+  disabled,
+  children,
+}: {
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+}) => (
   <Tooltip title={title} mouseEnterDelay={0.35}>
-    <button type="button" aria-label={title} disabled={disabled} onClick={onClick} className={iconButtonClassName}>{children}</button>
+    <button
+      type="button"
+      aria-label={title}
+      disabled={disabled}
+      onClick={onClick}
+      className={iconButtonClassName}
+    >
+      {children}
+    </button>
   </Tooltip>
 );
+
 const ToolbarDivider = () => <span className="mx-1 h-4 w-px shrink-0 bg-[#e5e7eb]" />;
-const clampPanelWidth = (value: number) => Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, value));
+
+const clampPanelWidth = (value: number) =>
+  Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, value));
+
 const initialPanelWidth = () => {
   if (typeof window === 'undefined') return DEFAULT_PANEL_WIDTH;
   const stored = Number(window.localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
-  return Number.isFinite(stored) && stored > 0 ? clampPanelWidth(stored) : DEFAULT_PANEL_WIDTH;
+  return Number.isFinite(stored) && stored > 0
+    ? clampPanelWidth(stored)
+    : DEFAULT_PANEL_WIDTH;
 };
+
+const clampResultHeight = (value: number) =>
+  Math.min(MAX_RESULT_HEIGHT, Math.max(MIN_RESULT_HEIGHT, value));
+
+const initialResultHeight = () => {
+  if (typeof window === 'undefined') return DEFAULT_RESULT_HEIGHT;
+  const stored = Number(window.localStorage.getItem(RESULT_HEIGHT_STORAGE_KEY));
+  return Number.isFinite(stored) && stored > 0
+    ? clampResultHeight(stored)
+    : DEFAULT_RESULT_HEIGHT;
+};
+
 const formatTime = (value?: string | null) => {
   if (!value) return '-';
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value.replace('T', ' ').slice(0, 19) : date.toLocaleString('zh-CN', { hour12: false });
+  return Number.isNaN(date.getTime())
+    ? value.replace('T', ' ').slice(0, 19)
+    : date.toLocaleString('zh-CN', { hour12: false });
 };
-const toFieldDrafts = (context?: DevelopmentDatasetNodeContext): DevelopmentDatasetFieldDraft[] =>
+
+const toFieldDrafts = (
+  context?: DevelopmentDatasetNodeContext,
+): DevelopmentDatasetFieldDraft[] =>
   (context?.dataset?.fields || []).map((field) => ({
     fieldId: field.fieldId,
     physicalName: field.physicalName,
@@ -70,27 +158,42 @@ const toFieldDrafts = (context?: DevelopmentDatasetNodeContext): DevelopmentData
     defaultRole: field.defaultRole,
   }));
 
-export default function DatasetNodeEditor({ node, onSaved, onDirtyChange }: DatasetNodeEditorProps) {
+export default function DatasetNodeEditor({
+  node,
+  onSaved,
+  onDirtyChange,
+}: DatasetNodeEditorProps) {
   const metadataContext = useSqlMetadataContext(node.id);
   const dirtyChangeRef = useRef(onDirtyChange);
   const savedDataSourceIdRef = useRef<DevelopmentId>();
+
   const [context, setContext] = useState<DevelopmentDatasetNodeContext>();
   const [sqlText, setSqlText] = useState('');
   const [description, setDescription] = useState('');
   const [fields, setFields] = useState<DevelopmentDatasetFieldDraft[]>([]);
+  const [queryResult, setQueryResult] = useState<DevelopmentTaskRunResult>();
   const [dirty, setDirty] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string>();
-  const [previewing, setPreviewing] = useState(false);
+  const [running, setRunning] = useState(false);
   const [saving, setSaving] = useState(false);
   const [activePanel, setActivePanel] = useState<RightPanelKey>();
   const [panelWidth, setPanelWidth] = useState(initialPanelWidth);
   const [resizing, setResizing] = useState(false);
+  const [resultHeight, setResultHeight] = useState(initialResultHeight);
+  const [resultResizing, setResultResizing] = useState(false);
   const [position, setPosition] = useState<SqlEditorPosition>(defaultPosition);
 
-  useEffect(() => { dirtyChangeRef.current = onDirtyChange; }, [onDirtyChange]);
-  const setDirtyState = useCallback((next: boolean) => { setDirty(next); dirtyChangeRef.current?.(next); }, []);
+  useEffect(() => {
+    dirtyChangeRef.current = onDirtyChange;
+  }, [onDirtyChange]);
+
+  const setDirtyState = useCallback((next: boolean) => {
+    setDirty(next);
+    dirtyChangeRef.current?.(next);
+  }, []);
   const markDirty = useCallback(() => setDirtyState(true), [setDirtyState]);
+
   useEffect(() => () => dirtyChangeRef.current?.(false), []);
 
   const applyContext = useCallback((next: DevelopmentDatasetNodeContext) => {
@@ -101,6 +204,7 @@ export default function DatasetNodeEditor({ node, onSaved, onDirtyChange }: Data
     setSqlText(currentVersion?.sql || '');
     setDescription(next.dataset?.description || '');
     setFields(toFieldDrafts(next));
+    setQueryResult(undefined);
     hydrateSqlTaskConfig(node.id, JSON.stringify(dataSourceId ? { dataSourceId } : {}));
     setDirtyState(false);
   }, [node.id, setDirtyState]);
@@ -119,54 +223,190 @@ export default function DatasetNodeEditor({ node, onSaved, onDirtyChange }: Data
       setLoading(false);
     }
   }, [applyContext, node.id]);
-  useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
   useEffect(() => {
     if (!context || loading || metadataContext.dataSourceId === savedDataSourceIdRef.current) return;
     setFields([]);
+    setQueryResult(undefined);
     markDirty();
   }, [context, loading, markDirty, metadataContext.dataSourceId]);
 
   const currentVersion = context?.dataset?.currentVersion;
-  const versions = useMemo(() => [...(context?.dataset?.versions || [])].sort((a, b) => b.versionNo - a.versionNo), [context?.dataset?.versions]);
-  const metadataPath = useMemo(() => [
-    metadataContext.dataSourceName || (metadataContext.dataSourceId ? `DS ${metadataContext.dataSourceId}` : undefined),
-    metadataContext.database,
-    metadataContext.schema,
-  ].filter(Boolean).join(' / '), [metadataContext.dataSourceId, metadataContext.dataSourceName, metadataContext.database, metadataContext.schema]);
+  const versions = useMemo(
+    () => [...(context?.dataset?.versions || [])].sort((a, b) => b.versionNo - a.versionNo),
+    [context?.dataset?.versions],
+  );
+  const metadataPath = useMemo(
+    () => [
+      metadataContext.dataSourceName
+        || (metadataContext.dataSourceId ? `DS ${metadataContext.dataSourceId}` : undefined),
+      metadataContext.database,
+      metadataContext.schema,
+    ].filter(Boolean).join(' / '),
+    [
+      metadataContext.dataSourceId,
+      metadataContext.dataSourceName,
+      metadataContext.database,
+      metadataContext.schema,
+    ],
+  );
+
   const execute = (command: SqlEditorCommand, fallback: string) => {
     if (!executeSqlEditorCommand(node.id, command)) message.info(fallback);
   };
-  const changeSql = (value: string) => { setSqlText(value); setFields([]); markDirty(); };
-  const updateField = useCallback((index: number, patch: Partial<DevelopmentDatasetFieldDraft>) => {
-    setFields((current) => current.map((field, fieldIndex) => fieldIndex === index ? { ...field, ...patch } : field));
+
+  const changeSql = (value: string) => {
+    setSqlText(value);
+    setFields([]);
+    setQueryResult(undefined);
+    markDirty();
+  };
+
+  const updateField = useCallback((
+    index: number,
+    patch: Partial<DevelopmentDatasetFieldDraft>,
+  ) => {
+    setFields((current) => current.map((field, fieldIndex) =>
+      fieldIndex === index ? { ...field, ...patch } : field,
+    ));
     markDirty();
   }, [markDirty]);
 
   const columns = useMemo<TableColumnsType<DevelopmentDatasetFieldDraft>>(() => [
-    { title: '字段', dataIndex: 'physicalName', width: 150, render: (value: string) => <span className="font-mono text-[11px] text-[#344054]">{value}</span> },
-    { title: '显示名称', dataIndex: 'displayName', width: 150, render: (value: string, _record, index) => <Input size="small" value={value} maxLength={200} onChange={(event) => updateField(index, { displayName: event.target.value })} /> },
-    { title: '类型', dataIndex: 'dataType', width: 92, render: (value: string) => <span className="font-mono text-[10px] text-[#667085]">{value}</span> },
-    { title: '角色', dataIndex: 'defaultRole', width: 105, render: (value: DevelopmentDatasetFieldRole, _record, index) => <Select size="small" value={value} options={roleOptions} className="w-[94px]" onChange={(next) => updateField(index, { defaultRole: next as DevelopmentDatasetFieldRole })} /> },
-    { title: '可空', dataIndex: 'nullable', width: 54, render: (value: boolean) => <span className="text-[11px] text-[#667085]">{value ? '是' : '否'}</span> },
-    { title: '描述', dataIndex: 'description', width: 180, render: (value: string | null | undefined, _record, index) => <Input size="small" value={value || ''} maxLength={1000} placeholder="字段说明" onChange={(event) => updateField(index, { description: event.target.value })} /> },
+    {
+      title: '字段',
+      dataIndex: 'physicalName',
+      width: 150,
+      render: (value: string) => (
+        <span className="font-mono text-[11px] text-[#344054]">{value}</span>
+      ),
+    },
+    {
+      title: '显示名称',
+      dataIndex: 'displayName',
+      width: 150,
+      render: (value: string, _record, index) => (
+        <Input
+          size="small"
+          value={value}
+          maxLength={200}
+          onChange={(event) => updateField(index, { displayName: event.target.value })}
+        />
+      ),
+    },
+    {
+      title: '类型',
+      dataIndex: 'dataType',
+      width: 92,
+      render: (value: string) => (
+        <span className="font-mono text-[10px] text-[#667085]">{value}</span>
+      ),
+    },
+    {
+      title: '角色',
+      dataIndex: 'defaultRole',
+      width: 105,
+      render: (value: DevelopmentDatasetFieldRole, _record, index) => (
+        <Select
+          size="small"
+          value={value}
+          options={roleOptions}
+          className="w-[94px]"
+          onChange={(next) => updateField(index, {
+            defaultRole: next as DevelopmentDatasetFieldRole,
+          })}
+        />
+      ),
+    },
+    {
+      title: '可空',
+      dataIndex: 'nullable',
+      width: 54,
+      render: (value: boolean) => (
+        <span className="text-[11px] text-[#667085]">{value ? '是' : '否'}</span>
+      ),
+    },
+    {
+      title: '描述',
+      dataIndex: 'description',
+      width: 180,
+      render: (value: string | null | undefined, _record, index) => (
+        <Input
+          size="small"
+          value={value || ''}
+          maxLength={1000}
+          placeholder="字段说明"
+          onChange={(event) => updateField(index, { description: event.target.value })}
+        />
+      ),
+    },
   ], [updateField]);
 
-  const preview = async () => {
+  const runQuery = async () => {
     const dataSourceId = metadataContext.dataSourceId;
-    if (!dataSourceId || !sqlText.trim() || previewing) return;
-    setPreviewing(true);
+    if (!dataSourceId || !sqlText.trim() || running) return;
+
+    setRunning(true);
+    setQueryResult({
+      status: 'RUNNING',
+      message: '正在执行 Dataset 查询',
+      durationMs: 0,
+      output: {},
+    });
+
     try {
-      const existing = new Map(fields.map((field) => [field.physicalName.toLowerCase(), field]));
-      const discovered = await previewDevelopmentDatasetNode(node.id, dataSourceId, sqlText);
+      const existing = new Map(
+        fields.map((field) => [field.physicalName.toLowerCase(), field]),
+      );
+      const result = await runDevelopmentDatasetNode(node.id, dataSourceId, sqlText);
+      const discovered = result?.fields || [];
+
       setFields(discovered.map((field) => {
         const previous = existing.get(field.physicalName.toLowerCase());
-        return previous ? { ...field, fieldId: previous.fieldId || field.fieldId, displayName: previous.displayName || field.displayName, description: previous.description, defaultRole: previous.defaultRole } : field;
+        return previous
+          ? {
+              ...field,
+              fieldId: previous.fieldId || field.fieldId,
+              displayName: previous.displayName || field.displayName,
+              description: previous.description,
+              defaultRole: previous.defaultRole,
+            }
+          : field;
       }));
       markDirty();
-      message.success(`已发现 ${discovered.length} 个字段`);
+
+      setQueryResult({
+        status: 'SUCCESS',
+        message: '查询成功',
+        durationMs: Number(result?.durationMs || 0),
+        output: {
+          kind: 'RESULT_SET',
+          columns: result?.columns || [],
+          rows: result?.rows || [],
+          returnedRows: Number(result?.returnedRows || 0),
+          truncated: Boolean(result?.truncated),
+          dataSourceId,
+        },
+      });
+      message.success(
+        `查询完成 · ${Number(result?.returnedRows || 0)} 行 / ${discovered.length} 个字段`,
+      );
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '发现 Dataset 字段失败');
-    } finally { setPreviewing(false); }
+      const text = error instanceof Error ? error.message : '运行 Dataset 查询失败';
+      setQueryResult({
+        status: 'FAILED',
+        message: text,
+        durationMs: 0,
+        output: {},
+      });
+      message.error(text);
+    } finally {
+      setRunning(false);
+    }
   };
 
   const save = async () => {
@@ -178,49 +418,110 @@ export default function DatasetNodeEditor({ node, onSaved, onDirtyChange }: Data
         dataSourceId,
         sql: sqlText,
         description: description.trim() || undefined,
-        fields: fields.map((field) => ({ ...field, displayName: field.displayName.trim() || field.physicalName, description: field.description?.trim() || undefined })),
+        fields: fields.map((field) => ({
+          ...field,
+          displayName: field.displayName.trim() || field.physicalName,
+          description: field.description?.trim() || undefined,
+        })),
       });
       applyContext(next);
       await onSaved?.();
       message.success(`数据集已保存 · DV${next.dataset?.currentVersion?.versionNo || 1}`);
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存 Dataset Node 失败');
-    } finally { setSaving(false); }
+    } finally {
+      setSaving(false);
+    }
   };
 
   const propertiesPanel = (
     <div className="text-[12px] leading-5">
       <div className="grid grid-cols-[88px_minmax(0,1fr)] items-center gap-x-4 gap-y-4">
-        <div className="text-[#667085]">数据集名称：</div><Input size="small" value={node.name} disabled />
-        <div className="text-[#667085]">数据源：</div><div className="break-all text-[#344054]">{metadataPath || '未选择数据源'}</div>
+        <div className="text-[#667085]">数据集名称：</div>
+        <Input size="small" value={node.name} disabled />
+        <div className="text-[#667085]">数据源：</div>
+        <div className="break-all text-[#344054]">{metadataPath || '未选择数据源'}</div>
         <div className="self-start pt-1 text-[#667085]">描述：</div>
-        <Input.TextArea autoSize={{ minRows: 3, maxRows: 6 }} maxLength={2000} value={description} placeholder="说明这个数据集提供什么数据" onChange={(event) => { setDescription(event.target.value); markDirty(); }} />
+        <Input.TextArea
+          autoSize={{ minRows: 3, maxRows: 6 }}
+          maxLength={2000}
+          value={description}
+          placeholder="说明这个数据集提供什么数据"
+          onChange={(event) => {
+            setDescription(event.target.value);
+            markDirty();
+          }}
+        />
       </div>
       <dl className="m-0 mt-5 grid grid-cols-[88px_minmax(0,1fr)] gap-x-4 gap-y-3 border-t border-[#eef0f2] pt-4">
-        <dt className="text-[#667085]">Dataset：</dt><dd className="m-0 text-[#344054]">{context?.dataset ? `#${context.dataset.datasetId}` : '尚未创建'}</dd>
-        <dt className="text-[#667085]">当前版本：</dt><dd className="m-0 text-[#344054]">{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存'}</dd>
-        <dt className="text-[#667085]">查询 SQL：</dt><dd className="m-0 text-[#344054]">{sqlText.trim() ? '已配置' : '未填写'}</dd>
-        <dt className="text-[#667085]">字段：</dt><dd className="m-0 text-[#344054]">{fields.length} 个</dd>
+        <dt className="text-[#667085]">Dataset：</dt>
+        <dd className="m-0 text-[#344054]">
+          {context?.dataset ? `#${context.dataset.datasetId}` : '尚未创建'}
+        </dd>
+        <dt className="text-[#667085]">当前版本：</dt>
+        <dd className="m-0 text-[#344054]">
+          {currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存'}
+        </dd>
+        <dt className="text-[#667085]">查询 SQL：</dt>
+        <dd className="m-0 text-[#344054]">{sqlText.trim() ? '已配置' : '未填写'}</dd>
+        <dt className="text-[#667085]">字段：</dt>
+        <dd className="m-0 text-[#344054]">{fields.length} 个</dd>
       </dl>
     </div>
   );
+
   const fieldsPanel = (
     <div>
-      <div className="mb-3 text-[11px] leading-5 text-[#98a2b3]">字段来自当前 SQL 输出结构。修改 SQL 后请重新发现字段，再调整显示名称、角色和描述。</div>
-      <Table<DevelopmentDatasetFieldDraft> size="small" pagination={false} rowKey={(record) => record.fieldId || record.physicalName} dataSource={fields} columns={columns} scroll={{ x: 730 }} locale={{ emptyText: '运行“发现字段”后生成字段结构' }} />
+      <div className="mb-3 text-[11px] leading-5 text-[#98a2b3]">
+        字段来自当前 SQL 输出结构。运行查询后会同步字段，再调整显示名称、角色和描述。
+      </div>
+      <Table<DevelopmentDatasetFieldDraft>
+        size="small"
+        pagination={false}
+        rowKey={(record) => record.fieldId || record.physicalName}
+        dataSource={fields}
+        columns={columns}
+        scroll={{ x: 730 }}
+        locale={{ emptyText: '运行查询后生成字段结构' }}
+      />
     </div>
   );
+
   const versionsPanel = (
     <div className="space-y-2 text-[12px]">
       {versions.length ? versions.map((version, index) => (
-        <div key={version.versionId} className="flex items-center gap-2 rounded-[3px] border border-[#eaecf0] px-2.5 py-2">
+        <div
+          key={version.versionId}
+          className="flex items-center gap-2 rounded-[3px] border border-[#eaecf0] px-2.5 py-2"
+        >
           <FileStack size={14} className="shrink-0 text-[#667085]" strokeWidth={1.7} />
-          <div className="min-w-0 flex-1"><div className="flex items-center gap-2"><span className="font-medium text-[#344054]">DV{version.versionNo}</span>{index === 0 ? <span className="rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[10px] text-[#667085]">当前</span> : null}</div><div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">{version.sourceType === 'SQL_QUERY' ? '独立 SQL' : version.sourceType} · {formatTime(version.createTime)}</div></div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-[#344054]">DV{version.versionNo}</span>
+              {index === 0 ? (
+                <span className="rounded bg-[#f2f4f7] px-1.5 py-0.5 text-[10px] text-[#667085]">
+                  当前
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">
+              {version.sourceType === 'SQL_QUERY' ? '独立 SQL' : version.sourceType}
+              {' · '}
+              {formatTime(version.createTime)}
+            </div>
+          </div>
         </div>
-      )) : <div className="py-8 text-center text-[11px] text-[#98a2b3]">暂无数据集版本</div>}
+      )) : (
+        <div className="py-8 text-center text-[11px] text-[#98a2b3]">暂无数据集版本</div>
+      )}
     </div>
   );
-  const panelContent: Record<RightPanelKey, ReactNode> = { properties: propertiesPanel, fields: fieldsPanel, versions: versionsPanel };
+
+  const panelContent: Record<RightPanelKey, ReactNode> = {
+    properties: propertiesPanel,
+    fields: fieldsPanel,
+    versions: versionsPanel,
+  };
 
   const handleResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!activePanel) return;
@@ -232,7 +533,10 @@ export default function DatasetNodeEditor({ node, onSaved, onDirtyChange }: Data
     setResizing(true);
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
-    const resize = (moveEvent: PointerEvent) => setPanelWidth(clampPanelWidth(startWidth + startX - moveEvent.clientX));
+
+    const resize = (moveEvent: PointerEvent) => {
+      setPanelWidth(clampPanelWidth(startWidth + startX - moveEvent.clientX));
+    };
     const finish = (upEvent: PointerEvent) => {
       const nextWidth = clampPanelWidth(startWidth + startX - upEvent.clientX);
       setPanelWidth(nextWidth);
@@ -244,52 +548,267 @@ export default function DatasetNodeEditor({ node, onSaved, onDirtyChange }: Data
       window.removeEventListener('pointerup', finish);
       window.removeEventListener('pointercancel', finish);
     };
+
     window.addEventListener('pointermove', resize);
     window.addEventListener('pointerup', finish);
     window.addEventListener('pointercancel', finish);
   };
 
-  if (loading) return <div className="flex min-h-0 flex-1 items-center justify-center bg-white"><Spin size="small" /></div>;
-  if (loadError || !context) return (
-    <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6"><div className="max-w-[520px] text-center"><div className="text-[14px] font-semibold text-[#344054]">Dataset Node 加载失败</div><div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">{loadError || '未返回有效编辑上下文'}</div><Button className="mt-4" size="small" icon={<RefreshCw size={13} />} onClick={() => void load()}>重新加载</Button></div></div>
-  );
-  const canPreview = Boolean(metadataContext.dataSourceId && sqlText.trim());
-  const canSave = canPreview && fields.length > 0 && dirty;
+  const handleResultResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const startY = event.clientY;
+    const startHeight = resultHeight;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    setResultResizing(true);
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+
+    const resize = (moveEvent: PointerEvent) => {
+      setResultHeight(clampResultHeight(startHeight + startY - moveEvent.clientY));
+    };
+    const finish = (upEvent: PointerEvent) => {
+      const nextHeight = clampResultHeight(startHeight + startY - upEvent.clientY);
+      setResultHeight(nextHeight);
+      setResultResizing(false);
+      window.localStorage.setItem(RESULT_HEIGHT_STORAGE_KEY, String(nextHeight));
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener('pointermove', resize);
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', finish);
+    };
+
+    window.addEventListener('pointermove', resize);
+    window.addEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', finish);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-white">
+        <Spin size="small" />
+      </div>
+    );
+  }
+
+  if (loadError || !context) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-white px-6">
+        <div className="max-w-[520px] text-center">
+          <div className="text-[14px] font-semibold text-[#344054]">Dataset Node 加载失败</div>
+          <div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">
+            {loadError || '未返回有效编辑上下文'}
+          </div>
+          <Button
+            className="mt-4"
+            size="small"
+            icon={<RefreshCw size={13} />}
+            onClick={() => void load()}
+          >
+            重新加载
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const canRun = Boolean(metadataContext.dataSourceId && sqlText.trim());
+  const canSave = canRun && fields.length > 0 && dirty;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-[#e8e9ec] bg-white px-2">
         <div className="flex shrink-0 items-center gap-0.5">
-          <ToolbarButton title={previewing ? '正在发现字段' : '发现字段'} disabled={!canPreview || previewing} onClick={() => void preview()}>{previewing ? <LoaderCircle size={15} className="animate-spin" /> : <Play size={15} strokeWidth={1.8} />}</ToolbarButton>
+          <ToolbarButton
+            title={running ? '正在运行查询' : '运行查询'}
+            disabled={!canRun || running}
+            onClick={() => void runQuery()}
+          >
+            {running ? (
+              <LoaderCircle size={15} className="animate-spin" />
+            ) : (
+              <Play size={15} strokeWidth={1.8} />
+            )}
+          </ToolbarButton>
           <ToolbarDivider />
-          <ToolbarButton title="保存数据集版本" disabled={!canSave || saving} onClick={() => void save()}>{saving ? <LoaderCircle size={15} className="animate-spin" /> : <Save size={15} strokeWidth={1.8} />}</ToolbarButton>
+          <ToolbarButton
+            title="保存数据集版本"
+            disabled={!canSave || saving}
+            onClick={() => void save()}
+          >
+            {saving ? (
+              <LoaderCircle size={15} className="animate-spin" />
+            ) : (
+              <Save size={15} strokeWidth={1.8} />
+            )}
+          </ToolbarButton>
           <ToolbarDivider />
-          <ToolbarButton title="撤销" onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}><Undo2 size={15} strokeWidth={1.8} /></ToolbarButton>
-          <ToolbarButton title="重做" onClick={() => execute('redo', 'SQL 编辑器尚未就绪')}><Redo2 size={15} strokeWidth={1.8} /></ToolbarButton>
-          <ToolbarButton title="查找" onClick={() => execute('find', 'SQL 编辑器尚未就绪')}><Search size={15} strokeWidth={1.8} /></ToolbarButton>
+          <ToolbarButton title="撤销" onClick={() => execute('undo', 'SQL 编辑器尚未就绪')}>
+            <Undo2 size={15} strokeWidth={1.8} />
+          </ToolbarButton>
+          <ToolbarButton title="重做" onClick={() => execute('redo', 'SQL 编辑器尚未就绪')}>
+            <Redo2 size={15} strokeWidth={1.8} />
+          </ToolbarButton>
+          <ToolbarButton title="查找" onClick={() => execute('find', 'SQL 编辑器尚未就绪')}>
+            <Search size={15} strokeWidth={1.8} />
+          </ToolbarButton>
           <ToolbarDivider />
-          <ToolbarButton title="格式化 SQL" onClick={() => execute('format', 'SQL 编辑器尚未就绪')}><Wand2 size={15} strokeWidth={1.8} /></ToolbarButton>
-          <ToolbarButton title="触发智能提示" onClick={() => execute('suggest', 'SQL 编辑器尚未就绪')}><Sparkles size={15} strokeWidth={1.8} /></ToolbarButton>
+          <ToolbarButton title="格式化 SQL" onClick={() => execute('format', 'SQL 编辑器尚未就绪')}>
+            <Wand2 size={15} strokeWidth={1.8} />
+          </ToolbarButton>
+          <ToolbarButton title="触发智能提示" onClick={() => execute('suggest', 'SQL 编辑器尚未就绪')}>
+            <Sparkles size={15} strokeWidth={1.8} />
+          </ToolbarButton>
         </div>
         <SqlMetadataContextToolbar nodeId={node.id} />
       </div>
+
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <section className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-          <div className="min-h-0 flex-1"><SqlMonacoEditor id={String(node.id)} value={sqlText} onChange={changeSql} onPositionChange={setPosition} /></div>
+          <div className="min-h-[220px] flex-1">
+            <SqlMonacoEditor
+              id={String(node.id)}
+              value={sqlText}
+              onChange={changeSql}
+              onPositionChange={setPosition}
+            />
+          </div>
+
           <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-2.5 text-[10px] text-[#7b808a]">
-            <div className="flex min-w-0 items-center gap-3"><span className="font-medium text-[#667085]">DATASET</span><span className="truncate">{node.name}</span>{dirty ? <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]"><span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />未保存</span> : null}<span className="max-w-[280px] truncate text-[#667085]" title={metadataPath || '未选择数据源'}>{metadataPath || '未选择数据源'}</span></div>
-            <div className="flex shrink-0 items-center gap-3"><span>{fields.length ? `${fields.length} 个字段` : '字段待发现'}</span><span>{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存版本'}</span>{position.selectionLength > 0 ? <span>已选择 {position.selectionLength} 字符</span> : null}<span>Ln {position.lineNumber}, Col {position.column}</span></div>
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="font-medium text-[#667085]">DATASET</span>
+              <span className="truncate">{node.name}</span>
+              {dirty ? (
+                <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#667085]" />
+                  未保存
+                </span>
+              ) : null}
+              <span
+                className="max-w-[280px] truncate text-[#667085]"
+                title={metadataPath || '未选择数据源'}
+              >
+                {metadataPath || '未选择数据源'}
+              </span>
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+              <span>{fields.length ? `${fields.length} 个字段` : '运行查询以发现字段'}</span>
+              <span>{currentVersion ? `DV${currentVersion.versionNo}` : '尚未保存版本'}</span>
+              {position.selectionLength > 0 ? (
+                <span>已选择 {position.selectionLength} 字符</span>
+              ) : null}
+              <span>Ln {position.lineNumber}, Col {position.column}</span>
+            </div>
+          </div>
+
+          <div
+            className={[
+              'relative shrink-0 bg-white',
+              resultResizing ? 'transition-none' : 'transition-[height] duration-200 ease-out',
+            ].join(' ')}
+            style={{ height: resultHeight }}
+          >
+            <div
+              role="separator"
+              aria-label="调整查询结果面板高度"
+              aria-orientation="horizontal"
+              onPointerDown={handleResultResizeStart}
+              className="group absolute inset-x-0 top-0 z-40 h-3 -translate-y-1/2 cursor-row-resize touch-none"
+            >
+              <div className="pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-[#e5e7eb] transition-[height,background-color] duration-150 group-hover:h-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:h-[2px] group-active:bg-[rgba(254,44,85,1)]" />
+            </div>
+            <div className="h-full overflow-hidden bg-white">
+              <SqlResultWorkspace result={queryResult} />
+            </div>
           </div>
         </section>
+
         <aside className="flex shrink-0 bg-white" style={BRAND_CSS_VARIABLES}>
-          <div className={['relative h-full shrink-0', resizing ? 'transition-none' : 'transition-[width] duration-200 ease-out'].join(' ')} style={{ width: activePanel ? panelWidth : 0 }}>
-            {activePanel ? <div role="separator" aria-label="调整右侧面板宽度" aria-orientation="vertical" onPointerDown={handleResizeStart} className="group absolute inset-y-0 left-0 z-30 w-3 -translate-x-1/2 cursor-col-resize touch-none"><div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e5e7eb] transition-[width,background-color] duration-150 group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:w-[2px] group-active:bg-[rgba(254,44,85,1)]" /></div> : null}
-            <div className="h-full overflow-hidden"><div className="flex h-full flex-col bg-white" style={{ width: panelWidth }}><div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4"><span className="text-[13px] font-semibold text-[#30323b]">{panelItems.find((item) => item.key === activePanel)?.label}</span><div className="flex items-center gap-1"><button type="button" title="刷新" onClick={() => { if (dirty) { message.warning('当前有未保存修改，请先保存'); return; } void load(); }} className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"><RefreshCw size={13} strokeWidth={1.8} />刷新</button><button type="button" title="关闭" aria-label="关闭右侧面板" onClick={() => setActivePanel(undefined)} className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"><X size={14} strokeWidth={1.8} /></button></div></div><div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">{activePanel ? panelContent[activePanel] : null}</div></div></div>
+          <div
+            className={[
+              'relative h-full shrink-0',
+              resizing ? 'transition-none' : 'transition-[width] duration-200 ease-out',
+            ].join(' ')}
+            style={{ width: activePanel ? panelWidth : 0 }}
+          >
+            {activePanel ? (
+              <div
+                role="separator"
+                aria-label="调整右侧面板宽度"
+                aria-orientation="vertical"
+                onPointerDown={handleResizeStart}
+                className="group absolute inset-y-0 left-0 z-30 w-3 -translate-x-1/2 cursor-col-resize touch-none"
+              >
+                <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[#e5e7eb] transition-[width,background-color] duration-150 group-hover:w-[2px] group-hover:bg-[rgba(254,44,85,.55)] group-active:w-[2px] group-active:bg-[rgba(254,44,85,1)]" />
+              </div>
+            ) : null}
+
+            <div className="h-full overflow-hidden">
+              <div className="flex h-full flex-col bg-white" style={{ width: panelWidth }}>
+                <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4">
+                  <span className="text-[13px] font-semibold text-[#30323b]">
+                    {panelItems.find((item) => item.key === activePanel)?.label}
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      title="刷新"
+                      onClick={() => {
+                        if (dirty) {
+                          message.warning('当前有未保存修改，请先保存');
+                          return;
+                        }
+                        void load();
+                      }}
+                      className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
+                    >
+                      <RefreshCw size={13} strokeWidth={1.8} />
+                      刷新
+                    </button>
+                    <button
+                      type="button"
+                      title="关闭"
+                      aria-label="关闭右侧面板"
+                      onClick={() => setActivePanel(undefined)}
+                      className="flex h-7 w-7 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"
+                    >
+                      <X size={14} strokeWidth={1.8} />
+                    </button>
+                  </div>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+                  {activePanel ? panelContent[activePanel] : null}
+                </div>
+              </div>
+            </div>
           </div>
+
           <div className="flex h-full w-9 shrink-0 flex-col border-l border-[#e5e7eb] bg-white">
             {panelItems.map((item, index) => {
               const active = activePanel === item.key;
-              return <button key={item.key} type="button" title={item.label} aria-label={`${active ? '收起' : '展开'}${item.label}`} aria-expanded={active} onClick={() => setActivePanel((current) => current === item.key ? undefined : item.key)} className={['relative flex min-h-[72px] w-9 shrink-0 items-center justify-center border-b border-[#e5e7eb] py-3 text-[12px] leading-5 transition-[color,background-color,opacity]', '[writing-mode:vertical-rl] [letter-spacing:3px]', index === 0 ? 'border-t' : '', active ? 'text-[var(--yak-brand-color)] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[var(--yak-brand-color)]' : 'text-[#475467] opacity-70 hover:bg-[#f7f8fa] hover:text-[#344054] hover:opacity-100'].join(' ')}>{item.label}</button>;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  title={item.label}
+                  aria-label={`${active ? '收起' : '展开'}${item.label}`}
+                  aria-expanded={active}
+                  onClick={() => setActivePanel((current) =>
+                    current === item.key ? undefined : item.key,
+                  )}
+                  className={[
+                    'relative flex min-h-[72px] w-9 shrink-0 items-center justify-center border-b border-[#e5e7eb] py-3 text-[12px] leading-5 transition-[color,background-color,opacity]',
+                    '[writing-mode:vertical-rl] [letter-spacing:3px]',
+                    index === 0 ? 'border-t' : '',
+                    active
+                      ? 'text-[var(--yak-brand-color)] opacity-100 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-[var(--yak-brand-color)]'
+                      : 'text-[#475467] opacity-70 hover:bg-[#f7f8fa] hover:text-[#344054] hover:opacity-100',
+                  ].join(' ')}
+                >
+                  {item.label}
+                </button>
+              );
             })}
           </div>
         </aside>

--- a/yak-ops-ui/src/pages/data-development/dataset-service.ts
+++ b/yak-ops-ui/src/pages/data-development/dataset-service.ts
@@ -2,7 +2,7 @@ import type { ApiResponse } from '@/services/http/response';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 
-import type { DevelopmentId } from './types';
+import type { DevelopmentId, DevelopmentSqlResultColumn } from './types';
 
 const NODE_API = '/api/v1/data-development/nodes';
 
@@ -69,6 +69,15 @@ export interface DevelopmentDatasetNodeContext {
   dataset?: DevelopmentDatasetNodeAsset | null;
 }
 
+export interface DevelopmentDatasetQueryResult {
+  fields: DevelopmentDatasetFieldDraft[];
+  columns: DevelopmentSqlResultColumn[];
+  rows: unknown[][];
+  returnedRows: number;
+  truncated: boolean;
+  durationMs: number;
+}
+
 export interface SaveDevelopmentDatasetNodePayload {
   dataSourceId: DevelopmentId;
   sql: string;
@@ -100,6 +109,18 @@ export const previewDevelopmentDatasetNode = async (
     { dataSourceId, sql },
   ),
   '发现 Dataset Node 字段失败',
+);
+
+export const runDevelopmentDatasetNode = async (
+  nodeId: DevelopmentId,
+  dataSourceId: DevelopmentId,
+  sql: string,
+): Promise<DevelopmentDatasetQueryResult> => unwrap(
+  await HttpUtils.post<DevelopmentDatasetQueryResult>(
+    `${NODE_API}/${nodeId}/dataset/query`,
+    { dataSourceId, sql },
+  ),
+  '运行 Dataset Node 查询失败',
 );
 
 export const saveDevelopmentDatasetNode = async (


### PR DESCRIPTION
## 背景

Dataset Node 目前虽然也是直接编写 SQL，但顶部执行动作仍叫“发现字段”，只拿 SQL 的输出结构，不展示真实 SQL Result。这样 Dataset、Data Service、SQL Node 三种 SQL 编辑体验并不一致。

这次将 Dataset Node 对齐到 Data Service / SQL Node 的查询体验：运行 SQL 后直接看到真实结果表格，同时继续从同一次查询结果同步 Dataset 字段契约。

## 主要改动

- Dataset 顶部“发现字段”调整为“运行查询”。
- 新增 Dataset query preview 接口，执行 Dataset 自有只读 SQL，返回：
  - Dataset 字段契约；
  - SQL 列元数据（name / label / typeName / jdbcType / nullable）；
  - rows；
  - returnedRows；
  - truncated；
  - durationMs。
- 查询预览最多返回 1000 行、默认超时 30 秒；继续复用现有 `DatasetSqlSafety` 只读 SQL 校验。
- 前端复用现有 `SqlResultWorkspace`，不再为 Dataset 单独实现结果表格。
- SQL 查询成功后，同时同步 Dataset 字段；已经维护过的 displayName / description / defaultRole / fieldId 会尽量保留。
- SQL 或数据源变化后清空旧查询结果，避免展示过期数据。

## 结果区拖拽

Dataset Result 区与 SQL / Data Service 保持一致：

- 默认高度 280px；
- 最小 160px，最大 520px；
- 可拖动 SQL 编辑器和 Result 之间的横向分隔线调整高度；
- hover / active 使用品牌红提示；
- 拖拽时使用 `row-resize` 并关闭文本选择；
- 复用 `yak-data-development.bottom-panel-height`，SQL、Data Service、Dataset 三类节点共享最近一次结果区高度。

## 兼容性

- 原 `/dataset/preview` 字段发现接口保留，避免影响已有调用方。
- 新增 `/dataset/query` 专门服务 Dataset 编辑器的“执行 + Result”体验。
- Dataset 保存、版本冻结、字段角色与描述维护逻辑保持不变。
- 不涉及数据库迁移。