### PR TITLE
feat(realtime): configure Local and SSH submitters per runtime environment

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
@@ -30,7 +30,11 @@ public class ComputeEnvironmentController {
   }
 
   public record SaveRequest(
-      String name, RuntimeConfig config, boolean enabled, boolean makeDefault) {}
+      String name,
+      String submitterType,
+      RuntimeConfig config,
+      boolean enabled,
+      boolean makeDefault) {}
 
   public record EnabledRequest(boolean enabled) {}
 
@@ -51,7 +55,12 @@ public class ComputeEnvironmentController {
   @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> create(@RequestBody SaveRequest request) {
     return Result.success(
-        service.create(request.name(), request.config(), request.enabled(), request.makeDefault()));
+        service.create(
+            request.name(),
+            request.submitterType(),
+            request.config(),
+            request.enabled(),
+            request.makeDefault()));
   }
 
   @Operation(summary = "更新运行环境")
@@ -61,6 +70,7 @@ public class ComputeEnvironmentController {
     service.update(
         id,
         request.name(),
+        request.submitterType(),
         request.config(),
         request.enabled(),
         request.makeDefault());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
@@ -32,7 +32,19 @@ public record ComputeEnvironment(
       String javaHome,
       String flinkVersion,
       String flinkCdcVersion,
-      SshConfig ssh) {}
+      SshConfig ssh) {
+
+    /** Source-compatible constructor for local/legacy environments that do not carry SSH config. */
+    public RuntimeConfig(
+        String restUrl,
+        String flinkHome,
+        String flinkCdcHome,
+        String javaHome,
+        String flinkVersion,
+        String flinkCdcVersion) {
+      this(restUrl, flinkHome, flinkCdcHome, javaHome, flinkVersion, flinkCdcVersion, null);
+    }
+  }
 
   /**
    * OpenSSH client settings for remote submission. Private key material is never stored here: the

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
@@ -22,9 +22,8 @@ public record ComputeEnvironment(
   public static final String SUBMITTER_SSH = "SSH";
 
   /**
-   * Stage one intentionally stores only the settings that describe where Flink CDC runs. Yak Ops
-   * operational settings such as timeouts, log retention and reconcile cadence remain application
-   * level settings.
+   * Settings that describe where and how Flink CDC is submitted. Yak Ops operational settings such
+   * as timeouts, log retention and reconcile cadence remain application-level settings.
    */
   public record RuntimeConfig(
       String restUrl,
@@ -32,5 +31,23 @@ public record ComputeEnvironment(
       String flinkCdcHome,
       String javaHome,
       String flinkVersion,
-      String flinkCdcVersion) {}
+      String flinkCdcVersion,
+      SshConfig ssh) {}
+
+  /**
+   * OpenSSH client settings for remote submission. Private key material is never stored here: the
+   * optional identityFile is only a filesystem path on the Yak Ops host. If it is empty, OpenSSH
+   * can use the system SSH configuration or ssh-agent.
+   */
+  public record SshConfig(
+      String executable,
+      String host,
+      Integer port,
+      String user,
+      String identityFile,
+      String knownHostsFile,
+      Boolean strictHostKeyChecking,
+      Integer connectTimeoutSeconds,
+      String remoteRestAddress,
+      Integer remoteRestPort) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
@@ -111,7 +111,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     result.put("restTransport", "DIRECT");
     result.put("submissionMode", mode.name());
     if (mode == SubmissionMode.SSH) {
-      result.put("submissionEndpoint", sshRunner.endpoint());
+      result.put("submissionEndpoint", sshRunner.endpoint(environment));
     } else {
       result.put("submissionEndpoint", "local");
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.sync.realtime.engine;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -33,18 +34,19 @@ final class SshFlinkCdcCommandRunner {
   }
 
   String configurationError(ComputeEnvironmentSnapshot environment) {
-    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+    SshConfig ssh = sshConfig(environment);
     RuntimeConfig config = requireConfig(environment);
-    if (!StringUtils.hasText(ssh.getExecutable())) {
+    if (!StringUtils.hasText(ssh.executable())) {
       return "SSH executable 不能为空";
     }
-    if (!StringUtils.hasText(ssh.getHost()) || !SSH_HOST.matcher(ssh.getHost()).matches()) {
+    if (!StringUtils.hasText(ssh.host()) || !SSH_HOST.matcher(ssh.host()).matches()) {
       return "SSH host 未配置或格式无效";
     }
-    if (!StringUtils.hasText(ssh.getUser()) || !SSH_USER.matcher(ssh.getUser()).matches()) {
+    if (!StringUtils.hasText(ssh.user()) || !SSH_USER.matcher(ssh.user()).matches()) {
       return "SSH user 未配置或格式无效";
     }
-    if (ssh.getPort() < 1 || ssh.getPort() > 65535) {
+    int port = ssh.port() == null ? 22 : ssh.port();
+    if (port < 1 || port > 65535) {
       return "SSH port 必须在 1-65535 之间";
     }
     if (!absoluteUnixPath(config.flinkHome()) || !absoluteUnixPath(config.flinkCdcHome())) {
@@ -53,7 +55,7 @@ final class SshFlinkCdcCommandRunner {
     if (StringUtils.hasText(config.javaHome()) && !absoluteUnixPath(config.javaHome())) {
       return "SSH 模式下 java-home 必须是远端 Linux 绝对路径";
     }
-    Integer remoteRestPort = ssh.getRemoteRestPort();
+    Integer remoteRestPort = ssh.remoteRestPort();
     if (remoteRestPort != null && (remoteRestPort < 1 || remoteRestPort > 65535)) {
       return "SSH remote-rest-port 必须在 1-65535 之间";
     }
@@ -61,10 +63,16 @@ final class SshFlinkCdcCommandRunner {
   }
 
   String endpoint() {
-    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
-    return StringUtils.hasText(ssh.getUser()) && StringUtils.hasText(ssh.getHost())
-        ? ssh.getUser() + "@" + ssh.getHost() + ":" + ssh.getPort()
-        : null;
+    return endpoint(bootstrapEnvironment());
+  }
+
+  String endpoint(ComputeEnvironmentSnapshot environment) {
+    SshConfig ssh = sshConfig(environment);
+    if (!StringUtils.hasText(ssh.user()) || !StringUtils.hasText(ssh.host())) {
+      return null;
+    }
+    int port = ssh.port() == null ? 22 : ssh.port();
+    return ssh.user() + "@" + ssh.host() + ":" + port;
   }
 
   void validateReady(URI restUri) {
@@ -76,18 +84,17 @@ final class SshFlinkCdcCommandRunner {
     if (error != null) {
       throw failure(error, false, null);
     }
-    remoteRestPort(restUri);
+    remoteRestPort(environment, restUri);
     Process process = null;
     try {
       process =
-          new ProcessBuilder(sshCommand(remoteProbeCommand(environment, restUri)))
+          new ProcessBuilder(
+                  sshCommand(environment, remoteProbeCommand(environment, restUri)))
               .redirectErrorStream(true)
               .redirectOutput(ProcessBuilder.Redirect.DISCARD)
               .start();
       process.getOutputStream().close();
-      Duration connectTimeout =
-          positiveDuration(properties.getSsh().getConnectTimeout(), Duration.ofSeconds(5));
-      Duration timeout = connectTimeout.plusSeconds(5);
+      Duration timeout = connectTimeout(sshConfig(environment)).plusSeconds(5);
       if (!process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS)) {
         destroy(process);
         throw failure("SSH 远端环境探测超时", false, null);
@@ -124,7 +131,7 @@ final class SshFlinkCdcCommandRunner {
     boolean started = false;
     try {
       ProcessBuilder builder =
-          new ProcessBuilder(sshCommand(remoteSubmitCommand(environment, restUri)))
+          new ProcessBuilder(sshCommand(environment, remoteSubmitCommand(environment, restUri)))
               .redirectErrorStream(true)
               .redirectOutput(outputLog.toFile());
       process = builder.start();
@@ -154,16 +161,17 @@ final class SshFlinkCdcCommandRunner {
     }
   }
 
-  private List<String> sshCommand(String remoteCommand) {
-    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+  private List<String> sshCommand(
+      ComputeEnvironmentSnapshot environment, String remoteCommand) {
+    SshConfig ssh = sshConfig(environment);
     List<String> command = new ArrayList<>();
-    command.add(ssh.getExecutable());
+    command.add(ssh.executable());
     command.add("-o");
     command.add("BatchMode=yes");
     command.add("-o");
     command.add("ConnectionAttempts=1");
     command.add("-o");
-    command.add("ConnectTimeout=" + seconds(ssh.getConnectTimeout()));
+    command.add("ConnectTimeout=" + seconds(ssh));
     command.add("-o");
     command.add("ServerAliveInterval=15");
     command.add("-o");
@@ -172,18 +180,19 @@ final class SshFlinkCdcCommandRunner {
     command.add("LogLevel=ERROR");
     command.add("-o");
     command.add(
-        "StrictHostKeyChecking=" + (ssh.isStrictHostKeyChecking() ? "yes" : "accept-new"));
-    if (StringUtils.hasText(ssh.getKnownHostsFile())) {
+        "StrictHostKeyChecking="
+            + (strictHostKeyChecking(ssh) ? "yes" : "accept-new"));
+    if (StringUtils.hasText(ssh.knownHostsFile())) {
       command.add("-o");
-      command.add("UserKnownHostsFile=" + ssh.getKnownHostsFile());
+      command.add("UserKnownHostsFile=" + ssh.knownHostsFile());
     }
-    if (StringUtils.hasText(ssh.getIdentityFile())) {
+    if (StringUtils.hasText(ssh.identityFile())) {
       command.add("-i");
-      command.add(ssh.getIdentityFile());
+      command.add(ssh.identityFile());
     }
     command.add("-p");
-    command.add(Integer.toString(ssh.getPort()));
-    command.add(ssh.getUser() + "@" + ssh.getHost());
+    command.add(Integer.toString(ssh.port() == null ? 22 : ssh.port()));
+    command.add(ssh.user() + "@" + ssh.host());
     command.add(remoteCommand);
     return command;
   }
@@ -204,7 +213,10 @@ final class SshFlinkCdcCommandRunner {
           .append(shellQuote(config.javaHome() + "/bin/java"))
           .append(" || exit 44; ");
     }
-    command.append("test -n ").append(shellQuote(remoteRestAddress(restUri))).append("; ");
+    command
+        .append("test -n ")
+        .append(shellQuote(remoteRestAddress(environment, restUri)))
+        .append("; ");
     command.append("echo YAK_REALTIME_SSH_READY");
     return command.toString();
   }
@@ -224,8 +236,12 @@ final class SshFlinkCdcCommandRunner {
     command.append(shellQuote(remoteCdcCli(environment))).append(" \"$tmp\"");
     command.append(" --flink-home ").append(shellQuote(config.flinkHome()));
     command.append(" --target remote");
-    command.append(" ").append(shellQuote("-Drest.address=" + remoteRestAddress(restUri)));
-    command.append(" ").append(shellQuote("-Drest.port=" + remoteRestPort(restUri)));
+    command
+        .append(" ")
+        .append(shellQuote("-Drest.address=" + remoteRestAddress(environment, restUri)));
+    command
+        .append(" ")
+        .append(shellQuote("-Drest.port=" + remoteRestPort(environment, restUri)));
     return command.toString();
   }
 
@@ -234,10 +250,11 @@ final class SshFlinkCdcCommandRunner {
     return home + "/bin/flink-cdc.sh";
   }
 
-  private String remoteRestAddress(URI restUri) {
+  private String remoteRestAddress(ComputeEnvironmentSnapshot environment, URI restUri) {
+    SshConfig ssh = sshConfig(environment);
     String value =
-        StringUtils.hasText(properties.getSsh().getRemoteRestAddress())
-            ? properties.getSsh().getRemoteRestAddress().trim()
+        StringUtils.hasText(ssh.remoteRestAddress())
+            ? ssh.remoteRestAddress().trim()
             : restUri.getHost();
     if (!StringUtils.hasText(value)) {
       throw new IllegalArgumentException("SSH remote REST address 不能为空");
@@ -245,8 +262,8 @@ final class SshFlinkCdcCommandRunner {
     return value;
   }
 
-  private int remoteRestPort(URI restUri) {
-    Integer configured = properties.getSsh().getRemoteRestPort();
+  private int remoteRestPort(ComputeEnvironmentSnapshot environment, URI restUri) {
+    Integer configured = sshConfig(environment).remoteRestPort();
     if (configured != null) {
       if (configured < 1 || configured > 65535) {
         throw new IllegalArgumentException("ssh.remote-rest-port 必须在 1-65535 之间");
@@ -277,6 +294,29 @@ final class SshFlinkCdcCommandRunner {
     return environment.config();
   }
 
+  private SshConfig sshConfig(ComputeEnvironmentSnapshot environment) {
+    RuntimeConfig config = requireConfig(environment);
+    return config.ssh() == null ? bootstrapSshConfig() : config.ssh();
+  }
+
+  private SshConfig bootstrapSshConfig() {
+    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+    Duration timeout = ssh.getConnectTimeout();
+    int timeoutSeconds =
+        timeout == null ? 5 : (int) Math.max(1, Math.min(120, timeout.toSeconds()));
+    return new SshConfig(
+        ssh.getExecutable(),
+        ssh.getHost(),
+        ssh.getPort(),
+        ssh.getUser(),
+        ssh.getIdentityFile(),
+        ssh.getKnownHostsFile(),
+        ssh.isStrictHostKeyChecking(),
+        timeoutSeconds,
+        ssh.getRemoteRestAddress(),
+        ssh.getRemoteRestPort());
+  }
+
   private ComputeEnvironmentSnapshot bootstrapEnvironment() {
     RuntimeConfig config =
         new RuntimeConfig(
@@ -285,7 +325,8 @@ final class SshFlinkCdcCommandRunner {
             properties.getFlinkCdcHome(),
             properties.getJavaHome(),
             properties.getFlinkVersion(),
-            properties.getFlinkCdcVersion());
+            properties.getFlinkCdcVersion(),
+            bootstrapSshConfig());
     return new ComputeEnvironmentSnapshot(
         0L,
         "application/default",
@@ -300,13 +341,21 @@ final class SshFlinkCdcCommandRunner {
     return StringUtils.hasText(value) && value.startsWith("/");
   }
 
+  private boolean strictHostKeyChecking(SshConfig ssh) {
+    return ssh.strictHostKeyChecking() == null || ssh.strictHostKeyChecking();
+  }
+
+  private Duration connectTimeout(SshConfig ssh) {
+    int seconds = ssh.connectTimeoutSeconds() == null ? 5 : ssh.connectTimeoutSeconds();
+    return Duration.ofSeconds(Math.max(1, Math.min(120, seconds)));
+  }
+
   private Duration positiveDuration(Duration value, Duration fallback) {
     return value == null || value.isNegative() || value.isZero() ? fallback : value;
   }
 
-  private int seconds(Duration value) {
-    Duration effective = positiveDuration(value, Duration.ofSeconds(5));
-    return (int) Math.max(1, Math.min(Integer.MAX_VALUE, (effective.toMillis() + 999) / 1000));
+  private int seconds(SshConfig ssh) {
+    return (int) Math.max(1, Math.min(Integer.MAX_VALUE, connectTimeout(ssh).toSeconds()));
   }
 
   private String shellQuote(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
@@ -89,11 +89,14 @@ public class ComputeEnvironmentStore {
     return Objects.requireNonNull(keys.getKey(), "新增运行环境未返回主键").longValue();
   }
 
-  public void update(long id, String name, RuntimeConfig config, boolean enabled) {
+  public void update(
+      long id, String name, String submitterType, RuntimeConfig config, boolean enabled) {
     int changed =
         db.update(
-            "update yak_compute_environment set name=?,config_json=?,enabled=?,version=version+1 where id=?",
+            "update yak_compute_environment set name=?,submitter_type=?,config_json=?,enabled=?,"
+                + "version=version+1 where id=?",
             name,
+            submitterType,
             write(config),
             enabled,
             id);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
@@ -5,12 +5,15 @@ import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.RuntimeOv
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.SubmissionMode;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
 import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
 import jakarta.annotation.PostConstruct;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.dao.DuplicateKeyException;
@@ -26,6 +29,8 @@ import org.springframework.util.StringUtils;
 public class ComputeEnvironmentService {
 
   private static final String BOOTSTRAP_NAME = "默认实时环境";
+  private static final Pattern SSH_USER = Pattern.compile("[A-Za-z0-9._-]+");
+  private static final Pattern SSH_HOST = Pattern.compile("[A-Za-z0-9._:%-]+");
 
   private final ComputeEnvironmentStore store;
   private final RealtimeSyncProperties properties;
@@ -43,6 +48,7 @@ public class ComputeEnvironmentService {
   @PostConstruct
   void initialize() {
     bootstrapDefaultEnvironment();
+    backfillLegacySshConfigurations();
     backfillLegacyRuntimeBindings();
     refreshRuntimeOverrides();
   }
@@ -55,9 +61,15 @@ public class ComputeEnvironmentService {
     return require(id);
   }
 
-  public long create(String name, RuntimeConfig config, boolean enabled, boolean makeDefault) {
+  public long create(
+      String name,
+      String submitterType,
+      RuntimeConfig config,
+      boolean enabled,
+      boolean makeDefault) {
     String normalizedName = normalizeName(name);
-    RuntimeConfig normalizedConfig = normalizeConfig(config);
+    String normalizedSubmitter = normalizeSubmitterType(submitterType, ComputeEnvironment.SUBMITTER_LOCAL);
+    RuntimeConfig normalizedConfig = normalizeConfig(config, normalizedSubmitter);
     if (makeDefault && !enabled) {
       throw new IllegalArgumentException("默认运行环境必须保持启用");
     }
@@ -73,7 +85,7 @@ public class ComputeEnvironmentService {
                     normalizedName,
                     ComputeEnvironment.ENGINE_FLINK_CDC,
                     ComputeEnvironment.DEPLOYMENT_REMOTE,
-                    ComputeEnvironment.SUBMITTER_LOCAL,
+                    normalizedSubmitter,
                     normalizedConfig,
                     enabled,
                     makeDefault);
@@ -88,10 +100,18 @@ public class ComputeEnvironmentService {
   }
 
   public void update(
-      long id, String name, RuntimeConfig config, boolean enabled, boolean makeDefault) {
+      long id,
+      String name,
+      String submitterType,
+      RuntimeConfig config,
+      boolean enabled,
+      boolean makeDefault) {
     ComputeEnvironment current = require(id);
     String normalizedName = normalizeName(name);
-    RuntimeConfig normalizedConfig = normalizeConfig(config);
+    String normalizedSubmitter =
+        normalizeSubmitterType(submitterType, current.submitterType());
+    RuntimeConfig requestedConfig = preserveExistingSshConfig(current, normalizedSubmitter, config);
+    RuntimeConfig normalizedConfig = normalizeConfig(requestedConfig, normalizedSubmitter);
     boolean switchingDefault = makeDefault && !current.defaultEnvironment();
 
     if (current.defaultEnvironment() && !enabled) {
@@ -104,7 +124,7 @@ public class ComputeEnvironmentService {
     try {
       transactions.executeWithoutResult(
           status -> {
-            store.update(id, normalizedName, normalizedConfig, enabled);
+            store.update(id, normalizedName, normalizedSubmitter, normalizedConfig, enabled);
             if (switchingDefault) {
               store.clearDefault();
               store.setDefault(id);
@@ -155,8 +175,7 @@ public class ComputeEnvironmentService {
 
   /**
    * The application/default override remains as a compatibility fallback for older integrations.
-   * Stage two runtime operations use the task/deployment environment explicitly and no longer rely
-   * on this mutable global value.
+   * Task lifecycle operations use the task/deployment environment explicitly.
    */
   @Scheduled(fixedDelayString = "${yak.sync.realtime.environment-refresh-delay:5000}")
   public void refreshRuntimeOverrides() {
@@ -182,6 +201,7 @@ public class ComputeEnvironmentService {
     if (store.count() > 0) {
       return;
     }
+    String submitterType = properties.getSubmissionMode().name();
     RuntimeConfig config =
         new RuntimeConfig(
             properties.getRestUrl(),
@@ -189,7 +209,8 @@ public class ComputeEnvironmentService {
             properties.getFlinkCdcHome(),
             properties.getJavaHome(),
             properties.getFlinkVersion(),
-            properties.getFlinkCdcVersion());
+            properties.getFlinkCdcVersion(),
+            ComputeEnvironment.SUBMITTER_SSH.equals(submitterType) ? bootstrapSshConfig() : null);
     try {
       transactions.executeWithoutResult(
           status -> {
@@ -198,14 +219,46 @@ public class ComputeEnvironmentService {
                   BOOTSTRAP_NAME,
                   ComputeEnvironment.ENGINE_FLINK_CDC,
                   ComputeEnvironment.DEPLOYMENT_REMOTE,
-                  properties.getSubmissionMode().name(),
-                  normalizeConfig(config),
+                  submitterType,
+                  normalizeConfig(config, submitterType),
                   true,
                   true);
             }
           });
     } catch (DuplicateKeyException ignored) {
       // Another Yak Ops instance won the bootstrap race.
+    }
+  }
+
+  /**
+   * Stage one/two could create an SSH environment whose SSH client settings still lived only in
+   * application.yml. Copy that non-secret connection metadata into config_json once so the stage
+   * three editor can manage it. Historical deployment snapshots remain unchanged.
+   */
+  private void backfillLegacySshConfigurations() {
+    SshConfig fallback = bootstrapSshConfig();
+    for (ComputeEnvironment environment : store.list()) {
+      RuntimeConfig config = environment.config();
+      if (!ComputeEnvironment.SUBMITTER_SSH.equals(environment.submitterType())
+          || config == null
+          || config.ssh() != null) {
+        continue;
+      }
+      RuntimeConfig migrated =
+          new RuntimeConfig(
+              config.restUrl(),
+              config.flinkHome(),
+              config.flinkCdcHome(),
+              config.javaHome(),
+              config.flinkVersion(),
+              config.flinkCdcVersion(),
+              fallback);
+      store.update(
+          environment.id(),
+          environment.name(),
+          environment.submitterType(),
+          migrated,
+          environment.enabled());
     }
   }
 
@@ -232,7 +285,36 @@ public class ComputeEnvironmentService {
     return normalized;
   }
 
-  private RuntimeConfig normalizeConfig(RuntimeConfig value) {
+  private String normalizeSubmitterType(String value, String fallback) {
+    String normalized =
+        StringUtils.hasText(value) ? value.trim().toUpperCase(Locale.ROOT) : fallback;
+    if (!ComputeEnvironment.SUBMITTER_LOCAL.equals(normalized)
+        && !ComputeEnvironment.SUBMITTER_SSH.equals(normalized)) {
+      throw new IllegalArgumentException("不支持的任务提交方式：" + value);
+    }
+    return normalized;
+  }
+
+  private RuntimeConfig preserveExistingSshConfig(
+      ComputeEnvironment current, String submitterType, RuntimeConfig requested) {
+    if (requested == null
+        || !ComputeEnvironment.SUBMITTER_SSH.equals(submitterType)
+        || requested.ssh() != null
+        || current.config() == null
+        || current.config().ssh() == null) {
+      return requested;
+    }
+    return new RuntimeConfig(
+        requested.restUrl(),
+        requested.flinkHome(),
+        requested.flinkCdcHome(),
+        requested.javaHome(),
+        requested.flinkVersion(),
+        requested.flinkCdcVersion(),
+        current.config().ssh());
+  }
+
+  private RuntimeConfig normalizeConfig(RuntimeConfig value, String submitterType) {
     if (value == null) {
       throw new IllegalArgumentException("运行环境配置不能为空");
     }
@@ -240,11 +322,88 @@ public class ComputeEnvironmentService {
     validateRestUrl(restUrl);
     String flinkHome = required(value.flinkHome(), "Flink Home", 500);
     String flinkCdcHome = required(value.flinkCdcHome(), "Flink CDC Home", 500);
-    String javaHome = optional(value.javaHome(), 500);
+    String javaHome = optional(value.javaHome(), "Java Home", 500);
     String flinkVersion = required(value.flinkVersion(), "Flink 版本", 64);
     String flinkCdcVersion = required(value.flinkCdcVersion(), "Flink CDC 版本", 64);
+    SshConfig ssh = null;
+    if (ComputeEnvironment.SUBMITTER_SSH.equals(submitterType)) {
+      if (!absoluteUnixPath(flinkHome) || !absoluteUnixPath(flinkCdcHome)) {
+        throw new IllegalArgumentException("SSH 远程执行时 Flink Home 和 Flink CDC Home 必须是 Linux 绝对路径");
+      }
+      if (StringUtils.hasText(javaHome) && !absoluteUnixPath(javaHome)) {
+        throw new IllegalArgumentException("SSH 远程执行时 Java Home 必须是 Linux 绝对路径");
+      }
+      ssh = normalizeSshConfig(value.ssh());
+    }
     return new RuntimeConfig(
-        restUrl, flinkHome, flinkCdcHome, javaHome, flinkVersion, flinkCdcVersion);
+        restUrl, flinkHome, flinkCdcHome, javaHome, flinkVersion, flinkCdcVersion, ssh);
+  }
+
+  private SshConfig normalizeSshConfig(SshConfig value) {
+    if (value == null) {
+      throw new IllegalArgumentException("请选择 SSH 远程执行并填写提交节点配置");
+    }
+    String executable =
+        StringUtils.hasText(value.executable()) ? value.executable().trim() : "ssh";
+    if (executable.length() > 500) {
+      throw new IllegalArgumentException("SSH executable 长度不能超过 500 个字符");
+    }
+    String host = required(value.host(), "SSH Host", 255);
+    if (!SSH_HOST.matcher(host).matches()) {
+      throw new IllegalArgumentException("SSH Host 格式无效");
+    }
+    int port = value.port() == null ? 22 : value.port();
+    requirePort(port, "SSH Port");
+    String user = required(value.user(), "SSH User", 128);
+    if (!SSH_USER.matcher(user).matches()) {
+      throw new IllegalArgumentException("SSH User 格式无效");
+    }
+    String identityFile = optional(value.identityFile(), "SSH Identity File", 500);
+    String knownHostsFile = optional(value.knownHostsFile(), "SSH Known Hosts File", 500);
+    boolean strictHostKeyChecking =
+        value.strictHostKeyChecking() == null || value.strictHostKeyChecking();
+    int connectTimeoutSeconds =
+        value.connectTimeoutSeconds() == null ? 5 : value.connectTimeoutSeconds();
+    if (connectTimeoutSeconds < 1 || connectTimeoutSeconds > 120) {
+      throw new IllegalArgumentException("SSH 连接超时必须在 1-120 秒之间");
+    }
+    String remoteRestAddress = optional(value.remoteRestAddress(), "远端 Flink REST 地址", 255);
+    if (StringUtils.hasText(remoteRestAddress) && !SSH_HOST.matcher(remoteRestAddress).matches()) {
+      throw new IllegalArgumentException("远端 Flink REST 地址格式无效");
+    }
+    Integer remoteRestPort = value.remoteRestPort();
+    if (remoteRestPort != null) {
+      requirePort(remoteRestPort, "远端 Flink REST Port");
+    }
+    return new SshConfig(
+        executable,
+        host,
+        port,
+        user,
+        identityFile,
+        knownHostsFile,
+        strictHostKeyChecking,
+        connectTimeoutSeconds,
+        remoteRestAddress,
+        remoteRestPort);
+  }
+
+  private SshConfig bootstrapSshConfig() {
+    RealtimeSyncProperties.Ssh ssh = properties.getSsh();
+    Duration timeout = ssh.getConnectTimeout();
+    int timeoutSeconds =
+        timeout == null ? 5 : (int) Math.max(1, Math.min(120, timeout.toSeconds()));
+    return new SshConfig(
+        ssh.getExecutable(),
+        ssh.getHost(),
+        ssh.getPort(),
+        ssh.getUser(),
+        ssh.getIdentityFile(),
+        ssh.getKnownHostsFile(),
+        ssh.isStrictHostKeyChecking(),
+        timeoutSeconds,
+        ssh.getRemoteRestAddress(),
+        ssh.getRemoteRestPort());
   }
 
   private void validateRestUrl(String value) {
@@ -273,15 +432,25 @@ public class ComputeEnvironmentService {
     return normalized;
   }
 
-  private String optional(String value, int maxLength) {
+  private String optional(String value, String label, int maxLength) {
     if (!StringUtils.hasText(value)) {
       return null;
     }
     String normalized = value.trim();
     if (normalized.length() > maxLength) {
-      throw new IllegalArgumentException("Java Home 长度不能超过 " + maxLength + " 个字符");
+      throw new IllegalArgumentException(label + "长度不能超过 " + maxLength + " 个字符");
     }
     return normalized;
+  }
+
+  private void requirePort(int port, String label) {
+    if (port < 1 || port > 65535) {
+      throw new IllegalArgumentException(label + " 必须在 1-65535 之间");
+    }
+  }
+
+  private boolean absoluteUnixPath(String value) {
+    return StringUtils.hasText(value) && value.startsWith("/");
   }
 
   private SubmissionMode submissionMode(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewaySshTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewaySshTest.java
@@ -8,6 +8,10 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.SubmissionMode;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.http.HttpClient;
@@ -48,17 +52,9 @@ class FlinkCdcEngineGatewaySshTest {
     FlinkCdcEngineGateway gateway =
         new FlinkCdcEngineGateway(HttpClient.newHttpClient(), new ObjectMapper(), properties);
 
-    String yaml =
-        "source:\n  password: ${SECRET:source.password}\n"
-            + "sink:\n  password: ${SECRET:sink.password}\n"
-            + "pipeline:\n  name: test\n";
+    String yaml = pipelineYaml();
     RealtimeEngineGateway.DeployResult result;
-    try (RealtimeDeployRequest request =
-        new RealtimeDeployRequest(
-            yaml,
-            "ssh-key",
-            new RealtimeDeployRequest.CredentialBinding("source", "source-secret"),
-            new RealtimeDeployRequest.CredentialBinding("sink", "sink-secret"))) {
+    try (RealtimeDeployRequest request = request(yaml, "ssh-key")) {
       result = gateway.deploy(request);
     }
 
@@ -77,22 +73,43 @@ class FlinkCdcEngineGatewaySshTest {
   }
 
   @Test
+  void usesEnvironmentScopedSshSettingsInsteadOfApplicationFallback() throws Exception {
+    Path captured = temp.resolve("environment-pipeline.yaml");
+    Path ssh = fakeSsh(captured, 0);
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setSubmissionMode(SubmissionMode.SSH);
+    properties.setWorkDirectory(temp.resolve("work-env").toString());
+    properties.setSubmitTimeout(Duration.ofSeconds(5));
+    // Deliberately unusable application fallback. The explicit environment must win.
+    properties.getSsh().setExecutable(temp.resolve("missing-ssh").toString());
+    properties.getSsh().setHost("fallback.invalid");
+    properties.getSsh().setUser("fallback");
+
+    FlinkCdcEngineGateway gateway =
+        new FlinkCdcEngineGateway(HttpClient.newHttpClient(), new ObjectMapper(), properties);
+    ComputeEnvironmentSnapshot environment = sshEnvironment(ssh, "10.0.0.88", 2222);
+
+    RealtimeEngineGateway.DeployResult result;
+    try (RealtimeDeployRequest request = request(pipelineYaml(), "environment-key")) {
+      result = gateway.deploy(environment, request);
+    }
+
+    assertThat(result.jobId()).isEqualTo(JOB_ID);
+    assertThat(gateway.capabilities(environment).path("submissionEndpoint").asText())
+        .isEqualTo("flink@10.0.0.88:2222");
+    assertThat(Files.readString(captured, StandardCharsets.UTF_8))
+        .contains("password: 'source-secret'")
+        .doesNotContain("${SECRET:");
+  }
+
+  @Test
   void propagatesSsh255AsUncertainEngineFailureAndRetainsLog() throws Exception {
     Path ssh = fakeSsh(temp.resolve("remote-uncertain.yaml"), 255);
     RealtimeSyncProperties properties = sshProperties(ssh);
     FlinkCdcEngineGateway gateway =
         new FlinkCdcEngineGateway(HttpClient.newHttpClient(), new ObjectMapper(), properties);
-    String yaml =
-        "source:\n  password: ${SECRET:source.password}\n"
-            + "sink:\n  password: ${SECRET:sink.password}\n"
-            + "pipeline:\n  name: test\n";
 
-    try (RealtimeDeployRequest request =
-        new RealtimeDeployRequest(
-            yaml,
-            "ssh-uncertain",
-            new RealtimeDeployRequest.CredentialBinding("source", "source-secret"),
-            new RealtimeDeployRequest.CredentialBinding("sink", "sink-secret"))) {
+    try (RealtimeDeployRequest request = request(pipelineYaml(), "ssh-uncertain")) {
       assertThatThrownBy(() -> gateway.deploy(request))
           .isInstanceOf(RealtimeEngineException.class)
           .satisfies(
@@ -101,6 +118,37 @@ class FlinkCdcEngineGatewaySshTest {
     }
 
     assertThat(temp.resolve("work/logs/submit-ssh-uncertain.log")).exists();
+  }
+
+  private ComputeEnvironmentSnapshot sshEnvironment(Path executable, String host, int port) {
+    int restPort = server.getAddress().getPort();
+    RuntimeConfig config =
+        new RuntimeConfig(
+            "http://127.0.0.1:" + restPort,
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0",
+            new SshConfig(
+                executable.toString(),
+                host,
+                port,
+                "flink",
+                null,
+                null,
+                true,
+                1,
+                "127.0.0.1",
+                restPort));
+    return new ComputeEnvironmentSnapshot(
+        9L,
+        "ssh-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_SSH,
+        config,
+        3);
   }
 
   private RealtimeSyncProperties sshProperties(Path executable) {
@@ -121,8 +169,22 @@ class FlinkCdcEngineGatewaySshTest {
     return properties;
   }
 
+  private RealtimeDeployRequest request(String yaml, String key) {
+    return new RealtimeDeployRequest(
+        yaml,
+        key,
+        new RealtimeDeployRequest.CredentialBinding("source", "source-secret"),
+        new RealtimeDeployRequest.CredentialBinding("sink", "sink-secret"));
+  }
+
+  private String pipelineYaml() {
+    return "source:\n  password: ${SECRET:source.password}\n"
+        + "sink:\n  password: ${SECRET:sink.password}\n"
+        + "pipeline:\n  name: test\n";
+  }
+
   private Path fakeSsh(Path captured, int submitExitCode) throws Exception {
-    Path script = temp.resolve("gateway-fake-ssh-" + submitExitCode + ".sh");
+    Path script = temp.resolve("gateway-fake-ssh-" + submitExitCode + "-" + captured.getFileName() + ".sh");
     String content =
         "#!/bin/sh\n"
             + "case \"$*\" in\n"

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentServiceTest.java
@@ -1,0 +1,111 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
+import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class ComputeEnvironmentServiceTest {
+
+  private ComputeEnvironmentStore store;
+  private ComputeEnvironmentService service;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(ComputeEnvironmentStore.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    service =
+        new ComputeEnvironmentService(store, new RealtimeSyncProperties(), transactionManager);
+  }
+
+  @Test
+  void createsSshEnvironmentWithNormalizedConnectionSettings() {
+    when(store.insert(any(), any(), any(), any(), any(), eq(true), eq(false))).thenReturn(11L);
+    RuntimeConfig config =
+        new RuntimeConfig(
+            "http://10.0.0.20:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            "/usr/lib/jvm/java-17",
+            "1.20.5",
+            "3.6.0",
+            new SshConfig(
+                " ssh ",
+                "10.0.0.30",
+                22,
+                "flink",
+                " C:\\keys\\flink_ed25519 ",
+                null,
+                true,
+                8,
+                "flink-jm.internal",
+                8081));
+
+    long id = service.create("生产 SSH 环境", "ssh", config, true, false);
+
+    assertThat(id).isEqualTo(11L);
+    ArgumentCaptor<RuntimeConfig> captured = ArgumentCaptor.forClass(RuntimeConfig.class);
+    verify(store)
+        .insert(
+            eq("生产 SSH 环境"),
+            eq(ComputeEnvironment.ENGINE_FLINK_CDC),
+            eq(ComputeEnvironment.DEPLOYMENT_REMOTE),
+            eq(ComputeEnvironment.SUBMITTER_SSH),
+            captured.capture(),
+            eq(true),
+            eq(false));
+    RuntimeConfig saved = captured.getValue();
+    assertThat(saved.ssh().executable()).isEqualTo("ssh");
+    assertThat(saved.ssh().identityFile()).isEqualTo("C:\\keys\\flink_ed25519");
+    assertThat(saved.ssh().remoteRestAddress()).isEqualTo("flink-jm.internal");
+  }
+
+  @Test
+  void rejectsSshEnvironmentWithoutSubmissionHost() {
+    RuntimeConfig config =
+        new RuntimeConfig(
+            "http://10.0.0.20:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0",
+            new SshConfig("ssh", null, 22, "flink", null, null, true, 5, null, null));
+
+    assertThatThrownBy(() -> service.create("bad", "SSH", config, true, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SSH Host");
+  }
+
+  @Test
+  void rejectsWindowsRuntimePathForRemoteLinuxSubmission() {
+    RuntimeConfig config =
+        new RuntimeConfig(
+            "http://10.0.0.20:8081",
+            "C:\\flink",
+            "C:\\flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0",
+            new SshConfig("ssh", "10.0.0.30", 22, "flink", null, null, true, 5, null, null));
+
+    assertThatThrownBy(() -> service.create("bad-path", "SSH", config, true, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Linux 绝对路径");
+  }
+}

--- a/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
@@ -10,8 +10,10 @@ import {
   Empty,
   Form,
   Input,
+  InputNumber,
   Modal,
   Popconfirm,
+  Radio,
   Spin,
   Switch,
   Tag,
@@ -27,35 +29,59 @@ import {
   type ComputeEnvironmentPayload,
 } from '../services/computeEnvironments';
 
+type SubmitterType = 'LOCAL' | 'SSH';
+
 interface FormValues {
   name: string;
   enabled: boolean;
   makeDefault: boolean;
+  submitterType: SubmitterType;
   restUrl: string;
   flinkHome: string;
   flinkCdcHome: string;
   javaHome?: string;
   flinkVersion: string;
   flinkCdcVersion: string;
+  sshExecutable?: string;
+  sshHost?: string;
+  sshPort?: number;
+  sshUser?: string;
+  sshIdentityFile?: string;
+  sshKnownHostsFile?: string;
+  sshStrictHostKeyChecking?: boolean;
+  sshConnectTimeoutSeconds?: number;
+  sshRemoteRestAddress?: string;
+  sshRemoteRestPort?: number;
 }
 
 const DEFAULT_FORM_VALUES: FormValues = {
   name: '',
   enabled: true,
   makeDefault: false,
+  submitterType: 'LOCAL',
   restUrl: 'http://127.0.0.1:8081',
   flinkHome: '/opt/flink',
   flinkCdcHome: '/opt/flink-cdc',
   javaHome: '',
   flinkVersion: '1.20.5',
   flinkCdcVersion: '3.6.0',
+  sshExecutable: 'ssh',
+  sshHost: '',
+  sshPort: 22,
+  sshUser: '',
+  sshIdentityFile: '',
+  sshKnownHostsFile: '',
+  sshStrictHostKeyChecking: true,
+  sshConnectTimeoutSeconds: 5,
+  sshRemoteRestAddress: '',
+  sshRemoteRestPort: undefined,
 };
 
 const errorText = (error: unknown, fallback: string): string =>
   error instanceof Error && error.message ? error.message : fallback;
 
-const runtimeLabel = (environment?: ComputeEnvironment | null) =>
-  environment?.submitterType === 'SSH' ? 'SSH 远程执行' : '本机执行';
+const submitterLabel = (value?: SubmitterType | string | null) =>
+  value === 'SSH' ? 'SSH 远程执行' : '本机执行';
 
 const ComputeEngineSettingsPanel = () => {
   const [form] = Form.useForm<FormValues>();
@@ -67,6 +93,7 @@ const ComputeEngineSettingsPanel = () => {
   const [switchingId, setSwitchingId] = useState<number | null>(null);
   const [defaultingId, setDefaultingId] = useState<number | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const submitterType = Form.useWatch('submitterType', form) || 'LOCAL';
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -92,17 +119,30 @@ const ComputeEngineSettingsPanel = () => {
   };
 
   const openEdit = (environment: ComputeEnvironment) => {
+    const ssh = environment.config.ssh;
     setEditing(environment);
     form.setFieldsValue({
+      ...DEFAULT_FORM_VALUES,
       name: environment.name,
       enabled: environment.enabled,
       makeDefault: environment.defaultEnvironment,
+      submitterType: environment.submitterType,
       restUrl: environment.config.restUrl,
       flinkHome: environment.config.flinkHome,
       flinkCdcHome: environment.config.flinkCdcHome,
       javaHome: environment.config.javaHome ?? '',
       flinkVersion: environment.config.flinkVersion,
       flinkCdcVersion: environment.config.flinkCdcVersion,
+      sshExecutable: ssh?.executable || 'ssh',
+      sshHost: ssh?.host || '',
+      sshPort: ssh?.port || 22,
+      sshUser: ssh?.user || '',
+      sshIdentityFile: ssh?.identityFile || '',
+      sshKnownHostsFile: ssh?.knownHostsFile || '',
+      sshStrictHostKeyChecking: ssh?.strictHostKeyChecking ?? true,
+      sshConnectTimeoutSeconds: ssh?.connectTimeoutSeconds || 5,
+      sshRemoteRestAddress: ssh?.remoteRestAddress || '',
+      sshRemoteRestPort: ssh?.remoteRestPort,
     });
     setModalOpen(true);
   };
@@ -117,6 +157,7 @@ const ComputeEngineSettingsPanel = () => {
 
     const payload: ComputeEnvironmentPayload = {
       name: values.name.trim(),
+      submitterType: values.submitterType,
       enabled: values.enabled,
       makeDefault: values.makeDefault,
       config: {
@@ -126,6 +167,21 @@ const ComputeEngineSettingsPanel = () => {
         javaHome: values.javaHome?.trim() || undefined,
         flinkVersion: values.flinkVersion.trim(),
         flinkCdcVersion: values.flinkCdcVersion.trim(),
+        ssh:
+          values.submitterType === 'SSH'
+            ? {
+                executable: values.sshExecutable?.trim() || 'ssh',
+                host: values.sshHost?.trim(),
+                port: values.sshPort || 22,
+                user: values.sshUser?.trim(),
+                identityFile: values.sshIdentityFile?.trim() || undefined,
+                knownHostsFile: values.sshKnownHostsFile?.trim() || undefined,
+                strictHostKeyChecking: values.sshStrictHostKeyChecking ?? true,
+                connectTimeoutSeconds: values.sshConnectTimeoutSeconds || 5,
+                remoteRestAddress: values.sshRemoteRestAddress?.trim() || undefined,
+                remoteRestPort: values.sshRemoteRestPort,
+              }
+            : undefined,
       },
     };
 
@@ -191,8 +247,8 @@ const ComputeEngineSettingsPanel = () => {
       <div className="mb-6 flex items-start justify-between gap-6">
         <div>
           <div className="text-[18px] font-semibold text-[#161823]">计算引擎</div>
-          <div className="mt-1.5 max-w-[680px] text-[12px] leading-5 text-[#667085]">
-            集中管理实时同步使用的运行环境。新建任务默认使用标记为“默认”的环境，也可以为每个任务单独选择运行环境。
+          <div className="mt-1.5 max-w-[700px] text-[12px] leading-5 text-[#667085]">
+            集中管理实时同步使用的运行环境。Yak Ops 可以在本机执行 Flink CDC，也可以通过 SSH 到远端提交节点执行。
           </div>
         </div>
         <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
@@ -201,7 +257,7 @@ const ComputeEngineSettingsPanel = () => {
       </div>
 
       <div className="mb-5 rounded-lg border border-[#e4e7ec] bg-[#f9fafb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-        当前阶段采用 Flink CDC + Remote Cluster。实时任务会显式绑定运行环境，并在每次部署时保存环境快照；切换默认环境或修改环境配置不会把已经运行的任务重定向到其他 Flink 集群。
+        任务只需要选择运行环境。Flink REST 用于状态、停止和指标；“任务提交方式”只决定 flink-cdc.sh 在 Yak Ops 本机执行，还是通过 SSH 在远端服务器执行。
       </div>
 
       {loading ? (
@@ -218,154 +274,167 @@ const ComputeEngineSettingsPanel = () => {
         </div>
       ) : (
         <div className="space-y-4">
-          {environments.map((environment) => (
-            <div
-              key={environment.id}
-              className="rounded-xl border border-[#e4e7ec] bg-white px-5 py-5 shadow-[0_1px_2px_rgba(16,24,40,0.03)]"
-            >
-              <div className="flex items-start justify-between gap-5">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="truncate text-[15px] font-semibold text-[#101828]">
-                      {environment.name}
-                    </span>
-                    {environment.defaultEnvironment && (
-                      <Tag color="gold" icon={<StarFilled />} className="!mr-0">
-                        默认
+          {environments.map((environment) => {
+            const ssh = environment.config.ssh;
+            return (
+              <div
+                key={environment.id}
+                className="rounded-xl border border-[#e4e7ec] bg-white px-5 py-5 shadow-[0_1px_2px_rgba(16,24,40,0.03)]"
+              >
+                <div className="flex items-start justify-between gap-5">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="truncate text-[15px] font-semibold text-[#101828]">
+                        {environment.name}
+                      </span>
+                      {environment.defaultEnvironment && (
+                        <Tag color="gold" icon={<StarFilled />} className="!mr-0">
+                          默认
+                        </Tag>
+                      )}
+                      <Tag color={environment.enabled ? 'green' : 'default'} className="!mr-0">
+                        {environment.enabled ? '已启用' : '已停用'}
                       </Tag>
-                    )}
-                    <Tag color={environment.enabled ? 'green' : 'default'} className="!mr-0">
-                      {environment.enabled ? '已启用' : '已停用'}
-                    </Tag>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
+                        <Database size={13} /> Flink CDC
+                      </span>
+                      <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
+                        <Server size={13} /> Remote Cluster
+                      </span>
+                      <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
+                        <SquareTerminal size={13} /> {submitterLabel(environment.submitterType)}
+                      </span>
+                    </div>
                   </div>
 
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
-                      <Database size={13} /> Flink CDC
-                    </span>
-                    <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
-                      <Server size={13} /> Remote Cluster
-                    </span>
-                    <span className="inline-flex items-center gap-1.5 rounded-md bg-[#f2f4f7] px-2.5 py-1 text-[12px] text-[#475467]">
-                      <SquareTerminal size={13} /> {runtimeLabel(environment)}
-                    </span>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <span className="text-[12px] text-[#98a2b3]">启用</span>
+                    <Tooltip
+                      title={
+                        environment.defaultEnvironment
+                          ? '默认运行环境必须保持启用'
+                          : undefined
+                      }
+                    >
+                      <Switch
+                        size="small"
+                        checked={environment.enabled}
+                        disabled={environment.defaultEnvironment}
+                        loading={switchingId === environment.id}
+                        onChange={(checked) => void toggleEnabled(environment, checked)}
+                      />
+                    </Tooltip>
                   </div>
                 </div>
 
-                <div className="flex shrink-0 items-center gap-2">
-                  <span className="text-[12px] text-[#98a2b3]">启用</span>
-                  <Tooltip
-                    title={
+                <div className="mt-5 grid gap-x-8 gap-y-3 border-t border-[#f2f4f7] pt-4 md:grid-cols-2">
+                  <div>
+                    <div className="text-[11px] text-[#98a2b3]">Flink REST</div>
+                    <div
+                      className="mt-1 truncate font-mono text-[12px] text-[#344054]"
+                      title={environment.config.restUrl}
+                    >
+                      {environment.config.restUrl}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] text-[#98a2b3]">运行版本</div>
+                    <div className="mt-1 text-[12px] text-[#344054]">
+                      Flink {environment.config.flinkVersion} · CDC {environment.config.flinkCdcVersion}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] text-[#98a2b3]">
+                      {environment.submitterType === 'SSH' ? '远端 Flink Home' : 'Flink Home'}
+                    </div>
+                    <div
+                      className="mt-1 truncate font-mono text-[12px] text-[#344054]"
+                      title={environment.config.flinkHome}
+                    >
+                      {environment.config.flinkHome}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] text-[#98a2b3]">
+                      {environment.submitterType === 'SSH' ? 'SSH 提交节点' : 'Flink CDC Home'}
+                    </div>
+                    <div
+                      className="mt-1 truncate font-mono text-[12px] text-[#344054]"
+                      title={
+                        environment.submitterType === 'SSH'
+                          ? `${ssh?.user || '-'}@${ssh?.host || '-'}:${ssh?.port || 22}`
+                          : environment.config.flinkCdcHome
+                      }
+                    >
+                      {environment.submitterType === 'SSH'
+                        ? `${ssh?.user || '-'}@${ssh?.host || '-'}:${ssh?.port || 22}`
+                        : environment.config.flinkCdcHome}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 flex items-center justify-end gap-1 border-t border-[#f2f4f7] pt-3">
+                  {!environment.defaultEnvironment && (
+                    <Tooltip title={!environment.enabled ? '请先启用该运行环境' : undefined}>
+                      <Button
+                        type="link"
+                        size="small"
+                        icon={<StarOutlined />}
+                        disabled={!environment.enabled}
+                        loading={defaultingId === environment.id}
+                        onClick={() => void setDefault(environment)}
+                      >
+                        设为默认
+                      </Button>
+                    </Tooltip>
+                  )}
+                  <Button
+                    type="link"
+                    size="small"
+                    icon={<EditOutlined />}
+                    onClick={() => openEdit(environment)}
+                  >
+                    编辑
+                  </Button>
+                  <Popconfirm
+                    title="删除运行环境"
+                    description={
                       environment.defaultEnvironment
-                        ? '默认运行环境必须保持启用'
-                        : undefined
+                        ? '默认运行环境不能删除，请先切换默认环境。'
+                        : `确定删除 ${environment.name} 吗？如果仍有实时任务绑定该环境，系统会拒绝删除。`
                     }
+                    disabled={environment.defaultEnvironment}
+                    okText="删除"
+                    cancelText="取消"
+                    okButtonProps={{ danger: true, loading: deletingId === environment.id }}
+                    onConfirm={() => remove(environment)}
                   >
-                    <Switch
-                      size="small"
-                      checked={environment.enabled}
-                      disabled={environment.defaultEnvironment}
-                      loading={switchingId === environment.id}
-                      onChange={(checked) => void toggleEnabled(environment, checked)}
-                    />
-                  </Tooltip>
+                    <Tooltip title={environment.defaultEnvironment ? '请先切换默认环境' : undefined}>
+                      <Button
+                        type="link"
+                        size="small"
+                        danger
+                        disabled={environment.defaultEnvironment}
+                        icon={<DeleteOutlined />}
+                      >
+                        删除
+                      </Button>
+                    </Tooltip>
+                  </Popconfirm>
                 </div>
               </div>
-
-              <div className="mt-5 grid gap-x-8 gap-y-3 border-t border-[#f2f4f7] pt-4 md:grid-cols-2">
-                <div>
-                  <div className="text-[11px] text-[#98a2b3]">Flink REST</div>
-                  <div
-                    className="mt-1 truncate font-mono text-[12px] text-[#344054]"
-                    title={environment.config.restUrl}
-                  >
-                    {environment.config.restUrl}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-[11px] text-[#98a2b3]">运行版本</div>
-                  <div className="mt-1 text-[12px] text-[#344054]">
-                    Flink {environment.config.flinkVersion} · CDC {environment.config.flinkCdcVersion}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-[11px] text-[#98a2b3]">Flink Home</div>
-                  <div
-                    className="mt-1 truncate font-mono text-[12px] text-[#344054]"
-                    title={environment.config.flinkHome}
-                  >
-                    {environment.config.flinkHome}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-[11px] text-[#98a2b3]">Flink CDC Home</div>
-                  <div
-                    className="mt-1 truncate font-mono text-[12px] text-[#344054]"
-                    title={environment.config.flinkCdcHome}
-                  >
-                    {environment.config.flinkCdcHome}
-                  </div>
-                </div>
-              </div>
-
-              <div className="mt-4 flex items-center justify-end gap-1 border-t border-[#f2f4f7] pt-3">
-                {!environment.defaultEnvironment && (
-                  <Tooltip title={!environment.enabled ? '请先启用该运行环境' : undefined}>
-                    <Button
-                      type="link"
-                      size="small"
-                      icon={<StarOutlined />}
-                      disabled={!environment.enabled}
-                      loading={defaultingId === environment.id}
-                      onClick={() => void setDefault(environment)}
-                    >
-                      设为默认
-                    </Button>
-                  </Tooltip>
-                )}
-                <Button
-                  type="link"
-                  size="small"
-                  icon={<EditOutlined />}
-                  onClick={() => openEdit(environment)}
-                >
-                  编辑
-                </Button>
-                <Popconfirm
-                  title="删除运行环境"
-                  description={
-                    environment.defaultEnvironment
-                      ? '默认运行环境不能删除，请先切换默认环境。'
-                      : `确定删除 ${environment.name} 吗？如果仍有实时任务绑定该环境，系统会拒绝删除。`
-                  }
-                  disabled={environment.defaultEnvironment}
-                  okText="删除"
-                  cancelText="取消"
-                  okButtonProps={{ danger: true, loading: deletingId === environment.id }}
-                  onConfirm={() => remove(environment)}
-                >
-                  <Tooltip title={environment.defaultEnvironment ? '请先切换默认环境' : undefined}>
-                    <Button
-                      type="link"
-                      size="small"
-                      danger
-                      disabled={environment.defaultEnvironment}
-                      icon={<DeleteOutlined />}
-                    >
-                      删除
-                    </Button>
-                  </Tooltip>
-                </Popconfirm>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 
       <Modal
         title={editing ? '编辑运行环境' : '新建运行环境'}
         open={modalOpen}
-        width={720}
+        width={760}
         okText="保存"
         cancelText="取消"
         confirmLoading={saving}
@@ -413,7 +482,7 @@ const ComputeEngineSettingsPanel = () => {
 
           <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
             <div className="mb-3 text-[13px] font-semibold text-[#1d2939]">运行方式</div>
-            <div className="grid gap-3 sm:grid-cols-3">
+            <div className="mb-4 grid gap-3 sm:grid-cols-2">
               <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
                 <div className="text-[11px] text-[#98a2b3]">引擎</div>
                 <div className="mt-1 font-medium text-[#344054]">Flink CDC</div>
@@ -422,16 +491,22 @@ const ComputeEngineSettingsPanel = () => {
                 <div className="text-[11px] text-[#98a2b3]">部署模式</div>
                 <div className="mt-1 font-medium text-[#344054]">Remote Cluster</div>
               </div>
-              <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
-                <div className="text-[11px] text-[#98a2b3]">任务提交方式</div>
-                <div className="mt-1 font-medium text-[#344054]">{runtimeLabel(editing)}</div>
-              </div>
             </div>
-            {editing?.submitterType === 'SSH' && (
-              <div className="mt-3 text-[11px] leading-5 text-[#667085]">
-                此环境继承了现有 SSH 启动配置；本阶段只在页面管理通用 Flink 运行参数，SSH 凭据仍由启动配置提供。
-              </div>
-            )}
+            <Form.Item name="submitterType" label="任务提交方式" className="!mb-3">
+              <Radio.Group
+                optionType="button"
+                buttonStyle="solid"
+                options={[
+                  { label: '本机执行', value: 'LOCAL' },
+                  { label: 'SSH 远程执行', value: 'SSH' },
+                ]}
+              />
+            </Form.Item>
+            <div className="rounded-lg bg-[#f9fafb] px-3 py-2.5 text-[11px] leading-5 text-[#667085]">
+              {submitterType === 'SSH'
+                ? 'Yak Ops 使用本机 OpenSSH 客户端连接远端提交节点，在远端执行 flink-cdc.sh；任务状态、停止和指标仍通过 Flink REST 管理。'
+                : 'Yak Ops 直接在当前服务器执行 flink-cdc.sh，适合 Yak Ops 与 Flink CDC Client 部署在同一台机器的场景。'}
+            </div>
           </div>
 
           <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
@@ -441,7 +516,7 @@ const ComputeEngineSettingsPanel = () => {
               label="JobManager REST URL"
               rules={[{ required: true, message: '请输入 Flink REST URL' }]}
             >
-              <Input placeholder="http://127.0.0.1:8081" />
+              <Input placeholder="http://192.168.10.20:8081" />
             </Form.Item>
             <div className="grid gap-4 sm:grid-cols-2">
               <Form.Item
@@ -461,8 +536,90 @@ const ComputeEngineSettingsPanel = () => {
             </div>
           </div>
 
+          {submitterType === 'SSH' && (
+            <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
+              <div className="mb-1 text-[13px] font-semibold text-[#1d2939]">SSH 提交节点</div>
+              <div className="mb-4 text-[11px] leading-5 text-[#98a2b3]">
+                当前只支持 OpenSSH 免密认证，不保存 SSH 密码或私钥内容。私钥文件字段只保存 Yak Ops 服务器上的文件路径；留空时使用系统 SSH 配置或 ssh-agent。
+              </div>
+              <div className="grid gap-4 sm:grid-cols-[1fr_120px]">
+                <Form.Item
+                  name="sshHost"
+                  label="服务器地址"
+                  rules={[{ required: true, message: '请输入 SSH 服务器地址' }]}
+                >
+                  <Input placeholder="192.168.10.30" />
+                </Form.Item>
+                <Form.Item name="sshPort" label="端口" rules={[{ required: true }]}>
+                  <InputNumber min={1} max={65535} className="w-full" />
+                </Form.Item>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Form.Item
+                  name="sshUser"
+                  label="用户名"
+                  rules={[{ required: true, message: '请输入 SSH 用户名' }]}
+                >
+                  <Input placeholder="flink" />
+                </Form.Item>
+                <Form.Item
+                  name="sshExecutable"
+                  label="OpenSSH 客户端"
+                  rules={[{ required: true, message: '请输入 ssh 可执行程序' }]}
+                >
+                  <Input placeholder="ssh" />
+                </Form.Item>
+              </div>
+              <Form.Item name="sshIdentityFile" label="私钥文件路径（可选）">
+                <Input placeholder="C:\\Users\\yak\\.ssh\\id_ed25519 或 /home/yak/.ssh/id_ed25519" />
+              </Form.Item>
+              <Form.Item name="sshKnownHostsFile" label="known_hosts 文件（可选）">
+                <Input placeholder="留空使用 OpenSSH 默认 known_hosts" />
+              </Form.Item>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Form.Item
+                  name="sshStrictHostKeyChecking"
+                  label="严格校验 Host Key"
+                  valuePropName="checked"
+                  className="!mb-0"
+                >
+                  <Switch />
+                </Form.Item>
+                <Form.Item
+                  name="sshConnectTimeoutSeconds"
+                  label="SSH 连接超时（秒）"
+                  className="!mb-0"
+                >
+                  <InputNumber min={1} max={120} className="w-full" />
+                </Form.Item>
+              </div>
+
+              <div className="mt-5 border-t border-[#f2f4f7] pt-4">
+                <div className="text-[12px] font-medium text-[#344054]">远端访问 Flink（可选）</div>
+                <div className="mb-3 mt-1 text-[11px] leading-5 text-[#98a2b3]">
+                  只有 SSH 提交节点访问 JobManager 的地址与上面的 REST URL 不同时才需要填写，例如 Yak Ops 访问 10.0.0.20，但远端提交机需要使用 flink-jm.internal。
+                </div>
+                <div className="grid gap-4 sm:grid-cols-[1fr_160px]">
+                  <Form.Item name="sshRemoteRestAddress" label="远端 REST 地址" className="!mb-0">
+                    <Input placeholder="留空则使用 REST URL 中的 Host" />
+                  </Form.Item>
+                  <Form.Item name="sshRemoteRestPort" label="远端 REST 端口" className="!mb-0">
+                    <InputNumber min={1} max={65535} className="w-full" placeholder="自动" />
+                  </Form.Item>
+                </div>
+              </div>
+            </div>
+          )}
+
           <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
-            <div className="mb-4 text-[13px] font-semibold text-[#1d2939]">本机运行路径</div>
+            <div className="mb-1 text-[13px] font-semibold text-[#1d2939]">
+              {submitterType === 'SSH' ? '远端运行路径' : '本机运行路径'}
+            </div>
+            <div className="mb-4 text-[11px] leading-5 text-[#98a2b3]">
+              {submitterType === 'SSH'
+                ? '以下路径填写 SSH 服务器上的 Linux 路径。'
+                : '以下路径填写 Yak Ops 所在服务器上的运行路径。'}
+            </div>
             <Form.Item
               name="flinkHome"
               label="Flink Home"

--- a/yak-ops-ui/src/pages/settings/services/computeEnvironments.ts
+++ b/yak-ops-ui/src/pages/settings/services/computeEnvironments.ts
@@ -2,6 +2,19 @@ import { request } from '@umijs/max';
 
 const PREFIX = '/api/v1/compute-environments';
 
+export interface ComputeEnvironmentSshConfig {
+  executable?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  identityFile?: string;
+  knownHostsFile?: string;
+  strictHostKeyChecking?: boolean;
+  connectTimeoutSeconds?: number;
+  remoteRestAddress?: string;
+  remoteRestPort?: number;
+}
+
 export interface ComputeEnvironmentRuntimeConfig {
   restUrl: string;
   flinkHome: string;
@@ -9,6 +22,7 @@ export interface ComputeEnvironmentRuntimeConfig {
   javaHome?: string;
   flinkVersion: string;
   flinkCdcVersion: string;
+  ssh?: ComputeEnvironmentSshConfig;
 }
 
 export interface ComputeEnvironment {
@@ -27,6 +41,7 @@ export interface ComputeEnvironment {
 
 export interface ComputeEnvironmentPayload {
   name: string;
+  submitterType: 'LOCAL' | 'SSH';
   config: ComputeEnvironmentRuntimeConfig;
   enabled: boolean;
   makeDefault: boolean;


### PR DESCRIPTION
## 背景

这是实时同步运行环境改造的第三阶段。

前两阶段已经完成：

- 设置 → 计算引擎 → 运行环境；
- 实时任务显式绑定运行环境；
- deployment 保存不可变环境快照；
- stop / reconcile / logs / metrics 按 deployment snapshot 路由到正确 Flink 集群。

本阶段只解决一个非常实际的问题：**flink-cdc.sh 到底在 Yak Ops 本机执行，还是在另一台内网服务器执行。**

目标仍然是“小而精”：用户只看到“本机执行 / SSH 远程执行”，不引入 Agent、Executor、Cluster Instance 等额外概念。

## 本次实现

### 1. 运行环境支持选择任务提交方式

`ComputeEnvironment` 现在支持：

- `LOCAL`：Yak Ops 所在服务器直接执行 Flink CDC CLI；
- `SSH`：Yak Ops 使用本机 OpenSSH 客户端连接远端提交节点，在远端执行 Flink CDC CLI。

Engine 仍固定为 `Flink CDC`，Deployment Mode 仍固定为 `Remote Cluster`，没有把未来 Yarn / Kubernetes 的复杂度提前暴露给用户。

运行环境切换 Local / SSH 会递增环境版本；已经运行的 deployment 继续使用自己的历史 snapshot，不受后续环境修改影响。

### 2. SSH 配置进入运行环境

SSH 模式新增环境级配置：

- OpenSSH executable（默认 `ssh`）；
- Host / Port / User；
- Identity File 路径（可选）；
- known_hosts 文件路径（可选）；
- StrictHostKeyChecking；
- SSH connect timeout；
- 远端访问 Flink REST 的 Address / Port override（可选）。

其中 Flink Home / Flink CDC Home / Java Home 在 SSH 模式下明确表示**远端 Linux 路径**。

远端 REST override 只用于一种场景：Yak Ops 访问 JobManager 的地址，和 SSH 提交节点访问 JobManager 的地址不同。未配置时自动复用 JobManager REST URL 中的 host/port。

### 3. 不保存 SSH 密码或私钥内容

为了保持模型简单并避免在 Yak Ops 数据库里增加一套 SSH Secret 管理，本阶段只支持 OpenSSH 免密认证：

- ssh-agent；
- 系统 SSH 配置；
- 或指定 Identity File 文件路径。

数据库只保存 `identityFile` 路径，不保存私钥内容，也不保存 SSH Password。

因此 Windows 上的 Yak Ops 可以填写例如：

`C:\Users\yak\.ssh\id_ed25519`

Linux 部署则可以填写：

`/home/yak/.ssh/id_ed25519`

### 4. SSH 配置跟随 deployment snapshot

Stage 2 的 `ComputeEnvironmentSnapshot` 会自然包含本次新增的 SSH 配置。

启动时：

`Job → Runtime Environment → Snapshot → SSH Submitter → flink-cdc.sh`

之后即使管理员把同一个环境从 SSH 改回 Local，或者修改 SSH Host，新启动会使用新环境版本；历史 deployment 保留启动当时的配置。

停止、状态对账、Checkpoint、Metrics 仍然走 deployment snapshot 中的 Flink REST URL，不依赖 SSH 连接。

### 5. SSH Runner 真正按任务环境执行

`SshFlinkCdcCommandRunner` 不再把 application.yml 中的全局 SSH 参数作为显式任务环境的主要来源。

现在以下内容全部从当前 `ComputeEnvironmentSnapshot` 读取：

- SSH executable；
- host / port / user；
- identity file / known_hosts；
- host key policy；
- connect timeout；
- remote Flink REST address / port；
- 远端 Flink / CDC / Java 路径。

application.yml / ENV 中原来的 SSH 参数仅作为 legacy / compatibility fallback。

`runtime/capabilities?environmentId=...` 返回的 `submissionEndpoint` 也会正确展示该环境自己的 `user@host:port`。

### 6. 设置页面优化

设置 → 计算引擎 → 新建/编辑运行环境：

- “任务提交方式”直接展示两个清晰选项：`本机执行` / `SSH 远程执行`；
- SSH 模式才展示 SSH 提交节点配置；
- 明确提示“不保存密码或私钥内容”；
- SSH 模式下路径区域自动改名为“远端运行路径”；
- 运行环境卡片直接展示 SSH 提交节点 `user@host:port`。

任务编辑页面保持不变，仍然只选择“运行环境”，不会把 SSH Host、密钥路径等基础设施参数暴露到每个任务里。

## 兼容性

- `config_json` 继续复用现有 `yak_compute_environment`，不新增数据库表或 Flyway；
- 旧的 Local 环境无需迁移；
- Stage 1/2 遗留的 SSH 环境如果 `config_json` 尚未包含 SSH 配置，启动时会把现有 application.yml / ENV 的非 Secret SSH 元数据补入环境配置；
- 旧 `RuntimeConfig` 六参数构造器继续保留，避免现有测试/集成源码被破坏；
- application.yml / ENV 仍保留为 bootstrap / compatibility fallback。

## 测试

新增 / 更新测试覆盖：

- SSH 环境字段归一化与校验；
- SSH 模式要求远端 Flink / CDC 路径为 Linux 绝对路径；
- 显式环境的 SSH executable / host / port 优先于 application fallback；
- environment-specific capabilities 返回正确 SSH endpoint；
- SSH 提交仍保持临时 pipeline 只存在于远端，提交日志保留在 Yak Ops。

## 建议人工验证

1. 设置 → 计算引擎，新建环境，选择“SSH 远程执行”；
2. 填写 SSH Host / Port / User，Identity File 留空测试 ssh-agent，或填写本机私钥路径；
3. Flink Home / Flink CDC Home 填写远端 Linux 路径；
4. 创建实时同步任务并选择该环境，发布并启动；
5. 确认 Yak Ops 本机没有创建 pipeline YAML，远端执行 `flink-cdc.sh` 并返回 JobId；
6. 查看运行详情、Checkpoint、Metrics，确认仍由 Yak Ops 直接访问正确的 Flink REST；
7. 停止任务后，把同一环境切成 Local 或修改 SSH Host，再次启动，新 deployment 应使用新的环境版本；
8. 历史 deployment 的 Flink REST / 环境快照保持不变。

## 后续阶段（不在本 PR）

Stage 4 再专门做运行环境检测与诊断：SSH 连通性、Flink REST、Flink CDC CLI、Java、版本自动识别、工作目录可用性等。本 PR 不提前引入这些检测逻辑。