### PR TITLE
refactor(offline-sync): materialize batch on trigger

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/compat/LegacyBatchTriggerCompatibilityMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/compat/LegacyBatchTriggerCompatibilityMapper.java
@@ -1,0 +1,77 @@
+package io.yak.ops.business.sync.offline.domain.compat;
+
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Transitional adapter for carrying stable batch identity through the legacy string trigger API.
+ *
+ * <p>The encoded token is application-boundary compatibility only. Core types never depend on Yak
+ * Schedule, Quartz, Link-Up or worker-specific objects.
+ */
+public final class LegacyBatchTriggerCompatibilityMapper {
+
+  private static final String SCHEDULE_PREFIX = "SCHEDULE@";
+
+  private LegacyBatchTriggerCompatibilityMapper() {}
+
+  public static String scheduleToken(String scheduleId, Instant plannedFireTime) {
+    Objects.requireNonNull(plannedFireTime, "plannedFireTime 不能为空");
+    return SCHEDULE_PREFIX
+        + encode(requireText(scheduleId, "scheduleId 不能为空"))
+        + "@"
+        + encode(plannedFireTime.toString());
+  }
+
+  public static Mapping parse(String triggerType) {
+    String value = requireText(triggerType, "triggerType 不能为空");
+    if (value.startsWith(SCHEDULE_PREFIX)) {
+      String payload = value.substring(SCHEDULE_PREFIX.length());
+      String[] parts = payload.split("@", -1);
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("SCHEDULE trigger 缺少稳定 Batch identity");
+      }
+      String scheduleId = decode(parts[0]);
+      Instant plannedFireTime = Instant.parse(decode(parts[1]));
+      return new Mapping(
+          "SCHEDULE",
+          BatchTrigger.SCHEDULE,
+          BatchKey.schedule(scheduleId, plannedFireTime));
+    }
+
+    String normalized = value.toUpperCase(Locale.ROOT);
+    return switch (normalized) {
+      case "SCHEDULE" -> new Mapping("SCHEDULE", BatchTrigger.SCHEDULE, null);
+      case "WORKFLOW" -> new Mapping("WORKFLOW", BatchTrigger.WORKFLOW, null);
+      case "BACKFILL" -> new Mapping("BACKFILL", BatchTrigger.BACKFILL, null);
+      case "RETRY" -> new Mapping("RETRY", null, null);
+      default -> new Mapping(value, BatchTrigger.MANUAL, null);
+    };
+  }
+
+  private static String encode(String value) {
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String decode(String value) {
+    try {
+      return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("trigger identity 编码不合法", exception);
+    }
+  }
+
+  private static String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  public record Mapping(String legacyTriggerType, BatchTrigger batchTrigger, BatchKey batchKey) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.domain.compat.LegacyBatchTriggerCompatibilityMapper;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
@@ -62,7 +63,9 @@ public class OfflineScheduleHandler implements ScheduleHandler {
     }
 
     try {
-      OfflineJobExecution execution = orchestrator.execute(definitionId, "SCHEDULE", null, 1);
+      String triggerToken = LegacyBatchTriggerCompatibilityMapper.scheduleToken(
+          context.key().value(), context.scheduledFireTime());
+      OfflineJobExecution execution = orchestrator.execute(definitionId, triggerToken, null, 1);
       return ScheduleExecutionResult.accepted(
           execution.getId() == null ? null : String.valueOf(execution.getId()),
           "离线同步任务已提交 Link-Up 执行");

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -5,8 +5,20 @@ import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.domain.compat.LegacyBatchTriggerCompatibilityMapper;
+import io.yak.ops.business.sync.offline.domain.compat.LegacyBatchTriggerCompatibilityMapper.Mapping;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -21,16 +33,22 @@ public class OfflineExecutionClaimService {
   private final OfflineJobDefinitionService definitionService;
   private final OfflineJobDefinitionRepository definitionRepository;
   private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineScheduleRepository scheduleRepository;
   private final OfflineSyncProperties properties;
 
   public OfflineExecutionClaimService(
       OfflineJobDefinitionService definitionService,
       OfflineJobDefinitionRepository definitionRepository,
       OfflineJobExecutionRepository executionRepository,
+      OfflineBatchExecutionRepository batchRepository,
+      OfflineScheduleRepository scheduleRepository,
       OfflineSyncProperties properties) {
     this.definitionService = definitionService;
     this.definitionRepository = definitionRepository;
     this.executionRepository = executionRepository;
+    this.batchRepository = batchRepository;
+    this.scheduleRepository = scheduleRepository;
     this.properties = properties;
   }
 
@@ -46,13 +64,14 @@ public class OfflineExecutionClaimService {
       throw new IllegalStateException("请先上线任务，再执行运行操作");
     }
     String logicalJobSpec = definitionService.resolveLogicalJobSpec(definition);
+    Mapping trigger = LegacyBatchTriggerCompatibilityMapper.parse(triggerType);
     return createClaim(
         definition,
         Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
         definition.getConfigDigest(),
         definition.getDefinitionJson(),
         logicalJobSpec,
-        triggerType,
+        trigger,
         retryFromExecutionId,
         attemptNo,
         null);
@@ -112,7 +131,7 @@ public class OfflineExecutionClaimService {
         configDigest,
         definitionSnapshotJson,
         logicalJobSpecJson,
-        triggerType,
+        LegacyBatchTriggerCompatibilityMapper.parse(triggerType),
         null,
         1,
         normalizedKey);
@@ -124,7 +143,7 @@ public class OfflineExecutionClaimService {
       String configDigest,
       String definitionSnapshotJson,
       String logicalJobSpecJson,
-      String triggerType,
+      Mapping trigger,
       Long retryFromExecutionId,
       int attemptNo,
       String idempotencyKey) {
@@ -133,18 +152,31 @@ public class OfflineExecutionClaimService {
       throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
     }
 
+    int normalizedAttemptNo = Math.max(1, attemptNo);
+    String normalizedIdempotencyKey =
+        StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : UUID.randomUUID().toString();
+    Long batchId = resolveBatchId(
+        definitionId,
+        definitionVersion,
+        configDigest,
+        definitionSnapshotJson,
+        trigger,
+        retryFromExecutionId,
+        normalizedAttemptNo,
+        normalizedIdempotencyKey);
+
     LocalDateTime now = LocalDateTime.now();
     OfflineJobExecution execution = new OfflineJobExecution();
     execution.setJobDefinitionId(definitionId);
+    execution.setBatchId(batchId);
     execution.setDefinitionVersion((int) Math.min(Integer.MAX_VALUE, definitionVersion));
     execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
     execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
-    execution.setIdempotencyKey(
-        StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : UUID.randomUUID().toString());
+    execution.setIdempotencyKey(normalizedIdempotencyKey);
     execution.setStatus(OfflineExecutionStatus.CREATED.name());
     execution.setStateVersion(1L);
-    execution.setAttemptNo(Math.max(1, attemptNo));
-    execution.setTriggerType(triggerType);
+    execution.setAttemptNo(normalizedAttemptNo);
+    execution.setTriggerType(trigger.legacyTriggerType());
     execution.setRetryFromExecutionId(retryFromExecutionId);
     execution.setCancellationRequested(false);
     execution.setRetryCreated(false);
@@ -163,6 +195,71 @@ public class OfflineExecutionClaimService {
       throw new IllegalStateException("创建离线同步执行实例失败");
     }
     return new ClaimResult(definition, logicalJobSpecJson, execution, false);
+  }
+
+  private Long resolveBatchId(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      Mapping trigger,
+      Long retryFromExecutionId,
+      int attemptNo,
+      String idempotencyKey) {
+    if (retryFromExecutionId != null || attemptNo > 1 || "RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) {
+      if (retryFromExecutionId == null) return null;
+      return executionRepository.findById(retryFromExecutionId)
+          .map(OfflineJobExecution::getBatchId)
+          .orElse(null);
+    }
+
+    BatchScope scope = BatchScope.fullSelection();
+    BatchTrigger batchTrigger = Objects.requireNonNull(trigger.batchTrigger(), "初始执行必须包含 BatchTrigger");
+    BatchKey batchKey = trigger.batchKey();
+    if (batchKey == null) {
+      batchKey = switch (batchTrigger) {
+        case MANUAL -> BatchKey.manual(idempotencyKey);
+        case WORKFLOW -> BatchKey.workflow(idempotencyKey);
+        case BACKFILL -> BatchKey.backfill(idempotencyKey, scope.fingerprint());
+        case SCHEDULE -> throw new IllegalArgumentException(
+            "SCHEDULE trigger 必须携带 scheduleId + plannedFireTime");
+      };
+    }
+
+    RetryPolicySnapshot retryPolicy = freezeRetryPolicy(definitionId);
+    ExecutionSnapshot snapshot = new ExecutionSnapshot(
+        requireText(definitionSnapshotJson, "definitionSnapshot 不能为空"),
+        (int) Math.min(Integer.MAX_VALUE, Math.max(1L, definitionVersion)),
+        retryPolicy,
+        requireText(configDigest, "configDigest 不能为空"));
+    BatchExecution batch = new BatchExecution(
+        null,
+        definitionId,
+        batchKey,
+        batchTrigger,
+        scope,
+        snapshot,
+        BatchStatus.PENDING,
+        java.util.List.of());
+    BatchExecution saved = batchRepository.insert(batch);
+    if (saved.id() == null) throw new IllegalStateException("创建 BatchExecution 后缺少 ID");
+    return saved.id();
+  }
+
+  private RetryPolicySnapshot freezeRetryPolicy(Long definitionId) {
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
+    int maxAttempts = schedule == null
+        ? properties.getControl().getDefaultMaxAttempts()
+        : schedule.retryMaxAttempts();
+    int backoffSeconds = schedule == null
+        ? properties.getControl().getDefaultRetryBackoffSeconds()
+        : schedule.retryBackoffSeconds();
+    return new RetryPolicySnapshot(Math.max(1, maxAttempts), Math.max(0, backoffSeconds));
+  }
+
+  private String requireText(String value, String message) {
+    if (!StringUtils.hasText(value)) throw new IllegalStateException(message);
+    return value.trim();
   }
 
   private void validateIdempotentReuse(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/compat/LegacyBatchTriggerCompatibilityMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/compat/LegacyBatchTriggerCompatibilityMapperTest.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.sync.offline.domain.compat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class LegacyBatchTriggerCompatibilityMapperTest {
+
+  @Test
+  void scheduleTokenCarriesStableScheduleIdentity() {
+    Instant plannedFireTime = Instant.parse("2026-08-23T03:15:00Z");
+
+    String token = LegacyBatchTriggerCompatibilityMapper.scheduleToken(
+        "offline-sync:42", plannedFireTime);
+    LegacyBatchTriggerCompatibilityMapper.Mapping mapping =
+        LegacyBatchTriggerCompatibilityMapper.parse(token);
+
+    assertEquals("SCHEDULE", mapping.legacyTriggerType());
+    assertEquals(BatchTrigger.SCHEDULE, mapping.batchTrigger());
+    assertEquals(BatchKey.schedule("offline-sync:42", plannedFireTime), mapping.batchKey());
+  }
+}


### PR DESCRIPTION
## Stage 6 · Wave 2

落实离线同步领域迁移的 `Trigger -> Batch -> Attempt` 主链路，同时继续让 legacy execution 承担现有运行时执行链。

### 本次改动

- trigger claim 时冻结 `BatchScope / ExecutionSnapshot / RetryPolicySnapshot`
- 首次触发先创建 `BatchExecution(PENDING)`，再创建带 `batchId` 的 legacy execution，使其成为 Attempt 1
- Manual / Workflow / Backfill 生成对应稳定 `BatchKey`
- Schedule 使用 `scheduleId + plannedFireTime` 生成稳定 `BatchKey`
  - `scheduleId = ScheduleExecutionContext.key().value()`
  - `plannedFireTime = ScheduleExecutionContext.scheduledFireTime()`
- 新增明确标注 transitional 的 compatibility mapper，在旧 `String triggerType` API 上承载 schedule identity；Core 不依赖 Yak Schedule / Quartz / Link-Up / Worker
- Retry 不创建新 Batch：若来源 execution 已绑定 Batch，则沿用原 `batchId`；旧历史 execution 无 batch 时保持 legacy 行为，完整 Retry 固化留到 Wave 3

### 边界 / 非目标

本 PR **不**：

- 改 Retry / UNKNOWN / LOST 的最终语义（Wave 3）
- 将 Batch 切换为 runtime truth（Wave 4）
- 改 Backfill / Cursor 推进（Wave 5）
- 清理 legacy execution / Task last-*（Wave 6）
- 引入 DefinitionVersion 或 Shared Sync Kernel

### 测试

新增 `LegacyBatchTriggerCompatibilityMapperTest`，锁定 Schedule BatchKey 必须由稳定的 `scheduleId + plannedFireTime` 生成。

> 当前 PR 仅通过代码结构与单测用例落地本 Wave；未在本地执行 Maven 测试，等待 GitHub CI 验证。