### PR TITLE
fix: remove SQL editor gutter divider

### DIFF
--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -235,10 +235,6 @@ ol {
 // SQL editor statement action follows Chat2DB: the active statement exposes a
 // compact outlined play glyph at its first line, while the current line keeps
 // Monaco's native very-light highlight.
-.yak-sql-editor .monaco-editor .margin {
-  border-right: 1px solid rgba(148, 163, 184, 0.18);
-}
-
 .yak-sql-run-glyph {
   width: 16px !important;
   height: 16px !important;


### PR DESCRIPTION
## Summary
- remove the vertical divider between the SQL editor gutter and the code area
- keep Monaco's existing gutter width, line numbers, and statement run glyph behavior unchanged
- limit the change to the existing SQL editor gutter style in `global.less`

## Verification
- compared the feature branch with `main`
- confirmed the diff only removes the 4-line `.yak-sql-editor .monaco-editor .margin` border rule
- no functional SQL editor logic was changed