### PR TITLE
fix(realtime): harden lifecycle idempotency and concurrency

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
@@ -139,8 +139,10 @@ public class RealtimeJobController {
   @Operation(summary = "重启实时同步任务")
   @PostMapping("/{id}/restart")
   @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeJobView.Deployment> restart(@PathVariable long id) {
-    return Result.success(service.restart(id));
+  public Result<RealtimeJobView.Deployment> restart(
+      @PathVariable long id,
+      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
+    return Result.success(service.restart(id, key));
   }
 
   @Operation(summary = "立即对账实时同步任务")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
@@ -42,7 +42,11 @@ public class RealtimeStateMachine {
         ObservedState.CONFLICT);
     allow(
         ObservedState.STOPPING, ObservedState.STOPPED, ObservedState.FAILED, ObservedState.UNKNOWN);
-    allow(ObservedState.FAILED, ObservedState.STOPPED, ObservedState.STARTING);
+    allow(
+        ObservedState.FAILED,
+        ObservedState.STOPPED,
+        ObservedState.STARTING,
+        ObservedState.STOPPING);
     allow(
         ObservedState.UNKNOWN,
         ObservedState.RUNNING,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
@@ -14,6 +14,8 @@ public class RealtimeStateMachine {
 
   private static final EnumSet<ObservedState> DEFINITION_MUTABLE_STATES =
       EnumSet.of(ObservedState.STOPPED, ObservedState.FAILED);
+  private static final EnumSet<ObservedState> STARTABLE_STATES =
+      EnumSet.of(ObservedState.STOPPED, ObservedState.FAILED);
 
   private final Map<ObservedState, EnumSet<ObservedState>> transitions =
       new EnumMap<>(ObservedState.class);
@@ -78,6 +80,15 @@ public class RealtimeStateMachine {
     if (desired != DesiredState.STOPPED || !DEFINITION_MUTABLE_STATES.contains(observed)) {
       throw new IllegalStateException(
           "任务运行态未稳定，只有已停止或明确失败的任务才能编辑、发布或删除");
+    }
+  }
+
+  /** A new deployment may only reserve a task that is definitely not active. */
+  public void requireStartable(String desiredValue, String observedValue) {
+    DesiredState desired = DesiredState.valueOf(desiredValue);
+    ObservedState observed = ObservedState.valueOf(observedValue);
+    if (desired != DesiredState.STOPPED || !STARTABLE_STATES.contains(observed)) {
+      throw new IllegalStateException("任务已在启动、运行或停止过程中，请勿重复启动");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -189,31 +189,58 @@ public class RealtimeJobStore {
     return Objects.requireNonNull(keys.getKey(), "新增部署未返回主键").longValue();
   }
 
+  /** Claims the lifecycle slot for a new deployment. The SQL predicate is a defensive CAS guard. */
   public void markStarting(long definitionId) {
-    db.update(
-        "update yak_realtime_job_definition set desired_state='RUNNING',"
-            + "observed_state='STARTING',last_error=null where id=?",
-        definitionId);
+    int changed =
+        db.update(
+            "update yak_realtime_job_definition set desired_state='RUNNING',"
+                + "observed_state='STARTING',last_error=null where id=? "
+                + "and desired_state='STOPPED' and observed_state in ('STOPPED','FAILED')",
+            definitionId);
+    if (changed != 1) {
+      throw new IllegalStateException("任务已被其他启动或停止请求抢占，请刷新后重试");
+    }
   }
 
+  /** Completes STARTING only while no concurrent stop request has changed the desired state. */
   public void markDeploymentRunning(
       long definitionId, long deploymentId, String engineJobId, String runtimeRevision) {
     db.update(
         "update yak_realtime_job_deployment set"
-            + " gateway_job_id=?,runtime_version=?,runtime_revision=?,status='RUNNING',result_uncertain=0,error_message=null"
-            + " where id=?",
+            + " gateway_job_id=?,runtime_version=?,runtime_revision=?,status='RUNNING',"
+            + "result_uncertain=0,error_message=null where id=?",
         engineJobId,
         runtimeRevision,
         runtimeRevision,
         deploymentId);
+    int changed =
+        db.update(
+            "update yak_realtime_job_definition set observed_state='RUNNING',last_error=null "
+                + "where id=? and desired_state='RUNNING' and observed_state='STARTING'",
+            definitionId);
+    if (changed != 1) {
+      throw new IllegalStateException("启动完成前任务状态已变化，不能覆盖当前运行意图");
+    }
+  }
+
+  /** Binds the real Flink job before cancelling a submission that raced with a stop request. */
+  public void bindDeploymentForStop(
+      long deploymentId, String engineJobId, String runtimeRevision) {
     db.update(
-        "update yak_realtime_job_definition set observed_state='RUNNING',last_error=null where"
-            + " id=?",
-        definitionId);
+        "update yak_realtime_job_deployment set gateway_job_id=?,runtime_version=?,"
+            + "runtime_revision=?,status='STOPPING',result_uncertain=0,error_message=null where id=?",
+        engineJobId,
+        runtimeRevision,
+        runtimeRevision,
+        deploymentId);
   }
 
   public void markDeployFailure(
-      long definitionId, long deploymentId, boolean uncertain, String message) {
+      long definitionId,
+      long deploymentId,
+      boolean uncertain,
+      boolean stopRequested,
+      String message) {
     db.update(
         "update yak_realtime_job_deployment set status=?,result_uncertain=?,error_message=? where"
             + " id=?",
@@ -221,10 +248,11 @@ public class RealtimeJobStore {
         uncertain,
         message,
         deploymentId);
+    String desiredState = stopRequested ? "STOPPED" : (uncertain ? "RUNNING" : "STOPPED");
     db.update(
         "update yak_realtime_job_definition set desired_state=?,observed_state=?,last_error=? where"
             + " id=?",
-        uncertain ? "RUNNING" : "STOPPED",
+        desiredState,
         uncertain ? "UNKNOWN" : "FAILED",
         message,
         definitionId);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -269,12 +269,7 @@ public class RealtimeJobService {
 
               String from = current.observedState();
               if (!"STOPPING".equals(from)) {
-                try {
-                  stateMachine.requireTransition(from, "STOPPING");
-                } catch (IllegalStateException ignored) {
-                  // A concurrent reconciler may already have moved the state to a terminal or
-                  // uncertain value. Never restore RUNNING from that stale STARTING snapshot.
-                }
+                stateMachine.requireTransition(from, "STOPPING");
                 store.markStopping(id, deploymentId);
               }
               store.bindDeploymentForStop(deploymentId, result.jobId(), prepared.runtimeRevision());
@@ -487,7 +482,9 @@ public class RealtimeJobService {
           // Another Yak Ops instance may still be inside the synchronous CLI submission. An
           // uncertain submission without a jobId also requires operator verification in Flink UI;
           // it must not be converted into a definite failure by the reconciler.
-          if (!"STARTING".equals(job.observedState()) && !"UNKNOWN".equals(job.observedState())) {
+          if (!"STARTING".equals(job.observedState())
+              && !"STOPPING".equals(job.observedState())
+              && !"UNKNOWN".equals(job.observedState())) {
             reconcile(job, deployment, new RuntimeStatus(null, RuntimeStatus.State.NONE));
           }
           continue;
@@ -563,7 +560,8 @@ public class RealtimeJobService {
     transactions.executeWithoutResult(
         status -> {
           DefinitionRow current = store.lockDefinition(job.id());
-          if (!sameLifecycleSnapshot(job, current)) {
+          if (!sameLifecycleSnapshot(job, current)
+              || !sameDeploymentSnapshot(job.id(), deployment)) {
             return;
           }
           stateMachine.requireTransition(current.observedState(), "FAILED");
@@ -587,7 +585,8 @@ public class RealtimeJobService {
     transactions.executeWithoutResult(
         status -> {
           DefinitionRow current = store.lockDefinition(job.id());
-          if (!sameLifecycleSnapshot(job, current)) {
+          if (!sameLifecycleSnapshot(job, current)
+              || !sameDeploymentSnapshot(job.id(), deployment)) {
             return;
           }
           stateMachine.requireTransition(current.observedState(), observed);
@@ -657,10 +656,10 @@ public class RealtimeJobService {
         Thread.sleep(250);
       } catch (InterruptedException exception) {
         Thread.currentThread().interrupt();
-        throw new IllegalStateException("等待 Flink 停止时被中断", exception);
+        throw new RealtimeEngineException("等待 Flink 停止时被中断", true, null, exception);
       }
     }
-    throw new IllegalStateException("Flink 任务未在 5 秒内停止，请稍后再重启");
+    throw new RealtimeEngineException("Flink 任务未在 5 秒内停止，等待后续对账", true, null, null);
   }
 
   private void markStopped(long definitionId, long deploymentId, String jobId, String message) {
@@ -700,6 +699,16 @@ public class RealtimeJobService {
   private boolean sameLifecycleSnapshot(DefinitionRow expected, DefinitionRow current) {
     return Objects.equals(expected.desiredState(), current.desiredState())
         && Objects.equals(expected.observedState(), current.observedState());
+  }
+
+  private boolean sameDeploymentSnapshot(long definitionId, DeploymentRow expected) {
+    DeploymentRow current = store.latestDeployment(definitionId).orElse(null);
+    if (expected == null) {
+      return current == null;
+    }
+    return current != null
+        && current.id() == expected.id()
+        && Objects.equals(current.engineJobId(), expected.engineJobId());
   }
 
   private ReentrantLock lifecycleLock(long id) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -53,7 +53,7 @@ public class RealtimeJobService {
   private final RealtimeLogRedactor logRedactor;
   private final TransactionTemplate transactions;
   private final RealtimeSyncProperties properties;
-  private final ReentrantLock lifecycleLock = new ReentrantLock();
+  private final ConcurrentHashMap<Long, ReentrantLock> lifecycleLocks = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<Long, AtomicInteger> consecutiveEngineFailures =
       new ConcurrentHashMap<>();
 
@@ -158,150 +158,281 @@ public class RealtimeJobService {
   }
 
   public RealtimeJobView.Deployment start(long id, String requestedKey) {
-    lifecycleLock.lock();
+    ReentrantLock lock = lifecycleLock(id);
+    lock.lock();
     try {
-      Prepared prepared = prepare(id, true);
-      String key = normalizeKey(requestedKey);
-      DeploymentRow existing = store.deploymentByIdempotencyKey(key).orElse(null);
-      if (existing != null) {
-        if (existing.definitionId() != id) {
-          throw new IllegalStateException("幂等键已被其他实时任务使用");
-        }
-        return store.deploymentView(existing);
-      }
+      return startLocked(id, requestedKey);
+    } finally {
+      lock.unlock();
+    }
+  }
 
-      gateway.validate(prepared.compiled().yaml());
-      Long deploymentId;
-      try {
-        deploymentId =
-            transactions.execute(
-                status -> {
-                  DefinitionRow locked = store.lockDefinition(id);
-                  requirePublished(locked);
-                  requirePreparedDefinitionCurrent(prepared, locked);
-                  stateMachine.requireTransition(locked.observedState(), "STARTING");
-                  long created =
-                      store.insertDeployment(
-                          locked,
-                          prepared.spec(),
-                          prepared.compiled().summary(),
-                          digest(prepared.compiled().yaml()),
-                          key);
-                  store.markStarting(id);
-                  store.event(
-                      id,
-                      created,
-                      "START_REQUESTED",
-                      locked.observedState(),
-                      "STARTING",
-                      "开始通过 Flink CDC CLI 提交任务");
-                  return created;
-                });
-      } catch (DuplicateKeyException exception) {
-        DeploymentRow raced =
-            store
-                .deploymentByIdempotencyKey(key)
-                .orElseThrow(() -> new IllegalStateException("幂等部署冲突", exception));
-        if (raced.definitionId() != id) {
-          throw new IllegalStateException("幂等键已被其他实时任务使用");
-        }
-        return store.deploymentView(raced);
-      }
+  private RealtimeJobView.Deployment startLocked(long id, String requestedKey) {
+    String key = normalizeKey(requestedKey);
+    DeploymentRow existing = idempotentDeployment(id, key);
+    if (existing != null) {
+      return store.deploymentView(existing);
+    }
 
-      long deployment = deploymentId == null ? 0 : deploymentId;
-      try {
-        RealtimeEngineGateway.DeployResult result = deploy(prepared, key);
-        transactions.executeWithoutResult(
+    Prepared prepared = prepare(id, true);
+    gateway.validate(prepared.compiled().yaml());
+
+    StartReservation reservation;
+    try {
+      reservation =
+          transactions.execute(
+              status -> {
+                DefinitionRow locked = store.lockDefinition(id);
+
+                // The first check happens outside the transaction for the common retry path. This
+                // second check is required for two Yak Ops instances racing with the same key.
+                DeploymentRow duplicate = idempotentDeployment(id, key);
+                if (duplicate != null) {
+                  return new StartReservation(duplicate.id(), false);
+                }
+
+                requirePublished(locked);
+                requirePreparedDefinitionCurrent(prepared, locked);
+                stateMachine.requireStartable(locked.desiredState(), locked.observedState());
+                stateMachine.requireTransition(locked.observedState(), "STARTING");
+                long created =
+                    store.insertDeployment(
+                        locked,
+                        prepared.spec(),
+                        prepared.compiled().summary(),
+                        digest(prepared.compiled().yaml()),
+                        key);
+                store.markStarting(id);
+                store.event(
+                    id,
+                    created,
+                    "START_REQUESTED",
+                    locked.observedState(),
+                    "STARTING",
+                    "开始通过 Flink CDC CLI 提交任务");
+                return new StartReservation(created, true);
+              });
+    } catch (DuplicateKeyException exception) {
+      DeploymentRow raced =
+          store
+              .deploymentByIdempotencyKey(key)
+              .orElseThrow(() -> new IllegalStateException("幂等部署冲突", exception));
+      requireIdempotencyOwner(id, raced);
+      return store.deploymentView(raced);
+    }
+
+    if (reservation == null) {
+      throw new IllegalStateException("未能创建实时同步启动预留");
+    }
+    if (!reservation.created()) {
+      DeploymentRow duplicate =
+          store
+              .deploymentByIdempotencyKey(key)
+              .orElseThrow(() -> new IllegalStateException("幂等部署记录不存在"));
+      requireIdempotencyOwner(id, duplicate);
+      return store.deploymentView(duplicate);
+    }
+
+    RealtimeEngineGateway.DeployResult result;
+    try {
+      result = deploy(prepared, key);
+    } catch (RealtimeEngineException exception) {
+      markStartFailure(id, reservation.deploymentId(), exception);
+      throw exception;
+    }
+
+    return completeStart(id, reservation.deploymentId(), prepared, result);
+  }
+
+  /**
+   * Finishes a successful CLI submission without overwriting a concurrent stop request. If stop
+   * won the race while the CLI was running, bind the returned JobId first and immediately cancel
+   * that exact Flink job.
+   */
+  private RealtimeJobView.Deployment completeStart(
+      long id,
+      long deploymentId,
+      Prepared prepared,
+      RealtimeEngineGateway.DeployResult result) {
+    Boolean cancelAfterSubmit =
+        transactions.execute(
             status -> {
-              store.markDeploymentRunning(
-                  id, deployment, result.jobId(), prepared.runtimeRevision());
-              store.event(id, deployment, "STARTED", "STARTING", "RUNNING", "Flink 已接受任务");
-            });
-      } catch (RealtimeEngineException exception) {
-        transactions.executeWithoutResult(
-            status -> {
-              store.markDeployFailure(
-                  id, deployment, exception.uncertain(), exception.getMessage());
+              DefinitionRow current = store.lockDefinition(id);
+              if ("RUNNING".equals(current.desiredState())
+                  && "STARTING".equals(current.observedState())) {
+                store.markDeploymentRunning(
+                    id, deploymentId, result.jobId(), prepared.runtimeRevision());
+                store.event(
+                    id, deploymentId, "STARTED", "STARTING", "RUNNING", "Flink 已接受任务");
+                return false;
+              }
+
+              String from = current.observedState();
+              if (!"STOPPING".equals(from)) {
+                try {
+                  stateMachine.requireTransition(from, "STOPPING");
+                } catch (IllegalStateException ignored) {
+                  // A concurrent reconciler may already have moved the state to a terminal or
+                  // uncertain value. Never restore RUNNING from that stale STARTING snapshot.
+                }
+                store.markStopping(id, deploymentId);
+              }
+              store.bindDeploymentForStop(deploymentId, result.jobId(), prepared.runtimeRevision());
               store.event(
                   id,
-                  deployment,
-                  exception.uncertain() ? "START_UNCERTAIN" : "START_FAILED",
-                  "STARTING",
-                  exception.uncertain() ? "UNKNOWN" : "FAILED",
-                  exception.getMessage());
+                  deploymentId,
+                  "START_CANCEL_PENDING",
+                  from,
+                  "STOPPING",
+                  "启动提交已返回，但期间运行意图已变化，立即取消该 Flink 任务");
+              return true;
             });
-        throw exception;
-      }
-      return store.deploymentView(
-          store.latestDeployment(id).orElseThrow(() -> new IllegalStateException("部署记录不存在")));
-    } finally {
-      lifecycleLock.unlock();
+
+    if (Boolean.TRUE.equals(cancelAfterSubmit)) {
+      stopBoundJob(id, deploymentId, result.jobId(), "并发停止请求已取消刚提交的 Flink 任务");
     }
+    return store.deploymentView(
+        store.latestDeployment(id).orElseThrow(() -> new IllegalStateException("部署记录不存在")));
+  }
+
+  private void markStartFailure(long id, long deploymentId, RealtimeEngineException exception) {
+    transactions.executeWithoutResult(
+        status -> {
+          DefinitionRow current = store.lockDefinition(id);
+          boolean stopRequested = "STOPPED".equals(current.desiredState());
+          String target = exception.uncertain() ? "UNKNOWN" : "FAILED";
+          stateMachine.requireTransition(current.observedState(), target);
+          store.markDeployFailure(
+              id,
+              deploymentId,
+              exception.uncertain(),
+              stopRequested,
+              exception.getMessage());
+          store.event(
+              id,
+              deploymentId,
+              exception.uncertain() ? "START_UNCERTAIN" : "START_FAILED",
+              current.observedState(),
+              target,
+              exception.getMessage());
+        });
   }
 
   public void stop(long id) {
-    lifecycleLock.lock();
+    ReentrantLock lock = lifecycleLock(id);
+    lock.lock();
     try {
-      DefinitionRow definition =
-          store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
-      DeploymentRow deployment = store.latestDeployment(id).orElse(null);
-      if ("STOPPED".equals(definition.desiredState())
-          && "STOPPED".equals(definition.observedState())) {
-        return;
-      }
-      String jobId = deployment == null ? null : deployment.engineJobId();
-      RuntimeStatus runtime =
-          StringUtils.hasText(jobId)
-              ? gateway.status(jobId)
-              : new RuntimeStatus(null, RuntimeStatus.State.NONE);
-      transactions.executeWithoutResult(
-          status -> {
-            stateMachine.requireTransition(definition.observedState(), "STOPPING");
-            store.markStopping(id, deployment == null ? null : deployment.id());
-            store.event(
-                id,
-                deployment == null ? null : deployment.id(),
-                "STOP_REQUESTED",
-                definition.observedState(),
-                "STOPPING",
-                "已请求 Flink 停止当前任务");
-          });
-      try {
-        if (runtime.state() == RuntimeStatus.State.RUNNING) {
-          gateway.stop(jobId);
-          waitForRuntimeStop(jobId);
-          markStopped(id, deployment, "Flink 已停止任务");
-        } else {
-          markStopped(id, deployment, "Flink 中已无活动任务");
-        }
-      } catch (RealtimeEngineException exception) {
-        transactions.executeWithoutResult(
-            status -> {
-              store.reconcile(
-                  id,
-                  deployment == null ? null : deployment.id(),
-                  "UNKNOWN",
-                  "UNKNOWN",
-                  deployment == null ? null : deployment.engineJobId(),
-                  exception.getMessage());
-              store.event(
-                  id,
-                  deployment == null ? null : deployment.id(),
-                  "STOP_UNCERTAIN",
-                  "STOPPING",
-                  "UNKNOWN",
-                  exception.getMessage());
-            });
-        throw exception;
-      }
+      stopLocked(id);
     } finally {
-      lifecycleLock.unlock();
+      lock.unlock();
     }
   }
 
+  private void stopLocked(long id) {
+    StopReservation reservation =
+        transactions.execute(
+            status -> {
+              DefinitionRow current = store.lockDefinition(id);
+              DeploymentRow deployment = store.latestDeployment(id).orElse(null);
+
+              if ("STOPPED".equals(current.desiredState())
+                  && ("STOPPED".equals(current.observedState())
+                      || "FAILED".equals(current.observedState()))) {
+                return new StopReservation(deployment, true, false);
+              }
+              if ("STOPPED".equals(current.desiredState())
+                  && "STOPPING".equals(current.observedState())) {
+                return new StopReservation(deployment, false, true);
+              }
+
+              stateMachine.requireTransition(current.observedState(), "STOPPING");
+              store.markStopping(id, deployment == null ? null : deployment.id());
+              store.event(
+                  id,
+                  deployment == null ? null : deployment.id(),
+                  "STOP_REQUESTED",
+                  current.observedState(),
+                  "STOPPING",
+                  "已请求 Flink 停止当前任务");
+              return new StopReservation(deployment, false, false);
+            });
+
+    if (reservation == null || reservation.settled() || reservation.inProgress()) {
+      return;
+    }
+
+    DeploymentRow deployment = reservation.deployment();
+    if (deployment == null || !StringUtils.hasText(deployment.engineJobId())) {
+      // STARTING may still be blocked inside the synchronous Flink CDC CLI. Keep STOPPING instead
+      // of pretending the task is stopped. The start owner will bind the returned JobId and cancel
+      // it in completeStart().
+      return;
+    }
+
+    stopBoundJob(id, deployment.id(), deployment.engineJobId(), "Flink 已停止任务");
+  }
+
+  private void stopBoundJob(long id, long deploymentId, String jobId, String successMessage) {
+    DeploymentRow deployment = store.latestDeployment(id).orElse(null);
+    try {
+      RuntimeStatus runtime = gateway.status(jobId);
+      if (runtime.state() == RuntimeStatus.State.RUNNING) {
+        gateway.stop(jobId);
+        waitForRuntimeStop(jobId);
+      } else if (runtime.state() == RuntimeStatus.State.UNKNOWN) {
+        throw new RealtimeEngineException("Flink 状态未知，无法确认停止结果", true, null, null);
+      }
+      markStopped(id, deploymentId, jobId, successMessage);
+    } catch (RealtimeEngineException exception) {
+      markStopUncertain(id, deployment, deploymentId, jobId, exception.getMessage());
+      throw exception;
+    }
+  }
+
+  private void markStopUncertain(
+      long id, DeploymentRow deployment, long deploymentId, String jobId, String message) {
+    transactions.executeWithoutResult(
+        status -> {
+          DefinitionRow current = store.lockDefinition(id);
+          stateMachine.requireTransition(current.observedState(), "UNKNOWN");
+          store.reconcile(id, deploymentId, "UNKNOWN", "UNKNOWN", jobId, message);
+          store.event(
+              id,
+              deployment == null ? deploymentId : deployment.id(),
+              "STOP_UNCERTAIN",
+              current.observedState(),
+              "UNKNOWN",
+              message);
+        });
+  }
+
+  public RealtimeJobView.Deployment restart(long id, String requestedKey) {
+    ReentrantLock lock = lifecycleLock(id);
+    lock.lock();
+    try {
+      String key = normalizeKey(requestedKey);
+      DeploymentRow existing = idempotentDeployment(id, key);
+      if (existing != null) {
+        return store.deploymentView(existing);
+      }
+
+      stopLocked(id);
+      DefinitionRow current =
+          store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+      if (!"STOPPED".equals(current.desiredState())
+          || !("STOPPED".equals(current.observedState())
+              || "FAILED".equals(current.observedState()))) {
+        throw new IllegalStateException("任务仍在停止中，请稍后使用相同 Idempotency-Key 重试重启");
+      }
+      return startLocked(id, key);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Compatibility entry point for callers that do not yet send an idempotency key. */
   public RealtimeJobView.Deployment restart(long id) {
-    stop(id);
-    return start(id, UUID.randomUUID().toString());
+    return restart(id, null);
   }
 
   public void delete(long id) {
@@ -340,10 +471,17 @@ public class RealtimeJobService {
   }
 
   public void reconcile() {
-    lifecycleLock.lock();
-    try {
-      List<DefinitionRow> candidates = store.desiredJobs();
-      for (DefinitionRow job : candidates) {
+    List<DefinitionRow> candidates = store.desiredJobs();
+    for (DefinitionRow snapshot : candidates) {
+      ReentrantLock lock = lifecycleLock(snapshot.id());
+      if (!lock.tryLock()) {
+        continue;
+      }
+      try {
+        DefinitionRow job = store.definition(snapshot.id()).orElse(null);
+        if (job == null) {
+          continue;
+        }
         DeploymentRow deployment = store.latestDeployment(job.id()).orElse(null);
         if (deployment == null || !StringUtils.hasText(deployment.engineJobId())) {
           // Another Yak Ops instance may still be inside the synchronous CLI submission. An
@@ -369,15 +507,16 @@ public class RealtimeJobService {
                 job, deployment, "UNKNOWN", "UNKNOWN", deployment.engineJobId(), "Flink 状态不可用");
           }
         }
+      } finally {
+        lock.unlock();
       }
-    } finally {
-      lifecycleLock.unlock();
     }
   }
 
   /** Performs an operator-requested reconciliation without submitting a new Flink job. */
   public RealtimeJobView reconcile(long id) {
-    lifecycleLock.lock();
+    ReentrantLock lock = lifecycleLock(id);
+    lock.lock();
     try {
       DefinitionRow definition =
           store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
@@ -386,7 +525,7 @@ public class RealtimeJobService {
       consecutiveEngineFailures.remove(id);
       return store.view(id);
     } finally {
-      lifecycleLock.unlock();
+      lock.unlock();
     }
   }
 
@@ -423,9 +562,14 @@ public class RealtimeJobService {
             : "Flink 中未找到期望运行的任务；为避免重复回放，不自动重新提交";
     transactions.executeWithoutResult(
         status -> {
+          DefinitionRow current = store.lockDefinition(job.id());
+          if (!sameLifecycleSnapshot(job, current)) {
+            return;
+          }
+          stateMachine.requireTransition(current.observedState(), "FAILED");
           store.markTerminalFailure(job.id(), deploymentId, message);
           store.event(
-              job.id(), deploymentId, "FLINK_JOB_LOST", job.observedState(), "FAILED", message);
+              job.id(), deploymentId, "FLINK_JOB_LOST", current.observedState(), "FAILED", message);
         });
   }
 
@@ -440,9 +584,13 @@ public class RealtimeJobService {
         && (error == null ? job.lastError() == null : error.equals(job.lastError()))) {
       return;
     }
-    stateMachine.requireTransition(job.observedState(), observed);
     transactions.executeWithoutResult(
         status -> {
+          DefinitionRow current = store.lockDefinition(job.id());
+          if (!sameLifecycleSnapshot(job, current)) {
+            return;
+          }
+          stateMachine.requireTransition(current.observedState(), observed);
           store.reconcile(
               job.id(),
               deployment == null ? null : deployment.id(),
@@ -454,7 +602,7 @@ public class RealtimeJobService {
               job.id(),
               deployment == null ? null : deployment.id(),
               "STATE_RECONCILED",
-              job.observedState(),
+              current.observedState(),
               observed,
               error == null ? "Flink 状态已对账" : error);
         });
@@ -498,8 +646,12 @@ public class RealtimeJobService {
   private void waitForRuntimeStop(String jobId) {
     for (int attempt = 0; attempt < 20; attempt++) {
       RuntimeStatus status = gateway.status(jobId);
-      if (status.state() != RuntimeStatus.State.RUNNING) {
+      if (status.state() == RuntimeStatus.State.TERMINATED
+          || status.state() == RuntimeStatus.State.NONE) {
         return;
+      }
+      if (status.state() == RuntimeStatus.State.UNKNOWN) {
+        throw new RealtimeEngineException("Flink 停止状态未知，等待后续对账", true, null, null);
       }
       try {
         Thread.sleep(250);
@@ -511,25 +663,47 @@ public class RealtimeJobService {
     throw new IllegalStateException("Flink 任务未在 5 秒内停止，请稍后再重启");
   }
 
-  private void markStopped(long definitionId, DeploymentRow deployment, String message) {
+  private void markStopped(long definitionId, long deploymentId, String jobId, String message) {
     transactions.executeWithoutResult(
         status -> {
-          stateMachine.requireTransition("STOPPING", "STOPPED");
-          store.reconcile(
-              definitionId,
-              deployment == null ? null : deployment.id(),
-              "STOPPED",
-              "STOPPED",
-              deployment == null ? null : deployment.engineJobId(),
-              null);
+          DefinitionRow current = store.lockDefinition(definitionId);
+          if ("STOPPED".equals(current.desiredState())
+              && "STOPPED".equals(current.observedState())) {
+            return;
+          }
+          stateMachine.requireTransition(current.observedState(), "STOPPED");
+          store.reconcile(definitionId, deploymentId, "STOPPED", "STOPPED", jobId, null);
           store.event(
               definitionId,
-              deployment == null ? null : deployment.id(),
+              deploymentId,
               "STOPPED",
-              "STOPPING",
+              current.observedState(),
               "STOPPED",
               message);
         });
+  }
+
+  private DeploymentRow idempotentDeployment(long id, String key) {
+    DeploymentRow existing = store.deploymentByIdempotencyKey(key).orElse(null);
+    if (existing != null) {
+      requireIdempotencyOwner(id, existing);
+    }
+    return existing;
+  }
+
+  private void requireIdempotencyOwner(long id, DeploymentRow deployment) {
+    if (deployment.definitionId() != id) {
+      throw new IllegalStateException("幂等键已被其他实时任务使用");
+    }
+  }
+
+  private boolean sameLifecycleSnapshot(DefinitionRow expected, DefinitionRow current) {
+    return Objects.equals(expected.desiredState(), current.desiredState())
+        && Objects.equals(expected.observedState(), current.observedState());
+  }
+
+  private ReentrantLock lifecycleLock(long id) {
+    return lifecycleLocks.computeIfAbsent(id, ignored -> new ReentrantLock());
   }
 
   private String normalizeKey(String requestedKey) {
@@ -594,4 +768,8 @@ public class RealtimeJobService {
       CompiledPipeline compiled,
       String runtimeRevision,
       JsonNode manifest) {}
+
+  private record StartReservation(long deploymentId, boolean created) {}
+
+  private record StopReservation(DeploymentRow deployment, boolean settled, boolean inProgress) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
@@ -48,4 +48,31 @@ class RealtimeStateMachineTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("运行态未稳定");
   }
+
+  @Test
+  void allowsStartOnlyFromDefinitelyInactiveStates() {
+    assertThatCode(() -> stateMachine.requireStartable("STOPPED", "STOPPED"))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> stateMachine.requireStartable("STOPPED", "FAILED"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void rejectsDuplicateOrUncertainStartReservations() {
+    assertThatThrownBy(() -> stateMachine.requireStartable("RUNNING", "STARTING"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+    assertThatThrownBy(() -> stateMachine.requireStartable("RUNNING", "RUNNING"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+    assertThatThrownBy(() -> stateMachine.requireStartable("STOPPED", "STOPPING"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+    assertThatThrownBy(() -> stateMachine.requireStartable("STOPPED", "UNKNOWN"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+    assertThatThrownBy(() -> stateMachine.requireStartable("STOPPED", "CONFLICT"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
@@ -19,6 +19,8 @@ class RealtimeStateMachineTest {
         .doesNotThrowAnyException();
     assertThatCode(() -> stateMachine.requireTransition("CONFLICT", "RUNNING"))
         .doesNotThrowAnyException();
+    assertThatCode(() -> stateMachine.requireTransition("FAILED", "STOPPING"))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
@@ -1,0 +1,185 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.MatchMode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.RestartPolicy;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.SchemaEvolution;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.SinkTuning;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.TableRoute;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDeployRequest.CredentialBinding;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.DeployResult;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.RuntimeStatus;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.ValidationResult;
+import io.yak.ops.business.sync.realtime.engine.RealtimeLogRedactor;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RealtimeJobServiceConcurrencyTest {
+
+  private static final long JOB_ID = 7L;
+  private static final long DEPLOYMENT_ID = 19L;
+
+  private RealtimeJobStore store;
+  private CdcPipelineSpecValidator specValidator;
+  private RealtimeDataSourceResolver dataSourceResolver;
+  private RealtimeConnectorCapabilityResolver capabilityResolver;
+  private PipelineYamlCompiler compiler;
+  private RealtimeEngineGateway gateway;
+  private RealtimeJobService service;
+  private CdcPipelineSpec spec;
+  private DefinitionRow stopped;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    specValidator = mock(CdcPipelineSpecValidator.class);
+    dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    capabilityResolver = mock(RealtimeConnectorCapabilityResolver.class);
+    compiler = mock(PipelineYamlCompiler.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    RealtimeLogRedactor logRedactor = mock(RealtimeLogRedactor.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenAnswer(ignored -> new SimpleTransactionStatus());
+
+    ObjectMapper json = new ObjectMapper();
+    ObjectNode capabilities = json.createObjectNode().put("runtimeVersion", "3.6.0");
+    when(gateway.capabilities()).thenReturn(capabilities);
+    when(gateway.validate(any())).thenReturn(new ValidationResult(true, "exactly-once"));
+    when(compiler.compile(any(), any(), any())).thenReturn(new CompiledPipeline("pipeline: test", "test"));
+
+    spec =
+        new CdcPipelineSpec(
+            1L,
+            2L,
+            List.of(new TableRoute("source_table", "sink_table", MatchMode.EXACT, List.of("id"))),
+            "initial",
+            SchemaEvolution.EVOLVE,
+            1,
+            10_000,
+            new RestartPolicy("none", 0, 0),
+            new SinkTuning(0, 100, 1000, 1024, 16, true));
+    stopped = definition("STOPPED", "STOPPED");
+    when(store.spec(any())).thenReturn(spec);
+
+    service =
+        new RealtimeJobService(
+            store,
+            json,
+            specValidator,
+            new RealtimeStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            logRedactor,
+            new RealtimeSyncProperties(),
+            transactionManager);
+  }
+
+  @Test
+  void rejectsDifferentKeyWhenAnotherInstanceAlreadyClaimedStarting() {
+    when(store.deploymentByIdempotencyKey("start-2")).thenReturn(Optional.empty());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
+    when(store.lockDefinition(JOB_ID)).thenReturn(definition("RUNNING", "STARTING"));
+
+    assertThatThrownBy(() -> service.start(JOB_ID, "start-2"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any());
+  }
+
+  @Test
+  void cancelsSubmittedJobWhenStopWinsDuringCliSubmission() {
+    DefinitionRow stopping = definition("STOPPED", "STOPPING");
+    DeploymentRow deployment = deployment("job-123", "STOPPING");
+
+    when(store.deploymentByIdempotencyKey("restart-safe")).thenReturn(Optional.empty());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
+    when(store.lockDefinition(JOB_ID)).thenReturn(stopped, stopping, stopping);
+    when(store.insertDeployment(any(), any(), any(), any(), eq("restart-safe")))
+        .thenReturn(DEPLOYMENT_ID);
+    when(dataSourceResolver.resolveCredentials(spec))
+        .thenReturn(
+            new CredentialBinding[] {
+              new CredentialBinding("source", "secret"),
+              new CredentialBinding("sink", "secret")
+            });
+    when(gateway.deploy(any())).thenReturn(new DeployResult("job-123", "exactly-once"));
+    when(gateway.status("job-123"))
+        .thenReturn(
+            new RuntimeStatus("job-123", RuntimeStatus.State.RUNNING),
+            new RuntimeStatus("job-123", RuntimeStatus.State.TERMINATED));
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+
+    assertThatCode(() -> service.start(JOB_ID, "restart-safe")).doesNotThrowAnyException();
+
+    verify(store, never()).markDeploymentRunning(anyLong(), anyLong(), any(), any());
+    verify(store).bindDeploymentForStop(DEPLOYMENT_ID, "job-123", "3.6.0");
+    verify(gateway).stop("job-123");
+    verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", "job-123", null);
+  }
+
+  private DefinitionRow definition(String desired, String observed) {
+    return new DefinitionRow(
+        JOB_ID,
+        "test-job",
+        null,
+        "{}",
+        "PUBLISHED",
+        desired,
+        observed,
+        1,
+        1,
+        "digest",
+        null,
+        null,
+        null);
+  }
+
+  private DeploymentRow deployment(String engineJobId, String status) {
+    return new DeploymentRow(
+        DEPLOYMENT_ID,
+        JOB_ID,
+        1,
+        "{}",
+        "test",
+        "digest",
+        "restart-safe",
+        engineJobId,
+        "3.6.0",
+        status,
+        false,
+        null,
+        null,
+        null);
+  }
+}

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -37,7 +37,10 @@ export const realtimeApi = {
   action: (id: number, action: 'publish' | 'validate' | 'start' | 'stop' | 'restart' | 'reconcile') =>
     request<ApiResponse<RealtimeDeployment | boolean>>(`${PREFIX}/${id}/${action}`, {
       method: 'POST',
-      headers: action === 'start' ? { 'Idempotency-Key': crypto.randomUUID() } : undefined,
+      headers:
+        action === 'start' || action === 'restart'
+          ? { 'Idempotency-Key': crypto.randomUUID() }
+          : undefined,
     }),
   remove: (id: number) => request<ApiResponse<boolean>>(`${PREFIX}/${id}`, { method: 'DELETE' }),
   events: (id: number) => request<ApiResponse<RealtimeEvent[]>>(`${PREFIX}/${id}/events`),


### PR DESCRIPTION
## 背景

在实时同步任务状态模型治理 #607 合并后，启停链路仍存在跨实例并发风险：

- 原来的 JVM 全局 `ReentrantLock` 既不能跨实例互斥，又会让不同实时任务的生命周期操作互相阻塞。
- 两个不同 `Idempotency-Key` 的并发启动可能在任务已进入 `STARTING` 后继续创建新 deployment，导致重复提交 Flink Job。
- `stop` 如果在同步 Flink CDC CLI 提交期间到达，此时 deployment 尚无 JobId，旧逻辑可能提前认为任务已停止；随后原 `start` 返回又把状态覆盖回 `RUNNING`。
- `restart` 没有请求级幂等键，接口重试/重复点击可能重复执行停止+启动。
- 旧 deployment 的延迟对账结果可能在快速重启后覆盖新 deployment 的状态。

本 PR 只处理第二阶段的“启停幂等与并发控制”。Flink JobId 孤儿发现、完整生命周期对账、日志与指标等继续放在后续独立改造中。

## 改动

- 将单个 JVM 全局生命周期锁改为按 `definitionId` 的本地锁：同一任务串行，不同任务可并行；跨实例正确性由数据库行锁和状态 CAS 保证。
- 新增 startable 状态约束：只有 `desired=STOPPED` 且 `observed=STOPPED/FAILED` 才能抢占新的启动权。
- `markStarting` 增加 SQL 条件 CAS，防止绕过 Service 后重复抢占 `STARTING`。
- 幂等键采用双重检查：快速返回路径 + `FOR UPDATE` 后再次检查；相同 key 的跨实例竞争复用同一 deployment，不重复提交。
- 启动完成时不再无条件覆盖状态：如果 CLI 返回 JobId 前已有 stop 请求，则先绑定真实 JobId，再立即取消该 Flink Job，不能把 `STOPPING` 覆盖回 `RUNNING`。
- stop 改为事务内抢占停止意图；重复 stop 直接复用已有 `STOPPING`，避免重复调用 Flink stop。
- STARTING 阶段尚无 JobId 时，stop 保持 `STOPPING`，不再错误标记为 `STOPPED`；待 submit 返回后由启动方精准取消。
- Flink stop 查询为 `UNKNOWN`、等待超时或线程中断时，统一进入 `UNKNOWN`，交给后续对账，不伪造停止成功。
- restart 支持 `Idempotency-Key`；前端 start/restart 都发送幂等键，并保留旧 `restart(long id)` 兼容入口。
- 对账落库前同时验证 lifecycle snapshot 和 latest deployment snapshot，避免旧 Job 的延迟结果污染快速重启后的新 deployment。

## 并发保证

- 同一任务连续/并发启动：最多只有一个请求能成功抢占 `STARTING`。
- 相同 `Idempotency-Key` 重试：返回同一 deployment，不重复调用 Flink deploy。
- 不同 key 并发启动：后到请求在数据库状态边界被拒绝，不会产生第二个 Flink Job。
- stop 在 submit 期间到达：启动完成后会绑定并停止刚提交的 Job，不会重新变成 RUNNING。
- 不同任务的 start/stop/reconcile 不再被一个 JVM 全局锁串行化。

## 测试

- 扩展 `RealtimeStateMachineTest`，覆盖 start reservation 的允许/拒绝状态及晚到 Job 的取消迁移。
- 新增 `RealtimeJobServiceConcurrencyTest`：
  - 模拟另一实例已经抢到 `STARTING`，验证第二个不同 key 请求不会创建 deployment / deploy。
  - 模拟 stop 在 CLI submit 期间获胜，验证返回 JobId 后走 bind + cancel，而不会 `markDeploymentRunning`。

当前执行环境无法直接拉取仓库运行 Maven，本 PR 已完成代码级静态检查，最终以仓库 CI/本地 Maven 测试结果为准。

## 后续

如果 submit owner 在 `STOPPING + 无 JobId` 时进程永久退出，仍需要后续“Flink Job 生命周期与状态对账”阶段补充孤儿 Job 发现/恢复策略；本 PR 不扩大到该范围。