### PR TITLE
style(login): 优化登录页左侧内容比例

### DIFF
--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -68,7 +68,7 @@ export default function LoginPanel() {
   };
 
   return (
-    <div className="w-full rounded-[24px] border border-[#e4e4e1] bg-white p-5 shadow-[0_12px_36px_rgba(15,23,42,0.035)] sm:p-6">
+    <div className="w-full rounded-[26px] border border-[#e4e4e1] bg-white p-6 shadow-[0_14px_40px_rgba(15,23,42,0.04)] sm:p-7">
       <Form
         layout="vertical"
         form={form}
@@ -76,7 +76,7 @@ export default function LoginPanel() {
         onFinish={handleAccountLogin}
       >
         <Form.Item
-          className="!mb-4"
+          className="!mb-5"
           label={
             <span className="text-[13px] font-medium text-[#333]">
               Username
@@ -86,14 +86,14 @@ export default function LoginPanel() {
           rules={[{ required: true, message: "请输入用户名" }]}
         >
           <Input
-            className="!h-10 !rounded-full !border-[#dededb] !bg-white !px-3.5 !text-[15px] !shadow-none placeholder:!text-[#aaa] hover:!border-[#bdbdb8] focus:!border-[#171717]"
+            className="!h-11 !rounded-full !border-[#dededb] !bg-white !px-4 !text-[15px] !shadow-none placeholder:!text-[#aaa] hover:!border-[#bdbdb8] focus:!border-[#171717]"
             placeholder="Enter your username"
             autoComplete="username"
           />
         </Form.Item>
 
         <Form.Item
-          className="!mb-5"
+          className="!mb-6"
           label={
             <span className="text-[13px] font-medium text-[#333]">
               Password
@@ -108,7 +108,7 @@ export default function LoginPanel() {
           ]}
         >
           <Input.Password
-            className="!h-10 !rounded-full !border-[#dededb] !bg-white !px-3.5 !shadow-none hover:!border-[#bdbdb8] focus-within:!border-[#171717] [&>input.ant-input]:!bg-white [&>input.ant-input]:!text-[15px]"
+            className="!h-11 !rounded-full !border-[#dededb] !bg-white !px-4 !shadow-none hover:!border-[#bdbdb8] focus-within:!border-[#171717] [&>input.ant-input]:!bg-white [&>input.ant-input]:!text-[15px]"
             placeholder="Enter your password"
             autoComplete="current-password"
           />
@@ -119,7 +119,7 @@ export default function LoginPanel() {
           type="primary"
           htmlType="submit"
           loading={loading}
-          className="!h-10 !rounded-full !border-[#171717] !bg-[#171717] !font-medium !text-white !shadow-none hover:!border-[#292929] hover:!bg-[#292929]"
+          className="!h-11 !rounded-full !border-[#171717] !bg-[#171717] !font-medium !text-white !shadow-none hover:!border-[#292929] hover:!bg-[#292929]"
         >
           Log in
         </Button>

--- a/yak-ops-ui/src/pages/login/index.tsx
+++ b/yak-ops-ui/src/pages/login/index.tsx
@@ -14,20 +14,20 @@ export default function LoginPage() {
           />
         </header>
 
-        <div className="grid flex-1 grid-cols-1 gap-10 pt-6 lg:grid-cols-[minmax(0,0.92fr)_minmax(520px,1fr)] lg:items-center lg:gap-12 lg:pt-0 xl:gap-16">
-          <section className="flex min-w-0 items-center justify-center py-7 lg:py-10">
-            <div className="w-full max-w-[520px]">
-              <div className="mb-8 text-center">
-                <h1 className="m-0 text-[42px] font-normal leading-[1.02] tracking-[-0.045em] text-[#171717] sm:text-[54px] lg:text-[58px]">
+        <div className="grid flex-1 grid-cols-1 gap-10 pt-6 lg:grid-cols-[minmax(0,1.05fr)_minmax(540px,0.95fr)] lg:items-center lg:gap-14 lg:pt-0 xl:gap-20">
+          <section className="flex min-w-0 items-center justify-center py-8 lg:py-10">
+            <div className="w-full max-w-[620px]">
+              <div className="mb-10 text-center">
+                <h1 className="m-0 text-[46px] font-normal leading-[1.01] tracking-[-0.045em] text-[#171717] sm:text-[60px] lg:text-[64px]">
                   Data ops,  &nbsp; simplified.
                 </h1>
 
-                <p className="mt-4 text-[15px] leading-6 text-[#555] sm:text-base">
+                <p className="mt-5 text-[16px] leading-7 text-[#555] sm:text-[17px]">
                   One workspace for your data.
                 </p>
               </div>
 
-              <div className="mx-auto w-full max-w-[390px]">
+              <div className="mx-auto w-full max-w-[430px]">
                 <LoginPanel />
               </div>
             </div>


### PR DESCRIPTION
## 变更说明

- 调整登录页左右区域比例，让左侧内容区更有存在感，同时保持整体简洁
- 左侧内容最大宽度从 `520px` 提升到 `620px`
- 登录表单最大宽度从 `390px` 提升到 `430px`
- 标题字号与标题/副标题间距适度放大，增强视觉层级
- 登录卡片圆角、内边距、输入框和按钮高度同步放大
- 未新增额外说明、功能入口或营销内容，避免左侧变得拥挤
- 右侧视频区域与原有视觉风格保持不变

## 设计思路

参考 Claude 登录页的比例处理，不通过堆叠更多内容填充空间，而是通过标题、表单、留白和左右栏宽度的重新分配，让左侧区域更完整、更稳。

## 影响范围

仅修改登录页布局与表单视觉尺寸，不涉及登录逻辑。

## 验证建议

- 重点查看 1440px、1600px、1920px 桌面宽度下左右视觉平衡
- 检查用户名/密码校验、登录 loading、密码显隐按钮是否正常
- 检查较小桌面宽度下右侧视频和左侧表单是否仍保持合理间距