### PR TITLE
feat(home): add operations workbench panels

### DIFF
--- a/yak-ops-ui/src/layouts/SiteLayout/index.tsx
+++ b/yak-ops-ui/src/layouts/SiteLayout/index.tsx
@@ -43,6 +43,7 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import MessageList, { MESSAGE_COUNT_CHANGED_EVENT } from "@/pages/system/messages/MessageList";
 import { getUnreadMessageCount } from "@/services/security/messages";
+import { recordRecentVisit } from "@/utils/recent-visits";
 
 const HEADER_HEIGHT = 48;
 const SIDEBAR_WIDTH = 200;
@@ -466,6 +467,19 @@ function SiteLayoutContent() {
   const routeMetadata = getRouteMetadata(location.pathname);
 
   const pageTitle = routeMetadata?.title ?? "Yak Ops";
+
+  useEffect(() => {
+    if (!routeMetadata || routeMetadata.id === "home") return;
+    recordRecentVisit({
+      path: `${location.pathname}${location.search}`,
+      title: routeMetadata.title,
+    });
+  }, [
+    location.pathname,
+    location.search,
+    routeMetadata?.id,
+    routeMetadata?.title,
+  ]);
 
   const userInitial = useMemo(() => {
     return currentUser?.name?.trim().slice(0, 1).toUpperCase() || "Y";

--- a/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
@@ -1,0 +1,241 @@
+import { history } from '@umijs/max';
+import {
+  AlertTriangle,
+  ArrowRightLeft,
+  CheckCircle2,
+  ChevronRight,
+  Clock3,
+  Code2,
+  History,
+  ShieldCheck,
+  Workflow,
+} from 'lucide-react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import {
+  readRecentVisits,
+  RECENT_VISITS_CHANGED_EVENT,
+  type RecentVisit,
+} from '@/utils/recent-visits';
+import { homeDataCenterApi, type HomeRecentTask } from './service';
+
+const FAILED_STATUSES = new Set(['FAILED', 'ERROR', 'LOST', 'TIMED_OUT']);
+
+const taskMeta: Record<string, { label: string; icon: ReactNode }> = {
+  OFFLINE_SYNC: {
+    label: '离线同步',
+    icon: <ArrowRightLeft size={15} strokeWidth={1.9} />,
+  },
+  WORKFLOW: {
+    label: '工作流',
+    icon: <Workflow size={15} strokeWidth={1.9} />,
+  },
+  DATA_QUALITY: {
+    label: '数据质量',
+    icon: <ShieldCheck size={15} strokeWidth={1.9} />,
+  },
+};
+
+const visitIcon = (path: string) => {
+  if (path.startsWith('/workflow')) {
+    return <Workflow size={15} strokeWidth={1.9} />;
+  }
+  if (path.startsWith('/sync')) {
+    return <ArrowRightLeft size={15} strokeWidth={1.9} />;
+  }
+  if (path.startsWith('/data-quality')) {
+    return <ShieldCheck size={15} strokeWidth={1.9} />;
+  }
+  return <Code2 size={15} strokeWidth={1.9} />;
+};
+
+const relativeTime = (value: string | number) => {
+  const timestamp = typeof value === 'number' ? value : new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return '-';
+  const minutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes}分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}小时前`;
+  const days = Math.floor(hours / 24);
+  return days < 30 ? `${days}天前` : new Date(timestamp).toLocaleDateString();
+};
+
+function PanelHeader({
+  title,
+  extra,
+}: {
+  title: string;
+  extra?: ReactNode;
+}) {
+  return (
+    <header className="flex h-8 items-start justify-between gap-4">
+      <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+        {title}
+      </h2>
+      {extra}
+    </header>
+  );
+}
+
+function EmptyPanel({ healthy = false }: { healthy?: boolean }) {
+  return (
+    <div className="flex min-h-[178px] flex-col items-center justify-center text-center">
+      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[#f4f7f5] text-[#4e8d68]">
+        {healthy ? (
+          <CheckCircle2 size={19} strokeWidth={1.8} />
+        ) : (
+          <History size={19} strokeWidth={1.8} />
+        )}
+      </span>
+      <strong className="mt-3 text-[13px] font-semibold text-[#464a53]">
+        {healthy ? '当前没有待处理异常' : '暂无最近访问'}
+      </strong>
+      <span className="mt-1 text-[11px] leading-5 text-[#9a9ea6]">
+        {healthy ? '平台任务运行正常' : '打开业务页面后会自动记录在这里'}
+      </span>
+    </div>
+  );
+}
+
+function AttentionList({ items }: { items: HomeRecentTask[] }) {
+  if (items.length === 0) return <EmptyPanel healthy />;
+  return (
+    <div className="mt-3 divide-y divide-[#f0f1f3]">
+      {items.map((item) => {
+        const meta = taskMeta[item.taskType] || {
+          label: '任务',
+          icon: <Clock3 size={15} strokeWidth={1.9} />,
+        };
+        return (
+          <button
+            key={`${item.taskType}-${item.taskId}`}
+            type="button"
+            onClick={() => item.detailPath && history.push(item.detailPath)}
+            className="group flex w-full items-center gap-3 border-0 bg-transparent py-3 text-left"
+          >
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#fff2f4] text-[#e24a65]">
+              {meta.icon}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-2">
+                <strong className="truncate text-[13px] font-semibold text-[#343842] transition-colors group-hover:text-[#161823]">
+                  {item.taskName}
+                </strong>
+                <span className="shrink-0 rounded bg-[#f5f6f8] px-1.5 py-0.5 text-[10px] text-[#858a93]">
+                  {meta.label}
+                </span>
+              </span>
+              <span className="mt-1 block text-[11px] text-[#969ba4]">
+                最近一次运行失败 · {relativeTime(item.lastRunTime)}
+              </span>
+            </span>
+            <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-[#d64a63]">
+              <AlertTriangle size={13} strokeWidth={1.9} />
+              待处理
+            </span>
+            <ChevronRight
+              size={14}
+              strokeWidth={1.8}
+              className="shrink-0 text-[#b2b6bd] transition-transform group-hover:translate-x-0.5"
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function RecentVisitList({ items }: { items: RecentVisit[] }) {
+  if (items.length === 0) return <EmptyPanel />;
+  return (
+    <div className="mt-3 divide-y divide-[#f0f1f3]">
+      {items.slice(0, 5).map((item) => (
+        <button
+          key={item.path}
+          type="button"
+          onClick={() => history.push(item.path)}
+          className="group flex w-full items-center gap-3 border-0 bg-transparent py-3 text-left"
+        >
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#f3f5f8] text-[#68707d]">
+            {visitIcon(item.path)}
+          </span>
+          <span className="min-w-0 flex-1">
+            <strong className="block truncate text-[13px] font-semibold text-[#3a3e47] transition-colors group-hover:text-[#161823]">
+              {item.title}
+            </strong>
+            <span className="mt-1 block truncate text-[10px] text-[#a0a4ac]">
+              {item.path}
+            </span>
+          </span>
+          <span className="shrink-0 text-[10px] text-[#9a9ea6]">
+            {relativeTime(item.visitedAt)}
+          </span>
+          <ChevronRight
+            size={14}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#b2b6bd] transition-transform group-hover:translate-x-0.5"
+          />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default function HomeWorkbench() {
+  const [recentTasks, setRecentTasks] = useState<HomeRecentTask[]>([]);
+  const [recentVisits, setRecentVisits] = useState<RecentVisit[]>(() =>
+    readRecentVisits(),
+  );
+
+  useEffect(() => {
+    let active = true;
+    homeDataCenterApi.recent()
+      .then((response) => {
+        if (active) setRecentTasks(response.data?.items || []);
+      })
+      .catch(() => {
+        if (active) setRecentTasks([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const refresh = () => setRecentVisits(readRecentVisits());
+    window.addEventListener(RECENT_VISITS_CHANGED_EVENT, refresh);
+    return () =>
+      window.removeEventListener(RECENT_VISITS_CHANGED_EVENT, refresh);
+  }, []);
+
+  const attentionItems = useMemo(
+    () =>
+      recentTasks
+        .filter((item) => FAILED_STATUSES.has(item.lastStatus?.toUpperCase()))
+        .slice(0, 5),
+    [recentTasks],
+  );
+
+  return (
+    <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_410px]">
+      <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-4 pt-5">
+        <PanelHeader
+          title="待处理事项"
+          extra={
+            <span className="mt-1 text-[11px] text-[#969ba4]">
+              {attentionItems.length > 0
+                ? `${attentionItems.length} 项需要关注`
+                : '运行状态正常'}
+            </span>
+          }
+        />
+        <AttentionList items={attentionItems} />
+      </section>
+
+      <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-4 pt-5">
+        <PanelHeader title="最近访问" />
+        <RecentVisitList items={recentVisits} />
+      </section>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/home/index.tsx
+++ b/yak-ops-ui/src/pages/home/index.tsx
@@ -1,3 +1,4 @@
+import { history } from '@umijs/max';
 import {
   ArrowRightLeft,
   BarChart3,
@@ -7,9 +8,12 @@ import {
   ShieldCheck,
   Workflow,
 } from 'lucide-react';
-import { type ReactNode } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
+import { fetchDataSourceSummary } from '@/pages/data-source/service';
 import DataCenter from './DataCenter';
+import HomeWorkbench from './HomeWorkbench';
 import ScheduleCenter from './ScheduleCenter';
+import { homeDataCenterApi } from './service';
 
 /* =========================================================
  * Types
@@ -253,12 +257,19 @@ interface ProfileStatProps {
   label: string;
   value: number;
   arrow?: boolean;
+  onClick?: () => void;
 }
 
-function ProfileStat({ label, value, arrow = false }: ProfileStatProps) {
+function ProfileStat({
+  label,
+  value,
+  arrow = false,
+  onClick,
+}: ProfileStatProps) {
   return (
     <button
       type="button"
+      onClick={onClick}
       className="
         flex items-center border-0 bg-transparent p-0 text-sm leading-[22px]
         text-[#747983] transition-colors duration-200 hover:text-[#292c35]
@@ -321,31 +332,49 @@ function HomeSecondaryPanels() {
  * ========================================================= */
 
 export default function CreatorWorkbenchPage() {
-  const handleAction = (key: string) => {
-    console.log('creator action:', key);
+  const [headerStats, setHeaderStats] = useState({
+    dataSourceCount: 0,
+    runningCount: 0,
+    exceptionCount: 0,
+  });
 
-    switch (key) {
-      case 'data-source':
-        // TODO 数据源管理
-        break;
-      case 'offline-sync':
-        // TODO 离线同步
-        break;
-      case 'development':
-        // TODO 数据开发
-        break;
-      case 'workflow':
-        // TODO 工作流
-        break;
-      case 'quality':
-        // TODO 数据质量
-        break;
-      case 'application':
-        // TODO 数据应用
-        break;
-      default:
-        break;
-    }
+  useEffect(() => {
+    let active = true;
+    Promise.allSettled([
+      fetchDataSourceSummary(),
+      homeDataCenterApi.overview('7d'),
+    ]).then(([dataSourceResult, overviewResult]) => {
+      if (!active) return;
+      setHeaderStats({
+        dataSourceCount:
+          dataSourceResult.status === 'fulfilled'
+            ? dataSourceResult.value.data?.total || 0
+            : 0,
+        runningCount:
+          overviewResult.status === 'fulfilled'
+            ? overviewResult.value.data?.metrics?.runningCount || 0
+            : 0,
+        exceptionCount:
+          overviewResult.status === 'fulfilled'
+            ? overviewResult.value.data?.metrics?.failedCount || 0
+            : 0,
+      });
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleAction = (key: string) => {
+    const routes: Record<string, string> = {
+      'data-source': '/data-source',
+      'offline-sync': '/sync/batch-link-up',
+      development: '/data-development',
+      workflow: '/workflow/definitions',
+      quality: '/data-quality/table-config',
+      application: '/dashboard',
+    };
+    if (routes[key]) history.push(routes[key]);
   };
 
   return (
@@ -414,9 +443,23 @@ export default function CreatorWorkbenchPage() {
               </div>
 
               <div className="mt-2.5 flex items-center gap-[27px]">
-                <ProfileStat label="数据源" value={0} arrow />
-                <ProfileStat label="运行中" value={0} arrow />
-                <ProfileStat label="今日异常" value={0} />
+                <ProfileStat
+                  label="数据源"
+                  value={headerStats.dataSourceCount}
+                  arrow
+                  onClick={() => history.push('/data-source')}
+                />
+                <ProfileStat
+                  label="运行中"
+                  value={headerStats.runningCount}
+                  arrow
+                  onClick={() => history.push('/data-development/executions')}
+                />
+                <ProfileStat
+                  label="近7日异常"
+                  value={headerStats.exceptionCount}
+                  onClick={() => history.push('/data-development/executions')}
+                />
               </div>
             </div>
           </div>
@@ -459,6 +502,7 @@ export default function CreatorWorkbenchPage() {
           </div>
 
           <HomeSecondaryPanels />
+          <HomeWorkbench />
         </main>
       </div>
     </div>

--- a/yak-ops-ui/src/utils/recent-visits.ts
+++ b/yak-ops-ui/src/utils/recent-visits.ts
@@ -1,0 +1,36 @@
+export interface RecentVisit {
+  path: string;
+  title: string;
+  visitedAt: number;
+}
+
+export const RECENT_VISITS_CHANGED_EVENT = 'yak-recent-visits-changed';
+
+const STORAGE_KEY = 'yak-ops:recent-visits';
+const MAX_RECENT_VISITS = 8;
+
+export const readRecentVisits = (): RecentVisit[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const value = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '[]');
+    if (!Array.isArray(value)) return [];
+    return value.filter(
+      (item): item is RecentVisit =>
+        typeof item?.path === 'string'
+        && typeof item?.title === 'string'
+        && typeof item?.visitedAt === 'number',
+    );
+  } catch {
+    return [];
+  }
+};
+
+export const recordRecentVisit = (visit: Omit<RecentVisit, 'visitedAt'>) => {
+  if (typeof window === 'undefined') return;
+  const next = [
+    { ...visit, visitedAt: Date.now() },
+    ...readRecentVisits().filter((item) => item.path !== visit.path),
+  ].slice(0, MAX_RECENT_VISITS);
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  window.dispatchEvent(new CustomEvent(RECENT_VISITS_CHANGED_EVENT));
+};


### PR DESCRIPTION
## 背景

首页已经具备快捷入口、运行总览和调度中心，但下半区仍缺少“登录后该处理什么”和“如何快速回到上次工作”的工作台能力。

## 本次改动

- 新增「待处理事项」面板
  - 复用现有 `/api/v1/home/data-center/recent` 接口
  - 聚合离线同步、工作流、数据质量最近一次运行失败的任务
  - 支持点击直接进入现有任务详情
  - 无异常时展示轻量健康状态
- 新增「最近访问」面板
  - 在 SiteLayout 中按真实路由记录最近访问页面
  - 本地最多保留 8 条并按路径去重
  - 首页展示最近 5 条，可直接返回对应页面
- 接通首页顶部统计
  - 数据源数量读取现有数据源 summary 接口
  - 运行中和近 7 日异常读取现有首页 overview 接口
  - 将原先硬编码的 `0` 替换为真实数据
- 接通 6 个首页快捷入口
  - 数据源管理
  - 离线同步
  - 数据开发
  - 工作流
  - 数据质量
  - 仪表盘

## 设计说明

继续复用 Yak Ops 当前首页的白底、浅灰边框、圆角和高密度布局。新增区域与「数据中心 / 调度中心」保持相同的左右比例，没有再堆叠额外统计图表。

## 影响范围

仅修改 4 个前端文件：

- `yak-ops-ui/src/pages/home/index.tsx`
- `yak-ops-ui/src/pages/home/HomeWorkbench.tsx`
- `yak-ops-ui/src/layouts/SiteLayout/index.tsx`
- `yak-ops-ui/src/utils/recent-visits.ts`

没有数据库迁移、后端接口变更或新依赖。

## 验证

已完成：

- 分支与最新 `main` 对齐：1 commit ahead / 0 behind
- `git diff --check` 通过
- 变更范围核对为 4 个预期前端文件
- 首页快捷入口逐项与 `navigation.ts` 路由核对
- 首页统计与现有 API 返回模型核对

当前执行环境没有安装 Yak Ops 前端依赖，因此未实际执行 TypeScript / Umi build。合并前建议运行：

```bash
cd yak-ops-ui
npm run tsc
npm run build
```
