### PR TITLE
refactor(offline-sync): implement Wave 5 backfill cursor semantics

### DIFF
--- a/docs/offline-sync/domain/README.md
+++ b/docs/offline-sync/domain/README.md
@@ -1,24 +1,30 @@
 # Offline Sync Domain
 
-> 当前实现阶段：Stage 6 / Wave 4。本文保留当前代码到目标领域的迁移映射；日常开发规则以模块 `DOMAIN.md` 为准。
+> 当前实现阶段：Stage 6 / Wave 5。本文保留当前代码到目标领域的迁移映射；日常开发规则以模块 `DOMAIN.md` 为准。
 
 ## 1. 目标模型
 
 ```text
 OfflineSyncTask
-      │ trigger
+      │ trigger / backfill request
       ▼
 BatchExecution
       ├── BatchKey
       ├── BatchScope
       ├── ExecutionSnapshot
+      │     └── logical JobSpec (no credentials)
       └── ExecutionAttempt 1..N
                 │
                 ▼
           Engine Adapter
+
+CursorRange Batch SUCCEEDED
+      │
+      ▼
+Task Cursor CAS
 ```
 
-硬规则：`Task != Batch != Attempt`；Retry 复用原 Batch/Scope/Snapshot；`UNKNOWN != FAILED`；Batch runtime status 只由 latest Attempt 推导。
+硬规则：`Task != Batch != Attempt`；Retry 复用原 Batch/Scope/Snapshot；`UNKNOWN != FAILED`；Batch runtime status 只由 latest Attempt 推导；Cursor 只由 SUCCEEDED Batch 推进。
 
 ## 2. 当前 Mapping
 
@@ -28,31 +34,103 @@ BatchExecution
 | `definition_json` | 当前 SyncDefinition 表现 | KEEP |
 | `mode=GUIDE_SINGLE/GUIDE_MULTI` | UI/配置模式，不是领域类型 | ADAPT |
 | `version` | `DefinitionRevision` | ADAPT |
-| `job_spec_json` | Link-Up 执行产物，不是定义真相 | ADAPT |
+| `job_spec_json` | current logical JobSpec，不是 runtime truth | ADAPT |
 | `release_state` | Task 是否允许产生新 Batch | KEEP |
 | `OfflineSchedule` | SchedulePolicy + RetryPolicy + runtime projection | ADAPT |
-| `yak_offline_batch_execution` | `BatchExecution` persistence + runtime truth | WAVE 4 DONE |
-| `yak_offline_job_execution.batch_id` | Attempt -> Batch 绑定 | WAVE 1 DONE / nullable history |
+| `yak_offline_batch_execution` | Batch persistence + runtime truth | WAVE 4 DONE |
+| `logical_job_spec_json` | Batch 冻结的不含凭据逻辑 JobSpec | WAVE 5 DONE |
 | Trigger claim | `Trigger -> Batch -> Attempt 1` | WAVE 2 DONE |
 | Schedule identity | `scheduleId + plannedFireTime` BatchKey | WAVE 2 DONE |
-| `retry_created` | FAILED Attempt 的 durable Retry reservation | WAVE 3 DONE |
-| Retry Attempt | same Batch + frozen Snapshot/RetryPolicy | WAVE 3 DONE |
-| `UNKNOWN` / legacy `LOST` | 不确定结果，持续 reconcile，不自动 Retry | WAVE 3 DONE |
+| Retry Attempt | same Batch + frozen Snapshot/RetryPolicy/JobSpec | WAVE 3/5 DONE |
+| `UNKNOWN` / legacy `LOST` | 持续 reconcile，不自动 Retry | WAVE 3 DONE |
 | Batch status dual-write | latest Attempt -> BatchStatus | WAVE 4 DONE |
-| Task command occupancy | `RUNNING/WAITING_RETRY/UNKNOWN` Batch | WAVE 4 DONE |
 | Task `last-*` | Read Model projection only | WAVE 4 DONE |
+| Backfill request | 一次请求 -> 一组 PENDING BACKFILL Batch | WAVE 5 DONE |
+| Backfill dispatcher | PENDING reservation -> Attempt 1，V1 单 Task 串行 | WAVE 5 DONE |
+| `yak_offline_sync_cursor` | Task Cursor route + position + CAS version | WAVE 5 DONE |
+| Cursor advancement | only SUCCEEDED CursorRange Batch | WAVE 5 DONE |
 | `OfflineJobExecution` | Attempt persistence compatibility view | MIGRATE |
 | `attempt_no / retry_from_execution_id` | Attempt 次序/血缘 | KEEP |
-| `idempotency_key / external_execution_id` | Attempt 幂等与外部提交身份 | KEEP |
 | `engine_job_id / worker_instance_id` | Engine evidence | KEEP |
 | metrics / error / start/end | Attempt 运行证据 | KEEP |
-| legacy execution snapshot | 过渡期兼容副本；Retry 从 Attempt 1 读取冻结 JobSpec | MIGRATE |
+| legacy execution snapshot | Attempt 级兼容副本 | MIGRATE |
 | `OfflineExecutionEvent` | Attempt 事件历史 | KEEP |
 | Link-Up / credential resolver | Infrastructure boundary | KEEP |
 
-## 3. Wave 4 Runtime Truth
+## 3. Wave 5 Backfill Group
 
-Wave 4 把运行真相从 Task/legacy execution 判断切换为：
+Backfill 不创建新的 Task 类型。一次请求先固定 Task 定义、RetryPolicy 与 logical JobSpec，再物化一组 Batch：
+
+```text
+Backfill(requestId)
+      │
+      ├── Scope A -> BatchKey(requestId + scopeFingerprint) -> PENDING Batch
+      ├── Scope B -> BatchKey(requestId + scopeFingerprint) -> PENDING Batch
+      └── Scope C -> BatchKey(requestId + scopeFingerprint) -> PENDING Batch
+
+all batches share one ExecutionSnapshot
+```
+
+关键约束：
+
+- 同一 `requestId + scopeFingerprint` 重放复用原 Batch，不重复物化；
+- 同一个 Backfill Request 的 Batch 必须共享同一 Snapshot；
+- Snapshot 现在包含 definition、DefinitionRevision、RetryPolicy、configDigest 和不含凭据的 logical JobSpec；
+- PENDING Backfill 不占 V1 execution slot，可以先排队；
+- dispatcher 只在 Task 没有 `RUNNING / WAITING_RETRY / UNKNOWN` Batch 时提交下一个；
+- PENDING -> RUNNING 使用 CAS reservation，再创建 Attempt 1；
+- Attempt 1 以及后续 Retry 都只读 Batch 冻结证据，不回读 current Task；
+- Scope 在 Engine Adapter 边界投影为实际过滤条件，凭据随后才解析。
+
+### Scoped execution V1
+
+当前 V1 有意收窄为 JDBC 单表 source：
+
+- `DataWindow`：使用冻结 JobSpec 的 `source.options.partition_column`；
+- `PartitionScope`：使用同一 `partition_column`；
+- `CursorRange`：使用 Cursor route 保存的 `sourceColumn`；
+- 已有 `where_condition` 与 Scope 条件使用 AND 合并；
+- multi-table scoped Backfill 和 custom source query + Scope 不做猜测，显式拒绝，后续需要先补 Domain Gap。
+
+## 4. Wave 5 Cursor
+
+Cursor 不属于 Attempt，也不把 cursorId 当成字段名。它单独持久化：
+
+```text
+OfflineSyncCursor
+  ├── taskId
+  ├── cursorId
+  ├── sourceColumn      <- route
+  ├── position
+  ├── lastSucceededBatchId
+  └── stateVersion
+```
+
+CursorRange Batch 使用：
+
+```text
+(cursorId, afterExclusive, throughInclusive)
+```
+
+推进规则固定为：
+
+```text
+Batch status == SUCCEEDED
+AND current.position == afterExclusive
+AND current.stateVersion == expectedVersion
+        │
+        ▼ CAS
+position = throughInclusive
+```
+
+因此：
+
+- FAILED / CANCELED / UNKNOWN Batch 永不推进 Cursor；
+- Attempt SUCCEEDED 但 Batch 尚未形成 SUCCEEDED runtime truth 时不推进；
+- 旧 Batch 晚到成功时，如果 Cursor 已离开 `afterExclusive`，结果为 STALE，不允许回退/跳跃；
+- 同一个 cursorId 的 Backfill ranges 必须连续；dispatcher 只有在 Cursor 当前 position 等于该 Batch `afterExclusive` 时才会启动它。
+
+## 5. Runtime Truth（Wave 4 保持不变）
 
 ```text
 Task command
@@ -62,108 +140,45 @@ BatchExecution
     │ status
     ▼
 latest ExecutionAttempt
+
+Task last-* = projection only
 ```
 
-BatchStatus 推导规则：
+BatchStatus：活动 Attempt -> RUNNING；FAILED + Retry 窗口 -> WAITING_RETRY；FAILED -> FAILED；UNKNOWN -> UNKNOWN；SUCCEEDED/CANCELED 对应同名终态。旧 Attempt 晚到事件不能回退 Batch，也不能覆盖 latest Task projection。
+
+## 6. Persistence Migration
+
+Wave 5 新增 V4 migration：
 
 ```text
-CREATED / SUBMITTED / QUEUED / RUNNING -> RUNNING
-FAILED + nextRetryTime                 -> WAITING_RETRY
-FAILED                                 -> FAILED
-UNKNOWN / legacy LOST                  -> UNKNOWN
-SUCCEEDED                              -> SUCCEEDED
-CANCELED                               -> CANCELED
+yak_offline_batch_execution
+  + logical_job_spec_json
+
+yak_offline_sync_cursor
+  + task/cursor unique identity
+  + source_column
+  + position_value
+  + last_succeeded_batch_id
+  + state_version
 ```
 
-关键约束：
+旧 Wave 2-4 Batch 的 `logical_job_spec_json` 从其 Attempt 1 `submitted_config` 回填。字段迁移期允许 NULL，但 repository 读取时如果旧行尚未回填，会退回读取 Attempt 1；若两者都不存在则拒绝猜测。
 
-- Attempt persistence 更新后同步刷新 Batch status；
-- Batch status 每次重新读取同 Batch 的 latest Attempt 后推导，不使用调用方传入的旧 Attempt 直接覆盖；
-- 旧 Attempt 的晚到 reconcile 不能把新 Attempt 已形成的 Batch 状态回退；
-- Initial Attempt 创建后 Batch 从 `PENDING` 切到 `RUNNING`；
-- Retry Attempt 创建后 Batch 从 `WAITING_RETRY` 切回 `RUNNING`；
-- FAILED 且仍有 Retry 窗口时 Batch 是 `WAITING_RETRY`，仍占用 V1 Task 执行槽位；
-- UNKNOWN Batch 继续占用执行槽位，必须先 reconcile；
-- `SUCCEEDED / FAILED / CANCELED` 是 Batch 终态。
+## 7. 当前仍未解决的 Domain Debt
 
-### 命令侧切换
+### Legacy Attempt persistence 名称/结构
 
-以下判断现在统一读取 Batch runtime truth：
-
-- 新 Batch 创建的 V1 单任务并发限制；
-- Schedule 到点时是否跳过本次触发；
-- Task 下线；
-- Task 删除；
-- Task 编辑保护；
-- Task 级 `cancelLatest`。
-
-`cancelLatest` 不再读取 `Task.lastExecutionId`。对于 `RUNNING / UNKNOWN` Batch，停止 latest Attempt；对于 `WAITING_RETRY` Batch，没有活动引擎 Attempt，因此直接关闭 Retry window，并把 Batch 标记为 `CANCELED`，已失败 Attempt 的历史证据保持不变。
-
-### Task last-* 投影
-
-`lastExecutionId / lastEngineJobId / lastJobStatus / lastErrorMessage / metrics` 继续写入 Task，目的是兼容列表和详情查询。它们不再用于运行、停止、编辑、下线、删除或调度并发判断。
-
-### 历史 Batch 回填
-
-Wave 2 / Wave 3 期间 Batch 创建后长期保持初始 `PENDING`，因此 Wave 4 新增 V3 data migration：按照每个 Batch 的 latest bound Attempt 回填 `yak_offline_batch_execution.status`。不增加新表或新列。
-
-## 4. 当前仍未解决的 Domain Debt
-
-### Backfill / Cursor 尚未迁移
-
-补数与 Cursor 推进还没有按目标模型完整实现。Wave 5 需要保证：
-
-```text
-Backfill request
-  -> Batch group
-  -> explicit BatchScope
-
-Cursor
-  -> only Batch SUCCEEDED advances
-```
-
-`FAILED / CANCELED / UNKNOWN` 一律不能推进 Cursor。
-
-### Legacy Attempt persistence 仍保留 execution 形态
-
-`yak_offline_job_execution` 已承担 Attempt persistence，但类名、表名和部分字段仍保留旧 execution-centered 结构。Wave 6 再做 contract/cleanup，不在 Wave 4 为了命名整洁重建历史。
+`yak_offline_job_execution` 已实际承担 Attempt persistence，但类名、表名和部分字段仍保留 execution-centered 结构。Wave 6 再做 contract/cleanup，不为了命名整洁推倒历史。
 
 ### Wave 1 前历史没有 Batch identity
 
-旧 execution 允许 `batch_id = NULL`。这类记录没有冻结 BatchScope / RetryPolicy Snapshot，不参与新的 Batch runtime truth，也不允许通过 current Task/SchedulePolicy 猜测后安全 Retry。
+`batch_id = NULL` 的旧 execution 不属于新的 Batch runtime truth，没有 BatchScope / frozen RetryPolicy / frozen logical JobSpec，不能通过 current Task 猜测补齐后 Retry。
 
-## 5. Wave 1-4 已完成迁移
+### Attempt snapshot 兼容副本
 
-当前持久化关系：
+`definition_snapshot_json / submitted_config / config_digest` 仍同时保留在 legacy Attempt persistence，用于兼容旧接口与历史。Batch Snapshot 已成为新运行链冻结证据，重复字段清理由 Wave 6 决定。
 
-```text
-yak_offline_job_definition
-        │ 1:N
-        ▼
-yak_offline_batch_execution
-        │ 1:N
-        ▼
-yak_offline_job_execution
-```
-
-已完成约束：
-
-- execution `batch_id` nullable，旧记录不强制回填；
-- Trigger 先创建 Batch，再创建 Attempt 1；
-- Schedule BatchKey 使用稳定 planned fire identity；
-- Retry 不创建新 Batch，不回读 current Task；
-- RetryPolicy 从 Batch `ExecutionSnapshot` 读取，不回读 current SchedulePolicy；
-- Retry 使用 Attempt 1 已冻结的逻辑 JobSpec，只在提交边界解析最新凭据；
-- `retry_created` 使用 CAS durable reservation，reservation 与新 Attempt insert 同事务；
-- FAILED 才能 Retry；UNKNOWN / legacy LOST 只 reconcile；
-- Batch status 与 Attempt 生命周期 dual-write；
-- Batch status 只由 latest Attempt 推导；
-- V1 Task occupancy 只看 `RUNNING / WAITING_RETRY / UNKNOWN` Batch；
-- Task `last-*` 只作为查询投影；
-- 不创建物理 FK；
-- Engine Job、metrics、error 继续属于 Attempt persistence。
-
-## 6. 迁移波次
+## 8. 迁移波次
 
 ```text
 Wave 0  DONE  Core VO + compatibility mapper
@@ -171,16 +186,16 @@ Wave 1  DONE  Batch persistence + execution.bind(batch_id)
 Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
 Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
 Wave 4  DONE  Runtime truth -> Batch/Attempt; Task last-* projection only
-Wave 5  NEXT  Backfill / Cursor
-Wave 6        Legacy cleanup
+Wave 5  DONE  Backfill group / BatchScope / Cursor success-only CAS
+Wave 6  NEXT  Legacy cleanup
 ```
 
 采用 `expand -> dual read/write -> switch -> verify -> contract`，不做一次性 schema 重建。
 
-## 7. 当前结论
+## 9. 当前结论
 
-1. Batch 已经同时承担业务身份和运行状态真相；Attempt 承担每次实际提交证据。
-2. Retry 固定 Batch/Scope/Snapshot/RetryPolicy，UNKNOWN 与 FAILED 分离。
-3. Task 命令生命周期不再依赖 `last-*` 或 `hasActiveExecution()`；Task `last-*` 仅保留查询投影职责。
-4. legacy `yak_offline_job_execution` 继续作为 Attempt persistence compatibility view，命名和历史清理留到 Wave 6。
-5. 下一步 Wave 5 只处理 Backfill / Cursor，不提前抽 Shared Sync Kernel，也不引入 immutable DefinitionVersion。
+1. Batch 已承担业务身份、冻结执行证据与 runtime truth；Attempt 只记录每次实际提交证据。
+2. Backfill 已成为 Batch group，而不是新的 Task 类型；PENDING queue 与实际执行解耦。
+3. Retry 和延迟 dispatch 都不再回读 current Task 生成执行配置。
+4. Cursor 已与 Attempt 生命周期分离，只接受 SUCCEEDED Batch 的有序 CAS 推进。
+5. Stage 6 下一步只剩 Wave 6 legacy cleanup：删除/收缩兼容分支、旧命名与重复 snapshot 字段前，先验证新链路已经完全覆盖。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DOMAIN.md
@@ -14,6 +14,7 @@ BatchExecution
       ├── BatchKey
       ├── BatchScope
       ├── ExecutionSnapshot
+      │     └── logical JobSpec (no credentials)
       └── ExecutionAttempt 1..N
                 │
                 ▼
@@ -30,56 +31,68 @@ BatchExecution
 4. Retry 必须保持同一个 Batch、BatchScope、ExecutionSnapshot 和 RetryPolicy Snapshot。
 5. `UNKNOWN != FAILED`；结果不确定时必须先 reconcile，禁止盲目 Retry。
 6. Batch 终态后不再追加 Attempt；再次运行同一数据范围应创建新 Batch。
-7. V1 同一个 Task 最多一个 `RUNNING / WAITING_RETRY / UNKNOWN` Batch；并发需求变化必须先定义 `ConcurrencyPolicy`。
+7. V1 同一个 Task 最多一个 `RUNNING / WAITING_RETRY / UNKNOWN` Batch；PENDING Backfill 只排队，不占执行槽位。
 8. 每个 Batch 必须有稳定 `BatchKey`；Schedule 使用 `scheduleId + plannedFireTime`，不能使用实际回调时间。
 9. `BatchScope` 描述数据范围；不得用 `sceneType/syncType` 代替 Scope / Route / Policy。
-10. Backfill 创建一组 Batch，不创建新的 Task 类型；同一次 Backfill 优先共享同一 Snapshot。
-11. Cursor 只允许在 Batch `SUCCEEDED` 后推进；`FAILED / CANCELED / UNKNOWN` 不得推进。
-12. Task `last-*` 只能作为查询投影；运行真相只能来自 Batch / Attempt。
-13. Batch 状态必须由同 Batch 的 latest Attempt 推导；旧 Attempt 的晚到事件不得回退 Batch 真相。
-14. `DefinitionRevision` 只是修订标识，不等于 immutable `DefinitionVersion`。
-15. Link-Up Job / Worker / Quartz / HTTP DTO / DataSource credential 都不是 Core Domain 对象。
-16. SyncDefinition / Snapshot 不长期保存密码；凭据只在 Attempt 提交边界解析。
-17. 实时同步和离线同步保持独立 Core；不得因为名字相似提前抽 Shared Sync Kernel。
+10. Backfill 创建一组 Batch，不创建新的 Task 类型；同一次 Backfill 共享同一 `ExecutionSnapshot`，每个 Scope 生成独立稳定 BatchKey。
+11. Backfill PENDING Batch 创建 Attempt 1 时必须经过 durable reservation；多节点不得重复创建 Attempt。
+12. Cursor route (`cursorId -> sourceColumn`) 与 BatchScope 分离；不得把 cursorId 当成数据库字段名。
+13. Cursor 只允许在对应 Batch `SUCCEEDED` 后推进；`FAILED / CANCELED / UNKNOWN` 不得推进。
+14. Cursor 推进必须用当前位置 + stateVersion CAS；旧 Batch 晚到成功不得回退或跨越 Cursor。
+15. Task `last-*` 只能作为查询投影；运行真相只能来自 Batch / Attempt。
+16. Batch 状态必须由同 Batch 的 latest Attempt 推导；旧 Attempt 的晚到事件不得回退 Batch 真相。
+17. `DefinitionRevision` 只是修订标识，不等于 immutable `DefinitionVersion`。
+18. Link-Up Job / Worker / Quartz / HTTP DTO / DataSource credential 都不是 Core Domain 对象。
+19. SyncDefinition / Snapshot 不长期保存密码；逻辑 JobSpec 可以冻结在 Batch Snapshot，但凭据只在 Attempt 提交边界解析。
+20. 实时同步和离线同步保持独立 Core；不得因为名字相似提前抽 Shared Sync Kernel。
 
 ## Domain Impact Analysis
 
 修改离线同步代码前，必须先回答：
 
-1. 变化属于 Task、Batch、Attempt、Scope、Snapshot 还是 Policy？
+1. 变化属于 Task、Batch、Attempt、Scope、Snapshot、Cursor 还是 Policy？
 2. 是否改变 Batch / Attempt 生命周期？
 3. 是否改变 Retry、UNKNOWN、Cancel 或并发语义？
 4. 是否改变 BatchKey / 幂等身份？
-5. 是否让 Retry 回读 current Task 或 current SchedulePolicy？
+5. 是否让 Retry / PENDING Backfill 回读 current Task 或 current SchedulePolicy？
 6. 是否把 Task `last-*`、Engine 状态或外部 JobId 当成领域真相？
 7. Batch 状态是否仍由 latest Attempt 唯一推导？
-8. 是否引入新的 `sceneType/syncType`、技术类型或凭据泄漏？
-9. 是否能映射现有模型？不能映射则记录 `Domain Gap`，先设计再编码。
+8. Cursor 是否只由 SUCCEEDED Batch 推进，并保留 CAS 顺序保护？
+9. 是否把 Route 偷塞进 BatchScope，或把 cursorId 当字段名？
+10. 是否引入新的 `sceneType/syncType`、技术类型或凭据泄漏？
+11. 是否能映射现有模型？不能映射则记录 `Domain Gap`，先设计再编码。
 
 ## Current Transition
 
-Wave 2 / Wave 3 / Wave 4 已完成 Trigger、Retry/UNKNOWN 与 runtime truth 主链迁移。当前命令侧运行真相为：
+Wave 2-5 已完成 Trigger、Retry/UNKNOWN、runtime truth 与 Backfill/Cursor 主链迁移。当前运行模型：
 
 ```text
-Task command
-    │
-    ▼
-BatchExecution status
-    │
-    ▼
-latest ExecutionAttempt
+Trigger / Backfill Request
+        │
+        ▼
+BatchExecution
+  ├── frozen Snapshot + logical JobSpec
+  ├── BatchScope
+  └── latest Attempt = runtime evidence
+        │
+        └── SUCCEEDED CursorRange
+                    │
+                    ▼
+                Cursor CAS
 
 Task last-* = projection only
 ```
 
-Wave 4 状态推导固定为：活动 Attempt -> `RUNNING`；FAILED 且存在 `nextRetryTime` -> `WAITING_RETRY`；FAILED 无 Retry 窗口 -> `FAILED`；UNKNOWN -> `UNKNOWN`；SUCCEEDED/CANCELED 对应同名 Batch 终态。Attempt 状态写入与 Batch 状态刷新 dual-write；Wave 2/3 历史 Batch 通过 V3 migration 从 latest Attempt 回填 runtime status。
+Wave 5 固定：一次 Backfill Request 物化一组 `PENDING` Batch，同组共享冻结 Snapshot；dispatcher 在 V1 单 Task execution slot 下逐个 reservation 并创建 Attempt 1。Scope 只在提交边界投影成 Engine 条件，凭据仍最后解析。Cursor 单独持久化 route、position 与 stateVersion，只接受 SUCCEEDED CursorRange Batch 的 CAS 推进；失败、不确定、取消和旧成功事件都不能改变 Cursor。
+
+当前 Wave 5 scoped execution V1 明确收窄为 **JDBC 单表 source**；DataWindow / PartitionScope 需要冻结 JobSpec 中的 `source.options.partition_column`，CursorRange 使用 Cursor route 的 `sourceColumn`。多表 scoped Backfill 与 custom source query 叠加 Scope 暂不猜测语义，属于后续显式 Domain Gap。
 
 仍保留的主要 Domain Debt：
 
 ```text
 OfflineJobExecution = legacy 名称/结构仍作为 Attempt persistence compatibility view
 Legacy history       = Wave 1 前 execution 可无 batch_id，不属于 Batch runtime truth
-Backfill / Cursor    = 尚未切入目标 BatchScope / Cursor 推进规则
+Legacy batch snapshot= Wave 5 migration 后仍保留 Attempt 级 snapshot 兼容副本
 ```
 
 ```text
@@ -88,8 +101,8 @@ Wave 1  DONE  Batch persistence + execution.bind(batch_id)
 Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
 Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
 Wave 4  DONE  Runtime truth -> Batch/Attempt; Task last-* projection only
-Wave 5  NEXT  Backfill / Cursor
-Wave 6        Legacy cleanup
+Wave 5  DONE  Backfill group / BatchScope / Cursor success-only CAS
+Wave 6  NEXT  Legacy cleanup
 ```
 
 迁移原则：`expand -> dual read/write -> switch -> verify -> contract`。
@@ -104,7 +117,12 @@ Wave 6        Legacy cleanup
 - 用 Task `lastJobStatus / lastExecutionId` 决定运行、停止、编辑、下线或删除；
 - 用非 latest Attempt 的状态覆盖 Batch runtime truth；
 - 用 actual callback time 作为 Schedule Batch 身份；
-- 让 Attempt 自己重新生成 Snapshot；
+- 让 Retry 或 PENDING Backfill 重新读取 current Task 生成 Snapshot / JobSpec；
+- 把 Backfill 建模成新的 Task 类型，或让同一 request 的 Scope 各自偷偷读取不同 Snapshot；
+- Attempt SUCCEEDED 就直接推进 Cursor，而不确认 Batch SUCCEEDED；
+- 在 FAILED / CANCELED / UNKNOWN Batch 上推进 Cursor；
+- 不做 position/version CAS 就覆盖 Cursor；
+- 把 cursorId 当 source column，或把 Route/Policy 塞进 BatchScope；
 - 把 Link-Up JobSpec、Worker、Connector、Quartz 类型放进 Core Domain；
 - 为“全量/增量/单表/多表/补数”继续增加任务类型枚举；
 - 为了和 realtime 一致而提前增加 immutable DefinitionVersion 或 Shared Sync Kernel。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineBackfillController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineBackfillController.java
@@ -1,0 +1,29 @@
+package io.yak.ops.business.sync.offline.controller;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.service.OfflineBackfillService;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Offline Backfill command API. */
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequiredArgsConstructor
+public class OfflineBackfillController {
+
+  private final OfflineBackfillService backfillService;
+
+  @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/backfill")
+  public Result<OfflineBackfillVO> backfill(
+      @PathVariable Long jobDefineId,
+      @Valid @RequestBody OfflineBackfillRequestDTO requestDTO) {
+    return Result.success(backfillService.submit(jobDefineId, requestDTO));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineBatchExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineBatchExecutionDao.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.sync.offline.dao;
 
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /** 离线同步业务批次数据访问接口。 */
@@ -13,6 +14,10 @@ public interface OfflineBatchExecutionDao {
   boolean existsByTaskIdAndStatuses(Long taskId, List<String> statuses);
 
   OfflineBatchExecutionPO selectLatestByTaskIdAndStatuses(Long taskId, List<String> statuses);
+
+  List<OfflineBatchExecutionPO> selectPendingBackfills(int limit);
+
+  boolean reservePendingBackfill(Long batchId, LocalDateTime updateTime);
 
   boolean insert(OfflineBatchExecutionPO batchPO);
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineSyncCursorDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineSyncCursorDao.java
@@ -1,0 +1,21 @@
+package io.yak.ops.business.sync.offline.dao;
+
+import io.yak.ops.common.bean.po.sync.offline.OfflineSyncCursorPO;
+import java.time.LocalDateTime;
+
+/** 离线同步 Cursor 数据访问接口。 */
+public interface OfflineSyncCursorDao {
+
+  OfflineSyncCursorPO select(Long taskId, String cursorId);
+
+  boolean insert(OfflineSyncCursorPO cursorPO);
+
+  boolean advance(
+      Long taskId,
+      String cursorId,
+      String expectedPosition,
+      long expectedVersion,
+      String nextPosition,
+      Long succeededBatchId,
+      LocalDateTime updateTime);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineBatchExecutionMapper;
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -53,6 +54,29 @@ public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
             .in(OfflineBatchExecutionPO::getStatus, statuses)
             .orderByDesc(OfflineBatchExecutionPO::getId)
             .last("LIMIT 1"));
+  }
+
+  @Override
+  public List<OfflineBatchExecutionPO> selectPendingBackfills(int limit) {
+    return mapper.selectList(
+        Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(OfflineBatchExecutionPO::getTriggerType, "BACKFILL")
+            .eq(OfflineBatchExecutionPO::getStatus, "PENDING")
+            .orderByAsc(OfflineBatchExecutionPO::getId)
+            .last("LIMIT " + Math.max(1, limit)));
+  }
+
+  @Override
+  public boolean reservePendingBackfill(Long batchId, LocalDateTime updateTime) {
+    if (batchId == null || batchId <= 0L) return false;
+    return mapper.update(
+        null,
+        Wrappers.<OfflineBatchExecutionPO>lambdaUpdate()
+            .eq(OfflineBatchExecutionPO::getId, batchId)
+            .eq(OfflineBatchExecutionPO::getTriggerType, "BACKFILL")
+            .eq(OfflineBatchExecutionPO::getStatus, "PENDING")
+            .set(OfflineBatchExecutionPO::getStatus, "RUNNING")
+            .set(OfflineBatchExecutionPO::getUpdateTime, updateTime)) > 0;
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineSyncCursorDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineSyncCursorDaoImpl.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.sync.offline.dao.impl;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineSyncCursorDao;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineSyncCursorMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineSyncCursorPO;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/** 基于 MyBatis-Plus 的离线同步 Cursor 数据访问实现。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineSyncCursorDaoImpl implements OfflineSyncCursorDao {
+
+  private final OfflineSyncCursorMapper mapper;
+
+  @Override
+  public OfflineSyncCursorPO select(Long taskId, String cursorId) {
+    if (taskId == null || taskId <= 0L || !StringUtils.hasText(cursorId)) return null;
+    return mapper.selectOne(
+        Wrappers.<OfflineSyncCursorPO>lambdaQuery()
+            .eq(OfflineSyncCursorPO::getJobDefinitionId, taskId)
+            .eq(OfflineSyncCursorPO::getCursorId, cursorId.trim())
+            .last("LIMIT 1"));
+  }
+
+  @Override
+  public boolean insert(OfflineSyncCursorPO cursorPO) {
+    return mapper.insert(cursorPO) > 0;
+  }
+
+  @Override
+  public boolean advance(
+      Long taskId,
+      String cursorId,
+      String expectedPosition,
+      long expectedVersion,
+      String nextPosition,
+      Long succeededBatchId,
+      LocalDateTime updateTime) {
+    if (taskId == null
+        || taskId <= 0L
+        || !StringUtils.hasText(cursorId)
+        || !StringUtils.hasText(expectedPosition)
+        || expectedVersion < 1L
+        || !StringUtils.hasText(nextPosition)
+        || succeededBatchId == null
+        || succeededBatchId <= 0L) {
+      return false;
+    }
+    return mapper.update(
+        null,
+        Wrappers.<OfflineSyncCursorPO>lambdaUpdate()
+            .eq(OfflineSyncCursorPO::getJobDefinitionId, taskId)
+            .eq(OfflineSyncCursorPO::getCursorId, cursorId.trim())
+            .eq(OfflineSyncCursorPO::getPositionValue, expectedPosition.trim())
+            .eq(OfflineSyncCursorPO::getStateVersion, expectedVersion)
+            .set(OfflineSyncCursorPO::getPositionValue, nextPosition.trim())
+            .set(OfflineSyncCursorPO::getLastSucceededBatchId, succeededBatchId)
+            .set(OfflineSyncCursorPO::getStateVersion, expectedVersion + 1L)
+            .set(OfflineSyncCursorPO::getUpdateTime, updateTime)) > 0;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineSyncCursorMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/mapper/OfflineSyncCursorMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.sync.offline.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineSyncCursorPO;
+
+/** 离线同步 Cursor Mapper。 */
+public interface OfflineSyncCursorMapper extends BaseMapper<OfflineSyncCursorPO> {
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineSyncCursor.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineSyncCursor.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.sync.offline.domain;
+
+/** Stable progress cursor owned by one OfflineSyncTask. */
+public record OfflineSyncCursor(
+    long taskId,
+    String cursorId,
+    String sourceColumn,
+    String position,
+    Long lastSucceededBatchId,
+    long stateVersion) {
+
+  public OfflineSyncCursor {
+    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
+    cursorId = requireText(cursorId, "cursorId 不能为空");
+    sourceColumn = requireText(sourceColumn, "sourceColumn 不能为空");
+    position = requireText(position, "position 不能为空");
+    if (lastSucceededBatchId != null && lastSucceededBatchId <= 0L) {
+      throw new IllegalArgumentException("lastSucceededBatchId 必须大于 0");
+    }
+    if (stateVersion < 1L) throw new IllegalArgumentException("stateVersion 必须大于 0");
+  }
+
+  private static String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapper.java
@@ -12,11 +12,10 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * Transitional mapper from the current execution model to Wave 0 core types.
+ * Transitional mapper from the current execution model to core domain types.
  *
  * <p>This mapper deliberately does not synthesize BatchExecution, BatchKey or BatchScope because
- * the legacy row does not contain stable batch identity. Wave 1 will provide persisted Batch
- * identity.
+ * a legacy execution row does not contain stable batch identity.
  */
 public final class LegacyOfflineExecutionCompatibilityMapper {
 
@@ -40,10 +39,8 @@ public final class LegacyOfflineExecutionCompatibilityMapper {
   }
 
   /**
-   * Builds the Batch-owned snapshot without reading current Task or SchedulePolicy.
-   *
-   * <p>The retry policy must be supplied by the caller from frozen batch evidence; this mapper
-   * never falls back to current task configuration.
+   * Builds Batch-owned frozen evidence from a bound legacy Attempt without reading current Task or
+   * SchedulePolicy.
    */
   public static ExecutionSnapshot toSnapshot(
       OfflineJobExecution source, RetryPolicySnapshot retryPolicy) {
@@ -53,7 +50,8 @@ public final class LegacyOfflineExecutionCompatibilityMapper {
         requireText(source.getDefinitionSnapshotJson(), "definitionSnapshot 不能为空"),
         positive(source.getDefinitionVersion(), "definitionVersion"),
         retryPolicy,
-        requireText(source.getConfigDigest(), "configDigest 不能为空"));
+        requireText(source.getConfigDigest(), "configDigest 不能为空"),
+        requireText(source.getSubmittedConfig(), "logicalJobSpec 不能为空"));
   }
 
   static AttemptStatus status(String value) {
@@ -61,6 +59,7 @@ public final class LegacyOfflineExecutionCompatibilityMapper {
     String normalized = value.trim().toUpperCase(Locale.ROOT);
     return switch (normalized) {
       case "CREATED" -> AttemptStatus.CREATED;
+      case "SUBMITTING" -> AttemptStatus.SUBMITTING;
       case "SUBMITTED" -> AttemptStatus.SUBMITTED;
       case "QUEUED" -> AttemptStatus.QUEUED;
       case "RUNNING" -> AttemptStatus.RUNNING;
@@ -68,7 +67,7 @@ public final class LegacyOfflineExecutionCompatibilityMapper {
       case "FAILED" -> AttemptStatus.FAILED;
       case "CANCELED", "CANCELLED" -> AttemptStatus.CANCELED;
       case "CANCELING", "CANCELLING" -> AttemptStatus.CANCELING;
-      case "LOST" -> AttemptStatus.UNKNOWN;
+      case "UNKNOWN", "LOST" -> AttemptStatus.UNKNOWN;
       default -> AttemptStatus.UNKNOWN;
     };
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/ExecutionSnapshot.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/ExecutionSnapshot.java
@@ -7,7 +7,8 @@ public record ExecutionSnapshot(
     String definitionSnapshot,
     int definitionRevision,
     RetryPolicySnapshot retryPolicy,
-    String configDigest) {
+    String configDigest,
+    String logicalJobSpec) {
 
   public ExecutionSnapshot {
     definitionSnapshot = requireText(definitionSnapshot, "definitionSnapshot 不能为空");
@@ -16,6 +17,7 @@ public record ExecutionSnapshot(
     }
     retryPolicy = Objects.requireNonNull(retryPolicy, "retryPolicy 不能为空");
     configDigest = requireText(configDigest, "configDigest 不能为空");
+    logicalJobSpec = requireText(logicalJobSpec, "logicalJobSpec 不能为空");
   }
 
   private static String requireText(String value, String message) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepository.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.sync.offline.repository;
 
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import java.util.List;
 import java.util.Optional;
 
 /** 离线同步业务批次领域仓储。 */
@@ -16,6 +17,12 @@ public interface OfflineBatchExecutionRepository {
 
   /** 返回任务最近一个占用执行槽位的 Batch；命令判断不得回退到 Task last-*。 */
   Optional<BatchExecution> findLatestOccupyingByTaskId(long taskId);
+
+  /** Wave 5 Backfill queue：只返回尚未创建 Attempt 1 的 PENDING Backfill Batch。 */
+  List<BatchExecution> findPendingBackfills(int limit);
+
+  /** PENDING -> RUNNING CAS reservation，防止多节点重复创建 Backfill Attempt 1。 */
+  boolean reservePendingBackfill(long batchId);
 
   BatchExecution insert(BatchExecution batch);
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.sync.offline.repository;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.compat.LegacyOfflineExecutionCompatibilityMapper;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchKey;
@@ -22,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 /** BatchExecution 与持久化模型之间的适配器。 */
 @ConditionalOnOfflineSyncEnabled
@@ -63,6 +65,17 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
   }
 
   @Override
+  public List<BatchExecution> findPendingBackfills(int limit) {
+    return dao.selectPendingBackfills(Math.max(1, limit)).stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public boolean reservePendingBackfill(long batchId) {
+    if (batchId <= 0L) throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    return dao.reservePendingBackfill(batchId, LocalDateTime.now());
+  }
+
+  @Override
   public BatchExecution insert(BatchExecution batch) {
     Objects.requireNonNull(batch, "BatchExecution 不能为空");
     if (batch.id() != null) throw new IllegalArgumentException("新 Batch 不应预先包含 ID");
@@ -98,6 +111,22 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
     if (!scope.fingerprint().equals(storedFingerprint)) {
       throw new IllegalStateException("BatchScope fingerprint 与持久化内容不一致");
     }
+
+    List<OfflineJobExecution> legacyAttempts = executionRepository.findByBatchId(po.getId());
+    String logicalJobSpec = trim(po.getLogicalJobSpecJson());
+    if (logicalJobSpec == null) {
+      logicalJobSpec = legacyAttempts.stream()
+          .filter(attempt -> attempt.getAttemptNo() != null && attempt.getAttemptNo() == 1)
+          .map(OfflineJobExecution::getSubmittedConfig)
+          .filter(StringUtils::hasText)
+          .findFirst()
+          .map(String::trim)
+          .orElse(null);
+    }
+    if (logicalJobSpec == null) {
+      throw new IllegalStateException("Batch 缺少冻结 logicalJobSpec：" + po.getId());
+    }
+
     RetryPolicySnapshot retryPolicy = new RetryPolicySnapshot(
         positive(po.getRetryMaxAttempts(), "retryMaxAttempts"),
         nonNegative(po.getRetryBackoffSeconds(), "retryBackoffSeconds"));
@@ -105,8 +134,9 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
         requireText(po.getDefinitionSnapshotJson(), "definitionSnapshot 不能为空"),
         positive(po.getDefinitionRevision(), "definitionRevision"),
         retryPolicy,
-        requireText(po.getConfigDigest(), "configDigest 不能为空"));
-    List<ExecutionAttempt> attempts = executionRepository.findByBatchId(po.getId()).stream()
+        requireText(po.getConfigDigest(), "configDigest 不能为空"),
+        logicalJobSpec);
+    List<ExecutionAttempt> attempts = legacyAttempts.stream()
         .map(LegacyOfflineExecutionCompatibilityMapper::toAttempt)
         .toList();
     return new BatchExecution(
@@ -134,6 +164,7 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
     po.setRetryMaxAttempts(batch.snapshot().retryPolicy().maxAttempts());
     po.setRetryBackoffSeconds(batch.snapshot().retryPolicy().backoffSeconds());
     po.setConfigDigest(batch.snapshot().configDigest());
+    po.setLogicalJobSpecJson(batch.snapshot().logicalJobSpec());
     po.setStatus(batch.status().name());
     LocalDateTime now = LocalDateTime.now();
     if (batch.id() == null) po.setCreateTime(now);
@@ -204,9 +235,14 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
     }
   }
 
+  private String trim(String value) {
+    return value == null || value.trim().isEmpty() ? null : value.trim();
+  }
+
   private String requireText(String value, String message) {
-    if (value == null || value.trim().isEmpty()) throw new IllegalStateException(message);
-    return value.trim();
+    String normalized = trim(value);
+    if (normalized == null) throw new IllegalStateException(message);
+    return normalized;
   }
 
   private long positive(Long value, String field) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepository.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import java.util.Optional;
+
+/** OfflineSyncTask Cursor 领域仓储。 */
+public interface OfflineSyncCursorRepository {
+
+  Optional<OfflineSyncCursor> find(long taskId, String cursorId);
+
+  OfflineSyncCursor initializeIfAbsent(
+      long taskId,
+      String cursorId,
+      String sourceColumn,
+      String initialPosition);
+
+  boolean advance(
+      OfflineSyncCursor current,
+      String expectedPosition,
+      String nextPosition,
+      long succeededBatchId);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapter.java
@@ -1,0 +1,114 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.OfflineSyncCursorDao;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.common.bean.po.sync.offline.OfflineSyncCursorPO;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Repository;
+
+/** OfflineSyncCursor 与持久化模型之间的适配器。 */
+@ConditionalOnOfflineSyncEnabled
+@Repository
+@RequiredArgsConstructor
+public class OfflineSyncCursorRepositoryAdapter implements OfflineSyncCursorRepository {
+
+  private final OfflineSyncCursorDao dao;
+
+  @Override
+  public Optional<OfflineSyncCursor> find(long taskId, String cursorId) {
+    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
+    return Optional.ofNullable(toDomain(dao.select(taskId, requireText(cursorId, "cursorId 不能为空"))));
+  }
+
+  @Override
+  public OfflineSyncCursor initializeIfAbsent(
+      long taskId,
+      String cursorId,
+      String sourceColumn,
+      String initialPosition) {
+    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
+    String normalizedId = requireText(cursorId, "cursorId 不能为空");
+    String normalizedColumn = requireText(sourceColumn, "sourceColumn 不能为空");
+    String normalizedPosition = requireText(initialPosition, "initialPosition 不能为空");
+
+    OfflineSyncCursor existing = toDomain(dao.select(taskId, normalizedId));
+    if (existing != null) return validateRoute(existing, normalizedColumn);
+
+    LocalDateTime now = LocalDateTime.now();
+    OfflineSyncCursorPO po = new OfflineSyncCursorPO();
+    po.setJobDefinitionId(taskId);
+    po.setCursorId(normalizedId);
+    po.setSourceColumn(normalizedColumn);
+    po.setPositionValue(normalizedPosition);
+    po.setStateVersion(1L);
+    po.setCreateTime(now);
+    po.setUpdateTime(now);
+    try {
+      if (dao.insert(po)) {
+        return new OfflineSyncCursor(taskId, normalizedId, normalizedColumn, normalizedPosition, null, 1L);
+      }
+    } catch (DuplicateKeyException ignored) {
+      // 多节点同时初始化时，唯一键决定赢家；下面统一重读并验证 route。
+    }
+    OfflineSyncCursor concurrent = toDomain(dao.select(taskId, normalizedId));
+    if (concurrent == null) {
+      throw new IllegalStateException("初始化离线同步 Cursor 失败：" + normalizedId);
+    }
+    return validateRoute(concurrent, normalizedColumn);
+  }
+
+  @Override
+  public boolean advance(
+      OfflineSyncCursor current,
+      String expectedPosition,
+      String nextPosition,
+      long succeededBatchId) {
+    Objects.requireNonNull(current, "current cursor 不能为空");
+    String expected = requireText(expectedPosition, "expectedPosition 不能为空");
+    String next = requireText(nextPosition, "nextPosition 不能为空");
+    if (!current.position().equals(expected)) return false;
+    if (succeededBatchId <= 0L) throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    return dao.advance(
+        current.taskId(),
+        current.cursorId(),
+        expected,
+        current.stateVersion(),
+        next,
+        succeededBatchId,
+        LocalDateTime.now());
+  }
+
+  private OfflineSyncCursor validateRoute(OfflineSyncCursor cursor, String sourceColumn) {
+    if (!cursor.sourceColumn().equals(sourceColumn)) {
+      throw new IllegalStateException(
+          "Cursor 已绑定不同 sourceColumn：" + cursor.cursorId());
+    }
+    return cursor;
+  }
+
+  private OfflineSyncCursor toDomain(OfflineSyncCursorPO po) {
+    if (po == null) return null;
+    return new OfflineSyncCursor(
+        positive(po.getJobDefinitionId(), "TaskId"),
+        requireText(po.getCursorId(), "cursorId 不能为空"),
+        requireText(po.getSourceColumn(), "sourceColumn 不能为空"),
+        requireText(po.getPositionValue(), "positionValue 不能为空"),
+        po.getLastSucceededBatchId(),
+        positive(po.getStateVersion(), "stateVersion"));
+  }
+
+  private long positive(Long value, String field) {
+    if (value == null || value <= 0L) throw new IllegalStateException(field + " 必须大于 0");
+    return value;
+  }
+
+  private String requireText(String value, String message) {
+    if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBackfillDispatcher.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBackfillDispatcher.java
@@ -1,0 +1,52 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Wave 5 Backfill queue dispatcher；PENDING Batch 按 V1 单 Task execution slot 串行提交。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@RequiredArgsConstructor
+public class OfflineBackfillDispatcher {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OfflineBackfillDispatcher.class);
+
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineBatchRuntimeService batchRuntimeService;
+  private final OfflineCursorService cursorService;
+  private final OfflineExecutionOrchestrator orchestrator;
+  private final OfflineSyncProperties properties;
+
+  @Scheduled(
+      initialDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}",
+      fixedDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}")
+  public void dispatch() {
+    int limit = Math.max(1, properties.getControl().getScanBatchSize());
+    List<BatchExecution> pending = batchRepository.findPendingBackfills(limit);
+    for (BatchExecution batch : pending) {
+      try {
+        if (batchRuntimeService.hasOccupyingBatch(batch.taskId())) continue;
+        if (!cursorReady(batch)) continue;
+        orchestrator.executePendingBackfill(batch.id());
+      } catch (RuntimeException exception) {
+        LOG.warn("Offline backfill dispatch failed, batchId={}", batch.id(), exception);
+      }
+    }
+  }
+
+  private boolean cursorReady(BatchExecution batch) {
+    if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) return true;
+    OfflineSyncCursor cursor = cursorService.find(batch.taskId(), range.cursorId()).orElse(null);
+    return cursor != null && cursor.position().equals(range.afterExclusive());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBackfillService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBackfillService.java
@@ -1,0 +1,277 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.service.support.OfflineBatchScopeExecutionAdapter;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillScopeDTO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Wave 5 Backfill command：一次请求物化一组共享 Snapshot 的 BatchExecution。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+@RequiredArgsConstructor
+public class OfflineBackfillService {
+
+  private static final Pattern SAFE_IDENTIFIER =
+      Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
+
+  private final OfflineJobDefinitionService definitionService;
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineScheduleRepository scheduleRepository;
+  private final OfflineCursorService cursorService;
+  private final OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+  private final OfflineSyncProperties properties;
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineBackfillVO submit(Long taskId, OfflineBackfillRequestDTO request) {
+    long id = positive(taskId, "TaskId");
+    if (request == null) throw new IllegalArgumentException("Backfill request 不能为空");
+    String requestId = requireText(request.getRequestId(), "requestId 不能为空");
+    if (request.getScopes() == null || request.getScopes().isEmpty()) {
+      throw new IllegalArgumentException("scopes 不能为空");
+    }
+
+    definitionRepository.lock(id);
+    OfflineJobDefinition definition = definitionService.require(id);
+
+    List<ScopePlan> plans = normalizeScopes(request.getScopes());
+    Map<String, BatchExecution> existingByFingerprint = new LinkedHashMap<>();
+    boolean hasMissing = false;
+    for (ScopePlan plan : plans) {
+      BatchKey key = BatchKey.backfill(requestId, plan.scope().fingerprint());
+      BatchExecution existing = batchRepository.findByTaskIdAndBatchKey(id, key).orElse(null);
+      if (existing == null) {
+        hasMissing = true;
+      } else {
+        validateExisting(existing, plan.scope());
+        existingByFingerprint.put(plan.scope().fingerprint(), existing);
+      }
+    }
+
+    if (hasMissing && !"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
+      throw new IllegalStateException("请先上线任务，再创建新的 Backfill Batch");
+    }
+
+    ExecutionSnapshot sharedSnapshot = sharedSnapshot(existingByFingerprint.values().stream().toList());
+    if (sharedSnapshot == null) {
+      sharedSnapshot = freezeSnapshot(definition);
+    }
+    validateCursorPlans(id, plans, existingByFingerprint, hasMissing);
+    validateExecutionScopes(id, plans, sharedSnapshot.logicalJobSpec());
+
+    List<Long> batchIds = new ArrayList<>();
+    int created = 0;
+    int reused = 0;
+    for (ScopePlan plan : plans) {
+      BatchExecution existing = existingByFingerprint.get(plan.scope().fingerprint());
+      if (existing != null) {
+        batchIds.add(existing.id());
+        reused++;
+        continue;
+      }
+      BatchExecution saved = batchRepository.insert(
+          new BatchExecution(
+              null,
+              id,
+              BatchKey.backfill(requestId, plan.scope().fingerprint()),
+              BatchTrigger.BACKFILL,
+              plan.scope(),
+              sharedSnapshot,
+              BatchStatus.PENDING,
+              List.of()));
+      batchIds.add(saved.id());
+      created++;
+    }
+
+    return OfflineBackfillVO.builder()
+        .jobDefinitionId(id)
+        .requestId(requestId)
+        .batchIds(List.copyOf(batchIds))
+        .createdCount(created)
+        .reusedCount(reused)
+        .build();
+  }
+
+  private List<ScopePlan> normalizeScopes(List<OfflineBackfillScopeDTO> values) {
+    LinkedHashMap<String, ScopePlan> unique = new LinkedHashMap<>();
+    for (OfflineBackfillScopeDTO value : values) {
+      if (value == null) throw new IllegalArgumentException("scope 不能为空");
+      String type = requireText(value.getType(), "scope.type 不能为空").toUpperCase(Locale.ROOT);
+      ScopePlan plan = switch (type) {
+        case "FULL_SELECTION" -> new ScopePlan(BatchScope.fullSelection(), null);
+        case "DATA_WINDOW" -> {
+          if (value.getStartInclusive() == null || value.getEndExclusive() == null) {
+            throw new IllegalArgumentException("DATA_WINDOW 需要 startInclusive / endExclusive");
+          }
+          yield new ScopePlan(
+              BatchScope.dataWindow(value.getStartInclusive(), value.getEndExclusive()), null);
+        }
+        case "PARTITION_SCOPE", "PARTITIONS" -> {
+          if (value.getPartitions() == null || value.getPartitions().isEmpty()) {
+            throw new IllegalArgumentException("PARTITION_SCOPE 需要 partitions");
+          }
+          yield new ScopePlan(BatchScope.partitions(value.getPartitions()), null);
+        }
+        case "CURSOR_RANGE" -> {
+          String cursorId = requireText(value.getCursorId(), "CURSOR_RANGE cursorId 不能为空");
+          String sourceColumn = safeColumn(
+              requireText(value.getCursorColumn(), "CURSOR_RANGE cursorColumn 不能为空"));
+          yield new ScopePlan(
+              BatchScope.cursorRange(
+                  cursorId,
+                  requireText(value.getAfterExclusive(), "CURSOR_RANGE afterExclusive 不能为空"),
+                  requireText(value.getThroughInclusive(), "CURSOR_RANGE throughInclusive 不能为空")),
+              sourceColumn);
+        }
+        default -> throw new IllegalArgumentException("未知 Backfill scope.type：" + type);
+      };
+      String fingerprint = plan.scope().fingerprint();
+      ScopePlan duplicate = unique.get(fingerprint);
+      if (duplicate != null && !Objects.equals(duplicate.cursorColumn(), plan.cursorColumn())) {
+        throw new IllegalArgumentException("相同 BatchScope 不能绑定不同 cursorColumn");
+      }
+      unique.putIfAbsent(fingerprint, plan);
+    }
+    return List.copyOf(unique.values());
+  }
+
+  private void validateCursorPlans(
+      long taskId,
+      List<ScopePlan> plans,
+      Map<String, BatchExecution> existingByFingerprint,
+      boolean hasMissing) {
+    Map<String, List<ScopePlan>> byCursor = new LinkedHashMap<>();
+    for (ScopePlan plan : plans) {
+      if (plan.scope() instanceof BatchScope.CursorRange range) {
+        byCursor.computeIfAbsent(range.cursorId(), ignored -> new ArrayList<>()).add(plan);
+      }
+    }
+
+    for (Map.Entry<String, List<ScopePlan>> entry : byCursor.entrySet()) {
+      List<ScopePlan> cursorPlans = entry.getValue();
+      BatchScope.CursorRange first = (BatchScope.CursorRange) cursorPlans.get(0).scope();
+      String sourceColumn = cursorPlans.get(0).cursorColumn();
+      for (int index = 1; index < cursorPlans.size(); index++) {
+        ScopePlan previousPlan = cursorPlans.get(index - 1);
+        ScopePlan currentPlan = cursorPlans.get(index);
+        BatchScope.CursorRange previous = (BatchScope.CursorRange) previousPlan.scope();
+        BatchScope.CursorRange current = (BatchScope.CursorRange) currentPlan.scope();
+        if (!Objects.equals(sourceColumn, currentPlan.cursorColumn())) {
+          throw new IllegalArgumentException("同一个 cursorId 不能绑定多个 sourceColumn：" + entry.getKey());
+        }
+        if (!previous.throughInclusive().equals(current.afterExclusive())) {
+          throw new IllegalArgumentException("同一 Cursor 的 Backfill ranges 必须连续：" + entry.getKey());
+        }
+      }
+
+      OfflineSyncCursor existingCursor = cursorService.find(taskId, entry.getKey()).orElse(null);
+      if (existingCursor != null
+          && hasMissing
+          && !existingCursor.position().equals(first.afterExclusive())) {
+        boolean allCursorBatchesAlreadyExist = cursorPlans.stream()
+            .allMatch(plan -> existingByFingerprint.containsKey(plan.scope().fingerprint()));
+        if (!allCursorBatchesAlreadyExist) {
+          throw new IllegalStateException(
+              "Cursor 已离开本 Backfill 起点，禁止追加会改变 Cursor 顺序的新 Batch：" + entry.getKey());
+        }
+      }
+      cursorService.initializeIfAbsent(
+          taskId,
+          entry.getKey(),
+          sourceColumn,
+          first.afterExclusive());
+    }
+  }
+
+  /** 在物化 PENDING Batch 前验证当前冻结 JobSpec 能明确投影所有 Scope。 */
+  private void validateExecutionScopes(
+      long taskId,
+      List<ScopePlan> plans,
+      String logicalJobSpec) {
+    for (ScopePlan plan : plans) {
+      scopeExecutionAdapter.apply(taskId, logicalJobSpec, plan.scope());
+    }
+  }
+
+  private ExecutionSnapshot sharedSnapshot(List<BatchExecution> existing) {
+    if (existing.isEmpty()) return null;
+    ExecutionSnapshot snapshot = existing.get(0).snapshot();
+    for (BatchExecution batch : existing) {
+      if (!snapshot.equals(batch.snapshot())) {
+        throw new IllegalStateException("同一 Backfill request 已存在不一致的 ExecutionSnapshot");
+      }
+    }
+    return snapshot;
+  }
+
+  private ExecutionSnapshot freezeSnapshot(OfflineJobDefinition definition) {
+    String logicalJobSpec = definitionService.resolveLogicalJobSpec(definition);
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definition.getId());
+    int maxAttempts = schedule == null
+        ? properties.getControl().getDefaultMaxAttempts()
+        : schedule.retryMaxAttempts();
+    int backoff = schedule == null
+        ? properties.getControl().getDefaultRetryBackoffSeconds()
+        : schedule.retryBackoffSeconds();
+    return new ExecutionSnapshot(
+        requireText(definition.getDefinitionJson(), "definitionSnapshot 不能为空"),
+        Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
+        new RetryPolicySnapshot(Math.max(1, maxAttempts), Math.max(0, backoff)),
+        requireText(definition.getConfigDigest(), "configDigest 不能为空"),
+        logicalJobSpec);
+  }
+
+  private void validateExisting(BatchExecution batch, BatchScope scope) {
+    if (batch.trigger() != BatchTrigger.BACKFILL) {
+      throw new IllegalStateException("Backfill BatchKey 已被非 BACKFILL Batch 占用");
+    }
+    if (!batch.batchScope().fingerprint().equals(scope.fingerprint())) {
+      throw new IllegalStateException("Backfill BatchKey 与 BatchScope 不一致");
+    }
+  }
+
+  private String safeColumn(String value) {
+    if (!SAFE_IDENTIFIER.matcher(value).matches()) {
+      throw new IllegalArgumentException("cursorColumn 不是安全标识符：" + value);
+    }
+    return value;
+  }
+
+  private long positive(Long value, String field) {
+    if (value == null || value <= 0L) throw new IllegalArgumentException(field + " 必须大于 0");
+    return value;
+  }
+
+  private String requireText(String value, String message) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  private record ScopePlan(BatchScope scope, String cursorColumn) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeService.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Wave 4 runtime truth boundary.
+ * Batch runtime truth boundary.
  *
  * <p>BatchExecution 是业务运行真相，状态只由同 Batch 的 latest Attempt 推导。Task last-* 只允许作为查询投影，
  * 不得进入这里的命令判断。
@@ -30,6 +30,7 @@ public class OfflineBatchRuntimeService {
 
   private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineCursorService cursorService;
 
   public boolean hasOccupyingBatch(Long taskId) {
     return batchRepository.hasOccupyingBatch(positive(taskId, "TaskId"));
@@ -76,7 +77,8 @@ public class OfflineBatchRuntimeService {
   /**
    * 从持久化的 latest Attempt 重新计算 BatchStatus。
    *
-   * <p>不得直接使用调用方传入 Attempt 的状态，否则旧 Attempt 的晚到 reconcile 可能回退 Batch 真相。
+   * <p>不得直接使用调用方传入 Attempt 的状态，否则旧 Attempt 的晚到 reconcile 可能回退 Batch 真相。Wave 5
+   * 同时把 Cursor advancement 放在同一事务中，保证只有 SUCCEEDED Batch 才能推进 Cursor。
    */
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public void refreshBatch(Long batchId) {
@@ -92,7 +94,12 @@ public class OfflineBatchRuntimeService {
                 .thenComparingLong(value -> number(value.getId(), 0L)))
         .orElseThrow();
     BatchStatus target = deriveStatus(latest);
-    if (batch.status() == target) return;
+    if (batch.status() == target) {
+      if (target == BatchStatus.SUCCEEDED) {
+        cursorService.advanceAfterSucceededBatch(batch);
+      }
+      return;
+    }
 
     BatchExecution updated = new BatchExecution(
         batch.id(),
@@ -105,6 +112,9 @@ public class OfflineBatchRuntimeService {
         batch.attempts());
     if (!batchRepository.update(updated)) {
       throw new IllegalStateException("更新 BatchExecution runtime status 失败：" + batch.id());
+    }
+    if (target == BatchStatus.SUCCEEDED) {
+      cursorService.advanceAfterSucceededBatch(updated);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineCursorService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineCursorService.java
@@ -1,0 +1,89 @@
+package io.yak.ops.business.sync.offline.service;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.repository.OfflineSyncCursorRepository;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Wave 5 Cursor boundary：只有 SUCCEEDED Batch 才能推进 Task Cursor。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+@RequiredArgsConstructor
+public class OfflineCursorService {
+
+  private final OfflineSyncCursorRepository repository;
+
+  public OfflineSyncCursor initializeIfAbsent(
+      long taskId,
+      String cursorId,
+      String sourceColumn,
+      String initialPosition) {
+    return repository.initializeIfAbsent(taskId, cursorId, sourceColumn, initialPosition);
+  }
+
+  public Optional<OfflineSyncCursor> find(long taskId, String cursorId) {
+    return repository.find(taskId, cursorId);
+  }
+
+  public String requireSourceColumn(long taskId, String cursorId) {
+    return find(taskId, cursorId)
+        .orElseThrow(() -> new IllegalStateException("Cursor 尚未初始化：" + cursorId))
+        .sourceColumn();
+  }
+
+  /**
+   * Cursor 只接受对应 CursorRange Batch 的成功证据。
+   *
+   * <p>CAS 使用 afterExclusive + stateVersion，旧 Batch 晚到成功不能回退或跨越当前 Cursor。
+   */
+  public AdvanceResult advanceAfterSucceededBatch(BatchExecution batch) {
+    Objects.requireNonNull(batch, "BatchExecution 不能为空");
+    if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) {
+      return AdvanceResult.NOT_CURSOR_SCOPE;
+    }
+    if (batch.status() != BatchStatus.SUCCEEDED) {
+      return AdvanceResult.NOT_SUCCEEDED;
+    }
+    if (batch.id() == null || batch.id() <= 0L) {
+      throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    }
+
+    OfflineSyncCursor current = repository.find(batch.taskId(), range.cursorId()).orElse(null);
+    if (current == null) return AdvanceResult.NOT_INITIALIZED;
+    if (current.position().equals(range.throughInclusive())) {
+      return AdvanceResult.ALREADY_ADVANCED;
+    }
+    if (!current.position().equals(range.afterExclusive())) {
+      return AdvanceResult.STALE;
+    }
+
+    if (repository.advance(
+        current,
+        range.afterExclusive(),
+        range.throughInclusive(),
+        batch.id())) {
+      return AdvanceResult.ADVANCED;
+    }
+
+    OfflineSyncCursor reread = repository.find(batch.taskId(), range.cursorId()).orElse(null);
+    if (reread != null && reread.position().equals(range.throughInclusive())) {
+      return AdvanceResult.ALREADY_ADVANCED;
+    }
+    return AdvanceResult.STALE;
+  }
+
+  public enum AdvanceResult {
+    NOT_CURSOR_SCOPE,
+    NOT_SUCCEEDED,
+    NOT_INITIALIZED,
+    ADVANCED,
+    ALREADY_ADVANCED,
+    STALE
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimService.java
@@ -150,9 +150,8 @@ public class OfflineExecutionClaimService {
   /**
    * 在原 Batch 内创建下一次 Retry Attempt。
    *
-   * <p>本方法不读取 current Task / current SchedulePolicy。Retry reservation 与下一 Attempt
-   * 持久化处于同一事务：reservation CAS 失败时不会创建重复 Attempt，Attempt 创建失败时 reservation
-   * 会随事务一起回滚。
+   * <p>Retry 只读取 Batch 自己冻结的 Snapshot / RetryPolicy / logical JobSpec，不回读 current
+   * Task 或 current SchedulePolicy。
    */
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public ClaimResult claimRetry(Long retryFromExecutionId) {
@@ -198,7 +197,7 @@ public class OfflineExecutionClaimService {
         .orElse(null);
     if (existingNext != null) {
       batchRuntimeService.refreshBatch(batchId);
-      return new ClaimResult(null, frozenLogicalJobSpec(attempts), existingNext, true);
+      return new ClaimResult(null, batch.snapshot().logicalJobSpec(), existingNext, true);
     }
 
     OfflineJobExecution latest = attempts.stream()
@@ -215,42 +214,75 @@ public class OfflineExecutionClaimService {
       throw new IllegalStateException("Retry 已达到 Batch 冻结的最大 Attempt 数");
     }
 
-    String logicalJobSpec = frozenLogicalJobSpec(attempts);
+    String logicalJobSpec = batch.snapshot().logicalJobSpec();
     if (!executionRepository.reserveRetry(previous.getId())) {
       throw new IllegalStateException("Retry 已被其他请求保留或已经创建");
     }
 
-    LocalDateTime now = LocalDateTime.now();
-    OfflineJobExecution execution = new OfflineJobExecution();
-    execution.setJobDefinitionId(batch.taskId());
-    execution.setBatchId(batch.id());
-    execution.setDefinitionVersion(batch.snapshot().definitionRevision());
-    execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
-    execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
-    execution.setIdempotencyKey(retryIdempotencyKey(batch.id(), nextAttemptNo));
-    execution.setStatus(OfflineExecutionStatus.CREATED.name());
-    execution.setStateVersion(1L);
-    execution.setAttemptNo(nextAttemptNo);
-    execution.setTriggerType("RETRY");
-    execution.setRetryFromExecutionId(previous.getId());
-    execution.setCancellationRequested(false);
-    execution.setRetryCreated(false);
-    execution.setConfigDigest(batch.snapshot().configDigest());
-    execution.setDefinitionSnapshotJson(batch.snapshot().definitionSnapshot());
-    execution.setSubmittedConfig(logicalJobSpec);
-    execution.setSourceRecordCount(0L);
-    execution.setSinkSuccessRecordCount(0L);
-    execution.setSourceReadBytes(0L);
-    execution.setSinkWrittenBytes(0L);
-    execution.setQps(0D);
-    execution.setDurationMillis(0L);
-    execution.setCreateTime(now);
-    execution.setUpdateTime(now);
+    OfflineJobExecution execution = newAttempt(
+        batch,
+        nextAttemptNo,
+        "RETRY",
+        previous.getId(),
+        retryIdempotencyKey(batch.id(), nextAttemptNo),
+        logicalJobSpec);
     if (!executionRepository.insert(execution) || execution.getId() == null) {
       throw new IllegalStateException("创建 Retry Attempt 失败");
     }
     batchRuntimeService.refreshBatch(batchId);
     return new ClaimResult(null, logicalJobSpec, execution, false);
+  }
+
+  /**
+   * Wave 5 Backfill dispatcher claim：从已经物化的 PENDING Batch 创建 Attempt 1。
+   *
+   * <p>Batch Snapshot 是唯一配置来源；PENDING -> RUNNING reservation 与 Attempt insert 同事务。
+   */
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public ClaimResult claimPendingBackfill(Long batchId) {
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    }
+    BatchExecution initial = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalArgumentException("Backfill BatchExecution 不存在：" + batchId));
+    if (initial.trigger() != BatchTrigger.BACKFILL) {
+      throw new IllegalStateException("只有 BACKFILL Batch 可以通过 pending dispatcher 创建 Attempt 1");
+    }
+
+    definitionRepository.lock(initial.taskId());
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Backfill BatchExecution 已不存在：" + batchId));
+    List<OfflineJobExecution> existingAttempts = executionRepository.findByBatchId(batchId);
+    OfflineJobExecution existingInitial = existingAttempts.stream()
+        .filter(attempt -> value(attempt.getAttemptNo(), 1) == 1)
+        .findFirst()
+        .orElse(null);
+    if (existingInitial != null) {
+      batchRuntimeService.refreshBatch(batchId);
+      return new ClaimResult(null, batch.snapshot().logicalJobSpec(), existingInitial, true);
+    }
+    if (batch.status() != BatchStatus.PENDING) {
+      throw new IllegalStateException("Backfill Batch 已不处于 PENDING：" + batch.status());
+    }
+    if (batchRuntimeService.hasOccupyingBatch(batch.taskId())) {
+      throw new IllegalStateException("Task 已有 occupying Batch，Backfill 保持排队");
+    }
+    if (!batchRepository.reservePendingBackfill(batchId)) {
+      throw new IllegalStateException("Backfill Batch 已被其他 dispatcher reservation");
+    }
+
+    OfflineJobExecution execution = newAttempt(
+        batch,
+        1,
+        "BACKFILL",
+        null,
+        "offline-backfill:" + batchId + ":1",
+        batch.snapshot().logicalJobSpec());
+    if (!executionRepository.insert(execution) || execution.getId() == null) {
+      throw new IllegalStateException("创建 Backfill Attempt 1 失败");
+    }
+    batchRuntimeService.refreshBatch(batchId);
+    return new ClaimResult(null, batch.snapshot().logicalJobSpec(), execution, false);
   }
 
   private ClaimResult createInitialClaim(
@@ -273,35 +305,19 @@ public class OfflineExecutionClaimService {
         definitionVersion,
         configDigest,
         definitionSnapshotJson,
+        logicalJobSpecJson,
         trigger,
         normalizedIdempotencyKey);
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("创建后无法读取 BatchExecution：" + batchId));
 
-    LocalDateTime now = LocalDateTime.now();
-    OfflineJobExecution execution = new OfflineJobExecution();
-    execution.setJobDefinitionId(definitionId);
-    execution.setBatchId(batchId);
-    execution.setDefinitionVersion((int) Math.min(Integer.MAX_VALUE, definitionVersion));
-    execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
-    execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
-    execution.setIdempotencyKey(normalizedIdempotencyKey);
-    execution.setStatus(OfflineExecutionStatus.CREATED.name());
-    execution.setStateVersion(1L);
-    execution.setAttemptNo(1);
-    execution.setTriggerType(trigger.legacyTriggerType());
-    execution.setRetryFromExecutionId(null);
-    execution.setCancellationRequested(false);
-    execution.setRetryCreated(false);
-    execution.setConfigDigest(configDigest);
-    execution.setDefinitionSnapshotJson(definitionSnapshotJson);
-    execution.setSubmittedConfig(logicalJobSpecJson);
-    execution.setSourceRecordCount(0L);
-    execution.setSinkSuccessRecordCount(0L);
-    execution.setSourceReadBytes(0L);
-    execution.setSinkWrittenBytes(0L);
-    execution.setQps(0D);
-    execution.setDurationMillis(0L);
-    execution.setCreateTime(now);
-    execution.setUpdateTime(now);
+    OfflineJobExecution execution = newAttempt(
+        batch,
+        1,
+        trigger.legacyTriggerType(),
+        null,
+        normalizedIdempotencyKey,
+        logicalJobSpecJson);
     if (!executionRepository.insert(execution) || execution.getId() == null) {
       throw new IllegalStateException("创建离线同步执行实例失败");
     }
@@ -314,6 +330,7 @@ public class OfflineExecutionClaimService {
       long definitionVersion,
       String configDigest,
       String definitionSnapshotJson,
+      String logicalJobSpecJson,
       Mapping trigger,
       String idempotencyKey) {
     BatchScope scope = BatchScope.fullSelection();
@@ -334,7 +351,8 @@ public class OfflineExecutionClaimService {
         requireText(definitionSnapshotJson, "definitionSnapshot 不能为空"),
         (int) Math.min(Integer.MAX_VALUE, Math.max(1L, definitionVersion)),
         retryPolicy,
-        requireText(configDigest, "configDigest 不能为空"));
+        requireText(configDigest, "configDigest 不能为空"),
+        requireText(logicalJobSpecJson, "logicalJobSpec 不能为空"));
     BatchExecution batch = new BatchExecution(
         null,
         definitionId,
@@ -349,6 +367,42 @@ public class OfflineExecutionClaimService {
     return saved.id();
   }
 
+  private OfflineJobExecution newAttempt(
+      BatchExecution batch,
+      int attemptNo,
+      String triggerType,
+      Long retryFromExecutionId,
+      String idempotencyKey,
+      String logicalJobSpec) {
+    LocalDateTime now = LocalDateTime.now();
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setJobDefinitionId(batch.taskId());
+    execution.setBatchId(batch.id());
+    execution.setDefinitionVersion(batch.snapshot().definitionRevision());
+    execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
+    execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
+    execution.setIdempotencyKey(requireText(idempotencyKey, "idempotencyKey 不能为空"));
+    execution.setStatus(OfflineExecutionStatus.CREATED.name());
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(Math.max(1, attemptNo));
+    execution.setTriggerType(requireText(triggerType, "triggerType 不能为空"));
+    execution.setRetryFromExecutionId(retryFromExecutionId);
+    execution.setCancellationRequested(false);
+    execution.setRetryCreated(false);
+    execution.setConfigDigest(batch.snapshot().configDigest());
+    execution.setDefinitionSnapshotJson(batch.snapshot().definitionSnapshot());
+    execution.setSubmittedConfig(requireText(logicalJobSpec, "logicalJobSpec 不能为空"));
+    execution.setSourceRecordCount(0L);
+    execution.setSinkSuccessRecordCount(0L);
+    execution.setSourceReadBytes(0L);
+    execution.setSinkWrittenBytes(0L);
+    execution.setQps(0D);
+    execution.setDurationMillis(0L);
+    execution.setCreateTime(now);
+    execution.setUpdateTime(now);
+    return execution;
+  }
+
   private RetryPolicySnapshot freezeRetryPolicy(Long definitionId) {
     OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
     int maxAttempts = schedule == null
@@ -358,16 +412,6 @@ public class OfflineExecutionClaimService {
         ? properties.getControl().getDefaultRetryBackoffSeconds()
         : schedule.retryBackoffSeconds();
     return new RetryPolicySnapshot(Math.max(1, maxAttempts), Math.max(0, backoffSeconds));
-  }
-
-  private String frozenLogicalJobSpec(List<OfflineJobExecution> attempts) {
-    return attempts.stream()
-        .filter(attempt -> value(attempt.getAttemptNo(), 1) == 1)
-        .map(OfflineJobExecution::getSubmittedConfig)
-        .filter(StringUtils::hasText)
-        .findFirst()
-        .map(String::trim)
-        .orElseThrow(() -> new IllegalStateException("Batch Attempt 1 缺少冻结的逻辑 JobSpec"));
   }
 
   private String retryIdempotencyKey(Long batchId, int attemptNo) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestrator.java
@@ -21,6 +21,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventReposito
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
+import io.yak.ops.business.sync.offline.service.support.OfflineBatchScopeExecutionAdapter;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -41,6 +42,7 @@ public class OfflineExecutionOrchestrator {
   private final OfflineJobExecutionRepository executionRepository;
   private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineBatchRuntimeService batchRuntimeService;
+  private final OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
   private final OfflineExecutionEventRepository eventRepository;
   private final LinkUpClient linkUpClient;
   private final ObjectMapper objectMapper;
@@ -52,6 +54,7 @@ public class OfflineExecutionOrchestrator {
       OfflineJobExecutionRepository executionRepository,
       OfflineBatchExecutionRepository batchRepository,
       OfflineBatchRuntimeService batchRuntimeService,
+      OfflineBatchScopeExecutionAdapter scopeExecutionAdapter,
       OfflineExecutionEventRepository eventRepository,
       LinkUpClient linkUpClient,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
@@ -61,6 +64,7 @@ public class OfflineExecutionOrchestrator {
     this.executionRepository = executionRepository;
     this.batchRepository = batchRepository;
     this.batchRuntimeService = batchRuntimeService;
+    this.scopeExecutionAdapter = scopeExecutionAdapter;
     this.eventRepository = eventRepository;
     this.linkUpClient = linkUpClient;
     this.objectMapper = objectMapper;
@@ -72,7 +76,7 @@ public class OfflineExecutionOrchestrator {
       Long retryFromExecutionId,
       int attemptNo) {
     ClaimResult claim = claimService.claim(definitionId, triggerType, retryFromExecutionId, attemptNo);
-    return submitClaim(claim, definitionService.resolveExecutionJobSpec(claim.getDefinition()));
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
   }
 
   /** 按工作流版本固定的任务配置快照执行，不回读任务当前 JobSpec。 */
@@ -107,9 +111,33 @@ public class OfflineExecutionOrchestrator {
         logicalJobSpecJson,
         "WORKFLOW",
         idempotencyKey);
-    return submitClaim(
-        claim,
-        definitionService.resolveExecutionJobSpec(claim.getLogicalJobSpecJson()));
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
+  }
+
+  /** Wave 5 dispatcher：只提交已经物化并 reservation 的 Backfill Batch。 */
+  public OfflineJobExecution executePendingBackfill(Long batchId) {
+    ClaimResult claim = claimService.claimPendingBackfill(batchId);
+    OfflineJobExecution execution = claim.getExecution();
+    if (claim.isReused()
+        && !OfflineExecutionStatus.CREATED.name().equalsIgnoreCase(execution.getStatus())) {
+      return execution;
+    }
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
+  }
+
+  private String resolveScopedExecutionJobSpec(ClaimResult claim) {
+    OfflineJobExecution execution = claim.getExecution();
+    String logicalJobSpec = claim.getLogicalJobSpecJson();
+    Long batchId = execution.getBatchId();
+    if (batchId != null && batchId > 0L) {
+      BatchExecution batch = batchRepository.findById(batchId)
+          .orElseThrow(() -> new IllegalStateException("Attempt 绑定的 BatchExecution 不存在：" + batchId));
+      logicalJobSpec = scopeExecutionAdapter.apply(
+          batch.taskId(),
+          logicalJobSpec,
+          batch.batchScope());
+    }
+    return definitionService.resolveExecutionJobSpec(logicalJobSpec);
   }
 
   private OfflineJobExecution submitClaim(ClaimResult claim, String resolvedExecutionJobSpec) {
@@ -177,7 +205,7 @@ public class OfflineExecutionOrchestrator {
     }
   }
 
-  /** Retry 只在原 Batch 内创建新 Attempt，并使用 Batch/Attempt 1 的冻结证据。 */
+  /** Retry 只在原 Batch 内创建新 Attempt，并使用 Batch 冻结证据。 */
   public OfflineJobExecution retryFrom(OfflineJobExecution previous) {
     if (previous == null || previous.getId() == null) {
       throw new IllegalArgumentException("重试来源实例不能为空");
@@ -188,9 +216,7 @@ public class OfflineExecutionOrchestrator {
         && !OfflineExecutionStatus.CREATED.name().equalsIgnoreCase(execution.getStatus())) {
       return execution;
     }
-    return submitClaim(
-        claim,
-        definitionService.resolveExecutionJobSpec(claim.getLogicalJobSpecJson()));
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
   }
 
   /** Task 级停止命令从 Batch runtime truth 选择 latest Attempt，不读取 Task.lastExecutionId。 */
@@ -352,10 +378,7 @@ public class OfflineExecutionOrchestrator {
     record(execution, previous, status.name(), status.name(), message, payload);
   }
 
-  /**
-   * Task last-* 只维护 latest Attempt / Batch 的查询投影。旧 Attempt 的晚到事件不得覆盖最新投影，
-   * 且任何运行判断都禁止反向读取这些字段。
-   */
+  /** Task last-* 只维护 latest Attempt / Batch 的查询投影。 */
   private void projectTaskLastState(OfflineJobExecution execution, String fallbackStatus) {
     String projectedStatus = fallbackStatus;
     Long batchId = execution.getBatchId();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineBatchScopeExecutionAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/service/support/OfflineBatchScopeExecutionAdapter.java
@@ -1,0 +1,153 @@
+package io.yak.ops.business.sync.offline.service.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.engine.ConnectorIdResolver;
+import io.yak.ops.business.sync.offline.service.OfflineCursorService;
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Applies a frozen BatchScope to the frozen logical JobSpec immediately before credential
+ * resolution.
+ *
+ * <p>Scope is domain data range; Link-Up where_condition is only an execution-boundary projection.
+ */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineBatchScopeExecutionAdapter {
+
+  private static final Pattern SAFE_IDENTIFIER =
+      Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
+
+  private final ObjectMapper objectMapper;
+  private final OfflineCursorService cursorService;
+
+  public OfflineBatchScopeExecutionAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineCursorService cursorService) {
+    this.objectMapper = objectMapper;
+    this.cursorService = cursorService;
+  }
+
+  public String apply(long taskId, String logicalJobSpecJson, BatchScope scope) {
+    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
+    if (!StringUtils.hasText(logicalJobSpecJson)) {
+      throw new IllegalArgumentException("logicalJobSpec 不能为空");
+    }
+    if (scope == null || scope instanceof BatchScope.FullSelection) {
+      return logicalJobSpecJson.trim();
+    }
+
+    ObjectNode root = parseObject(logicalJobSpecJson);
+    ObjectNode source = requireObject(root.get("source"), "scoped Batch 缺少 source JobSpec");
+    if (!ConnectorIdResolver.isJdbc(text(source, "connectorId"))) {
+      throw new IllegalStateException("Wave 5 scoped Batch V1 仅支持 JDBC source");
+    }
+    ObjectNode options = requireObject(source.get("options"), "scoped Batch 缺少 source.options");
+    if (!StringUtils.hasText(text(options, "table_path"))
+        || (options.has("table_list") && options.path("table_list").size() > 0)) {
+      throw new IllegalStateException("Wave 5 scoped Batch V1 仅支持单表 source");
+    }
+    if (StringUtils.hasText(text(options, "query"))) {
+      throw new IllegalStateException("自定义 source query 暂不支持叠加 BatchScope，请使用表 + whereCondition");
+    }
+
+    String predicate = predicate(taskId, options, scope);
+    String existing = text(options, "where_condition");
+    options.put(
+        "where_condition",
+        StringUtils.hasText(existing)
+            ? "(" + existing.trim() + ") AND (" + predicate + ")"
+            : predicate);
+    return write(root);
+  }
+
+  private String predicate(long taskId, ObjectNode options, BatchScope scope) {
+    if (scope instanceof BatchScope.DataWindow window) {
+      String column = safeColumn(requiredText(options, "partition_column", "DataWindow 需要 source.options.partition_column"));
+      return column
+          + " >= "
+          + literal(time(window.startInclusive()))
+          + " AND "
+          + column
+          + " < "
+          + literal(time(window.endExclusive()));
+    }
+    if (scope instanceof BatchScope.PartitionScope partitions) {
+      String column = safeColumn(requiredText(options, "partition_column", "PartitionScope 需要 source.options.partition_column"));
+      String values = partitions.partitions().stream()
+          .map(this::literal)
+          .reduce((left, right) -> left + ", " + right)
+          .orElseThrow();
+      return column + " IN (" + values + ")";
+    }
+    if (scope instanceof BatchScope.CursorRange range) {
+      String column = safeColumn(cursorService.requireSourceColumn(taskId, range.cursorId()));
+      return column
+          + " > "
+          + literal(range.afterExclusive())
+          + " AND "
+          + column
+          + " <= "
+          + literal(range.throughInclusive());
+    }
+    throw new IllegalArgumentException("不支持的 BatchScope：" + scope.getClass().getName());
+  }
+
+  private String safeColumn(String value) {
+    String normalized = value.trim();
+    if (!SAFE_IDENTIFIER.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("Scope source column 不是安全标识符：" + normalized);
+    }
+    return normalized;
+  }
+
+  private String literal(String value) {
+    return "'" + value.replace("'", "''") + "'";
+  }
+
+  private String time(LocalDateTime value) {
+    return value.toString().replace('T', ' ');
+  }
+
+  private ObjectNode parseObject(String json) {
+    try {
+      JsonNode value = objectMapper.readTree(json);
+      return requireObject(value, "logicalJobSpec 必须是 JSON 对象");
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("logicalJobSpec JSON 已损坏", exception);
+    }
+  }
+
+  private ObjectNode requireObject(JsonNode value, String message) {
+    if (value == null || !value.isObject()) throw new IllegalStateException(message);
+    return (ObjectNode) value;
+  }
+
+  private String requiredText(JsonNode node, String field, String message) {
+    String value = text(node, field);
+    if (!StringUtils.hasText(value)) throw new IllegalStateException(message);
+    return value.trim();
+  }
+
+  private String text(JsonNode node, String field) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || value.isNull() ? null : value.asText(null);
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 scoped logical JobSpec 失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V4__add_backfill_cursor_runtime.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V4__add_backfill_cursor_runtime.sql
@@ -1,0 +1,35 @@
+-- Wave 5 expand migration: freeze logical JobSpec on Batch and add durable Task Cursor.
+ALTER TABLE yak_offline_batch_execution
+    ADD COLUMN logical_job_spec_json LONGTEXT NULL COMMENT 'Batch 创建时冻结的不含凭据逻辑 JobSpec' AFTER config_digest,
+    ADD KEY idx_yak_offline_batch_trigger_status (trigger_type, status, id);
+
+-- Wave 2/3/4 Batch already have Attempt 1; copy the frozen logical JobSpec from the earliest Attempt 1.
+UPDATE yak_offline_batch_execution b
+JOIN (
+    SELECT e.batch_id, e.submitted_config
+    FROM yak_offline_job_execution e
+    JOIN (
+        SELECT batch_id, MIN(id) AS first_attempt_id
+        FROM yak_offline_job_execution
+        WHERE batch_id IS NOT NULL AND attempt_no = 1
+        GROUP BY batch_id
+    ) first_attempt ON first_attempt.first_attempt_id = e.id
+) frozen ON frozen.batch_id = b.id
+SET b.logical_job_spec_json = frozen.submitted_config
+WHERE b.logical_job_spec_json IS NULL;
+
+CREATE TABLE yak_offline_sync_cursor (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'Cursor persistence ID',
+    job_definition_id BIGINT NOT NULL COMMENT 'OfflineSyncTask ID',
+    cursor_id VARCHAR(128) NOT NULL COMMENT 'Task 内稳定 Cursor identity',
+    source_column VARCHAR(256) NOT NULL COMMENT 'Cursor 对应 source column route',
+    position_value VARCHAR(1024) NOT NULL COMMENT '当前已提交 Cursor 位置',
+    last_succeeded_batch_id BIGINT NULL COMMENT '最近一次推进 Cursor 的 SUCCEEDED Batch ID',
+    state_version BIGINT NOT NULL DEFAULT 1 COMMENT 'Cursor CAS version',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_offline_cursor_task_id (job_definition_id, cursor_id),
+    KEY idx_yak_offline_cursor_last_batch (last_succeeded_batch_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='离线同步 Task Cursor';

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/compat/LegacyOfflineExecutionCompatibilityMapperTest.java
@@ -48,12 +48,13 @@ class LegacyOfflineExecutionCompatibilityMapperTest {
   }
 
   @Test
-  void snapshotRequiresExplicitFrozenRetryPolicy() {
+  void snapshotRequiresExplicitFrozenRetryPolicyAndLogicalJobSpec() {
     OfflineJobExecution legacy =
         OfflineJobExecution.builder()
             .definitionVersion(7)
             .definitionSnapshotJson("{\"source\":{\"table\":\"orders\"}}")
             .configDigest("digest-7")
+            .submittedConfig("{\"kind\":\"BatchSyncJob\"}")
             .build();
     RetryPolicySnapshot retryPolicy = new RetryPolicySnapshot(4, 30);
 
@@ -64,6 +65,7 @@ class LegacyOfflineExecutionCompatibilityMapperTest {
     assertThat(snapshot.definitionSnapshot()).contains("orders");
     assertThat(snapshot.retryPolicy()).isSameAs(retryPolicy);
     assertThat(snapshot.configDigest()).isEqualTo("digest-7");
+    assertThat(snapshot.logicalJobSpec()).contains("BatchSyncJob");
   }
 
   @Test
@@ -73,6 +75,7 @@ class LegacyOfflineExecutionCompatibilityMapperTest {
             .definitionVersion(1)
             .definitionSnapshotJson("{\"source\":{}}")
             .configDigest("digest")
+            .submittedConfig("{}")
             .build();
 
     assertThatThrownBy(() -> LegacyOfflineExecutionCompatibilityMapper.toSnapshot(legacy, null))

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/core/OfflineCoreDomainTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/domain/core/OfflineCoreDomainTest.java
@@ -46,7 +46,12 @@ class OfflineCoreDomainTest {
   @Test
   void batchRequiresSequentialAttemptNumbers() {
     ExecutionSnapshot snapshot =
-        new ExecutionSnapshot("definition", 3, new RetryPolicySnapshot(3, 60), "digest");
+        new ExecutionSnapshot(
+            "definition",
+            3,
+            new RetryPolicySnapshot(3, 60),
+            "digest",
+            "{\"kind\":\"BatchSyncJob\"}");
     ExecutionAttempt first = attempt(1);
     ExecutionAttempt third = attempt(3);
 
@@ -63,6 +68,18 @@ class OfflineCoreDomainTest {
                     List.of(first, third)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("AttemptNo");
+  }
+
+  @Test
+  void executionSnapshotOwnsFrozenLogicalJobSpec() {
+    ExecutionSnapshot snapshot = new ExecutionSnapshot(
+        "definition",
+        2,
+        new RetryPolicySnapshot(2, 10),
+        "digest",
+        "{\"source\":{\"connectorId\":\"jdbc\"}}");
+
+    assertThat(snapshot.logicalJobSpec()).contains("jdbc");
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapterTest.java
@@ -38,11 +38,7 @@ class OfflineBatchExecutionRepositoryAdapterTest {
         BatchKey.schedule("schedule-42", Instant.parse("2026-08-23T02:00:00Z")),
         BatchTrigger.SCHEDULE,
         BatchScope.partitions(List.of("dt=2026-08-23", "dt=2026-08-22", "dt=2026-08-23")),
-        new ExecutionSnapshot(
-            "{\"source\":\"orders\"}",
-            7,
-            new RetryPolicySnapshot(3, 30),
-            "digest-7"),
+        snapshot(7, 3),
         BatchStatus.PENDING,
         List.of());
 
@@ -56,6 +52,7 @@ class OfflineBatchExecutionRepositoryAdapterTest {
     assertThat(reloaded.batchScope()).isEqualTo(source.batchScope());
     assertThat(reloaded.batchScope().fingerprint()).isEqualTo(source.batchScope().fingerprint());
     assertThat(reloaded.snapshot()).isEqualTo(source.snapshot());
+    assertThat(reloaded.snapshot().logicalJobSpec()).contains("BatchSyncJob");
     assertThat(reloaded.status()).isEqualTo(BatchStatus.PENDING);
     assertThat(reloaded.attempts()).isEmpty();
     assertThat(repository.findByTaskIdAndBatchKey(42L, source.batchKey())).contains(reloaded);
@@ -75,7 +72,7 @@ class OfflineBatchExecutionRepositoryAdapterTest {
         BatchKey.manual("request-9"),
         BatchTrigger.MANUAL,
         BatchScope.fullSelection(),
-        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(2, 5), "digest"),
+        snapshot(1, 2),
         BatchStatus.RUNNING,
         List.of()));
 
@@ -97,6 +94,30 @@ class OfflineBatchExecutionRepositoryAdapterTest {
   }
 
   @Test
+  void pendingBackfillUsesCasReservationBeforeAttemptCreation() {
+    FakeBatchDao dao = new FakeBatchDao();
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    when(executions.findByBatchId(anyLong())).thenReturn(List.of());
+    OfflineBatchExecutionRepositoryAdapter repository =
+        new OfflineBatchExecutionRepositoryAdapter(dao, executions);
+
+    BatchExecution pending = repository.insert(new BatchExecution(
+        null,
+        9L,
+        BatchKey.backfill("bf-1", BatchScope.fullSelection().fingerprint()),
+        BatchTrigger.BACKFILL,
+        BatchScope.fullSelection(),
+        snapshot(1, 2),
+        BatchStatus.PENDING,
+        List.of()));
+
+    assertThat(repository.findPendingBackfills(10)).containsExactly(pending);
+    assertThat(repository.reservePendingBackfill(pending.id())).isTrue();
+    assertThat(repository.reservePendingBackfill(pending.id())).isFalse();
+    assertThat(repository.findPendingBackfills(10)).isEmpty();
+  }
+
+  @Test
   void hydratesBoundLegacyExecutionsAsAttempts() {
     FakeBatchDao dao = new FakeBatchDao();
     OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
@@ -109,7 +130,7 @@ class OfflineBatchExecutionRepositoryAdapterTest {
         BatchKey.manual("request-9"),
         BatchTrigger.MANUAL,
         BatchScope.fullSelection(),
-        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(2, 5), "digest"),
+        snapshot(1, 2),
         BatchStatus.RUNNING,
         List.of()));
 
@@ -148,7 +169,7 @@ class OfflineBatchExecutionRepositoryAdapterTest {
         BatchKey.manual("request-7"),
         BatchTrigger.MANUAL,
         BatchScope.fullSelection(),
-        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(1, 0), "digest"),
+        snapshot(1, 1),
         BatchStatus.PENDING,
         List.of());
 
@@ -158,6 +179,15 @@ class OfflineBatchExecutionRepositoryAdapterTest {
     assertThatThrownBy(() -> repository.findById(inserted.id()))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("fingerprint");
+  }
+
+  private ExecutionSnapshot snapshot(int revision, int maxAttempts) {
+    return new ExecutionSnapshot(
+        "{\"source\":\"orders\"}",
+        revision,
+        new RetryPolicySnapshot(maxAttempts, 30),
+        "digest-" + revision,
+        "{\"kind\":\"BatchSyncJob\",\"source\":{\"connectorId\":\"jdbc\"}}");
   }
 
   private static final class FakeBatchDao implements OfflineBatchExecutionDao {
@@ -189,6 +219,28 @@ class OfflineBatchExecutionRepositoryAdapterTest {
         Long taskId,
         List<String> statuses) {
       return existsByTaskIdAndStatuses(taskId, statuses) ? stored : null;
+    }
+
+    @Override
+    public List<OfflineBatchExecutionPO> selectPendingBackfills(int limit) {
+      return stored != null
+              && "BACKFILL".equals(stored.getTriggerType())
+              && "PENDING".equals(stored.getStatus())
+          ? List.of(stored)
+          : List.of();
+    }
+
+    @Override
+    public boolean reservePendingBackfill(Long batchId, LocalDateTime updateTime) {
+      if (stored == null
+          || !stored.getId().equals(batchId)
+          || !"BACKFILL".equals(stored.getTriggerType())
+          || !"PENDING".equals(stored.getStatus())) {
+        return false;
+      }
+      stored.setStatus("RUNNING");
+      stored.setUpdateTime(updateTime);
+      return true;
     }
 
     @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapterTest.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.dao.OfflineSyncCursorDao;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.common.bean.po.sync.offline.OfflineSyncCursorPO;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncCursorRepositoryAdapterTest {
+
+  @Test
+  void initializesCursorRouteAndDelegatesCasAdvance() {
+    OfflineSyncCursorDao dao = mock(OfflineSyncCursorDao.class);
+    OfflineSyncCursorRepositoryAdapter repository = new OfflineSyncCursorRepositoryAdapter(dao);
+    when(dao.insert(any(OfflineSyncCursorPO.class))).thenReturn(true);
+
+    OfflineSyncCursor cursor = repository.initializeIfAbsent(
+        10L, "orders", "updated_at", "100");
+
+    assertThat(cursor.position()).isEqualTo("100");
+    assertThat(cursor.stateVersion()).isEqualTo(1L);
+    when(dao.advance(
+            10L,
+            "orders",
+            "100",
+            1L,
+            "200",
+            77L,
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(true);
+
+    assertThat(repository.advance(cursor, "100", "200", 77L)).isTrue();
+    verify(dao).advance(
+        org.mockito.ArgumentMatchers.eq(10L),
+        org.mockito.ArgumentMatchers.eq("orders"),
+        org.mockito.ArgumentMatchers.eq("100"),
+        org.mockito.ArgumentMatchers.eq(1L),
+        org.mockito.ArgumentMatchers.eq("200"),
+        org.mockito.ArgumentMatchers.eq(77L),
+        org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void existingCursorCannotBeReboundToDifferentSourceColumn() {
+    OfflineSyncCursorDao dao = mock(OfflineSyncCursorDao.class);
+    OfflineSyncCursorPO stored = new OfflineSyncCursorPO();
+    stored.setJobDefinitionId(10L);
+    stored.setCursorId("orders");
+    stored.setSourceColumn("updated_at");
+    stored.setPositionValue("100");
+    stored.setStateVersion(1L);
+    when(dao.select(10L, "orders")).thenReturn(stored);
+    OfflineSyncCursorRepositoryAdapter repository = new OfflineSyncCursorRepositoryAdapter(dao);
+
+    assertThatThrownBy(
+            () -> repository.initializeIfAbsent(10L, "orders", "id", "100"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("sourceColumn");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBackfillDispatcherTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBackfillDispatcherTest.java
@@ -1,0 +1,79 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class OfflineBackfillDispatcherTest {
+
+  @Test
+  void cursorRangeDispatchesOnlyWhenCursorMatchesAfterExclusive() {
+    OfflineBatchExecutionRepository batches = Mockito.mock(OfflineBatchExecutionRepository.class);
+    OfflineBatchRuntimeService runtime = Mockito.mock(OfflineBatchRuntimeService.class);
+    OfflineCursorService cursors = Mockito.mock(OfflineCursorService.class);
+    OfflineExecutionOrchestrator orchestrator = Mockito.mock(OfflineExecutionOrchestrator.class);
+    OfflineBackfillDispatcher dispatcher = new OfflineBackfillDispatcher(
+        batches, runtime, cursors, orchestrator, new OfflineSyncProperties());
+    BatchExecution pending = pendingCursor("100", "200");
+    when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));
+    when(runtime.hasOccupyingBatch(10L)).thenReturn(false);
+    when(cursors.find(10L, "orders"))
+        .thenReturn(Optional.of(new OfflineSyncCursor(10L, "orders", "updated_at", "100", null, 1L)));
+
+    dispatcher.dispatch();
+
+    verify(orchestrator).executePendingBackfill(77L);
+  }
+
+  @Test
+  void nextCursorRangeStaysPendingUntilPredecessorAdvancesCursor() {
+    OfflineBatchExecutionRepository batches = Mockito.mock(OfflineBatchExecutionRepository.class);
+    OfflineBatchRuntimeService runtime = Mockito.mock(OfflineBatchRuntimeService.class);
+    OfflineCursorService cursors = Mockito.mock(OfflineCursorService.class);
+    OfflineExecutionOrchestrator orchestrator = Mockito.mock(OfflineExecutionOrchestrator.class);
+    OfflineBackfillDispatcher dispatcher = new OfflineBackfillDispatcher(
+        batches, runtime, cursors, orchestrator, new OfflineSyncProperties());
+    BatchExecution pending = pendingCursor("200", "300");
+    when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));
+    when(runtime.hasOccupyingBatch(10L)).thenReturn(false);
+    when(cursors.find(10L, "orders"))
+        .thenReturn(Optional.of(new OfflineSyncCursor(10L, "orders", "updated_at", "100", null, 1L)));
+
+    dispatcher.dispatch();
+
+    verify(orchestrator, never()).executePendingBackfill(77L);
+  }
+
+  private BatchExecution pendingCursor(String after, String through) {
+    BatchScope.CursorRange scope = BatchScope.cursorRange("orders", after, through);
+    return new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill("bf", scope.fingerprint()),
+        BatchTrigger.BACKFILL,
+        scope,
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(2, 10),
+            "digest",
+            "{\"kind\":\"BatchSyncJob\"}"),
+        BatchStatus.PENDING,
+        List.of());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBackfillServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBackfillServiceTest.java
@@ -1,0 +1,192 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.service.support.OfflineBatchScopeExecutionAdapter;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillScopeDTO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineBackfillServiceTest {
+
+  @Mock private OfflineJobDefinitionService definitionService;
+  @Mock private OfflineJobDefinitionRepository definitionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineScheduleRepository scheduleRepository;
+  @Mock private OfflineCursorService cursorService;
+  @Mock private OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+
+  private OfflineBackfillService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new OfflineBackfillService(
+        definitionService,
+        definitionRepository,
+        batchRepository,
+        scheduleRepository,
+        cursorService,
+        scopeExecutionAdapter,
+        new OfflineSyncProperties());
+  }
+
+  @Test
+  void oneBackfillRequestMaterializesBatchGroupWithSharedSnapshot() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(definitionService.resolveLogicalJobSpec(definition))
+        .thenReturn("{\"kind\":\"BatchSyncJob\"}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any())).thenReturn(Optional.empty());
+    AtomicLong sequence = new AtomicLong(100L);
+    when(batchRepository.insert(any(BatchExecution.class)))
+        .thenAnswer(invocation -> persisted(invocation.getArgument(0), sequence.incrementAndGet()));
+
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("backfill-august");
+    request.setScopes(List.of(
+        window(LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 2, 0, 0)),
+        window(LocalDateTime.of(2026, 8, 2, 0, 0), LocalDateTime.of(2026, 8, 3, 0, 0))));
+
+    OfflineBackfillVO result = service.submit(10L, request);
+
+    assertThat(result.getCreatedCount()).isEqualTo(2);
+    assertThat(result.getReusedCount()).isZero();
+    assertThat(result.getBatchIds()).containsExactly(101L, 102L);
+    ArgumentCaptor<BatchExecution> captor = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batchRepository, org.mockito.Mockito.times(2)).insert(captor.capture());
+    List<BatchExecution> batches = captor.getAllValues();
+    assertThat(batches).allMatch(batch -> batch.trigger() == BatchTrigger.BACKFILL);
+    assertThat(batches).allMatch(batch -> batch.status() == BatchStatus.PENDING);
+    assertThat(batches.get(0).snapshot()).isEqualTo(batches.get(1).snapshot());
+    assertThat(batches.get(0).batchKey()).isNotEqualTo(batches.get(1).batchKey());
+    verify(scopeExecutionAdapter, org.mockito.Mockito.times(2)).apply(anyLong(), any(), any());
+    verify(definitionRepository).lock(10L);
+  }
+
+  @Test
+  void cursorBackfillRequiresContinuousRangesAndInitializesRoute() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any())).thenReturn(Optional.empty());
+    AtomicLong sequence = new AtomicLong(100L);
+    when(batchRepository.insert(any(BatchExecution.class)))
+        .thenAnswer(invocation -> persisted(invocation.getArgument(0), sequence.incrementAndGet()));
+
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("cursor-bf");
+    request.setScopes(List.of(
+        cursor("orders", "updated_at", "100", "200"),
+        cursor("orders", "updated_at", "200", "300")));
+
+    service.submit(10L, request);
+
+    verify(cursorService).initializeIfAbsent(10L, "orders", "updated_at", "100");
+  }
+
+  @Test
+  void cursorBackfillRejectsGapBeforeCreatingAnyBatch() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any())).thenReturn(Optional.empty());
+
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("cursor-gap");
+    request.setScopes(List.of(
+        cursor("orders", "updated_at", "100", "200"),
+        cursor("orders", "updated_at", "250", "300")));
+
+    assertThatThrownBy(() -> service.submit(10L, request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("连续");
+    verify(batchRepository, never()).insert(any(BatchExecution.class));
+  }
+
+  @Test
+  void invalidScopeProjectionIsRejectedBeforePendingBatchIsPersisted() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any())).thenReturn(Optional.empty());
+    when(scopeExecutionAdapter.apply(anyLong(), any(), any()))
+        .thenThrow(new IllegalStateException("Wave 5 scoped Batch V1 仅支持单表 source"));
+
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("invalid-scope");
+    request.setScopes(List.of(window(
+        LocalDateTime.of(2026, 8, 1, 0, 0),
+        LocalDateTime.of(2026, 8, 2, 0, 0))));
+
+    assertThatThrownBy(() -> service.submit(10L, request))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("单表");
+    verify(batchRepository, never()).insert(any(BatchExecution.class));
+  }
+
+  private OfflineJobDefinition definition(String releaseState) {
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState(releaseState);
+    definition.setDefinitionJson("{\"definition\":1}");
+    definition.setVersion(7);
+    definition.setConfigDigest("digest-7");
+    return definition;
+  }
+
+  private OfflineBackfillScopeDTO window(LocalDateTime start, LocalDateTime end) {
+    OfflineBackfillScopeDTO scope = new OfflineBackfillScopeDTO();
+    scope.setType("DATA_WINDOW");
+    scope.setStartInclusive(start);
+    scope.setEndExclusive(end);
+    return scope;
+  }
+
+  private OfflineBackfillScopeDTO cursor(
+      String cursorId, String column, String after, String through) {
+    OfflineBackfillScopeDTO scope = new OfflineBackfillScopeDTO();
+    scope.setType("CURSOR_RANGE");
+    scope.setCursorId(cursorId);
+    scope.setCursorColumn(column);
+    scope.setAfterExclusive(after);
+    scope.setThroughInclusive(through);
+    return scope;
+  }
+
+  private BatchExecution persisted(BatchExecution batch, long id) {
+    return new BatchExecution(
+        id,
+        batch.taskId(),
+        batch.batchKey(),
+        batch.trigger(),
+        batch.batchScope(),
+        batch.snapshot(),
+        batch.status(),
+        batch.attempts());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineBatchRuntimeServiceTest.java
@@ -31,9 +31,10 @@ class OfflineBatchRuntimeServiceTest {
   void latestAttemptIsTheOnlySourceOfBatchRuntimeTruth() {
     OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
     OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
-    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+    OfflineCursorService cursors = mock(OfflineCursorService.class);
+    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts, cursors);
 
-    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of());
+    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of(), BatchScope.fullSelection());
     OfflineJobExecution oldSucceeded = attempt(501L, 77L, 1, "SUCCEEDED");
     OfflineJobExecution latestRunning = attempt(502L, 77L, 2, "RUNNING");
     when(batches.findById(77L)).thenReturn(Optional.of(batch));
@@ -51,9 +52,10 @@ class OfflineBatchRuntimeServiceTest {
   void failedAttemptWithRetryReservationWindowMeansWaitingRetry() {
     OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
     OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
-    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+    OfflineBatchRuntimeService service =
+        new OfflineBatchRuntimeService(batches, attempts, mock(OfflineCursorService.class));
 
-    BatchExecution batch = batch(77L, BatchStatus.RUNNING, List.of());
+    BatchExecution batch = batch(77L, BatchStatus.RUNNING, List.of(), BatchScope.fullSelection());
     OfflineJobExecution failed = attempt(501L, 77L, 1, "FAILED");
     failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
     when(batches.findById(77L)).thenReturn(Optional.of(batch));
@@ -71,9 +73,10 @@ class OfflineBatchRuntimeServiceTest {
   void persistsAttemptBeforeRefreshingBatchTruth() {
     OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
     OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
-    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+    OfflineBatchRuntimeService service =
+        new OfflineBatchRuntimeService(batches, attempts, mock(OfflineCursorService.class));
 
-    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of());
+    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of(), BatchScope.fullSelection());
     OfflineJobExecution running = attempt(501L, 77L, 1, "RUNNING");
     when(attempts.update(running)).thenReturn(true);
     when(batches.findById(77L)).thenReturn(Optional.of(batch));
@@ -90,10 +93,32 @@ class OfflineBatchRuntimeServiceTest {
   }
 
   @Test
+  void succeededCursorBatchAdvancesCursorOnlyAfterBatchStatusIsPersisted() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineCursorService cursors = mock(OfflineCursorService.class);
+    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts, cursors);
+
+    BatchScope.CursorRange range = BatchScope.cursorRange("orders-cursor", "100", "200");
+    BatchExecution batch = batch(77L, BatchStatus.RUNNING, List.of(), range);
+    OfflineJobExecution succeeded = attempt(501L, 77L, 1, "SUCCEEDED");
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(succeeded));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    service.refreshBatch(77L);
+
+    InOrder order = inOrder(batches, cursors);
+    order.verify(batches).update(any(BatchExecution.class));
+    order.verify(cursors).advanceAfterSucceededBatch(any(BatchExecution.class));
+  }
+
+  @Test
   void unknownAttemptKeepsBatchInUnknownInsteadOfFailed() {
     OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(
         mock(OfflineBatchExecutionRepository.class),
-        mock(OfflineJobExecutionRepository.class));
+        mock(OfflineJobExecutionRepository.class),
+        mock(OfflineCursorService.class));
 
     OfflineJobExecution unknown = attempt(501L, 77L, 1, "UNKNOWN");
 
@@ -104,14 +129,16 @@ class OfflineBatchRuntimeServiceTest {
   void cancelWaitingRetryUsesSameCasReservationAsAutomaticRetry() {
     OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
     OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
-    OfflineBatchRuntimeService service = new OfflineBatchRuntimeService(batches, attempts);
+    OfflineBatchRuntimeService service =
+        new OfflineBatchRuntimeService(batches, attempts, mock(OfflineCursorService.class));
 
     OfflineJobExecution failed = attempt(501L, 77L, 1, "FAILED");
     failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
     BatchExecution waiting = batch(
         77L,
         BatchStatus.WAITING_RETRY,
-        List.of(LegacyOfflineExecutionCompatibilityMapper.toAttempt(failed)));
+        List.of(LegacyOfflineExecutionCompatibilityMapper.toAttempt(failed)),
+        BatchScope.fullSelection());
     when(attempts.findById(501L)).thenReturn(Optional.of(failed));
     when(attempts.reserveRetry(501L)).thenReturn(true);
     when(batches.update(any(BatchExecution.class))).thenReturn(true);
@@ -130,14 +157,20 @@ class OfflineBatchRuntimeServiceTest {
   private BatchExecution batch(
       long id,
       BatchStatus status,
-      List<io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt> attempts) {
+      List<io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt> attempts,
+      BatchScope scope) {
     return new BatchExecution(
         id,
         10L,
         new BatchKey("manual:test"),
         BatchTrigger.MANUAL,
-        BatchScope.fullSelection(),
-        new ExecutionSnapshot("{}", 1, new RetryPolicySnapshot(3, 30), "digest"),
+        scope,
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(3, 30),
+            "digest",
+            "{\"kind\":\"BatchSyncJob\"}"),
         status,
         attempts);
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineCursorServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineCursorServiceTest.java
@@ -1,0 +1,76 @@
+package io.yak.ops.business.sync.offline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineSyncCursorRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class OfflineCursorServiceTest {
+
+  @Test
+  void advancesOnlyFromSucceededCursorRangeBatch() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorService service = new OfflineCursorService(repository);
+    OfflineSyncCursor current = new OfflineSyncCursor(10L, "orders-updated", "updated_at", "100", null, 1L);
+    when(repository.find(10L, "orders-updated")).thenReturn(Optional.of(current));
+    when(repository.advance(current, "100", "200", 77L)).thenReturn(true);
+
+    assertThat(service.advanceAfterSucceededBatch(batch(BatchStatus.SUCCEEDED, "100", "200")))
+        .isEqualTo(OfflineCursorService.AdvanceResult.ADVANCED);
+    verify(repository).advance(current, "100", "200", 77L);
+  }
+
+  @Test
+  void failedBatchNeverAdvancesCursor() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorService service = new OfflineCursorService(repository);
+
+    assertThat(service.advanceAfterSucceededBatch(batch(BatchStatus.FAILED, "100", "200")))
+        .isEqualTo(OfflineCursorService.AdvanceResult.NOT_SUCCEEDED);
+    verify(repository, never()).advance(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  @Test
+  void staleSucceededBatchCannotMoveCursorBackwardOrSkipPosition() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorService service = new OfflineCursorService(repository);
+    OfflineSyncCursor current = new OfflineSyncCursor(10L, "orders-updated", "updated_at", "250", 70L, 3L);
+    when(repository.find(10L, "orders-updated")).thenReturn(Optional.of(current));
+
+    assertThat(service.advanceAfterSucceededBatch(batch(BatchStatus.SUCCEEDED, "100", "200")))
+        .isEqualTo(OfflineCursorService.AdvanceResult.STALE);
+    verify(repository, never()).advance(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  private BatchExecution batch(BatchStatus status, String after, String through) {
+    return new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill("bf-1", BatchScope.cursorRange("orders-updated", after, through).fingerprint()),
+        BatchTrigger.BACKFILL,
+        BatchScope.cursorRange("orders-updated", after, through),
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(2, 10),
+            "digest",
+            "{\"kind\":\"BatchSyncJob\"}"),
+        status,
+        List.of());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionClaimServiceTest.java
@@ -26,6 +26,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,30 +60,18 @@ class OfflineExecutionClaimServiceTest {
 
   @Test
   void shouldPersistCreatedExecutionBeforeAnyEngineProbe() {
-    OfflineJobDefinition definition = new OfflineJobDefinition();
-    definition.setId(10L);
-    definition.setReleaseState("ONLINE");
-    definition.setVersion(3);
-    definition.setConfigDigest("digest");
-    definition.setDefinitionJson("{}");
-
+    OfflineJobDefinition definition = definition();
     when(definitionService.require(10L)).thenReturn(definition);
     when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{\"job\":\"spec\"}");
     stubBatchInsert(77L);
-    when(executionRepository.insert(any(OfflineJobExecution.class)))
-        .thenAnswer(invocation -> {
-          OfflineJobExecution execution = invocation.getArgument(0);
-          execution.setId(99L);
-          return true;
-        });
+    stubExecutionInsert(99L);
 
     ClaimResult result = service.claim(10L, "WORKFLOW", null, 1);
 
     assertThat(result.getExecution().getId()).isEqualTo(99L);
     assertThat(result.getExecution().getBatchId()).isEqualTo(77L);
     assertThat(result.getExecution().getStatus()).isEqualTo("CREATED");
-    assertThat(result.getExecution().getWorkerInstanceId()).isNull();
-    assertThat(result.getExecution().getEngineBaseUrl()).isEqualTo("http://127.0.0.1:18080");
+    assertThat(result.getExecution().getSubmittedConfig()).isEqualTo("{\"job\":\"spec\"}");
     verify(definitionRepository).lock(10L);
     verify(batchRuntimeService).hasOccupyingBatch(10L);
     verify(executionRepository, never()).hasActiveExecution(10L);
@@ -93,17 +82,11 @@ class OfflineExecutionClaimServiceTest {
 
   @Test
   void shouldPersistWorkflowAttemptAsSnapshotIdempotencyKey() {
-    OfflineJobDefinition definition = new OfflineJobDefinition();
-    definition.setId(10L);
+    OfflineJobDefinition definition = definition();
     when(definitionService.require(10L)).thenReturn(definition);
     when(executionRepository.findByIdempotencyKey("attempt-123")).thenReturn(Optional.empty());
     stubBatchInsert(78L);
-    when(executionRepository.insert(any(OfflineJobExecution.class)))
-        .thenAnswer(invocation -> {
-          OfflineJobExecution execution = invocation.getArgument(0);
-          execution.setId(100L);
-          return true;
-        });
+    stubExecutionInsert(100L);
 
     ClaimResult result = service.claimSnapshot(
         10L,
@@ -120,16 +103,13 @@ class OfflineExecutionClaimServiceTest {
     assertThat(result.isReused()).isFalse();
     verify(definitionRepository).lock(10L);
     verify(batchRuntimeService).hasOccupyingBatch(10L);
-    verify(executionRepository, never()).hasActiveExecution(10L);
     verify(batchRepository).insert(any(BatchExecution.class));
-    verify(executionRepository).insert(result.getExecution());
     verify(batchRuntimeService).refreshBatch(78L);
   }
 
   @Test
   void shouldReuseSameWorkflowAttemptInsteadOfCreatingAnotherOfflineExecution() {
-    OfflineJobDefinition definition = new OfflineJobDefinition();
-    definition.setId(10L);
+    OfflineJobDefinition definition = definition();
     when(definitionService.require(10L)).thenReturn(definition);
 
     OfflineJobExecution existing = new OfflineJobExecution();
@@ -155,32 +135,25 @@ class OfflineExecutionClaimServiceTest {
 
     assertThat(result.getExecution()).isSameAs(existing);
     assertThat(result.isReused()).isTrue();
-    verify(definitionRepository).lock(10L);
     verify(batchRuntimeService, never()).hasOccupyingBatch(10L);
-    verify(executionRepository, never()).hasActiveExecution(10L);
     verify(batchRepository, never()).insert(any(BatchExecution.class));
     verify(executionRepository, never()).insert(any(OfflineJobExecution.class));
   }
 
   @Test
-  void shouldCreateRetryFromFrozenBatchWithoutReadingCurrentTaskOrSchedule() {
-    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{\"job\":\"frozen\"}");
-    BatchExecution batch = frozenBatch(77L, 3);
+  void retryReadsLogicalJobSpecFromBatchSnapshotNotLegacyAttemptCopy() {
+    OfflineJobExecution previous = failedAttempt(
+        99L, 77L, 1, "{\"job\":\"stale-attempt-copy\"}");
+    BatchExecution batch = frozenBatch(77L, 3, BatchStatus.WAITING_RETRY);
     when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
     when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
     when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));
     when(executionRepository.reserveRetry(99L)).thenReturn(true);
-    when(executionRepository.insert(any(OfflineJobExecution.class)))
-        .thenAnswer(invocation -> {
-          OfflineJobExecution execution = invocation.getArgument(0);
-          execution.setId(100L);
-          return true;
-        });
+    stubExecutionInsert(100L);
 
     ClaimResult result = service.claimRetry(99L);
     OfflineJobExecution retry = result.getExecution();
 
-    assertThat(retry.getId()).isEqualTo(100L);
     assertThat(retry.getBatchId()).isEqualTo(77L);
     assertThat(retry.getAttemptNo()).isEqualTo(2);
     assertThat(retry.getRetryFromExecutionId()).isEqualTo(99L);
@@ -188,9 +161,8 @@ class OfflineExecutionClaimServiceTest {
     assertThat(retry.getDefinitionVersion()).isEqualTo(3);
     assertThat(retry.getConfigDigest()).isEqualTo("frozen-digest");
     assertThat(retry.getDefinitionSnapshotJson()).isEqualTo("{\"definition\":\"frozen\"}");
-    assertThat(retry.getSubmittedConfig()).isEqualTo("{\"job\":\"frozen\"}");
+    assertThat(retry.getSubmittedConfig()).isEqualTo("{\"job\":\"batch-frozen\"}");
     assertThat(retry.getIdempotencyKey()).isEqualTo("offline-retry:77:2");
-    assertThat(result.isReused()).isFalse();
 
     InOrder order = inOrder(executionRepository);
     order.verify(executionRepository).reserveRetry(99L);
@@ -200,43 +172,81 @@ class OfflineExecutionClaimServiceTest {
   }
 
   @Test
+  void pendingBackfillReservationPrecedesAttemptOneInsertAndUsesFrozenSnapshot() {
+    BatchExecution pending = new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill("bf-1", BatchScope.partitions(List.of("2026-08-01")).fingerprint()),
+        BatchTrigger.BACKFILL,
+        BatchScope.partitions(List.of("2026-08-01")),
+        snapshot(3),
+        BatchStatus.PENDING,
+        List.of());
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(pending));
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of());
+    when(batchRuntimeService.hasOccupyingBatch(10L)).thenReturn(false);
+    when(batchRepository.reservePendingBackfill(77L)).thenReturn(true);
+    stubExecutionInsert(501L);
+
+    ClaimResult result = service.claimPendingBackfill(77L);
+
+    assertThat(result.getExecution().getAttemptNo()).isEqualTo(1);
+    assertThat(result.getExecution().getTriggerType()).isEqualTo("BACKFILL");
+    assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("offline-backfill:77:1");
+    assertThat(result.getExecution().getSubmittedConfig()).isEqualTo("{\"job\":\"batch-frozen\"}");
+    InOrder order = inOrder(batchRepository, executionRepository);
+    order.verify(batchRepository).reservePendingBackfill(77L);
+    order.verify(executionRepository).insert(result.getExecution());
+    verify(definitionRepository).lock(10L);
+    verifyNoInteractions(definitionService, scheduleRepository);
+    verify(batchRuntimeService).refreshBatch(77L);
+  }
+
+  @Test
   void shouldRejectUnknownWithoutBlindRetry() {
-    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{\"job\":\"frozen\"}");
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{}");
     previous.setStatus("UNKNOWN");
     when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
-    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L, 3)));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L, 3, BatchStatus.UNKNOWN)));
 
     assertThatThrownBy(() -> service.claimRetry(99L))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("UNKNOWN")
         .hasMessageContaining("reconcile");
-
     verify(executionRepository, never()).reserveRetry(99L);
-    verify(executionRepository, never()).insert(any(OfflineJobExecution.class));
   }
 
   @Test
   void shouldRespectFrozenRetryMaxAttempts() {
-    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{\"job\":\"frozen\"}");
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1, "{}");
     when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
-    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L, 1)));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L, 1, BatchStatus.WAITING_RETRY)));
     when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));
 
     assertThatThrownBy(() -> service.claimRetry(99L))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("最大 Attempt");
-
     verify(executionRepository, never()).reserveRetry(99L);
   }
 
   @Test
   void shouldRejectLegacyRetryWithoutBatchIdentity() {
-    OfflineJobExecution previous = failedAttempt(99L, null, 1, "{\"job\":\"legacy\"}");
+    OfflineJobExecution previous = failedAttempt(99L, null, 1, "{}");
     when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
 
     assertThatThrownBy(() -> service.claimRetry(99L))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("未绑定 Batch");
+  }
+
+  private OfflineJobDefinition definition() {
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState("ONLINE");
+    definition.setVersion(3);
+    definition.setConfigDigest("digest");
+    definition.setDefinitionJson("{}");
+    return definition;
   }
 
   private OfflineJobExecution failedAttempt(
@@ -255,27 +265,33 @@ class OfflineExecutionClaimServiceTest {
     return execution;
   }
 
-  private BatchExecution frozenBatch(long id, int maxAttempts) {
+  private BatchExecution frozenBatch(long id, int maxAttempts, BatchStatus status) {
     return new BatchExecution(
         id,
         10L,
         new BatchKey("manual:test"),
         BatchTrigger.MANUAL,
         BatchScope.fullSelection(),
-        new ExecutionSnapshot(
-            "{\"definition\":\"frozen\"}",
-            3,
-            new RetryPolicySnapshot(maxAttempts, 30),
-            "frozen-digest"),
-        BatchStatus.WAITING_RETRY,
+        snapshot(maxAttempts),
+        status,
         List.of());
   }
 
+  private ExecutionSnapshot snapshot(int maxAttempts) {
+    return new ExecutionSnapshot(
+        "{\"definition\":\"frozen\"}",
+        3,
+        new RetryPolicySnapshot(maxAttempts, 30),
+        "frozen-digest",
+        "{\"job\":\"batch-frozen\"}");
+  }
+
   private void stubBatchInsert(long id) {
+    AtomicReference<BatchExecution> saved = new AtomicReference<>();
     when(batchRepository.insert(any(BatchExecution.class)))
         .thenAnswer(invocation -> {
           BatchExecution batch = invocation.getArgument(0);
-          return new BatchExecution(
+          BatchExecution inserted = new BatchExecution(
               id,
               batch.taskId(),
               batch.batchKey(),
@@ -284,6 +300,18 @@ class OfflineExecutionClaimServiceTest {
               batch.snapshot(),
               batch.status(),
               batch.attempts());
+          saved.set(inserted);
+          return inserted;
+        });
+    when(batchRepository.findById(id)).thenAnswer(ignored -> Optional.ofNullable(saved.get()));
+  }
+
+  private void stubExecutionInsert(long id) {
+    when(executionRepository.insert(any(OfflineJobExecution.class)))
+        .thenAnswer(invocation -> {
+          OfflineJobExecution execution = invocation.getArgument(0);
+          execution.setId(id);
+          return true;
         });
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/OfflineExecutionOrchestratorTest.java
@@ -26,6 +26,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventReposito
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.service.OfflineExecutionClaimService.ClaimResult;
+import io.yak.ops.business.sync.offline.service.support.OfflineBatchScopeExecutionAdapter;
 import java.net.ConnectException;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +45,7 @@ class OfflineExecutionOrchestratorTest {
   @Mock private OfflineJobExecutionRepository executionRepository;
   @Mock private OfflineBatchExecutionRepository batchRepository;
   @Mock private OfflineBatchRuntimeService batchRuntimeService;
+  @Mock private OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
   @Mock private OfflineExecutionEventRepository eventRepository;
   @Mock private LinkUpClient linkUpClient;
 
@@ -58,6 +60,7 @@ class OfflineExecutionOrchestratorTest {
         executionRepository,
         batchRepository,
         batchRuntimeService,
+        scopeExecutionAdapter,
         eventRepository,
         linkUpClient,
         new ObjectMapper());
@@ -68,18 +71,13 @@ class OfflineExecutionOrchestratorTest {
     OfflineJobDefinition definition = new OfflineJobDefinition();
     definition.setId(10L);
 
-    OfflineJobExecution execution = new OfflineJobExecution();
-    execution.setId(99L);
-    execution.setJobDefinitionId(10L);
-    execution.setBatchId(77L);
-    execution.setStatus("CREATED");
-    execution.setStateVersion(1L);
-    execution.setAttemptNo(1);
-
+    OfflineJobExecution execution = execution(99L, "CREATED");
+    BatchExecution batch = frozenBatch(BatchStatus.RUNNING, BatchScope.fullSelection());
     when(claimService.claim(10L, "WORKFLOW", null, 1))
         .thenReturn(new ClaimResult(definition, "{}", execution));
-    when(definitionService.resolveExecutionJobSpec(definition)).thenReturn("{}");
-    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(BatchStatus.RUNNING)));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+    when(scopeExecutionAdapter.apply(10L, "{}", batch.batchScope())).thenReturn("{}");
+    when(definitionService.resolveExecutionJobSpec("{}")).thenReturn("{}");
     when(definitionRepository.findById(10L)).thenReturn(Optional.of(definition));
     when(linkUpClient.node())
         .thenThrow(new LinkUpTransportException(
@@ -93,22 +91,48 @@ class OfflineExecutionOrchestratorTest {
 
     assertThat(execution.getStatus()).isEqualTo("FAILED");
     assertThat(execution.getNextRetryTime()).isNotNull();
-    assertThat(execution.getErrorMessage())
-        .isEqualTo("无法连接 Link-Up Server：http://127.0.0.1:18080");
     verify(batchRuntimeService, atLeastOnce()).persistAttempt(execution);
     verify(batchRepository, atLeastOnce()).findById(77L);
+    verify(scopeExecutionAdapter).apply(10L, "{}", batch.batchScope());
     verify(eventRepository, atLeastOnce()).append(any());
   }
 
   @Test
+  void retryKeepsOriginalBatchScopeAtSubmissionBoundary() {
+    OfflineJobExecution previous = execution(98L, "FAILED");
+    OfflineJobExecution retry = execution(99L, "CREATED");
+    retry.setAttemptNo(2);
+    BatchScope.CursorRange range = BatchScope.cursorRange("orders", "100", "200");
+    BatchExecution batch = frozenBatch(BatchStatus.RUNNING, range);
+    when(claimService.claimRetry(98L)).thenReturn(new ClaimResult(null, "logical", retry));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+    when(scopeExecutionAdapter.apply(10L, "logical", range)).thenReturn("scoped");
+    when(definitionService.resolveExecutionJobSpec("scoped")).thenReturn("{}");
+    when(linkUpClient.node())
+        .thenThrow(new LinkUpTransportException("engine down", new ConnectException(), false));
+
+    assertThatThrownBy(() -> service.retryFrom(previous))
+        .isInstanceOf(LinkUpTransportException.class);
+
+    verify(scopeExecutionAdapter).apply(10L, "logical", range);
+  }
+
+  @Test
+  void reusedSubmittedBackfillDoesNotSubmitAgain() {
+    OfflineJobExecution existing = execution(99L, "SUBMITTED");
+    when(claimService.claimPendingBackfill(77L))
+        .thenReturn(new ClaimResult(null, "logical", existing, true));
+
+    OfflineJobExecution result = service.executePendingBackfill(77L);
+
+    assertThat(result).isSameAs(existing);
+    verifyNoInteractions(scopeExecutionAdapter, linkUpClient);
+  }
+
+  @Test
   void shouldMoveUncertainExecutionToUnknownAndDualWriteBatchTruth() {
-    OfflineJobExecution execution = new OfflineJobExecution();
-    execution.setId(99L);
-    execution.setJobDefinitionId(10L);
-    execution.setBatchId(77L);
-    execution.setStatus("RUNNING");
+    OfflineJobExecution execution = execution(99L, "RUNNING");
     execution.setStateVersion(3L);
-    execution.setAttemptNo(1);
     execution.setNextRetryTime(java.time.LocalDateTime.now().plusMinutes(1));
     execution.setEndTime(java.time.LocalDateTime.now());
     when(definitionRepository.findById(10L)).thenReturn(Optional.empty());
@@ -124,19 +148,9 @@ class OfflineExecutionOrchestratorTest {
 
   @Test
   void oldAttemptLateEventDoesNotOverwriteTaskLastProjection() {
-    OfflineJobExecution oldAttempt = new OfflineJobExecution();
-    oldAttempt.setId(99L);
-    oldAttempt.setJobDefinitionId(10L);
-    oldAttempt.setBatchId(77L);
-    oldAttempt.setStatus("RUNNING");
-    oldAttempt.setStateVersion(3L);
+    OfflineJobExecution oldAttempt = execution(99L, "RUNNING");
     oldAttempt.setAttemptNo(1);
-
-    OfflineJobExecution latestAttempt = new OfflineJobExecution();
-    latestAttempt.setId(100L);
-    latestAttempt.setJobDefinitionId(10L);
-    latestAttempt.setBatchId(77L);
-    latestAttempt.setStatus("RUNNING");
+    OfflineJobExecution latestAttempt = execution(100L, "RUNNING");
     latestAttempt.setAttemptNo(2);
     when(executionRepository.findByBatchId(77L)).thenReturn(List.of(oldAttempt, latestAttempt));
 
@@ -149,14 +163,9 @@ class OfflineExecutionOrchestratorTest {
 
   @Test
   void shouldCancelWaitingRetryFromBatchTruthWithoutReadingTaskLastExecution() {
-    BatchExecution waiting = frozenBatch(BatchStatus.WAITING_RETRY);
-    OfflineJobExecution latest = new OfflineJobExecution();
-    latest.setId(99L);
-    latest.setJobDefinitionId(10L);
-    latest.setBatchId(77L);
-    latest.setStatus("FAILED");
+    BatchExecution waiting = frozenBatch(BatchStatus.WAITING_RETRY, BatchScope.fullSelection());
+    OfflineJobExecution latest = execution(99L, "FAILED");
     latest.setStateVersion(4L);
-    latest.setAttemptNo(1);
 
     when(batchRuntimeService.requireLatestOccupyingBatch(10L)).thenReturn(waiting);
     when(batchRuntimeService.cancelWaitingRetry(waiting)).thenReturn(latest);
@@ -171,18 +180,30 @@ class OfflineExecutionOrchestratorTest {
     verify(eventRepository).append(any());
   }
 
-  private BatchExecution frozenBatch(BatchStatus status) {
+  private OfflineJobExecution execution(long id, String status) {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(id);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(77L);
+    execution.setStatus(status);
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(1);
+    return execution;
+  }
+
+  private BatchExecution frozenBatch(BatchStatus status, BatchScope scope) {
     return new BatchExecution(
         77L,
         10L,
         new BatchKey("manual:test"),
         BatchTrigger.MANUAL,
-        BatchScope.fullSelection(),
+        scope,
         new ExecutionSnapshot(
             "{}",
             1,
             new RetryPolicySnapshot(3, 30),
-            "digest"),
+            "digest",
+            "logical"),
         status,
         List.of());
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/support/OfflineBatchScopeExecutionAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/service/support/OfflineBatchScopeExecutionAdapterTest.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.sync.offline.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.service.OfflineCursorService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class OfflineBatchScopeExecutionAdapterTest {
+
+  private final OfflineCursorService cursorService = mock(OfflineCursorService.class);
+  private final OfflineBatchScopeExecutionAdapter adapter =
+      new OfflineBatchScopeExecutionAdapter(new ObjectMapper(), cursorService);
+
+  @Test
+  void dataWindowProjectsToWhereConditionWithoutChangingDomainScope() {
+    String logical = logicalJobSpec("tenant_id = 7");
+
+    String scoped = adapter.apply(
+        10L,
+        logical,
+        BatchScope.dataWindow(
+            LocalDateTime.of(2026, 8, 1, 0, 0),
+            LocalDateTime.of(2026, 8, 2, 0, 0)));
+
+    assertThat(scoped).contains("tenant_id = 7");
+    assertThat(scoped).contains("updated_at >= '2026-08-01 00:00'");
+    assertThat(scoped).contains("updated_at < '2026-08-02 00:00'");
+  }
+
+  @Test
+  void cursorRangeUsesCursorRouteInsteadOfTreatingCursorIdAsColumn() {
+    when(cursorService.requireSourceColumn(10L, "orders-watermark")).thenReturn("updated_at");
+
+    String scoped = adapter.apply(
+        10L,
+        logicalJobSpec(null),
+        BatchScope.cursorRange("orders-watermark", "100", "200"));
+
+    assertThat(scoped).contains("updated_at > '100'");
+    assertThat(scoped).contains("updated_at <= '200'");
+  }
+
+  @Test
+  void scopedBatchRejectsMultiTableJobSpecInsteadOfGuessingRoute() {
+    String logical = "{\"source\":{\"connectorId\":\"jdbc\",\"options\":{"
+        + "\"table_list\":[{\"table_path\":\"a\"},{\"table_path\":\"b\"}],"
+        + "\"partition_column\":\"updated_at\"}},\"sink\":{}}";
+
+    assertThatThrownBy(
+            () -> adapter.apply(10L, logical, BatchScope.partitions(java.util.List.of("p1"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("单表");
+  }
+
+  private String logicalJobSpec(String whereCondition) {
+    String where = whereCondition == null
+        ? ""
+        : ",\"where_condition\":\"" + whereCondition + "\"";
+    return "{\"kind\":\"BatchSyncJob\",\"source\":{\"connectorId\":\"jdbc\",\"options\":{"
+        + "\"table_path\":\"orders\",\"partition_column\":\"updated_at\""
+        + where
+        + "}},\"sink\":{}}";
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineBackfillRequestDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineBackfillRequestDTO.java
@@ -1,0 +1,19 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.Data;
+
+/** Offline backfill request: one request materializes a group of BatchExecution. */
+@Data
+public class OfflineBackfillRequestDTO {
+
+  @NotBlank(message = "requestId 不能为空")
+  private String requestId;
+
+  @Valid
+  @NotEmpty(message = "scopes 不能为空")
+  private List<OfflineBackfillScopeDTO> scopes;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineBackfillScopeDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineBackfillScopeDTO.java
@@ -1,0 +1,22 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Data;
+
+/** One data range inside an offline backfill request. */
+@Data
+public class OfflineBackfillScopeDTO {
+
+  @NotBlank(message = "scope.type 不能为空")
+  private String type;
+
+  private LocalDateTime startInclusive;
+  private LocalDateTime endExclusive;
+  private List<String> partitions;
+  private String cursorId;
+  private String cursorColumn;
+  private String afterExclusive;
+  private String throughInclusive;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineBatchExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineBatchExecutionPO.java
@@ -31,6 +31,11 @@ public class OfflineBatchExecutionPO {
   private Integer retryMaxAttempts;
   private Integer retryBackoffSeconds;
   private String configDigest;
+
+  /** Wave 5 后由 Batch Snapshot 持有的不含凭据逻辑 JobSpec；旧 Batch 迁移期允许为空。 */
+  @ToString.Exclude
+  private String logicalJobSpecJson;
+
   private String status;
   private LocalDateTime createTime;
   private LocalDateTime updateTime;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineSyncCursorPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineSyncCursorPO.java
@@ -1,0 +1,24 @@
+package io.yak.ops.common.bean.po.sync.offline;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 离线同步 Task Cursor 持久化模型。 */
+@Data
+@TableName("yak_offline_sync_cursor")
+public class OfflineSyncCursorPO {
+  @TableId(type = IdType.AUTO)
+  private Long id;
+
+  private Long jobDefinitionId;
+  private String cursorId;
+  private String sourceColumn;
+  private String positionValue;
+  private Long lastSucceededBatchId;
+  private Long stateVersion;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineBackfillVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineBackfillVO.java
@@ -1,0 +1,16 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+/** Result of materializing one backfill request into a Batch group. */
+@Data
+@Builder
+public class OfflineBackfillVO {
+  private Long jobDefinitionId;
+  private String requestId;
+  private List<Long> batchIds;
+  private Integer createdCount;
+  private Integer reusedCount;
+}


### PR DESCRIPTION
## Stage 6 · Wave 5

本 PR 继续以模块 `DOMAIN.md` 为领域约束，完成 `Backfill / Cursor` 主链，并同步把 Wave 5 标记为 DONE、Wave 6 标记为 NEXT。

### 1. Backfill = Batch group，不增加 Task 类型

新增 Backfill command：

```text
Backfill(requestId)
      │
      ├── Scope A -> BatchKey(requestId + scopeFingerprint) -> PENDING Batch
      ├── Scope B -> BatchKey(requestId + scopeFingerprint) -> PENDING Batch
      └── Scope C -> BatchKey(requestId + scopeFingerprint) -> PENDING Batch
```

- 一次 request 物化一组 `BACKFILL` Batch
- 同一 `requestId + scopeFingerprint` 重放复用原 Batch
- 同组 Batch 共享同一个 `ExecutionSnapshot`
- Backfill 不创建新的 Task / sceneType / syncType
- 新增 API：`POST /api/v1/job/batch-execution/{jobDefineId}/backfill`

### 2. Batch Snapshot 补齐 frozen logical JobSpec

Wave 5 将不含凭据的 logical JobSpec 正式归入 `ExecutionSnapshot`：

```text
ExecutionSnapshot
├── definitionSnapshot
├── definitionRevision
├── retryPolicy
├── configDigest
└── logicalJobSpec   // no credentials
```

原因是 Backfill Batch 可以先 PENDING、后续再 dispatch，届时不能回读 current Task 重新生成 JobSpec。

数据库新增 `yak_offline_batch_execution.logical_job_spec_json`，V4 migration 会从旧 Batch 的 Attempt 1 `submitted_config` 回填；兼容读取阶段若列尚为空，则只允许从该 Batch 的 Attempt 1 取冻结副本，不回读 current Task。

Retry 同样改成直接从 Batch Snapshot 读取 logical JobSpec，不再依赖 legacy Attempt 1 作为新链路真相。

### 3. PENDING Backfill durable queue

新增 `OfflineBackfillDispatcher`：

```text
PENDING Backfill Batch
        │
        │ V1 Task 无 occupying Batch
        ▼
PENDING -> RUNNING CAS reservation
        │
        ▼
Attempt 1
        │
        ▼
Engine submit
```

- PENDING Backfill 不占 `RUNNING / WAITING_RETRY / UNKNOWN` execution slot
- dispatcher 按 Batch ID 顺序扫描
- Attempt 1 创建前使用 `PENDING -> RUNNING` CAS reservation
- reservation 与 Attempt insert 同事务，防止多节点重复创建 Attempt
- Initial / Retry / delayed Backfill Attempt 均只使用 Batch 冻结证据

### 4. BatchScope 在 Engine 边界投影

新增 `OfflineBatchScopeExecutionAdapter`。Core Domain 只保存 BatchScope，真正的 Link-Up `where_condition` 只在 Attempt 提交边界生成，并且在生成后才解析数据源凭据。

当前 V1 有意收窄为 **JDBC 单表 source**：

- `FullSelection`：不附加过滤条件
- `DataWindow`：`partition_column >= start AND partition_column < end`
- `PartitionScope`：`partition_column IN (...)`
- `CursorRange`：`sourceColumn > afterExclusive AND sourceColumn <= throughInclusive`
- 已有 `where_condition` 使用 AND 组合
- custom source query + Scope、multi-table scoped Backfill 显式拒绝，不猜测语义

Backfill 在持久化 PENDING Batch **之前**先验证全部 Scope 能否从冻结 JobSpec 明确投影，避免错误配置进入 durable queue 后才失败。

### 5. Cursor 独立持久化，不属于 Attempt

新增：

```text
OfflineSyncCursor
├── taskId
├── cursorId
├── sourceColumn
├── position
├── lastSucceededBatchId
└── stateVersion
```

以及 `yak_offline_sync_cursor` 表。

`cursorId -> sourceColumn` 单独保存为 Route；不会把 cursorId 偷偷当成数据库字段名，也不会把 Route 塞进 BatchScope。

### 6. Cursor 只有 Batch SUCCEEDED 才推进

推进规则：

```text
Batch.status == SUCCEEDED
AND current.position == range.afterExclusive
AND current.stateVersion == expectedVersion
        │
        ▼ CAS
position = range.throughInclusive
```

因此：

- `FAILED / CANCELED / UNKNOWN` 永不推进 Cursor
- Attempt SUCCEEDED 本身不直接推进；必须先形成 Batch SUCCEEDED runtime truth
- old Batch 晚到成功时，如果 Cursor 已离开 afterExclusive，则结果为 STALE
- CAS 同时检查 position + stateVersion，禁止回退和跨越
- 同一个 cursorId 的 Backfill ranges 必须连续
- dispatcher 只有当当前 Cursor position == Batch.afterExclusive 时才会启动该 CursorRange Batch

### 7. Persistence migration

新增 `V4__add_backfill_cursor_runtime.sql`：

- `yak_offline_batch_execution.logical_job_spec_json`
- 旧 Batch frozen JobSpec backfill
- `yak_offline_sync_cursor`
- Task + cursorId unique identity
- Cursor stateVersion CAS evidence

没有物理 FK，也没有重建旧 execution 历史。

### 8. DOMAIN.md / Mapping 进度

已更新为：

```text
Wave 0  DONE  Core VO + compatibility mapper
Wave 1  DONE  Batch persistence + execution.bind(batch_id)
Wave 2  DONE  Trigger -> Batch -> Attempt 1 + Schedule BatchKey
Wave 3  DONE  Retry / UNKNOWN + durable retry reservation
Wave 4  DONE  Runtime truth -> Batch/Attempt; Task last-* projection only
Wave 5  DONE  Backfill group / BatchScope / Cursor success-only CAS
Wave 6  NEXT  Legacy cleanup
```

Wave 5 后剩余主要 Domain Debt：

- `OfflineJobExecution / yak_offline_job_execution` 仍是 Attempt persistence compatibility view，名称和重复字段待 Wave 6 contract/cleanup
- Wave 1 前 `batch_id = NULL` 的旧 execution 不属于新的 Batch runtime truth
- legacy Attempt 仍保留 definition/submittedConfig/configDigest 兼容副本

### 9. 测试覆盖

新增/更新测试锁定：

- 一个 Backfill Request 物化多个 PENDING Batch，并共享 Snapshot
- Cursor ranges 必须连续
- invalid scoped JobSpec 在 Batch 持久化前拒绝
- PENDING Backfill CAS reservation
- dispatcher 遵守 Task execution slot 与 Cursor predecessor
- Retry 使用 Batch frozen logical JobSpec
- delayed Backfill Attempt 1 只读 Batch Snapshot
- DataWindow / CursorRange Scope -> where_condition projection
- multi-table scoped execution 显式拒绝
- Cursor route 不可被重新绑定到其他 sourceColumn
- FAILED Batch 不推进 Cursor
- SUCCEEDED Batch 才推进 Cursor
- stale SUCCEEDED Batch 不能回退/跳过 Cursor
- Batch runtime status 持久化后才触发 Cursor advancement

> 当前执行环境无法解析 `github.com` DNS，无法 clone 仓库执行 Maven；本 PR 保持 Draft，等待 GitHub CI / 本地 `mvn test` / `compile` 验证。