### PR TITLE
style(data-quality): 收敛规则模板库红色强调

### DIFF
--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -259,3 +259,46 @@ ol {
 .yak-sql-run-glyph:active {
   transform: scale(1);
 }
+
+// Rule template library: keep the interface neutral and reserve brand red for
+// primary actions / destructive states instead of using it for every selection.
+div[class~='h-[calc(100vh-64px)]'][class~='min-h-[620px]'] {
+  aside button[class*='bg-[rgba(254,44,85,.08)]'] {
+    background: #f2f4f7 !important;
+    color: #161823 !important;
+  }
+
+  aside button[class*='bg-[rgba(254,44,85,.08)]']:hover {
+    background: #e9ecf1 !important;
+  }
+
+  aside button[class*='bg-[rgba(254,44,85,.08)]'] span[class*='text-[var(--yak-brand-color)]'] {
+    color: #475467 !important;
+  }
+
+  .ant-tabs .ant-tabs-ink-bar {
+    background: #161823 !important;
+  }
+
+  .ant-tabs .ant-tabs-tab-active .ant-tabs-tab-btn {
+    color: #161823 !important;
+    text-shadow: none !important;
+  }
+
+  .ant-tabs .ant-tabs-tab:hover .ant-tabs-tab-btn {
+    color: #344054 !important;
+  }
+
+  main button[class*='text-[var(--yak-brand-color)]'] {
+    color: #172033 !important;
+  }
+
+  main button[class*='text-[var(--yak-brand-color)]']:hover {
+    color: #101828 !important;
+  }
+
+  main .ant-table .ant-tag {
+    color: #667085 !important;
+    background: #f2f4f7 !important;
+  }
+}


### PR DESCRIPTION
## 变更说明

- 调整“规则模板库”页面的颜色层级，减少大面积品牌红使用
- 左侧质量维度与自定义模板类目的选中态由浅红底 + 红字调整为中性灰底 + 深色文字
- 系统模板 / 自定义模板 Tab 的激活文字和下划线改为深色，降低视觉噪音
- 表格中的“关联范围”标签统一改为灰色系，不再使用红色标签
- 自定义模板可点击名称改为深色交互样式
- 保留品牌红用于真正需要强调的主操作按钮，并保留删除等危险操作的语义红色

## 设计思路

当前页面同时在导航选中态、Tab、标签、可点击文本等多个位置使用红色，导致视觉焦点过多。此次改为以黑 / 灰为基础信息色，只让品牌红承担关键 CTA 和危险状态，使页面更稳、更清爽。

## 影响范围

仅增加规则模板库页面的局部样式覆盖，不修改业务逻辑、数据请求或交互行为。

## 验证建议

- 检查质量维度选中态和模板类目选中态是否为中性灰色
- 检查系统模板 / 自定义模板 Tab 激活态是否不再使用红色
- 检查表格“关联范围”标签是否统一为灰色
- 切换到自定义模板后确认新建按钮仍保留品牌色
- 检查删除目录 / 删除模板等危险操作仍保留红色语义