### PR TITLE
docs: define offline sync core domain model

### DIFF
--- a/docs/offline-sync/domain/README.md
+++ b/docs/offline-sync/domain/README.md
@@ -1,145 +1,214 @@
-# Offline Sync Domain — Stage 1
+# Offline Sync Domain
 
-> 目标：先统一边界和语言，不在本阶段决定最终 Aggregate、数据库结构或 Java 类型。
+> 当前阶段：Stage 2。只定义核心模型，不决定数据库结构或 Java 实现。
 
 ## 1. 领域使命
 
-离线同步领域负责描述：
-
-> **一份数据从哪里读取、按什么同步定义写入哪里，以及一次手动、调度或外部触发如何形成可追踪、可重试、可取消的离线执行。**
-
-离线同步的核心不是“某个 Link-Up Job”，而是 **Task Definition → Trigger → Execution Snapshot → Offline Execution**。
+> **描述一份数据从哪里读取、按什么定义写入哪里，以及一次手动、调度、工作流或补数触发如何形成可追踪、可重试、可取消的离线批次。**
 
 ```text
 OfflineSyncTask
       │ trigger
       ▼
-ExecutionSnapshot
-      │
-      ▼
-OfflineExecution
-      │ submit / reconcile / cancel
-      ▼
-Engine Adapter
+BatchExecution
+      ├── ExecutionSnapshot
+      ├── BatchScope
+      └── ExecutionAttempt 1..N
+                │
+                ▼
+          Engine Adapter
 ```
 
-## 2. 领域边界
+核心不是 Link-Up Job。
 
-### 本领域负责
+## 2. 核心模型
 
-- 离线同步任务及其可编辑同步定义；
-- 来源、目标、表选择/映射及读写策略；
-- 手动、定时、工作流等执行触发；
-- 每次执行使用的配置快照；
-- 执行状态、取消、失败重试和执行历史；
-- 执行指标、事件及外部引擎执行引用；
-- 任务级调度策略，但不负责调度器实现。
+### OfflineSyncTask
 
-### 本领域不负责
-
-- 数据源密码、JDBC 连接等凭据的长期存储；
-- 数据源生命周期管理；
-- Quartz / Yak Schedule 的实现细节；
-- Link-Up 节点、Worker、Connector 注册和调度；
-- 工作流 DAG 编排；
-- 将 Link-Up Job、Worker 或 HTTP 协议对象作为核心领域对象；
-- 数据开发中的通用 SQL/ETL 编排能力。
-
-## 3. 已确认统一语言
-
-| 术语 | 含义 |
-| --- | --- |
-| `OfflineSyncTask` | 用户长期维护的一项离线同步任务。Task 不等于某次执行。 |
-| `SyncDefinition` | 描述来源、目标、选择/映射和同步策略的业务定义。编辑器 JSON、JobSpec 都只是其表现或投影。 |
-| `SourceEndpoint` | 来源端业务引用。连接凭据属于 DataSource 上下文，不进入核心定义。 |
-| `SinkEndpoint` | 目标端业务引用。 |
-| `SyncRoute` | 一组来源选择到目标写入的映射关系。单表/多表优先由 Route/Selector 组合表达。 |
-| `SchedulePolicy` | 任务“什么时候触发”的业务策略；Quartz/Yak Schedule 只是基础设施。 |
-| `ExecutionTrigger` | 创建一次执行的原因，例如 `MANUAL`、`SCHEDULE`、`WORKFLOW`、`RETRY`。 |
-| `OfflineExecution` | 一次具体离线执行。它拥有自己的状态和执行证据，不是 Task 的运行字段。 |
-| `ExecutionSnapshot` | Execution 创建时固定的定义/执行配置证据；后续修改 Task 不应改写已有执行。 |
-| `EngineExecutionRef` | 对外部执行引擎实例的引用，例如 Link-Up JobId；引擎标识不是领域主键。 |
-| `IdempotencyKey` | 同一执行请求的幂等身份，用于避免重复创建/提交。 |
-| `RetryPolicy` | 失败后是否重试、最大次数和退避等规则。 |
-| `ExecutionEvent` | 执行状态变化和关键操作的历史证据。 |
-
-## 4. 当前执行状态语言
-
-当前实现已经稳定使用：
+用户长期维护的一项离线同步任务。
 
 ```text
-CREATED -> SUBMITTED -> QUEUED -> RUNNING
-                                  ├-> SUCCEEDED
-                                  ├-> FAILED
-                                  ├-> CANCELED
-                                  └-> LOST
+OfflineSyncTask
+├── TaskId / TaskProfile
+├── SyncDefinition
+├── SchedulePolicy?
+├── RetryPolicy
+└── DefinitionRevision
 ```
 
-Stage 1 只确认这些词用于描述当前执行状态；完整状态迁移规则留到 Stage 3。
+### BatchExecution
 
-## 5. 暂不定型的候选概念
+一次明确的**业务批次**。
 
-以下概念对离线同步很重要，但 **Stage 1 不直接定成最终模型**：
+```text
+BatchExecution
+├── BatchExecutionId
+├── TaskId
+├── ExecutionTrigger
+├── BatchScope
+├── ExecutionSnapshot
+└── ExecutionAttempt 1..N
+```
 
-| 候选概念 | Stage 2 要回答的问题 |
-| --- | --- |
-| `DefinitionVersion` | 当前 `version` 是修订号还是应升级为不可变发布版本？ |
-| `BatchScope` / `DataWindow` | 一次执行是否必须明确“处理哪段业务数据”？ |
-| `BatchExecution` | 是否需要把“一个业务批次”与技术执行实例分开？ |
-| `ExecutionAttempt` | `attemptNo/retryFromExecutionId` 是否应成为独立 Attempt 模型？ |
-| `Backfill` | 补历史数据是普通触发、批次集合还是独立业务动作？ |
-| `IncrementalCursor` | 增量位置属于 Definition、BatchScope 还是 Execution 证据？ |
-| `PartitionScope` | 分区范围是否是 BatchScope 的一种表达？ |
+### ExecutionAttempt
 
-如果 Stage 2 无法自然解释这些场景，应记录为 `Domain Gap`，不要先增加 `syncType/sceneType`。
+同一批次的一次实际提交尝试。
 
-## 6. 现有代码的临时对照
+```text
+ExecutionAttempt
+├── AttemptNo
+├── IdempotencyKey
+├── AttemptReason
+├── ExecutionStatus
+├── EngineExecutionRef?
+├── Metrics / Error
+└── StartedAt / EndedAt
+```
 
-这只是帮助阅读当前代码，**不是最终模型承诺**：
+因此：
+
+```text
+Task != BatchExecution != ExecutionAttempt
+
+Batch B100
+├── Attempt 1 FAILED
+├── Attempt 2 FAILED
+└── Attempt 3 SUCCEEDED
+```
+
+业务上仍然只有一个 B100。
+
+## 3. 关键决策
+
+### Retry
+
+```text
+ExecutionTrigger:
+MANUAL | SCHEDULE | WORKFLOW | BACKFILL
+
+AttemptReason:
+INITIAL | RETRY
+```
+
+Retry 创建新 Attempt，不创建新 Batch。
+
+### ExecutionSnapshot
+
+Batch 创建时冻结：
+
+```text
+ExecutionSnapshot
+├── SyncDefinition Snapshot
+├── DefinitionRevision
+├── RetryPolicy Snapshot
+└── ConfigDigest
+```
+
+Retry 必须继续使用同一 Snapshot，不能重新读取当前 Task。
+
+### 暂不引入 immutable DefinitionVersion
+
+当前采用：
+
+```text
+mutable Task Definition
+      │ create batch
+      ▼
+immutable ExecutionSnapshot
+```
+
+`DefinitionRevision` 只是修订标识，不是历史定义的 Source of Truth。
+
+只有未来明确需要“上线 V3 同时编辑 V4”或“任意重跑历史 V3”时，再把 immutable `DefinitionVersion` 作为 Domain Gap 单独设计。
+
+### BatchScope
+
+`BatchScope` 回答：**这个批次处理哪部分数据？**
+
+候选表达：
+
+```text
+FullSelection | DataWindow | PartitionScope | CursorRange
+```
+
+它不是 `syncType/sceneType`。具体范围和游标规则留到 Stage 3。
+
+### SyncDefinition
+
+```text
+SyncDefinition
+├── SourceEndpoint
+├── SinkEndpoint
+├── SyncRoute[]
+├── ReadPolicy
+└── WritePolicy
+```
+
+编辑器 JSON 是表现形式，Link-Up JobSpec 是执行适配产物，DataSource 凭据不进入定义。`GUIDE_SINGLE/GUIDE_MULTI` 不进入核心模型。
+
+## 4. 四个场景验证
+
+```text
+A. 手动执行
+Task T1 -> Batch B1 -> Attempt 1
+
+B. 每日调度
+08-22 -> Batch B22 -> Attempt 1
+08-23 -> Batch B23 -> Attempt 1
+
+C. 失败重试
+Batch B22
+├ Attempt 1 FAILED
+└ Attempt 2 SUCCEEDED
+
+D. 历史补数
+Scope 08-01 -> Batch B01
+Scope 08-02 -> Batch B02
+Scope 08-03 -> Batch B03
+```
+
+补数创建一组 Batch，不创建 `BACKFILL_TASK` 类型；同一次补数应优先固定同一份 ExecutionSnapshot。
+
+## 5. 当前代码的目标映射
 
 ```text
 OfflineJobDefinition
-≈ Task + mutable definition + schedule + last execution summary
+≈ OfflineSyncTask + SyncDefinition + SchedulePolicy
+  + legacy last-execution projection
 
 OfflineJobExecution
-≈ OfflineExecution + snapshot + retry metadata + engine evidence
+≈ BatchExecution + ExecutionAttempt
+  + ExecutionSnapshot + Engine evidence
 
-OfflineSchedule
-≈ SchedulePolicy 的查询/持久化投影
-
-OfflineExecutionOrchestrator
-= Application orchestration
-
-LinkUpClient / LinkUpJobSpecFactory
-= Infrastructure / Engine Adapter
+attemptNo / retryFromExecutionId
+≈ 当前代码尚未拆开的 Attempt 线索
 ```
 
-当前 `OfflineJobDefinition` 混合了多个关注点，后续 Stage 4 再决定哪些 KEEP / ADAPT / MIGRATE。
+这是 Stage 4 的输入，不代表现在就改代码。
 
-## 7. Stage 1 语言规则
+## 6. Stage 2 硬规则
 
-1. `Task != Execution`。
-2. 外部 Engine Job 不等于 `OfflineExecution`。
-3. Execution 必须能保留自己的执行快照，不能靠回读当前 Task 解释历史。
-4. Quartz、Yak Schedule、Link-Up、Worker、HTTP DTO 不进入核心领域语言。
-5. 数据源凭据只在执行边界解析，不成为 SyncDefinition 的长期事实。
-6. `GUIDE_SINGLE / GUIDE_MULTI` 属于当前交互/配置模式，不定义为不同的业务 Task 类型。
-7. 全量、增量、单表、多表优先尝试用 Scope / Route / Policy 组合表达，不先创造 `sceneType/syncType`。
-8. Retry 不应改写已经结束的执行历史；是否引入 `ExecutionAttempt` 留给 Stage 2 验证。
-9. 实时同步与离线同步暂时保持独立 Core，不因为名字相似提前抽 Shared Sync Kernel。
-10. 新需求无法映射到上述语言时，先记 `Domain Gap`，不要直接编码。
+1. `Task != BatchExecution != ExecutionAttempt`。
+2. Retry 创建新 Attempt，不创建新 Batch。
+3. Batch 创建后固定 ExecutionSnapshot。
+4. Retry 不得回读当前 Task 改变 Snapshot。
+5. `DefinitionRevision` 不等于 immutable DefinitionVersion。
+6. `BatchScope` 描述数据范围，不增加 `sceneType/syncType`。
+7. 单表/多表由 Route/Selector 组合表达。
+8. Backfill 生成多个 Batch，不创造新的 Task 类型。
+9. Engine Job 只是 Attempt 的外部引用。
+10. 实时同步与离线同步继续保持独立 Core。
 
-## 8. Stage 2 输入
+## 7. Stage 3 输入
 
-下一阶段只做核心模型设计，并用以下场景验证：
+下一阶段只定义生命周期和不变量：
 
-```text
-A. 单表手动执行
-B. 每日定时执行
-C. 失败后重试
-D. 历史补数
-```
+- BatchExecution / ExecutionAttempt 状态；
+- 什么时候允许创建下一 Attempt；
+- LOST / uncertain 如何处理；
+- 同一 Task 是否允许多个 Batch 并行；
+- Schedule 重复触发如何幂等；
+- Backfill 如何固定 Snapshot；
+- BatchScope / CursorRange 的边界。
 
-Stage 2 的重点不是“照搬实时同步”，而是回答：
-
-> **离线同步的一次业务批次、一次执行、一次重试，到底是不是同一个东西？**
+这些问题没有结论前，不修改数据库和执行代码。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -2,9 +2,9 @@
 
 ## 领域建设
 
-离线同步正在按独立领域逐步建模。Stage 1 只定义边界和统一语言，不改变现有实现：
+离线同步正在按独立领域逐步建模。当前已完成 Stage 2：核心领域模型；暂不改变现有实现：
 
-- [Offline Sync Domain — Stage 1](../../../docs/offline-sync/domain/README.md)
+- [Offline Sync Domain](../../../docs/offline-sync/domain/README.md)
 
 离线同步一期只承担三件事：任务配置、Link-Up 执行代理、执行历史。
 


### PR DESCRIPTION
## Summary

完成离线同步领域建设 Stage 2：核心领域模型。仅更新领域文档，不修改 Java、数据库、API、YAML 或现有运行行为。

## Core model

```text
OfflineSyncTask
      │ trigger
      ▼
BatchExecution
      ├── ExecutionSnapshot
      ├── BatchScope
      └── ExecutionAttempt 1..N
                │
                ▼
          Engine Adapter
```

核心结论：

- `Task != BatchExecution != ExecutionAttempt`；
- Retry 不创建新业务批次，只为原 Batch 创建新的 Attempt；
- Batch 创建时冻结 `ExecutionSnapshot`，Retry 不得回读当前 Task；
- `BatchScope` 描述“这个批次处理哪部分数据”，不增加 `sceneType/syncType`；
- Backfill 是创建一组 Batch 的业务动作，不创建新的 Task 类型；
- Engine Job 只是 Attempt 的外部引用。

## Definition decision

Stage 2 暂不照搬实时同步的 immutable `DefinitionVersion`。

当前模型采用：

```text
mutable Task Definition
      │ create batch
      ▼
immutable ExecutionSnapshot
```

`DefinitionRevision` 仅作为修订标识，不是历史定义的 Source of Truth。

只有未来明确需要“上线 V3 同时编辑 V4”或“任意重跑历史 V3”时，再把 immutable DefinitionVersion 作为 Domain Gap 单独设计。

## Scenario validation

```text
A. 手动执行
Task -> Batch -> Attempt 1

B. 每日调度
每次触发 -> 新 Batch -> Attempt 1

C. 失败重试
原 Batch -> Attempt 2

D. 历史补数
多个 BatchScope -> 多个 Batch
```

四个场景均能在当前模型内表达，不需要新增 scene/sync 类型。

## Current code mapping input

```text
OfflineJobDefinition
≈ OfflineSyncTask + SyncDefinition + SchedulePolicy
  + legacy last-execution projection

OfflineJobExecution
≈ BatchExecution + ExecutionAttempt
  + ExecutionSnapshot + Engine evidence
```

这里只作为后续 Stage 4 的映射输入，本 PR 不重构现有代码。

## Next

Stage 3 只定义生命周期和不变量：

- BatchExecution / ExecutionAttempt 状态；
- Retry 条件；
- LOST / uncertain；
- 同 Task 多 Batch 并发；
- Schedule 幂等；
- Backfill Snapshot；
- BatchScope / CursorRange 边界。

## Validation

Documentation-only change. No Java / DB / API / YAML behavior changes.