### PR TITLE
feat: add lossless realtime editor mode switching

### DIFF
--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeEditorModeSwitch.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeEditorModeSwitch.tsx
@@ -1,0 +1,26 @@
+import { CodeOutlined, FormOutlined } from '@ant-design/icons';
+import { Segmented } from 'antd';
+import type { RealtimeEditorMode } from './realtimeEditorMode';
+
+export default function RealtimeEditorModeSwitch({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: RealtimeEditorMode;
+  disabled?: boolean;
+  onChange: (mode: RealtimeEditorMode) => void;
+}) {
+  return (
+    <Segmented
+      size="small"
+      value={value}
+      disabled={disabled}
+      options={[
+        { value: 'wizard', label: '向导模式', icon: <FormOutlined /> },
+        { value: 'yaml', label: 'YAML 模式', icon: <CodeOutlined /> },
+      ]}
+      onChange={(next) => onChange(next as RealtimeEditorMode)}
+    />
+  );
+}

--- a/yak-ops-ui/src/pages/realtime-sync/WizardJobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/WizardJobEditor.tsx
@@ -27,6 +27,8 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BRAND_THEME } from '@/styles/brand';
 import { realtimeApi } from './api';
+import RealtimeEditorModeSwitch from './RealtimeEditorModeSwitch';
+import type { RealtimeEditorMode } from './realtimeEditorMode';
 import type {
   CdcPipelineSpec,
   DataSourceCatalogTable,
@@ -130,11 +132,13 @@ export default function WizardJobEditor({
   dataSources,
   onClose,
   onSaved,
+  onSwitchMode,
 }: {
   job: RealtimeJob;
   dataSources: DataSourceOption[];
   onClose: () => void;
   onSaved: () => void;
+  onSwitchMode?: (mode: RealtimeEditorMode, spec: CdcPipelineSpec) => void;
 }) {
   const [sourceId, setSourceId] = useState<number | undefined>(job.spec?.sourceDataSourceRef);
   const [sinkId, setSinkId] = useState<number | undefined>(job.spec?.sinkDataSourceRef);
@@ -165,7 +169,6 @@ export default function WizardJobEditor({
         })),
     [dataSources, sourceId],
   );
-
   const selectedNameSet = useMemo(
     () => new Set(selectedTables.map((item) => item.table.name)),
     [selectedTables],
@@ -195,7 +198,6 @@ export default function WizardJobEditor({
     try {
       const response = await realtimeApi.catalogTables(dataSourceId);
       if (requestId !== catalogRequestRef.current || sourceIdRef.current !== dataSourceId) return;
-
       const uniqueTables = Array.from(
         new Map(
           (response.data || [])
@@ -203,12 +205,11 @@ export default function WizardJobEditor({
             .map((table) => [table.name, table] as const),
         ).values(),
       ).sort((left, right) => left.name.localeCompare(right.name));
-
       setTables(uniqueTables);
       setSelectedTables((previous) =>
         previous.map((selected) => {
-          const catalogTable = uniqueTables.find((table) => table.name === selected.table.name);
-          return catalogTable ? { ...selected, table: catalogTable } : selected;
+          const current = uniqueTables.find((table) => table.name === selected.table.name);
+          return current ? { ...selected, table: current } : selected;
         }),
       );
     } catch (error: any) {
@@ -235,7 +236,6 @@ export default function WizardJobEditor({
           : selected,
       ),
     );
-
     try {
       const response = await realtimeApi.catalogColumns(dataSourceId, table);
       if (sourceIdRef.current !== dataSourceId) return;
@@ -243,34 +243,30 @@ export default function WizardJobEditor({
         .filter((column) => column.primaryKey)
         .sort((left, right) => (left.ordinalPosition || 0) - (right.ordinalPosition || 0))
         .map((column) => column.name);
-
       setSelectedTables((previous) =>
-        previous.map((selected) => {
-          if (selected.table.name !== table.name) return selected;
-          return {
-            ...selected,
-            table,
-            route: {
-              sourceTable: table.name,
-              sinkTable: selected.route.sinkTable || table.name,
-              matchMode: 'EXACT',
-              keyColumns,
-            },
-            status: keyColumns.length > 0 ? 'ready' : 'missing',
-            error: undefined,
-          };
-        }),
+        previous.map((selected) =>
+          selected.table.name === table.name
+            ? {
+                ...selected,
+                table,
+                route: {
+                  sourceTable: table.name,
+                  sinkTable: selected.route.sinkTable || table.name,
+                  matchMode: 'EXACT',
+                  keyColumns,
+                },
+                status: keyColumns.length > 0 ? 'ready' : 'missing',
+                error: undefined,
+              }
+            : selected,
+        ),
       );
     } catch (error: any) {
       if (sourceIdRef.current !== dataSourceId) return;
       setSelectedTables((previous) =>
         previous.map((selected) =>
           selected.table.name === table.name
-            ? {
-                ...selected,
-                status: 'error',
-                error: error?.message || '主键元数据读取失败',
-              }
+            ? { ...selected, status: 'error', error: error?.message || '主键元数据读取失败' }
             : selected,
         ),
       );
@@ -296,7 +292,6 @@ export default function WizardJobEditor({
       return;
     }
     if (selectedNameSet.has(table.name)) return;
-
     setSelectedTables((previous) => [
       ...previous,
       {
@@ -313,60 +308,43 @@ export default function WizardJobEditor({
     void resolvePrimaryKey(table, sourceId);
   };
 
-  const updateSinkTable = (sourceTable: string, sinkTable: string) => {
-    setSelectedTables((previous) =>
-      previous.map((selected) =>
-        selected.table.name === sourceTable
-          ? { ...selected, route: { ...selected.route, sinkTable } }
-          : selected,
-      ),
-    );
-  };
-
-  const updateAdvanced = <K extends keyof AdvancedSettings>(
-    key: K,
-    value: AdvancedSettings[K],
-  ) => {
-    setAdvanced((previous) => ({ ...previous, [key]: value }));
-  };
-
-  const save = async () => {
+  const buildCurrentSpec = (): CdcPipelineSpec | undefined => {
     if (!sourceId) {
       message.warning('请选择 Source 数据源');
-      return;
+      return undefined;
     }
     if (!sinkId) {
       message.warning('请选择 Sink 数据源');
-      return;
+      return undefined;
     }
     if (sourceId === sinkId) {
       message.warning('Source 与 Sink 不能使用同一个数据源');
-      return;
+      return undefined;
     }
     if (selectedTables.length === 0) {
       message.warning('请至少选择一张同步表');
-      return;
+      return undefined;
     }
     if (hasUnsupportedRoutes) {
-      message.warning('当前任务包含向导暂不支持的正则表规则，请使用原编辑器处理');
-      return;
+      message.warning('当前任务包含向导暂不支持的正则表规则，请切换到 YAML 模式编辑');
+      return undefined;
     }
     if (primaryKeyPending) {
-      message.warning('主键仍在识别中，请稍后再保存');
-      return;
+      message.warning('主键仍在识别中，请稍后再操作');
+      return undefined;
     }
     const invalidTables = selectedTables.filter((item) => item.status !== 'ready');
     if (invalidTables.length > 0) {
-      message.warning(`以下表暂不能保存：${invalidTables.map((item) => item.table.name).join('、')}`);
-      return;
+      message.warning(`以下表暂不能继续：${invalidTables.map((item) => item.table.name).join('、')}`);
+      return undefined;
     }
     if (sinkMappingInvalid) {
       message.warning('目标表名不能为空，也不能包含换行');
-      return;
+      return undefined;
     }
 
     const baseSpec = job.spec || DEFAULT_SPEC;
-    const spec: CdcPipelineSpec = {
+    return {
       ...baseSpec,
       sourceDataSourceRef: sourceId,
       sinkDataSourceRef: sinkId,
@@ -390,7 +368,21 @@ export default function WizardJobEditor({
         strictReplaySafety: true,
       },
     };
+  };
 
+  const switchToYaml = () => {
+    if (!onSwitchMode) return;
+    if (hasUnsupportedRoutes && job.spec) {
+      onSwitchMode('yaml', job.spec);
+      return;
+    }
+    const spec = buildCurrentSpec();
+    if (spec) onSwitchMode('yaml', spec);
+  };
+
+  const save = async () => {
+    const spec = buildCurrentSpec();
+    if (!spec) return;
     setSaving(true);
     try {
       await realtimeApi.update(job.id, {
@@ -412,22 +404,31 @@ export default function WizardJobEditor({
     <ConfigProvider theme={BRAND_THEME} variant="filled">
       <div className="min-h-[calc(100vh-64px)] bg-[#f7f8fa] text-[#161823]">
         <div className="mx-auto w-full max-w-[1180px] px-6 pb-28 pt-6">
-          <header className="mb-5 flex items-start justify-between gap-4 rounded-xl bg-white px-7 py-6">
+          <header className="mb-5 flex flex-wrap items-start justify-between gap-4 rounded-xl bg-white px-7 py-6">
             <div>
-              <div className="mb-1 text-[12px] font-medium text-[var(--yak-brand-color)]">向导模式 · 流程 3</div>
+              <div className="mb-1 text-[12px] font-medium text-[var(--yak-brand-color)]">实时同步编辑器</div>
               <h1 className="m-0 text-[20px] font-semibold text-[#101828]">配置实时同步任务</h1>
               <div className="mt-2 text-[13px] text-[#667085]">
                 {job.name} · 运行环境 #{job.runtimeEnvironmentId}
               </div>
             </div>
-            <div className="rounded-lg bg-[#f9fafb] px-4 py-2 text-[12px] text-[#667085]">
-              选数据源、选表、确认映射和同步方式即可完成配置
+            <div className="flex items-center gap-3">
+              <RealtimeEditorModeSwitch
+                value="wizard"
+                disabled={saving || primaryKeyPending}
+                onChange={(mode) => {
+                  if (mode === 'yaml') switchToYaml();
+                }}
+              />
+              <div className="rounded-lg bg-[#f9fafb] px-4 py-2 text-[12px] text-[#667085]">
+                切换模式不会自动保存
+              </div>
             </div>
           </header>
 
           {hasUnsupportedRoutes && (
             <div className="mb-5 rounded-xl border border-[#fedf89] bg-[#fffaeb] px-5 py-4 text-[13px] text-[#93370d]">
-              当前任务包含正则表规则，向导模式暂不能安全表达这些配置。本页可查看，但不会允许覆盖保存。
+              当前任务包含向导暂不支持的 REGEX 表规则。请切换到 YAML 模式继续编辑，向导不会覆盖这些配置。
             </div>
           )}
 
@@ -476,9 +477,7 @@ export default function WizardJobEditor({
                   <TableOutlined className="text-[var(--yak-brand-color)]" />
                   <h2 className="m-0 text-[16px] font-semibold text-[#101828]">同步表与目标映射</h2>
                 </div>
-                <div className="mt-1 text-[12px] text-[#98a2b3]">
-                  选择 1 张就是单表同步，选择多张就是多表同步；目标表默认同名，可按需修改。
-                </div>
+                <div className="mt-1 text-[12px] text-[#98a2b3]">目标表默认同名，可按需修改。</div>
               </div>
               <div className="flex items-center gap-2">
                 <Tag>{selectedTables.length} 张已选</Tag>
@@ -511,28 +510,19 @@ export default function WizardJobEditor({
                   </div>
                   <div className="max-h-[480px] overflow-y-auto">
                     {tableLoading ? (
-                      <div className="flex min-h-[220px] items-center justify-center">
-                        <Spin tip="正在读取 Source Catalog..." />
-                      </div>
+                      <div className="flex min-h-[220px] items-center justify-center"><Spin /></div>
                     ) : filteredTables.length === 0 ? (
-                      <div className="py-12">
-                        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="没有找到可同步的数据表" />
-                      </div>
+                      <div className="py-12"><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="没有找到可同步的数据表" /></div>
                     ) : (
                       filteredTables.map((table) => (
-                        <label
-                          key={table.name}
-                          className="flex cursor-pointer items-start gap-3 border-b border-[#f2f4f7] px-4 py-3 last:border-b-0 hover:bg-[#fafbfc]"
-                        >
+                        <label key={table.name} className="flex cursor-pointer items-start gap-3 border-b border-[#f2f4f7] px-4 py-3 last:border-b-0 hover:bg-[#fafbfc]">
                           <Checkbox
                             checked={selectedNameSet.has(table.name)}
                             onChange={(event) => handleTableToggle(table, event.target.checked)}
                           />
                           <div className="min-w-0 flex-1">
                             <div className="truncate text-[13px] font-medium text-[#344054]">{table.name}</div>
-                            <div className="mt-0.5 truncate text-[11px] text-[#98a2b3]">
-                              {table.remarks || table.type || 'TABLE'}
-                            </div>
+                            <div className="mt-0.5 truncate text-[11px] text-[#98a2b3]">{table.remarks || table.type || 'TABLE'}</div>
                           </div>
                         </label>
                       ))
@@ -547,53 +537,27 @@ export default function WizardJobEditor({
                   </div>
                   <div className="max-h-[480px] overflow-y-auto">
                     {selectedTables.length === 0 ? (
-                      <div className="py-12">
-                        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="还没有选择数据表" />
-                      </div>
+                      <div className="py-12"><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="还没有选择数据表" /></div>
                     ) : (
                       selectedTables.map((selected) => (
                         <div key={selected.table.name} className="border-b border-[#f2f4f7] px-4 py-4 last:border-b-0">
                           <div className="mb-2 flex items-start justify-between gap-3">
                             <div className="min-w-0">
-                              <div className="truncate text-[13px] font-medium text-[#344054]">
-                                {selected.table.name}
-                              </div>
+                              <div className="truncate text-[13px] font-medium text-[#344054]">{selected.table.name}</div>
                               <div className="mt-1 flex flex-wrap items-center gap-1.5">
-                                {selected.status === 'loading' && (
-                                  <span className="inline-flex items-center gap-1 text-[11px] text-[#667085]">
-                                    <Spin size="small" /> 正在识别主键
-                                  </span>
-                                )}
+                                {selected.status === 'loading' && <span className="text-[11px] text-[#667085]"><Spin size="small" /> 正在识别主键</span>}
                                 {selected.status === 'ready' && (
                                   <>
                                     <CheckCircleOutlined className="text-[#12b76a]" />
-                                    {selected.route.keyColumns.map((column) => (
-                                      <Tag key={column} icon={<KeyOutlined />}>
-                                        {column}
-                                      </Tag>
-                                    ))}
+                                    {selected.route.keyColumns.map((column) => <Tag key={column} icon={<KeyOutlined />}>{column}</Tag>)}
                                   </>
                                 )}
-                                {selected.status === 'missing' && (
-                                  <span className="inline-flex items-center gap-1 text-[11px] text-[#b54708]">
-                                    <WarningOutlined /> 未检测到主键，一期暂不支持保存
-                                  </span>
-                                )}
-                                {selected.status === 'error' && (
-                                  <span className="text-[11px] text-[#b42318]">
-                                    {selected.error || '主键识别失败'}
-                                  </span>
-                                )}
+                                {selected.status === 'missing' && <span className="text-[11px] text-[#b54708]"><WarningOutlined /> 未检测到主键</span>}
+                                {selected.status === 'error' && <span className="text-[11px] text-[#b42318]">{selected.error || '主键识别失败'}</span>}
                               </div>
                             </div>
                             {selected.status === 'error' && sourceId && (
-                              <Button
-                                size="small"
-                                type="link"
-                                onClick={() => void resolvePrimaryKey(selected.table, sourceId)}
-                              >
-                                重试
-                              </Button>
+                              <Button size="small" type="link" onClick={() => void resolvePrimaryKey(selected.table, sourceId)}>重试</Button>
                             )}
                           </div>
                           <div className="grid grid-cols-[minmax(0,1fr)_24px_minmax(0,1fr)] items-center gap-2">
@@ -604,7 +568,13 @@ export default function WizardJobEditor({
                               status={!selected.route.sinkTable.trim() ? 'error' : undefined}
                               placeholder="目标表名，例如 public.orders"
                               onChange={(event) =>
-                                updateSinkTable(selected.table.name, event.target.value)
+                                setSelectedTables((previous) =>
+                                  previous.map((item) =>
+                                    item.table.name === selected.table.name
+                                      ? { ...item, route: { ...item.route, sinkTable: event.target.value } }
+                                      : item,
+                                  ),
+                                )
                               }
                             />
                           </div>
@@ -635,126 +605,43 @@ export default function WizardJobEditor({
                     className={[
                       'relative min-h-[120px] rounded-xl border p-4 text-left transition-all',
                       selected
-                        ? 'border-[var(--yak-brand-color)] bg-[rgba(254,44,85,0.04)] shadow-[0_0_0_2px_rgba(254,44,85,0.06)]'
+                        ? 'border-[var(--yak-brand-color)] bg-[rgba(254,44,85,0.04)]'
                         : 'border-[#e4e7ec] bg-white hover:border-[#fda29b]',
                     ].join(' ')}
                     onClick={() => setStartupMode(mode.value)}
                   >
                     <div className="flex items-center justify-between gap-2">
                       <div className="text-[14px] font-semibold text-[#101828]">{mode.title}</div>
-                      {mode.badge && (
-                        <span className="rounded-full bg-[#fff1f0] px-2 py-0.5 text-[10px] font-medium text-[var(--yak-brand-color)]">
-                          {mode.badge}
-                        </span>
-                      )}
+                      {mode.badge && <Tag>{mode.badge}</Tag>}
                     </div>
                     <div className="mt-2 text-[12px] leading-5 text-[#667085]">{mode.description}</div>
                   </button>
                 );
               })}
-              <div className="relative min-h-[120px] rounded-xl border border-dashed border-[#d0d5dd] bg-[#f9fafb] p-4 opacity-75">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="text-[14px] font-semibold text-[#667085]">仅初始化数据</div>
-                  <Tag>后续</Tag>
-                </div>
-                <div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">
-                  Flink CDC 支持 snapshot，但 Yak 当前需先补齐 FINISHED 正常完成态语义，本流程暂不开放。
-                </div>
+              <div className="min-h-[120px] rounded-xl border border-dashed border-[#d0d5dd] bg-[#f9fafb] p-4 opacity-75">
+                <div className="flex items-center justify-between gap-2"><div className="text-[14px] font-semibold text-[#667085]">仅初始化数据</div><Tag>后续</Tag></div>
+                <div className="mt-2 text-[12px] leading-5 text-[#98a2b3]">需先补齐 FINISHED 正常完成态语义，本期暂不开放。</div>
               </div>
             </div>
           </section>
 
           <section className="rounded-xl bg-white px-7 py-6">
-            <button
-              type="button"
-              className="flex w-full items-center justify-between border-0 bg-transparent p-0 text-left"
-              onClick={() => setAdvancedOpen((value) => !value)}
-            >
+            <button type="button" className="flex w-full items-center justify-between border-0 bg-transparent p-0 text-left" onClick={() => setAdvancedOpen((value) => !value)}>
               <div className="flex items-center gap-2">
                 <SettingOutlined className="text-[var(--yak-brand-color)]" />
-                <div>
-                  <h2 className="m-0 text-[16px] font-semibold text-[#101828]">高级配置</h2>
-                  <div className="mt-1 text-[12px] text-[#98a2b3]">普通场景保持默认值即可。</div>
-                </div>
+                <div><h2 className="m-0 text-[16px] font-semibold text-[#101828]">高级配置</h2><div className="mt-1 text-[12px] text-[#98a2b3]">普通场景保持默认值即可。</div></div>
               </div>
-              {advancedOpen ? <UpOutlined className="text-[#98a2b3]" /> : <DownOutlined className="text-[#98a2b3]" />}
+              {advancedOpen ? <UpOutlined /> : <DownOutlined />}
             </button>
-
             {advancedOpen && (
-              <div className="mt-6 border-t border-[#f0f2f5] pt-6">
-                <div className="grid grid-cols-3 gap-x-5 gap-y-4 max-lg:grid-cols-2 max-md:grid-cols-1">
-                  <div>
-                    <div className="mb-2 text-[12px] font-medium text-[#475467]">Schema Evolution</div>
-                    <Select
-                      className="w-full"
-                      value={advanced.schemaEvolution}
-                      options={[
-                        { value: 'EVOLVE', label: '自动同步结构变更（EVOLVE）' },
-                        { value: 'IGNORE', label: '忽略结构变更（IGNORE）' },
-                        { value: 'FAIL', label: '遇到结构变更失败（FAIL）' },
-                      ]}
-                      onChange={(value) => updateAdvanced('schemaEvolution', value)}
-                    />
-                  </div>
-                  <div>
-                    <div className="mb-2 text-[12px] font-medium text-[#475467]">并行度</div>
-                    <InputNumber
-                      min={1}
-                      max={256}
-                      className="w-full"
-                      value={advanced.parallelism}
-                      onChange={(value) => updateAdvanced('parallelism', Number(value || 1))}
-                    />
-                  </div>
-                  <div>
-                    <div className="mb-2 text-[12px] font-medium text-[#475467]">Sink Batch Size</div>
-                    <InputNumber
-                      min={1}
-                      className="w-full"
-                      value={advanced.batchSize}
-                      onChange={(value) => updateAdvanced('batchSize', Number(value || 1))}
-                    />
-                  </div>
-                  <div>
-                    <div className="mb-2 text-[12px] font-medium text-[#475467]">Flush 间隔（ms）</div>
-                    <InputNumber
-                      min={1}
-                      className="w-full"
-                      value={advanced.flushIntervalMs}
-                      onChange={(value) => updateAdvanced('flushIntervalMs', Number(value || 1))}
-                    />
-                  </div>
-                  <div>
-                    <div className="mb-2 text-[12px] font-medium text-[#475467]">Sink 重试次数</div>
-                    <InputNumber
-                      min={0}
-                      className="w-full"
-                      value={advanced.maxRetries}
-                      onChange={(value) => updateAdvanced('maxRetries', Number(value || 0))}
-                    />
-                  </div>
-                  <div>
-                    <div className="mb-2 text-[12px] font-medium text-[#475467]">最大批次字节</div>
-                    <InputNumber
-                      min={1}
-                      className="w-full"
-                      value={advanced.maxBatchBytes}
-                      onChange={(value) => updateAdvanced('maxBatchBytes', Number(value || 1))}
-                    />
-                  </div>
-                  <div>
-                    <div className="mb-2 text-[12px] font-medium text-[#475467]">Statement Cache</div>
-                    <InputNumber
-                      min={1}
-                      className="w-full"
-                      value={advanced.statementCacheSize}
-                      onChange={(value) => updateAdvanced('statementCacheSize', Number(value || 1))}
-                    />
-                  </div>
-                </div>
-                <div className="mt-5 rounded-lg bg-[#f9fafb] px-4 py-3 text-[11px] leading-5 text-[#667085]">
-                  Checkpoint、重启策略继续使用一期稳定默认值；Strict Replay Safety 固定启用。已有任务进入向导时，会保留未在本页编辑的运行参数。
-                </div>
+              <div className="mt-6 grid grid-cols-3 gap-5 border-t border-[#f0f2f5] pt-6 max-lg:grid-cols-2 max-md:grid-cols-1">
+                <div><div className="mb-2 text-[12px] text-[#475467]">Schema Evolution</div><Select className="w-full" value={advanced.schemaEvolution} options={[{ value: 'EVOLVE', label: 'EVOLVE' }, { value: 'IGNORE', label: 'IGNORE' }, { value: 'FAIL', label: 'FAIL' }]} onChange={(value) => setAdvanced((previous) => ({ ...previous, schemaEvolution: value }))} /></div>
+                <div><div className="mb-2 text-[12px] text-[#475467]">并行度</div><InputNumber min={1} max={256} className="w-full" value={advanced.parallelism} onChange={(value) => setAdvanced((previous) => ({ ...previous, parallelism: Number(value || 1) }))} /></div>
+                <div><div className="mb-2 text-[12px] text-[#475467]">Sink Batch Size</div><InputNumber min={1} className="w-full" value={advanced.batchSize} onChange={(value) => setAdvanced((previous) => ({ ...previous, batchSize: Number(value || 1) }))} /></div>
+                <div><div className="mb-2 text-[12px] text-[#475467]">Flush 间隔（ms）</div><InputNumber min={1} className="w-full" value={advanced.flushIntervalMs} onChange={(value) => setAdvanced((previous) => ({ ...previous, flushIntervalMs: Number(value || 1) }))} /></div>
+                <div><div className="mb-2 text-[12px] text-[#475467]">Sink 重试次数</div><InputNumber min={0} className="w-full" value={advanced.maxRetries} onChange={(value) => setAdvanced((previous) => ({ ...previous, maxRetries: Number(value || 0) }))} /></div>
+                <div><div className="mb-2 text-[12px] text-[#475467]">最大批次字节</div><InputNumber min={1} className="w-full" value={advanced.maxBatchBytes} onChange={(value) => setAdvanced((previous) => ({ ...previous, maxBatchBytes: Number(value || 1) }))} /></div>
+                <div><div className="mb-2 text-[12px] text-[#475467]">Statement Cache</div><InputNumber min={1} className="w-full" value={advanced.statementCacheSize} onChange={(value) => setAdvanced((previous) => ({ ...previous, statementCacheSize: Number(value || 1) }))} /></div>
               </div>
             )}
           </section>
@@ -766,7 +653,7 @@ export default function WizardJobEditor({
               {primaryKeyPending
                 ? '正在读取主键元数据…'
                 : primaryKeyInvalid && selectedTables.length > 0
-                  ? '存在未识别主键的数据表，暂不能保存。'
+                  ? '存在未识别主键的数据表，暂不能保存或切换。'
                   : sinkMappingInvalid && selectedTables.length > 0
                     ? '请完善目标表映射。'
                     : selectedTables.length > 0
@@ -774,18 +661,8 @@ export default function WizardJobEditor({
                       : '请选择 Source、Sink 和至少一张数据表。'}
             </div>
             <div className="flex items-center gap-2">
-              <Button disabled={saving} onClick={onClose}>
-                取消
-              </Button>
-              <Button
-                type="primary"
-                danger
-                loading={saving}
-                disabled={hasUnsupportedRoutes || primaryKeyPending}
-                onClick={() => void save()}
-              >
-                保存向导配置
-              </Button>
+              <Button disabled={saving} onClick={onClose}>取消</Button>
+              <Button type="primary" danger loading={saving} disabled={hasUnsupportedRoutes || primaryKeyPending} onClick={() => void save()}>保存向导配置</Button>
             </div>
           </div>
         </footer>

--- a/yak-ops-ui/src/pages/realtime-sync/YamlJobEditor.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/YamlJobEditor.tsx
@@ -9,6 +9,8 @@ import { Button, ConfigProvider, Input, message, Spin, Tag } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { BRAND_THEME } from '@/styles/brand';
 import { realtimeApi } from './api';
+import RealtimeEditorModeSwitch from './RealtimeEditorModeSwitch';
+import type { RealtimeEditorMode } from './realtimeEditorMode';
 import type { CdcPipelineSpec, RealtimeJob } from './types';
 
 const EMPTY_TEMPLATE = `version: 1
@@ -44,16 +46,19 @@ export default function YamlJobEditor({
   job,
   onClose,
   onSaved,
+  onSwitchMode,
 }: {
   job: RealtimeJob;
   onClose: () => void;
   onSaved: () => void;
+  onSwitchMode?: (mode: RealtimeEditorMode, spec: CdcPipelineSpec) => void;
 }) {
   const [yamlText, setYamlText] = useState('');
   const [initialLoading, setInitialLoading] = useState(true);
   const [parsing, setParsing] = useState(false);
   const [formatting, setFormatting] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [switching, setSwitching] = useState(false);
   const [validatedSpec, setValidatedSpec] = useState<CdcPipelineSpec>();
   const [validationMessage, setValidationMessage] = useState<string>();
 
@@ -134,6 +139,22 @@ export default function YamlJobEditor({
     }
   };
 
+  const switchToWizard = async () => {
+    if (!onSwitchMode) return;
+    setSwitching(true);
+    setValidationMessage(undefined);
+    try {
+      const spec = await parseCurrentYaml();
+      onSwitchMode('wizard', spec);
+    } catch (error: any) {
+      setValidatedSpec(undefined);
+      setValidationMessage(error?.message || '当前 YAML 无法切换到向导模式');
+      message.error(error?.message || '当前 YAML 无法切换到向导模式');
+    } finally {
+      setSwitching(false);
+    }
+  };
+
   const save = async () => {
     setSaving(true);
     setValidationMessage(undefined);
@@ -157,23 +178,38 @@ export default function YamlJobEditor({
     }
   };
 
+  const busy = initialLoading || parsing || formatting || saving || switching;
+
   return (
     <ConfigProvider theme={BRAND_THEME} variant="filled">
       <div className="min-h-[calc(100vh-64px)] bg-[#f7f8fa] px-6 py-6 text-[#161823]">
         <div className="mx-auto w-full max-w-[1180px]">
-          <header className="mb-5 flex items-start justify-between gap-4 rounded-xl bg-white px-7 py-6">
+          <header className="mb-5 flex flex-wrap items-start justify-between gap-4 rounded-xl bg-white px-7 py-6">
             <div>
               <div className="flex items-center gap-2 text-[12px] font-medium text-[var(--yak-brand-color)]">
                 <CodeOutlined />
-                YAML 模式 · Yak Realtime YAML v1
+                实时同步编辑器 · Yak Realtime YAML v1
               </div>
               <h1 className="mb-0 mt-1 text-[20px] font-semibold text-[#101828]">{job.name}</h1>
               <div className="mt-1 text-[12px] text-[#98a2b3]">
                 任务 ID：{job.id} · 运行环境 #{job.runtimeEnvironmentId}
               </div>
             </div>
-            <Button disabled={saving} onClick={onClose}>返回任务列表</Button>
+            <div className="flex items-center gap-3">
+              <RealtimeEditorModeSwitch
+                value="yaml"
+                disabled={busy}
+                onChange={(mode) => {
+                  if (mode === 'wizard') void switchToWizard();
+                }}
+              />
+              <Button disabled={busy} onClick={onClose}>返回任务列表</Button>
+            </div>
           </header>
+
+          <div className="mb-5 rounded-xl border border-[#b2ddff] bg-[#eff8ff] px-5 py-3 text-[12px] leading-5 text-[#175cd3]">
+            模式切换只传递当前 Spec，不会自动保存数据库。YAML → 向导时会先解析当前文本；再次切回 YAML 时会生成规范化 YAML，因此注释和原始排版不会保留，但配置语义保持一致。
+          </div>
 
           <div className="grid grid-cols-[minmax(0,1fr)_300px] gap-5 max-lg:grid-cols-1">
             <section className="overflow-hidden rounded-xl bg-white">
@@ -189,7 +225,7 @@ export default function YamlJobEditor({
                     size="small"
                     icon={<SafetyOutlined />}
                     loading={parsing}
-                    disabled={initialLoading || saving || formatting}
+                    disabled={initialLoading || saving || formatting || switching}
                     onClick={() => void validate()}
                   >
                     校验
@@ -198,7 +234,7 @@ export default function YamlJobEditor({
                     size="small"
                     icon={<FormatPainterOutlined />}
                     loading={formatting}
-                    disabled={initialLoading || saving || parsing}
+                    disabled={initialLoading || saving || parsing || switching}
                     onClick={() => void format()}
                   >
                     格式化
@@ -209,7 +245,7 @@ export default function YamlJobEditor({
                     size="small"
                     icon={<SaveOutlined />}
                     loading={saving}
-                    disabled={initialLoading || parsing || formatting}
+                    disabled={initialLoading || parsing || formatting || switching}
                     onClick={() => void save()}
                   >
                     保存配置
@@ -264,7 +300,7 @@ export default function YamlJobEditor({
               </section>
 
               <section className="rounded-xl border border-[#fedf89] bg-[#fffaeb] p-5 text-[12px] leading-5 text-[#93370d]">
-                这里编辑的是 Yak Realtime YAML，不是原生 Flink CDC Pipeline YAML。最终启动时仍由现有 PipelineYamlCompiler 临时编译，并继续使用 SECRET 注入边界。
+                如果 YAML 包含 REGEX 表规则，向导模式会拒绝切换，避免静默丢失高级配置。这里编辑的仍是 Yak Realtime YAML，不是原生 Flink CDC Pipeline YAML。
               </section>
             </aside>
           </div>

--- a/yak-ops-ui/src/pages/realtime-sync/detail.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/detail.tsx
@@ -1,47 +1,107 @@
 import { history, useParams } from '@umijs/max';
 import { message, Spin } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { realtimeApi } from './api';
-import JobEditor from './JobEditor';
 import RealtimeExecutionPanel from './RealtimeExecutionPanel';
 import WizardJobEditor from './WizardJobEditor';
 import YamlJobEditor from './YamlJobEditor';
-import type { ComputeEnvironmentOption, DataSourceOption, RealtimeJob } from './types';
+import {
+  type RealtimeEditorMode,
+  wizardCompatibility,
+} from './realtimeEditorMode';
+import type { CdcPipelineSpec, DataSourceOption, RealtimeJob } from './types';
+
+const editorFromSearch = (): RealtimeEditorMode | undefined => {
+  const value = new URLSearchParams(history.location.search).get('editor');
+  return value === 'wizard' || value === 'yaml' ? value : undefined;
+};
+
+const replaceEditorQuery = (mode: RealtimeEditorMode) => {
+  const params = new URLSearchParams(history.location.search);
+  params.set('editor', mode);
+  history.replace(`${history.location.pathname}?${params.toString()}`);
+};
 
 export default function RealtimeSyncDetail() {
   const { id } = useParams<{ id: string }>();
   const [job, setJob] = useState<RealtimeJob>();
   const [dataSources, setDataSources] = useState<DataSourceOption[]>([]);
-  const [environments, setEnvironments] = useState<ComputeEnvironmentOption[]>([]);
+  const [editorMode, setEditorMode] = useState<RealtimeEditorMode>();
+  const [draftSpec, setDraftSpec] = useState<CdcPipelineSpec>();
   const [executionReady, setExecutionReady] = useState(false);
 
   useEffect(() => {
-    Promise.all([realtimeApi.detail(Number(id)), realtimeApi.dataSources(), realtimeApi.environments()])
-      .then(([detail, sources, runtimeEnvironments]) => {
-        setJob(detail.data);
+    let cancelled = false;
+    Promise.all([realtimeApi.detail(Number(id)), realtimeApi.dataSources()])
+      .then(([detail, sources]) => {
+        if (cancelled) return;
+        const nextJob = detail.data;
+        const requestedMode = editorFromSearch();
+        const compatibility = wizardCompatibility(nextJob.spec);
+        const resolvedMode: RealtimeEditorMode =
+          requestedMode === 'yaml'
+            ? 'yaml'
+            : requestedMode === 'wizard' && compatibility.supported
+              ? 'wizard'
+              : compatibility.supported
+                ? 'wizard'
+                : 'yaml';
+
+        if (requestedMode === 'wizard' && !compatibility.supported && compatibility.reason) {
+          message.warning(compatibility.reason);
+        }
+
+        setJob(nextJob);
         setDataSources(sources.data || []);
-        setEnvironments(runtimeEnvironments.data || []);
+        setEditorMode(resolvedMode);
+        setDraftSpec(undefined);
+        replaceEditorQuery(resolvedMode);
       })
       .catch((error) => message.error(error?.message || '加载实时同步配置失败'));
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
-  if (!job)
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Spin />
-      </div>
-    );
+  const editorJob = useMemo(() => {
+    if (!job || !draftSpec) return job;
+    return { ...job, spec: draftSpec };
+  }, [draftSpec, job]);
 
   const handleSaved = async () => {
+    if (!job) return;
     try {
       const refreshed = await realtimeApi.detail(job.id);
       setJob(refreshed.data);
+      setDraftSpec(undefined);
       setExecutionReady(true);
     } catch (error: any) {
       message.error(error?.message || '配置已保存，但刷新执行状态失败');
       history.push('/sync/realtime');
     }
   };
+
+  const handleSwitchMode = (nextMode: RealtimeEditorMode, spec: CdcPipelineSpec) => {
+    if (nextMode === 'wizard') {
+      const compatibility = wizardCompatibility(spec);
+      if (!compatibility.supported) {
+        message.warning(compatibility.reason || '当前配置无法切换到向导模式');
+        return;
+      }
+    }
+
+    setDraftSpec(spec);
+    setEditorMode(nextMode);
+    replaceEditorQuery(nextMode);
+  };
+
+  if (!job || !editorJob || !editorMode) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Spin />
+      </div>
+    );
+  }
 
   if (executionReady) {
     return (
@@ -53,35 +113,26 @@ export default function RealtimeSyncDetail() {
     );
   }
 
-  const editorMode = new URLSearchParams(history.location.search).get('editor');
   if (editorMode === 'yaml') {
     return (
       <YamlJobEditor
-        job={job}
+        key={`yaml-${job.id}-${draftSpec ? 'draft' : 'saved'}`}
+        job={editorJob}
         onClose={() => history.push('/sync/realtime')}
         onSaved={() => void handleSaved()}
-      />
-    );
-  }
-  if (editorMode === 'wizard') {
-    return (
-      <WizardJobEditor
-        job={job}
-        dataSources={dataSources}
-        onClose={() => history.push('/sync/realtime')}
-        onSaved={() => void handleSaved()}
+        onSwitchMode={handleSwitchMode}
       />
     );
   }
 
   return (
-    <JobEditor
-      open
-      job={job}
+    <WizardJobEditor
+      key={`wizard-${job.id}-${draftSpec ? 'draft' : 'saved'}`}
+      job={editorJob}
       dataSources={dataSources}
-      environments={environments}
       onClose={() => history.push('/sync/realtime')}
       onSaved={() => void handleSaved()}
+      onSwitchMode={handleSwitchMode}
     />
   );
 }

--- a/yak-ops-ui/src/pages/realtime-sync/realtimeEditorMode.test.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/realtimeEditorMode.test.ts
@@ -1,0 +1,41 @@
+import { wizardCompatibility } from './realtimeEditorMode';
+import type { CdcPipelineSpec } from './types';
+
+const spec = (matchMode: 'EXACT' | 'REGEX'): CdcPipelineSpec => ({
+  sourceDataSourceRef: 1,
+  sinkDataSourceRef: 2,
+  tables: [
+    {
+      sourceTable: matchMode === 'EXACT' ? 'orders' : 'orders_.*',
+      sinkTable: 'orders',
+      matchMode,
+      keyColumns: ['id'],
+    },
+  ],
+  startupMode: 'initial',
+  schemaEvolution: 'EVOLVE',
+  parallelism: 1,
+  checkpointIntervalMs: 60_000,
+  restart: { strategy: 'fixed-delay', attempts: 3, delayMs: 10_000 },
+  sink: {
+    maxRetries: 3,
+    batchSize: 1_000,
+    flushIntervalMs: 2_000,
+    maxBatchBytes: 16_777_216,
+    statementCacheSize: 128,
+    strictReplaySafety: true,
+  },
+});
+
+describe('wizardCompatibility', () => {
+  it('accepts specs fully representable by the wizard', () => {
+    expect(wizardCompatibility(spec('EXACT'))).toEqual({ supported: true });
+  });
+
+  it('rejects regex routes instead of silently losing them', () => {
+    const result = wizardCompatibility(spec('REGEX'));
+    expect(result.supported).toBe(false);
+    expect(result.reason).toContain('REGEX');
+    expect(result.reason).toContain('orders_.*');
+  });
+});

--- a/yak-ops-ui/src/pages/realtime-sync/realtimeEditorMode.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/realtimeEditorMode.ts
@@ -1,0 +1,31 @@
+import type { CdcPipelineSpec } from './types';
+
+export type RealtimeEditorMode = 'wizard' | 'yaml';
+
+export interface WizardCompatibility {
+  supported: boolean;
+  reason?: string;
+}
+
+/**
+ * The wizard is intentionally a safe subset of CdcPipelineSpec. Keep this check centralized so
+ * switching editor modes never drops configuration that the wizard cannot represent.
+ */
+export const wizardCompatibility = (spec?: CdcPipelineSpec): WizardCompatibility => {
+  if (!spec) return { supported: true };
+
+  const unsupportedRoutes = spec.tables.filter((route) => route.matchMode !== 'EXACT');
+  if (unsupportedRoutes.length > 0) {
+    const examples = unsupportedRoutes
+      .slice(0, 3)
+      .map((route) => route.sourceTable)
+      .join('、');
+    const suffix = unsupportedRoutes.length > 3 ? ` 等 ${unsupportedRoutes.length} 条` : '';
+    return {
+      supported: false,
+      reason: `当前配置包含向导模式暂不支持的 REGEX 表规则：${examples}${suffix}。请继续使用 YAML 模式编辑。`,
+    };
+  }
+
+  return { supported: true };
+};


### PR DESCRIPTION
## 背景

这是实时同步第一期的流程 7：完成 Wizard / YAML 双向切换，并保证切换时不会因为组件重新加载而丢失未保存的配置语义。

流程 1～6 已经完成创建入口、Wizard、YAML、统一 Spec、统一校验和统一发布/启动。本 PR 只处理编辑体验，不修改运行时执行链路。

## 核心设计

编辑模式仍然只是 `CdcPipelineSpec` 的两种视图：

```text
Wizard Form
    ↓ build current spec
CdcPipelineSpec ─────────┐
                        ├─> parent draftSpec
Yak YAML                 │
    ↓ parse current yaml │
CdcPipelineSpec ─────────┘
```

切换模式时：

- 不调用 `PUT /{id}`
- 不修改数据库
- 不发布任务
- 不触发 Flink
- 只把当前临时 `CdcPipelineSpec` 提升到详情页 state

真正点击“保存”后才继续走流程 5 / 6 的统一校验、保存和执行链路。

## Wizard → YAML

Wizard 把原本只存在于 `save()` 内部的 Spec 组装逻辑抽成 `buildCurrentSpec()`，保存和切换共同复用。

因此用户修改了：

- Source / Sink
- 已选表
- Sink 表映射
- 主键
- startupMode
- Schema Evolution
- 并行度
- Sink tuning

即使尚未保存，切到 YAML 时也会把当前状态组成临时 Spec，再由现有 `/yaml/render` 生成 YAML。

如果当前 Wizard 配置仍不完整（例如未选择 Sink、主键仍在识别），会阻止切换并给出明确提示，而不是生成一个不可解析的半成品 YAML。

## YAML → Wizard

YAML 切换前先调用现有：

```text
POST /api/v1/realtime-sync/yaml/parse
```

得到当前文本对应的 `CdcPipelineSpec`，再进行 Wizard compatibility 检查。

如果 YAML 包含向导暂不支持的配置，例如：

```yaml
matchMode: REGEX
```

则拒绝切换并提示继续使用 YAML 模式，不会丢掉正则 Route。

## 向导兼容性

新增统一 `wizardCompatibility(spec)`：

- EXACT Route：支持
- REGEX Route：不支持，阻止切换

后续如果 YAML 增加向导暂不支持的高级能力，可以继续在这个单点扩展，不需要散落在各页面判断。

新增 Jest 测试覆盖：

- EXACT Spec 可以进入 Wizard
- REGEX Spec 会被拒绝，并包含具体规则提示

## 默认编辑入口

旧任务点击“编辑”不再必须经过 Legacy JobEditor：

- 普通 EXACT 任务：默认打开 Wizard
- 包含 REGEX 的任务：默认打开 YAML
- URL 显式指定 `editor=wizard`，但 Spec 不兼容：自动回退 YAML 并提示原因

这样流程 7 对已有任务同样生效，不只服务于新建任务。

## URL 与编辑状态

当前编辑模式继续同步到：

```text
?editor=wizard
?editor=yaml
```

但真正未保存内容存放在详情页 `draftSpec` 中，不依赖 URL，也不会写入数据库。

## YAML 文本边界

本 PR 保证的是 **Spec 语义无损**，不是 YAML 源文本无损：

```text
YAML -> Spec -> Wizard -> Spec -> YAML
```

字段语义保持一致，但重新生成 YAML 时会规范化格式，因此：

- YAML 注释不保留
- 原始空行 / 缩进风格不保留
- 字段顺序按 Yak Realtime YAML renderer 输出

这与当前“数据库只保存 Spec、不保存 YAML 源文本”的架构保持一致。

## 与流程 6 的衔接

保存成功后仍进入现有 `RealtimeExecutionPanel`：

```text
编辑 / 切换模式
  ↓
保存统一 Spec
  ↓
运行校验
  ↓
发布
  ↓
启动
```

没有新增 Wizard runtime / YAML runtime。

## 不包含

- 原生 Flink CDC YAML 编辑
- YAML 注释持久化
- REGEX Route 的 Wizard UI
- snapshot / FINISHED 生命周期改造
- 发布 / 启动 / SSH / LOCAL 执行改造
- 数据库迁移

## 验证说明

已做分支 diff 和 TypeScript 静态检查。分支直接基于当前 `main`，当前为纯 ahead、`behind_by=0`。

新增 `realtimeEditorMode.test.ts` 覆盖 Wizard compatibility。当前执行环境未直接运行完整 Yarn/Jest/tsc，因此不声称本地完整构建已经通过，后续以仓库 CI / 本地开发环境结果为准。