### PR TITLE
refactor: make realtime execution lifecycle authoritative

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/RealtimeJobDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/RealtimeJobDao.java
@@ -26,6 +26,7 @@ public interface RealtimeJobDao {
   void markStopping(long definitionId, Long deploymentId);
   void reconcile(long definitionId, Long deploymentId, String observedState, String deploymentState, String engineJobId, String error);
   void markTerminalFailure(long definitionId, Long deploymentId, String message);
+  List<RealtimeJobDeploymentPO> reconcileExecutions();
   List<RealtimeJobDefinitionPO> desiredJobs();
   boolean hasOtherDesiredRunning(long id);
   int deleteDefinition(long id);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
@@ -58,8 +58,6 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, id)
-            .eq(RealtimeJobDefinitionPO::getDesiredState, "STOPPED")
-            .in(RealtimeJobDefinitionPO::getObservedState, List.of("STOPPED", "FAILED"))
             .set(RealtimeJobDefinitionPO::getJobName, name)
             .set(RealtimeJobDefinitionPO::getDescription, description)
             .set(RealtimeJobDefinitionPO::getRuntimeEnvironmentId, environmentId)
@@ -75,8 +73,6 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, id)
-            .eq(RealtimeJobDefinitionPO::getDesiredState, "STOPPED")
-            .in(RealtimeJobDefinitionPO::getObservedState, List.of("STOPPED", "FAILED"))
             .eq(RealtimeJobDefinitionPO::getDefinitionVersion, expectedDefinitionVersion)
             .eq(RealtimeJobDefinitionPO::getConfigDigest, expectedDigest)
             .set(RealtimeJobDefinitionPO::getReleaseState, "PUBLISHED")
@@ -149,8 +145,6 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, definitionId)
-            .eq(RealtimeJobDefinitionPO::getDesiredState, "STOPPED")
-            .in(RealtimeJobDefinitionPO::getObservedState, List.of("STOPPED", "FAILED"))
             .set(RealtimeJobDefinitionPO::getDesiredState, "RUNNING")
             .set(RealtimeJobDefinitionPO::getObservedState, "STARTING")
             .set(RealtimeJobDefinitionPO::getLastError, null));
@@ -159,24 +153,31 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
   @Override
   public int markDeploymentRunning(
       long definitionId, long deploymentId, String engineJobId, String runtimeRevision) {
-    deploymentMapper.update(
-        null,
-        Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
-            .eq(RealtimeJobDeploymentPO::getId, deploymentId)
-            .set(RealtimeJobDeploymentPO::getGatewayJobId, engineJobId)
-            .set(RealtimeJobDeploymentPO::getRuntimeVersion, runtimeRevision)
-            .set(RealtimeJobDeploymentPO::getRuntimeRevision, runtimeRevision)
-            .set(RealtimeJobDeploymentPO::getStatus, "RUNNING")
-            .set(RealtimeJobDeploymentPO::getResultUncertain, false)
-            .set(RealtimeJobDeploymentPO::getErrorMessage, null));
-    return definitionMapper.update(
+    int executionUpdated =
+        deploymentMapper.update(
+            null,
+            Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
+                .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+                .eq(RealtimeJobDeploymentPO::getDesiredState, "RUNNING")
+                .eq(RealtimeJobDeploymentPO::getObservedState, "STARTING")
+                .set(RealtimeJobDeploymentPO::getGatewayJobId, engineJobId)
+                .set(RealtimeJobDeploymentPO::getRuntimeVersion, runtimeRevision)
+                .set(RealtimeJobDeploymentPO::getRuntimeRevision, runtimeRevision)
+                .set(RealtimeJobDeploymentPO::getObservedState, "RUNNING")
+                .set(RealtimeJobDeploymentPO::getStatus, "RUNNING")
+                .set(RealtimeJobDeploymentPO::getResultUncertain, false)
+                .set(RealtimeJobDeploymentPO::getErrorMessage, null));
+    if (executionUpdated != 1) return executionUpdated;
+
+    definitionMapper.update(
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, definitionId)
-            .eq(RealtimeJobDefinitionPO::getDesiredState, "RUNNING")
-            .eq(RealtimeJobDefinitionPO::getObservedState, "STARTING")
+            .set(RealtimeJobDefinitionPO::getDesiredState, "RUNNING")
             .set(RealtimeJobDefinitionPO::getObservedState, "RUNNING")
             .set(RealtimeJobDefinitionPO::getLastError, null));
+    return executionUpdated;
   }
 
   @Override
@@ -200,38 +201,49 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       boolean uncertain,
       boolean stopRequested,
       String message) {
+    String desiredState = stopRequested ? "STOPPED" : (uncertain ? "RUNNING" : "STOPPED");
+    String observedState = uncertain ? "UNKNOWN" : "FAILED";
     deploymentMapper.update(
         null,
         Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
             .eq(RealtimeJobDeploymentPO::getId, deploymentId)
-            .set(RealtimeJobDeploymentPO::getStatus, uncertain ? "UNKNOWN" : "FAILED")
+            .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+            .set(RealtimeJobDeploymentPO::getDesiredState, desiredState)
+            .set(RealtimeJobDeploymentPO::getObservedState, observedState)
+            .set(RealtimeJobDeploymentPO::getStatus, observedState)
             .set(RealtimeJobDeploymentPO::getResultUncertain, uncertain)
             .set(RealtimeJobDeploymentPO::getErrorMessage, message));
-    String desiredState = stopRequested ? "STOPPED" : (uncertain ? "RUNNING" : "STOPPED");
     definitionMapper.update(
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, definitionId)
             .set(RealtimeJobDefinitionPO::getDesiredState, desiredState)
-            .set(RealtimeJobDefinitionPO::getObservedState, uncertain ? "UNKNOWN" : "FAILED")
+            .set(RealtimeJobDefinitionPO::getObservedState, observedState)
             .set(RealtimeJobDefinitionPO::getLastError, message));
   }
 
   @Override
   public void markStopping(long definitionId, Long deploymentId) {
+    if (deploymentId != null) {
+      int updated =
+          deploymentMapper.update(
+              null,
+              Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
+                  .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                  .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+                  .set(RealtimeJobDeploymentPO::getDesiredState, "STOPPED")
+                  .set(RealtimeJobDeploymentPO::getObservedState, "STOPPING")
+                  .set(RealtimeJobDeploymentPO::getStatus, "STOPPING"));
+      if (updated != 1) {
+        throw new IllegalStateException("Execution 不存在或已变化，无法记录停止意图：" + deploymentId);
+      }
+    }
     definitionMapper.update(
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, definitionId)
             .set(RealtimeJobDefinitionPO::getDesiredState, "STOPPED")
-            .set(RealtimeJobDefinitionPO::getObservedState, "STOPPING"));
-    if (deploymentId != null) {
-      deploymentMapper.update(
-          null,
-          Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
-              .eq(RealtimeJobDeploymentPO::getId, deploymentId)
-              .set(RealtimeJobDeploymentPO::getStatus, "STOPPING"));
-    }
+            .set(RealtimeJobDefinitionPO::getObservedState, deploymentId == null ? "STOPPED" : "STOPPING"));
   }
 
   @Override
@@ -242,19 +254,31 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       String deploymentState,
       String engineJobId,
       String error) {
+    if (deploymentId != null) {
+      commandMapper.reconcileDeployment(
+          deploymentId, observedState, deploymentState, engineJobId, error);
+    }
     definitionMapper.update(
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, definitionId)
             .set(RealtimeJobDefinitionPO::getObservedState, observedState)
             .set(RealtimeJobDefinitionPO::getLastError, error));
-    if (deploymentId != null) {
-      commandMapper.reconcileDeployment(deploymentId, deploymentState, engineJobId, error);
-    }
   }
 
   @Override
   public void markTerminalFailure(long definitionId, Long deploymentId, String message) {
+    if (deploymentId != null) {
+      deploymentMapper.update(
+          null,
+          Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
+              .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+              .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+              .set(RealtimeJobDeploymentPO::getDesiredState, "STOPPED")
+              .set(RealtimeJobDeploymentPO::getObservedState, "FAILED")
+              .set(RealtimeJobDeploymentPO::getStatus, "FAILED")
+              .set(RealtimeJobDeploymentPO::getErrorMessage, message));
+    }
     definitionMapper.update(
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
@@ -262,27 +286,24 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
             .set(RealtimeJobDefinitionPO::getDesiredState, "STOPPED")
             .set(RealtimeJobDefinitionPO::getObservedState, "FAILED")
             .set(RealtimeJobDefinitionPO::getLastError, message));
-    if (deploymentId != null) {
-      deploymentMapper.update(
-          null,
-          Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
-              .eq(RealtimeJobDeploymentPO::getId, deploymentId)
-              .set(RealtimeJobDeploymentPO::getStatus, "FAILED")
-              .set(RealtimeJobDeploymentPO::getErrorMessage, message));
-    }
+  }
+
+  @Override
+  public List<RealtimeJobDeploymentPO> reconcileExecutions() {
+    return commandMapper.reconcileExecutions();
   }
 
   @Override
   public List<RealtimeJobDefinitionPO> desiredJobs() {
-    return definitionMapper.selectList(
-        Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
-            .and(q ->
-                q.eq(RealtimeJobDefinitionPO::getDesiredState, "RUNNING")
-                    .or()
-                    .in(
-                        RealtimeJobDefinitionPO::getObservedState,
-                        List.of("STARTING", "STOPPING", "UNKNOWN", "CONFLICT")))
-            .orderByAsc(RealtimeJobDefinitionPO::getId));
+    List<Long> ids =
+        reconcileExecutions().stream()
+            .map(RealtimeJobDeploymentPO::getDefinitionId)
+            .distinct()
+            .toList();
+    if (ids.isEmpty()) return List.of();
+    return definitionMapper.selectBatchIds(ids).stream()
+        .sorted((left, right) -> Long.compare(left.getId(), right.getId()))
+        .toList();
   }
 
   @Override
@@ -292,13 +313,12 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public int deleteDefinition(long id) {
-    int deleted = definitionMapper.delete(
-        Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
-            .eq(RealtimeJobDefinitionPO::getId, id)
-            .eq(RealtimeJobDefinitionPO::getDesiredState, "STOPPED")
-            .in(RealtimeJobDefinitionPO::getObservedState, List.of("STOPPED", "FAILED")));
+    int deleted =
+        definitionMapper.delete(
+            Wrappers.<RealtimeJobDefinitionPO>lambdaQuery().eq(RealtimeJobDefinitionPO::getId, id));
     if (deleted != 1) return deleted;
 
+    // Audit-safe deletion is tracked separately as GAP-08 and is intentionally not changed in Wave 3.
     eventMapper.delete(
         Wrappers.<RealtimeJobEventPO>lambdaQuery()
             .eq(RealtimeJobEventPO::getDefinitionId, id));
@@ -335,10 +355,11 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
             .eq(RealtimeJobDeploymentPO::getIdempotencyKey, idempotencyKey)
             .isNull(RealtimeJobDeploymentPO::getGatewayJobId)
             .eq(RealtimeJobDeploymentPO::getRuntimeIdentityState, "REQUIRED")
-            .and(q ->
-                q.isNull(RealtimeJobDeploymentPO::getRuntimeJobName)
-                    .or()
-                    .eq(RealtimeJobDeploymentPO::getRuntimeJobName, runtimeJobName))
+            .and(
+                q ->
+                    q.isNull(RealtimeJobDeploymentPO::getRuntimeJobName)
+                        .or()
+                        .eq(RealtimeJobDeploymentPO::getRuntimeJobName, runtimeJobName))
             .set(RealtimeJobDeploymentPO::getRuntimeJobName, runtimeJobName)
             .set(RealtimeJobDeploymentPO::getRuntimeIdentityState, "BOUND"));
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeJobCommandMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeJobCommandMapper.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.sync.realtime.dao.mapper;
 
 import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -9,9 +10,11 @@ import org.apache.ibatis.annotations.Param;
 public interface RealtimeJobCommandMapper {
   RealtimeJobDefinitionPO lockDefinition(@Param("id") long id);
   List<Long> lockOtherDesiredRunning(@Param("id") long id);
+  List<RealtimeJobDeploymentPO> reconcileExecutions();
   int tryAcquireLease(@Param("owner") String owner, @Param("leaseSeconds") int leaseSeconds);
   int reconcileDeployment(
       @Param("deploymentId") long deploymentId,
+      @Param("observedState") String observedState,
       @Param("deploymentState") String deploymentState,
       @Param("engineJobId") String engineJobId,
       @Param("error") String error);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
@@ -21,6 +21,9 @@ public class RealtimeJobDeploymentPO {
   private String specSummary;
   private String configDigest;
   private String idempotencyKey;
+  private String engineType;
+  private String desiredState;
+  private String observedState;
   private String runtimeJobName;
   private String runtimeIdentityState;
   private String gatewayJobId;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecution.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecution.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+
+/**
+ * Lifecycle core of one realtime-sync execution.
+ *
+ * <p>One execution represents exactly one run. STOPPED and FAILED executions are historical facts
+ * and are never resurrected. During Stage-6 migration {@code definitionVersionId} may be null only
+ * when reading a legacy historical deployment created before immutable DefinitionVersion evidence
+ * existed. Newly created executions are bound to a DefinitionVersion before external submission.
+ */
+public record SyncExecution(
+    long id,
+    long taskId,
+    Long definitionVersionId,
+    DesiredState desiredState,
+    ObservedState observedState,
+    EngineExecutionRef engineExecutionRef,
+    boolean resultUncertain,
+    String errorMessage) {
+
+  public SyncExecution {
+    if (id <= 0) throw new IllegalArgumentException("ExecutionId 必须大于 0");
+    if (taskId <= 0) throw new IllegalArgumentException("TaskId 必须大于 0");
+    if (definitionVersionId != null && definitionVersionId <= 0) {
+      throw new IllegalArgumentException("DefinitionVersionId 必须大于 0");
+    }
+    if (desiredState == null) throw new IllegalArgumentException("Execution DesiredState 不能为空");
+    if (observedState == null) throw new IllegalArgumentException("Execution ObservedState 不能为空");
+    if (engineExecutionRef == null) {
+      throw new IllegalArgumentException("EngineExecutionRef 不能为空");
+    }
+  }
+
+  public boolean terminal() {
+    return observedState == ObservedState.STOPPED || observedState == ObservedState.FAILED;
+  }
+
+  public boolean activeOrUncertain() {
+    return !terminal();
+  }
+
+  public boolean versioned() {
+    return definitionVersionId != null;
+  }
+
+  /** Engine-neutral execution reference. externalExecutionId is absent before the engine binds it. */
+  public record EngineExecutionRef(String engineType, String externalExecutionId) {
+    public EngineExecutionRef {
+      if (!hasText(engineType)) {
+        throw new IllegalArgumentException("EngineType 不能为空");
+      }
+      engineType = engineType.trim();
+      externalExecutionId = hasText(externalExecutionId) ? externalExecutionId.trim() : null;
+    }
+
+    public boolean bound() {
+      return hasText(externalExecutionId);
+    }
+
+    private static boolean hasText(String value) {
+      return value != null && !value.trim().isEmpty();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachine.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachine.java
@@ -1,0 +1,87 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** State machine for one immutable-identity SyncExecution. */
+@Component
+public class SyncExecutionStateMachine {
+
+  private final Map<ObservedState, EnumSet<ObservedState>> transitions =
+      new EnumMap<>(ObservedState.class);
+
+  public SyncExecutionStateMachine() {
+    allow(
+        ObservedState.STARTING,
+        ObservedState.RUNNING,
+        ObservedState.STOPPING,
+        ObservedState.FAILED,
+        ObservedState.UNKNOWN,
+        ObservedState.CONFLICT);
+    allow(
+        ObservedState.RUNNING,
+        ObservedState.STOPPING,
+        ObservedState.FAILED,
+        ObservedState.UNKNOWN,
+        ObservedState.CONFLICT);
+    allow(
+        ObservedState.STOPPING,
+        ObservedState.STOPPED,
+        ObservedState.FAILED,
+        ObservedState.UNKNOWN);
+    allow(
+        ObservedState.UNKNOWN,
+        ObservedState.RUNNING,
+        ObservedState.STOPPING,
+        ObservedState.STOPPED,
+        ObservedState.FAILED,
+        ObservedState.CONFLICT);
+    allow(
+        ObservedState.CONFLICT,
+        ObservedState.RUNNING,
+        ObservedState.STOPPING,
+        ObservedState.STOPPED,
+        ObservedState.FAILED,
+        ObservedState.UNKNOWN);
+    // STOPPED / FAILED intentionally have no outgoing transitions. A later run is a new execution.
+  }
+
+  public void requireTransition(SyncExecution execution, String targetValue) {
+    if (execution == null) throw new IllegalArgumentException("SyncExecution 不能为空");
+    ObservedState target = ObservedState.valueOf(targetValue);
+    requireTransition(execution.observedState(), target);
+  }
+
+  public void requireTransition(ObservedState from, ObservedState target) {
+    if (from == target) return;
+    if (!transitions.getOrDefault(from, EnumSet.noneOf(ObservedState.class)).contains(target)) {
+      throw new IllegalStateException("非法 SyncExecution 状态迁移：" + from + " -> " + target);
+    }
+  }
+
+  /** New execution creation is allowed only when no execution exists or the latest one is terminal. */
+  public void requireNewExecutionAllowed(SyncExecution latest) {
+    if (latest != null && latest.activeOrUncertain()) {
+      throw new IllegalStateException("任务已有启动中、运行中、停止中或状态不确定的 Execution，请勿重复启动");
+    }
+  }
+
+  /** Wave-3 keeps the old product policy: editing/publishing still requires a terminal execution. */
+  public void requireDefinitionMutable(SyncExecution latest) {
+    if (latest != null && latest.activeOrUncertain()) {
+      throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能编辑、发布或删除");
+    }
+  }
+
+  public boolean activeOrUncertain(SyncExecution execution) {
+    return execution != null && execution.activeOrUncertain();
+  }
+
+  private void allow(ObservedState from, ObservedState... targets) {
+    transitions.put(from, EnumSet.copyOf(Arrays.asList(targets)));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -4,12 +4,16 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobEventView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution.EngineExecutionRef;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-/** Domain-facing repository contract for realtime definitions, deployments and lifecycle evidence. */
+/** Compatibility persistence contract while Task / Version / Execution are migrated independently. */
 public interface RealtimeJobStore {
   long insertDefinition(String name, String description, CdcPipelineSpec spec, String digest, long runtimeEnvironmentId);
   void updateDefinition(long id, String name, String description, CdcPipelineSpec spec, String digest, long runtimeEnvironmentId);
@@ -27,6 +31,9 @@ public interface RealtimeJobStore {
   }
   Optional<DeploymentRow> deploymentByIdempotencyKey(String key);
   Optional<DeploymentRow> latestDeployment(long definitionId);
+  default Optional<SyncExecution> latestExecution(long definitionId) {
+    return latestDeployment(definitionId).map(DeploymentRow::execution);
+  }
   default Optional<ComputeEnvironmentSnapshot> deploymentEnvironment(long deploymentId) {
     return Optional.empty();
   }
@@ -42,7 +49,16 @@ public interface RealtimeJobStore {
   void markStopping(long definitionId, Long deploymentId);
   void reconcile(long definitionId, Long deploymentId, String observedState, String deploymentState, String engineJobId, String error);
   void markTerminalFailure(long definitionId, Long deploymentId, String message);
+
+  /** Active/uncertain executions that require authoritative runtime reconciliation. */
+  default List<DeploymentRow> reconcileCandidates() {
+    return List.of();
+  }
+
+  /** Legacy compatibility query. New runtime logic must use reconcileCandidates/latestExecution. */
+  @Deprecated
   List<DefinitionRow> desiredJobs();
+
   boolean hasOtherDesiredRunning(long id);
   void delete(long id);
   void event(long definitionId, Long deploymentId, String type, String from, String to, String message);
@@ -91,6 +107,10 @@ public interface RealtimeJobStore {
       LocalDateTime createTime,
       LocalDateTime updateTime) {}
 
+  /**
+   * Persistence/read compatibility row. From Wave 3 onward desiredState/observedState are the
+   * authoritative lifecycle fields; status remains a legacy submission/read projection.
+   */
   record DeploymentRow(
       long id,
       long definitionId,
@@ -103,13 +123,74 @@ public interface RealtimeJobStore {
       String engineJobId,
       String runtimeRevision,
       ComputeEnvironmentSnapshot runtimeEnvironment,
+      String engineType,
+      String desiredState,
+      String observedState,
       String status,
       boolean resultUncertain,
       String errorMessage,
       LocalDateTime createTime,
       LocalDateTime updateTime) {
 
-    /** Compatibility constructor for tests/callers created before Wave 2 added the immutable ref. */
+    public DeploymentRow {
+      engineType = hasText(engineType) ? engineType.trim() : "FLINK_CDC";
+      desiredState = hasText(desiredState) ? desiredState.trim() : legacyDesiredState(status);
+      observedState = hasText(observedState) ? observedState.trim() : legacyObservedState(status);
+    }
+
+    public SyncExecution execution() {
+      return new SyncExecution(
+          id,
+          definitionId,
+          definitionVersionId,
+          DesiredState.valueOf(desiredState),
+          ObservedState.valueOf(observedState),
+          new EngineExecutionRef(engineType, engineJobId),
+          resultUncertain,
+          errorMessage);
+    }
+
+    /** Compatibility constructor for Wave-2 callers before execution lifecycle columns existed. */
+    public DeploymentRow(
+        long id,
+        long definitionId,
+        Long definitionVersionId,
+        int definitionVersion,
+        CdcPipelineSpec specSnapshot,
+        String specSummary,
+        String configDigest,
+        String idempotencyKey,
+        String engineJobId,
+        String runtimeRevision,
+        ComputeEnvironmentSnapshot runtimeEnvironment,
+        String status,
+        boolean resultUncertain,
+        String errorMessage,
+        LocalDateTime createTime,
+        LocalDateTime updateTime) {
+      this(
+          id,
+          definitionId,
+          definitionVersionId,
+          definitionVersion,
+          specSnapshot,
+          specSummary,
+          configDigest,
+          idempotencyKey,
+          engineJobId,
+          runtimeRevision,
+          runtimeEnvironment,
+          "FLINK_CDC",
+          legacyDesiredState(status),
+          legacyObservedState(status),
+          status,
+          resultUncertain,
+          errorMessage,
+          createTime,
+          updateTime);
+    }
+
+    /** Compatibility constructor for callers created before Wave 2 added DefinitionVersionId. */
     public DeploymentRow(
         long id,
         long definitionId,
@@ -143,6 +224,29 @@ public interface RealtimeJobStore {
           errorMessage,
           createTime,
           updateTime);
+    }
+
+    private static boolean hasText(String value) {
+      return value != null && !value.isBlank();
+    }
+
+    private static String legacyDesiredState(String status) {
+      return switch (status == null ? "" : status) {
+        case "STOPPING", "STOPPED", "FAILED", "REJECTED" -> "STOPPED";
+        default -> "RUNNING";
+      };
+    }
+
+    private static String legacyObservedState(String status) {
+      return switch (status == null ? "" : status) {
+        case "SUBMITTING" -> "STARTING";
+        case "RUNNING" -> "RUNNING";
+        case "STOPPING" -> "STOPPING";
+        case "STOPPED" -> "STOPPED";
+        case "FAILED", "REJECTED" -> "FAILED";
+        case "UNKNOWN" -> "UNKNOWN";
+        default -> "UNKNOWN";
+      };
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
@@ -36,7 +36,12 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
   }
 
   @Override
-  public long insertDefinition(String name, String description, CdcPipelineSpec spec, String digest, long runtimeEnvironmentId) {
+  public long insertDefinition(
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      String digest,
+      long runtimeEnvironmentId) {
     RealtimeJobDefinitionPO po = new RealtimeJobDefinitionPO();
     po.setJobName(name);
     po.setDescription(description);
@@ -47,9 +52,16 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
   }
 
   @Override
-  public void updateDefinition(long id, String name, String description, CdcPipelineSpec spec, String digest, long runtimeEnvironmentId) {
-    if (dao.updateDefinition(id, name, description, json.write(spec), digest, runtimeEnvironmentId) != 1) {
-      throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能编辑");
+  public void updateDefinition(
+      long id,
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      String digest,
+      long runtimeEnvironmentId) {
+    if (dao.updateDefinition(id, name, description, json.write(spec), digest, runtimeEnvironmentId)
+        != 1) {
+      throw new IllegalStateException("实时同步任务已变化或不存在，请刷新后重试");
     }
   }
 
@@ -60,12 +72,37 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
     }
   }
 
-  @Override public Optional<DefinitionRow> definition(long id) { return dao.findDefinition(id).map(this::definitionRow); }
-  @Override public DefinitionRow lockDefinition(long id) { return dao.lockDefinition(id).map(this::definitionRow).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id)); }
-  @Override public RealtimeJobPage page(int pageNo, int pageSize, String keyword) { return listQuery.page(pageNo, pageSize, keyword, null, null, null); }
-  @Override public Optional<PublishedDefinitionRow> publishedDefinition(long definitionId) { return Optional.empty(); }
-  @Override public Optional<DeploymentRow> deploymentByIdempotencyKey(String key) { return dao.deploymentByIdempotencyKey(key).map(this::deploymentRow); }
-  @Override public Optional<DeploymentRow> latestDeployment(long definitionId) { return dao.latestDeployment(definitionId).map(this::deploymentRow); }
+  @Override
+  public Optional<DefinitionRow> definition(long id) {
+    return dao.findDefinition(id).map(this::definitionRow);
+  }
+
+  @Override
+  public DefinitionRow lockDefinition(long id) {
+    return dao.lockDefinition(id)
+        .map(this::definitionRow)
+        .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+  }
+
+  @Override
+  public RealtimeJobPage page(int pageNo, int pageSize, String keyword) {
+    return listQuery.page(pageNo, pageSize, keyword, null, null, null);
+  }
+
+  @Override
+  public Optional<PublishedDefinitionRow> publishedDefinition(long definitionId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<DeploymentRow> deploymentByIdempotencyKey(String key) {
+    return dao.deploymentByIdempotencyKey(key).map(this::deploymentRow);
+  }
+
+  @Override
+  public Optional<DeploymentRow> latestDeployment(long definitionId) {
+    return dao.latestDeployment(definitionId).map(this::deploymentRow);
+  }
 
   @Override
   public Optional<ComputeEnvironmentSnapshot> deploymentEnvironment(long deploymentId) {
@@ -77,9 +114,15 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
 
   @Override
   public long insertDeployment(
-      DefinitionRow definition, CdcPipelineSpec spec, String summary, String digest,
-      ComputeEnvironmentSnapshot environment, String idempotencyKey) {
-    if (environment == null) throw new IllegalArgumentException("实时同步部署必须绑定运行环境快照");
+      DefinitionRow definition,
+      CdcPipelineSpec spec,
+      String summary,
+      String digest,
+      ComputeEnvironmentSnapshot environment,
+      String idempotencyKey) {
+    if (environment == null) {
+      throw new IllegalArgumentException("实时同步 Execution 必须绑定运行环境快照");
+    }
     RealtimeJobDeploymentPO po = new RealtimeJobDeploymentPO();
     po.setDefinitionId(definition.id());
     po.setDefinitionVersion(definition.definitionVersion());
@@ -90,6 +133,9 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
     po.setSpecSummary(summary);
     po.setConfigDigest(digest);
     po.setIdempotencyKey(idempotencyKey);
+    po.setEngineType("FLINK_CDC");
+    po.setDesiredState("RUNNING");
+    po.setObservedState("STARTING");
     po.setRuntimeIdentityState("REQUIRED");
     po.setStatus("SUBMITTING");
     po.setResultUncertain(false);
@@ -102,19 +148,93 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
     dao.bindDeploymentDefinitionVersion(deploymentId, definitionVersionId, sourceDraftRevision);
   }
 
-  @Override public void markStarting(long definitionId) { if (dao.markStarting(definitionId) != 1) throw new IllegalStateException("任务已被其他启动或停止请求抢占，请刷新后重试"); }
-  @Override public void markDeploymentRunning(long definitionId, long deploymentId, String engineJobId, String runtimeRevision) { if (dao.markDeploymentRunning(definitionId, deploymentId, engineJobId, runtimeRevision) != 1) throw new IllegalStateException("启动完成前任务状态已变化，不能覆盖当前运行意图"); }
-  @Override public void bindDeploymentForStop(long deploymentId, String engineJobId, String runtimeRevision) { dao.bindDeploymentForStop(deploymentId, engineJobId, runtimeRevision); }
-  @Override public void markDeployFailure(long definitionId, long deploymentId, boolean uncertain, boolean stopRequested, String message) { dao.markDeployFailure(definitionId, deploymentId, uncertain, stopRequested, message); }
-  @Override public void markStopping(long definitionId, Long deploymentId) { dao.markStopping(definitionId, deploymentId); }
-  @Override public void reconcile(long definitionId, Long deploymentId, String observedState, String deploymentState, String engineJobId, String error) { dao.reconcile(definitionId, deploymentId, observedState, deploymentState, engineJobId, error); }
-  @Override public void markTerminalFailure(long definitionId, Long deploymentId, String message) { dao.markTerminalFailure(definitionId, deploymentId, message); }
-  @Override public List<DefinitionRow> desiredJobs() { return dao.desiredJobs().stream().map(this::definitionRow).toList(); }
-  @Override public boolean hasOtherDesiredRunning(long id) { return dao.hasOtherDesiredRunning(id); }
-  @Override public void delete(long id) { if (dao.deleteDefinition(id) != 1) throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能删除"); }
+  @Override
+  public void markStarting(long definitionId) {
+    if (dao.markStarting(definitionId) != 1) {
+      throw new IllegalStateException("无法同步 Task 的 STARTING 兼容投影，请刷新后重试");
+    }
+  }
 
   @Override
-  public void event(long definitionId, Long deploymentId, String type, String from, String to, String message) {
+  public void markDeploymentRunning(
+      long definitionId,
+      long deploymentId,
+      String engineJobId,
+      String runtimeRevision) {
+    if (dao.markDeploymentRunning(definitionId, deploymentId, engineJobId, runtimeRevision) != 1) {
+      throw new IllegalStateException("Execution 状态已变化，不能覆盖当前运行意图");
+    }
+  }
+
+  @Override
+  public void bindDeploymentForStop(
+      long deploymentId, String engineJobId, String runtimeRevision) {
+    dao.bindDeploymentForStop(deploymentId, engineJobId, runtimeRevision);
+  }
+
+  @Override
+  public void markDeployFailure(
+      long definitionId,
+      long deploymentId,
+      boolean uncertain,
+      boolean stopRequested,
+      String message) {
+    dao.markDeployFailure(definitionId, deploymentId, uncertain, stopRequested, message);
+  }
+
+  @Override
+  public void markStopping(long definitionId, Long deploymentId) {
+    dao.markStopping(definitionId, deploymentId);
+  }
+
+  @Override
+  public void reconcile(
+      long definitionId,
+      Long deploymentId,
+      String observedState,
+      String deploymentState,
+      String engineJobId,
+      String error) {
+    dao.reconcile(
+        definitionId, deploymentId, observedState, deploymentState, engineJobId, error);
+  }
+
+  @Override
+  public void markTerminalFailure(long definitionId, Long deploymentId, String message) {
+    dao.markTerminalFailure(definitionId, deploymentId, message);
+  }
+
+  @Override
+  public List<DeploymentRow> reconcileCandidates() {
+    return dao.reconcileExecutions().stream().map(this::deploymentRow).toList();
+  }
+
+  @Override
+  @Deprecated
+  public List<DefinitionRow> desiredJobs() {
+    return dao.desiredJobs().stream().map(this::definitionRow).toList();
+  }
+
+  @Override
+  public boolean hasOtherDesiredRunning(long id) {
+    return dao.hasOtherDesiredRunning(id);
+  }
+
+  @Override
+  public void delete(long id) {
+    if (dao.deleteDefinition(id) != 1) {
+      throw new IllegalStateException("实时同步任务不存在或已被其他操作删除");
+    }
+  }
+
+  @Override
+  public void event(
+      long definitionId,
+      Long deploymentId,
+      String type,
+      String from,
+      String to,
+      String message) {
     RealtimeJobEventPO po = new RealtimeJobEventPO();
     po.setDefinitionId(definitionId);
     po.setDeploymentId(deploymentId);
@@ -126,48 +246,111 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
     events.publishEvent(new RealtimeJobChangeEvent(definitionId, type, from, to, message));
   }
 
-  @Override public boolean tryAcquireReconcileLease(String owner, int leaseSeconds) { return dao.tryAcquireReconcileLease(owner, leaseSeconds); }
+  @Override
+  public boolean tryAcquireReconcileLease(String owner, int leaseSeconds) {
+    return dao.tryAcquireReconcileLease(owner, leaseSeconds);
+  }
 
   @Override
   public List<RealtimeJobEventView> events(long definitionId) {
     return dao.events(definitionId).stream()
-        .map(po -> new RealtimeJobEventView(po.getId(), po.getDeploymentId(), po.getEventType(), po.getFromState(), po.getToState(), po.getMessage(), po.getCreateTime()))
+        .map(
+            po ->
+                new RealtimeJobEventView(
+                    po.getId(),
+                    po.getDeploymentId(),
+                    po.getEventType(),
+                    po.getFromState(),
+                    po.getToState(),
+                    po.getMessage(),
+                    po.getCreateTime()))
         .toList();
   }
 
   @Override
   public RealtimeJobView view(long id) {
-    DefinitionRow definition = definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+    DefinitionRow definition =
+        definition(id)
+            .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+    DeploymentRow latest = latestDeployment(id).orElse(null);
+    String desired = latest == null ? definition.desiredState() : latest.desiredState();
+    String observed = latest == null ? definition.observedState() : latest.observedState();
+    String error = latest == null ? definition.lastError() : latest.errorMessage();
     return new RealtimeJobView(
-        definition.id(), definition.name(), definition.description(), definition.spec(), definition.runtimeEnvironmentId(),
-        definition.releaseState(), definition.desiredState(), definition.observedState(), definition.definitionVersion(),
-        definition.publishedVersion(), definition.configDigest(), definition.lastError(), definition.createTime(),
-        definition.updateTime(), deploymentView(latestDeployment(id).orElse(null)));
+        definition.id(),
+        definition.name(),
+        definition.description(),
+        definition.spec(),
+        definition.runtimeEnvironmentId(),
+        definition.releaseState(),
+        desired,
+        observed,
+        definition.definitionVersion(),
+        definition.publishedVersion(),
+        definition.configDigest(),
+        error,
+        definition.createTime(),
+        definition.updateTime(),
+        deploymentView(latest));
   }
 
   @Override
   public RealtimeJobView.Deployment deploymentView(DeploymentRow deployment) {
     if (deployment == null) return null;
     return new RealtimeJobView.Deployment(
-        deployment.id(), deployment.definitionVersion(), deployment.specSummary(), deployment.configDigest(),
-        deployment.idempotencyKey(), deployment.engineJobId(), deployment.runtimeRevision(), deployment.runtimeEnvironment(),
-        deployment.status(), deployment.resultUncertain(), deployment.errorMessage(), deployment.createTime(), deployment.updateTime());
+        deployment.id(),
+        deployment.definitionVersion(),
+        deployment.specSummary(),
+        deployment.configDigest(),
+        deployment.idempotencyKey(),
+        deployment.engineJobId(),
+        deployment.runtimeRevision(),
+        deployment.runtimeEnvironment(),
+        deployment.status(),
+        deployment.resultUncertain(),
+        deployment.errorMessage(),
+        deployment.createTime(),
+        deployment.updateTime());
   }
 
   private DefinitionRow definitionRow(RealtimeJobDefinitionPO po) {
     return new DefinitionRow(
-        po.getId(), po.getJobName(), po.getDescription(), json.readSpec(po.getSpecJson()), po.getRuntimeEnvironmentId(),
-        po.getReleaseState(), po.getDesiredState(), po.getObservedState(),
-        po.getDefinitionVersion() == null ? 0 : po.getDefinitionVersion(), po.getPublishedVersion(),
-        po.getConfigDigest(), po.getLastError(), po.getCreateTime(), po.getUpdateTime());
+        po.getId(),
+        po.getJobName(),
+        po.getDescription(),
+        json.readSpec(po.getSpecJson()),
+        po.getRuntimeEnvironmentId(),
+        po.getReleaseState(),
+        po.getDesiredState(),
+        po.getObservedState(),
+        po.getDefinitionVersion() == null ? 0 : po.getDefinitionVersion(),
+        po.getPublishedVersion(),
+        po.getConfigDigest(),
+        po.getLastError(),
+        po.getCreateTime(),
+        po.getUpdateTime());
   }
 
   private DeploymentRow deploymentRow(RealtimeJobDeploymentPO po) {
     return new DeploymentRow(
-        po.getId(), po.getDefinitionId(), po.getDefinitionVersionId(),
+        po.getId(),
+        po.getDefinitionId(),
+        po.getDefinitionVersionId(),
         po.getDefinitionVersion() == null ? 0 : po.getDefinitionVersion(),
-        json.readSpec(po.getSpecSnapshotJson()), po.getSpecSummary(), po.getConfigDigest(), po.getIdempotencyKey(),
-        po.getGatewayJobId(), po.getRuntimeRevision(), json.readEnvironmentSnapshot(po.getRuntimeEnvironmentSnapshotJson()),
-        po.getStatus(), Boolean.TRUE.equals(po.getResultUncertain()), po.getErrorMessage(), po.getCreateTime(), po.getUpdateTime());
+        json.readSpec(po.getSpecSnapshotJson()),
+        po.getSpecSummary(),
+        po.getConfigDigest(),
+        po.getIdempotencyKey(),
+        po.getGatewayJobId(),
+        po.getRuntimeRevision(),
+        json.readEnvironmentSnapshot(po.getRuntimeEnvironmentSnapshotJson()),
+        po.getEngineType(),
+        po.getDesiredState(),
+        po.getObservedState(),
+        po.getStatus(),
+        Boolean.TRUE.equals(po.getResultUncertain()),
+        po.getErrorMessage(),
+        po.getCreateTime(),
+        po.getUpdateTime());
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
@@ -23,10 +23,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Stage-6 compatibility decorator that adds immutable DefinitionVersion persistence without
- * rewriting the existing RealtimeJobService lifecycle path.
- */
+/** Compatibility decorator for immutable DefinitionVersion plus the evolving execution store. */
 @Primary
 @Repository
 public class VersioningRealtimeJobStore implements RealtimeJobStore {
@@ -44,10 +41,7 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
     this.compatibilityMapper = compatibilityMapper;
   }
 
-  /**
-   * Publish remains guarded by the legacy Task-row CAS in Wave 1. The new immutable version and the
-   * legacy publish marker are written in the same business transaction.
-   */
+  /** Immutable version creation and legacy release projection remain one transaction. */
   @Override
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public void publish(long id, int expectedDefinitionVersion, String expectedDigest) {
@@ -61,10 +55,7 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
     }
 
     PublicationCandidate candidate = publicationCandidate(current, expectedDigest);
-
-    // Keep the existing STOPPED/FAILED CAS and legacy release projection unchanged in Wave 1.
     delegate.publish(id, expectedDefinitionVersion, expectedDigest);
-
     StoredVersion version = definitionVersions.findOrCreate(candidate);
     definitionVersions.bindPublishedReference(
         id, version.id(), expectedDefinitionVersion, expectedDigest);
@@ -88,8 +79,6 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
           digest,
           DomainMappingState.MAPPED);
     } catch (UnsupportedLegacyDefinitionException exception) {
-      // Preserve existing behavior: the immutable compatibility snapshot is still published, but we
-      // refuse to pretend an incomplete legacy policy is a valid Core Domain value object.
       return new PublicationCandidate(
           current.id(),
           current.definitionVersion(),
@@ -255,6 +244,12 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
   }
 
   @Override
+  public List<DeploymentRow> reconcileCandidates() {
+    return delegate.reconcileCandidates();
+  }
+
+  @Override
+  @Deprecated
   public List<DefinitionRow> desiredJobs() {
     return delegate.desiredJobs();
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinator.java
@@ -2,8 +2,10 @@ package io.yak.ops.business.sync.realtime.service;
 
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
-import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
 import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineException;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
@@ -26,7 +28,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
-/** Authoritative scheduled/manual reconciliation against the real Flink runtime. */
+/** Authoritative reconciliation between SyncExecution state and the real Flink runtime. */
 @Service
 public class RealtimeJobLifecycleCoordinator {
 
@@ -37,7 +39,7 @@ public class RealtimeJobLifecycleCoordinator {
   private final FlinkJobDiscoveryClient discovery;
   private final RealtimeEngineGateway gateway;
   private final RealtimeRuntimeResolver runtimeResolver;
-  private final RealtimeStateMachine stateMachine;
+  private final SyncExecutionStateMachine executionStateMachine;
   private final RealtimeSyncProperties properties;
   private final TransactionTemplate transactions;
   private final long orphanGraceSeconds;
@@ -50,7 +52,7 @@ public class RealtimeJobLifecycleCoordinator {
       FlinkJobDiscoveryClient discovery,
       RealtimeEngineGateway gateway,
       RealtimeRuntimeResolver runtimeResolver,
-      RealtimeStateMachine stateMachine,
+      SyncExecutionStateMachine executionStateMachine,
       RealtimeSyncProperties properties,
       @Value("${yak.sync.realtime.orphan-recovery-grace-seconds:120}") long orphanGraceSeconds,
       @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager) {
@@ -59,27 +61,28 @@ public class RealtimeJobLifecycleCoordinator {
     this.discovery = discovery;
     this.gateway = gateway;
     this.runtimeResolver = runtimeResolver;
-    this.stateMachine = stateMachine;
+    this.executionStateMachine = executionStateMachine;
     this.properties = properties;
     this.orphanGraceSeconds = Math.max(10, orphanGraceSeconds);
     this.transactions = new TransactionTemplate(transactionManager);
   }
 
   public void reconcileAll() {
-    for (DefinitionRow candidate : store.desiredJobs()) {
+    for (DeploymentRow candidate : store.reconcileCandidates()) {
+      long taskId = candidate.definitionId();
       try {
-        reconcile(candidate.id());
-        consecutiveEngineFailures.remove(candidate.id());
+        reconcile(taskId);
+        consecutiveEngineFailures.remove(taskId);
       } catch (RealtimeEngineException exception) {
         int failures =
             consecutiveEngineFailures
-                .computeIfAbsent(candidate.id(), ignored -> new AtomicInteger())
+                .computeIfAbsent(taskId, ignored -> new AtomicInteger())
                 .incrementAndGet();
         if (failures >= Math.max(1, properties.getReconcileFailureThreshold())) {
-          markEngineUnavailable(candidate.id(), exception.getMessage());
+          markEngineUnavailable(taskId, exception.getMessage());
         }
       } catch (RuntimeException exception) {
-        LOG.warn("Realtime job {} reconciliation failed", candidate.id(), exception);
+        LOG.warn("Realtime execution for task {} reconciliation failed", taskId, exception);
       }
     }
   }
@@ -106,14 +109,13 @@ public class RealtimeJobLifecycleCoordinator {
     return store.view(id);
   }
 
-  /** Refuses metadata deletion unless the deployment's Flink runtime proves no job is active. */
+  /** Refuses metadata deletion unless the latest execution is terminal and Flink is inactive. */
   public void assertSafeToDelete(long id) {
     DefinitionRow definition = requireDefinition(id);
-    stateMachine.requireDefinitionMutable(definition.desiredState(), definition.observedState());
     DeploymentRow deployment = store.latestDeployment(id).orElse(null);
-    if (deployment == null) {
-      return;
-    }
+    if (deployment == null) return;
+
+    executionStateMachine.requireDefinitionMutable(deployment.execution());
     ComputeEnvironmentSnapshot runtimeEnvironment = runtimeResolver.deployment(definition, deployment);
     if (StringUtils.hasText(deployment.engineJobId())) {
       requireInactive(gateway.status(runtimeEnvironment, deployment.engineJobId()));
@@ -121,8 +123,6 @@ public class RealtimeJobLifecycleCoordinator {
     }
     String runtimeName = identityStore.findByDeploymentId(deployment.id()).orElse(null);
     if (!StringUtils.hasText(runtimeName)) {
-      // Runtime identity is bound immediately before entering the CLI. If it is absent, submission
-      // never crossed that boundary and there cannot be an orphan Flink job from this deployment.
       return;
     }
     for (String jobId : discovery.findJobIds(runtimeEnvironment, runtimeName)) {
@@ -155,24 +155,25 @@ public class RealtimeJobLifecycleCoordinator {
     String recoveredJobId = matches.get(0);
     transactions.executeWithoutResult(
         ignored -> {
-          DefinitionRow current = store.lockDefinition(definition.id());
+          store.lockDefinition(definition.id());
           DeploymentRow latest = store.latestDeployment(definition.id()).orElse(null);
           if (!sameDeployment(deployment, latest) || StringUtils.hasText(latest.engineJobId())) {
             return;
           }
+          SyncExecution execution = latest.execution();
           store.reconcile(
-              current.id(),
+              definition.id(),
               latest.id(),
-              current.observedState(),
+              execution.observedState().name(),
               latest.status(),
               recoveredJobId,
-              current.lastError());
+              execution.errorMessage());
           store.event(
-              current.id(),
+              definition.id(),
               latest.id(),
               "FLINK_JOB_ID_RECOVERED",
-              current.observedState(),
-              current.observedState(),
+              execution.observedState().name(),
+              execution.observedState().name(),
               "已通过 runtime job identity 找回 Flink JobId：" + recoveredJobId);
         });
     return recoveredJobId;
@@ -187,7 +188,7 @@ public class RealtimeJobLifecycleCoordinator {
     Boolean stop =
         transactions.execute(
             ignored -> {
-              DefinitionRow current = store.lockDefinition(definitionId);
+              store.lockDefinition(definitionId);
               DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
               if (latest == null
                   || latest.id() != deploymentId
@@ -195,10 +196,11 @@ public class RealtimeJobLifecycleCoordinator {
                       && !Objects.equals(latest.engineJobId(), jobId))) {
                 return false;
               }
+              SyncExecution execution = latest.execution();
 
               if (runtime.state() == RuntimeStatus.State.UNKNOWN) {
                 transition(
-                    current,
+                    definitionId,
                     latest,
                     "UNKNOWN",
                     "UNKNOWN",
@@ -206,12 +208,12 @@ public class RealtimeJobLifecycleCoordinator {
                     "Flink 当前运行状态未知");
                 return false;
               }
-              if ("RUNNING".equals(current.desiredState())) {
+              if (execution.desiredState().name().equals("RUNNING")) {
                 if (runtime.state() == RuntimeStatus.State.RUNNING) {
-                  transition(current, latest, "RUNNING", "RUNNING", jobId, null);
+                  transition(definitionId, latest, "RUNNING", "RUNNING", jobId, null);
                 } else {
                   failExpectedRunning(
-                      current,
+                      definitionId,
                       latest,
                       runtime.state() == RuntimeStatus.State.TERMINATED
                           ? "Flink 任务已终止"
@@ -220,10 +222,10 @@ public class RealtimeJobLifecycleCoordinator {
                 return false;
               }
               if (runtime.state() == RuntimeStatus.State.RUNNING) {
-                transition(current, latest, "STOPPING", "STOPPING", jobId, null);
+                transition(definitionId, latest, "STOPPING", "STOPPING", jobId, null);
                 return true;
               }
-              toStopped(current, latest, jobId, "Flink 已确认无活动任务");
+              toStopped(definitionId, latest, jobId, "Flink 已确认无活动任务");
               return false;
             });
 
@@ -240,15 +242,16 @@ public class RealtimeJobLifecycleCoordinator {
   private void settleMissing(long definitionId, DeploymentRow deployment, String reason) {
     transactions.executeWithoutResult(
         ignored -> {
-          DefinitionRow current = store.lockDefinition(definitionId);
+          store.lockDefinition(definitionId);
           DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
           if (!sameDeployment(deployment, latest) || StringUtils.hasText(latest.engineJobId())) {
             return;
           }
-          if ("RUNNING".equals(current.desiredState())) {
-            failExpectedRunning(current, latest, "提交结果不确定，" + reason);
+          SyncExecution execution = latest.execution();
+          if (execution.desiredState().name().equals("RUNNING")) {
+            failExpectedRunning(definitionId, latest, "提交结果不确定，" + reason);
           } else {
-            toStopped(current, latest, null, reason + "，已确认停止");
+            toStopped(definitionId, latest, null, reason + "，已确认停止");
           }
         });
   }
@@ -256,26 +259,29 @@ public class RealtimeJobLifecycleCoordinator {
   private void markConflict(long definitionId, DeploymentRow deployment, int count) {
     transactions.executeWithoutResult(
         ignored -> {
-          DefinitionRow current = store.lockDefinition(definitionId);
+          store.lockDefinition(definitionId);
           DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
           if (!sameDeployment(deployment, latest) || StringUtils.hasText(latest.engineJobId())) {
             return;
           }
-          String target = "STOPPING".equals(current.observedState()) ? "UNKNOWN" : "CONFLICT";
+          SyncExecution execution = latest.execution();
+          String target =
+              execution.observedState() == ObservedState.STOPPING ? "UNKNOWN" : "CONFLICT";
           String message = "runtime job identity 匹配到 " + count + " 个 Flink Job，拒绝自动绑定";
-          transition(current, latest, target, "UNKNOWN", null, message);
+          transition(definitionId, latest, target, "UNKNOWN", null, message);
         });
   }
 
   private void failExpectedRunning(
-      DefinitionRow current, DeploymentRow deployment, String message) {
-    stateMachine.requireTransition(current.observedState(), "FAILED");
-    store.markTerminalFailure(current.id(), deployment.id(), message);
+      long definitionId, DeploymentRow deployment, String message) {
+    SyncExecution execution = deployment.execution();
+    executionStateMachine.requireTransition(execution, "FAILED");
+    store.markTerminalFailure(definitionId, deployment.id(), message);
     store.event(
-        current.id(),
+        definitionId,
         deployment.id(),
         "FLINK_JOB_LOST",
-        current.observedState(),
+        execution.observedState().name(),
         "FAILED",
         message);
   }
@@ -284,80 +290,88 @@ public class RealtimeJobLifecycleCoordinator {
     try {
       transactions.executeWithoutResult(
           ignored -> {
-            DefinitionRow current = store.lockDefinition(definitionId);
-            if ("UNKNOWN".equals(current.observedState())) {
+            store.lockDefinition(definitionId);
+            DeploymentRow deployment = store.latestDeployment(definitionId).orElse(null);
+            if (deployment == null) return;
+            SyncExecution execution = deployment.execution();
+            if (execution.terminal() || execution.observedState() == ObservedState.UNKNOWN) {
               return;
             }
-            DeploymentRow deployment = store.latestDeployment(definitionId).orElse(null);
-            stateMachine.requireTransition(current.observedState(), "UNKNOWN");
+            executionStateMachine.requireTransition(execution, "UNKNOWN");
             String message = "Flink 状态不可用" + (detail == null ? "" : "：" + detail);
             store.reconcile(
                 definitionId,
-                deployment == null ? null : deployment.id(),
+                deployment.id(),
                 "UNKNOWN",
                 "UNKNOWN",
-                deployment == null ? null : deployment.engineJobId(),
+                deployment.engineJobId(),
                 message);
             store.event(
                 definitionId,
-                deployment == null ? null : deployment.id(),
+                deployment.id(),
                 "FLINK_UNAVAILABLE",
-                current.observedState(),
+                execution.observedState().name(),
                 "UNKNOWN",
                 message);
           });
     } catch (RuntimeException exception) {
-      LOG.debug("Unable to mark realtime job {} UNKNOWN", definitionId, exception);
+      LOG.debug("Unable to mark realtime execution for task {} UNKNOWN", definitionId, exception);
     }
   }
 
   private void markUnknown(long definitionId, long deploymentId, String jobId, String message) {
     transactions.executeWithoutResult(
         ignored -> {
-          DefinitionRow current = store.lockDefinition(definitionId);
+          store.lockDefinition(definitionId);
           DeploymentRow latest = store.latestDeployment(definitionId).orElse(null);
           if (latest == null || latest.id() != deploymentId) {
             return;
           }
-          transition(current, latest, "UNKNOWN", "UNKNOWN", jobId, message);
+          transition(definitionId, latest, "UNKNOWN", "UNKNOWN", jobId, message);
         });
   }
 
   private void transition(
-      DefinitionRow current,
+      long definitionId,
       DeploymentRow deployment,
       String observed,
       String deploymentState,
       String jobId,
       String error) {
-    if (!observed.equals(current.observedState())) {
-      stateMachine.requireTransition(current.observedState(), observed);
-    }
-    store.reconcile(current.id(), deployment.id(), observed, deploymentState, jobId, error);
-    if (!observed.equals(current.observedState()) || !Objects.equals(error, current.lastError())) {
+    SyncExecution execution = deployment.execution();
+    executionStateMachine.requireTransition(execution, observed);
+    store.reconcile(definitionId, deployment.id(), observed, deploymentState, jobId, error);
+    if (!observed.equals(execution.observedState().name())
+        || !Objects.equals(error, execution.errorMessage())) {
       store.event(
-          current.id(),
+          definitionId,
           deployment.id(),
           "STATE_RECONCILED",
-          current.observedState(),
+          execution.observedState().name(),
           observed,
           error == null ? "Flink 状态已对账" : error);
     }
   }
 
   private void toStopped(
-      DefinitionRow current, DeploymentRow deployment, String jobId, String message) {
-    String from = current.observedState();
-    if ("STARTING".equals(from) || "RUNNING".equals(from)) {
-      stateMachine.requireTransition(from, "STOPPING");
-      store.reconcile(current.id(), deployment.id(), "STOPPING", "STOPPING", jobId, null);
-      from = "STOPPING";
+      long definitionId, DeploymentRow deployment, String jobId, String message) {
+    ObservedState from = deployment.execution().observedState();
+    if (from == ObservedState.STARTING || from == ObservedState.RUNNING) {
+      executionStateMachine.requireTransition(from, ObservedState.STOPPING);
+      store.reconcile(definitionId, deployment.id(), "STOPPING", "STOPPING", jobId, null);
+      from = ObservedState.STOPPING;
     }
-    if (!"STOPPED".equals(from)) {
-      stateMachine.requireTransition(from, "STOPPED");
+    if (from != ObservedState.STOPPED) {
+      executionStateMachine.requireTransition(from, ObservedState.STOPPED);
     }
-    store.reconcile(current.id(), deployment.id(), "STOPPED", "STOPPED", jobId, null);
-    store.event(current.id(), deployment.id(), "STOPPED", from, "STOPPED", message);
+    store.reconcile(definitionId, deployment.id(), "STOPPED", "STOPPED", jobId, null);
+    store.event(
+        definitionId,
+        deployment.id(),
+        "STOPPED",
+        from.name(),
+        "STOPPED",
+        message);
   }
 
   private void requireInactive(RuntimeStatus runtime) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -7,7 +7,8 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobEventView;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
-import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
 import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
@@ -36,14 +37,14 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
-/** Application service for realtime job definitions and lifecycle commands. */
+/** Application service for realtime task definitions and SyncExecution lifecycle commands. */
 @Service
 public class RealtimeJobService {
 
   private final RealtimeJobStore store;
   private final ObjectMapper json;
   private final CdcPipelineSpecValidator specValidator;
-  private final RealtimeStateMachine stateMachine;
+  private final SyncExecutionStateMachine executionStateMachine;
   private final RealtimeDataSourceResolver dataSourceResolver;
   private final RealtimeConnectorCapabilityResolver capabilityResolver;
   private final PipelineYamlCompiler compiler;
@@ -56,7 +57,7 @@ public class RealtimeJobService {
       RealtimeJobStore store,
       @Qualifier("realtimeObjectMapper") ObjectMapper json,
       CdcPipelineSpecValidator specValidator,
-      RealtimeStateMachine stateMachine,
+      SyncExecutionStateMachine executionStateMachine,
       RealtimeDataSourceResolver dataSourceResolver,
       RealtimeConnectorCapabilityResolver capabilityResolver,
       PipelineYamlCompiler compiler,
@@ -66,7 +67,7 @@ public class RealtimeJobService {
     this.store = store;
     this.json = json;
     this.specValidator = specValidator;
-    this.stateMachine = stateMachine;
+    this.executionStateMachine = executionStateMachine;
     this.dataSourceResolver = dataSourceResolver;
     this.capabilityResolver = capabilityResolver;
     this.compiler = compiler;
@@ -95,8 +96,8 @@ public class RealtimeJobService {
                 store.event(created, null, "DRAFT_CREATED", null, "DRAFT", "已创建实时同步草稿");
                 return created;
               }
-              DefinitionRow locked = store.lockDefinition(id);
-              stateMachine.requireDefinitionMutable(locked.desiredState(), locked.observedState());
+              DefinitionRow locked = store.lockDefinition(id); // cross-instance command mutex
+              requireDefinitionMutable(id);
               store.updateDefinition(
                   id, name.trim(), description, spec, digest, runtimeEnvironmentId);
               store.event(
@@ -133,13 +134,12 @@ public class RealtimeJobService {
 
   public void publish(long id) {
     Prepared prepared = prepare(id, false);
-    stateMachine.requireDefinitionMutable(
-        prepared.definition().desiredState(), prepared.definition().observedState());
+    requireDefinitionMutable(id);
     gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
     transactions.executeWithoutResult(
         status -> {
-          DefinitionRow locked = store.lockDefinition(id);
-          stateMachine.requireDefinitionMutable(locked.desiredState(), locked.observedState());
+          DefinitionRow locked = store.lockDefinition(id); // cross-instance command mutex
+          requireDefinitionMutable(id);
           requirePreparedDefinitionCurrent(prepared, locked);
           store.publish(
               id, prepared.definition().definitionVersion(), prepared.definition().configDigest());
@@ -184,10 +184,8 @@ public class RealtimeJobService {
       reservation =
           transactions.execute(
               status -> {
-                DefinitionRow locked = store.lockDefinition(id);
+                DefinitionRow locked = store.lockDefinition(id); // mutex, not lifecycle truth
 
-                // The first check happens outside the transaction for the common retry path. This
-                // second check is required for two Yak Ops instances racing with the same key.
                 DeploymentRow duplicate = idempotentDeployment(id, key);
                 if (duplicate != null) {
                   return new StartReservation(duplicate.id(), false);
@@ -195,8 +193,14 @@ public class RealtimeJobService {
 
                 PublishedDefinitionRow currentPublished = requirePublishedDefinition(id);
                 requirePreparedPublishedCurrent(prepared, currentPublished);
-                stateMachine.requireStartable(locked.desiredState(), locked.observedState());
-                stateMachine.requireTransition(locked.observedState(), "STARTING");
+
+                SyncExecution previous = store.latestExecution(id).orElse(null);
+                executionStateMachine.requireNewExecutionAllowed(previous);
+                String previousDescription =
+                    previous == null
+                        ? ""
+                        : "；上一 Execution 终态为 " + previous.observedState().name();
+
                 long created =
                     store.insertDeployment(
                         locked,
@@ -209,37 +213,38 @@ public class RealtimeJobService {
                     created,
                     prepared.publishedDefinition().id(),
                     prepared.publishedDefinition().sourceDraftRevision());
-                store.markStarting(id);
+                store.markStarting(id); // Task-row compatibility projection only
                 store.event(
                     id,
                     created,
                     "START_REQUESTED",
-                    locked.observedState(),
+                    null,
                     "STARTING",
                     "开始使用已发布版本 v"
                         + prepared.publishedDefinition().versionNo()
                         + "，通过运行环境「"
                         + prepared.runtimeEnvironment().name()
-                        + "」提交 Flink CDC 任务");
+                        + "」提交 Flink CDC 任务"
+                        + previousDescription);
                 return new StartReservation(created, true);
               });
     } catch (DuplicateKeyException exception) {
       DeploymentRow raced =
           store
               .deploymentByIdempotencyKey(key)
-              .orElseThrow(() -> new IllegalStateException("幂等部署冲突", exception));
+              .orElseThrow(() -> new IllegalStateException("幂等 Execution 冲突", exception));
       requireIdempotencyOwner(id, raced);
       return store.deploymentView(raced);
     }
 
     if (reservation == null) {
-      throw new IllegalStateException("未能创建实时同步启动预留");
+      throw new IllegalStateException("未能创建实时同步 Execution 启动预留");
     }
     if (!reservation.created()) {
       DeploymentRow duplicate =
           store
               .deploymentByIdempotencyKey(key)
-              .orElseThrow(() -> new IllegalStateException("幂等部署记录不存在"));
+              .orElseThrow(() -> new IllegalStateException("幂等 Execution 记录不存在"));
       requireIdempotencyOwner(id, duplicate);
       return store.deploymentView(duplicate);
     }
@@ -257,8 +262,8 @@ public class RealtimeJobService {
 
   /**
    * Finishes a successful CLI submission without overwriting a concurrent stop request. If stop
-   * won the race while the CLI was running, bind the returned JobId first and immediately cancel
-   * that exact Flink job.
+   * won while the CLI was running, bind the returned JobId first and immediately cancel that exact
+   * external execution.
    */
   private RealtimeJobView.Deployment completeStart(
       long id,
@@ -268,9 +273,13 @@ public class RealtimeJobService {
     Boolean cancelAfterSubmit =
         transactions.execute(
             status -> {
-              DefinitionRow current = store.lockDefinition(id);
-              if ("RUNNING".equals(current.desiredState())
-                  && "STARTING".equals(current.observedState())) {
+              store.lockDefinition(id); // cross-instance command mutex
+              DeploymentRow row = requireCurrentExecutionRow(id, deploymentId);
+              SyncExecution execution = row.execution();
+
+              if (execution.desiredState().name().equals("RUNNING")
+                  && execution.observedState().name().equals("STARTING")) {
+                executionStateMachine.requireTransition(execution, "RUNNING");
                 store.markDeploymentRunning(
                     id,
                     deploymentId,
@@ -281,9 +290,9 @@ public class RealtimeJobService {
                 return false;
               }
 
-              String from = current.observedState();
+              String from = execution.observedState().name();
               if (!"STOPPING".equals(from)) {
-                stateMachine.requireTransition(from, "STOPPING");
+                executionStateMachine.requireTransition(execution, "STOPPING");
                 store.markStopping(id, deploymentId);
               }
               store.bindDeploymentForStop(
@@ -294,24 +303,25 @@ public class RealtimeJobService {
                   "START_CANCEL_PENDING",
                   from,
                   "STOPPING",
-                  "启动提交已返回，但期间运行意图已变化，立即取消该 Flink 任务");
+                  "启动提交已返回，但期间 Execution 停止意图已生效，立即取消该 Flink 任务");
               return true;
             });
 
     if (Boolean.TRUE.equals(cancelAfterSubmit)) {
       stopBoundJob(id, deploymentId, result.jobId(), "并发停止请求已取消刚提交的 Flink 任务");
     }
-    return store.deploymentView(
-        store.latestDeployment(id).orElseThrow(() -> new IllegalStateException("部署记录不存在")));
+    return store.deploymentView(requireCurrentExecutionRow(id, deploymentId));
   }
 
   private void markStartFailure(long id, long deploymentId, RealtimeEngineException exception) {
     transactions.executeWithoutResult(
         status -> {
-          DefinitionRow current = store.lockDefinition(id);
-          boolean stopRequested = "STOPPED".equals(current.desiredState());
+          store.lockDefinition(id); // mutex
+          DeploymentRow row = requireCurrentExecutionRow(id, deploymentId);
+          SyncExecution execution = row.execution();
+          boolean stopRequested = execution.desiredState().name().equals("STOPPED");
           String target = exception.uncertain() ? "UNKNOWN" : "FAILED";
-          stateMachine.requireTransition(current.observedState(), target);
+          executionStateMachine.requireTransition(execution, target);
           store.markDeployFailure(
               id,
               deploymentId,
@@ -322,7 +332,7 @@ public class RealtimeJobService {
               id,
               deploymentId,
               exception.uncertain() ? "START_UNCERTAIN" : "START_FAILED",
-              current.observedState(),
+              execution.observedState().name(),
               target,
               exception.getMessage());
         });
@@ -342,28 +352,29 @@ public class RealtimeJobService {
     StopReservation reservation =
         transactions.execute(
             status -> {
-              DefinitionRow current = store.lockDefinition(id);
+              store.lockDefinition(id); // mutex
               DeploymentRow deployment = store.latestDeployment(id).orElse(null);
-
-              if ("STOPPED".equals(current.desiredState())
-                  && ("STOPPED".equals(current.observedState())
-                      || "FAILED".equals(current.observedState()))) {
+              if (deployment == null) {
+                return new StopReservation(null, true, false);
+              }
+              SyncExecution execution = deployment.execution();
+              if (execution.terminal()) {
                 return new StopReservation(deployment, true, false);
               }
-              if ("STOPPED".equals(current.desiredState())
-                  && "STOPPING".equals(current.observedState())) {
+              if (execution.desiredState().name().equals("STOPPED")
+                  && execution.observedState().name().equals("STOPPING")) {
                 return new StopReservation(deployment, false, true);
               }
 
-              stateMachine.requireTransition(current.observedState(), "STOPPING");
-              store.markStopping(id, deployment == null ? null : deployment.id());
+              executionStateMachine.requireTransition(execution, "STOPPING");
+              store.markStopping(id, deployment.id());
               store.event(
                   id,
-                  deployment == null ? null : deployment.id(),
+                  deployment.id(),
                   "STOP_REQUESTED",
-                  current.observedState(),
+                  execution.observedState().name(),
                   "STOPPING",
-                  "已请求 Flink 停止当前任务");
+                  "已请求停止当前 SyncExecution");
               return new StopReservation(deployment, false, false);
             });
 
@@ -373,9 +384,8 @@ public class RealtimeJobService {
 
     DeploymentRow deployment = reservation.deployment();
     if (deployment == null || !StringUtils.hasText(deployment.engineJobId())) {
-      // STARTING may still be blocked inside the synchronous Flink CDC CLI. Keep STOPPING instead
-      // of pretending the task is stopped. The start owner will bind the returned JobId and cancel
-      // it in completeStart().
+      // STARTING may still be blocked in the synchronous CLI. Keep Execution STOPPING; the start
+      // owner will bind the returned JobId and cancel it in completeStart().
       return;
     }
 
@@ -383,8 +393,7 @@ public class RealtimeJobService {
   }
 
   private void stopBoundJob(long id, long deploymentId, String jobId, String successMessage) {
-    DeploymentRow deployment =
-        store.latestDeployment(id).orElseThrow(() -> new IllegalStateException("部署记录不存在"));
+    DeploymentRow deployment = requireCurrentExecutionRow(id, deploymentId);
     ComputeEnvironmentSnapshot runtimeEnvironment = deploymentRuntime(id, deployment);
     try {
       RuntimeStatus runtime = gateway.status(runtimeEnvironment, jobId);
@@ -396,23 +405,25 @@ public class RealtimeJobService {
       }
       markStopped(id, deploymentId, jobId, successMessage);
     } catch (RealtimeEngineException exception) {
-      markStopUncertain(id, deployment, deploymentId, jobId, exception.getMessage());
+      markStopUncertain(id, deploymentId, jobId, exception.getMessage());
       throw exception;
     }
   }
 
   private void markStopUncertain(
-      long id, DeploymentRow deployment, long deploymentId, String jobId, String message) {
+      long id, long deploymentId, String jobId, String message) {
     transactions.executeWithoutResult(
         status -> {
-          DefinitionRow current = store.lockDefinition(id);
-          stateMachine.requireTransition(current.observedState(), "UNKNOWN");
+          store.lockDefinition(id);
+          DeploymentRow row = requireCurrentExecutionRow(id, deploymentId);
+          SyncExecution execution = row.execution();
+          executionStateMachine.requireTransition(execution, "UNKNOWN");
           store.reconcile(id, deploymentId, "UNKNOWN", "UNKNOWN", jobId, message);
           store.event(
               id,
-              deployment == null ? deploymentId : deployment.id(),
+              deploymentId,
               "STOP_UNCERTAIN",
-              current.observedState(),
+              execution.observedState().name(),
               "UNKNOWN",
               message);
         });
@@ -430,12 +441,9 @@ public class RealtimeJobService {
 
       PublishedDefinitionRow restartPublished = requirePublishedDefinition(id);
       stopLocked(id);
-      DefinitionRow current =
-          store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
-      if (!"STOPPED".equals(current.desiredState())
-          || !("STOPPED".equals(current.observedState())
-              || "FAILED".equals(current.observedState()))) {
-        throw new IllegalStateException("任务仍在停止中，请稍后使用相同 Idempotency-Key 重试重启");
+      SyncExecution settled = store.latestExecution(id).orElse(null);
+      if (settled != null && settled.activeOrUncertain()) {
+        throw new IllegalStateException("Execution 仍在停止中，请稍后使用相同 Idempotency-Key 重试重启");
       }
       return startLocked(id, key, restartPublished.id());
     } finally {
@@ -446,8 +454,8 @@ public class RealtimeJobService {
   public void delete(long id) {
     transactions.executeWithoutResult(
         status -> {
-          DefinitionRow locked = store.lockDefinition(id);
-          stateMachine.requireDefinitionMutable(locked.desiredState(), locked.observedState());
+          store.lockDefinition(id);
+          requireDefinitionMutable(id);
           store.delete(id);
         });
   }
@@ -534,6 +542,20 @@ public class RealtimeJobService {
     }
   }
 
+  private void requireDefinitionMutable(long id) {
+    executionStateMachine.requireDefinitionMutable(store.latestExecution(id).orElse(null));
+  }
+
+  private DeploymentRow requireCurrentExecutionRow(long taskId, long executionId) {
+    DeploymentRow latest =
+        store.latestDeployment(taskId)
+            .orElseThrow(() -> new IllegalStateException("SyncExecution 不存在：" + executionId));
+    if (latest.id() != executionId) {
+      throw new IllegalStateException("当前 SyncExecution 已变化，请刷新后重试");
+    }
+    return latest;
+  }
+
   private void waitForRuntimeStop(ComputeEnvironmentSnapshot runtimeEnvironment, String jobId) {
     for (int attempt = 0; attempt < 20; attempt++) {
       RuntimeStatus status = gateway.status(runtimeEnvironment, jobId);
@@ -557,18 +579,20 @@ public class RealtimeJobService {
   private void markStopped(long definitionId, long deploymentId, String jobId, String message) {
     transactions.executeWithoutResult(
         status -> {
-          DefinitionRow current = store.lockDefinition(definitionId);
-          if ("STOPPED".equals(current.desiredState())
-              && "STOPPED".equals(current.observedState())) {
+          store.lockDefinition(definitionId);
+          DeploymentRow row = requireCurrentExecutionRow(definitionId, deploymentId);
+          SyncExecution execution = row.execution();
+          if (execution.desiredState().name().equals("STOPPED")
+              && execution.observedState().name().equals("STOPPED")) {
             return;
           }
-          stateMachine.requireTransition(current.observedState(), "STOPPED");
+          executionStateMachine.requireTransition(execution, "STOPPED");
           store.reconcile(definitionId, deploymentId, "STOPPED", "STOPPED", jobId, null);
           store.event(
               definitionId,
               deploymentId,
               "STOPPED",
-              current.observedState(),
+              execution.observedState().name(),
               "STOPPED",
               message);
         });
@@ -613,7 +637,7 @@ public class RealtimeJobService {
 
   private ComputeEnvironmentSnapshot deploymentRuntime(long id, DeploymentRow deployment) {
     if (deployment == null) {
-      throw new IllegalStateException("任务尚无部署记录");
+      throw new IllegalStateException("任务尚无 Execution 记录");
     }
     DefinitionRow definition =
         store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
@@ -1,5 +1,5 @@
 -- Consolidated Realtime Sync schema baseline.
--- Runtime/definition/version/deployment/event references are logical and enforced by application services.
+-- Runtime/definition/version/execution/event references are logical and enforced by application services.
 CREATE TABLE IF NOT EXISTS yak_compute_environment (
     id BIGINT NOT NULL AUTO_INCREMENT,
     name VARCHAR(120) NOT NULL,
@@ -73,6 +73,9 @@ CREATE TABLE IF NOT EXISTS yak_realtime_job_deployment (
     spec_summary VARCHAR(1000) NULL,
     config_digest CHAR(64) NOT NULL,
     idempotency_key VARCHAR(128) NOT NULL,
+    engine_type VARCHAR(32) NOT NULL DEFAULT 'FLINK_CDC',
+    desired_state VARCHAR(16) NOT NULL DEFAULT 'RUNNING',
+    observed_state VARCHAR(32) NOT NULL DEFAULT 'STARTING',
     runtime_job_name VARCHAR(128) NULL,
     runtime_identity_state VARCHAR(16) NOT NULL DEFAULT 'REQUIRED',
     gateway_job_id VARCHAR(128) NULL,
@@ -88,6 +91,7 @@ CREATE TABLE IF NOT EXISTS yak_realtime_job_deployment (
     UNIQUE KEY uk_realtime_runtime_job_name (runtime_job_name),
     KEY idx_realtime_deployment_definition (definition_id, id),
     KEY idx_realtime_deployment_definition_version (definition_version_id, id),
+    KEY idx_realtime_execution_state (definition_id, observed_state, id),
     KEY idx_realtime_deployment_environment (runtime_environment_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobCommandMapper.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobCommandMapper.xml
@@ -5,9 +5,29 @@
     SELECT * FROM yak_realtime_job_definition WHERE id = #{id} FOR UPDATE
   </select>
   <select id="lockOtherDesiredRunning" resultType="long">
-    SELECT id FROM yak_realtime_job_definition
-    WHERE id &lt;&gt; #{id} AND desired_state = 'RUNNING'
+    SELECT p.id
+    FROM yak_realtime_job_deployment p
+    WHERE p.definition_id &lt;&gt; #{id}
+      AND p.id = (
+        SELECT MAX(p2.id)
+        FROM yak_realtime_job_deployment p2
+        WHERE p2.definition_id = p.definition_id
+      )
+      AND p.desired_state = 'RUNNING'
+      AND p.observed_state IN ('STARTING','RUNNING','STOPPING','UNKNOWN','CONFLICT')
     FOR UPDATE
+  </select>
+  <select id="reconcileExecutions"
+          resultType="io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO">
+    SELECT p.*
+    FROM yak_realtime_job_deployment p
+    WHERE p.id = (
+      SELECT MAX(p2.id)
+      FROM yak_realtime_job_deployment p2
+      WHERE p2.definition_id = p.definition_id
+    )
+      AND p.observed_state IN ('STARTING','RUNNING','STOPPING','UNKNOWN','CONFLICT')
+    ORDER BY p.definition_id ASC
   </select>
   <update id="tryAcquireLease">
     UPDATE yak_realtime_runtime_lease
@@ -17,8 +37,10 @@
   </update>
   <update id="reconcileDeployment">
     UPDATE yak_realtime_job_deployment
-    SET status = #{deploymentState},
+    SET observed_state = #{observedState},
+        status = #{deploymentState},
         gateway_job_id = COALESCE(gateway_job_id, #{engineJobId}),
+        result_uncertain = CASE WHEN #{observedState} = 'UNKNOWN' THEN result_uncertain ELSE 0 END,
         error_message = #{error}
     WHERE id = #{deploymentId}
   </update>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobQueryMapper">
+  <sql id="latestExecutionJoin">
+    LEFT JOIN yak_realtime_job_deployment p
+      ON p.id = (SELECT MAX(p2.id) FROM yak_realtime_job_deployment p2 WHERE p2.definition_id = d.id)
+  </sql>
+
   <sql id="filters">
     <where>
       <if test="keyword != null and keyword != ''">
@@ -8,14 +13,22 @@
       </if>
       <if test="id != null">AND d.id = #{id}</if>
       <if test="releaseState != null and releaseState != ''">AND d.release_state = #{releaseState}</if>
-      <if test="stateGroup == 'RUNNING'">AND d.observed_state IN ('STARTING','RUNNING','STOPPING')</if>
-      <if test="stateGroup == 'STOPPED'">AND d.observed_state = 'STOPPED'</if>
-      <if test="stateGroup == 'ABNORMAL'">AND d.observed_state IN ('FAILED','UNKNOWN','CONFLICT')</if>
+      <if test="stateGroup == 'RUNNING'">
+        AND COALESCE(p.observed_state, d.observed_state) IN ('STARTING','RUNNING','STOPPING')
+      </if>
+      <if test="stateGroup == 'STOPPED'">
+        AND COALESCE(p.observed_state, d.observed_state) = 'STOPPED'
+      </if>
+      <if test="stateGroup == 'ABNORMAL'">
+        AND COALESCE(p.observed_state, d.observed_state) IN ('FAILED','UNKNOWN','CONFLICT')
+      </if>
     </where>
   </sql>
 
   <select id="count" resultType="long">
-    SELECT COUNT(*) FROM yak_realtime_job_definition d
+    SELECT COUNT(*)
+    FROM yak_realtime_job_definition d
+    <include refid="latestExecutionJoin"/>
     <include refid="filters"/>
   </select>
 
@@ -26,12 +39,12 @@
            d.runtime_environment_id,
            d.spec_json,
            d.release_state,
-           d.desired_state,
-           d.observed_state,
+           COALESCE(p.desired_state, d.desired_state) AS desired_state,
+           COALESCE(p.observed_state, d.observed_state) AS observed_state,
            d.definition_version,
            d.published_version,
            d.config_digest,
-           d.last_error,
+           CASE WHEN p.id IS NULL THEN d.last_error ELSE p.error_message END AS last_error,
            d.create_time,
            d.update_time,
            p.id AS deployment_id,
@@ -48,8 +61,7 @@
            p.create_time AS deployment_create_time,
            p.update_time AS deployment_update_time
     FROM yak_realtime_job_definition d
-    LEFT JOIN yak_realtime_job_deployment p
-      ON p.id = (SELECT MAX(p2.id) FROM yak_realtime_job_deployment p2 WHERE p2.definition_id = d.id)
+    <include refid="latestExecutionJoin"/>
     <include refid="filters"/>
     ORDER BY d.update_time DESC, d.id DESC
     LIMIT #{limit} OFFSET #{offset}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachineTest.java
@@ -1,0 +1,78 @@
+package io.yak.ops.business.sync.realtime.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution.EngineExecutionRef;
+import org.junit.jupiter.api.Test;
+
+class SyncExecutionStateMachineTest {
+
+  private final SyncExecutionStateMachine stateMachine = new SyncExecutionStateMachine();
+
+  @Test
+  void terminalExecutionCannotBeResurrected() {
+    SyncExecution failed = execution(DesiredState.STOPPED, ObservedState.FAILED);
+    SyncExecution stopped = execution(DesiredState.STOPPED, ObservedState.STOPPED);
+
+    assertThatThrownBy(() -> stateMachine.requireTransition(failed, "STARTING"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("FAILED -> STARTING");
+    assertThatThrownBy(() -> stateMachine.requireTransition(stopped, "STARTING"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("STOPPED -> STARTING");
+
+    assertThatCode(() -> stateMachine.requireNewExecutionAllowed(failed)).doesNotThrowAnyException();
+    assertThatCode(() -> stateMachine.requireNewExecutionAllowed(stopped)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void activeOrUncertainExecutionBlocksAnotherExecution() {
+    for (ObservedState state :
+        new ObservedState[] {
+          ObservedState.STARTING,
+          ObservedState.RUNNING,
+          ObservedState.STOPPING,
+          ObservedState.UNKNOWN,
+          ObservedState.CONFLICT
+        }) {
+      SyncExecution current =
+          execution(
+              state == ObservedState.STOPPING ? DesiredState.STOPPED : DesiredState.RUNNING,
+              state);
+      assertThatThrownBy(() -> stateMachine.requireNewExecutionAllowed(current))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("请勿重复启动");
+    }
+  }
+
+  @Test
+  void definitionMutationPolicyReadsExecutionLifecycle() {
+    assertThatCode(
+            () ->
+                stateMachine.requireDefinitionMutable(
+                    execution(DesiredState.STOPPED, ObservedState.FAILED)))
+        .doesNotThrowAnyException();
+
+    assertThatThrownBy(
+            () ->
+                stateMachine.requireDefinitionMutable(
+                    execution(DesiredState.RUNNING, ObservedState.RUNNING)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("只有已停止或明确失败");
+  }
+
+  private SyncExecution execution(DesiredState desired, ObservedState observed) {
+    return new SyncExecution(
+        19L,
+        7L,
+        31L,
+        desired,
+        observed,
+        new EngineExecutionRef("FLINK_CDC", null),
+        observed == ObservedState.UNKNOWN,
+        null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapterExecutionProjectionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapterExecutionProjectionTest.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.sync.realtime.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.dao.RealtimeJobDao;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
+import io.yak.ops.business.sync.realtime.repository.support.RealtimeJsonCodec;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+class RealtimeJobStoreAdapterExecutionProjectionTest {
+
+  @Test
+  void detailProjectionUsesLatestExecutionStateInsteadOfStaleTaskRuntimeProjection() {
+    RealtimeJobDao dao = mock(RealtimeJobDao.class);
+    RealtimeJsonCodec json = mock(RealtimeJsonCodec.class);
+    RealtimeJobListQuery listQuery = mock(RealtimeJobListQuery.class);
+    ApplicationEventPublisher events = mock(ApplicationEventPublisher.class);
+    RealtimeJobStoreAdapter store = new RealtimeJobStoreAdapter(dao, json, listQuery, events);
+
+    RealtimeJobDefinitionPO task = new RealtimeJobDefinitionPO();
+    task.setId(7L);
+    task.setJobName("orders-sync");
+    task.setRuntimeEnvironmentId(4L);
+    task.setReleaseState("DRAFT");
+    task.setDesiredState("RUNNING");
+    task.setObservedState("UNKNOWN");
+    task.setDefinitionVersion(4);
+    task.setPublishedVersion(3);
+    task.setLastError("stale task projection error");
+    task.setCreateTime(LocalDateTime.now());
+    task.setUpdateTime(LocalDateTime.now());
+
+    RealtimeJobDeploymentPO execution = new RealtimeJobDeploymentPO();
+    execution.setId(19L);
+    execution.setDefinitionId(7L);
+    execution.setDefinitionVersionId(31L);
+    execution.setDefinitionVersion(3);
+    execution.setRuntimeEnvironmentId(3L);
+    execution.setRuntimeEnvironmentVersion(2);
+    execution.setRuntimeEnvironmentSnapshotJson("{}");
+    execution.setSpecSnapshotJson("{}");
+    execution.setConfigDigest("a".repeat(64));
+    execution.setIdempotencyKey("exec-19");
+    execution.setEngineType("FLINK_CDC");
+    execution.setDesiredState("STOPPED");
+    execution.setObservedState("STOPPED");
+    execution.setStatus("STOPPED");
+    execution.setResultUncertain(false);
+    execution.setErrorMessage(null);
+    execution.setCreateTime(LocalDateTime.now());
+    execution.setUpdateTime(LocalDateTime.now());
+
+    ComputeEnvironmentSnapshot runtime =
+        new ComputeEnvironmentSnapshot(
+            3L,
+            "published-env",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://127.0.0.1:8081",
+                "/opt/flink",
+                "/opt/flink-cdc",
+                null,
+                "1.20.5",
+                "3.6.0"),
+            2);
+
+    when(dao.findDefinition(7L)).thenReturn(Optional.of(task));
+    when(dao.latestDeployment(7L)).thenReturn(Optional.of(execution));
+    when(json.readEnvironmentSnapshot("{}")).thenReturn(runtime);
+
+    RealtimeJobView view = store.view(7L);
+
+    assertThat(view.desiredState()).isEqualTo("STOPPED");
+    assertThat(view.observedState()).isEqualTo("STOPPED");
+    assertThat(view.lastError()).isNull();
+    assertThat(view.releaseState()).isEqualTo("DRAFT");
+    assertThat(view.latestDeployment().runtimeEnvironment().id()).isEqualTo(3L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
@@ -14,6 +14,7 @@ import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.PublicationSnapshot;
 import io.yak.ops.business.sync.realtime.repository.DefinitionVersionRepository.StoredVersion;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -158,6 +159,20 @@ class VersioningRealtimeJobStoreTest {
     assertThatThrownBy(() -> store.publishedDefinition(TASK_ID))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("不属于当前实时同步任务");
+  }
+
+  @Test
+  void primaryVersioningStoreDelegatesExecutionReconcileCandidates() {
+    RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
+    DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
+    VersioningRealtimeJobStore store =
+        new VersioningRealtimeJobStore(
+            delegate, versions, new CdcPipelineSpecCompatibilityMapper());
+    DeploymentRow execution = mock(DeploymentRow.class);
+    when(delegate.reconcileCandidates()).thenReturn(List.of(execution));
+
+    assertThat(store.reconcileCandidates()).containsExactly(execution);
+    verify(delegate).reconcileCandidates();
   }
 
   private DefinitionRow definitionRow(CdcPipelineSpec spec) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionPathTest.java
@@ -16,7 +16,7 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
-import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
 import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
@@ -95,10 +95,13 @@ class RealtimeExecutionPathTest {
     CdcPipelineSpec spec = spec();
     ComputeEnvironmentSnapshot environment = environment();
     ResolvedCdcPipeline resolved = resolved();
-    DefinitionRow publishedStopped = definition(spec, environment.id(), "PUBLISHED", "STOPPED", "STOPPED", 1, 1);
-    DefinitionRow starting = definition(spec, environment.id(), "PUBLISHED", "RUNNING", "STARTING", 1, 1);
+    DefinitionRow publishedStopped =
+        definition(spec, environment.id(), "PUBLISHED", "STOPPED", "STOPPED", 1, 1);
+    DefinitionRow starting =
+        definition(spec, environment.id(), "PUBLISHED", "RUNNING", "STARTING", 1, 1);
     PublishedDefinitionRow published = published(spec, environment.id(), 1, 1);
-    DeploymentRow deployment = deployment(spec, environment, DEFINITION_VERSION_ID, 1);
+    DeploymentRow startingExecution =
+        deployment(spec, environment, DEFINITION_VERSION_ID, 1, "SUBMITTING");
 
     ObjectNode capabilities = capabilities(json);
 
@@ -106,11 +109,12 @@ class RealtimeExecutionPathTest {
     when(store.spec(any())).thenReturn(spec);
     when(store.runtimeEnvironmentId(JOB_ID)).thenReturn(environment.id());
     when(store.publishedDefinition(JOB_ID)).thenReturn(Optional.of(published));
+    when(store.latestExecution(JOB_ID)).thenReturn(Optional.empty());
     when(store.lockDefinition(JOB_ID)).thenReturn(publishedStopped, publishedStopped, starting);
     when(store.deploymentByIdempotencyKey("exec-1")).thenReturn(Optional.empty());
     when(store.insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("exec-1")))
         .thenReturn(DEPLOYMENT_ID);
-    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(startingExecution));
     when(runtimeResolver.definition(any(), eq(true))).thenReturn(environment);
     when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
     when(dataSourceResolver.resolve(spec)).thenReturn(resolved);
@@ -123,16 +127,17 @@ class RealtimeExecutionPathTest {
     when(gateway.deploy(eq(environment), any()))
         .thenReturn(new DeployResult(FLINK_JOB_ID, "at-least-once"));
 
-    RealtimeJobService service = service(
-        store,
-        json,
-        specValidator,
-        dataSourceResolver,
-        capabilityResolver,
-        compiler,
-        gateway,
-        runtimeResolver,
-        transactionManager);
+    RealtimeJobService service =
+        service(
+            store,
+            json,
+            specValidator,
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
 
     service.publish(JOB_ID);
     service.start(JOB_ID, "exec-1");
@@ -149,7 +154,9 @@ class RealtimeExecutionPathTest {
 
     verify(store)
         .insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("exec-1"));
-    verify(store).markDeploymentRunning(JOB_ID, DEPLOYMENT_ID, FLINK_JOB_ID, environment.runtimeRevision());
+    verify(store)
+        .markDeploymentRunning(
+            JOB_ID, DEPLOYMENT_ID, FLINK_JOB_ID, environment.runtimeRevision());
   }
 
   @Test
@@ -184,23 +191,40 @@ class RealtimeExecutionPathTest {
     long newerDraftEnvironmentId = 4L;
     ResolvedCdcPipeline resolved = resolved();
     DefinitionRow draftStopped =
-        definition(newerDraft, newerDraftEnvironmentId, "DRAFT", "STOPPED", "STOPPED", 2, 1);
-    DefinitionRow starting =
-        definition(newerDraft, newerDraftEnvironmentId, "DRAFT", "RUNNING", "STARTING", 2, 1);
-    PublishedDefinitionRow published = published(publishedSpec, publishedEnvironment.id(), 1, 1);
-    DeploymentRow deployment =
-        deployment(publishedSpec, publishedEnvironment, DEFINITION_VERSION_ID, 1);
+        definition(
+            newerDraft,
+            newerDraftEnvironmentId,
+            "DRAFT",
+            "STOPPED",
+            "STOPPED",
+            2,
+            1);
+    DefinitionRow staleStartingProjection =
+        definition(
+            newerDraft,
+            newerDraftEnvironmentId,
+            "DRAFT",
+            "RUNNING",
+            "STARTING",
+            2,
+            1);
+    PublishedDefinitionRow published =
+        published(publishedSpec, publishedEnvironment.id(), 1, 1);
+    DeploymentRow startingExecution =
+        deployment(publishedSpec, publishedEnvironment, DEFINITION_VERSION_ID, 1, "SUBMITTING");
     ObjectNode capabilities = capabilities(json);
 
     when(store.definition(JOB_ID)).thenReturn(Optional.of(draftStopped));
     when(store.publishedDefinition(JOB_ID)).thenReturn(Optional.of(published));
-    when(store.lockDefinition(JOB_ID)).thenReturn(draftStopped, starting);
+    when(store.latestExecution(JOB_ID)).thenReturn(Optional.empty());
+    when(store.lockDefinition(JOB_ID)).thenReturn(draftStopped, staleStartingProjection);
     when(store.deploymentByIdempotencyKey("published-v1")).thenReturn(Optional.empty());
     when(store.insertDeployment(
             any(), eq(publishedSpec), any(), any(), eq(publishedEnvironment), eq("published-v1")))
         .thenReturn(DEPLOYMENT_ID);
-    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
-    when(runtimeResolver.environment(publishedEnvironment.id(), true)).thenReturn(publishedEnvironment);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(startingExecution));
+    when(runtimeResolver.environment(publishedEnvironment.id(), true))
+        .thenReturn(publishedEnvironment);
     when(dataSourceResolver.resolve(publishedSpec)).thenReturn(resolved);
     when(dataSourceResolver.resolveCredentials(publishedSpec)).thenReturn(credentials());
     when(gateway.capabilities(publishedEnvironment)).thenReturn(capabilities);
@@ -211,16 +235,17 @@ class RealtimeExecutionPathTest {
     when(gateway.deploy(eq(publishedEnvironment), any()))
         .thenReturn(new DeployResult(FLINK_JOB_ID, "at-least-once"));
 
-    RealtimeJobService service = service(
-        store,
-        json,
-        specValidator,
-        dataSourceResolver,
-        capabilityResolver,
-        compiler,
-        gateway,
-        runtimeResolver,
-        transactionManager);
+    RealtimeJobService service =
+        service(
+            store,
+            json,
+            specValidator,
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
 
     service.start(JOB_ID, "published-v1");
 
@@ -230,7 +255,12 @@ class RealtimeExecutionPathTest {
     verify(runtimeResolver, never()).environment(newerDraftEnvironmentId, true);
     verify(store)
         .insertDeployment(
-            any(), eq(publishedSpec), any(), any(), eq(publishedEnvironment), eq("published-v1"));
+            any(),
+            eq(publishedSpec),
+            any(),
+            any(),
+            eq(publishedEnvironment),
+            eq("published-v1"));
     verify(store).bindDeploymentDefinitionVersion(DEPLOYMENT_ID, DEFINITION_VERSION_ID, 1);
   }
 
@@ -248,7 +278,7 @@ class RealtimeExecutionPathTest {
         store,
         json,
         specValidator,
-        new RealtimeStateMachine(),
+        new SyncExecutionStateMachine(),
         dataSourceResolver,
         capabilityResolver,
         compiler,
@@ -369,7 +399,8 @@ class RealtimeExecutionPathTest {
       CdcPipelineSpec spec,
       ComputeEnvironmentSnapshot environment,
       Long definitionVersionId,
-      int sourceDraftRevision) {
+      int sourceDraftRevision,
+      String status) {
     LocalDateTime now = LocalDateTime.now();
     return new DeploymentRow(
         DEPLOYMENT_ID,
@@ -380,10 +411,10 @@ class RealtimeExecutionPathTest {
         "mysql#1 -> mysql#2, tables=1",
         "pipeline-digest",
         "exec-1",
-        FLINK_JOB_ID,
+        null,
         environment.runtimeRevision(),
         environment,
-        "RUNNING",
+        status,
         false,
         null,
         now,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobLifecycleCoordinatorTest.java
@@ -11,7 +11,7 @@ import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
-import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
 import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.RuntimeStatus;
@@ -31,6 +31,7 @@ class RealtimeJobLifecycleCoordinatorTest {
 
   private static final long JOB_ID = 7L;
   private static final long DEPLOYMENT_ID = 19L;
+  private static final long DEFINITION_VERSION_ID = 31L;
   private static final String FLINK_JOB_ID = "0123456789abcdef0123456789abcdef";
 
   private RealtimeJobStore store;
@@ -54,74 +55,132 @@ class RealtimeJobLifecycleCoordinatorTest {
     when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
     RealtimeSyncProperties properties = new RealtimeSyncProperties();
     properties.setReconcileFailureThreshold(3);
-    coordinator = new RealtimeJobLifecycleCoordinator(
-        store,
-        identityStore,
-        discovery,
-        gateway,
-        runtimeResolver,
-        new RealtimeStateMachine(),
-        properties,
-        10,
-        transactionManager);
+    coordinator =
+        new RealtimeJobLifecycleCoordinator(
+            store,
+            identityStore,
+            discovery,
+            gateway,
+            runtimeResolver,
+            new SyncExecutionStateMachine(),
+            properties,
+            10,
+            transactionManager);
   }
 
   @Test
-  void recoversMissingJobIdThenReconcilesRunning() {
-    DefinitionRow definition = definition("RUNNING", "UNKNOWN");
-    DeploymentRow deployment = deployment(null, "UNKNOWN", LocalDateTime.now());
+  void recoversMissingJobIdThenReconcilesRunningFromExecutionEvenIfTaskProjectionIsStale() {
+    // Deliberately stale Task projection. Execution remains the lifecycle source of truth.
+    DefinitionRow definition = definition("STOPPED", "STOPPED");
+    DeploymentRow execution =
+        execution(null, "RUNNING", "UNKNOWN", "UNKNOWN", LocalDateTime.now());
     when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
     when(store.lockDefinition(JOB_ID)).thenReturn(definition);
-    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(execution));
     when(identityStore.findByDeploymentId(DEPLOYMENT_ID)).thenReturn(Optional.of("yak-rt-test"));
     when(discovery.findJobIds(environment, "yak-rt-test")).thenReturn(List.of(FLINK_JOB_ID));
-    when(gateway.status(environment, FLINK_JOB_ID)).thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
+    when(gateway.status(environment, FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
 
     coordinator.reconcile(JOB_ID);
 
-    verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "UNKNOWN", "UNKNOWN", FLINK_JOB_ID, null);
-    verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "RUNNING", "RUNNING", FLINK_JOB_ID, null);
-    verify(store).event(JOB_ID, DEPLOYMENT_ID, "FLINK_JOB_ID_RECOVERED", "UNKNOWN", "UNKNOWN", "已通过 runtime job identity 找回 Flink JobId：" + FLINK_JOB_ID);
+    verify(store)
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "UNKNOWN", "UNKNOWN", FLINK_JOB_ID, null);
+    verify(store)
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "RUNNING", "RUNNING", FLINK_JOB_ID, null);
+    verify(store)
+        .event(
+            JOB_ID,
+            DEPLOYMENT_ID,
+            "FLINK_JOB_ID_RECOVERED",
+            "UNKNOWN",
+            "UNKNOWN",
+            "已通过 runtime job identity 找回 Flink JobId：" + FLINK_JOB_ID);
   }
 
   @Test
-  void confirmsStoppedOnlyAfterRecoveryWindowAndNoMatchingFlinkJob() {
-    DefinitionRow definition = definition("STOPPED", "STOPPING");
-    DeploymentRow deployment = deployment(null, "UNKNOWN", LocalDateTime.now().minusMinutes(5));
-    when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
-    when(store.lockDefinition(JOB_ID)).thenReturn(definition);
-    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+  void confirmsStoppedFromExecutionIntentEvenIfTaskProjectionStillSaysRunning() {
+    DefinitionRow staleTaskProjection = definition("RUNNING", "RUNNING");
+    DeploymentRow execution =
+        execution(
+            null,
+            "STOPPED",
+            "STOPPING",
+            "UNKNOWN",
+            LocalDateTime.now().minusMinutes(5));
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(staleTaskProjection));
+    when(store.lockDefinition(JOB_ID)).thenReturn(staleTaskProjection);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(execution));
     when(identityStore.findByDeploymentId(DEPLOYMENT_ID)).thenReturn(Optional.of("yak-rt-test"));
     when(discovery.findJobIds(environment, "yak-rt-test")).thenReturn(List.of());
 
     coordinator.reconcile(JOB_ID);
 
     verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", null, null);
-    verify(store).event(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPING", "STOPPED", "恢复窗口内未发现匹配的 Flink runtime job，已确认停止");
+    verify(store)
+        .event(
+            JOB_ID,
+            DEPLOYMENT_ID,
+            "STOPPED",
+            "STOPPING",
+            "STOPPED",
+            "恢复窗口内未发现匹配的 Flink runtime job，已确认停止");
   }
 
   @Test
   void keepsRuntimeUnknownInsteadOfPretendingStopped() {
-    DefinitionRow definition = definition("STOPPED", "STOPPING");
-    DeploymentRow deployment = deployment(FLINK_JOB_ID, "STOPPING", LocalDateTime.now());
+    DefinitionRow definition = definition("RUNNING", "RUNNING");
+    DeploymentRow execution =
+        execution(FLINK_JOB_ID, "STOPPED", "STOPPING", "STOPPING", LocalDateTime.now());
     when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
     when(store.lockDefinition(JOB_ID)).thenReturn(definition);
-    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
-    when(gateway.status(environment, FLINK_JOB_ID)).thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.UNKNOWN));
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(execution));
+    when(gateway.status(environment, FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.UNKNOWN));
 
     coordinator.reconcile(JOB_ID);
 
-    verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "UNKNOWN", "UNKNOWN", FLINK_JOB_ID, "Flink 当前运行状态未知");
-    verify(store, never()).reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", FLINK_JOB_ID, null);
+    verify(store)
+        .reconcile(
+            JOB_ID,
+            DEPLOYMENT_ID,
+            "UNKNOWN",
+            "UNKNOWN",
+            FLINK_JOB_ID,
+            "Flink 当前运行状态未知");
+    verify(store, never())
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", FLINK_JOB_ID, null);
+  }
+
+  @Test
+  void reconcileAllUsesExecutionCandidatesInsteadOfTaskDesiredStateScan() {
+    DefinitionRow staleTaskProjection = definition("STOPPED", "STOPPED");
+    DeploymentRow execution =
+        execution(FLINK_JOB_ID, "RUNNING", "RUNNING", "RUNNING", LocalDateTime.now());
+    when(store.reconcileCandidates()).thenReturn(List.of(execution));
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(staleTaskProjection));
+    when(store.lockDefinition(JOB_ID)).thenReturn(staleTaskProjection);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(execution));
+    when(gateway.status(environment, FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
+
+    coordinator.reconcileAll();
+
+    verify(store).reconcileCandidates();
+    verify(store, never()).desiredJobs();
+    verify(store)
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "RUNNING", "RUNNING", FLINK_JOB_ID, null);
   }
 
   @Test
   void refusesDeleteWhenFlinkJobIsStillActive() {
     DefinitionRow definition = definition("STOPPED", "FAILED");
-    DeploymentRow deployment = deployment(FLINK_JOB_ID, "FAILED", LocalDateTime.now());
+    DeploymentRow execution =
+        execution(FLINK_JOB_ID, "STOPPED", "FAILED", "FAILED", LocalDateTime.now());
     when(store.definition(JOB_ID)).thenReturn(Optional.of(definition));
-    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
-    when(gateway.status(environment, FLINK_JOB_ID)).thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(execution));
+    when(gateway.status(environment, FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.RUNNING));
 
     assertThatThrownBy(() -> coordinator.assertSafeToDelete(JOB_ID))
         .isInstanceOf(IllegalStateException.class)
@@ -129,11 +188,49 @@ class RealtimeJobLifecycleCoordinatorTest {
   }
 
   private DefinitionRow definition(String desired, String observed) {
-    return new DefinitionRow(JOB_ID, "test-job", null, null, environment.id(), "PUBLISHED", desired, observed, 1, 1, "digest", null, null, null);
+    return new DefinitionRow(
+        JOB_ID,
+        "test-job",
+        null,
+        null,
+        environment.id(),
+        "PUBLISHED",
+        desired,
+        observed,
+        1,
+        1,
+        "digest",
+        null,
+        null,
+        null);
   }
 
-  private DeploymentRow deployment(String engineJobId, String status, LocalDateTime createTime) {
-    return new DeploymentRow(DEPLOYMENT_ID, JOB_ID, 1, null, "summary", "digest", "key", engineJobId, null, environment, status, true, null, createTime, createTime);
+  private DeploymentRow execution(
+      String engineJobId,
+      String desiredState,
+      String observedState,
+      String status,
+      LocalDateTime createTime) {
+    return new DeploymentRow(
+        DEPLOYMENT_ID,
+        JOB_ID,
+        DEFINITION_VERSION_ID,
+        1,
+        null,
+        "summary",
+        "digest",
+        "key",
+        engineJobId,
+        null,
+        environment,
+        "FLINK_CDC",
+        desiredState,
+        observedState,
+        status,
+        "UNKNOWN".equals(observedState),
+        null,
+        createTime,
+        createTime);
   }
 
   private ComputeEnvironmentSnapshot snapshot() {
@@ -143,7 +240,13 @@ class RealtimeJobLifecycleCoordinatorTest {
         ComputeEnvironment.ENGINE_FLINK_CDC,
         ComputeEnvironment.DEPLOYMENT_REMOTE,
         ComputeEnvironment.SUBMITTER_LOCAL,
-        new RuntimeConfig("http://127.0.0.1:8081", "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
         2);
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
@@ -22,7 +22,11 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
-import io.yak.ops.business.sync.realtime.domain.RealtimeStateMachine;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution.EngineExecutionRef;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
 import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
 import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
@@ -75,54 +79,69 @@ class RealtimeJobServiceConcurrencyTest {
 
     ObjectMapper json = new ObjectMapper();
     ObjectNode capabilities = json.createObjectNode().put("runtimeVersion", "flink-cdc-cli-3.6.0");
-    environment = new ComputeEnvironmentSnapshot(
-        3L,
-        "test-env",
-        ComputeEnvironment.ENGINE_FLINK_CDC,
-        ComputeEnvironment.DEPLOYMENT_REMOTE,
-        ComputeEnvironment.SUBMITTER_LOCAL,
-        new RuntimeConfig("http://127.0.0.1:8081", "/opt/flink", "/opt/flink-cdc", null, "1.20.5", "3.6.0"),
-        2);
+    environment =
+        new ComputeEnvironmentSnapshot(
+            3L,
+            "test-env",
+            ComputeEnvironment.ENGINE_FLINK_CDC,
+            ComputeEnvironment.DEPLOYMENT_REMOTE,
+            ComputeEnvironment.SUBMITTER_LOCAL,
+            new RuntimeConfig(
+                "http://127.0.0.1:8081",
+                "/opt/flink",
+                "/opt/flink-cdc",
+                null,
+                "1.20.5",
+                "3.6.0"),
+            2);
     when(runtimeResolver.definition(any(), eq(true))).thenReturn(environment);
     when(runtimeResolver.deployment(any(), any())).thenReturn(environment);
     when(runtimeResolver.environment(anyLong(), eq(true))).thenReturn(environment);
     when(gateway.capabilities(environment)).thenReturn(capabilities);
-    when(gateway.validate(eq(environment), any())).thenReturn(new ValidationResult(true, "exactly-once"));
-    when(compiler.compile(any(), any(), any())).thenReturn(new CompiledPipeline("pipeline: test", "test"));
+    when(gateway.validate(eq(environment), any()))
+        .thenReturn(new ValidationResult(true, "exactly-once"));
+    when(compiler.compile(any(), any(), any()))
+        .thenReturn(new CompiledPipeline("pipeline: test", "test"));
 
-    spec = new CdcPipelineSpec(
-        1L,
-        2L,
-        List.of(new TableRoute("source_table", "sink_table", MatchMode.EXACT, List.of("id"))),
-        "initial",
-        SchemaEvolution.EVOLVE,
-        1,
-        10_000,
-        new RestartPolicy("none", 0, 0),
-        new SinkTuning(0, 100, 1000, 1024, 16, true));
+    spec =
+        new CdcPipelineSpec(
+            1L,
+            2L,
+            List.of(
+                new TableRoute(
+                    "source_table", "sink_table", MatchMode.EXACT, List.of("id"))),
+            "initial",
+            SchemaEvolution.EVOLVE,
+            1,
+            10_000,
+            new RestartPolicy("none", 0, 0),
+            new SinkTuning(0, 100, 1000, 1024, 16, true));
     stopped = definition("STOPPED", "STOPPED");
     when(store.spec(any())).thenReturn(spec);
     when(store.runtimeEnvironmentId(JOB_ID)).thenReturn(environment.id());
     when(store.publishedDefinition(JOB_ID)).thenReturn(Optional.of(published()));
 
-    service = new RealtimeJobService(
-        store,
-        json,
-        specValidator,
-        new RealtimeStateMachine(),
-        dataSourceResolver,
-        capabilityResolver,
-        compiler,
-        gateway,
-        runtimeResolver,
-        transactionManager);
+    service =
+        new RealtimeJobService(
+            store,
+            json,
+            specValidator,
+            new SyncExecutionStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
   }
 
   @Test
-  void rejectsDifferentKeyWhenAnotherInstanceAlreadyClaimedStarting() {
+  void activeExecutionBlocksAnotherStartEvenWhenTaskProjectionSaysStopped() {
     when(store.deploymentByIdempotencyKey("start-2")).thenReturn(Optional.empty());
     when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
-    when(store.lockDefinition(JOB_ID)).thenReturn(definition("RUNNING", "STARTING"));
+    when(store.lockDefinition(JOB_ID)).thenReturn(stopped);
+    when(store.latestExecution(JOB_ID))
+        .thenReturn(Optional.of(execution(DesiredState.RUNNING, ObservedState.RUNNING, null)));
 
     assertThatThrownBy(() -> service.start(JOB_ID, "start-2"))
         .isInstanceOf(IllegalStateException.class)
@@ -130,6 +149,37 @@ class RealtimeJobServiceConcurrencyTest {
 
     verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
     verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
+  void terminalExecutionAllowsNewStartEvenWhenTaskProjectionIsStaleActive() {
+    DefinitionRow staleTaskProjection = definition("RUNNING", "STARTING");
+    DeploymentRow failed = deployment(null, "FAILED");
+    DeploymentRow starting = deployment(null, "SUBMITTING");
+
+    when(store.deploymentByIdempotencyKey("terminal-restart")).thenReturn(Optional.empty());
+    when(store.definition(JOB_ID)).thenReturn(Optional.of(staleTaskProjection));
+    when(store.lockDefinition(JOB_ID)).thenReturn(staleTaskProjection, staleTaskProjection);
+    when(store.latestExecution(JOB_ID))
+        .thenReturn(Optional.of(execution(DesiredState.STOPPED, ObservedState.FAILED, null)));
+    when(store.insertDeployment(any(), any(), any(), any(), eq(environment), eq("terminal-restart")))
+        .thenReturn(DEPLOYMENT_ID);
+    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(starting));
+    when(dataSourceResolver.resolveCredentials(spec))
+        .thenReturn(
+            new CredentialBinding[] {
+              new CredentialBinding("source", "secret"),
+              new CredentialBinding("sink", "secret")
+            });
+    when(gateway.deploy(eq(environment), any()))
+        .thenReturn(new DeployResult("job-new", "exactly-once"));
+
+    // completeStart sees the newly created execution as STARTING/RUNNING desired.
+    assertThatCode(() -> service.start(JOB_ID, "terminal-restart")).doesNotThrowAnyException();
+
+    verify(store).insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("terminal-restart"));
+    verify(store).markDeploymentRunning(JOB_ID, DEPLOYMENT_ID, "job-new", environment.runtimeRevision());
+    verify(store, never()).markTerminalFailure(eq(JOB_ID), eq(failed.id()), any());
   }
 
   @Test
@@ -149,34 +199,43 @@ class RealtimeJobServiceConcurrencyTest {
 
   @Test
   void cancelsSubmittedJobWhenStopWinsDuringCliSubmission() {
-    DefinitionRow stopping = definition("STOPPED", "STOPPING");
-    DeploymentRow deployment = deployment("job-123", "STOPPING");
+    DeploymentRow stopping = deployment("job-123", "STOPPING");
 
     when(store.deploymentByIdempotencyKey("restart-safe")).thenReturn(Optional.empty());
     when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
-    when(store.lockDefinition(JOB_ID)).thenReturn(stopped, stopping, stopping);
+    when(store.lockDefinition(JOB_ID)).thenReturn(stopped, stopped, stopped);
+    when(store.latestExecution(JOB_ID)).thenReturn(Optional.empty());
     when(store.insertDeployment(any(), any(), any(), any(), eq(environment), eq("restart-safe")))
         .thenReturn(DEPLOYMENT_ID);
     when(dataSourceResolver.resolveCredentials(spec))
-        .thenReturn(new CredentialBinding[] {
-          new CredentialBinding("source", "secret"),
-          new CredentialBinding("sink", "secret")
-        });
-    when(gateway.deploy(eq(environment), any())).thenReturn(new DeployResult("job-123", "exactly-once"));
+        .thenReturn(
+            new CredentialBinding[] {
+              new CredentialBinding("source", "secret"),
+              new CredentialBinding("sink", "secret")
+            });
+    when(gateway.deploy(eq(environment), any()))
+        .thenReturn(new DeployResult("job-123", "exactly-once"));
     when(gateway.status(environment, "job-123"))
         .thenReturn(
             new RuntimeStatus("job-123", RuntimeStatus.State.RUNNING),
             new RuntimeStatus("job-123", RuntimeStatus.State.TERMINATED));
-    when(store.latestDeployment(JOB_ID)).thenReturn(Optional.of(deployment));
+    when(store.latestDeployment(JOB_ID))
+        .thenReturn(
+            Optional.of(stopping),
+            Optional.of(stopping),
+            Optional.of(stopping));
 
     assertThatCode(() -> service.start(JOB_ID, "restart-safe")).doesNotThrowAnyException();
 
     verify(store)
         .bindDeploymentDefinitionVersion(DEPLOYMENT_ID, DEFINITION_VERSION_ID, 1);
     verify(store, never()).markDeploymentRunning(anyLong(), anyLong(), any(), any());
-    verify(store).bindDeploymentForStop(DEPLOYMENT_ID, "job-123", "flink-cdc-cli-3.6.0@env-3-v2");
+    verify(store)
+        .bindDeploymentForStop(
+            DEPLOYMENT_ID, "job-123", "flink-cdc-cli-3.6.0@env-3-v2");
     verify(gateway).stop(environment, "job-123");
-    verify(store).reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", "job-123", null);
+    verify(store)
+        .reconcile(JOB_ID, DEPLOYMENT_ID, "STOPPED", "STOPPED", "job-123", null);
   }
 
   @Test
@@ -197,7 +256,7 @@ class RealtimeJobServiceConcurrencyTest {
         .thenReturn(Optional.of(original), Optional.of(changed));
     when(store.lockDefinition(JOB_ID)).thenReturn(stopped);
     when(store.latestDeployment(JOB_ID)).thenReturn(Optional.empty());
-    when(store.definition(JOB_ID)).thenReturn(Optional.of(stopped));
+    when(store.latestExecution(JOB_ID)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.restart(JOB_ID, "restart-pin"))
         .isInstanceOf(IllegalStateException.class)
@@ -254,6 +313,19 @@ class RealtimeJobServiceConcurrencyTest {
         false,
         null,
         null,
+        null);
+  }
+
+  private SyncExecution execution(
+      DesiredState desired, ObservedState observed, String engineJobId) {
+    return new SyncExecution(
+        DEPLOYMENT_ID,
+        JOB_ID,
+        DEFINITION_VERSION_ID,
+        desired,
+        observed,
+        new EngineExecutionRef("FLINK_CDC", engineJobId),
+        observed == ObservedState.UNKNOWN,
         null);
   }
 }


### PR DESCRIPTION
## 背景

Realtime Sync Stage 6 已完成：

```text
Wave 0  Core VO + legacy mapper
Wave 1  immutable DefinitionVersion
Wave 2  Start by Published DefinitionVersion
```

本 PR 完成 **Wave 3：Deployment -> SyncExecution + Desired/Observed ownership**。

目标不是新增运行功能，而是把“运行状态到底属于谁”真正落到代码和数据库：

```text
SyncExecution / deployment row
  desiredState
  observedState
  error
  DefinitionVersionRef
  RuntimeEnvironmentSnapshot
  EngineExecutionRef
        ↑
        │ authoritative lifecycle source of truth

RealtimeSyncTask row
  desiredState
  observedState
  lastError
        ↑
        │ compatibility projection / dual-write only
```

本 PR **不提前执行 Wave 4**，运行中编辑/发布仍然保持禁止。

## Domain Impact Analysis

```text
Bounded Context: Realtime Sync
Aggregate(s): SyncExecution（主） + RealtimeSyncTask（兼容投影）
SyncDefinition Area: 不改
Invariant/Lifecycle:
  - DesiredState / ObservedState ownership -> SyncExecution
  - Task-row runtime state -> compatibility projection
  - STOPPED / FAILED 对单个 Execution 是终态
  - 下一次 Start 必须创建新的 Execution
  - STARTING/RUNNING/STOPPING/UNKNOWN/CONFLICT 阻止第二 Active Execution
Layer: Domain + Application + Repository/DAO + DB + Query Projection
Stage-4 Gap:
  - GAP-04 Execution lifecycle ownership
  - GAP-05 Terminal Execution identity
Migration Wave: Wave 3
Safety:
  - Start Idempotency-Key 保留
  - Task row FOR UPDATE 继续作为跨实例 command mutex
  - start reservation 保留
  - stop-during-start 保留
  - UNKNOWN / CONFLICT recovery 保留
  - runtime identity / RuntimeEnvironmentSnapshot 保留
  - credential zeroization / Flink / SSH 不重写
Domain Gap: no
```

---

## 1. 新增真正的 SyncExecution Core Model

新增：

```text
SyncExecution
├── executionId
├── taskId
├── definitionVersionId
├── DesiredState
├── ObservedState
├── EngineExecutionRef
├── resultUncertain
└── errorMessage
```

其中：

```text
EngineExecutionRef
├── engineType
└── externalExecutionId
```

Core `SyncExecution` 保持纯 Java，不引入 Flink YAML / SSH / Spring 工具类等基础设施细节。

### 终态语义

```text
STOPPED
FAILED
```

对**同一个 Execution** 都是终态。

禁止：

```text
FAILED -> STARTING
STOPPED -> STARTING
```

再次启动：

```text
E100 FAILED
   ↓ Start
E101 STARTING
```

而不是复活 E100。

---

## 2. 新增 SyncExecutionStateMachine

状态机固定：

```text
STARTING -> RUNNING / STOPPING / FAILED / UNKNOWN / CONFLICT
RUNNING  -> STOPPING / FAILED / UNKNOWN / CONFLICT
STOPPING -> STOPPED / FAILED / UNKNOWN
UNKNOWN  -> RUNNING / STOPPING / STOPPED / FAILED / CONFLICT
CONFLICT -> RUNNING / STOPPING / STOPPED / FAILED / UNKNOWN
STOPPED  -> terminal
FAILED   -> terminal
```

新 Execution 创建规则：

```text
latest execution == null / STOPPED / FAILED
    -> allow new Execution

latest execution in STARTING/RUNNING/STOPPING/UNKNOWN/CONFLICT
    -> reject second Execution
```

Wave 3 仍保留现有产品策略：只要 latest Execution active/uncertain，就继续禁止编辑、发布、删除。

Wave 4 再单独放开编辑/发布。

---

## 3. Deployment 表演进为 SyncExecution persistence

`yak_realtime_job_deployment` 增加：

```text
engine_type
execution desired_state
execution observed_state
```

新 Execution reservation 初始化：

```text
engine_type = FLINK_CDC
desired_state = RUNNING
observed_state = STARTING
status = SUBMITTING   // legacy submission/read projection
```

已有 Wave 2 字段继续保留：

```text
definition_version_id
runtime_environment_snapshot_json
spec_snapshot_json
runtime identity / job id
```

因此现有 deployment row 已经具备 SyncExecution 的主要持久化证据。

### legacy status 暂不删除

当前仍保留：

```text
status = SUBMITTING/RUNNING/STOPPING/UNKNOWN/FAILED/STOPPED
```

它只是兼容 submission/read projection。

真正生命周期判断只读：

```text
desired_state
observed_state
```

Wave 6 再处理 legacy status/name cleanup。

---

## 4. Task Row 状态降级为 Compatibility Projection

`yak_realtime_job_definition` 暂时继续保存：

```text
desired_state
observed_state
last_error
```

但它们不再是 Application command 的运行真相。

写路径统一：

```text
1. 先更新 SyncExecution
2. 再 dual-write Task compatibility projection
```

例如启动成功：

```text
Execution: STARTING -> RUNNING
Task projection: RUNNING / RUNNING
```

停止请求：

```text
Execution: desired=STOPPED, observed=STOPPING
Task projection: STOPPED / STOPPING
```

UNKNOWN / FAILED / STOPPED 同理。

---

## 5. Task 行锁保留，但它只是 Command Mutex

本 PR **没有删除** Task row `SELECT ... FOR UPDATE`。

它继续用于：

```text
多 Yak Ops 实例之间串行化 Start/Stop/Save/Publish/Delete/Reconcile
```

但：

> 锁在哪张表，不代表生命周期属于那张表。

锁内的运行判断已经改为：

```text
latest SyncExecution
```

而不是：

```text
Task.desiredState / Task.observedState
```

因此既保留原来的并发安全，又完成领域 ownership 迁移。

---

## 6. Start 真正按 Execution 判断单活

旧逻辑：

```text
Task Row state -> requireStartable
Task FAILED -> STARTING
```

新逻辑：

```text
Task lock
 ↓
latest SyncExecution
 ↓
terminal / none ?
 ├─ yes -> INSERT new Execution STARTING
 └─ no  -> reject duplicate active Execution
```

因此：

```text
Task projection = STOPPED
Execution = RUNNING
```

仍然禁止第二次 Start。

反过来：

```text
Task projection = RUNNING/STARTING（旧/脏投影）
latest Execution = FAILED
```

允许创建**新的** Execution。

这两种情况都有测试锁定。

---

## 7. Start Event 不再伪造终态复活

新 Execution 的 `START_REQUESTED`：

```text
fromState = null
toState   = STARTING
```

不会写成：

```text
FAILED -> STARTING
STOPPED -> STARTING
```

上一条 Execution 的终态只作为 message 上下文，不作为新 Execution 的状态迁移。

---

## 8. Stop / CompleteStart / Failure 全部读取 Execution

### stop

```text
latest Execution terminal -> no-op
STOPPED + STOPPING -> in progress
otherwise -> Execution desired=STOPPED / observed=STOPPING
```

### stop-during-start

CLI 返回 JobId 后，`completeStart()` 重新读取当前 Execution：

```text
RUNNING + STARTING
  -> mark RUNNING

STOPPED + STOPPING
  -> bind exact JobId
  -> immediately cancel exact Flink job
```

不再读取 Task projection 判断谁赢了竞态。

### start failure

```text
Execution STARTING/STOPPING
  -> FAILED or UNKNOWN
```

`stopRequested` 也从 Execution.desiredState 判断。

---

## 9. Restart 当前按 Execution terminal 判断

Wave 5 才正式实现：

```text
RestartExecution(oldExecution.versionRef)
ApplyPublishedVersion(task.publishedRef)
```

Wave 3 仍保留 Wave 2 的 PublishedVersion pin，避免静默升级。

停止完成后判断：

```text
latest Execution terminal?
```

而不是 Task projection 是否 STOPPED/FAILED。

---

## 10. Reconcile 候选改为 latest Execution

旧 `reconcileAll()`：

```text
scan Task desired/observed
```

现在：

```text
store.reconcileCandidates()
  -> 每个 Task 的 latest Execution
  -> observed in STARTING/RUNNING/STOPPING/UNKNOWN/CONFLICT
```

重要：不是“历史里找一条 active Execution”。

SQL 明确要求：

```text
p.id = MAX(id) for same task
+
latest execution is active/uncertain
```

因此历史旧 RUNNING/UNKNOWN 记录不会在已有新终态 Execution 后被重新对账。

`desiredJobs()` 暂时保留兼容，但它也改为从 Execution 候选反推 Task，不再扫描 Task 状态。

`@Primary VersioningRealtimeJobStore` 明确 delegate `reconcileCandidates()`，并有测试防止默认空集合让 reconcile 静默失效。

---

## 11. LifecycleCoordinator 全面切到 Execution

以下逻辑全部改读 `DeploymentRow.execution()`：

```text
runtime JobId recovery
runtime RUNNING/TERMINATED/NONE/UNKNOWN mapping
stop intent
orphan settle
CONFLICT
engine unavailable
terminal failure
manual reconcile
safe delete lifecycle guard
```

例如 Task projection 故意是：

```text
STOPPED / STOPPED
```

但 Execution：

```text
RUNNING / UNKNOWN
```

找回 JobId 后仍按 Execution 正确恢复到 RUNNING。

反过来 Task projection 写 RUNNING，但 Execution desired=STOPPED/STOPPING，也会按 Execution 正确收敛到 STOPPED。

---

## 12. Read Model 优先投影 Execution

### detail

`RealtimeJobStoreAdapter.view()`：

```text
有 latest Execution：
  desiredState  <- Execution
  observedState <- Execution
  lastError     <- Execution

无 Execution：
  fallback Task projection
```

### list

SQL 同样：

```text
COALESCE(latest_execution.desired_state, task.desired_state)
COALESCE(latest_execution.observed_state, task.observed_state)
```

错误信息特别使用：

```text
CASE WHEN execution exists
     THEN execution.error_message
     ELSE task.last_error
END
```

不会在 Execution 已清空错误后，又把 Task 上的旧 `lastError` 显示回来。

因此前端 API 字段不变，不需要 Wave 3 前端改造。

---

## 13. DAO 的 Task-runtime SQL guard 被移除

旧 `updateDefinition/publish/delete` SQL 直接带：

```text
Task desired = STOPPED
Task observed in STOPPED/FAILED
```

这会让 Task Row 继续拥有 lifecycle。

Wave 3 删除这些 runtime predicates。

现有产品行为仍由 Application 在 Task 行锁内执行：

```text
executionStateMachine.requireDefinitionMutable(latestExecution)
```

所以：

```text
Wave 3 行为不变
ownership 已迁移
```

Wave 4 才可以安全移除 Save/Publish 的 execution mutable guard。

---

## 14. Protection List 保持

没有重写：

```text
Idempotency-Key
idempotent deployment lookup / unique persistence
Task FOR UPDATE command serialization
start reservation before external submit
same-key race recovery
stop-during-start
submission uncertainty -> UNKNOWN
CONFLICT
runtime identity persistence/recovery
RuntimeEnvironmentSnapshot
Published DefinitionVersion snapshot
submission-scoped credentials / zeroization
FlinkCdcEngineGateway
SSH runner
log redaction
multi-instance reconcile lease
```

---

## 15. 测试

新增：

### SyncExecutionStateMachineTest

验证：

- STOPPED / FAILED 不可复活；
- terminal Execution 允许创建下一条新 Execution；
- STARTING/RUNNING/STOPPING/UNKNOWN/CONFLICT 阻止第二条；
- definition mutation guard 读取 Execution lifecycle。

### RealtimeJobStoreAdapterExecutionProjectionTest

故意构造：

```text
Task = RUNNING / UNKNOWN + stale error
latest Execution = STOPPED / STOPPED + error=null
```

断言 detail 输出：

```text
STOPPED / STOPPED / error=null
```

证明 read model 以 Execution 为准。

更新 `RealtimeJobServiceConcurrencyTest`：

- active Execution 阻止 Start，即使 Task projection=STOPPED；
- terminal FAILED Execution 允许新 Start，即使 Task projection=RUNNING/STARTING；
- stop-during-start 继续保护；
- immutable Published ref/no-fallback 继续保护；
- restart version pin 继续保护。

更新 `RealtimeExecutionPathTest`：

- Start 路径使用新的 SyncExecutionStateMachine；
- 新 reservation 明确为 STARTING Execution；
- Published V1 + Draft V2 仍只运行 Published snapshot。

更新 `RealtimeJobLifecycleCoordinatorTest`：

- stale Task projection 不影响 Execution reconcile；
- Execution stop intent 优先；
- UNKNOWN 不伪装 STOPPED；
- reconcileAll 从 Execution candidates 出发，不再调用 Task desired scan；
- delete 仍检查真实 Flink 活动状态。

更新 `VersioningRealtimeJobStoreTest`：

- `@Primary` store 必须 delegate Execution reconcile candidates。

## 验证说明

当前执行环境仍无法解析 `github.com`，实际 `git clone` 失败：

```text
Could not resolve host: github.com
```

因此无法执行完整 Maven reactor/module 测试。

已使用 JDK 21 对新增纯 Core：

```text
SyncExecution
SyncExecutionStateMachine
```

做独立 `javac --release 21` 语法编译检查，已通过。

**不声明完整 Maven / CI 已通过。**

PR 创建后继续检查 GitHub workflow/status。

---

## 本 PR 明确不做

```text
Wave 4  运行中编辑 / 发布
Wave 5  RestartExecution vs ApplyPublishedVersion
Wave 6  legacy Task state / status / class/package cleanup
```

也不处理：

- audit-safe deletion（GAP-08）；
- checkpoint/restart policy runtime application；
- FINISHED normal completion / snapshot-only；
- Compute Environment package ownership；
- `configDigest` legacy naming；
- public API 暴露 ExecutionId / DefinitionVersionId 新字段。

---

## Domain Compliance Report

```text
Domain rule implemented:
  DesiredState / ObservedState are owned by SyncExecution.

Aggregate(s) changed:
  SyncExecution lifecycle + persistence
  RealtimeSyncTask runtime fields become compatibility projection

Invariant/lifecycle:
  STOPPED/FAILED Execution terminal
  every new Start inserts a new Execution
  active/uncertain latest Execution blocks another Start
  reconcile operates on latest Execution

Legacy compatibility kept:
  Task desired/observed/lastError dual-write
  deployment.status legacy projection
  existing REST/UI fields
  existing table name yak_realtime_job_deployment

Safety preserved:
  idempotency / Task row mutex / reservation
  stop-during-start / UNKNOWN / CONFLICT
  runtime identity / RuntimeEnvironmentSnapshot
  published version binding / credentials / Flink / SSH

DB migration mode:
  expand + dual-write/read; no legacy column drop

Known gaps remaining:
  Wave 4+
  audit-safe delete
  ExecutionPolicy runtime gaps
  FINISHED normal completion
```

## Branch

```text
feat/realtime-sync-domain-stage-6-wave-3
```

分支基于合并 #639 后最新 `main`，创建 PR 前已 squash 为单 commit，并确认 `behind_by=0`。