### PR TITLE
feat: separate realtime restart and published version apply

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
@@ -171,7 +171,7 @@ A newer Draft MUST NOT mutate or invalidate historical Published versions or run
 
 A newer Draft MUST NOT automatically become the version used by an existing Execution.
 
-Wave 4 current rule:
+Wave 4+ current rule:
 
 ```text
 Active/uncertain SyncExecution
@@ -206,7 +206,7 @@ MUST:
 ```text
 Start -> new Execution
 RestartExecution -> new Execution pinned to the same DefinitionVersion
-ApplyPublishedVersion -> separate use case that starts the new Published version
+ApplyPublishedVersion -> separate use case that starts the explicitly captured Published version
 ```
 
 MUST NOT resurrect a terminal Execution.
@@ -231,6 +231,8 @@ CONFLICT
 ```
 
 Do not create a second Execution while one of the above exists.
+
+Version-changing lifecycle commands MUST NOT be used to bypass an uncertain runtime state. `RestartExecution` and `ApplyPublishedVersion` require a stable `RUNNING/RUNNING` execution in Wave 5.
 
 ---
 
@@ -276,9 +278,9 @@ Task row locking may remain a cross-instance command mutex; lock location does n
 
 ---
 
-# 7. Restart is not version upgrade
+# 7. RestartExecution and ApplyPublishedVersion are distinct commands
 
-These are different commands.
+These are different domain commands and MUST remain different in Application/API/UI semantics.
 
 ```text
 RestartExecution
@@ -290,21 +292,58 @@ ApplyPublishedVersion
 E100(v3) -> stop -> E101(v4)
 ```
 
-MUST NOT implement a generic `restart()` that silently reads whatever version is currently published and upgrades the task.
+## 7.1 RestartExecution
 
-Restart MUST pin the DefinitionVersion of the Execution being restarted.
+Restart MUST pin the immutable `DefinitionVersionId` from the Execution being restarted.
 
-Wave 4 transitional rule, until Wave 5 introduces explicit commands:
+It MUST NOT depend on the current `RealtimeSyncTask.publishedDefinitionRef`.
+
+Therefore this is valid:
 
 ```text
-active Execution.definitionVersionRef
-        !=
-Task.publishedDefinitionRef
+E100 runs V3
+Task.publishedDefinitionRef = V4
+RestartExecution(E100)
+  -> E101(V3)
 ```
 
-MUST cause Restart to reject **before Stop is issued**. Do not stop the old version first and only then discover that Restart would upgrade it.
+The legacy `/restart` endpoint, while it exists for compatibility, MUST delegate to `RestartExecution` semantics and MUST NEVER become a restart-to-latest shortcut.
 
-Do not infer this comparison from legacy `definition_version / published_version` integers. Domain version identity is the immutable `DefinitionVersionId`.
+## 7.2 ApplyPublishedVersion
+
+ApplyPublishedVersion explicitly captures `RealtimeSyncTask.publishedDefinitionRef` at command start.
+
+That captured immutable target MUST remain pinned for the entire command. If another Publish advances the Task to V5 while an Apply of V4 is already in progress, the existing command MUST NOT drift from V4 to V5.
+
+If the active Execution already uses the captured Published `DefinitionVersionId`, Apply MUST reject as unnecessary.
+
+## 7.3 Preflight before Stop
+
+Both commands MUST resolve and preflight their exact target DefinitionVersion **before** stopping the currently healthy Execution.
+
+If target datasource/runtime/connector validation fails, the command MUST fail before `STOPPING` is persisted or an engine Stop is issued.
+
+After target preflight succeeds, runtime Stop uncertainty continues to use the normal `STOPPING/UNKNOWN` rules; do not start a replacement Execution unless the old one is definitely terminal.
+
+## 7.4 Version identity
+
+Do not infer version identity from legacy `definition_version / published_version` integers.
+
+The authoritative comparison is:
+
+```text
+SyncExecution.definitionVersionId
+vs
+RealtimeSyncTask.publishedDefinitionVersionId
+```
+
+The UI/query projection may expose a derived fact such as:
+
+```text
+publishedUpdateAvailable
+```
+
+but that flag MUST be derived server-side from immutable VersionIds. It is not another version source of truth.
 
 ---
 
@@ -602,8 +641,8 @@ Wave 0  New Core VOs + legacy mapper, no behavior change                     ✅
 Wave 1  Immutable DefinitionVersion persistence + publish dual-write          ✅
 Wave 2  Start by Published DefinitionVersion                                  ✅
 Wave 3  Deployment evolves to SyncExecution; move desired/observed ownership  ✅
-Wave 4  Allow editing/publishing while execution is active                     ✅ current
-Wave 5  Separate RestartExecution from ApplyPublishedVersion                   pending
+Wave 4  Allow editing/publishing while execution is active                     ✅
+Wave 5  Separate RestartExecution from ApplyPublishedVersion                   ✅ current
 Wave 6  Cleanup legacy fields/package/names                                    pending
 ```
 
@@ -613,12 +652,15 @@ Critical ordering rule:
 
 Historical reason: before Wave 3, task-row state and DAO predicates participated in lifecycle ownership. Removing only service-level Save/Publish guards at that time would have produced inconsistent concurrency semantics.
 
-Current rule after Wave 3:
+Current rule after Wave 5:
 
 ```text
 Save Draft / Publish -> RealtimeSyncTask + DefinitionVersion lifecycle
-Start / Stop / Reconcile -> SyncExecution lifecycle
-Delete -> requires terminal Execution and runtime safety checks
+Start                -> current PublishedDefinitionRef -> new SyncExecution
+RestartExecution     -> current Execution VersionRef -> new same-version SyncExecution
+ApplyPublishedVersion-> command-time PublishedDefinitionRef -> new versioned SyncExecution
+Stop / Reconcile     -> SyncExecution lifecycle
+Delete               -> requires terminal Execution and runtime safety checks
 ```
 
 Database migration MUST use:
@@ -645,6 +687,7 @@ DeploymentRow                   -> SyncExecution persistence compatibility row
 configDigest on definition      -> draft DefinitionDigest-like value
 configDigest on deployment      -> ExecutionArtifactDigest
 ReleaseState DRAFT/PUBLISHED    -> legacy/derived presentation state
+legacy /restart endpoint        -> compatibility alias for RestartExecution
 ```
 
 Do not compare legacy `definition_version / published_version` as if they were immutable Domain `DefinitionVersionId` values.
@@ -699,6 +742,8 @@ Flink/SSH/JDBC credential fields in Core Domain
 Execution reading current Draft
 in-place mutation of Published Version
 Restart that may silently upgrade version
+ApplyPublishedVersion that re-reads a newer Published target after command start
+target-version command that stops a healthy Execution before target preflight succeeds
 second active Execution while UNKNOWN/CONFLICT exists
 UNKNOWN treated as FAILED solely to permit retry
 hard deletion of execution/version/audit history

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
@@ -117,14 +117,22 @@ public class RealtimeJobController {
   @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义") @PostMapping("/{id}/validate") @RequiresPermission(RealtimePermissionCode.UPDATE)
   public Result<RealtimeViews.Validation> validate(@PathVariable long id) { return Result.success(viewMapper.toView(validationService.validate(id))); }
 
-  @Operation(summary = "启动实时同步任务") @PostMapping("/{id}/start") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  @Operation(summary = "启动最新已发布实时同步版本") @PostMapping("/{id}/start") @RequiresPermission(RealtimePermissionCode.EXECUTE)
   public Result<RealtimeViews.Deployment> start(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.start(id, key))); }
 
   @Operation(summary = "停止实时同步任务") @PostMapping("/{id}/stop") @RequiresPermission(RealtimePermissionCode.EXECUTE)
   public Result<Boolean> stop(@PathVariable long id) { service.stop(id); return Result.success(true); }
 
-  @Operation(summary = "重启实时同步任务") @PostMapping("/{id}/restart") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> restart(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.restart(id, key))); }
+  @Operation(summary = "重启当前 SyncExecution（保持同一 DefinitionVersion）") @PostMapping("/{id}/restart-execution") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> restartExecution(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.restartExecution(id, key))); }
+
+  @Operation(summary = "应用最新已发布 DefinitionVersion") @PostMapping("/{id}/apply-published-version") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> applyPublishedVersion(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.applyPublishedVersion(id, key))); }
+
+  /** Compatibility endpoint. Semantics are RestartExecution and never upgrade to latest Published. */
+  @Deprecated
+  @Operation(summary = "兼容入口：重启当前 SyncExecution") @PostMapping("/{id}/restart") @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> restart(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.restartExecution(id, key))); }
 
   @Operation(summary = "立即对账实时同步任务") @PostMapping("/{id}/reconcile") @RequiresPermission(RealtimePermissionCode.EXECUTE)
   public Result<RealtimeViews.Job> reconcile(@PathVariable long id) { return Result.success(viewMapper.toView(lifecycleCoordinator.reconcile(id))); }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/mapper/RealtimeViewMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/mapper/RealtimeViewMapper.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 public class RealtimeViewMapper {
   public RealtimeViews.Job toView(RealtimeJobView value) {
     if (value == null) return null;
-    return new RealtimeViews.Job(value.id(), value.name(), value.description(), toView(value.spec()), value.runtimeEnvironmentId(), value.releaseState(), value.desiredState(), value.observedState(), value.definitionVersion(), value.publishedVersion(), value.configDigest(), value.lastError(), value.createTime(), value.updateTime(), toView(value.latestDeployment()));
+    return new RealtimeViews.Job(value.id(), value.name(), value.description(), toView(value.spec()), value.runtimeEnvironmentId(), value.releaseState(), value.desiredState(), value.observedState(), value.definitionVersion(), value.publishedVersion(), value.configDigest(), value.lastError(), value.createTime(), value.updateTime(), value.publishedUpdateAvailable(), toView(value.latestDeployment()));
   }
   public RealtimeViews.Page toView(RealtimeJobPage value) { return new RealtimeViews.Page(value.records().stream().map(this::toView).toList(), value.total(), value.pageNo(), value.pageSize()); }
   public RealtimeViews.Event toView(RealtimeJobEventView value) { return new RealtimeViews.Event(value.id(), value.deploymentId(), value.eventType(), value.fromState(), value.toState(), value.message(), value.createTime()); }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/vo/RealtimeViews.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/vo/RealtimeViews.java
@@ -35,7 +35,7 @@ public final class RealtimeViews {
       long id, String name, String description, PipelineSpec spec, long runtimeEnvironmentId,
       String releaseState, String desiredState, String observedState, int definitionVersion,
       Integer publishedVersion, String configDigest, String lastError, LocalDateTime createTime,
-      LocalDateTime updateTime, Deployment latestDeployment) {}
+      LocalDateTime updateTime, boolean publishedUpdateAvailable, Deployment latestDeployment) {}
 
   public record Page(List<Job> records, long total, int pageNo, int pageSize) {}
   public record Event(long id, Long deploymentId, String eventType, String fromState, String toState, String message, LocalDateTime createTime) {}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobListRow.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobListRow.java
@@ -16,6 +16,7 @@ public class RealtimeJobListRow {
   private String observedState;
   private Integer definitionVersion;
   private Integer publishedVersion;
+  private Boolean publishedUpdateAvailable;
   private String configDigest;
   private String lastError;
   private LocalDateTime createTime;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeJobView.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/RealtimeJobView.java
@@ -18,7 +18,44 @@ public record RealtimeJobView(
     String lastError,
     LocalDateTime createTime,
     LocalDateTime updateTime,
+    boolean publishedUpdateAvailable,
     Deployment latestDeployment) {
+
+  /** Compatibility constructor for callers created before Wave 5 added the derived capability. */
+  public RealtimeJobView(
+      long id,
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      long runtimeEnvironmentId,
+      String releaseState,
+      String desiredState,
+      String observedState,
+      int definitionVersion,
+      Integer publishedVersion,
+      String configDigest,
+      String lastError,
+      LocalDateTime createTime,
+      LocalDateTime updateTime,
+      Deployment latestDeployment) {
+    this(
+        id,
+        name,
+        description,
+        spec,
+        runtimeEnvironmentId,
+        releaseState,
+        desiredState,
+        observedState,
+        definitionVersion,
+        publishedVersion,
+        configDigest,
+        lastError,
+        createTime,
+        updateTime,
+        false,
+        latestDeployment);
+  }
 
   public record Deployment(
       long id,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQueryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobListQueryAdapter.java
@@ -101,6 +101,7 @@ public class RealtimeJobListQueryAdapter implements RealtimeJobListQuery {
         row.getLastError(),
         row.getCreateTime(),
         row.getUpdateTime(),
+        Boolean.TRUE.equals(row.getPublishedUpdateAvailable()),
         deployment);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -29,6 +29,10 @@ public interface RealtimeJobStore {
   default Optional<PublishedDefinitionRow> publishedDefinition(long definitionId) {
     return Optional.empty();
   }
+  /** Lookup one explicit immutable DefinitionVersion. */
+  default Optional<PublishedDefinitionRow> definitionVersion(long taskId, long definitionVersionId) {
+    return Optional.empty();
+  }
   Optional<DeploymentRow> deploymentByIdempotencyKey(String key);
   Optional<DeploymentRow> latestDeployment(long definitionId);
   default Optional<SyncExecution> latestExecution(long definitionId) {
@@ -102,10 +106,46 @@ public interface RealtimeJobStore {
       String observedState,
       int definitionVersion,
       Integer publishedVersion,
+      Long publishedDefinitionVersionId,
       String configDigest,
       String lastError,
       LocalDateTime createTime,
-      LocalDateTime updateTime) {}
+      LocalDateTime updateTime) {
+
+    /** Compatibility constructor for callers created before Wave 5 surfaced the immutable ref. */
+    public DefinitionRow(
+        long id,
+        String name,
+        String description,
+        CdcPipelineSpec spec,
+        long runtimeEnvironmentId,
+        String releaseState,
+        String desiredState,
+        String observedState,
+        int definitionVersion,
+        Integer publishedVersion,
+        String configDigest,
+        String lastError,
+        LocalDateTime createTime,
+        LocalDateTime updateTime) {
+      this(
+          id,
+          name,
+          description,
+          spec,
+          runtimeEnvironmentId,
+          releaseState,
+          desiredState,
+          observedState,
+          definitionVersion,
+          publishedVersion,
+          null,
+          configDigest,
+          lastError,
+          createTime,
+          updateTime);
+    }
+  }
 
   /**
    * Persistence/read compatibility row. From Wave 3 onward desiredState/observedState are the

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
@@ -12,6 +12,7 @@ import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.repository.support.RealtimeJsonCodec;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Repository;
@@ -276,6 +277,7 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
     String desired = latest == null ? definition.desiredState() : latest.desiredState();
     String observed = latest == null ? definition.observedState() : latest.observedState();
     String error = latest == null ? definition.lastError() : latest.errorMessage();
+    boolean publishedUpdateAvailable = publishedUpdateAvailable(definition, latest);
     return new RealtimeJobView(
         definition.id(),
         definition.name(),
@@ -291,6 +293,7 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
         error,
         definition.createTime(),
         definition.updateTime(),
+        publishedUpdateAvailable,
         deploymentView(latest));
   }
 
@@ -325,6 +328,7 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
         po.getObservedState(),
         po.getDefinitionVersion() == null ? 0 : po.getDefinitionVersion(),
         po.getPublishedVersion(),
+        po.getPublishedDefinitionVersionId(),
         po.getConfigDigest(),
         po.getLastError(),
         po.getCreateTime(),
@@ -352,5 +356,17 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
         po.getErrorMessage(),
         po.getCreateTime(),
         po.getUpdateTime());
+  }
+
+  private boolean publishedUpdateAvailable(DefinitionRow definition, DeploymentRow latest) {
+    if (latest == null
+        || !"RUNNING".equals(latest.desiredState())
+        || !"RUNNING".equals(latest.observedState())
+        || latest.definitionVersionId() == null
+        || definition.publishedDefinitionVersionId() == null) {
+      return false;
+    }
+    return !Objects.equals(
+        latest.definitionVersionId(), definition.publishedDefinitionVersionId());
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
@@ -95,17 +95,21 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
   public Optional<PublishedDefinitionRow> publishedDefinition(long definitionId) {
     Optional<Long> ref = definitionVersions.publishedDefinitionVersionId(definitionId);
     if (ref.isEmpty()) return Optional.empty();
-
-    PublicationSnapshot snapshot =
-        definitionVersions
-            .find(ref.get())
+    return Optional.of(
+        definitionVersion(definitionId, ref.get())
             .orElseThrow(
                 () ->
                     new IllegalStateException(
-                        "实时同步任务引用的 Published DefinitionVersion 不存在：" + ref.get()));
+                        "实时同步任务引用的 Published DefinitionVersion 不存在：" + ref.get())));
+  }
+
+  @Override
+  public Optional<PublishedDefinitionRow> definitionVersion(long taskId, long definitionVersionId) {
+    PublicationSnapshot snapshot = definitionVersions.find(definitionVersionId).orElse(null);
+    if (snapshot == null) return Optional.empty();
     StoredVersion version = snapshot.version();
-    if (version.taskId() != definitionId) {
-      throw new IllegalStateException("Published DefinitionVersion 不属于当前实时同步任务");
+    if (version.taskId() != taskId) {
+      throw new IllegalStateException("DefinitionVersion 不属于当前实时同步任务");
     }
     return Optional.of(
         new PublishedDefinitionRow(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -139,8 +139,6 @@ public class RealtimeJobService {
     transactions.executeWithoutResult(
         status -> {
           DefinitionRow locked = store.lockDefinition(id); // cross-instance command mutex
-          // Publishing advances Task.publishedDefinitionRef only. Any active SyncExecution stays
-          // pinned to the immutable DefinitionVersion recorded when that execution was created.
           requirePreparedDefinitionCurrent(prepared, locked);
           store.publish(
               id, prepared.definition().definitionVersion(), prepared.definition().configDigest());
@@ -163,22 +161,27 @@ public class RealtimeJobService {
     ReentrantLock lock = lifecycleLock(id);
     lock.lock();
     try {
-      return startLocked(id, requestedKey, null);
+      String key = normalizeKey(requestedKey);
+      DeploymentRow existing = idempotentDeployment(id, key);
+      if (existing != null) return store.deploymentView(existing);
+
+      PublishedDefinitionRow target = requirePublishedDefinition(id);
+      StartPrepared prepared = prepareVersion(id, target);
+      gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
+      return startPreparedLocked(id, key, prepared, true, StartIntent.START);
     } finally {
       lock.unlock();
     }
   }
 
-  private RealtimeJobView.Deployment startLocked(
-      long id, String requestedKey, Long expectedPublishedDefinitionVersionId) {
-    String key = normalizeKey(requestedKey);
+  private RealtimeJobView.Deployment startPreparedLocked(
+      long id,
+      String key,
+      StartPrepared prepared,
+      boolean requireCurrentPublished,
+      StartIntent intent) {
     DeploymentRow existing = idempotentDeployment(id, key);
-    if (existing != null) {
-      return store.deploymentView(existing);
-    }
-
-    StartPrepared prepared = preparePublished(id, expectedPublishedDefinitionVersionId);
-    gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
+    if (existing != null) return store.deploymentView(existing);
 
     StartReservation reservation;
     try {
@@ -192,8 +195,19 @@ public class RealtimeJobService {
                   return new StartReservation(duplicate.id(), false);
                 }
 
-                PublishedDefinitionRow currentPublished = requirePublishedDefinition(id);
-                requirePreparedPublishedCurrent(prepared, currentPublished);
+                PublishedDefinitionRow currentTarget;
+                if (requireCurrentPublished) {
+                  currentTarget = requirePublishedDefinition(id);
+                  requirePreparedVersionCurrent(
+                      prepared, currentTarget, "已发布定义在校验期间已变化，请刷新后重试");
+                } else {
+                  currentTarget =
+                      requireDefinitionVersion(id, prepared.definitionVersion().id());
+                  requirePreparedVersionCurrent(
+                      prepared,
+                      currentTarget,
+                      "目标 DefinitionVersion 在执行期间已变化，请刷新后重试");
+                }
 
                 SyncExecution previous = store.latestExecution(id).orElse(null);
                 executionStateMachine.requireNewExecutionAllowed(previous);
@@ -212,17 +226,18 @@ public class RealtimeJobService {
                         key);
                 store.bindDeploymentDefinitionVersion(
                     created,
-                    prepared.publishedDefinition().id(),
-                    prepared.publishedDefinition().sourceDraftRevision());
+                    prepared.definitionVersion().id(),
+                    prepared.definitionVersion().sourceDraftRevision());
                 store.markStarting(id); // Task-row compatibility projection only
                 store.event(
                     id,
                     created,
-                    "START_REQUESTED",
+                    intent.eventType,
                     null,
                     "STARTING",
-                    "开始使用已发布版本 v"
-                        + prepared.publishedDefinition().versionNo()
+                    intent.messagePrefix
+                        + " DefinitionVersion v"
+                        + prepared.definitionVersion().versionNo()
                         + "，通过运行环境「"
                         + prepared.runtimeEnvironment().name()
                         + "」提交 Flink CDC 任务"
@@ -385,8 +400,6 @@ public class RealtimeJobService {
 
     DeploymentRow deployment = reservation.deployment();
     if (deployment == null || !StringUtils.hasText(deployment.engineJobId())) {
-      // STARTING may still be blocked in the synchronous CLI. Keep Execution STOPPING; the start
-      // owner will bind the returned JobId and cancel it in completeStart().
       return;
     }
 
@@ -430,37 +443,82 @@ public class RealtimeJobService {
         });
   }
 
+  /** Compatibility alias. Domain semantics are RestartExecution, not generic restart-to-latest. */
+  @Deprecated
   public RealtimeJobView.Deployment restart(long id, String requestedKey) {
+    return restartExecution(id, requestedKey);
+  }
+
+  /** Stop the current RUNNING execution and create a new execution pinned to the same version. */
+  public RealtimeJobView.Deployment restartExecution(long id, String requestedKey) {
     ReentrantLock lock = lifecycleLock(id);
     lock.lock();
     try {
       String key = normalizeKey(requestedKey);
       DeploymentRow existing = idempotentDeployment(id, key);
-      if (existing != null) {
-        return store.deploymentView(existing);
+      if (existing != null) return store.deploymentView(existing);
+
+      DeploymentRow currentRow = requireStableRunningExecutionRow(id, "重启");
+      SyncExecution currentExecution = currentRow.execution();
+      long targetVersionId = requireExecutionVersionId(currentExecution);
+      PublishedDefinitionRow target = requireDefinitionVersion(id, targetVersionId);
+
+      // Preflight target before claiming the stop/replacement command.
+      StartPrepared prepared = prepareVersion(id, target);
+      gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
+
+      DeploymentRow reserved =
+          reserveVersionReplacementStop(
+              id,
+              currentRow.id(),
+              "RESTART_EXECUTION_STOP_REQUESTED",
+              "已为同版本 RestartExecution 预留停止当前运行实例");
+      stopBoundJob(
+          id,
+          reserved.id(),
+          reserved.engineJobId(),
+          "当前 SyncExecution 已停止，准备按原 DefinitionVersion 重启");
+      requireLatestExecutionSettled(id);
+      return startPreparedLocked(id, key, prepared, false, StartIntent.RESTART_EXECUTION);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Stop the current RUNNING execution and explicitly apply the PublishedDefinitionRef snapshot. */
+  public RealtimeJobView.Deployment applyPublishedVersion(long id, String requestedKey) {
+    ReentrantLock lock = lifecycleLock(id);
+    lock.lock();
+    try {
+      String key = normalizeKey(requestedKey);
+      DeploymentRow existing = idempotentDeployment(id, key);
+      if (existing != null) return store.deploymentView(existing);
+
+      DeploymentRow currentRow = requireStableRunningExecutionRow(id, "应用已发布版本");
+      SyncExecution currentExecution = currentRow.execution();
+      long currentVersionId = requireExecutionVersionId(currentExecution);
+      PublishedDefinitionRow target = requirePublishedDefinition(id); // command-time snapshot
+      if (currentVersionId == target.id()) {
+        throw new IllegalStateException("当前 SyncExecution 已经运行最新已发布 DefinitionVersion，无需应用");
       }
 
-      PublishedDefinitionRow restartPublished = requirePublishedDefinition(id);
-      SyncExecution restartExecution =
-          store.latestExecution(id).orElseThrow(() -> new IllegalStateException("当前没有可重启的 SyncExecution"));
-      if (restartExecution.terminal()) {
-        throw new IllegalStateException("当前 SyncExecution 已结束，请直接启动已发布版本");
-      }
-      Long runningVersionId = restartExecution.definitionVersionId();
-      if (runningVersionId == null) {
-        throw new IllegalStateException("当前 SyncExecution 缺少 DefinitionVersionRef，无法安全重启");
-      }
-      if (runningVersionId.longValue() != restartPublished.id()) {
-        throw new IllegalStateException(
-            "当前运行版本与最新发布版本不同，拒绝通过重启隐式升级；请停止后显式启动最新发布版本");
-      }
+      // Validate the exact target before claiming the stop/replacement command.
+      StartPrepared prepared = prepareVersion(id, target);
+      gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
 
-      stopLocked(id);
-      SyncExecution settled = store.latestExecution(id).orElse(null);
-      if (settled != null && settled.activeOrUncertain()) {
-        throw new IllegalStateException("Execution 仍在停止中，请稍后使用相同 Idempotency-Key 重试重启");
-      }
-      return startLocked(id, key, runningVersionId);
+      DeploymentRow reserved =
+          reserveVersionReplacementStop(
+              id,
+              currentRow.id(),
+              "APPLY_PUBLISHED_VERSION_STOP_REQUESTED",
+              "已为 ApplyPublishedVersion 预留停止当前运行实例");
+      stopBoundJob(
+          id,
+          reserved.id(),
+          reserved.engineJobId(),
+          "当前 SyncExecution 已停止，准备应用已发布 DefinitionVersion");
+      requireLatestExecutionSettled(id);
+      return startPreparedLocked(id, key, prepared, false, StartIntent.APPLY_PUBLISHED_VERSION);
     } finally {
       lock.unlock();
     }
@@ -476,7 +534,8 @@ public class RealtimeJobService {
   }
 
   public List<RealtimeJobEventView> events(long id) {
-    store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+    store.definition(id)
+        .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
     return store.events(id);
   }
 
@@ -486,7 +545,8 @@ public class RealtimeJobService {
 
   private Prepared prepare(long id, boolean requirePublished) {
     DefinitionRow definition =
-        store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+        store.definition(id)
+            .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
     if (requirePublished) {
       throw new IllegalArgumentException("内部调用错误：Start 必须通过 immutable Published Definition 准备");
     }
@@ -504,26 +564,23 @@ public class RealtimeJobService {
         manifest);
   }
 
-  private StartPrepared preparePublished(
-      long id, Long expectedPublishedDefinitionVersionId) {
+  private StartPrepared prepareVersion(long id, PublishedDefinitionRow version) {
     DefinitionRow task =
-        store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
-    PublishedDefinitionRow published = requirePublishedDefinition(id);
-    if (expectedPublishedDefinitionVersionId != null
-        && published.id() != expectedPublishedDefinitionVersionId) {
-      throw new IllegalStateException("重启期间已发布版本发生变化，请刷新后重新操作");
+        store.definition(id)
+            .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+    if (version.taskId() != id) {
+      throw new IllegalStateException("DefinitionVersion 不属于当前实时同步任务");
     }
-
-    CdcPipelineSpec spec = published.spec();
+    CdcPipelineSpec spec = version.spec();
     specValidator.validate(spec);
     ComputeEnvironmentSnapshot runtimeEnvironment =
-        runtimeResolver.environment(published.runtimeEnvironmentId(), true);
+        runtimeResolver.environment(version.runtimeEnvironmentId(), true);
     ResolvedCdcPipeline resolved = dataSourceResolver.resolve(spec);
     JsonNode manifest = gateway.capabilities(runtimeEnvironment);
     capabilityResolver.requireSupported(manifest, resolved, spec);
     return new StartPrepared(
         task,
-        published,
+        version,
         spec,
         compiler.compile(task.name(), spec, resolved),
         runtimeEnvironment,
@@ -536,14 +593,21 @@ public class RealtimeJobService {
         .orElseThrow(() -> new IllegalStateException("请先发布至少一个可运行的定义版本"));
   }
 
-  private void requirePreparedPublishedCurrent(
-      StartPrepared prepared, PublishedDefinitionRow currentPublished) {
-    PublishedDefinitionRow snapshot = prepared.publishedDefinition();
-    if (snapshot.id() != currentPublished.id()
-        || snapshot.taskId() != currentPublished.taskId()
-        || snapshot.sourceDraftRevision() != currentPublished.sourceDraftRevision()
-        || !Objects.equals(snapshot.sourceConfigDigest(), currentPublished.sourceConfigDigest())) {
-      throw new IllegalStateException("已发布定义在校验期间已变化，请刷新后重试");
+  private PublishedDefinitionRow requireDefinitionVersion(long taskId, long definitionVersionId) {
+    return store
+        .definitionVersion(taskId, definitionVersionId)
+        .orElseThrow(
+            () -> new IllegalStateException("DefinitionVersion 不存在：" + definitionVersionId));
+  }
+
+  private void requirePreparedVersionCurrent(
+      StartPrepared prepared, PublishedDefinitionRow current, String message) {
+    PublishedDefinitionRow snapshot = prepared.definitionVersion();
+    if (snapshot.id() != current.id()
+        || snapshot.taskId() != current.taskId()
+        || snapshot.sourceDraftRevision() != current.sourceDraftRevision()
+        || !Objects.equals(snapshot.sourceConfigDigest(), current.sourceConfigDigest())) {
+      throw new IllegalStateException(message);
     }
   }
 
@@ -561,6 +625,86 @@ public class RealtimeJobService {
     executionStateMachine.requireDefinitionMutable(store.latestExecution(id).orElse(null));
   }
 
+  private DeploymentRow requireStableRunningExecutionRow(long taskId, String action) {
+    DeploymentRow row =
+        store.latestDeployment(taskId)
+            .orElseThrow(() -> new IllegalStateException("当前没有可" + action + "的 SyncExecution"));
+    SyncExecution execution = row.execution();
+    requireStableRunningExecution(execution, action);
+    if (!execution.engineExecutionRef().bound() || !StringUtils.hasText(row.engineJobId())) {
+      throw new IllegalStateException(action + "要求当前 SyncExecution 已绑定 EngineExecutionRef，请先执行状态对账");
+    }
+    return row;
+  }
+
+  private void requireStableRunningExecution(SyncExecution execution, String action) {
+    if (execution.terminal()) {
+      throw new IllegalStateException("当前 SyncExecution 已结束，请直接启动已发布版本");
+    }
+    if (!"RUNNING".equals(execution.desiredState().name())
+        || !"RUNNING".equals(execution.observedState().name())
+        || execution.resultUncertain()) {
+      throw new IllegalStateException(
+          action
+              + "只允许对稳定 RUNNING 的 SyncExecution 执行；STARTING/STOPPING/UNKNOWN/CONFLICT 请先对账");
+    }
+  }
+
+  /**
+   * Linearization point for RestartExecution / ApplyPublishedVersion across multiple Yak instances.
+   * The expensive target preflight is intentionally done before this reservation. Once this
+   * transaction marks the expected execution STOPPING, this version command owns the replacement;
+   * a competing Stop/version command that won first makes this reservation fail instead.
+   */
+  private DeploymentRow reserveVersionReplacementStop(
+      long taskId, long expectedExecutionId, String eventType, String message) {
+    DeploymentRow reserved =
+        transactions.execute(
+            status -> {
+              store.lockDefinition(taskId); // cross-instance command mutex
+              DeploymentRow latest =
+                  store.latestDeployment(taskId)
+                      .orElseThrow(() -> new IllegalStateException("当前 SyncExecution 已变化，请刷新后重试"));
+              if (latest.id() != expectedExecutionId) {
+                throw new IllegalStateException("当前 SyncExecution 已变化，请刷新后重试");
+              }
+              SyncExecution execution = latest.execution();
+              requireStableRunningExecution(execution, "版本切换");
+              if (!execution.engineExecutionRef().bound() || !StringUtils.hasText(latest.engineJobId())) {
+                throw new IllegalStateException("当前 SyncExecution 缺少 EngineExecutionRef，请先执行状态对账");
+              }
+              executionStateMachine.requireTransition(execution, "STOPPING");
+              store.markStopping(taskId, latest.id());
+              store.event(
+                  taskId,
+                  latest.id(),
+                  eventType,
+                  execution.observedState().name(),
+                  "STOPPING",
+                  message);
+              return latest;
+            });
+    if (reserved == null) {
+      throw new IllegalStateException("未能预留版本切换停止命令");
+    }
+    return reserved;
+  }
+
+  private long requireExecutionVersionId(SyncExecution execution) {
+    Long versionId = execution.definitionVersionId();
+    if (versionId == null) {
+      throw new IllegalStateException("当前 SyncExecution 缺少 DefinitionVersionRef，无法安全执行版本命令");
+    }
+    return versionId;
+  }
+
+  private void requireLatestExecutionSettled(long taskId) {
+    SyncExecution settled = store.latestExecution(taskId).orElse(null);
+    if (settled != null && settled.activeOrUncertain()) {
+      throw new IllegalStateException("Execution 仍在停止中，请稍后使用相同 Idempotency-Key 重试");
+    }
+  }
+
   private DeploymentRow requireCurrentExecutionRow(long taskId, long executionId) {
     DeploymentRow latest =
         store.latestDeployment(taskId)
@@ -571,7 +715,8 @@ public class RealtimeJobService {
     return latest;
   }
 
-  private void waitForRuntimeStop(ComputeEnvironmentSnapshot runtimeEnvironment, String jobId) {
+  private void waitForRuntimeStop(
+      ComputeEnvironmentSnapshot runtimeEnvironment, String jobId) {
     for (int attempt = 0; attempt < 20; attempt++) {
       RuntimeStatus status = gateway.status(runtimeEnvironment, jobId);
       if (status.state() == RuntimeStatus.State.TERMINATED
@@ -591,7 +736,8 @@ public class RealtimeJobService {
     throw new RealtimeEngineException("Flink 任务未在 5 秒内停止，等待后续对账", true, null, null);
   }
 
-  private void markStopped(long definitionId, long deploymentId, String jobId, String message) {
+  private void markStopped(
+      long definitionId, long deploymentId, String jobId, String message) {
     transactions.executeWithoutResult(
         status -> {
           store.lockDefinition(definitionId);
@@ -655,7 +801,8 @@ public class RealtimeJobService {
       throw new IllegalStateException("任务尚无 Execution 记录");
     }
     DefinitionRow definition =
-        store.definition(id).orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
+        store.definition(id)
+            .orElseThrow(() -> new IllegalArgumentException("实时同步任务不存在：" + id));
     return runtimeResolver.deployment(definition, deployment);
   }
 
@@ -696,7 +843,7 @@ public class RealtimeJobService {
 
   private record StartPrepared(
       DefinitionRow task,
-      PublishedDefinitionRow publishedDefinition,
+      PublishedDefinitionRow definitionVersion,
       CdcPipelineSpec spec,
       CompiledPipeline compiled,
       ComputeEnvironmentSnapshot runtimeEnvironment,
@@ -704,5 +851,20 @@ public class RealtimeJobService {
 
   private record StartReservation(long deploymentId, boolean created) {}
 
-  private record StopReservation(DeploymentRow deployment, boolean settled, boolean inProgress) {}
+  private record StopReservation(
+      DeploymentRow deployment, boolean settled, boolean inProgress) {}
+
+  private enum StartIntent {
+    START("START_REQUESTED", "启动"),
+    RESTART_EXECUTION("RESTART_EXECUTION_REQUESTED", "重启当前运行版本"),
+    APPLY_PUBLISHED_VERSION("APPLY_PUBLISHED_VERSION_REQUESTED", "应用已发布版本");
+
+    private final String eventType;
+    private final String messagePrefix;
+
+    StartIntent(String eventType, String messagePrefix) {
+      this.eventType = eventType;
+      this.messagePrefix = messagePrefix;
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml
@@ -43,6 +43,15 @@
            COALESCE(p.observed_state, d.observed_state) AS observed_state,
            d.definition_version,
            d.published_version,
+           CASE
+             WHEN p.id IS NOT NULL
+              AND p.desired_state = 'RUNNING'
+              AND p.observed_state = 'RUNNING'
+              AND p.definition_version_id IS NOT NULL
+              AND d.published_definition_version_id IS NOT NULL
+              AND p.definition_version_id &lt;&gt; d.published_definition_version_id
+             THEN TRUE ELSE FALSE
+           END AS published_update_available,
            d.config_digest,
            CASE WHEN p.id IS NULL THEN d.last_error ELSE p.error_message END AS last_error,
            d.create_time,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapterExecutionProjectionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapterExecutionProjectionTest.java
@@ -21,6 +21,43 @@ class RealtimeJobStoreAdapterExecutionProjectionTest {
 
   @Test
   void detailProjectionUsesLatestExecutionStateInsteadOfStaleTaskRuntimeProjection() {
+    Fixture fixture = fixture();
+    fixture.task.setDesiredState("RUNNING");
+    fixture.task.setObservedState("UNKNOWN");
+    fixture.task.setLastError("stale task projection error");
+    fixture.execution.setDesiredState("STOPPED");
+    fixture.execution.setObservedState("STOPPED");
+    fixture.execution.setStatus("STOPPED");
+    fixture.execution.setErrorMessage(null);
+
+    RealtimeJobView view = fixture.store.view(7L);
+
+    assertThat(view.desiredState()).isEqualTo("STOPPED");
+    assertThat(view.observedState()).isEqualTo("STOPPED");
+    assertThat(view.lastError()).isNull();
+    assertThat(view.releaseState()).isEqualTo("DRAFT");
+    assertThat(view.latestDeployment().runtimeEnvironment().id()).isEqualTo(3L);
+    assertThat(view.publishedUpdateAvailable()).isFalse();
+  }
+
+  @Test
+  void publishedUpdateAvailableUsesImmutableVersionIdsNotLegacyRevisions() {
+    Fixture fixture = fixture();
+    fixture.task.setPublishedDefinitionVersionId(32L);
+    fixture.task.setPublishedVersion(4);
+    fixture.execution.setDefinitionVersionId(31L);
+    // Deliberately make the legacy revision numbers equal. They must not decide this capability.
+    fixture.execution.setDefinitionVersion(4);
+    fixture.execution.setDesiredState("RUNNING");
+    fixture.execution.setObservedState("RUNNING");
+    fixture.execution.setStatus("RUNNING");
+
+    RealtimeJobView view = fixture.store.view(7L);
+
+    assertThat(view.publishedUpdateAvailable()).isTrue();
+  }
+
+  private Fixture fixture() {
     RealtimeJobDao dao = mock(RealtimeJobDao.class);
     RealtimeJsonCodec json = mock(RealtimeJsonCodec.class);
     RealtimeJobListQuery listQuery = mock(RealtimeJobListQuery.class);
@@ -32,11 +69,11 @@ class RealtimeJobStoreAdapterExecutionProjectionTest {
     task.setJobName("orders-sync");
     task.setRuntimeEnvironmentId(4L);
     task.setReleaseState("DRAFT");
-    task.setDesiredState("RUNNING");
-    task.setObservedState("UNKNOWN");
+    task.setDesiredState("STOPPED");
+    task.setObservedState("STOPPED");
     task.setDefinitionVersion(4);
     task.setPublishedVersion(3);
-    task.setLastError("stale task projection error");
+    task.setPublishedDefinitionVersionId(31L);
     task.setCreateTime(LocalDateTime.now());
     task.setUpdateTime(LocalDateTime.now());
 
@@ -79,13 +116,11 @@ class RealtimeJobStoreAdapterExecutionProjectionTest {
     when(dao.findDefinition(7L)).thenReturn(Optional.of(task));
     when(dao.latestDeployment(7L)).thenReturn(Optional.of(execution));
     when(json.readEnvironmentSnapshot("{}")).thenReturn(runtime);
-
-    RealtimeJobView view = store.view(7L);
-
-    assertThat(view.desiredState()).isEqualTo("STOPPED");
-    assertThat(view.observedState()).isEqualTo("STOPPED");
-    assertThat(view.lastError()).isNull();
-    assertThat(view.releaseState()).isEqualTo("DRAFT");
-    assertThat(view.latestDeployment().runtimeEnvironment().id()).isEqualTo(3L);
+    return new Fixture(store, task, execution);
   }
+
+  private record Fixture(
+      RealtimeJobStoreAdapter store,
+      RealtimeJobDefinitionPO task,
+      RealtimeJobDeploymentPO execution) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStoreTest.java
@@ -110,16 +110,7 @@ class VersioningRealtimeJobStoreTest {
         new VersioningRealtimeJobStore(
             delegate, versions, new CdcPipelineSpecCompatibilityMapper());
     CdcPipelineSpec snapshotSpec = spec("fixed-delay");
-    StoredVersion stored =
-        new StoredVersion(
-            201L,
-            TASK_ID,
-            3,
-            8,
-            "b".repeat(64),
-            SOURCE_DIGEST,
-            DomainMappingState.MAPPED,
-            LocalDateTime.now());
+    StoredVersion stored = storedVersion(201L, TASK_ID, 3, 8);
     when(versions.publishedDefinitionVersionId(TASK_ID)).thenReturn(Optional.of(stored.id()));
     when(versions.find(stored.id()))
         .thenReturn(Optional.of(new PublicationSnapshot(stored, 33L, snapshotSpec)));
@@ -136,22 +127,47 @@ class VersioningRealtimeJobStoreTest {
   }
 
   @Test
+  void resolvesHistoricalVersionWithoutConsultingCurrentPublishedReference() {
+    RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
+    DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
+    VersioningRealtimeJobStore store =
+        new VersioningRealtimeJobStore(
+            delegate, versions, new CdcPipelineSpecCompatibilityMapper());
+    StoredVersion v3 = storedVersion(203L, TASK_ID, 3, 8);
+    CdcPipelineSpec snapshotSpec = spec("fixed-delay");
+    when(versions.find(v3.id()))
+        .thenReturn(Optional.of(new PublicationSnapshot(v3, 33L, snapshotSpec)));
+
+    PublishedDefinitionRow historical = store.definitionVersion(TASK_ID, v3.id()).orElseThrow();
+
+    assertThat(historical.id()).isEqualTo(v3.id());
+    assertThat(historical.versionNo()).isEqualTo(3);
+    assertThat(historical.spec()).isEqualTo(snapshotSpec);
+  }
+
+  @Test
+  void brokenPublishedReferenceIsReportedInsteadOfPretendingTaskIsUnpublished() {
+    RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
+    DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
+    VersioningRealtimeJobStore store =
+        new VersioningRealtimeJobStore(
+            delegate, versions, new CdcPipelineSpecCompatibilityMapper());
+    when(versions.publishedDefinitionVersionId(TASK_ID)).thenReturn(Optional.of(999L));
+    when(versions.find(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> store.publishedDefinition(TASK_ID))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("引用的 Published DefinitionVersion 不存在");
+  }
+
+  @Test
   void rejectsPublishedVersionThatBelongsToAnotherTask() {
     RealtimeJobStoreAdapter delegate = mock(RealtimeJobStoreAdapter.class);
     DefinitionVersionRepository versions = mock(DefinitionVersionRepository.class);
     VersioningRealtimeJobStore store =
         new VersioningRealtimeJobStore(
             delegate, versions, new CdcPipelineSpecCompatibilityMapper());
-    StoredVersion foreign =
-        new StoredVersion(
-            301L,
-            99L,
-            1,
-            1,
-            "b".repeat(64),
-            SOURCE_DIGEST,
-            DomainMappingState.MAPPED,
-            LocalDateTime.now());
+    StoredVersion foreign = storedVersion(301L, 99L, 1, 1);
     when(versions.publishedDefinitionVersionId(TASK_ID)).thenReturn(Optional.of(foreign.id()));
     when(versions.find(foreign.id()))
         .thenReturn(Optional.of(new PublicationSnapshot(foreign, 3L, spec("fixed-delay"))));
@@ -173,6 +189,19 @@ class VersioningRealtimeJobStoreTest {
 
     assertThat(store.reconcileCandidates()).containsExactly(execution);
     verify(delegate).reconcileCandidates();
+  }
+
+  private StoredVersion storedVersion(
+      long id, long taskId, int versionNo, int sourceDraftRevision) {
+    return new StoredVersion(
+        id,
+        taskId,
+        versionNo,
+        sourceDraftRevision,
+        "b".repeat(64),
+        SOURCE_DIGEST,
+        DomainMappingState.MAPPED,
+        LocalDateTime.now());
   }
 
   private DefinitionRow definitionRow(CdcPipelineSpec spec) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobServiceConcurrencyTest.java
@@ -174,7 +174,6 @@ class RealtimeJobServiceConcurrencyTest {
     when(gateway.deploy(eq(environment), any()))
         .thenReturn(new DeployResult("job-new", "exactly-once"));
 
-    // completeStart sees the newly created execution as STARTING/RUNNING desired.
     assertThatCode(() -> service.start(JOB_ID, "terminal-restart")).doesNotThrowAnyException();
 
     verify(store).insertDeployment(any(), eq(spec), any(), any(), eq(environment), eq("terminal-restart"));
@@ -239,28 +238,13 @@ class RealtimeJobServiceConcurrencyTest {
   }
 
   @Test
-  void restartRefusesToSilentlySwitchPublishedVersion() {
-    PublishedDefinitionRow original = published();
-    PublishedDefinitionRow changed =
-        new PublishedDefinitionRow(
-            DEFINITION_VERSION_ID + 1,
-            JOB_ID,
-            2,
-            2,
-            spec,
-            environment.id(),
-            "c".repeat(64),
-            "d".repeat(64));
-    when(store.deploymentByIdempotencyKey("restart-pin")).thenReturn(Optional.empty());
-    when(store.publishedDefinition(JOB_ID))
-        .thenReturn(Optional.of(original), Optional.of(changed));
-    when(store.lockDefinition(JOB_ID)).thenReturn(stopped);
+  void restartExecutionRequiresCurrentRunningExecution() {
+    when(store.deploymentByIdempotencyKey("restart-missing")).thenReturn(Optional.empty());
     when(store.latestDeployment(JOB_ID)).thenReturn(Optional.empty());
-    when(store.latestExecution(JOB_ID)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.restart(JOB_ID, "restart-pin"))
+    assertThatThrownBy(() -> service.restartExecution(JOB_ID, "restart-missing"))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("重启期间已发布版本发生变化");
+        .hasMessageContaining("当前没有可重启的 SyncExecution");
 
     verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
     verify(gateway, never()).deploy(any(), any());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave4DefinitionMutationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave4DefinitionMutationTest.java
@@ -1,6 +1,5 @@
 package io.yak.ops.business.sync.realtime.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -29,7 +28,6 @@ import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.Validation
 import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
-import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +40,6 @@ class RealtimeWave4DefinitionMutationTest {
 
   private static final long TASK_ID = 7L;
   private static final long RUNNING_VERSION_ID = 31L;
-  private static final long NEW_PUBLISHED_VERSION_ID = 32L;
 
   private RealtimeJobStore store;
   private CdcPipelineSpecValidator specValidator;
@@ -123,32 +120,6 @@ class RealtimeWave4DefinitionMutationTest {
     verify(store).publish(TASK_ID, task.definitionVersion(), task.configDigest());
     verify(store, never()).markStopping(anyLong(), any());
     verify(store, never()).markDeploymentRunning(anyLong(), anyLong(), any(), any());
-  }
-
-  @Test
-  void restartRejectsImplicitUpgradeWhenPublishedRefAdvanced() {
-    SyncExecution running = runningExecution(RUNNING_VERSION_ID);
-    PublishedDefinitionRow latestPublished =
-        new PublishedDefinitionRow(
-            NEW_PUBLISHED_VERSION_ID,
-            TASK_ID,
-            4,
-            4,
-            spec,
-            environment.id(),
-            "a".repeat(64),
-            "b".repeat(64));
-
-    when(store.deploymentByIdempotencyKey("restart-v3")).thenReturn(Optional.empty());
-    when(store.publishedDefinition(TASK_ID)).thenReturn(Optional.of(latestPublished));
-    when(store.latestExecution(TASK_ID)).thenReturn(Optional.of(running));
-
-    assertThatThrownBy(() -> service.restart(TASK_ID, "restart-v3"))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("拒绝通过重启隐式升级");
-
-    verify(store, never()).markStopping(anyLong(), any());
-    verify(gateway, never()).stop(any(), any());
   }
 
   private DefinitionRow task(String releaseState, int draftRevision, Integer publishedRevision) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandRaceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandRaceTest.java
@@ -1,0 +1,206 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.ValidationResult;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RealtimeWave5VersionCommandRaceTest {
+
+  @Test
+  void stopThatWinsDuringPreflightPreventsPublishedVersionReplacement() {
+    long taskId = 7L;
+    long executionId = 19L;
+    long v3Id = 31L;
+    long v4Id = 32L;
+    CdcPipelineSpec v3 = spec("orders_v3");
+    CdcPipelineSpec v4 = spec("orders_v4");
+    ComputeEnvironmentSnapshot environment = environment();
+    DefinitionRow task =
+        new DefinitionRow(
+            taskId,
+            "orders-sync",
+            null,
+            v4,
+            environment.id(),
+            "PUBLISHED",
+            "RUNNING",
+            "RUNNING",
+            4,
+            4,
+            v4Id,
+            "c".repeat(64),
+            null,
+            LocalDateTime.now(),
+            LocalDateTime.now());
+    DeploymentRow running =
+        execution(
+            executionId,
+            taskId,
+            v3Id,
+            v3,
+            environment,
+            "RUNNING",
+            "RUNNING",
+            "RUNNING");
+    DeploymentRow stopAlreadyWon =
+        execution(
+            executionId,
+            taskId,
+            v3Id,
+            v3,
+            environment,
+            "STOPPED",
+            "STOPPING",
+            "STOPPING");
+    PublishedDefinitionRow published =
+        new PublishedDefinitionRow(
+            v4Id,
+            taskId,
+            4,
+            4,
+            v4,
+            environment.id(),
+            "a".repeat(64),
+            "b".repeat(64));
+
+    RealtimeJobStore store = mock(RealtimeJobStore.class);
+    CdcPipelineSpecValidator specValidator = mock(CdcPipelineSpecValidator.class);
+    RealtimeDataSourceResolver dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    RealtimeConnectorCapabilityResolver capabilityResolver =
+        mock(RealtimeConnectorCapabilityResolver.class);
+    PipelineYamlCompiler compiler = mock(PipelineYamlCompiler.class);
+    RealtimeEngineGateway gateway = mock(RealtimeEngineGateway.class);
+    RealtimeRuntimeResolver runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+    CompiledPipeline compiled = new CompiledPipeline("pipeline: v4", "v4");
+    when(store.deploymentByIdempotencyKey("apply-race")).thenReturn(Optional.empty());
+    // First read is command preflight. Second read is the DB-lock reservation after another Stop won.
+    when(store.latestDeployment(taskId))
+        .thenReturn(Optional.of(running), Optional.of(stopAlreadyWon));
+    when(store.publishedDefinition(taskId)).thenReturn(Optional.of(published));
+    when(store.definition(taskId)).thenReturn(Optional.of(task));
+    when(store.lockDefinition(taskId)).thenReturn(task);
+    when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
+    when(dataSourceResolver.resolve(v4)).thenReturn(resolved);
+    when(gateway.capabilities(environment)).thenReturn(new ObjectMapper().createObjectNode());
+    when(compiler.compile("orders-sync", v4, resolved)).thenReturn(compiled);
+    when(gateway.validate(environment, compiled.yaml()))
+        .thenReturn(new ValidationResult(true, "at-least-once"));
+
+    RealtimeJobService service =
+        new RealtimeJobService(
+            store,
+            new ObjectMapper(),
+            specValidator,
+            new SyncExecutionStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
+
+    assertThatThrownBy(() -> service.applyPublishedVersion(taskId, "apply-race"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请先对账");
+
+    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).stop(any(), any());
+  }
+
+  private static DeploymentRow execution(
+      long executionId,
+      long taskId,
+      long versionId,
+      CdcPipelineSpec spec,
+      ComputeEnvironmentSnapshot environment,
+      String desired,
+      String observed,
+      String status) {
+    return new DeploymentRow(
+        executionId,
+        taskId,
+        versionId,
+        3,
+        spec,
+        "test",
+        "d".repeat(64),
+        "exec-" + executionId,
+        "job-v3",
+        environment.runtimeRevision(),
+        environment,
+        "FLINK_CDC",
+        desired,
+        observed,
+        status,
+        false,
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private static ComputeEnvironmentSnapshot environment() {
+    return new ComputeEnvironmentSnapshot(
+        3L,
+        "test-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
+        2);
+  }
+
+  private static CdcPipelineSpec spec(String table) {
+    return new CdcPipelineSpec(
+        1L,
+        2L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                table, "ods_" + table, CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandTest.java
@@ -1,0 +1,418 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution.EngineExecutionRef;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDeployRequest.CredentialBinding;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.DeployResult;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.RuntimeStatus;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.ValidationResult;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RealtimeWave5VersionCommandTest {
+
+  private static final long TASK_ID = 7L;
+  private static final long OLD_EXECUTION_ID = 19L;
+  private static final long NEW_EXECUTION_ID = 20L;
+  private static final long V3_ID = 31L;
+  private static final long V4_ID = 32L;
+
+  private RealtimeJobStore store;
+  private CdcPipelineSpecValidator specValidator;
+  private RealtimeDataSourceResolver dataSourceResolver;
+  private RealtimeConnectorCapabilityResolver capabilityResolver;
+  private PipelineYamlCompiler compiler;
+  private RealtimeEngineGateway gateway;
+  private RealtimeRuntimeResolver runtimeResolver;
+  private RealtimeJobService service;
+  private ComputeEnvironmentSnapshot environment;
+  private CdcPipelineSpec v3Spec;
+  private CdcPipelineSpec v4Spec;
+  private DefinitionRow task;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    specValidator = mock(CdcPipelineSpecValidator.class);
+    dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    capabilityResolver = mock(RealtimeConnectorCapabilityResolver.class);
+    compiler = mock(PipelineYamlCompiler.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    environment = environment();
+    v3Spec = spec("orders_v3");
+    v4Spec = spec("orders_v4");
+    task = task();
+
+    service =
+        new RealtimeJobService(
+            store,
+            new ObjectMapper(),
+            specValidator,
+            new SyncExecutionStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
+  }
+
+  @Test
+  void restartExecutionPreflightsRunningVersionEvenWhenPublishedRefIsNewer() {
+    DeploymentRow running = runningRow(V3_ID, v3Spec, "job-v3");
+    PublishedDefinitionRow v3 = version(V3_ID, 3, 3, v3Spec);
+    PublishedDefinitionRow v4 = version(V4_ID, 4, 4, v4Spec);
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+    CompiledPipeline compiled = new CompiledPipeline("pipeline: v3", "v3");
+
+    when(store.deploymentByIdempotencyKey("restart-v3")).thenReturn(Optional.empty());
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(running));
+    when(store.definitionVersion(TASK_ID, V3_ID)).thenReturn(Optional.of(v3));
+    when(store.publishedDefinition(TASK_ID)).thenReturn(Optional.of(v4));
+    when(store.definition(TASK_ID)).thenReturn(Optional.of(task));
+    when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
+    when(dataSourceResolver.resolve(v3Spec)).thenReturn(resolved);
+    when(gateway.capabilities(environment)).thenReturn(new ObjectMapper().createObjectNode());
+    when(compiler.compile("orders-sync", v3Spec, resolved)).thenReturn(compiled);
+    when(gateway.validate(environment, compiled.yaml()))
+        .thenThrow(new IllegalStateException("target-preflight-failed"));
+
+    assertThatThrownBy(() -> service.restartExecution(TASK_ID, "restart-v3"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("target-preflight-failed");
+
+    verify(store).definitionVersion(TASK_ID, V3_ID);
+    verify(store, never()).publishedDefinition(TASK_ID);
+    verify(compiler).compile("orders-sync", v3Spec, resolved);
+    verify(compiler, never()).compile(eq("orders-sync"), eq(v4Spec), any());
+    verify(store, never()).markStopping(anyLong(), any());
+    verify(gateway, never()).stop(any(), any());
+  }
+
+  @Test
+  void applyPublishedVersionPreflightsPinnedPublishedTargetBeforeStop() {
+    DeploymentRow running = runningRow(V3_ID, v3Spec, "job-v3");
+    PublishedDefinitionRow v4 = version(V4_ID, 4, 4, v4Spec);
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+    CompiledPipeline compiled = new CompiledPipeline("pipeline: v4", "v4");
+
+    when(store.deploymentByIdempotencyKey("apply-v4")).thenReturn(Optional.empty());
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(running));
+    when(store.publishedDefinition(TASK_ID)).thenReturn(Optional.of(v4));
+    when(store.definition(TASK_ID)).thenReturn(Optional.of(task));
+    when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
+    when(dataSourceResolver.resolve(v4Spec)).thenReturn(resolved);
+    when(gateway.capabilities(environment)).thenReturn(new ObjectMapper().createObjectNode());
+    when(compiler.compile("orders-sync", v4Spec, resolved)).thenReturn(compiled);
+    when(gateway.validate(environment, compiled.yaml()))
+        .thenThrow(new IllegalStateException("published-target-invalid"));
+
+    assertThatThrownBy(() -> service.applyPublishedVersion(TASK_ID, "apply-v4"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("published-target-invalid");
+
+    verify(store).publishedDefinition(TASK_ID);
+    verify(compiler).compile("orders-sync", v4Spec, resolved);
+    verify(store, never()).markStopping(anyLong(), any());
+    verify(gateway, never()).stop(any(), any());
+  }
+
+  @Test
+  void applyPublishedVersionRejectsWhenExecutionAlreadyUsesPublishedVersion() {
+    DeploymentRow running = runningRow(V4_ID, v4Spec, "job-v4");
+    PublishedDefinitionRow v4 = version(V4_ID, 4, 4, v4Spec);
+
+    when(store.deploymentByIdempotencyKey("apply-same")).thenReturn(Optional.empty());
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(running));
+    when(store.publishedDefinition(TASK_ID)).thenReturn(Optional.of(v4));
+
+    assertThatThrownBy(() -> service.applyPublishedVersion(TASK_ID, "apply-same"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("已经运行最新已发布");
+
+    verify(compiler, never()).compile(any(), any(), any());
+    verify(store, never()).markStopping(anyLong(), any());
+  }
+
+  @Test
+  void versionCommandsRejectUnknownExecutionInsteadOfBypassingReconcile() {
+    DeploymentRow unknown =
+        executionRow(
+            V3_ID,
+            v3Spec,
+            "job-v3",
+            DesiredState.RUNNING,
+            ObservedState.UNKNOWN,
+            true,
+            "UNKNOWN");
+
+    when(store.deploymentByIdempotencyKey("restart-unknown")).thenReturn(Optional.empty());
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(unknown));
+
+    assertThatThrownBy(() -> service.restartExecution(TASK_ID, "restart-unknown"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请先对账");
+
+    verify(store, never()).definitionVersion(anyLong(), anyLong());
+    verify(store, never()).markStopping(anyLong(), any());
+  }
+
+  @Test
+  void restartExecutionCreatesNewExecutionBoundToSameImmutableVersion() {
+    DeploymentRow running = runningRow(V3_ID, v3Spec, "job-v3");
+    DeploymentRow stopping =
+        executionRow(
+            V3_ID,
+            v3Spec,
+            "job-v3",
+            DesiredState.STOPPED,
+            ObservedState.STOPPING,
+            false,
+            "STOPPING");
+    DeploymentRow newStarting =
+        executionRowWithId(
+            NEW_EXECUTION_ID,
+            V3_ID,
+            v3Spec,
+            null,
+            DesiredState.RUNNING,
+            ObservedState.STARTING,
+            false,
+            "SUBMITTING");
+    DeploymentRow newRunning =
+        executionRowWithId(
+            NEW_EXECUTION_ID,
+            V3_ID,
+            v3Spec,
+            "job-new-v3",
+            DesiredState.RUNNING,
+            ObservedState.RUNNING,
+            false,
+            "RUNNING");
+    PublishedDefinitionRow v3 = version(V3_ID, 3, 3, v3Spec);
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+    CompiledPipeline compiled = new CompiledPipeline("pipeline: v3", "v3");
+
+    when(store.deploymentByIdempotencyKey("restart-success")).thenReturn(Optional.empty());
+    when(store.latestDeployment(TASK_ID))
+        .thenReturn(
+            Optional.of(running),
+            Optional.of(running),
+            Optional.of(running),
+            Optional.of(stopping),
+            Optional.of(newStarting),
+            Optional.of(newRunning));
+    when(store.definitionVersion(TASK_ID, V3_ID)).thenReturn(Optional.of(v3));
+    when(store.definition(TASK_ID)).thenReturn(Optional.of(task));
+    when(store.lockDefinition(TASK_ID)).thenReturn(task);
+    when(store.latestExecution(TASK_ID))
+        .thenReturn(
+            Optional.of(execution(OLD_EXECUTION_ID, V3_ID, DesiredState.STOPPED, ObservedState.STOPPED, "job-v3")),
+            Optional.of(execution(OLD_EXECUTION_ID, V3_ID, DesiredState.STOPPED, ObservedState.STOPPED, "job-v3")));
+    when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
+    when(runtimeResolver.deployment(any(), any())).thenReturn(environment);
+    when(dataSourceResolver.resolve(v3Spec)).thenReturn(resolved);
+    when(dataSourceResolver.resolveCredentials(v3Spec))
+        .thenReturn(
+            new CredentialBinding[] {
+              new CredentialBinding("source", "secret"),
+              new CredentialBinding("sink", "secret")
+            });
+    when(gateway.capabilities(environment)).thenReturn(new ObjectMapper().createObjectNode());
+    when(compiler.compile("orders-sync", v3Spec, resolved)).thenReturn(compiled);
+    when(gateway.validate(environment, compiled.yaml()))
+        .thenReturn(new ValidationResult(true, "at-least-once"));
+    when(gateway.status(environment, "job-v3"))
+        .thenReturn(
+            new RuntimeStatus("job-v3", RuntimeStatus.State.RUNNING),
+            new RuntimeStatus("job-v3", RuntimeStatus.State.TERMINATED));
+    when(store.insertDeployment(any(), eq(v3Spec), any(), any(), eq(environment), eq("restart-success")))
+        .thenReturn(NEW_EXECUTION_ID);
+    when(gateway.deploy(eq(environment), any()))
+        .thenReturn(new DeployResult("job-new-v3", "at-least-once"));
+
+    assertThatCode(() -> service.restartExecution(TASK_ID, "restart-success"))
+        .doesNotThrowAnyException();
+
+    verify(store).bindDeploymentDefinitionVersion(NEW_EXECUTION_ID, V3_ID, 3);
+    verify(store, never()).publishedDefinition(TASK_ID);
+    verify(gateway).stop(environment, "job-v3");
+    verify(store)
+        .markDeploymentRunning(
+            TASK_ID, NEW_EXECUTION_ID, "job-new-v3", environment.runtimeRevision());
+  }
+
+  private DefinitionRow task() {
+    return new DefinitionRow(
+        TASK_ID,
+        "orders-sync",
+        "test",
+        v4Spec,
+        environment.id(),
+        "PUBLISHED",
+        "RUNNING",
+        "RUNNING",
+        4,
+        4,
+        V4_ID,
+        "c".repeat(64),
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private PublishedDefinitionRow version(
+      long id, int versionNo, int sourceDraftRevision, CdcPipelineSpec spec) {
+    return new PublishedDefinitionRow(
+        id,
+        TASK_ID,
+        versionNo,
+        sourceDraftRevision,
+        spec,
+        environment.id(),
+        "a".repeat(64),
+        "b".repeat(64));
+  }
+
+  private DeploymentRow runningRow(long versionId, CdcPipelineSpec spec, String jobId) {
+    return executionRow(
+        versionId,
+        spec,
+        jobId,
+        DesiredState.RUNNING,
+        ObservedState.RUNNING,
+        false,
+        "RUNNING");
+  }
+
+  private DeploymentRow executionRow(
+      long versionId,
+      CdcPipelineSpec spec,
+      String jobId,
+      DesiredState desired,
+      ObservedState observed,
+      boolean uncertain,
+      String status) {
+    return executionRowWithId(
+        OLD_EXECUTION_ID, versionId, spec, jobId, desired, observed, uncertain, status);
+  }
+
+  private DeploymentRow executionRowWithId(
+      long executionId,
+      long versionId,
+      CdcPipelineSpec spec,
+      String jobId,
+      DesiredState desired,
+      ObservedState observed,
+      boolean uncertain,
+      String status) {
+    return new DeploymentRow(
+        executionId,
+        TASK_ID,
+        versionId,
+        3,
+        spec,
+        "test",
+        "d".repeat(64),
+        "execution-" + executionId,
+        jobId,
+        environment.runtimeRevision(),
+        environment,
+        "FLINK_CDC",
+        desired.name(),
+        observed.name(),
+        status,
+        uncertain,
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private SyncExecution execution(
+      long executionId,
+      long versionId,
+      DesiredState desired,
+      ObservedState observed,
+      String jobId) {
+    return new SyncExecution(
+        executionId,
+        TASK_ID,
+        versionId,
+        desired,
+        observed,
+        new EngineExecutionRef("FLINK_CDC", jobId),
+        observed == ObservedState.UNKNOWN,
+        null);
+  }
+
+  private ComputeEnvironmentSnapshot environment() {
+    return new ComputeEnvironmentSnapshot(
+        3L,
+        "test-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
+        2);
+  }
+
+  private CdcPipelineSpec spec(String table) {
+    return new CdcPipelineSpec(
+        1L,
+        2L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                table, "ods_" + table, CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}

--- a/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/RealtimeExecutionPanel.tsx
@@ -10,9 +10,10 @@ import { Alert, Button, Card, ConfigProvider, Descriptions, Space, Steps, Tag, m
 import { useEffect, useMemo, useState } from 'react';
 import { BRAND_THEME } from '@/styles/brand';
 import { realtimeApi } from './api';
+import type { RealtimeAction } from './api';
 import type { RealtimeJob, RuntimeCapabilities } from './types';
 
-type ExecutionAction = 'validate' | 'publish' | 'start' | 'stop' | 'reconcile';
+type ExecutionAction = Exclude<RealtimeAction, 'restart'>;
 
 const stateLabel: Record<string, string> = {
   STOPPED: '已停止',
@@ -23,6 +24,11 @@ const stateLabel: Record<string, string> = {
   UNKNOWN: '未知',
   CONFLICT: '冲突',
 };
+
+const isExecutionStartingAction = (action: ExecutionAction) =>
+  action === 'start' ||
+  action === 'restart-execution' ||
+  action === 'apply-published-version';
 
 export default function RealtimeExecutionPanel({
   job,
@@ -90,14 +96,22 @@ export default function RealtimeExecutionPanel({
             ? '当前草稿已发布；正在运行的 SyncExecution 继续使用启动时的 DefinitionVersion'
             : '当前定义版本已发布',
         );
-      } else if (action === 'start') {
+      } else if (isExecutionStartingAction(action)) {
         const refreshed = await waitForStartResult();
         if (refreshed.observedState === 'RUNNING') {
-          message.success('实时同步任务已启动');
+          if (action === 'restart-execution') {
+            message.success('已按当前 DefinitionVersion 创建新的 SyncExecution');
+          } else if (action === 'apply-published-version') {
+            message.success('已显式应用命令开始时固定的 Published DefinitionVersion');
+          } else {
+            message.success('实时同步任务已启动');
+          }
         } else if (refreshed.observedState === 'STARTING') {
           message.warning('Flink 任务仍在启动，可返回列表继续观察状态');
         } else {
-          message.warning(`Flink 启动结果：${stateLabel[refreshed.observedState] || refreshed.observedState}`);
+          message.warning(
+            `Flink 执行结果：${stateLabel[refreshed.observedState] || refreshed.observedState}`,
+          );
         }
       } else if (action === 'stop') {
         await refreshJob();
@@ -123,6 +137,7 @@ export default function RealtimeExecutionPanel({
     current.releaseState === 'PUBLISHED' && current.publishedVersion === current.definitionVersion;
   const hasUnpublishedChanges = hasPublishedVersion && !currentDraftPublished;
   const running = current.desiredState === 'RUNNING';
+  const stableRunning = running && current.observedState === 'RUNNING';
   const startable =
     hasPublishedVersion &&
     current.desiredState === 'STOPPED' &&
@@ -161,7 +176,9 @@ export default function RealtimeExecutionPanel({
       {
         title: '运行实例',
         description: running
-          ? `${stateLabel[current.observedState] || current.observedState} · 固定启动时 DefinitionVersion`
+          ? current.publishedUpdateAvailable
+            ? `${stateLabel[current.observedState] || current.observedState} · 有已发布更新可显式应用`
+            : `${stateLabel[current.observedState] || current.observedState} · 固定启动时 DefinitionVersion`
           : hasUnpublishedChanges
             ? `下一次启动使用已发布 v${current.publishedVersion}`
             : '等待启动',
@@ -172,7 +189,14 @@ export default function RealtimeExecutionPanel({
             : ('wait' as const),
       },
     ],
-    [current, currentDraftPublished, hasPublishedVersion, hasUnpublishedChanges, running, validated],
+    [
+      current,
+      currentDraftPublished,
+      hasPublishedVersion,
+      hasUnpublishedChanges,
+      running,
+      validated,
+    ],
   );
 
   return (
@@ -183,7 +207,7 @@ export default function RealtimeExecutionPanel({
             <div>
               <div className="flex items-center gap-2 text-[12px] font-medium text-[var(--yak-brand-color)]">
                 <CheckCircleOutlined />
-                配置已保存 · 定义与运行解耦
+                配置已保存 · 版本与运行显式解耦
               </div>
               <h1 className="mb-0 mt-1 text-[20px] font-semibold text-[#101828]">{current.name}</h1>
               <div className="mt-1 text-[12px] text-[#98a2b3]">
@@ -233,13 +257,13 @@ export default function RealtimeExecutionPanel({
             />
           )}
 
-          {running && currentDraftPublished && (
+          {current.publishedUpdateAvailable && (
             <Alert
               className="mb-5"
               type="warning"
               showIcon
-              message="发布不会热更新当前 SyncExecution"
-              description="Wave 4 的 Restart 也不会隐式升级版本：后端会用 immutable DefinitionVersionId 校验运行版本与最新 Published Ref；若不同会在停止前拒绝。Wave 5 会把 RestartExecution 与 ApplyPublishedVersion 正式拆成两个命令。"
+              message="存在新的 Published DefinitionVersion"
+              description="“重启当前版本”会保持当前运行版本；“应用已发布版本”才会停止当前 Execution，并显式创建使用新 Published DefinitionVersion 的 Execution。两个命令不会互相替代。"
             />
           )}
 
@@ -308,19 +332,41 @@ export default function RealtimeExecutionPanel({
                         <PlayCircleOutlined /> 3. 运行实例
                       </div>
                       <div className="mt-1 text-[12px] leading-5 text-[#667085]">
-                        新 Start 只读取不可变 Published DefinitionVersion；已有运行实例始终保持自己的启动快照。
+                        重启固定当前 DefinitionVersion；应用已发布版本是独立的显式升级命令。两个命令都会先预检目标版本，再停止当前稳定运行实例。
                       </div>
                     </div>
                     {running ? (
-                      <Button
-                        danger
-                        icon={<StopOutlined />}
-                        loading={acting === 'stop'}
-                        disabled={Boolean(acting)}
-                        onClick={() => void run('stop')}
-                      >
-                        停止任务
-                      </Button>
+                      <Space wrap>
+                        <Button
+                          danger
+                          icon={<StopOutlined />}
+                          loading={acting === 'stop'}
+                          disabled={Boolean(acting)}
+                          onClick={() => void run('stop')}
+                        >
+                          停止任务
+                        </Button>
+                        <Button
+                          icon={<ReloadOutlined />}
+                          loading={acting === 'restart-execution'}
+                          disabled={Boolean(acting) || !stableRunning}
+                          onClick={() => void run('restart-execution')}
+                        >
+                          重启当前版本
+                        </Button>
+                        {current.publishedUpdateAvailable && (
+                          <Button
+                            type="primary"
+                            danger
+                            icon={<PlayCircleOutlined />}
+                            loading={acting === 'apply-published-version'}
+                            disabled={Boolean(acting) || !stableRunning}
+                            onClick={() => void run('apply-published-version')}
+                          >
+                            应用已发布版本
+                          </Button>
+                        )}
+                      </Space>
                     ) : (
                       <Button
                         type="primary"
@@ -349,6 +395,9 @@ export default function RealtimeExecutionPanel({
                   </Descriptions.Item>
                   <Descriptions.Item label="当前运行定义">
                     {running ? '启动时 DefinitionVersion 快照（保持不变）' : '无活动运行'}
+                  </Descriptions.Item>
+                  <Descriptions.Item label="已发布更新">
+                    {current.publishedUpdateAvailable ? '有，可显式应用' : '无'}
                   </Descriptions.Item>
                   <Descriptions.Item label="运行状态">
                     <Tag>{stateLabel[current.observedState] || current.observedState}</Tag>

--- a/yak-ops-ui/src/pages/realtime-sync/api.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/api.ts
@@ -40,6 +40,16 @@ interface DefinitionValidationResult {
   deliverySemantics: string;
 }
 
+export type RealtimeAction =
+  | 'publish'
+  | 'validate'
+  | 'start'
+  | 'stop'
+  | 'restart-execution'
+  | 'apply-published-version'
+  | 'reconcile'
+  | 'restart';
+
 const validateDefinition = (spec: CdcPipelineSpec, runtimeEnvironmentId: number) =>
   request<ApiResponse<DefinitionValidationResult>>(`${PREFIX}/spec/validate`, {
     method: 'POST',
@@ -66,6 +76,9 @@ const capabilities = async (environmentId?: number) => {
   });
 };
 
+const needsIdempotencyKey = (action: RealtimeAction) =>
+  ['start', 'restart', 'restart-execution', 'apply-published-version'].includes(action);
+
 export const realtimeApi = {
   page: (params: RealtimePageQuery) =>
     request<ApiResponse<RealtimeJobPage>>(PREFIX, {
@@ -89,13 +102,12 @@ export const realtimeApi = {
       method: 'POST',
       data: { spec },
     }),
-  action: (id: number, action: 'publish' | 'validate' | 'start' | 'stop' | 'restart' | 'reconcile') =>
+  action: (id: number, action: RealtimeAction) =>
     request<ApiResponse<RealtimeDeployment | boolean>>(`${PREFIX}/${id}/${action}`, {
       method: 'POST',
-      headers:
-        action === 'start' || action === 'restart'
-          ? { 'Idempotency-Key': crypto.randomUUID() }
-          : undefined,
+      headers: needsIdempotencyKey(action)
+        ? { 'Idempotency-Key': crypto.randomUUID() }
+        : undefined,
     }),
   remove: (id: number) => request<ApiResponse<boolean>>(`${PREFIX}/${id}`, { method: 'DELETE' }),
   events: (id: number) => request<ApiResponse<RealtimeEvent[]>>(`${PREFIX}/${id}/events`),

--- a/yak-ops-ui/src/pages/realtime-sync/index.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/index.tsx
@@ -27,6 +27,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import CustomPagination from '../batch-link-up/CustomPagination';
 import { realtimeApi } from './api';
+import type { RealtimeAction } from './api';
 import JobEditor from './JobEditor';
 import CreateRealtimeTaskDrawer from './CreateRealtimeTaskDrawer';
 import RealtimeRuntimeDetail from './RealtimeRuntimeDetail';
@@ -110,6 +111,10 @@ const StateBadge = ({ state, label }: { state?: string; label?: string }) => {
 };
 
 const initialFilters: FilterState = { stateGroup: 'ALL' };
+const createsExecution = (action: RealtimeAction) =>
+  action === 'start' ||
+  action === 'restart-execution' ||
+  action === 'apply-published-version';
 
 export default function RealtimeSync() {
   const [jobs, setJobs] = useState<RealtimeJob[]>([]);
@@ -249,17 +254,24 @@ export default function RealtimeSync() {
     return 'STARTING';
   };
 
-  const action = async (
-    job: RealtimeJob,
-    name: 'publish' | 'validate' | 'start' | 'stop' | 'restart' | 'reconcile',
-  ) => {
+  const action = async (job: RealtimeJob, name: RealtimeAction) => {
     try {
       await realtimeApi.action(job.id, name);
-      if (name === 'start') {
+      if (createsExecution(name)) {
         const state = await waitForStartResult(job.id);
-        if (state === 'RUNNING') message.success('实时同步任务已启动');
-        else if (state === 'STARTING') message.warning('Flink 任务仍在启动，请稍后刷新状态');
-        else message.warning(`Flink 启动结果：${observedStateLabel[state] || state}`);
+        if (state === 'RUNNING') {
+          if (name === 'restart-execution') {
+            message.success('已按当前 DefinitionVersion 重启 SyncExecution');
+          } else if (name === 'apply-published-version') {
+            message.success('已显式应用新的 Published DefinitionVersion');
+          } else {
+            message.success('实时同步任务已启动');
+          }
+        } else if (state === 'STARTING') {
+          message.warning('Flink 任务仍在启动，请稍后刷新状态');
+        } else {
+          message.warning(`Flink 执行结果：${observedStateLabel[state] || state}`);
+        }
       } else if (name === 'publish') {
         message.success(
           job.desiredState === 'RUNNING'
@@ -387,14 +399,21 @@ export default function RealtimeSync() {
       deleteJob(job);
       return;
     }
-    if (key === 'validate' || key === 'publish' || key === 'restart' || key === 'reconcile') {
+    if (
+      key === 'validate' ||
+      key === 'publish' ||
+      key === 'restart-execution' ||
+      key === 'apply-published-version' ||
+      key === 'reconcile'
+    ) {
       void action(job, key);
     }
   };
 
   const moreItems = (job: RealtimeJob): MenuProps['items'] => {
     const running = job.desiredState === 'RUNNING';
-    return [
+    const stableRunning = running && job.observedState === 'RUNNING';
+    const items: MenuProps['items'] = [
       { key: 'detail', label: '查看运行详情' },
       {
         key: 'validate',
@@ -407,10 +426,19 @@ export default function RealtimeSync() {
         disabled: job.releaseState === 'PUBLISHED',
       },
       {
-        key: 'restart',
-        label: '重启任务',
-        disabled: !running,
+        key: 'restart-execution',
+        label: '重启当前版本',
+        disabled: !stableRunning,
       },
+    ];
+    if (job.publishedUpdateAvailable) {
+      items.push({
+        key: 'apply-published-version',
+        label: '应用已发布版本',
+        disabled: !stableRunning,
+      });
+    }
+    items.push(
       {
         key: 'reconcile',
         label: '立即状态对账',
@@ -422,7 +450,8 @@ export default function RealtimeSync() {
         label: <span className="text-[#d92d20]">删除任务</span>,
         disabled: job.desiredState !== 'STOPPED',
       },
-    ];
+    );
+    return items;
   };
 
   const columns: ColumnsType<RealtimeJob> = [
@@ -484,7 +513,14 @@ export default function RealtimeSync() {
       dataIndex: 'releaseState',
       width: 115,
       align: 'center',
-      render: (value) => <StateBadge state={value} label={releaseStateLabel[value] || value} />,
+      render: (value, job) => (
+        <div className="flex flex-col items-center gap-1">
+          <StateBadge state={value} label={releaseStateLabel[value] || value} />
+          {job.publishedUpdateAvailable && (
+            <span className="text-[10px] leading-4 text-[#b54708]">有更新可应用</span>
+          )}
+        </div>
+      ),
     },
     {
       title: '运行状态',

--- a/yak-ops-ui/src/pages/realtime-sync/types.ts
+++ b/yak-ops-ui/src/pages/realtime-sync/types.ts
@@ -92,6 +92,7 @@ export interface RealtimeJob {
   observedState: ObservedState;
   definitionVersion: number;
   publishedVersion?: number;
+  publishedUpdateAvailable: boolean;
   configDigest?: string;
   lastError?: string;
   createTime: string;


### PR DESCRIPTION
## 背景

Realtime Sync Stage 6 已完成：

```text
Wave 0  Core VO + legacy mapper
Wave 1  immutable DefinitionVersion
Wave 2  Start by Published DefinitionVersion
Wave 3  Deployment -> SyncExecution + Desired/Observed ownership
Wave 4  Active Execution 下继续编辑 / 发布
```

本 PR 完成 **Wave 5：正式拆分 RestartExecution 与 ApplyPublishedVersion**。

核心语义：

```text
RestartExecution
E100(V3) -> stop -> E101(V3)

ApplyPublishedVersion
E100(V3) -> stop -> E101(V4)
```

重启不再等价于“停止后读取最新 Published 再启动”；版本升级必须是显式命令。

---

## Domain Impact Analysis

```text
Bounded Context: Realtime Sync
Aggregate(s):
  - SyncExecution: RestartExecution
  - RealtimeSyncTask + PublishedDefinitionRef: ApplyPublishedVersion
SyncDefinition Area: no structural change
Invariant/Lifecycle:
  - RestartExecution creates a new Execution pinned to old Execution.definitionVersionId
  - ApplyPublishedVersion captures Task.publishedDefinitionRef at command start
  - neither command resurrects a terminal Execution
  - UNKNOWN / CONFLICT cannot be bypassed by a version command
Layer: Application + API + Query Projection + UI
Migration Wave: Wave 5
Safety:
  - Idempotency-Key retained
  - Task FOR UPDATE remains cross-instance command mutex
  - target DefinitionVersion preflight happens before Stop
  - replacement-stop reservation linearizes concurrent Stop/Restart/Apply
  - stop-during-start / UNKNOWN / CONFLICT retained
  - immutable DefinitionVersion + RuntimeEnvironmentSnapshot retained
Domain Gap: no
```

## 1. RestartExecution 真正固定当前运行版本

`restartExecution()` 的目标来自：

```text
current SyncExecution.definitionVersionId
```

而不是：

```text
Task.publishedDefinitionRef
```

所以现在合法支持：

```text
Running Execution = V3
Current Published = V4

RestartExecution
  -> preflight V3
  -> stop E100(V3)
  -> create E101(V3)
```

不会升级到 V4。

旧 `/restart` 暂时保留为兼容 endpoint，但只委托 `RestartExecution`，不再拥有“restart-to-latest”语义。

## 2. ApplyPublishedVersion 是独立显式升级命令

新增：

```text
POST /api/v1/realtime-sync/{id}/apply-published-version
```

命令开始时只读取一次：

```text
Task.publishedDefinitionRef
```

并固定该 immutable VersionId 作为本次目标。

例如：

```text
E100(V3) RUNNING
Published = V4

ApplyPublishedVersion
  -> capture V4
  -> preflight V4
  -> stop E100
  -> create E101(V4)
```

如果命令执行期间又 Publish V5：

```text
当前 Apply 仍然使用 V4
```

不会漂移到 V5。

## 3. 两个命令都先预检目标版本，再停止健康任务

目标版本的：

```text
Spec intrinsic validation
RuntimeEnvironment
DataSource resolution
Connector capability
Pipeline compile
Gateway validate
```

都在 Stop 前完成。

如果 V4 的环境 / Connector / 数据源不可运行：

```text
ApplyPublishedVersion fails
current E100(V3) remains RUNNING
```

不会为了一个不可运行的新版本先停线上任务。

RestartExecution 对旧 V3 也采用同样规则。

## 4. 增加跨实例 replacement-stop reservation

版本目标预检可能耗时，因此预检后会再次：

```text
Task FOR UPDATE
  -> verify same ExecutionId
  -> verify stable RUNNING/RUNNING
  -> verify EngineExecutionRef bound
  -> mark STOPPING
```

这是 Restart/Apply 的跨实例线性化点。

如果预检期间另一个实例已经：

```text
Stop
RestartExecution
ApplyPublishedVersion
```

抢先改变了 Execution：

```text
当前版本命令直接失败
```

不会在旧任务停止后又擅自拉起替换版本。

## 5. 只有稳定 RUNNING Execution 才能执行版本命令

Wave 5 明确拒绝：

```text
STARTING
STOPPING
UNKNOWN
CONFLICT
resultUncertain=true
terminal Execution
missing EngineExecutionRef
```

这些场景必须先完成状态对账或使用普通 Start，不允许借版本升级绕开不确定运行态。

## 6. 支持读取任意历史 immutable DefinitionVersion

`RealtimeJobStore` 新增显式只读边界：

```text
definitionVersion(taskId, definitionVersionId)
```

`VersioningRealtimeJobStore` 可以读取历史 V3，即使 Task 当前 Published 已经是 V4/V5。

同时保留数据完整性检查：

```text
Task 有 Published Ref
但对应 DefinitionVersion 行缺失
  -> 明确报错
```

不会伪装成“任务未发布”。

## 7. publishedUpdateAvailable 由后端 immutable ID 推导

前端不比较：

```text
definitionVersion
publishedVersion
Deployment.definitionVersion
```

这些仍是 legacy DraftRevision。

后端直接比较：

```text
latest stable Execution.definitionVersionId
!=
Task.publishedDefinitionVersionId
```

对外只暴露派生事实：

```text
publishedUpdateAvailable: boolean
```

它不是新的版本事实源。

列表 SQL 与详情查询都使用 immutable ID 推导。

## 8. API / UI 显式拆开两个动作

新增 endpoint：

```text
POST /{id}/restart-execution
POST /{id}/apply-published-version
```

前端稳定运行时展示：

```text
停止任务
重启当前版本
应用已发布版本   // only when publishedUpdateAvailable=true
```

列表“更多操作”同样拆分；发布状态会提示“有更新可应用”。

执行面板明确说明：

```text
Restart = same DefinitionVersion
Apply Published = explicit version switch
```

## 9. Protection List 保持

本 PR 没有重写：

```text
Start Idempotency-Key / unique persistence
Task FOR UPDATE command serialization
start reservation before external submit
same-key race recovery
stop-during-start
UNKNOWN / CONFLICT
runtime identity persistence/recovery
RuntimeEnvironmentSnapshot
submission-scoped credentials / zeroization
FlinkCdcEngineGateway
SSH runner
log redaction
reconcile lease
```

没有 DB schema 变更。

## 10. 测试

新增：

```text
RealtimeWave5VersionCommandTest
RealtimeWave5VersionCommandRaceTest
```

覆盖：

- Restart 在 Published 更高时仍预检 / 使用旧运行版本；
- Restart 完整成功路径创建新 Execution，并绑定同一个 immutable V3；
- Apply 预检命令开始时捕获的 Published V4；
- Apply 当前已经是最新版本时拒绝；
- UNKNOWN Execution 禁止执行版本命令；
- 目标预检失败时不会 Stop；
- 预检期间另一个 Stop 抢先时 replacement reservation 拒绝继续；
- `publishedUpdateAvailable` 使用 immutable IDs，而不是 legacy revisions；
- 历史 DefinitionVersion 显式读取；
- broken Published Ref 明确报数据完整性错误。

同时移除了 Wave 4 的临时断言“Published 变化后 Restart 必须拒绝”，因为 Wave 5 的正确语义已经变成“Restart old version / Apply new version”。

## 11. DOMAIN.md

模块领域宪法已推进到：

```text
Wave 0 ✅
Wave 1 ✅
Wave 2 ✅
Wave 3 ✅
Wave 4 ✅
Wave 5 ✅
Wave 6 pending
```

并新增硬规则：

- Restart 不读取当前 Published；
- Apply 目标在命令开始时固定；
- target preflight 必须在 Stop 前；
- immutable VersionId 才能做版本身份判断；
- legacy `/restart` 只能作为 RestartExecution alias；
- target preflight 后必须通过 DB-lock reservation 重新确认当前 Execution 未被其他命令抢占。

## 验证说明

当前执行环境此前无法解析 `github.com`，因此无法执行完整 Maven / Yarn / tsc 构建。

本 PR 已完成源码级路径审查和专项测试代码补充，但：

**不声明 Maven、Jest、tsc 或完整 CI 已通过。**

创建 PR 后继续检查 GitHub workflow/status。

## 本 PR 明确不做

```text
Wave 6  legacy field/package/name cleanup
```

也不处理：

- hot reload；
- Archive/Tombstone；
- checkpoint/restart runtime application gap；
- FINISHED normal completion / snapshot-only；
- legacy configDigest/status rename；
- 删除 legacy `/restart` endpoint。

## Domain Compliance Report

```text
Domain rule implemented:
  RestartExecution and ApplyPublishedVersion are explicit separate commands.

Aggregate(s) changed:
  SyncExecution lifecycle command semantics
  RealtimeSyncTask PublishedDefinitionRef read semantics

Invariant/lifecycle impact:
  restart pins current execution version
  apply pins command-time published version
  version commands require stable running execution
  replacement command is reserved under DB lock after preflight

Legacy compatibility kept:
  /restart -> RestartExecution alias
  DraftRevision / publishedVersion UI projections
  current deployment/read models

Safety preserved:
  idempotency / command mutex / stop-during-start / UNKNOWN / CONFLICT
  runtime identity / runtime snapshot / credential / Flink / SSH protections

DB migration mode:
  no schema change

Known gaps remaining:
  Wave 6 + existing Stage-4 gap register items
```

## Branch

```text
feat/realtime-sync-domain-stage-6-wave-5
```