### PR TITLE
docs: define offline sync domain constitution

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
@@ -1,0 +1,98 @@
+# Offline Sync Domain
+
+> 本文件是离线同步模块的当前领域约束。设计过程与迁移分析见 `docs/offline-sync/domain/README.md`。
+
+## Mission
+
+离线同步负责：定义一项离线同步任务，并把手动、调度、工作流或补数触发转换成可追踪、可重试、可取消的业务批次。
+
+```text
+OfflineSyncTask
+      │ trigger
+      ▼
+BatchExecution
+      ├── BatchKey
+      ├── BatchScope
+      ├── ExecutionSnapshot
+      └── ExecutionAttempt 1..N
+                │
+                ▼
+          Engine Adapter
+```
+
+核心关系：`Task != Batch != Attempt`。
+
+## Hard Rules
+
+1. `OfflineSyncTask` 是长期配置；`BatchExecution` 是一次业务批次；`ExecutionAttempt` 是一次实际提交。
+2. Retry 创建新 Attempt，不创建新 Batch。
+3. Batch 创建时冻结 `ExecutionSnapshot`；Retry 不得回读 current Task 改变 Snapshot。
+4. Retry 必须保持同一个 Batch、BatchScope、ExecutionSnapshot 和 RetryPolicy Snapshot。
+5. `UNKNOWN != FAILED`；结果不确定时必须先 reconcile，禁止盲目 Retry。
+6. Batch 终态后不再追加 Attempt；再次运行同一数据范围应创建新 Batch。
+7. V1 同一个 Task 最多一个 `RUNNING / WAITING_RETRY / UNKNOWN` Batch；并发需求变化必须先定义 `ConcurrencyPolicy`。
+8. 每个 Batch 必须有稳定 `BatchKey`；Schedule 使用 `scheduleId + plannedFireTime`，不能使用实际回调时间。
+9. `BatchScope` 描述数据范围；不得用 `sceneType/syncType` 代替 Scope / Route / Policy。
+10. Backfill 创建一组 Batch，不创建新的 Task 类型；同一次 Backfill 优先共享同一 Snapshot。
+11. Cursor 只允许在 Batch `SUCCEEDED` 后推进；`FAILED / CANCELED / UNKNOWN` 不得推进。
+12. Task `last-*` 只能作为查询投影；运行真相只能来自 Batch / Attempt。
+13. `DefinitionRevision` 只是修订标识，不等于 immutable `DefinitionVersion`。
+14. Link-Up Job / Worker / Quartz / HTTP DTO / DataSource credential 都不是 Core Domain 对象。
+15. SyncDefinition / Snapshot 不长期保存密码；凭据只在 Attempt 提交边界解析。
+16. 实时同步和离线同步保持独立 Core；不得因为名字相似提前抽 Shared Sync Kernel。
+
+## Domain Impact Analysis
+
+修改离线同步代码前，必须先回答：
+
+1. 变化属于 Task、Batch、Attempt、Scope、Snapshot 还是 Policy？
+2. 是否改变 Batch / Attempt 生命周期？
+3. 是否改变 Retry、UNKNOWN、Cancel 或并发语义？
+4. 是否改变 BatchKey / 幂等身份？
+5. 是否让 Retry 回读 current Task 或 current SchedulePolicy？
+6. 是否把 Task `last-*`、Engine 状态或外部 JobId 当成领域真相？
+7. 是否引入新的 `sceneType/syncType`、技术类型或凭据泄漏？
+8. 是否能映射现有模型？不能映射则记录 `Domain Gap`，先设计再编码。
+
+## Current Transition
+
+当前代码尚未完全满足上述目标模型。已确认的主要 Domain Debt：
+
+```text
+OfflineJobExecution = Batch + Attempt 混合
+retryFrom()          = 回读 current Task
+configureRetry()     = 回读 current RetryPolicy
+LOST                  = 当前会自动 Retry，应迁移为 UNKNOWN 语义
+Schedule              = 缺少稳定 BatchKey
+Task last-*           = 仍部分参与生命周期判断
+```
+
+这些问题按迁移波次处理，不允许临时建立第二套真相：
+
+```text
+Wave 0  Core VO + compatibility mapper
+Wave 1  Batch persistence + execution.bind(batch_id)
+Wave 2  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
+Wave 3  Retry / UNKNOWN + durable retry reservation
+Wave 4  Runtime truth -> Batch/Attempt; Task last-* projection only
+Wave 5  Backfill / Cursor
+Wave 6  Legacy cleanup
+```
+
+迁移原则：`expand -> dual read/write -> switch -> verify -> contract`。
+
+## Forbidden Shortcuts
+
+禁止：
+
+- 把 Retry 实现成一次新的普通 execute；
+- 把 UNKNOWN/LOST 直接当 FAILED 自动重试；
+- 用 `hasActiveExecution()` 代替 Batch 级并发和 reservation；
+- 用 actual callback time 作为 Schedule Batch 身份；
+- 让 Attempt 自己重新生成 Snapshot；
+- 用 Task `lastJobStatus` 决定真实运行状态；
+- 把 Link-Up JobSpec、Worker、Connector、Quartz 类型放进 Core Domain；
+- 为“全量/增量/单表/多表/补数”继续增加任务类型枚举；
+- 为了和 realtime 一致而提前增加 immutable DefinitionVersion 或 Shared Sync Kernel。
+
+如果需求无法在本模型内表达：`Domain Gap -> STOP -> 先补领域设计`。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -2,9 +2,10 @@
 
 ## 领域建设
 
-离线同步正在按独立领域逐步建模。当前已完成 Stage 4：现有代码到目标领域映射；暂不改变现有实现：
+离线同步当前已完成 Stage 5：领域约束已收敛为短小 `DOMAIN.md`。修改代码前先读当前规则，需要迁移背景时再看 Mapping 文档：
 
-- [Offline Sync Domain](../../../docs/offline-sync/domain/README.md)
+- [DOMAIN.md](./DOMAIN.md)
+- [Domain Mapping](../../../docs/offline-sync/domain/README.md)
 
 离线同步一期只承担三件事：任务配置、Link-Up 执行代理、执行历史。
 


### PR DESCRIPTION
## Summary

完成离线同步 Stage 5：新增短小 `DOMAIN.md`，把 Stage 1~4 已确认的领域规则变成 AI / 开发者修改代码前必须遵守的当前约束。

本 PR 只改文档，不修改 Java、数据库、API、YAML 或运行行为。

## DOMAIN.md

当前核心模型：

```text
OfflineSyncTask
      │ trigger
      ▼
BatchExecution
      ├── BatchKey
      ├── BatchScope
      ├── ExecutionSnapshot
      └── ExecutionAttempt 1..N
```

核心规则包括：

- `Task != Batch != Attempt`；
- Retry 创建新 Attempt，不创建新 Batch；
- Retry 固定原 Batch / Scope / Snapshot / RetryPolicy；
- `UNKNOWN != FAILED`，UNKNOWN 禁止盲目 Retry；
- Schedule BatchKey 使用 `scheduleId + plannedFireTime`；
- Task `last-*` 只做查询投影；
- Cursor 只在 Batch SUCCEEDED 后推进；
- 不新增 `sceneType/syncType`；
- 不提前引入 immutable DefinitionVersion 或 Shared Sync Kernel。

## Domain Impact Analysis

`DOMAIN.md` 要求每次修改代码前先回答 8 个问题：变化属于哪个领域对象、是否改变生命周期/Retry/幂等、是否回读 current Task、是否泄漏技术类型/凭据，以及是否存在 `Domain Gap`。

无法映射现有模型时：

```text
Domain Gap -> STOP -> 先补领域设计
```

## Transition boundary

文档明确区分“目标规则”和“当前尚未迁完的 Domain Debt”，避免 AI 误以为当前实现已经满足目标模型，也禁止跨 Wave 临时建立第二套真相。

```text
Wave 0  Core VO + compatibility mapper
Wave 1  Batch persistence + execution.bind(batch_id)
Wave 2  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
Wave 3  Retry / UNKNOWN + durable retry reservation
Wave 4  Runtime truth -> Batch/Attempt
Wave 5  Backfill / Cursor
Wave 6  Legacy cleanup
```

## Files

- 新增 `yak-ops-business-sync-offline/DOMAIN.md`（98 行）
- 模块 README 第一屏改为：开发前先读 `DOMAIN.md`，需要迁移背景再读 Mapping 文档

## Next

Stage 6 从 Wave 0 开始做最小增量代码重构：先引入 Core VO 和 compatibility mapper，不直接动完整执行链。

## Validation

Documentation-only change. No Java / DB / API / YAML behavior changes.