### PR TITLE
fix(realtime): harden realtime job state model

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.sync.realtime.domain;
 
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -7,9 +8,12 @@ import java.util.EnumSet;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
-/** Explicit transition policy for the observed-state axis. */
+/** Explicit transition and mutation policy for realtime job state axes. */
 @Component
 public class RealtimeStateMachine {
+
+  private static final EnumSet<ObservedState> DEFINITION_MUTABLE_STATES =
+      EnumSet.of(ObservedState.STOPPED, ObservedState.FAILED);
 
   private final Map<ObservedState, EnumSet<ObservedState>> transitions =
       new EnumMap<>(ObservedState.class);
@@ -60,6 +64,20 @@ public class RealtimeStateMachine {
     }
     if (!transitions.getOrDefault(from, EnumSet.noneOf(ObservedState.class)).contains(to)) {
       throw new IllegalStateException("非法实时任务状态迁移：" + from + " -> " + to);
+    }
+  }
+
+  /**
+   * Definition changes are release-axis operations and must not be allowed while runtime state is
+   * active or uncertain. A definite FAILED runtime is safe to edit because desired state has
+   * already returned to STOPPED and no active Flink job is expected.
+   */
+  public void requireDefinitionMutable(String desiredValue, String observedValue) {
+    DesiredState desired = DesiredState.valueOf(desiredValue);
+    ObservedState observed = ObservedState.valueOf(observedValue);
+    if (desired != DesiredState.STOPPED || !DEFINITION_MUTABLE_STATES.contains(observed)) {
+      throw new IllegalStateException(
+          "任务运行态未稳定，只有已停止或明确失败的任务才能编辑、发布或删除");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -63,25 +63,30 @@ public class RealtimeJobStore {
         db.update(
             "update yak_realtime_job_definition set job_name=?,description=?,spec_json=?,"
                 + "config_digest=?,definition_version=definition_version+1,release_state='DRAFT' "
-                + "where id=? and desired_state='STOPPED'",
+                + "where id=? and desired_state='STOPPED' "
+                + "and observed_state in ('STOPPED','FAILED')",
             name,
             description,
             write(spec),
             digest,
             id);
     if (changed != 1) {
-      throw new IllegalStateException("运行中的任务不能编辑，或任务不存在");
+      throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能编辑");
     }
   }
 
-  public void publish(long id) {
+  public void publish(long id, int expectedDefinitionVersion, String expectedDigest) {
     int changed =
         db.update(
             "update yak_realtime_job_definition set release_state='PUBLISHED',"
-                + "published_version=definition_version where id=? and desired_state='STOPPED'",
-            id);
+                + "published_version=definition_version where id=? and desired_state='STOPPED' "
+                + "and observed_state in ('STOPPED','FAILED') and definition_version=? "
+                + "and config_digest=?",
+            id,
+            expectedDefinitionVersion,
+            expectedDigest);
     if (changed != 1) {
-      throw new IllegalStateException("运行中的任务不能发布，或任务不存在");
+      throw new IllegalStateException("任务状态或定义版本已变化，请刷新后重新校验并发布");
     }
   }
 
@@ -292,9 +297,11 @@ public class RealtimeJobStore {
   public void delete(long id) {
     int changed =
         db.update(
-            "delete from yak_realtime_job_definition where id=? and desired_state='STOPPED'", id);
+            "delete from yak_realtime_job_definition where id=? and desired_state='STOPPED' "
+                + "and observed_state in ('STOPPED','FAILED')",
+            id);
     if (changed != 1) {
-      throw new IllegalStateException("运行中的任务不能删除，或任务不存在");
+      throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能删除");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -93,8 +94,16 @@ public class RealtimeJobService {
                 store.event(created, null, "DRAFT_CREATED", null, "DRAFT", "已创建实时同步草稿");
                 return created;
               }
+              DefinitionRow locked = store.lockDefinition(id);
+              stateMachine.requireDefinitionMutable(locked.desiredState(), locked.observedState());
               store.updateDefinition(id, name.trim(), description, spec, digest);
-              store.event(id, null, "DRAFT_SAVED", null, "DRAFT", "已保存草稿并生成新定义版本");
+              store.event(
+                  id,
+                  null,
+                  "DRAFT_SAVED",
+                  locked.releaseState(),
+                  "DRAFT",
+                  "已保存草稿并生成新定义版本");
               return id;
             });
     return saved == null ? 0 : saved;
@@ -123,11 +132,23 @@ public class RealtimeJobService {
 
   public void publish(long id) {
     Prepared prepared = prepare(id, false);
+    stateMachine.requireDefinitionMutable(
+        prepared.definition().desiredState(), prepared.definition().observedState());
     gateway.validate(prepared.compiled().yaml());
     transactions.executeWithoutResult(
         status -> {
-          store.publish(id);
-          store.event(id, null, "PUBLISHED", "DRAFT", "PUBLISHED", "Flink CDC 校验通过，任务已发布");
+          DefinitionRow locked = store.lockDefinition(id);
+          stateMachine.requireDefinitionMutable(locked.desiredState(), locked.observedState());
+          requirePreparedDefinitionCurrent(prepared, locked);
+          store.publish(
+              id, prepared.definition().definitionVersion(), prepared.definition().configDigest());
+          store.event(
+              id,
+              null,
+              "PUBLISHED",
+              locked.releaseState(),
+              "PUBLISHED",
+              "Flink CDC 校验通过，任务已发布");
         });
   }
 
@@ -157,6 +178,7 @@ public class RealtimeJobService {
                 status -> {
                   DefinitionRow locked = store.lockDefinition(id);
                   requirePublished(locked);
+                  requirePreparedDefinitionCurrent(prepared, locked);
                   stateMachine.requireTransition(locked.observedState(), "STARTING");
                   long created =
                       store.insertDeployment(
@@ -283,7 +305,12 @@ public class RealtimeJobService {
   }
 
   public void delete(long id) {
-    transactions.executeWithoutResult(status -> store.delete(id));
+    transactions.executeWithoutResult(
+        status -> {
+          DefinitionRow locked = store.lockDefinition(id);
+          stateMachine.requireDefinitionMutable(locked.desiredState(), locked.observedState());
+          store.delete(id);
+        });
   }
 
   public List<RealtimeJobEventView> events(long id) {
@@ -457,6 +484,14 @@ public class RealtimeJobService {
         || definition.publishedVersion() == null
         || definition.publishedVersion() != definition.definitionVersion()) {
       throw new IllegalStateException("请先发布当前定义版本");
+    }
+  }
+
+  private void requirePreparedDefinitionCurrent(Prepared prepared, DefinitionRow current) {
+    DefinitionRow snapshot = prepared.definition();
+    if (snapshot.definitionVersion() != current.definitionVersion()
+        || !Objects.equals(snapshot.configDigest(), current.configDigest())) {
+      throw new IllegalStateException("任务定义在校验期间已变化，请刷新后重试");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
@@ -27,4 +27,25 @@ class RealtimeStateMachineTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("非法实时任务状态迁移");
   }
+
+  @Test
+  void allowsDefinitionMutationOnlyWhenRuntimeIsStable() {
+    assertThatCode(() -> stateMachine.requireDefinitionMutable("STOPPED", "STOPPED"))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> stateMachine.requireDefinitionMutable("STOPPED", "FAILED"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void rejectsDefinitionMutationForActiveOrUncertainRuntime() {
+    assertThatThrownBy(() -> stateMachine.requireDefinitionMutable("RUNNING", "RUNNING"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("运行态未稳定");
+    assertThatThrownBy(() -> stateMachine.requireDefinitionMutable("STOPPED", "UNKNOWN"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("运行态未稳定");
+    assertThatThrownBy(() -> stateMachine.requireDefinitionMutable("STOPPED", "CONFLICT"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("运行态未稳定");
+  }
 }


### PR DESCRIPTION
## 背景

实时同步当前已经拆分了 `release_state / desired_state / observed_state` 三条状态轴，但配置变更边界仍有两个风险：

- `desired_state=STOPPED` 但 `observed_state=UNKNOWN/CONFLICT` 时，仍可能编辑、发布或删除任务；此时 Flink 真实运行态并不确定。
- 发布流程先执行 Flink CDC 校验、再更新发布状态。校验期间如果定义被修改，可能把未经本次校验的新版本标记为已发布。

本 PR 只处理第一阶段的“任务状态模型治理”，不包含启停并发、日志、指标或远程执行改造。

## 改动

- 增加统一的 definition mutation 状态策略：只有 `desired=STOPPED` 且 `observed=STOPPED/FAILED` 时允许编辑、发布、删除。
- Repository 层同步增加 SQL 条件兜底，阻止 `UNKNOWN / CONFLICT / STARTING / STOPPING / RUNNING` 等状态绕过 Service 直接修改定义。
- 编辑任务时先锁定 definition，再记录真实的 release state 变化，避免事件固定写成 `DRAFT -> DRAFT`。
- 发布任务时绑定本次校验的 `definitionVersion + configDigest`；校验期间定义发生变化则拒绝发布，要求刷新后重新校验。
- 启动任务在正式创建 deployment 前确认准备阶段的 definition snapshot 仍是当前版本，避免使用旧 Spec 配合新 definitionVersion 提交。
- 删除任务前锁定 definition 并应用统一状态策略。
- 增加状态边界测试，覆盖 STOPPED/FAILED 可修改以及 RUNNING/UNKNOWN/CONFLICT 禁止修改。

## 状态边界

允许 definition 变更：

- `desired=STOPPED, observed=STOPPED`
- `desired=STOPPED, observed=FAILED`

禁止 definition 变更：

- RUNNING
- STARTING
- STOPPING
- UNKNOWN
- CONFLICT

`validate()` 仍然只做配置/Flink CDC 校验，不修改 release/runtime 状态。

## 验证

- 已补 `RealtimeStateMachineTest` 状态边界用例。
- 当前环境无法直接拉取仓库执行 Maven 本地测试，待 GitHub Actions/CI 结果进一步确认。

## 后续

启停幂等、多实例并发、Flink Job 生命周期对账属于后续独立改造，不在本 PR 范围内。