### PR TITLE
feat: split realtime sync task creation into two stages

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
@@ -55,6 +55,16 @@ public class RealtimeJobController {
       @Size(max = 1000) String description,
       @Valid CdcPipelineSpec spec) {}
 
+  public record CreateRequest(
+      @NotBlank @Size(max = 200) String name, @Size(max = 1000) String description) {}
+
+  @Operation(summary = "创建实时同步基础任务")
+  @PostMapping
+  @RequiresPermission(RealtimePermissionCode.CREATE)
+  public Result<Long> create(@Valid @RequestBody CreateRequest request) {
+    return Result.success(service.create(request.name(), request.description()));
+  }
+
   @Operation(summary = "新建实时同步草稿")
   @PostMapping("/draft")
   @RequiresPermission(RealtimePermissionCode.CREATE)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -49,7 +49,7 @@ public class RealtimeJobStore {
                   Statement.RETURN_GENERATED_KEYS);
           statement.setString(1, name);
           statement.setString(2, description);
-          statement.setString(3, write(spec));
+          statement.setString(3, spec == null ? null : write(spec));
           statement.setString(4, digest);
           return statement;
         },
@@ -435,6 +435,9 @@ public class RealtimeJobStore {
   }
 
   private CdcPipelineSpec read(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
     try {
       return json.readValue(value, CdcPipelineSpec.class);
     } catch (Exception exception) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -98,6 +98,19 @@ public class RealtimeJobService {
     return saved == null ? 0 : saved;
   }
 
+  /** Creates the shell first; the editor supplies the pipeline spec in the second stage. */
+  public long create(String name, String description) {
+    requireName(name);
+    Long saved =
+        transactions.execute(
+            status -> {
+              long created = store.insertDefinition(name.trim(), description, null, null);
+              store.event(created, null, "DRAFT_CREATED", null, "DRAFT", "已创建实时同步基础任务");
+              return created;
+            });
+    return saved == null ? 0 : saved;
+  }
+
   public RealtimeJobView get(long id) {
     return store.view(id);
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V4__allow_two_stage_drafts.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V4__allow_two_stage_drafts.sql
@@ -1,0 +1,2 @@
+-- A realtime task is now created before its pipeline is configured.
+ALTER TABLE yak_realtime_job_definition MODIFY COLUMN spec_json LONGTEXT NULL;

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -63,6 +63,7 @@ export const appRoutes: readonly NavigationRoute[] = [
     quickCreateRequirement: { mode: 'one', permission: 'task:batch:create' },
     quickCreateLabel: '新建离线同步',
   },
+  { id: 'realtime-sync-detail', path: '/sync/realtime/:id/detail', title: '实时同步配置', component: './realtime-sync/detail', hidden: true, parentId: 'realtime-sync' },
   {
     id: 'realtime-sync', mode: 'one', permission: 'task:realtime:read',
     path: '/sync/realtime', title: '实时同步', component: './realtime-sync',

--- a/yak-ops-ui/src/pages/realtime-sync/CreateRealtimeTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/CreateRealtimeTaskDrawer.tsx
@@ -1,0 +1,111 @@
+import { ArrowRightOutlined } from '@ant-design/icons';
+import { history } from '@umijs/max';
+import { Button, Drawer, Form, Input, message, Select } from 'antd';
+import { useEffect, useRef, useState } from 'react';
+import { realtimeApi } from './api';
+
+interface Values {
+  sourceType: string;
+  sinkType: string;
+  name: string;
+  description?: string;
+}
+
+export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [form] = Form.useForm<Values>();
+  const [submitting, setSubmitting] = useState(false);
+  const automaticName = useRef('');
+
+  useEffect(() => {
+    if (!open) return;
+    automaticName.current = 'MYSQL → MYSQL 实时同步';
+    form.setFieldsValue({ sourceType: 'MYSQL', sinkType: 'MYSQL', name: automaticName.current });
+  }, [form, open]);
+
+  const updateName = (source: string, sink: string) => {
+    const next = `${source} → ${sink} 实时同步`;
+    if (!form.getFieldValue('name') || form.getFieldValue('name') === automaticName.current)
+      form.setFieldValue('name', next);
+    automaticName.current = next;
+  };
+
+  const submit = async () => {
+    try {
+      const values = await form.validateFields();
+      setSubmitting(true);
+      const response = await realtimeApi.createBasic({
+        name: values.name.trim(),
+        description: values.description?.trim(),
+      });
+      message.success('基础任务已创建，请继续完成同步配置');
+      form.resetFields();
+      history.push(`/sync/realtime/${response.data}/detail?scene=create`);
+    } catch (error: any) {
+      if (!error?.errorFields) message.error(error?.message || '创建实时同步任务失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Drawer
+      title="新建实时同步任务"
+      width={620}
+      open={open}
+      closable={false}
+      maskClosable={false}
+      onClose={onClose}
+      extra={
+        <div className="flex gap-2">
+          <Button disabled={submitting} onClick={onClose}>
+            取消
+          </Button>
+          <Button type="primary" danger loading={submitting} onClick={submit}>
+            创建并配置
+          </Button>
+        </div>
+      }
+      styles={{ header: { padding: '18px 24px' }, body: { padding: 24 } }}
+    >
+      <Form form={form} layout="vertical" requiredMark="optional">
+        <div className="grid grid-cols-[1fr_32px_1fr] items-end gap-3 mb-6">
+          <Form.Item name="sourceType" label="来源类型" rules={[{ required: true }]} className="!mb-0">
+            <Select
+              variant="filled"
+              options={[{ value: 'MYSQL', label: 'MYSQL' }]}
+              onChange={(v) => updateName(v, form.getFieldValue('sinkType'))}
+            />
+          </Form.Item>
+          <div className="flex h-8 items-center justify-center text-[#98a2b3]">
+            <ArrowRightOutlined />
+          </div>
+          <Form.Item name="sinkType" label="目标类型" rules={[{ required: true }]} className="!mb-0">
+            <Select
+              variant="filled"
+              options={[
+                { value: 'MYSQL', label: 'MYSQL' },
+                { value: 'POSTGRESQL', label: 'POSTGRESQL' },
+              ]}
+              onChange={(v) => updateName(form.getFieldValue('sourceType'), v)}
+            />
+          </Form.Item>
+        </div>
+        <Form.Item name="name" label="任务名称" rules={[{ required: true, message: '请输入任务名称' }, { max: 200 }]}>
+          <Input autoFocus variant="filled" maxLength={200} showCount />
+        </Form.Item>
+        <Form.Item name="description" label="任务描述（可选）" rules={[{ max: 1000 }]}>
+          <Input.TextArea
+            variant="filled"
+            rows={5}
+            maxLength={1000}
+            showCount
+            placeholder="请说明业务场景、同步范围和使用目的"
+          />
+        </Form.Item>
+        <div className="rounded-lg bg-[#f9fafb] p-4 text-sm text-[#667085]">
+          数据源、同步表和运行参数将在任务详情页配置；实时同步无需配置调度。
+        </div>
+      </Form>
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
@@ -54,7 +54,7 @@ const defaults: FormValue = {
 };
 
 const toFormValue = (job?: RealtimeJob): FormValue =>
-  job
+  job?.spec
     ? {
         name: job.name,
         description: job.description,

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -28,6 +28,8 @@ export const realtimeApi = {
       params,
     }),
   detail: (id: number) => request<ApiResponse<RealtimeJob>>(`${PREFIX}/${id}`),
+  createBasic: (payload: { name: string; description?: string }) =>
+    request<ApiResponse<number>>(PREFIX, { method: 'POST', data: payload }),
   create: (payload: { name: string; description?: string; spec: CdcPipelineSpec }) =>
     request<ApiResponse<number>>(`${PREFIX}/draft`, { method: 'POST', data: payload }),
   update: (id: number, payload: { name: string; description?: string; spec: CdcPipelineSpec }) =>

--- a/yak-ops-ui/src/pages/realtime-sync/detail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/detail.tsx
@@ -1,0 +1,35 @@
+import { history, useParams } from '@umijs/max';
+import { message, Spin } from 'antd';
+import { useEffect, useState } from 'react';
+import { realtimeApi } from './api';
+import JobEditor from './JobEditor';
+import type { DataSourceOption, RealtimeJob } from './types';
+
+export default function RealtimeSyncDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [job, setJob] = useState<RealtimeJob>();
+  const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
+  useEffect(() => {
+    Promise.all([realtimeApi.detail(Number(id)), realtimeApi.dataSources()])
+      .then(([detail, sources]) => {
+        setJob(detail.data);
+        setDataSources(sources.data || []);
+      })
+      .catch((error) => message.error(error?.message || '加载实时同步配置失败'));
+  }, [id]);
+  if (!job)
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Spin />
+      </div>
+    );
+  return (
+    <JobEditor
+      open
+      job={job}
+      dataSources={dataSources}
+      onClose={() => history.push('/sync/realtime')}
+      onSaved={() => history.push('/sync/realtime')}
+    />
+  );
+}

--- a/yak-ops-ui/src/pages/realtime-sync/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/index.tsx
@@ -1,3 +1,4 @@
+import { history } from '@umijs/max';
 import {
   Alert,
   Button,
@@ -26,6 +27,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import CustomPagination from '../batch-link-up/CustomPagination';
 import { realtimeApi } from './api';
 import JobEditor from './JobEditor';
+import CreateRealtimeTaskDrawer from './CreateRealtimeTaskDrawer';
 import type {
   DataSourceOption,
   RealtimeEvent,
@@ -118,6 +120,7 @@ export default function RealtimeSync() {
   const [filters, setFilters] = useState<FilterState>(initialFilters);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [editor, setEditor] = useState<{ open: boolean; job?: RealtimeJob }>({ open: false });
+  const [createOpen, setCreateOpen] = useState(false);
   const [detail, setDetail] = useState<RealtimeJob>();
   const [events, setEvents] = useState<RealtimeEvent[]>([]);
   const [logs, setLogs] = useState('');
@@ -525,7 +528,7 @@ export default function RealtimeSync() {
               size="small"
               className="!h-7 !px-1.5 !text-[12px]"
               disabled={running}
-              onClick={() => setEditor({ open: true, job })}
+              onClick={() => history.push(`/sync/realtime/${job.id}/detail?scene=edit`)}
             >
               编辑
             </Button>
@@ -759,7 +762,7 @@ export default function RealtimeSync() {
                 size="small"
                 danger
                 className="!h-7"
-                onClick={() => setEditor({ open: true })}
+                onClick={() => setCreateOpen(true)}
               >
                 <span className="text-[13px]">新建同步任务</span>
               </Button>
@@ -842,6 +845,7 @@ export default function RealtimeSync() {
             void loadJobs();
           }}
         />
+        <CreateRealtimeTaskDrawer open={createOpen} onClose={() => setCreateOpen(false)} />
 
         <Drawer
           width={820}

--- a/yak-ops-ui/src/pages/realtime-sync/types.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/types.ts
@@ -51,7 +51,7 @@ export interface RealtimeJob {
   id: number;
   name: string;
   description?: string;
-  spec: CdcPipelineSpec;
+  spec?: CdcPipelineSpec;
   releaseState: ReleaseState;
   desiredState: DesiredState;
   observedState: ObservedState;


### PR DESCRIPTION
### Motivation

- Align realtime sync creation with the offline two-stage flow so users first create a lightweight task shell and then fill pipeline/spec details in a separate configuration page.
- Avoid embedding secrets/connection coordinates into the control-plane model by supporting an initial unconfigured draft that omits the pipeline spec.

### Description

- Backend: added a lightweight create endpoint `POST /api/v1/realtime-sync` (`CreateRequest`) and `RealtimeJobService.create(name, description)` to create a shell draft without a pipeline spec, while preserving the existing `/draft` save endpoint for full-spec drafts; repository and serializer now accept `spec_json` as nullable and `read` returns `null` when absent (files changed: `RealtimeJobController.java`, `RealtimeJobService.java`, `RealtimeJobStore.java`).
- DB: added migration `V4__allow_two_stage_drafts.sql` to allow `spec_json` to be `NULL` during two-stage creation.
- UI/API: added `createBasic` client call and a new creation drawer `CreateRealtimeTaskDrawer` that matches the offline-style quick-create UX and redirects to a new detail route for configuration; added a detail page component `realtime-sync/detail` that loads the task and data sources and reuses `JobEditor` for the second-stage configuration (files added/modified: `api.ts`, `types.ts`, `CreateRealtimeTaskDrawer.tsx`, `detail.tsx`, `index.tsx`, `JobEditor.tsx`, `navigation.ts`).
- Types/UI guards: made `RealtimeJob.spec` optional in the TypeScript model and adjusted `JobEditor` mapping to handle an initially missing `spec`.

### Testing

- Ran TypeScript compile check with `cd yak-ops-ui && yarn tsc --noEmit`, which succeeded.
- Ran code style/lint fixes with `cd yak-ops-ui && yarn biome check --write src/pages/realtime-sync/CreateRealtimeTaskDrawer.tsx src/pages/realtime-sync/detail.tsx`, which fixed/validated files.
- Performed repository checks with `git diff --check` and `git diff --cached --check`, which reported no blocking issues after fixes.
- Attempted Maven compile for the realtime backend module with `mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime -am -DskipTests compile`, which failed to download parent POMs because the environment blocks access to Maven Central (HTTP 403), so full JVM integration testing could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a882a7d2024832394e1dc8cfe060f5b)