### PR TITLE
fix(ui): render sidebar navigation targets as links

### DIFF
--- a/yak-ops-ui/src/layouts/SiteLayout/index.tsx
+++ b/yak-ops-ui/src/layouts/SiteLayout/index.tsx
@@ -12,7 +12,7 @@ import { RouteAccessBoundary } from "@/components/security";
 import SecurityProjectSwitcher from "@/components/security/SecurityProjectSwitcher";
 import { SecurityProjectProvider, useSecurityProject } from "@/contexts/SecurityProjectContext";
 import { logout } from "@/services/security/account";
-import { history, Outlet, useLocation, useModel } from "@umijs/max";
+import { history, Link, Outlet, useLocation, useModel } from "@umijs/max";
 import { Badge, Button, Drawer, Dropdown, type MenuProps } from "antd";
 import {
   Activity,
@@ -217,10 +217,9 @@ function HeaderAction({
 
 function BrandLogo({ compact }: { compact: boolean }) {
   return (
-    <button
-      type="button"
+    <Link
+      to="/home"
       aria-label="返回首页"
-      onClick={() => history.push("/home")}
       className={[
         "mt-3 mb-1.5 flex h-12 w-full items-center border-0 bg-transparent",
         "transition-all duration-200",
@@ -251,7 +250,7 @@ function BrandLogo({ compact }: { compact: boolean }) {
           "
         />
       )}
-    </button>
+    </Link>
   );
 }
 
@@ -351,13 +350,12 @@ function SiteLayoutContent() {
     const active = activeNavigationId === route.id;
 
     return (
-      <button
+      <Link
         key={route.id}
-        type="button"
+        to={route.path}
         title={compact ? route.title : undefined}
         aria-label={compact ? route.title : undefined}
         aria-current={active ? "page" : undefined}
-        onClick={() => navigate(route.path)}
         className={[
           "group relative flex h-10 w-full items-center border-0 bg-transparent",
           "text-left transition-colors duration-150",
@@ -380,7 +378,7 @@ function SiteLayoutContent() {
         {compact && active && (
           <span className="absolute right-0 h-4 w-[2px] rounded-full bg-[#161823]" />
         )}
-      </button>
+      </Link>
     );
   };
 
@@ -485,14 +483,6 @@ function SiteLayoutContent() {
     return currentUser?.name?.trim().slice(0, 1).toUpperCase() || "Y";
   }, [currentUser?.name]);
 
-  const navigate = (path: string) => {
-    setQuickCreateOpen(false);
-
-    if (location.pathname !== path) {
-      history.push(path);
-    }
-  };
-
   const toggleGroup = (groupId: string) => {
     setOpenGroupIds((current) => {
       const next = new Set(current);
@@ -519,13 +509,12 @@ function SiteLayoutContent() {
     const active = activeNavigationId === route.id;
 
     return (
-      <button
+      <Link
         key={route.id}
-        type="button"
+        to={route.path}
         title={compact ? route.title : undefined}
         aria-label={compact ? route.title : undefined}
         aria-current={active ? "page" : undefined}
-        onClick={() => navigate(route.path)}
         className={[
           "group relative flex w-full items-center border-0",
           "bg-transparent text-left",
@@ -584,7 +573,7 @@ function SiteLayoutContent() {
             {route.title}
           </span>
         )}
-      </button>
+      </Link>
     );
   };
 
@@ -674,10 +663,10 @@ function SiteLayoutContent() {
             >
               {quickCreateRoutes.length > 0 ? (
                 quickCreateRoutes.map((route) => (
-                  <button
-                    type="button"
+                  <Link
                     key={route.id}
-                    onClick={() => navigate(route.path)}
+                    to={route.path}
+                    onClick={() => setQuickCreateOpen(false)}
                     className="
                         flex h-9 w-full items-center
                         rounded-md border-0 bg-transparent
@@ -706,7 +695,7 @@ function SiteLayoutContent() {
                     <span className="truncate">
                       {route.quickCreateLabel ?? route.title}
                     </span>
-                  </button>
+                  </Link>
                 ))
               ) : (
                 <div


### PR DESCRIPTION
### Motivation
- Support native browser link actions (open in new tab, copy link address, etc.) by rendering the brand logo and sidebar navigation targets as real links instead of buttons. 

### Description
- Import `Link` from `@umijs/max` and replace `button` elements with `Link` in `yak-ops-ui/src/layouts/SiteLayout/index.tsx` for the Brand logo, standalone routes, grouped navigation items and quick-create entries. 
- Preserve existing visual styles, active/compact behaviors and keyboard/ARIA attributes while using client-side links; quick-create entries call `onClick={() => setQuickCreateOpen(false)}` to dismiss the dropdown after navigation. 
- Remove the local `navigate` helper (routing now handled by `Link`) and keep using `history` where still appropriate. 

### Testing
- Ran `git diff --check` with no issues.
- Ran `yarn tsc` which failed due to a missing type definition for `minimatch` (`TS2688`).
- Ran `biome` check on the modified file which reported import ordering/format warnings for the file but no blocking runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a882bc28fc883239876bfe08d87ceea)