### PR TITLE
refactor(workflow): simplify schedule configuration flow

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
@@ -89,13 +89,15 @@ public class WorkflowDefinitionController {
   @Operation(summary = "发布或重新启用工作流版本")
   @PostMapping("/{id}/online")
   public Result<WorkflowDefinitionVO> online(@PathVariable("id") String id) {
-    return Result.success(definitionService.online(id));
+    WorkflowDefinitionVO workflow = definitionService.online(id);
+    scheduleGuard.activateConfiguredSchedules(id);
+    return Result.success(workflow);
   }
 
   @Operation(summary = "停用工作流正式运行入口")
   @PostMapping("/{id}/offline")
   public Result<WorkflowDefinitionVO> offline(@PathVariable("id") String id) {
-    scheduleGuard.ensureCanOffline(id);
+    scheduleGuard.deactivateConfiguredSchedules(id);
     return Result.success(definitionService.offline(id));
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuard.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuard.java
@@ -1,32 +1,54 @@
 package io.yak.ops.business.workflow.service;
 
 import io.yak.ops.business.workflow.dao.WorkflowScheduleDao;
+import java.time.Instant;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 
-/** 工作流定义生命周期与调度生命周期之间的约束。 */
+/** 工作流定义上下线与调度生命周期之间的联动。 */
 @Component
 public class WorkflowDefinitionScheduleGuard {
   private final ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider;
+  private final ObjectProvider<WorkflowScheduleLifecycle> scheduleLifecycleProvider;
 
-  public WorkflowDefinitionScheduleGuard(ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider) {
+  public WorkflowDefinitionScheduleGuard(
+      ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider,
+      ObjectProvider<WorkflowScheduleLifecycle> scheduleLifecycleProvider) {
     this.scheduleDaoProvider = scheduleDaoProvider;
+    this.scheduleLifecycleProvider = scheduleLifecycleProvider;
   }
 
   /**
-   * 工作流下线前必须先停用所有在线调度。
-   * database-disabled 的 focused development/test 环境没有调度 DAO，此时保持原有轻量行为。
+   * 工作流上线后自动启用已经保存的有效调度。
+   * database-disabled 的 focused development/test 环境没有调度组件，此时保持轻量行为。
    */
-  public void ensureCanOffline(String workflowId) {
+  public void activateConfiguredSchedules(String workflowId) {
+    String id = requireWorkflowId(workflowId);
+    WorkflowScheduleDao scheduleDao = scheduleDaoProvider.getIfAvailable();
+    WorkflowScheduleLifecycle lifecycle = scheduleLifecycleProvider.getIfAvailable();
+    if (scheduleDao == null || lifecycle == null) return;
+
+    Instant now = Instant.now();
+    scheduleDao.selectSchedules(id, "OFFLINE").stream()
+        .filter(schedule -> schedule.getEndTime() == null || schedule.getEndTime().isAfter(now))
+        .forEach(schedule -> lifecycle.online(schedule.getId()));
+  }
+
+  /** 工作流下线前自动停用所有在线调度，避免继续产生新的计划实例。 */
+  public void deactivateConfiguredSchedules(String workflowId) {
+    String id = requireWorkflowId(workflowId);
+    WorkflowScheduleDao scheduleDao = scheduleDaoProvider.getIfAvailable();
+    WorkflowScheduleLifecycle lifecycle = scheduleLifecycleProvider.getIfAvailable();
+    if (scheduleDao == null || lifecycle == null) return;
+
+    scheduleDao.selectSchedules(id, "ONLINE")
+        .forEach(schedule -> lifecycle.offline(schedule.getId()));
+  }
+
+  private String requireWorkflowId(String workflowId) {
     if (workflowId == null || workflowId.isBlank()) {
       throw new IllegalArgumentException("工作流 ID 不能为空");
     }
-
-    WorkflowScheduleDao scheduleDao = scheduleDaoProvider.getIfAvailable();
-    if (scheduleDao == null) return;
-
-    if (!scheduleDao.selectSchedules(workflowId.trim(), "ONLINE").isEmpty()) {
-      throw new IllegalStateException("工作流存在已启用调度，请先停用调度后再下线工作流");
-    }
+    return workflowId.trim();
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuardTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/service/WorkflowDefinitionScheduleGuardTest.java
@@ -1,11 +1,14 @@
 package io.yak.ops.business.workflow.service;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.workflow.dao.WorkflowScheduleDao;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,42 +21,69 @@ import org.springframework.beans.factory.ObjectProvider;
 class WorkflowDefinitionScheduleGuardTest {
 
   @Mock private ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider;
+  @Mock private ObjectProvider<WorkflowScheduleLifecycle> scheduleLifecycleProvider;
   @Mock private WorkflowScheduleDao scheduleDao;
+  @Mock private WorkflowScheduleLifecycle scheduleLifecycle;
 
   private WorkflowDefinitionScheduleGuard guard;
 
   @BeforeEach
   void setUp() {
-    guard = new WorkflowDefinitionScheduleGuard(scheduleDaoProvider);
+    guard = new WorkflowDefinitionScheduleGuard(scheduleDaoProvider, scheduleLifecycleProvider);
   }
 
   @Test
-  void shouldAllowOfflineWhenSchedulePersistenceIsUnavailable() {
+  void shouldKeepLightweightBehaviorWhenScheduleComponentsAreUnavailable() {
     when(scheduleDaoProvider.getIfAvailable()).thenReturn(null);
 
-    assertThatCode(() -> guard.ensureCanOffline("workflow-1")).doesNotThrowAnyException();
+    assertThatCode(() -> guard.activateConfiguredSchedules("workflow-1"))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> guard.deactivateConfiguredSchedules("workflow-1"))
+        .doesNotThrowAnyException();
   }
 
   @Test
-  void shouldAllowOfflineWhenNoOnlineScheduleExists() {
+  void shouldActivateSavedSchedulesWhenWorkflowGoesOnline() {
+    WorkflowSchedulePO schedule = schedule("schedule-1", "OFFLINE");
     when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
-    when(scheduleDao.selectSchedules("workflow-1", "ONLINE")).thenReturn(List.of());
+    when(scheduleLifecycleProvider.getIfAvailable()).thenReturn(scheduleLifecycle);
+    when(scheduleDao.selectSchedules("workflow-1", "OFFLINE")).thenReturn(List.of(schedule));
 
-    assertThatCode(() -> guard.ensureCanOffline("workflow-1")).doesNotThrowAnyException();
+    guard.activateConfiguredSchedules("workflow-1");
+
+    verify(scheduleLifecycle).online("schedule-1");
   }
 
   @Test
-  void shouldRejectOfflineWhenOnlineScheduleExists() {
-    WorkflowSchedulePO schedule = new WorkflowSchedulePO();
-    schedule.setId("schedule-1");
-    schedule.setWorkflowId("workflow-1");
-    schedule.setStatus("ONLINE");
-
+  void shouldSkipExpiredScheduleWhenWorkflowGoesOnline() {
+    WorkflowSchedulePO schedule = schedule("schedule-expired", "OFFLINE");
+    schedule.setEndTime(Instant.now().minus(1, ChronoUnit.DAYS));
     when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
+    when(scheduleLifecycleProvider.getIfAvailable()).thenReturn(scheduleLifecycle);
+    when(scheduleDao.selectSchedules("workflow-1", "OFFLINE")).thenReturn(List.of(schedule));
+
+    guard.activateConfiguredSchedules("workflow-1");
+
+    verifyNoInteractions(scheduleLifecycle);
+  }
+
+  @Test
+  void shouldDeactivateOnlineSchedulesBeforeWorkflowGoesOffline() {
+    WorkflowSchedulePO schedule = schedule("schedule-1", "ONLINE");
+    when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
+    when(scheduleLifecycleProvider.getIfAvailable()).thenReturn(scheduleLifecycle);
     when(scheduleDao.selectSchedules("workflow-1", "ONLINE")).thenReturn(List.of(schedule));
 
-    assertThatThrownBy(() -> guard.ensureCanOffline("workflow-1"))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("请先停用调度");
+    guard.deactivateConfiguredSchedules("workflow-1");
+
+    verify(scheduleLifecycle).offline("schedule-1");
+  }
+
+  private WorkflowSchedulePO schedule(String id, String status) {
+    WorkflowSchedulePO schedule = new WorkflowSchedulePO();
+    schedule.setId(id);
+    schedule.setWorkflowId("workflow-1");
+    schedule.setStatus(status);
+    return schedule;
   }
 }

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -73,7 +73,7 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'data-development-task', path: '/data-development/task/:id', title: '开发任务配置', component: './data-development/task', hidden: true, parentId: 'data-development' },
   { id: 'workflow-definition', mode: 'public', path: '/workflow/definitions', title: '工作流定义', component: './workflow/management', iconKey: 'workflow', menuGroup: 'workflow', order: 10 },
   { id: 'workflow-definition-editor', path: '/workflow/definition/:id', title: '工作流配置', component: './workflow/definition', hidden: true, parentId: 'workflow-definition' },
-  { id: 'workflow-schedules', path: '/workflow/schedules', title: '调度配置', component: './workflow/schedules', hidden: true, parentId: 'workflow-definition' },
+  { id: 'workflow-schedules', path: '/workflow/definition/:id/schedule', title: '调度配置', component: './workflow/schedules', hidden: true, parentId: 'workflow-definition' },
   { id: 'workflow-instances', mode: 'public', path: '/workflow/instances', title: '工作流实例', component: './workflow/instances', iconKey: 'instance', menuGroup: 'workflow', order: 30 },
   { id: 'workflow-instance-detail', path: '/workflow/instances/:executionId', title: '工作流实例详情', component: './workflow/instances/detail', hidden: true, parentId: 'workflow-instances' },
   { id: 'resource-management', mode: 'one', permission: 'resource:view', path: '/resource-management', title: '文件资源', component: './resource-management', iconKey: 'database', menuGroup: 'resources', order: 10 },

--- a/yak-ops-ui/src/pages/workflow/management/WorkflowDefinitionList.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/WorkflowDefinitionList.tsx
@@ -10,7 +10,6 @@ import {
   type WorkflowDefinition,
   type WorkflowDefinitionStatus,
 } from '@/services/workflow/definitions';
-import { listWorkflowSchedules } from '@/services/workflow/schedules';
 import {
   CalendarOutlined,
   CloudDownloadOutlined,
@@ -344,7 +343,9 @@ export default function WorkflowDefinitionList() {
   };
 
   const goToSchedules = (record: WorkflowDefinition) => {
-    history.push(`/workflow/schedules?workflowId=${encodeURIComponent(record.id)}`);
+    history.push(
+      `/workflow/definition/${encodeURIComponent(record.id)}/schedule`,
+    );
   };
 
   const handleDelete = (record: WorkflowDefinition) => {
@@ -423,7 +424,7 @@ export default function WorkflowDefinitionList() {
     Modal.confirm({
       centered: true,
       title: '工作流上线',
-      content: '上线后工作流可以被手动运行或调度触发，确认上线吗？',
+      content: '上线后工作流可以被手动运行，已保存的调度将同步启用。确认上线吗？',
       okText: '确认',
       cancelText: '取消',
       async onOk() {
@@ -436,38 +437,16 @@ export default function WorkflowDefinitionList() {
     });
   };
 
-  const confirmOffline = async (record: WorkflowDefinition) => {
+  const confirmOffline = (record: WorkflowDefinition) => {
     if (isActiveRuntime(record.latestExecutionStatus)) {
       message.warning('工作流存在活动执行，请先暂停或等待执行结束后再下线');
-      return;
-    }
-
-    try {
-      const onlineSchedules = await listWorkflowSchedules({
-        workflowId: record.id,
-        status: 'ONLINE',
-      });
-      if (onlineSchedules.length > 0) {
-        Modal.warning({
-          centered: true,
-          title: '请先停用工作流调度',
-          content: `当前工作流仍有 ${onlineSchedules.length} 个已启用调度。停用全部调度后才能下线工作流。`,
-          okText: '前往调度配置',
-          onOk: () => goToSchedules(record),
-        });
-        return;
-      }
-    } catch (error) {
-      message.error(
-        error instanceof Error ? error.message : '检查工作流调度状态失败',
-      );
       return;
     }
 
     Modal.confirm({
       centered: true,
       title: '工作流下线',
-      content: '下线后工作流将不能被手动运行或调度触发，确认下线吗？',
+      content: '下线后工作流将不能被手动运行或调度触发，已启用调度会同步停用。确认下线吗？',
       okText: '确认',
       cancelText: '取消',
       async onOk() {
@@ -493,7 +472,7 @@ export default function WorkflowDefinitionList() {
         confirmOnline(record);
         break;
       case 'offline':
-        void confirmOffline(record);
+        confirmOffline(record);
         break;
       case 'delete':
         handleDelete(record);
@@ -926,7 +905,7 @@ export default function WorkflowDefinitionList() {
               <span className="mr-2 text-[14px] text-[#faad14]">▲</span>
               <span className="font-medium text-[#344054]">【提示】</span>
               <span>
-                工作流完成节点编排并上线后即可运行或启用调度；存在活动执行或已启用调度时不可直接下线。
+                工作流可先完成节点编排与调度配置，再统一上线；上线会自动启用调度，下线会自动停用调度。
               </span>
             </div>
           </div>

--- a/yak-ops-ui/src/pages/workflow/schedules/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/index.tsx
@@ -1,23 +1,85 @@
-import { listWorkflowDefinitions, type WorkflowDefinition } from '@/services/workflow/definitions';
+import { getWorkflowDefinition, type WorkflowDefinition } from '@/services/workflow/definitions';
 import {
+  createWorkflowSchedule,
   deleteWorkflowSchedule,
   listWorkflowSchedules,
-  offlineWorkflowSchedule,
-  onlineWorkflowSchedule,
+  updateWorkflowSchedule,
   type WorkflowBackfill,
   type WorkflowSchedule,
+  type WorkflowScheduleExecutionStrategy,
+  type WorkflowScheduleMisfireStrategy,
 } from '@/services/workflow/schedules';
-import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
-import { history } from '@umijs/max';
-import { Button, ConfigProvider, Input, Modal, Select, Table, Tooltip, message } from 'antd';
-import { ArrowLeft, CalendarClock, DatabaseBackup, History, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { BRAND_THEME } from '@/styles/brand';
+import { history, useLocation, useParams } from '@umijs/max';
+import {
+  Button,
+  ConfigProvider,
+  DatePicker,
+  Empty,
+  Form,
+  Input,
+  Modal,
+  Select,
+  Spin,
+  Tooltip,
+  message,
+} from 'antd';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+import {
+  ArrowLeft,
+  CalendarClock,
+  DatabaseBackup,
+  History,
+  ListTree,
+  Save,
+  Trash2,
+} from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import BackfillDrawer from './BackfillDrawer';
 import BackfillHistoryDrawer from './BackfillHistoryDrawer';
-import ScheduleEditorDrawer from './ScheduleEditorDrawer';
 import TriggerLedgerDrawer from './TriggerLedgerDrawer';
 
-type StatusFilter = 'ALL' | 'ONLINE' | 'OFFLINE';
+interface FormValues {
+  name: string;
+  cronExpression: string;
+  timezone: string;
+  effectiveRange?: [Dayjs, Dayjs];
+  executionStrategy: WorkflowScheduleExecutionStrategy;
+  misfireStrategy: WorkflowScheduleMisfireStrategy;
+  inputJson: string;
+}
+
+const SECTION_ITEMS = [
+  { key: 'schedule-basic', label: '调度设置' },
+  { key: 'schedule-strategy', label: '运行策略' },
+  { key: 'schedule-advanced', label: '高级配置' },
+] as const;
+
+type SectionKey = (typeof SECTION_ITEMS)[number]['key'];
+
+const LAST_SECTION_KEY = SECTION_ITEMS[SECTION_ITEMS.length - 1].key;
+const SCROLL_BOTTOM_THRESHOLD = 12;
+const SECTION_TOP_OFFSET = 24;
+const LOCATE_LOCK_DURATION = 650;
+
+const CRON_PRESETS = [
+  { label: '每天 02:00', value: '0 0 2 * * ?' },
+  { label: '每小时', value: '0 0 * * * ?' },
+  { label: '每 10 分钟', value: '0 0/10 * * * ?' },
+] as const;
+
+const WORKFLOW_STATUS_LABEL: Record<string, string> = {
+  DRAFT: '草稿',
+  ONLINE: '已上线',
+  OFFLINE: '已下线',
+};
 
 const formatTime = (value?: string) => {
   if (!value) return '-';
@@ -25,364 +87,605 @@ const formatTime = (value?: string) => {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 };
 
-const STRATEGY_LABEL: Record<string, string> = {
-  SERIAL_WAIT: '串行等待',
-  SERIAL_DISCARD: '串行跳过',
-  PARALLEL: '并行',
-};
+interface SectionNavigatorProps {
+  activeKey: SectionKey;
+  onSelect: (key: SectionKey) => void;
+}
 
-const WorkflowSchedulesPage = () => {
-  const scopedWorkflowId = useMemo(() => {
-    const params = new URLSearchParams(history.location.search);
-    return params.get('workflowId') || undefined;
-  }, []);
-  const scoped = Boolean(scopedWorkflowId);
+function SectionNavigator({ activeKey, onSelect }: SectionNavigatorProps) {
+  return (
+    <nav aria-label="调度配置区块定位" className="rounded-xl bg-white px-3 py-4">
+      <div className="mb-3 px-2 text-[12px] font-semibold text-[#344054]">
+        快速定位
+      </div>
+      <div className="relative">
+        <span
+          aria-hidden
+          className="absolute bottom-4 left-[13px] top-4 w-px bg-[#e4e7ec]"
+        />
+        <div className="space-y-1">
+          {SECTION_ITEMS.map((item) => {
+            const active = activeKey === item.key;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                aria-current={active ? 'location' : undefined}
+                className={[
+                  'group relative flex w-full cursor-pointer items-center gap-3 rounded-lg border-0 px-2 py-2 text-left transition-colors',
+                  active
+                    ? 'bg-[rgba(254,44,85,0.08)]'
+                    : 'bg-transparent hover:bg-[#f7f8fa]',
+                ].join(' ')}
+                onClick={() => onSelect(item.key)}
+              >
+                <span
+                  aria-hidden
+                  className={[
+                    'relative z-10 h-[11px] w-[11px] shrink-0 rounded-full border transition-all duration-200',
+                    active
+                      ? 'border-[var(--yak-brand-color)] bg-[var(--yak-brand-color)] shadow-[0_0_0_3px_rgba(254,44,85,0.12)]'
+                      : 'border-[#d0d5dd] bg-[#98a2b3] group-hover:border-[#98a2b3]',
+                  ].join(' ')}
+                />
+                <span
+                  className={[
+                    'text-[12px] leading-5 transition-colors',
+                    active
+                      ? 'font-semibold text-[var(--yak-brand-color)]'
+                      : 'font-normal text-[#667085] group-hover:text-[#344054]',
+                  ].join(' ')}
+                >
+                  {item.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}
 
-  const [definitions, setDefinitions] = useState<WorkflowDefinition[]>([]);
-  const [schedules, setSchedules] = useState<WorkflowSchedule[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [keyword, setKeyword] = useState('');
-  const [workflowId, setWorkflowId] = useState<string | undefined>(() => scopedWorkflowId);
-  const [status, setStatus] = useState<StatusFilter>('ALL');
-  const [editorOpen, setEditorOpen] = useState(false);
-  const [editing, setEditing] = useState<WorkflowSchedule>();
-  const [ledgerOpen, setLedgerOpen] = useState(false);
-  const [ledgerSchedule, setLedgerSchedule] = useState<WorkflowSchedule>();
-  const [ledgerBackfill, setLedgerBackfill] = useState<WorkflowBackfill>();
-  const [backfillOpen, setBackfillOpen] = useState(false);
-  const [backfillSchedule, setBackfillSchedule] = useState<WorkflowSchedule>();
-  const [backfillHistoryOpen, setBackfillHistoryOpen] = useState(false);
+function SectionCard({
+  id,
+  title,
+  description,
+  children,
+}: {
+  id: SectionKey;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="overflow-hidden rounded-xl border border-[#eaecf0] bg-white">
+      <div className="border-b border-[#f0f2f5] px-6 py-4">
+        <div className="text-[14px] font-semibold text-[#161823]">{title}</div>
+        <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">{description}</div>
+      </div>
+      <div className="px-6 py-5">{children}</div>
+    </section>
+  );
+}
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [workflowData, scheduleData] = await Promise.all([
-        listWorkflowDefinitions(),
-        listWorkflowSchedules(scopedWorkflowId ? { workflowId: scopedWorkflowId } : undefined),
-      ]);
-      setDefinitions(workflowData || []);
-      setSchedules(scheduleData || []);
-    } catch (error) {
-      message.error(error instanceof Error ? error.message : '调度数据加载失败');
-    } finally {
-      setLoading(false);
-    }
-  }, [scopedWorkflowId]);
+export default function WorkflowScheduleConfigPage() {
+  const location = useLocation();
+  const routeParams = useParams<{ id?: string }>();
+  const pageRootRef = useRef<HTMLDivElement>(null);
+  const locatingSectionRef = useRef<SectionKey | null>(null);
+  const locateTimerRef = useRef<number>();
+  const [form] = Form.useForm<FormValues>();
 
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  const workflowMap = useMemo(
-    () => new Map(definitions.map((item) => [item.id, item])),
-    [definitions],
+  const workflowId = useMemo(
+    () =>
+      routeParams.id ||
+      new URLSearchParams(location.search).get('workflowId') ||
+      '',
+    [location.search, routeParams.id],
   );
 
-  const scopedWorkflow = scopedWorkflowId
-    ? workflowMap.get(scopedWorkflowId)
-    : undefined;
+  const [workflow, setWorkflow] = useState<WorkflowDefinition>();
+  const [schedules, setSchedules] = useState<WorkflowSchedule[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [activeSection, setActiveSection] = useState<SectionKey>('schedule-basic');
+  const [ledgerOpen, setLedgerOpen] = useState(false);
+  const [ledgerBackfill, setLedgerBackfill] = useState<WorkflowBackfill>();
+  const [backfillOpen, setBackfillOpen] = useState(false);
+  const [backfillHistoryOpen, setBackfillHistoryOpen] = useState(false);
 
-  const filtered = useMemo(() => {
-    const q = keyword.trim().toLowerCase();
-    return schedules.filter((item) => {
-      if (workflowId && item.workflowId !== workflowId) return false;
-      if (status !== 'ALL' && item.status !== status) return false;
-      if (!q) return true;
-      const workflow = workflowMap.get(item.workflowId);
-      return [item.name, item.cronExpression, item.timezone, workflow?.name || '']
-        .some((value) => value.toLowerCase().includes(q));
-    });
-  }, [keyword, schedules, status, workflowId, workflowMap]);
+  const primarySchedule = useMemo(
+    () =>
+      [...schedules].sort((left, right) =>
+        String(left.createTime || '').localeCompare(String(right.createTime || '')),
+      )[0],
+    [schedules],
+  );
 
-  const changeStatus = async (schedule: WorkflowSchedule) => {
+  const canEdit = Boolean(
+    workflow && workflow.status !== 'ONLINE' && primarySchedule?.status !== 'ONLINE',
+  );
+
+  const load = useCallback(async (silent = false) => {
+    if (!workflowId) return;
+    if (!silent) setLoading(true);
     try {
-      if (schedule.status === 'ONLINE') {
-        await offlineWorkflowSchedule(schedule.id);
-        message.success('调度已停用');
-      } else {
-        await onlineWorkflowSchedule(schedule.id);
-        message.success('调度已注册到 Yak Schedule');
-      }
-      await load();
+      const [workflowData, scheduleData] = await Promise.all([
+        getWorkflowDefinition(workflowId),
+        listWorkflowSchedules({ workflowId }),
+      ]);
+      setWorkflow(workflowData);
+      setSchedules(scheduleData || []);
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '调度状态变更失败');
+      message.error(error instanceof Error ? error.message : '调度配置加载失败');
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, [workflowId]);
+
+  useEffect(() => {
+    if (!workflowId) {
+      history.replace('/workflow/definitions');
+      return;
+    }
+    void load();
+  }, [load, workflowId]);
+
+  useEffect(() => {
+    if (!workflow) return;
+    form.setFieldsValue({
+      name: primarySchedule?.name || `${workflow.name} 调度`,
+      cronExpression: primarySchedule?.cronExpression || '0 0 2 * * ?',
+      timezone: primarySchedule?.timezone || 'Asia/Shanghai',
+      effectiveRange:
+        primarySchedule?.startTime && primarySchedule?.endTime
+          ? [dayjs(primarySchedule.startTime), dayjs(primarySchedule.endTime)]
+          : undefined,
+      executionStrategy: primarySchedule?.executionStrategy || 'SERIAL_WAIT',
+      misfireStrategy: primarySchedule?.misfireStrategy || 'FIRE_ONCE',
+      inputJson: JSON.stringify(primarySchedule?.input || {}, null, 2),
+    });
+  }, [form, primarySchedule, workflow]);
+
+  const updateActiveSection = useCallback(() => {
+    const container = pageRootRef.current;
+    if (!container || locatingSectionRef.current) return;
+
+    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    if (maxScrollTop - container.scrollTop <= SCROLL_BOTTOM_THRESHOLD) {
+      setActiveSection(LAST_SECTION_KEY);
+      return;
+    }
+
+    const threshold = container.getBoundingClientRect().top + 140;
+    let nextActive: SectionKey = SECTION_ITEMS[0].key;
+    SECTION_ITEMS.forEach((item) => {
+      const element = document.getElementById(item.key);
+      if (element && element.getBoundingClientRect().top <= threshold) {
+        nextActive = item.key;
+      }
+    });
+    setActiveSection(nextActive);
+  }, []);
+
+  useEffect(() => {
+    const container = pageRootRef.current;
+    if (!container || !workflow) return undefined;
+
+    let animationFrameId = 0;
+    const handleViewportChange = () => {
+      window.cancelAnimationFrame(animationFrameId);
+      animationFrameId = window.requestAnimationFrame(updateActiveSection);
+    };
+
+    container.addEventListener('scroll', handleViewportChange, { passive: true });
+    window.addEventListener('resize', handleViewportChange);
+    updateActiveSection();
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      container.removeEventListener('scroll', handleViewportChange);
+      window.removeEventListener('resize', handleViewportChange);
+    };
+  }, [updateActiveSection, workflow]);
+
+  useEffect(
+    () => () => {
+      if (locateTimerRef.current) window.clearTimeout(locateTimerRef.current);
+    },
+    [],
+  );
+
+  const handleSectionLocate = (key: SectionKey) => {
+    const container = pageRootRef.current;
+    const element = document.getElementById(key);
+    if (!container || !element) return;
+
+    if (locateTimerRef.current) window.clearTimeout(locateTimerRef.current);
+    locatingSectionRef.current = key;
+    setActiveSection(key);
+
+    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    const containerRect = container.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const expectedTop =
+      container.scrollTop + elementRect.top - containerRect.top - SECTION_TOP_OFFSET;
+    const nextScrollTop =
+      key === LAST_SECTION_KEY
+        ? maxScrollTop
+        : Math.min(Math.max(expectedTop, 0), maxScrollTop);
+
+    container.scrollTo({ top: nextScrollTop, behavior: 'smooth' });
+    locateTimerRef.current = window.setTimeout(() => {
+      locatingSectionRef.current = null;
+      updateActiveSection();
+    }, LOCATE_LOCK_DURATION);
+  };
+
+  const handleSave = async () => {
+    if (!workflow || !canEdit) return;
+    try {
+      const values = await form.validateFields();
+      let input: Record<string, unknown> = {};
+      try {
+        input = values.inputJson.trim() ? JSON.parse(values.inputJson) : {};
+      } catch {
+        message.error('调度运行参数必须是合法 JSON');
+        return;
+      }
+
+      const payload = {
+        name: values.name.trim(),
+        cronExpression: values.cronExpression.trim(),
+        timezone: values.timezone,
+        startTime: values.effectiveRange?.[0]?.toISOString(),
+        endTime: values.effectiveRange?.[1]?.toISOString(),
+        executionStrategy: values.executionStrategy,
+        misfireStrategy: values.misfireStrategy,
+        input,
+      };
+
+      setSaving(true);
+      if (primarySchedule) await updateWorkflowSchedule(primarySchedule.id, payload);
+      else await createWorkflowSchedule(workflow.id, payload);
+      message.success('调度配置已保存，上线工作流后将自动启用');
+      await load(true);
+    } catch (error: any) {
+      if (error?.errorFields) return;
+      message.error(error instanceof Error ? error.message : '保存调度配置失败');
+    } finally {
+      setSaving(false);
     }
   };
 
-  const removeSchedule = (schedule: WorkflowSchedule) => {
+  const handleDelete = () => {
+    if (!primarySchedule || !canEdit) return;
     Modal.confirm({
       centered: true,
-      title: '确认删除调度吗？',
-      content: `即将删除「${schedule.name}」。调度定义会删除，历史 Trigger Ledger 与已创建 Backfill 批次会保留用于审计。`,
+      title: '删除调度配置',
+      content: '删除后工作流仍可手动运行，但上线时不会再自动创建定时触发。历史 Trigger 与补数记录会继续保留用于审计。',
       okText: '删除',
       cancelText: '取消',
       okButtonProps: { danger: true },
       async onOk() {
         try {
-          await deleteWorkflowSchedule(schedule.id);
-          message.success('调度已删除');
-          await load();
+          await deleteWorkflowSchedule(primarySchedule.id);
+          message.success('调度配置已删除');
+          await load(true);
         } catch (error) {
-          message.error(error instanceof Error ? error.message : '删除调度失败');
+          message.error(error instanceof Error ? error.message : '删除调度配置失败');
         }
       },
     });
   };
 
-  const openNormalLedger = (schedule: WorkflowSchedule) => {
-    setLedgerBackfill(undefined);
-    setLedgerSchedule(schedule);
-    setLedgerOpen(true);
-  };
-
   const openBackfillLedger = (backfill: WorkflowBackfill) => {
     setLedgerBackfill(backfill);
-    setLedgerSchedule(schedules.find((item) => item.id === backfill.scheduleId));
+    setBackfillHistoryOpen(false);
     setLedgerOpen(true);
   };
 
-  const columns = [
-    {
-      title: '调度名称', dataIndex: 'name', width: 220,
-      render: (value: string, record: WorkflowSchedule) => (
-        <div><div className="font-medium text-[#344054]">{value}</div><div className="mt-1 text-[11px] text-[#98a2b3]">{record.id}</div></div>
-      ),
-    },
-    {
-      title: '工作流', dataIndex: 'workflowId', width: 210,
-      render: (value: string) => {
-        const workflow = workflowMap.get(value);
-        return <div><div className="text-[13px] text-[#475467]">{workflow?.name || value}</div><div className="mt-1 text-[11px] text-[#98a2b3]">{workflow?.status || 'UNKNOWN'}</div></div>;
-      },
-    },
-    {
-      title: 'Cron / 时区', dataIndex: 'cronExpression', width: 190,
-      render: (value: string, record: WorkflowSchedule) => (
-        <div><code className="text-[12px] text-[#344054]">{value}</code><div className="mt-1 text-[11px] text-[#98a2b3]">{record.timezone}</div></div>
-      ),
-    },
-    {
-      title: '调度状态', dataIndex: 'status', width: 100, align: 'center' as const,
-      render: (value: string) => (
-        <span className={value === 'ONLINE' ? 'text-[12px] font-medium text-[#fe2c55]' : 'text-[12px] text-[#98a2b3]'}>
-          {value === 'ONLINE' ? '已启用' : '已停用'}
-        </span>
-      ),
-    },
-    {
-      title: '实例策略', dataIndex: 'executionStrategy', width: 110,
-      render: (value: string) => <span className="text-[12px] text-[#667085]">{STRATEGY_LABEL[value] || value}</span>,
-    },
-    {
-      title: '生效区间', dataIndex: 'startTime', width: 210,
-      render: (_: unknown, record: WorkflowSchedule) => (
-        <div className="text-[11px] leading-5 text-[#667085]">
-          <div>{record.startTime ? formatTime(record.startTime) : '立即生效'}</div>
-          <div>{record.endTime ? `至 ${formatTime(record.endTime)}` : '长期有效'}</div>
-        </div>
-      ),
-    },
-    {
-      title: '最近 / 下次运行', dataIndex: 'nextFireTime', width: 215,
-      render: (_: unknown, record: WorkflowSchedule) => (
-        <div className="text-[11px] leading-5 text-[#667085]">
-          <div>最近：{record.lastFireTime ? formatTime(record.lastFireTime) : '尚未触发'}</div>
-          <div className={record.nextFireTime ? 'text-[#475467]' : 'text-[#98a2b3]'}>
-            下次：{record.nextFireTime
-              ? formatTime(record.nextFireTime)
-              : record.status === 'ONLINE' ? '暂无可执行时间' : '未启用'}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '更新时间', dataIndex: 'updateTime', width: 165,
-      render: (value?: string) => <span className="text-[12px] text-[#98a2b3]">{formatTime(value)}</span>,
-    },
-    {
-      title: '操作', dataIndex: 'operate', width: 380, fixed: 'right' as const,
-      render: (_: unknown, record: WorkflowSchedule) => {
-        const workflowOnline = workflowMap.get(record.workflowId)?.status === 'ONLINE';
-        const online = record.status === 'ONLINE';
-        return (
-          <div className="flex items-center gap-0.5 whitespace-nowrap">
-            <Tooltip title={!workflowOnline ? '工作流需先上线；调度本身可以处于停用状态' : undefined}>
-              <span>
-                <Button
-                  type="text"
-                  size="small"
-                  disabled={!workflowOnline}
-                  icon={<DatabaseBackup size={13} />}
-                  onClick={() => { setBackfillSchedule(record); setBackfillOpen(true); }}
-                >
-                  补数
-                </Button>
-              </span>
-            </Tooltip>
-            <Button
-              type="text"
-              size="small"
-              icon={<History size={13} />}
-              onClick={() => openNormalLedger(record)}
-            >
-              触发记录
-            </Button>
-            <Tooltip title={online ? '已启用调度请先停用后再修改配置' : undefined}>
-              <span>
-                <Button
-                  type="text"
-                  size="small"
-                  disabled={online}
-                  icon={<Pencil size={13} />}
-                  onClick={() => { setEditing(record); setEditorOpen(true); }}
-                >
-                  编辑
-                </Button>
-              </span>
-            </Tooltip>
-            <Tooltip title={!workflowOnline && !online ? '工作流需先上线' : undefined}>
-              <span>
-                <Button
-                  type="text"
-                  size="small"
-                  disabled={!workflowOnline && !online}
-                  icon={online ? <PowerOff size={13} /> : <Power size={13} />}
-                  onClick={() => void changeStatus(record)}
-                >
-                  {online ? '停用' : '启用'}
-                </Button>
-              </span>
-            </Tooltip>
-            {!online && (
-              <Button danger type="text" size="small" icon={<Trash2 size={13} />} onClick={() => removeSchedule(record)}>删除</Button>
-            )}
-          </div>
-        );
-      },
-    },
-  ];
+  const lifecycleText = !primarySchedule
+    ? '尚未配置调度，工作流仍可手动运行。'
+    : workflow?.status === 'ONLINE'
+      ? `调度已随工作流上线${primarySchedule.nextFireTime ? `，下次运行 ${formatTime(primarySchedule.nextFireTime)}` : ''}。`
+      : '调度配置已保存；上线工作流时自动启用，下线工作流时自动停用。';
+
+  if (!workflowId) return null;
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f8fa]">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!workflow) {
+    return (
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f8fa]">
+        <Empty description="未找到工作流" image={Empty.PRESENTED_IMAGE_SIMPLE}>
+          <Button onClick={() => history.push('/workflow/definitions')}>返回工作流定义</Button>
+        </Empty>
+      </div>
+    );
+  }
 
   return (
-    <ConfigProvider theme={{ token: { borderRadius: 9, colorBorder: '#eaecf0' }, components: { Input: { activeShadow: 'none' } } }}>
-      <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4 text-[#161823]">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-2.5">
-            {scoped && (
-              <Tooltip title="返回工作流定义">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<ArrowLeft size={15} />}
-                  className="!h-8 !w-8 !px-0"
-                  onClick={() => history.push('/workflow/definitions')}
-                />
-              </Tooltip>
-            )}
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="h-[calc(100vh-64px)] overflow-hidden bg-[#f7f8fa] text-[#161823]">
+        <div ref={pageRootRef} className="h-full overflow-y-auto overscroll-contain scroll-smooth">
+          <div className="mx-auto grid w-full max-w-[1280px] grid-cols-1 gap-6 px-6 pb-6 pt-6 max-xl:max-w-[1040px] xl:grid-cols-[minmax(0,1fr)_160px]">
             <div className="min-w-0">
-              <h1 className="m-0 truncate text-[17px] font-semibold leading-8">
-                {scoped ? '调度配置' : '调度管理'}
-              </h1>
-              <div className="truncate text-[11px] text-[#98a2b3]">
-                {scoped
-                  ? `${scopedWorkflow?.name || scopedWorkflowId} · ${scopedWorkflow?.status === 'ONLINE' ? '工作流已上线，可启用调度' : '工作流未上线，调度可配置但不能启用'}`
-                  : 'Yak Schedule / Quartz · Trigger Ledger、Backfill、调度参数与恢复'}
-              </div>
+              <main className="space-y-5 pb-4">
+                <div className="rounded-xl border border-[#eaecf0] bg-white px-6 py-5">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<ArrowLeft size={16} />}
+                        className="!mt-0.5 !h-8 !w-8 !shrink-0 !px-0"
+                        onClick={() => history.push('/workflow/definitions')}
+                      />
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h1 className="m-0 truncate text-[18px] font-semibold leading-8 text-[#161823]">
+                            调度配置
+                          </h1>
+                          <span className="rounded-md bg-[#f2f4f7] px-2 py-1 text-[11px] font-medium text-[#667085]">
+                            {WORKFLOW_STATUS_LABEL[workflow.status] || workflow.status}
+                          </span>
+                        </div>
+                        <div className="mt-1 truncate text-[12px] text-[#667085]">
+                          {workflow.name}
+                        </div>
+                        <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
+                          {lifecycleText}
+                        </div>
+                      </div>
+                    </div>
+
+                    {primarySchedule ? (
+                      <div className="flex shrink-0 items-center gap-1.5">
+                        <Tooltip title={workflow.status !== 'ONLINE' ? '工作流上线后才能执行历史补数' : undefined}>
+                          <span>
+                            <Button
+                              size="small"
+                              disabled={workflow.status !== 'ONLINE'}
+                              icon={<DatabaseBackup size={14} />}
+                              onClick={() => setBackfillOpen(true)}
+                            >
+                              补数
+                            </Button>
+                          </span>
+                        </Tooltip>
+                        <Button
+                          size="small"
+                          icon={<ListTree size={14} />}
+                          onClick={() => {
+                            setLedgerBackfill(undefined);
+                            setLedgerOpen(true);
+                          }}
+                        >
+                          触发记录
+                        </Button>
+                        <Button
+                          size="small"
+                          icon={<History size={14} />}
+                          onClick={() => setBackfillHistoryOpen(true)}
+                        >
+                          补数记录
+                        </Button>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+
+                {schedules.length > 1 ? (
+                  <div className="rounded-lg border border-[#fedf89] bg-[#fffaeb] px-4 py-3 text-[12px] leading-5 text-[#7a2e0e]">
+                    检测到该工作流存在 {schedules.length} 个历史调度。本页按简化模式只编辑最早创建的主调度；工作流上线、下线仍会联动全部已有调度。
+                  </div>
+                ) : null}
+
+                {!canEdit ? (
+                  <div className="rounded-lg border border-[#eaecf0] bg-[#f8f9fb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
+                    当前工作流或调度处于启用状态。需要修改调度时，请先在工作流定义页下线工作流；下线会自动停用调度。
+                  </div>
+                ) : null}
+
+                <Form form={form} layout="vertical" requiredMark="optional" disabled={!canEdit}>
+                  <div className="space-y-5">
+                    <SectionCard
+                      id="schedule-basic"
+                      title="调度设置"
+                      description="定义这个工作流什么时候执行。调度只保存配置，最终是否生效由工作流上线状态统一控制。"
+                    >
+                      <Form.Item
+                        name="name"
+                        label="调度名称"
+                        rules={[
+                          { required: true, message: '请输入调度名称' },
+                          { max: 100, message: '名称不能超过 100 个字符' },
+                        ]}
+                      >
+                        <Input variant="filled" placeholder="例如：每日凌晨订单同步" />
+                      </Form.Item>
+
+                      <Form.Item
+                        name="cronExpression"
+                        label="Cron 表达式"
+                        rules={[{ required: true, message: '请输入 Cron 表达式' }]}
+                        extra="使用 Quartz Cron 表达式，并按下方时区计算计划时间。"
+                      >
+                        <Input variant="filled" placeholder="0 0 2 * * ?" className="font-mono" />
+                      </Form.Item>
+
+                      <div className="-mt-3 mb-5 flex flex-wrap items-center gap-1.5">
+                        <span className="mr-1 text-[11px] text-[#98a2b3]">快捷设置</span>
+                        {CRON_PRESETS.map((preset) => (
+                          <Button
+                            key={preset.value}
+                            size="small"
+                            type="text"
+                            className="!h-7 !bg-[#f7f8fa] !px-2.5 !text-[11px] !text-[#667085] hover:!bg-[#eef0f3]"
+                            onClick={() => form.setFieldValue('cronExpression', preset.value)}
+                          >
+                            {preset.label}
+                          </Button>
+                        ))}
+                      </div>
+
+                      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                        <Form.Item name="timezone" label="时区" rules={[{ required: true }]}>
+                          <Select
+                            options={[
+                              { value: 'Asia/Shanghai', label: 'Asia/Shanghai' },
+                              { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
+                              { value: 'UTC', label: 'UTC' },
+                            ]}
+                          />
+                        </Form.Item>
+                        <Form.Item name="effectiveRange" label="生效区间（可选）">
+                          <DatePicker.RangePicker showTime className="w-full" />
+                        </Form.Item>
+                      </div>
+                    </SectionCard>
+
+                    <SectionCard
+                      id="schedule-strategy"
+                      title="运行策略"
+                      description="控制计划重叠和服务恢复时的行为。默认策略适合绝大多数离线批处理工作流。"
+                    >
+                      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                        <Form.Item
+                          name="executionStrategy"
+                          label="实例并发策略"
+                          rules={[{ required: true }]}
+                          extra="等待：前序完成后再执行；跳过：已有实例时记录为 SKIPPED；并行：允许同时创建实例。"
+                        >
+                          <Select
+                            options={[
+                              { value: 'SERIAL_WAIT', label: '等待上一次完成（推荐）' },
+                              { value: 'SERIAL_DISCARD', label: '上一次未完成则跳过' },
+                              { value: 'PARALLEL', label: '允许并行运行' },
+                            ]}
+                          />
+                        </Form.Item>
+                        <Form.Item
+                          name="misfireStrategy"
+                          label="错过调度策略"
+                          rules={[{ required: true }]}
+                          extra="服务恢复后可合并补跑一次，或直接跳过错过的计划并保留审计记录。"
+                        >
+                          <Select
+                            options={[
+                              { value: 'FIRE_ONCE', label: '恢复后补跑一次（推荐）' },
+                              { value: 'SKIP', label: '直接跳过' },
+                            ]}
+                          />
+                        </Form.Item>
+                      </div>
+                    </SectionCard>
+
+                    <SectionCard
+                      id="schedule-advanced"
+                      title="高级配置"
+                      description="按需覆盖工作流参数。业务日期和计划时间等系统参数仍由调度运行时自动注入。"
+                    >
+                      <Form.Item
+                        name="inputJson"
+                        label="调度运行参数 JSON"
+                        extra="合并顺序：工作流版本参数 < 调度参数 < Backfill 参数 < 系统参数。系统会注入 businessDate、scheduleTime、scheduleTimezone、triggerType、scheduleId，并在 __schedule 中保留完整副本。"
+                      >
+                        <Input.TextArea
+                          rows={8}
+                          spellCheck={false}
+                          className="font-mono text-[12px]"
+                        />
+                      </Form.Item>
+
+                      {primarySchedule && canEdit ? (
+                        <div className="mt-6 flex items-center justify-between border-t border-[#f0f2f5] pt-4">
+                          <div>
+                            <div className="text-[12px] font-medium text-[#475467]">不再需要定时执行？</div>
+                            <div className="mt-1 text-[11px] text-[#98a2b3]">删除调度不会删除工作流，也不会删除历史运行审计。</div>
+                          </div>
+                          <Button
+                            danger
+                            type="text"
+                            icon={<Trash2 size={14} />}
+                            onClick={handleDelete}
+                          >
+                            删除调度
+                          </Button>
+                        </div>
+                      ) : null}
+                    </SectionCard>
+                  </div>
+                </Form>
+              </main>
+
+              <footer className="sticky bottom-0 z-50 overflow-hidden rounded-t-lg border border-b-0 border-[#eaecf0] bg-white">
+                <div className="flex min-h-[76px] items-center gap-3 px-8 py-4">
+                  <Button
+                    type="primary"
+                    loading={saving}
+                    disabled={!canEdit}
+                    icon={<Save size={15} />}
+                    className="!h-9 !min-w-[120px] !rounded-lg !px-6 !font-medium !text-white"
+                    onClick={() => void handleSave()}
+                  >
+                    保存配置
+                  </Button>
+                  <Button
+                    disabled={saving}
+                    className="!h-9 !min-w-[120px] !rounded-lg !border-0 !bg-[#f2f3f5] !px-5 !font-medium !text-[#344054] hover:!bg-[#e9eaec]"
+                    onClick={() => history.push('/workflow/definitions')}
+                  >
+                    返回
+                  </Button>
+                  <div className="ml-auto hidden items-center gap-2 text-[11px] text-[#98a2b3] md:flex">
+                    <CalendarClock size={14} />
+                    {primarySchedule ? `当前 Cron：${primarySchedule.cronExpression}` : '保存后再上线工作流即可生效'}
+                  </div>
+                </div>
+              </footer>
             </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button size="small" icon={<History size={14} />} onClick={() => setBackfillHistoryOpen(true)}>
-              补数记录
-            </Button>
-            <Button danger type="primary" size="small" icon={<CalendarClock size={14} />} onClick={() => { setEditing(undefined); setEditorOpen(true); }}>
-              新建调度
-            </Button>
+
+            <aside className="hidden xl:block">
+              <div className="sticky top-6">
+                <SectionNavigator activeKey={activeSection} onSelect={handleSectionLocate} />
+              </div>
+            </aside>
           </div>
         </div>
-
-        <div className="mt-4 flex min-h-[52px] items-center justify-between gap-3 border-y border-[#f0f0f0]">
-          <div className="flex items-center gap-2">
-            <Select
-              allowClear={!scoped}
-              showSearch
-              disabled={scoped}
-              optionFilterProp="label"
-              placeholder="全部工作流"
-              className="w-[220px]"
-              value={workflowId}
-              onChange={setWorkflowId}
-              options={definitions.map((item) => ({ value: item.id, label: item.name }))}
-            />
-            <Select
-              value={status}
-              className="w-[120px]"
-              onChange={(value) => setStatus(value as StatusFilter)}
-              options={[{ value: 'ALL', label: '全部状态' }, { value: 'ONLINE', label: '已启用' }, { value: 'OFFLINE', label: '已停用' }]}
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <Input allowClear variant="filled" prefix={<SearchOutlined className="text-[#98a2b3]" />} placeholder="搜索名称、Cron、时区" className="!w-[260px]" value={keyword} onChange={(e) => setKeyword(e.target.value)} />
-            <Tooltip title="刷新调度运行时间">
-              <Button icon={<ReloadOutlined spin={loading} />} onClick={() => void load()} />
-            </Tooltip>
-          </div>
-        </div>
-
-        <div className="mt-3 flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
-          <span><b>【调度参数】</b> 工作流上线后才能启用调度；Cron 与 Backfill 均按逻辑计划时间注入 businessDate / scheduleTime。</span>
-        </div>
-
-        <div className="mt-4 flex-1">
-          <Table
-            rowKey="id"
-            bordered
-            size="small"
-            loading={loading}
-            columns={columns as any}
-            dataSource={filtered}
-            scroll={{ x: 1740 }}
-            pagination={{ pageSize: 10, showSizeChanger: true, pageSizeOptions: [10, 20, 50], showTotal: (total) => `共 ${total} 条` }}
-            className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-thead>tr>th]:!text-[#667085] [&_.ant-table-tbody>tr>td]:!py-2.5"
-          />
-        </div>
-
-        <ScheduleEditorDrawer
-          open={editorOpen}
-          definitions={definitions}
-          schedule={editing}
-          workflowId={scopedWorkflowId || workflowId}
-          lockWorkflow={scoped}
-          onClose={() => { setEditorOpen(false); setEditing(undefined); }}
-          onSaved={load}
-        />
-        <BackfillDrawer
-          open={backfillOpen}
-          schedule={backfillSchedule}
-          onClose={() => { setBackfillOpen(false); setBackfillSchedule(undefined); }}
-          onCreated={async () => {
-            await load();
-            setBackfillHistoryOpen(true);
-          }}
-        />
-        <BackfillHistoryDrawer
-          open={backfillHistoryOpen}
-          workflowId={workflowId}
-          onClose={() => setBackfillHistoryOpen(false)}
-          onOpenTriggers={openBackfillLedger}
-        />
-        <TriggerLedgerDrawer
-          open={ledgerOpen}
-          schedule={ledgerSchedule}
-          backfillId={ledgerBackfill?.id}
-          backfillName={ledgerBackfill?.name}
-          onClose={() => {
-            setLedgerOpen(false);
-            setLedgerSchedule(undefined);
-            setLedgerBackfill(undefined);
-          }}
-        />
       </div>
+
+      <BackfillDrawer
+        open={backfillOpen}
+        schedule={primarySchedule}
+        onClose={() => setBackfillOpen(false)}
+        onCreated={() => load(true)}
+      />
+      <BackfillHistoryDrawer
+        open={backfillHistoryOpen}
+        workflowId={workflow.id}
+        scheduleId={primarySchedule?.id}
+        onClose={() => setBackfillHistoryOpen(false)}
+        onOpenTriggers={openBackfillLedger}
+      />
+      <TriggerLedgerDrawer
+        open={ledgerOpen}
+        schedule={primarySchedule}
+        backfillId={ledgerBackfill?.id}
+        backfillName={ledgerBackfill?.name}
+        onClose={() => {
+          setLedgerOpen(false);
+          setLedgerBackfill(undefined);
+        }}
+      />
     </ConfigProvider>
   );
-};
-
-export default WorkflowSchedulesPage;
+}


### PR DESCRIPTION
## What changed

- replace the standalone schedule-management table with a workflow-scoped schedule configuration page
- reuse the offline-sync configuration layout: section cards, right-side quick navigation, and sticky footer actions
- remove the workflow selector and manual schedule enable/disable flow from the main UX
- make workflow online/offline own the schedule lifecycle: online automatically enables saved schedules, offline automatically disables active schedules
- keep Trigger Ledger, Backfill, and backfill history as contextual actions on the schedule configuration page
- simplify the frontend to a primary schedule per workflow while retaining compatibility with historical workflows that already contain multiple schedules

## UX flow

`工作流编排 → 调度配置 → 保存 → 上线工作流 → 自动启用调度`

`下线工作流 → 自动停用调度`

## Validation

- updated backend unit coverage for workflow/schedule lifecycle coupling
- reviewed the branch diff against `main` (6 changed files)
- a full local build could not be run in this environment because repository dependency/network access is unavailable; CI results should be used as the final build verification
