### PR TITLE
fix(dashboard): show current chart query in performance analysis

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetController.java
@@ -42,9 +42,11 @@ public class DatasetController {
   @GetMapping("/query-performance")
   public Result<List<DatasetQueryPerformance>> queryPerformance(
       @RequestParam(value = "datasetIds", required = false) List<Long> datasetIds,
+      @RequestParam(value = "queryIds", required = false) List<String> queryIds,
       @RequestParam(value = "limit", defaultValue = "100") int limit) {
-    Set<Long> filters = datasetIds == null ? Set.of() : new HashSet<>(datasetIds);
-    return Result.success(queryService.recentPerformance(filters, limit));
+    Set<Long> datasetFilters = datasetIds == null ? Set.of() : new HashSet<>(datasetIds);
+    Set<String> queryFilters = queryIds == null ? Set.of() : new HashSet<>(queryIds);
+    return Result.success(queryService.recentPerformance(datasetFilters, queryFilters, limit));
   }
 
   @Operation(summary = "查询 Dataset 详情、当前版本与版本历史")

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformanceService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryPerformanceService.java
@@ -27,11 +27,20 @@ public class DatasetQueryPerformanceService {
   }
 
   public List<DatasetQueryPerformance> recent(Set<Long> datasetIds, int requestedLimit) {
+    return recent(datasetIds, Set.of(), requestedLimit);
+  }
+
+  public List<DatasetQueryPerformance> recent(
+      Set<Long> datasetIds,
+      Set<String> queryIds,
+      int requestedLimit) {
     int limit = Math.max(1, Math.min(requestedLimit, MAX_QUERY_LIMIT));
     boolean filterDatasets = datasetIds != null && !datasetIds.isEmpty();
+    boolean filterQueries = queryIds != null && !queryIds.isEmpty();
     List<DatasetQueryPerformance> result = new ArrayList<>(Math.min(limit, traces.size()));
     for (DatasetQueryPerformance trace : traces) {
       if (filterDatasets && !datasetIds.contains(trace.datasetId())) continue;
+      if (filterQueries && !queryIds.contains(trace.queryId())) continue;
       result.add(trace);
       if (result.size() >= limit) break;
     }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryResult.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 /** Result returned to Dashboard/Chart consumers by the Dataset query runtime. */
 public record DatasetQueryResult(
+    String queryId,
     @JsonSerialize(using = ToStringSerializer.class) long datasetId,
     @JsonSerialize(using = ToStringSerializer.class) long datasetVersionId,
     int datasetVersionNo,
@@ -23,6 +24,43 @@ public record DatasetQueryResult(
     bindings = bindings == null ? List.of() : List.copyOf(bindings);
     columns = columns == null ? List.of() : List.copyOf(columns);
     rows = immutableRows(rows);
+  }
+
+  public DatasetQueryResult(
+      long datasetId,
+      long datasetVersionId,
+      int datasetVersionNo,
+      List<DatasetQueryColumnBinding> bindings,
+      List<SqlExecutionColumn> columns,
+      List<List<Object>> rows,
+      int returnedRows,
+      boolean truncated,
+      long elapsedMillis) {
+    this(
+        null,
+        datasetId,
+        datasetVersionId,
+        datasetVersionNo,
+        bindings,
+        columns,
+        rows,
+        returnedRows,
+        truncated,
+        elapsedMillis);
+  }
+
+  public DatasetQueryResult withQueryId(String value) {
+    return new DatasetQueryResult(
+        value,
+        datasetId,
+        datasetVersionId,
+        datasetVersionNo,
+        bindings,
+        columns,
+        rows,
+        returnedRows,
+        truncated,
+        elapsedMillis);
   }
 
   private static List<List<Object>> immutableRows(List<List<Object>> values) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
@@ -52,9 +52,10 @@ public class DatasetQueryService {
 
     DatasetQueryExecution execution = adapter.execute(dataset, version, fields, request);
     long totalMillis = elapsedMillis(queryStartedAt);
-    DatasetQueryResult result = execution.result();
+    String queryId = UUID.randomUUID().toString().replace("-", "");
+    DatasetQueryResult result = execution.result().withQueryId(queryId);
     performanceService.record(new DatasetQueryPerformance(
-        UUID.randomUUID().toString().replace("-", ""),
+        queryId,
         dataset.id(),
         dataset.name(),
         version.id(),
@@ -75,6 +76,13 @@ public class DatasetQueryService {
 
   public List<DatasetQueryPerformance> recentPerformance(Set<Long> datasetIds, int limit) {
     return performanceService.recent(datasetIds, limit);
+  }
+
+  public List<DatasetQueryPerformance> recentPerformance(
+      Set<Long> datasetIds,
+      Set<String> queryIds,
+      int limit) {
+    return performanceService.recent(datasetIds, queryIds, limit);
   }
 
   private DatasetVersion resolveVersion(Dataset dataset, Integer versionNo) {

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryPerformanceServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetQueryPerformanceServiceTest.java
@@ -23,6 +23,20 @@ class DatasetQueryPerformanceServiceTest {
   }
 
   @Test
+  void filtersRecentTracesByExactQueryIds() {
+    DatasetQueryPerformanceService service = new DatasetQueryPerformanceService();
+    service.record(trace("q1", 1L, 10L));
+    service.record(trace("q2", 1L, 20L));
+    service.record(trace("q3", 2L, 30L));
+
+    var traces = service.recent(Set.of(), Set.of("q1", "q3"), 10);
+
+    assertEquals(2, traces.size());
+    assertEquals("q3", traces.get(0).queryId());
+    assertEquals("q1", traces.get(1).queryId());
+  }
+
+  @Test
   void capsTheDiagnosticWindow() {
     DatasetQueryPerformanceService service = new DatasetQueryPerformanceService();
     for (int index = 0; index < DatasetQueryPerformanceService.MAX_TRACES + 5; index++) {

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -266,6 +266,7 @@ export interface DatasetQueryColumn {
 }
 
 export interface DatasetQueryResult {
+  queryId?: string;
   datasetId: string;
   datasetVersionId: string;
   datasetVersionNo: number;

--- a/yak-ops-ui/src/components/analysis/query-runtime.ts
+++ b/yak-ops-ui/src/components/analysis/query-runtime.ts
@@ -7,6 +7,7 @@ import type {
 
 const QUERY_RESULT_TTL_MS = 1_500;
 const MAX_QUERY_ENTRIES = 64;
+const MAX_QUERY_IDS = 128;
 
 type AnalysisQueryLoader = (
   datasetId: string,
@@ -20,6 +21,7 @@ interface QueryEntry {
 }
 
 const queryEntries = new Map<string, QueryEntry>();
+const latestQueryIds = new Map<string, string>();
 
 export const analysisQueryCacheKey = (
   dataset: Pick<PublishedDataset, 'id' | 'currentVersionNo'>,
@@ -38,6 +40,17 @@ const pruneQueryEntries = (now: number) => {
     const oldest = queryEntries.keys().next().value as string | undefined;
     if (!oldest) break;
     queryEntries.delete(oldest);
+  }
+};
+
+const rememberQueryId = (key: string, queryId?: string) => {
+  if (!queryId) return;
+  latestQueryIds.delete(key);
+  latestQueryIds.set(key, queryId);
+  while (latestQueryIds.size > MAX_QUERY_IDS) {
+    const oldest = latestQueryIds.keys().next().value as string | undefined;
+    if (!oldest) break;
+    latestQueryIds.delete(oldest);
   }
 };
 
@@ -66,6 +79,7 @@ export const queryAnalysisDatasetShared = (
     .then((result) => {
       entry.settled = true;
       entry.expiresAt = Date.now() + QUERY_RESULT_TTL_MS;
+      rememberQueryId(key, result.queryId);
       return result;
     })
     .catch((error) => {
@@ -81,6 +95,11 @@ export const queryAnalysisDatasetShared = (
   return promise;
 };
 
-export const clearAnalysisQueryRuntime = () => queryEntries.clear();
+export const latestAnalysisQueryId = (queryKey: string) => latestQueryIds.get(queryKey);
+
+export const clearAnalysisQueryRuntime = () => {
+  queryEntries.clear();
+  latestQueryIds.clear();
+};
 
 export const analysisQueryRuntimeSize = () => queryEntries.size;

--- a/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
+++ b/yak-ops-ui/src/pages/dashboard/chart-sheet-workspace.tsx
@@ -1,6 +1,12 @@
-import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
+import {
+  AnalysisPreview,
+  buildDatasetQueryPayload,
+  canQueryAnalysis,
+} from '@/components/analysis/AnalysisPreview';
+import { analysisQueryCacheKey } from '@/components/analysis/query-runtime';
 import { Empty } from 'antd';
 import { BarChart3 } from 'lucide-react';
+import { useEffect, useMemo } from 'react';
 import { ChartAppearanceConfigPanel } from './chart-editor';
 import { ChartDataColumn } from './chart-data-column';
 import { ChartEncodingShelf } from './chart-encoding-shelf';
@@ -15,6 +21,7 @@ import type {
   DashboardWidget,
   PublishedDataset,
 } from './model';
+import { registerDashboardPerformanceQuery } from './performance-runtime';
 
 export function DashboardChartSheetWorkspace({
   currentDashboardId,
@@ -58,6 +65,23 @@ export function DashboardChartSheetWorkspace({
     : widget.title?.trim() || '未命名图表';
   const chartTypeLabel = spec ? CHART_META[spec.type]?.label : undefined;
   const editable = !widget.analysisId && Boolean(widget.inlineAnalysis);
+  const performanceQueryKey = useMemo(() => {
+    if (!spec || !dataset || !canQueryAnalysis(spec)) return undefined;
+    return analysisQueryCacheKey(
+      dataset,
+      buildDatasetQueryPayload(spec, dataset, runtimeFilters),
+    );
+  }, [dataset, runtimeFilters, spec]);
+
+  useEffect(() => {
+    if (!dataset || !performanceQueryKey) return;
+    registerDashboardPerformanceQuery({
+      widgetId: widget.id,
+      widgetName: title,
+      datasetId: dataset.id,
+      queryKey: performanceQueryKey,
+    });
+  }, [dataset, performanceQueryKey, title, widget.id]);
 
   return (
     <div className="chart-sheet-workspace flex min-h-0 flex-1 overflow-hidden bg-[#f3f4f6]">

--- a/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
+++ b/yak-ops-ui/src/pages/dashboard/performance-modal.tsx
@@ -1,4 +1,4 @@
-import { fetchAnalyses } from '@/components/analysis/analysis-service';
+import { latestAnalysisQueryId } from '@/components/analysis/query-runtime';
 import {
   Alert,
   Button,
@@ -10,9 +10,9 @@ import {
   type TableColumnsType,
 } from 'antd';
 import { Download, RefreshCw } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { fetchDashboard } from './dashboard-service';
-import type { AnalysisAsset, DashboardWidget } from './model';
+import { getDashboardPerformanceQuery } from './performance-runtime';
 import {
   fetchDashboardQueryPerformance,
   type DashboardQueryPerformance,
@@ -26,16 +26,10 @@ const formatTime = (value?: string) => {
 
 const escapeCsv = (value: unknown) => `"${String(value ?? '').replace(/"/g, '""')}"`;
 
-const widgetDatasetId = (widget: DashboardWidget, analyses: AnalysisAsset[]) => (
-  widget.inlineAnalysis?.datasetId
-  ?? (widget.analysisId ? analyses.find((item) => item.id === widget.analysisId)?.datasetId : undefined)
-);
-
-const widgetTitle = (widget: DashboardWidget, analyses: AnalysisAsset[]) => (
-  widget.title?.trim()
-  || (widget.analysisId ? analyses.find((item) => item.id === widget.analysisId)?.name : undefined)
-  || '未命名组件'
-);
+type DashboardPerformanceRow = DashboardQueryPerformance & {
+  widgetId: string;
+  widgetName: string;
+};
 
 export function DashboardPerformanceModal({
   open,
@@ -50,39 +44,33 @@ export function DashboardPerformanceModal({
 }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
-  const [records, setRecords] = useState<DashboardQueryPerformance[]>([]);
+  const [records, setRecords] = useState<DashboardPerformanceRow[]>([]);
   const [detail, setDetail] = useState<DashboardQueryPerformance>();
-  const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
-  const [analyses, setAnalyses] = useState<AnalysisAsset[]>([]);
-
-  const widgetNamesByDataset = useMemo(() => {
-    const result = new Map<string, string[]>();
-    widgets.forEach((widget) => {
-      const datasetId = widgetDatasetId(widget, analyses);
-      if (!datasetId) return;
-      const current = result.get(datasetId) ?? [];
-      const title = widgetTitle(widget, analyses);
-      if (!current.includes(title)) current.push(title);
-      result.set(datasetId, current);
-    });
-    return result;
-  }, [analyses, widgets]);
 
   const load = useCallback(async () => {
     if (!/^\d+$/.test(dashboardId)) return;
     setLoading(true);
     setError(undefined);
     try {
-      const [dashboard, nextAnalyses] = await Promise.all([
-        fetchDashboard(dashboardId),
-        fetchAnalyses(),
-      ]);
-      setWidgets(dashboard.widgets);
-      setAnalyses(nextAnalyses);
-      const datasetIds = Array.from(new Set(dashboard.widgets
-        .map((widget) => widgetDatasetId(widget, nextAnalyses))
-        .filter((value): value is string => Boolean(value))));
-      setRecords(await fetchDashboardQueryPerformance(datasetIds, 100));
+      const dashboard = await fetchDashboard(dashboardId);
+      const executions = dashboard.widgets.flatMap((widget) => {
+        const binding = getDashboardPerformanceQuery(widget.id);
+        if (!binding) return [];
+        const queryId = latestAnalysisQueryId(binding.queryKey);
+        if (!queryId) return [];
+        return [{
+          widgetId: widget.id,
+          widgetName: binding.widgetName,
+          queryId,
+        }];
+      });
+      const queryIds = Array.from(new Set(executions.map((item) => item.queryId)));
+      const traces = await fetchDashboardQueryPerformance(queryIds);
+      const tracesById = new Map(traces.map((trace) => [trace.queryId, trace]));
+      setRecords(executions.flatMap((execution) => {
+        const trace = tracesById.get(execution.queryId);
+        return trace ? [{ ...trace, ...execution }] : [];
+      }));
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : '读取性能分析记录失败');
     } finally {
@@ -101,7 +89,7 @@ export function DashboardPerformanceModal({
     ];
     const rows = records.map((record) => [
       dashboardName,
-      (widgetNamesByDataset.get(record.datasetId) ?? []).join(' / '),
+      record.widgetName,
       record.datasetName || record.datasetId,
       record.queryId,
       record.waitMillis,
@@ -123,7 +111,7 @@ export function DashboardPerformanceModal({
     URL.revokeObjectURL(url);
   };
 
-  const columns: TableColumnsType<DashboardQueryPerformance> = [
+  const columns: TableColumnsType<DashboardPerformanceRow> = [
     {
       title: '一级资源名称',
       width: 130,
@@ -131,12 +119,13 @@ export function DashboardPerformanceModal({
     },
     {
       title: '二级资源名称',
+      dataIndex: 'widgetName',
       width: 180,
-      render: (_, record) => {
-        const names = widgetNamesByDataset.get(record.datasetId) ?? [];
-        const value = names.length ? names.join(' / ') : '-';
-        return <Tooltip title={value}><span className="block max-w-[160px] truncate">{value}</span></Tooltip>;
-      },
+      render: (value: string) => (
+        <Tooltip title={value}>
+          <span className="block max-w-[160px] truncate">{value || '-'}</span>
+        </Tooltip>
+      ),
     },
     {
       title: '数据集',
@@ -186,12 +175,12 @@ export function DashboardPerformanceModal({
         onCancel={onClose}
         footer={null}
         destroyOnClose={false}
-        styles={{ body: { paddingTop: 8 } }}
+        styles={{ body: { paddingTop: 8, height: 560, overflow: 'hidden' } }}
       >
         <div className="mb-3 flex items-center justify-between">
           <div>
             <div className="text-[12px] font-semibold text-[#344054]">核心信息</div>
-            <div className="mt-0.5 text-[10px] text-[#98a2b3]">最近 100 条当前已保存仪表盘的 Dataset SQL 查询记录</div>
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">当前仪表盘每个图表最近一次实际执行的 Dataset SQL 查询</div>
           </div>
           <div className="flex items-center gap-1">
             <Button type="text" size="small" icon={<RefreshCw size={12} />} loading={loading} onClick={() => void load()}>
@@ -205,19 +194,19 @@ export function DashboardPerformanceModal({
 
         {error ? <Alert className="mb-3" type="error" showIcon message={error} /> : null}
 
-        <Table<DashboardQueryPerformance>
-          rowKey="queryId"
+        <Table<DashboardPerformanceRow>
+          rowKey={(record) => `${record.widgetId}-${record.queryId}`}
           size="small"
           loading={loading}
           columns={columns}
           dataSource={records}
           pagination={false}
-          scroll={{ x: 1500, y: 430 }}
+          scroll={{ x: 1500, y: 420 }}
           locale={{
             emptyText: (
               <Empty
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
-                description="当前进程尚未采集到该仪表盘的查询记录，请操作或刷新图表后再查看"
+                description="当前仪表盘尚未产生可追踪的查询，请等待图表加载完成或刷新后再查看"
               />
             ),
           }}

--- a/yak-ops-ui/src/pages/dashboard/performance-runtime.ts
+++ b/yak-ops-ui/src/pages/dashboard/performance-runtime.ts
@@ -1,0 +1,21 @@
+export interface DashboardPerformanceQueryBinding {
+  widgetId: string;
+  widgetName: string;
+  datasetId: string;
+  queryKey: string;
+}
+
+const bindings = new Map<string, DashboardPerformanceQueryBinding>();
+
+/**
+ * Keeps the latest query signature for each chart rendered in the current browser session.
+ * Entries are intentionally overwritten by widget id so chart edits and runtime filters
+ * always point performance analysis at the query the chart actually executed.
+ */
+export const registerDashboardPerformanceQuery = (
+  binding: DashboardPerformanceQueryBinding,
+) => {
+  bindings.set(binding.widgetId, binding);
+};
+
+export const getDashboardPerformanceQuery = (widgetId: string) => bindings.get(widgetId);

--- a/yak-ops-ui/src/pages/dashboard/performance-service.ts
+++ b/yak-ops-ui/src/pages/dashboard/performance-service.ts
@@ -31,13 +31,12 @@ const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
 };
 
 export const fetchDashboardQueryPerformance = async (
-  datasetIds: string[],
-  limit = 100,
+  queryIds: string[],
 ): Promise<DashboardQueryPerformance[]> => {
-  if (!datasetIds.length) return [];
+  if (!queryIds.length) return [];
   const params = new URLSearchParams();
-  datasetIds.forEach((datasetId) => params.append('datasetIds', datasetId));
-  params.set('limit', String(limit));
+  queryIds.forEach((queryId) => params.append('queryIds', queryId));
+  params.set('limit', String(Math.min(queryIds.length, 200)));
   return unwrap(
     await HttpUtils.get<DashboardQueryPerformance[]>(`${PERFORMANCE_API}?${params.toString()}`),
     '查询 Dataset 性能分析记录失败',

--- a/yak-ops-ui/src/pages/dashboard/widget.tsx
+++ b/yak-ops-ui/src/pages/dashboard/widget.tsx
@@ -1,4 +1,9 @@
-import { AnalysisPreview } from '@/components/analysis/AnalysisPreview';
+import {
+  AnalysisPreview,
+  buildDatasetQueryPayload,
+  canQueryAnalysis,
+} from '@/components/analysis/AnalysisPreview';
+import { analysisQueryCacheKey } from '@/components/analysis/query-runtime';
 import { Empty, Tooltip } from 'antd';
 import {
   ChevronRight,
@@ -9,6 +14,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
+import { useEffect, useMemo } from 'react';
 import type {
   AnalysisAsset,
   AnalysisSelection,
@@ -19,6 +25,7 @@ import type {
   DashboardWidget,
   PublishedDataset,
 } from './model';
+import { registerDashboardPerformanceQuery } from './performance-runtime';
 
 export function WidgetShell({
   widget,
@@ -61,6 +68,23 @@ export function WidgetShell({
   const title = widget.analysisId
     ? analysis?.name ?? '历史图表'
     : widget.title ?? '未命名图表';
+  const performanceQueryKey = useMemo(() => {
+    if (!spec || !dataset || !canQueryAnalysis(spec)) return undefined;
+    return analysisQueryCacheKey(
+      dataset,
+      buildDatasetQueryPayload(spec, dataset, runtimeFilters),
+    );
+  }, [dataset, runtimeFilters, spec]);
+
+  useEffect(() => {
+    if (!dataset || !performanceQueryKey) return;
+    registerDashboardPerformanceQuery({
+      widgetId: widget.id,
+      widgetName: title,
+      datasetId: dataset.id,
+      queryKey: performanceQueryKey,
+    });
+  }, [dataset, performanceQueryKey, title, widget.id]);
 
   return (
     <div


### PR DESCRIPTION
## Summary

- return the Dataset query `queryId` to chart callers and allow performance traces to be filtered by exact query IDs
- track the latest actual query signature for each dashboard chart, including charts that share the same Dataset
- change Dashboard Performance Analysis from historical Dataset traces to one latest execution row per chart
- keep shared-query semantics: charts that reuse the same actual query can point to the same query ID without creating fake executions
- give the Performance Analysis modal a default 560px body height and keep the result table scrollable

## Why

The previous modal queried the latest 100 traces by Dataset ID. A single chart could therefore show many historical rows, and multiple charts bound to the same Dataset could not be distinguished reliably. The new flow follows the exact query ID produced by each chart's current Dataset execution.

## Tests

- added coverage for filtering performance traces by exact query IDs
- CI verification pending
