### PR TITLE
fix(data-development): restore missing editorModeStore build error

### DIFF
--- a/yak-ops-ui/src/pages/data-development/editors/session/editorModeStore.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/session/editorModeStore.ts
@@ -1,0 +1,50 @@
+import { useSyncExternalStore } from 'react';
+
+import type { DevelopmentId } from '../../types';
+
+export type EditorMode = 'inline' | 'resource';
+
+const DEFAULT_MODE: EditorMode = 'inline';
+
+const modes = new Map<DevelopmentId, EditorMode>();
+const listeners = new Set<() => void>();
+let version = 0;
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getVersion = () => version;
+
+const emitChange = () => {
+  version += 1;
+  listeners.forEach((listener) => listener());
+};
+
+export const getEditorMode = (nodeId: DevelopmentId): EditorMode =>
+  modes.get(nodeId) || DEFAULT_MODE;
+
+export const setEditorMode = (
+  nodeId: DevelopmentId,
+  mode: EditorMode,
+) => {
+  if (getEditorMode(nodeId) === mode) return;
+  modes.set(nodeId, mode);
+  emitChange();
+};
+
+export const clearEditorMode = (nodeId: DevelopmentId) => {
+  if (!modes.has(nodeId)) return;
+  modes.delete(nodeId);
+  emitChange();
+};
+
+export const useEditorMode = (nodeId: DevelopmentId) => {
+  useSyncExternalStore(subscribe, getVersion, getVersion);
+
+  return {
+    mode: getEditorMode(nodeId),
+    setMode: (mode: EditorMode) => setEditorMode(nodeId, mode),
+  };
+};


### PR DESCRIPTION
## 问题

修复数据开发编辑器启动构建失败问题。

当前前端编译时报错：

```
Could not resolve "./session/editorModeStore"
```

原因是 Python/Shell 编辑器以及任务持久化逻辑已经引用 `editorModeStore`，但是对应文件缺失，导致 Umi/esbuild 无法解析模块。

## 修改内容

- 新增 `editorModeStore.ts`
- 提供统一编辑模式管理能力：
  - `inline`
  - `resource`
- 补充：
  - `getEditorMode`
  - `setEditorMode`
  - `clearEditorMode`
  - `useEditorMode`
- 使用轻量级 external store，保持与现有 `editorSessionStore` 设计一致

## 验证

- 解决 esbuild 模块解析失败问题
- Python/Shell 编辑器导入路径恢复正常

后续可以继续增强编辑模式持久化能力（例如跟随 editorSessionStore 保存到 localStorage）。