### PR TITLE
refactor(datasource): establish phase 1 domain model and guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/datasource-domain.md
+++ b/.github/PULL_REQUEST_TEMPLATE/datasource-domain.md
@@ -1,0 +1,32 @@
+# Datasource Change
+
+> 开发前读 `REQUIREMENTS.md + DOMAIN.md`；Review 按 `REVIEW.md`。
+
+## Summary
+
+<!-- 这次改什么？是否属于 REQUIREMENTS.md 已有能力？ -->
+
+## Domain Impact Analysis
+
+```text
+Aggregate(s): DataSourceDefinition / ConnectionProfile / adjacent / none
+Invariant/lifecycle impact:
+Layer: Domain / Application / Infrastructure / Interface
+Domain Gap: no
+```
+
+## Compatibility
+
+<!-- 是否影响 REST / yak_ops_data_source / Flyway / Datasource Plugin SPI / 已有插件？ -->
+
+## Tests / Safety
+
+<!-- 跑了什么；涉及连接状态、Secret、Catalog / SQL 只读边界时说明是否保持。 -->
+
+## Domain Compliance Report
+
+```text
+Rule changed/implemented:
+Safety/tests:
+Known gaps:
+```

--- a/.github/workflows/datasource-domain-guardrails.yml
+++ b/.github/workflows/datasource-domain-guardrails.yml
@@ -1,0 +1,93 @@
+name: Datasource Domain Guardrails
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - 'yak-ops-business/yak-ops-business-datasource/**'
+      - 'yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/**'
+      - 'tools/datasource_domain_guardrails.py'
+      - '.github/PULL_REQUEST_TEMPLATE/datasource-domain.md'
+      - '.github/workflows/datasource-domain-guardrails.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'yak-ops-business/yak-ops-business-datasource/**'
+      - 'yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/**'
+      - 'tools/datasource_domain_guardrails.py'
+      - '.github/PULL_REQUEST_TEMPLATE/datasource-domain.md'
+      - '.github/workflows/datasource-domain-guardrails.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: datasource-domain-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DATASOURCE_MODULE: ':yak-ops-business-datasource'
+
+jobs:
+  static-domain-contract:
+    name: Static domain contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout yak-ops
+        uses: actions/checkout@v4
+
+      - name: Run zero-dependency datasource domain guard
+        run: python3 tools/datasource_domain_guardrails.py --event "$GITHUB_EVENT_PATH"
+
+  backend-domain-regression:
+    name: Backend regression hook
+    needs:
+      - static-domain-contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      YAK_FRAMEWORK_TOKEN: ${{ secrets.YAK_FRAMEWORK_TOKEN }}
+    steps:
+      - name: Checkout yak-ops
+        uses: actions/checkout@v4
+
+      - name: Explain private dependency requirement
+        if: env.YAK_FRAMEWORK_TOKEN == ''
+        run: |
+          echo "::notice title=Backend regression not executed::yak-framework is a private repository. Configure repository secret YAK_FRAMEWORK_TOKEN with read access to enable the full Maven/JUnit regression layer. Static Datasource Domain Contract remains mandatory and runs without this secret."
+
+      - name: Checkout yak-framework SNAPSHOT dependency
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        uses: actions/checkout@v4
+        with:
+          repository: weifuwan/yak-framework
+          path: .ci/yak-framework
+          token: ${{ env.YAK_FRAMEWORK_TOKEN }}
+
+      - name: Set up JDK 21 and Maven cache
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Install yak-framework SNAPSHOT
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        run: ./mvnw -B -ntp -f .ci/yak-framework/pom.xml -DskipTests install
+
+      - name: Build datasource module dependencies
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        run: ./mvnw -B -ntp -pl "$DATASOURCE_MODULE" -am -DskipTests install
+
+      - name: Run targeted datasource domain regression tests
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        run: >-
+          ./mvnw -B -ntp
+          -pl "$DATASOURCE_MODULE"
+          -Dtest=DataSourceDomainArchitectureTest,DataSourceLayeringConventionTest,DataSourceDefinitionTest,DataSourceRepositoryAdapterTest,DataSourceServiceImplTest,DataSourceViewMapperTest
+          -Dsurefire.failIfNoSpecifiedTests=false
+          test

--- a/tools/datasource_domain_guardrails.py
+++ b/tools/datasource_domain_guardrails.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Zero-dependency guardrails for the Datasource domain."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / "yak-ops-business/yak-ops-business-datasource"
+JAVA_ROOT = MODULE / "src/main/java/io/yak/ops/business/datasource"
+DOMAIN_DIR = JAVA_ROOT / "domain"
+
+CORE_FILES = (
+    "ConnectionProfile.java",
+    "DataSourceDefinition.java",
+    "DataSourceQuery.java",
+    "DataSourceSummary.java",
+)
+
+FORBIDDEN_IMPORTS = (
+    "org.springframework.",
+    "com.baomidou.",
+    "org.mybatis.",
+    "jakarta.persistence.",
+    "io.yak.ops.common.bean.dto.",
+    "io.yak.ops.common.bean.vo.",
+    "io.yak.ops.common.bean.po.",
+    "io.yak.ops.spi.datasource.",
+    "io.yak.ops.business.datasource.controller.",
+    "io.yak.ops.business.datasource.service.",
+    "io.yak.ops.business.datasource.repository.",
+    "io.yak.ops.business.datasource.dao.",
+    "io.yak.ops.business.datasource.plugin.",
+)
+
+
+class Guard:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.checks = 0
+
+    def check(self, ok: bool, message: str) -> None:
+        self.checks += 1
+        if not ok:
+            self.errors.append(message)
+
+    def read(self, path: Path) -> str:
+        self.check(path.exists(), f"Missing required file: {path.relative_to(ROOT)}")
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+
+    def finish(self) -> int:
+        if self.errors:
+            print("Datasource Domain Guardrails: FAILED")
+            for i, error in enumerate(self.errors, 1):
+                print(f"{i}. {error}")
+            return 1
+        print(f"Datasource Domain Guardrails: OK ({self.checks} checks)")
+        return 0
+
+
+def code_only(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
+    text = re.sub(r"//[^\n]*", " ", text)
+    text = re.sub(r'"(?:\\.|[^"\\])*"', '""', text)
+    return text
+
+
+def check_core(g: Guard) -> None:
+    for name in CORE_FILES:
+        text = g.read(DOMAIN_DIR / name)
+        imports = re.findall(r"(?m)^\s*import\s+(?:static\s+)?([^;]+);", text)
+        for imported in imports:
+            g.check(
+                not imported.startswith(FORBIDDEN_IMPORTS),
+                f"{name}: framework/adapter import is forbidden: {imported}",
+            )
+
+    definition = g.read(DOMAIN_DIR / "DataSourceDefinition.java")
+    profile = g.read(DOMAIN_DIR / "ConnectionProfile.java")
+    code = code_only(definition)
+
+    for behavior in (
+        "create(",
+        "updateConfiguration(",
+        "replaceConnectionProfile(",
+        "assertTypeUnchanged(",
+        "markConnected(",
+        "markDisconnected(",
+        "markConnectionUnknown(",
+    ):
+        g.check(behavior in code, f"DataSource aggregate behavior missing: {behavior}")
+
+    g.check(
+        "record ConnectionProfile" in profile,
+        "ConnectionProfile must remain an immutable record value object",
+    )
+    g.check(
+        '@ToString.Exclude private String jdbcUrl;' in definition,
+        "DataSourceDefinition jdbcUrl must stay excluded from toString",
+    )
+    g.check(
+        '@ToString.Exclude private String connectionParams;' in definition,
+        "DataSourceDefinition connectionParams must stay excluded from toString",
+    )
+    g.check(
+        '@ToString.Exclude private String originalJson;' in definition,
+        "DataSourceDefinition originalJson must stay excluded from toString",
+    )
+
+
+def check_application_mutations(g: Guard) -> None:
+    service = g.read(JAVA_ROOT / "service/impl/DataSourceServiceImpl.java")
+    code = code_only(service)
+
+    for required in (
+        "DataSourceDefinition.create(",
+        "existing.assertTypeUnchanged(",
+        "existing.updateConfiguration(",
+        "definition.markConnected(",
+        "definition.markDisconnected(",
+    ):
+        g.check(required in code, f"Application service bypassed aggregate behavior: missing {required}")
+
+    for forbidden in (
+        ".setConnStatus(",
+        ".setJdbcUrl(",
+        ".setConnectionParams(",
+        ".setOriginalJson(",
+    ):
+        g.check(forbidden not in code, f"Application service must not mutate aggregate scalar directly: {forbidden}")
+
+
+def check_docs(g: Guard) -> None:
+    requirements = g.read(MODULE / "REQUIREMENTS.md")
+    contract = g.read(MODULE / "DOMAIN.md")
+    review = g.read(MODULE / "REVIEW.md")
+    overview = g.read(MODULE / "README.md")
+
+    for name, text, limit in (
+        ("REQUIREMENTS.md", requirements, 150),
+        ("DOMAIN.md", contract, 180),
+        ("REVIEW.md", review, 210),
+    ):
+        g.check(
+            len(text.splitlines()) <= limit,
+            f"{name} exceeds {limit} lines; keep module contracts concise",
+        )
+
+    for phrase in ("核心能力", "模块边界", "Requirement Gap"):
+        g.check(phrase in requirements, f"REQUIREMENTS.md lost required phrase: {phrase}")
+
+    for phrase in (
+        "DataSourceDefinition",
+        "ConnectionProfile",
+        "12 条硬规则",
+        "Domain Impact Analysis",
+        "Domain Compliance Report",
+        "Domain Gap",
+    ):
+        g.check(phrase in contract, f"DOMAIN.md lost mandatory phrase: {phrase}")
+
+    for phrase in (
+        "Requirement Gap",
+        "Domain Gap",
+        "P0 Blocker",
+        "P1 Must Fix",
+        "Conclusion: PASS | CHANGES_REQUIRED",
+        "Missing Tests",
+    ):
+        g.check(phrase in review, f"REVIEW.md lost review protocol phrase: {phrase}")
+
+    for name in ("REQUIREMENTS.md", "DOMAIN.md", "REVIEW.md"):
+        g.check(name in overview, f"README.md must link {name}")
+
+
+def check_pr(g: Guard, event_path: Path | None) -> None:
+    if not event_path:
+        return
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    pr = event.get("pull_request")
+    if not pr:
+        return
+    body = pr.get("body") or ""
+    for phrase in (
+        "Domain Impact Analysis",
+        "Domain Gap",
+        "Compatibility",
+        "Domain Compliance Report",
+    ):
+        g.check(phrase.lower() in body.lower(), f"PR body must contain '{phrase}'")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path)
+    args = parser.parse_args()
+
+    g = Guard()
+    check_core(g)
+    check_application_mutations(g)
+    check_docs(g)
+    check_pr(g, args.event)
+    return g.finish()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
@@ -1,0 +1,163 @@
+# Datasource Domain
+
+> 本文件只保留**实现必须遵守的硬规则**，不记录设计过程。历史演进看 Git / PR。
+>
+> `REQUIREMENTS.md` 定义“需要什么”；`DOMAIN.md` 定义“不能违反什么”；`REVIEW.md` 定义“怎么判卷”。
+
+## 核心模型
+
+```text
+DataSourceDefinition  (Aggregate Root，当前保留历史命名)
+├── id
+├── name
+├── dbType
+├── environment
+├── ConnectionProfile
+│   ├── jdbcUrl
+│   ├── normalizedJson
+│   └── originalJson
+├── connectionStatus
+├── remark
+└── timestamps
+```
+
+```text
+DataSourceDefinition
+      │ persisted by
+      ▼
+DataSourceRepository (Domain Port)
+      │ implemented by
+      ▼
+Repository Adapter -> DAO / PO / MyBatis
+```
+
+Datasource Plugin SPI 是**邻接上下文**，不是 Core Domain。
+
+## 12 条硬规则
+
+1. **`DataSourceDefinition` 是 Business Datasource 当前唯一数据源业务事实。** DTO、VO、PO、Plugin SPI Model 都只是 Adapter / Projection / Protocol Model。
+2. **`ConnectionProfile` 是连接配置的领域值对象。** 新业务代码修改连接配置必须经过 Aggregate 行为，不直接散落修改 `jdbcUrl / connectionParams / originalJson`。
+3. **DataSource Type 创建后不可修改。** 更新时请求类型必须与 Aggregate 当前 `dbType` 一致。
+4. **连接配置被替换后，连接状态必须回到 `UNKNOWN`。** 旧配置的 `CONNECTED / DISCONNECTED` 不能继承给新配置。
+5. **`CONNECTED / DISCONNECTED` 只表示最近一次针对当前已保存配置的连接测试结果。** 配置可解析不等于连接成功。
+6. **未保存配置的连接测试不改变任何 Aggregate 状态。** 只有已保存数据源测试才持久化连接状态。
+7. **Core Domain 不依赖 Spring / MyBatis / HTTP DTO / VO / PO / Datasource Plugin SPI。** 插件、JDBC、Catalog 实现细节属于边界之外。
+8. **Repository Contract 只暴露 Domain。** PO、MyBatis `IPage`、Mapper Row 不得越过 Repository Adapter。
+9. **Secret 不是可观察业务数据。** 完整连接 JSON、密码、Token 不得进入 `toString()`、普通日志或未脱敏响应。
+10. **Catalog / SQL Execution / Plugin Capability 属于相邻子域。** Phase 1 不为了统一风格把它们硬塞进 `DataSourceDefinition`。
+11. **新的业务语义优先扩明确领域模型。** 不通过新增 `Map<String, Object>` key、临时 boolean、展示 VO 字段来绕过 Domain Gap。
+12. **无法映射现有模型就是 `Domain Gap`。** 先讨论模型和边界，不用 DTO / VO / PO / Plugin Model 冒充 Domain。
+
+## 关键不变量
+
+- `name` 必须非空。
+- `dbType` 必须存在。
+- `environment` 必须存在。
+- `ConnectionProfile.normalizedJson` 必须存在。
+- `dbType` 一旦创建不可变。
+- `ConnectionProfile` 变更后 `connectionStatus = UNKNOWN`。
+- 连接测试成功：`connectionStatus = CONNECTED`。
+- 连接测试失败：`connectionStatus = DISCONNECTED`。
+
+## 命令语义
+
+```text
+Create
+  -> new DataSourceDefinition
+  -> ConnectionProfile
+  -> UNKNOWN
+
+Update
+  -> same dbType
+  -> replace editable metadata / ConnectionProfile
+  -> UNKNOWN
+
+TestConnection(saved)
+  -> success -> CONNECTED
+  -> failure -> DISCONNECTED
+
+TestConnection(unsaved)
+  -> validation only
+  -> no persisted state
+```
+
+## 持久化兼容
+
+当前物理表仍然是：
+
+```text
+yak_ops_data_source
+```
+
+当前 PO 仍然保存：
+
+```text
+jdbc_url
+connection_params
+original_json
+conn_status
+```
+
+这些是持久化投影，不定义业务边界。Phase 1 保持物理结构兼容，由 Repository Adapter 负责 Domain 与持久化模型之间的映射。
+
+## 邻接上下文
+
+当前 Datasource Plugin SPI 提供连接解析、连接测试、Catalog 和 SQL 执行能力。Phase 1 为兼容性仍允许 Application Service 调用 SPI；后续阶段必须通过 Gateway / Adapter 收口。
+
+因此当前明确禁止：
+
+```text
+Plugin SPI Model -> Core Domain identity
+Plugin private config -> DataSource global field
+Controller VO -> Plugin stable business fact
+PO -> Service direct access
+```
+
+## 修改代码前后
+
+修改前先确认 `REQUIREMENTS.md` 中已有对应能力，再写一个短块：
+
+```text
+Domain Impact Analysis
+- Aggregate(s):
+- Invariant/lifecycle impact:
+- Layer:
+- Domain Gap: yes/no
+```
+
+修改后写：
+
+```text
+Domain Compliance Report
+- Rule changed/implemented:
+- Safety/tests:
+- Known gaps:
+```
+
+代码 Review 固定按 `REVIEW.md` 执行。
+
+## 自动护栏
+
+至少保留以下自动检查：
+
+```text
+Core Domain 不依赖 DTO / VO / PO / MyBatis / Spring / Datasource Plugin SPI
+Repository 只暴露 Domain
+Service 不直接注入 DAO / PO
+Controller 只通过 Service 进入业务链路
+ConnectionProfile / connection status 行为回归测试
+```
+
+**不要因为功能被护栏拦住就删护栏。** 如果规则真的变化，同一个 PR 中同步修改 `DOMAIN.md` 和对应测试。
+
+## 已知独立 Gap
+
+```text
+Datasource Plugin Gateway / Adapter
+Catalog Domain Model
+SQL Execution Domain Model
+Plugin Capability / Descriptor
+Plugin API VO dependency
+Map-based Catalog protocol
+Aggregate physical naming cleanup
+```

--- a/yak-ops-business/yak-ops-business-datasource/README.md
+++ b/yak-ops-business/yak-ops-business-datasource/README.md
@@ -1,39 +1,100 @@
 # Yak Ops Datasource
 
-数据源模块负责数据源注册、连接测试、Catalog 元数据访问和数据源插件配置。
+数据源模块负责数据源注册、连接测试、Catalog 元数据访问和数据源插件编排，并为数据开发、同步和任务等上层模块提供稳定的数据源引用。
 
-## 工程分层
+## 开发前必读
 
 ```text
-Controller -> DTO -> Service -> Domain
-           -> Repository -> Adapter -> DAO
-           -> BaseMapper / Mapper XML -> PO -> MySQL
-
-Domain -> View Mapper -> VO -> Controller
-
-Service -> Datasource Plugin SPI
-Catalog Service -> Domain Repository -> Datasource Plugin SPI
+REQUIREMENTS.md  -> 模块需要什么
+DOMAIN.md        -> 实现不能违反什么
+REVIEW.md        -> 按什么标准 Review
 ```
 
-约束：
+三份文档只维护当前有效规则，历史设计过程看 Issue / PR / Git。
+
+## 核心领域模型
+
+```text
+DataSourceDefinition  (Aggregate Root，当前保留历史命名)
+├── identity / name / dbType / environment
+├── ConnectionProfile
+│   ├── jdbcUrl
+│   ├── normalizedJson
+│   └── originalJson
+├── connectionStatus
+├── remark
+└── timestamps
+```
+
+关键业务规则：
+
+- 数据源类型创建后不可修改。
+- 新建数据源连接状态为 `UNKNOWN`。
+- 修改连接配置后，旧连接测试结果失效并回到 `UNKNOWN`。
+- 已保存数据源连接测试成功进入 `CONNECTED`，失败进入 `DISCONNECTED`。
+- 未保存配置的连接测试不产生持久化状态。
+- Secret、完整连接 JSON 和可能携带凭据的 JDBC URL 不得通过 `toString()` 或普通日志输出。
+
+详细规则见 `DOMAIN.md`。
+
+## 当前工程分层
+
+```text
+Controller
+    ↓
+Application Service
+    ↓
+Domain
+    ↓
+Repository Port
+    ↓
+Repository Adapter
+    ↓
+DAO / Mapper / PO / MySQL
+```
+
+当前 Phase 1 为保持兼容，Application Service 仍直接编排 Datasource Plugin SPI：
+
+```text
+Application Service -> Datasource Plugin SPI -> Plugin Implementation
+```
+
+Plugin Gateway / Adapter 隔离属于后续阶段，不在 Phase 1 中以 Big-Bang 方式同时修改 Business、REST、DB 和 Plugin SPI。
+
+## 分层约束
 
 - Controller 只通过 Service 进入业务链路，不直接依赖 Repository、DAO、Mapper 或插件实现。
-- Service 与 Catalog Service 使用 `DataSourceDefinition` 等 Domain，不直接操作 MyBatis PO。
+- Service 使用 `DataSourceDefinition` 等 Domain，不直接操作 MyBatis PO。
 - Repository 接口只暴露 Domain；PO 仅存在于 Adapter / DAO / Mapper 持久化层。
-- 分页遵循 `DAO IPage<PO> -> Adapter PageData<Domain> -> Service PagingData<VO>`；不再创建数据源模块私有 `DataSourcePage`。
-- HTTP 分页继续保持 `bizData + pagination`，第一阶段不要求前端迁移。
-- DAO 不接收 HTTP DTO，也不返回 HTTP VO；DAO 查询使用自己的 Query/Row 投影。
+- Core Domain 不依赖 Spring、MyBatis、HTTP DTO / VO / PO 或 Datasource Plugin SPI。
+- 分页遵循 `DAO IPage<PO> -> Adapter PageData<Domain> -> Service PagingData<VO>`。
+- DAO 不接收 HTTP DTO，也不返回 HTTP VO；DAO 查询使用自己的 Query / Row 投影。
 - 普通单表 CRUD 使用 MyBatis-Plus；统计等自定义 SQL 放在 `mapper/datasource/*.xml`。
-- `connectionParams`、`originalJson` 可以存在于内部 Domain，用于插件执行和密钥复用，但不得直接作为 HTTP 响应输出。
 - HTTP 详情必须通过 `DataSourceViewMapper` 和 `DataSourceSecretCodec` 做连接地址与连接 JSON 脱敏。
-- Catalog 读取使用 Repository 加载 Domain，再交给 Datasource Plugin SPI；Catalog 不直接访问 DAO/PO。
+- Catalog 读取使用 Repository 加载 Domain，再交给 Datasource Plugin SPI；Catalog 不直接访问 DAO / PO。
 
 ## 持久化
 
-当前数据源管理只维护一张业务表：
+当前数据源管理继续维护现有业务表：
 
 ```text
 yak_ops_data_source
 ```
 
+Phase 1 不修改现有表结构和 Flyway 历史。`jdbc_url / connection_params / original_json / conn_status` 是持久化投影，不是新的领域边界。
+
 业务模块共享 `yak.database` 对应的 `yakBusinessDataSource`、MyBatis SessionFactory 和事务管理器；数据源模块继续拥有自己的 Flyway migration location/history 边界。
+
+## 后续领域 Gap
+
+当前明确留给后续阶段处理：
+
+```text
+Datasource Plugin Gateway / Adapter
+Catalog Domain Model
+SQL Execution Domain Model
+Plugin Capability / Descriptor
+Plugin API VO dependency
+Map-based Catalog protocol typing
+Aggregate physical naming cleanup
+```

--- a/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
@@ -1,0 +1,123 @@
+# Datasource Requirements
+
+> 本文件只描述**模块需要什么**，不描述怎么实现。历史需求和讨论看 Issue / PR / Git。
+
+## 目标
+
+Datasource 提供 Yak Ops 的统一数据源控制面：注册和维护数据源配置、验证连接可用性、访问 Catalog 元数据，并向上层业务提供稳定的数据源引用和基础查询能力。
+
+## 核心能力
+
+- 创建、编辑、查询和删除数据源。
+- 支持数据源名称、类型、运行环境、备注和连接配置管理。
+- 支持已保存数据源和未保存配置的连接测试。
+- 记录数据源最近一次连接测试结果：`UNKNOWN / CONNECTED / DISCONNECTED`。
+- 提供数据库、Schema、表、字段等 Catalog 元数据访问能力。
+- 提供数据预览、数量统计和 SQL 模板等轻量读取能力。
+- 通过 Datasource Plugin SPI 扩展不同数据库或数据源类型。
+- 对连接密码等 Secret 做合并、脱敏和安全输出。
+- 为数据开发、同步、任务等上层模块提供稳定的数据源引用。
+
+## 关键业务行为
+
+### 创建数据源
+
+```text
+Create
+  -> validate name / type / environment / connection
+  -> DataSource aggregate
+  -> connection status = UNKNOWN
+  -> persist
+```
+
+新建数据源不会因为“配置可被解析”就自动标记为 `CONNECTED`；只有真实连接测试成功后才能进入 `CONNECTED`。
+
+### 编辑数据源
+
+```text
+Update
+  -> load current DataSource
+  -> data source type must remain unchanged
+  -> merge stored Secret when needed
+  -> replace connection profile / metadata
+  -> connection status = UNKNOWN
+  -> persist
+```
+
+数据源类型创建后不可修改。连接配置发生编辑后，旧连接测试结果不再代表当前配置，因此必须回到 `UNKNOWN`。
+
+### 连接测试
+
+```text
+Test saved datasource
+  -> load aggregate
+  -> execute plugin connection test
+  -> success: CONNECTED
+  -> failure: DISCONNECTED
+```
+
+未保存配置的连接测试只验证输入，不产生持久化状态。
+
+## 安全要求
+
+- Secret 不得通过普通 DTO / VO、异常文本、`toString()` 或业务日志明文暴露。
+- HTTP 详情中的 JDBC 地址和连接 JSON 必须经过脱敏边界。
+- 数据源编辑时允许复用已保存 Secret，但不能把掩码字符串当成真实凭据覆盖原值。
+- Domain、Repository Contract 和测试夹具不得为了调试方便打印完整连接 JSON。
+
+## 模块边界
+
+本模块负责：
+
+- 数据源业务定义和生命周期规则；
+- 数据源持久化；
+- 连接测试编排；
+- Catalog / 轻量读取能力的业务入口；
+- Datasource Plugin 的发现和调用边界。
+
+本模块不负责：
+
+- 实时同步任务的定义、发布和运行状态；
+- Flink / Flink CDC 集群生命周期；
+- 任意 ETL / 工作流编排；
+- 数据血缘计算；
+- JDBC Driver 或第三方数据源服务的部署；
+- 把某个插件的私有参数升级为全局业务字段。
+
+## 兼容性要求
+
+当前阶段保持以下外部契约兼容：
+
+- REST API 路径和主要请求/响应结构；
+- `yak_ops_data_source` 现有物理表结构；
+- 现有 Flyway 历史；
+- Datasource Plugin SPI 的现有签名；
+- MySQL / PostgreSQL / Oracle / Doris 等已有插件实现。
+
+领域改造不得以 Big-Bang 方式同时修改 REST、DB 和 Plugin SPI。
+
+## 当前明确未解决
+
+以下能力需要后续阶段单独设计，不在普通 Phase 1 修改中顺手完成：
+
+```text
+Business Domain 与 Datasource Plugin SPI 的 Gateway / Adapter 隔离
+Catalog Metadata 的完整业务领域模型
+SQL Execution 的领域模型与运行时拆分
+Plugin Capability / Descriptor 标准化
+Plugin API 中 VO 依赖清理
+Map<String, Object> Catalog 协议类型化
+DataSourceDefinition 物理命名清理
+```
+
+## 需求变更规则
+
+如果 PR 引入本文件没有描述的新业务能力或改变已有业务行为：
+
+```text
+Requirement Gap
+```
+
+先确认需求并更新本文件，再实现代码。Reviewer / AI 不得自行补需求。
+
+本文件只维护**当前有效需求**，不要追加迭代历史。

--- a/yak-ops-business/yak-ops-business-datasource/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-datasource/REVIEW.md
@@ -1,0 +1,192 @@
+# Datasource Review
+
+> 本文件定义**如何 Review**。Reviewer / AI 是裁判，不是需求设计者；不得边 Review 边自行补需求。
+
+## Review 前必读
+
+按顺序读取：
+
+```text
+REQUIREMENTS.md  -> 模块需要什么
+DOMAIN.md        -> 实现不能违反什么
+REVIEW.md        -> 按什么标准判卷
+PR diff / tests  -> 实际改了什么
+```
+
+## Review 顺序
+
+### 1. Requirement Alignment
+
+检查代码是否符合 `REQUIREMENTS.md`：
+
+- 是否实现已有能力？
+- 是否改变数据源创建、编辑、删除或连接测试行为？
+- 是否引入文档中没有的新能力？
+- 是否越过 Datasource 的模块边界？
+
+出现未定义的新能力或行为变化时，报告：
+
+```text
+Requirement Gap
+```
+
+不要替产品或开发者自行补需求。
+
+### 2. Domain Compliance
+
+检查 `DOMAIN.md`，重点关注：
+
+- DTO / VO / PO / Plugin SPI Model 是否被当成业务模型；
+- `dbType` 是否可能在更新时被修改；
+- ConnectionProfile 修改后是否仍保留旧 `CONNECTED / DISCONNECTED`；
+- 未保存配置的连接测试是否错误写入状态；
+- Core Domain 是否引入 Spring / MyBatis / Plugin SPI；
+- Repository 是否泄漏 PO / Mapper / MyBatis 类型；
+- Secret 是否可能进入 `toString()`、日志或响应；
+- 是否继续通过 `Map<String, Object>` key 偷渡新的业务语义。
+
+违反现有领域规则时，报告：
+
+```text
+Domain Violation
+```
+
+如果现有领域模型无法表达需求，报告：
+
+```text
+Domain Gap
+```
+
+### 3. Correctness
+
+检查真实错误，不做泛泛而谈：
+
+- 空值和边界值；
+- 名称重复校验；
+- 数据源类型解析；
+- 环境解析；
+- 连接配置规范化；
+- Secret 合并；
+- 事务边界；
+- 连接测试成功 / 失败状态；
+- Catalog 只读约束；
+- SQL 执行取消、超时和审计一致性。
+
+### 4. Compatibility
+
+检查是否破坏：
+
+- REST API；
+- `yak_ops_data_source` 表结构；
+- Flyway 历史；
+- 前端已有调用；
+- Datasource Plugin SPI；
+- 已有 MySQL / PostgreSQL / Oracle / Doris 等插件。
+
+破坏性变更必须有明确迁移方案，禁止 Big-Bang 修改。
+
+### 5. Safety
+
+重点检查：
+
+- Secret 明文输出；
+- 掩码值覆盖真实密码；
+- JDBC URL 中凭据泄漏；
+- 连接测试异常是否吞掉真实失败；
+- 失败连接是否仍显示 `CONNECTED`；
+- 新连接配置是否继承旧连接状态；
+- SQL / Catalog 入口是否绕过只读约束。
+
+### 6. Tests / Guardrails
+
+每个 P0 / P1 问题都回答：
+
+```text
+现有哪个测试应该挡住？
+```
+
+如果没有，指出缺失测试。优先补能锁住领域规则和安全行为的回归测试，不为了覆盖率堆测试。
+
+至少应覆盖：
+
+```text
+DataSource type immutable
+ConnectionProfile change -> UNKNOWN
+connection test success -> CONNECTED
+connection test failure -> DISCONNECTED
+ConnectionProfile toString secret-free
+Core Domain dependency guardrail
+Repository boundary guardrail
+```
+
+## 严重级别
+
+```text
+P0 Blocker
+- Secret 泄漏
+- 数据不可恢复破坏
+- 明确安全问题
+
+P1 Must Fix
+- 业务结果错误
+- 违反 REQUIREMENTS.md / DOMAIN.md
+- 连接状态错误
+- 类型不可变规则失效
+- 明确事务 / 兼容性缺陷
+- 高概率导致数据源不可用
+
+P2 Suggestion
+- 有明确收益的可维护性、性能或测试改进
+- 不阻塞合并
+```
+
+纯命名、格式、个人风格偏好不要作为问题提交，除非会造成真实歧义或风险。
+
+## 每个问题必须有证据
+
+一个有效 Review 问题至少包含：
+
+```text
+位置：文件 / 行或方法
+级别：P0 / P1 / P2
+依据：Requirement / Domain rule / correctness fact
+场景：什么输入或调用顺序会触发
+风险：会造成什么结果
+建议：修复方向，不必替作者重写整段代码
+测试：应补或应命中的测试
+```
+
+没有可说明的触发场景和风险，就不要凑问题。
+
+## 固定输出格式
+
+```text
+# Review Result
+
+Conclusion: PASS | CHANGES_REQUIRED
+
+## P0 Blocker
+无 / 问题列表
+
+## P1 Must Fix
+无 / 问题列表
+
+## P2 Suggestion
+无 / 问题列表
+
+## Requirement Gap
+无 / 说明
+
+## Domain Gap
+无 / 说明
+
+## Missing Tests
+无 / 说明
+```
+
+规则：
+
+- 有 P0 / P1 -> `CHANGES_REQUIRED`。
+- 只有 P2 -> 可以 `PASS`，P2 不阻塞。
+- 没发现真实问题 -> 直接 `PASS`，不要为了显得有价值硬凑问题。
+- Review 结论只基于当前需求、领域规则、代码事实和可复现风险，不猜未来需求。

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/ConnectionProfile.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/ConnectionProfile.java
@@ -1,0 +1,44 @@
+package io.yak.ops.business.datasource.domain;
+
+/** 数据源连接配置值对象。完整连接 JSON 属于敏感信息，禁止通过 toString 输出。 */
+public record ConnectionProfile(
+    String jdbcUrl,
+    String normalizedJson,
+    String originalJson) {
+
+  public ConnectionProfile {
+    jdbcUrl = normalizeNullable(jdbcUrl);
+    normalizedJson = requireText(normalizedJson, "规范化连接参数不能为空");
+    originalJson = normalizeNullable(originalJson);
+    if (originalJson == null) {
+      originalJson = normalizedJson;
+    }
+  }
+
+  public static ConnectionProfile of(String jdbcUrl, String normalizedJson) {
+    return new ConnectionProfile(jdbcUrl, normalizedJson, normalizedJson);
+  }
+
+  public boolean hasJdbcUrl() {
+    return jdbcUrl != null;
+  }
+
+  @Override
+  public String toString() {
+    return "ConnectionProfile[configured=true, jdbcUrlPresent=" + hasJdbcUrl() + "]";
+  }
+
+  private static String requireText(String value, String message) {
+    String normalized = normalizeNullable(value);
+    if (normalized == null) {
+      throw new IllegalArgumentException(message);
+    }
+    return normalized;
+  }
+
+  private static String normalizeNullable(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
@@ -19,7 +19,7 @@ public class DataSourceDefinition {
   private Long id;
   private String name;
   private DataSourceDbType dbType;
-  private String jdbcUrl;
+  @ToString.Exclude private String jdbcUrl;
   private DataSourceEnvironment environment;
   private DataSourceConnStatus connStatus;
   private String remark;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
@@ -4,10 +4,16 @@ import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.Data;
 import lombok.ToString;
 
-/** 数据源业务定义；与 MyBatis PO 和 HTTP VO 解耦。 */
+/**
+ * 数据源聚合根；当前保留 {@code DataSourceDefinition} 历史命名以维持兼容。
+ *
+ * <p>持久化层暂时仍以 jdbcUrl / connectionParams / originalJson 三个标量字段存储连接信息；业务修改必须把它们作为
+ * {@link ConnectionProfile} 整体处理，避免部分更新和旧连接状态漂移。
+ */
 @Data
 public class DataSourceDefinition {
   private Long id;
@@ -21,4 +27,90 @@ public class DataSourceDefinition {
   @ToString.Exclude private String originalJson;
   private LocalDateTime createTime;
   private LocalDateTime updateTime;
+
+  /** 创建新的数据源聚合。创建只代表配置有效，连接状态必须从 UNKNOWN 开始。 */
+  public static DataSourceDefinition create(
+      String name,
+      DataSourceDbType dbType,
+      ConnectionProfile connectionProfile,
+      DataSourceEnvironment environment,
+      String remark) {
+    DataSourceDefinition definition = new DataSourceDefinition();
+    definition.name = requireText(name, "数据源名称不能为空");
+    definition.dbType = Objects.requireNonNull(dbType, "数据源类型不能为空");
+    definition.environment = Objects.requireNonNull(environment, "数据源环境不能为空");
+    definition.remark = normalizeNullable(remark);
+    definition.replaceConnectionProfile(connectionProfile);
+    return definition;
+  }
+
+  /**
+   * 修改数据源可编辑配置。
+   *
+   * <p>数据源类型创建后不可修改；连接配置发生变化后，旧连接测试结果失效并回到 UNKNOWN。
+   */
+  public void updateConfiguration(
+      String name,
+      DataSourceDbType requestedType,
+      ConnectionProfile connectionProfile,
+      DataSourceEnvironment environment,
+      String remark) {
+    assertTypeUnchanged(requestedType);
+    this.name = requireText(name, "数据源名称不能为空");
+    this.environment = Objects.requireNonNull(environment, "数据源环境不能为空");
+    this.remark = normalizeNullable(remark);
+    replaceConnectionProfile(connectionProfile);
+  }
+
+  /** 将当前连接配置作为一个完整值对象读取。 */
+  public ConnectionProfile connectionProfile() {
+    return new ConnectionProfile(jdbcUrl, connectionParams, originalJson);
+  }
+
+  /** 整体替换连接配置，并使旧连接测试结果失效。 */
+  public void replaceConnectionProfile(ConnectionProfile connectionProfile) {
+    ConnectionProfile profile =
+        Objects.requireNonNull(connectionProfile, "数据源连接配置不能为空");
+    this.jdbcUrl = profile.jdbcUrl();
+    this.connectionParams = profile.normalizedJson();
+    this.originalJson = profile.originalJson();
+    markConnectionUnknown();
+  }
+
+  /** 校验编辑请求没有修改数据源类型。 */
+  public void assertTypeUnchanged(DataSourceDbType requestedType) {
+    DataSourceDbType target = Objects.requireNonNull(requestedType, "数据源类型不能为空");
+    if (dbType != null && dbType != target) {
+      throw new IllegalArgumentException("编辑数据源时不允许修改数据源类型");
+    }
+  }
+
+  /** 最近一次针对当前已保存配置的连接测试成功。 */
+  public void markConnected() {
+    connStatus = DataSourceConnStatus.CONNECTED;
+  }
+
+  /** 最近一次针对当前已保存配置的连接测试失败。 */
+  public void markDisconnected() {
+    connStatus = DataSourceConnStatus.DISCONNECTED;
+  }
+
+  /** 当前连接配置尚未被验证，或原有验证结果已因配置修改失效。 */
+  public void markConnectionUnknown() {
+    connStatus = DataSourceConnStatus.UNKNOWN;
+  }
+
+  private static String requireText(String value, String message) {
+    String normalized = normalizeNullable(value);
+    if (normalized == null) {
+      throw new IllegalArgumentException(message);
+    }
+    return normalized;
+  }
+
+  private static String normalizeNullable(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
@@ -4,6 +4,7 @@ import io.yak.framework.common.PageData;
 import io.yak.framework.common.PagingData;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.domain.ConnectionProfile;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.domain.DataSourceQuery;
 import io.yak.ops.business.datasource.exception.DataSourceException;
@@ -51,10 +52,17 @@ public class DataSourceServiceImpl implements DataSourceService {
     String name = normalizeName(dataSourceDTO.getName());
     ensureNameAvailable(name, null);
 
+    DataSourceDbType dbType = parseDbType(dataSourceDTO.getDbType());
+    DataSourceEnvironment environment = parseEnvironment(dataSourceDTO.getEnvironment());
+    ConnectionProfile connectionProfile =
+        buildConnectionProfile(dbType, dataSourceDTO.getConnectionParams());
     DataSourceDefinition definition =
-        buildDefinition(dataSourceDTO, dataSourceDTO.getConnectionParams());
-    definition.setName(name);
-    definition.setConnStatus(DataSourceConnStatus.UNKNOWN);
+        DataSourceDefinition.create(
+            name,
+            dbType,
+            connectionProfile,
+            environment,
+            normalizeNullable(dataSourceDTO.getRemark()));
 
     if (!repository.insert(definition)) {
       throw new DataSourceException(DataSourceErrorCode.CREATE_FAILED);
@@ -72,10 +80,13 @@ public class DataSourceServiceImpl implements DataSourceService {
     ensureNameAvailable(name, id);
 
     DataSourceDbType requestedType = parseDbType(dataSourceDTO.getDbType());
-    if (requestedType != existing.getDbType()) {
+    try {
+      existing.assertTypeUnchanged(requestedType);
+    } catch (IllegalArgumentException exception) {
       throw new DataSourceException(
           DataSourceErrorCode.INVALID_DB_TYPE,
-          "编辑数据源时不允许修改数据源类型");
+          exception.getMessage(),
+          exception);
     }
 
     DataSourcePlugin plugin = pluginRegistry.get(requestedType);
@@ -84,13 +95,17 @@ public class DataSourceServiceImpl implements DataSourceService {
             plugin,
             dataSourceDTO.getConnectionParams(),
             existing.getConnectionParams());
-    DataSourceDefinition definition = buildDefinition(dataSourceDTO, mergedConnectionJson);
-    definition.setId(id);
-    definition.setName(name);
-    definition.setConnStatus(DataSourceConnStatus.UNKNOWN);
-    definition.setCreateTime(existing.getCreateTime());
+    ConnectionProfile connectionProfile =
+        buildConnectionProfile(requestedType, mergedConnectionJson);
+    DataSourceEnvironment environment = parseEnvironment(dataSourceDTO.getEnvironment());
+    existing.updateConfiguration(
+        name,
+        requestedType,
+        connectionProfile,
+        environment,
+        normalizeNullable(dataSourceDTO.getRemark()));
 
-    if (!repository.update(definition)) {
+    if (!repository.update(existing)) {
       throw new DataSourceException(DataSourceErrorCode.UPDATE_FAILED);
     }
     return true;
@@ -143,10 +158,12 @@ public class DataSourceServiceImpl implements DataSourceService {
 
     try {
       plugin.testConnection(connection, connectionTimeoutSeconds());
-      repository.updateConnectionStatus(id, DataSourceConnStatus.CONNECTED);
+      definition.markConnected();
+      repository.updateConnectionStatus(id, definition.getConnStatus());
       return true;
     } catch (RuntimeException exception) {
-      repository.updateConnectionStatus(id, DataSourceConnStatus.DISCONNECTED);
+      definition.markDisconnected();
+      repository.updateConnectionStatus(id, definition.getConnStatus());
       throw connectException(exception);
     }
   }
@@ -199,22 +216,15 @@ public class DataSourceServiceImpl implements DataSourceService {
     return repository.findAll(normalizedType).stream().map(viewMapper::option).toList();
   }
 
-  private DataSourceDefinition buildDefinition(
-      DataSourceDTO dataSourceDTO,
+  private ConnectionProfile buildConnectionProfile(
+      DataSourceDbType dbType,
       String connectionJson) {
-    DataSourceDbType dbType = parseDbType(dataSourceDTO.getDbType());
-    DataSourceEnvironment environment = parseEnvironment(dataSourceDTO.getEnvironment());
     DataSourcePlugin plugin = pluginRegistry.get(dbType);
     DataSourceConnection connection = parseConnection(plugin, connectionJson);
-
-    DataSourceDefinition definition = new DataSourceDefinition();
-    definition.setDbType(dbType);
-    definition.setJdbcUrl(connection.jdbcUrl());
-    definition.setEnvironment(environment);
-    definition.setRemark(normalizeNullable(dataSourceDTO.getRemark()));
-    definition.setConnectionParams(connection.normalizedJson());
-    definition.setOriginalJson(connection.normalizedJson());
-    return definition;
+    return new ConnectionProfile(
+        connection.jdbcUrl(),
+        connection.normalizedJson(),
+        connection.normalizedJson());
   }
 
   private DataSourceConnection parseConnection(DataSourcePlugin plugin, String connectionJson) {

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceDomainArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceDomainArchitectureTest.java
@@ -1,0 +1,99 @@
+package io.yak.ops.business.datasource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.DataSourceQuery;
+import io.yak.ops.business.datasource.domain.DataSourceSummary;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataSourceDomainArchitectureTest {
+
+  private static final List<Class<?>> CORE_DOMAIN_TYPES =
+      List.of(
+          DataSourceDefinition.class,
+          ConnectionProfile.class,
+          DataSourceQuery.class,
+          DataSourceSummary.class);
+
+  private static final String[] FORBIDDEN_DEPENDENCIES = {
+    ".bean.dto.",
+    ".bean.vo.",
+    ".bean.po.",
+    ".spi.datasource",
+    "com.baomidou.mybatisplus",
+    "org.springframework"
+  };
+
+  @Test
+  void coreDomainDoesNotExposeTransportPersistenceOrPluginContracts() {
+    for (Class<?> type : CORE_DOMAIN_TYPES) {
+      for (Field field : type.getDeclaredFields()) {
+        assertTypeAvoids(type, field.getName(), field.getGenericType());
+      }
+      for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+        for (Type parameter : constructor.getGenericParameterTypes()) {
+          assertTypeAvoids(type, "constructor", parameter);
+        }
+      }
+      for (Method method : type.getDeclaredMethods()) {
+        assertTypeAvoids(type, method.getName(), method.getGenericReturnType());
+        for (Type parameter : method.getGenericParameterTypes()) {
+          assertTypeAvoids(type, method.getName(), parameter);
+        }
+      }
+    }
+  }
+
+  @Test
+  void connectionProfileIsImmutableDomainValueObject() {
+    assertThat(ConnectionProfile.class.isRecord()).isTrue();
+    assertThat(ConnectionProfile.class.getDeclaredFields())
+        .allMatch(field -> java.lang.reflect.Modifier.isFinal(field.getModifiers()));
+  }
+
+  @Test
+  void dataSourceAggregateOwnsConfigurationAndConnectionStateBehavior() throws Exception {
+    assertThat(
+            DataSourceDefinition.class.getMethod(
+                "updateConfiguration",
+                String.class,
+                io.yak.ops.common.enums.datasource.DataSourceDbType.class,
+                ConnectionProfile.class,
+                io.yak.ops.common.enums.datasource.DataSourceEnvironment.class,
+                String.class))
+        .isNotNull();
+    assertThat(DataSourceDefinition.class.getMethod("replaceConnectionProfile", ConnectionProfile.class))
+        .isNotNull();
+    assertThat(DataSourceDefinition.class.getMethod("markConnected")).isNotNull();
+    assertThat(DataSourceDefinition.class.getMethod("markDisconnected")).isNotNull();
+    assertThat(DataSourceDefinition.class.getMethod("markConnectionUnknown")).isNotNull();
+  }
+
+  private void assertTypeAvoids(Class<?> owner, String member, Type type) {
+    String signature = typeName(type);
+    for (String forbidden : FORBIDDEN_DEPENDENCIES) {
+      assertThat(signature)
+          .as("%s.%s must not expose %s", owner.getSimpleName(), member, forbidden)
+          .doesNotContain(forbidden);
+    }
+  }
+
+  private String typeName(Type type) {
+    if (type instanceof ParameterizedType parameterized) {
+      StringBuilder value = new StringBuilder(parameterized.getRawType().getTypeName());
+      for (Type argument : parameterized.getActualTypeArguments()) {
+        value.append('<').append(typeName(argument)).append('>');
+      }
+      return value.toString();
+    }
+    return type.getTypeName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/domain/DataSourceDefinitionTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/domain/DataSourceDefinitionTest.java
@@ -51,7 +51,7 @@ class DataSourceDefinitionTest {
             () ->
                 dataSource.updateConfiguration(
                     "orders-db",
-                    DataSourceDbType.POSTGRESQL,
+                    DataSourceDbType.POSTGRE_SQL,
                     profile("orders", "secret-b"),
                     DataSourceEnvironment.PROD,
                     null))

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/domain/DataSourceDefinitionTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/domain/DataSourceDefinitionTest.java
@@ -1,0 +1,107 @@
+package io.yak.ops.business.datasource.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+import org.junit.jupiter.api.Test;
+
+class DataSourceDefinitionTest {
+
+  @Test
+  void createStartsWithUnknownConnectionStatus() {
+    DataSourceDefinition dataSource =
+        DataSourceDefinition.create(
+            "orders-db",
+            DataSourceDbType.MYSQL,
+            profile("orders", "secret-a"),
+            DataSourceEnvironment.PROD,
+            "orders");
+
+    assertThat(dataSource.getName()).isEqualTo("orders-db");
+    assertThat(dataSource.getConnStatus()).isEqualTo(DataSourceConnStatus.UNKNOWN);
+    assertThat(dataSource.connectionProfile().normalizedJson()).contains("secret-a");
+  }
+
+  @Test
+  void changingConnectionProfileInvalidatesPreviousConnectionStatus() {
+    DataSourceDefinition dataSource = dataSource();
+    dataSource.markConnected();
+
+    dataSource.updateConfiguration(
+        "orders-db-v2",
+        DataSourceDbType.MYSQL,
+        profile("orders_v2", "secret-b"),
+        DataSourceEnvironment.TEST,
+        "updated");
+
+    assertThat(dataSource.getConnStatus()).isEqualTo(DataSourceConnStatus.UNKNOWN);
+    assertThat(dataSource.getName()).isEqualTo("orders-db-v2");
+    assertThat(dataSource.getEnvironment()).isEqualTo(DataSourceEnvironment.TEST);
+    assertThat(dataSource.getConnectionParams()).contains("secret-b");
+  }
+
+  @Test
+  void dataSourceTypeCannotChangeAfterCreation() {
+    DataSourceDefinition dataSource = dataSource();
+
+    assertThatThrownBy(
+            () ->
+                dataSource.updateConfiguration(
+                    "orders-db",
+                    DataSourceDbType.POSTGRESQL,
+                    profile("orders", "secret-b"),
+                    DataSourceEnvironment.PROD,
+                    null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("不允许修改数据源类型");
+
+    assertThat(dataSource.getDbType()).isEqualTo(DataSourceDbType.MYSQL);
+    assertThat(dataSource.getConnectionParams()).contains("secret-a");
+  }
+
+  @Test
+  void connectionStatusBehaviorTracksLatestSavedConfigurationTest() {
+    DataSourceDefinition dataSource = dataSource();
+
+    dataSource.markConnected();
+    assertThat(dataSource.getConnStatus()).isEqualTo(DataSourceConnStatus.CONNECTED);
+
+    dataSource.markDisconnected();
+    assertThat(dataSource.getConnStatus()).isEqualTo(DataSourceConnStatus.DISCONNECTED);
+
+    dataSource.markConnectionUnknown();
+    assertThat(dataSource.getConnStatus()).isEqualTo(DataSourceConnStatus.UNKNOWN);
+  }
+
+  @Test
+  void aggregateAndConnectionProfileToStringDoNotLeakConnectionSecrets() {
+    DataSourceDefinition dataSource = dataSource();
+    ConnectionProfile profile = dataSource.connectionProfile();
+
+    assertThat(dataSource.toString()).doesNotContain("secret-a").doesNotContain("root");
+    assertThat(profile.toString()).doesNotContain("secret-a").doesNotContain("root");
+  }
+
+  private DataSourceDefinition dataSource() {
+    return DataSourceDefinition.create(
+        "orders-db",
+        DataSourceDbType.MYSQL,
+        profile("orders", "secret-a"),
+        DataSourceEnvironment.PROD,
+        null);
+  }
+
+  private ConnectionProfile profile(String database, String password) {
+    String json =
+        "{\"host\":\"127.0.0.1\",\"username\":\"root\",\"password\":\""
+            + password
+            + "\"}";
+    return new ConnectionProfile(
+        "jdbc:mysql://root:" + password + "@127.0.0.1:3306/" + database,
+        json,
+        json);
+  }
+}


### PR DESCRIPTION
# Datasource Change

> 开发前读 `REQUIREMENTS.md + DOMAIN.md`；Review 按 `REVIEW.md`。

## Summary

完成 Datasource Domain Phase 1，保持 REST / DB / Plugin SPI 兼容，不做 Big-Bang 迁移。

- 新增 `REQUIREMENTS.md`、`DOMAIN.md`、`REVIEW.md`，对齐 realtime sync 的需求 / 领域 / Review 三层文档标准。
- 新增 Datasource Domain PR template，要求后续变更声明 Domain Impact / Compatibility / Compliance。
- 将 `DataSourceDefinition` 明确为当前 Aggregate Root（保留历史命名，避免无意义的大范围重命名）。
- 新增不可变 `ConnectionProfile` 值对象，连接配置在业务修改时作为整体处理。
- 数据源创建统一从 `UNKNOWN` 开始；更新连接配置统一使旧连接测试状态失效；连接测试成功 / 失败由 Aggregate 行为切换 `CONNECTED / DISCONNECTED`。
- `DataSourceServiceImpl` 改为通过 Aggregate 配置和状态行为完成 create / update / saved connection test 编排。
- JDBC URL、连接 JSON 不再进入 Aggregate / ConnectionProfile 的 `toString()`。
- 新增领域行为测试、Domain dependency architecture guardrails，以及 datasource 专用 GitHub Actions guardrail workflow。

## Domain Impact Analysis

```text
Aggregate(s): DataSourceDefinition / ConnectionProfile
Invariant/lifecycle impact:
- dbType 创建后不可修改
- create -> UNKNOWN
- connection profile update -> UNKNOWN
- saved connection test success -> CONNECTED
- saved connection test failure -> DISCONNECTED
Layer: Domain / Application / Test / Documentation / CI
Domain Gap: no
```

## Compatibility

本 PR 有意保持以下契约不变：

- REST API 路径和主要 DTO / VO
- `yak_ops_data_source` 表结构
- Flyway 历史
- Datasource Plugin SPI 签名
- 现有 JDBC / Doris 插件实现

Plugin Gateway / Adapter、Catalog Domain、SQL Execution Domain、SPI VO/Map 清理明确留给后续 Phase。

## Tests / Safety

新增：

- `DataSourceDefinitionTest`
  - create -> UNKNOWN
  - connection profile change -> UNKNOWN
  - dbType immutable
  - CONNECTED / DISCONNECTED / UNKNOWN 状态行为
  - Aggregate / ConnectionProfile `toString()` 不泄漏 Secret
- `DataSourceDomainArchitectureTest`
  - Core Domain 不暴露 DTO / VO / PO / MyBatis / Spring / Datasource Plugin SPI
  - `ConnectionProfile` 保持 immutable record
  - Aggregate 必须保留配置和连接状态行为
- `tools/datasource_domain_guardrails.py`
  - 校验 Core Domain import 边界
  - 校验 Application Service 不重新直接修改连接标量 / 状态
  - 校验三份领域契约文档和 PR Domain 声明

CI：

```text
Datasource Domain Guardrails / Static domain contract: PASS
Datasource Domain Guardrails / Backend regression hook: PASS (hook)
Maven/JUnit regression: SKIPPED - repository 未配置 YAK_FRAMEWORK_TOKEN
```

因此当前已通过零依赖静态领域契约；完整 Maven/JUnit 回归在配置 `YAK_FRAMEWORK_TOKEN` 后会自动启用。

## Domain Compliance Report

```text
Rule changed/implemented:
- DataSourceDefinition = current Aggregate Root
- ConnectionProfile = connection config value object
- data source type immutable
- connection config mutation invalidates old status
- Secret-free domain string representation
- Core Domain dependency guardrail
Safety/tests:
- aggregate invariant tests
- architecture guardrails
- zero-dependency CI contract PASS
- no REST / DB / SPI migration
Known gaps:
- Datasource Plugin Gateway / Adapter
- Catalog Domain Model
- SQL Execution Domain Model
- Plugin Capability / Descriptor
- Plugin API VO dependency
- Map-based Catalog protocol typing
- Aggregate physical naming cleanup
```
