### PR TITLE
fix(lineage): stabilize SQL lineage interactions

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/sql/lineage/ColumnLineageNode.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/lineage/ColumnLineageNode.tsx
@@ -1,16 +1,18 @@
 import { FunctionSquare, KeyRound, Table2 } from 'lucide-react';
 import { Handle, type NodeProps, Position } from 'reactflow';
+import { useLineageInteraction } from './LineageInteractionContext';
 
 export interface ColumnLineageField {
   name: string;
+  dataType?: string;
   transformed: boolean;
+  expression?: string;
 }
 
 export interface ColumnLineageNodeData {
   tableName: string;
   role: 'source' | 'target';
   fields: ColumnLineageField[];
-  activeFields: Set<string>;
   onFieldClick: (tableName: string, fieldName: string) => void;
   onFieldHover: (tableName?: string, fieldName?: string) => void;
 }
@@ -18,8 +20,9 @@ export interface ColumnLineageNodeData {
 export const columnHandleId = (fieldName: string) => `column:${fieldName}`;
 
 export default function ColumnLineageNode({ data }: NodeProps<ColumnLineageNodeData>) {
+  const interaction = useLineageInteraction();
   return (
-    <div className="w-[250px] overflow-hidden rounded-[10px] border border-[#dfe3e8] bg-white shadow-[0_8px_24px_rgba(16,24,40,.08)]">
+    <div className="w-[270px] overflow-hidden rounded-[10px] border border-[#dfe3e8] bg-white shadow-[0_3px_10px_rgba(16,24,40,.06)]">
       <div className="flex h-11 items-center gap-2 border-b border-[#e8eaed] bg-[#f7f8fa] px-3">
         <Table2 size={16} className="text-[#475467]" />
         <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#1d2939]" title={data.tableName}>
@@ -31,7 +34,7 @@ export default function ColumnLineageNode({ data }: NodeProps<ColumnLineageNodeD
       </div>
       <div className="py-1">
         {data.fields.map((field, index) => {
-          const active = data.activeFields.has(field.name);
+          const active = interaction.hoveredFieldKey === `${data.tableName}.${field.name}`;
           return (
             <button
               key={field.name}
@@ -46,6 +49,7 @@ export default function ColumnLineageNode({ data }: NodeProps<ColumnLineageNodeD
             >
               {index === 0 ? <KeyRound size={13} className="text-[#e0a400]" /> : <span className="w-[13px]" />}
               <span className="min-w-0 flex-1 truncate text-[12px] text-[#344054]">{field.name}</span>
+              <span className="text-[9px] font-medium text-[#98a2b3]">{field.dataType || 'UNKNOWN'}</span>
               {field.transformed ? <FunctionSquare size={13} className="text-[#7f56d9]" /> : null}
               {data.role === 'target' ? (
                 <Handle
@@ -66,6 +70,12 @@ export default function ColumnLineageNode({ data }: NodeProps<ColumnLineageNodeD
           );
         })}
       </div>
+      {data.fields.some((field) => field.expression) ? (
+        <div className="border-t border-[#eef0f2] bg-[#fcfcfd] px-3 py-2 text-[10px] text-[#667085]">
+          <div className="mb-1 font-medium uppercase tracking-wide text-[#98a2b3]">Transformation</div>
+          <code className="block truncate">{data.fields.find((field) => field.expression)?.expression}</code>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/data-development/editors/sql/lineage/LineageInteractionContext.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/lineage/LineageInteractionContext.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+export interface LineageInteractionState {
+  hoveredNodeId?: string;
+  hoveredFieldKey?: string;
+  relatedNodeIds: ReadonlySet<string>;
+  relatedEdgeIds: ReadonlySet<string>;
+  relatedMappingIds: ReadonlySet<string>;
+}
+
+export const EMPTY_LINEAGE_INTERACTION: LineageInteractionState = {
+  relatedNodeIds: new Set(),
+  relatedEdgeIds: new Set(),
+  relatedMappingIds: new Set(),
+};
+export const LineageInteractionContext = createContext<LineageInteractionState>(EMPTY_LINEAGE_INTERACTION);
+export const useLineageInteraction = () => useContext(LineageInteractionContext);

--- a/yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx
@@ -2,7 +2,17 @@ import { history } from '@umijs/max';
 import { Button, Drawer, Empty, Segmented, Tooltip } from 'antd';
 import { ArrowUpRight, Expand, Focus, GitBranch, LoaderCircle, RefreshCw, Shrink } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import ReactFlow, { Background, Controls, type Edge, MarkerType, type Node, type ReactFlowInstance } from 'reactflow';
+import ReactFlow, {
+  Background,
+  BaseEdge,
+  Controls,
+  type Edge,
+  type EdgeProps,
+  getSmoothStepPath,
+  MarkerType,
+  type Node,
+  type ReactFlowInstance,
+} from 'reactflow';
 import 'reactflow/dist/style.css';
 
 import { buildLineageView } from '@/pages/data-analysis/lineage/graph-layout';
@@ -10,6 +20,7 @@ import LineageNode, { type LineageNodeData } from '@/pages/data-analysis/lineage
 import type { LineageAssetType, LineageGraph } from '@/pages/data-analysis/lineage/types';
 import type { DevelopmentId, DevelopmentSqlLineageColumnMapping, DevelopmentSqlLineagePreview } from '../../../types';
 import ColumnLineageNode, { type ColumnLineageNodeData, columnHandleId } from './ColumnLineageNode';
+import { LineageInteractionContext, useLineageInteraction } from './LineageInteractionContext';
 
 interface Props {
   nodeId: DevelopmentId;
@@ -24,7 +35,63 @@ interface FieldSelection {
   mappings: DevelopmentSqlLineageColumnMapping[];
 }
 
-const nodeTypes = { lineage: LineageNode, columnLineage: ColumnLineageNode };
+interface InteractiveEdgeData {
+  defaultLabel?: string;
+}
+const InteractiveEdge = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  data,
+}: EdgeProps<InteractiveEdgeData>) => {
+  const interaction = useLineageInteraction();
+  const [path, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+  const hasHover = Boolean(interaction.hoveredNodeId || interaction.hoveredFieldKey);
+  const active = interaction.relatedEdgeIds.has(id) || interaction.relatedMappingIds.has(id);
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={path}
+        markerEnd={markerEnd}
+        style={{
+          stroke: active ? '#f04473' : '#c5cad1',
+          strokeWidth: active ? 2.2 : 1.25,
+          opacity: hasHover && !active ? 0.16 : 1,
+          transition: 'opacity 120ms, stroke 120ms',
+        }}
+      />
+      {data?.defaultLabel ? (
+        <text x={labelX} y={labelY} textAnchor="middle" className="fill-[#6941c6] text-[10px]">
+          {data.defaultLabel}
+        </text>
+      ) : null}
+    </>
+  );
+};
+const InteractiveLineageNode = (props: Parameters<typeof LineageNode>[0]) => {
+  const interaction = useLineageInteraction();
+  const dimmed = Boolean(interaction.hoveredNodeId && !interaction.relatedNodeIds.has(props.id));
+  return (
+    <div style={{ opacity: dimmed ? 0.25 : 1, transition: 'opacity 120ms' }}>
+      <LineageNode {...props} />
+    </div>
+  );
+};
+const nodeTypes = { lineage: InteractiveLineageNode, columnLineage: ColumnLineageNode };
+const edgeTypes = { interactive: InteractiveEdge };
 const visibleTypes = new Set<LineageAssetType>(['TABLE', 'SQL_TASK']);
 const statusLabel = { SUCCESS: '解析成功', PARTIAL: '部分解析', UNRESOLVED: '字段待解析', FAILED: '解析失败' } as const;
 const statusClassName = {
@@ -93,6 +160,15 @@ export default function SqlLineagePreviewPanel({ nodeId, preview, loading, onRef
     }
     return ids;
   }, [hoveredAsset, view]);
+  const relatedTableEdges = useMemo(
+    () =>
+      new Set(
+        view?.relations
+          .filter((edge) => relatedAssets.has(edge.sourceAssetId) && relatedAssets.has(edge.targetAssetId))
+          .map((edge) => edge.id) || [],
+      ),
+    [relatedAssets, view?.relations],
+  );
 
   const tableNodes = useMemo<Array<Node<LineageNodeData>>>(
     () =>
@@ -102,31 +178,19 @@ export default function SqlLineagePreviewPanel({ nodeId, preview, loading, onRef
         position,
         draggable: true,
         data: { asset, root: asset.id === graph?.root.id },
-        style: hoveredAsset && !relatedAssets.has(asset.id) ? { opacity: 0.28 } : undefined,
       })) || [],
-    [graph?.root.id, hoveredAsset, relatedAssets, view?.nodes],
+    [graph?.root.id, view?.nodes],
   );
   const tableEdges = useMemo<Edge[]>(
     () =>
-      view?.relations.map((relation) => {
-        const active = Boolean(
-          hoveredAsset && relatedAssets.has(relation.sourceAssetId) && relatedAssets.has(relation.targetAssetId),
-        );
-        return {
-          id: relation.id,
-          source: relation.sourceAssetId,
-          target: relation.targetAssetId,
-          type: 'smoothstep',
-          animated: active,
-          markerEnd: { type: MarkerType.ArrowClosed, width: 15, height: 15, color: active ? '#f04473' : '#98a2b3' },
-          style: {
-            stroke: active ? '#f04473' : '#c5cad1',
-            strokeWidth: active ? 2.2 : 1.25,
-            opacity: hoveredAsset && !active ? 0.2 : 1,
-          },
-        };
-      }) || [],
-    [hoveredAsset, relatedAssets, view?.relations],
+      view?.relations.map((relation) => ({
+        id: relation.id,
+        source: relation.sourceAssetId,
+        target: relation.targetAssetId,
+        type: 'interactive',
+        markerEnd: { type: MarkerType.ArrowClosed, width: 15, height: 15, color: '#98a2b3' },
+      })) || [],
+    [view?.relations],
   );
 
   const activeMappingIds = useMemo(
@@ -186,7 +250,6 @@ export default function SqlLineagePreviewPanel({ nodeId, preview, loading, onRef
                 (role === 'source' ? item.sourceColumn : item.targetColumn) === name && item.mappingKind !== 'IDENTITY',
             ),
           })),
-          activeFields: new Set(hoveredField && hoveredField.table === table ? [hoveredField.column] : []),
           onFieldClick: openField,
           onFieldHover: hoverField,
         },
@@ -196,34 +259,43 @@ export default function SqlLineagePreviewPanel({ nodeId, preview, loading, onRef
       ...layout.sourceTables.map(({ table, position }) => makeNode('source', table, position)),
       ...layout.targetTables.map(({ table, position }) => makeNode('target', table, position)),
     ];
-  }, [hoveredField, hoverField, layout, openField, preview?.columnMappings]);
+  }, [hoverField, layout, openField, preview?.columnMappings]);
   const columnEdges = useMemo<Edge[]>(
     () =>
       (preview?.columnMappings || [])
         .filter((item) => item.targetTable)
         .map((item) => {
           const id = `${item.outputOrdinal}:${item.sourceOrdinal}`;
-          const active = !hoveredField || activeMappingIds.has(id);
           return {
             id,
             source: nodeIdFor('source', item.sourceTable),
             sourceHandle: columnHandleId(item.sourceColumn),
             target: nodeIdFor('target', item.targetTable!),
             targetHandle: columnHandleId(item.targetColumn),
-            type: 'smoothstep',
-            animated: Boolean(hoveredField && active),
-            label: item.mappingKind === 'IDENTITY' ? undefined : item.mappingKind === 'AGGREGATION' ? '聚合' : '转换',
-            labelStyle: { fontSize: 10, fill: '#6941c6' },
-            labelBgStyle: { fill: '#f4f0ff' },
-            markerEnd: { type: MarkerType.ArrowClosed, color: active ? '#f04473' : '#b9c0c9', width: 13, height: 13 },
-            style: {
-              stroke: active ? '#f04473' : '#c7ccd4',
-              strokeWidth: active ? 2 : 1.15,
-              opacity: active ? 1 : 0.12,
+            type: 'interactive',
+            data: {
+              defaultLabel:
+                item.mappingKind === 'IDENTITY'
+                  ? undefined
+                  : item.mappingKind === 'AGGREGATION'
+                    ? 'SUM / COUNT'
+                    : 'TRANSFORM',
             },
+            markerEnd: { type: MarkerType.ArrowClosed, color: '#b9c0c9', width: 13, height: 13 },
           };
         }),
-    [activeMappingIds, hoveredField, preview?.columnMappings],
+    [preview?.columnMappings],
+  );
+
+  const interaction = useMemo(
+    () => ({
+      hoveredNodeId: hoveredAsset,
+      hoveredFieldKey: hoveredField ? fieldKey(hoveredField.table, hoveredField.column) : undefined,
+      relatedNodeIds: relatedAssets,
+      relatedEdgeIds: relatedTableEdges,
+      relatedMappingIds: hoveredField ? activeMappingIds : new Set<string>(),
+    }),
+    [activeMappingIds, hoveredAsset, hoveredField, relatedAssets, relatedTableEdges],
   );
 
   if (loading && !preview)
@@ -341,26 +413,28 @@ export default function SqlLineagePreviewPanel({ nodeId, preview, loading, onRef
         </Button>
       </div>
       <div className="relative min-h-0 flex-1 bg-[#f8fafc]">
-        <ReactFlow
-          key={`${mode}:${graph?.root.id}`}
-          nodes={isColumn ? columnNodes : tableNodes}
-          edges={isColumn ? columnEdges : tableEdges}
-          nodeTypes={nodeTypes}
-          fitView
-          fitViewOptions={{ padding: 0.25, minZoom: 0.45, maxZoom: 1 }}
-          minZoom={0.25}
-          maxZoom={1.5}
-          nodesDraggable
-          nodesConnectable={false}
-          elementsSelectable={false}
-          onInit={setFlow}
-          onNodeMouseEnter={(_, node) => !isColumn && setHoveredAsset(node.id)}
-          onNodeMouseLeave={() => setHoveredAsset(undefined)}
-          proOptions={{ hideAttribution: true }}
-        >
-          <Background gap={18} size={1} color="#dfe3e8" />
-          <Controls showInteractive={false} position="bottom-right" />
-        </ReactFlow>
+        <LineageInteractionContext.Provider value={interaction}>
+          <ReactFlow
+            nodes={isColumn ? columnNodes : tableNodes}
+            edges={isColumn ? columnEdges : tableEdges}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.25, minZoom: 0.45, maxZoom: 1 }}
+            minZoom={0.25}
+            maxZoom={1.5}
+            nodesDraggable
+            nodesConnectable={false}
+            elementsSelectable
+            onInit={setFlow}
+            onNodeMouseEnter={(_, node) => !isColumn && setHoveredAsset(node.id)}
+            onNodeMouseLeave={() => setHoveredAsset(undefined)}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background gap={18} size={1} color="#dfe3e8" />
+            <Controls showInteractive={false} position="bottom-right" />
+          </ReactFlow>
+        </LineageInteractionContext.Provider>
       </div>
       <Drawer width={430} title="字段血缘详情" open={Boolean(selection)} onClose={() => setSelection(undefined)}>
         {selection ? (


### PR DESCRIPTION
### Motivation

- 修复字段血缘预览中出现的血缘图在鼠标 hover / 切换字段时突然消失的问题，该问题源于交互状态参与到 ReactFlow `nodes`/`edges` 的构造中导致图模型被重复重建。 
- 将数据模型（graph nodes/edges）和交互状态（hover/selection/highlight）分离，以避免无意义的重新初始化并提升 hover 高亮体验。

### Description

- 将交互状态抽离为独立 Context：新增 `LineageInteractionContext`，用于承载 `hoveredNodeId`、`hoveredFieldKey`、以及计算好的关联节点/边/映射集合。 (yak-ops-ui/src/pages/data-development/editors/sql/lineage/LineageInteractionContext.ts)
- 稳定化 ReactFlow 元素：修改 `SqlLineagePreviewPanel` 中 `nodes` 与 `edges` 的构造，使其仅依赖实际血缘数据（`preview.graph` / `preview.columnMappings`），移除了 hover 等交互状态在 memo 依赖中的直接影响，从而避免在鼠标移动时重建元素或重置视图；并移除导致强制 remount 的动态 `key`。 (yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx)
- 渲染层实现高亮而非重建模型：新增自定义 edge/node 渲染器（`InteractiveEdge` / `InteractiveLineageNode`），通过 Context 驱动渲染样式变化（强调色、透明度、标签等），只在渲染层改变视觉效果而不调整节点 id/position/type。 (yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx)
- 优化字段卡片：在 `ColumnLineageNode` 中加入字段类型与 transformation 区域、调整卡片样式（更轻的阴影与更宽的宽度），并从 interaction context 读取 hovered-field，使字段高亮只影响渲染层而不改变列节点结构。 (yak-ops-ui/src/pages/data-development/editors/sql/lineage/ColumnLineageNode.tsx)
- 保留并强化字段级血缘信息：字段映射连线增加类型标签（如 `TRANSFORM` / `SUM / COUNT`），字段详情抽屉继续展示 expression 等转换逻辑。

### Testing

- 运行并修复代码风格/格式检查：`npx @biomejs/biome check --write src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx src/pages/data-development/editors/sql/lineage/ColumnLineageNode.tsx src/pages/data-development/editors/sql/lineage/LineageInteractionContext.ts`（自动修正并通过）。
- 单元测试：`npx jest src/pages/data-analysis/lineage/graph-layout.test.ts --runInBand`（1 个测试套件，3 个测试全部通过）。
- 类型检查：尝试运行 `npx tsc --noEmit` 时发现环境缺少项目中隐式依赖的 `minimatch` 类型定义，导致 TypeScript 报 `TS2688`（环境问题；代码变更本身保持 TypeScript 类型声明完整）。

Modified files: 
- `yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx` 
- `yak-ops-ui/src/pages/data-development/editors/sql/lineage/ColumnLineageNode.tsx` 
- `yak-ops-ui/src/pages/data-development/editors/sql/lineage/LineageInteractionContext.ts`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86c8e32f408326a8fcb52382981a6f)