### PR TITLE
Draft: 修复数据开发血缘字段类型展示

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentSqlLineagePreview.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentSqlLineagePreview.java
@@ -70,8 +70,10 @@ public record DevelopmentSqlLineagePreview(
   public record ColumnMapping(
       String sourceTable,
       String sourceColumn,
+      String sourceDataType,
       String targetTable,
       String targetColumn,
+      String targetDataType,
       String mappingKind,
       String expression,
       int outputOrdinal,

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
@@ -168,17 +168,28 @@ public class DevelopmentSqlLineagePreviewService {
         SqlProjectionLineageAnalyzer.ProjectionResult result = projectionAnalyzer.analyze(
             sql,
             projectionSchemaProvider(dataSourceId, defaultDatabase, defaultSchema));
-        List<ColumnMapping> mappings = result.mappings().stream()
-            .map(mapping -> new ColumnMapping(
-                mapping.sourceTable().qualifiedName(),
-                mapping.sourceColumnName(),
-                null,
-                mapping.outputColumnName(),
-                mapping.mappingKind().name(),
-                mapping.expression(),
-                mapping.outputOrdinal(),
-                mapping.sourceOrdinal()))
-            .toList();
+        List<ColumnMapping> mappings = result.mappings().stream().map(mapping -> {
+          String sourceType = catalogDataType(
+              dataSourceId,
+              mapping.sourceTable().databaseName(),
+              mapping.sourceTable().schemaName(),
+              mapping.sourceTable().tableName(),
+              mapping.sourceColumnName(),
+              defaultDatabase,
+              defaultSchema);
+          return new ColumnMapping(
+              mapping.sourceTable().qualifiedName(),
+              mapping.sourceColumnName(),
+              sourceType,
+              null,
+              mapping.outputColumnName(),
+              inferredTargetDataType(
+                  sourceType, mapping.mappingKind().name(), mapping.expression()),
+              mapping.mappingKind().name(),
+              mapping.expression(),
+              mapping.outputOrdinal(),
+              mapping.sourceOrdinal());
+        }).toList();
         return new ColumnAnalysis(
             mappings,
             result.candidateOutputCount(),
@@ -214,17 +225,37 @@ public class DevelopmentSqlLineagePreviewService {
     SqlColumnLineageParser.ParseResult result = columnParser.parse(
         sql,
         columnSchemaProvider(dataSourceId, defaultDatabase, defaultSchema));
-    List<ColumnMapping> mappings = result.mappings().stream()
-        .map(mapping -> new ColumnMapping(
-            mapping.sourceTable().qualifiedName(),
-            mapping.sourceColumnName(),
-            mapping.targetTable().qualifiedName(),
-            mapping.targetColumnName(),
-            mapping.mappingKind().name(),
-            mapping.expression(),
-            mapping.outputOrdinal(),
-            mapping.sourceOrdinal()))
-        .toList();
+    List<ColumnMapping> mappings = result.mappings().stream().map(mapping -> {
+      String sourceType = catalogDataType(
+          dataSourceId,
+          mapping.sourceTable().databaseName(),
+          mapping.sourceTable().schemaName(),
+          mapping.sourceTable().tableName(),
+          mapping.sourceColumnName(),
+          defaultDatabase,
+          defaultSchema);
+      String targetType = catalogDataType(
+          dataSourceId,
+          mapping.targetTable().databaseName(),
+          mapping.targetTable().schemaName(),
+          mapping.targetTable().tableName(),
+          mapping.targetColumnName(),
+          defaultDatabase,
+          defaultSchema);
+      return new ColumnMapping(
+          mapping.sourceTable().qualifiedName(),
+          mapping.sourceColumnName(),
+          sourceType,
+          mapping.targetTable().qualifiedName(),
+          mapping.targetColumnName(),
+          targetType == null
+              ? inferredTargetDataType(sourceType, mapping.mappingKind().name(), mapping.expression())
+              : targetType,
+          mapping.mappingKind().name(),
+          mapping.expression(),
+          mapping.outputOrdinal(),
+          mapping.sourceOrdinal());
+    }).toList();
     return new ColumnAnalysis(
         mappings,
         result.candidateOutputCount(),
@@ -323,7 +354,8 @@ public class DevelopmentSqlLineagePreviewService {
     List<CatalogColumn> result = new ArrayList<>();
     for (DataSourceCatalogColumnVO column : columns) {
       if (column == null || column.getName() == null || column.getName().isBlank()) continue;
-      result.add(new CatalogColumn(column.getName(), column.getOrdinalPosition()));
+      result.add(new CatalogColumn(
+          column.getName(), column.getTypeName(), column.getOrdinalPosition()));
     }
     return List.copyOf(result);
   }
@@ -344,6 +376,34 @@ public class DevelopmentSqlLineagePreviewService {
     } catch (RuntimeException exception) {
       return List.of();
     }
+  }
+
+  private String catalogDataType(
+      String dataSourceId,
+      String explicitDatabase,
+      String explicitSchema,
+      String table,
+      String columnName,
+      String defaultDatabase,
+      String defaultSchema) {
+    return catalogColumnsForTable(
+            dataSourceId, explicitDatabase, explicitSchema, table, defaultDatabase, defaultSchema)
+        .stream()
+        .filter(column -> column.name().equalsIgnoreCase(columnName))
+        .map(CatalogColumn::dataType)
+        .filter(type -> type != null && !type.isBlank())
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static String inferredTargetDataType(
+      String sourceDataType, String mappingKind, String expression) {
+    if ("AGGREGATION".equals(mappingKind)
+        && expression != null
+        && expression.stripLeading().toUpperCase(java.util.Locale.ROOT).startsWith("COUNT(")) {
+      return "BIGINT";
+    }
+    return sourceDataType;
   }
 
   private PreviewAsset taskAsset(DevelopmentNode node, String dataSourceId) {
@@ -490,7 +550,7 @@ public class DevelopmentSqlLineagePreviewService {
       TableIdentityResolver.SqlDialect dialect) {
   }
 
-  private record CatalogColumn(String name, Integer ordinalPosition) {
+  private record CatalogColumn(String name, String dataType, Integer ordinalPosition) {
   }
 
   private record ColumnAnalysis(

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
@@ -11,7 +11,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -79,6 +81,29 @@ class DevelopmentSqlLineagePreviewServiceTest {
   }
 
   @Test
+  void includesCatalogDataTypesInColumnMappings() {
+    DevelopmentSqlLineagePreviewService service = service(sqlNode(8L, "类型血缘"));
+    DataSourceCatalogService catalogService = mock(DataSourceCatalogService.class);
+    when(catalogService.listColumns(3L, null, "ods", "orders"))
+        .thenReturn(java.util.List.of(column("id", "BIGINT", 1)));
+    when(catalogService.listColumns(3L, null, "dws", "order_copy"))
+        .thenReturn(java.util.List.of(column("id", "DECIMAL(20,0)", 1)));
+    service.setDataSourceCatalogService(catalogService);
+
+    DevelopmentSqlLineagePreview preview = service.preview(
+        8L,
+        "SQL",
+        "INSERT INTO dws.order_copy (id) SELECT s.id FROM ods.orders s",
+        "{\"dataSourceId\":\"3\"}",
+        null,
+        null);
+
+    DevelopmentSqlLineagePreview.ColumnMapping mapping = preview.columnMappings().get(0);
+    assertEquals("BIGINT", mapping.sourceDataType());
+    assertEquals("DECIMAL(20,0)", mapping.targetDataType());
+  }
+
+  @Test
   void returnsFailedPreviewForInvalidSqlInsteadOfWritingStaleLineage() {
     DevelopmentSqlLineagePreviewService service = service(sqlNode(9L, "错误 SQL"));
 
@@ -141,5 +166,10 @@ class DevelopmentSqlLineagePreviewServiceTest {
         true,
         Instant.now(),
         Instant.now());
+  }
+
+  private static DataSourceCatalogColumnVO column(String name, String type, int ordinal) {
+    return new DataSourceCatalogColumnVO(
+        name, type, null, null, null, true, ordinal, false, null);
   }
 }

--- a/yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/sql/lineage/SqlLineagePreviewPanel.tsx
@@ -245,6 +245,9 @@ export default function SqlLineagePreviewPanel({ nodeId, preview, loading, onRef
           role,
           fields: names.map((name) => ({
             name,
+            dataType: mappings.find(
+              (item) => (role === 'source' ? item.sourceColumn : item.targetColumn) === name,
+            )?.[role === 'source' ? 'sourceDataType' : 'targetDataType'] || undefined,
             transformed: mappings.some(
               (item) =>
                 (role === 'source' ? item.sourceColumn : item.targetColumn) === name && item.mappingKind !== 'IDENTITY',

--- a/yak-ops-ui/src/pages/data-development/types.ts
+++ b/yak-ops-ui/src/pages/data-development/types.ts
@@ -163,8 +163,10 @@ export interface DevelopmentSqlLineagePreviewGraph {
 export interface DevelopmentSqlLineageColumnMapping {
   sourceTable: string;
   sourceColumn: string;
+  sourceDataType?: string | null;
   targetTable?: string | null;
   targetColumn: string;
+  targetDataType?: string | null;
   mappingKind: 'IDENTITY' | 'TRANSFORMATION' | 'AGGREGATION';
   expression?: string | null;
   outputOrdinal: number;


### PR DESCRIPTION
### Motivation
- 补充 SQL 血缘预览的列级映射中缺失的字段类型信息，避免前端展示为统一的 `UNKNOWN`，让血缘结果更真实可用。 

### Description
- 在后端预览模型中为 `ColumnMapping` 增加 `sourceDataType` 和 `targetDataType` 字段并在构建映射时填充类型信息。 
- 在血缘预览 Service 中从 DataSource Catalog 查询列类型并引入 `catalogDataType` 辅助方法，新增 `inferredTargetDataType` 对常见聚合（如 `COUNT`）做类型推断。 
- 将 Catalog 返回的列类型纳入物理解析和投影解析的映射构建逻辑，并在缺失目标类型时基于源类型或聚合规则回退。 
- 前端类型定义 `DevelopmentSqlLineageColumnMapping` 添加可选 `sourceDataType`/`targetDataType` 字段，并在 `SqlLineagePreviewPanel` 的列节点中展示后端返回的 `dataType`（若有）。 
- 新增后端单元测试 `includesCatalogDataTypesInColumnMappings`，模拟 `DataSourceCatalogService` 返回类型以断言映射包含期望的源/目标类型。 

### Testing
- 代码风格/静态检查：运行 `npx @biomejs/biome lint` 针对变更的前端文件检查通过。 
- 后端编译与单元测试尝试：尝试执行 Maven 编译与测试，但 CI 环境无法访问 Maven Central（HTTP 403），因此后端单元测试未能在当前环境中运行。 
- TypeScript 检查尝试：执行 `npx tsc --noEmit` 遇到缺失的 `minimatch` 类型定义导致无法完成全量类型检查。 
- 已在工作区完成变更并准备为 Draft PR（标题已设置为本 PR 标题）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8817e051188323afbdf2bad2932bf2)