### PR TITLE
feat: add immutable realtime definition versions

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeDefinitionVersionMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeDefinitionVersionMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.sync.realtime.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeDefinitionVersionPO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RealtimeDefinitionVersionMapper extends BaseMapper<RealtimeDefinitionVersionPO> {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeDefinitionVersionPO.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeDefinitionVersionPO.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.sync.realtime.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** Immutable published definition persistence record introduced by Stage 6 Wave 1. */
+@Data
+@TableName("yak_realtime_definition_version")
+public class RealtimeDefinitionVersionPO {
+  @TableId(type = IdType.AUTO)
+  private Long id;
+  private Long taskId;
+  private Integer versionNo;
+  private Integer sourceDraftRevision;
+  private Long runtimeEnvironmentId;
+  private String definitionJson;
+  private String definitionDigest;
+  private String sourceConfigDigest;
+  private String domainMappingState;
+  private LocalDateTime createTime;
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDefinitionPO.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDefinitionPO.java
@@ -20,6 +20,7 @@ public class RealtimeJobDefinitionPO {
   private String observedState;
   private Integer definitionVersion;
   private Integer publishedVersion;
+  private Long publishedDefinitionVersionId;
   private String configDigest;
   private String lastError;
   private LocalDateTime createTime;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/CdcPipelineSpecCompatibilityMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/CdcPipelineSpecCompatibilityMapper.java
@@ -1,0 +1,165 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.CheckpointPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ExactTableSelector;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ExecutionPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.FixedDelayRestart;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.NoRestart;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ReplayKey;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SchemaEvolutionPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SinkEndpoint;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SinkWritePolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SourceEndpoint;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SourceSelector;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.StartupPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SyncPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SyncRoute;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.TablePatternSelector;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.TableTarget;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Stage-6 compatibility mapper between the legacy CdcPipelineSpec and the Core SyncDefinition.
+ *
+ * <p>Adapter-private values are returned separately and never inserted into SyncDefinition.
+ */
+@Component
+public class CdcPipelineSpecCompatibilityMapper {
+
+  public MappingResult toDomain(CdcPipelineSpec spec) {
+    if (spec == null) throw new IllegalArgumentException("CdcPipelineSpec 不能为空");
+    if (!spec.sink().strictReplaySafety()) {
+      throw new IllegalArgumentException("Core Domain 不支持 strictReplaySafety=false");
+    }
+
+    List<SyncRoute> routes = spec.tables().stream().map(this::toRoute).toList();
+    SyncDefinition definition =
+        new SyncDefinition(
+            new SourceEndpoint(spec.sourceDataSourceRef()),
+            new SinkEndpoint(spec.sinkDataSourceRef()),
+            routes,
+            new SyncPolicy(startupPolicy(spec.startupMode()), schemaPolicy(spec.schemaEvolution())),
+            new ExecutionPolicy(
+                spec.parallelism(),
+                new CheckpointPolicy(spec.checkpointIntervalMs()),
+                restartPolicy(spec.restart()),
+                new SinkWritePolicy(
+                    spec.sink().maxRetries(),
+                    spec.sink().batchSize(),
+                    spec.sink().flushIntervalMs(),
+                    spec.sink().maxBatchBytes())));
+
+    return new MappingResult(
+        definition, new LegacyAdapterTuning(spec.sink().statementCacheSize()));
+  }
+
+  public CdcPipelineSpec toLegacy(
+      SyncDefinition definition, LegacyAdapterTuning adapterTuning) {
+    if (definition == null) throw new IllegalArgumentException("SyncDefinition 不能为空");
+    LegacyAdapterTuning tuning =
+        adapterTuning == null ? new LegacyAdapterTuning(128) : adapterTuning;
+
+    return new CdcPipelineSpec(
+        definition.source().dataSourceRef(),
+        definition.sink().dataSourceRef(),
+        definition.routes().stream().map(this::toLegacyRoute).toList(),
+        switch (definition.syncPolicy().startupPolicy()) {
+          case INITIAL_AND_CONTINUOUS -> "initial";
+          case CHANGES_ONLY -> "latest-offset";
+        },
+        CdcPipelineSpec.SchemaEvolution.valueOf(
+            definition.syncPolicy().schemaEvolutionPolicy().name()),
+        definition.executionPolicy().parallelism(),
+        definition.executionPolicy().checkpointPolicy().intervalMs(),
+        toLegacyRestart(definition.executionPolicy().restartPolicy()),
+        new CdcPipelineSpec.SinkTuning(
+            definition.executionPolicy().sinkWritePolicy().maxRetries(),
+            definition.executionPolicy().sinkWritePolicy().batchSize(),
+            definition.executionPolicy().sinkWritePolicy().flushIntervalMs(),
+            definition.executionPolicy().sinkWritePolicy().maxBatchBytes(),
+            tuning.statementCacheSize(),
+            true));
+  }
+
+  private SyncRoute toRoute(CdcPipelineSpec.TableRoute route) {
+    SourceSelector selector =
+        switch (route.matchMode()) {
+          case EXACT -> new ExactTableSelector(route.sourceTable());
+          case REGEX -> new TablePatternSelector(route.sourceTable());
+        };
+    return new SyncRoute(
+        selector, new TableTarget(route.sinkTable()), new ReplayKey(route.keyColumns()));
+  }
+
+  private CdcPipelineSpec.TableRoute toLegacyRoute(SyncRoute route) {
+    CdcPipelineSpec.MatchMode mode;
+    String expression;
+    switch (route.source()) {
+      case ExactTableSelector exact -> {
+        mode = CdcPipelineSpec.MatchMode.EXACT;
+        expression = exact.table();
+      }
+      case TablePatternSelector pattern -> {
+        mode = CdcPipelineSpec.MatchMode.REGEX;
+        expression = pattern.pattern();
+      }
+    }
+    TableTarget target = (TableTarget) route.target();
+    return new CdcPipelineSpec.TableRoute(
+        expression, target.table(), mode, route.replayKey().fields());
+  }
+
+  private StartupPolicy startupPolicy(String value) {
+    return switch (value) {
+      case "initial" -> StartupPolicy.INITIAL_AND_CONTINUOUS;
+      case "latest-offset" -> StartupPolicy.CHANGES_ONLY;
+      default -> throw new IllegalArgumentException("不支持的 legacy startupMode：" + value);
+    };
+  }
+
+  private SchemaEvolutionPolicy schemaPolicy(CdcPipelineSpec.SchemaEvolution value) {
+    return SchemaEvolutionPolicy.valueOf(value.name());
+  }
+
+  private SyncDefinition.RestartPolicy restartPolicy(CdcPipelineSpec.RestartPolicy restart) {
+    return switch (restart.strategy()) {
+      case "none" -> new NoRestart();
+      case "fixed-delay" -> new FixedDelayRestart(restart.attempts(), restart.delayMs());
+      case "failure-rate" ->
+          throw new UnsupportedLegacyDefinitionException(
+              "legacy failure-rate restart 缺少完整 failure-rate window 语义，暂不能映射为 Core RestartPolicy");
+      default ->
+          throw new IllegalArgumentException("不支持的 legacy restart strategy：" + restart.strategy());
+    };
+  }
+
+  private CdcPipelineSpec.RestartPolicy toLegacyRestart(
+      SyncDefinition.RestartPolicy restartPolicy) {
+    return switch (restartPolicy) {
+      case NoRestart ignored -> new CdcPipelineSpec.RestartPolicy("none", 0, 0);
+      case FixedDelayRestart fixed ->
+          new CdcPipelineSpec.RestartPolicy(
+              "fixed-delay", fixed.maxAttempts(), fixed.delayMs());
+    };
+  }
+
+  public record MappingResult(
+      SyncDefinition definition, LegacyAdapterTuning legacyAdapterTuning) {}
+
+  /** JDBC-only compatibility value kept outside the Core SyncDefinition. */
+  public record LegacyAdapterTuning(int statementCacheSize) {
+    public LegacyAdapterTuning {
+      if (statementCacheSize < 1) {
+        throw new IllegalArgumentException("statementCacheSize 必须大于 0");
+      }
+    }
+  }
+
+  /** Known legacy shape that is intentionally not promoted into the Core Domain. */
+  public static class UnsupportedLegacyDefinitionException extends IllegalArgumentException {
+    public UnsupportedLegacyDefinitionException(String message) {
+      super(message);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/DefinitionDigest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/DefinitionDigest.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+/** Semantic SHA-256 digest of a canonical SyncDefinition plus RuntimeEnvironmentRef. */
+public record DefinitionDigest(String value) {
+  public DefinitionDigest {
+    if (value == null || !value.matches("[0-9a-f]{64}")) {
+      throw new IllegalArgumentException("DefinitionDigest 必须是 64 位小写 SHA-256");
+    }
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/DefinitionVersion.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/DefinitionVersion.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/** Immutable published realtime synchronization definition. */
+public record DefinitionVersion(
+    long id,
+    long taskId,
+    int versionNo,
+    int sourceDraftRevision,
+    SyncDefinition definition,
+    RuntimeEnvironmentRef runtimeEnvironment,
+    DefinitionDigest definitionDigest,
+    LocalDateTime publishedAt) {
+
+  public DefinitionVersion {
+    if (id <= 0) throw new IllegalArgumentException("DefinitionVersionId 必须大于 0");
+    if (taskId <= 0) throw new IllegalArgumentException("TaskId 必须大于 0");
+    if (versionNo <= 0) throw new IllegalArgumentException("VersionNo 必须大于 0");
+    if (sourceDraftRevision <= 0) {
+      throw new IllegalArgumentException("Source DraftRevision 必须大于 0");
+    }
+    definition = Objects.requireNonNull(definition, "SyncDefinition 不能为空");
+    runtimeEnvironment =
+        Objects.requireNonNull(runtimeEnvironment, "RuntimeEnvironmentRef 不能为空");
+    definitionDigest = Objects.requireNonNull(definitionDigest, "DefinitionDigest 不能为空");
+    publishedAt = Objects.requireNonNull(publishedAt, "publishedAt 不能为空");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RuntimeEnvironmentRef.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RuntimeEnvironmentRef.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+/** Stable reference to the adjacent Compute Environment context. */
+public record RuntimeEnvironmentRef(long id) {
+  public RuntimeEnvironmentRef {
+    if (id <= 0) throw new IllegalArgumentException("RuntimeEnvironmentRef 必须大于 0");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncDefinition.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncDefinition.java
@@ -1,0 +1,171 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Engine-neutral realtime synchronization definition.
+ *
+ * <p>This is the target Core Domain value object introduced by Stage 6 Wave 0. Existing REST/YAML
+ * compatibility continues to use {@link CdcPipelineSpec} until later migration waves.
+ */
+public record SyncDefinition(
+    SourceEndpoint source,
+    SinkEndpoint sink,
+    List<SyncRoute> routes,
+    SyncPolicy syncPolicy,
+    ExecutionPolicy executionPolicy) {
+
+  public SyncDefinition {
+    source = Objects.requireNonNull(source, "SourceEndpoint 不能为空");
+    sink = Objects.requireNonNull(sink, "SinkEndpoint 不能为空");
+    routes = routes == null ? List.of() : List.copyOf(routes);
+    if (routes.isEmpty()) {
+      throw new IllegalArgumentException("SyncDefinition 至少需要一条 SyncRoute");
+    }
+    if (source.dataSourceRef() == sink.dataSourceRef()) {
+      throw new IllegalArgumentException("Source 与 Sink 不能引用同一个数据源");
+    }
+    syncPolicy = Objects.requireNonNull(syncPolicy, "SyncPolicy 不能为空");
+    executionPolicy = Objects.requireNonNull(executionPolicy, "ExecutionPolicy 不能为空");
+  }
+
+  public record SourceEndpoint(long dataSourceRef) {
+    public SourceEndpoint {
+      if (dataSourceRef <= 0) throw new IllegalArgumentException("Source DataSourceRef 必须大于 0");
+    }
+  }
+
+  public record SinkEndpoint(long dataSourceRef) {
+    public SinkEndpoint {
+      if (dataSourceRef <= 0) throw new IllegalArgumentException("Sink DataSourceRef 必须大于 0");
+    }
+  }
+
+  public record SyncRoute(SourceSelector source, SinkTarget target, ReplayKey replayKey) {
+    public SyncRoute {
+      source = Objects.requireNonNull(source, "SourceSelector 不能为空");
+      target = Objects.requireNonNull(target, "SinkTarget 不能为空");
+      replayKey = Objects.requireNonNull(replayKey, "ReplayKey 不能为空");
+    }
+  }
+
+  public sealed interface SourceSelector permits ExactTableSelector, TablePatternSelector {
+    String expression();
+  }
+
+  public record ExactTableSelector(String table) implements SourceSelector {
+    public ExactTableSelector {
+      table = requireText(table, "Exact table");
+    }
+
+    @Override
+    public String expression() {
+      return table;
+    }
+  }
+
+  public record TablePatternSelector(String pattern) implements SourceSelector {
+    public TablePatternSelector {
+      pattern = requireText(pattern, "Table pattern");
+    }
+
+    @Override
+    public String expression() {
+      return pattern;
+    }
+  }
+
+  public sealed interface SinkTarget permits TableTarget {}
+
+  public record TableTarget(String table) implements SinkTarget {
+    public TableTarget {
+      table = requireText(table, "Sink table");
+    }
+  }
+
+  public record ReplayKey(List<String> fields) {
+    public ReplayKey {
+      fields = fields == null ? List.of() : fields.stream().map(String::trim).toList();
+      if (fields.isEmpty() || fields.stream().anyMatch(String::isBlank)) {
+        throw new IllegalArgumentException("ReplayKey 必须包含至少一个非空字段");
+      }
+      Set<String> unique = new HashSet<>(fields);
+      if (unique.size() != fields.size()) {
+        throw new IllegalArgumentException("ReplayKey 字段不能重复");
+      }
+      fields = List.copyOf(fields);
+    }
+  }
+
+  public record SyncPolicy(
+      StartupPolicy startupPolicy, SchemaEvolutionPolicy schemaEvolutionPolicy) {
+    public SyncPolicy {
+      startupPolicy = Objects.requireNonNull(startupPolicy, "StartupPolicy 不能为空");
+      schemaEvolutionPolicy =
+          Objects.requireNonNull(schemaEvolutionPolicy, "SchemaEvolutionPolicy 不能为空");
+    }
+  }
+
+  public enum StartupPolicy {
+    INITIAL_AND_CONTINUOUS,
+    CHANGES_ONLY
+  }
+
+  public enum SchemaEvolutionPolicy {
+    EVOLVE,
+    IGNORE,
+    FAIL
+  }
+
+  public record ExecutionPolicy(
+      int parallelism,
+      CheckpointPolicy checkpointPolicy,
+      RestartPolicy restartPolicy,
+      SinkWritePolicy sinkWritePolicy) {
+    public ExecutionPolicy {
+      if (parallelism < 1) throw new IllegalArgumentException("Parallelism 必须大于 0");
+      checkpointPolicy = Objects.requireNonNull(checkpointPolicy, "CheckpointPolicy 不能为空");
+      restartPolicy = Objects.requireNonNull(restartPolicy, "RestartPolicy 不能为空");
+      sinkWritePolicy = Objects.requireNonNull(sinkWritePolicy, "SinkWritePolicy 不能为空");
+    }
+  }
+
+  public record CheckpointPolicy(long intervalMs) {
+    public CheckpointPolicy {
+      if (intervalMs < 10_000) {
+        throw new IllegalArgumentException("Checkpoint interval 不能小于 10000ms");
+      }
+    }
+  }
+
+  public sealed interface RestartPolicy permits NoRestart, FixedDelayRestart {}
+
+  public record NoRestart() implements RestartPolicy {}
+
+  public record FixedDelayRestart(int maxAttempts, long delayMs) implements RestartPolicy {
+    public FixedDelayRestart {
+      if (maxAttempts < 0 || delayMs < 0) {
+        throw new IllegalArgumentException("FixedDelayRestart 参数不能小于 0");
+      }
+    }
+  }
+
+  public record SinkWritePolicy(
+      int maxRetries, int batchSize, long flushIntervalMs, long maxBatchBytes) {
+    public SinkWritePolicy {
+      if (maxRetries < 0 || batchSize < 1 || flushIntervalMs < 1 || maxBatchBytes < 1) {
+        throw new IllegalArgumentException("SinkWritePolicy 参数无效");
+      }
+    }
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " 不能为空");
+    }
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncDefinitionDigestCalculator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncDefinitionDigestCalculator.java
@@ -1,0 +1,93 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ExactTableSelector;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.FixedDelayRestart;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.NoRestart;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SyncRoute;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.TablePatternSelector;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.TableTarget;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.stream.Collectors;
+
+/** Computes the canonical semantic digest used by immutable DefinitionVersion records. */
+public final class SyncDefinitionDigestCalculator {
+
+  private SyncDefinitionDigestCalculator() {}
+
+  public static DefinitionDigest calculate(
+      SyncDefinition definition, RuntimeEnvironmentRef runtimeEnvironment) {
+    if (definition == null || runtimeEnvironment == null) {
+      throw new IllegalArgumentException("Definition 与 RuntimeEnvironmentRef 不能为空");
+    }
+
+    String canonical = canonical(definition, runtimeEnvironment);
+    try {
+      byte[] digest =
+          MessageDigest.getInstance("SHA-256")
+              .digest(canonical.getBytes(StandardCharsets.UTF_8));
+      return new DefinitionDigest(HexFormat.of().formatHex(digest));
+    } catch (Exception exception) {
+      throw new IllegalStateException("无法计算 DefinitionDigest", exception);
+    }
+  }
+
+  static String canonical(
+      SyncDefinition definition, RuntimeEnvironmentRef runtimeEnvironment) {
+    String routes =
+        definition.routes().stream()
+            .map(SyncDefinitionDigestCalculator::routeKey)
+            .sorted()
+            .collect(Collectors.joining("\n"));
+
+    String restart =
+        switch (definition.executionPolicy().restartPolicy()) {
+          case NoRestart ignored -> "none";
+          case FixedDelayRestart fixed ->
+              "fixed-delay:"
+                  + fixed.maxAttempts()
+                  + ":"
+                  + fixed.delayMs();
+        };
+
+    return String.join(
+        "\n",
+        "source=" + definition.source().dataSourceRef(),
+        "sink=" + definition.sink().dataSourceRef(),
+        "startup=" + definition.syncPolicy().startupPolicy(),
+        "schema=" + definition.syncPolicy().schemaEvolutionPolicy(),
+        "parallelism=" + definition.executionPolicy().parallelism(),
+        "checkpoint=" + definition.executionPolicy().checkpointPolicy().intervalMs(),
+        "restart=" + restart,
+        "sink.maxRetries=" + definition.executionPolicy().sinkWritePolicy().maxRetries(),
+        "sink.batchSize=" + definition.executionPolicy().sinkWritePolicy().batchSize(),
+        "sink.flushIntervalMs=" + definition.executionPolicy().sinkWritePolicy().flushIntervalMs(),
+        "sink.maxBatchBytes=" + definition.executionPolicy().sinkWritePolicy().maxBatchBytes(),
+        "runtimeEnvironment=" + runtimeEnvironment.id(),
+        "routes:",
+        routes);
+  }
+
+  private static String routeKey(SyncRoute route) {
+    String selector =
+        switch (route.source()) {
+          case ExactTableSelector exact -> "exact:" + encoded(exact.table());
+          case TablePatternSelector pattern -> "pattern:" + encoded(pattern.pattern());
+        };
+    String target =
+        switch (route.target()) {
+          case TableTarget table -> "table:" + encoded(table.table());
+        };
+    String replayKey =
+        route.replayKey().fields().stream()
+            .sorted()
+            .map(SyncDefinitionDigestCalculator::encoded)
+            .collect(Collectors.joining("|"));
+    return selector + "->" + target + "#" + replayKey;
+  }
+
+  private static String encoded(String value) {
+    return value.length() + ":" + value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/DefinitionVersionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/DefinitionVersionRepository.java
@@ -1,0 +1,87 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.DefinitionDigest;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * Persistence boundary for immutable published definition versions.
+ *
+ * <p>The compatibility CdcPipelineSpec snapshot is intentionally retained during migration waves so
+ * future Wave 2 can start old versions without reading the mutable Task draft. It is a persistence
+ * representation, not a second Core Domain truth model.
+ */
+public interface DefinitionVersionRepository {
+
+  StoredVersion findOrCreate(PublicationCandidate candidate);
+
+  Optional<PublicationSnapshot> find(long definitionVersionId);
+
+  Optional<Long> publishedDefinitionVersionId(long taskId);
+
+  void bindPublishedReference(
+      long taskId,
+      long definitionVersionId,
+      int expectedDraftRevision,
+      String expectedSourceConfigDigest);
+
+  enum DomainMappingState {
+    MAPPED,
+    LEGACY_UNMAPPED
+  }
+
+  record PublicationCandidate(
+      long taskId,
+      int sourceDraftRevision,
+      long runtimeEnvironmentId,
+      CdcPipelineSpec compatibilityDefinition,
+      String sourceConfigDigest,
+      SyncDefinition domainDefinition,
+      DefinitionDigest definitionDigest,
+      DomainMappingState domainMappingState) {
+
+    public PublicationCandidate {
+      if (taskId <= 0) throw new IllegalArgumentException("TaskId 必须大于 0");
+      if (sourceDraftRevision <= 0) {
+        throw new IllegalArgumentException("Source DraftRevision 必须大于 0");
+      }
+      if (runtimeEnvironmentId <= 0) {
+        throw new IllegalArgumentException("RuntimeEnvironmentId 必须大于 0");
+      }
+      if (compatibilityDefinition == null) {
+        throw new IllegalArgumentException("Published definition snapshot 不能为空");
+      }
+      if (sourceConfigDigest == null || !sourceConfigDigest.matches("[0-9a-f]{64}")) {
+        throw new IllegalArgumentException("Source config digest 无效");
+      }
+      if (domainMappingState == null) {
+        throw new IllegalArgumentException("Domain mapping state 不能为空");
+      }
+      if (domainMappingState == DomainMappingState.MAPPED
+          && (domainDefinition == null || definitionDigest == null)) {
+        throw new IllegalArgumentException("MAPPED version 必须包含 Core Definition 与 DefinitionDigest");
+      }
+      if (domainMappingState == DomainMappingState.LEGACY_UNMAPPED
+          && (domainDefinition != null || definitionDigest != null)) {
+        throw new IllegalArgumentException("LEGACY_UNMAPPED version 不应伪造 Core Definition");
+      }
+    }
+  }
+
+  record StoredVersion(
+      long id,
+      long taskId,
+      int versionNo,
+      int sourceDraftRevision,
+      String definitionDigest,
+      String sourceConfigDigest,
+      DomainMappingState domainMappingState,
+      LocalDateTime createTime) {}
+
+  record PublicationSnapshot(
+      StoredVersion version,
+      long runtimeEnvironmentId,
+      CdcPipelineSpec compatibilityDefinition) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/DefinitionVersionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/DefinitionVersionRepositoryAdapter.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeDefinitionVersionMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDefinitionMapper;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeDefinitionVersionPO;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO;
+import io.yak.ops.business.sync.realtime.repository.support.RealtimeJsonCodec;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis persistence adapter for immutable published definition versions. */
+@Repository
+@DependsOn("realtimeSyncFlyway")
+public class DefinitionVersionRepositoryAdapter implements DefinitionVersionRepository {
+
+  private final RealtimeDefinitionVersionMapper versionMapper;
+  private final RealtimeJobDefinitionMapper definitionMapper;
+  private final RealtimeJsonCodec json;
+
+  public DefinitionVersionRepositoryAdapter(
+      RealtimeDefinitionVersionMapper versionMapper,
+      RealtimeJobDefinitionMapper definitionMapper,
+      RealtimeJsonCodec json) {
+    this.versionMapper = versionMapper;
+    this.definitionMapper = definitionMapper;
+    this.json = json;
+  }
+
+  @Override
+  public StoredVersion findOrCreate(PublicationCandidate candidate) {
+    RealtimeDefinitionVersionPO existing =
+        findBySourceConfigDigest(candidate.taskId(), candidate.sourceConfigDigest()).orElse(null);
+    if (existing != null) return stored(existing);
+
+    RealtimeDefinitionVersionPO po = new RealtimeDefinitionVersionPO();
+    po.setTaskId(candidate.taskId());
+    po.setVersionNo(nextVersionNo(candidate.taskId()));
+    po.setSourceDraftRevision(candidate.sourceDraftRevision());
+    po.setRuntimeEnvironmentId(candidate.runtimeEnvironmentId());
+    po.setDefinitionJson(json.write(candidate.compatibilityDefinition()));
+    po.setDefinitionDigest(
+        candidate.definitionDigest() == null ? null : candidate.definitionDigest().value());
+    po.setSourceConfigDigest(candidate.sourceConfigDigest());
+    po.setDomainMappingState(candidate.domainMappingState().name());
+    po.setCreateTime(LocalDateTime.now());
+
+    try {
+      versionMapper.insert(po);
+    } catch (DuplicateKeyException exception) {
+      return stored(
+          findBySourceConfigDigest(candidate.taskId(), candidate.sourceConfigDigest())
+              .orElseThrow(() -> new IllegalStateException("DefinitionVersion 幂等冲突后记录不存在", exception)));
+    }
+    if (po.getId() == null) {
+      throw new IllegalStateException("新增 DefinitionVersion 未返回主键");
+    }
+    return stored(po);
+  }
+
+  @Override
+  public Optional<PublicationSnapshot> find(long definitionVersionId) {
+    RealtimeDefinitionVersionPO po = versionMapper.selectById(definitionVersionId);
+    if (po == null) return Optional.empty();
+    return Optional.of(
+        new PublicationSnapshot(
+            stored(po), po.getRuntimeEnvironmentId(), json.readSpec(po.getDefinitionJson())));
+  }
+
+  @Override
+  public Optional<Long> publishedDefinitionVersionId(long taskId) {
+    return Optional.ofNullable(definitionMapper.selectById(taskId))
+        .map(RealtimeJobDefinitionPO::getPublishedDefinitionVersionId);
+  }
+
+  @Override
+  public void bindPublishedReference(
+      long taskId,
+      long definitionVersionId,
+      int expectedDraftRevision,
+      String expectedSourceConfigDigest) {
+    int updated =
+        definitionMapper.update(
+            null,
+            Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
+                .eq(RealtimeJobDefinitionPO::getId, taskId)
+                .eq(RealtimeJobDefinitionPO::getDefinitionVersion, expectedDraftRevision)
+                .eq(RealtimeJobDefinitionPO::getPublishedVersion, expectedDraftRevision)
+                .eq(RealtimeJobDefinitionPO::getConfigDigest, expectedSourceConfigDigest)
+                .set(
+                    RealtimeJobDefinitionPO::getPublishedDefinitionVersionId,
+                    definitionVersionId));
+    if (updated != 1) {
+      throw new IllegalStateException("绑定 Published DefinitionVersion 时 Task 已变化");
+    }
+  }
+
+  private Optional<RealtimeDefinitionVersionPO> findBySourceConfigDigest(
+      long taskId, String sourceConfigDigest) {
+    return versionMapper
+        .selectList(
+            Wrappers.<RealtimeDefinitionVersionPO>lambdaQuery()
+                .eq(RealtimeDefinitionVersionPO::getTaskId, taskId)
+                .eq(RealtimeDefinitionVersionPO::getSourceConfigDigest, sourceConfigDigest)
+                .last("LIMIT 1"))
+        .stream()
+        .findFirst();
+  }
+
+  private int nextVersionNo(long taskId) {
+    return versionMapper
+            .selectList(
+                Wrappers.<RealtimeDefinitionVersionPO>lambdaQuery()
+                    .eq(RealtimeDefinitionVersionPO::getTaskId, taskId)
+                    .orderByDesc(RealtimeDefinitionVersionPO::getVersionNo)
+                    .last("LIMIT 1"))
+            .stream()
+            .findFirst()
+            .map(RealtimeDefinitionVersionPO::getVersionNo)
+            .orElse(0)
+        + 1;
+  }
+
+  private StoredVersion stored(RealtimeDefinitionVersionPO po) {
+    return new StoredVersion(
+        po.getId(),
+        po.getTaskId(),
+        po.getVersionNo(),
+        po.getSourceDraftRevision(),
+        po.getDefinitionDigest(),
+        po.getSourceConfigDigest(),
+        DomainMappingState.valueOf(po.getDomainMappingState()),
+        po.getCreateTime());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
@@ -1,0 +1,266 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper.MappingResult;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper.UnsupportedLegacyDefinitionException;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.DefinitionDigest;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobEventView;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
+import io.yak.ops.business.sync.realtime.domain.RuntimeEnvironmentRef;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinitionDigestCalculator;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.DomainMappingState;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationCandidate;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.StoredVersion;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Stage-6 compatibility decorator that adds immutable DefinitionVersion persistence without
+ * rewriting the existing RealtimeJobService lifecycle path.
+ */
+@Primary
+@Repository
+public class VersioningRealtimeJobStore implements RealtimeJobStore {
+
+  private final RealtimeJobStoreAdapter delegate;
+  private final DefinitionVersionRepository definitionVersions;
+  private final CdcPipelineSpecCompatibilityMapper compatibilityMapper;
+
+  public VersioningRealtimeJobStore(
+      RealtimeJobStoreAdapter delegate,
+      DefinitionVersionRepository definitionVersions,
+      CdcPipelineSpecCompatibilityMapper compatibilityMapper) {
+    this.delegate = delegate;
+    this.definitionVersions = definitionVersions;
+    this.compatibilityMapper = compatibilityMapper;
+  }
+
+  /**
+   * Publish remains guarded by the legacy Task-row CAS in Wave 1. The new immutable version and the
+   * legacy publish marker are written in the same business transaction.
+   */
+  @Override
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void publish(long id, int expectedDefinitionVersion, String expectedDigest) {
+    DefinitionRow current = delegate.lockDefinition(id);
+    if (current.definitionVersion() != expectedDefinitionVersion
+        || !Objects.equals(current.configDigest(), expectedDigest)) {
+      throw new IllegalStateException("任务状态或定义版本已变化，请刷新后重新校验并发布");
+    }
+    if (current.spec() == null) {
+      throw new IllegalStateException("实时同步任务没有可发布的 Draft Definition");
+    }
+
+    PublicationCandidate candidate = publicationCandidate(current, expectedDigest);
+
+    // Keep the existing STOPPED/FAILED CAS and legacy release projection unchanged in Wave 1.
+    delegate.publish(id, expectedDefinitionVersion, expectedDigest);
+
+    StoredVersion version = definitionVersions.findOrCreate(candidate);
+    definitionVersions.bindPublishedReference(
+        id, version.id(), expectedDefinitionVersion, expectedDigest);
+  }
+
+  private PublicationCandidate publicationCandidate(
+      DefinitionRow current, String sourceConfigDigest) {
+    try {
+      MappingResult mapped = compatibilityMapper.toDomain(current.spec());
+      SyncDefinition definition = mapped.definition();
+      DefinitionDigest digest =
+          SyncDefinitionDigestCalculator.calculate(
+              definition, new RuntimeEnvironmentRef(current.runtimeEnvironmentId()));
+      return new PublicationCandidate(
+          current.id(),
+          current.definitionVersion(),
+          current.runtimeEnvironmentId(),
+          current.spec(),
+          sourceConfigDigest,
+          definition,
+          digest,
+          DomainMappingState.MAPPED);
+    } catch (UnsupportedLegacyDefinitionException exception) {
+      // Preserve existing behavior: the immutable compatibility snapshot is still published, but we
+      // refuse to pretend an incomplete legacy policy is a valid Core Domain value object.
+      return new PublicationCandidate(
+          current.id(),
+          current.definitionVersion(),
+          current.runtimeEnvironmentId(),
+          current.spec(),
+          sourceConfigDigest,
+          null,
+          null,
+          DomainMappingState.LEGACY_UNMAPPED);
+    }
+  }
+
+  @Override
+  public long insertDefinition(
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      String digest,
+      long runtimeEnvironmentId) {
+    return delegate.insertDefinition(name, description, spec, digest, runtimeEnvironmentId);
+  }
+
+  @Override
+  public void updateDefinition(
+      long id,
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      String digest,
+      long runtimeEnvironmentId) {
+    delegate.updateDefinition(id, name, description, spec, digest, runtimeEnvironmentId);
+  }
+
+  @Override
+  public Optional<DefinitionRow> definition(long id) {
+    return delegate.definition(id);
+  }
+
+  @Override
+  public DefinitionRow lockDefinition(long id) {
+    return delegate.lockDefinition(id);
+  }
+
+  @Override
+  public RealtimeJobPage page(int pageNo, int pageSize, String keyword) {
+    return delegate.page(pageNo, pageSize, keyword);
+  }
+
+  @Override
+  public Optional<DeploymentRow> deploymentByIdempotencyKey(String key) {
+    return delegate.deploymentByIdempotencyKey(key);
+  }
+
+  @Override
+  public Optional<DeploymentRow> latestDeployment(long definitionId) {
+    return delegate.latestDeployment(definitionId);
+  }
+
+  @Override
+  public Optional<ComputeEnvironmentSnapshot> deploymentEnvironment(long deploymentId) {
+    return delegate.deploymentEnvironment(deploymentId);
+  }
+
+  @Override
+  public long insertDeployment(
+      DefinitionRow definition,
+      CdcPipelineSpec spec,
+      String summary,
+      String digest,
+      ComputeEnvironmentSnapshot environment,
+      String idempotencyKey) {
+    return delegate.insertDeployment(
+        definition, spec, summary, digest, environment, idempotencyKey);
+  }
+
+  @Override
+  public void markStarting(long definitionId) {
+    delegate.markStarting(definitionId);
+  }
+
+  @Override
+  public void markDeploymentRunning(
+      long definitionId,
+      long deploymentId,
+      String engineJobId,
+      String runtimeRevision) {
+    delegate.markDeploymentRunning(
+        definitionId, deploymentId, engineJobId, runtimeRevision);
+  }
+
+  @Override
+  public void bindDeploymentForStop(
+      long deploymentId, String engineJobId, String runtimeRevision) {
+    delegate.bindDeploymentForStop(deploymentId, engineJobId, runtimeRevision);
+  }
+
+  @Override
+  public void markDeployFailure(
+      long definitionId,
+      long deploymentId,
+      boolean uncertain,
+      boolean stopRequested,
+      String message) {
+    delegate.markDeployFailure(
+        definitionId, deploymentId, uncertain, stopRequested, message);
+  }
+
+  @Override
+  public void markStopping(long definitionId, Long deploymentId) {
+    delegate.markStopping(definitionId, deploymentId);
+  }
+
+  @Override
+  public void reconcile(
+      long definitionId,
+      Long deploymentId,
+      String observedState,
+      String deploymentState,
+      String engineJobId,
+      String error) {
+    delegate.reconcile(
+        definitionId, deploymentId, observedState, deploymentState, engineJobId, error);
+  }
+
+  @Override
+  public void markTerminalFailure(long definitionId, Long deploymentId, String message) {
+    delegate.markTerminalFailure(definitionId, deploymentId, message);
+  }
+
+  @Override
+  public List<DefinitionRow> desiredJobs() {
+    return delegate.desiredJobs();
+  }
+
+  @Override
+  public boolean hasOtherDesiredRunning(long id) {
+    return delegate.hasOtherDesiredRunning(id);
+  }
+
+  @Override
+  public void delete(long id) {
+    delegate.delete(id);
+  }
+
+  @Override
+  public void event(
+      long definitionId,
+      Long deploymentId,
+      String type,
+      String from,
+      String to,
+      String message) {
+    delegate.event(definitionId, deploymentId, type, from, to, message);
+  }
+
+  @Override
+  public boolean tryAcquireReconcileLease(String owner, int leaseSeconds) {
+    return delegate.tryAcquireReconcileLease(owner, leaseSeconds);
+  }
+
+  @Override
+  public List<RealtimeJobEventView> events(long definitionId) {
+    return delegate.events(definitionId);
+  }
+
+  @Override
+  public RealtimeJobView view(long id) {
+    return delegate.view(id);
+  }
+
+  @Override
+  public RealtimeJobView.Deployment deploymentView(DeploymentRow deployment) {
+    return delegate.deploymentView(deployment);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
@@ -1,5 +1,5 @@
 -- Consolidated Realtime Sync schema baseline.
--- Runtime/definition/deployment/event references are logical and enforced by application services.
+-- Runtime/definition/version/deployment/event references are logical and enforced by application services.
 CREATE TABLE IF NOT EXISTS yak_compute_environment (
     id BIGINT NOT NULL AUTO_INCREMENT,
     name VARCHAR(120) NOT NULL,
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS yak_realtime_job_definition (
     observed_state VARCHAR(32) NOT NULL DEFAULT 'STOPPED',
     definition_version INT NOT NULL DEFAULT 1,
     published_version INT NULL,
+    published_definition_version_id BIGINT NULL,
     config_digest CHAR(64) NULL,
     last_error TEXT NULL,
     create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
@@ -38,7 +39,26 @@ CREATE TABLE IF NOT EXISTS yak_realtime_job_definition (
     PRIMARY KEY (id),
     UNIQUE KEY uk_realtime_name (job_name),
     KEY idx_realtime_states (desired_state, observed_state),
-    KEY idx_realtime_definition_environment (runtime_environment_id)
+    KEY idx_realtime_definition_environment (runtime_environment_id),
+    KEY idx_realtime_published_definition_version (published_definition_version_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS yak_realtime_definition_version (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    task_id BIGINT NOT NULL,
+    version_no INT NOT NULL,
+    source_draft_revision INT NOT NULL,
+    runtime_environment_id BIGINT NOT NULL,
+    definition_json LONGTEXT NOT NULL,
+    definition_digest CHAR(64) NULL,
+    source_config_digest CHAR(64) NOT NULL,
+    domain_mapping_state VARCHAR(32) NOT NULL,
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_realtime_definition_version_no (task_id, version_no),
+    UNIQUE KEY uk_realtime_definition_source_digest (task_id, source_config_digest),
+    KEY idx_realtime_definition_version_task_revision (task_id, source_draft_revision),
+    KEY idx_realtime_definition_version_environment (runtime_environment_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS yak_realtime_job_deployment (

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/CdcPipelineSpecCompatibilityMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/CdcPipelineSpecCompatibilityMapperTest.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper.MappingResult;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper.UnsupportedLegacyDefinitionException;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ExactTableSelector;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.FixedDelayRestart;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CdcPipelineSpecCompatibilityMapperTest {
+
+  private final CdcPipelineSpecCompatibilityMapper mapper =
+      new CdcPipelineSpecCompatibilityMapper();
+
+  @Test
+  void mapsLegacySpecToCoreDefinitionAndBackWithoutLeakingAdapterTuning() {
+    CdcPipelineSpec legacy = spec(new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000), 256);
+
+    MappingResult mapped = mapper.toDomain(legacy);
+
+    assertThat(mapped.definition().source().dataSourceRef()).isEqualTo(11);
+    assertThat(mapped.definition().sink().dataSourceRef()).isEqualTo(22);
+    assertThat(mapped.definition().routes()).hasSize(1);
+    assertThat(mapped.definition().routes().getFirst().source())
+        .isInstanceOf(ExactTableSelector.class);
+    assertThat(mapped.definition().executionPolicy().restartPolicy())
+        .isEqualTo(new FixedDelayRestart(3, 10_000));
+    assertThat(mapped.legacyAdapterTuning().statementCacheSize()).isEqualTo(256);
+
+    CdcPipelineSpec roundTrip =
+        mapper.toLegacy(mapped.definition(), mapped.legacyAdapterTuning());
+    assertThat(roundTrip).isEqualTo(legacy);
+  }
+
+  @Test
+  void incompleteLegacyFailureRatePolicyIsNotPretendedToBeCoreDomain() {
+    CdcPipelineSpec legacy =
+        spec(new CdcPipelineSpec.RestartPolicy("failure-rate", 3, 10_000), 128);
+
+    assertThatThrownBy(() -> mapper.toDomain(legacy))
+        .isInstanceOf(UnsupportedLegacyDefinitionException.class)
+        .hasMessageContaining("failure-rate");
+  }
+
+  private CdcPipelineSpec spec(CdcPipelineSpec.RestartPolicy restart, int statementCacheSize) {
+    return new CdcPipelineSpec(
+        11L,
+        22L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                "orders", "ods_orders", CdcPipelineSpec.MatchMode.EXACT, List.of("tenant_id", "id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        2,
+        60_000,
+        restart,
+        new CdcPipelineSpec.SinkTuning(
+            3, 1_000, 2_000, 16_777_216, statementCacheSize, true));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/SyncDefinitionDigestCalculatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/SyncDefinitionDigestCalculatorTest.java
@@ -1,0 +1,76 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper.MappingResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SyncDefinitionDigestCalculatorTest {
+
+  private final CdcPipelineSpecCompatibilityMapper mapper =
+      new CdcPipelineSpecCompatibilityMapper();
+
+  @Test
+  void digestIgnoresRouteAndReplayKeyOrdering() {
+    CdcPipelineSpec left =
+        spec(
+            List.of(
+                route("orders", "ods_orders", List.of("tenant_id", "id")),
+                route("customers", "ods_customers", List.of("id"))),
+            128);
+    CdcPipelineSpec right =
+        spec(
+            List.of(
+                route("customers", "ods_customers", List.of("id")),
+                route("orders", "ods_orders", List.of("id", "tenant_id"))),
+            128);
+
+    DefinitionDigest leftDigest = digest(left, 7);
+    DefinitionDigest rightDigest = digest(right, 7);
+
+    assertThat(rightDigest).isEqualTo(leftDigest);
+  }
+
+  @Test
+  void adapterPrivateStatementCacheDoesNotChangeCoreDefinitionDigest() {
+    CdcPipelineSpec left = spec(List.of(route("orders", "ods_orders", List.of("id"))), 64);
+    CdcPipelineSpec right = spec(List.of(route("orders", "ods_orders", List.of("id"))), 512);
+
+    assertThat(digest(right, 7)).isEqualTo(digest(left, 7));
+    assertThat(mapper.toDomain(right).definition()).isEqualTo(mapper.toDomain(left).definition());
+  }
+
+  @Test
+  void runtimeEnvironmentBindingChangesDefinitionDigest() {
+    CdcPipelineSpec spec = spec(List.of(route("orders", "ods_orders", List.of("id"))), 128);
+
+    assertThat(digest(spec, 8)).isNotEqualTo(digest(spec, 7));
+  }
+
+  private DefinitionDigest digest(CdcPipelineSpec spec, long environmentId) {
+    MappingResult mapped = mapper.toDomain(spec);
+    return SyncDefinitionDigestCalculator.calculate(
+        mapped.definition(), new RuntimeEnvironmentRef(environmentId));
+  }
+
+  private CdcPipelineSpec spec(List<CdcPipelineSpec.TableRoute> routes, int statementCacheSize) {
+    return new CdcPipelineSpec(
+        11L,
+        22L,
+        routes,
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        2,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(
+            3, 1_000, 2_000, 16_777_216, statementCacheSize, true));
+  }
+
+  private CdcPipelineSpec.TableRoute route(
+      String source, String sink, List<String> replayKey) {
+    return new CdcPipelineSpec.TableRoute(
+        source, sink, CdcPipelineSpec.MatchMode.EXACT, replayKey);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/DefinitionVersionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/DefinitionVersionRepositoryAdapterTest.java
@@ -1,0 +1,119 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeDefinitionVersionMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDefinitionMapper;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeDefinitionVersionPO;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper;
+import io.yak.ops.business.sync.realtime.domain.DefinitionDigest;
+import io.yak.ops.business.sync.realtime.domain.RuntimeEnvironmentRef;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinitionDigestCalculator;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.DomainMappingState;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationCandidate;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.StoredVersion;
+import io.yak.ops.business.sync.realtime.repository.support.RealtimeJsonCodec;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DefinitionVersionRepositoryAdapterTest {
+
+  private static final long TASK_ID = 9L;
+  private static final String SOURCE_DIGEST = "c".repeat(64);
+
+  @Test
+  void samePublishedContentReusesExistingImmutableVersion() {
+    RealtimeDefinitionVersionMapper versionMapper = mock(RealtimeDefinitionVersionMapper.class);
+    RealtimeJobDefinitionMapper definitionMapper = mock(RealtimeJobDefinitionMapper.class);
+    RealtimeJsonCodec json = mock(RealtimeJsonCodec.class);
+    DefinitionVersionRepositoryAdapter repository =
+        new DefinitionVersionRepositoryAdapter(versionMapper, definitionMapper, json);
+    RealtimeDefinitionVersionPO existing = storedPo(41L, 2, SOURCE_DIGEST);
+    when(versionMapper.selectList(any())).thenReturn(List.of(existing));
+
+    StoredVersion result = repository.findOrCreate(candidate());
+
+    assertThat(result.id()).isEqualTo(41L);
+    assertThat(result.versionNo()).isEqualTo(2);
+    verify(versionMapper, never()).insert(any());
+  }
+
+  @Test
+  void changedPublishedContentAllocatesNextMonotonicVersionNumber() {
+    RealtimeDefinitionVersionMapper versionMapper = mock(RealtimeDefinitionVersionMapper.class);
+    RealtimeJobDefinitionMapper definitionMapper = mock(RealtimeJobDefinitionMapper.class);
+    RealtimeJsonCodec json = mock(RealtimeJsonCodec.class);
+    DefinitionVersionRepositoryAdapter repository =
+        new DefinitionVersionRepositoryAdapter(versionMapper, definitionMapper, json);
+    RealtimeDefinitionVersionPO previous = storedPo(40L, 2, "d".repeat(64));
+    when(versionMapper.selectList(any())).thenReturn(List.of(), List.of(previous));
+    when(json.write(any())).thenReturn("{}");
+    when(versionMapper.insert(any()))
+        .thenAnswer(
+            invocation -> {
+              RealtimeDefinitionVersionPO inserted = invocation.getArgument(0);
+              inserted.setId(42L);
+              return 1;
+            });
+
+    StoredVersion result = repository.findOrCreate(candidate());
+
+    assertThat(result.id()).isEqualTo(42L);
+    assertThat(result.versionNo()).isEqualTo(3);
+    assertThat(result.sourceConfigDigest()).isEqualTo(SOURCE_DIGEST);
+  }
+
+  private PublicationCandidate candidate() {
+    CdcPipelineSpec spec = spec();
+    SyncDefinition definition = new CdcPipelineSpecCompatibilityMapper().toDomain(spec).definition();
+    DefinitionDigest digest =
+        SyncDefinitionDigestCalculator.calculate(definition, new RuntimeEnvironmentRef(3L));
+    return new PublicationCandidate(
+        TASK_ID,
+        5,
+        3L,
+        spec,
+        SOURCE_DIGEST,
+        definition,
+        digest,
+        DomainMappingState.MAPPED);
+  }
+
+  private RealtimeDefinitionVersionPO storedPo(long id, int versionNo, String sourceDigest) {
+    RealtimeDefinitionVersionPO po = new RealtimeDefinitionVersionPO();
+    po.setId(id);
+    po.setTaskId(TASK_ID);
+    po.setVersionNo(versionNo);
+    po.setSourceDraftRevision(4);
+    po.setRuntimeEnvironmentId(3L);
+    po.setDefinitionJson("{}");
+    po.setDefinitionDigest("e".repeat(64));
+    po.setSourceConfigDigest(sourceDigest);
+    po.setDomainMappingState(DomainMappingState.MAPPED.name());
+    po.setCreateTime(LocalDateTime.now());
+    return po;
+  }
+
+  private CdcPipelineSpec spec() {
+    return new CdcPipelineSpec(
+        11L,
+        22L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                "orders", "ods_orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
@@ -1,0 +1,132 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.DomainMappingState;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationCandidate;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.StoredVersion;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class VersioningRealtimeJobStoreTest {
+
+  private static final long TASK_ID = 7L;
+  private static final String SOURCE_DIGEST = "a".repeat(64);
+
+  @Test
+  void publishCreatesMappedImmutableVersionAndBindsReference() {
+    RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
+    DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
+    VersioningRealtimeJobStore store =
+        new VersioningRealtimeJobStore(
+            delegate, versions, new CdcPipelineSpecCompatibilityMapper());
+    DefinitionRow current = definitionRow(spec("fixed-delay"));
+    StoredVersion stored =
+        new StoredVersion(
+            101L,
+            TASK_ID,
+            1,
+            current.definitionVersion(),
+            "b".repeat(64),
+            SOURCE_DIGEST,
+            DomainMappingState.MAPPED,
+            LocalDateTime.now());
+    when(delegate.lockDefinition(TASK_ID)).thenReturn(current);
+    when(versions.findOrCreate(any())).thenReturn(stored);
+
+    store.publish(TASK_ID, current.definitionVersion(), SOURCE_DIGEST);
+
+    ArgumentCaptor<PublicationCandidate> candidate =
+        ArgumentCaptor.forClass(PublicationCandidate.class);
+    verify(delegate).publish(TASK_ID, current.definitionVersion(), SOURCE_DIGEST);
+    verify(versions).findOrCreate(candidate.capture());
+    verify(versions)
+        .bindPublishedReference(
+            TASK_ID, stored.id(), current.definitionVersion(), SOURCE_DIGEST);
+
+    assertThat(candidate.getValue().domainMappingState()).isEqualTo(DomainMappingState.MAPPED);
+    assertThat(candidate.getValue().domainDefinition()).isNotNull();
+    assertThat(candidate.getValue().definitionDigest()).isNotNull();
+    assertThat(candidate.getValue().sourceConfigDigest()).isEqualTo(SOURCE_DIGEST);
+    assertThat(candidate.getValue().compatibilityDefinition()).isEqualTo(current.spec());
+  }
+
+  @Test
+  void legacyFailureRateStillPublishesButIsMarkedUnmapped() {
+    RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
+    DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
+    VersioningRealtimeJobStore store =
+        new VersioningRealtimeJobStore(
+            delegate, versions, new CdcPipelineSpecCompatibilityMapper());
+    DefinitionRow current = definitionRow(spec("failure-rate"));
+    StoredVersion stored =
+        new StoredVersion(
+            102L,
+            TASK_ID,
+            1,
+            current.definitionVersion(),
+            null,
+            SOURCE_DIGEST,
+            DomainMappingState.LEGACY_UNMAPPED,
+            LocalDateTime.now());
+    when(delegate.lockDefinition(TASK_ID)).thenReturn(current);
+    when(versions.findOrCreate(any())).thenReturn(stored);
+
+    store.publish(TASK_ID, current.definitionVersion(), SOURCE_DIGEST);
+
+    ArgumentCaptor<PublicationCandidate> candidate =
+        ArgumentCaptor.forClass(PublicationCandidate.class);
+    verify(delegate).publish(TASK_ID, current.definitionVersion(), SOURCE_DIGEST);
+    verify(versions).findOrCreate(candidate.capture());
+    verify(versions)
+        .bindPublishedReference(
+            TASK_ID, stored.id(), current.definitionVersion(), SOURCE_DIGEST);
+
+    assertThat(candidate.getValue().domainMappingState())
+        .isEqualTo(DomainMappingState.LEGACY_UNMAPPED);
+    assertThat(candidate.getValue().domainDefinition()).isNull();
+    assertThat(candidate.getValue().definitionDigest()).isNull();
+  }
+
+  private DefinitionRow definitionRow(CdcPipelineSpec spec) {
+    return new DefinitionRow(
+        TASK_ID,
+        "orders-sync",
+        "test",
+        spec,
+        3L,
+        "DRAFT",
+        "STOPPED",
+        "STOPPED",
+        4,
+        3,
+        SOURCE_DIGEST,
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private CdcPipelineSpec spec(String restartStrategy) {
+    return new CdcPipelineSpec(
+        11L,
+        22L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                "orders", "ods_orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy(restartStrategy, 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}


### PR DESCRIPTION
## 背景

Realtime Sync Domain 阶段 1～5 已完成，本 PR 正式进入 **阶段 6：最小领域重构**。

本 PR 只执行 Stage-4 / `DOMAIN.md` 规定的：

```text
Wave 0  New Core VOs + legacy compatibility mapper
Wave 1  Immutable DefinitionVersion persistence + Publish dual-write
```

**不提前执行 Wave 2～6。**

## Domain Impact Analysis

```text
Bounded Context: Realtime Sync
Aggregate(s): RealtimeSyncTask + DefinitionVersion
SyncDefinition Area: Core VO foundation；暂不改变现有运行语义
Invariant/Lifecycle:
  - Publish 必须产生 immutable DefinitionVersion
  - DraftRevision 与 Published Version 分离
Layer: Domain + Application/Persistence boundary + DB
Stage-4 Gap:
  - GAP-01 Immutable DefinitionVersion Store
  - GAP-02 Published + newer Draft coexistence（先建立持久化基础）
Migration Wave: Wave 0 + Wave 1
Safety:
  - 保留现有 publish STOPPED/FAILED CAS
  - 保留现有事务/行锁
  - 不碰 Start/Stop/Restart/Reconcile
  - 不碰 UNKNOWN/CONFLICT/Idempotency/SSH/Flink
Domain Gap: no
```

---

## Wave 0：建立真正的 Core Definition 模型

新增：

```text
SyncDefinition
├── SourceEndpoint
├── SinkEndpoint
├── SyncRoute[]
│   ├── SourceSelector
│   │   ├── ExactTableSelector
│   │   └── TablePatternSelector
│   ├── SinkTarget/TableTarget
│   └── ReplayKey
├── SyncPolicy
│   ├── StartupPolicy
│   └── SchemaEvolutionPolicy
└── ExecutionPolicy
    ├── parallelism
    ├── CheckpointPolicy
    ├── RestartPolicy
    └── SinkWritePolicy
```

同时新增：

```text
RuntimeEnvironmentRef
DefinitionDigest
DefinitionVersion
```

这些类型是 Stage 2/3 已接受模型的第一批真实 Java 落地。

### Adapter-private tuning 不进入 Core Domain

当前：

```text
statementCacheSize
```

被放入：

```text
LegacyAdapterTuning
```

而不是 `SyncDefinition.ExecutionPolicy`。

因此 JDBC 私有调优不会继续污染 Core Definition。

### strictReplaySafety 不进入 Core Domain

Core Definition 通过：

```text
SyncRoute -> ReplayKey
```

表达 replay safety invariant。

兼容 mapper 只允许旧字段：

```text
strictReplaySafety = true
```

不会把 `false` 升格为新的 Domain Policy。

### legacy failure-rate 不伪造成 Core Policy

当前 legacy `failure-rate` 只有：

```text
attempts + delay
```

缺少完整 failure-rate window 语义。

因此 compatibility mapper 会显式抛：

```text
UnsupportedLegacyDefinitionException
```

Wave 1 Publish 会捕获这个已知兼容场景，将 immutable Version 标记为：

```text
LEGACY_UNMAPPED
```

并保存原始无密码 CdcPipelineSpec 快照。

**旧配置仍可按原有流程发布，但不会伪造一个错误的 Core RestartPolicy。**

---

## Semantic DefinitionDigest

新增 `SyncDefinitionDigestCalculator`。

定义：

```text
DefinitionDigest
= canonical SyncDefinition + RuntimeEnvironmentRef
```

当前 canonicalization 已明确消除：

```text
Route 排列顺序
ReplayKey 字段排列顺序
```

并且不会包含：

```text
statementCacheSize
Wizard/YAML 格式
Flink Pipeline YAML
Task display name
```

RuntimeEnvironmentRef 会进入 digest，因此同一 Definition 绑定不同运行环境属于不同发布语义。

为了避免自由文本分隔符造成 canonical encoding 歧义，Route selector/target/replay field 使用长度前缀编码。

> 注意：Wave 1 仍用 legacy `sourceConfigDigest` 做 Publish 幂等键，以完整保持当前 adapter-tuning 行为。Semantic DefinitionDigest 已建立，但尚未切成唯一 dedupe key；这属于后续迁移，不在本 PR 声称完全解决 GAP-06。

---

## Wave 1：真正的 Immutable DefinitionVersion

新增持久化表：

```text
yak_realtime_definition_version
```

逻辑字段：

```text
id                      DefinitionVersionId
task_id                 RealtimeSyncTask id
version_no              published version sequence
source_draft_revision   legacy DraftRevision 来源
runtime_environment_id  RuntimeEnvironmentRef
definition_json         immutable compatibility snapshot
definition_digest       semantic Core DefinitionDigest（可为空，仅 legacy-unmapped）
source_config_digest    legacy exact config digest
domain_mapping_state    MAPPED / LEGACY_UNMAPPED
create_time
```

约束：

```text
unique(task_id, version_no)
unique(task_id, source_config_digest)
```

### definition_version 与 version_no 正式分离

当前旧字段：

```text
yak_realtime_job_definition.definition_version
```

仍然保持：

```text
DraftRevision
```

新的：

```text
yak_realtime_definition_version.version_no
```

才是 immutable Published Definition 的业务版本序号。

本 PR 不重命名 legacy 字段，避免 Big-Bang migration。

---

## Task 增加稳定 Published Ref

`yak_realtime_job_definition` 新增：

```text
published_definition_version_id
```

它表达：

```text
RealtimeSyncTask.publishedDefinitionRef
```

保存新的 Draft 时不会覆盖这个字段。

所以 Wave 1 之后数据库已经具备表达：

```text
Published Version V1
+
newer mutable Draft revision
```

的基础。

不过 **Wave 2 之前 Start 仍使用旧路径**，暂时不会消费这个新 Ref。

---

## Publish 双写设计

新增：

```text
VersioningRealtimeJobStore
```

它是 `@Primary RealtimeJobStore` compatibility decorator。

除 `publish()` 外，全部原样委托当前 `RealtimeJobStoreAdapter`，因此不重写已有运行路径。

Publish 在原有事务中执行：

```text
lock current Task/Draft
   ↓
verify DraftRevision + source config digest
   ↓
legacy publish CAS
   ↓
find/create immutable DefinitionVersion
   ↓
bind Task.published_definition_version_id
```

使用同一个：

```text
yakBusinessTransactionManager
```

因此：

```text
legacy marker
+ immutable Version
+ Published Ref
```

会一起提交或一起回滚。

### 为什么仍保留 legacy publish CAS

本 PR **刻意不删除**：

```text
desired = STOPPED
observed IN (STOPPED, FAILED)
```

这些旧约束仍是当前 Task-row runtime concurrency 的一部分。

根据 `DOMAIN.md`：

> Wave 4 MUST NOT happen before Wave 3.

所以运行中编辑/发布不会在本 PR 提前放开。

---

## 为什么 Version 表暂时仍保存 CdcPipelineSpec JSON

这是 migration compatibility snapshot，不是第二套 editable truth。

理由：

1. Wave 2 Start 必须能从 immutable Version 还原**当时真正发布的配置**；
2. Core `SyncDefinition` 已主动排除了 JDBC `statementCacheSize` 等 adapter tuning；
3. 旧 `failure-rate` 目前无法无损映射成 Core Policy；
4. 不能为了领域纯洁而丢掉实际运行需要的 legacy compatibility 信息。

因此当前 Version 同时保存：

```text
immutable compatibility CdcPipelineSpec snapshot
+
semantic DefinitionDigest（能映射时）
+
domain_mapping_state
```

它不会保存：

```text
Flink Pipeline YAML
DataSource password
JDBC password
SSH secret
```

Wave 2 可以先安全 Start-by-Version；后续再逐步收缩 compatibility representation。

---

## 未改变的运行安全路径

本 PR **没有修改**：

```text
RealtimeJobService start/stop/restart
RealtimeJobLifecycleCoordinator
RealtimeStateMachine runtime transitions
Idempotency-Key
start reservation
same-key race recovery
stop-during-start
UNKNOWN / CONFLICT
runtime identity recovery
RuntimeEnvironmentSnapshot
submission-scoped credential zeroization
FlinkCdcEngineGateway
SSH runner
log redaction
reconcile lease
```

这些全部属于 Stage-5 Protection List。

---

## DB migration 策略

当前 realtime module 明确采用 consolidated Flyway baseline，并且 module README 已说明旧开发数据库不做 V1-V8 原地升级，而是重置 realtime schema/history 后重新初始化。

所以本 PR继续修改：

```text
V1__baseline_realtime_sync.sql
```

而不是新增面向已发布生产 schema 的 ALTER migration。

本 PR 的结构仍符合：

```text
expand -> dual write/read -> verify -> switch -> contract
```

当前只做到：

```text
expand + publish dual-write
```

没有 drop/rename legacy 字段。

---

## 测试

新增：

### CdcPipelineSpecCompatibilityMapperTest

验证：

- legacy fixed-delay Spec -> Core -> legacy round-trip；
- statementCacheSize 保持在 adapter tuning；
- incomplete failure-rate 不被伪造为 Core Policy。

### SyncDefinitionDigestCalculatorTest

验证：

- Route 顺序不影响 DefinitionDigest；
- ReplayKey 字段顺序不影响 DefinitionDigest；
- statementCacheSize 不影响 Core Definition/Digest；
- RuntimeEnvironmentRef 变化会改变 Digest。

### VersioningRealtimeJobStoreTest

验证：

- Publish 继续调用原 legacy publish；
- 创建 immutable MAPPED Version candidate；
- 绑定 Published Ref；
- legacy failure-rate 仍发布，但版本明确标记 `LEGACY_UNMAPPED`。

### DefinitionVersionRepositoryAdapterTest

验证：

- 相同 exact source config digest 重复发布复用已有 immutable Version；
- 新发布内容生成单调递增 `version_no`。

另外使用 JDK 21 对新增纯 Core VO + canonical digest 代码做了独立 `javac --release 21` 语法检查，已通过。

**完整 Maven reactor / module build 当前未执行，因此不声明 Maven/全部单测已通过。**

---

## 本 PR 明确不做

以下属于后续 Wave：

```text
Wave 2: Start by Task.publishedDefinitionVersionId / DefinitionVersion
Wave 3: Deployment -> SyncExecution + desired/observed ownership
Wave 4: 运行中编辑/发布
Wave 5: RestartExecution vs ApplyPublishedVersion
Wave 6: legacy field/package/name cleanup
```

也不做：

- public REST/YAML v1 破坏性变化；
- 前端改造；
- Snapshot-only；
- hard-delete/archive 重构；
- checkpoint/restart runtime application gap；
- Compute Environment package 拆分。

---

## Known gaps after this PR

仍然存在：

- Start 尚未消费 immutable DefinitionVersion（Wave 2）；
- Desired/Observed 尚未迁到 Execution（Wave 3）；
- Semantic DefinitionDigest 尚未成为 Version dedupe 的唯一判断；
- legacy failure-rate 仍是 `LEGACY_UNMAPPED`；
- Deployment configDigest 仍是 ExecutionArtifactDigest 的 legacy 名称；
- audit-safe deletion 尚未处理；
- checkpoint/restart ExecutionPolicy runtime application 尚未处理；
- FINISHED normal completion 尚未处理。

---

## Domain Compliance Report

```text
Domain rule implemented:
  Publish creates an immutable DefinitionVersion fact.

Aggregate(s) changed:
  DefinitionVersion persistence
  RealtimeSyncTask PublishedDefinitionRef persistence foundation

Invariant/lifecycle impact:
  DraftRevision and Published Version become separate concepts.
  Existing runtime mutation guards remain unchanged.

Legacy compatibility kept:
  release_state / published_version dual-write
  CdcPipelineSpec REST/YAML representation
  current Start/Stop/Restart behavior
  legacy failure-rate publish behavior

Safety properties preserved:
  existing publish CAS / transaction / row lock
  all Start/Stop/UNKNOWN/CONFLICT/idempotency/recovery/credential protections untouched

DB migration mode:
  expand + dual-write; no drop/rename/contract

Tests added:
  compatibility mapping
  semantic digest
  versioning publish decorator
  version repository idempotency/version sequence

Known gaps remaining:
  Wave 2+
```

## Branch

```text
feat/realtime-sync-domain-stage-6-wave-0-1
```

分支直接基于合并 Stage 5 后的最新 `main`。开 PR 前已 squash 为单一 commit，compare 为 `behind_by=0`。