### PR TITLE
fix(ui): preserve data development tabs when selecting directories

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'antd';
 import { Boxes, RefreshCw } from 'lucide-react';
-import { Component, type ReactNode, useMemo } from 'react';
+import { Component, type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { isDevelopmentTaskNode } from '../node-model';
 import type {
@@ -77,9 +77,21 @@ export default function DevelopmentEditorWorkspace({
   onNodeFocus,
   onNodesChanged,
 }: DevelopmentEditorWorkspaceProps) {
+  const [focusedNodeId, setFocusedNodeId] = useState<DevelopmentId | undefined>(selectedNodeId);
+
+  useEffect(() => {
+    if (!selectedNodeId || !nodes.some((node) => node.id === selectedNodeId)) return;
+    setFocusedNodeId(selectedNodeId);
+  }, [nodes, selectedNodeId]);
+
+  // Directory selection only changes the tree context. Keep the last focused
+  // development node so the workbench (and its open tabs) stays mounted.
+  const effectiveNodeId = selectedNodeId && nodes.some((node) => node.id === selectedNodeId)
+    ? selectedNodeId
+    : focusedNodeId;
   const selectedResource = useMemo(
-    () => nodes.find((node) => node.id === selectedNodeId),
-    [nodes, selectedNodeId],
+    () => nodes.find((node) => node.id === effectiveNodeId),
+    [effectiveNodeId, nodes],
   );
   const workbenchNodes = useMemo(
     () => nodes.filter((node) =>
@@ -88,6 +100,11 @@ export default function DevelopmentEditorWorkspace({
       || node.type === 'DATASET'),
     [nodes],
   );
+
+  const handleNodeFocus = (nodeId?: DevelopmentId) => {
+    setFocusedNodeId(nodeId);
+    onNodeFocus(nodeId);
+  };
 
   if (!selectedResource) {
     return (
@@ -116,7 +133,7 @@ export default function DevelopmentEditorWorkspace({
           nodes={workbenchNodes}
           directories={directories}
           selectedNodeId={selectedResource.id}
-          onNodeFocus={onNodeFocus}
+          onNodeFocus={handleNodeFocus}
           onNodesChanged={onNodesChanged}
         />
       </ResourceEditorBoundary>


### PR DESCRIPTION
## 问题

数据开发页面中，右侧已经打开多个开发节点 Tab 后，点击左侧目录会导致右侧 Tab 全部消失，并回到“选择一个开发节点”的空状态。

原因是目录被选中后，页面传给 `DevelopmentEditorWorkspace` 的 `selectedNodeId` 变为 `undefined`，进而直接卸载整个 `DevelopmentWorkbench`。Workbench 内部维护的 `openNodeIds` / `activeNodeId` 会随组件卸载一起丢失。

## 调整

- 在 `DevelopmentEditorWorkspace` 内保留最后一次聚焦的开发节点。
- 左侧选择目录时，只更新目录树上下文，不再卸载右侧 Workbench。
- 点击新的开发节点时仍正常切换/打开对应 Tab。
- Workbench 主动切换或关闭 Tab 时，继续通过原有 `onNodeFocus` 同步焦点。

## 预期交互

1. 打开多个 SQL / Shell / Dataset / Data Service Tab。
2. 点击左侧任意目录。
3. 右侧已打开的 Tab、当前编辑内容及 Workbench 状态保持不变。
4. 再点击具体开发节点时，继续正常打开或切换对应 Tab。

## 变更范围

仅修改数据开发编辑工作区的焦点保持逻辑，不调整接口、目录树数据结构和任务执行/保存逻辑。