### PR TITLE
feat(realtime): bind jobs to runtime environments

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/RealtimeJobController.java
@@ -62,16 +62,20 @@ public class RealtimeJobController {
   public record SaveRequest(
       @NotBlank @Size(max = 200) String name,
       @Size(max = 1000) String description,
+      Long runtimeEnvironmentId,
       @Valid CdcPipelineSpec spec) {}
 
   public record CreateRequest(
-      @NotBlank @Size(max = 200) String name, @Size(max = 1000) String description) {}
+      @NotBlank @Size(max = 200) String name,
+      @Size(max = 1000) String description,
+      Long runtimeEnvironmentId) {}
 
   @Operation(summary = "创建实时同步基础任务")
   @PostMapping
   @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> create(@Valid @RequestBody CreateRequest request) {
-    return Result.success(service.create(request.name(), request.description()));
+    return Result.success(
+        service.create(request.name(), request.description(), request.runtimeEnvironmentId()));
   }
 
   @Operation(summary = "新建实时同步草稿")
@@ -79,14 +83,25 @@ public class RealtimeJobController {
   @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> draft(@Valid @RequestBody SaveRequest request) {
     return Result.success(
-        service.save(null, request.name(), request.description(), request.spec()));
+        service.save(
+            null,
+            request.name(),
+            request.description(),
+            request.spec(),
+            request.runtimeEnvironmentId()));
   }
 
   @Operation(summary = "保存实时同步草稿")
   @PutMapping("/{id}")
   @RequiresPermission(RealtimePermissionCode.UPDATE)
   public Result<Long> save(@PathVariable long id, @Valid @RequestBody SaveRequest request) {
-    return Result.success(service.save(id, request.name(), request.description(), request.spec()));
+    return Result.success(
+        service.save(
+            id,
+            request.name(),
+            request.description(),
+            request.spec(),
+            request.runtimeEnvironmentId()));
   }
 
   @Operation(summary = "实时同步任务详情")
@@ -121,7 +136,7 @@ public class RealtimeJobController {
     return Result.success(true);
   }
 
-  @Operation(summary = "使用 Flink CDC 配置校验当前定义")
+  @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义")
   @PostMapping("/{id}/validate")
   @RequiresPermission(RealtimePermissionCode.UPDATE)
   public Result<RealtimeEngineGateway.ValidationResult> validate(@PathVariable long id) {
@@ -176,10 +191,11 @@ public class RealtimeJobController {
     return Result.success(service.events(id));
   }
 
-  @Operation(summary = "查询 Flink CDC 运行能力")
+  @Operation(summary = "查询指定 Flink CDC 运行环境能力")
   @GetMapping("/runtime/capabilities")
-  public Result<JsonNode> capabilities() {
-    return Result.success(service.capabilities());
+  public Result<JsonNode> capabilities(
+      @RequestParam(required = false) Long environmentId) {
+    return Result.success(service.capabilities(environmentId));
   }
 
   @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironmentSnapshot.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironmentSnapshot.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+
+/** Immutable runtime target captured for every realtime deployment. */
+public record ComputeEnvironmentSnapshot(
+    long id,
+    String name,
+    String engineType,
+    String deploymentMode,
+    String submitterType,
+    RuntimeConfig config,
+    int version) {
+
+  public static ComputeEnvironmentSnapshot from(ComputeEnvironment environment) {
+    if (environment == null) {
+      throw new IllegalArgumentException("运行环境不能为空");
+    }
+    return new ComputeEnvironmentSnapshot(
+        environment.id(),
+        environment.name(),
+        environment.engineType(),
+        environment.deploymentMode(),
+        environment.submitterType(),
+        environment.config(),
+        environment.version());
+  }
+
+  public String runtimeRevision() {
+    String cdcVersion = config == null ? "unknown" : config.flinkCdcVersion();
+    return "flink-cdc-cli-" + cdcVersion + "@env-" + id + "-v" + version;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeJobView.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeJobView.java
@@ -8,6 +8,7 @@ public record RealtimeJobView(
     String name,
     String description,
     CdcPipelineSpec spec,
+    Long runtimeEnvironmentId,
     String releaseState,
     String desiredState,
     String observedState,
@@ -19,6 +20,40 @@ public record RealtimeJobView(
     LocalDateTime updateTime,
     Deployment latestDeployment) {
 
+  /** Compatibility constructor for tests/integrations compiled before runtime binding was added. */
+  public RealtimeJobView(
+      long id,
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      String releaseState,
+      String desiredState,
+      String observedState,
+      int definitionVersion,
+      Integer publishedVersion,
+      String configDigest,
+      String lastError,
+      LocalDateTime createTime,
+      LocalDateTime updateTime,
+      Deployment latestDeployment) {
+    this(
+        id,
+        name,
+        description,
+        spec,
+        null,
+        releaseState,
+        desiredState,
+        observedState,
+        definitionVersion,
+        publishedVersion,
+        configDigest,
+        lastError,
+        createTime,
+        updateTime,
+        latestDeployment);
+  }
+
   public record Deployment(
       long id,
       int definitionVersion,
@@ -27,9 +62,41 @@ public record RealtimeJobView(
       String idempotencyKey,
       String engineJobId,
       String runtimeRevision,
+      ComputeEnvironmentSnapshot runtimeEnvironment,
       String status,
       boolean resultUncertain,
       String errorMessage,
       LocalDateTime createTime,
-      LocalDateTime updateTime) {}
+      LocalDateTime updateTime) {
+
+    /** Compatibility constructor for deployment rows created before environment snapshots existed. */
+    public Deployment(
+        long id,
+        int definitionVersion,
+        String specSummary,
+        String configDigest,
+        String idempotencyKey,
+        String engineJobId,
+        String runtimeRevision,
+        String status,
+        boolean resultUncertain,
+        String errorMessage,
+        LocalDateTime createTime,
+        LocalDateTime updateTime) {
+      this(
+          id,
+          definitionVersion,
+          specSummary,
+          configDigest,
+          idempotencyKey,
+          engineJobId,
+          runtimeRevision,
+          null,
+          status,
+          resultUncertain,
+          errorMessage,
+          createTime,
+          updateTime);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.SubmissionMode;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -66,20 +69,31 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   @Override
   public JsonNode health() {
-    return getJson("/overview", false, false);
+    return health(bootstrapEnvironment());
+  }
+
+  @Override
+  public JsonNode health(ComputeEnvironmentSnapshot environment) {
+    return getJson(environment, "/overview", false, false);
   }
 
   @Override
   public JsonNode capabilities() {
+    return capabilities(bootstrapEnvironment());
+  }
+
+  @Override
+  public JsonNode capabilities(ComputeEnvironmentSnapshot environment) {
+    RuntimeConfig config = requireConfig(environment);
     ObjectNode result = json.createObjectNode();
-    SubmissionMode mode = properties.getSubmissionMode();
+    SubmissionMode mode = submissionMode(environment);
     boolean deployEnabled;
     String disabledReason = null;
     if (mode == SubmissionMode.SSH) {
-      disabledReason = sshRunner.configurationError();
+      disabledReason = sshRunner.configurationError(environment);
       deployEnabled = disabledReason == null;
     } else {
-      Path cli = cliPath();
+      Path cli = cliPath(environment);
       deployEnabled = Files.isRegularFile(cli) && Files.isExecutable(cli);
       if (!deployEnabled) {
         disabledReason = "未找到可执行的 Flink CDC CLI：" + cli;
@@ -87,10 +101,13 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     }
 
     result.put("engineType", "flink-cdc-cli");
-    result.put("runtimeVersion", "flink-cdc-cli-" + properties.getFlinkCdcVersion());
-    result.put("flinkVersion", properties.getFlinkVersion());
-    result.put("flinkCdcVersion", properties.getFlinkCdcVersion());
-    result.put("restUrl", properties.getRestUrl());
+    result.put("runtimeVersion", "flink-cdc-cli-" + config.flinkCdcVersion());
+    result.put("runtimeEnvironmentId", environment.id());
+    result.put("runtimeEnvironmentName", environment.name());
+    result.put("runtimeEnvironmentVersion", environment.version());
+    result.put("flinkVersion", config.flinkVersion());
+    result.put("flinkCdcVersion", config.flinkCdcVersion());
+    result.put("restUrl", config.restUrl());
     result.put("restTransport", "DIRECT");
     result.put("submissionMode", mode.name());
     if (mode == SubmissionMode.SSH) {
@@ -117,20 +134,33 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   @Override
   public ValidationResult validate(String pipelineYaml) {
+    return validate(bootstrapEnvironment(), pipelineYaml);
+  }
+
+  @Override
+  public ValidationResult validate(ComputeEnvironmentSnapshot environment, String pipelineYaml) {
     validatePipelineShape(pipelineYaml);
-    URI rest = restUri();
-    if (properties.getSubmissionMode() == SubmissionMode.SSH) {
-      sshRunner.validateReady(rest);
-    } else if (!Files.isRegularFile(cliPath()) || !Files.isExecutable(cliPath())) {
-      throw failure("Flink CDC CLI 不存在或不可执行：" + cliPath(), false, null, null);
+    URI rest = restUri(environment);
+    if (submissionMode(environment) == SubmissionMode.SSH) {
+      sshRunner.validateReady(environment, rest);
+    } else if (!Files.isRegularFile(cliPath(environment))
+        || !Files.isExecutable(cliPath(environment))) {
+      throw failure(
+          "Flink CDC CLI 不存在或不可执行：" + cliPath(environment), false, null, null);
     }
-    health();
+    health(environment);
     return new ValidationResult(true, "at-least-once");
   }
 
   @Override
   public DeployResult deploy(RealtimeDeployRequest request) {
-    validate(request.pipelineYaml());
+    return deploy(bootstrapEnvironment(), request);
+  }
+
+  @Override
+  public DeployResult deploy(
+      ComputeEnvironmentSnapshot environment, RealtimeDeployRequest request) {
+    validate(environment, request.pipelineYaml());
     Path work = Path.of(properties.getWorkDirectory()).toAbsolutePath().normalize();
     Path submissionLog = null;
     Path pipelineFile = null;
@@ -140,18 +170,23 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       String resolved = resolveSecrets(request);
       writePrivate(submissionLog, "");
 
-      URI rest = restUri();
+      URI rest = restUri(environment);
       CommandResult result;
-      if (properties.getSubmissionMode() == SubmissionMode.SSH) {
+      if (submissionMode(environment) == SubmissionMode.SSH) {
         SshFlinkCdcCommandRunner.ExecutionResult sshResult =
-            sshRunner.submit(resolved, submissionLog, rest, properties.getSubmitTimeout());
+            sshRunner.submit(
+                environment,
+                resolved,
+                submissionLog,
+                rest,
+                properties.getSubmitTimeout());
         result = new CommandResult(sshResult.exitCode(), sshResult.uncertain());
       } else {
         Path pipelines = Files.createDirectories(work.resolve("pipelines"));
         String safeKey = safeKey(request.idempotencyKey());
         pipelineFile = pipelines.resolve("pipeline-" + safeKey + "-" + System.nanoTime() + ".yaml");
         writePrivate(pipelineFile, resolved);
-        result = submitLocal(pipelineFile, submissionLog, rest);
+        result = submitLocal(environment, pipelineFile, submissionLog, rest);
       }
 
       String output = Files.readString(submissionLog, StandardCharsets.UTF_8);
@@ -159,7 +194,8 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       writePrivate(submissionLog, output);
       if (result.exitCode() != 0) {
         String excerpt = tail(output, 20);
-        String prefix = properties.getSubmissionMode() == SubmissionMode.SSH ? "SSH Flink CDC" : "Flink CDC";
+        String prefix =
+            submissionMode(environment) == SubmissionMode.SSH ? "SSH Flink CDC" : "Flink CDC";
         throw failure(
             prefix
                 + " 提交失败，exitCode="
@@ -189,24 +225,26 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     }
   }
 
-  private CommandResult submitLocal(Path pipelineFile, Path submissionLog, URI rest)
+  private CommandResult submitLocal(
+      ComputeEnvironmentSnapshot environment, Path pipelineFile, Path submissionLog, URI rest)
       throws IOException, InterruptedException {
+    RuntimeConfig config = requireConfig(environment);
     int port = rest.getPort() < 0 ? defaultPort(rest) : rest.getPort();
     ProcessBuilder builder =
         new ProcessBuilder(
-                cliPath().toString(),
+                cliPath(environment).toString(),
                 pipelineFile.toString(),
                 "--flink-home",
-                Path.of(properties.getFlinkHome()).toAbsolutePath().normalize().toString(),
+                Path.of(config.flinkHome()).toAbsolutePath().normalize().toString(),
                 "--target",
                 "remote",
                 "-Drest.address=" + rest.getHost(),
                 "-Drest.port=" + port)
             .redirectErrorStream(true)
             .redirectOutput(submissionLog.toFile());
-    builder.environment().put("FLINK_HOME", properties.getFlinkHome());
-    if (StringUtils.hasText(properties.getJavaHome())) {
-      builder.environment().put("JAVA_HOME", properties.getJavaHome());
+    builder.environment().put("FLINK_HOME", config.flinkHome());
+    if (StringUtils.hasText(config.javaHome())) {
+      builder.environment().put("JAVA_HOME", config.javaHome());
     }
     Process process = builder.start();
     Duration timeout = properties.getSubmitTimeout();
@@ -229,8 +267,13 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   @Override
   public RuntimeStatus status(String jobId) {
+    return status(bootstrapEnvironment(), jobId);
+  }
+
+  @Override
+  public RuntimeStatus status(ComputeEnvironmentSnapshot environment, String jobId) {
     requireJobId(jobId);
-    JsonNode body = getJson("/jobs/" + jobId, true, true);
+    JsonNode body = getJson(environment, "/jobs/" + jobId, true, true);
     if (body == null) {
       return new RuntimeStatus(jobId, RuntimeStatus.State.NONE);
     }
@@ -246,12 +289,23 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   @Override
   public void stop(String jobId) {
+    stop(bootstrapEnvironment(), jobId);
+  }
+
+  @Override
+  public void stop(ComputeEnvironmentSnapshot environment, String jobId) {
     requireJobId(jobId);
-    send("/jobs/" + jobId, "PATCH", true, true);
+    send(environment, "/jobs/" + jobId, "PATCH", true, true);
   }
 
   @Override
   public String logs(String jobId, int tailLines) {
+    return logs(bootstrapEnvironment(), jobId, tailLines);
+  }
+
+  @Override
+  public String logs(
+      ComputeEnvironmentSnapshot environment, String jobId, int tailLines) {
     requireJobId(jobId);
     int tail = Math.max(1, Math.min(tailLines, properties.getMaxLogLines()));
     StringBuilder result = new StringBuilder();
@@ -259,7 +313,8 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     if (Files.isRegularFile(log)) {
       result.append("=== Flink CDC submit ===\n").append(tail(log, tail));
     }
-    JsonNode exceptions = getJson("/jobs/" + jobId + "/exceptions", false, true);
+    JsonNode exceptions =
+        getJson(environment, "/jobs/" + jobId + "/exceptions", false, true);
     if (exceptions != null) {
       if (!result.isEmpty()) {
         result.append('\n');
@@ -271,16 +326,26 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   @Override
   public JsonNode checkpoints(String jobId) {
+    return checkpoints(bootstrapEnvironment(), jobId);
+  }
+
+  @Override
+  public JsonNode checkpoints(ComputeEnvironmentSnapshot environment, String jobId) {
     requireJobId(jobId);
-    return getJson("/jobs/" + jobId + "/checkpoints", false, false);
+    return getJson(environment, "/jobs/" + jobId + "/checkpoints", false, false);
   }
 
   @Override
   public JsonNode metrics(String jobId) {
+    return metrics(bootstrapEnvironment(), jobId);
+  }
+
+  @Override
+  public JsonNode metrics(ComputeEnvironmentSnapshot environment, String jobId) {
     requireJobId(jobId);
     ObjectNode result = json.createObjectNode();
-    result.set("job", getJson("/jobs/" + jobId, false, false));
-    result.set("metrics", getJson("/jobs/" + jobId + "/metrics", false, false));
+    result.set("job", getJson(environment, "/jobs/" + jobId, false, false));
+    result.set("metrics", getJson(environment, "/jobs/" + jobId + "/metrics", false, false));
     return result;
   }
 
@@ -338,15 +403,24 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     }
   }
 
-  private JsonNode getJson(String path, boolean uncertain, boolean allowNotFound) {
-    Response response = send(path, "GET", uncertain, allowNotFound);
+  private JsonNode getJson(
+      ComputeEnvironmentSnapshot environment,
+      String path,
+      boolean uncertain,
+      boolean allowNotFound) {
+    Response response = send(environment, path, "GET", uncertain, allowNotFound);
     return response == null ? null : response.body();
   }
 
-  private Response send(String path, String method, boolean uncertain, boolean allowNotFound) {
+  private Response send(
+      ComputeEnvironmentSnapshot environment,
+      String path,
+      String method,
+      boolean uncertain,
+      boolean allowNotFound) {
     try {
       HttpRequest.Builder builder =
-          HttpRequest.newBuilder(URI.create(baseUrl() + path))
+          HttpRequest.newBuilder(URI.create(baseUrl(environment) + path))
               .timeout(properties.getRequestTimeout())
               .header("Accept", "application/json");
       HttpRequest request =
@@ -405,8 +479,8 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     return String.join(System.lineSeparator(), values);
   }
 
-  private Path cliPath() {
-    return Path.of(properties.getFlinkCdcHome(), "bin", "flink-cdc.sh")
+  private Path cliPath(ComputeEnvironmentSnapshot environment) {
+    return Path.of(requireConfig(environment).flinkCdcHome(), "bin", "flink-cdc.sh")
         .toAbsolutePath()
         .normalize();
   }
@@ -427,16 +501,51 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
         .normalize();
   }
 
-  private URI restUri() {
-    URI uri = URI.create(properties.getRestUrl());
+  private URI restUri(ComputeEnvironmentSnapshot environment) {
+    String restUrl = requireConfig(environment).restUrl();
+    URI uri = URI.create(restUrl);
     if (!StringUtils.hasText(uri.getScheme()) || !StringUtils.hasText(uri.getHost())) {
-      throw failure("Flink REST URL 无效：" + properties.getRestUrl(), false, null, null);
+      throw failure("Flink REST URL 无效：" + restUrl, false, null, null);
     }
     return uri;
   }
 
-  private String baseUrl() {
-    return properties.getRestUrl().replaceAll("/+$", "");
+  private String baseUrl(ComputeEnvironmentSnapshot environment) {
+    return requireConfig(environment).restUrl().replaceAll("/+$", "");
+  }
+
+  private RuntimeConfig requireConfig(ComputeEnvironmentSnapshot environment) {
+    if (environment == null || environment.config() == null) {
+      throw new IllegalArgumentException("运行环境配置不能为空");
+    }
+    return environment.config();
+  }
+
+  private SubmissionMode submissionMode(ComputeEnvironmentSnapshot environment) {
+    try {
+      return SubmissionMode.valueOf(environment.submitterType());
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("不支持的任务提交方式：" + environment.submitterType(), exception);
+    }
+  }
+
+  private ComputeEnvironmentSnapshot bootstrapEnvironment() {
+    RuntimeConfig config =
+        new RuntimeConfig(
+            properties.getRestUrl(),
+            properties.getFlinkHome(),
+            properties.getFlinkCdcHome(),
+            properties.getJavaHome(),
+            properties.getFlinkVersion(),
+            properties.getFlinkCdcVersion());
+    return new ComputeEnvironmentSnapshot(
+        0L,
+        "application/default",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        properties.getSubmissionMode().name(),
+        config,
+        0);
   }
 
   private int defaultPort(URI uri) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkJobDiscoveryClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkJobDiscoveryClient.java
@@ -3,6 +3,9 @@ package io.yak.ops.business.sync.realtime.engine;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -36,12 +39,17 @@ public class FlinkJobDiscoveryClient {
   }
 
   public List<String> findJobIds(String exactRuntimeJobName) {
+    return findJobIds(bootstrapEnvironment(), exactRuntimeJobName);
+  }
+
+  public List<String> findJobIds(
+      ComputeEnvironmentSnapshot environment, String exactRuntimeJobName) {
     if (exactRuntimeJobName == null || exactRuntimeJobName.isBlank()) {
       throw new IllegalArgumentException("runtime job name 不能为空");
     }
     try {
       HttpRequest request =
-          HttpRequest.newBuilder(URI.create(baseUrl() + "/jobs/overview"))
+          HttpRequest.newBuilder(URI.create(baseUrl(environment) + "/jobs/overview"))
               .timeout(properties.getRequestTimeout())
               .header("Accept", "application/json")
               .GET()
@@ -80,8 +88,30 @@ public class FlinkJobDiscoveryClient {
     }
   }
 
-  private String baseUrl() {
-    return properties.getRestUrl().replaceAll("/+$", "");
+  private String baseUrl(ComputeEnvironmentSnapshot environment) {
+    if (environment == null || environment.config() == null) {
+      throw new IllegalArgumentException("运行环境配置不能为空");
+    }
+    return environment.config().restUrl().replaceAll("/+$", "");
+  }
+
+  private ComputeEnvironmentSnapshot bootstrapEnvironment() {
+    RuntimeConfig config =
+        new RuntimeConfig(
+            properties.getRestUrl(),
+            properties.getFlinkHome(),
+            properties.getFlinkCdcHome(),
+            properties.getJavaHome(),
+            properties.getFlinkVersion(),
+            properties.getFlinkCdcVersion());
+    return new ComputeEnvironmentSnapshot(
+        0L,
+        "application/default",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        properties.getSubmissionMode().name(),
+        config,
+        0);
   }
 
   private RealtimeEngineException failure(String message, Throwable cause) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
@@ -3,6 +3,9 @@ package io.yak.ops.business.sync.realtime.engine;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.CheckpointDetail;
 import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.CheckpointSummary;
@@ -66,8 +69,13 @@ public class FlinkObservabilityClient {
   }
 
   public RealtimeObservabilityView snapshot(String jobId) {
+    return snapshot(bootstrapEnvironment(), jobId);
+  }
+
+  public RealtimeObservabilityView snapshot(
+      ComputeEnvironmentSnapshot environment, String jobId) {
     requireJobId(jobId);
-    JsonNode job = getJson("/jobs/" + jobId, true);
+    JsonNode job = getJson(environment, "/jobs/" + jobId, true);
     long sampledAt = System.currentTimeMillis();
     if (job == null) {
       return new RealtimeObservabilityView(
@@ -76,23 +84,23 @@ public class FlinkObservabilityClient {
           "NOT_FOUND",
           null,
           null,
-          flinkWebUrl(jobId),
+          flinkWebUrl(environment, jobId),
           sampledAt,
           emptyCheckpointSummary(),
           emptyMetricSummary());
     }
 
-    JsonNode checkpointBody = getJson("/jobs/" + jobId + "/checkpoints", true);
+    JsonNode checkpointBody = getJson(environment, "/jobs/" + jobId + "/checkpoints", true);
     return new RealtimeObservabilityView(
         jobId,
         text(job, "name"),
         text(job, "state"),
         number(job, "start-time"),
         number(job, "duration"),
-        flinkWebUrl(jobId),
+        flinkWebUrl(environment, jobId),
         sampledAt,
         checkpointSummary(checkpointBody),
-        metricSummary(jobId, job));
+        metricSummary(environment, jobId, job));
   }
 
   public String submissionLog(String idempotencyKey, int tailLines) {
@@ -118,9 +126,15 @@ public class FlinkObservabilityClient {
   }
 
   public RuntimeLog runtimeLog(String jobId, int maxExceptions) {
+    return runtimeLog(bootstrapEnvironment(), jobId, maxExceptions);
+  }
+
+  public RuntimeLog runtimeLog(
+      ComputeEnvironmentSnapshot environment, String jobId, int maxExceptions) {
     requireJobId(jobId);
     int limit = Math.max(1, Math.min(maxExceptions, 100));
-    JsonNode body = getJson("/jobs/" + jobId + "/exceptions?maxExceptions=" + limit, true);
+    JsonNode body =
+        getJson(environment, "/jobs/" + jobId + "/exceptions?maxExceptions=" + limit, true);
     if (body == null) {
       return new RuntimeLog(null, null, false, List.of());
     }
@@ -192,7 +206,8 @@ public class FlinkObservabilityClient {
         redactor.redact(firstText(node, "failure_message", "failure-message")));
   }
 
-  private MetricSummary metricSummary(String jobId, JsonNode job) {
+  private MetricSummary metricSummary(
+      ComputeEnvironmentSnapshot environment, String jobId, JsonNode job) {
     JsonNode vertices = job.path("vertices");
     if (!vertices.isArray()) {
       return emptyMetricSummary();
@@ -219,7 +234,7 @@ public class FlinkObservabilityClient {
       vertexCount++;
       Map<String, MetricAggregate> metrics;
       try {
-        metrics = vertexMetrics(jobId, vertexId);
+        metrics = vertexMetrics(environment, jobId, vertexId);
       } catch (RealtimeEngineException ignored) {
         // Jobs can change state while the UI snapshot is being sampled. Return partial metrics.
         continue;
@@ -260,9 +275,11 @@ public class FlinkObservabilityClient {
         vertexCount);
   }
 
-  private Map<String, MetricAggregate> vertexMetrics(String jobId, String vertexId) {
+  private Map<String, MetricAggregate> vertexMetrics(
+      ComputeEnvironmentSnapshot environment, String jobId, String vertexId) {
     JsonNode body =
         getJson(
+            environment,
             "/jobs/"
                 + jobId
                 + "/vertices/"
@@ -362,10 +379,11 @@ public class FlinkObservabilityClient {
     }
   }
 
-  private JsonNode getJson(String path, boolean allowNotFound) {
+  private JsonNode getJson(
+      ComputeEnvironmentSnapshot environment, String path, boolean allowNotFound) {
     try {
       HttpRequest request =
-          HttpRequest.newBuilder(URI.create(baseUrl() + path))
+          HttpRequest.newBuilder(URI.create(baseUrl(environment) + path))
               .timeout(properties.getRequestTimeout())
               .header("Accept", "application/json")
               .GET()
@@ -398,12 +416,38 @@ public class FlinkObservabilityClient {
     return new MetricSummary(null, null, null, null, null, null, null, null, null, null, null, 0);
   }
 
-  private String flinkWebUrl(String jobId) {
-    return baseUrl() + "/#/job/" + jobId + "/overview";
+  private String flinkWebUrl(ComputeEnvironmentSnapshot environment, String jobId) {
+    return baseUrl(environment) + "/#/job/" + jobId + "/overview";
   }
 
-  private String baseUrl() {
-    return properties.getRestUrl().replaceAll("/+$", "");
+  private String baseUrl(ComputeEnvironmentSnapshot environment) {
+    return requireConfig(environment).restUrl().replaceAll("/+$", "");
+  }
+
+  private RuntimeConfig requireConfig(ComputeEnvironmentSnapshot environment) {
+    if (environment == null || environment.config() == null) {
+      throw new IllegalArgumentException("运行环境配置不能为空");
+    }
+    return environment.config();
+  }
+
+  private ComputeEnvironmentSnapshot bootstrapEnvironment() {
+    RuntimeConfig config =
+        new RuntimeConfig(
+            properties.getRestUrl(),
+            properties.getFlinkHome(),
+            properties.getFlinkCdcHome(),
+            properties.getJavaHome(),
+            properties.getFlinkVersion(),
+            properties.getFlinkCdcVersion());
+    return new ComputeEnvironmentSnapshot(
+        0L,
+        "application/default",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        properties.getSubmissionMode().name(),
+        config,
+        0);
   }
 
   private String safeKey(String idempotencyKey) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeEngineGateway.java
@@ -1,27 +1,55 @@
 package io.yak.ops.business.sync.realtime.engine;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 
 /** Yak Ops-side adapter for Flink CDC CLI submission and Flink REST operations. */
 public interface RealtimeEngineGateway {
 
+  /** Compatibility path that resolves the current application/default runtime settings. */
   JsonNode health();
 
+  JsonNode health(ComputeEnvironmentSnapshot environment);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   JsonNode capabilities();
 
+  JsonNode capabilities(ComputeEnvironmentSnapshot environment);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   ValidationResult validate(String pipelineYaml);
 
+  ValidationResult validate(ComputeEnvironmentSnapshot environment, String pipelineYaml);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   DeployResult deploy(RealtimeDeployRequest request);
 
+  DeployResult deploy(ComputeEnvironmentSnapshot environment, RealtimeDeployRequest request);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   RuntimeStatus status(String jobId);
 
+  RuntimeStatus status(ComputeEnvironmentSnapshot environment, String jobId);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   void stop(String jobId);
 
+  void stop(ComputeEnvironmentSnapshot environment, String jobId);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   String logs(String jobId, int tailLines);
 
+  String logs(ComputeEnvironmentSnapshot environment, String jobId, int tailLines);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   JsonNode checkpoints(String jobId);
 
+  JsonNode checkpoints(ComputeEnvironmentSnapshot environment, String jobId);
+
+  /** Compatibility path that resolves the current application/default runtime settings. */
   JsonNode metrics(String jobId);
+
+  JsonNode metrics(ComputeEnvironmentSnapshot environment, String jobId);
 
   record ValidationResult(boolean valid, String deliverySemantics) {}
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
@@ -1,6 +1,9 @@
 package io.yak.ops.business.sync.realtime.engine;
 
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -26,7 +29,12 @@ final class SshFlinkCdcCommandRunner {
   }
 
   String configurationError() {
+    return configurationError(bootstrapEnvironment());
+  }
+
+  String configurationError(ComputeEnvironmentSnapshot environment) {
     RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+    RuntimeConfig config = requireConfig(environment);
     if (!StringUtils.hasText(ssh.getExecutable())) {
       return "SSH executable 不能为空";
     }
@@ -39,12 +47,10 @@ final class SshFlinkCdcCommandRunner {
     if (ssh.getPort() < 1 || ssh.getPort() > 65535) {
       return "SSH port 必须在 1-65535 之间";
     }
-    if (!absoluteUnixPath(properties.getFlinkHome())
-        || !absoluteUnixPath(properties.getFlinkCdcHome())) {
+    if (!absoluteUnixPath(config.flinkHome()) || !absoluteUnixPath(config.flinkCdcHome())) {
       return "SSH 模式下 flink-home 和 flink-cdc-home 必须是远端 Linux 绝对路径";
     }
-    if (StringUtils.hasText(properties.getJavaHome())
-        && !absoluteUnixPath(properties.getJavaHome())) {
+    if (StringUtils.hasText(config.javaHome()) && !absoluteUnixPath(config.javaHome())) {
       return "SSH 模式下 java-home 必须是远端 Linux 绝对路径";
     }
     Integer remoteRestPort = ssh.getRemoteRestPort();
@@ -62,7 +68,11 @@ final class SshFlinkCdcCommandRunner {
   }
 
   void validateReady(URI restUri) {
-    String error = configurationError();
+    validateReady(bootstrapEnvironment(), restUri);
+  }
+
+  void validateReady(ComputeEnvironmentSnapshot environment, URI restUri) {
+    String error = configurationError(environment);
     if (error != null) {
       throw failure(error, false, null);
     }
@@ -70,7 +80,7 @@ final class SshFlinkCdcCommandRunner {
     Process process = null;
     try {
       process =
-          new ProcessBuilder(sshCommand(remoteProbeCommand(restUri)))
+          new ProcessBuilder(sshCommand(remoteProbeCommand(environment, restUri)))
               .redirectErrorStream(true)
               .redirectOutput(ProcessBuilder.Redirect.DISCARD)
               .start();
@@ -96,7 +106,16 @@ final class SshFlinkCdcCommandRunner {
   }
 
   ExecutionResult submit(String pipelineYaml, Path outputLog, URI restUri, Duration timeout) {
-    String error = configurationError();
+    return submit(bootstrapEnvironment(), pipelineYaml, outputLog, restUri, timeout);
+  }
+
+  ExecutionResult submit(
+      ComputeEnvironmentSnapshot environment,
+      String pipelineYaml,
+      Path outputLog,
+      URI restUri,
+      Duration timeout) {
+    String error = configurationError(environment);
     if (error != null) {
       throw failure(error, false, null);
     }
@@ -105,7 +124,7 @@ final class SshFlinkCdcCommandRunner {
     boolean started = false;
     try {
       ProcessBuilder builder =
-          new ProcessBuilder(sshCommand(remoteSubmitCommand(restUri)))
+          new ProcessBuilder(sshCommand(remoteSubmitCommand(environment, restUri)))
               .redirectErrorStream(true)
               .redirectOutput(outputLog.toFile());
       process = builder.start();
@@ -169,22 +188,20 @@ final class SshFlinkCdcCommandRunner {
     return command;
   }
 
-  private String remoteProbeCommand(URI restUri) {
-    String cdc = remoteCdcCli();
+  private String remoteProbeCommand(ComputeEnvironmentSnapshot environment, URI restUri) {
+    RuntimeConfig config = requireConfig(environment);
+    String cdc = remoteCdcCli(environment);
     StringBuilder command = new StringBuilder("set -eu; ");
-    command
-        .append("test -x ")
-        .append(shellQuote(cdc))
-        .append(" || exit 41; ");
+    command.append("test -x ").append(shellQuote(cdc)).append(" || exit 41; ");
     command
         .append("test -d ")
-        .append(shellQuote(properties.getFlinkHome()))
+        .append(shellQuote(config.flinkHome()))
         .append(" || exit 42; ");
     command.append("command -v mktemp >/dev/null 2>&1 || exit 43; ");
-    if (StringUtils.hasText(properties.getJavaHome())) {
+    if (StringUtils.hasText(config.javaHome())) {
       command
           .append("test -x ")
-          .append(shellQuote(properties.getJavaHome() + "/bin/java"))
+          .append(shellQuote(config.javaHome() + "/bin/java"))
           .append(" || exit 44; ");
     }
     command.append("test -n ").append(shellQuote(remoteRestAddress(restUri))).append("; ");
@@ -192,29 +209,28 @@ final class SshFlinkCdcCommandRunner {
     return command.toString();
   }
 
-  private String remoteSubmitCommand(URI restUri) {
+  private String remoteSubmitCommand(ComputeEnvironmentSnapshot environment, URI restUri) {
+    RuntimeConfig config = requireConfig(environment);
     StringBuilder command = new StringBuilder();
     command.append("set -eu; umask 077; ");
     command.append("tmp=$(mktemp \"${TMPDIR:-/tmp}/yak-ops-cdc.XXXXXX.yaml\"); ");
     command.append("cleanup(){ rm -f \"$tmp\"; }; trap cleanup 0; ");
     command.append("trap 'exit 129' HUP; trap 'exit 130' INT; trap 'exit 143' TERM; ");
     command.append("cat > \"$tmp\"; ");
-    command.append("export FLINK_HOME=").append(shellQuote(properties.getFlinkHome())).append("; ");
-    if (StringUtils.hasText(properties.getJavaHome())) {
-      command.append("export JAVA_HOME=").append(shellQuote(properties.getJavaHome())).append("; ");
+    command.append("export FLINK_HOME=").append(shellQuote(config.flinkHome())).append("; ");
+    if (StringUtils.hasText(config.javaHome())) {
+      command.append("export JAVA_HOME=").append(shellQuote(config.javaHome())).append("; ");
     }
-    command.append(shellQuote(remoteCdcCli())).append(" \"$tmp\"");
-    command.append(" --flink-home ").append(shellQuote(properties.getFlinkHome()));
+    command.append(shellQuote(remoteCdcCli(environment))).append(" \"$tmp\"");
+    command.append(" --flink-home ").append(shellQuote(config.flinkHome()));
     command.append(" --target remote");
-    command
-        .append(" ")
-        .append(shellQuote("-Drest.address=" + remoteRestAddress(restUri)));
+    command.append(" ").append(shellQuote("-Drest.address=" + remoteRestAddress(restUri)));
     command.append(" ").append(shellQuote("-Drest.port=" + remoteRestPort(restUri)));
     return command.toString();
   }
 
-  private String remoteCdcCli() {
-    String home = properties.getFlinkCdcHome().replaceAll("/+$", "");
+  private String remoteCdcCli(ComputeEnvironmentSnapshot environment) {
+    String home = requireConfig(environment).flinkCdcHome().replaceAll("/+$", "");
     return home + "/bin/flink-cdc.sh";
   }
 
@@ -252,6 +268,32 @@ final class SshFlinkCdcCommandRunner {
       case 255 -> "SSH 连接或认证失败，请检查 host key、用户和密钥配置";
       default -> "SSH 远端运行环境未通过检查，exitCode=" + exitCode;
     };
+  }
+
+  private RuntimeConfig requireConfig(ComputeEnvironmentSnapshot environment) {
+    if (environment == null || environment.config() == null) {
+      throw new IllegalArgumentException("运行环境配置不能为空");
+    }
+    return environment.config();
+  }
+
+  private ComputeEnvironmentSnapshot bootstrapEnvironment() {
+    RuntimeConfig config =
+        new RuntimeConfig(
+            properties.getRestUrl(),
+            properties.getFlinkHome(),
+            properties.getFlinkCdcHome(),
+            properties.getJavaHome(),
+            properties.getFlinkVersion(),
+            properties.getFlinkCdcVersion());
+    return new ComputeEnvironmentSnapshot(
+        0L,
+        "application/default",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        properties.getSubmissionMode().name(),
+        config,
+        0);
   }
 
   private boolean absoluteUnixPath(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.sync.realtime.repository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -133,6 +134,35 @@ public class ComputeEnvironmentStore {
     }
   }
 
+  /**
+   * Stage two makes the runtime binding explicit. Rows created before V7 are bound to the current
+   * default environment once during application startup. Legacy deployment snapshots are a
+   * best-effort reconstruction because stage one did not persist the historical environment.
+   */
+  public void bindLegacyRealtimeJobs(ComputeEnvironment environment) {
+    ComputeEnvironmentSnapshot snapshot = ComputeEnvironmentSnapshot.from(environment);
+    db.update(
+        "update yak_realtime_job_definition set runtime_environment_id=? "
+            + "where runtime_environment_id is null",
+        environment.id());
+    db.update(
+        "update yak_realtime_job_deployment set runtime_environment_id=?,"
+            + "runtime_environment_version=?,runtime_environment_snapshot_json=? "
+            + "where runtime_environment_snapshot_json is null",
+        environment.id(),
+        environment.version(),
+        write(snapshot));
+  }
+
+  public boolean hasBoundRealtimeJobs(long id) {
+    Long count =
+        db.queryForObject(
+            "select count(*) from yak_realtime_job_definition where runtime_environment_id=?",
+            Long.class,
+            id);
+    return count != null && count > 0;
+  }
+
   public boolean hasActiveRealtimeJobs() {
     Long count =
         db.queryForObject(
@@ -157,9 +187,9 @@ public class ComputeEnvironmentStore {
         time(result.getTimestamp("update_time")));
   }
 
-  private String write(RuntimeConfig config) {
+  private String write(Object value) {
     try {
-      return json.writeValueAsString(config);
+      return json.writeValueAsString(value);
     } catch (Exception exception) {
       throw new IllegalArgumentException("无法序列化运行环境配置", exception);
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQuery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQuery.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.sync.realtime.repository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import java.sql.ResultSet;
@@ -84,6 +85,7 @@ public class RealtimeJobListQuery {
             + " p.idempotency_key as deployment_idempotency_key,"
             + " p.gateway_job_id as deployment_gateway_job_id,"
             + " p.runtime_revision as deployment_runtime_revision,"
+            + " p.runtime_environment_snapshot_json as deployment_runtime_environment_snapshot_json,"
             + " p.status as deployment_status,"
             + " p.result_uncertain as deployment_result_uncertain,"
             + " p.error_message as deployment_error_message,"
@@ -138,6 +140,8 @@ public class RealtimeJobListQuery {
               result.getString("deployment_idempotency_key"),
               result.getString("deployment_gateway_job_id"),
               result.getString("deployment_runtime_revision"),
+              readEnvironmentSnapshot(
+                  result.getString("deployment_runtime_environment_snapshot_json")),
               result.getString("deployment_status"),
               result.getBoolean("deployment_result_uncertain"),
               result.getString("deployment_error_message"),
@@ -150,6 +154,7 @@ public class RealtimeJobListQuery {
         result.getString("job_name"),
         result.getString("description"),
         readSpec(result.getString("spec_json")),
+        result.getObject("runtime_environment_id", Long.class),
         result.getString("release_state"),
         result.getString("desired_state"),
         result.getString("observed_state"),
@@ -163,8 +168,6 @@ public class RealtimeJobListQuery {
   }
 
   private CdcPipelineSpec readSpec(String value) {
-    // Two-stage drafts intentionally have no spec until the configuration page is saved.
-    // Keep those rows visible in list queries instead of attempting to deserialize SQL NULL.
     if (!StringUtils.hasText(value)) {
       return null;
     }
@@ -172,6 +175,17 @@ public class RealtimeJobListQuery {
       return json.readValue(value, CdcPipelineSpec.class);
     } catch (Exception exception) {
       throw new IllegalArgumentException("实时同步 Spec 无效", exception);
+    }
+  }
+
+  private ComputeEnvironmentSnapshot readEnvironmentSnapshot(String value) {
+    if (!StringUtils.hasText(value)) {
+      return null;
+    }
+    try {
+      return json.readValue(value, ComputeEnvironmentSnapshot.class);
+    } catch (Exception exception) {
+      throw new IllegalStateException("实时同步运行环境快照无效", exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.sync.realtime.repository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobChangeEvent;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobEventView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
@@ -20,7 +21,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.stereotype.Repository;
 
-/** JDBC persistence adapter for the three realtime-only tables. */
+/** JDBC persistence adapter for realtime job definitions, deployments and events. */
 @Repository
 public class RealtimeJobStore {
 
@@ -37,26 +38,43 @@ public class RealtimeJobStore {
     this.events = events;
   }
 
+  /** Compatibility overload retained for callers that do not yet bind a runtime environment. */
   public long insertDefinition(
       String name, String description, CdcPipelineSpec spec, String digest) {
+    return insertDefinition(name, description, spec, digest, null);
+  }
+
+  public long insertDefinition(
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      String digest,
+      Long runtimeEnvironmentId) {
     GeneratedKeyHolder keys = new GeneratedKeyHolder();
     db.update(
         connection -> {
           PreparedStatement statement =
               connection.prepareStatement(
                   "insert into yak_realtime_job_definition"
-                      + "(job_name,description,spec_json,config_digest) values(?,?,?,?)",
+                      + "(job_name,description,runtime_environment_id,spec_json,config_digest) "
+                      + "values(?,?,?,?,?)",
                   Statement.RETURN_GENERATED_KEYS);
           statement.setString(1, name);
           statement.setString(2, description);
-          statement.setString(3, spec == null ? null : write(spec));
-          statement.setString(4, digest);
+          if (runtimeEnvironmentId == null) {
+            statement.setObject(3, null);
+          } else {
+            statement.setLong(3, runtimeEnvironmentId);
+          }
+          statement.setString(4, spec == null ? null : write(spec));
+          statement.setString(5, digest);
           return statement;
         },
         keys);
     return Objects.requireNonNull(keys.getKey(), "新增实时任务未返回主键").longValue();
   }
 
+  /** Compatibility overload that preserves the current runtime environment binding. */
   public void updateDefinition(
       long id, String name, String description, CdcPipelineSpec spec, String digest) {
     int changed =
@@ -67,6 +85,30 @@ public class RealtimeJobStore {
                 + "and observed_state in ('STOPPED','FAILED')",
             name,
             description,
+            write(spec),
+            digest,
+            id);
+    if (changed != 1) {
+      throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能编辑");
+    }
+  }
+
+  public void updateDefinition(
+      long id,
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      String digest,
+      long runtimeEnvironmentId) {
+    int changed =
+        db.update(
+            "update yak_realtime_job_definition set job_name=?,description=?,runtime_environment_id=?,"
+                + "spec_json=?,config_digest=?,definition_version=definition_version+1,release_state='DRAFT' "
+                + "where id=? and desired_state='STOPPED' "
+                + "and observed_state in ('STOPPED','FAILED')",
+            name,
+            description,
+            runtimeEnvironmentId,
             write(spec),
             digest,
             id);
@@ -97,6 +139,18 @@ public class RealtimeJobStore {
             (result, row) -> definitionRow(result),
             id);
     return rows.stream().findFirst();
+  }
+
+  public Long runtimeEnvironmentId(long definitionId) {
+    List<Long> rows =
+        db.query(
+            "select runtime_environment_id from yak_realtime_job_definition where id=?",
+            (result, row) -> result.getObject("runtime_environment_id", Long.class),
+            definitionId);
+    if (rows.isEmpty()) {
+      throw new IllegalArgumentException("实时同步任务不存在：" + definitionId);
+    }
+    return rows.get(0);
   }
 
   public DefinitionRow lockDefinition(long id) {
@@ -161,11 +215,34 @@ public class RealtimeJobStore {
         .findFirst();
   }
 
+  public Optional<ComputeEnvironmentSnapshot> deploymentEnvironment(long deploymentId) {
+    List<String> rows =
+        db.query(
+            "select runtime_environment_snapshot_json from yak_realtime_job_deployment where id=?",
+            (result, row) -> result.getString("runtime_environment_snapshot_json"),
+            deploymentId);
+    if (rows.isEmpty() || rows.get(0) == null || rows.get(0).isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.of(readEnvironmentSnapshot(rows.get(0)));
+  }
+
+  /** Compatibility overload retained for tests and integrations compiled before Stage 2. */
   public long insertDeployment(
       DefinitionRow definition,
       CdcPipelineSpec spec,
       String summary,
       String digest,
+      String idempotencyKey) {
+    return insertDeployment(definition, spec, summary, digest, null, idempotencyKey);
+  }
+
+  public long insertDeployment(
+      DefinitionRow definition,
+      CdcPipelineSpec spec,
+      String summary,
+      String digest,
+      ComputeEnvironmentSnapshot environment,
       String idempotencyKey) {
     GeneratedKeyHolder keys = new GeneratedKeyHolder();
     db.update(
@@ -173,16 +250,26 @@ public class RealtimeJobStore {
           PreparedStatement statement =
               connection.prepareStatement(
                   "insert into yak_realtime_job_deployment"
-                      + "(definition_id,definition_version,spec_snapshot_json,pipeline_yaml,"
-                      + "spec_summary,config_digest,idempotency_key,status) "
-                      + "values(?,?,?,null,?,?,?,'SUBMITTING')",
+                      + "(definition_id,definition_version,runtime_environment_id,"
+                      + "runtime_environment_version,runtime_environment_snapshot_json,"
+                      + "spec_snapshot_json,pipeline_yaml,spec_summary,config_digest,"
+                      + "idempotency_key,status) values(?,?,?,?,?,?,null,?,?,?,'SUBMITTING')",
                   Statement.RETURN_GENERATED_KEYS);
           statement.setLong(1, definition.id());
           statement.setInt(2, definition.definitionVersion());
-          statement.setString(3, write(spec));
-          statement.setString(4, summary);
-          statement.setString(5, digest);
-          statement.setString(6, idempotencyKey);
+          if (environment == null) {
+            statement.setObject(3, null);
+            statement.setObject(4, null);
+            statement.setObject(5, null);
+          } else {
+            statement.setLong(3, environment.id());
+            statement.setInt(4, environment.version());
+            statement.setString(5, write(environment));
+          }
+          statement.setString(6, write(spec));
+          statement.setString(7, summary);
+          statement.setString(8, digest);
+          statement.setString(9, idempotencyKey);
           return statement;
         },
         keys);
@@ -397,6 +484,7 @@ public class RealtimeJobStore {
             deployment.idempotencyKey(),
             deployment.engineJobId(),
             deployment.runtimeRevision(),
+            deploymentEnvironment(deployment.id()).orElse(null),
             deployment.status(),
             deployment.resultUncertain(),
             deployment.errorMessage(),
@@ -410,6 +498,7 @@ public class RealtimeJobStore {
         definition.name(),
         definition.description(),
         read(definition.specJson()),
+        runtimeEnvironmentId(definition.id()),
         definition.releaseState(),
         definition.desiredState(),
         definition.observedState(),
@@ -465,7 +554,7 @@ public class RealtimeJobStore {
     try {
       return json.writeValueAsString(value);
     } catch (Exception exception) {
-      throw new IllegalArgumentException("无法序列化实时同步 Spec", exception);
+      throw new IllegalArgumentException("无法序列化实时同步数据", exception);
     }
   }
 
@@ -477,6 +566,14 @@ public class RealtimeJobStore {
       return json.readValue(value, CdcPipelineSpec.class);
     } catch (Exception exception) {
       throw new IllegalArgumentException("实时同步 Spec 无效", exception);
+    }
+  }
+
+  private ComputeEnvironmentSnapshot readEnvironmentSnapshot(String value) {
+    try {
+      return json.readValue(value, ComputeEnvironmentSnapshot.class);
+    } catch (Exception exception) {
+      throw new IllegalStateException("实时同步运行环境快照无效", exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
-/** Manages the small, user-facing runtime environment model for realtime Flink CDC. */
+/** Manages the user-facing runtime environment model for realtime Flink CDC. */
 @Service
 @DependsOn("realtimeSyncFlyway")
 public class ComputeEnvironmentService {
@@ -43,6 +43,7 @@ public class ComputeEnvironmentService {
   @PostConstruct
   void initialize() {
     bootstrapDefaultEnvironment();
+    backfillLegacyRuntimeBindings();
     refreshRuntimeOverrides();
   }
 
@@ -59,9 +60,6 @@ public class ComputeEnvironmentService {
     RuntimeConfig normalizedConfig = normalizeConfig(config);
     if (makeDefault && !enabled) {
       throw new IllegalArgumentException("默认运行环境必须保持启用");
-    }
-    if (makeDefault) {
-      requireRuntimeStable("切换默认运行环境");
     }
 
     try {
@@ -102,10 +100,6 @@ public class ComputeEnvironmentService {
     if (switchingDefault && !enabled) {
       throw new IllegalArgumentException("默认运行环境必须保持启用");
     }
-    if ((current.defaultEnvironment() && !current.config().equals(normalizedConfig))
-        || switchingDefault) {
-      requireRuntimeStable(switchingDefault ? "切换默认运行环境" : "修改默认运行环境");
-    }
 
     try {
       transactions.executeWithoutResult(
@@ -140,7 +134,6 @@ public class ComputeEnvironmentService {
     if (!target.enabled()) {
       throw new IllegalStateException("只有已启用的运行环境才能设为默认环境");
     }
-    requireRuntimeStable("切换默认运行环境");
     transactions.executeWithoutResult(
         status -> {
           store.clearDefault();
@@ -154,12 +147,16 @@ public class ComputeEnvironmentService {
     if (current.defaultEnvironment()) {
       throw new IllegalStateException("默认运行环境不能删除，请先切换默认环境");
     }
+    if (store.hasBoundRealtimeJobs(id)) {
+      throw new IllegalStateException("运行环境仍被实时同步任务引用，请先将这些任务切换到其他运行环境");
+    }
     store.delete(id);
   }
 
   /**
-   * Keeps every Yak Ops instance aligned with the database-selected default environment. Runtime
-   * environments cannot be changed while jobs are active, so the refresh is safe for running jobs.
+   * The application/default override remains as a compatibility fallback for older integrations.
+   * Stage two runtime operations use the task/deployment environment explicitly and no longer rely
+   * on this mutable global value.
    */
   @Scheduled(fixedDelayString = "${yak.sync.realtime.environment-refresh-delay:5000}")
   public void refreshRuntimeOverrides() {
@@ -212,14 +209,16 @@ public class ComputeEnvironmentService {
     }
   }
 
-  private ComputeEnvironment require(long id) {
-    return store.find(id).orElseThrow(() -> new IllegalArgumentException("运行环境不存在：" + id));
+  private void backfillLegacyRuntimeBindings() {
+    ComputeEnvironment environment = store.defaultEnvironment().orElse(null);
+    if (environment == null) {
+      return;
+    }
+    transactions.executeWithoutResult(status -> store.bindLegacyRealtimeJobs(environment));
   }
 
-  private void requireRuntimeStable(String action) {
-    if (store.hasActiveRealtimeJobs()) {
-      throw new IllegalStateException(action + "前请先停止所有实时同步任务");
-    }
+  private ComputeEnvironment require(long id) {
+    return store.find(id).orElseThrow(() -> new IllegalArgumentException("运行环境不存在：" + id));
   }
 
   private String normalizeName(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.sync.realtime.service;
 
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
 import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
@@ -35,6 +36,7 @@ public class RealtimeJobLifecycleCoordinator {
   private final RealtimeRuntimeIdentityStore identityStore;
   private final FlinkJobDiscoveryClient discovery;
   private final RealtimeEngineGateway gateway;
+  private final RealtimeRuntimeResolver runtimeResolver;
   private final RealtimeStateMachine stateMachine;
   private final RealtimeSyncProperties properties;
   private final TransactionTemplate transactions;
@@ -47,6 +49,7 @@ public class RealtimeJobLifecycleCoordinator {
       RealtimeRuntimeIdentityStore identityStore,
       FlinkJobDiscoveryClient discovery,
       RealtimeEngineGateway gateway,
+      RealtimeRuntimeResolver runtimeResolver,
       RealtimeStateMachine stateMachine,
       RealtimeSyncProperties properties,
       @Value("${yak.sync.realtime.orphan-recovery-grace-seconds:120}") long orphanGraceSeconds,
@@ -55,6 +58,7 @@ public class RealtimeJobLifecycleCoordinator {
     this.identityStore = identityStore;
     this.discovery = discovery;
     this.gateway = gateway;
+    this.runtimeResolver = runtimeResolver;
     this.stateMachine = stateMachine;
     this.properties = properties;
     this.orphanGraceSeconds = Math.max(10, orphanGraceSeconds);
@@ -96,12 +100,13 @@ public class RealtimeJobLifecycleCoordinator {
       deployment = store.latestDeployment(id).orElse(deployment);
     }
 
-    RuntimeStatus runtime = gateway.status(jobId);
-    applyRuntimeState(id, deployment.id(), jobId, runtime);
+    ComputeEnvironmentSnapshot runtimeEnvironment = runtimeResolver.deployment(definition, deployment);
+    RuntimeStatus runtime = gateway.status(runtimeEnvironment, jobId);
+    applyRuntimeState(id, deployment.id(), jobId, runtimeEnvironment, runtime);
     return store.view(id);
   }
 
-  /** Refuses metadata deletion unless Flink proves that no matching runtime job is active. */
+  /** Refuses metadata deletion unless the deployment's Flink runtime proves no job is active. */
   public void assertSafeToDelete(long id) {
     DefinitionRow definition = requireDefinition(id);
     stateMachine.requireDefinitionMutable(definition.desiredState(), definition.observedState());
@@ -109,14 +114,15 @@ public class RealtimeJobLifecycleCoordinator {
     if (deployment == null) {
       return;
     }
+    ComputeEnvironmentSnapshot runtimeEnvironment = runtimeResolver.deployment(definition, deployment);
     if (StringUtils.hasText(deployment.engineJobId())) {
-      requireInactive(gateway.status(deployment.engineJobId()));
+      requireInactive(gateway.status(runtimeEnvironment, deployment.engineJobId()));
       return;
     }
     String runtimeName = identityStore.findByDeploymentId(deployment.id()).orElse(null);
     if (StringUtils.hasText(runtimeName)) {
-      for (String jobId : discovery.findJobIds(runtimeName)) {
-        requireInactive(gateway.status(jobId));
+      for (String jobId : discovery.findJobIds(runtimeEnvironment, runtimeName)) {
+        requireInactive(gateway.status(runtimeEnvironment, jobId));
       }
       return;
     }
@@ -140,7 +146,8 @@ public class RealtimeJobLifecycleCoordinator {
       }
       return null;
     }
-    List<String> matches = discovery.findJobIds(runtimeName);
+    ComputeEnvironmentSnapshot runtimeEnvironment = runtimeResolver.deployment(definition, deployment);
+    List<String> matches = discovery.findJobIds(runtimeEnvironment, runtimeName);
     if (matches.size() > 1) {
       markConflict(definition.id(), deployment, matches.size());
       return null;
@@ -179,7 +186,11 @@ public class RealtimeJobLifecycleCoordinator {
   }
 
   private void applyRuntimeState(
-      long definitionId, long deploymentId, String jobId, RuntimeStatus runtime) {
+      long definitionId,
+      long deploymentId,
+      String jobId,
+      ComputeEnvironmentSnapshot runtimeEnvironment,
+      RuntimeStatus runtime) {
     Boolean stop =
         transactions.execute(
             ignored -> {
@@ -225,7 +236,7 @@ public class RealtimeJobLifecycleCoordinator {
 
     if (Boolean.TRUE.equals(stop)) {
       try {
-        gateway.stop(jobId);
+        gateway.stop(runtimeEnvironment, jobId);
       } catch (RealtimeEngineException exception) {
         markUnknown(definitionId, deploymentId, jobId, exception.getMessage());
         throw exception;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobEventView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
@@ -51,6 +52,7 @@ public class RealtimeJobService {
   private final PipelineYamlCompiler compiler;
   private final RealtimeEngineGateway gateway;
   private final RealtimeLogRedactor logRedactor;
+  private final RealtimeRuntimeResolver runtimeResolver;
   private final TransactionTemplate transactions;
   private final RealtimeSyncProperties properties;
   private final ConcurrentHashMap<Long, ReentrantLock> lifecycleLocks = new ConcurrentHashMap<>();
@@ -67,6 +69,7 @@ public class RealtimeJobService {
       PipelineYamlCompiler compiler,
       RealtimeEngineGateway gateway,
       RealtimeLogRedactor logRedactor,
+      RealtimeRuntimeResolver runtimeResolver,
       RealtimeSyncProperties properties,
       @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager) {
     this.store = store;
@@ -78,25 +81,42 @@ public class RealtimeJobService {
     this.compiler = compiler;
     this.gateway = gateway;
     this.logRedactor = logRedactor;
+    this.runtimeResolver = runtimeResolver;
     this.properties = properties;
     this.transactions = new TransactionTemplate(transactionManager);
   }
 
+  /** Compatibility entry point: existing clients keep the current binding or use the default. */
   public long save(Long id, String name, String description, CdcPipelineSpec spec) {
+    return save(id, name, description, spec, null);
+  }
+
+  public long save(
+      Long id,
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      Long requestedRuntimeEnvironmentId) {
     requireName(name);
     specValidator.validate(spec);
-    String digest = digest(write(spec));
+    long runtimeEnvironmentId =
+        resolveDefinitionEnvironmentId(id, requestedRuntimeEnvironmentId);
+    runtimeResolver.environment(runtimeEnvironmentId, true);
+    String digest = definitionDigest(spec, runtimeEnvironmentId);
     Long saved =
         transactions.execute(
             status -> {
               if (id == null) {
-                long created = store.insertDefinition(name.trim(), description, spec, digest);
+                long created =
+                    store.insertDefinition(
+                        name.trim(), description, spec, digest, runtimeEnvironmentId);
                 store.event(created, null, "DRAFT_CREATED", null, "DRAFT", "已创建实时同步草稿");
                 return created;
               }
               DefinitionRow locked = store.lockDefinition(id);
               stateMachine.requireDefinitionMutable(locked.desiredState(), locked.observedState());
-              store.updateDefinition(id, name.trim(), description, spec, digest);
+              store.updateDefinition(
+                  id, name.trim(), description, spec, digest, runtimeEnvironmentId);
               store.event(
                   id,
                   null,
@@ -111,11 +131,22 @@ public class RealtimeJobService {
 
   /** Creates the shell first; the editor supplies the pipeline spec in the second stage. */
   public long create(String name, String description) {
+    return create(name, description, null);
+  }
+
+  public long create(String name, String description, Long requestedRuntimeEnvironmentId) {
     requireName(name);
+    long runtimeEnvironmentId =
+        requestedRuntimeEnvironmentId == null
+            ? runtimeResolver.defaultEnvironmentId()
+            : requestedRuntimeEnvironmentId;
+    runtimeResolver.environment(runtimeEnvironmentId, true);
     Long saved =
         transactions.execute(
             status -> {
-              long created = store.insertDefinition(name.trim(), description, null, null);
+              long created =
+                  store.insertDefinition(
+                      name.trim(), description, null, null, runtimeEnvironmentId);
               store.event(created, null, "DRAFT_CREATED", null, "DRAFT", "已创建实时同步基础任务");
               return created;
             });
@@ -134,7 +165,7 @@ public class RealtimeJobService {
     Prepared prepared = prepare(id, false);
     stateMachine.requireDefinitionMutable(
         prepared.definition().desiredState(), prepared.definition().observedState());
-    gateway.validate(prepared.compiled().yaml());
+    gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
     transactions.executeWithoutResult(
         status -> {
           DefinitionRow locked = store.lockDefinition(id);
@@ -154,7 +185,7 @@ public class RealtimeJobService {
 
   public RealtimeEngineGateway.ValidationResult validate(long id) {
     Prepared prepared = prepare(id, false);
-    return gateway.validate(prepared.compiled().yaml());
+    return gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
   }
 
   public RealtimeJobView.Deployment start(long id, String requestedKey) {
@@ -175,7 +206,7 @@ public class RealtimeJobService {
     }
 
     Prepared prepared = prepare(id, true);
-    gateway.validate(prepared.compiled().yaml());
+    gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
 
     StartReservation reservation;
     try {
@@ -201,6 +232,7 @@ public class RealtimeJobService {
                         prepared.spec(),
                         prepared.compiled().summary(),
                         digest(prepared.compiled().yaml()),
+                        prepared.runtimeEnvironment(),
                         key);
                 store.markStarting(id);
                 store.event(
@@ -209,7 +241,9 @@ public class RealtimeJobService {
                     "START_REQUESTED",
                     locked.observedState(),
                     "STARTING",
-                    "开始通过 Flink CDC CLI 提交任务");
+                    "开始通过运行环境「"
+                        + prepared.runtimeEnvironment().name()
+                        + "」提交 Flink CDC 任务");
                 return new StartReservation(created, true);
               });
     } catch (DuplicateKeyException exception) {
@@ -261,7 +295,10 @@ public class RealtimeJobService {
               if ("RUNNING".equals(current.desiredState())
                   && "STARTING".equals(current.observedState())) {
                 store.markDeploymentRunning(
-                    id, deploymentId, result.jobId(), prepared.runtimeRevision());
+                    id,
+                    deploymentId,
+                    result.jobId(),
+                    prepared.runtimeEnvironment().runtimeRevision());
                 store.event(
                     id, deploymentId, "STARTED", "STARTING", "RUNNING", "Flink 已接受任务");
                 return false;
@@ -272,7 +309,8 @@ public class RealtimeJobService {
                 stateMachine.requireTransition(from, "STOPPING");
                 store.markStopping(id, deploymentId);
               }
-              store.bindDeploymentForStop(deploymentId, result.jobId(), prepared.runtimeRevision());
+              store.bindDeploymentForStop(
+                  deploymentId, result.jobId(), prepared.runtimeEnvironment().runtimeRevision());
               store.event(
                   id,
                   deploymentId,
@@ -368,12 +406,14 @@ public class RealtimeJobService {
   }
 
   private void stopBoundJob(long id, long deploymentId, String jobId, String successMessage) {
-    DeploymentRow deployment = store.latestDeployment(id).orElse(null);
+    DeploymentRow deployment =
+        store.latestDeployment(id).orElseThrow(() -> new IllegalStateException("部署记录不存在"));
+    ComputeEnvironmentSnapshot runtimeEnvironment = deploymentRuntime(id, deployment);
     try {
-      RuntimeStatus runtime = gateway.status(jobId);
+      RuntimeStatus runtime = gateway.status(runtimeEnvironment, jobId);
       if (runtime.state() == RuntimeStatus.State.RUNNING) {
-        gateway.stop(jobId);
-        waitForRuntimeStop(jobId);
+        gateway.stop(runtimeEnvironment, jobId);
+        waitForRuntimeStop(runtimeEnvironment, jobId);
       } else if (runtime.state() == RuntimeStatus.State.UNKNOWN) {
         throw new RealtimeEngineException("Flink 状态未知，无法确认停止结果", true, null, null);
       }
@@ -445,26 +485,36 @@ public class RealtimeJobService {
   }
 
   public JsonNode capabilities() {
-    return gateway.capabilities();
+    return capabilities(null);
+  }
+
+  public JsonNode capabilities(Long runtimeEnvironmentId) {
+    long resolvedId =
+        runtimeEnvironmentId == null
+            ? runtimeResolver.defaultEnvironmentId()
+            : runtimeEnvironmentId;
+    return gateway.capabilities(runtimeResolver.environment(resolvedId, true));
   }
 
   public String logs(long id, int tail) {
-    DeploymentRow deployment =
-        store.latestDeployment(id).orElseThrow(() -> new IllegalStateException("任务尚无部署记录"));
-    requireEngineJobId(deployment);
-    return logRedactor.redact(gateway.logs(deployment.engineJobId(), tail));
+    DeploymentRow deployment = latestDeploymentWithJobId(id);
+    ComputeEnvironmentSnapshot runtimeEnvironment = deploymentRuntime(id, deployment);
+    return logRedactor.redact(
+        gateway.logs(runtimeEnvironment, deployment.engineJobId(), tail));
   }
 
   public JsonNode checkpoints(long id) {
     DeploymentRow deployment = latestDeploymentWithJobId(id);
-    return gateway.checkpoints(deployment.engineJobId());
+    return gateway.checkpoints(
+        deploymentRuntime(id, deployment), deployment.engineJobId());
   }
 
   public JsonNode metrics(long id) {
     DeploymentRow deployment = latestDeploymentWithJobId(id);
-    return gateway.metrics(deployment.engineJobId());
+    return gateway.metrics(deploymentRuntime(id, deployment), deployment.engineJobId());
   }
 
+  /** Compatibility reconciler retained for existing internal callers. */
   public void reconcile() {
     List<DefinitionRow> candidates = store.desiredJobs();
     for (DefinitionRow snapshot : candidates) {
@@ -479,9 +529,6 @@ public class RealtimeJobService {
         }
         DeploymentRow deployment = store.latestDeployment(job.id()).orElse(null);
         if (deployment == null || !StringUtils.hasText(deployment.engineJobId())) {
-          // Another Yak Ops instance may still be inside the synchronous CLI submission. An
-          // uncertain submission without a jobId also requires operator verification in Flink UI;
-          // it must not be converted into a definite failure by the reconciler.
           if (!"STARTING".equals(job.observedState())
               && !"STOPPING".equals(job.observedState())
               && !"UNKNOWN".equals(job.observedState())) {
@@ -490,7 +537,8 @@ public class RealtimeJobService {
           continue;
         }
         try {
-          RuntimeStatus runtime = gateway.status(deployment.engineJobId());
+          RuntimeStatus runtime =
+              gateway.status(deploymentRuntime(job.id(), deployment), deployment.engineJobId());
           consecutiveEngineFailures.remove(job.id());
           reconcile(job, deployment, runtime);
         } catch (RealtimeEngineException exception) {
@@ -518,7 +566,11 @@ public class RealtimeJobService {
       DefinitionRow definition =
           store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
       DeploymentRow deployment = latestDeploymentWithJobId(id);
-      reconcile(definition, deployment, gateway.status(deployment.engineJobId()));
+      ComputeEnvironmentSnapshot runtimeEnvironment = runtimeResolver.deployment(definition, deployment);
+      reconcile(
+          definition,
+          deployment,
+          gateway.status(runtimeEnvironment, deployment.engineJobId()));
       consecutiveEngineFailures.remove(id);
       return store.view(id);
     } finally {
@@ -540,7 +592,7 @@ public class RealtimeJobService {
         changeState(job, deployment, "RUNNING", "RUNNING", runtime.jobId(), null);
       } else {
         try {
-          gateway.stop(expectedJobId);
+          gateway.stop(deploymentRuntime(job.id(), deployment), expectedJobId);
         } catch (RealtimeEngineException ignored) {
           changeState(job, deployment, "UNKNOWN", "UNKNOWN", runtime.jobId(), "停止状态对账失败");
         }
@@ -615,14 +667,15 @@ public class RealtimeJobService {
     }
     CdcPipelineSpec spec = store.spec(definition);
     specValidator.validate(spec);
+    ComputeEnvironmentSnapshot runtimeEnvironment = runtimeResolver.definition(definition, true);
     ResolvedCdcPipeline resolved = dataSourceResolver.resolve(spec);
-    JsonNode manifest = gateway.capabilities();
+    JsonNode manifest = gateway.capabilities(runtimeEnvironment);
     capabilityResolver.requireSupported(manifest, resolved, spec);
     return new Prepared(
         definition,
         spec,
         compiler.compile(definition.name(), spec, resolved),
-        manifest.path("runtimeVersion").asText("unknown"),
+        runtimeEnvironment,
         manifest);
   }
 
@@ -636,15 +689,17 @@ public class RealtimeJobService {
 
   private void requirePreparedDefinitionCurrent(Prepared prepared, DefinitionRow current) {
     DefinitionRow snapshot = prepared.definition();
+    Long currentRuntimeEnvironmentId = store.runtimeEnvironmentId(current.id());
     if (snapshot.definitionVersion() != current.definitionVersion()
-        || !Objects.equals(snapshot.configDigest(), current.configDigest())) {
+        || !Objects.equals(snapshot.configDigest(), current.configDigest())
+        || !Objects.equals(prepared.runtimeEnvironment().id(), currentRuntimeEnvironmentId)) {
       throw new IllegalStateException("任务定义在校验期间已变化，请刷新后重试");
     }
   }
 
-  private void waitForRuntimeStop(String jobId) {
+  private void waitForRuntimeStop(ComputeEnvironmentSnapshot runtimeEnvironment, String jobId) {
     for (int attempt = 0; attempt < 20; attempt++) {
-      RuntimeStatus status = gateway.status(jobId);
+      RuntimeStatus status = gateway.status(runtimeEnvironment, jobId);
       if (status.state() == RuntimeStatus.State.TERMINATED
           || status.state() == RuntimeStatus.State.NONE) {
         return;
@@ -730,7 +785,7 @@ public class RealtimeJobService {
     try (RealtimeDeployRequest request =
         new RealtimeDeployRequest(
             prepared.compiled().yaml(), key, credentials[0], credentials[1])) {
-      return gateway.deploy(request);
+      return gateway.deploy(prepared.runtimeEnvironment(), request);
     }
   }
 
@@ -739,6 +794,28 @@ public class RealtimeJobService {
         store.latestDeployment(id).orElseThrow(() -> new IllegalStateException("任务尚无部署记录"));
     requireEngineJobId(deployment);
     return deployment;
+  }
+
+  private ComputeEnvironmentSnapshot deploymentRuntime(long id, DeploymentRow deployment) {
+    if (deployment == null) {
+      throw new IllegalStateException("任务尚无部署记录");
+    }
+    DefinitionRow definition =
+        store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+    return runtimeResolver.deployment(definition, deployment);
+  }
+
+  private long resolveDefinitionEnvironmentId(Long id, Long requestedRuntimeEnvironmentId) {
+    if (requestedRuntimeEnvironmentId != null) {
+      return requestedRuntimeEnvironmentId;
+    }
+    if (id != null) {
+      Long current = store.runtimeEnvironmentId(id);
+      if (current != null) {
+        return current;
+      }
+    }
+    return runtimeResolver.defaultEnvironmentId();
   }
 
   private void requireEngineJobId(DeploymentRow deployment) {
@@ -751,6 +828,10 @@ public class RealtimeJobService {
     if (!StringUtils.hasText(name) || name.trim().length() > 200) {
       throw new IllegalArgumentException("任务名称不能为空且不能超过 200 个字符");
     }
+  }
+
+  private String definitionDigest(CdcPipelineSpec spec, long runtimeEnvironmentId) {
+    return digest(write(spec) + "\n@runtime-environment:" + runtimeEnvironmentId);
   }
 
   private String write(Object value) {
@@ -775,7 +856,7 @@ public class RealtimeJobService {
       DefinitionRow definition,
       CdcPipelineSpec spec,
       CompiledPipeline compiled,
-      String runtimeRevision,
+      ComputeEnvironmentSnapshot runtimeEnvironment,
       JsonNode manifest) {}
 
   private record StartReservation(long deploymentId, boolean created) {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityService.java
@@ -1,9 +1,11 @@
 package io.yak.ops.business.sync.realtime.service;
 
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.RuntimeLog;
 import io.yak.ops.business.sync.realtime.engine.FlinkObservabilityClient;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -13,40 +15,50 @@ import org.springframework.util.StringUtils;
 public class RealtimeObservabilityService {
 
   private final RealtimeJobStore store;
+  private final RealtimeRuntimeResolver runtimeResolver;
   private final FlinkObservabilityClient flink;
 
-  public RealtimeObservabilityService(RealtimeJobStore store, FlinkObservabilityClient flink) {
+  public RealtimeObservabilityService(
+      RealtimeJobStore store,
+      RealtimeRuntimeResolver runtimeResolver,
+      FlinkObservabilityClient flink) {
     this.store = store;
+    this.runtimeResolver = runtimeResolver;
     this.flink = flink;
   }
 
   public RealtimeObservabilityView snapshot(long definitionId) {
-    return flink.snapshot(requireJobId(definitionId));
+    DeploymentTarget target = requireTarget(definitionId, true);
+    return flink.snapshot(target.environment(), target.deployment().engineJobId());
   }
 
   public String submissionLog(long definitionId, int tailLines) {
-    DeploymentRow deployment = requireDeployment(definitionId);
+    DeploymentRow deployment = requireTarget(definitionId, false).deployment();
     return flink.submissionLog(deployment.idempotencyKey(), tailLines);
   }
 
   public RuntimeLog runtimeLog(long definitionId, int maxExceptions) {
-    return flink.runtimeLog(requireJobId(definitionId), maxExceptions);
+    DeploymentTarget target = requireTarget(definitionId, true);
+    return flink.runtimeLog(
+        target.environment(), target.deployment().engineJobId(), maxExceptions);
   }
 
-  private String requireJobId(long definitionId) {
-    DeploymentRow deployment = requireDeployment(definitionId);
-    if (!StringUtils.hasText(deployment.engineJobId())) {
+  private DeploymentTarget requireTarget(long definitionId, boolean requireJobId) {
+    DefinitionRow definition =
+        store
+            .definition(definitionId)
+            .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + definitionId));
+    DeploymentRow deployment =
+        store
+            .latestDeployment(definitionId)
+            .orElseThrow(() -> new IllegalStateException("任务尚无部署记录"));
+    if (requireJobId && !StringUtils.hasText(deployment.engineJobId())) {
       throw new IllegalStateException("部署记录尚无 Flink jobId，请先执行状态对账");
     }
-    return deployment.engineJobId();
+    return new DeploymentTarget(
+        deployment, runtimeResolver.deployment(definition, deployment));
   }
 
-  private DeploymentRow requireDeployment(long definitionId) {
-    store
-        .definition(definitionId)
-        .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + definitionId));
-    return store
-        .latestDeployment(definitionId)
-        .orElseThrow(() -> new IllegalStateException("任务尚无部署记录"));
-  }
+  private record DeploymentTarget(
+      DeploymentRow deployment, ComputeEnvironmentSnapshot environment) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeRuntimeResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeRuntimeResolver.java
@@ -1,0 +1,58 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import org.springframework.stereotype.Service;
+
+/** Resolves the mutable task binding and the immutable deployment runtime snapshot. */
+@Service
+public class RealtimeRuntimeResolver {
+
+  private final ComputeEnvironmentStore environments;
+  private final RealtimeJobStore jobs;
+
+  public RealtimeRuntimeResolver(ComputeEnvironmentStore environments, RealtimeJobStore jobs) {
+    this.environments = environments;
+    this.jobs = jobs;
+  }
+
+  public long defaultEnvironmentId() {
+    return environments
+        .defaultEnvironment()
+        .orElseThrow(() -> new IllegalStateException("请先在设置 → 计算引擎中配置默认运行环境"))
+        .id();
+  }
+
+  public ComputeEnvironmentSnapshot environment(long environmentId, boolean requireEnabled) {
+    ComputeEnvironment environment =
+        environments
+            .find(environmentId)
+            .orElseThrow(() -> new IllegalArgumentException("运行环境不存在：" + environmentId));
+    if (requireEnabled && !environment.enabled()) {
+      throw new IllegalStateException("运行环境已停用，请切换到已启用的运行环境：" + environment.name());
+    }
+    return ComputeEnvironmentSnapshot.from(environment);
+  }
+
+  public ComputeEnvironmentSnapshot definition(DefinitionRow definition, boolean requireEnabled) {
+    Long environmentId = jobs.runtimeEnvironmentId(definition.id());
+    if (environmentId == null) {
+      environmentId = defaultEnvironmentId();
+    }
+    return environment(environmentId, requireEnabled);
+  }
+
+  public ComputeEnvironmentSnapshot deployment(
+      DefinitionRow definition, DeploymentRow deployment) {
+    ComputeEnvironmentSnapshot snapshot = jobs.deploymentEnvironment(deployment.id()).orElse(null);
+    if (snapshot != null) {
+      return snapshot;
+    }
+    // Compatibility fallback for deployments created before V7. New deployments always snapshot.
+    return definition(definition, false);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V7__bind_jobs_to_compute_environment.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V7__bind_jobs_to_compute_environment.sql
@@ -1,0 +1,11 @@
+ALTER TABLE yak_realtime_job_definition
+  ADD COLUMN runtime_environment_id BIGINT NULL AFTER description,
+  ADD KEY idx_realtime_definition_environment (runtime_environment_id),
+  ADD CONSTRAINT fk_realtime_definition_environment
+    FOREIGN KEY (runtime_environment_id) REFERENCES yak_compute_environment(id) ON DELETE RESTRICT;
+
+ALTER TABLE yak_realtime_job_deployment
+  ADD COLUMN runtime_environment_id BIGINT NULL AFTER definition_version,
+  ADD COLUMN runtime_environment_version INT NULL AFTER runtime_environment_id,
+  ADD COLUMN runtime_environment_snapshot_json LONGTEXT NULL AFTER runtime_environment_version,
+  ADD KEY idx_realtime_deployment_environment (runtime_environment_id);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
 import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
@@ -34,7 +37,9 @@ class RealtimeJobLifecycleCoordinatorTest {
   private RealtimeRuntimeIdentityStore identityStore;
   private FlinkJobDiscoveryClient discovery;
   private RealtimeEngineGateway gateway;
+  private RealtimeRuntimeResolver runtimeResolver;
   private RealtimeJobLifecycleCoordinator coordinator;
+  private ComputeEnvironmentSnapshot environment;
 
   @BeforeEach
   void setUp() {
@@ -42,6 +47,18 @@ class RealtimeJobLifecycleCoordinatorTest {
     identityStore = mock(RealtimeRuntimeIdentityStore.class);
     discovery = mock(FlinkJobDiscoveryClient.class);
     gateway = mock(RealtimeEngineGateway.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    environment =
+        new ComputeEnvironmentSnapshot(
+            3L,
+            "test-env",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://127.0.0.1:8081", "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
+            2);
+    when(runtimeResolver.deployment(any(), any())).thenReturn(environment);
     PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
     when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
     RealtimeSyncProperties properties = new RealtimeSyncProperties();
@@ -52,6 +69,7 @@ class RealtimeJobLifecycleCoordinatorTest {
             identityStore,
             discovery,
             gateway,
+            runtimeResolver,
             new RealtimeStateMachine(),
             properties,
             10,
@@ -66,8 +84,8 @@ class RealtimeJobLifecycleCoordinatorTest {
     when(store.lockDefinition(JOB_ID)).thenReturn(definition);
     when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
     when(identityStore.findByDeploymentId(DEPLOYMENT_ID)).thenReturn(Optional.of("yak-rt-test"));
-    when(discovery.findJobIds("yak-rt-test")).thenReturn(List.of(FLINK_JOB_ID));
-    when(gateway.status(FLINK_JOB_ID))
+    when(discovery.findJobIds(environment, "yak-rt-test")).thenReturn(List.of(FLINK_JOB_ID));
+    when(gateway.status(environment, FLINK_JOB_ID))
         .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
 
     coordinator.reconcile(JOB_ID);
@@ -89,13 +107,12 @@ class RealtimeJobLifecycleCoordinatorTest {
   @Test
   void confirmsStoppedOnlyAfterRecoveryWindowAndNoMatchingFlinkJob() {
     DefinitionRow definition = definition("STOPPED", "STOPPING");
-    DeploymentRow deployment =
-        deployment(null, "UNKNOWN", LocalDateTime.now().minusMinutes(5));
+    DeploymentRow deployment = deployment(null, "UNKNOWN", LocalDateTime.now().minusMinutes(5));
     when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
     when(store.lockDefinition(JOB_ID)).thenReturn(definition);
     when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
     when(identityStore.findByDeploymentId(DEPLOYMENT_ID)).thenReturn(Optional.of("yak-rt-test"));
-    when(discovery.findJobIds("yak-rt-test")).thenReturn(List.of());
+    when(discovery.findJobIds(environment, "yak-rt-test")).thenReturn(List.of());
 
     coordinator.reconcile(JOB_ID);
 
@@ -117,7 +134,7 @@ class RealtimeJobLifecycleCoordinatorTest {
     when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
     when(store.lockDefinition(JOB_ID)).thenReturn(definition);
     when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
-    when(gateway.status(FLINK_JOB_ID))
+    when(gateway.status(environment, FLINK_JOB_ID))
         .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.UNKNOWN));
 
     coordinator.reconcile(JOB_ID);
@@ -140,7 +157,7 @@ class RealtimeJobLifecycleCoordinatorTest {
     DeploymentRow deployment = deployment(FLINK_JOB_ID, "FAILED", LocalDateTime.now());
     when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
     when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
-    when(gateway.status(FLINK_JOB_ID))
+    when(gateway.status(environment, FLINK_JOB_ID))
         .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
 
     assertThatThrownBy(() -> coordinator.assertSafeToDelete(JOB_ID))
@@ -165,8 +182,7 @@ class RealtimeJobLifecycleCoordinatorTest {
         null);
   }
 
-  private DeploymentRow deployment(
-      String engineJobId, String status, LocalDateTime createTime) {
+  private DeploymentRow deployment(String engineJobId, String status, LocalDateTime createTime) {
     return new DeploymentRow(
         DEPLOYMENT_ID,
         JOB_ID,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
@@ -20,6 +20,9 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.SchemaEvolution;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.SinkTuning;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.TableRoute;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
@@ -52,9 +55,11 @@ class RealtimeJobServiceConcurrencyTest {
   private RealtimeConnectorCapabilityResolver capabilityResolver;
   private PipelineYamlCompiler compiler;
   private RealtimeEngineGateway gateway;
+  private RealtimeRuntimeResolver runtimeResolver;
   private RealtimeJobService service;
   private CdcPipelineSpec spec;
   private DefinitionRow stopped;
+  private ComputeEnvironmentSnapshot environment;
 
   @BeforeEach
   void setUp() {
@@ -64,14 +69,29 @@ class RealtimeJobServiceConcurrencyTest {
     capabilityResolver = mock(RealtimeConnectorCapabilityResolver.class);
     compiler = mock(PipelineYamlCompiler.class);
     gateway = mock(RealtimeEngineGateway.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
     RealtimeLogRedactor logRedactor = mock(RealtimeLogRedactor.class);
     PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
     when(transactionManager.getTransaction(any())).thenAnswer(ignored -> new SimpleTransactionStatus());
 
     ObjectMapper json = new ObjectMapper();
-    ObjectNode capabilities = json.createObjectNode().put("runtimeVersion", "3.6.0");
-    when(gateway.capabilities()).thenReturn(capabilities);
-    when(gateway.validate(any())).thenReturn(new ValidationResult(true, "exactly-once"));
+    ObjectNode capabilities = json.createObjectNode().put("runtimeVersion", "flink-cdc-cli-3.6.0");
+    environment =
+        new ComputeEnvironmentSnapshot(
+            3L,
+            "test-env",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://127.0.0.1:8081", "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
+            2);
+    when(runtimeResolver.definition(any(), eq(true))).thenReturn(environment);
+    when(runtimeResolver.deployment(any(), any())).thenReturn(environment);
+    when(runtimeResolver.environment(anyLong(), eq(true))).thenReturn(environment);
+    when(runtimeResolver.defaultEnvironmentId()).thenReturn(environment.id());
+    when(gateway.capabilities(environment)).thenReturn(capabilities);
+    when(gateway.validate(eq(environment), any())).thenReturn(new ValidationResult(true, "exactly-once"));
     when(compiler.compile(any(), any(), any())).thenReturn(new CompiledPipeline("pipeline: test", "test"));
 
     spec =
@@ -87,6 +107,7 @@ class RealtimeJobServiceConcurrencyTest {
             new SinkTuning(0, 100, 1000, 1024, 16, true));
     stopped = definition("STOPPED", "STOPPED");
     when(store.spec(any())).thenReturn(spec);
+    when(store.runtimeEnvironmentId(JOB_ID)).thenReturn(environment.id());
 
     service =
         new RealtimeJobService(
@@ -99,6 +120,7 @@ class RealtimeJobServiceConcurrencyTest {
             compiler,
             gateway,
             logRedactor,
+            runtimeResolver,
             new RealtimeSyncProperties(),
             transactionManager);
   }
@@ -113,8 +135,8 @@ class RealtimeJobServiceConcurrencyTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("请勿重复启动");
 
-    verify(store, never()).insertDeployment(any(), any(), any(), any(), any());
-    verify(gateway, never()).deploy(any());
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
   }
 
   @Test
@@ -125,7 +147,7 @@ class RealtimeJobServiceConcurrencyTest {
     when(store.deploymentByIdempotencyKey("restart-safe")).thenReturn(Optional.empty());
     when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
     when(store.lockDefinition(JOB_ID)).thenReturn(stopped, stopping, stopping);
-    when(store.insertDeployment(any(), any(), any(), any(), eq("restart-safe")))
+    when(store.insertDeployment(any(), any(), any(), any(), eq(environment), eq("restart-safe")))
         .thenReturn(DEPLOYMENT_ID);
     when(dataSourceResolver.resolveCredentials(spec))
         .thenReturn(
@@ -133,8 +155,9 @@ class RealtimeJobServiceConcurrencyTest {
               new CredentialBinding("source", "secret"),
               new CredentialBinding("sink", "secret")
             });
-    when(gateway.deploy(any())).thenReturn(new DeployResult("job-123", "exactly-once"));
-    when(gateway.status("job-123"))
+    when(gateway.deploy(eq(environment), any()))
+        .thenReturn(new DeployResult("job-123", "exactly-once"));
+    when(gateway.status(environment, "job-123"))
         .thenReturn(
             new RuntimeStatus("job-123", RuntimeStatus.State.RUNNING),
             new RuntimeStatus("job-123", RuntimeStatus.State.TERMINATED));
@@ -143,8 +166,10 @@ class RealtimeJobServiceConcurrencyTest {
     assertThatCode(() -> service.start(JOB_ID, "restart-safe")).doesNotThrowAnyException();
 
     verify(store, never()).markDeploymentRunning(anyLong(), anyLong(), any(), any());
-    verify(store).bindDeploymentForStop(DEPLOYMENT_ID, "job-123", "3.6.0");
-    verify(gateway).stop("job-123");
+    verify(store)
+        .bindDeploymentForStop(
+            DEPLOYMENT_ID, "job-123", "flink-cdc-cli-3.6.0@env-3-v2");
+    verify(gateway).stop(environment, "job-123");
     verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", "job-123", null);
   }
 
@@ -175,7 +200,7 @@ class RealtimeJobServiceConcurrencyTest {
         "digest",
         "restart-safe",
         engineJobId,
-        "3.6.0",
+        "flink-cdc-cli-3.6.0@env-3-v2",
         status,
         false,
         null,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeObservabilityServiceTest.java
@@ -2,10 +2,14 @@ package io.yak.ops.business.sync.realtime.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.engine.FlinkObservabilityClient;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
@@ -20,13 +24,27 @@ class RealtimeObservabilityServiceTest {
   private static final long JOB_ID = 7L;
   private RealtimeJobStore store;
   private FlinkObservabilityClient flink;
+  private RealtimeRuntimeResolver runtimeResolver;
   private RealtimeObservabilityService service;
+  private ComputeEnvironmentSnapshot environment;
 
   @BeforeEach
   void setUp() {
     store = mock(RealtimeJobStore.class);
     flink = mock(FlinkObservabilityClient.class);
-    service = new RealtimeObservabilityService(store, flink);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    environment =
+        new ComputeEnvironmentSnapshot(
+            3L,
+            "test-env",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://127.0.0.1:8081", "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
+            2);
+    when(runtimeResolver.deployment(any(), any())).thenReturn(environment);
+    service = new RealtimeObservabilityService(store, runtimeResolver, flink);
     when(store.definition(JOB_ID)).thenReturn(Optional.of(definition()));
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeRuntimeResolverTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeRuntimeResolverTest.java
@@ -1,0 +1,137 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RealtimeRuntimeResolverTest {
+
+  private static final long JOB_ID = 7L;
+  private static final long DEPLOYMENT_ID = 19L;
+
+  private ComputeEnvironmentStore environments;
+  private RealtimeJobStore jobs;
+  private RealtimeRuntimeResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    environments = mock(ComputeEnvironmentStore.class);
+    jobs = mock(RealtimeJobStore.class);
+    resolver = new RealtimeRuntimeResolver(environments, jobs);
+  }
+
+  @Test
+  void deploymentUsesPersistedSnapshotEvenAfterEnvironmentChanges() {
+    ComputeEnvironmentSnapshot deployed =
+        snapshot(3L, "prod-a", "http://flink-a:8081", 2);
+    when(jobs.deploymentEnvironment(DEPLOYMENT_ID)).thenReturn(Optional.of(deployed));
+
+    // The mutable environment can move on to another version/endpoint after this deployment.
+    when(environments.find(3L))
+        .thenReturn(Optional.of(environment(3L, "prod-a", "http://flink-b:8081", 9, true)));
+
+    ComputeEnvironmentSnapshot resolved = resolver.deployment(definition(), deployment());
+
+    assertThat(resolved).isEqualTo(deployed);
+    assertThat(resolved.config().restUrl()).isEqualTo("http://flink-a:8081");
+    assertThat(resolved.version()).isEqualTo(2);
+  }
+
+  @Test
+  void definitionRefusesDisabledEnvironmentForNewDeployment() {
+    when(jobs.runtimeEnvironmentId(JOB_ID)).thenReturn(5L);
+    when(environments.find(5L))
+        .thenReturn(Optional.of(environment(5L, "disabled", "http://flink:8081", 1, false)));
+
+    assertThatThrownBy(() -> resolver.definition(definition(), true))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("已停用");
+  }
+
+  @Test
+  void definitionFallsBackToDefaultForLegacyUnboundTask() {
+    ComputeEnvironment fallback = environment(8L, "default", "http://flink:8081", 4, true);
+    when(jobs.runtimeEnvironmentId(JOB_ID)).thenReturn(null);
+    when(environments.defaultEnvironment()).thenReturn(Optional.of(fallback));
+    when(environments.find(8L)).thenReturn(Optional.of(fallback));
+
+    assertThat(resolver.definition(definition(), true).id()).isEqualTo(8L);
+  }
+
+  private ComputeEnvironment environment(
+      long id, String name, String restUrl, int version, boolean enabled) {
+    LocalDateTime now = LocalDateTime.now();
+    return new ComputeEnvironment(
+        id,
+        name,
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(restUrl, "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
+        enabled,
+        false,
+        version,
+        now,
+        now);
+  }
+
+  private ComputeEnvironmentSnapshot snapshot(
+      long id, String name, String restUrl, int version) {
+    return new ComputeEnvironmentSnapshot(
+        id,
+        name,
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(restUrl, "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
+        version);
+  }
+
+  private DefinitionRow definition() {
+    return new DefinitionRow(
+        JOB_ID,
+        "test-job",
+        null,
+        "{}",
+        "PUBLISHED",
+        "RUNNING",
+        "RUNNING",
+        1,
+        1,
+        "digest",
+        null,
+        null,
+        null);
+  }
+
+  private DeploymentRow deployment() {
+    return new DeploymentRow(
+        DEPLOYMENT_ID,
+        JOB_ID,
+        1,
+        "{}",
+        "summary",
+        "digest",
+        "key",
+        "0123456789abcdef0123456789abcdef",
+        "flink-cdc-cli-3.6.0@env-3-v2",
+        "RUNNING",
+        false,
+        null,
+        null,
+        null);
+  }
+}

--- a/yak-ops-ui/src/pages/realtime-sync/CreateRealtimeTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/CreateRealtimeTaskDrawer.tsx
@@ -1,25 +1,67 @@
 import { ArrowRightOutlined } from '@ant-design/icons';
 import { history } from '@umijs/max';
-import { Button, Drawer, Form, Input, message, Select } from 'antd';
-import { useEffect, useRef, useState } from 'react';
+import { Button, Drawer, Form, Input, message, Select, Spin } from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { realtimeApi } from './api';
+import type { ComputeEnvironmentOption } from './types';
 
 interface Values {
   sourceType: string;
   sinkType: string;
   name: string;
   description?: string;
+  runtimeEnvironmentId: number;
 }
+
+const preferredEnvironmentId = (environments: ComputeEnvironmentOption[]) =>
+  environments.find((item) => item.defaultEnvironment && item.enabled)?.id ??
+  environments.find((item) => item.enabled)?.id;
 
 export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [form] = Form.useForm<Values>();
   const [submitting, setSubmitting] = useState(false);
+  const [environmentLoading, setEnvironmentLoading] = useState(false);
+  const [environments, setEnvironments] = useState<ComputeEnvironmentOption[]>([]);
   const automaticName = useRef('');
+
+  const environmentOptions = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.id,
+        disabled: !environment.enabled,
+        label: `${environment.name}${environment.defaultEnvironment ? ' · 默认' : ''} · Flink ${environment.config.flinkVersion} / CDC ${environment.config.flinkCdcVersion}${environment.enabled ? '' : ' · 已停用'}`,
+      })),
+    [environments],
+  );
 
   useEffect(() => {
     if (!open) return;
     automaticName.current = 'MYSQL → MYSQL 实时同步';
     form.setFieldsValue({ sourceType: 'MYSQL', sinkType: 'MYSQL', name: automaticName.current });
+
+    let cancelled = false;
+    const loadEnvironments = async () => {
+      setEnvironmentLoading(true);
+      try {
+        const response = await realtimeApi.environments();
+        if (cancelled) return;
+        const rows = response.data || [];
+        setEnvironments(rows);
+        const defaultId = preferredEnvironmentId(rows);
+        if (defaultId) form.setFieldValue('runtimeEnvironmentId', defaultId);
+      } catch (error: any) {
+        if (!cancelled) {
+          setEnvironments([]);
+          message.error(error?.message || '运行环境加载失败');
+        }
+      } finally {
+        if (!cancelled) setEnvironmentLoading(false);
+      }
+    };
+    void loadEnvironments();
+    return () => {
+      cancelled = true;
+    };
   }, [form, open]);
 
   const updateName = (source: string, sink: string) => {
@@ -32,10 +74,18 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
   const submit = async () => {
     try {
       const values = await form.validateFields();
+      const environment = environments.find(
+        (item) => item.id === Number(values.runtimeEnvironmentId),
+      );
+      if (!environment || !environment.enabled) {
+        message.error('请选择已启用的运行环境');
+        return;
+      }
       setSubmitting(true);
       const response = await realtimeApi.createBasic({
         name: values.name.trim(),
         description: values.description?.trim(),
+        runtimeEnvironmentId: Number(values.runtimeEnvironmentId),
       });
       message.success('基础任务已创建，请继续完成同步配置');
       form.resetFields();
@@ -68,7 +118,7 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
       styles={{ header: { padding: '18px 24px' }, body: { padding: 24 } }}
     >
       <Form form={form} layout="vertical" requiredMark="optional">
-        <div className="grid grid-cols-[1fr_32px_1fr] items-end gap-3 mb-6">
+        <div className="mb-6 grid grid-cols-[1fr_32px_1fr] items-end gap-3">
           <Form.Item name="sourceType" label="来源类型" rules={[{ required: true }]} className="!mb-0">
             <Select
               variant="filled"
@@ -90,6 +140,27 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
             />
           </Form.Item>
         </div>
+
+        <Form.Item
+          name="runtimeEnvironmentId"
+          label="运行环境"
+          rules={[{ required: true, message: '请选择运行环境' }]}
+          extra="任务会绑定该环境；每次启动都会保存环境快照，后续切换默认环境不会影响已运行任务。"
+        >
+          <Select
+            showSearch
+            optionFilterProp="label"
+            variant="filled"
+            loading={environmentLoading}
+            disabled={environmentLoading}
+            placeholder="请选择 Flink CDC 运行环境"
+            options={environmentOptions}
+            notFoundContent={
+              environmentLoading ? <Spin size="small" /> : '请先到 设置 → 计算引擎 创建运行环境'
+            }
+          />
+        </Form.Item>
+
         <Form.Item name="name" label="任务名称" rules={[{ required: true, message: '请输入任务名称' }, { max: 200 }]}>
           <Input autoFocus variant="filled" maxLength={200} showCount />
         </Form.Item>
@@ -103,7 +174,7 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
           />
         </Form.Item>
         <div className="rounded-lg bg-[#f9fafb] p-4 text-sm text-[#667085]">
-          数据源、同步表和运行参数将在任务详情页配置；实时同步无需配置调度。
+          数据源、同步表和其他运行参数将在任务详情页配置；实时同步无需配置调度。
         </div>
       </Form>
     </Drawer>

--- a/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/JobEditor.tsx
@@ -16,7 +16,12 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { BRAND_THEME } from '@/styles/brand';
 import { realtimeApi } from './api';
-import type { CdcPipelineSpec, DataSourceOption, RealtimeJob } from './types';
+import type {
+  CdcPipelineSpec,
+  ComputeEnvironmentOption,
+  DataSourceOption,
+  RealtimeJob,
+} from './types';
 
 interface RouteFormValue {
   sourceTable: string;
@@ -27,12 +32,14 @@ interface RouteFormValue {
 interface FormValue extends Omit<CdcPipelineSpec, 'tables'> {
   name: string;
   description?: string;
+  runtimeEnvironmentId: number;
   tables: RouteFormValue[];
 }
 
 const defaults: FormValue = {
   name: '',
   description: '',
+  runtimeEnvironmentId: undefined as unknown as number,
   sourceDataSourceRef: undefined as unknown as number,
   sinkDataSourceRef: undefined as unknown as number,
   tables: [{ sourceTable: '', sinkTable: '', matchMode: 'EXACT', keyColumnsText: 'id' }],
@@ -62,15 +69,33 @@ type SectionKey = (typeof sections)[number]['key'];
 const SECTION_SCROLL_OFFSET = 24;
 const ACTIVE_SECTION_OFFSET = SECTION_SCROLL_OFFSET + 8;
 
-const toFormValue = (job?: RealtimeJob): FormValue =>
+const defaultEnvironmentId = (environments: ComputeEnvironmentOption[]) =>
+  environments.find((item) => item.defaultEnvironment && item.enabled)?.id ??
+  environments.find((item) => item.enabled)?.id;
+
+const toFormValue = (
+  job: RealtimeJob | undefined,
+  environments: ComputeEnvironmentOption[],
+): FormValue =>
   job?.spec
     ? {
         name: job.name,
         description: job.description,
+        runtimeEnvironmentId:
+          job.runtimeEnvironmentId ?? (defaultEnvironmentId(environments) as number),
         ...job.spec,
-        tables: job.spec.tables.map((route) => ({ ...route, keyColumnsText: route.keyColumns.join(',') })),
+        tables: job.spec.tables.map((route) => ({
+          ...route,
+          keyColumnsText: route.keyColumns.join(','),
+        })),
       }
-    : { ...defaults, name: job?.name || '', description: job?.description || '' };
+    : {
+        ...defaults,
+        name: job?.name || '',
+        description: job?.description || '',
+        runtimeEnvironmentId:
+          job?.runtimeEnvironmentId ?? (defaultEnvironmentId(environments) as number),
+      };
 
 const Card = ({ id, title, children }: { id: SectionKey; title: string; children: React.ReactNode }) => (
   <section id={id} className="scroll-mt-6 rounded-xl bg-white px-7 py-6">
@@ -83,12 +108,14 @@ export default function JobEditor({
   open,
   job,
   dataSources,
+  environments,
   onClose,
   onSaved,
 }: {
   open: boolean;
   job?: RealtimeJob;
   dataSources: DataSourceOption[];
+  environments: ComputeEnvironmentOption[];
   onClose: () => void;
   onSaved: () => void;
 }) {
@@ -97,15 +124,27 @@ export default function JobEditor({
   const [active, setActive] = useState<SectionKey>('task-basic');
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollingToRef = useRef<SectionKey | null>(null);
-  const sourceOptions = useMemo(() => dataSources.filter((item) => item.dbType === 'MYSQL'), [dataSources]);
+  const sourceOptions = useMemo(
+    () => dataSources.filter((item) => item.dbType === 'MYSQL'),
+    [dataSources],
+  );
   const sinkOptions = useMemo(
     () => dataSources.filter((item) => ['MYSQL', 'POSTGRE_SQL', 'POSTGRESQL'].includes(item.dbType)),
     [dataSources],
   );
+  const environmentOptions = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.id,
+        disabled: !environment.enabled,
+        label: `${environment.name}${environment.defaultEnvironment ? ' · 默认' : ''} · Flink ${environment.config.flinkVersion} / CDC ${environment.config.flinkCdcVersion}${environment.enabled ? '' : ' · 已停用'}`,
+      })),
+    [environments],
+  );
 
   useEffect(() => {
-    if (open) form.setFieldsValue(toFormValue(job));
-  }, [form, job, open]);
+    if (open) form.setFieldsValue(toFormValue(job, environments));
+  }, [environments, form, job, open]);
   useEffect(() => {
     if (!open) return;
     const root = scrollContainerRef.current;
@@ -180,7 +219,12 @@ export default function JobEditor({
         sink: { ...values.sink, strictReplaySafety: true },
       };
       setSaving(true);
-      const payload = { name: values.name.trim(), description: values.description?.trim(), spec };
+      const payload = {
+        name: values.name.trim(),
+        description: values.description?.trim(),
+        runtimeEnvironmentId: Number(values.runtimeEnvironmentId),
+        spec,
+      };
       if (job) await realtimeApi.update(job.id, payload);
       else await realtimeApi.create(payload);
       message.success('实时同步草稿已保存');
@@ -193,7 +237,10 @@ export default function JobEditor({
   };
 
   if (!open) return null;
-  const option = (item: DataSourceOption) => ({ label: `${item.label} (${item.dbType})`, value: Number(item.value) });
+  const option = (item: DataSourceOption) => ({
+    label: `${item.label} (${item.dbType})`,
+    value: Number(item.value),
+  });
   return (
     <ConfigProvider theme={BRAND_THEME} variant="filled">
       <div ref={scrollContainerRef} className="h-[calc(100vh-64px)] overflow-y-auto bg-[#f7f8fa] text-[#161823]">
@@ -323,6 +370,35 @@ export default function JobEditor({
               </Card>
 
               <Card id="runtime-params" title="运行参数">
+                <div className="mb-5 rounded-xl border border-[#e4e7ec] bg-[#fcfcfd] p-5">
+                  <Form.Item
+                    name="runtimeEnvironmentId"
+                    label="运行环境"
+                    rules={[
+                      { required: true, message: '请选择运行环境' },
+                      {
+                        validator: async (_, value) => {
+                          const environment = environments.find((item) => item.id === Number(value));
+                          if (!environment) throw new Error('运行环境不存在，请刷新后重试');
+                          if (!environment.enabled) throw new Error('当前运行环境已停用，请切换运行环境');
+                        },
+                      },
+                    ]}
+                    className="!mb-2"
+                  >
+                    <Select
+                      showSearch
+                      optionFilterProp="label"
+                      placeholder="请选择 Flink CDC 运行环境"
+                      options={environmentOptions}
+                      notFoundContent="请先到 设置 → 计算引擎 创建运行环境"
+                    />
+                  </Form.Item>
+                  <div className="text-[12px] leading-5 text-[#667085]">
+                    任务会显式绑定运行环境；每次启动都会固化一份环境快照。之后修改默认环境或环境配置，不会把已经运行的 Flink Job 重定向到其他集群。
+                  </div>
+                </div>
+
                 <Row gutter={16}>
                   <Col xs={24} md={8}>
                     <Form.Item name="startupMode" label="启动模式">

--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeRuntimeDetail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeRuntimeDetail.tsx
@@ -20,7 +20,6 @@ import type {
   RealtimeJob,
   RealtimeObservability,
   RealtimeRuntimeLog,
-  RuntimeCapabilities,
 } from './types';
 
 const ACTIVE_STATES = new Set(['STARTING', 'RUNNING', 'STOPPING', 'UNKNOWN']);
@@ -89,10 +88,9 @@ function CodeBlock({ children, empty }: { children?: string; empty: string }) {
 interface Props {
   job: RealtimeJob;
   events: RealtimeEvent[];
-  capabilities: RuntimeCapabilities;
 }
 
-export default function RealtimeRuntimeDetail({ job, events, capabilities }: Props) {
+export default function RealtimeRuntimeDetail({ job, events }: Props) {
   const [observability, setObservability] = useState<RealtimeObservability>();
   const [observabilityLoading, setObservabilityLoading] = useState(false);
   const [submissionLog, setSubmissionLog] = useState('');
@@ -101,6 +99,7 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
   const [runtimeLoading, setRuntimeLoading] = useState(false);
 
   const engineJobId = job.latestDeployment?.engineJobId;
+  const runtimeEnvironment = job.latestDeployment?.runtimeEnvironment;
   const hasDeployment = Boolean(job.latestDeployment);
   const canObserve = Boolean(engineJobId);
 
@@ -159,9 +158,10 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
 
   const flinkWebUrl = useMemo(() => {
     if (observability?.flinkWebUrl) return observability.flinkWebUrl;
-    if (!engineJobId || !capabilities.restUrl) return undefined;
-    return `${capabilities.restUrl.replace(/\/+$/, '')}/#/job/${engineJobId}/overview`;
-  }, [capabilities.restUrl, engineJobId, observability?.flinkWebUrl]);
+    const restUrl = runtimeEnvironment?.config.restUrl;
+    if (!engineJobId || !restUrl) return undefined;
+    return `${restUrl.replace(/\/+$/, '')}/#/job/${engineJobId}/overview`;
+  }, [engineJobId, observability?.flinkWebUrl, runtimeEnvironment?.config.restUrl]);
 
   const checkpoint = observability?.checkpoints;
   const latestCheckpoint = checkpoint?.latestCompleted;
@@ -220,6 +220,14 @@ export default function RealtimeRuntimeDetail({ job, events, capabilities }: Pro
           </Descriptions.Item>
           <Descriptions.Item label="运行意图">
             {job.desiredState} / {job.observedState}
+          </Descriptions.Item>
+          <Descriptions.Item label="运行环境">
+            {runtimeEnvironment
+              ? `${runtimeEnvironment.name} · env v${runtimeEnvironment.version}`
+              : `环境 #${job.runtimeEnvironmentId || '-'}`}
+          </Descriptions.Item>
+          <Descriptions.Item label="Flink REST">
+            {runtimeEnvironment?.config.restUrl || '-'}
           </Descriptions.Item>
           <Descriptions.Item label="Flink JobId">{engineJobId || '-'}</Descriptions.Item>
           <Descriptions.Item label="Flink CDC Revision">

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -2,6 +2,7 @@ import { request } from '@umijs/max';
 import type {
   ApiResponse,
   CdcPipelineSpec,
+  ComputeEnvironmentOption,
   DataSourceOption,
   RealtimeDeployment,
   RealtimeEvent,
@@ -24,17 +25,24 @@ export interface RealtimePageQuery {
   stateGroup?: 'RUNNING' | 'STOPPED' | 'ABNORMAL';
 }
 
+interface RealtimeDefinitionPayload {
+  name: string;
+  description?: string;
+  runtimeEnvironmentId: number;
+  spec: CdcPipelineSpec;
+}
+
 export const realtimeApi = {
   page: (params: RealtimePageQuery) =>
     request<ApiResponse<RealtimeJobPage>>(PREFIX, {
       params,
     }),
   detail: (id: number) => request<ApiResponse<RealtimeJob>>(`${PREFIX}/${id}`),
-  createBasic: (payload: { name: string; description?: string }) =>
+  createBasic: (payload: { name: string; description?: string; runtimeEnvironmentId?: number }) =>
     request<ApiResponse<number>>(PREFIX, { method: 'POST', data: payload }),
-  create: (payload: { name: string; description?: string; spec: CdcPipelineSpec }) =>
+  create: (payload: RealtimeDefinitionPayload) =>
     request<ApiResponse<number>>(`${PREFIX}/draft`, { method: 'POST', data: payload }),
-  update: (id: number, payload: { name: string; description?: string; spec: CdcPipelineSpec }) =>
+  update: (id: number, payload: RealtimeDefinitionPayload) =>
     request<ApiResponse<number>>(`${PREFIX}/${id}`, { method: 'PUT', data: payload }),
   action: (id: number, action: 'publish' | 'validate' | 'start' | 'stop' | 'restart' | 'reconcile') =>
     request<ApiResponse<RealtimeDeployment | boolean>>(`${PREFIX}/${id}/${action}`, {
@@ -59,6 +67,11 @@ export const realtimeApi = {
     request<ApiResponse<{ logs: string }>>(`${PREFIX}/${id}/logs`, { params: { tail: 500 } }),
   checkpoints: (id: number) => request<ApiResponse<unknown>>(`${PREFIX}/${id}/checkpoints`),
   metrics: (id: number) => request<ApiResponse<unknown>>(`${PREFIX}/${id}/metrics`),
-  capabilities: () => request<ApiResponse<RuntimeCapabilities>>(`${PREFIX}/runtime/capabilities`),
+  capabilities: (environmentId?: number) =>
+    request<ApiResponse<RuntimeCapabilities>>(`${PREFIX}/runtime/capabilities`, {
+      params: environmentId ? { environmentId } : undefined,
+    }),
+  environments: () =>
+    request<ApiResponse<ComputeEnvironmentOption[]>>('/api/v1/compute-environments'),
   dataSources: () => request<ApiResponse<DataSourceOption[]>>('/api/v1/data-source/option'),
 };

--- a/yak-ops-ui/src/pages/realtime-sync/detail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/detail.tsx
@@ -3,17 +3,19 @@ import { message, Spin } from 'antd';
 import { useEffect, useState } from 'react';
 import { realtimeApi } from './api';
 import JobEditor from './JobEditor';
-import type { DataSourceOption, RealtimeJob } from './types';
+import type { ComputeEnvironmentOption, DataSourceOption, RealtimeJob } from './types';
 
 export default function RealtimeSyncDetail() {
   const { id } = useParams<{ id: string }>();
   const [job, setJob] = useState<RealtimeJob>();
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
+  const [environments, setEnvironments] = useState<ComputeEnvironmentOption[]>([]);
   useEffect(() => {
-    Promise.all([realtimeApi.detail(Number(id)), realtimeApi.dataSources()])
-      .then(([detail, sources]) => {
+    Promise.all([realtimeApi.detail(Number(id)), realtimeApi.dataSources(), realtimeApi.environments()])
+      .then(([detail, sources, runtimeEnvironments]) => {
         setJob(detail.data);
         setDataSources(sources.data || []);
+        setEnvironments(runtimeEnvironments.data || []);
       })
       .catch((error) => message.error(error?.message || '加载实时同步配置失败'));
   }, [id]);
@@ -28,6 +30,7 @@ export default function RealtimeSyncDetail() {
       open
       job={job}
       dataSources={dataSources}
+      environments={environments}
       onClose={() => history.push('/sync/realtime')}
       onSaved={() => history.push('/sync/realtime')}
     />

--- a/yak-ops-ui/src/pages/realtime-sync/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/index.tsx
@@ -15,7 +15,13 @@ import {
   Table,
   Tooltip,
 } from 'antd';
-import { CopyOutlined, FilterOutlined, MoreOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons';
+import {
+  CopyOutlined,
+  FilterOutlined,
+  MoreOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -25,6 +31,7 @@ import JobEditor from './JobEditor';
 import CreateRealtimeTaskDrawer from './CreateRealtimeTaskDrawer';
 import RealtimeRuntimeDetail from './RealtimeRuntimeDetail';
 import type {
+  ComputeEnvironmentOption,
   DataSourceOption,
   RealtimeEvent,
   RealtimeJob,
@@ -112,6 +119,7 @@ export default function RealtimeSync() {
   const [loading, setLoading] = useState(false);
   const [capabilities, setCapabilities] = useState<RuntimeCapabilities>({});
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
+  const [environments, setEnvironments] = useState<ComputeEnvironmentOption[]>([]);
   const [filterDraft, setFilterDraft] = useState<FilterState>(initialFilters);
   const [filters, setFilters] = useState<FilterState>(initialFilters);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -124,6 +132,10 @@ export default function RealtimeSync() {
   const dataSourceMap = useMemo(
     () => new Map(dataSources.map((item) => [String(item.value), item])),
     [dataSources],
+  );
+  const environmentMap = useMemo(
+    () => new Map(environments.map((item) => [item.id, item])),
+    [environments],
   );
 
   const loadJobs = useCallback(async () => {
@@ -148,14 +160,18 @@ export default function RealtimeSync() {
   }, [filters, pageNo, pageSize]);
 
   const loadMetadata = useCallback(async () => {
-    const [caps, sources] = await Promise.allSettled([
+    const [caps, sources, runtimeEnvironments] = await Promise.allSettled([
       realtimeApi.capabilities(),
       realtimeApi.dataSources(),
+      realtimeApi.environments(),
     ]);
     setCapabilities(caps.status === 'fulfilled' ? caps.value.data || {} : {});
     setDataSources(sources.status === 'fulfilled' ? sources.value.data || [] : []);
-    if (caps.status === 'rejected') {
-      message.warning('Flink CDC 当前不可用，任务定义仍可查看');
+    setEnvironments(
+      runtimeEnvironments.status === 'fulfilled' ? runtimeEnvironments.value.data || [] : [],
+    );
+    if (runtimeEnvironments.status === 'rejected') {
+      message.warning('运行环境列表暂不可用，任务状态仍可查看');
     }
   }, []);
 
@@ -333,6 +349,9 @@ export default function RealtimeSync() {
   const sinkType = (job: RealtimeJob) =>
     dataSourceMap.get(String(job.spec?.sinkDataSourceRef))?.dbType || '-';
 
+  const boundEnvironment = (job: RealtimeJob) =>
+    job.runtimeEnvironmentId ? environmentMap.get(job.runtimeEnvironmentId) : undefined;
+
   const deleteJob = (job: RealtimeJob) => {
     Modal.confirm({
       title: '删除实时同步任务',
@@ -367,35 +386,38 @@ export default function RealtimeSync() {
     }
   };
 
-  const moreItems = (job: RealtimeJob): MenuProps['items'] => [
-    { key: 'detail', label: '查看运行详情' },
-    {
-      key: 'validate',
-      label: 'Flink CDC 校验',
-      disabled: job.releaseState === 'PUBLISHED',
-    },
-    {
-      key: 'publish',
-      label: '发布当前版本',
-      disabled: job.releaseState === 'PUBLISHED' || job.desiredState === 'RUNNING',
-    },
-    {
-      key: 'restart',
-      label: '重启任务',
-      disabled: job.desiredState !== 'RUNNING' || !capabilities.deployEnabled,
-    },
-    {
-      key: 'reconcile',
-      label: '立即状态对账',
-      disabled: !['UNKNOWN', 'CONFLICT', 'STARTING', 'STOPPING'].includes(job.observedState),
-    },
-    { type: 'divider' },
-    {
-      key: 'delete',
-      label: <span className="text-[#d92d20]">删除任务</span>,
-      disabled: job.desiredState !== 'STOPPED',
-    },
-  ];
+  const moreItems = (job: RealtimeJob): MenuProps['items'] => {
+    const environment = boundEnvironment(job);
+    return [
+      { key: 'detail', label: '查看运行详情' },
+      {
+        key: 'validate',
+        label: 'Flink CDC 校验',
+        disabled: job.releaseState === 'PUBLISHED',
+      },
+      {
+        key: 'publish',
+        label: '发布当前版本',
+        disabled: job.releaseState === 'PUBLISHED' || job.desiredState === 'RUNNING',
+      },
+      {
+        key: 'restart',
+        label: '重启任务',
+        disabled: job.desiredState !== 'RUNNING' || environment?.enabled === false,
+      },
+      {
+        key: 'reconcile',
+        label: '立即状态对账',
+        disabled: !['UNKNOWN', 'CONFLICT', 'STARTING', 'STOPPING'].includes(job.observedState),
+      },
+      { type: 'divider' },
+      {
+        key: 'delete',
+        label: <span className="text-[#d92d20]">删除任务</span>,
+        disabled: job.desiredState !== 'STOPPED',
+      },
+    ];
+  };
 
   const columns: ColumnsType<RealtimeJob> = [
     {
@@ -456,9 +478,7 @@ export default function RealtimeSync() {
       dataIndex: 'releaseState',
       width: 115,
       align: 'center',
-      render: (value) => (
-        <StateBadge state={value} label={releaseStateLabel[value] || value} />
-      ),
+      render: (value) => <StateBadge state={value} label={releaseStateLabel[value] || value} />,
     },
     {
       title: '运行状态',
@@ -476,17 +496,27 @@ export default function RealtimeSync() {
     {
       title: 'Flink 运行时',
       dataIndex: 'runtime',
-      width: 170,
-      render: (_, job) => (
-        <div className="text-[12px] leading-5 text-[#667085]">
-          <div className="truncate text-[#475467]" title={job.latestDeployment?.runtimeRevision}>
-            {job.latestDeployment?.runtimeRevision || '-'}
+      width: 210,
+      render: (_, job) => {
+        const deploymentEnvironment = job.latestDeployment?.runtimeEnvironment;
+        const definitionEnvironment = boundEnvironment(job);
+        return (
+          <div className="text-[12px] leading-5 text-[#667085]">
+            <div
+              className="truncate font-medium text-[#475467]"
+              title={deploymentEnvironment?.name || definitionEnvironment?.name}
+            >
+              {deploymentEnvironment?.name || definitionEnvironment?.name || `环境 #${job.runtimeEnvironmentId || '-'}`}
+            </div>
+            <div className="truncate text-[11px] text-[#98a2b3]" title={job.latestDeployment?.runtimeRevision}>
+              {job.latestDeployment?.runtimeRevision || '尚未部署'}
+            </div>
+            {job.latestDeployment?.engineJobId && (
+              <div className="truncate text-[10px] text-[#b0b7c3]">Job {job.latestDeployment.engineJobId}</div>
+            )}
           </div>
-          <div className="text-[11px] text-[#98a2b3]">
-            {job.latestDeployment?.engineJobId ? `Job ${job.latestDeployment.engineJobId}` : '尚未部署'}
-          </div>
-        </div>
-      ),
+        );
+      },
     },
     {
       title: '更新时间',
@@ -503,12 +533,11 @@ export default function RealtimeSync() {
       width: 215,
       render: (_, job) => {
         const running = job.desiredState === 'RUNNING';
-        const startDisabled =
-          !capabilities.deployEnabled ||
-          job.releaseState !== 'PUBLISHED' ||
-          running;
-        const startTooltip = !capabilities.deployEnabled
-          ? capabilities.deployDisabledReason || 'Flink CDC 尚未准备好提交任务'
+        const environment = boundEnvironment(job);
+        const environmentDisabled = environment?.enabled === false;
+        const startDisabled = job.releaseState !== 'PUBLISHED' || running || environmentDisabled;
+        const startTooltip = environmentDisabled
+          ? `运行环境“${environment?.name}”已停用，请先编辑任务切换环境`
           : job.releaseState !== 'PUBLISHED'
             ? '请先发布当前任务版本'
             : running
@@ -727,23 +756,23 @@ export default function RealtimeSync() {
                   placement="bottomLeft"
                   content={
                     <Descriptions size="small" column={1} className="w-[420px]">
+                      <Descriptions.Item label="默认运行环境">
+                        {capabilities.runtimeEnvironmentName || '-'}
+                      </Descriptions.Item>
                       <Descriptions.Item label="提交引擎">{capabilities.runtimeVersion || '-'}</Descriptions.Item>
                       <Descriptions.Item label="Flink">{capabilities.flinkVersion || '-'}</Descriptions.Item>
                       <Descriptions.Item label="Flink CDC">{capabilities.flinkCdcVersion || '-'}</Descriptions.Item>
                       <Descriptions.Item label="REST">{capabilities.restUrl || '-'}</Descriptions.Item>
                       <Descriptions.Item label="语义">{capabilities.deliverySemantics || '-'}</Descriptions.Item>
-                      <Descriptions.Item label="Sources">
-                        {capabilities.connectors?.sources?.join(', ') || '-'}
-                      </Descriptions.Item>
-                      <Descriptions.Item label="Sinks">
-                        {capabilities.connectors?.sinks?.join(', ') || '-'}
+                      <Descriptions.Item label="说明">
+                        这里只展示默认环境能力；任务启动会按各自绑定的运行环境独立校验。
                       </Descriptions.Item>
                     </Descriptions>
                   }
                 >
-                  <Button size="small" className="!h-8">Flink 能力</Button>
+                  <Button size="small" className="!h-8">默认环境能力</Button>
                 </Popover>
-                <Tooltip title="刷新任务与 Flink 能力">
+                <Tooltip title="刷新任务、数据源与运行环境">
                   <Button
                     size="small"
                     icon={<ReloadOutlined spin={loading} />}
@@ -762,7 +791,6 @@ export default function RealtimeSync() {
                 <span className="text-[13px]">新建同步任务</span>
               </Button>
             </div>
-
           </div>
 
           <Divider style={{ marginTop: 4, marginBottom: 16 }} />
@@ -827,6 +855,7 @@ export default function RealtimeSync() {
           open={editor.open}
           job={editor.job}
           dataSources={dataSources}
+          environments={environments}
           onClose={() => setEditor({ open: false })}
           onSaved={() => {
             setEditor({ open: false });
@@ -841,9 +870,7 @@ export default function RealtimeSync() {
           open={Boolean(detail)}
           onClose={() => setDetail(undefined)}
         >
-          {detail && (
-            <RealtimeRuntimeDetail job={detail} events={events} capabilities={capabilities} />
-          )}
+          {detail && <RealtimeRuntimeDetail job={detail} events={events} />}
         </Drawer>
       </div>
     </ConfigProvider>

--- a/yak-ops-ui/src/pages/realtime-sync/types.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/types.ts
@@ -9,6 +9,39 @@ export interface TableRoute {
   keyColumns: string[];
 }
 
+export interface RuntimeEnvironmentConfig {
+  restUrl: string;
+  flinkHome: string;
+  flinkCdcHome: string;
+  javaHome?: string;
+  flinkVersion: string;
+  flinkCdcVersion: string;
+}
+
+export interface ComputeEnvironmentOption {
+  id: number;
+  name: string;
+  engineType: 'FLINK_CDC';
+  deploymentMode: 'REMOTE';
+  submitterType: 'LOCAL' | 'SSH';
+  config: RuntimeEnvironmentConfig;
+  enabled: boolean;
+  defaultEnvironment: boolean;
+  version: number;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface ComputeEnvironmentSnapshot {
+  id: number;
+  name: string;
+  engineType: string;
+  deploymentMode: string;
+  submitterType: string;
+  config: RuntimeEnvironmentConfig;
+  version: number;
+}
+
 export interface CdcPipelineSpec {
   sourceDataSourceRef: number;
   sinkDataSourceRef: number;
@@ -40,6 +73,7 @@ export interface RealtimeDeployment {
   idempotencyKey: string;
   engineJobId?: string;
   runtimeRevision?: string;
+  runtimeEnvironment?: ComputeEnvironmentSnapshot;
   status: string;
   resultUncertain: boolean;
   errorMessage?: string;
@@ -52,6 +86,7 @@ export interface RealtimeJob {
   name: string;
   description?: string;
   spec?: CdcPipelineSpec;
+  runtimeEnvironmentId?: number;
   releaseState: ReleaseState;
   desiredState: DesiredState;
   observedState: ObservedState;
@@ -163,6 +198,9 @@ export interface DataSourceOption {
 export interface RuntimeCapabilities {
   engineType?: string;
   runtimeVersion?: string;
+  runtimeEnvironmentId?: number;
+  runtimeEnvironmentName?: string;
+  runtimeEnvironmentVersion?: number;
   restUrl?: string;
   restTransport?: 'DIRECT';
   submissionMode?: 'LOCAL' | 'SSH';

--- a/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
@@ -192,7 +192,7 @@ const ComputeEngineSettingsPanel = () => {
         <div>
           <div className="text-[18px] font-semibold text-[#161823]">计算引擎</div>
           <div className="mt-1.5 max-w-[680px] text-[12px] leading-5 text-[#667085]">
-            集中管理实时同步使用的运行环境。任务默认使用标记为“默认”的环境，Flink 的连接与本机运行路径只需配置一次。
+            集中管理实时同步使用的运行环境。新建任务默认使用标记为“默认”的环境，也可以为每个任务单独选择运行环境。
           </div>
         </div>
         <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
@@ -201,7 +201,7 @@ const ComputeEngineSettingsPanel = () => {
       </div>
 
       <div className="mb-5 rounded-lg border border-[#e4e7ec] bg-[#f9fafb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-        当前阶段采用 Flink CDC + Remote Cluster。切换或修改默认环境前，需要先停止正在运行的实时同步任务，避免任务被错误地管理到其他 Flink 集群。
+        当前阶段采用 Flink CDC + Remote Cluster。实时任务会显式绑定运行环境，并在每次部署时保存环境快照；切换默认环境或修改环境配置不会把已经运行的任务重定向到其他 Flink 集群。
       </div>
 
       {loading ? (
@@ -336,7 +336,7 @@ const ComputeEngineSettingsPanel = () => {
                   description={
                     environment.defaultEnvironment
                       ? '默认运行环境不能删除，请先切换默认环境。'
-                      : `确定删除 ${environment.name} 吗？`
+                      : `确定删除 ${environment.name} 吗？如果仍有实时任务绑定该环境，系统会拒绝删除。`
                   }
                   disabled={environment.defaultEnvironment}
                   okText="删除"


### PR DESCRIPTION
## 背景

这是实时同步运行环境改造的第二阶段。在第一阶段已经完成「设置 → 计算引擎 → 运行环境」之后，本阶段把运行环境真正下沉到实时同步任务与部署生命周期中。

核心目标是解决一个问题：**任务到底属于哪一套 Flink，以及默认环境/环境配置变化后，已经运行的 Job 还能不能被准确停止、对账和观测。**

## 本次实现

### 1. 实时任务显式绑定运行环境

`yak_realtime_job_definition` 新增 `runtime_environment_id`。

- 新建任务时可以直接选择运行环境；
- 任务编辑页可以切换运行环境；
- 未显式选择时兼容使用当前默认环境；
- 只有已停止/失败的任务才能修改定义，因此运行中的任务不能被切换到另一套 Flink；
- 运行环境变化属于任务定义变化，会重新进入 DRAFT，需要重新发布。

前端的「新建同步任务」和「运行参数」都增加了运行环境选择，默认选中已启用的默认环境。

### 2. 每次部署固化运行环境快照

`yak_realtime_job_deployment` 新增：

- `runtime_environment_id`
- `runtime_environment_version`
- `runtime_environment_snapshot_json`

启动任务时会把实际使用的运行环境完整固化到部署记录，包括：

- 环境 ID / 名称 / 版本
- Engine / Deployment Mode / Submitter
- Flink REST URL
- Flink Home / Flink CDC Home / Java Home
- Flink / Flink CDC 版本

因此，部署后的 stop / reconcile / logs / checkpoint / metrics / Flink Web UI 都读取**部署快照**，不再读取当前默认环境。

这意味着：即使后续切换默认环境，或者编辑某个运行环境，已经运行的 Job 仍然会访问它原来的 Flink 集群，不会串集群。

### 3. Flink Gateway 全链路环境化

`RealtimeEngineGateway` 增加运行环境维度，以下操作都支持指定 `ComputeEnvironmentSnapshot`：

- health / capabilities
- validate / deploy
- status / stop
- logs
- checkpoints / metrics

`FlinkCdcEngineGateway`、`FlinkObservabilityClient`、`FlinkJobDiscoveryClient`、SSH command runner 都同步改为按运行环境执行。

其中：

- validate / publish / start：读取任务当前绑定的已启用环境；
- stop / reconcile / observability：读取部署时保存的环境快照；
- `work-directory`、请求超时、日志上限、reconcile cadence 等仍保持 Yak Ops 应用级配置。

### 4. 默认环境不再是正在运行任务的全局开关

第一阶段为了避免串集群，运行期间禁止切换/修改默认环境。

第二阶段有了任务绑定和 deployment snapshot 后，这个全局限制已经不再需要：

- 可以独立切换默认环境；
- 已运行任务继续使用部署快照；
- 新任务默认使用新的默认环境；
- 非默认环境可以停用，停用后不能用于新启动；
- 被任务定义引用的环境不能删除，需要先把任务切换到其他环境。

`application.yml / ENV` 对默认环境的 RuntimeOverrides 继续保留，只作为旧调用路径的兼容 fallback，不再作为任务生命周期的路由依据。

### 5. 运行详情展示实际部署环境

实时同步列表和运行详情现在会展示实际部署的运行环境。

Flink Web UI 地址也优先从 deployment snapshot 的 REST URL 构造，避免默认环境改变后跳到错误集群。

### 6. 历史数据兼容

新增 Flyway：

`V7__bind_jobs_to_compute_environment.sql`

升级时数据库字段先保持 nullable。应用启动后，会把 Stage 1 之前没有环境绑定的任务和部署补到当前默认环境。

注意：第一阶段没有保存历史 deployment 环境快照，所以对于升级前已经存在的旧 deployment，只能使用升级时的默认环境做 best-effort 回填；从 V7 开始的新 deployment 都会保存精确快照。

## API 变化

实时任务创建/保存请求新增可选字段：

```json
{
  "runtimeEnvironmentId": 1
}
```

`GET /api/v1/realtime-sync/runtime/capabilities` 增加可选 `environmentId` 参数，可以查询指定运行环境的 Flink CDC 能力。

旧客户端不传 `runtimeEnvironmentId` 时继续兼容默认环境/已有任务绑定。

## 测试

本 PR 更新了现有 lifecycle / concurrency / observability 测试，并新增 `RealtimeRuntimeResolverTest`，重点覆盖：

- deployment 优先读取不可变环境快照；
- 环境配置修改后，历史 deployment 仍保持原 REST 地址与版本；
- 已停用环境不能创建新的部署；
- legacy 未绑定任务回退到默认环境；
- stop / reconcile / observability 使用 deployment snapshot。

## 建议人工验证

1. 创建环境 A、环境 B，并把 A 设为默认；
2. 新建实时任务并显式选择 A，发布并启动；
3. 将默认环境切换为 B；
4. 查看任务运行详情，Flink REST / Web UI 仍应指向 A；
5. 对该任务执行状态对账、查看日志/Checkpoint/Metrics、停止任务，应继续访问 A；
6. 停止后编辑任务，切换到 B，保存并重新发布；
7. 再次启动，新 deployment 应保存 B 的环境快照；
8. 修改 B 配置后，已经启动的 deployment 仍应保持启动时的 B 快照；
9. 尝试删除仍被任务定义引用的环境，应被拒绝。

## 后续阶段（不在本 PR）

- Stage 3：Local / SSH Submitter 页面化，SSH host/user/key/known-hosts 配置进入运行环境；
- Stage 4：运行环境检测、Flink/CDC 版本自动识别、健康状态与诊断；
- Future：Yarn / Kubernetes Application 等更多部署模式。
