### PR TITLE
feat(lineage): add graph and impact analysis

### DIFF
--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
@@ -10,8 +10,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import javax.sql.DataSource;
@@ -154,6 +156,32 @@ class JdbcLineageRepository implements LineageRepository {
     return jdbcTemplate.query(
         ASSET_COLUMNS + " WHERE asset_key = ? LIMIT 1", this::mapAsset, assetKey)
         .stream().findFirst();
+  }
+
+  @Override
+  public List<LineageAsset> searchAssets(String keyword, LineageAssetType assetType, int limit) {
+    StringBuilder sql = new StringBuilder(ASSET_COLUMNS).append(" WHERE 1 = 1");
+    List<Object> arguments = new ArrayList<>();
+
+    if (keyword != null && !keyword.isBlank()) {
+      String pattern = "%" + keyword.toLowerCase(Locale.ROOT) + "%";
+      sql.append(
+          " AND (LOWER(name) LIKE ? OR LOWER(asset_key) LIKE ?"
+              + " OR LOWER(COALESCE(table_name, '')) LIKE ?"
+              + " OR LOWER(COALESCE(column_name, '')) LIKE ?)");
+      arguments.add(pattern);
+      arguments.add(pattern);
+      arguments.add(pattern);
+      arguments.add(pattern);
+    }
+    if (assetType != null) {
+      sql.append(" AND asset_type = ?");
+      arguments.add(assetType.name());
+    }
+    sql.append(" ORDER BY update_time DESC, id DESC LIMIT ?");
+    arguments.add(limit);
+
+    return jdbcTemplate.query(sql.toString(), this::mapAsset, arguments.toArray());
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageController.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageController.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -68,6 +69,16 @@ public class LineageController {
         request.version(),
         request.observedAt(),
         request.properties())));
+  }
+
+  @Operation(summary = "搜索血缘资产")
+  @GetMapping("/assets")
+  public Result<List<LineageAsset>> searchAssets(
+      @RequestParam(value = "keyword", required = false) @Size(max = 200) String keyword,
+      @RequestParam(value = "assetType", required = false) LineageAssetType assetType,
+      @RequestParam(value = "limit", defaultValue = "30")
+      @Min(1) @Max(LineageService.MAX_ASSET_SEARCH_LIMIT) int limit) {
+    return Result.success(service.searchAssets(keyword, assetType, limit));
   }
 
   @Operation(summary = "查询血缘资产")

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
@@ -21,6 +21,8 @@ interface LineageRepository {
 
   Optional<LineageAsset> findAssetByKey(String assetKey);
 
+  List<LineageAsset> searchAssets(String keyword, LineageAssetType assetType, int limit);
+
   List<LineageAsset> findAssetsByIds(Set<Long> assetIds);
 
   List<LineageRelation> findOutgoingRelations(Set<Long> sourceAssetIds);

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LineageService {
 
   public static final int MAX_GRAPH_DEPTH = 10;
+  public static final int MAX_ASSET_SEARCH_LIMIT = 100;
 
   private final LineageRepository repository;
 
@@ -98,6 +99,16 @@ public class LineageService {
     String normalized = required(assetKey, "assetKey", 512);
     return repository.findAssetByKey(normalized)
         .orElseThrow(() -> new IllegalArgumentException("血缘资产不存在：" + normalized));
+  }
+
+  @Transactional(readOnly = true)
+  public List<LineageAsset> searchAssets(
+      String keyword,
+      LineageAssetType assetType,
+      int limit) {
+    String normalizedKeyword = optional(keyword, 200);
+    int actualLimit = Math.min(MAX_ASSET_SEARCH_LIMIT, Math.max(1, limit));
+    return repository.searchAssets(normalizedKeyword, assetType, actualLimit);
   }
 
   @Transactional(readOnly = true)

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -46,6 +46,28 @@ class LineageServiceTest {
     LineageGraph upstream = service.upstream(chartE.id(), 4);
     assertTrue(ids(upstream).contains(tableA.id()));
     assertTrue(ids(upstream).contains(datasetD.id()));
+  }
+
+  @Test
+  void searchesAssetsByKeywordTypeAndLimit() {
+    InMemoryLineageRepository repository = new InMemoryLineageRepository();
+    LineageService service = new LineageService(repository);
+
+    service.registerAsset(new LineageService.RegisterAssetCommand(
+        "dataset:1", LineageAssetType.DATASET, "Sales Dataset", "TEST", "1", null,
+        null, null, null, null, null, null));
+    service.registerAsset(new LineageService.RegisterAssetCommand(
+        "dataset:2", LineageAssetType.DATASET, "Inventory", "TEST", "2", null,
+        null, null, null, null, null, null));
+    service.registerAsset(new LineageService.RegisterAssetCommand(
+        "chart:1", LineageAssetType.CHART, "Sales Chart", "TEST", "3", null,
+        null, null, null, null, null, null));
+
+    List<LineageAsset> values = service.searchAssets("sales", LineageAssetType.DATASET, 10);
+
+    assertEquals(1, values.size());
+    assertEquals("dataset:1", values.get(0).assetKey());
+    assertEquals(1, service.searchAssets(null, LineageAssetType.DATASET, 1).size());
   }
 
   private static Set<Long> ids(LineageGraph graph) {
@@ -110,6 +132,18 @@ class LineageServiceTest {
     public Optional<LineageAsset> findAssetByKey(String assetKey) {
       Long id = assetKeys.get(assetKey);
       return id == null ? Optional.empty() : findAsset(id);
+    }
+
+    @Override
+    public List<LineageAsset> searchAssets(String keyword, LineageAssetType assetType, int limit) {
+      String normalized = keyword == null ? "" : keyword.toLowerCase(Locale.ROOT);
+      return assets.values().stream()
+          .filter(asset -> assetType == null || asset.assetType() == assetType)
+          .filter(asset -> normalized.isBlank()
+              || asset.name().toLowerCase(Locale.ROOT).contains(normalized)
+              || asset.assetKey().toLowerCase(Locale.ROOT).contains(normalized))
+          .limit(limit)
+          .toList();
     }
 
     @Override

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -44,6 +44,7 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'dashboard-editor', path: '/dashboard/:id/edit', title: '仪表盘编辑', component: './dashboard/editor', hidden: true, parentId: 'dashboard' },
   { id: 'dashboard-viewer', path: '/dashboard/:id', title: '仪表盘查看', component: './dashboard/viewer', hidden: true, parentId: 'dashboard' },
   { id: 'data-analysis-catalog', mode: 'public', path: '/data-analysis/data-catalog', title: '数据目录', component: './data-analysis/data-catalog', iconKey: 'database', menuGroup: 'data-analysis', order: 20 },
+  { id: 'data-analysis-lineage', mode: 'public', path: '/data-analysis/lineage', title: '数据血缘', component: './data-analysis/lineage', iconKey: 'workflow', menuGroup: 'data-analysis', order: 25 },
   { id: 'digital-screen', mode: 'public', path: '/digital-screen', title: '数字化大屏', component: './digital-screen', iconKey: 'insight', menuGroup: 'data-analysis', order: 30 },
   { id: 'digital-screen-new', path: '/digital-screen/new', title: '新建数字化大屏', component: './digital-screen/new', hidden: true, parentId: 'digital-screen' },
   { id: 'digital-screen-editor', path: '/digital-screen/:id/edit', title: '数字化大屏编辑', component: './digital-screen/editor', hidden: true, parentId: 'digital-screen' },

--- a/yak-ops-ui/src/pages/data-analysis/lineage/LineageNode.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/LineageNode.tsx
@@ -1,0 +1,105 @@
+import {
+  BarChart3,
+  Braces,
+  Database,
+  FileCode2,
+  LayoutDashboard,
+  Rows3,
+  TableProperties,
+} from 'lucide-react';
+import { Handle, Position, type NodeProps } from 'reactflow';
+import { assetTypeLabel, type LineageAsset } from './types';
+
+export interface LineageNodeData {
+  asset: LineageAsset;
+  root: boolean;
+}
+
+const iconByType = {
+  TABLE: TableProperties,
+  COLUMN: Braces,
+  SQL_TASK: FileCode2,
+  DATASET: Database,
+  DATASET_FIELD: Rows3,
+  CHART: BarChart3,
+  DASHBOARD: LayoutDashboard,
+};
+
+const subtitle = (asset: LineageAsset) => {
+  if (asset.assetType === 'COLUMN') {
+    return [asset.tableName, asset.columnName].filter(Boolean).join('.') || asset.sourceType || '字段';
+  }
+  if (asset.assetType === 'TABLE') {
+    return [asset.databaseName, asset.schemaName, asset.tableName]
+      .filter(Boolean)
+      .join('.') || asset.sourceType || '数据表';
+  }
+  if (asset.assetType === 'DATASET_FIELD') return asset.sourceType || 'Dataset 字段';
+  if (asset.assetType === 'SQL_TASK') return '数据开发';
+  if (asset.assetType === 'CHART') return 'Analysis';
+  if (asset.assetType === 'DASHBOARD') return '数据消费';
+  return asset.sourceType || assetTypeLabel[asset.assetType];
+};
+
+export default function LineageNode({ data, selected }: NodeProps<LineageNodeData>) {
+  const { asset, root } = data;
+  const Icon = iconByType[asset.assetType];
+  return (
+    <div
+      className="relative flex h-[74px] w-[238px] items-center gap-3 rounded-[8px] border bg-white px-3"
+      style={{
+        borderColor: root
+          ? 'rgba(254,44,85,.35)'
+          : selected
+            ? '#aeb4bd'
+            : '#e2e5e9',
+        boxShadow: 'none',
+        background: root ? 'rgba(254,44,85,.025)' : '#fff',
+      }}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        style={{
+          width: 7,
+          height: 7,
+          border: '1px solid #c7ccd4',
+          background: '#fff',
+        }}
+      />
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[7px] bg-[#f3f4f6] text-[#5f6670]">
+        <Icon size={17} strokeWidth={1.7} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#161823]" title={asset.name}>
+            {asset.name}
+          </span>
+          {root ? (
+            <span className="shrink-0 rounded-[4px] bg-[rgba(254,44,85,.07)] px-1.5 py-0.5 text-[10px] font-medium text-[rgba(254,44,85,.82)]">
+              当前
+            </span>
+          ) : null}
+        </div>
+        <div className="mt-1 flex min-w-0 items-center gap-1.5">
+          <span className="shrink-0 rounded-[4px] bg-[#f5f6f7] px-1.5 py-0.5 text-[10px] font-medium text-[#667085]">
+            {assetTypeLabel[asset.assetType]}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[11px] text-[#8a8f99]" title={subtitle(asset)}>
+            {subtitle(asset)}
+          </span>
+        </div>
+      </div>
+      <Handle
+        type="source"
+        position={Position.Right}
+        style={{
+          width: 7,
+          height: 7,
+          border: '1px solid #c7ccd4',
+          background: '#fff',
+        }}
+      />
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-analysis/lineage/graph-layout.test.ts
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/graph-layout.test.ts
@@ -1,0 +1,66 @@
+import { buildLineageView, downstreamImpact, lineageLevels } from './graph-layout';
+import type { LineageAsset, LineageGraph, LineageRelation } from './types';
+
+const asset = (id: string, assetType: LineageAsset['assetType']): LineageAsset => ({
+  id,
+  assetKey: `${assetType.toLowerCase()}:${id}`,
+  assetType,
+  name: `${assetType}-${id}`,
+});
+
+const relation = (
+  id: string,
+  sourceAssetId: string,
+  targetAssetId: string,
+): LineageRelation => ({
+  id,
+  sourceAssetId,
+  targetAssetId,
+  relationType: 'DERIVES_FROM',
+});
+
+const graph = (): LineageGraph => ({
+  root: asset('3', 'DATASET'),
+  direction: 'BOTH',
+  depth: 3,
+  nodes: [
+    asset('1', 'TABLE'),
+    asset('2', 'SQL_TASK'),
+    asset('3', 'DATASET'),
+    asset('4', 'CHART'),
+    asset('5', 'DASHBOARD'),
+  ],
+  relations: [
+    relation('r1', '1', '2'),
+    relation('r2', '2', '3'),
+    relation('r3', '3', '4'),
+    relation('r4', '4', '5'),
+  ],
+});
+
+describe('lineage graph layout', () => {
+  test('places upstream left and downstream right by hop', () => {
+    const levels = lineageLevels(graph());
+    expect(levels.get('1')).toBe(-2);
+    expect(levels.get('2')).toBe(-1);
+    expect(levels.get('3')).toBe(0);
+    expect(levels.get('4')).toBe(1);
+    expect(levels.get('5')).toBe(2);
+  });
+
+  test('direction and type filters keep the root and matching side', () => {
+    const visible = new Set<LineageAsset['assetType']>(['TABLE', 'SQL_TASK', 'DATASET']);
+    const view = buildLineageView(graph(), 'UPSTREAM', visible);
+    expect(view.nodes.map((node) => node.asset.id).sort()).toEqual(['1', '2', '3']);
+    expect(view.nodes.find((node) => node.asset.id === '1')?.position.x).toBeLessThan(0);
+    expect(view.relations).toHaveLength(2);
+  });
+
+  test('impact counts only downstream reachable assets', () => {
+    const impact = downstreamImpact(graph());
+    expect(impact.total).toBe(2);
+    expect(impact.byType.CHART).toBe(1);
+    expect(impact.byType.DASHBOARD).toBe(1);
+    expect(impact.byType.TABLE).toBe(0);
+  });
+});

--- a/yak-ops-ui/src/pages/data-analysis/lineage/graph-layout.ts
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/graph-layout.ts
@@ -1,0 +1,155 @@
+import type {
+  LineageAsset,
+  LineageAssetType,
+  LineageDirection,
+  LineageGraph,
+  LineageRelation,
+} from './types';
+
+const HORIZONTAL_GAP = 330;
+const VERTICAL_GAP = 108;
+
+export interface PositionedLineageAsset {
+  asset: LineageAsset;
+  level: number;
+  position: { x: number; y: number };
+}
+
+export interface LineageView {
+  nodes: PositionedLineageAsset[];
+  relations: LineageRelation[];
+}
+
+export interface ImpactSummary {
+  total: number;
+  byType: Record<LineageAssetType, number>;
+  assetIds: Set<string>;
+}
+
+const emptyTypeCounts = (): Record<LineageAssetType, number> => ({
+  TABLE: 0,
+  COLUMN: 0,
+  SQL_TASK: 0,
+  DATASET: 0,
+  DATASET_FIELD: 0,
+  CHART: 0,
+  DASHBOARD: 0,
+});
+
+const distances = (
+  rootId: string,
+  relations: LineageRelation[],
+  direction: 'UPSTREAM' | 'DOWNSTREAM',
+) => {
+  const result = new Map<string, number>([[rootId, 0]]);
+  const queue = [rootId];
+  let cursor = 0;
+
+  while (cursor < queue.length) {
+    const current = queue[cursor++];
+    const currentDistance = result.get(current) || 0;
+    relations.forEach((relation) => {
+      const matches = direction === 'UPSTREAM'
+        ? relation.targetAssetId === current
+        : relation.sourceAssetId === current;
+      if (!matches) return;
+      const next = direction === 'UPSTREAM'
+        ? relation.sourceAssetId
+        : relation.targetAssetId;
+      if (result.has(next)) return;
+      result.set(next, currentDistance + 1);
+      queue.push(next);
+    });
+  }
+  return result;
+};
+
+export const lineageLevels = (graph: LineageGraph) => {
+  const upstream = distances(graph.root.id, graph.relations, 'UPSTREAM');
+  const downstream = distances(graph.root.id, graph.relations, 'DOWNSTREAM');
+  const levels = new Map<string, number>([[graph.root.id, 0]]);
+
+  graph.nodes.forEach((asset) => {
+    if (asset.id === graph.root.id) return;
+    const upstreamDistance = upstream.get(asset.id);
+    const downstreamDistance = downstream.get(asset.id);
+    if (upstreamDistance == null && downstreamDistance == null) return;
+    if (upstreamDistance != null && downstreamDistance != null) {
+      levels.set(
+        asset.id,
+        upstreamDistance <= downstreamDistance ? -upstreamDistance : downstreamDistance,
+      );
+      return;
+    }
+    if (upstreamDistance != null) levels.set(asset.id, -upstreamDistance);
+    else if (downstreamDistance != null) levels.set(asset.id, downstreamDistance);
+  });
+  return levels;
+};
+
+export const buildLineageView = (
+  graph: LineageGraph,
+  direction: LineageDirection,
+  visibleTypes: ReadonlySet<LineageAssetType>,
+): LineageView => {
+  const levels = lineageLevels(graph);
+  const visibleAssets = graph.nodes.filter((asset) => {
+    if (asset.id === graph.root.id) return true;
+    const level = levels.get(asset.id);
+    if (level == null) return false;
+    if (direction === 'UPSTREAM' && level >= 0) return false;
+    if (direction === 'DOWNSTREAM' && level <= 0) return false;
+    return visibleTypes.has(asset.assetType);
+  });
+
+  const groups = new Map<number, LineageAsset[]>();
+  visibleAssets.forEach((asset) => {
+    const level = levels.get(asset.id) || 0;
+    const group = groups.get(level) || [];
+    group.push(asset);
+    groups.set(level, group);
+  });
+
+  const positioned: PositionedLineageAsset[] = [];
+  [...groups.entries()]
+    .sort(([left], [right]) => left - right)
+    .forEach(([level, assets]) => {
+      assets
+        .sort((left, right) => {
+          const typeCompare = left.assetType.localeCompare(right.assetType);
+          return typeCompare || left.name.localeCompare(right.name, 'zh-CN');
+        })
+        .forEach((asset, index) => {
+          positioned.push({
+            asset,
+            level,
+            position: {
+              x: level * HORIZONTAL_GAP,
+              y: (index - (assets.length - 1) / 2) * VERTICAL_GAP,
+            },
+          });
+        });
+    });
+
+  const visibleIds = new Set(positioned.map((item) => item.asset.id));
+  return {
+    nodes: positioned,
+    relations: graph.relations.filter(
+      (relation) => visibleIds.has(relation.sourceAssetId)
+        && visibleIds.has(relation.targetAssetId),
+    ),
+  };
+};
+
+export const downstreamImpact = (graph: LineageGraph): ImpactSummary => {
+  const reachable = distances(graph.root.id, graph.relations, 'DOWNSTREAM');
+  reachable.delete(graph.root.id);
+  const byType = emptyTypeCounts();
+  const assetIds = new Set<string>();
+  graph.nodes.forEach((asset) => {
+    if (!reachable.has(asset.id)) return;
+    assetIds.add(asset.id);
+    byType[asset.assetType] += 1;
+  });
+  return { total: assetIds.size, byType, assetIds };
+};

--- a/yak-ops-ui/src/pages/data-analysis/lineage/index.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/index.tsx
@@ -1,0 +1,659 @@
+import {
+  BRAND_COLOR,
+  BRAND_COLOR_SOFT,
+  BRAND_THEME,
+} from '@/styles/brand';
+import { history } from '@umijs/max';
+import {
+  Button,
+  ConfigProvider,
+  Empty,
+  Select,
+  Segmented,
+  Spin,
+  Tooltip,
+  message,
+} from 'antd';
+import {
+  ArrowUpRight,
+  Boxes,
+  ChevronRight,
+  GitBranch,
+  LocateFixed,
+  RefreshCw,
+  Search,
+  X,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  MarkerType,
+  type Edge,
+  type Node,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import LineageNode, { type LineageNodeData } from './LineageNode';
+import { buildLineageView, downstreamImpact } from './graph-layout';
+import {
+  fetchLineageAssetByKey,
+  fetchLineageGraph,
+  searchLineageAssets,
+} from './service';
+import {
+  LINEAGE_ASSET_TYPES,
+  assetTypeLabel,
+  relationTypeLabel,
+  type LineageAsset,
+  type LineageAssetType,
+  type LineageDirection,
+  type LineageGraph,
+  type LineageRelation,
+} from './types';
+
+const DEFAULT_DEPTH = 3;
+const SEARCH_LIMIT = 30;
+const ALL_TYPES = [...LINEAGE_ASSET_TYPES];
+
+const nodeTypes = { lineage: LineageNode };
+
+const formatTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  }).format(date).replaceAll('/', '-');
+};
+
+const formatValue = (value: unknown) => {
+  if (value == null) return '-';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const assetLocation = (asset: LineageAsset) => [
+  asset.databaseName,
+  asset.schemaName,
+  asset.tableName,
+  asset.columnName,
+].filter(Boolean).join('.') || '-';
+
+const businessLink = (asset: LineageAsset): { label: string; path: string } | undefined => {
+  if (asset.assetType === 'SQL_TASK' && asset.sourceId) {
+    return { label: '打开开发任务', path: `/data-development/task/${encodeURIComponent(asset.sourceId)}` };
+  }
+  if (asset.assetType === 'DASHBOARD' && asset.sourceId) {
+    return { label: '打开仪表盘', path: `/dashboard/${encodeURIComponent(asset.sourceId)}` };
+  }
+  if (asset.assetType === 'DATASET' || asset.assetType === 'DATASET_FIELD') {
+    return { label: '打开数据目录', path: '/data-analysis/data-catalog' };
+  }
+  if (asset.assetType === 'CHART') {
+    return { label: '打开仪表盘', path: '/dashboard' };
+  }
+  if (asset.assetType === 'TABLE' || asset.assetType === 'COLUMN') {
+    return { label: '打开数据源', path: '/data-source' };
+  }
+  return undefined;
+};
+
+const assetPropertyEntries = (asset?: LineageAsset) => Object.entries(asset?.properties || {})
+  .filter(([, value]) => value !== undefined && value !== null)
+  .slice(0, 18);
+
+const relationPropertyEntries = (relation?: LineageRelation) => Object.entries(relation?.properties || {})
+  .filter(([, value]) => value !== undefined && value !== null)
+  .slice(0, 18);
+
+const DetailRow = ({ label, value }: { label: string; value: unknown }) => (
+  <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-3 py-2 text-[12px]">
+    <span className="text-[#8a8f99]">{label}</span>
+    <span className="min-w-0 break-all text-[#344054]">{formatValue(value)}</span>
+  </div>
+);
+
+const ImpactChip = ({ label, value }: { label: string; value: number }) => (
+  <span className="inline-flex h-7 items-center gap-1.5 rounded-[6px] border border-[#e5e7eb] bg-white px-2.5 text-[12px] text-[#667085]">
+    <span>{label}</span>
+    <strong className="font-semibold text-[#344054]">{value}</strong>
+  </span>
+);
+
+export default function LineagePage() {
+  const [rootAsset, setRootAsset] = useState<LineageAsset>();
+  const [graph, setGraph] = useState<LineageGraph>();
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState('');
+  const [depth, setDepth] = useState(DEFAULT_DEPTH);
+  const [direction, setDirection] = useState<LineageDirection>('BOTH');
+  const [visibleTypes, setVisibleTypes] = useState<LineageAssetType[]>(ALL_TYPES);
+  const [selectedAsset, setSelectedAsset] = useState<LineageAsset>();
+  const [selectedRelation, setSelectedRelation] = useState<LineageRelation>();
+
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [searchType, setSearchType] = useState<'ALL' | LineageAssetType>('ALL');
+  const [searchResults, setSearchResults] = useState<LineageAsset[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  const selectRoot = useCallback((asset: LineageAsset, syncUrl = true) => {
+    setRootAsset(asset);
+    setSelectedAsset(asset);
+    setSelectedRelation(undefined);
+    setLoadError('');
+    if (syncUrl) {
+      history.replace(`/data-analysis/lineage?assetKey=${encodeURIComponent(asset.assetKey)}`);
+    }
+  }, []);
+
+  const loadAssetByKey = useCallback(async (assetKey: string, syncUrl = true) => {
+    setLoading(true);
+    setLoadError('');
+    try {
+      const asset = await fetchLineageAssetByKey(assetKey);
+      selectRoot(asset, syncUrl);
+    } catch (error) {
+      const text = error instanceof Error ? error.message : '查询血缘资产失败';
+      setLoadError(text);
+      message.error(text);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectRoot]);
+
+  useEffect(() => {
+    const assetKey = new URLSearchParams(window.location.search).get('assetKey');
+    if (assetKey) void loadAssetByKey(assetKey, false);
+  }, [loadAssetByKey]);
+
+  useEffect(() => {
+    if (!rootAsset) {
+      setGraph(undefined);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setLoadError('');
+    void fetchLineageGraph(rootAsset.id, depth)
+      .then((value) => {
+        if (cancelled) return;
+        setGraph(value);
+        setSelectedAsset((current) => {
+          if (!current || current.id === rootAsset.id) return value.root;
+          return value.nodes.find((item) => item.id === current.id) || value.root;
+        });
+        setSelectedRelation((current) =>
+          current ? value.relations.find((item) => item.id === current.id) : undefined,
+        );
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        const text = error instanceof Error ? error.message : '加载血缘图失败';
+        setGraph(undefined);
+        setLoadError(text);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [depth, rootAsset]);
+
+  useEffect(() => {
+    const keyword = searchKeyword.trim();
+    if (!keyword && searchType === 'ALL') {
+      setSearchResults([]);
+      setSearching(false);
+      return;
+    }
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      setSearching(true);
+      void searchLineageAssets({
+        keyword,
+        assetType: searchType === 'ALL' ? undefined : searchType,
+        limit: SEARCH_LIMIT,
+      })
+        .then((values) => {
+          if (!cancelled) setSearchResults(values);
+        })
+        .catch(() => {
+          if (!cancelled) setSearchResults([]);
+        })
+        .finally(() => {
+          if (!cancelled) setSearching(false);
+        });
+    }, 220);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [searchKeyword, searchType]);
+
+  const view = useMemo(() => {
+    if (!graph) return undefined;
+    return buildLineageView(graph, direction, new Set(visibleTypes));
+  }, [direction, graph, visibleTypes]);
+
+  const impact = useMemo(
+    () => (graph ? downstreamImpact(graph) : undefined),
+    [graph],
+  );
+
+  const flowNodes = useMemo<Array<Node<LineageNodeData>>>(() => (
+    view?.nodes.map(({ asset, position }) => ({
+      id: asset.id,
+      type: 'lineage',
+      position,
+      draggable: false,
+      selectable: true,
+      selected: selectedAsset?.id === asset.id && !selectedRelation,
+      data: { asset, root: asset.id === graph?.root.id },
+    })) || []
+  ), [graph?.root.id, selectedAsset?.id, selectedRelation, view?.nodes]);
+
+  const flowEdges = useMemo<Edge[]>(() => (
+    view?.relations.map((relation) => ({
+      id: relation.id,
+      source: relation.sourceAssetId,
+      target: relation.targetAssetId,
+      type: 'smoothstep',
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 14,
+        height: 14,
+        color: selectedRelation?.id === relation.id ? BRAND_COLOR : '#b9bec6',
+      },
+      style: {
+        stroke: selectedRelation?.id === relation.id ? BRAND_COLOR : '#c9cdd3',
+        strokeWidth: selectedRelation?.id === relation.id ? 1.6 : 1.15,
+      },
+      data: { relation },
+    })) || []
+  ), [selectedRelation?.id, view?.relations]);
+
+  const nodeById = useMemo(
+    () => new Map((graph?.nodes || []).map((asset) => [asset.id, asset])),
+    [graph?.nodes],
+  );
+  const selectedRelationSource = selectedRelation
+    ? nodeById.get(selectedRelation.sourceAssetId)
+    : undefined;
+  const selectedRelationTarget = selectedRelation
+    ? nodeById.get(selectedRelation.targetAssetId)
+    : undefined;
+  const selectedBusinessLink = selectedAsset ? businessLink(selectedAsset) : undefined;
+  const graphKey = rootAsset
+    ? `${rootAsset.id}:${depth}:${direction}:${visibleTypes.join(',')}`
+    : 'empty';
+
+  const refresh = () => {
+    if (!rootAsset) return;
+    setLoading(true);
+    setLoadError('');
+    void fetchLineageGraph(rootAsset.id, depth)
+      .then((value) => {
+        setGraph(value);
+        setSelectedAsset(value.root);
+        setSelectedRelation(undefined);
+      })
+      .catch((error) => setLoadError(error instanceof Error ? error.message : '加载血缘图失败'))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="lineage-page flex h-full min-h-[560px] flex-col overflow-hidden bg-white text-[#161823]">
+        <header className="shrink-0 border-b border-[#e5e7eb] px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex shrink-0 items-center gap-2 pr-2">
+              <GitBranch size={17} className="text-[#475467]" />
+              <span className="text-[15px] font-semibold">数据血缘</span>
+            </div>
+
+            <Select
+              showSearch
+              allowClear
+              value={undefined}
+              searchValue={searchKeyword}
+              filterOption={false}
+              loading={searching}
+              placeholder={rootAsset ? `当前：${rootAsset.name}` : '搜索名称、表名或 assetKey'}
+              className="w-[320px]"
+              suffixIcon={<Search size={14} className="text-[#8a8f99]" />}
+              onSearch={setSearchKeyword}
+              onClear={() => {
+                setSearchKeyword('');
+                setSearchResults([]);
+              }}
+              onChange={(assetKey) => {
+                const asset = searchResults.find((item) => item.assetKey === assetKey);
+                setSearchKeyword('');
+                if (asset) selectRoot(asset);
+                else if (assetKey) void loadAssetByKey(String(assetKey));
+              }}
+              options={searchResults.map((asset) => ({
+                value: asset.assetKey,
+                label: (
+                  <div className="flex min-w-0 items-center gap-2 py-0.5">
+                    <span className="shrink-0 rounded-[4px] bg-[#f3f4f6] px-1.5 py-0.5 text-[10px] text-[#667085]">
+                      {assetTypeLabel[asset.assetType]}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[13px] text-[#344054]">{asset.name}</span>
+                  </div>
+                ),
+              }))}
+              notFoundContent={searching ? <Spin size="small" /> : '输入关键词定位资产'}
+            />
+
+            <Select
+              value={searchType}
+              className="w-[118px]"
+              onChange={setSearchType}
+              options={[
+                { value: 'ALL', label: '全部类型' },
+                ...LINEAGE_ASSET_TYPES.map((value) => ({ value, label: assetTypeLabel[value] })),
+              ]}
+            />
+
+            <div className="h-5 w-px bg-[#e5e7eb]" />
+
+            <Segmented
+              size="small"
+              value={direction}
+              onChange={(value) => setDirection(value as LineageDirection)}
+              options={[
+                { label: '上下游', value: 'BOTH' },
+                { label: '仅上游', value: 'UPSTREAM' },
+                { label: '仅下游', value: 'DOWNSTREAM' },
+              ]}
+            />
+
+            <Select
+              value={depth}
+              className="w-[96px]"
+              onChange={setDepth}
+              options={[1, 2, 3, 4, 5].map((value) => ({
+                value,
+                label: `${value} 跳`,
+              }))}
+            />
+
+            <Tooltip title="刷新血缘">
+              <Button
+                aria-label="刷新血缘"
+                icon={<RefreshCw size={14} />}
+                loading={loading}
+                disabled={!rootAsset}
+                onClick={refresh}
+              />
+            </Tooltip>
+          </div>
+
+          {rootAsset ? (
+            <div className="mt-2 flex min-w-0 items-center gap-2 text-[12px]">
+              <span className="shrink-0 text-[#8a8f99]">当前资产</span>
+              <span className="truncate font-medium text-[#344054]">{rootAsset.name}</span>
+              <ChevronRight size={12} className="shrink-0 text-[#c0c4ca]" />
+              <span className="shrink-0 rounded-[4px] bg-[#f4f5f7] px-1.5 py-0.5 text-[10px] text-[#667085]">
+                {assetTypeLabel[rootAsset.assetType]}
+              </span>
+              <span className="min-w-0 truncate font-mono text-[11px] text-[#98a2b3]">{rootAsset.assetKey}</span>
+              <div className="ml-auto flex shrink-0 items-center gap-1.5">
+                <ImpactChip label="下游" value={impact?.total || 0} />
+                <ImpactChip label="Dataset" value={impact?.byType.DATASET || 0} />
+                <ImpactChip label="图表" value={impact?.byType.CHART || 0} />
+                <ImpactChip label="仪表盘" value={impact?.byType.DASHBOARD || 0} />
+              </div>
+            </div>
+          ) : null}
+        </header>
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <main className="relative min-w-0 flex-1 bg-[#f8f9fb]">
+            <div className="absolute left-3 top-3 z-10 flex items-center gap-2 rounded-[7px] border border-[#e2e5e9] bg-white px-2 py-1.5">
+              <span className="text-[11px] text-[#8a8f99]">显示</span>
+              <Select
+                mode="multiple"
+                size="small"
+                value={visibleTypes}
+                className="w-[310px]"
+                maxTagCount="responsive"
+                onChange={(values) => setVisibleTypes(values as LineageAssetType[])}
+                options={LINEAGE_ASSET_TYPES.map((value) => ({
+                  value,
+                  label: assetTypeLabel[value],
+                }))}
+              />
+              <Button
+                type="text"
+                size="small"
+                disabled={visibleTypes.length === ALL_TYPES.length}
+                onClick={() => setVisibleTypes(ALL_TYPES)}
+              >
+                全部
+              </Button>
+            </div>
+
+            {!rootAsset ? (
+              <div className="flex h-full min-h-[560px] items-center justify-center">
+                <Empty
+                  image={<div className="mx-auto flex h-12 w-12 items-center justify-center rounded-[10px] bg-[#eef0f3] text-[#667085]"><Boxes size={22} /></div>}
+                  description={(
+                    <div>
+                      <div className="text-[14px] font-medium text-[#344054]">选择一个资产开始查看血缘</div>
+                      <div className="mt-1 text-[12px] text-[#8a8f99]">可搜索数据表、SQL 任务、Dataset、图表或仪表盘</div>
+                    </div>
+                  )}
+                />
+              </div>
+            ) : loadError && !graph ? (
+              <div className="flex h-full min-h-[560px] items-center justify-center">
+                <Empty description={loadError}>
+                  <Button onClick={refresh}>重新加载</Button>
+                </Empty>
+              </div>
+            ) : (
+              <Spin spinning={loading && !graph} wrapperClassName="lineage-graph-spinner">
+                <div className="h-full min-h-[560px] w-full">
+                  <ReactFlow
+                    key={graphKey}
+                    nodes={flowNodes}
+                    edges={flowEdges}
+                    nodeTypes={nodeTypes}
+                    fitView
+                    fitViewOptions={{ padding: 0.22, minZoom: 0.55, maxZoom: 1.1 }}
+                    minZoom={0.25}
+                    maxZoom={1.6}
+                    nodesDraggable={false}
+                    nodesConnectable={false}
+                    elementsSelectable
+                    proOptions={{ hideAttribution: true }}
+                    onNodeClick={(_, node) => {
+                      setSelectedAsset(node.data.asset);
+                      setSelectedRelation(undefined);
+                    }}
+                    onNodeDoubleClick={(_, node) => selectRoot(node.data.asset)}
+                    onEdgeClick={(_, edge) => {
+                      const relation = view?.relations.find((item) => item.id === edge.id);
+                      if (!relation) return;
+                      setSelectedRelation(relation);
+                      setSelectedAsset(undefined);
+                    }}
+                    onPaneClick={() => {
+                      if (graph) setSelectedAsset(graph.root);
+                      setSelectedRelation(undefined);
+                    }}
+                  >
+                    <Background gap={18} size={1} color="#e3e6ea" />
+                    <Controls showInteractive={false} position="bottom-left" />
+                  </ReactFlow>
+                </div>
+              </Spin>
+            )}
+          </main>
+
+          <aside className="w-[330px] shrink-0 overflow-y-auto border-l border-[#e5e7eb] bg-white">
+            {selectedRelation ? (
+              <div>
+                <div className="sticky top-0 z-10 flex items-center justify-between border-b border-[#eef0f2] bg-white px-4 py-3">
+                  <div>
+                    <div className="text-[13px] font-semibold text-[#161823]">关系详情</div>
+                    <div className="mt-0.5 text-[11px] text-[#8a8f99]">Evidence / Provenance</div>
+                  </div>
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={<X size={14} />}
+                    onClick={() => {
+                      setSelectedRelation(undefined);
+                      if (graph) setSelectedAsset(graph.root);
+                    }}
+                  />
+                </div>
+                <div className="px-4 py-2">
+                  <div className="mb-2 rounded-[7px] border border-[#e5e7eb] bg-[#fafbfc] p-3">
+                    <div className="truncate text-[12px] font-medium text-[#344054]">{selectedRelationSource?.name || selectedRelation.sourceAssetId}</div>
+                    <div className="my-1.5 flex items-center gap-1 text-[11px] text-[#8a8f99]">
+                      <span>{relationTypeLabel[selectedRelation.relationType]}</span>
+                      <ChevronRight size={11} />
+                    </div>
+                    <div className="truncate text-[12px] font-medium text-[#344054]">{selectedRelationTarget?.name || selectedRelation.targetAssetId}</div>
+                  </div>
+                  <DetailRow label="关系类型" value={relationTypeLabel[selectedRelation.relationType]} />
+                  <DetailRow label="证据来源" value={selectedRelation.sourceType} />
+                  <DetailRow label="来源 ID" value={selectedRelation.sourceId} />
+                  <DetailRow label="版本" value={selectedRelation.version} />
+                  <DetailRow label="可信度" value={selectedRelation.confidence} />
+                  <DetailRow label="观测时间" value={formatTime(selectedRelation.observedAt)} />
+                  {selectedRelation.expression ? (
+                    <div className="mt-3 border-t border-[#eef0f2] pt-3">
+                      <div className="mb-2 text-[11px] font-medium text-[#667085]">表达式 / SQL</div>
+                      <pre className="max-h-[180px] overflow-auto whitespace-pre-wrap break-words rounded-[7px] bg-[#f6f7f8] p-3 text-[11px] leading-5 text-[#475467]">{selectedRelation.expression}</pre>
+                    </div>
+                  ) : null}
+                  {relationPropertyEntries(selectedRelation).length ? (
+                    <div className="mt-3 border-t border-[#eef0f2] pt-2">
+                      <div className="py-1 text-[11px] font-medium text-[#667085]">关系属性</div>
+                      {relationPropertyEntries(selectedRelation).map(([key, value]) => (
+                        <DetailRow key={key} label={key} value={value} />
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ) : selectedAsset ? (
+              <div>
+                <div className="sticky top-0 z-10 border-b border-[#eef0f2] bg-white px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-[14px] font-semibold text-[#161823]" title={selectedAsset.name}>{selectedAsset.name}</div>
+                      <div className="mt-1 flex items-center gap-1.5">
+                        <span className="rounded-[4px] bg-[#f4f5f7] px-1.5 py-0.5 text-[10px] text-[#667085]">{assetTypeLabel[selectedAsset.assetType]}</span>
+                        {selectedAsset.id === graph?.root.id ? (
+                          <span className="rounded-[4px] px-1.5 py-0.5 text-[10px]" style={{ background: BRAND_COLOR_SOFT, color: BRAND_COLOR }}>当前中心</span>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 gap-1">
+                      {selectedAsset.id !== graph?.root.id ? (
+                        <Tooltip title="以此资产重新加载上下游">
+                          <Button size="small" icon={<LocateFixed size={13} />} onClick={() => selectRoot(selectedAsset)}>设为中心</Button>
+                        </Tooltip>
+                      ) : null}
+                    </div>
+                  </div>
+                  {selectedBusinessLink ? (
+                    <Button
+                      className="mt-3 w-full"
+                      size="small"
+                      icon={<ArrowUpRight size={13} />}
+                      onClick={() => history.push(selectedBusinessLink.path)}
+                    >
+                      {selectedBusinessLink.label}
+                    </Button>
+                  ) : null}
+                </div>
+
+                <div className="px-4 py-2">
+                  <DetailRow label="assetKey" value={selectedAsset.assetKey} />
+                  <DetailRow label="来源类型" value={selectedAsset.sourceType} />
+                  <DetailRow label="来源 ID" value={selectedAsset.sourceId} />
+                  <DetailRow label="数据源" value={selectedAsset.dataSourceId} />
+                  <DetailRow label="物理位置" value={assetLocation(selectedAsset)} />
+                  <DetailRow label="更新时间" value={formatTime(selectedAsset.updateTime)} />
+
+                  {selectedAsset.id === graph?.root.id && impact ? (
+                    <div className="mt-3 border-t border-[#eef0f2] pt-3">
+                      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
+                        <GitBranch size={12} /> 下游影响（当前 {depth} 跳）
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        {[
+                          ['全部下游', impact.total],
+                          ['SQL 任务', impact.byType.SQL_TASK],
+                          ['Dataset', impact.byType.DATASET],
+                          ['图表', impact.byType.CHART],
+                          ['仪表盘', impact.byType.DASHBOARD],
+                          ['数据表', impact.byType.TABLE],
+                        ].map(([label, value]) => (
+                          <div key={String(label)} className="rounded-[7px] border border-[#e8eaed] bg-[#fafbfc] px-3 py-2">
+                            <div className="text-[11px] text-[#8a8f99]">{label}</div>
+                            <div className="mt-0.5 text-[17px] font-semibold text-[#344054]">{value}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {assetPropertyEntries(selectedAsset).length ? (
+                    <div className="mt-3 border-t border-[#eef0f2] pt-2">
+                      <div className="py-1 text-[11px] font-medium text-[#667085]">资产属性</div>
+                      {assetPropertyEntries(selectedAsset).map(([key, value]) => (
+                        <DetailRow key={key} label={key} value={value} />
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ) : (
+              <div className="flex h-full min-h-[420px] items-center justify-center px-8 text-center text-[12px] text-[#8a8f99]">
+                点击节点查看资产详情，点击连线查看关系证据
+              </div>
+            )}
+          </aside>
+        </div>
+
+        <style>{`
+          .lineage-page .lineage-graph-spinner,
+          .lineage-page .lineage-graph-spinner > .ant-spin-container { height: 100%; }
+          .lineage-page .react-flow__controls {
+            border: 1px solid #e1e4e8;
+            border-radius: 7px;
+            box-shadow: none;
+            overflow: hidden;
+          }
+          .lineage-page .react-flow__controls-button {
+            width: 28px;
+            height: 28px;
+            border-bottom-color: #edf0f2;
+            background: #fff;
+            color: #667085;
+          }
+          .lineage-page .react-flow__controls-button:hover { background: #f6f7f8; }
+          .lineage-page .react-flow__edge { cursor: pointer; }
+          .lineage-page .react-flow__node { cursor: pointer; }
+          .lineage-page .react-flow__pane { cursor: grab; }
+          .lineage-page .react-flow__pane.dragging { cursor: grabbing; }
+        `}</style>
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/yak-ops-ui/src/pages/data-analysis/lineage/service.ts
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/service.ts
@@ -1,0 +1,100 @@
+import type { ApiResponse } from '@/services/http/response';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import HttpUtils from '@/utils/HttpUtils';
+import type {
+  LineageAsset,
+  LineageAssetType,
+  LineageDirection,
+  LineageGraph,
+  LineageRelation,
+} from './types';
+
+const LINEAGE_API = '/api/v1/lineage';
+type WireId = string | number;
+
+interface LineageAssetWire extends Omit<LineageAsset, 'id' | 'parentAssetId'> {
+  id: WireId;
+  parentAssetId?: WireId | null;
+}
+
+interface LineageRelationWire extends Omit<LineageRelation, 'id' | 'sourceAssetId' | 'targetAssetId'> {
+  id: WireId;
+  sourceAssetId: WireId;
+  targetAssetId: WireId;
+}
+
+interface LineageGraphWire {
+  root: LineageAssetWire;
+  direction: LineageDirection;
+  depth: number;
+  nodes?: LineageAssetWire[];
+  relations?: LineageRelationWire[];
+}
+
+const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
+    throw new Error(response?.message || response?.msg || fallback);
+  }
+  return response.data;
+};
+
+const toAsset = (value: LineageAssetWire): LineageAsset => ({
+  ...value,
+  id: String(value.id),
+  parentAssetId: value.parentAssetId == null ? undefined : String(value.parentAssetId),
+});
+
+const toRelation = (value: LineageRelationWire): LineageRelation => ({
+  ...value,
+  id: String(value.id),
+  sourceAssetId: String(value.sourceAssetId),
+  targetAssetId: String(value.targetAssetId),
+});
+
+const toGraph = (value: LineageGraphWire): LineageGraph => ({
+  root: toAsset(value.root),
+  direction: value.direction,
+  depth: value.depth,
+  nodes: (value.nodes || []).map(toAsset),
+  relations: (value.relations || []).map(toRelation),
+});
+
+export interface SearchLineageAssetsParams {
+  keyword?: string;
+  assetType?: LineageAssetType;
+  limit?: number;
+}
+
+export const searchLineageAssets = async ({
+  keyword,
+  assetType,
+  limit = 30,
+}: SearchLineageAssetsParams): Promise<LineageAsset[]> => {
+  const query = new URLSearchParams();
+  if (keyword?.trim()) query.set('keyword', keyword.trim());
+  if (assetType) query.set('assetType', assetType);
+  query.set('limit', String(limit));
+  const response = await HttpUtils.get<LineageAssetWire[]>(
+    `${LINEAGE_API}/assets?${query.toString()}`,
+  );
+  return unwrap(response, '搜索血缘资产失败').map(toAsset);
+};
+
+export const fetchLineageAssetByKey = async (assetKey: string): Promise<LineageAsset> => {
+  const query = new URLSearchParams({ assetKey });
+  const response = await HttpUtils.get<LineageAssetWire>(
+    `${LINEAGE_API}/assets/by-key?${query.toString()}`,
+  );
+  return toAsset(unwrap(response, '查询血缘资产失败'));
+};
+
+export const fetchLineageGraph = async (
+  assetId: string,
+  depth = 3,
+): Promise<LineageGraph> => {
+  const query = new URLSearchParams({ direction: 'BOTH', depth: String(depth) });
+  const response = await HttpUtils.get<LineageGraphWire>(
+    `${LINEAGE_API}/assets/${encodeURIComponent(assetId)}/graph?${query.toString()}`,
+  );
+  return toGraph(unwrap(response, '查询血缘图失败'));
+};

--- a/yak-ops-ui/src/pages/data-analysis/lineage/types.ts
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/types.ts
@@ -1,0 +1,78 @@
+export const LINEAGE_ASSET_TYPES = [
+  'TABLE',
+  'COLUMN',
+  'SQL_TASK',
+  'DATASET',
+  'DATASET_FIELD',
+  'CHART',
+  'DASHBOARD',
+] as const;
+
+export type LineageAssetType = (typeof LINEAGE_ASSET_TYPES)[number];
+export type LineageDirection = 'BOTH' | 'UPSTREAM' | 'DOWNSTREAM';
+export type LineageRelationType =
+  | 'READS_FROM'
+  | 'WRITES_TO'
+  | 'DERIVES_FROM'
+  | 'CONSUMES'
+  | 'CONTAINS';
+
+export interface LineageAsset {
+  id: string;
+  assetKey: string;
+  assetType: LineageAssetType;
+  name: string;
+  sourceType?: string;
+  sourceId?: string;
+  parentAssetId?: string;
+  dataSourceId?: string;
+  databaseName?: string;
+  schemaName?: string;
+  tableName?: string;
+  columnName?: string;
+  properties?: Record<string, unknown>;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface LineageRelation {
+  id: string;
+  sourceAssetId: string;
+  targetAssetId: string;
+  relationType: LineageRelationType;
+  sourceType?: string;
+  sourceId?: string;
+  expression?: string;
+  confidence?: number;
+  version?: string;
+  observedAt?: string;
+  properties?: Record<string, unknown>;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface LineageGraph {
+  root: LineageAsset;
+  direction: LineageDirection;
+  depth: number;
+  nodes: LineageAsset[];
+  relations: LineageRelation[];
+}
+
+export const assetTypeLabel: Record<LineageAssetType, string> = {
+  TABLE: '数据表',
+  COLUMN: '字段',
+  SQL_TASK: 'SQL 任务',
+  DATASET: 'Dataset',
+  DATASET_FIELD: 'Dataset 字段',
+  CHART: '图表',
+  DASHBOARD: '仪表盘',
+};
+
+export const relationTypeLabel: Record<LineageRelationType, string> = {
+  READS_FROM: '读取',
+  WRITES_TO: '写入',
+  DERIVES_FROM: '派生',
+  CONSUMES: '消费',
+  CONTAINS: '包含',
+};


### PR DESCRIPTION
## 目标

在已经打通的 Yak Ops 后端元数据关系图之上，补齐第一版可直接使用的 **Lineage Graph + Impact Analysis** 前端工作区。

这一阶段把完整主链真正可视化：

```text
TABLE / COLUMN
      ↓
   SQL_TASK
      ↓
DATASET / DATASET_FIELD
      ↓
     CHART
      ↓
  DASHBOARD
```

页面入口放在：

```text
数据消费
  ├─ 仪表盘
  ├─ 数据目录
  ├─ 数据血缘   ← 新增
  └─ 数字化大屏
```

设计继续保持 Yak Ops 当前的白底、浅灰边框、高密度、少阴影风格，不做彩虹色关系图。

## 1. 新增血缘资产定位接口

现有 Lineage API 已经支持按 assetId / assetKey 查单资产以及按 root 查询 graph，但独立血缘页面还缺“先找到一个 root”的能力。

新增只读接口：

```http
GET /api/v1/lineage/assets?keyword=&assetType=&limit=
```

支持：

- 名称模糊搜索
- assetKey 模糊搜索
- tableName / columnName 模糊搜索
- assetType 过滤
- limit，最大 100

该接口只服务于前端资产定位，不引入新的资产目录、分页体系或搜索服务。

实际关系图仍然使用已有：

```http
GET /api/v1/lineage/assets/{assetId}/graph?direction=BOTH&depth=3
```

## 2. 新增“数据消费 → 数据血缘”页面

新路由：

```text
/data-analysis/lineage
```

支持稳定深链：

```text
/data-analysis/lineage?assetKey={stableAssetKey}
```

例如后续可以从 Dataset、SQL Task、Dashboard 详情页直接跳到指定资产的血缘中心，而不依赖数据库自增 ID。

## 3. ReactFlow 血缘图

项目已经存在：

```text
reactflow 11.11.4
```

本阶段直接复用，不新增前端依赖。

节点类型覆盖：

```text
TABLE
COLUMN
SQL_TASK
DATASET
DATASET_FIELD
CHART
DASHBOARD
```

所有节点采用一致的中性卡片：

- 白色背景
- 浅灰边框
- 无卡片阴影
- lucide 图标区分资产类型
- 当前中心节点仅使用非常轻的品牌红强调

不为不同资产类型铺大量高饱和颜色，避免复杂血缘下视觉噪音过高。

## 4. 真正按有向关系计算“上游左 / 下游右”

布局没有依赖后端返回数组顺序。

前端会从 root 分别执行：

```text
incoming BFS  -> upstream hop
outgoing BFS  -> downstream hop
```

映射为：

```text
-3  -2  -1   0   +1  +2  +3
上游        ROOT        下游
```

因此无论后端 nodes / relations 返回顺序如何变化，布局语义保持稳定。

环路通过 visited distance 自动停止，不会无限展开。

## 5. 方向与深度控制

顶部支持：

```text
上下游
仅上游
仅下游
```

以及：

```text
1 ~ 5 跳
```

后端始终读取 BOTH graph slice，方向切换在前端过滤，这样即使当前只看 upstream，右侧 Impact Analysis 仍然有完整的当前 depth 下游信息。

## 6. 类型显示过滤

画布左上角可以选择当前显示的资产类型，例如：

```text
TABLE
SQL_TASK
DATASET
CHART
DASHBOARD
```

root 始终保留。

V1 的类型过滤是“隐藏对应节点和直接关联边”，不会伪造跨越隐藏节点的关系。后续如需要可以升级成折叠/聚合节点，而不是现在就生成不存在的 shortcut edge。

## 7. 节点交互

### 单击节点

右侧显示资产详情：

- assetKey
- assetType
- sourceType / sourceId
- dataSourceId
- database / schema / table / column
- updateTime
- properties

### 双击节点

直接将该资产切换成新的 root，重新读取其上下游。

### “设为中心”

右侧详情也提供显式按钮，作用与双击一致。

URL 会同步为新的 stable assetKey，因此页面状态可复制和分享。

## 8. 关系 Evidence Inspector

单击血缘连线后，右侧从资产详情切换为关系详情。

展示：

```text
source asset
relation type
target asset
sourceType
sourceId
version
confidence
observedAt
expression / SQL
properties
```

因此前端不仅能回答：

```text
A -> B
```

还可以回答：

```text
为什么存在 A -> B？
由哪一次 SQL / Dataset / Analysis / Dashboard 绑定生成？
具体 expression 是什么？
```

## 9. Impact Analysis 首版

以当前 root 为起点，沿 persisted upstream → downstream 方向执行 outgoing BFS。

统计当前 depth 范围内的：

```text
全部下游
SQL Task
Dataset
Chart
Dashboard
Table
```

顶部保留最常用的轻量摘要：

```text
下游 N
Dataset N
图表 N
仪表盘 N
```

root 详情里再展示完整类型统计。

Impact 只统计真正有向可达的 downstream，不用“节点在画布右边”或 assetType 顺序来猜影响关系。

## 10. 业务页面跳转

节点详情提供轻量业务入口：

```text
SQL_TASK        -> 数据开发任务
DATASET/FIELD   -> 数据目录
CHART           -> 仪表盘工作区
DASHBOARD       -> 仪表盘查看
TABLE/COLUMN    -> 数据源管理
```

V1 不强行修改各业务页实现复杂 deep-link 选中状态；先保证血缘工作区本身闭环，后续可以逐页增强“一键定位到具体 Dataset / Table / Analysis”。

## 11. Tests

### Backend

`LineageServiceTest` 新增：

- keyword 搜索
- assetType 过滤
- limit 行为

### Frontend

新增 `graph-layout.test.ts`：

- upstream 映射为负 hop / 左侧
- downstream 映射为正 hop / 右侧
- root 固定 level 0
- direction/type 过滤
- downstream impact 只统计真正 outgoing reachable assets

## 影响范围

当前分支相对 main：

```text
1 commit ahead
0 behind
12 files changed
```

涉及：

```text
yak-ops-business-lineage
  + asset search repository/service/controller
  + search test

yak-ops-ui
  + 数据血缘导航入口
  + ReactFlow lineage workspace
  + graph layout / impact pure functions
  + service / types
  + layout tests
```

没有：

- Flyway migration
- DB schema change
- 新 npm dependency
- Dataset / Analysis / Dashboard 业务表变更
- SQL parser 变更
- Runtime/OpenLineage event

## Validation

已完成：

- 基于最新 main 开分支
- compare：`1 ahead / 0 behind`
- 变更范围确认恰好 12 个预期文件
- 复用项目现有 ReactFlow 11.11.4
- graph API / asset model / relation model 与当前 main 对齐
- SiteLayout 页面高度与导航结构对齐
- `LineageRepository` 实现范围核对
- 不通过隐藏节点伪造 shortcut lineage

当前执行环境通过 GitHub connector 修改仓库，没有本地 Yak Ops workspace，因此这里不能实际执行 Maven / TypeScript / Umi build；没有把静态检查冒充成测试通过。

建议合并前执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-lineage -am test

cd yak-ops-ui
npm run tsc
npm run jest -- src/pages/data-analysis/lineage/graph-layout.test.ts
npm run build
```

## 后续建议

这一版先把“可用的血缘图 + 影响分析”建立起来。后续可以沿真实使用反馈逐步增强：

- Table / Column 折叠与展开
- 大图自动聚合
- 路径高亮
- 只看某个 downstream type
- 影响列表（不只显示数量）
- 从数据目录 / SQL Task / Dashboard 一键打开指定 assetKey
- relation evidence 可复制 / SQL 详情
- graph snapshot / diff

优先保持图清晰、可解释，不急着把 V1 做成复杂 metadata graph IDE。