### PR TITLE
重构实时同步编辑页为离线布局，修复列表查询空 Spec 报错

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQuery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQuery.java
@@ -163,6 +163,11 @@ public class RealtimeJobListQuery {
   }
 
   private CdcPipelineSpec readSpec(String value) {
+    // Two-stage drafts intentionally have no spec until the configuration page is saved.
+    // Keep those rows visible in list queries instead of attempting to deserialize SQL NULL.
+    if (!StringUtils.hasText(value)) {
+      return null;
+    }
     try {
       return json.readValue(value, CdcPipelineSpec.class);
     } catch (Exception exception) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQueryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQueryTest.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import java.lang.reflect.Method;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RealtimeJobListQueryTest {
+
+  @Test
+  void acceptsMissingSpecForTwoStageDrafts() throws Exception {
+    RealtimeJobListQuery query =
+        new RealtimeJobListQuery(Mockito.mock(DataSource.class), new ObjectMapper());
+    Method readSpec = RealtimeJobListQuery.class.getDeclaredMethod("readSpec", String.class);
+    readSpec.setAccessible(true);
+
+    assertThat((CdcPipelineSpec) readSpec.invoke(query, new Object[] {null})).isNull();
+    assertThat((CdcPipelineSpec) readSpec.invoke(query, "  ")).isNull();
+  }
+}

--- a/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
@@ -1,8 +1,8 @@
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import {
-  Alert,
   Button,
   Col,
-  Drawer,
+  ConfigProvider,
   Form,
   Input,
   InputNumber,
@@ -11,11 +11,10 @@ import {
   Row,
   Select,
   Space,
-  Steps,
   Switch,
-  Typography,
 } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
+import { BRAND_THEME } from '@/styles/brand';
 import { realtimeApi } from './api';
 import type { CdcPipelineSpec, DataSourceOption, RealtimeJob } from './types';
 
@@ -25,7 +24,6 @@ interface RouteFormValue {
   matchMode: 'EXACT' | 'REGEX';
   keyColumnsText: string;
 }
-
 interface FormValue extends Omit<CdcPipelineSpec, 'tables'> {
   name: string;
   description?: string;
@@ -53,18 +51,30 @@ const defaults: FormValue = {
   },
 };
 
+const sections = [
+  { key: 'task-basic', label: '任务基础信息' },
+  { key: 'source-sink', label: 'Source / Sink 配置' },
+  { key: 'table-rules', label: '表规则' },
+  { key: 'runtime-params', label: '运行参数' },
+] as const;
+type SectionKey = (typeof sections)[number]['key'];
+
 const toFormValue = (job?: RealtimeJob): FormValue =>
   job?.spec
     ? {
         name: job.name,
         description: job.description,
         ...job.spec,
-        tables: job.spec.tables.map((route) => ({
-          ...route,
-          keyColumnsText: route.keyColumns.join(','),
-        })),
+        tables: job.spec.tables.map((route) => ({ ...route, keyColumnsText: route.keyColumns.join(',') })),
       }
-    : defaults;
+    : { ...defaults, name: job?.name || '', description: job?.description || '' };
+
+const Card = ({ id, title, children }: { id: SectionKey; title: string; children: React.ReactNode }) => (
+  <section id={id} className="scroll-mt-6 rounded-xl bg-white px-7 py-6">
+    <h2 className="mb-6 mt-0 text-[17px] font-semibold text-[#101828]">{title}</h2>
+    {children}
+  </section>
+);
 
 export default function JobEditor({
   open,
@@ -80,8 +90,8 @@ export default function JobEditor({
   onSaved: () => void;
 }) {
   const [form] = Form.useForm<FormValue>();
-  const [step, setStep] = useState(0);
   const [saving, setSaving] = useState(false);
+  const [active, setActive] = useState<SectionKey>('task-basic');
   const sourceOptions = useMemo(() => dataSources.filter((item) => item.dbType === 'MYSQL'), [dataSources]);
   const sinkOptions = useMemo(
     () => dataSources.filter((item) => ['MYSQL', 'POSTGRE_SQL', 'POSTGRESQL'].includes(item.dbType)),
@@ -89,11 +99,25 @@ export default function JobEditor({
   );
 
   useEffect(() => {
-    if (open) {
-      form.setFieldsValue(toFormValue(job));
-      setStep(0);
-    }
+    if (open) form.setFieldsValue(toFormValue(job));
   }, [form, job, open]);
+  useEffect(() => {
+    if (!open) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (visible) setActive(visible.target.id as SectionKey);
+      },
+      { rootMargin: '-15% 0px -65%', threshold: [0, 0.2, 0.5] },
+    );
+    sections.forEach(({ key }) => {
+      const node = document.getElementById(key);
+      if (node) observer.observe(node);
+    });
+    return () => observer.disconnect();
+  }, [open]);
 
   const save = async () => {
     try {
@@ -130,235 +154,242 @@ export default function JobEditor({
     }
   };
 
+  if (!open) return null;
+  const option = (item: DataSourceOption) => ({ label: `${item.label} (${item.dbType})`, value: Number(item.value) });
   return (
-    <Drawer
-      title={job ? `编辑：${job.name}` : '新建实时同步'}
-      width={860}
-      open={open}
-      onClose={onClose}
-      destroyOnClose
-      extra={
-        <Button type="primary" loading={saving} onClick={save}>
-          保存草稿
-        </Button>
-      }
-    >
-      <Steps
-        current={step}
-        onChange={setStep}
-        items={[{ title: 'Source / Sink' }, { title: '表规则' }, { title: '运行参数' }]}
-        style={{ marginBottom: 24 }}
-      />
-      <Form form={form} layout="vertical" initialValues={defaults}>
-        <div style={{ display: step === 0 ? 'block' : 'none' }}>
-          <Row gutter={16}>
-            <Col span={16}>
-              <Form.Item name="name" label="任务名称" rules={[{ required: true }]}>
-                <Input maxLength={200} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name="startupMode" label="启动模式">
-                <Select
-                  options={[
-                    { value: 'initial', label: '全量 + 增量' },
-                    { value: 'latest-offset', label: '仅最新增量' },
-                  ]}
-                />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Form.Item name="description" label="描述">
-            <Input.TextArea maxLength={1000} rows={2} />
-          </Form.Item>
-          <Row gutter={16}>
-            <Col span={12}>
-              <Form.Item
-                name="sourceDataSourceRef"
-                label="MySQL Source"
-                rules={[{ required: true, message: '请选择 Source 数据源' }]}
-              >
-                <Select
-                  showSearch
-                  optionFilterProp="label"
-                  options={sourceOptions.map((item) => ({ label: item.label, value: Number(item.value) }))}
-                />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item
-                name="sinkDataSourceRef"
-                label="MySQL / PostgreSQL Sink"
-                rules={[{ required: true, message: '请选择 Sink 数据源' }]}
-              >
-                <Select
-                  showSearch
-                  optionFilterProp="label"
-                  options={sinkOptions.map((item) => ({
-                    label: `${item.label} (${item.dbType})`,
-                    value: Number(item.value),
-                  }))}
-                />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Alert
-            type="info"
-            showIcon
-            message="任务定义只保存数据源引用；连接坐标在发布和启动时重新解析，密码不会进入任务定义、部署快照或接口响应。"
-          />
-        </div>
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="h-[calc(100vh-64px)] overflow-y-auto bg-[#f7f8fa] text-[#161823]">
+        <Form form={form} layout="vertical" initialValues={defaults}>
+          <div className="mx-auto grid w-full max-w-[1280px] grid-cols-[minmax(0,1fr)_160px] gap-6 px-6 pb-6 pt-6 max-xl:grid-cols-1">
+            <main className="min-w-0 space-y-5">
+              <Card id="task-basic" title="任务基础信息">
+                <Form.Item name="name" label="任务名称" rules={[{ required: true, message: '请输入任务名称' }]}>
+                  <Input maxLength={200} showCount />
+                </Form.Item>
+                <Form.Item name="description" label="任务描述">
+                  <Input.TextArea maxLength={1000} showCount rows={4} />
+                </Form.Item>
+              </Card>
 
-        <div style={{ display: step === 1 ? 'block' : 'none' }}>
-          <Form.List name="tables">
-            {(fields, { add, remove }) => (
-              <Space direction="vertical" style={{ width: '100%' }} size={12}>
-                {fields.map((field, index) => (
-                  <div key={field.key} style={{ padding: 16, border: '1px solid #eee', borderRadius: 8 }}>
-                    <Typography.Text strong>表规则 {index + 1}</Typography.Text>
-                    <Row gutter={12} style={{ marginTop: 12 }}>
-                      <Col span={8}>
-                        <Form.Item
-                          {...field}
-                          name={[field.name, 'sourceTable']}
-                          label="Source 表 / 正则"
-                          rules={[{ required: true }]}
-                        >
-                          <Input placeholder="orders（数据源库内）" />
-                        </Form.Item>
-                      </Col>
-                      <Col span={5}>
-                        <Form.Item {...field} name={[field.name, 'matchMode']} label="匹配方式">
-                          <Radio.Group
-                            options={[
-                              { label: '精确', value: 'EXACT' },
-                              { label: '正则', value: 'REGEX' },
-                            ]}
-                          />
-                        </Form.Item>
-                      </Col>
-                      <Col span={7}>
-                        <Form.Item
-                          {...field}
-                          name={[field.name, 'sinkTable']}
-                          label="Sink 表"
-                          rules={[{ required: true }]}
-                        >
-                          <Input placeholder="public.orders" />
-                        </Form.Item>
-                      </Col>
-                      <Col span={4}>
-                        <Form.Item
-                          {...field}
-                          name={[field.name, 'keyColumnsText']}
-                          label="主键字段"
-                          rules={[{ required: true }]}
-                        >
-                          <Input placeholder="id,tenant_id" />
-                        </Form.Item>
-                      </Col>
-                    </Row>
-                    {fields.length > 1 && (
-                      <Button danger size="small" onClick={() => remove(field.name)}>
-                        删除规则
+              <Card id="source-sink" title="Source / Sink 配置">
+                <Row gutter={20}>
+                  <Col xs={24} lg={12}>
+                    <div className="rounded-xl border border-[#e4e7ec] bg-[#fcfcfd] p-5">
+                      <h3 className="mb-5 mt-0 text-[14px] font-semibold">Source 来源配置</h3>
+                      <Form.Item
+                        name="sourceDataSourceRef"
+                        label="MySQL Source"
+                        rules={[{ required: true, message: '请选择 Source 数据源' }]}
+                      >
+                        <Select
+                          showSearch
+                          optionFilterProp="label"
+                          placeholder="请选择来源数据源"
+                          options={sourceOptions.map(option)}
+                        />
+                      </Form.Item>
+                    </div>
+                  </Col>
+                  <Col xs={24} lg={12}>
+                    <div className="rounded-xl border border-[#e4e7ec] bg-[#fcfcfd] p-5">
+                      <h3 className="mb-5 mt-0 text-[14px] font-semibold">Sink 目标配置</h3>
+                      <Form.Item
+                        name="sinkDataSourceRef"
+                        label="MySQL / PostgreSQL Sink"
+                        rules={[{ required: true, message: '请选择 Sink 数据源' }]}
+                      >
+                        <Select
+                          showSearch
+                          optionFilterProp="label"
+                          placeholder="请选择目标数据源"
+                          options={sinkOptions.map(option)}
+                        />
+                      </Form.Item>
+                    </div>
+                  </Col>
+                </Row>
+                <div className="mt-4 rounded-lg border border-[#ffccc7] bg-[#fff2f0] px-4 py-3 text-[12px] text-[#475467]">
+                  任务定义只保存数据源引用；连接信息会在发布和启动时重新解析，密码不会进入任务定义、部署快照或接口响应。
+                </div>
+              </Card>
+
+              <Card id="table-rules" title="表规则">
+                <Form.List name="tables">
+                  {(fields, { add, remove }) => (
+                    <Space direction="vertical" className="w-full" size={12}>
+                      {fields.map((field, index) => (
+                        <div key={field.key} className="rounded-xl border border-[#e4e7ec] bg-[#fcfcfd] p-5">
+                          <div className="mb-3 flex items-center justify-between">
+                            <strong>表规则 {index + 1}</strong>
+                            {fields.length > 1 && (
+                              <Button type="text" danger icon={<DeleteOutlined />} onClick={() => remove(field.name)}>
+                                删除
+                              </Button>
+                            )}
+                          </div>
+                          <Row gutter={12}>
+                            <Col xs={24} lg={7}>
+                              <Form.Item
+                                {...field}
+                                name={[field.name, 'sourceTable']}
+                                label="Source 表 / 正则"
+                                rules={[{ required: true }]}
+                              >
+                                <Input placeholder="orders" />
+                              </Form.Item>
+                            </Col>
+                            <Col xs={24} lg={6}>
+                              <Form.Item {...field} name={[field.name, 'matchMode']} label="匹配方式">
+                                <Radio.Group
+                                  options={[
+                                    { label: '精确', value: 'EXACT' },
+                                    { label: '正则', value: 'REGEX' },
+                                  ]}
+                                />
+                              </Form.Item>
+                            </Col>
+                            <Col xs={24} lg={6}>
+                              <Form.Item
+                                {...field}
+                                name={[field.name, 'sinkTable']}
+                                label="Sink 表"
+                                rules={[{ required: true }]}
+                              >
+                                <Input placeholder="public.orders" />
+                              </Form.Item>
+                            </Col>
+                            <Col xs={24} lg={5}>
+                              <Form.Item
+                                {...field}
+                                name={[field.name, 'keyColumnsText']}
+                                label="主键字段"
+                                rules={[{ required: true }]}
+                              >
+                                <Input placeholder="id,tenant_id" />
+                              </Form.Item>
+                            </Col>
+                          </Row>
+                        </div>
+                      ))}
+                      <Button
+                        icon={<PlusOutlined />}
+                        onClick={() =>
+                          add({ sourceTable: '', sinkTable: '', matchMode: 'EXACT', keyColumnsText: 'id' })
+                        }
+                      >
+                        添加表规则
                       </Button>
-                    )}
-                  </div>
-                ))}
-                <Button
-                  onClick={() => add({ sourceTable: '', sinkTable: '', matchMode: 'EXACT', keyColumnsText: 'id' })}
-                >
-                  添加表规则
-                </Button>
-              </Space>
-            )}
-          </Form.List>
-        </div>
+                    </Space>
+                  )}
+                </Form.List>
+              </Card>
 
-        <div style={{ display: step === 2 ? 'block' : 'none' }}>
-          <Alert
-            type="warning"
-            showIcon
-            message="一期交付语义固定为 At-least-once，并强制 strict Replay Safety 与主键声明。"
-            style={{ marginBottom: 16 }}
-          />
-          <Alert
-            type="info"
-            showIcon
-            message="当前固定 Runtime Gateway 尚不接受每任务 Checkpoint 与重启策略覆盖；以下两项作为逻辑 Spec 保留，但由 Runtime 固定配置接管。"
-            style={{ marginBottom: 16 }}
-          />
-          <Row gutter={16}>
-            <Col span={8}>
-              <Form.Item name="parallelism" label="并行度">
-                <InputNumber min={1} max={256} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name="checkpointIntervalMs" label="Checkpoint 间隔 (Runtime 固定)">
-                <InputNumber disabled min={10000} step={10000} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name="schemaEvolution" label="Schema Evolution">
-                <Select options={['EVOLVE', 'IGNORE', 'FAIL'].map((value) => ({ value, label: value }))} />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={8}>
-              <Form.Item name={['restart', 'strategy']} label="重启策略 (Runtime 固定)">
-                <Select
-                  disabled
-                  options={['fixed-delay', 'failure-rate', 'none'].map((value) => ({ value, label: value }))}
-                />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name={['restart', 'attempts']} label="重试次数 (Runtime 固定)">
-                <InputNumber disabled min={0} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name={['restart', 'delayMs']} label="重试间隔 (Runtime 固定)">
-                <InputNumber disabled min={0} step={1000} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Row gutter={16}>
-            <Col span={8}>
-              <Form.Item name={['sink', 'batchSize']} label="Sink Batch Size">
-                <InputNumber min={1} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name={['sink', 'flushIntervalMs']} label="Flush 间隔 (ms)">
-                <InputNumber min={1} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name={['sink', 'maxRetries']} label="Sink 重试次数">
-                <InputNumber min={0} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name={['sink', 'maxBatchBytes']} label="最大批次字节">
-                <InputNumber min={1} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name={['sink', 'statementCacheSize']} label="Statement Cache">
-                <InputNumber min={1} style={{ width: '100%' }} />
-              </Form.Item>
-            </Col>
-            <Col span={8}>
-              <Form.Item name={['sink', 'strictReplaySafety']} label="Strict Replay Safety" valuePropName="checked">
-                <Switch disabled />
-              </Form.Item>
-            </Col>
-          </Row>
-        </div>
-      </Form>
-    </Drawer>
+              <Card id="runtime-params" title="运行参数">
+                <Row gutter={16}>
+                  <Col xs={24} md={8}>
+                    <Form.Item name="startupMode" label="启动模式">
+                      <Select
+                        options={[
+                          { value: 'initial', label: '全量 + 增量' },
+                          { value: 'latest-offset', label: '仅最新增量' },
+                        ]}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item name="parallelism" label="并行度">
+                      <InputNumber min={1} max={256} className="w-full" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item name="schemaEvolution" label="Schema Evolution">
+                      <Select options={['EVOLVE', 'IGNORE', 'FAIL'].map((value) => ({ value, label: value }))} />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item name={['sink', 'batchSize']} label="Sink Batch Size">
+                      <InputNumber min={1} className="w-full" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item name={['sink', 'flushIntervalMs']} label="Flush 间隔 (ms)">
+                      <InputNumber min={1} className="w-full" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item name={['sink', 'maxRetries']} label="Sink 重试次数">
+                      <InputNumber min={0} className="w-full" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item name={['sink', 'maxBatchBytes']} label="最大批次字节">
+                      <InputNumber min={1} className="w-full" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item name={['sink', 'statementCacheSize']} label="Statement Cache">
+                      <InputNumber min={1} className="w-full" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={8}>
+                    <Form.Item
+                      name={['sink', 'strictReplaySafety']}
+                      label="Strict Replay Safety"
+                      valuePropName="checked"
+                    >
+                      <Switch disabled />
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <Form.Item name="checkpointIntervalMs" hidden>
+                  <InputNumber />
+                </Form.Item>
+                <Form.Item name={['restart', 'strategy']} hidden>
+                  <Input />
+                </Form.Item>
+                <Form.Item name={['restart', 'attempts']} hidden>
+                  <InputNumber />
+                </Form.Item>
+                <Form.Item name={['restart', 'delayMs']} hidden>
+                  <InputNumber />
+                </Form.Item>
+              </Card>
+
+              <footer className="sticky bottom-0 z-20 flex min-h-[80px] items-center gap-3 rounded-t-lg border border-b-0 border-[#eaecf0] bg-white px-8 py-4 shadow-[0_-8px_16px_rgba(0,0,0,0.06)]">
+                <Button type="primary" loading={saving} className="!h-9 !min-w-[120px] !rounded-lg" onClick={save}>
+                  保存配置
+                </Button>
+                <Button disabled={saving} className="!h-9 !min-w-[120px] !border-0 !bg-[#f2f3f5]" onClick={onClose}>
+                  取消
+                </Button>
+              </footer>
+            </main>
+            <aside className="max-xl:hidden">
+              <nav className="sticky top-6 rounded-xl bg-white px-3 py-4">
+                <div className="mb-3 px-2 text-[12px] font-semibold text-[#344054]">快速定位</div>
+                <div className="relative space-y-1 before:absolute before:bottom-4 before:left-[13px] before:top-4 before:w-px before:bg-[#e4e7ec]">
+                  {sections.map((item) => (
+                    <button
+                      key={item.key}
+                      type="button"
+                      className={`relative flex w-full items-center gap-3 rounded-lg border-0 px-2 py-2 text-left text-[12px] ${active === item.key ? 'bg-[rgba(254,44,85,0.08)] font-semibold text-[var(--yak-brand-color)]' : 'bg-transparent text-[#667085]'}`}
+                      onClick={() => {
+                        setActive(item.key);
+                        document.getElementById(item.key)?.scrollIntoView({ behavior: 'smooth' });
+                      }}
+                    >
+                      <span
+                        className={`relative z-10 h-[11px] w-[11px] rounded-full border ${active === item.key ? 'border-[var(--yak-brand-color)] bg-[var(--yak-brand-color)]' : 'border-[#d0d5dd] bg-[#98a2b3]'}`}
+                      />
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </nav>
+            </aside>
+          </div>
+        </Form>
+      </div>
+    </ConfigProvider>
   );
 }


### PR DESCRIPTION
### Motivation
- 将实时同步的编辑体验与离线同步页面保持一致，提高编辑器可用性并支持更复杂的配置场景。 
- 修复列表查询在遇到两阶段创建但尚未配置 `spec_json`（NULL/空白）时抛出解析异常的问题，避免草稿在列表中不可见或报错。

### Description
- 前端：将实时同步编辑器从抽屉式分步表单重构为全页卡片布局，按 `任务基础信息、Source / Sink 配置、表规则、运行参数` 划分区域，并新增右侧快速定位导航与滚动感知（使用 `IntersectionObserver`）；主要修改文件：`yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx`。 
- 前端：采用响应式双栏 Source/Sink 面板、动态表规则列表、底部固定保存/取消操作区，保留原有的保存接口与负载结构（`realtimeApi.create` / `realtimeApi.update`）。 
- 后端：在列表读取时允许 `spec_json` 为空返回 `null`，避免对空/空白字符串反序列化导致抛出 `IllegalArgumentException`，修改文件：`yak-ops-business/.../RealtimeJobListQuery.java`（在 `readSpec` 中增加空值检查并返回 `null`）。 
- 测试：新增单元回归测试以覆盖空/空白 `spec_json` 场景，文件：`.../RealtimeJobListQueryTest.java`，测试断言确保 `readSpec(null)` 和 `readSpec("  ")` 返回 `null`。 

### Testing
- 运行并修复了 `./node_modules/.bin/biome check --write src/pages/realtime-sync/JobEditor.tsx` 和 `./node_modules/.bin/biome check src/pages/realtime-sync/JobEditor.tsx`，均成功。 
- 运行 `git diff --cached --check` 校验通过。 
- 尝试类型检查 `yarn tsc`，在当前环境中因缺失 `minimatch` 类型定义导致 TypeScript 初始化阶段报错（失败，环境依赖问题）。 
- 尝试运行 Maven 单元测试（针对新增 `RealtimeJobListQueryTest`），在当前网络/环境下依赖下载被代理/仓库请求返回 403 导致构建失败（失败，网络/仓库访问受限）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a882d8f8210832395693af7214bacef)