### PR TITLE
refactor(offline-sync): switch runtime truth to batch

### DIFF
--- a/docs/offline-sync/domain/README.md
+++ b/docs/offline-sync/domain/README.md
@@ -1,6 +1,6 @@
 # Offline Sync Domain
 
-> 当前实现阶段：Stage 6 / Wave 3。本文保留当前代码到目标领域的迁移映射；日常开发规则以模块 `DOMAIN.md` 为准。
+> 当前实现阶段：Stage 6 / Wave 4。本文保留当前代码到目标领域的迁移映射；日常开发规则以模块 `DOMAIN.md` 为准。
 
 ## 1. 目标模型
 
@@ -18,7 +18,7 @@ BatchExecution
           Engine Adapter
 ```
 
-硬规则：`Task != Batch != Attempt`；Retry 复用原 Batch/Scope/Snapshot；`UNKNOWN != FAILED`。
+硬规则：`Task != Batch != Attempt`；Retry 复用原 Batch/Scope/Snapshot；`UNKNOWN != FAILED`；Batch runtime status 只由 latest Attempt 推导。
 
 ## 2. 当前 Mapping
 
@@ -31,49 +31,108 @@ BatchExecution
 | `job_spec_json` | Link-Up 执行产物，不是定义真相 | ADAPT |
 | `release_state` | Task 是否允许产生新 Batch | KEEP |
 | `OfflineSchedule` | SchedulePolicy + RetryPolicy + runtime projection | ADAPT |
-| `yak_offline_batch_execution` | `BatchExecution` persistence | WAVE 1 DONE |
-| `yak_offline_job_execution.batch_id` | Attempt -> Batch 绑定 | WAVE 1 DONE / nullable |
+| `yak_offline_batch_execution` | `BatchExecution` persistence + runtime truth | WAVE 4 DONE |
+| `yak_offline_job_execution.batch_id` | Attempt -> Batch 绑定 | WAVE 1 DONE / nullable history |
 | Trigger claim | `Trigger -> Batch -> Attempt 1` | WAVE 2 DONE |
 | Schedule identity | `scheduleId + plannedFireTime` BatchKey | WAVE 2 DONE |
 | `retry_created` | FAILED Attempt 的 durable Retry reservation | WAVE 3 DONE |
 | Retry Attempt | same Batch + frozen Snapshot/RetryPolicy | WAVE 3 DONE |
 | `UNKNOWN` / legacy `LOST` | 不确定结果，持续 reconcile，不自动 Retry | WAVE 3 DONE |
-| `OfflineJobExecution` | legacy 运行链仍混合 Batch + Attempt | MIGRATE |
+| Batch status dual-write | latest Attempt -> BatchStatus | WAVE 4 DONE |
+| Task command occupancy | `RUNNING/WAITING_RETRY/UNKNOWN` Batch | WAVE 4 DONE |
+| Task `last-*` | Read Model projection only | WAVE 4 DONE |
+| `OfflineJobExecution` | Attempt persistence compatibility view | MIGRATE |
 | `attempt_no / retry_from_execution_id` | Attempt 次序/血缘 | KEEP |
 | `idempotency_key / external_execution_id` | Attempt 幂等与外部提交身份 | KEEP |
 | `engine_job_id / worker_instance_id` | Engine evidence | KEEP |
 | metrics / error / start/end | Attempt 运行证据 | KEEP |
 | legacy execution snapshot | 过渡期兼容副本；Retry 从 Attempt 1 读取冻结 JobSpec | MIGRATE |
 | `OfflineExecutionEvent` | Attempt 事件历史 | KEEP |
-| Task `last-*` | 只允许做 Read Model projection | MIGRATE |
 | Link-Up / credential resolver | Infrastructure boundary | KEEP |
 
-## 3. 当前仍未解决的 Domain Debt
+## 3. Wave 4 Runtime Truth
 
-### Runtime truth 尚未切换
-
-Batch 已经真实创建，Retry/UNKNOWN 也已经按 Batch 规则运行，但 Task `lastJobStatus` 和 legacy execution 查询仍参与部分命令判断。
-
-Wave 4 目标：
+Wave 4 把运行真相从 Task/legacy execution 判断切换为：
 
 ```text
-Runtime truth
-  -> BatchExecution
-  -> latest ExecutionAttempt
-
-Task last-*
-  -> projection only
+Task command
+    │
+    ▼
+BatchExecution
+    │ status
+    ▼
+latest ExecutionAttempt
 ```
 
-### Batch 生命周期尚未完整 dual-write
+BatchStatus 推导规则：
 
-`yak_offline_batch_execution.status` 已有持久化字段，但当前执行状态更新仍主要落在 legacy execution；Wave 4 才会把 Batch / Attempt 生命周期切成运行真相。
+```text
+CREATED / SUBMITTED / QUEUED / RUNNING -> RUNNING
+FAILED + nextRetryTime                 -> WAITING_RETRY
+FAILED                                 -> FAILED
+UNKNOWN / legacy LOST                  -> UNKNOWN
+SUCCEEDED                              -> SUCCEEDED
+CANCELED                               -> CANCELED
+```
 
-### Legacy history 无 Batch identity
+关键约束：
 
-Wave 1 前历史 execution 允许 `batch_id = NULL`。这类记录没有冻结的 BatchScope / RetryPolicy Snapshot，因此 Wave 3 明确禁止从它们安全 Retry，不通过回读 current Task/SchedulePolicy 猜测历史语义。
+- Attempt persistence 更新后同步刷新 Batch status；
+- Batch status 每次重新读取同 Batch 的 latest Attempt 后推导，不使用调用方传入的旧 Attempt 直接覆盖；
+- 旧 Attempt 的晚到 reconcile 不能把新 Attempt 已形成的 Batch 状态回退；
+- Initial Attempt 创建后 Batch 从 `PENDING` 切到 `RUNNING`；
+- Retry Attempt 创建后 Batch 从 `WAITING_RETRY` 切回 `RUNNING`；
+- FAILED 且仍有 Retry 窗口时 Batch 是 `WAITING_RETRY`，仍占用 V1 Task 执行槽位；
+- UNKNOWN Batch 继续占用执行槽位，必须先 reconcile；
+- `SUCCEEDED / FAILED / CANCELED` 是 Batch 终态。
 
-## 4. Wave 1-3 已完成迁移
+### 命令侧切换
+
+以下判断现在统一读取 Batch runtime truth：
+
+- 新 Batch 创建的 V1 单任务并发限制；
+- Schedule 到点时是否跳过本次触发；
+- Task 下线；
+- Task 删除；
+- Task 编辑保护；
+- Task 级 `cancelLatest`。
+
+`cancelLatest` 不再读取 `Task.lastExecutionId`。对于 `RUNNING / UNKNOWN` Batch，停止 latest Attempt；对于 `WAITING_RETRY` Batch，没有活动引擎 Attempt，因此直接关闭 Retry window，并把 Batch 标记为 `CANCELED`，已失败 Attempt 的历史证据保持不变。
+
+### Task last-* 投影
+
+`lastExecutionId / lastEngineJobId / lastJobStatus / lastErrorMessage / metrics` 继续写入 Task，目的是兼容列表和详情查询。它们不再用于运行、停止、编辑、下线、删除或调度并发判断。
+
+### 历史 Batch 回填
+
+Wave 2 / Wave 3 期间 Batch 创建后长期保持初始 `PENDING`，因此 Wave 4 新增 V3 data migration：按照每个 Batch 的 latest bound Attempt 回填 `yak_offline_batch_execution.status`。不增加新表或新列。
+
+## 4. 当前仍未解决的 Domain Debt
+
+### Backfill / Cursor 尚未迁移
+
+补数与 Cursor 推进还没有按目标模型完整实现。Wave 5 需要保证：
+
+```text
+Backfill request
+  -> Batch group
+  -> explicit BatchScope
+
+Cursor
+  -> only Batch SUCCEEDED advances
+```
+
+`FAILED / CANCELED / UNKNOWN` 一律不能推进 Cursor。
+
+### Legacy Attempt persistence 仍保留 execution 形态
+
+`yak_offline_job_execution` 已承担 Attempt persistence，但类名、表名和部分字段仍保留旧 execution-centered 结构。Wave 6 再做 contract/cleanup，不在 Wave 4 为了命名整洁重建历史。
+
+### Wave 1 前历史没有 Batch identity
+
+旧 execution 允许 `batch_id = NULL`。这类记录没有冻结 BatchScope / RetryPolicy Snapshot，不参与新的 Batch runtime truth，也不允许通过 current Task/SchedulePolicy 猜测后安全 Retry。
+
+## 5. Wave 1-4 已完成迁移
 
 当前持久化关系：
 
@@ -89,36 +148,39 @@ yak_offline_job_execution
 
 已完成约束：
 
-- execution `batch_id` nullable，旧记录不要求回填；
-- `bindBatch(executionId, batchId)` 只允许 `NULL -> batchId` 或重复绑定同一个 Batch；
+- execution `batch_id` nullable，旧记录不强制回填；
 - Trigger 先创建 Batch，再创建 Attempt 1；
 - Schedule BatchKey 使用稳定 planned fire identity；
 - Retry 不创建新 Batch，不回读 current Task；
 - RetryPolicy 从 Batch `ExecutionSnapshot` 读取，不回读 current SchedulePolicy；
 - Retry 使用 Attempt 1 已冻结的逻辑 JobSpec，只在提交边界解析最新凭据；
-- `retry_created` 通过 CAS reservation 防止并发创建重复 Attempt，reservation 与新 Attempt insert 同事务；
+- `retry_created` 使用 CAS durable reservation，reservation 与新 Attempt insert 同事务；
 - FAILED 才能 Retry；UNKNOWN / legacy LOST 只 reconcile；
+- Batch status 与 Attempt 生命周期 dual-write；
+- Batch status 只由 latest Attempt 推导；
+- V1 Task occupancy 只看 `RUNNING / WAITING_RETRY / UNKNOWN` Batch；
+- Task `last-*` 只作为查询投影；
 - 不创建物理 FK；
 - Engine Job、metrics、error 继续属于 Attempt persistence。
 
-## 5. 迁移波次
+## 6. 迁移波次
 
 ```text
 Wave 0  DONE  Core VO + compatibility mapper
 Wave 1  DONE  Batch persistence + execution.bind(batch_id)
 Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
 Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
-Wave 4  NEXT  Runtime truth -> Batch/Attempt; Task last-* projection only
-Wave 5        Backfill / Cursor
+Wave 4  DONE  Runtime truth -> Batch/Attempt; Task last-* projection only
+Wave 5  NEXT  Backfill / Cursor
 Wave 6        Legacy cleanup
 ```
 
 采用 `expand -> dual read/write -> switch -> verify -> contract`，不做一次性 schema 重建。
 
-## 6. 当前结论
+## 7. 当前结论
 
-1. Batch 已成为 Trigger 的真实业务身份，Attempt 1 与后续 Retry Attempt 都绑定同一 Batch。
-2. Retry 已固定 Batch/Scope/Snapshot/RetryPolicy，不再通过 current Task/SchedulePolicy 漂移。
-3. UNKNOWN 已与 FAILED 分离，不确定结果只 reconcile，不自动 Retry。
-4. `yak_offline_job_execution` 继续作为过渡期 Attempt persistence；Batch/Attempt runtime truth 在 Wave 4 切换。
-5. 暂不引入 immutable DefinitionVersion，也不抽 Realtime/Offline Shared Kernel。
+1. Batch 已经同时承担业务身份和运行状态真相；Attempt 承担每次实际提交证据。
+2. Retry 固定 Batch/Scope/Snapshot/RetryPolicy，UNKNOWN 与 FAILED 分离。
+3. Task 命令生命周期不再依赖 `last-*` 或 `hasActiveExecution()`；Task `last-*` 仅保留查询投影职责。
+4. legacy `yak_offline_job_execution` 继续作为 Attempt persistence compatibility view，命名和历史清理留到 Wave 6。
+5. 下一步 Wave 5 只处理 Backfill / Cursor，不提前抽 Shared Sync Kernel，也不引入 immutable DefinitionVersion。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
@@ -36,10 +36,11 @@ BatchExecution
 10. Backfill 创建一组 Batch，不创建新的 Task 类型；同一次 Backfill 优先共享同一 Snapshot。
 11. Cursor 只允许在 Batch `SUCCEEDED` 后推进；`FAILED / CANCELED / UNKNOWN` 不得推进。
 12. Task `last-*` 只能作为查询投影；运行真相只能来自 Batch / Attempt。
-13. `DefinitionRevision` 只是修订标识，不等于 immutable `DefinitionVersion`。
-14. Link-Up Job / Worker / Quartz / HTTP DTO / DataSource credential 都不是 Core Domain 对象。
-15. SyncDefinition / Snapshot 不长期保存密码；凭据只在 Attempt 提交边界解析。
-16. 实时同步和离线同步保持独立 Core；不得因为名字相似提前抽 Shared Sync Kernel。
+13. Batch 状态必须由同 Batch 的 latest Attempt 推导；旧 Attempt 的晚到事件不得回退 Batch 真相。
+14. `DefinitionRevision` 只是修订标识，不等于 immutable `DefinitionVersion`。
+15. Link-Up Job / Worker / Quartz / HTTP DTO / DataSource credential 都不是 Core Domain 对象。
+16. SyncDefinition / Snapshot 不长期保存密码；凭据只在 Attempt 提交边界解析。
+17. 实时同步和离线同步保持独立 Core；不得因为名字相似提前抽 Shared Sync Kernel。
 
 ## Domain Impact Analysis
 
@@ -51,29 +52,43 @@ BatchExecution
 4. 是否改变 BatchKey / 幂等身份？
 5. 是否让 Retry 回读 current Task 或 current SchedulePolicy？
 6. 是否把 Task `last-*`、Engine 状态或外部 JobId 当成领域真相？
-7. 是否引入新的 `sceneType/syncType`、技术类型或凭据泄漏？
-8. 是否能映射现有模型？不能映射则记录 `Domain Gap`，先设计再编码。
+7. Batch 状态是否仍由 latest Attempt 唯一推导？
+8. 是否引入新的 `sceneType/syncType`、技术类型或凭据泄漏？
+9. 是否能映射现有模型？不能映射则记录 `Domain Gap`，先设计再编码。
 
 ## Current Transition
 
-当前代码尚未完全满足上述目标模型。Wave 2 / Wave 3 已解决 Trigger、Schedule BatchKey、Retry 漂移与 UNKNOWN 自动重试问题；仍保留的主要 Domain Debt：
+Wave 2 / Wave 3 / Wave 4 已完成 Trigger、Retry/UNKNOWN 与 runtime truth 主链迁移。当前命令侧运行真相为：
 
 ```text
-OfflineJobExecution = legacy 运行链仍以 execution 为中心
-Batch status         = 已持久化，但尚未成为完整 runtime truth
-Task last-*          = 仍部分参与生命周期判断
-Legacy history       = Wave 1 前 execution 允许没有 batch_id，不可安全 Retry
+Task command
+    │
+    ▼
+BatchExecution status
+    │
+    ▼
+latest ExecutionAttempt
+
+Task last-* = projection only
 ```
 
-Wave 2 已切成 `Trigger -> Batch -> Attempt 1`，Schedule BatchKey 固定为 `scheduleId + plannedFireTime`。Wave 3 已把 Retry 切成原 Batch 内新 Attempt：从 Batch 读取冻结的 Snapshot / RetryPolicy，从 Attempt 1 读取过渡期冻结 JobSpec；`retry_created` 通过 CAS reservation 与下一 Attempt 创建处于同一事务。`LOST` 仅作为旧数据兼容输入并统一解释为 `UNKNOWN`，UNKNOWN 继续 reconcile，不进入自动 Retry。
+Wave 4 状态推导固定为：活动 Attempt -> `RUNNING`；FAILED 且存在 `nextRetryTime` -> `WAITING_RETRY`；FAILED 无 Retry 窗口 -> `FAILED`；UNKNOWN -> `UNKNOWN`；SUCCEEDED/CANCELED 对应同名 Batch 终态。Attempt 状态写入与 Batch 状态刷新 dual-write；Wave 2/3 历史 Batch 通过 V3 migration 从 latest Attempt 回填 runtime status。
+
+仍保留的主要 Domain Debt：
+
+```text
+OfflineJobExecution = legacy 名称/结构仍作为 Attempt persistence compatibility view
+Legacy history       = Wave 1 前 execution 可无 batch_id，不属于 Batch runtime truth
+Backfill / Cursor    = 尚未切入目标 BatchScope / Cursor 推进规则
+```
 
 ```text
 Wave 0  DONE  Core VO + compatibility mapper
 Wave 1  DONE  Batch persistence + execution.bind(batch_id)
 Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
 Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
-Wave 4  NEXT  Runtime truth -> Batch/Attempt; Task last-* projection only
-Wave 5        Backfill / Cursor
+Wave 4  DONE  Runtime truth -> Batch/Attempt; Task last-* projection only
+Wave 5  NEXT  Backfill / Cursor
 Wave 6        Legacy cleanup
 ```
 
@@ -86,9 +101,10 @@ Wave 6        Legacy cleanup
 - 把 Retry 实现成一次新的普通 execute；
 - 把 UNKNOWN/LOST 直接当 FAILED 自动重试；
 - 用 `hasActiveExecution()` 代替 Batch 级并发和 reservation；
+- 用 Task `lastJobStatus / lastExecutionId` 决定运行、停止、编辑、下线或删除；
+- 用非 latest Attempt 的状态覆盖 Batch runtime truth；
 - 用 actual callback time 作为 Schedule Batch 身份；
 - 让 Attempt 自己重新生成 Snapshot；
-- 用 Task `lastJobStatus` 决定真实运行状态；
 - 把 Link-Up JobSpec、Worker、Connector、Quartz 类型放进 Core Domain；
 - 为“全量/增量/单表/多表/补数”继续增加任务类型枚举；
 - 为了和 realtime 一致而提前增加 immutable DefinitionVersion 或 Shared Sync Kernel。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineBatchExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineBatchExecutionDao.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.sync.offline.dao;
 
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import java.util.List;
 
 /** 离线同步业务批次数据访问接口。 */
 public interface OfflineBatchExecutionDao {
@@ -8,6 +9,10 @@ public interface OfflineBatchExecutionDao {
   OfflineBatchExecutionPO selectById(Long id);
 
   OfflineBatchExecutionPO selectByTaskIdAndBatchKey(Long taskId, String batchKey);
+
+  boolean existsByTaskIdAndStatuses(Long taskId, List<String> statuses);
+
+  OfflineBatchExecutionPO selectLatestByTaskIdAndStatuses(Long taskId, List<String> statuses);
 
   boolean insert(OfflineBatchExecutionPO batchPO);
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineBatchExecutionMapper;
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -29,6 +30,28 @@ public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
         Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
             .eq(OfflineBatchExecutionPO::getJobDefinitionId, taskId)
             .eq(OfflineBatchExecutionPO::getBatchKey, batchKey.trim())
+            .last("LIMIT 1"));
+  }
+
+  @Override
+  public boolean existsByTaskIdAndStatuses(Long taskId, List<String> statuses) {
+    if (taskId == null || taskId <= 0L || statuses == null || statuses.isEmpty()) return false;
+    return mapper.selectCount(
+        Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(OfflineBatchExecutionPO::getJobDefinitionId, taskId)
+            .in(OfflineBatchExecutionPO::getStatus, statuses)) > 0L;
+  }
+
+  @Override
+  public OfflineBatchExecutionPO selectLatestByTaskIdAndStatuses(
+      Long taskId,
+      List<String> statuses) {
+    if (taskId == null || taskId <= 0L || statuses == null || statuses.isEmpty()) return null;
+    return mapper.selectOne(
+        Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(OfflineBatchExecutionPO::getJobDefinitionId, taskId)
+            .in(OfflineBatchExecutionPO::getStatus, statuses)
+            .orderByDesc(OfflineBatchExecutionPO::getId)
             .last("LIMIT 1"));
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepository.java
@@ -11,6 +11,12 @@ public interface OfflineBatchExecutionRepository {
 
   Optional<BatchExecution> findByTaskIdAndBatchKey(long taskId, BatchKey batchKey);
 
+  /** V1 Task runtime truth：RUNNING / WAITING_RETRY / UNKNOWN Batch 会占用任务执行槽位。 */
+  boolean hasOccupyingBatch(long taskId);
+
+  /** 返回任务最近一个占用执行槽位的 Batch；命令判断不得回退到 Task last-*。 */
+  Optional<BatchExecution> findLatestOccupyingByTaskId(long taskId);
+
   BatchExecution insert(BatchExecution batch);
 
   boolean update(BatchExecution batch);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
@@ -14,6 +14,7 @@ import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
@@ -22,11 +23,17 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-/** BatchExecution 与 Wave 1 持久化模型之间的适配器。 */
+/** BatchExecution 与持久化模型之间的适配器。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
 @RequiredArgsConstructor
 public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecutionRepository {
+
+  private static final List<String> OCCUPYING_STATUSES =
+      Arrays.stream(BatchStatus.values())
+          .filter(BatchStatus::occupiesTaskExecutionSlot)
+          .map(Enum::name)
+          .toList();
 
   private final OfflineBatchExecutionDao dao;
   private final OfflineJobExecutionRepository executionRepository;
@@ -44,11 +51,23 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
   }
 
   @Override
+  public boolean hasOccupyingBatch(long taskId) {
+    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
+    return dao.existsByTaskIdAndStatuses(taskId, OCCUPYING_STATUSES);
+  }
+
+  @Override
+  public Optional<BatchExecution> findLatestOccupyingByTaskId(long taskId) {
+    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
+    return Optional.ofNullable(toDomain(dao.selectLatestByTaskIdAndStatuses(taskId, OCCUPYING_STATUSES)));
+  }
+
+  @Override
   public BatchExecution insert(BatchExecution batch) {
     Objects.requireNonNull(batch, "BatchExecution 不能为空");
     if (batch.id() != null) throw new IllegalArgumentException("新 Batch 不应预先包含 ID");
     if (!batch.attempts().isEmpty()) {
-      throw new IllegalArgumentException("Wave 1 创建 Batch 时不能同时持久化 Attempt");
+      throw new IllegalArgumentException("创建 Batch 时不能同时持久化 Attempt");
     }
     OfflineBatchExecutionPO po = toPO(batch);
     if (!dao.insert(po) || po.getId() == null) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
@@ -9,17 +9,17 @@ import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
 import io.yak.ops.business.sync.offline.domain.compat.LegacyBatchTriggerCompatibilityMapper;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.service.OfflineBatchRuntimeService;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionOrchestrator;
 import org.springframework.stereotype.Component;
 
-/** Yak Schedule 离线同步 Handler：到点后统一进入现有 Offline Execution 执行链。 */
+/** Yak Schedule 离线同步 Handler：到点后统一进入 Batch -> Attempt 执行链。 */
 @ConditionalOnOfflineSyncEnabled
 @Component(OfflineScheduleEngineBridge.HANDLER)
 public class OfflineScheduleHandler implements ScheduleHandler {
   private final OfflineJobDefinitionRepository definitionRepository;
-  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineBatchRuntimeService batchRuntimeService;
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineExecutionOrchestrator orchestrator;
   private final OfflineScheduleEngineBridge engine;
@@ -27,13 +27,13 @@ public class OfflineScheduleHandler implements ScheduleHandler {
 
   public OfflineScheduleHandler(
       OfflineJobDefinitionRepository definitionRepository,
-      OfflineJobExecutionRepository executionRepository,
+      OfflineBatchRuntimeService batchRuntimeService,
       OfflineScheduleRepository scheduleRepository,
       OfflineExecutionOrchestrator orchestrator,
       OfflineScheduleEngineBridge engine,
       OfflineScheduleLifecycle lifecycle) {
     this.definitionRepository = definitionRepository;
-    this.executionRepository = executionRepository;
+    this.batchRuntimeService = batchRuntimeService;
     this.scheduleRepository = scheduleRepository;
     this.orchestrator = orchestrator;
     this.engine = engine;
@@ -57,9 +57,9 @@ public class OfflineScheduleHandler implements ScheduleHandler {
       return ScheduleExecutionResult.accepted(null, "离线同步任务未启用调度，本次触发忽略");
     }
 
-    if (executionRepository.hasActiveExecution(definitionId)) {
+    if (batchRuntimeService.hasOccupyingBatch(definitionId)) {
       lifecycle.refreshRuntimeState(definitionId, context.actualFireTime());
-      return ScheduleExecutionResult.accepted(null, "任务已有运行实例，本次调度触发跳过");
+      return ScheduleExecutionResult.accepted(null, "任务已有运行中的 BatchExecution，本次调度触发跳过");
     }
 
     try {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeService.java
@@ -1,0 +1,171 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Wave 4 runtime truth boundary.
+ *
+ * <p>BatchExecution 是业务运行真相，状态只由同 Batch 的 latest Attempt 推导。Task last-* 只允许作为查询投影，
+ * 不得进入这里的命令判断。
+ */
+@ConditionalOnOfflineSyncEnabled
+@Service
+@RequiredArgsConstructor
+public class OfflineBatchRuntimeService {
+
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineJobExecutionRepository executionRepository;
+
+  public boolean hasOccupyingBatch(Long taskId) {
+    return batchRepository.hasOccupyingBatch(positive(taskId, "TaskId"));
+  }
+
+  public Optional<BatchExecution> findLatestOccupyingBatch(Long taskId) {
+    return batchRepository.findLatestOccupyingByTaskId(positive(taskId, "TaskId"));
+  }
+
+  public BatchExecution requireLatestOccupyingBatch(Long taskId) {
+    return findLatestOccupyingBatch(taskId)
+        .orElseThrow(() -> new IllegalStateException("任务没有运行中的 BatchExecution"));
+  }
+
+  /** 返回 Batch latest Attempt 的 legacy persistence view；仅作为过渡期 Attempt 存储模型使用。 */
+  public OfflineJobExecution requireLatestAttempt(BatchExecution batch) {
+    Objects.requireNonNull(batch, "BatchExecution 不能为空");
+    ExecutionAttempt latest = batch.latestAttempt()
+        .orElseThrow(() -> new IllegalStateException("BatchExecution 缺少 Attempt"));
+    if (latest.id() == null || latest.id() <= 0L) {
+      throw new IllegalStateException("latest Attempt 缺少持久化 ID");
+    }
+    OfflineJobExecution execution = executionRepository.findById(latest.id())
+        .orElseThrow(() -> new IllegalStateException("latest Attempt persistence 不存在：" + latest.id()));
+    if (!Objects.equals(execution.getBatchId(), batch.id())) {
+      throw new IllegalStateException("latest Attempt 与 BatchExecution 绑定不一致");
+    }
+    return execution;
+  }
+
+  /** Attempt 与 Batch status 在同一事务内 dual-write。 */
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public void persistAttempt(OfflineJobExecution execution) {
+    Objects.requireNonNull(execution, "Attempt persistence 不能为空");
+    if (execution.getId() == null || execution.getId() <= 0L) {
+      throw new IllegalArgumentException("AttemptId 必须大于 0");
+    }
+    if (!executionRepository.update(execution)) {
+      throw new IllegalStateException("更新离线同步 Attempt 失败：" + execution.getId());
+    }
+    refreshBatch(execution.getBatchId());
+  }
+
+  /**
+   * 从持久化的 latest Attempt 重新计算 BatchStatus。
+   *
+   * <p>不得直接使用调用方传入 Attempt 的状态，否则旧 Attempt 的晚到 reconcile 可能回退 Batch 真相。
+   */
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public void refreshBatch(Long batchId) {
+    if (batchId == null || batchId <= 0L) return;
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Attempt 绑定的 BatchExecution 不存在：" + batchId));
+    List<OfflineJobExecution> attempts = executionRepository.findByBatchId(batchId);
+    if (attempts.isEmpty()) return;
+
+    OfflineJobExecution latest = attempts.stream()
+        .max(
+            Comparator.comparingInt((OfflineJobExecution value) -> number(value.getAttemptNo(), 1))
+                .thenComparingLong(value -> number(value.getId(), 0L)))
+        .orElseThrow();
+    BatchStatus target = deriveStatus(latest);
+    if (batch.status() == target) return;
+
+    BatchExecution updated = new BatchExecution(
+        batch.id(),
+        batch.taskId(),
+        batch.batchKey(),
+        batch.trigger(),
+        batch.batchScope(),
+        batch.snapshot(),
+        target,
+        batch.attempts());
+    if (!batchRepository.update(updated)) {
+      throw new IllegalStateException("更新 BatchExecution runtime status 失败：" + batch.id());
+    }
+  }
+
+  /** WAITING_RETRY 没有活动引擎 Attempt，停止语义是原子占用 Retry reservation 后取消 Batch。 */
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineJobExecution cancelWaitingRetry(BatchExecution batch) {
+    Objects.requireNonNull(batch, "BatchExecution 不能为空");
+    if (batch.status() != BatchStatus.WAITING_RETRY) {
+      throw new IllegalStateException("只有 WAITING_RETRY Batch 可以直接取消 Retry 等待");
+    }
+    OfflineJobExecution latest = requireLatestAttempt(batch);
+    if (OfflineExecutionStatus.parse(latest.getStatus()) != OfflineExecutionStatus.FAILED) {
+      throw new IllegalStateException("WAITING_RETRY Batch 的 latest Attempt 必须是 FAILED");
+    }
+
+    // 与自动 Retry 使用同一个 CAS reservation，防止“取消等待”和“创建下一 Attempt”并发穿透。
+    if (!executionRepository.reserveRetry(latest.getId())) {
+      throw new IllegalStateException("Retry 已被其他请求保留，无法安全取消等待");
+    }
+    latest.setNextRetryTime(null);
+    latest.setRetryCreated(true);
+    latest.setUpdateTime(LocalDateTime.now());
+
+    BatchExecution canceled = new BatchExecution(
+        batch.id(),
+        batch.taskId(),
+        batch.batchKey(),
+        batch.trigger(),
+        batch.batchScope(),
+        batch.snapshot(),
+        BatchStatus.CANCELED,
+        batch.attempts());
+    if (!batchRepository.update(canceled)) {
+      throw new IllegalStateException("取消 WAITING_RETRY Batch 失败：" + batch.id());
+    }
+    return latest;
+  }
+
+  BatchStatus deriveStatus(OfflineJobExecution latest) {
+    OfflineExecutionStatus status = OfflineExecutionStatus.parse(latest.getStatus());
+    return switch (status) {
+      case CREATED, SUBMITTED, QUEUED, RUNNING -> BatchStatus.RUNNING;
+      case UNKNOWN, LOST -> BatchStatus.UNKNOWN;
+      case SUCCEEDED -> BatchStatus.SUCCEEDED;
+      case CANCELED -> BatchStatus.CANCELED;
+      case FAILED -> latest.getNextRetryTime() == null
+          ? BatchStatus.FAILED
+          : BatchStatus.WAITING_RETRY;
+    };
+  }
+
+  private long positive(Long value, String field) {
+    if (value == null || value <= 0L) throw new IllegalArgumentException(field + " 必须大于 0");
+    return value;
+  }
+
+  private int number(Integer value, int fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private long number(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -37,6 +37,7 @@ public class OfflineExecutionClaimService {
   private final OfflineJobExecutionRepository executionRepository;
   private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineScheduleRepository scheduleRepository;
+  private final OfflineBatchRuntimeService batchRuntimeService;
   private final OfflineSyncProperties properties;
 
   public OfflineExecutionClaimService(
@@ -45,12 +46,14 @@ public class OfflineExecutionClaimService {
       OfflineJobExecutionRepository executionRepository,
       OfflineBatchExecutionRepository batchRepository,
       OfflineScheduleRepository scheduleRepository,
+      OfflineBatchRuntimeService batchRuntimeService,
       OfflineSyncProperties properties) {
     this.definitionService = definitionService;
     this.definitionRepository = definitionRepository;
     this.executionRepository = executionRepository;
     this.batchRepository = batchRepository;
     this.scheduleRepository = scheduleRepository;
+    this.batchRuntimeService = batchRuntimeService;
     this.properties = properties;
   }
 
@@ -194,6 +197,7 @@ public class OfflineExecutionClaimService {
         .findFirst()
         .orElse(null);
     if (existingNext != null) {
+      batchRuntimeService.refreshBatch(batchId);
       return new ClaimResult(null, frozenLogicalJobSpec(attempts), existingNext, true);
     }
 
@@ -245,6 +249,7 @@ public class OfflineExecutionClaimService {
     if (!executionRepository.insert(execution) || execution.getId() == null) {
       throw new IllegalStateException("创建 Retry Attempt 失败");
     }
+    batchRuntimeService.refreshBatch(batchId);
     return new ClaimResult(null, logicalJobSpec, execution, false);
   }
 
@@ -257,8 +262,8 @@ public class OfflineExecutionClaimService {
       Mapping trigger,
       String idempotencyKey) {
     Long definitionId = definition.getId();
-    if (executionRepository.hasActiveExecution(definitionId)) {
-      throw new IllegalStateException("任务已有运行中的执行实例，不能重复提交");
+    if (batchRuntimeService.hasOccupyingBatch(definitionId)) {
+      throw new IllegalStateException("任务已有运行中的 BatchExecution，不能重复提交");
     }
 
     String normalizedIdempotencyKey =
@@ -300,6 +305,7 @@ public class OfflineExecutionClaimService {
     if (!executionRepository.insert(execution) || execution.getId() == null) {
       throw new IllegalStateException("创建离线同步执行实例失败");
     }
+    batchRuntimeService.refreshBatch(batchId);
     return new ClaimResult(definition, logicalJobSpecJson, execution, false);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
 import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
@@ -23,6 +24,8 @@ import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.Cla
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -37,6 +40,7 @@ public class OfflineExecutionOrchestrator {
   private final OfflineJobDefinitionRepository definitionRepository;
   private final OfflineJobExecutionRepository executionRepository;
   private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineBatchRuntimeService batchRuntimeService;
   private final OfflineExecutionEventRepository eventRepository;
   private final LinkUpClient linkUpClient;
   private final ObjectMapper objectMapper;
@@ -47,6 +51,7 @@ public class OfflineExecutionOrchestrator {
       OfflineJobDefinitionRepository definitionRepository,
       OfflineJobExecutionRepository executionRepository,
       OfflineBatchExecutionRepository batchRepository,
+      OfflineBatchRuntimeService batchRuntimeService,
       OfflineExecutionEventRepository eventRepository,
       LinkUpClient linkUpClient,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
@@ -55,6 +60,7 @@ public class OfflineExecutionOrchestrator {
     this.definitionRepository = definitionRepository;
     this.executionRepository = executionRepository;
     this.batchRepository = batchRepository;
+    this.batchRuntimeService = batchRuntimeService;
     this.eventRepository = eventRepository;
     this.linkUpClient = linkUpClient;
     this.objectMapper = objectMapper;
@@ -119,7 +125,7 @@ public class OfflineExecutionOrchestrator {
       LinkUpNodeResponse node = linkUpClient.node();
       execution.setWorkerInstanceId(node.getInstanceId());
       execution.setUpdateTime(LocalDateTime.now());
-      executionRepository.update(execution);
+      batchRuntimeService.persistAttempt(execution);
 
       JsonNode jobSpec = readJobSpec(resolvedExecutionJobSpec);
       transition(
@@ -145,14 +151,19 @@ public class OfflineExecutionOrchestrator {
       throw exception;
     } catch (LinkUpTransportException exception) {
       if (exception.isUncertain()) {
+        String previous = execution.getStatus();
+        execution.setStatus(OfflineExecutionStatus.UNKNOWN.name());
         execution.setErrorMessage(exception.getMessage());
+        execution.setNextRetryTime(null);
+        execution.setEndTime(null);
         execution.setLastSyncTime(LocalDateTime.now());
         execution.setUpdateTime(LocalDateTime.now());
-        executionRepository.update(execution);
+        batchRuntimeService.persistAttempt(execution);
+        projectTaskLastState(execution, OfflineExecutionStatus.UNKNOWN.name());
         record(
             execution,
-            execution.getStatus(),
-            execution.getStatus(),
+            previous,
+            OfflineExecutionStatus.UNKNOWN.name(),
             "SUBMIT_UNCERTAIN",
             exception.getMessage(),
             null);
@@ -182,14 +193,34 @@ public class OfflineExecutionOrchestrator {
         definitionService.resolveExecutionJobSpec(claim.getLogicalJobSpecJson()));
   }
 
+  /** Task 级停止命令从 Batch runtime truth 选择 latest Attempt，不读取 Task.lastExecutionId。 */
+  public OfflineJobExecution cancelLatestBatch(Long definitionId) {
+    BatchExecution batch = batchRuntimeService.requireLatestOccupyingBatch(definitionId);
+    if (batch.status() == BatchStatus.WAITING_RETRY) {
+      OfflineJobExecution latest = batchRuntimeService.cancelWaitingRetry(batch);
+      projectTaskLastState(latest, BatchStatus.CANCELED.name());
+      record(
+          latest,
+          latest.getStatus(),
+          latest.getStatus(),
+          "BATCH_CANCELLED_WAITING_RETRY",
+          "已取消 Batch 的 Retry 等待，不再创建新的 Attempt",
+          null);
+      return latest;
+    }
+    OfflineJobExecution latest = batchRuntimeService.requireLatestAttempt(batch);
+    return cancel(latest.getId());
+  }
+
   public OfflineJobExecution cancel(Long id) {
     OfflineJobExecution execution = require(id);
+    ensureLatestAttemptForCancel(execution);
     if (!OfflineExecutionStatus.isActive(execution.getStatus())) {
       throw new IllegalStateException("当前执行实例已结束，无需停止");
     }
     execution.setCancellationRequested(true);
     execution.setUpdateTime(LocalDateTime.now());
-    executionRepository.update(execution);
+    batchRuntimeService.persistAttempt(execution);
     record(
         execution,
         execution.getStatus(),
@@ -231,8 +262,8 @@ public class OfflineExecutionOrchestrator {
     execution.setLastSyncTime(LocalDateTime.now());
     execution.setUpdateTime(LocalDateTime.now());
     configureRetry(execution, next, retryable(response, next));
-    executionRepository.update(execution);
-    updateDefinition(execution, next);
+    batchRuntimeService.persistAttempt(execution);
+    projectTaskLastState(execution, next.name());
 
     if (!next.name().equals(previous)) {
       record(
@@ -285,8 +316,8 @@ public class OfflineExecutionOrchestrator {
     execution.setEndTime(null);
     execution.setLastSyncTime(LocalDateTime.now());
     execution.setUpdateTime(LocalDateTime.now());
-    executionRepository.update(execution);
-    updateDefinition(execution, OfflineExecutionStatus.UNKNOWN);
+    batchRuntimeService.persistAttempt(execution);
+    projectTaskLastState(execution, OfflineExecutionStatus.UNKNOWN.name());
     record(
         execution,
         previous,
@@ -316,17 +347,37 @@ public class OfflineExecutionOrchestrator {
     execution.setLastSyncTime(LocalDateTime.now());
     execution.setUpdateTime(LocalDateTime.now());
     configureRetry(execution, status, retryable);
-    executionRepository.update(execution);
-    updateDefinition(execution, status);
+    batchRuntimeService.persistAttempt(execution);
+    projectTaskLastState(execution, status.name());
     record(execution, previous, status.name(), status.name(), message, payload);
   }
 
-  private void updateDefinition(OfflineJobExecution execution, OfflineExecutionStatus status) {
+  /**
+   * Task last-* 只维护 latest Attempt / Batch 的查询投影。旧 Attempt 的晚到事件不得覆盖最新投影，
+   * 且任何运行判断都禁止反向读取这些字段。
+   */
+  private void projectTaskLastState(OfflineJobExecution execution, String fallbackStatus) {
+    String projectedStatus = fallbackStatus;
+    Long batchId = execution.getBatchId();
+    if (batchId != null && batchId > 0L) {
+      List<OfflineJobExecution> attempts = executionRepository.findByBatchId(batchId);
+      if (!attempts.isEmpty()) {
+        OfflineJobExecution latest = attempts.stream()
+            .max(
+                Comparator.comparingInt((OfflineJobExecution value) -> value(value.getAttemptNo(), 1))
+                    .thenComparingLong(value -> value(value.getId(), 0L)))
+            .orElseThrow();
+        if (!Objects.equals(latest.getId(), execution.getId())) return;
+      }
+      BatchExecution batch = batchRepository.findById(batchId).orElse(null);
+      if (batch != null) projectedStatus = batch.status().name();
+    }
+
     OfflineJobDefinition definition = definitionRepository.findById(execution.getJobDefinitionId()).orElse(null);
     if (definition == null) return;
     definition.setLastExecutionId(execution.getId());
     definition.setLastEngineJobId(execution.getEngineJobId());
-    definition.setLastJobStatus(status.name());
+    definition.setLastJobStatus(projectedStatus);
     definition.setLastErrorMessage(execution.getErrorMessage());
     definition.setLastDurationMillis(execution.getDurationMillis());
     definition.setLastReadRowCount(execution.getSourceRecordCount());
@@ -349,7 +400,7 @@ public class OfflineExecutionOrchestrator {
     execution.setStatus(target.name());
     execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
     execution.setUpdateTime(LocalDateTime.now());
-    executionRepository.update(execution);
+    batchRuntimeService.persistAttempt(execution);
     record(execution, previous, target.name(), type, message, payload);
   }
 
@@ -374,6 +425,17 @@ public class OfflineExecutionOrchestrator {
     BatchExecution batch = batchRepository.findById(batchId).orElse(null);
     if (batch == null || !Objects.equals(execution.getJobDefinitionId(), batch.taskId())) return null;
     return batch.snapshot().retryPolicy();
+  }
+
+  private void ensureLatestAttemptForCancel(OfflineJobExecution execution) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) return;
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Attempt 绑定的 BatchExecution 不存在：" + batchId));
+    Long latestId = batch.latestAttempt().map(attempt -> attempt.id()).orElse(null);
+    if (!Objects.equals(latestId, execution.getId())) {
+      throw new IllegalStateException("只能停止 Batch 的 latest Attempt");
+    }
   }
 
   private boolean retryable(LinkUpJobResponse response, OfflineExecutionStatus status) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionService.java
@@ -5,10 +5,8 @@ import io.yak.framework.common.PageData;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
-import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.schedule.OfflineScheduleLifecycle;
 import io.yak.ops.business.sync.offline.service.OfflineDefinitionSupport.DraftDefinition;
@@ -31,7 +29,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class OfflineJobDefinitionService {
   private final OfflineJobDefinitionRepository definitionRepository;
-  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineBatchRuntimeService batchRuntimeService;
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineDefinitionSupport support;
   private final OfflineScheduleSupport scheduleSupport;
@@ -192,8 +190,8 @@ public class OfflineJobDefinitionService {
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public boolean offline(Long id) {
     OfflineJobDefinition definition = require(id);
-    if (executionRepository.hasActiveExecution(id)) {
-      throw new IllegalStateException("运行中的任务不能下线，请先停止任务");
+    if (batchRuntimeService.hasOccupyingBatch(id)) {
+      throw new IllegalStateException("运行中的 BatchExecution 不能下线，请先停止任务");
     }
     definition.setReleaseState("OFFLINE");
     definition.setUpdateTime(LocalDateTime.now());
@@ -208,8 +206,8 @@ public class OfflineJobDefinitionService {
     if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
       throw new IllegalStateException("已上线任务不能删除，请先下线");
     }
-    if (executionRepository.hasActiveExecution(id)) {
-      throw new IllegalStateException("运行中的任务不能删除");
+    if (batchRuntimeService.hasOccupyingBatch(id)) {
+      throw new IllegalStateException("运行中的 BatchExecution 不能删除");
     }
     scheduleLifecycle.remove(id);
     return definitionRepository.delete(id);
@@ -226,9 +224,8 @@ public class OfflineJobDefinitionService {
     if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
       throw new IllegalStateException("已上线任务不能修改，请先下线");
     }
-    if (OfflineExecutionStatus.isActive(definition.getLastJobStatus())
-        || executionRepository.hasActiveExecution(definition.getId())) {
-      throw new IllegalStateException("运行中的任务不能修改");
+    if (batchRuntimeService.hasOccupyingBatch(definition.getId())) {
+      throw new IllegalStateException("运行中的 BatchExecution 不能修改");
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineJobExecutionService.java
@@ -3,7 +3,6 @@ package io.yak.ops.business.sync.offline.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
@@ -30,7 +29,6 @@ public class OfflineJobExecutionService {
   private final OfflineExecutionOrchestrator orchestrator;
   private final OfflineExecutionReadService readService;
   private final OfflineExecutionLogService logService;
-  private final OfflineJobDefinitionService definitionService;
   private final LinkUpClient linkUpClient;
   private final OfflineSyncViewMapper viewMapper;
 
@@ -86,12 +84,9 @@ public class OfflineJobExecutionService {
     return readService.toVO(orchestrator.cancel(id));
   }
 
+  /** Task 级停止只从 BatchExecution/latest Attempt 选择目标，不读取 Task.lastExecutionId。 */
   public OfflineJobExecutionVO cancelLatest(Long definitionId) {
-    OfflineJobDefinition definition = definitionService.require(definitionId);
-    if (definition.getLastExecutionId() == null) {
-      throw new IllegalStateException("任务没有可停止的执行实例");
-    }
-    return cancel(definition.getLastExecutionId());
+    return readService.toVO(orchestrator.cancelLatestBatch(definitionId));
   }
 
   public OfflineBatchOperationVO batchExecute(OfflineBatchOperationDTO request) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__backfill_offline_batch_runtime_status.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__backfill_offline_batch_runtime_status.sql
@@ -1,0 +1,23 @@
+-- Wave 4 data migration: make persisted BatchExecution status reflect the latest bound Attempt.
+-- No schema change is required; this backfills Wave 2/3 batches that were created as PENDING
+-- before Batch status became runtime truth.
+UPDATE yak_offline_batch_execution batch
+JOIN yak_offline_job_execution latest
+  ON latest.batch_id = batch.id
+LEFT JOIN yak_offline_job_execution newer
+  ON newer.batch_id = latest.batch_id
+ AND (
+      newer.attempt_no > latest.attempt_no
+      OR (newer.attempt_no = latest.attempt_no AND newer.id > latest.id)
+ )
+SET batch.status = CASE
+      WHEN UPPER(latest.status) IN ('CREATED', 'SUBMITTED', 'QUEUED', 'RUNNING') THEN 'RUNNING'
+      WHEN UPPER(latest.status) IN ('UNKNOWN', 'LOST') THEN 'UNKNOWN'
+      WHEN UPPER(latest.status) IN ('SUCCEEDED', 'FINISHED', 'COMPLETED') THEN 'SUCCEEDED'
+      WHEN UPPER(latest.status) IN ('CANCELED', 'CANCELLED', 'CANCELING', 'CANCELLING') THEN 'CANCELED'
+      WHEN UPPER(latest.status) = 'FAILED' AND latest.next_retry_time IS NOT NULL THEN 'WAITING_RETRY'
+      WHEN UPPER(latest.status) = 'FAILED' THEN 'FAILED'
+      ELSE batch.status
+    END,
+    batch.update_time = CURRENT_TIMESTAMP(3)
+WHERE newer.id IS NULL;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapterTest.java
@@ -62,6 +62,41 @@ class OfflineBatchExecutionRepositoryAdapterTest {
   }
 
   @Test
+  void exposesOnlyOccupyingBatchAsRuntimeTruth() {
+    FakeBatchDao dao = new FakeBatchDao();
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    when(executions.findByBatchId(anyLong())).thenReturn(List.of());
+    OfflineBatchExecutionRepositoryAdapter repository =
+        new OfflineBatchExecutionRepositoryAdapter(dao, executions);
+
+    BatchExecution running = repository.insert(new BatchExecution(
+        null,
+        9L,
+        BatchKey.manual("request-9"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(2, 5), "digest"),
+        BatchStatus.RUNNING,
+        List.of()));
+
+    assertThat(repository.hasOccupyingBatch(9L)).isTrue();
+    assertThat(repository.findLatestOccupyingByTaskId(9L)).contains(running);
+
+    repository.update(new BatchExecution(
+        running.id(),
+        running.taskId(),
+        running.batchKey(),
+        running.trigger(),
+        running.batchScope(),
+        running.snapshot(),
+        BatchStatus.SUCCEEDED,
+        running.attempts()));
+
+    assertThat(repository.hasOccupyingBatch(9L)).isFalse();
+    assertThat(repository.findLatestOccupyingByTaskId(9L)).isEmpty();
+  }
+
+  @Test
   void hydratesBoundLegacyExecutionsAsAttempts() {
     FakeBatchDao dao = new FakeBatchDao();
     OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
@@ -140,6 +175,20 @@ class OfflineBatchExecutionRepositoryAdapterTest {
               && stored.getBatchKey().equals(batchKey)
           ? stored
           : null;
+    }
+
+    @Override
+    public boolean existsByTaskIdAndStatuses(Long taskId, List<String> statuses) {
+      return stored != null
+          && stored.getJobDefinitionId().equals(taskId)
+          && statuses.contains(stored.getStatus());
+    }
+
+    @Override
+    public OfflineBatchExecutionPO selectLatestByTaskIdAndStatuses(
+        Long taskId,
+        List<String> statuses) {
+      return existsByTaskIdAndStatuses(taskId, statuses) ? stored : null;
     }
 
     @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeServiceTest.java
@@ -1,0 +1,159 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.compat.LegacyOfflineExecutionCompatibilityMapper;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+class OfflineBatchRuntimeServiceTest {
+
+  @Test
+  void latestAttemptIsTheOnlySourceOfBatchRuntimeTruth() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+
+    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of());
+    OfflineJobExecution oldSucceeded = attempt(501L, 77L, 1, "SUCCEEDED");
+    OfflineJobExecution latestRunning = attempt(502L, 77L, 2, "RUNNING");
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(oldSucceeded, latestRunning));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    service.refreshBatch(77L);
+
+    ArgumentCaptor<BatchExecution> captured = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batches).update(captured.capture());
+    assertThat(captured.getValue().status()).isEqualTo(BatchStatus.RUNNING);
+  }
+
+  @Test
+  void failedAttemptWithRetryReservationWindowMeansWaitingRetry() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+
+    BatchExecution batch = batch(77L, BatchStatus.RUNNING, List.of());
+    OfflineJobExecution failed = attempt(501L, 77L, 1, "FAILED");
+    failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(failed));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    service.refreshBatch(77L);
+
+    ArgumentCaptor<BatchExecution> captured = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batches).update(captured.capture());
+    assertThat(captured.getValue().status()).isEqualTo(BatchStatus.WAITING_RETRY);
+  }
+
+  @Test
+  void persistsAttemptBeforeRefreshingBatchTruth() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+
+    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of());
+    OfflineJobExecution running = attempt(501L, 77L, 1, "RUNNING");
+    when(attempts.update(running)).thenReturn(true);
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(running));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    service.persistAttempt(running);
+
+    InOrder order = inOrder(attempts, batches);
+    order.verify(attempts).update(running);
+    order.verify(batches).findById(77L);
+    order.verify(attempts).findByBatchId(77L);
+    order.verify(batches).update(any(BatchExecution.class));
+  }
+
+  @Test
+  void unknownAttemptKeepsBatchInUnknownInsteadOfFailed() {
+    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(
+        mock(OfflineBatchExecutionRepository.class),
+        mock(OfflineJobExecutionRepository.class));
+
+    OfflineJobExecution unknown = attempt(501L, 77L, 1, "UNKNOWN");
+
+    assertThat(service.deriveStatus(unknown)).isEqualTo(BatchStatus.UNKNOWN);
+  }
+
+  @Test
+  void cancelWaitingRetryUsesSameCasReservationAsAutomaticRetry() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+
+    OfflineJobExecution failed = attempt(501L, 77L, 1, "FAILED");
+    failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
+    BatchExecution waiting = batch(
+        77L,
+        BatchStatus.WAITING_RETRY,
+        List.of(LegacyOfflineExecutionCompatibilityMapper.toAttempt(failed)));
+    when(attempts.findById(501L)).thenReturn(Optional.of(failed));
+    when(attempts.reserveRetry(501L)).thenReturn(true);
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    OfflineJobExecution result = service.cancelWaitingRetry(waiting);
+
+    assertThat(result).isSameAs(failed);
+    assertThat(failed.getNextRetryTime()).isNull();
+    assertThat(failed.getRetryCreated()).isTrue();
+    verify(attempts).reserveRetry(501L);
+    ArgumentCaptor<BatchExecution> captured = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batches).update(captured.capture());
+    assertThat(captured.getValue().status()).isEqualTo(BatchStatus.CANCELED);
+  }
+
+  private BatchExecution batch(
+      long id,
+      BatchStatus status,
+      List<io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt> attempts) {
+    return new BatchExecution(
+        id,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(3, 30), "digest"),
+        status,
+        attempts);
+  }
+
+  private OfflineJobExecution attempt(long id, long batchId, int attemptNo, String status) {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(id);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(batchId);
+    execution.setAttemptNo(attemptNo);
+    execution.setTriggerType(attemptNo == 1 ? "MANUAL" : "RETRY");
+    execution.setIdempotencyKey("attempt-" + id);
+    execution.setExternalExecutionId("external-" + id);
+    execution.setStatus(status);
+    execution.setRetryCreated(false);
+    execution.setCreateTime(LocalDateTime.of(2026, 8, 23, 10, attemptNo));
+    return execution;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -41,6 +41,7 @@ class OfflineExecutionClaimServiceTest {
   @Mock private OfflineJobExecutionRepository executionRepository;
   @Mock private OfflineBatchExecutionRepository batchRepository;
   @Mock private OfflineScheduleRepository scheduleRepository;
+  @Mock private OfflineBatchRuntimeService batchRuntimeService;
 
   private OfflineExecutionClaimService service;
 
@@ -52,6 +53,7 @@ class OfflineExecutionClaimServiceTest {
         executionRepository,
         batchRepository,
         scheduleRepository,
+        batchRuntimeService,
         new OfflineSyncProperties());
   }
 
@@ -82,9 +84,11 @@ class OfflineExecutionClaimServiceTest {
     assertThat(result.getExecution().getWorkerInstanceId()).isNull();
     assertThat(result.getExecution().getEngineBaseUrl()).isEqualTo("http://127.0.0.1:18080");
     verify(definitionRepository).lock(10L);
-    verify(executionRepository).hasActiveExecution(10L);
+    verify(batchRuntimeService).hasOccupyingBatch(10L);
+    verify(executionRepository, never()).hasActiveExecution(10L);
     verify(batchRepository).insert(any(BatchExecution.class));
     verify(executionRepository).insert(result.getExecution());
+    verify(batchRuntimeService).refreshBatch(77L);
   }
 
   @Test
@@ -115,9 +119,11 @@ class OfflineExecutionClaimServiceTest {
     assertThat(result.getExecution().getTriggerType()).isEqualTo("WORKFLOW");
     assertThat(result.isReused()).isFalse();
     verify(definitionRepository).lock(10L);
-    verify(executionRepository).hasActiveExecution(10L);
+    verify(batchRuntimeService).hasOccupyingBatch(10L);
+    verify(executionRepository, never()).hasActiveExecution(10L);
     verify(batchRepository).insert(any(BatchExecution.class));
     verify(executionRepository).insert(result.getExecution());
+    verify(batchRuntimeService).refreshBatch(78L);
   }
 
   @Test
@@ -150,6 +156,7 @@ class OfflineExecutionClaimServiceTest {
     assertThat(result.getExecution()).isSameAs(existing);
     assertThat(result.isReused()).isTrue();
     verify(definitionRepository).lock(10L);
+    verify(batchRuntimeService, never()).hasOccupyingBatch(10L);
     verify(executionRepository, never()).hasActiveExecution(10L);
     verify(batchRepository, never()).insert(any(BatchExecution.class));
     verify(executionRepository, never()).insert(any(OfflineJobExecution.class));
@@ -188,6 +195,7 @@ class OfflineExecutionClaimServiceTest {
     InOrder order = inOrder(executionRepository);
     order.verify(executionRepository).reserveRetry(99L);
     order.verify(executionRepository).insert(retry);
+    verify(batchRuntimeService).refreshBatch(77L);
     verifyNoInteractions(definitionService, definitionRepository, scheduleRepository);
   }
 
@@ -259,7 +267,7 @@ class OfflineExecutionClaimServiceTest {
             3,
             new RetryPolicySnapshot(maxAttempts, 30),
             "frozen-digest"),
-        BatchStatus.PENDING,
+        BatchStatus.WAITING_RETRY,
         List.of());
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,6 +43,7 @@ class OfflineExecutionOrchestratorTest {
   @Mock private OfflineJobDefinitionRepository definitionRepository;
   @Mock private OfflineJobExecutionRepository executionRepository;
   @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineBatchRuntimeService batchRuntimeService;
   @Mock private OfflineExecutionEventRepository eventRepository;
   @Mock private LinkUpClient linkUpClient;
 
@@ -54,13 +57,14 @@ class OfflineExecutionOrchestratorTest {
         definitionRepository,
         executionRepository,
         batchRepository,
+        batchRuntimeService,
         eventRepository,
         linkUpClient,
         new ObjectMapper());
   }
 
   @Test
-  void shouldScheduleFailedRetryFromFrozenBatchPolicy() {
+  void shouldScheduleFailedRetryFromFrozenBatchPolicyAndDualWriteBatchTruth() {
     OfflineJobDefinition definition = new OfflineJobDefinition();
     definition.setId(10L);
 
@@ -75,7 +79,7 @@ class OfflineExecutionOrchestratorTest {
     when(claimService.claim(10L, "WORKFLOW", null, 1))
         .thenReturn(new ClaimResult(definition, "{}", execution));
     when(definitionService.resolveExecutionJobSpec(definition)).thenReturn("{}");
-    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch()));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(BatchStatus.RUNNING)));
     when(definitionRepository.findById(10L)).thenReturn(Optional.of(definition));
     when(linkUpClient.node())
         .thenThrow(new LinkUpTransportException(
@@ -91,13 +95,13 @@ class OfflineExecutionOrchestratorTest {
     assertThat(execution.getNextRetryTime()).isNotNull();
     assertThat(execution.getErrorMessage())
         .isEqualTo("无法连接 Link-Up Server：http://127.0.0.1:18080");
-    verify(executionRepository, atLeastOnce()).update(execution);
-    verify(batchRepository).findById(77L);
+    verify(batchRuntimeService, atLeastOnce()).persistAttempt(execution);
+    verify(batchRepository, atLeastOnce()).findById(77L);
     verify(eventRepository, atLeastOnce()).append(any());
   }
 
   @Test
-  void shouldMoveUncertainExecutionToUnknownWithoutRetryTime() {
+  void shouldMoveUncertainExecutionToUnknownAndDualWriteBatchTruth() {
     OfflineJobExecution execution = new OfflineJobExecution();
     execution.setId(99L);
     execution.setJobDefinitionId(10L);
@@ -114,11 +118,60 @@ class OfflineExecutionOrchestratorTest {
     assertThat(execution.getStatus()).isEqualTo("UNKNOWN");
     assertThat(execution.getNextRetryTime()).isNull();
     assertThat(execution.getEndTime()).isNull();
-    verify(executionRepository).update(execution);
+    verify(batchRuntimeService).persistAttempt(execution);
     verify(eventRepository).append(any());
   }
 
-  private BatchExecution frozenBatch() {
+  @Test
+  void oldAttemptLateEventDoesNotOverwriteTaskLastProjection() {
+    OfflineJobExecution oldAttempt = new OfflineJobExecution();
+    oldAttempt.setId(99L);
+    oldAttempt.setJobDefinitionId(10L);
+    oldAttempt.setBatchId(77L);
+    oldAttempt.setStatus("RUNNING");
+    oldAttempt.setStateVersion(3L);
+    oldAttempt.setAttemptNo(1);
+
+    OfflineJobExecution latestAttempt = new OfflineJobExecution();
+    latestAttempt.setId(100L);
+    latestAttempt.setJobDefinitionId(10L);
+    latestAttempt.setBatchId(77L);
+    latestAttempt.setStatus("RUNNING");
+    latestAttempt.setAttemptNo(2);
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(oldAttempt, latestAttempt));
+
+    service.markUnknown(oldAttempt, "旧 Attempt 晚到对账结果");
+
+    verify(batchRuntimeService).persistAttempt(oldAttempt);
+    verify(definitionRepository, never()).findById(10L);
+    verify(definitionRepository, never()).update(any(OfflineJobDefinition.class));
+  }
+
+  @Test
+  void shouldCancelWaitingRetryFromBatchTruthWithoutReadingTaskLastExecution() {
+    BatchExecution waiting = frozenBatch(BatchStatus.WAITING_RETRY);
+    OfflineJobExecution latest = new OfflineJobExecution();
+    latest.setId(99L);
+    latest.setJobDefinitionId(10L);
+    latest.setBatchId(77L);
+    latest.setStatus("FAILED");
+    latest.setStateVersion(4L);
+    latest.setAttemptNo(1);
+
+    when(batchRuntimeService.requireLatestOccupyingBatch(10L)).thenReturn(waiting);
+    when(batchRuntimeService.cancelWaitingRetry(waiting)).thenReturn(latest);
+    when(definitionRepository.findById(10L)).thenReturn(Optional.empty());
+
+    OfflineJobExecution result = service.cancelLatestBatch(10L);
+
+    assertThat(result).isSameAs(latest);
+    verify(batchRuntimeService).requireLatestOccupyingBatch(10L);
+    verify(batchRuntimeService).cancelWaitingRetry(waiting);
+    verifyNoInteractions(definitionService);
+    verify(eventRepository).append(any());
+  }
+
+  private BatchExecution frozenBatch(BatchStatus status) {
     return new BatchExecution(
         77L,
         10L,
@@ -130,7 +183,7 @@ class OfflineExecutionOrchestratorTest {
             1,
             new RetryPolicySnapshot(3, 30),
             "digest"),
-        BatchStatus.PENDING,
+        status,
         List.of());
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceRuntimeTruthTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineJobDefinitionServiceRuntimeTruthTest.java
@@ -1,0 +1,81 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleLifecycle;
+import io.yak.ops.business.sync.offline.service.support.OfflineScheduleSupport;
+import io.yak.ops.business.sync.offline.service.support.OfflineSyncViewMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OfflineJobDefinitionServiceRuntimeTruthTest {
+
+  @Test
+  void offlineUsesBatchTruthAndIgnoresStaleTaskStatusProjection() {
+    OfflineJobDefinitionRepository definitions = mock(OfflineJobDefinitionRepository.class);
+    OfflineBatchRuntimeService runtime = mock(OfflineBatchRuntimeService.class);
+    OfflineScheduleRepository schedules = mock(OfflineScheduleRepository.class);
+    OfflineScheduleLifecycle lifecycle = mock(OfflineScheduleLifecycle.class);
+    OfflineJobDefinitionService service = service(definitions, runtime, schedules, lifecycle);
+
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState("ONLINE");
+    definition.setLastJobStatus("RUNNING");
+    when(definitions.findById(10L)).thenReturn(Optional.of(definition));
+    when(runtime.hasOccupyingBatch(10L)).thenReturn(false);
+    when(definitions.update(definition)).thenReturn(true);
+
+    assertThat(service.offline(10L)).isTrue();
+
+    assertThat(definition.getReleaseState()).isEqualTo("OFFLINE");
+    verify(runtime).hasOccupyingBatch(10L);
+    verify(lifecycle).sync(10L);
+  }
+
+  @Test
+  void deleteIsBlockedByOccupyingBatchEvenWhenTaskProjectionLooksTerminal() {
+    OfflineJobDefinitionRepository definitions = mock(OfflineJobDefinitionRepository.class);
+    OfflineBatchRuntimeService runtime = mock(OfflineBatchRuntimeService.class);
+    OfflineScheduleRepository schedules = mock(OfflineScheduleRepository.class);
+    OfflineScheduleLifecycle lifecycle = mock(OfflineScheduleLifecycle.class);
+    OfflineJobDefinitionService service = service(definitions, runtime, schedules, lifecycle);
+
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState("OFFLINE");
+    definition.setLastJobStatus("SUCCEEDED");
+    when(definitions.findById(10L)).thenReturn(Optional.of(definition));
+    when(runtime.hasOccupyingBatch(10L)).thenReturn(true);
+
+    assertThatThrownBy(() -> service.delete(10L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("BatchExecution");
+
+    verify(runtime).hasOccupyingBatch(10L);
+    verify(lifecycle, never()).remove(10L);
+  }
+
+  private OfflineJobDefinitionService service(
+      OfflineJobDefinitionRepository definitions,
+      OfflineBatchRuntimeService runtime,
+      OfflineScheduleRepository schedules,
+      OfflineScheduleLifecycle lifecycle) {
+    return new OfflineJobDefinitionService(
+        definitions,
+        runtime,
+        schedules,
+        mock(OfflineDefinitionSupport.class),
+        mock(OfflineScheduleSupport.class),
+        lifecycle,
+        mock(OfflineSyncViewMapper.class));
+  }
+}


### PR DESCRIPTION
## Stage 6 · Wave 4

本 PR 继续以模块 `DOMAIN.md` 为领域约束，落实 `Runtime truth -> Batch/Attempt; Task last-* projection only`，并同步把 Wave 4 标记为 DONE、Wave 5 标记为 NEXT。

### 本次领域改造

- 新增 `OfflineBatchRuntimeService` 作为 Batch runtime truth 边界
- Batch status 只由同 Batch 的 **latest Attempt** 推导：
  - `CREATED / SUBMITTED / QUEUED / RUNNING -> RUNNING`
  - `FAILED + nextRetryTime -> WAITING_RETRY`
  - `FAILED -> FAILED`
  - `UNKNOWN / legacy LOST -> UNKNOWN`
  - `SUCCEEDED -> SUCCEEDED`
  - `CANCELED -> CANCELED`
- Attempt lifecycle 持久化与 Batch status 刷新 dual-write
- Initial Attempt 创建后：`PENDING -> RUNNING`
- Retry Attempt 创建后：`WAITING_RETRY -> RUNNING`
- 旧 Attempt 晚到 reconcile 时，Batch status 仍按 latest Attempt 重算，禁止回退 runtime truth

### 命令侧 runtime truth 切换

以下判断不再使用 `hasActiveExecution()` 或 Task `last-*`：

- 新 Batch 的 V1 单 Task 并发限制
- Schedule 触发跳过判断
- Task 编辑保护
- Task 下线
- Task 删除
- Task 级 `cancelLatest`

`cancelLatest` 现在从最新 occupying Batch 选择目标：

- `RUNNING / UNKNOWN`：停止 latest Attempt
- `WAITING_RETRY`：没有活动引擎 Attempt，使用和自动 Retry 相同的 CAS reservation 原子关闭 Retry window，再把 Batch 标记为 `CANCELED`

### Task last-* = projection only

`lastExecutionId / lastEngineJobId / lastJobStatus / lastErrorMessage / metrics` 继续写入 Task，兼容现有列表与详情查询，但：

- 不再参与运行、停止、编辑、下线、删除、调度并发判断
- 只允许 latest Attempt 更新投影
- 旧 Attempt 的晚到状态禁止覆盖 latest projection
- 有 Batch identity 时，`lastJobStatus` 优先投影 BatchStatus

### 历史数据切换

新增 `V3__backfill_offline_batch_runtime_status.sql`：

- 不新增表/列
- 按每个 Batch 的 latest bound Attempt 回填 `yak_offline_batch_execution.status`
- 解决 Wave 2 / Wave 3 已创建 Batch 仍停留在初始 `PENDING` 的迁移问题

### 文档进度

`DOMAIN.md` 与 `docs/offline-sync/domain/README.md` 已更新为：

```text
Wave 0  DONE  Core VO + compatibility mapper
Wave 1  DONE  Batch persistence + execution.bind(batch_id)
Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
Wave 4  DONE  Runtime truth -> Batch/Attempt; Task last-* projection only
Wave 5  NEXT  Backfill / Cursor
Wave 6        Legacy cleanup
```

Wave 4 后仍保留的 Domain Debt 只包含：

- `OfflineJobExecution` 仍是 Attempt persistence compatibility view
- Wave 1 前 `batch_id = NULL` 的 legacy history 不属于新的 Batch runtime truth
- Backfill / Cursor 尚未迁移（Wave 5）

### 测试覆盖

新增/更新测试锁定：

- latest Attempt 是 Batch status 的唯一来源
- FAILED + Retry window -> `WAITING_RETRY`
- UNKNOWN -> Batch UNKNOWN
- Attempt 更新先于 Batch truth 刷新
- WAITING_RETRY cancel 与自动 Retry 共用 CAS reservation
- Repository 只把 `RUNNING / WAITING_RETRY / UNKNOWN` 识别为 occupying Batch
- Initial / Retry claim 刷新 Batch status，不再检查 `hasActiveExecution()`
- 老 Attempt 晚到事件不能覆盖 Task last-* 投影
- stale Task `lastJobStatus` 不参与下线/删除命令判断

### 边界 / 非目标

本 PR **不**：

- 实现 Backfill / Cursor（Wave 5）
- 重命名/重建 legacy execution persistence（Wave 6）
- 强制回填 Wave 1 前 `batch_id = NULL` 的历史 execution
- 引入 immutable DefinitionVersion
- 抽 Realtime / Offline Shared Sync Kernel

> 当前执行环境无法解析 `github.com` DNS，因此无法在容器中 clone 仓库执行 Maven；本 PR 保持 Draft，等待 GitHub CI / 本地 Maven 验证。