### PR TITLE
fix: resolve HttpRealtimeEngineGateway parse compile error

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/HttpRealtimeEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/HttpRealtimeEngineGateway.java
@@ -91,7 +91,7 @@ public class HttpRealtimeEngineGateway implements RealtimeEngineGateway {
       HttpRequest request = request("/stop").POST(HttpRequest.BodyPublishers.noBody()).build();
       HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() != 200) {
-        throw httpError(response.statusCode(), parse(response.body()), true);
+        throw httpError(response.statusCode(), parse(response.body(), true), true);
       }
     } catch (HttpTimeoutException exception) {
       throw new GatewayException(Kind.UNAVAILABLE, "Runtime 停止结果不确定", true, null, exception);


### PR DESCRIPTION
## Fix HttpRealtimeEngineGateway compile error

### Problem
`HttpRealtimeEngineGateway.parse` method signature changed from:

```java
parse(String)
```

to:

```java
parse(String, boolean)
```

but `stop()` still used the old invocation, causing compilation failure.

### Change
Update `stop()` error handling path to pass the uncertainty flag:

```java
parse(response.body(), true)
```

### Impact
- Fixes build failure in `yak-ops-business-sync-realtime` module.
- Keeps existing uncertain failure semantics for stop operations.
- No functional behavior change for successful requests.