### PR TITLE
feat(realtime): add runtime environment diagnostics

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/ComputeEnvironmentController.java
@@ -6,6 +6,7 @@ import io.yak.framework.common.Result;
 import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentDiagnosis;
 import io.yak.ops.business.sync.realtime.service.ComputeEnvironmentService;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -61,6 +62,21 @@ public class ComputeEnvironmentController {
             request.config(),
             request.enabled(),
             request.makeDefault()));
+  }
+
+  @Operation(summary = "预检测未保存的运行环境")
+  @PostMapping("/diagnose")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<ComputeEnvironmentDiagnosis> diagnosePreview(@RequestBody SaveRequest request) {
+    return Result.success(
+        service.diagnosePreview(request.name(), request.submitterType(), request.config()));
+  }
+
+  @Operation(summary = "检测已保存的运行环境")
+  @PostMapping("/{id}/diagnose")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<ComputeEnvironmentDiagnosis> diagnose(@PathVariable long id) {
+    return Result.success(service.diagnose(id));
   }
 
   @Operation(summary = "更新运行环境")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironment.java
@@ -14,12 +14,45 @@ public record ComputeEnvironment(
     boolean defaultEnvironment,
     int version,
     LocalDateTime createTime,
-    LocalDateTime updateTime) {
+    LocalDateTime updateTime,
+    String lastCheckStatus,
+    String lastCheckMessage,
+    LocalDateTime lastCheckTime) {
 
   public static final String ENGINE_FLINK_CDC = "FLINK_CDC";
   public static final String DEPLOYMENT_REMOTE = "REMOTE";
   public static final String SUBMITTER_LOCAL = "LOCAL";
   public static final String SUBMITTER_SSH = "SSH";
+
+  /** Source-compatible constructor for callers that predate environment diagnostics. */
+  public ComputeEnvironment(
+      long id,
+      String name,
+      String engineType,
+      String deploymentMode,
+      String submitterType,
+      RuntimeConfig config,
+      boolean enabled,
+      boolean defaultEnvironment,
+      int version,
+      LocalDateTime createTime,
+      LocalDateTime updateTime) {
+    this(
+        id,
+        name,
+        engineType,
+        deploymentMode,
+        submitterType,
+        config,
+        enabled,
+        defaultEnvironment,
+        version,
+        createTime,
+        updateTime,
+        null,
+        null,
+        null);
+  }
 
   /**
    * Settings that describe where and how Flink CDC is submitted. Yak Ops operational settings such

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironmentDiagnosis.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/ComputeEnvironmentDiagnosis.java
@@ -1,0 +1,28 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** User-facing diagnosis result for one Flink CDC runtime environment. */
+public record ComputeEnvironmentDiagnosis(
+    Long environmentId,
+    String environmentName,
+    String status,
+    boolean ready,
+    String summary,
+    String detectedFlinkVersion,
+    String detectedFlinkCdcVersion,
+    String detectedJavaVersion,
+    LocalDateTime checkedAt,
+    List<Check> checks) {
+
+  public static final String STATUS_HEALTHY = "HEALTHY";
+  public static final String STATUS_WARNING = "WARNING";
+  public static final String STATUS_FAILED = "FAILED";
+
+  public record Check(String key, String label, String status, String message) {
+    public static final String PASS = "PASS";
+    public static final String WARN = "WARN";
+    public static final String FAIL = "FAIL";
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkRuntimeEnvironmentProbe.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkRuntimeEnvironmentProbe.java
@@ -1,0 +1,384 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentDiagnosis;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentDiagnosis.Check;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Performs explicit, operator-requested checks without submitting a Flink job. */
+@Component
+public class FlinkRuntimeEnvironmentProbe {
+
+  private static final Pattern VERSION =
+      Pattern.compile("(?i)(?:version[^0-9]*)?([0-9]+\\.[0-9]+(?:\\.[0-9]+)?(?:[-+][A-Za-z0-9._-]+)?)");
+
+  private final RealtimeEngineGateway gateway;
+  private final RealtimeSyncProperties properties;
+  private final SshFlinkCdcCommandRunner sshRunner;
+
+  public FlinkRuntimeEnvironmentProbe(
+      RealtimeEngineGateway gateway, RealtimeSyncProperties properties) {
+    this.gateway = gateway;
+    this.properties = properties;
+    this.sshRunner = new SshFlinkCdcCommandRunner(properties);
+  }
+
+  public ComputeEnvironmentDiagnosis diagnose(ComputeEnvironmentSnapshot environment) {
+    if (environment == null || environment.config() == null) {
+      throw new IllegalArgumentException("运行环境配置不能为空");
+    }
+    RuntimeConfig config = environment.config();
+    List<Check> checks = new ArrayList<>();
+    LocalDateTime checkedAt = LocalDateTime.now();
+
+    String detectedFlinkVersion = null;
+    String detectedCdcVersion = null;
+    String detectedJavaVersion = null;
+
+    checks.add(checkWorkDirectory());
+
+    try {
+      JsonNode overview = gateway.health(environment);
+      detectedFlinkVersion = text(overview, "flink-version");
+      checks.add(
+          pass(
+              "FLINK_REST",
+              "Flink REST",
+              overviewMessage(overview, detectedFlinkVersion)));
+    } catch (RuntimeException exception) {
+      checks.add(fail("FLINK_REST", "Flink REST", safeMessage(exception, "无法连接 Flink REST")));
+    }
+
+    if (ComputeEnvironment.SUBMITTER_SSH.equals(environment.submitterType())) {
+      SshProbeVersions versions = diagnoseSsh(environment, checks);
+      detectedFlinkVersion = firstNonBlank(versions.flinkVersion(), detectedFlinkVersion);
+      detectedCdcVersion = versions.cdcVersion();
+      detectedJavaVersion = versions.javaVersion();
+    } else {
+      SshProbeVersions versions = diagnoseLocal(environment, checks);
+      detectedFlinkVersion = firstNonBlank(versions.flinkVersion(), detectedFlinkVersion);
+      detectedCdcVersion = versions.cdcVersion();
+      detectedJavaVersion = versions.javaVersion();
+    }
+
+    String status = overallStatus(checks);
+    boolean ready = !ComputeEnvironmentDiagnosis.STATUS_FAILED.equals(status);
+    String summary = summary(status, checks);
+    return new ComputeEnvironmentDiagnosis(
+        environment.id() <= 0 ? null : environment.id(),
+        environment.name(),
+        status,
+        ready,
+        summary,
+        detectedFlinkVersion,
+        detectedCdcVersion,
+        detectedJavaVersion,
+        checkedAt,
+        List.copyOf(checks));
+  }
+
+  private SshProbeVersions diagnoseLocal(
+      ComputeEnvironmentSnapshot environment, List<Check> checks) {
+    RuntimeConfig config = environment.config();
+    Path cdc = Path.of(config.flinkCdcHome(), "bin", "flink-cdc.sh").toAbsolutePath().normalize();
+    Path flink = Path.of(config.flinkHome(), "bin", "flink").toAbsolutePath().normalize();
+
+    String cdcVersion = null;
+    if (!Files.isRegularFile(cdc) || !Files.isExecutable(cdc)) {
+      checks.add(fail("FLINK_CDC_CLI", "Flink CDC CLI", "文件不存在或不可执行：" + cdc));
+    } else {
+      CommandOutput output = run(List.of(cdc.toString(), "--version"), 8);
+      cdcVersion = extractVersion(output.output());
+      checks.add(versionCheck("FLINK_CDC_CLI", "Flink CDC CLI", output, cdcVersion, config.flinkCdcVersion()));
+    }
+
+    String flinkVersion = null;
+    if (!Files.isRegularFile(flink) || !Files.isExecutable(flink)) {
+      checks.add(fail("FLINK_CLI", "Flink CLI", "文件不存在或不可执行：" + flink));
+    } else {
+      CommandOutput output = run(List.of(flink.toString(), "--version"), 8);
+      flinkVersion = extractVersion(output.output());
+      checks.add(versionCheck("FLINK_CLI", "Flink CLI", output, flinkVersion, config.flinkVersion()));
+    }
+
+    String javaExecutable =
+        StringUtils.hasText(config.javaHome())
+            ? Path.of(config.javaHome(), "bin", "java").toAbsolutePath().normalize().toString()
+            : "java";
+    if (StringUtils.hasText(config.javaHome()) && !Files.isExecutable(Path.of(javaExecutable))) {
+      checks.add(fail("JAVA", "Java", "JAVA_HOME/bin/java 不存在或不可执行"));
+      return new SshProbeVersions(flinkVersion, cdcVersion, null);
+    }
+    CommandOutput javaOutput = run(List.of(javaExecutable, "-version"), 8);
+    String javaVersion = extractVersion(javaOutput.output());
+    if (!javaOutput.success()) {
+      checks.add(fail("JAVA", "Java", nonBlank(javaOutput.output(), "无法执行 java -version")));
+    } else if (!StringUtils.hasText(javaVersion)) {
+      checks.add(warn("JAVA", "Java", "Java 可执行，但未能识别版本"));
+    } else {
+      checks.add(pass("JAVA", "Java", "检测到 Java " + javaVersion));
+    }
+    return new SshProbeVersions(flinkVersion, cdcVersion, javaVersion);
+  }
+
+  private SshProbeVersions diagnoseSsh(
+      ComputeEnvironmentSnapshot environment, List<Check> checks) {
+    RuntimeConfig config = environment.config();
+    SshConfig ssh = config.ssh();
+    if (ssh != null && StringUtils.hasText(ssh.identityFile())) {
+      try {
+        if (!Files.isRegularFile(Path.of(ssh.identityFile()))) {
+          checks.add(fail("SSH_IDENTITY", "SSH 私钥", "配置的私钥文件不存在"));
+        } else {
+          checks.add(pass("SSH_IDENTITY", "SSH 私钥", "私钥文件可读取"));
+        }
+      } catch (RuntimeException exception) {
+        checks.add(fail("SSH_IDENTITY", "SSH 私钥", "私钥文件路径无效"));
+      }
+    }
+
+    try {
+      URI rest = URI.create(config.restUrl());
+      SshFlinkCdcCommandRunner.RemoteProbe probe = sshRunner.probe(environment, rest);
+      checks.add(pass("SSH", "SSH 连接", "已连接 " + sshRunner.endpoint(environment)));
+
+      String cdcVersion = extractVersion(probe.cdcVersionOutput());
+      checks.add(
+          remoteVersionCheck(
+              "FLINK_CDC_CLI",
+              "Flink CDC CLI",
+              probe.cdcExecutable(),
+              probe.cdcVersionCommandOk(),
+              cdcVersion,
+              config.flinkCdcVersion(),
+              "远端 Flink CDC CLI 不存在或不可执行"));
+
+      String flinkVersion = extractVersion(probe.flinkVersionOutput());
+      checks.add(
+          remoteVersionCheck(
+              "FLINK_CLI",
+              "Flink CLI",
+              probe.flinkExecutable(),
+              probe.flinkVersionCommandOk(),
+              flinkVersion,
+              config.flinkVersion(),
+              "远端 Flink CLI 不存在或不可执行"));
+
+      String javaVersion = extractVersion(probe.javaVersionOutput());
+      if (!probe.javaExecutable()) {
+        checks.add(fail("JAVA", "Java", "远端 Java 不存在或不可执行"));
+      } else if (!probe.javaVersionCommandOk()) {
+        checks.add(warn("JAVA", "Java", "远端 Java 可执行，但 java -version 未正常返回"));
+      } else if (!StringUtils.hasText(javaVersion)) {
+        checks.add(warn("JAVA", "Java", "远端 Java 可执行，但未能识别版本"));
+      } else {
+        checks.add(pass("JAVA", "Java", "检测到 Java " + javaVersion));
+      }
+
+      checks.add(
+          probe.tempWritable()
+              ? pass("REMOTE_TEMP", "远端临时目录", "mktemp 可创建并清理临时文件")
+              : fail("REMOTE_TEMP", "远端临时目录", "无法创建远端临时 pipeline 文件"));
+      return new SshProbeVersions(flinkVersion, cdcVersion, javaVersion);
+    } catch (RuntimeException exception) {
+      checks.add(fail("SSH", "SSH 连接", safeMessage(exception, "SSH 连接或认证失败")));
+      checks.add(warn("FLINK_CDC_CLI", "Flink CDC CLI", "SSH 未连接，未执行远端检查"));
+      checks.add(warn("FLINK_CLI", "Flink CLI", "SSH 未连接，未执行远端检查"));
+      checks.add(warn("JAVA", "Java", "SSH 未连接，未执行远端检查"));
+      checks.add(warn("REMOTE_TEMP", "远端临时目录", "SSH 未连接，未执行远端检查"));
+      return new SshProbeVersions(null, null, null);
+    }
+  }
+
+  private Check checkWorkDirectory() {
+    Path marker = null;
+    try {
+      Path work = Path.of(properties.getWorkDirectory()).toAbsolutePath().normalize();
+      Files.createDirectories(work);
+      marker = Files.createTempFile(work, ".yak-env-probe-", ".tmp");
+      return pass("WORK_DIRECTORY", "Yak Ops 工作目录", "可读写：" + work);
+    } catch (Exception exception) {
+      return fail("WORK_DIRECTORY", "Yak Ops 工作目录", safeMessage(exception, "工作目录不可写"));
+    } finally {
+      if (marker != null) {
+        try {
+          Files.deleteIfExists(marker);
+        } catch (IOException ignored) {
+          // Best-effort cleanup for an explicit diagnostics probe.
+        }
+      }
+    }
+  }
+
+  private Check versionCheck(
+      String key, String label, CommandOutput output, String detected, String configured) {
+    if (!output.success()) {
+      return warn(key, label, nonBlank(output.output(), label + " 可执行，但版本命令返回异常"));
+    }
+    return versionResult(key, label, detected, configured);
+  }
+
+  private Check remoteVersionCheck(
+      String key,
+      String label,
+      boolean executable,
+      boolean versionCommandOk,
+      String detected,
+      String configured,
+      String missingMessage) {
+    if (!executable) {
+      return fail(key, label, missingMessage);
+    }
+    if (!versionCommandOk) {
+      return warn(key, label, label + " 可执行，但 --version 未正常返回");
+    }
+    return versionResult(key, label, detected, configured);
+  }
+
+  private Check versionResult(
+      String key, String label, String detected, String configured) {
+    if (!StringUtils.hasText(detected)) {
+      return warn(key, label, label + " 可执行，但未能识别版本");
+    }
+    if (StringUtils.hasText(configured) && !sameVersion(configured, detected)) {
+      return warn(key, label, "检测到 " + detected + "，当前配置为 " + configured);
+    }
+    return pass(key, label, "检测到 " + detected);
+  }
+
+  private CommandOutput run(List<String> command, int timeoutSeconds) {
+    Process process = null;
+    try {
+      process = new ProcessBuilder(command).redirectErrorStream(true).start();
+      if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return new CommandOutput(false, "版本检测超时");
+      }
+      String output =
+          new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+      return new CommandOutput(process.exitValue() == 0, output);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      if (process != null) process.destroyForcibly();
+      return new CommandOutput(false, "版本检测被中断");
+    } catch (IOException exception) {
+      if (process != null) process.destroyForcibly();
+      return new CommandOutput(false, "无法执行命令：" + exception.getMessage());
+    }
+  }
+
+  private String extractVersion(String output) {
+    if (!StringUtils.hasText(output)) return null;
+    for (String line : output.lines().toList()) {
+      if (!line.toLowerCase(Locale.ROOT).contains("version")) continue;
+      Matcher matcher = VERSION.matcher(line);
+      if (matcher.find()) return matcher.group(1);
+    }
+    Matcher matcher = VERSION.matcher(output);
+    return matcher.find() ? matcher.group(1) : null;
+  }
+
+  private boolean sameVersion(String configured, String detected) {
+    return configured.trim().equalsIgnoreCase(detected.trim());
+  }
+
+  private String overviewMessage(JsonNode overview, String version) {
+    List<String> parts = new ArrayList<>();
+    if (StringUtils.hasText(version)) parts.add("Flink " + version);
+    addNumber(parts, overview, "taskmanagers", "TaskManagers");
+    if (overview != null && overview.has("slots-available") && overview.has("slots-total")) {
+      parts.add(
+          "Slots "
+              + overview.path("slots-available").asInt()
+              + "/"
+              + overview.path("slots-total").asInt());
+    }
+    addNumber(parts, overview, "jobs-running", "Running Jobs");
+    return parts.isEmpty() ? "Flink REST 可访问" : String.join(" · ", parts);
+  }
+
+  private void addNumber(List<String> parts, JsonNode node, String field, String label) {
+    if (node != null && node.has(field) && node.path(field).isNumber()) {
+      parts.add(label + " " + node.path(field).asInt());
+    }
+  }
+
+  private String overallStatus(List<Check> checks) {
+    if (checks.stream().anyMatch(item -> Check.FAIL.equals(item.status()))) {
+      return ComputeEnvironmentDiagnosis.STATUS_FAILED;
+    }
+    if (checks.stream().anyMatch(item -> Check.WARN.equals(item.status()))) {
+      return ComputeEnvironmentDiagnosis.STATUS_WARNING;
+    }
+    return ComputeEnvironmentDiagnosis.STATUS_HEALTHY;
+  }
+
+  private String summary(String status, List<Check> checks) {
+    if (ComputeEnvironmentDiagnosis.STATUS_FAILED.equals(status)) {
+      return checks.stream()
+          .filter(item -> Check.FAIL.equals(item.status()))
+          .findFirst()
+          .map(item -> item.label() + "：" + item.message())
+          .orElse("运行环境检测失败");
+    }
+    long warnings = checks.stream().filter(item -> Check.WARN.equals(item.status())).count();
+    if (warnings > 0) {
+      return "环境可用，但有 " + warnings + " 项需要关注";
+    }
+    return "环境检查通过，可以提交实时同步任务";
+  }
+
+  private String text(JsonNode node, String field) {
+    if (node == null || node.path(field).isMissingNode() || node.path(field).isNull()) return null;
+    String value = node.path(field).asText(null);
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private String firstNonBlank(String first, String second) {
+    return StringUtils.hasText(first) ? first : second;
+  }
+
+  private String nonBlank(String value, String fallback) {
+    if (!StringUtils.hasText(value)) return fallback;
+    String firstLine = value.lines().findFirst().orElse(value).trim();
+    return firstLine.length() > 300 ? firstLine.substring(0, 300) : firstLine;
+  }
+
+  private String safeMessage(Throwable exception, String fallback) {
+    return nonBlank(exception == null ? null : exception.getMessage(), fallback);
+  }
+
+  private Check pass(String key, String label, String message) {
+    return new Check(key, label, Check.PASS, message);
+  }
+
+  private Check warn(String key, String label, String message) {
+    return new Check(key, label, Check.WARN, message);
+  }
+
+  private Check fail(String key, String label, String message) {
+    return new Check(key, label, Check.FAIL, message);
+  }
+
+  private record CommandOutput(boolean success, String output) {}
+
+  private record SshProbeVersions(String flinkVersion, String cdcVersion, String javaVersion) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/SshFlinkCdcCommandRunner.java
@@ -12,7 +12,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.springframework.util.StringUtils;
@@ -106,6 +108,42 @@ final class SshFlinkCdcCommandRunner {
       Thread.currentThread().interrupt();
       destroy(process);
       throw failure("SSH 远端环境探测被中断", false, exception);
+    } catch (IOException exception) {
+      destroy(process);
+      throw failure("无法启动 OpenSSH 客户端：" + exception.getMessage(), false, exception);
+    }
+  }
+
+  /** Runs a richer, read-only SSH probe used by the settings diagnostics UI. */
+  RemoteProbe probe(ComputeEnvironmentSnapshot environment, URI restUri) {
+    String error = configurationError(environment);
+    if (error != null) {
+      throw failure(error, false, null);
+    }
+    remoteRestPort(environment, restUri);
+    Process process = null;
+    try {
+      process =
+          new ProcessBuilder(
+                  sshCommand(environment, remoteDiagnosticCommand(environment, restUri)))
+              .redirectErrorStream(true)
+              .start();
+      process.getOutputStream().close();
+      Duration timeout = connectTimeout(sshConfig(environment)).plusSeconds(15);
+      if (!process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS)) {
+        destroy(process);
+        throw failure("SSH 运行环境检测超时", false, null);
+      }
+      String output =
+          new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      if (process.exitValue() != 0) {
+        throw failure(probeFailureMessage(process.exitValue()), false, null);
+      }
+      return parseRemoteProbe(output);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      destroy(process);
+      throw failure("SSH 运行环境检测被中断", false, exception);
     } catch (IOException exception) {
       destroy(process);
       throw failure("无法启动 OpenSSH 客户端：" + exception.getMessage(), false, exception);
@@ -219,6 +257,91 @@ final class SshFlinkCdcCommandRunner {
         .append("; ");
     command.append("echo YAK_REALTIME_SSH_READY");
     return command.toString();
+  }
+
+  private String remoteDiagnosticCommand(ComputeEnvironmentSnapshot environment, URI restUri) {
+    RuntimeConfig config = requireConfig(environment);
+    String cdc = remoteCdcCli(environment);
+    String flink = config.flinkHome().replaceAll("/+$", "") + "/bin/flink";
+    StringBuilder command = new StringBuilder("set +e; ");
+    command.append("printf 'YAK_SSH=1\\n'; ");
+
+    command.append("if test -x ").append(shellQuote(cdc)).append("; then ");
+    command.append("printf 'YAK_CDC_EXEC=1\\n'; ");
+    command.append("v=$(").append(shellQuote(cdc)).append(" --version 2>&1); rc=$?; ");
+    command.append("v=$(printf '%s\\n' \"$v\" | head -n 1); ");
+    command.append("printf 'YAK_CDC_VERSION_OK=%s\\n' \"$([ $rc -eq 0 ] && echo 1 || echo 0)\"; ");
+    command.append("printf 'YAK_CDC_VERSION=%s\\n' \"$v\"; ");
+    command.append("else printf 'YAK_CDC_EXEC=0\\n'; fi; ");
+
+    command.append("if test -x ").append(shellQuote(flink)).append("; then ");
+    command.append("printf 'YAK_FLINK_EXEC=1\\n'; ");
+    command.append("v=$(").append(shellQuote(flink)).append(" --version 2>&1); rc=$?; ");
+    command.append("v=$(printf '%s\\n' \"$v\" | head -n 1); ");
+    command.append("printf 'YAK_FLINK_VERSION_OK=%s\\n' \"$([ $rc -eq 0 ] && echo 1 || echo 0)\"; ");
+    command.append("printf 'YAK_FLINK_VERSION=%s\\n' \"$v\"; ");
+    command.append("else printf 'YAK_FLINK_EXEC=0\\n'; fi; ");
+
+    if (StringUtils.hasText(config.javaHome())) {
+      String java = config.javaHome().replaceAll("/+$", "") + "/bin/java";
+      command.append("if test -x ").append(shellQuote(java)).append("; then ");
+      command.append("printf 'YAK_JAVA_EXEC=1\\n'; ");
+      command.append("v=$(").append(shellQuote(java)).append(" -version 2>&1); rc=$?; ");
+    } else {
+      command.append("if command -v java >/dev/null 2>&1; then ");
+      command.append("printf 'YAK_JAVA_EXEC=1\\n'; ");
+      command.append("v=$(java -version 2>&1); rc=$?; ");
+    }
+    command.append("v=$(printf '%s\\n' \"$v\" | head -n 1); ");
+    command.append("printf 'YAK_JAVA_VERSION_OK=%s\\n' \"$([ $rc -eq 0 ] && echo 1 || echo 0)\"; ");
+    command.append("printf 'YAK_JAVA_VERSION=%s\\n' \"$v\"; ");
+    command.append("else printf 'YAK_JAVA_EXEC=0\\n'; fi; ");
+
+    command.append("if command -v mktemp >/dev/null 2>&1; then ");
+    command.append("tmp=$(mktemp \"${TMPDIR:-/tmp}/yak-ops-probe.XXXXXX\" 2>/dev/null); ");
+    command.append("if test -n \"$tmp\" && test -f \"$tmp\"; then rm -f \"$tmp\"; printf 'YAK_TEMP=1\\n'; ");
+    command.append("else printf 'YAK_TEMP=0\\n'; fi; else printf 'YAK_TEMP=0\\n'; fi; ");
+
+    command
+        .append("printf 'YAK_REMOTE_REST=%s:%s\\n' ")
+        .append(shellQuote(remoteRestAddress(environment, restUri)))
+        .append(" ")
+        .append(shellQuote(Integer.toString(remoteRestPort(environment, restUri))))
+        .append("; exit 0");
+    return command.toString();
+  }
+
+  private RemoteProbe parseRemoteProbe(String output) {
+    Map<String, String> values = new HashMap<>();
+    if (output != null) {
+      output.lines()
+          .filter(line -> line.startsWith("YAK_"))
+          .forEach(
+              line -> {
+                int separator = line.indexOf('=');
+                if (separator > 0) {
+                  values.put(line.substring(0, separator), line.substring(separator + 1).trim());
+                }
+              });
+    }
+    if (!"1".equals(values.get("YAK_SSH"))) {
+      throw failure("SSH 已连接，但远端检测命令未返回预期标记", false, null);
+    }
+    return new RemoteProbe(
+        flag(values, "YAK_CDC_EXEC"),
+        flag(values, "YAK_CDC_VERSION_OK"),
+        values.get("YAK_CDC_VERSION"),
+        flag(values, "YAK_FLINK_EXEC"),
+        flag(values, "YAK_FLINK_VERSION_OK"),
+        values.get("YAK_FLINK_VERSION"),
+        flag(values, "YAK_JAVA_EXEC"),
+        flag(values, "YAK_JAVA_VERSION_OK"),
+        values.get("YAK_JAVA_VERSION"),
+        flag(values, "YAK_TEMP"));
+  }
+
+  private boolean flag(Map<String, String> values, String key) {
+    return "1".equals(values.get(key));
   }
 
   private String remoteSubmitCommand(ComputeEnvironmentSnapshot environment, URI restUri) {
@@ -385,4 +508,16 @@ final class SshFlinkCdcCommandRunner {
   }
 
   record ExecutionResult(int exitCode, boolean uncertain) {}
+
+  record RemoteProbe(
+      boolean cdcExecutable,
+      boolean cdcVersionCommandOk,
+      String cdcVersionOutput,
+      boolean flinkExecutable,
+      boolean flinkVersionCommandOk,
+      String flinkVersionOutput,
+      boolean javaExecutable,
+      boolean javaVersionCommandOk,
+      String javaVersionOutput,
+      boolean tempWritable) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
@@ -117,18 +117,20 @@ public class ComputeEnvironmentStore {
     }
   }
 
+  /** Persists a diagnosis only if the environment configuration did not change during the probe. */
   public void saveDiagnosis(
-      long id, String status, String message, LocalDateTime checkedAt) {
+      long id, int expectedVersion, String status, String message, LocalDateTime checkedAt) {
     int changed =
         db.update(
             "update yak_compute_environment set last_check_status=?,last_check_message=?,"
-                + "last_check_time=? where id=?",
+                + "last_check_time=? where id=? and version=?",
             status,
             message,
             checkedAt == null ? null : Timestamp.valueOf(checkedAt),
-            id);
+            id,
+            expectedVersion);
     if (changed != 1) {
-      throw new IllegalArgumentException("运行环境不存在：" + id);
+      throw new IllegalStateException("运行环境配置在检测期间已变化，请重新检测");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
@@ -117,20 +117,18 @@ public class ComputeEnvironmentStore {
     }
   }
 
-  /** Persists a diagnosis only if the environment configuration did not change during the probe. */
   public void saveDiagnosis(
-      long id, int expectedVersion, String status, String message, LocalDateTime checkedAt) {
+      long id, String status, String message, LocalDateTime checkedAt) {
     int changed =
         db.update(
             "update yak_compute_environment set last_check_status=?,last_check_message=?,"
-                + "last_check_time=? where id=? and version=?",
+                + "last_check_time=? where id=?",
             status,
             message,
             checkedAt == null ? null : Timestamp.valueOf(checkedAt),
-            id,
-            expectedVersion);
+            id);
     if (changed != 1) {
-      throw new IllegalStateException("运行环境配置在检测期间已变化，请重新检测");
+      throw new IllegalArgumentException("运行环境不存在：" + id);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
@@ -94,7 +94,8 @@ public class ComputeEnvironmentStore {
     int changed =
         db.update(
             "update yak_compute_environment set name=?,submitter_type=?,config_json=?,enabled=?,"
-                + "version=version+1 where id=?",
+                + "version=version+1,last_check_status=null,last_check_message=null,last_check_time=null "
+                + "where id=?",
             name,
             submitterType,
             write(config),
@@ -110,6 +111,21 @@ public class ComputeEnvironmentStore {
         db.update(
             "update yak_compute_environment set enabled=?,version=version+1 where id=?",
             enabled,
+            id);
+    if (changed != 1) {
+      throw new IllegalArgumentException("运行环境不存在：" + id);
+    }
+  }
+
+  public void saveDiagnosis(
+      long id, String status, String message, LocalDateTime checkedAt) {
+    int changed =
+        db.update(
+            "update yak_compute_environment set last_check_status=?,last_check_message=?,"
+                + "last_check_time=? where id=?",
+            status,
+            message,
+            checkedAt == null ? null : Timestamp.valueOf(checkedAt),
             id);
     if (changed != 1) {
       throw new IllegalArgumentException("运行环境不存在：" + id);
@@ -187,7 +203,10 @@ public class ComputeEnvironmentStore {
         result.getBoolean("is_default"),
         result.getInt("version"),
         time(result.getTimestamp("create_time")),
-        time(result.getTimestamp("update_time")));
+        time(result.getTimestamp("update_time")),
+        result.getString("last_check_status"),
+        result.getString("last_check_message"),
+        time(result.getTimestamp("last_check_time")));
   }
 
   private String write(Object value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
@@ -6,6 +6,9 @@ import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties.Submissio
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentDiagnosis;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.engine.FlinkRuntimeEnvironmentProbe;
 import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
 import jakarta.annotation.PostConstruct;
 import java.net.URI;
@@ -34,14 +37,17 @@ public class ComputeEnvironmentService {
 
   private final ComputeEnvironmentStore store;
   private final RealtimeSyncProperties properties;
+  private final FlinkRuntimeEnvironmentProbe probe;
   private final TransactionTemplate transactions;
 
   public ComputeEnvironmentService(
       ComputeEnvironmentStore store,
       RealtimeSyncProperties properties,
+      FlinkRuntimeEnvironmentProbe probe,
       @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager) {
     this.store = store;
     this.properties = properties;
+    this.probe = probe;
     this.transactions = new TransactionTemplate(transactionManager);
   }
 
@@ -68,8 +74,9 @@ public class ComputeEnvironmentService {
       boolean enabled,
       boolean makeDefault) {
     String normalizedName = normalizeName(name);
-    String normalizedSubmitter = normalizeSubmitterType(submitterType, ComputeEnvironment.SUBMITTER_LOCAL);
-    RuntimeConfig normalizedConfig = normalizeConfig(config, normalizedSubmitter);
+    String normalizedSubmitter =
+        normalizeSubmitterType(submitterType, ComputeEnvironment.SUBMITTER_LOCAL);
+    RuntimeConfig normalizedConfig = normalizeConfig(config, normalizedSubmitter, true);
     if (makeDefault && !enabled) {
       throw new IllegalArgumentException("默认运行环境必须保持启用");
     }
@@ -111,7 +118,7 @@ public class ComputeEnvironmentService {
     String normalizedSubmitter =
         normalizeSubmitterType(submitterType, current.submitterType());
     RuntimeConfig requestedConfig = preserveExistingSshConfig(current, normalizedSubmitter, config);
-    RuntimeConfig normalizedConfig = normalizeConfig(requestedConfig, normalizedSubmitter);
+    RuntimeConfig normalizedConfig = normalizeConfig(requestedConfig, normalizedSubmitter, true);
     boolean switchingDefault = makeDefault && !current.defaultEnvironment();
 
     if (current.defaultEnvironment() && !enabled) {
@@ -136,6 +143,36 @@ public class ComputeEnvironmentService {
     if (current.defaultEnvironment() || switchingDefault) {
       refreshRuntimeOverrides();
     }
+  }
+
+  /** Diagnoses a saved environment and stores only the small summary shown on its settings card. */
+  public ComputeEnvironmentDiagnosis diagnose(long id) {
+    ComputeEnvironment environment = require(id);
+    ComputeEnvironmentDiagnosis result = probe.diagnose(ComputeEnvironmentSnapshot.from(environment));
+    store.saveDiagnosis(id, result.status(), result.summary(), result.checkedAt());
+    return result;
+  }
+
+  /**
+   * Diagnoses an unsaved form so users can validate connectivity and auto-fill detected versions
+   * before creating or updating the environment. Preview checks never write to the database.
+   */
+  public ComputeEnvironmentDiagnosis diagnosePreview(
+      String name, String submitterType, RuntimeConfig config) {
+    String normalizedSubmitter =
+        normalizeSubmitterType(submitterType, ComputeEnvironment.SUBMITTER_LOCAL);
+    RuntimeConfig normalizedConfig = normalizeConfig(config, normalizedSubmitter, false);
+    String normalizedName = StringUtils.hasText(name) ? normalizeName(name) : "未保存环境";
+    ComputeEnvironmentSnapshot preview =
+        new ComputeEnvironmentSnapshot(
+            0L,
+            normalizedName,
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            normalizedSubmitter,
+            normalizedConfig,
+            0);
+    return probe.diagnose(preview);
   }
 
   public void setEnabled(long id, boolean enabled) {
@@ -220,7 +257,7 @@ public class ComputeEnvironmentService {
                   ComputeEnvironment.ENGINE_FLINK_CDC,
                   ComputeEnvironment.DEPLOYMENT_REMOTE,
                   submitterType,
-                  normalizeConfig(config, submitterType),
+                  normalizeConfig(config, submitterType, true),
                   true,
                   true);
             }
@@ -314,7 +351,8 @@ public class ComputeEnvironmentService {
         current.config().ssh());
   }
 
-  private RuntimeConfig normalizeConfig(RuntimeConfig value, String submitterType) {
+  private RuntimeConfig normalizeConfig(
+      RuntimeConfig value, String submitterType, boolean requireVersions) {
     if (value == null) {
       throw new IllegalArgumentException("运行环境配置不能为空");
     }
@@ -323,8 +361,14 @@ public class ComputeEnvironmentService {
     String flinkHome = required(value.flinkHome(), "Flink Home", 500);
     String flinkCdcHome = required(value.flinkCdcHome(), "Flink CDC Home", 500);
     String javaHome = optional(value.javaHome(), "Java Home", 500);
-    String flinkVersion = required(value.flinkVersion(), "Flink 版本", 64);
-    String flinkCdcVersion = required(value.flinkCdcVersion(), "Flink CDC 版本", 64);
+    String flinkVersion =
+        requireVersions
+            ? required(value.flinkVersion(), "Flink 版本", 64)
+            : optional(value.flinkVersion(), "Flink 版本", 64);
+    String flinkCdcVersion =
+        requireVersions
+            ? required(value.flinkCdcVersion(), "Flink CDC 版本", 64)
+            : optional(value.flinkCdcVersion(), "Flink CDC 版本", 64);
     SshConfig ssh = null;
     if (ComputeEnvironment.SUBMITTER_SSH.equals(submitterType)) {
       if (!absoluteUnixPath(flinkHome) || !absoluteUnixPath(flinkCdcHome)) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V8__add_compute_environment_diagnostics.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V8__add_compute_environment_diagnostics.sql
@@ -1,0 +1,4 @@
+ALTER TABLE yak_compute_environment
+  ADD COLUMN last_check_status VARCHAR(16) NULL AFTER version,
+  ADD COLUMN last_check_message VARCHAR(500) NULL AFTER last_check_status,
+  ADD COLUMN last_check_time DATETIME(3) NULL AFTER last_check_message;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewaySshTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewaySshTest.java
@@ -14,6 +14,7 @@ import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -103,6 +104,29 @@ class FlinkCdcEngineGatewaySshTest {
   }
 
   @Test
+  void probesSshRuntimeWithoutSubmittingPipeline() throws Exception {
+    Path captured = temp.resolve("should-not-contain-pipeline.yaml");
+    Path ssh = fakeSsh(captured, 0);
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.getSsh().setExecutable(temp.resolve("fallback-missing-ssh").toString());
+    SshFlinkCdcCommandRunner runner = new SshFlinkCdcCommandRunner(properties);
+    ComputeEnvironmentSnapshot environment = sshEnvironment(ssh, "10.0.0.99", 2202);
+
+    SshFlinkCdcCommandRunner.RemoteProbe result =
+        runner.probe(environment, URI.create(environment.config().restUrl()));
+
+    assertThat(result.cdcExecutable()).isTrue();
+    assertThat(result.cdcVersionCommandOk()).isTrue();
+    assertThat(result.cdcVersionOutput()).contains("3.6.0");
+    assertThat(result.flinkExecutable()).isTrue();
+    assertThat(result.flinkVersionOutput()).contains("1.20.5");
+    assertThat(result.javaExecutable()).isTrue();
+    assertThat(result.javaVersionOutput()).contains("17.0.12");
+    assertThat(result.tempWritable()).isTrue();
+    assertThat(captured).doesNotExist();
+  }
+
+  @Test
   void propagatesSsh255AsUncertainEngineFailureAndRetainsLog() throws Exception {
     Path ssh = fakeSsh(temp.resolve("remote-uncertain.yaml"), 255);
     RealtimeSyncProperties properties = sshProperties(ssh);
@@ -189,6 +213,19 @@ class FlinkCdcEngineGatewaySshTest {
         "#!/bin/sh\n"
             + "case \"$*\" in\n"
             + "  *YAK_REALTIME_SSH_READY*) exit 0 ;;\n"
+            + "  *YAK_CDC_EXEC*)\n"
+            + "    echo 'YAK_SSH=1'\n"
+            + "    echo 'YAK_CDC_EXEC=1'\n"
+            + "    echo 'YAK_CDC_VERSION_OK=1'\n"
+            + "    echo 'YAK_CDC_VERSION=Flink CDC version 3.6.0'\n"
+            + "    echo 'YAK_FLINK_EXEC=1'\n"
+            + "    echo 'YAK_FLINK_VERSION_OK=1'\n"
+            + "    echo 'YAK_FLINK_VERSION=Version: 1.20.5'\n"
+            + "    echo 'YAK_JAVA_EXEC=1'\n"
+            + "    echo 'YAK_JAVA_VERSION_OK=1'\n"
+            + "    echo 'YAK_JAVA_VERSION=openjdk version 17.0.12'\n"
+            + "    echo 'YAK_TEMP=1'\n"
+            + "    exit 0 ;;\n"
             + "esac\n"
             + "cat > "
             + shell(captured)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkRuntimeEnvironmentProbeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkRuntimeEnvironmentProbeTest.java
@@ -1,0 +1,119 @@
+package io.yak.ops.business.sync.realtime.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentDiagnosis;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FlinkRuntimeEnvironmentProbeTest {
+
+  @TempDir Path temp;
+
+  @Test
+  void detectsLocalFlinkCdcJavaAndWritableWorkDirectory() throws Exception {
+    Path flinkHome = Files.createDirectories(temp.resolve("flink/bin")).getParent();
+    Path cdcHome = Files.createDirectories(temp.resolve("flink-cdc/bin")).getParent();
+    Path javaHome = Files.createDirectories(temp.resolve("java/bin")).getParent();
+
+    executable(flinkHome.resolve("bin/flink"), "#!/bin/sh\necho 'Version: 1.20.5'\n");
+    executable(cdcHome.resolve("bin/flink-cdc.sh"), "#!/bin/sh\necho 'Flink CDC version 3.6.0'\n");
+    executable(javaHome.resolve("bin/java"), "#!/bin/sh\necho 'openjdk version \"17.0.12\"' >&2\n");
+
+    RealtimeEngineGateway gateway = mock(RealtimeEngineGateway.class);
+    ObjectNode overview = new ObjectMapper().createObjectNode();
+    overview.put("flink-version", "1.20.5");
+    overview.put("taskmanagers", 2);
+    overview.put("slots-total", 8);
+    overview.put("slots-available", 6);
+    overview.put("jobs-running", 1);
+    when(gateway.health(org.mockito.ArgumentMatchers.any())).thenReturn(overview);
+
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setWorkDirectory(temp.resolve("work").toString());
+    FlinkRuntimeEnvironmentProbe probe = new FlinkRuntimeEnvironmentProbe(gateway, properties);
+    ComputeEnvironmentSnapshot environment =
+        new ComputeEnvironmentSnapshot(
+            3L,
+            "local",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://flink:8081",
+                flinkHome.toString(),
+                cdcHome.toString(),
+                javaHome.toString(),
+                "1.20.5",
+                "3.6.0"),
+            2);
+
+    ComputeEnvironmentDiagnosis result = probe.diagnose(environment);
+
+    assertThat(result.status()).isEqualTo(ComputeEnvironmentDiagnosis.STATUS_HEALTHY);
+    assertThat(result.ready()).isTrue();
+    assertThat(result.detectedFlinkVersion()).isEqualTo("1.20.5");
+    assertThat(result.detectedFlinkCdcVersion()).isEqualTo("3.6.0");
+    assertThat(result.detectedJavaVersion()).isEqualTo("17.0.12");
+    assertThat(result.checks())
+        .allMatch(check -> ComputeEnvironmentDiagnosis.Check.PASS.equals(check.status()));
+  }
+
+  @Test
+  void reportsConfiguredVersionMismatchAsWarningNotFailure() throws Exception {
+    Path flinkHome = Files.createDirectories(temp.resolve("flink2/bin")).getParent();
+    Path cdcHome = Files.createDirectories(temp.resolve("flink-cdc2/bin")).getParent();
+    Path javaHome = Files.createDirectories(temp.resolve("java2/bin")).getParent();
+
+    executable(flinkHome.resolve("bin/flink"), "#!/bin/sh\necho 'Version: 1.20.5'\n");
+    executable(cdcHome.resolve("bin/flink-cdc.sh"), "#!/bin/sh\necho 'Flink CDC version 3.6.0'\n");
+    executable(javaHome.resolve("bin/java"), "#!/bin/sh\necho 'openjdk version \"17.0.12\"' >&2\n");
+
+    RealtimeEngineGateway gateway = mock(RealtimeEngineGateway.class);
+    ObjectNode overview = new ObjectMapper().createObjectNode();
+    overview.put("flink-version", "1.20.5");
+    when(gateway.health(org.mockito.ArgumentMatchers.any())).thenReturn(overview);
+
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setWorkDirectory(temp.resolve("work2").toString());
+    FlinkRuntimeEnvironmentProbe probe = new FlinkRuntimeEnvironmentProbe(gateway, properties);
+    ComputeEnvironmentSnapshot environment =
+        new ComputeEnvironmentSnapshot(
+            4L,
+            "mismatch",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://flink:8081",
+                flinkHome.toString(),
+                cdcHome.toString(),
+                javaHome.toString(),
+                "1.19.0",
+                "3.5.0"),
+            1);
+
+    ComputeEnvironmentDiagnosis result = probe.diagnose(environment);
+
+    assertThat(result.status()).isEqualTo(ComputeEnvironmentDiagnosis.STATUS_WARNING);
+    assertThat(result.ready()).isTrue();
+    assertThat(result.checks()).anyMatch(check -> check.message().contains("当前配置为"));
+  }
+
+  private void executable(Path path, String content) throws Exception {
+    Files.writeString(path, content, StandardCharsets.UTF_8);
+    Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentServiceTest.java
@@ -12,7 +12,13 @@ import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.SshConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentDiagnosis;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.engine.FlinkRuntimeEnvironmentProbe;
 import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -22,15 +28,18 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 class ComputeEnvironmentServiceTest {
 
   private ComputeEnvironmentStore store;
+  private FlinkRuntimeEnvironmentProbe probe;
   private ComputeEnvironmentService service;
 
   @BeforeEach
   void setUp() {
     store = mock(ComputeEnvironmentStore.class);
+    probe = mock(FlinkRuntimeEnvironmentProbe.class);
     PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
     when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
     service =
-        new ComputeEnvironmentService(store, new RealtimeSyncProperties(), transactionManager);
+        new ComputeEnvironmentService(
+            store, new RealtimeSyncProperties(), probe, transactionManager);
   }
 
   @Test
@@ -107,5 +116,48 @@ class ComputeEnvironmentServiceTest {
     assertThatThrownBy(() -> service.create("bad-path", "SSH", config, true, false))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Linux 绝对路径");
+  }
+
+  @Test
+  void persistsDiagnosisSummaryForSavedEnvironment() {
+    LocalDateTime checkedAt = LocalDateTime.of(2026, 8, 22, 10, 0);
+    ComputeEnvironment environment =
+        new ComputeEnvironment(
+            11L,
+            "生产实时环境",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://flink:8081", "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
+            true,
+            false,
+            3,
+            checkedAt.minusDays(1),
+            checkedAt.minusDays(1));
+    ComputeEnvironmentDiagnosis diagnosis =
+        new ComputeEnvironmentDiagnosis(
+            11L,
+            environment.name(),
+            ComputeEnvironmentDiagnosis.STATUS_HEALTHY,
+            true,
+            "环境检查通过，可以提交实时同步任务",
+            "1.20.5",
+            "3.6.0",
+            "17.0.12",
+            checkedAt,
+            List.of());
+    when(store.find(11L)).thenReturn(Optional.of(environment));
+    when(probe.diagnose(any(ComputeEnvironmentSnapshot.class))).thenReturn(diagnosis);
+
+    ComputeEnvironmentDiagnosis result = service.diagnose(11L);
+
+    assertThat(result).isEqualTo(diagnosis);
+    verify(store)
+        .saveDiagnosis(
+            11L,
+            ComputeEnvironmentDiagnosis.STATUS_HEALTHY,
+            "环境检查通过，可以提交实时同步任务",
+            checkedAt);
   }
 }

--- a/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ComputeEngineSettingsPanel.tsx
@@ -1,11 +1,16 @@
 import {
+  CheckCircleFilled,
+  CloseCircleFilled,
   DeleteOutlined,
   EditOutlined,
   PlusOutlined,
+  ReloadOutlined,
   StarFilled,
   StarOutlined,
+  WarningFilled,
 } from '@ant-design/icons';
 import {
+  Alert,
   Button,
   Empty,
   Form,
@@ -26,6 +31,9 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   computeEnvironmentApi,
   type ComputeEnvironment,
+  type ComputeEnvironmentDiagnosis,
+  type ComputeEnvironmentDiagnosisCheck,
+  type ComputeEnvironmentHealthStatus,
   type ComputeEnvironmentPayload,
 } from '../services/computeEnvironments';
 
@@ -83,6 +91,58 @@ const errorText = (error: unknown, fallback: string): string =>
 const submitterLabel = (value?: SubmitterType | string | null) =>
   value === 'SSH' ? 'SSH 远程执行' : '本机执行';
 
+const healthMeta = (status?: ComputeEnvironmentHealthStatus) => {
+  switch (status) {
+    case 'HEALTHY':
+      return { label: '环境正常', color: 'green', icon: <CheckCircleFilled /> };
+    case 'WARNING':
+      return { label: '需要关注', color: 'gold', icon: <WarningFilled /> };
+    case 'FAILED':
+      return { label: '检测失败', color: 'red', icon: <CloseCircleFilled /> };
+    default:
+      return { label: '未检测', color: 'default', icon: undefined };
+  }
+};
+
+const checkIcon = (check: ComputeEnvironmentDiagnosisCheck) => {
+  if (check.status === 'PASS') return <CheckCircleFilled className="text-[#12b76a]" />;
+  if (check.status === 'WARN') return <WarningFilled className="text-[#f79009]" />;
+  return <CloseCircleFilled className="text-[#f04438]" />;
+};
+
+const formatTime = (value?: string) =>
+  value ? new Date(value).toLocaleString('zh-CN') : '尚未检测';
+
+const toPayload = (values: FormValues): ComputeEnvironmentPayload => ({
+  name: values.name.trim(),
+  submitterType: values.submitterType,
+  enabled: values.enabled,
+  makeDefault: values.makeDefault,
+  config: {
+    restUrl: values.restUrl.trim(),
+    flinkHome: values.flinkHome.trim(),
+    flinkCdcHome: values.flinkCdcHome.trim(),
+    javaHome: values.javaHome?.trim() || undefined,
+    flinkVersion: values.flinkVersion.trim(),
+    flinkCdcVersion: values.flinkCdcVersion.trim(),
+    ssh:
+      values.submitterType === 'SSH'
+        ? {
+            executable: values.sshExecutable?.trim() || 'ssh',
+            host: values.sshHost?.trim(),
+            port: values.sshPort || 22,
+            user: values.sshUser?.trim(),
+            identityFile: values.sshIdentityFile?.trim() || undefined,
+            knownHostsFile: values.sshKnownHostsFile?.trim() || undefined,
+            strictHostKeyChecking: values.sshStrictHostKeyChecking ?? true,
+            connectTimeoutSeconds: values.sshConnectTimeoutSeconds || 5,
+            remoteRestAddress: values.sshRemoteRestAddress?.trim() || undefined,
+            remoteRestPort: values.sshRemoteRestPort,
+          }
+        : undefined,
+  },
+});
+
 const ComputeEngineSettingsPanel = () => {
   const [form] = Form.useForm<FormValues>();
   const [environments, setEnvironments] = useState<ComputeEnvironment[]>([]);
@@ -93,6 +153,9 @@ const ComputeEngineSettingsPanel = () => {
   const [switchingId, setSwitchingId] = useState<number | null>(null);
   const [defaultingId, setDefaultingId] = useState<number | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [diagnosingId, setDiagnosingId] = useState<number | null>(null);
+  const [previewDiagnosing, setPreviewDiagnosing] = useState(false);
+  const [diagnosis, setDiagnosis] = useState<ComputeEnvironmentDiagnosis | null>(null);
   const submitterType = Form.useWatch('submitterType', form) || 'LOCAL';
 
   const load = useCallback(async () => {
@@ -155,44 +218,15 @@ const ComputeEngineSettingsPanel = () => {
       return;
     }
 
-    const payload: ComputeEnvironmentPayload = {
-      name: values.name.trim(),
-      submitterType: values.submitterType,
-      enabled: values.enabled,
-      makeDefault: values.makeDefault,
-      config: {
-        restUrl: values.restUrl.trim(),
-        flinkHome: values.flinkHome.trim(),
-        flinkCdcHome: values.flinkCdcHome.trim(),
-        javaHome: values.javaHome?.trim() || undefined,
-        flinkVersion: values.flinkVersion.trim(),
-        flinkCdcVersion: values.flinkCdcVersion.trim(),
-        ssh:
-          values.submitterType === 'SSH'
-            ? {
-                executable: values.sshExecutable?.trim() || 'ssh',
-                host: values.sshHost?.trim(),
-                port: values.sshPort || 22,
-                user: values.sshUser?.trim(),
-                identityFile: values.sshIdentityFile?.trim() || undefined,
-                knownHostsFile: values.sshKnownHostsFile?.trim() || undefined,
-                strictHostKeyChecking: values.sshStrictHostKeyChecking ?? true,
-                connectTimeoutSeconds: values.sshConnectTimeoutSeconds || 5,
-                remoteRestAddress: values.sshRemoteRestAddress?.trim() || undefined,
-                remoteRestPort: values.sshRemoteRestPort,
-              }
-            : undefined,
-      },
-    };
-
     setSaving(true);
     try {
+      const payload = toPayload(values);
       if (editing) {
         await computeEnvironmentApi.update(editing.id, payload);
-        message.success('运行环境已更新');
+        message.success('运行环境已更新，建议重新检测环境');
       } else {
         await computeEnvironmentApi.create(payload);
-        message.success('运行环境已创建');
+        message.success('运行环境已创建，建议执行一次环境检测');
       }
       setModalOpen(false);
       await load();
@@ -200,6 +234,53 @@ const ComputeEngineSettingsPanel = () => {
       message.error(errorText(error, editing ? '运行环境更新失败' : '运行环境创建失败'));
     } finally {
       setSaving(false);
+    }
+  };
+
+  const diagnosePreview = async () => {
+    let values: FormValues;
+    try {
+      values = await form.validateFields();
+    } catch {
+      return;
+    }
+    setPreviewDiagnosing(true);
+    try {
+      const response = await computeEnvironmentApi.diagnosePreview(toPayload(values));
+      const result = response.data;
+      const detected: Partial<FormValues> = {};
+      if (result.detectedFlinkVersion) detected.flinkVersion = result.detectedFlinkVersion;
+      if (result.detectedFlinkCdcVersion) detected.flinkCdcVersion = result.detectedFlinkCdcVersion;
+      if (Object.keys(detected).length) {
+        form.setFieldsValue(detected);
+      }
+      setDiagnosis(result);
+      if (result.ready) {
+        message.success(
+          Object.keys(detected).length ? '检测完成，已自动填入识别到的版本' : '运行环境检测完成',
+        );
+      } else {
+        message.warning('检测发现阻塞项，请按结果修正后再保存');
+      }
+    } catch (error) {
+      message.error(errorText(error, '运行环境检测失败'));
+    } finally {
+      setPreviewDiagnosing(false);
+    }
+  };
+
+  const diagnoseSaved = async (environment: ComputeEnvironment) => {
+    setDiagnosingId(environment.id);
+    try {
+      const response = await computeEnvironmentApi.diagnose(environment.id);
+      setDiagnosis(response.data);
+      await load();
+      if (response.data.ready) message.success('运行环境检测完成');
+      else message.warning('检测发现阻塞项，请查看检测详情');
+    } catch (error) {
+      message.error(errorText(error, '运行环境检测失败'));
+    } finally {
+      setDiagnosingId(null);
     }
   };
 
@@ -248,7 +329,7 @@ const ComputeEngineSettingsPanel = () => {
         <div>
           <div className="text-[18px] font-semibold text-[#161823]">计算引擎</div>
           <div className="mt-1.5 max-w-[700px] text-[12px] leading-5 text-[#667085]">
-            集中管理实时同步使用的运行环境。Yak Ops 可以在本机执行 Flink CDC，也可以通过 SSH 到远端提交节点执行。
+            集中管理实时同步使用的运行环境。配置完成后可以一键检测 SSH、Flink REST、CLI、Java 和工作目录，并自动识别运行版本。
           </div>
         </div>
         <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
@@ -257,7 +338,7 @@ const ComputeEngineSettingsPanel = () => {
       </div>
 
       <div className="mb-5 rounded-lg border border-[#e4e7ec] bg-[#f9fafb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-        任务只需要选择运行环境。Flink REST 用于状态、停止和指标；“任务提交方式”只决定 flink-cdc.sh 在 Yak Ops 本机执行，还是通过 SSH 在远端服务器执行。
+        任务只需要选择运行环境。检测只做连通性和只读运行检查，不会提交 Flink Job；修改环境配置后，历史检测状态会自动失效，建议重新检测。
       </div>
 
       {loading ? (
@@ -276,6 +357,7 @@ const ComputeEngineSettingsPanel = () => {
         <div className="space-y-4">
           {environments.map((environment) => {
             const ssh = environment.config.ssh;
+            const health = healthMeta(environment.lastCheckStatus);
             return (
               <div
                 key={environment.id}
@@ -294,6 +376,9 @@ const ComputeEngineSettingsPanel = () => {
                       )}
                       <Tag color={environment.enabled ? 'green' : 'default'} className="!mr-0">
                         {environment.enabled ? '已启用' : '已停用'}
+                      </Tag>
+                      <Tag color={health.color} icon={health.icon} className="!mr-0">
+                        {health.label}
                       </Tag>
                     </div>
 
@@ -376,54 +461,71 @@ const ComputeEngineSettingsPanel = () => {
                   </div>
                 </div>
 
-                <div className="mt-4 flex items-center justify-end gap-1 border-t border-[#f2f4f7] pt-3">
-                  {!environment.defaultEnvironment && (
-                    <Tooltip title={!environment.enabled ? '请先启用该运行环境' : undefined}>
-                      <Button
-                        type="link"
-                        size="small"
-                        icon={<StarOutlined />}
-                        disabled={!environment.enabled}
-                        loading={defaultingId === environment.id}
-                        onClick={() => void setDefault(environment)}
-                      >
-                        设为默认
-                      </Button>
-                    </Tooltip>
-                  )}
-                  <Button
-                    type="link"
-                    size="small"
-                    icon={<EditOutlined />}
-                    onClick={() => openEdit(environment)}
-                  >
-                    编辑
-                  </Button>
-                  <Popconfirm
-                    title="删除运行环境"
-                    description={
-                      environment.defaultEnvironment
-                        ? '默认运行环境不能删除，请先切换默认环境。'
-                        : `确定删除 ${environment.name} 吗？如果仍有实时任务绑定该环境，系统会拒绝删除。`
-                    }
-                    disabled={environment.defaultEnvironment}
-                    okText="删除"
-                    cancelText="取消"
-                    okButtonProps={{ danger: true, loading: deletingId === environment.id }}
-                    onConfirm={() => remove(environment)}
-                  >
-                    <Tooltip title={environment.defaultEnvironment ? '请先切换默认环境' : undefined}>
-                      <Button
-                        type="link"
-                        size="small"
-                        danger
-                        disabled={environment.defaultEnvironment}
-                        icon={<DeleteOutlined />}
-                      >
-                        删除
-                      </Button>
-                    </Tooltip>
-                  </Popconfirm>
+                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-[#f2f4f7] pt-3">
+                  <div className="min-w-0 text-[11px] text-[#98a2b3]">
+                    <span>{formatTime(environment.lastCheckTime)}</span>
+                    {environment.lastCheckMessage && (
+                      <span className="ml-2">· {environment.lastCheckMessage}</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="link"
+                      size="small"
+                      icon={<ReloadOutlined />}
+                      loading={diagnosingId === environment.id}
+                      onClick={() => void diagnoseSaved(environment)}
+                    >
+                      检测环境
+                    </Button>
+                    {!environment.defaultEnvironment && (
+                      <Tooltip title={!environment.enabled ? '请先启用该运行环境' : undefined}>
+                        <Button
+                          type="link"
+                          size="small"
+                          icon={<StarOutlined />}
+                          disabled={!environment.enabled}
+                          loading={defaultingId === environment.id}
+                          onClick={() => void setDefault(environment)}
+                        >
+                          设为默认
+                        </Button>
+                      </Tooltip>
+                    )}
+                    <Button
+                      type="link"
+                      size="small"
+                      icon={<EditOutlined />}
+                      onClick={() => openEdit(environment)}
+                    >
+                      编辑
+                    </Button>
+                    <Popconfirm
+                      title="删除运行环境"
+                      description={
+                        environment.defaultEnvironment
+                          ? '默认运行环境不能删除，请先切换默认环境。'
+                          : `确定删除 ${environment.name} 吗？如果仍有实时任务绑定该环境，系统会拒绝删除。`
+                      }
+                      disabled={environment.defaultEnvironment}
+                      okText="删除"
+                      cancelText="取消"
+                      okButtonProps={{ danger: true, loading: deletingId === environment.id }}
+                      onConfirm={() => remove(environment)}
+                    >
+                      <Tooltip title={environment.defaultEnvironment ? '请先切换默认环境' : undefined}>
+                        <Button
+                          type="link"
+                          size="small"
+                          danger
+                          disabled={environment.defaultEnvironment}
+                          icon={<DeleteOutlined />}
+                        >
+                          删除
+                        </Button>
+                      </Tooltip>
+                    </Popconfirm>
+                  </div>
                 </div>
               </div>
             );
@@ -439,7 +541,7 @@ const ComputeEngineSettingsPanel = () => {
         cancelText="取消"
         confirmLoading={saving}
         onOk={() => void save()}
-        onCancel={() => !saving && setModalOpen(false)}
+        onCancel={() => !saving && !previewDiagnosing && setModalOpen(false)}
       >
         <Form<FormValues>
           form={form}
@@ -510,7 +612,22 @@ const ComputeEngineSettingsPanel = () => {
           </div>
 
           <div className="mt-4 rounded-lg border border-[#eaecf0] px-4 py-4">
-            <div className="mb-4 text-[13px] font-semibold text-[#1d2939]">Flink 集群</div>
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <div className="text-[13px] font-semibold text-[#1d2939]">Flink 集群</div>
+                <div className="mt-1 text-[11px] text-[#98a2b3]">
+                  可先填写连接和路径，再点击检测自动识别 Flink / CDC 版本。
+                </div>
+              </div>
+              <Button
+                size="small"
+                icon={<ReloadOutlined />}
+                loading={previewDiagnosing}
+                onClick={() => void diagnosePreview()}
+              >
+                检测并识别版本
+              </Button>
+            </div>
             <Form.Item
               name="restUrl"
               label="JobManager REST URL"
@@ -524,14 +641,14 @@ const ComputeEngineSettingsPanel = () => {
                 label="Flink 版本"
                 rules={[{ required: true, message: '请输入 Flink 版本' }]}
               >
-                <Input placeholder="1.20.5" />
+                <Input placeholder="检测后自动填写，也可手动输入" />
               </Form.Item>
               <Form.Item
                 name="flinkCdcVersion"
                 label="Flink CDC 版本"
                 rules={[{ required: true, message: '请输入 Flink CDC 版本' }]}
               >
-                <Input placeholder="3.6.0" />
+                <Input placeholder="检测后自动填写，也可手动输入" />
               </Form.Item>
             </div>
           </div>
@@ -617,8 +734,8 @@ const ComputeEngineSettingsPanel = () => {
             </div>
             <div className="mb-4 text-[11px] leading-5 text-[#98a2b3]">
               {submitterType === 'SSH'
-                ? '以下路径填写 SSH 服务器上的 Linux 路径。'
-                : '以下路径填写 Yak Ops 所在服务器上的运行路径。'}
+                ? '以下路径填写 SSH 服务器上的 Linux 路径。环境检测会检查 CLI、Java 和远端临时目录。'
+                : '以下路径填写 Yak Ops 所在服务器上的运行路径。环境检测会检查 CLI、Java 和 Yak Ops 工作目录。'}
             </div>
             <Form.Item
               name="flinkHome"
@@ -639,6 +756,76 @@ const ComputeEngineSettingsPanel = () => {
             </Form.Item>
           </div>
         </Form>
+      </Modal>
+
+      <Modal
+        title="运行环境检测"
+        open={Boolean(diagnosis)}
+        width={680}
+        footer={
+          <Button type="primary" onClick={() => setDiagnosis(null)}>
+            关闭
+          </Button>
+        }
+        onCancel={() => setDiagnosis(null)}
+      >
+        {diagnosis && (
+          <div className="pt-2">
+            <Alert
+              showIcon
+              type={
+                diagnosis.status === 'HEALTHY'
+                  ? 'success'
+                  : diagnosis.status === 'WARNING'
+                    ? 'warning'
+                    : 'error'
+              }
+              message={diagnosis.summary}
+              description={`检测时间：${formatTime(diagnosis.checkedAt)}`}
+            />
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
+                <div className="text-[11px] text-[#98a2b3]">Flink</div>
+                <div className="mt-1 font-medium text-[#344054]">
+                  {diagnosis.detectedFlinkVersion || '未识别'}
+                </div>
+              </div>
+              <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
+                <div className="text-[11px] text-[#98a2b3]">Flink CDC</div>
+                <div className="mt-1 font-medium text-[#344054]">
+                  {diagnosis.detectedFlinkCdcVersion || '未识别'}
+                </div>
+              </div>
+              <div className="rounded-lg bg-[#f9fafb] px-3 py-3">
+                <div className="text-[11px] text-[#98a2b3]">Java</div>
+                <div className="mt-1 font-medium text-[#344054]">
+                  {diagnosis.detectedJavaVersion || '未识别'}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-5 overflow-hidden rounded-lg border border-[#eaecf0]">
+              {diagnosis.checks.map((check, index) => (
+                <div
+                  key={check.key}
+                  className={[
+                    'flex items-start gap-3 px-4 py-3',
+                    index > 0 ? 'border-t border-[#f2f4f7]' : '',
+                  ].join(' ')}
+                >
+                  <span className="mt-0.5 text-[15px]">{checkIcon(check)}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[12px] font-medium text-[#344054]">{check.label}</div>
+                    <div className="mt-0.5 break-all text-[11px] leading-5 text-[#667085]">
+                      {check.message}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </Modal>
     </div>
   );

--- a/yak-ops-ui/src/pages/settings/services/computeEnvironments.ts
+++ b/yak-ops-ui/src/pages/settings/services/computeEnvironments.ts
@@ -25,6 +25,29 @@ export interface ComputeEnvironmentRuntimeConfig {
   ssh?: ComputeEnvironmentSshConfig;
 }
 
+export type ComputeEnvironmentCheckStatus = 'PASS' | 'WARN' | 'FAIL';
+export type ComputeEnvironmentHealthStatus = 'HEALTHY' | 'WARNING' | 'FAILED';
+
+export interface ComputeEnvironmentDiagnosisCheck {
+  key: string;
+  label: string;
+  status: ComputeEnvironmentCheckStatus;
+  message: string;
+}
+
+export interface ComputeEnvironmentDiagnosis {
+  environmentId?: number;
+  environmentName: string;
+  status: ComputeEnvironmentHealthStatus;
+  ready: boolean;
+  summary: string;
+  detectedFlinkVersion?: string;
+  detectedFlinkCdcVersion?: string;
+  detectedJavaVersion?: string;
+  checkedAt: string;
+  checks: ComputeEnvironmentDiagnosisCheck[];
+}
+
 export interface ComputeEnvironment {
   id: number;
   name: string;
@@ -37,6 +60,9 @@ export interface ComputeEnvironment {
   version: number;
   createTime?: string;
   updateTime?: string;
+  lastCheckStatus?: ComputeEnvironmentHealthStatus;
+  lastCheckMessage?: string;
+  lastCheckTime?: string;
 }
 
 export interface ComputeEnvironmentPayload {
@@ -61,6 +87,15 @@ export const computeEnvironmentApi = {
     request<ApiResponse<number>>(PREFIX, { method: 'POST', data: payload }),
   update: (id: number, payload: ComputeEnvironmentPayload) =>
     request<ApiResponse<boolean>>(`${PREFIX}/${id}`, { method: 'PUT', data: payload }),
+  diagnosePreview: (payload: ComputeEnvironmentPayload) =>
+    request<ApiResponse<ComputeEnvironmentDiagnosis>>(`${PREFIX}/diagnose`, {
+      method: 'POST',
+      data: payload,
+    }),
+  diagnose: (id: number) =>
+    request<ApiResponse<ComputeEnvironmentDiagnosis>>(`${PREFIX}/${id}/diagnose`, {
+      method: 'POST',
+    }),
   setEnabled: (id: number, enabled: boolean) =>
     request<ApiResponse<boolean>>(`${PREFIX}/${id}/enabled`, {
       method: 'PUT',


### PR DESCRIPTION
## 背景

这是实时同步运行环境改造的第四阶段，也是本轮“小而精”运行环境能力的收尾阶段。

前三阶段已经完成：

- 设置 → 计算引擎 → 运行环境；
- 实时任务显式绑定运行环境，并在 deployment 中保存不可变环境快照；
- 支持 Local / SSH 两种任务提交方式。

本阶段只解决一个体验问题：**环境配置好了以后，用户怎样在启动任务之前就知道它到底能不能用、哪里有问题、实际运行版本是什么。**

因此本 PR 新增显式的「检测环境」能力，不增加新的部署模型，也不做后台巡检或自动修复。

## 本次实现

### 1. 一键检测运行环境

设置 → 计算引擎的每个运行环境卡片增加「检测环境」。

检测结果统一分为：

- `HEALTHY`：环境正常，可以提交任务；
- `WARNING`：环境可用，但存在需要关注的配置/版本差异；
- `FAILED`：存在阻塞项，不建议提交任务。

每个检测项单独展示 PASS / WARN / FAIL 和可读原因，避免只返回一个“连接失败”。

### 2. 检测范围

共同检测：

- Yak Ops realtime work-directory 是否可创建/写入临时文件；
- Flink JobManager REST `/overview` 是否可访问；
- Flink REST 返回的 TaskManager、Slot、Running Job 等基本信息；
- Flink CLI 是否存在/可执行；
- Flink CDC CLI 是否存在/可执行；
- Java 是否可执行；
- Flink / Flink CDC / Java 版本识别。

Local 模式直接检查 Yak Ops 所在服务器的本地运行环境。

SSH 模式额外检测：

- SSH 是否可以免交互连接/认证；
- 配置的 Identity File（如果有）在 Yak Ops 主机上是否存在；
- 远端 Flink / Flink CDC / Java；
- 远端 `mktemp` 是否能够创建并清理临时文件。

检测过程只执行只读/临时探测命令，**不会提交 Flink Job，也不会把 pipeline 或数据源密码带入检测命令。**

### 3. 自动识别运行版本

新建/编辑运行环境时增加「检测并识别版本」。

检测到版本后会自动回填表单中的：

- Flink 版本；
- Flink CDC 版本。

Java 版本只在检测详情中展示，不增加额外配置字段。

如果实际版本与当前填写版本不同，不直接判定环境失败，而是返回 WARNING，例如：

`检测到 1.20.5，当前配置为 1.20.0`

这样用户可以确认后保存正确版本。

### 4. 卡片直接展示最近检测状态

`yak_compute_environment` 新增：

- `last_check_status`
- `last_check_message`
- `last_check_time`

运行环境卡片直接展示：

- 环境正常 / 需要关注 / 检测失败 / 未检测；
- 最近检测时间；
- 最近检测摘要。

编辑运行环境的实际运行配置后，会清空旧检测状态，避免把旧结果误认为当前配置仍然有效。

这里只持久化一个很小的最近检测摘要；完整检查明细仍然是本次请求的即时结果，不引入额外诊断历史表。

### 5. API

新增：

- `POST /api/v1/compute-environments/{id}/diagnose`：检测已保存环境，并更新最近检测摘要；
- `POST /api/v1/compute-environments/diagnose`：检测尚未保存/正在编辑的表单配置，不写数据库。

Preview API 允许版本暂时为空，便于后续前端继续演进为完全依赖自动检测；正式保存仍保持版本必填约束。

### 6. SSH 检测仍保持轻量

没有引入 Agent，也没有在远端部署任何 Yak Ops 组件。

SSH 检测复用现有 OpenSSH 连接方式，通过一次远端命令返回结构化标记，用于判断：

- SSH 可达；
- CLI 可执行；
- 版本命令结果；
- Java；
- 临时目录。

任务真正运行时的提交链路没有改变。

## 数据库

新增 Flyway：

`V8__add_compute_environment_diagnostics.sql`

只给 `yak_compute_environment` 增加三个最近检测字段，不新增业务表。

## 测试

新增 / 更新测试覆盖：

- Local 模式能识别 Flink / Flink CDC / Java，并检查工作目录；
- 配置版本与实际版本不一致时返回 WARNING，而不是 FAILED；
- SSH 环境探测能够读取远端 CLI / Java / 临时目录结果，并且不会写入 pipeline；
- 已保存环境检测后会持久化最近检测摘要；
- Stage 3 的 SSH 提交与环境级 SSH 配置行为继续保留。

当前没有可用的 GitHub Actions 运行结果，因此这里不声明 CI 已通过。

## 建议人工验证

1. 进入 设置 → 计算引擎，选择一个 Local 环境，点击「检测环境」；
2. 确认 REST、Flink CLI、CDC CLI、Java、工作目录均按项展示；
3. 故意把 Flink / CDC 版本填错，点击「检测并识别版本」，确认检测结果为 WARNING 且表单自动回填实际版本；
4. 新建 SSH 环境，填写 Host / Port / User / Identity File，点击检测；
5. 分别制造 SSH 不通、CDC 路径错误、Java 路径错误，确认页面给出对应失败项；
6. 修正配置重新检测，卡片应显示「环境正常」和最近检测时间；
7. 修改环境配置并保存，旧检测状态应清空，提示用户重新检测；
8. 确认整个检测过程中 Flink 集群没有新增 Job。

## 本轮阶段完成后的边界

到本 PR 为止，Yak Ops 的实时同步运行环境形成完整闭环：

`配置运行环境 → 检测环境 → 任务选择环境 → Local/SSH 提交 → Deployment Snapshot → Flink REST 运维`

Yarn / Kubernetes、Agent、自动后台巡检等继续作为未来能力，不在当前“小而精”的范围内。