### PR TITLE
feat(realtime): add Flink observability and runtime diagnostics

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
@@ -9,11 +9,13 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobEventView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobListQuery;
 import io.yak.ops.business.sync.realtime.service.RealtimeEventStreamService;
 import io.yak.ops.business.sync.realtime.service.RealtimeJobLifecycleCoordinator;
 import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
+import io.yak.ops.business.sync.realtime.service.RealtimeObservabilityService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -40,16 +42,19 @@ public class RealtimeJobController {
 
   private final RealtimeJobService service;
   private final RealtimeJobLifecycleCoordinator lifecycleCoordinator;
+  private final RealtimeObservabilityService observabilityService;
   private final RealtimeJobListQuery listQuery;
   private final RealtimeEventStreamService eventStream;
 
   public RealtimeJobController(
       RealtimeJobService service,
       RealtimeJobLifecycleCoordinator lifecycleCoordinator,
+      RealtimeObservabilityService observabilityService,
       RealtimeJobListQuery listQuery,
       RealtimeEventStreamService eventStream) {
     this.service = service;
     this.lifecycleCoordinator = lifecycleCoordinator;
+    this.observabilityService = observabilityService;
     this.listQuery = listQuery;
     this.eventStream = eventStream;
   }
@@ -177,20 +182,43 @@ public class RealtimeJobController {
     return Result.success(service.capabilities());
   }
 
-  @Operation(summary = "查询当前任务提交日志和 Flink 异常")
+  @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics")
+  @GetMapping("/{id}/observability")
+  public Result<RealtimeObservabilityView> observability(@PathVariable long id) {
+    return Result.success(observabilityService.snapshot(id));
+  }
+
+  @Operation(summary = "查询 Flink CDC 提交日志")
+  @GetMapping("/{id}/logs/submission")
+  public Result<Map<String, String>> submissionLog(
+      @PathVariable long id, @RequestParam(defaultValue = "500") int tail) {
+    return Result.success(Map.of("logs", observabilityService.submissionLog(id, tail)));
+  }
+
+  @Operation(summary = "查询 Flink 运行异常历史")
+  @GetMapping("/{id}/logs/runtime")
+  public Result<RealtimeObservabilityView.RuntimeLog> runtimeLog(
+      @PathVariable long id, @RequestParam(defaultValue = "50") int maxExceptions) {
+    return Result.success(observabilityService.runtimeLog(id, maxExceptions));
+  }
+
+  /** Compatibility endpoint retained for existing clients. */
+  @Operation(summary = "查询当前任务提交日志和 Flink 异常（兼容接口）")
   @GetMapping("/{id}/logs")
   public Result<Map<String, String>> logs(
       @PathVariable long id, @RequestParam(defaultValue = "200") int tail) {
     return Result.success(Map.of("logs", service.logs(id, tail)));
   }
 
-  @Operation(summary = "查询当前任务 Checkpoint 统计")
+  /** Compatibility endpoint retained for existing clients. */
+  @Operation(summary = "查询当前任务原始 Checkpoint 统计")
   @GetMapping("/{id}/checkpoints")
   public Result<JsonNode> checkpoints(@PathVariable long id) {
     return Result.success(service.checkpoints(id));
   }
 
-  @Operation(summary = "查询当前任务 Flink 指标")
+  /** Compatibility endpoint retained for existing clients. */
+  @Operation(summary = "查询当前任务原始 Flink 指标")
   @GetMapping("/{id}/metrics")
   public Result<JsonNode> metrics(@PathVariable long id) {
     return Result.success(service.metrics(id));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeObservabilityView.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeObservabilityView.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import java.util.List;
+
+/** Stable, UI-oriented observability model derived from Flink REST responses. */
+public record RealtimeObservabilityView(
+    String engineJobId,
+    String flinkJobName,
+    String flinkState,
+    Long startTime,
+    Long durationMs,
+    String flinkWebUrl,
+    long sampledAt,
+    CheckpointSummary checkpoints,
+    MetricSummary metrics) {
+
+  public record CheckpointSummary(
+      long total,
+      long completed,
+      long failed,
+      long inProgress,
+      long restored,
+      CheckpointDetail latestCompleted,
+      CheckpointDetail latestFailed) {}
+
+  public record CheckpointDetail(
+      Long id,
+      Long triggerTimestamp,
+      Long latestAckTimestamp,
+      Long durationMs,
+      Long stateSizeBytes,
+      Long checkpointedSizeBytes,
+      Integer acknowledgedSubtasks,
+      Integer totalSubtasks,
+      String failureMessage) {}
+
+  public record MetricSummary(
+      Long recordsRead,
+      Double recordsReadPerSecond,
+      Long recordsWritten,
+      Double recordsWrittenPerSecond,
+      Long bytesRead,
+      Double bytesReadPerSecond,
+      Long bytesWritten,
+      Double bytesWrittenPerSecond,
+      Double maxBusyMsPerSecond,
+      Double maxBackpressuredMsPerSecond,
+      Double maxIdleMsPerSecond,
+      int vertexCount) {}
+
+  public record RuntimeLog(
+      String rootException,
+      Long timestamp,
+      boolean truncated,
+      List<RuntimeExceptionEntry> exceptions) {
+    public RuntimeLog {
+      exceptions = exceptions == null ? List.of() : List.copyOf(exceptions);
+    }
+  }
+
+  public record RuntimeExceptionEntry(
+      String exceptionName,
+      String stacktrace,
+      Long timestamp,
+      String taskName,
+      String taskManagerId,
+      String endpoint) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
@@ -11,7 +11,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -113,17 +112,17 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
   public DeployResult deploy(RealtimeDeployRequest request) {
     validate(request.pipelineYaml());
     Path work = Path.of(properties.getWorkDirectory()).toAbsolutePath().normalize();
-    Path pendingLog = null;
+    Path submissionLog = null;
     Path pipelineFile = null;
     try {
       Path pipelines = Files.createDirectories(work.resolve("pipelines"));
-      Path logs = Files.createDirectories(work.resolve("logs"));
-      String safeKey = request.idempotencyKey().replaceAll("[^A-Za-z0-9._-]", "_");
+      Files.createDirectories(work.resolve("logs"));
+      String safeKey = safeKey(request.idempotencyKey());
       pipelineFile = pipelines.resolve("pipeline-" + safeKey + "-" + System.nanoTime() + ".yaml");
-      pendingLog = logs.resolve("submit-" + safeKey + "-" + System.nanoTime() + ".log");
+      submissionLog = submitLogByKey(request.idempotencyKey());
       String resolved = resolveSecrets(request);
       writePrivate(pipelineFile, resolved);
-      writePrivate(pendingLog, "");
+      writePrivate(submissionLog, "");
 
       URI rest = restUri();
       int port = rest.getPort() < 0 ? defaultPort(rest) : rest.getPort();
@@ -138,7 +137,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
                   "-Drest.address=" + rest.getHost(),
                   "-Drest.port=" + port)
               .redirectErrorStream(true)
-              .redirectOutput(pendingLog.toFile());
+              .redirectOutput(submissionLog.toFile());
       builder.environment().put("FLINK_HOME", properties.getFlinkHome());
       if (StringUtils.hasText(properties.getJavaHome())) {
         builder.environment().put("JAVA_HOME", properties.getJavaHome());
@@ -147,11 +146,12 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       Duration timeout = properties.getSubmitTimeout();
       if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
         process.destroyForcibly();
+        process.waitFor(5, TimeUnit.SECONDS);
         throw failure("Flink CDC 提交超时，结果不确定，请在 Flink UI 中核对", true, null, null);
       }
-      String output = Files.readString(pendingLog, StandardCharsets.UTF_8);
+      String output = Files.readString(submissionLog, StandardCharsets.UTF_8);
       output = sanitizeOutput(output, request);
-      writePrivate(pendingLog, output);
+      writePrivate(submissionLog, output);
       if (process.exitValue() != 0) {
         String excerpt = tail(output, 20);
         throw failure(
@@ -167,16 +167,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
         throw failure("Flink CDC CLI 未返回 jobId，提交结果不确定", true, null, null);
       }
       String jobId = matcher.group(1).toLowerCase(Locale.ROOT);
-      try {
-        Files.move(
-            pendingLog,
-            submitLog(jobId),
-            StandardCopyOption.REPLACE_EXISTING,
-            StandardCopyOption.ATOMIC_MOVE);
-      } catch (AtomicMoveNotSupportedException ignored) {
-        Files.move(pendingLog, submitLog(jobId), StandardCopyOption.REPLACE_EXISTING);
-      }
-      pendingLog = null;
+      Files.copy(submissionLog, submitLog(jobId), StandardCopyOption.REPLACE_EXISTING);
       return new DeployResult(jobId, "at-least-once");
     } catch (RealtimeEngineException exception) {
       throw exception;
@@ -186,8 +177,8 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     } catch (IOException exception) {
       throw failure("无法执行 Flink CDC CLI：" + exception.getMessage(), false, null, exception);
     } finally {
+      sanitizeLogQuietly(submissionLog, request);
       deleteQuietly(pipelineFile);
-      deleteQuietly(pendingLog);
     }
   }
 
@@ -278,6 +269,18 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     return sanitized;
   }
 
+  private void sanitizeLogQuietly(Path log, RealtimeDeployRequest request) {
+    if (log == null || !Files.isRegularFile(log)) {
+      return;
+    }
+    try {
+      String output = Files.readString(log, StandardCharsets.UTF_8);
+      writePrivate(log, sanitizeOutput(output, request));
+    } catch (IOException ignored) {
+      // Log retention is best-effort and must never mask the actual submission result.
+    }
+  }
+
   private void writePrivate(Path path, String content) throws IOException {
     Files.writeString(path, content, StandardCharsets.UTF_8);
     try {
@@ -359,6 +362,16 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   private Path cliPath() {
     return Path.of(properties.getFlinkCdcHome(), "bin", "flink-cdc.sh")
+        .toAbsolutePath()
+        .normalize();
+  }
+
+  private String safeKey(String idempotencyKey) {
+    return idempotencyKey.replaceAll("[^A-Za-z0-9._-]", "_");
+  }
+
+  private Path submitLogByKey(String idempotencyKey) {
+    return Path.of(properties.getWorkDirectory(), "logs", "submit-" + safeKey(idempotencyKey) + ".log")
         .toAbsolutePath()
         .normalize();
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
@@ -95,11 +95,16 @@ public class FlinkObservabilityClient {
         metricSummary(jobId, job));
   }
 
-  public String submissionLog(String jobId, int tailLines) {
-    requireJobId(jobId);
+  public String submissionLog(String idempotencyKey, int tailLines) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) {
+      throw new IllegalArgumentException("Idempotency-Key 不能为空");
+    }
     int tail = Math.max(1, Math.min(tailLines, properties.getMaxLogLines()));
     Path log =
-        Path.of(properties.getWorkDirectory(), "logs", jobId + ".submit.log")
+        Path.of(
+                properties.getWorkDirectory(),
+                "logs",
+                "submit-" + safeKey(idempotencyKey) + ".log")
             .toAbsolutePath()
             .normalize();
     if (!Files.isRegularFile(log)) {
@@ -399,6 +404,10 @@ public class FlinkObservabilityClient {
 
   private String baseUrl() {
     return properties.getRestUrl().replaceAll("/+$", "");
+  }
+
+  private String safeKey(String idempotencyKey) {
+    return idempotencyKey.replaceAll("[^A-Za-z0-9._-]", "_");
   }
 
   private void requireJobId(String jobId) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
@@ -1,0 +1,427 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.CheckpointDetail;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.CheckpointSummary;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.MetricSummary;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.RuntimeExceptionEntry;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.RuntimeLog;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/** Read-only Flink REST/file adapter that normalizes runtime observability for the Yak Ops UI. */
+@Component
+public class FlinkObservabilityClient {
+
+  private static final Pattern JOB_ID = Pattern.compile("(?i)[0-9a-f]{32}");
+  private static final String METRIC_IDS =
+      String.join(
+          ",",
+          "numRecordsIn",
+          "numRecordsInPerSecond",
+          "numRecordsOut",
+          "numRecordsOutPerSecond",
+          "numBytesIn",
+          "numBytesInPerSecond",
+          "numBytesOut",
+          "numBytesOutPerSecond",
+          "busyTimeMsPerSecond",
+          "backPressuredTimeMsPerSecond",
+          "idleTimeMsPerSecond");
+
+  private final HttpClient client;
+  private final ObjectMapper json;
+  private final RealtimeSyncProperties properties;
+  private final RealtimeLogRedactor redactor;
+
+  public FlinkObservabilityClient(
+      @Qualifier("realtimeHttpClient") HttpClient client,
+      @Qualifier("realtimeObjectMapper") ObjectMapper json,
+      RealtimeSyncProperties properties,
+      RealtimeLogRedactor redactor) {
+    this.client = client;
+    this.json = json;
+    this.properties = properties;
+    this.redactor = redactor;
+  }
+
+  public RealtimeObservabilityView snapshot(String jobId) {
+    requireJobId(jobId);
+    JsonNode job = getJson("/jobs/" + jobId, true);
+    long sampledAt = System.currentTimeMillis();
+    if (job == null) {
+      return new RealtimeObservabilityView(
+          jobId,
+          null,
+          "NOT_FOUND",
+          null,
+          null,
+          flinkWebUrl(jobId),
+          sampledAt,
+          emptyCheckpointSummary(),
+          emptyMetricSummary());
+    }
+
+    JsonNode checkpointBody = getJson("/jobs/" + jobId + "/checkpoints", true);
+    return new RealtimeObservabilityView(
+        jobId,
+        text(job, "name"),
+        text(job, "state"),
+        number(job, "start-time"),
+        number(job, "duration"),
+        flinkWebUrl(jobId),
+        sampledAt,
+        checkpointSummary(checkpointBody),
+        metricSummary(jobId, job));
+  }
+
+  public String submissionLog(String jobId, int tailLines) {
+    requireJobId(jobId);
+    int tail = Math.max(1, Math.min(tailLines, properties.getMaxLogLines()));
+    Path log =
+        Path.of(properties.getWorkDirectory(), "logs", jobId + ".submit.log")
+            .toAbsolutePath()
+            .normalize();
+    if (!Files.isRegularFile(log)) {
+      return "";
+    }
+    try (var lines = Files.lines(log, StandardCharsets.UTF_8)) {
+      return redactor.redact(tail(lines.toList(), tail));
+    } catch (IOException exception) {
+      throw failure("无法读取 Flink CDC 提交日志", false, exception);
+    }
+  }
+
+  public RuntimeLog runtimeLog(String jobId, int maxExceptions) {
+    requireJobId(jobId);
+    int limit = Math.max(1, Math.min(maxExceptions, 100));
+    JsonNode body = getJson("/jobs/" + jobId + "/exceptions?maxExceptions=" + limit, true);
+    if (body == null) {
+      return new RuntimeLog(null, null, false, List.of());
+    }
+
+    JsonNode history = body.path("exceptionHistory");
+    List<RuntimeExceptionEntry> entries = new ArrayList<>();
+    if (history.path("entries").isArray()) {
+      for (JsonNode entry : history.path("entries")) {
+        addException(entries, entry);
+        JsonNode concurrent = entry.path("concurrentExceptions");
+        if (concurrent.isArray()) {
+          for (JsonNode nested : concurrent) {
+            addException(entries, nested);
+          }
+        }
+      }
+    }
+
+    String root = entries.isEmpty() ? text(body, "root-exception") : entries.get(0).stacktrace();
+    Long timestamp = entries.isEmpty() ? number(body, "timestamp") : entries.get(0).timestamp();
+    boolean truncated = history.path("truncated").asBoolean(body.path("truncated").asBoolean(false));
+    return new RuntimeLog(redactor.redact(root), timestamp, truncated, entries);
+  }
+
+  private void addException(List<RuntimeExceptionEntry> entries, JsonNode node) {
+    String stacktrace = text(node, "stacktrace");
+    if (stacktrace == null) {
+      stacktrace = text(node, "exception");
+    }
+    entries.add(
+        new RuntimeExceptionEntry(
+            text(node, "exceptionName"),
+            redactor.redact(stacktrace),
+            number(node, "timestamp"),
+            firstText(node, "taskName", "task"),
+            text(node, "taskManagerId"),
+            firstText(node, "endpoint", "location")));
+  }
+
+  private CheckpointSummary checkpointSummary(JsonNode body) {
+    if (body == null || body.isMissingNode() || body.isNull()) {
+      return emptyCheckpointSummary();
+    }
+    JsonNode counts = body.path("counts");
+    JsonNode latest = body.path("latest");
+    return new CheckpointSummary(
+        counts.path("total").asLong(0),
+        counts.path("completed").asLong(0),
+        counts.path("failed").asLong(0),
+        counts.path("in_progress").asLong(0),
+        counts.path("restored").asLong(0),
+        checkpointDetail(latest.path("completed")),
+        checkpointDetail(latest.path("failed")));
+  }
+
+  private CheckpointDetail checkpointDetail(JsonNode node) {
+    if (node == null || node.isMissingNode() || node.isNull() || node.isEmpty()) {
+      return null;
+    }
+    return new CheckpointDetail(
+        number(node, "id"),
+        number(node, "trigger_timestamp"),
+        number(node, "latest_ack_timestamp"),
+        number(node, "end_to_end_duration"),
+        number(node, "state_size"),
+        number(node, "checkpointed_size"),
+        integer(node, "num_acknowledged_subtasks"),
+        integer(node, "num_subtasks"),
+        redactor.redact(firstText(node, "failure_message", "failure-message")));
+  }
+
+  private MetricSummary metricSummary(String jobId, JsonNode job) {
+    JsonNode vertices = job.path("vertices");
+    if (!vertices.isArray()) {
+      return emptyMetricSummary();
+    }
+
+    Double recordsRead = null;
+    Double recordsReadRate = null;
+    Double recordsWritten = null;
+    Double recordsWrittenRate = null;
+    Double bytesRead = null;
+    Double bytesReadRate = null;
+    Double bytesWritten = null;
+    Double bytesWrittenRate = null;
+    Double maxBusy = null;
+    Double maxBackpressure = null;
+    Double maxIdle = null;
+    int vertexCount = 0;
+
+    for (JsonNode vertex : vertices) {
+      String vertexId = text(vertex, "id");
+      if (vertexId == null || vertexId.isBlank()) {
+        continue;
+      }
+      vertexCount++;
+      Map<String, MetricAggregate> metrics;
+      try {
+        metrics = vertexMetrics(jobId, vertexId);
+      } catch (RealtimeEngineException ignored) {
+        // Jobs can change state while the UI snapshot is being sampled. Return partial metrics.
+        continue;
+      }
+      String name = String.valueOf(text(vertex, "name")).toLowerCase(Locale.ROOT);
+      boolean source = name.contains("source");
+      boolean sink = name.contains("sink");
+
+      if (source) {
+        recordsRead = add(recordsRead, sum(metrics, "numRecordsOut"));
+        recordsReadRate = add(recordsReadRate, sum(metrics, "numRecordsOutPerSecond"));
+        bytesRead = add(bytesRead, sum(metrics, "numBytesOut"));
+        bytesReadRate = add(bytesReadRate, sum(metrics, "numBytesOutPerSecond"));
+      }
+      if (sink) {
+        recordsWritten = add(recordsWritten, sum(metrics, "numRecordsIn"));
+        recordsWrittenRate = add(recordsWrittenRate, sum(metrics, "numRecordsInPerSecond"));
+        bytesWritten = add(bytesWritten, sum(metrics, "numBytesIn"));
+        bytesWrittenRate = add(bytesWrittenRate, sum(metrics, "numBytesInPerSecond"));
+      }
+      maxBusy = max(maxBusy, max(metrics, "busyTimeMsPerSecond"));
+      maxBackpressure = max(maxBackpressure, max(metrics, "backPressuredTimeMsPerSecond"));
+      maxIdle = max(maxIdle, max(metrics, "idleTimeMsPerSecond"));
+    }
+
+    return new MetricSummary(
+        rounded(recordsRead),
+        recordsReadRate,
+        rounded(recordsWritten),
+        recordsWrittenRate,
+        rounded(bytesRead),
+        bytesReadRate,
+        rounded(bytesWritten),
+        bytesWrittenRate,
+        maxBusy,
+        maxBackpressure,
+        maxIdle,
+        vertexCount);
+  }
+
+  private Map<String, MetricAggregate> vertexMetrics(String jobId, String vertexId) {
+    JsonNode body =
+        getJson(
+            "/jobs/"
+                + jobId
+                + "/vertices/"
+                + vertexId
+                + "/subtasks/metrics?get="
+                + METRIC_IDS
+                + "&agg=sum,avg,max",
+            true);
+    Map<String, MetricAggregate> result = new HashMap<>();
+    if (body == null || !body.isArray()) {
+      return result;
+    }
+    for (JsonNode metric : body) {
+      String id = text(metric, "id");
+      if (id != null) {
+        result.put(
+            id,
+            new MetricAggregate(
+                decimal(metric.get("sum")),
+                decimal(metric.get("avg")),
+                decimal(metric.get("max"))));
+      }
+    }
+    return result;
+  }
+
+  private Double sum(Map<String, MetricAggregate> metrics, String id) {
+    MetricAggregate metric = metrics.get(id);
+    return metric == null ? null : metric.sum();
+  }
+
+  private Double max(Map<String, MetricAggregate> metrics, String id) {
+    MetricAggregate metric = metrics.get(id);
+    return metric == null ? null : metric.max();
+  }
+
+  private Double add(Double left, Double right) {
+    if (right == null) {
+      return left;
+    }
+    return (left == null ? 0D : left) + right;
+  }
+
+  private Double max(Double left, Double right) {
+    if (right == null) {
+      return left;
+    }
+    return left == null ? right : Math.max(left, right);
+  }
+
+  private Long rounded(Double value) {
+    return value == null ? null : Math.round(value);
+  }
+
+  private Double decimal(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return null;
+    }
+    try {
+      return Double.valueOf(node.asText());
+    } catch (NumberFormatException exception) {
+      return null;
+    }
+  }
+
+  private String firstText(JsonNode node, String first, String second) {
+    String value = text(node, first);
+    return value == null ? text(node, second) : value;
+  }
+
+  private String text(JsonNode node, String field) {
+    if (node == null || node.path(field).isMissingNode() || node.path(field).isNull()) {
+      return null;
+    }
+    String value = node.path(field).asText(null);
+    return value == null || value.isBlank() ? null : value;
+  }
+
+  private Long number(JsonNode node, String field) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull()) {
+      return null;
+    }
+    return value.isNumber() ? value.longValue() : parseLong(value.asText());
+  }
+
+  private Integer integer(JsonNode node, String field) {
+    Long value = number(node, field);
+    return value == null ? null : value.intValue();
+  }
+
+  private Long parseLong(String value) {
+    try {
+      return value == null || value.isBlank() ? null : Long.valueOf(value);
+    } catch (NumberFormatException exception) {
+      return null;
+    }
+  }
+
+  private JsonNode getJson(String path, boolean allowNotFound) {
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder(URI.create(baseUrl() + path))
+              .timeout(properties.getRequestTimeout())
+              .header("Accept", "application/json")
+              .GET()
+              .build();
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      if (allowNotFound && response.statusCode() == 404) {
+        return null;
+      }
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        throw failure("Flink REST HTTP " + response.statusCode(), true, null);
+      }
+      return response.body() == null || response.body().isBlank()
+          ? json.createObjectNode()
+          : json.readTree(response.body());
+    } catch (HttpTimeoutException exception) {
+      throw failure("Flink REST 请求超时", true, exception);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw failure("Flink REST 请求被中断", true, exception);
+    } catch (IOException exception) {
+      throw failure("Flink REST 连接失败", true, exception);
+    }
+  }
+
+  private CheckpointSummary emptyCheckpointSummary() {
+    return new CheckpointSummary(0, 0, 0, 0, 0, null, null);
+  }
+
+  private MetricSummary emptyMetricSummary() {
+    return new MetricSummary(null, null, null, null, null, null, null, null, null, null, null, 0);
+  }
+
+  private String flinkWebUrl(String jobId) {
+    return baseUrl() + "/#/job/" + jobId + "/overview";
+  }
+
+  private String baseUrl() {
+    return properties.getRestUrl().replaceAll("/+$", "");
+  }
+
+  private void requireJobId(String jobId) {
+    if (jobId == null || !JOB_ID.matcher(jobId).matches()) {
+      throw new IllegalArgumentException("Flink jobId 格式无效");
+    }
+  }
+
+  private String tail(List<String> input, int lines) {
+    Deque<String> values = new ArrayDeque<>(lines);
+    input.forEach(
+        line -> {
+          if (values.size() == lines) {
+            values.removeFirst();
+          }
+          values.addLast(line);
+        });
+    return String.join(System.lineSeparator(), values);
+  }
+
+  private RealtimeEngineException failure(String message, boolean uncertain, Throwable cause) {
+    return new RealtimeEngineException(message, uncertain, null, cause);
+  }
+
+  private record MetricAggregate(Double sum, Double avg, Double max) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityService.java
@@ -25,7 +25,8 @@ public class RealtimeObservabilityService {
   }
 
   public String submissionLog(long definitionId, int tailLines) {
-    return flink.submissionLog(requireJobId(definitionId), tailLines);
+    DeploymentRow deployment = requireDeployment(definitionId);
+    return flink.submissionLog(deployment.idempotencyKey(), tailLines);
   }
 
   public RuntimeLog runtimeLog(long definitionId, int maxExceptions) {
@@ -33,16 +34,19 @@ public class RealtimeObservabilityService {
   }
 
   private String requireJobId(long definitionId) {
-    store
-        .definition(definitionId)
-        .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + definitionId));
-    DeploymentRow deployment =
-        store
-            .latestDeployment(definitionId)
-            .orElseThrow(() -> new IllegalStateException("任务尚无部署记录"));
+    DeploymentRow deployment = requireDeployment(definitionId);
     if (!StringUtils.hasText(deployment.engineJobId())) {
       throw new IllegalStateException("部署记录尚无 Flink jobId，请先执行状态对账");
     }
     return deployment.engineJobId();
+  }
+
+  private DeploymentRow requireDeployment(long definitionId) {
+    store
+        .definition(definitionId)
+        .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + definitionId));
+    return store
+        .latestDeployment(definitionId)
+        .orElseThrow(() -> new IllegalStateException("任务尚无部署记录"));
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityService.java
@@ -1,0 +1,48 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.RuntimeLog;
+import io.yak.ops.business.sync.realtime.engine.FlinkObservabilityClient;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** Application facade for read-only realtime sync observability. */
+@Service
+public class RealtimeObservabilityService {
+
+  private final RealtimeJobStore store;
+  private final FlinkObservabilityClient flink;
+
+  public RealtimeObservabilityService(RealtimeJobStore store, FlinkObservabilityClient flink) {
+    this.store = store;
+    this.flink = flink;
+  }
+
+  public RealtimeObservabilityView snapshot(long definitionId) {
+    return flink.snapshot(requireJobId(definitionId));
+  }
+
+  public String submissionLog(long definitionId, int tailLines) {
+    return flink.submissionLog(requireJobId(definitionId), tailLines);
+  }
+
+  public RuntimeLog runtimeLog(long definitionId, int maxExceptions) {
+    return flink.runtimeLog(requireJobId(definitionId), maxExceptions);
+  }
+
+  private String requireJobId(long definitionId) {
+    store
+        .definition(definitionId)
+        .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + definitionId));
+    DeploymentRow deployment =
+        store
+            .latestDeployment(definitionId)
+            .orElseThrow(() -> new IllegalStateException("任务尚无部署记录"));
+    if (!StringUtils.hasText(deployment.engineJobId())) {
+      throw new IllegalStateException("部署记录尚无 Flink jobId，请先执行状态对账");
+    }
+    return deployment.engineJobId();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewayTest.java
@@ -89,6 +89,10 @@ class FlinkCdcEngineGatewayTest {
         .contains("Flink job exceptions")
         .doesNotContain("source-secret", "sink-secret");
 
+    Path logs = temp.resolve("work/logs");
+    assertThat(logs.resolve("submit-test-key.log")).exists();
+    assertThat(logs.resolve(JOB_ID + ".submit.log")).exists();
+
     gateway.stop(JOB_ID);
     assertThat(cancelled).isTrue();
     try (var files = Files.list(temp.resolve("work/pipelines"))) {
@@ -104,7 +108,7 @@ class FlinkCdcEngineGatewayTest {
   }
 
   @Test
-  void redactsFailedSubmitOutputAndDeletesPipelineFile() throws Exception {
+  void redactsFailedSubmitOutputRetainsLogAndDeletesPipelineFile() throws Exception {
     Path cli = temp.resolve("flink-cdc/bin/flink-cdc.sh");
     Files.writeString(
         cli,
@@ -129,6 +133,12 @@ class FlinkCdcEngineGatewayTest {
           .hasMessageNotContaining("source-secret")
           .hasMessageNotContaining("sink-secret");
     }
+
+    Path retained = temp.resolve("work/logs/submit-failed-key.log");
+    assertThat(retained).exists();
+    assertThat(Files.readString(retained, StandardCharsets.UTF_8))
+        .contains("password=******")
+        .doesNotContain("source-secret");
     try (var files = Files.list(temp.resolve("work/pipelines"))) {
       assertThat(files).isEmpty();
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClientTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClientTest.java
@@ -70,11 +70,11 @@ class FlinkObservabilityClientTest {
   void separatesSubmissionLogFromRuntimeExceptionHistory() throws Exception {
     Path logs = Files.createDirectories(temp.resolve("work/logs"));
     Files.writeString(
-        logs.resolve(JOB_ID + ".submit.log"),
+        logs.resolve("submit-test-key.log"),
         "submitted\npassword=plain-secret\n",
         StandardCharsets.UTF_8);
 
-    assertThat(client.submissionLog(JOB_ID, 20))
+    assertThat(client.submissionLog("test-key", 20))
         .contains("submitted")
         .contains("password=******")
         .doesNotContain("plain-secret");
@@ -154,7 +154,15 @@ class FlinkObservabilityClientTest {
   }
 
   private String metric(String id, double sum, double max) {
-    return "{\"id\":\"" + id + "\",\"sum\":\"" + sum + "\",\"avg\":\"" + sum + "\",\"max\":\"" + max + "\"}";
+    return "{\"id\":\""
+        + id
+        + "\",\"sum\":\""
+        + sum
+        + "\",\"avg\":\""
+        + sum
+        + "\",\"max\":\""
+        + max
+        + "\"}";
   }
 
   private void json(HttpExchange exchange, int status, String body) throws IOException {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClientTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClientTest.java
@@ -1,0 +1,167 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FlinkObservabilityClientTest {
+
+  private static final String JOB_ID = "0123456789abcdef0123456789abcdef";
+
+  @TempDir Path temp;
+  private HttpServer server;
+  private FlinkObservabilityClient client;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/jobs/", this::jobApi);
+    server.start();
+
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setRestUrl("http://127.0.0.1:" + server.getAddress().getPort());
+    properties.setWorkDirectory(temp.resolve("work").toString());
+    client =
+        new FlinkObservabilityClient(
+            HttpClient.newHttpClient(),
+            new ObjectMapper(),
+            properties,
+            new RealtimeLogRedactor());
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  void normalizesJobCheckpointAndVertexMetrics() {
+    RealtimeObservabilityView view = client.snapshot(JOB_ID);
+
+    assertThat(view.flinkState()).isEqualTo("RUNNING");
+    assertThat(view.durationMs()).isEqualTo(5000L);
+    assertThat(view.checkpoints().completed()).isEqualTo(3);
+    assertThat(view.checkpoints().latestCompleted().id()).isEqualTo(9L);
+    assertThat(view.checkpoints().latestCompleted().durationMs()).isEqualTo(320L);
+    assertThat(view.metrics().recordsRead()).isEqualTo(1200L);
+    assertThat(view.metrics().recordsReadPerSecond()).isEqualTo(24D);
+    assertThat(view.metrics().recordsWritten()).isEqualTo(1188L);
+    assertThat(view.metrics().recordsWrittenPerSecond()).isEqualTo(23D);
+    assertThat(view.metrics().maxBackpressuredMsPerSecond()).isEqualTo(120D);
+    assertThat(view.metrics().vertexCount()).isEqualTo(2);
+    assertThat(view.flinkWebUrl()).contains("/#/job/" + JOB_ID + "/overview");
+  }
+
+  @Test
+  void separatesSubmissionLogFromRuntimeExceptionHistory() throws Exception {
+    Path logs = Files.createDirectories(temp.resolve("work/logs"));
+    Files.writeString(
+        logs.resolve(JOB_ID + ".submit.log"),
+        "submitted\npassword=plain-secret\n",
+        StandardCharsets.UTF_8);
+
+    assertThat(client.submissionLog(JOB_ID, 20))
+        .contains("submitted")
+        .contains("password=******")
+        .doesNotContain("plain-secret");
+
+    RealtimeObservabilityView.RuntimeLog runtime = client.runtimeLog(JOB_ID, 20);
+    assertThat(runtime.rootException()).contains("boom");
+    assertThat(runtime.exceptions()).hasSize(1);
+    assertThat(runtime.exceptions().get(0).taskName()).isEqualTo("Sink: yak-jdbc");
+  }
+
+  private void jobApi(HttpExchange exchange) throws IOException {
+    String path = exchange.getRequestURI().getPath();
+    if (path.equals("/jobs/" + JOB_ID)) {
+      json(
+          exchange,
+          200,
+          "{\"jid\":\""
+              + JOB_ID
+              + "\",\"name\":\"yak-rt-demo\",\"state\":\"RUNNING\","
+              + "\"start-time\":1000,\"duration\":5000,\"vertices\":["
+              + "{\"id\":\"source-vertex\",\"name\":\"Source: mysql-cdc\"},"
+              + "{\"id\":\"sink-vertex\",\"name\":\"Sink: yak-jdbc\"}]}");
+      return;
+    }
+    if (path.equals("/jobs/" + JOB_ID + "/checkpoints")) {
+      json(
+          exchange,
+          200,
+          "{\"counts\":{\"total\":4,\"completed\":3,\"failed\":1,\"in_progress\":0,\"restored\":0},"
+              + "\"latest\":{\"completed\":{\"id\":9,\"trigger_timestamp\":2000,"
+              + "\"latest_ack_timestamp\":2320,\"end_to_end_duration\":320,\"state_size\":4096,"
+              + "\"checkpointed_size\":2048,\"num_acknowledged_subtasks\":2,\"num_subtasks\":2}}}");
+      return;
+    }
+    if (path.equals("/jobs/" + JOB_ID + "/exceptions")) {
+      json(
+          exchange,
+          200,
+          "{\"exceptionHistory\":{\"truncated\":false,\"entries\":[{"
+              + "\"exceptionName\":\"java.lang.RuntimeException\",\"stacktrace\":\"boom\\nstack\","
+              + "\"timestamp\":3000,\"taskName\":\"Sink: yak-jdbc\","
+              + "\"taskManagerId\":\"tm-1\",\"endpoint\":\"127.0.0.1:1234\"}]}}}");
+      return;
+    }
+    if (path.endsWith("/subtasks/metrics")) {
+      boolean source = path.contains("source-vertex");
+      json(
+          exchange,
+          200,
+          source
+              ? metrics("numRecordsOut", 1200, "numRecordsOutPerSecond", 24, 50, 20, 900)
+              : metrics("numRecordsIn", 1188, "numRecordsInPerSecond", 23, 700, 120, 180));
+      return;
+    }
+    json(exchange, 404, "{}");
+  }
+
+  private String metrics(
+      String recordsId,
+      int records,
+      String rateId,
+      int rate,
+      int busy,
+      int backpressure,
+      int idle) {
+    return "["
+        + metric(recordsId, records, records)
+        + ","
+        + metric(rateId, rate, rate)
+        + ","
+        + metric("busyTimeMsPerSecond", busy, busy)
+        + ","
+        + metric("backPressuredTimeMsPerSecond", backpressure, backpressure)
+        + ","
+        + metric("idleTimeMsPerSecond", idle, idle)
+        + "]";
+  }
+
+  private String metric(String id, double sum, double max) {
+    return "{\"id\":\"" + id + "\",\"sum\":\"" + sum + "\",\"avg\":\"" + sum + "\",\"max\":\"" + max + "\"}";
+  }
+
+  private void json(HttpExchange exchange, int status, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityServiceTest.java
@@ -1,0 +1,87 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.engine.FlinkObservabilityClient;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RealtimeObservabilityServiceTest {
+
+  private static final long JOB_ID = 7L;
+  private RealtimeJobStore store;
+  private FlinkObservabilityClient flink;
+  private RealtimeObservabilityService service;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    flink = mock(FlinkObservabilityClient.class);
+    service = new RealtimeObservabilityService(store, flink);
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(definition()));
+  }
+
+  @Test
+  void readsSubmissionLogBeforeFlinkJobIdIsRecovered() {
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment(null)));
+    when(flink.submissionLog("start-key", 500)).thenReturn("submitting");
+
+    assertThat(service.submissionLog(JOB_ID, 500)).isEqualTo("submitting");
+    verify(flink).submissionLog("start-key", 500);
+  }
+
+  @Test
+  void runtimeObservabilityStillRequiresFlinkJobId() {
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment(null)));
+
+    assertThatThrownBy(() -> service.runtimeLog(JOB_ID, 50))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("尚无 Flink jobId");
+  }
+
+  private DefinitionRow definition() {
+    LocalDateTime now = LocalDateTime.now();
+    return new DefinitionRow(
+        JOB_ID,
+        "test-job",
+        null,
+        "{}",
+        "PUBLISHED",
+        "RUNNING",
+        "STARTING",
+        1,
+        1,
+        "digest",
+        null,
+        now,
+        now);
+  }
+
+  private DeploymentRow deployment(String engineJobId) {
+    LocalDateTime now = LocalDateTime.now();
+    return new DeploymentRow(
+        19L,
+        JOB_ID,
+        1,
+        "{}",
+        "summary",
+        "digest",
+        "start-key",
+        engineJobId,
+        null,
+        "SUBMITTING",
+        true,
+        null,
+        now,
+        now);
+  }
+}

--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeRuntimeDetail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeRuntimeDetail.tsx
@@ -46,6 +46,9 @@ const formatBytes = (value?: number) => {
   return `${current.toFixed(current >= 100 ? 0 : current >= 10 ? 1 : 2)} ${units[index]}`;
 };
 
+const formatByteRate = (value?: number) =>
+  value === undefined || value === null ? '-' : `${formatBytes(value)}/s`;
+
 const formatDuration = (value?: number) => {
   if (value === undefined || value === null) return '-';
   const seconds = Math.max(0, Math.floor(value / 1000));
@@ -98,6 +101,7 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
   const [runtimeLoading, setRuntimeLoading] = useState(false);
 
   const engineJobId = job.latestDeployment?.engineJobId;
+  const hasDeployment = Boolean(job.latestDeployment);
   const canObserve = Boolean(engineJobId);
 
   const refreshObservability = useCallback(
@@ -170,11 +174,13 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
       <Space direction="vertical" size={16} style={{ width: '100%' }}>
         <div className="flex items-center justify-between gap-3">
           <div className="text-[12px] text-[#98a2b3]">
-            {observability?.sampledAt ? `采样时间：${formatTime(observability.sampledAt)}` : '正在读取 Flink 状态'}
+            {observability?.sampledAt
+              ? `采样时间：${formatTime(observability.sampledAt)}`
+              : '正在读取 Flink 状态'}
           </div>
           <Space>
             {flinkWebUrl && (
-              <Button size="small" href={flinkWebUrl} target="_blank" rel="noreferrer">
+              <Button size="small" href={flinkWebUrl} target="_blank">
                 打开 Flink Web UI
               </Button>
             )}
@@ -221,7 +227,9 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
           </Descriptions.Item>
           <Descriptions.Item label="启动时间">{formatTime(observability?.startTime)}</Descriptions.Item>
           <Descriptions.Item label="最近 Checkpoint">
-            {latestCheckpoint?.id ? `#${latestCheckpoint.id} · ${formatDuration(latestCheckpoint.durationMs)}` : '-'}
+            {latestCheckpoint?.id
+              ? `#${latestCheckpoint.id} · ${formatDuration(latestCheckpoint.durationMs)}`
+              : '-'}
           </Descriptions.Item>
           <Descriptions.Item label="部署摘要" span={2}>
             {job.latestDeployment?.specSummary || '-'}
@@ -234,32 +242,32 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
     </Spin>
   );
 
-  const logs = !canObserve ? (
-    <Empty description="当前任务还没有 Flink JobId，暂无日志可查询" />
-  ) : (
+  const logs = (
     <Tabs
       items={[
         {
           key: 'submission',
           label: '提交日志',
-          children: (
+          children: hasDeployment ? (
             <Space direction="vertical" style={{ width: '100%' }}>
               <Alert
                 type="info"
                 showIcon
-                message="这里展示 Flink CDC CLI 提交过程；密码、Token 等敏感字段会在后端再次脱敏。"
+                message="这里展示 Flink CDC CLI 提交过程；即使提交失败、超时或 JobId 尚未恢复，也会按本次部署保留日志。密码、Token 等敏感字段会在后端再次脱敏。"
               />
               <Button loading={submissionLoading} onClick={() => void loadSubmissionLog()}>
                 读取最近提交日志
               </Button>
               <CodeBlock empty="尚未读取提交日志">{submissionLog}</CodeBlock>
             </Space>
+          ) : (
+            <Empty description="任务尚无部署记录，暂无提交日志" />
           ),
         },
         {
           key: 'runtime',
           label: '运行诊断',
-          children: (
+          children: canObserve ? (
             <Space direction="vertical" style={{ width: '100%' }}>
               <Alert
                 type="info"
@@ -274,7 +282,9 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
                   type="error"
                   showIcon
                   message={`最近异常 · ${formatTime(runtimeLog.timestamp)}`}
-                  description={<pre className="m-0 whitespace-pre-wrap text-[12px]">{runtimeLog.rootException}</pre>}
+                  description={
+                    <pre className="m-0 whitespace-pre-wrap text-[12px]">{runtimeLog.rootException}</pre>
+                  }
                 />
               )}
               {runtimeLog?.truncated && (
@@ -290,7 +300,8 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
                           {item.exceptionName || 'Runtime Exception'}
                         </div>
                         <div className="mt-0.5 text-[11px] text-[#98a2b3]">
-                          {formatTime(item.timestamp)} · {item.taskName || '-'} · {item.taskManagerId || '-'}
+                          {formatTime(item.timestamp)} · {item.taskName || '-'} ·{' '}
+                          {item.taskManagerId || '-'}
                         </div>
                         {item.stacktrace && (
                           <pre className="mt-2 max-h-[220px] overflow-auto whitespace-pre-wrap rounded bg-[#f8f9fb] p-3 text-[11px] text-[#475467]">
@@ -305,6 +316,8 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
                 <Empty description={runtimeLog ? 'Flink 当前没有异常历史' : '尚未读取运行诊断'} />
               )}
             </Space>
+          ) : (
+            <Empty description="Flink JobId 尚未确认；可以先查看提交日志，待状态对账恢复 JobId 后再读取运行诊断" />
           ),
         },
       ]}
@@ -336,9 +349,15 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
         {latestCheckpoint ? (
           <Descriptions bordered size="small" column={2}>
             <Descriptions.Item label="最近成功 ID">#{latestCheckpoint.id}</Descriptions.Item>
-            <Descriptions.Item label="完成时间">{formatTime(latestCheckpoint.latestAckTimestamp)}</Descriptions.Item>
-            <Descriptions.Item label="耗时">{formatDuration(latestCheckpoint.durationMs)}</Descriptions.Item>
-            <Descriptions.Item label="状态大小">{formatBytes(latestCheckpoint.stateSizeBytes)}</Descriptions.Item>
+            <Descriptions.Item label="完成时间">
+              {formatTime(latestCheckpoint.latestAckTimestamp)}
+            </Descriptions.Item>
+            <Descriptions.Item label="耗时">
+              {formatDuration(latestCheckpoint.durationMs)}
+            </Descriptions.Item>
+            <Descriptions.Item label="状态大小">
+              {formatBytes(latestCheckpoint.stateSizeBytes)}
+            </Descriptions.Item>
             <Descriptions.Item label="Checkpointed Size">
               {formatBytes(latestCheckpoint.checkpointedSizeBytes)}
             </Descriptions.Item>
@@ -350,7 +369,12 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
           <Empty description="还没有成功的 Checkpoint" />
         )}
         {checkpoint?.latestFailed?.failureMessage && (
-          <Alert type="error" showIcon message="最近 Checkpoint 失败" description={checkpoint.latestFailed.failureMessage} />
+          <Alert
+            type="error"
+            showIcon
+            message="最近 Checkpoint 失败"
+            description={checkpoint.latestFailed.failureMessage}
+          />
         )}
       </Space>
     </Spin>
@@ -388,12 +412,12 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
           <MetricCard
             label="Source Bytes"
             value={formatBytes(metrics?.bytesRead)}
-            hint={`${formatBytes(metrics?.bytesReadPerSecond)}/s`}
+            hint={formatByteRate(metrics?.bytesReadPerSecond)}
           />
           <MetricCard
             label="Sink Bytes"
             value={formatBytes(metrics?.bytesWritten)}
-            hint={`${formatBytes(metrics?.bytesWrittenPerSecond)}/s`}
+            hint={formatByteRate(metrics?.bytesWrittenPerSecond)}
           />
         </div>
         <Card size="small" title="运行压力">
@@ -410,7 +434,15 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
                 <span>最大 Backpressure</span>
                 <span>{metrics?.maxBackpressuredMsPerSecond?.toFixed(0) ?? '-'} ms/s</span>
               </div>
-              <Progress percent={pressurePercent(metrics?.maxBackpressuredMsPerSecond)} showInfo={false} status={pressurePercent(metrics?.maxBackpressuredMsPerSecond) >= 70 ? 'exception' : 'normal'} />
+              <Progress
+                percent={pressurePercent(metrics?.maxBackpressuredMsPerSecond)}
+                showInfo={false}
+                status={
+                  pressurePercent(metrics?.maxBackpressuredMsPerSecond) >= 70
+                    ? 'exception'
+                    : 'normal'
+                }
+              />
             </div>
             <div>
               <div className="mb-1 flex justify-between text-[12px] text-[#667085]">

--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeRuntimeDetail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeRuntimeDetail.tsx
@@ -1,0 +1,464 @@
+import {
+  Alert,
+  Button,
+  Card,
+  Descriptions,
+  Empty,
+  Progress,
+  Space,
+  Spin,
+  Tabs,
+  Timeline,
+  Typography,
+  message,
+} from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { realtimeApi } from './api';
+import type {
+  RealtimeEvent,
+  RealtimeJob,
+  RealtimeObservability,
+  RealtimeRuntimeLog,
+  RuntimeCapabilities,
+} from './types';
+
+const ACTIVE_STATES = new Set(['STARTING', 'RUNNING', 'STOPPING', 'UNKNOWN']);
+
+const formatNumber = (value?: number) =>
+  value === undefined || value === null
+    ? '-'
+    : new Intl.NumberFormat('zh-CN', { maximumFractionDigits: 0 }).format(value);
+
+const formatRate = (value?: number) =>
+  value === undefined || value === null ? '-' : `${formatNumber(value)}/s`;
+
+const formatBytes = (value?: number) => {
+  if (value === undefined || value === null) return '-';
+  if (value < 1024) return `${value} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let current = value / 1024;
+  let index = 0;
+  while (current >= 1024 && index < units.length - 1) {
+    current /= 1024;
+    index += 1;
+  }
+  return `${current.toFixed(current >= 100 ? 0 : current >= 10 ? 1 : 2)} ${units[index]}`;
+};
+
+const formatDuration = (value?: number) => {
+  if (value === undefined || value === null) return '-';
+  const seconds = Math.max(0, Math.floor(value / 1000));
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const rest = seconds % 60;
+  if (days > 0) return `${days}天 ${hours}小时`;
+  if (hours > 0) return `${hours}小时 ${minutes}分`;
+  if (minutes > 0) return `${minutes}分 ${rest}秒`;
+  return `${rest}秒`;
+};
+
+const formatTime = (value?: number) =>
+  value === undefined || value === null ? '-' : new Date(value).toLocaleString('zh-CN');
+
+const pressurePercent = (value?: number) =>
+  value === undefined || value === null ? 0 : Math.max(0, Math.min(100, Math.round(value / 10)));
+
+function MetricCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <Card size="small" className="h-full">
+      <div className="text-[12px] text-[#667085]">{label}</div>
+      <div className="mt-1 text-[22px] font-semibold leading-8 text-[#101828]">{value}</div>
+      {hint && <div className="mt-1 text-[11px] text-[#98a2b3]">{hint}</div>}
+    </Card>
+  );
+}
+
+function CodeBlock({ children, empty }: { children?: string; empty: string }) {
+  return (
+    <pre className="max-h-[520px] min-h-[180px] overflow-auto rounded-lg bg-[#101828] p-4 text-[12px] leading-5 text-[#d0d5dd]">
+      {children || empty}
+    </pre>
+  );
+}
+
+interface Props {
+  job: RealtimeJob;
+  events: RealtimeEvent[];
+  capabilities: RuntimeCapabilities;
+}
+
+export default function RealtimeRuntimeDetail({ job, events, capabilities }: Props) {
+  const [observability, setObservability] = useState<RealtimeObservability>();
+  const [observabilityLoading, setObservabilityLoading] = useState(false);
+  const [submissionLog, setSubmissionLog] = useState('');
+  const [runtimeLog, setRuntimeLog] = useState<RealtimeRuntimeLog>();
+  const [submissionLoading, setSubmissionLoading] = useState(false);
+  const [runtimeLoading, setRuntimeLoading] = useState(false);
+
+  const engineJobId = job.latestDeployment?.engineJobId;
+  const canObserve = Boolean(engineJobId);
+
+  const refreshObservability = useCallback(
+    async (showError = true) => {
+      if (!engineJobId) return;
+      setObservabilityLoading(true);
+      try {
+        const result = await realtimeApi.observability(job.id);
+        setObservability(result.data);
+      } catch (error: any) {
+        if (showError) message.error(error?.message || 'Flink 观测数据不可用');
+      } finally {
+        setObservabilityLoading(false);
+      }
+    },
+    [engineJobId, job.id],
+  );
+
+  useEffect(() => {
+    setObservability(undefined);
+    setSubmissionLog('');
+    setRuntimeLog(undefined);
+    if (engineJobId) void refreshObservability(false);
+  }, [engineJobId, job.id, refreshObservability]);
+
+  useEffect(() => {
+    if (!engineJobId || !ACTIVE_STATES.has(job.observedState)) return undefined;
+    const timer = window.setInterval(() => void refreshObservability(false), 5000);
+    return () => window.clearInterval(timer);
+  }, [engineJobId, job.observedState, refreshObservability]);
+
+  const loadSubmissionLog = async () => {
+    setSubmissionLoading(true);
+    try {
+      const result = await realtimeApi.submissionLog(job.id);
+      setSubmissionLog(result.data.logs || '');
+    } catch (error: any) {
+      message.error(error?.message || '提交日志不可用');
+    } finally {
+      setSubmissionLoading(false);
+    }
+  };
+
+  const loadRuntimeLog = async () => {
+    setRuntimeLoading(true);
+    try {
+      const result = await realtimeApi.runtimeLog(job.id);
+      setRuntimeLog(result.data);
+    } catch (error: any) {
+      message.error(error?.message || '运行诊断不可用');
+    } finally {
+      setRuntimeLoading(false);
+    }
+  };
+
+  const flinkWebUrl = useMemo(() => {
+    if (observability?.flinkWebUrl) return observability.flinkWebUrl;
+    if (!engineJobId || !capabilities.restUrl) return undefined;
+    return `${capabilities.restUrl.replace(/\/+$/, '')}/#/job/${engineJobId}/overview`;
+  }, [capabilities.restUrl, engineJobId, observability?.flinkWebUrl]);
+
+  const checkpoint = observability?.checkpoints;
+  const latestCheckpoint = checkpoint?.latestCompleted;
+  const metrics = observability?.metrics;
+
+  const overview = !canObserve ? (
+    <Empty description="当前任务还没有可观测的 Flink JobId" />
+  ) : (
+    <Spin spinning={observabilityLoading && !observability}>
+      <Space direction="vertical" size={16} style={{ width: '100%' }}>
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-[12px] text-[#98a2b3]">
+            {observability?.sampledAt ? `采样时间：${formatTime(observability.sampledAt)}` : '正在读取 Flink 状态'}
+          </div>
+          <Space>
+            {flinkWebUrl && (
+              <Button size="small" href={flinkWebUrl} target="_blank" rel="noreferrer">
+                打开 Flink Web UI
+              </Button>
+            )}
+            <Button
+              size="small"
+              icon={<ReloadOutlined />}
+              loading={observabilityLoading}
+              onClick={() => void refreshObservability()}
+            >
+              刷新
+            </Button>
+          </Space>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <MetricCard
+            label="Flink 状态"
+            value={observability?.flinkState || job.observedState || '-'}
+            hint={observability?.flinkJobName || '等待 Flink 返回运行名称'}
+          />
+          <MetricCard label="运行时长" value={formatDuration(observability?.durationMs)} />
+          <MetricCard
+            label="读取速率"
+            value={formatRate(metrics?.recordsReadPerSecond)}
+            hint={`累计 ${formatNumber(metrics?.recordsRead)} 条`}
+          />
+          <MetricCard
+            label="写入速率"
+            value={formatRate(metrics?.recordsWrittenPerSecond)}
+            hint={`累计 ${formatNumber(metrics?.recordsWritten)} 条`}
+          />
+        </div>
+
+        <Descriptions bordered size="small" column={2}>
+          <Descriptions.Item label="定义版本">
+            v{job.definitionVersion} / 已发布 v{job.publishedVersion || '-'}
+          </Descriptions.Item>
+          <Descriptions.Item label="运行意图">
+            {job.desiredState} / {job.observedState}
+          </Descriptions.Item>
+          <Descriptions.Item label="Flink JobId">{engineJobId || '-'}</Descriptions.Item>
+          <Descriptions.Item label="Flink CDC Revision">
+            {job.latestDeployment?.runtimeRevision || '-'}
+          </Descriptions.Item>
+          <Descriptions.Item label="启动时间">{formatTime(observability?.startTime)}</Descriptions.Item>
+          <Descriptions.Item label="最近 Checkpoint">
+            {latestCheckpoint?.id ? `#${latestCheckpoint.id} · ${formatDuration(latestCheckpoint.durationMs)}` : '-'}
+          </Descriptions.Item>
+          <Descriptions.Item label="部署摘要" span={2}>
+            {job.latestDeployment?.specSummary || '-'}
+          </Descriptions.Item>
+          <Descriptions.Item label="最近错误" span={2}>
+            {job.lastError || '-'}
+          </Descriptions.Item>
+        </Descriptions>
+      </Space>
+    </Spin>
+  );
+
+  const logs = !canObserve ? (
+    <Empty description="当前任务还没有 Flink JobId，暂无日志可查询" />
+  ) : (
+    <Tabs
+      items={[
+        {
+          key: 'submission',
+          label: '提交日志',
+          children: (
+            <Space direction="vertical" style={{ width: '100%' }}>
+              <Alert
+                type="info"
+                showIcon
+                message="这里展示 Flink CDC CLI 提交过程；密码、Token 等敏感字段会在后端再次脱敏。"
+              />
+              <Button loading={submissionLoading} onClick={() => void loadSubmissionLog()}>
+                读取最近提交日志
+              </Button>
+              <CodeBlock empty="尚未读取提交日志">{submissionLog}</CodeBlock>
+            </Space>
+          ),
+        },
+        {
+          key: 'runtime',
+          label: '运行诊断',
+          children: (
+            <Space direction="vertical" style={{ width: '100%' }}>
+              <Alert
+                type="info"
+                showIcon
+                message="运行诊断来自 Flink Job Exception History，用于定位作业失败和 Task 异常；完整 JobManager/TaskManager 日志请进入 Flink Web UI。"
+              />
+              <Button loading={runtimeLoading} onClick={() => void loadRuntimeLog()}>
+                刷新运行诊断
+              </Button>
+              {runtimeLog?.rootException && (
+                <Alert
+                  type="error"
+                  showIcon
+                  message={`最近异常 · ${formatTime(runtimeLog.timestamp)}`}
+                  description={<pre className="m-0 whitespace-pre-wrap text-[12px]">{runtimeLog.rootException}</pre>}
+                />
+              )}
+              {runtimeLog?.truncated && (
+                <Alert type="warning" showIcon message="Flink 异常历史已截断，仅展示最近部分记录" />
+              )}
+              {runtimeLog?.exceptions?.length ? (
+                <Timeline
+                  items={runtimeLog.exceptions.map((item, index) => ({
+                    color: 'red',
+                    children: (
+                      <div key={`${item.timestamp || 0}-${index}`}>
+                        <div className="font-medium text-[#344054]">
+                          {item.exceptionName || 'Runtime Exception'}
+                        </div>
+                        <div className="mt-0.5 text-[11px] text-[#98a2b3]">
+                          {formatTime(item.timestamp)} · {item.taskName || '-'} · {item.taskManagerId || '-'}
+                        </div>
+                        {item.stacktrace && (
+                          <pre className="mt-2 max-h-[220px] overflow-auto whitespace-pre-wrap rounded bg-[#f8f9fb] p-3 text-[11px] text-[#475467]">
+                            {item.stacktrace}
+                          </pre>
+                        )}
+                      </div>
+                    ),
+                  }))}
+                />
+              ) : (
+                <Empty description={runtimeLog ? 'Flink 当前没有异常历史' : '尚未读取运行诊断'} />
+              )}
+            </Space>
+          ),
+        },
+      ]}
+    />
+  );
+
+  const checkpoints = !canObserve ? (
+    <Empty description="当前任务还没有 Flink JobId，暂无 Checkpoint 数据" />
+  ) : (
+    <Spin spinning={observabilityLoading && !observability}>
+      <Space direction="vertical" size={16} style={{ width: '100%' }}>
+        <div className="flex items-center justify-between">
+          <Typography.Text type="secondary">Checkpoint 汇总由 Flink REST 归一化展示</Typography.Text>
+          <Button
+            size="small"
+            icon={<ReloadOutlined />}
+            loading={observabilityLoading}
+            onClick={() => void refreshObservability()}
+          >
+            刷新
+          </Button>
+        </div>
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <MetricCard label="成功" value={formatNumber(checkpoint?.completed)} />
+          <MetricCard label="失败" value={formatNumber(checkpoint?.failed)} />
+          <MetricCard label="进行中" value={formatNumber(checkpoint?.inProgress)} />
+          <MetricCard label="总计" value={formatNumber(checkpoint?.total)} />
+        </div>
+        {latestCheckpoint ? (
+          <Descriptions bordered size="small" column={2}>
+            <Descriptions.Item label="最近成功 ID">#{latestCheckpoint.id}</Descriptions.Item>
+            <Descriptions.Item label="完成时间">{formatTime(latestCheckpoint.latestAckTimestamp)}</Descriptions.Item>
+            <Descriptions.Item label="耗时">{formatDuration(latestCheckpoint.durationMs)}</Descriptions.Item>
+            <Descriptions.Item label="状态大小">{formatBytes(latestCheckpoint.stateSizeBytes)}</Descriptions.Item>
+            <Descriptions.Item label="Checkpointed Size">
+              {formatBytes(latestCheckpoint.checkpointedSizeBytes)}
+            </Descriptions.Item>
+            <Descriptions.Item label="确认 Subtasks">
+              {latestCheckpoint.acknowledgedSubtasks ?? '-'} / {latestCheckpoint.totalSubtasks ?? '-'}
+            </Descriptions.Item>
+          </Descriptions>
+        ) : (
+          <Empty description="还没有成功的 Checkpoint" />
+        )}
+        {checkpoint?.latestFailed?.failureMessage && (
+          <Alert type="error" showIcon message="最近 Checkpoint 失败" description={checkpoint.latestFailed.failureMessage} />
+        )}
+      </Space>
+    </Spin>
+  );
+
+  const metricPanel = !canObserve ? (
+    <Empty description="当前任务还没有 Flink JobId，暂无 Metrics 数据" />
+  ) : (
+    <Spin spinning={observabilityLoading && !observability}>
+      <Space direction="vertical" size={16} style={{ width: '100%' }}>
+        <div className="flex items-center justify-between">
+          <Typography.Text type="secondary">
+            Source/Sink 吞吐来自 Flink vertex 聚合指标；无法可靠识别时显示为 “-”
+          </Typography.Text>
+          <Button
+            size="small"
+            icon={<ReloadOutlined />}
+            loading={observabilityLoading}
+            onClick={() => void refreshObservability()}
+          >
+            刷新
+          </Button>
+        </div>
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <MetricCard
+            label="Source Records"
+            value={formatNumber(metrics?.recordsRead)}
+            hint={formatRate(metrics?.recordsReadPerSecond)}
+          />
+          <MetricCard
+            label="Sink Records"
+            value={formatNumber(metrics?.recordsWritten)}
+            hint={formatRate(metrics?.recordsWrittenPerSecond)}
+          />
+          <MetricCard
+            label="Source Bytes"
+            value={formatBytes(metrics?.bytesRead)}
+            hint={`${formatBytes(metrics?.bytesReadPerSecond)}/s`}
+          />
+          <MetricCard
+            label="Sink Bytes"
+            value={formatBytes(metrics?.bytesWritten)}
+            hint={`${formatBytes(metrics?.bytesWrittenPerSecond)}/s`}
+          />
+        </div>
+        <Card size="small" title="运行压力">
+          <Space direction="vertical" size={14} style={{ width: '100%' }}>
+            <div>
+              <div className="mb-1 flex justify-between text-[12px] text-[#667085]">
+                <span>最大 Busy</span>
+                <span>{metrics?.maxBusyMsPerSecond?.toFixed(0) ?? '-'} ms/s</span>
+              </div>
+              <Progress percent={pressurePercent(metrics?.maxBusyMsPerSecond)} showInfo={false} />
+            </div>
+            <div>
+              <div className="mb-1 flex justify-between text-[12px] text-[#667085]">
+                <span>最大 Backpressure</span>
+                <span>{metrics?.maxBackpressuredMsPerSecond?.toFixed(0) ?? '-'} ms/s</span>
+              </div>
+              <Progress percent={pressurePercent(metrics?.maxBackpressuredMsPerSecond)} showInfo={false} status={pressurePercent(metrics?.maxBackpressuredMsPerSecond) >= 70 ? 'exception' : 'normal'} />
+            </div>
+            <div>
+              <div className="mb-1 flex justify-between text-[12px] text-[#667085]">
+                <span>最大 Idle</span>
+                <span>{metrics?.maxIdleMsPerSecond?.toFixed(0) ?? '-'} ms/s</span>
+              </div>
+              <Progress percent={pressurePercent(metrics?.maxIdleMsPerSecond)} showInfo={false} />
+            </div>
+            <Typography.Text type="secondary" className="text-[11px]">
+              当前采集到 {metrics?.vertexCount || 0} 个 Flink Vertex。
+            </Typography.Text>
+          </Space>
+        </Card>
+      </Space>
+    </Spin>
+  );
+
+  return (
+    <Tabs
+      items={[
+        { key: 'overview', label: '运行概览', children: overview },
+        {
+          key: 'events',
+          label: '状态事件',
+          children: events.length ? (
+            <Timeline
+              items={events.map((event) => ({
+                color:
+                  event.toState === 'FAILED' || event.toState === 'CONFLICT' ? 'red' : 'blue',
+                children: (
+                  <div>
+                    <Typography.Text strong>{event.eventType}</Typography.Text>{' '}
+                    <Typography.Text type="secondary">{event.createTime}</Typography.Text>
+                    <div>
+                      {event.fromState || '-'} → {event.toState || '-'} · {event.message}
+                    </div>
+                  </div>
+                ),
+              }))}
+            />
+          ) : (
+            <Empty description="暂无状态事件" />
+          ),
+        },
+        { key: 'logs', label: '日志', children: logs },
+        { key: 'checkpoints', label: 'Checkpoint', children: checkpoints },
+        { key: 'metrics', label: 'Metrics', children: metricPanel },
+      ]}
+    />
+  );
+}

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -7,6 +7,8 @@ import type {
   RealtimeEvent,
   RealtimeJob,
   RealtimeJobPage,
+  RealtimeObservability,
+  RealtimeRuntimeLog,
   ReleaseState,
   RuntimeCapabilities,
 } from './types';
@@ -44,7 +46,17 @@ export const realtimeApi = {
     }),
   remove: (id: number) => request<ApiResponse<boolean>>(`${PREFIX}/${id}`, { method: 'DELETE' }),
   events: (id: number) => request<ApiResponse<RealtimeEvent[]>>(`${PREFIX}/${id}/events`),
-  logs: (id: number) => request<ApiResponse<{ logs: string }>>(`${PREFIX}/${id}/logs`, { params: { tail: 500 } }),
+  observability: (id: number) =>
+    request<ApiResponse<RealtimeObservability>>(`${PREFIX}/${id}/observability`),
+  submissionLog: (id: number, tail = 500) =>
+    request<ApiResponse<{ logs: string }>>(`${PREFIX}/${id}/logs/submission`, { params: { tail } }),
+  runtimeLog: (id: number, maxExceptions = 50) =>
+    request<ApiResponse<RealtimeRuntimeLog>>(`${PREFIX}/${id}/logs/runtime`, {
+      params: { maxExceptions },
+    }),
+  // Compatibility calls retained for older screens/integrations.
+  logs: (id: number) =>
+    request<ApiResponse<{ logs: string }>>(`${PREFIX}/${id}/logs`, { params: { tail: 500 } }),
   checkpoints: (id: number) => request<ApiResponse<unknown>>(`${PREFIX}/${id}/checkpoints`),
   metrics: (id: number) => request<ApiResponse<unknown>>(`${PREFIX}/${id}/metrics`),
   capabilities: () => request<ApiResponse<RuntimeCapabilities>>(`${PREFIX}/runtime/capabilities`),

--- a/yak-ops-ui/src/pages/realtime-sync/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/index.tsx
@@ -12,12 +12,8 @@ import {
   Modal,
   Popover,
   Select,
-  Space,
   Table,
-  Tabs,
-  Timeline,
   Tooltip,
-  Typography,
 } from 'antd';
 import { CopyOutlined, FilterOutlined, MoreOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
@@ -27,6 +23,7 @@ import CustomPagination from '../batch-link-up/CustomPagination';
 import { realtimeApi } from './api';
 import JobEditor from './JobEditor';
 import CreateRealtimeTaskDrawer from './CreateRealtimeTaskDrawer';
+import RealtimeRuntimeDetail from './RealtimeRuntimeDetail';
 import type {
   DataSourceOption,
   RealtimeEvent,
@@ -122,9 +119,6 @@ export default function RealtimeSync() {
   const [createOpen, setCreateOpen] = useState(false);
   const [detail, setDetail] = useState<RealtimeJob>();
   const [events, setEvents] = useState<RealtimeEvent[]>([]);
-  const [logs, setLogs] = useState('');
-  const [checkpointData, setCheckpointData] = useState<unknown>();
-  const [metricsData, setMetricsData] = useState<unknown>();
   const [streamConnected, setStreamConnected] = useState(false);
 
   const dataSourceMap = useMemo(
@@ -267,9 +261,6 @@ export default function RealtimeSync() {
       ]);
       setDetail(jobResult.data);
       setEvents(eventResult.data || []);
-      setLogs('');
-      setCheckpointData(undefined);
-      setMetricsData(undefined);
     } catch (error: any) {
       message.error(error?.message || '加载运行详情失败');
     }
@@ -845,126 +836,13 @@ export default function RealtimeSync() {
         <CreateRealtimeTaskDrawer open={createOpen} onClose={() => setCreateOpen(false)} />
 
         <Drawer
-          width={820}
+          width={960}
           title={detail?.name}
           open={Boolean(detail)}
           onClose={() => setDetail(undefined)}
         >
           {detail && (
-            <Tabs
-              items={[
-                {
-                  key: 'overview',
-                  label: '运行概览',
-                  children: (
-                    <Descriptions column={1} bordered size="small">
-                      <Descriptions.Item label="定义版本">
-                        v{detail.definitionVersion} / 已发布 v{detail.publishedVersion || '-'}
-                      </Descriptions.Item>
-                      <Descriptions.Item label="状态">
-                        {detail.releaseState} · {detail.desiredState} · {detail.observedState}
-                      </Descriptions.Item>
-                      <Descriptions.Item label="部署摘要">
-                        {detail.latestDeployment?.specSummary || '-'}
-                      </Descriptions.Item>
-                      <Descriptions.Item label="Engine Job ID">
-                        {detail.latestDeployment?.engineJobId || '-'}
-                      </Descriptions.Item>
-                      <Descriptions.Item label="Flink CDC Revision">
-                        {detail.latestDeployment?.runtimeRevision || '-'}
-                      </Descriptions.Item>
-                      <Descriptions.Item label="最近错误">{detail.lastError || '-'}</Descriptions.Item>
-                    </Descriptions>
-                  ),
-                },
-                {
-                  key: 'events',
-                  label: '状态事件',
-                  children: (
-                    <Timeline
-                      items={events.map((event) => ({
-                        color:
-                          event.toState === 'FAILED' || event.toState === 'CONFLICT'
-                            ? 'red'
-                            : 'blue',
-                        children: (
-                          <div>
-                            <Typography.Text strong>{event.eventType}</Typography.Text>{' '}
-                            <Typography.Text type="secondary">{event.createTime}</Typography.Text>
-                            <div>
-                              {event.fromState || '-'} → {event.toState || '-'} · {event.message}
-                            </div>
-                          </div>
-                        ),
-                      }))}
-                    />
-                  ),
-                },
-                {
-                  key: 'logs',
-                  label: '任务日志',
-                  children: (
-                    <Space direction="vertical" style={{ width: '100%' }}>
-                      <Button
-                        onClick={async () => {
-                          try {
-                            setLogs((await realtimeApi.logs(detail.id)).data.logs);
-                          } catch (error: any) {
-                            message.error(error?.message || '日志不可用');
-                          }
-                        }}
-                      >
-                        读取最近日志
-                      </Button>
-                      <pre
-                        style={{
-                          whiteSpace: 'pre-wrap',
-                          maxHeight: 520,
-                          overflow: 'auto',
-                          background: '#111',
-                          color: '#ddd',
-                          padding: 12,
-                        }}
-                      >
-                        {logs || '尚未读取'}
-                      </pre>
-                    </Space>
-                  ),
-                },
-                {
-                  key: 'observability',
-                  label: 'Checkpoint / Metrics',
-                  children: (
-                    <Space direction="vertical" style={{ width: '100%' }}>
-                      <Button
-                        onClick={async () => {
-                          try {
-                            const [checkpoints, metrics] = await Promise.all([
-                              realtimeApi.checkpoints(detail.id),
-                              realtimeApi.metrics(detail.id),
-                            ]);
-                            setCheckpointData(checkpoints.data);
-                            setMetricsData(metrics.data);
-                          } catch (error: any) {
-                            message.error(error?.message || 'Checkpoint / Metrics 不可用');
-                          }
-                        }}
-                      >
-                        刷新 Flink 观测数据
-                      </Button>
-                      <Typography.Text strong>Checkpoints</Typography.Text>
-                      <pre className="max-h-[300px] overflow-auto rounded bg-[#f8f9fb] p-3 text-[12px]">
-                        {checkpointData ? JSON.stringify(checkpointData, null, 2) : '尚未读取'}
-                      </pre>
-                      <Typography.Text strong>Job Metrics</Typography.Text>
-                      <pre className="max-h-[300px] overflow-auto rounded bg-[#f8f9fb] p-3 text-[12px]">
-                        {metricsData ? JSON.stringify(metricsData, null, 2) : '尚未读取'}
-                      </pre>
-                    </Space>
-                  ),
-                },
-              ]}
-            />
+            <RealtimeRuntimeDetail job={detail} events={events} capabilities={capabilities} />
           )}
         </Drawer>
       </div>

--- a/yak-ops-ui/src/pages/realtime-sync/types.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/types.ts
@@ -89,6 +89,71 @@ export interface RealtimeJobChange {
   message?: string;
 }
 
+export interface RealtimeCheckpointDetail {
+  id?: number;
+  triggerTimestamp?: number;
+  latestAckTimestamp?: number;
+  durationMs?: number;
+  stateSizeBytes?: number;
+  checkpointedSizeBytes?: number;
+  acknowledgedSubtasks?: number;
+  totalSubtasks?: number;
+  failureMessage?: string;
+}
+
+export interface RealtimeCheckpointSummary {
+  total: number;
+  completed: number;
+  failed: number;
+  inProgress: number;
+  restored: number;
+  latestCompleted?: RealtimeCheckpointDetail;
+  latestFailed?: RealtimeCheckpointDetail;
+}
+
+export interface RealtimeMetricSummary {
+  recordsRead?: number;
+  recordsReadPerSecond?: number;
+  recordsWritten?: number;
+  recordsWrittenPerSecond?: number;
+  bytesRead?: number;
+  bytesReadPerSecond?: number;
+  bytesWritten?: number;
+  bytesWrittenPerSecond?: number;
+  maxBusyMsPerSecond?: number;
+  maxBackpressuredMsPerSecond?: number;
+  maxIdleMsPerSecond?: number;
+  vertexCount: number;
+}
+
+export interface RealtimeObservability {
+  engineJobId: string;
+  flinkJobName?: string;
+  flinkState?: string;
+  startTime?: number;
+  durationMs?: number;
+  flinkWebUrl?: string;
+  sampledAt: number;
+  checkpoints: RealtimeCheckpointSummary;
+  metrics: RealtimeMetricSummary;
+}
+
+export interface RealtimeRuntimeException {
+  exceptionName?: string;
+  stacktrace?: string;
+  timestamp?: number;
+  taskName?: string;
+  taskManagerId?: string;
+  endpoint?: string;
+}
+
+export interface RealtimeRuntimeLog {
+  rootException?: string;
+  timestamp?: number;
+  truncated: boolean;
+  exceptions: RealtimeRuntimeException[];
+}
+
 export interface DataSourceOption {
   label: string;
   value: string;


### PR DESCRIPTION
## 背景

前三阶段已经完成实时同步状态模型、启停幂等/并发、Flink Job 生命周期恢复与状态对账。本 PR 继续处理第四阶段：**提交日志、运行诊断、Checkpoint、Metrics 和前端可观测性**。

当前页面虽然已经能直接读取 Flink 原始接口，但主要问题是：

- 提交日志和 Flink 运行异常混在同一块文本里，不容易区分“提交失败”还是“运行失败”。
- 提交失败、超时、JobId 丢失时，旧实现会在 finally 删除 pending submit log，最需要排障时反而没有日志。
- Checkpoint / Metrics 直接 `JSON.stringify` 原始 Flink REST 响应，用户无法快速判断健康状态、吞吐和背压。
- 原始 `/jobs/{jobId}/metrics` 并不能直接表达 source/sink 读写吞吐，需要按 Job Vertex/Subtask 指标归一化。
- Flink JobId 尚未恢复时，旧页面无法查看本次 CLI 提交日志。

本 PR 不处理 SSH、Runtime Agent 或部署形态调整。

## 后端改动

### 1. 提交日志稳定保留并脱敏

`FlinkCdcEngineGateway` 调整提交日志生命周期：

- 每次 deployment 按 `Idempotency-Key` 保留稳定的 submit log。
- 成功、失败、超时、被中断、CLI 未返回 JobId 都不再删除本次提交日志。
- finally 再执行一次敏感信息脱敏，避免异常路径绕过正常 sanitize。
- 提交成功后同时复制一份 `<jobId>.submit.log`，兼容现有 `/logs` 行为。
- Pipeline 临时 YAML 仍然在 finally 删除，不改变现有安全边界。

因此即使任务停留在 `STARTING / UNKNOWN` 且 JobId 尚未恢复，也能查看本次 CLI 提交输出。

### 2. 新增稳定的可观测性 DTO

新增 `RealtimeObservabilityView`，把 Flink REST 原始 JSON 收敛为 UI 需要的稳定模型：

- Flink Job 状态 / Job Name / JobId
- 启动时间、运行时长、Flink Web UI 地址
- Checkpoint 汇总和最近成功/失败详情
- Source/Sink records、records/s
- Source/Sink bytes、bytes/s
- Busy / Backpressure / Idle
- Runtime Exception History

缺失或无法可靠识别的指标返回 `null`，前端展示 `-`，不伪造 0。

### 3. 新增 FlinkObservabilityClient

基于 Flink 1.20 Monitoring REST API：

- `/jobs/{jobId}`：运行状态、时长、Vertices
- `/jobs/{jobId}/checkpoints`：Checkpoint counts/latest
- `/jobs/{jobId}/vertices/{vertexId}/subtasks/metrics`：使用 `get + agg=sum,avg,max` 聚合 Vertex 指标
- `/jobs/{jobId}/exceptions?maxExceptions=...`：使用 `exceptionHistory` 作为运行诊断来源

Source/Sink 吞吐仅在 Vertex 名称可以可靠识别时聚合；无法识别时保留为空值。

### 4. 新增 Observability Service / API

新增接口：

- `GET /api/v1/realtime-sync/{id}/observability`
- `GET /api/v1/realtime-sync/{id}/logs/submission`
- `GET /api/v1/realtime-sync/{id}/logs/runtime`

其中 submission log 只依赖 latest deployment 的 `Idempotency-Key`，**不要求已经有 Flink JobId**。

旧接口继续保留兼容：

- `/logs`
- `/checkpoints`
- `/metrics`

## 前端改动

新增 `RealtimeRuntimeDetail`，将运行详情 Drawer 改成结构化的 5 个 Tab：

1. **运行概览**
   - Flink 状态
   - 运行时长
   - 读取/写入速率
   - JobId / Revision / 最近 Checkpoint / 最近错误
   - 一键打开 Flink Web UI

2. **状态事件**
   - 保留现有事件时间线

3. **日志**
   - 提交日志：即使 JobId 尚未恢复也可查看
   - 运行诊断：展示 Flink Exception History
   - 明确提示完整 JobManager / TaskManager 日志仍应进入 Flink Web UI

4. **Checkpoint**
   - 成功 / 失败 / 进行中 / 总数
   - 最近成功 Checkpoint ID、完成时间、耗时、状态大小、Subtask 确认数
   - 最近失败原因

5. **Metrics**
   - Source/Sink records 和速率
   - Source/Sink bytes 和速率
   - Busy / Backpressure / Idle 压力展示

运行中的任务每 5 秒自动刷新观测快照；日志保持手动刷新，避免持续拉取大文本。

原来详情页直接展示原始 Checkpoint/Metrics JSON 的逻辑已删除，任务列表、筛选和启停按钮逻辑未改。

## 测试

新增/扩展测试覆盖：

- Job / Checkpoint / Vertex Metrics 归一化。
- Flink `exceptionHistory` 运行诊断解析。
- 提交日志二次脱敏。
- 成功提交同时保留 deployment-key log 和 legacy JobId log。
- 提交失败时日志仍保留且不包含明文密码。
- JobId 尚未恢复时仍可通过 deployment `Idempotency-Key` 读取提交日志。

本执行环境无法解析 `github.com` DNS，因此不能 clone 当前分支实际执行 Maven/npm；本 PR 已完成代码级静态检查，并按 Flink 1.20 REST API 字段核对。最终仍以仓库 CI 或本地 Maven/前端构建结果为准。

## 范围外

本 PR 不处理：

- SSH / Runtime Agent 远程执行方案。
- 日志集中存储、ES/Loki 等日志平台接入。
- Prometheus 长周期指标存储和趋势图。
- 自动告警规则。
- Flink JobManager / TaskManager 完整日志代理下载。

第四阶段原则：**页面优先展示可判断、可排障的稳定指标；原始 Flink JSON 留给兼容接口和 Flink Web UI，不直接作为产品交互。**