### PR TITLE
refactor(database): replace physical foreign keys with logical references

### DIFF
--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisDeletionGuard.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisDeletionGuard.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.analysis;
+
+/** Cross-domain extension point for assets that may block Analysis deletion. */
+@FunctionalInterface
+public interface AnalysisDeletionGuard {
+
+  void requireDeletable(long analysisId);
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisService.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/AnalysisService.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.analysis.repository.AnalysisRepository;
 import io.yak.ops.business.analysis.service.event.AnalysisLineageRefreshRequested;
 import io.yak.ops.business.analysis.service.support.AnalysisDefinitionNormalizer;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,14 +16,26 @@ public class AnalysisService {
   private final AnalysisRepository repository;
   private final AnalysisDefinitionNormalizer normalizer;
   private final ApplicationEventPublisher eventPublisher;
+  private final List<AnalysisDeletionGuard> deletionGuards;
 
+  @Autowired
+  public AnalysisService(
+      AnalysisRepository repository,
+      AnalysisDefinitionNormalizer normalizer,
+      ApplicationEventPublisher eventPublisher,
+      List<AnalysisDeletionGuard> deletionGuards) {
+    this.repository = repository;
+    this.normalizer = normalizer;
+    this.eventPublisher = eventPublisher;
+    this.deletionGuards = deletionGuards == null ? List.of() : List.copyOf(deletionGuards);
+  }
+
+  /** Focused tests and callers without cross-domain deletion guards retain the lightweight path. */
   public AnalysisService(
       AnalysisRepository repository,
       AnalysisDefinitionNormalizer normalizer,
       ApplicationEventPublisher eventPublisher) {
-    this.repository = repository;
-    this.normalizer = normalizer;
-    this.eventPublisher = eventPublisher;
+    this(repository, normalizer, eventPublisher, List.of());
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", readOnly = true)
@@ -59,6 +72,7 @@ public class AnalysisService {
   public void delete(long analysisId) {
     requireAnalysisId(analysisId);
     get(analysisId);
+    deletionGuards.forEach(guard -> guard.requireDeletable(analysisId));
     repository.delete(analysisId);
     eventPublisher.publishEvent(AnalysisLineageRefreshRequested.deleted(analysisId));
   }

--- a/yak-ops-business/yak-ops-business-analysis/src/main/resources/db/migration/yak-analysis/V2__remove_physical_foreign_keys.sql
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/resources/db/migration/yak-analysis/V2__remove_physical_foreign_keys.sql
@@ -1,0 +1,16 @@
+-- Yak Ops uses logical references at the application layer instead of database FK constraints.
+SET @drop_fk_sql = IF(
+    EXISTS (
+        SELECT 1
+        FROM information_schema.TABLE_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'yak_analysis'
+          AND CONSTRAINT_NAME = 'fk_yak_analysis_dataset'
+          AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    ),
+    'ALTER TABLE yak_analysis DROP FOREIGN KEY fk_yak_analysis_dataset',
+    'SELECT 1'
+);
+PREPARE drop_fk_stmt FROM @drop_fk_sql;
+EXECUTE drop_fk_stmt;
+DEALLOCATE PREPARE drop_fk_stmt;

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/AnalysisDeletionGuardTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/AnalysisDeletionGuardTest.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.analysis.repository.AnalysisRepository;
+import io.yak.ops.business.analysis.service.support.AnalysisDefinitionNormalizer;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+class AnalysisDeletionGuardTest {
+
+  @Test
+  void blocksDeleteWhenCrossDomainGuardRejectsReference() {
+    AnalysisRepository repository = mock(AnalysisRepository.class);
+    AnalysisDeletionGuard guard = mock(AnalysisDeletionGuard.class);
+    when(repository.findById(7L)).thenReturn(Optional.of(mock(AnalysisAsset.class)));
+    doThrow(new IllegalStateException("still referenced"))
+        .when(guard)
+        .requireDeletable(7L);
+
+    AnalysisService service = new AnalysisService(
+        repository,
+        mock(AnalysisDefinitionNormalizer.class),
+        mock(ApplicationEventPublisher.class),
+        List.of(guard));
+
+    assertThrows(IllegalStateException.class, () -> service.delete(7L));
+    verify(repository, never()).delete(7L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/DashboardDao.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/DashboardDao.java
@@ -50,6 +50,8 @@ public interface DashboardDao {
 
     List<DashboardInteractionPO> selectInteractions(long versionId);
 
+    boolean existsWidgetByAnalysisId(long analysisId);
+
     int selectNextVersionNo(long dashboardId);
 
     int deleteDashboard(long dashboardId);

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/impl/DashboardDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/impl/DashboardDaoImpl.java
@@ -174,6 +174,13 @@ public class DashboardDaoImpl implements DashboardDao {
     }
 
     @Override
+    public boolean existsWidgetByAnalysisId(long analysisId) {
+        return widgetMapper.selectCount(
+                Wrappers.<DashboardWidgetPO>lambdaQuery()
+                        .eq(DashboardWidgetPO::getAnalysisId, analysisId)) > 0L;
+    }
+
+    @Override
     public int selectNextVersionNo(long dashboardId) {
         List<Object> values = versionMapper.selectObjs(
                 Wrappers.<DashboardVersionPO>query()
@@ -187,6 +194,36 @@ public class DashboardDaoImpl implements DashboardDao {
 
     @Override
     public int deleteDashboard(long dashboardId) {
-        return dashboardMapper.deleteById(dashboardId);
+        List<Long> versionIds = versionMapper.selectObjs(
+                        Wrappers.<DashboardVersionPO>query()
+                                .select("id")
+                                .eq("dashboard_id", dashboardId))
+                .stream()
+                .filter(Number.class::isInstance)
+                .map(Number.class::cast)
+                .map(Number::longValue)
+                .toList();
+
+        int deleted = dashboardMapper.deleteById(dashboardId);
+        if (deleted != 1 || versionIds.isEmpty()) {
+            return deleted;
+        }
+
+        interactionMapper.delete(
+                Wrappers.<DashboardInteractionPO>lambdaQuery()
+                        .in(DashboardInteractionPO::getDashboardVersionId, versionIds));
+        filterBindingMapper.delete(
+                Wrappers.<DashboardFilterBindingPO>lambdaQuery()
+                        .in(DashboardFilterBindingPO::getDashboardVersionId, versionIds));
+        filterMapper.delete(
+                Wrappers.<DashboardFilterPO>lambdaQuery()
+                        .in(DashboardFilterPO::getDashboardVersionId, versionIds));
+        widgetMapper.delete(
+                Wrappers.<DashboardWidgetPO>lambdaQuery()
+                        .in(DashboardWidgetPO::getDashboardVersionId, versionIds));
+        versionMapper.delete(
+                Wrappers.<DashboardVersionPO>lambdaQuery()
+                        .in(DashboardVersionPO::getId, versionIds));
+        return deleted;
     }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/repository/DashboardAnalysisDeletionGuard.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/repository/DashboardAnalysisDeletionGuard.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.dashboard.repository;
+
+import io.yak.ops.business.analysis.AnalysisDeletionGuard;
+import io.yak.ops.business.dashboard.dao.DashboardDao;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Preserves the former dashboard-widget Analysis RESTRICT rule at the application boundary. */
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DashboardAnalysisDeletionGuard implements AnalysisDeletionGuard {
+
+    private final DashboardDao dashboardDao;
+
+    @Override
+    public void requireDeletable(long analysisId) {
+        if (dashboardDao.existsWidgetByAnalysisId(analysisId)) {
+            throw new IllegalStateException(
+                    "Analysis 仍被 Dashboard 历史版本引用，不能删除：" + analysisId);
+        }
+    }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V5__remove_physical_foreign_keys.sql
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V5__remove_physical_foreign_keys.sql
@@ -1,0 +1,56 @@
+-- Dashboard relationships remain indexed logical references; lifecycle cleanup is application-owned.
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_version'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_version_dashboard' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_version DROP FOREIGN KEY fk_yak_dashboard_version_dashboard', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_widget'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_widget_version' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_widget DROP FOREIGN KEY fk_yak_dashboard_widget_version', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_widget'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_widget_analysis' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_widget DROP FOREIGN KEY fk_yak_dashboard_widget_analysis', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_filter'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_filter_version' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_filter DROP FOREIGN KEY fk_yak_dashboard_filter_version', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_filter_binding'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_filter_binding_filter' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_filter_binding DROP FOREIGN KEY fk_yak_dashboard_filter_binding_filter', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_filter_binding'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_filter_binding_widget' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_filter_binding DROP FOREIGN KEY fk_yak_dashboard_filter_binding_widget', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_interaction'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_interaction_widget' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_interaction DROP FOREIGN KEY fk_yak_dashboard_interaction_widget', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dashboard_interaction'
+      AND CONSTRAINT_NAME = 'fk_yak_dashboard_interaction_filter' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dashboard_interaction DROP FOREIGN KEY fk_yak_dashboard_interaction_filter', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;

--- a/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V4__remove_physical_foreign_keys.sql
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V4__remove_physical_foreign_keys.sql
@@ -1,0 +1,14 @@
+-- Dataset identity/version relationships are maintained by the application layer.
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dataset_version'
+      AND CONSTRAINT_NAME = 'fk_yak_dataset_version_dataset' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dataset_version DROP FOREIGN KEY fk_yak_dataset_version_dataset', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_dataset_field'
+      AND CONSTRAINT_NAME = 'fk_yak_dataset_field_version' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_dataset_field DROP FOREIGN KEY fk_yak_dataset_field_version', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V3__remove_physical_foreign_keys.sql
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V3__remove_physical_foreign_keys.sql
@@ -1,0 +1,21 @@
+-- Lineage graph relationships are intentionally logical so graph lifecycle stays business-controlled.
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_metadata_asset'
+      AND CONSTRAINT_NAME = 'fk_yak_metadata_asset_parent' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_metadata_asset DROP FOREIGN KEY fk_yak_metadata_asset_parent', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_metadata_relation'
+      AND CONSTRAINT_NAME = 'fk_yak_metadata_relation_source' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_metadata_relation DROP FOREIGN KEY fk_yak_metadata_relation_source', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_metadata_relation'
+      AND CONSTRAINT_NAME = 'fk_yak_metadata_relation_target' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_metadata_relation DROP FOREIGN KEY fk_yak_metadata_relation_target', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
@@ -6,9 +6,13 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineExecutionEventMapper;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineWriteMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
@@ -26,6 +30,8 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
       List.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING");
 
   private final OfflineJobDefinitionMapper mapper;
+  private final OfflineJobExecutionMapper executionMapper;
+  private final OfflineExecutionEventMapper eventMapper;
   private final OfflineWriteMapper writeMapper;
 
   @Override
@@ -45,7 +51,28 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
 
   @Override
   public boolean deleteById(Long id) {
-    return mapper.deleteById(id) > 0;
+    List<Long> executionIds = executionMapper.selectObjs(
+            Wrappers.<OfflineJobExecutionPO>query()
+                .select("id")
+                .eq("job_definition_id", id))
+        .stream()
+        .filter(Number.class::isInstance)
+        .map(Number.class::cast)
+        .map(Number::longValue)
+        .toList();
+
+    boolean deleted = mapper.deleteById(id) > 0;
+    if (!deleted) return false;
+
+    if (!executionIds.isEmpty()) {
+      eventMapper.delete(
+          Wrappers.<OfflineExecutionEventPO>lambdaQuery()
+              .in(OfflineExecutionEventPO::getExecutionId, executionIds));
+    }
+    executionMapper.delete(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(OfflineJobExecutionPO::getJobDefinitionId, id));
+    return true;
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__remove_physical_foreign_keys.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__remove_physical_foreign_keys.sql
@@ -1,0 +1,14 @@
+-- Offline-sync history is cleaned explicitly by the application when a definition is deleted.
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_offline_job_execution'
+      AND CONSTRAINT_NAME = 'fk_yak_offline_execution_definition' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_offline_job_execution DROP FOREIGN KEY fk_yak_offline_execution_definition', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_offline_execution_event'
+      AND CONSTRAINT_NAME = 'fk_yak_offline_event_execution' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_offline_execution_event DROP FOREIGN KEY fk_yak_offline_event_execution', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
@@ -275,11 +275,20 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public int deleteDefinition(long id) {
-    return definitionMapper.delete(
+    int deleted = definitionMapper.delete(
         Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
             .eq(RealtimeJobDefinitionPO::getId, id)
             .eq(RealtimeJobDefinitionPO::getDesiredState, "STOPPED")
             .in(RealtimeJobDefinitionPO::getObservedState, List.of("STOPPED", "FAILED")));
+    if (deleted != 1) return deleted;
+
+    eventMapper.delete(
+        Wrappers.<RealtimeJobEventPO>lambdaQuery()
+            .eq(RealtimeJobEventPO::getDefinitionId, id));
+    deploymentMapper.delete(
+        Wrappers.<RealtimeJobDeploymentPO>lambdaQuery()
+            .eq(RealtimeJobDeploymentPO::getDefinitionId, id));
+    return deleted;
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V2__remove_physical_foreign_keys.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V2__remove_physical_foreign_keys.sql
@@ -1,0 +1,21 @@
+-- Realtime-sync references stay indexed while validation and delete semantics live in services/DAOs.
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_realtime_job_definition'
+      AND CONSTRAINT_NAME = 'fk_realtime_definition_environment' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_realtime_job_definition DROP FOREIGN KEY fk_realtime_definition_environment', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_realtime_job_deployment'
+      AND CONSTRAINT_NAME = 'fk_realtime_deployment_definition' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_realtime_job_deployment DROP FOREIGN KEY fk_realtime_deployment_definition', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;
+
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_realtime_job_event'
+      AND CONSTRAINT_NAME = 'fk_realtime_event_definition' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_realtime_job_event DROP FOREIGN KEY fk_realtime_event_definition', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowCatalogDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowCatalogDaoImpl.java
@@ -3,14 +3,17 @@ package io.yak.ops.business.workflow.dao.impl;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.workflow.dao.WorkflowCatalogDao;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowVersionMapper;
 import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 /** 基于 MyBatis-Plus 的工作流定义与版本 DAO。 */
 @Repository
@@ -24,6 +27,7 @@ import org.springframework.stereotype.Repository;
 public class WorkflowCatalogDaoImpl implements WorkflowCatalogDao {
   private final WorkflowDefinitionMapper definitionMapper;
   private final WorkflowVersionMapper versionMapper;
+  private final WorkflowScheduleMapper scheduleMapper;
 
   @Override
   public List<WorkflowDefinitionPO> selectDefinitions() {
@@ -57,8 +61,24 @@ public class WorkflowCatalogDaoImpl implements WorkflowCatalogDao {
   }
 
   @Override
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
   public int deleteDefinition(String workflowId) {
-    return definitionMapper.deleteById(workflowId);
+    List<String> scheduleIds = scheduleMapper.selectObjs(
+            Wrappers.<WorkflowSchedulePO>query()
+                .select("id")
+                .eq("workflow_id", workflowId))
+        .stream()
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .toList();
+
+    int deleted = definitionMapper.deleteById(workflowId);
+    if (deleted != 1 || scheduleIds.isEmpty()) return deleted;
+
+    scheduleMapper.delete(
+        Wrappers.<WorkflowSchedulePO>lambdaQuery()
+            .in(WorkflowSchedulePO::getId, scheduleIds));
+    return deleted;
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V6__remove_physical_foreign_keys.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V6__remove_physical_foreign_keys.sql
@@ -1,0 +1,7 @@
+-- Workflow schedule ownership is enforced by the application layer; trigger ledger remains historical.
+SET @drop_fk_sql = IF(EXISTS (
+    SELECT 1 FROM information_schema.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'yak_workflow_schedule'
+      AND CONSTRAINT_NAME = 'fk_yak_workflow_schedule_workflow' AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+), 'ALTER TABLE yak_workflow_schedule DROP FOREIGN KEY fk_yak_workflow_schedule_workflow', 'SELECT 1');
+PREPARE drop_fk_stmt FROM @drop_fk_sql; EXECUTE drop_fk_stmt; DEALLOCATE PREPARE drop_fk_stmt;


### PR DESCRIPTION
## 背景

作为数据库重构的第一阶段，本 PR 只处理 **物理外键约束移除**，不在本阶段合并、重排或重写历史 Flyway migration。Flyway 表结构整理会单独放到下一阶段，避免把约束语义变更和 migration 历史整理混在一起。

## 本阶段改动

- 新增增量 Flyway migration，移除 Analysis、Dashboard、Dataset、Lineage、Offline Sync、Realtime Sync、Workflow 中现存的 20 个物理 `FOREIGN KEY` 约束。
- 不修改已经发布的历史 V1/V2/... migration，避免已有环境出现 Flyway checksum mismatch。
- 保留逻辑关联字段、现有普通索引、唯一索引和主键约束。
- 将原先依赖数据库 `ON DELETE CASCADE` / `RESTRICT` 的关键生命周期语义迁回应用层：
  - Dashboard 删除时显式清理 version/widget/filter/binding/interaction；
  - Analysis 删除前通过跨域 deletion guard 检查 Dashboard 历史版本引用，保持原 RESTRICT 语义；
  - Offline Sync 删除定义时显式清理 execution/event；
  - Realtime Sync 删除定义时显式清理 deployment/event；
  - Workflow 删除定义时显式清理 schedule，并放在业务事务中；
  - Realtime compute environment 已有 `hasBoundRealtimeJobs` 业务校验，继续由应用层保持引用约束；
  - Lineage 当前删除逻辑本身就只删除无上下游关系、无子节点的 owned asset，因此无需依赖数据库 cascade/set-null。
- 增加 Analysis deletion guard 的 focused test。

## 设计原则

数据库只负责：主键、唯一约束、NOT NULL、索引等数据结构约束；跨业务模块的引用关系由 `xxx_id + INDEX + Service/DAO` 维护，不再通过数据库 FK 耦合模块生命周期。

## 与第二阶段的边界

本 PR **不会**：

- 合并 V1/V2/V3/V4；
- 重写历史 Flyway 文件；
- 统一 Flyway 文件命名与字段顺序；
- 做 baseline/schema consolidation。

这些内容留到第二阶段 `Flyway 表结构整理` 单独处理。

## 验证

当前变更已按模块逐项检查依赖数据库级联/限制的删除路径。Draft PR 创建后继续以 CI 结果为准；若 CI 暴露兼容问题，会在本分支继续修复。