### PR TITLE
fix: close realtime sync review safety gaps

### DIFF
--- a/tools/realtime_domain_guardrails.py
+++ b/tools/realtime_domain_guardrails.py
@@ -120,27 +120,52 @@ def check_core(g: Guard) -> None:
 
 
 def check_runtime_truth(g: Guard) -> None:
-    dao = g.read(JAVA_ROOT / "dao/impl/RealtimeJobDaoImpl.java")
+    dao_sources = "\n".join(
+        path.read_text(encoding="utf-8") for path in (JAVA_ROOT / "dao").rglob("*.java")
+    )
+    repository_sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (JAVA_ROOT / "repository").rglob("*.java")
+    )
     query = g.read(MODULE / "src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml")
     store = g.read(JAVA_ROOT / "repository/RealtimeJobStore.java")
+    baseline = g.read(
+        MODULE
+        / "src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql"
+    )
 
     for token in (
         "RealtimeJobDefinitionPO::getDesiredState",
         "RealtimeJobDefinitionPO::getObservedState",
         "RealtimeJobDefinitionPO::getLastError",
     ):
-        g.check(token not in dao, f"Task runtime dual-write reintroduced: {token}")
+        g.check(token not in dao_sources, f"Task runtime truth reintroduced in DAO layer: {token}")
 
     for token in ("d.desired_state", "d.observed_state", "d.last_error"):
         g.check(token not in query, f"Task runtime fallback reintroduced: {token}")
 
-    for method in ("desiredJobs", "hasOtherDesiredRunning", "markStarting"):
-        g.check(not re.search(rf"\b{method}\s*\(", store), f"Legacy runtime side-path reintroduced: {method}")
+    for method in (
+        "desiredJobs",
+        "hasOtherDesiredRunning",
+        "markStarting",
+        "hasActiveRealtimeJobs",
+    ):
+        text = store + repository_sources + dao_sources
+        g.check(
+            not re.search(rf"\b{method}\s*\(", text),
+            f"Legacy runtime side-path reintroduced: {method}",
+        )
 
     g.check(
         "p.definition_version_id" in query and "d.published_definition_version_id" in query,
         "publishedUpdateAvailable must compare immutable DefinitionVersion IDs",
     )
+    for column in (
+        "replacement_command_type",
+        "replacement_target_definition_version_id",
+        "replacement_idempotency_key",
+    ):
+        g.check(column in baseline, f"Replacement command intent persistence missing: {column}")
 
 
 def check_commands(g: Guard) -> None:
@@ -164,6 +189,9 @@ def check_commands(g: Guard) -> None:
 
     g.check("requirePublishedDefinition(id)" in service, "Start must resolve Published DefinitionVersion")
     g.check("prepare(id, true)" not in service, "Start must not fall back to mutable Draft")
+    g.check("reserveReplacementStop(" in service, "Replacement stop must persist command intent")
+    g.check("resumeReplacement(" in service, "Replacement command must be resumable by Idempotency-Key")
+    g.check("replacementPending()" in service, "Ordinary Start must see pending replacement intent")
 
 
 def check_semantic_names(g: Guard) -> None:

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/ComputeEnvironmentDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/ComputeEnvironmentDao.java
@@ -16,6 +16,5 @@ public interface ComputeEnvironmentDao {
   void clearDefault();
   int setDefault(long id);
   int delete(long id);
-  boolean hasBoundRealtimeJobs(long id);
-  boolean hasActiveRealtimeJobs();
+  boolean hasRuntimeEnvironmentReferences(long id);
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/RealtimeJobDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/RealtimeJobDao.java
@@ -23,6 +23,13 @@ public interface RealtimeJobDao {
   void bindDeploymentForStop(long deploymentId, String engineJobId, String runtimeRevision);
   void markDeployFailure(long definitionId, long deploymentId, boolean uncertain, boolean stopRequested, String message);
   void markStopping(long definitionId, Long deploymentId);
+  void reserveReplacementStop(
+      long definitionId,
+      long deploymentId,
+      String commandType,
+      long targetDefinitionVersionId,
+      String idempotencyKey);
+  void clearReplacementIntent(long deploymentId, String idempotencyKey);
   void reconcile(long definitionId, Long deploymentId, String observedState, String deploymentState, String engineJobId, String error);
   void markTerminalFailure(long definitionId, Long deploymentId, String message);
   List<RealtimeJobDeploymentPO> reconcileExecutions();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/ComputeEnvironmentDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/ComputeEnvironmentDaoImpl.java
@@ -3,12 +3,19 @@ package io.yak.ops.business.sync.realtime.dao.impl;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.sync.realtime.dao.ComputeEnvironmentDao;
 import io.yak.ops.business.sync.realtime.dao.mapper.ComputeEnvironmentMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeDefinitionVersionMapper;
 import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDefinitionMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDeploymentMapper;
 import io.yak.ops.business.sync.realtime.dao.model.ComputeEnvironmentPO;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeDefinitionVersionPO;
 import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
@@ -16,14 +23,23 @@ import org.springframework.stereotype.Repository;
 @DependsOn("realtimeSyncFlyway")
 public class ComputeEnvironmentDaoImpl implements ComputeEnvironmentDao {
 
+  private static final List<String> ACTIVE_EXECUTION_STATES =
+      List.of("STARTING", "RUNNING", "STOPPING", "UNKNOWN", "CONFLICT");
+
   private final ComputeEnvironmentMapper environmentMapper;
   private final RealtimeJobDefinitionMapper definitionMapper;
+  private final RealtimeDefinitionVersionMapper definitionVersionMapper;
+  private final RealtimeJobDeploymentMapper deploymentMapper;
 
   public ComputeEnvironmentDaoImpl(
       ComputeEnvironmentMapper environmentMapper,
-      RealtimeJobDefinitionMapper definitionMapper) {
+      RealtimeJobDefinitionMapper definitionMapper,
+      RealtimeDefinitionVersionMapper definitionVersionMapper,
+      RealtimeJobDeploymentMapper deploymentMapper) {
     this.environmentMapper = environmentMapper;
     this.definitionMapper = definitionMapper;
+    this.definitionVersionMapper = definitionVersionMapper;
+    this.deploymentMapper = deploymentMapper;
   }
 
   @Override
@@ -126,18 +142,65 @@ public class ComputeEnvironmentDaoImpl implements ComputeEnvironmentDao {
   }
 
   @Override
-  public boolean hasBoundRealtimeJobs(long id) {
-    return definitionMapper.selectCount(
+  public boolean hasRuntimeEnvironmentReferences(long id) {
+    if (definitionMapper.selectCount(
             Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
-                .eq(RealtimeJobDefinitionPO::getRuntimeEnvironmentId, id)) > 0;
+                .eq(RealtimeJobDefinitionPO::getRuntimeEnvironmentId, id))
+        > 0) {
+      return true;
+    }
+
+    List<Long> publishedVersionIds =
+        definitionMapper.selectList(
+                Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
+                    .isNotNull(RealtimeJobDefinitionPO::getPublishedDefinitionVersionId))
+            .stream()
+            .map(RealtimeJobDefinitionPO::getPublishedDefinitionVersionId)
+            .distinct()
+            .toList();
+    if (versionReferencesEnvironment(publishedVersionIds, id)) {
+      return true;
+    }
+
+    List<Long> pendingTargetVersionIds = latestPendingReplacementTargets();
+    if (versionReferencesEnvironment(pendingTargetVersionIds, id)) {
+      return true;
+    }
+
+    return deploymentMapper.selectCount(
+            Wrappers.<RealtimeJobDeploymentPO>lambdaQuery()
+                .eq(RealtimeJobDeploymentPO::getRuntimeEnvironmentId, id)
+                .in(RealtimeJobDeploymentPO::getObservedState, ACTIVE_EXECUTION_STATES))
+        > 0;
   }
 
-  @Override
-  public boolean hasActiveRealtimeJobs() {
-    return definitionMapper.selectCount(
-            Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
-                .and(q -> q.eq(RealtimeJobDefinitionPO::getDesiredState, "RUNNING")
-                    .or()
-                    .notIn(RealtimeJobDefinitionPO::getObservedState, List.of("STOPPED", "FAILED")))) > 0;
+  private List<Long> latestPendingReplacementTargets() {
+    List<RealtimeJobDeploymentPO> rows =
+        deploymentMapper.selectList(
+            Wrappers.<RealtimeJobDeploymentPO>lambdaQuery()
+                .orderByAsc(RealtimeJobDeploymentPO::getDefinitionId)
+                .orderByDesc(RealtimeJobDeploymentPO::getId));
+    Set<Long> seenTasks = new HashSet<>();
+    List<Long> result = new ArrayList<>();
+    for (RealtimeJobDeploymentPO row : rows) {
+      if (!seenTasks.add(row.getDefinitionId())) {
+        continue;
+      }
+      if (row.getReplacementTargetDefinitionVersionId() != null
+          && row.getReplacementIdempotencyKey() != null
+          && !row.getReplacementIdempotencyKey().isBlank()) {
+        result.add(row.getReplacementTargetDefinitionVersionId());
+      }
+    }
+    return result.stream().distinct().toList();
+  }
+
+  private boolean versionReferencesEnvironment(List<Long> versionIds, long environmentId) {
+    return !versionIds.isEmpty()
+        && definitionVersionMapper.selectCount(
+                Wrappers.<RealtimeDefinitionVersionPO>lambdaQuery()
+                    .in(RealtimeDefinitionVersionPO::getId, versionIds)
+                    .eq(RealtimeDefinitionVersionPO::getRuntimeEnvironmentId, environmentId))
+            > 0;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
@@ -153,7 +153,6 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
             .set(RealtimeJobDeploymentPO::getRuntimeVersion, runtimeRevision)
             .set(RealtimeJobDeploymentPO::getRuntimeRevision, runtimeRevision)
             .set(RealtimeJobDeploymentPO::getObservedState, "RUNNING")
-            // Physical status remains a write-only compatibility mirror in Wave 6.
             .set(RealtimeJobDeploymentPO::getStatus, "RUNNING")
             .set(RealtimeJobDeploymentPO::getResultUncertain, false)
             .set(RealtimeJobDeploymentPO::getErrorMessage, null));
@@ -212,6 +211,52 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
   }
 
   @Override
+  public void reserveReplacementStop(
+      long definitionId,
+      long deploymentId,
+      String commandType,
+      long targetDefinitionVersionId,
+      String idempotencyKey) {
+    int updated =
+        deploymentMapper.update(
+            null,
+            Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
+                .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+                .eq(RealtimeJobDeploymentPO::getDesiredState, "RUNNING")
+                .eq(RealtimeJobDeploymentPO::getObservedState, "RUNNING")
+                .eq(RealtimeJobDeploymentPO::getResultUncertain, false)
+                .isNull(RealtimeJobDeploymentPO::getReplacementIdempotencyKey)
+                .set(RealtimeJobDeploymentPO::getDesiredState, "STOPPED")
+                .set(RealtimeJobDeploymentPO::getObservedState, "STOPPING")
+                .set(RealtimeJobDeploymentPO::getStatus, "STOPPING")
+                .set(RealtimeJobDeploymentPO::getReplacementCommandType, commandType)
+                .set(
+                    RealtimeJobDeploymentPO::getReplacementTargetDefinitionVersionId,
+                    targetDefinitionVersionId)
+                .set(RealtimeJobDeploymentPO::getReplacementIdempotencyKey, idempotencyKey));
+    if (updated != 1) {
+      throw new IllegalStateException("Execution 已变化，无法预留版本替换命令：" + deploymentId);
+    }
+  }
+
+  @Override
+  public void clearReplacementIntent(long deploymentId, String idempotencyKey) {
+    int updated =
+        deploymentMapper.update(
+            null,
+            Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
+                .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                .eq(RealtimeJobDeploymentPO::getReplacementIdempotencyKey, idempotencyKey)
+                .set(RealtimeJobDeploymentPO::getReplacementCommandType, null)
+                .set(RealtimeJobDeploymentPO::getReplacementTargetDefinitionVersionId, null)
+                .set(RealtimeJobDeploymentPO::getReplacementIdempotencyKey, null));
+    if (updated != 1) {
+      throw new IllegalStateException("版本替换命令完成标记失败：" + deploymentId);
+    }
+  }
+
+  @Override
   public void reconcile(
       long definitionId,
       Long deploymentId,
@@ -251,7 +296,7 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
             Wrappers.<RealtimeJobDefinitionPO>lambdaQuery().eq(RealtimeJobDefinitionPO::getId, id));
     if (deleted != 1) return deleted;
 
-    // Audit-safe deletion remains a separate GAP-08; Wave 6 does not pretend to solve it.
+    // Audit-safe deletion remains a separate GAP; this change does not pretend to solve it.
     eventMapper.delete(
         Wrappers.<RealtimeJobEventPO>lambdaQuery()
             .eq(RealtimeJobEventPO::getDefinitionId, id));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
@@ -39,6 +39,9 @@ public class RealtimeJobDeploymentPO {
   private String status;
   private Boolean resultUncertain;
   private String errorMessage;
+  private String replacementCommandType;
+  private Long replacementTargetDefinitionVersionId;
+  private String replacementIdempotencyKey;
   private LocalDateTime createTime;
   private LocalDateTime updateTime;
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
@@ -37,6 +37,9 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
 
   private static final Pattern JOB_ID = Pattern.compile("(?i)\\b[0-9a-f]{32}\\b");
   private static final Pattern SUBMITTED_JOB_ID = Pattern.compile("(?i)Job ID:\\s*([0-9a-f]{32})");
+  private static final Pattern KEY_VALUE_SECRET =
+      Pattern.compile("(?i)((?:password|pwd|token|secret)\\s*[=:]\\s*)[^\\s,;]+");
+  private static final Pattern URL_PASSWORD = Pattern.compile("(?i)(://[^:/?#\\s]+:)[^@/?#\\s]+@");
   private static final Set<String> ACTIVE_STATES =
       Set.of(
           "CREATED",
@@ -280,16 +283,23 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
   }
 
   private String sanitizeOutput(String output, RealtimeDeployRequest request) {
+    String sanitized = redactSecretVariants(output, request.source().password());
+    sanitized = redactSecretVariants(sanitized, request.sink().password());
+    sanitized = KEY_VALUE_SECRET.matcher(sanitized).replaceAll("$1******");
+    return URL_PASSWORD.matcher(sanitized).replaceAll("$1******@");
+  }
+
+  private String redactSecretVariants(String output, char[] value) {
+    String secret = new String(value);
+    if (secret.isEmpty()) {
+      return output;
+    }
+    String yamlEscaped = secret.replace("'", "''");
     String sanitized = output;
-    String sourcePassword = new String(request.source().password());
-    String sinkPassword = new String(request.sink().password());
-    if (!sourcePassword.isEmpty()) {
-      sanitized = sanitized.replace(sourcePassword, "******");
+    if (!yamlEscaped.equals(secret)) {
+      sanitized = sanitized.replace(yamlEscaped, "******");
     }
-    if (!sinkPassword.isEmpty()) {
-      sanitized = sanitized.replace(sinkPassword, "******");
-    }
-    return sanitized;
+    return sanitized.replace(secret, "******");
   }
 
   private void sanitizeLogQuietly(Path log, RealtimeDeployRequest request) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStore.java
@@ -36,7 +36,5 @@ public interface ComputeEnvironmentStore {
 
   void delete(long id);
 
-  boolean hasBoundRealtimeJobs(long id);
-
-  boolean hasActiveRealtimeJobs();
+  boolean hasRuntimeEnvironmentReferences(long id);
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStoreAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/ComputeEnvironmentStoreAdapter.java
@@ -97,13 +97,8 @@ public class ComputeEnvironmentStoreAdapter implements ComputeEnvironmentStore {
   }
 
   @Override
-  public boolean hasBoundRealtimeJobs(long id) {
-    return dao.hasBoundRealtimeJobs(id);
-  }
-
-  @Override
-  public boolean hasActiveRealtimeJobs() {
-    return dao.hasActiveRealtimeJobs();
+  public boolean hasRuntimeEnvironmentReferences(long id) {
+    return dao.hasRuntimeEnvironmentReferences(id);
   }
 
   private ComputeEnvironment map(ComputeEnvironmentPO po) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStore.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.sync.realtime.domain.SyncExecution;
 import io.yak.ops.business.sync.realtime.domain.SyncExecution.EngineExecutionRef;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -56,6 +57,13 @@ public interface RealtimeJobStore {
   void bindDeploymentForStop(long deploymentId, String engineJobId, String runtimeRevision);
   void markDeployFailure(long definitionId, long deploymentId, boolean uncertain, boolean stopRequested, String message);
   void markStopping(long definitionId, Long deploymentId);
+  void reserveReplacementStop(
+      long definitionId,
+      long deploymentId,
+      String commandType,
+      long targetDefinitionVersionId,
+      String idempotencyKey);
+  void clearReplacementIntent(long deploymentId, String idempotencyKey);
   void reconcile(long definitionId, Long deploymentId, String observedState, String deploymentState, String engineJobId, String error);
   void markTerminalFailure(long definitionId, Long deploymentId, String message);
 
@@ -172,7 +180,8 @@ public interface RealtimeJobStore {
    * SyncExecution persistence compatibility row.
    *
    * <p>The physical table is still named yak_realtime_job_deployment. desiredState/observedState
-   * are authoritative. status/configDigest are compatibility storage names only.
+   * are authoritative. status/configDigest are compatibility storage names only. Replacement fields
+   * persist a RestartExecution/ApplyPublishedVersion intent across the STOPPED -> successor window.
    */
   record DeploymentRow(
       long id,
@@ -192,6 +201,9 @@ public interface RealtimeJobStore {
       String status,
       boolean resultUncertain,
       String errorMessage,
+      String replacementCommandType,
+      Long replacementTargetDefinitionVersionId,
+      String replacementIdempotencyKey,
       LocalDateTime createTime,
       LocalDateTime updateTime) {
 
@@ -199,6 +211,10 @@ public interface RealtimeJobStore {
       engineType = hasText(engineType) ? engineType.trim() : "FLINK_CDC";
       desiredState = hasText(desiredState) ? desiredState.trim() : legacyDesiredState(status);
       observedState = hasText(observedState) ? observedState.trim() : legacyObservedState(status);
+      replacementCommandType =
+          hasText(replacementCommandType) ? replacementCommandType.trim() : null;
+      replacementIdempotencyKey =
+          hasText(replacementIdempotencyKey) ? replacementIdempotencyKey.trim() : null;
     }
 
     /** Legacy source DraftRevision evidence; not immutable DefinitionVersionId. */
@@ -211,6 +227,20 @@ public interface RealtimeJobStore {
       return configDigest;
     }
 
+    public boolean replacementPending() {
+      return replacementCommandType != null
+          && replacementTargetDefinitionVersionId != null
+          && replacementIdempotencyKey != null;
+    }
+
+    public boolean replacementMatches(
+        String commandType, long targetDefinitionVersionId, String key) {
+      return replacementPending()
+          && Objects.equals(replacementCommandType, commandType)
+          && replacementTargetDefinitionVersionId == targetDefinitionVersionId
+          && Objects.equals(replacementIdempotencyKey, key);
+    }
+
     public SyncExecution execution() {
       return new SyncExecution(
           id,
@@ -221,6 +251,52 @@ public interface RealtimeJobStore {
           new EngineExecutionRef(engineType, engineJobId),
           resultUncertain,
           errorMessage);
+    }
+
+    /** Constructor matching the pre-replacement-intent execution row contract. */
+    public DeploymentRow(
+        long id,
+        long definitionId,
+        Long definitionVersionId,
+        int definitionVersion,
+        CdcPipelineSpec specSnapshot,
+        String specSummary,
+        String configDigest,
+        String idempotencyKey,
+        String engineJobId,
+        String runtimeRevision,
+        ComputeEnvironmentSnapshot runtimeEnvironment,
+        String engineType,
+        String desiredState,
+        String observedState,
+        String status,
+        boolean resultUncertain,
+        String errorMessage,
+        LocalDateTime createTime,
+        LocalDateTime updateTime) {
+      this(
+          id,
+          definitionId,
+          definitionVersionId,
+          definitionVersion,
+          specSnapshot,
+          specSummary,
+          configDigest,
+          idempotencyKey,
+          engineJobId,
+          runtimeRevision,
+          runtimeEnvironment,
+          engineType,
+          desiredState,
+          observedState,
+          status,
+          resultUncertain,
+          errorMessage,
+          null,
+          null,
+          null,
+          createTime,
+          updateTime);
     }
 
     /** Compatibility constructor for persisted rows created before execution lifecycle columns. */
@@ -259,6 +335,9 @@ public interface RealtimeJobStore {
           status,
           resultUncertain,
           errorMessage,
+          null,
+          null,
+          null,
           createTime,
           updateTime);
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/RealtimeJobStoreAdapter.java
@@ -132,7 +132,6 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
     po.setRuntimeEnvironmentSnapshotJson(json.write(environment));
     po.setSpecSnapshotJson(json.write(spec));
     po.setSpecSummary(summary);
-    // Physical column is still config_digest; semantically this is ExecutionArtifactDigest.
     po.setConfigDigest(artifactDigest);
     po.setIdempotencyKey(idempotencyKey);
     po.setEngineType("FLINK_CDC");
@@ -174,12 +173,33 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
       boolean uncertain,
       boolean stopRequested,
       String message) {
-    dao.markDeployFailure(definitionId, deploymentId, uncertain, stopRequested, message);
+    dao.markDeployFailure(
+        definitionId, deploymentId, uncertain, stopRequested, message);
   }
 
   @Override
   public void markStopping(long definitionId, Long deploymentId) {
     dao.markStopping(definitionId, deploymentId);
+  }
+
+  @Override
+  public void reserveReplacementStop(
+      long definitionId,
+      long deploymentId,
+      String commandType,
+      long targetDefinitionVersionId,
+      String idempotencyKey) {
+    dao.reserveReplacementStop(
+        definitionId,
+        deploymentId,
+        commandType,
+        targetDefinitionVersionId,
+        idempotencyKey);
+  }
+
+  @Override
+  public void clearReplacementIntent(long deploymentId, String idempotencyKey) {
+    dao.clearReplacementIntent(deploymentId, idempotencyKey);
   }
 
   @Override
@@ -307,7 +327,6 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
         json.readSpec(po.getSpecJson()),
         po.getRuntimeEnvironmentId(),
         po.getReleaseState(),
-        // Wave 6: Task runtime columns are inert compatibility storage, never application truth.
         "STOPPED",
         "STOPPED",
         po.getDefinitionVersion() == null ? 0 : po.getDefinitionVersion(),
@@ -338,6 +357,9 @@ public class RealtimeJobStoreAdapter implements RealtimeJobStore {
         po.getStatus(),
         Boolean.TRUE.equals(po.getResultUncertain()),
         po.getErrorMessage(),
+        po.getReplacementCommandType(),
+        po.getReplacementTargetDefinitionVersionId(),
+        po.getReplacementIdempotencyKey(),
         po.getCreateTime(),
         po.getUpdateTime());
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/repository/VersioningRealtimeJobStore.java
@@ -226,6 +226,26 @@ public class VersioningRealtimeJobStore implements RealtimeJobStore {
   }
 
   @Override
+  public void reserveReplacementStop(
+      long definitionId,
+      long deploymentId,
+      String commandType,
+      long targetDefinitionVersionId,
+      String idempotencyKey) {
+    delegate.reserveReplacementStop(
+        definitionId,
+        deploymentId,
+        commandType,
+        targetDefinitionVersionId,
+        idempotencyKey);
+  }
+
+  @Override
+  public void clearReplacementIntent(long deploymentId, String idempotencyKey) {
+    delegate.clearReplacementIntent(deploymentId, idempotencyKey);
+  }
+
+  @Override
   public void reconcile(
       long definitionId,
       Long deploymentId,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/ComputeEnvironmentService.java
@@ -179,8 +179,9 @@ public class ComputeEnvironmentService {
     if (current.defaultEnvironment()) {
       throw new IllegalStateException("默认运行环境不能删除，请先切换默认环境");
     }
-    if (store.hasBoundRealtimeJobs(id)) {
-      throw new IllegalStateException("运行环境仍被实时同步任务引用，请先将这些任务切换到其他运行环境");
+    if (store.hasRuntimeEnvironmentReferences(id)) {
+      throw new IllegalStateException(
+          "运行环境仍被实时同步 Draft、Published Version 或活动 Execution 引用，请先解除引用");
     }
     store.delete(id);
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -97,8 +97,6 @@ public class RealtimeJobService {
                 return created;
               }
               DefinitionRow locked = store.lockDefinition(id); // cross-instance command mutex
-              // Draft belongs to RealtimeSyncTask, not SyncExecution. Active executions keep their
-              // immutable DefinitionVersion and RuntimeEnvironmentSnapshot while this draft evolves.
               store.updateDefinition(
                   id,
                   name.trim(),
@@ -216,7 +214,9 @@ public class RealtimeJobService {
                       "目标 DefinitionVersion 在执行期间已变化，请刷新后重试");
                 }
 
-                SyncExecution previous = store.latestExecution(id).orElse(null);
+                DeploymentRow previousRow = store.latestDeployment(id).orElse(null);
+                requireReplacementAllowsStart(previousRow, key, prepared.definitionVersion().id(), intent);
+                SyncExecution previous = previousRow == null ? null : previousRow.execution();
                 executionStateMachine.requireNewExecutionAllowed(previous);
                 String previousDescription =
                     previous == null
@@ -280,6 +280,22 @@ public class RealtimeJobService {
     }
 
     return completeStart(id, reservation.deploymentId(), prepared, result);
+  }
+
+  private void requireReplacementAllowsStart(
+      DeploymentRow previous,
+      String key,
+      long targetDefinitionVersionId,
+      StartIntent intent) {
+    if (previous == null || !previous.replacementPending()) {
+      return;
+    }
+    if (intent == StartIntent.START) {
+      throw new IllegalStateException("已有 Restart/Apply 版本替换命令待完成，请使用原 Idempotency-Key 继续该命令");
+    }
+    if (!previous.replacementMatches(intent.name(), targetDefinitionVersionId, key)) {
+      throw new IllegalStateException("已有其他版本替换命令待完成，请使用原 Idempotency-Key 继续该命令");
+    }
   }
 
   /**
@@ -458,12 +474,16 @@ public class RealtimeJobService {
       DeploymentRow existing = idempotentDeployment(id, key);
       if (existing != null) return store.deploymentView(existing);
 
+      DeploymentRow pending = pendingReplacement(id);
+      if (pending != null) {
+        return resumeReplacement(id, key, pending, StartIntent.RESTART_EXECUTION);
+      }
+
       DeploymentRow currentRow = requireStableRunningExecutionRow(id, "重启");
       SyncExecution currentExecution = currentRow.execution();
       long targetVersionId = requireExecutionVersionId(currentExecution);
       PublishedDefinitionRow target = requireDefinitionVersion(id, targetVersionId);
 
-      // Preflight target before claiming the stop/replacement command.
       StartPrepared prepared = prepareVersion(id, target);
       gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
 
@@ -471,15 +491,18 @@ public class RealtimeJobService {
           reserveVersionReplacementStop(
               id,
               currentRow.id(),
+              targetVersionId,
+              key,
+              StartIntent.RESTART_EXECUTION,
               "RESTART_EXECUTION_STOP_REQUESTED",
               "已为同版本 RestartExecution 预留停止当前运行实例");
-      stopBoundJob(
+      return completeReplacement(
           id,
-          reserved.id(),
-          reserved.engineJobId(),
+          key,
+          prepared,
+          reserved,
+          StartIntent.RESTART_EXECUTION,
           "当前 SyncExecution 已停止，准备按原 DefinitionVersion 重启");
-      requireLatestExecutionSettled(id);
-      return startPreparedLocked(id, key, prepared, false, StartIntent.RESTART_EXECUTION);
     } finally {
       lock.unlock();
     }
@@ -494,6 +517,11 @@ public class RealtimeJobService {
       DeploymentRow existing = idempotentDeployment(id, key);
       if (existing != null) return store.deploymentView(existing);
 
+      DeploymentRow pending = pendingReplacement(id);
+      if (pending != null) {
+        return resumeReplacement(id, key, pending, StartIntent.APPLY_PUBLISHED_VERSION);
+      }
+
       DeploymentRow currentRow = requireStableRunningExecutionRow(id, "应用已发布版本");
       SyncExecution currentExecution = currentRow.execution();
       long currentVersionId = requireExecutionVersionId(currentExecution);
@@ -502,7 +530,6 @@ public class RealtimeJobService {
         throw new IllegalStateException("当前 SyncExecution 已经运行最新已发布 DefinitionVersion，无需应用");
       }
 
-      // Validate the exact target before claiming the stop/replacement command.
       StartPrepared prepared = prepareVersion(id, target);
       gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
 
@@ -510,18 +537,80 @@ public class RealtimeJobService {
           reserveVersionReplacementStop(
               id,
               currentRow.id(),
+              target.id(),
+              key,
+              StartIntent.APPLY_PUBLISHED_VERSION,
               "APPLY_PUBLISHED_VERSION_STOP_REQUESTED",
               "已为 ApplyPublishedVersion 预留停止当前运行实例");
-      stopBoundJob(
+      return completeReplacement(
           id,
-          reserved.id(),
-          reserved.engineJobId(),
+          key,
+          prepared,
+          reserved,
+          StartIntent.APPLY_PUBLISHED_VERSION,
           "当前 SyncExecution 已停止，准备应用已发布 DefinitionVersion");
-      requireLatestExecutionSettled(id);
-      return startPreparedLocked(id, key, prepared, false, StartIntent.APPLY_PUBLISHED_VERSION);
     } finally {
       lock.unlock();
     }
+  }
+
+  private DeploymentRow pendingReplacement(long taskId) {
+    DeploymentRow latest = store.latestDeployment(taskId).orElse(null);
+    return latest != null && latest.replacementPending() ? latest : null;
+  }
+
+  private RealtimeJobView.Deployment resumeReplacement(
+      long taskId, String key, DeploymentRow pending, StartIntent intent) {
+    if (!Objects.equals(pending.replacementIdempotencyKey(), key)) {
+      throw new IllegalStateException("已有版本替换命令待完成，请使用原 Idempotency-Key 继续该命令");
+    }
+    if (!Objects.equals(pending.replacementCommandType(), intent.name())) {
+      throw new IllegalStateException("该 Idempotency-Key 已绑定另一种版本替换命令");
+    }
+    Long targetVersionId = pending.replacementTargetDefinitionVersionId();
+    if (targetVersionId == null) {
+      throw new IllegalStateException("待恢复的版本替换命令缺少目标 DefinitionVersionId");
+    }
+
+    PublishedDefinitionRow target = requireDefinitionVersion(taskId, targetVersionId);
+    StartPrepared prepared = prepareVersion(taskId, target);
+    gateway.validate(prepared.runtimeEnvironment(), prepared.compiled().yaml());
+    return completeReplacement(
+        taskId,
+        key,
+        prepared,
+        pending,
+        intent,
+        intent == StartIntent.RESTART_EXECUTION
+            ? "当前 SyncExecution 已停止，继续按原 DefinitionVersion 重启"
+            : "当前 SyncExecution 已停止，继续应用已固定的 Published DefinitionVersion");
+  }
+
+  private RealtimeJobView.Deployment completeReplacement(
+      long taskId,
+      String key,
+      StartPrepared prepared,
+      DeploymentRow source,
+      StartIntent intent,
+      String stoppedMessage) {
+    DeploymentRow latest = requireCurrentExecutionRow(taskId, source.id());
+    SyncExecution execution = latest.execution();
+    String observed = execution.observedState().name();
+
+    if ("UNKNOWN".equals(observed) || "CONFLICT".equals(observed)) {
+      throw new IllegalStateException("版本替换 Execution 状态不确定，请先执行状态对账");
+    }
+    if ("STOPPING".equals(observed)) {
+      if (!StringUtils.hasText(latest.engineJobId())) {
+        throw new IllegalStateException("版本替换 Execution 缺少 EngineExecutionRef，请先执行状态对账");
+      }
+      stopBoundJob(taskId, latest.id(), latest.engineJobId(), stoppedMessage);
+    } else if (!"STOPPED".equals(observed)) {
+      throw new IllegalStateException("版本替换命令只能从 STOPPING/STOPPED 状态继续，请先执行状态对账");
+    }
+
+    requireLatestExecutionSettled(taskId);
+    return startPreparedLocked(taskId, key, prepared, false, intent);
   }
 
   public void delete(long id) {
@@ -629,6 +718,9 @@ public class RealtimeJobService {
     DeploymentRow row =
         store.latestDeployment(taskId)
             .orElseThrow(() -> new IllegalStateException("当前没有可" + action + "的 SyncExecution"));
+    if (row.replacementPending()) {
+      throw new IllegalStateException("已有版本替换命令待完成，请使用原 Idempotency-Key 继续该命令");
+    }
     SyncExecution execution = row.execution();
     requireStableRunningExecution(execution, action);
     if (!execution.engineExecutionRef().bound() || !StringUtils.hasText(row.engineJobId())) {
@@ -652,12 +744,17 @@ public class RealtimeJobService {
 
   /**
    * Linearization point for RestartExecution / ApplyPublishedVersion across multiple Yak instances.
-   * The expensive target preflight is intentionally done before this reservation. Once this
-   * transaction marks the expected execution STOPPING, this version command owns the replacement;
-   * a competing Stop/version command that won first makes this reservation fail instead.
+   * The target and Idempotency-Key are persisted on the source execution in the same transaction as
+   * RUNNING -> STOPPING, so a STOPPED source still blocks unrelated Start and the command can resume.
    */
   private DeploymentRow reserveVersionReplacementStop(
-      long taskId, long expectedExecutionId, String eventType, String message) {
+      long taskId,
+      long expectedExecutionId,
+      long targetDefinitionVersionId,
+      String key,
+      StartIntent intent,
+      String eventType,
+      String message) {
     DeploymentRow reserved =
         transactions.execute(
             status -> {
@@ -674,7 +771,8 @@ public class RealtimeJobService {
                 throw new IllegalStateException("当前 SyncExecution 缺少 EngineExecutionRef，请先执行状态对账");
               }
               executionStateMachine.requireTransition(execution, "STOPPING");
-              store.markStopping(taskId, latest.id());
+              store.reserveReplacementStop(
+                  taskId, latest.id(), intent.name(), targetDefinitionVersionId, key);
               store.event(
                   taskId,
                   latest.id(),

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V1__baseline_realtime_sync.sql
@@ -84,6 +84,9 @@ CREATE TABLE IF NOT EXISTS yak_realtime_job_deployment (
     status VARCHAR(32) NOT NULL,
     result_uncertain TINYINT(1) NOT NULL DEFAULT 0,
     error_message TEXT NULL,
+    replacement_command_type VARCHAR(32) NULL,
+    replacement_target_definition_version_id BIGINT NULL,
+    replacement_idempotency_key VARCHAR(128) NULL,
     create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
     PRIMARY KEY (id),
@@ -92,7 +95,8 @@ CREATE TABLE IF NOT EXISTS yak_realtime_job_deployment (
     KEY idx_realtime_deployment_definition (definition_id, id),
     KEY idx_realtime_deployment_definition_version (definition_version_id, id),
     KEY idx_realtime_execution_state (definition_id, observed_state, id),
-    KEY idx_realtime_deployment_environment (runtime_environment_id)
+    KEY idx_realtime_deployment_environment (runtime_environment_id),
+    KEY idx_realtime_replacement_pending (definition_id, replacement_idempotency_key, id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS yak_realtime_job_event (

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/RealtimeArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/RealtimeArchitectureTest.java
@@ -100,6 +100,9 @@ class RealtimeArchitectureTest {
     assertThat(storeMethods)
         .doesNotContain("desiredJobs", "hasOtherDesiredRunning", "markStarting");
 
+    Set<String> environmentMethods = methodNames(ComputeEnvironmentStore.class);
+    assertThat(environmentMethods).doesNotContain("hasActiveRealtimeJobs");
+
     Set<String> serviceMethods = methodNames(RealtimeJobService.class);
     assertThat(serviceMethods)
         .contains("restartExecution", "applyPublishedVersion")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/dao/impl/ComputeEnvironmentDaoImplReferenceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/dao/impl/ComputeEnvironmentDaoImplReferenceTest.java
@@ -1,0 +1,92 @@
+package io.yak.ops.business.sync.realtime.dao.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.dao.mapper.ComputeEnvironmentMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeDefinitionVersionMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDefinitionMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDeploymentMapper;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ComputeEnvironmentDaoImplReferenceTest {
+
+  private RealtimeJobDefinitionMapper definitionMapper;
+  private RealtimeDefinitionVersionMapper definitionVersionMapper;
+  private RealtimeJobDeploymentMapper deploymentMapper;
+  private ComputeEnvironmentDaoImpl dao;
+
+  @BeforeEach
+  void setUp() {
+    ComputeEnvironmentMapper environmentMapper = mock(ComputeEnvironmentMapper.class);
+    definitionMapper = mock(RealtimeJobDefinitionMapper.class);
+    definitionVersionMapper = mock(RealtimeDefinitionVersionMapper.class);
+    deploymentMapper = mock(RealtimeJobDeploymentMapper.class);
+    dao =
+        new ComputeEnvironmentDaoImpl(
+            environmentMapper, definitionMapper, definitionVersionMapper, deploymentMapper);
+  }
+
+  @Test
+  void publishedDefinitionReferencePreventsEnvironmentDeletionAfterDraftMovesElsewhere() {
+    RealtimeJobDefinitionPO task = new RealtimeJobDefinitionPO();
+    task.setPublishedDefinitionVersionId(31L);
+
+    when(definitionMapper.selectCount(any())).thenReturn(0L);
+    when(definitionMapper.selectList(any())).thenReturn(List.of(task));
+    when(definitionVersionMapper.selectCount(any())).thenReturn(1L);
+
+    assertThat(dao.hasRuntimeEnvironmentReferences(3L)).isTrue();
+  }
+
+  @Test
+  void activeExecutionReferencePreventsEnvironmentDeletion() {
+    when(definitionMapper.selectCount(any())).thenReturn(0L);
+    when(definitionMapper.selectList(any())).thenReturn(List.of());
+    when(deploymentMapper.selectList(any())).thenReturn(List.of());
+    when(deploymentMapper.selectCount(any())).thenReturn(1L);
+
+    assertThat(dao.hasRuntimeEnvironmentReferences(3L)).isTrue();
+  }
+
+  @Test
+  void latestPendingReplacementTargetPreventsEnvironmentDeletion() {
+    RealtimeJobDeploymentPO pending = new RealtimeJobDeploymentPO();
+    pending.setId(19L);
+    pending.setDefinitionId(7L);
+    pending.setReplacementTargetDefinitionVersionId(32L);
+    pending.setReplacementIdempotencyKey("apply-v4");
+
+    when(definitionMapper.selectCount(any())).thenReturn(0L);
+    when(definitionMapper.selectList(any())).thenReturn(List.of());
+    when(deploymentMapper.selectList(any())).thenReturn(List.of(pending));
+    when(definitionVersionMapper.selectCount(any())).thenReturn(1L);
+
+    assertThat(dao.hasRuntimeEnvironmentReferences(3L)).isTrue();
+  }
+
+  @Test
+  void historicalReplacementIntentDoesNotBlockAfterNewerExecutionExists() {
+    RealtimeJobDeploymentPO current = new RealtimeJobDeploymentPO();
+    current.setId(20L);
+    current.setDefinitionId(7L);
+    RealtimeJobDeploymentPO historical = new RealtimeJobDeploymentPO();
+    historical.setId(19L);
+    historical.setDefinitionId(7L);
+    historical.setReplacementTargetDefinitionVersionId(32L);
+    historical.setReplacementIdempotencyKey("apply-v4");
+
+    when(definitionMapper.selectCount(any())).thenReturn(0L);
+    when(definitionMapper.selectList(any())).thenReturn(List.of());
+    when(deploymentMapper.selectList(any())).thenReturn(List.of(current, historical));
+    when(deploymentMapper.selectCount(any())).thenReturn(0L);
+
+    assertThat(dao.hasRuntimeEnvironmentReferences(3L)).isFalse();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGatewayTest.java
@@ -135,12 +135,44 @@ class FlinkCdcEngineGatewayTest {
     }
   }
 
+  @Test
+  void redactsRawAndYamlEscapedSecretsBeforeRetainingCliOutput() throws Exception {
+    Path cli = temp.resolve("flink-cdc/bin/flink-cdc.sh");
+    Files.writeString(
+        cli,
+        "#!/bin/sh\ncat \"$1\"\necho \"connector rejected password=source''secret\"\nexit 7\n",
+        StandardCharsets.UTF_8);
+    Files.setPosixFilePermissions(cli, PosixFilePermissions.fromString("rwx------"));
+
+    try (RealtimeDeployRequest request =
+        request(pipelineYaml(), "escaped-secret", "source'secret", "sink'secret")) {
+      assertThatThrownBy(() -> gateway.deploy(environment, request))
+          .isInstanceOf(RealtimeEngineException.class)
+          .hasMessageNotContaining("source'secret")
+          .hasMessageNotContaining("source''secret")
+          .hasMessageNotContaining("sink'secret")
+          .hasMessageNotContaining("sink''secret");
+    }
+
+    String retained =
+        Files.readString(
+            temp.resolve("work/logs/submit-escaped-secret.log"), StandardCharsets.UTF_8);
+    assertThat(retained)
+        .contains("password: ******")
+        .doesNotContain("source'secret", "source''secret", "sink'secret", "sink''secret");
+  }
+
   private RealtimeDeployRequest request(String yaml, String key) {
+    return request(yaml, key, "source-secret", "sink-secret");
+  }
+
+  private RealtimeDeployRequest request(
+      String yaml, String key, String sourcePassword, String sinkPassword) {
     return new RealtimeDeployRequest(
         yaml,
         key,
-        new RealtimeDeployRequest.CredentialBinding("source", "source-secret"),
-        new RealtimeDeployRequest.CredentialBinding("sink", "sink-secret"));
+        new RealtimeDeployRequest.CredentialBinding("source", sourcePassword),
+        new RealtimeDeployRequest.CredentialBinding("sink", sinkPassword));
   }
 
   private String pipelineYaml() {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeReplacementRecoveryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeReplacementRecoveryTest.java
@@ -1,0 +1,221 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.ValidationResult;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RealtimeReplacementRecoveryTest {
+
+  private static final long TASK_ID = 7L;
+  private static final long SOURCE_EXECUTION_ID = 19L;
+  private static final long V3_ID = 31L;
+  private static final long V4_ID = 32L;
+
+  private RealtimeJobStore store;
+  private RealtimeDataSourceResolver dataSourceResolver;
+  private PipelineYamlCompiler compiler;
+  private RealtimeEngineGateway gateway;
+  private RealtimeRuntimeResolver runtimeResolver;
+  private RealtimeJobService service;
+  private ComputeEnvironmentSnapshot environment;
+  private CdcPipelineSpec v4Spec;
+  private DefinitionRow task;
+  private PublishedDefinitionRow v4;
+  private DeploymentRow pendingApply;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    CdcPipelineSpecValidator specValidator = mock(CdcPipelineSpecValidator.class);
+    dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    RealtimeConnectorCapabilityResolver capabilityResolver =
+        mock(RealtimeConnectorCapabilityResolver.class);
+    compiler = mock(PipelineYamlCompiler.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    environment = environment();
+    v4Spec = spec("orders_v4");
+    task = task();
+    v4 = version(V4_ID, 4, v4Spec);
+    pendingApply = pendingApply();
+
+    service =
+        new RealtimeJobService(
+            store,
+            new ObjectMapper(),
+            specValidator,
+            new SyncExecutionStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
+
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+    CompiledPipeline compiled = new CompiledPipeline("pipeline: v4", "v4");
+    when(store.definition(TASK_ID)).thenReturn(Optional.of(task));
+    when(runtimeResolver.environment(environment.id(), true)).thenReturn(environment);
+    when(dataSourceResolver.resolve(v4Spec)).thenReturn(resolved);
+    when(gateway.capabilities(environment)).thenReturn(new ObjectMapper().createObjectNode());
+    when(compiler.compile("orders-sync", v4Spec, resolved)).thenReturn(compiled);
+    when(gateway.validate(environment, compiled.yaml()))
+        .thenReturn(new ValidationResult(true, "at-least-once"));
+    when(store.lockDefinition(TASK_ID)).thenReturn(task);
+  }
+
+  @Test
+  void ordinaryStartCannotStealSuccessorSlotFromStoppedPendingReplacement() {
+    when(store.deploymentByIdempotencyKey("plain-start")).thenReturn(Optional.empty());
+    when(store.publishedDefinition(TASK_ID)).thenReturn(Optional.of(v4));
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(pendingApply));
+
+    assertThatThrownBy(() -> service.start(TASK_ID, "plain-start"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("版本替换");
+
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void sameIdempotencyKeyResumesStoppedApplyUsingPersistedTargetVersion() {
+    when(store.deploymentByIdempotencyKey("apply-resume")).thenReturn(Optional.empty());
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(pendingApply));
+    when(store.latestExecution(TASK_ID)).thenReturn(Optional.of(pendingApply.execution()));
+    when(store.definitionVersion(TASK_ID, V4_ID)).thenReturn(Optional.of(v4));
+    when(store.insertDeployment(
+            any(), eq(v4Spec), any(), any(), eq(environment), eq("apply-resume")))
+        .thenThrow(new IllegalStateException("successor-insert-reached"));
+
+    assertThatThrownBy(() -> service.applyPublishedVersion(TASK_ID, "apply-resume"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("successor-insert-reached");
+
+    verify(store, never()).publishedDefinition(TASK_ID);
+    verify(store).definitionVersion(TASK_ID, V4_ID);
+    verify(store)
+        .insertDeployment(any(), eq(v4Spec), any(), any(), eq(environment), eq("apply-resume"));
+  }
+
+  private DeploymentRow pendingApply() {
+    return new DeploymentRow(
+        SOURCE_EXECUTION_ID,
+        TASK_ID,
+        V3_ID,
+        3,
+        spec("orders_v3"),
+        "v3",
+        "d".repeat(64),
+        "old-execution-key",
+        "job-v3",
+        environment.runtimeRevision(),
+        environment,
+        "FLINK_CDC",
+        "STOPPED",
+        "STOPPED",
+        "STOPPED",
+        false,
+        null,
+        "APPLY_PUBLISHED_VERSION",
+        V4_ID,
+        "apply-resume",
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private DefinitionRow task() {
+    return new DefinitionRow(
+        TASK_ID,
+        "orders-sync",
+        null,
+        v4Spec,
+        environment.id(),
+        "PUBLISHED",
+        "STOPPED",
+        "STOPPED",
+        4,
+        4,
+        V4_ID,
+        "c".repeat(64),
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private PublishedDefinitionRow version(long id, int versionNo, CdcPipelineSpec spec) {
+    return new PublishedDefinitionRow(
+        id,
+        TASK_ID,
+        versionNo,
+        versionNo,
+        spec,
+        environment.id(),
+        "a".repeat(64),
+        "b".repeat(64));
+  }
+
+  private static ComputeEnvironmentSnapshot environment() {
+    return new ComputeEnvironmentSnapshot(
+        3L,
+        "test-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
+        2);
+  }
+
+  private static CdcPipelineSpec spec(String table) {
+    return new CdcPipelineSpec(
+        1L,
+        2L,
+        List.of(
+            new CdcPipelineSpec.TableRoute(
+                table, "ods_" + table, CdcPipelineSpec.MatchMode.EXACT, List.of("id"))),
+        "initial",
+        CdcPipelineSpec.SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new CdcPipelineSpec.RestartPolicy("fixed-delay", 3, 10_000),
+        new CdcPipelineSpec.SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandRaceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandRaceTest.java
@@ -106,9 +106,9 @@ class RealtimeWave5VersionCommandRaceTest {
     ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
     CompiledPipeline compiled = new CompiledPipeline("pipeline: v4", "v4");
     when(store.deploymentByIdempotencyKey("apply-race")).thenReturn(Optional.empty());
-    // First read is command preflight. Second read is the DB-lock reservation after another Stop won.
+    // Initial pending check + stable read see RUNNING; DB-lock reservation sees competing Stop.
     when(store.latestDeployment(taskId))
-        .thenReturn(Optional.of(running), Optional.of(stopAlreadyWon));
+        .thenReturn(Optional.of(running), Optional.of(running), Optional.of(stopAlreadyWon));
     when(store.publishedDefinition(taskId)).thenReturn(Optional.of(published));
     when(store.definition(taskId)).thenReturn(Optional.of(task));
     when(store.lockDefinition(taskId)).thenReturn(task);
@@ -136,7 +136,8 @@ class RealtimeWave5VersionCommandRaceTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("请先对账");
 
-    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never())
+        .reserveReplacementStop(anyLong(), anyLong(), any(), anyLong(), any());
     verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
     verify(gateway, never()).stop(any(), any());
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeWave5VersionCommandTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
@@ -124,7 +123,7 @@ class RealtimeWave5VersionCommandTest {
     verify(store, never()).publishedDefinition(TASK_ID);
     verify(compiler).compile("orders-sync", v3Spec, resolved);
     verify(compiler, never()).compile(eq("orders-sync"), eq(v4Spec), any());
-    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never()).reserveReplacementStop(anyLong(), anyLong(), any(), anyLong(), any());
     verify(gateway, never()).stop(any(), any());
   }
 
@@ -152,7 +151,7 @@ class RealtimeWave5VersionCommandTest {
 
     verify(store).publishedDefinition(TASK_ID);
     verify(compiler).compile("orders-sync", v4Spec, resolved);
-    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never()).reserveReplacementStop(anyLong(), anyLong(), any(), anyLong(), any());
     verify(gateway, never()).stop(any(), any());
   }
 
@@ -170,7 +169,7 @@ class RealtimeWave5VersionCommandTest {
         .hasMessageContaining("已经运行最新已发布");
 
     verify(compiler, never()).compile(any(), any(), any());
-    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never()).reserveReplacementStop(anyLong(), anyLong(), any(), anyLong(), any());
   }
 
   @Test
@@ -193,21 +192,14 @@ class RealtimeWave5VersionCommandTest {
         .hasMessageContaining("请先对账");
 
     verify(store, never()).definitionVersion(anyLong(), anyLong());
-    verify(store, never()).markStopping(anyLong(), any());
+    verify(store, never()).reserveReplacementStop(anyLong(), anyLong(), any(), anyLong(), any());
   }
 
   @Test
   void restartExecutionCreatesNewExecutionBoundToSameImmutableVersion() {
     DeploymentRow running = runningRow(V3_ID, v3Spec, "job-v3");
-    DeploymentRow stopping =
-        executionRow(
-            V3_ID,
-            v3Spec,
-            "job-v3",
-            DesiredState.STOPPED,
-            ObservedState.STOPPING,
-            false,
-            "STOPPING");
+    DeploymentRow stopping = replacementRow(DesiredState.STOPPED, ObservedState.STOPPING, "STOPPING");
+    DeploymentRow stopped = replacementRow(DesiredState.STOPPED, ObservedState.STOPPED, "STOPPED");
     DeploymentRow newStarting =
         executionRowWithId(
             NEW_EXECUTION_ID,
@@ -239,6 +231,9 @@ class RealtimeWave5VersionCommandTest {
             Optional.of(running),
             Optional.of(running),
             Optional.of(stopping),
+            Optional.of(stopping),
+            Optional.of(stopping),
+            Optional.of(stopped),
             Optional.of(newStarting),
             Optional.of(newRunning));
     when(store.definitionVersion(TASK_ID, V3_ID)).thenReturn(Optional.of(v3));
@@ -273,6 +268,13 @@ class RealtimeWave5VersionCommandTest {
     assertThatCode(() -> service.restartExecution(TASK_ID, "restart-success"))
         .doesNotThrowAnyException();
 
+    verify(store)
+        .reserveReplacementStop(
+            TASK_ID,
+            OLD_EXECUTION_ID,
+            "RESTART_EXECUTION",
+            V3_ID,
+            "restart-success");
     verify(store).bindDeploymentDefinitionVersion(NEW_EXECUTION_ID, V3_ID, 3);
     verify(store, never()).publishedDefinition(TASK_ID);
     verify(gateway).stop(environment, "job-v3");
@@ -322,6 +324,33 @@ class RealtimeWave5VersionCommandTest {
         ObservedState.RUNNING,
         false,
         "RUNNING");
+  }
+
+  private DeploymentRow replacementRow(
+      DesiredState desired, ObservedState observed, String status) {
+    return new DeploymentRow(
+        OLD_EXECUTION_ID,
+        TASK_ID,
+        V3_ID,
+        3,
+        v3Spec,
+        "test",
+        "d".repeat(64),
+        "old-execution-key",
+        "job-v3",
+        environment.runtimeRevision(),
+        environment,
+        "FLINK_CDC",
+        desired.name(),
+        observed.name(),
+        status,
+        false,
+        null,
+        "RESTART_EXECUTION",
+        V3_ID,
+        "restart-success",
+        LocalDateTime.now(),
+        LocalDateTime.now());
   }
 
   private DeploymentRow executionRow(


### PR DESCRIPTION
## Summary

修复按 `REQUIREMENTS.md / DOMAIN.md / REVIEW.md` 全量 Review 后确认的 4 个问题：

- P0：提交日志可能保留 YAML 转义后的 Secret；
- P1：Restart/Apply 在 source Execution 已 STOPPED、successor 尚未创建时缺少可恢复的持久化 reservation；
- P1：Runtime Environment 删除只检查当前 Draft，可能删断 Published Version / Active Execution / pending replacement target；
- P1：移除 `hasActiveRealtimeJobs()` 对 Task legacy runtime state 的错误依赖。

## Domain Impact Analysis

```text
Aggregate(s): SyncExecution; DefinitionVersion / RuntimeEnvironmentRef
Invariant/lifecycle impact:
- pending replacement 在 source STOPPED 后仍保持持久化证据
- 普通 Start 不能抢占 pending Restart/Apply 的 successor slot
- 相同 Idempotency-Key 可继续原 replacement command，target DefinitionVersion 不漂移
- Runtime Environment 不能删断 Draft / Published / Active Execution / current pending replacement 引用
Layer: Application / Persistence / Engine / Test
Domain Gap: no
```

## Changes

### Secret safety
- retained submission log 同时脱敏 raw Secret 与 YAML single-quote escaped Secret；
- 再叠加 password/pwd/token/secret 与 URL credential 通用 redaction；
- 新增包含单引号密码且 CLI 直接输出 Pipeline YAML 的回归测试。

### Durable replacement intent
- `yak_realtime_job_deployment` 增加 replacement command type / target DefinitionVersionId / Idempotency-Key；
- RUNNING -> STOPPING reservation 与 replacement intent 在同一 DB command 中持久化；
- Restart/Apply 若检测到 pending intent，使用原 Idempotency-Key + 已固定 target Version 恢复；
- 普通 Start 遇到 pending replacement 时拒绝抢占；
- intent 作为 source Execution 历史证据保留，只有 latest Execution 上的 intent 被视为当前 pending command。

### Runtime Environment reference protection
删除前检查：
- current Draft ref；
- current Published DefinitionVersion ref；
- Active / Uncertain Execution ref；
- latest pending replacement target DefinitionVersion ref。

### Execution-only runtime truth
- 删除 `hasActiveRealtimeJobs()` / `hasBoundRealtimeJobs()` 旧接口；
- Static Guard 扩展为扫描整个 realtime DAO/repository 层，禁止 Task `desired/observed/lastError` 再成为运行真相。

## Tests / Safety

新增/更新：

```text
FlinkCdcEngineGatewayTest
RealtimeReplacementRecoveryTest
ComputeEnvironmentDaoImplReferenceTest
RealtimeWave5VersionCommandTest
RealtimeWave5VersionCommandRaceTest
RealtimeArchitectureTest
Static Domain Guard
```

重点覆盖：
- raw + YAML-escaped Secret 均不进入 retained log；
- STOPPED pending replacement 阻止普通 Start；
- 同 key 从 STOPPED source 恢复 Apply，继续已固定 Version；
- Published / Active Execution / pending replacement target 保护 Runtime Environment；
- 历史 replacement intent 在已有 successor 后不永久阻止环境删除；
- Task runtime truth 旁路不能重新引入。

Schema 仍遵循本模块 consolidated V1 约定，本 PR 不新增 API/YAML 业务语义。

## Domain Compliance Report

```text
Rule changed/implemented:
- reinforce existing replacement-stop reservation, SyncExecution-only runtime truth and secret-free retained logs
Safety/tests:
- add regression coverage for all four review findings
Known gaps:
- Archive/Tombstone, ExecutionPolicy runtime application, FINISHED/snapshot-only 等既有 Gap 不在本 PR 扩展
```
