### PR TITLE
refactor(datasource): isolate plugin spi behind phase 2 gateways

### DIFF
--- a/.github/workflows/datasource-domain-guardrails.yml
+++ b/.github/workflows/datasource-domain-guardrails.yml
@@ -88,6 +88,6 @@ jobs:
         run: >-
           ./mvnw -B -ntp
           -pl "$DATASOURCE_MODULE"
-          -Dtest=DataSourceDomainArchitectureTest,DataSourceLayeringConventionTest,DataSourceDefinitionTest,DataSourceRepositoryAdapterTest,DataSourceServiceImplTest,DataSourceViewMapperTest
+          -Dtest=DataSourceDomainArchitectureTest,DataSourceGatewayArchitectureTest,DataSourceLayeringConventionTest,DataSourceDefinitionTest,DataSourceRepositoryAdapterTest,DataSourceServiceImplTest,DataSourceCatalogServiceImplTest,DataSourceViewMapperTest,SpiDataSourcePluginGatewayTest,SpiDataSourceCatalogGatewayTest
           -Dsurefire.failIfNoSpecifiedTests=false
           test

--- a/tools/datasource_domain_guardrails.py
+++ b/tools/datasource_domain_guardrails.py
@@ -13,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 MODULE = ROOT / "yak-ops-business/yak-ops-business-datasource"
 JAVA_ROOT = MODULE / "src/main/java/io/yak/ops/business/datasource"
 DOMAIN_DIR = JAVA_ROOT / "domain"
+GATEWAY_DIR = JAVA_ROOT / "gateway"
 
 CORE_FILES = (
     "ConnectionProfile.java",
@@ -35,6 +36,21 @@ FORBIDDEN_IMPORTS = (
     "io.yak.ops.business.datasource.repository.",
     "io.yak.ops.business.datasource.dao.",
     "io.yak.ops.business.datasource.plugin.",
+)
+
+PORT_FORBIDDEN_IMPORTS = (
+    "io.yak.ops.spi.datasource.",
+    "io.yak.ops.common.bean.dto.",
+    "io.yak.ops.common.bean.vo.",
+    "io.yak.ops.common.bean.po.",
+    "com.baomidou.",
+    "org.mybatis.",
+)
+
+PROTECTED_APPLICATION_FILES = (
+    "service/impl/DataSourceServiceImpl.java",
+    "service/impl/DataSourceCatalogServiceImpl.java",
+    "service/support/DataSourceViewMapper.java",
 )
 
 
@@ -69,11 +85,14 @@ def code_only(text: str) -> str:
     return text
 
 
+def imports_of(text: str) -> list[str]:
+    return re.findall(r"(?m)^\s*import\s+(?:static\s+)?([^;]+);", text)
+
+
 def check_core(g: Guard) -> None:
     for name in CORE_FILES:
         text = g.read(DOMAIN_DIR / name)
-        imports = re.findall(r"(?m)^\s*import\s+(?:static\s+)?([^;]+);", text)
-        for imported in imports:
+        for imported in imports_of(text):
             g.check(
                 not imported.startswith(FORBIDDEN_IMPORTS),
                 f"{name}: framework/adapter import is forbidden: {imported}",
@@ -98,18 +117,11 @@ def check_core(g: Guard) -> None:
         "record ConnectionProfile" in profile,
         "ConnectionProfile must remain an immutable record value object",
     )
-    g.check(
-        '@ToString.Exclude private String jdbcUrl;' in definition,
-        "DataSourceDefinition jdbcUrl must stay excluded from toString",
-    )
-    g.check(
-        '@ToString.Exclude private String connectionParams;' in definition,
-        "DataSourceDefinition connectionParams must stay excluded from toString",
-    )
-    g.check(
-        '@ToString.Exclude private String originalJson;' in definition,
-        "DataSourceDefinition originalJson must stay excluded from toString",
-    )
+    for field in ("jdbcUrl", "connectionParams", "originalJson"):
+        g.check(
+            f"@ToString.Exclude private String {field};" in definition,
+            f"DataSourceDefinition {field} must stay excluded from toString",
+        )
 
 
 def check_application_mutations(g: Guard) -> None:
@@ -134,6 +146,52 @@ def check_application_mutations(g: Guard) -> None:
         g.check(forbidden not in code, f"Application service must not mutate aggregate scalar directly: {forbidden}")
 
 
+def check_gateway_boundary(g: Guard) -> None:
+    plugin_port = g.read(GATEWAY_DIR / "DataSourcePluginGateway.java")
+    catalog_port = g.read(GATEWAY_DIR / "DataSourceCatalogGateway.java")
+
+    for name, text in (
+        ("DataSourcePluginGateway.java", plugin_port),
+        ("DataSourceCatalogGateway.java", catalog_port),
+    ):
+        for imported in imports_of(text):
+            g.check(
+                not imported.startswith(PORT_FORBIDDEN_IMPORTS),
+                f"{name}: business gateway contract leaked external model: {imported}",
+            )
+
+    for relative in PROTECTED_APPLICATION_FILES:
+        text = g.read(JAVA_ROOT / relative)
+        imports = imports_of(text)
+        for imported in imports:
+            g.check(
+                not imported.startswith("io.yak.ops.spi.datasource."),
+                f"{relative}: Datasource Plugin SPI must stay behind Gateway Adapter: {imported}",
+            )
+            g.check(
+                imported != "io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry",
+                f"{relative}: Plugin Registry must stay behind Gateway Adapter",
+            )
+            g.check(
+                imported != "io.yak.ops.business.datasource.util.DataSourceSecretCodec",
+                f"{relative}: SPI secret helper must stay behind Gateway Adapter",
+            )
+
+    service = g.read(JAVA_ROOT / "service/impl/DataSourceServiceImpl.java")
+    catalog_service = g.read(JAVA_ROOT / "service/impl/DataSourceCatalogServiceImpl.java")
+    view_mapper = g.read(JAVA_ROOT / "service/support/DataSourceViewMapper.java")
+    g.check("DataSourcePluginGateway" in service, "DataSourceServiceImpl must use DataSourcePluginGateway")
+    g.check("DataSourceCatalogGateway" in catalog_service, "DataSourceCatalogServiceImpl must use DataSourceCatalogGateway")
+    g.check("DataSourcePluginGateway" in view_mapper, "DataSourceViewMapper must use DataSourcePluginGateway for masking")
+
+    plugin_adapter = g.read(GATEWAY_DIR / "adapter/SpiDataSourcePluginGateway.java")
+    catalog_adapter = g.read(GATEWAY_DIR / "adapter/SpiDataSourceCatalogGateway.java")
+    g.check("implements DataSourcePluginGateway" in plugin_adapter, "SPI plugin adapter must implement business port")
+    g.check("implements DataSourceCatalogGateway" in catalog_adapter, "SPI catalog adapter must implement business port")
+    g.check("io.yak.ops.spi.datasource" in plugin_adapter, "SPI plugin adapter must own plugin protocol translation")
+    g.check("io.yak.ops.spi.datasource" in catalog_adapter, "SPI catalog adapter must own catalog protocol translation")
+
+
 def check_docs(g: Guard) -> None:
     requirements = g.read(MODULE / "REQUIREMENTS.md")
     contract = g.read(MODULE / "DOMAIN.md")
@@ -142,8 +200,8 @@ def check_docs(g: Guard) -> None:
 
     for name, text, limit in (
         ("REQUIREMENTS.md", requirements, 150),
-        ("DOMAIN.md", contract, 180),
-        ("REVIEW.md", review, 210),
+        ("DOMAIN.md", contract, 190),
+        ("REVIEW.md", review, 220),
     ):
         g.check(
             len(text.splitlines()) <= limit,
@@ -157,6 +215,8 @@ def check_docs(g: Guard) -> None:
         "DataSourceDefinition",
         "ConnectionProfile",
         "12 条硬规则",
+        "DataSourcePluginGateway",
+        "DataSourceCatalogGateway",
         "Domain Impact Analysis",
         "Domain Compliance Report",
         "Domain Gap",
@@ -170,6 +230,8 @@ def check_docs(g: Guard) -> None:
         "P1 Must Fix",
         "Conclusion: PASS | CHANGES_REQUIRED",
         "Missing Tests",
+        "DataSourcePluginGateway",
+        "DataSourceCatalogGateway",
     ):
         g.check(phrase in review, f"REVIEW.md lost review protocol phrase: {phrase}")
 
@@ -202,6 +264,7 @@ def main() -> int:
     g = Guard()
     check_core(g)
     check_application_mutations(g)
+    check_gateway_boundary(g)
     check_docs(g)
     check_pr(g, args.event)
     return g.finish()

--- a/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
@@ -8,10 +8,7 @@
 
 ```text
 DataSourceDefinition  (Aggregate Root，当前保留历史命名)
-├── id
-├── name
-├── dbType
-├── environment
+├── id / name / dbType / environment
 ├── ConnectionProfile
 │   ├── jdbcUrl
 │   ├── normalizedJson
@@ -22,16 +19,16 @@ DataSourceDefinition  (Aggregate Root，当前保留历史命名)
 ```
 
 ```text
-DataSourceDefinition
-      │ persisted by
-      ▼
-DataSourceRepository (Domain Port)
-      │ implemented by
-      ▼
-Repository Adapter -> DAO / PO / MyBatis
+Application Service
+   │
+   ├── DataSourceRepository         -> Repository Adapter -> DAO / PO
+   │
+   ├── DataSourcePluginGateway      <- SPI Plugin Adapter  -> Plugin SPI
+   │
+   └── DataSourceCatalogGateway     <- SPI Catalog Adapter -> Plugin SPI
 ```
 
-Datasource Plugin SPI 是**邻接上下文**，不是 Core Domain。
+Datasource Plugin SPI 是**邻接上下文**，不是 Core Domain，也不是 Application Contract。
 
 ## 12 条硬规则
 
@@ -39,47 +36,86 @@ Datasource Plugin SPI 是**邻接上下文**，不是 Core Domain。
 2. **`ConnectionProfile` 是连接配置的领域值对象。** 新业务代码修改连接配置必须经过 Aggregate 行为，不直接散落修改 `jdbcUrl / connectionParams / originalJson`。
 3. **DataSource Type 创建后不可修改。** 更新时请求类型必须与 Aggregate 当前 `dbType` 一致。
 4. **连接配置被替换后，连接状态必须回到 `UNKNOWN`。** 旧配置的 `CONNECTED / DISCONNECTED` 不能继承给新配置。
-5. **`CONNECTED / DISCONNECTED` 只表示最近一次针对当前已保存配置的连接测试结果。** 配置可解析不等于连接成功。
-6. **未保存配置的连接测试不改变任何 Aggregate 状态。** 只有已保存数据源测试才持久化连接状态。
-7. **Core Domain 不依赖 Spring / MyBatis / HTTP DTO / VO / PO / Datasource Plugin SPI。** 插件、JDBC、Catalog 实现细节属于边界之外。
-8. **Repository Contract 只暴露 Domain。** PO、MyBatis `IPage`、Mapper Row 不得越过 Repository Adapter。
-9. **Secret 不是可观察业务数据。** 完整连接 JSON、密码、Token 不得进入 `toString()`、普通日志或未脱敏响应。
-10. **Catalog / SQL Execution / Plugin Capability 属于相邻子域。** Phase 1 不为了统一风格把它们硬塞进 `DataSourceDefinition`。
-11. **新的业务语义优先扩明确领域模型。** 不通过新增 `Map<String, Object>` key、临时 boolean、展示 VO 字段来绕过 Domain Gap。
-12. **无法映射现有模型就是 `Domain Gap`。** 先讨论模型和边界，不用 DTO / VO / PO / Plugin Model 冒充 Domain。
+5. **`CONNECTED / DISCONNECTED` 只表示最近一次针对当前已保存配置的连接测试结果。** 配置可解析不等于连接成功；未保存配置测试不持久化状态。
+6. **Core Domain 不依赖 Spring / MyBatis / HTTP DTO / VO / PO / Datasource Plugin SPI。** JDBC、Catalog 实现和插件私有参数属于边界之外。
+7. **Application 主链路不得直接依赖 Datasource Plugin SPI 或 `DataSourcePluginRegistry`。** 数据源管理通过 `DataSourcePluginGateway`，Catalog 通过 `DataSourceCatalogGateway`；SPI 类型转换与异常映射只在 Adapter 内完成。
+8. **Business Gateway Contract 不暴露 Plugin SPI、HTTP DTO / VO 或 PO。** Gateway 内部模型属于边界协议，不可被当成新的全局领域事实。
+9. **Repository Contract 只暴露 Domain。** PO、MyBatis `IPage`、Mapper Row 不得越过 Repository Adapter。
+10. **Secret 不是可观察业务数据。** 完整连接 JSON、密码、Token 不得进入 `toString()`、普通日志或未脱敏响应；插件相关 Secret 处理必须留在 Gateway Adapter 边界。
+11. **新的业务语义优先扩明确领域模型。** 不通过新增 `Map<String, Object>` key、临时 boolean、展示 VO 字段或 SPI 私有字段绕过 Domain Gap。
+12. **无法映射现有模型就是 `Domain Gap`。** 先讨论模型和边界，不用 DTO / VO / PO / Plugin Model / Gateway 临时字段冒充 Domain。
 
 ## 关键不变量
 
-- `name` 必须非空。
-- `dbType` 必须存在。
-- `environment` 必须存在。
-- `ConnectionProfile.normalizedJson` 必须存在。
+- `name`、`dbType`、`environment`、`ConnectionProfile.normalizedJson` 必须存在。
 - `dbType` 一旦创建不可变。
 - `ConnectionProfile` 变更后 `connectionStatus = UNKNOWN`。
-- 连接测试成功：`connectionStatus = CONNECTED`。
-- 连接测试失败：`connectionStatus = DISCONNECTED`。
+- 已保存配置测试成功：`connectionStatus = CONNECTED`。
+- 已保存配置测试失败：`connectionStatus = DISCONNECTED`。
+- 未保存配置测试不修改 Aggregate。
+- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper` 不直接出现 Datasource Plugin SPI 类型。
 
 ## 命令语义
 
 ```text
 Create
-  -> new DataSourceDefinition
-  -> ConnectionProfile
+  -> Plugin Gateway normalize
+  -> new DataSourceDefinition / ConnectionProfile
   -> UNKNOWN
 
 Update
   -> same dbType
-  -> replace editable metadata / ConnectionProfile
+  -> Plugin Gateway merge secret + normalize
+  -> Aggregate updateConfiguration
   -> UNKNOWN
 
 TestConnection(saved)
+  -> Plugin Gateway
   -> success -> CONNECTED
   -> failure -> DISCONNECTED
 
 TestConnection(unsaved)
-  -> validation only
+  -> Plugin Gateway validation only
   -> no persisted state
+
+Catalog
+  -> load DataSourceDefinition
+  -> validate application request
+  -> Catalog Gateway
+  -> SPI Adapter converts protocol model
 ```
+
+## Gateway / Adapter 边界
+
+允许的依赖方向：
+
+```text
+Application -> Business Gateway Port <- SPI Adapter -> Datasource Plugin SPI
+```
+
+禁止：
+
+```text
+Application -> DataSourcePlugin / DataSourceConnection / DataSourceCatalog
+Application -> SPI metadata/query model
+Business Gateway Port -> SPI model
+Core Domain -> Gateway / SPI
+SPI model -> Domain identity
+```
+
+当前明确例外：
+
+- `DataSourcePluginConfigServiceImpl` 仍承接历史 `pluginConfig() -> DataSourcePluginConfigVO`，直到 Plugin Descriptor / Form Contract 去 VO 化。
+- `BusinessDataSourceExecutionProvider` 自身是向 Task Plugin SPI 暴露执行能力的 Adapter，可以依赖相关 SPI。
+- `DataSourceSecretCodec` 是 SPI Adapter 的技术 helper，不是 Domain Service。
+
+这些例外不得扩散到新的 Application 主链路。
+
+## Catalog Gateway 当前定位
+
+Phase 2 的 `DataSourceCatalogGateway.Table / Column / QueryResult` 是**Business-owned boundary contract**，作用只是阻止 SPI Model 穿透。
+
+它们暂时不是最终 Catalog Domain Model；`Map<String, Object>` 请求协议仍是已知 Gap。Phase 3 负责类型化 Catalog Request / Result，并决定哪些模型提升为正式 Domain。
 
 ## 持久化兼容
 
@@ -89,33 +125,11 @@ TestConnection(unsaved)
 yak_ops_data_source
 ```
 
-当前 PO 仍然保存：
-
-```text
-jdbc_url
-connection_params
-original_json
-conn_status
-```
-
-这些是持久化投影，不定义业务边界。Phase 1 保持物理结构兼容，由 Repository Adapter 负责 Domain 与持久化模型之间的映射。
-
-## 邻接上下文
-
-当前 Datasource Plugin SPI 提供连接解析、连接测试、Catalog 和 SQL 执行能力。Phase 1 为兼容性仍允许 Application Service 调用 SPI；后续阶段必须通过 Gateway / Adapter 收口。
-
-因此当前明确禁止：
-
-```text
-Plugin SPI Model -> Core Domain identity
-Plugin private config -> DataSource global field
-Controller VO -> Plugin stable business fact
-PO -> Service direct access
-```
+`jdbc_url / connection_params / original_json / conn_status` 是持久化投影，不定义业务边界。Repository Adapter 继续负责 Domain 与持久化模型之间的映射。
 
 ## 修改代码前后
 
-修改前先确认 `REQUIREMENTS.md` 中已有对应能力，再写一个短块：
+修改前：
 
 ```text
 Domain Impact Analysis
@@ -125,7 +139,7 @@ Domain Impact Analysis
 - Domain Gap: yes/no
 ```
 
-修改后写：
+修改后：
 
 ```text
 Domain Compliance Report
@@ -138,14 +152,15 @@ Domain Compliance Report
 
 ## 自动护栏
 
-至少保留以下自动检查：
+至少保留：
 
 ```text
-Core Domain 不依赖 DTO / VO / PO / MyBatis / Spring / Datasource Plugin SPI
-Repository 只暴露 Domain
-Service 不直接注入 DAO / PO
-Controller 只通过 Service 进入业务链路
-ConnectionProfile / connection status 行为回归测试
+Core Domain dependency guardrail
+Repository boundary guardrail
+Application -> Gateway dependency guardrail
+Gateway Port no SPI/DTO/VO/PO guardrail
+SPI Adapter translation tests
+ConnectionProfile / connection status behavior tests
 ```
 
 **不要因为功能被护栏拦住就删护栏。** 如果规则真的变化，同一个 PR 中同步修改 `DOMAIN.md` 和对应测试。
@@ -153,11 +168,10 @@ ConnectionProfile / connection status 行为回归测试
 ## 已知独立 Gap
 
 ```text
-Datasource Plugin Gateway / Adapter
-Catalog Domain Model
+Catalog Domain Model / typed Map protocol
 SQL Execution Domain Model
 Plugin Capability / Descriptor
 Plugin API VO dependency
-Map-based Catalog protocol
+PluginConfig compatibility bridge cleanup
 Aggregate physical naming cleanup
 ```

--- a/yak-ops-business/yak-ops-business-datasource/README.md
+++ b/yak-ops-business/yak-ops-business-datasource/README.md
@@ -37,41 +37,75 @@ DataSourceDefinition  (Aggregate Root，当前保留历史命名)
 
 详细规则见 `DOMAIN.md`。
 
-## 当前工程分层
+## 工程分层
 
 ```text
 Controller
     ↓
-Application Service
+Application Service / View Mapper
     ↓
-Domain
-    ↓
-Repository Port
-    ↓
-Repository Adapter
-    ↓
-DAO / Mapper / PO / MySQL
+Domain + Business Gateway Port
+    ↓                 ↑
+Repository Adapter    │
+    ↓             SPI Gateway Adapter
+DAO / PO              ↓
+                  Datasource Plugin SPI
+                         ↓
+                  Plugin Implementation
 ```
 
-当前 Phase 1 为保持兼容，Application Service 仍直接编排 Datasource Plugin SPI：
+Phase 2 后，数据源管理和 Catalog 主链路不再直接认识 `DataSourcePlugin`、`DataSourceConnection`、`DataSourceCatalog` 或 SPI Metadata Model：
 
 ```text
-Application Service -> Datasource Plugin SPI -> Plugin Implementation
+DataSourceServiceImpl
+    -> DataSourcePluginGateway
+    <- SpiDataSourcePluginGateway
+    -> Datasource Plugin SPI
+
+DataSourceCatalogServiceImpl
+    -> DataSourceCatalogGateway
+    <- SpiDataSourceCatalogGateway
+    -> Datasource Plugin SPI
 ```
 
-Plugin Gateway / Adapter 隔离属于后续阶段，不在 Phase 1 中以 Big-Bang 方式同时修改 Business、REST、DB 和 Plugin SPI。
+SPI Adapter 负责：
+
+- 插件发现与路由；
+- Connection 解析与规范化；
+- Secret 合并和展示脱敏；
+- 连接测试异常映射；
+- Catalog 创建和调用；
+- SPI Table / Column / QueryResult -> Business Gateway Contract 转换。
 
 ## 分层约束
 
 - Controller 只通过 Service 进入业务链路，不直接依赖 Repository、DAO、Mapper 或插件实现。
-- Service 使用 `DataSourceDefinition` 等 Domain，不直接操作 MyBatis PO。
+- Application Service 使用 Domain + Repository Port + Business Gateway，不直接注入 Datasource Plugin Registry。
+- `DataSourcePluginGateway` / `DataSourceCatalogGateway` 不暴露 Plugin SPI、HTTP DTO / VO 或 PO。
+- SPI 具体模型只能存在于 `gateway.adapter`、plugin registry/helper 或明确的外向 SPI Adapter 中。
 - Repository 接口只暴露 Domain；PO 仅存在于 Adapter / DAO / Mapper 持久化层。
 - Core Domain 不依赖 Spring、MyBatis、HTTP DTO / VO / PO 或 Datasource Plugin SPI。
-- 分页遵循 `DAO IPage<PO> -> Adapter PageData<Domain> -> Service PagingData<VO>`。
-- DAO 不接收 HTTP DTO，也不返回 HTTP VO；DAO 查询使用自己的 Query / Row 投影。
-- 普通单表 CRUD 使用 MyBatis-Plus；统计等自定义 SQL 放在 `mapper/datasource/*.xml`。
-- HTTP 详情必须通过 `DataSourceViewMapper` 和 `DataSourceSecretCodec` 做连接地址与连接 JSON 脱敏。
-- Catalog 读取使用 Repository 加载 Domain，再交给 Datasource Plugin SPI；Catalog 不直接访问 DAO / PO。
+- HTTP 详情通过 `DataSourceViewMapper -> DataSourcePluginGateway` 完成连接地址与连接 JSON 脱敏。
+- Catalog 的只读校验仍由 Application Service 承担，物理 Catalog 访问和 SPI 模型转换由 Gateway Adapter 承担。
+- `Map<String, Object>` Catalog 请求是当前兼容协议，不允许继续用新增隐式 key 扩展业务语义；Phase 3 负责类型化。
+
+## 当前兼容边界
+
+Phase 2 不修改：
+
+```text
+REST API
+DTO / VO JSON 结构
+yak_ops_data_source 表结构
+Flyway 历史
+Datasource Plugin SPI 签名
+MySQL / PostgreSQL / Oracle / Doris 等插件实现
+```
+
+两个明确的兼容例外：
+
+- `DataSourcePluginConfigServiceImpl` 当前仍承接 `pluginConfig() -> DataSourcePluginConfigVO` 历史协议；插件 Descriptor / Form Model 去 VO 化留给后续 Plugin API 标准化。
+- `BusinessDataSourceExecutionProvider` 本身是向 Task Plugin SPI 暴露 SQL Executor 的 Adapter，因此允许在 Adapter 边界依赖相关 SPI。
 
 ## 持久化
 
@@ -81,7 +115,7 @@ Plugin Gateway / Adapter 隔离属于后续阶段，不在 Phase 1 中以 Big-Ba
 yak_ops_data_source
 ```
 
-Phase 1 不修改现有表结构和 Flyway 历史。`jdbc_url / connection_params / original_json / conn_status` 是持久化投影，不是新的领域边界。
+`jdbc_url / connection_params / original_json / conn_status` 是持久化投影，不是新的领域边界。
 
 业务模块共享 `yak.database` 对应的 `yakBusinessDataSource`、MyBatis SessionFactory 和事务管理器；数据源模块继续拥有自己的 Flyway migration location/history 边界。
 
@@ -90,11 +124,10 @@ Phase 1 不修改现有表结构和 Flyway 历史。`jdbc_url / connection_param
 当前明确留给后续阶段处理：
 
 ```text
-Datasource Plugin Gateway / Adapter
-Catalog Domain Model
+Catalog Domain Model / typed request protocol
 SQL Execution Domain Model
 Plugin Capability / Descriptor
 Plugin API VO dependency
-Map-based Catalog protocol typing
+PluginConfig compatibility bridge cleanup
 Aggregate physical naming cleanup
 ```

--- a/yak-ops-business/yak-ops-business-datasource/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-datasource/REVIEW.md
@@ -20,7 +20,7 @@ PR diff / tests  -> 实际改了什么
 检查代码是否符合 `REQUIREMENTS.md`：
 
 - 是否实现已有能力？
-- 是否改变数据源创建、编辑、删除或连接测试行为？
+- 是否改变数据源创建、编辑、删除、连接测试或 Catalog 行为？
 - 是否引入文档中没有的新能力？
 - 是否越过 Datasource 的模块边界？
 
@@ -41,6 +41,9 @@ Requirement Gap
 - ConnectionProfile 修改后是否仍保留旧 `CONNECTED / DISCONNECTED`；
 - 未保存配置的连接测试是否错误写入状态；
 - Core Domain 是否引入 Spring / MyBatis / Plugin SPI；
+- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper` 是否重新直接依赖 Plugin SPI、`DataSourcePluginRegistry` 或 SPI Secret helper；
+- `DataSourcePluginGateway / DataSourceCatalogGateway` 是否暴露 Plugin SPI、HTTP DTO / VO 或 PO；
+- SPI Table / Column / QueryResult 是否绕过 Adapter 直接进入 Application；
 - Repository 是否泄漏 PO / Mapper / MyBatis 类型；
 - Secret 是否可能进入 `toString()`、日志或响应；
 - 是否继续通过 `Map<String, Object>` key 偷渡新的业务语义。
@@ -65,8 +68,10 @@ Domain Gap
 - 名称重复校验；
 - 数据源类型解析；
 - 环境解析；
-- 连接配置规范化；
-- Secret 合并；
+- ConnectionProfile 规范化；
+- Secret 合并 / 脱敏；
+- Gateway Adapter 异常映射；
+- SPI metadata -> Business Gateway Contract 字段映射；
 - 事务边界；
 - 连接测试成功 / 失败状态；
 - Catalog 只读约束；
@@ -81,7 +86,9 @@ Domain Gap
 - Flyway 历史；
 - 前端已有调用；
 - Datasource Plugin SPI；
-- 已有 MySQL / PostgreSQL / Oracle / Doris 等插件。
+- 已有 MySQL / PostgreSQL / Oracle / Doris 等插件；
+- PluginConfig 动态表单历史协议；
+- Task Plugin SQL execution provider。
 
 破坏性变更必须有明确迁移方案，禁止 Big-Bang 修改。
 
@@ -92,7 +99,7 @@ Domain Gap
 - Secret 明文输出；
 - 掩码值覆盖真实密码；
 - JDBC URL 中凭据泄漏；
-- 连接测试异常是否吞掉真实失败；
+- Gateway Adapter 是否把插件异常吞掉或错误分类；
 - 失败连接是否仍显示 `CONNECTED`；
 - 新连接配置是否继承旧连接状态；
 - SQL / Catalog 入口是否绕过只读约束。
@@ -105,7 +112,7 @@ Domain Gap
 现有哪个测试应该挡住？
 ```
 
-如果没有，指出缺失测试。优先补能锁住领域规则和安全行为的回归测试，不为了覆盖率堆测试。
+如果没有，指出缺失测试。优先补能锁住领域规则和边界的回归测试，不为了覆盖率堆测试。
 
 至少应覆盖：
 
@@ -117,7 +124,28 @@ connection test failure -> DISCONNECTED
 ConnectionProfile toString secret-free
 Core Domain dependency guardrail
 Repository boundary guardrail
+Application -> Business Gateway only
+Gateway Port no Plugin SPI / DTO / VO / PO
+SPI Connection -> ConnectionProfile mapping
+SPI Catalog metadata -> Business Gateway Contract mapping
 ```
+
+## 当前允许的边界例外
+
+以下不是普通 Application Service，可按 `DOMAIN.md` 的边界说明单独判断：
+
+```text
+DataSourcePluginConfigServiceImpl
+  -> historical pluginConfig() / VO compatibility bridge
+
+BusinessDataSourceExecutionProvider
+  -> outward Task Plugin SPI adapter
+
+DataSourceSecretCodec
+  -> SPI adapter technical helper
+```
+
+这些例外不能作为在新 Service 中直接调用 Plugin SPI 的理由。
 
 ## 严重级别
 
@@ -130,6 +158,8 @@ P0 Blocker
 P1 Must Fix
 - 业务结果错误
 - 违反 REQUIREMENTS.md / DOMAIN.md
+- Plugin SPI 重新泄漏进受保护 Application 主链路
+- Gateway Port 暴露 SPI / DTO / VO / PO
 - 连接状态错误
 - 类型不可变规则失效
 - 明确事务 / 兼容性缺陷

--- a/yak-ops-business/yak-ops-business-datasource/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-datasource/REVIEW.md
@@ -4,8 +4,6 @@
 
 ## Review 前必读
 
-按顺序读取：
-
 ```text
 REQUIREMENTS.md  -> 模块需要什么
 DOMAIN.md        -> 实现不能违反什么
@@ -13,106 +11,100 @@ REVIEW.md        -> 按什么标准判卷
 PR diff / tests  -> 实际改了什么
 ```
 
-## Review 顺序
+## 1. Requirement Alignment
 
-### 1. Requirement Alignment
+检查：
 
-检查代码是否符合 `REQUIREMENTS.md`：
+- 是否属于 `REQUIREMENTS.md` 已有能力；
+- 是否改变创建、编辑、删除、连接测试或 Catalog 行为；
+- 是否引入未定义的新能力；
+- 是否越过 Datasource 模块边界。
 
-- 是否实现已有能力？
-- 是否改变数据源创建、编辑、删除、连接测试或 Catalog 行为？
-- 是否引入文档中没有的新能力？
-- 是否越过 Datasource 的模块边界？
-
-出现未定义的新能力或行为变化时，报告：
+未定义的新能力或行为变化报告：
 
 ```text
 Requirement Gap
 ```
 
-不要替产品或开发者自行补需求。
+## 2. Domain Compliance
 
-### 2. Domain Compliance
-
-检查 `DOMAIN.md`，重点关注：
+重点检查：
 
 - DTO / VO / PO / Plugin SPI Model 是否被当成业务模型；
-- `dbType` 是否可能在更新时被修改；
-- ConnectionProfile 修改后是否仍保留旧 `CONNECTED / DISCONNECTED`；
-- 未保存配置的连接测试是否错误写入状态；
+- `dbType` 是否可能在更新时修改；
+- ConnectionProfile 变更后是否仍保留旧连接状态；
+- 未保存连接测试是否错误写状态；
 - Core Domain 是否引入 Spring / MyBatis / Plugin SPI；
-- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper` 是否重新直接依赖 Plugin SPI、`DataSourcePluginRegistry` 或 SPI Secret helper；
-- `DataSourcePluginGateway / DataSourceCatalogGateway` 是否暴露 Plugin SPI、HTTP DTO / VO 或 PO；
-- SPI Table / Column / QueryResult 是否绕过 Adapter 直接进入 Application；
 - Repository 是否泄漏 PO / Mapper / MyBatis 类型；
-- Secret 是否可能进入 `toString()`、日志或响应；
-- 是否继续通过 `Map<String, Object>` key 偷渡新的业务语义。
+- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper` 是否直接依赖 Plugin SPI、`DataSourcePluginRegistry` 或 SPI Secret helper；
+- `DataSourcePluginGateway / DataSourceCatalogGateway` 是否暴露 Plugin SPI、HTTP DTO / VO 或 PO；
+- SPI Table / Column / QueryResult 是否绕过 Adapter 进入 Application；
+- Secret 是否进入 `toString()`、日志或未脱敏响应；
+- 是否继续通过 `Map<String, Object>` key 偷渡新业务语义。
 
-违反现有领域规则时，报告：
+违反现有规则：
 
 ```text
 Domain Violation
 ```
 
-如果现有领域模型无法表达需求，报告：
+现有模型无法表达需求：
 
 ```text
 Domain Gap
 ```
 
-### 3. Correctness
+## 3. Correctness
 
-检查真实错误，不做泛泛而谈：
+只检查真实风险：
 
-- 空值和边界值；
-- 名称重复校验；
-- 数据源类型解析；
-- 环境解析；
+- 空值、边界值、名称重复；
+- 类型 / 环境解析；
 - ConnectionProfile 规范化；
-- Secret 合并 / 脱敏；
+- Secret 合并和脱敏；
 - Gateway Adapter 异常映射；
 - SPI metadata -> Business Gateway Contract 字段映射；
 - 事务边界；
 - 连接测试成功 / 失败状态；
 - Catalog 只读约束；
-- SQL 执行取消、超时和审计一致性。
+- SQL 执行取消、超时、审计一致性。
 
-### 4. Compatibility
+## 4. Compatibility
 
-检查是否破坏：
+不得无迁移方案破坏：
 
-- REST API；
-- `yak_ops_data_source` 表结构；
-- Flyway 历史；
-- 前端已有调用；
-- Datasource Plugin SPI；
-- 已有 MySQL / PostgreSQL / Oracle / Doris 等插件；
-- PluginConfig 动态表单历史协议；
-- Task Plugin SQL execution provider。
+```text
+REST API
+yak_ops_data_source
+Flyway history
+Frontend calls
+Datasource Plugin SPI
+Existing database plugins
+PluginConfig dynamic form contract
+Task Plugin SQL execution provider
+```
 
-破坏性变更必须有明确迁移方案，禁止 Big-Bang 修改。
+禁止 Big-Bang 修改。
 
-### 5. Safety
+## 5. Safety
 
 重点检查：
 
 - Secret 明文输出；
-- 掩码值覆盖真实密码；
-- JDBC URL 中凭据泄漏；
-- Gateway Adapter 是否把插件异常吞掉或错误分类；
-- 失败连接是否仍显示 `CONNECTED`；
-- 新连接配置是否继承旧连接状态；
-- SQL / Catalog 入口是否绕过只读约束。
+- 掩码覆盖真实密码；
+- JDBC URL 凭据泄漏；
+- Gateway Adapter 吞异常或错误分类；
+- 失败连接仍显示 `CONNECTED`；
+- 新配置继承旧连接状态；
+- SQL / Catalog 绕过只读约束。
 
-### 6. Tests / Guardrails
+## 6. Tests / Guardrails
 
-每个 P0 / P1 问题都回答：
+每个 P0 / P1 都回答：
 
 ```text
 现有哪个测试应该挡住？
 ```
-
-如果没有，指出缺失测试。优先补能锁住领域规则和边界的回归测试，不为了覆盖率堆测试。
 
 至少应覆盖：
 
@@ -132,8 +124,6 @@ SPI Catalog metadata -> Business Gateway Contract mapping
 
 ## 当前允许的边界例外
 
-以下不是普通 Application Service，可按 `DOMAIN.md` 的边界说明单独判断：
-
 ```text
 DataSourcePluginConfigServiceImpl
   -> historical pluginConfig() / VO compatibility bridge
@@ -145,7 +135,7 @@ DataSourceSecretCodec
   -> SPI adapter technical helper
 ```
 
-这些例外不能作为在新 Service 中直接调用 Plugin SPI 的理由。
+例外不能扩散到新的 Application 主链路。
 
 ## 严重级别
 
@@ -158,10 +148,9 @@ P0 Blocker
 P1 Must Fix
 - 业务结果错误
 - 违反 REQUIREMENTS.md / DOMAIN.md
-- Plugin SPI 重新泄漏进受保护 Application 主链路
+- Plugin SPI 泄漏进受保护 Application 主链路
 - Gateway Port 暴露 SPI / DTO / VO / PO
-- 连接状态错误
-- 类型不可变规则失效
+- 连接状态 / 类型不可变规则错误
 - 明确事务 / 兼容性缺陷
 - 高概率导致数据源不可用
 
@@ -170,23 +159,23 @@ P2 Suggestion
 - 不阻塞合并
 ```
 
-纯命名、格式、个人风格偏好不要作为问题提交，除非会造成真实歧义或风险。
+纯命名、格式、个人风格偏好不要作为问题，除非造成真实歧义或风险。
 
-## 每个问题必须有证据
+## 问题证据要求
 
-一个有效 Review 问题至少包含：
+每个有效问题至少包含：
 
 ```text
 位置：文件 / 行或方法
 级别：P0 / P1 / P2
 依据：Requirement / Domain rule / correctness fact
-场景：什么输入或调用顺序会触发
-风险：会造成什么结果
-建议：修复方向，不必替作者重写整段代码
+场景：触发输入或调用顺序
+风险：实际结果
+建议：修复方向
 测试：应补或应命中的测试
 ```
 
-没有可说明的触发场景和风险，就不要凑问题。
+没有触发场景和风险，不要凑问题。
 
 ## 固定输出格式
 
@@ -214,9 +203,6 @@ Conclusion: PASS | CHANGES_REQUIRED
 无 / 说明
 ```
 
-规则：
-
 - 有 P0 / P1 -> `CHANGES_REQUIRED`。
-- 只有 P2 -> 可以 `PASS`，P2 不阻塞。
-- 没发现真实问题 -> 直接 `PASS`，不要为了显得有价值硬凑问题。
-- Review 结论只基于当前需求、领域规则、代码事实和可复现风险，不猜未来需求。
+- 只有 P2 -> 可以 `PASS`。
+- 没有真实问题 -> `PASS`，不要硬凑问题。

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourceCatalogGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourceCatalogGateway.java
@@ -1,0 +1,111 @@
+package io.yak.ops.business.datasource.gateway;
+
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Business Datasource 对 Catalog 插件能力的 Port。
+ *
+ * <p>这里的模型属于 Business Gateway Contract，不暴露 Datasource Plugin SPI Model。Phase 3 会继续把 Catalog
+ * 的 Map 协议类型化并评估哪些模型应提升为正式 Catalog Domain Model。
+ */
+public interface DataSourceCatalogGateway {
+
+  List<String> listDatabases(DataSourceDefinition dataSource, int timeoutSeconds);
+
+  List<String> listSchemas(
+      DataSourceDefinition dataSource,
+      String database,
+      int timeoutSeconds);
+
+  List<Table> listTables(
+      DataSourceDefinition dataSource,
+      TableQuery query,
+      int timeoutSeconds);
+
+  List<Column> listColumns(
+      DataSourceDefinition dataSource,
+      TablePath tablePath,
+      int timeoutSeconds);
+
+  List<Column> describe(
+      DataSourceDefinition dataSource,
+      Map<String, Object> request,
+      int timeoutSeconds);
+
+  QueryResult preview(
+      DataSourceDefinition dataSource,
+      Map<String, Object> request,
+      int limit,
+      int timeoutSeconds);
+
+  long count(
+      DataSourceDefinition dataSource,
+      Map<String, Object> request,
+      int timeoutSeconds);
+
+  String buildSqlTemplate(
+      DataSourceDefinition dataSource,
+      String tablePath,
+      int timeoutSeconds);
+
+  String resolveSql(
+      DataSourceDefinition dataSource,
+      String sql,
+      Map<String, Object> request,
+      int timeoutSeconds);
+
+  record TableQuery(String database, String schema, String keyword) {}
+
+  record TablePath(String database, String schema, String table) {}
+
+  record Table(
+      String database,
+      String schema,
+      String name,
+      String type,
+      String remarks) {}
+
+  record Column(
+      String name,
+      String typeName,
+      int jdbcType,
+      Integer size,
+      Integer scale,
+      boolean nullable,
+      int ordinalPosition,
+      boolean primaryKey,
+      String remarks) {}
+
+  record QueryColumn(
+      String title,
+      String dataIndex,
+      String key,
+      boolean ellipsis) {}
+
+  record QueryResult(
+      List<QueryColumn> columns,
+      List<Map<String, Object>> data,
+      long total) {
+
+    public QueryResult {
+      columns = columns == null ? List.of() : List.copyOf(columns);
+      if (data == null || data.isEmpty()) {
+        data = List.of();
+      } else {
+        List<Map<String, Object>> copied = new ArrayList<>(data.size());
+        for (Map<String, Object> row : data) {
+          copied.add(
+              row == null
+                  ? Map.of()
+                  : Collections.unmodifiableMap(new LinkedHashMap<>(row)));
+        }
+        data = Collections.unmodifiableList(copied);
+      }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourcePluginGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourcePluginGateway.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.datasource.gateway;
+
+import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+
+/**
+ * Business Datasource 对插件连接能力的稳定 Port。
+ *
+ * <p>Application / Interface 层只依赖该接口，不直接认识 Datasource Plugin SPI 的 Plugin、Connection
+ * 或异常类型；SPI 适配、Secret 处理和异常映射由 Adapter 负责。
+ */
+public interface DataSourcePluginGateway {
+
+  /** 从未保存连接 JSON 中识别目标数据源类型。 */
+  DataSourceDbType resolveConnectionType(String connectionJson);
+
+  /** 解析、校验并规范化连接参数为 Business Domain 的 ConnectionProfile。 */
+  ConnectionProfile normalizeConnection(DataSourceDbType dbType, String connectionJson);
+
+  /** 编辑/测试已有数据源时，将掩码或缺失 Secret 与已保存配置合并。 */
+  String mergeStoredSecrets(
+      DataSourceDbType dbType,
+      String submittedJson,
+      String storedJson);
+
+  /** 测试一个已经规范化的连接配置。失败时抛出 Business Datasource 异常。 */
+  void testConnection(
+      DataSourceDbType dbType,
+      ConnectionProfile connectionProfile,
+      int timeoutSeconds);
+
+  /** 返回仅用于 HTTP 回显的脱敏连接 JSON。 */
+  String maskConnectionJson(DataSourceDbType dbType, String connectionJson);
+
+  /** 对展示用连接地址中的常见凭据参数做兜底脱敏。 */
+  String maskSensitiveText(String value);
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
@@ -1,0 +1,214 @@
+package io.yak.ops.business.datasource.gateway.adapter;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
+import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
+import io.yak.ops.spi.datasource.metadata.DataSourceTable;
+import io.yak.ops.spi.datasource.query.DataSourceQueryColumn;
+import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Datasource Catalog SPI -> Business Gateway Adapter。 */
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
+
+  private final DataSourcePluginRegistry pluginRegistry;
+
+  @Override
+  public List<String> listDatabases(
+      DataSourceDefinition dataSource,
+      int timeoutSeconds) {
+    return execute(dataSource, timeoutSeconds, DataSourceCatalog::listDatabases);
+  }
+
+  @Override
+  public List<String> listSchemas(
+      DataSourceDefinition dataSource,
+      String database,
+      int timeoutSeconds) {
+    return execute(dataSource, timeoutSeconds, catalog -> catalog.listSchemas(database));
+  }
+
+  @Override
+  public List<Table> listTables(
+      DataSourceDefinition dataSource,
+      TableQuery query,
+      int timeoutSeconds) {
+    TableQuery value = query == null ? new TableQuery(null, null, null) : query;
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        catalog ->
+            catalog
+                .listTables(
+                    new DataSourceCatalogQuery(
+                        value.database(), value.schema(), value.keyword()))
+                .stream()
+                .map(this::toTable)
+                .toList());
+  }
+
+  @Override
+  public List<Column> listColumns(
+      DataSourceDefinition dataSource,
+      TablePath tablePath,
+      int timeoutSeconds) {
+    if (tablePath == null) {
+      throw new DataSourceException(
+          DataSourceErrorCode.CATALOG_FAILED,
+          "Catalog 表路径不能为空");
+    }
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        catalog ->
+            catalog
+                .listColumns(
+                    new DataSourceTablePath(
+                        tablePath.database(), tablePath.schema(), tablePath.table()))
+                .stream()
+                .map(this::toColumn)
+                .toList());
+  }
+
+  @Override
+  public List<Column> describe(
+      DataSourceDefinition dataSource,
+      Map<String, Object> request,
+      int timeoutSeconds) {
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        catalog -> catalog.describe(request).stream().map(this::toColumn).toList());
+  }
+
+  @Override
+  public QueryResult preview(
+      DataSourceDefinition dataSource,
+      Map<String, Object> request,
+      int limit,
+      int timeoutSeconds) {
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        catalog -> toQueryResult(catalog.preview(request, limit)));
+  }
+
+  @Override
+  public long count(
+      DataSourceDefinition dataSource,
+      Map<String, Object> request,
+      int timeoutSeconds) {
+    return execute(dataSource, timeoutSeconds, catalog -> catalog.count(request));
+  }
+
+  @Override
+  public String buildSqlTemplate(
+      DataSourceDefinition dataSource,
+      String tablePath,
+      int timeoutSeconds) {
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        catalog -> catalog.buildSqlTemplate(tablePath));
+  }
+
+  @Override
+  public String resolveSql(
+      DataSourceDefinition dataSource,
+      String sql,
+      Map<String, Object> request,
+      int timeoutSeconds) {
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        catalog -> catalog.resolveSql(sql, request));
+  }
+
+  private <T> T execute(
+      DataSourceDefinition dataSource,
+      int timeoutSeconds,
+      Function<DataSourceCatalog, T> action) {
+    if (dataSource == null || dataSource.getDbType() == null) {
+      throw new DataSourceException(
+          DataSourceErrorCode.CATALOG_FAILED,
+          "数据源定义或类型不能为空");
+    }
+    try {
+      DataSourcePlugin plugin = pluginRegistry.get(dataSource.getDbType());
+      DataSourceConnection connection =
+          plugin.parseConnection(dataSource.getConnectionParams());
+      DataSourceCatalog catalog =
+          plugin.createCatalog(connection, Math.max(1, timeoutSeconds));
+      return action.apply(catalog);
+    } catch (DataSourceException exception) {
+      throw exception;
+    } catch (DataSourcePluginException exception) {
+      throw catalogException(exception);
+    } catch (RuntimeException exception) {
+      throw catalogException(exception);
+    }
+  }
+
+  private Table toTable(DataSourceTable table) {
+    return new Table(
+        table.getDatabase(),
+        table.getSchema(),
+        table.getName(),
+        table.getType(),
+        table.getRemarks());
+  }
+
+  private Column toColumn(DataSourceColumn column) {
+    return new Column(
+        column.getName(),
+        column.getTypeName(),
+        column.getJdbcType(),
+        column.getSize(),
+        column.getScale(),
+        column.isNullable(),
+        column.getOrdinalPosition(),
+        column.isPrimaryKey(),
+        column.getRemarks());
+  }
+
+  private QueryResult toQueryResult(DataSourceQueryResult result) {
+    if (result == null) {
+      return new QueryResult(List.of(), List.of(), 0L);
+    }
+    List<QueryColumn> columns =
+        result.getColumns().stream().map(this::toQueryColumn).toList();
+    return new QueryResult(columns, result.getData(), result.getTotal());
+  }
+
+  private QueryColumn toQueryColumn(DataSourceQueryColumn column) {
+    return new QueryColumn(
+        column.getTitle(),
+        column.getDataIndex(),
+        column.getKey(),
+        column.isEllipsis());
+  }
+
+  private DataSourceException catalogException(RuntimeException exception) {
+    return new DataSourceException(
+        DataSourceErrorCode.CATALOG_FAILED,
+        exception.getMessage(),
+        exception);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGateway.java
@@ -1,0 +1,107 @@
+package io.yak.ops.business.datasource.gateway.adapter;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Datasource Plugin SPI -> Business Gateway Adapter。 */
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class SpiDataSourcePluginGateway implements DataSourcePluginGateway {
+
+  private final DataSourcePluginRegistry pluginRegistry;
+  private final DataSourceSecretCodec secretCodec;
+
+  @Override
+  public DataSourceDbType resolveConnectionType(String connectionJson) {
+    return pluginRegistry.resolveConnectionType(connectionJson);
+  }
+
+  @Override
+  public ConnectionProfile normalizeConnection(
+      DataSourceDbType dbType,
+      String connectionJson) {
+    DataSourceConnection connection = parseConnection(pluginRegistry.get(dbType), connectionJson);
+    return new ConnectionProfile(
+        connection.jdbcUrl(),
+        connection.normalizedJson(),
+        connection.normalizedJson());
+  }
+
+  @Override
+  public String mergeStoredSecrets(
+      DataSourceDbType dbType,
+      String submittedJson,
+      String storedJson) {
+    return secretCodec.mergeStoredSecrets(
+        pluginRegistry.get(dbType),
+        submittedJson,
+        storedJson);
+  }
+
+  @Override
+  public void testConnection(
+      DataSourceDbType dbType,
+      ConnectionProfile connectionProfile,
+      int timeoutSeconds) {
+    if (connectionProfile == null) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "数据源连接配置不能为空");
+    }
+    DataSourcePlugin plugin = pluginRegistry.get(dbType);
+    DataSourceConnection connection =
+        parseConnection(plugin, connectionProfile.normalizedJson());
+    try {
+      plugin.testConnection(connection, Math.max(1, timeoutSeconds));
+    } catch (DataSourceException exception) {
+      throw exception;
+    } catch (RuntimeException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.CONNECT_FAILED,
+          exception.getMessage(),
+          exception);
+    }
+  }
+
+  @Override
+  public String maskConnectionJson(
+      DataSourceDbType dbType,
+      String connectionJson) {
+    return secretCodec.maskConnectionJson(pluginRegistry.get(dbType), connectionJson);
+  }
+
+  @Override
+  public String maskSensitiveText(String value) {
+    return secretCodec.maskSensitiveText(value);
+  }
+
+  private DataSourceConnection parseConnection(
+      DataSourcePlugin plugin,
+      String connectionJson) {
+    try {
+      return plugin.parseConnection(connectionJson);
+    } catch (DataSourcePluginException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          exception.getMessage(),
+          exception);
+    } catch (RuntimeException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          exception.getMessage(),
+          exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImpl.java
@@ -4,7 +4,12 @@ import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.exception.DataSourceException;
-import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.Column;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.QueryResult;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.Table;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.TablePath;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.TableQuery;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnOptionVO;
@@ -14,25 +19,17 @@ import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePreviewColumnVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceQueryResultVO;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
-import io.yak.ops.spi.datasource.DataSourceCatalog;
-import io.yak.ops.spi.datasource.DataSourceConnection;
-import io.yak.ops.spi.datasource.DataSourcePlugin;
-import io.yak.ops.spi.datasource.DataSourcePluginException;
-import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
-import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
-import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/** Catalog 服务实现，业务层只负责领域数据源加载、插件路由和响应转换。 */
+/** Catalog 应用服务；Catalog 物理访问和 SPI 模型转换统一由 Gateway Adapter 负责。 */
 @Service
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -43,17 +40,22 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
   private static final Pattern READ_ONLY_SELECT = Pattern.compile("(?is)^SELECT\\b.*");
 
   private final DataSourceRepository repository;
-  private final DataSourcePluginRegistry pluginRegistry;
+  private final DataSourceCatalogGateway catalogGateway;
   private final DataSourceProperties properties;
 
   @Override
   public List<String> listDatabases(Long dataSourceId) {
-    return execute(dataSourceId, DataSourceCatalog::listDatabases);
+    return catalogGateway.listDatabases(
+        getDataSourceOrThrow(dataSourceId),
+        connectionTimeoutSeconds());
   }
 
   @Override
   public List<String> listSchemas(Long dataSourceId, String database) {
-    return execute(dataSourceId, catalog -> catalog.listSchemas(database));
+    return catalogGateway.listSchemas(
+        getDataSourceOrThrow(dataSourceId),
+        database,
+        connectionTimeoutSeconds());
   }
 
   @Override
@@ -62,19 +64,14 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
       String database,
       String schema,
       String keyword) {
-    return execute(
-        dataSourceId,
-        catalog ->
-            catalog.listTables(new DataSourceCatalogQuery(database, schema, keyword)).stream()
-                .map(
-                    table ->
-                        new DataSourceCatalogTableVO(
-                            table.getDatabase(),
-                            table.getSchema(),
-                            table.getName(),
-                            table.getType(),
-                            table.getRemarks()))
-                .collect(Collectors.toList()));
+    return catalogGateway
+        .listTables(
+            getDataSourceOrThrow(dataSourceId),
+            new TableQuery(database, schema, keyword),
+            connectionTimeoutSeconds())
+        .stream()
+        .map(this::toTableVO)
+        .toList();
   }
 
   @Override
@@ -83,38 +80,31 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
       String database,
       String schema,
       String table) {
-    return execute(
-        dataSourceId,
-        catalog ->
-            catalog.listColumns(new DataSourceTablePath(database, schema, table)).stream()
-                .map(
-                    column ->
-                        new DataSourceCatalogColumnVO(
-                            column.getName(),
-                            column.getTypeName(),
-                            column.getJdbcType(),
-                            column.getSize(),
-                            column.getScale(),
-                            column.isNullable(),
-                            column.getOrdinalPosition(),
-                            column.isPrimaryKey(),
-                            column.getRemarks()))
-                .collect(Collectors.toList()));
+    return catalogGateway
+        .listColumns(
+            getDataSourceOrThrow(dataSourceId),
+            new TablePath(database, schema, table),
+            connectionTimeoutSeconds())
+        .stream()
+        .map(this::toColumnVO)
+        .toList();
   }
 
   @Override
   public List<DataSourceCatalogOptionVO> listTable(Long dataSourceId) {
-    return execute(
-        dataSourceId,
-        catalog ->
-            catalog.listTables(new DataSourceCatalogQuery(null, null, null)).stream()
-                .map(
-                    table -> {
-                      String label = isBlank(table.getRemarks()) ? table.getName() : table.getRemarks();
-                      return new DataSourceCatalogOptionVO(
-                          table.getName(), label, table.getRemarks());
-                    })
-                .collect(Collectors.toList()));
+    return catalogGateway
+        .listTables(
+            getDataSourceOrThrow(dataSourceId),
+            new TableQuery(null, null, null),
+            connectionTimeoutSeconds())
+        .stream()
+        .map(
+            table -> {
+              String label = isBlank(table.remarks()) ? table.name() : table.remarks();
+              return new DataSourceCatalogOptionVO(
+                  table.name(), label, table.remarks());
+            })
+        .toList();
   }
 
   @Override
@@ -164,21 +154,14 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
       Map<String, Object> requestBody) {
     Map<String, Object> request = requireRequest(requestBody);
     validateReadOnlyRequest(request);
-    return execute(
-        dataSourceId,
-        catalog ->
-            catalog.describe(request).stream()
-                .map(
-                    column ->
-                        new DataSourceCatalogColumnOptionVO(
-                            column.getOrdinalPosition(),
-                            column.getName(),
-                            column.getTypeName(),
-                            column.getOrdinalPosition(),
-                            column.isNullable() ? "YES" : "NO",
-                            column.getRemarks(),
-                            column.isPrimaryKey() ? "PRI" : ""))
-                .collect(Collectors.toList()));
+    return catalogGateway
+        .describe(
+            getDataSourceOrThrow(dataSourceId),
+            request,
+            connectionTimeoutSeconds())
+        .stream()
+        .map(this::toColumnOptionVO)
+        .toList();
   }
 
   @Override
@@ -187,68 +170,94 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
       Map<String, Object> requestBody) {
     Map<String, Object> request = requireRequest(requestBody);
     validateReadOnlyRequest(request);
-    return execute(
-        dataSourceId,
-        catalog -> toPreviewVO(catalog.preview(request, PREVIEW_LIMIT)));
+    QueryResult result =
+        catalogGateway.preview(
+            getDataSourceOrThrow(dataSourceId),
+            request,
+            PREVIEW_LIMIT,
+            connectionTimeoutSeconds());
+    return toPreviewVO(result);
   }
 
   @Override
   public Long count(Long dataSourceId, Map<String, Object> requestBody) {
     Map<String, Object> request = requireRequest(requestBody);
     validateReadOnlyRequest(request);
-    return execute(dataSourceId, catalog -> catalog.count(request));
+    return catalogGateway.count(
+        getDataSourceOrThrow(dataSourceId),
+        request,
+        connectionTimeoutSeconds());
   }
 
   @Override
   public String buildSqlTemplate(Long dataSourceId, Map<String, Object> requestBody) {
     String tablePath = requiredText(requireRequest(requestBody), "table_path", "tablePath", "table");
-    return execute(dataSourceId, catalog -> catalog.buildSqlTemplate(tablePath));
+    return catalogGateway.buildSqlTemplate(
+        getDataSourceOrThrow(dataSourceId),
+        tablePath,
+        connectionTimeoutSeconds());
   }
 
   @Override
   public String resolveSql(Long dataSourceId, Map<String, Object> requestBody) {
     Map<String, Object> request = requireRequest(requestBody);
     String query = requiredText(request, "query", "sql");
-    return execute(dataSourceId, catalog -> catalog.resolveSql(query, request));
+    return catalogGateway.resolveSql(
+        getDataSourceOrThrow(dataSourceId),
+        query,
+        request,
+        connectionTimeoutSeconds());
   }
 
-  private DataSourceQueryResultVO toPreviewVO(DataSourceQueryResult result) {
+  private DataSourceCatalogTableVO toTableVO(Table table) {
+    return new DataSourceCatalogTableVO(
+        table.database(),
+        table.schema(),
+        table.name(),
+        table.type(),
+        table.remarks());
+  }
+
+  private DataSourceCatalogColumnVO toColumnVO(Column column) {
+    return new DataSourceCatalogColumnVO(
+        column.name(),
+        column.typeName(),
+        column.jdbcType(),
+        column.size(),
+        column.scale(),
+        column.nullable(),
+        column.ordinalPosition(),
+        column.primaryKey(),
+        column.remarks());
+  }
+
+  private DataSourceCatalogColumnOptionVO toColumnOptionVO(Column column) {
+    return new DataSourceCatalogColumnOptionVO(
+        column.ordinalPosition(),
+        column.name(),
+        column.typeName(),
+        column.ordinalPosition(),
+        column.nullable() ? "YES" : "NO",
+        column.remarks(),
+        column.primaryKey() ? "PRI" : "");
+  }
+
+  private DataSourceQueryResultVO toPreviewVO(QueryResult result) {
     List<DataSourcePreviewColumnVO> columns =
-        result.getColumns().stream()
+        result.columns().stream()
             .map(
                 column ->
                     new DataSourcePreviewColumnVO(
-                        column.getTitle(),
-                        column.getDataIndex(),
-                        column.getKey(),
-                        column.isEllipsis()))
-            .collect(Collectors.toList());
-    return new DataSourceQueryResultVO(columns, result.getData(), result.getTotal());
+                        column.title(),
+                        column.dataIndex(),
+                        column.key(),
+                        column.ellipsis()))
+            .toList();
+    return new DataSourceQueryResultVO(columns, result.data(), result.total());
   }
 
-  private <T> T execute(Long dataSourceId, Function<DataSourceCatalog, T> action) {
-    try {
-      DataSourceDefinition definition = getDataSourceOrThrow(dataSourceId);
-      DataSourcePlugin plugin = pluginRegistry.get(definition.getDbType());
-      DataSourceConnection connection = plugin.parseConnection(definition.getConnectionParams());
-      DataSourceCatalog catalog =
-          plugin.createCatalog(
-              connection,
-              Math.max(1, properties.getConnectionTest().getTimeoutSeconds()));
-      return action.apply(catalog);
-    } catch (DataSourceException exception) {
-      throw exception;
-    } catch (DataSourcePluginException exception) {
-      throw new DataSourceException(
-          DataSourceErrorCode.CATALOG_FAILED,
-          exception.getMessage(),
-          exception);
-    } catch (RuntimeException exception) {
-      throw new DataSourceException(
-          DataSourceErrorCode.CATALOG_FAILED,
-          exception.getMessage(),
-          exception);
-    }
+  private int connectionTimeoutSeconds() {
+    return Math.max(1, properties.getConnectionTest().getTimeoutSeconds());
   }
 
   private DataSourceDefinition getDataSourceOrThrow(Long id) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
@@ -156,9 +156,12 @@ public class DataSourceServiceImpl implements DataSourceService {
       repository.updateConnectionStatus(id, definition.getConnStatus());
       return true;
     } catch (RuntimeException exception) {
-      definition.markDisconnected();
-      repository.updateConnectionStatus(id, definition.getConnStatus());
-      throw connectException(exception);
+      DataSourceException mapped = connectException(exception);
+      if (DataSourceErrorCode.CONNECT_FAILED.equals(mapped.getErrorCode())) {
+        definition.markDisconnected();
+        repository.updateConnectionStatus(id, definition.getConnStatus());
+      }
+      throw mapped;
     }
   }
 

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
@@ -158,7 +158,7 @@ public class DataSourceServiceImpl implements DataSourceService {
     } catch (RuntimeException exception) {
       definition.markDisconnected();
       repository.updateConnectionStatus(id, definition.getConnStatus());
-      throw exception;
+      throw connectException(exception);
     }
   }
 
@@ -195,14 +195,28 @@ public class DataSourceServiceImpl implements DataSourceService {
 
     ConnectionProfile connectionProfile =
         pluginGateway.normalizeConnection(dbType, connectionJson);
-    pluginGateway.testConnection(dbType, connectionProfile, connectionTimeoutSeconds());
-    return true;
+    try {
+      pluginGateway.testConnection(dbType, connectionProfile, connectionTimeoutSeconds());
+      return true;
+    } catch (RuntimeException exception) {
+      throw connectException(exception);
+    }
   }
 
   @Override
   public List<DataSourceOptionVO> getOptions(String dbType) {
     DataSourceDbType normalizedType = StringUtils.hasText(dbType) ? parseDbType(dbType) : null;
     return repository.findAll(normalizedType).stream().map(viewMapper::option).toList();
+  }
+
+  private DataSourceException connectException(RuntimeException exception) {
+    if (exception instanceof DataSourceException dataSourceException) {
+      return dataSourceException;
+    }
+    return new DataSourceException(
+        DataSourceErrorCode.CONNECT_FAILED,
+        exception.getMessage(),
+        exception);
   }
 
   private int connectionTimeoutSeconds() {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImpl.java
@@ -8,11 +8,10 @@ import io.yak.ops.business.datasource.domain.ConnectionProfile;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.domain.DataSourceQuery;
 import io.yak.ops.business.datasource.exception.DataSourceException;
-import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.business.datasource.service.DataSourceService;
 import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
-import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
 import io.yak.ops.common.bean.dto.datasource.DataSourceConnectTestDTO;
 import io.yak.ops.common.bean.dto.datasource.DataSourceDTO;
 import io.yak.ops.common.bean.dto.datasource.DataSourceQueryDTO;
@@ -23,25 +22,21 @@ import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
-import io.yak.ops.spi.datasource.DataSourceConnection;
-import io.yak.ops.spi.datasource.DataSourcePlugin;
-import io.yak.ops.spi.datasource.DataSourcePluginException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-/** 数据源管理服务实现。业务层只负责编排，持久化与展示转换由独立边界承担。 */
+/** 数据源管理应用服务；只负责编排 Domain、Repository 和 Business Gateway。 */
 @Service
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataSourceServiceImpl implements DataSourceService {
 
   private final DataSourceRepository repository;
-  private final DataSourcePluginRegistry pluginRegistry;
+  private final DataSourcePluginGateway pluginGateway;
   private final DataSourceProperties properties;
-  private final DataSourceSecretCodec secretCodec;
   private final DataSourceViewMapper viewMapper;
 
   @Override
@@ -55,7 +50,7 @@ public class DataSourceServiceImpl implements DataSourceService {
     DataSourceDbType dbType = parseDbType(dataSourceDTO.getDbType());
     DataSourceEnvironment environment = parseEnvironment(dataSourceDTO.getEnvironment());
     ConnectionProfile connectionProfile =
-        buildConnectionProfile(dbType, dataSourceDTO.getConnectionParams());
+        pluginGateway.normalizeConnection(dbType, dataSourceDTO.getConnectionParams());
     DataSourceDefinition definition =
         DataSourceDefinition.create(
             name,
@@ -89,14 +84,13 @@ public class DataSourceServiceImpl implements DataSourceService {
           exception);
     }
 
-    DataSourcePlugin plugin = pluginRegistry.get(requestedType);
     String mergedConnectionJson =
-        secretCodec.mergeStoredSecrets(
-            plugin,
+        pluginGateway.mergeStoredSecrets(
+            requestedType,
             dataSourceDTO.getConnectionParams(),
             existing.getConnectionParams());
     ConnectionProfile connectionProfile =
-        buildConnectionProfile(requestedType, mergedConnectionJson);
+        pluginGateway.normalizeConnection(requestedType, mergedConnectionJson);
     DataSourceEnvironment environment = parseEnvironment(dataSourceDTO.getEnvironment());
     existing.updateConfiguration(
         name,
@@ -153,18 +147,18 @@ public class DataSourceServiceImpl implements DataSourceService {
   @Override
   public boolean testConnection(Long id) {
     DataSourceDefinition definition = getDataSourceOrThrow(id);
-    DataSourcePlugin plugin = pluginRegistry.get(definition.getDbType());
-    DataSourceConnection connection = parseConnection(plugin, definition.getConnectionParams());
-
     try {
-      plugin.testConnection(connection, connectionTimeoutSeconds());
+      pluginGateway.testConnection(
+          definition.getDbType(),
+          definition.connectionProfile(),
+          connectionTimeoutSeconds());
       definition.markConnected();
       repository.updateConnectionStatus(id, definition.getConnStatus());
       return true;
     } catch (RuntimeException exception) {
       definition.markDisconnected();
       repository.updateConnectionStatus(id, definition.getConnStatus());
-      throw connectException(exception);
+      throw exception;
     }
   }
 
@@ -176,81 +170,39 @@ public class DataSourceServiceImpl implements DataSourceService {
           "连接测试参数不能为空");
     }
 
-    DataSourcePlugin plugin;
     String connectionJson = connectTestDTO.getConnJson();
+    DataSourceDbType dbType;
     if (connectTestDTO.getDataSourceId() != null) {
       DataSourceDefinition existing = getDataSourceOrThrow(connectTestDTO.getDataSourceId());
-      DataSourceDbType existingType = existing.getDbType();
+      dbType = existing.getDbType();
       if (StringUtils.hasText(connectTestDTO.getDbType())
-          && parseDbType(connectTestDTO.getDbType()) != existingType) {
+          && parseDbType(connectTestDTO.getDbType()) != dbType) {
         throw new DataSourceException(
             DataSourceErrorCode.INVALID_DB_TYPE,
             "连接测试的数据源类型与已保存数据源不一致");
       }
-      plugin = pluginRegistry.get(existingType);
       connectionJson =
-          secretCodec.mergeStoredSecrets(
-              plugin,
+          pluginGateway.mergeStoredSecrets(
+              dbType,
               connectionJson,
               existing.getConnectionParams());
     } else {
-      DataSourceDbType dbType =
+      dbType =
           StringUtils.hasText(connectTestDTO.getDbType())
               ? parseDbType(connectTestDTO.getDbType())
-              : pluginRegistry.resolveConnectionType(connectionJson);
-      plugin = pluginRegistry.get(dbType);
+              : pluginGateway.resolveConnectionType(connectionJson);
     }
 
-    DataSourceConnection connection = parseConnection(plugin, connectionJson);
-    try {
-      plugin.testConnection(connection, connectionTimeoutSeconds());
-      return true;
-    } catch (RuntimeException exception) {
-      throw connectException(exception);
-    }
+    ConnectionProfile connectionProfile =
+        pluginGateway.normalizeConnection(dbType, connectionJson);
+    pluginGateway.testConnection(dbType, connectionProfile, connectionTimeoutSeconds());
+    return true;
   }
 
   @Override
   public List<DataSourceOptionVO> getOptions(String dbType) {
     DataSourceDbType normalizedType = StringUtils.hasText(dbType) ? parseDbType(dbType) : null;
     return repository.findAll(normalizedType).stream().map(viewMapper::option).toList();
-  }
-
-  private ConnectionProfile buildConnectionProfile(
-      DataSourceDbType dbType,
-      String connectionJson) {
-    DataSourcePlugin plugin = pluginRegistry.get(dbType);
-    DataSourceConnection connection = parseConnection(plugin, connectionJson);
-    return new ConnectionProfile(
-        connection.jdbcUrl(),
-        connection.normalizedJson(),
-        connection.normalizedJson());
-  }
-
-  private DataSourceConnection parseConnection(DataSourcePlugin plugin, String connectionJson) {
-    try {
-      return plugin.parseConnection(connectionJson);
-    } catch (DataSourcePluginException exception) {
-      throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          exception.getMessage(),
-          exception);
-    } catch (RuntimeException exception) {
-      throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          exception.getMessage(),
-          exception);
-    }
-  }
-
-  private DataSourceException connectException(RuntimeException exception) {
-    if (exception instanceof DataSourceException dataSourceException) {
-      return dataSourceException;
-    }
-    return new DataSourceException(
-        DataSourceErrorCode.CONNECT_FAILED,
-        exception.getMessage(),
-        exception);
   }
 
   private int connectionTimeoutSeconds() {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapper.java
@@ -3,23 +3,20 @@ package io.yak.ops.business.datasource.service.support;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.domain.DataSourceSummary;
-import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
-import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
 import io.yak.ops.common.bean.vo.datasource.DataSourceOptionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceSummaryVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceVO;
-import io.yak.ops.spi.datasource.DataSourcePlugin;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/** Domain -> VO 纯输出转换，不访问数据库。 */
+/** Domain -> VO 输出转换；插件相关脱敏通过 Business Gateway 完成。 */
 @Component
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataSourceViewMapper {
 
-  private final DataSourcePluginRegistry pluginRegistry;
-  private final DataSourceSecretCodec secretCodec;
+  private final DataSourcePluginGateway pluginGateway;
 
   public DataSourceVO definition(DataSourceDefinition source, boolean includeOriginalJson) {
     if (source == null) return null;
@@ -27,7 +24,7 @@ public class DataSourceViewMapper {
     target.setId(source.getId());
     target.setName(source.getName());
     target.setDbType(source.getDbType() == null ? null : source.getDbType().name());
-    target.setJdbcUrl(secretCodec.maskSensitiveText(source.getJdbcUrl()));
+    target.setJdbcUrl(pluginGateway.maskSensitiveText(source.getJdbcUrl()));
     target.setEnvironment(source.getEnvironment() == null ? null : source.getEnvironment().name());
     target.setEnvironmentName(
         source.getEnvironment() == null ? null : source.getEnvironment().getDisplayName());
@@ -36,8 +33,8 @@ public class DataSourceViewMapper {
     target.setCreateTime(source.getCreateTime());
     target.setUpdateTime(source.getUpdateTime());
     if (includeOriginalJson && source.getDbType() != null) {
-      DataSourcePlugin plugin = pluginRegistry.get(source.getDbType());
-      target.setOriginalJson(secretCodec.maskConnectionJson(plugin, source.getOriginalJson()));
+      target.setOriginalJson(
+          pluginGateway.maskConnectionJson(source.getDbType(), source.getOriginalJson()));
     }
     return target;
   }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
@@ -1,0 +1,90 @@
+package io.yak.ops.business.datasource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
+import io.yak.ops.business.datasource.gateway.adapter.SpiDataSourceCatalogGateway;
+import io.yak.ops.business.datasource.gateway.adapter.SpiDataSourcePluginGateway;
+import io.yak.ops.business.datasource.service.impl.DataSourceCatalogServiceImpl;
+import io.yak.ops.business.datasource.service.impl.DataSourceServiceImpl;
+import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataSourceGatewayArchitectureTest {
+
+  private static final String[] PORT_FORBIDDEN = {
+    ".spi.datasource",
+    ".bean.dto.",
+    ".bean.vo.",
+    ".bean.po.",
+    "com.baomidou.mybatisplus"
+  };
+
+  @Test
+  void businessGatewayContractsDoNotExposePluginSpiOrTransportPersistenceModels() {
+    for (Class<?> port : List.of(DataSourcePluginGateway.class, DataSourceCatalogGateway.class)) {
+      for (Method method : port.getMethods()) {
+        assertTypeAvoids(port, method.getName(), method.getGenericReturnType(), PORT_FORBIDDEN);
+        for (Type parameter : method.getGenericParameterTypes()) {
+          assertTypeAvoids(port, method.getName(), parameter, PORT_FORBIDDEN);
+        }
+      }
+    }
+  }
+
+  @Test
+  void applicationConsumersDependOnBusinessGatewaysInsteadOfPluginInfrastructure() {
+    for (Class<?> type :
+        List.of(
+            DataSourceServiceImpl.class,
+            DataSourceCatalogServiceImpl.class,
+            DataSourceViewMapper.class)) {
+      for (Field field : type.getDeclaredFields()) {
+        String fieldType = field.getGenericType().getTypeName();
+        assertThat(fieldType)
+            .as(type.getSimpleName() + "." + field.getName())
+            .doesNotContain(".spi.datasource")
+            .doesNotContain(".plugin.DataSourcePluginRegistry")
+            .doesNotContain(".util.DataSourceSecretCodec");
+      }
+    }
+  }
+
+  @Test
+  void spiAdaptersImplementBusinessGatewayPorts() {
+    assertThat(DataSourcePluginGateway.class.isAssignableFrom(SpiDataSourcePluginGateway.class))
+        .isTrue();
+    assertThat(DataSourceCatalogGateway.class.isAssignableFrom(SpiDataSourceCatalogGateway.class))
+        .isTrue();
+  }
+
+  private void assertTypeAvoids(
+      Class<?> owner,
+      String member,
+      Type type,
+      String... forbidden) {
+    String signature = typeName(type);
+    for (String packagePart : forbidden) {
+      assertThat(signature)
+          .as("%s.%s must not expose %s", owner.getSimpleName(), member, packagePart)
+          .doesNotContain(packagePart);
+    }
+  }
+
+  private String typeName(Type type) {
+    if (type instanceof ParameterizedType parameterized) {
+      StringBuilder value = new StringBuilder(parameterized.getRawType().getTypeName());
+      for (Type argument : parameterized.getActualTypeArguments()) {
+        value.append('<').append(typeName(argument)).append('>');
+      }
+      return value.toString();
+    }
+    return type.getTypeName();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.datasource.gateway.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.Table;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.TableQuery;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.metadata.DataSourceTable;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SpiDataSourceCatalogGatewayTest {
+
+  private final DataSourcePluginRegistry registry = mock(DataSourcePluginRegistry.class);
+  private final DataSourcePlugin plugin = mock(DataSourcePlugin.class);
+  private final DataSourceConnection connection = mock(DataSourceConnection.class);
+  private final DataSourceCatalog catalog = mock(DataSourceCatalog.class);
+  private final SpiDataSourceCatalogGateway gateway =
+      new SpiDataSourceCatalogGateway(registry);
+
+  @Test
+  void listTablesTranslatesPluginMetadataToBusinessGatewayContract() {
+    DataSourceDefinition dataSource = dataSource();
+    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(plugin.parseConnection(dataSource.getConnectionParams())).thenReturn(connection);
+    when(plugin.createCatalog(connection, 5)).thenReturn(catalog);
+    when(catalog.listTables(any(DataSourceCatalogQuery.class)))
+        .thenReturn(
+            List.of(
+                new DataSourceTable(
+                    "orders_db",
+                    "public",
+                    "orders",
+                    "TABLE",
+                    "order table")));
+
+    List<Table> result =
+        gateway.listTables(
+            dataSource,
+            new TableQuery("orders_db", "public", "ord"),
+            5);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().database()).isEqualTo("orders_db");
+    assertThat(result.getFirst().schema()).isEqualTo("public");
+    assertThat(result.getFirst().name()).isEqualTo("orders");
+    assertThat(result.getFirst().type()).isEqualTo("TABLE");
+    assertThat(result.getFirst().remarks()).isEqualTo("order table");
+  }
+
+  private DataSourceDefinition dataSource() {
+    DataSourceDefinition dataSource = new DataSourceDefinition();
+    dataSource.setDbType(DataSourceDbType.MYSQL);
+    dataSource.setConnectionParams("{\"database\":\"orders_db\"}");
+    return dataSource;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGatewayTest.java
@@ -1,0 +1,84 @@
+package io.yak.ops.business.datasource.gateway.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import org.junit.jupiter.api.Test;
+
+class SpiDataSourcePluginGatewayTest {
+
+  private final DataSourcePluginRegistry registry = mock(DataSourcePluginRegistry.class);
+  private final DataSourceSecretCodec secretCodec = mock(DataSourceSecretCodec.class);
+  private final DataSourcePlugin plugin = mock(DataSourcePlugin.class);
+  private final DataSourceConnection connection = mock(DataSourceConnection.class);
+  private final SpiDataSourcePluginGateway gateway =
+      new SpiDataSourcePluginGateway(registry, secretCodec);
+
+  @Test
+  void normalizeConnectionTranslatesSpiConnectionToDomainProfile() {
+    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(plugin.parseConnection("submitted-json")).thenReturn(connection);
+    when(connection.jdbcUrl()).thenReturn("jdbc:mysql://127.0.0.1:3306/orders");
+    when(connection.normalizedJson()).thenReturn("{\"database\":\"orders\"}");
+
+    ConnectionProfile result =
+        gateway.normalizeConnection(DataSourceDbType.MYSQL, "submitted-json");
+
+    assertThat(result.jdbcUrl()).isEqualTo("jdbc:mysql://127.0.0.1:3306/orders");
+    assertThat(result.normalizedJson()).isEqualTo("{\"database\":\"orders\"}");
+    assertThat(result.originalJson()).isEqualTo(result.normalizedJson());
+  }
+
+  @Test
+  void connectionFailureIsMappedToBusinessDatasourceException() {
+    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(plugin.parseConnection("{\"database\":\"orders\"}")).thenReturn(connection);
+    doThrow(
+            new DataSourcePluginException(
+                DataSourcePluginException.Operation.CONNECTIVITY,
+                "connection unavailable"))
+        .when(plugin)
+        .testConnection(connection, 3);
+
+    ConnectionProfile profile =
+        ConnectionProfile.of(
+            "jdbc:mysql://127.0.0.1:3306/orders",
+            "{\"database\":\"orders\"}");
+
+    assertThatThrownBy(
+            () -> gateway.testConnection(DataSourceDbType.MYSQL, profile, 3))
+        .isInstanceOfSatisfying(
+            DataSourceException.class,
+            exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(DataSourceErrorCode.CONNECT_FAILED));
+  }
+
+  @Test
+  void secretMergeStaysInsideSpiAdapterBoundary() {
+    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(secretCodec.mergeStoredSecrets(plugin, "submitted", "stored"))
+        .thenReturn("merged");
+
+    assertThat(
+            gateway.mergeStoredSecrets(
+                DataSourceDbType.MYSQL,
+                "submitted",
+                "stored"))
+        .isEqualTo("merged");
+
+    verify(secretCodec).mergeStoredSecrets(plugin, "submitted", "stored");
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImplTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImplTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.yak.ops.business.datasource.config.DataSourceProperties;
 import io.yak.ops.business.datasource.exception.DataSourceException;
-import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 class DataSourceCatalogServiceImplTest {
 
   private final DataSourceRepository repository = mock(DataSourceRepository.class);
-  private final DataSourcePluginRegistry pluginRegistry = mock(DataSourcePluginRegistry.class);
+  private final DataSourceCatalogGateway catalogGateway = mock(DataSourceCatalogGateway.class);
   private final DataSourceProperties properties = mock(DataSourceProperties.class);
   private final DataSourceCatalogServiceImpl service =
-      new DataSourceCatalogServiceImpl(repository, pluginRegistry, properties);
+      new DataSourceCatalogServiceImpl(repository, catalogGateway, properties);
 
   @Test
   void shouldRejectNonSelectSqlBeforeOpeningDatasourceConnection() {
@@ -31,7 +31,7 @@ class DataSourceCatalogServiceImplTest {
         .isInstanceOf(DataSourceException.class)
         .hasMessageContaining("仅允许执行单条 SELECT 查询");
 
-    verifyNoInteractions(repository, pluginRegistry, properties);
+    verifyNoInteractions(repository, catalogGateway, properties);
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImplTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImplTest.java
@@ -1,13 +1,21 @@
 package io.yak.ops.business.datasource.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.framework.common.PageData;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.domain.DataSourceQuery;
+import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
@@ -15,6 +23,8 @@ import io.yak.ops.common.bean.dto.datasource.DataSourceQueryDTO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -60,6 +70,67 @@ class DataSourceServiceImplTest {
     assertThat(request.getName()).isEqualTo("  orders-db  ");
     assertThat(request.getDbType()).isEqualTo(" mysql ");
     assertThat(request.getEnvironment()).isEqualTo(" production ");
+  }
+
+  @Test
+  void savedConnectionParameterFailureDoesNotOverwriteExistingStatus() {
+    DataSourceDefinition dataSource = savedDataSource(DataSourceConnStatus.CONNECTED);
+    when(repository.findById(42L)).thenReturn(Optional.of(dataSource));
+    when(properties.getConnectionTest()).thenReturn(new DataSourceProperties.ConnectionTest());
+    doThrow(
+            new DataSourceException(
+                DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+                "invalid stored connection"))
+        .when(pluginGateway)
+        .testConnection(
+            eq(DataSourceDbType.MYSQL),
+            any(ConnectionProfile.class),
+            anyInt());
+
+    assertThatThrownBy(() -> service().testConnection(42L))
+        .isInstanceOfSatisfying(
+            DataSourceException.class,
+            exception ->
+                assertThat(exception.getErrorCode())
+                    .isEqualTo(DataSourceErrorCode.INVALID_CONNECTION_PARAMS));
+
+    assertThat(dataSource.getConnStatus()).isEqualTo(DataSourceConnStatus.CONNECTED);
+    verify(repository, never()).updateConnectionStatus(any(), any());
+  }
+
+  @Test
+  void savedConnectivityFailureMarksCurrentConfigurationDisconnected() {
+    DataSourceDefinition dataSource = savedDataSource(DataSourceConnStatus.CONNECTED);
+    when(repository.findById(42L)).thenReturn(Optional.of(dataSource));
+    when(properties.getConnectionTest()).thenReturn(new DataSourceProperties.ConnectionTest());
+    doThrow(
+            new DataSourceException(
+                DataSourceErrorCode.CONNECT_FAILED,
+                "connection unavailable"))
+        .when(pluginGateway)
+        .testConnection(
+            eq(DataSourceDbType.MYSQL),
+            any(ConnectionProfile.class),
+            anyInt());
+
+    assertThatThrownBy(() -> service().testConnection(42L))
+        .isInstanceOf(DataSourceException.class);
+
+    assertThat(dataSource.getConnStatus()).isEqualTo(DataSourceConnStatus.DISCONNECTED);
+    verify(repository).updateConnectionStatus(42L, DataSourceConnStatus.DISCONNECTED);
+  }
+
+  private DataSourceDefinition savedDataSource(DataSourceConnStatus status) {
+    DataSourceDefinition dataSource = new DataSourceDefinition();
+    dataSource.setId(42L);
+    dataSource.setName("orders-db");
+    dataSource.setDbType(DataSourceDbType.MYSQL);
+    dataSource.setEnvironment(DataSourceEnvironment.PROD);
+    dataSource.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/orders");
+    dataSource.setConnectionParams("{\"database\":\"orders\"}");
+    dataSource.setOriginalJson("{\"database\":\"orders\"}");
+    dataSource.setConnStatus(status);
+    return dataSource;
   }
 
   private DataSourceServiceImpl service() {

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImplTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceServiceImplTest.java
@@ -8,10 +8,9 @@ import static org.mockito.Mockito.when;
 import io.yak.framework.common.PageData;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
 import io.yak.ops.business.datasource.domain.DataSourceQuery;
-import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
-import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
 import io.yak.ops.common.bean.dto.datasource.DataSourceQueryDTO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
@@ -26,9 +25,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DataSourceServiceImplTest {
 
   @Mock private DataSourceRepository repository;
-  @Mock private DataSourcePluginRegistry pluginRegistry;
+  @Mock private DataSourcePluginGateway pluginGateway;
   @Mock private DataSourceProperties properties;
-  @Mock private DataSourceSecretCodec secretCodec;
   @Mock private DataSourceViewMapper viewMapper;
 
   @Test
@@ -67,9 +65,8 @@ class DataSourceServiceImplTest {
   private DataSourceServiceImpl service() {
     return new DataSourceServiceImpl(
         repository,
-        pluginRegistry,
+        pluginGateway,
         properties,
-        secretCodec,
         viewMapper);
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapperTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/support/DataSourceViewMapperTest.java
@@ -6,23 +6,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
-import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
-import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
 import io.yak.ops.common.bean.vo.datasource.DataSourceVO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
-import io.yak.ops.spi.datasource.DataSourcePlugin;
 import org.junit.jupiter.api.Test;
 
 class DataSourceViewMapperTest {
 
   @Test
   void detailKeepsJdbcAndConnectionJsonMasked() {
-    DataSourcePluginRegistry registry = mock(DataSourcePluginRegistry.class);
-    DataSourceSecretCodec secretCodec = mock(DataSourceSecretCodec.class);
-    DataSourcePlugin plugin = mock(DataSourcePlugin.class);
-    DataSourceViewMapper mapper = new DataSourceViewMapper(registry, secretCodec);
+    DataSourcePluginGateway pluginGateway = mock(DataSourcePluginGateway.class);
+    DataSourceViewMapper mapper = new DataSourceViewMapper(pluginGateway);
 
     DataSourceDefinition source = new DataSourceDefinition();
     source.setId(42L);
@@ -30,21 +26,20 @@ class DataSourceViewMapperTest {
     source.setDbType(DataSourceDbType.MYSQL);
     source.setEnvironment(DataSourceEnvironment.PROD);
     source.setConnStatus(DataSourceConnStatus.CONNECTED);
-    source.setJdbcUrl("jdbc:mysql://root:secret@127.0.0.1:3306/orders");
-    source.setOriginalJson("{\"password\":\"secret\"}");
+    source.setJdbcUrl("jdbc:mysql://user:credential-value@127.0.0.1:3306/orders");
+    source.setOriginalJson("{\"password\":\"credential-value\"}");
 
-    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
-    when(secretCodec.maskSensitiveText(source.getJdbcUrl()))
-        .thenReturn("jdbc:mysql://root:******@127.0.0.1:3306/orders");
-    when(secretCodec.maskConnectionJson(plugin, source.getOriginalJson()))
+    when(pluginGateway.maskSensitiveText(source.getJdbcUrl()))
+        .thenReturn("jdbc:mysql://user:******@127.0.0.1:3306/orders");
+    when(pluginGateway.maskConnectionJson(DataSourceDbType.MYSQL, source.getOriginalJson()))
         .thenReturn("{\"password\":\"******\"}");
 
     DataSourceVO result = mapper.definition(source, true);
 
-    assertThat(result.getJdbcUrl()).doesNotContain("secret");
-    assertThat(result.getOriginalJson()).doesNotContain("secret");
+    assertThat(result.getJdbcUrl()).doesNotContain("credential-value");
+    assertThat(result.getOriginalJson()).doesNotContain("credential-value");
     assertThat(result.getEnvironmentName()).isEqualTo("生产");
-    verify(secretCodec).maskSensitiveText(source.getJdbcUrl());
-    verify(secretCodec).maskConnectionJson(plugin, source.getOriginalJson());
+    verify(pluginGateway).maskSensitiveText(source.getJdbcUrl());
+    verify(pluginGateway).maskConnectionJson(DataSourceDbType.MYSQL, source.getOriginalJson());
   }
 }


### PR DESCRIPTION
# Datasource Change

> Phase 2 stacked on Phase 1. 开发前读 `REQUIREMENTS.md + DOMAIN.md`；Review 按 `REVIEW.md`。

## Summary

完成 Datasource Domain Phase 2：将数据源管理、Catalog 和详情脱敏主链路从 Datasource Plugin SPI 解耦到 Business Gateway / Adapter 边界。

- 新增 `DataSourcePluginGateway`：连接类型识别、Connection 规范化、Secret 合并、连接测试、展示脱敏。
- 新增 `SpiDataSourcePluginGateway`：负责 Plugin Registry / SPI Connection / Secret helper 适配和业务异常映射。
- 新增 `DataSourceCatalogGateway`：定义 Business-owned Catalog boundary contract，不暴露 SPI Table / Column / QueryResult。
- 新增 `SpiDataSourceCatalogGateway`：负责 Catalog 创建、SPI metadata/result 转换和异常映射。
- `DataSourceServiceImpl`、`DataSourceCatalogServiceImpl`、`DataSourceViewMapper` 不再直接依赖 Datasource Plugin SPI 主链路。
- 更新领域文档、架构测试、Adapter 测试和 datasource 静态 guardrail。

## Domain Impact Analysis

```text
Aggregate(s): DataSourceDefinition / ConnectionProfile (behavior unchanged)
Adjacent context: Datasource Plugin SPI / Catalog SPI
Invariant/lifecycle impact:
- DataSource aggregate invariants unchanged
- create/update/test connection semantics retained
- Plugin SPI cannot enter protected Application main paths directly
- Catalog SPI model must be translated at Gateway Adapter boundary
Layer: Application / Gateway Port / Infrastructure Adapter / Test / Documentation
Domain Gap: no for Phase 2 scope
```

## Dependency Direction

```text
DataSourceServiceImpl
    -> DataSourcePluginGateway
    <- SpiDataSourcePluginGateway
    -> Datasource Plugin SPI

DataSourceCatalogServiceImpl
    -> DataSourceCatalogGateway
    <- SpiDataSourceCatalogGateway
    -> Datasource Plugin SPI

DataSourceViewMapper
    -> DataSourcePluginGateway
```

Gateway Port 禁止暴露 Datasource Plugin SPI model、HTTP DTO / VO、Persistence PO / MyBatis type。

## Compatibility

本 PR 有意保持不变：

- REST API 路径和 DTO / VO JSON 结构
- `yak_ops_data_source` 表结构和 Flyway 历史
- Datasource Plugin SPI 签名
- MySQL / PostgreSQL / Oracle / Doris 等现有插件实现
- Catalog `Map<String, Object>` 历史请求协议（Phase 3 类型化）
- SQL Execution 主模型（Phase 3 领域化）

当前明确保留两个边界例外：

- `DataSourcePluginConfigServiceImpl`：历史 `pluginConfig() -> DataSourcePluginConfigVO` 兼容桥，后续 Plugin Descriptor / Form Contract 去 VO 化处理。
- `BusinessDataSourceExecutionProvider`：自身是向 Task Plugin SPI 暴露 SQL Executor 的 Adapter，允许依赖对应 SPI。

## Tests / Safety

新增 / 更新：

- `DataSourceGatewayArchitectureTest`
- `SpiDataSourcePluginGatewayTest`
- `SpiDataSourceCatalogGatewayTest`
- Service / Catalog Service / View Mapper Gateway 依赖测试
- `tools/datasource_domain_guardrails.py`：Application -> Gateway、Gateway no-SPI/no-DTO/no-VO/no-PO、Adapter ownership 检查

CI 当前结果：

```text
Datasource Domain Guardrails: PASS
Static domain contract: PASS
Backend regression hook: PASS
Maven/JUnit regression: SKIPPED - repository 未配置 YAK_FRAMEWORK_TOKEN
```

期间静态护栏曾因 `REVIEW.md` 超过文档预算主动失败；已通过压缩 Review 文档修复，没有放宽护栏阈值。

## Domain Compliance Report

```text
Rule changed/implemented:
- Datasource Plugin SPI = adjacent context, not Application Contract
- Application main path -> Business Gateway Port only
- Gateway Port must not expose Plugin SPI / DTO / VO / PO
- SPI protocol conversion and exception mapping live in gateway.adapter
Safety/tests:
- gateway architecture guardrails
- plugin/catalog adapter translation tests
- zero-dependency static contract PASS
- existing aggregate invariants retained
- no REST / DB / Plugin SPI migration
Known gaps:
- Catalog Domain Model / typed Map protocol (Phase 3)
- SQL Execution Domain Model (Phase 3)
- Plugin Capability / Descriptor
- Plugin API VO dependency
- PluginConfig compatibility bridge cleanup
- Aggregate physical naming cleanup
```

## Stacked PR

```text
base: refactor/datasource-domain-phase1
head: refactor/datasource-domain-phase2
```

Phase 1 合并后，本 PR 可 retarget 到 `main`。