### PR TITLE
feat(lineage): connect Chart and Dashboard consumption

### DIFF
--- a/yak-ops-business/yak-ops-business-analysis/pom.xml
+++ b/yak-ops-business/yak-ops-business-analysis/pom.xml
@@ -31,6 +31,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-lineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisLineageRefreshListener.java
@@ -1,0 +1,58 @@
+package io.yak.ops.business.analysis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** Keeps reusable Chart lineage aligned with committed Analysis mutations. */
+@Component
+class AnalysisLineageRefreshListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AnalysisLineageRefreshListener.class);
+
+  private final AnalysisService analysisService;
+  private final AnalysisLineageService lineageService;
+
+  AnalysisLineageRefreshListener(
+      AnalysisService analysisService,
+      AnalysisLineageService lineageService) {
+    this.analysisService = analysisService;
+    this.lineageService = lineageService;
+  }
+
+  @TransactionalEventListener(
+      phase = TransactionPhase.AFTER_COMMIT,
+      fallbackExecution = true)
+  public void refresh(AnalysisLineageRefreshRequested event) {
+    if (event == null || event.analysisId() <= 0L) return;
+    try {
+      if (event.deleted()) {
+        lineageService.clear(event.analysisId());
+      } else {
+        lineageService.syncCurrent(analysisService.get(event.analysisId()));
+      }
+    } catch (RuntimeException exception) {
+      LOGGER.warn(
+          "Analysis lineage refresh failed after commit for analysis {}: {}",
+          event.analysisId(),
+          exception.getMessage(),
+          exception);
+    }
+  }
+}
+
+record AnalysisLineageRefreshRequested(long analysisId, boolean deleted) {
+  AnalysisLineageRefreshRequested {
+    if (analysisId <= 0L) throw new IllegalArgumentException("analysisId 必须大于 0");
+  }
+
+  static AnalysisLineageRefreshRequested refresh(long analysisId) {
+    return new AnalysisLineageRefreshRequested(analysisId, false);
+  }
+
+  static AnalysisLineageRefreshRequested deleted(long analysisId) {
+    return new AnalysisLineageRefreshRequested(analysisId, true);
+  }
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisLineageService.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisLineageService.java
@@ -1,0 +1,258 @@
+package io.yak.ops.business.analysis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Builds Dataset/DatasetField -> reusable Analysis Chart lineage. */
+@Service
+public class AnalysisLineageService {
+
+  static final String EVIDENCE_SOURCE_TYPE = "ANALYSIS_BINDING";
+
+  private final LineageService lineageService;
+  private final LineageMaintenanceService maintenanceService;
+  private final ObjectMapper objectMapper;
+
+  public AnalysisLineageService(
+      LineageService lineageService,
+      LineageMaintenanceService maintenanceService,
+      ObjectMapper objectMapper) {
+    this.lineageService = lineageService;
+    this.maintenanceService = maintenanceService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Transactional(
+      transactionManager = "yakBusinessTransactionManager",
+      propagation = Propagation.REQUIRES_NEW)
+  public void syncCurrent(AnalysisAsset analysis) {
+    if (analysis == null || analysis.id() <= 0L) return;
+
+    String evidenceId = String.valueOf(analysis.id());
+    maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
+
+    LineageAsset chart = registerChartAsset(analysis);
+    LineageAsset dataset = resolveDatasetAsset(analysis.datasetId());
+    Instant observedAt = analysis.updateTime() == null ? Instant.now() : analysis.updateTime();
+
+    lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+        dataset.id(),
+        chart.id(),
+        LineageRelationType.CONSUMES,
+        EVIDENCE_SOURCE_TYPE,
+        evidenceId,
+        null,
+        BigDecimal.ONE,
+        "analysis-current:dataset",
+        observedAt,
+        datasetRelationProperties(analysis)));
+
+    Map<String, FieldUsage> usages = fieldUsages(analysis.querySpec());
+    int index = 0;
+    for (Map.Entry<String, FieldUsage> entry : usages.entrySet()) {
+      index++;
+      String fieldId = entry.getKey();
+      LineageAsset field = resolveDatasetFieldAsset(dataset, analysis.datasetId(), fieldId);
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+          field.id(),
+          chart.id(),
+          LineageRelationType.CONSUMES,
+          EVIDENCE_SOURCE_TYPE,
+          evidenceId,
+          null,
+          BigDecimal.ONE,
+          "analysis-current:field:" + index,
+          observedAt,
+          fieldRelationProperties(analysis, fieldId, entry.getValue())));
+    }
+  }
+
+  @Transactional(
+      transactionManager = "yakBusinessTransactionManager",
+      propagation = Propagation.REQUIRES_NEW)
+  public void clear(long analysisId) {
+    if (analysisId <= 0L) return;
+    maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, String.valueOf(analysisId));
+  }
+
+  private LineageAsset registerChartAsset(AnalysisAsset analysis) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("analysisId", String.valueOf(analysis.id()));
+    properties.put("datasetId", String.valueOf(analysis.datasetId()));
+    properties.put("chartType", analysis.chartType().name());
+    if (analysis.description() != null) properties.put("description", analysis.description());
+    if (analysis.updateTime() != null) properties.put("analysisUpdatedAt", analysis.updateTime().toString());
+    properties.put("bindingMode", "REUSABLE_ANALYSIS");
+
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        chartAssetKey(analysis.id()),
+        LineageAssetType.CHART,
+        analysis.name(),
+        "ANALYSIS",
+        String.valueOf(analysis.id()),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        properties));
+  }
+
+  private LineageAsset resolveDatasetAsset(long datasetId) {
+    String key = datasetAssetKey(datasetId);
+    try {
+      return lineageService.getAssetByKey(key);
+    } catch (IllegalArgumentException missing) {
+      ObjectNode properties = objectMapper.createObjectNode();
+      properties.put("datasetId", String.valueOf(datasetId));
+      properties.put("lineageRegistration", "ANALYSIS_FALLBACK");
+      return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+          key,
+          LineageAssetType.DATASET,
+          key,
+          "DATASET",
+          String.valueOf(datasetId),
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          properties));
+    }
+  }
+
+  private LineageAsset resolveDatasetFieldAsset(
+      LineageAsset dataset,
+      long datasetId,
+      String fieldId) {
+    String key = datasetFieldAssetKey(datasetId, fieldId);
+    try {
+      return lineageService.getAssetByKey(key);
+    } catch (IllegalArgumentException missing) {
+      ObjectNode properties = objectMapper.createObjectNode();
+      properties.put("datasetId", String.valueOf(datasetId));
+      properties.put("fieldId", fieldId);
+      properties.put("lineageRegistration", "ANALYSIS_FALLBACK");
+      return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+          key,
+          LineageAssetType.DATASET_FIELD,
+          fieldId,
+          "DATASET",
+          datasetId + ":" + fieldId,
+          dataset.id(),
+          null,
+          null,
+          null,
+          null,
+          null,
+          properties));
+    }
+  }
+
+  private Map<String, FieldUsage> fieldUsages(AnalysisQuerySpec querySpec) {
+    Map<String, FieldUsage> result = new LinkedHashMap<>();
+    if (querySpec == null) return result;
+
+    if (querySpec.dimensions() != null) {
+      querySpec.dimensions().forEach(fieldId -> usage(result, fieldId).roles().add("DIMENSION"));
+    }
+    if (querySpec.metrics() != null) {
+      querySpec.metrics().forEach(metric -> {
+        if (metric == null) return;
+        FieldUsage usage = usage(result, metric.fieldId());
+        usage.roles().add("METRIC");
+        if (metric.aggregation() != null) usage.metricAggregations().add(metric.aggregation().name());
+      });
+    }
+    if (querySpec.filters() != null) {
+      querySpec.filters().forEach(filter -> {
+        if (filter != null) usage(result, filter.fieldId()).roles().add("FILTER");
+      });
+    }
+    if (querySpec.sorts() != null) {
+      querySpec.sorts().forEach(sort -> {
+        if (sort == null) return;
+        FieldUsage usage = usage(result, sort.fieldId());
+        usage.roles().add("SORT");
+        if (sort.aggregation() != null) usage.sortAggregations().add(sort.aggregation().name());
+      });
+    }
+    return result;
+  }
+
+  private FieldUsage usage(Map<String, FieldUsage> usages, String fieldId) {
+    if (fieldId == null || fieldId.isBlank()) {
+      throw new IllegalStateException("Analysis lineage fieldId 不能为空");
+    }
+    return usages.computeIfAbsent(
+        fieldId.trim(),
+        ignored -> new FieldUsage(new LinkedHashSet<>(), new LinkedHashSet<>(), new LinkedHashSet<>()));
+  }
+
+  private ObjectNode datasetRelationProperties(AnalysisAsset analysis) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("lineageLevel", "DATASET");
+    properties.put("analysisId", String.valueOf(analysis.id()));
+    properties.put("datasetId", String.valueOf(analysis.datasetId()));
+    properties.put("chartType", analysis.chartType().name());
+    return properties;
+  }
+
+  private ObjectNode fieldRelationProperties(
+      AnalysisAsset analysis,
+      String fieldId,
+      FieldUsage usage) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("lineageLevel", "DATASET_FIELD");
+    properties.put("analysisId", String.valueOf(analysis.id()));
+    properties.put("datasetId", String.valueOf(analysis.datasetId()));
+    properties.put("fieldId", fieldId);
+
+    ArrayNode roles = properties.putArray("usageRoles");
+    usage.roles().forEach(roles::add);
+    if (!usage.metricAggregations().isEmpty()) {
+      ArrayNode aggregations = properties.putArray("metricAggregations");
+      usage.metricAggregations().forEach(aggregations::add);
+    }
+    if (!usage.sortAggregations().isEmpty()) {
+      ArrayNode aggregations = properties.putArray("sortAggregations");
+      usage.sortAggregations().forEach(aggregations::add);
+    }
+    return properties;
+  }
+
+  static String chartAssetKey(long analysisId) {
+    return "chart:analysis:" + analysisId;
+  }
+
+  static String datasetAssetKey(long datasetId) {
+    return "dataset:" + datasetId;
+  }
+
+  static String datasetFieldAssetKey(long datasetId, String fieldId) {
+    return "dataset-field:" + datasetId + ":" + fieldId;
+  }
+
+  private record FieldUsage(
+      Set<String> roles,
+      Set<String> metricAggregations,
+      Set<String> sortAggregations) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/JdbcAnalysisRepository.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/JdbcAnalysisRepository.java
@@ -10,7 +10,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -29,9 +31,20 @@ class JdbcAnalysisRepository implements AnalysisRepository {
       """;
 
   private final JdbcTemplate jdbcTemplate;
+  private final ApplicationEventPublisher eventPublisher;
 
-  JdbcAnalysisRepository(@Qualifier("yakBusinessDataSource") DataSource dataSource) {
+  @Autowired
+  JdbcAnalysisRepository(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      ApplicationEventPublisher eventPublisher) {
     this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.eventPublisher = eventPublisher;
+  }
+
+  /** Keeps focused repository tests source-compatible without a Spring event publisher. */
+  JdbcAnalysisRepository(DataSource dataSource) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.eventPublisher = null;
   }
 
   @Override
@@ -62,7 +75,9 @@ class JdbcAnalysisRepository implements AnalysisRepository {
     }, keyHolder);
     Number key = keyHolder.getKey();
     if (key == null) throw new IllegalStateException("创建 Analysis 后未返回主键");
-    return key.longValue();
+    long analysisId = key.longValue();
+    requestLineageRefresh(AnalysisLineageRefreshRequested.refresh(analysisId));
+    return analysisId;
   }
 
   @Override
@@ -89,6 +104,7 @@ class JdbcAnalysisRepository implements AnalysisRepository {
         visualConfigJson,
         analysisId);
     if (updated != 1) throw new IllegalArgumentException("Analysis 不存在：" + analysisId);
+    requestLineageRefresh(AnalysisLineageRefreshRequested.refresh(analysisId));
   }
 
   @Override
@@ -110,6 +126,11 @@ class JdbcAnalysisRepository implements AnalysisRepository {
   public void delete(long analysisId) {
     int deleted = jdbcTemplate.update("DELETE FROM yak_analysis WHERE id = ?", analysisId);
     if (deleted != 1) throw new IllegalArgumentException("Analysis 不存在：" + analysisId);
+    requestLineageRefresh(AnalysisLineageRefreshRequested.deleted(analysisId));
+  }
+
+  private void requestLineageRefresh(AnalysisLineageRefreshRequested event) {
+    if (eventPublisher != null) eventPublisher.publishEvent(event);
   }
 
   private static AnalysisRow map(ResultSet rs, int rowNum) throws SQLException {

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/AnalysisLineageRefreshListenerTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/AnalysisLineageRefreshListenerTest.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AnalysisLineageRefreshListenerTest {
+
+  @Test
+  void refreshReadsCommittedAnalysisSnapshot() {
+    AnalysisService analysisService = mock(AnalysisService.class);
+    AnalysisLineageService lineageService = mock(AnalysisLineageService.class);
+    AnalysisLineageRefreshListener listener =
+        new AnalysisLineageRefreshListener(analysisService, lineageService);
+    AnalysisAsset asset = new AnalysisAsset(
+        5L,
+        "A",
+        null,
+        9L,
+        AnalysisChartType.METRIC,
+        new AnalysisQuerySpec(
+            List.of(),
+            List.of(new AnalysisMetricBinding("amount", AnalysisAggregation.SUM)),
+            List.of(),
+            List.of(),
+            100,
+            30),
+        new AnalysisVisualConfig(false, false, false, false),
+        Instant.EPOCH,
+        Instant.EPOCH);
+    when(analysisService.get(5L)).thenReturn(asset);
+
+    listener.refresh(AnalysisLineageRefreshRequested.refresh(5L));
+
+    verify(lineageService).syncCurrent(asset);
+  }
+
+  @Test
+  void refreshFailureDoesNotEscapeCommittedBusinessCall() {
+    AnalysisService analysisService = mock(AnalysisService.class);
+    AnalysisLineageService lineageService = mock(AnalysisLineageService.class);
+    AnalysisLineageRefreshListener listener =
+        new AnalysisLineageRefreshListener(analysisService, lineageService);
+    when(analysisService.get(5L)).thenThrow(new IllegalStateException("lineage unavailable"));
+
+    assertDoesNotThrow(() -> listener.refresh(AnalysisLineageRefreshRequested.refresh(5L)));
+  }
+
+  @Test
+  void deleteClearsEvidenceWithoutReadingDeletedAnalysis() {
+    AnalysisService analysisService = mock(AnalysisService.class);
+    AnalysisLineageService lineageService = mock(AnalysisLineageService.class);
+    AnalysisLineageRefreshListener listener =
+        new AnalysisLineageRefreshListener(analysisService, lineageService);
+
+    listener.refresh(AnalysisLineageRefreshRequested.deleted(5L));
+
+    verify(lineageService).clear(5L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/AnalysisLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/AnalysisLineageServiceTest.java
@@ -1,0 +1,124 @@
+package io.yak.ops.business.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AnalysisLineageServiceTest {
+
+  @Test
+  void syncBuildsStableDatasetAndFieldConsumptionAndMergesUsageRoles() {
+    LineageService lineage = mock(LineageService.class);
+    LineageMaintenanceService maintenance = mock(LineageMaintenanceService.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    AtomicLong ids = new AtomicLong(100L);
+
+    when(lineage.getAssetByKey(anyString())).thenThrow(new IllegalArgumentException("missing"));
+    when(lineage.registerAsset(any())).thenAnswer(invocation ->
+        asset(ids.incrementAndGet(), invocation.getArgument(0)));
+
+    AnalysisLineageService service = new AnalysisLineageService(lineage, maintenance, objectMapper);
+    AnalysisAsset analysis = new AnalysisAsset(
+        7L,
+        "区域销售",
+        "销售分析",
+        21L,
+        AnalysisChartType.BAR,
+        new AnalysisQuerySpec(
+            List.of("region"),
+            List.of(new AnalysisMetricBinding("amount", AnalysisAggregation.SUM)),
+            List.of(new AnalysisFilterBinding("region", AnalysisFilterOperator.EQ, "华南")),
+            List.of(new AnalysisSortBinding("amount", AnalysisAggregation.SUM, AnalysisSortDirection.DESC)),
+            500,
+            30),
+        new AnalysisVisualConfig(false, false, false, true),
+        Instant.EPOCH,
+        Instant.EPOCH);
+
+    service.syncCurrent(analysis);
+
+    verify(maintenance).clearRelationsByEvidence(AnalysisLineageService.EVIDENCE_SOURCE_TYPE, "7");
+
+    ArgumentCaptor<LineageService.RegisterAssetCommand> assets =
+        ArgumentCaptor.forClass(LineageService.RegisterAssetCommand.class);
+    verify(lineage, org.mockito.Mockito.atLeast(4)).registerAsset(assets.capture());
+    assertTrue(assets.getAllValues().stream().anyMatch(command ->
+        "chart:analysis:7".equals(command.assetKey()) && command.assetType() == LineageAssetType.CHART));
+    assertTrue(assets.getAllValues().stream().anyMatch(command ->
+        "dataset:21".equals(command.assetKey()) && command.assetType() == LineageAssetType.DATASET));
+    assertTrue(assets.getAllValues().stream().anyMatch(command ->
+        "dataset-field:21:region".equals(command.assetKey())
+            && command.assetType() == LineageAssetType.DATASET_FIELD));
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineage, org.mockito.Mockito.times(3)).registerRelation(relations.capture());
+    assertTrue(relations.getAllValues().stream().allMatch(relation ->
+        relation.relationType() == LineageRelationType.CONSUMES));
+
+    LineageService.RegisterRelationCommand region = relations.getAllValues().stream()
+        .filter(relation -> relation.properties() != null
+            && "region".equals(relation.properties().path("fieldId").asText()))
+        .findFirst()
+        .orElseThrow();
+    List<String> roles = new java.util.ArrayList<>();
+    region.properties().path("usageRoles").forEach(node -> roles.add(node.asText()));
+    assertEquals(List.of("DIMENSION", "FILTER"), roles);
+
+    LineageService.RegisterRelationCommand amount = relations.getAllValues().stream()
+        .filter(relation -> relation.properties() != null
+            && "amount".equals(relation.properties().path("fieldId").asText()))
+        .findFirst()
+        .orElseThrow();
+    assertEquals("SUM", amount.properties().path("metricAggregations").get(0).asText());
+  }
+
+  @Test
+  void clearOnlyRemovesAnalysisScopedEvidence() {
+    LineageMaintenanceService maintenance = mock(LineageMaintenanceService.class);
+    AnalysisLineageService service = new AnalysisLineageService(
+        mock(LineageService.class), maintenance, new ObjectMapper());
+
+    service.clear(19L);
+
+    verify(maintenance).clearRelationsByEvidence(
+        AnalysisLineageService.EVIDENCE_SOURCE_TYPE, "19");
+  }
+
+  private static LineageAsset asset(
+      long id,
+      LineageService.RegisterAssetCommand command) {
+    return new LineageAsset(
+        id,
+        command.assetKey(),
+        command.assetType(),
+        command.name(),
+        command.sourceType(),
+        command.sourceId(),
+        command.parentAssetId(),
+        command.dataSourceId(),
+        command.databaseName(),
+        command.schemaName(),
+        command.tableName(),
+        command.columnName(),
+        command.properties(),
+        Instant.EPOCH,
+        Instant.EPOCH);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/pom.xml
+++ b/yak-ops-business/yak-ops-business-dashboard/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.yak.ops</groupId>
@@ -16,6 +16,7 @@
         <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-common</artifactId></dependency>
         <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-datasource</artifactId></dependency>
         <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-analysis</artifactId><version>${project.version}</version></dependency>
+        <dependency><groupId>io.yak.ops</groupId><artifactId>yak-ops-business-lineage</artifactId><version>${project.version}</version></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-validation</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardLineageRefreshListener.java
@@ -1,0 +1,128 @@
+package io.yak.ops.business.dashboard;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** Refreshes effective Dashboard lineage only after the dashboard transaction has committed. */
+@Component
+class DashboardLineageRefreshListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DashboardLineageRefreshListener.class);
+
+  private final DashboardService dashboardService;
+  private final LineageOperations lineageOperations;
+
+  @Autowired
+  DashboardLineageRefreshListener(
+      DashboardService dashboardService,
+      DashboardLineageTransactionRunner transactionRunner) {
+    this(dashboardService, new LineageOperations() {
+      @Override
+      public void syncVersion(
+          DashboardAsset dashboard,
+          DashboardVersion version,
+          List<DashboardWidgetSnapshot> widgets,
+          boolean published) {
+        transactionRunner.syncVersion(dashboard, version, widgets, published);
+      }
+
+      @Override
+      public void clear(long dashboardId) {
+        transactionRunner.clear(dashboardId);
+      }
+    });
+  }
+
+  /** Keeps focused tests source-compatible while production uses the REQUIRES_NEW runner. */
+  DashboardLineageRefreshListener(
+      DashboardService dashboardService,
+      DashboardLineageService lineageService) {
+    this(dashboardService, new LineageOperations() {
+      @Override
+      public void syncVersion(
+          DashboardAsset dashboard,
+          DashboardVersion version,
+          List<DashboardWidgetSnapshot> widgets,
+          boolean published) {
+        lineageService.syncVersion(dashboard, version, widgets, published);
+      }
+
+      @Override
+      public void clear(long dashboardId) {
+        lineageService.clear(dashboardId);
+      }
+    });
+  }
+
+  private DashboardLineageRefreshListener(
+      DashboardService dashboardService,
+      LineageOperations lineageOperations) {
+    this.dashboardService = dashboardService;
+    this.lineageOperations = lineageOperations;
+  }
+
+  @TransactionalEventListener(
+      phase = TransactionPhase.AFTER_COMMIT,
+      fallbackExecution = true)
+  public void refresh(DashboardLineageRefreshRequested event) {
+    if (event == null || event.dashboardId() <= 0L) return;
+    try {
+      if (event.deleted()) {
+        lineageOperations.clear(event.dashboardId());
+        return;
+      }
+
+      DashboardDetail current = dashboardService.get(event.dashboardId());
+      DashboardAsset dashboard = current.dashboard();
+      if (dashboard.publishedVersionId() != null) {
+        DashboardVersionDetail published = dashboardService.published(event.dashboardId());
+        lineageOperations.syncVersion(
+            dashboard,
+            published.version(),
+            published.widgets(),
+            true);
+      } else {
+        lineageOperations.syncVersion(
+            dashboard,
+            current.currentVersion(),
+            current.widgets(),
+            false);
+      }
+    } catch (RuntimeException exception) {
+      LOGGER.warn(
+          "Dashboard lineage refresh failed after commit for dashboard {}: {}",
+          event.dashboardId(),
+          exception.getMessage(),
+          exception);
+    }
+  }
+
+  private interface LineageOperations {
+    void syncVersion(
+        DashboardAsset dashboard,
+        DashboardVersion version,
+        List<DashboardWidgetSnapshot> widgets,
+        boolean published);
+
+    void clear(long dashboardId);
+  }
+}
+
+record DashboardLineageRefreshRequested(long dashboardId, boolean deleted) {
+  DashboardLineageRefreshRequested {
+    if (dashboardId <= 0L) throw new IllegalArgumentException("dashboardId 必须大于 0");
+  }
+
+  static DashboardLineageRefreshRequested refresh(long dashboardId) {
+    return new DashboardLineageRefreshRequested(dashboardId, false);
+  }
+
+  static DashboardLineageRefreshRequested deleted(long dashboardId) {
+    return new DashboardLineageRefreshRequested(dashboardId, true);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardLineageService.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardLineageService.java
@@ -1,0 +1,444 @@
+package io.yak.ops.business.dashboard;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+/** Builds reusable/inline Chart -> Dashboard lineage from one authoritative Dashboard snapshot. */
+@Service
+class DashboardLineageService {
+
+  static final String EVIDENCE_SOURCE_TYPE = "DASHBOARD_BINDING";
+
+  private final LineageService lineageService;
+  private final LineageMaintenanceService maintenanceService;
+  private final ObjectMapper objectMapper;
+
+  DashboardLineageService(
+      LineageService lineageService,
+      LineageMaintenanceService maintenanceService,
+      ObjectMapper objectMapper) {
+    this.lineageService = lineageService;
+    this.maintenanceService = maintenanceService;
+    this.objectMapper = objectMapper;
+  }
+
+  void syncVersion(
+      DashboardAsset dashboard,
+      DashboardVersion version,
+      List<DashboardWidgetSnapshot> widgets,
+      boolean published) {
+    if (dashboard == null || dashboard.id() <= 0L) return;
+
+    String evidenceId = String.valueOf(dashboard.id());
+    maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
+
+    LineageAsset dashboardAsset = registerDashboardAsset(dashboard, version, widgets, published);
+    if (version == null) return;
+
+    List<DashboardWidgetSnapshot> source = widgets == null ? List.of() : widgets;
+    Instant observedAt = version.createTime() == null ? Instant.now() : version.createTime();
+    for (DashboardWidgetSnapshot widget : source) {
+      if (widget == null || widget.widgetKey() == null || widget.widgetKey().isBlank()) continue;
+      if (widget.analysisId() != null && widget.analysisId() > 0L) {
+        LineageAsset chart = resolveAnalysisChart(widget.analysisId(), widget.title());
+        registerContainment(
+            chart,
+            dashboardAsset,
+            dashboard,
+            version,
+            widget,
+            published,
+            "LINKED_ANALYSIS",
+            observedAt);
+        continue;
+      }
+      if (widget.inlineAnalysis() != null) {
+        InlineBinding inline = parseInline(widget.inlineAnalysis());
+        LineageAsset chart = registerInlineChart(
+            dashboardAsset, dashboard, version, widget, inline, published);
+        registerContainment(
+            chart,
+            dashboardAsset,
+            dashboard,
+            version,
+            widget,
+            published,
+            "INLINE_ANALYSIS",
+            observedAt);
+        registerInlineUpstream(chart, dashboard, version, widget, inline, published, observedAt);
+      }
+    }
+  }
+
+  void clear(long dashboardId) {
+    if (dashboardId <= 0L) return;
+    maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, String.valueOf(dashboardId));
+  }
+
+  private LineageAsset registerDashboardAsset(
+      DashboardAsset dashboard,
+      DashboardVersion version,
+      List<DashboardWidgetSnapshot> widgets,
+      boolean published) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    if (dashboard.currentVersionId() != null) {
+      properties.put("currentVersionId", String.valueOf(dashboard.currentVersionId()));
+      properties.put("currentVersionNo", dashboard.currentVersionNo());
+    }
+    if (dashboard.publishedVersionId() != null) {
+      properties.put("publishedVersionId", String.valueOf(dashboard.publishedVersionId()));
+      properties.put("publishedVersionNo", dashboard.publishedVersionNo());
+    }
+    if (version != null) {
+      properties.put("effectiveVersionId", String.valueOf(version.id()));
+      properties.put("effectiveVersionNo", version.versionNo());
+    }
+    properties.put("effectiveSnapshot", published ? "PUBLISHED" : "DRAFT");
+    properties.put("widgetCount", widgets == null ? 0 : widgets.size());
+
+    String name = version != null && version.name() != null && !version.name().isBlank()
+        ? version.name()
+        : dashboard.name();
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        dashboardAssetKey(dashboard.id()),
+        LineageAssetType.DASHBOARD,
+        name,
+        "DASHBOARD",
+        String.valueOf(dashboard.id()),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        properties));
+  }
+
+  private LineageAsset resolveAnalysisChart(long analysisId, String title) {
+    String key = analysisChartAssetKey(analysisId);
+    try {
+      return lineageService.getAssetByKey(key);
+    } catch (IllegalArgumentException missing) {
+      ObjectNode properties = objectMapper.createObjectNode();
+      properties.put("analysisId", String.valueOf(analysisId));
+      properties.put("lineageRegistration", "DASHBOARD_FALLBACK");
+      properties.put("bindingMode", "REUSABLE_ANALYSIS");
+      return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+          key,
+          LineageAssetType.CHART,
+          title == null || title.isBlank() ? "analysis:" + analysisId : title,
+          "ANALYSIS",
+          String.valueOf(analysisId),
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          properties));
+    }
+  }
+
+  private LineageAsset registerInlineChart(
+      LineageAsset dashboardAsset,
+      DashboardAsset dashboard,
+      DashboardVersion version,
+      DashboardWidgetSnapshot widget,
+      InlineBinding inline,
+      boolean published) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("dashboardId", String.valueOf(dashboard.id()));
+    properties.put("dashboardVersionId", String.valueOf(version.id()));
+    properties.put("dashboardVersionNo", version.versionNo());
+    properties.put("widgetKey", widget.widgetKey());
+    properties.put("bindingMode", "INLINE_ANALYSIS");
+    properties.put("effectiveSnapshot", published ? "PUBLISHED" : "DRAFT");
+    properties.put("lineageParseStatus", inline.parseStatus());
+    if (inline.datasetId() != null) properties.put("datasetId", String.valueOf(inline.datasetId()));
+    if (inline.chartType() != null) properties.put("chartType", inline.chartType());
+    properties.put("referencedFieldCount", inline.fieldUsages().size());
+
+    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+        inlineChartAssetKey(dashboard.id(), widget.widgetKey()),
+        LineageAssetType.CHART,
+        widget.title() == null || widget.title().isBlank() ? widget.widgetKey() : widget.title(),
+        "DASHBOARD_INLINE_ANALYSIS",
+        dashboard.id() + ":" + widget.widgetKey(),
+        dashboardAsset.id(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        properties));
+  }
+
+  private void registerContainment(
+      LineageAsset chart,
+      LineageAsset dashboard,
+      DashboardAsset dashboardSource,
+      DashboardVersion version,
+      DashboardWidgetSnapshot widget,
+      boolean published,
+      String bindingMode,
+      Instant observedAt) {
+    ObjectNode properties = versionProperties(dashboardSource, version, published);
+    properties.put("lineageLevel", "CHART");
+    properties.put("widgetKey", widget.widgetKey());
+    properties.put("bindingMode", bindingMode);
+    if (widget.title() != null) properties.put("widgetTitle", widget.title());
+    if (widget.analysisId() != null) properties.put("analysisId", String.valueOf(widget.analysisId()));
+    properties.put("gridX", widget.x());
+    properties.put("gridY", widget.y());
+    properties.put("gridW", widget.w());
+    properties.put("gridH", widget.h());
+
+    lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+        chart.id(),
+        dashboard.id(),
+        LineageRelationType.CONTAINS,
+        EVIDENCE_SOURCE_TYPE,
+        String.valueOf(dashboardSource.id()),
+        null,
+        BigDecimal.ONE,
+        relationVersion(version, widget.widgetKey(), "contains"),
+        observedAt,
+        properties));
+  }
+
+  private void registerInlineUpstream(
+      LineageAsset chart,
+      DashboardAsset dashboard,
+      DashboardVersion version,
+      DashboardWidgetSnapshot widget,
+      InlineBinding inline,
+      boolean published,
+      Instant observedAt) {
+    if (inline.datasetId() == null || inline.datasetId() <= 0L) return;
+
+    LineageAsset dataset = resolveDatasetAsset(inline.datasetId());
+    ObjectNode datasetProperties = versionProperties(dashboard, version, published);
+    datasetProperties.put("lineageLevel", "DATASET");
+    datasetProperties.put("widgetKey", widget.widgetKey());
+    datasetProperties.put("bindingMode", "INLINE_ANALYSIS");
+    datasetProperties.put("datasetId", String.valueOf(inline.datasetId()));
+    lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+        dataset.id(),
+        chart.id(),
+        LineageRelationType.CONSUMES,
+        EVIDENCE_SOURCE_TYPE,
+        String.valueOf(dashboard.id()),
+        null,
+        BigDecimal.ONE,
+        relationVersion(version, widget.widgetKey(), "dataset"),
+        observedAt,
+        datasetProperties));
+
+    int index = 0;
+    for (Map.Entry<String, Set<String>> entry : inline.fieldUsages().entrySet()) {
+      index++;
+      LineageAsset field = resolveDatasetFieldAsset(dataset, inline.datasetId(), entry.getKey());
+      ObjectNode properties = versionProperties(dashboard, version, published);
+      properties.put("lineageLevel", "DATASET_FIELD");
+      properties.put("widgetKey", widget.widgetKey());
+      properties.put("bindingMode", "INLINE_ANALYSIS");
+      properties.put("datasetId", String.valueOf(inline.datasetId()));
+      properties.put("fieldId", entry.getKey());
+      ArrayNode roles = properties.putArray("usageRoles");
+      entry.getValue().forEach(roles::add);
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(
+          field.id(),
+          chart.id(),
+          LineageRelationType.CONSUMES,
+          EVIDENCE_SOURCE_TYPE,
+          String.valueOf(dashboard.id()),
+          null,
+          BigDecimal.ONE,
+          relationVersion(version, widget.widgetKey(), "field:" + index),
+          observedAt,
+          properties));
+    }
+  }
+
+  private LineageAsset resolveDatasetAsset(long datasetId) {
+    String key = datasetAssetKey(datasetId);
+    try {
+      return lineageService.getAssetByKey(key);
+    } catch (IllegalArgumentException missing) {
+      ObjectNode properties = objectMapper.createObjectNode();
+      properties.put("datasetId", String.valueOf(datasetId));
+      properties.put("lineageRegistration", "DASHBOARD_INLINE_FALLBACK");
+      return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+          key,
+          LineageAssetType.DATASET,
+          key,
+          "DATASET",
+          String.valueOf(datasetId),
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          properties));
+    }
+  }
+
+  private LineageAsset resolveDatasetFieldAsset(
+      LineageAsset dataset,
+      long datasetId,
+      String fieldId) {
+    String key = datasetFieldAssetKey(datasetId, fieldId);
+    try {
+      return lineageService.getAssetByKey(key);
+    } catch (IllegalArgumentException missing) {
+      ObjectNode properties = objectMapper.createObjectNode();
+      properties.put("datasetId", String.valueOf(datasetId));
+      properties.put("fieldId", fieldId);
+      properties.put("lineageRegistration", "DASHBOARD_INLINE_FALLBACK");
+      return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+          key,
+          LineageAssetType.DATASET_FIELD,
+          fieldId,
+          "DATASET",
+          datasetId + ":" + fieldId,
+          dataset.id(),
+          null,
+          null,
+          null,
+          null,
+          null,
+          properties));
+    }
+  }
+
+  private InlineBinding parseInline(Object value) {
+    try {
+      JsonNode root = objectMapper.valueToTree(value);
+      if (root == null || !root.isObject()) {
+        return new InlineBinding(null, null, Map.of(), "UNRESOLVED");
+      }
+      Long datasetId = positiveLong(root.get("datasetId"));
+      String chartType = text(root.get("chartType"));
+      JsonNode query = root.has("querySpec") && root.get("querySpec").isObject()
+          ? root.get("querySpec")
+          : root;
+
+      Map<String, Set<String>> usages = new LinkedHashMap<>();
+      addStringArray(usages, query.get("dimensions"), "DIMENSION");
+      addFieldBindings(usages, query.get("metrics"), "METRIC");
+      addFieldBindings(usages, query.get("filters"), "FILTER");
+      addFieldBindings(usages, query.get("sorts"), "SORT");
+
+      String status;
+      if (datasetId == null) status = "UNRESOLVED";
+      else if (usages.isEmpty()) status = "PARTIAL";
+      else status = "SUCCESS";
+      return new InlineBinding(datasetId, chartType, immutableUsages(usages), status);
+    } catch (RuntimeException exception) {
+      return new InlineBinding(null, null, Map.of(), "UNRESOLVED");
+    }
+  }
+
+  private Map<String, Set<String>> immutableUsages(Map<String, Set<String>> usages) {
+    Map<String, Set<String>> result = new LinkedHashMap<>();
+    usages.forEach((fieldId, roles) -> result.put(fieldId, Set.copyOf(roles)));
+    return Map.copyOf(result);
+  }
+
+  private void addStringArray(Map<String, Set<String>> usages, JsonNode array, String role) {
+    if (array == null || !array.isArray()) return;
+    for (JsonNode item : array) {
+      String fieldId = text(item);
+      if (fieldId != null) usage(usages, fieldId).add(role);
+    }
+  }
+
+  private void addFieldBindings(Map<String, Set<String>> usages, JsonNode array, String role) {
+    if (array == null || !array.isArray()) return;
+    for (JsonNode item : array) {
+      if (item == null || !item.isObject()) continue;
+      String fieldId = text(item.get("fieldId"));
+      if (fieldId != null) usage(usages, fieldId).add(role);
+    }
+  }
+
+  private Set<String> usage(Map<String, Set<String>> usages, String fieldId) {
+    return usages.computeIfAbsent(fieldId, ignored -> new LinkedHashSet<>());
+  }
+
+  private Long positiveLong(JsonNode value) {
+    if (value == null || value.isNull()) return null;
+    try {
+      long parsed = value.isNumber() ? value.longValue() : Long.parseLong(value.asText().trim());
+      return parsed > 0L ? parsed : null;
+    } catch (RuntimeException exception) {
+      return null;
+    }
+  }
+
+  private String text(JsonNode value) {
+    if (value == null || value.isNull() || !value.isValueNode()) return null;
+    String text = value.asText();
+    return text == null || text.isBlank() ? null : text.trim();
+  }
+
+  private ObjectNode versionProperties(
+      DashboardAsset dashboard,
+      DashboardVersion version,
+      boolean published) {
+    ObjectNode properties = objectMapper.createObjectNode();
+    properties.put("dashboardId", String.valueOf(dashboard.id()));
+    properties.put("dashboardVersionId", String.valueOf(version.id()));
+    properties.put("dashboardVersionNo", version.versionNo());
+    properties.put("effectiveSnapshot", published ? "PUBLISHED" : "DRAFT");
+    return properties;
+  }
+
+  static String dashboardAssetKey(long dashboardId) {
+    return "dashboard:" + dashboardId;
+  }
+
+  static String analysisChartAssetKey(long analysisId) {
+    return "chart:analysis:" + analysisId;
+  }
+
+  static String inlineChartAssetKey(long dashboardId, String widgetKey) {
+    return "chart:dashboard:" + dashboardId + ":widget:" + widgetKey;
+  }
+
+  static String datasetAssetKey(long datasetId) {
+    return "dataset:" + datasetId;
+  }
+
+  static String datasetFieldAssetKey(long datasetId, String fieldId) {
+    return "dataset-field:" + datasetId + ":" + fieldId;
+  }
+
+  private String relationVersion(DashboardVersion version, String widgetKey, String suffix) {
+    String value = "dashboard-v" + version.versionNo() + ":" + widgetKey + ":" + suffix;
+    return value.length() <= 128 ? value : value.substring(0, 128);
+  }
+
+  private record InlineBinding(
+      Long datasetId,
+      String chartType,
+      Map<String, Set<String>> fieldUsages,
+      String parseStatus) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardLineageTransactionRunner.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardLineageTransactionRunner.java
@@ -1,0 +1,35 @@
+package io.yak.ops.business.dashboard;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Starts an independent transaction for derived Dashboard lineage after the business commit. */
+@Service
+public class DashboardLineageTransactionRunner {
+
+  private final DashboardLineageService lineageService;
+
+  public DashboardLineageTransactionRunner(DashboardLineageService lineageService) {
+    this.lineageService = lineageService;
+  }
+
+  @Transactional(
+      transactionManager = "yakBusinessTransactionManager",
+      propagation = Propagation.REQUIRES_NEW)
+  public void syncVersion(
+      DashboardAsset dashboard,
+      DashboardVersion version,
+      List<DashboardWidgetSnapshot> widgets,
+      boolean published) {
+    lineageService.syncVersion(dashboard, version, widgets, published);
+  }
+
+  @Transactional(
+      transactionManager = "yakBusinessTransactionManager",
+      propagation = Propagation.REQUIRES_NEW)
+  public void clear(long dashboardId) {
+    lineageService.clear(dashboardId);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/JdbcDashboardRepository.java
@@ -12,7 +12,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -31,12 +33,23 @@ class JdbcDashboardRepository implements DashboardRepository {
 
   private final JdbcTemplate jdbcTemplate;
   private final ObjectMapper objectMapper;
+  private final ApplicationEventPublisher eventPublisher;
 
+  @Autowired
   JdbcDashboardRepository(
       @Qualifier("yakBusinessDataSource") DataSource dataSource,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      ApplicationEventPublisher eventPublisher) {
     this.jdbcTemplate = new JdbcTemplate(dataSource);
     this.objectMapper = objectMapper;
+    this.eventPublisher = eventPublisher;
+  }
+
+  /** Keeps focused repository tests source-compatible without a Spring event publisher. */
+  JdbcDashboardRepository(DataSource dataSource, ObjectMapper objectMapper) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+    this.eventPublisher = null;
   }
 
   @Override
@@ -140,6 +153,7 @@ class JdbcDashboardRepository implements DashboardRepository {
         "UPDATE yak_dashboard SET current_version_id = ?, current_version_no = ?, name = ?, description = ?, update_time = NOW(6) WHERE id = ?",
         versionId, versionNo, name, description, dashboardId);
     if (updated != 1) throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
+    requestLineageRefresh(DashboardLineageRefreshRequested.refresh(dashboardId));
   }
 
   @Override
@@ -148,6 +162,7 @@ class JdbcDashboardRepository implements DashboardRepository {
         "UPDATE yak_dashboard SET published_version_id = ?, published_version_no = ?, published_time = NOW(6), update_time = NOW(6) WHERE id = ?",
         versionId, versionNo, dashboardId);
     if (updated != 1) throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
+    requestLineageRefresh(DashboardLineageRefreshRequested.refresh(dashboardId));
   }
 
   @Override
@@ -243,6 +258,11 @@ class JdbcDashboardRepository implements DashboardRepository {
   public void deleteDashboard(long dashboardId) {
     int deleted = jdbcTemplate.update("DELETE FROM yak_dashboard WHERE id = ?", dashboardId);
     if (deleted != 1) throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
+    requestLineageRefresh(DashboardLineageRefreshRequested.deleted(dashboardId));
+  }
+
+  private void requestLineageRefresh(DashboardLineageRefreshRequested event) {
+    if (eventPublisher != null) eventPublisher.publishEvent(event);
   }
 
   private static DashboardAsset mapDashboard(ResultSet rs, int rowNum) throws SQLException {

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardLineageRefreshListenerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardLineageRefreshListenerTest.java
@@ -1,0 +1,93 @@
+package io.yak.ops.business.dashboard;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DashboardLineageRefreshListenerTest {
+
+  @Test
+  void publishedDashboardUsesPublishedSnapshotInsteadOfNewerDraft() {
+    DashboardService dashboardService = mock(DashboardService.class);
+    DashboardLineageService lineageService = mock(DashboardLineageService.class);
+    DashboardLineageRefreshListener listener =
+        new DashboardLineageRefreshListener(dashboardService, lineageService);
+
+    DashboardAsset dashboard = new DashboardAsset(
+        7L, "Draft V2", null, 102L, 2, 101L, 1, Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
+    DashboardVersion draft = new DashboardVersion(
+        102L, 7L, 2, "Draft V2", null, null, Instant.EPOCH);
+    DashboardVersion published = new DashboardVersion(
+        101L, 7L, 1, "Published V1", null, null, Instant.EPOCH);
+    DashboardWidgetSnapshot draftWidget = widget(2L, 102L, "draft", 22L);
+    DashboardWidgetSnapshot publishedWidget = widget(1L, 101L, "live", 11L);
+
+    when(dashboardService.get(7L)).thenReturn(new DashboardDetail(
+        dashboard, draft, List.of(draft, published), List.of(draftWidget), List.of(), List.of()));
+    when(dashboardService.published(7L)).thenReturn(new DashboardVersionDetail(
+        dashboard, published, List.of(publishedWidget), List.of(), List.of()));
+
+    listener.refresh(DashboardLineageRefreshRequested.refresh(7L));
+
+    verify(lineageService).syncVersion(
+        dashboard, published, List.of(publishedWidget), true);
+  }
+
+  @Test
+  void unpublishedDashboardUsesCurrentDraft() {
+    DashboardService dashboardService = mock(DashboardService.class);
+    DashboardLineageService lineageService = mock(DashboardLineageService.class);
+    DashboardLineageRefreshListener listener =
+        new DashboardLineageRefreshListener(dashboardService, lineageService);
+
+    DashboardAsset dashboard = new DashboardAsset(
+        7L, "Draft", null, 102L, 2, null, 0, null, Instant.EPOCH, Instant.EPOCH);
+    DashboardVersion draft = new DashboardVersion(
+        102L, 7L, 2, "Draft", null, null, Instant.EPOCH);
+    DashboardWidgetSnapshot widget = widget(2L, 102L, "draft", 22L);
+    when(dashboardService.get(7L)).thenReturn(new DashboardDetail(
+        dashboard, draft, List.of(draft), List.of(widget), List.of(), List.of()));
+
+    listener.refresh(DashboardLineageRefreshRequested.refresh(7L));
+
+    verify(lineageService).syncVersion(dashboard, draft, List.of(widget), false);
+  }
+
+  @Test
+  void lineageFailureNeverEscapesCommittedDashboardMutation() {
+    DashboardService dashboardService = mock(DashboardService.class);
+    DashboardLineageService lineageService = mock(DashboardLineageService.class);
+    DashboardLineageRefreshListener listener =
+        new DashboardLineageRefreshListener(dashboardService, lineageService);
+    when(dashboardService.get(7L)).thenThrow(new IllegalStateException("lineage unavailable"));
+
+    assertDoesNotThrow(() -> listener.refresh(DashboardLineageRefreshRequested.refresh(7L)));
+  }
+
+  @Test
+  void deleteClearsDashboardScopedEvidence() {
+    DashboardService dashboardService = mock(DashboardService.class);
+    DashboardLineageService lineageService = mock(DashboardLineageService.class);
+    DashboardLineageRefreshListener listener =
+        new DashboardLineageRefreshListener(dashboardService, lineageService);
+
+    listener.refresh(DashboardLineageRefreshRequested.deleted(7L));
+
+    verify(lineageService).clear(7L);
+  }
+
+  private static DashboardWidgetSnapshot widget(
+      long id,
+      long versionId,
+      String key,
+      long analysisId) {
+    return new DashboardWidgetSnapshot(
+        id, versionId, key, analysisId, key, null,
+        0, 0, 8, 6, null, null, 1);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/DashboardLineageServiceTest.java
@@ -1,0 +1,199 @@
+package io.yak.ops.business.dashboard;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.lineage.LineageAsset;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageMaintenanceService;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.LineageService;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DashboardLineageServiceTest {
+
+  @Test
+  void syncBuildsLinkedAndInlineChartLineageAndKeepsRepeatedWidgetsDistinct() {
+    LineageService lineage = mock(LineageService.class);
+    LineageMaintenanceService maintenance = mock(LineageMaintenanceService.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    when(lineage.getAssetByKey(anyString())).thenAnswer(invocation -> {
+      String key = invocation.getArgument(0);
+      return switch (key) {
+        case "chart:analysis:11" -> asset(201L, key, LineageAssetType.CHART, null);
+        case "dataset:22" -> asset(202L, key, LineageAssetType.DATASET, null);
+        case "dataset-field:22:region" -> asset(203L, key, LineageAssetType.DATASET_FIELD, 202L);
+        case "dataset-field:22:amount" -> asset(204L, key, LineageAssetType.DATASET_FIELD, 202L);
+        default -> throw new IllegalArgumentException("missing: " + key);
+      };
+    });
+    when(lineage.registerAsset(any())).thenAnswer(invocation -> {
+      LineageService.RegisterAssetCommand command = invocation.getArgument(0);
+      long id = command.assetKey().startsWith("dashboard:") ? 300L : 301L;
+      return new LineageAsset(
+          id,
+          command.assetKey(),
+          command.assetType(),
+          command.name(),
+          command.sourceType(),
+          command.sourceId(),
+          command.parentAssetId(),
+          command.dataSourceId(),
+          command.databaseName(),
+          command.schemaName(),
+          command.tableName(),
+          command.columnName(),
+          command.properties(),
+          Instant.EPOCH,
+          Instant.EPOCH);
+    });
+
+    DashboardLineageService service = new DashboardLineageService(lineage, maintenance, objectMapper);
+    DashboardAsset dashboard = dashboard(1L, 102L, 2, 101L, 1);
+    DashboardVersion version = new DashboardVersion(
+        101L, 1L, 1, "销售驾驶舱", null, null, Instant.EPOCH);
+    Object inline = Map.of(
+        "datasetId", "22",
+        "chartType", "BAR",
+        "querySpec", Map.of(
+            "dimensions", List.of("region"),
+            "metrics", List.of(Map.of("fieldId", "amount", "aggregation", "SUM")),
+            "filters", List.of(Map.of("fieldId", "region", "operator", "EQ")),
+            "sorts", List.of()));
+    List<DashboardWidgetSnapshot> widgets = List.of(
+        widget(1L, 101L, "w1", 11L, "区域销售", null, 1),
+        widget(2L, 101L, "w2", 11L, "区域销售副本", null, 2),
+        widget(3L, 101L, "inline-gmv", null, "GMV", inline, 3));
+
+    service.syncVersion(dashboard, version, widgets, true);
+
+    verify(maintenance).clearRelationsByEvidence(DashboardLineageService.EVIDENCE_SOURCE_TYPE, "1");
+
+    ArgumentCaptor<LineageService.RegisterAssetCommand> assets =
+        ArgumentCaptor.forClass(LineageService.RegisterAssetCommand.class);
+    verify(lineage, org.mockito.Mockito.times(2)).registerAsset(assets.capture());
+    LineageService.RegisterAssetCommand dashboardAsset = assets.getAllValues().stream()
+        .filter(command -> command.assetType() == LineageAssetType.DASHBOARD)
+        .findFirst().orElseThrow();
+    LineageService.RegisterAssetCommand inlineAsset = assets.getAllValues().stream()
+        .filter(command -> "chart:dashboard:1:widget:inline-gmv".equals(command.assetKey()))
+        .findFirst().orElseThrow();
+    assertEquals("dashboard:1", dashboardAsset.assetKey());
+    assertEquals(300L, inlineAsset.parentAssetId());
+    assertEquals("SUCCESS", inlineAsset.properties().path("lineageParseStatus").asText());
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineage, org.mockito.Mockito.times(6)).registerRelation(relations.capture());
+    long containsCount = relations.getAllValues().stream()
+        .filter(relation -> relation.relationType() == LineageRelationType.CONTAINS)
+        .count();
+    long consumesCount = relations.getAllValues().stream()
+        .filter(relation -> relation.relationType() == LineageRelationType.CONSUMES)
+        .count();
+    assertEquals(3L, containsCount);
+    assertEquals(3L, consumesCount);
+
+    List<String> linkedVersions = relations.getAllValues().stream()
+        .filter(relation -> relation.relationType() == LineageRelationType.CONTAINS)
+        .filter(relation -> "LINKED_ANALYSIS".equals(
+            relation.properties().path("bindingMode").asText()))
+        .map(LineageService.RegisterRelationCommand::version)
+        .toList();
+    assertEquals(2, linkedVersions.size());
+    assertTrue(linkedVersions.stream().anyMatch(value -> value.contains(":w1:")));
+    assertTrue(linkedVersions.stream().anyMatch(value -> value.contains(":w2:")));
+
+    LineageService.RegisterRelationCommand region = relations.getAllValues().stream()
+        .filter(relation -> "region".equals(relation.properties().path("fieldId").asText()))
+        .findFirst().orElseThrow();
+    List<String> roles = new ArrayList<>();
+    region.properties().path("usageRoles").forEach(node -> roles.add(node.asText()));
+    assertEquals(Set.of("DIMENSION", "FILTER"), Set.copyOf(roles));
+  }
+
+  @Test
+  void unresolvedInlineStillCreatesChartContainmentWithoutInventingDataset() {
+    LineageService lineage = mock(LineageService.class);
+    LineageMaintenanceService maintenance = mock(LineageMaintenanceService.class);
+    when(lineage.registerAsset(any())).thenAnswer(invocation -> {
+      LineageService.RegisterAssetCommand command = invocation.getArgument(0);
+      return new LineageAsset(
+          command.assetType() == LineageAssetType.DASHBOARD ? 10L : 11L,
+          command.assetKey(), command.assetType(), command.name(), command.sourceType(),
+          command.sourceId(), command.parentAssetId(), null, null, null, null, null,
+          command.properties(), Instant.EPOCH, Instant.EPOCH);
+    });
+    DashboardLineageService service = new DashboardLineageService(
+        lineage, maintenance, new ObjectMapper());
+    DashboardAsset dashboard = dashboard(1L, 101L, 1, null, 0);
+    DashboardVersion version = new DashboardVersion(
+        101L, 1L, 1, "D", null, null, Instant.EPOCH);
+
+    service.syncVersion(
+        dashboard,
+        version,
+        List.of(widget(1L, 101L, "w", null, "临时", Map.of("type", "bar"), 1)),
+        false);
+
+    ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
+        ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
+    verify(lineage, org.mockito.Mockito.times(1)).registerRelation(relations.capture());
+    assertEquals(LineageRelationType.CONTAINS, relations.getValue().relationType());
+  }
+
+  private static DashboardAsset dashboard(
+      long id,
+      Long currentVersionId,
+      int currentVersionNo,
+      Long publishedVersionId,
+      int publishedVersionNo) {
+    return new DashboardAsset(
+        id,
+        "D",
+        null,
+        currentVersionId,
+        currentVersionNo,
+        publishedVersionId,
+        publishedVersionNo,
+        publishedVersionId == null ? null : Instant.EPOCH,
+        Instant.EPOCH,
+        Instant.EPOCH);
+  }
+
+  private static DashboardWidgetSnapshot widget(
+      long id,
+      long versionId,
+      String key,
+      Long analysisId,
+      String title,
+      Object inline,
+      int sortOrder) {
+    return new DashboardWidgetSnapshot(
+        id, versionId, key, analysisId, title, inline,
+        0, sortOrder - 1, 8, 6, null, null, sortOrder);
+  }
+
+  private static LineageAsset asset(
+      long id,
+      String key,
+      LineageAssetType type,
+      Long parentId) {
+    return new LineageAsset(
+        id, key, type, key, "TEST", key, parentId,
+        null, null, null, null, null, null, Instant.EPOCH, Instant.EPOCH);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageRefreshListener.java
@@ -1,7 +1,9 @@
 package io.yak.ops.business.dataset;
 
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,13 +15,27 @@ class DatasetLineageRefreshListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(DatasetLineageRefreshListener.class);
 
   private final DatasetService datasetService;
-  private final DatasetLineageService lineageService;
+  private final Consumer<DatasetDetail> syncOperation;
 
+  @Autowired
+  DatasetLineageRefreshListener(
+      DatasetService datasetService,
+      DatasetLineageTransactionRunner transactionRunner) {
+    this(datasetService, transactionRunner::sync);
+  }
+
+  /** Keeps focused tests source-compatible while production uses the REQUIRES_NEW runner. */
   DatasetLineageRefreshListener(
       DatasetService datasetService,
       DatasetLineageService lineageService) {
+    this(datasetService, lineageService::syncCurrent);
+  }
+
+  private DatasetLineageRefreshListener(
+      DatasetService datasetService,
+      Consumer<DatasetDetail> syncOperation) {
     this.datasetService = datasetService;
-    this.lineageService = lineageService;
+    this.syncOperation = syncOperation;
   }
 
   @TransactionalEventListener(
@@ -28,7 +44,7 @@ class DatasetLineageRefreshListener {
   public void refresh(DatasetLineageRefreshRequested event) {
     if (event == null || event.datasetId() <= 0L) return;
     try {
-      lineageService.syncCurrent(datasetService.get(event.datasetId()));
+      syncOperation.accept(datasetService.get(event.datasetId()));
     } catch (RuntimeException exception) {
       // Lineage is derived metadata. A refresh failure must never turn a committed Dataset publish
       // into an apparent business failure for the caller.

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageTransactionRunner.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetLineageTransactionRunner.java
@@ -1,0 +1,23 @@
+package io.yak.ops.business.dataset;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Starts an independent transaction for derived Dataset lineage after the business commit. */
+@Service
+public class DatasetLineageTransactionRunner {
+
+  private final DatasetLineageService lineageService;
+
+  public DatasetLineageTransactionRunner(DatasetLineageService lineageService) {
+    this.lineageService = lineageService;
+  }
+
+  @Transactional(
+      transactionManager = "yakBusinessTransactionManager",
+      propagation = Propagation.REQUIRES_NEW)
+  public void sync(DatasetDetail detail) {
+    lineageService.syncCurrent(detail);
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
@@ -92,7 +92,8 @@ public class LineageService {
         .orElseThrow(() -> new IllegalArgumentException("血缘资产不存在：" + assetId));
   }
 
-  @Transactional(readOnly = true)
+  /** Missing-by-key is a normal fallback branch for derived metadata registration. */
+  @Transactional(readOnly = true, noRollbackFor = IllegalArgumentException.class)
   public LineageAsset getAssetByKey(String assetKey) {
     String normalized = required(assetKey, "assetKey", 512);
     return repository.findAssetByKey(normalized)


### PR DESCRIPTION
## 目标

继续 Yak Ops 血缘最后一段消费链路，把已经完成的 Dataset / DatasetField 血缘接到 Analysis（Chart）和 Dashboard：

```text
TABLE / COLUMN
      ↓
DATASET / DATASET_FIELD
      ↓
CHART (Analysis)
      ↓
DASHBOARD
```

本阶段不增加新的业务表，也不改前端；直接使用 Yak Ops 已有稳定业务 ID 和绑定关系生成 Lineage Asset / Relation。

## 1. Analysis 正式映射为 CHART Asset

当前 `AnalysisAsset` 本身就是可复用的图表定义，已经稳定保存：

```text
analysisId
datasetId
chartType
querySpec.dimensions
querySpec.metrics[].fieldId
querySpec.filters[].fieldId
querySpec.sorts[].fieldId
```

因此本阶段不额外发明 Chart 业务模型，直接映射：

```text
AnalysisAsset -> LineageAssetType.CHART
```

稳定 key：

```text
chart:analysis:{analysisId}
```

### Dataset -> Chart

```text
dataset:{datasetId}
    ↓ CONSUMES
chart:analysis:{analysisId}
```

### DatasetField -> Chart

Analysis `querySpec` 引用到的字段都会建立：

```text
dataset-field:{datasetId}:{fieldId}
    ↓ CONSUMES
chart:analysis:{analysisId}
```

关系 properties 保留字段用途：

```text
DIMENSION
METRIC
FILTER
SORT
```

同一个 fieldId 同时作为多个角色时只保留一个稳定关系，并合并 `usageRoles`。

Metric / Sort 的 aggregation 也保留在 evidence 中，例如：

```text
SUM
AVG
COUNT_DISTINCT
```

## 2. Analysis 血缘生命周期

新增独立 evidence scope：

```text
sourceType = ANALYSIS_BINDING
sourceId   = analysisId
```

Analysis：

```text
create
update
  ↓
AFTER_COMMIT
  ↓
重新读取已提交 Analysis
  ↓
清理旧 ANALYSIS_BINDING
  ↓
重建 Dataset / DatasetField -> Chart
```

删除 Analysis 时只清理对应 evidence，不影响其他资产关系。

## 3. Dashboard 映射为稳定 DASHBOARD Asset

稳定 key：

```text
dashboard:{dashboardId}
```

Widget 引用已有 `analysisId` 时：

```text
chart:analysis:{analysisId}
    ↓ CONTAINS
dashboard:{dashboardId}
```

关系保留：

```text
widgetKey
widgetTitle
gridX / gridY / gridW / gridH
DashboardVersion
```

## 4. 同一个 Analysis 在 Dashboard 出现多次不会被错误去重

Yak Ops 允许：

```text
Analysis A -> Widget w1
Analysis A -> Widget w2
```

虽然 source / target 相同，但这是两个真实的 Dashboard 组件实例。

因此 relation evidence version 包含 `widgetKey`：

```text
dashboard-v1:w1:contains
dashboard-v1:w2:contains
```

不会被 Relation 唯一键合并成一条。

## 5. Published Dashboard 是权威血缘

Dashboard 当前模型同时存在：

```text
currentVersionId    // 编辑草稿
publishedVersionId  // 读者可见版本
```

本阶段明确规则：

```text
如果已经发布：使用 published version 建血缘
如果从未发布：使用 current draft 建血缘
```

因此：

```text
Published V1
Current Draft V2
```

保存 V2 草稿不会提前改变线上影响分析；真正 `publish()` 后，Dashboard lineage 才切换到 V2。

这和 Dashboard 当前 reader-facing version 语义保持一致。

## 6. inlineAnalysis 也纳入血缘

Dashboard Widget 当前支持二选一：

```text
analysisId
inlineAnalysis
```

所以本阶段没有只处理 reusable Analysis。

每个 inline Widget 创建稳定匿名 Chart：

```text
chart:dashboard:{dashboardId}:widget:{widgetKey}
```

并建立：

```text
Inline Chart -> Dashboard / CONTAINS
```

### 可识别 inline schema

如果 inline JSON 明确包含：

```text
datasetId
querySpec.dimensions
querySpec.metrics[].fieldId
querySpec.filters[].fieldId
querySpec.sorts[].fieldId
```

则继续建立：

```text
Dataset -> Inline Chart / CONSUMES
DatasetField -> Inline Chart / CONSUMES
```

### 非标准 inline JSON

当前业务层只要求 `inlineAnalysis` 是 JSON Object，并没有统一强 schema。

因此不做危险猜测：

```text
无法明确 datasetId / fieldId
    ↓
仍创建 Inline Chart -> Dashboard
    ↓
不伪造 Dataset / DatasetField upstream
```

Chart properties 会记录：

```text
lineageParseStatus = SUCCESS / PARTIAL / UNRESOLVED
```

## 7. 不从 activeDataset / GlobalFilter / Interaction 猜血缘

当前 Dashboard 中还存在：

```text
activeDatasetId
globalFilters[].bindings[].fieldId
interactions[].sourceFieldId
```

但现有业务校验还没有提供足够的 Dataset/Widget 字段上下文，不能保证这些 fieldId 能唯一、安全地绑定到一个 DatasetField。

因此本阶段明确不把它们直接当血缘来源，避免生成错误影响链路。

等这些绑定具备明确 semantic validation 后再补。

## 8. Dashboard 当前关系会替换，不残留陈旧 Widget

Dashboard 使用独立 evidence scope：

```text
sourceType = DASHBOARD_BINDING
sourceId   = dashboardId
```

刷新时先：

```text
clearRelationsByEvidence(...)
```

再根据当前权威 snapshot 重建。

因此移除 Widget、替换 Analysis、发布新版本后不会继续残留旧 Dashboard relation。

## 9. AFTER_COMMIT 事务语义补强

这一轮自查时补了一个和 #566 Dataset lineage 相关的事务正确性问题。

目标语义应该是真正的：

```text
业务事务
  ↓ COMMIT
AFTER_COMMIT listener
  ↓
读取最终业务快照
  ↓
REQUIRES_NEW 派生血缘事务
  ↓
独立 COMMIT / ROLLBACK
```

而不是在 AFTER_COMMIT 中继续用普通 REQUIRED 写派生数据。

因此本 PR：

- Analysis lineage 使用独立 `REQUIRES_NEW`
- Dashboard lineage 通过 `DashboardLineageTransactionRunner` 使用 `REQUIRES_NEW`
- 上一阶段 Dataset lineage 也补成 `DatasetLineageTransactionRunner + REQUIRES_NEW`
- listener 仍捕获 RuntimeException，血缘失败不会让已提交业务请求表现成失败

此外，派生血缘经常需要：

```text
getAssetByKey
  ↓ missing
fallback registerAsset
```

“找不到资产”是正常 fallback 分支，所以 `getAssetByKey` 增加：

```java
noRollbackFor = IllegalArgumentException.class
```

避免正常 miss 把新派生事务错误标记为 rollback-only；真正写失败仍然会回滚。

## 10. Tests

### AnalysisLineageServiceTest

覆盖：

- stable `chart:analysis:{id}`
- Dataset -> Chart
- DatasetField -> Chart
- DIMENSION / METRIC / FILTER / SORT usage
- 同一 fieldId 多角色合并
- aggregation evidence
- Analysis evidence clear

### AnalysisLineageRefreshListenerTest

覆盖：

- AFTER_COMMIT 后读取最终 Analysis snapshot
- delete 清理 evidence
- lineage failure 不向业务调用传播

### DashboardLineageServiceTest

覆盖：

- linked Analysis -> Dashboard
- 同一个 Analysis 作为两个 Widget 时保留两条组件关系
- stable inline Chart key
- inline Chart parent Dashboard
- canonical inline Dataset / DatasetField upstream
- inline field role 合并
- 非标准 inline JSON 不伪造 Dataset upstream

### DashboardLineageRefreshListenerTest

覆盖：

- published V1 优先于 newer draft V2
- 未发布 Dashboard 使用 current draft
- delete 清理 evidence
- lineage failure 不传播

## 影响范围

当前分支相对最新 `main`：

```text
1 commit ahead
0 behind
16 files changed
```

涉及：

```text
yak-ops-business-lineage
  + expected missing lookup transaction semantics

yak-ops-business-dataset
  + AFTER_COMMIT REQUIRES_NEW runner fix

yak-ops-business-analysis
  + CHART lineage
  + lifecycle refresh
  + tests

yak-ops-business-dashboard
  + DASHBOARD / inline CHART lineage
  + published snapshot semantics
  + lifecycle refresh
  + tests
```

没有：

- Flyway migration
- DB schema change
- REST API change
- frontend change
- SQL parser change
- Runtime/OpenLineage event

## Validation

已完成：

- 基于 #566 合并后的 main，并在开发期间跟进 #567 后重新基于最新 main 构建
- compare：`1 ahead / 0 behind`
- 变更范围确认仅上述 16 个预期文件
- Analysis 当前真实模型核对：`analysisId + datasetId + querySpec(fieldId)`
- Dashboard current/published version 与 widget model 核对
- Relation 唯一键下重复 Widget evidence 设计核对
- Dataset / DatasetField / Chart / Dashboard stable asset key 对齐
- AFTER_COMMIT + REQUIRES_NEW 事务边界核对

当前执行环境没有 Yak Ops 本地工作区，且无法通过容器访问 GitHub 拉取仓库，所以不能在这里实际执行 Maven reactor；没有把静态检查冒充成 CI 通过。

建议合并前执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-dataset -am test
mvn -pl yak-ops-business/yak-ops-business-analysis -am test
mvn -pl yak-ops-business/yak-ops-business-dashboard -am test
mvn -pl yak-ops-boot -am package -DskipTests
```

## 下一阶段

这个 PR 合并后，Yak Ops 后端完整主链会形成：

```text
TABLE / COLUMN
      ↓
SQL_TASK
      ↓
DATASET / DATASET_FIELD
      ↓
CHART
      ↓
DASHBOARD
```

下一阶段建议正式进入前端 Lineage Graph + Impact Analysis：

- 当前资产居中
- upstream 左 / downstream 右
- 类型 / 深度过滤
- Table / Column 展开收起
- Relation evidence 侧边栏
- 下游影响摘要
- Dataset / Chart / Dashboard 一键跳转业务页面

前端保持 Yak Ops 现在的白底、浅灰边框、高密度、少阴影风格，不做花哨关系图。