### PR TITLE
style(ui): 统一 Table 组件滚动条样式

### DIFF
--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -68,6 +68,67 @@ body {
   background: transparent;
 }
 
+// Ant Design Table uses its own scroll containers and, with sticky enabled,
+// an extra simulated scrollbar. Keep both variants aligned with the global style.
+.ant-table-content,
+.ant-table-body {
+  scrollbar-color: rgba(0, 0, 0, 0.32) transparent;
+  scrollbar-width: thin;
+}
+
+.ant-table-content::-webkit-scrollbar,
+.ant-table-body::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.ant-table-content::-webkit-scrollbar-track,
+.ant-table-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.ant-table-content::-webkit-scrollbar-thumb,
+.ant-table-body::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.32);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+  border-radius: 999px;
+}
+
+.ant-table-content::-webkit-scrollbar-thumb:hover,
+.ant-table-body::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.45);
+  background-clip: padding-box;
+}
+
+.ant-table-content::-webkit-scrollbar-button,
+.ant-table-body::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.ant-table-content::-webkit-scrollbar-corner,
+.ant-table-body::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.ant-table-wrapper .ant-table-sticky-scroll {
+  height: 10px !important;
+  background: transparent !important;
+}
+
+.ant-table-wrapper .ant-table-sticky-scroll-bar {
+  bottom: 2px !important;
+  height: 6px !important;
+  background: rgba(0, 0, 0, 0.32) !important;
+  border-radius: 999px !important;
+}
+
+.ant-table-wrapper .ant-table-sticky-scroll-bar:hover {
+  background: rgba(0, 0, 0, 0.45) !important;
+}
+
 ul,
 ol {
   list-style: none;


### PR DESCRIPTION
## 变更说明

- 在 `yak-ops-ui/src/global.less` 中补充 Ant Design `Table` 专用滚动条样式
- 统一 `.ant-table-content` / `.ant-table-body` 的横向、纵向滚动条视觉
- 隐藏 Windows / WebKit 下滚动条两端的原生箭头按钮
- 兼容 Firefox 的 `scrollbar-width` / `scrollbar-color`
- 同步覆盖 Ant Design `sticky` Table 使用的模拟滚动条，使其与全局滚动条保持一致
- 保持现有全局滚动条的 10px 容器、约 6px 可见滑块、透明轨道和轻微 hover 加深效果

## 影响范围

仅修改 `global.less` 中的样式，不涉及 Table 业务逻辑和组件调用方式。

## 验证建议

重点检查离线同步、数据开发以及其他使用 Ant Design `<Table />` 且存在横向/纵向滚动的页面，确认：

- 横向滚动条不再出现两端箭头
- Table 滚动条粗细、圆角、颜色与页面其他滚动区域一致
- `sticky` Table 的底部滚动条样式一致
- hover 状态正常，固定列与滚动行为不受影响