### PR TITLE
refactor(datasource): land phase 3 catalog and sql execution domain

### DIFF
--- a/.github/workflows/datasource-domain-guardrails.yml
+++ b/.github/workflows/datasource-domain-guardrails.yml
@@ -88,6 +88,6 @@ jobs:
         run: >-
           ./mvnw -B -ntp
           -pl "$DATASOURCE_MODULE"
-          -Dtest=DataSourceDomainArchitectureTest,DataSourceGatewayArchitectureTest,DataSourceLayeringConventionTest,DataSourceDefinitionTest,DataSourceRepositoryAdapterTest,DataSourceServiceImplTest,DataSourceCatalogServiceImplTest,DataSourceViewMapperTest,SpiDataSourcePluginGatewayTest,SpiDataSourceCatalogGatewayTest
+          -Dtest=DataSourceDomainArchitectureTest,DataSourceGatewayArchitectureTest,DataSourceLayeringConventionTest,DataSourceDefinitionTest,DataSourceRepositoryAdapterTest,DataSourceServiceImplTest,DataSourceCatalogServiceImplTest,DataSourceViewMapperTest,SpiDataSourcePluginGatewayTest,SpiDataSourceCatalogGatewayTest,DefaultSqlExecutionRuntimeTest,DefaultSqlExecutionTransactionCancellationTest,ObservableSqlExecutionRuntimeTest,SqlExecutionAggregateTest,SpiSqlExecutionGatewayTest
           -Dsurefire.failIfNoSpecifiedTests=false
           test

--- a/.github/workflows/datasource-domain-guardrails.yml
+++ b/.github/workflows/datasource-domain-guardrails.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - 'yak-ops-business/yak-ops-business-datasource/**'
       - 'yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/**'
+      - 'yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/**'
       - 'tools/datasource_domain_guardrails.py'
+      - 'tools/datasource-domain-smoke/**'
       - '.github/PULL_REQUEST_TEMPLATE/datasource-domain.md'
       - '.github/workflows/datasource-domain-guardrails.yml'
   push:
@@ -15,7 +17,9 @@ on:
     paths:
       - 'yak-ops-business/yak-ops-business-datasource/**'
       - 'yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/**'
+      - 'yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/**'
       - 'tools/datasource_domain_guardrails.py'
+      - 'tools/datasource-domain-smoke/**'
       - '.github/PULL_REQUEST_TEMPLATE/datasource-domain.md'
       - '.github/workflows/datasource-domain-guardrails.yml'
   workflow_dispatch:
@@ -42,10 +46,41 @@ jobs:
       - name: Run zero-dependency datasource domain guard
         run: python3 tools/datasource_domain_guardrails.py --event "$GITHUB_EVENT_PATH"
 
+  phase3-domain-smoke:
+    name: Framework-free Phase 3 domain smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout yak-ops
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Compile typed Catalog and SQL lifecycle domain
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/datasource-domain"
+          rm -rf "$OUT"
+          mkdir -p "$OUT"
+
+          javac --release 21 -d "$OUT" \
+            yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/*.java \
+            yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/*.java \
+            yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/domain/SqlExecutionAggregate.java \
+            tools/datasource-domain-smoke/DatasourceDomainSmoke.java
+
+          java -cp "$OUT" DatasourceDomainSmoke
+
   backend-domain-regression:
     name: Backend regression hook
     needs:
       - static-domain-contract
+      - phase3-domain-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -57,7 +92,7 @@ jobs:
       - name: Explain private dependency requirement
         if: env.YAK_FRAMEWORK_TOKEN == ''
         run: |
-          echo "::notice title=Backend regression not executed::yak-framework is a private repository. Configure repository secret YAK_FRAMEWORK_TOKEN with read access to enable the full Maven/JUnit regression layer. Static Datasource Domain Contract remains mandatory and runs without this secret."
+          echo "::notice title=Backend regression not executed::yak-framework is a private repository. Configure repository secret YAK_FRAMEWORK_TOKEN with read access to enable the full Maven/JUnit regression layer. Static and framework-free Datasource domain checks remain mandatory without this secret."
 
       - name: Checkout yak-framework SNAPSHOT dependency
         if: env.YAK_FRAMEWORK_TOKEN != ''

--- a/tools/datasource-domain-smoke/DatasourceDomainSmoke.java
+++ b/tools/datasource-domain-smoke/DatasourceDomainSmoke.java
@@ -1,0 +1,70 @@
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.ReadMode;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.Variable;
+import io.yak.ops.business.datasource.execution.domain.SqlExecutionAggregate;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementClassification;
+import io.yak.ops.core.execution.sql.SqlStatementRequest;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import java.util.List;
+import java.util.Set;
+
+/** Framework-free smoke test for Phase 3 Datasource domain contracts. */
+public final class DatasourceDomainSmoke {
+
+  private DatasourceDomainSmoke() {}
+
+  public static void main(String[] args) {
+    CatalogReadRequest catalog =
+        new CatalogReadRequest(
+            ReadMode.SQL,
+            null,
+            "select * from orders where day = ${day}",
+            List.of(new Variable("day", "2026-08-23")));
+    require(catalog.sqlMode(), "Catalog SQL mode was lost");
+    require(catalog.variables().size() == 1, "Catalog variable projection was lost");
+
+    SqlExecutionPlan plan =
+        new SqlExecutionPlan(
+            "42",
+            List.of(
+                new SqlStatementRequest("select 1", 10, 5),
+                new SqlStatementRequest("update demo set enabled = 1", 10, 5)),
+            SqlExecutionContext.of(SqlExecutionCaller.CONSOLE, "smoke"));
+    SqlExecutionAggregate execution =
+        new SqlExecutionAggregate(
+            "sql-smoke",
+            plan,
+            List.of(
+                classification(SqlStatementType.SELECT),
+                classification(SqlStatementType.UPDATE)));
+
+    require(execution.snapshot().status() == SqlExecutionStatus.PENDING, "Execution must start PENDING");
+    execution.markRunning();
+    execution.markStatementRunning(0);
+    execution.markStatementFailed(0, "smoke failure");
+    execution.finishFailed(1, "smoke failure");
+
+    require(execution.snapshot().status() == SqlExecutionStatus.FAILED, "Execution failure terminal state was lost");
+    require(
+        execution.snapshot().statements().get(0).status() == SqlStatementStatus.FAILED,
+        "Failed statement state was lost");
+    require(
+        execution.snapshot().statements().get(1).status() == SqlStatementStatus.SKIPPED,
+        "Remaining statement must be SKIPPED");
+
+    System.out.println("Datasource Phase 3 domain smoke: OK");
+  }
+
+  private static SqlStatementClassification classification(SqlStatementType type) {
+    return new SqlStatementClassification(type, Set.of(type));
+  }
+
+  private static void require(boolean condition, String message) {
+    if (!condition) throw new IllegalStateException(message);
+  }
+}

--- a/tools/datasource_domain_guardrails.py
+++ b/tools/datasource_domain_guardrails.py
@@ -13,6 +13,8 @@ ROOT = Path(__file__).resolve().parents[1]
 MODULE = ROOT / "yak-ops-business/yak-ops-business-datasource"
 JAVA_ROOT = MODULE / "src/main/java/io/yak/ops/business/datasource"
 DOMAIN_DIR = JAVA_ROOT / "domain"
+CATALOG_DOMAIN_DIR = DOMAIN_DIR / "catalog"
+EXECUTION_DOMAIN_DIR = JAVA_ROOT / "execution/domain"
 GATEWAY_DIR = JAVA_ROOT / "gateway"
 
 CORE_FILES = (
@@ -20,6 +22,15 @@ CORE_FILES = (
     "DataSourceDefinition.java",
     "DataSourceQuery.java",
     "DataSourceSummary.java",
+)
+
+CATALOG_DOMAIN_FILES = (
+    "CatalogReadRequest.java",
+    "CatalogTableQuery.java",
+    "CatalogTablePath.java",
+    "CatalogTable.java",
+    "CatalogColumn.java",
+    "CatalogQueryResult.java",
 )
 
 FORBIDDEN_IMPORTS = (
@@ -51,6 +62,7 @@ PROTECTED_APPLICATION_FILES = (
     "service/impl/DataSourceServiceImpl.java",
     "service/impl/DataSourceCatalogServiceImpl.java",
     "service/support/DataSourceViewMapper.java",
+    "execution/DefaultSqlExecutionRuntime.java",
 )
 
 
@@ -89,14 +101,17 @@ def imports_of(text: str) -> list[str]:
     return re.findall(r"(?m)^\s*import\s+(?:static\s+)?([^;]+);", text)
 
 
+def check_no_forbidden_imports(g: Guard, name: str, text: str) -> None:
+    for imported in imports_of(text):
+        g.check(
+            not imported.startswith(FORBIDDEN_IMPORTS),
+            f"{name}: framework/adapter import is forbidden: {imported}",
+        )
+
+
 def check_core(g: Guard) -> None:
     for name in CORE_FILES:
-        text = g.read(DOMAIN_DIR / name)
-        for imported in imports_of(text):
-            g.check(
-                not imported.startswith(FORBIDDEN_IMPORTS),
-                f"{name}: framework/adapter import is forbidden: {imported}",
-            )
+        check_no_forbidden_imports(g, name, g.read(DOMAIN_DIR / name))
 
     definition = g.read(DOMAIN_DIR / "DataSourceDefinition.java")
     profile = g.read(DOMAIN_DIR / "ConnectionProfile.java")
@@ -124,6 +139,31 @@ def check_core(g: Guard) -> None:
         )
 
 
+def check_catalog_domain(g: Guard) -> None:
+    for name in CATALOG_DOMAIN_FILES:
+        text = g.read(CATALOG_DOMAIN_DIR / name)
+        check_no_forbidden_imports(g, f"catalog/{name}", text)
+
+    request = g.read(CATALOG_DOMAIN_DIR / "CatalogReadRequest.java")
+    g.check("enum ReadMode" in request, "CatalogReadRequest must own explicit TABLE/SQL mode")
+    g.check("TABLE" in request and "SQL" in request, "Catalog read modes must remain explicit")
+
+    gateway = g.read(GATEWAY_DIR / "DataSourceCatalogGateway.java")
+    code = code_only(gateway)
+    g.check("CatalogReadRequest" in gateway, "Catalog gateway must use typed CatalogReadRequest")
+    g.check("Map<String" not in code and "Map<" not in code, "Catalog gateway must not expose Map protocol")
+    for name in ("CatalogTable", "CatalogColumn", "CatalogQueryResult"):
+        g.check(name in gateway, f"Catalog gateway must expose business catalog model: {name}")
+
+    service = g.read(JAVA_ROOT / "service/impl/DataSourceCatalogServiceImpl.java")
+    g.check("toCatalogReadRequest(" in service, "HTTP Catalog Map must be parsed once at application boundary")
+    g.check("CatalogReadRequest" in service, "Catalog application service must use typed request")
+
+    adapter = g.read(GATEWAY_DIR / "adapter/SpiDataSourceCatalogGateway.java")
+    g.check("toPluginRequest(" in adapter, "SPI catalog adapter must own legacy Map projection")
+    g.check("Map<String, Object>" in adapter, "Legacy Plugin Map must stay isolated in SPI adapter")
+
+
 def check_application_mutations(g: Guard) -> None:
     service = g.read(JAVA_ROOT / "service/impl/DataSourceServiceImpl.java")
     code = code_only(service)
@@ -147,13 +187,13 @@ def check_application_mutations(g: Guard) -> None:
 
 
 def check_gateway_boundary(g: Guard) -> None:
-    plugin_port = g.read(GATEWAY_DIR / "DataSourcePluginGateway.java")
-    catalog_port = g.read(GATEWAY_DIR / "DataSourceCatalogGateway.java")
-
-    for name, text in (
-        ("DataSourcePluginGateway.java", plugin_port),
-        ("DataSourceCatalogGateway.java", catalog_port),
-    ):
+    ports = (
+        "DataSourcePluginGateway.java",
+        "DataSourceCatalogGateway.java",
+        "SqlExecutionGateway.java",
+    )
+    for name in ports:
+        text = g.read(GATEWAY_DIR / name)
         for imported in imports_of(text):
             g.check(
                 not imported.startswith(PORT_FORBIDDEN_IMPORTS),
@@ -162,8 +202,7 @@ def check_gateway_boundary(g: Guard) -> None:
 
     for relative in PROTECTED_APPLICATION_FILES:
         text = g.read(JAVA_ROOT / relative)
-        imports = imports_of(text)
-        for imported in imports:
+        for imported in imports_of(text):
             g.check(
                 not imported.startswith("io.yak.ops.spi.datasource."),
                 f"{relative}: Datasource Plugin SPI must stay behind Gateway Adapter: {imported}",
@@ -180,16 +219,66 @@ def check_gateway_boundary(g: Guard) -> None:
     service = g.read(JAVA_ROOT / "service/impl/DataSourceServiceImpl.java")
     catalog_service = g.read(JAVA_ROOT / "service/impl/DataSourceCatalogServiceImpl.java")
     view_mapper = g.read(JAVA_ROOT / "service/support/DataSourceViewMapper.java")
+    runtime = g.read(JAVA_ROOT / "execution/DefaultSqlExecutionRuntime.java")
     g.check("DataSourcePluginGateway" in service, "DataSourceServiceImpl must use DataSourcePluginGateway")
     g.check("DataSourceCatalogGateway" in catalog_service, "DataSourceCatalogServiceImpl must use DataSourceCatalogGateway")
     g.check("DataSourcePluginGateway" in view_mapper, "DataSourceViewMapper must use DataSourcePluginGateway for masking")
+    g.check("SqlExecutionGateway" in runtime, "DefaultSqlExecutionRuntime must use SqlExecutionGateway")
 
-    plugin_adapter = g.read(GATEWAY_DIR / "adapter/SpiDataSourcePluginGateway.java")
-    catalog_adapter = g.read(GATEWAY_DIR / "adapter/SpiDataSourceCatalogGateway.java")
-    g.check("implements DataSourcePluginGateway" in plugin_adapter, "SPI plugin adapter must implement business port")
-    g.check("implements DataSourceCatalogGateway" in catalog_adapter, "SPI catalog adapter must implement business port")
-    g.check("io.yak.ops.spi.datasource" in plugin_adapter, "SPI plugin adapter must own plugin protocol translation")
-    g.check("io.yak.ops.spi.datasource" in catalog_adapter, "SPI catalog adapter must own catalog protocol translation")
+    adapters = (
+        ("adapter/SpiDataSourcePluginGateway.java", "implements DataSourcePluginGateway"),
+        ("adapter/SpiDataSourceCatalogGateway.java", "implements DataSourceCatalogGateway"),
+        ("adapter/SpiSqlExecutionGateway.java", "implements SqlExecutionGateway"),
+    )
+    for relative, marker in adapters:
+        text = g.read(GATEWAY_DIR / relative)
+        g.check(marker in text, f"{relative}: SPI adapter must implement business port")
+        g.check("io.yak.ops.spi.datasource" in text, f"{relative}: adapter must own plugin protocol translation")
+
+
+def check_sql_execution_domain(g: Guard) -> None:
+    aggregate = g.read(EXECUTION_DOMAIN_DIR / "SqlExecutionAggregate.java")
+    for imported in imports_of(aggregate):
+        g.check(
+            not imported.startswith("io.yak.ops.spi.datasource."),
+            f"SqlExecutionAggregate must not import datasource SPI: {imported}",
+        )
+        g.check(
+            not imported.startswith("org.springframework."),
+            f"SqlExecutionAggregate must not import Spring: {imported}",
+        )
+        g.check(
+            not imported.startswith("java.util.concurrent."),
+            f"SqlExecutionAggregate must not own concurrency runtime: {imported}",
+        )
+
+    code = code_only(aggregate)
+    for behavior in (
+        "requestCancel(",
+        "markRunning(",
+        "markStatementRunning(",
+        "markStatementSucceeded(",
+        "finishSucceeded(",
+        "finishFailed(",
+        "finishTimedOut(",
+        "finishCancelled(",
+        "snapshot(",
+    ):
+        g.check(behavior in code, f"SqlExecutionAggregate lifecycle behavior missing: {behavior}")
+
+    runtime = g.read(JAVA_ROOT / "execution/DefaultSqlExecutionRuntime.java")
+    runtime_code = code_only(runtime)
+    for forbidden in (
+        "DataSourceExecutionProvider",
+        "DataSourceSqlExecutor",
+        "DataSourceSqlRequest",
+        "DataSourceSqlResult",
+        "class ManagedExecution",
+        "class MutableStatement",
+    ):
+        g.check(forbidden not in runtime_code, f"DefaultSqlExecutionRuntime leaked physical/lifecycle concern: {forbidden}")
+    g.check("SqlExecutionAggregate" in runtime, "Runtime must delegate lifecycle to SqlExecutionAggregate")
+    g.check("SqlExecutionGateway" in runtime, "Runtime must delegate physical SQL to SqlExecutionGateway")
 
 
 def check_docs(g: Guard) -> None:
@@ -208,7 +297,7 @@ def check_docs(g: Guard) -> None:
             f"{name} exceeds {limit} lines; keep module contracts concise",
         )
 
-    for phrase in ("核心能力", "模块边界", "Requirement Gap"):
+    for phrase in ("核心能力", "模块边界", "Requirement Gap", "CatalogReadRequest", "SQL Execution"):
         g.check(phrase in requirements, f"REQUIREMENTS.md lost required phrase: {phrase}")
 
     for phrase in (
@@ -217,6 +306,9 @@ def check_docs(g: Guard) -> None:
         "12 条硬规则",
         "DataSourcePluginGateway",
         "DataSourceCatalogGateway",
+        "CatalogReadRequest",
+        "SqlExecutionGateway",
+        "SqlExecutionAggregate",
         "Domain Impact Analysis",
         "Domain Compliance Report",
         "Domain Gap",
@@ -232,6 +324,8 @@ def check_docs(g: Guard) -> None:
         "Missing Tests",
         "DataSourcePluginGateway",
         "DataSourceCatalogGateway",
+        "SqlExecutionGateway",
+        "SqlExecutionAggregate",
     ):
         g.check(phrase in review, f"REVIEW.md lost review protocol phrase: {phrase}")
 
@@ -263,8 +357,10 @@ def main() -> int:
 
     g = Guard()
     check_core(g)
+    check_catalog_domain(g)
     check_application_mutations(g)
     check_gateway_boundary(g)
+    check_sql_execution_domain(g)
     check_docs(g)
     check_pr(g, args.event)
     return g.finish()

--- a/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
@@ -1,135 +1,123 @@
 # Datasource Domain
 
-> 本文件只保留**实现必须遵守的硬规则**，不记录设计过程。历史演进看 Git / PR。
->
-> `REQUIREMENTS.md` 定义“需要什么”；`DOMAIN.md` 定义“不能违反什么”；`REVIEW.md` 定义“怎么判卷”。
+> 本文件只保留**实现必须遵守的硬规则**。`REQUIREMENTS.md` 定义需要什么；`DOMAIN.md` 定义不能违反什么；`REVIEW.md` 定义怎么判卷。
 
 ## 核心模型
 
 ```text
-DataSourceDefinition  (Aggregate Root，当前保留历史命名)
-├── id / name / dbType / environment
-├── ConnectionProfile
-│   ├── jdbcUrl
-│   ├── normalizedJson
-│   └── originalJson
-├── connectionStatus
-├── remark
-└── timestamps
+DataSourceDefinition (Aggregate Root)
+└── ConnectionProfile
+
+Catalog Subdomain
+├── CatalogReadRequest
+├── CatalogTableQuery / CatalogTablePath
+├── CatalogTable / CatalogColumn
+└── CatalogQueryResult
+
+SQL Execution
+├── yak-ops-core: SqlExecutionRequest / Plan / Result / Snapshot
+├── SqlExecutionAggregate          <- lifecycle truth
+└── SqlExecutionGateway            <- physical execution Port
 ```
 
 ```text
-Application Service
-   │
-   ├── DataSourceRepository         -> Repository Adapter -> DAO / PO
-   │
-   ├── DataSourcePluginGateway      <- SPI Plugin Adapter  -> Plugin SPI
-   │
-   └── DataSourceCatalogGateway     <- SPI Catalog Adapter -> Plugin SPI
+Application
+   ├── DataSourceRepository      -> Repository Adapter -> DAO / PO
+   ├── DataSourcePluginGateway   <- SPI Adapter -> Plugin SPI
+   ├── DataSourceCatalogGateway  <- SPI Adapter -> Plugin SPI
+   └── SqlExecutionGateway       <- SPI Adapter -> Execution SPI
 ```
 
-Datasource Plugin SPI 是**邻接上下文**，不是 Core Domain，也不是 Application Contract。
+Datasource Plugin SPI 是邻接上下文，不是 Core Domain，也不是 Application Contract。
 
 ## 12 条硬规则
 
-1. **`DataSourceDefinition` 是 Business Datasource 当前唯一数据源业务事实。** DTO、VO、PO、Plugin SPI Model 都只是 Adapter / Projection / Protocol Model。
-2. **`ConnectionProfile` 是连接配置的领域值对象。** 新业务代码修改连接配置必须经过 Aggregate 行为，不直接散落修改 `jdbcUrl / connectionParams / originalJson`。
-3. **DataSource Type 创建后不可修改。** 更新时请求类型必须与 Aggregate 当前 `dbType` 一致。
-4. **连接配置被替换后，连接状态必须回到 `UNKNOWN`。** 旧配置的 `CONNECTED / DISCONNECTED` 不能继承给新配置。
-5. **`CONNECTED / DISCONNECTED` 只表示最近一次针对当前已保存配置的连接测试结果。** 配置可解析不等于连接成功；未保存配置测试不持久化状态。
-6. **Core Domain 不依赖 Spring / MyBatis / HTTP DTO / VO / PO / Datasource Plugin SPI。** JDBC、Catalog 实现和插件私有参数属于边界之外。
-7. **Application 主链路不得直接依赖 Datasource Plugin SPI 或 `DataSourcePluginRegistry`。** 数据源管理通过 `DataSourcePluginGateway`，Catalog 通过 `DataSourceCatalogGateway`；SPI 类型转换与异常映射只在 Adapter 内完成。
-8. **Business Gateway Contract 不暴露 Plugin SPI、HTTP DTO / VO 或 PO。** Gateway 内部模型属于边界协议，不可被当成新的全局领域事实。
-9. **Repository Contract 只暴露 Domain。** PO、MyBatis `IPage`、Mapper Row 不得越过 Repository Adapter。
-10. **Secret 不是可观察业务数据。** 完整连接 JSON、密码、Token 不得进入 `toString()`、普通日志或未脱敏响应；插件相关 Secret 处理必须留在 Gateway Adapter 边界。
-11. **新的业务语义优先扩明确领域模型。** 不通过新增 `Map<String, Object>` key、临时 boolean、展示 VO 字段或 SPI 私有字段绕过 Domain Gap。
-12. **无法映射现有模型就是 `Domain Gap`。** 先讨论模型和边界，不用 DTO / VO / PO / Plugin Model / Gateway 临时字段冒充 Domain。
+1. **`DataSourceDefinition` 是数据源配置唯一业务事实。** DTO、VO、PO、Plugin SPI Model 不能替代 Domain。
+2. **`ConnectionProfile` 是连接配置值对象。** 修改连接配置必须通过 Aggregate 行为；`dbType` 创建后不可修改；配置变化后状态回到 `UNKNOWN`。
+3. **连接状态只描述当前已保存配置最近一次真实连接测试。** 成功 `CONNECTED`，连通失败 `DISCONNECTED`；未保存配置测试不持久化状态。
+4. **Core Domain 不依赖 Spring / MyBatis / HTTP DTO / VO / PO / Datasource Plugin SPI。** Secret、JDBC、插件私参属于边界之外。
+5. **Application 主链路只依赖 Business Port。** `DataSourceServiceImpl`、`DataSourceCatalogServiceImpl`、`DataSourceViewMapper`、`DefaultSqlExecutionRuntime` 不直接依赖 Datasource Plugin SPI。
+6. **Business Gateway Contract 不暴露 Plugin SPI、HTTP DTO / VO、PO。** SPI 类型转换与异常映射只在 `gateway.adapter`。
+7. **Catalog 内部必须类型化。** HTTP `Map<String,Object>` 只允许在兼容入口解析成 `CatalogReadRequest`；`DataSourceCatalogGateway` 禁止 Map 协议。旧 Plugin SPI Map 只能由 SPI Adapter 投影。
+8. **Catalog Metadata 是 Business-owned Domain。** `CatalogTable / CatalogColumn / CatalogQueryResult` 不以 SPI Table / Column / QueryResult 为 identity。
+9. **SQL Execution 不复制 `yak-ops-core` contract。** Request / Plan / Result / Snapshot 的公共真相继续由 core 提供；Datasource 只拥有生命周期与物理数据源适配。
+10. **`SqlExecutionAggregate` 拥有执行和 Statement 状态变化。** Runtime 负责线程、Future、Session、I/O；不得重新在 Runtime 中维护第二套 PENDING/RUNNING/终态状态机。
+11. **物理 SQL 只能通过 `SqlExecutionGateway`。** `DefaultSqlExecutionRuntime` 不直接持有 `DataSourceExecutionProvider / DataSourceSqlExecutor / DataSourceSqlRequest / DataSourceSqlResult`。
+12. **无法表达现有需求就是 `Domain Gap`。** 不通过隐藏 Map key、临时 boolean、VO 字段或 Plugin 私有字段绕过模型。
 
-## 关键不变量
+## DataSource 不变量
 
-- `name`、`dbType`、`environment`、`ConnectionProfile.normalizedJson` 必须存在。
-- `dbType` 一旦创建不可变。
-- `ConnectionProfile` 变更后 `connectionStatus = UNKNOWN`。
-- 已保存配置测试成功：`connectionStatus = CONNECTED`。
-- 已保存配置测试失败：`connectionStatus = DISCONNECTED`。
-- 未保存配置测试不修改 Aggregate。
-- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper` 不直接出现 Datasource Plugin SPI 类型。
+- `name / dbType / environment / ConnectionProfile.normalizedJson` 必须存在。
+- `dbType` 不可变。
+- ConnectionProfile 变化 -> `UNKNOWN`。
+- 已保存连接测试成功 -> `CONNECTED`；连通失败 -> `DISCONNECTED`。
+- Secret、完整连接 JSON、可能携带凭据的 JDBC URL 不得进入普通日志或 `toString()`。
 
-## 命令语义
+## Catalog 不变量
 
 ```text
-Create
-  -> Plugin Gateway normalize
-  -> new DataSourceDefinition / ConnectionProfile
-  -> UNKNOWN
-
-Update
-  -> same dbType
-  -> Plugin Gateway merge secret + normalize
-  -> Aggregate updateConfiguration
-  -> UNKNOWN
-
-TestConnection(saved)
-  -> Plugin Gateway
-  -> success -> CONNECTED
-  -> failure -> DISCONNECTED
-
-TestConnection(unsaved)
-  -> Plugin Gateway validation only
-  -> no persisted state
-
-Catalog
-  -> load DataSourceDefinition
-  -> validate application request
-  -> Catalog Gateway
-  -> SPI Adapter converts protocol model
+HTTP Map
+  -> Application parse once
+  -> CatalogReadRequest
+  -> read-only validation
+  -> DataSourceCatalogGateway
+  -> SpiDataSourceCatalogGateway
+  -> legacy Plugin Map
 ```
+
+- `TABLE` 模式必须有 `tablePath`；`SQL` 模式必须有 `sql`。
+- preview / count / describe 的 SQL 模式只允许单条 SELECT。
+- `paramsList` 等历史字段只在兼容入口和 Adapter 之间映射，不是 Domain extension point。
+- 新 Catalog 语义先扩 typed Domain，不增加隐藏 Map key。
+
+## SQL Execution 生命周期
+
+```text
+PENDING
+  -> RUNNING
+  -> CANCELLING
+  -> SUCCEEDED | FAILED | CANCELLED | TIMED_OUT
+```
+
+Statement 终态为 `SUCCEEDED / FAILED / CANCELLED / TIMED_OUT / SKIPPED`。
+
+- Cancel 请求不能把已终态执行重新打开。
+- 失败/取消/超时后，未执行 Statement 必须进入 `SKIPPED`。
+- Statement timeout 必须使 Execution 收敛到 `TIMED_OUT`。
+- `SINGLE_TRANSACTION` 的 begin/execute/commit/rollback 必须使用同一 Gateway Session。
+- 物理 cancel 是 best-effort；领域终态不能悬空。
 
 ## Gateway / Adapter 边界
 
-允许的依赖方向：
+允许：
 
 ```text
-Application -> Business Gateway Port <- SPI Adapter -> Datasource Plugin SPI
+Application / Runtime -> Business Gateway Port <- SPI Adapter -> Datasource Plugin SPI
 ```
 
 禁止：
 
 ```text
-Application -> DataSourcePlugin / DataSourceConnection / DataSourceCatalog
-Application -> SPI metadata/query model
+Application / Runtime -> Datasource Plugin SPI
 Business Gateway Port -> SPI model
+Catalog Domain -> HTTP Map / SPI model
+SqlExecutionAggregate -> Spring / concurrency / physical Session
 Core Domain -> Gateway / SPI
-SPI model -> Domain identity
 ```
 
-当前明确例外：
+当前兼容例外：
 
-- `DataSourcePluginConfigServiceImpl` 仍承接历史 `pluginConfig() -> DataSourcePluginConfigVO`，直到 Plugin Descriptor / Form Contract 去 VO 化。
-- `BusinessDataSourceExecutionProvider` 自身是向 Task Plugin SPI 暴露执行能力的 Adapter，可以依赖相关 SPI。
-- `DataSourceSecretCodec` 是 SPI Adapter 的技术 helper，不是 Domain Service。
+- `DataSourcePluginConfigServiceImpl` 仍承接历史 `pluginConfig() -> DataSourcePluginConfigVO`。
+- `BusinessDataSourceExecutionProvider` 是向 Task Plugin SPI 暴露 Executor 的外向 Adapter。
+- `DataSourceSecretCodec` 是 SPI Adapter technical helper。
 
-这些例外不得扩散到新的 Application 主链路。
-
-## Catalog Gateway 当前定位
-
-Phase 2 的 `DataSourceCatalogGateway.Table / Column / QueryResult` 是**Business-owned boundary contract**，作用只是阻止 SPI Model 穿透。
-
-它们暂时不是最终 Catalog Domain Model；`Map<String, Object>` 请求协议仍是已知 Gap。Phase 3 负责类型化 Catalog Request / Result，并决定哪些模型提升为正式 Domain。
+例外不得扩散到新的主链路。
 
 ## 持久化兼容
 
-当前物理表仍然是：
+`yak_ops_data_source` 以及 `jdbc_url / connection_params / original_json / conn_status` 保持现状；它们是持久化投影，由 Repository Adapter 映射。
 
-```text
-yak_ops_data_source
-```
-
-`jdbc_url / connection_params / original_json / conn_status` 是持久化投影，不定义业务边界。Repository Adapter 继续负责 Domain 与持久化模型之间的映射。
-
-## 修改代码前后
-
-修改前：
+## 修改前后
 
 ```text
 Domain Impact Analysis
@@ -137,18 +125,12 @@ Domain Impact Analysis
 - Invariant/lifecycle impact:
 - Layer:
 - Domain Gap: yes/no
-```
 
-修改后：
-
-```text
 Domain Compliance Report
 - Rule changed/implemented:
 - Safety/tests:
 - Known gaps:
 ```
-
-代码 Review 固定按 `REVIEW.md` 执行。
 
 ## 自动护栏
 
@@ -156,22 +138,23 @@ Domain Compliance Report
 
 ```text
 Core Domain dependency guardrail
-Repository boundary guardrail
-Application -> Gateway dependency guardrail
-Gateway Port no SPI/DTO/VO/PO guardrail
-SPI Adapter translation tests
-ConnectionProfile / connection status behavior tests
+Application / Runtime -> Gateway only
+Gateway Port no SPI/DTO/VO/PO
+Catalog Gateway no Map protocol
+Catalog typed boundary tests
+SqlExecutionAggregate lifecycle tests
+SqlExecutionGateway SPI adapter tests
+ConnectionProfile / connection status tests
 ```
 
-**不要因为功能被护栏拦住就删护栏。** 如果规则真的变化，同一个 PR 中同步修改 `DOMAIN.md` 和对应测试。
+**不要通过删护栏或放宽文档预算绕过失败。** 规则真实变化时，同一个 PR 同步修改文档与测试。
 
 ## 已知独立 Gap
 
 ```text
-Catalog Domain Model / typed Map protocol
-SQL Execution Domain Model
 Plugin Capability / Descriptor
 Plugin API VO dependency
 PluginConfig compatibility bridge cleanup
+Plugin Catalog Map SPI 最终类型化
 Aggregate physical naming cleanup
 ```

--- a/yak-ops-business/yak-ops-business-datasource/README.md
+++ b/yak-ops-business/yak-ops-business-datasource/README.md
@@ -1,6 +1,6 @@
 # Yak Ops Datasource
 
-数据源模块负责数据源注册、连接测试、Catalog 元数据访问和数据源插件编排，并为数据开发、同步和任务等上层模块提供稳定的数据源引用。
+数据源模块负责数据源注册、连接测试、Catalog 元数据访问、SQL Execution 和数据源插件编排，并为数据开发、同步、任务等上层模块提供稳定的数据源引用。
 
 ## 开发前必读
 
@@ -12,122 +12,118 @@ REVIEW.md        -> 按什么标准 Review
 
 三份文档只维护当前有效规则，历史设计过程看 Issue / PR / Git。
 
-## 核心领域模型
+## 核心模型
 
 ```text
-DataSourceDefinition  (Aggregate Root，当前保留历史命名)
-├── identity / name / dbType / environment
-├── ConnectionProfile
-│   ├── jdbcUrl
-│   ├── normalizedJson
-│   └── originalJson
-├── connectionStatus
-├── remark
-└── timestamps
+DataSourceDefinition (Aggregate Root)
+└── ConnectionProfile
+
+Catalog Domain
+├── CatalogReadRequest
+├── CatalogTableQuery / CatalogTablePath
+├── CatalogTable / CatalogColumn
+└── CatalogQueryResult
+
+SQL Execution
+├── yak-ops-core canonical Request / Plan / Result / Snapshot
+├── SqlExecutionAggregate
+└── SqlExecutionGateway
 ```
 
-关键业务规则：
-
-- 数据源类型创建后不可修改。
-- 新建数据源连接状态为 `UNKNOWN`。
-- 修改连接配置后，旧连接测试结果失效并回到 `UNKNOWN`。
-- 已保存数据源连接测试成功进入 `CONNECTED`，失败进入 `DISCONNECTED`。
-- 未保存配置的连接测试不产生持久化状态。
-- Secret、完整连接 JSON 和可能携带凭据的 JDBC URL 不得通过 `toString()` 或普通日志输出。
-
-详细规则见 `DOMAIN.md`。
+关键规则：数据源类型创建后不可修改；连接配置变化回到 `UNKNOWN`；Secret 不输出；Catalog 内部 typed；SQL 生命周期由 Aggregate 管理，物理执行经 Gateway。
 
 ## 工程分层
 
 ```text
-Controller
-    ↓
-Application Service / View Mapper
-    ↓
+Controller / Application
+      ↓
 Domain + Business Gateway Port
-    ↓                 ↑
-Repository Adapter    │
-    ↓             SPI Gateway Adapter
-DAO / PO              ↓
-                  Datasource Plugin SPI
-                         ↓
-                  Plugin Implementation
+      ↓                     ↑
+Repository Adapter      SPI Gateway Adapter
+      ↓                     ↓
+DAO / PO             Datasource Plugin SPI
 ```
 
-Phase 2 后，数据源管理和 Catalog 主链路不再直接认识 `DataSourcePlugin`、`DataSourceConnection`、`DataSourceCatalog` 或 SPI Metadata Model：
+主要边界：
 
 ```text
-DataSourceServiceImpl
-    -> DataSourcePluginGateway
-    <- SpiDataSourcePluginGateway
-    -> Datasource Plugin SPI
-
-DataSourceCatalogServiceImpl
-    -> DataSourceCatalogGateway
-    <- SpiDataSourceCatalogGateway
-    -> Datasource Plugin SPI
+DataSourceServiceImpl -> DataSourcePluginGateway <- SpiDataSourcePluginGateway
+DataSourceCatalogServiceImpl -> DataSourceCatalogGateway <- SpiDataSourceCatalogGateway
+DefaultSqlExecutionRuntime -> SqlExecutionGateway <- SpiSqlExecutionGateway
 ```
 
-SPI Adapter 负责：
+SPI Adapter 负责插件发现、Connection 解析、Secret 处理、Catalog 协议转换、SQL Executor 适配和异常边界；Application / Runtime 不直接持有 Datasource Plugin SPI。
 
-- 插件发现与路由；
-- Connection 解析与规范化；
-- Secret 合并和展示脱敏；
-- 连接测试异常映射；
-- Catalog 创建和调用；
-- SPI Table / Column / QueryResult -> Business Gateway Contract 转换。
+## Catalog 类型化
+
+现有 REST POST 接口为兼容前端仍接受 `Map<String,Object>`，但 Map 只存在于入口：
+
+```text
+HTTP Map
+  -> DataSourceCatalogServiceImpl
+  -> CatalogReadRequest
+  -> DataSourceCatalogGateway
+  -> SpiDataSourceCatalogGateway
+  -> legacy Plugin Map
+```
+
+支持的历史字段为 `read_mode/readMode`、`table_path/tablePath/table`、`query/sql`、`paramsList`。未知 Map key 不再作为 Business 扩展协议；新语义必须进入 typed Catalog Domain。
+
+Catalog 的 Table / Column / QueryResult 由 Business 自己拥有，Plugin SPI metadata 只能在 Adapter 中转换。
+
+## SQL Execution
+
+`yak-ops-core` 已定义跨模块统一 SQL contract，因此 Datasource 不复制同名 DTO：
+
+```text
+SqlExecutionRequest / SqlExecutionPlan
+  -> SqlExecutionPolicy
+  -> SqlExecutionAggregate
+  -> DefaultSqlExecutionRuntime
+  -> SqlExecutionGateway
+  -> Datasource execution SPI
+```
+
+职责拆分：
+
+- `SqlExecutionAggregate`：Execution / Statement 状态、取消意图、终态和 Snapshot。
+- `DefaultSqlExecutionRuntime`：线程、Future、事务编排、物理 Session、超时异常识别。
+- `SqlExecutionGateway`：Datasource 物理 SQL Session Port。
+- `SpiSqlExecutionGateway`：`DataSourceExecutionProvider / DataSourceSqlExecutor` 的唯一 Runtime Adapter。
+- `ObservableSqlExecutionRuntime`：终态观察和审计通知，不改变底层生命周期。
 
 ## 分层约束
 
-- Controller 只通过 Service 进入业务链路，不直接依赖 Repository、DAO、Mapper 或插件实现。
-- Application Service 使用 Domain + Repository Port + Business Gateway，不直接注入 Datasource Plugin Registry。
-- `DataSourcePluginGateway` / `DataSourceCatalogGateway` 不暴露 Plugin SPI、HTTP DTO / VO 或 PO。
-- SPI 具体模型只能存在于 `gateway.adapter`、plugin registry/helper 或明确的外向 SPI Adapter 中。
-- Repository 接口只暴露 Domain；PO 仅存在于 Adapter / DAO / Mapper 持久化层。
-- Core Domain 不依赖 Spring、MyBatis、HTTP DTO / VO / PO 或 Datasource Plugin SPI。
-- HTTP 详情通过 `DataSourceViewMapper -> DataSourcePluginGateway` 完成连接地址与连接 JSON 脱敏。
-- Catalog 的只读校验仍由 Application Service 承担，物理 Catalog 访问和 SPI 模型转换由 Gateway Adapter 承担。
-- `Map<String, Object>` Catalog 请求是当前兼容协议，不允许继续用新增隐式 key 扩展业务语义；Phase 3 负责类型化。
+- Controller 只通过 Service 进入业务链路。
+- Repository 只暴露 Domain，PO/MyBatis 只在持久化 Adapter 内。
+- Core Domain 不依赖 Spring、MyBatis、DTO / VO / PO、Datasource Plugin SPI。
+- `DataSourcePluginGateway / DataSourceCatalogGateway / SqlExecutionGateway` 不暴露 Plugin SPI、DTO / VO 或 PO。
+- `DataSourceCatalogGateway` 不接受 `Map<String,Object>`。
+- `DefaultSqlExecutionRuntime` 不直接依赖 datasource execution SPI。
+- Catalog 只读检查仍在 Application 层；物理访问由 Adapter 执行。
+- Secret 脱敏通过 `DataSourceViewMapper -> DataSourcePluginGateway` 完成。
 
-## 当前兼容边界
+## 兼容边界
 
-Phase 2 不修改：
+Phase 3 不修改：
 
 ```text
-REST API
-DTO / VO JSON 结构
+REST API 路径和主要 JSON 结构
 yak_ops_data_source 表结构
 Flyway 历史
 Datasource Plugin SPI 签名
 MySQL / PostgreSQL / Oracle / Doris 等插件实现
+yak-ops-core SQL Execution contract
 ```
 
-两个明确的兼容例外：
-
-- `DataSourcePluginConfigServiceImpl` 当前仍承接 `pluginConfig() -> DataSourcePluginConfigVO` 历史协议；插件 Descriptor / Form Model 去 VO 化留给后续 Plugin API 标准化。
-- `BusinessDataSourceExecutionProvider` 本身是向 Task Plugin SPI 暴露 SQL Executor 的 Adapter，因此允许在 Adapter 边界依赖相关 SPI。
-
-## 持久化
-
-当前数据源管理继续维护现有业务表：
-
-```text
-yak_ops_data_source
-```
-
-`jdbc_url / connection_params / original_json / conn_status` 是持久化投影，不是新的领域边界。
-
-业务模块共享 `yak.database` 对应的 `yakBusinessDataSource`、MyBatis SessionFactory 和事务管理器；数据源模块继续拥有自己的 Flyway migration location/history 边界。
+当前例外：`DataSourcePluginConfigServiceImpl` 仍承接历史 PluginConfig VO；`BusinessDataSourceExecutionProvider` 是向 Task Plugin SPI 暴露 Executor 的外向 Adapter。这两项留给后续 Plugin API 标准化。
 
 ## 后续领域 Gap
 
-当前明确留给后续阶段处理：
-
 ```text
-Catalog Domain Model / typed request protocol
-SQL Execution Domain Model
 Plugin Capability / Descriptor
 Plugin API VO dependency
 PluginConfig compatibility bridge cleanup
-Aggregate physical naming cleanup
+Plugin Catalog Map SPI 最终类型化
+DataSourceDefinition 物理命名清理
 ```

--- a/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
@@ -4,120 +4,132 @@
 
 ## 目标
 
-Datasource 提供 Yak Ops 的统一数据源控制面：注册和维护数据源配置、验证连接可用性、访问 Catalog 元数据，并向上层业务提供稳定的数据源引用和基础查询能力。
+Datasource 提供 Yak Ops 的统一数据源控制面：维护数据源配置、验证连接、访问 Catalog 元数据，并向数据开发、同步、任务等模块提供稳定的数据源引用和 SQL 执行能力。
 
 ## 核心能力
 
 - 创建、编辑、查询和删除数据源。
-- 支持数据源名称、类型、运行环境、备注和连接配置管理。
+- 管理名称、类型、运行环境、备注和连接配置。
 - 支持已保存数据源和未保存配置的连接测试。
-- 记录数据源最近一次连接测试结果：`UNKNOWN / CONNECTED / DISCONNECTED`。
+- 记录最近一次已保存配置的连接测试结果：`UNKNOWN / CONNECTED / DISCONNECTED`。
 - 提供数据库、Schema、表、字段等 Catalog 元数据访问能力。
-- 提供数据预览、数量统计和 SQL 模板等轻量读取能力。
+- 提供数据预览、数量统计、SQL 模板和 SQL 变量解析能力。
+- Catalog 业务内部使用明确的 typed request / metadata / result，不依赖隐式 Map key 扩展语义。
+- 提供统一 SQL Execution contract，支持单语句、多语句、事务、取消、超时和终态观测。
 - 通过 Datasource Plugin SPI 扩展不同数据库或数据源类型。
-- 对连接密码等 Secret 做合并、脱敏和安全输出。
-- 为数据开发、同步、任务等上层模块提供稳定的数据源引用。
+- 对连接 Secret 做合并、脱敏和安全输出。
 
 ## 关键业务行为
 
-### 创建数据源
+### 数据源生命周期
 
 ```text
 Create
-  -> validate name / type / environment / connection
-  -> DataSource aggregate
-  -> connection status = UNKNOWN
-  -> persist
-```
+  -> validate + normalize
+  -> DataSourceDefinition / ConnectionProfile
+  -> UNKNOWN
 
-新建数据源不会因为“配置可被解析”就自动标记为 `CONNECTED`；只有真实连接测试成功后才能进入 `CONNECTED`。
-
-### 编辑数据源
-
-```text
 Update
-  -> load current DataSource
-  -> data source type must remain unchanged
-  -> merge stored Secret when needed
-  -> replace connection profile / metadata
-  -> connection status = UNKNOWN
-  -> persist
+  -> dbType unchanged
+  -> merge Secret + replace ConnectionProfile
+  -> UNKNOWN
+
+Test saved datasource
+  -> success: CONNECTED
+  -> connectivity failure: DISCONNECTED
+
+Test unsaved configuration
+  -> validation only
+  -> no persisted state
 ```
 
-数据源类型创建后不可修改。连接配置发生编辑后，旧连接测试结果不再代表当前配置，因此必须回到 `UNKNOWN`。
+配置可解析不等于连接成功；连接配置变化后旧测试结果失效。
 
-### 连接测试
+### Catalog
 
 ```text
-Test saved datasource
-  -> load aggregate
-  -> execute plugin connection test
-  -> success: CONNECTED
-  -> failure: DISCONNECTED
+HTTP compatibility request
+  -> typed CatalogReadRequest
+  -> read-only validation when executing preview/count/describe SQL
+  -> DataSourceCatalogGateway
+  -> Plugin Adapter
 ```
 
-未保存配置的连接测试只验证输入，不产生持久化状态。
+- 表模式必须有 `table_path`；SQL 模式必须有 `query`。
+- 预览、统计和字段探测的 SQL 模式只允许单条只读 SELECT。
+- 现有 HTTP JSON 和 Plugin SPI Map 协议保持兼容，但 Map 不是新的业务扩展机制。
+
+### SQL Execution
+
+```text
+SqlExecutionRequest / SqlExecutionPlan   (yak-ops-core canonical contract)
+  -> policy validation
+  -> SqlExecutionAggregate lifecycle
+  -> SqlExecutionGateway
+  -> physical datasource session
+```
+
+- Runtime 不自行发明第二套 Request / Plan / Snapshot 真相。
+- 多语句边界由调用方显式提供，不按分号自动拆 SQL。
+- `SINGLE_TRANSACTION` 必须在同一物理 Session 中执行；不支持事务时快速失败。
+- Cancel 是 best-effort 物理动作，但生命周期必须最终收敛到明确终态。
+- Statement timeout 必须提升为 execution `TIMED_OUT`。
+- 终态至少包括 `SUCCEEDED / FAILED / CANCELLED / TIMED_OUT`。
 
 ## 安全要求
 
 - Secret 不得通过普通 DTO / VO、异常文本、`toString()` 或业务日志明文暴露。
 - HTTP 详情中的 JDBC 地址和连接 JSON 必须经过脱敏边界。
-- 数据源编辑时允许复用已保存 Secret，但不能把掩码字符串当成真实凭据覆盖原值。
-- Domain、Repository Contract 和测试夹具不得为了调试方便打印完整连接 JSON。
+- 编辑时掩码、空值或缺失 Secret 可以沿用已保存值，但掩码不得覆盖真实凭据。
+- Dataset / Data Service / Analysis 等只读调用方不得绕过 SQL Policy 执行写操作。
+- Catalog preview/count/describe 不得绕过只读检查。
 
 ## 模块边界
 
 本模块负责：
 
-- 数据源业务定义和生命周期规则；
-- 数据源持久化；
+- DataSource 聚合与持久化；
 - 连接测试编排；
-- Catalog / 轻量读取能力的业务入口；
-- Datasource Plugin 的发现和调用边界。
+- typed Catalog 子域和轻量读取入口；
+- SQL Execution 生命周期与 Datasource 物理执行适配；
+- Datasource Plugin 的发现、调用和反腐边界。
 
 本模块不负责：
 
-- 实时同步任务的定义、发布和运行状态；
-- Flink / Flink CDC 集群生命周期；
+- 实时同步任务定义、发布和 Flink 生命周期；
 - 任意 ETL / 工作流编排；
 - 数据血缘计算；
-- JDBC Driver 或第三方数据源服务的部署；
-- 把某个插件的私有参数升级为全局业务字段。
+- JDBC Driver 或第三方服务部署；
+- 把插件私有参数升级为全局业务字段。
 
 ## 兼容性要求
 
-当前阶段保持以下外部契约兼容：
+当前阶段保持：
 
 - REST API 路径和主要请求/响应结构；
-- `yak_ops_data_source` 现有物理表结构；
-- 现有 Flyway 历史；
-- Datasource Plugin SPI 的现有签名；
-- MySQL / PostgreSQL / Oracle / Doris 等已有插件实现。
+- `yak_ops_data_source` 表结构和 Flyway 历史；
+- Datasource Plugin SPI 现有签名；
+- MySQL / PostgreSQL / Oracle / Doris 等已有插件实现；
+- `yak-ops-core` SQL Execution 对外 contract。
 
-领域改造不得以 Big-Bang 方式同时修改 REST、DB 和 Plugin SPI。
+领域改造不得 Big-Bang 同时修改 REST、DB 和 Plugin SPI。
 
 ## 当前明确未解决
 
-以下能力需要后续阶段单独设计，不在普通 Phase 1 修改中顺手完成：
-
 ```text
-Business Domain 与 Datasource Plugin SPI 的 Gateway / Adapter 隔离
-Catalog Metadata 的完整业务领域模型
-SQL Execution 的领域模型与运行时拆分
 Plugin Capability / Descriptor 标准化
 Plugin API 中 VO 依赖清理
-Map<String, Object> Catalog 协议类型化
+PluginConfig compatibility bridge cleanup
+Plugin Catalog Map SPI 的最终类型化
 DataSourceDefinition 物理命名清理
 ```
 
 ## 需求变更规则
 
-如果 PR 引入本文件没有描述的新业务能力或改变已有业务行为：
+本文件未描述的新能力或行为变化统一报告：
 
 ```text
 Requirement Gap
 ```
 
 先确认需求并更新本文件，再实现代码。Reviewer / AI 不得自行补需求。
-
-本文件只维护**当前有效需求**，不要追加迭代历史。

--- a/yak-ops-business/yak-ops-business-datasource/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-datasource/REVIEW.md
@@ -13,14 +13,7 @@ PR diff / tests  -> 实际改了什么
 
 ## 1. Requirement Alignment
 
-检查：
-
-- 是否属于 `REQUIREMENTS.md` 已有能力；
-- 是否改变创建、编辑、删除、连接测试或 Catalog 行为；
-- 是否引入未定义的新能力；
-- 是否越过 Datasource 模块边界。
-
-未定义的新能力或行为变化报告：
+检查是否属于已有能力，是否改变数据源生命周期、Catalog 或 SQL Execution 行为，是否越过模块边界。未定义的新能力统一报告：
 
 ```text
 Requirement Gap
@@ -30,25 +23,22 @@ Requirement Gap
 
 重点检查：
 
-- DTO / VO / PO / Plugin SPI Model 是否被当成业务模型；
-- `dbType` 是否可能在更新时修改；
-- ConnectionProfile 变更后是否仍保留旧连接状态；
-- 未保存连接测试是否错误写状态；
+- DTO / VO / PO / Plugin SPI Model 是否冒充 Domain；
+- `dbType` 不可变和 ConnectionProfile -> `UNKNOWN` 是否保持；
 - Core Domain 是否引入 Spring / MyBatis / Plugin SPI；
-- Repository 是否泄漏 PO / Mapper / MyBatis 类型；
-- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper` 是否直接依赖 Plugin SPI、`DataSourcePluginRegistry` 或 SPI Secret helper；
-- `DataSourcePluginGateway / DataSourceCatalogGateway` 是否暴露 Plugin SPI、HTTP DTO / VO 或 PO；
-- SPI Table / Column / QueryResult 是否绕过 Adapter 进入 Application；
-- Secret 是否进入 `toString()`、日志或未脱敏响应；
-- 是否继续通过 `Map<String, Object>` key 偷渡新业务语义。
+- Repository 是否泄漏持久化类型；
+- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper / DefaultSqlExecutionRuntime` 是否直接依赖 Datasource Plugin SPI；
+- `DataSourcePluginGateway / DataSourceCatalogGateway / SqlExecutionGateway` 是否暴露 SPI、DTO / VO 或 PO；
+- `DataSourceCatalogGateway` 是否重新接受 `Map<String,Object>`；
+- HTTP Map 是否在 Application 入口后继续传播；
+- Catalog SPI metadata 是否绕过 Adapter 进入 Domain/Application；
+- `SqlExecutionAggregate` 是否重新持有线程、Future、Spring 或物理 Session；
+- Runtime 是否重新维护第二套 Execution / Statement 状态机；
+- Runtime 是否绕过 `SqlExecutionGateway` 直接调用 datasource execution SPI；
+- Secret 是否进入日志、异常或未脱敏响应；
+- 是否通过隐藏 Map key 绕过 `Domain Gap`。
 
-违反现有规则：
-
-```text
-Domain Violation
-```
-
-现有模型无法表达需求：
+违反规则报告 `Domain Violation`；模型无法表达需求报告：
 
 ```text
 Domain Gap
@@ -56,70 +46,69 @@ Domain Gap
 
 ## 3. Correctness
 
-只检查真实风险：
+检查真实风险：
 
-- 空值、边界值、名称重复；
-- 类型 / 环境解析；
-- ConnectionProfile 规范化；
+- 空值、边界值、名称重复、类型 / 环境解析；
 - Secret 合并和脱敏；
-- Gateway Adapter 异常映射；
-- SPI metadata -> Business Gateway Contract 字段映射；
-- 事务边界；
-- 连接测试成功 / 失败状态；
-- Catalog 只读约束；
-- SQL 执行取消、超时、审计一致性。
+- Gateway Adapter 异常及字段映射；
+- Catalog TABLE / SQL 模式解析与历史 alias；
+- Catalog preview/count/describe 单条 SELECT 约束；
+- Catalog variable 投影是否保持兼容；
+- SQL Policy 是否在打开数据源前拒绝非法 SQL；
+- 多 Statement 顺序和 `SKIPPED` 语义；
+- `SINGLE_TRANSACTION` 是否同 Session begin/commit/rollback；
+- cancel、timeout、失败是否收敛到正确终态；
+- 审计观察是否不改变物理执行生命周期。
 
 ## 4. Compatibility
 
 不得无迁移方案破坏：
 
 ```text
-REST API
-yak_ops_data_source
-Flyway history
-Frontend calls
+REST API / JSON shape
+yak_ops_data_source / Flyway
 Datasource Plugin SPI
 Existing database plugins
 PluginConfig dynamic form contract
 Task Plugin SQL execution provider
+yak-ops-core SQL Execution contract
 ```
 
-禁止 Big-Bang 修改。
+禁止 Big-Bang 修改。Catalog HTTP Map 可以作为兼容入口存在；Plugin Map 可以作为 Adapter 投影存在，但两者不得重新成为 Business Contract。
 
 ## 5. Safety
 
 重点检查：
 
-- Secret 明文输出；
-- 掩码覆盖真实密码；
+- Secret 明文输出或掩码覆盖真实密码；
 - JDBC URL 凭据泄漏；
 - Gateway Adapter 吞异常或错误分类；
-- 失败连接仍显示 `CONNECTED`；
-- 新配置继承旧连接状态；
-- SQL / Catalog 绕过只读约束。
+- 连接状态错误；
+- Catalog 绕过只读检查；
+- Dataset / Data Service / Analysis 绕过 SQL read-only policy；
+- cancel 后继续执行剩余 Statement；
+- transaction 失败未 rollback；
+- timeout 被错误归类为普通 FAILED。
 
 ## 6. Tests / Guardrails
 
-每个 P0 / P1 都回答：
-
-```text
-现有哪个测试应该挡住？
-```
-
-至少应覆盖：
+每个 P0 / P1 都回答“哪个测试应该挡住”。至少覆盖：
 
 ```text
 DataSource type immutable
 ConnectionProfile change -> UNKNOWN
-connection test success -> CONNECTED
-connection test failure -> DISCONNECTED
-ConnectionProfile toString secret-free
-Core Domain dependency guardrail
-Repository boundary guardrail
-Application -> Business Gateway only
+Core Domain / Repository boundary
+Application / Runtime -> Business Gateway only
 Gateway Port no Plugin SPI / DTO / VO / PO
-SPI Connection -> ConnectionProfile mapping
-SPI Catalog metadata -> Business Gateway Contract mapping
+DataSourceCatalogGateway no Map
+HTTP Map -> CatalogReadRequest
+CatalogReadRequest -> legacy Plugin Map only in Adapter
+SPI Catalog metadata -> Catalog Domain
+SqlExecutionAggregate lifecycle
+SqlExecutionGateway SPI mapping
+policy reject before datasource open
+transaction commit / rollback / cancellation
+timeout -> TIMED_OUT
 ```
 
 ## 当前允许的边界例外
@@ -135,7 +124,7 @@ DataSourceSecretCodec
   -> SPI adapter technical helper
 ```
 
-例外不能扩散到新的 Application 主链路。
+例外不能扩散。
 
 ## 严重级别
 
@@ -148,34 +137,21 @@ P0 Blocker
 P1 Must Fix
 - 业务结果错误
 - 违反 REQUIREMENTS.md / DOMAIN.md
-- Plugin SPI 泄漏进受保护 Application 主链路
-- Gateway Port 暴露 SPI / DTO / VO / PO
-- 连接状态 / 类型不可变规则错误
-- 明确事务 / 兼容性缺陷
-- 高概率导致数据源不可用
+- SPI 泄漏进受保护主链路
+- Gateway 暴露外部模型或 Catalog Map 回流
+- SQL lifecycle / transaction / cancel / timeout 错误
+- 明确兼容性缺陷
 
 P2 Suggestion
 - 有明确收益的可维护性、性能或测试改进
 - 不阻塞合并
 ```
 
-纯命名、格式、个人风格偏好不要作为问题，除非造成真实歧义或风险。
+纯命名、格式或个人偏好不算问题，除非造成真实歧义或风险。
 
 ## 问题证据要求
 
-每个有效问题至少包含：
-
-```text
-位置：文件 / 行或方法
-级别：P0 / P1 / P2
-依据：Requirement / Domain rule / correctness fact
-场景：触发输入或调用顺序
-风险：实际结果
-建议：修复方向
-测试：应补或应命中的测试
-```
-
-没有触发场景和风险，不要凑问题。
+每个有效问题包含：位置、级别、依据、触发场景、风险、修复方向、应命中的测试。没有触发场景和实际风险，不要凑问题。
 
 ## 固定输出格式
 

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogColumn.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogColumn.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.datasource.domain.catalog;
+
+/** Business-owned column metadata. */
+public record CatalogColumn(
+    String name,
+    String typeName,
+    int jdbcType,
+    Integer size,
+    Integer scale,
+    boolean nullable,
+    int ordinalPosition,
+    boolean primaryKey,
+    String remarks) {
+
+  public CatalogColumn {
+    name = requireText(name, "Catalog 字段名不能为空");
+    typeName = normalizeNullable(typeName);
+    remarks = normalizeNullable(remarks);
+  }
+
+  private static String requireText(String value, String message) {
+    String normalized = normalizeNullable(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+
+  private static String normalizeNullable(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogQueryResult.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogQueryResult.java
@@ -1,0 +1,37 @@
+package io.yak.ops.business.datasource.domain.catalog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Immutable preview/query result inside the Catalog subdomain. */
+public record CatalogQueryResult(
+    List<QueryColumn> columns,
+    List<Map<String, Object>> rows,
+    long total) {
+
+  public CatalogQueryResult {
+    columns = columns == null ? List.of() : List.copyOf(columns);
+    if (rows == null || rows.isEmpty()) {
+      rows = List.of();
+    } else {
+      List<Map<String, Object>> copied = new ArrayList<>(rows.size());
+      for (Map<String, Object> row : rows) {
+        copied.add(
+            row == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(row)));
+      }
+      rows = Collections.unmodifiableList(copied);
+    }
+    if (total < 0L) throw new IllegalArgumentException("Catalog 查询总数不能为负数");
+  }
+
+  public record QueryColumn(
+      String title,
+      String dataIndex,
+      String key,
+      boolean ellipsis) {}
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogReadRequest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogReadRequest.java
@@ -1,0 +1,56 @@
+package io.yak.ops.business.datasource.domain.catalog;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Typed Catalog read request used inside the Business Datasource boundary. */
+public record CatalogReadRequest(
+    ReadMode mode,
+    String tablePath,
+    String sql,
+    List<Variable> variables) {
+
+  public CatalogReadRequest {
+    mode = Objects.requireNonNull(mode, "Catalog 读取模式不能为空");
+    tablePath = normalizeNullable(tablePath);
+    sql = normalizeNullable(sql);
+    variables = variables == null ? List.of() : List.copyOf(variables);
+    if (variables.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("Catalog 变量不能为空");
+    }
+    if (mode == ReadMode.TABLE && tablePath == null) {
+      throw new IllegalArgumentException("表模式下 table_path 不能为空");
+    }
+    if (mode == ReadMode.SQL && sql == null) {
+      throw new IllegalArgumentException("SQL 模式下 query 不能为空");
+    }
+  }
+
+  public boolean sqlMode() {
+    return mode == ReadMode.SQL;
+  }
+
+  public enum ReadMode {
+    TABLE,
+    SQL
+  }
+
+  public record Variable(String name, String value) {
+    public Variable {
+      name = requireText(name, "Catalog 变量名不能为空");
+      value = normalizeNullable(value);
+    }
+  }
+
+  private static String requireText(String value, String message) {
+    String normalized = normalizeNullable(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+
+  private static String normalizeNullable(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogTable.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogTable.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.datasource.domain.catalog;
+
+/** Business-owned table metadata. */
+public record CatalogTable(
+    String database,
+    String schema,
+    String name,
+    String type,
+    String remarks) {
+
+  public CatalogTable {
+    database = normalizeNullable(database);
+    schema = normalizeNullable(schema);
+    name = requireText(name, "Catalog 表名不能为空");
+    type = normalizeNullable(type);
+    remarks = normalizeNullable(remarks);
+  }
+
+  private static String requireText(String value, String message) {
+    String normalized = normalizeNullable(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+
+  private static String normalizeNullable(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogTablePath.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogTablePath.java
@@ -1,0 +1,23 @@
+package io.yak.ops.business.datasource.domain.catalog;
+
+/** Complete business-side locator for one table. */
+public record CatalogTablePath(String database, String schema, String table) {
+
+  public CatalogTablePath {
+    database = normalizeNullable(database);
+    schema = normalizeNullable(schema);
+    table = requireText(table, "Catalog 表名不能为空");
+  }
+
+  private static String requireText(String value, String message) {
+    String normalized = normalizeNullable(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+
+  private static String normalizeNullable(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogTableQuery.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/catalog/CatalogTableQuery.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.datasource.domain.catalog;
+
+/** Typed table discovery query. */
+public record CatalogTableQuery(String database, String schema, String keyword) {
+
+  public CatalogTableQuery {
+    database = normalizeNullable(database);
+    schema = normalizeNullable(schema);
+    keyword = normalizeNullable(keyword);
+  }
+
+  private static String normalizeNullable(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
@@ -1,6 +1,10 @@
 package io.yak.ops.business.datasource.execution;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.execution.domain.SqlExecutionAggregate;
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway;
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway.Command;
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway.Session;
 import io.yak.ops.core.execution.sql.LexicalSqlStatementClassifier;
 import io.yak.ops.core.execution.sql.SqlExecutionColumn;
 import io.yak.ops.core.execution.sql.SqlExecutionException;
@@ -11,23 +15,13 @@ import io.yak.ops.core.execution.sql.SqlExecutionResult;
 import io.yak.ops.core.execution.sql.SqlExecutionResultType;
 import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
-import io.yak.ops.core.execution.sql.SqlExecutionStatus;
 import io.yak.ops.core.execution.sql.SqlExecutionTiming;
 import io.yak.ops.core.execution.sql.SqlStatementClassification;
 import io.yak.ops.core.execution.sql.SqlStatementClassifier;
 import io.yak.ops.core.execution.sql.SqlStatementRequest;
-import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
-import io.yak.ops.core.execution.sql.SqlStatementStatus;
-import io.yak.ops.core.execution.sql.SqlStatementType;
 import io.yak.ops.core.execution.sql.SqlTransactionMode;
-import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
-import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
 import jakarta.annotation.PreDestroy;
 import java.sql.SQLTimeoutException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -39,38 +33,37 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/** Default SQL runtime backed by the existing datasource execution SPI. */
+/** SQL runtime orchestration backed by a Business SQL execution Gateway. */
 @Component
 @ConditionalOnDataSourceEnabled
 public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
 
   private static final int MAX_COMPLETED_EXECUTIONS = 512;
 
-  private final DataSourceExecutionProvider executionProvider;
+  private final SqlExecutionGateway executionGateway;
   private final SqlStatementClassifier statementClassifier;
   private final SqlExecutionPolicy executionPolicy;
   private final ExecutorService lifecycleExecutor;
-  private final ConcurrentMap<String, ManagedExecution> executions = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, RuntimeExecution> executions = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> completedOrder = new ConcurrentLinkedDeque<>();
 
   /** Spring entry point: policy remains replaceable while the standard classifier is deterministic. */
   @Autowired
   public DefaultSqlExecutionRuntime(
-      DataSourceExecutionProvider executionProvider,
+      SqlExecutionGateway executionGateway,
       SqlExecutionPolicy executionPolicy) {
-    this(executionProvider, new LexicalSqlStatementClassifier(), executionPolicy);
+    this(executionGateway, new LexicalSqlStatementClassifier(), executionPolicy);
   }
 
   DefaultSqlExecutionRuntime(
-      DataSourceExecutionProvider executionProvider,
+      SqlExecutionGateway executionGateway,
       SqlStatementClassifier statementClassifier,
       SqlExecutionPolicy executionPolicy) {
-    this.executionProvider = Objects.requireNonNull(executionProvider, "executionProvider");
+    this.executionGateway = Objects.requireNonNull(executionGateway, "executionGateway");
     this.statementClassifier = Objects.requireNonNull(statementClassifier, "statementClassifier");
     this.executionPolicy = Objects.requireNonNull(executionPolicy, "executionPolicy");
     this.lifecycleExecutor = Executors.newVirtualThreadPerTaskExecutor();
@@ -92,7 +85,9 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     }
 
     String executionId = "sql-" + UUID.randomUUID();
-    ManagedExecution execution = new ManagedExecution(executionId, plan, classifications);
+    SqlExecutionAggregate aggregate =
+        new SqlExecutionAggregate(executionId, plan, classifications);
+    RuntimeExecution execution = new RuntimeExecution(aggregate);
     executions.put(executionId, execution);
     try {
       lifecycleExecutor.submit(() -> run(execution));
@@ -106,13 +101,13 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
   @Override
   public Optional<SqlExecutionSnapshot> find(String executionId) {
     if (executionId == null || executionId.isBlank()) return Optional.empty();
-    ManagedExecution execution = executions.get(executionId.trim());
+    RuntimeExecution execution = executions.get(executionId.trim());
     return execution == null ? Optional.empty() : Optional.of(execution.snapshot());
   }
 
   @Override
   public SqlExecutionSnapshot await(String executionId) {
-    ManagedExecution execution = requireExecution(executionId);
+    RuntimeExecution execution = requireExecution(executionId);
     try {
       return execution.completion().join();
     } catch (RuntimeException exception) {
@@ -122,16 +117,10 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
 
   @Override
   public boolean cancel(String executionId) {
-    ManagedExecution execution = executions.get(normalizeExecutionId(executionId));
+    RuntimeExecution execution = executions.get(normalizeExecutionId(executionId));
     if (execution == null || !execution.requestCancel()) return false;
-    DataSourceSqlExecutor active = execution.activeExecutor().get();
-    if (active != null) {
-      try {
-        active.cancel();
-      } catch (RuntimeException ignored) {
-        // Cancellation is best-effort. The worker still observes cancelRequested.
-      }
-    }
+    Session active = execution.activeSession().get();
+    if (active != null) cancelSafely(active);
     return true;
   }
 
@@ -148,7 +137,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     return classification;
   }
 
-  private void run(ManagedExecution execution) {
+  private void run(RuntimeExecution execution) {
     execution.markRunning();
     try {
       if (execution.plan().transactionMode() == SqlTransactionMode.SINGLE_TRANSACTION) {
@@ -166,7 +155,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     }
   }
 
-  private void runAutoCommit(ManagedExecution execution) {
+  private void runAutoCommit(RuntimeExecution execution) {
     List<SqlStatementRequest> statements = execution.plan().statements();
     for (int index = 0; index < statements.size(); index++) {
       if (execution.cancelRequested()) {
@@ -178,8 +167,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       execution.markStatementRunning(index);
       SqlExecutionRequest request = request(execution, statement);
       try {
-        SqlExecutionResult result =
-            executeFresh(request, execution.activeExecutor(), execution);
+        SqlExecutionResult result = executeFresh(request, execution.activeSession(), execution);
         execution.markStatementSucceeded(index, result);
       } catch (RuntimeException exception) {
         finishStatementException(execution, index, exception);
@@ -194,34 +182,32 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     }
   }
 
-  private void runSingleTransaction(ManagedExecution execution) {
+  private void runSingleTransaction(RuntimeExecution execution) {
     if (execution.cancelRequested()) {
       execution.finishCancelled(0, "SQL execution cancelled");
       return;
     }
 
-    DataSourceSqlExecutor executor = null;
+    Session session = null;
     boolean transactionStarted = false;
     try {
-      executor = executionProvider.open(execution.plan().dataSourceId());
-      execution.activeExecutor().set(executor);
+      session = executionGateway.open(execution.plan().dataSourceId());
+      execution.activeSession().set(session);
 
       if (execution.cancelRequested()) {
-        cancelSafely(executor);
+        cancelSafely(session);
         execution.finishCancelled(0, "SQL execution cancelled");
         return;
       }
-      if (!executor.supportsTransactions()) {
-        execution.finishFailed(
-            0,
-            "Datasource SQL executor does not support SINGLE_TRANSACTION");
+      if (!session.supportsTransactions()) {
+        execution.finishFailed(0, "Datasource SQL executor does not support SINGLE_TRANSACTION");
         return;
       }
 
-      executor.beginTransaction();
+      session.beginTransaction();
       transactionStarted = true;
       if (execution.cancelRequested()) {
-        String rollbackError = rollbackSafely(executor);
+        String rollbackError = rollbackSafely(session);
         transactionStarted = false;
         execution.finishCancelled(
             0,
@@ -232,7 +218,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       List<SqlStatementRequest> statements = execution.plan().statements();
       for (int index = 0; index < statements.size(); index++) {
         if (execution.cancelRequested()) {
-          String rollbackError = rollbackSafely(executor);
+          String rollbackError = rollbackSafely(session);
           transactionStarted = false;
           execution.finishCancelled(
               index,
@@ -244,10 +230,10 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
         execution.markStatementRunning(index);
         SqlExecutionRequest request = request(execution, statement);
         try {
-          SqlExecutionResult result = executeExisting(request, executor);
+          SqlExecutionResult result = executeExisting(request, session);
           execution.markStatementSucceeded(index, result);
         } catch (RuntimeException exception) {
-          String rollbackError = rollbackSafely(executor);
+          String rollbackError = rollbackSafely(session);
           transactionStarted = false;
           finishStatementException(execution, index, exception, rollbackError);
           return;
@@ -255,7 +241,7 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       }
 
       if (execution.cancelRequested()) {
-        String rollbackError = rollbackSafely(executor);
+        String rollbackError = rollbackSafely(session);
         transactionStarted = false;
         execution.finishCancelled(
             statements.size(),
@@ -264,20 +250,19 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       }
 
       try {
-        executor.commitTransaction();
+        session.commitTransaction();
         transactionStarted = false;
         execution.finishSucceeded();
       } catch (RuntimeException exception) {
-        String rollbackError = rollbackSafely(executor);
+        String rollbackError = rollbackSafely(session);
         transactionStarted = false;
         execution.finishFailed(
             statements.size(),
             appendRollbackError(safeMessage(exception), rollbackError));
       }
     } catch (RuntimeException exception) {
-      String rollbackError = transactionStarted && executor != null
-          ? rollbackSafely(executor)
-          : null;
+      String rollbackError =
+          transactionStarted && session != null ? rollbackSafely(session) : null;
       if (execution.cancelRequested()) {
         execution.finishCancelled(
             0,
@@ -288,19 +273,13 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
             appendRollbackError(safeMessage(exception), rollbackError));
       }
     } finally {
-      execution.activeExecutor().compareAndSet(executor, null);
-      if (executor != null) {
-        try {
-          executor.close();
-        } catch (RuntimeException ignored) {
-          // Transaction outcome is already reflected above; close is best-effort cleanup.
-        }
-      }
+      execution.activeSession().compareAndSet(session, null);
+      closeSafely(session);
     }
   }
 
   private SqlExecutionRequest request(
-      ManagedExecution execution,
+      RuntimeExecution execution,
       SqlStatementRequest statement) {
     return new SqlExecutionRequest(
         execution.plan().dataSourceId(),
@@ -312,14 +291,14 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
   }
 
   private void finishStatementException(
-      ManagedExecution execution,
+      RuntimeExecution execution,
       int index,
       RuntimeException exception) {
     finishStatementException(execution, index, exception, null);
   }
 
   private void finishStatementException(
-      ManagedExecution execution,
+      RuntimeExecution execution,
       int index,
       RuntimeException exception,
       String rollbackError) {
@@ -338,44 +317,45 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
 
   private SqlExecutionResult executeFresh(
       SqlExecutionRequest request,
-      AtomicReference<DataSourceSqlExecutor> activeExecutor,
-      ManagedExecution managedExecution) {
+      AtomicReference<Session> activeSession,
+      RuntimeExecution runtimeExecution) {
     long totalStartedAt = System.nanoTime();
     long openStartedAt = System.nanoTime();
-    DataSourceSqlExecutor executor = executionProvider.open(request.dataSourceId());
+    Session session = executionGateway.open(request.dataSourceId());
     long openMillis = elapsedMillis(openStartedAt);
-    if (activeExecutor != null) activeExecutor.set(executor);
+    if (activeSession != null) activeSession.set(session);
 
-    try (executor) {
-      if (managedExecution != null && managedExecution.cancelRequested()) {
-        cancelSafely(executor);
+    try (session) {
+      if (runtimeExecution != null && runtimeExecution.cancelRequested()) {
+        cancelSafely(session);
         throw new IllegalStateException("SQL execution cancelled");
       }
-      return executeOnExecutor(request, executor, openMillis, totalStartedAt);
-    } catch (RuntimeException exception) {
-      throw exception;
-    } catch (Exception exception) {
-      throw new SqlExecutionException(request.dataSourceId(), request.context(), exception);
+      return executeOnSession(request, session, openMillis, totalStartedAt);
     } finally {
-      if (activeExecutor != null) activeExecutor.compareAndSet(executor, null);
+      if (activeSession != null) activeSession.compareAndSet(session, null);
     }
   }
 
   private SqlExecutionResult executeExisting(
       SqlExecutionRequest request,
-      DataSourceSqlExecutor executor) {
+      Session session) {
     long totalStartedAt = System.nanoTime();
-    return executeOnExecutor(request, executor, 0L, totalStartedAt);
+    return executeOnSession(request, session, 0L, totalStartedAt);
   }
 
-  private SqlExecutionResult executeOnExecutor(
+  private SqlExecutionResult executeOnSession(
       SqlExecutionRequest request,
-      DataSourceSqlExecutor executor,
+      Session session,
       long openMillis,
       long totalStartedAt) {
     long executeStartedAt = System.nanoTime();
-    DataSourceSqlResult result = executor.execute(new DataSourceSqlRequest(
-        request.sql(), request.maxRows(), request.timeoutSeconds(), request.parameters()));
+    SqlExecutionGateway.Result result =
+        session.execute(
+            new Command(
+                request.sql(),
+                request.parameters(),
+                request.maxRows(),
+                request.timeoutSeconds()));
     long executeMillis = elapsedMillis(executeStartedAt);
     long totalMillis = elapsedMillis(totalStartedAt);
 
@@ -388,20 +368,30 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
         new SqlExecutionTiming(openMillis, executeMillis, totalMillis));
   }
 
-  private static void cancelSafely(DataSourceSqlExecutor executor) {
+  private static void cancelSafely(Session session) {
+    if (session == null) return;
     try {
-      executor.cancel();
+      session.cancel();
     } catch (RuntimeException ignored) {
       // Best effort cancellation.
     }
   }
 
-  private String rollbackSafely(DataSourceSqlExecutor executor) {
+  private String rollbackSafely(Session session) {
     try {
-      executor.rollbackTransaction();
+      session.rollbackTransaction();
       return null;
     } catch (RuntimeException exception) {
       return safeMessage(exception);
+    }
+  }
+
+  private static void closeSafely(Session session) {
+    if (session == null) return;
+    try {
+      session.close();
+    } catch (RuntimeException ignored) {
+      // Execution outcome is already reflected in the lifecycle aggregate.
     }
   }
 
@@ -410,9 +400,9 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     return message + "; rollback failed: " + rollbackError;
   }
 
-  private ManagedExecution requireExecution(String executionId) {
+  private RuntimeExecution requireExecution(String executionId) {
     String normalized = normalizeExecutionId(executionId);
-    ManagedExecution execution = executions.get(normalized);
+    RuntimeExecution execution = executions.get(normalized);
     if (execution == null) {
       throw new IllegalArgumentException("SQL execution not found: " + normalized);
     }
@@ -434,14 +424,16 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     }
   }
 
-  private static List<SqlExecutionColumn> mapColumns(List<DataSourceSqlColumn> columns) {
+  private static List<SqlExecutionColumn> mapColumns(List<SqlExecutionGateway.Column> columns) {
     return columns.stream()
-        .map(column -> new SqlExecutionColumn(
-            column.name(),
-            column.label(),
-            column.typeName(),
-            column.jdbcType(),
-            column.nullable()))
+        .map(
+            column ->
+                new SqlExecutionColumn(
+                    column.name(),
+                    column.label(),
+                    column.typeName(),
+                    column.jdbcType(),
+                    column.nullable()))
         .toList();
   }
 
@@ -466,45 +458,26 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     return Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
   }
 
-  private static final class ManagedExecution {
+  private static final class RuntimeExecution {
 
-    private final String executionId;
-    private final SqlExecutionPlan plan;
-    private final List<MutableStatement> statements;
-    private final AtomicBoolean cancelRequested = new AtomicBoolean(false);
-    private final AtomicReference<DataSourceSqlExecutor> activeExecutor = new AtomicReference<>();
+    private final SqlExecutionAggregate aggregate;
+    private final AtomicReference<Session> activeSession = new AtomicReference<>();
     private final CompletableFuture<SqlExecutionSnapshot> completion = new CompletableFuture<>();
-    private SqlExecutionStatus status = SqlExecutionStatus.PENDING;
-    private Instant startedAt;
-    private Instant finishedAt;
-    private String errorMessage;
 
-    private ManagedExecution(
-        String executionId,
-        SqlExecutionPlan plan,
-        List<SqlStatementClassification> classifications) {
-      this.executionId = executionId;
-      this.plan = plan;
-      this.statements = new ArrayList<>(plan.statements().size());
-      for (int index = 0; index < plan.statements().size(); index++) {
-        this.statements.add(new MutableStatement(
-            executionId + ":stmt:" + (index + 1),
-            index,
-            plan.statements().get(index).sql(),
-            classifications.get(index).primaryType()));
-      }
+    private RuntimeExecution(SqlExecutionAggregate aggregate) {
+      this.aggregate = aggregate;
     }
 
     String executionId() {
-      return executionId;
+      return aggregate.executionId();
     }
 
     SqlExecutionPlan plan() {
-      return plan;
+      return aggregate.plan();
     }
 
-    AtomicReference<DataSourceSqlExecutor> activeExecutor() {
-      return activeExecutor;
+    AtomicReference<Session> activeSession() {
+      return activeSession;
     }
 
     CompletableFuture<SqlExecutionSnapshot> completion() {
@@ -512,165 +485,74 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
     }
 
     boolean cancelRequested() {
-      return cancelRequested.get();
+      return aggregate.cancelRequested();
     }
 
-    synchronized void markRunning() {
-      if (status.terminal()) return;
-      startedAt = Instant.now();
-      status = cancelRequested.get() ? SqlExecutionStatus.CANCELLING : SqlExecutionStatus.RUNNING;
+    boolean requestCancel() {
+      return aggregate.requestCancel();
     }
 
-    synchronized void markStatementRunning(int index) {
-      MutableStatement statement = statements.get(index);
-      statement.status = SqlStatementStatus.RUNNING;
-      statement.startedAt = Instant.now();
+    void markRunning() {
+      aggregate.markRunning();
     }
 
-    synchronized void markStatementSucceeded(int index, SqlExecutionResult result) {
-      MutableStatement statement = statements.get(index);
-      statement.result = result;
-      statement.status = SqlStatementStatus.SUCCEEDED;
-      statement.finishedAt = Instant.now();
+    void markStatementRunning(int index) {
+      aggregate.markStatementRunning(index);
     }
 
-    synchronized void markStatementFailed(int index, String message) {
-      finishStatement(index, SqlStatementStatus.FAILED, message);
+    void markStatementSucceeded(int index, SqlExecutionResult result) {
+      aggregate.markStatementSucceeded(index, result);
     }
 
-    synchronized void markStatementTimedOut(int index, String message) {
-      finishStatement(index, SqlStatementStatus.TIMED_OUT, message);
+    void markStatementFailed(int index, String message) {
+      aggregate.markStatementFailed(index, message);
     }
 
-    synchronized void markStatementCancelled(int index, String message) {
-      finishStatement(index, SqlStatementStatus.CANCELLED, message);
+    void markStatementTimedOut(int index, String message) {
+      aggregate.markStatementTimedOut(index, message);
     }
 
-    private void finishStatement(int index, SqlStatementStatus statementStatus, String message) {
-      MutableStatement statement = statements.get(index);
-      statement.status = statementStatus;
-      statement.errorMessage = message;
-      statement.finishedAt = Instant.now();
+    void markStatementCancelled(int index, String message) {
+      aggregate.markStatementCancelled(index, message);
     }
 
-    synchronized boolean requestCancel() {
-      if (status.terminal()) return false;
-      cancelRequested.set(true);
-      status = SqlExecutionStatus.CANCELLING;
-      return true;
+    void finishSucceeded() {
+      aggregate.finishSucceeded();
+      completeIfTerminal();
     }
 
-    synchronized void finishSucceeded() {
-      complete(SqlExecutionStatus.SUCCEEDED, null, statements.size());
+    void finishFailed(int skipFrom, String message) {
+      aggregate.finishFailed(skipFrom, message);
+      completeIfTerminal();
     }
 
-    synchronized void finishFailed(int skipFrom, String message) {
-      complete(SqlExecutionStatus.FAILED, message, skipFrom);
+    void finishTimedOut(int skipFrom, String message) {
+      aggregate.finishTimedOut(skipFrom, message);
+      completeIfTerminal();
     }
 
-    synchronized void finishTimedOut(int skipFrom, String message) {
-      complete(SqlExecutionStatus.TIMED_OUT, message, skipFrom);
+    void finishCancelled(int skipFrom, String message) {
+      aggregate.finishCancelled(skipFrom, message);
+      completeIfTerminal();
     }
 
-    synchronized void finishCancelled(int skipFrom, String message) {
-      complete(SqlExecutionStatus.CANCELLED, message, skipFrom);
+    void finishUnexpectedFailure(String message) {
+      aggregate.finishUnexpectedFailure(message);
+      completeIfTerminal();
     }
 
-    synchronized void finishUnexpectedFailure(String message) {
-      if (status.terminal()) return;
-      int skipFrom = 0;
-      for (int index = 0; index < statements.size(); index++) {
-        MutableStatement statement = statements.get(index);
-        if (statement.status == SqlStatementStatus.RUNNING) {
-          statement.status = SqlStatementStatus.FAILED;
-          statement.errorMessage = message;
-          statement.finishedAt = Instant.now();
-          skipFrom = index + 1;
-          break;
-        }
-        if (statement.status == SqlStatementStatus.SUCCEEDED) {
-          skipFrom = index + 1;
-          continue;
-        }
-        skipFrom = index;
-        break;
-      }
-      complete(SqlExecutionStatus.FAILED, message, skipFrom);
+    void failBeforeStart(Throwable throwable) {
+      aggregate.failBeforeStart(safeMessage(throwable));
+      completeIfTerminal();
     }
 
-    synchronized void failBeforeStart(Throwable throwable) {
-      startedAt = Instant.now();
-      complete(SqlExecutionStatus.FAILED, safeMessage(throwable), 0);
+    SqlExecutionSnapshot snapshot() {
+      return aggregate.snapshot();
     }
 
-    private void complete(SqlExecutionStatus finalStatus, String message, int skipFrom) {
-      if (status.terminal()) return;
-      Instant now = Instant.now();
-      for (int index = Math.max(0, skipFrom); index < statements.size(); index++) {
-        MutableStatement statement = statements.get(index);
-        if (statement.status == SqlStatementStatus.PENDING) {
-          statement.status = SqlStatementStatus.SKIPPED;
-          statement.finishedAt = now;
-          statement.errorMessage = message;
-        }
-      }
-      status = finalStatus;
-      errorMessage = message;
-      finishedAt = now;
-      SqlExecutionSnapshot snapshot = snapshot();
-      completion.complete(snapshot);
-    }
-
-    synchronized SqlExecutionSnapshot snapshot() {
-      List<SqlStatementSnapshot> snapshots = statements.stream()
-          .map(MutableStatement::snapshot)
-          .toList();
-      return new SqlExecutionSnapshot(
-          executionId,
-          status,
-          plan.dataSourceId(),
-          plan.context(),
-          plan.transactionMode(),
-          snapshots,
-          startedAt,
-          finishedAt,
-          errorMessage);
-    }
-  }
-
-  private static final class MutableStatement {
-    private final String statementId;
-    private final int index;
-    private final String sql;
-    private final SqlStatementType statementType;
-    private SqlStatementStatus status = SqlStatementStatus.PENDING;
-    private SqlExecutionResult result;
-    private String errorMessage;
-    private Instant startedAt;
-    private Instant finishedAt;
-
-    private MutableStatement(
-        String statementId,
-        int index,
-        String sql,
-        SqlStatementType statementType) {
-      this.statementId = statementId;
-      this.index = index;
-      this.sql = sql;
-      this.statementType = statementType;
-    }
-
-    private SqlStatementSnapshot snapshot() {
-      return new SqlStatementSnapshot(
-          statementId,
-          index,
-          sql,
-          statementType,
-          status,
-          result,
-          errorMessage,
-          startedAt,
-          finishedAt);
+    private void completeIfTerminal() {
+      SqlExecutionSnapshot snapshot = aggregate.snapshot();
+      if (snapshot.terminal()) completion.complete(snapshot);
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/domain/SqlExecutionAggregate.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/domain/SqlExecutionAggregate.java
@@ -1,0 +1,241 @@
+package io.yak.ops.business.datasource.execution.domain;
+
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionResult;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementClassification;
+import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.execution.sql.SqlStatementType;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * SQL execution lifecycle aggregate.
+ *
+ * <p>This object owns execution/statement state transitions only. Threads, futures, physical
+ * datasource sessions and cancellation I/O remain runtime concerns.
+ */
+public final class SqlExecutionAggregate {
+
+  private final String executionId;
+  private final SqlExecutionPlan plan;
+  private final List<StatementState> statements;
+
+  private boolean cancelRequested;
+  private SqlExecutionStatus status = SqlExecutionStatus.PENDING;
+  private Instant startedAt;
+  private Instant finishedAt;
+  private String errorMessage;
+
+  public SqlExecutionAggregate(
+      String executionId,
+      SqlExecutionPlan plan,
+      List<SqlStatementClassification> classifications) {
+    if (executionId == null || executionId.isBlank()) {
+      throw new IllegalArgumentException("executionId must not be blank");
+    }
+    this.executionId = executionId.trim();
+    this.plan = Objects.requireNonNull(plan, "plan");
+    List<SqlStatementClassification> values =
+        classifications == null ? List.of() : List.copyOf(classifications);
+    if (values.size() != plan.statements().size()) {
+      throw new IllegalArgumentException("statement classifications must match execution plan");
+    }
+    this.statements = new ArrayList<>(plan.statements().size());
+    for (int index = 0; index < plan.statements().size(); index++) {
+      SqlStatementClassification classification =
+          Objects.requireNonNull(values.get(index), "statement classification");
+      statements.add(
+          new StatementState(
+              this.executionId + ":stmt:" + (index + 1),
+              index,
+              plan.statements().get(index).sql(),
+              classification.primaryType()));
+    }
+  }
+
+  public String executionId() {
+    return executionId;
+  }
+
+  public SqlExecutionPlan plan() {
+    return plan;
+  }
+
+  public synchronized boolean cancelRequested() {
+    return cancelRequested;
+  }
+
+  public synchronized boolean requestCancel() {
+    if (status.terminal()) return false;
+    cancelRequested = true;
+    status = SqlExecutionStatus.CANCELLING;
+    return true;
+  }
+
+  public synchronized void markRunning() {
+    if (status.terminal()) return;
+    if (startedAt == null) startedAt = Instant.now();
+    status = cancelRequested ? SqlExecutionStatus.CANCELLING : SqlExecutionStatus.RUNNING;
+  }
+
+  public synchronized void markStatementRunning(int index) {
+    StatementState statement = statement(index);
+    statement.status = SqlStatementStatus.RUNNING;
+    statement.startedAt = Instant.now();
+  }
+
+  public synchronized void markStatementSucceeded(int index, SqlExecutionResult result) {
+    StatementState statement = statement(index);
+    statement.result = Objects.requireNonNull(result, "result");
+    statement.status = SqlStatementStatus.SUCCEEDED;
+    statement.finishedAt = Instant.now();
+  }
+
+  public synchronized void markStatementFailed(int index, String message) {
+    finishStatement(index, SqlStatementStatus.FAILED, message);
+  }
+
+  public synchronized void markStatementTimedOut(int index, String message) {
+    finishStatement(index, SqlStatementStatus.TIMED_OUT, message);
+  }
+
+  public synchronized void markStatementCancelled(int index, String message) {
+    finishStatement(index, SqlStatementStatus.CANCELLED, message);
+  }
+
+  public synchronized void finishSucceeded() {
+    complete(SqlExecutionStatus.SUCCEEDED, null, statements.size());
+  }
+
+  public synchronized void finishFailed(int skipFrom, String message) {
+    complete(SqlExecutionStatus.FAILED, message, skipFrom);
+  }
+
+  public synchronized void finishTimedOut(int skipFrom, String message) {
+    complete(SqlExecutionStatus.TIMED_OUT, message, skipFrom);
+  }
+
+  public synchronized void finishCancelled(int skipFrom, String message) {
+    complete(SqlExecutionStatus.CANCELLED, message, skipFrom);
+  }
+
+  public synchronized void finishUnexpectedFailure(String message) {
+    if (status.terminal()) return;
+    int skipFrom = 0;
+    for (int index = 0; index < statements.size(); index++) {
+      StatementState statement = statements.get(index);
+      if (statement.status == SqlStatementStatus.RUNNING) {
+        statement.status = SqlStatementStatus.FAILED;
+        statement.errorMessage = message;
+        statement.finishedAt = Instant.now();
+        skipFrom = index + 1;
+        break;
+      }
+      if (statement.status == SqlStatementStatus.SUCCEEDED) {
+        skipFrom = index + 1;
+        continue;
+      }
+      skipFrom = index;
+      break;
+    }
+    complete(SqlExecutionStatus.FAILED, message, skipFrom);
+  }
+
+  public synchronized void failBeforeStart(String message) {
+    if (startedAt == null) startedAt = Instant.now();
+    complete(SqlExecutionStatus.FAILED, message, 0);
+  }
+
+  public synchronized boolean terminal() {
+    return status.terminal();
+  }
+
+  public synchronized SqlExecutionSnapshot snapshot() {
+    List<SqlStatementSnapshot> snapshots = statements.stream().map(StatementState::snapshot).toList();
+    return new SqlExecutionSnapshot(
+        executionId,
+        status,
+        plan.dataSourceId(),
+        plan.context(),
+        plan.transactionMode(),
+        snapshots,
+        startedAt,
+        finishedAt,
+        errorMessage);
+  }
+
+  private void finishStatement(int index, SqlStatementStatus statementStatus, String message) {
+    StatementState statement = statement(index);
+    statement.status = statementStatus;
+    statement.errorMessage = message;
+    statement.finishedAt = Instant.now();
+  }
+
+  private StatementState statement(int index) {
+    if (index < 0 || index >= statements.size()) {
+      throw new IllegalArgumentException("statement index out of range: " + index);
+    }
+    return statements.get(index);
+  }
+
+  private void complete(SqlExecutionStatus finalStatus, String message, int skipFrom) {
+    if (status.terminal()) return;
+    if (!finalStatus.terminal()) {
+      throw new IllegalArgumentException("final execution status must be terminal");
+    }
+    Instant now = Instant.now();
+    for (int index = Math.max(0, skipFrom); index < statements.size(); index++) {
+      StatementState statement = statements.get(index);
+      if (statement.status == SqlStatementStatus.PENDING) {
+        statement.status = SqlStatementStatus.SKIPPED;
+        statement.finishedAt = now;
+        statement.errorMessage = message;
+      }
+    }
+    status = finalStatus;
+    errorMessage = message;
+    finishedAt = now;
+  }
+
+  private static final class StatementState {
+
+    private final String statementId;
+    private final int index;
+    private final String sql;
+    private final SqlStatementType statementType;
+    private SqlStatementStatus status = SqlStatementStatus.PENDING;
+    private SqlExecutionResult result;
+    private String errorMessage;
+    private Instant startedAt;
+    private Instant finishedAt;
+
+    private StatementState(
+        String statementId,
+        int index,
+        String sql,
+        SqlStatementType statementType) {
+      this.statementId = statementId;
+      this.index = index;
+      this.sql = sql;
+      this.statementType = statementType;
+    }
+
+    private SqlStatementSnapshot snapshot() {
+      return new SqlStatementSnapshot(
+          statementId,
+          index,
+          sql,
+          statementType,
+          status,
+          result,
+          errorMessage,
+          startedAt,
+          finishedAt);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourceCatalogGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourceCatalogGateway.java
@@ -1,17 +1,18 @@
 package io.yak.ops.business.datasource.gateway;
 
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTable;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTablePath;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTableQuery;
 import java.util.List;
-import java.util.Map;
 
 /**
- * Business Datasource 对 Catalog 插件能力的 Port。
+ * Business Datasource 对 Catalog 物理能力的 Port。
  *
- * <p>这里的模型属于 Business Gateway Contract，不暴露 Datasource Plugin SPI Model。Phase 3 会继续把 Catalog
- * 的 Map 协议类型化并评估哪些模型应提升为正式 Catalog Domain Model。
+ * <p>Gateway 只接受 Business-owned typed catalog models；Plugin SPI 的 Map 协议和 metadata model 必须在 Adapter 内完成转换。
  */
 public interface DataSourceCatalogGateway {
 
@@ -22,30 +23,30 @@ public interface DataSourceCatalogGateway {
       String database,
       int timeoutSeconds);
 
-  List<Table> listTables(
+  List<CatalogTable> listTables(
       DataSourceDefinition dataSource,
-      TableQuery query,
+      CatalogTableQuery query,
       int timeoutSeconds);
 
-  List<Column> listColumns(
+  List<CatalogColumn> listColumns(
       DataSourceDefinition dataSource,
-      TablePath tablePath,
+      CatalogTablePath tablePath,
       int timeoutSeconds);
 
-  List<Column> describe(
+  List<CatalogColumn> describe(
       DataSourceDefinition dataSource,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int timeoutSeconds);
 
-  QueryResult preview(
+  CatalogQueryResult preview(
       DataSourceDefinition dataSource,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int limit,
       int timeoutSeconds);
 
   long count(
       DataSourceDefinition dataSource,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int timeoutSeconds);
 
   String buildSqlTemplate(
@@ -55,57 +56,6 @@ public interface DataSourceCatalogGateway {
 
   String resolveSql(
       DataSourceDefinition dataSource,
-      String sql,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int timeoutSeconds);
-
-  record TableQuery(String database, String schema, String keyword) {}
-
-  record TablePath(String database, String schema, String table) {}
-
-  record Table(
-      String database,
-      String schema,
-      String name,
-      String type,
-      String remarks) {}
-
-  record Column(
-      String name,
-      String typeName,
-      int jdbcType,
-      Integer size,
-      Integer scale,
-      boolean nullable,
-      int ordinalPosition,
-      boolean primaryKey,
-      String remarks) {}
-
-  record QueryColumn(
-      String title,
-      String dataIndex,
-      String key,
-      boolean ellipsis) {}
-
-  record QueryResult(
-      List<QueryColumn> columns,
-      List<Map<String, Object>> data,
-      long total) {
-
-    public QueryResult {
-      columns = columns == null ? List.of() : List.copyOf(columns);
-      if (data == null || data.isEmpty()) {
-        data = List.of();
-      } else {
-        List<Map<String, Object>> copied = new ArrayList<>(data.size());
-        for (Map<String, Object> row : data) {
-          copied.add(
-              row == null
-                  ? Map.of()
-                  : Collections.unmodifiableMap(new LinkedHashMap<>(row)));
-        }
-        data = Collections.unmodifiableList(copied);
-      }
-    }
-  }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/SqlExecutionGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/SqlExecutionGateway.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.datasource.gateway;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Business-side Port for physical SQL execution. Datasource Plugin SPI stays behind its Adapter. */
+public interface SqlExecutionGateway {
+
+  Session open(String dataSourceId);
+
+  interface Session extends AutoCloseable {
+
+    Result execute(Command command);
+
+    default boolean supportsTransactions() {
+      return false;
+    }
+
+    default void beginTransaction() {
+      throw new UnsupportedOperationException("Transactions are not supported");
+    }
+
+    default void commitTransaction() {
+      throw new UnsupportedOperationException("Transactions are not supported");
+    }
+
+    default void rollbackTransaction() {
+      throw new UnsupportedOperationException("Transactions are not supported");
+    }
+
+    default void cancel() {}
+
+    @Override
+    default void close() {}
+  }
+
+  record Command(
+      String sql,
+      List<Object> parameters,
+      int maxRows,
+      int timeoutSeconds) {
+
+    public Command {
+      if (sql == null || sql.isBlank()) throw new IllegalArgumentException("sql must not be blank");
+      sql = sql.trim();
+      parameters = immutableNullableList(parameters);
+      if (maxRows <= 0) throw new IllegalArgumentException("maxRows must be greater than zero");
+      if (timeoutSeconds <= 0) {
+        throw new IllegalArgumentException("timeoutSeconds must be greater than zero");
+      }
+    }
+  }
+
+  record Column(
+      String name,
+      String label,
+      String typeName,
+      int jdbcType,
+      boolean nullable) {}
+
+  record Result(
+      boolean resultSet,
+      List<Column> columns,
+      List<List<Object>> rows,
+      long affectedRows,
+      boolean truncated) {
+
+    public Result {
+      columns = columns == null ? List.of() : List.copyOf(columns);
+      rows = immutableNullableRows(rows);
+    }
+  }
+
+  private static List<Object> immutableNullableList(List<Object> values) {
+    if (values == null || values.isEmpty()) return List.of();
+    return Collections.unmodifiableList(new ArrayList<>(values));
+  }
+
+  private static List<List<Object>> immutableNullableRows(List<List<Object>> rows) {
+    if (rows == null || rows.isEmpty()) return List.of();
+    List<List<Object>> copied = new ArrayList<>(rows.size());
+    for (List<Object> row : rows) {
+      copied.add(row == null ? List.of() : immutableNullableList(row));
+    }
+    return Collections.unmodifiableList(copied);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
@@ -2,6 +2,13 @@ package io.yak.ops.business.datasource.gateway.adapter;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult.QueryColumn;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTable;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTablePath;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTableQuery;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
@@ -16,13 +23,15 @@ import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
 import io.yak.ops.spi.datasource.metadata.DataSourceTable;
 import io.yak.ops.spi.datasource.query.DataSourceQueryColumn;
 import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/** Datasource Catalog SPI -> Business Gateway Adapter。 */
+/** Datasource Catalog SPI -> typed Business Catalog Gateway Adapter。 */
 @Component
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -46,11 +55,12 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
   }
 
   @Override
-  public List<Table> listTables(
+  public List<CatalogTable> listTables(
       DataSourceDefinition dataSource,
-      TableQuery query,
+      CatalogTableQuery query,
       int timeoutSeconds) {
-    TableQuery value = query == null ? new TableQuery(null, null, null) : query;
+    CatalogTableQuery value =
+        query == null ? new CatalogTableQuery(null, null, null) : query;
     return execute(
         dataSource,
         timeoutSeconds,
@@ -65,9 +75,9 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
   }
 
   @Override
-  public List<Column> listColumns(
+  public List<CatalogColumn> listColumns(
       DataSourceDefinition dataSource,
-      TablePath tablePath,
+      CatalogTablePath tablePath,
       int timeoutSeconds) {
     if (tablePath == null) {
       throw new DataSourceException(
@@ -88,34 +98,37 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
   }
 
   @Override
-  public List<Column> describe(
+  public List<CatalogColumn> describe(
       DataSourceDefinition dataSource,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int timeoutSeconds) {
+    Map<String, Object> pluginRequest = toPluginRequest(request);
     return execute(
         dataSource,
         timeoutSeconds,
-        catalog -> catalog.describe(request).stream().map(this::toColumn).toList());
+        catalog -> catalog.describe(pluginRequest).stream().map(this::toColumn).toList());
   }
 
   @Override
-  public QueryResult preview(
+  public CatalogQueryResult preview(
       DataSourceDefinition dataSource,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int limit,
       int timeoutSeconds) {
+    Map<String, Object> pluginRequest = toPluginRequest(request);
     return execute(
         dataSource,
         timeoutSeconds,
-        catalog -> toQueryResult(catalog.preview(request, limit)));
+        catalog -> toQueryResult(catalog.preview(pluginRequest, limit)));
   }
 
   @Override
   public long count(
       DataSourceDefinition dataSource,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int timeoutSeconds) {
-    return execute(dataSource, timeoutSeconds, catalog -> catalog.count(request));
+    Map<String, Object> pluginRequest = toPluginRequest(request);
+    return execute(dataSource, timeoutSeconds, catalog -> catalog.count(pluginRequest));
   }
 
   @Override
@@ -132,13 +145,18 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
   @Override
   public String resolveSql(
       DataSourceDefinition dataSource,
-      String sql,
-      Map<String, Object> request,
+      CatalogReadRequest request,
       int timeoutSeconds) {
+    if (request == null || request.sql() == null) {
+      throw new DataSourceException(
+          DataSourceErrorCode.CATALOG_FAILED,
+          "解析 SQL 时 query 不能为空");
+    }
+    Map<String, Object> pluginRequest = toPluginRequest(request);
     return execute(
         dataSource,
         timeoutSeconds,
-        catalog -> catalog.resolveSql(sql, request));
+        catalog -> catalog.resolveSql(request.sql(), pluginRequest));
   }
 
   private <T> T execute(
@@ -152,8 +170,7 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
     }
     try {
       DataSourcePlugin plugin = pluginRegistry.get(dataSource.getDbType());
-      DataSourceConnection connection =
-          plugin.parseConnection(dataSource.getConnectionParams());
+      DataSourceConnection connection = plugin.parseConnection(dataSource.getConnectionParams());
       DataSourceCatalog catalog =
           plugin.createCatalog(connection, Math.max(1, timeoutSeconds));
       return action.apply(catalog);
@@ -166,8 +183,31 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
     }
   }
 
-  private Table toTable(DataSourceTable table) {
-    return new Table(
+  private Map<String, Object> toPluginRequest(CatalogReadRequest request) {
+    if (request == null) {
+      throw new DataSourceException(
+          DataSourceErrorCode.CATALOG_FAILED,
+          "Catalog 请求不能为空");
+    }
+    Map<String, Object> values = new LinkedHashMap<>();
+    values.put("read_mode", request.sqlMode() ? "sql" : "table");
+    if (request.tablePath() != null) values.put("table_path", request.tablePath());
+    if (request.sql() != null) values.put("query", request.sql());
+    if (!request.variables().isEmpty()) {
+      List<Map<String, Object>> params = new ArrayList<>(request.variables().size());
+      for (CatalogReadRequest.Variable variable : request.variables()) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("paramName", variable.name());
+        item.put("paramValue", variable.value());
+        params.add(item);
+      }
+      values.put("paramsList", List.copyOf(params));
+    }
+    return Map.copyOf(values);
+  }
+
+  private CatalogTable toTable(DataSourceTable table) {
+    return new CatalogTable(
         table.getDatabase(),
         table.getSchema(),
         table.getName(),
@@ -175,8 +215,8 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
         table.getRemarks());
   }
 
-  private Column toColumn(DataSourceColumn column) {
-    return new Column(
+  private CatalogColumn toColumn(DataSourceColumn column) {
+    return new CatalogColumn(
         column.getName(),
         column.getTypeName(),
         column.getJdbcType(),
@@ -188,13 +228,13 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
         column.getRemarks());
   }
 
-  private QueryResult toQueryResult(DataSourceQueryResult result) {
+  private CatalogQueryResult toQueryResult(DataSourceQueryResult result) {
     if (result == null) {
-      return new QueryResult(List.of(), List.of(), 0L);
+      return new CatalogQueryResult(List.of(), List.of(), 0L);
     }
     List<QueryColumn> columns =
         result.getColumns().stream().map(this::toQueryColumn).toList();
-    return new QueryResult(columns, result.getData(), result.getTotal());
+    return new CatalogQueryResult(columns, result.getData(), result.getTotal());
   }
 
   private QueryColumn toQueryColumn(DataSourceQueryColumn column) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiSqlExecutionGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiSqlExecutionGateway.java
@@ -1,0 +1,97 @@
+package io.yak.ops.business.datasource.gateway.adapter;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Datasource SQL execution SPI -> Business SQL execution Gateway Adapter. */
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class SpiSqlExecutionGateway implements SqlExecutionGateway {
+
+  private final DataSourceExecutionProvider executionProvider;
+
+  @Override
+  public Session open(String dataSourceId) {
+    return new SessionAdapter(executionProvider.open(dataSourceId));
+  }
+
+  private static final class SessionAdapter implements Session {
+
+    private final DataSourceSqlExecutor delegate;
+
+    private SessionAdapter(DataSourceSqlExecutor delegate) {
+      if (delegate == null) throw new IllegalStateException("Datasource SQL executor must not be null");
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Result execute(Command command) {
+      DataSourceSqlResult result =
+          delegate.execute(
+              new DataSourceSqlRequest(
+                  command.sql(),
+                  command.maxRows(),
+                  command.timeoutSeconds(),
+                  command.parameters()));
+      return new Result(
+          result.resultSet(),
+          mapColumns(result.columns()),
+          result.rows(),
+          result.affectedRows(),
+          result.truncated());
+    }
+
+    @Override
+    public boolean supportsTransactions() {
+      return delegate.supportsTransactions();
+    }
+
+    @Override
+    public void beginTransaction() {
+      delegate.beginTransaction();
+    }
+
+    @Override
+    public void commitTransaction() {
+      delegate.commitTransaction();
+    }
+
+    @Override
+    public void rollbackTransaction() {
+      delegate.rollbackTransaction();
+    }
+
+    @Override
+    public void cancel() {
+      delegate.cancel();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
+
+    private static List<Column> mapColumns(List<DataSourceSqlColumn> columns) {
+      if (columns == null || columns.isEmpty()) return List.of();
+      return columns.stream()
+          .map(
+              column ->
+                  new Column(
+                      column.name(),
+                      column.label(),
+                      column.typeName(),
+                      column.jdbcType(),
+                      column.nullable()))
+          .toList();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImpl.java
@@ -3,13 +3,16 @@ package io.yak.ops.business.datasource.service.impl;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.ReadMode;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.Variable;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTable;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTablePath;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTableQuery;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
-import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.Column;
-import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.QueryResult;
-import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.Table;
-import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.TablePath;
-import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.TableQuery;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnOptionVO;
@@ -19,6 +22,7 @@ import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePreviewColumnVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceQueryResultVO;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +33,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/** Catalog 应用服务；Catalog 物理访问和 SPI 模型转换统一由 Gateway Adapter 负责。 */
+/** Catalog 应用服务；HTTP Map 兼容协议在入口解析一次，内部统一使用 typed Catalog Domain。 */
 @Service
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -67,7 +71,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
     return catalogGateway
         .listTables(
             getDataSourceOrThrow(dataSourceId),
-            new TableQuery(database, schema, keyword),
+            new CatalogTableQuery(database, schema, keyword),
             connectionTimeoutSeconds())
         .stream()
         .map(this::toTableVO)
@@ -83,7 +87,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
     return catalogGateway
         .listColumns(
             getDataSourceOrThrow(dataSourceId),
-            new TablePath(database, schema, table),
+            new CatalogTablePath(database, schema, table),
             connectionTimeoutSeconds())
         .stream()
         .map(this::toColumnVO)
@@ -92,19 +96,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
 
   @Override
   public List<DataSourceCatalogOptionVO> listTable(Long dataSourceId) {
-    return catalogGateway
-        .listTables(
-            getDataSourceOrThrow(dataSourceId),
-            new TableQuery(null, null, null),
-            connectionTimeoutSeconds())
-        .stream()
-        .map(
-            table -> {
-              String label = isBlank(table.remarks()) ? table.name() : table.remarks();
-              return new DataSourceCatalogOptionVO(
-                  table.name(), label, table.remarks());
-            })
-        .toList();
+    return listAllTables(dataSourceId).stream().map(this::toOptionVO).toList();
   }
 
   @Override
@@ -112,8 +104,8 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
       Long dataSourceId,
       String matchMode,
       String keyword) {
-    List<DataSourceCatalogOptionVO> options = listTable(dataSourceId);
-    if (isBlank(keyword)) return options;
+    List<CatalogTable> tables = listAllTables(dataSourceId);
+    if (isBlank(keyword)) return tables.stream().map(this::toOptionVO).toList();
     if (keyword.length() > MAX_MATCH_KEYWORD_LENGTH) {
       throw new DataSourceException(
           DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
@@ -123,9 +115,10 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
     if ("2".equals(matchMode)) {
       try {
         Pattern pattern = Pattern.compile(keyword);
-        return options.stream()
-            .filter(option -> pattern.matcher(String.valueOf(option.getValue())).matches())
-            .collect(Collectors.toList());
+        return tables.stream()
+            .filter(table -> pattern.matcher(table.name()).matches())
+            .map(this::toOptionVO)
+            .toList();
       } catch (PatternSyntaxException exception) {
         throw new DataSourceException(
             DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
@@ -140,19 +133,20 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
               .map(String::trim)
               .filter(name -> !name.isEmpty())
               .collect(Collectors.toSet());
-      return options.stream()
-          .filter(option -> exactNames.contains(String.valueOf(option.getValue())))
-          .collect(Collectors.toList());
+      return tables.stream()
+          .filter(table -> exactNames.contains(table.name()))
+          .map(this::toOptionVO)
+          .toList();
     }
 
-    return options;
+    return tables.stream().map(this::toOptionVO).toList();
   }
 
   @Override
   public List<DataSourceCatalogColumnOptionVO> listColumn(
       Long dataSourceId,
       Map<String, Object> requestBody) {
-    Map<String, Object> request = requireRequest(requestBody);
+    CatalogReadRequest request = toCatalogReadRequest(requestBody);
     validateReadOnlyRequest(request);
     return catalogGateway
         .describe(
@@ -168,9 +162,9 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
   public DataSourceQueryResultVO preview(
       Long dataSourceId,
       Map<String, Object> requestBody) {
-    Map<String, Object> request = requireRequest(requestBody);
+    CatalogReadRequest request = toCatalogReadRequest(requestBody);
     validateReadOnlyRequest(request);
-    QueryResult result =
+    CatalogQueryResult result =
         catalogGateway.preview(
             getDataSourceOrThrow(dataSourceId),
             request,
@@ -181,7 +175,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
 
   @Override
   public Long count(Long dataSourceId, Map<String, Object> requestBody) {
-    Map<String, Object> request = requireRequest(requestBody);
+    CatalogReadRequest request = toCatalogReadRequest(requestBody);
     validateReadOnlyRequest(request);
     return catalogGateway.count(
         getDataSourceOrThrow(dataSourceId),
@@ -200,16 +194,26 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
 
   @Override
   public String resolveSql(Long dataSourceId, Map<String, Object> requestBody) {
-    Map<String, Object> request = requireRequest(requestBody);
-    String query = requiredText(request, "query", "sql");
+    CatalogReadRequest request = toCatalogReadRequest(requestBody);
+    if (request.sql() == null) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "query 不能为空");
+    }
     return catalogGateway.resolveSql(
         getDataSourceOrThrow(dataSourceId),
-        query,
         request,
         connectionTimeoutSeconds());
   }
 
-  private DataSourceCatalogTableVO toTableVO(Table table) {
+  private List<CatalogTable> listAllTables(Long dataSourceId) {
+    return catalogGateway.listTables(
+        getDataSourceOrThrow(dataSourceId),
+        new CatalogTableQuery(null, null, null),
+        connectionTimeoutSeconds());
+  }
+
+  private DataSourceCatalogTableVO toTableVO(CatalogTable table) {
     return new DataSourceCatalogTableVO(
         table.database(),
         table.schema(),
@@ -218,7 +222,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
         table.remarks());
   }
 
-  private DataSourceCatalogColumnVO toColumnVO(Column column) {
+  private DataSourceCatalogColumnVO toColumnVO(CatalogColumn column) {
     return new DataSourceCatalogColumnVO(
         column.name(),
         column.typeName(),
@@ -231,7 +235,7 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
         column.remarks());
   }
 
-  private DataSourceCatalogColumnOptionVO toColumnOptionVO(Column column) {
+  private DataSourceCatalogColumnOptionVO toColumnOptionVO(CatalogColumn column) {
     return new DataSourceCatalogColumnOptionVO(
         column.ordinalPosition(),
         column.name(),
@@ -242,7 +246,12 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
         column.primaryKey() ? "PRI" : "");
   }
 
-  private DataSourceQueryResultVO toPreviewVO(QueryResult result) {
+  private DataSourceCatalogOptionVO toOptionVO(CatalogTable table) {
+    String label = isBlank(table.remarks()) ? table.name() : table.remarks();
+    return new DataSourceCatalogOptionVO(table.name(), label, table.remarks());
+  }
+
+  private DataSourceQueryResultVO toPreviewVO(CatalogQueryResult result) {
     List<DataSourcePreviewColumnVO> columns =
         result.columns().stream()
             .map(
@@ -253,7 +262,54 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
                         column.key(),
                         column.ellipsis()))
             .toList();
-    return new DataSourceQueryResultVO(columns, result.data(), result.total());
+    return new DataSourceQueryResultVO(columns, result.rows(), result.total());
+  }
+
+  private CatalogReadRequest toCatalogReadRequest(Map<String, Object> requestBody) {
+    Map<String, Object> request = requireRequest(requestBody);
+    String readMode = optionalText(request, "read_mode", "readMode");
+    String tablePath = optionalText(request, "table_path", "tablePath", "table");
+    String query = optionalText(request, "query", "sql");
+    ReadMode mode =
+        "sql".equalsIgnoreCase(readMode) || (!isBlank(query) && isBlank(tablePath))
+            ? ReadMode.SQL
+            : ReadMode.TABLE;
+    try {
+      return new CatalogReadRequest(mode, tablePath, query, variables(request));
+    } catch (IllegalArgumentException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          exception.getMessage(),
+          exception);
+    }
+  }
+
+  private List<Variable> variables(Map<String, Object> request) {
+    Object value = request.get("paramsList");
+    if (!(value instanceof Iterable<?> items)) return List.of();
+    List<Variable> variables = new ArrayList<>();
+    for (Object item : items) {
+      if (!(item instanceof Map<?, ?> map)) continue;
+      String name = mapText(map, "paramName", "name");
+      Object rawValue = mapValue(map, "paramValue", "value");
+      if (!isBlank(name)) {
+        variables.add(new Variable(name, rawValue == null ? null : String.valueOf(rawValue)));
+      }
+    }
+    return List.copyOf(variables);
+  }
+
+  private void validateReadOnlyRequest(CatalogReadRequest request) {
+    if (!request.sqlMode()) return;
+    String normalized = request.sql().trim();
+    if (normalized.endsWith(";")) {
+      normalized = normalized.substring(0, normalized.length() - 1).trim();
+    }
+    if (normalized.indexOf(';') >= 0 || !READ_ONLY_SELECT.matcher(normalized).matches()) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
+          "数据预览仅允许执行单条 SELECT 查询");
+    }
   }
 
   private int connectionTimeoutSeconds() {
@@ -277,30 +333,6 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
     return requestBody;
   }
 
-  private void validateReadOnlyRequest(Map<String, Object> request) {
-    String readMode = optionalText(request, "read_mode", "readMode");
-    String tablePath = optionalText(request, "table_path", "tablePath", "table");
-    String query = optionalText(request, "query", "sql");
-    boolean sqlMode =
-        "sql".equalsIgnoreCase(readMode) || (!isBlank(query) && isBlank(tablePath));
-    if (!sqlMode) return;
-    if (isBlank(query)) {
-      throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          "SQL 模式下 query 不能为空");
-    }
-
-    String normalized = query.trim();
-    if (normalized.endsWith(";")) {
-      normalized = normalized.substring(0, normalized.length() - 1).trim();
-    }
-    if (normalized.indexOf(';') >= 0 || !READ_ONLY_SELECT.matcher(normalized).matches()) {
-      throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          "数据预览仅允许执行单条 SELECT 查询");
-    }
-  }
-
   private String requiredText(Map<String, Object> request, String... keys) {
     String value = optionalText(request, keys);
     if (!isBlank(value)) return value;
@@ -310,11 +342,20 @@ public class DataSourceCatalogServiceImpl implements DataSourceCatalogService {
   }
 
   private String optionalText(Map<String, Object> request, String... keys) {
+    Object value = mapValue(request, keys);
+    return value == null || String.valueOf(value).trim().isEmpty()
+        ? null
+        : String.valueOf(value).trim();
+  }
+
+  private String mapText(Map<?, ?> request, String... keys) {
+    Object value = mapValue(request, keys);
+    return value == null ? null : String.valueOf(value).trim();
+  }
+
+  private Object mapValue(Map<?, ?> request, String... keys) {
     for (String key : keys) {
-      Object value = request.get(key);
-      if (value != null && !String.valueOf(value).trim().isEmpty()) {
-        return String.valueOf(value).trim();
-      }
+      if (request.containsKey(key)) return request.get(key);
     }
     return null;
   }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
@@ -2,10 +2,14 @@ package io.yak.ops.business.datasource.architecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.business.datasource.execution.DefaultSqlExecutionRuntime;
+import io.yak.ops.business.datasource.execution.domain.SqlExecutionAggregate;
 import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
 import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway;
 import io.yak.ops.business.datasource.gateway.adapter.SpiDataSourceCatalogGateway;
 import io.yak.ops.business.datasource.gateway.adapter.SpiDataSourcePluginGateway;
+import io.yak.ops.business.datasource.gateway.adapter.SpiSqlExecutionGateway;
 import io.yak.ops.business.datasource.service.impl.DataSourceCatalogServiceImpl;
 import io.yak.ops.business.datasource.service.impl.DataSourceServiceImpl;
 import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
@@ -28,7 +32,11 @@ class DataSourceGatewayArchitectureTest {
 
   @Test
   void businessGatewayContractsDoNotExposePluginSpiOrTransportPersistenceModels() {
-    for (Class<?> port : List.of(DataSourcePluginGateway.class, DataSourceCatalogGateway.class)) {
+    for (Class<?> port :
+        List.of(
+            DataSourcePluginGateway.class,
+            DataSourceCatalogGateway.class,
+            SqlExecutionGateway.class)) {
       for (Method method : port.getMethods()) {
         assertTypeAvoids(port, method.getName(), method.getGenericReturnType(), PORT_FORBIDDEN);
         for (Type parameter : method.getGenericParameterTypes()) {
@@ -44,7 +52,8 @@ class DataSourceGatewayArchitectureTest {
         List.of(
             DataSourceServiceImpl.class,
             DataSourceCatalogServiceImpl.class,
-            DataSourceViewMapper.class)) {
+            DataSourceViewMapper.class,
+            DefaultSqlExecutionRuntime.class)) {
       for (Field field : type.getDeclaredFields()) {
         String fieldType = field.getGenericType().getTypeName();
         assertThat(fieldType)
@@ -62,6 +71,19 @@ class DataSourceGatewayArchitectureTest {
         .isTrue();
     assertThat(DataSourceCatalogGateway.class.isAssignableFrom(SpiDataSourceCatalogGateway.class))
         .isTrue();
+    assertThat(SqlExecutionGateway.class.isAssignableFrom(SpiSqlExecutionGateway.class)).isTrue();
+  }
+
+  @Test
+  void sqlExecutionAggregateDoesNotOwnPhysicalPluginInfrastructure() {
+    for (Field field : SqlExecutionAggregate.class.getDeclaredFields()) {
+      String fieldType = field.getGenericType().getTypeName();
+      assertThat(fieldType)
+          .as("SqlExecutionAggregate." + field.getName())
+          .doesNotContain(".spi.datasource")
+          .doesNotContain("org.springframework")
+          .doesNotContain("java.util.concurrent");
+    }
   }
 
   private void assertTypeAvoids(

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.yak.ops.business.datasource.gateway.adapter.SpiSqlExecutionGateway;
 import io.yak.ops.core.execution.sql.SqlExecutionCaller;
 import io.yak.ops.core.execution.sql.SqlExecutionContext;
 import io.yak.ops.core.execution.sql.SqlExecutionPlan;
@@ -342,7 +343,9 @@ class DefaultSqlExecutionRuntimeTest {
   }
 
   private static DefaultSqlExecutionRuntime runtime(DataSourceExecutionProvider provider) {
-    return new DefaultSqlExecutionRuntime(provider, new DefaultSqlExecutionPolicy());
+    return new DefaultSqlExecutionRuntime(
+        new SpiSqlExecutionGateway(provider),
+        new DefaultSqlExecutionPolicy());
   }
 
   private record CapturedRequest(String dataSourceId, List<Object> parameters) {}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionTransactionCancellationTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionTransactionCancellationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.yak.ops.business.datasource.gateway.adapter.SpiSqlExecutionGateway;
 import io.yak.ops.core.execution.sql.SqlExecutionCaller;
 import io.yak.ops.core.execution.sql.SqlExecutionContext;
 import io.yak.ops.core.execution.sql.SqlExecutionPlan;
@@ -26,16 +27,19 @@ class DefaultSqlExecutionTransactionCancellationTest {
   @Test
   void rollsBackSingleTransactionWhenActiveStatementIsCancelled() throws Exception {
     BlockingTransactionExecutor executor = new BlockingTransactionExecutor();
-    DefaultSqlExecutionRuntime runtime = new DefaultSqlExecutionRuntime(
-        dataSourceId -> executor,
-        new DefaultSqlExecutionPolicy());
-    SqlExecutionSnapshot started = runtime.start(new SqlExecutionPlan(
-        "42",
-        List.of(
-            new SqlStatementRequest("update orders set status = 'RUNNING'", 10, 30),
-            new SqlStatementRequest("insert into audit_log(id) values (1)", 10, 30)),
-        SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-cancel"),
-        SqlTransactionMode.SINGLE_TRANSACTION));
+    DefaultSqlExecutionRuntime runtime =
+        new DefaultSqlExecutionRuntime(
+            new SpiSqlExecutionGateway(dataSourceId -> executor),
+            new DefaultSqlExecutionPolicy());
+    SqlExecutionSnapshot started =
+        runtime.start(
+            new SqlExecutionPlan(
+                "42",
+                List.of(
+                    new SqlStatementRequest("update orders set status = 'RUNNING'", 10, 30),
+                    new SqlStatementRequest("insert into audit_log(id) values (1)", 10, 30)),
+                SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-cancel"),
+                SqlTransactionMode.SINGLE_TRANSACTION));
 
     assertTrue(executor.started.await(2, TimeUnit.SECONDS));
     assertTrue(runtime.cancel(started.executionId()));

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/domain/SqlExecutionAggregateTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/domain/SqlExecutionAggregateTest.java
@@ -1,0 +1,108 @@
+package io.yak.ops.business.datasource.execution.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.core.execution.sql.LexicalSqlStatementClassifier;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementClassification;
+import io.yak.ops.core.execution.sql.SqlStatementRequest;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SqlExecutionAggregateTest {
+
+  private final LexicalSqlStatementClassifier classifier = new LexicalSqlStatementClassifier();
+
+  @Test
+  void lifecycleStartsPendingAndCompletesSucceeded() {
+    SqlExecutionAggregate aggregate = aggregate();
+
+    assertThat(aggregate.snapshot().status()).isEqualTo(SqlExecutionStatus.PENDING);
+    aggregate.markRunning();
+    aggregate.markStatementRunning(0);
+    aggregate.markStatementSucceeded(0, result());
+    aggregate.markStatementRunning(1);
+    aggregate.markStatementSucceeded(1, result());
+    aggregate.finishSucceeded();
+
+    assertThat(aggregate.snapshot().status()).isEqualTo(SqlExecutionStatus.SUCCEEDED);
+    assertThat(aggregate.snapshot().statements())
+        .allMatch(statement -> statement.status() == SqlStatementStatus.SUCCEEDED);
+    assertThat(aggregate.snapshot().startedAt()).isNotNull();
+    assertThat(aggregate.snapshot().finishedAt()).isNotNull();
+  }
+
+  @Test
+  void cancellationIsDomainStateAndSkipsRemainingStatements() {
+    SqlExecutionAggregate aggregate = aggregate();
+    aggregate.markRunning();
+    aggregate.markStatementRunning(0);
+
+    assertThat(aggregate.requestCancel()).isTrue();
+    assertThat(aggregate.snapshot().status()).isEqualTo(SqlExecutionStatus.CANCELLING);
+    aggregate.markStatementCancelled(0, "cancelled");
+    aggregate.finishCancelled(1, "cancelled");
+
+    assertThat(aggregate.snapshot().status()).isEqualTo(SqlExecutionStatus.CANCELLED);
+    assertThat(aggregate.snapshot().statements().get(0).status())
+        .isEqualTo(SqlStatementStatus.CANCELLED);
+    assertThat(aggregate.snapshot().statements().get(1).status())
+        .isEqualTo(SqlStatementStatus.SKIPPED);
+    assertThat(aggregate.requestCancel()).isFalse();
+  }
+
+  @Test
+  void statementFailureOwnsExecutionFailureAndRemainingSkipSemantics() {
+    SqlExecutionAggregate aggregate = aggregate();
+    aggregate.markRunning();
+    aggregate.markStatementRunning(0);
+    aggregate.markStatementFailed(0, "boom");
+    aggregate.finishFailed(1, "boom");
+
+    assertThat(aggregate.snapshot().status()).isEqualTo(SqlExecutionStatus.FAILED);
+    assertThat(aggregate.snapshot().statements().get(0).status())
+        .isEqualTo(SqlStatementStatus.FAILED);
+    assertThat(aggregate.snapshot().statements().get(1).status())
+        .isEqualTo(SqlStatementStatus.SKIPPED);
+    assertThat(aggregate.snapshot().errorMessage()).isEqualTo("boom");
+  }
+
+  @Test
+  void classificationsMustMatchPlanStatements() {
+    SqlExecutionPlan plan = plan();
+    assertThatThrownBy(() -> new SqlExecutionAggregate("sql-1", plan, List.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("classifications");
+  }
+
+  private SqlExecutionAggregate aggregate() {
+    SqlExecutionPlan plan = plan();
+    List<SqlStatementClassification> classifications =
+        plan.statements().stream().map(statement -> classifier.classify(statement.sql())).toList();
+    return new SqlExecutionAggregate("sql-test", plan, classifications);
+  }
+
+  private SqlExecutionPlan plan() {
+    return new SqlExecutionPlan(
+        "42",
+        List.of(
+            new SqlStatementRequest("select 1", 10, 5),
+            new SqlStatementRequest("update demo set enabled = 1", 10, 5)),
+        SqlExecutionContext.of(SqlExecutionCaller.CONSOLE, "console-1"));
+  }
+
+  private io.yak.ops.core.execution.sql.SqlExecutionResult result() {
+    return new io.yak.ops.core.execution.sql.SqlExecutionResult(
+        io.yak.ops.core.execution.sql.SqlExecutionResultType.UPDATE_COUNT,
+        List.of(),
+        List.of(),
+        1L,
+        false,
+        new io.yak.ops.core.execution.sql.SqlExecutionTiming(0L, 1L, 1L));
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
@@ -2,12 +2,18 @@ package io.yak.ops.business.datasource.gateway.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
-import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.Table;
-import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway.TableQuery;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.ReadMode;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.Variable;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTable;
+import io.yak.ops.business.datasource.domain.catalog.CatalogTableQuery;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
@@ -15,8 +21,11 @@ import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
 import io.yak.ops.spi.datasource.metadata.DataSourceTable;
+import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class SpiDataSourceCatalogGatewayTest {
 
@@ -24,29 +33,22 @@ class SpiDataSourceCatalogGatewayTest {
   private final DataSourcePlugin plugin = mock(DataSourcePlugin.class);
   private final DataSourceConnection connection = mock(DataSourceConnection.class);
   private final DataSourceCatalog catalog = mock(DataSourceCatalog.class);
-  private final SpiDataSourceCatalogGateway gateway =
-      new SpiDataSourceCatalogGateway(registry);
+  private final SpiDataSourceCatalogGateway gateway = new SpiDataSourceCatalogGateway(registry);
 
   @Test
-  void listTablesTranslatesPluginMetadataToBusinessGatewayContract() {
-    DataSourceDefinition dataSource = dataSource();
-    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
-    when(plugin.parseConnection(dataSource.getConnectionParams())).thenReturn(connection);
-    when(plugin.createCatalog(connection, 5)).thenReturn(catalog);
+  void listTablesTranslatesPluginMetadataToCatalogDomain() {
+    DataSourceDefinition dataSource = configuredDataSource();
+    stubCatalog(dataSource);
     when(catalog.listTables(any(DataSourceCatalogQuery.class)))
         .thenReturn(
             List.of(
                 new DataSourceTable(
-                    "orders_db",
-                    "public",
-                    "orders",
-                    "TABLE",
-                    "order table")));
+                    "orders_db", "public", "orders", "TABLE", "order table")));
 
-    List<Table> result =
+    List<CatalogTable> result =
         gateway.listTables(
             dataSource,
-            new TableQuery("orders_db", "public", "ord"),
+            new CatalogTableQuery("orders_db", "public", "ord"),
             5);
 
     assertThat(result).hasSize(1);
@@ -57,7 +59,37 @@ class SpiDataSourceCatalogGatewayTest {
     assertThat(result.getFirst().remarks()).isEqualTo("order table");
   }
 
-  private DataSourceDefinition dataSource() {
+  @Test
+  void typedCatalogRequestIsProjectedToLegacyPluginMapOnlyInsideAdapter() {
+    DataSourceDefinition dataSource = configuredDataSource();
+    stubCatalog(dataSource);
+    when(catalog.preview(any(Map.class), eq(20)))
+        .thenReturn(new DataSourceQueryResult(List.of(), List.of(), 0L));
+    CatalogReadRequest request =
+        new CatalogReadRequest(
+            ReadMode.SQL,
+            null,
+            "select * from orders where day = ${day}",
+            List.of(new Variable("day", "2026-08-23")));
+
+    CatalogQueryResult result = gateway.preview(dataSource, request, 20, 5);
+
+    ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+    verify(catalog).preview(captor.capture(), eq(20));
+    Map<String, Object> pluginRequest = captor.getValue();
+    assertThat(pluginRequest.get("read_mode")).isEqualTo("sql");
+    assertThat(pluginRequest.get("query")).isEqualTo(request.sql());
+    assertThat(pluginRequest.get("paramsList")).isInstanceOf(List.class);
+    assertThat(result.total()).isZero();
+  }
+
+  private void stubCatalog(DataSourceDefinition dataSource) {
+    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(plugin.parseConnection(dataSource.getConnectionParams())).thenReturn(connection);
+    when(plugin.createCatalog(connection, 5)).thenReturn(catalog);
+  }
+
+  private DataSourceDefinition configuredDataSource() {
     DataSourceDefinition dataSource = new DataSourceDefinition();
     dataSource.setDbType(DataSourceDbType.MYSQL);
     dataSource.setConnectionParams("{\"database\":\"orders_db\"}");

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiSqlExecutionGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiSqlExecutionGatewayTest.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.datasource.gateway.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway.Command;
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway.Result;
+import io.yak.ops.business.datasource.gateway.SqlExecutionGateway.Session;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlColumn;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlRequest;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SpiSqlExecutionGatewayTest {
+
+  @Test
+  void mapsBusinessCommandAndPluginResultWithoutLeakingSpi() {
+    DataSourceExecutionProvider provider = mock(DataSourceExecutionProvider.class);
+    DataSourceSqlExecutor executor = mock(DataSourceSqlExecutor.class);
+    when(provider.open("42")).thenReturn(executor);
+    when(executor.execute(any(DataSourceSqlRequest.class)))
+        .thenReturn(
+            DataSourceSqlResult.resultSet(
+                List.of(new DataSourceSqlColumn("name", "name", "VARCHAR", Types.VARCHAR, true)),
+                List.of(Arrays.asList("Yak", null)),
+                false));
+
+    SpiSqlExecutionGateway gateway = new SpiSqlExecutionGateway(provider);
+    try (Session session = gateway.open("42")) {
+      Result result = session.execute(new Command("select name from demo", List.of(), 20, 5));
+
+      assertThat(result.resultSet()).isTrue();
+      assertThat(result.columns()).hasSize(1);
+      assertThat(result.columns().getFirst().name()).isEqualTo("name");
+      assertThat(result.rows().getFirst()).containsExactly("Yak", null);
+    }
+
+    verify(provider).open("42");
+    verify(executor).close();
+  }
+
+  @Test
+  void transactionAndCancellationCapabilitiesDelegateOnlyInsideAdapter() {
+    DataSourceExecutionProvider provider = mock(DataSourceExecutionProvider.class);
+    DataSourceSqlExecutor executor = mock(DataSourceSqlExecutor.class);
+    when(provider.open("9")).thenReturn(executor);
+    when(executor.supportsTransactions()).thenReturn(true);
+
+    SpiSqlExecutionGateway gateway = new SpiSqlExecutionGateway(provider);
+    try (Session session = gateway.open("9")) {
+      assertThat(session.supportsTransactions()).isTrue();
+      session.beginTransaction();
+      session.cancel();
+      session.rollbackTransaction();
+    }
+
+    verify(executor).beginTransaction();
+    verify(executor).cancel();
+    verify(executor).rollbackTransaction();
+    verify(executor).close();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImplTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourceCatalogServiceImplTest.java
@@ -1,15 +1,27 @@
 package io.yak.ops.business.datasource.service.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.ReadMode;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class DataSourceCatalogServiceImplTest {
 
@@ -25,9 +37,7 @@ class DataSourceCatalogServiceImplTest {
             () ->
                 service.preview(
                     1L,
-                    Map.of(
-                        "read_mode", "sql",
-                        "query", "DELETE FROM patient")))
+                    Map.of("read_mode", "sql", "query", "DELETE FROM patient")))
         .isInstanceOf(DataSourceException.class)
         .hasMessageContaining("仅允许执行单条 SELECT 查询");
 
@@ -41,9 +51,42 @@ class DataSourceCatalogServiceImplTest {
                 service.count(
                     1L,
                     Map.of(
-                        "read_mode", "sql",
-                        "query", "SELECT * FROM patient; DROP TABLE patient")))
+                        "read_mode",
+                        "sql",
+                        "query",
+                        "SELECT * FROM patient; DROP TABLE patient")))
         .isInstanceOf(DataSourceException.class)
         .hasMessageContaining("仅允许执行单条 SELECT 查询");
+  }
+
+  @Test
+  void legacyHttpMapIsParsedOnceIntoTypedCatalogRequest() {
+    DataSourceRepository typedRepository = mock(DataSourceRepository.class);
+    DataSourceCatalogGateway typedGateway = mock(DataSourceCatalogGateway.class);
+    DataSourceProperties typedProperties = new DataSourceProperties();
+    DataSourceCatalogServiceImpl typedService =
+        new DataSourceCatalogServiceImpl(typedRepository, typedGateway, typedProperties);
+    DataSourceDefinition dataSource = new DataSourceDefinition();
+    when(typedRepository.findById(1L)).thenReturn(Optional.of(dataSource));
+    when(typedGateway.preview(eq(dataSource), any(CatalogReadRequest.class), eq(20), eq(5)))
+        .thenReturn(new CatalogQueryResult(List.of(), List.of(), 0L));
+
+    typedService.preview(
+        1L,
+        Map.of(
+            "readMode",
+            "sql",
+            "sql",
+            "SELECT * FROM patient WHERE day = ${day}",
+            "paramsList",
+            List.of(Map.of("paramName", "day", "paramValue", "2026-08-23"))));
+
+    ArgumentCaptor<CatalogReadRequest> captor = ArgumentCaptor.forClass(CatalogReadRequest.class);
+    verify(typedGateway).preview(eq(dataSource), captor.capture(), eq(20), eq(5));
+    CatalogReadRequest request = captor.getValue();
+    assertThat(request.mode()).isEqualTo(ReadMode.SQL);
+    assertThat(request.sql()).isEqualTo("SELECT * FROM patient WHERE day = ${day}");
+    assertThat(request.variables()).hasSize(1);
+    assertThat(request.variables().getFirst().name()).isEqualTo("day");
   }
 }


### PR DESCRIPTION
# Datasource Change

> Recovery landing PR for Phase 3. #665 was merged into the Phase 2 branch after Phase 2 had already landed to `main`, so this PR restores the intended `Phase 3 -> main` landing path without adding Phase 4 code.

## Summary

将已完成并通过 guardrail 的 Datasource Phase 3 真正落到 `main`：

- Catalog typed Business Domain：`CatalogReadRequest / CatalogTableQuery / CatalogTablePath / CatalogTable / CatalogColumn / CatalogQueryResult`
- `DataSourceCatalogGateway` Map-free typed contract
- `SqlExecutionAggregate` 生命周期领域对象
- `SqlExecutionGateway` + `SpiSqlExecutionGateway`
- `DefaultSqlExecutionRuntime` 与 Datasource execution SPI 解耦
- Phase 3 static guardrail + framework-free Java 21 domain smoke

## Domain Impact Analysis

```text
Aggregate(s): SqlExecutionAggregate
Subdomain(s): typed Catalog Domain
Layer: Domain / Application / Gateway / Adapter / Runtime / Test / Documentation
Invariant/lifecycle impact: identical to already-reviewed Phase 3 #665
Domain Gap: no
```

## Compatibility

保持 REST API、DTO/VO JSON、`yak_ops_data_source`、Flyway、Datasource Plugin SPI、现有数据库插件、`yak-ops-core` SQL public contract 不变。

## Tests / Safety

#665 最新验证：

```text
Datasource Domain Guardrails: PASS
Static domain contract: PASS
Framework-free Phase 3 domain smoke: PASS
Backend regression hook: PASS
Maven/JUnit: SKIPPED - YAK_FRAMEWORK_TOKEN 未配置
```

## Domain Compliance Report

```text
Rule changed/implemented:
- Catalog Business path typed and Map-free
- SQL lifecycle owned by SqlExecutionAggregate
- physical SQL access behind SqlExecutionGateway
Safety/tests:
- Phase 3 static contract retained
- Java 21 compile/smoke retained
Known gaps:
- Phase 4 Plugin Capability / Descriptor / API standardization
```

## History recovery

```text
Phase 2 #664 -> merged to main
Phase 3 #665 -> accidentally merged into Phase 2 branch
this PR       -> correct Phase 3 landing into main
```
