### PR TITLE
perf(lineage): batch column lineage writes

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Publishes authoritative table- and column-level lineage for immutable SQL task revisions. */
@@ -41,6 +42,7 @@ public class DevelopmentSqlLineageService {
   private final TableIdentityResolver identityResolver = new TableIdentityResolver();
 
   private DataSourceCatalogService dataSourceCatalogService;
+  private int lineageBatchSize = 200;
 
   public DevelopmentSqlLineageService(
       LineageService lineageService,
@@ -62,6 +64,14 @@ public class DevelopmentSqlLineageService {
   @Autowired(required = false)
   void setDataSourceCatalogService(DataSourceCatalogService dataSourceCatalogService) {
     this.dataSourceCatalogService = dataSourceCatalogService;
+  }
+
+  @Value("${yak.lineage.write-batch-size:200}")
+  void setLineageBatchSize(int lineageBatchSize) {
+    if (lineageBatchSize < 1) {
+      throw new IllegalArgumentException("yak.lineage.write-batch-size 必须大于 0");
+    }
+    this.lineageBatchSize = lineageBatchSize;
   }
 
   /** Performs parsing and optional catalog lookups without opening a database transaction. */
@@ -215,25 +225,19 @@ public class DevelopmentSqlLineageService {
       String evidenceId,
       Instant observedAt,
       Map<String, LineageAsset> tableAssets) {
+    Map<String, LineageService.RegisterAssetCommand> columnCommands = new LinkedHashMap<>();
+    Map<String, PendingColumnRelation> pendingRelations = new LinkedHashMap<>();
     int mappingIndex = 0;
     for (SqlColumnLineageParser.ColumnMapping mapping : parsed.mappings()) {
       mappingIndex++;
       LineageAsset sourceTable = registerTableAsset(sqlContext, mapping.sourceTable(), tableAssets);
       LineageAsset targetTable = registerTableAsset(sqlContext, mapping.targetTable(), tableAssets);
-      LineageAsset sourceColumn = registerColumnAsset(
-          sqlContext,
-          sourceTable,
-          mapping.sourceTable(),
-          mapping.sourceColumnName());
-      LineageAsset targetColumn = registerColumnAsset(
-          sqlContext,
-          targetTable,
-          mapping.targetTable(),
-          mapping.targetColumnName());
-
-      // UPDATE a = a + 1 is a valid dependency, but Lineage Core intentionally forbids self edges.
-      // The authoritative TABLE -> SQL_TASK -> TABLE path remains available for that case.
-      if (sourceColumn.id() == targetColumn.id()) continue;
+      LineageService.RegisterAssetCommand sourceColumn = columnAssetCommand(
+          sqlContext, sourceTable, mapping.sourceTable(), mapping.sourceColumnName());
+      LineageService.RegisterAssetCommand targetColumn = columnAssetCommand(
+          sqlContext, targetTable, mapping.targetTable(), mapping.targetColumnName());
+      columnCommands.putIfAbsent(sourceColumn.assetKey(), sourceColumn);
+      columnCommands.putIfAbsent(targetColumn.assetKey(), targetColumn);
 
       String relationVersion = revision.revisionNo()
           + ":column:"
@@ -244,19 +248,40 @@ public class DevelopmentSqlLineageService {
           + mapping.sourceOrdinal()
           + ":"
           + mappingIndex;
-      lineageService.registerRelation(new LineageService.RegisterRelationCommand(
-          sourceColumn.id(),
-          targetColumn.id(),
+      String edgeKey = sourceColumn.assetKey() + "\u0000" + targetColumn.assetKey() + "\u0000"
+          + mapping.statementIndex() + "\u0000" + mapping.outputOrdinal() + "\u0000"
+          + mapping.sourceOrdinal();
+      pendingRelations.putIfAbsent(edgeKey, new PendingColumnRelation(
+          sourceColumn.assetKey(), targetColumn.assetKey(), mapping, relationVersion));
+    }
+
+    Map<String, LineageAsset> columns = lineageService.registerAssetsBatch(
+        List.copyOf(columnCommands.values()), lineageBatchSize);
+    List<LineageService.RegisterRelationCommand> relations = new ArrayList<>();
+    for (PendingColumnRelation pending : pendingRelations.values()) {
+      LineageAsset sourceColumn = columns.get(pending.sourceAssetKey());
+      LineageAsset targetColumn = columns.get(pending.targetAssetKey());
+      if (sourceColumn == null || targetColumn == null) {
+        throw new IllegalStateException("批量保存字段资产后缺少返回的资产身份");
+      }
+      // UPDATE a = a + 1 is a valid dependency, but Lineage Core intentionally forbids self edges.
+      if (sourceColumn.id() == targetColumn.id()) continue;
+      relations.add(new LineageService.RegisterRelationCommand(
+          sourceColumn.id(), targetColumn.id(),
           LineageRelationType.DERIVES_FROM,
           EVIDENCE_SOURCE_TYPE,
           evidenceId,
-          truncate(mapping.expression(), MAX_EVIDENCE_SQL_LENGTH),
+          truncate(pending.mapping().expression(), MAX_EVIDENCE_SQL_LENGTH),
           BigDecimal.ONE,
-          relationVersion,
+          pending.relationVersion(),
           observedAt,
-          columnRelationProperties(task, revision, mapping)));
+          columnRelationProperties(task, revision, pending.mapping())));
     }
+    lineageService.registerRelationsBatch(relations, lineageBatchSize);
   }
+
+  private record PendingColumnRelation(String sourceAssetKey, String targetAssetKey,
+      SqlColumnLineageParser.ColumnMapping mapping, String relationVersion) {}
 
   private LineageAsset registerTaskAsset(
       DevelopmentNode node,
@@ -351,7 +376,7 @@ public class DevelopmentSqlLineageService {
     return registered;
   }
 
-  private LineageAsset registerColumnAsset(
+  private LineageService.RegisterAssetCommand columnAssetCommand(
       SqlContext sqlContext,
       LineageAsset tableAsset,
       SqlTableLineageParser.TableRef table,
@@ -359,7 +384,7 @@ public class DevelopmentSqlLineageService {
     ObjectNode properties = objectMapper.createObjectNode();
     properties.put("qualifiedName", table.qualifiedName() + "." + columnName);
 
-    return lineageService.registerAsset(new LineageService.RegisterAssetCommand(
+    return new LineageService.RegisterAssetCommand(
         columnAssetKey(resolve(table, sqlContext), columnName),
         LineageAssetType.COLUMN,
         columnName,
@@ -371,7 +396,7 @@ public class DevelopmentSqlLineageService {
         emptyToNull(resolve(table, sqlContext).schemaName()),
         resolve(table, sqlContext).tableName(),
         columnName,
-        properties));
+        properties);
   }
 
   private JsonNode tableRelationProperties(DevelopmentTaskRevision revision, String role) {

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -54,6 +55,7 @@ class DevelopmentSqlLineageServiceTest {
     when(columnParser.parse(sql)).thenReturn(new SqlColumnLineageParser.ParseResult(
         List.of(
             mapping(orders, "id", sales, "order_id", 1, 1),
+            mapping(orders, "id", sales, "order_id", 1, 1),
             mapping(users, "name", sales, "user_name", 2, 1)),
         1,
         2,
@@ -66,12 +68,18 @@ class DevelopmentSqlLineageServiceTest {
 
     ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
         ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
-    verify(lineageService, times(5)).registerRelation(relations.capture());
+    verify(lineageService, times(3)).registerRelation(relations.capture());
+    ArgumentCaptor<List<LineageService.RegisterRelationCommand>> columnRelations =
+        ArgumentCaptor.forClass(List.class);
+    verify(lineageService).registerRelationsBatch(columnRelations.capture(), anyInt());
+    List<LineageService.RegisterRelationCommand> allRelations =
+        new java.util.ArrayList<>(relations.getAllValues());
+    allRelations.addAll(columnRelations.getValue());
 
-    assertEquals(2, count(relations, LineageRelationType.READS_FROM));
-    assertEquals(1, count(relations, LineageRelationType.WRITES_TO));
-    assertEquals(2, count(relations, LineageRelationType.DERIVES_FROM));
-    assertTrue(relations.getAllValues().stream()
+    assertEquals(2, count(allRelations, LineageRelationType.READS_FROM));
+    assertEquals(1, count(allRelations, LineageRelationType.WRITES_TO));
+    assertEquals(2, count(allRelations, LineageRelationType.DERIVES_FROM));
+    assertTrue(allRelations.stream()
         .filter(value -> value.relationType() == LineageRelationType.DERIVES_FROM)
         .allMatch(value -> "COLUMN".equals(value.properties().path("lineageLevel").asText())));
   }
@@ -99,10 +107,16 @@ class DevelopmentSqlLineageServiceTest {
 
     ArgumentCaptor<LineageService.RegisterAssetCommand> assets =
         ArgumentCaptor.forClass(LineageService.RegisterAssetCommand.class);
-    verify(lineageService, times(5)).registerAsset(assets.capture());
+    verify(lineageService, times(3)).registerAsset(assets.capture());
+    ArgumentCaptor<List<LineageService.RegisterAssetCommand>> columnAssets =
+        ArgumentCaptor.forClass(List.class);
+    verify(lineageService).registerAssetsBatch(columnAssets.capture(), anyInt());
 
     Map<String, LineageService.RegisterAssetCommand> byKey = new LinkedHashMap<>();
     for (LineageService.RegisterAssetCommand command : assets.getAllValues()) {
+      byKey.put(command.assetKey(), command);
+    }
+    for (LineageService.RegisterAssetCommand command : columnAssets.getValue()) {
       byKey.put(command.assetKey(), command);
     }
 
@@ -151,16 +165,22 @@ class DevelopmentSqlLineageServiceTest {
 
     ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
         ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
-    verify(lineageService, times(4)).registerRelation(relations.capture());
+    verify(lineageService, times(2)).registerRelation(relations.capture());
+    ArgumentCaptor<List<LineageService.RegisterRelationCommand>> columnRelations =
+        ArgumentCaptor.forClass(List.class);
+    verify(lineageService).registerRelationsBatch(columnRelations.capture(), anyInt());
+    List<LineageService.RegisterRelationCommand> allRelations =
+        new java.util.ArrayList<>(relations.getAllValues());
+    allRelations.addAll(columnRelations.getValue());
 
-    assertEquals(1, count(relations, LineageRelationType.READS_FROM));
-    assertEquals(1, count(relations, LineageRelationType.WRITES_TO));
-    assertEquals(2, count(relations, LineageRelationType.DERIVES_FROM));
-    assertTrue(relations.getAllValues().stream()
+    assertEquals(1, count(allRelations, LineageRelationType.READS_FROM));
+    assertEquals(1, count(allRelations, LineageRelationType.WRITES_TO));
+    assertEquals(2, count(allRelations, LineageRelationType.DERIVES_FROM));
+    assertTrue(allRelations.stream()
         .filter(value -> value.relationType() == LineageRelationType.DERIVES_FROM)
         .anyMatch(value -> "id".equals(value.properties().path("sourceColumn").asText())
             && "order_id".equals(value.properties().path("targetColumn").asText())));
-    assertTrue(relations.getAllValues().stream()
+    assertTrue(allRelations.stream()
         .filter(value -> value.relationType() == LineageRelationType.DERIVES_FROM)
         .anyMatch(value -> "amount".equals(value.properties().path("sourceColumn").asText())
             && "order_amount".equals(value.properties().path("targetColumn").asText())));
@@ -222,7 +242,12 @@ class DevelopmentSqlLineageServiceTest {
   private static long count(
       ArgumentCaptor<LineageService.RegisterRelationCommand> relations,
       LineageRelationType type) {
-    return relations.getAllValues().stream()
+    return count(relations.getAllValues(), type);
+  }
+
+  private static long count(
+      List<LineageService.RegisterRelationCommand> relations, LineageRelationType type) {
+    return relations.stream()
         .filter(value -> value.relationType() == type)
         .count();
   }
@@ -289,6 +314,20 @@ class DevelopmentSqlLineageServiceTest {
           command.properties(),
           Instant.parse("2026-08-20T00:00:00Z"),
           Instant.parse("2026-08-20T00:00:00Z"));
+    });
+    when(lineageService.registerAssetsBatch(any(), anyInt())).thenAnswer(invocation -> {
+      List<LineageService.RegisterAssetCommand> commands = invocation.getArgument(0);
+      Map<String, LineageAsset> result = new LinkedHashMap<>();
+      for (LineageService.RegisterAssetCommand command : commands) {
+        long id = stableIds.computeIfAbsent(command.assetKey(), ignored -> ids.getAndIncrement());
+        result.put(command.assetKey(), new LineageAsset(
+            id, command.assetKey(), command.assetType(), command.name(), command.sourceType(),
+            command.sourceId(), command.parentAssetId(), command.dataSourceId(),
+            command.databaseName(), command.schemaName(), command.tableName(), command.columnName(),
+            command.properties(), Instant.parse("2026-08-20T00:00:00Z"),
+            Instant.parse("2026-08-20T00:00:00Z")));
+      }
+      return result;
     });
   }
 

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
@@ -12,8 +12,10 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.sql.DataSource;
@@ -137,6 +139,69 @@ class JdbcLineageRepository implements LineageRepository {
   }
 
   @Override
+  public Map<String, LineageAsset> upsertAssets(List<AssetWrite> writes, int batchSize) {
+    if (writes == null || writes.isEmpty()) return Map.of();
+    Map<String, LineageAsset> result = new LinkedHashMap<>();
+    for (int start = 0; start < writes.size(); start += batchSize) {
+      List<AssetWrite> batch = writes.subList(start, Math.min(start + batchSize, writes.size()));
+      jdbcTemplate.batchUpdate(
+          """
+          INSERT INTO yak_metadata_asset
+            (asset_key, asset_type, name, source_type, source_id, parent_asset_id,
+             data_source_id, database_name, schema_name, table_name, column_name, properties,
+             create_time, update_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6), NOW(6))
+          ON DUPLICATE KEY UPDATE
+            asset_type=VALUES(asset_type), name=VALUES(name), source_type=VALUES(source_type),
+            source_id=VALUES(source_id), parent_asset_id=VALUES(parent_asset_id),
+            data_source_id=VALUES(data_source_id), database_name=VALUES(database_name),
+            schema_name=VALUES(schema_name), table_name=VALUES(table_name),
+            column_name=VALUES(column_name), properties=VALUES(properties), update_time=NOW(6)
+          """,
+          batch,
+          batch.size(),
+          (statement, write) -> bindAsset(statement, write));
+      List<String> keys = batch.stream().map(AssetWrite::assetKey).toList();
+      String placeholders = String.join(",", Collections.nCopies(keys.size(), "?"));
+      for (LineageAsset asset : jdbcTemplate.query(
+          ASSET_COLUMNS + " WHERE asset_key IN (" + placeholders + ")", this::mapAsset,
+          keys.toArray())) {
+        result.put(asset.assetKey(), asset);
+      }
+    }
+    if (result.size() != writes.size()) {
+      throw new IllegalStateException("批量保存血缘资产后无法读取全部资产");
+    }
+    return result;
+  }
+
+  static int batchExecutionCount(int itemCount, int batchSize) {
+    if (itemCount <= 0) return 0;
+    if (batchSize < 1) throw new IllegalArgumentException("batchSize must be positive");
+    return (itemCount + batchSize - 1) / batchSize;
+  }
+
+  @Override
+  public void upsertRelations(List<RelationWrite> writes, int batchSize) {
+    if (writes == null || writes.isEmpty()) return;
+    for (int start = 0; start < writes.size(); start += batchSize) {
+      List<RelationWrite> batch = writes.subList(start, Math.min(start + batchSize, writes.size()));
+      jdbcTemplate.batchUpdate(
+          """
+          INSERT INTO yak_metadata_relation
+            (source_asset_id, target_asset_id, relation_type, source_type, source_id,
+             expression, confidence, version, observed_at, properties, create_time, update_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6), NOW(6))
+          ON DUPLICATE KEY UPDATE expression=VALUES(expression), confidence=VALUES(confidence),
+            observed_at=VALUES(observed_at), properties=VALUES(properties), update_time=NOW(6)
+          """,
+          batch,
+          batch.size(),
+          (statement, write) -> bindRelation(statement, write));
+    }
+  }
+
+  @Override
   public int deleteRelationsByEvidence(String sourceType, String sourceId) {
     return jdbcTemplate.update(
         "DELETE FROM yak_metadata_relation WHERE source_type = ? AND source_id = ?",
@@ -219,6 +284,35 @@ class JdbcLineageRepository implements LineageRepository {
         RELATION_COLUMNS + " WHERE id = ? LIMIT 1", this::mapRelation, relationId)
         .stream().findFirst()
         .orElseThrow(() -> new IllegalStateException("保存血缘关系后无法读取关系"));
+  }
+
+  private void bindAsset(PreparedStatement statement, AssetWrite write) throws SQLException {
+    statement.setString(1, write.assetKey());
+    statement.setString(2, write.assetType().name());
+    statement.setString(3, write.name());
+    statement.setString(4, write.sourceType());
+    statement.setString(5, write.sourceId());
+    if (write.parentAssetId() == null) statement.setNull(6, java.sql.Types.BIGINT);
+    else statement.setLong(6, write.parentAssetId());
+    statement.setString(7, write.dataSourceId());
+    statement.setString(8, write.databaseName());
+    statement.setString(9, write.schemaName());
+    statement.setString(10, write.tableName());
+    statement.setString(11, write.columnName());
+    statement.setString(12, toJson(write.properties()));
+  }
+
+  private void bindRelation(PreparedStatement statement, RelationWrite write) throws SQLException {
+    statement.setLong(1, write.sourceAssetId());
+    statement.setLong(2, write.targetAssetId());
+    statement.setString(3, write.relationType().name());
+    statement.setString(4, write.sourceType());
+    statement.setString(5, write.sourceId());
+    statement.setString(6, write.expression());
+    statement.setBigDecimal(7, write.confidence());
+    statement.setString(8, write.version());
+    statement.setTimestamp(9, Timestamp.from(write.observedAt()));
+    statement.setString(10, toJson(write.properties()));
   }
 
   private LineageAsset mapAsset(ResultSet rs, int rowNum) throws SQLException {

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -12,6 +13,14 @@ interface LineageRepository {
   LineageAsset upsertAsset(AssetWrite write);
 
   LineageRelation upsertRelation(RelationWrite write);
+
+  default Map<String, LineageAsset> upsertAssets(List<AssetWrite> writes, int batchSize) {
+    throw new UnsupportedOperationException("Batch asset registration is not supported");
+  }
+
+  default void upsertRelations(List<RelationWrite> writes, int batchSize) {
+    throw new UnsupportedOperationException("Batch relation registration is not supported");
+  }
 
   default int deleteRelationsByEvidence(String sourceType, String sourceId) {
     throw new UnsupportedOperationException("Relation evidence cleanup is not supported");

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
@@ -86,6 +86,65 @@ public class LineageService {
         command.properties()));
   }
 
+  /** Registers deduplicated assets with JDBC batches and returns their database identities. */
+  @Transactional
+  public Map<String, LineageAsset> registerAssetsBatch(
+      List<RegisterAssetCommand> commands, int batchSize) {
+    requireBatchSize(batchSize);
+    if (commands == null || commands.isEmpty()) return Map.of();
+    Map<String, LineageRepository.AssetWrite> writes = new LinkedHashMap<>();
+    for (RegisterAssetCommand command : commands) {
+      Objects.requireNonNull(command, "command");
+      String assetKey = required(command.assetKey(), "assetKey", 512);
+      LineageAssetType assetType = Objects.requireNonNull(command.assetType(), "assetType");
+      String name = optional(command.name(), 200);
+      if (name == null) name = assetKey;
+      if (command.parentAssetId() != null) requirePositive(command.parentAssetId(), "parentAssetId");
+      writes.putIfAbsent(assetKey, new LineageRepository.AssetWrite(
+          assetKey, assetType, name, valueOrEmpty(command.sourceType(), 64),
+          valueOrEmpty(command.sourceId(), 200), command.parentAssetId(),
+          optional(command.dataSourceId(), 64), optional(command.databaseName(), 256),
+          optional(command.schemaName(), 256), optional(command.tableName(), 256),
+          optional(command.columnName(), 256), command.properties()));
+    }
+    return repository.upsertAssets(List.copyOf(writes.values()), batchSize);
+  }
+
+  /** Registers deduplicated relations using real JDBC batch execution. */
+  @Transactional
+  public void registerRelationsBatch(List<RegisterRelationCommand> commands, int batchSize) {
+    requireBatchSize(batchSize);
+    if (commands == null || commands.isEmpty()) return;
+    Map<String, LineageRepository.RelationWrite> writes = new LinkedHashMap<>();
+    for (RegisterRelationCommand command : commands) {
+      Objects.requireNonNull(command, "command");
+      requirePositive(command.sourceAssetId(), "sourceAssetId");
+      requirePositive(command.targetAssetId(), "targetAssetId");
+      if (command.sourceAssetId() == command.targetAssetId()) {
+        throw new IllegalArgumentException("血缘关系不能指向资产自身");
+      }
+      LineageRelationType type = Objects.requireNonNull(command.relationType(), "relationType");
+      BigDecimal confidence = command.confidence() == null ? BigDecimal.ONE : command.confidence();
+      if (confidence.compareTo(BigDecimal.ZERO) < 0 || confidence.compareTo(BigDecimal.ONE) > 0) {
+        throw new IllegalArgumentException("confidence 必须在 0 到 1 之间");
+      }
+      String sourceType = valueOrEmpty(command.sourceType(), 64);
+      String sourceId = valueOrEmpty(command.sourceId(), 200);
+      String version = valueOrEmpty(command.version(), 128);
+      String identity = command.sourceAssetId() + "\u0000" + command.targetAssetId() + "\u0000"
+          + type + "\u0000" + sourceType + "\u0000" + sourceId + "\u0000" + version;
+      writes.putIfAbsent(identity, new LineageRepository.RelationWrite(
+          command.sourceAssetId(), command.targetAssetId(), type, sourceType, sourceId,
+          optional(command.expression(), 16000), confidence, version,
+          command.observedAt() == null ? Instant.now() : command.observedAt(), command.properties()));
+    }
+    repository.upsertRelations(List.copyOf(writes.values()), batchSize);
+  }
+
+  private static void requireBatchSize(int batchSize) {
+    if (batchSize < 1) throw new IllegalArgumentException("batchSize 必须大于 0");
+  }
+
   @Transactional(readOnly = true)
   public LineageAsset getAsset(long assetId) {
     requirePositive(assetId, "assetId");

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
@@ -70,6 +70,37 @@ class LineageServiceTest {
     assertEquals(1, service.searchAssets(null, LineageAssetType.DATASET, 1).size());
   }
 
+  @Test
+  void batchSizingMakesThousandColumnLineageWritesBounded() {
+    // 1,000 unique edges with two unique endpoints each: asset batch + identity read + edge batch.
+    assertEquals(25, 2 * JdbcLineageRepository.batchExecutionCount(2_000, 200)
+        + JdbcLineageRepository.batchExecutionCount(1_000, 200));
+    assertEquals(5, JdbcLineageRepository.batchExecutionCount(1_000, 256));
+    assertEquals(0, JdbcLineageRepository.batchExecutionCount(0, 200));
+  }
+
+  @Test
+  void batchApiDeduplicatesInputsAndSkipsEmptyCollections() {
+    InMemoryLineageRepository repository = new InMemoryLineageRepository();
+    LineageService service = new LineageService(repository);
+
+    Map<String, LineageAsset> assets = service.registerAssetsBatch(
+        List.of(asset("column:a", LineageAssetType.COLUMN),
+            asset("column:a", LineageAssetType.COLUMN),
+            asset("column:b", LineageAssetType.COLUMN)), 1);
+    service.registerRelationsBatch(List.of(
+        relation(assets.get("column:a").id(), assets.get("column:b").id(),
+            LineageRelationType.DERIVES_FROM),
+        relation(assets.get("column:a").id(), assets.get("column:b").id(),
+            LineageRelationType.DERIVES_FROM)), 7);
+
+    assertEquals(2, assets.size());
+    assertEquals(1, repository.relations.size());
+    assertTrue(service.registerAssetsBatch(List.of(), 10).isEmpty());
+    service.registerRelationsBatch(List.of(), 10);
+    assertEquals(1, repository.relations.size());
+  }
+
   private static Set<Long> ids(LineageGraph graph) {
     return graph.nodes().stream().map(LineageAsset::id).collect(Collectors.toSet());
   }
@@ -121,6 +152,18 @@ class LineageServiceTest {
           write.version(), write.observedAt(), write.properties(), now, now);
       relations.put(id, relation);
       return relation;
+    }
+
+    @Override
+    public Map<String, LineageAsset> upsertAssets(List<AssetWrite> writes, int batchSize) {
+      Map<String, LineageAsset> result = new LinkedHashMap<>();
+      for (AssetWrite write : writes) result.put(write.assetKey(), upsertAsset(write));
+      return result;
+    }
+
+    @Override
+    public void upsertRelations(List<RelationWrite> writes, int batchSize) {
+      for (RelationWrite write : writes) upsertRelation(write);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

- 解决字段血缘写入时逐字段、逐边发起大量单条 SQL（N+1）的问题，将写入放到可控批量执行以显著降低数据库往返次数。
- 保证同一 revision 的字段资产与字段血缘在短事务边界内原子替换且幂等，避免重复同步产生重复资产或边。
- 提供可配置的批量大小以兼容不同数据库驱动、SQL 长度和数据包限制，并在内存中先完成去重与组装以减少数据库交互次数。

### Description

- 在 `LineageService` 中新增 `registerAssetsBatch` 与 `registerRelationsBatch` 接口，负责在应用层去重并调用持久层的批量写入 API；新增 `requireBatchSize` 校验与幂等写入逻辑。 (`LineageService`) 。
- 扩展 `LineageRepository` 接口加入 `upsertAssets(List, int)` 与 `upsertRelations(List, int)` 默认方法，并在 `JdbcLineageRepository` 中使用 `JdbcTemplate.batchUpdate` 实现真实 JDBC 批处理与批量读取资产 ID 的语义，批次大小按参数拆分执行并使用 `ON DUPLICATE KEY UPDATE` 保持幂等。 (`JdbcLineageRepository`, `LineageRepository`) 。
- 在 `DevelopmentSqlLineageService` 中将字段资产与字段边先在内存中以资产键和边身份去重、组装为 `RegisterAssetCommand` / `RegisterRelationCommand`，调用批量接口一次性持久化；增加 `PendingColumnRelation` 用于在写入后把返回的资产 ID 组装成关系。并新增配置 `yak.lineage.write-batch-size`（默认 `200`）以控制每次 JDBC 批量大小。 (`DevelopmentSqlLineageService`) 。
- 保持已有表级血缘、资产身份、解析语义不变，批量实现仍在现有短事务边界（`REQUIRES_NEW`）内执行，任何批次失败会抛出并导致事务回滚，未添加额外数据库迁移或索引改动。 （`DevelopmentLineageWriteTransaction`、migration V1 保持不变）。

- 实际 SQL 次数对比（示例, 1,000 条字段边、2,000 个不同字段资产、batch size=200）：
  - 优化前（逐项 upsert/查询）：约 8,000 次 SQL 调用（约 4,000 次字段资产相关 + 4,000 次字段边相关）。
  - 优化后（batch=200）：约 25 次批量执行（10 次资产写批 + 10 次资产按键批量读 ID + 5 次边写批）。

### Testing

- 代码风格与差异检查：`git diff --check` 已执行且通过。 (成功)。
- 单元测试修改：已更新并新增对批量 API 的单元测试（`LineageServiceTest` 与 `DevelopmentSqlLineageServiceTest`），这些测试在代码库中以 mock/内存仓库方式覆盖了去重、空集合、安全跳过与 batch-sizing 断言。 (测试代码已提交但未在 CI 中运行)。
- 构建/编译尝试：运行 `mvn -pl yak-ops-business/yak-ops-business-data-development -am -DskipTests compile` 与 `./mvnw ...` 时因运行环境无法访问 Maven Central（代理返回 HTTP 403）而失败，导致无法在该容器中完成实际的模块编译或 JUnit 执行。 (失败，网络依赖)。
- 代码提交与分支：已在本地创建并提交分支 `codex/p1-batch-column-lineage`（提交 `420cfe3 perf(lineage): batch column lineage writes`），但 `git push` 到远端和使用 `gh` 创建 Draft PR 均因网络/认证限制（HTTP 403 / 未登录）而未能完成。 (推送与 PR 创建失败)。

已知限制：

- 本次提交在当前受限环境中无法跑完整的 Maven 构建与单元测试，需要在有正常外网访问或镜像缓存的 CI 环境中执行 `mvn test`/`mvn -DskipTests=false test` 验证所有模块。 
- JDBC 批处理采用 `JdbcTemplate.batchUpdate`（真实 executeBatch），但是否被底层驱动转换为单条多值 `INSERT` 取决于具体 JDBC 驱动和数据库；请在目标环境验证 `batchSize` 与 `max_allowed_packet` / 参数数量限制的兼容性并按需调整 `yak.lineage.write-batch-size`。 
- 我已准备 Draft PR 元数据并在本地提交分支，但由于网络/认证限制无法推送或在 GitHub 创建 Draft PR；建议在具备网络权限的环境执行 `git push -u origin codex/p1-batch-column-lineage` 并使用 `gh pr create --draft --base main` 或通过 GitHub UI 创建 Draft PR。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86e518a13c83269d11f6da3a3a1120)