### PR TITLE
feat(realtime): support remote Flink CDC submission over SSH

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/README.md
@@ -1,0 +1,143 @@
+# Realtime Sync deployment
+
+实时同步控制面支持两种 Flink CDC 提交方式：
+
+- `LOCAL`：Yak Ops 与 Flink CDC CLI 位于同一执行环境，直接通过本地 `ProcessBuilder` 调用 `flink-cdc.sh`。
+- `SSH`：Yak Ops 可以运行在 Windows 或其他机器，通过本机 OpenSSH 客户端连接 Linux 执行节点，在远端调用 `flink-cdc.sh`。
+
+无论使用哪种提交方式，任务状态、JobId 恢复、Checkpoint、Metrics 和运行诊断仍然通过 `yak.sync.realtime.rest-url` 直接访问 Flink REST API。SSH 不作为 Flink REST 代理。
+
+## LOCAL 模式
+
+默认配置就是 `LOCAL`，现有部署无需调整：
+
+```yaml
+yak:
+  sync:
+    realtime:
+      submission-mode: LOCAL
+      rest-url: http://127.0.0.1:8081
+      flink-home: /opt/flink
+      flink-cdc-home: /opt/flink-cdc
+      java-home: /usr/lib/jvm/java-17
+      work-directory: ./data/realtime-sync
+```
+
+`flink-home`、`flink-cdc-home`、`java-home` 都表示 Yak Ops 所在机器的本地路径。
+
+## SSH 模式：Yak Ops 在 Windows，Flink CDC 在 Linux
+
+推荐使用 OpenSSH key 或 ssh-agent，Yak Ops 不保存 SSH 登录密码。
+
+```yaml
+yak:
+  sync:
+    realtime:
+      submission-mode: SSH
+
+      # Yak Ops 后端必须可以直接访问这个 Flink REST 地址。
+      rest-url: http://10.0.0.20:8081
+
+      # SSH 模式下，这三个路径都是 Linux 执行节点上的绝对路径。
+      flink-home: /opt/flink-1.20.5
+      flink-cdc-home: /opt/flink-cdc-3.6.0
+      java-home: /usr/lib/jvm/java-17
+
+      # 这里只保存脱敏后的提交日志，不保存远端 Pipeline YAML。
+      work-directory: ./data/realtime-sync
+
+      ssh:
+        # Windows 可显式配置 C:/Windows/System32/OpenSSH/ssh.exe；
+        # 如果 ssh 已加入 PATH，保留默认值 ssh 即可。
+        executable: C:/Windows/System32/OpenSSH/ssh.exe
+        host: 10.0.0.20
+        port: 22
+        user: flink
+
+        # identity-file 可以省略，此时 OpenSSH 使用默认 key / ssh-agent。
+        identity-file: C:/Users/your-user/.ssh/id_ed25519
+        known-hosts-file: C:/Users/your-user/.ssh/known_hosts
+        strict-host-key-checking: true
+        connect-timeout: 5s
+
+        # 这是 Linux 执行节点调用 Flink CDC CLI 时传给 -Drest.address/-Drest.port 的地址。
+        # 如果 Linux 上的 Flink REST 只监听 localhost，可以与上面的 rest-url 不同。
+        remote-rest-address: 127.0.0.1
+        remote-rest-port: 8081
+```
+
+典型链路：
+
+```text
+Windows / Yak Ops
+  ├─ HTTP ───────────────> Flink REST 10.0.0.20:8081
+  └─ OpenSSH ────────────> Linux 10.0.0.20
+                              └─ /opt/flink-cdc/bin/flink-cdc.sh
+                                     └─ Flink cluster
+```
+
+## SSH 账号要求
+
+SSH 用户不需要 root 权限，但至少需要：
+
+- 能执行 `${flink-cdc-home}/bin/flink-cdc.sh`。
+- 能读取 Flink CDC 的 `lib`/connector 文件和 Flink 安装目录。
+- 能在远端 `${TMPDIR:-/tmp}` 创建临时文件。
+- 能从 Linux 执行节点访问 `remote-rest-address:remote-rest-port`。
+
+Yak Ops 会使用 `BatchMode=yes`，因此任何需要交互输入密码、验证码或首次确认 host key 的 SSH 登录都会失败。
+
+建议提前在 Yak Ops 运行账号下验证：
+
+```bash
+ssh -i ~/.ssh/id_ed25519 flink@10.0.0.20 'test -x /opt/flink-cdc/bin/flink-cdc.sh && echo ok'
+```
+
+开启 `strict-host-key-checking: true` 时，应提前维护可信 `known_hosts`。不要为了绕过 host key 问题长期关闭校验。
+
+## Pipeline YAML 安全边界
+
+SSH 模式不会在 Yak Ops 本地创建包含数据源密码的 Pipeline YAML 文件。
+
+提交过程为：
+
+```text
+Yak Ops 内存中的 Pipeline YAML
+  -> OpenSSH stdin
+  -> Linux mktemp 临时文件（umask 077）
+  -> flink-cdc.sh
+  -> trap 自动删除远端临时文件
+```
+
+Yak Ops 本地只保留提交 stdout/stderr，并在落盘前后执行密码脱敏。提交成功、失败、超时或 SSH 中断时都保留本次 deployment 的脱敏提交日志，便于排障。
+
+## 失败语义
+
+OpenSSH exit code `255`、SSH 连接在提交过程中断开、提交超时或线程中断都会被视为“提交结果不确定”。控制面不会自动再次提交，而是交给已有的 runtime identity / JobId 恢复与生命周期对账逻辑确认 Flink 中是否已经存在该 Job。
+
+远端 CLI 明确返回普通非零 exit code 时，按确定失败处理，并保留脱敏后的 CLI 输出。
+
+## 能力接口
+
+`GET /api/v1/realtime-sync/runtime/capabilities` 会额外返回：
+
+```json
+{
+  "submissionMode": "SSH",
+  "submissionEndpoint": "flink@10.0.0.20:22",
+  "restTransport": "DIRECT"
+}
+```
+
+`deployEnabled=true` 表示配置字段完整；发布/启动时还会执行一次 SSH 远端环境探测，确认远端 Flink CDC CLI、Flink Home、Java（如配置）和 `mktemp` 可用。
+
+## 不包含的能力
+
+当前 SSH 模式只解决“远程执行 Flink CDC CLI”。它不包含：
+
+- SSH 隧道代理 Flink REST。
+- Runtime Agent / 常驻远端进程。
+- SSH 密码托管。
+- JobManager/TaskManager 日志文件通过 SSH 下载。
+
+如果 Yak Ops 无法直接访问 Flink REST，应优先通过内网网络、反向代理或安全网关开放 REST 可达性，再考虑额外的 Runtime Agent 方案。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncProperties.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncProperties.java
@@ -6,6 +6,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("yak.sync.realtime")
 public class RealtimeSyncProperties {
 
+  public enum SubmissionMode {
+    LOCAL,
+    SSH
+  }
+
   private boolean enabled = true;
   private String restUrl = "http://127.0.0.1:8081";
   private String flinkHome = "/opt/flink";
@@ -14,6 +19,8 @@ public class RealtimeSyncProperties {
   private String workDirectory = "./data/realtime-sync";
   private String flinkVersion = "1.20.5";
   private String flinkCdcVersion = "3.6.0";
+  private SubmissionMode submissionMode = SubmissionMode.LOCAL;
+  private final Ssh ssh = new Ssh();
   private Duration connectTimeout = Duration.ofSeconds(3);
   private Duration requestTimeout = Duration.ofSeconds(15);
   private Duration submitTimeout = Duration.ofSeconds(60);
@@ -85,6 +92,18 @@ public class RealtimeSyncProperties {
     this.flinkCdcVersion = flinkCdcVersion;
   }
 
+  public SubmissionMode getSubmissionMode() {
+    return submissionMode;
+  }
+
+  public void setSubmissionMode(SubmissionMode submissionMode) {
+    this.submissionMode = submissionMode == null ? SubmissionMode.LOCAL : submissionMode;
+  }
+
+  public Ssh getSsh() {
+    return ssh;
+  }
+
   public Duration getConnectTimeout() {
     return connectTimeout;
   }
@@ -131,5 +150,99 @@ public class RealtimeSyncProperties {
 
   public void setMaxLogLines(int maxLogLines) {
     this.maxLogLines = maxLogLines;
+  }
+
+  /** OpenSSH client settings used only when submission-mode=SSH. */
+  public static class Ssh {
+    private String executable = "ssh";
+    private String host;
+    private int port = 22;
+    private String user;
+    private String identityFile;
+    private String knownHostsFile;
+    private boolean strictHostKeyChecking = true;
+    private Duration connectTimeout = Duration.ofSeconds(5);
+    private String remoteRestAddress;
+    private Integer remoteRestPort;
+
+    public String getExecutable() {
+      return executable;
+    }
+
+    public void setExecutable(String executable) {
+      this.executable = executable;
+    }
+
+    public String getHost() {
+      return host;
+    }
+
+    public void setHost(String host) {
+      this.host = host;
+    }
+
+    public int getPort() {
+      return port;
+    }
+
+    public void setPort(int port) {
+      this.port = port;
+    }
+
+    public String getUser() {
+      return user;
+    }
+
+    public void setUser(String user) {
+      this.user = user;
+    }
+
+    public String getIdentityFile() {
+      return identityFile;
+    }
+
+    public void setIdentityFile(String identityFile) {
+      this.identityFile = identityFile;
+    }
+
+    public String getKnownHostsFile() {
+      return knownHostsFile;
+    }
+
+    public void setKnownHostsFile(String knownHostsFile) {
+      this.knownHostsFile = knownHostsFile;
+    }
+
+    public boolean isStrictHostKeyChecking() {
+      return strictHostKeyChecking;
+    }
+
+    public void setStrictHostKeyChecking(boolean strictHostKeyChecking) {
+      this.strictHostKeyChecking = strictHostKeyChecking;
+    }
+
+    public Duration getConnectTimeout() {
+      return connectTimeout;
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+      this.connectTimeout = connectTimeout;
+    }
+
+    public String getRemoteRestAddress() {
+      return remoteRestAddress;
+    }
+
+    public void setRemoteRestAddress(String remoteRestAddress) {
+      this.remoteRestAddress = remoteRestAddress;
+    }
+
+    public Integer getRemoteRestPort() {
+      return remoteRestPort;
+    }
+
+    public void setRemoteRestPort(Integer remoteRestPort) {
+      this.remoteRestPort = remoteRestPort;
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.SubmissionMode;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -28,7 +29,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** Submits Flink CDC YAML with the local CLI and manages each job through Flink REST. */
+/** Submits Flink CDC YAML locally or through SSH and manages jobs through direct Flink REST. */
 @Component
 public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
@@ -51,6 +52,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
   private final HttpClient client;
   private final ObjectMapper json;
   private final RealtimeSyncProperties properties;
+  private final SshFlinkCdcCommandRunner sshRunner;
 
   public FlinkCdcEngineGateway(
       @Qualifier("realtimeHttpClient") HttpClient client,
@@ -59,6 +61,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     this.client = client;
     this.json = json;
     this.properties = properties;
+    this.sshRunner = new SshFlinkCdcCommandRunner(properties);
   }
 
   @Override
@@ -69,13 +72,32 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
   @Override
   public JsonNode capabilities() {
     ObjectNode result = json.createObjectNode();
-    Path cli = cliPath();
-    boolean deployEnabled = Files.isRegularFile(cli) && Files.isExecutable(cli);
+    SubmissionMode mode = properties.getSubmissionMode();
+    boolean deployEnabled;
+    String disabledReason = null;
+    if (mode == SubmissionMode.SSH) {
+      disabledReason = sshRunner.configurationError();
+      deployEnabled = disabledReason == null;
+    } else {
+      Path cli = cliPath();
+      deployEnabled = Files.isRegularFile(cli) && Files.isExecutable(cli);
+      if (!deployEnabled) {
+        disabledReason = "未找到可执行的 Flink CDC CLI：" + cli;
+      }
+    }
+
     result.put("engineType", "flink-cdc-cli");
     result.put("runtimeVersion", "flink-cdc-cli-" + properties.getFlinkCdcVersion());
     result.put("flinkVersion", properties.getFlinkVersion());
     result.put("flinkCdcVersion", properties.getFlinkCdcVersion());
     result.put("restUrl", properties.getRestUrl());
+    result.put("restTransport", "DIRECT");
+    result.put("submissionMode", mode.name());
+    if (mode == SubmissionMode.SSH) {
+      result.put("submissionEndpoint", sshRunner.endpoint());
+    } else {
+      result.put("submissionEndpoint", "local");
+    }
     result.put("deliverySemantics", "at-least-once");
     result.put("checkpointsApi", true);
     result.put("metricsApi", true);
@@ -84,7 +106,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     result.put("protocolCompatible", true);
     result.put("deployEnabled", deployEnabled);
     if (!deployEnabled) {
-      result.put("deployDisabledReason", "未找到可执行的 Flink CDC CLI：" + cli);
+      result.put("deployDisabledReason", disabledReason);
     }
     ObjectNode connectors = result.putObject("connectors");
     connectors.putArray("sources").add("mysql");
@@ -95,13 +117,11 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   @Override
   public ValidationResult validate(String pipelineYaml) {
-    if (!StringUtils.hasText(pipelineYaml)
-        || !pipelineYaml.contains("source:")
-        || !pipelineYaml.contains("sink:")
-        || !pipelineYaml.contains("pipeline:")) {
-      throw failure("Pipeline YAML 缺少 source、sink 或 pipeline 配置", false, null, null);
-    }
-    if (!Files.isRegularFile(cliPath()) || !Files.isExecutable(cliPath())) {
+    validatePipelineShape(pipelineYaml);
+    URI rest = restUri();
+    if (properties.getSubmissionMode() == SubmissionMode.SSH) {
+      sshRunner.validateReady(rest);
+    } else if (!Files.isRegularFile(cliPath()) || !Files.isExecutable(cliPath())) {
       throw failure("Flink CDC CLI 不存在或不可执行：" + cliPath(), false, null, null);
     }
     health();
@@ -115,50 +135,37 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     Path submissionLog = null;
     Path pipelineFile = null;
     try {
-      Path pipelines = Files.createDirectories(work.resolve("pipelines"));
       Files.createDirectories(work.resolve("logs"));
-      String safeKey = safeKey(request.idempotencyKey());
-      pipelineFile = pipelines.resolve("pipeline-" + safeKey + "-" + System.nanoTime() + ".yaml");
       submissionLog = submitLogByKey(request.idempotencyKey());
       String resolved = resolveSecrets(request);
-      writePrivate(pipelineFile, resolved);
       writePrivate(submissionLog, "");
 
       URI rest = restUri();
-      int port = rest.getPort() < 0 ? defaultPort(rest) : rest.getPort();
-      ProcessBuilder builder =
-          new ProcessBuilder(
-                  cliPath().toString(),
-                  pipelineFile.toString(),
-                  "--flink-home",
-                  Path.of(properties.getFlinkHome()).toAbsolutePath().normalize().toString(),
-                  "--target",
-                  "remote",
-                  "-Drest.address=" + rest.getHost(),
-                  "-Drest.port=" + port)
-              .redirectErrorStream(true)
-              .redirectOutput(submissionLog.toFile());
-      builder.environment().put("FLINK_HOME", properties.getFlinkHome());
-      if (StringUtils.hasText(properties.getJavaHome())) {
-        builder.environment().put("JAVA_HOME", properties.getJavaHome());
+      CommandResult result;
+      if (properties.getSubmissionMode() == SubmissionMode.SSH) {
+        SshFlinkCdcCommandRunner.ExecutionResult sshResult =
+            sshRunner.submit(resolved, submissionLog, rest, properties.getSubmitTimeout());
+        result = new CommandResult(sshResult.exitCode(), sshResult.uncertain());
+      } else {
+        Path pipelines = Files.createDirectories(work.resolve("pipelines"));
+        String safeKey = safeKey(request.idempotencyKey());
+        pipelineFile = pipelines.resolve("pipeline-" + safeKey + "-" + System.nanoTime() + ".yaml");
+        writePrivate(pipelineFile, resolved);
+        result = submitLocal(pipelineFile, submissionLog, rest);
       }
-      Process process = builder.start();
-      Duration timeout = properties.getSubmitTimeout();
-      if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
-        process.destroyForcibly();
-        process.waitFor(5, TimeUnit.SECONDS);
-        throw failure("Flink CDC 提交超时，结果不确定，请在 Flink UI 中核对", true, null, null);
-      }
+
       String output = Files.readString(submissionLog, StandardCharsets.UTF_8);
       output = sanitizeOutput(output, request);
       writePrivate(submissionLog, output);
-      if (process.exitValue() != 0) {
+      if (result.exitCode() != 0) {
         String excerpt = tail(output, 20);
+        String prefix = properties.getSubmissionMode() == SubmissionMode.SSH ? "SSH Flink CDC" : "Flink CDC";
         throw failure(
-            "Flink CDC 提交失败，exitCode="
-                + process.exitValue()
+            prefix
+                + " 提交失败，exitCode="
+                + result.exitCode()
                 + (excerpt.isBlank() ? "" : "：\n" + excerpt),
-            false,
+            result.uncertain(),
             null,
             null);
       }
@@ -175,10 +182,48 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       Thread.currentThread().interrupt();
       throw failure("Flink CDC 提交被中断，结果不确定", true, null, exception);
     } catch (IOException exception) {
-      throw failure("无法执行 Flink CDC CLI：" + exception.getMessage(), false, null, exception);
+      throw failure("无法执行 Flink CDC 提交命令：" + exception.getMessage(), false, null, exception);
     } finally {
       sanitizeLogQuietly(submissionLog, request);
       deleteQuietly(pipelineFile);
+    }
+  }
+
+  private CommandResult submitLocal(Path pipelineFile, Path submissionLog, URI rest)
+      throws IOException, InterruptedException {
+    int port = rest.getPort() < 0 ? defaultPort(rest) : rest.getPort();
+    ProcessBuilder builder =
+        new ProcessBuilder(
+                cliPath().toString(),
+                pipelineFile.toString(),
+                "--flink-home",
+                Path.of(properties.getFlinkHome()).toAbsolutePath().normalize().toString(),
+                "--target",
+                "remote",
+                "-Drest.address=" + rest.getHost(),
+                "-Drest.port=" + port)
+            .redirectErrorStream(true)
+            .redirectOutput(submissionLog.toFile());
+    builder.environment().put("FLINK_HOME", properties.getFlinkHome());
+    if (StringUtils.hasText(properties.getJavaHome())) {
+      builder.environment().put("JAVA_HOME", properties.getJavaHome());
+    }
+    Process process = builder.start();
+    Duration timeout = properties.getSubmitTimeout();
+    if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+      process.destroyForcibly();
+      process.waitFor(5, TimeUnit.SECONDS);
+      throw failure("Flink CDC 提交超时，结果不确定，请在 Flink UI 中核对", true, null, null);
+    }
+    return new CommandResult(process.exitValue(), false);
+  }
+
+  private void validatePipelineShape(String pipelineYaml) {
+    if (!StringUtils.hasText(pipelineYaml)
+        || !pipelineYaml.contains("source:")
+        || !pipelineYaml.contains("sink:")
+        || !pipelineYaml.contains("pipeline:")) {
+      throw failure("Pipeline YAML 缺少 source、sink 或 pipeline 配置", false, null, null);
     }
   }
 
@@ -419,6 +464,8 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       String message, boolean uncertain, Integer status, Throwable cause) {
     return new RealtimeEngineException(message, uncertain, status, cause);
   }
+
+  private record CommandResult(int exitCode, boolean uncertain) {}
 
   private record Response(int status, JsonNode body) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
@@ -39,9 +39,16 @@ final class SshFlinkCdcCommandRunner {
     if (ssh.getPort() < 1 || ssh.getPort() > 65535) {
       return "SSH port 必须在 1-65535 之间";
     }
-    if (!StringUtils.hasText(properties.getFlinkHome())
-        || !StringUtils.hasText(properties.getFlinkCdcHome())) {
-      return "SSH 模式下必须配置远端 flink-home 和 flink-cdc-home";
+    if (!absoluteUnixPath(properties.getFlinkHome())
+        || !absoluteUnixPath(properties.getFlinkCdcHome())) {
+      return "SSH 模式下 flink-home 和 flink-cdc-home 必须是远端 Linux 绝对路径";
+    }
+    if (StringUtils.hasText(properties.getJavaHome()) && !absoluteUnixPath(properties.getJavaHome())) {
+      return "SSH 模式下 java-home 必须是远端 Linux 绝对路径";
+    }
+    Integer remoteRestPort = ssh.getRemoteRestPort();
+    if (remoteRestPort != null && (remoteRestPort < 1 || remoteRestPort > 65535)) {
+      return "SSH remote-rest-port 必须在 1-65535 之间";
     }
     return null;
   }
@@ -58,6 +65,7 @@ final class SshFlinkCdcCommandRunner {
     if (error != null) {
       throw failure(error, false, null);
     }
+    remoteRestPort(restUri);
     Process process = null;
     try {
       process =
@@ -66,7 +74,8 @@ final class SshFlinkCdcCommandRunner {
               .redirectOutput(ProcessBuilder.Redirect.DISCARD)
               .start();
       process.getOutputStream().close();
-      Duration timeout = properties.getSsh().getConnectTimeout().plusSeconds(5);
+      Duration connectTimeout = positiveDuration(properties.getSsh().getConnectTimeout(), Duration.ofSeconds(5));
+      Duration timeout = connectTimeout.plusSeconds(5);
       if (!process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS)) {
         destroy(process);
         throw failure("SSH 远端环境探测超时", false, null);
@@ -93,6 +102,7 @@ final class SshFlinkCdcCommandRunner {
     if (error != null) {
       throw failure(error, false, null);
     }
+    Duration effectiveTimeout = positiveDuration(timeout, Duration.ofSeconds(60));
     Process process = null;
     boolean started = false;
     try {
@@ -106,7 +116,7 @@ final class SshFlinkCdcCommandRunner {
         stdin.write(pipelineYaml.getBytes(StandardCharsets.UTF_8));
         stdin.flush();
       }
-      if (!process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS)) {
+      if (!process.waitFor(Math.max(1, effectiveTimeout.toMillis()), TimeUnit.MILLISECONDS)) {
         destroy(process);
         throw failure("SSH Flink CDC 提交超时，远端结果不确定，请通过状态对账确认", true, null);
       }
@@ -182,7 +192,7 @@ final class SshFlinkCdcCommandRunner {
     StringBuilder command = new StringBuilder();
     command.append("set -eu; umask 077; ");
     command.append("tmp=$(mktemp \"${TMPDIR:-/tmp}/yak-ops-cdc.XXXXXX.yaml\"); ");
-    command.append("cleanup(){ rm -f \"$tmp\"; }; trap cleanup EXIT HUP INT TERM; ");
+    command.append("cleanup(){ rm -f \"$tmp\"; }; trap cleanup 0 HUP INT TERM; ");
     command.append("cat > \"$tmp\"; ");
     command.append("export FLINK_HOME=").append(shellQuote(properties.getFlinkHome())).append("; ");
     if (StringUtils.hasText(properties.getJavaHome())) {
@@ -204,9 +214,14 @@ final class SshFlinkCdcCommandRunner {
   }
 
   private String remoteRestAddress(URI restUri) {
-    return StringUtils.hasText(properties.getSsh().getRemoteRestAddress())
-        ? properties.getSsh().getRemoteRestAddress().trim()
-        : restUri.getHost();
+    String value =
+        StringUtils.hasText(properties.getSsh().getRemoteRestAddress())
+            ? properties.getSsh().getRemoteRestAddress().trim()
+            : restUri.getHost();
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException("SSH remote REST address 不能为空");
+    }
+    return value;
   }
 
   private int remoteRestPort(URI restUri) {
@@ -223,11 +238,17 @@ final class SshFlinkCdcCommandRunner {
     return "https".equalsIgnoreCase(restUri.getScheme()) ? 443 : 80;
   }
 
+  private boolean absoluteUnixPath(String value) {
+    return StringUtils.hasText(value) && value.startsWith("/");
+  }
+
+  private Duration positiveDuration(Duration value, Duration fallback) {
+    return value == null || value.isNegative() || value.isZero() ? fallback : value;
+  }
+
   private int seconds(Duration value) {
-    if (value == null || value.isNegative() || value.isZero()) {
-      return 5;
-    }
-    return (int) Math.max(1, Math.min(Integer.MAX_VALUE, (value.toMillis() + 999) / 1000));
+    Duration effective = positiveDuration(value, Duration.ofSeconds(5));
+    return (int) Math.max(1, Math.min(Integer.MAX_VALUE, (effective.toMillis() + 999) / 1000));
   }
 
   private String shellQuote(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
@@ -1,0 +1,260 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.springframework.util.StringUtils;
+
+/** Executes Flink CDC CLI remotely through the operating system OpenSSH client. */
+final class SshFlinkCdcCommandRunner {
+
+  private static final Pattern SSH_USER = Pattern.compile("[A-Za-z0-9._-]+");
+  private static final Pattern SSH_HOST = Pattern.compile("[A-Za-z0-9._:%-]+");
+
+  private final RealtimeSyncProperties properties;
+
+  SshFlinkCdcCommandRunner(RealtimeSyncProperties properties) {
+    this.properties = properties;
+  }
+
+  String configurationError() {
+    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+    if (!StringUtils.hasText(ssh.getExecutable())) {
+      return "SSH executable 不能为空";
+    }
+    if (!StringUtils.hasText(ssh.getHost()) || !SSH_HOST.matcher(ssh.getHost()).matches()) {
+      return "SSH host 未配置或格式无效";
+    }
+    if (!StringUtils.hasText(ssh.getUser()) || !SSH_USER.matcher(ssh.getUser()).matches()) {
+      return "SSH user 未配置或格式无效";
+    }
+    if (ssh.getPort() < 1 || ssh.getPort() > 65535) {
+      return "SSH port 必须在 1-65535 之间";
+    }
+    if (!StringUtils.hasText(properties.getFlinkHome())
+        || !StringUtils.hasText(properties.getFlinkCdcHome())) {
+      return "SSH 模式下必须配置远端 flink-home 和 flink-cdc-home";
+    }
+    return null;
+  }
+
+  String endpoint() {
+    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+    return StringUtils.hasText(ssh.getUser()) && StringUtils.hasText(ssh.getHost())
+        ? ssh.getUser() + "@" + ssh.getHost() + ":" + ssh.getPort()
+        : null;
+  }
+
+  void validateReady(URI restUri) {
+    String error = configurationError();
+    if (error != null) {
+      throw failure(error, false, null);
+    }
+    Process process = null;
+    try {
+      process =
+          new ProcessBuilder(sshCommand(remoteProbeCommand(restUri)))
+              .redirectErrorStream(true)
+              .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+              .start();
+      process.getOutputStream().close();
+      Duration timeout = properties.getSsh().getConnectTimeout().plusSeconds(5);
+      if (!process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS)) {
+        destroy(process);
+        throw failure("SSH 远端环境探测超时", false, null);
+      }
+      if (process.exitValue() != 0) {
+        String message =
+            process.exitValue() == 255
+                ? "SSH 连接或认证失败，请检查 host key、用户和密钥配置"
+                : "SSH 已连接，但远端 Flink/Flink CDC/Java 环境未通过检查";
+        throw failure(message + "，exitCode=" + process.exitValue(), false, null);
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      destroy(process);
+      throw failure("SSH 远端环境探测被中断", false, exception);
+    } catch (IOException exception) {
+      destroy(process);
+      throw failure("无法启动 OpenSSH 客户端：" + exception.getMessage(), false, exception);
+    }
+  }
+
+  ExecutionResult submit(String pipelineYaml, Path outputLog, URI restUri, Duration timeout) {
+    String error = configurationError();
+    if (error != null) {
+      throw failure(error, false, null);
+    }
+    Process process = null;
+    boolean started = false;
+    try {
+      ProcessBuilder builder =
+          new ProcessBuilder(sshCommand(remoteSubmitCommand(restUri)))
+              .redirectErrorStream(true)
+              .redirectOutput(outputLog.toFile());
+      process = builder.start();
+      started = true;
+      try (OutputStream stdin = process.getOutputStream()) {
+        stdin.write(pipelineYaml.getBytes(StandardCharsets.UTF_8));
+        stdin.flush();
+      }
+      if (!process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS)) {
+        destroy(process);
+        throw failure("SSH Flink CDC 提交超时，远端结果不确定，请通过状态对账确认", true, null);
+      }
+      int exitCode = process.exitValue();
+      return new ExecutionResult(exitCode, exitCode == 255);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      destroy(process);
+      throw failure("SSH Flink CDC 提交被中断，远端结果不确定", started, exception);
+    } catch (IOException exception) {
+      destroy(process);
+      throw failure(
+          started
+              ? "SSH 连接在提交过程中异常，远端结果不确定"
+              : "无法启动 OpenSSH 客户端：" + exception.getMessage(),
+          started,
+          exception);
+    }
+  }
+
+  private List<String> sshCommand(String remoteCommand) {
+    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+    List<String> command = new ArrayList<>();
+    command.add(ssh.getExecutable());
+    command.add("-o");
+    command.add("BatchMode=yes");
+    command.add("-o");
+    command.add("ConnectionAttempts=1");
+    command.add("-o");
+    command.add("ConnectTimeout=" + seconds(ssh.getConnectTimeout()));
+    command.add("-o");
+    command.add("ServerAliveInterval=15");
+    command.add("-o");
+    command.add("ServerAliveCountMax=2");
+    command.add("-o");
+    command.add("LogLevel=ERROR");
+    command.add("-o");
+    command.add(
+        "StrictHostKeyChecking=" + (ssh.isStrictHostKeyChecking() ? "yes" : "accept-new"));
+    if (StringUtils.hasText(ssh.getKnownHostsFile())) {
+      command.add("-o");
+      command.add("UserKnownHostsFile=" + ssh.getKnownHostsFile());
+    }
+    if (StringUtils.hasText(ssh.getIdentityFile())) {
+      command.add("-i");
+      command.add(ssh.getIdentityFile());
+    }
+    command.add("-p");
+    command.add(Integer.toString(ssh.getPort()));
+    command.add(ssh.getUser() + "@" + ssh.getHost());
+    command.add(remoteCommand);
+    return command;
+  }
+
+  private String remoteProbeCommand(URI restUri) {
+    String cdc = remoteCdcCli();
+    StringBuilder command = new StringBuilder("set -eu; ");
+    command.append("test -x ").append(shellQuote(cdc)).append("; ");
+    command.append("test -d ").append(shellQuote(properties.getFlinkHome())).append("; ");
+    command.append("command -v mktemp >/dev/null 2>&1; ");
+    if (StringUtils.hasText(properties.getJavaHome())) {
+      command
+          .append("test -x ")
+          .append(shellQuote(properties.getJavaHome() + "/bin/java"))
+          .append("; ");
+    }
+    command.append("test -n ").append(shellQuote(remoteRestAddress(restUri))).append("; ");
+    command.append("echo YAK_REALTIME_SSH_READY");
+    return command.toString();
+  }
+
+  private String remoteSubmitCommand(URI restUri) {
+    StringBuilder command = new StringBuilder();
+    command.append("set -eu; umask 077; ");
+    command.append("tmp=$(mktemp \"${TMPDIR:-/tmp}/yak-ops-cdc.XXXXXX.yaml\"); ");
+    command.append("cleanup(){ rm -f \"$tmp\"; }; trap cleanup EXIT HUP INT TERM; ");
+    command.append("cat > \"$tmp\"; ");
+    command.append("export FLINK_HOME=").append(shellQuote(properties.getFlinkHome())).append("; ");
+    if (StringUtils.hasText(properties.getJavaHome())) {
+      command.append("export JAVA_HOME=").append(shellQuote(properties.getJavaHome())).append("; ");
+    }
+    command.append(shellQuote(remoteCdcCli())).append(" \"$tmp\"");
+    command.append(" --flink-home ").append(shellQuote(properties.getFlinkHome()));
+    command.append(" --target remote");
+    command
+        .append(" ")
+        .append(shellQuote("-Drest.address=" + remoteRestAddress(restUri)));
+    command.append(" ").append(shellQuote("-Drest.port=" + remoteRestPort(restUri)));
+    return command.toString();
+  }
+
+  private String remoteCdcCli() {
+    String home = properties.getFlinkCdcHome().replaceAll("/+$", "");
+    return home + "/bin/flink-cdc.sh";
+  }
+
+  private String remoteRestAddress(URI restUri) {
+    return StringUtils.hasText(properties.getSsh().getRemoteRestAddress())
+        ? properties.getSsh().getRemoteRestAddress().trim()
+        : restUri.getHost();
+  }
+
+  private int remoteRestPort(URI restUri) {
+    Integer configured = properties.getSsh().getRemoteRestPort();
+    if (configured != null) {
+      if (configured < 1 || configured > 65535) {
+        throw new IllegalArgumentException("ssh.remote-rest-port 必须在 1-65535 之间");
+      }
+      return configured;
+    }
+    if (restUri.getPort() > 0) {
+      return restUri.getPort();
+    }
+    return "https".equalsIgnoreCase(restUri.getScheme()) ? 443 : 80;
+  }
+
+  private int seconds(Duration value) {
+    if (value == null || value.isNegative() || value.isZero()) {
+      return 5;
+    }
+    return (int) Math.max(1, Math.min(Integer.MAX_VALUE, (value.toMillis() + 999) / 1000));
+  }
+
+  private String shellQuote(String value) {
+    if (value == null) {
+      throw new IllegalArgumentException("远端命令参数不能为空");
+    }
+    return "'" + value.replace("'", "'\"'\"'") + "'";
+  }
+
+  private void destroy(Process process) {
+    if (process == null || !process.isAlive()) {
+      return;
+    }
+    process.destroy();
+    try {
+      if (!process.waitFor(2, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      process.destroyForcibly();
+    }
+  }
+
+  private RealtimeEngineException failure(String message, boolean uncertain, Throwable cause) {
+    return new RealtimeEngineException(message, uncertain, null, cause);
+  }
+
+  record ExecutionResult(int exitCode, boolean uncertain) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
@@ -43,7 +43,8 @@ final class SshFlinkCdcCommandRunner {
         || !absoluteUnixPath(properties.getFlinkCdcHome())) {
       return "SSH 模式下 flink-home 和 flink-cdc-home 必须是远端 Linux 绝对路径";
     }
-    if (StringUtils.hasText(properties.getJavaHome()) && !absoluteUnixPath(properties.getJavaHome())) {
+    if (StringUtils.hasText(properties.getJavaHome())
+        && !absoluteUnixPath(properties.getJavaHome())) {
       return "SSH 模式下 java-home 必须是远端 Linux 绝对路径";
     }
     Integer remoteRestPort = ssh.getRemoteRestPort();
@@ -74,18 +75,15 @@ final class SshFlinkCdcCommandRunner {
               .redirectOutput(ProcessBuilder.Redirect.DISCARD)
               .start();
       process.getOutputStream().close();
-      Duration connectTimeout = positiveDuration(properties.getSsh().getConnectTimeout(), Duration.ofSeconds(5));
+      Duration connectTimeout =
+          positiveDuration(properties.getSsh().getConnectTimeout(), Duration.ofSeconds(5));
       Duration timeout = connectTimeout.plusSeconds(5);
       if (!process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS)) {
         destroy(process);
         throw failure("SSH 远端环境探测超时", false, null);
       }
       if (process.exitValue() != 0) {
-        String message =
-            process.exitValue() == 255
-                ? "SSH 连接或认证失败，请检查 host key、用户和密钥配置"
-                : "SSH 已连接，但远端 Flink/Flink CDC/Java 环境未通过检查";
-        throw failure(message + "，exitCode=" + process.exitValue(), false, null);
+        throw failure(probeFailureMessage(process.exitValue()), false, null);
       }
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
@@ -174,14 +172,20 @@ final class SshFlinkCdcCommandRunner {
   private String remoteProbeCommand(URI restUri) {
     String cdc = remoteCdcCli();
     StringBuilder command = new StringBuilder("set -eu; ");
-    command.append("test -x ").append(shellQuote(cdc)).append("; ");
-    command.append("test -d ").append(shellQuote(properties.getFlinkHome())).append("; ");
-    command.append("command -v mktemp >/dev/null 2>&1; ");
+    command
+        .append("test -x ")
+        .append(shellQuote(cdc))
+        .append(" || exit 41; ");
+    command
+        .append("test -d ")
+        .append(shellQuote(properties.getFlinkHome()))
+        .append(" || exit 42; ");
+    command.append("command -v mktemp >/dev/null 2>&1 || exit 43; ");
     if (StringUtils.hasText(properties.getJavaHome())) {
       command
           .append("test -x ")
           .append(shellQuote(properties.getJavaHome() + "/bin/java"))
-          .append("; ");
+          .append(" || exit 44; ");
     }
     command.append("test -n ").append(shellQuote(remoteRestAddress(restUri))).append("; ");
     command.append("echo YAK_REALTIME_SSH_READY");
@@ -192,7 +196,8 @@ final class SshFlinkCdcCommandRunner {
     StringBuilder command = new StringBuilder();
     command.append("set -eu; umask 077; ");
     command.append("tmp=$(mktemp \"${TMPDIR:-/tmp}/yak-ops-cdc.XXXXXX.yaml\"); ");
-    command.append("cleanup(){ rm -f \"$tmp\"; }; trap cleanup 0 HUP INT TERM; ");
+    command.append("cleanup(){ rm -f \"$tmp\"; }; trap cleanup 0; ");
+    command.append("trap 'exit 129' HUP; trap 'exit 130' INT; trap 'exit 143' TERM; ");
     command.append("cat > \"$tmp\"; ");
     command.append("export FLINK_HOME=").append(shellQuote(properties.getFlinkHome())).append("; ");
     if (StringUtils.hasText(properties.getJavaHome())) {
@@ -236,6 +241,17 @@ final class SshFlinkCdcCommandRunner {
       return restUri.getPort();
     }
     return "https".equalsIgnoreCase(restUri.getScheme()) ? 443 : 80;
+  }
+
+  private String probeFailureMessage(int exitCode) {
+    return switch (exitCode) {
+      case 41 -> "SSH 已连接，但远端 Flink CDC CLI 不存在或不可执行";
+      case 42 -> "SSH 已连接，但远端 Flink Home 不存在";
+      case 43 -> "SSH 已连接，但远端缺少 mktemp 命令";
+      case 44 -> "SSH 已连接，但远端 JAVA_HOME/bin/java 不存在或不可执行";
+      case 255 -> "SSH 连接或认证失败，请检查 host key、用户和密钥配置";
+      default -> "SSH 远端运行环境未通过检查，exitCode=" + exitCode;
+    };
   }
 
   private boolean absoluteUnixPath(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewaySshTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewaySshTest.java
@@ -1,0 +1,157 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.SubmissionMode;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FlinkCdcEngineGatewaySshTest {
+
+  private static final String JOB_ID = "0123456789abcdef0123456789abcdef";
+
+  @TempDir Path temp;
+  private HttpServer server;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/overview", exchange -> json(exchange, 200, "{\"jobs-running\":0}"));
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  void submitsThroughSshWithoutCreatingLocalPipelineFile() throws Exception {
+    Path captured = temp.resolve("remote-pipeline.yaml");
+    Path ssh = fakeSsh(captured, 0);
+    RealtimeSyncProperties properties = sshProperties(ssh);
+    FlinkCdcEngineGateway gateway =
+        new FlinkCdcEngineGateway(HttpClient.newHttpClient(), new ObjectMapper(), properties);
+
+    String yaml =
+        "source:\n  password: ${SECRET:source.password}\n"
+            + "sink:\n  password: ${SECRET:sink.password}\n"
+            + "pipeline:\n  name: test\n";
+    RealtimeEngineGateway.DeployResult result;
+    try (RealtimeDeployRequest request =
+        new RealtimeDeployRequest(
+            yaml,
+            "ssh-key",
+            new RealtimeDeployRequest.CredentialBinding("source", "source-secret"),
+            new RealtimeDeployRequest.CredentialBinding("sink", "sink-secret"))) {
+      result = gateway.deploy(request);
+    }
+
+    assertThat(result.jobId()).isEqualTo(JOB_ID);
+    assertThat(gateway.capabilities().path("submissionMode").asText()).isEqualTo("SSH");
+    assertThat(gateway.capabilities().path("submissionEndpoint").asText())
+        .isEqualTo("flink@10.0.0.20:22");
+    assertThat(gateway.capabilities().path("restTransport").asText()).isEqualTo("DIRECT");
+    assertThat(Files.readString(captured, StandardCharsets.UTF_8))
+        .contains("password: 'source-secret'")
+        .contains("password: 'sink-secret'")
+        .doesNotContain("${SECRET:");
+    assertThat(temp.resolve("work/pipelines")).doesNotExist();
+    assertThat(temp.resolve("work/logs/submit-ssh-key.log")).exists();
+    assertThat(temp.resolve("work/logs/" + JOB_ID + ".submit.log")).exists();
+  }
+
+  @Test
+  void propagatesSsh255AsUncertainEngineFailureAndRetainsLog() throws Exception {
+    Path ssh = fakeSsh(temp.resolve("remote-uncertain.yaml"), 255);
+    RealtimeSyncProperties properties = sshProperties(ssh);
+    FlinkCdcEngineGateway gateway =
+        new FlinkCdcEngineGateway(HttpClient.newHttpClient(), new ObjectMapper(), properties);
+    String yaml =
+        "source:\n  password: ${SECRET:source.password}\n"
+            + "sink:\n  password: ${SECRET:sink.password}\n"
+            + "pipeline:\n  name: test\n";
+
+    try (RealtimeDeployRequest request =
+        new RealtimeDeployRequest(
+            yaml,
+            "ssh-uncertain",
+            new RealtimeDeployRequest.CredentialBinding("source", "source-secret"),
+            new RealtimeDeployRequest.CredentialBinding("sink", "sink-secret"))) {
+      assertThatThrownBy(() -> gateway.deploy(request))
+          .isInstanceOf(RealtimeEngineException.class)
+          .satisfies(
+              error -> assertThat(((RealtimeEngineException) error).uncertain()).isTrue())
+          .hasMessageContaining("exitCode=255");
+    }
+
+    assertThat(temp.resolve("work/logs/submit-ssh-uncertain.log")).exists();
+  }
+
+  private RealtimeSyncProperties sshProperties(Path executable) {
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setSubmissionMode(SubmissionMode.SSH);
+    properties.setRestUrl("http://127.0.0.1:" + server.getAddress().getPort());
+    properties.setFlinkHome("/opt/flink");
+    properties.setFlinkCdcHome("/opt/flink-cdc");
+    properties.setWorkDirectory(temp.resolve("work").toString());
+    properties.setSubmitTimeout(Duration.ofSeconds(5));
+    properties.getSsh().setExecutable(executable.toString());
+    properties.getSsh().setHost("10.0.0.20");
+    properties.getSsh().setPort(22);
+    properties.getSsh().setUser("flink");
+    properties.getSsh().setConnectTimeout(Duration.ofSeconds(1));
+    properties.getSsh().setRemoteRestAddress("127.0.0.1");
+    properties.getSsh().setRemoteRestPort(server.getAddress().getPort());
+    return properties;
+  }
+
+  private Path fakeSsh(Path captured, int submitExitCode) throws Exception {
+    Path script = temp.resolve("gateway-fake-ssh-" + submitExitCode + ".sh");
+    String content =
+        "#!/bin/sh\n"
+            + "case \"$*\" in\n"
+            + "  *YAK_REALTIME_SSH_READY*) exit 0 ;;\n"
+            + "esac\n"
+            + "cat > "
+            + shell(captured)
+            + "\n"
+            + "echo 'Pipeline has been submitted to cluster.'\n"
+            + "echo 'Job ID: "
+            + JOB_ID
+            + "'\n"
+            + "exit "
+            + submitExitCode
+            + "\n";
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+    Files.setPosixFilePermissions(script, PosixFilePermissions.fromString("rwx------"));
+    return script;
+  }
+
+  private String shell(Path path) {
+    return "'" + path.toString().replace("'", "'\"'\"'") + "'";
+  }
+
+  private void json(HttpExchange exchange, int status, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewayTest.java
@@ -105,6 +105,9 @@ class FlinkCdcEngineGatewayTest {
     assertThat(gateway.health().path("jobs-running").asInt()).isEqualTo(1);
     assertThat(gateway.capabilities().path("deployEnabled").asBoolean()).isTrue();
     assertThat(gateway.capabilities().path("checkpointsApi").asBoolean()).isTrue();
+    assertThat(gateway.capabilities().path("submissionMode").asText()).isEqualTo("LOCAL");
+    assertThat(gateway.capabilities().path("submissionEndpoint").asText()).isEqualTo("local");
+    assertThat(gateway.capabilities().path("restTransport").asText()).isEqualTo("DIRECT");
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunnerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunnerTest.java
@@ -1,0 +1,111 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SshFlinkCdcCommandRunnerTest {
+
+  @TempDir Path temp;
+
+  @Test
+  void streamsPipelineOverStdinAndBuildsHardenedSshCommand() throws Exception {
+    Path captured = temp.resolve("captured.yaml");
+    Path args = temp.resolve("args.txt");
+    Path ssh = fakeSsh(captured, args, 0);
+    RealtimeSyncProperties properties = properties(ssh);
+    properties.getSsh().setRemoteRestAddress("127.0.0.1");
+    properties.getSsh().setRemoteRestPort(8081);
+    SshFlinkCdcCommandRunner runner = new SshFlinkCdcCommandRunner(properties);
+
+    URI rest = URI.create("http://10.0.0.20:8081");
+    runner.validateReady(rest);
+    Path log = temp.resolve("submit.log");
+    SshFlinkCdcCommandRunner.ExecutionResult result =
+        runner.submit("pipeline:\n  name: demo\n", log, rest, Duration.ofSeconds(5));
+
+    assertThat(result.exitCode()).isZero();
+    assertThat(result.uncertain()).isFalse();
+    assertThat(Files.readString(captured, StandardCharsets.UTF_8))
+        .isEqualTo("pipeline:\n  name: demo\n");
+    assertThat(Files.readString(log, StandardCharsets.UTF_8)).contains("Job ID:");
+    assertThat(Files.readString(args, StandardCharsets.UTF_8))
+        .contains("BatchMode=yes")
+        .contains("StrictHostKeyChecking=yes")
+        .contains("flink@10.0.0.20")
+        .contains("/opt/flink-cdc/bin/flink-cdc.sh")
+        .contains("-Drest.address=127.0.0.1")
+        .contains("-Drest.port=8081");
+  }
+
+  @Test
+  void treatsOpenSshExit255AsUncertainSubmission() throws Exception {
+    Path ssh = fakeSsh(temp.resolve("ignored.yaml"), temp.resolve("args-255.txt"), 255);
+    RealtimeSyncProperties properties = properties(ssh);
+    SshFlinkCdcCommandRunner runner = new SshFlinkCdcCommandRunner(properties);
+    URI rest = URI.create("http://10.0.0.20:8081");
+
+    runner.validateReady(rest);
+    SshFlinkCdcCommandRunner.ExecutionResult result =
+        runner.submit("pipeline:\n  name: demo\n", temp.resolve("255.log"), rest, Duration.ofSeconds(5));
+
+    assertThat(result.exitCode()).isEqualTo(255);
+    assertThat(result.uncertain()).isTrue();
+  }
+
+  @Test
+  void reportsIncompleteSshConfigurationBeforeStartingProcess() {
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.getSsh().setUser("flink");
+    SshFlinkCdcCommandRunner runner = new SshFlinkCdcCommandRunner(properties);
+
+    assertThat(runner.configurationError()).contains("SSH host");
+  }
+
+  private RealtimeSyncProperties properties(Path sshExecutable) {
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setFlinkHome("/opt/flink");
+    properties.setFlinkCdcHome("/opt/flink-cdc");
+    properties.getSsh().setExecutable(sshExecutable.toString());
+    properties.getSsh().setHost("10.0.0.20");
+    properties.getSsh().setUser("flink");
+    properties.getSsh().setPort(22);
+    properties.getSsh().setConnectTimeout(Duration.ofSeconds(1));
+    return properties;
+  }
+
+  private Path fakeSsh(Path captured, Path args, int submitExitCode) throws Exception {
+    Path script = temp.resolve("fake-ssh-" + submitExitCode + ".sh");
+    String content =
+        "#!/bin/sh\n"
+            + "printf '%s\\n' \"$*\" > "
+            + shell(args)
+            + "\n"
+            + "case \"$*\" in\n"
+            + "  *YAK_REALTIME_SSH_READY*) exit 0 ;;\n"
+            + "esac\n"
+            + "cat > "
+            + shell(captured)
+            + "\n"
+            + "echo 'Pipeline has been submitted to cluster.'\n"
+            + "echo 'Job ID: 0123456789abcdef0123456789abcdef'\n"
+            + "exit "
+            + submitExitCode
+            + "\n";
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+    Files.setPosixFilePermissions(script, PosixFilePermissions.fromString("rwx------"));
+    return script;
+  }
+
+  private String shell(Path path) {
+    return "'" + path.toString().replace("'", "'\"'\"'") + "'";
+  }
+}

--- a/yak-ops-ui/src/pages/realtime-sync/types.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/types.ts
@@ -164,6 +164,9 @@ export interface RuntimeCapabilities {
   engineType?: string;
   runtimeVersion?: string;
   restUrl?: string;
+  restTransport?: 'DIRECT';
+  submissionMode?: 'LOCAL' | 'SSH';
+  submissionEndpoint?: string;
   flinkVersion?: string;
   flinkCdcVersion?: string;
   deliverySemantics?: string;


### PR DESCRIPTION
## 背景

前四阶段已经完成实时同步状态模型、启停幂等/并发、Flink Job 生命周期恢复，以及日志/Checkpoint/Metrics 可观测性。本 PR 完成第五阶段：**让 Yak Ops 与 Flink CDC CLI 可以分离部署**。

目标场景：

```text
Windows / Yak Ops
  ├─ HTTP ───────────────> Flink REST
  └─ OpenSSH ────────────> Linux Flink CDC 执行节点
                              └─ flink-cdc.sh
```

本阶段不引入 Runtime Agent。SSH 只负责远程执行 Flink CDC CLI；任务状态、JobId 恢复、停止、Checkpoint、Metrics、运行诊断仍然复用现有 Flink REST 链路。

## 核心改动

### 1. 新增 LOCAL / SSH 两种提交模式

`yak.sync.realtime.submission-mode`：

- `LOCAL`：默认值，完全兼容现有同机部署。
- `SSH`：通过 Yak Ops 所在机器的 OpenSSH 客户端连接 Linux，在远端调用 `flink-cdc.sh`。

现有 `flink-home / flink-cdc-home / java-home`：

- LOCAL 模式：表示 Yak Ops 本机路径。
- SSH 模式：表示远端 Linux 节点的绝对路径。

### 2. 新增 SSH 配置

支持：

- `ssh.executable`
- `ssh.host / port / user`
- `ssh.identity-file`
- `ssh.known-hosts-file`
- `ssh.strict-host-key-checking`
- `ssh.connect-timeout`
- `ssh.remote-rest-address / remote-rest-port`

SSH 使用 `BatchMode=yes`，只支持 OpenSSH key / ssh-agent 非交互认证；**不在 Yak Ops 中保存 SSH 登录密码**。

`remote-rest-address / remote-rest-port` 用于 Linux 节点执行 Flink CDC CLI 时传递 `-Drest.address/-Drest.port`。它可以和 Yak Ops 直接访问的 `rest-url` 不同，例如：

- Yak Ops：`rest-url=http://10.0.0.20:8081`
- Linux CLI：`remote-rest-address=127.0.0.1`

### 3. Pipeline YAML 通过 SSH stdin 安全传输

SSH 模式不在 Yak Ops 本地创建包含数据源密码的 Pipeline YAML 文件。

流程：

```text
Yak Ops 内存 Pipeline YAML
  -> OpenSSH stdin
  -> Linux mktemp
  -> umask 077
  -> flink-cdc.sh
  -> EXIT trap 删除远端临时文件
```

远端同时处理 HUP / INT / TERM，退出后统一通过 EXIT trap 清理临时 YAML。

本地仍只保留脱敏后的 submission log。

### 4. SSH 环境探测与配置校验

发布/启动前会通过 SSH 检查：

- Flink CDC CLI 是否存在且可执行。
- Flink Home 是否存在。
- `mktemp` 是否可用。
- 配置 JAVA_HOME 时，`JAVA_HOME/bin/java` 是否可执行。
- SSH host/user/port、远端路径、remote REST port 是否有效。

错误会区分：CLI 缺失、Flink Home 缺失、Java 缺失、mktemp 缺失、SSH 认证/host key 失败，避免只返回一个模糊的“远程环境不可用”。

### 5. SSH 失败继续复用第三阶段恢复能力

以下情况视为“提交结果不确定”：

- OpenSSH exit code `255`。
- SSH 已启动后连接/传输异常。
- SSH 提交超时。
- 提交线程被中断。

Yak Ops **不会直接自动重新提交**，仍然交给现有 runtime identity / JobId 恢复和生命周期对账逻辑判断 Flink 中是否已经存在 Job，避免重复回放。

远端 CLI 明确返回普通非零 exit code 时，按确定失败处理。

### 6. Flink REST 保持 DIRECT

SSH 不代理 Flink REST。

`yak.sync.realtime.rest-url` 仍必须从 Yak Ops 后端可访问，用于：

- health
- Job status / stop
- JobId recovery
- logs/runtime diagnostics
- Checkpoint
- Metrics

这样前四阶段代码无需为 SSH 再实现一套远程控制通道。

### 7. 能力接口增加执行模式信息

`/api/v1/realtime-sync/runtime/capabilities` 新增：

```json
{
  "submissionMode": "SSH",
  "submissionEndpoint": "flink@10.0.0.20:22",
  "restTransport": "DIRECT"
}
```

前端 `RuntimeCapabilities` 类型同步增加这三个字段。

### 8. 部署文档

新增 realtime 模块 README，包含：

- LOCAL 模式配置。
- Windows Yak Ops + Linux Flink CDC 的 SSH 配置模板。
- OpenSSH key / known_hosts 要求。
- Linux SSH 用户最小权限说明。
- Pipeline YAML 安全边界。
- SSH 失败语义。
- 直接 REST 网络要求。

## 测试

新增/扩展测试覆盖：

- LOCAL 仍为默认模式，现有本地 CLI 行为不变。
- SSH Pipeline YAML 确实通过 stdin 发送。
- SSH 命令启用 `BatchMode`、host key 校验、连接超时和 keepalive。
- 远端 Flink CDC CLI / REST 参数生成正确。
- SSH 模式不创建 Yak Ops 本地 pipeline 临时文件。
- SSH 成功提交仍保留 deployment-key / JobId submission log。
- OpenSSH `255` 被标记为 uncertain，供生命周期恢复接管。
- SSH 配置不完整时在启动进程前直接拒绝。

当前执行环境仍无法解析 `github.com` DNS，因此不能 clone 本分支实际运行 Maven/npm；本 PR 已完成代码级静态检查。最终仍以仓库 CI 或本地测试结果为准。

## 兼容性

- 默认 `submission-mode=LOCAL`，老部署无需改配置。
- 无数据库 migration。
- RealtimeEngineGateway 对外接口未变化。
- 状态机、启停幂等、JobId 恢复、Checkpoint/Metrics API 均未改协议。

## 范围外

本 PR 不包含：

- Runtime Agent / 常驻远端服务。
- SSH 密码托管。
- SSH Tunnel 代理 Flink REST。
- 通过 SSH 下载完整 JobManager / TaskManager 日志。
- 多 SSH 执行节点调度。

第五阶段原则：**远程执行只解决“CLI 在哪里运行”，Flink Job 的事实状态仍由 REST 和已有生命周期控制面负责。**