### PR TITLE
fix(ui): unify SQL row run actions in data development

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -51,6 +51,16 @@ const ensureYakThemes = () => {
   YAK_EDITOR_THEMES.forEach((theme) => monaco.editor.defineTheme(theme.name, theme.data));
 };
 
+const findFallbackRunButton = (container: HTMLElement | null) => {
+  let element = container;
+  while (element) {
+    const button = element.querySelector<HTMLButtonElement>('button[aria-label="运行查询"]');
+    if (button) return button;
+    element = element.parentElement;
+  }
+  return undefined;
+};
+
 const SqlMonacoEditor = ({
   id,
   value,
@@ -151,19 +161,67 @@ const SqlMonacoEditor = ({
     });
 
     let statementRanges = getSqlStatementRanges(model.getValue());
+    let hoveredStatementStartLine: number | undefined;
     const runDecorations = editor.createDecorationsCollection();
-    const refreshStatementDecorations = () => {
-      statementRanges = getSqlStatementRanges(model.getValue());
-      runDecorations.set(
-        readOnly
-          ? []
-          : statementRanges.map((statement) => ({
-              range: new monaco.Range(statement.startLine, 1, statement.startLine, 1),
-              options: { glyphMarginClassName: 'yak-sql-run-glyph' },
-            })),
-      );
+
+    const clearStatementDecoration = () => {
+      hoveredStatementStartLine = undefined;
+      runDecorations.clear();
     };
-    refreshStatementDecorations();
+
+    const canRunStatement = () => {
+      if (onRunStatementRef.current) return true;
+      const button = findFallbackRunButton(containerRef.current);
+      return Boolean(button && !button.disabled);
+    };
+
+    const runStatement = (sql: string) => {
+      if (onRunStatementRef.current) {
+        onRunStatementRef.current(sql);
+        return;
+      }
+      const button = findFallbackRunButton(containerRef.current);
+      if (button && !button.disabled) button.click();
+    };
+
+    const refreshStatementRanges = () => {
+      statementRanges = getSqlStatementRanges(model.getValue());
+      clearStatementDecoration();
+    };
+
+    const showStatementDecoration = (lineNumber?: number) => {
+      if (readOnly || runningRef.current || !lineNumber || !canRunStatement()) {
+        clearStatementDecoration();
+        return;
+      }
+
+      const statement = statementRanges.find((candidate) => candidate.startLine === lineNumber);
+      if (!statement) {
+        clearStatementDecoration();
+        return;
+      }
+      if (hoveredStatementStartLine === statement.startLine) return;
+
+      hoveredStatementStartLine = statement.startLine;
+      runDecorations.set([
+        {
+          range: new monaco.Range(statement.startLine, 1, statement.startLine, 1),
+          options: { glyphMarginClassName: 'yak-sql-run-glyph' },
+        },
+        {
+          range: new monaco.Range(
+            statement.startLine,
+            1,
+            statement.endLine,
+            model.getLineMaxColumn(statement.endLine),
+          ),
+          options: {
+            isWholeLine: true,
+            className: 'bg-[rgba(34,160,107,0.035)]',
+          },
+        },
+      ]);
+    };
 
     let wordWrapEnabled = initialSettings.wordWrap;
     let minimapEnabled = initialSettings.showMinimap;
@@ -228,20 +286,28 @@ const SqlMonacoEditor = ({
     };
 
     const contentDisposable = model.onDidChangeContent(() => {
-      refreshStatementDecorations();
+      refreshStatementRanges();
       if (!readOnly) onChangeRef.current(model.getValue());
+    });
+    const hoverDisposable = editor.onMouseMove((event) => {
+      showStatementDecoration(event.target.position?.lineNumber);
+    });
+    const mouseLeaveDisposable = editor.onMouseLeave(() => {
+      clearStatementDecoration();
     });
     const gutterDisposable = editor.onMouseDown((event) => {
       if (
         readOnly ||
         event.target.type !== monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN ||
         runningRef.current ||
-        !onRunStatementRef.current
+        !canRunStatement()
       ) return;
       const lineNumber = event.target.position?.lineNumber;
       if (!lineNumber) return;
       const statement = statementRanges.find((candidate) => candidate.startLine === lineNumber);
-      if (statement) onRunStatementRef.current(statement.sql);
+      if (!statement) return;
+      clearStatementDecoration();
+      runStatement(statement.sql);
     });
     const cursorDisposable = editor.onDidChangeCursorPosition(emitEditorState);
     const selectionDisposable = editor.onDidChangeCursorSelection(emitEditorState);
@@ -253,6 +319,8 @@ const SqlMonacoEditor = ({
       emitEditorState();
       unsubscribeSettings();
       contentDisposable.dispose();
+      hoverDisposable.dispose();
+      mouseLeaveDisposable.dispose();
       gutterDisposable.dispose();
       cursorDisposable.dispose();
       selectionDisposable.dispose();


### PR DESCRIPTION
## 问题

数据开发中的 SQL / Dataset / Data Service 共用 `SqlMonacoEditor`。此前编辑器会给所有 SQL statement 起始行常驻绘制运行按钮，但只有 SQL 节点传入了 `onRunStatement`；Dataset / Data Service 因此会出现“按钮看起来可运行，但点击没有动作”的情况。

## 调整

- 行级运行按钮默认隐藏，仅在鼠标 hover 到可运行 SQL statement 的起始行时显示。
- hover 当前 statement 时增加非常浅的绿色背景，帮助识别运行范围，但不做重色强调。
- SQL 节点继续调用现有 statement 执行逻辑。
- Dataset / Data Service 未提供 statement handler 时，回落到各自已经存在的“运行查询”流程，只在对应运行按钮可用时展示行级运行入口。
- 运行中、只读或运行条件不满足时不展示行级运行按钮。
- 鼠标离开编辑器、SQL 内容变化后及时清理 hover decoration。

## 统一方式

交互统一收敛在公共 `SqlMonacoEditor` 中，SQL / Dataset / Data Service 自动保持一致，避免三套编辑器分别维护相同的运行按钮样式和交互。

## 变更范围

仅修改 `SqlMonacoEditor.tsx`，不调整后端接口、节点保存、发布和上线逻辑。