### PR TITLE
feat(settings): add Flink CDC runtime environment management

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncProperties.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncProperties.java
@@ -11,6 +11,19 @@ public class RealtimeSyncProperties {
     SSH
   }
 
+  /**
+   * Environment-scoped runtime settings. The object is replaced atomically when the default
+   * compute environment changes, while application.yml / ENV values remain the bootstrap fallback.
+   */
+  public record RuntimeOverrides(
+      String restUrl,
+      String flinkHome,
+      String flinkCdcHome,
+      String javaHome,
+      String flinkVersion,
+      String flinkCdcVersion,
+      SubmissionMode submissionMode) {}
+
   private boolean enabled = true;
   private String restUrl = "http://127.0.0.1:8081";
   private String flinkHome = "/opt/flink";
@@ -27,6 +40,7 @@ public class RealtimeSyncProperties {
   private int maxLogLines = 1_000;
   private int reconcileFailureThreshold = 3;
   private int reconcileLeaseSeconds = 30;
+  private volatile RuntimeOverrides runtimeOverrides;
 
   public boolean isEnabled() {
     return enabled;
@@ -37,7 +51,8 @@ public class RealtimeSyncProperties {
   }
 
   public String getRestUrl() {
-    return restUrl;
+    RuntimeOverrides current = runtimeOverrides;
+    return current == null ? restUrl : current.restUrl();
   }
 
   public void setRestUrl(String restUrl) {
@@ -45,7 +60,8 @@ public class RealtimeSyncProperties {
   }
 
   public String getFlinkHome() {
-    return flinkHome;
+    RuntimeOverrides current = runtimeOverrides;
+    return current == null ? flinkHome : current.flinkHome();
   }
 
   public void setFlinkHome(String flinkHome) {
@@ -53,7 +69,8 @@ public class RealtimeSyncProperties {
   }
 
   public String getFlinkCdcHome() {
-    return flinkCdcHome;
+    RuntimeOverrides current = runtimeOverrides;
+    return current == null ? flinkCdcHome : current.flinkCdcHome();
   }
 
   public void setFlinkCdcHome(String flinkCdcHome) {
@@ -61,13 +78,18 @@ public class RealtimeSyncProperties {
   }
 
   public String getJavaHome() {
-    return javaHome;
+    RuntimeOverrides current = runtimeOverrides;
+    return current == null ? javaHome : current.javaHome();
   }
 
   public void setJavaHome(String javaHome) {
     this.javaHome = javaHome;
   }
 
+  /**
+   * The work directory is intentionally application-scoped in stage one. Submission logs for
+   * historical deployments must not move when the default compute environment is switched.
+   */
   public String getWorkDirectory() {
     return workDirectory;
   }
@@ -77,7 +99,8 @@ public class RealtimeSyncProperties {
   }
 
   public String getFlinkVersion() {
-    return flinkVersion;
+    RuntimeOverrides current = runtimeOverrides;
+    return current == null ? flinkVersion : current.flinkVersion();
   }
 
   public void setFlinkVersion(String flinkVersion) {
@@ -85,7 +108,8 @@ public class RealtimeSyncProperties {
   }
 
   public String getFlinkCdcVersion() {
-    return flinkCdcVersion;
+    RuntimeOverrides current = runtimeOverrides;
+    return current == null ? flinkCdcVersion : current.flinkCdcVersion();
   }
 
   public void setFlinkCdcVersion(String flinkCdcVersion) {
@@ -93,7 +117,8 @@ public class RealtimeSyncProperties {
   }
 
   public SubmissionMode getSubmissionMode() {
-    return submissionMode;
+    RuntimeOverrides current = runtimeOverrides;
+    return current == null ? submissionMode : current.submissionMode();
   }
 
   public void setSubmissionMode(SubmissionMode submissionMode) {
@@ -102,6 +127,14 @@ public class RealtimeSyncProperties {
 
   public Ssh getSsh() {
     return ssh;
+  }
+
+  public void applyRuntimeOverrides(RuntimeOverrides overrides) {
+    this.runtimeOverrides = overrides;
+  }
+
+  public void clearRuntimeOverrides() {
+    this.runtimeOverrides = null;
   }
 
   public Duration getConnectTimeout() {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
@@ -58,10 +58,12 @@ public class ComputeEnvironmentController {
   @PutMapping("/{id}")
   @RequiresPermission(RealtimePermissionCode.UPDATE)
   public Result<Boolean> update(@PathVariable long id, @RequestBody SaveRequest request) {
-    service.update(id, request.name(), request.config(), request.enabled());
-    if (request.makeDefault()) {
-      service.setDefault(id);
-    }
+    service.update(
+        id,
+        request.name(),
+        request.config(),
+        request.enabled(),
+        request.makeDefault());
     return Result.success(true);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
@@ -1,0 +1,92 @@
+package io.yak.ops.business.sync.realtime.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.service.ComputeEnvironmentService;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "计算引擎运行环境")
+@RestController
+@RequestMapping("/api/v1/compute-environments")
+@RequiresPermission(RealtimePermissionCode.READ)
+public class ComputeEnvironmentController {
+
+  private final ComputeEnvironmentService service;
+
+  public ComputeEnvironmentController(ComputeEnvironmentService service) {
+    this.service = service;
+  }
+
+  public record SaveRequest(
+      String name, RuntimeConfig config, boolean enabled, boolean makeDefault) {}
+
+  public record EnabledRequest(boolean enabled) {}
+
+  @Operation(summary = "查询运行环境列表")
+  @GetMapping
+  public Result<List<ComputeEnvironment>> list() {
+    return Result.success(service.list());
+  }
+
+  @Operation(summary = "查询运行环境详情")
+  @GetMapping("/{id}")
+  public Result<ComputeEnvironment> detail(@PathVariable long id) {
+    return Result.success(service.get(id));
+  }
+
+  @Operation(summary = "新建运行环境")
+  @PostMapping
+  @RequiresPermission(RealtimePermissionCode.CREATE)
+  public Result<Long> create(@RequestBody SaveRequest request) {
+    return Result.success(
+        service.create(request.name(), request.config(), request.enabled(), request.makeDefault()));
+  }
+
+  @Operation(summary = "更新运行环境")
+  @PutMapping("/{id}")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Boolean> update(@PathVariable long id, @RequestBody SaveRequest request) {
+    service.update(id, request.name(), request.config(), request.enabled());
+    if (request.makeDefault()) {
+      service.setDefault(id);
+    }
+    return Result.success(true);
+  }
+
+  @Operation(summary = "启用或停用运行环境")
+  @PutMapping("/{id}/enabled")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Boolean> setEnabled(
+      @PathVariable long id, @RequestBody EnabledRequest request) {
+    service.setEnabled(id, request.enabled());
+    return Result.success(true);
+  }
+
+  @Operation(summary = "设置默认运行环境")
+  @PostMapping("/{id}/default")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Boolean> setDefault(@PathVariable long id) {
+    service.setDefault(id);
+    return Result.success(true);
+  }
+
+  @Operation(summary = "删除运行环境")
+  @DeleteMapping("/{id}")
+  @RequiresPermission(RealtimePermissionCode.DELETE)
+  public Result<Boolean> delete(@PathVariable long id) {
+    service.delete(id);
+    return Result.success(true);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeExceptionHandler.java
@@ -8,7 +8,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(assignableTypes = RealtimeJobController.class)
+@RestControllerAdvice(
+    assignableTypes = {RealtimeJobController.class, ComputeEnvironmentController.class})
 public class RealtimeExceptionHandler {
 
   @ExceptionHandler(IllegalArgumentException.class)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import java.time.LocalDateTime;
+
+/** Runtime environment used by Yak Ops to submit realtime jobs to Flink CDC. */
+public record ComputeEnvironment(
+    long id,
+    String name,
+    String engineType,
+    String deploymentMode,
+    String submitterType,
+    RuntimeConfig config,
+    boolean enabled,
+    boolean defaultEnvironment,
+    int version,
+    LocalDateTime createTime,
+    LocalDateTime updateTime) {
+
+  public static final String ENGINE_FLINK_CDC = "FLINK_CDC";
+  public static final String DEPLOYMENT_REMOTE = "REMOTE";
+  public static final String SUBMITTER_LOCAL = "LOCAL";
+  public static final String SUBMITTER_SSH = "SSH";
+
+  /**
+   * Stage one intentionally stores only the settings that describe where Flink CDC runs. Yak Ops
+   * operational settings such as timeouts, log retention and reconcile cadence remain application
+   * level settings.
+   */
+  public record RuntimeConfig(
+      String restUrl,
+      String flinkHome,
+      String flinkCdcHome,
+      String javaHome,
+      String flinkVersion,
+      String flinkCdcVersion) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
@@ -1,0 +1,179 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.stereotype.Repository;
+
+/** JDBC persistence adapter for compute runtime environments. */
+@Repository
+public class ComputeEnvironmentStore {
+
+  private final JdbcTemplate db;
+  private final ObjectMapper json;
+
+  public ComputeEnvironmentStore(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      @Qualifier("realtimeObjectMapper") ObjectMapper json) {
+    this.db = new JdbcTemplate(dataSource);
+    this.json = json;
+  }
+
+  public long count() {
+    Long value = db.queryForObject("select count(*) from yak_compute_environment", Long.class);
+    return value == null ? 0 : value;
+  }
+
+  public List<ComputeEnvironment> list() {
+    return db.query(
+        "select * from yak_compute_environment order by is_default desc, enabled desc, update_time desc, id desc",
+        (result, row) -> map(result));
+  }
+
+  public Optional<ComputeEnvironment> find(long id) {
+    return db.query(
+            "select * from yak_compute_environment where id=?", (result, row) -> map(result), id)
+        .stream()
+        .findFirst();
+  }
+
+  public Optional<ComputeEnvironment> defaultEnvironment() {
+    return db.query(
+            "select * from yak_compute_environment where is_default=1 and enabled=1 order by id limit 1",
+            (result, row) -> map(result))
+        .stream()
+        .findFirst();
+  }
+
+  public long insert(
+      String name,
+      String engineType,
+      String deploymentMode,
+      String submitterType,
+      RuntimeConfig config,
+      boolean enabled,
+      boolean defaultEnvironment) {
+    GeneratedKeyHolder keys = new GeneratedKeyHolder();
+    db.update(
+        connection -> {
+          PreparedStatement statement =
+              connection.prepareStatement(
+                  "insert into yak_compute_environment"
+                      + "(name,engine_type,deployment_mode,submitter_type,config_json,enabled,is_default) "
+                      + "values(?,?,?,?,?,?,?)",
+                  Statement.RETURN_GENERATED_KEYS);
+          statement.setString(1, name);
+          statement.setString(2, engineType);
+          statement.setString(3, deploymentMode);
+          statement.setString(4, submitterType);
+          statement.setString(5, write(config));
+          statement.setBoolean(6, enabled);
+          statement.setBoolean(7, defaultEnvironment);
+          return statement;
+        },
+        keys);
+    return Objects.requireNonNull(keys.getKey(), "新增运行环境未返回主键").longValue();
+  }
+
+  public void update(long id, String name, RuntimeConfig config, boolean enabled) {
+    int changed =
+        db.update(
+            "update yak_compute_environment set name=?,config_json=?,enabled=?,version=version+1 where id=?",
+            name,
+            write(config),
+            enabled,
+            id);
+    if (changed != 1) {
+      throw new IllegalArgumentException("运行环境不存在：" + id);
+    }
+  }
+
+  public void setEnabled(long id, boolean enabled) {
+    int changed =
+        db.update(
+            "update yak_compute_environment set enabled=?,version=version+1 where id=?",
+            enabled,
+            id);
+    if (changed != 1) {
+      throw new IllegalArgumentException("运行环境不存在：" + id);
+    }
+  }
+
+  public void clearDefault() {
+    db.update("update yak_compute_environment set is_default=0 where is_default=1");
+  }
+
+  public void setDefault(long id) {
+    int changed =
+        db.update(
+            "update yak_compute_environment set is_default=1,version=version+1 where id=? and enabled=1",
+            id);
+    if (changed != 1) {
+      throw new IllegalStateException("只有已启用的运行环境才能设为默认环境");
+    }
+  }
+
+  public void delete(long id) {
+    int changed = db.update("delete from yak_compute_environment where id=? and is_default=0", id);
+    if (changed != 1) {
+      throw new IllegalStateException("默认运行环境不能删除，请先切换默认环境");
+    }
+  }
+
+  public boolean hasActiveRealtimeJobs() {
+    Long count =
+        db.queryForObject(
+            "select count(*) from yak_realtime_job_definition where desired_state='RUNNING' "
+                + "or observed_state not in ('STOPPED','FAILED')",
+            Long.class);
+    return count != null && count > 0;
+  }
+
+  private ComputeEnvironment map(ResultSet result) throws SQLException {
+    return new ComputeEnvironment(
+        result.getLong("id"),
+        result.getString("name"),
+        result.getString("engine_type"),
+        result.getString("deployment_mode"),
+        result.getString("submitter_type"),
+        read(result.getString("config_json")),
+        result.getBoolean("enabled"),
+        result.getBoolean("is_default"),
+        result.getInt("version"),
+        time(result.getTimestamp("create_time")),
+        time(result.getTimestamp("update_time")));
+  }
+
+  private String write(RuntimeConfig config) {
+    try {
+      return json.writeValueAsString(config);
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("无法序列化运行环境配置", exception);
+    }
+  }
+
+  private RuntimeConfig read(String value) {
+    try {
+      return json.readValue(value, RuntimeConfig.class);
+    } catch (Exception exception) {
+      throw new IllegalStateException("运行环境配置无法解析", exception);
+    }
+  }
+
+  private LocalDateTime time(Timestamp value) {
+    return value == null ? null : value.toLocalDateTime();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
@@ -89,24 +89,37 @@ public class ComputeEnvironmentService {
     }
   }
 
-  public void update(long id, String name, RuntimeConfig config, boolean enabled) {
+  public void update(
+      long id, String name, RuntimeConfig config, boolean enabled, boolean makeDefault) {
     ComputeEnvironment current = require(id);
     String normalizedName = normalizeName(name);
     RuntimeConfig normalizedConfig = normalizeConfig(config);
+    boolean switchingDefault = makeDefault && !current.defaultEnvironment();
 
     if (current.defaultEnvironment() && !enabled) {
       throw new IllegalStateException("默认运行环境不能停用，请先切换默认环境");
     }
-    if (current.defaultEnvironment() && !current.config().equals(normalizedConfig)) {
-      requireRuntimeStable("修改默认运行环境");
+    if (switchingDefault && !enabled) {
+      throw new IllegalArgumentException("默认运行环境必须保持启用");
+    }
+    if ((current.defaultEnvironment() && !current.config().equals(normalizedConfig))
+        || switchingDefault) {
+      requireRuntimeStable(switchingDefault ? "切换默认运行环境" : "修改默认运行环境");
     }
 
     try {
-      store.update(id, normalizedName, normalizedConfig, enabled);
+      transactions.executeWithoutResult(
+          status -> {
+            store.update(id, normalizedName, normalizedConfig, enabled);
+            if (switchingDefault) {
+              store.clearDefault();
+              store.setDefault(id);
+            }
+          });
     } catch (DuplicateKeyException exception) {
       throw new IllegalArgumentException("运行环境名称已存在：" + normalizedName, exception);
     }
-    if (current.defaultEnvironment()) {
+    if (current.defaultEnvironment() || switchingDefault) {
       refreshRuntimeOverrides();
     }
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
@@ -1,0 +1,282 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.RuntimeOverrides;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.SubmissionMode;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
+import jakarta.annotation.PostConstruct;
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.StringUtils;
+
+/** Manages the small, user-facing runtime environment model for realtime Flink CDC. */
+@Service
+@DependsOn("realtimeSyncFlyway")
+public class ComputeEnvironmentService {
+
+  private static final String BOOTSTRAP_NAME = "默认实时环境";
+
+  private final ComputeEnvironmentStore store;
+  private final RealtimeSyncProperties properties;
+  private final TransactionTemplate transactions;
+
+  public ComputeEnvironmentService(
+      ComputeEnvironmentStore store,
+      RealtimeSyncProperties properties,
+      @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager) {
+    this.store = store;
+    this.properties = properties;
+    this.transactions = new TransactionTemplate(transactionManager);
+  }
+
+  @PostConstruct
+  void initialize() {
+    bootstrapDefaultEnvironment();
+    refreshRuntimeOverrides();
+  }
+
+  public List<ComputeEnvironment> list() {
+    return store.list();
+  }
+
+  public ComputeEnvironment get(long id) {
+    return require(id);
+  }
+
+  public long create(String name, RuntimeConfig config, boolean enabled, boolean makeDefault) {
+    String normalizedName = normalizeName(name);
+    RuntimeConfig normalizedConfig = normalizeConfig(config);
+    if (makeDefault && !enabled) {
+      throw new IllegalArgumentException("默认运行环境必须保持启用");
+    }
+    if (makeDefault) {
+      requireRuntimeStable("切换默认运行环境");
+    }
+
+    try {
+      Long id =
+          transactions.execute(
+              status -> {
+                if (makeDefault) {
+                  store.clearDefault();
+                }
+                return store.insert(
+                    normalizedName,
+                    ComputeEnvironment.ENGINE_FLINK_CDC,
+                    ComputeEnvironment.DEPLOYMENT_REMOTE,
+                    ComputeEnvironment.SUBMITTER_LOCAL,
+                    normalizedConfig,
+                    enabled,
+                    makeDefault);
+              });
+      if (makeDefault) {
+        refreshRuntimeOverrides();
+      }
+      return Objects.requireNonNull(id, "新增运行环境失败");
+    } catch (DuplicateKeyException exception) {
+      throw new IllegalArgumentException("运行环境名称已存在：" + normalizedName, exception);
+    }
+  }
+
+  public void update(long id, String name, RuntimeConfig config, boolean enabled) {
+    ComputeEnvironment current = require(id);
+    String normalizedName = normalizeName(name);
+    RuntimeConfig normalizedConfig = normalizeConfig(config);
+
+    if (current.defaultEnvironment() && !enabled) {
+      throw new IllegalStateException("默认运行环境不能停用，请先切换默认环境");
+    }
+    if (current.defaultEnvironment() && !current.config().equals(normalizedConfig)) {
+      requireRuntimeStable("修改默认运行环境");
+    }
+
+    try {
+      store.update(id, normalizedName, normalizedConfig, enabled);
+    } catch (DuplicateKeyException exception) {
+      throw new IllegalArgumentException("运行环境名称已存在：" + normalizedName, exception);
+    }
+    if (current.defaultEnvironment()) {
+      refreshRuntimeOverrides();
+    }
+  }
+
+  public void setEnabled(long id, boolean enabled) {
+    ComputeEnvironment current = require(id);
+    if (current.defaultEnvironment() && !enabled) {
+      throw new IllegalStateException("默认运行环境不能停用，请先切换默认环境");
+    }
+    store.setEnabled(id, enabled);
+  }
+
+  public void setDefault(long id) {
+    ComputeEnvironment target = require(id);
+    if (target.defaultEnvironment()) {
+      return;
+    }
+    if (!target.enabled()) {
+      throw new IllegalStateException("只有已启用的运行环境才能设为默认环境");
+    }
+    requireRuntimeStable("切换默认运行环境");
+    transactions.executeWithoutResult(
+        status -> {
+          store.clearDefault();
+          store.setDefault(id);
+        });
+    refreshRuntimeOverrides();
+  }
+
+  public void delete(long id) {
+    ComputeEnvironment current = require(id);
+    if (current.defaultEnvironment()) {
+      throw new IllegalStateException("默认运行环境不能删除，请先切换默认环境");
+    }
+    store.delete(id);
+  }
+
+  /**
+   * Keeps every Yak Ops instance aligned with the database-selected default environment. Runtime
+   * environments cannot be changed while jobs are active, so the refresh is safe for running jobs.
+   */
+  @Scheduled(fixedDelayString = "${yak.sync.realtime.environment-refresh-delay:5000}")
+  public void refreshRuntimeOverrides() {
+    ComputeEnvironment environment = store.defaultEnvironment().orElse(null);
+    if (environment == null) {
+      properties.clearRuntimeOverrides();
+      return;
+    }
+    RuntimeConfig config = environment.config();
+    SubmissionMode mode = submissionMode(environment.submitterType());
+    properties.applyRuntimeOverrides(
+        new RuntimeOverrides(
+            config.restUrl(),
+            config.flinkHome(),
+            config.flinkCdcHome(),
+            config.javaHome(),
+            config.flinkVersion(),
+            config.flinkCdcVersion(),
+            mode));
+  }
+
+  private void bootstrapDefaultEnvironment() {
+    if (store.count() > 0) {
+      return;
+    }
+    RuntimeConfig config =
+        new RuntimeConfig(
+            properties.getRestUrl(),
+            properties.getFlinkHome(),
+            properties.getFlinkCdcHome(),
+            properties.getJavaHome(),
+            properties.getFlinkVersion(),
+            properties.getFlinkCdcVersion());
+    try {
+      transactions.executeWithoutResult(
+          status -> {
+            if (store.count() == 0) {
+              store.insert(
+                  BOOTSTRAP_NAME,
+                  ComputeEnvironment.ENGINE_FLINK_CDC,
+                  ComputeEnvironment.DEPLOYMENT_REMOTE,
+                  properties.getSubmissionMode().name(),
+                  normalizeConfig(config),
+                  true,
+                  true);
+            }
+          });
+    } catch (DuplicateKeyException ignored) {
+      // Another Yak Ops instance won the bootstrap race.
+    }
+  }
+
+  private ComputeEnvironment require(long id) {
+    return store.find(id).orElseThrow(() -> new IllegalArgumentException("运行环境不存在：" + id));
+  }
+
+  private void requireRuntimeStable(String action) {
+    if (store.hasActiveRealtimeJobs()) {
+      throw new IllegalStateException(action + "前请先停止所有实时同步任务");
+    }
+  }
+
+  private String normalizeName(String value) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException("运行环境名称不能为空");
+    }
+    String normalized = value.trim();
+    if (normalized.length() > 120) {
+      throw new IllegalArgumentException("运行环境名称不能超过 120 个字符");
+    }
+    return normalized;
+  }
+
+  private RuntimeConfig normalizeConfig(RuntimeConfig value) {
+    if (value == null) {
+      throw new IllegalArgumentException("运行环境配置不能为空");
+    }
+    String restUrl = required(value.restUrl(), "Flink REST URL", 500);
+    validateRestUrl(restUrl);
+    String flinkHome = required(value.flinkHome(), "Flink Home", 500);
+    String flinkCdcHome = required(value.flinkCdcHome(), "Flink CDC Home", 500);
+    String javaHome = optional(value.javaHome(), 500);
+    String flinkVersion = required(value.flinkVersion(), "Flink 版本", 64);
+    String flinkCdcVersion = required(value.flinkCdcVersion(), "Flink CDC 版本", 64);
+    return new RuntimeConfig(
+        restUrl, flinkHome, flinkCdcHome, javaHome, flinkVersion, flinkCdcVersion);
+  }
+
+  private void validateRestUrl(String value) {
+    try {
+      URI uri = URI.create(value);
+      String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+      if (!("http".equals(scheme) || "https".equals(scheme)) || !StringUtils.hasText(uri.getHost())) {
+        throw new IllegalArgumentException("Flink REST URL 必须是完整的 http/https 地址");
+      }
+    } catch (IllegalArgumentException exception) {
+      if (exception.getMessage() != null && exception.getMessage().startsWith("Flink REST URL")) {
+        throw exception;
+      }
+      throw new IllegalArgumentException("Flink REST URL 格式无效", exception);
+    }
+  }
+
+  private String required(String value, String label, int maxLength) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(label + "不能为空");
+    }
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) {
+      throw new IllegalArgumentException(label + "长度不能超过 " + maxLength + " 个字符");
+    }
+    return normalized;
+  }
+
+  private String optional(String value, int maxLength) {
+    if (!StringUtils.hasText(value)) {
+      return null;
+    }
+    String normalized = value.trim();
+    if (normalized.length() > maxLength) {
+      throw new IllegalArgumentException("Java Home 长度不能超过 " + maxLength + " 个字符");
+    }
+    return normalized;
+  }
+
+  private SubmissionMode submissionMode(String value) {
+    try {
+      return SubmissionMode.valueOf(value);
+    } catch (Exception exception) {
+      throw new IllegalStateException("不支持的任务提交方式：" + value, exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V6__create_compute_environment.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V6__create_compute_environment.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS yak_compute_environment (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(120) NOT NULL,
+  engine_type VARCHAR(32) NOT NULL DEFAULT 'FLINK_CDC',
+  deployment_mode VARCHAR(32) NOT NULL DEFAULT 'REMOTE',
+  submitter_type VARCHAR(32) NOT NULL DEFAULT 'LOCAL',
+  config_json LONGTEXT NOT NULL,
+  enabled TINYINT(1) NOT NULL DEFAULT 1,
+  is_default TINYINT(1) NOT NULL DEFAULT 0,
+  version INT NOT NULL DEFAULT 1,
+  create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_compute_environment_name (name),
+  KEY idx_compute_environment_default (is_default, enabled)
+);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncPropertiesTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncPropertiesTest.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.sync.realtime.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.RuntimeOverrides;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.SubmissionMode;
+import org.junit.jupiter.api.Test;
+
+class RealtimeSyncPropertiesTest {
+
+  @Test
+  void defaultEnvironmentOverridesRuntimeSettingsWithoutMovingWorkDirectory() {
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setRestUrl("http://bootstrap:8081");
+    properties.setFlinkHome("/bootstrap/flink");
+    properties.setFlinkCdcHome("/bootstrap/cdc");
+    properties.setJavaHome("/bootstrap/java");
+    properties.setFlinkVersion("1.20.0");
+    properties.setFlinkCdcVersion("3.5.0");
+    properties.setWorkDirectory("/var/lib/yak/realtime");
+
+    properties.applyRuntimeOverrides(
+        new RuntimeOverrides(
+            "http://production:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            "/opt/java",
+            "1.20.5",
+            "3.6.0",
+            SubmissionMode.LOCAL));
+
+    assertThat(properties.getRestUrl()).isEqualTo("http://production:8081");
+    assertThat(properties.getFlinkHome()).isEqualTo("/opt/flink");
+    assertThat(properties.getFlinkCdcHome()).isEqualTo("/opt/flink-cdc");
+    assertThat(properties.getJavaHome()).isEqualTo("/opt/java");
+    assertThat(properties.getFlinkVersion()).isEqualTo("1.20.5");
+    assertThat(properties.getFlinkCdcVersion()).isEqualTo("3.6.0");
+    assertThat(properties.getWorkDirectory()).isEqualTo("/var/lib/yak/realtime");
+
+    properties.clearRuntimeOverrides();
+
+    assertThat(properties.getRestUrl()).isEqualTo("http://bootstrap:8081");
+    assertThat(properties.getFlinkHome()).isEqualTo("/bootstrap/flink");
+    assertThat(properties.getFlinkCdcHome()).isEqualTo("/bootstrap/cdc");
+    assertThat(properties.getJavaHome()).isEqualTo("/bootstrap/java");
+    assertThat(properties.getFlinkVersion()).isEqualTo("1.20.0");
+    assertThat(properties.getFlinkCdcVersion()).isEqualTo("3.5.0");
+  }
+}

--- a/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
@@ -18,7 +18,7 @@ import {
   Tooltip,
   message,
 } from 'antd';
-import { Database, Server, TerminalSquare } from 'lucide-react';
+import { Database, Server, SquareTerminal } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
 import {
@@ -108,7 +108,13 @@ const ComputeEngineSettingsPanel = () => {
   };
 
   const save = async () => {
-    const values = await form.validateFields();
+    let values: FormValues;
+    try {
+      values = await form.validateFields();
+    } catch {
+      return;
+    }
+
     const payload: ComputeEnvironmentPayload = {
       name: values.name.trim(),
       enabled: values.enabled,
@@ -204,10 +210,7 @@ const ComputeEngineSettingsPanel = () => {
         </div>
       ) : environments.length === 0 ? (
         <div className="rounded-xl border border-dashed border-[#d0d5dd] py-14">
-          <Empty
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description="暂无运行环境"
-          >
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无运行环境">
             <Button type="primary" onClick={openCreate}>
               新建运行环境
             </Button>
@@ -244,7 +247,7 @@ const ComputeEngineSettingsPanel = () => {
                       <Server size={13} /> Remote Cluster
                     </span>
                     <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
-                      <TerminalSquare size={13} /> {runtimeLabel(environment)}
+                      <SquareTerminal size={13} /> {runtimeLabel(environment)}
                     </span>
                   </div>
                 </div>
@@ -272,7 +275,10 @@ const ComputeEngineSettingsPanel = () => {
               <div className="mt-5 grid gap-x-8 gap-y-3 border-t border-[#f2f4f7] pt-4 md:grid-cols-2">
                 <div>
                   <div className="text-[11px] text-[#98a2b3]">Flink REST</div>
-                  <div className="mt-1 truncate font-mono text-[12px] text-[#344054]" title={environment.config.restUrl}>
+                  <div
+                    className="mt-1 truncate font-mono text-[12px] text-[#344054]"
+                    title={environment.config.restUrl}
+                  >
                     {environment.config.restUrl}
                   </div>
                 </div>
@@ -284,13 +290,19 @@ const ComputeEngineSettingsPanel = () => {
                 </div>
                 <div>
                   <div className="text-[11px] text-[#98a2b3]">Flink Home</div>
-                  <div className="mt-1 truncate font-mono text-[12px] text-[#344054]" title={environment.config.flinkHome}>
+                  <div
+                    className="mt-1 truncate font-mono text-[12px] text-[#344054]"
+                    title={environment.config.flinkHome}
+                  >
                     {environment.config.flinkHome}
                   </div>
                 </div>
                 <div>
                   <div className="text-[11px] text-[#98a2b3]">Flink CDC Home</div>
-                  <div className="mt-1 truncate font-mono text-[12px] text-[#344054]" title={environment.config.flinkCdcHome}>
+                  <div
+                    className="mt-1 truncate font-mono text-[12px] text-[#344054]"
+                    title={environment.config.flinkCdcHome}
+                  >
                     {environment.config.flinkCdcHome}
                   </div>
                 </div>
@@ -380,10 +392,20 @@ const ComputeEngineSettingsPanel = () => {
               <Input placeholder="例如：生产实时环境" />
             </Form.Item>
             <div className="grid grid-cols-2 gap-5">
-              <Form.Item name="enabled" label="启用环境" valuePropName="checked" className="!mb-0">
+              <Form.Item
+                name="enabled"
+                label="启用环境"
+                valuePropName="checked"
+                className="!mb-0"
+              >
                 <Switch disabled={editing?.defaultEnvironment} />
               </Form.Item>
-              <Form.Item name="makeDefault" label="设为默认" valuePropName="checked" className="!mb-0">
+              <Form.Item
+                name="makeDefault"
+                label="设为默认"
+                valuePropName="checked"
+                className="!mb-0"
+              >
                 <Switch disabled={editing?.defaultEnvironment} />
               </Form.Item>
             </div>

--- a/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
@@ -1,0 +1,468 @@
+import {
+  DeleteOutlined,
+  EditOutlined,
+  PlusOutlined,
+  StarFilled,
+  StarOutlined,
+} from '@ant-design/icons';
+import {
+  Button,
+  Empty,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Spin,
+  Switch,
+  Tag,
+  Tooltip,
+  message,
+} from 'antd';
+import { Database, Server, TerminalSquare } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  computeEnvironmentApi,
+  type ComputeEnvironment,
+  type ComputeEnvironmentPayload,
+} from '../services/computeEnvironments';
+
+interface FormValues {
+  name: string;
+  enabled: boolean;
+  makeDefault: boolean;
+  restUrl: string;
+  flinkHome: string;
+  flinkCdcHome: string;
+  javaHome?: string;
+  flinkVersion: string;
+  flinkCdcVersion: string;
+}
+
+const DEFAULT_FORM_VALUES: FormValues = {
+  name: '',
+  enabled: true,
+  makeDefault: false,
+  restUrl: 'http://127.0.0.1:8081',
+  flinkHome: '/opt/flink',
+  flinkCdcHome: '/opt/flink-cdc',
+  javaHome: '',
+  flinkVersion: '1.20.5',
+  flinkCdcVersion: '3.6.0',
+};
+
+const errorText = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message ? error.message : fallback;
+
+const runtimeLabel = (environment?: ComputeEnvironment | null) =>
+  environment?.submitterType === 'SSH' ? 'SSH 远程执行' : '本机执行';
+
+const ComputeEngineSettingsPanel = () => {
+  const [form] = Form.useForm<FormValues>();
+  const [environments, setEnvironments] = useState<ComputeEnvironment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<ComputeEnvironment | null>(null);
+  const [switchingId, setSwitchingId] = useState<number | null>(null);
+  const [defaultingId, setDefaultingId] = useState<number | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await computeEnvironmentApi.list();
+      setEnvironments(response.data ?? []);
+    } catch (error) {
+      setEnvironments([]);
+      message.error(errorText(error, '运行环境加载失败'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const openCreate = () => {
+    setEditing(null);
+    form.setFieldsValue(DEFAULT_FORM_VALUES);
+    setModalOpen(true);
+  };
+
+  const openEdit = (environment: ComputeEnvironment) => {
+    setEditing(environment);
+    form.setFieldsValue({
+      name: environment.name,
+      enabled: environment.enabled,
+      makeDefault: environment.defaultEnvironment,
+      restUrl: environment.config.restUrl,
+      flinkHome: environment.config.flinkHome,
+      flinkCdcHome: environment.config.flinkCdcHome,
+      javaHome: environment.config.javaHome ?? '',
+      flinkVersion: environment.config.flinkVersion,
+      flinkCdcVersion: environment.config.flinkCdcVersion,
+    });
+    setModalOpen(true);
+  };
+
+  const save = async () => {
+    const values = await form.validateFields();
+    const payload: ComputeEnvironmentPayload = {
+      name: values.name.trim(),
+      enabled: values.enabled,
+      makeDefault: values.makeDefault,
+      config: {
+        restUrl: values.restUrl.trim(),
+        flinkHome: values.flinkHome.trim(),
+        flinkCdcHome: values.flinkCdcHome.trim(),
+        javaHome: values.javaHome?.trim() || undefined,
+        flinkVersion: values.flinkVersion.trim(),
+        flinkCdcVersion: values.flinkCdcVersion.trim(),
+      },
+    };
+
+    setSaving(true);
+    try {
+      if (editing) {
+        await computeEnvironmentApi.update(editing.id, payload);
+        message.success('运行环境已更新');
+      } else {
+        await computeEnvironmentApi.create(payload);
+        message.success('运行环境已创建');
+      }
+      setModalOpen(false);
+      await load();
+    } catch (error) {
+      message.error(errorText(error, editing ? '运行环境更新失败' : '运行环境创建失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleEnabled = async (environment: ComputeEnvironment, enabled: boolean) => {
+    setSwitchingId(environment.id);
+    try {
+      await computeEnvironmentApi.setEnabled(environment.id, enabled);
+      message.success(enabled ? '运行环境已启用' : '运行环境已停用');
+      await load();
+    } catch (error) {
+      message.error(errorText(error, '运行环境状态更新失败'));
+    } finally {
+      setSwitchingId(null);
+    }
+  };
+
+  const setDefault = async (environment: ComputeEnvironment) => {
+    setDefaultingId(environment.id);
+    try {
+      await computeEnvironmentApi.setDefault(environment.id);
+      message.success(`已将 ${environment.name} 设为默认运行环境`);
+      await load();
+    } catch (error) {
+      message.error(errorText(error, '默认运行环境切换失败'));
+    } finally {
+      setDefaultingId(null);
+    }
+  };
+
+  const remove = async (environment: ComputeEnvironment) => {
+    setDeletingId(environment.id);
+    try {
+      await computeEnvironmentApi.remove(environment.id);
+      message.success('运行环境已删除');
+      await load();
+    } catch (error) {
+      message.error(errorText(error, '运行环境删除失败'));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="text-[13px] text-[#344054]">
+      <div className="mb-6 flex items-start justify-between gap-6">
+        <div>
+          <div className="text-[18px] font-semibold text-[#161823]">计算引擎</div>
+          <div className="mt-1.5 max-w-[680px] text-[12px] leading-5 text-[#667085]">
+            集中管理实时同步使用的运行环境。任务默认使用标记为“默认”的环境，Flink 的连接与本机运行路径只需配置一次。
+          </div>
+        </div>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+          新建运行环境
+        </Button>
+      </div>
+
+      <div className="mb-5 rounded-lg border border-[#e4e7ec] bg-[#f9fafb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
+        当前阶段采用 Flink CDC + Remote Cluster。切换或修改默认环境前，需要先停止正在运行的实时同步任务，避免任务被错误地管理到其他 Flink 集群。
+      </div>
+
+      {loading ? (
+        <div className="flex h-56 items-center justify-center">
+          <Spin size="small" />
+        </div>
+      ) : environments.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-[#d0d5dd] py-14">
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description="暂无运行环境"
+          >
+            <Button type="primary" onClick={openCreate}>
+              新建运行环境
+            </Button>
+          </Empty>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {environments.map((environment) => (
+            <div
+              key={environment.id}
+              className="rounded-xl border border-[#e4e7ec] bg-white px-5 py-5 shadow-[0_1px_2px_rgba(16,24,40,0.03)]"
+            >
+              <div className="flex items-start justify-between gap-5">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="truncate text-[15px] font-semibold text-[#101828]">
+                      {environment.name}
+                    </span>
+                    {environment.defaultEnvironment && (
+                      <Tag color="gold" icon={<StarFilled />} className="!mr-0">
+                        默认
+                      </Tag>
+                    )}
+                    <Tag color={environment.enabled ? 'green' : 'default'} className="!mr-0">
+                      {environment.enabled ? '已启用' : '已停用'}
+                    </Tag>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
+                      <Database size={13} /> Flink CDC
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
+                      <Server size={13} /> Remote Cluster
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
+                      <TerminalSquare size={13} /> {runtimeLabel(environment)}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="text-[12px] text-[#98a2b3]">启用</span>
+                  <Tooltip
+                    title={
+                      environment.defaultEnvironment
+                        ? '默认运行环境必须保持启用'
+                        : undefined
+                    }
+                  >
+                    <Switch
+                      size="small"
+                      checked={environment.enabled}
+                      disabled={environment.defaultEnvironment}
+                      loading={switchingId === environment.id}
+                      onChange={(checked) => void toggleEnabled(environment, checked)}
+                    />
+                  </Tooltip>
+                </div>
+              </div>
+
+              <div className="mt-5 grid gap-x-8 gap-y-3 border-t border-[#f2f4f7] pt-4 md:grid-cols-2">
+                <div>
+                  <div className="text-[11px] text-[#98a2b3]">Flink REST</div>
+                  <div className="mt-1 truncate font-mono text-[12px] text-[#344054]" title={environment.config.restUrl}>
+                    {environment.config.restUrl}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[11px] text-[#98a2b3]">运行版本</div>
+                  <div className="mt-1 text-[12px] text-[#344054]">
+                    Flink {environment.config.flinkVersion} · CDC {environment.config.flinkCdcVersion}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[11px] text-[#98a2b3]">Flink Home</div>
+                  <div className="mt-1 truncate font-mono text-[12px] text-[#344054]" title={environment.config.flinkHome}>
+                    {environment.config.flinkHome}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[11px] text-[#98a2b3]">Flink CDC Home</div>
+                  <div className="mt-1 truncate font-mono text-[12px] text-[#344054]" title={environment.config.flinkCdcHome}>
+                    {environment.config.flinkCdcHome}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-4 flex items-center justify-end gap-1 border-t border-[#f2f4f7] pt-3">
+                {!environment.defaultEnvironment && (
+                  <Tooltip title={!environment.enabled ? '请先启用该运行环境' : undefined}>
+                    <Button
+                      type="link"
+                      size="small"
+                      icon={<StarOutlined />}
+                      disabled={!environment.enabled}
+                      loading={defaultingId === environment.id}
+                      onClick={() => void setDefault(environment)}
+                    >
+                      设为默认
+                    </Button>
+                  </Tooltip>
+                )}
+                <Button
+                  type="link"
+                  size="small"
+                  icon={<EditOutlined />}
+                  onClick={() => openEdit(environment)}
+                >
+                  编辑
+                </Button>
+                <Popconfirm
+                  title="删除运行环境"
+                  description={
+                    environment.defaultEnvironment
+                      ? '默认运行环境不能删除，请先切换默认环境。'
+                      : `确定删除 ${environment.name} 吗？`
+                  }
+                  disabled={environment.defaultEnvironment}
+                  okText="删除"
+                  cancelText="取消"
+                  okButtonProps={{ danger: true, loading: deletingId === environment.id }}
+                  onConfirm={() => remove(environment)}
+                >
+                  <Tooltip title={environment.defaultEnvironment ? '请先切换默认环境' : undefined}>
+                    <Button
+                      type="link"
+                      size="small"
+                      danger
+                      disabled={environment.defaultEnvironment}
+                      icon={<DeleteOutlined />}
+                    >
+                      删除
+                    </Button>
+                  </Tooltip>
+                </Popconfirm>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        title={editing ? '编辑运行环境' : '新建运行环境'}
+        open={modalOpen}
+        width={720}
+        okText="保存"
+        cancelText="取消"
+        confirmLoading={saving}
+        onOk={() => void save()}
+        onCancel={() => !saving && setModalOpen(false)}
+      >
+        <Form<FormValues>
+          form={form}
+          layout="vertical"
+          variant="filled"
+          initialValues={DEFAULT_FORM_VALUES}
+          className="mt-5"
+        >
+          <div className="rounded-lg border border-[#eaecf0] px-4 py-4">
+            <div className="mb-4 text-[13px] font-semibold text-[#1d2939]">基础信息</div>
+            <Form.Item
+              name="name"
+              label="环境名称"
+              rules={[
+                { required: true, message: '请输入环境名称' },
+                { max: 120, message: '环境名称不能超过 120 个字符' },
+              ]}
+            >
+              <Input placeholder="例如：生产实时环境" />
+            </Form.Item>
+            <div className="grid grid-cols-2 gap-5">
+              <Form.Item name="enabled" label="启用环境" valuePropName="checked" className="!mb-0">
+                <Switch disabled={editing?.defaultEnvironment} />
+              </Form.Item>
+              <Form.Item name="makeDefault" label="设为默认" valuePropName="checked" className="!mb-0">
+                <Switch disabled={editing?.defaultEnvironment} />
+              </Form.Item>
+            </div>
+          </div>
+
+          <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
+            <div className="mb-3 text-[13px] font-semibold text-[#1d2939]">运行方式</div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
+                <div className="text-[11px] text-[#98a2b3]">引擎</div>
+                <div className="mt-1 font-medium text-[#344054]">Flink CDC</div>
+              </div>
+              <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
+                <div className="text-[11px] text-[#98a2b3]">部署模式</div>
+                <div className="mt-1 font-medium text-[#344054]">Remote Cluster</div>
+              </div>
+              <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
+                <div className="text-[11px] text-[#98a2b3]">任务提交方式</div>
+                <div className="mt-1 font-medium text-[#344054]">{runtimeLabel(editing)}</div>
+              </div>
+            </div>
+            {editing?.submitterType === 'SSH' && (
+              <div className="mt-3 text-[11px] leading-5 text-[#667085]">
+                此环境继承了现有 SSH 启动配置；本阶段只在页面管理通用 Flink 运行参数，SSH 凭据仍由启动配置提供。
+              </div>
+            )}
+          </div>
+
+          <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
+            <div className="mb-4 text-[13px] font-semibold text-[#1d2939]">Flink 集群</div>
+            <Form.Item
+              name="restUrl"
+              label="JobManager REST URL"
+              rules={[{ required: true, message: '请输入 Flink REST URL' }]}
+            >
+              <Input placeholder="http://127.0.0.1:8081" />
+            </Form.Item>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Form.Item
+                name="flinkVersion"
+                label="Flink 版本"
+                rules={[{ required: true, message: '请输入 Flink 版本' }]}
+              >
+                <Input placeholder="1.20.5" />
+              </Form.Item>
+              <Form.Item
+                name="flinkCdcVersion"
+                label="Flink CDC 版本"
+                rules={[{ required: true, message: '请输入 Flink CDC 版本' }]}
+              >
+                <Input placeholder="3.6.0" />
+              </Form.Item>
+            </div>
+          </div>
+
+          <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
+            <div className="mb-4 text-[13px] font-semibold text-[#1d2939]">本机运行路径</div>
+            <Form.Item
+              name="flinkHome"
+              label="Flink Home"
+              rules={[{ required: true, message: '请输入 Flink Home' }]}
+            >
+              <Input placeholder="/opt/flink" />
+            </Form.Item>
+            <Form.Item
+              name="flinkCdcHome"
+              label="Flink CDC Home"
+              rules={[{ required: true, message: '请输入 Flink CDC Home' }]}
+            >
+              <Input placeholder="/opt/flink-cdc" />
+            </Form.Item>
+            <Form.Item name="javaHome" label="Java Home（可选）" className="!mb-0">
+              <Input placeholder="/usr/lib/jvm/java-17" />
+            </Form.Item>
+          </div>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+export default ComputeEngineSettingsPanel;

--- a/yak-ops-ui/src/pages/settings/index.tsx
+++ b/yak-ops-ui/src/pages/settings/index.tsx
@@ -1,16 +1,18 @@
-import { Bell, Braces, LayoutTemplate, SlidersHorizontal } from 'lucide-react';
+import { Bell, Braces, Cpu, LayoutTemplate, SlidersHorizontal } from 'lucide-react';
 import { history, useLocation } from '@umijs/max';
 
 import AlertSettingsPanel from './components/AlertSettingsPanel';
+import ComputeEngineSettingsPanel from './components/ComputeEngineSettingsPanel';
 import EditorSettingsPanel from './components/EditorSettingsPanel';
 import EnvironmentSettingsPanel from './components/EnvironmentSettingsPanel';
 import ScreenTemplateSettingsPanel from './components/ScreenTemplateSettingsPanel';
 
-type SettingsTab = 'editor' | 'environment' | 'screen-template' | 'alert';
+type SettingsTab = 'editor' | 'environment' | 'compute' | 'screen-template' | 'alert';
 
 const tabs: { key: SettingsTab; label: string; icon: React.ReactNode }[] = [
   { key: 'editor', label: '编辑器设置', icon: <SlidersHorizontal size={15} strokeWidth={1.8} /> },
   { key: 'environment', label: '环境变量', icon: <Braces size={15} strokeWidth={1.8} /> },
+  { key: 'compute', label: '计算引擎', icon: <Cpu size={15} strokeWidth={1.8} /> },
   { key: 'screen-template', label: '大屏模板', icon: <LayoutTemplate size={15} strokeWidth={1.8} /> },
   { key: 'alert', label: '告警设置', icon: <Bell size={15} strokeWidth={1.8} /> },
 ];
@@ -54,12 +56,19 @@ const SettingsPage = () => {
       </aside>
 
       <section className="min-w-0 flex-1 overflow-auto">
-        <div className={[
-          'mx-auto w-full px-10 py-8 xl:px-14',
-          activeTab === 'screen-template' ? 'max-w-[1220px]' : 'max-w-[920px]',
-        ].join(' ')}>
+        <div
+          className={[
+            'mx-auto w-full px-10 py-8 xl:px-14',
+            activeTab === 'screen-template'
+              ? 'max-w-[1220px]'
+              : activeTab === 'compute'
+                ? 'max-w-[1080px]'
+                : 'max-w-[920px]',
+          ].join(' ')}
+        >
           {activeTab === 'editor' && <EditorSettingsPanel />}
           {activeTab === 'environment' && <EnvironmentSettingsPanel />}
+          {activeTab === 'compute' && <ComputeEngineSettingsPanel />}
           {activeTab === 'screen-template' && <ScreenTemplateSettingsPanel />}
           {activeTab === 'alert' && <AlertSettingsPanel />}
         </div>

--- a/yak-ops-ui/src/pages/settings/services/computeEnvironments.ts
+++ b/yak-ops-ui/src/pages/settings/services/computeEnvironments.ts
@@ -1,0 +1,58 @@
+import { request } from '@umijs/max';
+
+const PREFIX = '/api/v1/compute-environments';
+
+export interface ComputeEnvironmentRuntimeConfig {
+  restUrl: string;
+  flinkHome: string;
+  flinkCdcHome: string;
+  javaHome?: string;
+  flinkVersion: string;
+  flinkCdcVersion: string;
+}
+
+export interface ComputeEnvironment {
+  id: number;
+  name: string;
+  engineType: 'FLINK_CDC';
+  deploymentMode: 'REMOTE';
+  submitterType: 'LOCAL' | 'SSH';
+  config: ComputeEnvironmentRuntimeConfig;
+  enabled: boolean;
+  defaultEnvironment: boolean;
+  version: number;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface ComputeEnvironmentPayload {
+  name: string;
+  config: ComputeEnvironmentRuntimeConfig;
+  enabled: boolean;
+  makeDefault: boolean;
+}
+
+interface ApiResponse<T> {
+  code: number;
+  data: T;
+  msg?: string;
+  message?: string;
+}
+
+export const computeEnvironmentApi = {
+  list: () => request<ApiResponse<ComputeEnvironment[]>>(PREFIX),
+  detail: (id: number) => request<ApiResponse<ComputeEnvironment>>(`${PREFIX}/${id}`),
+  create: (payload: ComputeEnvironmentPayload) =>
+    request<ApiResponse<number>>(PREFIX, { method: 'POST', data: payload }),
+  update: (id: number, payload: ComputeEnvironmentPayload) =>
+    request<ApiResponse<boolean>>(`${PREFIX}/${id}`, { method: 'PUT', data: payload }),
+  setEnabled: (id: number, enabled: boolean) =>
+    request<ApiResponse<boolean>>(`${PREFIX}/${id}/enabled`, {
+      method: 'PUT',
+      data: { enabled },
+    }),
+  setDefault: (id: number) =>
+    request<ApiResponse<boolean>>(`${PREFIX}/${id}/default`, { method: 'POST' }),
+  remove: (id: number) =>
+    request<ApiResponse<boolean>>(`${PREFIX}/${id}`, { method: 'DELETE' }),
+};


### PR DESCRIPTION
## 背景

把实时同步的 Flink CDC 运行配置从“只存在于 application.yml / ENV 的单一全局配置”向页面化运行环境迈出第一步，同时保持 Yak Ops 的模型尽量小而清晰。

本 PR 只实现第一阶段：**设置 → 计算引擎 → 运行环境**。任务级运行环境选择、SSH 可视化配置、环境检测、Yarn/Kubernetes 都不在本 PR 范围内。

## 本次实现

### 1. 新增运行环境模型

新增 `yak_compute_environment`，核心模型保持固定且简单：

- Engine: `FLINK_CDC`
- Deployment Mode: `REMOTE`
- Submitter: 新建环境固定为 `LOCAL`
- 环境配置：Flink REST URL、Flink Home、Flink CDC Home、Java Home、Flink / CDC 版本
- 支持启用 / 停用、默认环境、版本号

首次升级后，如果数据库中还没有运行环境，会自动把当前 application.yml / ENV 中的实时同步配置迁移成一个 **“默认实时环境”**，避免升级后需要重新配置。

### 2. 默认环境真正参与实时同步运行

`application.yml / ENV` 继续作为 Bootstrap / fallback 配置；存在已启用的默认运行环境后，默认环境会覆盖 Flink REST、Flink / CDC / Java 路径及运行版本。

为了避免 Stage 1 尚未绑定任务环境时把运行中的任务误操作到另一套 Flink：

- 有实时任务处于活动/不稳定状态时，禁止切换默认环境；
- 有实时任务运行时，禁止修改默认环境的运行配置；
- 默认环境不能停用或删除；
- 多 Yak Ops 实例每 5 秒从数据库同步一次默认运行环境。

`work-directory`、超时、日志上限、reconcile 等仍保持应用级配置，不随环境切换，避免历史提交日志路径发生漂移。

### 3. 设置页新增「计算引擎」

新增运行环境卡片页，用户只需要理解：

- 环境名称
- Flink CDC
- Remote Cluster
- 本机执行
- Flink REST
- Flink / CDC / Java 路径与版本

支持：

- 新建运行环境
- 编辑运行环境
- 启用 / 停用
- 设为默认
- 删除非默认环境

固定能力使用只读信息展示，不使用只有一个选项的下拉框，避免把未来的复杂度提前暴露给用户。

如果现有启动配置已经是 SSH 模式，Bootstrap 环境会保留该模式；本阶段页面只管理通用 Flink 参数，SSH 凭据仍由原启动配置提供，不会被覆盖。

### 4. API

新增 `/api/v1/compute-environments`：

- `GET /` 列表
- `GET /{id}` 详情
- `POST /` 新建
- `PUT /{id}` 编辑
- `PUT /{id}/enabled` 启停
- `POST /{id}/default` 设为默认
- `DELETE /{id}` 删除

复用现有实时同步权限，不新增一套用户需要理解的权限模型。

## 数据库

新增 Flyway：

`V6__create_compute_environment.sql`

## 测试 / 验证

新增 `RealtimeSyncPropertiesTest`，覆盖默认运行环境 override 以及 application.yml fallback 行为。

建议人工验证：

1. 使用现有 application.yml 启动，进入 设置 → 计算引擎，应自动看到“默认实时环境”；
2. 新建第二个 Local 运行环境并设为默认，实时同步 runtime capabilities 应读取新环境配置；
3. 默认环境不可停用/删除；
4. 启动实时任务后，切换默认环境或修改默认环境运行参数应被拒绝；
5. 停止任务后可以正常切换默认环境。

## 后续阶段（不在本 PR）

- Stage 2：实时任务显式选择运行环境 + deployment snapshot
- Stage 3：Local / SSH Submitter 页面化
- Stage 4：环境检测、版本自动识别、健康状态与诊断
- Future：Yarn / Kubernetes Application
