### PR TITLE
refactor(offline-sync): enforce Wave 3 retry semantics

### DIFF
--- a/docs/offline-sync/domain/README.md
+++ b/docs/offline-sync/domain/README.md
@@ -1,6 +1,6 @@
 # Offline Sync Domain
 
-> 当前实现阶段：Stage 6 / Wave 1。本文保留当前代码到目标领域的迁移映射；日常开发规则以模块 `DOMAIN.md` 为准。
+> 当前实现阶段：Stage 6 / Wave 3。本文保留当前代码到目标领域的迁移映射；日常开发规则以模块 `DOMAIN.md` 为准。
 
 ## 1. 目标模型
 
@@ -33,57 +33,47 @@ BatchExecution
 | `OfflineSchedule` | SchedulePolicy + RetryPolicy + runtime projection | ADAPT |
 | `yak_offline_batch_execution` | `BatchExecution` persistence | WAVE 1 DONE |
 | `yak_offline_job_execution.batch_id` | Attempt -> Batch 绑定 | WAVE 1 DONE / nullable |
+| Trigger claim | `Trigger -> Batch -> Attempt 1` | WAVE 2 DONE |
+| Schedule identity | `scheduleId + plannedFireTime` BatchKey | WAVE 2 DONE |
+| `retry_created` | FAILED Attempt 的 durable Retry reservation | WAVE 3 DONE |
+| Retry Attempt | same Batch + frozen Snapshot/RetryPolicy | WAVE 3 DONE |
+| `UNKNOWN` / legacy `LOST` | 不确定结果，持续 reconcile，不自动 Retry | WAVE 3 DONE |
 | `OfflineJobExecution` | legacy 运行链仍混合 Batch + Attempt | MIGRATE |
 | `attempt_no / retry_from_execution_id` | Attempt 次序/血缘 | KEEP |
 | `idempotency_key / external_execution_id` | Attempt 幂等与外部提交身份 | KEEP |
 | `engine_job_id / worker_instance_id` | Engine evidence | KEEP |
 | metrics / error / start/end | Attempt 运行证据 | KEEP |
-| legacy execution snapshot | 过渡期兼容副本 | MIGRATE |
+| legacy execution snapshot | 过渡期兼容副本；Retry 从 Attempt 1 读取冻结 JobSpec | MIGRATE |
 | `OfflineExecutionEvent` | Attempt 事件历史 | KEEP |
 | Task `last-*` | 只允许做 Read Model projection | MIGRATE |
 | Link-Up / credential resolver | Infrastructure boundary | KEEP |
 
-## 3. 仍未解决的 Domain Debt
-
-### Trigger 尚未切 Batch
-
-Batch 表已经存在，但当前手动/调度/工作流执行仍直接创建 legacy execution。Wave 2 才切成：
-
-```text
-Trigger -> claim Batch -> create Attempt 1
-```
-
-### Retry 漂移
-
-当前 `retryFrom(previous)` 会重新读取 current Task；`configureRetry()` 还会读取 current Schedule/RetryPolicy。
-
-目标：
-
-```text
-Retry
- -> same Batch
- -> same ExecutionSnapshot
- -> same RetryPolicy Snapshot
- -> new Attempt
-```
-
-### LOST 自动重试
-
-当前 `LOST` 会进入 retry candidate。目标中无法确认引擎结果属于 `UNKNOWN`，必须先 reconcile，不能直接 Retry。
-
-### Schedule 幂等不足
-
-当前 Schedule 仍主要靠 `hasActiveExecution(taskId)` 防重复。Wave 2 必须使用：
-
-```text
-SCHEDULE BatchKey = scheduleId + plannedFireTime
-```
+## 3. 当前仍未解决的 Domain Debt
 
 ### Runtime truth 尚未切换
 
-Task `lastJobStatus` 仍参与部分命令判断；生命周期最终必须只读 Batch/Attempt。
+Batch 已经真实创建，Retry/UNKNOWN 也已经按 Batch 规则运行，但 Task `lastJobStatus` 和 legacy execution 查询仍参与部分命令判断。
 
-## 4. Wave 1 Persistence
+Wave 4 目标：
+
+```text
+Runtime truth
+  -> BatchExecution
+  -> latest ExecutionAttempt
+
+Task last-*
+  -> projection only
+```
+
+### Batch 生命周期尚未完整 dual-write
+
+`yak_offline_batch_execution.status` 已有持久化字段，但当前执行状态更新仍主要落在 legacy execution；Wave 4 才会把 Batch / Attempt 生命周期切成运行真相。
+
+### Legacy history 无 Batch identity
+
+Wave 1 前历史 execution 允许 `batch_id = NULL`。这类记录没有冻结的 BatchScope / RetryPolicy Snapshot，因此 Wave 3 明确禁止从它们安全 Retry，不通过回读 current Task/SchedulePolicy 猜测历史语义。
+
+## 4. Wave 1-3 已完成迁移
 
 当前持久化关系：
 
@@ -97,24 +87,28 @@ yak_offline_batch_execution
 yak_offline_job_execution
 ```
 
-Wave 1 约束：
+已完成约束：
 
-- 新增 Batch 表，不重建旧 execution/event 历史；
 - execution `batch_id` nullable，旧记录不要求回填；
 - `bindBatch(executionId, batchId)` 只允许 `NULL -> batchId` 或重复绑定同一个 Batch；
+- Trigger 先创建 Batch，再创建 Attempt 1；
+- Schedule BatchKey 使用稳定 planned fire identity；
+- Retry 不创建新 Batch，不回读 current Task；
+- RetryPolicy 从 Batch `ExecutionSnapshot` 读取，不回读 current SchedulePolicy；
+- Retry 使用 Attempt 1 已冻结的逻辑 JobSpec，只在提交边界解析最新凭据；
+- `retry_created` 通过 CAS reservation 防止并发创建重复 Attempt，reservation 与新 Attempt insert 同事务；
+- FAILED 才能 Retry；UNKNOWN / legacy LOST 只 reconcile；
 - 不创建物理 FK；
-- Batch Repository 只持久化 Batch 业务身份、Scope、Snapshot/RetryPolicy 和状态；
-- Engine Job、metrics、error 继续属于 Attempt persistence；
-- 现有 Service/Orchestrator/Schedule/Retry 尚不使用 Batch Repository。
+- Engine Job、metrics、error 继续属于 Attempt persistence。
 
 ## 5. 迁移波次
 
 ```text
 Wave 0  DONE  Core VO + compatibility mapper
 Wave 1  DONE  Batch persistence + execution.bind(batch_id)
-Wave 2  NEXT  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
-Wave 3        Retry / UNKNOWN + durable retry reservation
-Wave 4        Runtime truth -> Batch/Attempt; Task last-* projection only
+Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
+Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
+Wave 4  NEXT  Runtime truth -> Batch/Attempt; Task last-* projection only
 Wave 5        Backfill / Cursor
 Wave 6        Legacy cleanup
 ```
@@ -123,8 +117,8 @@ Wave 6        Legacy cleanup
 
 ## 6. 当前结论
 
-1. Batch 已有真实持久化身份，但尚未成为现有运行链的入口。
-2. `yak_offline_job_execution` 继续演进为 Attempt persistence，不推倒重建。
-3. Wave 2 是第一次运行链切换：Trigger 先 claim Batch，再创建 Attempt 1。
-4. Retry/UNKNOWN、Task runtime truth、Backfill/Cursor 继续按后续 Wave 独立迁移。
+1. Batch 已成为 Trigger 的真实业务身份，Attempt 1 与后续 Retry Attempt 都绑定同一 Batch。
+2. Retry 已固定 Batch/Scope/Snapshot/RetryPolicy，不再通过 current Task/SchedulePolicy 漂移。
+3. UNKNOWN 已与 FAILED 分离，不确定结果只 reconcile，不自动 Retry。
+4. `yak_offline_job_execution` 继续作为过渡期 Attempt persistence；Batch/Attempt runtime truth 在 Wave 4 切换。
 5. 暂不引入 immutable DefinitionVersion，也不抽 Realtime/Offline Shared Kernel。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
@@ -56,25 +56,23 @@ BatchExecution
 
 ## Current Transition
 
-当前代码尚未完全满足上述目标模型。已确认的主要 Domain Debt：
+当前代码尚未完全满足上述目标模型。Wave 2 / Wave 3 已解决 Trigger、Schedule BatchKey、Retry 漂移与 UNKNOWN 自动重试问题；仍保留的主要 Domain Debt：
 
 ```text
 OfflineJobExecution = legacy 运行链仍以 execution 为中心
-retryFrom()          = 回读 current Task
-configureRetry()     = 回读 current RetryPolicy
-LOST                  = 当前会自动 Retry，应迁移为 UNKNOWN 语义
-Schedule              = 缺少稳定 BatchKey
-Task last-*           = 仍部分参与生命周期判断
+Batch status         = 已持久化，但尚未成为完整 runtime truth
+Task last-*          = 仍部分参与生命周期判断
+Legacy history       = Wave 1 前 execution 允许没有 batch_id，不可安全 Retry
 ```
 
-Wave 0 已完成 Core VO 与兼容映射；Wave 1 已新增 Batch persistence，并给 legacy execution 增加 nullable `batch_id` 与安全绑定能力。现有 Trigger/Retry/Schedule 尚未切换到 Batch，因此不得把“Batch 表已存在”理解成运行真相已经迁移。
+Wave 2 已切成 `Trigger -> Batch -> Attempt 1`，Schedule BatchKey 固定为 `scheduleId + plannedFireTime`。Wave 3 已把 Retry 切成原 Batch 内新 Attempt：从 Batch 读取冻结的 Snapshot / RetryPolicy，从 Attempt 1 读取过渡期冻结 JobSpec；`retry_created` 通过 CAS reservation 与下一 Attempt 创建处于同一事务。`LOST` 仅作为旧数据兼容输入并统一解释为 `UNKNOWN`，UNKNOWN 继续 reconcile，不进入自动 Retry。
 
 ```text
 Wave 0  DONE  Core VO + compatibility mapper
 Wave 1  DONE  Batch persistence + execution.bind(batch_id)
-Wave 2  NEXT  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
-Wave 3        Retry / UNKNOWN + durable retry reservation
-Wave 4        Runtime truth -> Batch/Attempt; Task last-* projection only
+Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
+Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
+Wave 4  NEXT  Runtime truth -> Batch/Attempt; Task last-* projection only
 Wave 5        Backfill / Cursor
 Wave 6        Legacy cleanup
 ```

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineJobExecutionDao.java
@@ -26,7 +26,8 @@ public interface OfflineJobExecutionDao {
 
   List<OfflineJobExecutionPO> selectRetryCandidates(LocalDateTime now, int limit);
 
-  void markRetryCreated(Long executionId, LocalDateTime updateTime);
+  /** 原子保留一次 FAILED Attempt 的 Retry 创建权。 */
+  boolean reserveRetry(Long executionId, LocalDateTime updateTime);
 
   IPage<OfflineJobExecutionPO> selectPage(PageQuery query);
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
@@ -22,7 +22,7 @@ import org.springframework.util.StringUtils;
 public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
 
   private static final List<String> ACTIVE_STATUSES =
-      List.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING");
+      List.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING", "UNKNOWN", "LOST");
 
   private final OfflineJobExecutionMapper mapper;
 
@@ -97,8 +97,9 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   public List<OfflineJobExecutionPO> selectRetryCandidates(LocalDateTime now, int limit) {
     return mapper.selectList(
         Wrappers.<OfflineJobExecutionPO>lambdaQuery()
-            .in(OfflineJobExecutionPO::getStatus, List.of("FAILED", "LOST"))
+            .eq(OfflineJobExecutionPO::getStatus, "FAILED")
             .eq(OfflineJobExecutionPO::getRetryCreated, false)
+            .isNotNull(OfflineJobExecutionPO::getBatchId)
             .isNotNull(OfflineJobExecutionPO::getNextRetryTime)
             .le(OfflineJobExecutionPO::getNextRetryTime, now)
             .orderByAsc(OfflineJobExecutionPO::getNextRetryTime)
@@ -106,13 +107,18 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   }
 
   @Override
-  public void markRetryCreated(Long executionId, LocalDateTime updateTime) {
-    mapper.update(
+  public boolean reserveRetry(Long executionId, LocalDateTime updateTime) {
+    if (executionId == null || executionId <= 0L) return false;
+    return mapper.update(
         null,
         Wrappers.<OfflineJobExecutionPO>lambdaUpdate()
             .eq(OfflineJobExecutionPO::getId, executionId)
+            .eq(OfflineJobExecutionPO::getStatus, "FAILED")
+            .eq(OfflineJobExecutionPO::getRetryCreated, false)
+            .isNotNull(OfflineJobExecutionPO::getBatchId)
             .set(OfflineJobExecutionPO::getRetryCreated, true)
-            .set(OfflineJobExecutionPO::getUpdateTime, updateTime));
+            .set(OfflineJobExecutionPO::getNextRetryTime, null)
+            .set(OfflineJobExecutionPO::getUpdateTime, updateTime)) > 0;
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatus.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatus.java
@@ -17,10 +17,12 @@ public enum OfflineExecutionStatus {
   SUCCEEDED,
   FAILED,
   CANCELED,
+  UNKNOWN,
+  /** Wave 3 仅保留旧数据兼容；读取 LOST 时统一解释为 UNKNOWN。 */
   LOST;
 
   private static final Set<OfflineExecutionStatus> ACTIVE =
-      EnumSet.of(CREATED, SUBMITTED, QUEUED, RUNNING);
+      EnumSet.of(CREATED, SUBMITTED, QUEUED, RUNNING, UNKNOWN, LOST);
 
   public boolean isActive() {
     return ACTIVE.contains(this);
@@ -41,6 +43,9 @@ public enum OfflineExecutionStatus {
     if ("CANCELLED".equals(normalized) || "CANCELING".equals(normalized)
         || "CANCELLING".equals(normalized)) {
       return CANCELED;
+    }
+    if ("LOST".equals(normalized)) {
+      return UNKNOWN;
     }
     return valueOf(normalized);
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepository.java
@@ -18,6 +18,7 @@ public interface OfflineJobExecutionRepository {
   boolean hasActiveExecution(Long definitionId);
   List<OfflineJobExecution> findActiveExecutions(int limit);
   List<OfflineJobExecution> findRetryCandidates(LocalDateTime now, int limit);
-  void markRetryCreated(Long executionId);
+  /** 原子保留一次 FAILED Attempt 的 Retry 创建权。 */
+  boolean reserveRetry(Long executionId);
   PageData<OfflineJobExecution> page(OfflineExecutionQuery query);
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapter.java
@@ -77,8 +77,11 @@ public class OfflineJobExecutionRepositoryAdapter implements OfflineJobExecution
   }
 
   @Override
-  public void markRetryCreated(Long executionId) {
-    dao.markRetryCreated(executionId, LocalDateTime.now());
+  public boolean reserveRetry(Long executionId) {
+    if (executionId == null || executionId <= 0L) {
+      throw new IllegalArgumentException("ExecutionId 必须大于 0");
+    }
+    return dao.reserveRetry(executionId, LocalDateTime.now());
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -20,6 +20,8 @@ import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepositor
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -58,22 +60,25 @@ public class OfflineExecutionClaimService {
       String triggerType,
       Long retryFromExecutionId,
       int attemptNo) {
+    Mapping trigger = LegacyBatchTriggerCompatibilityMapper.parse(triggerType);
+    if (retryFromExecutionId != null
+        || attemptNo > 1
+        || "RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) {
+      throw new IllegalArgumentException("Retry 必须通过 Batch 内 claimRetry 创建新 Attempt");
+    }
     definitionRepository.lock(definitionId);
     OfflineJobDefinition definition = definitionService.require(definitionId);
     if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
       throw new IllegalStateException("请先上线任务，再执行运行操作");
     }
     String logicalJobSpec = definitionService.resolveLogicalJobSpec(definition);
-    Mapping trigger = LegacyBatchTriggerCompatibilityMapper.parse(triggerType);
-    return createClaim(
+    return createInitialClaim(
         definition,
         Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
         definition.getConfigDigest(),
         definition.getDefinitionJson(),
         logicalJobSpec,
         trigger,
-        retryFromExecutionId,
-        attemptNo,
         null);
   }
 
@@ -109,6 +114,10 @@ public class OfflineExecutionClaimService {
     if (!StringUtils.hasText(logicalJobSpecJson)) {
       throw new IllegalArgumentException("任务版本快照缺少 JobSpec");
     }
+    Mapping trigger = LegacyBatchTriggerCompatibilityMapper.parse(triggerType);
+    if ("RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) {
+      throw new IllegalArgumentException("Retry 不能通过 claimSnapshot 创建新 Batch");
+    }
     definitionRepository.lock(definitionId);
     OfflineJobDefinition current = definitionService.require(definitionId);
     String normalizedKey = StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : null;
@@ -125,44 +134,141 @@ public class OfflineExecutionClaimService {
         return new ClaimResult(current, logicalJobSpecJson, existing, true);
       }
     }
-    return createClaim(
+    return createInitialClaim(
         current,
         Math.max(1L, definitionVersion),
         configDigest,
         definitionSnapshotJson,
         logicalJobSpecJson,
-        LegacyBatchTriggerCompatibilityMapper.parse(triggerType),
-        null,
-        1,
+        trigger,
         normalizedKey);
   }
 
-  private ClaimResult createClaim(
+  /**
+   * 在原 Batch 内创建下一次 Retry Attempt。
+   *
+   * <p>本方法不读取 current Task / current SchedulePolicy。Retry reservation 与下一 Attempt
+   * 持久化处于同一事务：reservation CAS 失败时不会创建重复 Attempt，Attempt 创建失败时 reservation
+   * 会随事务一起回滚。
+   */
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public ClaimResult claimRetry(Long retryFromExecutionId) {
+    if (retryFromExecutionId == null || retryFromExecutionId <= 0L) {
+      throw new IllegalArgumentException("重试来源实例不能为空");
+    }
+    OfflineJobExecution previous = executionRepository.findById(retryFromExecutionId)
+        .orElseThrow(() -> new IllegalArgumentException("重试来源实例不存在：" + retryFromExecutionId));
+    Long batchId = previous.getBatchId();
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalStateException("旧执行实例未绑定 Batch，不能按领域规则安全 Retry");
+    }
+
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Retry 所属 BatchExecution 不存在：" + batchId));
+    if (!Objects.equals(previous.getJobDefinitionId(), batch.taskId())) {
+      throw new IllegalStateException("Retry 来源 Attempt 与 Batch 的 Task 不一致");
+    }
+    if (batch.status().isTerminal()) {
+      throw new IllegalStateException("Batch 已进入终态，不能追加 Retry Attempt");
+    }
+
+    OfflineExecutionStatus previousStatus = parseStatus(previous.getStatus());
+    if (previousStatus == OfflineExecutionStatus.UNKNOWN
+        || "LOST".equalsIgnoreCase(previous.getStatus())) {
+      throw new IllegalStateException("执行结果为 UNKNOWN，必须先 reconcile，禁止盲目 Retry");
+    }
+    if (previousStatus != OfflineExecutionStatus.FAILED) {
+      throw new IllegalStateException("只有明确 FAILED 的 Attempt 才能 Retry");
+    }
+
+    List<OfflineJobExecution> attempts = executionRepository.findByBatchId(batchId);
+    if (attempts.isEmpty()) {
+      throw new IllegalStateException("Batch 缺少 Attempt 历史，不能 Retry");
+    }
+    int previousAttemptNo = positive(previous.getAttemptNo(), "attemptNo");
+    int nextAttemptNo = previousAttemptNo + 1;
+
+    OfflineJobExecution existingNext = attempts.stream()
+        .filter(attempt -> value(attempt.getAttemptNo(), 1) == nextAttemptNo)
+        .filter(attempt -> Objects.equals(attempt.getRetryFromExecutionId(), previous.getId()))
+        .findFirst()
+        .orElse(null);
+    if (existingNext != null) {
+      return new ClaimResult(null, frozenLogicalJobSpec(attempts), existingNext, true);
+    }
+
+    OfflineJobExecution latest = attempts.stream()
+        .max(
+            Comparator.comparingInt((OfflineJobExecution attempt) -> value(attempt.getAttemptNo(), 1))
+                .thenComparingLong(attempt -> value(attempt.getId(), 0L)))
+        .orElseThrow(() -> new IllegalStateException("Batch 缺少最新 Attempt"));
+    if (!Objects.equals(latest.getId(), previous.getId())) {
+      throw new IllegalStateException("只能从 Batch 最新 Attempt 创建 Retry");
+    }
+
+    RetryPolicySnapshot retryPolicy = batch.snapshot().retryPolicy();
+    if (nextAttemptNo > retryPolicy.maxAttempts()) {
+      throw new IllegalStateException("Retry 已达到 Batch 冻结的最大 Attempt 数");
+    }
+
+    String logicalJobSpec = frozenLogicalJobSpec(attempts);
+    if (!executionRepository.reserveRetry(previous.getId())) {
+      throw new IllegalStateException("Retry 已被其他请求保留或已经创建");
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setJobDefinitionId(batch.taskId());
+    execution.setBatchId(batch.id());
+    execution.setDefinitionVersion(batch.snapshot().definitionRevision());
+    execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
+    execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
+    execution.setIdempotencyKey(retryIdempotencyKey(batch.id(), nextAttemptNo));
+    execution.setStatus(OfflineExecutionStatus.CREATED.name());
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(nextAttemptNo);
+    execution.setTriggerType("RETRY");
+    execution.setRetryFromExecutionId(previous.getId());
+    execution.setCancellationRequested(false);
+    execution.setRetryCreated(false);
+    execution.setConfigDigest(batch.snapshot().configDigest());
+    execution.setDefinitionSnapshotJson(batch.snapshot().definitionSnapshot());
+    execution.setSubmittedConfig(logicalJobSpec);
+    execution.setSourceRecordCount(0L);
+    execution.setSinkSuccessRecordCount(0L);
+    execution.setSourceReadBytes(0L);
+    execution.setSinkWrittenBytes(0L);
+    execution.setQps(0D);
+    execution.setDurationMillis(0L);
+    execution.setCreateTime(now);
+    execution.setUpdateTime(now);
+    if (!executionRepository.insert(execution) || execution.getId() == null) {
+      throw new IllegalStateException("创建 Retry Attempt 失败");
+    }
+    return new ClaimResult(null, logicalJobSpec, execution, false);
+  }
+
+  private ClaimResult createInitialClaim(
       OfflineJobDefinition definition,
       long definitionVersion,
       String configDigest,
       String definitionSnapshotJson,
       String logicalJobSpecJson,
       Mapping trigger,
-      Long retryFromExecutionId,
-      int attemptNo,
       String idempotencyKey) {
     Long definitionId = definition.getId();
     if (executionRepository.hasActiveExecution(definitionId)) {
       throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
     }
 
-    int normalizedAttemptNo = Math.max(1, attemptNo);
     String normalizedIdempotencyKey =
         StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : UUID.randomUUID().toString();
-    Long batchId = resolveBatchId(
+    Long batchId = createBatch(
         definitionId,
         definitionVersion,
         configDigest,
         definitionSnapshotJson,
         trigger,
-        retryFromExecutionId,
-        normalizedAttemptNo,
         normalizedIdempotencyKey);
 
     LocalDateTime now = LocalDateTime.now();
@@ -175,9 +281,9 @@ public class OfflineExecutionClaimService {
     execution.setIdempotencyKey(normalizedIdempotencyKey);
     execution.setStatus(OfflineExecutionStatus.CREATED.name());
     execution.setStateVersion(1L);
-    execution.setAttemptNo(normalizedAttemptNo);
+    execution.setAttemptNo(1);
     execution.setTriggerType(trigger.legacyTriggerType());
-    execution.setRetryFromExecutionId(retryFromExecutionId);
+    execution.setRetryFromExecutionId(null);
     execution.setCancellationRequested(false);
     execution.setRetryCreated(false);
     execution.setConfigDigest(configDigest);
@@ -197,22 +303,13 @@ public class OfflineExecutionClaimService {
     return new ClaimResult(definition, logicalJobSpecJson, execution, false);
   }
 
-  private Long resolveBatchId(
+  private Long createBatch(
       Long definitionId,
       long definitionVersion,
       String configDigest,
       String definitionSnapshotJson,
       Mapping trigger,
-      Long retryFromExecutionId,
-      int attemptNo,
       String idempotencyKey) {
-    if (retryFromExecutionId != null || attemptNo > 1 || "RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) {
-      if (retryFromExecutionId == null) return null;
-      return executionRepository.findById(retryFromExecutionId)
-          .map(OfflineJobExecution::getBatchId)
-          .orElse(null);
-    }
-
     BatchScope scope = BatchScope.fullSelection();
     BatchTrigger batchTrigger = Objects.requireNonNull(trigger.batchTrigger(), "初始执行必须包含 BatchTrigger");
     BatchKey batchKey = trigger.batchKey();
@@ -240,7 +337,7 @@ public class OfflineExecutionClaimService {
         scope,
         snapshot,
         BatchStatus.PENDING,
-        java.util.List.of());
+        List.of());
     BatchExecution saved = batchRepository.insert(batch);
     if (saved.id() == null) throw new IllegalStateException("创建 BatchExecution 后缺少 ID");
     return saved.id();
@@ -257,9 +354,44 @@ public class OfflineExecutionClaimService {
     return new RetryPolicySnapshot(Math.max(1, maxAttempts), Math.max(0, backoffSeconds));
   }
 
+  private String frozenLogicalJobSpec(List<OfflineJobExecution> attempts) {
+    return attempts.stream()
+        .filter(attempt -> value(attempt.getAttemptNo(), 1) == 1)
+        .map(OfflineJobExecution::getSubmittedConfig)
+        .filter(StringUtils::hasText)
+        .findFirst()
+        .map(String::trim)
+        .orElseThrow(() -> new IllegalStateException("Batch Attempt 1 缺少冻结的逻辑 JobSpec"));
+  }
+
+  private String retryIdempotencyKey(Long batchId, int attemptNo) {
+    return "offline-retry:" + batchId + ":" + attemptNo;
+  }
+
+  private OfflineExecutionStatus parseStatus(String status) {
+    try {
+      return OfflineExecutionStatus.parse(status);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalStateException("Retry 来源 Attempt 状态不合法：" + status, exception);
+    }
+  }
+
+  private int positive(Integer value, String field) {
+    if (value == null || value < 1) throw new IllegalStateException(field + " 必须大于 0");
+    return value;
+  }
+
   private String requireText(String value, String message) {
     if (!StringUtils.hasText(value)) throw new IllegalStateException(message);
     return value.trim();
+  }
+
+  private int value(Integer value, int fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
   }
 
   private void validateIdempotentReuse(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -4,25 +4,26 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
-import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -35,10 +36,9 @@ public class OfflineExecutionOrchestrator {
   private final OfflineExecutionClaimService claimService;
   private final OfflineJobDefinitionRepository definitionRepository;
   private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineExecutionEventRepository eventRepository;
-  private final OfflineScheduleRepository scheduleRepository;
   private final LinkUpClient linkUpClient;
-  private final OfflineSyncProperties properties;
   private final ObjectMapper objectMapper;
 
   public OfflineExecutionOrchestrator(
@@ -46,19 +46,17 @@ public class OfflineExecutionOrchestrator {
       OfflineExecutionClaimService claimService,
       OfflineJobDefinitionRepository definitionRepository,
       OfflineJobExecutionRepository executionRepository,
+      OfflineBatchExecutionRepository batchRepository,
       OfflineExecutionEventRepository eventRepository,
-      OfflineScheduleRepository scheduleRepository,
       LinkUpClient linkUpClient,
-      OfflineSyncProperties properties,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.definitionService = definitionService;
     this.claimService = claimService;
     this.definitionRepository = definitionRepository;
     this.executionRepository = executionRepository;
+    this.batchRepository = batchRepository;
     this.eventRepository = eventRepository;
-    this.scheduleRepository = scheduleRepository;
     this.linkUpClient = linkUpClient;
-    this.properties = properties;
     this.objectMapper = objectMapper;
   }
 
@@ -168,15 +166,20 @@ public class OfflineExecutionOrchestrator {
     }
   }
 
+  /** Retry 只在原 Batch 内创建新 Attempt，并使用 Batch/Attempt 1 的冻结证据。 */
   public OfflineJobExecution retryFrom(OfflineJobExecution previous) {
     if (previous == null || previous.getId() == null) {
       throw new IllegalArgumentException("重试来源实例不能为空");
     }
-    return execute(
-        previous.getJobDefinitionId(),
-        "RETRY",
-        previous.getId(),
-        value(previous.getAttemptNo(), 1) + 1);
+    ClaimResult claim = claimService.claimRetry(previous.getId());
+    OfflineJobExecution execution = claim.getExecution();
+    if (claim.isReused()
+        && !OfflineExecutionStatus.CREATED.name().equalsIgnoreCase(execution.getStatus())) {
+      return execution;
+    }
+    return submitClaim(
+        claim,
+        definitionService.resolveExecutionJobSpec(claim.getLogicalJobSpecJson()));
   }
 
   public OfflineJobExecution cancel(Long id) {
@@ -269,10 +272,28 @@ public class OfflineExecutionOrchestrator {
     execution.setQps(sourceAverageQps > 0D ? sourceAverageQps : sinkAverageQps);
   }
 
-  public void markLost(OfflineJobExecution execution, String message) {
-    if (execution != null && OfflineExecutionStatus.isActive(execution.getStatus())) {
-      markTerminal(execution, OfflineExecutionStatus.LOST, message, null, true);
-    }
+  /** 结果无法确认时进入 UNKNOWN，继续 reconcile，并明确禁止自动 Retry。 */
+  public void markUnknown(OfflineJobExecution execution, String message) {
+    if (execution == null || !OfflineExecutionStatus.isActive(execution.getStatus())) return;
+    if (OfflineExecutionStatus.UNKNOWN.name().equalsIgnoreCase(execution.getStatus())) return;
+
+    String previous = execution.getStatus();
+    execution.setStatus(OfflineExecutionStatus.UNKNOWN.name());
+    execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
+    execution.setErrorMessage(message);
+    execution.setNextRetryTime(null);
+    execution.setEndTime(null);
+    execution.setLastSyncTime(LocalDateTime.now());
+    execution.setUpdateTime(LocalDateTime.now());
+    executionRepository.update(execution);
+    updateDefinition(execution, OfflineExecutionStatus.UNKNOWN);
+    record(
+        execution,
+        previous,
+        OfflineExecutionStatus.UNKNOWN.name(),
+        "UNKNOWN",
+        message,
+        null);
   }
 
   public OfflineJobExecution require(Long id) {
@@ -332,29 +353,30 @@ public class OfflineExecutionOrchestrator {
     record(execution, previous, target.name(), type, message, payload);
   }
 
+  /** 使用 Batch 创建时冻结的 RetryPolicy Snapshot，禁止回读 current SchedulePolicy。 */
   private void configureRetry(
       OfflineJobExecution execution,
       OfflineExecutionStatus status,
       boolean retryable) {
     execution.setNextRetryTime(null);
-    if (!retryable
-        || (status != OfflineExecutionStatus.FAILED && status != OfflineExecutionStatus.LOST)) {
-      return;
-    }
-    OfflineSchedule schedule = scheduleRepository.findSchedule(execution.getJobDefinitionId());
-    int attempts = schedule == null
-        ? properties.getControl().getDefaultMaxAttempts()
-        : schedule.retryMaxAttempts();
-    int backoff = schedule == null
-        ? properties.getControl().getDefaultRetryBackoffSeconds()
-        : schedule.retryBackoffSeconds();
-    if (value(execution.getAttemptNo(), 1) < Math.max(1, attempts)) {
-      execution.setNextRetryTime(LocalDateTime.now().plusSeconds(Math.max(1, backoff)));
+    if (!retryable || status != OfflineExecutionStatus.FAILED) return;
+    RetryPolicySnapshot retryPolicy = frozenRetryPolicy(execution);
+    if (retryPolicy == null) return;
+    if (value(execution.getAttemptNo(), 1) < retryPolicy.maxAttempts()) {
+      execution.setNextRetryTime(
+          LocalDateTime.now().plusSeconds(Math.max(0, retryPolicy.backoffSeconds())));
     }
   }
 
+  private RetryPolicySnapshot frozenRetryPolicy(OfflineJobExecution execution) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) return null;
+    BatchExecution batch = batchRepository.findById(batchId).orElse(null);
+    if (batch == null || !Objects.equals(execution.getJobDefinitionId(), batch.taskId())) return null;
+    return batch.snapshot().retryPolicy();
+  }
+
   private boolean retryable(LinkUpJobResponse response, OfflineExecutionStatus status) {
-    if (status == OfflineExecutionStatus.LOST) return true;
     if (status != OfflineExecutionStatus.FAILED) return false;
     String code = response == null ? null : response.getErrorCode();
     if (!StringUtils.hasText(code)) return true;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionReconciler.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.sync.offline.service;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
@@ -56,11 +57,13 @@ public class OfflineExecutionReconciler {
       RuntimeException probeError) {
     try {
       if (probeError != null) throw probeError;
-      if (node != null
+      boolean workerChanged = node != null
           && StringUtils.hasText(execution.getWorkerInstanceId())
           && StringUtils.hasText(node.getInstanceId())
-          && !execution.getWorkerInstanceId().equals(node.getInstanceId())) {
-        executionService.markLost(execution, "Link-Up instanceId 已变化，旧实例执行结果无法继续确认");
+          && !execution.getWorkerInstanceId().equals(node.getInstanceId());
+      if (workerChanged
+          && OfflineExecutionStatus.parse(execution.getStatus()) != OfflineExecutionStatus.UNKNOWN) {
+        executionService.markUnknown(execution, "Link-Up instanceId 已变化，旧实例执行结果无法继续确认");
         return;
       }
       LinkUpJobResponse response = StringUtils.hasText(execution.getEngineJobId())
@@ -77,8 +80,8 @@ public class OfflineExecutionReconciler {
             "CANCEL_RECONCILED");
       }
     } catch (RuntimeException exception) {
-      if (isPastLostDeadline(execution)) {
-        executionService.markLost(execution, "Link-Up 状态对账超时：" + exception.getMessage());
+      if (isPastUnknownDeadline(execution)) {
+        executionService.markUnknown(execution, "Link-Up 状态对账超时：" + exception.getMessage());
       } else {
         LOG.debug("Offline execution reconcile failed, executionId={}", execution.getId(), exception);
       }
@@ -88,13 +91,12 @@ public class OfflineExecutionReconciler {
   private void retry(OfflineJobExecution execution) {
     try {
       executionService.retryFrom(execution);
-      executionRepository.markRetryCreated(execution.getId());
     } catch (RuntimeException exception) {
       LOG.warn("Offline execution retry failed, executionId={}", execution.getId(), exception);
     }
   }
 
-  private boolean isPastLostDeadline(OfflineJobExecution execution) {
+  private boolean isPastUnknownDeadline(OfflineJobExecution execution) {
     LocalDateTime reference = execution.getLastSyncTime() == null
         ? execution.getCreateTime()
         : execution.getLastSyncTime();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -131,8 +131,8 @@ public class OfflineJobExecutionService {
     orchestrator.applySnapshot(execution, response, type);
   }
 
-  public void markLost(OfflineJobExecution execution, String message) {
-    orchestrator.markLost(execution, message);
+  public void markUnknown(OfflineJobExecution execution, String message) {
+    orchestrator.markUnknown(execution, message);
   }
 
   private OfflineBatchOperationVO batch(OfflineBatchOperationDTO request, boolean execute) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatusTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionStatusTest.java
@@ -7,15 +7,18 @@ import org.junit.jupiter.api.Test;
 class OfflineExecutionStatusTest {
 
   @Test
-  void shouldExposeOnlyOfflineBatchLifecycle() {
+  void shouldExposeOfflineBatchLifecycleIncludingUnknown() {
     assertThat(OfflineExecutionStatus.CREATED.isActive()).isTrue();
     assertThat(OfflineExecutionStatus.SUBMITTED.isActive()).isTrue();
     assertThat(OfflineExecutionStatus.QUEUED.isActive()).isTrue();
     assertThat(OfflineExecutionStatus.RUNNING.isActive()).isTrue();
+    assertThat(OfflineExecutionStatus.UNKNOWN.isActive()).isTrue();
+    assertThat(OfflineExecutionStatus.LOST.isActive()).isTrue();
     assertThat(OfflineExecutionStatus.SUCCEEDED.isTerminal()).isTrue();
     assertThat(OfflineExecutionStatus.FAILED.isTerminal()).isTrue();
     assertThat(OfflineExecutionStatus.CANCELED.isTerminal()).isTrue();
-    assertThat(OfflineExecutionStatus.LOST.isTerminal()).isTrue();
+    assertThat(OfflineExecutionStatus.UNKNOWN.isTerminal()).isFalse();
+    assertThat(OfflineExecutionStatus.LOST.isTerminal()).isFalse();
   }
 
   @Test
@@ -31,5 +34,7 @@ class OfflineExecutionStatusTest {
         .isEqualTo(OfflineExecutionStatus.SUCCEEDED);
     assertThat(OfflineExecutionStatus.parse("CANCELLING"))
         .isEqualTo(OfflineExecutionStatus.CANCELED);
+    assertThat(OfflineExecutionStatus.parse("LOST"))
+        .isEqualTo(OfflineExecutionStatus.UNKNOWN);
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapterBatchBindingTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobExecutionRepositoryAdapterBatchBindingTest.java
@@ -25,6 +25,17 @@ class OfflineJobExecutionRepositoryAdapterBatchBindingTest {
   }
 
   @Test
+  void delegatesDurableRetryReservationToDao() {
+    OfflineJobExecutionDao dao = mock(OfflineJobExecutionDao.class);
+    when(dao.reserveRetry(org.mockito.ArgumentMatchers.eq(9L), any())).thenReturn(true);
+    OfflineJobExecutionRepositoryAdapter repository =
+        new OfflineJobExecutionRepositoryAdapter(dao);
+
+    assertThat(repository.reserveRetry(9L)).isTrue();
+    verify(dao).reserveRetry(org.mockito.ArgumentMatchers.eq(9L), any());
+  }
+
+  @Test
   void rejectsInvalidBindingIdentityBeforeDao() {
     OfflineJobExecutionDao dao = mock(OfflineJobExecutionDao.class);
     OfflineJobExecutionRepositoryAdapter repository =
@@ -36,5 +47,8 @@ class OfflineJobExecutionRepositoryAdapterBatchBindingTest {
     assertThatThrownBy(() -> repository.bindBatch(9L, 0L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("BatchExecutionId");
+    assertThatThrownBy(() -> repository.reserveRetry(0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ExecutionId");
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -1,24 +1,35 @@
 package io.yak.ops.business.sync.offline.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -142,6 +153,114 @@ class OfflineExecutionClaimServiceTest {
     verify(executionRepository, never()).hasActiveExecution(10L);
     verify(batchRepository, never()).insert(any(BatchExecution.class));
     verify(executionRepository, never()).insert(any(OfflineJobExecution.class));
+  }
+
+  @Test
+  void shouldCreateRetryFromFrozenBatchWithoutReadingCurrentTaskOrSchedule() {
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{\"job\":\"frozen\"}");
+    BatchExecution batch = frozenBatch(77L, 3);
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));
+    when(executionRepository.reserveRetry(99L)).thenReturn(true);
+    when(executionRepository.insert(any(OfflineJobExecution.class)))
+        .thenAnswer(invocation -> {
+          OfflineJobExecution execution = invocation.getArgument(0);
+          execution.setId(100L);
+          return true;
+        });
+
+    ClaimResult result = service.claimRetry(99L);
+    OfflineJobExecution retry = result.getExecution();
+
+    assertThat(retry.getId()).isEqualTo(100L);
+    assertThat(retry.getBatchId()).isEqualTo(77L);
+    assertThat(retry.getAttemptNo()).isEqualTo(2);
+    assertThat(retry.getRetryFromExecutionId()).isEqualTo(99L);
+    assertThat(retry.getTriggerType()).isEqualTo("RETRY");
+    assertThat(retry.getDefinitionVersion()).isEqualTo(3);
+    assertThat(retry.getConfigDigest()).isEqualTo("frozen-digest");
+    assertThat(retry.getDefinitionSnapshotJson()).isEqualTo("{\"definition\":\"frozen\"}");
+    assertThat(retry.getSubmittedConfig()).isEqualTo("{\"job\":\"frozen\"}");
+    assertThat(retry.getIdempotencyKey()).isEqualTo("offline-retry:77:2");
+    assertThat(result.isReused()).isFalse();
+
+    InOrder order = inOrder(executionRepository);
+    order.verify(executionRepository).reserveRetry(99L);
+    order.verify(executionRepository).insert(retry);
+    verifyNoInteractions(definitionService, definitionRepository, scheduleRepository);
+  }
+
+  @Test
+  void shouldRejectUnknownWithoutBlindRetry() {
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{\"job\":\"frozen\"}");
+    previous.setStatus("UNKNOWN");
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L, 3)));
+
+    assertThatThrownBy(() -> service.claimRetry(99L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("UNKNOWN")
+        .hasMessageContaining("reconcile");
+
+    verify(executionRepository, never()).reserveRetry(99L);
+    verify(executionRepository, never()).insert(any(OfflineJobExecution.class));
+  }
+
+  @Test
+  void shouldRespectFrozenRetryMaxAttempts() {
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{\"job\":\"frozen\"}");
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L, 1)));
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));
+
+    assertThatThrownBy(() -> service.claimRetry(99L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("最大 Attempt");
+
+    verify(executionRepository, never()).reserveRetry(99L);
+  }
+
+  @Test
+  void shouldRejectLegacyRetryWithoutBatchIdentity() {
+    OfflineJobExecution previous = failedAttempt(99L, null, 1, "{\"job\":\"legacy\"}");
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+
+    assertThatThrownBy(() -> service.claimRetry(99L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("未绑定 Batch");
+  }
+
+  private OfflineJobExecution failedAttempt(
+      Long id,
+      Long batchId,
+      int attemptNo,
+      String submittedConfig) {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(id);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(batchId);
+    execution.setAttemptNo(attemptNo);
+    execution.setStatus("FAILED");
+    execution.setSubmittedConfig(submittedConfig);
+    execution.setRetryCreated(false);
+    return execution;
+  }
+
+  private BatchExecution frozenBatch(long id, int maxAttempts) {
+    return new BatchExecution(
+        id,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot(
+            "{\"definition\":\"frozen\"}",
+            3,
+            new RetryPolicySnapshot(maxAttempts, 30),
+            "frozen-digest"),
+        BatchStatus.PENDING,
+        List.of());
   }
 
   private void stubBatchInsert(long id) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
@@ -2,24 +2,31 @@ package io.yak.ops.business.sync.offline.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
-import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
 import java.net.ConnectException;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,10 +38,10 @@ class OfflineExecutionOrchestratorTest {
 
   @Mock private OfflineJobDefinitionService definitionService;
   @Mock private OfflineExecutionClaimService claimService;
-  @Mock private OfflineJobDefinitionDao definitionDao;
-  @Mock private OfflineJobExecutionDao executionDao;
-  @Mock private OfflineExecutionControlRepository executionRepository;
-  @Mock private OfflineScheduleRepository scheduleRepository;
+  @Mock private OfflineJobDefinitionRepository definitionRepository;
+  @Mock private OfflineJobExecutionRepository executionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineExecutionEventRepository eventRepository;
   @Mock private LinkUpClient linkUpClient;
 
   private OfflineExecutionOrchestrator service;
@@ -44,30 +51,32 @@ class OfflineExecutionOrchestratorTest {
     service = new OfflineExecutionOrchestrator(
         definitionService,
         claimService,
-        definitionDao,
-        executionDao,
+        definitionRepository,
         executionRepository,
-        scheduleRepository,
+        batchRepository,
+        eventRepository,
         linkUpClient,
-        new OfflineSyncProperties(),
         new ObjectMapper());
   }
 
   @Test
-  void shouldPersistFailureWhenLinkUpCannotBeReached() {
-    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+  void shouldScheduleFailedRetryFromFrozenBatchPolicy() {
+    OfflineJobDefinition definition = new OfflineJobDefinition();
     definition.setId(10L);
 
-    OfflineJobExecutionPO execution = new OfflineJobExecutionPO();
+    OfflineJobExecution execution = new OfflineJobExecution();
     execution.setId(99L);
     execution.setJobDefinitionId(10L);
+    execution.setBatchId(77L);
     execution.setStatus("CREATED");
     execution.setStateVersion(1L);
     execution.setAttemptNo(1);
 
     when(claimService.claim(10L, "WORKFLOW", null, 1))
         .thenReturn(new ClaimResult(definition, "{}", execution));
-    when(definitionDao.selectById(10L)).thenReturn(definition);
+    when(definitionService.resolveExecutionJobSpec(definition)).thenReturn("{}");
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch()));
+    when(definitionRepository.findById(10L)).thenReturn(Optional.of(definition));
     when(linkUpClient.node())
         .thenThrow(new LinkUpTransportException(
             "无法连接 Link-Up Server：http://127.0.0.1:18080",
@@ -79,25 +88,49 @@ class OfflineExecutionOrchestratorTest {
         .hasMessage("无法连接 Link-Up Server：http://127.0.0.1:18080");
 
     assertThat(execution.getStatus()).isEqualTo("FAILED");
+    assertThat(execution.getNextRetryTime()).isNotNull();
     assertThat(execution.getErrorMessage())
         .isEqualTo("无法连接 Link-Up Server：http://127.0.0.1:18080");
-    assertThat(execution.getEndTime()).isNotNull();
-    verify(executionDao, atLeastOnce()).updateById(execution);
-    verify(executionRepository).recordExecutionEvent(
-        eq(99L),
-        eq(1L),
-        isNull(),
-        eq("CREATED"),
-        eq("EXECUTION_CREATED"),
-        eq("使用 application.yml 中的固定 Link-Up 地址"),
-        isNull());
-    verify(executionRepository).recordExecutionEvent(
-        eq(99L),
-        eq(2L),
-        eq("CREATED"),
-        eq("FAILED"),
-        eq("FAILED"),
-        eq("无法连接 Link-Up Server：http://127.0.0.1:18080"),
-        isNull());
+    verify(executionRepository, atLeastOnce()).update(execution);
+    verify(batchRepository).findById(77L);
+    verify(eventRepository, atLeastOnce()).append(any());
+  }
+
+  @Test
+  void shouldMoveUncertainExecutionToUnknownWithoutRetryTime() {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(99L);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(77L);
+    execution.setStatus("RUNNING");
+    execution.setStateVersion(3L);
+    execution.setAttemptNo(1);
+    execution.setNextRetryTime(java.time.LocalDateTime.now().plusMinutes(1));
+    execution.setEndTime(java.time.LocalDateTime.now());
+    when(definitionRepository.findById(10L)).thenReturn(Optional.empty());
+
+    service.markUnknown(execution, "状态无法确认");
+
+    assertThat(execution.getStatus()).isEqualTo("UNKNOWN");
+    assertThat(execution.getNextRetryTime()).isNull();
+    assertThat(execution.getEndTime()).isNull();
+    verify(executionRepository).update(execution);
+    verify(eventRepository).append(any());
+  }
+
+  private BatchExecution frozenBatch() {
+    return new BatchExecution(
+        77L,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(3, 30),
+            "digest"),
+        BatchStatus.PENDING,
+        List.of());
   }
 }


### PR DESCRIPTION
## Stage 6 · Wave 3

本 PR 以模块 `DOMAIN.md` 为领域约束，落实 `Retry / UNKNOWN + durable retry reservation`，并同步更新 Wave 2 / Wave 3 文档进度。

### 本次领域改造

- Retry 不再走普通 `execute()`，新增独立的 Batch 内 Retry claim
- Retry 固定复用原 `BatchExecution`，不创建新 Batch
- Retry 从 Batch 冻结证据读取：
  - `DefinitionRevision`
  - `ExecutionSnapshot`
  - `RetryPolicySnapshot`
  - `configDigest`
- 过渡期逻辑 JobSpec 从同 Batch 的 Attempt 1 `submittedConfig` 读取，不回读 current Task；凭据仍只在 Attempt 提交边界解析
- Retry Attempt 使用稳定幂等身份：`offline-retry:{batchId}:{attemptNo}`
- `retry_created` 改为 CAS durable reservation；reservation 与下一 Attempt insert 处于同一事务，避免并发重复 Retry
- 自动 Retry candidate 只允许明确 `FAILED` 且已绑定 Batch 的 Attempt
- `UNKNOWN != FAILED`：
  - 新增 `UNKNOWN` legacy runtime 状态
  - 旧 `LOST` 输入统一映射为 `UNKNOWN`
  - UNKNOWN / LOST 不进入自动 Retry candidate
  - reconcile 超时或 worker instance 变化改为 UNKNOWN，继续 reconcile，不盲目 Retry
- Wave 1 以前 `batch_id = NULL` 的历史 execution 明确禁止安全 Retry，避免通过 current Task / SchedulePolicy 猜测历史语义

### 文档进度同步

`DOMAIN.md` 与 `docs/offline-sync/domain/README.md` 已更新为：

```text
Wave 0  DONE  Core VO + compatibility mapper
Wave 1  DONE  Batch persistence + execution.bind(batch_id)
Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
Wave 4  NEXT  Runtime truth -> Batch/Attempt; Task last-* projection only
Wave 5        Backfill / Cursor
Wave 6        Legacy cleanup
```

同时移除了已由 Wave 2 / Wave 3 解决的 Domain Debt，保留 Wave 4 之后仍真实存在的债务：legacy execution-centered runtime、Batch status 尚未成为完整 runtime truth、Task last-* 仍参与部分判断、历史 NULL batch_id 不可安全 Retry。

### 边界 / 非目标

本 PR **不**：

- 把 Batch / Attempt 切成完整 runtime truth（Wave 4）
- 清理 Task `last-*` 生命周期判断（Wave 4）
- 实现 Backfill / Cursor 推进（Wave 5）
- 清理 legacy execution（Wave 6）
- 引入 immutable DefinitionVersion
- 抽 Realtime / Offline Shared Sync Kernel

### 测试覆盖

新增/更新测试覆盖：

- Retry 使用冻结 Batch Snapshot / RetryPolicy / Attempt 1 JobSpec
- Retry 路径不读取 current Task / current SchedulePolicy
- CAS reservation 先于下一 Attempt insert
- UNKNOWN 禁止盲目 Retry
- 冻结 `maxAttempts` 生效
- legacy NULL batch_id 禁止安全 Retry
- legacy LOST -> UNKNOWN
- UNKNOWN 保持 reconcileable / non-terminal
- repository durable reservation delegation
- FAILED 自动重试时间来自冻结 Batch RetryPolicy

> 当前环境无法直接执行仓库 Maven 测试；PR 保持 Draft，等待 CI / 本地 Maven 验证。