### PR TITLE
fix(lineage): resolve unqualified physical table identities

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
@@ -34,6 +34,7 @@ public class DevelopmentSqlLineagePreviewService {
   private final SqlColumnLineageParser columnParser;
   private final SqlProjectionLineageAnalyzer projectionAnalyzer;
   private final ObjectMapper objectMapper;
+  private final TableIdentityResolver identityResolver = new TableIdentityResolver();
 
   private DataSourceCatalogService dataSourceCatalogService;
 
@@ -66,9 +67,12 @@ public class DevelopmentSqlLineagePreviewService {
     if (sql == null || sql.isBlank()) {
       throw new IllegalArgumentException("SQL 不能为空");
     }
-    String dataSourceId = dataSourceId(configJson);
-    String defaultDatabase = normalizeContext(databaseName);
-    String defaultSchema = normalizeContext(schemaName);
+    SqlContext persisted = sqlContext(configJson);
+    String dataSourceId = persisted.dataSourceId();
+    // Explicit preview parameters override persisted revision context.
+    String defaultDatabase = firstNonBlank(databaseName, persisted.databaseName());
+    String defaultSchema = firstNonBlank(schemaName, persisted.schemaName());
+    SqlContext context = new SqlContext(dataSourceId, defaultDatabase, defaultSchema, persisted.dialect());
     PreviewAsset task = taskAsset(node, dataSourceId);
 
     final SqlTableLineageParser.ParseResult tableParsed;
@@ -89,7 +93,7 @@ public class DevelopmentSqlLineagePreviewService {
     nodes.put(task.id(), task);
 
     for (SqlTableLineageParser.TableRef input : tableParsed.inputs()) {
-      PreviewAsset table = tableAsset(dataSourceId, input);
+      PreviewAsset table = tableAsset(context, input);
       nodes.putIfAbsent(table.id(), table);
       PreviewRelation relation = tableRelation(
           table,
@@ -100,7 +104,7 @@ public class DevelopmentSqlLineagePreviewService {
       relations.putIfAbsent(relation.id(), relation);
     }
     for (SqlTableLineageParser.TableRef output : tableParsed.outputs()) {
-      PreviewAsset table = tableAsset(dataSourceId, output);
+      PreviewAsset table = tableAsset(context, output);
       nodes.putIfAbsent(table.id(), table);
       PreviewRelation relation = tableRelation(
           task,
@@ -360,20 +364,23 @@ public class DevelopmentSqlLineagePreviewService {
         Map.of("preview", true));
   }
 
-  private PreviewAsset tableAsset(String dataSourceId, SqlTableLineageParser.TableRef table) {
-    String key = "table:" + dataSourceId + ":" + table.canonicalName();
+  private PreviewAsset tableAsset(SqlContext context, SqlTableLineageParser.TableRef table) {
+    TableIdentityResolver.PhysicalTableIdentity identity = identityResolver.resolve(
+        table, new TableIdentityResolver.ResolutionContext(
+            context.dataSourceId(), context.databaseName(), context.schemaName(), context.dialect()));
+    String key = identity.assetKey();
     return new PreviewAsset(
         key,
         key,
         LineageAssetType.TABLE,
         table.qualifiedName(),
         "DATASOURCE",
-        dataSourceId,
+        context.dataSourceId(),
         null,
-        dataSourceId,
-        table.databaseName(),
-        table.schemaName(),
-        table.tableName(),
+        context.dataSourceId(),
+        emptyToNull(identity.databaseName()),
+        emptyToNull(identity.schemaName()),
+        identity.tableName(),
         null,
         Map.of("qualifiedName", table.qualifiedName(), "preview", true));
   }
@@ -415,7 +422,7 @@ public class DevelopmentSqlLineagePreviewService {
         List.of());
   }
 
-  private String dataSourceId(String configJson) {
+  private SqlContext sqlContext(String configJson) {
     try {
       JsonNode root = objectMapper.readTree(
           configJson == null || configJson.isBlank() ? "{}" : configJson);
@@ -424,7 +431,11 @@ public class DevelopmentSqlLineagePreviewService {
       if (dataSourceId == null || dataSourceId.isBlank()) {
         throw new IllegalArgumentException("SQL task dataSourceId 不能为空");
       }
-      return dataSourceId.trim();
+      return new SqlContext(
+          dataSourceId.trim(),
+          text(root, "databaseName", "database", "catalog"),
+          text(root, "schemaName", "schema"),
+          TableIdentityResolver.SqlDialect.from(text(root, "dialect", "dbType")));
     } catch (JsonProcessingException exception) {
       throw new IllegalArgumentException("SQL task configJson 不是合法 JSON", exception);
     }
@@ -433,6 +444,24 @@ public class DevelopmentSqlLineagePreviewService {
   private static String normalizeContext(String value) {
     if (value == null || value.isBlank()) return null;
     return value.trim();
+  }
+
+
+  private static String firstNonBlank(String explicit, String persisted) {
+    String normalized = normalizeContext(explicit);
+    return normalized == null ? normalizeContext(persisted) : normalized;
+  }
+
+  private static String text(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode value = root == null ? null : root.get(name);
+      if (value != null && !value.isNull() && !value.asText().isBlank()) return value.asText().trim();
+    }
+    return null;
+  }
+
+  private static String emptyToNull(String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
 
   private static String schemaCacheKey(
@@ -452,6 +481,13 @@ public class DevelopmentSqlLineagePreviewService {
       return throwable == null ? "unknown parser error" : throwable.getClass().getSimpleName();
     }
     return message.length() > 1000 ? message.substring(0, 1000) : message;
+  }
+
+  private record SqlContext(
+      String dataSourceId,
+      String databaseName,
+      String schemaName,
+      TableIdentityResolver.SqlDialect dialect) {
   }
 
   private record CatalogColumn(String name, Integer ordinalPosition) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -38,6 +38,7 @@ public class DevelopmentSqlLineageService {
   private final SqlTableLineageParser tableParser;
   private final SqlColumnLineageParser columnParser;
   private final ObjectMapper objectMapper;
+  private final TableIdentityResolver identityResolver = new TableIdentityResolver();
 
   private DataSourceCatalogService dataSourceCatalogService;
 
@@ -68,7 +69,8 @@ public class DevelopmentSqlLineageService {
     if (!"SQL".equalsIgnoreCase(revision.definition().taskType())) return;
 
     String evidenceId = String.valueOf(node.id());
-    String dataSourceId = dataSourceId(revision.definition().configJson());
+    SqlContext sqlContext = sqlContext(revision.definition().configJson());
+    String dataSourceId = sqlContext.dataSourceId();
     String sql = revision.definition().content();
 
     try {
@@ -107,7 +109,7 @@ public class DevelopmentSqlLineageService {
       Map<String, LineageAsset> tableAssets = new LinkedHashMap<>();
 
       for (SqlTableLineageParser.TableRef input : tableParsed.inputs()) {
-        LineageAsset table = registerTableAsset(dataSourceId, input, tableAssets);
+        LineageAsset table = registerTableAsset(sqlContext, input, tableAssets);
         lineageService.registerRelation(new LineageService.RegisterRelationCommand(
             table.id(),
             task.id(),
@@ -122,7 +124,7 @@ public class DevelopmentSqlLineageService {
       }
 
       for (SqlTableLineageParser.TableRef output : tableParsed.outputs()) {
-        LineageAsset table = registerTableAsset(dataSourceId, output, tableAssets);
+        LineageAsset table = registerTableAsset(sqlContext, output, tableAssets);
         lineageService.registerRelation(new LineageService.RegisterRelationCommand(
             task.id(),
             table.id(),
@@ -138,7 +140,7 @@ public class DevelopmentSqlLineageService {
 
       if (columnParsed != null) {
         registerColumnLineage(
-            dataSourceId,
+            sqlContext,
             task,
             revision,
             columnParsed,
@@ -234,7 +236,7 @@ public class DevelopmentSqlLineageService {
   }
 
   private void registerColumnLineage(
-      String dataSourceId,
+      SqlContext sqlContext,
       LineageAsset task,
       DevelopmentTaskRevision revision,
       SqlColumnLineageParser.ParseResult parsed,
@@ -244,15 +246,15 @@ public class DevelopmentSqlLineageService {
     int mappingIndex = 0;
     for (SqlColumnLineageParser.ColumnMapping mapping : parsed.mappings()) {
       mappingIndex++;
-      LineageAsset sourceTable = registerTableAsset(dataSourceId, mapping.sourceTable(), tableAssets);
-      LineageAsset targetTable = registerTableAsset(dataSourceId, mapping.targetTable(), tableAssets);
+      LineageAsset sourceTable = registerTableAsset(sqlContext, mapping.sourceTable(), tableAssets);
+      LineageAsset targetTable = registerTableAsset(sqlContext, mapping.targetTable(), tableAssets);
       LineageAsset sourceColumn = registerColumnAsset(
-          dataSourceId,
+          sqlContext,
           sourceTable,
           mapping.sourceTable(),
           mapping.sourceColumnName());
       LineageAsset targetColumn = registerColumnAsset(
-          dataSourceId,
+          sqlContext,
           targetTable,
           mapping.targetTable(),
           mapping.targetColumnName());
@@ -350,10 +352,11 @@ public class DevelopmentSqlLineageService {
   }
 
   private LineageAsset registerTableAsset(
-      String dataSourceId,
+      SqlContext sqlContext,
       SqlTableLineageParser.TableRef table,
       Map<String, LineageAsset> cache) {
-    String key = tableAssetKey(dataSourceId, table);
+    TableIdentityResolver.PhysicalTableIdentity identity = resolve(table, sqlContext);
+    String key = identity.assetKey();
     LineageAsset cached = cache.get(key);
     if (cached != null) return cached;
 
@@ -364,12 +367,12 @@ public class DevelopmentSqlLineageService {
         LineageAssetType.TABLE,
         table.qualifiedName(),
         "DATASOURCE",
-        dataSourceId,
+        sqlContext.dataSourceId(),
         null,
-        dataSourceId,
-        table.databaseName(),
-        table.schemaName(),
-        table.tableName(),
+        sqlContext.dataSourceId(),
+        emptyToNull(identity.databaseName()),
+        emptyToNull(identity.schemaName()),
+        identity.tableName(),
         null,
         properties));
     cache.put(key, registered);
@@ -377,7 +380,7 @@ public class DevelopmentSqlLineageService {
   }
 
   private LineageAsset registerColumnAsset(
-      String dataSourceId,
+      SqlContext sqlContext,
       LineageAsset tableAsset,
       SqlTableLineageParser.TableRef table,
       String columnName) {
@@ -385,16 +388,16 @@ public class DevelopmentSqlLineageService {
     properties.put("qualifiedName", table.qualifiedName() + "." + columnName);
 
     return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
-        columnAssetKey(dataSourceId, table, columnName),
+        columnAssetKey(resolve(table, sqlContext), columnName),
         LineageAssetType.COLUMN,
         columnName,
         "DATASOURCE",
-        dataSourceId,
+        sqlContext.dataSourceId(),
         tableAsset.id(),
-        dataSourceId,
-        table.databaseName(),
-        table.schemaName(),
-        table.tableName(),
+        sqlContext.dataSourceId(),
+        emptyToNull(resolve(table, sqlContext).databaseName()),
+        emptyToNull(resolve(table, sqlContext).schemaName()),
+        resolve(table, sqlContext).tableName(),
         columnName,
         properties));
   }
@@ -428,7 +431,7 @@ public class DevelopmentSqlLineageService {
     return properties;
   }
 
-  private String dataSourceId(String configJson) {
+  private SqlContext sqlContext(String configJson) {
     try {
       JsonNode root = objectMapper.readTree(
           configJson == null || configJson.isBlank() ? "{}" : configJson);
@@ -437,28 +440,46 @@ public class DevelopmentSqlLineageService {
       if (dataSourceId == null || dataSourceId.isBlank()) {
         throw new IllegalArgumentException("SQL task dataSourceId 不能为空");
       }
-      return dataSourceId.trim();
+      return new SqlContext(
+          dataSourceId.trim(),
+          text(root, "databaseName", "database", "catalog"),
+          text(root, "schemaName", "schema"),
+          TableIdentityResolver.SqlDialect.from(text(root, "dialect", "dbType")));
     } catch (JsonProcessingException exception) {
       throw new IllegalArgumentException("SQL task configJson 不是合法 JSON", exception);
     }
   }
 
-  private static String tableAssetKey(
-      String dataSourceId,
-      SqlTableLineageParser.TableRef table) {
-    return "table:" + dataSourceId + ":" + table.canonicalName();
+  private TableIdentityResolver.PhysicalTableIdentity resolve(
+      SqlTableLineageParser.TableRef table, SqlContext context) {
+    return identityResolver.resolve(table, new TableIdentityResolver.ResolutionContext(
+        context.dataSourceId(), context.databaseName(), context.schemaName(), context.dialect()));
   }
 
   private static String columnAssetKey(
-      String dataSourceId,
-      SqlTableLineageParser.TableRef table,
+      TableIdentityResolver.PhysicalTableIdentity table,
       String columnName) {
-    return "column:"
-        + dataSourceId
-        + ":"
-        + table.canonicalName()
-        + "."
-        + columnName.toLowerCase(java.util.Locale.ROOT);
+    return table.assetKey().replaceFirst("^table:", "column:")
+        + "." + columnName.toLowerCase(java.util.Locale.ROOT);
+  }
+
+  private static String text(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode value = root == null ? null : root.get(name);
+      if (value != null && !value.isNull() && !value.asText().isBlank()) return value.asText().trim();
+    }
+    return null;
+  }
+
+  private static String emptyToNull(String value) {
+    return value == null || value.isEmpty() ? null : value;
+  }
+
+  private record SqlContext(
+      String dataSourceId,
+      String databaseName,
+      String schemaName,
+      TableIdentityResolver.SqlDialect dialect) {
   }
 
   private static String truncate(String value, int maxLength) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/TableIdentityResolver.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/TableIdentityResolver.java
@@ -21,22 +21,24 @@ public class TableIdentityResolver {
 
     ResolutionContext actual = context == null ? ResolutionContext.empty() : context;
 
-    String database = firstNonBlank(
-        table.databaseName(),
-        actual.databaseName());
-    String schema = firstNonBlank(
-        table.schemaName(),
-        actual.schemaName());
+    boolean unqualified = table.databaseName() == null && table.schemaName() == null;
+    String database = table.databaseName();
+    String schema = table.schemaName();
+    if (unqualified) {
+      database = actual.databaseName();
+      schema = actual.schemaName();
+    } else if (database == null && schema != null && actual.dialect() == SqlDialect.MYSQL) {
+      // JSQLParser exposes a two-part name as schema.table. Its SQL meaning is dialect-specific:
+      // PostgreSQL keeps that interpretation, while MySQL treats the first part as database.
+      database = schema;
+      schema = null;
+    }
 
     return new PhysicalTableIdentity(
         normalize(actual.dataSourceId()),
         normalize(database),
         normalize(schema),
         normalize(table.tableName()));
-  }
-
-  private String firstNonBlank(String value, String fallback) {
-    return value == null || value.isBlank() ? fallback : value;
   }
 
   private String normalize(String value) {
@@ -48,10 +50,30 @@ public class TableIdentityResolver {
   public record ResolutionContext(
       String dataSourceId,
       String databaseName,
-      String schemaName) {
+      String schemaName,
+      SqlDialect dialect) {
+
+    public ResolutionContext(String dataSourceId, String databaseName, String schemaName) {
+      this(dataSourceId, databaseName, schemaName, SqlDialect.UNKNOWN);
+    }
 
     public static ResolutionContext empty() {
-      return new ResolutionContext(null, null, null);
+      return new ResolutionContext(null, null, null, SqlDialect.UNKNOWN);
+    }
+  }
+
+  public enum SqlDialect {
+    POSTGRESQL,
+    MYSQL,
+    UNKNOWN;
+
+    public static SqlDialect from(String value) {
+      if (value == null) return UNKNOWN;
+      String normalized = value.trim().toLowerCase(Locale.ROOT);
+      if (normalized.contains("postgres")) return POSTGRESQL;
+      if (normalized.contains("mysql") || normalized.contains("mariadb")
+          || normalized.contains("doris")) return MYSQL;
+      return UNKNOWN;
     }
   }
 
@@ -62,7 +84,10 @@ public class TableIdentityResolver {
       String tableName) {
 
     public String assetKey() {
-      return "table:%s:%s.%s.%s".formatted(
+      // Legacy configs without database/schema must never alias a confirmed physical asset.
+      String resolution = databaseName.isEmpty() && schemaName.isEmpty() ? "unresolved:" : "";
+      return "table:%s%s:%s.%s.%s".formatted(
+          resolution,
           dataSourceId,
           databaseName,
           schemaName,

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
@@ -106,8 +106,8 @@ class DevelopmentSqlLineageServiceTest {
       byKey.put(command.assetKey(), command);
     }
 
-    LineageService.RegisterAssetCommand sourceColumn = byKey.get("column:12:ods.orders.id");
-    LineageService.RegisterAssetCommand targetColumn = byKey.get("column:12:dws.sales.order_id");
+    LineageService.RegisterAssetCommand sourceColumn = byKey.get("column:12:.ods.orders.id");
+    LineageService.RegisterAssetCommand targetColumn = byKey.get("column:12:.dws.sales.order_id");
     assertNotNull(sourceColumn);
     assertNotNull(targetColumn);
     assertEquals(LineageAssetType.COLUMN, sourceColumn.assetType());

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/TableIdentityResolverTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/TableIdentityResolverTest.java
@@ -1,0 +1,71 @@
+package io.yak.ops.business.development.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TableIdentityResolverTest {
+  private final TableIdentityResolver resolver = new TableIdentityResolver();
+
+  @Test
+  void unqualifiedNameUsesExecutionContextAndDatasource() {
+    var identity = resolve(table("orders", null, null, "orders"), "1", "sales", "public", "postgresql");
+    assertEquals("table:1:sales.public.orders", identity.assetKey());
+  }
+
+  @Test
+  void databasesSchemasAndDatasourcesCannotCollide() {
+    var table = table("orders", null, null, "orders");
+    assertNotEquals(resolve(table, "1", "sales", "public", "postgresql").assetKey(),
+        resolve(table, "1", "marketing", "public", "postgresql").assetKey());
+    assertNotEquals(resolve(table, "1", "sales", "public", "postgresql").assetKey(),
+        resolve(table, "1", "sales", "private", "postgresql").assetKey());
+    assertNotEquals(resolve(table, "1", "sales", "public", "postgresql").assetKey(),
+        resolve(table, "2", "sales", "public", "postgresql").assetKey());
+  }
+
+  @Test
+  void explicitTwoAndThreePartNamesAreNotOverwritten() {
+    assertEquals("table:1:sales.archive.orders",
+        resolve(table("archive.orders", null, "archive", "orders"),
+            "1", "sales", "public", "postgresql").assetKey());
+    assertEquals("table:1:warehouse.archive.orders",
+        resolve(table("warehouse.archive.orders", "warehouse", "archive", "orders"),
+            "1", "sales", "public", "postgresql").assetKey());
+  }
+
+  @Test
+  void twoPartMeaningFollowsDialect() {
+    var twoPart = table("archive.orders", null, "archive", "orders");
+    assertEquals("table:1:sales.archive.orders",
+        resolve(twoPart, "1", "sales", "public", "postgresql").assetKey());
+    assertEquals("table:1:archive..orders",
+        resolve(twoPart, "1", "sales", "public", "mysql").assetKey());
+  }
+
+  @Test
+  void legacyContextIsIsolatedFromConfirmedAssets() {
+    var identity = resolve(table("orders", null, null, "orders"), "1", null, null, null);
+    assertEquals("table:unresolved:1:..orders", identity.assetKey());
+  }
+
+  @Test
+  void canonicalizationIsStableForCaseAndSpecialCharacters() {
+    var identity = resolve(table("\"Sales Schema\".\"Order-Items\"", null,
+        "Sales Schema", "Order-Items"), "DS-A", null, null, "postgresql");
+    assertEquals("table:ds-a:.sales schema.order-items", identity.assetKey());
+  }
+
+  private TableIdentityResolver.PhysicalTableIdentity resolve(
+      SqlTableLineageParser.TableRef table, String ds, String database, String schema, String dialect) {
+    return resolver.resolve(table, new TableIdentityResolver.ResolutionContext(
+        ds, database, schema, TableIdentityResolver.SqlDialect.from(dialect)));
+  }
+
+  private static SqlTableLineageParser.TableRef table(
+      String qualified, String database, String schema, String table) {
+    return new SqlTableLineageParser.TableRef(
+        qualified.toLowerCase(), qualified, database, schema, table);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskConfig.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskConfig.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /** SQL task plugin-owned schemaVersion=1 configuration. */
 record SqlTaskConfig(
     String dataSourceId,
+    String databaseName,
+    String schemaName,
+    String dialect,
     int maxRows,
     int timeoutSeconds) {
 
@@ -32,7 +35,13 @@ record SqlTaskConfig(
               DEFAULT_TIMEOUT_SECONDS,
               1,
               MAX_TIMEOUT_SECONDS);
-      return new SqlTaskConfig(dataSourceId, maxRows, timeoutSeconds);
+      return new SqlTaskConfig(
+          dataSourceId,
+          firstText(root, "databaseName", "database", "catalog"),
+          firstText(root, "schemaName", "schema"),
+          firstText(root, "dialect", "dbType"),
+          maxRows,
+          timeoutSeconds);
     } catch (IllegalArgumentException exception) {
       throw exception;
     } catch (Exception exception) {
@@ -45,6 +54,14 @@ record SqlTaskConfig(
     if (value == null || value.isNull()) return null;
     String text = value.asText();
     return text == null || text.isBlank() ? null : text.trim();
+  }
+
+  private static String firstText(JsonNode root, String... keys) {
+    for (String key : keys) {
+      String value = text(root, key);
+      if (value != null) return value;
+    }
+    return null;
   }
 
   private static int integer(

--- a/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
@@ -1,7 +1,7 @@
-import { useSyncExternalStore } from 'react';
+import { useSyncExternalStore } from "react";
 
-import { updateEditorSessionConfig } from '../../session/editorSessionStore';
-import type { DevelopmentId } from '../../../types';
+import { updateEditorSessionConfig } from "../../session/editorSessionStore";
+import type { DevelopmentId } from "../../../types";
 
 export interface SqlMetadataContext {
   nodeId: DevelopmentId;
@@ -13,7 +13,7 @@ export interface SqlMetadataContext {
   updatedAt: number;
 }
 
-const STORAGE_KEY = 'yak-data-development.sql-metadata-contexts.v1';
+const STORAGE_KEY = "yak-data-development.sql-metadata-contexts.v1";
 
 interface PersistedSqlMetadataContexts {
   version: 1;
@@ -26,19 +26,21 @@ const listeners = new Set<() => void>();
 let hydrated = false;
 let version = 0;
 
-const isBrowser = () => typeof window !== 'undefined';
+const isBrowser = () => typeof window !== "undefined";
 
 const isPersistedContext = (value: unknown): value is SqlMetadataContext => {
-  if (!value || typeof value !== 'object') return false;
+  if (!value || typeof value !== "object") return false;
   const context = value as Partial<SqlMetadataContext>;
   return (
-    typeof context.nodeId === 'string' &&
-    typeof context.updatedAt === 'number' &&
-    (context.dataSourceId === undefined || typeof context.dataSourceId === 'string') &&
-    (context.dataSourceName === undefined || typeof context.dataSourceName === 'string') &&
-    (context.dbType === undefined || typeof context.dbType === 'string') &&
-    (context.database === undefined || typeof context.database === 'string') &&
-    (context.schema === undefined || typeof context.schema === 'string')
+    typeof context.nodeId === "string" &&
+    typeof context.updatedAt === "number" &&
+    (context.dataSourceId === undefined ||
+      typeof context.dataSourceId === "string") &&
+    (context.dataSourceName === undefined ||
+      typeof context.dataSourceName === "string") &&
+    (context.dbType === undefined || typeof context.dbType === "string") &&
+    (context.database === undefined || typeof context.database === "string") &&
+    (context.schema === undefined || typeof context.schema === "string")
   );
 };
 
@@ -89,8 +91,17 @@ const getVersion = () => {
   return version;
 };
 
-const configJsonForDataSource = (dataSourceId?: string) =>
-  JSON.stringify(dataSourceId ? { dataSourceId } : {});
+const configJsonForContext = (context: Partial<SqlMetadataContext>) =>
+  JSON.stringify(
+    Object.fromEntries(
+      Object.entries({
+        dataSourceId: context.dataSourceId,
+        databaseName: context.database,
+        schemaName: context.schema,
+        dialect: context.dbType,
+      }).filter(([, value]) => value !== undefined && value !== ""),
+    ),
+  );
 
 export const ensureSqlMetadataContext = (
   nodeId: DevelopmentId,
@@ -113,11 +124,11 @@ export const getSqlMetadataContext = (nodeId: DevelopmentId) => {
 };
 
 export const getSqlTaskConfigJson = (nodeId: DevelopmentId) =>
-  configJsonForDataSource(ensureSqlMetadataContext(nodeId).dataSourceId);
+  configJsonForContext(ensureSqlMetadataContext(nodeId));
 
 export const updateSqlMetadataContext = (
   nodeId: DevelopmentId,
-  patch: Partial<Omit<SqlMetadataContext, 'nodeId' | 'updatedAt'>>,
+  patch: Partial<Omit<SqlMetadataContext, "nodeId" | "updatedAt">>,
 ) => {
   const current = ensureSqlMetadataContext(nodeId);
   const next: SqlMetadataContext = {
@@ -137,9 +148,23 @@ export const hydrateSqlTaskConfig = (
   configJson: string,
 ) => {
   let dataSourceId: string | undefined;
+  let databaseName: string | undefined;
+  let schemaName: string | undefined;
+  let dialect: string | undefined;
   try {
-    const parsed = JSON.parse(configJson || '{}') as { dataSourceId?: unknown };
-    dataSourceId = typeof parsed.dataSourceId === 'string' ? parsed.dataSourceId : undefined;
+    const parsed = JSON.parse(configJson || "{}") as {
+      dataSourceId?: unknown;
+      databaseName?: unknown;
+      schemaName?: unknown;
+      dialect?: unknown;
+    };
+    dataSourceId =
+      typeof parsed.dataSourceId === "string" ? parsed.dataSourceId : undefined;
+    databaseName =
+      typeof parsed.databaseName === "string" ? parsed.databaseName : undefined;
+    schemaName =
+      typeof parsed.schemaName === "string" ? parsed.schemaName : undefined;
+    dialect = typeof parsed.dialect === "string" ? parsed.dialect : undefined;
   } catch {
     dataSourceId = undefined;
   }
@@ -151,9 +176,9 @@ export const hydrateSqlTaskConfig = (
     nodeId,
     dataSourceId,
     dataSourceName: sameDataSource ? current.dataSourceName : undefined,
-    dbType: sameDataSource ? current.dbType : undefined,
-    database: sameDataSource ? current.database : undefined,
-    schema: sameDataSource ? current.schema : undefined,
+    dbType: dialect ?? (sameDataSource ? current.dbType : undefined),
+    database: databaseName,
+    schema: schemaName,
     updatedAt: Date.now(),
   };
   contexts.set(nodeId, next);
@@ -173,23 +198,30 @@ export const selectSqlDataSourceContext = (
     database: undefined,
     schema: undefined,
   });
-  updateEditorSessionConfig(nodeId, configJsonForDataSource(next.dataSourceId));
+  updateEditorSessionConfig(nodeId, configJsonForContext(next));
   return next;
 };
 
 export const selectSqlDatabaseContext = (
   nodeId: DevelopmentId,
   database?: string,
-) =>
-  updateSqlMetadataContext(nodeId, {
+) => {
+  const next = updateSqlMetadataContext(nodeId, {
     database,
     schema: undefined,
   });
+  updateEditorSessionConfig(nodeId, configJsonForContext(next));
+  return next;
+};
 
 export const selectSqlSchemaContext = (
   nodeId: DevelopmentId,
   schema?: string,
-) => updateSqlMetadataContext(nodeId, { schema });
+) => {
+  const next = updateSqlMetadataContext(nodeId, { schema });
+  updateEditorSessionConfig(nodeId, configJsonForContext(next));
+  return next;
+};
 
 export const useSqlMetadataContext = (nodeId: DevelopmentId) => {
   useSyncExternalStore(subscribe, getVersion, getVersion);


### PR DESCRIPTION
### Motivation
- Prevent accidental merging of same-name tables from different datasources/databases/schemas by introducing a stable, unique physical table identity.
- Centralize identity resolution so table-level lineage, column lineage and asset registration share one authoritative resolver instead of ad-hoc string keys.
- Preserve explicit SQL qualifiers and respect SQL dialects when interpreting two-part identifiers (Postgres `schema.table` vs MySQL `database.table`).
- Keep backward compatibility for legacy `configJson` that may lack database/schema while avoiding silent aliasing of confirmed assets.

### Description
- Add a single `TableIdentityResolver` responsible for producing `PhysicalTableIdentity` from `SqlTableLineageParser.TableRef` and a `ResolutionContext`, including a `SqlDialect` hint and normalization rules, and emit asset keys through `PhysicalTableIdentity.assetKey()`; legacy unresolved contexts are placed into an `unresolved:` namespace.
- Update `DevelopmentSqlLineageService` to derive a `SqlContext` from `configJson` and use the `TableIdentityResolver` for all table and column asset registration so table- and column-level lineage share identical physical identities; column keys are derived from the parent table identity.
- Update `DevelopmentSqlLineagePreviewService` to use the same identity resolution for preview output and apply request-time overrides with priority `request params > persisted configJson` when filling database/schema for unqualified names.
- Persist editor SQL context in the front-end by extending `sqlMetadataContextStore` to include `dataSourceId`, `databaseName`, `schemaName` and `dialect`, and write a `configJson` that can be stored on revision to ensure previews/published revisions can rehydrate the same context.
- Extend `SqlTaskConfig` parsing to read optional `databaseName`, `schemaName` and `dialect` fields from `configJson` so published revisions can carry context without breaking existing configs.
- Add `TableIdentityResolverTest` unit tests covering unqualified name completion, datasource/database/schema isolation, preservation of explicit two- and three-part names, dialect interpretation for two-part names, legacy unresolved handling, and canonicalization of quoted/cased identifiers.

### Testing
- `Prettier` formatting check and auto-format: passed after formatting changes in the UI file.
- Java source sanity checks (brace/count) and lightweight static sanity: passed for modified files.
- Unit tests: new `TableIdentityResolverTest` added to repo but JVM test execution was not completed in this environment.
- `mvn` / `./mvnw -DskipTests compile`: failed due to network access to Maven Central being blocked (HTTP 403) in the execution environment, so full compilation and automated tests could not be run here.
- Draft PR creation / push: unable to push branch or create Draft PR because the environment cannot access GitHub (HTTPS tunnel returned HTTP 403) and no authenticated GitHub CLI token was available, so a remote Draft PR URL could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86e13582408326b69694cebbf792f4)