### PR TITLE
fix(ui): allow opening sidebar menu items in new tab/window

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -7,6 +7,7 @@ import { history } from "@umijs/max";
 
 import defaultSettings from "../config/defaultSettings";
 import { GlobalSearch, Knowledge } from "./components/RightContent";
+import SidebarMenuLink from "./components/SidebarMenuLink";
 import { getCurrentUser } from "./services/security/account";
 import { toCurrentUser } from "./services/security/currentIdentity";
 import {
@@ -73,6 +74,11 @@ export const layout: RunTimeLayoutConfig = ({
     menuProps: {
       defaultOpenKeys: ["/sync"],
     },
+    menuItemRender: (menuItemProps, defaultDom) => (
+      <SidebarMenuLink path={menuItemProps.path}>
+        {defaultDom}
+      </SidebarMenuLink>
+    ),
     actionsRender: () => [
       <GlobalSearch key="globalsearch" />,
       // <OpenAPI key="open-api" />,

--- a/yak-ops-ui/src/components/SidebarMenuLink/index.test.ts
+++ b/yak-ops-ui/src/components/SidebarMenuLink/index.test.ts
@@ -1,0 +1,25 @@
+import { shouldNavigateInApp } from './index';
+
+describe('SidebarMenuLink', () => {
+  const click = {
+    button: 0,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+  };
+
+  it('uses in-app navigation for an ordinary left click', () => {
+    expect(shouldNavigateInApp(click)).toBe(true);
+  });
+
+  it.each([
+    { ...click, button: 1 },
+    { ...click, ctrlKey: true },
+    { ...click, metaKey: true },
+    { ...click, shiftKey: true },
+    { ...click, altKey: true },
+  ])('leaves new-page gestures to the browser (%o)', (event) => {
+    expect(shouldNavigateInApp(event)).toBe(false);
+  });
+});

--- a/yak-ops-ui/src/components/SidebarMenuLink/index.tsx
+++ b/yak-ops-ui/src/components/SidebarMenuLink/index.tsx
@@ -1,0 +1,38 @@
+import type { MouseEvent, ReactNode } from 'react';
+import { history } from '@umijs/max';
+
+interface SidebarMenuLinkProps {
+  children: ReactNode;
+  path?: string;
+}
+
+export const shouldNavigateInApp = (
+  event: Pick<MouseEvent<HTMLAnchorElement>, 'button' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'altKey'>,
+) => event.button === 0
+  && !event.ctrlKey
+  && !event.metaKey
+  && !event.shiftKey
+  && !event.altKey;
+
+/**
+ * Give sidebar entries a real URL so the browser's context menu can open them
+ * in a new tab/window, while keeping ordinary clicks as SPA navigation.
+ */
+const SidebarMenuLink = ({ children, path }: SidebarMenuLinkProps) => {
+  if (!path) return children;
+
+  return (
+    <a
+      href={path}
+      onClick={(event) => {
+        if (!shouldNavigateInApp(event)) return;
+        event.preventDefault();
+        history.push(path);
+      }}
+    >
+      {children}
+    </a>
+  );
+};
+
+export default SidebarMenuLink;


### PR DESCRIPTION
### Motivation

- 侧边栏菜单项右键无法在新标签/新窗口打开，用户期望保留浏览器原生的“在新标签页/窗口中打开”操作。 

### Description

- 新增 `SidebarMenuLink` 组件（`yak-ops-ui/src/components/SidebarMenuLink/index.tsx`），为侧边栏菜单项渲染真实的 `<a href>` 链接并根据按键/修饰键决定是否进行 SPA 内导航。 
- 将 `SidebarMenuLink` 通过 ProLayout 的 `menuItemRender` 注入到侧边栏（`yak-ops-ui/src/app.tsx`），以便所有侧边栏项都支持右键/中键等浏览器新页面手势。 
- 增加单元测试（`yak-ops-ui/src/components/SidebarMenuLink/index.test.ts`）覆盖普通左键导航与中键/修饰键触发新页面的行为判断函数 `shouldNavigateInApp`。 

### Testing

- 运行 `yarn jest src/components/SidebarMenuLink/index.test.ts --runInBand`，测试套件 1 个、测试 6 项，全部通过。 
- 运行 `git diff --check` 没有发现问题。 
- 运行 `yarn --cwd yak-ops-ui tsc` 会在当前环境中因为缺少 `minimatch` 的类型定义报 `TS2688`（这是现有依赖环境的问题，与本次变更逻辑无关）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a882a078c908323b297b0a97299e58b)