### PR TITLE
feat(lineage): connect Dataset and DatasetField lineage

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlProjectionLineageAnalyzer.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlProjectionLineageAnalyzer.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+
+/** Reuses the data-development SQL lineage engine for source-neutral SELECT projection analysis. */
+@Component
+public class DevelopmentSqlProjectionLineageAnalyzer implements SqlProjectionLineageAnalyzer {
+
+  private static final String SYNTHETIC_TARGET = "__yak_dataset_projection__";
+
+  private final SqlColumnLineageParser parser;
+
+  public DevelopmentSqlProjectionLineageAnalyzer(SqlColumnLineageParser parser) {
+    this.parser = parser;
+  }
+
+  @Override
+  public ProjectionResult analyze(String sql, SchemaProvider schemaProvider) {
+    if (sql == null || sql.isBlank()) {
+      return new ProjectionResult(List.of(), 0, 0);
+    }
+
+    String normalized = stripTerminalSemicolon(sql);
+    SqlColumnLineageParser.SchemaProvider provider = adapt(schemaProvider);
+    SqlColumnLineageParser.ParseResult parsed = parser.parse(
+        "CREATE TABLE " + SYNTHETIC_TARGET + " AS " + normalized,
+        provider);
+
+    List<ProjectionMapping> mappings = new ArrayList<>();
+    for (SqlColumnLineageParser.ColumnMapping mapping : parsed.mappings()) {
+      if (mapping.targetTable() == null
+          || !SYNTHETIC_TARGET.equalsIgnoreCase(mapping.targetTable().canonicalName())) {
+        continue;
+      }
+      mappings.add(new ProjectionMapping(
+          table(mapping.sourceTable()),
+          mapping.sourceColumnName(),
+          mapping.targetColumnName(),
+          MappingKind.valueOf(mapping.mappingKind().name()),
+          mapping.expression(),
+          mapping.outputOrdinal(),
+          mapping.sourceOrdinal()));
+    }
+
+    return new ProjectionResult(
+        mappings,
+        parsed.candidateOutputCount(),
+        parsed.unresolvedReferenceCount());
+  }
+
+  private SqlColumnLineageParser.SchemaProvider adapt(SchemaProvider schemaProvider) {
+    SchemaProvider actual = schemaProvider == null ? SchemaProvider.none() : schemaProvider;
+    return table -> {
+      List<SchemaColumn> columns = actual.columns(table(table));
+      if (columns == null || columns.isEmpty()) return List.of();
+      return columns.stream()
+          .filter(column -> column != null && column.name() != null && !column.name().isBlank())
+          .map(column -> new SqlColumnLineageParser.SchemaColumn(
+              column.name(), column.ordinalPosition()))
+          .toList();
+    };
+  }
+
+  private TableRef table(SqlTableLineageParser.TableRef table) {
+    return new TableRef(
+        table.canonicalName(),
+        table.qualifiedName(),
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName());
+  }
+
+  private String stripTerminalSemicolon(String sql) {
+    String value = sql.trim();
+    while (value.endsWith(";")) {
+      value = value.substring(0, value.length() - 1).trim();
+    }
+    if (value.isEmpty()) throw new IllegalArgumentException("SQL projection 不能为空");
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlProjectionLineageAnalyzerTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlProjectionLineageAnalyzerTest.java
@@ -1,0 +1,122 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentSqlProjectionLineageAnalyzerTest {
+
+  private final DevelopmentSqlProjectionLineageAnalyzer analyzer =
+      new DevelopmentSqlProjectionLineageAnalyzer(new DerivedAwareSqlColumnLineageParser());
+
+  @Test
+  void analyzesSimpleProjectionWithoutCreatingARealTargetTable() {
+    SqlProjectionLineageAnalyzer.ProjectionResult result = analyzer.analyze("""
+        SELECT o.user_id, SUM(o.amount) AS gmv
+        FROM ods.orders o
+        GROUP BY o.user_id
+        """);
+
+    assertEquals(2, result.mappings().size());
+    assertMapping(
+        result,
+        "ods.orders",
+        "user_id",
+        "user_id",
+        SqlProjectionLineageAnalyzer.MappingKind.IDENTITY);
+    assertMapping(
+        result,
+        "ods.orders",
+        "amount",
+        "gmv",
+        SqlProjectionLineageAnalyzer.MappingKind.AGGREGATION);
+  }
+
+  @Test
+  void preservesCteAggregationWhenProjectionIsFlattened() {
+    SqlProjectionLineageAnalyzer.ProjectionResult result = analyzer.analyze("""
+        WITH summary AS (
+          SELECT user_id, SUM(amount) AS gmv
+          FROM ods.orders
+          GROUP BY user_id
+        )
+        SELECT user_id, gmv
+        FROM summary
+        """);
+
+    assertEquals(2, result.mappings().size());
+    assertMapping(
+        result,
+        "ods.orders",
+        "amount",
+        "gmv",
+        SqlProjectionLineageAnalyzer.MappingKind.AGGREGATION);
+    assertTrue(result.mappings().stream()
+        .noneMatch(mapping -> mapping.sourceTable().canonicalName().equals("summary")));
+  }
+
+  @Test
+  void expandsStarUsingSourceNeutralSchemaProvider() {
+    SqlProjectionLineageAnalyzer.ProjectionResult result = analyzer.analyze(
+        "SELECT * FROM ods.orders",
+        schema(Map.of("ods.orders", List.of("id", "amount"))));
+
+    assertEquals(2, result.mappings().size());
+    assertEquals(0, result.unresolvedReferenceCount());
+    assertMapping(
+        result,
+        "ods.orders",
+        "id",
+        "id",
+        SqlProjectionLineageAnalyzer.MappingKind.IDENTITY);
+    assertMapping(
+        result,
+        "ods.orders",
+        "amount",
+        "amount",
+        SqlProjectionLineageAnalyzer.MappingKind.IDENTITY);
+  }
+
+  private static SqlProjectionLineageAnalyzer.SchemaProvider schema(
+      Map<String, List<String>> definitions) {
+    Map<String, List<SqlProjectionLineageAnalyzer.SchemaColumn>> schemas = new LinkedHashMap<>();
+    definitions.forEach((table, columns) -> {
+      List<SqlProjectionLineageAnalyzer.SchemaColumn> mapped = new ArrayList<>();
+      for (int i = 0; i < columns.size(); i++) {
+        mapped.add(new SqlProjectionLineageAnalyzer.SchemaColumn(columns.get(i), i + 1));
+      }
+      schemas.put(table, List.copyOf(mapped));
+    });
+    return table -> schemas.getOrDefault(table.canonicalName(), List.of());
+  }
+
+  private static void assertMapping(
+      SqlProjectionLineageAnalyzer.ProjectionResult result,
+      String sourceTable,
+      String sourceColumn,
+      String outputColumn,
+      SqlProjectionLineageAnalyzer.MappingKind kind) {
+    assertTrue(
+        result.mappings().stream().anyMatch(mapping ->
+            mapping.sourceTable().canonicalName().equals(sourceTable)
+                && mapping.sourceColumnName().equals(sourceColumn)
+                && mapping.outputColumnName().equals(outputColumn)
+                && mapping.mappingKind() == kind),
+        () -> "Missing mapping "
+            + sourceTable
+            + "."
+            + sourceColumn
+            + " -> "
+            + outputColumn
+            + " ("
+            + kind
+            + ") in "
+            + result.mappings());
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/pom.xml
+++ b/yak-ops-business/yak-ops-business-dataset/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>yak-ops-business-task-catalog</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-lineage</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageRefreshListener.java
@@ -1,0 +1,48 @@
+package io.yak.ops.business.dataset;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** Refreshes derived Dataset lineage only after the Dataset business transaction has committed. */
+@Component
+class DatasetLineageRefreshListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatasetLineageRefreshListener.class);
+
+  private final DatasetService datasetService;
+  private final DatasetLineageService lineageService;
+
+  DatasetLineageRefreshListener(
+      DatasetService datasetService,
+      DatasetLineageService lineageService) {
+    this.datasetService = datasetService;
+    this.lineageService = lineageService;
+  }
+
+  @TransactionalEventListener(
+      phase = TransactionPhase.AFTER_COMMIT,
+      fallbackExecution = true)
+  public void refresh(DatasetLineageRefreshRequested event) {
+    if (event == null || event.datasetId() <= 0L) return;
+    try {
+      lineageService.syncCurrent(datasetService.get(event.datasetId()));
+    } catch (RuntimeException exception) {
+      // Lineage is derived metadata. A refresh failure must never turn a committed Dataset publish
+      // into an apparent business failure for the caller.
+      LOGGER.warn(
+          "Dataset lineage refresh failed after commit for dataset {}: {}",
+          event.datasetId(),
+          exception.getMessage(),
+          exception);
+    }
+  }
+}
+
+record DatasetLineageRefreshRequested(long datasetId) {
+  DatasetLineageRefreshRequested {
+    if (datasetId <= 0L) throw new IllegalArgumentException("datasetId 必须大于 0");
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageService.java
@@ -1,0 +1,617 @@
+package io.yak.ops.business.dataset;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer;
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer.ProjectionMapping;
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer.ProjectionResult;
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer.SchemaColumn;
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer.TableRef;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/** Builds current Dataset/DatasetField lineage from the Dataset's immutable source snapshot. */
+@Service
+public class DatasetLineageService {
+
+  static final String EVIDENCE_SOURCE_TYPE = "DATASET_SOURCE_PARSE";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatasetLineageService.class);
+  private static final int MAX_EXPRESSION_LENGTH = 16000;
+
+  private final LineageService lineageService;
+  private final LineageMaintenanceService maintenanceService;
+  private final TaskCatalogService taskCatalogService;
+  private final ObjectMapper objectMapper;
+
+  private SqlProjectionLineageAnalyzer projectionAnalyzer;
+  private DataSourceCatalogService dataSourceCatalogService;
+
+  public DatasetLineageService(
+      LineageService lineageService,
+      LineageMaintenanceService maintenanceService,
+      TaskCatalogService taskCatalogService,
+      ObjectMapper objectMapper) {
+    this.lineageService = lineageService;
+    this.maintenanceService = maintenanceService;
+    this.taskCatalogService = taskCatalogService;
+    this.objectMapper = objectMapper;
+  }
+
+  /** The SQL analyzer is supplied by data-development without creating a Dataset -> development dependency. */
+  @Autowired(required = false)
+  void setProjectionAnalyzer(SqlProjectionLineageAnalyzer projectionAnalyzer) {
+    this.projectionAnalyzer = projectionAnalyzer;
+  }
+
+  /** Catalog metadata is an optional accuracy enhancement; lineage remains best-effort without it. */
+  @Autowired(required = false)
+  void setDataSourceCatalogService(DataSourceCatalogService dataSourceCatalogService) {
+    this.dataSourceCatalogService = dataSourceCatalogService;
+  }
+
+  public void syncCurrent(DatasetDetail detail) {
+    if (detail == null || detail.dataset() == null) return;
+
+    Dataset dataset = detail.dataset();
+    String evidenceId = String.valueOf(dataset.id());
+    maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
+
+    DatasetVersion version = detail.currentVersion();
+    if (version == null) {
+      registerDatasetAsset(dataset, null, null, "SKIPPED", null, null, 0);
+      return;
+    }
+
+    SourceSnapshot source;
+    try {
+      source = resolveSource(version);
+    } catch (RuntimeException exception) {
+      source = SourceSnapshot.failed(version.sourceType(), safeMessage(exception));
+    }
+
+    ProjectionResult projection = null;
+    String parseStatus;
+    String parseError = source.error();
+    if (parseError != null) {
+      parseStatus = "FAILED";
+    } else if (source.sql() == null || source.sql().isBlank()) {
+      parseStatus = "SKIPPED";
+    } else if (projectionAnalyzer == null) {
+      parseStatus = "SKIPPED";
+      parseError = "SqlProjectionLineageAnalyzer is not available";
+    } else {
+      try {
+        projection = projectionAnalyzer.analyze(
+            source.sql(), schemaProvider(source.dataSourceId()));
+        parseStatus = projection.unresolvedReferenceCount() > 0
+            ? (projection.mappings().isEmpty() ? "UNRESOLVED" : "PARTIAL")
+            : "SUCCESS";
+      } catch (RuntimeException exception) {
+        parseStatus = "FAILED";
+        parseError = safeMessage(exception);
+        LOGGER.warn(
+            "Failed to analyze Dataset lineage for dataset {} version {}: {}",
+            dataset.id(), version.versionNo(), parseError);
+      }
+    }
+
+    Map<String, DatasetField> fieldsByPhysicalName = new LinkedHashMap<>();
+    for (DatasetField field : detail.fields()) {
+      if (field != null && field.physicalName() != null) {
+        fieldsByPhysicalName.put(field.physicalName().toLowerCase(Locale.ROOT), field);
+      }
+    }
+
+    int unmatchedMappings = 0;
+    if (projection != null) {
+      for (ProjectionMapping mapping : projection.mappings()) {
+        if (!fieldsByPhysicalName.containsKey(mapping.outputColumnName().toLowerCase(Locale.ROOT))) {
+          unmatchedMappings++;
+        }
+      }
+      if (unmatchedMappings > 0 && "SUCCESS".equals(parseStatus)) parseStatus = "PARTIAL";
+    }
+
+    LineageAsset datasetAsset = registerDatasetAsset(
+        dataset, version, source, parseStatus, parseError, projection, unmatchedMappings);
+    Instant observedAt = version.createTime() == null ? Instant.now() : version.createTime();
+
+    Map<String, LineageAsset> fieldAssets = new LinkedHashMap<>();
+    for (DatasetField field : detail.fields()) {
+      LineageAsset fieldAsset = registerDatasetFieldAsset(
+          datasetAsset, dataset, version, source.dataSourceId(), field);
+      fieldAssets.put(field.fieldId(), fieldAsset);
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+          fieldAsset.id(),
+          datasetAsset.id(),
+          LineageRelationType.CONTAINS,
+          EVIDENCE_SOURCE_TYPE,
+          evidenceId,
+          null,
+          BigDecimal.ONE,
+          relationVersion(version, "field:" + field.sortOrder()),
+          observedAt,
+          fieldContainmentProperties(version, field)));
+    }
+
+    if (source.taskAsset() != null) {
+      LineageAsset task = resolveSqlTaskAsset(source, version);
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+          task.id(),
+          datasetAsset.id(),
+          LineageRelationType.DERIVES_FROM,
+          EVIDENCE_SOURCE_TYPE,
+          evidenceId,
+          null,
+          BigDecimal.ONE,
+          relationVersion(version, "source-task"),
+          observedAt,
+          sourceTaskProperties(version, source)));
+    }
+
+    if (projection == null) return;
+
+    Map<String, LineageAsset> tableAssets = new LinkedHashMap<>();
+    Set<String> tableRelations = new LinkedHashSet<>();
+    int mappingIndex = 0;
+    for (ProjectionMapping mapping : projection.mappings()) {
+      mappingIndex++;
+      DatasetField field = fieldsByPhysicalName.get(
+          mapping.outputColumnName().toLowerCase(Locale.ROOT));
+      if (field == null) continue;
+
+      LineageAsset table = registerTableAsset(source.dataSourceId(), mapping.sourceTable(), tableAssets);
+      if (tableRelations.add(mapping.sourceTable().canonicalName())) {
+        lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+            table.id(),
+            datasetAsset.id(),
+            LineageRelationType.DERIVES_FROM,
+            EVIDENCE_SOURCE_TYPE,
+            evidenceId,
+            null,
+            BigDecimal.ONE,
+            relationVersion(version, "table:" + tableRelations.size()),
+            observedAt,
+            tableRelationProperties(version, source, mapping.sourceTable())));
+      }
+
+      LineageAsset sourceColumn = registerColumnAsset(
+          source.dataSourceId(), table, mapping.sourceTable(), mapping.sourceColumnName());
+      LineageAsset targetField = fieldAssets.get(field.fieldId());
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+          sourceColumn.id(),
+          targetField.id(),
+          LineageRelationType.DERIVES_FROM,
+          EVIDENCE_SOURCE_TYPE,
+          evidenceId,
+          truncate(mapping.expression(), MAX_EXPRESSION_LENGTH),
+          BigDecimal.ONE,
+          relationVersion(
+              version,
+              "column:"
+                  + mapping.outputOrdinal()
+                  + ":"
+                  + mapping.sourceOrdinal()
+                  + ":"
+                  + mappingIndex),
+          observedAt,
+          columnRelationProperties(version, source, field, mapping)));
+    }
+  }
+
+  private SourceSnapshot resolveSource(DatasetVersion version) {
+    if (version.sourceType() == DatasetSourceType.SQL_QUERY) {
+      if (version.dataSourceId() == null || version.dataSourceId().isBlank()) {
+        throw new IllegalStateException("SQL_QUERY DatasetVersion 缺少 dataSourceId");
+      }
+      if (version.sql() == null || version.sql().isBlank()) {
+        throw new IllegalStateException("SQL_QUERY DatasetVersion 缺少 SQL snapshot");
+      }
+      return new SourceSnapshot(
+          DatasetSourceType.SQL_QUERY,
+          version.dataSourceId().trim(),
+          version.sql(),
+          null,
+          null,
+          null);
+    }
+
+    if (version.sourceType() == DatasetSourceType.QUERY_REVISION) {
+      TaskAssetRevision resolved = taskCatalogService.resolveRevision(
+          version.sourceTaskAssetId(), version.sourceTaskRevisionId());
+      TaskSourceRevision revision = resolved.revision();
+      if (revision.revisionNo() != version.sourceTaskRevisionNo()) {
+        throw new IllegalStateException(
+            "DatasetVersion source revisionNo 不一致：dataset="
+                + version.sourceTaskRevisionNo()
+                + ", resolved="
+                + revision.revisionNo());
+      }
+      TaskDefinition definition = revision.definition();
+      if (!"SQL".equalsIgnoreCase(definition.taskType())) {
+        throw new IllegalStateException("Dataset QUERY_REVISION 来源不是 SQL：" + definition.taskType());
+      }
+      return new SourceSnapshot(
+          DatasetSourceType.QUERY_REVISION,
+          dataSourceId(definition.configJson()),
+          definition.content(),
+          resolved.asset(),
+          revision,
+          null);
+    }
+
+    return new SourceSnapshot(version.sourceType(), null, null, null, null, null);
+  }
+
+  private SqlProjectionLineageAnalyzer.SchemaProvider schemaProvider(String dataSourceId) {
+    DataSourceCatalogService catalogService = this.dataSourceCatalogService;
+    if (catalogService == null || dataSourceId == null || dataSourceId.isBlank()) {
+      return SqlProjectionLineageAnalyzer.SchemaProvider.none();
+    }
+
+    final Long numericDataSourceId;
+    try {
+      numericDataSourceId = Long.valueOf(dataSourceId);
+    } catch (NumberFormatException exception) {
+      return SqlProjectionLineageAnalyzer.SchemaProvider.none();
+    }
+
+    Map<String, List<SchemaColumn>> cache = new LinkedHashMap<>();
+    return table -> cache.computeIfAbsent(
+        table.canonicalName(),
+        ignored -> loadSchemaColumns(catalogService, numericDataSourceId, table));
+  }
+
+  private List<SchemaColumn> loadSchemaColumns(
+      DataSourceCatalogService catalogService,
+      Long dataSourceId,
+      TableRef table) {
+    List<DataSourceCatalogColumnVO> columns = listColumns(
+        catalogService,
+        dataSourceId,
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName());
+    if (columns.isEmpty() && table.databaseName() == null && table.schemaName() != null) {
+      columns = listColumns(
+          catalogService,
+          dataSourceId,
+          table.schemaName(),
+          null,
+          table.tableName());
+    }
+
+    List<SchemaColumn> result = new ArrayList<>();
+    for (DataSourceCatalogColumnVO column : columns) {
+      if (column == null || column.getName() == null || column.getName().isBlank()) continue;
+      result.add(new SchemaColumn(column.getName(), column.getOrdinalPosition()));
+    }
+    return List.copyOf(result);
+  }
+
+  private List<DataSourceCatalogColumnVO> listColumns(
+      DataSourceCatalogService catalogService,
+      Long dataSourceId,
+      String database,
+      String schema,
+      String table) {
+    try {
+      List<DataSourceCatalogColumnVO> columns =
+          catalogService.listColumns(dataSourceId, database, schema, table);
+      return columns == null ? List.of() : columns;
+    } catch (RuntimeException exception) {
+      LOGGER.debug(
+          "Dataset lineage catalog lookup failed for datasource {} table {}.{}.{}: {}",
+          dataSourceId,
+          database,
+          schema,
+          table,
+          exception.getMessage());
+      return List.of();
+    }
+  }
+
+  private LineageAsset registerDatasetAsset(
+      Dataset dataset,
+      DatasetVersion version,
+      SourceSnapshot source,
+      String parseStatus,
+      String parseError,
+      ProjectionResult projection,
+      int unmatchedMappings) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("status", dataset.status().name());
+    if (dataset.currentVersionId() != null) {
+      properties.put("currentVersionId", String.valueOf(dataset.currentVersionId()));
+    }
+    properties.put("lineageParseStatus", parseStatus);
+    if (parseError != null && !parseError.isBlank()) {
+      properties.put("lineageParseError", truncate(parseError, 1000));
+    }
+    if (version != null) {
+      properties.put("datasetVersionId", String.valueOf(version.id()));
+      properties.put("datasetVersionNo", version.versionNo());
+      properties.put("sourceType", version.sourceType().name());
+      properties.put("sourceTaskAssetId", String.valueOf(version.sourceTaskAssetId()));
+      properties.put("sourceTaskRevisionId", String.valueOf(version.sourceTaskRevisionId()));
+      properties.put("sourceTaskRevisionNo", version.sourceTaskRevisionNo());
+    }
+    if (source != null && source.dataSourceId() != null) {
+      properties.put("dataSourceId", source.dataSourceId());
+    }
+    if (projection != null) {
+      properties.put("candidateOutputColumnCount", projection.candidateOutputCount());
+      properties.put("columnMappingCount", projection.mappings().size());
+      properties.put("unresolvedColumnReferenceCount", projection.unresolvedReferenceCount());
+      properties.put("unmatchedOutputMappingCount", unmatchedMappings);
+    }
+
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        "dataset:" + dataset.id(),
+        LineageAssetType.DATASET,
+        dataset.name(),
+        "DATASET",
+        String.valueOf(dataset.id()),
+        null,
+        source == null ? null : source.dataSourceId(),
+        null,
+        null,
+        null,
+        null,
+        properties));
+  }
+
+  private LineageAsset registerDatasetFieldAsset(
+      LineageAsset datasetAsset,
+      Dataset dataset,
+      DatasetVersion version,
+      String dataSourceId,
+      DatasetField field) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("datasetId", String.valueOf(dataset.id()));
+    properties.put("datasetVersionId", String.valueOf(version.id()));
+    properties.put("datasetVersionNo", version.versionNo());
+    properties.put("fieldId", field.fieldId());
+    properties.put("physicalName", field.physicalName());
+    properties.put("displayName", field.displayName());
+    properties.put("dataType", field.dataType().name());
+    properties.put("nullable", field.nullable());
+    properties.put("defaultRole", field.defaultRole().name());
+    properties.put("sortOrder", field.sortOrder());
+    if (field.description() != null) properties.put("description", field.description());
+
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        "dataset-field:" + dataset.id() + ":" + field.fieldId(),
+        LineageAssetType.DATASET_FIELD,
+        field.displayName(),
+        "DATASET",
+        dataset.id() + ":" + field.fieldId(),
+        datasetAsset.id(),
+        dataSourceId,
+        null,
+        null,
+        null,
+        null,
+        properties));
+  }
+
+  private LineageAsset resolveSqlTaskAsset(SourceSnapshot source, DatasetVersion version) {
+    TaskAsset taskAsset = source.taskAsset();
+    String key = "sql-task:data-development:" + taskAsset.sourceRef();
+    try {
+      return lineageService.getAssetByKey(key);
+    } catch (IllegalArgumentException missing) {
+      ObjectNode properties = objectMapper.createObjectNode();
+      properties.put("taskAssetId", String.valueOf(taskAsset.id()));
+      properties.put("sourceTaskRevisionId", String.valueOf(version.sourceTaskRevisionId()));
+      properties.put("sourceTaskRevisionNo", version.sourceTaskRevisionNo());
+      properties.put("lineageRegistration", "DATASET_FALLBACK");
+      return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+          key,
+          LineageAssetType.SQL_TASK,
+          taskAsset.name(),
+          "DATA_DEVELOPMENT",
+          taskAsset.sourceRef(),
+          null,
+          source.dataSourceId(),
+          null,
+          null,
+          null,
+          null,
+          properties));
+    }
+  }
+
+  private LineageAsset registerTableAsset(
+      String dataSourceId,
+      TableRef table,
+      Map<String, LineageAsset> cache) {
+    String key = tableAssetKey(dataSourceId, table);
+    LineageAsset cached = cache.get(key);
+    if (cached != null) return cached;
+
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("qualifiedName", table.qualifiedName());
+    LineageAsset registered = lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        key,
+        LineageAssetType.TABLE,
+        table.qualifiedName(),
+        "DATASOURCE",
+        dataSourceId,
+        null,
+        dataSourceId,
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName(),
+        null,
+        properties));
+    cache.put(key, registered);
+    return registered;
+  }
+
+  private LineageAsset registerColumnAsset(
+      String dataSourceId,
+      LineageAsset tableAsset,
+      TableRef table,
+      String columnName) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("qualifiedName", table.qualifiedName() + "." + columnName);
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        columnAssetKey(dataSourceId, table, columnName),
+        LineageAssetType.COLUMN,
+        columnName,
+        "DATASOURCE",
+        dataSourceId,
+        tableAsset.id(),
+        dataSourceId,
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName(),
+        columnName,
+        properties));
+  }
+
+  private JsonNode fieldContainmentProperties(DatasetVersion version, DatasetField field) {
+    ObjectNode properties = versionProperties(version);
+    properties.put("lineageLevel", "STRUCTURE");
+    properties.put("fieldId", field.fieldId());
+    properties.put("physicalName", field.physicalName());
+    return properties;
+  }
+
+  private JsonNode sourceTaskProperties(DatasetVersion version, SourceSnapshot source) {
+    ObjectNode properties = versionProperties(version);
+    properties.put("lineageLevel", "DATASET");
+    properties.put("sourceKind", "QUERY_REVISION");
+    properties.put("taskAssetId", String.valueOf(source.taskAsset().id()));
+    properties.put("taskSourceRef", source.taskAsset().sourceRef());
+    return properties;
+  }
+
+  private JsonNode tableRelationProperties(
+      DatasetVersion version,
+      SourceSnapshot source,
+      TableRef table) {
+    ObjectNode properties = versionProperties(version);
+    properties.put("lineageLevel", "TABLE");
+    properties.put("sourceKind", source.sourceType().name());
+    properties.put("sourceTable", table.qualifiedName());
+    return properties;
+  }
+
+  private JsonNode columnRelationProperties(
+      DatasetVersion version,
+      SourceSnapshot source,
+      DatasetField field,
+      ProjectionMapping mapping) {
+    ObjectNode properties = versionProperties(version);
+    properties.put("lineageLevel", "COLUMN");
+    properties.put("sourceKind", source.sourceType().name());
+    properties.put("fieldId", field.fieldId());
+    properties.put("outputColumn", mapping.outputColumnName());
+    properties.put("mappingKind", mapping.mappingKind().name());
+    properties.put("outputOrdinal", mapping.outputOrdinal());
+    properties.put("sourceOrdinal", mapping.sourceOrdinal());
+    properties.put("sourceTable", mapping.sourceTable().qualifiedName());
+    properties.put("sourceColumn", mapping.sourceColumnName());
+    return properties;
+  }
+
+  private ObjectNode versionProperties(DatasetVersion version) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("datasetVersionId", String.valueOf(version.id()));
+    properties.put("datasetVersionNo", version.versionNo());
+    properties.put("sourceType", version.sourceType().name());
+    properties.put("sourceTaskAssetId", String.valueOf(version.sourceTaskAssetId()));
+    properties.put("sourceTaskRevisionId", String.valueOf(version.sourceTaskRevisionId()));
+    properties.put("sourceTaskRevisionNo", version.sourceTaskRevisionNo());
+    return properties;
+  }
+
+  private String dataSourceId(String configJson) {
+    try {
+      JsonNode root = objectMapper.readTree(
+          configJson == null || configJson.isBlank() ? "{}" : configJson);
+      JsonNode value = root == null ? null : root.get("dataSourceId");
+      String dataSourceId = value == null || value.isNull() ? null : value.asText();
+      if (dataSourceId == null || dataSourceId.isBlank()) {
+        throw new IllegalArgumentException("Dataset source SQL dataSourceId 不能为空");
+      }
+      return dataSourceId.trim();
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("Dataset source SQL configJson 不是合法 JSON", exception);
+    }
+  }
+
+  private static String tableAssetKey(String dataSourceId, TableRef table) {
+    return "table:" + dataSourceId + ":" + table.canonicalName();
+  }
+
+  private static String columnAssetKey(
+      String dataSourceId,
+      TableRef table,
+      String columnName) {
+    return "column:"
+        + dataSourceId
+        + ":"
+        + table.canonicalName()
+        + "."
+        + columnName.toLowerCase(Locale.ROOT);
+  }
+
+  private static String relationVersion(DatasetVersion version, String suffix) {
+    return "dataset-v" + version.versionNo() + ":" + suffix;
+  }
+
+  private static String truncate(String value, int maxLength) {
+    if (value == null) return null;
+    return value.length() <= maxLength ? value : value.substring(0, maxLength);
+  }
+
+  private static String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "unknown lineage error" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 1000 ? message.substring(0, 1000) : message;
+  }
+
+  private record SourceSnapshot(
+      DatasetSourceType sourceType,
+      String dataSourceId,
+      String sql,
+      TaskAsset taskAsset,
+      TaskSourceRevision taskRevision,
+      String error) {
+
+    static SourceSnapshot failed(DatasetSourceType sourceType, String error) {
+      return new SourceSnapshot(sourceType, null, null, null, null, error);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/JdbcDatasetRepository.java
@@ -10,7 +10,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -32,9 +34,20 @@ class JdbcDatasetRepository implements DatasetRepository {
           + "schema_snapshot, create_time FROM yak_dataset_version";
 
   private final JdbcTemplate jdbcTemplate;
+  private final ApplicationEventPublisher eventPublisher;
 
-  JdbcDatasetRepository(@Qualifier("yakBusinessDataSource") DataSource dataSource) {
+  @Autowired
+  JdbcDatasetRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ApplicationEventPublisher eventPublisher) {
     this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.eventPublisher = eventPublisher;
+  }
+
+  /** Keeps focused repository tests source-compatible without a Spring event publisher. */
+  JdbcDatasetRepository(DataSource dataSource) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.eventPublisher = null;
   }
 
   @Override
@@ -155,6 +168,7 @@ class JdbcDatasetRepository implements DatasetRepository {
         "UPDATE yak_dataset SET current_version_id = ?, update_time = NOW(6) WHERE id = ?",
         versionId, datasetId);
     if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
+    requestLineageRefresh(datasetId);
   }
 
   @Override
@@ -163,6 +177,7 @@ class JdbcDatasetRepository implements DatasetRepository {
         "UPDATE yak_dataset SET status = ?, update_time = NOW(6) WHERE id = ?",
         status.name(), datasetId);
     if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
+    requestLineageRefresh(datasetId);
   }
 
   @Override
@@ -171,6 +186,7 @@ class JdbcDatasetRepository implements DatasetRepository {
         "UPDATE yak_dataset SET name = ?, description = ?, update_time = NOW(6) WHERE id = ?",
         name, description, datasetId);
     if (updated != 1) throw new IllegalArgumentException("Dataset 不存在：" + datasetId);
+    requestLineageRefresh(datasetId);
   }
 
   @Override
@@ -242,6 +258,12 @@ class JdbcDatasetRepository implements DatasetRepository {
         "SELECT COALESCE(MAX(version_no), 0) + 1 FROM yak_dataset_version WHERE dataset_id = ?",
         Integer.class, datasetId);
     return value == null ? 1 : value;
+  }
+
+  private void requestLineageRefresh(long datasetId) {
+    if (eventPublisher != null) {
+      eventPublisher.publishEvent(new DatasetLineageRefreshRequested(datasetId));
+    }
   }
 
   private static Dataset mapDataset(ResultSet rs, int rowNum) throws SQLException {

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetLineageRefreshListenerTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetLineageRefreshListenerTest.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DatasetLineageRefreshListenerTest {
+
+  @Test
+  void refreshLoadsCommittedSnapshotAndSynchronizesLineage() {
+    DatasetService datasetService = mock(DatasetService.class);
+    DatasetLineageService lineageService = mock(DatasetLineageService.class);
+    DatasetLineageRefreshListener listener =
+        new DatasetLineageRefreshListener(datasetService, lineageService);
+
+    Dataset dataset = new Dataset(
+        21L, "sales", null, DatasetStatus.ONLINE, null, Instant.EPOCH, Instant.EPOCH);
+    DatasetDetail detail = new DatasetDetail(dataset, null, List.of(), List.of());
+    when(datasetService.get(21L)).thenReturn(detail);
+
+    listener.refresh(new DatasetLineageRefreshRequested(21L));
+
+    verify(datasetService).get(21L);
+    verify(lineageService).syncCurrent(detail);
+  }
+
+  @Test
+  void lineageFailureDoesNotEscapeAfterDatasetCommit() {
+    DatasetService datasetService = mock(DatasetService.class);
+    DatasetLineageService lineageService = mock(DatasetLineageService.class);
+    DatasetLineageRefreshListener listener =
+        new DatasetLineageRefreshListener(datasetService, lineageService);
+
+    when(datasetService.get(21L)).thenThrow(new IllegalStateException("lineage read failed"));
+
+    assertDoesNotThrow(() -> listener.refresh(new DatasetLineageRefreshRequested(21L)));
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetLineageServiceTest.java
@@ -1,0 +1,338 @@
+package io.yak.ops.business.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DatasetLineageServiceTest {
+
+  @Test
+  void queryRevisionUsesFrozenRevisionAndConnectsPhysicalColumnsToStableDatasetFields() {
+    LineageService lineage = mock(LineageService.class);
+    LineageMaintenanceService maintenance = mock(LineageMaintenanceService.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    SqlProjectionLineageAnalyzer analyzer = mock(SqlProjectionLineageAnalyzer.class);
+    Map<String, LineageAsset> assets = stubAssets(lineage);
+
+    DatasetLineageService service = new DatasetLineageService(
+        lineage, maintenance, catalog, new ObjectMapper());
+    service.setProjectionAnalyzer(analyzer);
+
+    TaskAsset taskAsset = new TaskAsset(
+        11L,
+        TaskAssetSource.DATA_DEVELOPMENT,
+        "101",
+        7L,
+        "sales.sql",
+        "SQL",
+        TaskAssetStatus.ONLINE,
+        new TaskRevisionRef(11L, 99L, 5),
+        Instant.EPOCH,
+        Instant.EPOCH);
+    TaskSourceRevision frozenRevision = new TaskSourceRevision(
+        71L,
+        3,
+        new TaskDefinition(
+            "SQL",
+            1,
+            "SELECT o.id AS order_id, o.amount FROM ods.orders o",
+            "{\"dataSourceId\":\"12\"}"),
+        "checksum-71");
+    when(catalog.resolveRevision(11L, 71L)).thenReturn(
+        new TaskAssetRevision(taskAsset, frozenRevision));
+
+    SqlProjectionLineageAnalyzer.TableRef orders = table("ods.orders", "ods", "orders");
+    when(analyzer.analyze(anyString(), any())).thenReturn(
+        new SqlProjectionLineageAnalyzer.ProjectionResult(
+            List.of(
+                mapping(orders, "id", "order_id", 1),
+                mapping(orders, "amount", "amount", 2)),
+            2,
+            0));
+
+    DatasetDetail detail = queryRevisionDataset();
+    service.syncCurrent(detail);
+
+    verify(catalog).resolveRevision(11L, 71L);
+    verify(maintenance).clearRelationsByEvidence(
+        DatasetLineageService.EVIDENCE_SOURCE_TYPE, "21");
+
+    LineageAsset dataset = assets.get("dataset:21");
+    LineageAsset orderField = assets.get("dataset-field:21:field-order");
+    LineageAsset amountField = assets.get("dataset-field:21:field-amount");
+    assertNotNull(dataset);
+    assertNotNull(orderField);
+    assertNotNull(amountField);
+    assertEquals(dataset.id(), orderField.parentAssetId());
+    assertEquals("71", dataset.properties().path("sourceTaskRevisionId").asText());
+    assertEquals("SUCCESS", dataset.properties().path("lineageParseStatus").asText());
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineage, org.mockito.Mockito.times(6)).registerRelation(relations.capture());
+    assertEquals(2, count(relations, LineageRelationType.CONTAINS));
+    assertEquals(4, count(relations, LineageRelationType.DERIVES_FROM));
+
+    assertTrue(relations.getAllValues().stream().anyMatch(relation ->
+        key(assets, relation.sourceAssetId()).equals("dataset-field:21:field-order")
+            && key(assets, relation.targetAssetId()).equals("dataset:21")
+            && relation.relationType() == LineageRelationType.CONTAINS));
+    assertTrue(relations.getAllValues().stream().anyMatch(relation ->
+        key(assets, relation.sourceAssetId()).equals("column:12:ods.orders.id")
+            && key(assets, relation.targetAssetId()).equals("dataset-field:21:field-order")
+            && relation.relationType() == LineageRelationType.DERIVES_FROM));
+    assertTrue(assets.containsKey("sql-task:data-development:101"));
+  }
+
+  @Test
+  void standaloneSqlDatasetBuildsLineageWithoutTaskCatalog() {
+    LineageService lineage = mock(LineageService.class);
+    LineageMaintenanceService maintenance = mock(LineageMaintenanceService.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    SqlProjectionLineageAnalyzer analyzer = mock(SqlProjectionLineageAnalyzer.class);
+    Map<String, LineageAsset> assets = stubAssets(lineage);
+
+    DatasetLineageService service = new DatasetLineageService(
+        lineage, maintenance, catalog, new ObjectMapper());
+    service.setProjectionAnalyzer(analyzer);
+
+    SqlProjectionLineageAnalyzer.TableRef orders = table("ods.orders", "ods", "orders");
+    when(analyzer.analyze(anyString(), any())).thenReturn(
+        new SqlProjectionLineageAnalyzer.ProjectionResult(
+            List.of(mapping(orders, "id", "order_id", 1)),
+            1,
+            0));
+
+    Dataset dataset = new Dataset(
+        22L, "standalone", null, DatasetStatus.ONLINE, 41L, Instant.EPOCH, Instant.EPOCH);
+    DatasetVersion version = new DatasetVersion(
+        41L,
+        22L,
+        1,
+        DatasetSourceType.SQL_QUERY,
+        0L,
+        0L,
+        0,
+        "12",
+        "SELECT o.id AS order_id FROM ods.orders o",
+        "[]",
+        Instant.EPOCH);
+    DatasetField field = new DatasetField(
+        "field-order",
+        41L,
+        "order_id",
+        "order_id",
+        DatasetFieldDataType.NUMBER,
+        false,
+        null,
+        DatasetFieldRole.DIMENSION,
+        1);
+
+    service.syncCurrent(new DatasetDetail(dataset, version, List.of(version), List.of(field)));
+
+    verifyNoInteractions(catalog);
+    assertTrue(assets.containsKey("dataset:22"));
+    assertTrue(assets.containsKey("column:12:ods.orders.id"));
+    assertTrue(assets.keySet().stream().noneMatch(key -> key.startsWith("sql-task:")));
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineage, org.mockito.Mockito.times(3)).registerRelation(relations.capture());
+    assertEquals(1, count(relations, LineageRelationType.CONTAINS));
+    assertEquals(2, count(relations, LineageRelationType.DERIVES_FROM));
+  }
+
+  @Test
+  void analyzerFailureReplacesStaleFactsButKeepsDatasetStructure() {
+    LineageService lineage = mock(LineageService.class);
+    LineageMaintenanceService maintenance = mock(LineageMaintenanceService.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    SqlProjectionLineageAnalyzer analyzer = mock(SqlProjectionLineageAnalyzer.class);
+    Map<String, LineageAsset> assets = stubAssets(lineage);
+
+    DatasetLineageService service = new DatasetLineageService(
+        lineage, maintenance, catalog, new ObjectMapper());
+    service.setProjectionAnalyzer(analyzer);
+    when(analyzer.analyze(anyString(), any())).thenThrow(new IllegalStateException("parse failed"));
+
+    Dataset dataset = new Dataset(
+        23L, "broken", null, DatasetStatus.ONLINE, 42L, Instant.EPOCH, Instant.EPOCH);
+    DatasetVersion version = new DatasetVersion(
+        42L,
+        23L,
+        1,
+        DatasetSourceType.SQL_QUERY,
+        0L,
+        0L,
+        0,
+        "12",
+        "SELECT broken",
+        "[]",
+        Instant.EPOCH);
+    DatasetField field = new DatasetField(
+        "field-one",
+        42L,
+        "one",
+        "one",
+        DatasetFieldDataType.NUMBER,
+        true,
+        null,
+        DatasetFieldRole.DIMENSION,
+        1);
+
+    service.syncCurrent(new DatasetDetail(dataset, version, List.of(version), List.of(field)));
+
+    verify(maintenance).clearRelationsByEvidence(
+        DatasetLineageService.EVIDENCE_SOURCE_TYPE, "23");
+    assertEquals("FAILED", assets.get("dataset:23").properties().path("lineageParseStatus").asText());
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineage).registerRelation(relations.capture());
+    assertEquals(LineageRelationType.CONTAINS, relations.getValue().relationType());
+  }
+
+  private static DatasetDetail queryRevisionDataset() {
+    Dataset dataset = new Dataset(
+        21L, "sales", "sales dataset", DatasetStatus.ONLINE, 31L, Instant.EPOCH, Instant.EPOCH);
+    DatasetVersion version = new DatasetVersion(
+        31L,
+        21L,
+        1,
+        DatasetSourceType.QUERY_REVISION,
+        11L,
+        71L,
+        3,
+        "[]",
+        Instant.EPOCH);
+    DatasetField orderField = new DatasetField(
+        "field-order",
+        31L,
+        "order_id",
+        "订单 ID",
+        DatasetFieldDataType.NUMBER,
+        false,
+        null,
+        DatasetFieldRole.DIMENSION,
+        1);
+    DatasetField amountField = new DatasetField(
+        "field-amount",
+        31L,
+        "amount",
+        "销售额",
+        DatasetFieldDataType.NUMBER,
+        true,
+        null,
+        DatasetFieldRole.MEASURE,
+        2);
+    return new DatasetDetail(
+        dataset, version, List.of(version), List.of(orderField, amountField));
+  }
+
+  private static SqlProjectionLineageAnalyzer.TableRef table(
+      String qualifiedName,
+      String schema,
+      String table) {
+    return new SqlProjectionLineageAnalyzer.TableRef(
+        qualifiedName,
+        qualifiedName,
+        null,
+        schema,
+        table);
+  }
+
+  private static SqlProjectionLineageAnalyzer.ProjectionMapping mapping(
+      SqlProjectionLineageAnalyzer.TableRef sourceTable,
+      String sourceColumn,
+      String outputColumn,
+      int outputOrdinal) {
+    return new SqlProjectionLineageAnalyzer.ProjectionMapping(
+        sourceTable,
+        sourceColumn,
+        outputColumn,
+        SqlProjectionLineageAnalyzer.MappingKind.IDENTITY,
+        sourceTable.tableName() + "." + sourceColumn,
+        outputOrdinal,
+        1);
+  }
+
+  private static long count(
+      ArgumentCaptor<LineageService.RegisterRelationCommand> relations,
+      LineageRelationType type) {
+    return relations.getAllValues().stream()
+        .filter(value -> value.relationType() == type)
+        .count();
+  }
+
+  private static Map<String, LineageAsset> stubAssets(LineageService lineage) {
+    AtomicLong ids = new AtomicLong(1);
+    Map<String, LineageAsset> assets = new LinkedHashMap<>();
+    when(lineage.registerAsset(any())).thenAnswer(invocation -> {
+      LineageService.RegisterAssetCommand command = invocation.getArgument(0);
+      LineageAsset existing = assets.get(command.assetKey());
+      long id = existing == null ? ids.getAndIncrement() : existing.id();
+      LineageAsset asset = new LineageAsset(
+          id,
+          command.assetKey(),
+          command.assetType(),
+          command.name(),
+          command.sourceType(),
+          command.sourceId(),
+          command.parentAssetId(),
+          command.dataSourceId(),
+          command.databaseName(),
+          command.schemaName(),
+          command.tableName(),
+          command.columnName(),
+          command.properties(),
+          Instant.EPOCH,
+          Instant.EPOCH);
+      assets.put(command.assetKey(), asset);
+      return asset;
+    });
+    when(lineage.getAssetByKey(anyString())).thenAnswer(invocation -> {
+      String key = invocation.getArgument(0);
+      LineageAsset asset = assets.get(key);
+      if (asset == null) throw new IllegalArgumentException("missing: " + key);
+      return asset;
+    });
+    return assets;
+  }
+
+  private static String key(Map<String, LineageAsset> assets, long id) {
+    return assets.values().stream()
+        .filter(asset -> asset.id() == id)
+        .map(LineageAsset::assetKey)
+        .findFirst()
+        .orElse("<missing:" + id + ">");
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/SqlProjectionLineageAnalyzer.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/SqlProjectionLineageAnalyzer.java
@@ -1,0 +1,83 @@
+package io.yak.ops.business.lineage;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Source-neutral contract for resolving a read-only SQL projection to physical source columns.
+ *
+ * <p>The lineage core deliberately owns only the contract. SQL parser implementations live in
+ * authoring/runtime modules so Dataset and future consumers can reuse projection lineage without a
+ * dependency on data-development or a concrete SQL parser library.
+ */
+public interface SqlProjectionLineageAnalyzer {
+
+  ProjectionResult analyze(String sql, SchemaProvider schemaProvider);
+
+  default ProjectionResult analyze(String sql) {
+    return analyze(sql, SchemaProvider.none());
+  }
+
+  enum MappingKind {
+    IDENTITY,
+    TRANSFORMATION,
+    AGGREGATION
+  }
+
+  record TableRef(
+      String canonicalName,
+      String qualifiedName,
+      String databaseName,
+      String schemaName,
+      String tableName) {
+
+    public TableRef {
+      Objects.requireNonNull(canonicalName, "canonicalName");
+      Objects.requireNonNull(qualifiedName, "qualifiedName");
+      Objects.requireNonNull(tableName, "tableName");
+    }
+  }
+
+  record SchemaColumn(String name, Integer ordinalPosition) {
+  }
+
+  @FunctionalInterface
+  interface SchemaProvider {
+    List<SchemaColumn> columns(TableRef table);
+
+    static SchemaProvider none() {
+      return table -> List.of();
+    }
+  }
+
+  record ProjectionMapping(
+      TableRef sourceTable,
+      String sourceColumnName,
+      String outputColumnName,
+      MappingKind mappingKind,
+      String expression,
+      int outputOrdinal,
+      int sourceOrdinal) {
+
+    public ProjectionMapping {
+      Objects.requireNonNull(sourceTable, "sourceTable");
+      Objects.requireNonNull(sourceColumnName, "sourceColumnName");
+      Objects.requireNonNull(outputColumnName, "outputColumnName");
+      Objects.requireNonNull(mappingKind, "mappingKind");
+    }
+  }
+
+  record ProjectionResult(
+      List<ProjectionMapping> mappings,
+      int candidateOutputCount,
+      int unresolvedReferenceCount) {
+
+    public ProjectionResult {
+      mappings = mappings == null ? List.of() : List.copyOf(mappings);
+      if (candidateOutputCount < 0) throw new IllegalArgumentException("candidateOutputCount < 0");
+      if (unresolvedReferenceCount < 0) {
+        throw new IllegalArgumentException("unresolvedReferenceCount < 0");
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 目标

继续 Yak Ops 血缘下一阶段：把已经稳定的数据开发 SQL 血缘接到数据消费层，正式建立 **Table / Column -> Dataset / DatasetField** 的关系。

本阶段同时覆盖 Yak Ops 当前两种 Dataset 来源：

1. `QUERY_REVISION`：legacy / release 流程，DatasetVersion 冻结某个 SQL TaskAsset 的 immutable TaskRevision；
2. `SQL_QUERY`：新的 Dataset Node，DatasetVersion 自己冻结 `dataSourceId + SQL + field contract`。

目标链路：

```text
TABLE -----------------------> DATASET
  |                               ^
  |                               |
  v                               | CONTAINS
COLUMN -> DATASET_FIELD ----------+

QUERY_REVISION 额外保留：

SQL_TASK -> DATASET
```

所有关系继续遵循 Lineage Core 的统一方向：

```text
source/upstream -> target/downstream
```

因此 `CONTAINS` 的语义是“下游 target contains 上游 source”，所以字段结构关系写成：

```text
DATASET_FIELD -> DATASET / CONTAINS
```

这样后续可以自然继续：

```text
COLUMN
  -> DATASET_FIELD
  -> DATASET
  -> CHART
  -> DASHBOARD
```

## 1. Lineage Core 增加中立 SQL Projection Analyzer Contract

新增：

```text
SqlProjectionLineageAnalyzer
```

Lineage Core 只定义 source-neutral contract：

```java
ProjectionResult analyze(String sql, SchemaProvider schemaProvider)
```

核心模型：

```text
TableRef
SchemaColumn
ProjectionMapping
ProjectionResult
MappingKind
```

不引入 JSQLParser，也不依赖 Dataset / data-development。

这么做的目的，是避免：

```text
Dataset -> data-development
```

因为当前已经存在：

```text
data-development -> Dataset
```

如果 Dataset 为了复用 SQL Parser 反向依赖 data-development，会直接形成 Maven cycle。

现在依赖关系保持：

```text
lineage
   ^
   |
Dataset
   ^
   |
data-development
```

## 2. data-development 复用现有 SQL Lineage Engine

新增：

```text
DevelopmentSqlProjectionLineageAnalyzer
```

它把一个 SELECT projection 包装成解析期 synthetic CTAS：

```sql
CREATE TABLE __yak_dataset_projection__ AS
<dataset select sql>
```

然后直接复用当前已经合并的：

```text
SqlColumnLineageParser
+ Schema-aware resolver
+ DerivedAwareSqlColumnLineageParser
+ CTE/Subquery propagation
```

最终只把 synthetic target 的映射翻译成 source-neutral `ProjectionMapping`。

所以 Dataset 没有复制一套 SQL Parser，也不会出现：

```text
数据开发字段血缘一套规则
Dataset 字段血缘另一套规则
```

两边共享同一套真实解析能力。

## 3. Dataset 是稳定资产，DatasetVersion 只作为证据版本

Dataset asset：

```text
dataset:{datasetId}
```

类型：

```text
DATASET
```

DatasetVersion 不创建单独 Asset。

版本信息写入 Asset / Relation evidence：

```text
datasetVersionId
datasetVersionNo
sourceType
sourceTaskAssetId
sourceTaskRevisionId
sourceTaskRevisionNo
```

所以：

```text
Dataset V1
Dataset V2
Dataset V3
```

在图上始终还是同一个 Dataset 节点，只替换当前权威关系。

## 4. DatasetField 使用稳定 fieldId

Asset key：

```text
dataset-field:{datasetId}:{fieldId}
```

类型：

```text
DATASET_FIELD
```

并设置：

```text
parentAssetId = Dataset Asset
```

Yak Ops 当前已经在 Dataset version 之间保持稳定 fieldId，因此用户修改：

```text
显示名
描述
角色
```

不会让血缘图生成一个新字段身份。

## 5. QUERY_REVISION 必须使用 DatasetVersion 冻结的 TaskRevision

这是本阶段最重要的 correctness 约束之一。

假设：

```text
Dataset V1 -> TaskRevision 71 / v3

之后 SQL Task 已经发布到：
TaskRevision 99 / v5
```

Dataset V1 的血缘仍然必须解析：

```text
TaskRevision 71 / v3
```

而不是 TaskAsset 当前最新的 v5。

实现通过：

```java
taskCatalogService.resolveRevision(
    version.sourceTaskAssetId(),
    version.sourceTaskRevisionId())
```

并校验 `revisionNo` 与 DatasetVersion snapshot 一致。

所以 Dataset immutable version 和 lineage evidence 不会漂移。

## 6. SQL_QUERY（新 Dataset Node）直接解析 Dataset 自己冻结的 SQL

当前新的 Dataset Node 已经使用：

```text
DatasetVersion.sourceType = SQL_QUERY
DatasetVersion.dataSourceId
DatasetVersion.sql
```

本阶段直接使用这份 immutable snapshot：

```text
DatasetVersion.sql
+ DatasetVersion.dataSourceId
+ Datasource Catalog
        |
        v
Projection Analyzer
        |
        v
physical COLUMN -> DATASET_FIELD
```

不要求创建 SQL TaskAsset。

所以新 Dataset 编辑器和 legacy release Dataset 都有血缘。

## 7. Datasource Catalog Schema-aware 继续复用

DatasetLineageService 为 Analyzer 提供 source-neutral SchemaProvider。

每次 Dataset lineage refresh 内按 table canonical name 缓存 Catalog 结果。

继续兼容两段表名：

```text
PostgreSQL: schema.table
MySQL/Doris: database.table
```

lookup：

```text
1. database=null, schema=qualifier
2. 无结果时 database=qualifier, schema=null
```

Catalog 查询失败只返回空 schema metadata，不阻断 Dataset lineage 主流程。

## 8. 当前关系

### Table -> Dataset

每个实际参与字段映射的 source table：

```text
TABLE -> DATASET / DERIVES_FROM
```

### Column -> DatasetField

例如 Dataset SQL：

```sql
SELECT
  o.user_id,
  SUM(o.amount) AS gmv
FROM ods.orders o
GROUP BY o.user_id
```

得到：

```text
ods.orders.user_id
      -> dataset.user_id / IDENTITY

ods.orders.amount
      -> dataset.gmv / AGGREGATION
```

持久化：

```text
COLUMN -> DATASET_FIELD / DERIVES_FROM
```

Relation evidence 保留：

```text
mappingKind
expression
sourceTable
sourceColumn
outputColumn
outputOrdinal
sourceOrdinal
DatasetVersion
```

### DatasetField -> Dataset

```text
DATASET_FIELD -> DATASET / CONTAINS
```

用于结构关系和后续多跳影响分析。

### SQL_TASK -> Dataset

仅 `QUERY_REVISION`：

```text
SQL_TASK -> DATASET / DERIVES_FROM
```

如果 SQL Task lineage asset 因历史原因不存在，会用稳定 key：

```text
sql-task:data-development:{TaskAsset.sourceRef}
```

做最小 fallback 注册。

## 9. 当前版本关系替换，不保留陈旧关系

Dataset lineage 使用独立 evidence scope：

```text
sourceType = DATASET_SOURCE_PARSE
sourceId   = datasetId
```

刷新前：

```java
clearRelationsByEvidence(...)
```

再写当前 DatasetVersion 的关系。

所以 V1：

```text
ods.old_amount -> dataset.gmv
```

更新到 V2：

```text
ods.new_amount -> dataset.gmv
```

不会在图里同时残留 old + new。

历史 DatasetField Asset 可以继续存在用于未来版本能力，但旧字段会失去当前 evidence relation，不再出现在当前可达图里。

## 10. AFTER_COMMIT：血缘失败不回滚 Dataset

Dataset 是业务主链，Lineage 是 derived metadata。

本阶段没有在 Dataset save transaction 里同步执行 Lineage，而是在 `JdbcDatasetRepository` 成功修改：

```text
currentVersion
status
metadata
```

后发布：

```text
DatasetLineageRefreshRequested
```

监听器：

```java
@TransactionalEventListener(
  phase = AFTER_COMMIT,
  fallbackExecution = true)
```

事务成功提交后再读取最终 Dataset snapshot 并同步 lineage。

如果：

```text
Catalog 暂不可用
SQL parser 异常
Lineage DB 写入异常
```

监听器只记录 warning，不会让已经成功提交的 Dataset 请求表现为失败。

这同时覆盖：

```text
legacy Dataset publish
Dataset createVersion
新 Dataset Node SQL_QUERY save
Dataset metadata/status 更新
```

而不需要在多个 service 里重复写 lifecycle hook。

## 11. Parse status

Dataset Asset properties 记录：

```text
lineageParseStatus
```

可能值：

```text
SUCCESS
PARTIAL
UNRESOLVED
FAILED
SKIPPED
```

以及：

```text
lineageParseError
candidateOutputColumnCount
columnMappingCount
unresolvedColumnReferenceCount
unmatchedOutputMappingCount
```

后续前端可以直接展示“字段血缘是否完整”。

## Tests

### DevelopmentSqlProjectionLineageAnalyzerTest

覆盖：

- 普通 SELECT projection
- Aggregate mapping
- CTE aggregate propagation
- synthetic target 不泄漏为真实资产
- SchemaProvider + SELECT *

### DatasetLineageServiceTest

覆盖：

- QUERY_REVISION 解析 frozen TaskRevision，而不是 TaskAsset latest revision
- stable Dataset / DatasetField asset key
- DatasetField parent asset
- SQL_TASK -> Dataset
- TABLE -> Dataset
- COLUMN -> DatasetField
- DatasetField -> Dataset / CONTAINS
- SQL_QUERY 不访问 TaskCatalog
- Analyzer failure 会清理旧 evidence，但仍保留 Dataset structure

### DatasetLineageRefreshListenerTest

覆盖：

- AFTER_COMMIT listener 读取最终 Dataset snapshot
- lineage refresh failure 不向 Dataset caller 传播

## 影响范围

当前分支相对 `main`：

```text
1 commit ahead
0 behind
9 files changed
```

涉及：

```text
yak-ops-business-lineage
  + source-neutral Projection Analyzer contract

yak-ops-business-data-development
  + existing SQL parser adapter

yak-ops-business-dataset
  + LineageService integration
  + after-commit refresh
  + lineage dependency
```

没有：

- Flyway migration
- Lineage Core DB schema change
- Dataset DB schema change
- REST API change
- frontend change
- Chart / Dashboard change
- Runtime/OpenLineage event

## Validation

已完成：

- 基于 #565 合并后的最新 `main`
- compare：`1 ahead / 0 behind`
- 变更范围确认仅 9 个预期文件
- TaskCatalog immutable revision API 核对
- Dataset `QUERY_REVISION / SQL_QUERY` 当前模型核对
- Lineage Asset/Relation 长度与方向约束核对
- JSQLParser 能力通过已经合并的 data-development parser adapter 复用，不新增 parser dependency

尝试在当前执行环境 clone 分支执行 Maven reactor，但环境 DNS 无法解析 `github.com`，因此无法下载仓库/依赖，没有把静态检查冒充成 Maven CI 通过。

建议合并前正常执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-dataset -am test
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
mvn -pl yak-ops-boot -am package -DskipTests
```

## 下一阶段建议

这个 PR 合并后，主链会来到：

```text
TABLE / COLUMN
      |
      v
DATASET / DATASET_FIELD
```

下一阶段建议继续接：

```text
DATASET_FIELD -> CHART
CHART -> DASHBOARD
```

其中 Chart 不需要 SQL Parser，应该直接根据现有 Analysis / Chart 配置中的稳定 `datasetId + fieldId` 建结构化关系。