### PR TITLE
feat: establish offline sync wave 0 domain core

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
@@ -67,16 +67,18 @@ Schedule              = 缺少稳定 BatchKey
 Task last-*           = 仍部分参与生命周期判断
 ```
 
+Wave 0 已完成 Core VO 与兼容映射；现有执行链和数据库仍保持原行为，不得把“Core 已存在”理解成迁移已经完成。
+
 这些问题按迁移波次处理，不允许临时建立第二套真相：
 
 ```text
-Wave 0  Core VO + compatibility mapper
-Wave 1  Batch persistence + execution.bind(batch_id)
-Wave 2  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
-Wave 3  Retry / UNKNOWN + durable retry reservation
-Wave 4  Runtime truth -> Batch/Attempt; Task last-* projection only
-Wave 5  Backfill / Cursor
-Wave 6  Legacy cleanup
+Wave 0  DONE  Core VO + compatibility mapper
+Wave 1  NEXT  Batch persistence + execution.bind(batch_id)
+Wave 2        Trigger -> Batch -> Attempt 1 + Schedule BatchKey
+Wave 3        Retry / UNKNOWN + durable retry reservation
+Wave 4        Runtime truth -> Batch/Attempt; Task last-* projection only
+Wave 5        Backfill / Cursor
+Wave 6        Legacy cleanup
 ```
 
 迁移原则：`expand -> dual read/write -> switch -> verify -> contract`。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -2,7 +2,7 @@
 
 ## 领域建设
 
-离线同步当前已完成 Stage 5：领域约束已收敛为短小 `DOMAIN.md`。修改代码前先读当前规则，需要迁移背景时再看 Mapping 文档：
+离线同步当前已完成 Stage 6 Wave 0：Core VO + compatibility mapper。现有执行链和数据库尚未切换；修改代码前先读当前规则，需要迁移背景时再看 Mapping 文档：
 
 - [DOMAIN.md](./DOMAIN.md)
 - [Domain Mapping](../../../docs/offline-sync/domain/README.md)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapper.java
@@ -1,0 +1,134 @@
+package io.yak.ops.business.sync.offline.domain.compat;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.AttemptMetrics;
+import io.yak.ops.business.sync.offline.domain.core.AttemptReason;
+import io.yak.ops.business.sync.offline.domain.core.AttemptStatus;
+import io.yak.ops.business.sync.offline.domain.core.EngineExecutionRef;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Transitional mapper from the current execution model to Wave 0 core types.
+ *
+ * <p>This mapper deliberately does not synthesize BatchExecution, BatchKey or BatchScope because
+ * the legacy row does not contain stable batch identity. Wave 1 will provide persisted Batch
+ * identity.
+ */
+public final class LegacyOfflineExecutionCompatibilityMapper {
+
+  private LegacyOfflineExecutionCompatibilityMapper() {}
+
+  public static ExecutionAttempt toAttempt(OfflineJobExecution source) {
+    Objects.requireNonNull(source, "legacy execution 不能为空");
+    return new ExecutionAttempt(
+        source.getId(),
+        positive(source.getAttemptNo(), "attemptNo"),
+        reason(source),
+        requireText(source.getIdempotencyKey(), "idempotencyKey 不能为空"),
+        requireText(source.getExternalExecutionId(), "externalExecutionId 不能为空"),
+        status(source.getStatus()),
+        engineRef(source),
+        metrics(source),
+        source.getErrorMessage(),
+        Objects.requireNonNull(source.getCreateTime(), "createTime 不能为空"),
+        source.getStartTime(),
+        source.getEndTime());
+  }
+
+  /**
+   * Builds the Batch-owned snapshot without reading current Task or SchedulePolicy.
+   *
+   * <p>The retry policy must be supplied by the caller from frozen batch evidence; this mapper
+   * never falls back to current task configuration.
+   */
+  public static ExecutionSnapshot toSnapshot(
+      OfflineJobExecution source, RetryPolicySnapshot retryPolicy) {
+    Objects.requireNonNull(source, "legacy execution 不能为空");
+    Objects.requireNonNull(retryPolicy, "retryPolicy 不能为空");
+    return new ExecutionSnapshot(
+        requireText(source.getDefinitionSnapshotJson(), "definitionSnapshot 不能为空"),
+        positive(source.getDefinitionVersion(), "definitionVersion"),
+        retryPolicy,
+        requireText(source.getConfigDigest(), "configDigest 不能为空"));
+  }
+
+  static AttemptStatus status(String value) {
+    if (value == null || value.trim().isEmpty()) return AttemptStatus.CREATED;
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    return switch (normalized) {
+      case "CREATED" -> AttemptStatus.CREATED;
+      case "SUBMITTED" -> AttemptStatus.SUBMITTED;
+      case "QUEUED" -> AttemptStatus.QUEUED;
+      case "RUNNING" -> AttemptStatus.RUNNING;
+      case "SUCCEEDED", "FINISHED", "COMPLETED" -> AttemptStatus.SUCCEEDED;
+      case "FAILED" -> AttemptStatus.FAILED;
+      case "CANCELED", "CANCELLED" -> AttemptStatus.CANCELED;
+      case "CANCELING", "CANCELLING" -> AttemptStatus.CANCELING;
+      case "LOST" -> AttemptStatus.UNKNOWN;
+      default -> AttemptStatus.UNKNOWN;
+    };
+  }
+
+  private static AttemptReason reason(OfflineJobExecution source) {
+    return value(source.getAttemptNo(), 1) > 1
+            || source.getRetryFromExecutionId() != null
+            || "RETRY".equalsIgnoreCase(source.getTriggerType())
+        ? AttemptReason.RETRY
+        : AttemptReason.INITIAL;
+  }
+
+  private static EngineExecutionRef engineRef(OfflineJobExecution source) {
+    String jobId = trim(source.getEngineJobId());
+    String workerId = trim(source.getWorkerInstanceId());
+    return jobId == null && workerId == null ? null : new EngineExecutionRef(jobId, workerId);
+  }
+
+  private static AttemptMetrics metrics(OfflineJobExecution source) {
+    return new AttemptMetrics(
+        value(source.getSourceRecordCount(), 0L),
+        value(source.getSinkAttemptedRecordCount(), 0L),
+        value(source.getSinkSuccessRecordCount(), 0L),
+        value(source.getSinkCommittedRecordCount(), 0L),
+        value(source.getSourceReadBytes(), 0L),
+        value(source.getSinkWrittenBytes(), 0L),
+        value(source.getSourceAverageQps(), 0D),
+        value(source.getSinkAverageQps(), 0D),
+        value(source.getFailedRecordCount(), 0L),
+        value(source.getSkippedRecordCount(), 0L),
+        value(source.getDatabaseCommitMillis(), 0L),
+        value(source.getSqlExecutionMillis(), 0L),
+        value(source.getQps(), 0D),
+        value(source.getDurationMillis(), 0L));
+  }
+
+  private static int positive(Integer value, String field) {
+    if (value == null || value < 1) throw new IllegalArgumentException(field + " 必须大于 0");
+    return value;
+  }
+
+  private static int value(Integer value, int fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private static long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private static double value(Double value, double fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private static String trim(String value) {
+    return value == null || value.trim().isEmpty() ? null : value.trim();
+  }
+
+  private static String requireText(String value, String message) {
+    String normalized = trim(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/AttemptMetrics.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/AttemptMetrics.java
@@ -1,0 +1,50 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+/** Runtime evidence retained by an ExecutionAttempt. */
+public record AttemptMetrics(
+    long sourceRecordCount,
+    long sinkAttemptedRecordCount,
+    long sinkSuccessRecordCount,
+    long sinkCommittedRecordCount,
+    long sourceReadBytes,
+    long sinkWrittenBytes,
+    double sourceAverageQps,
+    double sinkAverageQps,
+    long failedRecordCount,
+    long skippedRecordCount,
+    long databaseCommitMillis,
+    long sqlExecutionMillis,
+    double qps,
+    long durationMillis) {
+
+  public AttemptMetrics {
+    requireNonNegative(sourceRecordCount, "sourceRecordCount");
+    requireNonNegative(sinkAttemptedRecordCount, "sinkAttemptedRecordCount");
+    requireNonNegative(sinkSuccessRecordCount, "sinkSuccessRecordCount");
+    requireNonNegative(sinkCommittedRecordCount, "sinkCommittedRecordCount");
+    requireNonNegative(sourceReadBytes, "sourceReadBytes");
+    requireNonNegative(sinkWrittenBytes, "sinkWrittenBytes");
+    requireNonNegative(sourceAverageQps, "sourceAverageQps");
+    requireNonNegative(sinkAverageQps, "sinkAverageQps");
+    requireNonNegative(failedRecordCount, "failedRecordCount");
+    requireNonNegative(skippedRecordCount, "skippedRecordCount");
+    requireNonNegative(databaseCommitMillis, "databaseCommitMillis");
+    requireNonNegative(sqlExecutionMillis, "sqlExecutionMillis");
+    requireNonNegative(qps, "qps");
+    requireNonNegative(durationMillis, "durationMillis");
+  }
+
+  public static AttemptMetrics empty() {
+    return new AttemptMetrics(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  }
+
+  private static void requireNonNegative(long value, String field) {
+    if (value < 0) throw new IllegalArgumentException(field + " 不能小于 0");
+  }
+
+  private static void requireNonNegative(double value, String field) {
+    if (Double.isNaN(value) || Double.isInfinite(value) || value < 0) {
+      throw new IllegalArgumentException(field + " 必须是非负有限数");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/AttemptReason.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/AttemptReason.java
@@ -1,0 +1,6 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+public enum AttemptReason {
+  INITIAL,
+  RETRY
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/AttemptStatus.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/AttemptStatus.java
@@ -1,0 +1,23 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+/** Target lifecycle state for one execution attempt. */
+public enum AttemptStatus {
+  CREATED,
+  SUBMITTING,
+  SUBMITTED,
+  QUEUED,
+  RUNNING,
+  SUCCEEDED,
+  FAILED,
+  CANCELING,
+  CANCELED,
+  UNKNOWN;
+
+  public boolean isTerminal() {
+    return this == SUCCEEDED || this == FAILED || this == CANCELED;
+  }
+
+  public boolean blocksNextAttempt() {
+    return !isTerminal();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchExecution.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchExecution.java
@@ -1,0 +1,39 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Aggregate root for one business batch. */
+public record BatchExecution(
+    Long id,
+    long taskId,
+    BatchKey batchKey,
+    BatchTrigger trigger,
+    BatchScope batchScope,
+    ExecutionSnapshot snapshot,
+    BatchStatus status,
+    List<ExecutionAttempt> attempts) {
+
+  public BatchExecution {
+    if (id != null && id <= 0) throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    if (taskId <= 0) throw new IllegalArgumentException("TaskId 必须大于 0");
+    batchKey = Objects.requireNonNull(batchKey, "BatchKey 不能为空");
+    trigger = Objects.requireNonNull(trigger, "BatchTrigger 不能为空");
+    batchScope = Objects.requireNonNull(batchScope, "BatchScope 不能为空");
+    snapshot = Objects.requireNonNull(snapshot, "ExecutionSnapshot 不能为空");
+    status = Objects.requireNonNull(status, "BatchStatus 不能为空");
+    attempts = List.copyOf(Objects.requireNonNull(attempts, "attempts 不能为空"));
+    for (int index = 0; index < attempts.size(); index++) {
+      ExecutionAttempt attempt = Objects.requireNonNull(attempts.get(index), "Attempt 不能为空");
+      int expected = index + 1;
+      if (attempt.attemptNo() != expected) {
+        throw new IllegalArgumentException("AttemptNo 必须从 1 开始连续递增");
+      }
+    }
+  }
+
+  public Optional<ExecutionAttempt> latestAttempt() {
+    return attempts.isEmpty() ? Optional.empty() : Optional.of(attempts.get(attempts.size() - 1));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchKey.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchKey.java
@@ -1,0 +1,51 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Objects;
+
+/** Stable business identity for one offline batch inside a task. */
+public record BatchKey(String value) {
+
+  public BatchKey {
+    value = requireText(value, "BatchKey 不能为空");
+  }
+
+  public static BatchKey manual(String requestId) {
+    return new BatchKey("manual:" + encode(requireText(requestId, "requestId 不能为空")));
+  }
+
+  public static BatchKey schedule(String scheduleId, Instant plannedFireTime) {
+    Objects.requireNonNull(plannedFireTime, "plannedFireTime 不能为空");
+    return new BatchKey(
+        "schedule:"
+            + encode(requireText(scheduleId, "scheduleId 不能为空"))
+            + ":"
+            + encode(plannedFireTime.toString()));
+  }
+
+  public static BatchKey workflow(String executionIdentity) {
+    return new BatchKey(
+        "workflow:" + encode(requireText(executionIdentity, "workflow identity 不能为空")));
+  }
+
+  public static BatchKey backfill(String requestId, String scopeFingerprint) {
+    return new BatchKey(
+        "backfill:"
+            + encode(requireText(requestId, "backfillRequestId 不能为空"))
+            + ":"
+            + encode(requireText(scopeFingerprint, "scopeFingerprint 不能为空")));
+  }
+
+  private static String encode(String value) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchScope.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchScope.java
@@ -1,0 +1,137 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable data range owned by a BatchExecution. */
+public sealed interface BatchScope
+    permits BatchScope.FullSelection,
+        BatchScope.DataWindow,
+        BatchScope.PartitionScope,
+        BatchScope.CursorRange {
+
+  String canonicalValue();
+
+  default String fingerprint() {
+    try {
+      return HexFormat.of()
+          .formatHex(
+              MessageDigest.getInstance("SHA-256")
+                  .digest(canonicalValue().getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成 BatchScope fingerprint 失败", exception);
+    }
+  }
+
+  static FullSelection fullSelection() {
+    return new FullSelection();
+  }
+
+  static DataWindow dataWindow(LocalDateTime startInclusive, LocalDateTime endExclusive) {
+    return new DataWindow(startInclusive, endExclusive);
+  }
+
+  static PartitionScope partitions(List<String> partitions) {
+    return new PartitionScope(partitions);
+  }
+
+  static CursorRange cursorRange(
+      String cursorId, String afterExclusive, String throughInclusive) {
+    return new CursorRange(cursorId, afterExclusive, throughInclusive);
+  }
+
+  record FullSelection() implements BatchScope {
+    @Override
+    public String canonicalValue() {
+      return "FULL_SELECTION";
+    }
+  }
+
+  record DataWindow(LocalDateTime startInclusive, LocalDateTime endExclusive)
+      implements BatchScope {
+
+    public DataWindow {
+      startInclusive = Objects.requireNonNull(startInclusive, "startInclusive 不能为空");
+      endExclusive = Objects.requireNonNull(endExclusive, "endExclusive 不能为空");
+      if (!startInclusive.isBefore(endExclusive)) {
+        throw new IllegalArgumentException("DataWindow 必须满足 start < end");
+      }
+    }
+
+    @Override
+    public String canonicalValue() {
+      return "DATA_WINDOW|" + startInclusive + "|" + endExclusive;
+    }
+  }
+
+  record PartitionScope(List<String> partitions) implements BatchScope {
+
+    public PartitionScope {
+      Objects.requireNonNull(partitions, "partitions 不能为空");
+      List<String> normalized =
+          partitions.stream()
+              .map(PartitionScope::requirePartition)
+              .distinct()
+              .sorted(Comparator.naturalOrder())
+              .toList();
+      if (normalized.isEmpty()) throw new IllegalArgumentException("PartitionScope 不能为空");
+      partitions = List.copyOf(normalized);
+    }
+
+    @Override
+    public String canonicalValue() {
+      return "PARTITIONS|"
+          + partitions.stream()
+              .map(BatchScope::encode)
+              .reduce((left, right) -> left + "," + right)
+              .orElse("");
+    }
+
+    private static String requirePartition(String value) {
+      if (value == null || value.trim().isEmpty()) {
+        throw new IllegalArgumentException("partition 不能为空");
+      }
+      return value.trim();
+    }
+  }
+
+  record CursorRange(String cursorId, String afterExclusive, String throughInclusive)
+      implements BatchScope {
+
+    public CursorRange {
+      cursorId = requireText(cursorId, "cursorId 不能为空");
+      afterExclusive = requireText(afterExclusive, "afterExclusive 不能为空");
+      throughInclusive = requireText(throughInclusive, "throughInclusive 不能为空");
+      if (afterExclusive.equals(throughInclusive)) {
+        throw new IllegalArgumentException("CursorRange 起止位置不能相同");
+      }
+    }
+
+    @Override
+    public String canonicalValue() {
+      return "CURSOR_RANGE|"
+          + encode(cursorId)
+          + "|"
+          + encode(afterExclusive)
+          + "|"
+          + encode(throughInclusive);
+    }
+  }
+
+  private static String encode(String value) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchStatus.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchStatus.java
@@ -1,0 +1,20 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+/** Business lifecycle state for one offline batch. */
+public enum BatchStatus {
+  PENDING,
+  RUNNING,
+  WAITING_RETRY,
+  SUCCEEDED,
+  FAILED,
+  CANCELED,
+  UNKNOWN;
+
+  public boolean isTerminal() {
+    return this == SUCCEEDED || this == FAILED || this == CANCELED;
+  }
+
+  public boolean occupiesTaskExecutionSlot() {
+    return this == RUNNING || this == WAITING_RETRY || this == UNKNOWN;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchTrigger.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchTrigger.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+/** Business reason that created a BatchExecution. Retry is an AttemptReason, not a BatchTrigger. */
+public enum BatchTrigger {
+  MANUAL,
+  SCHEDULE,
+  WORKFLOW,
+  BACKFILL
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/EngineExecutionRef.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/EngineExecutionRef.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+/** Generic evidence that links an Attempt to an external engine execution. */
+public record EngineExecutionRef(String jobId, String workerInstanceId) {
+
+  public EngineExecutionRef {
+    jobId = trim(jobId);
+    workerInstanceId = trim(workerInstanceId);
+    if (jobId == null && workerInstanceId == null) {
+      throw new IllegalArgumentException("EngineExecutionRef 至少需要一个外部标识");
+    }
+  }
+
+  private static String trim(String value) {
+    return value == null || value.trim().isEmpty() ? null : value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/ExecutionAttempt.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/ExecutionAttempt.java
@@ -1,0 +1,36 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/** One concrete submission attempt inside a BatchExecution. */
+public record ExecutionAttempt(
+    Long id,
+    int attemptNo,
+    AttemptReason reason,
+    String idempotencyKey,
+    String externalExecutionId,
+    AttemptStatus status,
+    EngineExecutionRef engineExecutionRef,
+    AttemptMetrics metrics,
+    String errorMessage,
+    LocalDateTime createdAt,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt) {
+
+  public ExecutionAttempt {
+    if (id != null && id <= 0) throw new IllegalArgumentException("AttemptId 必须大于 0");
+    if (attemptNo < 1) throw new IllegalArgumentException("attemptNo 必须大于 0");
+    reason = Objects.requireNonNull(reason, "reason 不能为空");
+    idempotencyKey = requireText(idempotencyKey, "idempotencyKey 不能为空");
+    externalExecutionId = requireText(externalExecutionId, "externalExecutionId 不能为空");
+    status = Objects.requireNonNull(status, "status 不能为空");
+    metrics = Objects.requireNonNull(metrics, "metrics 不能为空");
+    createdAt = Objects.requireNonNull(createdAt, "createdAt 不能为空");
+  }
+
+  private static String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/ExecutionSnapshot.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/ExecutionSnapshot.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+import java.util.Objects;
+
+/** Immutable task definition evidence shared by all attempts in one batch. */
+public record ExecutionSnapshot(
+    String definitionSnapshot,
+    int definitionRevision,
+    RetryPolicySnapshot retryPolicy,
+    String configDigest) {
+
+  public ExecutionSnapshot {
+    definitionSnapshot = requireText(definitionSnapshot, "definitionSnapshot 不能为空");
+    if (definitionRevision < 1) {
+      throw new IllegalArgumentException("definitionRevision 必须大于 0");
+    }
+    retryPolicy = Objects.requireNonNull(retryPolicy, "retryPolicy 不能为空");
+    configDigest = requireText(configDigest, "configDigest 不能为空");
+  }
+
+  private static String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/RetryPolicySnapshot.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/RetryPolicySnapshot.java
@@ -1,0 +1,10 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+/** Retry policy frozen when a BatchExecution is created. */
+public record RetryPolicySnapshot(int maxAttempts, int backoffSeconds) {
+
+  public RetryPolicySnapshot {
+    if (maxAttempts < 1) throw new IllegalArgumentException("maxAttempts 必须大于 0");
+    if (backoffSeconds < 0) throw new IllegalArgumentException("backoffSeconds 不能小于 0");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapperTest.java
@@ -1,0 +1,82 @@
+package io.yak.ops.business.sync.offline.domain.compat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.AttemptReason;
+import io.yak.ops.business.sync.offline.domain.core.AttemptStatus;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class LegacyOfflineExecutionCompatibilityMapperTest {
+
+  @Test
+  void lostLegacyExecutionMapsToUnknownRetryAttempt() {
+    OfflineJobExecution legacy =
+        OfflineJobExecution.builder()
+            .id(20L)
+            .definitionVersion(3)
+            .engineJobId("engine-job-20")
+            .externalExecutionId("external-20")
+            .idempotencyKey("idem-20")
+            .workerInstanceId("worker-a")
+            .status("LOST")
+            .attemptNo(2)
+            .triggerType("RETRY")
+            .retryFromExecutionId(10L)
+            .sourceRecordCount(100L)
+            .sinkSuccessRecordCount(90L)
+            .failedRecordCount(10L)
+            .qps(25D)
+            .durationMillis(5000L)
+            .createTime(LocalDateTime.of(2026, 8, 23, 10, 0))
+            .build();
+
+    ExecutionAttempt attempt = LegacyOfflineExecutionCompatibilityMapper.toAttempt(legacy);
+
+    assertThat(attempt.id()).isEqualTo(20L);
+    assertThat(attempt.attemptNo()).isEqualTo(2);
+    assertThat(attempt.reason()).isEqualTo(AttemptReason.RETRY);
+    assertThat(attempt.status()).isEqualTo(AttemptStatus.UNKNOWN);
+    assertThat(attempt.engineExecutionRef().jobId()).isEqualTo("engine-job-20");
+    assertThat(attempt.metrics().sourceRecordCount()).isEqualTo(100L);
+    assertThat(attempt.metrics().failedRecordCount()).isEqualTo(10L);
+  }
+
+  @Test
+  void snapshotRequiresExplicitFrozenRetryPolicy() {
+    OfflineJobExecution legacy =
+        OfflineJobExecution.builder()
+            .definitionVersion(7)
+            .definitionSnapshotJson("{\"source\":{\"table\":\"orders\"}}")
+            .configDigest("digest-7")
+            .build();
+    RetryPolicySnapshot retryPolicy = new RetryPolicySnapshot(4, 30);
+
+    ExecutionSnapshot snapshot =
+        LegacyOfflineExecutionCompatibilityMapper.toSnapshot(legacy, retryPolicy);
+
+    assertThat(snapshot.definitionRevision()).isEqualTo(7);
+    assertThat(snapshot.definitionSnapshot()).contains("orders");
+    assertThat(snapshot.retryPolicy()).isSameAs(retryPolicy);
+    assertThat(snapshot.configDigest()).isEqualTo("digest-7");
+  }
+
+  @Test
+  void snapshotMapperNeverFallsBackWhenFrozenEvidenceIsMissing() {
+    OfflineJobExecution legacy =
+        OfflineJobExecution.builder()
+            .definitionVersion(1)
+            .definitionSnapshotJson("{\"source\":{}}")
+            .configDigest("digest")
+            .build();
+
+    assertThatThrownBy(() -> LegacyOfflineExecutionCompatibilityMapper.toSnapshot(legacy, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("retryPolicy");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/core/OfflineCoreDomainTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/core/OfflineCoreDomainTest.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.sync.offline.domain.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineCoreDomainTest {
+
+  @Test
+  void scheduleBatchKeyUsesPlannedFireIdentity() {
+    Instant planned = Instant.parse("2026-08-23T02:00:00Z");
+
+    BatchKey first = BatchKey.schedule("task-1", planned);
+    BatchKey replay = BatchKey.schedule("task-1", planned);
+    BatchKey next = BatchKey.schedule("task-1", planned.plusSeconds(3600));
+
+    assertThat(first).isEqualTo(replay);
+    assertThat(first).isNotEqualTo(next);
+  }
+
+  @Test
+  void partitionScopeNormalizesOrderAndDuplicates() {
+    BatchScope.PartitionScope first =
+        BatchScope.partitions(List.of(" dt=2026-08-22 ", "dt=2026-08-21", "dt=2026-08-22"));
+    BatchScope.PartitionScope second =
+        BatchScope.partitions(List.of("dt=2026-08-21", "dt=2026-08-22"));
+
+    assertThat(first.partitions()).containsExactly("dt=2026-08-21", "dt=2026-08-22");
+    assertThat(first.fingerprint()).isEqualTo(second.fingerprint());
+  }
+
+  @Test
+  void dataWindowRejectsEmptyOrReversedWindow() {
+    LocalDateTime start = LocalDateTime.of(2026, 8, 23, 0, 0);
+
+    assertThatThrownBy(() -> BatchScope.dataWindow(start, start))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> BatchScope.dataWindow(start, start.minusDays(1)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void batchRequiresSequentialAttemptNumbers() {
+    ExecutionSnapshot snapshot =
+        new ExecutionSnapshot("definition", 3, new RetryPolicySnapshot(3, 60), "digest");
+    ExecutionAttempt first = attempt(1);
+    ExecutionAttempt third = attempt(3);
+
+    assertThatThrownBy(
+            () ->
+                new BatchExecution(
+                    null,
+                    1L,
+                    BatchKey.manual("request-1"),
+                    BatchTrigger.MANUAL,
+                    BatchScope.fullSelection(),
+                    snapshot,
+                    BatchStatus.RUNNING,
+                    List.of(first, third)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("AttemptNo");
+  }
+
+  @Test
+  void unknownOccupiesExecutionSlotAndIsNotTerminal() {
+    assertThat(AttemptStatus.UNKNOWN.isTerminal()).isFalse();
+    assertThat(AttemptStatus.UNKNOWN.blocksNextAttempt()).isTrue();
+    assertThat(BatchStatus.UNKNOWN.isTerminal()).isFalse();
+    assertThat(BatchStatus.UNKNOWN.occupiesTaskExecutionSlot()).isTrue();
+  }
+
+  private ExecutionAttempt attempt(int attemptNo) {
+    return new ExecutionAttempt(
+        null,
+        attemptNo,
+        attemptNo == 1 ? AttemptReason.INITIAL : AttemptReason.RETRY,
+        "idem-" + attemptNo,
+        "ext-" + attemptNo,
+        AttemptStatus.RUNNING,
+        null,
+        AttemptMetrics.empty(),
+        null,
+        LocalDateTime.of(2026, 8, 23, 10, 0),
+        null,
+        null);
+  }
+}


### PR DESCRIPTION
## Summary

完成离线同步 Stage 6 / Wave 0：建立目标 Core Domain 类型和 legacy compatibility mapper，不切换现有执行链，不修改数据库、API、YAML 或调度/重试行为。

## Domain Impact Analysis

```text
Aggregate(s): BatchExecution / ExecutionAttempt
Lifecycle impact: no runtime behavior change; only target lifecycle types are introduced
Persistence impact: none
Compatibility: legacy OfflineJobExecution remains the running model
Domain Gap: no
```

## Core types

新增纯 JDK `domain/core`：

```text
BatchKey
BatchScope
BatchExecution
BatchStatus
BatchTrigger
ExecutionAttempt
AttemptStatus
AttemptReason
ExecutionSnapshot
RetryPolicySnapshot
EngineExecutionRef
AttemptMetrics
```

核心约束：

- `Task != Batch != Attempt`；
- BatchKey 提供 MANUAL / SCHEDULE / WORKFLOW / BACKFILL 稳定身份工厂；
- Schedule identity 使用 `plannedFireTime`；
- BatchScope 支持 FullSelection / DataWindow / Partition / CursorRange 表达和稳定 fingerprint；
- BatchExecution 保证 AttemptNo 从 1 连续递增；
- `UNKNOWN` 不是终态，并阻止下一 Attempt；
- `WAITING_RETRY / UNKNOWN / RUNNING` 占用 V1 Task 执行槽；
- ExecutionSnapshot 显式包含 frozen RetryPolicy。

Core 不依赖 Spring、Jackson、MyBatis、Lombok 或 Link-Up 协议类型。

## Compatibility mapper

新增 `LegacyOfflineExecutionCompatibilityMapper`：

```text
legacy OfflineJobExecution
  -> ExecutionAttempt

legacy snapshot + explicit frozen RetryPolicy
  -> ExecutionSnapshot
```

重要边界：mapper **不会**凭空生成 BatchExecution / BatchKey / BatchScope，因为 legacy row 没有稳定 Batch 身份；Wave 1 持久化 Batch 后再绑定。

映射中：

- legacy `LOST -> AttemptStatus.UNKNOWN`；
- legacy retry metadata -> `AttemptReason.RETRY`；
- Engine Job/Worker identity 和 metrics 作为 Attempt evidence 保留；
- Snapshot mapper 必须显式传入 frozen RetryPolicy，禁止 fallback 到 current Task / current SchedulePolicy。

## Tests

新增：

```text
OfflineCoreDomainTest
LegacyOfflineExecutionCompatibilityMapperTest
```

覆盖：

- Schedule BatchKey 稳定性；
- PartitionScope 规范化和 fingerprint；
- DataWindow 边界；
- Attempt 连续编号；
- UNKNOWN 非终态且占执行槽；
- LOST -> UNKNOWN；
- retry attempt 识别；
- legacy metrics/evidence 映射；
- Snapshot 必须使用显式 frozen RetryPolicy。

另外对 Core + compatibility mapper 做了独立 `javac` 语法编译验证。

## Transition

`DOMAIN.md` 标记：

```text
Wave 0  DONE
Wave 1  NEXT  Batch persistence + execution.bind(batch_id)
```

现有 Service / Orchestrator / Reconciler / ScheduleHandler / schema 均未切换到新 Core，因此本 PR 不改变线上运行语义。

## Next

Wave 1：新增 Batch persistence，并让现有 `yak_offline_job_execution` 绑定 `batch_id`；继续采用 expand / dual-read-write，不做一次性重建。