### PR TITLE
feat: unify realtime publish and start execution flow

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
@@ -1,0 +1,201 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDeployRequest;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDeployRequest.CredentialBinding;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.DeployResult;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.ValidationResult;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RealtimeExecutionPathTest {
+
+  private static final long JOB_ID = 7L;
+  private static final long DEPLOYMENT_ID = 19L;
+  private static final String FLINK_JOB_ID = "0123456789abcdef0123456789abcdef";
+  private static final String CANONICAL_YAML =
+      "source:\n  type: mysql\nsink:\n  type: yak-jdbc\npipeline:\n  name: test-job\n";
+
+  @Test
+  void publishAndStartUseTheSameCompiledPipelineYaml() {
+    RealtimeJobStore store = mock(RealtimeJobStore.class);
+    CdcPipelineSpecValidator specValidator = mock(CdcPipelineSpecValidator.class);
+    RealtimeDataSourceResolver dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    RealtimeConnectorCapabilityResolver capabilityResolver =
+        mock(RealtimeConnectorCapabilityResolver.class);
+    PipelineYamlCompiler compiler = mock(PipelineYamlCompiler.class);
+    RealtimeEngineGateway gateway = mock(RealtimeEngineGateway.class);
+    RealtimeRuntimeResolver runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    ObjectMapper json = new ObjectMapper();
+    CdcPipelineSpec spec = spec();
+    ComputeEnvironmentSnapshot environment = environment();
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+    DefinitionRow publishedStopped = definition(spec, environment, "STOPPED", "STOPPED");
+    DefinitionRow starting = definition(spec, environment, "RUNNING", "STARTING");
+    DeploymentRow deployment = deployment(spec, environment);
+
+    ObjectNode capabilities = json.createObjectNode();
+    capabilities.put("runtimeVersion", "flink-cdc-cli-3.6.0");
+    capabilities.put("deliverySemantics", "at-least-once");
+
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(publishedStopped));
+    when(store.spec(any())).thenReturn(spec);
+    when(store.runtimeEnvironmentId(JOB_ID)).thenReturn(environment.id());
+    when(store.lockDefinition(JOB_ID)).thenReturn(publishedStopped, publishedStopped, starting);
+    when(store.deploymentByIdempotencyKey("exec-1")).thenReturn(Optional.empty());
+    when(store.insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("exec-1")))
+        .thenReturn(DEPLOYMENT_ID);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(runtimeResolver.definition(any(), eq(true))).thenReturn(environment);
+    when(dataSourceResolver.resolve(spec)).thenReturn(resolved);
+    when(dataSourceResolver.resolveCredentials(spec))
+        .thenReturn(
+            new CredentialBinding[] {
+              new CredentialBinding("source", "source-secret"),
+              new CredentialBinding("sink", "sink-secret")
+            });
+    when(gateway.capabilities(environment)).thenReturn(capabilities);
+    when(compiler.compile("test-job", spec, resolved))
+        .thenReturn(new CompiledPipeline(CANONICAL_YAML, "mysql#1 -> mysql#2, tables=1"));
+    when(gateway.validate(environment, CANONICAL_YAML))
+        .thenReturn(new ValidationResult(true, "at-least-once"));
+    when(gateway.deploy(eq(environment), any()))
+        .thenReturn(new DeployResult(FLINK_JOB_ID, "at-least-once"));
+
+    RealtimeJobService service =
+        new RealtimeJobService(
+            store,
+            json,
+            specValidator,
+            new RealtimeStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
+
+    service.publish(JOB_ID);
+    service.start(JOB_ID, "exec-1");
+
+    verify(compiler, times(2)).compile("test-job", spec, resolved);
+    verify(gateway, times(2)).validate(environment, CANONICAL_YAML);
+
+    ArgumentCaptor<RealtimeDeployRequest> requestCaptor =
+        ArgumentCaptor.forClass(RealtimeDeployRequest.class);
+    verify(gateway).deploy(eq(environment), requestCaptor.capture());
+    assertThat(requestCaptor.getValue().pipelineYaml()).isEqualTo(CANONICAL_YAML);
+    assertThat(requestCaptor.getValue().idempotencyKey()).isEqualTo("exec-1");
+
+    verify(store)
+        .insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("exec-1"));
+    verify(store).markDeploymentRunning(JOB_ID, DEPLOYMENT_ID, FLINK_JOB_ID, environment.runtimeRevision());
+  }
+
+  private CdcPipelineSpec spec() {
+    return new CdcPipelineSpec(
+        1L,
+        2L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                "orders", "orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+
+  private ComputeEnvironmentSnapshot environment() {
+    return new ComputeEnvironmentSnapshot(
+        3L,
+        "test-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
+        2);
+  }
+
+  private DefinitionRow definition(
+      CdcPipelineSpec spec,
+      ComputeEnvironmentSnapshot environment,
+      String desiredState,
+      String observedState) {
+    return new DefinitionRow(
+        JOB_ID,
+        "test-job",
+        null,
+        spec,
+        environment.id(),
+        "PUBLISHED",
+        desiredState,
+        observedState,
+        1,
+        1,
+        "definition-digest",
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private DeploymentRow deployment(
+      CdcPipelineSpec spec, ComputeEnvironmentSnapshot environment) {
+    LocalDateTime now = LocalDateTime.now();
+    return new DeploymentRow(
+        DEPLOYMENT_ID,
+        JOB_ID,
+        1,
+        spec,
+        "mysql#1 -> mysql#2, tables=1",
+        "pipeline-digest",
+        "exec-1",
+        FLINK_JOB_ID,
+        environment.runtimeRevision(),
+        environment,
+        "RUNNING",
+        false,
+        null,
+        now,
+        now);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
@@ -29,6 +29,8 @@ import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import jakarta.validation.Validation;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +46,55 @@ class RealtimeExecutionPathTest {
   private static final String FLINK_JOB_ID = "0123456789abcdef0123456789abcdef";
   private static final String CANONICAL_YAML =
       "source:\n  type: mysql\nsink:\n  type: yak-jdbc\npipeline:\n  name: test-job\n";
+
+  @Test
+  void wizardAndYamlSpecsCompileToTheSameRuntimePipeline() {
+    CdcPipelineSpec wizardSpec = spec();
+    RealtimeDefinitionValidator specValidator =
+        new RealtimeDefinitionValidator(
+            Validation.buildDefaultValidatorFactory().getValidator(),
+            new CdcPipelineSpecValidator(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    RealtimeYamlCodec yamlCodec = new RealtimeYamlCodec(specValidator);
+
+    String logicalYaml = yamlCodec.render(wizardSpec);
+    CdcPipelineSpec yamlSpec = yamlCodec.parse(logicalYaml);
+
+    ResolvedCdcPipeline resolved =
+        new ResolvedCdcPipeline(
+            new ResolvedCdcPipeline.Endpoint(
+                1L,
+                "source",
+                DataSourceDbType.MYSQL,
+                "mysql-source",
+                3306,
+                "jdbc:mysql://mysql-source:3306/shop",
+                "com.mysql.cj.jdbc.Driver",
+                "reader",
+                "shop"),
+            new ResolvedCdcPipeline.Endpoint(
+                2L,
+                "sink",
+                DataSourceDbType.MYSQL,
+                "mysql-sink",
+                3306,
+                "jdbc:mysql://mysql-sink:3306/dw",
+                "com.mysql.cj.jdbc.Driver",
+                "writer",
+                "dw"));
+    PipelineYamlCompiler compiler = new PipelineYamlCompiler();
+
+    String wizardPipeline = compiler.compile("test-job", wizardSpec, resolved).yaml();
+    String yamlPipeline = compiler.compile("test-job", yamlSpec, resolved).yaml();
+
+    assertThat(yamlSpec).isEqualTo(wizardSpec);
+    assertThat(yamlPipeline).isEqualTo(wizardPipeline);
+  }
 
   @Test
   void publishAndStartUseTheSameCompiledPipelineYaml() {

--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
@@ -1,0 +1,328 @@
+import {
+  CheckCircleOutlined,
+  CloudServerOutlined,
+  PlayCircleOutlined,
+  ReloadOutlined,
+  SafetyOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
+import { Alert, Button, Card, ConfigProvider, Descriptions, Space, Steps, Tag, message } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import { BRAND_THEME } from '@/styles/brand';
+import { realtimeApi } from './api';
+import type { RealtimeJob, RuntimeCapabilities } from './types';
+
+type ExecutionAction = 'validate' | 'publish' | 'start' | 'stop' | 'reconcile';
+
+const stateLabel: Record<string, string> = {
+  STOPPED: '已停止',
+  STARTING: '启动中',
+  RUNNING: '运行中',
+  STOPPING: '停止中',
+  FAILED: '失败',
+  UNKNOWN: '未知',
+  CONFLICT: '冲突',
+};
+
+export default function RealtimeExecutionPanel({
+  job,
+  onEdit,
+  onBack,
+}: {
+  job: RealtimeJob;
+  onEdit: () => void;
+  onBack: () => void;
+}) {
+  const [current, setCurrent] = useState(job);
+  const [capabilities, setCapabilities] = useState<RuntimeCapabilities>({});
+  const [validated, setValidated] = useState(false);
+  const [acting, setActing] = useState<ExecutionAction>();
+
+  useEffect(() => {
+    setCurrent(job);
+  }, [job]);
+
+  useEffect(() => {
+    let cancelled = false;
+    realtimeApi
+      .capabilities(job.runtimeEnvironmentId)
+      .then((response) => {
+        if (!cancelled) setCapabilities(response.data || {});
+      })
+      .catch(() => {
+        if (!cancelled) setCapabilities({});
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [job.runtimeEnvironmentId]);
+
+  const refreshJob = async () => {
+    const response = await realtimeApi.detail(current.id);
+    setCurrent(response.data);
+    return response.data;
+  };
+
+  const waitForStartResult = async () => {
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      const refreshed = await refreshJob();
+      if (['RUNNING', 'FAILED', 'UNKNOWN', 'CONFLICT'].includes(refreshed.observedState)) {
+        return refreshed;
+      }
+      await new Promise((resolve) => window.setTimeout(resolve, 1500));
+    }
+    return refreshJob();
+  };
+
+  const run = async (action: ExecutionAction) => {
+    setActing(action);
+    try {
+      await realtimeApi.action(current.id, action);
+      if (action === 'validate') {
+        setValidated(true);
+        message.success('Flink CDC 运行校验通过');
+        await refreshJob();
+      } else if (action === 'publish') {
+        setValidated(true);
+        const refreshed = await refreshJob();
+        message.success(
+          refreshed.releaseState === 'PUBLISHED' ? '当前定义版本已发布' : '发布请求已完成',
+        );
+      } else if (action === 'start') {
+        const refreshed = await waitForStartResult();
+        if (refreshed.observedState === 'RUNNING') {
+          message.success('实时同步任务已启动');
+        } else if (refreshed.observedState === 'STARTING') {
+          message.warning('Flink 任务仍在启动，可返回列表继续观察状态');
+        } else {
+          message.warning(`Flink 启动结果：${stateLabel[refreshed.observedState] || refreshed.observedState}`);
+        }
+      } else if (action === 'stop') {
+        await refreshJob();
+        message.success('已提交停止请求');
+      } else {
+        await refreshJob();
+        message.success('状态对账已完成');
+      }
+    } catch (error: any) {
+      message.error(error?.message || '执行操作失败');
+      try {
+        await refreshJob();
+      } catch {
+        // Keep the last known state when the follow-up read also fails.
+      }
+    } finally {
+      setActing(undefined);
+    }
+  };
+
+  const published =
+    current.releaseState === 'PUBLISHED' && current.publishedVersion === current.definitionVersion;
+  const running = current.desiredState === 'RUNNING';
+  const startable =
+    published &&
+    current.desiredState === 'STOPPED' &&
+    ['STOPPED', 'FAILED'].includes(current.observedState);
+  const runtimeDisabled = capabilities.deployEnabled === false;
+  const runtimeDisabledReason = capabilities.deployDisabledReason || '当前运行环境不可提交任务';
+
+  const steps = useMemo(
+    () => [
+      {
+        title: '保存草稿',
+        description: `定义 v${current.definitionVersion}`,
+        status: 'finish' as const,
+      },
+      {
+        title: '运行校验',
+        description: 'Flink CDC / Connector',
+        status: validated || published || running ? ('finish' as const) : ('process' as const),
+      },
+      {
+        title: '发布版本',
+        description: published ? `已发布 v${current.publishedVersion}` : '锁定当前定义版本',
+        status: published || running
+          ? ('finish' as const)
+          : validated
+            ? ('process' as const)
+            : ('wait' as const),
+      },
+      {
+        title: '启动任务',
+        description: running ? stateLabel[current.observedState] || current.observedState : '提交到 Flink CDC',
+        status: current.observedState === 'RUNNING'
+          ? ('finish' as const)
+          : published
+            ? ('process' as const)
+            : ('wait' as const),
+      },
+    ],
+    [current, published, running, validated],
+  );
+
+  return (
+    <ConfigProvider theme={BRAND_THEME} variant="filled">
+      <div className="min-h-[calc(100vh-64px)] bg-[#f7f8fa] px-6 py-6 text-[#161823]">
+        <div className="mx-auto w-full max-w-[1100px]">
+          <header className="mb-5 flex flex-wrap items-start justify-between gap-4 rounded-xl bg-white px-7 py-6">
+            <div>
+              <div className="flex items-center gap-2 text-[12px] font-medium text-[var(--yak-brand-color)]">
+                <CheckCircleOutlined />
+                配置已保存 · 统一执行链路
+              </div>
+              <h1 className="mb-0 mt-1 text-[20px] font-semibold text-[#101828]">{current.name}</h1>
+              <div className="mt-1 text-[12px] text-[#98a2b3]">
+                任务 ID：{current.id} · 定义版本 v{current.definitionVersion}
+              </div>
+            </div>
+            <Space>
+              <Button disabled={Boolean(acting)} onClick={onEdit}>
+                继续编辑
+              </Button>
+              <Button disabled={Boolean(acting)} onClick={onBack}>
+                返回任务列表
+              </Button>
+            </Space>
+          </header>
+
+          <Card className="mb-5">
+            <Steps responsive items={steps} />
+          </Card>
+
+          {runtimeDisabled && (
+            <Alert
+              className="mb-5"
+              type="warning"
+              showIcon
+              message="当前运行环境暂不可提交任务"
+              description={runtimeDisabledReason}
+            />
+          )}
+
+          <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)] gap-5 max-lg:grid-cols-1">
+            <Card title="下一步操作">
+              <div className="space-y-4">
+                <div className="rounded-xl border border-[#eaecf0] p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2 text-[14px] font-semibold text-[#101828]">
+                        <SafetyOutlined /> 1. 校验运行环境
+                      </div>
+                      <div className="mt-1 text-[12px] leading-5 text-[#667085]">
+                        使用任务绑定的运行环境执行 Flink CDC CLI / REST readiness 和 Connector 校验。
+                      </div>
+                    </div>
+                    <Button
+                      loading={acting === 'validate'}
+                      disabled={Boolean(acting) || !current.spec || runtimeDisabled}
+                      onClick={() => void run('validate')}
+                    >
+                      运行校验
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-[#eaecf0] p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2 text-[14px] font-semibold text-[#101828]">
+                        <CloudServerOutlined /> 2. 发布当前版本
+                      </div>
+                      <div className="mt-1 text-[12px] leading-5 text-[#667085]">
+                        发布会再次运行完整校验，并锁定当前 definitionVersion / configDigest。
+                      </div>
+                    </div>
+                    <Button
+                      type="primary"
+                      loading={acting === 'publish'}
+                      disabled={Boolean(acting) || published || running || !current.spec || runtimeDisabled}
+                      onClick={() => void run('publish')}
+                    >
+                      {published ? '已发布' : '发布当前版本'}
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-[#eaecf0] p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2 text-[14px] font-semibold text-[#101828]">
+                        <PlayCircleOutlined /> 3. 启动实时任务
+                      </div>
+                      <div className="mt-1 text-[12px] leading-5 text-[#667085]">
+                        启动只读取已发布的统一 Spec，由 PipelineYamlCompiler 生成临时 Flink CDC YAML 后通过 LOCAL / SSH 提交。
+                      </div>
+                    </div>
+                    {running ? (
+                      <Button
+                        danger
+                        icon={<StopOutlined />}
+                        loading={acting === 'stop'}
+                        disabled={Boolean(acting)}
+                        onClick={() => void run('stop')}
+                      >
+                        停止任务
+                      </Button>
+                    ) : (
+                      <Button
+                        type="primary"
+                        danger
+                        icon={<PlayCircleOutlined />}
+                        loading={acting === 'start'}
+                        disabled={Boolean(acting) || !startable || runtimeDisabled}
+                        onClick={() => void run('start')}
+                      >
+                        启动任务
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </Card>
+
+            <div className="space-y-5">
+              <Card title="当前执行状态">
+                <Descriptions size="small" column={1}>
+                  <Descriptions.Item label="发布状态">
+                    <Tag>{current.releaseState}</Tag>
+                  </Descriptions.Item>
+                  <Descriptions.Item label="运行状态">
+                    <Tag>{stateLabel[current.observedState] || current.observedState}</Tag>
+                  </Descriptions.Item>
+                  <Descriptions.Item label="运行环境">
+                    {capabilities.runtimeEnvironmentName || `环境 #${current.runtimeEnvironmentId}`}
+                  </Descriptions.Item>
+                  <Descriptions.Item label="提交方式">
+                    {capabilities.submissionMode || '-'}
+                  </Descriptions.Item>
+                  <Descriptions.Item label="Flink / CDC">
+                    {capabilities.flinkVersion || '-'} / {capabilities.flinkCdcVersion || '-'}
+                  </Descriptions.Item>
+                  <Descriptions.Item label="Engine JobId">
+                    {current.latestDeployment?.engineJobId || '-'}
+                  </Descriptions.Item>
+                </Descriptions>
+                <Button
+                  className="mt-3"
+                  size="small"
+                  icon={<ReloadOutlined />}
+                  disabled={Boolean(acting)}
+                  onClick={() => void refreshJob()}
+                >
+                  刷新状态
+                </Button>
+              </Card>
+
+              <Alert
+                type="info"
+                showIcon
+                message="Wizard 与 YAML 共用这一条执行链路"
+                description="编辑方式不会写入任务运行定义。发布和启动只认同一份 CdcPipelineSpec；数据库不保存原生 Flink CDC YAML。"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -46,6 +46,26 @@ const validateDefinition = (spec: CdcPipelineSpec, runtimeEnvironmentId: number)
     data: { spec, runtimeEnvironmentId },
   });
 
+const environments = () =>
+  request<ApiResponse<ComputeEnvironmentOption[]>>('/api/v1/compute-environments');
+
+const capabilities = async (environmentId?: number) => {
+  let resolvedEnvironmentId = environmentId;
+  if (!resolvedEnvironmentId) {
+    const response = await environments();
+    const rows = response.data || [];
+    resolvedEnvironmentId =
+      rows.find((item) => item.defaultEnvironment && item.enabled)?.id ??
+      rows.find((item) => item.enabled)?.id;
+  }
+  if (!resolvedEnvironmentId) {
+    throw new Error('暂无已启用的 Flink CDC 运行环境');
+  }
+  return request<ApiResponse<RuntimeCapabilities>>(`${PREFIX}/runtime/capabilities`, {
+    params: { environmentId: resolvedEnvironmentId },
+  });
+};
+
 export const realtimeApi = {
   page: (params: RealtimePageQuery) =>
     request<ApiResponse<RealtimeJobPage>>(PREFIX, {
@@ -87,12 +107,8 @@ export const realtimeApi = {
     request<ApiResponse<RealtimeRuntimeLog>>(`${PREFIX}/${id}/logs/runtime`, {
       params: { maxExceptions },
     }),
-  capabilities: (environmentId: number) =>
-    request<ApiResponse<RuntimeCapabilities>>(`${PREFIX}/runtime/capabilities`, {
-      params: { environmentId },
-    }),
-  environments: () =>
-    request<ApiResponse<ComputeEnvironmentOption[]>>('/api/v1/compute-environments'),
+  capabilities,
+  environments,
   dataSources: () => request<ApiResponse<DataSourceOption[]>>(`${DATA_SOURCE_PREFIX}/option`),
   catalogTables: (dataSourceId: number) =>
     request<ApiResponse<DataSourceCatalogTable[]>>(`${DATA_SOURCE_PREFIX}/catalog/${dataSourceId}/tables`),

--- a/yak-ops-ui/src/pages/realtime-sync/detail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/detail.tsx
@@ -3,6 +3,7 @@ import { message, Spin } from 'antd';
 import { useEffect, useState } from 'react';
 import { realtimeApi } from './api';
 import JobEditor from './JobEditor';
+import RealtimeExecutionPanel from './RealtimeExecutionPanel';
 import WizardJobEditor from './WizardJobEditor';
 import YamlJobEditor from './YamlJobEditor';
 import type { ComputeEnvironmentOption, DataSourceOption, RealtimeJob } from './types';
@@ -12,6 +13,7 @@ export default function RealtimeSyncDetail() {
   const [job, setJob] = useState<RealtimeJob>();
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
   const [environments, setEnvironments] = useState<ComputeEnvironmentOption[]>([]);
+  const [executionReady, setExecutionReady] = useState(false);
 
   useEffect(() => {
     Promise.all([realtimeApi.detail(Number(id)), realtimeApi.dataSources(), realtimeApi.environments()])
@@ -30,13 +32,34 @@ export default function RealtimeSyncDetail() {
       </div>
     );
 
+  const handleSaved = async () => {
+    try {
+      const refreshed = await realtimeApi.detail(job.id);
+      setJob(refreshed.data);
+      setExecutionReady(true);
+    } catch (error: any) {
+      message.error(error?.message || '配置已保存，但刷新执行状态失败');
+      history.push('/sync/realtime');
+    }
+  };
+
+  if (executionReady) {
+    return (
+      <RealtimeExecutionPanel
+        job={job}
+        onEdit={() => setExecutionReady(false)}
+        onBack={() => history.push('/sync/realtime')}
+      />
+    );
+  }
+
   const editorMode = new URLSearchParams(history.location.search).get('editor');
   if (editorMode === 'yaml') {
     return (
       <YamlJobEditor
         job={job}
         onClose={() => history.push('/sync/realtime')}
-        onSaved={() => history.push('/sync/realtime')}
+        onSaved={() => void handleSaved()}
       />
     );
   }
@@ -46,7 +69,7 @@ export default function RealtimeSyncDetail() {
         job={job}
         dataSources={dataSources}
         onClose={() => history.push('/sync/realtime')}
-        onSaved={() => history.push('/sync/realtime')}
+        onSaved={() => void handleSaved()}
       />
     );
   }
@@ -58,7 +81,7 @@ export default function RealtimeSyncDetail() {
       dataSources={dataSources}
       environments={environments}
       onClose={() => history.push('/sync/realtime')}
-      onSaved={() => history.push('/sync/realtime')}
+      onSaved={() => void handleSaved()}
     />
   );
 }


### PR DESCRIPTION
## 背景

这是实时同步第一期的流程 6：把 Wizard / YAML 保存后的配置正式交接到统一发布、启动执行链路，并用回归测试锁死执行等价性。

流程 1～5 已经完成创建入口、向导、YAML、统一 Spec 和保存前校验。本 PR 不重写 Flink 提交后端，而是复用已经存在的 `validate / publish / start / stop` API 和 `RealtimeJobService.prepare()` 执行路径。

## 核心执行链路

```text
Wizard ─┐
        ├─> CdcPipelineSpec -> spec_json
YAML ───┘
                         ↓
                    runtime validate
                         ↓
                       publish
                         ↓
                 published definition
                         ↓
                        start
                         ↓
                RealtimeJobService.prepare
                         ↓
              RealtimeDataSourceResolver
                         ↓
               PipelineYamlCompiler
                         ↓
             transient Flink CDC YAML
                         ↓
                  LOCAL / SSH Gateway
                         ↓
                       Flink
```

编辑模式仍然不会进入运行定义，也没有新增 WizardExecutor / YamlExecutor。

## 前端改动

### 保存后统一执行交接

新增 `RealtimeExecutionPanel`。

现在 Wizard、YAML、Legacy JobEditor 保存完成后，不再直接把用户丢回任务列表，而是进入同一执行页面：

1. 配置已保存
2. Flink CDC 运行校验
3. 发布当前 definitionVersion
4. 启动任务

执行面板只调用现有 API：

- `POST /{id}/validate`
- `POST /{id}/publish`
- `POST /{id}/start`
- `POST /{id}/stop`

没有新增第二套发布/启动接口。

### 运行环境能力

修正列表页已有的默认环境能力调用：原页面调用 `realtimeApi.capabilities()`，但 API 类型要求 `environmentId`。

现在：

- 显式传 `environmentId`：查询任务绑定环境能力
- 未传：自动选择默认且启用的环境；没有默认环境时回退第一个启用环境

任务执行面板始终显式使用任务自己的 `runtimeEnvironmentId`。

## 后端执行契约测试

新增 `RealtimeExecutionPathTest`，覆盖两层等价性。

### 1. Wizard / YAML 执行等价

```text
Wizard CdcPipelineSpec
        ↓ render
Yak Realtime YAML
        ↓ parse
CdcPipelineSpec
```

使用真实 `PipelineYamlCompiler` 分别编译两份 Spec，断言：

- YAML parse 后 Spec 与 Wizard Spec 相等
- 最终 Flink CDC Pipeline YAML 完全一致

### 2. Publish / Start 执行等价

测试同时调用：

```text
service.publish(id)
service.start(id, key)
```

断言：

- 两个阶段都使用同一个 `PipelineYamlCompiler` 结果
- `gateway.validate()` 看到的 Pipeline YAML 一致
- 真正传入 `gateway.deploy()` 的 `RealtimeDeployRequest.pipelineYaml` 与发布阶段校验的 YAML 完全一致
- Start 的 deployment snapshot 使用同一 `CdcPipelineSpec`

这样未来修改 compiler 或 lifecycle 时，如果发布和启动链路被改叉，测试会直接失败。

## 不改动

本 PR 没有修改：

- `RealtimeJobService` 执行实现
- `PipelineYamlCompiler` 实现
- `FlinkCdcEngineGateway`
- LOCAL 提交
- SSH 提交
- Secret 注入
- Stop / Restart / Reconcile 后端语义
- 数据库结构
- 原生 Flink CDC YAML 持久化策略

## 仍然遵守的边界

- 数据库只保存结构化 `CdcPipelineSpec`
- deployment 保存 Spec snapshot / digest / runtime environment snapshot
- 原生 Flink CDC YAML 仅在执行边界临时生成
- 密码仍通过 submission-scoped SECRET binding 注入
- Wizard / YAML 只是两个编辑入口，不是两个 runtime

## 验证说明

已完成分支 diff 和静态代码检查。分支直接基于当前 `main`，当前为纯 ahead、`behind_by=0`。

新增测试覆盖 Wizard/YAML 编译等价和 publish/start pipeline 等价。当前执行环境未直接运行完整 Maven / Yarn 构建，因此不声称本地完整构建已通过，后续以仓库 CI / 本地开发环境结果为准。