### PR TITLE
feat: allow realtime draft publishing during active execution

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
@@ -155,7 +155,7 @@ If legacy Published content cannot be reconstructed reliably, do not guess and d
 
 ---
 
-# 4. Draft and Published may coexist
+# 4. Draft, Published, and active Execution may coexist
 
 The following is valid and expected:
 
@@ -171,7 +171,27 @@ A newer Draft MUST NOT mutate or invalidate historical Published versions or run
 
 A newer Draft MUST NOT automatically become the version used by an existing Execution.
 
-After Stage-4 migration reaches the required wave, a newer Draft SHOULD NOT prevent starting the explicit Published version.
+Wave 4 current rule:
+
+```text
+Active/uncertain SyncExecution
+    MUST NOT block saving a newer Draft
+    MUST NOT block publishing a newer DefinitionVersion
+```
+
+Save/Publish MUST NOT mutate the active Execution's:
+
+```text
+DefinitionVersionRef
+RuntimeEnvironmentSnapshot
+DesiredState
+ObservedState
+EngineExecutionRef
+```
+
+Publishing while an Execution is active only advances `RealtimeSyncTask.publishedDefinitionRef`.
+
+Delete remains lifecycle-guarded and is NOT made safe merely because Save/Publish are now independent from execution state.
 
 Do not model Draft/Published as a permanent mutually-exclusive domain state.
 
@@ -248,9 +268,11 @@ Rules:
 - `CONFLICT` means ambiguous runtime identity; do not guess which external job is correct.
 - A submission timeout with uncertain external result MUST NOT immediately become a fresh retry that can double-run the task.
 
-Target ownership: Desired/Observed lifecycle belongs to `SyncExecution`, not `RealtimeSyncTask`.
+Current ownership (Wave 3+): Desired/Observed lifecycle belongs to `SyncExecution`, not `RealtimeSyncTask`.
 
-Legacy task-row state fields are compatibility/persistence shortcuts, not the final domain ownership model.
+Task-row `desired_state / observed_state / last_error` are compatibility projections only. They MUST NOT be used as command truth for Start/Stop/Reconcile or for deciding whether an Execution is active.
+
+Task row locking may remain a cross-instance command mutex; lock location does not imply lifecycle ownership.
 
 ---
 
@@ -271,6 +293,18 @@ E100(v3) -> stop -> E101(v4)
 MUST NOT implement a generic `restart()` that silently reads whatever version is currently published and upgrades the task.
 
 Restart MUST pin the DefinitionVersion of the Execution being restarted.
+
+Wave 4 transitional rule, until Wave 5 introduces explicit commands:
+
+```text
+active Execution.definitionVersionRef
+        !=
+Task.publishedDefinitionRef
+```
+
+MUST cause Restart to reject **before Stop is issued**. Do not stop the old version first and only then discover that Restart would upgrade it.
+
+Do not infer this comparison from legacy `definition_version / published_version` integers. Domain version identity is the immutable `DefinitionVersionId`.
 
 ---
 
@@ -564,20 +598,28 @@ Do not rewrite working Flink/SSH/recovery code merely to make packages look more
 Do not skip migration waves casually.
 
 ```text
-Wave 0  New Core VOs + legacy mapper, no behavior change
-Wave 1  Immutable DefinitionVersion persistence + publish dual-write
-Wave 2  Start by Published DefinitionVersion
-Wave 3  Deployment evolves to SyncExecution; move desired/observed ownership
-Wave 4  Only now allow editing/publishing while execution is active
-Wave 5  Separate RestartExecution from ApplyPublishedVersion
-Wave 6  Cleanup legacy fields/package/names
+Wave 0  New Core VOs + legacy mapper, no behavior change                     ✅
+Wave 1  Immutable DefinitionVersion persistence + publish dual-write          ✅
+Wave 2  Start by Published DefinitionVersion                                  ✅
+Wave 3  Deployment evolves to SyncExecution; move desired/observed ownership  ✅
+Wave 4  Allow editing/publishing while execution is active                     ✅ current
+Wave 5  Separate RestartExecution from ApplyPublishedVersion                   pending
+Wave 6  Cleanup legacy fields/package/names                                    pending
 ```
 
-Critical rule:
+Critical ordering rule:
 
 > **Wave 4 MUST NOT be implemented before Wave 3.**
 
-Today runtime state is still used in task-row/DAO CAS conditions. Removing only service-level guards would produce inconsistent concurrency semantics.
+Historical reason: before Wave 3, task-row state and DAO predicates participated in lifecycle ownership. Removing only service-level Save/Publish guards at that time would have produced inconsistent concurrency semantics.
+
+Current rule after Wave 3:
+
+```text
+Save Draft / Publish -> RealtimeSyncTask + DefinitionVersion lifecycle
+Start / Stop / Reconcile -> SyncExecution lifecycle
+Delete -> requires terminal Execution and runtime safety checks
+```
 
 Database migration MUST use:
 
@@ -598,12 +640,14 @@ CdcPipelineSpec                 -> compatibility definition model
 TableRoute                      -> compatibility route model
 definition_version              -> DraftRevision / legacy revision
 published_version               -> legacy published marker
-DefinitionRow desired/observed  -> latest execution projection / legacy ownership
-DeploymentRow                   -> close to SyncExecution persistence
+DefinitionRow desired/observed  -> latest SyncExecution compatibility projection
+DeploymentRow                   -> SyncExecution persistence compatibility row
 configDigest on definition      -> draft DefinitionDigest-like value
 configDigest on deployment      -> ExecutionArtifactDigest
 ReleaseState DRAFT/PUBLISHED    -> legacy/derived presentation state
 ```
+
+Do not compare legacy `definition_version / published_version` as if they were immutable Domain `DefinitionVersionId` values.
 
 Do not infer the target domain model solely from current class/table/field names.
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -97,7 +97,8 @@ public class RealtimeJobService {
                 return created;
               }
               DefinitionRow locked = store.lockDefinition(id); // cross-instance command mutex
-              requireDefinitionMutable(id);
+              // Draft belongs to RealtimeSyncTask, not SyncExecution. Active executions keep their
+              // immutable DefinitionVersion and RuntimeEnvironmentSnapshot while this draft evolves.
               store.updateDefinition(
                   id, name.trim(), description, spec, digest, runtimeEnvironmentId);
               store.event(
@@ -106,7 +107,7 @@ public class RealtimeJobService {
                   "DRAFT_SAVED",
                   locked.releaseState(),
                   "DRAFT",
-                  "已保存草稿并生成新定义版本");
+                  "已保存草稿并生成新定义版本；当前 SyncExecution 不受影响");
               return id;
             });
     return saved == null ? 0 : saved;
@@ -134,12 +135,12 @@ public class RealtimeJobService {
 
   public void publish(long id) {
     Prepared prepared = prepare(id, false);
-    requireDefinitionMutable(id);
     gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
     transactions.executeWithoutResult(
         status -> {
           DefinitionRow locked = store.lockDefinition(id); // cross-instance command mutex
-          requireDefinitionMutable(id);
+          // Publishing advances Task.publishedDefinitionRef only. Any active SyncExecution stays
+          // pinned to the immutable DefinitionVersion recorded when that execution was created.
           requirePreparedDefinitionCurrent(prepared, locked);
           store.publish(
               id, prepared.definition().definitionVersion(), prepared.definition().configDigest());
@@ -149,7 +150,7 @@ public class RealtimeJobService {
               "PUBLISHED",
               locked.releaseState(),
               "PUBLISHED",
-              "Flink CDC 校验通过，任务已发布");
+              "Flink CDC 校验通过，当前草稿已发布；已有 SyncExecution 继续运行原 DefinitionVersion");
         });
   }
 
@@ -440,12 +441,26 @@ public class RealtimeJobService {
       }
 
       PublishedDefinitionRow restartPublished = requirePublishedDefinition(id);
+      SyncExecution restartExecution =
+          store.latestExecution(id).orElseThrow(() -> new IllegalStateException("当前没有可重启的 SyncExecution"));
+      if (restartExecution.terminal()) {
+        throw new IllegalStateException("当前 SyncExecution 已结束，请直接启动已发布版本");
+      }
+      Long runningVersionId = restartExecution.definitionVersionId();
+      if (runningVersionId == null) {
+        throw new IllegalStateException("当前 SyncExecution 缺少 DefinitionVersionRef，无法安全重启");
+      }
+      if (runningVersionId.longValue() != restartPublished.id()) {
+        throw new IllegalStateException(
+            "当前运行版本与最新发布版本不同，拒绝通过重启隐式升级；请停止后显式启动最新发布版本");
+      }
+
       stopLocked(id);
       SyncExecution settled = store.latestExecution(id).orElse(null);
       if (settled != null && settled.activeOrUncertain()) {
         throw new IllegalStateException("Execution 仍在停止中，请稍后使用相同 Idempotency-Key 重试重启");
       }
-      return startLocked(id, key, restartPublished.id());
+      return startLocked(id, key, runningVersionId);
     } finally {
       lock.unlock();
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave4DefinitionMutationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave4DefinitionMutationTest.java
@@ -1,0 +1,215 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution.EngineExecutionRef;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.ValidationResult;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RealtimeWave4DefinitionMutationTest {
+
+  private static final long TASK_ID = 7L;
+  private static final long RUNNING_VERSION_ID = 31L;
+  private static final long NEW_PUBLISHED_VERSION_ID = 32L;
+
+  private RealtimeJobStore store;
+  private CdcPipelineSpecValidator specValidator;
+  private RealtimeDataSourceResolver dataSourceResolver;
+  private RealtimeConnectorCapabilityResolver capabilityResolver;
+  private PipelineYamlCompiler compiler;
+  private RealtimeEngineGateway gateway;
+  private RealtimeRuntimeResolver runtimeResolver;
+  private RealtimeJobService service;
+  private CdcPipelineSpec spec;
+  private ComputeEnvironmentSnapshot environment;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    specValidator = mock(CdcPipelineSpecValidator.class);
+    dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    capabilityResolver = mock(RealtimeConnectorCapabilityResolver.class);
+    compiler = mock(PipelineYamlCompiler.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    spec = spec();
+    environment = environment();
+    service =
+        new RealtimeJobService(
+            store,
+            new ObjectMapper(),
+            specValidator,
+            new SyncExecutionStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
+  }
+
+  @Test
+  void savesNewDraftWhilePreviousExecutionIsRunning() {
+    DefinitionRow task = task("PUBLISHED", 3, 3);
+    when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
+    when(store.lockDefinition(TASK_ID)).thenReturn(task);
+    when(store.latestExecution(TASK_ID)).thenReturn(Optional.of(runningExecution(RUNNING_VERSION_ID)));
+
+    service.save(TASK_ID, "orders-sync", "changed", spec, environment.id());
+
+    verify(store)
+        .updateDefinition(
+            TASK_ID, "orders-sync", "changed", spec, any(String.class), environment.id());
+    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never()).reconcile(anyLong(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void publishesNewVersionWhilePreviousExecutionKeepsRunning() {
+    DefinitionRow task = task("DRAFT", 4, 3);
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+    ObjectNode capabilities = new ObjectMapper().createObjectNode();
+    CompiledPipeline compiled = new CompiledPipeline("pipeline: v4", "orders");
+
+    when(store.definition(TASK_ID)).thenReturn(Optional.of(task));
+    when(store.spec(task)).thenReturn(spec);
+    when(store.runtimeEnvironmentId(TASK_ID)).thenReturn(environment.id());
+    when(store.lockDefinition(TASK_ID)).thenReturn(task);
+    when(store.latestExecution(TASK_ID)).thenReturn(Optional.of(runningExecution(RUNNING_VERSION_ID)));
+    when(runtimeResolver.definition(task, true)).thenReturn(environment);
+    when(dataSourceResolver.resolve(spec)).thenReturn(resolved);
+    when(gateway.capabilities(environment)).thenReturn(capabilities);
+    when(compiler.compile("orders-sync", spec, resolved)).thenReturn(compiled);
+    when(gateway.validate(environment, compiled.yaml()))
+        .thenReturn(new ValidationResult(true, "at-least-once"));
+
+    service.publish(TASK_ID);
+
+    verify(store).publish(TASK_ID, task.definitionVersion(), task.configDigest());
+    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never()).markDeploymentRunning(anyLong(), anyLong(), any(), any());
+  }
+
+  @Test
+  void restartRejectsImplicitUpgradeWhenPublishedRefAdvanced() {
+    SyncExecution running = runningExecution(RUNNING_VERSION_ID);
+    PublishedDefinitionRow latestPublished =
+        new PublishedDefinitionRow(
+            NEW_PUBLISHED_VERSION_ID,
+            TASK_ID,
+            4,
+            4,
+            spec,
+            environment.id(),
+            "a".repeat(64),
+            "b".repeat(64));
+
+    when(store.deploymentByIdempotencyKey("restart-v3")).thenReturn(Optional.empty());
+    when(store.publishedDefinition(TASK_ID)).thenReturn(Optional.of(latestPublished));
+    when(store.latestExecution(TASK_ID)).thenReturn(Optional.of(running));
+
+    assertThatThrownBy(() -> service.restart(TASK_ID, "restart-v3"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("拒绝通过重启隐式升级");
+
+    verify(store, never()).markStopping(anyLong(), any());
+    verify(gateway, never()).stop(any(), any());
+  }
+
+  private DefinitionRow task(String releaseState, int draftRevision, Integer publishedRevision) {
+    return new DefinitionRow(
+        TASK_ID,
+        "orders-sync",
+        "test",
+        spec,
+        environment.id(),
+        releaseState,
+        "RUNNING",
+        "RUNNING",
+        draftRevision,
+        publishedRevision,
+        "c".repeat(64),
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private SyncExecution runningExecution(long definitionVersionId) {
+    return new SyncExecution(
+        19L,
+        TASK_ID,
+        definitionVersionId,
+        DesiredState.RUNNING,
+        ObservedState.RUNNING,
+        new EngineExecutionRef("FLINK_CDC", "job-1"),
+        false,
+        null);
+  }
+
+  private ComputeEnvironmentSnapshot environment() {
+    return new ComputeEnvironmentSnapshot(
+        3L,
+        "test-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
+        2);
+  }
+
+  private CdcPipelineSpec spec() {
+    return new CdcPipelineSpec(
+        1L,
+        2L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                "orders", "ods_orders", CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}

--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
@@ -86,7 +86,9 @@ export default function RealtimeExecutionPanel({
         setValidated(true);
         const refreshed = await refreshJob();
         message.success(
-          refreshed.releaseState === 'PUBLISHED' ? '当前定义版本已发布' : '发布请求已完成',
+          refreshed.desiredState === 'RUNNING'
+            ? '当前草稿已发布；正在运行的 SyncExecution 继续使用启动时的 DefinitionVersion'
+            : '当前定义版本已发布',
         );
       } else if (action === 'start') {
         const refreshed = await waitForStartResult();
@@ -138,8 +140,8 @@ export default function RealtimeExecutionPanel({
       },
       {
         title: '运行校验',
-        description: 'Flink CDC / Connector',
-        status: validated || currentDraftPublished || running ? ('finish' as const) : ('process' as const),
+        description: '当前草稿 / Connector',
+        status: validated || currentDraftPublished ? ('finish' as const) : ('process' as const),
       },
       {
         title: '发布版本',
@@ -148,7 +150,7 @@ export default function RealtimeExecutionPanel({
           : hasPublishedVersion
             ? `已发布 v${current.publishedVersion} · 当前草稿未发布`
             : '锁定当前定义版本',
-        status: currentDraftPublished || running
+        status: currentDraftPublished
           ? ('finish' as const)
           : validated
             ? ('process' as const)
@@ -157,12 +159,12 @@ export default function RealtimeExecutionPanel({
               : ('wait' as const),
       },
       {
-        title: '启动任务',
+        title: '运行实例',
         description: running
-          ? stateLabel[current.observedState] || current.observedState
+          ? `${stateLabel[current.observedState] || current.observedState} · 固定启动时 DefinitionVersion`
           : hasUnpublishedChanges
-            ? `将启动已发布 v${current.publishedVersion}`
-            : '提交到 Flink CDC',
+            ? `下一次启动使用已发布 v${current.publishedVersion}`
+            : '等待启动',
         status: current.observedState === 'RUNNING'
           ? ('finish' as const)
           : hasPublishedVersion
@@ -181,7 +183,7 @@ export default function RealtimeExecutionPanel({
             <div>
               <div className="flex items-center gap-2 text-[12px] font-medium text-[var(--yak-brand-color)]">
                 <CheckCircleOutlined />
-                配置已保存 · 统一执行链路
+                配置已保存 · 定义与运行解耦
               </div>
               <h1 className="mb-0 mt-1 text-[20px] font-semibold text-[#101828]">{current.name}</h1>
               <div className="mt-1 text-[12px] text-[#98a2b3]">
@@ -203,7 +205,7 @@ export default function RealtimeExecutionPanel({
             <Steps responsive items={steps} />
           </Card>
 
-          {hasUnpublishedChanges && (
+          {hasUnpublishedChanges && !running && (
             <Alert
               className="mb-5"
               type="info"
@@ -213,12 +215,40 @@ export default function RealtimeExecutionPanel({
             />
           )}
 
+          {running && (
+            <Alert
+              className="mb-5"
+              type={hasUnpublishedChanges ? 'info' : 'success'}
+              showIcon
+              message={
+                hasUnpublishedChanges
+                  ? `当前 SyncExecution 正在运行，草稿 v${current.definitionVersion} 可继续编辑`
+                  : '当前 SyncExecution 与任务定义生命周期已解耦'
+              }
+              description={
+                hasUnpublishedChanges
+                  ? '保存草稿不会修改当前运行实例。发布草稿只会推进 Published DefinitionVersion；当前 Flink Job 继续使用启动时固定的 DefinitionVersion。'
+                  : '即使继续编辑或重新发布任务，当前运行实例仍保持启动时的 DefinitionVersion 与 RuntimeEnvironmentSnapshot，不会发生热更新。'
+              }
+            />
+          )}
+
+          {running && currentDraftPublished && (
+            <Alert
+              className="mb-5"
+              type="warning"
+              showIcon
+              message="发布不会热更新当前 SyncExecution"
+              description="Wave 4 的 Restart 也不会隐式升级版本：后端会用 immutable DefinitionVersionId 校验运行版本与最新 Published Ref；若不同会在停止前拒绝。Wave 5 会把 RestartExecution 与 ApplyPublishedVersion 正式拆成两个命令。"
+            />
+          )}
+
           {runtimeDisabled && currentDraftPublished && (
             <Alert
               className="mb-5"
               type="warning"
               showIcon
-              message="当前已发布版本绑定的运行环境暂不可提交任务"
+              message="当前草稿绑定的运行环境暂不可提交任务"
               description={runtimeDisabledReason}
             />
           )}
@@ -230,10 +260,10 @@ export default function RealtimeExecutionPanel({
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
                       <div className="flex items-center gap-2 text-[14px] font-semibold text-[#101828]">
-                        <SafetyOutlined /> 1. 校验运行环境
+                        <SafetyOutlined /> 1. 校验当前草稿
                       </div>
                       <div className="mt-1 text-[12px] leading-5 text-[#667085]">
-                        校验当前草稿绑定的运行环境和 Connector；启动时后端会再次按实际 Published Version 独立校验。
+                        校验当前草稿绑定的运行环境和 Connector；已有 SyncExecution 不参与这次定义校验。
                       </div>
                     </div>
                     <Button
@@ -253,16 +283,20 @@ export default function RealtimeExecutionPanel({
                         <CloudServerOutlined /> 2. 发布当前版本
                       </div>
                       <div className="mt-1 text-[12px] leading-5 text-[#667085]">
-                        发布会再次运行完整校验，并创建不可变的 DefinitionVersion。
+                        发布形成不可变 DefinitionVersion；运行中发布只推进 Task 的 Published Ref，不修改当前 SyncExecution。
                       </div>
                     </div>
                     <Button
                       type="primary"
                       loading={acting === 'publish'}
-                      disabled={Boolean(acting) || currentDraftPublished || running || !current.spec || runtimeDisabled}
+                      disabled={Boolean(acting) || currentDraftPublished || !current.spec || runtimeDisabled}
                       onClick={() => void run('publish')}
                     >
-                      {currentDraftPublished ? '已发布' : '发布当前版本'}
+                      {currentDraftPublished
+                        ? '已发布'
+                        : running
+                          ? '发布当前版本（不影响运行）'
+                          : '发布当前版本'}
                     </Button>
                   </div>
                 </div>
@@ -271,10 +305,10 @@ export default function RealtimeExecutionPanel({
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
                       <div className="flex items-center gap-2 text-[14px] font-semibold text-[#101828]">
-                        <PlayCircleOutlined /> 3. 启动实时任务
+                        <PlayCircleOutlined /> 3. 运行实例
                       </div>
                       <div className="mt-1 text-[12px] leading-5 text-[#667085]">
-                        启动只读取不可变的 Published DefinitionVersion，由 PipelineYamlCompiler 生成临时 Flink CDC YAML 后通过 LOCAL / SSH 提交。
+                        新 Start 只读取不可变 Published DefinitionVersion；已有运行实例始终保持自己的启动快照。
                       </div>
                     </div>
                     {running ? (
@@ -305,7 +339,7 @@ export default function RealtimeExecutionPanel({
             </Card>
 
             <div className="space-y-5">
-              <Card title="当前执行状态">
+              <Card title="当前状态">
                 <Descriptions size="small" column={1}>
                   <Descriptions.Item label="当前草稿">
                     v{current.definitionVersion} · {current.releaseState}
@@ -313,17 +347,17 @@ export default function RealtimeExecutionPanel({
                   <Descriptions.Item label="已发布版本">
                     {hasPublishedVersion ? `v${current.publishedVersion}` : '未发布'}
                   </Descriptions.Item>
+                  <Descriptions.Item label="当前运行定义">
+                    {running ? '启动时 DefinitionVersion 快照（保持不变）' : '无活动运行'}
+                  </Descriptions.Item>
                   <Descriptions.Item label="运行状态">
                     <Tag>{stateLabel[current.observedState] || current.observedState}</Tag>
                   </Descriptions.Item>
                   <Descriptions.Item label="当前草稿运行环境">
                     {capabilities.runtimeEnvironmentName || `环境 #${current.runtimeEnvironmentId}`}
                   </Descriptions.Item>
-                  <Descriptions.Item label="提交方式">
-                    {capabilities.submissionMode || '-'}
-                  </Descriptions.Item>
-                  <Descriptions.Item label="Flink / CDC">
-                    {capabilities.flinkVersion || '-'} / {capabilities.flinkCdcVersion || '-'}
+                  <Descriptions.Item label="运行实例环境">
+                    {current.latestDeployment?.runtimeEnvironment?.name || '无活动运行'}
                   </Descriptions.Item>
                   <Descriptions.Item label="Engine JobId">
                     {current.latestDeployment?.engineJobId || '-'}
@@ -343,8 +377,8 @@ export default function RealtimeExecutionPanel({
               <Alert
                 type="info"
                 showIcon
-                message="Wizard 与 YAML 共用这一条执行链路"
-                description="编辑方式不会写入任务运行定义。发布形成不可变 DefinitionVersion；启动只读取该版本快照，数据库不保存原生 Flink CDC YAML。"
+                message="Wizard 与 YAML 共用同一个 SyncDefinition"
+                description="编辑方式不会进入运行领域。发布形成不可变 DefinitionVersion；SyncExecution 只引用启动时的版本和运行环境快照。"
               />
             </div>
           </div>

--- a/yak-ops-ui/src/pages/realtime-sync/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/index.tsx
@@ -260,6 +260,12 @@ export default function RealtimeSync() {
         if (state === 'RUNNING') message.success('实时同步任务已启动');
         else if (state === 'STARTING') message.warning('Flink 任务仍在启动，请稍后刷新状态');
         else message.warning(`Flink 启动结果：${observedStateLabel[state] || state}`);
+      } else if (name === 'publish') {
+        message.success(
+          job.desiredState === 'RUNNING'
+            ? '当前草稿已发布，运行中的 SyncExecution 继续使用启动时的 DefinitionVersion'
+            : '当前草稿已发布',
+        );
       } else {
         message.success(name === 'validate' ? 'Flink CDC 校验通过' : '操作成功');
       }
@@ -387,7 +393,7 @@ export default function RealtimeSync() {
   };
 
   const moreItems = (job: RealtimeJob): MenuProps['items'] => {
-    const environment = boundEnvironment(job);
+    const running = job.desiredState === 'RUNNING';
     return [
       { key: 'detail', label: '查看运行详情' },
       {
@@ -397,13 +403,13 @@ export default function RealtimeSync() {
       },
       {
         key: 'publish',
-        label: '发布当前版本',
-        disabled: job.releaseState === 'PUBLISHED' || job.desiredState === 'RUNNING',
+        label: running ? '发布当前版本（不影响运行）' : '发布当前版本',
+        disabled: job.releaseState === 'PUBLISHED',
       },
       {
         key: 'restart',
         label: '重启任务',
-        disabled: job.desiredState !== 'RUNNING' || environment?.enabled === false,
+        disabled: !running,
       },
       {
         key: 'reconcile',
@@ -551,15 +557,16 @@ export default function RealtimeSync() {
 
         return (
           <div className="flex min-h-7 items-center gap-0.5 whitespace-nowrap">
-            <Button
-              type="link"
-              size="small"
-              className="!h-7 !px-1.5 !text-[12px]"
-              disabled={running}
-              onClick={() => history.push(`/sync/realtime/${job.id}/detail?scene=edit`)}
-            >
-              编辑
-            </Button>
+            <Tooltip title={running ? '运行中编辑只修改草稿，不影响当前 SyncExecution' : undefined}>
+              <Button
+                type="link"
+                size="small"
+                className="!h-7 !px-1.5 !text-[12px]"
+                onClick={() => history.push(`/sync/realtime/${job.id}/detail?scene=edit`)}
+              >
+                编辑
+              </Button>
+            </Tooltip>
             {running ? (
               <Button
                 type="link"


### PR DESCRIPTION
## 背景

Realtime Sync Stage 6 已完成：

```text
Wave 0  Core VO + legacy mapper
Wave 1  immutable DefinitionVersion
Wave 2  Start by Published DefinitionVersion
Wave 3  Deployment -> SyncExecution + Desired/Observed ownership
```

本 PR 完成 **Wave 4：允许运行中继续编辑 Draft / 发布新 DefinitionVersion**。

目标状态：

```text
SyncExecution E100(V3)  RUNNING
        +
RealtimeSyncTask Draft r4 可继续编辑/保存
        +
Publish -> DefinitionVersion V4
```

关键不变量：

```text
E100 仍然固定使用启动时的 V3
Task.publishedDefinitionRef -> V4
```

**发布不是热更新，编辑/发布不能修改当前 SyncExecution。**

本 PR 不提前实现 Wave 5 的 `RestartExecution / ApplyPublishedVersion` 两个正式命令。

---

## Domain Impact Analysis

```text
Bounded Context: Realtime Sync
Aggregate(s):
  - RealtimeSyncTask: Draft / PublishedDefinitionRef
  - SyncExecution: independent running instance
SyncDefinition Area: no structural change
Invariant/Lifecycle:
  - active Execution no longer blocks Draft Save
  - active Execution no longer blocks Publish new DefinitionVersion
  - Publish only advances Task.publishedDefinitionRef
  - active Execution.definitionVersionId remains unchanged
  - Restart cannot silently upgrade
Layer: Application + UI + module domain guardrails
Stage-4 Gap:
  - GAP-02 Published + newer Draft coexistence complete
Migration Wave: Wave 4
Safety:
  - Task FOR UPDATE remains cross-instance command mutex
  - prepared Draft/Published re-check remains
  - SyncExecution lifecycle ownership remains Wave 3 semantics
  - UNKNOWN / CONFLICT / stop-during-start unchanged
  - Delete still requires terminal Execution + runtime safety checks
Domain Gap: no
```

---

## 1. Save Draft 不再被 Active Execution 阻塞

旧行为：

```text
active SyncExecution
  -> requireDefinitionMutable()
  -> Save Draft rejected
```

Wave 4：

```text
Task row FOR UPDATE
  -> serialize command
  -> update current Draft
```

不再读取 active Execution 作为 Draft mutation guard。

运行中的 Execution 保持自己的：

```text
DefinitionVersionRef
RuntimeEnvironmentSnapshot
DesiredState / ObservedState
EngineExecutionRef
```

Draft Save 不会触碰这些字段，也不会触发 Stop/Reconcile。

事件文案明确为：

```text
已保存草稿并生成新定义版本；当前 SyncExecution 不受影响
```

---

## 2. Publish 可以与 Active Execution 并行

旧行为：

```text
active SyncExecution
  -> publish rejected
```

现在：

```text
prepare current Draft
  -> full contextual/adapter validation
  -> Task row FOR UPDATE
  -> verify prepared Draft still current
  -> store.publish(...)
  -> create/reuse immutable DefinitionVersion
  -> advance Task.publishedDefinitionRef
```

当前 Execution 不会被修改。

例如：

```text
E100(V3) RUNNING
Draft r4
   ↓ publish
PublishedRef -> V4
E100.definitionVersionRef remains V3
```

因此：

> Publish = 创建/切换“未来运行可使用的已发布定义”；不是修改正在运行的 Flink Job。

---

## 3. Delete 守卫没有放开

Wave 4 只放开：

```text
Save Draft
Publish
```

Delete 仍然：

```text
Task row lock
  -> latest SyncExecution must be terminal
  -> LifecycleCoordinator must confirm Flink inactive
  -> delete path
```

不会因为“定义可以运行中编辑”就错误推导成“运行中也能删除任务”。

---

## 4. Restart 增加 Wave-4 过渡保护

Wave 4 后允许：

```text
E100(V3) RUNNING
PublishedRef = V4
```

因此旧 generic `restart()` 如果直接读取当前 Published Ref，会产生：

```text
stop V3
  -> start V4
```

这不是 Restart，而是版本升级。

本 PR 在 **Stop 之前**执行 immutable VersionRef 检查：

```text
activeExecution.definitionVersionId
        ==
currentPublishedDefinitionVersionId
```

如果不一致：

```text
拒绝通过重启隐式升级
```

并且：

```text
不会先 markStopping
不会调用 Flink stop
```

Wave 5 再正式拆成：

```text
RestartExecution(E100.versionRef)
ApplyPublishedVersion(Task.publishedRef)
```

---

## 5. Version 判断只认 immutable DefinitionVersionId

审查过程中专门修正了一处容易误导 AI/UI 的逻辑。

以下字段仍然是 legacy revision：

```text
Task.definitionVersion
Task.publishedVersion
Deployment.definitionVersion
```

它们不是：

```text
DefinitionVersionId
```

因此 UI **不再**比较：

```text
deployment.definitionVersion != publishedVersion
```

来判断“运行版本是否落后”。

真实版本一致性只由后端比较：

```text
SyncExecution.definitionVersionId
vs
PublishedDefinitionRow.id
```

这样可以正确处理“只改名称/描述、或语义相同配置复用同一个 immutable DefinitionVersion”的情况。

---

## 6. 列表页允许运行中编辑 / 发布

### Edit

运行中不再禁用“编辑”。

Tooltip 明确：

```text
运行中编辑只修改草稿，不影响当前 SyncExecution
```

### Publish

只要当前 Draft 尚未发布，就可以发布；不再因为 `desiredState=RUNNING` 禁用。

运行中按钮文案：

```text
发布当前版本（不影响运行）
```

成功提示：

```text
当前草稿已发布，运行中的 SyncExecution 继续使用启动时的 DefinitionVersion
```

Restart 按钮继续可发请求，但版本一致性由后端 immutable ID 权威校验，前端不使用 legacy revision 猜测。

---

## 7. Execution Panel 显式展示“定义与运行解耦”

执行面板现在区分：

```text
当前草稿
已发布版本（legacy UI revision projection）
当前运行定义 = 启动时 DefinitionVersion 快照（不显示伪造的版本号）
运行状态
当前草稿运行环境
运行实例环境 snapshot
```

运行中允许：

```text
继续编辑
发布当前版本（不影响运行）
```

并明确说明：

```text
Save 不修改当前 Execution
Publish 不热更新当前 Execution
当前 Execution 保持启动时 DefinitionVersion + RuntimeEnvironmentSnapshot
```

没有把 legacy DraftRevision 冒充真正的运行 DefinitionVersion。

---

## 8. DOMAIN.md 同步推进到 Wave 4

模块级领域宪法同步更新：

- Wave 3+ Desired/Observed ownership 已正式属于 SyncExecution；
- Task row runtime state 明确为 compatibility projection；
- Active Execution 不阻止 Save Draft / Publish；
- Save/Publish 禁止修改 active Execution 的 VersionRef / Runtime snapshot / lifecycle；
- Restart 跨 immutable DefinitionVersionRef 必须在 Stop 前拒绝；
- 明确禁止拿 legacy `definition_version / published_version` 当 Domain VersionId；
- Migration progress 更新为 Wave 0~4 complete，Wave 5/6 pending。

---

## 9. 专项测试

新增：

```text
RealtimeWave4DefinitionMutationTest
```

覆盖：

### active Execution 下 Save Draft

```text
latest Execution = RUNNING
service.save(...)
  -> updateDefinition success
  -> no markStopping
  -> no reconcile lifecycle mutation
```

### active Execution 下 Publish

```text
latest Execution = RUNNING
service.publish(...)
  -> current Draft preflight/compile/validate
  -> publish success
  -> no stop
  -> no runtime mutation
```

### Restart 拒绝隐式升级

```text
active Execution VersionId = 31
current Published VersionId = 32
restart()
  -> throws before stop
  -> no markStopping
  -> no gateway.stop
```

---

## 10. Protection List 未改变

本 PR 没有重写：

```text
Idempotency-Key
unique start persistence
Task FOR UPDATE command serialization
start reservation before external submit
same-key race recovery
prepared Published re-check
stop-during-start
UNKNOWN / CONFLICT
runtime identity persistence/recovery
RuntimeEnvironmentSnapshot
credential zeroization
FlinkCdcEngineGateway
SSH runner
log redaction
reconcile lease
```

也没有修改：

```text
SyncExecutionStateMachine
Flink/SSH submission
DB schema
DefinitionVersion storage
```

---

## 验证说明

当前执行环境此前无法解析 `github.com`，因此本轮没有可声明的完整 Maven / Yarn / tsc 执行结果。

本 PR 已完成源码级静态审查和专项测试代码补充，但：

**不声明 Maven、Jest、tsc 或完整 CI 已通过。**

PR 创建后会继续检查 GitHub workflow/status。

---

## 本 PR 明确不做

```text
Wave 5  RestartExecution vs ApplyPublishedVersion
Wave 6  legacy field/package/name cleanup
```

也不处理：

- hot reload / running execution live mutation；
- audit-safe Archive/Tombstone；
- checkpoint/restart runtime application gap；
- FINISHED normal completion / snapshot-only；
- legacy `configDigest/status` rename；
- public API 暴露 DefinitionVersionId。

---

## Domain Compliance Report

```text
Domain rule implemented:
  Draft/Publish lifecycle is independent from active SyncExecution.

Aggregate(s) changed:
  RealtimeSyncTask Draft/Published lifecycle behavior only.
  SyncExecution itself is intentionally not mutated by Save/Publish.

Invariant/lifecycle impact:
  active Execution no longer blocks Save/Publish
  Publish advances PublishedDefinitionRef only
  Restart cannot silently cross immutable DefinitionVersionRef

Legacy compatibility kept:
  DraftRevision / publishedVersion UI projections
  CdcPipelineSpec compatibility representation
  Task runtime projection fields
  current public API shape

Safety preserved:
  Task command mutex
  Start/Stop/UNKNOWN/CONFLICT/idempotency/recovery protections
  Delete runtime safety guard

DB migration mode:
  no schema change in Wave 4

Tests added:
  active Save
  active Publish
  restart no implicit upgrade

Known gaps remaining:
  Wave 5 + Wave 6 and existing Stage-4 gap register items
```

## Branch

```text
feat/realtime-sync-domain-stage-6-wave-4
```

分支基于合并 Wave 3 后的最新 `main`；开 PR 前已 squash 为单一 commit，并确认 `behind_by=0`。