### PR TITLE
feat: add dataset lineage tab to data catalog

### DIFF
--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/DatasetLineageTab.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/DatasetLineageTab.tsx
@@ -1,0 +1,356 @@
+import { BRAND_COLOR } from '@/styles/brand';
+import { Button, Empty, Segmented, Select, Spin, Tag } from 'antd';
+import {
+  ArrowUpRight,
+  GitBranch,
+  RefreshCw,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  MarkerType,
+  type Edge,
+  type Node,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import LineageNode, {
+  type LineageNodeData,
+} from '../lineage/LineageNode';
+import {
+  buildLineageView,
+  lineageLevels,
+} from '../lineage/graph-layout';
+import {
+  fetchLineageGraph,
+  searchLineageAssets,
+} from '../lineage/service';
+import {
+  LINEAGE_ASSET_TYPES,
+  assetTypeLabel,
+  type LineageAsset,
+  type LineageAssetType,
+  type LineageDirection,
+  type LineageGraph,
+} from '../lineage/types';
+import type { CatalogDataset } from './service';
+
+const DEFAULT_DEPTH = 3;
+const nodeTypes = { lineage: LineageNode };
+const visibleTypes = new Set<LineageAssetType>(LINEAGE_ASSET_TYPES);
+
+interface DatasetLineageTabProps {
+  dataset: CatalogDataset;
+}
+
+const uniqueAssets = (values: LineageAsset[]) => {
+  const result = new Map<string, LineageAsset>();
+  values.forEach((asset) => result.set(asset.id, asset));
+  return [...result.values()];
+};
+
+const pickDatasetAsset = (
+  dataset: CatalogDataset,
+  candidates: LineageAsset[],
+) => {
+  const sourceMatched = candidates.find(
+    (asset) => String(asset.sourceId || '') === dataset.id,
+  );
+  if (sourceMatched) return sourceMatched;
+
+  const normalizedId = dataset.id.toLowerCase();
+  const keyMatched = candidates.find((asset) => {
+    const key = asset.assetKey.toLowerCase();
+    return key === normalizedId
+      || key.endsWith(`:${normalizedId}`)
+      || key.endsWith(`/${normalizedId}`);
+  });
+  if (keyMatched) return keyMatched;
+
+  return candidates.find((asset) => asset.name === dataset.name);
+};
+
+const resolveDatasetAsset = async (dataset: CatalogDataset) => {
+  const byName = await searchLineageAssets({
+    keyword: dataset.name,
+    assetType: 'DATASET',
+    limit: 50,
+  });
+  let candidates = uniqueAssets(byName);
+  let matched = pickDatasetAsset(dataset, candidates);
+  if (matched) return matched;
+
+  const byId = await searchLineageAssets({
+    keyword: dataset.id,
+    assetType: 'DATASET',
+    limit: 50,
+  });
+  candidates = uniqueAssets([...candidates, ...byId]);
+  matched = pickDatasetAsset(dataset, candidates);
+  return matched;
+};
+
+const typeCounts = (graph?: LineageGraph) => {
+  const counts = new Map<LineageAssetType, number>();
+  graph?.nodes.forEach((asset) => {
+    if (asset.id === graph.root.id) return;
+    counts.set(asset.assetType, (counts.get(asset.assetType) || 0) + 1);
+  });
+  return counts;
+};
+
+export default function DatasetLineageTab({ dataset }: DatasetLineageTabProps) {
+  const [rootAsset, setRootAsset] = useState<LineageAsset>();
+  const [graph, setGraph] = useState<LineageGraph>();
+  const [assetLoading, setAssetLoading] = useState(false);
+  const [graphLoading, setGraphLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [depth, setDepth] = useState(DEFAULT_DEPTH);
+  const [direction, setDirection] = useState<LineageDirection>('BOTH');
+  const [refreshVersion, setRefreshVersion] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setAssetLoading(true);
+    setError('');
+    setRootAsset(undefined);
+    setGraph(undefined);
+
+    void resolveDatasetAsset(dataset)
+      .then((asset) => {
+        if (cancelled) return;
+        if (!asset) {
+          setError('当前 Dataset 尚未生成血缘资产，请先确认血缘采集任务已完成。');
+          return;
+        }
+        setRootAsset(asset);
+      })
+      .catch((requestError) => {
+        if (cancelled) return;
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : '查询 Dataset 血缘资产失败',
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setAssetLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dataset.id, dataset.name]);
+
+  useEffect(() => {
+    if (!rootAsset) return;
+    let cancelled = false;
+    setGraphLoading(true);
+    setError('');
+
+    void fetchLineageGraph(rootAsset.id, depth)
+      .then((value) => {
+        if (!cancelled) setGraph(value);
+      })
+      .catch((requestError) => {
+        if (cancelled) return;
+        setGraph(undefined);
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : '加载 Dataset 血缘图失败',
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setGraphLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [depth, refreshVersion, rootAsset]);
+
+  const view = useMemo(
+    () => (graph ? buildLineageView(graph, direction, visibleTypes) : undefined),
+    [direction, graph],
+  );
+
+  const flowNodes = useMemo<Array<Node<LineageNodeData>>>(() => (
+    view?.nodes.map(({ asset, position }) => ({
+      id: asset.id,
+      type: 'lineage',
+      position,
+      draggable: false,
+      selectable: false,
+      data: {
+        asset,
+        root: asset.id === graph?.root.id,
+      },
+    })) || []
+  ), [graph?.root.id, view?.nodes]);
+
+  const flowEdges = useMemo<Edge[]>(() => (
+    view?.relations.map((relation) => ({
+      id: relation.id,
+      source: relation.sourceAssetId,
+      target: relation.targetAssetId,
+      type: 'smoothstep',
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 14,
+        height: 14,
+        color: '#b9bec6',
+      },
+      style: {
+        stroke: '#c9cdd3',
+        strokeWidth: 1.2,
+      },
+    })) || []
+  ), [view?.relations]);
+
+  const summary = useMemo(() => {
+    if (!graph) return { upstream: 0, downstream: 0 };
+    const levels = lineageLevels(graph);
+    let upstream = 0;
+    let downstream = 0;
+    levels.forEach((level, assetId) => {
+      if (assetId === graph.root.id) return;
+      if (level < 0) upstream += 1;
+      if (level > 0) downstream += 1;
+    });
+    return { upstream, downstream };
+  }, [graph]);
+
+  const counts = useMemo(() => typeCounts(graph), [graph]);
+  const loading = assetLoading || graphLoading;
+  const graphKey = `${rootAsset?.id || 'empty'}:${depth}:${direction}:${refreshVersion}`;
+
+  return (
+    <div className="flex h-full min-h-[480px] flex-col overflow-hidden border border-[#e4e7ec] bg-white">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-[#e4e7ec] bg-[#fafbfc] px-3 py-2">
+        <div className="mr-2 flex items-center gap-2 text-[13px] font-medium text-[#344054]">
+          <GitBranch size={14} />
+          <span>Dataset 血缘</span>
+        </div>
+        <Segmented
+          size="small"
+          value={direction}
+          options={[
+            { label: '全部', value: 'BOTH' },
+            { label: '上游', value: 'UPSTREAM' },
+            { label: '下游', value: 'DOWNSTREAM' },
+          ]}
+          onChange={(value) => setDirection(value as LineageDirection)}
+        />
+        <span className="ml-1 text-[12px] text-[#8a8f99]">深度</span>
+        <Select
+          size="small"
+          value={depth}
+          className="w-[76px]"
+          onChange={setDepth}
+          options={[1, 2, 3, 4, 5].map((value) => ({
+            label: `${value} 层`,
+            value,
+          }))}
+        />
+        <Button
+          size="small"
+          icon={<RefreshCw size={13} />}
+          loading={loading}
+          disabled={!rootAsset}
+          onClick={() => setRefreshVersion((value) => value + 1)}
+        >
+          刷新
+        </Button>
+        <div className="ml-auto flex items-center gap-2 text-[12px] text-[#667085]">
+          <span>上游 {summary.upstream}</span>
+          <span className="h-3 w-px bg-[#dfe3e8]" />
+          <span>下游 {summary.downstream}</span>
+          {rootAsset ? (
+            <Button
+              type="link"
+              size="small"
+              className="px-1"
+              href={`/data-analysis/lineage?assetKey=${encodeURIComponent(rootAsset.assetKey)}`}
+              icon={<ArrowUpRight size={12} />}
+            >
+              完整血缘
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-[#f0f2f5] px-3 py-2 text-[12px] text-[#667085]">
+        <span>上游：数据同步 / 来源表 / 数据开发</span>
+        <span className="text-[#c1c5cc]">→</span>
+        <Tag
+          bordered={false}
+          className="m-0 bg-[rgba(254,44,85,.06)] text-[11px]"
+          style={{ color: BRAND_COLOR }}
+        >
+          当前 Dataset
+        </Tag>
+        <span className="text-[#c1c5cc]">→</span>
+        <span>下游：图表 / 仪表盘</span>
+        {LINEAGE_ASSET_TYPES.map((type) => {
+          const count = counts.get(type) || 0;
+          return count > 0 ? (
+            <span key={type} className="ml-1 text-[#8a8f99]">
+              {assetTypeLabel[type]} {count}
+            </span>
+          ) : null;
+        })}
+      </div>
+
+      <div className="relative min-h-0 flex-1 bg-[#fcfcfd]">
+        {loading && !graph ? (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/70">
+            <Spin tip="正在加载血缘..." />
+          </div>
+        ) : error && !graph ? (
+          <div className="flex h-full items-center justify-center px-6">
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={error}
+            />
+          </div>
+        ) : graph && flowNodes.length ? (
+          <>
+            <ReactFlow
+              key={graphKey}
+              nodes={flowNodes}
+              edges={flowEdges}
+              nodeTypes={nodeTypes}
+              fitView
+              fitViewOptions={{ padding: 0.24, maxZoom: 1 }}
+              minZoom={0.25}
+              maxZoom={1.5}
+              nodesConnectable={false}
+              nodesDraggable={false}
+              elementsSelectable={false}
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background color="#e8eaed" gap={18} size={1} />
+              <Controls showInteractive={false} />
+            </ReactFlow>
+            {graph.relations.length === 0 ? (
+              <div className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-[6px] border border-[#e4e7ec] bg-white px-3 py-1.5 text-[12px] text-[#667085] shadow-sm">
+                已定位当前 Dataset，但暂未采集到上下游关系
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <Empty description="暂无可展示的血缘关系" />
+          </div>
+        )}
+
+        {graphLoading && graph ? (
+          <div className="pointer-events-none absolute right-3 top-3 flex items-center gap-2 rounded-[6px] border border-[#e4e7ec] bg-white px-2.5 py-1.5 text-[12px] text-[#667085] shadow-sm">
+            <Spin size="small" /> 更新中
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/index.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/index.tsx
@@ -35,6 +35,7 @@ import {
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import DatasetLineageTab from './DatasetLineageTab';
 import {
   fetchCatalogWorkspace,
   offlineCatalogDataset,
@@ -274,7 +275,7 @@ const DataCatalogPage = () => {
     'ALL' | CatalogDatasetSourceType
   >('ALL');
   const [detailTab, setDetailTab] = useState<
-    'fields' | 'versions' | 'overview'
+    'fields' | 'versions' | 'overview' | 'lineage'
   >('fields');
   const [current, setCurrent] = useState(1);
   const [pageSize, setPageSize] = useState(20);
@@ -780,6 +781,7 @@ const DataCatalogPage = () => {
       { key: 'fields', label: `字段信息 ${summary.fields}` },
       { key: 'versions', label: `版本历史 ${dataset.versions.length}` },
       { key: 'overview', label: '基本信息' },
+      { key: 'lineage', label: '血缘' },
     ] as const;
 
     const fieldColumns: ColumnsType<CatalogDataset['fields'][number]> = [
@@ -981,7 +983,7 @@ const DataCatalogPage = () => {
               label: tab.label,
             }))}
             onChange={(key) =>
-              setDetailTab(key as 'fields' | 'versions' | 'overview')
+              setDetailTab(key as 'fields' | 'versions' | 'overview' | 'lineage')
             }
             className="dataset-detail-tabs"
           />
@@ -1013,6 +1015,8 @@ const DataCatalogPage = () => {
                 scroll={{ x: 760 }}
                 locale={{ emptyText: '暂无 DatasetVersion' }}
               />
+            ) : detailTab === 'lineage' ? (
+              <DatasetLineageTab key={dataset.id} dataset={dataset} />
             ) : (
               <div className="max-w-[980px]">
                 <div className="grid grid-cols-4 gap-3">


### PR DESCRIPTION
## What
- 在数据目录的 Dataset 详情中新增「血缘」Tab
- 复用现有血缘资产搜索和图谱接口，以当前 Dataset 为中心展示上游/下游关系
- 支持全部/上游/下游方向切换、1-5 层深度、刷新和跳转完整血缘页
- 展示上游/下游数量与资产类型统计，并处理尚未采集血缘的空状态

## Lineage scope
- 上游可展示现有血缘模型中的数据源、SQL 任务、表/视图、Dataset 等资产
- 下游可展示图表、仪表盘等消费资产
- 实际可见节点取决于后端 `/api/v1/lineage` 已采集的资产和关系

## Implementation
- 新增 `yak-ops-ui/src/pages/data-analysis/data-catalog/DatasetLineageTab.tsx`
- 修改 `yak-ops-ui/src/pages/data-analysis/data-catalog/index.tsx`，增加「血缘」Tab
- 复用现有 `lineage/service.ts`、`graph-layout.ts`、`LineageNode.tsx`
- 不新增依赖，不新增后端接口

## Testing
- 已完成代码级检查和分支 diff 检查
- 当前执行环境没有本仓库前端依赖，未实际运行 `npm run typecheck` / `npm run build`
- 仓库当前未发现 GitHub Actions workflow，因此没有可等待的 CI 检查
