### PR TITLE
fix(ui): unify realtime sync form variant and stabilize quick navigation

### DIFF
--- a/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
@@ -13,7 +13,7 @@ import {
   Space,
   Switch,
 } from 'antd';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { BRAND_THEME } from '@/styles/brand';
 import { realtimeApi } from './api';
 import type { CdcPipelineSpec, DataSourceOption, RealtimeJob } from './types';
@@ -59,6 +59,9 @@ const sections = [
 ] as const;
 type SectionKey = (typeof sections)[number]['key'];
 
+const SECTION_SCROLL_OFFSET = 24;
+const ACTIVE_SECTION_OFFSET = SECTION_SCROLL_OFFSET + 8;
+
 const toFormValue = (job?: RealtimeJob): FormValue =>
   job?.spec
     ? {
@@ -92,6 +95,8 @@ export default function JobEditor({
   const [form] = Form.useForm<FormValue>();
   const [saving, setSaving] = useState(false);
   const [active, setActive] = useState<SectionKey>('task-basic');
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const scrollingToRef = useRef<SectionKey | null>(null);
   const sourceOptions = useMemo(() => dataSources.filter((item) => item.dbType === 'MYSQL'), [dataSources]);
   const sinkOptions = useMemo(
     () => dataSources.filter((item) => ['MYSQL', 'POSTGRE_SQL', 'POSTGRESQL'].includes(item.dbType)),
@@ -103,20 +108,53 @@ export default function JobEditor({
   }, [form, job, open]);
   useEffect(() => {
     if (!open) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
-        if (visible) setActive(visible.target.id as SectionKey);
-      },
-      { rootMargin: '-15% 0px -65%', threshold: [0, 0.2, 0.5] },
-    );
-    sections.forEach(({ key }) => {
-      const node = document.getElementById(key);
-      if (node) observer.observe(node);
-    });
-    return () => observer.disconnect();
+    const root = scrollContainerRef.current;
+    if (!root) return;
+
+    let frame = 0;
+    let releaseTimer: number | undefined;
+
+    const updateActiveFromScroll = () => {
+      if (scrollingToRef.current) return;
+
+      if (root.scrollTop + root.clientHeight >= root.scrollHeight - 1) {
+        const lastSection = sections[sections.length - 1].key;
+        setActive((current) => (current === lastSection ? current : lastSection));
+        return;
+      }
+
+      const rootTop = root.getBoundingClientRect().top;
+      let next: SectionKey = sections[0].key;
+      for (const { key } of sections) {
+        const node = root.querySelector<HTMLElement>(`#${key}`);
+        if (!node) continue;
+        if (node.getBoundingClientRect().top - rootTop <= ACTIVE_SECTION_OFFSET) next = key;
+        else break;
+      }
+      setActive((current) => (current === next ? current : next));
+    };
+
+    const handleScroll = () => {
+      if (scrollingToRef.current) {
+        if (releaseTimer !== undefined) window.clearTimeout(releaseTimer);
+        releaseTimer = window.setTimeout(() => {
+          scrollingToRef.current = null;
+          updateActiveFromScroll();
+        }, 120);
+        return;
+      }
+
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(updateActiveFromScroll);
+    };
+
+    updateActiveFromScroll();
+    root.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      root.removeEventListener('scroll', handleScroll);
+      window.cancelAnimationFrame(frame);
+      if (releaseTimer !== undefined) window.clearTimeout(releaseTimer);
+    };
   }, [open]);
 
   const save = async () => {
@@ -157,8 +195,8 @@ export default function JobEditor({
   if (!open) return null;
   const option = (item: DataSourceOption) => ({ label: `${item.label} (${item.dbType})`, value: Number(item.value) });
   return (
-    <ConfigProvider theme={BRAND_THEME}>
-      <div className="h-[calc(100vh-64px)] overflow-y-auto bg-[#f7f8fa] text-[#161823]">
+    <ConfigProvider theme={BRAND_THEME} variant="filled">
+      <div ref={scrollContainerRef} className="h-[calc(100vh-64px)] overflow-y-auto bg-[#f7f8fa] text-[#161823]">
         <Form form={form} layout="vertical" initialValues={defaults}>
           <div className="mx-auto grid w-full max-w-[1280px] grid-cols-[minmax(0,1fr)_160px] gap-6 px-6 pb-6 pt-6 max-xl:grid-cols-1">
             <main className="min-w-0 space-y-5">
@@ -374,8 +412,27 @@ export default function JobEditor({
                       type="button"
                       className={`relative flex w-full items-center gap-3 rounded-lg border-0 px-2 py-2 text-left text-[12px] ${active === item.key ? 'bg-[rgba(254,44,85,0.08)] font-semibold text-[var(--yak-brand-color)]' : 'bg-transparent text-[#667085]'}`}
                       onClick={() => {
+                        const root = scrollContainerRef.current;
+                        const target = root?.querySelector<HTMLElement>(`#${item.key}`);
+                        if (!root || !target) return;
+
+                        const targetTop = Math.min(
+                          Math.max(
+                            root.scrollTop +
+                              target.getBoundingClientRect().top -
+                              root.getBoundingClientRect().top -
+                              SECTION_SCROLL_OFFSET,
+                            0,
+                          ),
+                          root.scrollHeight - root.clientHeight,
+                        );
+                        scrollingToRef.current = item.key;
                         setActive(item.key);
-                        document.getElementById(item.key)?.scrollIntoView({ behavior: 'smooth' });
+                        if (Math.abs(root.scrollTop - targetTop) <= 1) {
+                          scrollingToRef.current = null;
+                          return;
+                        }
+                        root.scrollTo({ top: targetTop, behavior: 'smooth' });
                       }}
                     >
                       <span


### PR DESCRIPTION
## 修改内容

- 实时同步编辑页统一使用 Ant Design `filled` 表单风格，覆盖 Input、TextArea、Select、InputNumber 等数据录入组件。
- 修复右侧「快速定位」在滚动/点击平滑滚动时 active 状态来回切换的问题：
  - 以编辑页自身滚动容器作为唯一滚动基准；
  - 改为基于固定锚点位置计算当前 section，避免 IntersectionObserver 多 section 阈值竞争；
  - 点击快速定位时锁定目标项，平滑滚动结束后再恢复滚动同步；
  - 使用 requestAnimationFrame 限制滚动状态更新频率，并处理页面底部最后一个 section。

## 影响范围

仅修改 `yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx`，不涉及后端接口和实时同步任务定义。

## 验证建议

- 打开实时同步新建/编辑页，确认 Input / Select / InputNumber / TextArea 样式均为 filled。
- 连续点击「任务基础信息 / Source / Sink 配置 / 表规则 / 运行参数」，确认定位高亮不会在滚动过程中来回跳。
- 手动滚动页面，确认右侧 active 项按 section 稳定切换，滚动到底部时「运行参数」保持激活。