### PR TITLE
docs: add realtime sync requirements and review contracts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md
+++ b/.github/PULL_REQUEST_TEMPLATE/realtime-sync-domain.md
@@ -1,8 +1,10 @@
 # Realtime Sync Change
 
+> 开发前读 `REQUIREMENTS.md + DOMAIN.md`；Review 按 `REVIEW.md`。
+
 ## Summary
 
-<!-- 这次改什么？ -->
+<!-- 这次改什么？是否属于 REQUIREMENTS.md 已有能力？ -->
 
 ## Domain Impact Analysis
 

--- a/tools/realtime_domain_guardrails.py
+++ b/tools/realtime_domain_guardrails.py
@@ -175,9 +175,24 @@ def check_semantic_names(g: Guard) -> None:
 
 
 def check_docs(g: Guard) -> None:
+    requirements = g.read(MODULE / "REQUIREMENTS.md")
     contract = g.read(MODULE / "DOMAIN.md")
+    review = g.read(MODULE / "REVIEW.md")
     overview = g.read(DOC_DIR / "README.md")
     decisions = g.read(DOC_DIR / "DECISIONS.md")
+
+    for name, text, limit in (
+        ("REQUIREMENTS.md", requirements, 150),
+        ("DOMAIN.md", contract, 180),
+        ("REVIEW.md", review, 200),
+    ):
+        g.check(
+            len(text.splitlines()) <= limit,
+            f"{name} exceeds {limit} lines; keep module contracts concise and move detail to code/tests/Git history",
+        )
+
+    for phrase in ("核心能力", "模块边界", "Requirement Gap"):
+        g.check(phrase in requirements, f"REQUIREMENTS.md lost required phrase: {phrase}")
 
     for phrase in (
         "RealtimeSyncTask",
@@ -187,6 +202,16 @@ def check_docs(g: Guard) -> None:
         "Domain Compliance Report",
     ):
         g.check(phrase in contract, f"DOMAIN.md lost mandatory phrase: {phrase}")
+
+    for phrase in (
+        "Requirement Gap",
+        "Domain Gap",
+        "P0 Blocker",
+        "P1 Must Fix",
+        "Conclusion: PASS | CHANGES_REQUIRED",
+        "Missing Tests",
+    ):
+        g.check(phrase in review, f"REVIEW.md lost review protocol phrase: {phrase}")
 
     g.check("历史设计过程看 Git / PR" in overview, "README.md must describe current model, not stage history")
     g.check("文档保持小" in decisions, "DECISIONS.md must preserve the documentation-budget decision")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
@@ -1,6 +1,8 @@
 # Realtime Sync Domain
 
-> 本文件只保留**必须遵守的硬规则**，不记录设计过程。历史演进看 Git / PR。
+> 本文件只保留**实现必须遵守的硬规则**，不记录设计过程。历史演进看 Git / PR。
+>
+> `REQUIREMENTS.md` 定义“需要什么”；`DOMAIN.md` 定义“不能违反什么”；`REVIEW.md` 定义“怎么判卷”。
 
 ## 核心模型
 
@@ -99,7 +101,7 @@ multi-instance reconcile lease
 
 ## 修改代码前后
 
-修改前写一个短块即可：
+修改前先确认 `REQUIREMENTS.md` 中已有对应能力，再写一个短块：
 
 ```text
 Domain Impact Analysis
@@ -117,6 +119,8 @@ Domain Compliance Report
 - Safety/tests:
 - Known gaps:
 ```
+
+代码 Review 固定按 `REVIEW.md` 执行。
 
 ## 自动护栏
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/README.md
@@ -1,9 +1,8 @@
 # Realtime Sync
 
-> **开发 / AI 修改本模块前必读：[`DOMAIN.md`](./DOMAIN.md)**  
-> Realtime Sync 的领域设计不是从现有 Flink/SSH 实现反推出来的。任何新需求必须先做 Domain Impact Analysis；无法映射到既有领域模型时标记为 `Domain Gap`，先讨论模型，不直接新增 `syncType / sceneType / *Spec / *Task`。
->
-> 完整设计：`docs/realtime-sync/domain/`。
+> 开发 / AI 修改本模块前：先读 [`REQUIREMENTS.md`](./REQUIREMENTS.md) 和 [`DOMAIN.md`](./DOMAIN.md)。  
+> Review 本模块代码：按 [`REVIEW.md`](./REVIEW.md) 执行。  
+> 当前领域模型总览：`docs/realtime-sync/domain/`。
 
 实时同步控制面以 **Compute Environment** 作为唯一运行时配置来源。任务在创建时必须绑定一个已启用的运行环境；每次部署都会保存不可变的运行环境快照，后续修改默认环境或环境配置不会把历史部署重定向到其他 Flink 集群。
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/REQUIREMENTS.md
@@ -1,0 +1,88 @@
+# Realtime Sync Requirements
+
+> 本文件只描述**模块需要什么**，不描述怎么实现。历史需求和讨论看 Issue / PR / Git。
+
+## 目标
+
+Realtime Sync 提供持续数据同步的控制面：定义同步任务、发布可运行版本、控制运行实例，并查看运行状态和基础可观测信息。
+
+## 核心能力
+
+- 创建、编辑、校验和保存实时同步任务。
+- 描述 Source、Sink、同步路由、启动策略、Schema 演进和执行策略。
+- Wizard 与 Yak YAML 编辑同一份逻辑配置，不产生两套业务定义。
+- 发布可追踪、不可变的已发布版本。
+- 启动、停止任务，并查看当前运行状态。
+- 支持“重启当前版本”和“应用最新已发布版本”两个明确操作。
+- 查看提交日志、运行异常、Checkpoint 和基础 Metrics。
+- 任务绑定运行环境；支持本地或远程执行 Flink CDC CLI。
+- 保存每次运行所使用的定义版本和运行环境快照，便于追踪和恢复。
+
+## 关键业务行为
+
+允许同时存在：
+
+```text
+Running E100(V3)
++
+Draft V4
++
+Published V4
+```
+
+此时必须满足：
+
+```text
+Save Draft             -> 不影响 E100
+Publish V4             -> 不热更新 E100
+Start                   -> 使用当前 Published Version
+RestartExecution(E100) -> 新建同版本 Execution
+ApplyPublishedVersion  -> 新建使用目标 Published Version 的 Execution
+```
+
+## 运行安全要求
+
+- 同一 Task 最多一个 Active / Uncertain Execution。
+- `UNKNOWN / CONFLICT` 时不能盲目创建第二个运行实例。
+- 启动请求必须具备幂等保护，不能因超时或重试造成重复运行。
+- Stop 与 Start 并发时不能留下失控的外部 Job。
+- 外部提交结果不确定时必须保留可恢复身份并通过 Reconcile 查明事实。
+- 数据源凭据只在提交边界短暂使用，不长期写入定义、快照或日志。
+- 已运行实例使用自己的运行环境快照，不跟随之后的环境修改漂移。
+
+## 模块边界
+
+本模块负责实时同步控制面，不负责：
+
+- 启动、扩缩容或管理 Flink Cluster 生命周期；
+- 托管数据源密码或 SSH 登录密码；
+- 把 Flink Job、Pipeline YAML、SSH 命令当成业务 Task/Definition；
+- 通用工作流编排；
+- 通用 ETL / 任意复杂转换引擎；
+- 数据血缘计算；
+- Connector 工程的构建和部署管理。
+
+## 当前明确未解决
+
+以下能力不是普通需求变更可以顺手加入的内容，需要单独设计：
+
+```text
+Archive / Tombstone
+ExecutionPolicy checkpoint/restart 完整运行时生效
+Flink FINISHED / snapshot-only
+legacy failure-rate mapping
+Compute Environment 物理上下文拆分
+API v2 / 物理 Schema 命名清理
+```
+
+## 需求变更规则
+
+如果 PR 引入本文件没有描述的新业务能力或改变已有业务行为：
+
+```text
+Requirement Gap
+```
+
+先确认需求并更新本文件，再实现代码。Reviewer / AI 不得自行补需求。
+
+本文件只维护**当前有效需求**，不要追加迭代历史。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/REVIEW.md
@@ -1,0 +1,179 @@
+# Realtime Sync Review
+
+> 本文件定义**如何 Review**。Reviewer / AI 是裁判，不是需求设计者；不得边 Review 边自行补需求。
+
+## Review 前必读
+
+按顺序读取：
+
+```text
+REQUIREMENTS.md  -> 模块需要什么
+DOMAIN.md        -> 实现不能违反什么
+REVIEW.md        -> 按什么标准判卷
+PR diff / tests  -> 实际改了什么
+```
+
+## Review 顺序
+
+### 1. Requirement Alignment
+
+检查代码是否符合 `REQUIREMENTS.md`：
+
+- 是否实现已有能力？
+- 是否改变已有业务行为？
+- 是否引入文档中没有的新能力？
+- 是否越过模块边界？
+
+出现未定义的新能力或行为变化时，报告：
+
+```text
+Requirement Gap
+```
+
+不要替产品或开发者自行补需求。
+
+### 2. Domain Compliance
+
+检查 `DOMAIN.md`，重点关注：
+
+- Task / DefinitionVersion / SyncExecution 是否混淆；
+- Execution 是否读取 current Draft；
+- Published Version 是否可能被原地修改；
+- Restart 是否可能隐式升级；
+- Apply 的目标版本是否可能执行中漂移；
+- `UNKNOWN / CONFLICT` 是否可能创建第二实例；
+- Runtime state 是否重新回到 Task；
+- Flink / SSH / Credential / Adapter 参数是否泄漏进 Core Domain；
+- 是否重新引入 `syncType / sceneType / 第二套 Spec`。
+
+违反现有领域规则时，报告：
+
+```text
+Domain Violation
+```
+
+如果现有领域模型无法表达需求，报告：
+
+```text
+Domain Gap
+```
+
+### 3. Correctness
+
+检查真实错误，不做泛泛而谈：
+
+- 状态迁移；
+- 空值和边界值；
+- 事务边界；
+- 并发 / CAS / 锁；
+- 幂等；
+- 重试；
+- 外部调用超时和部分失败；
+- Start / Stop / Reconcile / Restart / Apply 的竞态；
+- 快照、版本、外部 JobId 是否可能错配。
+
+### 4. Compatibility
+
+检查是否破坏：
+
+- REST API；
+- DB / Flyway；
+- Yak YAML；
+- 历史数据；
+- 前端调用；
+- 已存在运行实例或版本记录。
+
+破坏性变更必须有明确迁移方案，禁止 Big-Bang 修改。
+
+### 5. Safety
+
+重点检查：
+
+- 重复启动 / 双实例；
+- stop-during-start；
+- `UNKNOWN / CONFLICT`；
+- runtime identity 恢复；
+- RuntimeEnvironmentSnapshot；
+- 密码 / Secret 是否落库或进日志；
+- 提交临时文件是否安全清理。
+
+### 6. Tests / Guardrails
+
+每个 P0 / P1 问题都回答：
+
+```text
+现有哪个测试应该挡住？
+```
+
+如果没有，指出缺失测试。优先补能锁住领域行为的回归测试，不为了覆盖率堆测试。
+
+## 严重级别
+
+```text
+P0 Blocker
+- 数据丢失 / 不可恢复破坏
+- 重复运行导致严重数据风险
+- Secret 泄漏
+- 明确安全问题
+
+P1 Must Fix
+- 业务结果错误
+- 违反 REQUIREMENTS.md / DOMAIN.md
+- 明确并发、幂等、事务、兼容性缺陷
+- 高概率导致运行故障
+
+P2 Suggestion
+- 有明确收益的可维护性、性能或测试改进
+- 不阻塞合并
+```
+
+纯命名、格式、个人风格偏好不要作为问题提交，除非会造成真实歧义或风险。
+
+## 每个问题必须有证据
+
+一个有效 Review 问题至少包含：
+
+```text
+位置：文件 / 行或方法
+级别：P0 / P1 / P2
+依据：Requirement / Domain rule / correctness fact
+场景：什么输入或并发顺序会触发
+风险：会造成什么结果
+建议：修复方向，不必替作者重写整段代码
+测试：应补或应命中的测试
+```
+
+没有可说明的触发场景和风险，就不要凑问题。
+
+## 固定输出格式
+
+```text
+# Review Result
+
+Conclusion: PASS | CHANGES_REQUIRED
+
+## P0 Blocker
+无 / 问题列表
+
+## P1 Must Fix
+无 / 问题列表
+
+## P2 Suggestion
+无 / 问题列表
+
+## Requirement Gap
+无 / 说明
+
+## Domain Gap
+无 / 说明
+
+## Missing Tests
+无 / 说明
+```
+
+规则：
+
+- 有 P0 / P1 -> `CHANGES_REQUIRED`。
+- 只有 P2 -> 可以 `PASS`，P2 不阻塞。
+- 没发现真实问题 -> 直接 `PASS`，不要为了显得有价值硬凑问题。
+- Review 结论只基于当前需求、领域规则、代码事实和可复现风险，不猜未来需求。


### PR DESCRIPTION
## Summary

为 Realtime Sync 增加一套固定、短小的模块治理三件套：

```text
REQUIREMENTS.md  = 需要什么
DOMAIN.md        = 不能违反什么
REVIEW.md        = 怎么判卷
```

目标是让以后“帮我 Review 一下”不再依赖 AI 临场发挥，而是按固定标准检查。

## Domain Impact Analysis

```text
Aggregate(s): none
Invariant/lifecycle impact: none
Layer: docs / review governance
Domain Gap: no
```

## Changes

- 新增 `REQUIREMENTS.md`：只描述能力、边界、关键验收和安全要求，不写实现；
- 新增 `REVIEW.md`：固定 Requirement → Domain → Correctness → Compatibility → Safety → Tests 的 Review 顺序；
- 固定 P0 / P1 / P2 级别和 Review 输出格式；
- 明确 `Requirement Gap / Domain Gap`，禁止 Reviewer / AI 自行补需求；
- 明确“没有真实问题就 PASS，不为了显得有价值硬凑问题”；
- `DOMAIN.md`、模块 README、PR 模板增加三件套入口；
- Static Guard 强制三件套存在并保留核心 Review 协议；
- 增加文档预算：`REQUIREMENTS <= 150`、`DOMAIN <= 180`、`REVIEW <= 200` 行，防止再次膨胀。

## Tests / Safety

本 PR 不修改业务代码、DB、API、YAML 或 Flink/SSH 行为。

由现有 Realtime Sync Domain Guardrails 验证：

```text
Static domain contract
Framework-free core domain smoke
Backend regression hook（private token 未配置时深层 Maven/JUnit 仍会明确 skipped）
```

## Domain Compliance Report

```text
Rule changed/implemented: add fixed requirement/review contracts for stable AI review
Safety/tests: existing Stage 7 guardrails + document line budgets
Known gaps: none introduced
```
