### PR TITLE
fix(lineage): move SQL publish sync to durable outbox

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageOutbox.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageOutbox.java
@@ -1,0 +1,55 @@
+package io.yak.ops.business.development.service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** Durable SQL-lineage work committed atomically with the published revision. */
+@Repository
+public class DevelopmentLineageOutbox {
+  private final JdbcTemplate jdbc;
+
+  public DevelopmentLineageOutbox(JdbcTemplate jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  public void enqueue(long nodeId, long revisionId) {
+    jdbc.update("INSERT IGNORE INTO yak_dev_lineage_outbox "
+        + "(task_id,node_id,revision_id,status,attempts,next_attempt_time,create_time,update_time) "
+        + "VALUES (?,?,?,'PENDING',0,NOW(6),NOW(6),NOW(6))",
+        UUID.randomUUID().toString(), nodeId, revisionId);
+  }
+
+  public List<Task> due(int limit) {
+    return jdbc.query("SELECT task_id,node_id,revision_id,attempts FROM yak_dev_lineage_outbox "
+            + "WHERE (status IN ('PENDING','FAILED') AND next_attempt_time<=NOW(6)) "
+            + "OR (status='RUNNING' AND update_time<DATE_SUB(NOW(6), INTERVAL 10 MINUTE)) "
+            + "ORDER BY create_time LIMIT ?",
+        (rs, row) -> new Task(rs.getString(1), rs.getLong(2), rs.getLong(3), rs.getInt(4)), limit);
+  }
+
+  public boolean claim(Task task) {
+    return jdbc.update("UPDATE yak_dev_lineage_outbox SET status='RUNNING',attempts=attempts+1,"
+            + "update_time=NOW(6) WHERE task_id=? AND revision_id=? AND (status IN ('PENDING','FAILED') "
+            + "OR (status='RUNNING' AND update_time<DATE_SUB(NOW(6), INTERVAL 10 MINUTE)))",
+        task.taskId(), task.revisionId()) == 1;
+  }
+
+  public void complete(Task task) {
+    jdbc.update("UPDATE yak_dev_lineage_outbox SET status='SUCCEEDED',last_error=NULL,update_time=NOW(6) "
+        + "WHERE task_id=? AND revision_id=? AND status='RUNNING'", task.taskId(), task.revisionId());
+  }
+
+  public void fail(Task task, Throwable failure) {
+    long delay = Math.min(3600, 1L << Math.min(12, task.attempts()));
+    String message = failure.getMessage() == null ? failure.getClass().getSimpleName() : failure.getMessage();
+    jdbc.update("UPDATE yak_dev_lineage_outbox SET status='FAILED',last_error=?,"
+            + "next_attempt_time=DATE_ADD(NOW(6), INTERVAL ? SECOND),update_time=NOW(6) "
+            + "WHERE task_id=? AND revision_id=? AND status='RUNNING'",
+        message.substring(0, Math.min(2000, message.length())), delay, task.taskId(), task.revisionId());
+  }
+
+  public record Task(String taskId, long nodeId, long revisionId, int attempts) {}
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageSchedulingConfiguration.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageSchedulingConfiguration.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.development.service;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+class DevelopmentLineageSchedulingConfiguration {}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageWorker.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageWorker.java
@@ -1,0 +1,50 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Polls the durable outbox; parsing/catalog IO deliberately happens before the write transaction. */
+@Component
+public class DevelopmentLineageWorker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DevelopmentLineageWorker.class);
+  private final DevelopmentLineageOutbox outbox;
+  private final DevelopmentNodeRepository nodes;
+  private final DevelopmentTaskRevisionRepository revisions;
+  private final DevelopmentSqlLineageService lineage;
+  private final DevelopmentLineageWriteTransaction writer;
+
+  public DevelopmentLineageWorker(DevelopmentLineageOutbox outbox, DevelopmentNodeRepository nodes,
+      DevelopmentTaskRevisionRepository revisions, DevelopmentSqlLineageService lineage,
+      DevelopmentLineageWriteTransaction writer) {
+    this.outbox = outbox;
+    this.nodes = nodes;
+    this.revisions = revisions;
+    this.lineage = lineage;
+    this.writer = writer;
+  }
+
+  @Scheduled(fixedDelayString = "${yak.development.lineage-outbox.poll-delay-ms:1000}")
+  public void poll() {
+    for (DevelopmentLineageOutbox.Task task : outbox.due(20)) process(task);
+  }
+
+  void process(DevelopmentLineageOutbox.Task task) {
+    if (!outbox.claim(task)) return;
+    try {
+      DevelopmentNode node = nodes.findById(task.nodeId()).orElseThrow();
+      DevelopmentTaskRevision revision = revisions.findById(task.revisionId()).orElseThrow();
+      DevelopmentSqlLineageService.PreparedLineage prepared = lineage.prepare(node, revision);
+      writer.writeIfLatest(node, revision, prepared);
+      outbox.complete(task);
+    } catch (Throwable failure) {
+      outbox.fail(task, failure);
+      LOGGER.warn("SQL lineage outbox task {} failed; publish remains committed", task.taskId(), failure);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageWriteTransaction.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentLineageWriteTransaction.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.development.service;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Atomically replaces table and column lineage in one independent short transaction. */
+@Service
+public class DevelopmentLineageWriteTransaction {
+  private final JdbcTemplate jdbc;
+  private final DevelopmentSqlLineageService lineage;
+
+  public DevelopmentLineageWriteTransaction(JdbcTemplate jdbc,
+      DevelopmentSqlLineageService lineage) {
+    this.jdbc = jdbc;
+    this.lineage = lineage;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager", propagation = Propagation.REQUIRES_NEW)
+  public void writeIfLatest(DevelopmentNode node, DevelopmentTaskRevision revision,
+      DevelopmentSqlLineageService.PreparedLineage prepared) {
+    // The range lock serializes this replacement with a concurrent publish for the same node.
+    Long latestId = jdbc.query("SELECT id FROM yak_dev_task_revision WHERE node_id=? "
+            + "ORDER BY revision_no DESC LIMIT 1 FOR UPDATE",
+        rs -> rs.next() ? rs.getLong(1) : null, node.id());
+    if (!revision.id().equals(latestId)) return;
+    lineage.applyPrepared(node, revision, prepared);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -64,100 +64,72 @@ public class DevelopmentSqlLineageService {
     this.dataSourceCatalogService = dataSourceCatalogService;
   }
 
-  public void syncPublished(DevelopmentNode node, DevelopmentTaskRevision revision) {
-    if (node == null || revision == null || revision.definition() == null) return;
-    if (!"SQL".equalsIgnoreCase(revision.definition().taskType())) return;
-
-    String evidenceId = String.valueOf(node.id());
-    SqlContext sqlContext = sqlContext(revision.definition().configJson());
-    String dataSourceId = sqlContext.dataSourceId();
-    String sql = revision.definition().content();
-
+  /** Performs parsing and optional catalog lookups without opening a database transaction. */
+  public PreparedLineage prepare(DevelopmentNode node, DevelopmentTaskRevision revision) {
+    if (node == null || revision == null || revision.definition() == null
+        || !"SQL".equalsIgnoreCase(revision.definition().taskType())) {
+      return null;
+    }
+    SqlContext context = sqlContext(revision.definition().configJson());
     try {
-      SqlTableLineageParser.ParseResult tableParsed = tableParser.parse(sql);
-      SqlColumnLineageParser.ParseResult columnParsed = null;
-      SqlColumnLineageParser.SqlColumnLineageParseException columnFailure = null;
+      SqlTableLineageParser.ParseResult tables = tableParser.parse(revision.definition().content());
       try {
-        if (dataSourceCatalogService == null) {
-          columnParsed = columnParser.parse(sql);
-        } else {
-          columnParsed = columnParser.parse(sql, schemaProvider(dataSourceId));
-        }
-      } catch (SqlColumnLineageParser.SqlColumnLineageParseException exception) {
-        columnFailure = exception;
-        LOGGER.warn(
-            "Failed to parse SQL column lineage for development node {} revision {}: {}",
-            node.id(),
-            revision.revisionNo(),
-            exception.getMessage());
+        SqlColumnLineageParser.ParseResult columns = dataSourceCatalogService == null
+            ? columnParser.parse(revision.definition().content())
+            : columnParser.parse(revision.definition().content(), schemaProvider(context.dataSourceId()));
+        return new PreparedLineage(context, tables, columns, null, null);
+      } catch (SqlColumnLineageParser.SqlColumnLineageParseException failure) {
+        return new PreparedLineage(context, tables, null, null, failure);
       }
-
-      // Table and column lineage share one evidence scope. A new immutable revision replaces every
-      // generated relationship from the previous revision before current facts are written.
-      maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
-
-      LineageAsset task = registerTaskAsset(
-          node,
-          revision,
-          dataSourceId,
-          tableParsed,
-          columnParsed,
-          null,
-          columnFailure);
-      String evidenceSql = truncate(sql, MAX_EVIDENCE_SQL_LENGTH);
-      Instant observedAt = revision.createTime() == null ? Instant.now() : revision.createTime();
-      Map<String, LineageAsset> tableAssets = new LinkedHashMap<>();
-
-      for (SqlTableLineageParser.TableRef input : tableParsed.inputs()) {
-        LineageAsset table = registerTableAsset(sqlContext, input, tableAssets);
-        lineageService.registerRelation(new LineageService.RegisterRelationCommand(
-            table.id(),
-            task.id(),
-            LineageRelationType.READS_FROM,
-            EVIDENCE_SOURCE_TYPE,
-            evidenceId,
-            evidenceSql,
-            BigDecimal.ONE,
-            Integer.toString(revision.revisionNo()),
-            observedAt,
-            tableRelationProperties(revision, "INPUT")));
-      }
-
-      for (SqlTableLineageParser.TableRef output : tableParsed.outputs()) {
-        LineageAsset table = registerTableAsset(sqlContext, output, tableAssets);
-        lineageService.registerRelation(new LineageService.RegisterRelationCommand(
-            task.id(),
-            table.id(),
-            LineageRelationType.WRITES_TO,
-            EVIDENCE_SOURCE_TYPE,
-            evidenceId,
-            evidenceSql,
-            BigDecimal.ONE,
-            Integer.toString(revision.revisionNo()),
-            observedAt,
-            tableRelationProperties(revision, "OUTPUT")));
-      }
-
-      if (columnParsed != null) {
-        registerColumnLineage(
-            sqlContext,
-            task,
-            revision,
-            columnParsed,
-            evidenceId,
-            observedAt,
-            tableAssets);
-      }
-    } catch (SqlTableLineageParser.SqlLineageParseException exception) {
-      maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
-      registerTaskAsset(node, revision, dataSourceId, null, null, exception, null);
-      LOGGER.warn(
-          "Failed to parse SQL table lineage for development node {} revision {}: {}",
-          node.id(),
-          revision.revisionNo(),
-          exception.getMessage());
+    } catch (SqlTableLineageParser.SqlLineageParseException failure) {
+      return new PreparedLineage(context, null, null, failure, null);
     }
   }
+
+  /** Compatibility entry point; production outbox uses prepare then an independent write transaction. */
+  public void syncPublished(DevelopmentNode node, DevelopmentTaskRevision revision) {
+    PreparedLineage prepared = prepare(node, revision);
+    if (prepared != null) applyPrepared(node, revision, prepared);
+  }
+
+  /** Writes an already prepared snapshot. Caller supplies the atomic transaction. */
+  public void applyPrepared(DevelopmentNode node, DevelopmentTaskRevision revision,
+      PreparedLineage prepared) {
+    String evidenceId = String.valueOf(node.id());
+    String dataSourceId = prepared.context().dataSourceId();
+    maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
+    if (prepared.tableFailure() != null) {
+      registerTaskAsset(node, revision, dataSourceId, null, null, prepared.tableFailure(), null);
+      return;
+    }
+    SqlTableLineageParser.ParseResult tableParsed = prepared.tables();
+    SqlColumnLineageParser.ParseResult columnParsed = prepared.columns();
+    LineageAsset task = registerTaskAsset(node, revision, dataSourceId, tableParsed, columnParsed,
+        null, prepared.columnFailure());
+    String evidenceSql = truncate(revision.definition().content(), MAX_EVIDENCE_SQL_LENGTH);
+    Instant observedAt = revision.createTime() == null ? Instant.now() : revision.createTime();
+    Map<String, LineageAsset> tableAssets = new LinkedHashMap<>();
+    for (SqlTableLineageParser.TableRef input : tableParsed.inputs()) {
+      LineageAsset table = registerTableAsset(prepared.context(), input, tableAssets);
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(table.id(), task.id(),
+          LineageRelationType.READS_FROM, EVIDENCE_SOURCE_TYPE, evidenceId, evidenceSql,
+          BigDecimal.ONE, Integer.toString(revision.revisionNo()), observedAt,
+          tableRelationProperties(revision, "INPUT")));
+    }
+    for (SqlTableLineageParser.TableRef output : tableParsed.outputs()) {
+      LineageAsset table = registerTableAsset(prepared.context(), output, tableAssets);
+      lineageService.registerRelation(new LineageService.RegisterRelationCommand(task.id(), table.id(),
+          LineageRelationType.WRITES_TO, EVIDENCE_SOURCE_TYPE, evidenceId, evidenceSql,
+          BigDecimal.ONE, Integer.toString(revision.revisionNo()), observedAt,
+          tableRelationProperties(revision, "OUTPUT")));
+    }
+    if (columnParsed != null) registerColumnLineage(prepared.context(), task, revision, columnParsed,
+        evidenceId, observedAt, tableAssets);
+  }
+
+  public record PreparedLineage(SqlContext context, SqlTableLineageParser.ParseResult tables,
+      SqlColumnLineageParser.ParseResult columns, RuntimeException tableFailure,
+      RuntimeException columnFailure) {}
 
   private SqlColumnLineageParser.SchemaProvider schemaProvider(String dataSourceId) {
     DataSourceCatalogService catalogService = this.dataSourceCatalogService;
@@ -475,7 +447,7 @@ public class DevelopmentSqlLineageService {
     return value == null || value.isEmpty() ? null : value;
   }
 
-  private record SqlContext(
+  record SqlContext(
       String dataSourceId,
       String databaseName,
       String schemaName,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
@@ -39,12 +39,12 @@ public class DevelopmentTaskService {
   private final TaskCatalogService taskCatalogService;
   private final TaskPluginRegistry pluginRegistry;
   private final ObjectMapper objectMapper;
-  private final DevelopmentSqlLineageService sqlLineageService;
+  private final DevelopmentLineageOutbox outbox;
 
   /**
    * Keeps focused unit tests and non-Spring callers source compatible.
    *
-   * <p>Production wiring uses the annotated constructor below so SQL lineage is synchronized after
+   * <p>Production wiring uses the annotated constructor below so durable SQL-lineage work is persisted with
    * a successful publish.
    */
   public DevelopmentTaskService(
@@ -72,14 +72,14 @@ public class DevelopmentTaskService {
       TaskCatalogService taskCatalogService,
       TaskPluginRegistry pluginRegistry,
       ObjectMapper objectMapper,
-      DevelopmentSqlLineageService sqlLineageService) {
+      DevelopmentLineageOutbox outbox) {
     this.nodeRepository = nodeRepository;
     this.draftRepository = draftRepository;
     this.revisionRepository = revisionRepository;
     this.taskCatalogService = taskCatalogService;
     this.pluginRegistry = pluginRegistry;
     this.objectMapper = objectMapper;
-    this.sqlLineageService = sqlLineageService;
+    this.outbox = outbox;
   }
 
   public DevelopmentTaskDraft getDraft(Long nodeId) {
@@ -160,8 +160,8 @@ public class DevelopmentTaskService {
         definition.taskType(),
         published.id(),
         published.revisionNo());
-    if (sqlLineageService != null) {
-      sqlLineageService.syncPublished(node, published);
+    if (outbox != null && "SQL".equalsIgnoreCase(definition.taskType())) {
+      outbox.enqueue(node.id(), published.id());
     }
     return published;
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V13__add_sql_lineage_outbox.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V13__add_sql_lineage_outbox.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS yak_dev_lineage_outbox (
+    task_id CHAR(36) NOT NULL,
+    node_id BIGINT NOT NULL,
+    revision_id BIGINT NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    attempts INT NOT NULL DEFAULT 0,
+    next_attempt_time DATETIME(6) NOT NULL,
+    last_error VARCHAR(2000) NULL,
+    create_time DATETIME(6) NOT NULL,
+    update_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (task_id),
+    UNIQUE KEY uk_yak_dev_lineage_outbox_revision (node_id, revision_id),
+    KEY idx_yak_dev_lineage_outbox_due (status, next_attempt_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentLineageWorkerTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentLineageWorkerTest.java
@@ -1,0 +1,65 @@
+package io.yak.ops.business.development.service;
+
+import static org.mockito.Mockito.*;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentLineageWorkerTest {
+  @Test
+  void preparesOutsideWriterAndCompletesOnlyAfterSuccessfulWrite() {
+    DevelopmentLineageOutbox outbox = mock(DevelopmentLineageOutbox.class);
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    DevelopmentTaskRevisionRepository revisions = mock(DevelopmentTaskRevisionRepository.class);
+    DevelopmentSqlLineageService lineage = mock(DevelopmentSqlLineageService.class);
+    DevelopmentLineageWriteTransaction writer = mock(DevelopmentLineageWriteTransaction.class);
+    DevelopmentLineageOutbox.Task task = new DevelopmentLineageOutbox.Task("task", 1, 11, 0);
+    DevelopmentNode node = node();
+    DevelopmentTaskRevision revision = revision(11, 1);
+    DevelopmentSqlLineageService.PreparedLineage prepared = mock(DevelopmentSqlLineageService.PreparedLineage.class);
+    when(outbox.claim(task)).thenReturn(true);
+    when(nodes.findById(1L)).thenReturn(Optional.of(node));
+    when(revisions.findById(11L)).thenReturn(Optional.of(revision));
+    when(lineage.prepare(node, revision)).thenReturn(prepared);
+
+    new DevelopmentLineageWorker(outbox, nodes, revisions, lineage, writer).process(task);
+
+    var order = inOrder(lineage, writer, outbox);
+    order.verify(lineage).prepare(node, revision);
+    order.verify(writer).writeIfLatest(node, revision, prepared);
+    order.verify(outbox).complete(task);
+  }
+
+  @Test
+  void failureIsRetriedWithoutEscapingWorker() {
+    DevelopmentLineageOutbox outbox = mock(DevelopmentLineageOutbox.class);
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    DevelopmentLineageOutbox.Task task = new DevelopmentLineageOutbox.Task("task", 1, 11, 2);
+    RuntimeException failure = new RuntimeException("catalog unavailable");
+    when(outbox.claim(task)).thenReturn(true);
+    when(nodes.findById(1L)).thenThrow(failure);
+
+    new DevelopmentLineageWorker(outbox, nodes, mock(DevelopmentTaskRevisionRepository.class),
+        mock(DevelopmentSqlLineageService.class), mock(DevelopmentLineageWriteTransaction.class))
+        .process(task);
+
+    verify(outbox).fail(task, failure);
+    verify(outbox, never()).complete(task);
+  }
+
+  private static DevelopmentNode node() {
+    return new DevelopmentNode(1L, "sql", "SQL", null, null, true, Instant.now(), Instant.now());
+  }
+
+  private static DevelopmentTaskRevision revision(long id, int number) {
+    return new DevelopmentTaskRevision(id, 1L, number, number,
+        new TaskDefinition("SQL", 1, "insert into b select * from a", "{\"dataSourceId\":\"1\"}"),
+        "checksum", Instant.now());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentLineageWriteTransactionTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentLineageWriteTransactionTest.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.development.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ResultSetExtractor;
+
+class DevelopmentLineageWriteTransactionTest {
+  @Test
+  void staleRevisionCannotReplaceNewerLineage() {
+    JdbcTemplate jdbc = mock(JdbcTemplate.class);
+    DevelopmentSqlLineageService lineage = mock(DevelopmentSqlLineageService.class);
+    when(jdbc.query(anyString(), any(ResultSetExtractor.class), eq(1L))).thenReturn(12L);
+    DevelopmentTaskRevision old = revision(11, 1);
+
+    new DevelopmentLineageWriteTransaction(jdbc, lineage)
+        .writeIfLatest(node(), old, mock(DevelopmentSqlLineageService.PreparedLineage.class));
+
+    verify(lineage, never()).applyPrepared(any(), any(), any());
+  }
+
+  private static DevelopmentNode node() {
+    return new DevelopmentNode(1L, "sql", "SQL", null, null, true, Instant.now(), Instant.now());
+  }
+
+  private static DevelopmentTaskRevision revision(long id, int number) {
+    return new DevelopmentTaskRevision(id, 1L, number, number,
+        new TaskDefinition("SQL", 1, "select 1", "{\"dataSourceId\":\"1\"}"), "c", Instant.now());
+  }
+}


### PR DESCRIPTION
### Motivation

- Prevent SQL parsing, catalog lookups and lineage writes from running inside the publish transaction so publish rollbacks/timeout/long transactions are not caused by lineage failures.
- Ensure lineage work is durable, idempotent and retryable across application restarts while not affecting the committed publish.

### Description

- Replace in-transaction immediate `DevelopmentSqlLineageService.syncPublished` call with a durable outbox insert via `DevelopmentLineageOutbox.enqueue` performed inside the publish transaction so outbox insertion rolls back with the publish if necessary.
- Add a persistent outbox table `yak_dev_lineage_outbox` and an `DevelopmentLineageOutbox` repository that supports idempotent `task_id + revision_id`, `due` selection, `claim`, `complete` and `fail` operations with exponential backoff and stale-running recovery.
- Introduce `DevelopmentLineageWorker` that polls the outbox after commit, calls `DevelopmentSqlLineageService.prepare` (parsing and optional catalog lookup outside any DB transaction), and uses `DevelopmentLineageWriteTransaction.writeIfLatest` (a `REQUIRES_NEW` short transaction) to atomically apply prepared lineage only if the revision is still the latest.
- Refactor `DevelopmentSqlLineageService` into `prepare` (transaction-free parse/catalog stage) and `applyPrepared` (atomic write stage) so table/column asset registration and relation replacement occur in one short independent transaction and cannot be overwritten by stale tasks.

### Testing

- `git diff --cached --check` was executed and passed for staged changes.
- Created unit tests `DevelopmentLineageWorkerTest` and `DevelopmentLineageWriteTransactionTest` to assert ordering (prepare -> write -> complete) and that stale revisions do not overwrite newer lineage, but these tests were added and not executed in this environment.
- Attempted to compile the `yak-ops-business-data-development` module with Maven, but the build failed due to inability to resolve parent artifacts from Maven Central (HTTP 403 from the environment/proxy), so automated tests were not run here.
- Draft PR metadata was prepared but could not be pushed or created because the environment lacked GitHub authentication and the local `make_pr` helper could not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86e3607d5c8326bec2081090fdac10)