### PR TITLE
style(ui): refine active tab seam in data development

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorTabs.tsx
@@ -144,7 +144,7 @@ const EditorTabs = ({
                 className={[
                   'group relative flex h-9 min-w-[120px] max-w-[220px] flex-none items-center border-b border-b-transparent border-r border-r-[#e5e7eb] border-t-2 transition-colors',
                   active
-                    ? 'z-10 border-b-white border-t-[rgba(254,44,85,1)] bg-white text-[#344054]'
+                    ? `z-10 border-b-white border-t-[rgba(254,44,85,1)] bg-white text-[#344054] after:pointer-events-none after:absolute after:-bottom-px after:left-0 after:right-0 after:z-20 after:h-px after:bg-white after:content-['']`
                     : 'border-t-transparent bg-[#f7f7f8] text-[#667085] hover:bg-[#f0f1f2] hover:text-[#344054]',
                 ].join(' ')}
               >


### PR DESCRIPTION
## 背景

数据开发页面的编辑器 Tab 当前有一条贯穿整个 Tab 区域的底部分隔线。即使当前 Tab 已经是白色背景，选中 Tab 下方仍然能看到灰色线条，视觉上会把当前 Tab 与下方编辑区割开。

## 调整

- 保留 Tab 栏整体的底部分隔线。
- 当前激活 Tab 对应宽度范围内，用白色覆盖底部分隔线。
- 保留现有顶部品牌红激活线、图标、文字、hover 与关闭按钮交互。
- 不调整 Tab 尺寸、工作台布局和业务逻辑。

## 预期效果

激活 Tab 与下方编辑器白色区域自然连成一体；未激活区域仍保留灰色分隔线，层级更加清晰，更接近 IDE / 数据库开发工具的 Tab 视觉。