### PR TITLE
feat(lineage): add SQL column lineage for data development

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -13,11 +13,13 @@ import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.LineageService;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-/** Publishes authoritative table-level lineage for immutable SQL task revisions. */
+/** Publishes authoritative table- and column-level lineage for immutable SQL task revisions. */
 @Service
 public class DevelopmentSqlLineageService {
 
@@ -28,17 +30,20 @@ public class DevelopmentSqlLineageService {
 
   private final LineageService lineageService;
   private final LineageMaintenanceService maintenanceService;
-  private final SqlTableLineageParser parser;
+  private final SqlTableLineageParser tableParser;
+  private final SqlColumnLineageParser columnParser;
   private final ObjectMapper objectMapper;
 
   public DevelopmentSqlLineageService(
       LineageService lineageService,
       LineageMaintenanceService maintenanceService,
-      SqlTableLineageParser parser,
+      SqlTableLineageParser tableParser,
+      SqlColumnLineageParser columnParser,
       ObjectMapper objectMapper) {
     this.lineageService = lineageService;
     this.maintenanceService = maintenanceService;
-    this.parser = parser;
+    this.tableParser = tableParser;
+    this.columnParser = columnParser;
     this.objectMapper = objectMapper;
   }
 
@@ -51,15 +56,38 @@ public class DevelopmentSqlLineageService {
     String sql = revision.definition().content();
 
     try {
-      SqlTableLineageParser.ParseResult parsed = parser.parse(sql);
+      SqlTableLineageParser.ParseResult tableParsed = tableParser.parse(sql);
+      SqlColumnLineageParser.ParseResult columnParsed = null;
+      SqlColumnLineageParser.SqlColumnLineageParseException columnFailure = null;
+      try {
+        columnParsed = columnParser.parse(sql);
+      } catch (SqlColumnLineageParser.SqlColumnLineageParseException exception) {
+        columnFailure = exception;
+        LOGGER.warn(
+            "Failed to parse SQL column lineage for development node {} revision {}: {}",
+            node.id(),
+            revision.revisionNo(),
+            exception.getMessage());
+      }
+
+      // Table and column lineage share one evidence scope. A new immutable revision replaces every
+      // generated relationship from the previous revision before current facts are written.
       maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
 
-      LineageAsset task = registerTaskAsset(node, revision, dataSourceId, parsed, null);
+      LineageAsset task = registerTaskAsset(
+          node,
+          revision,
+          dataSourceId,
+          tableParsed,
+          columnParsed,
+          null,
+          columnFailure);
       String evidenceSql = truncate(sql, MAX_EVIDENCE_SQL_LENGTH);
       Instant observedAt = revision.createTime() == null ? Instant.now() : revision.createTime();
+      Map<String, LineageAsset> tableAssets = new LinkedHashMap<>();
 
-      for (SqlTableLineageParser.TableRef input : parsed.inputs()) {
-        LineageAsset table = registerTableAsset(dataSourceId, input);
+      for (SqlTableLineageParser.TableRef input : tableParsed.inputs()) {
+        LineageAsset table = registerTableAsset(dataSourceId, input, tableAssets);
         lineageService.registerRelation(new LineageService.RegisterRelationCommand(
             table.id(),
             task.id(),
@@ -70,11 +98,11 @@ public class DevelopmentSqlLineageService {
             BigDecimal.ONE,
             Integer.toString(revision.revisionNo()),
             observedAt,
-            relationProperties(revision, "INPUT")));
+            tableRelationProperties(revision, "INPUT")));
       }
 
-      for (SqlTableLineageParser.TableRef output : parsed.outputs()) {
-        LineageAsset table = registerTableAsset(dataSourceId, output);
+      for (SqlTableLineageParser.TableRef output : tableParsed.outputs()) {
+        LineageAsset table = registerTableAsset(dataSourceId, output, tableAssets);
         lineageService.registerRelation(new LineageService.RegisterRelationCommand(
             task.id(),
             table.id(),
@@ -85,16 +113,78 @@ public class DevelopmentSqlLineageService {
             BigDecimal.ONE,
             Integer.toString(revision.revisionNo()),
             observedAt,
-            relationProperties(revision, "OUTPUT")));
+            tableRelationProperties(revision, "OUTPUT")));
+      }
+
+      if (columnParsed != null) {
+        registerColumnLineage(
+            dataSourceId,
+            task,
+            revision,
+            columnParsed,
+            evidenceId,
+            observedAt,
+            tableAssets);
       }
     } catch (SqlTableLineageParser.SqlLineageParseException exception) {
       maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
-      registerTaskAsset(node, revision, dataSourceId, null, exception);
+      registerTaskAsset(node, revision, dataSourceId, null, null, exception, null);
       LOGGER.warn(
-          "Failed to parse SQL lineage for development node {} revision {}: {}",
+          "Failed to parse SQL table lineage for development node {} revision {}: {}",
           node.id(),
           revision.revisionNo(),
           exception.getMessage());
+    }
+  }
+
+  private void registerColumnLineage(
+      String dataSourceId,
+      LineageAsset task,
+      DevelopmentTaskRevision revision,
+      SqlColumnLineageParser.ParseResult parsed,
+      String evidenceId,
+      Instant observedAt,
+      Map<String, LineageAsset> tableAssets) {
+    int mappingIndex = 0;
+    for (SqlColumnLineageParser.ColumnMapping mapping : parsed.mappings()) {
+      mappingIndex++;
+      LineageAsset sourceTable = registerTableAsset(dataSourceId, mapping.sourceTable(), tableAssets);
+      LineageAsset targetTable = registerTableAsset(dataSourceId, mapping.targetTable(), tableAssets);
+      LineageAsset sourceColumn = registerColumnAsset(
+          dataSourceId,
+          sourceTable,
+          mapping.sourceTable(),
+          mapping.sourceColumnName());
+      LineageAsset targetColumn = registerColumnAsset(
+          dataSourceId,
+          targetTable,
+          mapping.targetTable(),
+          mapping.targetColumnName());
+
+      // UPDATE a = a + 1 is a valid dependency, but Lineage Core intentionally forbids self edges.
+      // The authoritative TABLE -> SQL_TASK -> TABLE path remains available for that case.
+      if (sourceColumn.id() == targetColumn.id()) continue;
+
+      String relationVersion = revision.revisionNo()
+          + ":column:"
+          + mapping.statementIndex()
+          + ":"
+          + mapping.outputOrdinal()
+          + ":"
+          + mapping.sourceOrdinal()
+          + ":"
+          + mappingIndex;
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+          sourceColumn.id(),
+          targetColumn.id(),
+          LineageRelationType.DERIVES_FROM,
+          EVIDENCE_SOURCE_TYPE,
+          evidenceId,
+          truncate(mapping.expression(), MAX_EVIDENCE_SQL_LENGTH),
+          BigDecimal.ONE,
+          relationVersion,
+          observedAt,
+          columnRelationProperties(task, revision, mapping)));
     }
   }
 
@@ -102,24 +192,47 @@ public class DevelopmentSqlLineageService {
       DevelopmentNode node,
       DevelopmentTaskRevision revision,
       String dataSourceId,
-      SqlTableLineageParser.ParseResult parsed,
-      RuntimeException parseFailure) {
+      SqlTableLineageParser.ParseResult tableParsed,
+      SqlColumnLineageParser.ParseResult columnParsed,
+      RuntimeException tableFailure,
+      RuntimeException columnFailure) {
     ObjectNode properties = objectMapper.createObjectNode();
     if (node.projectId() != null) properties.put("projectId", String.valueOf(node.projectId()));
     properties.put("revisionId", String.valueOf(revision.id()));
     properties.put("revisionNo", revision.revisionNo());
     properties.put("checksum", revision.checksum());
     properties.put("dataSourceId", dataSourceId);
-    if (parseFailure == null && parsed != null) {
+
+    if (tableFailure == null && tableParsed != null) {
       properties.put("parseStatus", "SUCCESS");
-      properties.put("statementCount", parsed.statementCount());
-      properties.put("inputTableCount", parsed.inputs().size());
-      properties.put("outputTableCount", parsed.outputs().size());
+      properties.put("statementCount", tableParsed.statementCount());
+      properties.put("inputTableCount", tableParsed.inputs().size());
+      properties.put("outputTableCount", tableParsed.outputs().size());
     } else {
       properties.put("parseStatus", "FAILED");
       properties.put("parseError", truncate(
-          parseFailure == null ? "Unknown SQL lineage parser failure" : parseFailure.getMessage(),
+          tableFailure == null ? "Unknown SQL table lineage parser failure" : tableFailure.getMessage(),
           1000));
+    }
+
+    if (tableFailure != null) {
+      properties.put("columnParseStatus", "SKIPPED");
+    } else if (columnFailure != null) {
+      properties.put("columnParseStatus", "FAILED");
+      properties.put("columnParseError", truncate(columnFailure.getMessage(), 1000));
+    } else if (columnParsed != null) {
+      properties.put("columnMappingCount", columnParsed.mappings().size());
+      properties.put("candidateOutputColumnCount", columnParsed.candidateOutputCount());
+      properties.put("unresolvedColumnReferenceCount", columnParsed.unresolvedReferenceCount());
+      if (columnParsed.unresolvedReferenceCount() > 0 && !columnParsed.mappings().isEmpty()) {
+        properties.put("columnParseStatus", "PARTIAL");
+      } else if (columnParsed.unresolvedReferenceCount() > 0) {
+        properties.put("columnParseStatus", "UNRESOLVED");
+      } else {
+        properties.put("columnParseStatus", "SUCCESS");
+      }
+    } else {
+      properties.put("columnParseStatus", "SKIPPED");
     }
 
     return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
@@ -139,12 +252,16 @@ public class DevelopmentSqlLineageService {
 
   private LineageAsset registerTableAsset(
       String dataSourceId,
-      SqlTableLineageParser.TableRef table) {
+      SqlTableLineageParser.TableRef table,
+      Map<String, LineageAsset> cache) {
+    String key = tableAssetKey(dataSourceId, table);
+    LineageAsset cached = cache.get(key);
+    if (cached != null) return cached;
+
     ObjectNode properties = objectMapper.createObjectNode();
     properties.put("qualifiedName", table.qualifiedName());
-
-    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
-        "table:" + dataSourceId + ":" + table.canonicalName(),
+    LineageAsset registered = lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        key,
         LineageAssetType.TABLE,
         table.qualifiedName(),
         "DATASOURCE",
@@ -156,13 +273,59 @@ public class DevelopmentSqlLineageService {
         table.tableName(),
         null,
         properties));
+    cache.put(key, registered);
+    return registered;
   }
 
-  private JsonNode relationProperties(DevelopmentTaskRevision revision, String role) {
+  private LineageAsset registerColumnAsset(
+      String dataSourceId,
+      LineageAsset tableAsset,
+      SqlTableLineageParser.TableRef table,
+      String columnName) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("qualifiedName", table.qualifiedName() + "." + columnName);
+
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        columnAssetKey(dataSourceId, table, columnName),
+        LineageAssetType.COLUMN,
+        columnName,
+        "DATASOURCE",
+        dataSourceId,
+        tableAsset.id(),
+        dataSourceId,
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName(),
+        columnName,
+        properties));
+  }
+
+  private JsonNode tableRelationProperties(DevelopmentTaskRevision revision, String role) {
     ObjectNode properties = objectMapper.createObjectNode();
     properties.put("revisionId", String.valueOf(revision.id()));
     properties.put("revisionNo", revision.revisionNo());
+    properties.put("lineageLevel", "TABLE");
     properties.put("tableRole", role);
+    return properties;
+  }
+
+  private JsonNode columnRelationProperties(
+      LineageAsset task,
+      DevelopmentTaskRevision revision,
+      SqlColumnLineageParser.ColumnMapping mapping) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("revisionId", String.valueOf(revision.id()));
+    properties.put("revisionNo", revision.revisionNo());
+    properties.put("lineageLevel", "COLUMN");
+    properties.put("sqlTaskAssetId", String.valueOf(task.id()));
+    properties.put("mappingKind", mapping.mappingKind().name());
+    properties.put("statementIndex", mapping.statementIndex());
+    properties.put("outputOrdinal", mapping.outputOrdinal());
+    properties.put("sourceOrdinal", mapping.sourceOrdinal());
+    properties.put("sourceTable", mapping.sourceTable().qualifiedName());
+    properties.put("sourceColumn", mapping.sourceColumnName());
+    properties.put("targetTable", mapping.targetTable().qualifiedName());
+    properties.put("targetColumn", mapping.targetColumnName());
     return properties;
   }
 
@@ -179,6 +342,24 @@ public class DevelopmentSqlLineageService {
     } catch (JsonProcessingException exception) {
       throw new IllegalArgumentException("SQL task configJson 不是合法 JSON", exception);
     }
+  }
+
+  private static String tableAssetKey(
+      String dataSourceId,
+      SqlTableLineageParser.TableRef table) {
+    return "table:" + dataSourceId + ":" + table.canonicalName();
+  }
+
+  private static String columnAssetKey(
+      String dataSourceId,
+      SqlTableLineageParser.TableRef table,
+      String columnName) {
+    return "column:"
+        + dataSourceId
+        + ":"
+        + table.canonicalName()
+        + "."
+        + columnName.toLowerCase(java.util.Locale.ROOT);
   }
 
   private static String truncate(String value, int maxLength) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlColumnLineageParser.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlColumnLineageParser.java
@@ -1,0 +1,602 @@
+package io.yak.ops.business.development.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.select.AllColumns;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.FromItem;
+import net.sf.jsqlparser.statement.select.Join;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectItem;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.statement.select.WithItem;
+import net.sf.jsqlparser.statement.update.Update;
+import net.sf.jsqlparser.statement.update.UpdateSet;
+import org.springframework.stereotype.Component;
+
+/**
+ * Extracts conservative column-to-column lineage from SQL ASTs.
+ *
+ * <p>V1 only emits a mapping when both source and target columns can be identified without
+ * guessing. Unsupported or ambiguous expressions are counted as unresolved and safely fall back
+ * to the already-persisted table-level lineage.
+ */
+@Component
+public class SqlColumnLineageParser {
+
+  private static final Set<String> AGGREGATE_FUNCTIONS = Set.of(
+      "AVG", "COUNT", "GROUP_CONCAT", "MAX", "MIN", "SUM",
+      "STDDEV", "STDDEV_POP", "STDDEV_SAMP", "VAR_POP", "VAR_SAMP", "VARIANCE");
+
+  public ParseResult parse(String sql) {
+    if (sql == null || sql.isBlank()) {
+      return new ParseResult(List.of(), 0, 0, 0);
+    }
+
+    try {
+      Statements parsed = CCJSqlParserUtil.parseStatements(sql);
+      Map<String, ColumnMapping> mappings = new LinkedHashMap<>();
+      MutableStats stats = new MutableStats();
+      int statementIndex = 0;
+
+      for (Statement statement : parsed.getStatements()) {
+        statementIndex++;
+        analyze(statement, statementIndex, mappings, stats);
+      }
+
+      return new ParseResult(
+          List.copyOf(mappings.values()),
+          statementIndex,
+          stats.candidateOutputCount,
+          stats.unresolvedReferenceCount);
+    } catch (JSQLParserException | RuntimeException exception) {
+      if (exception instanceof SqlColumnLineageParseException parseException) {
+        throw parseException;
+      }
+      throw new SqlColumnLineageParseException(
+          "SQL 字段级血缘解析失败：" + safeMessage(exception), exception);
+    }
+  }
+
+  private void analyze(
+      Statement statement,
+      int statementIndex,
+      Map<String, ColumnMapping> mappings,
+      MutableStats stats) {
+    if (statement instanceof Insert insert) {
+      analyzeInsert(insert, statementIndex, mappings, stats);
+    } else if (statement instanceof CreateTable createTable) {
+      analyzeCreateTable(createTable, statementIndex, mappings, stats);
+    } else if (statement instanceof Update update) {
+      analyzeUpdate(update, statementIndex, mappings, stats);
+    }
+  }
+
+  private void analyzeInsert(
+      Insert insert,
+      int statementIndex,
+      Map<String, ColumnMapping> mappings,
+      MutableStats stats) {
+    SqlTableLineageParser.TableRef target = tableRef(insert.getTable());
+    Select select = insert.getSelect();
+    if (target == null || select == null) return;
+
+    List<String> targetColumns = new ArrayList<>();
+    if (insert.getColumns() != null) {
+      for (Column column : insert.getColumns()) {
+        targetColumns.add(normalizeColumnName(column.getColumnName()));
+      }
+    }
+
+    // INSERT without an explicit target column list depends on the physical target schema.
+    // V1 deliberately does not infer target column names from SELECT aliases because that can
+    // silently produce incorrect lineage. Table-level lineage remains available.
+    if (targetColumns.isEmpty()) {
+      stats.unresolvedReferenceCount++;
+      return;
+    }
+
+    analyzeSelect(
+        select,
+        target,
+        targetColumns,
+        statementIndex,
+        mappings,
+        stats,
+        cteNames(insert.getWithItemsList()));
+  }
+
+  private void analyzeCreateTable(
+      CreateTable createTable,
+      int statementIndex,
+      Map<String, ColumnMapping> mappings,
+      MutableStats stats) {
+    SqlTableLineageParser.TableRef target = tableRef(createTable.getTable());
+    Select select = createTable.getSelect();
+    if (target == null || select == null) return;
+
+    List<String> targetColumns = new ArrayList<>();
+    if (createTable.getColumns() != null) {
+      for (String column : createTable.getColumns()) {
+        targetColumns.add(normalizeColumnName(column));
+      }
+    }
+    if (targetColumns.isEmpty()) {
+      targetColumns = inferSelectOutputNames(select);
+    }
+
+    analyzeSelect(
+        select,
+        target,
+        targetColumns,
+        statementIndex,
+        mappings,
+        stats,
+        Set.of());
+  }
+
+  private void analyzeUpdate(
+      Update update,
+      int statementIndex,
+      Map<String, ColumnMapping> mappings,
+      MutableStats stats) {
+    SqlTableLineageParser.TableRef target = tableRef(update.getTable());
+    if (target == null || update.getUpdateSets() == null) return;
+
+    Set<String> cteNames = cteNames(update.getWithItemsList());
+    Scope scope = new Scope();
+    addFromItem(scope, update.getTable(), cteNames);
+    addFromItem(scope, update.getFromItem(), cteNames);
+    addJoins(scope, update.getStartJoins(), cteNames);
+    addJoins(scope, update.getJoins(), cteNames);
+
+    int outputOrdinal = 0;
+    for (UpdateSet updateSet : update.getUpdateSets()) {
+      int count = Math.min(updateSet.getColumns().size(), updateSet.getValues().size());
+      for (int i = 0; i < count; i++) {
+        outputOrdinal++;
+        stats.candidateOutputCount++;
+
+        String targetColumn = normalizeColumnName(updateSet.getColumn(i).getColumnName());
+        Expression expression = updateSet.getValue(i);
+        if (targetColumn == null || expression == null) {
+          stats.unresolvedReferenceCount++;
+          continue;
+        }
+
+        collectMappings(
+            expression,
+            target,
+            targetColumn,
+            scope,
+            statementIndex,
+            outputOrdinal,
+            mappings,
+            stats);
+      }
+      if (updateSet.getColumns().size() != updateSet.getValues().size()) {
+        stats.unresolvedReferenceCount +=
+            Math.abs(updateSet.getColumns().size() - updateSet.getValues().size());
+      }
+    }
+  }
+
+  private Set<String> cteNames(List<WithItem> withItems) {
+    if (withItems == null || withItems.isEmpty()) return Set.of();
+    Set<String> names = new LinkedHashSet<>();
+    for (WithItem withItem : withItems) {
+      if (withItem != null
+          && withItem.getAlias() != null
+          && withItem.getAlias().getName() != null) {
+        names.add(withItem.getAlias().getName().toLowerCase(Locale.ROOT));
+      }
+    }
+    return names;
+  }
+
+  private void analyzeSelect(
+      Select select,
+      SqlTableLineageParser.TableRef target,
+      List<String> targetColumns,
+      int statementIndex,
+      Map<String, ColumnMapping> mappings,
+      MutableStats stats,
+      Set<String> inheritedCteNames) {
+    if (select == null) return;
+
+    Set<String> cteNames = new LinkedHashSet<>(inheritedCteNames);
+    if (select.getWithItemsList() != null) {
+      for (WithItem withItem : select.getWithItemsList()) {
+        if (withItem.getAlias() != null && withItem.getAlias().getName() != null) {
+          cteNames.add(withItem.getAlias().getName().toLowerCase(Locale.ROOT));
+        }
+      }
+    }
+
+    if (select instanceof PlainSelect plainSelect) {
+      analyzePlainSelect(
+          plainSelect,
+          target,
+          targetColumns,
+          statementIndex,
+          mappings,
+          stats,
+          cteNames);
+      return;
+    }
+
+    if (select instanceof SetOperationList setOperationList) {
+      if (setOperationList.getSelects() == null) return;
+      for (Select child : setOperationList.getSelects()) {
+        analyzeSelect(
+            child,
+            target,
+            targetColumns,
+            statementIndex,
+            mappings,
+            stats,
+            cteNames);
+      }
+      return;
+    }
+
+    stats.unresolvedReferenceCount++;
+  }
+
+  private void analyzePlainSelect(
+      PlainSelect select,
+      SqlTableLineageParser.TableRef target,
+      List<String> targetColumns,
+      int statementIndex,
+      Map<String, ColumnMapping> mappings,
+      MutableStats stats,
+      Set<String> cteNames) {
+    if (select.getSelectItems() == null) return;
+
+    Scope scope = buildScope(select, cteNames);
+    List<SelectItem<?>> items = select.getSelectItems();
+    for (int i = 0; i < items.size(); i++) {
+      stats.candidateOutputCount++;
+      SelectItem<?> item = items.get(i);
+      Expression expression = item == null ? null : item.getExpression();
+
+      String targetColumn =
+          i < targetColumns.size() ? normalizeColumnName(targetColumns.get(i)) : null;
+      if (targetColumn == null) {
+        stats.unresolvedReferenceCount++;
+        continue;
+      }
+      if (expression == null
+          || expression instanceof AllColumns
+          || expression instanceof AllTableColumns) {
+        stats.unresolvedReferenceCount++;
+        continue;
+      }
+
+      collectMappings(
+          expression,
+          target,
+          targetColumn,
+          scope,
+          statementIndex,
+          i + 1,
+          mappings,
+          stats);
+    }
+
+    if (targetColumns.size() > items.size()) {
+      stats.unresolvedReferenceCount += targetColumns.size() - items.size();
+    }
+  }
+
+  private void collectMappings(
+      Expression expression,
+      SqlTableLineageParser.TableRef target,
+      String targetColumn,
+      Scope scope,
+      int statementIndex,
+      int outputOrdinal,
+      Map<String, ColumnMapping> mappings,
+      MutableStats stats) {
+    SourceCollection collected = collectSources(expression, scope);
+    stats.unresolvedReferenceCount += collected.unresolvedCount();
+
+    MappingKind kind =
+        expression instanceof Column
+            ? MappingKind.IDENTITY
+            : collected.aggregate()
+                ? MappingKind.AGGREGATION
+                : MappingKind.TRANSFORMATION;
+
+    int sourceOrdinal = 0;
+    for (SourceColumnRef source : collected.sources()) {
+      sourceOrdinal++;
+      ColumnMapping mapping = new ColumnMapping(
+          source.table(),
+          source.columnName(),
+          target,
+          targetColumn,
+          kind,
+          expression.toString(),
+          statementIndex,
+          outputOrdinal,
+          sourceOrdinal);
+      mappings.putIfAbsent(mappingKey(mapping), mapping);
+    }
+  }
+
+  private SourceCollection collectSources(Expression expression, Scope scope) {
+    Map<String, SourceColumnRef> sources = new LinkedHashMap<>();
+    int[] unresolved = new int[] {0};
+    boolean[] aggregate = new boolean[] {false};
+
+    expression.accept(new ExpressionVisitorAdapter() {
+      @Override
+      public void visit(Column column) {
+        String columnName = normalizeColumnName(column.getColumnName());
+        SqlTableLineageParser.TableRef table = resolveTable(column, scope);
+        if (columnName == null || table == null) {
+          unresolved[0]++;
+          return;
+        }
+        SourceColumnRef source = new SourceColumnRef(table, columnName);
+        sources.putIfAbsent(
+            table.canonicalName() + "." + columnName.toLowerCase(Locale.ROOT),
+            source);
+      }
+
+      @Override
+      public void visit(Function function) {
+        String name = function.getName();
+        if (name != null && AGGREGATE_FUNCTIONS.contains(name.toUpperCase(Locale.ROOT))) {
+          aggregate[0] = true;
+        }
+        super.visit(function);
+      }
+    });
+
+    return new SourceCollection(List.copyOf(sources.values()), unresolved[0], aggregate[0]);
+  }
+
+  private Scope buildScope(PlainSelect select, Set<String> cteNames) {
+    Scope scope = new Scope();
+    addFromItem(scope, select.getFromItem(), cteNames);
+    addJoins(scope, select.getJoins(), cteNames);
+    return scope;
+  }
+
+  private void addJoins(Scope scope, List<Join> joins, Set<String> cteNames) {
+    if (joins == null) return;
+    for (Join join : joins) {
+      if (join != null) addFromItem(scope, join.getRightItem(), cteNames);
+    }
+  }
+
+  private void addFromItem(Scope scope, FromItem fromItem, Set<String> cteNames) {
+    if (!(fromItem instanceof Table table)) return;
+
+    String rawName = table.getFullyQualifiedName();
+    String simpleName = table.getName();
+    if (rawName != null
+        && !rawName.contains(".")
+        && simpleName != null
+        && cteNames.contains(simpleName.toLowerCase(Locale.ROOT))) {
+      return;
+    }
+
+    SqlTableLineageParser.TableRef ref = tableRef(table);
+    if (ref == null) return;
+
+    String alias =
+        table.getAlias() == null || table.getAlias().getName() == null
+            ? null
+            : table.getAlias().getName();
+    scope.add(ref, alias);
+  }
+
+  private SqlTableLineageParser.TableRef resolveTable(Column column, Scope scope) {
+    Table qualifier = column.getTable();
+    String rawQualifier = qualifier == null ? null : qualifier.getFullyQualifiedName();
+    if (rawQualifier != null && !rawQualifier.isBlank()) {
+      return scope.resolve(rawQualifier);
+    }
+    return scope.onlyTable();
+  }
+
+  private SqlTableLineageParser.TableRef tableRef(Table table) {
+    if (table == null) return null;
+    String rawName = table.getFullyQualifiedName();
+    if (rawName == null || rawName.isBlank()) return null;
+
+    List<String> parts = new ArrayList<>();
+    for (String part : rawName.trim().split("\\.")) {
+      String normalized = normalizeIdentifier(part);
+      if (normalized != null) parts.add(normalized);
+    }
+    if (parts.isEmpty()) return null;
+
+    String tableName = parts.get(parts.size() - 1);
+    String schemaName = parts.size() >= 2 ? parts.get(parts.size() - 2) : null;
+    String databaseName = parts.size() >= 3 ? parts.get(parts.size() - 3) : null;
+    String qualifiedName = String.join(".", parts);
+    return new SqlTableLineageParser.TableRef(
+        qualifiedName.toLowerCase(Locale.ROOT),
+        qualifiedName,
+        databaseName,
+        schemaName,
+        tableName);
+  }
+
+  private List<String> inferSelectOutputNames(Select select) {
+    if (select instanceof PlainSelect plainSelect) {
+      List<String> names = new ArrayList<>();
+      if (plainSelect.getSelectItems() == null) return names;
+      for (SelectItem<?> item : plainSelect.getSelectItems()) {
+        if (item == null || item.getExpression() == null) {
+          names.add(null);
+        } else if (item.getAlias() != null && item.getAlias().getName() != null) {
+          names.add(normalizeColumnName(item.getAlias().getName()));
+        } else if (item.getExpression() instanceof Column column) {
+          names.add(normalizeColumnName(column.getColumnName()));
+        } else {
+          names.add(null);
+        }
+      }
+      return names;
+    }
+
+    if (select instanceof SetOperationList setOperationList
+        && setOperationList.getSelects() != null
+        && !setOperationList.getSelects().isEmpty()) {
+      return inferSelectOutputNames(setOperationList.getSelect(0));
+    }
+    return List.of();
+  }
+
+  private static String mappingKey(ColumnMapping mapping) {
+    return mapping.sourceTable().canonicalName()
+        + "|"
+        + mapping.sourceColumnName().toLowerCase(Locale.ROOT)
+        + "|"
+        + mapping.targetTable().canonicalName()
+        + "|"
+        + mapping.targetColumnName().toLowerCase(Locale.ROOT)
+        + "|"
+        + mapping.statementIndex()
+        + "|"
+        + mapping.outputOrdinal()
+        + "|"
+        + mapping.expression();
+  }
+
+  private static String normalizeColumnName(String value) {
+    return normalizeIdentifier(value);
+  }
+
+  private static String normalizeIdentifier(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    if (normalized.isEmpty()) return null;
+    if (normalized.length() >= 2) {
+      char first = normalized.charAt(0);
+      char last = normalized.charAt(normalized.length() - 1);
+      if ((first == '`' && last == '`')
+          || (first == '"' && last == '"')
+          || (first == '[' && last == ']')) {
+        normalized = normalized.substring(1, normalized.length() - 1);
+      }
+    }
+    return normalized.isBlank() ? null : normalized;
+  }
+
+  private static String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "unknown parser error" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 500 ? message.substring(0, 500) : message;
+  }
+
+  public enum MappingKind {
+    IDENTITY,
+    TRANSFORMATION,
+    AGGREGATION
+  }
+
+  public record ParseResult(
+      List<ColumnMapping> mappings,
+      int statementCount,
+      int candidateOutputCount,
+      int unresolvedReferenceCount) {
+  }
+
+  public record ColumnMapping(
+      SqlTableLineageParser.TableRef sourceTable,
+      String sourceColumnName,
+      SqlTableLineageParser.TableRef targetTable,
+      String targetColumnName,
+      MappingKind mappingKind,
+      String expression,
+      int statementIndex,
+      int outputOrdinal,
+      int sourceOrdinal) {
+  }
+
+  private record SourceColumnRef(
+      SqlTableLineageParser.TableRef table,
+      String columnName) {
+  }
+
+  private record SourceCollection(
+      List<SourceColumnRef> sources,
+      int unresolvedCount,
+      boolean aggregate) {
+  }
+
+  private static final class MutableStats {
+    private int candidateOutputCount;
+    private int unresolvedReferenceCount;
+  }
+
+  private static final class Scope {
+    private final Map<String, SqlTableLineageParser.TableRef> tables = new LinkedHashMap<>();
+    private final Map<String, SqlTableLineageParser.TableRef> qualifiers = new LinkedHashMap<>();
+    private final Set<String> ambiguousQualifiers = new LinkedHashSet<>();
+
+    void add(SqlTableLineageParser.TableRef table, String alias) {
+      tables.putIfAbsent(table.canonicalName(), table);
+      addQualifier(table.qualifiedName(), table);
+      addQualifier(table.tableName(), table);
+      if (table.schemaName() != null) {
+        addQualifier(table.schemaName() + "." + table.tableName(), table);
+      }
+      addQualifier(alias, table);
+    }
+
+    SqlTableLineageParser.TableRef resolve(String qualifier) {
+      if (qualifier == null || qualifier.isBlank()) return null;
+      String key = qualifier.trim().toLowerCase(Locale.ROOT);
+      if (ambiguousQualifiers.contains(key)) return null;
+      return qualifiers.get(key);
+    }
+
+    SqlTableLineageParser.TableRef onlyTable() {
+      return tables.size() == 1 ? tables.values().iterator().next() : null;
+    }
+
+    private void addQualifier(String qualifier, SqlTableLineageParser.TableRef table) {
+      if (qualifier == null || qualifier.isBlank()) return;
+      String key = qualifier.trim().toLowerCase(Locale.ROOT);
+      SqlTableLineageParser.TableRef existing = qualifiers.get(key);
+      if (existing != null && !existing.canonicalName().equals(table.canonicalName())) {
+        ambiguousQualifiers.add(key);
+        qualifiers.remove(key);
+      } else if (!ambiguousQualifiers.contains(key)) {
+        qualifiers.putIfAbsent(key, table);
+      }
+    }
+  }
+
+  public static final class SqlColumnLineageParseException extends RuntimeException {
+    SqlColumnLineageParseException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.development.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -20,7 +21,9 @@ import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.LineageService;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,31 +31,185 @@ import org.mockito.ArgumentCaptor;
 class DevelopmentSqlLineageServiceTest {
 
   @Test
-  void replacesGeneratedRelationsWithPublishedSqlLineage() {
+  void replacesGeneratedRelationsWithTableAndColumnLineage() {
     LineageService lineageService = mock(LineageService.class);
     LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
-    SqlTableLineageParser parser = mock(SqlTableLineageParser.class);
+    SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
+    SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
     ObjectMapper objectMapper = new ObjectMapper();
-    DevelopmentSqlLineageService service =
-        new DevelopmentSqlLineageService(lineageService, maintenanceService, parser, objectMapper);
+    stubAssetRegistration(lineageService);
+    DevelopmentSqlLineageService service = new DevelopmentSqlLineageService(
+        lineageService, maintenanceService, tableParser, columnParser, objectMapper);
 
     String sql =
-        "INSERT INTO dws.sales SELECT o.id FROM ods.orders o JOIN dim.users u ON u.id=o.user_id";
-    when(parser.parse(sql)).thenReturn(new SqlTableLineageParser.ParseResult(
+        "INSERT INTO dws.sales (order_id, user_name) "
+            + "SELECT o.id, u.name FROM ods.orders o JOIN dim.users u ON u.id=o.user_id";
+    SqlTableLineageParser.TableRef orders = table("ods.orders", "ods", "orders");
+    SqlTableLineageParser.TableRef users = table("dim.users", "dim", "users");
+    SqlTableLineageParser.TableRef sales = table("dws.sales", "dws", "sales");
+    when(tableParser.parse(sql)).thenReturn(new SqlTableLineageParser.ParseResult(
+        List.of(users, orders), List.of(sales), 1));
+    when(columnParser.parse(sql)).thenReturn(new SqlColumnLineageParser.ParseResult(
         List.of(
-            new SqlTableLineageParser.TableRef(
-                "dim.users", "dim.users", null, "dim", "users"),
-            new SqlTableLineageParser.TableRef(
-                "ods.orders", "ods.orders", null, "ods", "orders")),
-        List.of(new SqlTableLineageParser.TableRef(
-            "dws.sales", "dws.sales", null, "dws", "sales")),
-        1));
+            mapping(orders, "id", sales, "order_id", 1, 1),
+            mapping(users, "name", sales, "user_name", 2, 1)),
+        1,
+        2,
+        0));
 
+    service.syncPublished(node(), revision(sql));
+
+    verify(maintenanceService).clearRelationsByEvidence(
+        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineageService, times(5)).registerRelation(relations.capture());
+
+    assertEquals(2, count(relations, LineageRelationType.READS_FROM));
+    assertEquals(1, count(relations, LineageRelationType.WRITES_TO));
+    assertEquals(2, count(relations, LineageRelationType.DERIVES_FROM));
+    assertTrue(relations.getAllValues().stream()
+        .filter(value -> value.relationType() == LineageRelationType.DERIVES_FROM)
+        .allMatch(value -> "COLUMN".equals(value.properties().path("lineageLevel").asText())));
+  }
+
+  @Test
+  void columnAssetsAreParentedByStableTableAssets() {
+    LineageService lineageService = mock(LineageService.class);
+    LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
+    SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    stubAssetRegistration(lineageService);
+    DevelopmentSqlLineageService service = new DevelopmentSqlLineageService(
+        lineageService, maintenanceService, tableParser, columnParser, objectMapper);
+
+    String sql = "INSERT INTO dws.sales (order_id) SELECT o.id FROM ods.orders o";
+    SqlTableLineageParser.TableRef orders = table("ods.orders", "ods", "orders");
+    SqlTableLineageParser.TableRef sales = table("dws.sales", "dws", "sales");
+    when(tableParser.parse(sql)).thenReturn(new SqlTableLineageParser.ParseResult(
+        List.of(orders), List.of(sales), 1));
+    when(columnParser.parse(sql)).thenReturn(new SqlColumnLineageParser.ParseResult(
+        List.of(mapping(orders, "id", sales, "order_id", 1, 1)), 1, 1, 0));
+
+    service.syncPublished(node(), revision(sql));
+
+    ArgumentCaptor<LineageService.RegisterAssetCommand> assets =
+        ArgumentCaptor.forClass(LineageService.RegisterAssetCommand.class);
+    verify(lineageService, times(5)).registerAsset(assets.capture());
+
+    Map<String, LineageService.RegisterAssetCommand> byKey = new LinkedHashMap<>();
+    for (LineageService.RegisterAssetCommand command : assets.getAllValues()) {
+      byKey.put(command.assetKey(), command);
+    }
+
+    LineageService.RegisterAssetCommand sourceColumn = byKey.get("column:12:ods.orders.id");
+    LineageService.RegisterAssetCommand targetColumn = byKey.get("column:12:dws.sales.order_id");
+    assertNotNull(sourceColumn);
+    assertNotNull(targetColumn);
+    assertEquals(LineageAssetType.COLUMN, sourceColumn.assetType());
+    assertEquals(LineageAssetType.COLUMN, targetColumn.assetType());
+    assertNotNull(sourceColumn.parentAssetId());
+    assertNotNull(targetColumn.parentAssetId());
+  }
+
+  @Test
+  void columnParserFailureKeepsCurrentTableLineage() {
+    LineageService lineageService = mock(LineageService.class);
+    LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
+    SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    stubAssetRegistration(lineageService);
+    DevelopmentSqlLineageService service = new DevelopmentSqlLineageService(
+        lineageService, maintenanceService, tableParser, columnParser, objectMapper);
+
+    String sql = "INSERT INTO dws.sales (id) SELECT o.id FROM ods.orders o";
+    SqlTableLineageParser.TableRef orders = table("ods.orders", "ods", "orders");
+    SqlTableLineageParser.TableRef sales = table("dws.sales", "dws", "sales");
+    when(tableParser.parse(sql)).thenReturn(new SqlTableLineageParser.ParseResult(
+        List.of(orders), List.of(sales), 1));
+    when(columnParser.parse(sql)).thenThrow(
+        new SqlColumnLineageParser.SqlColumnLineageParseException(
+            "column parse failed", new RuntimeException("column parse failed")));
+
+    assertDoesNotThrow(() -> service.syncPublished(node(), revision(sql)));
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineageService, times(2)).registerRelation(relations.capture());
+    assertEquals(1, count(relations, LineageRelationType.READS_FROM));
+    assertEquals(1, count(relations, LineageRelationType.WRITES_TO));
+    assertEquals(0, count(relations, LineageRelationType.DERIVES_FROM));
+  }
+
+  @Test
+  void tableParserFailureClearsStaleRelationsAndSkipsColumnParsing() {
+    LineageService lineageService = mock(LineageService.class);
+    LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
+    SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    stubAssetRegistration(lineageService);
+    DevelopmentSqlLineageService service = new DevelopmentSqlLineageService(
+        lineageService, maintenanceService, tableParser, columnParser, objectMapper);
+
+    String sql = "SELECT FROM";
+    when(tableParser.parse(sql)).thenThrow(new SqlTableLineageParser.SqlLineageParseException(
+        "table parse failed", new RuntimeException("table parse failed")));
+
+    assertDoesNotThrow(() -> service.syncPublished(node(), revision(sql)));
+
+    verify(maintenanceService).clearRelationsByEvidence(
+        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
+    verify(columnParser, never()).parse(any());
+    verify(lineageService, never()).registerRelation(any());
+  }
+
+  private static long count(
+      ArgumentCaptor<LineageService.RegisterRelationCommand> relations,
+      LineageRelationType type) {
+    return relations.getAllValues().stream()
+        .filter(value -> value.relationType() == type)
+        .count();
+  }
+
+  private static SqlColumnLineageParser.ColumnMapping mapping(
+      SqlTableLineageParser.TableRef sourceTable,
+      String sourceColumn,
+      SqlTableLineageParser.TableRef targetTable,
+      String targetColumn,
+      int outputOrdinal,
+      int sourceOrdinal) {
+    return new SqlColumnLineageParser.ColumnMapping(
+        sourceTable,
+        sourceColumn,
+        targetTable,
+        targetColumn,
+        SqlColumnLineageParser.MappingKind.IDENTITY,
+        sourceTable.tableName() + "." + sourceColumn,
+        1,
+        outputOrdinal,
+        sourceOrdinal);
+  }
+
+  private static SqlTableLineageParser.TableRef table(
+      String qualifiedName,
+      String schema,
+      String table) {
+    return new SqlTableLineageParser.TableRef(
+        qualifiedName, qualifiedName, null, schema, table);
+  }
+
+  private static void stubAssetRegistration(LineageService lineageService) {
     AtomicLong ids = new AtomicLong(1);
+    Map<String, Long> stableIds = new LinkedHashMap<>();
     when(lineageService.registerAsset(any())).thenAnswer(invocation -> {
       LineageService.RegisterAssetCommand command = invocation.getArgument(0);
+      long id = stableIds.computeIfAbsent(command.assetKey(), ignored -> ids.getAndIncrement());
       return new LineageAsset(
-          ids.getAndIncrement(),
+          id,
           command.assetKey(),
           command.assetType(),
           command.name(),
@@ -68,66 +225,6 @@ class DevelopmentSqlLineageServiceTest {
           Instant.parse("2026-08-20T00:00:00Z"),
           Instant.parse("2026-08-20T00:00:00Z"));
     });
-
-    service.syncPublished(node(), revision(sql));
-
-    verify(maintenanceService).clearRelationsByEvidence(
-        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
-
-    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
-        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
-    verify(lineageService, times(3)).registerRelation(relations.capture());
-
-    long reads = relations.getAllValues().stream()
-        .filter(value -> value.relationType() == LineageRelationType.READS_FROM)
-        .count();
-    long writes = relations.getAllValues().stream()
-        .filter(value -> value.relationType() == LineageRelationType.WRITES_TO)
-        .count();
-    assertEquals(2, reads);
-    assertEquals(1, writes);
-    assertTrue(relations.getAllValues().stream()
-        .allMatch(value -> value.sourceType().equals(
-            DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE)));
-  }
-
-  @Test
-  void parserFailureClearsStaleRelationsWithoutBreakingTaskPublish() {
-    LineageService lineageService = mock(LineageService.class);
-    LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
-    SqlTableLineageParser parser = mock(SqlTableLineageParser.class);
-    ObjectMapper objectMapper = new ObjectMapper();
-    DevelopmentSqlLineageService service =
-        new DevelopmentSqlLineageService(lineageService, maintenanceService, parser, objectMapper);
-
-    String sql = "SELECT FROM";
-    when(parser.parse(sql)).thenThrow(new SqlTableLineageParser.SqlLineageParseException(
-        "parse failed", new RuntimeException("parse failed")));
-    when(lineageService.registerAsset(any())).thenAnswer(invocation -> {
-      LineageService.RegisterAssetCommand command = invocation.getArgument(0);
-      return new LineageAsset(
-          1L,
-          command.assetKey(),
-          LineageAssetType.SQL_TASK,
-          command.name(),
-          command.sourceType(),
-          command.sourceId(),
-          null,
-          command.dataSourceId(),
-          null,
-          null,
-          null,
-          null,
-          command.properties(),
-          Instant.parse("2026-08-20T00:00:00Z"),
-          Instant.parse("2026-08-20T00:00:00Z"));
-    });
-
-    assertDoesNotThrow(() -> service.syncPublished(node(), revision(sql)));
-
-    verify(maintenanceService).clearRelationsByEvidence(
-        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
-    verify(lineageService, never()).registerRelation(any());
   }
 
   private static DevelopmentNode node() {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/SqlColumnLineageParserTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/SqlColumnLineageParserTest.java
@@ -1,0 +1,178 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SqlColumnLineageParserTest {
+
+  private final SqlColumnLineageParser parser = new SqlColumnLineageParser();
+
+  @Test
+  void parsesInsertSelectIdentityTransformationAndAggregation() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        INSERT INTO dws.sales_daily (user_id, gross_amount, order_count)
+        SELECT
+          o.user_id,
+          o.quantity * o.price AS gross_amount,
+          COUNT(o.id) AS order_count
+        FROM ods.orders o
+        GROUP BY o.user_id, o.quantity, o.price
+        """);
+
+    assertEquals(4, result.mappings().size());
+    assertMapping(
+        result.mappings(), "ods.orders", "user_id", "dws.sales_daily", "user_id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "ods.orders", "quantity", "dws.sales_daily", "gross_amount",
+        SqlColumnLineageParser.MappingKind.TRANSFORMATION);
+    assertMapping(
+        result.mappings(), "ods.orders", "price", "dws.sales_daily", "gross_amount",
+        SqlColumnLineageParser.MappingKind.TRANSFORMATION);
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.sales_daily", "order_count",
+        SqlColumnLineageParser.MappingKind.AGGREGATION);
+    assertEquals(0, result.unresolvedReferenceCount());
+  }
+
+  @Test
+  void resolvesQualifiedJoinColumnsWithoutCreatingCrossProductMappings() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        INSERT INTO dws.order_customer (order_id, customer_name)
+        SELECT o.id, c.name
+        FROM ods.orders o
+        JOIN dim.customer c ON c.id = o.customer_id
+        """);
+
+    assertEquals(2, result.mappings().size());
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.order_customer", "order_id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "dim.customer", "name", "dws.order_customer", "customer_name",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+  }
+
+  @Test
+  void leavesAmbiguousUnqualifiedJoinColumnUnresolved() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        INSERT INTO dws.ambiguous_result (id)
+        SELECT id
+        FROM ods.orders o
+        JOIN dim.customer c ON c.id = o.customer_id
+        """);
+
+    assertTrue(result.mappings().isEmpty());
+    assertEquals(1, result.unresolvedReferenceCount());
+  }
+
+  @Test
+  void derivesCtasOutputNamesFromAliasesAndDirectColumns() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        CREATE TABLE dws.order_summary AS
+        SELECT o.id AS order_id, o.amount * 1.1 AS taxed_amount
+        FROM ods.orders o
+        """);
+
+    assertEquals(2, result.mappings().size());
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.order_summary", "order_id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "ods.orders", "amount", "dws.order_summary", "taxed_amount",
+        SqlColumnLineageParser.MappingKind.TRANSFORMATION);
+  }
+
+  @Test
+  void parsesUpdateExpressionDependencies() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        UPDATE dws.sales_daily s
+        SET gmv = s.net_amount + s.tax_amount
+        """);
+
+    assertEquals(2, result.mappings().size());
+    assertMapping(
+        result.mappings(), "dws.sales_daily", "net_amount", "dws.sales_daily", "gmv",
+        SqlColumnLineageParser.MappingKind.TRANSFORMATION);
+    assertMapping(
+        result.mappings(), "dws.sales_daily", "tax_amount", "dws.sales_daily", "gmv",
+        SqlColumnLineageParser.MappingKind.TRANSFORMATION);
+  }
+
+  @Test
+  void mapsEveryUnionBranchToTheSameTargetColumn() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        INSERT INTO dws.all_ids (id)
+        SELECT a.id FROM ods.orders a
+        UNION ALL
+        SELECT b.id FROM archive.orders b
+        """);
+
+    assertEquals(2, result.mappings().size());
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.all_ids", "id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "archive.orders", "id", "dws.all_ids", "id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+  }
+
+  @Test
+  void starProjectionFallsBackToTableLineage() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        INSERT INTO dws.orders_copy (id)
+        SELECT * FROM ods.orders
+        """);
+
+    assertTrue(result.mappings().isEmpty());
+    assertEquals(1, result.unresolvedReferenceCount());
+  }
+
+  @Test
+  void cteReferencesDoNotBecomeFakePhysicalColumnAssets() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        INSERT INTO dws.active_users (user_id)
+        WITH active AS (
+          SELECT user_id FROM ods.orders WHERE status = 'PAID'
+        )
+        SELECT a.user_id FROM active a
+        """);
+
+    assertTrue(result.mappings().isEmpty());
+    assertTrue(result.unresolvedReferenceCount() > 0);
+  }
+
+  @Test
+  void insertWithoutExplicitTargetColumnsStaysConservative() {
+    SqlColumnLineageParser.ParseResult result = parser.parse("""
+        INSERT INTO dws.orders_copy
+        SELECT o.id FROM ods.orders o
+        """);
+
+    assertTrue(result.mappings().isEmpty());
+    assertTrue(result.unresolvedReferenceCount() > 0);
+  }
+
+  private static void assertMapping(
+      List<SqlColumnLineageParser.ColumnMapping> mappings,
+      String sourceTable,
+      String sourceColumn,
+      String targetTable,
+      String targetColumn,
+      SqlColumnLineageParser.MappingKind kind) {
+    assertTrue(
+        mappings.stream().anyMatch(mapping ->
+            mapping.sourceTable().canonicalName().equals(sourceTable)
+                && mapping.sourceColumnName().equals(sourceColumn)
+                && mapping.targetTable().canonicalName().equals(targetTable)
+                && mapping.targetColumnName().equals(targetColumn)
+                && mapping.mappingKind() == kind),
+        () -> "Missing mapping "
+            + sourceTable + "." + sourceColumn
+            + " -> " + targetTable + "." + targetColumn
+            + " (" + kind + ") in " + mappings);
+  }
+}


### PR DESCRIPTION
## 目标

实现 Yak Ops 数据血缘第三阶段：在第二阶段 **SQL 表级血缘** 之上，补齐第一版可解释、可验证的 **SQL 字段级血缘**。

本阶段继续以数据开发的 immutable `DevelopmentTaskRevision` 为权威设计态来源，并复用第一阶段已经存在的 `COLUMN` Asset 与 `DERIVES_FROM` Relation，不新增底层表结构。

## 核心模型

表级血缘保持第二阶段不变：

```text
TABLE -> SQL_TASK -> TABLE
```

- 输入表 -> SQL Task：`READS_FROM`
- SQL Task -> 输出表：`WRITES_TO`

字段级血缘新增精准的直接映射：

```text
source COLUMN -> target COLUMN
          DERIVES_FROM
```

例如：

```sql
INSERT INTO dws.sales_daily (user_id, gmv)
SELECT o.user_id, o.quantity * o.price
FROM ods.orders o;
```

形成：

```text
ods.orders.user_id  ----------------> dws.sales_daily.user_id

ods.orders.quantity ----┐
                        ├-----------> dws.sales_daily.gmv
ods.orders.price --------┘
```

## 为什么字段级不统一绕 SQL_TASK？

如果一个 SQL 有 5 个输入字段和 5 个输出字段，采用：

```text
COLUMN -> SQL_TASK -> COLUMN
```

会让图遍历天然产生假的 5×5 可达关系，无法回答“这个字段到底影响哪个字段”。

因此：

- `SQL_TASK` 继续承担任务级 / 表级数据流语义
- 精准字段依赖直接使用 `COLUMN -> COLUMN / DERIVES_FROM`
- 字段边的 evidence 中保存 `sqlTaskAssetId / revision / expression / mappingKind`

这样既保留 SQL Task 证据，又不会污染字段影响分析。

## 本次实现

### 1. 新增 `SqlColumnLineageParser`

继续复用项目现有 **JSQLParser 4.9**，从 SQL AST 中提取保守、精准的字段映射。

V1 支持：

- `INSERT ... SELECT`（目标字段显式声明）
- `CREATE TABLE ... AS SELECT`
- `UPDATE ... SET`
- 表别名 / 字段别名
- JOIN 中的 qualified column
- 单表场景下的裸字段
- 普通表达式字段依赖
- 聚合字段依赖
- `UNION / UNION ALL` 多分支字段来源
- 多语句 SQL

字段映射分类：

- `IDENTITY`
- `TRANSFORMATION`
- `AGGREGATION`

例如：

```text
o.user_id              -> user_id       IDENTITY
o.quantity * o.price   -> gmv           TRANSFORMATION
COUNT(o.id)             -> order_count   AGGREGATION
```

### 2. 保守降级，不猜字段血缘

以下场景 V1 不生成不可靠的 Column Relation，而是保留第二阶段已经存在的表级血缘：

- `SELECT * / table.*`
- 多表 JOIN 中无法确定来源的裸字段
- `INSERT` 未显式声明目标字段列表
- CTE 字段传播
- 嵌套子查询的完整字段作用域传播
- 当前无法可靠识别的表达式 / FromItem

这些情况会计入 `unresolvedColumnReferenceCount`，SQL Task 资产记录：

- `columnParseStatus=SUCCESS`
- `columnParseStatus=PARTIAL`
- `columnParseStatus=UNRESOLVED`
- `columnParseStatus=FAILED`
- `columnParseStatus=SKIPPED`

原则是：**宁可没有字段边，也不生成错误字段边。**

### 3. COLUMN 资产

稳定 Asset Key：

```text
column:{dataSourceId}:{qualifiedTableName}.{columnName}
```

例如：

```text
column:12:ods.orders.user_id
column:12:dws.sales_daily.gmv
```

Column 通过 `parentAssetId` 挂到对应 TABLE Asset，并保留：

- dataSourceId
- databaseName
- schemaName
- tableName
- columnName
- qualifiedName

### 4. 字段边证据

`DERIVES_FROM` Relation 保存：

- `expression`
- `revisionId / revisionNo`
- `sqlTaskAssetId`
- `mappingKind`
- `statementIndex`
- `outputOrdinal`
- `sourceOrdinal`
- `sourceTable / sourceColumn`
- `targetTable / targetColumn`

关系仍使用第二阶段的 evidence：

```text
sourceType = DATA_DEVELOPMENT_SQL_PARSE
sourceId   = nodeId
```

因此同一个 SQL 节点重新发布新 Revision 时，会统一清理旧的自动表级 + 字段级关系，然后重建当前 Revision 的权威血缘，不会留下陈旧字段边。

### 5. Parser 降级语义

- **表级 Parser 失败**：行为保持第二阶段一致，清理旧关系、保留 SQL_TASK 的失败状态，不阻断 SQL Task 发布
- **字段级 Parser 失败**：当前 Revision 的表级血缘仍正常写入，只跳过字段级关系并记录 `columnParseStatus=FAILED`

字段解析能力不会反过来降低已有表级血缘的可用性。

## 测试

新增 / 更新测试覆盖：

- INSERT SELECT：直接字段、表达式、聚合
- JOIN qualified column 精准映射，避免交叉关联
- 多表裸字段歧义降级
- CTAS alias / transformation
- UPDATE 多源字段依赖
- UNION 多分支映射到同一目标字段
- SELECT * 降级
- CTE 不生成假的物理 Column Asset
- INSERT 无目标字段列表降级
- TABLE + COLUMN Relation 同步写入
- Column Asset 正确挂载父 Table Asset
- column parser failure 保留当前 table lineage
- table parser failure 清理旧关系并跳过 column parser

## 影响范围

仅修改 `yak-ops-business-data-development`：

```text
2 production files
2 test files
```

无：

- Flyway 迁移
- POM / dependency 变更
- API route 变更
- 前端变更
- Dataset / Chart / Dashboard 变更

分支基于已合并的 PR #562，当前相对 `main` 为 **1 commit ahead / 0 behind**。

## 本阶段暂不包含

- Catalog/schema-aware `SELECT *` 展开
- 多表裸字段通过 Catalog 元数据消歧
- CTE 字段传播
- nested subquery 字段作用域传播
- CASE / Window 的细粒度 DIRECT / INDIRECT 分类
- JOIN / FILTER / GROUP_BY 等 OpenLineage-style INDIRECT dependency
- Runtime / OpenLineage event
- SeaTunnel runtime lineage
- Dataset / DatasetField lineage
- Chart / Dashboard lineage
- 前端血缘图

## 后续建议

下一小阶段优先做 **schema-aware 字段解析**：把 Yak Ops 已有 Datasource Catalog 的 column metadata 接进 resolver，用真实 Schema 解决：

1. `SELECT *` 展开
2. 多表裸字段消歧
3. INSERT 无目标列时按目标表 ordinal 对齐

再往后进入 CTE / Subquery 字段传播，最后接 Dataset -> Chart -> Dashboard 数据消费链路。