### PR TITLE
feat(lineage): add SQL table lineage for data development

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-development/pom.xml
@@ -43,6 +43,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-lineage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-dataset</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -1,0 +1,188 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Publishes authoritative table-level lineage for immutable SQL task revisions. */
+@Service
+public class DevelopmentSqlLineageService {
+
+  static final String EVIDENCE_SOURCE_TYPE = "DATA_DEVELOPMENT_SQL_PARSE";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DevelopmentSqlLineageService.class);
+  private static final int MAX_EVIDENCE_SQL_LENGTH = 16000;
+
+  private final LineageService lineageService;
+  private final LineageMaintenanceService maintenanceService;
+  private final SqlTableLineageParser parser;
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentSqlLineageService(
+      LineageService lineageService,
+      LineageMaintenanceService maintenanceService,
+      SqlTableLineageParser parser,
+      ObjectMapper objectMapper) {
+    this.lineageService = lineageService;
+    this.maintenanceService = maintenanceService;
+    this.parser = parser;
+    this.objectMapper = objectMapper;
+  }
+
+  public void syncPublished(DevelopmentNode node, DevelopmentTaskRevision revision) {
+    if (node == null || revision == null || revision.definition() == null) return;
+    if (!"SQL".equalsIgnoreCase(revision.definition().taskType())) return;
+
+    String evidenceId = String.valueOf(node.id());
+    String dataSourceId = dataSourceId(revision.definition().configJson());
+    String sql = revision.definition().content();
+
+    try {
+      SqlTableLineageParser.ParseResult parsed = parser.parse(sql);
+      maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
+
+      LineageAsset task = registerTaskAsset(node, revision, dataSourceId, parsed, null);
+      String evidenceSql = truncate(sql, MAX_EVIDENCE_SQL_LENGTH);
+      Instant observedAt = revision.createTime() == null ? Instant.now() : revision.createTime();
+
+      for (SqlTableLineageParser.TableRef input : parsed.inputs()) {
+        LineageAsset table = registerTableAsset(dataSourceId, input);
+        lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+            table.id(),
+            task.id(),
+            LineageRelationType.READS_FROM,
+            EVIDENCE_SOURCE_TYPE,
+            evidenceId,
+            evidenceSql,
+            BigDecimal.ONE,
+            Integer.toString(revision.revisionNo()),
+            observedAt,
+            relationProperties(revision, "INPUT")));
+      }
+
+      for (SqlTableLineageParser.TableRef output : parsed.outputs()) {
+        LineageAsset table = registerTableAsset(dataSourceId, output);
+        lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+            task.id(),
+            table.id(),
+            LineageRelationType.WRITES_TO,
+            EVIDENCE_SOURCE_TYPE,
+            evidenceId,
+            evidenceSql,
+            BigDecimal.ONE,
+            Integer.toString(revision.revisionNo()),
+            observedAt,
+            relationProperties(revision, "OUTPUT")));
+      }
+    } catch (SqlTableLineageParser.SqlLineageParseException exception) {
+      maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
+      registerTaskAsset(node, revision, dataSourceId, null, exception);
+      LOGGER.warn(
+          "Failed to parse SQL lineage for development node {} revision {}: {}",
+          node.id(),
+          revision.revisionNo(),
+          exception.getMessage());
+    }
+  }
+
+  private LineageAsset registerTaskAsset(
+      DevelopmentNode node,
+      DevelopmentTaskRevision revision,
+      String dataSourceId,
+      SqlTableLineageParser.ParseResult parsed,
+      RuntimeException parseFailure) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    if (node.projectId() != null) properties.put("projectId", String.valueOf(node.projectId()));
+    properties.put("revisionId", String.valueOf(revision.id()));
+    properties.put("revisionNo", revision.revisionNo());
+    properties.put("checksum", revision.checksum());
+    properties.put("dataSourceId", dataSourceId);
+    if (parseFailure == null && parsed != null) {
+      properties.put("parseStatus", "SUCCESS");
+      properties.put("statementCount", parsed.statementCount());
+      properties.put("inputTableCount", parsed.inputs().size());
+      properties.put("outputTableCount", parsed.outputs().size());
+    } else {
+      properties.put("parseStatus", "FAILED");
+      properties.put("parseError", truncate(
+          parseFailure == null ? "Unknown SQL lineage parser failure" : parseFailure.getMessage(),
+          1000));
+    }
+
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        "sql-task:data-development:" + node.id(),
+        LineageAssetType.SQL_TASK,
+        node.name(),
+        "DATA_DEVELOPMENT",
+        String.valueOf(node.id()),
+        null,
+        dataSourceId,
+        null,
+        null,
+        null,
+        null,
+        properties));
+  }
+
+  private LineageAsset registerTableAsset(
+      String dataSourceId,
+      SqlTableLineageParser.TableRef table) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("qualifiedName", table.qualifiedName());
+
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        "table:" + dataSourceId + ":" + table.canonicalName(),
+        LineageAssetType.TABLE,
+        table.qualifiedName(),
+        "DATASOURCE",
+        dataSourceId,
+        null,
+        dataSourceId,
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName(),
+        null,
+        properties));
+  }
+
+  private JsonNode relationProperties(DevelopmentTaskRevision revision, String role) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("revisionId", String.valueOf(revision.id()));
+    properties.put("revisionNo", revision.revisionNo());
+    properties.put("tableRole", role);
+    return properties;
+  }
+
+  private String dataSourceId(String configJson) {
+    try {
+      JsonNode root = objectMapper.readTree(
+          configJson == null || configJson.isBlank() ? "{}" : configJson);
+      JsonNode value = root == null ? null : root.get("dataSourceId");
+      String dataSourceId = value == null || value.isNull() ? null : value.asText();
+      if (dataSourceId == null || dataSourceId.isBlank()) {
+        throw new IllegalArgumentException("SQL task dataSourceId 不能为空");
+      }
+      return dataSourceId.trim();
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("SQL task configJson 不是合法 JSON", exception);
+    }
+  }
+
+  private static String truncate(String value, int maxLength) {
+    if (value == null) return null;
+    return value.length() <= maxLength ? value : value.substring(0, maxLength);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
@@ -25,6 +25,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +39,14 @@ public class DevelopmentTaskService {
   private final TaskCatalogService taskCatalogService;
   private final TaskPluginRegistry pluginRegistry;
   private final ObjectMapper objectMapper;
+  private final DevelopmentSqlLineageService sqlLineageService;
 
+  /**
+   * Keeps focused unit tests and non-Spring callers source compatible.
+   *
+   * <p>Production wiring uses the annotated constructor below so SQL lineage is synchronized after
+   * a successful publish.
+   */
   public DevelopmentTaskService(
       DevelopmentNodeRepository nodeRepository,
       DevelopmentTaskDraftRepository draftRepository,
@@ -46,12 +54,32 @@ public class DevelopmentTaskService {
       TaskCatalogService taskCatalogService,
       TaskPluginRegistry pluginRegistry,
       ObjectMapper objectMapper) {
+    this(
+        nodeRepository,
+        draftRepository,
+        revisionRepository,
+        taskCatalogService,
+        pluginRegistry,
+        objectMapper,
+        null);
+  }
+
+  @Autowired
+  public DevelopmentTaskService(
+      DevelopmentNodeRepository nodeRepository,
+      DevelopmentTaskDraftRepository draftRepository,
+      DevelopmentTaskRevisionRepository revisionRepository,
+      TaskCatalogService taskCatalogService,
+      TaskPluginRegistry pluginRegistry,
+      ObjectMapper objectMapper,
+      DevelopmentSqlLineageService sqlLineageService) {
     this.nodeRepository = nodeRepository;
     this.draftRepository = draftRepository;
     this.revisionRepository = revisionRepository;
     this.taskCatalogService = taskCatalogService;
     this.pluginRegistry = pluginRegistry;
     this.objectMapper = objectMapper;
+    this.sqlLineageService = sqlLineageService;
   }
 
   public DevelopmentTaskDraft getDraft(Long nodeId) {
@@ -132,6 +160,9 @@ public class DevelopmentTaskService {
         definition.taskType(),
         published.id(),
         published.revisionNo());
+    if (sqlLineageService != null) {
+      sqlLineageService.syncPublished(node, published);
+    }
     return published;
   }
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlTableLineageParser.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlTableLineageParser.java
@@ -1,0 +1,184 @@
+package io.yak.ops.business.development.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.truncate.Truncate;
+import net.sf.jsqlparser.statement.update.Update;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Extracts table-level dependencies from SQL without coupling the generic lineage module to SQL.
+ *
+ * <p>V1 intentionally focuses on SELECT / INSERT / UPDATE / DELETE / CREATE TABLE / TRUNCATE.
+ * CTEs, joins, subqueries and unions are handled by JSQLParser's table visitor.
+ */
+@Component
+public class SqlTableLineageParser {
+
+  public ParseResult parse(String sql) {
+    if (sql == null || sql.isBlank()) {
+      return new ParseResult(List.of(), List.of(), 0);
+    }
+
+    try {
+      Statements parsed = CCJSqlParserUtil.parseStatements(sql);
+      Map<String, TableRef> inputs = new LinkedHashMap<>();
+      Map<String, TableRef> outputs = new LinkedHashMap<>();
+      int statementCount = 0;
+
+      for (Statement statement : parsed.getStatements()) {
+        statementCount++;
+        StatementTables tables = analyze(statement);
+        tables.inputs().forEach(table -> inputs.putIfAbsent(table.canonicalName(), table));
+        tables.outputs().forEach(table -> outputs.putIfAbsent(table.canonicalName(), table));
+      }
+
+      return new ParseResult(
+          inputs.values().stream().sorted(Comparator.comparing(TableRef::canonicalName)).toList(),
+          outputs.values().stream().sorted(Comparator.comparing(TableRef::canonicalName)).toList(),
+          statementCount);
+    } catch (JSQLParserException | RuntimeException exception) {
+      if (exception instanceof SqlLineageParseException parseException) {
+        throw parseException;
+      }
+      throw new SqlLineageParseException(
+          "SQL 表级血缘解析失败：" + safeMessage(exception), exception);
+    }
+  }
+
+  private StatementTables analyze(Statement statement) {
+    TablesNamesFinder finder = new TablesNamesFinder();
+    Set<String> discovered = finder.getTables(statement);
+    LinkedHashSet<TableRef> inputs = new LinkedHashSet<>();
+    for (String tableName : discovered) {
+      TableRef ref = tableRef(tableName);
+      if (ref != null) inputs.add(ref);
+    }
+
+    LinkedHashSet<TableRef> outputs = new LinkedHashSet<>();
+    TableRef target = target(statement);
+    if (target != null) {
+      outputs.add(target);
+      if (statement instanceof Insert || statement instanceof CreateTable || statement instanceof Truncate) {
+        inputs.removeIf(input -> input.canonicalName().equals(target.canonicalName()));
+      } else if (statement instanceof Update || statement instanceof Delete) {
+        inputs.add(target);
+      }
+    }
+
+    if (!(statement instanceof Select
+        || statement instanceof Insert
+        || statement instanceof Update
+        || statement instanceof Delete
+        || statement instanceof CreateTable
+        || statement instanceof Truncate)) {
+      // Unknown statements may still expose read tables through TablesNamesFinder. Keep those inputs
+      // but do not guess a write target.
+    }
+    return new StatementTables(List.copyOf(inputs), List.copyOf(outputs));
+  }
+
+  private TableRef target(Statement statement) {
+    Table table = null;
+    if (statement instanceof Insert insert) {
+      table = insert.getTable();
+    } else if (statement instanceof Update update) {
+      table = update.getTable();
+    } else if (statement instanceof Delete delete) {
+      table = delete.getTable();
+    } else if (statement instanceof CreateTable createTable) {
+      table = createTable.getTable();
+    } else if (statement instanceof Truncate truncate) {
+      table = truncate.getTable();
+    }
+    return table == null ? null : tableRef(table.getFullyQualifiedName());
+  }
+
+  private TableRef tableRef(String rawName) {
+    if (rawName == null || rawName.isBlank()) return null;
+    String cleaned = cleanQualifiedName(rawName);
+    if (cleaned.isBlank()) return null;
+
+    List<String> parts = new ArrayList<>();
+    for (String part : cleaned.split("\\.")) {
+      String normalized = stripIdentifierQuotes(part.trim());
+      if (!normalized.isBlank()) parts.add(normalized);
+    }
+    if (parts.isEmpty()) return null;
+
+    String tableName = parts.get(parts.size() - 1);
+    String schemaName = parts.size() >= 2 ? parts.get(parts.size() - 2) : null;
+    String databaseName = parts.size() >= 3 ? parts.get(parts.size() - 3) : null;
+    String qualifiedName = String.join(".", parts);
+    return new TableRef(
+        qualifiedName.toLowerCase(Locale.ROOT),
+        qualifiedName,
+        databaseName,
+        schemaName,
+        tableName);
+  }
+
+  private String cleanQualifiedName(String value) {
+    return value.trim();
+  }
+
+  private String stripIdentifierQuotes(String value) {
+    if (value.length() >= 2) {
+      char first = value.charAt(0);
+      char last = value.charAt(value.length() - 1);
+      if ((first == '`' && last == '`')
+          || (first == '"' && last == '"')
+          || (first == '[' && last == ']')) {
+        return value.substring(1, value.length() - 1);
+      }
+    }
+    return value;
+  }
+
+  private static String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "unknown parser error" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 500 ? message.substring(0, 500) : message;
+  }
+
+  public record ParseResult(
+      List<TableRef> inputs,
+      List<TableRef> outputs,
+      int statementCount) {
+  }
+
+  public record TableRef(
+      String canonicalName,
+      String qualifiedName,
+      String databaseName,
+      String schemaName,
+      String tableName) {
+  }
+
+  private record StatementTables(List<TableRef> inputs, List<TableRef> outputs) {
+  }
+
+  public static final class SqlLineageParseException extends RuntimeException {
+    SqlLineageParseException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
@@ -1,0 +1,155 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DevelopmentSqlLineageServiceTest {
+
+  @Test
+  void replacesGeneratedRelationsWithPublishedSqlLineage() {
+    LineageService lineageService = mock(LineageService.class);
+    LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    SqlTableLineageParser parser = mock(SqlTableLineageParser.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    DevelopmentSqlLineageService service =
+        new DevelopmentSqlLineageService(lineageService, maintenanceService, parser, objectMapper);
+
+    String sql =
+        "INSERT INTO dws.sales SELECT o.id FROM ods.orders o JOIN dim.users u ON u.id=o.user_id";
+    when(parser.parse(sql)).thenReturn(new SqlTableLineageParser.ParseResult(
+        List.of(
+            new SqlTableLineageParser.TableRef(
+                "dim.users", "dim.users", null, "dim", "users"),
+            new SqlTableLineageParser.TableRef(
+                "ods.orders", "ods.orders", null, "ods", "orders")),
+        List.of(new SqlTableLineageParser.TableRef(
+            "dws.sales", "dws.sales", null, "dws", "sales")),
+        1));
+
+    AtomicLong ids = new AtomicLong(1);
+    when(lineageService.registerAsset(any())).thenAnswer(invocation -> {
+      LineageService.RegisterAssetCommand command = invocation.getArgument(0);
+      return new LineageAsset(
+          ids.getAndIncrement(),
+          command.assetKey(),
+          command.assetType(),
+          command.name(),
+          command.sourceType(),
+          command.sourceId(),
+          command.parentAssetId(),
+          command.dataSourceId(),
+          command.databaseName(),
+          command.schemaName(),
+          command.tableName(),
+          command.columnName(),
+          command.properties(),
+          Instant.parse("2026-08-20T00:00:00Z"),
+          Instant.parse("2026-08-20T00:00:00Z"));
+    });
+
+    service.syncPublished(node(), revision(sql));
+
+    verify(maintenanceService).clearRelationsByEvidence(
+        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineageService, times(3)).registerRelation(relations.capture());
+
+    long reads = relations.getAllValues().stream()
+        .filter(value -> value.relationType() == LineageRelationType.READS_FROM)
+        .count();
+    long writes = relations.getAllValues().stream()
+        .filter(value -> value.relationType() == LineageRelationType.WRITES_TO)
+        .count();
+    assertEquals(2, reads);
+    assertEquals(1, writes);
+    assertTrue(relations.getAllValues().stream()
+        .allMatch(value -> value.sourceType().equals(
+            DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE)));
+  }
+
+  @Test
+  void parserFailureClearsStaleRelationsWithoutBreakingTaskPublish() {
+    LineageService lineageService = mock(LineageService.class);
+    LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    SqlTableLineageParser parser = mock(SqlTableLineageParser.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    DevelopmentSqlLineageService service =
+        new DevelopmentSqlLineageService(lineageService, maintenanceService, parser, objectMapper);
+
+    String sql = "SELECT FROM";
+    when(parser.parse(sql)).thenThrow(new SqlTableLineageParser.SqlLineageParseException(
+        "parse failed", new RuntimeException("parse failed")));
+    when(lineageService.registerAsset(any())).thenAnswer(invocation -> {
+      LineageService.RegisterAssetCommand command = invocation.getArgument(0);
+      return new LineageAsset(
+          1L,
+          command.assetKey(),
+          LineageAssetType.SQL_TASK,
+          command.name(),
+          command.sourceType(),
+          command.sourceId(),
+          null,
+          command.dataSourceId(),
+          null,
+          null,
+          null,
+          null,
+          command.properties(),
+          Instant.parse("2026-08-20T00:00:00Z"),
+          Instant.parse("2026-08-20T00:00:00Z"));
+    });
+
+    assertDoesNotThrow(() -> service.syncPublished(node(), revision(sql)));
+
+    verify(maintenanceService).clearRelationsByEvidence(
+        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
+    verify(lineageService, never()).registerRelation(any());
+  }
+
+  private static DevelopmentNode node() {
+    return new DevelopmentNode(
+        42L,
+        "sales sql",
+        "SQL",
+        7L,
+        3L,
+        true,
+        Instant.parse("2026-08-20T00:00:00Z"),
+        Instant.parse("2026-08-20T00:00:00Z"));
+  }
+
+  private static DevelopmentTaskRevision revision(String sql) {
+    return new DevelopmentTaskRevision(
+        100L,
+        42L,
+        3,
+        9L,
+        new TaskDefinition("SQL", 1, sql, "{\"dataSourceId\":\"12\"}"),
+        "checksum",
+        Instant.parse("2026-08-20T00:00:00Z"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/SqlTableLineageParserTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/SqlTableLineageParserTest.java
@@ -1,0 +1,74 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class SqlTableLineageParserTest {
+
+  private final SqlTableLineageParser parser = new SqlTableLineageParser();
+
+  @Test
+  void extractsInsertSelectInputsAndOutput() {
+    SqlTableLineageParser.ParseResult result = parser.parse(
+        """
+        INSERT INTO dws.sales_daily (user_id, amount)
+        SELECT o.user_id, o.amount
+        FROM ods.orders o
+        JOIN dim.users u ON u.id = o.user_id
+        WHERE o.status = 'PAID'
+        """);
+
+    assertEquals(Set.of("ods.orders", "dim.users"), canonical(result.inputs()));
+    assertEquals(Set.of("dws.sales_daily"), canonical(result.outputs()));
+    assertEquals(1, result.statementCount());
+  }
+
+  @Test
+  void excludesCteAliasFromPhysicalInputs() {
+    SqlTableLineageParser.ParseResult result = parser.parse(
+        """
+        WITH recent_orders AS (
+          SELECT user_id, amount
+          FROM ods.orders
+        )
+        SELECT r.user_id, r.amount
+        FROM recent_orders r
+        JOIN dim.users u ON u.id = r.user_id
+        """);
+
+    assertEquals(Set.of("ods.orders", "dim.users"), canonical(result.inputs()));
+    assertTrue(result.outputs().isEmpty());
+  }
+
+  @Test
+  void treatsCreateTableAsSelectAsWriteTarget() {
+    SqlTableLineageParser.ParseResult result = parser.parse(
+        "CREATE TABLE dwd.new_orders AS SELECT * FROM ods.orders");
+
+    assertEquals(Set.of("ods.orders"), canonical(result.inputs()));
+    assertEquals(Set.of("dwd.new_orders"), canonical(result.outputs()));
+  }
+
+  @Test
+  void treatsUpdateAndDeleteTargetsAsReadWriteTables() {
+    SqlTableLineageParser.ParseResult result = parser.parse(
+        """
+        UPDATE mart.orders SET status = 'DONE' WHERE id = 1;
+        DELETE FROM mart.bad_orders WHERE id = 2;
+        """);
+
+    assertEquals(Set.of("mart.orders", "mart.bad_orders"), canonical(result.inputs()));
+    assertEquals(Set.of("mart.orders", "mart.bad_orders"), canonical(result.outputs()));
+    assertEquals(2, result.statementCount());
+  }
+
+  private static Set<String> canonical(java.util.List<SqlTableLineageParser.TableRef> tables) {
+    return tables.stream()
+        .map(SqlTableLineageParser.TableRef::canonicalName)
+        .collect(Collectors.toSet());
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
@@ -135,6 +135,14 @@ class JdbcLineageRepository implements LineageRepository {
   }
 
   @Override
+  public int deleteRelationsByEvidence(String sourceType, String sourceId) {
+    return jdbcTemplate.update(
+        "DELETE FROM yak_metadata_relation WHERE source_type = ? AND source_id = ?",
+        sourceType,
+        sourceId);
+  }
+
+  @Override
   public Optional<LineageAsset> findAsset(long assetId) {
     return jdbcTemplate.query(
         ASSET_COLUMNS + " WHERE id = ? LIMIT 1", this::mapAsset, assetId)

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageMaintenanceService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageMaintenanceService.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.lineage;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Maintenance operations for replacing provenance-scoped generated lineage. */
+@Service
+public class LineageMaintenanceService {
+
+  private final LineageRepository repository;
+
+  LineageMaintenanceService(LineageRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional
+  public int clearRelationsByEvidence(String sourceType, String sourceId) {
+    String normalizedType = required(sourceType, "sourceType", 64);
+    String normalizedId = required(sourceId, "sourceId", 200);
+    return repository.deleteRelationsByEvidence(normalizedType, normalizedId);
+  }
+
+  private static String required(String value, String field, int maxLength) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " 不能为空");
+    }
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) {
+      throw new IllegalArgumentException(field + " 长度不能超过 " + maxLength);
+    }
+    return normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
@@ -13,6 +13,10 @@ interface LineageRepository {
 
   LineageRelation upsertRelation(RelationWrite write);
 
+  default int deleteRelationsByEvidence(String sourceType, String sourceId) {
+    throw new UnsupportedOperationException("Relation evidence cleanup is not supported");
+  }
+
   Optional<LineageAsset> findAsset(long assetId);
 
   Optional<LineageAsset> findAssetByKey(String assetKey);

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V2__index_relation_evidence.sql
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V2__index_relation_evidence.sql
@@ -1,0 +1,3 @@
+-- Stage 2 SQL lineage replaces generated relations by parser evidence on every publish.
+ALTER TABLE yak_metadata_relation
+    ADD KEY idx_yak_metadata_relation_evidence (source_type, source_id);


### PR DESCRIPTION
## 目标

实现 Yak Ops 数据血缘第二阶段：把 **数据开发 SQL 的已发布不可变 Revision** 接入第一阶段的 Lineage Core，自动形成真实的表级上下游关系。

## 核心链路

```text
input TABLE(s) -> SQL_TASK -> output TABLE(s)
```

关系仍遵循 Lineage Core 的统一方向：**upstream -> downstream**。

- 输入表 -> SQL Task：`READS_FROM`
- SQL Task -> 输出表：`WRITES_TO`

## 本次实现

- 数据开发模块接入 `yak-ops-business-lineage`
- 新增 `SqlTableLineageParser`
  - 复用项目现有 JSQLParser 4.9 解析栈，不额外引入新的 SQL Parser
  - 支持多语句 SQL
  - V1 覆盖 `SELECT / INSERT / UPDATE / DELETE / CREATE TABLE AS SELECT / TRUNCATE`
  - JOIN / CTE / 子查询 / UNION 的物理输入表交由 JSQLParser table visitor 解析
- 新增 `DevelopmentSqlLineageService`
  - 以 **发布后的 immutable DevelopmentTaskRevision** 作为权威设计态血缘
  - SQL Task 使用稳定资产 Key：`sql-task:data-development:{nodeId}`
  - Table 使用稳定资产 Key：`table:{dataSourceId}:{qualifiedTableName}`
  - 在 Asset properties 中保留 revisionId / revisionNo / checksum / parseStatus / input/output 数量
  - 在 Relation 中保留 SQL、revision、tableRole 等证据信息
- 在 `DevelopmentTaskService.publish()` 成功发布 Task Catalog 后同步 SQL 表级血缘
- 新增按 evidence 替换关系的维护能力
  - evidence：`DATA_DEVELOPMENT_SQL_PARSE + nodeId`
  - 同一个 SQL 节点重新发布时，先删除旧自动血缘，再写当前 Revision
  - 避免修改 SQL 后旧表关系残留在图中
- SQL 解析失败时：
  - 不因为 parser error 阻断 SQL Task 发布
  - 清理旧自动关系，避免继续展示过期血缘
  - 保留 SQL_TASK 资产并记录 `parseStatus=FAILED / parseError`
- 为 evidence cleanup 增加数据库索引

## 示例

```sql
INSERT INTO dws.sales_daily
SELECT o.user_id, o.amount
FROM ods.orders o
JOIN dim.users u ON u.id = o.user_id;
```

会自动形成：

```text
ods.orders ----->
                 SQL Task -----> dws.sales_daily
dim.users ------>
```

## 测试

新增测试覆盖：

- INSERT SELECT + JOIN 的输入/输出表解析
- CTE 只保留真实物理表，不把 CTE alias 当成资产
- CTAS 表级血缘
- UPDATE / DELETE 的 read + write 语义
- 多语句 SQL
- 发布新版时按 evidence 清理旧关系
- parser failure 不向外抛出并清理陈旧关系

## 设计取舍

### 为什么发布时生成，而不是草稿保存时生成？

草稿编辑过程中 SQL 经常是不完整甚至暂时不可解析的。第二阶段把 **已发布 Revision** 定义成权威设计态血缘来源，避免血缘图跟着编辑器半成品频繁抖动，也方便后续按 Revision 做版本演进。

### 为什么暂时不用 Druid / Calcite？

当前 data-development 已经使用 JSQLParser 4.9。表级血缘所需能力足够，先复用现有依赖可以把第二阶段保持轻量。第三阶段进入字段级表达式解析后，再根据复杂 SQL 与方言覆盖情况评估是否升级解析引擎。

## 暂不包含

- 字段级 lineage
- SQL 表达式 / alias / aggregate 字段传播
- 草稿实时 lineage preview
- Runtime / OpenLineage event
- SeaTunnel runtime lineage
- 血缘前端图
- 跨数据源 SQL 的自动语义推断

## 下一阶段

进入 **SQL 字段级血缘**：从简单字段映射开始，逐步补 Alias、JOIN、聚合、CASE、CTE 等字段传播规则。