### PR TITLE
test: automate realtime sync domain guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md
+++ b/.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md
@@ -1,0 +1,59 @@
+# Realtime Sync Change
+
+> This template is for changes touching `yak-ops-business-sync-realtime` or `yak-ops-ui/src/pages/realtime-sync`.
+> Read `yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md` first.
+
+## Summary
+
+<!-- What user/product problem does this PR solve? -->
+
+## Domain Impact Analysis
+
+```text
+Bounded context: Realtime Sync / adjacent context
+Aggregate(s): RealtimeSyncTask / DefinitionVersion / SyncExecution / none
+SyncDefinition area: Endpoint / Route / Selector / Target / ReplayKey / SyncPolicy / ExecutionPolicy / none
+Invariant/lifecycle impact:
+Layer: Domain / Application / Infrastructure / Interface
+Current mapping/gap:
+Safety properties to preserve:
+Domain Gap: no
+```
+
+If `Domain Gap: yes`, explain the approved domain-model extension before implementation.
+
+## Behavior / compatibility
+
+<!-- Explain DB/API/YAML/UI compatibility. Do not call legacy DraftRevision fields DefinitionVersion IDs. -->
+
+## Safety checklist
+
+- [ ] No second editable Spec/Definition truth was introduced.
+- [ ] Start/Restart/Apply do not read mutable Draft incorrectly.
+- [ ] UNKNOWN/CONFLICT cannot create a second active Execution.
+- [ ] Idempotency / DB command serialization / stop-during-start are preserved when relevant.
+- [ ] RuntimeEnvironmentSnapshot / runtime identity / credential zeroization are preserved when relevant.
+- [ ] Core Domain remains free from Flink/SSH/JDBC/Spring/persistence concerns.
+- [ ] No Big-Bang schema/API rename/drop was introduced.
+
+## Tests / guardrails
+
+```text
+Static domain guard:
+Core domain smoke:
+Targeted JUnit tests:
+Other validation:
+```
+
+## Domain Compliance Report
+
+```text
+Domain rule implemented:
+Aggregate(s) affected:
+Invariant/lifecycle changes:
+Legacy compatibility retained:
+Safety properties preserved:
+DB/API migration mode:
+Tests/guardrails added or updated:
+Known gaps remaining:
+```

--- a/.github/workflows/realtime-sync-domain-guardrails.yml
+++ b/.github/workflows/realtime-sync-domain-guardrails.yml
@@ -1,0 +1,134 @@
+name: Realtime Sync Domain Guardrails
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - 'yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/**'
+      - 'yak-ops-ui/src/pages/realtime-sync/**'
+      - 'docs/realtime-sync/domain/**'
+      - 'tools/realtime_domain_guardrails.py'
+      - 'tools/realtime-domain-smoke/**'
+      - '.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md'
+      - '.github/workflows/realtime-sync-domain-guardrails.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/**'
+      - 'yak-ops-ui/src/pages/realtime-sync/**'
+      - 'docs/realtime-sync/domain/**'
+      - 'tools/realtime_domain_guardrails.py'
+      - 'tools/realtime-domain-smoke/**'
+      - '.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md'
+      - '.github/workflows/realtime-sync-domain-guardrails.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: realtime-sync-domain-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REALTIME_MODULE: ':yak-ops-business-sync-realtime'
+  CORE_DOMAIN: yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain
+
+jobs:
+  static-domain-contract:
+    name: Static domain contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout yak-ops
+        uses: actions/checkout@v4
+
+      - name: Run zero-dependency domain guard
+        run: python3 tools/realtime_domain_guardrails.py --event "$GITHUB_EVENT_PATH"
+
+  core-domain-smoke:
+    name: Framework-free core domain smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout yak-ops
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Compile core domain without Spring or Maven classpath
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/realtime-domain-core"
+          rm -rf "$OUT"
+          mkdir -p "$OUT"
+
+          javac --release 21 -d "$OUT" \
+            "$CORE_DOMAIN/RealtimeJobState.java" \
+            "$CORE_DOMAIN/SyncDefinition.java" \
+            "$CORE_DOMAIN/RuntimeEnvironmentRef.java" \
+            "$CORE_DOMAIN/DefinitionDigest.java" \
+            "$CORE_DOMAIN/SyncDefinitionDigestCalculator.java" \
+            "$CORE_DOMAIN/DefinitionVersion.java" \
+            "$CORE_DOMAIN/SyncExecution.java" \
+            "$CORE_DOMAIN/SyncExecutionStateMachine.java" \
+            tools/realtime-domain-smoke/RealtimeDomainSmoke.java
+
+          java -cp "$OUT" RealtimeDomainSmoke
+
+  backend-domain-regression:
+    name: Backend regression hook
+    needs:
+      - static-domain-contract
+      - core-domain-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      YAK_FRAMEWORK_TOKEN: ${{ secrets.YAK_FRAMEWORK_TOKEN }}
+    steps:
+      - name: Checkout yak-ops
+        uses: actions/checkout@v4
+
+      - name: Explain private dependency requirement
+        if: env.YAK_FRAMEWORK_TOKEN == ''
+        run: |
+          echo "::notice title=Backend regression not executed::yak-framework is a private repository. Configure repository secret YAK_FRAMEWORK_TOKEN with read access to enable the full Maven/JUnit regression layer. Static Domain Contract and framework-free Core Smoke remain mandatory and already run without this secret."
+
+      - name: Checkout yak-framework SNAPSHOT dependency
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        uses: actions/checkout@v4
+        with:
+          repository: weifuwan/yak-framework
+          path: .ci/yak-framework
+          token: ${{ env.YAK_FRAMEWORK_TOKEN }}
+
+      - name: Set up JDK 21 and Maven cache
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Install yak-framework SNAPSHOT
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        run: ./mvnw -B -ntp -f .ci/yak-framework/pom.xml -DskipTests install
+
+      - name: Build realtime module dependencies
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        run: ./mvnw -B -ntp -pl "$REALTIME_MODULE" -am -DskipTests install
+
+      - name: Run targeted realtime domain regression tests
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        run: >-
+          ./mvnw -B -ntp
+          -pl "$REALTIME_MODULE"
+          -Dtest=RealtimeArchitectureTest,SyncExecutionStateMachineTest,SyncDefinitionDigestCalculatorTest,CdcPipelineSpecCompatibilityMapperTest,DefinitionVersionRepositoryAdapterTest,VersioningRealtimeJobStoreTest,RealtimeJobDaoImplExecutionIsolationTest,RealtimeJobStoreAdapterExecutionProjectionTest,RealtimeExecutionPathTest,RealtimeJobServiceConcurrencyTest,RealtimeJobLifecycleCoordinatorTest,RealtimeWave4DefinitionMutationTest,RealtimeWave5VersionCommandTest,RealtimeWave5VersionCommandRaceTest
+          -Dsurefire.failIfNoSpecifiedTests=false
+          test

--- a/docs/realtime-sync/domain/07-automated-domain-guardrails.md
+++ b/docs/realtime-sync/domain/07-automated-domain-guardrails.md
@@ -1,0 +1,633 @@
+# Stage 7 — Automated Realtime Sync Domain Guardrails
+
+> Status: implemented.
+>
+> Goal: turn the accepted Realtime Sync domain model and Stage 6 migration result into executable checks that resist architectural drift.
+
+---
+
+## 1. Why Stage 7 exists
+
+Stages 1～6 established and implemented:
+
+```text
+RealtimeSyncTask
+      │ publish
+      ▼
+DefinitionVersion (immutable)
+      │ start / restart / apply
+      ▼
+SyncExecution
+```
+
+Stage 7 does **not** add a new aggregate or change runtime semantics.
+
+It converts accepted rules into:
+
+```text
+Domain rules
+   ↓
+Static checks + framework-free smoke + regression hook + PR contract
+   ↓
+CI feedback before merge
+```
+
+---
+
+## 2. Four enforcement layers
+
+```text
+Layer A  Static Domain Contract            mandatory
+Layer B  Framework-free Core Domain Smoke mandatory
+Layer C  Maven/JUnit Deep Regression Hook conditional on private dependency token
+Layer D  Pull Request Domain Contract      mandatory for realtime PRs
+```
+
+The important design choice is that **Layer A/B do not depend on Maven, Node, DB, Flink, SSH, or private repositories**.
+
+Therefore domain governance remains executable even when the broader build environment is unavailable.
+
+---
+
+# 3. Layer A — zero-dependency Static Domain Contract
+
+Entry point:
+
+```text
+tools/realtime_domain_guardrails.py
+```
+
+Local command:
+
+```bash
+python3 tools/realtime_domain_guardrails.py
+```
+
+Pull-request workflow command:
+
+```bash
+python3 tools/realtime_domain_guardrails.py --event "$GITHUB_EVENT_PATH"
+```
+
+The script uses Python standard library only.
+
+## 3.1 Core Domain purity
+
+Current executable Core kernel:
+
+```text
+RealtimeJobState.java
+SyncDefinition.java
+RuntimeEnvironmentRef.java
+DefinitionDigest.java
+SyncDefinitionDigestCalculator.java
+DefinitionVersion.java
+SyncExecution.java
+SyncExecutionStateMachine.java
+```
+
+These files may import only:
+
+```text
+java.*
+io.yak.ops.business.sync.realtime.domain.*
+```
+
+The guard rejects Core dependencies on:
+
+```text
+Spring
+Jackson
+MyBatis / MyBatis-Plus
+Controller
+Service
+Repository
+DAO
+Engine / Flink adapter
+persistence frameworks
+```
+
+It also rejects infrastructure identifiers in Core such as:
+
+```text
+pipelineYaml
+flinkHome
+flinkCdcHome
+flinkRestUrl
+sshHost
+sshUser
+identityFile
+jdbcUrl
+password
+```
+
+## 3.2 Scenario/type explosion prevention
+
+Inside realtime Domain, the guard blocks suspicious second-truth names such as:
+
+```text
+Wizard*Spec
+Yaml*Spec
+Flink*Spec
+Mysql*Definition
+Kafka*Definition
+*SceneType*
+*SyncType*
+```
+
+and identifiers:
+
+```text
+sceneType
+syncType
+```
+
+A legitimate new scenario that cannot fit Selector / Route / Target / Policy must first be treated as a Domain Gap.
+
+## 3.3 SyncExecution remains runtime truth
+
+The guard rejects reintroduction of Task runtime ownership.
+
+It checks that DAO/Application code does not again dual-write:
+
+```text
+Task.desiredState
+Task.observedState
+Task.lastError
+```
+
+and that query SQL does not again fallback to:
+
+```text
+d.desired_state
+d.observed_state
+d.last_error
+```
+
+It also blocks the old side paths:
+
+```text
+desiredJobs
+hasOtherDesiredRunning
+markStarting
+```
+
+## 3.4 Immutable version identity
+
+Published-update detection must compare:
+
+```text
+SyncExecution.definitionVersionId
+vs
+RealtimeSyncTask.publishedDefinitionVersionId
+```
+
+The guard rejects using legacy:
+
+```text
+definition_version
+published_version
+```
+
+as immutable DefinitionVersion identity.
+
+## 3.5 Restart and Apply stay separate
+
+Application must expose:
+
+```text
+restartExecution
+applyPublishedVersion
+```
+
+and must not reintroduce a generic Application `restart()`.
+
+Frontend must use:
+
+```text
+restart-execution
+apply-published-version
+```
+
+as separate actions.
+
+The legacy HTTP `/restart` alias may exist only when it delegates to `restartExecution()`.
+
+## 3.6 Start may not read current Draft
+
+The static guard requires the Start path to resolve a Published DefinitionVersion and rejects the old mutable-Draft preparation path.
+
+Protected behavior:
+
+```text
+Published V3 + Draft r4
+Start -> V3
+```
+
+## 3.7 Digest/revision naming
+
+The migrated semantic aliases must remain visible:
+
+```text
+sourceConfigDigest
+draftRevision
+artifactDigest
+```
+
+This prevents future code from collapsing Draft CAS digest, DefinitionDigest and ExecutionArtifactDigest into one ambiguous concept.
+
+---
+
+# 4. Layer B — framework-free Core Domain compile
+
+Stage 7 removes Spring `@Component` from:
+
+```text
+SyncExecutionStateMachine
+```
+
+Spring configuration now owns construction:
+
+```text
+RealtimeSyncConfiguration
+   ↓ @Bean
+SyncExecutionStateMachine
+```
+
+GitHub Actions compiles the Core kernel directly with JDK 21:
+
+```text
+javac --release 21
+```
+
+No Maven/Spring classpath is supplied.
+
+This means a future accidental Core import from Spring/Jackson/adapter code causes a real compile failure, not merely a style warning.
+
+---
+
+# 5. Layer B behavior smoke
+
+Executable:
+
+```text
+tools/realtime-domain-smoke/RealtimeDomainSmoke.java
+```
+
+It verifies framework-free domain behavior:
+
+### SyncDefinition invariants
+
+```text
+ReplayKey duplicate fields -> reject
+SourceRef == SinkRef       -> reject
+valid routes               -> accept
+```
+
+### DefinitionDigest
+
+```text
+route ordering only changes      -> same digest
+ReplayKey ordering only changes  -> same digest
+RuntimeEnvironmentRef changes    -> different digest
+```
+
+### SyncExecution lifecycle
+
+```text
+RUNNING -> blocks second Execution
+UNKNOWN -> blocks second Execution
+STOPPED -> permits next Execution
+STOPPED -> STARTING same Execution -> reject
+FAILED  -> RUNNING same Execution  -> reject
+```
+
+---
+
+# 6. Layer C — Maven/JUnit deep regression hook
+
+The repository already contains deeper tests for:
+
+```text
+architecture boundaries
+DefinitionVersion persistence
+SyncExecution DAO isolation
+Published-vs-Draft execution path
+stop-during-start
+UNKNOWN / CONFLICT
+RestartExecution / ApplyPublishedVersion
+cross-instance replacement races
+```
+
+The GitHub workflow contains a `Backend regression hook` for these tests.
+
+However `yak-ops` depends on:
+
+```text
+io.yak.framework:*:1.0.0-SNAPSHOT
+```
+
+and `weifuwan/yak-framework` is a **private GitHub repository**.
+
+A normal repository-scoped `GITHUB_TOKEN` for `yak-ops` cannot checkout that private sibling repository.
+
+Therefore the deep regression layer is enabled only when repository secret:
+
+```text
+YAK_FRAMEWORK_TOKEN
+```
+
+is configured with read access to `weifuwan/yak-framework`.
+
+## When the secret exists
+
+The workflow performs:
+
+```text
+checkout yak-framework
+install 1.0.0-SNAPSHOT
+build yak-ops realtime reactor dependencies
+run targeted realtime JUnit suite
+```
+
+including:
+
+```text
+RealtimeArchitectureTest
+SyncExecutionStateMachineTest
+SyncDefinitionDigestCalculatorTest
+CdcPipelineSpecCompatibilityMapperTest
+DefinitionVersionRepositoryAdapterTest
+VersioningRealtimeJobStoreTest
+RealtimeJobDaoImplExecutionIsolationTest
+RealtimeJobStoreAdapterExecutionProjectionTest
+RealtimeExecutionPathTest
+RealtimeJobServiceConcurrencyTest
+RealtimeJobLifecycleCoordinatorTest
+RealtimeWave4DefinitionMutationTest
+RealtimeWave5VersionCommandTest
+RealtimeWave5VersionCommandRaceTest
+```
+
+## When the secret does not exist
+
+The Job emits an explicit GitHub Actions notice:
+
+```text
+Backend regression not executed
+```
+
+and skips Maven/JUnit steps.
+
+**A green Backend regression hook without the secret must not be interpreted as “JUnit passed”.**
+
+The mandatory enforcement layers remain:
+
+```text
+Static domain contract
+Framework-free core domain smoke
+PR contract
+```
+
+If the team wants full backend regression to become a mandatory required check, configure `YAK_FRAMEWORK_TOKEN` first and then make the JUnit step required in branch protection.
+
+---
+
+# 7. Layer D — Pull Request Domain Contract
+
+Realtime-related pull requests must contain:
+
+```text
+Domain Impact Analysis
+Domain Gap
+Domain Compliance Report
+```
+
+The workflow receives `$GITHUB_EVENT_PATH`, so the static guard validates the actual PR body.
+
+The workflow also listens to PR `edited` events. A developer can fix the PR description and have the domain contract re-evaluated without pushing a dummy code commit.
+
+Dedicated template:
+
+```text
+.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md
+```
+
+Minimal pre-implementation contract:
+
+```text
+Domain Impact Analysis
+- Bounded context:
+- Aggregate(s):
+- SyncDefinition area:
+- Invariant/lifecycle impact:
+- Layer:
+- Current mapping/gap:
+- Safety properties to preserve:
+- Domain Gap: yes/no
+```
+
+Completion contract:
+
+```text
+Domain Compliance Report
+- Domain rule implemented:
+- Aggregate(s) affected:
+- Invariant/lifecycle changes:
+- Legacy compatibility retained:
+- Safety properties preserved:
+- DB/API migration mode:
+- Tests/guardrails:
+- Known gaps remaining:
+```
+
+---
+
+# 8. GitHub Actions workflow
+
+File:
+
+```text
+.github/workflows/realtime-sync-domain-guardrails.yml
+```
+
+Path scope:
+
+```text
+realtime backend module
+realtime frontend pages
+docs/realtime-sync/domain
+DOMAIN.md / guardrail tools
+realtime PR template
+workflow itself
+```
+
+Mandatory jobs:
+
+```text
+Static domain contract
+Framework-free core domain smoke
+```
+
+Conditional deep job:
+
+```text
+Backend regression hook
+  -> full Maven/JUnit only when YAK_FRAMEWORK_TOKEN exists
+```
+
+This keeps architectural enforcement reliable without pretending the private cross-repository dependency does not exist.
+
+---
+
+# 9. JUnit architecture guard remains valuable
+
+`RealtimeArchitectureTest` is extended to inspect Core Domain root/nested types through reflection.
+
+It checks framework/adapter leakage through:
+
+```text
+annotations
+fields
+record components
+method return types
+method parameter types
+constructor parameter types
+```
+
+When the Maven deep layer is enabled, the same architectural rule is therefore checked in two independent ways:
+
+```text
+source-level Python guard
++
+runtime-reflection JUnit guard
+```
+
+---
+
+# 10. Guardrail modification rule
+
+The guardrail itself is part of the domain contract.
+
+Forbidden shortcut:
+
+```text
+feature fails guard
+  ↓
+disable/remove guard
+  ↓
+merge feature
+```
+
+Correct process:
+
+```text
+guard fails
+  ↓
+implementation bug or Domain Gap?
+  ↓
+fix implementation
+or approve domain change
+  ↓
+update DOMAIN.md + design docs + replacement guard together
+```
+
+A PR weakening a check must explain:
+
+```text
+which accepted domain rule changed
+why the previous check is no longer correct
+which replacement check enforces the new rule
+```
+
+---
+
+# 11. What Stage 7 does not solve
+
+Guardrails protect the accepted model. They do not invent answers for unresolved gaps:
+
+```text
+Audit-safe Archive / Tombstone
+ExecutionPolicy runtime application
+Flink FINISHED normal completion / snapshot-only
+legacy failure-rate mapping
+Compute Environment physical context cleanup
+API v2 / physical schema naming cleanup
+```
+
+These still require independent Domain Impact Analysis.
+
+---
+
+# 12. Local workflow
+
+Fast deterministic check:
+
+```bash
+python3 tools/realtime_domain_guardrails.py
+```
+
+Framework-free Core compile/smoke:
+
+```bash
+CORE=yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain
+OUT=.tmp/realtime-domain-core
+rm -rf "$OUT" && mkdir -p "$OUT"
+
+javac --release 21 -d "$OUT" \
+  "$CORE/RealtimeJobState.java" \
+  "$CORE/SyncDefinition.java" \
+  "$CORE/RuntimeEnvironmentRef.java" \
+  "$CORE/DefinitionDigest.java" \
+  "$CORE/SyncDefinitionDigestCalculator.java" \
+  "$CORE/DefinitionVersion.java" \
+  "$CORE/SyncExecution.java" \
+  "$CORE/SyncExecutionStateMachine.java" \
+  tools/realtime-domain-smoke/RealtimeDomainSmoke.java
+
+java -cp "$OUT" RealtimeDomainSmoke
+```
+
+Full targeted Maven/JUnit requires local access to the private `yak-framework` SNAPSHOT dependency or the configured CI token.
+
+---
+
+# 13. Stage 7 acceptance
+
+Stage 7 is considered implemented when:
+
+```text
+[x] Core StateMachine is framework-free
+[x] Spring config owns StateMachine bean creation
+[x] zero-dependency static domain guard exists
+[x] framework-free javac + smoke exists
+[x] JUnit architecture guard checks Core purity
+[x] realtime PR body contract is machine checked
+[x] path-scoped GitHub Actions workflow exists
+[x] PR edited event rechecks the contract
+[x] private-framework Maven regression has an explicit opt-in hook
+[x] DOMAIN.md documents automated enforcement
+[x] domain README points to Stage 7
+```
+
+End-state development loop:
+
+```text
+AI / developer change
+      ↓
+DOMAIN.md
+      ↓
+Domain Impact Analysis
+      ↓
+implementation
+      ↓
+Static Guard + Core Smoke
+      ↓
+optional deep Maven/JUnit when private dependency access exists
+      ↓
+Domain Compliance Report
+      ↓
+review
+```
+
+The Realtime Sync domain is now documented, implemented, and protected by executable checks rather than reviewer memory alone.

--- a/docs/realtime-sync/domain/README.md
+++ b/docs/realtime-sync/domain/README.md
@@ -1,15 +1,8 @@
 # Realtime Sync Domain Design
 
-> 目标：为 Yak Ops 实时同步建立稳定、可演进、可约束 AI 的领域内核。
+> 目标：为 Yak Ops 实时同步建立稳定、可演进、可约束 AI 的领域内核，并用自动化检查抵抗架构漂移。
 
-这组文档描述的是 **Realtime Sync Domain**，不是 Flink CDC 使用手册，也不是前端页面说明。
-
-任何实时同步需求进入代码前，都应先判断它属于：
-
-- Domain：实时同步业务概念与规则；
-- Application：用例编排、发布、启动、停止、重启、版本切换；
-- Infrastructure：Flink、CDC Connector、SSH、REST、YAML 编译、数据库持久化；
-- Interface/UI：Controller、DTO、Wizard、YAML Editor 等交互适配。
+这组文档描述 **Realtime Sync Domain**，不是 Flink CDC 使用手册，也不是前端页面说明。
 
 ## 阶段路线
 
@@ -18,25 +11,25 @@
 | 1 | [领域边界与统一语言](./01-domain-boundary-and-language.md) | 定义实时同步负责什么、绝不负责什么，以及统一术语 |
 | 2 | [核心领域模型 v1](./02-core-domain-model.md) | 确定聚合根、Entity、Value Object 和核心对象关系 |
 | 3 | [领域不变量与生命周期](./03-invariants-and-lifecycle.md) | 固定 Draft / Publish / Execution 不变量、状态机、并发和快照规则 |
-| 4 | [现有代码到领域模型 Mapping](./04-current-code-mapping.md) | 迁移前/迁移中的代码 Mapping、Gap 与施工顺序 |
-| 5 | [AI 领域开发宪法](./05-ai-domain-rules.md) | 把阶段 1～4 转换成 AI 强制执行规则 |
+| 4 | [现有代码到领域模型 Mapping](./04-current-code-mapping.md) | 记录迁移前/迁移中的 Mapping、Gap 与施工顺序 |
+| 5 | [AI 领域开发宪法](./05-ai-domain-rules.md) | 把领域设计转换成 AI 强制执行规则 |
 | 6 | [Stage 6 Migration Completion](./06-stage6-migration-completion.md) | 记录 Wave 0～6 完成后的当前实现事实、兼容边界和剩余 Gap |
-| 7 | 待补充 | 自动化领域护栏扩展 |
+| 7 | [自动化领域护栏](./07-automated-domain-guardrails.md) | 将领域规则转成 Static Guard / Core Smoke / PR Contract，以及可选 private-framework JUnit Hook |
 
-模块级最高优先级硬规则入口：
+模块级最高优先级规则入口：
 
 ```text
 yak-ops-business/yak-ops-business-sync/
 yak-ops-business-sync-realtime/DOMAIN.md
 ```
 
-任何 AI / Codex / 开发者修改 realtime-sync 代码前，都必须先读 `DOMAIN.md`。
+任何 AI / Codex / 开发者修改 realtime-sync 前都应先读 `DOMAIN.md`。
 
 ---
 
 ## 当前领域模型
 
-Realtime Sync Core Domain 使用三个聚合根：
+Realtime Sync 使用三个聚合根：
 
 ```text
 RealtimeSyncTask
@@ -44,7 +37,7 @@ DefinitionVersion
 SyncExecution
 ```
 
-`SyncDefinition` 是唯一配置事实模型：
+唯一配置事实模型：
 
 ```text
 SyncDefinition
@@ -65,25 +58,23 @@ DefinitionVersion (immutable)
 SyncExecution
 ```
 
-核心原则：
+固定原则：
 
 - `Task ≠ Definition ≠ Version ≠ Execution`；
 - Draft 可以在旧 Execution 运行时继续编辑/发布；
-- Start 只读取不可变 Published DefinitionVersion；
+- Start 只读取 immutable Published DefinitionVersion；
 - RestartExecution 固定旧 Execution 的 VersionRef；
-- ApplyPublishedVersion 显式使用命令开始时捕获的 Published Ref；
+- ApplyPublishedVersion 使用命令开始时捕获的 Published Ref；
 - 每次 Start/Restart/Apply 都创建新的 SyncExecution；
 - 单个 Execution 的 `STOPPED / FAILED` 是终态；
 - `UNKNOWN / CONFLICT` 禁止自动创建第二个运行实例；
 - Runtime Environment：Definition 存 Ref，Execution 存 Snapshot；
-- Flink / YAML / SSH / JDBC credentials / adapter-private tuning 不进入 Core Domain；
+- Flink / YAML / SSH / JDBC credential / adapter-private tuning 不进入 Core Domain；
 - 新场景优先扩 Selector / Route / Target / Policy，不优先增加 sceneType/syncType。
 
 ---
 
 ## Stage 6 当前实现事实
-
-Stage 6 已按既定顺序完成：
 
 ```text
 Wave 0  Core VO + compatibility mapper                         ✅
@@ -116,47 +107,92 @@ Runtime state    -> SyncExecution only
 Version identity -> immutable DefinitionVersionId only
 ```
 
-### Task runtime legacy columns
+Task 表的 `desired_state / observed_state / last_error` 即使物理存在，也只是 inert compatibility storage：Application 不写、Runtime command 不读、Read Model 不 fallback。
 
-物理表仍可能存在：
+兼容名如 `job_definition / job_deployment / definition_version / published_version / config_digest / status / latestDeployment / HTTP /restart` 可以暂时存在，但不能反向决定领域语义。
 
-```text
-desired_state
-observed_state
-last_error
-```
+阶段 4 文档中的“当前实现事实”是历史迁移快照；Stage 6 后的当前事实以 [06-stage6-migration-completion.md](./06-stage6-migration-completion.md) 和 `DOMAIN.md` 为准。
 
-但 Wave 6 后它们是 inert compatibility storage：
+---
 
-- Application 不写；
-- Runtime command 不读；
-- Read model 不 fallback；
-- 无 Execution 的 Task 派生为 STOPPED / STOPPED / null。
+## Stage 7 自动化护栏
 
-### Legacy names still physically/API-visible
+Stage 7 已把关键规则转成机器检查。
 
-为了兼容，以下名字可以暂时存在：
+### 强制层 A：Static Domain Contract
 
 ```text
-yak_realtime_job_definition
-yak_realtime_job_deployment
-definition_version
-published_version
-config_digest
-status
-latestDeployment
-HTTP /restart alias
+tools/realtime_domain_guardrails.py
 ```
 
-它们不再决定领域语义。
+检查：
 
-当前 Mapping 以 [Stage 6 Migration Completion](./06-stage6-migration-completion.md) 为准；阶段 4 文档中的“当前实现事实”是当时的**历史迁移快照**，不能覆盖 Stage 6 后的新事实。
+```text
+Core Domain dependency purity
+second Spec / syncType / sceneType anti-pattern
+Task runtime truth 回流
+immutable VersionId identity
+RestartExecution / ApplyPublishedVersion 分离
+Start-by-Published
+Digest semantic aliases
+Realtime PR body contract
+```
+
+本地最快命令：
+
+```bash
+python3 tools/realtime_domain_guardrails.py
+```
+
+### 强制层 B：Framework-free Core Smoke
+
+GitHub Actions 使用 JDK 21、无 Spring/Maven classpath 直接编译 Core Domain，并运行：
+
+```text
+tools/realtime-domain-smoke/RealtimeDomainSmoke.java
+```
+
+覆盖 Definition invariant、semantic digest 和 Execution terminal/active 规则。
+
+### 强制层 C：PR Contract
+
+Realtime PR 必须包含：
+
+```text
+Domain Impact Analysis
+Domain Gap
+Domain Compliance Report
+```
+
+PR description 编辑后也会重新触发检查。
+
+### 条件层：Backend Maven/JUnit Regression Hook
+
+深层 JUnit 依赖私有：
+
+```text
+weifuwan/yak-framework
+```
+
+普通 yak-ops `GITHUB_TOKEN` 无法读取该 sibling private repo。
+
+因此完整 Maven/JUnit 回归只有在仓库配置：
+
+```text
+YAK_FRAMEWORK_TOKEN
+```
+
+并具有 yak-framework read 权限时才执行。
+
+没有 secret 时 workflow 会明确发 Notice 并 skip Maven/JUnit；**绿色 Backend regression hook 不代表 JUnit 已通过**。
+
+详细设计见 [07-automated-domain-guardrails.md](./07-automated-domain-guardrails.md)。
 
 ---
 
 ## 仍然存在的独立 Gap
 
-Stage 6 完成不代表所有技术债清零。以下问题必须单独评审：
+Stage 6/7 完成不代表所有技术债清零：
 
 ```text
 Audit-safe Archive/Tombstone delete
@@ -168,24 +204,25 @@ Compute Environment physical context/package cleanup
 API v2 / physical schema naming cleanup
 ```
 
-这些问题不能以“cleanup”名义偷偷进入普通功能 PR。
+这些问题必须单独做 Domain Impact Analysis，不能以“cleanup”名义混入普通功能 PR，也不能先关闭 guardrail 绕过领域讨论。
 
 ---
 
-## AI 使用顺序
-
-以后修改 realtime-sync：
+## AI / 开发执行顺序
 
 ```text
 1. 读 DOMAIN.md
-2. 做 Domain Impact Analysis
-3. 查 06-stage6-migration-completion.md 当前事实
-4. 需要设计依据时再查 01～05 文档
-5. 对照测试与现有 Adapter
-6. 实现前确认没有 Domain Gap
+2. 输出 Domain Impact Analysis
+3. 查 Stage 6 当前事实
+4. 需要设计依据时查 01～05
+5. 实现代码
+6. 运行 Static Domain Guard
+7. 等待 Mandatory Stage 7 CI
+8. 有 private framework token 的环境再跑完整 Maven/JUnit regression
+9. 输出 Domain Compliance Report
 ```
 
-如果一个新需求无法映射到三个聚合、`SyncDefinition` 子模型、现有生命周期或明确的邻接上下文：
+如果需求无法映射到三个聚合、`SyncDefinition` 子模型、现有生命周期或明确邻接上下文：
 
 ```text
 Domain Gap = yes

--- a/tools/realtime-domain-smoke/RealtimeDomainSmoke.java
+++ b/tools/realtime-domain-smoke/RealtimeDomainSmoke.java
@@ -1,0 +1,179 @@
+import io.yak.ops.business.sync.realtime.domain.DefinitionDigest;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+import io.yak.ops.business.sync.realtime.domain.RuntimeEnvironmentRef;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.CheckpointPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ExactTableSelector;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ExecutionPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.NoRestart;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.ReplayKey;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SchemaEvolutionPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SinkEndpoint;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SinkWritePolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SourceEndpoint;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.StartupPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SyncPolicy;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.SyncRoute;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition.TableTarget;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinitionDigestCalculator;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution.EngineExecutionRef;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import java.util.List;
+
+/** Framework-free executable smoke test for the Realtime Sync core domain. */
+public final class RealtimeDomainSmoke {
+
+  private RealtimeDomainSmoke() {}
+
+  public static void main(String[] args) {
+    definitionInvariantsStayStrict();
+    definitionDigestStaysSemantic();
+    executionLifecycleStaysOneRunPerExecution();
+    System.out.println("Realtime Domain Smoke: OK");
+  }
+
+  private static void definitionInvariantsStayStrict() {
+    SyncDefinition valid = definition(routesInOrder());
+    check(valid.routes().size() == 2, "valid SyncDefinition should keep both routes");
+
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> new ReplayKey(List.of("id", "id")),
+        "ReplayKey must reject duplicate fields");
+
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            new SyncDefinition(
+                new SourceEndpoint(1L),
+                new SinkEndpoint(1L),
+                routesInOrder(),
+                policy(),
+                executionPolicy()),
+        "Source and Sink must not use the same DataSourceRef");
+  }
+
+  private static void definitionDigestStaysSemantic() {
+    SyncDefinition first = definition(routesInOrder());
+    SyncDefinition reordered =
+        definition(
+            List.of(
+                new SyncRoute(
+                    new ExactTableSelector("customers"),
+                    new TableTarget("ods_customers"),
+                    new ReplayKey(List.of("id"))),
+                new SyncRoute(
+                    new ExactTableSelector("orders"),
+                    new TableTarget("ods_orders"),
+                    new ReplayKey(List.of("id", "tenant_id")))));
+
+    DefinitionDigest firstDigest =
+        SyncDefinitionDigestCalculator.calculate(first, new RuntimeEnvironmentRef(3L));
+    DefinitionDigest reorderedDigest =
+        SyncDefinitionDigestCalculator.calculate(reordered, new RuntimeEnvironmentRef(3L));
+    DefinitionDigest otherEnvironmentDigest =
+        SyncDefinitionDigestCalculator.calculate(first, new RuntimeEnvironmentRef(4L));
+
+    check(
+        firstDigest.equals(reorderedDigest),
+        "route/replay-key ordering without business semantics must not change DefinitionDigest");
+    check(
+        !firstDigest.equals(otherEnvironmentDigest),
+        "RuntimeEnvironmentRef is part of DefinitionVersion semantics and must change digest");
+  }
+
+  private static void executionLifecycleStaysOneRunPerExecution() {
+    SyncExecutionStateMachine stateMachine = new SyncExecutionStateMachine();
+
+    SyncExecution running =
+        execution(101L, DesiredState.RUNNING, ObservedState.RUNNING, "flink-job-101");
+    expectThrows(
+        IllegalStateException.class,
+        () -> stateMachine.requireNewExecutionAllowed(running),
+        "active execution must block a second execution");
+
+    SyncExecution unknown =
+        execution(102L, DesiredState.RUNNING, ObservedState.UNKNOWN, null);
+    expectThrows(
+        IllegalStateException.class,
+        () -> stateMachine.requireNewExecutionAllowed(unknown),
+        "UNKNOWN is active/uncertain and must block a second execution");
+
+    SyncExecution stopped =
+        execution(103L, DesiredState.STOPPED, ObservedState.STOPPED, "flink-job-103");
+    stateMachine.requireNewExecutionAllowed(stopped);
+
+    expectThrows(
+        IllegalStateException.class,
+        () -> stateMachine.requireTransition(ObservedState.STOPPED, ObservedState.STARTING),
+        "STOPPED execution must be terminal");
+    expectThrows(
+        IllegalStateException.class,
+        () -> stateMachine.requireTransition(ObservedState.FAILED, ObservedState.RUNNING),
+        "FAILED execution must be terminal");
+  }
+
+  private static SyncExecution execution(
+      long id, DesiredState desired, ObservedState observed, String externalExecutionId) {
+    return new SyncExecution(
+        id,
+        7L,
+        31L,
+        desired,
+        observed,
+        new EngineExecutionRef("FLINK_CDC", externalExecutionId),
+        observed == ObservedState.UNKNOWN,
+        null);
+  }
+
+  private static SyncDefinition definition(List<SyncRoute> routes) {
+    return new SyncDefinition(
+        new SourceEndpoint(11L),
+        new SinkEndpoint(22L),
+        routes,
+        policy(),
+        executionPolicy());
+  }
+
+  private static List<SyncRoute> routesInOrder() {
+    return List.of(
+        new SyncRoute(
+            new ExactTableSelector("orders"),
+            new TableTarget("ods_orders"),
+            new ReplayKey(List.of("tenant_id", "id"))),
+        new SyncRoute(
+            new ExactTableSelector("customers"),
+            new TableTarget("ods_customers"),
+            new ReplayKey(List.of("id"))));
+  }
+
+  private static SyncPolicy policy() {
+    return new SyncPolicy(StartupPolicy.INITIAL_AND_CONTINUOUS, SchemaEvolutionPolicy.EVOLVE);
+  }
+
+  private static ExecutionPolicy executionPolicy() {
+    return new ExecutionPolicy(
+        1,
+        new CheckpointPolicy(60_000L),
+        new NoRestart(),
+        new SinkWritePolicy(3, 1_000, 2_000L, 16_777_216L));
+  }
+
+  private static void check(boolean condition, String message) {
+    if (!condition) throw new AssertionError(message);
+  }
+
+  private static void expectThrows(
+      Class<? extends Throwable> expected, Runnable operation, String message) {
+    try {
+      operation.run();
+    } catch (Throwable actual) {
+      if (expected.isInstance(actual)) return;
+      throw new AssertionError(
+          message + "; expected " + expected.getSimpleName() + " but got " + actual, actual);
+    }
+    throw new AssertionError(message + "; expected " + expected.getSimpleName());
+  }
+}

--- a/tools/realtime_domain_guardrails.py
+++ b/tools/realtime_domain_guardrails.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Automated guardrails for the Realtime Sync domain.
+
+The script intentionally uses only Python's standard library so it can run:
+- locally without Maven/Node dependencies;
+- in GitHub Actions before any project dependency resolution.
+
+It enforces stable architectural facts established by Realtime Sync DOMAIN.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / "yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime"
+JAVA_ROOT = MODULE / "src/main/java/io/yak/ops/business/sync/realtime"
+DOMAIN_DIR = JAVA_ROOT / "domain"
+
+CORE_DOMAIN_FILES = (
+    "RealtimeJobState.java",
+    "SyncDefinition.java",
+    "RuntimeEnvironmentRef.java",
+    "DefinitionDigest.java",
+    "SyncDefinitionDigestCalculator.java",
+    "DefinitionVersion.java",
+    "SyncExecution.java",
+    "SyncExecutionStateMachine.java",
+)
+
+FORBIDDEN_CORE_IMPORT_PREFIXES = (
+    "org.springframework.",
+    "com.fasterxml.jackson.",
+    "com.baomidou.",
+    "org.mybatis.",
+    "jakarta.persistence.",
+    "io.yak.ops.business.sync.realtime.controller.",
+    "io.yak.ops.business.sync.realtime.service.",
+    "io.yak.ops.business.sync.realtime.repository.",
+    "io.yak.ops.business.sync.realtime.dao.",
+    "io.yak.ops.business.sync.realtime.engine.",
+)
+
+FORBIDDEN_CORE_IDENTIFIERS = (
+    "pipelineYaml",
+    "flinkHome",
+    "flinkCdcHome",
+    "flinkRestUrl",
+    "sshHost",
+    "sshUser",
+    "identityFile",
+    "jdbcUrl",
+    "password",
+    "sceneType",
+    "syncType",
+)
+
+FORBIDDEN_DOMAIN_FILENAME_PATTERNS = (
+    re.compile(r"^(Wizard|Yaml|Flink|Mysql|Postgres|Kafka).*(Spec|Definition|Task)\.java$", re.I),
+    re.compile(r".*(SceneType|SyncType).*\.java$", re.I),
+)
+
+
+class Guardrails:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.checks = 0
+
+    def check(self, condition: bool, message: str) -> None:
+        self.checks += 1
+        if not condition:
+            self.errors.append(message)
+
+    def require_file(self, path: Path) -> str:
+        self.check(path.exists(), f"Missing required file: {path.relative_to(ROOT)}")
+        if not path.exists():
+            return ""
+        return path.read_text(encoding="utf-8")
+
+    def report(self) -> int:
+        if self.errors:
+            print("Realtime Sync Domain Guardrails: FAILED")
+            for index, error in enumerate(self.errors, start=1):
+                print(f"{index}. {error}")
+            print(f"\n{len(self.errors)} failure(s), {self.checks} checks executed.")
+            return 1
+        print(f"Realtime Sync Domain Guardrails: OK ({self.checks} checks)")
+        return 0
+
+
+def java_code_without_comments_and_strings(text: str) -> str:
+    # Imports are checked separately. Identifier checks only need comments and strings removed.
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
+    text = re.sub(r"//[^\n]*", " ", text)
+    text = re.sub(r'"(?:\\.|[^"\\])*"', '""', text)
+    text = re.sub(r"'(?:\\.|[^'\\])*'", "''", text)
+    return text
+
+
+def check_core_domain_purity(g: Guardrails) -> None:
+    for filename in CORE_DOMAIN_FILES:
+        path = DOMAIN_DIR / filename
+        text = g.require_file(path)
+        if not text:
+            continue
+
+        imports = re.findall(r"(?m)^\s*import\s+(?:static\s+)?([^;]+);", text)
+        for imported in imports:
+            g.check(
+                imported.startswith("java.")
+                or imported.startswith("io.yak.ops.business.sync.realtime.domain."),
+                f"{filename}: Core Domain import is not JDK/domain-local: {imported}",
+            )
+            g.check(
+                not imported.startswith(FORBIDDEN_CORE_IMPORT_PREFIXES),
+                f"{filename}: forbidden framework/adapter import: {imported}",
+            )
+
+        code = java_code_without_comments_and_strings(text)
+        for identifier in FORBIDDEN_CORE_IDENTIFIERS:
+            g.check(
+                re.search(rf"\b{re.escape(identifier)}\b", code) is None,
+                f"{filename}: forbidden Core Domain identifier: {identifier}",
+            )
+
+
+def check_domain_naming(g: Guardrails) -> None:
+    if not DOMAIN_DIR.exists():
+        g.check(False, f"Missing domain directory: {DOMAIN_DIR.relative_to(ROOT)}")
+        return
+
+    for path in DOMAIN_DIR.glob("*.java"):
+        for pattern in FORBIDDEN_DOMAIN_FILENAME_PATTERNS:
+            g.check(
+                pattern.match(path.name) is None,
+                f"Domain anti-pattern filename requires domain review: {path.name}",
+            )
+
+        code = java_code_without_comments_and_strings(path.read_text(encoding="utf-8"))
+        for identifier in ("sceneType", "syncType"):
+            g.check(
+                re.search(rf"\b{identifier}\b", code) is None,
+                f"{path.name}: scene/sync type discriminator is forbidden without domain review: {identifier}",
+            )
+
+
+def check_execution_is_runtime_truth(g: Guardrails) -> None:
+    dao_path = JAVA_ROOT / "dao/impl/RealtimeJobDaoImpl.java"
+    query_path = MODULE / "src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml"
+    store_path = JAVA_ROOT / "repository/RealtimeJobStore.java"
+
+    dao = g.require_file(dao_path)
+    query = g.require_file(query_path)
+    store = g.require_file(store_path)
+
+    for token in (
+        "RealtimeJobDefinitionPO::getDesiredState",
+        "RealtimeJobDefinitionPO::getObservedState",
+        "RealtimeJobDefinitionPO::getLastError",
+    ):
+        g.check(token not in dao, f"Task runtime dual-write reintroduced in DAO: {token}")
+
+    for token in ("d.desired_state", "d.observed_state", "d.last_error"):
+        g.check(token not in query, f"Task runtime fallback reintroduced in query model: {token}")
+
+    for method in ("desiredJobs", "hasOtherDesiredRunning", "markStarting"):
+        g.check(
+            re.search(rf"\b{method}\s*\(", store) is None,
+            f"Legacy Task runtime side-path reintroduced in RealtimeJobStore: {method}",
+        )
+
+    g.check(
+        "p.definition_version_id" in query and "d.published_definition_version_id" in query,
+        "publishedUpdateAvailable must compare immutable DefinitionVersion IDs",
+    )
+    g.check(
+        not re.search(
+            r"p\.definition_version\s*(?:!=|<>|&lt;&gt;)\s*d\.published_version", query
+        ),
+        "Legacy DraftRevision comparison must not be used as version identity",
+    )
+
+
+def check_execution_commands(g: Guardrails) -> None:
+    service_path = JAVA_ROOT / "service/RealtimeJobService.java"
+    controller_path = JAVA_ROOT / "controller/v1/RealtimeJobController.java"
+    frontend_api_path = ROOT / "yak-ops-ui/src/pages/realtime-sync/api.ts"
+
+    service = g.require_file(service_path)
+    controller = g.require_file(controller_path)
+    frontend = g.require_file(frontend_api_path)
+
+    g.check(
+        re.search(r"\brestartExecution\s*\(", service) is not None,
+        "RealtimeJobService must expose RestartExecution semantics",
+    )
+    g.check(
+        re.search(r"\bapplyPublishedVersion\s*\(", service) is not None,
+        "RealtimeJobService must expose ApplyPublishedVersion semantics",
+    )
+    g.check(
+        re.search(r"\bpublic\s+[^\n{;]+\brestart\s*\(", service) is None,
+        "Generic Application restart() must not be reintroduced",
+    )
+    g.check(
+        "service.restart(" not in controller,
+        "Controller compatibility endpoint must never delegate to generic restart()",
+    )
+    if '@PostMapping("/{id}/restart")' in controller:
+        g.check(
+            "service.restartExecution(id, key)" in controller,
+            "Legacy HTTP /restart endpoint must delegate to restartExecution()",
+        )
+
+    g.check(
+        re.search(r"\|\s*'restart'\s*;", frontend) is None
+        and re.search(r"\|\s*'restart'\s*\n", frontend) is None,
+        "Frontend RealtimeAction must not reintroduce generic 'restart'",
+    )
+    g.check(
+        "'restart-execution'" in frontend and "'apply-published-version'" in frontend,
+        "Frontend must keep restart-execution and apply-published-version as separate actions",
+    )
+
+    g.check(
+        "requirePublishedDefinition(id)" in service,
+        "Start path must resolve an immutable PublishedDefinitionRef",
+    )
+    g.check(
+        "prepare(id, true)" not in service,
+        "Start must not fall back to preparing the mutable current Draft",
+    )
+
+
+def check_digest_semantics(g: Guardrails) -> None:
+    store = g.require_file(JAVA_ROOT / "repository/RealtimeJobStore.java")
+    view = g.require_file(DOMAIN_DIR / "RealtimeJobView.java")
+
+    for symbol in ("sourceConfigDigest()", "artifactDigest()", "draftRevision()"):
+        g.check(
+            symbol in store or symbol in view,
+            f"Expected explicit digest/revision semantic alias is missing: {symbol}",
+        )
+
+
+def check_required_domain_docs(g: Guardrails) -> None:
+    domain_contract = MODULE / "DOMAIN.md"
+    stage6 = ROOT / "docs/realtime-sync/domain/06-stage6-migration-completion.md"
+    stage7 = ROOT / "docs/realtime-sync/domain/07-automated-domain-guardrails.md"
+
+    contract = g.require_file(domain_contract)
+    g.require_file(stage6)
+    g.require_file(stage7)
+
+    for phrase in (
+        "RealtimeSyncTask",
+        "DefinitionVersion",
+        "SyncExecution",
+        "Domain Impact Analysis",
+        "Domain Compliance Report",
+    ):
+        g.check(phrase in contract, f"DOMAIN.md lost mandatory contract phrase: {phrase}")
+
+
+def check_pr_body(g: Guardrails, event_path: Path | None) -> None:
+    if event_path is None:
+        return
+    if not event_path.exists():
+        g.check(False, f"GitHub event file does not exist: {event_path}")
+        return
+
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    pull_request = event.get("pull_request")
+    if not pull_request:
+        return
+
+    body = pull_request.get("body") or ""
+    for required in ("Domain Impact Analysis", "Domain Compliance Report", "Domain Gap"):
+        g.check(
+            required.lower() in body.lower(),
+            f"Realtime-sync PR body must contain '{required}'",
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--event",
+        type=Path,
+        help="Optional GitHub event JSON. Pull requests are checked for the domain review contract.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    g = Guardrails()
+    check_core_domain_purity(g)
+    check_domain_naming(g)
+    check_execution_is_runtime_truth(g)
+    check_execution_commands(g)
+    check_digest_semantics(g)
+    check_required_domain_docs(g)
+    check_pr_body(g, args.event)
+    return g.report()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
@@ -1,49 +1,44 @@
 # Realtime Sync Domain Guardrails
 
-> Scope: `yak-ops-business-sync-realtime` and any change that creates, publishes, executes, observes, serializes, or persists realtime sync tasks.
+> Scope: `yak-ops-business-sync-realtime` and every change that creates, edits, publishes, executes, observes, serializes, or persists realtime-sync tasks.
 >
-> This file is the **module-level mandatory domain contract**. Before changing realtime-sync code, read this file and `docs/realtime-sync/domain/`.
+> This file is the **module-level mandatory domain contract**. Detailed design/history lives under `docs/realtime-sync/domain/`.
+
+---
 
 ## 0. Mandatory Domain Impact Analysis
 
 **Do not start coding before performing a Domain Impact Analysis.**
 
-Every realtime-sync change MUST first answer:
+Every realtime-sync change MUST answer:
 
 ```text
-1. Which bounded context owns this requirement?
-2. Which aggregate is changed?
-   - RealtimeSyncTask
-   - DefinitionVersion
-   - SyncExecution
-   - adjacent context / none
-3. If SyncDefinition changes, which part changes?
-   - Endpoint
-   - Route / Selector / Target / ReplayKey
-   - SyncPolicy
-   - ExecutionPolicy
-4. Which invariant or lifecycle transition changes?
-5. Is the change Domain, Application, Infrastructure, or Interface/UI?
-6. Does it create another editable definition source of truth?
-7. Does it introduce a new syncType / sceneType / task subclass?
-8. Does it leak Flink/YAML/SSH/JDBC credentials or adapter tuning into Core Domain?
-9. Which accepted migration/current implementation boundary is affected?
-10. Which safety properties must remain protected?
+Domain Impact Analysis
+- Bounded context:
+- Aggregate(s): RealtimeSyncTask / DefinitionVersion / SyncExecution / adjacent context
+- SyncDefinition area: Endpoint / Route / Selector / Target / ReplayKey / SyncPolicy / ExecutionPolicy / none
+- Invariant/lifecycle impact:
+- Layer: Domain / Application / Infrastructure / Interface
+- Current mapping/gap:
+- Safety properties to preserve:
+- Domain Gap: yes/no
 ```
 
-If items 2–4 cannot be answered, mark:
+If the requirement cannot be mapped to the accepted aggregates, `SyncDefinition` sub-model, lifecycle, or an explicit adjacent context:
 
 ```text
-Domain Gap
+Domain Gap: yes
 ```
 
-**STOP. Extend/review the domain model before implementation. Do not add a temporary field, enum, `*Spec`, `*Task`, or `*Service` to bypass the gap.**
+**STOP. Review/extend the domain model before implementation.**
+
+Do not bypass a Domain Gap with a temporary field, boolean, enum, `syncType`, `sceneType`, `*Spec`, `*Task`, or `*Service`.
 
 ---
 
-# 1. Core model: do not leave this coordinate system
+# 1. Core coordinate system
 
-Realtime Sync Core Domain has three aggregate roots:
+Realtime Sync has three aggregate roots:
 
 ```text
 RealtimeSyncTask
@@ -51,18 +46,21 @@ DefinitionVersion
 SyncExecution
 ```
 
-The canonical sync configuration is the immutable value object:
+Canonical configuration:
 
 ```text
 SyncDefinition
 ├── SourceEndpoint
 ├── SinkEndpoint
 ├── SyncRoute[]
+│   ├── SourceSelector
+│   ├── SinkTarget
+│   └── ReplayKey
 ├── SyncPolicy
 └── ExecutionPolicy
 ```
 
-Lifecycle coordinate:
+Lifecycle:
 
 ```text
 RealtimeSyncTask.currentDraft
@@ -77,7 +75,7 @@ SyncExecution
 Meanings MUST remain separate:
 
 ```text
-RealtimeSyncTask  = long-lived task identity + current Draft + PublishedDefinitionRef
+RealtimeSyncTask  = long-lived identity + current Draft + PublishedDefinitionRef
 SyncDefinition    = what/how to synchronize
 DefinitionVersion = immutable published fact
 SyncExecution     = one actual run of one immutable published version
@@ -85,13 +83,11 @@ SyncExecution     = one actual run of one immutable published version
 
 **Task ≠ Definition ≠ Version ≠ Execution.**
 
-Do not collapse them back into one giant `RealtimeJob` model.
-
 ---
 
 # 2. One definition truth only
 
-`SyncDefinition` is the single domain source of truth for realtime sync configuration.
+`SyncDefinition` is the single domain source of truth.
 
 These are adapters/projections only:
 
@@ -99,11 +95,11 @@ These are adapters/projections only:
 Wizard
 Yak Realtime YAML
 HTTP DTO / VO
-DB JSON representation
+DB JSON compatibility representation
 Flink CDC Pipeline YAML
 ```
 
-MUST NOT create editable domain truths such as:
+MUST NOT create a second editable truth such as:
 
 ```text
 WizardSpec
@@ -114,71 +110,59 @@ PostgresSyncSpec
 KafkaSyncDefinition
 ```
 
-A serializer/editor may have a document DTO, but it MUST map to/from `SyncDefinition` and MUST NOT become a second business definition.
-
-Flink Pipeline YAML is a transient compiled artifact. It MUST NOT become persisted domain truth.
+Flink Pipeline YAML remains a transient compiled artifact.
 
 ---
 
 # 3. Version rules
 
-A published version is an immutable domain fact.
-
-MUST:
+A Published DefinitionVersion is immutable.
 
 ```text
 Publish -> create/reuse immutable DefinitionVersion
-DefinitionVersion -> immutable after creation
 Execution -> reference explicit DefinitionVersionId
 ```
 
 MUST NOT:
 
 ```text
-publish by only toggling a marker on mutable Draft content
-modify a Published DefinitionVersion in place
-make an Execution read the latest mutable Draft
+publish by only toggling a mutable Draft marker
+modify Published Version in place
+make an Execution read current Draft
 replace historical Published content with current Draft
 ```
 
-Legacy warning:
+Authoritative identity:
 
 ```text
-definition_version = DraftRevision compatibility field
-published_version  = published DraftRevision compatibility marker
+Task.publishedDefinitionVersionId
+SyncExecution.definitionVersionId
 ```
 
-They are **not** immutable DefinitionVersion identity.
-
-Authoritative identity is:
+Legacy compatibility only:
 
 ```text
-published_definition_version_id
-execution.definition_version_id
+definition_version = DraftRevision
+published_version  = published DraftRevision marker
 ```
 
-If historical Published content cannot be reconstructed reliably, do not guess and do not use the current Draft as a substitute.
+Do not use those legacy integers as immutable version identity.
 
 ---
 
-# 4. Draft, Published, and active Execution may coexist
+# 4. Draft, Published and active Execution may coexist
 
-This is valid and expected:
-
-```text
-Published V3
-+
-Draft r4 candidate
-+
-Execution E100(V3)
-```
-
-Active/uncertain SyncExecution MUST NOT block:
+Valid state:
 
 ```text
-Save newer Draft
-Publish newer DefinitionVersion
+Execution E100(V3) RUNNING
++
+Draft r4
++
+Published V4
 ```
+
+Active/uncertain Execution MUST NOT block Save Draft or Publish.
 
 Save/Publish MUST NOT mutate the active Execution's:
 
@@ -190,25 +174,19 @@ ObservedState
 EngineExecutionRef
 ```
 
-Publishing while an Execution is active only advances `RealtimeSyncTask.publishedDefinitionRef`.
-
-Delete remains lifecycle-guarded. Definition/Execution independence does not make active-runtime deletion safe.
+Publish is **not** hot reload.
 
 ---
 
-# 5. Execution rules
+# 5. SyncExecution owns runtime lifecycle
 
-Every actual run is a new `SyncExecution`.
-
-MUST:
+Every actual run is a new Execution:
 
 ```text
-Start -> new Execution
-RestartExecution -> new Execution pinned to the same DefinitionVersion
-ApplyPublishedVersion -> new Execution pinned to the explicitly captured Published version
+Start                 -> new Execution
+RestartExecution      -> new Execution, same DefinitionVersion
+ApplyPublishedVersion -> new Execution, captured Published DefinitionVersion
 ```
-
-MUST NOT resurrect a terminal Execution.
 
 For one Execution:
 
@@ -217,7 +195,9 @@ STOPPED = terminal
 FAILED  = terminal
 ```
 
-For v1, one Task may have at most one Active / Uncertain Execution:
+Terminal Execution MUST NOT be resurrected.
+
+v1 allows at most one Active / Uncertain Execution per Task:
 
 ```text
 STARTING
@@ -227,148 +207,93 @@ UNKNOWN
 CONFLICT
 ```
 
-Do not create a second Execution while one of the above exists.
-
-Version-changing/replacement commands MUST NOT bypass uncertain runtime state. `RestartExecution` and `ApplyPublishedVersion` require a stable `RUNNING/RUNNING` Execution with a bound EngineExecutionRef.
-
 ---
 
-# 6. DesiredState and ObservedState belong to SyncExecution
+# 6. DesiredState and ObservedState are different facts
 
 ```text
 DesiredState  = control-plane/user intent
 ObservedState = latest known runtime fact
 ```
 
-Allowed desired values in v1:
-
-```text
-RUNNING
-STOPPED
-```
-
-Observed values in v1:
-
-```text
-STARTING
-RUNNING
-STOPPING
-STOPPED
-FAILED
-UNKNOWN
-CONFLICT
-```
-
 Rules:
 
-- Stop MUST persist `desired = STOPPED` before waiting for engine convergence.
-- Reconcile updates observed/runtime facts; it MUST NOT rewrite user intent merely to match the engine.
+- Stop persists `desired = STOPPED` before engine convergence.
+- Reconcile updates observed/runtime facts, not user intent merely to match the engine.
 - `UNKNOWN` means insufficient knowledge, not failure.
-- `CONFLICT` means ambiguous runtime identity; do not guess.
-- uncertain external submission MUST NOT become a fresh retry that can double-run the task.
-
-## Wave 6 current ownership
+- `CONFLICT` means ambiguous external identity; do not guess.
+- uncertain submission must not create a second Execution.
 
 Runtime lifecycle truth is **SyncExecution only**.
 
 Physical Task columns:
 
 ```text
-yak_realtime_job_definition.desired_state
-yak_realtime_job_definition.observed_state
-yak_realtime_job_definition.last_error
+desired_state
+observed_state
+last_error
 ```
 
-are now **inert compatibility storage**.
+are inert compatibility storage.
 
-MUST NOT:
+MUST NOT reintroduce:
 
 ```text
-dual-write Execution lifecycle into those Task columns
-read those Task columns as Application command truth
-fallback API runtime state to those Task columns
-reintroduce desiredJobs / hasOtherDesiredRunning style Task-runtime queries
+Execution lifecycle dual-write to Task columns
+runtime fallback to Task columns
+desiredJobs
+hasOtherDesiredRunning
+markStarting
 ```
 
-Read model rule:
+Read model:
 
 ```text
-latest SyncExecution exists -> derive desired/observed/error from that Execution
-no SyncExecution            -> STOPPED / STOPPED / null
+latest Execution exists -> state/error from Execution
+no Execution            -> STOPPED / STOPPED / null
 ```
 
 Task row locking may remain a cross-instance command mutex; lock location does not imply lifecycle ownership.
 
 ---
 
-# 7. RestartExecution and ApplyPublishedVersion are distinct commands
+# 7. RestartExecution and ApplyPublishedVersion stay distinct
 
-These commands MUST remain different in Application/API/UI semantics.
+## RestartExecution
 
 ```text
-RestartExecution
 E100(V3) -> stop -> E101(V3)
 ```
 
-```text
-ApplyPublishedVersion
-E100(V3) -> stop -> E101(V4)
-```
+Target is `currentExecution.definitionVersionId`, never current PublishedRef.
 
-## 7.1 RestartExecution
-
-Target MUST come from:
+## ApplyPublishedVersion
 
 ```text
-current SyncExecution.definitionVersionId
+E100(V3), Published=V4 -> explicit apply -> E101(V4)
 ```
 
-It MUST NOT depend on current `Task.publishedDefinitionRef`.
+Target is captured at command start and remains pinned. A later Publish V5 does not change an already-running Apply V4 command.
 
-Therefore this is valid:
+## Preflight before Stop
 
-```text
-E100 runs V3
-Task.publishedDefinitionRef = V4
-RestartExecution(E100)
-  -> E101(V3)
-```
+Both commands MUST validate/resolve/compile the exact target version before stopping a healthy Execution.
 
-## 7.2 ApplyPublishedVersion
+After preflight, DB-lock replacement reservation must re-check the same stable RUNNING Execution before STOPPING.
 
-Target MUST be captured from `Task.publishedDefinitionRef` at command start.
-
-That immutable target remains pinned for the command. If another Publish advances to V5 while Apply V4 is in progress, the existing command MUST remain V4.
-
-If the active Execution already uses the captured VersionId, Apply MUST reject as unnecessary.
-
-## 7.3 Preflight before Stop
-
-Both commands MUST resolve/validate/compile their exact target DefinitionVersion **before** stopping a healthy Execution.
-
-If target datasource/runtime/connector validation fails, the old Execution stays running.
-
-After preflight, a DB-lock replacement-stop reservation MUST re-check the same stable Execution before persisting STOPPING. A competing Stop/Restart/Apply that already won makes the later command fail.
-
-## 7.4 Compatibility `/restart`
-
-The HTTP v1 `/restart` endpoint may remain as an external compatibility alias, but it MUST delegate to `RestartExecution` semantics.
-
-Internal Application/UI code MUST NOT use a generic `restart-to-latest` action.
+HTTP v1 `/restart` may remain only as an external alias for `restartExecution()`.
 
 ---
 
-# 8. Route/Selector/Policy composition comes before scene enums
-
-Do not model product labels directly as Task types.
+# 8. Route / Selector / Policy composition comes before scenario enums
 
 Prefer:
 
 ```text
-1 Exact Route            -> UI may call it single-table
-N Exact Routes           -> UI may call it multi-table
-Pattern Selector         -> rule matching
-future DatabaseSelector  -> whole-database capability
+1 Exact Route           -> UI single-table
+N Exact Routes          -> UI multi-table
+Pattern Selector        -> pattern matching
+future DatabaseSelector -> whole-database capability
 ```
 
 MUST NOT add without explicit domain review:
@@ -384,62 +309,25 @@ MysqlRealtimeTask
 KafkaRealtimeTask
 ```
 
-New scenarios SHOULD first extend:
-
-```text
-SourceSelector
-SyncRoute
-SinkTarget
-SyncPolicy
-ExecutionPolicy
-```
-
-If composition cannot express the scenario, mark `Domain Gap` first.
+New scenarios first extend Selector / Route / Target / Policy. If they cannot, mark `Domain Gap`.
 
 ---
 
 # 9. Replay safety is an invariant
 
-v1 requires each route to have a non-empty `ReplayKey`.
+Every v1 route has a non-empty `ReplayKey` with unique fields.
 
-MUST:
+Contextual preflight validates current source uniqueness semantics and ambiguous routing.
 
-- ReplayKey is non-empty;
-- ReplayKey fields are unique;
-- contextual preflight verifies actual source uniqueness semantics supported by the implementation;
-- ambiguous routing is rejected before Publish/Start.
-
-Core Domain MUST NOT introduce:
-
-```text
-strictReplaySafety = false
-```
-
-The legacy boolean is a compatibility field, not a desired Core policy.
+Core Domain MUST NOT model `strictReplaySafety=false`.
 
 ---
 
-# 10. Runtime Environment is an adjacent context
+# 10. Runtime Environment / DataSource are adjacent contexts
 
-`SyncDefinition` MUST NOT own runtime-environment internals.
+Definition stores runtime reference; Execution stores runtime snapshot.
 
-Correct relationship:
-
-```text
-DefinitionDraft
-├── SyncDefinition
-└── RuntimeEnvironmentRef
-
-DefinitionVersion
-├── SyncDefinition
-└── RuntimeEnvironmentRef
-
-SyncExecution
-├── DefinitionVersionRef
-└── RuntimeEnvironmentSnapshot
-```
-
-Core Domain MUST NOT contain:
+Core Domain MUST NOT contain connection/runtime internals such as:
 
 ```text
 flinkHome
@@ -449,409 +337,311 @@ sshHost
 sshUser
 identityFile
 javaHome
-```
-
-These belong to Compute/Runtime Environment and infrastructure adapters.
-
-A physical Java/Maven package location does not change bounded-context ownership.
-
----
-
-# 11. DataSource is an adjacent context
-
-Realtime Sync stores/references datasource identity, not credentials or connection definitions.
-
-Core Domain MUST NOT persist/copy:
-
-```text
-password
 jdbcUrl
 host
 port
 username
+password
 connectionJson
-driver
 ```
 
-Credentials are resolved at the submission boundary and MUST retain short lifetime / zeroization behavior.
+Credentials exist only at submission boundary and retain short lifetime / zeroization.
 
 ---
 
-# 12. Flink is Infrastructure
+# 11. Flink is Infrastructure
 
-Flink CDC is the current engine adapter, not the realtime-sync domain.
+Core Domain does not model Flink Job as Task, Flink YAML as Definition, Flink commands, SSH mode, or connector JAR paths.
 
-Core Domain MUST NOT model:
-
-```text
-Flink Job as Task
-Flink YAML as Definition
-Flink REST status as business enum directly
-flink-cdc.sh command
-SSH submission mode as task type
-Connector JAR path as definition field
-```
-
-Keep translation boundary:
+Boundary:
 
 ```text
 SyncDefinition / DefinitionVersion
-        ↓ Application/Compiler
+        ↓ Application/compiler
 Compiled engine artifact
         ↓
-Flink CDC Adapter
+Flink CDC adapter
 ```
 
-`EngineExecutionRef` is the engine-neutral reference. A Flink JobId is one adapter-specific external ID.
+`EngineExecutionRef` is engine-neutral; Flink JobId is adapter-specific external identity.
 
 ---
 
-# 13. Adapter-private tuning must not leak into Core Domain
+# 12. Adapter-private tuning stays outside Core Domain
 
-Only engine-neutral execution semantics belong in `ExecutionPolicy`.
+If `ExecutionPolicy` accepts a setting, the engine must apply it or explicitly reject it during preflight.
 
-Adapter-private knobs stay outside Core Domain, including:
+MUST NOT silently persist a no-op policy.
 
-```text
-statementCacheSize
-connectorJarPath
-flinkRestAddress
-ssh options
-JDBC driver-specific cache settings
-```
-
-If Core `ExecutionPolicy` accepts a setting, the current engine adapter MUST either:
-
-```text
-apply it correctly
-or
-reject it explicitly during preflight
-```
-
-MUST NOT silently persist a policy with no runtime effect.
-
-Known gap: checkpoint/restart settings are not yet fully applied by the compiler/runtime path.
+Known gap: checkpoint/restart settings are not yet fully applied by the current runtime path.
 
 ---
 
-# 14. Validation has three layers
-
-Do not merge all failures into “domain invalid”.
+# 13. Validation has three layers
 
 ```text
-1. Intrinsic Domain Validation
-   - object/value invariants
-   - no external I/O
-
-2. Contextual Preflight
-   - datasource catalog
-   - replay-key drift
-   - runtime/environment capability
-   - route ambiguity against current metadata
-
-3. Adapter/Artifact Validation
-   - Flink connector support
-   - compiled YAML shape
-   - engine readiness where required
+Intrinsic Domain Validation
+Contextual Preflight
+Adapter / Artifact Validation
 ```
 
-A source DB being temporarily offline does not mutate historical `SyncDefinition` into an intrinsically invalid object.
+External connectivity failure does not mutate a historical SyncDefinition into an intrinsically invalid object.
 
 ---
 
-# 15. Digest semantics must remain distinct
-
-MUST distinguish:
+# 14. Digest semantics remain distinct
 
 ```text
 DefinitionDigest
-= semantic canonical digest of SyncDefinition + RuntimeEnvironmentRef
+= canonical SyncDefinition + RuntimeEnvironmentRef
 
 sourceConfigDigest
-= exact compatibility digest used for mutable Draft / publish CAS
+= exact mutable-Draft / publish-CAS compatibility digest
 
-ExecutionArtifactDigest / artifactDigest
-= digest of compiled runtime artifact for one Execution
+artifactDigest / ExecutionArtifactDigest
+= compiled runtime artifact digest for one Execution
 ```
 
-Physical schema may still contain two columns both named `config_digest`. That physical name does **not** collapse the semantics.
-
-New Application/Domain code MUST use semantic names such as:
-
-```text
-sourceConfigDigest
-artifactDigest
-DefinitionDigest
-```
-
-and MUST NOT introduce a new ambiguous generic digest concept.
-
-Definition canonicalization MUST ignore ordering with no business semantics, including route order and ReplayKey field order where order is not meaningful.
-
-Do not use YAML comments/formatting/editor mode/task display name as DefinitionDigest inputs.
+Physical `config_digest` columns may remain, but new Domain/Application code uses semantic names.
 
 ---
 
-# 16. Historical evidence is append-only/immutable by default
+# 15. Historical evidence is immutable by default
 
-`DefinitionVersion` and `SyncExecution` are historical facts.
+DefinitionVersion and SyncExecution are historical facts.
 
-MUST NOT casually hard-delete:
+Do not casually hard-delete published versions, execution history, or audit events.
 
-```text
-published versions
-execution history
-events/audit evidence
-```
-
-Hard delete is only suitable for a never-published, never-executed, externally-unreferenced task with no active/uncertain runtime.
-
-Otherwise prefer Archive/Tombstone semantics.
-
-Current hard-delete behavior remains a known gap; do not treat Stage 6 cleanup as solving it.
+Current hard delete is a known gap; Archive/Tombstone requires its own domain decision.
 
 ---
 
-# 17. Preserve the safety protection list
+# 16. Safety protection list
 
-Refactoring MUST preserve these safety properties unless an explicit replacement is proven equivalent or safer:
+Preserve unless an explicit replacement is proven equivalent or safer:
 
 ```text
 Idempotency-Key
-unique persistence constraint for start idempotency
-DB locking / CAS around lifecycle commands
+unique start persistence
+DB command serialization
 start reservation before external submit
 same-key race recovery
-prepared-definition/version re-check
-stop-during-start safety
+prepared version re-check
+stop-during-start
 uncertain submission -> UNKNOWN
-runtime identity persistence before CLI boundary
-runtime job discovery/recovery
-ambiguous matches -> CONFLICT
-RuntimeEnvironmentSnapshot per execution
-submission-scoped credentials and zeroization
-secret-free persistent definition/snapshot
-submission log redaction
-reconcile lease for multi-instance reconciliation
-replacement-stop reservation for Restart/Apply
+runtime identity persistence/recovery
+ambiguous match -> CONFLICT
+RuntimeEnvironmentSnapshot
+replacement-stop reservation
+submission-scoped credentials + zeroization
+secret-free persistence
+log redaction
+multi-instance reconcile lease
 ```
-
-Do not rewrite working Flink/SSH/recovery code merely to make packages look more DDD-like.
 
 ---
 
-# 18. Stage 6 migration is complete
-
-Accepted migration sequence:
+# 17. Stage 6 migration is complete
 
 ```text
-Wave 0  Core VOs + compatibility mapper                                ✅
-Wave 1  Immutable DefinitionVersion persistence                         ✅
-Wave 2  Start by Published DefinitionVersion                            ✅
-Wave 3  SyncExecution owns desired/observed lifecycle                   ✅
-Wave 4  Active Execution no longer blocks Draft Save / Publish          ✅
-Wave 5  RestartExecution / ApplyPublishedVersion explicit split          ✅
-Wave 6  Contract cleanup / legacy runtime projection isolation           ✅
+Wave 0  Core VOs + compatibility mapper                      ✅
+Wave 1  Immutable DefinitionVersion                          ✅
+Wave 2  Start by Published DefinitionVersion                 ✅
+Wave 3  SyncExecution lifecycle ownership                    ✅
+Wave 4  Active Execution allows Draft Save / Publish         ✅
+Wave 5  RestartExecution / ApplyPublishedVersion split       ✅
+Wave 6  Legacy runtime projection / contract cleanup         ✅
 ```
 
-Current command ownership:
+Physical/v1 compatibility names may remain temporarily (`job_definition`, `job_deployment`, `definition_version`, `published_version`, `config_digest`, `status`, `latestDeployment`, HTTP `/restart`). They are not domain truth.
 
-```text
-Save Draft             -> RealtimeSyncTask.currentDraft
-Publish                -> DefinitionVersion + Task.publishedDefinitionRef
-Start                  -> command-time PublishedDefinitionRef -> new SyncExecution
-RestartExecution       -> current Execution VersionRef -> new same-version Execution
-ApplyPublishedVersion  -> command-time PublishedDefinitionRef -> new versioned Execution
-Stop / Reconcile       -> SyncExecution lifecycle
-Delete                 -> terminal Execution + runtime safety guard
-```
-
-## 18.1 Contract-but-not-drop
-
-Stage 6 does **not** perform a Big-Bang physical schema/API rename.
-
-These physical/v1 names may remain temporarily:
-
-```text
-yak_realtime_job_definition
-yak_realtime_job_deployment
-Task desired_state / observed_state / last_error
-Deployment status
-Definition/Deployment config_digest
-definition_version / published_version
-latestDeployment JSON
-legacy HTTP /restart
-```
-
-But existing compatibility names MUST NOT be used to infer domain ownership.
-
-Database/API contract removal must remain incremental:
+Physical contract removal remains incremental:
 
 ```text
 expand -> switch readers/writers -> verify -> contract
 ```
 
-Never edit/drop an already-applied schema merely to make names look cleaner.
-
 ---
 
-# 19. Current legacy-name mapping
+# 18. Known gaps
 
-When reading current code/schema, interpret these names as follows:
-
-```text
-CdcPipelineSpec
-  -> compatibility definition representation; SyncDefinition is Core truth
-
-TableRoute
-  -> compatibility route representation
-
-definition_version
-  -> DraftRevision compatibility field
-
-published_version
-  -> published DraftRevision compatibility marker
-
-published_definition_version_id
-  -> immutable Published DefinitionVersion identity
-
-DefinitionRow desired/observed/lastError
-  -> inert compatibility values; not runtime truth
-
-RealtimeJobDeploymentPO / DeploymentRow
-  -> SyncExecution persistence compatibility row
-
-Deployment.status
-  -> physical compatibility mirror; not lifecycle truth
-
-DefinitionRow.configDigest
-  -> sourceConfigDigest compatibility storage
-
-DeploymentRow.configDigest
-  -> ExecutionArtifactDigest compatibility storage
-
-latestDeployment JSON
-  -> latest SyncExecution read projection
-
-ReleaseState DRAFT/PUBLISHED
-  -> legacy/derived presentation state
-
-HTTP /restart
-  -> compatibility alias for RestartExecution only
-```
-
-Do not compare `definition_version / published_version` as immutable VersionIds.
-
-Do not introduce a new dependency on inert Task runtime columns.
-
-Accepted domain documents have higher semantic authority than legacy naming.
-
----
-
-# 20. Known gaps after Stage 6
-
-Stage 6 completion does not mean all architecture work is finished.
-
-Keep these as explicit independent gaps:
+Keep separate until explicitly designed:
 
 ```text
-Audit-safe Archive/Tombstone delete
+Audit-safe Archive / Tombstone
 ExecutionPolicy checkpoint/restart runtime application
 Flink FINISHED normal completion / snapshot-only
 legacy failure-rate mapping
 Read-model package hygiene
-Compute Environment physical context/package cleanup
+Compute Environment physical context cleanup
 API v2 / physical schema naming cleanup
 ```
 
-Do not sneak these changes into unrelated feature PRs. Each needs its own Domain Impact Analysis.
+---
+
+# 19. Stage 7 automated enforcement
+
+The domain contract is machine checked.
+
+## Mandatory: Static Domain Contract
+
+```bash
+python3 tools/realtime_domain_guardrails.py
+```
+
+It checks Core purity, anti-pattern naming, Execution-only runtime truth, immutable version identity, Restart/Apply separation, Start-by-Published, digest semantics, required docs, and realtime PR body contract.
+
+## Mandatory: framework-free Core Smoke
+
+GitHub Actions compiles Core Domain with JDK 21 and **no Spring/Maven classpath**, then runs:
+
+```text
+tools/realtime-domain-smoke/RealtimeDomainSmoke.java
+```
+
+`SyncExecutionStateMachine` is pure Java; Spring construction belongs in `RealtimeSyncConfiguration`.
+
+## Conditional: Maven/JUnit deep regression
+
+The existing deeper JUnit suite depends on private repository:
+
+```text
+weifuwan/yak-framework
+```
+
+A repository-scoped `GITHUB_TOKEN` for yak-ops cannot read that private sibling repo.
+
+Workflow Job `Backend regression hook` therefore runs full Maven/JUnit only when repository secret:
+
+```text
+YAK_FRAMEWORK_TOKEN
+```
+
+is configured with read access to yak-framework.
+
+Without that secret the Job emits an explicit notice and skips Maven/JUnit steps.
+
+**A green Backend regression hook without `YAK_FRAMEWORK_TOKEN` does not mean JUnit passed.**
+
+The mandatory required checks remain Static Domain Contract + Framework-free Core Smoke + PR contract.
+
+## Mandatory: PR contract
+
+Realtime PR bodies contain:
+
+```text
+Domain Impact Analysis
+Domain Gap
+Domain Compliance Report
+```
+
+Workflow listens to PR `edited` so description fixes are re-evaluated.
+
+Files:
+
+```text
+.github/workflows/realtime-sync-domain-guardrails.yml
+.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md
+docs/realtime-sync/domain/07-automated-domain-guardrails.md
+```
+
+## Guard modification rule
+
+Do not disable a guard merely because a feature fails it.
+
+If an accepted domain rule changes, update:
+
+```text
+DOMAIN.md
+relevant design docs
+replacement automated guard
+```
+
+together in the same reviewed change.
 
 ---
 
-# 21. AI coding contract
+# 20. AI implementation/completion contract
 
-Before proposing code changes, AI MUST output:
+Before code:
 
 ```text
 Domain Impact Analysis
 - Bounded context
 - Aggregate(s)
-- SyncDefinition area (if any)
+- SyncDefinition area
 - Invariant/lifecycle impact
 - Layer
 - Current mapping/gap
-- Safety properties to preserve
+- Safety properties
 - Domain Gap: yes/no
 ```
 
-If `Domain Gap: yes`, implementation stops at domain-design proposal unless the user explicitly approves the extension.
-
-After implementation, report:
+After code:
 
 ```text
+Domain Compliance Report
 - Domain rule implemented
-- Aggregates changed
-- Invariants/lifecycle affected
+- Aggregate(s) affected
+- Invariant/lifecycle changes
 - Legacy compatibility retained
 - Safety properties preserved
 - DB/API migration mode
-- Tests added/updated
+- Tests/guardrails added or updated
 - Known gaps remaining
 ```
 
-Do not claim “domain-compliant” merely because class names were renamed.
+A realtime PR should not be considered complete until mandatory Stage 7 guardrails pass.
 
 ---
 
-# 22. Review rejection triggers
+# 21. Review rejection triggers
 
-Return a realtime-sync PR for domain review if it introduces any of these without an explicit decision:
+Return for domain review if a PR introduces without explicit approval:
 
 ```text
-new WizardSpec / YamlSpec / engine-specific domain Spec
-new syncType / sceneType for a UI scenario
-Flink/SSH/JDBC credential fields in Core Domain
+second editable Spec/Definition truth
+syncType / sceneType scenario modeling
+Flink/SSH/JDBC/Spring/persistence concerns in Core Domain
 Execution reading current Draft
-in-place mutation of Published Version
-Restart that may silently upgrade version
-ApplyPublishedVersion that re-reads a newer target after command start
-target-version command that stops healthy Execution before target preflight
-second active Execution while UNKNOWN/CONFLICT exists
-UNKNOWN treated as FAILED solely to permit retry
-new read/write dependency on Task runtime compatibility columns
-Deployment.status used as lifecycle truth
-legacy revision integer used as DefinitionVersion identity
-ambiguous generic configDigest introduced into new domain/application code
-hard deletion of execution/version/audit history presented as a harmless cleanup
-adapter-private tuning added to SyncDefinition
-accepted ExecutionPolicy silently ignored by runtime adapter
-Big-Bang schema/API rename/drop without migration verification
+Published Version mutation
+Restart that may silently upgrade
+Apply target drift after command start
+stop-before-target-preflight
+second active Execution under UNKNOWN/CONFLICT
+UNKNOWN -> FAILED only to permit retry
+Task runtime truth reintroduction
+Deployment.status as lifecycle truth
+legacy revision as immutable Version identity
+ambiguous new generic configDigest
+hard-delete history presented as harmless cleanup
+adapter-private tuning in SyncDefinition
+silent ExecutionPolicy no-op
+Big-Bang schema/API rename/drop
+disabling a Stage 7 guard instead of resolving the violated rule
 ```
 
 ---
 
-# 23. Source documents
-
-Detailed accepted design/current migration status:
+# 22. Source documents / authority order
 
 ```text
 docs/realtime-sync/domain/01-domain-boundary-and-language.md
 docs/realtime-sync/domain/02-core-domain-model.md
 docs/realtime-sync/domain/03-invariants-and-lifecycle.md
-docs/realtime-sync/domain/04-current-code-mapping.md       # historical mapping snapshot
+docs/realtime-sync/domain/04-current-code-mapping.md       # historical snapshot
 docs/realtime-sync/domain/05-ai-domain-rules.md
-docs/realtime-sync/domain/06-stage6-migration-completion.md # current Stage 6 implementation facts
+docs/realtime-sync/domain/06-stage6-migration-completion.md # current implementation facts
+docs/realtime-sync/domain/07-automated-domain-guardrails.md  # executable enforcement
 ```
 
-Conflict resolution order:
+Authority order:
 
 ```text
-1. Explicit newest approved user/domain decision
-2. DOMAIN.md hard guardrails
-3. 06-stage6-migration-completion.md current implementation facts
-4. Accepted domain design docs
-5. Tests encoding approved invariants
-6. Current legacy names / physical schema details
+1. Newest approved user/domain decision
+2. DOMAIN.md current hard rules
+3. Stage 6 current implementation facts
+4. accepted detailed domain design docs
+5. Stage 7 automated checks + invariant tests
+6. legacy names / physical schema details
 ```
-
-Current implementation is compatibility evidence; legacy naming is not automatically domain truth.

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncConfiguration.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/config/RealtimeSyncConfiguration.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.sync.realtime.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
 import java.net.http.HttpClient;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
@@ -20,6 +21,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Import(BusinessDatabaseConfiguration.class)
 @ConditionalOnProperty(prefix = "yak.sync.realtime", name = "enabled", matchIfMissing = true)
 public class RealtimeSyncConfiguration {
+
+  @Bean
+  SyncExecutionStateMachine syncExecutionStateMachine() {
+    return new SyncExecutionStateMachine();
+  }
 
   @Bean(initMethod = "migrate")
   Flyway realtimeSyncFlyway(@Qualifier("yakBusinessDataSource") DataSource dataSource) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachine.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachine.java
@@ -5,10 +5,8 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Map;
-import org.springframework.stereotype.Component;
 
 /** State machine for one immutable-identity SyncExecution. */
-@Component
 public class SyncExecutionStateMachine {
 
   private final Map<ObservedState, EnumSet<ObservedState>> transitions =
@@ -70,10 +68,10 @@ public class SyncExecutionStateMachine {
     }
   }
 
-  /** Wave-3 keeps the old product policy: editing/publishing still requires a terminal execution. */
+  /** Destructive metadata mutation (currently delete) requires a terminal execution. */
   public void requireDefinitionMutable(SyncExecution latest) {
     if (latest != null && latest.activeOrUncertain()) {
-      throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能编辑、发布或删除");
+      throw new IllegalStateException("任务运行态未稳定，只有已停止或明确失败的任务才能执行该操作");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/RealtimeArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/RealtimeArchitectureTest.java
@@ -4,6 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.yak.ops.business.sync.realtime.controller.v1.ComputeEnvironmentController;
 import io.yak.ops.business.sync.realtime.controller.v1.RealtimeJobController;
+import io.yak.ops.business.sync.realtime.domain.DefinitionDigest;
+import io.yak.ops.business.sync.realtime.domain.DefinitionVersion;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState;
+import io.yak.ops.business.sync.realtime.domain.RuntimeEnvironmentRef;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinition;
+import io.yak.ops.business.sync.realtime.domain.SyncDefinitionDigestCalculator;
+import io.yak.ops.business.sync.realtime.domain.SyncExecution;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
 import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobListQuery;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
@@ -14,8 +22,12 @@ import io.yak.ops.business.sync.realtime.service.RealtimeJobQueryService;
 import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
 import io.yak.ops.business.sync.realtime.service.RealtimeObservabilityService;
 import io.yak.ops.business.sync.realtime.service.RealtimeRuntimeResolver;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,34 +35,58 @@ import org.junit.jupiter.api.Test;
 
 class RealtimeArchitectureTest {
 
+  private static final String[] CORE_FORBIDDEN = {
+    "org.springframework",
+    "com.fasterxml.jackson",
+    "com.baomidou",
+    ".controller.",
+    ".service.",
+    ".repository.",
+    ".dao.",
+    ".engine.",
+    "JdbcTemplate"
+  };
+
   @Test
   void controllersDependOnApplicationBoundariesInsteadOfPersistenceOrEnginePorts() {
-    assertFieldsAvoid(RealtimeJobController.class, ".repository.", ".dao.", "RealtimeEngineGateway", "JdbcTemplate");
-    assertFieldsAvoid(ComputeEnvironmentController.class, ".repository.", ".dao.", "RealtimeEngineGateway", "JdbcTemplate");
+    assertFieldsAvoid(
+        RealtimeJobController.class,
+        ".repository.",
+        ".dao.",
+        "RealtimeEngineGateway",
+        "JdbcTemplate");
+    assertFieldsAvoid(
+        ComputeEnvironmentController.class,
+        ".repository.",
+        ".dao.",
+        "RealtimeEngineGateway",
+        "JdbcTemplate");
   }
 
   @Test
   void servicesDoNotDependOnDaoMapperPoOrJdbcTemplate() {
-    for (Class<?> type : new Class<?>[] {
-        RealtimeJobService.class,
-        RealtimeJobLifecycleCoordinator.class,
-        RealtimeJobQueryService.class,
-        RealtimeObservabilityService.class,
-        RealtimeRuntimeResolver.class,
-        ComputeEnvironmentService.class
-    }) {
+    for (Class<?> type :
+        new Class<?>[] {
+          RealtimeJobService.class,
+          RealtimeJobLifecycleCoordinator.class,
+          RealtimeJobQueryService.class,
+          RealtimeObservabilityService.class,
+          RealtimeRuntimeResolver.class,
+          ComputeEnvironmentService.class
+        }) {
       assertFieldsAvoid(type, ".dao.", ".dao.mapper.", ".dao.model.", "JdbcTemplate");
     }
   }
 
   @Test
   void repositoryContractsDoNotExposeDaoOrControllerTypes() {
-    for (Class<?> repository : new Class<?>[] {
-        RealtimeJobStore.class,
-        RealtimeJobListQuery.class,
-        RealtimeRuntimeIdentityStore.class,
-        ComputeEnvironmentStore.class
-    }) {
+    for (Class<?> repository :
+        new Class<?>[] {
+          RealtimeJobStore.class,
+          RealtimeJobListQuery.class,
+          RealtimeRuntimeIdentityStore.class,
+          ComputeEnvironmentStore.class
+        }) {
       for (Method method : repository.getDeclaredMethods()) {
         assertTypeBoundary(method.getReturnType());
         for (Class<?> parameterType : method.getParameterTypes()) assertTypeBoundary(parameterType);
@@ -68,6 +104,75 @@ class RealtimeArchitectureTest {
     assertThat(serviceMethods)
         .contains("restartExecution", "applyPublishedVersion")
         .doesNotContain("restart");
+  }
+
+  @Test
+  void coreDomainTypesStayFrameworkAndAdapterFree() {
+    for (Class<?> root :
+        new Class<?>[] {
+          RealtimeJobState.class,
+          SyncDefinition.class,
+          RuntimeEnvironmentRef.class,
+          DefinitionDigest.class,
+          SyncDefinitionDigestCalculator.class,
+          DefinitionVersion.class,
+          SyncExecution.class,
+          SyncExecutionStateMachine.class
+        }) {
+      assertCoreType(root);
+      for (Class<?> nested : root.getDeclaredClasses()) assertCoreType(nested);
+    }
+  }
+
+  private static void assertCoreType(Class<?> type) {
+    assertAnnotationsAvoid(type, CORE_FORBIDDEN);
+
+    for (Field field : type.getDeclaredFields()) {
+      assertTypeAvoids(type, field.getName(), field.getGenericType(), CORE_FORBIDDEN);
+      assertAnnotationsAvoid(field, CORE_FORBIDDEN);
+    }
+    for (Method method : type.getDeclaredMethods()) {
+      assertTypeAvoids(type, method.getName() + " return", method.getGenericReturnType(), CORE_FORBIDDEN);
+      for (Type parameter : method.getGenericParameterTypes()) {
+        assertTypeAvoids(type, method.getName() + " parameter", parameter, CORE_FORBIDDEN);
+      }
+      assertAnnotationsAvoid(method, CORE_FORBIDDEN);
+    }
+    for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+      for (Type parameter : constructor.getGenericParameterTypes()) {
+        assertTypeAvoids(type, "constructor parameter", parameter, CORE_FORBIDDEN);
+      }
+      assertAnnotationsAvoid(constructor, CORE_FORBIDDEN);
+    }
+    if (type.isRecord()) {
+      for (RecordComponent component : type.getRecordComponents()) {
+        assertTypeAvoids(type, component.getName(), component.getGenericType(), CORE_FORBIDDEN);
+        assertAnnotationsAvoid(component, CORE_FORBIDDEN);
+      }
+    }
+  }
+
+  private static void assertAnnotationsAvoid(AnnotatedElement element, String... forbidden) {
+    Arrays.stream(element.getDeclaredAnnotations())
+        .forEach(
+            annotation -> {
+              String name = annotation.annotationType().getName();
+              for (String value : forbidden) {
+                assertThat(name)
+                    .as("%s must not carry annotation from %s", element, value)
+                    .doesNotContain(value);
+              }
+            });
+  }
+
+  private static void assertTypeAvoids(
+      Class<?> owner, String member, Type type, String... forbidden) {
+    String name = type.getTypeName();
+    for (String value : forbidden) {
+      assertThat(name)
+          .as("%s.%s must not reference %s", owner.getSimpleName(), member, value)
+          .doesNotContain(value);
+    }
   }
 
   private static Set<String> methodNames(Class<?> type) {


### PR DESCRIPTION
## 背景

Realtime Sync Stage 1～6 已完成领域设计、AI 宪法与 Wave 0～6 代码迁移。本 PR 完成最后的 **Stage 7：Automated Domain Guardrails**，把已接受规则转成机器检查。

```text
Domain rules
  ↓
Static Domain Contract
+ Framework-free Core Smoke
+ PR Domain Contract
+ optional private-framework Maven/JUnit hook
  ↓
CI feedback before merge
```

## Domain Impact Analysis

```text
Bounded context: Realtime Sync
Aggregate(s): none; protects RealtimeSyncTask / DefinitionVersion / SyncExecution
SyncDefinition area: no business structure change
Invariant/lifecycle impact: no semantic change; existing rules become executable checks
Layer: Test / CI / Repository governance
Current mapping/gap: Stage 7 automated guardrails
Safety properties to preserve:
  - immutable DefinitionVersion
  - SyncExecution-only runtime lifecycle truth
  - Start by Published DefinitionVersion
  - RestartExecution vs ApplyPublishedVersion split
  - UNKNOWN / CONFLICT single-active protection
  - Idempotency / DB command serialization / stop-during-start
  - RuntimeEnvironmentSnapshot / runtime identity / credential zeroization
Domain Gap: no
```

## 1. Mandatory Static Domain Contract

新增：

```text
tools/realtime_domain_guardrails.py
```

零第三方依赖，自动检查：

- Core Domain 不得依赖 Spring/Jackson/MyBatis/Controller/Service/Repository/DAO/Engine；
- Core 不得出现 Flink/SSH/JDBC credential 等基础设施字段；
- 禁止 `sceneType / syncType` 和 engine/editor-specific second Spec/Definition；
- 禁止 Task runtime lifecycle dual-write/read fallback；
- 禁止 `desiredJobs / hasOtherDesiredRunning / markStarting` 回流；
- 版本身份必须用 immutable DefinitionVersion IDs；
- RestartExecution / ApplyPublishedVersion 必须保持分离；
- frontend 不得重新增加 generic `restart`；
- Start 必须读取 Published DefinitionVersion，不能 fallback current Draft；
- digest/revision semantic aliases 必须保留；
- realtime PR body 必须包含 Domain Impact / Domain Gap / Domain Compliance。

## 2. Mandatory Framework-free Core Domain Smoke

`SyncExecutionStateMachine` 移除 Spring `@Component`，变成纯 Java domain type，由 `RealtimeSyncConfiguration` 通过 `@Bean` 装配。

GitHub Actions 直接使用：

```text
javac --release 21
```

在**没有 Spring/Maven classpath**的情况下编译核心 Domain，并执行：

```text
tools/realtime-domain-smoke/RealtimeDomainSmoke.java
```

Smoke 锁住：

- ReplayKey duplicate / Source==Sink invariant；
- Route / ReplayKey 无业务顺序不改变 DefinitionDigest；
- RuntimeEnvironmentRef 变化改变 digest；
- RUNNING / UNKNOWN 阻止第二 Execution；
- STOPPED 允许下一 Execution；
- STOPPED / FAILED Execution 不允许复活。

## 3. JUnit Architecture Guard

扩展 `RealtimeArchitectureTest`，对 Core Domain 根类型和嵌套类型检查：

```text
annotations
fields
record components
method return / parameter types
constructor parameters
```

禁止框架/Adapter 依赖泄漏。

## 4. GitHub Actions

新增：

```text
.github/workflows/realtime-sync-domain-guardrails.yml
```

Realtime path PR/main push 自动触发。

### 强制 Job

```text
Static domain contract
Framework-free core domain smoke
```

### Private-framework 深层回归 Hook

`yak-ops` 依赖 `io.yak.framework:*:1.0.0-SNAPSHOT`，而 `weifuwan/yak-framework` 是 private repo。yak-ops 自带的 repository-scoped `GITHUB_TOKEN` 无法读取 sibling private repo。

因此 `Backend regression hook` 只有在仓库配置：

```text
YAK_FRAMEWORK_TOKEN
```

且具备 yak-framework read 权限时，才执行完整：

```text
checkout yak-framework
install 1.0.0-SNAPSHOT
build realtime reactor dependencies
targeted Maven/JUnit regression
```

没有 secret 时，Job 会明确发 Notice 并 skip Maven/JUnit steps。

**绿色 Backend regression hook 在 secret 未配置时，不代表 JUnit 已通过。**

## 5. PR Domain Contract

新增：

```text
.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md
```

Realtime PR 强制要求：

```text
Domain Impact Analysis
Domain Gap
Domain Compliance Report
```

workflow 监听 `pull_request.edited`，修改 PR 描述后可直接重新校验，不需要 dummy commit。

## 6. Docs / DOMAIN.md

新增：

```text
docs/realtime-sync/domain/07-automated-domain-guardrails.md
```

并更新：

```text
DOMAIN.md
docs/realtime-sync/domain/README.md
```

Guardrail 本身也是领域契约的一部分：功能被拦时不能直接删检查；如果领域规则真的变化，必须同步修改 `DOMAIN.md + design docs + replacement guard`。

## 7. 当前 CI 验证结果

第一次 workflow 暴露了 private sibling repository token 边界；调整为显式 hook 后，第二次 workflow 已整体成功：

```text
✅ Static domain contract
✅ Framework-free core domain smoke
✅ Backend regression hook
   - private YAK_FRAMEWORK_TOKEN 未配置
   - Maven/JUnit steps 明确 skipped
```

因此当前**可以声明 Mandatory Stage 7 guardrails 已通过**，但**不能声明完整 Maven/JUnit 已通过**。

## 8. 本 PR 不改

```text
DB schema
REST/YAML business contract
Flink/SSH runtime behavior
Start/Stop/Restart/Apply semantics
DefinitionVersion persistence
SyncExecution lifecycle
frontend business UI
```

仍然保留独立 Gap：

```text
Archive/Tombstone
ExecutionPolicy runtime application
FINISHED normal completion / snapshot-only
legacy failure-rate mapping
Compute Environment physical context cleanup
API v2 / physical schema naming cleanup
```

## Domain Compliance Report

```text
Domain rule implemented:
  Accepted Realtime Sync model now has executable resistance to architectural drift.

Aggregate(s) affected:
  none semantically; guardrails protect RealtimeSyncTask / DefinitionVersion / SyncExecution.

Invariant/lifecycle changes:
  none.

Legacy compatibility retained:
  DB/API/YAML/Flink/SSH behavior unchanged.

Safety properties preserved:
  immutable versioning, SyncExecution lifecycle, idempotency, DB serialization,
  stop-during-start, UNKNOWN/CONFLICT, runtime identity/snapshot, credentials.

DB/API migration mode:
  none.

Tests/guardrails added or updated:
  zero-dependency Python guard,
  framework-free JDK smoke,
  reflection architecture test,
  path-scoped GitHub Actions,
  realtime PR template/body contract,
  conditional private-framework Maven/JUnit hook.

Known gaps remaining:
  Archive/Tombstone, ExecutionPolicy runtime application, FINISHED/snapshot-only,
  failure-rate mapping, package/API/schema-v2 cleanup.
```

## Branch

```text
test/realtime-sync-domain-stage-7-guardrails
```