### PR TITLE
feat: unify realtime definition validation before save

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
@@ -70,181 +70,80 @@ public class RealtimeJobController {
     this.yamlCodec = yamlCodec;
   }
 
-  @Operation(summary = "创建实时同步基础任务")
-  @PostMapping
-  @RequiresPermission(RealtimePermissionCode.CREATE)
-  public Result<Long> create(@Valid @RequestBody RealtimeJobRequests.CreateRequest request) {
-    return Result.success(
-        service.create(request.name(), request.description(), request.runtimeEnvironmentId()));
-  }
+  @Operation(summary = "创建实时同步基础任务") @PostMapping @RequiresPermission(RealtimePermissionCode.CREATE)
+  public Result<Long> create(@Valid @RequestBody RealtimeJobRequests.CreateRequest request) { return Result.success(service.create(request.name(), request.description(), request.runtimeEnvironmentId())); }
 
-  @Operation(summary = "新建实时同步草稿")
-  @PostMapping("/draft")
-  @RequiresPermission(RealtimePermissionCode.CREATE)
+  @Operation(summary = "新建实时同步草稿") @PostMapping("/draft") @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> draft(@Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
     CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
     validationService.validateDefinition(spec, request.runtimeEnvironmentId());
-    return Result.success(
-        service.save(
-            null,
-            request.name(),
-            request.description(),
-            spec,
-            request.runtimeEnvironmentId()));
+    return Result.success(service.save(null, request.name(), request.description(), spec, request.runtimeEnvironmentId()));
   }
 
-  @Operation(summary = "校验未保存的实时同步定义")
-  @PostMapping("/spec/validate")
-  public Result<RealtimeViews.Validation> validateDefinition(
-      @Valid @RequestBody RealtimeJobRequests.DefinitionValidationRequest request) {
-    return Result.success(
-        viewMapper.toView(
-            validationService.validateDefinition(
-                requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
+  @Operation(summary = "校验未保存的实时同步定义") @PostMapping("/spec/validate")
+  public Result<RealtimeViews.Validation> validateDefinition(@Valid @RequestBody RealtimeJobRequests.DefinitionValidationRequest request) {
+    return Result.success(viewMapper.toView(validationService.validateDefinition(requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
   }
 
-  @Operation(summary = "解析 Yak Realtime YAML")
-  @PostMapping("/yaml/parse")
-  public Result<RealtimeViews.PipelineSpec> parseYaml(
-      @Valid @RequestBody RealtimeJobRequests.YamlRequest request) {
+  @Operation(summary = "解析 Yak Realtime YAML") @PostMapping("/yaml/parse")
+  public Result<RealtimeViews.PipelineSpec> parseYaml(@Valid @RequestBody RealtimeJobRequests.YamlRequest request) {
     return Result.success(viewMapper.toView(yamlCodec.parse(request.yaml())));
   }
 
-  @Operation(summary = "将实时同步 Spec 渲染为 Yak Realtime YAML")
-  @PostMapping("/yaml/render")
-  public Result<Map<String, String>> renderYaml(
-      @Valid @RequestBody RealtimeJobRequests.YamlRenderRequest request) {
+  @Operation(summary = "将实时同步 Spec 渲染为 Yak Realtime YAML") @PostMapping("/yaml/render")
+  public Result<Map<String, String>> renderYaml(@Valid @RequestBody RealtimeJobRequests.YamlRenderRequest request) {
     return Result.success(Map.of("yaml", yamlCodec.render(requestMapper.toSpec(request.spec()))));
   }
 
-  @Operation(summary = "保存实时同步草稿")
-  @PutMapping("/{id}")
-  @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Long> save(
-      @PathVariable long id, @Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
+  @Operation(summary = "保存实时同步草稿") @PutMapping("/{id}") @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Long> save(@PathVariable long id, @Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
     CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
     validationService.validateDefinition(spec, request.runtimeEnvironmentId());
-    return Result.success(
-        service.save(
-            id,
-            request.name(),
-            request.description(),
-            spec,
-            request.runtimeEnvironmentId()));
+    return Result.success(service.save(id, request.name(), request.description(), spec, request.runtimeEnvironmentId()));
   }
 
-  @Operation(summary = "实时同步任务详情")
-  @GetMapping("/{id}")
-  public Result<RealtimeViews.Job> detail(@PathVariable long id) {
-    return Result.success(viewMapper.toView(service.get(id)));
-  }
+  @Operation(summary = "实时同步任务详情") @GetMapping("/{id}")
+  public Result<RealtimeViews.Job> detail(@PathVariable long id) { return Result.success(viewMapper.toView(service.get(id))); }
 
-  @Operation(summary = "实时同步任务分页")
-  @GetMapping
-  public Result<RealtimeViews.Page> page(
-      @RequestParam(defaultValue = "1") int pageNo,
-      @RequestParam(defaultValue = "20") int pageSize,
-      @RequestParam(required = false) String keyword,
-      @RequestParam(required = false) Long id,
-      @RequestParam(required = false) String releaseState,
-      @RequestParam(required = false) String stateGroup) {
-    return Result.success(
-        viewMapper.toView(
-            queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup)));
-  }
+  @Operation(summary = "实时同步任务分页") @GetMapping
+  public Result<RealtimeViews.Page> page(@RequestParam(defaultValue = "1") int pageNo, @RequestParam(defaultValue = "20") int pageSize, @RequestParam(required = false) String keyword, @RequestParam(required = false) Long id, @RequestParam(required = false) String releaseState, @RequestParam(required = false) String stateGroup) { return Result.success(viewMapper.toView(queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup))); }
 
-  @Operation(summary = "订阅实时同步任务状态")
-  @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter stream() {
-    return eventStream.subscribe();
-  }
+  @Operation(summary = "订阅实时同步任务状态") @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter stream() { return eventStream.subscribe(); }
 
-  @Operation(summary = "发布当前定义版本")
-  @PostMapping("/{id}/publish")
-  @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Boolean> publish(@PathVariable long id) {
-    service.publish(id);
-    return Result.success(true);
-  }
+  @Operation(summary = "发布当前定义版本") @PostMapping("/{id}/publish") @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Boolean> publish(@PathVariable long id) { service.publish(id); return Result.success(true); }
 
-  @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义")
-  @PostMapping("/{id}/validate")
-  @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<RealtimeViews.Validation> validate(@PathVariable long id) {
-    return Result.success(viewMapper.toView(validationService.validate(id)));
-  }
+  @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义") @PostMapping("/{id}/validate") @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<RealtimeViews.Validation> validate(@PathVariable long id) { return Result.success(viewMapper.toView(validationService.validate(id))); }
 
-  @Operation(summary = "启动实时同步任务")
-  @PostMapping("/{id}/start")
-  @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> start(
-      @PathVariable long id,
-      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
-    return Result.success(viewMapper.toView(service.start(id, key)));
-  }
+  @Operation(summary = "启动实时同步任务") @PostMapping("/{id}/start") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> start(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.start(id, key))); }
 
-  @Operation(summary = "停止实时同步任务")
-  @PostMapping("/{id}/stop")
-  @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<Boolean> stop(@PathVariable long id) {
-    service.stop(id);
-    return Result.success(true);
-  }
+  @Operation(summary = "停止实时同步任务") @PostMapping("/{id}/stop") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<Boolean> stop(@PathVariable long id) { service.stop(id); return Result.success(true); }
 
-  @Operation(summary = "重启实时同步任务")
-  @PostMapping("/{id}/restart")
-  @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> restart(
-      @PathVariable long id,
-      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
-    return Result.success(viewMapper.toView(service.restart(id, key)));
-  }
+  @Operation(summary = "重启实时同步任务") @PostMapping("/{id}/restart") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> restart(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.restart(id, key))); }
 
-  @Operation(summary = "立即对账实时同步任务")
-  @PostMapping("/{id}/reconcile")
-  @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Job> reconcile(@PathVariable long id) {
-    return Result.success(viewMapper.toView(lifecycleCoordinator.reconcile(id)));
-  }
+  @Operation(summary = "立即对账实时同步任务") @PostMapping("/{id}/reconcile") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Job> reconcile(@PathVariable long id) { return Result.success(viewMapper.toView(lifecycleCoordinator.reconcile(id))); }
 
-  @Operation(summary = "删除已停止的实时同步任务")
-  @DeleteMapping("/{id}")
-  @RequiresPermission(RealtimePermissionCode.DELETE)
-  public Result<Boolean> delete(@PathVariable long id) {
-    lifecycleCoordinator.assertSafeToDelete(id);
-    service.delete(id);
-    return Result.success(true);
-  }
+  @Operation(summary = "删除已停止的实时同步任务") @DeleteMapping("/{id}") @RequiresPermission(RealtimePermissionCode.DELETE)
+  public Result<Boolean> delete(@PathVariable long id) { lifecycleCoordinator.assertSafeToDelete(id); service.delete(id); return Result.success(true); }
 
-  @Operation(summary = "查询任务状态事件")
-  @GetMapping("/{id}/events")
-  public Result<List<RealtimeViews.Event>> events(@PathVariable long id) {
-    return Result.success(service.events(id).stream().map(viewMapper::toView).toList());
-  }
+  @Operation(summary = "查询任务状态事件") @GetMapping("/{id}/events")
+  public Result<List<RealtimeViews.Event>> events(@PathVariable long id) { return Result.success(service.events(id).stream().map(viewMapper::toView).toList()); }
 
-  @Operation(summary = "查询指定 Flink CDC 运行环境能力")
-  @GetMapping("/runtime/capabilities")
-  public Result<JsonNode> capabilities(@RequestParam long environmentId) {
-    return Result.success(service.capabilities(environmentId));
-  }
+  @Operation(summary = "查询指定 Flink CDC 运行环境能力") @GetMapping("/runtime/capabilities")
+  public Result<JsonNode> capabilities(@RequestParam long environmentId) { return Result.success(service.capabilities(environmentId)); }
 
-  @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics")
-  @GetMapping("/{id}/observability")
-  public Result<RealtimeViews.Observability> observability(@PathVariable long id) {
-    return Result.success(viewMapper.toView(observabilityService.snapshot(id)));
-  }
+  @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics") @GetMapping("/{id}/observability")
+  public Result<RealtimeViews.Observability> observability(@PathVariable long id) { return Result.success(viewMapper.toView(observabilityService.snapshot(id))); }
 
-  @Operation(summary = "查询 Flink CDC 提交日志")
-  @GetMapping("/{id}/logs/submission")
-  public Result<Map<String, String>> submissionLog(
-      @PathVariable long id, @RequestParam(defaultValue = "500") int tail) {
-    return Result.success(Map.of("logs", observabilityService.submissionLog(id, tail)));
-  }
+  @Operation(summary = "查询 Flink CDC 提交日志") @GetMapping("/{id}/logs/submission")
+  public Result<Map<String, String>> submissionLog(@PathVariable long id, @RequestParam(defaultValue = "500") int tail) { return Result.success(Map.of("logs", observabilityService.submissionLog(id, tail))); }
 
-  @Operation(summary = "查询 Flink 运行异常历史")
-  @GetMapping("/{id}/logs/runtime")
-  public Result<RealtimeViews.RuntimeLog> runtimeLog(
-      @PathVariable long id, @RequestParam(defaultValue = "50") int maxExceptions) {
-    return Result.success(viewMapper.toView(observabilityService.runtimeLog(id, maxExceptions)));
-  }
+  @Operation(summary = "查询 Flink 运行异常历史") @GetMapping("/{id}/logs/runtime")
+  public Result<RealtimeViews.RuntimeLog> runtimeLog(@PathVariable long id, @RequestParam(defaultValue = "50") int maxExceptions) { return Result.success(viewMapper.toView(observabilityService.runtimeLog(id, maxExceptions))); }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.sync.realtime.controller.v1.dto.RealtimeJobRequests;
 import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeRequestMapper;
 import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeViewMapper;
 import io.yak.ops.business.sync.realtime.controller.v1.vo.RealtimeViews;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.service.RealtimeEventStreamService;
 import io.yak.ops.business.sync.realtime.service.RealtimeJobLifecycleCoordinator;
 import io.yak.ops.business.sync.realtime.service.RealtimeJobQueryService;
@@ -69,67 +70,181 @@ public class RealtimeJobController {
     this.yamlCodec = yamlCodec;
   }
 
-  @Operation(summary = "创建实时同步基础任务") @PostMapping @RequiresPermission(RealtimePermissionCode.CREATE)
-  public Result<Long> create(@Valid @RequestBody RealtimeJobRequests.CreateRequest request) { return Result.success(service.create(request.name(), request.description(), request.runtimeEnvironmentId())); }
+  @Operation(summary = "创建实时同步基础任务")
+  @PostMapping
+  @RequiresPermission(RealtimePermissionCode.CREATE)
+  public Result<Long> create(@Valid @RequestBody RealtimeJobRequests.CreateRequest request) {
+    return Result.success(
+        service.create(request.name(), request.description(), request.runtimeEnvironmentId()));
+  }
 
-  @Operation(summary = "新建实时同步草稿") @PostMapping("/draft") @RequiresPermission(RealtimePermissionCode.CREATE)
-  public Result<Long> draft(@Valid @RequestBody RealtimeJobRequests.SaveRequest request) { return Result.success(service.save(null, request.name(), request.description(), requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())); }
+  @Operation(summary = "新建实时同步草稿")
+  @PostMapping("/draft")
+  @RequiresPermission(RealtimePermissionCode.CREATE)
+  public Result<Long> draft(@Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
+    CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
+    validationService.validateDefinition(spec, request.runtimeEnvironmentId());
+    return Result.success(
+        service.save(
+            null,
+            request.name(),
+            request.description(),
+            spec,
+            request.runtimeEnvironmentId()));
+  }
 
-  @Operation(summary = "解析 Yak Realtime YAML") @PostMapping("/yaml/parse")
-  public Result<RealtimeViews.PipelineSpec> parseYaml(@Valid @RequestBody RealtimeJobRequests.YamlRequest request) {
+  @Operation(summary = "校验未保存的实时同步定义")
+  @PostMapping("/spec/validate")
+  public Result<RealtimeViews.Validation> validateDefinition(
+      @Valid @RequestBody RealtimeJobRequests.DefinitionValidationRequest request) {
+    return Result.success(
+        viewMapper.toView(
+            validationService.validateDefinition(
+                requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
+  }
+
+  @Operation(summary = "解析 Yak Realtime YAML")
+  @PostMapping("/yaml/parse")
+  public Result<RealtimeViews.PipelineSpec> parseYaml(
+      @Valid @RequestBody RealtimeJobRequests.YamlRequest request) {
     return Result.success(viewMapper.toView(yamlCodec.parse(request.yaml())));
   }
 
-  @Operation(summary = "将实时同步 Spec 渲染为 Yak Realtime YAML") @PostMapping("/yaml/render")
-  public Result<Map<String, String>> renderYaml(@Valid @RequestBody RealtimeJobRequests.YamlRenderRequest request) {
+  @Operation(summary = "将实时同步 Spec 渲染为 Yak Realtime YAML")
+  @PostMapping("/yaml/render")
+  public Result<Map<String, String>> renderYaml(
+      @Valid @RequestBody RealtimeJobRequests.YamlRenderRequest request) {
     return Result.success(Map.of("yaml", yamlCodec.render(requestMapper.toSpec(request.spec()))));
   }
 
-  @Operation(summary = "保存实时同步草稿") @PutMapping("/{id}") @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Long> save(@PathVariable long id, @Valid @RequestBody RealtimeJobRequests.SaveRequest request) { return Result.success(service.save(id, request.name(), request.description(), requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())); }
+  @Operation(summary = "保存实时同步草稿")
+  @PutMapping("/{id}")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Long> save(
+      @PathVariable long id, @Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
+    CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
+    validationService.validateDefinition(spec, request.runtimeEnvironmentId());
+    return Result.success(
+        service.save(
+            id,
+            request.name(),
+            request.description(),
+            spec,
+            request.runtimeEnvironmentId()));
+  }
 
-  @Operation(summary = "实时同步任务详情") @GetMapping("/{id}")
-  public Result<RealtimeViews.Job> detail(@PathVariable long id) { return Result.success(viewMapper.toView(service.get(id))); }
+  @Operation(summary = "实时同步任务详情")
+  @GetMapping("/{id}")
+  public Result<RealtimeViews.Job> detail(@PathVariable long id) {
+    return Result.success(viewMapper.toView(service.get(id)));
+  }
 
-  @Operation(summary = "实时同步任务分页") @GetMapping
-  public Result<RealtimeViews.Page> page(@RequestParam(defaultValue = "1") int pageNo, @RequestParam(defaultValue = "20") int pageSize, @RequestParam(required = false) String keyword, @RequestParam(required = false) Long id, @RequestParam(required = false) String releaseState, @RequestParam(required = false) String stateGroup) { return Result.success(viewMapper.toView(queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup))); }
+  @Operation(summary = "实时同步任务分页")
+  @GetMapping
+  public Result<RealtimeViews.Page> page(
+      @RequestParam(defaultValue = "1") int pageNo,
+      @RequestParam(defaultValue = "20") int pageSize,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) Long id,
+      @RequestParam(required = false) String releaseState,
+      @RequestParam(required = false) String stateGroup) {
+    return Result.success(
+        viewMapper.toView(
+            queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup)));
+  }
 
-  @Operation(summary = "订阅实时同步任务状态") @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter stream() { return eventStream.subscribe(); }
+  @Operation(summary = "订阅实时同步任务状态")
+  @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter stream() {
+    return eventStream.subscribe();
+  }
 
-  @Operation(summary = "发布当前定义版本") @PostMapping("/{id}/publish") @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Boolean> publish(@PathVariable long id) { service.publish(id); return Result.success(true); }
+  @Operation(summary = "发布当前定义版本")
+  @PostMapping("/{id}/publish")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Boolean> publish(@PathVariable long id) {
+    service.publish(id);
+    return Result.success(true);
+  }
 
-  @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义") @PostMapping("/{id}/validate") @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<RealtimeViews.Validation> validate(@PathVariable long id) { return Result.success(viewMapper.toView(validationService.validate(id))); }
+  @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义")
+  @PostMapping("/{id}/validate")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<RealtimeViews.Validation> validate(@PathVariable long id) {
+    return Result.success(viewMapper.toView(validationService.validate(id)));
+  }
 
-  @Operation(summary = "启动实时同步任务") @PostMapping("/{id}/start") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> start(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.start(id, key))); }
+  @Operation(summary = "启动实时同步任务")
+  @PostMapping("/{id}/start")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> start(
+      @PathVariable long id,
+      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
+    return Result.success(viewMapper.toView(service.start(id, key)));
+  }
 
-  @Operation(summary = "停止实时同步任务") @PostMapping("/{id}/stop") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<Boolean> stop(@PathVariable long id) { service.stop(id); return Result.success(true); }
+  @Operation(summary = "停止实时同步任务")
+  @PostMapping("/{id}/stop")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<Boolean> stop(@PathVariable long id) {
+    service.stop(id);
+    return Result.success(true);
+  }
 
-  @Operation(summary = "重启实时同步任务") @PostMapping("/{id}/restart") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> restart(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.restart(id, key))); }
+  @Operation(summary = "重启实时同步任务")
+  @PostMapping("/{id}/restart")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> restart(
+      @PathVariable long id,
+      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
+    return Result.success(viewMapper.toView(service.restart(id, key)));
+  }
 
-  @Operation(summary = "立即对账实时同步任务") @PostMapping("/{id}/reconcile") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Job> reconcile(@PathVariable long id) { return Result.success(viewMapper.toView(lifecycleCoordinator.reconcile(id))); }
+  @Operation(summary = "立即对账实时同步任务")
+  @PostMapping("/{id}/reconcile")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Job> reconcile(@PathVariable long id) {
+    return Result.success(viewMapper.toView(lifecycleCoordinator.reconcile(id)));
+  }
 
-  @Operation(summary = "删除已停止的实时同步任务") @DeleteMapping("/{id}") @RequiresPermission(RealtimePermissionCode.DELETE)
-  public Result<Boolean> delete(@PathVariable long id) { lifecycleCoordinator.assertSafeToDelete(id); service.delete(id); return Result.success(true); }
+  @Operation(summary = "删除已停止的实时同步任务")
+  @DeleteMapping("/{id}")
+  @RequiresPermission(RealtimePermissionCode.DELETE)
+  public Result<Boolean> delete(@PathVariable long id) {
+    lifecycleCoordinator.assertSafeToDelete(id);
+    service.delete(id);
+    return Result.success(true);
+  }
 
-  @Operation(summary = "查询任务状态事件") @GetMapping("/{id}/events")
-  public Result<List<RealtimeViews.Event>> events(@PathVariable long id) { return Result.success(service.events(id).stream().map(viewMapper::toView).toList()); }
+  @Operation(summary = "查询任务状态事件")
+  @GetMapping("/{id}/events")
+  public Result<List<RealtimeViews.Event>> events(@PathVariable long id) {
+    return Result.success(service.events(id).stream().map(viewMapper::toView).toList());
+  }
 
-  @Operation(summary = "查询指定 Flink CDC 运行环境能力") @GetMapping("/runtime/capabilities")
-  public Result<JsonNode> capabilities(@RequestParam long environmentId) { return Result.success(service.capabilities(environmentId)); }
+  @Operation(summary = "查询指定 Flink CDC 运行环境能力")
+  @GetMapping("/runtime/capabilities")
+  public Result<JsonNode> capabilities(@RequestParam long environmentId) {
+    return Result.success(service.capabilities(environmentId));
+  }
 
-  @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics") @GetMapping("/{id}/observability")
-  public Result<RealtimeViews.Observability> observability(@PathVariable long id) { return Result.success(viewMapper.toView(observabilityService.snapshot(id))); }
+  @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics")
+  @GetMapping("/{id}/observability")
+  public Result<RealtimeViews.Observability> observability(@PathVariable long id) {
+    return Result.success(viewMapper.toView(observabilityService.snapshot(id)));
+  }
 
-  @Operation(summary = "查询 Flink CDC 提交日志") @GetMapping("/{id}/logs/submission")
-  public Result<Map<String, String>> submissionLog(@PathVariable long id, @RequestParam(defaultValue = "500") int tail) { return Result.success(Map.of("logs", observabilityService.submissionLog(id, tail))); }
+  @Operation(summary = "查询 Flink CDC 提交日志")
+  @GetMapping("/{id}/logs/submission")
+  public Result<Map<String, String>> submissionLog(
+      @PathVariable long id, @RequestParam(defaultValue = "500") int tail) {
+    return Result.success(Map.of("logs", observabilityService.submissionLog(id, tail)));
+  }
 
-  @Operation(summary = "查询 Flink 运行异常历史") @GetMapping("/{id}/logs/runtime")
-  public Result<RealtimeViews.RuntimeLog> runtimeLog(@PathVariable long id, @RequestParam(defaultValue = "50") int maxExceptions) { return Result.success(viewMapper.toView(observabilityService.runtimeLog(id, maxExceptions))); }
+  @Operation(summary = "查询 Flink 运行异常历史")
+  @GetMapping("/{id}/logs/runtime")
+  public Result<RealtimeViews.RuntimeLog> runtimeLog(
+      @PathVariable long id, @RequestParam(defaultValue = "50") int maxExceptions) {
+    return Result.success(viewMapper.toView(observabilityService.runtimeLog(id, maxExceptions)));
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
@@ -80,7 +80,7 @@ public class RealtimeJobController {
     return Result.success(service.save(null, request.name(), request.description(), spec, request.runtimeEnvironmentId()));
   }
 
-  @Operation(summary = "校验未保存的实时同步定义") @PostMapping("/spec/validate")
+  @Operation(summary = "校验未保存的实时同步定义") @PostMapping("/spec/validate") @RequiresPermission(RealtimePermissionCode.UPDATE)
   public Result<RealtimeViews.Validation> validateDefinition(@Valid @RequestBody RealtimeJobRequests.DefinitionValidationRequest request) {
     return Result.success(viewMapper.toView(validationService.validateDefinition(requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/dto/RealtimeJobRequests.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/dto/RealtimeJobRequests.java
@@ -22,7 +22,11 @@ public final class RealtimeJobRequests {
       @NotBlank @Size(max = 200) String name,
       @Size(max = 1000) String description,
       @NotNull Long runtimeEnvironmentId,
-      @Valid PipelineSpec spec) {}
+      @Valid @NotNull PipelineSpec spec) {}
+
+  public record DefinitionValidationRequest(
+      @NotNull Long runtimeEnvironmentId,
+      @Valid @NotNull PipelineSpec spec) {}
 
   public record YamlRequest(@NotBlank @Size(max = 65_536) String yaml) {}
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidator.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.sync.realtime.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
@@ -10,18 +11,24 @@ import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResol
 import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
 import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.springframework.stereotype.Service;
 
 /**
  * Unified definition-level validation boundary shared by draft preflight and save flows.
  *
  * <p>This deliberately does not call Flink REST health checks. A draft must remain saveable when the
- * remote cluster is temporarily offline; publish/start still perform runtime validation through the
- * existing job lifecycle path.
+ * remote Flink cluster is temporarily offline; publish/start still perform runtime validation through
+ * the existing job lifecycle path. Source metadata is validated because table/key drift is part of
+ * the definition itself, not a Flink runtime concern.
  */
 @Service
 public class RealtimeDefinitionValidator {
@@ -30,6 +37,7 @@ public class RealtimeDefinitionValidator {
   private final CdcPipelineSpecValidator specValidator;
   private final RealtimeRuntimeResolver runtimeResolver;
   private final RealtimeDataSourceResolver dataSourceResolver;
+  private final DataSourceCatalogService catalogService;
   private final RealtimeConnectorCapabilityResolver capabilityResolver;
   private final PipelineYamlCompiler compiler;
   private final RealtimeEngineGateway gateway;
@@ -39,6 +47,7 @@ public class RealtimeDefinitionValidator {
       CdcPipelineSpecValidator specValidator,
       RealtimeRuntimeResolver runtimeResolver,
       RealtimeDataSourceResolver dataSourceResolver,
+      DataSourceCatalogService catalogService,
       RealtimeConnectorCapabilityResolver capabilityResolver,
       PipelineYamlCompiler compiler,
       RealtimeEngineGateway gateway) {
@@ -46,6 +55,7 @@ public class RealtimeDefinitionValidator {
     this.specValidator = specValidator;
     this.runtimeResolver = runtimeResolver;
     this.dataSourceResolver = dataSourceResolver;
+    this.catalogService = catalogService;
     this.capabilityResolver = capabilityResolver;
     this.compiler = compiler;
     this.gateway = gateway;
@@ -55,6 +65,7 @@ public class RealtimeDefinitionValidator {
     validateSpec(spec);
     ComputeEnvironmentSnapshot environment = runtimeResolver.environment(runtimeEnvironmentId, true);
     ResolvedCdcPipeline resolved = dataSourceResolver.resolve(spec);
+    validateSourceCatalog(spec);
     JsonNode manifest = gateway.capabilities(environment);
     capabilityResolver.requireSupported(manifest, resolved, spec);
 
@@ -81,8 +92,104 @@ public class RealtimeDefinitionValidator {
     specValidator.validate(spec);
   }
 
+  private void validateSourceCatalog(CdcPipelineSpec spec) {
+    List<DataSourceCatalogTableVO> physicalTables;
+    try {
+      physicalTables =
+          catalogService.listTables(spec.sourceDataSourceRef(), null, null, null).stream()
+              .filter(this::isPhysicalTable)
+              .toList();
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException(
+          "Source 数据源元数据读取失败：" + message(exception), exception);
+    }
+
+    for (CdcPipelineSpec.TableRoute route : spec.tables()) {
+      List<DataSourceCatalogTableVO> matched = matchTables(route, physicalTables);
+      if (matched.isEmpty()) {
+        throw new IllegalArgumentException(
+            route.matchMode() == CdcPipelineSpec.MatchMode.EXACT
+                ? "Source 表不存在：" + route.sourceTable()
+                : "Source 表正则未匹配到任何物理表：" + route.sourceTable());
+      }
+      for (DataSourceCatalogTableVO table : matched) {
+        validatePrimaryKey(spec.sourceDataSourceRef(), table, route.keyColumns());
+      }
+    }
+  }
+
+  private List<DataSourceCatalogTableVO> matchTables(
+      CdcPipelineSpec.TableRoute route, List<DataSourceCatalogTableVO> tables) {
+    if (route.matchMode() == CdcPipelineSpec.MatchMode.EXACT) {
+      return tables.stream().filter(table -> route.sourceTable().equals(table.getName())).toList();
+    }
+    Pattern pattern = Pattern.compile(route.sourceTable());
+    return tables.stream()
+        .filter(table -> table.getName() != null && pattern.matcher(table.getName()).matches())
+        .toList();
+  }
+
+  private void validatePrimaryKey(
+      Long dataSourceId, DataSourceCatalogTableVO table, List<String> configuredKeys) {
+    List<DataSourceCatalogColumnVO> columns;
+    try {
+      columns =
+          catalogService.listColumns(
+              dataSourceId, table.getDatabase(), table.getSchema(), table.getName());
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException(
+          "Source 表字段元数据读取失败：" + table.getName() + "，" + message(exception), exception);
+    }
+    if (columns == null || columns.isEmpty()) {
+      throw new IllegalArgumentException("Source 表不存在或无可读字段：" + table.getName());
+    }
+
+    List<String> actualKeys =
+        columns.stream()
+            .filter(column -> Boolean.TRUE.equals(column.getPrimaryKey()))
+            .sorted(
+                Comparator.comparing(
+                    column ->
+                        column.getOrdinalPosition() == null
+                            ? Integer.MAX_VALUE
+                            : column.getOrdinalPosition()))
+            .map(DataSourceCatalogColumnVO::getName)
+            .toList();
+    if (actualKeys.isEmpty()) {
+      throw new IllegalArgumentException("Source 表未检测到主键：" + table.getName());
+    }
+
+    Set<String> configured = new LinkedHashSet<>(configuredKeys);
+    if (configured.size() != configuredKeys.size()) {
+      throw new IllegalArgumentException("表规则主键字段不能重复：" + table.getName());
+    }
+    Set<String> actual = new LinkedHashSet<>(actualKeys);
+    if (!actual.equals(configured)) {
+      throw new IllegalArgumentException(
+          "Source 表主键与任务配置不一致："
+              + table.getName()
+              + "，当前主键="
+              + actualKeys
+              + "，配置主键="
+              + configuredKeys);
+    }
+  }
+
+  private boolean isPhysicalTable(DataSourceCatalogTableVO table) {
+    return table != null
+        && table.getName() != null
+        && (table.getType() == null
+            || !table.getType().toUpperCase().contains("VIEW"));
+  }
+
   private String violationMessage(ConstraintViolation<CdcPipelineSpec> violation) {
     String path = violation.getPropertyPath().toString();
     return (path.isBlank() ? "配置" : path) + " " + violation.getMessage();
+  }
+
+  private String message(RuntimeException exception) {
+    return exception.getMessage() == null || exception.getMessage().isBlank()
+        ? exception.getClass().getSimpleName()
+        : exception.getMessage();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidator.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeValidationResult;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * Unified definition-level validation boundary shared by draft preflight and save flows.
+ *
+ * <p>This deliberately does not call Flink REST health checks. A draft must remain saveable when the
+ * remote cluster is temporarily offline; publish/start still perform runtime validation through the
+ * existing job lifecycle path.
+ */
+@Service
+public class RealtimeDefinitionValidator {
+
+  private final Validator beanValidator;
+  private final CdcPipelineSpecValidator specValidator;
+  private final RealtimeRuntimeResolver runtimeResolver;
+  private final RealtimeDataSourceResolver dataSourceResolver;
+  private final RealtimeConnectorCapabilityResolver capabilityResolver;
+  private final PipelineYamlCompiler compiler;
+  private final RealtimeEngineGateway gateway;
+
+  public RealtimeDefinitionValidator(
+      Validator beanValidator,
+      CdcPipelineSpecValidator specValidator,
+      RealtimeRuntimeResolver runtimeResolver,
+      RealtimeDataSourceResolver dataSourceResolver,
+      RealtimeConnectorCapabilityResolver capabilityResolver,
+      PipelineYamlCompiler compiler,
+      RealtimeEngineGateway gateway) {
+    this.beanValidator = beanValidator;
+    this.specValidator = specValidator;
+    this.runtimeResolver = runtimeResolver;
+    this.dataSourceResolver = dataSourceResolver;
+    this.capabilityResolver = capabilityResolver;
+    this.compiler = compiler;
+    this.gateway = gateway;
+  }
+
+  public RealtimeValidationResult validate(CdcPipelineSpec spec, long runtimeEnvironmentId) {
+    validateSpec(spec);
+    ComputeEnvironmentSnapshot environment = runtimeResolver.environment(runtimeEnvironmentId, true);
+    ResolvedCdcPipeline resolved = dataSourceResolver.resolve(spec);
+    JsonNode manifest = gateway.capabilities(environment);
+    capabilityResolver.requireSupported(manifest, resolved, spec);
+
+    // Compile the logical definition as part of preflight so route escaping and connector YAML shape
+    // fail before persistence. No secrets are resolved and no Flink REST call is made here.
+    compiler.compile("definition-preflight", spec, resolved);
+
+    return new RealtimeValidationResult(
+        true, manifest.path("deliverySemantics").asText("at-least-once"));
+  }
+
+  public void validateSpec(CdcPipelineSpec spec) {
+    if (spec == null) {
+      throw new IllegalArgumentException("实时同步 Spec 不能为空");
+    }
+    List<String> violations =
+        beanValidator.validate(spec).stream()
+            .sorted(Comparator.comparing(value -> value.getPropertyPath().toString()))
+            .map(this::violationMessage)
+            .toList();
+    if (!violations.isEmpty()) {
+      throw new IllegalArgumentException("实时同步 Spec 配置无效：" + String.join("；", violations));
+    }
+    specValidator.validate(spec);
+  }
+
+  private String violationMessage(ConstraintViolation<CdcPipelineSpec> violation) {
+    String path = violation.getPropertyPath().toString();
+    return (path.isBlank() ? "配置" : path) + " " + violation.getMessage();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeValidationService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeValidationService.java
@@ -1,18 +1,29 @@
 package io.yak.ops.business.sync.realtime.service;
 
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.RealtimeValidationResult;
 import org.springframework.stereotype.Service;
 
-/** HTTP-neutral application boundary for validating the current realtime definition. */
+/** HTTP-neutral application boundary for realtime definition and runtime validation. */
 @Service
 public class RealtimeValidationService {
 
   private final RealtimeJobService jobs;
+  private final RealtimeDefinitionValidator definitions;
 
-  public RealtimeValidationService(RealtimeJobService jobs) {
+  public RealtimeValidationService(
+      RealtimeJobService jobs, RealtimeDefinitionValidator definitions) {
     this.jobs = jobs;
+    this.definitions = definitions;
   }
 
+  /** Definition-level preflight for unsaved Wizard/YAML/legacy editor payloads. */
+  public RealtimeValidationResult validateDefinition(
+      CdcPipelineSpec spec, long runtimeEnvironmentId) {
+    return definitions.validate(spec, runtimeEnvironmentId);
+  }
+
+  /** Runtime validation for the already persisted definition, including Flink REST/CLI readiness. */
   public RealtimeValidationResult validate(long definitionId) {
     var result = jobs.validate(definitionId);
     return new RealtimeValidationResult(result.valid(), result.deliverySemantics());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeYamlCodec.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeYamlCodec.java
@@ -7,10 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
-import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validator;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import org.springframework.stereotype.Component;
@@ -36,17 +32,15 @@ public class RealtimeYamlCodec {
           new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
 
   private final ObjectMapper yaml;
-  private final Validator beanValidator;
-  private final CdcPipelineSpecValidator specValidator;
+  private final RealtimeDefinitionValidator definitionValidator;
 
-  public RealtimeYamlCodec(Validator beanValidator, CdcPipelineSpecValidator specValidator) {
+  public RealtimeYamlCodec(RealtimeDefinitionValidator definitionValidator) {
     YAMLFactory factory = new YAMLFactory();
     factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
     this.yaml = new ObjectMapper(factory);
     this.yaml.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     this.yaml.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
-    this.beanValidator = beanValidator;
-    this.specValidator = specValidator;
+    this.definitionValidator = definitionValidator;
   }
 
   public CdcPipelineSpec parse(String source) {
@@ -68,7 +62,7 @@ public class RealtimeYamlCodec {
       }
 
       CdcPipelineSpec spec = toSpec(document);
-      validate(spec);
+      definitionValidator.validateSpec(spec);
       return spec;
     } catch (IllegalArgumentException exception) {
       throw exception;
@@ -81,16 +75,18 @@ public class RealtimeYamlCodec {
                   + " 行，第 "
                   + exception.getLocation().getColumnNr()
                   + " 列）";
-      throw new IllegalArgumentException("Yak Realtime YAML 解析失败" + location + "：" + exception.getOriginalMessage());
+      throw new IllegalArgumentException(
+          "Yak Realtime YAML 解析失败" + location + "：" + exception.getOriginalMessage());
     }
   }
 
   public String render(CdcPipelineSpec spec) {
-    validate(spec);
+    definitionValidator.validateSpec(spec);
     try {
       return yaml.writeValueAsString(fromSpec(spec));
     } catch (JsonProcessingException exception) {
-      throw new IllegalArgumentException("Yak Realtime YAML 生成失败：" + exception.getOriginalMessage());
+      throw new IllegalArgumentException(
+          "Yak Realtime YAML 生成失败：" + exception.getOriginalMessage());
     }
   }
 
@@ -120,14 +116,17 @@ public class RealtimeYamlCodec {
         new CdcPipelineSpec.RestartPolicy(
             textOrDefault(
                 restart == null ? null : restart.strategy(), DEFAULT_SPEC.restart().strategy()),
-            intOrDefault(restart == null ? null : restart.attempts(), DEFAULT_SPEC.restart().attempts()),
-            longOrDefault(restart == null ? null : restart.delayMs(), DEFAULT_SPEC.restart().delayMs())),
+            intOrDefault(
+                restart == null ? null : restart.attempts(), DEFAULT_SPEC.restart().attempts()),
+            longOrDefault(
+                restart == null ? null : restart.delayMs(), DEFAULT_SPEC.restart().delayMs())),
         new CdcPipelineSpec.SinkTuning(
             intOrDefault(
                 sinkOptions == null ? null : sinkOptions.maxRetries(),
                 DEFAULT_SPEC.sink().maxRetries()),
             intOrDefault(
-                sinkOptions == null ? null : sinkOptions.batchSize(), DEFAULT_SPEC.sink().batchSize()),
+                sinkOptions == null ? null : sinkOptions.batchSize(),
+                DEFAULT_SPEC.sink().batchSize()),
             longOrDefault(
                 sinkOptions == null ? null : sinkOptions.flushIntervalMs(),
                 DEFAULT_SPEC.sink().flushIntervalMs()),
@@ -187,23 +186,6 @@ public class RealtimeYamlCodec {
                 spec.sink().maxBatchBytes(),
                 spec.sink().statementCacheSize(),
                 spec.sink().strictReplaySafety())));
-  }
-
-  private void validate(CdcPipelineSpec spec) {
-    List<String> violations =
-        beanValidator.validate(spec).stream()
-            .sorted(Comparator.comparing(v -> v.getPropertyPath().toString()))
-            .map(this::violationMessage)
-            .toList();
-    if (!violations.isEmpty()) {
-      throw new IllegalArgumentException("Yak Realtime YAML 配置无效：" + String.join("；", violations));
-    }
-    specValidator.validate(spec);
-  }
-
-  private String violationMessage(ConstraintViolation<CdcPipelineSpec> violation) {
-    String path = violation.getPropertyPath().toString();
-    return (path.isBlank() ? "配置" : path) + " " + violation.getMessage();
   }
 
   private CdcPipelineSpec.SchemaEvolution schemaEvolution(String value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
@@ -49,8 +49,10 @@ class RealtimeDefinitionValidatorTest {
     capabilityResolver = mock(RealtimeConnectorCapabilityResolver.class);
     compiler = mock(PipelineYamlCompiler.class);
     gateway = mock(RealtimeEngineGateway.class);
-    environment = mock(ComputeEnvironmentSnapshot.class);
-    resolved = mock(ResolvedCdcPipeline.class);
+    environment =
+        new ComputeEnvironmentSnapshot(
+            3L, "test-env", "FLINK_CDC", "REMOTE", "LOCAL", null, 1);
+    resolved = new ResolvedCdcPipeline(null, null);
 
     when(runtimeResolver.environment(3L, true)).thenReturn(environment);
     when(dataSourceResolver.resolve(any(CdcPipelineSpec.class))).thenReturn(resolved);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
@@ -1,0 +1,119 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RealtimeDefinitionValidatorTest {
+
+  private Validator beanValidator;
+  private CdcPipelineSpecValidator specValidator;
+  private RealtimeRuntimeResolver runtimeResolver;
+  private RealtimeDataSourceResolver dataSourceResolver;
+  private RealtimeConnectorCapabilityResolver capabilityResolver;
+  private PipelineYamlCompiler compiler;
+  private RealtimeEngineGateway gateway;
+  private RealtimeDefinitionValidator validator;
+  private ComputeEnvironmentSnapshot environment;
+  private ResolvedCdcPipeline resolved;
+
+  @BeforeEach
+  void setUp() {
+    beanValidator = mock(Validator.class);
+    specValidator = mock(CdcPipelineSpecValidator.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    capabilityResolver = mock(RealtimeConnectorCapabilityResolver.class);
+    compiler = mock(PipelineYamlCompiler.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    environment = mock(ComputeEnvironmentSnapshot.class);
+    resolved = mock(ResolvedCdcPipeline.class);
+
+    when(beanValidator.validate(any(CdcPipelineSpec.class))).thenReturn(Set.of());
+    when(runtimeResolver.environment(3L, true)).thenReturn(environment);
+    when(dataSourceResolver.resolve(any(CdcPipelineSpec.class))).thenReturn(resolved);
+    ObjectNode manifest = new ObjectMapper().createObjectNode();
+    manifest.put("deliverySemantics", "at-least-once");
+    manifest.putObject("connectors")
+        .putArray("sources")
+        .add("mysql");
+    manifest.withObject("connectors").putArray("sinks").add("yak-jdbc:mysql");
+    manifest.withObject("connectors").putArray("schemaEvolution").add("evolve");
+    when(gateway.capabilities(environment)).thenReturn(manifest);
+
+    validator =
+        new RealtimeDefinitionValidator(
+            beanValidator,
+            specValidator,
+            runtimeResolver,
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway);
+  }
+
+  @Test
+  void validatesDefinitionWithoutCallingRuntimeHealth() {
+    CdcPipelineSpec spec = spec();
+
+    var result = validator.validate(spec, 3L);
+
+    assertThat(result.valid()).isTrue();
+    assertThat(result.deliverySemantics()).isEqualTo("at-least-once");
+    verify(specValidator).validate(spec);
+    verify(runtimeResolver).environment(3L, true);
+    verify(dataSourceResolver).resolve(spec);
+    verify(capabilityResolver).requireSupported(any(), eq(resolved), eq(spec));
+    verify(compiler).compile("definition-preflight", spec, resolved);
+    verify(gateway, never()).validate(any(), any());
+  }
+
+  @Test
+  void rejectsDatasourceResolutionFailureBeforePersistence() {
+    CdcPipelineSpec spec = spec();
+    when(dataSourceResolver.resolve(spec))
+        .thenThrow(new IllegalArgumentException("Source 数据源不存在：1"));
+
+    assertThatThrownBy(() -> validator.validate(spec, 3L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Source 数据源不存在");
+
+    verify(compiler, never()).compile(any(), any(), any());
+  }
+
+  private CdcPipelineSpec spec() {
+    return new CdcPipelineSpec(
+        1L,
+        2L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                "orders", "orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
@@ -55,11 +55,10 @@ class RealtimeDefinitionValidatorTest {
     when(dataSourceResolver.resolve(any(CdcPipelineSpec.class))).thenReturn(resolved);
     ObjectNode manifest = new ObjectMapper().createObjectNode();
     manifest.put("deliverySemantics", "at-least-once");
-    manifest.putObject("connectors")
-        .putArray("sources")
-        .add("mysql");
-    manifest.withObject("connectors").putArray("sinks").add("yak-jdbc:mysql");
-    manifest.withObject("connectors").putArray("schemaEvolution").add("evolve");
+    ObjectNode connectors = manifest.putObject("connectors");
+    connectors.putArray("sources").add("mysql");
+    connectors.putArray("sinks").add("yak-jdbc:mysql");
+    connectors.putArray("schemaEvolution").add("evolve");
     when(gateway.capabilities(environment)).thenReturn(manifest);
 
     validator =

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
@@ -19,15 +19,13 @@ import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResol
 import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
 import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
-import jakarta.validation.Validator;
+import jakarta.validation.Validation;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class RealtimeDefinitionValidatorTest {
 
-  private Validator beanValidator;
   private CdcPipelineSpecValidator specValidator;
   private RealtimeRuntimeResolver runtimeResolver;
   private RealtimeDataSourceResolver dataSourceResolver;
@@ -40,7 +38,6 @@ class RealtimeDefinitionValidatorTest {
 
   @BeforeEach
   void setUp() {
-    beanValidator = mock(Validator.class);
     specValidator = mock(CdcPipelineSpecValidator.class);
     runtimeResolver = mock(RealtimeRuntimeResolver.class);
     dataSourceResolver = mock(RealtimeDataSourceResolver.class);
@@ -50,7 +47,6 @@ class RealtimeDefinitionValidatorTest {
     environment = mock(ComputeEnvironmentSnapshot.class);
     resolved = mock(ResolvedCdcPipeline.class);
 
-    when(beanValidator.validate(any(CdcPipelineSpec.class))).thenReturn(Set.of());
     when(runtimeResolver.environment(3L, true)).thenReturn(environment);
     when(dataSourceResolver.resolve(any(CdcPipelineSpec.class))).thenReturn(resolved);
     ObjectNode manifest = new ObjectMapper().createObjectNode();
@@ -63,7 +59,7 @@ class RealtimeDefinitionValidatorTest {
 
     validator =
         new RealtimeDefinitionValidator(
-            beanValidator,
+            Validation.buildDefaultValidatorFactory().getValidator(),
             specValidator,
             runtimeResolver,
             dataSourceResolver,
@@ -99,6 +95,29 @@ class RealtimeDefinitionValidatorTest {
         .hasMessageContaining("Source 数据源不存在");
 
     verify(compiler, never()).compile(any(), any(), any());
+  }
+
+  @Test
+  void rejectsBeanValidationFailureBeforeDatasourceResolution() {
+    CdcPipelineSpec invalid =
+        new CdcPipelineSpec(
+            1L,
+            2L,
+            List.of(
+                new CdcPipelineSpec.TableRoute(
+                    "orders", "orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+            "initial",
+            CdcPipelineSpec.SchemaEvolution.EVOLVE,
+            0,
+            60_000,
+            new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+            new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+
+    assertThatThrownBy(() -> validator.validate(invalid, 3L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("parallelism");
+
+    verify(dataSourceResolver, never()).resolve(any());
   }
 
   private CdcPipelineSpec spec() {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeDefinitionValidatorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
@@ -19,6 +20,8 @@ import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResol
 import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
 import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
 import jakarta.validation.Validation;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +32,7 @@ class RealtimeDefinitionValidatorTest {
   private CdcPipelineSpecValidator specValidator;
   private RealtimeRuntimeResolver runtimeResolver;
   private RealtimeDataSourceResolver dataSourceResolver;
+  private DataSourceCatalogService catalogService;
   private RealtimeConnectorCapabilityResolver capabilityResolver;
   private PipelineYamlCompiler compiler;
   private RealtimeEngineGateway gateway;
@@ -41,6 +45,7 @@ class RealtimeDefinitionValidatorTest {
     specValidator = mock(CdcPipelineSpecValidator.class);
     runtimeResolver = mock(RealtimeRuntimeResolver.class);
     dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    catalogService = mock(DataSourceCatalogService.class);
     capabilityResolver = mock(RealtimeConnectorCapabilityResolver.class);
     compiler = mock(PipelineYamlCompiler.class);
     gateway = mock(RealtimeEngineGateway.class);
@@ -49,6 +54,14 @@ class RealtimeDefinitionValidatorTest {
 
     when(runtimeResolver.environment(3L, true)).thenReturn(environment);
     when(dataSourceResolver.resolve(any(CdcPipelineSpec.class))).thenReturn(resolved);
+    when(catalogService.listTables(1L, null, null, null))
+        .thenReturn(List.of(new DataSourceCatalogTableVO("shop", null, "orders", "TABLE", null)));
+    when(catalogService.listColumns(1L, "shop", null, "orders"))
+        .thenReturn(
+            List.of(
+                new DataSourceCatalogColumnVO(
+                    "id", "BIGINT", null, null, null, false, 1, true, null)));
+
     ObjectNode manifest = new ObjectMapper().createObjectNode();
     manifest.put("deliverySemantics", "at-least-once");
     ObjectNode connectors = manifest.putObject("connectors");
@@ -63,6 +76,7 @@ class RealtimeDefinitionValidatorTest {
             specValidator,
             runtimeResolver,
             dataSourceResolver,
+            catalogService,
             capabilityResolver,
             compiler,
             gateway);
@@ -79,6 +93,8 @@ class RealtimeDefinitionValidatorTest {
     verify(specValidator).validate(spec);
     verify(runtimeResolver).environment(3L, true);
     verify(dataSourceResolver).resolve(spec);
+    verify(catalogService).listTables(1L, null, null, null);
+    verify(catalogService).listColumns(1L, "shop", null, "orders");
     verify(capabilityResolver).requireSupported(any(), eq(resolved), eq(spec));
     verify(compiler).compile("definition-preflight", spec, resolved);
     verify(gateway, never()).validate(any(), any());
@@ -94,6 +110,25 @@ class RealtimeDefinitionValidatorTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Source 数据源不存在");
 
+    verify(catalogService, never()).listTables(any(), any(), any(), any());
+    verify(compiler, never()).compile(any(), any(), any());
+  }
+
+  @Test
+  void rejectsPrimaryKeyDriftBeforePersistence() {
+    CdcPipelineSpec spec = spec();
+    when(catalogService.listColumns(1L, "shop", null, "orders"))
+        .thenReturn(
+            List.of(
+                new DataSourceCatalogColumnVO(
+                    "order_id", "BIGINT", null, null, null, false, 1, true, null)));
+
+    assertThatThrownBy(() -> validator.validate(spec, 3L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("主键与任务配置不一致")
+        .hasMessageContaining("order_id");
+
+    verify(capabilityResolver, never()).requireSupported(any(), any(), any());
     verify(compiler, never()).compile(any(), any(), any());
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeYamlCodecTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeYamlCodecTest.java
@@ -19,6 +19,7 @@ class RealtimeYamlCodecTest {
           null,
           null,
           null,
+          null,
           null);
 
   private final RealtimeYamlCodec codec = new RealtimeYamlCodec(definitionValidator);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeYamlCodecTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeYamlCodecTest.java
@@ -11,10 +11,17 @@ import org.junit.jupiter.api.Test;
 
 class RealtimeYamlCodecTest {
 
-  private final RealtimeYamlCodec codec =
-      new RealtimeYamlCodec(
+  private final RealtimeDefinitionValidator definitionValidator =
+      new RealtimeDefinitionValidator(
           Validation.buildDefaultValidatorFactory().getValidator(),
-          new CdcPipelineSpecValidator());
+          new CdcPipelineSpecValidator(),
+          null,
+          null,
+          null,
+          null,
+          null);
+
+  private final RealtimeYamlCodec codec = new RealtimeYamlCodec(definitionValidator);
 
   @Test
   void parsesConciseYamlAndAppliesStableDefaults() {
@@ -37,9 +44,10 @@ class RealtimeYamlCodecTest {
     assertThat(spec.startupMode()).isEqualTo("initial");
     assertThat(spec.schemaEvolution()).isEqualTo(CdcPipelineSpec.SchemaEvolution.EVOLVE);
     assertThat(spec.parallelism()).isEqualTo(1);
-    assertThat(spec.tables()).containsExactly(
-        new CdcPipelineSpec.TableRoute(
-            "orders", "orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id")));
+    assertThat(spec.tables())
+        .containsExactly(
+            new CdcPipelineSpec.TableRoute(
+                "orders", "orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id")));
     assertThat(spec.sink().batchSize()).isEqualTo(1_000);
     assertThat(spec.sink().strictReplaySafety()).isTrue();
   }
@@ -52,7 +60,10 @@ class RealtimeYamlCodecTest {
             22L,
             List.of(
                 new CdcPipelineSpec.TableRoute(
-                    "orders", "public.ods_orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id")),
+                    "orders",
+                    "public.ods_orders",
+                    CdcPipelineSpec.MatchMode.EXACT,
+                    List.of("id")),
                 new CdcPipelineSpec.TableRoute(
                     "user_.*", "public.users", CdcPipelineSpec.MatchMode.REGEX, List.of("id"))),
             "latest-offset",

--- a/yak-ops-ui/src/pages/realtime-sync/YamlJobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/YamlJobEditor.tsx
@@ -103,7 +103,9 @@ export default function YamlJobEditor({
     setParsing(true);
     setValidationMessage(undefined);
     try {
-      await parseCurrentYaml();
+      const spec = await parseCurrentYaml();
+      await realtimeApi.validateDefinition(spec, job.runtimeEnvironmentId);
+      setValidationMessage('YAML 已通过解析、Spec、运行环境与数据源预校验');
       message.success('YAML 校验通过');
     } catch (error: any) {
       setValidatedSpec(undefined);
@@ -143,7 +145,7 @@ export default function YamlJobEditor({
         runtimeEnvironmentId: job.runtimeEnvironmentId,
         spec,
       });
-      setValidationMessage('YAML 已解析为统一 Spec 并保存为实时同步草稿');
+      setValidationMessage('YAML 已通过统一预校验并保存为实时同步草稿');
       message.success('YAML 配置已保存');
       onSaved();
     } catch (error: any) {
@@ -238,7 +240,7 @@ export default function YamlJobEditor({
               <section className="rounded-xl bg-white p-5">
                 <div className="text-[13px] font-semibold text-[#101828]">校验状态</div>
                 <div className="mt-3 rounded-lg bg-[#f9fafb] px-4 py-3 text-[12px] leading-5 text-[#667085]">
-                  {validationMessage || '编辑后点击“校验”，确认 YAML 可以转换为统一 CdcPipelineSpec。'}
+                  {validationMessage || '编辑后点击“校验”，确认 YAML 可以转换并通过统一定义预校验。'}
                 </div>
                 {validatedSpec && (
                   <div className="mt-3 rounded-lg border border-[#abefc6] bg-[#ecfdf3] px-4 py-3 text-[12px] text-[#027a48]">

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -46,15 +46,6 @@ const validateDefinition = (spec: CdcPipelineSpec, runtimeEnvironmentId: number)
     data: { spec, runtimeEnvironmentId },
   });
 
-const saveDefinition = async (
-  method: 'POST' | 'PUT',
-  url: string,
-  payload: RealtimeDefinitionPayload,
-) => {
-  await validateDefinition(payload.spec, payload.runtimeEnvironmentId);
-  return request<ApiResponse<number>>(url, { method, data: payload });
-};
-
 export const realtimeApi = {
   page: (params: RealtimePageQuery) =>
     request<ApiResponse<RealtimeJobPage>>(PREFIX, {
@@ -64,9 +55,9 @@ export const realtimeApi = {
   createBasic: (payload: { name: string; description?: string; runtimeEnvironmentId: number }) =>
     request<ApiResponse<number>>(PREFIX, { method: 'POST', data: payload }),
   create: (payload: RealtimeDefinitionPayload) =>
-    saveDefinition('POST', `${PREFIX}/draft`, payload),
+    request<ApiResponse<number>>(`${PREFIX}/draft`, { method: 'POST', data: payload }),
   update: (id: number, payload: RealtimeDefinitionPayload) =>
-    saveDefinition('PUT', `${PREFIX}/${id}`, payload),
+    request<ApiResponse<number>>(`${PREFIX}/${id}`, { method: 'PUT', data: payload }),
   validateDefinition,
   parseYaml: (yaml: string) =>
     request<ApiResponse<CdcPipelineSpec>>(`${PREFIX}/yaml/parse`, {

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -35,6 +35,26 @@ interface RealtimeDefinitionPayload {
   spec: CdcPipelineSpec;
 }
 
+interface DefinitionValidationResult {
+  valid: boolean;
+  deliverySemantics: string;
+}
+
+const validateDefinition = (spec: CdcPipelineSpec, runtimeEnvironmentId: number) =>
+  request<ApiResponse<DefinitionValidationResult>>(`${PREFIX}/spec/validate`, {
+    method: 'POST',
+    data: { spec, runtimeEnvironmentId },
+  });
+
+const saveDefinition = async (
+  method: 'POST' | 'PUT',
+  url: string,
+  payload: RealtimeDefinitionPayload,
+) => {
+  await validateDefinition(payload.spec, payload.runtimeEnvironmentId);
+  return request<ApiResponse<number>>(url, { method, data: payload });
+};
+
 export const realtimeApi = {
   page: (params: RealtimePageQuery) =>
     request<ApiResponse<RealtimeJobPage>>(PREFIX, {
@@ -44,9 +64,10 @@ export const realtimeApi = {
   createBasic: (payload: { name: string; description?: string; runtimeEnvironmentId: number }) =>
     request<ApiResponse<number>>(PREFIX, { method: 'POST', data: payload }),
   create: (payload: RealtimeDefinitionPayload) =>
-    request<ApiResponse<number>>(`${PREFIX}/draft`, { method: 'POST', data: payload }),
+    saveDefinition('POST', `${PREFIX}/draft`, payload),
   update: (id: number, payload: RealtimeDefinitionPayload) =>
-    request<ApiResponse<number>>(`${PREFIX}/${id}`, { method: 'PUT', data: payload }),
+    saveDefinition('PUT', `${PREFIX}/${id}`, payload),
+  validateDefinition,
   parseYaml: (yaml: string) =>
     request<ApiResponse<CdcPipelineSpec>>(`${PREFIX}/yaml/parse`, {
       method: 'POST',


### PR DESCRIPTION
## 背景

这是实时同步第一期的流程 5：统一 Wizard、YAML 和原编辑器的定义校验与保存边界。

流程 4 已经把两种编辑模式都收敛到统一 `CdcPipelineSpec`。本 PR 继续把保存前校验收口到同一个后端定义级校验器，避免不同编辑器各自维护一套规则。

## 核心设计

校验分成两层，职责明确：

```text
Wizard / YAML / Legacy Editor
            ↓
       CdcPipelineSpec
            ↓
RealtimeDefinitionValidator
            ↓
       保存 spec_json
            ↓
     发布 / 启动阶段
            ↓
现有 Flink Runtime Validation
```

### 定义级预校验（本 PR）

保存草稿前检查：

- Bean Validation：并行度、Checkpoint、Sink 参数等字段约束
- `CdcPipelineSpecValidator`：Source/Sink 不同、Route、Replay Safety、Regex 等跨字段规则
- 运行环境存在且启用
- Source / Sink 数据源存在、连接参数可解析且角色类型受支持
- Source Catalog 可读取
- EXACT Source 表必须真实存在
- REGEX Source 规则必须至少匹配一张物理表
- 每个匹配 Source 表必须存在主键
- `keyColumns` 必须与 Source 当前主键一致，发现主键漂移直接阻止保存
- 运行环境声明的 Connector / Schema Evolution 能力必须兼容任务 Spec
- `PipelineYamlCompiler` 必须能成功编译当前逻辑定义

### 运行级校验（保持现有行为）

发布 / 启动继续走现有完整校验，包括 Flink REST / CLI readiness。

**定义级预校验不会调用 `gateway.validate()`，不会因为 Flink 集群临时离线而阻止编辑草稿。**

> 注意：Source 数据库 Catalog 属于任务定义的一部分，因此 Source 元数据不可读时会阻止保存，避免把错误表名或过期主键写入任务定义。

## 后端改动

- 新增 `RealtimeDefinitionValidator`
- `RealtimeValidationService` 同时提供：
  - 未保存定义预校验
  - 已保存任务运行级校验
- 新增：
  - `POST /api/v1/realtime-sync/spec/validate`
- `/spec/validate` 要求 `task:realtime:update` 权限，因为会读取 Source Catalog 元数据
- `/draft` 和 `PUT /{id}` 在真正持久化前执行同一套定义级校验
- `SaveRequest.spec` 明确增加 `@NotNull`
- `RealtimeYamlCodec` 不再维护自己的 Bean Validator / Spec Validator，统一复用 `RealtimeDefinitionValidator.validateSpec()`

## 前端改动

- 保留 `realtimeApi.validateDefinition()` 作为显式预校验入口
- YAML 编辑器“校验”按钮现在执行：

```text
YAML parse
  ↓
CdcPipelineSpec
  ↓
/spec/validate
  ↓
运行环境 + 数据源 + Source Catalog + PK + Connector + Compile
```

- Wizard / Legacy / YAML 的最终保存仍直接调用原 `POST /draft` / `PUT /{id}`；服务端会在写库前统一预校验
- 没有在前端保存前重复调用一次 Catalog，避免多表任务产生双倍元数据查询

## 为什么检查主键漂移

流程 2 会自动识别主键，但数据库结构之后可能发生变化；YAML 模式也允许用户显式填写 `keyColumns`。

因此保存时以后端 Source Catalog 为准，例如：

```text
任务配置：orders -> keyColumns: [id]
当前数据库：PRIMARY KEY(order_id)

=> 保存失败，提示主键与任务配置不一致
```

这样错误在任务定义阶段暴露，而不是等 Flink 启动后才发现。

## 测试

新增 / 调整测试覆盖：

- 合法定义可通过预校验
- 定义预校验不会调用 Flink runtime `gateway.validate()`
- 数据源解析失败时在持久化前失败
- Source 主键漂移时阻止保存
- Bean Validation 失败时不会继续访问数据源
- YAML Codec 继续复用统一 Spec 校验规则

## 边界

本 PR 不包含：

- `snapshot` / FINISHED 正常完成态
- Wizard ↔ YAML 页面内直接切换
- 发布 / 启动 / 停止执行链路重构
- Sink 目标表必须预先存在的校验（Schema Evolution / Sink 创建策略仍按现有运行链路处理）
- 数据库表结构变更

## 验证说明

已做分支 diff、构造器、DTO、权限和测试代码静态检查。分支基于当前 `main`，当前为纯 ahead、`behind_by=0`。当前执行环境未直接运行完整 Maven / Yarn 构建，因此不声称本地完整构建已经通过，后续以仓库 CI / 本地开发环境结果为准。