### PR TITLE
refactor(ui): redesign workflow editor studio layout

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowNodeInspector.tsx
@@ -70,7 +70,6 @@ const WorkflowNodeInspector = ({
       disabled: locked,
       onClick: onDuplicate,
     },
-    { type: 'divider' },
     {
       key: 'delete',
       icon: <Trash2 size={14} />,
@@ -82,53 +81,53 @@ const WorkflowNodeInspector = ({
   ], [locked, onDelete, onDuplicate]);
 
   return (
-    <aside className="absolute bottom-3 right-3 top-3 z-20 flex w-[400px] flex-col overflow-hidden rounded-2xl border border-[#e2e5e9] bg-white shadow-[0_12px_36px_rgba(22,24,35,.12)]">
-      <header className="shrink-0 border-b border-[#eceef1] bg-white">
-        <div className="flex items-center gap-2 px-4 pb-2 pt-4">
+    <aside className="absolute bottom-0 right-0 top-0 z-20 flex w-[340px] flex-col overflow-hidden border-l border-[#e8eaee] bg-white">
+      <header className="shrink-0 border-b border-[#eef0f2] bg-white">
+        <div className="flex h-12 items-center gap-2 px-4">
           <WorkflowNodeIcon taskType={node.data.taskType} size="sm" />
-          <div className="min-w-0 flex-1 truncate text-[14px] font-semibold text-[#161823]">
-            {node.data.label}
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[13px] font-semibold text-[#161823]">
+              {node.data.label}
+            </div>
+            <div className="mt-0.5 truncate text-[9px] text-[#98a2b3]">
+              {node.data.typeLabel || node.data.taskType || '任务节点'}
+            </div>
           </div>
 
           <div className="flex shrink-0 items-center gap-0.5">
             <ActionButton label="复制节点" onClick={locked ? undefined : onDuplicate}>
-              <Copy size={15} />
+              <Copy size={14} />
             </ActionButton>
             <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
               <span>
                 <ActionButton label="更多操作">
-                  <Ellipsis size={16} />
+                  <Ellipsis size={15} />
                 </ActionButton>
               </span>
             </Dropdown>
-            <div className="mx-1 h-4 w-px bg-[#e7e9ed]" />
             <ActionButton label="关闭" onClick={onClose}>
-              <X size={16} />
+              <X size={15} />
             </ActionButton>
           </div>
         </div>
 
-        <div className="px-4 pb-2 text-[11px] leading-5 text-[rgba(22,24,35,.36)]">
-          配置节点失败后的重试和异常处理方式。
-        </div>
-
-        <nav className="flex h-10 items-end gap-5 px-4" aria-label="节点配置页签">
+        <nav className="flex h-9 items-end gap-5 px-4" aria-label="节点配置页签">
           <button
             type="button"
             className={[
-              'relative h-10 border-0 bg-transparent px-0 text-[12px] font-semibold transition-colors',
-              activeTab === 'settings' ? 'text-[#344054]' : 'text-[#667085] hover:text-[#344054]',
+              'relative h-9 border-0 bg-transparent px-0 text-[11px] font-medium transition-colors',
+              activeTab === 'settings' ? 'text-[#161823]' : 'text-[#98a2b3] hover:text-[#475467]',
             ].join(' ')}
             onClick={() => setActiveTab('settings')}
           >
-            设置
+            属性
             {activeTab === 'settings' ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
           </button>
           <button
             type="button"
             className={[
-              'relative h-10 border-0 bg-transparent px-0 text-[12px] font-semibold transition-colors',
-              activeTab === 'lastRun' ? 'text-[#344054]' : 'text-[#667085] hover:text-[#344054]',
+              'relative h-9 border-0 bg-transparent px-0 text-[11px] font-medium transition-colors',
+              activeTab === 'lastRun' ? 'text-[#161823]' : 'text-[#98a2b3] hover:text-[#475467]',
             ].join(' ')}
             onClick={() => setActiveTab('lastRun')}
           >

--- a/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskLibrary.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/canvas/WorkflowTaskLibrary.tsx
@@ -1,22 +1,15 @@
 import type { WorkflowTaskDefinition } from '@/services/workflow';
+import { history } from '@umijs/max';
+import { Input, Tooltip } from 'antd';
 import {
-  getWorkflowDefinition,
-  type WorkflowDefinition,
-} from '@/services/workflow/definitions';
-import { history, useParams } from '@umijs/max';
-import { Tooltip } from 'antd';
-import {
-  Activity,
+  Boxes,
   ChevronLeft,
-  CircleHelp,
-  GitBranch,
-  History as HistoryIcon,
-  Home,
-  ScrollText,
-  Workflow,
+  Database,
+  Search,
 } from 'lucide-react';
-import type { DragEvent, ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import type { DragEvent } from 'react';
+import { useMemo, useState } from 'react';
+import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
 
 interface WorkflowTaskLibraryProps {
   tasks: WorkflowTaskDefinition[];
@@ -25,155 +18,162 @@ interface WorkflowTaskLibraryProps {
   onDragStart: (event: DragEvent<HTMLDivElement>, task: WorkflowTaskDefinition) => void;
 }
 
-interface WorkspaceNavItemProps {
-  icon: ReactNode;
-  label: string;
-  active?: boolean;
-  disabled?: boolean;
-  onClick?: () => void;
-}
+type LibraryPanel = 'nodes' | 'resources';
 
-const STATUS_LABEL: Record<string, string> = {
-  DRAFT: '草稿',
-  ONLINE: '已上线',
-  OFFLINE: '已下线',
+const taskTypeLabel = (taskType?: string) => {
+  if (!taskType || taskType === 'SYNC') return '数据同步';
+  if (taskType === 'SQL') return 'SQL';
+  return taskType;
 };
 
-const WorkspaceNavItem = ({
-  icon,
+const RailButton = ({
+  active,
   label,
-  active = false,
-  disabled = false,
+  icon,
   onClick,
-}: WorkspaceNavItemProps) => {
-  const button = (
+}: {
+  active?: boolean;
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+}) => (
+  <Tooltip title={label} placement="right">
     <button
       type="button"
-      disabled={disabled}
+      aria-label={label}
       className={[
-        'flex h-9 w-full items-center gap-2.5 rounded-lg border-0 px-3 text-left text-[13px] font-medium transition-colors',
+        'flex h-9 w-9 items-center justify-center rounded-lg border-0 transition-colors',
         active
-          ? 'bg-[rgba(254,44,85,.07)] text-[#fe2c55]'
-          : disabled
-            ? 'cursor-not-allowed bg-transparent text-[#c0c4cc]'
-            : 'bg-transparent text-[#475467] hover:bg-[#f5f6f7] hover:text-[#161823]',
+          ? 'bg-[#f2f4f7] text-[#161823]'
+          : 'bg-transparent text-[#98a2b3] hover:bg-[#f7f8fa] hover:text-[#475467]',
       ].join(' ')}
       onClick={onClick}
     >
-      <span className="flex h-5 w-5 shrink-0 items-center justify-center">{icon}</span>
-      <span className="truncate">{label}</span>
+      {icon}
     </button>
-  );
+  </Tooltip>
+);
 
-  return disabled ? (
-    <Tooltip title="即将支持" placement="right">
-      <span className="block">{button}</span>
-    </Tooltip>
-  ) : button;
-};
+const WorkflowTaskLibrary = ({
+  tasks,
+  loading,
+  locked,
+  onDragStart,
+}: WorkflowTaskLibraryProps) => {
+  const [activePanel, setActivePanel] = useState<LibraryPanel>('nodes');
+  const [keyword, setKeyword] = useState('');
 
-/**
- * The old permanent task library has been replaced by a workflow-scoped
- * workspace sidebar. Tasks are added on demand through WorkflowTaskPicker,
- * while this rail owns workflow-level navigation and identity.
- *
- * Keep the legacy props temporarily so WorkflowDefinitionEditor does not need
- * a high-risk orchestration rewrite just for the shell migration.
- */
-const WorkflowTaskLibrary = (_props: WorkflowTaskLibraryProps) => {
-  const { id = '' } = useParams<{ id: string }>();
-  const [definition, setDefinition] = useState<WorkflowDefinition>();
-
-  useEffect(() => {
-    let active = true;
-    if (!id) return undefined;
-
-    void getWorkflowDefinition(id)
-      .then((value) => {
-        if (active) setDefinition(value);
-      })
-      .catch(() => {
-        // The editor already owns the primary loading/error state. This
-        // secondary identity request should never block the workspace shell.
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [id]);
-
-  const workflowName = definition?.name || '工作流';
-  const statusLabel = STATUS_LABEL[definition?.status || 'DRAFT'] || definition?.status || '草稿';
+  const filteredTasks = useMemo(() => {
+    const normalized = keyword.trim().toLowerCase();
+    if (!normalized) return tasks;
+    return tasks.filter((task) =>
+      task.name.toLowerCase().includes(normalized)
+      || taskTypeLabel(task.type).toLowerCase().includes(normalized));
+  }, [keyword, tasks]);
 
   return (
-    <aside className="flex w-[216px] shrink-0 flex-col border-r border-[#e8e9ec] bg-white">
-      <div className="flex h-[52px] shrink-0 items-center gap-1.5 border-b border-[#f0f1f3] px-3">
-        <Tooltip title="返回工作流定义">
+    <aside className="flex w-[280px] shrink-0 border-r border-[#e8eaee] bg-white">
+      <div className="flex w-12 shrink-0 flex-col items-center border-r border-[#eef0f2] bg-[#fbfbfc] py-2">
+        <Tooltip title="返回工作流列表" placement="right">
           <button
             type="button"
-            aria-label="返回工作流定义"
-            className="flex h-7 w-7 items-center justify-center rounded-md border-0 bg-transparent text-[#667085] hover:bg-[#f5f6f7] hover:text-[#161823]"
+            aria-label="返回工作流列表"
+            className="mb-2 flex h-9 w-9 items-center justify-center rounded-lg border-0 bg-transparent text-[#667085] transition-colors hover:bg-[#f2f4f7] hover:text-[#161823]"
             onClick={() => history.push('/workflow/definitions')}
           >
-            <ChevronLeft size={15} />
+            <ChevronLeft size={17} strokeWidth={1.9} />
           </button>
         </Tooltip>
-        <Home size={13} className="text-[#98a2b3]" />
-        <span className="text-[11px] text-[#c0c4cc]">/</span>
-        <span className="truncate text-[12px] font-semibold text-[#344054]">工作流</span>
+
+        <div className="mb-2 h-px w-6 bg-[#eceef1]" />
+
+        <RailButton
+          active={activePanel === 'nodes'}
+          label="节点"
+          icon={<Boxes size={17} strokeWidth={1.8} />}
+          onClick={() => setActivePanel('nodes')}
+        />
+        <RailButton
+          active={activePanel === 'resources'}
+          label="资源"
+          icon={<Database size={17} strokeWidth={1.8} />}
+          onClick={() => setActivePanel('resources')}
+        />
       </div>
 
-      <div className="px-3 pb-3 pt-4">
-        <div className="flex items-center gap-2.5 rounded-xl px-1 py-1.5">
-          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[rgba(254,44,85,.08)] text-[#fe2c55]">
-            <GitBranch size={19} strokeWidth={2.1} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-[13px] font-semibold text-[#161823]">{workflowName}</div>
-            <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-[#98a2b3]">
-              <span>工作流</span>
-              <span className="text-[#d0d5dd]">·</span>
-              <span>{statusLabel}</span>
+      <div className="flex min-w-0 flex-1 flex-col bg-white">
+        <div className="flex h-11 shrink-0 items-center px-4 text-[13px] font-semibold text-[#161823]">
+          {activePanel === 'nodes' ? '节点' : '资源'}
+        </div>
+
+        {activePanel === 'nodes' ? (
+          <>
+            <div className="px-3 pb-3">
+              <Input
+                allowClear
+                variant="filled"
+                value={keyword}
+                prefix={<Search size={13} className="text-[#98a2b3]" />}
+                placeholder="搜索节点"
+                className="!h-8 !rounded-lg !text-[12px]"
+                onChange={(event) => setKeyword(event.target.value)}
+              />
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-4">
+              <div className="mb-2 px-1 text-[10px] font-medium uppercase tracking-[0.08em] text-[#98a2b3]">
+                任务节点
+              </div>
+
+              {loading ? (
+                <div className="space-y-2">
+                  {[0, 1, 2].map((item) => (
+                    <div key={item} className="h-12 animate-pulse rounded-lg bg-[#f5f6f7]" />
+                  ))}
+                </div>
+              ) : filteredTasks.length ? (
+                <div className="space-y-1.5">
+                  {filteredTasks.map((task) => (
+                    <div
+                      key={task.id}
+                      draggable={!locked}
+                      className={[
+                        'group flex min-h-12 items-center gap-2.5 rounded-lg border border-transparent px-2.5 py-2 transition-colors',
+                        locked
+                          ? 'cursor-not-allowed opacity-50'
+                          : 'cursor-grab hover:border-[#e4e7ec] hover:bg-[#fafbfc] active:cursor-grabbing',
+                      ].join(' ')}
+                      onDragStart={(event) => !locked && onDragStart(event, task)}
+                    >
+                      <WorkflowNodeIcon taskType={task.type} size="sm" />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[12px] font-medium text-[#344054]">
+                          {task.name}
+                        </div>
+                        <div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">
+                          {taskTypeLabel(task.type)}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="px-3 py-10 text-center text-[11px] text-[#98a2b3]">
+                  暂无匹配节点
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col px-3 pb-4">
+            <div className="rounded-lg bg-[#f7f8fa] px-3 py-3 text-[11px] leading-5 text-[#667085]">
+              资源面板用于集中展示工作流可引用的数据源、文件和运行资源。
+            </div>
+            <div className="flex flex-1 items-center justify-center text-[11px] text-[#b0b4bc]">
+              暂无可用资源
             </div>
           </div>
-        </div>
-      </div>
-
-      <nav className="flex-1 px-3" aria-label="工作流工作区导航">
-        <div className="space-y-1">
-          <WorkspaceNavItem
-            active
-            label="编排"
-            icon={<Workflow size={16} strokeWidth={1.9} />}
-          />
-          <WorkspaceNavItem
-            label="运行记录"
-            icon={<HistoryIcon size={16} strokeWidth={1.9} />}
-            onClick={() => history.push('/workflow/instances')}
-          />
-          <WorkspaceNavItem
-            disabled
-            label="日志"
-            icon={<ScrollText size={16} strokeWidth={1.9} />}
-          />
-          <WorkspaceNavItem
-            disabled
-            label="监控"
-            icon={<Activity size={16} strokeWidth={1.9} />}
-          />
-        </div>
-      </nav>
-
-      <div className="border-t border-[#f0f1f3] p-3">
-        <Tooltip title="帮助中心即将支持" placement="right">
-          <button
-            type="button"
-            className="flex h-9 w-full cursor-default items-center gap-2.5 rounded-lg border-0 bg-transparent px-3 text-left text-[12px] text-[#98a2b3]"
-          >
-            <CircleHelp size={15} strokeWidth={1.9} />
-            <span>帮助中心</span>
-          </button>
-        </Tooltip>
+        )}
       </div>
     </aside>
   );

--- a/yak-ops-ui/src/pages/workflow/definition/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/index.tsx
@@ -1,26 +1,145 @@
 import WorkflowDefinitionEditor from './WorkflowDefinitionEditor';
 
 /**
- * Workflow Definition uses its own workspace chrome (workflow sidebar + toolbar +
- * ReactFlow canvas), so it should consume the whole browser viewport when the
- * route is mounted outside SiteLayout.
- *
- * Keep the sizing override here instead of coupling the large orchestration
- * component to a specific application shell. This also keeps the existing
- * editor behavior intact while allowing immersive routes to own 100vh.
+ * Workflow Definition owns a full-screen editor shell. The layout deliberately
+ * follows a professional canvas editor rather than a workflow-product sidebar:
+ * one global toolbar, a compact asset rail, canvas workspace and docked inspector.
  */
 export default function WorkflowDefinitionFullscreenPage() {
   return (
-    <div className="workflow-definition-fullscreen-shell h-screen overflow-hidden bg-[#f2f4f7]">
+    <div className="workflow-definition-fullscreen-shell h-screen overflow-hidden bg-[#f5f6f8]">
       <WorkflowDefinitionEditor />
       <style>{`
         .workflow-definition-fullscreen-shell > div:first-child {
           height: 100vh !important;
           min-height: 100vh !important;
+          padding-top: 52px;
+          box-sizing: border-box;
+          background: #f5f6f8 !important;
         }
 
         .workflow-definition-fullscreen-shell .workflow-editor-toolbar {
+          position: fixed !important;
+          inset: 0 0 auto 0 !important;
+          z-index: 60 !important;
+          width: 100vw !important;
           height: 52px !important;
+          border-bottom: 1px solid #e8eaee !important;
+          background: rgba(255,255,255,.98) !important;
+          padding-left: 18px !important;
+          padding-right: 14px !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div[style],
+        .workflow-definition-fullscreen-shell section > div.relative {
+          background: #f5f6f8 !important;
+        }
+
+        .workflow-definition-fullscreen-shell .react-flow {
+          background: #f7f8fa !important;
+        }
+
+        .workflow-definition-fullscreen-shell .react-flow__background pattern circle {
+          fill: #dfe3e8 !important;
+          opacity: .7;
+        }
+
+        .workflow-definition-fullscreen-shell .react-flow__minimap {
+          display: none !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside {
+          top: 0 !important;
+          right: 0 !important;
+          bottom: 0 !important;
+          left: auto !important;
+          width: 340px !important;
+          border: 0 !important;
+          border-left: 1px solid #e8eaee !important;
+          border-radius: 0 !important;
+          box-shadow: none !important;
+          background: #fff !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > .react-flow {
+          width: calc(100% - 340px) !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside > header {
+          border-bottom: 1px solid #eef0f2 !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside > header > div:nth-child(2) {
+          display: none !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside > header > div:first-child {
+          padding: 14px 16px 8px !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside > header nav {
+          height: 38px !important;
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+          gap: 20px !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside .mx-4.border-t {
+          display: none !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside section {
+          padding-top: 13px !important;
+          padding-bottom: 13px !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) > aside .rounded-xl {
+          border-radius: 8px !important;
+        }
+
+        .workflow-definition-fullscreen-shell [class*="absolute left-3 top-1/2"] {
+          top: 12px !important;
+          left: 50% !important;
+          bottom: auto !important;
+          transform: translateX(-50%) !important;
+          flex-direction: row !important;
+          border-radius: 9px !important;
+          box-shadow: 0 2px 10px rgba(22,24,35,.06) !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) [class*="absolute left-3 top-1/2"] {
+          left: calc((100% - 340px) / 2) !important;
+        }
+
+        .workflow-definition-fullscreen-shell [class*="absolute bottom-2 left-1/2"] {
+          bottom: 14px !important;
+          border-radius: 9px !important;
+          box-shadow: 0 2px 10px rgba(22,24,35,.06) !important;
+        }
+
+        .workflow-definition-fullscreen-shell section > div:has(> aside) [class*="absolute bottom-2 left-1/2"] {
+          left: calc((100% - 340px) / 2) !important;
+        }
+
+        .workflow-definition-fullscreen-shell [class*="absolute left-3 top-1/2"] > div[class*="h-px"] {
+          width: 1px !important;
+          height: 18px !important;
+          margin: 0 4px !important;
+        }
+
+        @media (max-width: 1180px) {
+          .workflow-definition-fullscreen-shell section > div:has(> aside) > aside {
+            width: 320px !important;
+          }
+
+          .workflow-definition-fullscreen-shell section > div:has(> aside) > .react-flow {
+            width: calc(100% - 320px) !important;
+          }
+
+          .workflow-definition-fullscreen-shell section > div:has(> aside) [class*="absolute left-3 top-1/2"],
+          .workflow-definition-fullscreen-shell section > div:has(> aside) [class*="absolute bottom-2 left-1/2"] {
+            left: calc((100% - 320px) / 2) !important;
+          }
         }
       `}</style>
     </div>


### PR DESCRIPTION
## What changed

- move the workflow editor toward a professional canvas/studio layout instead of the previous Dify-like workspace shell
- make the top workflow toolbar span the full editor width
- replace the workflow navigation sidebar with a compact icon rail + node/resource library
- add searchable draggable task nodes to the left library
- move the floating canvas tool group to the top-center area and simplify the canvas chrome
- hide the minimap and soften the canvas background/grid
- dock the node inspector to the right edge instead of using a floating rounded panel
- shrink the inspector width, remove the large shadow/rounded container, reduce dividers, and simplify the node header/tabs
- automatically reserve canvas width when the right inspector is open so node properties no longer cover the canvas
- apply the same docked/right-panel treatment to the start-node inspector through the editor shell styles

## Layout direction

`顶部全局工具栏`

`左侧图标栏 + 节点/资源面板 | 工作流画布 | 右侧节点属性`

The intent is closer to a Figma/BI-style editor shell while keeping Yak Ops workflow behavior and brand styling.

## Scope

Changed 3 workflow editor UI files only:

- `WorkflowTaskLibrary.tsx`
- `WorkflowNodeInspector.tsx`
- `definition/index.tsx`

No workflow runtime, persistence, scheduling, or node execution behavior is changed.

## Validation

- branch is based on the latest `main`
- reviewed the branch diff: 3 commits / 3 changed files
- local clone/build could not be executed in this environment because outbound network/DNS access to GitHub is unavailable; CI should be used for final TypeScript/build verification
