### PR TITLE
lineage: reclaim unreferenced task-owned assets (evidence‑scoped replacement)

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Publishes authoritative table- and column-level lineage for immutable SQL task revisions. */
 @Service
@@ -97,19 +98,25 @@ public class DevelopmentSqlLineageService {
   }
 
   /** Compatibility entry point; production outbox uses prepare then an independent write transaction. */
+  @Transactional
   public void syncPublished(DevelopmentNode node, DevelopmentTaskRevision revision) {
     PreparedLineage prepared = prepare(node, revision);
     if (prepared != null) applyPrepared(node, revision, prepared);
   }
 
-  /** Writes an already prepared snapshot. Caller supplies the atomic transaction. */
+  /** Writes and reclaims one snapshot atomically. */
+  @Transactional
   public void applyPrepared(DevelopmentNode node, DevelopmentTaskRevision revision,
       PreparedLineage prepared) {
     String evidenceId = String.valueOf(node.id());
     String dataSourceId = prepared.context().dataSourceId();
-    maintenanceService.clearRelationsByEvidence(EVIDENCE_SOURCE_TYPE, evidenceId);
+    if (!maintenanceService.lockAndAcceptRevision(
+        "sql-task:data-development:" + node.id(), revision.revisionNo())) return;
+    LineageMaintenanceService.CleanupScope cleanup = maintenanceService.beginReplacement(
+        EVIDENCE_SOURCE_TYPE, evidenceId, "DATA_DEVELOPMENT", evidenceId);
     if (prepared.tableFailure() != null) {
       registerTaskAsset(node, revision, dataSourceId, null, null, prepared.tableFailure(), null);
+      maintenanceService.finishReplacement(cleanup);
       return;
     }
     SqlTableLineageParser.ParseResult tableParsed = prepared.tables();
@@ -135,6 +142,7 @@ public class DevelopmentSqlLineageService {
     }
     if (columnParsed != null) registerColumnLineage(prepared.context(), task, revision, columnParsed,
         evidenceId, observedAt, tableAssets);
+    maintenanceService.finishReplacement(cleanup);
   }
 
   public record PreparedLineage(SqlContext context, SqlTableLineageParser.ParseResult tables,

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
@@ -37,6 +37,7 @@ class DevelopmentSqlLineageServiceTest {
   void replacesGeneratedRelationsWithTableAndColumnLineage() {
     LineageService lineageService = mock(LineageService.class);
     LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    when(maintenanceService.lockAndAcceptRevision(anyString(), anyInt())).thenReturn(true);
     SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
     SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
     ObjectMapper objectMapper = new ObjectMapper();
@@ -63,8 +64,9 @@ class DevelopmentSqlLineageServiceTest {
 
     service.syncPublished(node(), revision(sql));
 
-    verify(maintenanceService).clearRelationsByEvidence(
-        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
+    verify(maintenanceService).beginReplacement(
+        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42", "DATA_DEVELOPMENT", "42");
+    verify(maintenanceService).finishReplacement(null);
 
     ArgumentCaptor<LineageService.RegisterRelationCommand> relations =
         ArgumentCaptor.forClass(LineageService.RegisterRelationCommand.class);
@@ -88,6 +90,7 @@ class DevelopmentSqlLineageServiceTest {
   void columnAssetsAreParentedByStableTableAssets() {
     LineageService lineageService = mock(LineageService.class);
     LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    when(maintenanceService.lockAndAcceptRevision(anyString(), anyInt())).thenReturn(true);
     SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
     SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
     ObjectMapper objectMapper = new ObjectMapper();
@@ -134,6 +137,7 @@ class DevelopmentSqlLineageServiceTest {
   void catalogSchemaEnablesStarAndImplicitTargetColumnLineage() {
     LineageService lineageService = mock(LineageService.class);
     LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    when(maintenanceService.lockAndAcceptRevision(anyString(), anyInt())).thenReturn(true);
     SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
     SqlColumnLineageParser columnParser = new SqlColumnLineageParser();
     DataSourceCatalogService catalogService = mock(DataSourceCatalogService.class);
@@ -190,6 +194,7 @@ class DevelopmentSqlLineageServiceTest {
   void columnParserFailureKeepsCurrentTableLineage() {
     LineageService lineageService = mock(LineageService.class);
     LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    when(maintenanceService.lockAndAcceptRevision(anyString(), anyInt())).thenReturn(true);
     SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
     SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
     ObjectMapper objectMapper = new ObjectMapper();
@@ -220,6 +225,7 @@ class DevelopmentSqlLineageServiceTest {
   void tableParserFailureClearsStaleRelationsAndSkipsColumnParsing() {
     LineageService lineageService = mock(LineageService.class);
     LineageMaintenanceService maintenanceService = mock(LineageMaintenanceService.class);
+    when(maintenanceService.lockAndAcceptRevision(anyString(), anyInt())).thenReturn(true);
     SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
     SqlColumnLineageParser columnParser = mock(SqlColumnLineageParser.class);
     ObjectMapper objectMapper = new ObjectMapper();
@@ -233,8 +239,9 @@ class DevelopmentSqlLineageServiceTest {
 
     assertDoesNotThrow(() -> service.syncPublished(node(), revision(sql)));
 
-    verify(maintenanceService).clearRelationsByEvidence(
-        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42");
+    verify(maintenanceService).beginReplacement(
+        DevelopmentSqlLineageService.EVIDENCE_SOURCE_TYPE, "42", "DATA_DEVELOPMENT", "42");
+    verify(maintenanceService).finishReplacement(null);
     verify(columnParser, never()).parse(any());
     verify(lineageService, never()).registerRelation(any());
   }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/JdbcLineageRepository.java
@@ -210,6 +210,42 @@ class JdbcLineageRepository implements LineageRepository {
   }
 
   @Override
+  public Set<Long> findAssetIdsByEvidence(String sourceType, String sourceId) {
+    return Set.copyOf(jdbcTemplate.queryForList("""
+        SELECT source_asset_id AS asset_id FROM yak_metadata_relation
+         WHERE source_type = ? AND source_id = ?
+        UNION
+        SELECT target_asset_id AS asset_id FROM yak_metadata_relation
+         WHERE source_type = ? AND source_id = ?
+        """, Long.class, sourceType, sourceId, sourceType, sourceId));
+  }
+
+  @Override
+  public int deleteUnreferencedOwnedAssets(Set<Long> assetIds, String ownerType, String ownerId) {
+    if (assetIds == null || assetIds.isEmpty()) return 0;
+    String placeholders = String.join(",", Collections.nCopies(assetIds.size(), "?"));
+    List<Object> arguments = new ArrayList<>(assetIds);
+    arguments.add(ownerType);
+    arguments.add(ownerId);
+    return jdbcTemplate.update("""
+        DELETE asset FROM yak_metadata_asset asset
+        LEFT JOIN yak_metadata_relation outgoing ON outgoing.source_asset_id = asset.id
+        LEFT JOIN yak_metadata_relation incoming ON incoming.target_asset_id = asset.id
+        LEFT JOIN yak_metadata_asset child ON child.parent_asset_id = asset.id
+         WHERE asset.id IN (%s)
+           AND asset.source_type = ? AND asset.source_id = ?
+           AND outgoing.id IS NULL AND incoming.id IS NULL AND child.id IS NULL
+        """.formatted(placeholders), arguments.toArray());
+  }
+
+  @Override
+  public Optional<LineageAsset> lockAssetByKey(String assetKey) {
+    return jdbcTemplate.query(
+        ASSET_COLUMNS + " WHERE asset_key = ? LIMIT 1 FOR UPDATE", this::mapAsset, assetKey)
+        .stream().findFirst();
+  }
+
+  @Override
   public Optional<LineageAsset> findAsset(long assetId) {
     return jdbcTemplate.query(
         ASSET_COLUMNS + " WHERE id = ? LIMIT 1", this::mapAsset, assetId)

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageMaintenanceService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageMaintenanceService.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.lineage;
 
+import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,44 @@ public class LineageMaintenanceService {
     String normalizedType = required(sourceType, "sourceType", 64);
     String normalizedId = required(sourceId, "sourceId", 200);
     return repository.deleteRelationsByEvidence(normalizedType, normalizedId);
+  }
+
+  /** Starts an evidence-scoped replacement and remembers only its former endpoints. */
+  @Transactional
+  public CleanupScope beginReplacement(
+      String sourceType, String sourceId, String ownerType, String ownerId) {
+    String evidenceType = required(sourceType, "sourceType", 64);
+    String evidenceId = required(sourceId, "sourceId", 200);
+    CleanupScope scope = new CleanupScope(evidenceType, evidenceId,
+        required(ownerType, "ownerType", 64), required(ownerId, "ownerId", 200),
+        repository.findAssetIdsByEvidence(evidenceType, evidenceId));
+    repository.deleteRelationsByEvidence(evidenceType, evidenceId);
+    return scope;
+  }
+
+  /** Deletes old endpoints only when explicit ownership, all edges, and children permit it. */
+  @Transactional
+  public int finishReplacement(CleanupScope scope) {
+    if (scope == null) throw new IllegalArgumentException("cleanupScope 不能为空");
+    return repository.deleteUnreferencedOwnedAssets(
+        scope.candidateAssetIds(), scope.ownerType(), scope.ownerId());
+  }
+
+  /** Serializes publishers and rejects an older revision after a newer revision has committed. */
+  @Transactional
+  public boolean lockAndAcceptRevision(String assetKey, int revisionNo) {
+    String key = required(assetKey, "assetKey", 512);
+    return repository.lockAssetByKey(key).map(asset -> {
+      if (asset.properties() == null || !asset.properties().has("revisionNo")) return true;
+      return asset.properties().path("revisionNo").asInt(Integer.MIN_VALUE) <= revisionNo;
+    }).orElse(true);
+  }
+
+  public record CleanupScope(String sourceType, String sourceId, String ownerType, String ownerId,
+      Set<Long> candidateAssetIds) {
+    public CleanupScope {
+      candidateAssetIds = candidateAssetIds == null ? Set.of() : Set.copyOf(candidateAssetIds);
+    }
   }
 
   private static String required(String value, String field, int maxLength) {

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageRepository.java
@@ -26,6 +26,18 @@ interface LineageRepository {
     throw new UnsupportedOperationException("Relation evidence cleanup is not supported");
   }
 
+  default Set<Long> findAssetIdsByEvidence(String sourceType, String sourceId) {
+    throw new UnsupportedOperationException("Relation evidence lookup is not supported");
+  }
+
+  default int deleteUnreferencedOwnedAssets(Set<Long> assetIds, String ownerType, String ownerId) {
+    throw new UnsupportedOperationException("Owned asset cleanup is not supported");
+  }
+
+  default Optional<LineageAsset> lockAssetByKey(String assetKey) {
+    return findAssetByKey(assetKey);
+  }
+
   Optional<LineageAsset> findAsset(long assetId);
 
   Optional<LineageAsset> findAssetByKey(String assetKey);

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageMaintenanceServiceTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageMaintenanceServiceTest.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.lineage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class LineageMaintenanceServiceTest {
+
+  @Test
+  void replacementCapturesEndpointsThenUsesOneOwnershipGuardedBulkDelete() {
+    LineageRepository repository = mock(LineageRepository.class);
+    when(repository.findAssetIdsByEvidence("PARSE", "task-1"))
+        .thenReturn(Set.of(1L, 2L, 3L));
+    LineageMaintenanceService service = new LineageMaintenanceService(repository);
+
+    LineageMaintenanceService.CleanupScope scope =
+        service.beginReplacement("PARSE", "task-1", "TASK", "task-1");
+    service.finishReplacement(scope);
+
+    InOrder order = inOrder(repository);
+    order.verify(repository).findAssetIdsByEvidence("PARSE", "task-1");
+    order.verify(repository).deleteRelationsByEvidence("PARSE", "task-1");
+    order.verify(repository).deleteUnreferencedOwnedAssets(Set.of(1L, 2L, 3L), "TASK", "task-1");
+  }
+
+  @Test
+  void revisionLockRejectsStalePublisherAndAcceptsCurrentPublisher() throws Exception {
+    LineageRepository repository = mock(LineageRepository.class);
+    LineageMaintenanceService service = new LineageMaintenanceService(repository);
+    LineageAsset asset = new LineageAsset(1, "task:key", LineageAssetType.SQL_TASK, "task",
+        "TASK", "1", null, null, null, null, null, null,
+        new ObjectMapper().readTree("{\"revisionNo\":8}"), Instant.EPOCH, Instant.EPOCH);
+    when(repository.lockAssetByKey("task:key")).thenReturn(Optional.of(asset));
+
+    assertFalse(service.lockAndAcceptRevision("task:key", 7));
+    assertTrue(service.lockAndAcceptRevision("task:key", 8));
+    verify(repository, org.mockito.Mockito.times(2)).lockAssetByKey("task:key");
+  }
+}


### PR DESCRIPTION
### Motivation

- 修复在替换/删除血缘关系时仅清理关系但不回收属于该 task/revision 且已无任何引用的资产，导致任务资产、派生字段或 task 自有资产残留的问题。
- 要求回收逻辑必须严格基于 owner/source/revision 标识，并在删除前校验上下游关系、父子资产及其它 Dataset/任务引用，避免误删物理表、共享字段或人工维护资产。

### Description

- 新增证据范围的替换流程：先批量收集本次 evidence（sourceType/sourceId）在关系表中出现的所有端点资产 id，删除该 evidence 的旧关系，然后在同一事务内写入新血缘，最后以批量 SQL 回收仍无任何引用且 owner 精确匹配的旧资产（关键实现见 `LineageMaintenanceService.beginReplacement/finishReplacement`）。
- 在仓库层添加批量接口与安全删除实现：`LineageRepository` 增加 `findAssetIdsByEvidence`、`deleteUnreferencedOwnedAssets` 和行级锁 `lockAssetByKey` 的默认/实现，`JdbcLineageRepository` 使用一次 `UNION` 查询收集端点并用单次带 LEFT JOIN 的 `DELETE ...` 语句确保没有入/出关系或子资产来回收，避免逐资产 N+1 SQL。
- 引入发布序号（`revisionNo`）行级锁检查以序列化发布并拒绝落后的旧 revision 回收，从而避免旧 revision 在新 revision 已提交后删除新血缘或其资产（在 SQL 任务写入路径调用 `lockAndAcceptRevision`）。
- 将 SQL 血缘替换流程（revision 检查、清旧关系、写新关系、回收旧资产）置于 Spring 事务边界以保证原子性，并新增单元测试 `LineageMaintenanceServiceTest` 验证端点捕获、调用顺序与 revision 锁行为；同时对 `DevelopmentSqlLineageService` 和相关测试做了配套修改以调用新流程。

### Testing

- 已执行静态检查 `git diff --check` 并通过本地代码检查，新增/修改的单元测试文件已加入源码（`LineageMaintenanceServiceTest` 和对 `DevelopmentSqlLineageServiceTest` 的适配）。
- 尝试运行 Maven 测试（`mvn` / `./mvnw -pl ... test`）时因执行环境无法从 Maven Central 下载依赖（HTTP 403 / 代理限制），构建/测试未能完成，因此实际单元测试没有在 CI 环境中跑通。
- 本地提交已保存到开发分支并准备推送，但由于当前运行环境对外网和 GitHub 的连接被代理拒绝且未配置 `gh` 登录，无法远端推送或在 GitHub 上创建 Draft PR。
- 已手动验证关键新 SQL/批量路径逻辑为批量执行（`UNION` 收集端点与单次 `DELETE ... LEFT JOIN` 回收），从实现上避免了逐资产 N+1 查询；新增单测覆盖了替换顺序与 revision 锁的逻辑（可在可联网环境下通过 `mvn test` 复现）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86e7c94b388326b0990894e5d2c5c0)