### PR TITLE
refactor(datasource): land final phase 4 plugin standard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/datasource-domain.md
+++ b/.github/PULL_REQUEST_TEMPLATE/datasource-domain.md
@@ -1,6 +1,6 @@
 # Datasource Change
 
-> 开发前读 `REQUIREMENTS.md + DOMAIN.md`；Review 按 `REVIEW.md`。
+> 开发前读 `REQUIREMENTS.md + DOMAIN.md`；涉及插件时同时读 `yak-ops-plugins/yak-ops-plugin-datasource/PLUGIN.md`；Review 按 `REVIEW.md`。
 
 ## Summary
 
@@ -9,19 +9,29 @@
 ## Domain Impact Analysis
 
 ```text
-Aggregate(s): DataSourceDefinition / ConnectionProfile / adjacent / none
+Aggregate(s): DataSourceDefinition / SqlExecutionAggregate / adjacent / none
+Subdomain(s): Catalog / Plugin / SQL Execution / none
 Invariant/lifecycle impact:
-Layer: Domain / Application / Infrastructure / Interface
+Layer: Domain / Application / Gateway / Adapter / Infrastructure / Interface
 Domain Gap: no
+```
+
+## Plugin Contract Impact
+
+```text
+Plugin API changed: no
+Descriptor / Capability changed: no
+Catalog SPI changed: no
+apiVersion / migration required: no
 ```
 
 ## Compatibility
 
-<!-- 是否影响 REST / yak_ops_data_source / Flyway / Datasource Plugin SPI / 已有插件？ -->
+<!-- 是否影响 REST / yak_ops_data_source / Flyway / Plugin SPI / 内置或第三方插件 / yak-ops-core SQL contract？ -->
 
 ## Tests / Safety
 
-<!-- 跑了什么；涉及连接状态、Secret、Catalog / SQL 只读边界时说明是否保持。 -->
+<!-- 跑了什么；涉及连接状态、Secret、Catalog、Plugin Contract、SQL lifecycle 时说明对应 guardrail。 -->
 
 ## Domain Compliance Report
 

--- a/.github/workflows/datasource-domain-guardrails.yml
+++ b/.github/workflows/datasource-domain-guardrails.yml
@@ -5,10 +5,12 @@ on:
     types: [opened, synchronize, reopened, edited]
     paths:
       - 'yak-ops-business/yak-ops-business-datasource/**'
+      - 'yak-ops-plugins/yak-ops-plugin-datasource/**'
       - 'yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/**'
       - 'yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/**'
       - 'tools/datasource_domain_guardrails.py'
       - 'tools/datasource-domain-smoke/**'
+      - 'tools/datasource-plugin-smoke/**'
       - '.github/PULL_REQUEST_TEMPLATE/datasource-domain.md'
       - '.github/workflows/datasource-domain-guardrails.yml'
   push:
@@ -16,10 +18,12 @@ on:
       - main
     paths:
       - 'yak-ops-business/yak-ops-business-datasource/**'
+      - 'yak-ops-plugins/yak-ops-plugin-datasource/**'
       - 'yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/**'
       - 'yak-ops-core/src/main/java/io/yak/ops/core/execution/sql/**'
       - 'tools/datasource_domain_guardrails.py'
       - 'tools/datasource-domain-smoke/**'
+      - 'tools/datasource-plugin-smoke/**'
       - '.github/PULL_REQUEST_TEMPLATE/datasource-domain.md'
       - '.github/workflows/datasource-domain-guardrails.yml'
   workflow_dispatch:
@@ -76,11 +80,56 @@ jobs:
 
           java -cp "$OUT" DatasourceDomainSmoke
 
+  phase4-plugin-contract-smoke:
+    name: Framework-free Phase 4 plugin contract smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout yak-ops
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Compile plugin API and typed JDBC Catalog
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/datasource-plugin"
+          STUB="$RUNNER_TEMP/datasource-plugin-stub"
+          rm -rf "$OUT" "$STUB"
+          mkdir -p "$OUT" "$STUB/io/yak/ops/common/enums/datasource"
+
+          cat > "$STUB/io/yak/ops/common/enums/datasource/DataSourceDbType.java" <<'EOF'
+          package io.yak.ops.common.enums.datasource;
+          public enum DataSourceDbType {
+            MYSQL("MySQL"), ORACLE("Oracle"), POSTGRE_SQL("PostgreSQL"), DORIS("Doris"),
+            KINGBASE("KingbaseES"), DAMENG("达梦");
+            private final String displayName;
+            DataSourceDbType(String displayName) { this.displayName = displayName; }
+            public String getDisplayName() { return displayName; }
+          }
+          EOF
+
+          javac --release 21 -d "$OUT" \
+            "$STUB/io/yak/ops/common/enums/datasource/DataSourceDbType.java" \
+            $(find yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java -name '*.java' -print) \
+            yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/SshTunnelConfig.java \
+            yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcConnectionProperties.java \
+            yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java \
+            tools/datasource-plugin-smoke/DatasourcePluginContractSmoke.java
+
+          java -cp "$OUT" DatasourcePluginContractSmoke
+
   backend-domain-regression:
     name: Backend regression hook
     needs:
       - static-domain-contract
       - phase3-domain-smoke
+      - phase4-plugin-contract-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -92,7 +141,7 @@ jobs:
       - name: Explain private dependency requirement
         if: env.YAK_FRAMEWORK_TOKEN == ''
         run: |
-          echo "::notice title=Backend regression not executed::yak-framework is a private repository. Configure repository secret YAK_FRAMEWORK_TOKEN with read access to enable the full Maven/JUnit regression layer. Static and framework-free Datasource domain checks remain mandatory without this secret."
+          echo "::notice title=Backend regression not executed::yak-framework is a private repository. Configure repository secret YAK_FRAMEWORK_TOKEN with read access to enable Maven/JUnit regression. Static, Phase 3 domain smoke and Phase 4 plugin contract smoke remain mandatory without this secret."
 
       - name: Checkout yak-framework SNAPSHOT dependency
         if: env.YAK_FRAMEWORK_TOKEN != ''
@@ -114,15 +163,27 @@ jobs:
         if: env.YAK_FRAMEWORK_TOKEN != ''
         run: ./mvnw -B -ntp -f .ci/yak-framework/pom.xml -DskipTests install
 
-      - name: Build datasource module dependencies
+      - name: Build datasource business and plugin modules
         if: env.YAK_FRAMEWORK_TOKEN != ''
-        run: ./mvnw -B -ntp -pl "$DATASOURCE_MODULE" -am -DskipTests install
+        run: >-
+          ./mvnw -B -ntp
+          -pl :yak-ops-business-datasource,:yak-ops-plugin-datasource-jdbc,:yak-ops-plugin-datasource-doris
+          -am -DskipTests install
 
-      - name: Run targeted datasource domain regression tests
+      - name: Run targeted datasource business regression tests
         if: env.YAK_FRAMEWORK_TOKEN != ''
         run: >-
           ./mvnw -B -ntp
           -pl "$DATASOURCE_MODULE"
-          -Dtest=DataSourceDomainArchitectureTest,DataSourceGatewayArchitectureTest,DataSourceLayeringConventionTest,DataSourceDefinitionTest,DataSourceRepositoryAdapterTest,DataSourceServiceImplTest,DataSourceCatalogServiceImplTest,DataSourceViewMapperTest,SpiDataSourcePluginGatewayTest,SpiDataSourceCatalogGatewayTest,DefaultSqlExecutionRuntimeTest,DefaultSqlExecutionTransactionCancellationTest,ObservableSqlExecutionRuntimeTest,SqlExecutionAggregateTest,SpiSqlExecutionGatewayTest
+          -Dtest=DataSourceDomainArchitectureTest,DataSourceGatewayArchitectureTest,DataSourceLayeringConventionTest,DataSourceDefinitionTest,DataSourceRepositoryAdapterTest,DataSourceServiceImplTest,DataSourceCatalogServiceImplTest,DataSourcePluginConfigServiceImplTest,DataSourceViewMapperTest,DataSourcePluginViewMapperTest,DataSourceSecretCodecTest,SpiDataSourcePluginGatewayTest,SpiDataSourceCatalogGatewayTest,DefaultSqlExecutionRuntimeTest,DefaultSqlExecutionTransactionCancellationTest,ObservableSqlExecutionRuntimeTest,SqlExecutionAggregateTest,SpiSqlExecutionGatewayTest
+          -Dsurefire.failIfNoSpecifiedTests=false
+          test
+
+      - name: Run datasource plugin contract regression tests
+        if: env.YAK_FRAMEWORK_TOKEN != ''
+        run: >-
+          ./mvnw -B -ntp
+          -pl :yak-ops-plugin-datasource-jdbc,:yak-ops-plugin-datasource-doris
+          -Dtest=JdbcDatasourcePluginContractTest,GenericJdbcCatalogTypedRequestTest,MySqlDataSourcePluginTest,DorisDataSourcePluginTest
           -Dsurefire.failIfNoSpecifiedTests=false
           test

--- a/tools/datasource-plugin-smoke/DatasourcePluginContractSmoke.java
+++ b/tools/datasource-plugin-smoke/DatasourcePluginContractSmoke.java
@@ -1,0 +1,57 @@
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.plugin.database.jdbc.GenericJdbcCatalog;
+import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.ConnectionForm;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class DatasourcePluginContractSmoke {
+
+  public static void main(String[] args) {
+    DataSourcePluginDescriptor descriptor =
+        new DataSourcePluginDescriptor(
+            DataSourceDbType.MYSQL,
+            "MySQL",
+            DataSourcePluginDescriptor.CURRENT_API_VERSION,
+            Set.of(
+                DataSourceCapability.CONNECTION_TEST,
+                DataSourceCapability.CATALOG_METADATA,
+                DataSourceCapability.CATALOG_READ),
+            ConnectionForm.empty(),
+            false,
+            null);
+    require(descriptor.supports(DataSourceCapability.CATALOG_READ), "capability missing");
+    require("1".equals(descriptor.apiVersion()), "api version mismatch");
+
+    JdbcConnectionProperties connection =
+        new JdbcConnectionProperties(
+            DataSourceDbType.MYSQL,
+            "jdbc:mysql://localhost:3306/demo",
+            "test.Driver",
+            "test_user",
+            null,
+            "demo",
+            null,
+            Map.of(),
+            "{}");
+    GenericJdbcCatalog catalog = new GenericJdbcCatalog(connection, 5);
+    DataSourceCatalogReadRequest request =
+        DataSourceCatalogReadRequest.sql(
+            "select '${day}' as day_value, ${var:tenant} as tenant_value",
+            Map.of("day", "2026-08-23", "tenant", "42"));
+    String resolved = catalog.resolveSql(request.query(), request);
+    require(
+        "select '2026-08-23' as day_value, 42 as tenant_value".equals(resolved),
+        "typed catalog variable resolution failed: " + resolved);
+
+    System.out.println("Datasource Plugin Contract Smoke: OK");
+  }
+
+  private static void require(boolean condition, String message) {
+    if (!condition) throw new IllegalStateException(message);
+  }
+}

--- a/tools/datasource_domain_guardrails.py
+++ b/tools/datasource_domain_guardrails.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Zero-dependency guardrails for the Datasource domain."""
+"""Zero-dependency guardrails for the Datasource domain and plugin contract."""
 
 from __future__ import annotations
 
@@ -14,8 +14,15 @@ MODULE = ROOT / "yak-ops-business/yak-ops-business-datasource"
 JAVA_ROOT = MODULE / "src/main/java/io/yak/ops/business/datasource"
 DOMAIN_DIR = JAVA_ROOT / "domain"
 CATALOG_DOMAIN_DIR = DOMAIN_DIR / "catalog"
+PLUGIN_DOMAIN_DIR = DOMAIN_DIR / "plugin"
 EXECUTION_DOMAIN_DIR = JAVA_ROOT / "execution/domain"
 GATEWAY_DIR = JAVA_ROOT / "gateway"
+PLUGIN_ROOT = ROOT / "yak-ops-plugins/yak-ops-plugin-datasource"
+PLUGIN_API_DIR = (
+    PLUGIN_ROOT
+    / "yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource"
+)
+PLUGIN_DOC = PLUGIN_ROOT / "PLUGIN.md"
 
 CORE_FILES = (
     "ConnectionProfile.java",
@@ -61,7 +68,9 @@ PORT_FORBIDDEN_IMPORTS = (
 PROTECTED_APPLICATION_FILES = (
     "service/impl/DataSourceServiceImpl.java",
     "service/impl/DataSourceCatalogServiceImpl.java",
+    "service/impl/DataSourcePluginConfigServiceImpl.java",
     "service/support/DataSourceViewMapper.java",
+    "service/support/DataSourcePluginViewMapper.java",
     "execution/DefaultSqlExecutionRuntime.java",
 )
 
@@ -128,10 +137,7 @@ def check_core(g: Guard) -> None:
     ):
         g.check(behavior in code, f"DataSource aggregate behavior missing: {behavior}")
 
-    g.check(
-        "record ConnectionProfile" in profile,
-        "ConnectionProfile must remain an immutable record value object",
-    )
+    g.check("record ConnectionProfile" in profile, "ConnectionProfile must remain immutable")
     for field in ("jdbcUrl", "connectionParams", "originalJson"):
         g.check(
             f"@ToString.Exclude private String {field};" in definition,
@@ -145,29 +151,32 @@ def check_catalog_domain(g: Guard) -> None:
         check_no_forbidden_imports(g, f"catalog/{name}", text)
 
     request = g.read(CATALOG_DOMAIN_DIR / "CatalogReadRequest.java")
-    g.check("enum ReadMode" in request, "CatalogReadRequest must own explicit TABLE/SQL mode")
+    g.check("enum ReadMode" in request, "CatalogReadRequest must own TABLE/SQL mode")
     g.check("TABLE" in request and "SQL" in request, "Catalog read modes must remain explicit")
 
     gateway = g.read(GATEWAY_DIR / "DataSourceCatalogGateway.java")
-    code = code_only(gateway)
+    gateway_code = code_only(gateway)
     g.check("CatalogReadRequest" in gateway, "Catalog gateway must use typed CatalogReadRequest")
-    g.check("Map<String" not in code and "Map<" not in code, "Catalog gateway must not expose Map protocol")
+    g.check("Map<" not in gateway_code, "Business Catalog gateway must not expose Map protocol")
     for name in ("CatalogTable", "CatalogColumn", "CatalogQueryResult"):
-        g.check(name in gateway, f"Catalog gateway must expose business catalog model: {name}")
+        g.check(name in gateway, f"Catalog gateway missing business model: {name}")
 
     service = g.read(JAVA_ROOT / "service/impl/DataSourceCatalogServiceImpl.java")
-    g.check("toCatalogReadRequest(" in service, "HTTP Catalog Map must be parsed once at application boundary")
-    g.check("CatalogReadRequest" in service, "Catalog application service must use typed request")
+    g.check("toCatalogReadRequest(" in service, "HTTP Catalog Map must be parsed once")
+    g.check("CatalogReadRequest" in service, "Catalog service must use typed request")
 
     adapter = g.read(GATEWAY_DIR / "adapter/SpiDataSourceCatalogGateway.java")
-    g.check("toPluginRequest(" in adapter, "SPI catalog adapter must own legacy Map projection")
-    g.check("Map<String, Object>" in adapter, "Legacy Plugin Map must stay isolated in SPI adapter")
+    g.check(
+        "DataSourceCatalogReadRequest" in adapter,
+        "Catalog SPI adapter must translate Business request to typed Plugin request",
+    )
+    for legacy in ("paramsList", '"read_mode"', "Map<String, Object>"):
+        g.check(legacy not in adapter, f"Legacy Catalog Map leaked into Plugin adapter: {legacy}")
 
 
 def check_application_mutations(g: Guard) -> None:
     service = g.read(JAVA_ROOT / "service/impl/DataSourceServiceImpl.java")
     code = code_only(service)
-
     for required in (
         "DataSourceDefinition.create(",
         "existing.assertTypeUnchanged(",
@@ -175,29 +184,27 @@ def check_application_mutations(g: Guard) -> None:
         "definition.markConnected(",
         "definition.markDisconnected(",
     ):
-        g.check(required in code, f"Application service bypassed aggregate behavior: missing {required}")
-
+        g.check(required in code, f"Application service bypassed aggregate behavior: {required}")
     for forbidden in (
         ".setConnStatus(",
         ".setJdbcUrl(",
         ".setConnectionParams(",
         ".setOriginalJson(",
     ):
-        g.check(forbidden not in code, f"Application service must not mutate aggregate scalar directly: {forbidden}")
+        g.check(forbidden not in code, f"Application service must not mutate scalar: {forbidden}")
 
 
 def check_gateway_boundary(g: Guard) -> None:
-    ports = (
+    for name in (
         "DataSourcePluginGateway.java",
         "DataSourceCatalogGateway.java",
         "SqlExecutionGateway.java",
-    )
-    for name in ports:
+    ):
         text = g.read(GATEWAY_DIR / name)
         for imported in imports_of(text):
             g.check(
                 not imported.startswith(PORT_FORBIDDEN_IMPORTS),
-                f"{name}: business gateway contract leaked external model: {imported}",
+                f"{name}: business gateway leaked external model: {imported}",
             )
 
     for relative in PROTECTED_APPLICATION_FILES:
@@ -205,52 +212,127 @@ def check_gateway_boundary(g: Guard) -> None:
         for imported in imports_of(text):
             g.check(
                 not imported.startswith("io.yak.ops.spi.datasource."),
-                f"{relative}: Datasource Plugin SPI must stay behind Gateway Adapter: {imported}",
+                f"{relative}: Plugin SPI must stay behind Adapter: {imported}",
             )
             g.check(
                 imported != "io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry",
-                f"{relative}: Plugin Registry must stay behind Gateway Adapter",
+                f"{relative}: Plugin Registry must stay behind Adapter",
             )
             g.check(
                 imported != "io.yak.ops.business.datasource.util.DataSourceSecretCodec",
-                f"{relative}: SPI secret helper must stay behind Gateway Adapter",
+                f"{relative}: Secret helper must stay behind Adapter",
             )
 
     service = g.read(JAVA_ROOT / "service/impl/DataSourceServiceImpl.java")
     catalog_service = g.read(JAVA_ROOT / "service/impl/DataSourceCatalogServiceImpl.java")
+    plugin_config_service = g.read(JAVA_ROOT / "service/impl/DataSourcePluginConfigServiceImpl.java")
     view_mapper = g.read(JAVA_ROOT / "service/support/DataSourceViewMapper.java")
+    plugin_view_mapper = g.read(JAVA_ROOT / "service/support/DataSourcePluginViewMapper.java")
     runtime = g.read(JAVA_ROOT / "execution/DefaultSqlExecutionRuntime.java")
-    g.check("DataSourcePluginGateway" in service, "DataSourceServiceImpl must use DataSourcePluginGateway")
-    g.check("DataSourceCatalogGateway" in catalog_service, "DataSourceCatalogServiceImpl must use DataSourceCatalogGateway")
-    g.check("DataSourcePluginGateway" in view_mapper, "DataSourceViewMapper must use DataSourcePluginGateway for masking")
-    g.check("SqlExecutionGateway" in runtime, "DefaultSqlExecutionRuntime must use SqlExecutionGateway")
+    g.check("DataSourcePluginGateway" in service, "DataSourceServiceImpl must use plugin gateway")
+    g.check("DataSourceCatalogGateway" in catalog_service, "Catalog service must use catalog gateway")
+    g.check("DataSourcePluginGateway" in plugin_config_service, "Plugin config service must use gateway")
+    g.check("DataSourcePluginViewMapper" in plugin_config_service, "Plugin config service must use view mapper")
+    g.check("DataSourcePluginGateway" in view_mapper, "DataSourceViewMapper must use plugin gateway")
+    g.check("DataSourcePluginDescriptor" in plugin_view_mapper, "Plugin view mapper must project Business descriptor")
+    g.check("SqlExecutionGateway" in runtime, "SQL Runtime must use SqlExecutionGateway")
 
-    adapters = (
+    for relative, marker in (
         ("adapter/SpiDataSourcePluginGateway.java", "implements DataSourcePluginGateway"),
         ("adapter/SpiDataSourceCatalogGateway.java", "implements DataSourceCatalogGateway"),
         ("adapter/SpiSqlExecutionGateway.java", "implements SqlExecutionGateway"),
-    )
-    for relative, marker in adapters:
+    ):
         text = g.read(GATEWAY_DIR / relative)
         g.check(marker in text, f"{relative}: SPI adapter must implement business port")
-        g.check("io.yak.ops.spi.datasource" in text, f"{relative}: adapter must own plugin protocol translation")
+        g.check("io.yak.ops.spi.datasource" in text, f"{relative}: adapter must own SPI translation")
+
+
+def check_plugin_contract(g: Guard) -> None:
+    plugin_api = g.read(PLUGIN_API_DIR / "DataSourcePlugin.java")
+    catalog_api = g.read(PLUGIN_API_DIR / "DataSourceCatalog.java")
+    descriptor = g.read(PLUGIN_API_DIR / "DataSourcePluginDescriptor.java")
+    capability = g.read(PLUGIN_API_DIR / "DataSourceCapability.java")
+    typed_request = g.read(PLUGIN_API_DIR / "catalog/DataSourceCatalogReadRequest.java")
+
+    g.check("descriptor()" in plugin_api, "DataSourcePlugin must expose descriptor()")
+    g.check("pluginConfig(" not in plugin_api, "DataSourcePlugin.pluginConfig() must not return")
+    g.check("DataSourcePluginConfigVO" not in plugin_api, "Plugin API must not depend on HTTP VO")
+    g.check("DataSourceCatalogReadRequest" in catalog_api, "Plugin Catalog must use typed read request")
+    g.check("Map<" not in code_only(catalog_api), "Plugin Catalog stable contract must be Map-free")
+    g.check("CURRENT_API_VERSION" in descriptor, "Plugin Descriptor must expose API version")
+    g.check("secretFieldKeys()" in descriptor, "Plugin Descriptor must declare secret-field semantics")
+    g.check("record DataSourceCatalogReadRequest" in typed_request, "Typed Plugin Catalog request missing")
+
+    for name in (
+        "CONNECTION_TEST",
+        "CATALOG_METADATA",
+        "CATALOG_READ",
+        "SQL_EXECUTION",
+        "TRANSACTIONS",
+        "SSH_TUNNEL",
+    ):
+        g.check(name in capability, f"Datasource capability missing: {name}")
+
+    for path in PLUGIN_API_DIR.rglob("*.java"):
+        text = path.read_text(encoding="utf-8")
+        for forbidden in (
+            "io.yak.ops.common.bean.vo.",
+            "io.yak.ops.common.bean.dto.",
+            "io.yak.ops.business.datasource.",
+        ):
+            g.check(forbidden not in text, f"Plugin API leaked application model: {path.name}:{forbidden}")
+
+    for module in ("yak-ops-plugin-datasource-jdbc", "yak-ops-plugin-datasource-doris"):
+        source_root = PLUGIN_ROOT / module / "src/main/java"
+        for path in source_root.rglob("*.java"):
+            text = path.read_text(encoding="utf-8")
+            g.check("DataSourcePluginConfigVO" not in text, f"Plugin implementation leaked HTTP VO: {path}")
+            g.check("pluginConfig(" not in text, f"Legacy pluginConfig() implementation returned: {path}")
+
+        service_file = (
+            PLUGIN_ROOT
+            / module
+            / "src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin"
+        )
+        g.check(service_file.exists(), f"{module}: ServiceLoader registration missing")
+
+    registry = g.read(JAVA_ROOT / "plugin/DataSourcePluginRegistry.java")
+    for marker in (
+        "validateDescriptor(",
+        "CURRENT_API_VERSION",
+        "TRANSACTIONS",
+        "SQL_EXECUTION",
+        "CATALOG_READ",
+        "CATALOG_METADATA",
+    ):
+        g.check(marker in registry, f"Plugin registry validation missing: {marker}")
+
+    secret_codec = g.read(JAVA_ROOT / "util/DataSourceSecretCodec.java")
+    g.check("DataSourcePluginDescriptor" in secret_codec, "Secret codec must read Plugin Descriptor")
+    g.check("DataSourcePluginConfigVO" not in secret_codec, "Secret codec must not read HTTP VO")
+    g.check("FormFieldVO" not in secret_codec, "Secret codec must not read VO form fields")
+
+    business_descriptor = g.read(PLUGIN_DOMAIN_DIR / "DataSourcePluginDescriptor.java")
+    check_no_forbidden_imports(g, "plugin/DataSourcePluginDescriptor.java", business_descriptor)
+
+    plugin_doc = g.read(PLUGIN_DOC)
+    for phrase in (
+        "DataSourcePluginDescriptor",
+        "DataSourceCapability",
+        "DataSourceCatalogReadRequest",
+        "ServiceLoader",
+        "Phase 4 SPI 迁移",
+        "Review Checklist",
+    ):
+        g.check(phrase in plugin_doc, f"PLUGIN.md lost required phrase: {phrase}")
 
 
 def check_sql_execution_domain(g: Guard) -> None:
     aggregate = g.read(EXECUTION_DOMAIN_DIR / "SqlExecutionAggregate.java")
     for imported in imports_of(aggregate):
-        g.check(
-            not imported.startswith("io.yak.ops.spi.datasource."),
-            f"SqlExecutionAggregate must not import datasource SPI: {imported}",
-        )
-        g.check(
-            not imported.startswith("org.springframework."),
-            f"SqlExecutionAggregate must not import Spring: {imported}",
-        )
-        g.check(
-            not imported.startswith("java.util.concurrent."),
-            f"SqlExecutionAggregate must not own concurrency runtime: {imported}",
-        )
+        g.check(not imported.startswith("io.yak.ops.spi.datasource."), f"Aggregate imported SPI: {imported}")
+        g.check(not imported.startswith("org.springframework."), f"Aggregate imported Spring: {imported}")
+        g.check(not imported.startswith("java.util.concurrent."), f"Aggregate owns concurrency: {imported}")
 
     code = code_only(aggregate)
     for behavior in (
@@ -264,7 +346,7 @@ def check_sql_execution_domain(g: Guard) -> None:
         "finishCancelled(",
         "snapshot(",
     ):
-        g.check(behavior in code, f"SqlExecutionAggregate lifecycle behavior missing: {behavior}")
+        g.check(behavior in code, f"SqlExecutionAggregate behavior missing: {behavior}")
 
     runtime = g.read(JAVA_ROOT / "execution/DefaultSqlExecutionRuntime.java")
     runtime_code = code_only(runtime)
@@ -276,9 +358,9 @@ def check_sql_execution_domain(g: Guard) -> None:
         "class ManagedExecution",
         "class MutableStatement",
     ):
-        g.check(forbidden not in runtime_code, f"DefaultSqlExecutionRuntime leaked physical/lifecycle concern: {forbidden}")
-    g.check("SqlExecutionAggregate" in runtime, "Runtime must delegate lifecycle to SqlExecutionAggregate")
-    g.check("SqlExecutionGateway" in runtime, "Runtime must delegate physical SQL to SqlExecutionGateway")
+        g.check(forbidden not in runtime_code, f"DefaultSqlExecutionRuntime leaked concern: {forbidden}")
+    g.check("SqlExecutionAggregate" in runtime, "Runtime must delegate lifecycle to Aggregate")
+    g.check("SqlExecutionGateway" in runtime, "Runtime must delegate physical SQL to Gateway")
 
 
 def check_docs(g: Guard) -> None:
@@ -292,13 +374,18 @@ def check_docs(g: Guard) -> None:
         ("DOMAIN.md", contract, 190),
         ("REVIEW.md", review, 220),
     ):
-        g.check(
-            len(text.splitlines()) <= limit,
-            f"{name} exceeds {limit} lines; keep module contracts concise",
-        )
+        g.check(len(text.splitlines()) <= limit, f"{name} exceeds {limit} lines")
 
-    for phrase in ("核心能力", "模块边界", "Requirement Gap", "CatalogReadRequest", "SQL Execution"):
-        g.check(phrase in requirements, f"REQUIREMENTS.md lost required phrase: {phrase}")
+    for phrase in (
+        "核心能力",
+        "模块边界",
+        "Requirement Gap",
+        "CatalogReadRequest",
+        "SQL Execution",
+        "Plugin 标准",
+        "DataSourcePluginDescriptor",
+    ):
+        g.check(phrase in requirements, f"REQUIREMENTS.md lost: {phrase}")
 
     for phrase in (
         "DataSourceDefinition",
@@ -307,13 +394,15 @@ def check_docs(g: Guard) -> None:
         "DataSourcePluginGateway",
         "DataSourceCatalogGateway",
         "CatalogReadRequest",
+        "DataSourcePluginDescriptor",
+        "Plugin Capability",
         "SqlExecutionGateway",
         "SqlExecutionAggregate",
         "Domain Impact Analysis",
         "Domain Compliance Report",
         "Domain Gap",
     ):
-        g.check(phrase in contract, f"DOMAIN.md lost mandatory phrase: {phrase}")
+        g.check(phrase in contract, f"DOMAIN.md lost: {phrase}")
 
     for phrase in (
         "Requirement Gap",
@@ -324,13 +413,15 @@ def check_docs(g: Guard) -> None:
         "Missing Tests",
         "DataSourcePluginGateway",
         "DataSourceCatalogGateway",
+        "DataSourcePluginConfigVO",
         "SqlExecutionGateway",
         "SqlExecutionAggregate",
+        "PLUGIN.md",
     ):
-        g.check(phrase in review, f"REVIEW.md lost review protocol phrase: {phrase}")
+        g.check(phrase in review, f"REVIEW.md lost: {phrase}")
 
-    for name in ("REQUIREMENTS.md", "DOMAIN.md", "REVIEW.md"):
-        g.check(name in overview, f"README.md must link {name}")
+    for name in ("REQUIREMENTS.md", "DOMAIN.md", "REVIEW.md", "PLUGIN.md"):
+        g.check(name in overview, f"README.md must reference {name}")
 
 
 def check_pr(g: Guard, event_path: Path | None) -> None:
@@ -360,6 +451,7 @@ def main() -> int:
     check_catalog_domain(g)
     check_application_mutations(g)
     check_gateway_boundary(g)
+    check_plugin_contract(g)
     check_sql_execution_domain(g)
     check_docs(g)
     check_pr(g, args.event)

--- a/tools/datasource_domain_guardrails.py
+++ b/tools/datasource_domain_guardrails.py
@@ -166,12 +166,16 @@ def check_catalog_domain(g: Guard) -> None:
     g.check("CatalogReadRequest" in service, "Catalog service must use typed request")
 
     adapter = g.read(GATEWAY_DIR / "adapter/SpiDataSourceCatalogGateway.java")
+    adapter_code = code_only(adapter)
     g.check(
         "DataSourceCatalogReadRequest" in adapter,
         "Catalog SPI adapter must translate Business request to typed Plugin request",
     )
     for legacy in ("paramsList", '"read_mode"', "Map<String, Object>"):
-        g.check(legacy not in adapter, f"Legacy Catalog Map leaked into Plugin adapter: {legacy}")
+        g.check(
+            legacy not in adapter_code,
+            f"Legacy Catalog Map leaked into executable Plugin adapter code: {legacy}",
+        )
 
 
 def check_application_mutations(g: Guard) -> None:

--- a/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-datasource/DOMAIN.md
@@ -8,41 +8,44 @@
 DataSourceDefinition (Aggregate Root)
 └── ConnectionProfile
 
-Catalog Subdomain
+Catalog Domain
 ├── CatalogReadRequest
 ├── CatalogTableQuery / CatalogTablePath
 ├── CatalogTable / CatalogColumn
 └── CatalogQueryResult
 
+Plugin Domain Projection
+└── DataSourcePluginDescriptor
+
 SQL Execution
-├── yak-ops-core: SqlExecutionRequest / Plan / Result / Snapshot
-├── SqlExecutionAggregate          <- lifecycle truth
-└── SqlExecutionGateway            <- physical execution Port
+├── yak-ops-core: Request / Plan / Result / Snapshot
+├── SqlExecutionAggregate        <- lifecycle truth
+└── SqlExecutionGateway          <- physical execution Port
 ```
 
 ```text
 Application
    ├── DataSourceRepository      -> Repository Adapter -> DAO / PO
-   ├── DataSourcePluginGateway   <- SPI Adapter -> Plugin SPI
-   ├── DataSourceCatalogGateway  <- SPI Adapter -> Plugin SPI
+   ├── DataSourcePluginGateway   <- SPI Adapter -> Plugin SPI Descriptor
+   ├── DataSourceCatalogGateway  <- SPI Adapter -> typed Catalog SPI
    └── SqlExecutionGateway       <- SPI Adapter -> Execution SPI
 ```
 
-Datasource Plugin SPI 是邻接上下文，不是 Core Domain，也不是 Application Contract。
+Datasource Plugin SPI 是邻接上下文，不是 Core Domain，也不是 HTTP Contract。
 
 ## 12 条硬规则
 
-1. **`DataSourceDefinition` 是数据源配置唯一业务事实。** DTO、VO、PO、Plugin SPI Model 不能替代 Domain。
-2. **`ConnectionProfile` 是连接配置值对象。** 修改连接配置必须通过 Aggregate 行为；`dbType` 创建后不可修改；配置变化后状态回到 `UNKNOWN`。
-3. **连接状态只描述当前已保存配置最近一次真实连接测试。** 成功 `CONNECTED`，连通失败 `DISCONNECTED`；未保存配置测试不持久化状态。
-4. **Core Domain 不依赖 Spring / MyBatis / HTTP DTO / VO / PO / Datasource Plugin SPI。** Secret、JDBC、插件私参属于边界之外。
-5. **Application 主链路只依赖 Business Port。** `DataSourceServiceImpl`、`DataSourceCatalogServiceImpl`、`DataSourceViewMapper`、`DefaultSqlExecutionRuntime` 不直接依赖 Datasource Plugin SPI。
-6. **Business Gateway Contract 不暴露 Plugin SPI、HTTP DTO / VO、PO。** SPI 类型转换与异常映射只在 `gateway.adapter`。
-7. **Catalog 内部必须类型化。** HTTP `Map<String,Object>` 只允许在兼容入口解析成 `CatalogReadRequest`；`DataSourceCatalogGateway` 禁止 Map 协议。旧 Plugin SPI Map 只能由 SPI Adapter 投影。
-8. **Catalog Metadata 是 Business-owned Domain。** `CatalogTable / CatalogColumn / CatalogQueryResult` 不以 SPI Table / Column / QueryResult 为 identity。
-9. **SQL Execution 不复制 `yak-ops-core` contract。** Request / Plan / Result / Snapshot 的公共真相继续由 core 提供；Datasource 只拥有生命周期与物理数据源适配。
-10. **`SqlExecutionAggregate` 拥有执行和 Statement 状态变化。** Runtime 负责线程、Future、Session、I/O；不得重新在 Runtime 中维护第二套 PENDING/RUNNING/终态状态机。
-11. **物理 SQL 只能通过 `SqlExecutionGateway`。** `DefaultSqlExecutionRuntime` 不直接持有 `DataSourceExecutionProvider / DataSourceSqlExecutor / DataSourceSqlRequest / DataSourceSqlResult`。
+1. **`DataSourceDefinition` 是数据源配置唯一业务事实。** DTO、VO、PO、Plugin SPI Model 不得替代 Domain。
+2. **`ConnectionProfile` 是连接配置值对象。** `dbType` 创建后不可变；连接配置变化后状态回到 `UNKNOWN`；已保存配置真实测试才产生 `CONNECTED / DISCONNECTED`。
+3. **Core Domain 不依赖 Spring / MyBatis / HTTP DTO / VO / PO / Datasource Plugin SPI。** Secret、JDBC、插件私参属于边界之外。
+4. **Application / Runtime 主链路只依赖 Business Port。** Plugin Registry、Plugin SPI、Secret helper 不进入受保护 Service / Runtime。
+5. **Business Gateway Contract 不暴露 Plugin SPI、HTTP DTO / VO、PO。** SPI 类型转换和异常映射只在 `gateway.adapter`。
+6. **Catalog Business 和 Plugin SPI 都必须类型化。** HTTP Map 只允许在兼容入口解析一次；`DataSourceCatalogGateway` 与 `DataSourceCatalog` 均禁止 Map 协议。
+7. **Catalog Metadata 是 Business-owned Domain。** Plugin Table / Column / QueryResult 必须经 Adapter 转为 `CatalogTable / CatalogColumn / CatalogQueryResult`。
+8. **Plugin Descriptor 是插件元数据唯一稳定协议。** Plugin API 不依赖 `DataSourcePluginConfigVO`；Business `DataSourcePluginDescriptor` 是反腐投影，HTTP VO 只在 View Mapper 生成。
+9. **Plugin Capability 必须显式声明且与实现一致。** `TRANSACTIONS -> SQL_EXECUTION`；`CATALOG_READ -> CATALOG_METADATA`；调用方不得用异常探测正常能力。
+10. **SQL Execution 不复制 `yak-ops-core` contract。** `SqlExecutionAggregate` 拥有 Execution/Statement 生命周期；Runtime 只负责并发、事务编排、Session I/O 和异常识别。
+11. **物理 SQL 只能通过 `SqlExecutionGateway`。** Runtime 不直接持有 Datasource execution SPI；事务、取消、关闭必须经同一 Gateway Session。
 12. **无法表达现有需求就是 `Domain Gap`。** 不通过隐藏 Map key、临时 boolean、VO 字段或 Plugin 私有字段绕过模型。
 
 ## DataSource 不变量
@@ -51,71 +54,85 @@ Datasource Plugin SPI 是邻接上下文，不是 Core Domain，也不是 Applic
 - `dbType` 不可变。
 - ConnectionProfile 变化 -> `UNKNOWN`。
 - 已保存连接测试成功 -> `CONNECTED`；连通失败 -> `DISCONNECTED`。
-- Secret、完整连接 JSON、可能携带凭据的 JDBC URL 不得进入普通日志或 `toString()`。
+- 未保存配置测试不持久化状态。
+- Secret、完整连接 JSON、可能携带凭据的 JDBC URL 不进入普通日志或 `toString()`。
 
 ## Catalog 不变量
 
 ```text
 HTTP Map
-  -> Application parse once
   -> CatalogReadRequest
   -> read-only validation
   -> DataSourceCatalogGateway
-  -> SpiDataSourceCatalogGateway
-  -> legacy Plugin Map
+  -> DataSourceCatalogReadRequest
+  -> DataSourceCatalog
 ```
 
-- `TABLE` 模式必须有 `tablePath`；`SQL` 模式必须有 `sql`。
+- `TABLE` 必须有 `tablePath`；`SQL` 必须有 `sql/query`。
 - preview / count / describe 的 SQL 模式只允许单条 SELECT。
-- `paramsList` 等历史字段只在兼容入口和 Adapter 之间映射，不是 Domain extension point。
-- 新 Catalog 语义先扩 typed Domain，不增加隐藏 Map key。
+- HTTP `paramsList` 只在兼容入口解析为 typed variable；空变量值维持历史“忽略替换”语义。
+- Plugin SPI 不再接受 `Map<String,Object>`。
+- 新 Catalog 语义扩 typed Domain / SPI，不新增隐藏 key。
+
+## Plugin Contract
+
+```text
+DataSourcePlugin
+├── dbType
+├── descriptor
+│   ├── apiVersion
+│   ├── capabilities
+│   └── connectionForm
+├── parseConnection
+├── testConnection
+├── createCatalog
+└── createSqlExecutor (when SQL_EXECUTION)
+```
+
+- `descriptor.dbType == plugin.dbType()`。
+- 当前 `apiVersion = 1`。
+- `TRANSACTIONS` 只能和 `SQL_EXECUTION` 一起声明。
+- `CATALOG_READ` 只能和 `CATALOG_METADATA` 一起声明。
+- Secret 字段通过 `FieldType.PASSWORD` 声明，Business Secret Codec 从 Descriptor 推导。
+- Plugin 单例不持有请求级 Connection/Statement 状态。
+- PluginConfig HTTP shape 由 `DataSourcePluginViewMapper` 投影，不是 SPI 模型。
+- 详细插件开发规则见 `yak-ops-plugins/yak-ops-plugin-datasource/PLUGIN.md`。
 
 ## SQL Execution 生命周期
 
 ```text
-PENDING
-  -> RUNNING
-  -> CANCELLING
-  -> SUCCEEDED | FAILED | CANCELLED | TIMED_OUT
+PENDING -> RUNNING -> CANCELLING
+                   -> SUCCEEDED | FAILED | CANCELLED | TIMED_OUT
 ```
 
-Statement 终态为 `SUCCEEDED / FAILED / CANCELLED / TIMED_OUT / SKIPPED`。
+- 终态不能重新打开。
+- 失败/取消/超时后未执行 Statement -> `SKIPPED`。
+- Statement timeout -> Execution `TIMED_OUT`。
+- `SINGLE_TRANSACTION` begin/execute/commit/rollback 使用同一 Session。
+- physical cancel best-effort，但领域终态必须收敛。
 
-- Cancel 请求不能把已终态执行重新打开。
-- 失败/取消/超时后，未执行 Statement 必须进入 `SKIPPED`。
-- Statement timeout 必须使 Execution 收敛到 `TIMED_OUT`。
-- `SINGLE_TRANSACTION` 的 begin/execute/commit/rollback 必须使用同一 Gateway Session。
-- 物理 cancel 是 best-effort；领域终态不能悬空。
-
-## Gateway / Adapter 边界
-
-允许：
+## 允许的依赖方向
 
 ```text
-Application / Runtime -> Business Gateway Port <- SPI Adapter -> Datasource Plugin SPI
+Application / Runtime -> Business Port <- SPI Adapter -> Datasource Plugin SPI
+Plugin SPI Descriptor -> SPI Adapter -> Business Plugin Descriptor -> View Mapper -> HTTP VO
 ```
 
 禁止：
 
 ```text
-Application / Runtime -> Datasource Plugin SPI
-Business Gateway Port -> SPI model
-Catalog Domain -> HTTP Map / SPI model
+Plugin API -> Business DTO / VO
+Application / Runtime -> Plugin SPI
+Business Port -> SPI Model
+Catalog Domain -> HTTP Map / SPI Model
 SqlExecutionAggregate -> Spring / concurrency / physical Session
-Core Domain -> Gateway / SPI
 ```
 
-当前兼容例外：
-
-- `DataSourcePluginConfigServiceImpl` 仍承接历史 `pluginConfig() -> DataSourcePluginConfigVO`。
-- `BusinessDataSourceExecutionProvider` 是向 Task Plugin SPI 暴露 Executor 的外向 Adapter。
-- `DataSourceSecretCodec` 是 SPI Adapter technical helper。
-
-例外不得扩散到新的主链路。
+唯一保留的明确 SPI 例外：`BusinessDataSourceExecutionProvider` 本身是向 Task Plugin SPI 暴露 Executor 的外向 Adapter；该例外不得扩散到 Application 主链路。
 
 ## 持久化兼容
 
-`yak_ops_data_source` 以及 `jdbc_url / connection_params / original_json / conn_status` 保持现状；它们是持久化投影，由 Repository Adapter 映射。
+`yak_ops_data_source` 及 `jdbc_url / connection_params / original_json / conn_status` 保持现状；它们是持久化投影，由 Repository Adapter 映射。
 
 ## 修改前后
 
@@ -140,21 +157,17 @@ Domain Compliance Report
 Core Domain dependency guardrail
 Application / Runtime -> Gateway only
 Gateway Port no SPI/DTO/VO/PO
-Catalog Gateway no Map protocol
-Catalog typed boundary tests
+Catalog Business + Plugin SPI no Map
+Plugin API no Business VO
+Descriptor / Capability contract tests
 SqlExecutionAggregate lifecycle tests
-SqlExecutionGateway SPI adapter tests
 ConnectionProfile / connection status tests
 ```
 
-**不要通过删护栏或放宽文档预算绕过失败。** 规则真实变化时，同一个 PR 同步修改文档与测试。
+**不要通过删护栏或放宽文档预算绕过失败。** 规则真实变化时，同一 PR 同步修改文档与测试。
 
 ## 已知独立 Gap
 
 ```text
-Plugin Capability / Descriptor
-Plugin API VO dependency
-PluginConfig compatibility bridge cleanup
-Plugin Catalog Map SPI 最终类型化
-Aggregate physical naming cleanup
+DataSourceDefinition 物理命名清理
 ```

--- a/yak-ops-business/yak-ops-business-datasource/README.md
+++ b/yak-ops-business/yak-ops-business-datasource/README.md
@@ -1,6 +1,6 @@
 # Yak Ops Datasource
 
-数据源模块负责数据源注册、连接测试、Catalog 元数据访问、SQL Execution 和数据源插件编排，并为数据开发、同步、任务等上层模块提供稳定的数据源引用。
+Datasource 负责数据源注册、连接测试、typed Catalog、SQL Execution 与 Plugin 编排，并向数据开发、同步、任务等模块提供稳定数据源引用。
 
 ## 开发前必读
 
@@ -8,75 +8,111 @@
 REQUIREMENTS.md  -> 模块需要什么
 DOMAIN.md        -> 实现不能违反什么
 REVIEW.md        -> 按什么标准 Review
+PLUGIN.md        -> Datasource Plugin 开发标准
 ```
 
-三份文档只维护当前有效规则，历史设计过程看 Issue / PR / Git。
+Plugin 文档位于：`yak-ops-plugins/yak-ops-plugin-datasource/PLUGIN.md`。
 
 ## 核心模型
 
 ```text
-DataSourceDefinition (Aggregate Root)
-└── ConnectionProfile
+DataSourceDefinition -> ConnectionProfile
 
 Catalog Domain
-├── CatalogReadRequest
-├── CatalogTableQuery / CatalogTablePath
-├── CatalogTable / CatalogColumn
-└── CatalogQueryResult
+  -> CatalogReadRequest / Table / Column / QueryResult
+
+Plugin Domain Projection
+  -> DataSourcePluginDescriptor
 
 SQL Execution
-├── yak-ops-core canonical Request / Plan / Result / Snapshot
-├── SqlExecutionAggregate
-└── SqlExecutionGateway
+  -> yak-ops-core Request / Plan / Result / Snapshot
+  -> SqlExecutionAggregate
+  -> SqlExecutionGateway
 ```
 
-关键规则：数据源类型创建后不可修改；连接配置变化回到 `UNKNOWN`；Secret 不输出；Catalog 内部 typed；SQL 生命周期由 Aggregate 管理，物理执行经 Gateway。
-
-## 工程分层
+## 最终依赖方向
 
 ```text
 Controller / Application
       ↓
-Domain + Business Gateway Port
-      ↓                     ↑
-Repository Adapter      SPI Gateway Adapter
-      ↓                     ↓
+Domain + Business Port
+      ↓                       ↑
+Repository Adapter        SPI Adapter
+      ↓                       ↓
 DAO / PO             Datasource Plugin SPI
+                          ↓
+                   Plugin Implementation
 ```
 
-主要边界：
+主要链路：
 
 ```text
-DataSourceServiceImpl -> DataSourcePluginGateway <- SpiDataSourcePluginGateway
-DataSourceCatalogServiceImpl -> DataSourceCatalogGateway <- SpiDataSourceCatalogGateway
-DefaultSqlExecutionRuntime -> SqlExecutionGateway <- SpiSqlExecutionGateway
+DataSourceServiceImpl
+  -> DataSourcePluginGateway
+  <- SpiDataSourcePluginGateway
+  -> DataSourcePlugin / Descriptor
+
+DataSourceCatalogServiceImpl
+  -> CatalogReadRequest
+  -> DataSourceCatalogGateway
+  <- SpiDataSourceCatalogGateway
+  -> DataSourceCatalogReadRequest
+  -> DataSourceCatalog
+
+DefaultSqlExecutionRuntime
+  -> SqlExecutionAggregate
+  -> SqlExecutionGateway
+  <- SpiSqlExecutionGateway
+  -> Datasource execution SPI
 ```
 
-SPI Adapter 负责插件发现、Connection 解析、Secret 处理、Catalog 协议转换、SQL Executor 适配和异常边界；Application / Runtime 不直接持有 Datasource Plugin SPI。
+## Plugin 标准
+
+Phase 4 后 Plugin API 不再返回 HTTP VO：
+
+```text
+DataSourcePlugin
+  -> descriptor(apiVersion, capabilities, connectionForm)
+  -> parseConnection
+  -> testConnection
+  -> createCatalog
+  -> createSqlExecutor
+```
+
+`DataSourcePluginDescriptor` 是 SPI 唯一插件元数据协议；Business Gateway 将其映射为 Business-owned Descriptor，`DataSourcePluginViewMapper` 再投影成现有 `DataSourcePluginConfigVO`。因此前端 JSON shape 保持不变，但 Plugin API 与 HTTP VO 解耦。
+
+当前 Capability：
+
+```text
+CONNECTION_TEST
+CATALOG_METADATA
+CATALOG_READ
+SQL_EXECUTION
+TRANSACTIONS
+SSH_TUNNEL
+```
+
+Registry 在加载时校验 apiVersion、dbType 和 Capability 依赖。Secret 字段由 Descriptor 的 `PASSWORD` field 声明。
 
 ## Catalog 类型化
 
-现有 REST POST 接口为兼容前端仍接受 `Map<String,Object>`，但 Map 只存在于入口：
+REST 为兼容旧前端仍可接受 `Map<String,Object>`，但 Map 到此为止：
 
 ```text
 HTTP Map
   -> DataSourceCatalogServiceImpl
   -> CatalogReadRequest
   -> DataSourceCatalogGateway
-  -> SpiDataSourceCatalogGateway
-  -> legacy Plugin Map
+  -> DataSourceCatalogReadRequest
+  -> Plugin Catalog
 ```
 
-支持的历史字段为 `read_mode/readMode`、`table_path/tablePath/table`、`query/sql`、`paramsList`。未知 Map key 不再作为 Business 扩展协议；新语义必须进入 typed Catalog Domain。
-
-Catalog 的 Table / Column / QueryResult 由 Business 自己拥有，Plugin SPI metadata 只能在 Adapter 中转换。
+Business Gateway 和 Plugin `DataSourceCatalog` 都不接受 Map。历史 `paramsList` 被解析为 typed variable；新增语义必须扩 typed model。
 
 ## SQL Execution
 
-`yak-ops-core` 已定义跨模块统一 SQL contract，因此 Datasource 不复制同名 DTO：
-
 ```text
-SqlExecutionRequest / SqlExecutionPlan
+SqlExecutionRequest / SqlExecutionPlan (yak-ops-core)
   -> SqlExecutionPolicy
   -> SqlExecutionAggregate
   -> DefaultSqlExecutionRuntime
@@ -84,46 +120,50 @@ SqlExecutionRequest / SqlExecutionPlan
   -> Datasource execution SPI
 ```
 
-职责拆分：
-
-- `SqlExecutionAggregate`：Execution / Statement 状态、取消意图、终态和 Snapshot。
-- `DefaultSqlExecutionRuntime`：线程、Future、事务编排、物理 Session、超时异常识别。
-- `SqlExecutionGateway`：Datasource 物理 SQL Session Port。
-- `SpiSqlExecutionGateway`：`DataSourceExecutionProvider / DataSourceSqlExecutor` 的唯一 Runtime Adapter。
-- `ObservableSqlExecutionRuntime`：终态观察和审计通知，不改变底层生命周期。
+- Aggregate：Execution / Statement 状态、取消意图、终态、Snapshot。
+- Runtime：线程、Future、事务编排、物理 Session、超时识别。
+- Gateway：物理 SQL Session Port。
+- Adapter：唯一 execution SPI 翻译边界。
 
 ## 分层约束
 
-- Controller 只通过 Service 进入业务链路。
-- Repository 只暴露 Domain，PO/MyBatis 只在持久化 Adapter 内。
-- Core Domain 不依赖 Spring、MyBatis、DTO / VO / PO、Datasource Plugin SPI。
-- `DataSourcePluginGateway / DataSourceCatalogGateway / SqlExecutionGateway` 不暴露 Plugin SPI、DTO / VO 或 PO。
-- `DataSourceCatalogGateway` 不接受 `Map<String,Object>`。
-- `DefaultSqlExecutionRuntime` 不直接依赖 datasource execution SPI。
-- Catalog 只读检查仍在 Application 层；物理访问由 Adapter 执行。
-- Secret 脱敏通过 `DataSourceViewMapper -> DataSourcePluginGateway` 完成。
+- Core Domain 不依赖 Spring、MyBatis、DTO / VO / PO、Plugin SPI。
+- Repository 只暴露 Domain。
+- Application / Runtime 不直接依赖 Plugin Registry / SPI。
+- Business Gateway 不暴露 SPI、DTO / VO / PO。
+- Business Catalog 和 Plugin Catalog 都不接受 `Map<String,Object>`。
+- Plugin API 不依赖 `DataSourcePluginConfigVO`。
+- PluginConfig HTTP VO 只由 Business View Mapper 生成。
+- Default SQL Runtime 不直接依赖 datasource execution SPI。
+- Secret 不进入普通日志、异常、`toString()` 或未脱敏响应。
 
-## 兼容边界
+## Phase 4 兼容边界
 
-Phase 3 不修改：
+保持：
 
 ```text
-REST API 路径和主要 JSON 结构
+REST API 路径和主要 JSON shape
 yak_ops_data_source 表结构
 Flyway 历史
-Datasource Plugin SPI 签名
-MySQL / PostgreSQL / Oracle / Doris 等插件实现
 yak-ops-core SQL Execution contract
+内置数据库插件运行行为
 ```
 
-当前例外：`DataSourcePluginConfigServiceImpl` 仍承接历史 PluginConfig VO；`BusinessDataSourceExecutionProvider` 是向 Task Plugin SPI 暴露 Executor 的外向 Adapter。这两项留给后续 Plugin API 标准化。
-
-## 后续领域 Gap
+Phase 4 有意做一次 Plugin SPI source-level migration：
 
 ```text
-Plugin Capability / Descriptor
-Plugin API VO dependency
-PluginConfig compatibility bridge cleanup
-Plugin Catalog Map SPI 最终类型化
+pluginConfig() -> descriptor()
+Catalog Map -> DataSourceCatalogReadRequest
+```
+
+仓库内置插件同步迁移；第三方插件按 `PLUGIN.md` 升级。该迁移不改变 REST / DB。
+
+## 持久化
+
+`yak_ops_data_source` 以及 `jdbc_url / connection_params / original_json / conn_status` 仍是持久化投影，由 Repository Adapter 映射。
+
+## 剩余独立 Gap
+
+```text
 DataSourceDefinition 物理命名清理
 ```

--- a/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
@@ -4,123 +4,118 @@
 
 ## 目标
 
-Datasource 提供 Yak Ops 的统一数据源控制面：维护数据源配置、验证连接、访问 Catalog 元数据，并向数据开发、同步、任务等模块提供稳定的数据源引用和 SQL 执行能力。
+Datasource 提供 Yak Ops 的统一数据源控制面：维护数据源配置、验证连接、访问 Catalog 元数据、提供 SQL Execution，并通过标准 Plugin API 扩展不同数据源。
 
 ## 核心能力
 
-- 创建、编辑、查询和删除数据源。
-- 管理名称、类型、运行环境、备注和连接配置。
+- 创建、编辑、查询、删除数据源。
+- 管理名称、类型、环境、备注和连接配置。
 - 支持已保存数据源和未保存配置的连接测试。
-- 记录最近一次已保存配置的连接测试结果：`UNKNOWN / CONNECTED / DISCONNECTED`。
-- 提供数据库、Schema、表、字段等 Catalog 元数据访问能力。
-- 提供数据预览、数量统计、SQL 模板和 SQL 变量解析能力。
-- Catalog 业务内部使用明确的 typed request / metadata / result，不依赖隐式 Map key 扩展语义。
-- 提供统一 SQL Execution contract，支持单语句、多语句、事务、取消、超时和终态观测。
-- 通过 Datasource Plugin SPI 扩展不同数据库或数据源类型。
+- 记录已保存配置最近一次连接测试结果：`UNKNOWN / CONNECTED / DISCONNECTED`。
+- 提供数据库、Schema、表、字段、预览、统计、SQL 模板和变量解析。
+- Catalog Business 链路和 Plugin SPI 均使用 typed request / metadata / result，不以 Map key 扩展业务语义。
+- 提供统一 SQL Execution，支持单语句、多语句、事务、取消、超时和终态观测。
+- Plugin 通过 versioned Descriptor 声明表单、Secret 字段和 Capability。
+- Plugin API 不依赖 Business DTO / VO；HTTP PluginConfig 由 Business 投影。
 - 对连接 Secret 做合并、脱敏和安全输出。
 
-## 关键业务行为
-
-### 数据源生命周期
+## 数据源生命周期
 
 ```text
-Create
-  -> validate + normalize
-  -> DataSourceDefinition / ConnectionProfile
-  -> UNKNOWN
-
-Update
-  -> dbType unchanged
-  -> merge Secret + replace ConnectionProfile
-  -> UNKNOWN
-
-Test saved datasource
-  -> success: CONNECTED
-  -> connectivity failure: DISCONNECTED
-
-Test unsaved configuration
-  -> validation only
-  -> no persisted state
+Create -> normalize -> DataSourceDefinition / ConnectionProfile -> UNKNOWN
+Update -> dbType unchanged -> replace ConnectionProfile -> UNKNOWN
+Test saved -> success CONNECTED / connectivity failure DISCONNECTED
+Test unsaved -> validation only -> no persisted state
 ```
 
-配置可解析不等于连接成功；连接配置变化后旧测试结果失效。
+配置可解析不等于连接成功；配置变化后旧连接结果失效。
 
-### Catalog
+## Catalog
 
 ```text
-HTTP compatibility request
-  -> typed CatalogReadRequest
-  -> read-only validation when executing preview/count/describe SQL
+HTTP compatibility Map
+  -> CatalogReadRequest
+  -> read-only validation
   -> DataSourceCatalogGateway
-  -> Plugin Adapter
+  -> DataSourceCatalogReadRequest (Plugin SPI)
+  -> Plugin Catalog
 ```
 
-- 表模式必须有 `table_path`；SQL 模式必须有 `query`。
-- 预览、统计和字段探测的 SQL 模式只允许单条只读 SELECT。
-- 现有 HTTP JSON 和 Plugin SPI Map 协议保持兼容，但 Map 不是新的业务扩展机制。
+- TABLE 模式必须有 `table_path`；SQL 模式必须有 `query`。
+- preview / count / describe 的 SQL 模式只允许单条只读 SELECT。
+- HTTP 历史 alias 和 `paramsList` 继续兼容，但 Map 只能停在 Interface/Application 兼容入口。
+- Plugin Catalog SPI 不接受 `Map<String,Object>`。
 
-### SQL Execution
+## SQL Execution
 
 ```text
-SqlExecutionRequest / SqlExecutionPlan   (yak-ops-core canonical contract)
-  -> policy validation
-  -> SqlExecutionAggregate lifecycle
+SqlExecutionRequest / SqlExecutionPlan (yak-ops-core)
+  -> policy
+  -> SqlExecutionAggregate
   -> SqlExecutionGateway
-  -> physical datasource session
+  -> Datasource execution SPI
 ```
 
-- Runtime 不自行发明第二套 Request / Plan / Snapshot 真相。
-- 多语句边界由调用方显式提供，不按分号自动拆 SQL。
-- `SINGLE_TRANSACTION` 必须在同一物理 Session 中执行；不支持事务时快速失败。
-- Cancel 是 best-effort 物理动作，但生命周期必须最终收敛到明确终态。
+- `yak-ops-core` 是 Request / Plan / Result / Snapshot 唯一公共 contract。
+- 多 Statement 边界由调用方显式提供，不按分号自动拆分。
+- `SINGLE_TRANSACTION` 必须在同一 Session 执行；不支持事务时快速失败。
+- Cancel 为 best-effort 物理动作，但生命周期必须收敛终态。
 - Statement timeout 必须提升为 execution `TIMED_OUT`。
-- 终态至少包括 `SUCCEEDED / FAILED / CANCELLED / TIMED_OUT`。
+
+## Plugin 标准
+
+每个 `DataSourcePlugin` 必须提供：
+
+```text
+dbType
+descriptor(apiVersion, capabilities, connectionForm)
+parseConnection
+testConnection
+createCatalog
+createSqlExecutor (声明 SQL_EXECUTION 时)
+```
+
+当前 Capability：
+
+```text
+CONNECTION_TEST
+CATALOG_METADATA
+CATALOG_READ
+SQL_EXECUTION
+TRANSACTIONS
+SSH_TUNNEL
+```
+
+依赖关系：`TRANSACTIONS -> SQL_EXECUTION`，`CATALOG_READ -> CATALOG_METADATA`。详细规范见 `yak-ops-plugins/yak-ops-plugin-datasource/PLUGIN.md`。
 
 ## 安全要求
 
-- Secret 不得通过普通 DTO / VO、异常文本、`toString()` 或业务日志明文暴露。
-- HTTP 详情中的 JDBC 地址和连接 JSON 必须经过脱敏边界。
-- 编辑时掩码、空值或缺失 Secret 可以沿用已保存值，但掩码不得覆盖真实凭据。
-- Dataset / Data Service / Analysis 等只读调用方不得绕过 SQL Policy 执行写操作。
-- Catalog preview/count/describe 不得绕过只读检查。
+- Secret 不得通过异常、`toString()`、普通日志或未脱敏响应输出。
+- HTTP 详情中的 JDBC 地址和连接 JSON 必须脱敏。
+- 掩码、空值或缺失 Secret 可以沿用已保存值，掩码不得覆盖真实凭据。
+- Secret 字段由 Plugin Descriptor Schema 声明，Business 不依赖 Plugin HTTP VO 判断 Secret。
+- Dataset / Data Service / Analysis 等只读调用方不得绕过 SQL Policy。
 
 ## 模块边界
 
-本模块负责：
-
-- DataSource 聚合与持久化；
-- 连接测试编排；
-- typed Catalog 子域和轻量读取入口；
-- SQL Execution 生命周期与 Datasource 物理执行适配；
-- Datasource Plugin 的发现、调用和反腐边界。
-
-本模块不负责：
-
-- 实时同步任务定义、发布和 Flink 生命周期；
-- 任意 ETL / 工作流编排；
-- 数据血缘计算；
-- JDBC Driver 或第三方服务部署；
-- 把插件私有参数升级为全局业务字段。
+本模块负责 DataSource Domain、持久化、连接测试、typed Catalog、SQL Execution 生命周期、Plugin discovery/adapter；不负责实时同步定义/Flink 生命周期、任意 ETL 编排、血缘计算或第三方 Driver 部署。
 
 ## 兼容性要求
 
-当前阶段保持：
+保持：
 
-- REST API 路径和主要请求/响应结构；
-- `yak_ops_data_source` 表结构和 Flyway 历史；
-- Datasource Plugin SPI 现有签名；
-- MySQL / PostgreSQL / Oracle / Doris 等已有插件实现；
-- `yak-ops-core` SQL Execution 对外 contract。
+```text
+REST API 路径和主要 JSON shape
+yak_ops_data_source / Flyway
+yak-ops-core SQL Execution contract
+MySQL / PostgreSQL / Oracle / Doris / 达梦 / Kingbase 内置插件行为
+```
 
-领域改造不得 Big-Bang 同时修改 REST、DB 和 Plugin SPI。
+Phase 4 **有意做一次 Plugin SPI source-level breaking change**：`pluginConfig() -> descriptor()`，Catalog Map -> typed request。仓库内置插件同步迁移；第三方插件按 `PLUGIN.md` 升级。该 SPI 迁移不得连带修改 REST 或数据库结构。
 
 ## 当前明确未解决
 
 ```text
-Plugin Capability / Descriptor 标准化
-Plugin API 中 VO 依赖清理
-PluginConfig compatibility bridge cleanup
-Plugin Catalog Map SPI 的最终类型化
 DataSourceDefinition 物理命名清理
 ```
 

--- a/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-datasource/REQUIREMENTS.md
@@ -15,7 +15,7 @@ Datasource 提供 Yak Ops 的统一数据源控制面：维护数据源配置、
 - 提供数据库、Schema、表、字段、预览、统计、SQL 模板和变量解析。
 - Catalog Business 链路和 Plugin SPI 均使用 typed request / metadata / result，不以 Map key 扩展业务语义。
 - 提供统一 SQL Execution，支持单语句、多语句、事务、取消、超时和终态观测。
-- Plugin 通过 versioned Descriptor 声明表单、Secret 字段和 Capability。
+- Plugin 通过 versioned `DataSourcePluginDescriptor` 声明表单、Secret 字段和 Capability。
 - Plugin API 不依赖 Business DTO / VO；HTTP PluginConfig 由 Business 投影。
 - 对连接 Secret 做合并、脱敏和安全输出。
 

--- a/yak-ops-business/yak-ops-business-datasource/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-datasource/REVIEW.md
@@ -28,7 +28,7 @@ Requirement Gap
 - `dbType` 不可变、ConnectionProfile -> `UNKNOWN` 是否保持；
 - Core Domain 是否引入 Spring / MyBatis / Plugin SPI；
 - Application / Runtime 是否绕过 Business Gateway；
-- Gateway 是否暴露 SPI、DTO / VO 或 PO；
+- `DataSourcePluginGateway / DataSourceCatalogGateway / SqlExecutionGateway` 是否暴露 SPI、DTO / VO 或 PO；
 - Business Catalog 或 Plugin `DataSourceCatalog` 是否重新接受 `Map<String,Object>`；
 - Catalog SPI metadata 是否绕过 Adapter 进入 Domain/Application；
 - Plugin API 是否重新依赖 `DataSourcePluginConfigVO` 或其他 Business/HTTP VO；

--- a/yak-ops-business/yak-ops-business-datasource/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-datasource/REVIEW.md
@@ -5,15 +5,16 @@
 ## Review 前必读
 
 ```text
-REQUIREMENTS.md  -> 模块需要什么
-DOMAIN.md        -> 实现不能违反什么
-REVIEW.md        -> 按什么标准判卷
-PR diff / tests  -> 实际改了什么
+REQUIREMENTS.md
+DOMAIN.md
+REVIEW.md
+yak-ops-plugins/yak-ops-plugin-datasource/PLUGIN.md
+PR diff / tests
 ```
 
 ## 1. Requirement Alignment
 
-检查是否属于已有能力，是否改变数据源生命周期、Catalog 或 SQL Execution 行为，是否越过模块边界。未定义的新能力统一报告：
+检查是否属于已有能力，是否改变数据源生命周期、Catalog、SQL Execution 或 Plugin Contract。未定义的新能力统一报告：
 
 ```text
 Requirement Gap
@@ -24,19 +25,19 @@ Requirement Gap
 重点检查：
 
 - DTO / VO / PO / Plugin SPI Model 是否冒充 Domain；
-- `dbType` 不可变和 ConnectionProfile -> `UNKNOWN` 是否保持；
+- `dbType` 不可变、ConnectionProfile -> `UNKNOWN` 是否保持；
 - Core Domain 是否引入 Spring / MyBatis / Plugin SPI；
-- Repository 是否泄漏持久化类型；
-- `DataSourceServiceImpl / DataSourceCatalogServiceImpl / DataSourceViewMapper / DefaultSqlExecutionRuntime` 是否直接依赖 Datasource Plugin SPI；
-- `DataSourcePluginGateway / DataSourceCatalogGateway / SqlExecutionGateway` 是否暴露 SPI、DTO / VO 或 PO；
-- `DataSourceCatalogGateway` 是否重新接受 `Map<String,Object>`；
-- HTTP Map 是否在 Application 入口后继续传播；
+- Application / Runtime 是否绕过 Business Gateway；
+- Gateway 是否暴露 SPI、DTO / VO 或 PO；
+- Business Catalog 或 Plugin `DataSourceCatalog` 是否重新接受 `Map<String,Object>`；
 - Catalog SPI metadata 是否绕过 Adapter 进入 Domain/Application；
+- Plugin API 是否重新依赖 `DataSourcePluginConfigVO` 或其他 Business/HTTP VO；
+- Plugin 是否缺少 Descriptor / apiVersion / Capability；
+- Capability 是否与真实实现冲突；
+- Secret 是否仍从 HTTP VO 猜测，而不是 Descriptor Schema；
 - `SqlExecutionAggregate` 是否重新持有线程、Future、Spring 或物理 Session；
-- Runtime 是否重新维护第二套 Execution / Statement 状态机；
-- Runtime 是否绕过 `SqlExecutionGateway` 直接调用 datasource execution SPI；
-- Secret 是否进入日志、异常或未脱敏响应；
-- 是否通过隐藏 Map key 绕过 `Domain Gap`。
+- Runtime 是否重新维护第二套 Execution / Statement 状态机或直接调用 execution SPI；
+- 是否通过隐藏 Map key、boolean、VO 字段绕过 `Domain Gap`。
 
 违反规则报告 `Domain Violation`；模型无法表达需求报告：
 
@@ -48,83 +49,82 @@ Domain Gap
 
 检查真实风险：
 
-- 空值、边界值、名称重复、类型 / 环境解析；
-- Secret 合并和脱敏；
-- Gateway Adapter 异常及字段映射；
-- Catalog TABLE / SQL 模式解析与历史 alias；
-- Catalog preview/count/describe 单条 SELECT 约束；
-- Catalog variable 投影是否保持兼容；
+- 空值、边界值、类型 / 环境解析；
+- Secret merge / mask 和嵌套 SSH Secret；
+- Descriptor `dbType / apiVersion / connectionForm`；
+- `TRANSACTIONS -> SQL_EXECUTION`、`CATALOG_READ -> CATALOG_METADATA`；
+- Plugin Registry 重复类型与 descriptor mismatch；
+- Catalog TABLE / SQL 模式、变量、历史 HTTP alias；
+- Catalog preview/count/describe 单条 SELECT；
+- SPI typed Catalog request 与 Business CatalogReadRequest 字段映射；
 - SQL Policy 是否在打开数据源前拒绝非法 SQL；
-- 多 Statement 顺序和 `SKIPPED` 语义；
-- `SINGLE_TRANSACTION` 是否同 Session begin/commit/rollback；
-- cancel、timeout、失败是否收敛到正确终态；
-- 审计观察是否不改变物理执行生命周期。
+- transaction 同 Session、rollback、cancel、timeout 和 `SKIPPED`；
+- PluginConfig Descriptor -> Business -> VO 是否保持前端 shape。
 
 ## 4. Compatibility
 
-不得无迁移方案破坏：
+必须保持：
 
 ```text
 REST API / JSON shape
 yak_ops_data_source / Flyway
-Datasource Plugin SPI
-Existing database plugins
-PluginConfig dynamic form contract
-Task Plugin SQL execution provider
 yak-ops-core SQL Execution contract
+built-in plugin runtime behavior
+Task Plugin SQL execution provider
 ```
 
-禁止 Big-Bang 修改。Catalog HTTP Map 可以作为兼容入口存在；Plugin Map 可以作为 Adapter 投影存在，但两者不得重新成为 Business Contract。
+Phase 4 允许且仅允许本次明确的 Plugin SPI source-level 迁移：
+
+```text
+pluginConfig() -> descriptor()
+Catalog Map -> DataSourceCatalogReadRequest
+```
+
+第三方插件必须有迁移说明；禁止借此连带修改 REST / DB。后续再次做 SPI breaking change 必须先定义新的 API version 和迁移计划。
 
 ## 5. Safety
 
 重点检查：
 
-- Secret 明文输出或掩码覆盖真实密码；
+- Secret 明文输出、Descriptor defaultValue 泄漏 Secret、掩码覆盖真实凭据；
 - JDBC URL 凭据泄漏；
-- Gateway Adapter 吞异常或错误分类；
-- 连接状态错误；
+- Plugin / Adapter 异常消息泄漏 Secret；
+- Capability 声明了不真实的能力；
 - Catalog 绕过只读检查；
-- Dataset / Data Service / Analysis 绕过 SQL read-only policy；
-- cancel 后继续执行剩余 Statement；
-- transaction 失败未 rollback；
-- timeout 被错误归类为普通 FAILED。
+- read-only caller 绕过 SQL Policy；
+- cancel 后继续 Statement；transaction 失败未 rollback；timeout 误归类。
 
 ## 6. Tests / Guardrails
 
 每个 P0 / P1 都回答“哪个测试应该挡住”。至少覆盖：
 
 ```text
-DataSource type immutable
-ConnectionProfile change -> UNKNOWN
+DataSource type immutable / ConnectionProfile -> UNKNOWN
 Core Domain / Repository boundary
 Application / Runtime -> Business Gateway only
-Gateway Port no Plugin SPI / DTO / VO / PO
-DataSourceCatalogGateway no Map
-HTTP Map -> CatalogReadRequest
-CatalogReadRequest -> legacy Plugin Map only in Adapter
-SPI Catalog metadata -> Catalog Domain
+Gateway Port no SPI / DTO / VO / PO
+Business Catalog + Plugin Catalog no Map
+Plugin API no DataSourcePluginConfigVO
+Descriptor apiVersion / dbType / capability dependencies
+MySQL/PostgreSQL/Oracle/Doris/达梦/Kingbase descriptor contract
+Descriptor -> PluginConfig VO compatibility projection
+Descriptor-driven Secret masking
+Catalog typed request mapping
 SqlExecutionAggregate lifecycle
-SqlExecutionGateway SPI mapping
-policy reject before datasource open
-transaction commit / rollback / cancellation
-timeout -> TIMED_OUT
+transaction / rollback / cancellation / timeout
 ```
 
 ## 当前允许的边界例外
 
 ```text
-DataSourcePluginConfigServiceImpl
-  -> historical pluginConfig() / VO compatibility bridge
-
 BusinessDataSourceExecutionProvider
   -> outward Task Plugin SPI adapter
 
 DataSourceSecretCodec
-  -> SPI adapter technical helper
+  -> plugin SPI adapter technical helper; reads SPI Descriptor, not HTTP VO
 ```
 
-例外不能扩散。
+例外不能扩散到普通 Application 主链路。
 
 ## 严重级别
 
@@ -136,9 +136,10 @@ P0 Blocker
 
 P1 Must Fix
 - 业务结果错误
-- 违反 REQUIREMENTS.md / DOMAIN.md
+- 违反 REQUIREMENTS.md / DOMAIN.md / PLUGIN.md
 - SPI 泄漏进受保护主链路
-- Gateway 暴露外部模型或 Catalog Map 回流
+- Plugin API 重新依赖 VO / Catalog Map
+- Capability 与实现不一致
 - SQL lifecycle / transaction / cancel / timeout 错误
 - 明确兼容性缺陷
 

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/plugin/DataSourcePluginDescriptor.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/plugin/DataSourcePluginDescriptor.java
@@ -1,0 +1,95 @@
+package io.yak.ops.business.datasource.domain.plugin;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** Business-owned projection of one datasource plugin descriptor. */
+public record DataSourcePluginDescriptor(
+    DataSourceDbType dbType,
+    String displayName,
+    String apiVersion,
+    Set<Capability> capabilities,
+    List<FormSection> sections,
+    List<FormField> legacyFields,
+    boolean installRequired,
+    String installHint) {
+
+  public DataSourcePluginDescriptor {
+    dbType = Objects.requireNonNull(dbType, "dbType");
+    displayName = requireText(displayName, "displayName");
+    apiVersion = requireText(apiVersion, "apiVersion");
+    capabilities = capabilities == null ? Set.of() : Set.copyOf(capabilities);
+    sections = sections == null ? List.of() : List.copyOf(sections);
+    legacyFields = legacyFields == null ? List.of() : List.copyOf(legacyFields);
+  }
+
+  public boolean supports(Capability capability) {
+    return capability != null && capabilities.contains(capability);
+  }
+
+  public enum Capability {
+    CONNECTION_TEST,
+    CATALOG_METADATA,
+    CATALOG_READ,
+    SQL_EXECUTION,
+    TRANSACTIONS,
+    SSH_TUNNEL
+  }
+
+  public record FormSection(
+      String key,
+      String title,
+      String description,
+      boolean collapsible,
+      boolean defaultExpanded,
+      List<FormField> fields) {
+    public FormSection {
+      fields = fields == null ? List.of() : List.copyOf(fields);
+    }
+  }
+
+  public record FormField(
+      String key,
+      String label,
+      String type,
+      String placeholder,
+      Object defaultValue,
+      List<FormOption> options,
+      List<FormRule> rules,
+      List<String> dependsOn,
+      List<VisibilityCondition> visibleWhen,
+      JdbcUrlLinkage jdbcUrlLinkage) {
+    public FormField {
+      options = options == null ? List.of() : List.copyOf(options);
+      rules = rules == null ? List.of() : List.copyOf(rules);
+      dependsOn = dependsOn == null ? List.of() : List.copyOf(dependsOn);
+      visibleWhen = visibleWhen == null ? List.of() : List.copyOf(visibleWhen);
+    }
+  }
+
+  public record FormOption(String label, Object value) {}
+
+  public record FormRule(Boolean required, String pattern, Integer min, Integer max, String message) {}
+
+  public record VisibilityCondition(String field, String operator, Object value, List<Object> values) {
+    public VisibilityCondition {
+      values = values == null ? List.of() : List.copyOf(values);
+    }
+  }
+
+  public record JdbcUrlLinkage(
+      String template,
+      String hostField,
+      String portField,
+      String databaseField,
+      boolean preserveSuffix) {}
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourcePluginGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/DataSourcePluginGateway.java
@@ -1,37 +1,36 @@
 package io.yak.ops.business.datasource.gateway;
 
 import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 
-/**
- * Business Datasource 对插件连接能力的稳定 Port。
- *
- * <p>Application / Interface 层只依赖该接口，不直接认识 Datasource Plugin SPI 的 Plugin、Connection
- * 或异常类型；SPI 适配、Secret 处理和异常映射由 Adapter 负责。
- */
+/** Business port for datasource plugin capabilities and descriptor metadata. */
 public interface DataSourcePluginGateway {
 
-  /** 从未保存连接 JSON 中识别目标数据源类型。 */
+  /** Resolve the target datasource type from unsaved connection JSON. */
   DataSourceDbType resolveConnectionType(String connectionJson);
 
-  /** 解析、校验并规范化连接参数为 Business Domain 的 ConnectionProfile。 */
+  /** Return the Business-owned descriptor projection for one installed plugin. */
+  DataSourcePluginDescriptor descriptor(DataSourceDbType dbType);
+
+  /** Parse, validate and normalize connection parameters into Business Domain. */
   ConnectionProfile normalizeConnection(DataSourceDbType dbType, String connectionJson);
 
-  /** 编辑/测试已有数据源时，将掩码或缺失 Secret 与已保存配置合并。 */
+  /** Merge masked/missing submitted secrets with the stored normalized connection. */
   String mergeStoredSecrets(
       DataSourceDbType dbType,
       String submittedJson,
       String storedJson);
 
-  /** 测试一个已经规范化的连接配置。失败时抛出 Business Datasource 异常。 */
+  /** Test one normalized connection profile. */
   void testConnection(
       DataSourceDbType dbType,
       ConnectionProfile connectionProfile,
       int timeoutSeconds);
 
-  /** 返回仅用于 HTTP 回显的脱敏连接 JSON。 */
+  /** Return masked connection JSON for interface projection. */
   String maskConnectionJson(DataSourceDbType dbType, String connectionJson);
 
-  /** 对展示用连接地址中的常见凭据参数做兜底脱敏。 */
+  /** Fallback masking for sensitive values embedded in display text/JDBC URLs. */
   String maskSensitiveText(String value);
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
@@ -190,7 +190,11 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
     }
     Map<String, String> variables = new LinkedHashMap<>();
     for (CatalogReadRequest.Variable variable : request.variables()) {
-      variables.put(variable.name(), variable.value());
+      // Historic plugin behavior ignored paramsList entries with null values. Preserve that
+      // compatibility while removing the implicit Map protocol from the stable SPI.
+      if (variable.value() != null) {
+        variables.put(variable.name(), variable.value());
+      }
     }
     return new DataSourceCatalogReadRequest(
         request.sqlMode()

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGateway.java
@@ -13,17 +13,18 @@ import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
 import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
 import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
 import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
 import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
 import io.yak.ops.spi.datasource.metadata.DataSourceTable;
 import io.yak.ops.spi.datasource.query.DataSourceQueryColumn;
 import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,7 @@ import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/** Datasource Catalog SPI -> typed Business Catalog Gateway Adapter。 */
+/** Datasource Catalog SPI -> typed Business Catalog Gateway Adapter. */
 @Component
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -40,30 +41,32 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
   private final DataSourcePluginRegistry pluginRegistry;
 
   @Override
-  public List<String> listDatabases(
-      DataSourceDefinition dataSource,
-      int timeoutSeconds) {
-    return execute(dataSource, timeoutSeconds, DataSourceCatalog::listDatabases);
+  public List<String> listDatabases(DataSourceDefinition dataSource, int timeoutSeconds) {
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        DataSourceCapability.CATALOG_METADATA,
+        DataSourceCatalog::listDatabases);
   }
 
   @Override
   public List<String> listSchemas(
-      DataSourceDefinition dataSource,
-      String database,
-      int timeoutSeconds) {
-    return execute(dataSource, timeoutSeconds, catalog -> catalog.listSchemas(database));
+      DataSourceDefinition dataSource, String database, int timeoutSeconds) {
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        DataSourceCapability.CATALOG_METADATA,
+        catalog -> catalog.listSchemas(database));
   }
 
   @Override
   public List<CatalogTable> listTables(
-      DataSourceDefinition dataSource,
-      CatalogTableQuery query,
-      int timeoutSeconds) {
-    CatalogTableQuery value =
-        query == null ? new CatalogTableQuery(null, null, null) : query;
+      DataSourceDefinition dataSource, CatalogTableQuery query, int timeoutSeconds) {
+    CatalogTableQuery value = query == null ? new CatalogTableQuery(null, null, null) : query;
     return execute(
         dataSource,
         timeoutSeconds,
+        DataSourceCapability.CATALOG_METADATA,
         catalog ->
             catalog
                 .listTables(
@@ -76,17 +79,14 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
 
   @Override
   public List<CatalogColumn> listColumns(
-      DataSourceDefinition dataSource,
-      CatalogTablePath tablePath,
-      int timeoutSeconds) {
+      DataSourceDefinition dataSource, CatalogTablePath tablePath, int timeoutSeconds) {
     if (tablePath == null) {
-      throw new DataSourceException(
-          DataSourceErrorCode.CATALOG_FAILED,
-          "Catalog 表路径不能为空");
+      throw new DataSourceException(DataSourceErrorCode.CATALOG_FAILED, "Catalog 表路径不能为空");
     }
     return execute(
         dataSource,
         timeoutSeconds,
+        DataSourceCapability.CATALOG_METADATA,
         catalog ->
             catalog
                 .listColumns(
@@ -99,13 +99,12 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
 
   @Override
   public List<CatalogColumn> describe(
-      DataSourceDefinition dataSource,
-      CatalogReadRequest request,
-      int timeoutSeconds) {
-    Map<String, Object> pluginRequest = toPluginRequest(request);
+      DataSourceDefinition dataSource, CatalogReadRequest request, int timeoutSeconds) {
+    DataSourceCatalogReadRequest pluginRequest = toPluginRequest(request);
     return execute(
         dataSource,
         timeoutSeconds,
+        DataSourceCapability.CATALOG_READ,
         catalog -> catalog.describe(pluginRequest).stream().map(this::toColumn).toList());
   }
 
@@ -115,64 +114,66 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
       CatalogReadRequest request,
       int limit,
       int timeoutSeconds) {
-    Map<String, Object> pluginRequest = toPluginRequest(request);
+    DataSourceCatalogReadRequest pluginRequest = toPluginRequest(request);
     return execute(
         dataSource,
         timeoutSeconds,
+        DataSourceCapability.CATALOG_READ,
         catalog -> toQueryResult(catalog.preview(pluginRequest, limit)));
   }
 
   @Override
   public long count(
-      DataSourceDefinition dataSource,
-      CatalogReadRequest request,
-      int timeoutSeconds) {
-    Map<String, Object> pluginRequest = toPluginRequest(request);
-    return execute(dataSource, timeoutSeconds, catalog -> catalog.count(pluginRequest));
+      DataSourceDefinition dataSource, CatalogReadRequest request, int timeoutSeconds) {
+    DataSourceCatalogReadRequest pluginRequest = toPluginRequest(request);
+    return execute(
+        dataSource,
+        timeoutSeconds,
+        DataSourceCapability.CATALOG_READ,
+        catalog -> catalog.count(pluginRequest));
   }
 
   @Override
   public String buildSqlTemplate(
-      DataSourceDefinition dataSource,
-      String tablePath,
-      int timeoutSeconds) {
+      DataSourceDefinition dataSource, String tablePath, int timeoutSeconds) {
     return execute(
         dataSource,
         timeoutSeconds,
+        DataSourceCapability.CATALOG_READ,
         catalog -> catalog.buildSqlTemplate(tablePath));
   }
 
   @Override
   public String resolveSql(
-      DataSourceDefinition dataSource,
-      CatalogReadRequest request,
-      int timeoutSeconds) {
+      DataSourceDefinition dataSource, CatalogReadRequest request, int timeoutSeconds) {
     if (request == null || request.sql() == null) {
-      throw new DataSourceException(
-          DataSourceErrorCode.CATALOG_FAILED,
-          "解析 SQL 时 query 不能为空");
+      throw new DataSourceException(DataSourceErrorCode.CATALOG_FAILED, "解析 SQL 时 query 不能为空");
     }
-    Map<String, Object> pluginRequest = toPluginRequest(request);
+    DataSourceCatalogReadRequest pluginRequest = toPluginRequest(request);
     return execute(
         dataSource,
         timeoutSeconds,
+        DataSourceCapability.CATALOG_READ,
         catalog -> catalog.resolveSql(request.sql(), pluginRequest));
   }
 
   private <T> T execute(
       DataSourceDefinition dataSource,
       int timeoutSeconds,
+      DataSourceCapability capability,
       Function<DataSourceCatalog, T> action) {
     if (dataSource == null || dataSource.getDbType() == null) {
-      throw new DataSourceException(
-          DataSourceErrorCode.CATALOG_FAILED,
-          "数据源定义或类型不能为空");
+      throw new DataSourceException(DataSourceErrorCode.CATALOG_FAILED, "数据源定义或类型不能为空");
     }
     try {
       DataSourcePlugin plugin = pluginRegistry.get(dataSource.getDbType());
+      if (!plugin.supports(capability)) {
+        throw new DataSourceException(
+            DataSourceErrorCode.CATALOG_FAILED,
+            "数据源插件未声明能力 " + capability.name() + "：" + plugin.dbType().name());
+      }
       DataSourceConnection connection = plugin.parseConnection(dataSource.getConnectionParams());
-      DataSourceCatalog catalog =
-          plugin.createCatalog(connection, Math.max(1, timeoutSeconds));
+      DataSourceCatalog catalog = plugin.createCatalog(connection, Math.max(1, timeoutSeconds));
       return action.apply(catalog);
     } catch (DataSourceException exception) {
       throw exception;
@@ -183,27 +184,21 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
     }
   }
 
-  private Map<String, Object> toPluginRequest(CatalogReadRequest request) {
+  private DataSourceCatalogReadRequest toPluginRequest(CatalogReadRequest request) {
     if (request == null) {
-      throw new DataSourceException(
-          DataSourceErrorCode.CATALOG_FAILED,
-          "Catalog 请求不能为空");
+      throw new DataSourceException(DataSourceErrorCode.CATALOG_FAILED, "Catalog 请求不能为空");
     }
-    Map<String, Object> values = new LinkedHashMap<>();
-    values.put("read_mode", request.sqlMode() ? "sql" : "table");
-    if (request.tablePath() != null) values.put("table_path", request.tablePath());
-    if (request.sql() != null) values.put("query", request.sql());
-    if (!request.variables().isEmpty()) {
-      List<Map<String, Object>> params = new ArrayList<>(request.variables().size());
-      for (CatalogReadRequest.Variable variable : request.variables()) {
-        Map<String, Object> item = new LinkedHashMap<>();
-        item.put("paramName", variable.name());
-        item.put("paramValue", variable.value());
-        params.add(item);
-      }
-      values.put("paramsList", List.copyOf(params));
+    Map<String, String> variables = new LinkedHashMap<>();
+    for (CatalogReadRequest.Variable variable : request.variables()) {
+      variables.put(variable.name(), variable.value());
     }
-    return Map.copyOf(values);
+    return new DataSourceCatalogReadRequest(
+        request.sqlMode()
+            ? DataSourceCatalogReadRequest.Mode.SQL
+            : DataSourceCatalogReadRequest.Mode.TABLE,
+        request.tablePath(),
+        request.sql(),
+        variables);
   }
 
   private CatalogTable toTable(DataSourceTable table) {
@@ -229,26 +224,18 @@ public class SpiDataSourceCatalogGateway implements DataSourceCatalogGateway {
   }
 
   private CatalogQueryResult toQueryResult(DataSourceQueryResult result) {
-    if (result == null) {
-      return new CatalogQueryResult(List.of(), List.of(), 0L);
-    }
-    List<QueryColumn> columns =
-        result.getColumns().stream().map(this::toQueryColumn).toList();
+    if (result == null) return new CatalogQueryResult(List.of(), List.of(), 0L);
+    List<QueryColumn> columns = result.getColumns().stream().map(this::toQueryColumn).toList();
     return new CatalogQueryResult(columns, result.getData(), result.getTotal());
   }
 
   private QueryColumn toQueryColumn(DataSourceQueryColumn column) {
     return new QueryColumn(
-        column.getTitle(),
-        column.getDataIndex(),
-        column.getKey(),
-        column.isEllipsis());
+        column.getTitle(), column.getDataIndex(), column.getKey(), column.isEllipsis());
   }
 
   private DataSourceException catalogException(RuntimeException exception) {
     return new DataSourceException(
-        DataSourceErrorCode.CATALOG_FAILED,
-        exception.getMessage(),
-        exception);
+        DataSourceErrorCode.CATALOG_FAILED, exception.getMessage(), exception);
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGateway.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGateway.java
@@ -2,19 +2,23 @@ package io.yak.ops.business.datasource.gateway.adapter;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor.Capability;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
 import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/** Datasource Plugin SPI -> Business Gateway Adapter。 */
+/** Datasource Plugin SPI -> Business Plugin Gateway adapter. */
 @Component
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -29,57 +33,48 @@ public class SpiDataSourcePluginGateway implements DataSourcePluginGateway {
   }
 
   @Override
-  public ConnectionProfile normalizeConnection(
-      DataSourceDbType dbType,
-      String connectionJson) {
+  public DataSourcePluginDescriptor descriptor(DataSourceDbType dbType) {
+    return toBusinessDescriptor(pluginRegistry.get(dbType).descriptor());
+  }
+
+  @Override
+  public ConnectionProfile normalizeConnection(DataSourceDbType dbType, String connectionJson) {
     DataSourceConnection connection = parseConnection(pluginRegistry.get(dbType), connectionJson);
     return new ConnectionProfile(
-        connection.jdbcUrl(),
-        connection.normalizedJson(),
-        connection.normalizedJson());
+        connection.jdbcUrl(), connection.normalizedJson(), connection.normalizedJson());
   }
 
   @Override
   public String mergeStoredSecrets(
-      DataSourceDbType dbType,
-      String submittedJson,
-      String storedJson) {
-    return secretCodec.mergeStoredSecrets(
-        pluginRegistry.get(dbType),
-        submittedJson,
-        storedJson);
+      DataSourceDbType dbType, String submittedJson, String storedJson) {
+    DataSourcePlugin plugin = pluginRegistry.get(dbType);
+    return secretCodec.mergeStoredSecrets(plugin.descriptor(), submittedJson, storedJson);
   }
 
   @Override
   public void testConnection(
-      DataSourceDbType dbType,
-      ConnectionProfile connectionProfile,
-      int timeoutSeconds) {
+      DataSourceDbType dbType, ConnectionProfile connectionProfile, int timeoutSeconds) {
     if (connectionProfile == null) {
       throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          "数据源连接配置不能为空");
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS, "数据源连接配置不能为空");
     }
     DataSourcePlugin plugin = pluginRegistry.get(dbType);
-    DataSourceConnection connection =
-        parseConnection(plugin, connectionProfile.normalizedJson());
+    requireCapability(plugin, DataSourceCapability.CONNECTION_TEST, DataSourceErrorCode.CONNECT_FAILED);
+    DataSourceConnection connection = parseConnection(plugin, connectionProfile.normalizedJson());
     try {
       plugin.testConnection(connection, Math.max(1, timeoutSeconds));
     } catch (DataSourceException exception) {
       throw exception;
     } catch (RuntimeException exception) {
       throw new DataSourceException(
-          DataSourceErrorCode.CONNECT_FAILED,
-          exception.getMessage(),
-          exception);
+          DataSourceErrorCode.CONNECT_FAILED, exception.getMessage(), exception);
     }
   }
 
   @Override
-  public String maskConnectionJson(
-      DataSourceDbType dbType,
-      String connectionJson) {
-    return secretCodec.maskConnectionJson(pluginRegistry.get(dbType), connectionJson);
+  public String maskConnectionJson(DataSourceDbType dbType, String connectionJson) {
+    DataSourcePlugin plugin = pluginRegistry.get(dbType);
+    return secretCodec.maskConnectionJson(plugin.descriptor(), connectionJson);
   }
 
   @Override
@@ -87,21 +82,85 @@ public class SpiDataSourcePluginGateway implements DataSourcePluginGateway {
     return secretCodec.maskSensitiveText(value);
   }
 
-  private DataSourceConnection parseConnection(
-      DataSourcePlugin plugin,
-      String connectionJson) {
+  private DataSourceConnection parseConnection(DataSourcePlugin plugin, String connectionJson) {
     try {
       return plugin.parseConnection(connectionJson);
     } catch (DataSourcePluginException exception) {
       throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          exception.getMessage(),
-          exception);
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS, exception.getMessage(), exception);
     } catch (RuntimeException exception) {
       throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          exception.getMessage(),
-          exception);
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS, exception.getMessage(), exception);
     }
+  }
+
+  private void requireCapability(
+      DataSourcePlugin plugin, DataSourceCapability capability, DataSourceErrorCode errorCode) {
+    if (!plugin.supports(capability)) {
+      throw new DataSourceException(
+          errorCode,
+          "数据源插件未声明能力 " + capability.name() + "：" + plugin.dbType().name());
+    }
+  }
+
+  private DataSourcePluginDescriptor toBusinessDescriptor(
+      io.yak.ops.spi.datasource.DataSourcePluginDescriptor source) {
+    if (source == null) {
+      throw new DataSourceException(DataSourceErrorCode.PLUGIN_NOT_FOUND, "数据源插件描述不能为空");
+    }
+    return new DataSourcePluginDescriptor(
+        source.dbType(),
+        source.displayName(),
+        source.apiVersion(),
+        source.capabilities().stream().map(value -> Capability.valueOf(value.name())).collect(java.util.stream.Collectors.toUnmodifiableSet()),
+        source.connectionForm().sections().stream().map(this::toSection).toList(),
+        source.connectionForm().legacyFields().stream().map(this::toField).toList(),
+        source.installRequired(),
+        source.installHint());
+  }
+
+  private DataSourcePluginDescriptor.FormSection toSection(
+      io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormSection source) {
+    return new DataSourcePluginDescriptor.FormSection(
+        source.key(),
+        source.title(),
+        source.description(),
+        source.collapsible(),
+        source.defaultExpanded(),
+        source.fields().stream().map(this::toField).toList());
+  }
+
+  private DataSourcePluginDescriptor.FormField toField(
+      io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField source) {
+    return new DataSourcePluginDescriptor.FormField(
+        source.key(),
+        source.label(),
+        source.type().name(),
+        source.placeholder(),
+        source.defaultValue(),
+        source.options().stream()
+            .map(value -> new DataSourcePluginDescriptor.FormOption(value.label(), value.value()))
+            .toList(),
+        source.rules().stream()
+            .map(
+                value ->
+                    new DataSourcePluginDescriptor.FormRule(
+                        value.required(), value.pattern(), value.min(), value.max(), value.message()))
+            .toList(),
+        source.dependsOn(),
+        source.visibleWhen().stream()
+            .map(
+                value ->
+                    new DataSourcePluginDescriptor.VisibilityCondition(
+                        value.field(), value.operator().name(), value.value(), value.values()))
+            .toList(),
+        source.jdbcUrlLinkage() == null
+            ? null
+            : new DataSourcePluginDescriptor.JdbcUrlLinkage(
+                source.jdbcUrlLinkage().template(),
+                source.jdbcUrlLinkage().hostField(),
+                source.jdbcUrlLinkage().portField(),
+                source.jdbcUrlLinkage().databaseField(),
+                source.jdbcUrlLinkage().preserveSuffix()));
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/plugin/DataSourcePluginRegistry.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/plugin/DataSourcePluginRegistry.java
@@ -6,7 +6,9 @@ import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
 import jakarta.annotation.PostConstruct;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -16,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-/** 通过 Java ServiceLoader 发现并路由数据源插件。 */
+/** Discovers datasource plugins with ServiceLoader and validates their stable descriptor contract. */
 @Slf4j
 @Component
 @ConditionalOnDataSourceEnabled
@@ -29,22 +31,26 @@ public class DataSourcePluginRegistry {
   @PostConstruct
   public void initialize() {
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-    if (classLoader == null) {
-      classLoader = DataSourcePluginRegistry.class.getClassLoader();
-    }
+    if (classLoader == null) classLoader = DataSourcePluginRegistry.class.getClassLoader();
 
     Map<DataSourceDbType, DataSourcePlugin> discovered = new EnumMap<>(DataSourceDbType.class);
     for (DataSourcePlugin plugin : ServiceLoader.load(DataSourcePlugin.class, classLoader)) {
+      validateDescriptor(plugin);
       DataSourcePlugin existing = discovered.putIfAbsent(plugin.dbType(), plugin);
       if (existing != null) {
         throw new IllegalStateException(
-            "Duplicate datasource plugin for " + plugin.dbType().name()
-                + ": " + existing.getClass().getName()
-                + " and " + plugin.getClass().getName());
+            "Duplicate datasource plugin for "
+                + plugin.dbType().name()
+                + ": "
+                + existing.getClass().getName()
+                + " and "
+                + plugin.getClass().getName());
       }
       log.info(
-          "Registered datasource plugin: type={}, implementation={}",
+          "Registered datasource plugin: type={}, apiVersion={}, capabilities={}, implementation={}",
           plugin.dbType(),
+          plugin.descriptor().apiVersion(),
+          plugin.descriptor().capabilities(),
           plugin.getClass().getName());
     }
     plugins = Collections.unmodifiableMap(discovered);
@@ -55,9 +61,7 @@ public class DataSourcePluginRegistry {
       return get(DataSourceDbType.parse(dbType));
     } catch (IllegalArgumentException exception) {
       throw new DataSourceException(
-          DataSourceErrorCode.INVALID_DB_TYPE,
-          exception.getMessage(),
-          exception);
+          DataSourceErrorCode.INVALID_DB_TYPE, exception.getMessage(), exception);
     }
   }
 
@@ -71,34 +75,28 @@ public class DataSourcePluginRegistry {
     return plugin;
   }
 
-  /** 只解析路由字段；具体连接参数仍由目标插件解析。 */
+  /** Parse only the routing field; the target plugin still owns connection parsing. */
   public DataSourceDbType resolveConnectionType(String connectionJson) {
     try {
       JsonNode root = objectMapper.readTree(connectionJson);
       if (root == null || !root.isObject()) {
         throw new DataSourceException(
-            DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-            "连接参数必须是 JSON 对象");
+            DataSourceErrorCode.INVALID_CONNECTION_PARAMS, "连接参数必须是 JSON 对象");
       }
       String value = firstText(root, "dbType", "type", "pluginType");
       if (value == null || value.trim().isEmpty()) {
         throw new DataSourceException(
-            DataSourceErrorCode.INVALID_DB_TYPE,
-            "连接参数中缺少 dbType 或 pluginType");
+            DataSourceErrorCode.INVALID_DB_TYPE, "连接参数中缺少 dbType 或 pluginType");
       }
       return DataSourceDbType.parse(value);
     } catch (DataSourceException exception) {
       throw exception;
     } catch (IllegalArgumentException exception) {
       throw new DataSourceException(
-          DataSourceErrorCode.INVALID_DB_TYPE,
-          exception.getMessage(),
-          exception);
+          DataSourceErrorCode.INVALID_DB_TYPE, exception.getMessage(), exception);
     } catch (Exception exception) {
       throw new DataSourceException(
-          DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-          "无法识别连接参数中的插件类型",
-          exception);
+          DataSourceErrorCode.INVALID_CONNECTION_PARAMS, "无法识别连接参数中的插件类型", exception);
     }
   }
 
@@ -106,12 +104,44 @@ public class DataSourcePluginRegistry {
     return plugins;
   }
 
+  private void validateDescriptor(DataSourcePlugin plugin) {
+    if (plugin == null || plugin.dbType() == null) {
+      throw new IllegalStateException("Datasource plugin and dbType must not be null");
+    }
+    DataSourcePluginDescriptor descriptor = plugin.descriptor();
+    if (descriptor == null) {
+      throw new IllegalStateException("Datasource plugin descriptor must not be null: " + plugin.getClass().getName());
+    }
+    if (descriptor.dbType() != plugin.dbType()) {
+      throw new IllegalStateException(
+          "Datasource plugin descriptor type mismatch: plugin="
+              + plugin.dbType()
+              + ", descriptor="
+              + descriptor.dbType());
+    }
+    if (!DataSourcePluginDescriptor.CURRENT_API_VERSION.equals(descriptor.apiVersion())) {
+      throw new IllegalStateException(
+          "Unsupported datasource plugin API version "
+              + descriptor.apiVersion()
+              + " for "
+              + plugin.dbType());
+    }
+    if (descriptor.supports(DataSourceCapability.TRANSACTIONS)
+        && !descriptor.supports(DataSourceCapability.SQL_EXECUTION)) {
+      throw new IllegalStateException(
+          "Datasource plugin TRANSACTIONS requires SQL_EXECUTION: " + plugin.dbType());
+    }
+    if (descriptor.supports(DataSourceCapability.CATALOG_READ)
+        && !descriptor.supports(DataSourceCapability.CATALOG_METADATA)) {
+      throw new IllegalStateException(
+          "Datasource plugin CATALOG_READ requires CATALOG_METADATA: " + plugin.dbType());
+    }
+  }
+
   private String firstText(JsonNode root, String... keys) {
     for (String key : keys) {
       JsonNode value = root.get(key);
-      if (value != null && !value.isNull()) {
-        return value.asText();
-      }
+      if (value != null && !value.isNull()) return value.asText();
     }
     return null;
   }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourcePluginConfigServiceImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/impl/DataSourcePluginConfigServiceImpl.java
@@ -1,28 +1,43 @@
 package io.yak.ops.business.datasource.service.impl;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
-import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
+import io.yak.ops.business.datasource.exception.DataSourceException;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
 import io.yak.ops.business.datasource.service.DataSourcePluginConfigService;
+import io.yak.ops.business.datasource.service.support.DataSourcePluginViewMapper;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/** 数据源动态表单配置服务，配置内容由具体插件提供。 */
+/** Datasource plugin configuration service backed by the Business plugin descriptor boundary. */
 @Service
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataSourcePluginConfigServiceImpl implements DataSourcePluginConfigService {
 
-  private final DataSourcePluginRegistry pluginRegistry;
+  private final DataSourcePluginGateway pluginGateway;
+  private final DataSourcePluginViewMapper viewMapper;
 
   @Override
   public DataSourcePluginConfigVO getPluginConfig(String pluginType) {
-    return pluginRegistry.get(pluginType).pluginConfig();
+    DataSourceDbType dbType = parseDbType(pluginType);
+    return viewMapper.config(pluginGateway.descriptor(dbType));
   }
 
   @Override
   public boolean installPlugin(String pluginType) {
-    pluginRegistry.get(pluginType);
+    pluginGateway.descriptor(parseDbType(pluginType));
     return true;
+  }
+
+  private DataSourceDbType parseDbType(String value) {
+    try {
+      return DataSourceDbType.parse(value);
+    } catch (IllegalArgumentException exception) {
+      throw new DataSourceException(
+          DataSourceErrorCode.INVALID_DB_TYPE, exception.getMessage(), exception);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/BusinessDataSourceExecutionProvider.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/BusinessDataSourceExecutionProvider.java
@@ -5,13 +5,15 @@ import io.yak.ops.business.datasource.config.DataSourceProperties;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
 import org.springframework.stereotype.Component;
 
-/** Resolves platform datasource IDs without exposing connection credentials to Task Plugins. */
+/** Outward Task-Plugin adapter that resolves platform datasource IDs to SQL executors. */
 @Component
 @ConditionalOnDataSourceEnabled
 public class BusinessDataSourceExecutionProvider implements DataSourceExecutionProvider {
@@ -37,10 +39,14 @@ public class BusinessDataSourceExecutionProvider implements DataSourceExecutionP
             .findById(dataSourceId)
             .orElseThrow(() -> new IllegalArgumentException("数据源不存在：" + dataSourceReference));
     DataSourcePlugin plugin = pluginRegistry.get(definition.getDbType());
+    if (!plugin.supports(DataSourceCapability.SQL_EXECUTION)) {
+      throw new DataSourcePluginException(
+          DataSourcePluginException.Operation.EXECUTION,
+          "当前数据源插件未声明 SQL_EXECUTION 能力：" + plugin.dbType().name());
+    }
     DataSourceConnection connection = plugin.parseConnection(definition.getConnectionParams());
     return plugin.createSqlExecutor(
-        connection,
-        Math.max(1, properties.getConnectionTest().getTimeoutSeconds()));
+        connection, Math.max(1, properties.getConnectionTest().getTimeoutSeconds()));
   }
 
   private long parseDataSourceId(String reference) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/DataSourcePluginViewMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/service/support/DataSourcePluginViewMapper.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.datasource.service.support;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.JdbcUrlLinkageVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.OptionVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.RuleVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.VisibilityConditionVO;
+import org.springframework.stereotype.Component;
+
+/** Business plugin descriptor -> existing HTTP plugin-config VO projection. */
+@Component
+@ConditionalOnDataSourceEnabled
+public class DataSourcePluginViewMapper {
+
+  public DataSourcePluginConfigVO config(DataSourcePluginDescriptor source) {
+    if (source == null) return null;
+    return DataSourcePluginConfigVO.builder()
+        .pluginType(source.dbType().name())
+        .sections(source.sections().stream().map(this::section).toList())
+        .formFields(source.legacyFields().stream().map(this::field).toList())
+        .installRequired(source.installRequired())
+        .installHint(source.installHint())
+        .build();
+  }
+
+  private FormSectionVO section(DataSourcePluginDescriptor.FormSection source) {
+    return FormSectionVO.builder()
+        .key(source.key())
+        .title(source.title())
+        .description(source.description())
+        .collapsible(source.collapsible())
+        .defaultExpanded(source.defaultExpanded())
+        .fields(source.fields().stream().map(this::field).toList())
+        .build();
+  }
+
+  private FormFieldVO field(DataSourcePluginDescriptor.FormField source) {
+    return FormFieldVO.builder()
+        .key(source.key())
+        .label(source.label())
+        .type(source.type())
+        .placeholder(source.placeholder())
+        .defaultValue(source.defaultValue())
+        .options(
+            source.options().stream()
+                .map(value -> new OptionVO(value.label(), value.value()))
+                .toList())
+        .rules(
+            source.rules().stream()
+                .map(
+                    value ->
+                        new RuleVO(
+                            value.required(),
+                            value.pattern(),
+                            value.min(),
+                            value.max(),
+                            value.message()))
+                .toList())
+        .dependsOn(source.dependsOn())
+        .visibleWhen(
+            source.visibleWhen().stream()
+                .map(
+                    value ->
+                        new VisibilityConditionVO(
+                            value.field(), value.operator(), value.value(), value.values()))
+                .toList())
+        .urlLinkage(linkage(source.jdbcUrlLinkage()))
+        .build();
+  }
+
+  private JdbcUrlLinkageVO linkage(DataSourcePluginDescriptor.JdbcUrlLinkage source) {
+    if (source == null) return null;
+    return JdbcUrlLinkageVO.builder()
+        .template(source.template())
+        .hostField(source.hostField())
+        .portField(source.portField())
+        .databaseField(source.databaseField())
+        .preserveSuffix(source.preserveSuffix())
+        .build();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/util/DataSourceSecretCodec.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/util/DataSourceSecretCodec.java
@@ -6,19 +6,17 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.exception.DataSourceException;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
-import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/** 连接参数敏感字段的脱敏和编辑合并工具。 */
+/** Connection-secret masking and stored-secret merge helper used by the SPI adapter boundary. */
 @Component
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -41,41 +39,32 @@ public class DataSourceSecretCodec {
 
   private final ObjectMapper objectMapper;
 
-  /** 返回仅用于前端回显的脱敏 JSON。 */
-  public String maskConnectionJson(DataSourcePlugin plugin, String connectionJson) {
-    if (connectionJson == null || connectionJson.trim().isEmpty()) {
-      return null;
-    }
+  /** Return masked JSON for interface projection only. */
+  public String maskConnectionJson(DataSourcePluginDescriptor descriptor, String connectionJson) {
+    if (connectionJson == null || connectionJson.trim().isEmpty()) return null;
     ObjectNode root = readObject(connectionJson);
-    maskObject(root, secretKeys(plugin));
+    maskObject(root, secretKeys(descriptor));
     return write(root);
   }
 
-  /**
-   * 编辑或测试已有数据源时，前端传回掩码、空值或缺失字段都表示沿用已保存密钥。
-   */
+  /** Merge masked, empty or missing secret fields with the stored connection JSON. */
   public String mergeStoredSecrets(
-      DataSourcePlugin plugin,
-      String submittedJson,
-      String storedJson) {
+      DataSourcePluginDescriptor descriptor, String submittedJson, String storedJson) {
     ObjectNode submitted = readObject(submittedJson);
     ObjectNode stored = readObject(storedJson);
-    mergeObject(submitted, stored, secretKeys(plugin));
+    mergeObject(submitted, stored, secretKeys(descriptor));
     return write(submitted);
   }
 
-  /** 对展示用连接地址中的常见凭据参数进行兜底脱敏。 */
+  /** Fallback masking for sensitive credentials embedded in display text/JDBC URLs. */
   public String maskSensitiveText(String value) {
-    if (value == null || value.isEmpty()) {
-      return value;
-    }
+    if (value == null || value.isEmpty()) return value;
     String masked =
         value.replaceAll(
             "(?i)((?:^|[?&;])(?:password|pwd|token|secret)=)[^&;\\s]*",
             "$1" + MASKED_VALUE);
     return masked.replaceAll(
-        "(?i)(://[^:/?#\\s]+:)[^@/?#\\s]+@",
-        "$1" + MASKED_VALUE + "@");
+        "(?i)(://[^:/?#\\s]+:)[^@/?#\\s]+@", "$1" + MASKED_VALUE + "@");
   }
 
   private void maskObject(ObjectNode object, Set<String> configuredKeys) {
@@ -103,10 +92,7 @@ public class DataSourceSecretCodec {
     }
   }
 
-  private void mergeObject(
-      ObjectNode submitted,
-      ObjectNode stored,
-      Set<String> configuredKeys) {
+  private void mergeObject(ObjectNode submitted, ObjectNode stored, Set<String> configuredKeys) {
     Iterator<Map.Entry<String, JsonNode>> storedFields = stored.fields();
     while (storedFields.hasNext()) {
       Map.Entry<String, JsonNode> field = storedFields.next();
@@ -120,26 +106,17 @@ public class DataSourceSecretCodec {
           && storedValue.isObject()
           && submittedValue != null
           && submittedValue.isObject()) {
-        mergeObject(
-            (ObjectNode) submittedValue,
-            (ObjectNode) storedValue,
-            configuredKeys);
+        mergeObject((ObjectNode) submittedValue, (ObjectNode) storedValue, configuredKeys);
       } else if (storedValue != null
           && storedValue.isArray()
           && submittedValue != null
           && submittedValue.isArray()) {
-        mergeArray(
-            (ArrayNode) submittedValue,
-            (ArrayNode) storedValue,
-            configuredKeys);
+        mergeArray((ArrayNode) submittedValue, (ArrayNode) storedValue, configuredKeys);
       }
     }
   }
 
-  private void mergeArray(
-      ArrayNode submitted,
-      ArrayNode stored,
-      Set<String> configuredKeys) {
+  private void mergeArray(ArrayNode submitted, ArrayNode stored, Set<String> configuredKeys) {
     int length = Math.min(submitted.size(), stored.size());
     for (int index = 0; index < length; index++) {
       JsonNode submittedValue = submitted.get(index);
@@ -148,37 +125,21 @@ public class DataSourceSecretCodec {
           && submittedValue.isObject()
           && storedValue != null
           && storedValue.isObject()) {
-        mergeObject(
-            (ObjectNode) submittedValue,
-            (ObjectNode) storedValue,
-            configuredKeys);
+        mergeObject((ObjectNode) submittedValue, (ObjectNode) storedValue, configuredKeys);
       } else if (submittedValue != null
           && submittedValue.isArray()
           && storedValue != null
           && storedValue.isArray()) {
-        mergeArray(
-            (ArrayNode) submittedValue,
-            (ArrayNode) storedValue,
-            configuredKeys);
+        mergeArray((ArrayNode) submittedValue, (ArrayNode) storedValue, configuredKeys);
       }
     }
   }
 
-  private Set<String> secretKeys(DataSourcePlugin plugin) {
+  private Set<String> secretKeys(DataSourcePluginDescriptor descriptor) {
     Set<String> keys = new LinkedHashSet<>();
-    if (plugin == null || plugin.pluginConfig() == null) {
-      return keys;
-    }
-    List<FormFieldVO> fields = plugin.pluginConfig().getFormFields();
-    if (fields == null) {
-      return keys;
-    }
-    for (FormFieldVO field : fields) {
-      if (field != null
-          && field.getKey() != null
-          && "PASSWORD".equalsIgnoreCase(field.getType())) {
-        keys.add(normalizeKey(field.getKey()));
-      }
+    if (descriptor == null) return keys;
+    for (String key : descriptor.secretFieldKeys()) {
+      keys.add(normalizeKey(key));
     }
     return keys;
   }
@@ -197,19 +158,12 @@ public class DataSourceSecretCodec {
   private String normalizeKey(String key) {
     return key == null
         ? ""
-        : key.replace("_", "")
-            .replace("-", "")
-            .trim()
-            .toLowerCase(Locale.ROOT);
+        : key.replace("_", "").replace("-", "").trim().toLowerCase(Locale.ROOT);
   }
 
   private boolean shouldPreserve(JsonNode value) {
-    if (value == null || value.isNull()) {
-      return true;
-    }
-    if (!value.isTextual()) {
-      return false;
-    }
+    if (value == null || value.isNull()) return true;
+    if (!value.isTextual()) return false;
     String text = value.asText();
     return text == null || text.trim().isEmpty() || MASKED_VALUE.equals(text.trim());
   }
@@ -237,9 +191,6 @@ public class DataSourceSecretCodec {
   }
 
   private DataSourceException invalidJson(String message, Throwable cause) {
-    return new DataSourceException(
-        DataSourceErrorCode.INVALID_CONNECTION_PARAMS,
-        message,
-        cause);
+    return new DataSourceException(DataSourceErrorCode.INVALID_CONNECTION_PARAMS, message, cause);
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.datasource.architecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
 import io.yak.ops.business.datasource.execution.DefaultSqlExecutionRuntime;
 import io.yak.ops.business.datasource.execution.domain.SqlExecutionAggregate;
 import io.yak.ops.business.datasource.gateway.DataSourceCatalogGateway;
@@ -11,7 +12,9 @@ import io.yak.ops.business.datasource.gateway.adapter.SpiDataSourceCatalogGatewa
 import io.yak.ops.business.datasource.gateway.adapter.SpiDataSourcePluginGateway;
 import io.yak.ops.business.datasource.gateway.adapter.SpiSqlExecutionGateway;
 import io.yak.ops.business.datasource.service.impl.DataSourceCatalogServiceImpl;
+import io.yak.ops.business.datasource.service.impl.DataSourcePluginConfigServiceImpl;
 import io.yak.ops.business.datasource.service.impl.DataSourceServiceImpl;
+import io.yak.ops.business.datasource.service.support.DataSourcePluginViewMapper;
 import io.yak.ops.business.datasource.service.support.DataSourceViewMapper;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -52,7 +55,9 @@ class DataSourceGatewayArchitectureTest {
         List.of(
             DataSourceServiceImpl.class,
             DataSourceCatalogServiceImpl.class,
+            DataSourcePluginConfigServiceImpl.class,
             DataSourceViewMapper.class,
+            DataSourcePluginViewMapper.class,
             DefaultSqlExecutionRuntime.class)) {
       for (Field field : type.getDeclaredFields()) {
         String fieldType = field.getGenericType().getTypeName();
@@ -75,6 +80,16 @@ class DataSourceGatewayArchitectureTest {
   }
 
   @Test
+  void businessPluginDescriptorDoesNotExposeSpiOrHttpProjectionTypes() {
+    for (Field field : DataSourcePluginDescriptor.class.getDeclaredFields()) {
+      assertThat(field.getGenericType().getTypeName())
+          .doesNotContain(".spi.datasource")
+          .doesNotContain(".bean.vo.")
+          .doesNotContain(".bean.dto.");
+    }
+  }
+
+  @Test
   void sqlExecutionAggregateDoesNotOwnPhysicalPluginInfrastructure() {
     for (Field field : SqlExecutionAggregate.class.getDeclaredFields()) {
       String fieldType = field.getGenericType().getTypeName();
@@ -87,10 +102,7 @@ class DataSourceGatewayArchitectureTest {
   }
 
   private void assertTypeAvoids(
-      Class<?> owner,
-      String member,
-      Type type,
-      String... forbidden) {
+      Class<?> owner, String member, Type type, String... forbidden) {
     String signature = typeName(type);
     for (String packagePart : forbidden) {
       assertThat(signature)

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
@@ -16,14 +16,15 @@ import io.yak.ops.business.datasource.domain.catalog.CatalogTable;
 import io.yak.ops.business.datasource.domain.catalog.CatalogTableQuery;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
 import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
 import io.yak.ops.spi.datasource.metadata.DataSourceTable;
 import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -38,7 +39,7 @@ class SpiDataSourceCatalogGatewayTest {
   @Test
   void listTablesTranslatesPluginMetadataToCatalogDomain() {
     DataSourceDefinition dataSource = configuredDataSource();
-    stubCatalog(dataSource);
+    stubCatalog(dataSource, DataSourceCapability.CATALOG_METADATA);
     when(catalog.listTables(any(DataSourceCatalogQuery.class)))
         .thenReturn(
             List.of(
@@ -47,9 +48,7 @@ class SpiDataSourceCatalogGatewayTest {
 
     List<CatalogTable> result =
         gateway.listTables(
-            dataSource,
-            new CatalogTableQuery("orders_db", "public", "ord"),
-            5);
+            dataSource, new CatalogTableQuery("orders_db", "public", "ord"), 5);
 
     assertThat(result).hasSize(1);
     assertThat(result.getFirst().database()).isEqualTo("orders_db");
@@ -60,10 +59,10 @@ class SpiDataSourceCatalogGatewayTest {
   }
 
   @Test
-  void typedCatalogRequestIsProjectedToLegacyPluginMapOnlyInsideAdapter() {
+  void typedCatalogRequestIsTranslatedToTypedPluginRequest() {
     DataSourceDefinition dataSource = configuredDataSource();
-    stubCatalog(dataSource);
-    when(catalog.preview(any(Map.class), eq(20)))
+    stubCatalog(dataSource, DataSourceCapability.CATALOG_READ);
+    when(catalog.preview(any(DataSourceCatalogReadRequest.class), eq(20)))
         .thenReturn(new DataSourceQueryResult(List.of(), List.of(), 0L));
     CatalogReadRequest request =
         new CatalogReadRequest(
@@ -74,17 +73,19 @@ class SpiDataSourceCatalogGatewayTest {
 
     CatalogQueryResult result = gateway.preview(dataSource, request, 20, 5);
 
-    ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<DataSourceCatalogReadRequest> captor =
+        ArgumentCaptor.forClass(DataSourceCatalogReadRequest.class);
     verify(catalog).preview(captor.capture(), eq(20));
-    Map<String, Object> pluginRequest = captor.getValue();
-    assertThat(pluginRequest.get("read_mode")).isEqualTo("sql");
-    assertThat(pluginRequest.get("query")).isEqualTo(request.sql());
-    assertThat(pluginRequest.get("paramsList")).isInstanceOf(List.class);
+    DataSourceCatalogReadRequest pluginRequest = captor.getValue();
+    assertThat(pluginRequest.mode()).isEqualTo(DataSourceCatalogReadRequest.Mode.SQL);
+    assertThat(pluginRequest.query()).isEqualTo(request.sql());
+    assertThat(pluginRequest.variables()).containsEntry("day", "2026-08-23");
     assertThat(result.total()).isZero();
   }
 
-  private void stubCatalog(DataSourceDefinition dataSource) {
+  private void stubCatalog(DataSourceDefinition dataSource, DataSourceCapability capability) {
     when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(plugin.supports(capability)).thenReturn(true);
     when(plugin.parseConnection(dataSource.getConnectionParams())).thenReturn(connection);
     when(plugin.createCatalog(connection, 5)).thenReturn(catalog);
   }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourcePluginGatewayTest.java
@@ -8,14 +8,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
 import io.yak.ops.business.datasource.util.DataSourceSecretCodec;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.ConnectionForm;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class SpiDataSourcePluginGatewayTest {
@@ -24,8 +29,19 @@ class SpiDataSourcePluginGatewayTest {
   private final DataSourceSecretCodec secretCodec = mock(DataSourceSecretCodec.class);
   private final DataSourcePlugin plugin = mock(DataSourcePlugin.class);
   private final DataSourceConnection connection = mock(DataSourceConnection.class);
-  private final SpiDataSourcePluginGateway gateway =
-      new SpiDataSourcePluginGateway(registry, secretCodec);
+  private final SpiDataSourcePluginGateway gateway = new SpiDataSourcePluginGateway(registry, secretCodec);
+
+  @Test
+  void descriptorTranslatesSpiMetadataToBusinessOwnedProjection() {
+    when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(plugin.descriptor()).thenReturn(spiDescriptor());
+
+    DataSourcePluginDescriptor result = gateway.descriptor(DataSourceDbType.MYSQL);
+
+    assertThat(result.dbType()).isEqualTo(DataSourceDbType.MYSQL);
+    assertThat(result.apiVersion()).isEqualTo("1");
+    assertThat(result.capabilities()).contains(DataSourcePluginDescriptor.Capability.SQL_EXECUTION);
+  }
 
   @Test
   void normalizeConnectionTranslatesSpiConnectionToDomainProfile() {
@@ -34,8 +50,7 @@ class SpiDataSourcePluginGatewayTest {
     when(connection.jdbcUrl()).thenReturn("jdbc:mysql://127.0.0.1:3306/orders");
     when(connection.normalizedJson()).thenReturn("{\"database\":\"orders\"}");
 
-    ConnectionProfile result =
-        gateway.normalizeConnection(DataSourceDbType.MYSQL, "submitted-json");
+    ConnectionProfile result = gateway.normalizeConnection(DataSourceDbType.MYSQL, "submitted-json");
 
     assertThat(result.jdbcUrl()).isEqualTo("jdbc:mysql://127.0.0.1:3306/orders");
     assertThat(result.normalizedJson()).isEqualTo("{\"database\":\"orders\"}");
@@ -45,40 +60,46 @@ class SpiDataSourcePluginGatewayTest {
   @Test
   void connectionFailureIsMappedToBusinessDatasourceException() {
     when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
+    when(plugin.descriptor()).thenReturn(spiDescriptor());
+    when(plugin.supports(DataSourceCapability.CONNECTION_TEST)).thenReturn(true);
     when(plugin.parseConnection("{\"database\":\"orders\"}")).thenReturn(connection);
     doThrow(
             new DataSourcePluginException(
-                DataSourcePluginException.Operation.CONNECTIVITY,
-                "connection unavailable"))
+                DataSourcePluginException.Operation.CONNECTIVITY, "connection unavailable"))
         .when(plugin)
         .testConnection(connection, 3);
 
     ConnectionProfile profile =
         ConnectionProfile.of(
-            "jdbc:mysql://127.0.0.1:3306/orders",
-            "{\"database\":\"orders\"}");
+            "jdbc:mysql://127.0.0.1:3306/orders", "{\"database\":\"orders\"}");
 
-    assertThatThrownBy(
-            () -> gateway.testConnection(DataSourceDbType.MYSQL, profile, 3))
+    assertThatThrownBy(() -> gateway.testConnection(DataSourceDbType.MYSQL, profile, 3))
         .isInstanceOfSatisfying(
             DataSourceException.class,
-            exception ->
-                assertThat(exception.getErrorCode()).isEqualTo(DataSourceErrorCode.CONNECT_FAILED));
+            exception -> assertThat(exception.getErrorCode()).isEqualTo(DataSourceErrorCode.CONNECT_FAILED));
   }
 
   @Test
   void secretMergeStaysInsideSpiAdapterBoundary() {
+    io.yak.ops.spi.datasource.DataSourcePluginDescriptor descriptor = spiDescriptor();
     when(registry.get(DataSourceDbType.MYSQL)).thenReturn(plugin);
-    when(secretCodec.mergeStoredSecrets(plugin, "submitted", "stored"))
-        .thenReturn("merged");
+    when(plugin.descriptor()).thenReturn(descriptor);
+    when(secretCodec.mergeStoredSecrets(descriptor, "submitted", "stored")).thenReturn("merged");
 
-    assertThat(
-            gateway.mergeStoredSecrets(
-                DataSourceDbType.MYSQL,
-                "submitted",
-                "stored"))
+    assertThat(gateway.mergeStoredSecrets(DataSourceDbType.MYSQL, "submitted", "stored"))
         .isEqualTo("merged");
 
-    verify(secretCodec).mergeStoredSecrets(plugin, "submitted", "stored");
+    verify(secretCodec).mergeStoredSecrets(descriptor, "submitted", "stored");
+  }
+
+  private io.yak.ops.spi.datasource.DataSourcePluginDescriptor spiDescriptor() {
+    return new io.yak.ops.spi.datasource.DataSourcePluginDescriptor(
+        DataSourceDbType.MYSQL,
+        "MySQL",
+        "1",
+        Set.of(DataSourceCapability.CONNECTION_TEST, DataSourceCapability.SQL_EXECUTION),
+        ConnectionForm.empty(),
+        false,
+        null);
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourcePluginConfigServiceImplTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/impl/DataSourcePluginConfigServiceImplTest.java
@@ -1,0 +1,59 @@
+package io.yak.ops.business.datasource.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
+import io.yak.ops.business.datasource.gateway.DataSourcePluginGateway;
+import io.yak.ops.business.datasource.service.support.DataSourcePluginViewMapper;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DataSourcePluginConfigServiceImplTest {
+
+  @Test
+  void pluginConfigFlowsThroughBusinessDescriptorAndViewMapper() {
+    DataSourcePluginGateway gateway = mock(DataSourcePluginGateway.class);
+    DataSourcePluginViewMapper mapper = mock(DataSourcePluginViewMapper.class);
+    DataSourcePluginDescriptor descriptor = descriptor();
+    DataSourcePluginConfigVO expected = DataSourcePluginConfigVO.builder().pluginType("MYSQL").build();
+    when(gateway.descriptor(DataSourceDbType.MYSQL)).thenReturn(descriptor);
+    when(mapper.config(descriptor)).thenReturn(expected);
+
+    DataSourcePluginConfigServiceImpl service = new DataSourcePluginConfigServiceImpl(gateway, mapper);
+    DataSourcePluginConfigVO result = service.getPluginConfig("mysql");
+
+    assertThat(result).isSameAs(expected);
+    verify(gateway).descriptor(DataSourceDbType.MYSQL);
+    verify(mapper).config(descriptor);
+  }
+
+  @Test
+  void installCheckUsesDescriptorInsteadOfPluginRegistry() {
+    DataSourcePluginGateway gateway = mock(DataSourcePluginGateway.class);
+    DataSourcePluginViewMapper mapper = mock(DataSourcePluginViewMapper.class);
+    when(gateway.descriptor(DataSourceDbType.MYSQL)).thenReturn(descriptor());
+
+    DataSourcePluginConfigServiceImpl service = new DataSourcePluginConfigServiceImpl(gateway, mapper);
+
+    assertThat(service.installPlugin("MYSQL")).isTrue();
+    verify(gateway).descriptor(DataSourceDbType.MYSQL);
+  }
+
+  private DataSourcePluginDescriptor descriptor() {
+    return new DataSourcePluginDescriptor(
+        DataSourceDbType.MYSQL,
+        "MySQL",
+        "1",
+        Set.of(DataSourcePluginDescriptor.Capability.CONNECTION_TEST),
+        List.of(),
+        List.of(),
+        false,
+        null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/support/DataSourcePluginViewMapperTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/service/support/DataSourcePluginViewMapperTest.java
@@ -1,0 +1,58 @@
+package io.yak.ops.business.datasource.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor.Capability;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor.FormField;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor.FormSection;
+import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor.JdbcUrlLinkage;
+import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DataSourcePluginViewMapperTest {
+
+  @Test
+  void descriptorProjectsToLegacyHttpShapeWithoutLeakingSpiTypes() {
+    FormField jdbc =
+        new FormField(
+            "jdbcUrl",
+            "JDBC 地址",
+            "JDBC_URL",
+            "自动生成",
+            null,
+            List.of(),
+            List.of(),
+            List.of("host"),
+            List.of(),
+            new JdbcUrlLinkage(
+                "jdbc:mysql://{host}:{port}/{database}",
+                "host",
+                "port",
+                "database",
+                true));
+    DataSourcePluginDescriptor descriptor =
+        new DataSourcePluginDescriptor(
+            DataSourceDbType.MYSQL,
+            "MySQL",
+            "1",
+            Set.of(Capability.CONNECTION_TEST, Capability.CATALOG_METADATA),
+            List.of(new FormSection("connection", "连接参数", "", false, true, List.of(jdbc))),
+            List.of(jdbc),
+            false,
+            null);
+
+    DataSourcePluginConfigVO result = new DataSourcePluginViewMapper().config(descriptor);
+
+    assertThat(result.getPluginType()).isEqualTo("MYSQL");
+    assertThat(result.getSections()).hasSize(1);
+    assertThat(result.getFormFields()).hasSize(1);
+    assertThat(result.getFormFields().getFirst().getType()).isEqualTo("JDBC_URL");
+    assertThat(result.getFormFields().getFirst().getUrlLinkage().getTemplate())
+        .isEqualTo("jdbc:mysql://{host}:{port}/{database}");
+    assertThat(result.getInstallRequired()).isFalse();
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/util/DataSourceSecretCodecTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/util/DataSourceSecretCodecTest.java
@@ -1,15 +1,16 @@
 package io.yak.ops.business.datasource.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
-import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.ConnectionForm;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class DataSourceSecretCodecTest {
@@ -19,115 +20,99 @@ class DataSourceSecretCodecTest {
 
   @Test
   void shouldMaskPasswordInResponseJsonAndJdbcUrl() throws Exception {
-    DataSourcePlugin plugin = pluginWithPasswordField();
+    DataSourcePluginDescriptor descriptor = descriptorWithPasswordField();
 
     String masked =
         codec.maskConnectionJson(
-            plugin,
-            "{\"host\":\"db\",\"username\":\"root\","
-                + "\"password\":\"top-secret\","
-                + "\"properties\":{\"accessToken\":\"nested-secret\"}}"
-        );
+            descriptor,
+            "{\"host\":\"db\",\"username\":\"test_user\","
+                + "\"password\":\"TEST_ONLY_VALUE\","
+                + "\"properties\":{\"accessToken\":\"TEST_ONLY_TOKEN\"}}");
     JsonNode root = objectMapper.readTree(masked);
 
     assertThat(root.get("password").asText()).isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
     assertThat(root.path("properties").path("accessToken").asText())
         .isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
-    assertThat(root.get("username").asText()).isEqualTo("root");
-    assertThat(
-            codec.maskSensitiveText(
-                "jdbc:mysql://root:top-secret@db/demo?password=another-secret"))
-        .isEqualTo("jdbc:mysql://root:******@db/demo?password=******");
+    assertThat(root.get("username").asText()).isEqualTo("test_user");
+    assertThat(codec.maskSensitiveText("jdbc:mysql://test_user:TEST_ONLY_VALUE@db/demo?password=TEST_ONLY_VALUE"))
+        .isEqualTo("jdbc:mysql://test_user:******@db/demo?password=******");
   }
 
   @Test
   void shouldMaskNestedSshCredentials() throws Exception {
-    DataSourcePlugin plugin = pluginWithPasswordField();
-
     String masked =
         codec.maskConnectionJson(
-            plugin,
+            descriptorWithPasswordField(),
             "{\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion\","
-                + "\"password\":\"ssh-password\",\"privateKey\":\"private-key\","
-                + "\"passphrase\":\"key-passphrase\"}}"
-        );
+                + "\"password\":\"TEST_ONLY_VALUE\",\"privateKey\":\"TEST_ONLY_KEY\","
+                + "\"passphrase\":\"TEST_ONLY_PHRASE\"}}");
     JsonNode ssh = objectMapper.readTree(masked).path("sshTunnel");
 
-    assertThat(ssh.path("password").asText())
-        .isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
-    assertThat(ssh.path("privateKey").asText())
-        .isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
-    assertThat(ssh.path("passphrase").asText())
-        .isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
+    assertThat(ssh.path("password").asText()).isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
+    assertThat(ssh.path("privateKey").asText()).isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
+    assertThat(ssh.path("passphrase").asText()).isEqualTo(DataSourceSecretCodec.MASKED_VALUE);
     assertThat(ssh.path("host").asText()).isEqualTo("bastion");
   }
 
   @Test
   void shouldReuseStoredPasswordWhenEditSubmitsMask() throws Exception {
-    DataSourcePlugin plugin = pluginWithPasswordField();
-
     String merged =
         codec.mergeStoredSecrets(
-            plugin,
+            descriptorWithPasswordField(),
             "{\"host\":\"new-db\",\"password\":\"******\","
                 + "\"properties\":{\"accessToken\":\"******\"}}",
-            "{\"host\":\"old-db\",\"password\":\"top-secret\","
-                + "\"properties\":{\"accessToken\":\"nested-secret\"}}"
-        );
+            "{\"host\":\"old-db\",\"password\":\"TEST_ONLY_VALUE\","
+                + "\"properties\":{\"accessToken\":\"TEST_ONLY_TOKEN\"}}");
     JsonNode root = objectMapper.readTree(merged);
 
     assertThat(root.get("host").asText()).isEqualTo("new-db");
-    assertThat(root.get("password").asText()).isEqualTo("top-secret");
+    assertThat(root.get("password").asText()).isEqualTo("TEST_ONLY_VALUE");
     assertThat(root.path("properties").path("accessToken").asText())
-        .isEqualTo("nested-secret");
+        .isEqualTo("TEST_ONLY_TOKEN");
   }
 
   @Test
   void shouldReuseStoredSshSecretsWhenEditSubmitsMask() throws Exception {
-    DataSourcePlugin plugin = pluginWithPasswordField();
-
     String merged =
         codec.mergeStoredSecrets(
-            plugin,
+            descriptorWithPasswordField(),
             "{\"sshTunnel\":{\"enabled\":true,\"host\":\"new-bastion\","
                 + "\"password\":\"******\",\"privateKey\":\"******\","
                 + "\"passphrase\":\"******\"}}",
             "{\"sshTunnel\":{\"enabled\":true,\"host\":\"old-bastion\","
-                + "\"password\":\"ssh-password\",\"privateKey\":\"private-key\","
-                + "\"passphrase\":\"key-passphrase\"}}"
-        );
+                + "\"password\":\"TEST_ONLY_VALUE\",\"privateKey\":\"TEST_ONLY_KEY\","
+                + "\"passphrase\":\"TEST_ONLY_PHRASE\"}}");
     JsonNode ssh = objectMapper.readTree(merged).path("sshTunnel");
 
     assertThat(ssh.path("host").asText()).isEqualTo("new-bastion");
-    assertThat(ssh.path("password").asText()).isEqualTo("ssh-password");
-    assertThat(ssh.path("privateKey").asText()).isEqualTo("private-key");
-    assertThat(ssh.path("passphrase").asText()).isEqualTo("key-passphrase");
+    assertThat(ssh.path("password").asText()).isEqualTo("TEST_ONLY_VALUE");
+    assertThat(ssh.path("privateKey").asText()).isEqualTo("TEST_ONLY_KEY");
+    assertThat(ssh.path("passphrase").asText()).isEqualTo("TEST_ONLY_PHRASE");
   }
 
   @Test
   void shouldUseNewPasswordWhenUserChangesIt() throws Exception {
-    DataSourcePlugin plugin = pluginWithPasswordField();
-
     String merged =
         codec.mergeStoredSecrets(
-            plugin,
-            "{\"password\":\"new-secret\"}",
-            "{\"password\":\"old-secret\"}");
+            descriptorWithPasswordField(),
+            "{\"password\":\"TEST_ONLY_NEW\"}",
+            "{\"password\":\"TEST_ONLY_OLD\"}");
 
-    assertThat(objectMapper.readTree(merged).get("password").asText())
-        .isEqualTo("new-secret");
+    assertThat(objectMapper.readTree(merged).get("password").asText()).isEqualTo("TEST_ONLY_NEW");
   }
 
-  private DataSourcePlugin pluginWithPasswordField() {
-    DataSourcePlugin plugin = mock(DataSourcePlugin.class);
-    DataSourcePluginConfigVO config =
-        DataSourcePluginConfigVO.builder()
-            .formFields(
-                List.of(
-                    FormFieldVO.builder().key("username").type("INPUT").build(),
-                    FormFieldVO.builder().key("password").type("PASSWORD").build()))
-            .build();
-    when(plugin.pluginConfig()).thenReturn(config);
-    return plugin;
+  private DataSourcePluginDescriptor descriptorWithPasswordField() {
+    FormField username = new FormField(
+        "username", "用户名", FieldType.INPUT, null, null, List.of(), List.of(), List.of(), List.of(), null);
+    FormField password = new FormField(
+        "password", "密码", FieldType.PASSWORD, null, null, List.of(), List.of(), List.of(), List.of(), null);
+    return new DataSourcePluginDescriptor(
+        DataSourceDbType.MYSQL,
+        "MySQL",
+        DataSourcePluginDescriptor.CURRENT_API_VERSION,
+        Set.of(),
+        new ConnectionForm(List.of(), List.of(username, password)),
+        false,
+        null);
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/PLUGIN.md
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/PLUGIN.md
@@ -1,0 +1,244 @@
+# Datasource Plugin Contract
+
+> 本文定义 Datasource Plugin 的**当前开发标准**。业务领域规则看 `yak-ops-business/yak-ops-business-datasource/DOMAIN.md`；历史演进看 PR / Git。
+
+## 1. 模块职责
+
+```text
+yak-ops-plugin-datasource-api
+  -> 稳定扩展协议，不依赖 Business DTO / VO
+
+yak-ops-plugin-datasource-jdbc
+  -> 通用 JDBC 基座 + MySQL/PostgreSQL/Oracle/达梦/Kingbase
+
+yak-ops-plugin-datasource-doris
+  -> Doris 专用扩展
+
+yak-ops-plugin-datasource-all
+  -> 聚合打包
+```
+
+Plugin 负责“如何连接和访问某类数据源”，Business Datasource 负责“数据源是什么、生命周期是什么、如何提供业务能力”。
+
+## 2. 必须实现的稳定入口
+
+每个插件实现 `DataSourcePlugin`：
+
+```java
+DataSourceDbType dbType();
+DataSourcePluginDescriptor descriptor();
+DataSourceConnection parseConnection(String connectionJson);
+void testConnection(DataSourceConnection connection, int timeoutSeconds);
+DataSourceCatalog createCatalog(DataSourceConnection connection, int timeoutSeconds);
+```
+
+支持 SQL 时覆盖：
+
+```java
+DataSourceSqlExecutor createSqlExecutor(
+    DataSourceConnection connection,
+    int connectionTimeoutSeconds);
+```
+
+插件必须通过：
+
+```text
+META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
+```
+
+注册实现类。Business 通过 `ServiceLoader` 发现，不允许在业务代码硬编码具体插件类。
+
+## 3. Descriptor 是唯一插件元数据协议
+
+`DataSourcePluginDescriptor` 描述：
+
+```text
+dbType
+apiVersion
+capabilities
+connectionForm
+installRequired / installHint
+```
+
+硬规则：
+
+- Plugin API 不返回 `DataSourcePluginConfigVO` 或其他 HTTP VO。
+- Descriptor 必须 immutable。
+- `descriptor.dbType == plugin.dbType()`。
+- 当前 `apiVersion = 1`。
+- 表单字段类型使用 `FieldType`，不靠特殊 key 猜组件类型。
+- Secret 字段使用 `FieldType.PASSWORD` 声明，Business 由 Descriptor 推导脱敏字段。
+- 前端 VO 由 Business `DataSourcePluginViewMapper` 投影，Plugin 不认识 Controller / VO。
+
+## 4. Capability
+
+当前标准能力：
+
+```text
+CONNECTION_TEST
+CATALOG_METADATA
+CATALOG_READ
+SQL_EXECUTION
+TRANSACTIONS
+SSH_TUNNEL
+```
+
+依赖规则：
+
+```text
+TRANSACTIONS -> requires SQL_EXECUTION
+CATALOG_READ -> requires CATALOG_METADATA
+```
+
+调用方必须先看 Capability，不以“调用后抛 UnsupportedOperationException”作为正常能力发现机制。
+
+新增能力时：
+
+1. 先确认 Business Requirement / Domain；
+2. 扩 `DataSourceCapability`；
+3. 明确依赖关系与降级行为；
+4. 更新 Registry 校验、PLUGIN.md、contract tests；
+5. 不通过插件私有 boolean 偷渡平台级能力。
+
+## 5. Connection Contract
+
+`parseConnection` 必须：
+
+- 校验输入属于当前 `dbType`；
+- 输出规范化 `DataSourceConnection`；
+- 规范化 JSON 可持久化、可再次解析；
+- 不在 `toString()` / 日志输出 Secret；
+- 参数错误使用 `DataSourcePluginException(Operation.PARAMETER, ...)`。
+
+连接测试错误使用：
+
+```text
+Operation.CONNECTIVITY
+```
+
+SQL 执行错误使用：
+
+```text
+Operation.EXECUTION
+```
+
+Catalog 错误使用：
+
+```text
+Operation.CATALOG
+```
+
+异常消息不得包含密码、Token、Private Key 等 Secret。
+
+## 6. Secret 与表单
+
+插件通过 Descriptor 表单 Schema 声明 PASSWORD 字段。Business 的 Secret merge / mask 只读取 Descriptor，不读取 HTTP VO。
+
+通用规则：
+
+- 用户提交 `******`、空值或缺失 Secret 时，可沿用已保存值；
+- 新的明确 Secret 值覆盖旧值；
+- `password / token / secret / privateKey / passphrase` 等常见 key 仍有兜底识别；
+- SSH 等嵌套对象同样必须脱敏；
+- 测试夹具使用明显的 `TEST_ONLY_*` 值，不放真实凭据。
+
+## 7. Catalog Contract
+
+`DataSourceCatalog` 已完全类型化：
+
+```java
+List<String> listDatabases();
+List<String> listSchemas(String database);
+List<DataSourceTable> listTables(DataSourceCatalogQuery query);
+List<DataSourceColumn> listColumns(DataSourceTablePath tablePath);
+List<DataSourceColumn> describe(DataSourceCatalogReadRequest request);
+DataSourceQueryResult preview(DataSourceCatalogReadRequest request, int limit);
+long count(DataSourceCatalogReadRequest request);
+String buildSqlTemplate(String tablePath);
+String resolveSql(String sql, DataSourceCatalogReadRequest request);
+```
+
+禁止在稳定 SPI 新增 `Map<String,Object>` 协议。新增 Catalog 语义应扩 typed request/model。
+
+`DataSourceCatalogReadRequest` 只有两种模式：
+
+```text
+TABLE -> tablePath required
+SQL   -> query required
+```
+
+变量通过 `variables` 显式传递。Business 的旧 HTTP `paramsList` 兼容解析不能扩散回 Plugin SPI。
+
+## 8. SQL Executor Contract
+
+一个 `DataSourceSqlExecutor` 表示一次物理执行 Session：
+
+- `execute` 执行 SQL；
+- `cancel` 为 best-effort；
+- `close` 必须安全释放资源；
+- 声明 `TRANSACTIONS` 时必须支持 begin / commit / rollback；
+- transaction 内多个 statement 必须使用同一物理连接；
+- timeout / cancel / failure 不得吞异常。
+
+Business SQL Runtime 通过 `SqlExecutionGateway` 访问该 SPI，插件模型不得进入 Runtime Domain。
+
+## 9. Thread Safety / 生命周期
+
+- `DataSourcePlugin` 可被 Registry 单例复用，应保持无请求级可变状态。
+- `DataSourceCatalog` 可以按调用创建，不假设跨线程共享。
+- `DataSourceSqlExecutor` 是一次 Session，不要求跨线程复用。
+- JDBC Connection / Statement 必须在完成、失败、取消路径正确关闭。
+- 不允许把正在执行的 Connection / Statement 缓存在 Plugin 单例字段。
+
+## 10. 新增插件步骤
+
+```text
+1. 确认 DataSourceDbType
+2. 实现 DataSourcePlugin
+3. 定义 descriptor + capabilities + connection form
+4. 实现 parseConnection / testConnection
+5. 按能力实现 Catalog / SQL Executor
+6. 注册 META-INF/services
+7. 增加 descriptor contract test
+8. 增加 connection normalize / invalid input test
+9. 增加 Catalog typed request test（如支持）
+10. 增加 SQL transaction / cancel test（如声明能力）
+```
+
+如果新插件需要平台当前没有的业务概念，先报告 `Requirement Gap / Domain Gap`，不要直接把私有字段扩成全局约定。
+
+## 11. Phase 4 SPI 迁移
+
+Phase 4 有意做一次 source-level SPI breaking change，仓库内置插件已同步迁移：
+
+```text
+pluginConfig() -> descriptor()
+Catalog Map request -> DataSourceCatalogReadRequest
+```
+
+第三方插件升级步骤：
+
+```text
+1. 将 DataSourcePluginConfigVO 转为 DataSourcePluginDescriptor
+2. 声明真实 Capability
+3. 将 PASSWORD 字段保留为 FieldType.PASSWORD
+4. 将 Catalog Map 解析改为 DataSourceCatalogReadRequest
+5. 更新 apiVersion = CURRENT_API_VERSION
+6. 运行 contract tests
+```
+
+REST API、Business DTO / VO、数据库表结构不因该 SPI 迁移改变。
+
+## 12. Review Checklist
+
+```text
+[ ] Plugin API 无 Business DTO / VO 依赖
+[ ] descriptor dbType / apiVersion 正确
+[ ] Capability 与真实实现一致
+[ ] Secret 字段可被 Descriptor 识别
+[ ] Catalog 无 Map 协议
+[ ] 异常 Operation 分类正确且不泄露 Secret
+[ ] ServiceLoader 注册存在
+[ ] transaction / cancel / close 与 Capability 一致
+[ ] 内置/新增插件 contract tests 通过
+```

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourceCapability.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourceCapability.java
@@ -1,0 +1,11 @@
+package io.yak.ops.spi.datasource;
+
+/** Stable capabilities that a datasource plugin can explicitly advertise. */
+public enum DataSourceCapability {
+  CONNECTION_TEST,
+  CATALOG_METADATA,
+  CATALOG_READ,
+  SQL_EXECUTION,
+  TRANSACTIONS,
+  SSH_TUNNEL
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourceCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourceCatalog.java
@@ -1,14 +1,14 @@
 package io.yak.ops.spi.datasource;
 
 import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
 import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
 import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
 import io.yak.ops.spi.datasource.metadata.DataSourceTable;
 import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
 import java.util.List;
-import java.util.Map;
 
-/** 数据源 Catalog 元数据和轻量查询能力契约。 */
+/** Typed datasource Catalog metadata and lightweight-read contract. */
 public interface DataSourceCatalog {
 
   List<String> listDatabases();
@@ -19,18 +19,18 @@ public interface DataSourceCatalog {
 
   List<DataSourceColumn> listColumns(DataSourceTablePath tablePath);
 
-  /** 根据表模式或 SQL 模式请求解析字段。 */
-  List<DataSourceColumn> describe(Map<String, Object> request);
+  /** Resolve columns for a typed TABLE or SQL read request. */
+  List<DataSourceColumn> describe(DataSourceCatalogReadRequest request);
 
-  /** 查询预览数据，插件必须限制最大返回行数。 */
-  DataSourceQueryResult preview(Map<String, Object> request, int limit);
+  /** Preview data with a plugin-enforced maximum row limit. */
+  DataSourceQueryResult preview(DataSourceCatalogReadRequest request, int limit);
 
-  /** 统计表或 SQL 查询结果行数。 */
-  long count(Map<String, Object> request);
+  /** Count rows for a typed TABLE or SQL read request. */
+  long count(DataSourceCatalogReadRequest request);
 
-  /** 根据表字段构建 SELECT 模板。 */
+  /** Build a SELECT template from one logical table path. */
   String buildSqlTemplate(String tablePath);
 
-  /** 解析插件支持的 SQL 变量和调用方参数。 */
-  String resolveSql(String sql, Map<String, Object> request);
+  /** Resolve plugin-supported SQL variables using the typed request context. */
+  String resolveSql(String sql, DataSourceCatalogReadRequest request);
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePlugin.java
@@ -1,33 +1,33 @@
 package io.yak.ops.spi.datasource;
 
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
 
-/** 数据源插件稳定扩展契约。 */
+/** Datasource plugin stable extension contract. */
 public interface DataSourcePlugin {
 
-  /** 插件唯一对应的数据源类型。 */
+  /** Plugin identity. */
   DataSourceDbType dbType();
 
-  /** 插件负责下发自己的动态表单和默认参数。 */
-  DataSourcePluginConfigVO pluginConfig();
+  /** Immutable plugin metadata, declared capabilities and connection form schema. */
+  DataSourcePluginDescriptor descriptor();
 
-  /** 解析、校验并规范化前端连接参数。 */
+  /** Parse, validate and normalize connection JSON. */
   DataSourceConnection parseConnection(String connectionJson);
 
-  /** 执行连接测试，失败时抛出 {@link DataSourcePluginException}。 */
+  /** Test connectivity; failures must throw {@link DataSourcePluginException}. */
   void testConnection(DataSourceConnection connection, int timeoutSeconds);
 
-  /** 创建由插件实现的 Catalog 元数据访问器。 */
+  /** Create the plugin-owned Catalog accessor. */
   DataSourceCatalog createCatalog(DataSourceConnection connection, int timeoutSeconds);
 
-  /**
-   * 创建一次 SQL 物理执行器。
-   *
-   * <p>默认不支持，JDBC 等具备 SQL 执行能力的插件显式覆盖。Task Plugin 不直接接触 JDBC
-   * Connection 或凭据，只通过这个稳定契约获得执行能力。
-   */
+  /** Whether this plugin explicitly declares a stable capability. */
+  default boolean supports(DataSourceCapability capability) {
+    DataSourcePluginDescriptor value = descriptor();
+    return value != null && value.supports(capability);
+  }
+
+  /** Create one physical SQL executor. Plugins without SQL capability keep the default failure. */
   default DataSourceSqlExecutor createSqlExecutor(
       DataSourceConnection connection,
       int connectionTimeoutSeconds) {
@@ -36,7 +36,7 @@ public interface DataSourcePlugin {
         "当前数据源插件不支持 SQL 执行：" + dbType());
   }
 
-  /** 插件是否理解指定连接地址。 */
+  /** Whether the plugin understands the supplied JDBC URL. */
   default boolean acceptsUrl(String jdbcUrl) {
     return false;
   }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePluginDescriptor.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/DataSourcePluginDescriptor.java
@@ -1,0 +1,240 @@
+package io.yak.ops.spi.datasource;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable datasource plugin metadata and connection-form contract. */
+public record DataSourcePluginDescriptor(
+    DataSourceDbType dbType,
+    String displayName,
+    String apiVersion,
+    Set<DataSourceCapability> capabilities,
+    ConnectionForm connectionForm,
+    boolean installRequired,
+    String installHint) {
+
+  public static final String CURRENT_API_VERSION = "1";
+
+  public DataSourcePluginDescriptor {
+    dbType = Objects.requireNonNull(dbType, "dbType");
+    displayName = normalize(displayName, dbType.getDisplayName());
+    apiVersion = normalize(apiVersion, CURRENT_API_VERSION);
+    capabilities = immutableCapabilities(capabilities);
+    connectionForm = connectionForm == null ? ConnectionForm.empty() : connectionForm;
+    installHint = trimToNull(installHint);
+  }
+
+  public boolean supports(DataSourceCapability capability) {
+    return capability != null && capabilities.contains(capability);
+  }
+
+  public Set<String> secretFieldKeys() {
+    java.util.LinkedHashSet<String> keys = new java.util.LinkedHashSet<>();
+    for (FormField field : connectionForm.allFields()) {
+      if (field != null && field.secret()) keys.add(field.key());
+    }
+    return Collections.unmodifiableSet(keys);
+  }
+
+  public record ConnectionForm(List<FormSection> sections, List<FormField> legacyFields) {
+    public ConnectionForm {
+      sections = sections == null ? List.of() : List.copyOf(sections);
+      legacyFields = legacyFields == null ? List.of() : List.copyOf(legacyFields);
+    }
+
+    public static ConnectionForm empty() {
+      return new ConnectionForm(List.of(), List.of());
+    }
+
+    public List<FormField> allFields() {
+      List<FormField> fields = new ArrayList<>(legacyFields);
+      for (FormSection section : sections) {
+        if (section != null) fields.addAll(section.fields());
+      }
+      return List.copyOf(fields);
+    }
+  }
+
+  public record FormSection(
+      String key,
+      String title,
+      String description,
+      boolean collapsible,
+      boolean defaultExpanded,
+      List<FormField> fields) {
+    public FormSection {
+      key = requireText(key, "section key");
+      title = requireText(title, "section title");
+      description = description == null ? "" : description;
+      fields = fields == null ? List.of() : List.copyOf(fields);
+    }
+
+    public FormSection withFields(List<FormField> replacement) {
+      return new FormSection(key, title, description, collapsible, defaultExpanded, replacement);
+    }
+  }
+
+  public record FormField(
+      String key,
+      String label,
+      FieldType type,
+      String placeholder,
+      Object defaultValue,
+      List<FormOption> options,
+      List<FormRule> rules,
+      List<String> dependsOn,
+      List<VisibilityCondition> visibleWhen,
+      JdbcUrlLinkage jdbcUrlLinkage) {
+    public FormField {
+      key = requireText(key, "field key");
+      label = requireText(label, "field label");
+      type = Objects.requireNonNull(type, "field type");
+      placeholder = trimToNull(placeholder);
+      defaultValue = immutableValue(defaultValue);
+      options = options == null ? List.of() : List.copyOf(options);
+      rules = rules == null ? List.of() : List.copyOf(rules);
+      dependsOn = dependsOn == null ? List.of() : List.copyOf(dependsOn);
+      visibleWhen = visibleWhen == null ? List.of() : List.copyOf(visibleWhen);
+    }
+
+    public boolean secret() {
+      return type == FieldType.PASSWORD;
+    }
+
+    public FormField withType(FieldType replacement) {
+      return new FormField(
+          key, label, replacement, placeholder, defaultValue, options, rules, dependsOn, visibleWhen,
+          jdbcUrlLinkage);
+    }
+
+    public FormField withPlaceholder(String replacement) {
+      return new FormField(
+          key, label, type, replacement, defaultValue, options, rules, dependsOn, visibleWhen,
+          jdbcUrlLinkage);
+    }
+
+    public FormField withDependsOn(List<String> replacement) {
+      return new FormField(
+          key, label, type, placeholder, defaultValue, options, rules, replacement, visibleWhen,
+          jdbcUrlLinkage);
+    }
+
+    public FormField withVisibleWhen(List<VisibilityCondition> replacement) {
+      return new FormField(
+          key, label, type, placeholder, defaultValue, options, rules, dependsOn, replacement,
+          jdbcUrlLinkage);
+    }
+
+    public FormField withJdbcUrlLinkage(JdbcUrlLinkage replacement) {
+      return new FormField(
+          key, label, type, placeholder, defaultValue, options, rules, dependsOn, visibleWhen,
+          replacement);
+    }
+  }
+
+  public enum FieldType {
+    INPUT,
+    PASSWORD,
+    SELECT,
+    NUMBER,
+    SWITCH,
+    TEXTAREA,
+    CUSTOM_SELECT,
+    DRIVER,
+    SSH,
+    JDBC_URL
+  }
+
+  public record FormOption(String label, Object value) {
+    public FormOption {
+      label = requireText(label, "option label");
+      value = immutableValue(value);
+    }
+  }
+
+  public record FormRule(Boolean required, String pattern, Integer min, Integer max, String message) {
+    public FormRule {
+      pattern = trimToNull(pattern);
+      message = trimToNull(message);
+    }
+  }
+
+  public record VisibilityCondition(
+      String field,
+      VisibilityOperator operator,
+      Object value,
+      List<Object> values) {
+    public VisibilityCondition {
+      field = trimToNull(field);
+      operator = Objects.requireNonNull(operator, "visibility operator");
+      value = immutableValue(value);
+      values = values == null ? List.of() : values.stream().map(DataSourcePluginDescriptor::immutableValue).toList();
+    }
+  }
+
+  public enum VisibilityOperator {
+    EQUALS,
+    NOT_EQUALS,
+    IN,
+    NOT_IN,
+    TRUTHY,
+    FALSY
+  }
+
+  public record JdbcUrlLinkage(
+      String template,
+      String hostField,
+      String portField,
+      String databaseField,
+      boolean preserveSuffix) {
+    public JdbcUrlLinkage {
+      template = requireText(template, "JDBC URL template");
+      hostField = normalize(hostField, "host");
+      portField = normalize(portField, "port");
+      databaseField = normalize(databaseField, "database");
+    }
+  }
+
+  private static Set<DataSourceCapability> immutableCapabilities(Set<DataSourceCapability> values) {
+    if (values == null || values.isEmpty()) return Set.of();
+    return Collections.unmodifiableSet(EnumSet.copyOf(values));
+  }
+
+  private static Object immutableValue(Object value) {
+    if (value instanceof Map<?, ?> map) {
+      Map<Object, Object> copied = new LinkedHashMap<>();
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        copied.put(entry.getKey(), immutableValue(entry.getValue()));
+      }
+      return Collections.unmodifiableMap(copied);
+    }
+    if (value instanceof List<?> list) {
+      return list.stream().map(DataSourcePluginDescriptor::immutableValue).toList();
+    }
+    return value;
+  }
+
+  private static String normalize(String value, String fallback) {
+    String normalized = trimToNull(value);
+    return normalized == null ? fallback : normalized;
+  }
+
+  private static String requireText(String value, String name) {
+    String normalized = trimToNull(value);
+    if (normalized == null) throw new IllegalArgumentException(name + " must not be blank");
+    return normalized;
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/catalog/DataSourceCatalogReadRequest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/catalog/DataSourceCatalogReadRequest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.spi.datasource.catalog;
 
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /** Typed Catalog read request used by datasource plugins. */
@@ -8,16 +9,13 @@ public record DataSourceCatalogReadRequest(
     Mode mode,
     String tablePath,
     String query,
-    List<Variable> variables) {
+    Map<String, String> variables) {
 
   public DataSourceCatalogReadRequest {
     mode = Objects.requireNonNull(mode, "mode");
     tablePath = trimToNull(tablePath);
     query = trimToNull(query);
-    variables = variables == null ? List.of() : List.copyOf(variables);
-    if (variables.stream().anyMatch(Objects::isNull)) {
-      throw new IllegalArgumentException("variables must not contain null");
-    }
+    variables = variables == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(variables));
     if (mode == Mode.TABLE && tablePath == null) {
       throw new IllegalArgumentException("tablePath must not be blank in TABLE mode");
     }
@@ -26,11 +24,12 @@ public record DataSourceCatalogReadRequest(
     }
   }
 
-  public static DataSourceCatalogReadRequest table(String tablePath, List<Variable> variables) {
+  public static DataSourceCatalogReadRequest table(
+      String tablePath, Map<String, String> variables) {
     return new DataSourceCatalogReadRequest(Mode.TABLE, tablePath, null, variables);
   }
 
-  public static DataSourceCatalogReadRequest sql(String query, List<Variable> variables) {
+  public static DataSourceCatalogReadRequest sql(String query, Map<String, String> variables) {
     return new DataSourceCatalogReadRequest(Mode.SQL, null, query, variables);
   }
 
@@ -41,20 +40,6 @@ public record DataSourceCatalogReadRequest(
   public enum Mode {
     TABLE,
     SQL
-  }
-
-  /** Catalog SQL variable. Null value is retained for compatibility with the historic request. */
-  public record Variable(String name, String value) {
-    public Variable {
-      name = requireText(name, "variable name");
-      value = trimToNull(value);
-    }
-  }
-
-  private static String requireText(String value, String name) {
-    String normalized = trimToNull(value);
-    if (normalized == null) throw new IllegalArgumentException(name + " must not be blank");
-    return normalized;
   }
 
   private static String trimToNull(String value) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/catalog/DataSourceCatalogReadRequest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/catalog/DataSourceCatalogReadRequest.java
@@ -1,7 +1,6 @@
 package io.yak.ops.spi.datasource.catalog;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 
 /** Typed Catalog read request used by datasource plugins. */
@@ -9,13 +8,16 @@ public record DataSourceCatalogReadRequest(
     Mode mode,
     String tablePath,
     String query,
-    Map<String, String> variables) {
+    List<Variable> variables) {
 
   public DataSourceCatalogReadRequest {
     mode = Objects.requireNonNull(mode, "mode");
     tablePath = trimToNull(tablePath);
     query = trimToNull(query);
-    variables = variables == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(variables));
+    variables = variables == null ? List.of() : List.copyOf(variables);
+    if (variables.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("variables must not contain null");
+    }
     if (mode == Mode.TABLE && tablePath == null) {
       throw new IllegalArgumentException("tablePath must not be blank in TABLE mode");
     }
@@ -24,15 +26,11 @@ public record DataSourceCatalogReadRequest(
     }
   }
 
-  public static DataSourceCatalogReadRequest table(
-      String tablePath,
-      Map<String, String> variables) {
+  public static DataSourceCatalogReadRequest table(String tablePath, List<Variable> variables) {
     return new DataSourceCatalogReadRequest(Mode.TABLE, tablePath, null, variables);
   }
 
-  public static DataSourceCatalogReadRequest sql(
-      String query,
-      Map<String, String> variables) {
+  public static DataSourceCatalogReadRequest sql(String query, List<Variable> variables) {
     return new DataSourceCatalogReadRequest(Mode.SQL, null, query, variables);
   }
 
@@ -43,6 +41,20 @@ public record DataSourceCatalogReadRequest(
   public enum Mode {
     TABLE,
     SQL
+  }
+
+  /** Catalog SQL variable. Null value is retained for compatibility with the historic request. */
+  public record Variable(String name, String value) {
+    public Variable {
+      name = requireText(name, "variable name");
+      value = trimToNull(value);
+    }
+  }
+
+  private static String requireText(String value, String name) {
+    String normalized = trimToNull(value);
+    if (normalized == null) throw new IllegalArgumentException(name + " must not be blank");
+    return normalized;
   }
 
   private static String trimToNull(String value) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/catalog/DataSourceCatalogReadRequest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-api/src/main/java/io/yak/ops/spi/datasource/catalog/DataSourceCatalogReadRequest.java
@@ -1,0 +1,53 @@
+package io.yak.ops.spi.datasource.catalog;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Typed Catalog read request used by datasource plugins. */
+public record DataSourceCatalogReadRequest(
+    Mode mode,
+    String tablePath,
+    String query,
+    Map<String, String> variables) {
+
+  public DataSourceCatalogReadRequest {
+    mode = Objects.requireNonNull(mode, "mode");
+    tablePath = trimToNull(tablePath);
+    query = trimToNull(query);
+    variables = variables == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(variables));
+    if (mode == Mode.TABLE && tablePath == null) {
+      throw new IllegalArgumentException("tablePath must not be blank in TABLE mode");
+    }
+    if (mode == Mode.SQL && query == null) {
+      throw new IllegalArgumentException("query must not be blank in SQL mode");
+    }
+  }
+
+  public static DataSourceCatalogReadRequest table(
+      String tablePath,
+      Map<String, String> variables) {
+    return new DataSourceCatalogReadRequest(Mode.TABLE, tablePath, null, variables);
+  }
+
+  public static DataSourceCatalogReadRequest sql(
+      String query,
+      Map<String, String> variables) {
+    return new DataSourceCatalogReadRequest(Mode.SQL, null, query, variables);
+  }
+
+  public boolean sqlMode() {
+    return mode == Mode.SQL;
+  }
+
+  public enum Mode {
+    TABLE,
+    SQL
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/main/java/io/yak/ops/plugin/database/doris/DorisDataSourcePlugin.java
@@ -2,17 +2,15 @@ package io.yak.ops.plugin.database.doris;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
-import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
 import java.util.Collections;
 import java.util.List;
 
-/** Doris 独立数据源插件。JDBC 连接复用通用基座，Catalog 行为由 Doris 自己实现。 */
+/** Doris datasource plugin. JDBC connection is shared; Catalog behavior is Doris-specific. */
 public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
@@ -21,10 +19,8 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   }
 
   @Override
-  public DataSourcePluginConfigVO pluginConfig() {
-    return JdbcUrlSchemaSupport.apply(
-        super.pluginConfig(),
-        "jdbc:mysql://{host}:{port}/{database}");
+  protected String jdbcUrlTemplate() {
+    return "jdbc:mysql://{host}:{port}/{database}";
   }
 
   @Override
@@ -48,7 +44,7 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   }
 
   @Override
-  protected void appendFormFields(List<FormFieldVO> fields) {
+  protected void appendFormFields(List<FormField> fields) {
     fields.add(
         field(
             "fenodes",
@@ -69,8 +65,7 @@ public final class DorisDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
   protected DataSourceCatalog createJdbcCatalog(
-      JdbcConnectionProperties connection,
-      int timeoutSeconds) {
+      JdbcConnectionProperties connection, int timeoutSeconds) {
     return new DorisJdbcCatalog(connection, timeoutSeconds, this::openJdbcConnection);
   }
 

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/test/java/io/yak/ops/plugin/database/doris/DorisDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-doris/src/test/java/io/yak/ops/plugin/database/doris/DorisDataSourcePluginTest.java
@@ -2,7 +2,9 @@ package io.yak.ops.plugin.database.doris;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
 import org.junit.jupiter.api.Test;
 
 class DorisDataSourcePluginTest {
@@ -13,7 +15,7 @@ class DorisDataSourcePluginTest {
         new DorisDataSourcePlugin()
             .parseConnection(
                 "{\"dbType\":\"DORIS\",\"host\":\"doris-fe\","
-                    + "\"database\":\"warehouse\",\"username\":\"root\","
+                    + "\"database\":\"warehouse\",\"username\":\"test_user\","
                     + "\"fenodes\":\"doris-fe:8030\"}");
 
     assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://doris-fe:9030/warehouse");
@@ -24,8 +26,17 @@ class DorisDataSourcePluginTest {
   }
 
   @Test
-  void shouldExposeDorisSpecificFormField() {
-    assertThat(new DorisDataSourcePlugin().pluginConfig().getFormFields())
-        .anyMatch(field -> "fenodes".equals(field.getKey()));
+  void shouldExposeDorisDescriptorAndSpecificFormField() {
+    DataSourcePluginDescriptor descriptor = new DorisDataSourcePlugin().descriptor();
+
+    assertThat(descriptor.apiVersion()).isEqualTo(DataSourcePluginDescriptor.CURRENT_API_VERSION);
+    assertThat(descriptor.capabilities())
+        .contains(
+            DataSourceCapability.CATALOG_METADATA,
+            DataSourceCapability.CATALOG_READ,
+            DataSourceCapability.SQL_EXECUTION,
+            DataSourceCapability.TRANSACTIONS);
+    assertThat(descriptor.connectionForm().legacyFields())
+        .anyMatch(field -> "fenodes".equals(field.key()));
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/AbstractJdbcDataSourcePlugin.java
@@ -3,15 +3,19 @@ package io.yak.ops.plugin.database.jdbc;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.RuleVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.VisibilityConditionVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
 import io.yak.ops.spi.datasource.DataSourceConnection;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.ConnectionForm;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormRule;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormSection;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.VisibilityCondition;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.VisibilityOperator;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
 import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlExecutor;
@@ -19,21 +23,23 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
-/** JDBC 数据源插件基座，统一负责参数解析、表单配置、连接测试、SSH 隧道和 SQL 执行。 */
+/** JDBC datasource plugin base: descriptor, connection parsing, connectivity, SSH and SQL. */
 public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Override
-  public DataSourcePluginConfigVO pluginConfig() {
-    List<FormFieldVO> connectionFields = new ArrayList<>();
+  public DataSourcePluginDescriptor descriptor() {
+    List<FormField> connectionFields = new ArrayList<>();
     connectionFields.add(
         field(
             "host",
@@ -91,7 +97,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             null,
             Collections.emptyList()));
 
-    List<FormFieldVO> sshFields = new ArrayList<>();
+    List<FormField> sshFields = new ArrayList<>();
     sshFields.add(
         field(
             "sshTunnel",
@@ -101,7 +107,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             sshDefaultValue(),
             Collections.emptyList()));
 
-    List<FormFieldVO> driverFields = new ArrayList<>();
+    List<FormField> driverFields = new ArrayList<>();
     driverFields.add(
         field(
             "driverClassName",
@@ -111,8 +117,8 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             defaultDriverClassName(),
             required("请输入 JDBC 驱动类")));
 
-    List<FormFieldVO> advancedFields = new ArrayList<>();
-    FormFieldVO propertiesField =
+    List<FormField> advancedFields = new ArrayList<>();
+    FormField propertiesField =
         field(
             "properties",
             "扩展属性",
@@ -120,61 +126,54 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
             "可选；请输入 JSON 对象，例如 {\"useSSL\":\"false\"}",
             null,
             Collections.emptyList());
-    propertiesField.setDependsOn(Collections.singletonList("driverClassName"));
-    propertiesField.setVisibleWhen(
-        Collections.singletonList(
-            VisibilityConditionVO.builder().operator("TRUTHY").build()));
+    propertiesField =
+        propertiesField
+            .withDependsOn(Collections.singletonList("driverClassName"))
+            .withVisibleWhen(
+                Collections.singletonList(
+                    new VisibilityCondition(null, VisibilityOperator.TRUTHY, null, List.of())));
     advancedFields.add(propertiesField);
     appendFormFields(advancedFields);
 
-    List<FormSectionVO> sections = new ArrayList<>();
-    sections.add(
-        section(
-            "connection",
-            "连接参数",
-            "",
-            false,
-            true,
-            connectionFields));
-    sections.add(
-        section(
-            "ssh",
-            "SSH 隧道",
-            "",
-            true,
-            false,
-            sshFields));
-    sections.add(
-        section(
-            "driver",
-            "驱动配置",
-            "",
-            true,
-            true,
-            driverFields));
+    List<FormSection> sections = new ArrayList<>();
+    sections.add(section("connection", "连接参数", "", false, true, connectionFields));
+    sections.add(section("ssh", "SSH 隧道", "", true, false, sshFields));
+    sections.add(section("driver", "驱动配置", "", true, true, driverFields));
     if (!advancedFields.isEmpty()) {
-      sections.add(
-          section(
-              "advanced",
-              "高级配置",
-              "",
-              true,
-              false,
-              advancedFields));
+      sections.add(section("advanced", "高级配置", "", true, false, advancedFields));
     }
 
-    // 旧版 formFields 不下发 SSH 对象字段，避免旧前端把复合配置误渲染为普通 Input。
-    List<FormFieldVO> fields = new ArrayList<>();
+    // Legacy flat fields intentionally omit the composite SSH field.
+    List<FormField> fields = new ArrayList<>();
     fields.addAll(connectionFields);
     fields.addAll(driverFields);
     fields.addAll(advancedFields);
 
-    return DataSourcePluginConfigVO.builder()
-        .pluginType(dbType().name())
-        .sections(sections)
-        .formFields(fields)
-        .installRequired(false)
-        .build();
+    DataSourcePluginDescriptor descriptor =
+        new DataSourcePluginDescriptor(
+            dbType(),
+            dbType().getDisplayName(),
+            DataSourcePluginDescriptor.CURRENT_API_VERSION,
+            capabilities(),
+            new ConnectionForm(sections, fields),
+            false,
+            null);
+    return JdbcUrlSchemaSupport.apply(descriptor, jdbcUrlTemplate());
+  }
+
+  protected Set<DataSourceCapability> capabilities() {
+    return EnumSet.of(
+        DataSourceCapability.CONNECTION_TEST,
+        DataSourceCapability.CATALOG_METADATA,
+        DataSourceCapability.CATALOG_READ,
+        DataSourceCapability.SQL_EXECUTION,
+        DataSourceCapability.TRANSACTIONS,
+        DataSourceCapability.SSH_TUNNEL);
+  }
+
+  /** JDBC URL linkage template used by the standard form component. */
+  protected String jdbcUrlTemplate() {
+    return null;
   }
 
   @Override
@@ -194,9 +193,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
       String username = firstText(root, "username", "user");
       String password = firstText(root, "password");
       String driver =
-          defaultIfBlank(
-              firstText(root, "driverClassName", "driver"),
-              defaultDriverClassName());
+          defaultIfBlank(firstText(root, "driverClassName", "driver"), defaultDriverClassName());
       SshTunnelConfig sshTunnel = parseSshTunnel(root);
 
       if (isBlank(username)) {
@@ -204,8 +201,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
       }
       if (sshTunnel.enabled() && !isBlank(explicitUrl)) {
         throw parameterError(
-            "启用 SSH 隧道时请使用 host、port、database 参数，不支持自定义 JDBC 地址",
-            null);
+            "启用 SSH 隧道时请使用 host、port、database 参数，不支持自定义 JDBC 地址", null);
       }
 
       String jdbcUrl = explicitUrl;
@@ -281,10 +277,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
           "数据库驱动未安装：" + jdbcConnection.driverClassName(),
           exception);
     } catch (Exception exception) {
-      throw new DataSourcePluginException(
-          Operation.CONNECTIVITY,
-          safeMessage(exception),
-          exception);
+      throw new DataSourcePluginException(Operation.CONNECTIVITY, safeMessage(exception), exception);
     }
   }
 
@@ -295,8 +288,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
 
   @Override
   public DataSourceSqlExecutor createSqlExecutor(
-      DataSourceConnection connection,
-      int connectionTimeoutSeconds) {
+      DataSourceConnection connection, int connectionTimeoutSeconds) {
     return new JdbcDataSourceSqlExecutor(
         requireJdbcConnection(connection),
         Math.max(1, connectionTimeoutSeconds),
@@ -304,8 +296,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
   }
 
   protected DataSourceCatalog createJdbcCatalog(
-      JdbcConnectionProperties connection,
-      int timeoutSeconds) {
+      JdbcConnectionProperties connection, int timeoutSeconds) {
     return new GenericJdbcCatalog(connection, timeoutSeconds) {
       @Override
       protected Connection openConnection() throws Exception {
@@ -315,38 +306,24 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
   }
 
   protected Connection openJdbcConnection(
-      JdbcConnectionProperties connection,
-      int timeoutSeconds)
-      throws Exception {
+      JdbcConnectionProperties connection, int timeoutSeconds) throws Exception {
     Class.forName(connection.driverClassName());
     int safeTimeout = Math.max(1, timeoutSeconds);
     DriverManager.setLoginTimeout(safeTimeout);
 
     SshTunnelConfig sshTunnel = connection.sshTunnel();
     if (!sshTunnel.enabled()) {
-      return DriverManager.getConnection(
-          connection.jdbcUrl(),
-          connectionProperties(connection));
+      return DriverManager.getConnection(connection.jdbcUrl(), connectionProperties(connection));
     }
 
     SshTunnel tunnel =
-        SshTunnel.open(
-            sshTunnel,
-            connection.host(),
-            connection.port(),
-            safeTimeout);
+        SshTunnel.open(sshTunnel, connection.host(), connection.port(), safeTimeout);
     try {
       JsonNode normalized = OBJECT_MAPPER.readTree(connection.normalizedJson());
       String tunneledJdbcUrl =
-          buildJdbcUrl(
-              "127.0.0.1",
-              tunnel.localPort(),
-              connection.database(),
-              normalized);
+          buildJdbcUrl("127.0.0.1", tunnel.localPort(), connection.database(), normalized);
       Connection opened =
-          DriverManager.getConnection(
-              tunneledJdbcUrl,
-              connectionProperties(connection));
+          DriverManager.getConnection(tunneledJdbcUrl, connectionProperties(connection));
       return SshTunneledConnection.wrap(opened, tunnel);
     } catch (Exception exception) {
       tunnel.close();
@@ -359,20 +336,15 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
   protected abstract String defaultDriverClassName();
 
   protected abstract String buildJdbcUrl(
-      String host,
-      int port,
-      String database,
-      JsonNode connectionJson);
+      String host, int port, String database, JsonNode connectionJson);
 
   protected String databaseLabel() {
     return "数据库";
   }
 
-  protected void appendFormFields(List<FormFieldVO> fields) {
-  }
+  protected void appendFormFields(List<FormField> fields) {}
 
-  protected void appendNormalizedFields(JsonNode source, ObjectNode normalized) {
-  }
+  protected void appendNormalizedFields(JsonNode source, ObjectNode normalized) {}
 
   protected String inferDatabase(String jdbcUrl) {
     if (isBlank(jdbcUrl)) {
@@ -390,10 +362,9 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
   }
 
   protected JdbcConnectionProperties requireJdbcConnection(DataSourceConnection connection) {
-    if (!(connection instanceof JdbcConnectionProperties)) {
+    if (!(connection instanceof JdbcConnectionProperties jdbcConnection)) {
       throw parameterError("连接参数与插件类型不匹配", null);
     }
-    JdbcConnectionProperties jdbcConnection = (JdbcConnectionProperties) connection;
     if (connection.dbType() != dbType()) {
       throw parameterError("连接参数与插件类型不匹配", null);
     }
@@ -417,53 +388,46 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
     if (isBlank(message)) {
       return throwable == null ? "未知错误" : throwable.getClass().getSimpleName();
     }
-    String sanitized =
-        message.replaceAll("(?i)(password|pwd)=([^;&\\s]+)", "$1=******");
+    String sanitized = message.replaceAll("(?i)(password|pwd)=([^;&\\s]+)", "$1=******");
     return sanitized.length() > 300 ? sanitized.substring(0, 300) : sanitized;
   }
 
-  protected FormFieldVO field(
+  protected FormField field(
       String key,
       String label,
       String type,
       String placeholder,
       Object defaultValue,
-      List<RuleVO> rules) {
-    return FormFieldVO.builder()
-        .key(key)
-        .label(label)
-        .type(type)
-        .placeholder(placeholder)
-        .defaultValue(defaultValue)
-        .rules(rules)
-        .build();
+      List<FormRule> rules) {
+    return new FormField(
+        key,
+        label,
+        FieldType.valueOf(type),
+        placeholder,
+        defaultValue,
+        List.of(),
+        rules,
+        List.of(),
+        List.of(),
+        null);
   }
 
-  protected FormSectionVO section(
+  protected FormSection section(
       String key,
       String title,
       String description,
       boolean collapsible,
       boolean defaultExpanded,
-      List<FormFieldVO> fields) {
-    return FormSectionVO.builder()
-        .key(key)
-        .title(title)
-        .description(description)
-        .collapsible(collapsible)
-        .defaultExpanded(defaultExpanded)
-        .fields(fields)
-        .build();
+      List<FormField> fields) {
+    return new FormSection(key, title, description, collapsible, defaultExpanded, fields);
   }
 
-  protected List<RuleVO> required(String message) {
-    return Collections.singletonList(
-        RuleVO.builder().required(true).message(message).build());
+  protected List<FormRule> required(String message) {
+    return Collections.singletonList(new FormRule(true, null, null, null, message));
   }
 
-  protected List<RuleVO> rangeRule(int min, int max, String message) {
-    return Collections.singletonList(
-        RuleVO.builder().required(true).min(min).max(max).message(message).build());
+  protected List<FormRule> rangeRule(int min, int max, String message) {
+    return Collections.singletonList(new FormRule(true, null, min, max, message));
   }
 
   private Map<String, Object> sshDefaultValue() {
@@ -508,8 +472,7 @@ public abstract class AbstractJdbcDataSourcePlugin implements DataSourcePlugin {
     String sshPassword = firstText(node, "password");
     String privateKey = firstText(node, "privateKey", "privateKeyContent");
     String passphrase = firstText(node, "passphrase", "privateKeyPassphrase");
-    boolean strictHostKeyChecking =
-        booleanValue(node, false, "strictHostKeyChecking");
+    boolean strictHostKeyChecking = booleanValue(node, false, "strictHostKeyChecking");
     String knownHosts = firstText(node, "knownHosts", "knownHostsContent");
 
     if (isBlank(host)) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -5,6 +5,7 @@ import io.yak.ops.spi.datasource.DataSourceCatalog;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
 import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
 import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
 import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
 import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
 import io.yak.ops.spi.datasource.metadata.DataSourceTable;
@@ -35,11 +36,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-/** 基于 JDBC {@link DatabaseMetaData} 的通用 Catalog 和轻量预览实现。 */
+/** Generic JDBC Catalog based on {@link DatabaseMetaData} and typed lightweight-read requests. */
 public class GenericJdbcCatalog implements DataSourceCatalog {
 
-  private static final Pattern PLUGIN_VARIABLE_PATTERN =
-      Pattern.compile("\\$\\{var:([^}]+)}");
+  private static final Pattern PLUGIN_VARIABLE_PATTERN = Pattern.compile("\\$\\{var:([^}]+)}");
   private static final DateTimeFormatter DATETIME_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -58,9 +58,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
       try (ResultSet resultSet = opened.getMetaData().getCatalogs()) {
         while (resultSet.next()) {
           String database = resultSet.getString(1);
-          if (includeDatabase(database)) {
-            databases.add(database);
-          }
+          if (includeDatabase(database)) databases.add(database);
         }
       }
       if (databases.isEmpty() && includeDatabase(connection.database())) {
@@ -80,9 +78,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
       try (ResultSet resultSet = schemas(metadata, trimToNull(database))) {
         while (resultSet.next()) {
           String schema = resultSet.getString("TABLE_SCHEM");
-          if (includeSchema(schema)) {
-            schemas.add(schema);
-          }
+          if (includeSchema(schema)) schemas.add(schema);
         }
       }
       if (schemas.isEmpty() && includeSchema(connection.schema())) {
@@ -96,20 +92,15 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
 
   @Override
   public List<DataSourceTable> listTables(DataSourceCatalogQuery query) {
-    String database =
-        firstNonBlank(query == null ? null : query.getDatabase(), connection.database());
-    String schema =
-        firstNonBlank(query == null ? null : query.getSchema(), connection.schema());
+    String database = firstNonBlank(query == null ? null : query.getDatabase(), connection.database());
+    String schema = firstNonBlank(query == null ? null : query.getSchema(), connection.schema());
     String keyword = query == null ? null : trimToNull(query.getKeyword());
     try (Connection opened = openConnection();
-        ResultSet resultSet =
-            opened.getMetaData().getTables(database, schema, "%", tableTypes())) {
+        ResultSet resultSet = opened.getMetaData().getTables(database, schema, "%", tableTypes())) {
       List<DataSourceTable> tables = new ArrayList<>();
       while (resultSet.next()) {
         String name = resultSet.getString("TABLE_NAME");
-        if (!matchesKeyword(name, keyword)) {
-          continue;
-        }
+        if (!matchesKeyword(name, keyword)) continue;
         tables.add(
             new DataSourceTable(
                 resultSet.getString("TABLE_CAT"),
@@ -130,11 +121,9 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     String schema = firstNonBlank(tablePath.getSchema(), connection.schema());
     try (Connection opened = openConnection()) {
       DatabaseMetaData metadata = opened.getMetaData();
-      Set<String> primaryKeys =
-          primaryKeys(metadata, database, schema, tablePath.getTable());
+      Set<String> primaryKeys = primaryKeys(metadata, database, schema, tablePath.getTable());
       List<DataSourceColumn> columns = new ArrayList<>();
-      try (ResultSet resultSet =
-          metadata.getColumns(database, schema, tablePath.getTable(), "%")) {
+      try (ResultSet resultSet = metadata.getColumns(database, schema, tablePath.getTable(), "%")) {
         while (resultSet.next()) {
           String name = resultSet.getString("COLUMN_NAME");
           columns.add(
@@ -157,19 +146,17 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   }
 
   @Override
-  public List<DataSourceColumn> describe(Map<String, Object> request) {
-    CatalogRequest catalogRequest = resolveRequest(request);
-    if (!catalogRequest.sqlMode()) {
-      return listColumns(resolveTablePath(catalogRequest.tablePath()));
+  public List<DataSourceColumn> describe(DataSourceCatalogReadRequest request) {
+    DataSourceCatalogReadRequest value = requireRequest(request);
+    if (!value.sqlMode()) {
+      return listColumns(resolveTablePath(value.tablePath()));
     }
 
-    String query = resolveSql(catalogRequest.query(), request);
+    String query = resolveSql(value.query(), value);
     try (Connection opened = openConnection();
         PreparedStatement statement = opened.prepareStatement(stripTrailingSemicolon(query))) {
       ResultSetMetaData metadata = statement.getMetaData();
-      if (metadata != null) {
-        return columnsFromMetadata(metadata);
-      }
+      if (metadata != null) return columnsFromMetadata(metadata);
       statement.setMaxRows(1);
       try (ResultSet resultSet = statement.executeQuery()) {
         return columnsFromMetadata(resultSet.getMetaData());
@@ -180,9 +167,10 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   }
 
   @Override
-  public DataSourceQueryResult preview(Map<String, Object> request, int limit) {
+  public DataSourceQueryResult preview(DataSourceCatalogReadRequest request, int limit) {
+    DataSourceCatalogReadRequest value = requireRequest(request);
     int safeLimit = Math.max(1, Math.min(limit, 200));
-    String query = buildQuery(request);
+    String query = buildQuery(value);
     try (Connection opened = openConnection();
         PreparedStatement statement = opened.prepareStatement(query)) {
       statement.setMaxRows(safeLimit);
@@ -193,12 +181,11 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
         while (resultSet.next() && rows.size() < safeLimit) {
           Map<String, Object> row = new LinkedHashMap<>();
           for (int index = 1; index <= metadata.getColumnCount(); index++) {
-            String key = columnKey(metadata, index);
-            row.put(key, resultSet.getObject(index));
+            row.put(columnKey(metadata, index), resultSet.getObject(index));
           }
           rows.add(row);
         }
-        return new DataSourceQueryResult(columns, rows, count(request));
+        return new DataSourceQueryResult(columns, rows, count(value));
       }
     } catch (Exception exception) {
       throw catalogError("查询预览数据失败", exception);
@@ -206,8 +193,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   }
 
   @Override
-  public long count(Map<String, Object> request) {
-    String query = buildQuery(request);
+  public long count(DataSourceCatalogReadRequest request) {
+    String query = buildQuery(requireRequest(request));
     String countSql = "SELECT COUNT(*) FROM (" + query + ") yak_ops_count";
     try (Connection opened = openConnection();
         PreparedStatement statement = opened.prepareStatement(countSql);
@@ -222,9 +209,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   public String buildSqlTemplate(String tablePath) {
     DataSourceTablePath resolvedPath = resolveTablePath(tablePath);
     List<DataSourceColumn> columns = listColumns(resolvedPath);
-    if (columns.isEmpty()) {
-      throw catalogError("未找到表字段：" + tablePath, null);
-    }
+    if (columns.isEmpty()) throw catalogError("未找到表字段：" + tablePath, null);
     String columnSql =
         columns.stream()
             .map(DataSourceColumn::getName)
@@ -234,16 +219,14 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   }
 
   @Override
-  public String resolveSql(String sql, Map<String, Object> request) {
-    if (isBlank(sql)) {
-      return sql;
-    }
+  public String resolveSql(String sql, DataSourceCatalogReadRequest request) {
+    if (isBlank(sql)) return sql;
+    DataSourceCatalogReadRequest value = requireRequest(request);
 
     String resolved = sql;
-    for (Map.Entry<String, String> variable : requestVariables(request).entrySet()) {
+    for (Map.Entry<String, String> variable : value.variables().entrySet()) {
       resolved = resolved.replace("${" + variable.getKey() + "}", variable.getValue());
-      resolved =
-          resolved.replace("${var:" + variable.getKey() + "}", variable.getValue());
+      resolved = resolved.replace("${var:" + variable.getKey() + "}", variable.getValue());
     }
 
     Matcher matcher = PLUGIN_VARIABLE_PATTERN.matcher(resolved);
@@ -284,14 +267,11 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
 
   protected boolean matchesKeyword(String value, String keyword) {
     return keyword == null
-        || (value != null
-            && value.toLowerCase(Locale.ROOT).contains(keyword.toLowerCase(Locale.ROOT)));
+        || (value != null && value.toLowerCase(Locale.ROOT).contains(keyword.toLowerCase(Locale.ROOT)));
   }
 
   protected String quoteIdentifier(String identifier) {
-    if (isBlank(identifier)) {
-      throw new IllegalArgumentException("数据库标识符不能为空");
-    }
+    if (isBlank(identifier)) throw new IllegalArgumentException("数据库标识符不能为空");
     String quote = usesBacktick() ? "`" : "\"";
     return quote + identifier.trim().replace(quote, quote + quote) + quote;
   }
@@ -299,50 +279,30 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   protected DataSourcePluginException catalogError(String action, Throwable throwable) {
     String message = safeMessage(throwable);
     return new DataSourcePluginException(
-        Operation.CATALOG,
-        action + (message == null ? "" : "：" + message),
-        throwable);
+        Operation.CATALOG, action + (message == null ? "" : "：" + message), throwable);
   }
 
   protected String safeMessage(Throwable throwable) {
     String message = throwable == null ? null : throwable.getMessage();
-    if (isBlank(message)) {
-      return throwable == null ? null : throwable.getClass().getSimpleName();
-    }
-    String sanitized =
-        message.replaceAll("(?i)(password|pwd)=([^;&\\s]+)", "$1=******");
+    if (isBlank(message)) return throwable == null ? null : throwable.getClass().getSimpleName();
+    String sanitized = message.replaceAll("(?i)(password|pwd)=([^;&\\s]+)", "$1=******");
     return sanitized.length() > 300 ? sanitized.substring(0, 300) : sanitized;
   }
 
-  private String buildQuery(Map<String, Object> request) {
-    CatalogRequest catalogRequest = resolveRequest(request);
-    if (catalogRequest.sqlMode()) {
-      return stripTrailingSemicolon(resolveSql(catalogRequest.query(), request));
+  private String buildQuery(DataSourceCatalogReadRequest request) {
+    if (request.sqlMode()) {
+      return stripTrailingSemicolon(resolveSql(request.query(), request));
     }
-    return "SELECT * FROM " + buildTableReference(resolveTablePath(catalogRequest.tablePath()));
+    return "SELECT * FROM " + buildTableReference(resolveTablePath(request.tablePath()));
   }
 
-  private CatalogRequest resolveRequest(Map<String, Object> request) {
-    if (request == null) {
-      throw catalogError("requestBody 不能为空", null);
-    }
-    String readMode = text(request, "read_mode", "readMode");
-    String tablePath = text(request, "table_path", "tablePath", "table");
-    String query = text(request, "query", "sql");
-    boolean sqlMode = "sql".equalsIgnoreCase(readMode) || (!isBlank(query) && isBlank(tablePath));
-    if (sqlMode && isBlank(query)) {
-      throw catalogError("SQL 模式下 query 不能为空", null);
-    }
-    if (!sqlMode && isBlank(tablePath)) {
-      throw catalogError("表模式下 table_path 不能为空", null);
-    }
-    return new CatalogRequest(sqlMode, trimToNull(tablePath), trimToNull(query));
+  private DataSourceCatalogReadRequest requireRequest(DataSourceCatalogReadRequest request) {
+    if (request == null) throw catalogError("Catalog 读取请求不能为空", null);
+    return request;
   }
 
   private DataSourceTablePath resolveTablePath(String tablePath) {
-    if (isBlank(tablePath)) {
-      throw catalogError("table_path 不能为空", null);
-    }
+    if (isBlank(tablePath)) throw catalogError("table_path 不能为空", null);
     String[] parts =
         java.util.Arrays.stream(tablePath.split("\\."))
             .map(String::trim)
@@ -353,14 +313,10 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
       return new DataSourceTablePath(connection.database(), connection.schema(), parts[0]);
     }
     if (parts.length == 2) {
-      if (usesCatalogAsNamespace()) {
-        return new DataSourceTablePath(parts[0], null, parts[1]);
-      }
+      if (usesCatalogAsNamespace()) return new DataSourceTablePath(parts[0], null, parts[1]);
       return new DataSourceTablePath(connection.database(), parts[0], parts[1]);
     }
-    if (parts.length == 3) {
-      return new DataSourceTablePath(parts[0], parts[1], parts[2]);
-    }
+    if (parts.length == 3) return new DataSourceTablePath(parts[0], parts[1], parts[2]);
     throw catalogError("table_path 格式不正确：" + tablePath, null);
   }
 
@@ -368,21 +324,16 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     List<String> parts = new ArrayList<>();
     if (usesCatalogAsNamespace()) {
       String database = firstNonBlank(tablePath.getDatabase(), connection.database());
-      if (!isBlank(database)) {
-        parts.add(quoteIdentifier(database));
-      }
+      if (!isBlank(database)) parts.add(quoteIdentifier(database));
     } else {
       String schema = firstNonBlank(tablePath.getSchema(), connection.schema());
-      if (!isBlank(schema)) {
-        parts.add(quoteIdentifier(schema));
-      }
+      if (!isBlank(schema)) parts.add(quoteIdentifier(schema));
     }
     parts.add(quoteIdentifier(tablePath.getTable()));
     return String.join(".", parts);
   }
 
-  private List<DataSourceColumn> columnsFromMetadata(ResultSetMetaData metadata)
-      throws SQLException {
+  private List<DataSourceColumn> columnsFromMetadata(ResultSetMetaData metadata) throws SQLException {
     List<DataSourceColumn> columns = new ArrayList<>();
     for (int index = 1; index <= metadata.getColumnCount(); index++) {
       columns.add(
@@ -400,8 +351,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     return columns;
   }
 
-  private List<DataSourceQueryColumn> previewColumns(ResultSetMetaData metadata)
-      throws SQLException {
+  private List<DataSourceQueryColumn> previewColumns(ResultSetMetaData metadata) throws SQLException {
     List<DataSourceQueryColumn> columns = new ArrayList<>();
     for (int index = 1; index <= metadata.getColumnCount(); index++) {
       String key = columnKey(metadata, index);
@@ -424,15 +374,10 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   }
 
   private Set<String> primaryKeys(
-      DatabaseMetaData metadata,
-      String database,
-      String schema,
-      String table) {
+      DatabaseMetaData metadata, String database, String schema, String table) {
     try (ResultSet resultSet = metadata.getPrimaryKeys(database, schema, table)) {
       Set<String> keys = new LinkedHashSet<>();
-      while (resultSet.next()) {
-        keys.add(resultSet.getString("COLUMN_NAME"));
-      }
+      while (resultSet.next()) keys.add(resultSet.getString("COLUMN_NAME"));
       return keys;
     } catch (Exception ignored) {
       return Collections.emptySet();
@@ -447,37 +392,9 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   private Properties connectionPropertiesInternal() {
     Properties properties = new Properties();
     properties.putAll(connection.properties());
-    if (!isBlank(connection.username())) {
-      properties.setProperty("user", connection.username());
-    }
-    if (connection.password() != null) {
-      properties.setProperty("password", connection.password());
-    }
+    if (!isBlank(connection.username())) properties.setProperty("user", connection.username());
+    if (connection.password() != null) properties.setProperty("password", connection.password());
     return properties;
-  }
-
-  private Map<String, String> requestVariables(Map<String, Object> request) {
-    if (request == null) {
-      return Collections.emptyMap();
-    }
-    Object paramsListObj = request.get("paramsList");
-    if (!(paramsListObj instanceof Iterable<?>)) {
-      return Collections.emptyMap();
-    }
-    Iterable<?> items = (Iterable<?>) paramsListObj;
-    Map<String, String> variables = new LinkedHashMap<>();
-    for (Object item : items) {
-      if (!(item instanceof Map<?, ?>)) {
-        continue;
-      }
-      Map<?, ?> value = (Map<?, ?>) item;
-      String name = mapText(value, "paramName", "name");
-      String variableValue = mapText(value, "paramValue", "value");
-      if (!isBlank(name) && variableValue != null) {
-        variables.put(name.trim(), variableValue);
-      }
-    }
-    return variables;
   }
 
   private String builtInVariable(String name) {
@@ -494,29 +411,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     return value == null ? null : "'" + DATETIME_FORMATTER.format(value) + "'";
   }
 
-  private String text(Map<String, Object> request, String... keys) {
-    for (String key : keys) {
-      Object value = request.get(key);
-      if (value != null) {
-        return String.valueOf(value);
-      }
-    }
-    return null;
-  }
-
-  private String mapText(Map<?, ?> request, String... keys) {
-    for (String key : keys) {
-      Object value = request.get(key);
-      if (value != null) {
-        return String.valueOf(value);
-      }
-    }
-    return null;
-  }
-
   private boolean usesCatalogAsNamespace() {
-    return connection.dbType() == DataSourceDbType.MYSQL
-        || connection.dbType() == DataSourceDbType.DORIS;
+    return connection.dbType() == DataSourceDbType.MYSQL || connection.dbType() == DataSourceDbType.DORIS;
   }
 
   private boolean usesBacktick() {
@@ -551,29 +447,5 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
 
   private boolean isBlank(String value) {
     return value == null || value.trim().isEmpty();
-  }
-
-  private static final class CatalogRequest {
-    private final boolean sqlMode;
-    private final String tablePath;
-    private final String query;
-
-    private CatalogRequest(boolean sqlMode, String tablePath, String query) {
-      this.sqlMode = sqlMode;
-      this.tablePath = tablePath;
-      this.query = query;
-    }
-
-    public boolean sqlMode() {
-      return sqlMode;
-    }
-
-    public String tablePath() {
-      return tablePath;
-    }
-
-    public String query() {
-      return query;
-    }
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcUrlSchemaSupport.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/JdbcUrlSchemaSupport.java
@@ -1,84 +1,79 @@
 package io.yak.ops.plugin.database.jdbc;
 
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.JdbcUrlLinkageVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.VisibilityConditionVO;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.ConnectionForm;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormSection;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.JdbcUrlLinkage;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.VisibilityCondition;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.VisibilityOperator;
 import java.util.ArrayList;
 import java.util.List;
 
-/** JDBC URL Schema 标准能力：由插件声明模板，前端统一完成 Host / Port / Database 双向联动。 */
+/** Standard JDBC URL schema capability used by the shared frontend component. */
 public final class JdbcUrlSchemaSupport {
 
   private static final String JDBC_URL_FIELD = "jdbcUrl";
   private static final String SSH_FIELD = "sshTunnel";
   private static final String SSH_ENABLED_FIELD = "sshTunnel.enabled";
 
-  private JdbcUrlSchemaSupport() {
+  private JdbcUrlSchemaSupport() {}
+
+  public static DataSourcePluginDescriptor apply(
+      DataSourcePluginDescriptor descriptor, String template) {
+    if (descriptor == null || template == null || template.trim().isEmpty()) {
+      return descriptor;
+    }
+
+    ConnectionForm form = descriptor.connectionForm();
+    List<FormSection> sections =
+        form.sections().stream()
+            .map(section -> section.withFields(configureFields(section.fields(), template)))
+            .toList();
+    List<FormField> legacyFields = configureFields(form.legacyFields(), template);
+
+    return new DataSourcePluginDescriptor(
+        descriptor.dbType(),
+        descriptor.displayName(),
+        descriptor.apiVersion(),
+        descriptor.capabilities(),
+        new ConnectionForm(sections, legacyFields),
+        descriptor.installRequired(),
+        descriptor.installHint());
   }
 
-  public static DataSourcePluginConfigVO apply(
-      DataSourcePluginConfigVO config,
-      String template) {
-    if (config == null || template == null || template.trim().isEmpty()) {
-      return config;
-    }
-
-    if (config.getSections() != null) {
-      for (FormSectionVO section : config.getSections()) {
-        if (section == null || section.getFields() == null) continue;
-        section.getFields().forEach(field -> configureField(field, template));
-      }
-    }
-    if (config.getFormFields() != null) {
-      config.getFormFields().forEach(field -> configureField(field, template));
-    }
-    return config;
+  private static List<FormField> configureFields(List<FormField> fields, String template) {
+    if (fields == null || fields.isEmpty()) return List.of();
+    return fields.stream().map(field -> configureField(field, template)).toList();
   }
 
-  private static void configureField(FormFieldVO field, String template) {
-    if (field == null || !JDBC_URL_FIELD.equals(field.getKey())) return;
+  private static FormField configureField(FormField field, String template) {
+    if (field == null || !JDBC_URL_FIELD.equals(field.key())) return field;
 
-    field.setType("JDBC_URL");
-    field.setPlaceholder("根据主机、端口和数据库自动生成，也可以直接修改");
-    field.setUrlLinkage(
-        JdbcUrlLinkageVO.builder()
-            .template(template.trim())
-            .hostField("host")
-            .portField("port")
-            .databaseField("database")
-            .preserveSuffix(true)
-            .build());
+    List<String> dependencies = new ArrayList<>(field.dependsOn());
+    if (!dependencies.contains(SSH_FIELD)) dependencies.add(SSH_FIELD);
 
-    List<String> dependencies =
-        field.getDependsOn() == null
-            ? new ArrayList<>()
-            : new ArrayList<>(field.getDependsOn());
-    // SSH 是一个复合对象字段；监听父字段可确保开关变化一定触发前端重新计算可见性。
-    if (!dependencies.contains(SSH_FIELD)) {
-      dependencies.add(SSH_FIELD);
-    }
-    field.setDependsOn(dependencies);
-
-    List<VisibilityConditionVO> conditions =
-        field.getVisibleWhen() == null
-            ? new ArrayList<>()
-            : new ArrayList<>(field.getVisibleWhen());
-    boolean hasSshVisibilityRule =
+    List<VisibilityCondition> conditions = new ArrayList<>(field.visibleWhen());
+    boolean hasSshRule =
         conditions.stream()
             .anyMatch(
                 condition ->
                     condition != null
-                        && SSH_ENABLED_FIELD.equals(condition.getField())
-                        && "FALSY".equalsIgnoreCase(condition.getOperator()));
-    if (!hasSshVisibilityRule) {
+                        && SSH_ENABLED_FIELD.equals(condition.field())
+                        && condition.operator() == VisibilityOperator.FALSY);
+    if (!hasSshRule) {
       conditions.add(
-          VisibilityConditionVO.builder()
-              .field(SSH_ENABLED_FIELD)
-              .operator("FALSY")
-              .build());
+          new VisibilityCondition(
+              SSH_ENABLED_FIELD, VisibilityOperator.FALSY, null, List.of()));
     }
-    field.setVisibleWhen(conditions);
+
+    return field
+        .withType(FieldType.JDBC_URL)
+        .withPlaceholder("根据主机、端口和数据库自动生成，也可以直接修改")
+        .withJdbcUrlLinkage(
+            new JdbcUrlLinkage(template.trim(), "host", "port", "database", true))
+        .withDependsOn(dependencies)
+        .withVisibleWhen(conditions);
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/dameng/DamengDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/dameng/DamengDataSourcePlugin.java
@@ -1,12 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.dameng;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
-import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
-/** 达梦 JDBC 数据源插件。 */
+/** Dameng JDBC datasource plugin. */
 public final class DamengDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
@@ -15,10 +13,8 @@ public final class DamengDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   }
 
   @Override
-  public DataSourcePluginConfigVO pluginConfig() {
-    return JdbcUrlSchemaSupport.apply(
-        super.pluginConfig(),
-        "jdbc:dm://{host}:{port}/{database}");
+  protected String jdbcUrlTemplate() {
+    return "jdbc:dm://{host}:{port}/{database}";
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/kingbase/KingbaseDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/kingbase/KingbaseDataSourcePlugin.java
@@ -1,12 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.kingbase;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
-import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
-/** KingbaseES JDBC 数据源插件。 */
+/** KingbaseES JDBC datasource plugin. */
 public final class KingbaseDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
@@ -15,10 +13,8 @@ public final class KingbaseDataSourcePlugin extends AbstractJdbcDataSourcePlugin
   }
 
   @Override
-  public DataSourcePluginConfigVO pluginConfig() {
-    return JdbcUrlSchemaSupport.apply(
-        super.pluginConfig(),
-        "jdbc:kingbase8://{host}:{port}/{database}");
+  protected String jdbcUrlTemplate() {
+    return "jdbc:kingbase8://{host}:{port}/{database}";
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePlugin.java
@@ -1,12 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.mysql;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
-import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
-/** MySQL JDBC 数据源插件。 */
+/** MySQL JDBC datasource plugin. */
 public final class MySqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
@@ -15,10 +13,8 @@ public final class MySqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   }
 
   @Override
-  public DataSourcePluginConfigVO pluginConfig() {
-    return JdbcUrlSchemaSupport.apply(
-        super.pluginConfig(),
-        "jdbc:mysql://{host}:{port}/{database}");
+  protected String jdbcUrlTemplate() {
+    return "jdbc:mysql://{host}:{port}/{database}";
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/oracle/OracleDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/oracle/OracleDataSourcePlugin.java
@@ -1,12 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.oracle;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
-import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
-/** Oracle JDBC 数据源插件。 */
+/** Oracle JDBC datasource plugin. */
 public final class OracleDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
@@ -15,10 +13,8 @@ public final class OracleDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
   }
 
   @Override
-  public DataSourcePluginConfigVO pluginConfig() {
-    return JdbcUrlSchemaSupport.apply(
-        super.pluginConfig(),
-        "jdbc:oracle:thin:@//{host}:{port}/{database}");
+  protected String jdbcUrlTemplate() {
+    return "jdbc:oracle:thin:@//{host}:{port}/{database}";
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/postgresql/PostgreSqlDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/postgresql/PostgreSqlDataSourcePlugin.java
@@ -1,12 +1,10 @@
 package io.yak.ops.plugin.database.jdbc.postgresql;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
-import io.yak.ops.plugin.database.jdbc.JdbcUrlSchemaSupport;
 
-/** PostgreSQL JDBC 数据源插件。 */
+/** PostgreSQL JDBC datasource plugin. */
 public final class PostgreSqlDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
 
   @Override
@@ -15,10 +13,8 @@ public final class PostgreSqlDataSourcePlugin extends AbstractJdbcDataSourcePlug
   }
 
   @Override
-  public DataSourcePluginConfigVO pluginConfig() {
-    return JdbcUrlSchemaSupport.apply(
-        super.pluginConfig(),
-        "jdbc:postgresql://{host}:{port}/{database}");
+  protected String jdbcUrlTemplate() {
+    return "jdbc:postgresql://{host}:{port}/{database}";
   }
 
   @Override

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
@@ -1,0 +1,47 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class GenericJdbcCatalogTypedRequestTest {
+
+  @Test
+  void resolveSqlUsesTypedVariablesWithoutLegacyMapKeys() {
+    GenericJdbcCatalog catalog = new GenericJdbcCatalog(connection(), 5);
+    DataSourceCatalogReadRequest request =
+        DataSourceCatalogReadRequest.sql(
+            "select '${day}' as day_value, ${var:tenant} as tenant_value",
+            Map.of("day", "2026-08-23", "tenant", "42"));
+
+    String resolved = catalog.resolveSql(request.query(), request);
+
+    assertThat(resolved)
+        .isEqualTo("select '2026-08-23' as day_value, 42 as tenant_value");
+  }
+
+  @Test
+  void typedRequestRejectsMissingModePayload() {
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> new DataSourceCatalogReadRequest(
+                DataSourceCatalogReadRequest.Mode.SQL, null, null, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("query");
+  }
+
+  private JdbcConnectionProperties connection() {
+    return new JdbcConnectionProperties(
+        DataSourceDbType.MYSQL,
+        "jdbc:mysql://localhost:3306/demo",
+        "com.mysql.cj.jdbc.Driver",
+        "test_user",
+        null,
+        "demo",
+        null,
+        Map.of(),
+        "{}");
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDatasourcePluginContractTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDatasourcePluginContractTest.java
@@ -1,0 +1,63 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.plugin.database.jdbc.dameng.DamengDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.kingbase.KingbaseDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.mysql.MySqlDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.oracle.OracleDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.postgresql.PostgreSqlDataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JdbcDatasourcePluginContractTest {
+
+  @Test
+  void builtInJdbcPluginsExposeVersionedDescriptorAndRequiredCapabilities() {
+    for (DataSourcePlugin plugin : plugins()) {
+      DataSourcePluginDescriptor descriptor = plugin.descriptor();
+
+      assertThat(descriptor.dbType()).isEqualTo(plugin.dbType());
+      assertThat(descriptor.apiVersion()).isEqualTo(DataSourcePluginDescriptor.CURRENT_API_VERSION);
+      assertThat(descriptor.capabilities())
+          .contains(
+              DataSourceCapability.CONNECTION_TEST,
+              DataSourceCapability.CATALOG_METADATA,
+              DataSourceCapability.CATALOG_READ,
+              DataSourceCapability.SQL_EXECUTION,
+              DataSourceCapability.TRANSACTIONS,
+              DataSourceCapability.SSH_TUNNEL);
+      assertThat(descriptor.secretFieldKeys()).contains("password");
+      assertThat(descriptor.connectionForm().allFields())
+          .anySatisfy(
+              field -> {
+                if ("jdbcUrl".equals(field.key())) {
+                  assertThat(field.type()).isEqualTo(FieldType.JDBC_URL);
+                  assertThat(field.jdbcUrlLinkage()).isNotNull();
+                }
+              });
+    }
+  }
+
+  @Test
+  void transactionCapabilityNeverExistsWithoutSqlExecution() {
+    for (DataSourcePlugin plugin : plugins()) {
+      if (plugin.supports(DataSourceCapability.TRANSACTIONS)) {
+        assertThat(plugin.supports(DataSourceCapability.SQL_EXECUTION)).isTrue();
+      }
+    }
+  }
+
+  private List<DataSourcePlugin> plugins() {
+    return List.of(
+        new MySqlDataSourcePlugin(),
+        new PostgreSqlDataSourcePlugin(),
+        new OracleDataSourcePlugin(),
+        new DamengDataSourcePlugin(),
+        new KingbaseDataSourcePlugin());
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDatasourcePluginContractTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDatasourcePluginContractTest.java
@@ -11,6 +11,7 @@ import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
 import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -32,14 +33,13 @@ class JdbcDatasourcePluginContractTest {
               DataSourceCapability.TRANSACTIONS,
               DataSourceCapability.SSH_TUNNEL);
       assertThat(descriptor.secretFieldKeys()).contains("password");
-      assertThat(descriptor.connectionForm().allFields())
-          .anySatisfy(
-              field -> {
-                if ("jdbcUrl".equals(field.key())) {
-                  assertThat(field.type()).isEqualTo(FieldType.JDBC_URL);
-                  assertThat(field.jdbcUrlLinkage()).isNotNull();
-                }
-              });
+      FormField jdbcUrlField =
+          descriptor.connectionForm().allFields().stream()
+              .filter(field -> "jdbcUrl".equals(field.key()))
+              .findFirst()
+              .orElseThrow();
+      assertThat(jdbcUrlField.type()).isEqualTo(FieldType.JDBC_URL);
+      assertThat(jdbcUrlField.jdbcUrlLinkage()).isNotNull();
     }
   }
 

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/mysql/MySqlDataSourcePluginTest.java
@@ -3,12 +3,14 @@ package io.yak.ops.plugin.database.jdbc.mysql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormFieldVO;
-import io.yak.ops.common.bean.vo.datasource.DataSourcePluginConfigVO.FormSectionVO;
 import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
 import io.yak.ops.plugin.database.jdbc.SshTunnelConfig;
+import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormSection;
 import io.yak.ops.spi.datasource.DataSourcePluginException;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +22,7 @@ class MySqlDataSourcePluginTest {
         new MySqlDataSourcePlugin()
             .parseConnection(
                 "{\"dbType\":\"MYSQL\",\"host\":\"127.0.0.1\","
-                    + "\"database\":\"demo\",\"username\":\"root\"}");
+                    + "\"database\":\"demo\",\"username\":\"test_user\"}");
 
     assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://127.0.0.1:3306/demo");
     assertThat(connection.driverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
@@ -30,63 +32,70 @@ class MySqlDataSourcePluginTest {
   }
 
   @Test
-  void shouldExposeSectionedFormSchemaAndKeepLegacyFields() {
-    DataSourcePluginConfigVO config = new MySqlDataSourcePlugin().pluginConfig();
+  void shouldExposeStableDescriptorCapabilitiesAndSectionedFormSchema() {
+    DataSourcePluginDescriptor descriptor = new MySqlDataSourcePlugin().descriptor();
 
-    assertThat(config.getSections())
-        .extracting(FormSectionVO::getKey)
+    assertThat(descriptor.apiVersion()).isEqualTo(DataSourcePluginDescriptor.CURRENT_API_VERSION);
+    assertThat(descriptor.capabilities())
+        .contains(
+            DataSourceCapability.CONNECTION_TEST,
+            DataSourceCapability.CATALOG_METADATA,
+            DataSourceCapability.CATALOG_READ,
+            DataSourceCapability.SQL_EXECUTION,
+            DataSourceCapability.TRANSACTIONS,
+            DataSourceCapability.SSH_TUNNEL);
+    assertThat(descriptor.connectionForm().sections())
+        .extracting(FormSection::key)
         .containsExactly("connection", "ssh", "driver", "advanced");
-    assertThat(config.getSections().get(0).getCollapsible()).isFalse();
-    assertThat(config.getSections().get(1).getCollapsible()).isTrue();
-    assertThat(config.getSections().get(1).getDefaultExpanded()).isFalse();
-    assertThat(config.getSections().get(1).getFields())
+    assertThat(descriptor.connectionForm().sections().get(0).collapsible()).isFalse();
+    assertThat(descriptor.connectionForm().sections().get(1).collapsible()).isTrue();
+    assertThat(descriptor.connectionForm().sections().get(1).defaultExpanded()).isFalse();
+    assertThat(descriptor.connectionForm().sections().get(1).fields())
         .singleElement()
         .satisfies(
             field -> {
-              assertThat(field.getKey()).isEqualTo("sshTunnel");
-              assertThat(field.getType()).isEqualTo("SSH");
+              assertThat(field.key()).isEqualTo("sshTunnel");
+              assertThat(field.type()).isEqualTo(FieldType.SSH);
             });
-    assertThat(config.getSections().get(2).getDefaultExpanded()).isTrue();
-    assertThat(config.getSections().get(3).getDefaultExpanded()).isFalse();
 
-    FormFieldVO jdbcUrlField =
-        config.getSections().get(0).getFields().stream()
-            .filter(field -> "jdbcUrl".equals(field.getKey()))
+    FormField jdbcUrlField =
+        descriptor.connectionForm().sections().get(0).fields().stream()
+            .filter(field -> "jdbcUrl".equals(field.key()))
             .findFirst()
             .orElseThrow();
-    assertThat(jdbcUrlField.getType()).isEqualTo("JDBC_URL");
-    assertThat(jdbcUrlField.getUrlLinkage()).isNotNull();
-    assertThat(jdbcUrlField.getUrlLinkage().getTemplate())
+    assertThat(jdbcUrlField.type()).isEqualTo(FieldType.JDBC_URL);
+    assertThat(jdbcUrlField.jdbcUrlLinkage()).isNotNull();
+    assertThat(jdbcUrlField.jdbcUrlLinkage().template())
         .isEqualTo("jdbc:mysql://{host}:{port}/{database}");
-    assertThat(jdbcUrlField.getUrlLinkage().getHostField()).isEqualTo("host");
-    assertThat(jdbcUrlField.getUrlLinkage().getPortField()).isEqualTo("port");
-    assertThat(jdbcUrlField.getUrlLinkage().getDatabaseField()).isEqualTo("database");
-    assertThat(jdbcUrlField.getUrlLinkage().getPreserveSuffix()).isTrue();
-    assertThat(jdbcUrlField.getDependsOn()).contains("sshTunnel");
-    assertThat(jdbcUrlField.getVisibleWhen())
+    assertThat(jdbcUrlField.jdbcUrlLinkage().hostField()).isEqualTo("host");
+    assertThat(jdbcUrlField.jdbcUrlLinkage().portField()).isEqualTo("port");
+    assertThat(jdbcUrlField.jdbcUrlLinkage().databaseField()).isEqualTo("database");
+    assertThat(jdbcUrlField.jdbcUrlLinkage().preserveSuffix()).isTrue();
+    assertThat(jdbcUrlField.dependsOn()).contains("sshTunnel");
+    assertThat(jdbcUrlField.visibleWhen())
         .singleElement()
         .satisfies(
             condition -> {
-              assertThat(condition.getField()).isEqualTo("sshTunnel.enabled");
-              assertThat(condition.getOperator()).isEqualTo("FALSY");
+              assertThat(condition.field()).isEqualTo("sshTunnel.enabled");
+              assertThat(condition.operator().name()).isEqualTo("FALSY");
             });
 
-    FormFieldVO propertiesField =
-        config.getSections().get(3).getFields().stream()
-            .filter(field -> "properties".equals(field.getKey()))
+    FormField propertiesField =
+        descriptor.connectionForm().sections().get(3).fields().stream()
+            .filter(field -> "properties".equals(field.key()))
             .findFirst()
             .orElseThrow();
-    assertThat(propertiesField.getDependsOn()).containsExactly("driverClassName");
-    assertThat(propertiesField.getVisibleWhen())
+    assertThat(propertiesField.dependsOn()).containsExactly("driverClassName");
+    assertThat(propertiesField.visibleWhen())
         .singleElement()
         .satisfies(
             condition -> {
-              assertThat(condition.getField()).isNull();
-              assertThat(condition.getOperator()).isEqualTo("TRUTHY");
+              assertThat(condition.field()).isNull();
+              assertThat(condition.operator().name()).isEqualTo("TRUTHY");
             });
 
-    // 旧版前端仍可继续消费扁平 formFields，SSH 复合字段只通过新版 sections 下发。
-    assertThat(config.getFormFields()).hasSize(9);
+    assertThat(descriptor.secretFieldKeys()).contains("password");
+    assertThat(descriptor.connectionForm().legacyFields()).hasSize(9);
   }
 
   @Test
@@ -96,19 +105,18 @@ class MySqlDataSourcePluginTest {
             new MySqlDataSourcePlugin()
                 .parseConnection(
                     "{\"dbType\":\"MYSQL\",\"host\":\"db.internal\","
-                        + "\"port\":3306,\"database\":\"demo\",\"username\":\"root\","
-                        + "\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion.example.com\","
-                        + "\"port\":22,\"username\":\"ops\",\"authType\":\"PASSWORD\","
-                        + "\"password\":\"secret\"}}}");
+                        + "\"port\":3306,\"database\":\"demo\",\"username\":\"test_user\","
+                        + "\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion.example.invalid\","
+                        + "\"port\":22,\"username\":\"test_ops\",\"authType\":\"PASSWORD\","
+                        + "\"password\":\"TEST_ONLY_VALUE\"}}}");
 
     assertThat(connection.host()).isEqualTo("db.internal");
     assertThat(connection.port()).isEqualTo(3306);
     assertThat(connection.sshTunnel().enabled()).isTrue();
-    assertThat(connection.sshTunnel().host()).isEqualTo("bastion.example.com");
+    assertThat(connection.sshTunnel().host()).isEqualTo("bastion.example.invalid");
     assertThat(connection.sshTunnel().port()).isEqualTo(22);
-    assertThat(connection.sshTunnel().username()).isEqualTo("ops");
-    assertThat(connection.sshTunnel().authType())
-        .isEqualTo(SshTunnelConfig.AuthType.PASSWORD);
+    assertThat(connection.sshTunnel().username()).isEqualTo("test_ops");
+    assertThat(connection.sshTunnel().authType()).isEqualTo(SshTunnelConfig.AuthType.PASSWORD);
     assertThat(connection.normalizedJson()).contains("\"sshTunnel\"");
   }
 
@@ -119,10 +127,10 @@ class MySqlDataSourcePluginTest {
                 new MySqlDataSourcePlugin()
                     .parseConnection(
                         "{\"dbType\":\"MYSQL\",\"host\":\"db.internal\","
-                            + "\"database\":\"demo\",\"username\":\"root\","
+                            + "\"database\":\"demo\",\"username\":\"test_user\","
                             + "\"jdbcUrl\":\"jdbc:mysql://db.internal:3306/demo\","
-                            + "\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion.example.com\","
-                            + "\"username\":\"ops\",\"password\":\"secret\"}}}"))
+                            + "\"sshTunnel\":{\"enabled\":true,\"host\":\"bastion.example.invalid\","
+                            + "\"username\":\"test_ops\",\"password\":\"TEST_ONLY_VALUE\"}}}"))
         .isInstanceOf(DataSourcePluginException.class)
         .hasMessageContaining("启用 SSH 隧道时");
   }


### PR DESCRIPTION
# Datasource Change

> Final Phase 4 landing PR to `main`. #668 was merged into the historical Phase 3 branch, so this PR carries the complete Phase 4 head — including the post-#668 guardrail/document fixes — onto the actual mainline.

## Summary

完成 Datasource Domain Phase 4 最终标准化：

- `DataSourcePluginDescriptor`：versioned immutable Plugin metadata / form contract
- `DataSourceCapability`：显式能力声明与依赖校验
- `DataSourcePlugin.pluginConfig()` -> `descriptor()`
- Plugin API 完全移除 `DataSourcePluginConfigVO` 依赖
- Business-owned Plugin Descriptor + Gateway Adapter + `DataSourcePluginViewMapper`
- Secret 识别由 Descriptor Schema 驱动，不再读取 HTTP VO
- `DataSourceCatalogReadRequest`：Plugin Catalog SPI typed request
- `DataSourceCatalog` 稳定接口完全 Map-free
- MySQL / PostgreSQL / Oracle / Doris / 达梦 / Kingbase 内置插件全部迁移
- Plugin Registry 校验 apiVersion / dbType / Capability dependency
- 新增 `PLUGIN.md`、Plugin contract tests、framework-free Plugin Contract smoke

## Domain Impact Analysis

```text
Aggregate(s):
- DataSourceDefinition / ConnectionProfile: unchanged
- SqlExecutionAggregate: unchanged
Subdomain(s): Plugin Contract / Catalog SPI
Invariant/lifecycle impact:
- DataSource and SQL lifecycle semantics unchanged
- plugin metadata truth becomes versioned Descriptor
- capability discovery becomes explicit
- HTTP PluginConfig remains Business projection only
- Plugin Catalog SPI becomes typed and Map-free
Layer: Domain / Application / Gateway / SPI API / Plugin Implementation / Test / Documentation / CI
Domain Gap: no for Phase 4 scope
```

## Plugin Contract Impact

```text
Plugin API changed: yes, intentional source-level migration
Descriptor / Capability changed: yes
Catalog SPI changed: Map -> DataSourceCatalogReadRequest
apiVersion: 1
third-party migration required: yes, documented in PLUGIN.md
```

Migration:

```text
pluginConfig() -> descriptor()
DataSourceCatalog Map request -> DataSourceCatalogReadRequest
```

## Compatibility

Preserved:

- REST API paths and PluginConfig JSON shape
- `yak_ops_data_source` / Flyway history
- DataSource lifecycle behavior
- Catalog HTTP historical aliases and paramsList behavior
- `yak-ops-core` SQL Execution public contract
- built-in database plugin runtime behavior
- Task Plugin SQL execution provider behavior

Intentional break:

- third-party datasource plugins compiled against the pre-Phase-4 SPI must migrate/recompile for API version 1.

## Tests / Safety

Added / updated:

- JDBC / Doris descriptor contract tests
- typed Catalog SPI tests
- Business Descriptor -> HTTP VO compatibility tests
- Descriptor-driven Secret mask/merge tests
- Gateway architecture tests
- Plugin Registry static contract checks
- `tools/datasource_domain_guardrails.py`
- `tools/datasource-plugin-smoke/DatasourcePluginContractSmoke.java`

Latest PR CI on `main + Phase 4` merge environment:

```text
Datasource Domain Guardrails: PASS
Static Domain / Plugin Contract: PASS
Framework-free Phase 3 Domain Smoke: PASS
Framework-free Phase 4 Plugin Contract Smoke: PASS
  - JDK 21 real javac compile
  - Datasource Plugin API / Descriptor / Capability
  - typed DataSourceCatalogReadRequest / DataSourceCatalog
  - GenericJdbcCatalog typed variable execution smoke
Backend regression hook: PASS
Maven/JUnit regression: SKIPPED - repository 未配置 YAK_FRAMEWORK_TOKEN
```

因此 Plugin API 与 typed JDBC Catalog 已经在 PR merge 环境真实编译/执行；Spring Business、完整 JDBC/Doris plugin module 的 Maven/JUnit 层仍需配置 `YAK_FRAMEWORK_TOKEN` 才能自动执行。

## Domain Compliance Report

```text
Rule changed/implemented:
- Plugin Descriptor is the only stable plugin metadata protocol
- Plugin API has no Business/HTTP VO dependency
- Capability is explicit and dependency-validated
- Plugin Catalog SPI is typed and Map-free
- PluginConfig HTTP VO is Business projection only
- Secret schema comes from Descriptor
Safety/tests:
- built-in plugin descriptor contract tests
- typed Catalog SPI tests
- descriptor-driven Secret tests
- architecture/static guardrails
- framework-free Plugin Contract compile/smoke PASS
Known gaps:
- DataSourceDefinition physical naming cleanup only; intentionally excluded
```

## History recovery

```text
Phase 1 #662 -> main
Phase 2 #664 -> main
Phase 3 #666 -> main
Phase 4 #668 -> accidentally merged into historical Phase 3 branch
this PR #669 -> final complete Phase 4 landing to main
```
