### PR TITLE
test(offline-sync): align Wave 2 claim service tests

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -9,8 +9,11 @@ import static org.mockito.Mockito.when;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +28,8 @@ class OfflineExecutionClaimServiceTest {
   @Mock private OfflineJobDefinitionService definitionService;
   @Mock private OfflineJobDefinitionRepository definitionRepository;
   @Mock private OfflineJobExecutionRepository executionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineScheduleRepository scheduleRepository;
 
   private OfflineExecutionClaimService service;
 
@@ -34,6 +39,8 @@ class OfflineExecutionClaimServiceTest {
         definitionService,
         definitionRepository,
         executionRepository,
+        batchRepository,
+        scheduleRepository,
         new OfflineSyncProperties());
   }
 
@@ -48,6 +55,7 @@ class OfflineExecutionClaimServiceTest {
 
     when(definitionService.require(10L)).thenReturn(definition);
     when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{\"job\":\"spec\"}");
+    stubBatchInsert(77L);
     when(executionRepository.insert(any(OfflineJobExecution.class)))
         .thenAnswer(invocation -> {
           OfflineJobExecution execution = invocation.getArgument(0);
@@ -58,11 +66,13 @@ class OfflineExecutionClaimServiceTest {
     ClaimResult result = service.claim(10L, "WORKFLOW", null, 1);
 
     assertThat(result.getExecution().getId()).isEqualTo(99L);
+    assertThat(result.getExecution().getBatchId()).isEqualTo(77L);
     assertThat(result.getExecution().getStatus()).isEqualTo("CREATED");
     assertThat(result.getExecution().getWorkerInstanceId()).isNull();
     assertThat(result.getExecution().getEngineBaseUrl()).isEqualTo("http://127.0.0.1:18080");
     verify(definitionRepository).lock(10L);
     verify(executionRepository).hasActiveExecution(10L);
+    verify(batchRepository).insert(any(BatchExecution.class));
     verify(executionRepository).insert(result.getExecution());
   }
 
@@ -72,6 +82,7 @@ class OfflineExecutionClaimServiceTest {
     definition.setId(10L);
     when(definitionService.require(10L)).thenReturn(definition);
     when(executionRepository.findByIdempotencyKey("attempt-123")).thenReturn(Optional.empty());
+    stubBatchInsert(78L);
     when(executionRepository.insert(any(OfflineJobExecution.class)))
         .thenAnswer(invocation -> {
           OfflineJobExecution execution = invocation.getArgument(0);
@@ -89,10 +100,12 @@ class OfflineExecutionClaimServiceTest {
         "attempt-123");
 
     assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("attempt-123");
+    assertThat(result.getExecution().getBatchId()).isEqualTo(78L);
     assertThat(result.getExecution().getTriggerType()).isEqualTo("WORKFLOW");
     assertThat(result.isReused()).isFalse();
     verify(definitionRepository).lock(10L);
     verify(executionRepository).hasActiveExecution(10L);
+    verify(batchRepository).insert(any(BatchExecution.class));
     verify(executionRepository).insert(result.getExecution());
   }
 
@@ -127,6 +140,23 @@ class OfflineExecutionClaimServiceTest {
     assertThat(result.isReused()).isTrue();
     verify(definitionRepository).lock(10L);
     verify(executionRepository, never()).hasActiveExecution(10L);
+    verify(batchRepository, never()).insert(any(BatchExecution.class));
     verify(executionRepository, never()).insert(any(OfflineJobExecution.class));
+  }
+
+  private void stubBatchInsert(long id) {
+    when(batchRepository.insert(any(BatchExecution.class)))
+        .thenAnswer(invocation -> {
+          BatchExecution batch = invocation.getArgument(0);
+          return new BatchExecution(
+              id,
+              batch.taskId(),
+              batch.batchKey(),
+              batch.trigger(),
+              batch.batchScope(),
+              batch.snapshot(),
+              batch.status(),
+              batch.attempts());
+        });
   }
 }


### PR DESCRIPTION
## Stage 6 · Wave 2 follow-up

#655 was created as Draft but was merged by the repository immediately after creation. The production Wave 2 implementation is therefore already on `main`.

This follow-up keeps the remaining compatibility fix reviewable as a Draft PR:

- updates `OfflineExecutionClaimServiceTest` for the new `OfflineBatchExecutionRepository` / `OfflineScheduleRepository` constructor dependencies
- stubs persisted Batch IDs
- asserts the created legacy execution is bound to the persisted Batch (`batchId`), i.e. it is materialized as Attempt 1
- preserves the existing workflow idempotent-reuse assertions

No production behavior changes are included in this follow-up.

> Maven tests have not been executed locally; this PR is intentionally left Draft for CI/review.