### PR TITLE
feat(lineage): add metadata graph core foundation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-business-lineage</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-business-resource</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-bom/pom.xml
+++ b/yak-ops-bom/pom.xml
@@ -88,6 +88,11 @@
             </dependency>
             <dependency>
                 <groupId>io.yak.ops</groupId>
+                <artifactId>yak-ops-business-lineage</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.yak.ops</groupId>
                 <artifactId>yak-ops-business-resource</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -42,6 +42,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-lineage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-dataset</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/yak-ops-business/pom.xml
+++ b/yak-ops-business/pom.xml
@@ -23,6 +23,7 @@
         <module>yak-ops-business-job</module>
         <module>yak-ops-business-task-catalog</module>
         <module>yak-ops-business-data-development</module>
+        <module>yak-ops-business-lineage</module>
         <module>yak-ops-business-dataset</module>
         <module>yak-ops-business-analysis</module>
         <module>yak-ops-business-dashboard</module>

--- a/yak-ops-business/yak-ops-business-lineage/pom.xml
+++ b/yak-ops-business/yak-ops-business-lineage/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.yak.ops</groupId>
+        <artifactId>yak-ops-business</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>yak-ops-business-lineage</artifactId>
+
+    <name>Yak Ops Business Lineage</name>
+    <description>Unified metadata assets, typed relations and lineage graph traversal</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
@@ -1,0 +1,247 @@
+package io.yak.ops.business.lineage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@DependsOn("yakLineageFlyway")
+@ConditionalOnDataSourceEnabled
+class JdbcLineageRepository implements LineageRepository {
+
+  private static final String ASSET_COLUMNS =
+      "SELECT id, asset_key, asset_type, name, source_type, source_id, parent_asset_id, "
+          + "data_source_id, database_name, schema_name, table_name, column_name, properties, "
+          + "create_time, update_time FROM yak_metadata_asset";
+
+  private static final String RELATION_COLUMNS =
+      "SELECT id, source_asset_id, target_asset_id, relation_type, source_type, source_id, "
+          + "expression, confidence, version, observed_at, properties, create_time, update_time "
+          + "FROM yak_metadata_relation";
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+
+  JdbcLineageRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ObjectMapper objectMapper) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public LineageAsset upsertAsset(AssetWrite write) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(connection -> {
+      PreparedStatement statement = connection.prepareStatement(
+          """
+          INSERT INTO yak_metadata_asset
+            (asset_key, asset_type, name, source_type, source_id, parent_asset_id,
+             data_source_id, database_name, schema_name, table_name, column_name, properties,
+             create_time, update_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6), NOW(6))
+          ON DUPLICATE KEY UPDATE
+            asset_type = VALUES(asset_type),
+            name = VALUES(name),
+            source_type = VALUES(source_type),
+            source_id = VALUES(source_id),
+            parent_asset_id = VALUES(parent_asset_id),
+            data_source_id = VALUES(data_source_id),
+            database_name = VALUES(database_name),
+            schema_name = VALUES(schema_name),
+            table_name = VALUES(table_name),
+            column_name = VALUES(column_name),
+            properties = VALUES(properties),
+            id = LAST_INSERT_ID(id),
+            update_time = NOW(6)
+          """,
+          Statement.RETURN_GENERATED_KEYS);
+      statement.setString(1, write.assetKey());
+      statement.setString(2, write.assetType().name());
+      statement.setString(3, write.name());
+      statement.setString(4, write.sourceType());
+      statement.setString(5, write.sourceId());
+      if (write.parentAssetId() == null) statement.setNull(6, java.sql.Types.BIGINT);
+      else statement.setLong(6, write.parentAssetId());
+      statement.setString(7, write.dataSourceId());
+      statement.setString(8, write.databaseName());
+      statement.setString(9, write.schemaName());
+      statement.setString(10, write.tableName());
+      statement.setString(11, write.columnName());
+      statement.setString(12, toJson(write.properties()));
+      return statement;
+    }, keyHolder);
+    Number key = keyHolder.getKey();
+    if (key == null) {
+      return findAssetByKey(write.assetKey())
+          .orElseThrow(() -> new IllegalStateException("保存血缘资产后未返回主键"));
+    }
+    return findAsset(key.longValue())
+        .orElseThrow(() -> new IllegalStateException("保存血缘资产后无法读取资产"));
+  }
+
+  @Override
+  public LineageRelation upsertRelation(RelationWrite write) {
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(connection -> {
+      PreparedStatement statement = connection.prepareStatement(
+          """
+          INSERT INTO yak_metadata_relation
+            (source_asset_id, target_asset_id, relation_type, source_type, source_id,
+             expression, confidence, version, observed_at, properties, create_time, update_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6), NOW(6))
+          ON DUPLICATE KEY UPDATE
+            expression = VALUES(expression),
+            confidence = VALUES(confidence),
+            observed_at = VALUES(observed_at),
+            properties = VALUES(properties),
+            id = LAST_INSERT_ID(id),
+            update_time = NOW(6)
+          """,
+          Statement.RETURN_GENERATED_KEYS);
+      statement.setLong(1, write.sourceAssetId());
+      statement.setLong(2, write.targetAssetId());
+      statement.setString(3, write.relationType().name());
+      statement.setString(4, write.sourceType());
+      statement.setString(5, write.sourceId());
+      statement.setString(6, write.expression());
+      statement.setBigDecimal(7, write.confidence());
+      statement.setString(8, write.version());
+      statement.setTimestamp(9, Timestamp.from(write.observedAt()));
+      statement.setString(10, toJson(write.properties()));
+      return statement;
+    }, keyHolder);
+    Number key = keyHolder.getKey();
+    if (key == null) throw new IllegalStateException("保存血缘关系后未返回主键");
+    return findRelation(key.longValue());
+  }
+
+  @Override
+  public Optional<LineageAsset> findAsset(long assetId) {
+    return jdbcTemplate.query(
+        ASSET_COLUMNS + " WHERE id = ? LIMIT 1", this::mapAsset, assetId)
+        .stream().findFirst();
+  }
+
+  @Override
+  public Optional<LineageAsset> findAssetByKey(String assetKey) {
+    return jdbcTemplate.query(
+        ASSET_COLUMNS + " WHERE asset_key = ? LIMIT 1", this::mapAsset, assetKey)
+        .stream().findFirst();
+  }
+
+  @Override
+  public List<LineageAsset> findAssetsByIds(Set<Long> assetIds) {
+    if (assetIds == null || assetIds.isEmpty()) return List.of();
+    String placeholders = String.join(",", Collections.nCopies(assetIds.size(), "?"));
+    return jdbcTemplate.query(
+        ASSET_COLUMNS + " WHERE id IN (" + placeholders + ") ORDER BY id ASC",
+        this::mapAsset,
+        assetIds.toArray());
+  }
+
+  @Override
+  public List<LineageRelation> findOutgoingRelations(Set<Long> sourceAssetIds) {
+    if (sourceAssetIds == null || sourceAssetIds.isEmpty()) return List.of();
+    String placeholders = String.join(",", Collections.nCopies(sourceAssetIds.size(), "?"));
+    return jdbcTemplate.query(
+        RELATION_COLUMNS + " WHERE source_asset_id IN (" + placeholders + ") ORDER BY id ASC",
+        this::mapRelation,
+        sourceAssetIds.toArray());
+  }
+
+  @Override
+  public List<LineageRelation> findIncomingRelations(Set<Long> targetAssetIds) {
+    if (targetAssetIds == null || targetAssetIds.isEmpty()) return List.of();
+    String placeholders = String.join(",", Collections.nCopies(targetAssetIds.size(), "?"));
+    return jdbcTemplate.query(
+        RELATION_COLUMNS + " WHERE target_asset_id IN (" + placeholders + ") ORDER BY id ASC",
+        this::mapRelation,
+        targetAssetIds.toArray());
+  }
+
+  private LineageRelation findRelation(long relationId) {
+    return jdbcTemplate.query(
+        RELATION_COLUMNS + " WHERE id = ? LIMIT 1", this::mapRelation, relationId)
+        .stream().findFirst()
+        .orElseThrow(() -> new IllegalStateException("保存血缘关系后无法读取关系"));
+  }
+
+  private LineageAsset mapAsset(ResultSet rs, int rowNum) throws SQLException {
+    long parentValue = rs.getLong("parent_asset_id");
+    Long parentAssetId = rs.wasNull() ? null : parentValue;
+    return new LineageAsset(
+        rs.getLong("id"),
+        rs.getString("asset_key"),
+        LineageAssetType.valueOf(rs.getString("asset_type")),
+        rs.getString("name"),
+        rs.getString("source_type"),
+        rs.getString("source_id"),
+        parentAssetId,
+        rs.getString("data_source_id"),
+        rs.getString("database_name"),
+        rs.getString("schema_name"),
+        rs.getString("table_name"),
+        rs.getString("column_name"),
+        fromJson(rs.getString("properties")),
+        instant(rs.getTimestamp("create_time")),
+        instant(rs.getTimestamp("update_time")));
+  }
+
+  private LineageRelation mapRelation(ResultSet rs, int rowNum) throws SQLException {
+    return new LineageRelation(
+        rs.getLong("id"),
+        rs.getLong("source_asset_id"),
+        rs.getLong("target_asset_id"),
+        LineageRelationType.valueOf(rs.getString("relation_type")),
+        rs.getString("source_type"),
+        rs.getString("source_id"),
+        rs.getString("expression"),
+        rs.getBigDecimal("confidence"),
+        rs.getString("version"),
+        instant(rs.getTimestamp("observed_at")),
+        fromJson(rs.getString("properties")),
+        instant(rs.getTimestamp("create_time")),
+        instant(rs.getTimestamp("update_time")));
+  }
+
+  private String toJson(JsonNode value) {
+    if (value == null || value.isNull()) return null;
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalArgumentException("血缘 properties 不是有效 JSON", ex);
+    }
+  }
+
+  private JsonNode fromJson(String value) {
+    if (value == null || value.isBlank()) return null;
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("数据库中的血缘 properties 不是有效 JSON", ex);
+    }
+  }
+
+  private static Instant instant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageAsset.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageAsset.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.lineage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
+
+/** Stable identity for an object participating in the Yak Ops metadata graph. */
+public record LineageAsset(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    String assetKey,
+    LineageAssetType assetType,
+    String name,
+    String sourceType,
+    String sourceId,
+    @JsonSerialize(using = ToStringSerializer.class) Long parentAssetId,
+    String dataSourceId,
+    String databaseName,
+    String schemaName,
+    String tableName,
+    String columnName,
+    JsonNode properties,
+    Instant createTime,
+    Instant updateTime) {
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageAssetType.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageAssetType.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.lineage;
+
+/** First-stage asset types shared by data development, catalog and BI consumption. */
+public enum LineageAssetType {
+  TABLE,
+  COLUMN,
+  SQL_TASK,
+  DATASET,
+  DATASET_FIELD,
+  CHART,
+  DASHBOARD
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageController.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageController.java
@@ -1,0 +1,140 @@
+package io.yak.ops.business.lineage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "数据血缘接口")
+@Validated
+@RestController
+@RequestMapping("/api/v1/lineage")
+public class LineageController {
+
+  private final LineageService service;
+
+  public LineageController(LineageService service) {
+    this.service = service;
+  }
+
+  @Operation(summary = "注册或更新元数据资产")
+  @PostMapping("/assets")
+  public Result<LineageAsset> registerAsset(@Valid @RequestBody RegisterAssetRequest request) {
+    return Result.success(service.registerAsset(new LineageService.RegisterAssetCommand(
+        request.assetKey(),
+        request.assetType(),
+        request.name(),
+        request.sourceType(),
+        request.sourceId(),
+        request.parentAssetId(),
+        request.dataSourceId(),
+        request.databaseName(),
+        request.schemaName(),
+        request.tableName(),
+        request.columnName(),
+        request.properties())));
+  }
+
+  @Operation(summary = "注册或更新元数据关系")
+  @PostMapping("/relations")
+  public Result<LineageRelation> registerRelation(
+      @Valid @RequestBody RegisterRelationRequest request) {
+    return Result.success(service.registerRelation(new LineageService.RegisterRelationCommand(
+        request.sourceAssetId(),
+        request.targetAssetId(),
+        request.relationType(),
+        request.sourceType(),
+        request.sourceId(),
+        request.expression(),
+        request.confidence(),
+        request.version(),
+        request.observedAt(),
+        request.properties())));
+  }
+
+  @Operation(summary = "查询血缘资产")
+  @GetMapping("/assets/{assetId}")
+  public Result<LineageAsset> getAsset(@PathVariable("assetId") long assetId) {
+    return Result.success(service.getAsset(assetId));
+  }
+
+  @Operation(summary = "按稳定 assetKey 查询血缘资产")
+  @GetMapping("/assets/by-key")
+  public Result<LineageAsset> getAssetByKey(@RequestParam("assetKey") String assetKey) {
+    return Result.success(service.getAssetByKey(assetKey));
+  }
+
+  @Operation(summary = "查询上游血缘")
+  @GetMapping("/assets/{assetId}/upstream")
+  public Result<LineageGraph> upstream(
+      @PathVariable("assetId") long assetId,
+      @RequestParam(value = "depth", defaultValue = "1")
+      @Min(1) @Max(LineageService.MAX_GRAPH_DEPTH) int depth) {
+    return Result.success(service.upstream(assetId, depth));
+  }
+
+  @Operation(summary = "查询下游血缘")
+  @GetMapping("/assets/{assetId}/downstream")
+  public Result<LineageGraph> downstream(
+      @PathVariable("assetId") long assetId,
+      @RequestParam(value = "depth", defaultValue = "1")
+      @Min(1) @Max(LineageService.MAX_GRAPH_DEPTH) int depth) {
+    return Result.success(service.downstream(assetId, depth));
+  }
+
+  @Operation(summary = "查询指定方向的多跳血缘图")
+  @GetMapping("/assets/{assetId}/graph")
+  public Result<LineageGraph> graph(
+      @PathVariable("assetId") long assetId,
+      @RequestParam(value = "direction", defaultValue = "BOTH") LineageDirection direction,
+      @RequestParam(value = "depth", defaultValue = "3")
+      @Min(1) @Max(LineageService.MAX_GRAPH_DEPTH) int depth) {
+    return Result.success(service.graph(assetId, direction, depth));
+  }
+
+  public record RegisterAssetRequest(
+      @NotBlank @Size(max = 512) String assetKey,
+      @NotNull LineageAssetType assetType,
+      @Size(max = 200) String name,
+      @Size(max = 64) String sourceType,
+      @Size(max = 200) String sourceId,
+      Long parentAssetId,
+      @Size(max = 64) String dataSourceId,
+      @Size(max = 256) String databaseName,
+      @Size(max = 256) String schemaName,
+      @Size(max = 256) String tableName,
+      @Size(max = 256) String columnName,
+      JsonNode properties) {
+  }
+
+  public record RegisterRelationRequest(
+      @NotNull Long sourceAssetId,
+      @NotNull Long targetAssetId,
+      @NotNull LineageRelationType relationType,
+      @Size(max = 64) String sourceType,
+      @Size(max = 200) String sourceId,
+      @Size(max = 16000) String expression,
+      @DecimalMin("0.0") @DecimalMax("1.0") BigDecimal confidence,
+      @Size(max = 128) String version,
+      Instant observedAt,
+      JsonNode properties) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageDirection.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageDirection.java
@@ -1,0 +1,7 @@
+package io.yak.ops.business.lineage;
+
+public enum LineageDirection {
+  UPSTREAM,
+  DOWNSTREAM,
+  BOTH
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageGraph.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageGraph.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.lineage;
+
+import java.util.List;
+
+/** Materialized graph slice around a selected root asset. */
+public record LineageGraph(
+    LineageAsset root,
+    LineageDirection direction,
+    int depth,
+    List<LineageAsset> nodes,
+    List<LineageRelation> relations) {
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineagePersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineagePersistenceConfiguration.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.lineage;
+
+import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDataSourceEnabled
+@EnableConfigurationProperties(DataSourceProperties.class)
+@Import(BusinessDatabaseConfiguration.class)
+public class LineagePersistenceConfiguration {
+
+  @Bean(name = "yakLineageFlyway", initMethod = "migrate")
+  public Flyway lineageFlyway(@Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    return Flyway.configure()
+        .dataSource(dataSource)
+        .locations("classpath:db/migration/yak-lineage")
+        .table("flyway_schema_history_lineage")
+        .baselineVersion(MigrationVersion.fromVersion("0"))
+        .baselineOnMigrate(true)
+        .load();
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRelation.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRelation.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.lineage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Directed upstream-to-downstream edge with optional provenance evidence. */
+public record LineageRelation(
+    @JsonSerialize(using = ToStringSerializer.class) long id,
+    @JsonSerialize(using = ToStringSerializer.class) long sourceAssetId,
+    @JsonSerialize(using = ToStringSerializer.class) long targetAssetId,
+    LineageRelationType relationType,
+    String sourceType,
+    String sourceId,
+    String expression,
+    BigDecimal confidence,
+    String version,
+    Instant observedAt,
+    JsonNode properties,
+    Instant createTime,
+    Instant updateTime) {
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRelationType.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRelationType.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.lineage;
+
+/**
+ * Typed metadata relationships. Every edge is persisted from upstream asset to downstream asset.
+ * The type describes how the downstream target uses, derives from or contains the upstream source.
+ */
+public enum LineageRelationType {
+  READS_FROM,
+  WRITES_TO,
+  DERIVES_FROM,
+  CONSUMES,
+  CONTAINS
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.lineage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+interface LineageRepository {
+
+  LineageAsset upsertAsset(AssetWrite write);
+
+  LineageRelation upsertRelation(RelationWrite write);
+
+  Optional<LineageAsset> findAsset(long assetId);
+
+  Optional<LineageAsset> findAssetByKey(String assetKey);
+
+  List<LineageAsset> findAssetsByIds(Set<Long> assetIds);
+
+  List<LineageRelation> findOutgoingRelations(Set<Long> sourceAssetIds);
+
+  List<LineageRelation> findIncomingRelations(Set<Long> targetAssetIds);
+
+  record AssetWrite(
+      String assetKey,
+      LineageAssetType assetType,
+      String name,
+      String sourceType,
+      String sourceId,
+      Long parentAssetId,
+      String dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String columnName,
+      JsonNode properties) {
+  }
+
+  record RelationWrite(
+      long sourceAssetId,
+      long targetAssetId,
+      LineageRelationType relationType,
+      String sourceType,
+      String sourceId,
+      String expression,
+      BigDecimal confidence,
+      String version,
+      Instant observedAt,
+      JsonNode properties) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
@@ -1,0 +1,217 @@
+package io.yak.ops.business.lineage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Core service for asset registration, typed relations and bounded multi-hop traversal. */
+@Service
+public class LineageService {
+
+  public static final int MAX_GRAPH_DEPTH = 10;
+
+  private final LineageRepository repository;
+
+  public LineageService(LineageRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional
+  public LineageAsset registerAsset(RegisterAssetCommand command) {
+    Objects.requireNonNull(command, "command");
+    String assetKey = required(command.assetKey(), "assetKey", 512);
+    LineageAssetType assetType = Objects.requireNonNull(command.assetType(), "assetType");
+    String name = optional(command.name(), 200);
+    if (name == null) name = assetKey;
+
+    Long parentAssetId = command.parentAssetId();
+    if (parentAssetId != null) {
+      requirePositive(parentAssetId, "parentAssetId");
+      getAsset(parentAssetId);
+    }
+
+    return repository.upsertAsset(new LineageRepository.AssetWrite(
+        assetKey,
+        assetType,
+        name,
+        valueOrEmpty(command.sourceType(), 64),
+        valueOrEmpty(command.sourceId(), 200),
+        parentAssetId,
+        optional(command.dataSourceId(), 64),
+        optional(command.databaseName(), 256),
+        optional(command.schemaName(), 256),
+        optional(command.tableName(), 256),
+        optional(command.columnName(), 256),
+        command.properties()));
+  }
+
+  @Transactional
+  public LineageRelation registerRelation(RegisterRelationCommand command) {
+    Objects.requireNonNull(command, "command");
+    requirePositive(command.sourceAssetId(), "sourceAssetId");
+    requirePositive(command.targetAssetId(), "targetAssetId");
+    if (command.sourceAssetId() == command.targetAssetId()) {
+      throw new IllegalArgumentException("血缘关系不能指向资产自身");
+    }
+    getAsset(command.sourceAssetId());
+    getAsset(command.targetAssetId());
+
+    LineageRelationType relationType =
+        Objects.requireNonNull(command.relationType(), "relationType");
+    BigDecimal confidence = command.confidence() == null ? BigDecimal.ONE : command.confidence();
+    if (confidence.compareTo(BigDecimal.ZERO) < 0 || confidence.compareTo(BigDecimal.ONE) > 0) {
+      throw new IllegalArgumentException("confidence 必须在 0 到 1 之间");
+    }
+
+    return repository.upsertRelation(new LineageRepository.RelationWrite(
+        command.sourceAssetId(),
+        command.targetAssetId(),
+        relationType,
+        valueOrEmpty(command.sourceType(), 64),
+        valueOrEmpty(command.sourceId(), 200),
+        optional(command.expression(), 16000),
+        confidence,
+        valueOrEmpty(command.version(), 128),
+        command.observedAt() == null ? Instant.now() : command.observedAt(),
+        command.properties()));
+  }
+
+  @Transactional(readOnly = true)
+  public LineageAsset getAsset(long assetId) {
+    requirePositive(assetId, "assetId");
+    return repository.findAsset(assetId)
+        .orElseThrow(() -> new IllegalArgumentException("血缘资产不存在：" + assetId));
+  }
+
+  @Transactional(readOnly = true)
+  public LineageAsset getAssetByKey(String assetKey) {
+    String normalized = required(assetKey, "assetKey", 512);
+    return repository.findAssetByKey(normalized)
+        .orElseThrow(() -> new IllegalArgumentException("血缘资产不存在：" + normalized));
+  }
+
+  @Transactional(readOnly = true)
+  public LineageGraph upstream(long assetId, int depth) {
+    return graph(assetId, LineageDirection.UPSTREAM, depth);
+  }
+
+  @Transactional(readOnly = true)
+  public LineageGraph downstream(long assetId, int depth) {
+    return graph(assetId, LineageDirection.DOWNSTREAM, depth);
+  }
+
+  @Transactional(readOnly = true)
+  public LineageGraph graph(long assetId, LineageDirection direction, int depth) {
+    LineageAsset root = getAsset(assetId);
+    LineageDirection actualDirection = direction == null ? LineageDirection.BOTH : direction;
+    if (depth < 1 || depth > MAX_GRAPH_DEPTH) {
+      throw new IllegalArgumentException("depth 必须在 1 到 " + MAX_GRAPH_DEPTH + " 之间");
+    }
+
+    Map<Long, LineageAsset> nodes = new LinkedHashMap<>();
+    Map<Long, LineageRelation> relations = new LinkedHashMap<>();
+    nodes.put(root.id(), root);
+
+    Set<Long> visited = new LinkedHashSet<>();
+    visited.add(root.id());
+    Set<Long> frontier = new LinkedHashSet<>();
+    frontier.add(root.id());
+
+    for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
+      List<LineageRelation> discoveredRelations = new ArrayList<>();
+      if (actualDirection != LineageDirection.UPSTREAM) {
+        discoveredRelations.addAll(repository.findOutgoingRelations(frontier));
+      }
+      if (actualDirection != LineageDirection.DOWNSTREAM) {
+        discoveredRelations.addAll(repository.findIncomingRelations(frontier));
+      }
+
+      Set<Long> endpointIds = new LinkedHashSet<>();
+      Set<Long> nextFrontier = new LinkedHashSet<>();
+      for (LineageRelation relation : discoveredRelations) {
+        relations.putIfAbsent(relation.id(), relation);
+        endpointIds.add(relation.sourceAssetId());
+        endpointIds.add(relation.targetAssetId());
+        if (!visited.contains(relation.sourceAssetId())) nextFrontier.add(relation.sourceAssetId());
+        if (!visited.contains(relation.targetAssetId())) nextFrontier.add(relation.targetAssetId());
+      }
+
+      for (LineageAsset asset : repository.findAssetsByIds(endpointIds)) {
+        nodes.putIfAbsent(asset.id(), asset);
+      }
+      nextFrontier.removeAll(visited);
+      visited.addAll(nextFrontier);
+      frontier = nextFrontier;
+    }
+
+    return new LineageGraph(
+        root,
+        actualDirection,
+        depth,
+        List.copyOf(nodes.values()),
+        List.copyOf(relations.values()));
+  }
+
+  private static long requirePositive(long value, String field) {
+    if (value <= 0) throw new IllegalArgumentException(field + " 必须大于 0");
+    return value;
+  }
+
+  private static String required(String value, String field, int maxLength) {
+    String normalized = optional(value, maxLength);
+    if (normalized == null) throw new IllegalArgumentException(field + " 不能为空");
+    return normalized;
+  }
+
+  private static String valueOrEmpty(String value, int maxLength) {
+    String normalized = optional(value, maxLength);
+    return normalized == null ? "" : normalized;
+  }
+
+  private static String optional(String value, int maxLength) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    if (normalized.isEmpty()) return null;
+    if (normalized.length() > maxLength) {
+      throw new IllegalArgumentException("字段长度不能超过 " + maxLength);
+    }
+    return normalized;
+  }
+
+  public record RegisterAssetCommand(
+      String assetKey,
+      LineageAssetType assetType,
+      String name,
+      String sourceType,
+      String sourceId,
+      Long parentAssetId,
+      String dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String columnName,
+      JsonNode properties) {
+  }
+
+  public record RegisterRelationCommand(
+      long sourceAssetId,
+      long targetAssetId,
+      LineageRelationType relationType,
+      String sourceType,
+      String sourceId,
+      String expression,
+      BigDecimal confidence,
+      String version,
+      Instant observedAt,
+      JsonNode properties) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V1__create_lineage_core.sql
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V1__create_lineage_core.sql
@@ -1,0 +1,54 @@
+-- Lineage Core V1: unified metadata assets and typed upstream-to-downstream relationships.
+CREATE TABLE IF NOT EXISTS yak_metadata_asset (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    asset_key VARCHAR(512) NOT NULL,
+    asset_type VARCHAR(32) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    source_type VARCHAR(64) NOT NULL DEFAULT '',
+    source_id VARCHAR(200) NOT NULL DEFAULT '',
+    parent_asset_id BIGINT NULL,
+    data_source_id VARCHAR(64) NULL,
+    database_name VARCHAR(256) NULL,
+    schema_name VARCHAR(256) NULL,
+    table_name VARCHAR(256) NULL,
+    column_name VARCHAR(256) NULL,
+    properties JSON NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_metadata_asset_key (asset_key),
+    KEY idx_yak_metadata_asset_type (asset_type),
+    KEY idx_yak_metadata_asset_source (source_type, source_id),
+    KEY idx_yak_metadata_asset_parent (parent_asset_id),
+    KEY idx_yak_metadata_asset_datasource (data_source_id),
+    CONSTRAINT fk_yak_metadata_asset_parent
+        FOREIGN KEY (parent_asset_id) REFERENCES yak_metadata_asset(id)
+        ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_metadata_relation (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    source_asset_id BIGINT NOT NULL,
+    target_asset_id BIGINT NOT NULL,
+    relation_type VARCHAR(32) NOT NULL,
+    source_type VARCHAR(64) NOT NULL DEFAULT '',
+    source_id VARCHAR(200) NOT NULL DEFAULT '',
+    expression TEXT NULL,
+    confidence DECIMAL(5,4) NOT NULL DEFAULT 1.0000,
+    version VARCHAR(128) NOT NULL DEFAULT '',
+    observed_at DATETIME(6) NOT NULL,
+    properties JSON NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_metadata_relation_identity
+        (source_asset_id, target_asset_id, relation_type, source_type, source_id, version),
+    KEY idx_yak_metadata_relation_source (source_asset_id, relation_type),
+    KEY idx_yak_metadata_relation_target (target_asset_id, relation_type),
+    CONSTRAINT fk_yak_metadata_relation_source
+        FOREIGN KEY (source_asset_id) REFERENCES yak_metadata_asset(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_yak_metadata_relation_target
+        FOREIGN KEY (target_asset_id) REFERENCES yak_metadata_asset(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
@@ -1,0 +1,134 @@
+package io.yak.ops.business.lineage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class LineageServiceTest {
+
+  @Test
+  void traversesMultiHopGraphAndStopsAtVisitedAssets() {
+    InMemoryLineageRepository repository = new InMemoryLineageRepository();
+    LineageService service = new LineageService(repository);
+
+    LineageAsset tableA = service.registerAsset(asset("table:a", LineageAssetType.TABLE));
+    LineageAsset taskB = service.registerAsset(asset("sql:b", LineageAssetType.SQL_TASK));
+    LineageAsset tableC = service.registerAsset(asset("table:c", LineageAssetType.TABLE));
+    LineageAsset datasetD = service.registerAsset(asset("dataset:d", LineageAssetType.DATASET));
+    LineageAsset chartE = service.registerAsset(asset("chart:e", LineageAssetType.CHART));
+
+    service.registerRelation(relation(tableA.id(), taskB.id(), LineageRelationType.READS_FROM));
+    service.registerRelation(relation(taskB.id(), tableC.id(), LineageRelationType.WRITES_TO));
+    service.registerRelation(relation(tableC.id(), datasetD.id(), LineageRelationType.DERIVES_FROM));
+    service.registerRelation(relation(datasetD.id(), chartE.id(), LineageRelationType.CONSUMES));
+    service.registerRelation(relation(chartE.id(), taskB.id(), LineageRelationType.CONSUMES));
+
+    LineageGraph downstream = service.downstream(tableA.id(), 10);
+    assertEquals(
+        Set.of(tableA.id(), taskB.id(), tableC.id(), datasetD.id(), chartE.id()),
+        ids(downstream));
+    assertEquals(5, downstream.relations().size());
+
+    LineageGraph twoHops = service.downstream(tableA.id(), 2);
+    assertEquals(Set.of(tableA.id(), taskB.id(), tableC.id()), ids(twoHops));
+    assertEquals(2, twoHops.relations().size());
+
+    LineageGraph upstream = service.upstream(chartE.id(), 4);
+    assertTrue(ids(upstream).contains(tableA.id()));
+    assertTrue(ids(upstream).contains(datasetD.id()));
+  }
+
+  private static Set<Long> ids(LineageGraph graph) {
+    return graph.nodes().stream().map(LineageAsset::id).collect(Collectors.toSet());
+  }
+
+  private static LineageService.RegisterAssetCommand asset(
+      String assetKey, LineageAssetType assetType) {
+    return new LineageService.RegisterAssetCommand(
+        assetKey, assetType, assetKey, "TEST", assetKey, null,
+        null, null, null, null, null, null);
+  }
+
+  private static LineageService.RegisterRelationCommand relation(
+      long sourceAssetId, long targetAssetId, LineageRelationType relationType) {
+    return new LineageService.RegisterRelationCommand(
+        sourceAssetId, targetAssetId, relationType, "TEST", "case", null,
+        null, "v1", Instant.parse("2026-08-20T00:00:00Z"), null);
+  }
+
+  private static final class InMemoryLineageRepository implements LineageRepository {
+    private final AtomicLong assetIds = new AtomicLong(1);
+    private final AtomicLong relationIds = new AtomicLong(1);
+    private final Map<Long, LineageAsset> assets = new LinkedHashMap<>();
+    private final Map<String, Long> assetKeys = new LinkedHashMap<>();
+    private final Map<Long, LineageRelation> relations = new LinkedHashMap<>();
+
+    @Override
+    public LineageAsset upsertAsset(AssetWrite write) {
+      Long existingId = assetKeys.get(write.assetKey());
+      long id = existingId == null ? assetIds.getAndIncrement() : existingId;
+      Instant now = Instant.parse("2026-08-20T00:00:00Z");
+      LineageAsset existing = assets.get(id);
+      LineageAsset asset = new LineageAsset(
+          id, write.assetKey(), write.assetType(), write.name(), write.sourceType(), write.sourceId(),
+          write.parentAssetId(), write.dataSourceId(), write.databaseName(), write.schemaName(),
+          write.tableName(), write.columnName(), write.properties(),
+          existing == null ? now : existing.createTime(), now);
+      assets.put(id, asset);
+      assetKeys.put(write.assetKey(), id);
+      return asset;
+    }
+
+    @Override
+    public LineageRelation upsertRelation(RelationWrite write) {
+      long id = relationIds.getAndIncrement();
+      Instant now = Instant.parse("2026-08-20T00:00:00Z");
+      LineageRelation relation = new LineageRelation(
+          id, write.sourceAssetId(), write.targetAssetId(), write.relationType(),
+          write.sourceType(), write.sourceId(), write.expression(), write.confidence(),
+          write.version(), write.observedAt(), write.properties(), now, now);
+      relations.put(id, relation);
+      return relation;
+    }
+
+    @Override
+    public Optional<LineageAsset> findAsset(long assetId) {
+      return Optional.ofNullable(assets.get(assetId));
+    }
+
+    @Override
+    public Optional<LineageAsset> findAssetByKey(String assetKey) {
+      Long id = assetKeys.get(assetKey);
+      return id == null ? Optional.empty() : findAsset(id);
+    }
+
+    @Override
+    public List<LineageAsset> findAssetsByIds(Set<Long> assetIds) {
+      return assetIds.stream().map(assets::get).filter(java.util.Objects::nonNull).toList();
+    }
+
+    @Override
+    public List<LineageRelation> findOutgoingRelations(Set<Long> sourceAssetIds) {
+      return relations.values().stream()
+          .filter(relation -> sourceAssetIds.contains(relation.sourceAssetId()))
+          .toList();
+    }
+
+    @Override
+    public List<LineageRelation> findIncomingRelations(Set<Long> targetAssetIds) {
+      return relations.values().stream()
+          .filter(relation -> targetAssetIds.contains(relation.targetAssetId()))
+          .toList();
+    }
+  }
+}


### PR DESCRIPTION
## 目标

实现 Yak Ops 数据血缘第一阶段：先建立统一的 **Metadata Asset + Typed Relation** 底座，为后续 SQL 表级血缘、字段级血缘、Dataset、Chart、Dashboard 接入提供稳定模型。

## 本次内容

- 新增独立业务模块 `yak-ops-business-lineage`
- 新增统一资产类型：
  - `TABLE`
  - `COLUMN`
  - `SQL_TASK`
  - `DATASET`
  - `DATASET_FIELD`
  - `CHART`
  - `DASHBOARD`
- 新增关系类型：
  - `READS_FROM`
  - `WRITES_TO`
  - `DERIVES_FROM`
  - `CONSUMES`
  - `CONTAINS`
- 统一约定关系存储方向为 **upstream -> downstream**，方便后续上下游和影响分析复用同一套遍历逻辑
- 新增 Flyway 表：
  - `yak_metadata_asset`
  - `yak_metadata_relation`
- `asset_key` 作为稳定资产标识，支持幂等注册/更新
- 关系保存 provenance/evidence 信息：`source_type`、`source_id`、`expression`、`confidence`、`version`、`observed_at`、`properties`
- 新增最多 10 跳的循环安全 BFS 图遍历
- 新增 REST API：
  - `POST /api/v1/lineage/assets`
  - `POST /api/v1/lineage/relations`
  - `GET /api/v1/lineage/assets/{assetId}`
  - `GET /api/v1/lineage/assets/by-key`
  - `GET /api/v1/lineage/assets/{assetId}/upstream`
  - `GET /api/v1/lineage/assets/{assetId}/downstream`
  - `GET /api/v1/lineage/assets/{assetId}/graph`
- 新增 `LineageServiceTest`，覆盖多跳遍历、深度限制和环路场景
- 接入 root dependency management、BOM、business reactor 与 boot assembly

## 暂不包含

这个 PR 只做 Lineage Core，不提前进入下一阶段：

- 不解析 SQL
- 不自动生成表级/字段级血缘
- 不接 Dataset / Chart / Dashboard
- 不做前端血缘图
- 不引入 Neo4j / OpenLineage runtime event

## 下一阶段

在此底座之上接入 **数据开发 SQL 表级血缘**：SQL 保存/发布时解析 input tables / output tables，并注册为 Lineage Asset + Relation。