### PR TITLE
style(workflow): refine disabled schedule save button

### DIFF
--- a/yak-ops-ui/src/pages/workflow/schedules/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/index.tsx
@@ -575,7 +575,12 @@ export default function WorkflowScheduleConfigPage() {
                     loading={saving}
                     disabled={!canEdit}
                     icon={<Save size={15} />}
-                    className="!h-9 !min-w-[112px] !rounded-lg !px-5 !font-medium !text-white"
+                    className={[
+                      '!h-9 !min-w-[112px] !rounded-lg !px-5 !font-medium',
+                      canEdit
+                        ? '!text-white'
+                        : '!border-[#e3e6eb] !bg-[#f2f3f5] !text-[#a5acb6] !shadow-none',
+                    ].join(' ')}
                     onClick={() => void handleSave()}
                   >
                     保存配置


### PR DESCRIPTION
## Summary

- refine the disabled state of the workflow schedule "保存配置" primary button
- replace the white disabled text with a neutral gray text/icon treatment
- use a light gray background and subtle border so the disabled state is visually clear without looking washed out
- preserve the existing primary brand style when the schedule is editable

## Scope

- UI-only change in `yak-ops-ui/src/pages/workflow/schedules/index.tsx`
- no workflow schedule behavior or lifecycle logic changed

## Verification

- branch created from the latest `main`
- compared against `main`: 1 commit, 1 changed file, 6 additions / 1 deletion
- CI verification pending
