### PR TITLE
feat: start realtime jobs from published definition versions

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/RealtimeJobDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/RealtimeJobDao.java
@@ -17,6 +17,8 @@ public interface RealtimeJobDao {
   Optional<RealtimeJobDeploymentPO> latestDeployment(long definitionId);
   Optional<RealtimeJobDeploymentPO> findDeployment(long deploymentId);
   long insertDeployment(RealtimeJobDeploymentPO deployment);
+  void bindDeploymentDefinitionVersion(
+      long deploymentId, long definitionVersionId, int sourceDraftRevision);
   int markStarting(long definitionId);
   int markDeploymentRunning(long definitionId, long deploymentId, String engineJobId, String runtimeRevision);
   void bindDeploymentForStop(long deploymentId, String engineJobId, String runtimeRevision);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
@@ -127,6 +127,23 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
   }
 
   @Override
+  public void bindDeploymentDefinitionVersion(
+      long deploymentId, long definitionVersionId, int sourceDraftRevision) {
+    int updated =
+        deploymentMapper.update(
+            null,
+            Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
+                .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                .eq(RealtimeJobDeploymentPO::getStatus, "SUBMITTING")
+                .isNull(RealtimeJobDeploymentPO::getDefinitionVersionId)
+                .set(RealtimeJobDeploymentPO::getDefinitionVersionId, definitionVersionId)
+                .set(RealtimeJobDeploymentPO::getDefinitionVersion, sourceDraftRevision));
+    if (updated != 1) {
+      throw new IllegalStateException("部署绑定 Published DefinitionVersion 失败：" + deploymentId);
+    }
+  }
+
+  @Override
   public int markStarting(long definitionId) {
     return definitionMapper.update(
         null,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
@@ -12,6 +12,7 @@ public class RealtimeJobDeploymentPO {
   @TableId(type = IdType.AUTO)
   private Long id;
   private Long definitionId;
+  private Long definitionVersionId;
   private Integer definitionVersion;
   private Long runtimeEnvironmentId;
   private Integer runtimeEnvironmentVersion;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -22,12 +22,19 @@ public interface RealtimeJobStore {
   }
   DefinitionRow lockDefinition(long id);
   RealtimeJobPage page(int pageNo, int pageSize, String keyword);
+  default Optional<PublishedDefinitionRow> publishedDefinition(long definitionId) {
+    return Optional.empty();
+  }
   Optional<DeploymentRow> deploymentByIdempotencyKey(String key);
   Optional<DeploymentRow> latestDeployment(long definitionId);
   default Optional<ComputeEnvironmentSnapshot> deploymentEnvironment(long deploymentId) {
     return Optional.empty();
   }
   long insertDeployment(DefinitionRow definition, CdcPipelineSpec spec, String summary, String digest, ComputeEnvironmentSnapshot environment, String idempotencyKey);
+  default void bindDeploymentDefinitionVersion(
+      long deploymentId, long definitionVersionId, int sourceDraftRevision) {
+    throw new UnsupportedOperationException("当前 RealtimeJobStore 不支持 DefinitionVersion 绑定");
+  }
   void markStarting(long definitionId);
   void markDeploymentRunning(long definitionId, long deploymentId, String engineJobId, String runtimeRevision);
   void bindDeploymentForStop(long deploymentId, String engineJobId, String runtimeRevision);
@@ -44,6 +51,29 @@ public interface RealtimeJobStore {
   RealtimeJobView view(long id);
   default CdcPipelineSpec spec(DefinitionRow definition) { return definition.spec(); }
   RealtimeJobView.Deployment deploymentView(DeploymentRow deployment);
+
+  record PublishedDefinitionRow(
+      long id,
+      long taskId,
+      int versionNo,
+      int sourceDraftRevision,
+      CdcPipelineSpec spec,
+      long runtimeEnvironmentId,
+      String sourceConfigDigest,
+      String definitionDigest) {
+    public PublishedDefinitionRow {
+      if (id <= 0) throw new IllegalArgumentException("DefinitionVersionId 必须大于 0");
+      if (taskId <= 0) throw new IllegalArgumentException("TaskId 必须大于 0");
+      if (versionNo <= 0) throw new IllegalArgumentException("Published versionNo 必须大于 0");
+      if (sourceDraftRevision <= 0) {
+        throw new IllegalArgumentException("Published sourceDraftRevision 必须大于 0");
+      }
+      if (spec == null) throw new IllegalArgumentException("Published definition snapshot 不能为空");
+      if (runtimeEnvironmentId <= 0) {
+        throw new IllegalArgumentException("Published RuntimeEnvironmentRef 必须大于 0");
+      }
+    }
+  }
 
   record DefinitionRow(
       long id,
@@ -64,6 +94,7 @@ public interface RealtimeJobStore {
   record DeploymentRow(
       long id,
       long definitionId,
+      Long definitionVersionId,
       int definitionVersion,
       CdcPipelineSpec specSnapshot,
       String specSummary,
@@ -76,5 +107,42 @@ public interface RealtimeJobStore {
       boolean resultUncertain,
       String errorMessage,
       LocalDateTime createTime,
-      LocalDateTime updateTime) {}
+      LocalDateTime updateTime) {
+
+    /** Compatibility constructor for tests/callers created before Wave 2 added the immutable ref. */
+    public DeploymentRow(
+        long id,
+        long definitionId,
+        int definitionVersion,
+        CdcPipelineSpec specSnapshot,
+        String specSummary,
+        String configDigest,
+        String idempotencyKey,
+        String engineJobId,
+        String runtimeRevision,
+        ComputeEnvironmentSnapshot runtimeEnvironment,
+        String status,
+        boolean resultUncertain,
+        String errorMessage,
+        LocalDateTime createTime,
+        LocalDateTime updateTime) {
+      this(
+          id,
+          definitionId,
+          null,
+          definitionVersion,
+          specSnapshot,
+          specSummary,
+          configDigest,
+          idempotencyKey,
+          engineJobId,
+          runtimeRevision,
+          runtimeEnvironment,
+          status,
+          resultUncertain,
+          errorMessage,
+          createTime,
+          updateTime);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
@@ -63,6 +63,7 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
   @Override public Optional<DefinitionRow> definition(long id) { return dao.findDefinition(id).map(this::definitionRow); }
   @Override public DefinitionRow lockDefinition(long id) { return dao.lockDefinition(id).map(this::definitionRow).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id)); }
   @Override public RealtimeJobPage page(int pageNo, int pageSize, String keyword) { return listQuery.page(pageNo, pageSize, keyword, null, null, null); }
+  @Override public Optional<PublishedDefinitionRow> publishedDefinition(long definitionId) { return Optional.empty(); }
   @Override public Optional<DeploymentRow> deploymentByIdempotencyKey(String key) { return dao.deploymentByIdempotencyKey(key).map(this::deploymentRow); }
   @Override public Optional<DeploymentRow> latestDeployment(long definitionId) { return dao.latestDeployment(definitionId).map(this::deploymentRow); }
 
@@ -93,6 +94,12 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
     po.setStatus("SUBMITTING");
     po.setResultUncertain(false);
     return dao.insertDeployment(po);
+  }
+
+  @Override
+  public void bindDeploymentDefinitionVersion(
+      long deploymentId, long definitionVersionId, int sourceDraftRevision) {
+    dao.bindDeploymentDefinitionVersion(deploymentId, definitionVersionId, sourceDraftRevision);
   }
 
   @Override public void markStarting(long definitionId) { if (dao.markStarting(definitionId) != 1) throw new IllegalStateException("任务已被其他启动或停止请求抢占，请刷新后重试"); }
@@ -157,7 +164,8 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
 
   private DeploymentRow deploymentRow(RealtimeJobDeploymentPO po) {
     return new DeploymentRow(
-        po.getId(), po.getDefinitionId(), po.getDefinitionVersion() == null ? 0 : po.getDefinitionVersion(),
+        po.getId(), po.getDefinitionId(), po.getDefinitionVersionId(),
+        po.getDefinitionVersion() == null ? 0 : po.getDefinitionVersion(),
         json.readSpec(po.getSpecSnapshotJson()), po.getSpecSummary(), po.getConfigDigest(), po.getIdempotencyKey(),
         po.getGatewayJobId(), po.getRuntimeRevision(), json.readEnvironmentSnapshot(po.getRuntimeEnvironmentSnapshotJson()),
         po.getStatus(), Boolean.TRUE.equals(po.getResultUncertain()), po.getErrorMessage(), po.getCreateTime(), po.getUpdateTime());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
@@ -14,6 +14,7 @@ import io.yak.ops.business.sync.realtime.domain.SyncDefinition;
 import io.yak.ops.business.sync.realtime.domain.SyncDefinitionDigestCalculator;
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.DomainMappingState;
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationCandidate;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationSnapshot;
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.StoredVersion;
 import java.util.List;
 import java.util.Objects;
@@ -102,6 +103,34 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
   }
 
   @Override
+  public Optional<PublishedDefinitionRow> publishedDefinition(long definitionId) {
+    Optional<Long> ref = definitionVersions.publishedDefinitionVersionId(definitionId);
+    if (ref.isEmpty()) return Optional.empty();
+
+    PublicationSnapshot snapshot =
+        definitionVersions
+            .find(ref.get())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "实时同步任务引用的 Published DefinitionVersion 不存在：" + ref.get()));
+    StoredVersion version = snapshot.version();
+    if (version.taskId() != definitionId) {
+      throw new IllegalStateException("Published DefinitionVersion 不属于当前实时同步任务");
+    }
+    return Optional.of(
+        new PublishedDefinitionRow(
+            version.id(),
+            version.taskId(),
+            version.versionNo(),
+            version.sourceDraftRevision(),
+            snapshot.compatibilityDefinition(),
+            snapshot.runtimeEnvironmentId(),
+            version.sourceConfigDigest(),
+            version.definitionDigest()));
+  }
+
+  @Override
   public long insertDefinition(
       String name,
       String description,
@@ -162,6 +191,13 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
       String idempotencyKey) {
     return delegate.insertDeployment(
         definition, spec, summary, digest, environment, idempotencyKey);
+  }
+
+  @Override
+  public void bindDeploymentDefinitionVersion(
+      long deploymentId, long definitionVersionId, int sourceDraftRevision) {
+    delegate.bindDeploymentDefinitionVersion(
+        deploymentId, definitionVersionId, sourceDraftRevision);
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -20,6 +20,7 @@ import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HexFormat;
@@ -161,20 +162,21 @@ public class RealtimeJobService {
     ReentrantLock lock = lifecycleLock(id);
     lock.lock();
     try {
-      return startLocked(id, requestedKey);
+      return startLocked(id, requestedKey, null);
     } finally {
       lock.unlock();
     }
   }
 
-  private RealtimeJobView.Deployment startLocked(long id, String requestedKey) {
+  private RealtimeJobView.Deployment startLocked(
+      long id, String requestedKey, Long expectedPublishedDefinitionVersionId) {
     String key = normalizeKey(requestedKey);
     DeploymentRow existing = idempotentDeployment(id, key);
     if (existing != null) {
       return store.deploymentView(existing);
     }
 
-    Prepared prepared = prepare(id, true);
+    StartPrepared prepared = preparePublished(id, expectedPublishedDefinitionVersionId);
     gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
 
     StartReservation reservation;
@@ -191,8 +193,8 @@ public class RealtimeJobService {
                   return new StartReservation(duplicate.id(), false);
                 }
 
-                requirePublished(locked);
-                requirePreparedDefinitionCurrent(prepared, locked);
+                PublishedDefinitionRow currentPublished = requirePublishedDefinition(id);
+                requirePreparedPublishedCurrent(prepared, currentPublished);
                 stateMachine.requireStartable(locked.desiredState(), locked.observedState());
                 stateMachine.requireTransition(locked.observedState(), "STARTING");
                 long created =
@@ -203,6 +205,10 @@ public class RealtimeJobService {
                         digest(prepared.compiled().yaml()),
                         prepared.runtimeEnvironment(),
                         key);
+                store.bindDeploymentDefinitionVersion(
+                    created,
+                    prepared.publishedDefinition().id(),
+                    prepared.publishedDefinition().sourceDraftRevision());
                 store.markStarting(id);
                 store.event(
                     id,
@@ -210,7 +216,9 @@ public class RealtimeJobService {
                     "START_REQUESTED",
                     locked.observedState(),
                     "STARTING",
-                    "开始通过运行环境「"
+                    "开始使用已发布版本 v"
+                        + prepared.publishedDefinition().versionNo()
+                        + "，通过运行环境「"
                         + prepared.runtimeEnvironment().name()
                         + "」提交 Flink CDC 任务");
                 return new StartReservation(created, true);
@@ -255,7 +263,7 @@ public class RealtimeJobService {
   private RealtimeJobView.Deployment completeStart(
       long id,
       long deploymentId,
-      Prepared prepared,
+      StartPrepared prepared,
       RealtimeEngineGateway.DeployResult result) {
     Boolean cancelAfterSubmit =
         transactions.execute(
@@ -420,6 +428,7 @@ public class RealtimeJobService {
         return store.deploymentView(existing);
       }
 
+      PublishedDefinitionRow restartPublished = requirePublishedDefinition(id);
       stopLocked(id);
       DefinitionRow current =
           store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
@@ -428,7 +437,7 @@ public class RealtimeJobService {
               || "FAILED".equals(current.observedState()))) {
         throw new IllegalStateException("任务仍在停止中，请稍后使用相同 Idempotency-Key 重试重启");
       }
-      return startLocked(id, key);
+      return startLocked(id, key, restartPublished.id());
     } finally {
       lock.unlock();
     }
@@ -456,7 +465,7 @@ public class RealtimeJobService {
     DefinitionRow definition =
         store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
     if (requirePublished) {
-      requirePublished(definition);
+      throw new IllegalArgumentException("内部调用错误：Start 必须通过 immutable Published Definition 准备");
     }
     CdcPipelineSpec spec = store.spec(definition);
     specValidator.validate(spec);
@@ -472,11 +481,46 @@ public class RealtimeJobService {
         manifest);
   }
 
-  private void requirePublished(DefinitionRow definition) {
-    if (!"PUBLISHED".equals(definition.releaseState())
-        || definition.publishedVersion() == null
-        || definition.publishedVersion() != definition.definitionVersion()) {
-      throw new IllegalStateException("请先发布当前定义版本");
+  private StartPrepared preparePublished(
+      long id, Long expectedPublishedDefinitionVersionId) {
+    DefinitionRow task =
+        store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+    PublishedDefinitionRow published = requirePublishedDefinition(id);
+    if (expectedPublishedDefinitionVersionId != null
+        && published.id() != expectedPublishedDefinitionVersionId) {
+      throw new IllegalStateException("重启期间已发布版本发生变化，请刷新后重新操作");
+    }
+
+    CdcPipelineSpec spec = published.spec();
+    specValidator.validate(spec);
+    ComputeEnvironmentSnapshot runtimeEnvironment =
+        runtimeResolver.environment(published.runtimeEnvironmentId(), true);
+    ResolvedCdcPipeline resolved = dataSourceResolver.resolve(spec);
+    JsonNode manifest = gateway.capabilities(runtimeEnvironment);
+    capabilityResolver.requireSupported(manifest, resolved, spec);
+    return new StartPrepared(
+        task,
+        published,
+        spec,
+        compiler.compile(task.name(), spec, resolved),
+        runtimeEnvironment,
+        manifest);
+  }
+
+  private PublishedDefinitionRow requirePublishedDefinition(long id) {
+    return store
+        .publishedDefinition(id)
+        .orElseThrow(() -> new IllegalStateException("请先发布至少一个可运行的定义版本"));
+  }
+
+  private void requirePreparedPublishedCurrent(
+      StartPrepared prepared, PublishedDefinitionRow currentPublished) {
+    PublishedDefinitionRow snapshot = prepared.publishedDefinition();
+    if (snapshot.id() != currentPublished.id()
+        || snapshot.taskId() != currentPublished.taskId()
+        || snapshot.sourceDraftRevision() != currentPublished.sourceDraftRevision()
+        || !Objects.equals(snapshot.sourceConfigDigest(), currentPublished.sourceConfigDigest())) {
+      throw new IllegalStateException("已发布定义在校验期间已变化，请刷新后重试");
     }
   }
 
@@ -557,7 +601,7 @@ public class RealtimeJobService {
     return key;
   }
 
-  private RealtimeEngineGateway.DeployResult deploy(Prepared prepared, String key) {
+  private RealtimeEngineGateway.DeployResult deploy(StartPrepared prepared, String key) {
     RealtimeDeployRequest.CredentialBinding[] credentials =
         dataSourceResolver.resolveCredentials(prepared.spec());
     try (RealtimeDeployRequest request =
@@ -606,6 +650,14 @@ public class RealtimeJobService {
 
   private record Prepared(
       DefinitionRow definition,
+      CdcPipelineSpec spec,
+      CompiledPipeline compiled,
+      ComputeEnvironmentSnapshot runtimeEnvironment,
+      JsonNode manifest) {}
+
+  private record StartPrepared(
+      DefinitionRow task,
+      PublishedDefinitionRow publishedDefinition,
       CdcPipelineSpec spec,
       CompiledPipeline compiled,
       ComputeEnvironmentSnapshot runtimeEnvironment,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
@@ -64,6 +64,7 @@ CREATE TABLE IF NOT EXISTS yak_realtime_definition_version (
 CREATE TABLE IF NOT EXISTS yak_realtime_job_deployment (
     id BIGINT NOT NULL AUTO_INCREMENT,
     definition_id BIGINT NOT NULL,
+    definition_version_id BIGINT NULL,
     definition_version INT NOT NULL,
     runtime_environment_id BIGINT NOT NULL,
     runtime_environment_version INT NOT NULL,
@@ -86,6 +87,7 @@ CREATE TABLE IF NOT EXISTS yak_realtime_job_deployment (
     UNIQUE KEY uk_realtime_idempotency (idempotency_key),
     UNIQUE KEY uk_realtime_runtime_job_name (runtime_job_name),
     KEY idx_realtime_deployment_definition (definition_id, id),
+    KEY idx_realtime_deployment_definition_version (definition_version_id, id),
     KEY idx_realtime_deployment_environment (runtime_environment_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.sync.realtime.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -10,10 +11,13 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecCompatibilityMapper;
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.DomainMappingState;
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationCandidate;
+import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationSnapshot;
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.StoredVersion;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -95,6 +99,65 @@ class VersioningRealtimeJobStoreTest {
         .isEqualTo(DomainMappingState.LEGACY_UNMAPPED);
     assertThat(candidate.getValue().domainDefinition()).isNull();
     assertThat(candidate.getValue().definitionDigest()).isNull();
+  }
+
+  @Test
+  void resolvesPublishedDefinitionThroughTaskReference() {
+    RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
+    DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
+    VersioningRealtimeJobStore store =
+        new VersioningRealtimeJobStore(
+            delegate, versions, new CdcPipelineSpecCompatibilityMapper());
+    CdcPipelineSpec snapshotSpec = spec("fixed-delay");
+    StoredVersion stored =
+        new StoredVersion(
+            201L,
+            TASK_ID,
+            3,
+            8,
+            "b".repeat(64),
+            SOURCE_DIGEST,
+            DomainMappingState.MAPPED,
+            LocalDateTime.now());
+    when(versions.publishedDefinitionVersionId(TASK_ID)).thenReturn(Optional.of(stored.id()));
+    when(versions.find(stored.id()))
+        .thenReturn(Optional.of(new PublicationSnapshot(stored, 33L, snapshotSpec)));
+
+    PublishedDefinitionRow published = store.publishedDefinition(TASK_ID).orElseThrow();
+
+    assertThat(published.id()).isEqualTo(stored.id());
+    assertThat(published.taskId()).isEqualTo(TASK_ID);
+    assertThat(published.versionNo()).isEqualTo(3);
+    assertThat(published.sourceDraftRevision()).isEqualTo(8);
+    assertThat(published.spec()).isEqualTo(snapshotSpec);
+    assertThat(published.runtimeEnvironmentId()).isEqualTo(33L);
+    assertThat(published.sourceConfigDigest()).isEqualTo(SOURCE_DIGEST);
+  }
+
+  @Test
+  void rejectsPublishedVersionThatBelongsToAnotherTask() {
+    RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
+    DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
+    VersioningRealtimeJobStore store =
+        new VersioningRealtimeJobStore(
+            delegate, versions, new CdcPipelineSpecCompatibilityMapper());
+    StoredVersion foreign =
+        new StoredVersion(
+            301L,
+            99L,
+            1,
+            1,
+            "b".repeat(64),
+            SOURCE_DIGEST,
+            DomainMappingState.MAPPED,
+            LocalDateTime.now());
+    when(versions.publishedDefinitionVersionId(TASK_ID)).thenReturn(Optional.of(foreign.id()));
+    when(versions.find(foreign.id()))
+        .thenReturn(Optional.of(new PublicationSnapshot(foreign, 3L, spec("fixed-delay"))));
+
+    assertThatThrownBy(() -> store.publishedDefinition(TASK_ID))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("不属于当前实时同步任务");
   }
 
   private DefinitionRow definitionRow(CdcPipelineSpec spec) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,7 @@ import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import jakarta.validation.Validation;
 import java.time.LocalDateTime;
@@ -43,6 +45,7 @@ class RealtimeExecutionPathTest {
 
   private static final long JOB_ID = 7L;
   private static final long DEPLOYMENT_ID = 19L;
+  private static final long DEFINITION_VERSION_ID = 31L;
   private static final String FLINK_JOB_ID = "0123456789abcdef0123456789abcdef";
   private static final String CANONICAL_YAML =
       "source:\n  type: mysql\nsink:\n  type: yak-jdbc\npipeline:\n  name: test-job\n";
@@ -65,28 +68,7 @@ class RealtimeExecutionPathTest {
     String logicalYaml = yamlCodec.render(wizardSpec);
     CdcPipelineSpec yamlSpec = yamlCodec.parse(logicalYaml);
 
-    ResolvedCdcPipeline resolved =
-        new ResolvedCdcPipeline(
-            new ResolvedCdcPipeline.Endpoint(
-                1L,
-                "source",
-                DataSourceDbType.MYSQL,
-                "mysql-source",
-                3306,
-                "jdbc:mysql://mysql-source:3306/shop",
-                "com.mysql.cj.jdbc.Driver",
-                "reader",
-                "shop"),
-            new ResolvedCdcPipeline.Endpoint(
-                2L,
-                "sink",
-                DataSourceDbType.MYSQL,
-                "mysql-sink",
-                3306,
-                "jdbc:mysql://mysql-sink:3306/dw",
-                "com.mysql.cj.jdbc.Driver",
-                "writer",
-                "dw"));
+    ResolvedCdcPipeline resolved = resolved();
     PipelineYamlCompiler compiler = new PipelineYamlCompiler();
 
     String wizardPipeline = compiler.compile("test-job", wizardSpec, resolved).yaml();
@@ -97,7 +79,7 @@ class RealtimeExecutionPathTest {
   }
 
   @Test
-  void publishAndStartUseTheSameCompiledPipelineYaml() {
+  void publishAndStartUseTheSameCompiledPipelineYamlWhenDraftIsUnchanged() {
     RealtimeJobStore store = mock(RealtimeJobStore.class);
     CdcPipelineSpecValidator specValidator = mock(CdcPipelineSpecValidator.class);
     RealtimeDataSourceResolver dataSourceResolver = mock(RealtimeDataSourceResolver.class);
@@ -112,31 +94,27 @@ class RealtimeExecutionPathTest {
     ObjectMapper json = new ObjectMapper();
     CdcPipelineSpec spec = spec();
     ComputeEnvironmentSnapshot environment = environment();
-    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
-    DefinitionRow publishedStopped = definition(spec, environment, "STOPPED", "STOPPED");
-    DefinitionRow starting = definition(spec, environment, "RUNNING", "STARTING");
-    DeploymentRow deployment = deployment(spec, environment);
+    ResolvedCdcPipeline resolved = resolved();
+    DefinitionRow publishedStopped = definition(spec, environment.id(), "PUBLISHED", "STOPPED", "STOPPED", 1, 1);
+    DefinitionRow starting = definition(spec, environment.id(), "PUBLISHED", "RUNNING", "STARTING", 1, 1);
+    PublishedDefinitionRow published = published(spec, environment.id(), 1, 1);
+    DeploymentRow deployment = deployment(spec, environment, DEFINITION_VERSION_ID, 1);
 
-    ObjectNode capabilities = json.createObjectNode();
-    capabilities.put("runtimeVersion", "flink-cdc-cli-3.6.0");
-    capabilities.put("deliverySemantics", "at-least-once");
+    ObjectNode capabilities = capabilities(json);
 
     when(store.definition(JOB_ID)).thenReturn(Optional.of(publishedStopped));
     when(store.spec(any())).thenReturn(spec);
     when(store.runtimeEnvironmentId(JOB_ID)).thenReturn(environment.id());
+    when(store.publishedDefinition(JOB_ID)).thenReturn(Optional.of(published));
     when(store.lockDefinition(JOB_ID)).thenReturn(publishedStopped, publishedStopped, starting);
     when(store.deploymentByIdempotencyKey("exec-1")).thenReturn(Optional.empty());
     when(store.insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("exec-1")))
         .thenReturn(DEPLOYMENT_ID);
     when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
     when(runtimeResolver.definition(any(), eq(true))).thenReturn(environment);
+    when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
     when(dataSourceResolver.resolve(spec)).thenReturn(resolved);
-    when(dataSourceResolver.resolveCredentials(spec))
-        .thenReturn(
-            new CredentialBinding[] {
-              new CredentialBinding("source", "source-secret"),
-              new CredentialBinding("sink", "sink-secret")
-            });
+    when(dataSourceResolver.resolveCredentials(spec)).thenReturn(credentials());
     when(gateway.capabilities(environment)).thenReturn(capabilities);
     when(compiler.compile("test-job", spec, resolved))
         .thenReturn(new CompiledPipeline(CANONICAL_YAML, "mysql#1 -> mysql#2, tables=1"));
@@ -145,24 +123,23 @@ class RealtimeExecutionPathTest {
     when(gateway.deploy(eq(environment), any()))
         .thenReturn(new DeployResult(FLINK_JOB_ID, "at-least-once"));
 
-    RealtimeJobService service =
-        new RealtimeJobService(
-            store,
-            json,
-            specValidator,
-            new RealtimeStateMachine(),
-            dataSourceResolver,
-            capabilityResolver,
-            compiler,
-            gateway,
-            runtimeResolver,
-            transactionManager);
+    RealtimeJobService service = service(
+        store,
+        json,
+        specValidator,
+        dataSourceResolver,
+        capabilityResolver,
+        compiler,
+        gateway,
+        runtimeResolver,
+        transactionManager);
 
     service.publish(JOB_ID);
     service.start(JOB_ID, "exec-1");
 
     verify(compiler, times(2)).compile("test-job", spec, resolved);
     verify(gateway, times(2)).validate(environment, CANONICAL_YAML);
+    verify(store).bindDeploymentDefinitionVersion(DEPLOYMENT_ID, DEFINITION_VERSION_ID, 1);
 
     ArgumentCaptor<RealtimeDeployRequest> requestCaptor =
         ArgumentCaptor.forClass(RealtimeDeployRequest.class);
@@ -173,6 +150,125 @@ class RealtimeExecutionPathTest {
     verify(store)
         .insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("exec-1"));
     verify(store).markDeploymentRunning(JOB_ID, DEPLOYMENT_ID, FLINK_JOB_ID, environment.runtimeRevision());
+  }
+
+  @Test
+  void startUsesPublishedSnapshotWhenCurrentDraftHasAdvanced() {
+    RealtimeJobStore store = mock(RealtimeJobStore.class);
+    CdcPipelineSpecValidator specValidator = mock(CdcPipelineSpecValidator.class);
+    RealtimeDataSourceResolver dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    RealtimeConnectorCapabilityResolver capabilityResolver =
+        mock(RealtimeConnectorCapabilityResolver.class);
+    PipelineYamlCompiler compiler = mock(PipelineYamlCompiler.class);
+    RealtimeEngineGateway gateway = mock(RealtimeEngineGateway.class);
+    RealtimeRuntimeResolver runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    ObjectMapper json = new ObjectMapper();
+    CdcPipelineSpec publishedSpec = spec();
+    CdcPipelineSpec newerDraft =
+        new CdcPipelineSpec(
+            publishedSpec.sourceDataSourceRef(),
+            publishedSpec.sinkDataSourceRef(),
+            List.of(
+                new CdcPipelineSpec.TableRoute(
+                    "orders_v2", "orders_v2", CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+            "latest-offset",
+            publishedSpec.schemaEvolution(),
+            publishedSpec.parallelism(),
+            publishedSpec.checkpointIntervalMs(),
+            publishedSpec.restart(),
+            publishedSpec.sink());
+    ComputeEnvironmentSnapshot publishedEnvironment = environment();
+    long newerDraftEnvironmentId = 4L;
+    ResolvedCdcPipeline resolved = resolved();
+    DefinitionRow draftStopped =
+        definition(newerDraft, newerDraftEnvironmentId, "DRAFT", "STOPPED", "STOPPED", 2, 1);
+    DefinitionRow starting =
+        definition(newerDraft, newerDraftEnvironmentId, "DRAFT", "RUNNING", "STARTING", 2, 1);
+    PublishedDefinitionRow published = published(publishedSpec, publishedEnvironment.id(), 1, 1);
+    DeploymentRow deployment =
+        deployment(publishedSpec, publishedEnvironment, DEFINITION_VERSION_ID, 1);
+    ObjectNode capabilities = capabilities(json);
+
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(draftStopped));
+    when(store.publishedDefinition(JOB_ID)).thenReturn(Optional.of(published));
+    when(store.lockDefinition(JOB_ID)).thenReturn(draftStopped, starting);
+    when(store.deploymentByIdempotencyKey("published-v1")).thenReturn(Optional.empty());
+    when(store.insertDeployment(
+            any(), eq(publishedSpec), any(), any(), eq(publishedEnvironment), eq("published-v1")))
+        .thenReturn(DEPLOYMENT_ID);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(runtimeResolver.environment(publishedEnvironment.id(), true)).thenReturn(publishedEnvironment);
+    when(dataSourceResolver.resolve(publishedSpec)).thenReturn(resolved);
+    when(dataSourceResolver.resolveCredentials(publishedSpec)).thenReturn(credentials());
+    when(gateway.capabilities(publishedEnvironment)).thenReturn(capabilities);
+    when(compiler.compile("test-job", publishedSpec, resolved))
+        .thenReturn(new CompiledPipeline(CANONICAL_YAML, "mysql#1 -> mysql#2, tables=1"));
+    when(gateway.validate(publishedEnvironment, CANONICAL_YAML))
+        .thenReturn(new ValidationResult(true, "at-least-once"));
+    when(gateway.deploy(eq(publishedEnvironment), any()))
+        .thenReturn(new DeployResult(FLINK_JOB_ID, "at-least-once"));
+
+    RealtimeJobService service = service(
+        store,
+        json,
+        specValidator,
+        dataSourceResolver,
+        capabilityResolver,
+        compiler,
+        gateway,
+        runtimeResolver,
+        transactionManager);
+
+    service.start(JOB_ID, "published-v1");
+
+    verify(compiler).compile("test-job", publishedSpec, resolved);
+    verify(compiler, never()).compile(eq("test-job"), eq(newerDraft), any());
+    verify(runtimeResolver).environment(publishedEnvironment.id(), true);
+    verify(runtimeResolver, never()).environment(newerDraftEnvironmentId, true);
+    verify(store)
+        .insertDeployment(
+            any(), eq(publishedSpec), any(), any(), eq(publishedEnvironment), eq("published-v1"));
+    verify(store).bindDeploymentDefinitionVersion(DEPLOYMENT_ID, DEFINITION_VERSION_ID, 1);
+  }
+
+  private RealtimeJobService service(
+      RealtimeJobStore store,
+      ObjectMapper json,
+      CdcPipelineSpecValidator specValidator,
+      RealtimeDataSourceResolver dataSourceResolver,
+      RealtimeConnectorCapabilityResolver capabilityResolver,
+      PipelineYamlCompiler compiler,
+      RealtimeEngineGateway gateway,
+      RealtimeRuntimeResolver runtimeResolver,
+      PlatformTransactionManager transactionManager) {
+    return new RealtimeJobService(
+        store,
+        json,
+        specValidator,
+        new RealtimeStateMachine(),
+        dataSourceResolver,
+        capabilityResolver,
+        compiler,
+        gateway,
+        runtimeResolver,
+        transactionManager);
+  }
+
+  private ObjectNode capabilities(ObjectMapper json) {
+    ObjectNode capabilities = json.createObjectNode();
+    capabilities.put("runtimeVersion", "flink-cdc-cli-3.6.0");
+    capabilities.put("deliverySemantics", "at-least-once");
+    return capabilities;
+  }
+
+  private CredentialBinding[] credentials() {
+    return new CredentialBinding[] {
+      new CredentialBinding("source", "source-secret"),
+      new CredentialBinding("sink", "sink-secret")
+    };
   }
 
   private CdcPipelineSpec spec() {
@@ -188,6 +284,30 @@ class RealtimeExecutionPathTest {
         60_000,
         new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
         new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+
+  private ResolvedCdcPipeline resolved() {
+    return new ResolvedCdcPipeline(
+        new ResolvedCdcPipeline.Endpoint(
+            1L,
+            "source",
+            DataSourceDbType.MYSQL,
+            "mysql-source",
+            3306,
+            "jdbc:mysql://mysql-source:3306/shop",
+            "com.mysql.cj.jdbc.Driver",
+            "reader",
+            "shop"),
+        new ResolvedCdcPipeline.Endpoint(
+            2L,
+            "sink",
+            DataSourceDbType.MYSQL,
+            "mysql-sink",
+            3306,
+            "jdbc:mysql://mysql-sink:3306/dw",
+            "com.mysql.cj.jdbc.Driver",
+            "writer",
+            "dw"));
   }
 
   private ComputeEnvironmentSnapshot environment() {
@@ -207,22 +327,38 @@ class RealtimeExecutionPathTest {
         2);
   }
 
+  private PublishedDefinitionRow published(
+      CdcPipelineSpec spec, long runtimeEnvironmentId, int versionNo, int sourceDraftRevision) {
+    return new PublishedDefinitionRow(
+        DEFINITION_VERSION_ID,
+        JOB_ID,
+        versionNo,
+        sourceDraftRevision,
+        spec,
+        runtimeEnvironmentId,
+        "a".repeat(64),
+        "b".repeat(64));
+  }
+
   private DefinitionRow definition(
       CdcPipelineSpec spec,
-      ComputeEnvironmentSnapshot environment,
+      long runtimeEnvironmentId,
+      String releaseState,
       String desiredState,
-      String observedState) {
+      String observedState,
+      int definitionVersion,
+      Integer publishedVersion) {
     return new DefinitionRow(
         JOB_ID,
         "test-job",
         null,
         spec,
-        environment.id(),
-        "PUBLISHED",
+        runtimeEnvironmentId,
+        releaseState,
         desiredState,
         observedState,
-        1,
-        1,
+        definitionVersion,
+        publishedVersion,
         "definition-digest",
         null,
         LocalDateTime.now(),
@@ -230,12 +366,16 @@ class RealtimeExecutionPathTest {
   }
 
   private DeploymentRow deployment(
-      CdcPipelineSpec spec, ComputeEnvironmentSnapshot environment) {
+      CdcPipelineSpec spec,
+      ComputeEnvironmentSnapshot environment,
+      Long definitionVersionId,
+      int sourceDraftRevision) {
     LocalDateTime now = LocalDateTime.now();
     return new DeploymentRow(
         DEPLOYMENT_ID,
         JOB_ID,
-        1,
+        definitionVersionId,
+        sourceDraftRevision,
         spec,
         "mysql#1 -> mysql#2, tables=1",
         "pipeline-digest",

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
@@ -35,6 +35,7 @@ import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.Validation
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +47,7 @@ class RealtimeJobServiceConcurrencyTest {
 
   private static final long JOB_ID = 7L;
   private static final long DEPLOYMENT_ID = 19L;
+  private static final long DEFINITION_VERSION_ID = 31L;
 
   private RealtimeJobStore store;
   private CdcPipelineSpecValidator specValidator;
@@ -101,6 +103,7 @@ class RealtimeJobServiceConcurrencyTest {
     stopped = definition("STOPPED", "STOPPED");
     when(store.spec(any())).thenReturn(spec);
     when(store.runtimeEnvironmentId(JOB_ID)).thenReturn(environment.id());
+    when(store.publishedDefinition(JOB_ID)).thenReturn(Optional.of(published()));
 
     service = new RealtimeJobService(
         store,
@@ -130,6 +133,21 @@ class RealtimeJobServiceConcurrencyTest {
   }
 
   @Test
+  void refusesLegacyPublishedMarkerWithoutImmutablePublishedReference() {
+    when(store.deploymentByIdempotencyKey("no-ref")).thenReturn(Optional.empty());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
+    when(store.publishedDefinition(JOB_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.start(JOB_ID, "no-ref"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请先发布至少一个可运行的定义版本");
+
+    verify(compiler, never()).compile(any(), any(), any());
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
   void cancelsSubmittedJobWhenStopWinsDuringCliSubmission() {
     DefinitionRow stopping = definition("STOPPED", "STOPPING");
     DeploymentRow deployment = deployment("job-123", "STOPPING");
@@ -153,10 +171,52 @@ class RealtimeJobServiceConcurrencyTest {
 
     assertThatCode(() -> service.start(JOB_ID, "restart-safe")).doesNotThrowAnyException();
 
+    verify(store)
+        .bindDeploymentDefinitionVersion(DEPLOYMENT_ID, DEFINITION_VERSION_ID, 1);
     verify(store, never()).markDeploymentRunning(anyLong(), anyLong(), any(), any());
     verify(store).bindDeploymentForStop(DEPLOYMENT_ID, "job-123", "flink-cdc-cli-3.6.0@env-3-v2");
     verify(gateway).stop(environment, "job-123");
     verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", "job-123", null);
+  }
+
+  @Test
+  void restartRefusesToSilentlySwitchPublishedVersion() {
+    PublishedDefinitionRow original = published();
+    PublishedDefinitionRow changed =
+        new PublishedDefinitionRow(
+            DEFINITION_VERSION_ID + 1,
+            JOB_ID,
+            2,
+            2,
+            spec,
+            environment.id(),
+            "c".repeat(64),
+            "d".repeat(64));
+    when(store.deploymentByIdempotencyKey("restart-pin")).thenReturn(Optional.empty());
+    when(store.publishedDefinition(JOB_ID))
+        .thenReturn(Optional.of(original), Optional.of(changed));
+    when(store.lockDefinition(JOB_ID)).thenReturn(stopped);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.empty());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
+
+    assertThatThrownBy(() -> service.restart(JOB_ID, "restart-pin"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("重启期间已发布版本发生变化");
+
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  private PublishedDefinitionRow published() {
+    return new PublishedDefinitionRow(
+        DEFINITION_VERSION_ID,
+        JOB_ID,
+        1,
+        1,
+        spec,
+        environment.id(),
+        "a".repeat(64),
+        "b".repeat(64));
   }
 
   private DefinitionRow definition(String desired, String observed) {
@@ -181,6 +241,7 @@ class RealtimeJobServiceConcurrencyTest {
     return new DeploymentRow(
         DEPLOYMENT_ID,
         JOB_ID,
+        DEFINITION_VERSION_ID,
         1,
         spec,
         "test",

--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
@@ -45,7 +45,7 @@ export default function RealtimeExecutionPanel({
   useEffect(() => {
     let cancelled = false;
     realtimeApi
-      .capabilities(job.runtimeEnvironmentId)
+      .capabilities(current.runtimeEnvironmentId)
       .then((response) => {
         if (!cancelled) setCapabilities(response.data || {});
       })
@@ -55,7 +55,7 @@ export default function RealtimeExecutionPanel({
     return () => {
       cancelled = true;
     };
-  }, [job.runtimeEnvironmentId]);
+  }, [current.runtimeEnvironmentId]);
 
   const refreshJob = async () => {
     const response = await realtimeApi.detail(current.id);
@@ -116,14 +116,17 @@ export default function RealtimeExecutionPanel({
     }
   };
 
-  const published =
+  const hasPublishedVersion = current.publishedVersion != null;
+  const currentDraftPublished =
     current.releaseState === 'PUBLISHED' && current.publishedVersion === current.definitionVersion;
+  const hasUnpublishedChanges = hasPublishedVersion && !currentDraftPublished;
   const running = current.desiredState === 'RUNNING';
   const startable =
-    published &&
+    hasPublishedVersion &&
     current.desiredState === 'STOPPED' &&
     ['STOPPED', 'FAILED'].includes(current.observedState);
   const runtimeDisabled = capabilities.deployEnabled === false;
+  const blockStartForDisplayedRuntime = currentDraftPublished && runtimeDisabled;
   const runtimeDisabledReason = capabilities.deployDisabledReason || '当前运行环境不可提交任务';
 
   const steps = useMemo(
@@ -136,28 +139,38 @@ export default function RealtimeExecutionPanel({
       {
         title: '运行校验',
         description: 'Flink CDC / Connector',
-        status: validated || published || running ? ('finish' as const) : ('process' as const),
+        status: validated || currentDraftPublished || running ? ('finish' as const) : ('process' as const),
       },
       {
         title: '发布版本',
-        description: published ? `已发布 v${current.publishedVersion}` : '锁定当前定义版本',
-        status: published || running
+        description: currentDraftPublished
+          ? `已发布 v${current.publishedVersion}`
+          : hasPublishedVersion
+            ? `已发布 v${current.publishedVersion} · 当前草稿未发布`
+            : '锁定当前定义版本',
+        status: currentDraftPublished || running
           ? ('finish' as const)
           : validated
             ? ('process' as const)
-            : ('wait' as const),
+            : hasPublishedVersion
+              ? ('finish' as const)
+              : ('wait' as const),
       },
       {
         title: '启动任务',
-        description: running ? stateLabel[current.observedState] || current.observedState : '提交到 Flink CDC',
+        description: running
+          ? stateLabel[current.observedState] || current.observedState
+          : hasUnpublishedChanges
+            ? `将启动已发布 v${current.publishedVersion}`
+            : '提交到 Flink CDC',
         status: current.observedState === 'RUNNING'
           ? ('finish' as const)
-          : published
+          : hasPublishedVersion
             ? ('process' as const)
             : ('wait' as const),
       },
     ],
-    [current, published, running, validated],
+    [current, currentDraftPublished, hasPublishedVersion, hasUnpublishedChanges, running, validated],
   );
 
   return (
@@ -172,7 +185,8 @@ export default function RealtimeExecutionPanel({
               </div>
               <h1 className="mb-0 mt-1 text-[20px] font-semibold text-[#101828]">{current.name}</h1>
               <div className="mt-1 text-[12px] text-[#98a2b3]">
-                任务 ID：{current.id} · 定义版本 v{current.definitionVersion}
+                任务 ID：{current.id} · 当前草稿 v{current.definitionVersion}
+                {hasPublishedVersion ? ` · 已发布 v${current.publishedVersion}` : ''}
               </div>
             </div>
             <Space>
@@ -189,12 +203,22 @@ export default function RealtimeExecutionPanel({
             <Steps responsive items={steps} />
           </Card>
 
-          {runtimeDisabled && (
+          {hasUnpublishedChanges && (
+            <Alert
+              className="mb-5"
+              type="info"
+              showIcon
+              message={`当前草稿 v${current.definitionVersion} 尚未发布`}
+              description={`点击“启动任务”会运行已发布版本 v${current.publishedVersion}；当前草稿及其运行环境配置不会影响这次启动。`}
+            />
+          )}
+
+          {runtimeDisabled && currentDraftPublished && (
             <Alert
               className="mb-5"
               type="warning"
               showIcon
-              message="当前运行环境暂不可提交任务"
+              message="当前已发布版本绑定的运行环境暂不可提交任务"
               description={runtimeDisabledReason}
             />
           )}
@@ -209,7 +233,7 @@ export default function RealtimeExecutionPanel({
                         <SafetyOutlined /> 1. 校验运行环境
                       </div>
                       <div className="mt-1 text-[12px] leading-5 text-[#667085]">
-                        使用任务绑定的运行环境执行 Flink CDC CLI / REST readiness 和 Connector 校验。
+                        校验当前草稿绑定的运行环境和 Connector；启动时后端会再次按实际 Published Version 独立校验。
                       </div>
                     </div>
                     <Button
@@ -229,16 +253,16 @@ export default function RealtimeExecutionPanel({
                         <CloudServerOutlined /> 2. 发布当前版本
                       </div>
                       <div className="mt-1 text-[12px] leading-5 text-[#667085]">
-                        发布会再次运行完整校验，并锁定当前 definitionVersion / configDigest。
+                        发布会再次运行完整校验，并创建不可变的 DefinitionVersion。
                       </div>
                     </div>
                     <Button
                       type="primary"
                       loading={acting === 'publish'}
-                      disabled={Boolean(acting) || published || running || !current.spec || runtimeDisabled}
+                      disabled={Boolean(acting) || currentDraftPublished || running || !current.spec || runtimeDisabled}
                       onClick={() => void run('publish')}
                     >
-                      {published ? '已发布' : '发布当前版本'}
+                      {currentDraftPublished ? '已发布' : '发布当前版本'}
                     </Button>
                   </div>
                 </div>
@@ -250,7 +274,7 @@ export default function RealtimeExecutionPanel({
                         <PlayCircleOutlined /> 3. 启动实时任务
                       </div>
                       <div className="mt-1 text-[12px] leading-5 text-[#667085]">
-                        启动只读取已发布的统一 Spec，由 PipelineYamlCompiler 生成临时 Flink CDC YAML 后通过 LOCAL / SSH 提交。
+                        启动只读取不可变的 Published DefinitionVersion，由 PipelineYamlCompiler 生成临时 Flink CDC YAML 后通过 LOCAL / SSH 提交。
                       </div>
                     </div>
                     {running ? (
@@ -269,10 +293,10 @@ export default function RealtimeExecutionPanel({
                         danger
                         icon={<PlayCircleOutlined />}
                         loading={acting === 'start'}
-                        disabled={Boolean(acting) || !startable || runtimeDisabled}
+                        disabled={Boolean(acting) || !startable || blockStartForDisplayedRuntime}
                         onClick={() => void run('start')}
                       >
-                        启动任务
+                        {hasUnpublishedChanges ? `启动已发布 v${current.publishedVersion}` : '启动任务'}
                       </Button>
                     )}
                   </div>
@@ -283,13 +307,16 @@ export default function RealtimeExecutionPanel({
             <div className="space-y-5">
               <Card title="当前执行状态">
                 <Descriptions size="small" column={1}>
-                  <Descriptions.Item label="发布状态">
-                    <Tag>{current.releaseState}</Tag>
+                  <Descriptions.Item label="当前草稿">
+                    v{current.definitionVersion} · {current.releaseState}
+                  </Descriptions.Item>
+                  <Descriptions.Item label="已发布版本">
+                    {hasPublishedVersion ? `v${current.publishedVersion}` : '未发布'}
                   </Descriptions.Item>
                   <Descriptions.Item label="运行状态">
                     <Tag>{stateLabel[current.observedState] || current.observedState}</Tag>
                   </Descriptions.Item>
-                  <Descriptions.Item label="运行环境">
+                  <Descriptions.Item label="当前草稿运行环境">
                     {capabilities.runtimeEnvironmentName || `环境 #${current.runtimeEnvironmentId}`}
                   </Descriptions.Item>
                   <Descriptions.Item label="提交方式">
@@ -317,7 +344,7 @@ export default function RealtimeExecutionPanel({
                 type="info"
                 showIcon
                 message="Wizard 与 YAML 共用这一条执行链路"
-                description="编辑方式不会写入任务运行定义。发布和启动只认同一份 CdcPipelineSpec；数据库不保存原生 Flink CDC YAML。"
+                description="编辑方式不会写入任务运行定义。发布形成不可变 DefinitionVersion；启动只读取该版本快照，数据库不保存原生 Flink CDC YAML。"
               />
             </div>
           </div>

--- a/yak-ops-ui/src/pages/realtime-sync/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/index.tsx
@@ -534,15 +534,20 @@ export default function RealtimeSync() {
       render: (_, job) => {
         const running = job.desiredState === 'RUNNING';
         const environment = boundEnvironment(job);
-        const environmentDisabled = environment?.enabled === false;
-        const startDisabled = job.releaseState !== 'PUBLISHED' || running || environmentDisabled;
+        const hasPublishedVersion = job.publishedVersion != null;
+        const currentDraftIsPublished =
+          job.releaseState === 'PUBLISHED' && job.publishedVersion === job.definitionVersion;
+        const environmentDisabled = currentDraftIsPublished && environment?.enabled === false;
+        const startDisabled = !hasPublishedVersion || running || environmentDisabled;
         const startTooltip = environmentDisabled
-          ? `运行环境“${environment?.name}”已停用，请先编辑任务切换环境`
-          : job.releaseState !== 'PUBLISHED'
-            ? '请先发布当前任务版本'
+          ? `运行环境“${environment?.name}”已停用，请先编辑任务切换环境并重新发布`
+          : !hasPublishedVersion
+            ? '请先发布至少一个任务版本'
             : running
               ? '任务已处于运行期望状态'
-              : undefined;
+              : !currentDraftIsPublished
+                ? `当前草稿尚未发布，将启动已发布版本 v${job.publishedVersion}`
+                : undefined;
 
         return (
           <div className="flex min-h-7 items-center gap-0.5 whitespace-nowrap">


### PR DESCRIPTION
## 背景

Realtime Sync Stage 6 的 Wave 0/1 已在 #638 合入 `main`：

```text
Wave 0  Core VO + legacy compatibility mapper
Wave 1  immutable DefinitionVersion persistence + Publish dual-write
```

本 PR 继续严格执行 **Wave 2：Start by Published DefinitionVersion**。

目标只有一个：

> Start 不再从 `RealtimeSyncTask` 当前 mutable Draft 读取运行配置，而是从 `published_definition_version_id` 指向的 immutable DefinitionVersion snapshot 读取 Spec 和 RuntimeEnvironmentRef。

本 PR **不提前执行 Wave 3～6**。

## Domain Impact Analysis

```text
Bounded Context: Realtime Sync
Aggregate(s): RealtimeSyncTask + DefinitionVersion + SyncExecution creation boundary
SyncDefinition Area: 不新增配置字段，只改变 Start 的定义读取来源
Invariant/Lifecycle:
  - Start 只能读取 PublishedDefinitionRef
  - newer Draft 不得改变已发布版本的启动语义
Layer: Application + Repository read path + execution evidence persistence + UI projection
Stage-4 Gap:
  - GAP-02 Published + newer Draft coexistence
  - GAP-03 Start by DefinitionVersionRef
Migration Wave: Wave 2
Safety:
  - Idempotency-Key 保留
  - start reservation / DB CAS 保留
  - stop-during-start 保留
  - UNKNOWN / CONFLICT 保留
  - RuntimeEnvironmentSnapshot 保留
  - runtime identity recovery 保留
  - submission-scoped credential / zeroization 保留
  - Flink / SSH path 不重写
Domain Gap: no
```

---

## 1. Start 改为读取 immutable Published Definition

新增 `RealtimeJobStore.PublishedDefinitionRow` 只读投影：

```text
id                     DefinitionVersionId
taskId
versionNo               immutable published version sequence
sourceDraftRevision     legacy DraftRevision evidence
spec                    immutable compatibility snapshot
runtimeEnvironmentId    Published RuntimeEnvironmentRef
sourceConfigDigest
definitionDigest
```

`VersioningRealtimeJobStore.publishedDefinition(taskId)`：

```text
Task.published_definition_version_id
        ↓
DefinitionVersionRepository
        ↓
immutable PublicationSnapshot
        ↓
PublishedDefinitionRow
```

同时校验：

```text
DefinitionVersion.taskId == requested TaskId
```

禁止跨 Task 绑定错误版本。

## 2. preparePublished() 成为 Start 唯一配置入口

`RealtimeJobService.start()` 现在走：

```text
Start
 ↓
preparePublished(taskId)
 ↓
PublishedDefinitionRow.spec
 ↓
PublishedDefinitionRow.runtimeEnvironmentId
 ↓
DataSource resolve
Connector capability
PipelineYamlCompiler
Gateway validate
 ↓
Start reservation
 ↓
credential resolve
Flink/SSH deploy
```

当前 Task Draft 只继续提供：

```text
Task identity/name
Desired/Observed compatibility state
```

不会再参与：

```text
runtime Spec
runtime environment
connector resolution
credential resolution
compiled pipeline
```

## 3. Published V1 + Draft V2 可以真正启动 V1

这是 Wave 2 最核心的行为变化。

例如：

```text
Published Definition V1
  spec = orders
  runtime env = #3

Current Draft V2
  spec = orders_v2
  runtime env = #4
  releaseState = DRAFT
```

Start 现在明确使用：

```text
Published V1 spec
Published V1 RuntimeEnvironmentRef #3
```

不会读取：

```text
Draft V2 spec
Draft V2 environment #4
```

因此阶段 2/3 的领域关系开始真正进入运行链路：

```text
RealtimeSyncTask.currentDraft
        ≠
SyncExecution.definitionVersionRef
```

## 4. Start reservation 内再次确认 Published Ref

外部 preflight 与真正创建 deployment 之间可能发生并发变化。

因此 Start transaction 内会再次读取：

```text
current PublishedDefinitionRef
```

并与 preflight snapshot 比较：

```text
DefinitionVersionId
taskId
sourceDraftRevision
sourceConfigDigest
```

如果发生变化：

```text
已发布定义在校验期间已变化，请刷新后重试
```

不会把 A 版本校验结果用于 B 版本提交。

## 5. Deployment 保存明确的 DefinitionVersion evidence

仅从 Published Version 编译还不够。

原实现创建 Deployment 时：

```text
deployment.definition_version = current Task.definition_version
```

而当前 `definition_version` 实际是 DraftRevision。

在：

```text
Published V1(sourceDraftRevision=1)
+
Draft revision=2
```

场景下会出现错误证据：

```text
spec snapshot = Published V1
deployment.definition_version = 2  // wrong
```

所以本 PR 给：

```text
yak_realtime_job_deployment
```

新增：

```text
definition_version_id BIGINT NULL
```

形成证据链：

```text
Task.published_definition_version_id
       ↓
DefinitionVersion.id
       ↓
Deployment.definition_version_id
```

Start reservation 创建后、进入外部提交前，在同一事务中调用：

```text
bindDeploymentDefinitionVersion(
  deploymentId,
  publishedDefinitionVersionId,
  published.sourceDraftRevision
)
```

同时 legacy `deployment.definition_version` 会改写为该 Published Version 的 `sourceDraftRevision`，避免继续误写当前 DraftRevision。

> `definition_version_id` 在 Wave 2 仍允许 NULL，以兼容历史 Deployment；Wave 3 再把 Deployment 正式演进为 SyncExecution persistence。

## 6. 没有 immutable ref 时绝不 fallback 到 Draft

即使 legacy row 仍然是：

```text
releaseState = PUBLISHED
publishedVersion != null
```

只要：

```text
published_definition_version_id
```

不存在，Start 就拒绝：

```text
请先发布至少一个可运行的定义版本
```

不会为了 legacy 兼容重新读取 mutable `spec_json`。

当前 realtime 模块使用 consolidated baseline；旧开发数据库仍按模块 README 的既有约定重置 realtime schema/history 后初始化。

## 7. Restart 增加 Wave-2 过渡保护

正式 `RestartExecution(oldExecution.versionRef)` 属于 Wave 5。

但 Wave 2 把 Start 改为 current Published Ref 后，必须避免在过渡期引入“Restart 偷偷升级”的回归。

因此当前 Restart 会：

```text
记录 restart 开始时的 Published DefinitionVersionId
 ↓
执行原有 stop
 ↓
再次 startLocked(expectedPublishedDefinitionVersionId)
```

如果期间 Published Ref 发生变化：

```text
重启期间已发布版本发生变化，请刷新后重新操作
```

它会拒绝继续，而不是拿新版本启动。

当前 Wave 4 还未执行，所以运行中仍不能编辑/发布；这个 pin 是 Wave 2→Wave 5 的防御性保护，不替代 Wave 5 的最终模型。

## 8. UI 与 Wave 2 语义对齐

### 列表页

旧逻辑：

```text
releaseState == PUBLISHED 才允许 Start
```

这会错误阻止：

```text
Published V1 + Draft V2
```

现在改为：

```text
存在 publishedVersion compatibility projection
  -> UI 允许发起 Start
  -> 后端以 immutable Published Ref 为最终权威
```

当当前 Draft 尚未发布时，Tooltip 明确提示会启动已发布版本。

如果当前 Draft 与 Published 相同，仍可使用当前页面已加载的运行环境能力提前禁用按钮；如果 Draft 已经变化，当前 Draft 的环境状态不再用于阻断旧 Published Version，后端会按 Published RuntimeEnvironmentRef 做权威校验。

### RealtimeExecutionPanel

现在分别展示：

```text
当前草稿
已发布版本
运行状态
```

存在 newer Draft 时显示提示：

```text
当前草稿尚未发布；启动会运行已发布版本，当前草稿及其运行环境不会影响这次启动。
```

启动按钮不再要求“当前 Draft 就是 Published”。

## 9. Protection List 保持不变

本 PR没有重写：

```text
Idempotency-Key
unique idempotency persistence
DB lifecycle lock / CAS
start reservation before external submit
same-key race recovery
stop-during-start
submission uncertainty -> UNKNOWN
CONFLICT
runtime identity recovery
RuntimeEnvironmentSnapshot
submission-scoped credentials / zeroization
FlinkCdcEngineGateway
SshFlinkCdcCommandRunner
log redaction
reconcile lease
```

`desiredState / observedState` 仍然是 legacy Task-row ownership，等待 Wave 3。

---

## 测试改动

### RealtimeExecutionPathTest

新增/增强：

1. current Draft 未变化时 Publish/Start 仍编译同一 pipeline；
2. **Published V1 + Draft V2** 时：
   - compiler 只接收 Published V1；
   - 不编译 Draft V2；
   - runtime resolver 只解析 Published env；
   - 不解析 Draft env；
   - Deployment snapshot 使用 Published V1；
   - Deployment 绑定 immutable DefinitionVersionId。

### RealtimeJobServiceConcurrencyTest

继续保护：

- another instance STARTING 时不能重复启动；
- stop-during-start 仍会取消刚提交的准确 Flink Job；
- Start reservation 会绑定 DefinitionVersion evidence；
- Restart 期间 Published Ref 改变时拒绝继续，避免静默升级；
- legacy PUBLISHED marker 没有 immutable ref 时拒绝 Start，不 fallback Draft。

### VersioningRealtimeJobStoreTest

新增：

- Task Published Ref 能正确解析 immutable PublicationSnapshot；
- DefinitionVersion 属于其他 Task 时拒绝返回。

## 验证说明

当前执行环境无法解析 `github.com`，因此无法把分支 clone/materialize 到本地执行完整 Maven / Yarn 构建。

本 PR 已做源码级路径审查和测试补充，但：

**不声明 Maven、Jest、tsc 或完整 CI 已通过。**

创建 PR 后会继续检查 GitHub 是否触发 workflow/status。

---

## 本 PR 明确不做

```text
Wave 3  Deployment -> SyncExecution + desired/observed ownership
Wave 4  运行中编辑/发布
Wave 5  正式 RestartExecution vs ApplyPublishedVersion
Wave 6  legacy field/package/name cleanup
```

也不处理：

- audit-safe deletion；
- checkpoint/restart ExecutionPolicy runtime gap；
- FINISHED normal completion / snapshot-only；
- Compute Environment package ownership；
- Deployment `configDigest` semantic rename；
- public API 暴露 `DefinitionVersionId`。

---

## Domain Compliance Report

```text
Domain rule implemented:
  Start reads immutable Published DefinitionVersion only.

Aggregate(s) changed:
  RealtimeSyncTask PublishedDefinitionRef read boundary
  DefinitionVersion read boundary
  SyncExecution/Deployment creation evidence

Invariant/lifecycle changes:
  newer Draft no longer changes Start configuration
  no immutable Published Ref => no Start
  restart cannot silently switch ref during operation

Legacy compatibility kept:
  releaseState / publishedVersion projection
  CdcPipelineSpec compatibility snapshot
  legacy deployment.definition_version column
  existing Start/Stop runtime state ownership

Safety properties preserved:
  idempotency / CAS / reservation / concurrent stop
  UNKNOWN / CONFLICT
  runtime identity recovery
  RuntimeEnvironmentSnapshot
  credentials / Flink / SSH / logging paths

DB migration mode:
  expand only; definition_version_id added, no drop/rename

Tests added/updated:
  published-vs-draft execution path
  immutable ref resolution
  no-fallback rule
  restart pin
  existing concurrency protections

Known gaps remaining:
  Wave 3+
```

## Branch

```text
feat/realtime-sync-domain-stage-6-wave-2
```

分支基于合并 #638 后的最新 `main`；开 PR 前已 squash 为单一 commit，并确认 `behind_by=0`。