### PR TITLE
feat(lineage): add schema-aware SQL column resolution

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.lineage.LineageAsset;
@@ -11,12 +12,16 @@ import io.yak.ops.business.lineage.LineageAssetType;
 import io.yak.ops.business.lineage.LineageMaintenanceService;
 import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.LineageService;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Publishes authoritative table- and column-level lineage for immutable SQL task revisions. */
@@ -34,6 +39,8 @@ public class DevelopmentSqlLineageService {
   private final SqlColumnLineageParser columnParser;
   private final ObjectMapper objectMapper;
 
+  private DataSourceCatalogService dataSourceCatalogService;
+
   public DevelopmentSqlLineageService(
       LineageService lineageService,
       LineageMaintenanceService maintenanceService,
@@ -45,6 +52,15 @@ public class DevelopmentSqlLineageService {
     this.tableParser = tableParser;
     this.columnParser = columnParser;
     this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Catalog is optional because datasource support itself can be disabled. Lineage must continue to
+   * publish table-level facts and conservative column facts when Catalog metadata is unavailable.
+   */
+  @Autowired(required = false)
+  void setDataSourceCatalogService(DataSourceCatalogService dataSourceCatalogService) {
+    this.dataSourceCatalogService = dataSourceCatalogService;
   }
 
   public void syncPublished(DevelopmentNode node, DevelopmentTaskRevision revision) {
@@ -60,7 +76,11 @@ public class DevelopmentSqlLineageService {
       SqlColumnLineageParser.ParseResult columnParsed = null;
       SqlColumnLineageParser.SqlColumnLineageParseException columnFailure = null;
       try {
-        columnParsed = columnParser.parse(sql);
+        if (dataSourceCatalogService == null) {
+          columnParsed = columnParser.parse(sql);
+        } else {
+          columnParsed = columnParser.parse(sql, schemaProvider(dataSourceId));
+        }
       } catch (SqlColumnLineageParser.SqlColumnLineageParseException exception) {
         columnFailure = exception;
         LOGGER.warn(
@@ -137,6 +157,82 @@ public class DevelopmentSqlLineageService {
     }
   }
 
+  private SqlColumnLineageParser.SchemaProvider schemaProvider(String dataSourceId) {
+    DataSourceCatalogService catalogService = this.dataSourceCatalogService;
+    if (catalogService == null) {
+      return SqlColumnLineageParser.SchemaProvider.none();
+    }
+
+    final Long numericDataSourceId;
+    try {
+      numericDataSourceId = Long.valueOf(dataSourceId);
+    } catch (NumberFormatException exception) {
+      LOGGER.debug("Skip schema-aware lineage because datasource id is not numeric: {}", dataSourceId);
+      return SqlColumnLineageParser.SchemaProvider.none();
+    }
+
+    Map<String, List<SqlColumnLineageParser.SchemaColumn>> cache = new LinkedHashMap<>();
+    return table -> cache.computeIfAbsent(
+        table.canonicalName(),
+        ignored -> loadSchemaColumns(catalogService, numericDataSourceId, table));
+  }
+
+  private List<SqlColumnLineageParser.SchemaColumn> loadSchemaColumns(
+      DataSourceCatalogService catalogService,
+      Long dataSourceId,
+      SqlTableLineageParser.TableRef table) {
+    List<DataSourceCatalogColumnVO> columns = listColumns(
+        catalogService,
+        dataSourceId,
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName());
+
+    // A two-part SQL name is dialect-dependent: PostgreSQL usually means schema.table while
+    // MySQL/Doris usually means database.table. Try the alternate interpretation only when the
+    // primary lookup produced no metadata, keeping the resolver dialect-tolerant without leaking
+    // datasource-plugin details into the SQL parser.
+    if (columns.isEmpty() && table.databaseName() == null && table.schemaName() != null) {
+      columns = listColumns(
+          catalogService,
+          dataSourceId,
+          table.schemaName(),
+          null,
+          table.tableName());
+    }
+
+    List<SqlColumnLineageParser.SchemaColumn> result = new ArrayList<>();
+    for (DataSourceCatalogColumnVO column : columns) {
+      if (column == null || column.getName() == null || column.getName().isBlank()) continue;
+      result.add(new SqlColumnLineageParser.SchemaColumn(
+          column.getName(),
+          column.getOrdinalPosition()));
+    }
+    return List.copyOf(result);
+  }
+
+  private List<DataSourceCatalogColumnVO> listColumns(
+      DataSourceCatalogService catalogService,
+      Long dataSourceId,
+      String database,
+      String schema,
+      String table) {
+    try {
+      List<DataSourceCatalogColumnVO> columns =
+          catalogService.listColumns(dataSourceId, database, schema, table);
+      return columns == null ? List.of() : columns;
+    } catch (RuntimeException exception) {
+      LOGGER.debug(
+          "Catalog column lookup failed for datasource {} table {}.{}.{}: {}",
+          dataSourceId,
+          database,
+          schema,
+          table,
+          exception.getMessage());
+      return List.of();
+    }
+  }
+
   private void registerColumnLineage(
       String dataSourceId,
       LineageAsset task,
@@ -202,6 +298,9 @@ public class DevelopmentSqlLineageService {
     properties.put("revisionNo", revision.revisionNo());
     properties.put("checksum", revision.checksum());
     properties.put("dataSourceId", dataSourceId);
+    properties.put(
+        "columnSchemaResolution",
+        dataSourceCatalogService == null ? "NONE" : "DATASOURCE_CATALOG");
 
     if (tableFailure == null && tableParsed != null) {
       properties.put("parseStatus", "SUCCESS");

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlColumnLineageParser.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/SqlColumnLineageParser.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.development.service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,9 +35,9 @@ import org.springframework.stereotype.Component;
 /**
  * Extracts conservative column-to-column lineage from SQL ASTs.
  *
- * <p>V1 only emits a mapping when both source and target columns can be identified without
- * guessing. Unsupported or ambiguous expressions are counted as unresolved and safely fall back
- * to the already-persisted table-level lineage.
+ * <p>The parser never guesses. Without schema metadata it preserves the V1 conservative behavior.
+ * When a {@link SchemaProvider} is supplied it can expand stars, disambiguate unqualified columns
+ * across joins and align INSERT projections with physical target-column order.
  */
 @Component
 public class SqlColumnLineageParser {
@@ -46,10 +47,15 @@ public class SqlColumnLineageParser {
       "STDDEV", "STDDEV_POP", "STDDEV_SAMP", "VAR_POP", "VAR_SAMP", "VARIANCE");
 
   public ParseResult parse(String sql) {
+    return parse(sql, SchemaProvider.none());
+  }
+
+  public ParseResult parse(String sql, SchemaProvider schemaProvider) {
     if (sql == null || sql.isBlank()) {
       return new ParseResult(List.of(), 0, 0, 0);
     }
 
+    SchemaProvider provider = schemaProvider == null ? SchemaProvider.none() : schemaProvider;
     try {
       Statements parsed = CCJSqlParserUtil.parseStatements(sql);
       Map<String, ColumnMapping> mappings = new LinkedHashMap<>();
@@ -58,7 +64,7 @@ public class SqlColumnLineageParser {
 
       for (Statement statement : parsed.getStatements()) {
         statementIndex++;
-        analyze(statement, statementIndex, mappings, stats);
+        analyze(statement, statementIndex, mappings, stats, provider);
       }
 
       return new ParseResult(
@@ -79,13 +85,14 @@ public class SqlColumnLineageParser {
       Statement statement,
       int statementIndex,
       Map<String, ColumnMapping> mappings,
-      MutableStats stats) {
+      MutableStats stats,
+      SchemaProvider schemaProvider) {
     if (statement instanceof Insert insert) {
-      analyzeInsert(insert, statementIndex, mappings, stats);
+      analyzeInsert(insert, statementIndex, mappings, stats, schemaProvider);
     } else if (statement instanceof CreateTable createTable) {
-      analyzeCreateTable(createTable, statementIndex, mappings, stats);
+      analyzeCreateTable(createTable, statementIndex, mappings, stats, schemaProvider);
     } else if (statement instanceof Update update) {
-      analyzeUpdate(update, statementIndex, mappings, stats);
+      analyzeUpdate(update, statementIndex, mappings, stats, schemaProvider);
     }
   }
 
@@ -93,7 +100,8 @@ public class SqlColumnLineageParser {
       Insert insert,
       int statementIndex,
       Map<String, ColumnMapping> mappings,
-      MutableStats stats) {
+      MutableStats stats,
+      SchemaProvider schemaProvider) {
     SqlTableLineageParser.TableRef target = tableRef(insert.getTable());
     Select select = insert.getSelect();
     if (target == null || select == null) return;
@@ -105,9 +113,9 @@ public class SqlColumnLineageParser {
       }
     }
 
-    // INSERT without an explicit target column list depends on the physical target schema.
-    // V1 deliberately does not infer target column names from SELECT aliases because that can
-    // silently produce incorrect lineage. Table-level lineage remains available.
+    if (targetColumns.isEmpty()) {
+      targetColumns = schemaColumnNames(schemaProvider, target);
+    }
     if (targetColumns.isEmpty()) {
       stats.unresolvedReferenceCount++;
       return;
@@ -120,14 +128,16 @@ public class SqlColumnLineageParser {
         statementIndex,
         mappings,
         stats,
-        cteNames(insert.getWithItemsList()));
+        cteNames(insert.getWithItemsList()),
+        schemaProvider);
   }
 
   private void analyzeCreateTable(
       CreateTable createTable,
       int statementIndex,
       Map<String, ColumnMapping> mappings,
-      MutableStats stats) {
+      MutableStats stats,
+      SchemaProvider schemaProvider) {
     SqlTableLineageParser.TableRef target = tableRef(createTable.getTable());
     Select select = createTable.getSelect();
     if (target == null || select == null) return;
@@ -139,7 +149,7 @@ public class SqlColumnLineageParser {
       }
     }
     if (targetColumns.isEmpty()) {
-      targetColumns = inferSelectOutputNames(select);
+      targetColumns = inferSelectOutputNames(select, schemaProvider, Set.of());
     }
 
     analyzeSelect(
@@ -149,14 +159,16 @@ public class SqlColumnLineageParser {
         statementIndex,
         mappings,
         stats,
-        Set.of());
+        Set.of(),
+        schemaProvider);
   }
 
   private void analyzeUpdate(
       Update update,
       int statementIndex,
       Map<String, ColumnMapping> mappings,
-      MutableStats stats) {
+      MutableStats stats,
+      SchemaProvider schemaProvider) {
     SqlTableLineageParser.TableRef target = tableRef(update.getTable());
     if (target == null || update.getUpdateSets() == null) return;
 
@@ -189,7 +201,8 @@ public class SqlColumnLineageParser {
             statementIndex,
             outputOrdinal,
             mappings,
-            stats);
+            stats,
+            schemaProvider);
       }
       if (updateSet.getColumns().size() != updateSet.getValues().size()) {
         stats.unresolvedReferenceCount +=
@@ -218,7 +231,8 @@ public class SqlColumnLineageParser {
       int statementIndex,
       Map<String, ColumnMapping> mappings,
       MutableStats stats,
-      Set<String> inheritedCteNames) {
+      Set<String> inheritedCteNames,
+      SchemaProvider schemaProvider) {
     if (select == null) return;
 
     Set<String> cteNames = new LinkedHashSet<>(inheritedCteNames);
@@ -238,7 +252,8 @@ public class SqlColumnLineageParser {
           statementIndex,
           mappings,
           stats,
-          cteNames);
+          cteNames,
+          schemaProvider);
       return;
     }
 
@@ -252,7 +267,8 @@ public class SqlColumnLineageParser {
             statementIndex,
             mappings,
             stats,
-            cteNames);
+            cteNames,
+            schemaProvider);
       }
       return;
     }
@@ -267,25 +283,52 @@ public class SqlColumnLineageParser {
       int statementIndex,
       Map<String, ColumnMapping> mappings,
       MutableStats stats,
-      Set<String> cteNames) {
+      Set<String> cteNames,
+      SchemaProvider schemaProvider) {
     if (select.getSelectItems() == null) return;
 
     Scope scope = buildScope(select, cteNames);
-    List<SelectItem<?>> items = select.getSelectItems();
-    for (int i = 0; i < items.size(); i++) {
-      stats.candidateOutputCount++;
-      SelectItem<?> item = items.get(i);
+    int outputOrdinal = 0;
+    for (SelectItem<?> item : select.getSelectItems()) {
       Expression expression = item == null ? null : item.getExpression();
 
-      String targetColumn =
-          i < targetColumns.size() ? normalizeColumnName(targetColumns.get(i)) : null;
-      if (targetColumn == null) {
-        stats.unresolvedReferenceCount++;
+      if (expression instanceof AllColumns || expression instanceof AllTableColumns) {
+        List<SourceColumnRef> expanded = expandStar(expression, scope, schemaProvider);
+        if (expanded.isEmpty()) {
+          outputOrdinal++;
+          stats.candidateOutputCount++;
+          stats.unresolvedReferenceCount++;
+          continue;
+        }
+
+        for (SourceColumnRef source : expanded) {
+          outputOrdinal++;
+          stats.candidateOutputCount++;
+          String targetColumn = targetColumn(targetColumns, outputOrdinal);
+          if (targetColumn == null) {
+            stats.unresolvedReferenceCount++;
+            continue;
+          }
+          putMapping(
+              new ColumnMapping(
+                  source.table(),
+                  source.columnName(),
+                  target,
+                  targetColumn,
+                  MappingKind.IDENTITY,
+                  expression.toString(),
+                  statementIndex,
+                  outputOrdinal,
+                  1),
+              mappings);
+        }
         continue;
       }
-      if (expression == null
-          || expression instanceof AllColumns
-          || expression instanceof AllTableColumns) {
+
+      outputOrdinal++;
+      stats.candidateOutputCount++;
+      String targetColumn = targetColumn(targetColumns, outputOrdinal);
+      if (targetColumn == null || expression == null) {
         stats.unresolvedReferenceCount++;
         continue;
       }
@@ -296,14 +339,56 @@ public class SqlColumnLineageParser {
           targetColumn,
           scope,
           statementIndex,
-          i + 1,
+          outputOrdinal,
           mappings,
-          stats);
+          stats,
+          schemaProvider);
     }
 
-    if (targetColumns.size() > items.size()) {
-      stats.unresolvedReferenceCount += targetColumns.size() - items.size();
+    if (targetColumns.size() > outputOrdinal) {
+      stats.unresolvedReferenceCount += targetColumns.size() - outputOrdinal;
     }
+  }
+
+  private String targetColumn(List<String> targetColumns, int outputOrdinal) {
+    int index = outputOrdinal - 1;
+    return index >= 0 && index < targetColumns.size()
+        ? normalizeColumnName(targetColumns.get(index))
+        : null;
+  }
+
+  private List<SourceColumnRef> expandStar(
+      Expression expression,
+      Scope scope,
+      SchemaProvider schemaProvider) {
+    if (expression instanceof AllColumns allColumns
+        && ((allColumns.getExceptColumns() != null && !allColumns.getExceptColumns().isEmpty())
+            || (allColumns.getReplaceExpressions() != null
+                && !allColumns.getReplaceExpressions().isEmpty()))) {
+      return List.of();
+    }
+
+    List<SqlTableLineageParser.TableRef> tables = new ArrayList<>();
+
+    if (expression instanceof AllTableColumns allTableColumns) {
+      Table qualifier = allTableColumns.getTable();
+      String rawQualifier = qualifier == null ? null : qualifier.getFullyQualifiedName();
+      SqlTableLineageParser.TableRef table = scope.resolve(rawQualifier);
+      if (table != null) tables.add(table);
+    } else {
+      tables.addAll(scope.orderedTables());
+    }
+
+    List<SourceColumnRef> expanded = new ArrayList<>();
+    for (SqlTableLineageParser.TableRef table : tables) {
+      for (SchemaColumn column : safeColumns(schemaProvider, table)) {
+        String columnName = normalizeColumnName(column.name());
+        if (columnName != null) {
+          expanded.add(new SourceColumnRef(table, columnName));
+        }
+      }
+    }
+    return expanded;
   }
 
   private void collectMappings(
@@ -314,8 +399,9 @@ public class SqlColumnLineageParser {
       int statementIndex,
       int outputOrdinal,
       Map<String, ColumnMapping> mappings,
-      MutableStats stats) {
-    SourceCollection collected = collectSources(expression, scope);
+      MutableStats stats,
+      SchemaProvider schemaProvider) {
+    SourceCollection collected = collectSources(expression, scope, schemaProvider);
     stats.unresolvedReferenceCount += collected.unresolvedCount();
 
     MappingKind kind =
@@ -328,21 +414,25 @@ public class SqlColumnLineageParser {
     int sourceOrdinal = 0;
     for (SourceColumnRef source : collected.sources()) {
       sourceOrdinal++;
-      ColumnMapping mapping = new ColumnMapping(
-          source.table(),
-          source.columnName(),
-          target,
-          targetColumn,
-          kind,
-          expression.toString(),
-          statementIndex,
-          outputOrdinal,
-          sourceOrdinal);
-      mappings.putIfAbsent(mappingKey(mapping), mapping);
+      putMapping(
+          new ColumnMapping(
+              source.table(),
+              source.columnName(),
+              target,
+              targetColumn,
+              kind,
+              expression.toString(),
+              statementIndex,
+              outputOrdinal,
+              sourceOrdinal),
+          mappings);
     }
   }
 
-  private SourceCollection collectSources(Expression expression, Scope scope) {
+  private SourceCollection collectSources(
+      Expression expression,
+      Scope scope,
+      SchemaProvider schemaProvider) {
     Map<String, SourceColumnRef> sources = new LinkedHashMap<>();
     int[] unresolved = new int[] {0};
     boolean[] aggregate = new boolean[] {false};
@@ -351,7 +441,8 @@ public class SqlColumnLineageParser {
       @Override
       public void visit(Column column) {
         String columnName = normalizeColumnName(column.getColumnName());
-        SqlTableLineageParser.TableRef table = resolveTable(column, scope);
+        SqlTableLineageParser.TableRef table =
+            resolveTable(column, scope, schemaProvider);
         if (columnName == null || table == null) {
           unresolved[0]++;
           return;
@@ -411,13 +502,44 @@ public class SqlColumnLineageParser {
     scope.add(ref, alias);
   }
 
-  private SqlTableLineageParser.TableRef resolveTable(Column column, Scope scope) {
+  private SqlTableLineageParser.TableRef resolveTable(
+      Column column,
+      Scope scope,
+      SchemaProvider schemaProvider) {
     Table qualifier = column.getTable();
     String rawQualifier = qualifier == null ? null : qualifier.getFullyQualifiedName();
     if (rawQualifier != null && !rawQualifier.isBlank()) {
       return scope.resolve(rawQualifier);
     }
-    return scope.onlyTable();
+
+    SqlTableLineageParser.TableRef only = scope.onlyTable();
+    if (only != null) return only;
+
+    String columnName = normalizeColumnName(column.getColumnName());
+    if (columnName == null) return null;
+
+    SqlTableLineageParser.TableRef resolved = null;
+    for (SqlTableLineageParser.TableRef table : scope.orderedTables()) {
+      if (!hasColumn(schemaProvider, table, columnName)) continue;
+      if (resolved != null
+          && !resolved.canonicalName().equals(table.canonicalName())) {
+        return null;
+      }
+      resolved = table;
+    }
+    return resolved;
+  }
+
+  private boolean hasColumn(
+      SchemaProvider schemaProvider,
+      SqlTableLineageParser.TableRef table,
+      String columnName) {
+    for (SchemaColumn column : safeColumns(schemaProvider, table)) {
+      if (column.name() != null && column.name().equalsIgnoreCase(columnName)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private SqlTableLineageParser.TableRef tableRef(Table table) {
@@ -444,8 +566,21 @@ public class SqlColumnLineageParser {
         tableName);
   }
 
-  private List<String> inferSelectOutputNames(Select select) {
+  private List<String> inferSelectOutputNames(
+      Select select,
+      SchemaProvider schemaProvider,
+      Set<String> inheritedCteNames) {
     if (select instanceof PlainSelect plainSelect) {
+      Set<String> cteNames = new LinkedHashSet<>(inheritedCteNames);
+      if (select.getWithItemsList() != null) {
+        for (WithItem withItem : select.getWithItemsList()) {
+          if (withItem.getAlias() != null && withItem.getAlias().getName() != null) {
+            cteNames.add(withItem.getAlias().getName().toLowerCase(Locale.ROOT));
+          }
+        }
+      }
+
+      Scope scope = buildScope(plainSelect, cteNames);
       List<String> names = new ArrayList<>();
       if (plainSelect.getSelectItems() == null) return names;
       for (SelectItem<?> item : plainSelect.getSelectItems()) {
@@ -455,6 +590,17 @@ public class SqlColumnLineageParser {
           names.add(normalizeColumnName(item.getAlias().getName()));
         } else if (item.getExpression() instanceof Column column) {
           names.add(normalizeColumnName(column.getColumnName()));
+        } else if (item.getExpression() instanceof AllColumns
+            || item.getExpression() instanceof AllTableColumns) {
+          List<SourceColumnRef> expanded =
+              expandStar(item.getExpression(), scope, schemaProvider);
+          if (expanded.isEmpty()) {
+            names.add(null);
+          } else {
+            for (SourceColumnRef source : expanded) {
+              names.add(source.columnName());
+            }
+          }
         } else {
           names.add(null);
         }
@@ -465,9 +611,46 @@ public class SqlColumnLineageParser {
     if (select instanceof SetOperationList setOperationList
         && setOperationList.getSelects() != null
         && !setOperationList.getSelects().isEmpty()) {
-      return inferSelectOutputNames(setOperationList.getSelect(0));
+      return inferSelectOutputNames(
+          setOperationList.getSelect(0), schemaProvider, inheritedCteNames);
     }
     return List.of();
+  }
+
+  private List<String> schemaColumnNames(
+      SchemaProvider schemaProvider,
+      SqlTableLineageParser.TableRef table) {
+    List<String> names = new ArrayList<>();
+    for (SchemaColumn column : safeColumns(schemaProvider, table)) {
+      String name = normalizeColumnName(column.name());
+      if (name != null) names.add(name);
+    }
+    return names;
+  }
+
+  private List<SchemaColumn> safeColumns(
+      SchemaProvider schemaProvider,
+      SqlTableLineageParser.TableRef table) {
+    if (schemaProvider == null || table == null) return List.of();
+    try {
+      List<SchemaColumn> columns = schemaProvider.columns(table);
+      if (columns == null || columns.isEmpty()) return List.of();
+      return columns.stream()
+          .filter(column -> column != null && normalizeColumnName(column.name()) != null)
+          .sorted(Comparator.comparingInt(
+              column -> column.ordinalPosition() == null
+                  ? Integer.MAX_VALUE
+                  : column.ordinalPosition()))
+          .toList();
+    } catch (RuntimeException ignored) {
+      return List.of();
+    }
+  }
+
+  private static void putMapping(
+      ColumnMapping mapping,
+      Map<String, ColumnMapping> mappings) {
+    mappings.putIfAbsent(mappingKey(mapping), mapping);
   }
 
   private static String mappingKey(ColumnMapping mapping) {
@@ -539,6 +722,18 @@ public class SqlColumnLineageParser {
       int sourceOrdinal) {
   }
 
+  public record SchemaColumn(String name, Integer ordinalPosition) {
+  }
+
+  @FunctionalInterface
+  public interface SchemaProvider {
+    List<SchemaColumn> columns(SqlTableLineageParser.TableRef table);
+
+    static SchemaProvider none() {
+      return table -> List.of();
+    }
+  }
+
   private record SourceColumnRef(
       SqlTableLineageParser.TableRef table,
       String columnName) {
@@ -579,6 +774,10 @@ public class SqlColumnLineageParser {
 
     SqlTableLineageParser.TableRef onlyTable() {
       return tables.size() == 1 ? tables.values().iterator().next() : null;
+    }
+
+    List<SqlTableLineageParser.TableRef> orderedTables() {
+      return List.copyOf(tables.values());
     }
 
     private void addQualifier(String qualifier, SqlTableLineageParser.TableRef table) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.lineage.LineageAsset;
@@ -19,6 +20,7 @@ import io.yak.ops.business.lineage.LineageAssetType;
 import io.yak.ops.business.lineage.LineageMaintenanceService;
 import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.LineageService;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -115,6 +117,56 @@ class DevelopmentSqlLineageServiceTest {
   }
 
   @Test
+  void catalogSchemaEnablesStarAndImplicitTargetColumnLineage() {
+    LineageService lineageService = mock(LineageService.class);
+    LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
+    SqlColumnLineageParser columnParser = new SqlColumnLineageParser();
+    DataSourceCatalogService catalogService = mock(DataSourceCatalogService.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    stubAssetRegistration(lineageService);
+
+    DevelopmentSqlLineageService service = new DevelopmentSqlLineageService(
+        lineageService, maintenanceService, tableParser, columnParser, objectMapper);
+    service.setDataSourceCatalogService(catalogService);
+
+    String sql = "INSERT INTO dws.orders_copy SELECT * FROM ods.orders";
+    SqlTableLineageParser.TableRef orders = table("ods.orders", "ods", "orders");
+    SqlTableLineageParser.TableRef copy = table("dws.orders_copy", "dws", "orders_copy");
+    when(tableParser.parse(sql)).thenReturn(new SqlTableLineageParser.ParseResult(
+        List.of(orders), List.of(copy), 1));
+
+    // Simulate a MySQL/Doris style two-part name. The first schema.table interpretation returns no
+    // metadata; the service retries the same qualifier as database.table.
+    when(catalogService.listColumns(12L, null, "ods", "orders")).thenReturn(List.of());
+    when(catalogService.listColumns(12L, "ods", null, "orders")).thenReturn(List.of(
+        catalogColumn("id", 1),
+        catalogColumn("amount", 2)));
+    when(catalogService.listColumns(12L, null, "dws", "orders_copy")).thenReturn(List.of());
+    when(catalogService.listColumns(12L, "dws", null, "orders_copy")).thenReturn(List.of(
+        catalogColumn("order_id", 1),
+        catalogColumn("order_amount", 2)));
+
+    service.syncPublished(node(), revision(sql));
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineageService, times(4)).registerRelation(relations.capture());
+
+    assertEquals(1, count(relations, LineageRelationType.READS_FROM));
+    assertEquals(1, count(relations, LineageRelationType.WRITES_TO));
+    assertEquals(2, count(relations, LineageRelationType.DERIVES_FROM));
+    assertTrue(relations.getAllValues().stream()
+        .filter(value -> value.relationType() == LineageRelationType.DERIVES_FROM)
+        .anyMatch(value -> "id".equals(value.properties().path("sourceColumn").asText())
+            && "order_id".equals(value.properties().path("targetColumn").asText())));
+    assertTrue(relations.getAllValues().stream()
+        .filter(value -> value.relationType() == LineageRelationType.DERIVES_FROM)
+        .anyMatch(value -> "amount".equals(value.properties().path("sourceColumn").asText())
+            && "order_amount".equals(value.properties().path("targetColumn").asText())));
+  }
+
+  @Test
   void columnParserFailureKeepsCurrentTableLineage() {
     LineageService lineageService = mock(LineageService.class);
     LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
@@ -200,6 +252,19 @@ class DevelopmentSqlLineageServiceTest {
       String table) {
     return new SqlTableLineageParser.TableRef(
         qualifiedName, qualifiedName, null, schema, table);
+  }
+
+  private static DataSourceCatalogColumnVO catalogColumn(String name, int ordinal) {
+    return new DataSourceCatalogColumnVO(
+        name,
+        "VARCHAR",
+        null,
+        null,
+        null,
+        true,
+        ordinal,
+        false,
+        null);
   }
 
   private static void stubAssetRegistration(LineageService lineageService) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/SqlColumnLineageParserTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/SqlColumnLineageParserTest.java
@@ -3,7 +3,10 @@ package io.yak.ops.business.development.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class SqlColumnLineageParserTest {
@@ -57,7 +60,7 @@ class SqlColumnLineageParserTest {
   }
 
   @Test
-  void leavesAmbiguousUnqualifiedJoinColumnUnresolved() {
+  void leavesAmbiguousUnqualifiedJoinColumnUnresolvedWithoutSchema() {
     SqlColumnLineageParser.ParseResult result = parser.parse("""
         INSERT INTO dws.ambiguous_result (id)
         SELECT id
@@ -121,7 +124,7 @@ class SqlColumnLineageParserTest {
   }
 
   @Test
-  void starProjectionFallsBackToTableLineage() {
+  void starProjectionFallsBackToTableLineageWithoutSchema() {
     SqlColumnLineageParser.ParseResult result = parser.parse("""
         INSERT INTO dws.orders_copy (id)
         SELECT * FROM ods.orders
@@ -146,7 +149,7 @@ class SqlColumnLineageParserTest {
   }
 
   @Test
-  void insertWithoutExplicitTargetColumnsStaysConservative() {
+  void insertWithoutExplicitTargetColumnsStaysConservativeWithoutSchema() {
     SqlColumnLineageParser.ParseResult result = parser.parse("""
         INSERT INTO dws.orders_copy
         SELECT o.id FROM ods.orders o
@@ -154,6 +157,137 @@ class SqlColumnLineageParserTest {
 
     assertTrue(result.mappings().isEmpty());
     assertTrue(result.unresolvedReferenceCount() > 0);
+  }
+
+  @Test
+  void schemaAwareStarExpansionMapsSourceColumnsByProjectionOrder() {
+    SqlColumnLineageParser.ParseResult result = parser.parse(
+        """
+            INSERT INTO dws.orders_copy (id, amount)
+            SELECT * FROM ods.orders
+            """,
+        schema(Map.of("ods.orders", List.of("id", "amount"))));
+
+    assertEquals(2, result.mappings().size());
+    assertEquals(0, result.unresolvedReferenceCount());
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.orders_copy", "id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "ods.orders", "amount", "dws.orders_copy", "amount",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+  }
+
+  @Test
+  void schemaAwareQualifiedStarExpandsOnlyReferencedAlias() {
+    SqlColumnLineageParser.ParseResult result = parser.parse(
+        """
+            INSERT INTO dws.customer_copy (customer_id, customer_name)
+            SELECT c.*
+            FROM ods.orders o
+            JOIN dim.customer c ON c.id = o.customer_id
+            """,
+        schema(Map.of(
+            "ods.orders", List.of("id", "customer_id"),
+            "dim.customer", List.of("customer_id", "customer_name"))));
+
+    assertEquals(2, result.mappings().size());
+    assertEquals(0, result.unresolvedReferenceCount());
+    assertTrue(result.mappings().stream()
+        .allMatch(mapping -> mapping.sourceTable().canonicalName().equals("dim.customer")));
+  }
+
+  @Test
+  void schemaAwareResolverDisambiguatesUniqueUnqualifiedJoinColumns() {
+    SqlColumnLineageParser.ParseResult result = parser.parse(
+        """
+            INSERT INTO dws.order_customer (order_id, customer_name)
+            SELECT id, name
+            FROM ods.orders o
+            JOIN dim.customer c ON c.customer_id = o.customer_id
+            """,
+        schema(Map.of(
+            "ods.orders", List.of("id", "customer_id", "amount"),
+            "dim.customer", List.of("customer_id", "name"))));
+
+    assertEquals(2, result.mappings().size());
+    assertEquals(0, result.unresolvedReferenceCount());
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.order_customer", "order_id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "dim.customer", "name", "dws.order_customer", "customer_name",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+  }
+
+  @Test
+  void schemaAwareResolverKeepsColumnAmbiguousWhenMultipleTablesOwnIt() {
+    SqlColumnLineageParser.ParseResult result = parser.parse(
+        """
+            INSERT INTO dws.ambiguous_result (id)
+            SELECT id
+            FROM ods.orders o
+            JOIN dim.customer c ON c.id = o.customer_id
+            """,
+        schema(Map.of(
+            "ods.orders", List.of("id", "customer_id"),
+            "dim.customer", List.of("id", "name"))));
+
+    assertTrue(result.mappings().isEmpty());
+    assertEquals(1, result.unresolvedReferenceCount());
+  }
+
+  @Test
+  void schemaAwareInsertWithoutTargetListUsesPhysicalTargetOrdinal() {
+    SqlColumnLineageParser.ParseResult result = parser.parse(
+        """
+            INSERT INTO dws.orders_copy
+            SELECT o.id, o.amount FROM ods.orders o
+            """,
+        schema(Map.of(
+            "ods.orders", List.of("id", "amount"),
+            "dws.orders_copy", List.of("order_id", "order_amount"))));
+
+    assertEquals(2, result.mappings().size());
+    assertEquals(0, result.unresolvedReferenceCount());
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.orders_copy", "order_id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "ods.orders", "amount", "dws.orders_copy", "order_amount",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+  }
+
+  @Test
+  void schemaAwareCtasStarInfersTargetColumnNamesFromSourceSchema() {
+    SqlColumnLineageParser.ParseResult result = parser.parse(
+        """
+            CREATE TABLE dws.orders_copy AS
+            SELECT * FROM ods.orders
+            """,
+        schema(Map.of("ods.orders", List.of("id", "amount"))));
+
+    assertEquals(2, result.mappings().size());
+    assertEquals(0, result.unresolvedReferenceCount());
+    assertMapping(
+        result.mappings(), "ods.orders", "id", "dws.orders_copy", "id",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+    assertMapping(
+        result.mappings(), "ods.orders", "amount", "dws.orders_copy", "amount",
+        SqlColumnLineageParser.MappingKind.IDENTITY);
+  }
+
+  private static SqlColumnLineageParser.SchemaProvider schema(
+      Map<String, List<String>> definitions) {
+    Map<String, List<SqlColumnLineageParser.SchemaColumn>> schemas = new LinkedHashMap<>();
+    definitions.forEach((table, columns) -> {
+      List<SqlColumnLineageParser.SchemaColumn> mapped = new ArrayList<>();
+      for (int i = 0; i < columns.size(); i++) {
+        mapped.add(new SqlColumnLineageParser.SchemaColumn(columns.get(i), i + 1));
+      }
+      schemas.put(table, List.copyOf(mapped));
+    });
+    return table -> schemas.getOrDefault(table.canonicalName(), List.of());
   }
 
   private static void assertMapping(


### PR DESCRIPTION
## 目标

继续 Yak Ops 血缘下一阶段：在已经合并的 SQL 字段级血缘 V1 之上，把 **Datasource Catalog 的真实字段元数据** 接进 SQL Column Resolver，提高字段血缘覆盖率，同时继续坚持“无法可靠判断就降级，不猜”。

本阶段重点解决上一阶段明确留下的 3 个问题：

1. `SELECT * / table.*` 无法展开；
2. 多表 JOIN 中裸字段无法消歧；
3. `INSERT INTO target SELECT ...` 未显式声明目标字段时无法按真实目标表字段顺序映射。

## 核心链路

```text
DevelopmentTaskRevision
        |
        v
DataSourceCatalogService
        |
        +--> table columns / ordinalPosition
        |
        v
SqlColumnLineageParser + SchemaProvider
        |
        v
COLUMN -> COLUMN / DERIVES_FROM
```

表级血缘仍保持：

```text
TABLE -> SQL_TASK -> TABLE
```

## 本次实现

### 1. `SqlColumnLineageParser` 增加可选 SchemaProvider

保留原有 API：

```java
parse(sql)
```

新增：

```java
parse(sql, schemaProvider)
```

所以：

- 没有 Catalog 时，行为与上一阶段一致；
- 有 Catalog 时，只增强能够被真实 schema 证明的字段映射；
- 不要求 SQL Parser 直接依赖 datasource 模块。

SchemaProvider 只向 Parser 暴露：

```text
TableRef -> [columnName, ordinalPosition]
```

SQL AST 和 Catalog 仍然解耦。

### 2. `SELECT *` / `table.*` 展开

例如：

```sql
INSERT INTO dws.orders_copy (id, amount)
SELECT *
FROM ods.orders;
```

Catalog：

```text
ods.orders
1 id
2 amount
```

现在会得到：

```text
ods.orders.id     -> dws.orders_copy.id
ods.orders.amount -> dws.orders_copy.amount
```

同样支持：

```sql
SELECT c.*
FROM orders o
JOIN customer c ...
```

只展开 alias `c` 对应表的字段，不把 JOIN 里的其他表字段混进来。

对于 `SELECT * EXCEPT(...) / REPLACE(...)` 等高级 star 语义，本阶段仍然保守降级，不生成可能错误的字段边。

### 3. 多表裸字段通过 Catalog 消歧

上一阶段：

```sql
SELECT id, name
FROM orders o
JOIN customer c ...
```

只要有多个表，`id/name` 就无法可靠判断来源。

现在 Resolver 会读取真实 schema：

```text
orders   : id, customer_id, amount
customer : customer_id, name
```

于是可以证明：

```text
id   -> orders.id
name -> customer.name
```

如果两个表都存在 `id`：

```text
orders.id
customer.id
```

仍然标记 unresolved，不猜。

### 4. INSERT 未写目标字段时按目标表 ordinal 对齐

例如：

```sql
INSERT INTO dws.orders_copy
SELECT o.id, o.amount
FROM ods.orders o;
```

Catalog：

```text
dws.orders_copy
1 order_id
2 order_amount
```

现在会生成：

```text
ods.orders.id     -> dws.orders_copy.order_id
ods.orders.amount -> dws.orders_copy.order_amount
```

字段顺序使用 Catalog 返回的 `ordinalPosition`，而不是 SELECT alias 猜测。

如果目标表 schema 无法获取，则退回上一阶段的保守行为。

### 5. CTAS + `SELECT *`

支持：

```sql
CREATE TABLE dws.orders_copy AS
SELECT * FROM ods.orders;
```

通过 source table schema 推导输出字段名，并生成字段级 IDENTITY lineage。

### 6. Datasource Catalog 接入

`DevelopmentSqlLineageService` 使用可选注入：

```text
DataSourceCatalogService
```

Datasource 功能关闭或 Catalog Bean 不存在时不会影响 Lineage Service 启动。

发布一个 SQL Revision 时会创建一次 schema provider，并在本次解析内按 table canonical name 缓存字段列表，避免同一条 SQL 中多次访问同一个表时重复访问 Catalog。

### 7. 两段表名的方言兼容

当前 `TableRef` 对两段名称统一表达为：

```text
qualifier.table
```

但实际 SQL 方言可能表示：

```text
PostgreSQL: schema.table
MySQL/Doris: database.table
```

因此 Catalog lookup 采用 best-effort：

```text
第一次：database=null, schema=qualifier

如果无结果：
第二次：database=qualifier, schema=null
```

避免为了这个阶段把具体 datasource plugin / dbType 判断泄漏到 SQL Parser 中。

### 8. Catalog 失败不阻断发布

Catalog lookup：

- 返回空；
- 数据源暂不可用；
- Plugin Catalog 报错；

都会被转换为“本表无 schema metadata”，然后继续使用上一阶段的保守解析能力。

不会因为 schema-aware 增强能力导致：

```text
SQL 发布失败
表级血缘丢失
已有简单字段血缘失效
```

### 9. SQL Task 记录 schema resolution 来源

SQL Task Asset properties 新增：

```text
columnSchemaResolution = NONE | DATASOURCE_CATALOG
```

方便后续前端或排障判断字段血缘是否尝试使用真实 Catalog 元数据。

## 测试覆盖

扩展 `SqlColumnLineageParserTest`：

- 无 schema 时继续保守处理 star；
- `SELECT *` 按 schema 字段顺序展开；
- `table.*` 只展开指定 alias；
- 多表裸字段通过真实 schema 唯一消歧；
- 多表都存在同名字段时继续 unresolved；
- INSERT 无显式目标字段时按 target ordinal 映射；
- CTAS + star 从 source schema 推导目标字段。

扩展 `DevelopmentSqlLineageServiceTest`：

- 发布期真实接入 `DataSourceCatalogService`；
- 验证 `database.table / schema.table` 两段名称 fallback；
- 验证 Catalog 支持下 `SELECT * + implicit target columns` 能真正落 DERIVES_FROM 字段边。

## 影响范围

仅修改：

```text
yak-ops-business-data-development
```

共 4 个文件：

```text
2 production files
2 test files
```

没有：

- Flyway 迁移
- Maven dependency 变更
- REST API 变更
- 前端变更
- Dataset / Chart / Dashboard 变更
- Lineage Core 表结构变更

分支基于已经合并的 PR #563，当前相对 `main` 为：

```text
1 commit ahead
0 behind
```

## 本阶段仍暂不包含

- CTE 字段向外传播
- nested subquery 字段作用域传播
- correlated subquery
- CASE / Window 的 DIRECT / INDIRECT 精细分类
- JOIN / FILTER / GROUP_BY 条件依赖
- Runtime / OpenLineage Event
- Dataset / DatasetField lineage
- Chart / Dashboard lineage
- 前端血缘图

## Validation

当前执行环境无法访问 GitHub Maven 依赖，因此没有冒充完整 Maven reactor 已通过。

已完成：

- 分支基于最新 `main`；
- compare 为 `1 ahead / 0 behind`；
- 变更范围确认只有 4 个 data-development 文件；
- JSQLParser 4.9 `AllColumns / AllTableColumns / Join / UpdateSet / SetOperationList` API 兼容性核对；
- Java 源文件语法级检查，无括号、语句结构等语法错误。

建议合并前正常执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
mvn -pl yak-ops-boot -am package -DskipTests
```

## 下一阶段建议

Schema-aware 做完以后，SQL 字段血缘已经从“简单 AST 映射”升级到“AST + 真实元数据解析”。

下一步建议进入 **CTE / Subquery 字段传播**，把：

```text
physical table column
        -> CTE output
        -> outer SELECT
        -> target column
```

真正串起来。

完成这一小阶段后，再开始接 `Dataset -> DatasetField -> Chart -> Dashboard` 会比较稳。