### PR TITLE
fix: register MyBatis mappers outside boot package

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
@@ -1,5 +1,7 @@
 package io.yak.ops.boot;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -9,6 +11,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * <p>Yak Ops modules are scanned from their shared root package. Yak Framework integrations are
  * loaded through their Spring Boot auto-configuration metadata.</p>
  */
+@MapperScan(basePackages = "io.yak.ops", annotationClass = Mapper.class)
 @SpringBootApplication(scanBasePackages = "io.yak.ops")
 public class YakOpsApplication {
 


### PR DESCRIPTION
## Summary

- explicitly scan `io.yak.ops` for interfaces annotated with `@Mapper`
- keep the existing Spring component scan unchanged
- avoid treating unrelated interfaces as MyBatis mappers by filtering on the `@Mapper` annotation

## Root cause

`YakOpsApplication` is located under `io.yak.ops.boot`, while `DatasetMapper` is under `io.yak.ops.business.dataset.dao.mapper`.

The application already expands Spring component scanning with `scanBasePackages = "io.yak.ops"`, but MyBatis mapper discovery was not covering the sibling business packages. As a result, `DatasetMapper` was not registered and `DatasetDaoImpl` could not be constructed during startup.

## Fix

Add an explicit mapper scan at the application entry point:

```java
@MapperScan(basePackages = "io.yak.ops", annotationClass = Mapper.class)
```

## Validation

- confirmed `DatasetMapper` is already annotated with `@Mapper`
- branch is 1 commit ahead of `main`
- diff is limited to `YakOpsApplication.java` with 3 added lines
- no GitHub Actions run / commit status was available before opening this PR

## Reported startup error

`No qualifying bean of type 'io.yak.ops.business.dataset.dao.mapper.DatasetMapper' available`