### PR TITLE
feat: persist offline sync batch identity

### DIFF
--- a/docs/offline-sync/domain/README.md
+++ b/docs/offline-sync/domain/README.md
@@ -1,6 +1,6 @@
 # Offline Sync Domain
 
-> 当前阶段：Stage 4。只做现有代码到目标领域的映射，不改业务实现。
+> 当前实现阶段：Stage 6 / Wave 1。本文保留当前代码到目标领域的迁移映射；日常开发规则以模块 `DOMAIN.md` 为准。
 
 ## 1. 目标模型
 
@@ -20,11 +20,9 @@ BatchExecution
 
 硬规则：`Task != Batch != Attempt`；Retry 复用原 Batch/Scope/Snapshot；`UNKNOWN != FAILED`。
 
-## 2. Mapping
+## 2. 当前 Mapping
 
-标记：`KEEP` 直接复用；`ADAPT` 保留但调整语义；`MIGRATE` 需要迁移；`DEBT` 当前行为违反目标领域。
-
-| 当前实现 | 目标语义 | 结论 |
+| 当前实现 | 目标语义 | 状态 |
 | --- | --- | --- |
 | `OfflineJobDefinition` | Task + SyncDefinition + Schedule/Retry Policy + 查询投影 | ADAPT |
 | `definition_json` | 当前 SyncDefinition 表现 | KEEP |
@@ -33,25 +31,31 @@ BatchExecution
 | `job_spec_json` | Link-Up 执行产物，不是定义真相 | ADAPT |
 | `release_state` | Task 是否允许产生新 Batch | KEEP |
 | `OfflineSchedule` | SchedulePolicy + RetryPolicy + runtime projection | ADAPT |
-| `OfflineJobExecution` / `yak_offline_job_execution` | 当前更接近 `ExecutionAttempt` | MIGRATE |
+| `yak_offline_batch_execution` | `BatchExecution` persistence | WAVE 1 DONE |
+| `yak_offline_job_execution.batch_id` | Attempt -> Batch 绑定 | WAVE 1 DONE / nullable |
+| `OfflineJobExecution` | legacy 运行链仍混合 Batch + Attempt | MIGRATE |
 | `attempt_no / retry_from_execution_id` | Attempt 次序/血缘 | KEEP |
 | `idempotency_key / external_execution_id` | Attempt 幂等与外部提交身份 | KEEP |
 | `engine_job_id / worker_instance_id` | Engine evidence | KEEP |
 | metrics / error / start/end | Attempt 运行证据 | KEEP |
-| `definition_snapshot_json / submitted_config` | 应归属 Batch 的 ExecutionSnapshot | MIGRATE |
+| legacy execution snapshot | 过渡期兼容副本 | MIGRATE |
 | `OfflineExecutionEvent` | Attempt 事件历史 | KEEP |
-| `OfflineExecutionStatus` | Attempt 状态 | MIGRATE |
-| `OfflineExecutionClaimService` | Batch/Attempt claim 的基础 | ADAPT |
-| `OfflineExecutionReconciler` | Attempt reconcile | ADAPT |
-| `OfflineScheduleHandler` | Schedule trigger adapter | ADAPT |
 | Task `last-*` | 只允许做 Read Model projection | MIGRATE |
 | Link-Up / credential resolver | Infrastructure boundary | KEEP |
 
-## 3. 已确认 Domain Debt
+## 3. 仍未解决的 Domain Debt
+
+### Trigger 尚未切 Batch
+
+Batch 表已经存在，但当前手动/调度/工作流执行仍直接创建 legacy execution。Wave 2 才切成：
+
+```text
+Trigger -> claim Batch -> create Attempt 1
+```
 
 ### Retry 漂移
 
-当前 `retryFrom(previous)` 重新进入 `execute(definitionId, ...)`，会读取 **current Task**；`configureRetry()` 还会读取 **current Schedule/RetryPolicy**。
+当前 `retryFrom(previous)` 会重新读取 current Task；`configureRetry()` 还会读取 current Schedule/RetryPolicy。
 
 目标：
 
@@ -67,114 +71,60 @@ Retry
 
 当前 `LOST` 会进入 retry candidate。目标中无法确认引擎结果属于 `UNKNOWN`，必须先 reconcile，不能直接 Retry。
 
-### 缺少 Batch 身份
-
-当前一条 `yak_offline_job_execution` 同时承担 Batch + Attempt。数据库缺少：
-
-```text
-batch_id
-batch_key
-batch_scope
-batch_status
-```
-
-现有 execution 表包含大量 Attempt 字段，因此优先把它演进为 Attempt persistence，而不是推倒重建。
-
 ### Schedule 幂等不足
 
-当前 Schedule 主要靠 `hasActiveExecution(taskId)` 防重复，没有稳定 `BatchKey`。同一计划触发重复回调、且前一次已快速结束时，可能形成第二个业务批次。
-
-目标：
+当前 Schedule 仍主要靠 `hasActiveExecution(taskId)` 防重复。Wave 2 必须使用：
 
 ```text
 SCHEDULE BatchKey = scheduleId + plannedFireTime
 ```
 
-### WAITING_RETRY 未占用 Task 执行资格
+### Runtime truth 尚未切换
 
-当前 FAILED/LOST execution 等待 `nextRetryTime` 时已经不算 active，新的手动/调度执行可能先进入；这与 V1 “同 Task 最多一个 RUNNING / WAITING_RETRY / UNKNOWN Batch” 不一致。
+Task `lastJobStatus` 仍参与部分命令判断；生命周期最终必须只读 Batch/Attempt。
 
-### Task last-* 仍参与命令判断
+## 4. Wave 1 Persistence
 
-`lastJobStatus` 当前不仅用于展示/筛选，还参与 `ensureEditable()`。目标中 Task `last-*` 只能是查询投影，生命周期判断必须读取 Batch/Attempt。
-
-### 状态更新缺少目标状态机保护
-
-当前 reconcile 主要依赖 Engine 返回状态直接覆盖 execution。后续需要按 Attempt 状态机和单调版本处理 stale/out-of-order snapshot，终态不能被旧响应复活。
-
-## 4. 现有资产怎么复用
-
-### 当前 execution 表
-
-不建议重建整套执行历史。目标迁移：
+当前持久化关系：
 
 ```text
-new BatchExecution persistence
+yak_offline_job_definition
+        │ 1:N
+        ▼
+yak_offline_batch_execution
         │ 1:N
         ▼
 yak_offline_job_execution
-        ≈ ExecutionAttempt persistence
 ```
 
-先新增 `batch_id` 绑定；物理表名可暂时保留，命名清理放最后。
+Wave 1 约束：
 
-### Snapshot
+- 新增 Batch 表，不重建旧 execution/event 历史；
+- execution `batch_id` nullable，旧记录不要求回填；
+- `bindBatch(executionId, batchId)` 只允许 `NULL -> batchId` 或重复绑定同一个 Batch；
+- 不创建物理 FK；
+- Batch Repository 只持久化 Batch 业务身份、Scope、Snapshot/RetryPolicy 和状态；
+- Engine Job、metrics、error 继续属于 Attempt persistence；
+- 现有 Service/Orchestrator/Schedule/Retry 尚不使用 Batch Repository。
 
-当前每个 execution 已保存 definition/JobSpec snapshot，这是好基础。迁移后：
-
-```text
-Batch owns immutable ExecutionSnapshot
-Attempt references Batch Snapshot
-```
-
-过渡期允许 Attempt 保留兼容副本，但不能成为第二份真相。
-
-### Task 行锁与幂等
-
-Task 行锁可以继续作为 V1 串行化命令入口；现有 Attempt `idempotencyKey` 继续使用，同时新增 BatchKey 解决“同一个业务批次”的幂等。
-
-### 凭据边界
-
-现有 `sanitizeForPersistence + resolveExecutionJobSpec()` 方向正确：SyncDefinition/Snapshot 不保存 DataSource 密码，Attempt 提交时再解析当前凭据。
-
-## 5. 推荐迁移波次
+## 5. 迁移波次
 
 ```text
-Wave 0  Core VO + compatibility mapper
-        BatchKey / BatchScope / BatchExecution / ExecutionAttempt
-
-Wave 1  Batch persistence
-        新增 Batch 表；现有 execution 绑定 batch_id
-
-Wave 2  Trigger -> Batch -> Attempt 1
-        手动/调度/工作流先 claim Batch，再创建 Attempt
-        Schedule 使用 planned BatchKey
-
-Wave 3  Retry / UNKNOWN
-        Retry 固定 Batch Snapshot/Policy
-        UNKNOWN 禁止自动 Retry
-        持久化 retry reservation
-
-Wave 4  Runtime truth
-        生命周期只读 Batch/Attempt
-        Task last-* 降级为 projection
-
-Wave 5  Backfill / Cursor
-        shared Snapshot、Scope identity、成功后推进 cursor
-
-Wave 6  Cleanup
-        LOST / legacy retry fields / GUIDE mode / 物理命名兼容清理
+Wave 0  DONE  Core VO + compatibility mapper
+Wave 1  DONE  Batch persistence + execution.bind(batch_id)
+Wave 2  NEXT  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
+Wave 3        Retry / UNKNOWN + durable retry reservation
+Wave 4        Runtime truth -> Batch/Attempt; Task last-* projection only
+Wave 5        Backfill / Cursor
+Wave 6        Legacy cleanup
 ```
 
 采用 `expand -> dual read/write -> switch -> verify -> contract`，不做一次性 schema 重建。
 
-## 6. Stage 4 结论
+## 6. 当前结论
 
-1. 当前 Task/Engine/事件/凭据边界大部分可复用。
-2. `yak_offline_job_execution` 应优先演进为 Attempt persistence。
-3. 新增 Batch persistence 是后续重构的核心支点。
-4. Retry 漂移、LOST 自动重试、Schedule 无 BatchKey 是优先安全债。
-5. 暂不引入 immutable DefinitionVersion；Batch Snapshot 继续作为执行真相。
-6. 暂不抽 Realtime/Offline Shared Kernel。
-
-下一阶段先建立短小的 `DOMAIN.md`，把上述规则变成 AI 修改离线同步前必须遵守的约束；仍不开始大规模重构。
+1. Batch 已有真实持久化身份，但尚未成为现有运行链的入口。
+2. `yak_offline_job_execution` 继续演进为 Attempt persistence，不推倒重建。
+3. Wave 2 是第一次运行链切换：Trigger 先 claim Batch，再创建 Attempt 1。
+4. Retry/UNKNOWN、Task runtime truth、Backfill/Cursor 继续按后续 Wave 独立迁移。
+5. 暂不引入 immutable DefinitionVersion，也不抽 Realtime/Offline Shared Kernel。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
@@ -59,7 +59,7 @@ BatchExecution
 当前代码尚未完全满足上述目标模型。已确认的主要 Domain Debt：
 
 ```text
-OfflineJobExecution = Batch + Attempt 混合
+OfflineJobExecution = legacy 运行链仍以 execution 为中心
 retryFrom()          = 回读 current Task
 configureRetry()     = 回读 current RetryPolicy
 LOST                  = 当前会自动 Retry，应迁移为 UNKNOWN 语义
@@ -67,14 +67,12 @@ Schedule              = 缺少稳定 BatchKey
 Task last-*           = 仍部分参与生命周期判断
 ```
 
-Wave 0 已完成 Core VO 与兼容映射；现有执行链和数据库仍保持原行为，不得把“Core 已存在”理解成迁移已经完成。
-
-这些问题按迁移波次处理，不允许临时建立第二套真相：
+Wave 0 已完成 Core VO 与兼容映射；Wave 1 已新增 Batch persistence，并给 legacy execution 增加 nullable `batch_id` 与安全绑定能力。现有 Trigger/Retry/Schedule 尚未切换到 Batch，因此不得把“Batch 表已存在”理解成运行真相已经迁移。
 
 ```text
 Wave 0  DONE  Core VO + compatibility mapper
-Wave 1  NEXT  Batch persistence + execution.bind(batch_id)
-Wave 2        Trigger -> Batch -> Attempt 1 + Schedule BatchKey
+Wave 1  DONE  Batch persistence + execution.bind(batch_id)
+Wave 2  NEXT  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
 Wave 3        Retry / UNKNOWN + durable retry reservation
 Wave 4        Runtime truth -> Batch/Attempt; Task last-* projection only
 Wave 5        Backfill / Cursor

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -2,7 +2,7 @@
 
 ## 领域建设
 
-离线同步当前已完成 Stage 6 Wave 0：Core VO + compatibility mapper。现有执行链和数据库尚未切换；修改代码前先读当前规则，需要迁移背景时再看 Mapping 文档：
+离线同步当前已完成 Stage 6 Wave 1：Batch persistence + nullable `execution.batch_id`。现有 Trigger/Retry/Schedule 仍走 legacy 链路；修改代码前先读当前规则，需要迁移背景时再看 Mapping 文档：
 
 - [DOMAIN.md](./DOMAIN.md)
 - [Domain Mapping](../../../docs/offline-sync/domain/README.md)
@@ -70,14 +70,21 @@ Domain -> View Mapper -> VO -> Controller
 
 ## 数据表
 
-仅保留：
+当前保留：
 
 - `yak_offline_job_definition`
+- `yak_offline_batch_execution`
 - `yak_offline_job_execution`
 - `yak_offline_execution_event`
 
-调度配置直接保存在任务定义表。每次执行保存任务定义和 JobSpec 快照，不再维护独立任务版本表。
+Wave 1 通过 V2 expand migration 新增 Batch 表，并给 `yak_offline_job_execution` 增加 nullable `batch_id`。旧 execution 可以暂时没有 Batch；Wave 2 才会让新 Trigger 先创建 Batch 再创建 Attempt。
 
-## 数据库重建
+调度配置继续保存在任务定义表。Batch 保存稳定业务身份、Scope 和 frozen Snapshot/RetryPolicy；execution 继续保存引擎提交、指标、错误等 Attempt 证据。
 
-本阶段明确不兼容旧离线同步表。Flyway 使用新的 `yak_offline_core_schema_history`，V1 会删除旧离线同步业务表和旧 `yak_offline_schema_history` 后重新建表。部署前应确认历史离线同步数据无需保留。
+## 数据库迁移
+
+Flyway 使用 `yak_offline_core_schema_history`：
+
+- V1 是离线同步 baseline；
+- V2 只做 expand：新增 `yak_offline_batch_execution` 和 nullable `execution.batch_id`；
+- Wave 1 不回填旧 execution，不创建物理 FK，也不切换现有执行链。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineBatchExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineBatchExecutionDao.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.sync.offline.dao;
+
+import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+
+/** 离线同步业务批次数据访问接口。 */
+public interface OfflineBatchExecutionDao {
+
+  OfflineBatchExecutionPO selectById(Long id);
+
+  OfflineBatchExecutionPO selectByTaskIdAndBatchKey(Long taskId, String batchKey);
+
+  boolean insert(OfflineBatchExecutionPO batchPO);
+
+  boolean updateById(OfflineBatchExecutionPO batchPO);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobExecutionDao.java
@@ -12,9 +12,13 @@ public interface OfflineJobExecutionDao {
 
   OfflineJobExecutionPO selectByIdempotencyKey(String idempotencyKey);
 
+  List<OfflineJobExecutionPO> selectByBatchId(Long batchId);
+
   boolean insert(OfflineJobExecutionPO executionPO);
 
   boolean updateById(OfflineJobExecutionPO executionPO);
+
+  boolean bindBatch(Long executionId, Long batchId, LocalDateTime updateTime);
 
   boolean hasActiveExecution(Long definitionId);
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
@@ -1,0 +1,44 @@
+package io.yak.ops.business.sync.offline.dao.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineBatchExecutionMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/** 基于 MyBatis-Plus 的离线同步业务批次数据访问实现。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
+
+  private final OfflineBatchExecutionMapper mapper;
+
+  @Override
+  public OfflineBatchExecutionPO selectById(Long id) {
+    return mapper.selectById(id);
+  }
+
+  @Override
+  public OfflineBatchExecutionPO selectByTaskIdAndBatchKey(Long taskId, String batchKey) {
+    if (taskId == null || taskId <= 0L || !StringUtils.hasText(batchKey)) return null;
+    return mapper.selectOne(
+        Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(OfflineBatchExecutionPO::getJobDefinitionId, taskId)
+            .eq(OfflineBatchExecutionPO::getBatchKey, batchKey.trim())
+            .last("LIMIT 1"));
+  }
+
+  @Override
+  public boolean insert(OfflineBatchExecutionPO batchPO) {
+    return mapper.insert(batchPO) > 0;
+  }
+
+  @Override
+  public boolean updateById(OfflineBatchExecutionPO batchPO) {
+    return mapper.updateById(batchPO) > 0;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
@@ -41,6 +41,16 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   }
 
   @Override
+  public List<OfflineJobExecutionPO> selectByBatchId(Long batchId) {
+    if (batchId == null || batchId <= 0L) return List.of();
+    return mapper.selectList(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(OfflineJobExecutionPO::getBatchId, batchId)
+            .orderByAsc(OfflineJobExecutionPO::getAttemptNo)
+            .orderByAsc(OfflineJobExecutionPO::getId));
+  }
+
+  @Override
   public boolean insert(OfflineJobExecutionPO executionPO) {
     return mapper.insert(executionPO) > 0;
   }
@@ -48,6 +58,22 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   @Override
   public boolean updateById(OfflineJobExecutionPO executionPO) {
     return mapper.updateById(executionPO) > 0;
+  }
+
+  @Override
+  public boolean bindBatch(Long executionId, Long batchId, LocalDateTime updateTime) {
+    if (executionId == null || executionId <= 0L || batchId == null || batchId <= 0L) return false;
+    return mapper.update(
+        null,
+        Wrappers.<OfflineJobExecutionPO>lambdaUpdate()
+            .eq(OfflineJobExecutionPO::getId, executionId)
+            .and(
+                condition -> condition
+                    .isNull(OfflineJobExecutionPO::getBatchId)
+                    .or()
+                    .eq(OfflineJobExecutionPO::getBatchId, batchId))
+            .set(OfflineJobExecutionPO::getBatchId, batchId)
+            .set(OfflineJobExecutionPO::getUpdateTime, updateTime)) > 0;
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineBatchExecutionMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineBatchExecutionMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.sync.offline.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+
+/** 离线同步业务批次 Mapper。 */
+public interface OfflineBatchExecutionMapper extends BaseMapper<OfflineBatchExecutionPO> {
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobExecution.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobExecution.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class OfflineJobExecution {
   private Long id;
   private Long jobDefinitionId;
+  private Long batchId;
   private Integer definitionVersion;
   private String engineBaseUrl;
   private String engineJobId;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepository.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import java.util.Optional;
+
+/** 离线同步业务批次领域仓储。 */
+public interface OfflineBatchExecutionRepository {
+
+  Optional<BatchExecution> findById(Long id);
+
+  Optional<BatchExecution> findByTaskIdAndBatchKey(long taskId, BatchKey batchKey);
+
+  BatchExecution insert(BatchExecution batch);
+
+  boolean update(BatchExecution batch);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
@@ -1,0 +1,207 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
+import io.yak.ops.business.sync.offline.domain.compat.LegacyOfflineExecutionCompatibilityMapper;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/** BatchExecution 与 Wave 1 持久化模型之间的适配器。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecutionRepository {
+
+  private final OfflineBatchExecutionDao dao;
+  private final OfflineJobExecutionRepository executionRepository;
+
+  @Override
+  public Optional<BatchExecution> findById(Long id) {
+    return Optional.ofNullable(toDomain(dao.selectById(id)));
+  }
+
+  @Override
+  public Optional<BatchExecution> findByTaskIdAndBatchKey(long taskId, BatchKey batchKey) {
+    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
+    Objects.requireNonNull(batchKey, "BatchKey 不能为空");
+    return Optional.ofNullable(toDomain(dao.selectByTaskIdAndBatchKey(taskId, batchKey.value())));
+  }
+
+  @Override
+  public BatchExecution insert(BatchExecution batch) {
+    Objects.requireNonNull(batch, "BatchExecution 不能为空");
+    if (batch.id() != null) throw new IllegalArgumentException("新 Batch 不应预先包含 ID");
+    if (!batch.attempts().isEmpty()) {
+      throw new IllegalArgumentException("Wave 1 创建 Batch 时不能同时持久化 Attempt");
+    }
+    OfflineBatchExecutionPO po = toPO(batch);
+    if (!dao.insert(po) || po.getId() == null) {
+      throw new IllegalStateException("创建离线同步 BatchExecution 失败");
+    }
+    return new BatchExecution(
+        po.getId(),
+        batch.taskId(),
+        batch.batchKey(),
+        batch.trigger(),
+        batch.batchScope(),
+        batch.snapshot(),
+        batch.status(),
+        List.of());
+  }
+
+  @Override
+  public boolean update(BatchExecution batch) {
+    Objects.requireNonNull(batch, "BatchExecution 不能为空");
+    if (batch.id() == null) throw new IllegalArgumentException("更新 Batch 必须包含 ID");
+    return dao.updateById(toPO(batch));
+  }
+
+  private BatchExecution toDomain(OfflineBatchExecutionPO po) {
+    if (po == null) return null;
+    BatchScope scope = readScope(po.getBatchScopeType(), po.getBatchScopeValue());
+    String storedFingerprint = requireText(po.getBatchScopeFingerprint(), "batchScopeFingerprint 不能为空");
+    if (!scope.fingerprint().equals(storedFingerprint)) {
+      throw new IllegalStateException("BatchScope fingerprint 与持久化内容不一致");
+    }
+    RetryPolicySnapshot retryPolicy = new RetryPolicySnapshot(
+        positive(po.getRetryMaxAttempts(), "retryMaxAttempts"),
+        nonNegative(po.getRetryBackoffSeconds(), "retryBackoffSeconds"));
+    ExecutionSnapshot snapshot = new ExecutionSnapshot(
+        requireText(po.getDefinitionSnapshotJson(), "definitionSnapshot 不能为空"),
+        positive(po.getDefinitionRevision(), "definitionRevision"),
+        retryPolicy,
+        requireText(po.getConfigDigest(), "configDigest 不能为空"));
+    List<ExecutionAttempt> attempts = executionRepository.findByBatchId(po.getId()).stream()
+        .map(LegacyOfflineExecutionCompatibilityMapper::toAttempt)
+        .toList();
+    return new BatchExecution(
+        positive(po.getId(), "BatchExecutionId"),
+        positive(po.getJobDefinitionId(), "TaskId"),
+        new BatchKey(requireText(po.getBatchKey(), "BatchKey 不能为空")),
+        enumValue(BatchTrigger.class, po.getTriggerType(), "triggerType"),
+        scope,
+        snapshot,
+        enumValue(BatchStatus.class, po.getStatus(), "status"),
+        attempts);
+  }
+
+  private OfflineBatchExecutionPO toPO(BatchExecution batch) {
+    OfflineBatchExecutionPO po = new OfflineBatchExecutionPO();
+    po.setId(batch.id());
+    po.setJobDefinitionId(batch.taskId());
+    po.setBatchKey(batch.batchKey().value());
+    po.setTriggerType(batch.trigger().name());
+    po.setBatchScopeType(scopeType(batch.batchScope()));
+    po.setBatchScopeValue(batch.batchScope().canonicalValue());
+    po.setBatchScopeFingerprint(batch.batchScope().fingerprint());
+    po.setDefinitionSnapshotJson(batch.snapshot().definitionSnapshot());
+    po.setDefinitionRevision(batch.snapshot().definitionRevision());
+    po.setRetryMaxAttempts(batch.snapshot().retryPolicy().maxAttempts());
+    po.setRetryBackoffSeconds(batch.snapshot().retryPolicy().backoffSeconds());
+    po.setConfigDigest(batch.snapshot().configDigest());
+    po.setStatus(batch.status().name());
+    LocalDateTime now = LocalDateTime.now();
+    if (batch.id() == null) po.setCreateTime(now);
+    po.setUpdateTime(now);
+    return po;
+  }
+
+  private String scopeType(BatchScope scope) {
+    if (scope instanceof BatchScope.FullSelection) return "FULL_SELECTION";
+    if (scope instanceof BatchScope.DataWindow) return "DATA_WINDOW";
+    if (scope instanceof BatchScope.PartitionScope) return "PARTITION_SCOPE";
+    if (scope instanceof BatchScope.CursorRange) return "CURSOR_RANGE";
+    throw new IllegalArgumentException("不支持的 BatchScope：" + scope.getClass().getName());
+  }
+
+  private BatchScope readScope(String type, String value) {
+    String normalizedType = requireText(type, "batchScopeType 不能为空").toUpperCase(Locale.ROOT);
+    String canonical = requireText(value, "batchScopeValue 不能为空");
+    return switch (normalizedType) {
+      case "FULL_SELECTION" -> {
+        if (!"FULL_SELECTION".equals(canonical)) {
+          throw new IllegalStateException("FullSelection 持久化内容不正确");
+        }
+        yield BatchScope.fullSelection();
+      }
+      case "DATA_WINDOW" -> {
+        String[] parts = canonical.split("\\|", -1);
+        if (parts.length != 3 || !"DATA_WINDOW".equals(parts[0])) {
+          throw new IllegalStateException("DataWindow 持久化内容不正确");
+        }
+        yield BatchScope.dataWindow(
+            LocalDateTime.parse(parts[1]), LocalDateTime.parse(parts[2]));
+      }
+      case "PARTITION_SCOPE" -> {
+        String prefix = "PARTITIONS|";
+        if (!canonical.startsWith(prefix) || canonical.length() == prefix.length()) {
+          throw new IllegalStateException("PartitionScope 持久化内容不正确");
+        }
+        yield BatchScope.partitions(
+            java.util.Arrays.stream(canonical.substring(prefix.length()).split(",", -1))
+                .map(this::decode)
+                .toList());
+      }
+      case "CURSOR_RANGE" -> {
+        String[] parts = canonical.split("\\|", -1);
+        if (parts.length != 4 || !"CURSOR_RANGE".equals(parts[0])) {
+          throw new IllegalStateException("CursorRange 持久化内容不正确");
+        }
+        yield BatchScope.cursorRange(decode(parts[1]), decode(parts[2]), decode(parts[3]));
+      }
+      default -> throw new IllegalStateException("未知 BatchScope 类型：" + normalizedType);
+    };
+  }
+
+  private String decode(String value) {
+    try {
+      return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalStateException("BatchScope 持久化编码不正确", exception);
+    }
+  }
+
+  private <T extends Enum<T>> T enumValue(Class<T> type, String value, String field) {
+    try {
+      return Enum.valueOf(type, requireText(value, field + " 不能为空").toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalStateException(field + " 持久化值不合法：" + value, exception);
+    }
+  }
+
+  private String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalStateException(message);
+    return value.trim();
+  }
+
+  private long positive(Long value, String field) {
+    if (value == null || value <= 0L) throw new IllegalStateException(field + " 必须大于 0");
+    return value;
+  }
+
+  private int positive(Integer value, String field) {
+    if (value == null || value <= 0) throw new IllegalStateException(field + " 必须大于 0");
+    return value;
+  }
+
+  private int nonNegative(Integer value, String field) {
+    if (value == null || value < 0) throw new IllegalStateException(field + " 不能小于 0");
+    return value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepository.java
@@ -11,8 +11,10 @@ import java.util.Optional;
 public interface OfflineJobExecutionRepository {
   Optional<OfflineJobExecution> findById(Long id);
   Optional<OfflineJobExecution> findByIdempotencyKey(String idempotencyKey);
+  List<OfflineJobExecution> findByBatchId(Long batchId);
   boolean insert(OfflineJobExecution execution);
   boolean update(OfflineJobExecution execution);
+  boolean bindBatch(Long executionId, Long batchId);
   boolean hasActiveExecution(Long definitionId);
   List<OfflineJobExecution> findActiveExecutions(int limit);
   List<OfflineJobExecution> findRetryCandidates(LocalDateTime now, int limit);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapter.java
@@ -33,6 +33,11 @@ public class OfflineJobExecutionRepositoryAdapter implements OfflineJobExecution
   }
 
   @Override
+  public List<OfflineJobExecution> findByBatchId(Long batchId) {
+    return dao.selectByBatchId(batchId).stream().map(this::toDomain).toList();
+  }
+
+  @Override
   public boolean insert(OfflineJobExecution execution) {
     OfflineJobExecutionPO po = toPO(execution);
     boolean inserted = dao.insert(po);
@@ -43,6 +48,17 @@ public class OfflineJobExecutionRepositoryAdapter implements OfflineJobExecution
   @Override
   public boolean update(OfflineJobExecution execution) {
     return dao.updateById(toPO(execution));
+  }
+
+  @Override
+  public boolean bindBatch(Long executionId, Long batchId) {
+    if (executionId == null || executionId <= 0L) {
+      throw new IllegalArgumentException("ExecutionId 必须大于 0");
+    }
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    }
+    return dao.bindBatch(executionId, batchId, LocalDateTime.now());
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V2__add_offline_batch_execution.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V2__add_offline_batch_execution.sql
@@ -1,0 +1,27 @@
+-- Wave 1 expand migration: introduce persisted BatchExecution identity without switching runtime paths.
+CREATE TABLE yak_offline_batch_execution (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '业务批次 ID',
+    job_definition_id BIGINT NOT NULL COMMENT '离线同步任务 ID',
+    batch_key VARCHAR(512) NOT NULL COMMENT '任务内稳定业务批次身份',
+    trigger_type VARCHAR(32) NOT NULL COMMENT 'MANUAL/SCHEDULE/WORKFLOW/BACKFILL',
+    batch_scope_type VARCHAR(32) NOT NULL COMMENT 'FULL_SELECTION/DATA_WINDOW/PARTITION_SCOPE/CURSOR_RANGE',
+    batch_scope_value LONGTEXT NOT NULL COMMENT 'BatchScope canonical value',
+    batch_scope_fingerprint CHAR(64) NOT NULL COMMENT 'BatchScope SHA-256 fingerprint',
+    definition_snapshot_json LONGTEXT NOT NULL COMMENT 'Batch 创建时冻结的 SyncDefinition 快照',
+    definition_revision INT NOT NULL COMMENT 'Batch 创建时的定义修订号',
+    retry_max_attempts INT NOT NULL COMMENT 'Batch 创建时冻结的最大 Attempt 数',
+    retry_backoff_seconds INT NOT NULL COMMENT 'Batch 创建时冻结的 Retry backoff 秒数',
+    config_digest CHAR(64) NOT NULL COMMENT '冻结配置摘要',
+    status VARCHAR(32) NOT NULL COMMENT 'PENDING/RUNNING/WAITING_RETRY/SUCCEEDED/FAILED/CANCELED/UNKNOWN',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_offline_batch_task_key (job_definition_id, batch_key),
+    KEY idx_yak_offline_batch_task_status (job_definition_id, status, id),
+    KEY idx_yak_offline_batch_scope (batch_scope_fingerprint)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='离线同步业务批次';
+
+ALTER TABLE yak_offline_job_execution
+    ADD COLUMN batch_id BIGINT NULL COMMENT '所属业务批次 ID；Wave 1 兼容期允许为空' AFTER job_definition_id,
+    ADD KEY idx_yak_offline_execution_batch (batch_id, attempt_no, id);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
@@ -7,17 +7,20 @@ import io.yak.framework.common.PageData;
 import io.yak.ops.business.sync.offline.controller.OfflineControlPlaneController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobDefinitionController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobExecutionController;
+import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionQuery;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
@@ -50,6 +53,7 @@ class OfflineSyncLayeringConventionTest {
   @Test
   void repositoriesExposeOnlyDomainContracts() {
     for (Class<?> type : List.of(
+        OfflineBatchExecutionRepository.class,
         OfflineJobDefinitionRepository.class,
         OfflineJobExecutionRepository.class,
         OfflineExecutionEventRepository.class,
@@ -80,6 +84,7 @@ class OfflineSyncLayeringConventionTest {
   @Test
   void daosDoNotDependOnTransportModels() {
     for (Class<?> type : List.of(
+        OfflineBatchExecutionDao.class,
         OfflineJobDefinitionDao.class,
         OfflineJobExecutionDao.class,
         OfflineExecutionEventDao.class)) {
@@ -88,10 +93,14 @@ class OfflineSyncLayeringConventionTest {
   }
 
   @Test
-  void phaseOnePersistenceRemainsThreeTables() {
+  void waveOnePersistenceAddsBatchTableWithoutReplacingLegacyTables() throws Exception {
+    assertTable(OfflineBatchExecutionPO.class, "yak_offline_batch_execution");
     assertTable(OfflineJobDefinitionPO.class, "yak_offline_job_definition");
     assertTable(OfflineJobExecutionPO.class, "yak_offline_job_execution");
     assertTable(OfflineExecutionEventPO.class, "yak_offline_execution_event");
+
+    Field batchId = OfflineJobExecutionPO.class.getDeclaredField("batchId");
+    assertThat(batchId.getType()).isEqualTo(Long.class);
   }
 
   private void assertMethodsAvoid(Class<?> owner, String... forbidden) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapterTest.java
@@ -1,0 +1,158 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.AttemptStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineBatchExecutionRepositoryAdapterTest {
+
+  @Test
+  void roundTripsBatchIdentityScopeAndFrozenSnapshot() {
+    FakeBatchDao dao = new FakeBatchDao();
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    when(executions.findByBatchId(anyLong())).thenReturn(List.of());
+    OfflineBatchExecutionRepositoryAdapter repository =
+        new OfflineBatchExecutionRepositoryAdapter(dao, executions);
+
+    BatchExecution source = new BatchExecution(
+        null,
+        42L,
+        BatchKey.schedule("schedule-42", Instant.parse("2026-08-23T02:00:00Z")),
+        BatchTrigger.SCHEDULE,
+        BatchScope.partitions(List.of("dt=2026-08-23", "dt=2026-08-22", "dt=2026-08-23")),
+        new ExecutionSnapshot(
+            "{\"source\":\"orders\"}",
+            7,
+            new RetryPolicySnapshot(3, 30),
+            "digest-7"),
+        BatchStatus.PENDING,
+        List.of());
+
+    BatchExecution inserted = repository.insert(source);
+    BatchExecution reloaded = repository.findById(inserted.id()).orElseThrow();
+
+    assertThat(inserted.id()).isEqualTo(101L);
+    assertThat(reloaded.taskId()).isEqualTo(42L);
+    assertThat(reloaded.batchKey()).isEqualTo(source.batchKey());
+    assertThat(reloaded.trigger()).isEqualTo(BatchTrigger.SCHEDULE);
+    assertThat(reloaded.batchScope()).isEqualTo(source.batchScope());
+    assertThat(reloaded.batchScope().fingerprint()).isEqualTo(source.batchScope().fingerprint());
+    assertThat(reloaded.snapshot()).isEqualTo(source.snapshot());
+    assertThat(reloaded.status()).isEqualTo(BatchStatus.PENDING);
+    assertThat(reloaded.attempts()).isEmpty();
+    assertThat(repository.findByTaskIdAndBatchKey(42L, source.batchKey())).contains(reloaded);
+  }
+
+  @Test
+  void hydratesBoundLegacyExecutionsAsAttempts() {
+    FakeBatchDao dao = new FakeBatchDao();
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchExecutionRepositoryAdapter repository =
+        new OfflineBatchExecutionRepositoryAdapter(dao, executions);
+
+    BatchExecution inserted = repository.insert(new BatchExecution(
+        null,
+        9L,
+        BatchKey.manual("request-9"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(2, 5), "digest"),
+        BatchStatus.RUNNING,
+        List.of()));
+
+    OfflineJobExecution legacyAttempt = OfflineJobExecution.builder()
+        .id(501L)
+        .jobDefinitionId(9L)
+        .batchId(inserted.id())
+        .attemptNo(1)
+        .triggerType("MANUAL")
+        .idempotencyKey("attempt-501")
+        .externalExecutionId("external-501")
+        .status("RUNNING")
+        .createTime(LocalDateTime.of(2026, 8, 23, 10, 0))
+        .build();
+    when(executions.findByBatchId(inserted.id())).thenReturn(List.of(legacyAttempt));
+
+    BatchExecution reloaded = repository.findById(inserted.id()).orElseThrow();
+
+    assertThat(reloaded.attempts()).hasSize(1);
+    assertThat(reloaded.attempts().get(0).id()).isEqualTo(501L);
+    assertThat(reloaded.attempts().get(0).attemptNo()).isEqualTo(1);
+    assertThat(reloaded.attempts().get(0).status()).isEqualTo(AttemptStatus.RUNNING);
+  }
+
+  @Test
+  void rejectsCorruptedScopeEvidence() {
+    FakeBatchDao dao = new FakeBatchDao();
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    when(executions.findByBatchId(anyLong())).thenReturn(List.of());
+    OfflineBatchExecutionRepositoryAdapter repository =
+        new OfflineBatchExecutionRepositoryAdapter(dao, executions);
+
+    BatchExecution source = new BatchExecution(
+        null,
+        7L,
+        BatchKey.manual("request-7"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(1, 0), "digest"),
+        BatchStatus.PENDING,
+        List.of());
+
+    BatchExecution inserted = repository.insert(source);
+    dao.stored.setBatchScopeFingerprint("corrupted");
+
+    assertThatThrownBy(() -> repository.findById(inserted.id()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("fingerprint");
+  }
+
+  private static final class FakeBatchDao implements OfflineBatchExecutionDao {
+    private OfflineBatchExecutionPO stored;
+
+    @Override
+    public OfflineBatchExecutionPO selectById(Long id) {
+      return stored != null && stored.getId().equals(id) ? stored : null;
+    }
+
+    @Override
+    public OfflineBatchExecutionPO selectByTaskIdAndBatchKey(Long taskId, String batchKey) {
+      return stored != null
+              && stored.getJobDefinitionId().equals(taskId)
+              && stored.getBatchKey().equals(batchKey)
+          ? stored
+          : null;
+    }
+
+    @Override
+    public boolean insert(OfflineBatchExecutionPO batchPO) {
+      batchPO.setId(101L);
+      stored = batchPO;
+      return true;
+    }
+
+    @Override
+    public boolean updateById(OfflineBatchExecutionPO batchPO) {
+      stored = batchPO;
+      return true;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapterBatchBindingTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapterBatchBindingTest.java
@@ -1,0 +1,40 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import org.junit.jupiter.api.Test;
+
+class OfflineJobExecutionRepositoryAdapterBatchBindingTest {
+
+  @Test
+  void delegatesSafeBatchBindingToDao() {
+    OfflineJobExecutionDao dao = mock(OfflineJobExecutionDao.class);
+    when(dao.bindBatch(org.mockito.ArgumentMatchers.eq(9L), org.mockito.ArgumentMatchers.eq(101L), any()))
+        .thenReturn(true);
+    OfflineJobExecutionRepositoryAdapter repository =
+        new OfflineJobExecutionRepositoryAdapter(dao);
+
+    assertThat(repository.bindBatch(9L, 101L)).isTrue();
+    verify(dao).bindBatch(org.mockito.ArgumentMatchers.eq(9L), org.mockito.ArgumentMatchers.eq(101L), any());
+  }
+
+  @Test
+  void rejectsInvalidBindingIdentityBeforeDao() {
+    OfflineJobExecutionDao dao = mock(OfflineJobExecutionDao.class);
+    OfflineJobExecutionRepositoryAdapter repository =
+        new OfflineJobExecutionRepositoryAdapter(dao);
+
+    assertThatThrownBy(() -> repository.bindBatch(0L, 101L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ExecutionId");
+    assertThatThrownBy(() -> repository.bindBatch(9L, 0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("BatchExecutionId");
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineBatchExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineBatchExecutionPO.java
@@ -1,0 +1,37 @@
+package io.yak.ops.common.bean.po.sync.offline;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.ToString;
+
+/** 离线同步业务批次持久化模型。 */
+@Data
+@TableName("yak_offline_batch_execution")
+public class OfflineBatchExecutionPO {
+  @TableId(type = IdType.AUTO)
+  private Long id;
+
+  private Long jobDefinitionId;
+  private String batchKey;
+  private String triggerType;
+  private String batchScopeType;
+
+  @ToString.Exclude
+  private String batchScopeValue;
+
+  private String batchScopeFingerprint;
+
+  @ToString.Exclude
+  private String definitionSnapshotJson;
+
+  private Integer definitionRevision;
+  private Integer retryMaxAttempts;
+  private Integer retryBackoffSeconds;
+  private String configDigest;
+  private String status;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
@@ -14,6 +14,7 @@ public class OfflineJobExecutionPO {
   @TableId(type = IdType.AUTO)
   private Long id;
   private Long jobDefinitionId;
+  private Long batchId;
   private Integer definitionVersion;
   private String engineBaseUrl;
   private String engineJobId;


### PR DESCRIPTION
## Summary

完成离线同步 Stage 6 / Wave 1：新增 BatchExecution 持久化，并让 legacy `yak_offline_job_execution` 可以安全绑定 `batch_id`。

本 PR 仍不切换现有 Trigger / Retry / Schedule 运行链；Wave 2 才开始 `Trigger -> Batch -> Attempt 1`。

## Domain Impact Analysis

```text
Aggregate(s): BatchExecution / ExecutionAttempt
Lifecycle impact: no runtime path switch
Persistence impact: expand only
Compatibility: legacy execution.batch_id remains nullable
Domain Gap: no
```

## Persistence

新增 V2 expand migration：

```text
yak_offline_job_definition
        │ 1:N
        ▼
yak_offline_batch_execution
        │ 1:N
        ▼
yak_offline_job_execution
```

`yak_offline_batch_execution` 保存：

- task / stable BatchKey；
- BatchTrigger；
- BatchScope canonical value + fingerprint；
- frozen definition snapshot / DefinitionRevision；
- frozen RetryPolicy；
- config digest；
- BatchStatus。

现有 `yak_offline_job_execution` 只新增 nullable `batch_id`，不回填历史记录，不创建物理 FK。

## Safe execution binding

新增：

```text
executionRepository.bindBatch(executionId, batchId)
```

DAO 使用 CAS 式条件，只允许：

```text
NULL -> batchId
same batchId -> same batchId
```

如果 execution 已绑定其他 Batch，不允许改挂。

同时新增 `findByBatchId(batchId)`，按 `(batch_id, attempt_no, id)` 顺序读取 Attempt。

## Batch repository

新增：

```text
OfflineBatchExecutionRepository
OfflineBatchExecutionRepositoryAdapter
OfflineBatchExecutionDao
OfflineBatchExecutionDaoImpl
OfflineBatchExecutionMapper
OfflineBatchExecutionPO
```

Batch Repository 读取时会：

```text
Batch row
+
bound legacy executions
        ↓
LegacyOfflineExecutionCompatibilityMapper
        ↓
BatchExecution + ExecutionAttempt[]
```

因此不会返回一个永远 `attempts=[]` 的半 Aggregate。

BatchScope 持久化后会重新计算 fingerprint；数据库内容和 fingerprint 不一致时直接拒绝读取。

## Compatibility boundary

- 当前 Service / Orchestrator / Reconciler / ScheduleHandler 没有使用新 Batch Repository；
- legacy execution 没有 `batch_id` 时行为保持不变；
- Batch 表已存在 ≠ runtime truth 已切换；
- Wave 1 不把 Link-Up JobSpec 塞进 Core Domain，也不建立第二套定义真相。

## Tests

新增/更新：

```text
OfflineBatchExecutionRepositoryAdapterTest
OfflineJobExecutionRepositoryAdapterBatchBindingTest
OfflineSyncLayeringConventionTest
```

覆盖：

- BatchKey / Scope / frozen Snapshot round-trip；
- PartitionScope canonical persistence；
- scope fingerprint corruption rejection；
- bound legacy execution -> ExecutionAttempt hydration；
- execution batch binding contract；
- Repository / DAO 分层；
- Wave 1 第四张 Batch 表和 nullable batchId 结构。

## Docs

- `DOMAIN.md`：Wave 1 DONE / Wave 2 NEXT；
- 模块 README：更新当前四表结构和 V2 expand 边界；
- Mapping README：只保留当前迁移事实，不追加 Stage 历史文档。

## Validation

- branch relative to main: 1 commit, behind=0；
- 未修改现有 runtime orchestration path；
- 当前执行环境无法解析 `github.com`，因此无法在本地 clone 并运行完整 Maven/JUnit；不声明完整构建已通过。

## Next

Wave 2：手动 / 调度 / 工作流 Trigger 先 claim stable Batch，再创建 Attempt 1；Schedule 使用 `scheduleId + plannedFireTime` 形成稳定 BatchKey。