### PR TITLE
feat: add realtime sync creation mode entry

### DIFF
--- a/yak-ops-ui/src/pages/realtime-sync/CreateRealtimeTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/CreateRealtimeTaskDrawer.tsx
@@ -1,13 +1,13 @@
-import { ArrowRightOutlined } from '@ant-design/icons';
+import { CodeOutlined, CompassOutlined } from '@ant-design/icons';
 import { history } from '@umijs/max';
 import { Button, Drawer, Form, Input, message, Select, Spin } from 'antd';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { realtimeApi } from './api';
 import type { ComputeEnvironmentOption } from './types';
 
+type EditorMode = 'wizard' | 'yaml';
+
 interface Values {
-  sourceType: string;
-  sinkType: string;
   name: string;
   description?: string;
   runtimeEnvironmentId: number;
@@ -17,12 +17,34 @@ const preferredEnvironmentId = (environments: ComputeEnvironmentOption[]) =>
   environments.find((item) => item.defaultEnvironment && item.enabled)?.id ??
   environments.find((item) => item.enabled)?.id;
 
+const editorModes: Array<{
+  value: EditorMode;
+  title: string;
+  description: string;
+  badge?: string;
+  icon: React.ReactNode;
+}> = [
+  {
+    value: 'wizard',
+    title: '向导模式',
+    description: '通过选择数据源、数据表和同步方式快速创建任务，适合大多数同步场景。',
+    badge: '推荐',
+    icon: <CompassOutlined />,
+  },
+  {
+    value: 'yaml',
+    title: 'YAML 模式',
+    description: '使用 YAML 描述同步任务，为高级配置和复杂同步规则保留完整扩展能力。',
+    icon: <CodeOutlined />,
+  },
+];
+
 export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [form] = Form.useForm<Values>();
+  const [editorMode, setEditorMode] = useState<EditorMode>('wizard');
   const [submitting, setSubmitting] = useState(false);
   const [environmentLoading, setEnvironmentLoading] = useState(false);
   const [environments, setEnvironments] = useState<ComputeEnvironmentOption[]>([]);
-  const automaticName = useRef('');
 
   const environmentOptions = useMemo(
     () =>
@@ -36,8 +58,8 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
 
   useEffect(() => {
     if (!open) return;
-    automaticName.current = 'MYSQL → MYSQL 实时同步';
-    form.setFieldsValue({ sourceType: 'MYSQL', sinkType: 'MYSQL', name: automaticName.current });
+    form.resetFields();
+    setEditorMode('wizard');
 
     let cancelled = false;
     const loadEnvironments = async () => {
@@ -64,13 +86,6 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
     };
   }, [form, open]);
 
-  const updateName = (source: string, sink: string) => {
-    const next = `${source} → ${sink} 实时同步`;
-    if (!form.getFieldValue('name') || form.getFieldValue('name') === automaticName.current)
-      form.setFieldValue('name', next);
-    automaticName.current = next;
-  };
-
   const submit = async () => {
     try {
       const values = await form.validateFields();
@@ -89,7 +104,9 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
       });
       message.success('基础任务已创建，请继续完成同步配置');
       form.resetFields();
-      history.push(`/sync/realtime/${response.data}/detail?scene=create`);
+      history.push(
+        `/sync/realtime/${response.data}/detail?scene=create&editor=${editorMode}`,
+      );
     } catch (error: any) {
       if (!error?.errorFields) message.error(error?.message || '创建实时同步任务失败');
     } finally {
@@ -100,7 +117,7 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
   return (
     <Drawer
       title="新建实时同步任务"
-      width={620}
+      width={680}
       open={open}
       closable={false}
       maskClosable={false}
@@ -118,27 +135,44 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
       styles={{ header: { padding: '18px 24px' }, body: { padding: 24 } }}
     >
       <Form form={form} layout="vertical" requiredMark="optional">
-        <div className="mb-6 grid grid-cols-[1fr_32px_1fr] items-end gap-3">
-          <Form.Item name="sourceType" label="来源类型" rules={[{ required: true }]} className="!mb-0">
-            <Select
-              variant="filled"
-              options={[{ value: 'MYSQL', label: 'MYSQL' }]}
-              onChange={(v) => updateName(v, form.getFieldValue('sinkType'))}
-            />
-          </Form.Item>
-          <div className="flex h-8 items-center justify-center text-[#98a2b3]">
-            <ArrowRightOutlined />
-          </div>
-          <Form.Item name="sinkType" label="目标类型" rules={[{ required: true }]} className="!mb-0">
-            <Select
-              variant="filled"
-              options={[
-                { value: 'MYSQL', label: 'MYSQL' },
-                { value: 'POSTGRESQL', label: 'POSTGRESQL' },
-              ]}
-              onChange={(v) => updateName(form.getFieldValue('sourceType'), v)}
-            />
-          </Form.Item>
+        <div className="mb-2 text-[14px] font-medium text-[#344054]">创建方式</div>
+        <div className="mb-6 grid grid-cols-2 gap-3 max-sm:grid-cols-1">
+          {editorModes.map((mode) => {
+            const selected = editorMode === mode.value;
+            return (
+              <button
+                key={mode.value}
+                type="button"
+                className={[
+                  'relative min-h-[142px] rounded-xl border bg-white p-5 text-left transition-all',
+                  selected
+                    ? 'border-[#ff4d4f] shadow-[0_0_0_2px_rgba(255,77,79,0.08)]'
+                    : 'border-[#e4e7ec] hover:border-[#fda29b] hover:bg-[#fffbfa]',
+                ].join(' ')}
+                onClick={() => setEditorMode(mode.value)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <span
+                    className={[
+                      'flex h-9 w-9 items-center justify-center rounded-lg text-[18px]',
+                      selected
+                        ? 'bg-[#fff1f0] text-[#ff4d4f]'
+                        : 'bg-[#f2f4f7] text-[#667085]',
+                    ].join(' ')}
+                  >
+                    {mode.icon}
+                  </span>
+                  {mode.badge && (
+                    <span className="rounded-full bg-[#fff1f0] px-2 py-0.5 text-[11px] font-medium text-[#ff4d4f]">
+                      {mode.badge}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-4 text-[15px] font-semibold text-[#101828]">{mode.title}</div>
+                <div className="mt-1.5 text-[12px] leading-5 text-[#667085]">{mode.description}</div>
+              </button>
+            );
+          })}
         </div>
 
         <Form.Item
@@ -161,20 +195,30 @@ export default function CreateRealtimeTaskDrawer({ open, onClose }: { open: bool
           />
         </Form.Item>
 
-        <Form.Item name="name" label="任务名称" rules={[{ required: true, message: '请输入任务名称' }, { max: 200 }]}>
-          <Input autoFocus variant="filled" maxLength={200} showCount />
+        <Form.Item
+          name="name"
+          label="任务名称"
+          rules={[
+            { required: true, message: '请输入任务名称' },
+            { max: 200 },
+          ]}
+        >
+          <Input autoFocus variant="filled" maxLength={200} showCount placeholder="例如：订单实时同步" />
         </Form.Item>
         <Form.Item name="description" label="任务描述（可选）" rules={[{ max: 1000 }]}>
           <Input.TextArea
             variant="filled"
-            rows={5}
+            rows={4}
             maxLength={1000}
             showCount
             placeholder="请说明业务场景、同步范围和使用目的"
           />
         </Form.Item>
-        <div className="rounded-lg bg-[#f9fafb] p-4 text-sm text-[#667085]">
-          数据源、同步表和其他运行参数将在任务详情页配置；实时同步无需配置调度。
+
+        <div className="rounded-lg bg-[#f9fafb] p-4 text-sm leading-6 text-[#667085]">
+          {editorMode === 'wizard'
+            ? '创建后进入向导配置页。数据源、同步表和同步方式将在后续步骤中完成配置。'
+            : '创建后进入 YAML 配置页。YAML 与任务 Spec 的互转能力将在后续流程中接入。'}
         </div>
       </Form>
     </Drawer>

--- a/yak-ops-ui/src/pages/realtime-sync/YamlJobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/YamlJobEditor.tsx
@@ -1,0 +1,45 @@
+import { CodeOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
+import type { RealtimeJob } from './types';
+
+export default function YamlJobEditor({
+  job,
+  onClose,
+}: {
+  job: RealtimeJob;
+  onClose: () => void;
+}) {
+  return (
+    <div className="min-h-[calc(100vh-64px)] bg-[#f7f8fa] px-6 py-6 text-[#161823]">
+      <div className="mx-auto w-full max-w-[1120px]">
+        <div className="mb-5 flex items-center justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 text-[12px] font-medium text-[#ff4d4f]">
+              <CodeOutlined />
+              YAML 模式
+            </div>
+            <h1 className="mb-0 mt-1 text-[20px] font-semibold text-[#101828]">{job.name}</h1>
+            <div className="mt-1 text-[12px] text-[#98a2b3]">任务 ID：{job.id} · 当前为基础草稿</div>
+          </div>
+          <Button onClick={onClose}>返回任务列表</Button>
+        </div>
+
+        <section className="rounded-xl bg-white p-7">
+          <div className="rounded-xl border border-dashed border-[#d0d5dd] bg-[#fcfcfd] px-6 py-10 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-[#fff1f0] text-[22px] text-[#ff4d4f]">
+              <CodeOutlined />
+            </div>
+            <div className="mt-4 text-[16px] font-semibold text-[#101828]">YAML 编辑入口已建立</div>
+            <div className="mx-auto mt-2 max-w-[620px] text-[13px] leading-6 text-[#667085]">
+              流程 1 只负责创建方式和编辑入口分流。YAML 与 CdcPipelineSpec 的解析、序列化、校验和保存能力将在后续 YAML 流程中接入。
+            </div>
+          </div>
+
+          <div className="mt-5 rounded-lg bg-[#f9fafb] px-5 py-4 text-[12px] leading-6 text-[#667085]">
+            当前不会持久化原生 Flink CDC YAML，也不会改变现有任务 Spec、发布、启动、停止、SSH 提交和可观测链路。
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/realtime-sync/detail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/detail.tsx
@@ -3,6 +3,7 @@ import { message, Spin } from 'antd';
 import { useEffect, useState } from 'react';
 import { realtimeApi } from './api';
 import JobEditor from './JobEditor';
+import YamlJobEditor from './YamlJobEditor';
 import type { ComputeEnvironmentOption, DataSourceOption, RealtimeJob } from './types';
 
 export default function RealtimeSyncDetail() {
@@ -10,6 +11,7 @@ export default function RealtimeSyncDetail() {
   const [job, setJob] = useState<RealtimeJob>();
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
   const [environments, setEnvironments] = useState<ComputeEnvironmentOption[]>([]);
+
   useEffect(() => {
     Promise.all([realtimeApi.detail(Number(id)), realtimeApi.dataSources(), realtimeApi.environments()])
       .then(([detail, sources, runtimeEnvironments]) => {
@@ -19,12 +21,19 @@ export default function RealtimeSyncDetail() {
       })
       .catch((error) => message.error(error?.message || '加载实时同步配置失败'));
   }, [id]);
+
   if (!job)
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
         <Spin />
       </div>
     );
+
+  const editorMode = new URLSearchParams(history.location.search).get('editor');
+  if (editorMode === 'yaml') {
+    return <YamlJobEditor job={job} onClose={() => history.push('/sync/realtime')} />;
+  }
+
   return (
     <JobEditor
       open


### PR DESCRIPTION
## 背景

第一期实时同步计划统一保留一套任务 Spec / 运行链路，只在编辑入口区分向导模式与 YAML 模式。本 PR 先完成流程 1：创建方式选择和编辑入口分流。

## 本次改动

- 新建实时同步任务时增加「向导模式 / YAML 模式」选择
- 移除创建阶段未持久化的 Source / Sink 类型选择，避免重复配置
- 基础任务创建完成后通过 `editor=wizard|yaml` 路由到对应编辑入口
- 现有 `JobEditor` 继续作为向导模式入口，已有任务编辑行为保持兼容
- 新增 YAML 编辑入口骨架；暂不解析、保存或提交 YAML，后续流程再接入 YAML ↔ CdcPipelineSpec

## 边界

本 PR 不修改：

- `CdcPipelineSpec` / 数据库表结构
- Pipeline YAML 编译器
- 发布、启动、停止、重启流程
- LOCAL / SSH 提交链路
- 日志、Metrics、Checkpoint、Reconcile

## 后续

流程 2 将实现向导模式下 Source / Sink 数据源和数据表选择，并自动生成基础表映射。