### PR TITLE
feat(data-development): add SQL lineage preview to workbench

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
@@ -31,4 +31,12 @@ public final class DevelopmentTaskApi {
       String content,
       String configJson) {
   }
+
+  /** Parses the current SQL editor definition without saving, publishing or persisting lineage. */
+  public record LineagePreviewRequest(
+      @NotBlank String taskType,
+      @Min(1) int schemaVersion,
+      String content,
+      String configJson) {
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentTaskApi.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
 /** HTTP request contracts for data-development task authoring and manual execution. */
 public final class DevelopmentTaskApi {
@@ -37,6 +38,8 @@ public final class DevelopmentTaskApi {
       @NotBlank String taskType,
       @Min(1) int schemaVersion,
       String content,
-      String configJson) {
+      String configJson,
+      @Size(max = 256) String databaseName,
+      @Size(max = 256) String schemaName) {
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
@@ -101,7 +101,9 @@ public class DevelopmentTaskController {
         nodeId,
         request.taskType(),
         request.content(),
-        request.configJson()));
+        request.configJson(),
+        request.databaseName(),
+        request.schemaName()));
   }
 
   @Operation(summary = "发布节点版本")

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
@@ -4,14 +4,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.framework.security.extend.CurrentUserProvider;
+import io.yak.ops.business.development.api.DevelopmentTaskApi.LineagePreviewRequest;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.PublishRequest;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.RunRequest;
 import io.yak.ops.business.development.api.DevelopmentTaskApi.SaveDraftRequest;
+import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview;
 import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
 import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
 import io.yak.ops.business.development.service.DevelopmentNodeService;
+import io.yak.ops.business.development.service.DevelopmentSqlLineagePreviewService;
 import io.yak.ops.business.development.service.DevelopmentTaskRunService;
 import io.yak.ops.business.development.service.DevelopmentTaskService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,16 +36,19 @@ public class DevelopmentTaskController {
 
   private final DevelopmentTaskService service;
   private final DevelopmentTaskRunService runService;
+  private final DevelopmentSqlLineagePreviewService lineagePreviewService;
   private final DevelopmentNodeService nodeService;
   private final CurrentUserProvider currentUserProvider;
 
   public DevelopmentTaskController(
       DevelopmentTaskService service,
       DevelopmentTaskRunService runService,
+      DevelopmentSqlLineagePreviewService lineagePreviewService,
       DevelopmentNodeService nodeService,
       CurrentUserProvider currentUserProvider) {
     this.service = service;
     this.runService = runService;
+    this.lineagePreviewService = lineagePreviewService;
     this.nodeService = nodeService;
     this.currentUserProvider = currentUserProvider;
   }
@@ -84,6 +90,18 @@ public class DevelopmentTaskController {
             request.content(),
             request.configJson(),
             operatorName(servletRequest)));
+  }
+
+  @Operation(summary = "预览当前 SQL 编辑器血缘")
+  @PostMapping("/{nodeId}/lineage/preview")
+  public Result<DevelopmentSqlLineagePreview> previewLineage(
+      @PathVariable("nodeId") Long nodeId,
+      @Valid @RequestBody LineagePreviewRequest request) {
+    return Result.success(lineagePreviewService.preview(
+        nodeId,
+        request.taskType(),
+        request.content(),
+        request.configJson()));
   }
 
   @Operation(summary = "发布节点版本")

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentSqlLineagePreview.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentSqlLineagePreview.java
@@ -1,0 +1,80 @@
+package io.yak.ops.business.development.domain;
+
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageDirection;
+import io.yak.ops.business.lineage.LineageRelationType;
+import java.util.List;
+import java.util.Map;
+
+/** Read-only lineage result generated from the current SQL editor content. */
+public record DevelopmentSqlLineagePreview(
+    String status,
+    String dataSourceId,
+    int statementCount,
+    int inputTableCount,
+    int outputTableCount,
+    int columnMappingCount,
+    int candidateOutputColumnCount,
+    int unresolvedColumnReferenceCount,
+    String parseError,
+    String columnParseError,
+    PreviewGraph graph,
+    List<ColumnMapping> columnMappings) {
+
+  public DevelopmentSqlLineagePreview {
+    columnMappings = columnMappings == null ? List.of() : List.copyOf(columnMappings);
+  }
+
+  public record PreviewGraph(
+      PreviewAsset root,
+      LineageDirection direction,
+      int depth,
+      List<PreviewAsset> nodes,
+      List<PreviewRelation> relations) {
+
+    public PreviewGraph {
+      nodes = nodes == null ? List.of() : List.copyOf(nodes);
+      relations = relations == null ? List.of() : List.copyOf(relations);
+    }
+  }
+
+  /** Mirrors the persisted LineageAsset JSON shape while keeping preview identities string-based. */
+  public record PreviewAsset(
+      String id,
+      String assetKey,
+      LineageAssetType assetType,
+      String name,
+      String sourceType,
+      String sourceId,
+      String parentAssetId,
+      String dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String columnName,
+      Map<String, Object> properties) {
+  }
+
+  /** Mirrors the persisted LineageRelation JSON shape without writing derived metadata. */
+  public record PreviewRelation(
+      String id,
+      String sourceAssetId,
+      String targetAssetId,
+      LineageRelationType relationType,
+      String sourceType,
+      String sourceId,
+      String expression,
+      Map<String, Object> properties) {
+  }
+
+  public record ColumnMapping(
+      String sourceTable,
+      String sourceColumn,
+      String targetTable,
+      String targetColumn,
+      String mappingKind,
+      String expression,
+      int outputOrdinal,
+      int sourceOrdinal) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
@@ -1,0 +1,381 @@
+package io.yak.ops.business.development.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview;
+import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview.ColumnMapping;
+import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview.PreviewAsset;
+import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview.PreviewGraph;
+import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview.PreviewRelation;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.lineage.LineageAssetType;
+import io.yak.ops.business.lineage.LineageDirection;
+import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/** Builds editor-time SQL lineage without registering assets or relations in Lineage Core. */
+@Service
+public class DevelopmentSqlLineagePreviewService {
+
+  private static final String PREVIEW_SOURCE_TYPE = "DATA_DEVELOPMENT_SQL_PREVIEW";
+
+  private final DevelopmentNodeRepository nodeRepository;
+  private final SqlTableLineageParser tableParser;
+  private final SqlColumnLineageParser columnParser;
+  private final SqlProjectionLineageAnalyzer projectionAnalyzer;
+  private final ObjectMapper objectMapper;
+
+  private DataSourceCatalogService dataSourceCatalogService;
+
+  public DevelopmentSqlLineagePreviewService(
+      DevelopmentNodeRepository nodeRepository,
+      SqlTableLineageParser tableParser,
+      SqlColumnLineageParser columnParser,
+      SqlProjectionLineageAnalyzer projectionAnalyzer,
+      ObjectMapper objectMapper) {
+    this.nodeRepository = nodeRepository;
+    this.tableParser = tableParser;
+    this.columnParser = columnParser;
+    this.projectionAnalyzer = projectionAnalyzer;
+    this.objectMapper = objectMapper;
+  }
+
+  @Autowired(required = false)
+  void setDataSourceCatalogService(DataSourceCatalogService dataSourceCatalogService) {
+    this.dataSourceCatalogService = dataSourceCatalogService;
+  }
+
+  public DevelopmentSqlLineagePreview preview(
+      Long nodeId,
+      String taskType,
+      String sql,
+      String configJson) {
+    DevelopmentNode node = requireSqlNode(nodeId, taskType);
+    if (sql == null || sql.isBlank()) {
+      throw new IllegalArgumentException("SQL 不能为空");
+    }
+    String dataSourceId = dataSourceId(configJson);
+    PreviewAsset task = taskAsset(node, dataSourceId);
+
+    final SqlTableLineageParser.ParseResult tableParsed;
+    try {
+      tableParsed = tableParser.parse(sql);
+    } catch (RuntimeException exception) {
+      return failedPreview(task, dataSourceId, safeMessage(exception));
+    }
+
+    ColumnAnalysis columnAnalysis = analyzeColumns(sql, dataSourceId, tableParsed.outputs().isEmpty());
+    Map<String, PreviewAsset> nodes = new LinkedHashMap<>();
+    Map<String, PreviewRelation> relations = new LinkedHashMap<>();
+    nodes.put(task.id(), task);
+
+    for (SqlTableLineageParser.TableRef input : tableParsed.inputs()) {
+      PreviewAsset table = tableAsset(dataSourceId, input);
+      nodes.putIfAbsent(table.id(), table);
+      PreviewRelation relation = tableRelation(table, task, LineageRelationType.READS_FROM, "INPUT", node.id());
+      relations.putIfAbsent(relation.id(), relation);
+    }
+    for (SqlTableLineageParser.TableRef output : tableParsed.outputs()) {
+      PreviewAsset table = tableAsset(dataSourceId, output);
+      nodes.putIfAbsent(table.id(), table);
+      PreviewRelation relation = tableRelation(task, table, LineageRelationType.WRITES_TO, "OUTPUT", node.id());
+      relations.putIfAbsent(relation.id(), relation);
+    }
+
+    String status;
+    if (columnAnalysis.error() != null) {
+      status = "PARTIAL";
+    } else if (columnAnalysis.unresolvedReferenceCount() > 0) {
+      status = columnAnalysis.mappings().isEmpty() ? "UNRESOLVED" : "PARTIAL";
+    } else {
+      status = "SUCCESS";
+    }
+
+    return new DevelopmentSqlLineagePreview(
+        status,
+        dataSourceId,
+        tableParsed.statementCount(),
+        tableParsed.inputs().size(),
+        tableParsed.outputs().size(),
+        columnAnalysis.mappings().size(),
+        columnAnalysis.candidateOutputCount(),
+        columnAnalysis.unresolvedReferenceCount(),
+        null,
+        columnAnalysis.error(),
+        new PreviewGraph(
+            task,
+            LineageDirection.BOTH,
+            1,
+            List.copyOf(nodes.values()),
+            List.copyOf(relations.values())),
+        columnAnalysis.mappings());
+  }
+
+  private DevelopmentNode requireSqlNode(Long nodeId, String taskType) {
+    if (nodeId == null || nodeId <= 0L) throw new IllegalArgumentException("节点 ID 非法");
+    DevelopmentNode node = nodeRepository.findById(nodeId)
+        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + nodeId));
+    if (!"SQL".equalsIgnoreCase(node.type())) {
+      throw new IllegalArgumentException("只有 SQL 节点支持血缘预览：" + node.type());
+    }
+    if (taskType == null || !"SQL".equalsIgnoreCase(taskType.trim())) {
+      throw new IllegalArgumentException("血缘预览 taskType 必须为 SQL");
+    }
+    return node;
+  }
+
+  private ColumnAnalysis analyzeColumns(String sql, String dataSourceId, boolean projectionOnly) {
+    if (projectionOnly) {
+      try {
+        SqlProjectionLineageAnalyzer.ProjectionResult result = projectionAnalyzer.analyze(
+            sql,
+            projectionSchemaProvider(dataSourceId));
+        List<ColumnMapping> mappings = result.mappings().stream()
+            .map(mapping -> new ColumnMapping(
+                mapping.sourceTable().qualifiedName(),
+                mapping.sourceColumnName(),
+                null,
+                mapping.outputColumnName(),
+                mapping.mappingKind().name(),
+                mapping.expression(),
+                mapping.outputOrdinal(),
+                mapping.sourceOrdinal()))
+            .toList();
+        return new ColumnAnalysis(
+            mappings,
+            result.candidateOutputCount(),
+            result.unresolvedReferenceCount(),
+            null);
+      } catch (RuntimeException projectionFailure) {
+        // Non-projection statements can also have no write target. Fall through to the baseline
+        // parser before surfacing a column-level preview failure.
+        try {
+          return analyzePhysicalColumns(sql, dataSourceId);
+        } catch (RuntimeException ignored) {
+          return new ColumnAnalysis(List.of(), 0, 0, safeMessage(projectionFailure));
+        }
+      }
+    }
+
+    try {
+      return analyzePhysicalColumns(sql, dataSourceId);
+    } catch (RuntimeException exception) {
+      return new ColumnAnalysis(List.of(), 0, 0, safeMessage(exception));
+    }
+  }
+
+  private ColumnAnalysis analyzePhysicalColumns(String sql, String dataSourceId) {
+    SqlColumnLineageParser.ParseResult result = columnParser.parse(sql, columnSchemaProvider(dataSourceId));
+    List<ColumnMapping> mappings = result.mappings().stream()
+        .map(mapping -> new ColumnMapping(
+            mapping.sourceTable().qualifiedName(),
+            mapping.sourceColumnName(),
+            mapping.targetTable().qualifiedName(),
+            mapping.targetColumnName(),
+            mapping.mappingKind().name(),
+            mapping.expression(),
+            mapping.outputOrdinal(),
+            mapping.sourceOrdinal()))
+        .toList();
+    return new ColumnAnalysis(
+        mappings,
+        result.candidateOutputCount(),
+        result.unresolvedReferenceCount(),
+        null);
+  }
+
+  private SqlColumnLineageParser.SchemaProvider columnSchemaProvider(String dataSourceId) {
+    Map<String, List<CatalogColumn>> cache = new LinkedHashMap<>();
+    return table -> cache.computeIfAbsent(
+            table.canonicalName(),
+            ignored -> catalogColumns(
+                dataSourceId,
+                table.databaseName(),
+                table.schemaName(),
+                table.tableName()))
+        .stream()
+        .map(column -> new SqlColumnLineageParser.SchemaColumn(column.name(), column.ordinalPosition()))
+        .toList();
+  }
+
+  private SqlProjectionLineageAnalyzer.SchemaProvider projectionSchemaProvider(String dataSourceId) {
+    Map<String, List<CatalogColumn>> cache = new LinkedHashMap<>();
+    return table -> cache.computeIfAbsent(
+            table.canonicalName(),
+            ignored -> catalogColumns(
+                dataSourceId,
+                table.databaseName(),
+                table.schemaName(),
+                table.tableName()))
+        .stream()
+        .map(column -> new SqlProjectionLineageAnalyzer.SchemaColumn(column.name(), column.ordinalPosition()))
+        .toList();
+  }
+
+  private List<CatalogColumn> catalogColumns(
+      String dataSourceId,
+      String database,
+      String schema,
+      String table) {
+    DataSourceCatalogService catalogService = this.dataSourceCatalogService;
+    if (catalogService == null) return List.of();
+
+    final Long numericDataSourceId;
+    try {
+      numericDataSourceId = Long.valueOf(dataSourceId);
+    } catch (NumberFormatException exception) {
+      return List.of();
+    }
+
+    List<DataSourceCatalogColumnVO> columns = listColumns(
+        catalogService,
+        numericDataSourceId,
+        database,
+        schema,
+        table);
+    if (columns.isEmpty() && database == null && schema != null) {
+      columns = listColumns(catalogService, numericDataSourceId, schema, null, table);
+    }
+
+    List<CatalogColumn> result = new ArrayList<>();
+    for (DataSourceCatalogColumnVO column : columns) {
+      if (column == null || column.getName() == null || column.getName().isBlank()) continue;
+      result.add(new CatalogColumn(column.getName(), column.getOrdinalPosition()));
+    }
+    return List.copyOf(result);
+  }
+
+  private List<DataSourceCatalogColumnVO> listColumns(
+      DataSourceCatalogService catalogService,
+      Long dataSourceId,
+      String database,
+      String schema,
+      String table) {
+    try {
+      List<DataSourceCatalogColumnVO> columns = catalogService.listColumns(
+          dataSourceId,
+          database,
+          schema,
+          table);
+      return columns == null ? List.of() : columns;
+    } catch (RuntimeException exception) {
+      return List.of();
+    }
+  }
+
+  private PreviewAsset taskAsset(DevelopmentNode node, String dataSourceId) {
+    String key = "sql-task:data-development:" + node.id();
+    return new PreviewAsset(
+        key,
+        key,
+        LineageAssetType.SQL_TASK,
+        node.name(),
+        "DATA_DEVELOPMENT",
+        String.valueOf(node.id()),
+        null,
+        dataSourceId,
+        null,
+        null,
+        null,
+        null,
+        Map.of("preview", true));
+  }
+
+  private PreviewAsset tableAsset(String dataSourceId, SqlTableLineageParser.TableRef table) {
+    String key = "table:" + dataSourceId + ":" + table.canonicalName();
+    return new PreviewAsset(
+        key,
+        key,
+        LineageAssetType.TABLE,
+        table.qualifiedName(),
+        "DATASOURCE",
+        dataSourceId,
+        null,
+        dataSourceId,
+        table.databaseName(),
+        table.schemaName(),
+        table.tableName(),
+        null,
+        Map.of("qualifiedName", table.qualifiedName(), "preview", true));
+  }
+
+  private PreviewRelation tableRelation(
+      PreviewAsset source,
+      PreviewAsset target,
+      LineageRelationType relationType,
+      String role,
+      long nodeId) {
+    String id = source.id() + "->" + target.id() + ":" + relationType.name();
+    return new PreviewRelation(
+        id,
+        source.id(),
+        target.id(),
+        relationType,
+        PREVIEW_SOURCE_TYPE,
+        String.valueOf(nodeId),
+        null,
+        Map.of("lineageLevel", "TABLE", "tableRole", role, "preview", true));
+  }
+
+  private DevelopmentSqlLineagePreview failedPreview(
+      PreviewAsset task,
+      String dataSourceId,
+      String parseError) {
+    return new DevelopmentSqlLineagePreview(
+        "FAILED",
+        dataSourceId,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        parseError,
+        null,
+        new PreviewGraph(task, LineageDirection.BOTH, 1, List.of(task), List.of()),
+        List.of());
+  }
+
+  private String dataSourceId(String configJson) {
+    try {
+      JsonNode root = objectMapper.readTree(
+          configJson == null || configJson.isBlank() ? "{}" : configJson);
+      JsonNode value = root == null ? null : root.get("dataSourceId");
+      String dataSourceId = value == null || value.isNull() ? null : value.asText();
+      if (dataSourceId == null || dataSourceId.isBlank()) {
+        throw new IllegalArgumentException("SQL task dataSourceId 不能为空");
+      }
+      return dataSourceId.trim();
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("SQL task configJson 不是合法 JSON", exception);
+    }
+  }
+
+  private static String safeMessage(Throwable throwable) {
+    String message = throwable == null ? null : throwable.getMessage();
+    if (message == null || message.isBlank()) {
+      return throwable == null ? "unknown parser error" : throwable.getClass().getSimpleName();
+    }
+    return message.length() > 1000 ? message.substring(0, 1000) : message;
+  }
+
+  private record CatalogColumn(String name, Integer ordinalPosition) {
+  }
+
+  private record ColumnAnalysis(
+      List<ColumnMapping> mappings,
+      int candidateOutputCount,
+      int unresolvedReferenceCount,
+      String error) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
@@ -59,12 +59,16 @@ public class DevelopmentSqlLineagePreviewService {
       Long nodeId,
       String taskType,
       String sql,
-      String configJson) {
+      String configJson,
+      String databaseName,
+      String schemaName) {
     DevelopmentNode node = requireSqlNode(nodeId, taskType);
     if (sql == null || sql.isBlank()) {
       throw new IllegalArgumentException("SQL 不能为空");
     }
     String dataSourceId = dataSourceId(configJson);
+    String defaultDatabase = normalizeContext(databaseName);
+    String defaultSchema = normalizeContext(schemaName);
     PreviewAsset task = taskAsset(node, dataSourceId);
 
     final SqlTableLineageParser.ParseResult tableParsed;
@@ -74,7 +78,12 @@ public class DevelopmentSqlLineagePreviewService {
       return failedPreview(task, dataSourceId, safeMessage(exception));
     }
 
-    ColumnAnalysis columnAnalysis = analyzeColumns(sql, dataSourceId, tableParsed.outputs().isEmpty());
+    ColumnAnalysis columnAnalysis = analyzeColumns(
+        sql,
+        dataSourceId,
+        tableParsed.outputs().isEmpty(),
+        defaultDatabase,
+        defaultSchema);
     Map<String, PreviewAsset> nodes = new LinkedHashMap<>();
     Map<String, PreviewRelation> relations = new LinkedHashMap<>();
     nodes.put(task.id(), task);
@@ -82,13 +91,23 @@ public class DevelopmentSqlLineagePreviewService {
     for (SqlTableLineageParser.TableRef input : tableParsed.inputs()) {
       PreviewAsset table = tableAsset(dataSourceId, input);
       nodes.putIfAbsent(table.id(), table);
-      PreviewRelation relation = tableRelation(table, task, LineageRelationType.READS_FROM, "INPUT", node.id());
+      PreviewRelation relation = tableRelation(
+          table,
+          task,
+          LineageRelationType.READS_FROM,
+          "INPUT",
+          node.id());
       relations.putIfAbsent(relation.id(), relation);
     }
     for (SqlTableLineageParser.TableRef output : tableParsed.outputs()) {
       PreviewAsset table = tableAsset(dataSourceId, output);
       nodes.putIfAbsent(table.id(), table);
-      PreviewRelation relation = tableRelation(task, table, LineageRelationType.WRITES_TO, "OUTPUT", node.id());
+      PreviewRelation relation = tableRelation(
+          task,
+          table,
+          LineageRelationType.WRITES_TO,
+          "OUTPUT",
+          node.id());
       relations.putIfAbsent(relation.id(), relation);
     }
 
@@ -134,12 +153,17 @@ public class DevelopmentSqlLineagePreviewService {
     return node;
   }
 
-  private ColumnAnalysis analyzeColumns(String sql, String dataSourceId, boolean projectionOnly) {
+  private ColumnAnalysis analyzeColumns(
+      String sql,
+      String dataSourceId,
+      boolean projectionOnly,
+      String defaultDatabase,
+      String defaultSchema) {
     if (projectionOnly) {
       try {
         SqlProjectionLineageAnalyzer.ProjectionResult result = projectionAnalyzer.analyze(
             sql,
-            projectionSchemaProvider(dataSourceId));
+            projectionSchemaProvider(dataSourceId, defaultDatabase, defaultSchema));
         List<ColumnMapping> mappings = result.mappings().stream()
             .map(mapping -> new ColumnMapping(
                 mapping.sourceTable().qualifiedName(),
@@ -160,7 +184,11 @@ public class DevelopmentSqlLineagePreviewService {
         // Non-projection statements can also have no write target. Fall through to the baseline
         // parser before surfacing a column-level preview failure.
         try {
-          return analyzePhysicalColumns(sql, dataSourceId);
+          return analyzePhysicalColumns(
+              sql,
+              dataSourceId,
+              defaultDatabase,
+              defaultSchema);
         } catch (RuntimeException ignored) {
           return new ColumnAnalysis(List.of(), 0, 0, safeMessage(projectionFailure));
         }
@@ -168,14 +196,20 @@ public class DevelopmentSqlLineagePreviewService {
     }
 
     try {
-      return analyzePhysicalColumns(sql, dataSourceId);
+      return analyzePhysicalColumns(sql, dataSourceId, defaultDatabase, defaultSchema);
     } catch (RuntimeException exception) {
       return new ColumnAnalysis(List.of(), 0, 0, safeMessage(exception));
     }
   }
 
-  private ColumnAnalysis analyzePhysicalColumns(String sql, String dataSourceId) {
-    SqlColumnLineageParser.ParseResult result = columnParser.parse(sql, columnSchemaProvider(dataSourceId));
+  private ColumnAnalysis analyzePhysicalColumns(
+      String sql,
+      String dataSourceId,
+      String defaultDatabase,
+      String defaultSchema) {
+    SqlColumnLineageParser.ParseResult result = columnParser.parse(
+        sql,
+        columnSchemaProvider(dataSourceId, defaultDatabase, defaultSchema));
     List<ColumnMapping> mappings = result.mappings().stream()
         .map(mapping -> new ColumnMapping(
             mapping.sourceTable().qualifiedName(),
@@ -194,32 +228,67 @@ public class DevelopmentSqlLineagePreviewService {
         null);
   }
 
-  private SqlColumnLineageParser.SchemaProvider columnSchemaProvider(String dataSourceId) {
+  private SqlColumnLineageParser.SchemaProvider columnSchemaProvider(
+      String dataSourceId,
+      String defaultDatabase,
+      String defaultSchema) {
     Map<String, List<CatalogColumn>> cache = new LinkedHashMap<>();
     return table -> cache.computeIfAbsent(
-            table.canonicalName(),
-            ignored -> catalogColumns(
+            schemaCacheKey(table.canonicalName(), defaultDatabase, defaultSchema),
+            ignored -> catalogColumnsForTable(
                 dataSourceId,
                 table.databaseName(),
                 table.schemaName(),
-                table.tableName()))
+                table.tableName(),
+                defaultDatabase,
+                defaultSchema))
         .stream()
-        .map(column -> new SqlColumnLineageParser.SchemaColumn(column.name(), column.ordinalPosition()))
+        .map(column -> new SqlColumnLineageParser.SchemaColumn(
+            column.name(),
+            column.ordinalPosition()))
         .toList();
   }
 
-  private SqlProjectionLineageAnalyzer.SchemaProvider projectionSchemaProvider(String dataSourceId) {
+  private SqlProjectionLineageAnalyzer.SchemaProvider projectionSchemaProvider(
+      String dataSourceId,
+      String defaultDatabase,
+      String defaultSchema) {
     Map<String, List<CatalogColumn>> cache = new LinkedHashMap<>();
     return table -> cache.computeIfAbsent(
-            table.canonicalName(),
-            ignored -> catalogColumns(
+            schemaCacheKey(table.canonicalName(), defaultDatabase, defaultSchema),
+            ignored -> catalogColumnsForTable(
                 dataSourceId,
                 table.databaseName(),
                 table.schemaName(),
-                table.tableName()))
+                table.tableName(),
+                defaultDatabase,
+                defaultSchema))
         .stream()
-        .map(column -> new SqlProjectionLineageAnalyzer.SchemaColumn(column.name(), column.ordinalPosition()))
+        .map(column -> new SqlProjectionLineageAnalyzer.SchemaColumn(
+            column.name(),
+            column.ordinalPosition()))
         .toList();
+  }
+
+  /**
+   * Only unqualified table references inherit the editor database/schema context. Two-part names
+   * remain parser-owned so the existing PostgreSQL schema.table / MySQL database.table fallback is
+   * preserved.
+   */
+  private List<CatalogColumn> catalogColumnsForTable(
+      String dataSourceId,
+      String explicitDatabase,
+      String explicitSchema,
+      String table,
+      String defaultDatabase,
+      String defaultSchema) {
+    String database = explicitDatabase;
+    String schema = explicitSchema;
+    if (database == null && schema == null) {
+      database = defaultDatabase;
+      schema = defaultSchema;
+    }
+    return catalogColumns(dataSourceId, database, schema, table);
   }
 
   private List<CatalogColumn> catalogColumns(
@@ -359,6 +428,22 @@ public class DevelopmentSqlLineagePreviewService {
     } catch (JsonProcessingException exception) {
       throw new IllegalArgumentException("SQL task configJson 不是合法 JSON", exception);
     }
+  }
+
+  private static String normalizeContext(String value) {
+    if (value == null || value.isBlank()) return null;
+    return value.trim();
+  }
+
+  private static String schemaCacheKey(
+      String canonicalName,
+      String defaultDatabase,
+      String defaultSchema) {
+    return canonicalName
+        + "|"
+        + (defaultDatabase == null ? "" : defaultDatabase)
+        + "|"
+        + (defaultSchema == null ? "" : defaultSchema);
   }
 
   private static String safeMessage(Throwable throwable) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
@@ -30,7 +30,9 @@ class DevelopmentSqlLineagePreviewServiceTest {
             FROM ods.orders o
             GROUP BY o.id
             """,
-        "{\"dataSourceId\":\"12\"}");
+        "{\"dataSourceId\":\"12\"}",
+        null,
+        null);
 
     assertEquals("SUCCESS", preview.status());
     assertEquals(1, preview.inputTableCount());
@@ -56,7 +58,9 @@ class DevelopmentSqlLineagePreviewServiceTest {
         7L,
         "SQL",
         "INSERT INTO dws.order_copy (id) SELECT s.id FROM ods.orders s",
-        "{\"dataSourceId\":\"3\"}");
+        "{\"dataSourceId\":\"3\"}",
+        null,
+        null);
 
     assertEquals("SUCCESS", preview.status());
     assertEquals(1, preview.inputTableCount());
@@ -81,8 +85,10 @@ class DevelopmentSqlLineagePreviewServiceTest {
     DevelopmentSqlLineagePreview preview = service.preview(
         9L,
         "SQL",
-        "SELECT FROM",
-        "{\"dataSourceId\":\"1\"}");
+        "SELECT (",
+        "{\"dataSourceId\":\"1\"}",
+        null,
+        null);
 
     assertEquals("FAILED", preview.status());
     assertTrue(preview.parseError() != null && !preview.parseError().isBlank());
@@ -108,7 +114,9 @@ class DevelopmentSqlLineagePreviewServiceTest {
             5L,
             "SQL",
             "SELECT 1",
-            "{\"dataSourceId\":\"1\"}"));
+            "{\"dataSourceId\":\"1\"}",
+            null,
+            null));
   }
 
   private static DevelopmentSqlLineagePreviewService service(DevelopmentNode node) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
@@ -1,0 +1,137 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.lineage.LineageRelationType;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentSqlLineagePreviewServiceTest {
+
+  @Test
+  void previewsCurrentSelectWithoutPersistingAProductionTarget() {
+    DevelopmentSqlLineagePreviewService service = service(sqlNode(1L, "订单汇总"));
+
+    DevelopmentSqlLineagePreview preview = service.preview(
+        1L,
+        "SQL",
+        """
+            SELECT o.id, SUM(o.amount) AS total_amount
+            FROM ods.orders o
+            GROUP BY o.id
+            """,
+        "{\"dataSourceId\":\"12\"}");
+
+    assertEquals("SUCCESS", preview.status());
+    assertEquals(1, preview.inputTableCount());
+    assertEquals(0, preview.outputTableCount());
+    assertEquals(2, preview.columnMappingCount());
+    assertEquals(2, preview.graph().nodes().size());
+    assertEquals(1, preview.graph().relations().size());
+    assertEquals(LineageRelationType.READS_FROM, preview.graph().relations().get(0).relationType());
+    assertTrue(preview.graph().nodes().stream()
+        .anyMatch(asset -> "table:12:ods.orders".equals(asset.assetKey())));
+    assertTrue(preview.columnMappings().stream()
+        .anyMatch(mapping -> "amount".equals(mapping.sourceColumn())
+            && "total_amount".equals(mapping.targetColumn())
+            && "AGGREGATION".equals(mapping.mappingKind())));
+    assertNull(preview.columnMappings().get(0).targetTable());
+  }
+
+  @Test
+  void previewsInsertAsInputTaskOutputAndKeepsColumnEvidence() {
+    DevelopmentSqlLineagePreviewService service = service(sqlNode(7L, "写入汇总"));
+
+    DevelopmentSqlLineagePreview preview = service.preview(
+        7L,
+        "SQL",
+        "INSERT INTO dws.order_copy (id) SELECT s.id FROM ods.orders s",
+        "{\"dataSourceId\":\"3\"}");
+
+    assertEquals("SUCCESS", preview.status());
+    assertEquals(1, preview.inputTableCount());
+    assertEquals(1, preview.outputTableCount());
+    assertEquals(3, preview.graph().nodes().size());
+    assertEquals(2, preview.graph().relations().size());
+    assertTrue(preview.graph().relations().stream()
+        .anyMatch(relation -> relation.relationType() == LineageRelationType.READS_FROM));
+    assertTrue(preview.graph().relations().stream()
+        .anyMatch(relation -> relation.relationType() == LineageRelationType.WRITES_TO));
+    assertTrue(preview.columnMappings().stream()
+        .anyMatch(mapping -> "ods.orders".equals(mapping.sourceTable())
+            && "id".equals(mapping.sourceColumn())
+            && "dws.order_copy".equals(mapping.targetTable())
+            && "id".equals(mapping.targetColumn())));
+  }
+
+  @Test
+  void returnsFailedPreviewForInvalidSqlInsteadOfWritingStaleLineage() {
+    DevelopmentSqlLineagePreviewService service = service(sqlNode(9L, "错误 SQL"));
+
+    DevelopmentSqlLineagePreview preview = service.preview(
+        9L,
+        "SQL",
+        "SELECT FROM",
+        "{\"dataSourceId\":\"1\"}");
+
+    assertEquals("FAILED", preview.status());
+    assertTrue(preview.parseError() != null && !preview.parseError().isBlank());
+    assertEquals(1, preview.graph().nodes().size());
+    assertTrue(preview.graph().relations().isEmpty());
+  }
+
+  @Test
+  void rejectsNonSqlNode() {
+    DevelopmentSqlLineagePreviewService service = service(new DevelopmentNode(
+        5L,
+        "Python",
+        "PYTHON",
+        null,
+        null,
+        true,
+        Instant.now(),
+        Instant.now()));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.preview(
+            5L,
+            "SQL",
+            "SELECT 1",
+            "{\"dataSourceId\":\"1\"}"));
+  }
+
+  private static DevelopmentSqlLineagePreviewService service(DevelopmentNode node) {
+    DevelopmentNodeRepository repository = mock(DevelopmentNodeRepository.class);
+    when(repository.findById(node.id())).thenReturn(Optional.of(node));
+    SqlColumnLineageParser columnParser = new DerivedAwareSqlColumnLineageParser();
+    return new DevelopmentSqlLineagePreviewService(
+        repository,
+        new SqlTableLineageParser(),
+        columnParser,
+        new DevelopmentSqlProjectionLineageAnalyzer(columnParser),
+        new ObjectMapper());
+  }
+
+  private static DevelopmentNode sqlNode(long id, String name) {
+    return new DevelopmentNode(
+        id,
+        name,
+        "SQL",
+        null,
+        null,
+        true,
+        Instant.now(),
+        Instant.now());
+  }
+}

--- a/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/DevelopmentWorkbench.tsx
@@ -16,6 +16,7 @@ import {
 import { isDevelopmentTaskNode } from '../../node-model';
 import {
   getDevelopmentTaskDraft,
+  previewDevelopmentSqlLineage,
   publishDevelopmentTask,
   runDevelopmentTask,
   saveDevelopmentTaskDraft,
@@ -25,6 +26,7 @@ import type {
   DevelopmentId,
   DevelopmentNode,
   DevelopmentResourceNode,
+  DevelopmentSqlLineagePreview,
   DevelopmentTaskDraft,
   DevelopmentTaskRunResult,
 } from '../../types';
@@ -34,7 +36,9 @@ import EditorHost from './EditorHost';
 import EditorTabs, { type EditorTabAction } from './EditorTabs';
 import EditorToolbar from './EditorToolbar';
 import RightPanel from './RightPanel';
-import RunResultPanel from './RunResultPanel';
+import RunResultPanel, {
+  type WorkbenchBottomPanelView,
+} from './RunResultPanel';
 
 interface DevelopmentWorkbenchProps {
   nodes: DevelopmentResourceNode[];
@@ -131,9 +135,15 @@ const DevelopmentWorkbench = ({
   const [openNodeIds, setOpenNodeIds] = useState<DevelopmentId[]>([]);
   const [activeNodeId, setActiveNodeId] = useState<DevelopmentId>();
   const [runPanelOpen, setRunPanelOpen] = useState(false);
+  const [bottomPanelView, setBottomPanelView] =
+    useState<WorkbenchBottomPanelView>('result');
   const [runResults, setRunResults] = useState<
     Partial<Record<DevelopmentId, DevelopmentTaskRunResult>>
   >({});
+  const [lineagePreviews, setLineagePreviews] = useState<
+    Partial<Record<DevelopmentId, DevelopmentSqlLineagePreview>>
+  >({});
+  const [lineageLoadingNodeIds, setLineageLoadingNodeIds] = useState<DevelopmentId[]>([]);
   const [runningNodeIds, setRunningNodeIds] = useState<DevelopmentId[]>([]);
   const [pendingClose, setPendingClose] = useState<PendingCloseRequest>();
   const [saving, setSaving] = useState(false);
@@ -165,6 +175,7 @@ const DevelopmentWorkbench = ({
       current && nodeMap.has(current) ? current : undefined,
     );
     setResourceDirtyNodeIds((current) => current.filter((nodeId) => nodeMap.has(nodeId)));
+    setLineageLoadingNodeIds((current) => current.filter((nodeId) => nodeMap.has(nodeId)));
   }, [nodeMap]);
 
   useEffect(() => {
@@ -199,6 +210,9 @@ const DevelopmentWorkbench = ({
   const activeRunning = activeTaskNode
     ? runningNodeIds.includes(activeTaskNode.id)
     : false;
+  const activeLineageLoading = activeTaskNode
+    ? lineageLoadingNodeIds.includes(activeTaskNode.id)
+    : false;
   const openDataServiceNodes = useMemo(
     () => openNodeIds
       .map((nodeId) => nodeMap.get(nodeId))
@@ -218,6 +232,7 @@ const DevelopmentWorkbench = ({
     setOpenNodeIds((current) => current.includes(nodeId) ? current : [...current, nodeId]);
     setActiveNodeId(nodeId);
     if (!isDevelopmentTaskNode(target)) setRunPanelOpen(false);
+    else if (target.type !== 'SQL') setBottomPanelView('result');
     onNodeFocus(nodeId);
   };
 
@@ -267,6 +282,7 @@ const DevelopmentWorkbench = ({
     const node = activeTaskNode;
     const startedAt = Date.now();
     setRunPanelOpen(true);
+    setBottomPanelView('result');
     setRunningNodeIds((current) => [...current, node.id]);
     setRunResults((current) => ({
       ...current,
@@ -306,6 +322,34 @@ const DevelopmentWorkbench = ({
       message.error(errorMessage);
     } finally {
       setRunningNodeIds((current) => current.filter((nodeId) => nodeId !== node.id));
+    }
+  };
+
+  const previewActiveLineage = async () => {
+    if (!activeTaskNode || activeTaskNode.type !== 'SQL' || activeLineageLoading) return;
+    const node = activeTaskNode;
+    setRunPanelOpen(true);
+    setBottomPanelView('lineage');
+    setLineageLoadingNodeIds((current) =>
+      current.includes(node.id) ? current : [...current, node.id],
+    );
+
+    try {
+      const definition = prepareDevelopmentTaskDefinition(node);
+      const preview = responseData(
+        await previewDevelopmentSqlLineage(node.id, definition),
+        '血缘解析失败',
+      );
+      setLineagePreviews((current) => ({ ...current, [node.id]: preview }));
+      if (preview.status === 'FAILED') {
+        message.error(preview.parseError || '当前 SQL 血缘解析失败');
+      } else if (preview.status === 'PARTIAL' || preview.status === 'UNRESOLVED') {
+        message.warning('血缘解析完成，部分字段暂未能解析');
+      }
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '血缘解析失败');
+    } finally {
+      setLineageLoadingNodeIds((current) => current.filter((nodeId) => nodeId !== node.id));
     }
   };
 
@@ -355,6 +399,8 @@ const DevelopmentWorkbench = ({
     const nextNode = nextActiveId ? nodeMap.get(nextActiveId) : undefined;
     if (!nextNode || !isDevelopmentTaskNode(nextNode)) {
       setRunPanelOpen(false);
+    } else if (nextNode.type !== 'SQL') {
+      setBottomPanelView('result');
     }
   };
 
@@ -492,9 +538,13 @@ const DevelopmentWorkbench = ({
               onRun={() => void runActiveTask()}
               onSave={() => void saveActiveDraft()}
               onPublish={() => void publishActiveTask()}
+              onLineage={activeTaskNode.type === 'SQL'
+                ? () => void previewActiveLineage()
+                : undefined}
               running={activeRunning}
               saving={saving}
               publishing={publishing}
+              lineageLoading={activeLineageLoading}
             />
 
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -520,6 +570,13 @@ const DevelopmentWorkbench = ({
                 directory={activeDirectory}
                 definition={definition}
                 result={runResults[activeTaskNode.id]}
+                view={bottomPanelView}
+                onViewChange={setBottomPanelView}
+                lineagePreview={lineagePreviews[activeTaskNode.id]}
+                lineageLoading={activeLineageLoading}
+                onRefreshLineage={activeTaskNode.type === 'SQL'
+                  ? () => void previewActiveLineage()
+                  : undefined}
                 onClose={() => setRunPanelOpen(false)}
               />
             </div>

--- a/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/EditorToolbar.tsx
@@ -11,9 +11,11 @@ interface EditorToolbarProps {
   onRun: () => void;
   onSave: () => void;
   onPublish: () => void;
+  onLineage?: () => void;
   running: boolean;
   saving: boolean;
   publishing: boolean;
+  lineageLoading?: boolean;
 }
 
 const iconButtonClassName =
@@ -26,9 +28,11 @@ const EditorToolbar = ({
   onRun,
   onSave,
   onPublish,
+  onLineage,
   running,
   saving,
   publishing,
+  lineageLoading,
 }: EditorToolbarProps) => {
   const Toolbar = definition.Toolbar;
   const capabilities = definition.capabilities;
@@ -43,9 +47,11 @@ const EditorToolbar = ({
             onRun={onRun}
             onSave={onSave}
             onPublish={onPublish}
+            onLineage={onLineage}
             running={running}
             saving={saving}
             publishing={publishing}
+            lineageLoading={lineageLoading}
           />
         </div>
       ) : (

--- a/yak-ops-ui/src/pages/data-development/components/workbench/RunResultPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/workbench/RunResultPanel.tsx
@@ -1,13 +1,17 @@
-import { LoaderCircle, X } from 'lucide-react';
+import { GitBranch, LoaderCircle, Table2, X } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useState } from 'react';
 
+import SqlLineagePreviewPanel from '../../editors/sql/lineage/SqlLineagePreviewPanel';
 import type { DevelopmentEditorDefinition } from '../../editors/types';
 import type {
   DevelopmentDirectory,
   DevelopmentNode,
+  DevelopmentSqlLineagePreview,
   DevelopmentTaskRunResult,
 } from '../../types';
+
+export type WorkbenchBottomPanelView = 'result' | 'lineage';
 
 interface RunResultPanelProps {
   open: boolean;
@@ -15,6 +19,11 @@ interface RunResultPanelProps {
   directory?: DevelopmentDirectory;
   definition: DevelopmentEditorDefinition;
   result?: DevelopmentTaskRunResult;
+  view: WorkbenchBottomPanelView;
+  onViewChange: (view: WorkbenchBottomPanelView) => void;
+  lineagePreview?: DevelopmentSqlLineagePreview;
+  lineageLoading?: boolean;
+  onRefreshLineage?: () => void;
   onClose: () => void;
 }
 
@@ -44,16 +53,30 @@ const statusText = (result?: DevelopmentTaskRunResult) => {
   return result.status;
 };
 
+const tabClassName = (active: boolean) => [
+  'relative flex h-full items-center gap-1.5 px-2 text-[12px] transition-colors',
+  active
+    ? 'font-medium text-[#344054] after:absolute after:inset-x-1 after:bottom-0 after:h-[2px] after:bg-[rgba(254,44,85,.9)]'
+    : 'text-[#8a8f99] hover:text-[#475467]',
+].join(' ');
+
 const RunResultPanel = ({
   open,
   node,
   directory,
   definition,
   result,
+  view,
+  onViewChange,
+  lineagePreview,
+  lineageLoading = false,
+  onRefreshLineage,
   onClose,
 }: RunResultPanelProps) => {
   const [height, setHeight] = useState(initialHeight);
   const [resizing, setResizing] = useState(false);
+  const lineageAvailable = node.type === 'SQL' && Boolean(onRefreshLineage);
+  const actualView = view === 'lineage' && lineageAvailable ? 'lineage' : 'result';
 
   const handleResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!open) return;
@@ -103,7 +126,7 @@ const RunResultPanel = ({
         <>
           <div
             role="separator"
-            aria-label="调整运行结果面板高度"
+            aria-label="调整底部面板高度"
             aria-orientation="horizontal"
             onPointerDown={handleResizeStart}
             className="group absolute inset-x-0 top-0 z-40 h-3 -translate-y-1/2 cursor-row-resize touch-none"
@@ -112,29 +135,49 @@ const RunResultPanel = ({
           </div>
 
           <div className="flex h-full flex-col overflow-hidden bg-white">
-            <div className="flex h-10 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-3">
-              <div className="flex min-w-0 items-center gap-3">
-                <span className="shrink-0 text-[12px] font-medium text-[#344054]">
-                  运行结果
-                </span>
-                <span className="truncate text-[11px] text-[#98a2b3]">
+            <div className="flex h-10 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-2">
+              <div className="flex h-full min-w-0 items-center gap-1">
+                <button
+                  type="button"
+                  className={tabClassName(actualView === 'result')}
+                  onClick={() => onViewChange('result')}
+                >
+                  <Table2 size={13} strokeWidth={1.8} />
+                  结果
+                </button>
+                {lineageAvailable ? (
+                  <button
+                    type="button"
+                    className={tabClassName(actualView === 'lineage')}
+                    onClick={() => onViewChange('lineage')}
+                  >
+                    <GitBranch size={13} strokeWidth={1.8} />
+                    血缘
+                  </button>
+                ) : null}
+                <span className="mx-1 h-4 w-px bg-[#e5e7eb]" />
+                <span className="max-w-[240px] truncate text-[11px] text-[#98a2b3]">
                   当前节点：{node.name}
                 </span>
-                {result?.status === 'RUNNING' ? (
+                {actualView === 'result' && result?.status === 'RUNNING' ? (
                   <span className="inline-flex shrink-0 items-center gap-1 text-[11px] text-[#667085]">
                     <LoaderCircle size={12} className="animate-spin" />
                     运行中
                   </span>
-                ) : statusText(result) ? (
+                ) : actualView === 'result' && statusText(result) ? (
                   <span className="shrink-0 text-[11px] text-[#667085]">
                     {statusText(result)}
+                  </span>
+                ) : actualView === 'lineage' ? (
+                  <span className="shrink-0 text-[11px] text-[#667085]">
+                    当前 SQL · 预览血缘
                   </span>
                 ) : null}
               </div>
               <button
                 type="button"
                 title="关闭"
-                aria-label="关闭运行结果面板"
+                aria-label="关闭底部面板"
                 onClick={onClose}
                 className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[3px] text-[#667085] transition-colors hover:bg-[#f5f5f6] hover:text-[#344054]"
               >
@@ -143,7 +186,14 @@ const RunResultPanel = ({
             </div>
 
             <div className="min-h-0 flex-1 overflow-hidden bg-white">
-              {Result ? (
+              {actualView === 'lineage' && onRefreshLineage ? (
+                <SqlLineagePreviewPanel
+                  nodeId={node.id}
+                  preview={lineagePreview}
+                  loading={lineageLoading}
+                  onRefresh={onRefreshLineage}
+                />
+              ) : Result ? (
                 <Result node={node} directory={directory} result={result} />
               ) : (
                 <div className="flex h-full items-center justify-center text-center">

--- a/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/SqlToolbar.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, message } from 'antd';
 import {
+  GitBranch,
   LoaderCircle,
   Play,
   Redo2,
@@ -50,9 +51,11 @@ const SqlToolbar = ({
   onRun,
   onSave,
   onPublish,
+  onLineage,
   running,
   saving,
   publishing,
+  lineageLoading,
 }: DevelopmentEditorToolbarContext) => {
   const execute = (command: SqlEditorCommand, fallback: string) => {
     if (!executeSqlEditorCommand(node.id, command)) {
@@ -97,6 +100,19 @@ const SqlToolbar = ({
             <Rocket size={15} strokeWidth={1.8} />
           )}
         </ToolbarButton>
+        {onLineage ? (
+          <ToolbarButton
+            title={lineageLoading ? '血缘解析中' : '解析当前 SQL 血缘'}
+            disabled={Boolean(lineageLoading || saving || publishing || running)}
+            onClick={onLineage}
+          >
+            {lineageLoading ? (
+              <LoaderCircle size={15} className="animate-spin" />
+            ) : (
+              <GitBranch size={15} strokeWidth={1.8} />
+            )}
+          </ToolbarButton>
+        ) : null}
         <ToolbarDivider />
         <ToolbarButton
           title="撤销"

--- a/yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx
@@ -1,0 +1,233 @@
+import { history } from '@umijs/max';
+import { Button, Empty, Tooltip } from 'antd';
+import { ArrowUpRight, GitBranch, LoaderCircle, RefreshCw } from 'lucide-react';
+import { useMemo } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  MarkerType,
+  type Edge,
+  type Node,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+import LineageNode, {
+  type LineageNodeData,
+} from '@/pages/data-analysis/lineage/LineageNode';
+import { buildLineageView } from '@/pages/data-analysis/lineage/graph-layout';
+import type {
+  LineageAssetType,
+  LineageGraph,
+} from '@/pages/data-analysis/lineage/types';
+
+import type {
+  DevelopmentId,
+  DevelopmentSqlLineagePreview,
+} from '../../../types';
+
+interface SqlLineagePreviewPanelProps {
+  nodeId: DevelopmentId;
+  preview?: DevelopmentSqlLineagePreview;
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+const nodeTypes = { lineage: LineageNode };
+const visibleTypes = new Set<LineageAssetType>(['TABLE', 'SQL_TASK']);
+
+const statusLabel: Record<DevelopmentSqlLineagePreview['status'], string> = {
+  SUCCESS: '解析成功',
+  PARTIAL: '部分解析',
+  UNRESOLVED: '字段待解析',
+  FAILED: '解析失败',
+};
+
+const statusClassName: Record<DevelopmentSqlLineagePreview['status'], string> = {
+  SUCCESS: 'bg-[#ecfdf3] text-[#027a48]',
+  PARTIAL: 'bg-[#fffaeb] text-[#b54708]',
+  UNRESOLVED: 'bg-[#f2f4f7] text-[#667085]',
+  FAILED: 'bg-[#fef3f2] text-[#b42318]',
+};
+
+const Metric = ({ label, value }: { label: string; value: number }) => (
+  <span className="inline-flex items-center gap-1 text-[11px] text-[#8a8f99]">
+    <span>{label}</span>
+    <span className="font-medium tabular-nums text-[#475467]">{value}</span>
+  </span>
+);
+
+const SqlLineagePreviewPanel = ({
+  nodeId,
+  preview,
+  loading,
+  onRefresh,
+}: SqlLineagePreviewPanelProps) => {
+  const graph: LineageGraph | undefined = preview?.graph;
+  const view = useMemo(
+    () => (graph ? buildLineageView(graph, 'BOTH', visibleTypes) : undefined),
+    [graph],
+  );
+
+  const flowNodes = useMemo<Array<Node<LineageNodeData>>>(() => (
+    view?.nodes.map(({ asset, position }) => ({
+      id: asset.id,
+      type: 'lineage',
+      position,
+      draggable: false,
+      selectable: false,
+      data: { asset, root: asset.id === graph?.root.id },
+    })) || []
+  ), [graph?.root.id, view?.nodes]);
+
+  const flowEdges = useMemo<Edge[]>(() => (
+    view?.relations.map((relation) => ({
+      id: relation.id,
+      source: relation.sourceAssetId,
+      target: relation.targetAssetId,
+      type: 'smoothstep',
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 14,
+        height: 14,
+        color: '#b9bec6',
+      },
+      style: {
+        stroke: '#c9cdd3',
+        strokeWidth: 1.15,
+      },
+    })) || []
+  ), [view?.relations]);
+
+  const productionAssetKey = `sql-task:data-development:${nodeId}`;
+  const graphKey = graph
+    ? graph.nodes.map((node) => node.id).join('|') || graph.root.id
+    : 'empty';
+
+  if (loading && !preview) {
+    return (
+      <div className="flex h-full items-center justify-center bg-[#fbfcfd] text-[12px] text-[#667085]">
+        <LoaderCircle size={16} className="mr-2 animate-spin" />
+        正在解析当前 SQL 血缘
+      </div>
+    );
+  }
+
+  if (!preview) {
+    return (
+      <div className="flex h-full items-center justify-center bg-[#fbfcfd]">
+        <Empty
+          image={(
+            <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-[9px] bg-[#eef0f3] text-[#667085]">
+              <GitBranch size={20} />
+            </div>
+          )}
+          description={(
+            <div>
+              <div className="text-[13px] font-medium text-[#475467]">解析当前 SQL 查看血缘</div>
+              <div className="mt-1 text-[11px] text-[#98a2b3]">预览只解析当前编辑内容，不保存、不发布、也不写入正式血缘。</div>
+            </div>
+          )}
+        >
+          <Button size="small" icon={<RefreshCw size={13} />} onClick={onRefresh}>
+            解析血缘
+          </Button>
+        </Empty>
+      </div>
+    );
+  }
+
+  if (preview.status === 'FAILED') {
+    return (
+      <div className="flex h-full items-center justify-center bg-[#fbfcfd] px-8">
+        <Empty
+          description={(
+            <div className="max-w-[620px]">
+              <div className="text-[13px] font-medium text-[#b42318]">SQL 血缘解析失败</div>
+              <div className="mt-1 break-words text-[11px] leading-5 text-[#8a8f99]">
+                {preview.parseError || '当前 SQL 暂时无法解析，请检查语法后重试。'}
+              </div>
+            </div>
+          )}
+        >
+          <Button size="small" icon={<RefreshCw size={13} />} onClick={onRefresh}>
+            再次解析
+          </Button>
+        </Empty>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-white">
+      <div className="flex h-9 shrink-0 items-center gap-3 border-b border-[#eef0f2] px-3">
+        <span
+          className={[
+            'shrink-0 rounded-[4px] px-1.5 py-0.5 text-[10px] font-medium',
+            statusClassName[preview.status],
+          ].join(' ')}
+        >
+          {statusLabel[preview.status]}
+        </span>
+        <Metric label="输入表" value={preview.inputTableCount} />
+        <Metric label="输出表" value={preview.outputTableCount} />
+        <Metric label="字段映射" value={preview.columnMappingCount} />
+        <Metric label="未解析" value={preview.unresolvedColumnReferenceCount} />
+        {preview.columnParseError ? (
+          <span
+            className="min-w-0 flex-1 truncate text-[11px] text-[#b54708]"
+            title={preview.columnParseError}
+          >
+            字段级解析降级：{preview.columnParseError}
+          </span>
+        ) : (
+          <span className="min-w-0 flex-1" />
+        )}
+        <Tooltip title="重新解析当前编辑器 SQL">
+          <Button
+            type="text"
+            size="small"
+            loading={loading}
+            icon={<RefreshCw size={13} />}
+            onClick={onRefresh}
+          >
+            再次解析
+          </Button>
+        </Tooltip>
+        <Tooltip title="打开该 SQL 节点已发布并持久化的正式血缘">
+          <Button
+            type="text"
+            size="small"
+            icon={<ArrowUpRight size={13} />}
+            onClick={() => history.push(
+              `/data-analysis/lineage?assetKey=${encodeURIComponent(productionAssetKey)}`,
+            )}
+          >
+            生产血缘
+          </Button>
+        </Tooltip>
+      </div>
+
+      <div className="relative min-h-0 flex-1 bg-[#fbfcfd]">
+        <ReactFlow
+          key={graphKey}
+          nodes={flowNodes}
+          edges={flowEdges}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.28, minZoom: 0.62, maxZoom: 1.05 }}
+          minZoom={0.35}
+          maxZoom={1.35}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background gap={18} size={1} color="#e4e7eb" />
+          <Controls showInteractive={false} position="bottom-right" />
+        </ReactFlow>
+      </div>
+    </div>
+  );
+};
+
+export default SqlLineagePreviewPanel;

--- a/yak-ops-ui/src/pages/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/types.ts
@@ -26,9 +26,11 @@ export interface DevelopmentEditorToolbarContext
   onRun: () => void;
   onSave: () => void;
   onPublish: () => void;
+  onLineage?: () => void;
   running: boolean;
   saving: boolean;
   publishing: boolean;
+  lineageLoading?: boolean;
 }
 
 export interface DevelopmentEditorRunResultContext

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -2,6 +2,7 @@ import type { ApiResponse } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 
 import type { YakEditorSettings } from './editors/sql/editorSettings';
+import { getSqlMetadataContext } from './editors/sql/metadata/sqlMetadataContextStore';
 import type {
   CreateDevelopmentDirectoryPayload,
   CreateDevelopmentNodePayload,
@@ -90,11 +91,17 @@ export const runDevelopmentTask = (
 export const previewDevelopmentSqlLineage = (
   nodeId: DevelopmentId,
   payload: DevelopmentSqlLineagePreviewRequest,
-): Promise<ApiResponse<DevelopmentSqlLineagePreview>> =>
-  HttpUtils.post<DevelopmentSqlLineagePreview>(
+): Promise<ApiResponse<DevelopmentSqlLineagePreview>> => {
+  const metadataContext = getSqlMetadataContext(nodeId);
+  return HttpUtils.post<DevelopmentSqlLineagePreview>(
     `${NODE_API}/${nodeId}/lineage/preview`,
-    payload,
+    {
+      ...payload,
+      databaseName: payload.databaseName ?? metadataContext?.database,
+      schemaName: payload.schemaName ?? metadataContext?.schema,
+    },
   );
+};
 
 const queryString = (query: object) => {
   const params = new URLSearchParams();

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -12,6 +12,7 @@ import type {
   DevelopmentReleaseQuery,
   DevelopmentReleaseSummary,
   DevelopmentResourceNode,
+  DevelopmentSqlLineagePreview,
   DevelopmentTaskDefinition,
   DevelopmentTaskDraft,
   DevelopmentTaskExecutionDetail,
@@ -83,6 +84,16 @@ export const runDevelopmentTask = (
   payload: DevelopmentTaskDefinition,
 ): Promise<ApiResponse<DevelopmentTaskRunResult>> =>
   HttpUtils.post<DevelopmentTaskRunResult>(`${NODE_API}/${nodeId}/run`, payload);
+
+/** Parse current SQL editor content without saving, publishing or registering lineage. */
+export const previewDevelopmentSqlLineage = (
+  nodeId: DevelopmentId,
+  payload: DevelopmentTaskDefinition,
+): Promise<ApiResponse<DevelopmentSqlLineagePreview>> =>
+  HttpUtils.post<DevelopmentSqlLineagePreview>(
+    `${NODE_API}/${nodeId}/lineage/preview`,
+    payload,
+  );
 
 const queryString = (query: object) => {
   const params = new URLSearchParams();

--- a/yak-ops-ui/src/pages/data-development/service.ts
+++ b/yak-ops-ui/src/pages/data-development/service.ts
@@ -13,6 +13,7 @@ import type {
   DevelopmentReleaseSummary,
   DevelopmentResourceNode,
   DevelopmentSqlLineagePreview,
+  DevelopmentSqlLineagePreviewRequest,
   DevelopmentTaskDefinition,
   DevelopmentTaskDraft,
   DevelopmentTaskExecutionDetail,
@@ -88,7 +89,7 @@ export const runDevelopmentTask = (
 /** Parse current SQL editor content without saving, publishing or registering lineage. */
 export const previewDevelopmentSqlLineage = (
   nodeId: DevelopmentId,
-  payload: DevelopmentTaskDefinition,
+  payload: DevelopmentSqlLineagePreviewRequest,
 ): Promise<ApiResponse<DevelopmentSqlLineagePreview>> =>
   HttpUtils.post<DevelopmentSqlLineagePreview>(
     `${NODE_API}/${nodeId}/lineage/preview`,

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -114,6 +114,73 @@ export interface DevelopmentSqlRunOutput {
   dataSourceId?: string;
 }
 
+export type DevelopmentSqlLineagePreviewStatus =
+  | 'SUCCESS'
+  | 'PARTIAL'
+  | 'UNRESOLVED'
+  | 'FAILED';
+
+export interface DevelopmentSqlLineagePreviewAsset {
+  id: string;
+  assetKey: string;
+  assetType: 'TABLE' | 'SQL_TASK';
+  name: string;
+  sourceType?: string;
+  sourceId?: string;
+  parentAssetId?: string;
+  dataSourceId?: string;
+  databaseName?: string;
+  schemaName?: string;
+  tableName?: string;
+  columnName?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface DevelopmentSqlLineagePreviewRelation {
+  id: string;
+  sourceAssetId: string;
+  targetAssetId: string;
+  relationType: 'READS_FROM' | 'WRITES_TO';
+  sourceType?: string;
+  sourceId?: string;
+  expression?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface DevelopmentSqlLineagePreviewGraph {
+  root: DevelopmentSqlLineagePreviewAsset;
+  direction: 'BOTH';
+  depth: number;
+  nodes: DevelopmentSqlLineagePreviewAsset[];
+  relations: DevelopmentSqlLineagePreviewRelation[];
+}
+
+export interface DevelopmentSqlLineageColumnMapping {
+  sourceTable: string;
+  sourceColumn: string;
+  targetTable?: string | null;
+  targetColumn: string;
+  mappingKind: 'IDENTITY' | 'TRANSFORMATION' | 'AGGREGATION';
+  expression?: string | null;
+  outputOrdinal: number;
+  sourceOrdinal: number;
+}
+
+export interface DevelopmentSqlLineagePreview {
+  status: DevelopmentSqlLineagePreviewStatus;
+  dataSourceId: string;
+  statementCount: number;
+  inputTableCount: number;
+  outputTableCount: number;
+  columnMappingCount: number;
+  candidateOutputColumnCount: number;
+  unresolvedColumnReferenceCount: number;
+  parseError?: string | null;
+  columnParseError?: string | null;
+  graph: DevelopmentSqlLineagePreviewGraph;
+  columnMappings: DevelopmentSqlLineageColumnMapping[];
+}
+
 export interface DevelopmentTaskExecutionSummary {
   id: DevelopmentId;
   nodeId: DevelopmentId;

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -114,6 +114,11 @@ export interface DevelopmentSqlRunOutput {
   dataSourceId?: string;
 }
 
+export interface DevelopmentSqlLineagePreviewRequest extends DevelopmentTaskDefinition {
+  databaseName?: string;
+  schemaName?: string;
+}
+
 export type DevelopmentSqlLineagePreviewStatus =
   | 'SUCCESS'
   | 'PARTIAL'


### PR DESCRIPTION
## What
- add a read-only SQL lineage preview API for the current editor content
- reuse the existing table/column lineage parsers and datasource catalog; preview does not persist assets or relations
- add a SQL toolbar lineage action and a `结果 / 血缘` bottom-panel switch
- reuse the existing lineage graph components and provide a link to the published production lineage

## Behavior
- clicking `血缘` parses the current SQL directly without save or publish
- the selected SQL database/schema context is passed to preview parsing so unqualified `SELECT * FROM table` can resolve catalog columns
- published lineage remains unchanged: `DevelopmentSqlLineageService -> LineageService -> yak_metadata_asset/yak_metadata_relation`

## Tests
- add `DevelopmentSqlLineagePreviewServiceTest` covering SELECT projection lineage, INSERT input/output lineage, parse failure, and non-SQL rejection
- CI pending