### PR TITLE
fix(ui): align SQL statement run action with Chat2DB

### DIFF
--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -232,24 +232,30 @@ ol {
   display: none;
 }
 
-// SQL editor statement action: compact green play marker in Monaco's glyph margin.
+// SQL editor statement action follows Chat2DB: the active statement exposes a
+// compact outlined play glyph at its first line, while the current line keeps
+// Monaco's native very-light highlight.
+.yak-sql-editor .monaco-editor .margin {
+  border-right: 1px solid rgba(148, 163, 184, 0.18);
+}
+
 .yak-sql-run-glyph {
+  width: 16px !important;
+  height: 16px !important;
   cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5 3l14 9-14 9V3z' fill='none' stroke='%23667085' stroke-width='1.8' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 15px 15px;
+  opacity: 0.82;
+  transition: transform 0.16s ease-in-out, opacity 0.16s ease-in-out;
 }
 
-.yak-sql-run-glyph::before {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 0;
-  height: 0;
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  border-left: 8px solid #22a06b;
-  content: '';
-  transform: translate(-42%, -50%);
+.yak-sql-run-glyph:hover {
+  opacity: 1;
+  transform: scale(1.18);
 }
 
-.yak-sql-run-glyph:hover::before {
-  border-left-color: #138a5b;
+.yak-sql-run-glyph:active {
+  transform: scale(1);
 }

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -23,7 +23,10 @@ import {
 } from '../editorSettings';
 import { formatSqlText } from '../formatting/formatSqlText';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
-import { getSqlStatementRanges } from '../monaco/sqlStatementRanges';
+import {
+  getSqlStatementRanges,
+  type SqlStatementRange,
+} from '../monaco/sqlStatementRanges';
 
 export interface SqlEditorPosition {
   lineNumber: number;
@@ -78,12 +81,16 @@ const SqlMonacoEditor = ({
   const onChangeRef = useRef(onChange);
   const onRunStatementRef = useRef(onRunStatement);
   const runningRef = useRef(running);
+  const refreshRunDecorationRef = useRef<() => void>(() => {});
   const onPositionChangeRef = useRef(onPositionChange);
   const onViewStateChangeRef = useRef(onViewStateChange);
 
   useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
   useEffect(() => { onRunStatementRef.current = onRunStatement; }, [onRunStatement]);
-  useEffect(() => { runningRef.current = running; }, [running]);
+  useEffect(() => {
+    runningRef.current = running;
+    refreshRunDecorationRef.current();
+  }, [running]);
   useEffect(() => { onPositionChangeRef.current = onPositionChange; }, [onPositionChange]);
   useEffect(() => { onViewStateChangeRef.current = onViewStateChange; }, [onViewStateChange]);
 
@@ -161,19 +168,49 @@ const SqlMonacoEditor = ({
     });
 
     let statementRanges = getSqlStatementRanges(model.getValue());
-    let hoveredStatementStartLine: number | undefined;
+    let activeStatement: SqlStatementRange | undefined;
     const runDecorations = editor.createDecorationsCollection();
 
-    const clearStatementDecoration = () => {
-      hoveredStatementStartLine = undefined;
-      runDecorations.clear();
-    };
-
     const canRunStatement = () => {
+      if (readOnly || runningRef.current) return false;
       if (onRunStatementRef.current) return true;
       const button = findFallbackRunButton(containerRef.current);
       return Boolean(button && !button.disabled);
     };
+
+    const findStatementAtPosition = (position?: monaco.Position | null) => {
+      if (!position) return undefined;
+      const offset = model.getOffsetAt(position);
+      const exact = statementRanges.find(
+        (statement) => offset >= statement.startOffset && offset <= statement.endOffset,
+      );
+      if (exact) return exact;
+      return statementRanges.find(
+        (statement) =>
+          position.lineNumber >= statement.startLine
+          && position.lineNumber <= statement.endLine,
+      );
+    };
+
+    const updateRunDecoration = (position = editor.getPosition()) => {
+      activeStatement = findStatementAtPosition(position);
+      if (!activeStatement || !canRunStatement()) {
+        runDecorations.clear();
+        return;
+      }
+
+      runDecorations.set([
+        {
+          range: new monaco.Range(activeStatement.startLine, 1, activeStatement.startLine, 1),
+          options: {
+            isWholeLine: false,
+            glyphMarginClassName: 'yak-sql-run-glyph',
+          },
+        },
+      ]);
+    };
+
+    refreshRunDecorationRef.current = () => updateRunDecoration();
 
     const runStatement = (sql: string) => {
       if (onRunStatementRef.current) {
@@ -186,41 +223,7 @@ const SqlMonacoEditor = ({
 
     const refreshStatementRanges = () => {
       statementRanges = getSqlStatementRanges(model.getValue());
-      clearStatementDecoration();
-    };
-
-    const showStatementDecoration = (lineNumber?: number) => {
-      if (readOnly || runningRef.current || !lineNumber || !canRunStatement()) {
-        clearStatementDecoration();
-        return;
-      }
-
-      const statement = statementRanges.find((candidate) => candidate.startLine === lineNumber);
-      if (!statement) {
-        clearStatementDecoration();
-        return;
-      }
-      if (hoveredStatementStartLine === statement.startLine) return;
-
-      hoveredStatementStartLine = statement.startLine;
-      runDecorations.set([
-        {
-          range: new monaco.Range(statement.startLine, 1, statement.startLine, 1),
-          options: { glyphMarginClassName: 'yak-sql-run-glyph' },
-        },
-        {
-          range: new monaco.Range(
-            statement.startLine,
-            1,
-            statement.endLine,
-            model.getLineMaxColumn(statement.endLine),
-          ),
-          options: {
-            isWholeLine: true,
-            className: 'bg-[rgba(34,160,107,0.035)]',
-          },
-        },
-      ]);
+      updateRunDecoration();
     };
 
     let wordWrapEnabled = initialSettings.wordWrap;
@@ -289,38 +292,32 @@ const SqlMonacoEditor = ({
       refreshStatementRanges();
       if (!readOnly) onChangeRef.current(model.getValue());
     });
-    const hoverDisposable = editor.onMouseMove((event) => {
-      showStatementDecoration(event.target.position?.lineNumber);
-    });
-    const mouseLeaveDisposable = editor.onMouseLeave(() => {
-      clearStatementDecoration();
-    });
     const gutterDisposable = editor.onMouseDown((event) => {
       if (
         readOnly ||
         event.target.type !== monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN ||
         runningRef.current ||
-        !canRunStatement()
+        !activeStatement
       ) return;
       const lineNumber = event.target.position?.lineNumber;
-      if (!lineNumber) return;
-      const statement = statementRanges.find((candidate) => candidate.startLine === lineNumber);
-      if (!statement) return;
-      clearStatementDecoration();
-      runStatement(statement.sql);
+      if (!lineNumber || lineNumber !== activeStatement.startLine) return;
+      runStatement(activeStatement.sql);
     });
-    const cursorDisposable = editor.onDidChangeCursorPosition(emitEditorState);
+    const cursorDisposable = editor.onDidChangeCursorPosition(() => {
+      emitEditorState();
+      updateRunDecoration();
+    });
     const selectionDisposable = editor.onDidChangeCursorSelection(emitEditorState);
     const scrollDisposable = editor.onDidScrollChange(emitEditorState);
 
     emitEditorState();
+    updateRunDecoration();
 
     return () => {
       emitEditorState();
+      refreshRunDecorationRef.current = () => {};
       unsubscribeSettings();
       contentDisposable.dispose();
-      hoverDisposable.dispose();
-      mouseLeaveDisposable.dispose();
       gutterDisposable.dispose();
       cursorDisposable.dispose();
       selectionDisposable.dispose();

--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -299,6 +299,8 @@ const SqlMonacoEditor = ({
         runningRef.current ||
         !activeStatement
       ) return;
+      const target = event.target.element;
+      if (!(target instanceof HTMLElement) || !target.classList.contains('yak-sql-run-glyph')) return;
       const lineNumber = event.target.position?.lineNumber;
       if (!lineNumber || lineNumber !== activeStatement.startLine) return;
       runStatement(activeStatement.sql);
@@ -344,7 +346,7 @@ const SqlMonacoEditor = ({
     model.pushEditOperations([], [{ range: model.getFullModelRange(), text: value }], () => null);
   }, [value]);
 
-  return <div ref={containerRef} className="h-full min-h-0 w-full" />;
+  return <div ref={containerRef} className="yak-sql-editor h-full min-h-0 w-full" />;
 };
 
 export default SqlMonacoEditor;


### PR DESCRIPTION
## 背景

上一版 #548 已经解决了 Dataset / Data Service 行级运行入口没有实际动作的问题，但交互理解偏成了“鼠标 hover 某一行显示运行按钮”。

这次直接参考 Chat2DB 的 SQL Editor 源码和实际交互重新调整：运行按钮应跟随 **editor caret 所在的 SQL statement**，而不是跟随鼠标 hover。

参考实现：
- `chat2db-community-client/src/components/SQLEditor/editor/SQLEditor/index.tsx`
  - `onDidChangeCursorPosition -> updateDecoration`
  - 根据当前位置查找 `currentStatement`
  - 只在 `currentStatement.sqlStartRowNum` 添加 execute glyph
- `chat2db-community-client/src/components/SQLEditor/core/setDecorations.ts`
  - `setExecuteButtonDecorations`
- `chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/index.less`
  - 16px play glyph
  - hover scale 动效

## 调整

- 移除上一版基于 `onMouseMove / onMouseLeave` 的 statement hover 逻辑。
- 光标进入某个 SQL statement 后，只在该 statement 的第一行显示运行按钮。
- 光标在同一个多行 statement 内移动时，运行按钮固定在 statement 起始行，不跟随当前物理行移动。
- 光标移动到 SQL statement 之外的空白行时，运行按钮立即消失。
- 多条 SQL 时，光标进入不同 statement，运行按钮自动切换到对应 statement 起始行。
- SQL 内容变化后重新计算 statement range，并保持当前光标对应的运行入口。
- 移除整段 statement 的浅绿色背景，恢复 Monaco 原生的当前行轻量高亮，更接近 Chat2DB。
- 运行按钮调整为 Chat2DB 风格的灰色描边 Play glyph，hover 轻微放大。
- gutter 点击只响应真实的 `yak-sql-run-glyph`，避免其他 glyph 被误触。
- SQL 节点继续执行当前 statement；Dataset / Data Service 仍回落到各自已有且可用的“运行查询”动作。
- 运行中、只读或 Dataset / Data Service 运行条件不满足时不显示行级运行入口。

## 变更范围

- `SqlMonacoEditor.tsx`
- `global.less`

不调整后端 API、Dataset 保存逻辑或 Data Service 发布/上线逻辑。