### PR TITLE
fix(realtime): recover and reconcile Flink job lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
@@ -12,6 +12,7 @@ import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobListQuery;
 import io.yak.ops.business.sync.realtime.service.RealtimeEventStreamService;
+import io.yak.ops.business.sync.realtime.service.RealtimeJobLifecycleCoordinator;
 import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -38,14 +39,17 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class RealtimeJobController {
 
   private final RealtimeJobService service;
+  private final RealtimeJobLifecycleCoordinator lifecycleCoordinator;
   private final RealtimeJobListQuery listQuery;
   private final RealtimeEventStreamService eventStream;
 
   public RealtimeJobController(
       RealtimeJobService service,
+      RealtimeJobLifecycleCoordinator lifecycleCoordinator,
       RealtimeJobListQuery listQuery,
       RealtimeEventStreamService eventStream) {
     this.service = service;
+    this.lifecycleCoordinator = lifecycleCoordinator;
     this.listQuery = listQuery;
     this.eventStream = eventStream;
   }
@@ -149,13 +153,14 @@ public class RealtimeJobController {
   @PostMapping("/{id}/reconcile")
   @RequiresPermission(RealtimePermissionCode.EXECUTE)
   public Result<RealtimeJobView> reconcile(@PathVariable long id) {
-    return Result.success(service.reconcile(id));
+    return Result.success(lifecycleCoordinator.reconcile(id));
   }
 
   @Operation(summary = "删除已停止的实时同步任务")
   @DeleteMapping("/{id}")
   @RequiresPermission(RealtimePermissionCode.DELETE)
   public Result<Boolean> delete(@PathVariable long id) {
+    lifecycleCoordinator.assertSafeToDelete(id);
     service.delete(id);
     return Result.success(true);
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachine.java
@@ -46,7 +46,9 @@ public class RealtimeStateMachine {
         ObservedState.FAILED,
         ObservedState.STOPPED,
         ObservedState.STARTING,
-        ObservedState.STOPPING);
+        ObservedState.STOPPING,
+        ObservedState.UNKNOWN,
+        ObservedState.CONFLICT);
     allow(
         ObservedState.UNKNOWN,
         ObservedState.RUNNING,
@@ -59,6 +61,7 @@ public class RealtimeStateMachine {
         ObservedState.RUNNING,
         ObservedState.STOPPING,
         ObservedState.STOPPED,
+        ObservedState.FAILED,
         ObservedState.UNKNOWN);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkJobDiscoveryClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkJobDiscoveryClient.java
@@ -1,0 +1,90 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/** Exact-name lookup used only for recovering deployments that have no persisted Flink JobId. */
+@Component
+public class FlinkJobDiscoveryClient {
+
+  private static final Pattern JOB_ID = Pattern.compile("(?i)[0-9a-f]{32}");
+
+  private final HttpClient client;
+  private final ObjectMapper json;
+  private final RealtimeSyncProperties properties;
+
+  public FlinkJobDiscoveryClient(
+      @Qualifier("realtimeHttpClient") HttpClient client,
+      @Qualifier("realtimeObjectMapper") ObjectMapper json,
+      RealtimeSyncProperties properties) {
+    this.client = client;
+    this.json = json;
+    this.properties = properties;
+  }
+
+  public List<String> findJobIds(String exactRuntimeJobName) {
+    if (exactRuntimeJobName == null || exactRuntimeJobName.isBlank()) {
+      throw new IllegalArgumentException("runtime job name 不能为空");
+    }
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder(URI.create(baseUrl() + "/jobs/overview"))
+              .timeout(properties.getRequestTimeout())
+              .header("Accept", "application/json")
+              .GET()
+              .build();
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        throw failure("Flink jobs overview HTTP " + response.statusCode(), null);
+      }
+      JsonNode root =
+          response.body() == null || response.body().isBlank()
+              ? json.createObjectNode()
+              : json.readTree(response.body());
+      JsonNode jobs = root.path("jobs");
+      if (!jobs.isArray()) {
+        throw failure("Flink jobs overview 缺少 jobs 数组", null);
+      }
+      List<String> result = new ArrayList<>();
+      for (JsonNode job : jobs) {
+        if (!exactRuntimeJobName.equals(job.path("name").asText())) {
+          continue;
+        }
+        String id = job.path("jid").asText().toLowerCase(Locale.ROOT);
+        if (!JOB_ID.matcher(id).matches()) {
+          throw failure("Flink jobs overview 返回了无效 jobId", null);
+        }
+        result.add(id);
+      }
+      return List.copyOf(result);
+    } catch (HttpTimeoutException exception) {
+      throw failure("Flink jobs overview 请求超时", exception);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw failure("Flink jobs overview 请求被中断", exception);
+    } catch (IOException exception) {
+      throw failure("Flink jobs overview 连接失败", exception);
+    }
+  }
+
+  private String baseUrl() {
+    return properties.getRestUrl().replaceAll("/+$", "");
+  }
+
+  private RealtimeEngineException failure(String message, Throwable cause) {
+    return new RealtimeEngineException(message, true, null, cause);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeRuntimeIdentity.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeRuntimeIdentity.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Deterministic identity used to recover a Flink job after an uncertain CLI submission. */
+public final class RealtimeRuntimeIdentity {
+
+  private static final Pattern PIPELINE_NAME =
+      Pattern.compile("(?m)(^pipeline:\\s*\\R[ \\t]+name:\\s*)[^\\r\\n]+");
+
+  private RealtimeRuntimeIdentity() {}
+
+  public static String jobName(String idempotencyKey) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) {
+      throw new IllegalArgumentException("Idempotency-Key 不能为空");
+    }
+    try {
+      byte[] digest =
+          MessageDigest.getInstance("SHA-256")
+              .digest(idempotencyKey.getBytes(StandardCharsets.UTF_8));
+      return "yak-rt-" + HexFormat.of().formatHex(digest, 0, 16);
+    } catch (Exception exception) {
+      throw new IllegalStateException("无法生成 Flink runtime job identity", exception);
+    }
+  }
+
+  public static String decoratePipeline(String pipelineYaml, String idempotencyKey) {
+    if (pipelineYaml == null || pipelineYaml.isBlank()) {
+      throw new IllegalArgumentException("Pipeline YAML 不能为空");
+    }
+    Matcher matcher = PIPELINE_NAME.matcher(pipelineYaml);
+    if (!matcher.find()) {
+      throw new IllegalArgumentException("Pipeline YAML 缺少 pipeline.name，无法生成可恢复任务标识");
+    }
+    String runtimeName = jobName(idempotencyKey);
+    return pipelineYaml.substring(0, matcher.start())
+        + matcher.group(1)
+        + runtimeName
+        + pipelineYaml.substring(matcher.end());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RecoverableRealtimeEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RecoverableRealtimeEngineGateway.java
@@ -1,0 +1,79 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.sync.realtime.repository.RealtimeRuntimeIdentityStore;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds a deterministic Flink job name before submission so Yak Ops can recover the JobId after an
+ * uncertain CLI result or a process crash between submit and persistence.
+ */
+@Primary
+@Component
+public class RecoverableRealtimeEngineGateway implements RealtimeEngineGateway {
+
+  private final FlinkCdcEngineGateway delegate;
+  private final RealtimeRuntimeIdentityStore identityStore;
+
+  public RecoverableRealtimeEngineGateway(
+      FlinkCdcEngineGateway delegate, RealtimeRuntimeIdentityStore identityStore) {
+    this.delegate = delegate;
+    this.identityStore = identityStore;
+  }
+
+  @Override
+  public JsonNode health() {
+    return delegate.health();
+  }
+
+  @Override
+  public JsonNode capabilities() {
+    return delegate.capabilities();
+  }
+
+  @Override
+  public ValidationResult validate(String pipelineYaml) {
+    return delegate.validate(pipelineYaml);
+  }
+
+  @Override
+  public DeployResult deploy(RealtimeDeployRequest request) {
+    String runtimeJobName = RealtimeRuntimeIdentity.jobName(request.idempotencyKey());
+    identityStore.bind(request.idempotencyKey(), runtimeJobName);
+    String recoverableYaml =
+        RealtimeRuntimeIdentity.decoratePipeline(request.pipelineYaml(), request.idempotencyKey());
+    RealtimeDeployRequest recoverable =
+        new RealtimeDeployRequest(
+            recoverableYaml,
+            request.idempotencyKey(),
+            request.source(),
+            request.sink());
+    return delegate.deploy(recoverable);
+  }
+
+  @Override
+  public RuntimeStatus status(String jobId) {
+    return delegate.status(jobId);
+  }
+
+  @Override
+  public void stop(String jobId) {
+    delegate.stop(jobId);
+  }
+
+  @Override
+  public String logs(String jobId, int tailLines) {
+    return delegate.logs(jobId, tailLines);
+  }
+
+  @Override
+  public JsonNode checkpoints(String jobId) {
+    return delegate.checkpoints(jobId);
+  }
+
+  @Override
+  public JsonNode metrics(String jobId) {
+    return delegate.metrics(jobId);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RecoverableRealtimeEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RecoverableRealtimeEngineGateway.java
@@ -40,9 +40,12 @@ public class RecoverableRealtimeEngineGateway implements RealtimeEngineGateway {
   @Override
   public DeployResult deploy(RealtimeDeployRequest request) {
     String runtimeJobName = RealtimeRuntimeIdentity.jobName(request.idempotencyKey());
-    identityStore.bind(request.idempotencyKey(), runtimeJobName);
     String recoverableYaml =
         RealtimeRuntimeIdentity.decoratePipeline(request.pipelineYaml(), request.idempotencyKey());
+
+    // This is the last durable step before entering the CLI. REQUIRED means the CLI never started;
+    // BOUND means an orphan Flink job is possible and exact-name recovery must be attempted.
+    identityStore.bind(request.idempotencyKey(), runtimeJobName);
     RealtimeDeployRequest recoverable =
         new RealtimeDeployRequest(
             recoverableYaml,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeRuntimeIdentityStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeRuntimeIdentityStore.java
@@ -17,11 +17,13 @@ public class RealtimeRuntimeIdentityStore {
     this.db = new JdbcTemplate(dataSource);
   }
 
+  /** Must succeed before the Flink CDC CLI is started. */
   public void bind(String idempotencyKey, String runtimeJobName) {
     int changed =
         db.update(
-            "update yak_realtime_job_deployment set runtime_job_name=? "
+            "update yak_realtime_job_deployment set runtime_job_name=?,runtime_identity_state='BOUND' "
                 + "where idempotency_key=? and gateway_job_id is null "
+                + "and runtime_identity_state='REQUIRED' "
                 + "and (runtime_job_name is null or runtime_job_name=?)",
             runtimeJobName,
             idempotencyKey,
@@ -36,6 +38,17 @@ public class RealtimeRuntimeIdentityStore {
         .query(
             "select runtime_job_name from yak_realtime_job_deployment where id=?",
             (result, row) -> result.getString("runtime_job_name"),
+            deploymentId)
+        .stream()
+        .filter(value -> value != null && !value.isBlank())
+        .findFirst();
+  }
+
+  public Optional<String> state(long deploymentId) {
+    return db
+        .query(
+            "select runtime_identity_state from yak_realtime_job_deployment where id=?",
+            (result, row) -> result.getString("runtime_identity_state"),
             deploymentId)
         .stream()
         .filter(value -> value != null && !value.isBlank())

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeRuntimeIdentityStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeRuntimeIdentityStore.java
@@ -1,0 +1,44 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** Persists the deterministic Flink runtime name separately from the user-facing task name. */
+@Repository
+public class RealtimeRuntimeIdentityStore {
+
+  private final JdbcTemplate db;
+
+  public RealtimeRuntimeIdentityStore(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.db = new JdbcTemplate(dataSource);
+  }
+
+  public void bind(String idempotencyKey, String runtimeJobName) {
+    int changed =
+        db.update(
+            "update yak_realtime_job_deployment set runtime_job_name=? "
+                + "where idempotency_key=? and gateway_job_id is null "
+                + "and (runtime_job_name is null or runtime_job_name=?)",
+            runtimeJobName,
+            idempotencyKey,
+            runtimeJobName);
+    if (changed != 1) {
+      throw new IllegalStateException("无法绑定实时同步 runtime job identity，部署状态可能已变化");
+    }
+  }
+
+  public Optional<String> findByDeploymentId(long deploymentId) {
+    return db
+        .query(
+            "select runtime_job_name from yak_realtime_job_deployment where id=?",
+            (result, row) -> result.getString("runtime_job_name"),
+            deploymentId)
+        .stream()
+        .filter(value -> value != null && !value.isBlank())
+        .findFirst();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
@@ -1,0 +1,291 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
+import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineException;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.RuntimeStatus;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeRuntimeIdentityStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.StringUtils;
+
+/** Authoritative scheduled/manual reconciliation against the real Flink runtime. */
+@Service
+public class RealtimeJobLifecycleCoordinator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RealtimeJobLifecycleCoordinator.class);
+
+  private final RealtimeJobStore store;
+  private final RealtimeRuntimeIdentityStore identityStore;
+  private final FlinkJobDiscoveryClient discovery;
+  private final RealtimeEngineGateway gateway;
+  private final RealtimeStateMachine stateMachine;
+  private final TransactionTemplate transactions;
+  private final long orphanGraceSeconds;
+
+  public RealtimeJobLifecycleCoordinator(
+      RealtimeJobStore store,
+      RealtimeRuntimeIdentityStore identityStore,
+      FlinkJobDiscoveryClient discovery,
+      RealtimeEngineGateway gateway,
+      RealtimeStateMachine stateMachine,
+      @Value("${yak.sync.realtime.orphan-recovery-grace-seconds:120}") long orphanGraceSeconds,
+      @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager) {
+    this.store = store;
+    this.identityStore = identityStore;
+    this.discovery = discovery;
+    this.gateway = gateway;
+    this.stateMachine = stateMachine;
+    this.orphanGraceSeconds = Math.max(10, orphanGraceSeconds);
+    this.transactions = new TransactionTemplate(transactionManager);
+  }
+
+  public void reconcileAll() {
+    for (DefinitionRow candidate : store.desiredJobs()) {
+      try {
+        reconcile(candidate.id());
+      } catch (RuntimeException exception) {
+        LOG.warn("Realtime job {} reconciliation failed", candidate.id(), exception);
+      }
+    }
+  }
+
+  public RealtimeJobView reconcile(long id) {
+    DefinitionRow definition = requireDefinition(id);
+    DeploymentRow deployment = store.latestDeployment(id).orElse(null);
+    if (deployment == null) {
+      return store.view(id);
+    }
+
+    String jobId = deployment.engineJobId();
+    if (!StringUtils.hasText(jobId)) {
+      jobId = recoverJobId(definition, deployment);
+      if (!StringUtils.hasText(jobId)) {
+        return store.view(id);
+      }
+      deployment = store.latestDeployment(id).orElse(deployment);
+    }
+
+    RuntimeStatus runtime = gateway.status(jobId);
+    applyRuntimeState(id, deployment.id(), jobId, runtime);
+    return store.view(id);
+  }
+
+  /** Refuses metadata deletion unless Flink proves that no matching runtime job is active. */
+  public void assertSafeToDelete(long id) {
+    DefinitionRow definition = requireDefinition(id);
+    stateMachine.requireDefinitionMutable(definition.desiredState(), definition.observedState());
+    DeploymentRow deployment = store.latestDeployment(id).orElse(null);
+    if (deployment == null) {
+      return;
+    }
+    if (StringUtils.hasText(deployment.engineJobId())) {
+      requireInactive(gateway.status(deployment.engineJobId()));
+      return;
+    }
+    String runtimeName = identityStore.findByDeploymentId(deployment.id()).orElse(null);
+    if (StringUtils.hasText(runtimeName)) {
+      for (String jobId : discovery.findJobIds(runtimeName)) {
+        requireInactive(gateway.status(jobId));
+      }
+    } else if (deployment.resultUncertain()) {
+      throw new IllegalStateException(
+          "历史部署结果不确定且缺少 runtime job identity，请先在 Flink UI 确认无活动任务");
+    }
+  }
+
+  private String recoverJobId(DefinitionRow definition, DeploymentRow deployment) {
+    String runtimeName = identityStore.findByDeploymentId(deployment.id()).orElse(null);
+    if (!StringUtils.hasText(runtimeName)) {
+      return null;
+    }
+    List<String> matches = discovery.findJobIds(runtimeName);
+    if (matches.size() > 1) {
+      markConflict(definition.id(), deployment, matches.size());
+      return null;
+    }
+    if (matches.isEmpty()) {
+      if (graceExpired(deployment)) {
+        settleMissing(definition.id(), deployment);
+      }
+      return null;
+    }
+
+    String recoveredJobId = matches.get(0);
+    transactions.executeWithoutResult(
+        ignored -> {
+          DefinitionRow current = store.lockDefinition(definition.id());
+          DeploymentRow latest = store.latestDeployment(definition.id()).orElse(null);
+          if (!sameDeployment(deployment, latest) || StringUtils.hasText(latest.engineJobId())) {
+            return;
+          }
+          store.reconcile(
+              current.id(), latest.id(), current.observedState(), latest.status(), recoveredJobId,
+              current.lastError());
+          store.event(
+              current.id(), latest.id(), "FLINK_JOB_ID_RECOVERED", current.observedState(),
+              current.observedState(), "已通过 runtime job identity 找回 Flink JobId：" + recoveredJobId);
+        });
+    return recoveredJobId;
+  }
+
+  private void applyRuntimeState(
+      long definitionId, long deploymentId, String jobId, RuntimeStatus runtime) {
+    Boolean stop =
+        transactions.execute(
+            ignored -> {
+              DefinitionRow current = store.lockDefinition(definitionId);
+              DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
+              if (latest == null || latest.id() != deploymentId
+                  || (StringUtils.hasText(latest.engineJobId())
+                      && !Objects.equals(latest.engineJobId(), jobId))) {
+                return false;
+              }
+
+              if (runtime.state() == RuntimeStatus.State.UNKNOWN) {
+                transition(current, latest, "UNKNOWN", "UNKNOWN", jobId, "Flink 当前运行状态未知");
+                return false;
+              }
+              if ("RUNNING".equals(current.desiredState())) {
+                if (runtime.state() == RuntimeStatus.State.RUNNING) {
+                  transition(current, latest, "RUNNING", "RUNNING", jobId, null);
+                } else {
+                  failExpectedRunning(current, latest,
+                      runtime.state() == RuntimeStatus.State.TERMINATED
+                          ? "Flink 任务已终止" : "Flink 中未找到期望运行的任务");
+                }
+                return false;
+              }
+              if (runtime.state() == RuntimeStatus.State.RUNNING) {
+                transition(current, latest, "STOPPING", "STOPPING", jobId, null);
+                return true;
+              }
+              toStopped(current, latest, jobId, "Flink 已确认无活动任务");
+              return false;
+            });
+
+    if (Boolean.TRUE.equals(stop)) {
+      try {
+        gateway.stop(jobId);
+      } catch (RealtimeEngineException exception) {
+        markUnknown(definitionId, deploymentId, jobId, exception.getMessage());
+        throw exception;
+      }
+    }
+  }
+
+  private void settleMissing(long definitionId, DeploymentRow deployment) {
+    transactions.executeWithoutResult(
+        ignored -> {
+          DefinitionRow current = store.lockDefinition(definitionId);
+          DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
+          if (!sameDeployment(deployment, latest) || StringUtils.hasText(latest.engineJobId())) {
+            return;
+          }
+          if ("RUNNING".equals(current.desiredState())) {
+            failExpectedRunning(current, latest,
+                "提交结果不确定，恢复窗口内未发现匹配的 Flink runtime job");
+          } else {
+            toStopped(current, latest, null, "Flink jobs overview 未发现匹配任务，已确认停止");
+          }
+        });
+  }
+
+  private void markConflict(long definitionId, DeploymentRow deployment, int count) {
+    transactions.executeWithoutResult(
+        ignored -> {
+          DefinitionRow current = store.lockDefinition(definitionId);
+          DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
+          if (!sameDeployment(deployment, latest) || StringUtils.hasText(latest.engineJobId())) {
+            return;
+          }
+          String target = "STOPPING".equals(current.observedState()) ? "UNKNOWN" : "CONFLICT";
+          String message = "runtime job identity 匹配到 " + count + " 个 Flink Job，拒绝自动绑定";
+          transition(current, latest, target, "UNKNOWN", null, message);
+        });
+  }
+
+  private void failExpectedRunning(
+      DefinitionRow current, DeploymentRow deployment, String message) {
+    stateMachine.requireTransition(current.observedState(), "FAILED");
+    store.markTerminalFailure(current.id(), deployment.id(), message);
+    store.event(current.id(), deployment.id(), "FLINK_JOB_LOST", current.observedState(), "FAILED", message);
+  }
+
+  private void markUnknown(
+      long definitionId, long deploymentId, String jobId, String message) {
+    transactions.executeWithoutResult(
+        ignored -> {
+          DefinitionRow current = store.lockDefinition(definitionId);
+          DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
+          if (latest == null || latest.id() != deploymentId) {
+            return;
+          }
+          transition(current, latest, "UNKNOWN", "UNKNOWN", jobId, message);
+        });
+  }
+
+  private void transition(
+      DefinitionRow current, DeploymentRow deployment, String observed, String deploymentState,
+      String jobId, String error) {
+    if (!observed.equals(current.observedState())) {
+      stateMachine.requireTransition(current.observedState(), observed);
+    }
+    store.reconcile(current.id(), deployment.id(), observed, deploymentState, jobId, error);
+    if (!observed.equals(current.observedState()) || !Objects.equals(error, current.lastError())) {
+      store.event(current.id(), deployment.id(), "STATE_RECONCILED", current.observedState(), observed,
+          error == null ? "Flink 状态已对账" : error);
+    }
+  }
+
+  private void toStopped(
+      DefinitionRow current, DeploymentRow deployment, String jobId, String message) {
+    String from = current.observedState();
+    if ("STARTING".equals(from) || "RUNNING".equals(from)) {
+      stateMachine.requireTransition(from, "STOPPING");
+      store.reconcile(current.id(), deployment.id(), "STOPPING", "STOPPING", jobId, null);
+      from = "STOPPING";
+    }
+    if (!"STOPPED".equals(from)) {
+      stateMachine.requireTransition(from, "STOPPED");
+    }
+    store.reconcile(current.id(), deployment.id(), "STOPPED", "STOPPED", jobId, null);
+    store.event(current.id(), deployment.id(), "STOPPED", from, "STOPPED", message);
+  }
+
+  private void requireInactive(RuntimeStatus runtime) {
+    if (runtime.state() == RuntimeStatus.State.RUNNING) {
+      throw new IllegalStateException("Flink 中仍存在活动任务，禁止删除实时同步元数据");
+    }
+    if (runtime.state() == RuntimeStatus.State.UNKNOWN) {
+      throw new IllegalStateException("无法确认 Flink 任务是否已停止，禁止删除实时同步元数据");
+    }
+  }
+
+  private boolean graceExpired(DeploymentRow deployment) {
+    return deployment.createTime() != null
+        && deployment.createTime().isBefore(LocalDateTime.now().minusSeconds(orphanGraceSeconds));
+  }
+
+  private boolean sameDeployment(DeploymentRow expected, DeploymentRow current) {
+    return expected != null && current != null && expected.id() == current.id();
+  }
+
+  private DefinitionRow requireDefinition(long id) {
+    return store.definition(id)
+        .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.sync.realtime.service;
 
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
 import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
@@ -13,6 +14,8 @@ import io.yak.ops.business.sync.realtime.repository.RealtimeRuntimeIdentityStore
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,8 +36,11 @@ public class RealtimeJobLifecycleCoordinator {
   private final FlinkJobDiscoveryClient discovery;
   private final RealtimeEngineGateway gateway;
   private final RealtimeStateMachine stateMachine;
+  private final RealtimeSyncProperties properties;
   private final TransactionTemplate transactions;
   private final long orphanGraceSeconds;
+  private final ConcurrentHashMap<Long, AtomicInteger> consecutiveEngineFailures =
+      new ConcurrentHashMap<>();
 
   public RealtimeJobLifecycleCoordinator(
       RealtimeJobStore store,
@@ -42,6 +48,7 @@ public class RealtimeJobLifecycleCoordinator {
       FlinkJobDiscoveryClient discovery,
       RealtimeEngineGateway gateway,
       RealtimeStateMachine stateMachine,
+      RealtimeSyncProperties properties,
       @Value("${yak.sync.realtime.orphan-recovery-grace-seconds:120}") long orphanGraceSeconds,
       @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager) {
     this.store = store;
@@ -49,6 +56,7 @@ public class RealtimeJobLifecycleCoordinator {
     this.discovery = discovery;
     this.gateway = gateway;
     this.stateMachine = stateMachine;
+    this.properties = properties;
     this.orphanGraceSeconds = Math.max(10, orphanGraceSeconds);
     this.transactions = new TransactionTemplate(transactionManager);
   }
@@ -57,6 +65,15 @@ public class RealtimeJobLifecycleCoordinator {
     for (DefinitionRow candidate : store.desiredJobs()) {
       try {
         reconcile(candidate.id());
+        consecutiveEngineFailures.remove(candidate.id());
+      } catch (RealtimeEngineException exception) {
+        int failures =
+            consecutiveEngineFailures
+                .computeIfAbsent(candidate.id(), ignored -> new AtomicInteger())
+                .incrementAndGet();
+        if (failures >= Math.max(1, properties.getReconcileFailureThreshold())) {
+          markEngineUnavailable(candidate.id(), exception.getMessage());
+        }
       } catch (RuntimeException exception) {
         LOG.warn("Realtime job {} reconciliation failed", candidate.id(), exception);
       }
@@ -130,8 +147,7 @@ public class RealtimeJobLifecycleCoordinator {
     }
     if (matches.isEmpty()) {
       if (graceExpired(deployment)) {
-        settleMissing(
-            definition.id(), deployment, "恢复窗口内未发现匹配的 Flink runtime job");
+        settleMissing(definition.id(), deployment, "恢复窗口内未发现匹配的 Flink runtime job");
       }
       return null;
     }
@@ -145,11 +161,19 @@ public class RealtimeJobLifecycleCoordinator {
             return;
           }
           store.reconcile(
-              current.id(), latest.id(), current.observedState(), latest.status(), recoveredJobId,
+              current.id(),
+              latest.id(),
+              current.observedState(),
+              latest.status(),
+              recoveredJobId,
               current.lastError());
           store.event(
-              current.id(), latest.id(), "FLINK_JOB_ID_RECOVERED", current.observedState(),
-              current.observedState(), "已通过 runtime job identity 找回 Flink JobId：" + recoveredJobId);
+              current.id(),
+              latest.id(),
+              "FLINK_JOB_ID_RECOVERED",
+              current.observedState(),
+              current.observedState(),
+              "已通过 runtime job identity 找回 Flink JobId：" + recoveredJobId);
         });
     return recoveredJobId;
   }
@@ -161,23 +185,33 @@ public class RealtimeJobLifecycleCoordinator {
             ignored -> {
               DefinitionRow current = store.lockDefinition(definitionId);
               DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
-              if (latest == null || latest.id() != deploymentId
+              if (latest == null
+                  || latest.id() != deploymentId
                   || (StringUtils.hasText(latest.engineJobId())
                       && !Objects.equals(latest.engineJobId(), jobId))) {
                 return false;
               }
 
               if (runtime.state() == RuntimeStatus.State.UNKNOWN) {
-                transition(current, latest, "UNKNOWN", "UNKNOWN", jobId, "Flink 当前运行状态未知");
+                transition(
+                    current,
+                    latest,
+                    "UNKNOWN",
+                    "UNKNOWN",
+                    jobId,
+                    "Flink 当前运行状态未知");
                 return false;
               }
               if ("RUNNING".equals(current.desiredState())) {
                 if (runtime.state() == RuntimeStatus.State.RUNNING) {
                   transition(current, latest, "RUNNING", "RUNNING", jobId, null);
                 } else {
-                  failExpectedRunning(current, latest,
+                  failExpectedRunning(
+                      current,
+                      latest,
                       runtime.state() == RuntimeStatus.State.TERMINATED
-                          ? "Flink 任务已终止" : "Flink 中未找到期望运行的任务");
+                          ? "Flink 任务已终止"
+                          : "Flink 中未找到期望运行的任务");
                 }
                 return false;
               }
@@ -233,11 +267,47 @@ public class RealtimeJobLifecycleCoordinator {
       DefinitionRow current, DeploymentRow deployment, String message) {
     stateMachine.requireTransition(current.observedState(), "FAILED");
     store.markTerminalFailure(current.id(), deployment.id(), message);
-    store.event(current.id(), deployment.id(), "FLINK_JOB_LOST", current.observedState(), "FAILED", message);
+    store.event(
+        current.id(),
+        deployment.id(),
+        "FLINK_JOB_LOST",
+        current.observedState(),
+        "FAILED",
+        message);
   }
 
-  private void markUnknown(
-      long definitionId, long deploymentId, String jobId, String message) {
+  private void markEngineUnavailable(long definitionId, String detail) {
+    try {
+      transactions.executeWithoutResult(
+          ignored -> {
+            DefinitionRow current = store.lockDefinition(definitionId);
+            if ("UNKNOWN".equals(current.observedState())) {
+              return;
+            }
+            DeploymentRow deployment = store.latestDeployment(definitionId).orElse(null);
+            stateMachine.requireTransition(current.observedState(), "UNKNOWN");
+            String message = "Flink 状态不可用" + (detail == null ? "" : "：" + detail);
+            store.reconcile(
+                definitionId,
+                deployment == null ? null : deployment.id(),
+                "UNKNOWN",
+                "UNKNOWN",
+                deployment == null ? null : deployment.engineJobId(),
+                message);
+            store.event(
+                definitionId,
+                deployment == null ? null : deployment.id(),
+                "FLINK_UNAVAILABLE",
+                current.observedState(),
+                "UNKNOWN",
+                message);
+          });
+    } catch (RuntimeException exception) {
+      LOG.debug("Unable to mark realtime job {} UNKNOWN", definitionId, exception);
+    }
+  }
+
+  private void markUnknown(long definitionId, long deploymentId, String jobId, String message) {
     transactions.executeWithoutResult(
         ignored -> {
           DefinitionRow current = store.lockDefinition(definitionId);
@@ -250,14 +320,23 @@ public class RealtimeJobLifecycleCoordinator {
   }
 
   private void transition(
-      DefinitionRow current, DeploymentRow deployment, String observed, String deploymentState,
-      String jobId, String error) {
+      DefinitionRow current,
+      DeploymentRow deployment,
+      String observed,
+      String deploymentState,
+      String jobId,
+      String error) {
     if (!observed.equals(current.observedState())) {
       stateMachine.requireTransition(current.observedState(), observed);
     }
     store.reconcile(current.id(), deployment.id(), observed, deploymentState, jobId, error);
     if (!observed.equals(current.observedState()) || !Objects.equals(error, current.lastError())) {
-      store.event(current.id(), deployment.id(), "STATE_RECONCILED", current.observedState(), observed,
+      store.event(
+          current.id(),
+          deployment.id(),
+          "STATE_RECONCILED",
+          current.observedState(),
+          observed,
           error == null ? "Flink 状态已对账" : error);
     }
   }
@@ -296,7 +375,8 @@ public class RealtimeJobLifecycleCoordinator {
   }
 
   private DefinitionRow requireDefinition(long id) {
-    return store.definition(id)
+    return store
+        .definition(id)
         .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
@@ -101,7 +101,13 @@ public class RealtimeJobLifecycleCoordinator {
       for (String jobId : discovery.findJobIds(runtimeName)) {
         requireInactive(gateway.status(jobId));
       }
-    } else if (deployment.resultUncertain()) {
+      return;
+    }
+    String identityState = identityStore.state(deployment.id()).orElse("LEGACY");
+    if ("REQUIRED".equals(identityState)) {
+      return;
+    }
+    if (deployment.resultUncertain()) {
       throw new IllegalStateException(
           "历史部署结果不确定且缺少 runtime job identity，请先在 Flink UI 确认无活动任务");
     }
@@ -110,6 +116,11 @@ public class RealtimeJobLifecycleCoordinator {
   private String recoverJobId(DefinitionRow definition, DeploymentRow deployment) {
     String runtimeName = identityStore.findByDeploymentId(deployment.id()).orElse(null);
     if (!StringUtils.hasText(runtimeName)) {
+      String identityState = identityStore.state(deployment.id()).orElse("LEGACY");
+      if ("REQUIRED".equals(identityState) && graceExpired(deployment)) {
+        settleMissing(
+            definition.id(), deployment, "Gateway 尚未绑定 runtime identity，确认 CLI 未开始提交");
+      }
       return null;
     }
     List<String> matches = discovery.findJobIds(runtimeName);
@@ -119,7 +130,8 @@ public class RealtimeJobLifecycleCoordinator {
     }
     if (matches.isEmpty()) {
       if (graceExpired(deployment)) {
-        settleMissing(definition.id(), deployment);
+        settleMissing(
+            definition.id(), deployment, "恢复窗口内未发现匹配的 Flink runtime job");
       }
       return null;
     }
@@ -187,7 +199,7 @@ public class RealtimeJobLifecycleCoordinator {
     }
   }
 
-  private void settleMissing(long definitionId, DeploymentRow deployment) {
+  private void settleMissing(long definitionId, DeploymentRow deployment, String reason) {
     transactions.executeWithoutResult(
         ignored -> {
           DefinitionRow current = store.lockDefinition(definitionId);
@@ -196,10 +208,9 @@ public class RealtimeJobLifecycleCoordinator {
             return;
           }
           if ("RUNNING".equals(current.desiredState())) {
-            failExpectedRunning(current, latest,
-                "提交结果不确定，恢复窗口内未发现匹配的 Flink runtime job");
+            failExpectedRunning(current, latest, "提交结果不确定，" + reason);
           } else {
-            toStopped(current, latest, null, "Flink jobs overview 未发现匹配任务，已确认停止");
+            toStopped(current, latest, null, reason + "，已确认停止");
           }
         });
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobReconciler.java
@@ -8,19 +8,21 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/** Periodically recovers observed state after Yak Ops restarts or uncertain Gateway calls. */
+/** Periodically recovers JobIds and reconciles Yak Ops state against the real Flink runtime. */
 @Component
 public class RealtimeJobReconciler {
 
   private static final Logger LOG = LoggerFactory.getLogger(RealtimeJobReconciler.class);
-  private final RealtimeJobService service;
+  private final RealtimeJobLifecycleCoordinator lifecycleCoordinator;
   private final RealtimeJobStore store;
   private final RealtimeSyncProperties properties;
   private final String leaseOwner = UUID.randomUUID().toString();
 
   public RealtimeJobReconciler(
-      RealtimeJobService service, RealtimeJobStore store, RealtimeSyncProperties properties) {
-    this.service = service;
+      RealtimeJobLifecycleCoordinator lifecycleCoordinator,
+      RealtimeJobStore store,
+      RealtimeSyncProperties properties) {
+    this.lifecycleCoordinator = lifecycleCoordinator;
     this.store = store;
     this.properties = properties;
   }
@@ -31,7 +33,7 @@ public class RealtimeJobReconciler {
       if (!store.tryAcquireReconcileLease(leaseOwner, properties.getReconcileLeaseSeconds())) {
         return;
       }
-      service.reconcile();
+      lifecycleCoordinator.reconcileAll();
     } catch (RuntimeException exception) {
       LOG.warn("Realtime state reconciliation failed", exception);
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V5__add_runtime_job_identity.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V5__add_runtime_job_identity.sql
@@ -1,0 +1,7 @@
+ALTER TABLE yak_realtime_job_deployment
+  ADD COLUMN runtime_job_name VARCHAR(128) NULL AFTER idempotency_key,
+  ADD UNIQUE KEY uk_realtime_runtime_job_name(runtime_job_name);
+
+-- Existing deployments intentionally remain NULL. Only submissions created after this migration
+-- have a deterministic runtime identity and can be recovered automatically after an uncertain CLI
+-- result without guessing from the Flink job list.

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V5__add_runtime_job_identity.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V5__add_runtime_job_identity.sql
@@ -1,7 +1,13 @@
 ALTER TABLE yak_realtime_job_deployment
   ADD COLUMN runtime_job_name VARCHAR(128) NULL AFTER idempotency_key,
+  ADD COLUMN runtime_identity_state VARCHAR(16) NOT NULL DEFAULT 'REQUIRED' AFTER runtime_job_name,
   ADD UNIQUE KEY uk_realtime_runtime_job_name(runtime_job_name);
 
--- Existing deployments intentionally remain NULL. Only submissions created after this migration
--- have a deterministic runtime identity and can be recovered automatically after an uncertain CLI
--- result without guessing from the Flink job list.
+-- Rows that existed before this migration never had the deterministic runtime name injected into
+-- their Flink pipeline. Mark them LEGACY so recovery never guesses by the user-facing task name.
+UPDATE yak_realtime_job_deployment
+SET runtime_identity_state='LEGACY'
+WHERE runtime_job_name IS NULL;
+
+-- New deployments use the column default REQUIRED. The gateway changes it to BOUND before it starts
+-- the Flink CDC CLI, so a crash before BOUND proves no runtime job could have been submitted.

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/RealtimeStateMachineTest.java
@@ -24,6 +24,16 @@ class RealtimeStateMachineTest {
   }
 
   @Test
+  void acceptsRecoveryEvidenceSettlingFailureAndConflict() {
+    assertThatCode(() -> stateMachine.requireTransition("FAILED", "UNKNOWN"))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> stateMachine.requireTransition("FAILED", "CONFLICT"))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> stateMachine.requireTransition("CONFLICT", "FAILED"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
   void rejectsImpossibleDirectTransition() {
     assertThatThrownBy(() -> stateMachine.requireTransition("STOPPED", "RUNNING"))
         .isInstanceOf(IllegalStateException.class)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkJobDiscoveryClientTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkJobDiscoveryClientTest.java
@@ -1,0 +1,56 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FlinkJobDiscoveryClientTest {
+
+  private static final String JOB_ID = "0123456789abcdef0123456789abcdef";
+  private HttpServer server;
+  private FlinkJobDiscoveryClient client;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext(
+        "/jobs/overview",
+        exchange -> {
+          String body =
+              "{\"jobs\":["
+                  + "{\"jid\":\"" + JOB_ID + "\",\"name\":\"yak-rt-target\",\"state\":\"RUNNING\"},"
+                  + "{\"jid\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"name\":\"other\",\"state\":\"RUNNING\"}]}";
+          byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, bytes.length);
+          exchange.getResponseBody().write(bytes);
+          exchange.close();
+        });
+    server.start();
+
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setRestUrl("http://127.0.0.1:" + server.getAddress().getPort());
+    client =
+        new FlinkJobDiscoveryClient(
+            HttpClient.newHttpClient(), new ObjectMapper(), properties);
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  void findsOnlyExactRuntimeName() {
+    assertThat(client.findJobIds("yak-rt-target")).containsExactly(JOB_ID);
+    assertThat(client.findJobIds("yak-rt")).isEmpty();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/RealtimeRuntimeIdentityTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/RealtimeRuntimeIdentityTest.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RealtimeRuntimeIdentityTest {
+
+  @Test
+  void createsStableRuntimeNameAndRewritesPipelineName() {
+    String key = "same-request-key";
+    String name = RealtimeRuntimeIdentity.jobName(key);
+    String yaml =
+        "pipeline:\n  name: user-facing-name\n  parallelism: 1\nsource:\n  type: mysql\n";
+
+    assertThat(name).startsWith("yak-rt-").hasSize(39);
+    assertThat(RealtimeRuntimeIdentity.jobName(key)).isEqualTo(name);
+    assertThat(RealtimeRuntimeIdentity.decoratePipeline(yaml, key))
+        .contains("pipeline:\n  name: " + name + "\n")
+        .doesNotContain("user-facing-name");
+  }
+
+  @Test
+  void rejectsPipelineWithoutName() {
+    assertThatThrownBy(
+            () -> RealtimeRuntimeIdentity.decoratePipeline("pipeline:\n  parallelism: 1\n", "key"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("pipeline.name");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/RecoverableRealtimeEngineGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/RecoverableRealtimeEngineGatewayTest.java
@@ -1,0 +1,46 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.repository.RealtimeRuntimeIdentityStore;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RecoverableRealtimeEngineGatewayTest {
+
+  @Test
+  void persistsRuntimeIdentityBeforeDelegatingSubmission() {
+    FlinkCdcEngineGateway delegate = mock(FlinkCdcEngineGateway.class);
+    RealtimeRuntimeIdentityStore identityStore = mock(RealtimeRuntimeIdentityStore.class);
+    RecoverableRealtimeEngineGateway gateway =
+        new RecoverableRealtimeEngineGateway(delegate, identityStore);
+    String key = "deploy-key";
+    String yaml =
+        "pipeline:\n  name: display-name\nsource:\n  password: ${SECRET:source.password}\n"
+            + "sink:\n  password: ${SECRET:sink.password}\n";
+    when(delegate.deploy(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(new RealtimeEngineGateway.DeployResult(
+            "0123456789abcdef0123456789abcdef", "at-least-once"));
+
+    try (RealtimeDeployRequest request =
+        new RealtimeDeployRequest(
+            yaml,
+            key,
+            new RealtimeDeployRequest.CredentialBinding("source", "s1"),
+            new RealtimeDeployRequest.CredentialBinding("sink", "s2"))) {
+      gateway.deploy(request);
+    }
+
+    String runtimeName = RealtimeRuntimeIdentity.jobName(key);
+    verify(identityStore).bind(key, runtimeName);
+    ArgumentCaptor<RealtimeDeployRequest> captor =
+        ArgumentCaptor.forClass(RealtimeDeployRequest.class);
+    verify(delegate).deploy(captor.capture());
+    assertThat(captor.getValue().pipelineYaml())
+        .contains("pipeline:\n  name: " + runtimeName + "\n")
+        .doesNotContain("display-name");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
@@ -1,10 +1,13 @@
 package io.yak.ops.business.sync.realtime.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
 import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
@@ -41,6 +44,8 @@ class RealtimeJobLifecycleCoordinatorTest {
     gateway = mock(RealtimeEngineGateway.class);
     PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
     when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setReconcileFailureThreshold(3);
     coordinator =
         new RealtimeJobLifecycleCoordinator(
             store,
@@ -48,6 +53,7 @@ class RealtimeJobLifecycleCoordinatorTest {
             discovery,
             gateway,
             new RealtimeStateMachine(),
+            properties,
             10,
             transactionManager);
   }
@@ -102,6 +108,44 @@ class RealtimeJobLifecycleCoordinatorTest {
             "STOPPING",
             "STOPPED",
             "恢复窗口内未发现匹配的 Flink runtime job，已确认停止");
+  }
+
+  @Test
+  void keepsRuntimeUnknownInsteadOfPretendingStopped() {
+    DefinitionRow definition = definition("STOPPED", "STOPPING");
+    DeploymentRow deployment = deployment(FLINK_JOB_ID, "STOPPING", LocalDateTime.now());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
+    when(store.lockDefinition(JOB_ID)).thenReturn(definition);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(gateway.status(FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.UNKNOWN));
+
+    coordinator.reconcile(JOB_ID);
+
+    verify(store)
+        .reconcile(
+            JOB_ID,
+            DEPLOYMENT_ID,
+            "UNKNOWN",
+            "UNKNOWN",
+            FLINK_JOB_ID,
+            "Flink 当前运行状态未知");
+    verify(store, never())
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", FLINK_JOB_ID, null);
+  }
+
+  @Test
+  void refusesDeleteWhenFlinkJobIsStillActive() {
+    DefinitionRow definition = definition("STOPPED", "FAILED");
+    DeploymentRow deployment = deployment(FLINK_JOB_ID, "FAILED", LocalDateTime.now());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(gateway.status(FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
+
+    assertThatThrownBy(() -> coordinator.assertSafeToDelete(JOB_ID))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("仍存在活动任务");
   }
 
   private DefinitionRow definition(String desired, String observed) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
@@ -1,0 +1,142 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.RuntimeStatus;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeRuntimeIdentityStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RealtimeJobLifecycleCoordinatorTest {
+
+  private static final long JOB_ID = 7L;
+  private static final long DEPLOYMENT_ID = 19L;
+  private static final String FLINK_JOB_ID = "0123456789abcdef0123456789abcdef";
+
+  private RealtimeJobStore store;
+  private RealtimeRuntimeIdentityStore identityStore;
+  private FlinkJobDiscoveryClient discovery;
+  private RealtimeEngineGateway gateway;
+  private RealtimeJobLifecycleCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    identityStore = mock(RealtimeRuntimeIdentityStore.class);
+    discovery = mock(FlinkJobDiscoveryClient.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    coordinator =
+        new RealtimeJobLifecycleCoordinator(
+            store,
+            identityStore,
+            discovery,
+            gateway,
+            new RealtimeStateMachine(),
+            10,
+            transactionManager);
+  }
+
+  @Test
+  void recoversMissingJobIdThenReconcilesRunning() {
+    DefinitionRow definition = definition("RUNNING", "UNKNOWN");
+    DeploymentRow deployment = deployment(null, "UNKNOWN", LocalDateTime.now());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
+    when(store.lockDefinition(JOB_ID)).thenReturn(definition);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(identityStore.findByDeploymentId(DEPLOYMENT_ID)).thenReturn(Optional.of("yak-rt-test"));
+    when(discovery.findJobIds("yak-rt-test")).thenReturn(List.of(FLINK_JOB_ID));
+    when(gateway.status(FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
+
+    coordinator.reconcile(JOB_ID);
+
+    verify(store)
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "UNKNOWN", "UNKNOWN", FLINK_JOB_ID, null);
+    verify(store)
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "RUNNING", "RUNNING", FLINK_JOB_ID, null);
+    verify(store)
+        .event(
+            JOB_ID,
+            DEPLOYMENT_ID,
+            "FLINK_JOB_ID_RECOVERED",
+            "UNKNOWN",
+            "UNKNOWN",
+            "已通过 runtime job identity 找回 Flink JobId：" + FLINK_JOB_ID);
+  }
+
+  @Test
+  void confirmsStoppedOnlyAfterRecoveryWindowAndNoMatchingFlinkJob() {
+    DefinitionRow definition = definition("STOPPED", "STOPPING");
+    DeploymentRow deployment =
+        deployment(null, "UNKNOWN", LocalDateTime.now().minusMinutes(5));
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
+    when(store.lockDefinition(JOB_ID)).thenReturn(definition);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(identityStore.findByDeploymentId(DEPLOYMENT_ID)).thenReturn(Optional.of("yak-rt-test"));
+    when(discovery.findJobIds("yak-rt-test")).thenReturn(List.of());
+
+    coordinator.reconcile(JOB_ID);
+
+    verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", null, null);
+    verify(store)
+        .event(
+            JOB_ID,
+            DEPLOYMENT_ID,
+            "STOPPED",
+            "STOPPING",
+            "STOPPED",
+            "Flink jobs overview 未发现匹配任务，已确认停止");
+  }
+
+  private DefinitionRow definition(String desired, String observed) {
+    return new DefinitionRow(
+        JOB_ID,
+        "test-job",
+        null,
+        "{}",
+        "PUBLISHED",
+        desired,
+        observed,
+        1,
+        1,
+        "digest",
+        null,
+        null,
+        null);
+  }
+
+  private DeploymentRow deployment(
+      String engineJobId, String status, LocalDateTime createTime) {
+    return new DeploymentRow(
+        DEPLOYMENT_ID,
+        JOB_ID,
+        1,
+        "{}",
+        "summary",
+        "digest",
+        "key",
+        engineJobId,
+        null,
+        status,
+        true,
+        null,
+        createTime,
+        createTime);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
@@ -101,7 +101,7 @@ class RealtimeJobLifecycleCoordinatorTest {
             "STOPPED",
             "STOPPING",
             "STOPPED",
-            "Flink jobs overview 未发现匹配任务，已确认停止");
+            "恢复窗口内未发现匹配的 Flink runtime job，已确认停止");
   }
 
   private DefinitionRow definition(String desired, String observed) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobReconcilerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobReconcilerTest.java
@@ -17,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class RealtimeJobReconcilerTest {
 
-  @Mock private RealtimeJobService service;
+  @Mock private RealtimeJobLifecycleCoordinator lifecycleCoordinator;
   @Mock private RealtimeJobStore store;
   private RealtimeJobReconciler reconciler;
 
@@ -25,26 +25,24 @@ class RealtimeJobReconcilerTest {
   void setUp() {
     RealtimeSyncProperties properties = new RealtimeSyncProperties();
     properties.setReconcileLeaseSeconds(30);
-    reconciler = new RealtimeJobReconciler(service, store, properties);
+    reconciler = new RealtimeJobReconciler(lifecycleCoordinator, store, properties);
   }
 
   @Test
   void skipsReconciliationWhenAnotherInstanceOwnsTheLease() {
-    when(store.tryAcquireReconcileLease(anyString(), eq(30)))
-        .thenReturn(false);
+    when(store.tryAcquireReconcileLease(anyString(), eq(30))).thenReturn(false);
 
     reconciler.reconcile();
 
-    verify(service, never()).reconcile();
+    verify(lifecycleCoordinator, never()).reconcileAll();
   }
 
   @Test
   void reconcilesWhenThisInstanceOwnsTheLease() {
-    when(store.tryAcquireReconcileLease(anyString(), eq(30)))
-        .thenReturn(true);
+    when(store.tryAcquireReconcileLease(anyString(), eq(30))).thenReturn(true);
 
     reconciler.reconcile();
 
-    verify(service).reconcile();
+    verify(lifecycleCoordinator).reconcileAll();
   }
 }


### PR DESCRIPTION
## 背景

前两阶段已经完成实时同步状态模型治理（#607）和启停幂等/并发控制（#608）。第三阶段继续处理控制面与 Flink 真实生命周期之间的缺口，重点解决：

- Flink CDC CLI 已经提交成功，但 Yak Ops 在拿到/持久化 JobId 前超时或进程退出，导致产生“孤儿 Flink Job”。
- `STOPPING + 无 JobId` 时 submit owner 崩溃，Yak Ops 无法再精准找到并停止已经提交的 Job。
- 旧逻辑只能在已有 `gateway_job_id` 时对账，无法可靠恢复缺失 JobId。
- 删除任务此前主要依赖数据库状态，无法阻止“数据库已停止但 Flink 实际仍运行”的误删。
- Flink REST 故障或返回 UNKNOWN 时，控制面不能伪造 STOPPED。

本 PR 只处理第三阶段“Flink Job 生命周期与状态对账”。日志、指标、Checkpoint 展示优化继续留在后续阶段。

## 核心方案

### 1. 为每次 deployment 建立确定且唯一的 Flink runtime identity

新增 `RealtimeRuntimeIdentity`，根据 deployment 的 `Idempotency-Key` 生成稳定的内部 Flink Job Name，例如：

`yak-rt-<128bit hash>`

提交前由 `RecoverableRealtimeEngineGateway` 将 Pipeline YAML 中的 `pipeline.name` 替换成该内部 runtime name。

这样 JobId 丢失后，可以通过 Flink REST `/jobs/overview` 按**精确 runtime name**找回 Job，而不是通过“提交前后列表 diff”或用户任务名猜测。

### 2. 在 CLI 启动前持久化 runtime identity

新增 migration V5：

- `runtime_job_name`
- `runtime_identity_state`
- runtime name 唯一索引

状态语义：

- `REQUIRED`：新 deployment 已创建，但 Gateway 尚未进入 CLI 提交流程。
- `BOUND`：runtime name 已落库，随后才允许调用 Flink CDC CLI；此时如果进程崩溃，存在孤儿 Job 的可能，必须通过 runtime name 恢复。
- `LEGACY`：升级前的历史 deployment，没有确定 runtime identity，禁止自动猜 JobId。

因此：

- 崩在 BOUND 前，可以证明 CLI 尚未开始。
- 崩在 BOUND 后，可以通过 runtime name 精确恢复。
- 历史数据不做危险的自动绑定。

### 3. 新增 Flink JobId 恢复与生命周期 Coordinator

新增 `RealtimeJobLifecycleCoordinator`，作为定时和手工对账的统一入口：

- 已有 JobId：直接查询真实 Flink 状态。
- 缺失 JobId + BOUND runtime identity：通过 `/jobs/overview` 精确查找。
- 唯一匹配：回填 `gateway_job_id`，记录 `FLINK_JOB_ID_RECOVERED`，继续对账。
- 多个匹配：进入 `CONFLICT / UNKNOWN`，拒绝自动绑定。
- 恢复窗口后仍无匹配：根据 desired state 收敛为 FAILED 或 STOPPED。
- `desired=STOPPED` 但 Flink 实际仍 RUNNING：恢复 STOPPING 并主动取消真实 Job。
- Flink 返回 UNKNOWN：Yak Ops 保持 UNKNOWN，不伪造停止成功。
- `desired=RUNNING` 但 Flink 已终止/不存在：收敛 FAILED，不自动重新提交，避免重复回放。

默认 orphan recovery grace window 为 120 秒，可通过：

`yak.sync.realtime.orphan-recovery-grace-seconds`

调整。

### 4. 保留 Flink 不可用的故障阈值

迁移旧对账逻辑中的 `reconcileFailureThreshold`：

- Flink REST 偶发失败不立即污染状态。
- 连续达到阈值后才将任务收敛为 UNKNOWN。
- 后续对账恢复成功后清除连续失败计数。

### 5. 删除前校验真实 Flink 状态

DELETE 现在先经过 Lifecycle Coordinator：

- 已有 JobId：必须确认 Flink 非 RUNNING/UNKNOWN。
- 缺失 JobId但有 runtime identity：先精确发现匹配 Job，再逐个确认非活动状态。
- 新 deployment 仍为 REQUIRED：说明 CLI 尚未开始，可以安全删除。
- LEGACY + result uncertain：拒绝自动删除，要求先到 Flink UI 人工确认。

数据库状态不再是删除安全性的唯一依据。

### 6. 定时与手工对账统一

- `RealtimeJobReconciler` 改为调用 `RealtimeJobLifecycleCoordinator.reconcileAll()`。
- `/api/v1/realtime-sync/{id}/reconcile` 改为走新的 Coordinator。
- 旧 `RealtimeJobService` 的启停主链不做第三阶段侵入性重构。

## 状态边界补充

恢复证据可能推翻之前的失败/冲突判断，因此补充恢复态迁移：

- `FAILED -> UNKNOWN / CONFLICT`
- `CONFLICT -> FAILED`

正常 start/stop 状态边界保持不变。

## 测试

新增/扩展测试覆盖：

- deterministic runtime identity 稳定生成及 Pipeline YAML name 替换。
- Gateway 在 CLI 提交前持久化 runtime identity。
- `/jobs/overview` 只允许 exact runtime name 匹配。
- 缺失 JobId -> 精确找回 JobId -> RUNNING 对账。
- STOPPING + 无匹配 Job，在恢复窗口后确认 STOPPED。
- Flink UNKNOWN 不允许伪装成 STOPPED。
- Flink Job 仍处于 RUNNING 时禁止删除任务元数据。
- Reconciler lease 仍然保证只有持有 lease 的实例执行批量对账。
- FAILED / CONFLICT 恢复态迁移。

当前执行环境无法直接运行仓库 Maven 测试，已完成代码级静态检查；最终以仓库 CI 或本地 Maven 测试结果为准。

## 范围外

本 PR 不处理：

- 提交日志 / JobManager / TaskManager 日志体验优化。
- Records / TPS / Checkpoint 等指标聚合和前端展示。
- SSH / Runtime Agent 部署模式。
- 自动重新提交失败 Job。

第三阶段原则仍然是：**能证明就自动恢复，不能证明就 UNKNOWN/CONFLICT，不猜、不自动重复提交。**