### PR TITLE
feat: redesign data lineage workspace

### DIFF
--- a/yak-ops-ui/src/pages/data-analysis/lineage/LineageNode.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/LineageNode.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { Handle, Position, type NodeProps } from 'reactflow';
 import { assetTypeLabel, type LineageAsset } from './types';
+import { lineageAssetVisual } from './visual';
 
 export interface LineageNodeData {
   asset: LineageAsset;
@@ -44,60 +45,100 @@ const subtitle = (asset: LineageAsset) => {
 export default function LineageNode({ data, selected }: NodeProps<LineageNodeData>) {
   const { asset, root } = data;
   const Icon = iconByType[asset.assetType];
+  const visual = lineageAssetVisual[asset.assetType];
+  const emphasized = root || selected;
+
   return (
     <div
-      className="relative flex h-[74px] w-[238px] items-center gap-3 rounded-[8px] border bg-white px-3"
+      className="group relative flex h-[86px] w-[260px] items-center gap-3.5 overflow-hidden rounded-[12px] border bg-white px-3.5 py-3 transition-[transform,box-shadow,border-color] duration-200"
       style={{
-        borderColor: root
-          ? 'rgba(254,44,85,.35)'
-          : selected
-            ? '#aeb4bd'
-            : '#e2e5e9',
-        boxShadow: 'none',
-        background: root ? 'rgba(254,44,85,.025)' : '#fff',
+        borderColor: emphasized ? visual.accent : '#E4E8EE',
+        boxShadow: emphasized
+          ? `0 12px 30px -18px ${visual.glow}, 0 4px 12px -8px ${visual.glow}`
+          : '0 4px 14px -12px rgba(15, 23, 42, 0.28)',
       }}
     >
+      <div
+        className="absolute inset-y-0 left-0 w-[4px]"
+        style={{ background: visual.accent }}
+      />
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-14 opacity-70"
+        style={{
+          background: `linear-gradient(180deg, ${visual.soft} 0%, rgba(255,255,255,0) 100%)`,
+        }}
+      />
+
       <Handle
         type="target"
         position={Position.Left}
         style={{
-          width: 7,
-          height: 7,
-          border: '1px solid #c7ccd4',
+          width: 8,
+          height: 8,
+          border: `2px solid ${visual.accent}`,
           background: '#fff',
+          left: -5,
         }}
       />
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[7px] bg-[#f3f4f6] text-[#5f6670]">
-        <Icon size={17} strokeWidth={1.7} />
+
+      <div
+        className="relative z-[1] flex h-11 w-11 shrink-0 items-center justify-center rounded-[10px] border"
+        style={{
+          color: visual.accent,
+          background: visual.softStrong,
+          borderColor: visual.border,
+        }}
+      >
+        <Icon size={19} strokeWidth={1.8} />
       </div>
-      <div className="min-w-0 flex-1">
+
+      <div className="relative z-[1] min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#161823]" title={asset.name}>
+          <span
+            className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#182230]"
+            title={asset.name}
+          >
             {asset.name}
           </span>
           {root ? (
-            <span className="shrink-0 rounded-[4px] bg-[rgba(254,44,85,.07)] px-1.5 py-0.5 text-[10px] font-medium text-[rgba(254,44,85,.82)]">
+            <span
+              className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold"
+              style={{ color: visual.accent, background: visual.softStrong }}
+            >
               当前
             </span>
           ) : null}
         </div>
-        <div className="mt-1 flex min-w-0 items-center gap-1.5">
-          <span className="shrink-0 rounded-[4px] bg-[#f5f6f7] px-1.5 py-0.5 text-[10px] font-medium text-[#667085]">
+
+        <div className="mt-1.5 flex min-w-0 items-center gap-1.5">
+          <span
+            className="shrink-0 rounded-[5px] border px-1.5 py-0.5 text-[10px] font-semibold"
+            style={{
+              color: visual.accent,
+              background: visual.soft,
+              borderColor: visual.border,
+            }}
+          >
             {assetTypeLabel[asset.assetType]}
           </span>
-          <span className="min-w-0 flex-1 truncate text-[11px] text-[#8a8f99]" title={subtitle(asset)}>
+          <span
+            className="min-w-0 flex-1 truncate text-[11px] text-[#7A8493]"
+            title={subtitle(asset)}
+          >
             {subtitle(asset)}
           </span>
         </div>
       </div>
+
       <Handle
         type="source"
         position={Position.Right}
         style={{
-          width: 7,
-          height: 7,
-          border: '1px solid #c7ccd4',
+          width: 8,
+          height: 8,
+          border: `2px solid ${visual.accent}`,
           background: '#fff',
+          right: -5,
         }}
       />
     </div>

--- a/yak-ops-ui/src/pages/data-analysis/lineage/index.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/index.tsx
@@ -19,9 +19,12 @@ import {
   Boxes,
   ChevronRight,
   GitBranch,
+  Layers3,
   LocateFixed,
+  Network,
   RefreshCw,
   Search,
+  Sparkles,
   X,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -29,6 +32,7 @@ import ReactFlow, {
   Background,
   Controls,
   MarkerType,
+  MiniMap,
   type Edge,
   type Node,
 } from 'reactflow';
@@ -50,6 +54,7 @@ import {
   type LineageGraph,
   type LineageRelation,
 } from './types';
+import { lineageAssetVisual, lineageRelationColor } from './visual';
 
 const DEFAULT_DEPTH = 3;
 const SEARCH_LIMIT = 30;
@@ -62,8 +67,13 @@ const formatTime = (value?: string) => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return new Intl.DateTimeFormat('zh-CN', {
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
   }).format(date).replaceAll('/', '-');
 };
 
@@ -87,10 +97,16 @@ const assetLocation = (asset: LineageAsset) => [
 
 const businessLink = (asset: LineageAsset): { label: string; path: string } | undefined => {
   if (asset.assetType === 'SQL_TASK' && asset.sourceId) {
-    return { label: '打开开发任务', path: `/data-development/task/${encodeURIComponent(asset.sourceId)}` };
+    return {
+      label: '打开开发任务',
+      path: `/data-development/task/${encodeURIComponent(asset.sourceId)}`,
+    };
   }
   if (asset.assetType === 'DASHBOARD' && asset.sourceId) {
-    return { label: '打开仪表盘', path: `/dashboard/${encodeURIComponent(asset.sourceId)}` };
+    return {
+      label: '打开仪表盘',
+      path: `/dashboard/${encodeURIComponent(asset.sourceId)}`,
+    };
   }
   if (asset.assetType === 'DATASET' || asset.assetType === 'DATASET_FIELD') {
     return { label: '打开数据目录', path: '/data-analysis/data-catalog' };
@@ -112,18 +128,73 @@ const relationPropertyEntries = (relation?: LineageRelation) => Object.entries(r
   .filter(([, value]) => value !== undefined && value !== null)
   .slice(0, 18);
 
+const AssetTypePill = ({
+  type,
+  compact = false,
+}: {
+  type: LineageAssetType;
+  compact?: boolean;
+}) => {
+  const visual = lineageAssetVisual[type];
+  return (
+    <span
+      className={[
+        'inline-flex shrink-0 items-center rounded-full border font-semibold',
+        compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-1.5 px-2 py-1 text-[11px]',
+      ].join(' ')}
+      style={{
+        color: visual.accent,
+        background: visual.soft,
+        borderColor: visual.border,
+      }}
+    >
+      <span
+        className={compact ? 'h-1.5 w-1.5 rounded-full' : 'h-2 w-2 rounded-full'}
+        style={{ background: visual.accent }}
+      />
+      {assetTypeLabel[type]}
+    </span>
+  );
+};
+
 const DetailRow = ({ label, value }: { label: string; value: unknown }) => (
-  <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-3 py-2 text-[12px]">
-    <span className="text-[#8a8f99]">{label}</span>
-    <span className="min-w-0 break-all text-[#344054]">{formatValue(value)}</span>
+  <div className="grid grid-cols-[92px_minmax(0,1fr)] gap-3 border-b border-[#F0F2F5] py-2.5 text-[12px] last:border-b-0">
+    <span className="text-[#8A94A3]">{label}</span>
+    <span className="min-w-0 break-all font-medium text-[#3C4655]">
+      {formatValue(value)}
+    </span>
   </div>
 );
 
-const ImpactChip = ({ label, value }: { label: string; value: number }) => (
-  <span className="inline-flex h-7 items-center gap-1.5 rounded-[6px] border border-[#e5e7eb] bg-white px-2.5 text-[12px] text-[#667085]">
-    <span>{label}</span>
-    <strong className="font-semibold text-[#344054]">{value}</strong>
-  </span>
+const ImpactChip = ({
+  label,
+  value,
+  type,
+}: {
+  label: string;
+  value: number;
+  type?: LineageAssetType;
+}) => {
+  const visual = type ? lineageAssetVisual[type] : undefined;
+  return (
+    <span
+      className="inline-flex h-8 items-center gap-2 rounded-full border px-3 text-[12px]"
+      style={{
+        color: visual?.accent || '#526071',
+        background: visual?.soft || '#F8FAFC',
+        borderColor: visual?.border || '#E2E8F0',
+      }}
+    >
+      <span>{label}</span>
+      <strong className="font-bold text-[#182230]">{value}</strong>
+    </span>
+  );
+};
+
+const SectionTitle = ({ children }: { children: React.ReactNode }) => (
+  <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8A94A3]">
+    {children}
+  </div>
 );
 
 export default function LineagePage() {
@@ -260,23 +331,29 @@ export default function LineagePage() {
   ), [graph?.root.id, selectedAsset?.id, selectedRelation, view?.nodes]);
 
   const flowEdges = useMemo<Edge[]>(() => (
-    view?.relations.map((relation) => ({
-      id: relation.id,
-      source: relation.sourceAssetId,
-      target: relation.targetAssetId,
-      type: 'smoothstep',
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        width: 14,
-        height: 14,
-        color: selectedRelation?.id === relation.id ? BRAND_COLOR : '#b9bec6',
-      },
-      style: {
-        stroke: selectedRelation?.id === relation.id ? BRAND_COLOR : '#c9cdd3',
-        strokeWidth: selectedRelation?.id === relation.id ? 1.6 : 1.15,
-      },
-      data: { relation },
-    })) || []
+    view?.relations.map((relation) => {
+      const selected = selectedRelation?.id === relation.id;
+      const color = lineageRelationColor[relation.relationType];
+      return {
+        id: relation.id,
+        source: relation.sourceAssetId,
+        target: relation.targetAssetId,
+        type: 'smoothstep',
+        animated: selected,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: selected ? 17 : 14,
+          height: selected ? 17 : 14,
+          color,
+        },
+        style: {
+          stroke: color,
+          strokeWidth: selected ? 2.4 : 1.5,
+          opacity: selected ? 1 : 0.58,
+        },
+        data: { relation },
+      };
+    }) || []
   ), [selectedRelation?.id, view?.relations]);
 
   const nodeById = useMemo(
@@ -290,6 +367,12 @@ export default function LineagePage() {
     ? nodeById.get(selectedRelation.targetAssetId)
     : undefined;
   const selectedBusinessLink = selectedAsset ? businessLink(selectedAsset) : undefined;
+  const selectedAssetVisual = selectedAsset
+    ? lineageAssetVisual[selectedAsset.assetType]
+    : undefined;
+  const selectedRelationColor = selectedRelation
+    ? lineageRelationColor[selectedRelation.relationType]
+    : '#64748B';
   const graphKey = rootAsset
     ? `${rootAsset.id}:${depth}:${direction}:${visibleTypes.join(',')}`
     : 'empty';
@@ -304,20 +387,55 @@ export default function LineagePage() {
         setSelectedAsset(value.root);
         setSelectedRelation(undefined);
       })
-      .catch((error) => setLoadError(error instanceof Error ? error.message : '加载血缘图失败'))
+      .catch((error) => {
+        setLoadError(error instanceof Error ? error.message : '加载血缘图失败');
+      })
       .finally(() => setLoading(false));
   };
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
-      <div className="lineage-page flex h-full min-h-[560px] flex-col overflow-hidden bg-white text-[#161823]">
-        <header className="shrink-0 border-b border-[#e5e7eb] px-4 py-3">
+      <div className="lineage-page flex h-full min-h-[600px] flex-col overflow-hidden bg-[#F6F8FC] text-[#182230]">
+        <header
+          className="shrink-0 border-b border-[#E7EAF0] bg-white px-5 pb-4 pt-4"
+          style={{
+            backgroundImage: 'linear-gradient(180deg, #FFFFFF 0%, #FBFCFF 100%)',
+          }}
+        >
           <div className="flex min-w-0 items-center gap-3">
-            <div className="flex shrink-0 items-center gap-2 pr-2">
-              <GitBranch size={17} className="text-[#475467]" />
-              <span className="text-[15px] font-semibold">数据血缘</span>
+            <div
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[13px] text-white shadow-[0_8px_24px_-12px_rgba(254,44,85,.8)]"
+              style={{
+                background: 'linear-gradient(135deg, #FE2C55 0%, #A855F7 100%)',
+              }}
+            >
+              <Network size={20} strokeWidth={1.9} />
             </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <h1 className="m-0 text-[18px] font-bold leading-6 text-[#182230]">
+                  数据血缘
+                </h1>
+                <span className="rounded-full bg-[#F3E8FF] px-2 py-0.5 text-[10px] font-semibold text-[#7C3AED]">
+                  Lineage
+                </span>
+              </div>
+              <div className="mt-0.5 text-[12px] text-[#7A8493]">
+                从数据来源到消费端，追踪资产依赖、变更影响和流转路径
+              </div>
+            </div>
+            {rootAsset ? (
+              <div className="ml-auto hidden items-center gap-2 xl:flex">
+                <span className="text-[11px] text-[#8A94A3]">当前中心</span>
+                <AssetTypePill type={rootAsset.assetType} compact />
+                <span className="max-w-[220px] truncate text-[12px] font-semibold text-[#344054]">
+                  {rootAsset.name}
+                </span>
+              </div>
+            ) : null}
+          </div>
 
+          <div className="mt-4 flex min-w-0 flex-wrap items-center gap-2 rounded-[14px] border border-[#E4E8F0] bg-[#F8FAFD] p-2 shadow-[inset_0_1px_0_rgba(255,255,255,.75)]">
             <Select
               showSearch
               allowClear
@@ -325,9 +443,9 @@ export default function LineagePage() {
               searchValue={searchKeyword}
               filterOption={false}
               loading={searching}
-              placeholder={rootAsset ? `当前：${rootAsset.name}` : '搜索名称、表名或 assetKey'}
-              className="w-[320px]"
-              suffixIcon={<Search size={14} className="text-[#8a8f99]" />}
+              placeholder={rootAsset ? `搜索并切换中心资产，当前：${rootAsset.name}` : '搜索名称、表名或 assetKey'}
+              className="w-[390px]"
+              suffixIcon={<Search size={14} className="text-[#8A94A3]" />}
               onSearch={setSearchKeyword}
               onClear={() => {
                 setSearchKeyword('');
@@ -342,11 +460,11 @@ export default function LineagePage() {
               options={searchResults.map((asset) => ({
                 value: asset.assetKey,
                 label: (
-                  <div className="flex min-w-0 items-center gap-2 py-0.5">
-                    <span className="shrink-0 rounded-[4px] bg-[#f3f4f6] px-1.5 py-0.5 text-[10px] text-[#667085]">
-                      {assetTypeLabel[asset.assetType]}
+                  <div className="flex min-w-0 items-center gap-2 py-1">
+                    <AssetTypePill type={asset.assetType} compact />
+                    <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#344054]">
+                      {asset.name}
                     </span>
-                    <span className="min-w-0 flex-1 truncate text-[13px] text-[#344054]">{asset.name}</span>
                   </div>
                 ),
               }))}
@@ -355,18 +473,21 @@ export default function LineagePage() {
 
             <Select
               value={searchType}
-              className="w-[118px]"
+              className="w-[126px]"
               onChange={setSearchType}
               options={[
                 { value: 'ALL', label: '全部类型' },
-                ...LINEAGE_ASSET_TYPES.map((value) => ({ value, label: assetTypeLabel[value] })),
+                ...LINEAGE_ASSET_TYPES.map((value) => ({
+                  value,
+                  label: assetTypeLabel[value],
+                })),
               ]}
             />
 
-            <div className="h-5 w-px bg-[#e5e7eb]" />
+            <div className="mx-1 h-5 w-px bg-[#DDE2EA]" />
 
             <Segmented
-              size="small"
+              size="middle"
               value={direction}
               onChange={(value) => setDirection(value as LineageDirection)}
               options={[
@@ -398,260 +519,459 @@ export default function LineagePage() {
           </div>
 
           {rootAsset ? (
-            <div className="mt-2 flex min-w-0 items-center gap-2 text-[12px]">
-              <span className="shrink-0 text-[#8a8f99]">当前资产</span>
-              <span className="truncate font-medium text-[#344054]">{rootAsset.name}</span>
-              <ChevronRight size={12} className="shrink-0 text-[#c0c4ca]" />
-              <span className="shrink-0 rounded-[4px] bg-[#f4f5f7] px-1.5 py-0.5 text-[10px] text-[#667085]">
-                {assetTypeLabel[rootAsset.assetType]}
-              </span>
-              <span className="min-w-0 truncate font-mono text-[11px] text-[#98a2b3]">{rootAsset.assetKey}</span>
-              <div className="ml-auto flex shrink-0 items-center gap-1.5">
-                <ImpactChip label="下游" value={impact?.total || 0} />
-                <ImpactChip label="Dataset" value={impact?.byType.DATASET || 0} />
-                <ImpactChip label="图表" value={impact?.byType.CHART || 0} />
-                <ImpactChip label="仪表盘" value={impact?.byType.DASHBOARD || 0} />
+            <div className="mt-3 flex min-w-0 flex-wrap items-center gap-2">
+              <div className="mr-1 flex min-w-0 items-center gap-2 rounded-full border border-[#E4E8F0] bg-white py-1 pl-2 pr-3 shadow-[0_4px_14px_-12px_rgba(15,23,42,.35)]">
+                <span
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+                  style={{
+                    color: lineageAssetVisual[rootAsset.assetType].accent,
+                    background: lineageAssetVisual[rootAsset.assetType].softStrong,
+                  }}
+                >
+                  <LocateFixed size={12} />
+                </span>
+                <span className="shrink-0 text-[11px] text-[#8A94A3]">中心资产</span>
+                <span className="max-w-[220px] truncate text-[12px] font-semibold text-[#344054]">
+                  {rootAsset.name}
+                </span>
+                <ChevronRight size={12} className="shrink-0 text-[#B5BDC8]" />
+                <span className="max-w-[260px] truncate font-mono text-[10px] text-[#98A2B3]">
+                  {rootAsset.assetKey}
+                </span>
               </div>
+
+              <ImpactChip label="下游" value={impact?.total || 0} />
+              <ImpactChip label="Dataset" value={impact?.byType.DATASET || 0} type="DATASET" />
+              <ImpactChip label="图表" value={impact?.byType.CHART || 0} type="CHART" />
+              <ImpactChip label="仪表盘" value={impact?.byType.DASHBOARD || 0} type="DASHBOARD" />
             </div>
           ) : null}
         </header>
 
-        <div className="flex min-h-0 flex-1 overflow-hidden">
-          <main className="relative min-w-0 flex-1 bg-[#f8f9fb]">
-            <div className="absolute left-3 top-3 z-10 flex items-center gap-2 rounded-[7px] border border-[#e2e5e9] bg-white px-2 py-1.5">
-              <span className="text-[11px] text-[#8a8f99]">显示</span>
-              <Select
-                mode="multiple"
-                size="small"
-                value={visibleTypes}
-                className="w-[310px]"
-                maxTagCount="responsive"
-                onChange={(values) => setVisibleTypes(values as LineageAssetType[])}
-                options={LINEAGE_ASSET_TYPES.map((value) => ({
-                  value,
-                  label: assetTypeLabel[value],
-                }))}
-              />
-              <Button
-                type="text"
-                size="small"
-                disabled={visibleTypes.length === ALL_TYPES.length}
-                onClick={() => setVisibleTypes(ALL_TYPES)}
-              >
-                全部
-              </Button>
-            </div>
-
-            {!rootAsset ? (
-              <div className="flex h-full min-h-[560px] items-center justify-center">
-                <Empty
-                  image={<div className="mx-auto flex h-12 w-12 items-center justify-center rounded-[10px] bg-[#eef0f3] text-[#667085]"><Boxes size={22} /></div>}
-                  description={(
-                    <div>
-                      <div className="text-[14px] font-medium text-[#344054]">选择一个资产开始查看血缘</div>
-                      <div className="mt-1 text-[12px] text-[#8a8f99]">可搜索数据表、SQL 任务、Dataset、图表或仪表盘</div>
+        <div className="min-h-0 flex-1 p-3">
+          <div className="flex h-full min-h-0 overflow-hidden rounded-[18px] border border-[#E2E7EF] bg-white shadow-[0_12px_40px_-28px_rgba(15,23,42,.45)]">
+            <main
+              className="relative min-w-0 flex-1 overflow-hidden"
+              style={{
+                background: 'linear-gradient(180deg, #F8FAFF 0%, #F5F7FB 100%)',
+              }}
+            >
+              {rootAsset ? (
+                <>
+                  <div className="absolute left-4 top-4 z-10 flex max-w-[calc(100%-32px)] items-center gap-2 rounded-[12px] border border-[#DDE3EC] bg-white/95 p-2 shadow-[0_10px_28px_-20px_rgba(15,23,42,.45)] backdrop-blur-sm">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[#F3E8FF] text-[#7C3AED]">
+                      <Layers3 size={14} />
                     </div>
-                  )}
-                />
-              </div>
-            ) : loadError && !graph ? (
-              <div className="flex h-full min-h-[560px] items-center justify-center">
-                <Empty description={loadError}>
-                  <Button onClick={refresh}>重新加载</Button>
-                </Empty>
-              </div>
-            ) : (
-              <Spin spinning={loading && !graph} wrapperClassName="lineage-graph-spinner">
-                <div className="h-full min-h-[560px] w-full">
-                  <ReactFlow
-                    key={graphKey}
-                    nodes={flowNodes}
-                    edges={flowEdges}
-                    nodeTypes={nodeTypes}
-                    fitView
-                    fitViewOptions={{ padding: 0.22, minZoom: 0.55, maxZoom: 1.1 }}
-                    minZoom={0.25}
-                    maxZoom={1.6}
-                    nodesDraggable={false}
-                    nodesConnectable={false}
-                    elementsSelectable
-                    proOptions={{ hideAttribution: true }}
-                    onNodeClick={(_, node) => {
-                      setSelectedAsset(node.data.asset);
-                      setSelectedRelation(undefined);
-                    }}
-                    onNodeDoubleClick={(_, node) => selectRoot(node.data.asset)}
-                    onEdgeClick={(_, edge) => {
-                      const relation = view?.relations.find((item) => item.id === edge.id);
-                      if (!relation) return;
-                      setSelectedRelation(relation);
-                      setSelectedAsset(undefined);
-                    }}
-                    onPaneClick={() => {
-                      if (graph) setSelectedAsset(graph.root);
-                      setSelectedRelation(undefined);
-                    }}
-                  >
-                    <Background gap={18} size={1} color="#e3e6ea" />
-                    <Controls showInteractive={false} position="bottom-left" />
-                  </ReactFlow>
-                </div>
-              </Spin>
-            )}
-          </main>
-
-          <aside className="w-[330px] shrink-0 overflow-y-auto border-l border-[#e5e7eb] bg-white">
-            {selectedRelation ? (
-              <div>
-                <div className="sticky top-0 z-10 flex items-center justify-between border-b border-[#eef0f2] bg-white px-4 py-3">
-                  <div>
-                    <div className="text-[13px] font-semibold text-[#161823]">关系详情</div>
-                    <div className="mt-0.5 text-[11px] text-[#8a8f99]">Evidence / Provenance</div>
+                    <span className="shrink-0 text-[11px] font-semibold text-[#667085]">
+                      显示资产
+                    </span>
+                    <Select
+                      mode="multiple"
+                      size="small"
+                      value={visibleTypes}
+                      className="w-[330px]"
+                      maxTagCount="responsive"
+                      onChange={(values) => setVisibleTypes(values as LineageAssetType[])}
+                      options={LINEAGE_ASSET_TYPES.map((value) => ({
+                        value,
+                        label: assetTypeLabel[value],
+                      }))}
+                    />
+                    <Button
+                      type="text"
+                      size="small"
+                      disabled={visibleTypes.length === ALL_TYPES.length}
+                      onClick={() => setVisibleTypes(ALL_TYPES)}
+                    >
+                      全部
+                    </Button>
                   </div>
-                  <Button
-                    type="text"
-                    size="small"
-                    icon={<X size={14} />}
-                    onClick={() => {
-                      setSelectedRelation(undefined);
-                      if (graph) setSelectedAsset(graph.root);
-                    }}
-                  />
-                </div>
-                <div className="px-4 py-2">
-                  <div className="mb-2 rounded-[7px] border border-[#e5e7eb] bg-[#fafbfc] p-3">
-                    <div className="truncate text-[12px] font-medium text-[#344054]">{selectedRelationSource?.name || selectedRelation.sourceAssetId}</div>
-                    <div className="my-1.5 flex items-center gap-1 text-[11px] text-[#8a8f99]">
-                      <span>{relationTypeLabel[selectedRelation.relationType]}</span>
-                      <ChevronRight size={11} />
-                    </div>
-                    <div className="truncate text-[12px] font-medium text-[#344054]">{selectedRelationTarget?.name || selectedRelation.targetAssetId}</div>
+
+                  <div className="absolute right-4 top-4 z-10 hidden items-center gap-2 rounded-full border border-[#E2E7EF] bg-white/90 px-3 py-1.5 text-[11px] text-[#7A8493] shadow-[0_8px_24px_-20px_rgba(15,23,42,.45)] backdrop-blur-sm 2xl:flex">
+                    <Sparkles size={12} className="text-[#7C3AED]" />
+                    单击查看详情 · 双击节点设为中心
                   </div>
-                  <DetailRow label="关系类型" value={relationTypeLabel[selectedRelation.relationType]} />
-                  <DetailRow label="证据来源" value={selectedRelation.sourceType} />
-                  <DetailRow label="来源 ID" value={selectedRelation.sourceId} />
-                  <DetailRow label="版本" value={selectedRelation.version} />
-                  <DetailRow label="可信度" value={selectedRelation.confidence} />
-                  <DetailRow label="观测时间" value={formatTime(selectedRelation.observedAt)} />
-                  {selectedRelation.expression ? (
-                    <div className="mt-3 border-t border-[#eef0f2] pt-3">
-                      <div className="mb-2 text-[11px] font-medium text-[#667085]">表达式 / SQL</div>
-                      <pre className="max-h-[180px] overflow-auto whitespace-pre-wrap break-words rounded-[7px] bg-[#f6f7f8] p-3 text-[11px] leading-5 text-[#475467]">{selectedRelation.expression}</pre>
+                </>
+              ) : null}
+
+              {!rootAsset ? (
+                <div className="flex h-full min-h-[560px] items-center justify-center px-6">
+                  <div className="relative w-full max-w-[560px] overflow-hidden rounded-[24px] border border-[#E1E6EF] bg-white px-8 py-10 text-center shadow-[0_28px_70px_-46px_rgba(30,41,59,.55)]">
+                    <div className="pointer-events-none absolute -left-16 -top-16 h-40 w-40 rounded-full bg-[#EEF4FF] blur-2xl" />
+                    <div className="pointer-events-none absolute -bottom-20 -right-10 h-44 w-44 rounded-full bg-[#FCE7F3] blur-2xl" />
+                    <div
+                      className="relative mx-auto flex h-16 w-16 items-center justify-center rounded-[18px] text-white shadow-[0_14px_34px_-16px_rgba(124,58,237,.65)]"
+                      style={{
+                        background: 'linear-gradient(135deg, #2563EB 0%, #7C3AED 52%, #FE2C55 100%)',
+                      }}
+                    >
+                      <Boxes size={28} strokeWidth={1.65} />
                     </div>
-                  ) : null}
-                  {relationPropertyEntries(selectedRelation).length ? (
-                    <div className="mt-3 border-t border-[#eef0f2] pt-2">
-                      <div className="py-1 text-[11px] font-medium text-[#667085]">关系属性</div>
-                      {relationPropertyEntries(selectedRelation).map(([key, value]) => (
-                        <DetailRow key={key} label={key} value={value} />
+                    <div className="relative mt-5 text-[18px] font-bold text-[#182230]">
+                      从一个资产开始探索完整数据链路
+                    </div>
+                    <div className="relative mx-auto mt-2 max-w-[430px] text-[13px] leading-6 text-[#7A8493]">
+                      在顶部搜索数据表、SQL 任务、Dataset、图表或仪表盘，系统会自动展开它的上下游依赖关系。
+                    </div>
+                    <div className="relative mt-5 flex flex-wrap justify-center gap-2">
+                      {(['TABLE', 'SQL_TASK', 'DATASET', 'CHART', 'DASHBOARD'] as LineageAssetType[]).map((type) => (
+                        <AssetTypePill key={type} type={type} />
                       ))}
                     </div>
-                  ) : null}
+                    <div className="relative mt-6 inline-flex items-center gap-2 rounded-full bg-[#F8FAFC] px-3 py-1.5 text-[11px] text-[#8A94A3]">
+                      <Search size={12} />
+                      从顶部搜索框定位中心资产
+                    </div>
+                  </div>
                 </div>
-              </div>
-            ) : selectedAsset ? (
-              <div>
-                <div className="sticky top-0 z-10 border-b border-[#eef0f2] bg-white px-4 py-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="truncate text-[14px] font-semibold text-[#161823]" title={selectedAsset.name}>{selectedAsset.name}</div>
-                      <div className="mt-1 flex items-center gap-1.5">
-                        <span className="rounded-[4px] bg-[#f4f5f7] px-1.5 py-0.5 text-[10px] text-[#667085]">{assetTypeLabel[selectedAsset.assetType]}</span>
-                        {selectedAsset.id === graph?.root.id ? (
-                          <span className="rounded-[4px] px-1.5 py-0.5 text-[10px]" style={{ background: BRAND_COLOR_SOFT, color: BRAND_COLOR }}>当前中心</span>
-                        ) : null}
+              ) : loadError && !graph ? (
+                <div className="flex h-full min-h-[560px] items-center justify-center px-6">
+                  <div className="rounded-[18px] border border-[#F1D4DA] bg-white p-8 shadow-[0_18px_45px_-36px_rgba(254,44,85,.45)]">
+                    <Empty description={loadError}>
+                      <Button type="primary" onClick={refresh}>重新加载</Button>
+                    </Empty>
+                  </div>
+                </div>
+              ) : (
+                <Spin spinning={loading && !graph} wrapperClassName="lineage-graph-spinner">
+                  <div className="h-full min-h-[560px] w-full">
+                    <ReactFlow
+                      key={graphKey}
+                      nodes={flowNodes}
+                      edges={flowEdges}
+                      nodeTypes={nodeTypes}
+                      fitView
+                      fitViewOptions={{ padding: 0.24, minZoom: 0.5, maxZoom: 1.05 }}
+                      minZoom={0.22}
+                      maxZoom={1.7}
+                      nodesDraggable={false}
+                      nodesConnectable={false}
+                      elementsSelectable
+                      proOptions={{ hideAttribution: true }}
+                      onNodeClick={(_, node) => {
+                        setSelectedAsset(node.data.asset);
+                        setSelectedRelation(undefined);
+                      }}
+                      onNodeDoubleClick={(_, node) => selectRoot(node.data.asset)}
+                      onEdgeClick={(_, edge) => {
+                        const relation = view?.relations.find((item) => item.id === edge.id);
+                        if (!relation) return;
+                        setSelectedRelation(relation);
+                        setSelectedAsset(undefined);
+                      }}
+                      onPaneClick={() => {
+                        if (graph) setSelectedAsset(graph.root);
+                        setSelectedRelation(undefined);
+                      }}
+                    >
+                      <Background gap={22} size={1} color="#D9E1EC" />
+                      <Controls showInteractive={false} position="bottom-left" />
+                      <MiniMap
+                        position="bottom-right"
+                        pannable
+                        zoomable
+                        nodeColor={(node) => {
+                          const asset = node.data?.asset as LineageAsset | undefined;
+                          return asset
+                            ? lineageAssetVisual[asset.assetType].accent
+                            : '#94A3B8';
+                        }}
+                        nodeStrokeColor="#FFFFFF"
+                        nodeStrokeWidth={4}
+                        maskColor="rgba(238, 242, 247, 0.72)"
+                      />
+                    </ReactFlow>
+                  </div>
+                </Spin>
+              )}
+
+              {loading && graph ? (
+                <div className="pointer-events-none absolute bottom-4 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2 rounded-full border border-[#DDE3EC] bg-white/95 px-3 py-1.5 text-[11px] text-[#667085] shadow-[0_10px_30px_-20px_rgba(15,23,42,.5)] backdrop-blur-sm">
+                  <Spin size="small" />
+                  正在更新血缘关系
+                </div>
+              ) : null}
+            </main>
+
+            <aside
+              className="w-[360px] shrink-0 overflow-y-auto border-l border-[#E3E8EF]"
+              style={{
+                background: 'linear-gradient(180deg, #FFFFFF 0%, #FBFCFE 100%)',
+              }}
+            >
+              {selectedRelation ? (
+                <div>
+                  <div className="sticky top-0 z-10 border-b border-[#EDF0F4] bg-white/95 px-4 py-4 backdrop-blur-md">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2.5">
+                        <div
+                          className="flex h-9 w-9 items-center justify-center rounded-[10px] text-white"
+                          style={{ background: selectedRelationColor }}
+                        >
+                          <GitBranch size={16} />
+                        </div>
+                        <div>
+                          <div className="text-[14px] font-bold text-[#182230]">关系详情</div>
+                          <div className="mt-0.5 text-[10px] uppercase tracking-[0.08em] text-[#98A2B3]">
+                            Evidence / Provenance
+                          </div>
+                        </div>
+                      </div>
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<X size={14} />}
+                        onClick={() => {
+                          setSelectedRelation(undefined);
+                          if (graph) setSelectedAsset(graph.root);
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="p-4">
+                    <div
+                      className="mb-4 rounded-[14px] border p-3.5"
+                      style={{
+                        borderColor: `${selectedRelationColor}35`,
+                        background: `${selectedRelationColor}0D`,
+                      }}
+                    >
+                      <div className="truncate text-[12px] font-semibold text-[#344054]">
+                        {selectedRelationSource?.name || selectedRelation.sourceAssetId}
+                      </div>
+                      <div className="my-2 flex items-center gap-1.5 text-[11px] font-semibold" style={{ color: selectedRelationColor }}>
+                        <span className="h-1.5 w-1.5 rounded-full" style={{ background: selectedRelationColor }} />
+                        <span>{relationTypeLabel[selectedRelation.relationType]}</span>
+                        <ChevronRight size={11} />
+                      </div>
+                      <div className="truncate text-[12px] font-semibold text-[#344054]">
+                        {selectedRelationTarget?.name || selectedRelation.targetAssetId}
                       </div>
                     </div>
-                    <div className="flex shrink-0 gap-1">
+
+                    <SectionTitle>关系信息</SectionTitle>
+                    <div className="rounded-[12px] border border-[#E8ECF2] bg-white px-3">
+                      <DetailRow label="关系类型" value={relationTypeLabel[selectedRelation.relationType]} />
+                      <DetailRow label="证据来源" value={selectedRelation.sourceType} />
+                      <DetailRow label="来源 ID" value={selectedRelation.sourceId} />
+                      <DetailRow label="版本" value={selectedRelation.version} />
+                      <DetailRow label="可信度" value={selectedRelation.confidence} />
+                      <DetailRow label="观测时间" value={formatTime(selectedRelation.observedAt)} />
+                    </div>
+
+                    {selectedRelation.expression ? (
+                      <div className="mt-5">
+                        <SectionTitle>表达式 / SQL</SectionTitle>
+                        <pre className="max-h-[220px] overflow-auto whitespace-pre-wrap break-words rounded-[12px] border border-[#E8ECF2] bg-[#F7F9FC] p-3 text-[11px] leading-5 text-[#475467]">
+                          {selectedRelation.expression}
+                        </pre>
+                      </div>
+                    ) : null}
+
+                    {relationPropertyEntries(selectedRelation).length ? (
+                      <div className="mt-5">
+                        <SectionTitle>关系属性</SectionTitle>
+                        <div className="rounded-[12px] border border-[#E8ECF2] bg-white px-3">
+                          {relationPropertyEntries(selectedRelation).map(([key, value]) => (
+                            <DetailRow key={key} label={key} value={value} />
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ) : selectedAsset ? (
+                <div>
+                  <div
+                    className="sticky top-0 z-10 border-b bg-white/95 px-4 py-4 backdrop-blur-md"
+                    style={{ borderColor: selectedAssetVisual?.border || '#EDF0F4' }}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="mb-2 flex items-center gap-2">
+                          <AssetTypePill type={selectedAsset.assetType} />
+                          {selectedAsset.id === graph?.root.id ? (
+                            <span
+                              className="rounded-full px-2 py-1 text-[10px] font-semibold"
+                              style={{ background: BRAND_COLOR_SOFT, color: BRAND_COLOR }}
+                            >
+                              当前中心
+                            </span>
+                          ) : null}
+                        </div>
+                        <div
+                          className="truncate text-[16px] font-bold text-[#182230]"
+                          title={selectedAsset.name}
+                        >
+                          {selectedAsset.name}
+                        </div>
+                        <div className="mt-1 truncate font-mono text-[10px] text-[#98A2B3]">
+                          {selectedAsset.assetKey}
+                        </div>
+                      </div>
+
                       {selectedAsset.id !== graph?.root.id ? (
                         <Tooltip title="以此资产重新加载上下游">
-                          <Button size="small" icon={<LocateFixed size={13} />} onClick={() => selectRoot(selectedAsset)}>设为中心</Button>
+                          <Button
+                            size="small"
+                            icon={<LocateFixed size={13} />}
+                            onClick={() => selectRoot(selectedAsset)}
+                          >
+                            设为中心
+                          </Button>
                         </Tooltip>
                       ) : null}
                     </div>
+
+                    {selectedBusinessLink ? (
+                      <Button
+                        className="mt-3 w-full"
+                        size="small"
+                        icon={<ArrowUpRight size={13} />}
+                        onClick={() => history.push(selectedBusinessLink.path)}
+                        style={selectedAssetVisual ? {
+                          color: selectedAssetVisual.accent,
+                          borderColor: selectedAssetVisual.border,
+                          background: selectedAssetVisual.soft,
+                        } : undefined}
+                      >
+                        {selectedBusinessLink.label}
+                      </Button>
+                    ) : null}
                   </div>
-                  {selectedBusinessLink ? (
-                    <Button
-                      className="mt-3 w-full"
-                      size="small"
-                      icon={<ArrowUpRight size={13} />}
-                      onClick={() => history.push(selectedBusinessLink.path)}
-                    >
-                      {selectedBusinessLink.label}
-                    </Button>
-                  ) : null}
-                </div>
 
-                <div className="px-4 py-2">
-                  <DetailRow label="assetKey" value={selectedAsset.assetKey} />
-                  <DetailRow label="来源类型" value={selectedAsset.sourceType} />
-                  <DetailRow label="来源 ID" value={selectedAsset.sourceId} />
-                  <DetailRow label="数据源" value={selectedAsset.dataSourceId} />
-                  <DetailRow label="物理位置" value={assetLocation(selectedAsset)} />
-                  <DetailRow label="更新时间" value={formatTime(selectedAsset.updateTime)} />
-
-                  {selectedAsset.id === graph?.root.id && impact ? (
-                    <div className="mt-3 border-t border-[#eef0f2] pt-3">
-                      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-[#667085]">
-                        <GitBranch size={12} /> 下游影响（当前 {depth} 跳）
-                      </div>
-                      <div className="grid grid-cols-2 gap-2">
-                        {[
-                          ['全部下游', impact.total],
-                          ['SQL 任务', impact.byType.SQL_TASK],
-                          ['Dataset', impact.byType.DATASET],
-                          ['图表', impact.byType.CHART],
-                          ['仪表盘', impact.byType.DASHBOARD],
-                          ['数据表', impact.byType.TABLE],
-                        ].map(([label, value]) => (
-                          <div key={String(label)} className="rounded-[7px] border border-[#e8eaed] bg-[#fafbfc] px-3 py-2">
-                            <div className="text-[11px] text-[#8a8f99]">{label}</div>
-                            <div className="mt-0.5 text-[17px] font-semibold text-[#344054]">{value}</div>
-                          </div>
-                        ))}
-                      </div>
+                  <div className="p-4">
+                    <SectionTitle>资产信息</SectionTitle>
+                    <div className="rounded-[12px] border border-[#E8ECF2] bg-white px-3">
+                      <DetailRow label="assetKey" value={selectedAsset.assetKey} />
+                      <DetailRow label="来源类型" value={selectedAsset.sourceType} />
+                      <DetailRow label="来源 ID" value={selectedAsset.sourceId} />
+                      <DetailRow label="数据源" value={selectedAsset.dataSourceId} />
+                      <DetailRow label="物理位置" value={assetLocation(selectedAsset)} />
+                      <DetailRow label="更新时间" value={formatTime(selectedAsset.updateTime)} />
                     </div>
-                  ) : null}
 
-                  {assetPropertyEntries(selectedAsset).length ? (
-                    <div className="mt-3 border-t border-[#eef0f2] pt-2">
-                      <div className="py-1 text-[11px] font-medium text-[#667085]">资产属性</div>
-                      {assetPropertyEntries(selectedAsset).map(([key, value]) => (
-                        <DetailRow key={key} label={key} value={value} />
-                      ))}
-                    </div>
-                  ) : null}
+                    {selectedAsset.id === graph?.root.id && impact ? (
+                      <div className="mt-5">
+                        <div className="mb-2 flex items-center justify-between">
+                          <SectionTitle>下游影响</SectionTitle>
+                          <span className="mb-2 text-[10px] text-[#98A2B3]">当前 {depth} 跳</span>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          {[
+                            { label: '全部下游', value: impact.total },
+                            { label: 'SQL 任务', value: impact.byType.SQL_TASK, type: 'SQL_TASK' as LineageAssetType },
+                            { label: 'Dataset', value: impact.byType.DATASET, type: 'DATASET' as LineageAssetType },
+                            { label: '图表', value: impact.byType.CHART, type: 'CHART' as LineageAssetType },
+                            { label: '仪表盘', value: impact.byType.DASHBOARD, type: 'DASHBOARD' as LineageAssetType },
+                            { label: '数据表', value: impact.byType.TABLE, type: 'TABLE' as LineageAssetType },
+                          ].map((item) => {
+                            const visual = item.type ? lineageAssetVisual[item.type] : undefined;
+                            return (
+                              <div
+                                key={item.label}
+                                className="rounded-[12px] border px-3 py-2.5"
+                                style={{
+                                  borderColor: visual?.border || '#E3E8EF',
+                                  background: visual?.soft || '#F8FAFC',
+                                }}
+                              >
+                                <div
+                                  className="text-[11px] font-medium"
+                                  style={{ color: visual?.accent || '#7A8493' }}
+                                >
+                                  {item.label}
+                                </div>
+                                <div className="mt-1 text-[20px] font-bold text-[#182230]">
+                                  {item.value}
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ) : null}
+
+                    {assetPropertyEntries(selectedAsset).length ? (
+                      <div className="mt-5">
+                        <SectionTitle>资产属性</SectionTitle>
+                        <div className="rounded-[12px] border border-[#E8ECF2] bg-white px-3">
+                          {assetPropertyEntries(selectedAsset).map(([key, value]) => (
+                            <DetailRow key={key} label={key} value={value} />
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
                 </div>
-              </div>
-            ) : (
-              <div className="flex h-full min-h-[420px] items-center justify-center px-8 text-center text-[12px] text-[#8a8f99]">
-                点击节点查看资产详情，点击连线查看关系证据
-              </div>
-            )}
-          </aside>
+              ) : (
+                <div className="flex h-full min-h-[420px] items-center justify-center px-8 text-center">
+                  <div className="max-w-[250px]">
+                    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-[14px] bg-[#EEF2FF] text-[#6366F1]">
+                      <GitBranch size={20} />
+                    </div>
+                    <div className="mt-4 text-[13px] font-semibold text-[#475467]">
+                      选择节点或关系
+                    </div>
+                    <div className="mt-1.5 text-[11px] leading-5 text-[#98A2B3]">
+                      单击节点查看资产信息，单击连线查看关系证据与 SQL 表达式。
+                    </div>
+                  </div>
+                </div>
+              )}
+            </aside>
+          </div>
         </div>
 
         <style>{`
           .lineage-page .lineage-graph-spinner,
           .lineage-page .lineage-graph-spinner > .ant-spin-container { height: 100%; }
+
           .lineage-page .react-flow__controls {
-            border: 1px solid #e1e4e8;
-            border-radius: 7px;
-            box-shadow: none;
             overflow: hidden;
+            border: 1px solid #dce3ec;
+            border-radius: 10px;
+            background: rgba(255, 255, 255, 0.96);
+            box-shadow: 0 10px 28px -20px rgba(15, 23, 42, 0.5);
           }
           .lineage-page .react-flow__controls-button {
-            width: 28px;
-            height: 28px;
-            border-bottom-color: #edf0f2;
+            width: 30px;
+            height: 30px;
+            border-bottom-color: #edf0f4;
             background: #fff;
             color: #667085;
           }
-          .lineage-page .react-flow__controls-button:hover { background: #f6f7f8; }
+          .lineage-page .react-flow__controls-button:hover {
+            background: #f7f9fc;
+            color: #344054;
+          }
+
+          .lineage-page .react-flow__minimap {
+            overflow: hidden;
+            border: 1px solid #dce3ec;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.95);
+            box-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.55);
+          }
+
           .lineage-page .react-flow__edge { cursor: pointer; }
+          .lineage-page .react-flow__edge-path { transition: stroke-width .18s ease, opacity .18s ease; }
+          .lineage-page .react-flow__edge:hover .react-flow__edge-path { opacity: 1 !important; stroke-width: 2.1px !important; }
           .lineage-page .react-flow__node { cursor: pointer; }
+          .lineage-page .react-flow__node-lineage:hover > div {
+            transform: translateY(-2px);
+            box-shadow: 0 16px 34px -22px rgba(15, 23, 42, .5) !important;
+          }
           .lineage-page .react-flow__pane { cursor: grab; }
           .lineage-page .react-flow__pane.dragging { cursor: grabbing; }
+
+          .lineage-page .ant-segmented {
+            background: #eef2f7;
+          }
+          .lineage-page .ant-segmented-item-selected {
+            box-shadow: 0 2px 8px -6px rgba(15, 23, 42, .45);
+          }
         `}</style>
       </div>
     </ConfigProvider>

--- a/yak-ops-ui/src/pages/data-analysis/lineage/visual.ts
+++ b/yak-ops-ui/src/pages/data-analysis/lineage/visual.ts
@@ -1,0 +1,69 @@
+import type { LineageAssetType, LineageRelationType } from './types';
+
+export interface LineageAssetVisual {
+  accent: string;
+  soft: string;
+  softStrong: string;
+  border: string;
+  glow: string;
+}
+
+export const lineageAssetVisual: Record<LineageAssetType, LineageAssetVisual> = {
+  TABLE: {
+    accent: '#2563EB',
+    soft: '#EFF6FF',
+    softStrong: '#DBEAFE',
+    border: '#BFDBFE',
+    glow: 'rgba(37, 99, 235, 0.18)',
+  },
+  COLUMN: {
+    accent: '#0891B2',
+    soft: '#ECFEFF',
+    softStrong: '#CFFAFE',
+    border: '#A5F3FC',
+    glow: 'rgba(8, 145, 178, 0.16)',
+  },
+  SQL_TASK: {
+    accent: '#7C3AED',
+    soft: '#F5F3FF',
+    softStrong: '#EDE9FE',
+    border: '#DDD6FE',
+    glow: 'rgba(124, 58, 237, 0.18)',
+  },
+  DATASET: {
+    accent: '#FE2C55',
+    soft: '#FFF1F4',
+    softStrong: '#FFE4EA',
+    border: '#FFC2CF',
+    glow: 'rgba(254, 44, 85, 0.18)',
+  },
+  DATASET_FIELD: {
+    accent: '#DB2777',
+    soft: '#FDF2F8',
+    softStrong: '#FCE7F3',
+    border: '#FBCFE8',
+    glow: 'rgba(219, 39, 119, 0.16)',
+  },
+  CHART: {
+    accent: '#EA580C',
+    soft: '#FFF7ED',
+    softStrong: '#FFEDD5',
+    border: '#FED7AA',
+    glow: 'rgba(234, 88, 12, 0.16)',
+  },
+  DASHBOARD: {
+    accent: '#059669',
+    soft: '#ECFDF5',
+    softStrong: '#D1FAE5',
+    border: '#A7F3D0',
+    glow: 'rgba(5, 150, 105, 0.17)',
+  },
+};
+
+export const lineageRelationColor: Record<LineageRelationType, string> = {
+  READS_FROM: '#4F7FEA',
+  WRITES_TO: '#7C3AED',
+  DERIVES_FROM: '#E44767',
+  CONSUMES: '#E87920',
+  CONTAINS: '#0F9F8F',
+};


### PR DESCRIPTION
## What
- 重构「数据血缘」页面整体视觉，弱化大面积灰色，改为更明亮、有层次的数据资产工作台
- 顶部区域重新组织为标题区 + 搜索/筛选工作区 + 当前中心资产摘要
- 血缘画布增加卡片化容器、MiniMap、交互提示和更清晰的缩放控件
- 空状态升级为引导式入口，突出数据表、SQL 任务、Dataset、图表、仪表盘等核心资产类型
- 右侧资产/关系详情面板重新分组，增强信息层级和可读性

## Node & relation visual
- 为不同资产类型引入独立色板：
  - 数据表：蓝色
  - 字段：青色
  - SQL 任务：紫色
  - Dataset：品牌红
  - Dataset 字段：玫红
  - 图表：橙色
  - 仪表盘：绿色
- 节点增加彩色左侧强调条、图标底色、类型标签、中心/选中高亮和 hover 浮起效果
- 不同关系类型使用低饱和彩色连线，选中关系时加强线宽并显示动画

## Implementation
- 修改 `yak-ops-ui/src/pages/data-analysis/lineage/index.tsx`
- 修改 `yak-ops-ui/src/pages/data-analysis/lineage/LineageNode.tsx`
- 新增 `yak-ops-ui/src/pages/data-analysis/lineage/visual.ts`，统一维护资产和关系视觉色板
- 保留现有搜索、上下游方向、深度、资产过滤、节点详情、关系证据、双击设为中心等交互逻辑
- 不新增 npm 依赖

## Validation
- 已检查与 `main` 的分支 diff，当前分支仅涉及上述 3 个血缘前端文件
- `reactflow` 版本为 11.11.4，页面使用的 MiniMap/Controls 能力由当前依赖提供
- 当前连接环境无法在仓库工作区执行 `npm run tsc` / `npm run build`，因此 PR 保持 Draft，建议本地或 CI 通过后再 Ready for review
