### PR TITLE
fix(editor): match Chat2DB caret feel

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -128,9 +128,12 @@ const SqlMonacoEditor = ({
       insertSpaces: true,
       scrollBeyondLastLine: false,
       smoothScrolling: true,
-      cursorSmoothCaretAnimation: 'on',
-      cursorBlinking: 'smooth',
-      cursorWidth: 1,
+      // Keep the caret aligned with Chat2DB/Monaco's immediate line-cursor feel.
+      // Interpolated caret travel looks smooth in isolation but trails fast typing/navigation.
+      cursorStyle: 'line',
+      cursorSmoothCaretAnimation: 'off',
+      cursorBlinking: 'blink',
+      cursorWidth: 2,
       showFoldingControls: 'mouseover',
       glyphMargin: !readOnly,
       lineDecorationsWidth: 24,
@@ -201,8 +204,25 @@ const SqlMonacoEditor = ({
       );
     };
 
-    const updateRunDecoration = (position = editor.getPosition()) => {
-      activeStatement = findStatementAtPosition(position);
+    const isSameStatement = (
+      left?: SqlStatementRange,
+      right?: SqlStatementRange,
+    ) =>
+      left?.startOffset === right?.startOffset
+      && left?.endOffset === right?.endOffset
+      && left?.startLine === right?.startLine;
+
+    const updateRunDecoration = (
+      position = editor.getPosition(),
+      force = false,
+    ) => {
+      const nextActiveStatement = findStatementAtPosition(position);
+      const statementChanged = !isSameStatement(activeStatement, nextActiveStatement);
+      activeStatement = nextActiveStatement;
+
+      // Moving within the same SQL statement should not recreate the same gutter decoration.
+      if (!force && !statementChanged) return;
+
       if (!activeStatement || !canRunStatement()) {
         runDecorations.clear();
         return;
@@ -219,7 +239,7 @@ const SqlMonacoEditor = ({
       ]);
     };
 
-    refreshRunDecorationRef.current = () => updateRunDecoration();
+    refreshRunDecorationRef.current = () => updateRunDecoration(editor.getPosition(), true);
 
     const runStatement = (sql: string) => {
       if (onRunStatementRef.current) {
@@ -232,7 +252,7 @@ const SqlMonacoEditor = ({
 
     const refreshStatementRanges = () => {
       statementRanges = getSqlStatementRanges(model.getValue());
-      updateRunDecoration();
+      updateRunDecoration(editor.getPosition(), true);
     };
 
     let wordWrapEnabled = initialSettings.wordWrap;
@@ -297,6 +317,15 @@ const SqlMonacoEditor = ({
       });
     };
 
+    let editorStateFrame: number | undefined;
+    const scheduleEditorStateEmit = () => {
+      if (editorStateFrame !== undefined) return;
+      editorStateFrame = window.requestAnimationFrame(() => {
+        editorStateFrame = undefined;
+        emitEditorState();
+      });
+    };
+
     const contentDisposable = model.onDidChangeContent(() => {
       refreshStatementRanges();
       if (!readOnly) onChangeRef.current(model.getValue());
@@ -314,17 +343,21 @@ const SqlMonacoEditor = ({
       if (!lineNumber || lineNumber !== activeStatement.startLine) return;
       runStatement(activeStatement.sql);
     });
-    const cursorDisposable = editor.onDidChangeCursorPosition(() => {
-      emitEditorState();
-      updateRunDecoration();
+    const cursorDisposable = editor.onDidChangeCursorPosition((event) => {
+      scheduleEditorStateEmit();
+      updateRunDecoration(event.position);
     });
-    const selectionDisposable = editor.onDidChangeCursorSelection(emitEditorState);
-    const scrollDisposable = editor.onDidScrollChange(emitEditorState);
+    const selectionDisposable = editor.onDidChangeCursorSelection(scheduleEditorStateEmit);
+    const scrollDisposable = editor.onDidScrollChange(scheduleEditorStateEmit);
 
     emitEditorState();
-    updateRunDecoration();
+    updateRunDecoration(editor.getPosition(), true);
 
     return () => {
+      if (editorStateFrame !== undefined) {
+        window.cancelAnimationFrame(editorStateFrame);
+        editorStateFrame = undefined;
+      }
       emitEditorState();
       refreshRunDecorationRef.current = () => {};
       unsubscribeSettings();


### PR DESCRIPTION
## Summary

- match the SQL editor caret to Chat2DB's immediate Monaco line-cursor feel
- switch the caret from 1px to 2px and remove the interpolated movement delay
- use normal blink timing instead of smooth blinking
- coalesce cursor / selection / scroll state updates to one animation frame
- avoid rebuilding the SQL run glyph while the caret stays inside the same statement

## Why

The provided 60fps recordings show Yak Ops' caret feeling slightly behind input/navigation and visually thinner than Chat2DB. Yak Ops was explicitly enabling `cursorSmoothCaretAnimation: 'on'`, `cursorBlinking: 'smooth'`, and `cursorWidth: 1`, while Chat2DB uses the same `monaco-editor` `^0.52.0` line and relies on the editor's immediate cursor behavior.

## Validation

- compared Yak Ops and Chat2DB Monaco editor configuration/source
- reviewed the final diff for cursor option and cursor-event hot-path changes
- no SQL execution, completion, formatting, session restoration, or editor settings behavior is intentionally changed

Draft PR for visual/interaction verification against the supplied recordings.