### PR TITLE
fix(dashboard): apply chart palette changes immediately

### DIFF
--- a/yak-ops-ui/src/components/analysis/analysis-theme.test.ts
+++ b/yak-ops-ui/src/components/analysis/analysis-theme.test.ts
@@ -16,7 +16,7 @@ describe('analysis theme', () => {
     expect(theme.gridColor).toBeTruthy();
   });
 
-  it('applies palette, axes, legend, tooltip and block-chart borders', () => {
+  it('preserves a chart-local palette while applying the remaining theme tokens', () => {
     const option = {
       color: ['#old'],
       tooltip: { trigger: 'item' },
@@ -46,7 +46,7 @@ describe('analysis theme', () => {
       tooltipTextColor: '#edf8ff',
     });
 
-    expect(themed.color).toEqual(['#38bdf8', '#818cf8']);
+    expect(themed.color).toEqual(['#old']);
     expect(themed.legend.textStyle.color).toBe('#8db3d3');
     expect(themed.tooltip.backgroundColor).toBe('#071624');
     expect(themed.tooltip.textStyle.color).toBe('#edf8ff');
@@ -55,5 +55,14 @@ describe('analysis theme', () => {
     expect(themed.series[0].label.color).toBe('#e5f3ff');
     expect(themed.series[0].itemStyle.borderColor).toBe('#0a2138');
     expect(option.series[0].itemStyle.borderColor).toBe('#fff');
+  });
+
+  it('falls back to the dashboard theme palette when the chart does not define colors', () => {
+    const themed = applyAnalysisChartTheme(
+      { series: [{ type: 'bar', data: [1, 2] }] },
+      { palette: ['#38bdf8', '#818cf8'] },
+    );
+
+    expect(themed.color).toEqual(['#38bdf8', '#818cf8']);
   });
 });

--- a/yak-ops-ui/src/components/analysis/analysis-theme.ts
+++ b/yak-ops-ui/src/components/analysis/analysis-theme.ts
@@ -95,7 +95,7 @@ const themeSeries = (series: any, theme: AnalysisThemeTokens) => {
 
 /**
  * Apply presentation-only tokens to an ECharts option built from Analysis semantics.
- * The Analysis spec remains unchanged, so Dashboard themes never rewrite chart configuration.
+ * Chart-local colors stay authoritative; the Dashboard theme palette is only a fallback.
  */
 export const applyAnalysisChartTheme = (
   option: any,
@@ -103,10 +103,13 @@ export const applyAnalysisChartTheme = (
 ) => {
   if (!option) return option;
   const theme = resolveAnalysisThemeTokens(value);
+  const palette = Array.isArray(option.color) && option.color.length
+    ? option.color
+    : theme.palette;
   return {
     ...option,
     backgroundColor: 'transparent',
-    color: [...theme.palette],
+    color: [...palette],
     textStyle: {
       ...(option.textStyle || {}),
       color: theme.textColor,


### PR DESCRIPTION
## Summary

- keep chart-local palette selections authoritative when applying Dashboard theme tokens
- use the Dashboard theme palette only when a chart option does not define its own colors
- preserve existing theme behavior for axes, grid lines, legends, tooltips and block-chart borders
- add regression coverage for chart palette precedence and theme fallback behavior

## Why

The chart style panel correctly updated `style.palette`, and the chart option builder correctly produced the selected palette. `applyAnalysisChartTheme()` then replaced `option.color` with the Dashboard theme palette, so the palette selector changed visually while the rendered ECharts chart stayed on the previous color scheme.

The intended precedence is now:

`chart-local palette > Dashboard theme palette > renderer defaults`

## Verification

- added regression tests in `analysis-theme.test.ts`
- branch is based on the latest `main`
- CI verification pending
