### PR TITLE
refactor(offline-sync): complete Stage 9 application entry consolidation

### DIFF
--- a/docs/offline-sync/architecture/STAGE9.md
+++ b/docs/offline-sync/architecture/STAGE9.md
@@ -1,0 +1,176 @@
+# Offline Sync Stage 9 — Application Entry Consolidation
+
+## Goal
+
+Stage 8 已经把离线同步按 `definition / execution / backfill / cursor / schedule / reconcile` 等子系统归位。Stage 9 进一步收紧调用边界：**目录内部类不因为 `public` 或 Spring Bean 身份而自动成为跨子系统 API。**
+
+本阶段固定三个稳定 Application Facade：
+
+```text
+OfflineJobDefinitionService
+OfflineJobExecutionService
+OfflineBackfillService
+```
+
+Controller、后台触发器以及后续其他业务模块，应优先通过这些 Facade 进入离线同步业务链，而不是直接依赖 execution 内部 Coordinator / Runtime / Query / Adapter。
+
+## Stable application entries
+
+### Definition
+
+```text
+OfflineJobDefinitionController
+  -> OfflineJobDefinitionService
+```
+
+`OfflineJobDefinitionService` 负责定义保存、查询、上下线和删除等应用入口。它可以在内部协调 Runtime Guard、Schedule Lifecycle、Repository 等专业组件。
+
+### Execution
+
+```text
+OfflineJobExecutionController
+OfflineControlPlaneController
+OfflineScheduleHandler
+OfflineBackfillDispatcher
+OfflineExecutionReconciler
+  -> OfflineJobExecutionService
+```
+
+`OfflineJobExecutionService` 是 execution 子系统对外稳定门面。Stage 9 新增的后台入口只做委托：
+
+```text
+hasOccupyingBatch(definitionId)
+executeScheduled(definitionId, triggerToken)
+executePendingBackfill(batchId)
+```
+
+Batch runtime truth、claim/reservation、Link-Up submit、Retry/UNKNOWN/Cancel 等规则仍留在现有内部组件，不复制到 Facade。
+
+### Backfill command
+
+```text
+OfflineBackfillController
+  -> OfflineBackfillService
+```
+
+Backfill request 的 Scope 规范化、Snapshot 冻结、Batch materialization 和 Cursor 前置校验仍由 Backfill 子系统内部完成。
+
+## Removed cross-subsystem shortcuts
+
+### Schedule
+
+Stage 8 后：
+
+```text
+OfflineScheduleHandler
+  -> OfflineBatchRuntimeService
+  -> OfflineExecutionOrchestrator
+```
+
+Stage 9：
+
+```text
+OfflineScheduleHandler
+  -> OfflineJobExecutionService
+       -> OfflineBatchRuntimeService
+       -> OfflineExecutionOrchestrator
+```
+
+Schedule Handler 仍负责 schedule truth、trigger token 和 runtime fire-state 更新，但不再知道 execution 内部 Runtime / Orchestrator。
+
+### Backfill dispatcher
+
+Stage 8 后：
+
+```text
+OfflineBackfillDispatcher
+  -> OfflineBatchRuntimeService
+  -> OfflineExecutionOrchestrator
+```
+
+Stage 9：
+
+```text
+OfflineBackfillDispatcher
+  -> OfflineJobExecutionService
+       -> OfflineBatchRuntimeService
+       -> OfflineExecutionOrchestrator
+```
+
+Dispatcher 继续负责扫描 PENDING Backfill 和 Cursor readiness；execution slot 判断与 Attempt 提交通过 Facade 进入 execution 子系统。
+
+### Reconcile
+
+`OfflineExecutionReconciler` 在 Stage 8 已经通过 `OfflineJobExecutionService` 执行 `applySnapshot / markUnknown / retryFrom`，Stage 9 保留该边界，不做无意义改写。
+
+## Internal execution API
+
+下列类型继续是 execution 子系统内部专业角色，不作为跨子系统 Application API：
+
+```text
+OfflineExecutionOrchestrator
+OfflineExecutionClaimService
+OfflineBatchRuntimeService
+execution.query.*
+execution.adapter.*
+```
+
+它们可以被 `OfflineJobExecutionService` 以及确有业务职责的稳定 Facade 内部协调，但 Schedule / Dispatcher / Controller 等外部入口不得直接依赖。
+
+Stage 9 不通过 Java `package-private` 强行隐藏 Spring Bean，因为现有测试和后续 Stage 10/11 仍需要独立演进这些角色；本阶段用明确依赖规则和架构测试建立边界。
+
+## Architecture guardrails
+
+`OfflineSyncLayeringConventionTest` 增加三组规则：
+
+1. HTTP Controller 的业务依赖只能是三个稳定 Application Facade；
+2. Schedule Handler、Backfill Dispatcher、Execution Reconciler 进入 execution 时必须经过 `OfflineJobExecutionService`；
+3. 非 execution 内部源码不得随意 import Orchestrator / Claim / BatchRuntime / Query / Adapter。
+
+当前保留两个明确的 Facade 内部例外：
+
+```text
+OfflineJobDefinitionService
+OfflineBackfillService
+```
+
+它们本身是稳定 Application Facade，现阶段分别需要 Batch runtime guard 和 BatchScope execution validation。Stage 9 不为了消灭 import 制造 Definition <-> Execution 循环依赖。
+
+## Validation
+
+新增 `OfflineJobExecutionServiceEntryPointTest` 验证：
+
+- occupancy 查询只委托 Batch Runtime；
+- Schedule trigger token 原样传给 Orchestrator；
+- PENDING Backfill 提交只委托 Orchestrator；
+- Facade 不复制 execution 状态规则。
+
+`OfflineBackfillDispatcherTest` 同步改为验证 Dispatcher 只通过 execution Facade 触发运行。
+
+## Non-goals
+
+Stage 9 不做：
+
+- 不重命名 `OfflineExecutionOrchestrator / OfflineExecutionClaimService / OfflineBatchRuntimeService`；
+- 不拆 `OfflineExecutionOrchestrator`、Claim 或 Backfill 大类；
+- 不修改 REST 路径、DTO/VO；
+- 不修改数据库、Flyway；
+- 不改变 Task / Batch / Attempt / Cursor 运行语义；
+- 不改变 Retry / UNKNOWN / Cancel / Backfill / Schedule 业务规则；
+- 不引入新的通用 `ApplicationService`、`Facade` 接口层。
+
+## Next
+
+```text
+Stage 10 — Role Naming
+```
+
+Stage 10 再基于 Stage 7 的角色分类评估内部命名，例如：
+
+```text
+OfflineExecutionOrchestrator  -> OfflineExecutionCoordinator
+OfflineExecutionClaimService  -> OfflineExecutionClaimManager
+OfflineBatchRuntimeService    -> OfflineBatchRuntime
+```
+
+命名变化与 Stage 9 的调用边界收敛分开 Review。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -11,7 +11,8 @@
 - [REVIEW.md](./REVIEW.md) — Review 标准：按什么规则判卷
 - [Domain Mapping](../../../docs/offline-sync/domain/README.md) — Stage 6 Wave 0-6 历史迁移映射
 - [Architecture Responsibility Inventory](../../../docs/offline-sync/architecture/README.md) — Stage 7 职责盘点
-- [Stage 8 Package Restructuring](../../../docs/offline-sync/architecture/STAGE8.md) — 当前业务子系统目录
+- [Stage 8 Package Restructuring](../../../docs/offline-sync/architecture/STAGE8.md) — 业务子系统目录归位
+- [Stage 9 Application Entry Consolidation](../../../docs/offline-sync/architecture/STAGE9.md) — 当前 Application 入口边界
 
 ```text
 OfflineSyncTask
@@ -31,9 +32,9 @@ BatchExecution
 
 ## 架构职责治理
 
-**Stage 8 已完成：Package Restructuring。**
+**Stage 9 已完成：Application Entry Consolidation。**
 
-离线同步不再把不同角色平铺在一个 `service` 包中。当前生产目录按业务子系统组织：
+Stage 8 已经把生产代码从 `service` 大平层按业务子系统归位；Stage 9 在此基础上进一步固定“谁可以作为业务入口”。当前生产目录：
 
 ```text
 offline
@@ -62,7 +63,9 @@ OfflineJobExecutionService
 OfflineBackfillService
 ```
 
-其余 Coordinator / Runtime / Query / Dispatcher / Reconciler / Adapter / Mapper 均作为内部专业角色归入所属子系统。Stage 8 只改变 package/import，不改变业务语义；类级角色命名和核心大类拆分留给后续阶段。
+Controller 只通过这三个入口进入业务链。Schedule Handler、Backfill Dispatcher、Execution Reconciler 进入 execution 子系统时统一通过 `OfflineJobExecutionService`；不直接依赖 `OfflineExecutionOrchestrator`、`OfflineExecutionClaimService`、`OfflineBatchRuntimeService`、`execution.query.*` 或 `execution.adapter.*`。
+
+Facade 内部仍可以协调专业组件。Stage 9 不复制业务规则，不为了隐藏类制造额外接口层，也不提前做 Stage 10 的角色重命名。
 
 ## Link-Up 边界
 
@@ -84,21 +87,24 @@ Offline Job Definition
   -> OfflineScheduleEngineBridge
   -> Yak Schedule / Quartz
   -> OfflineScheduleHandler
+  -> OfflineJobExecutionService
   -> BatchExecution
   -> ExecutionAttempt
   -> Link-Up
 ```
 
-Yak Schedule 只负责“什么时候触发”。Task 是否已有运行占用、是否能创建新 Batch，只读取 Batch runtime truth。
+Yak Schedule 只负责“什么时候触发”。Task 是否已有运行占用、是否能创建新 Batch，只读取 Batch runtime truth；Schedule Handler 不再直接持有 Batch Runtime / Orchestrator。
 
-Link-Up 状态对账和失败重试由 `reconcile.OfflineExecutionReconciler` 负责；Wave 1 前 `batch_id = NULL` 的 execution 是只读历史，不参与 Reconcile / Retry / Cancel。
+Link-Up 状态对账和失败重试由 `reconcile.OfflineExecutionReconciler` 负责；Reconciler 通过 `OfflineJobExecutionService` 应用 execution 状态规则。Wave 1 前 `batch_id = NULL` 的 execution 是只读历史，不参与 Reconcile / Retry / Cancel。
 
 ## Backfill / Cursor
 
 ```text
 Backfill Request
+  -> OfflineBackfillService
   -> PENDING Batch group
-  -> dispatcher reservation
+  -> OfflineBackfillDispatcher
+  -> OfflineJobExecutionService
   -> Attempt 1
 ```
 
@@ -106,15 +112,19 @@ V1 同 Task 保持单 occupying Batch。Cursor 独立持久化 route + position 
 
 ## 工程依赖约束
 
-Stage 8 改变目录，不改变已有依赖边界：
+Stage 9 在 Stage 8 目录边界之上增加 Application Entry 护栏：
 
-- Controller 通过 Application Facade 进入业务链路，不直接依赖 Repository、DAO 或 Link-Up Client。
+- Controller 只依赖三个稳定 Application Facade，不直接依赖 Repository、DAO、Engine Client 或 execution 内部组件。
+- Schedule Handler / Backfill Dispatcher / Execution Reconciler 进入 execution 时只依赖 `OfflineJobExecutionService`。
+- Execution 内部 Coordinator / Claim / Runtime / Query / Adapter 不作为跨子系统公共 API。
 - Definition / Execution / Backfill 使用 Domain，不直接操作 MyBatis PO。
 - Repository 接口只暴露 Domain；PO 与 DAO 仅存在于持久化适配层。
 - Task runtime occupancy 只由 Batch Repository / Runtime 提供；Attempt Repository 不提供 `hasActiveExecution`。
 - 新 Attempt 创建时必须已经绑定 Batch；不提供 retroactive `bindBatch`。
 - Query 负责读取/展示，不承担 Batch/Attempt 状态命令。
 - Link-Up 协议对象不直接暴露为 HTTP Domain。
+
+这些边界由 `OfflineSyncLayeringConventionTest` 持续守护，避免后续新功能重新穿透 Application Facade。
 
 ## 数据表
 
@@ -129,8 +139,9 @@ Stage 8 改变目录，不改变已有依赖边界：
 ## Stage 状态
 
 ```text
-Stage 6  COMPLETE  Domain runtime contract
-Stage 7  COMPLETE  Service Responsibility Inventory
-Stage 8  COMPLETE  Package Restructuring
-Stage 9  NEXT      Application Entry Consolidation
+Stage 6   COMPLETE  Domain Runtime Contract
+Stage 7   COMPLETE  Service Responsibility Inventory
+Stage 8   COMPLETE  Package Restructuring
+Stage 9   COMPLETE  Application Entry Consolidation
+Stage 10  NEXT      Role Naming
 ```

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcher.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcher.java
@@ -6,8 +6,7 @@ import io.yak.ops.business.sync.offline.cursor.OfflineCursorService;
 import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchScope;
-import io.yak.ops.business.sync.offline.execution.OfflineBatchRuntimeService;
-import io.yak.ops.business.sync.offline.execution.OfflineExecutionOrchestrator;
+import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +20,34 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class OfflineBackfillDispatcher {
+
   private static final Logger LOG = LoggerFactory.getLogger(OfflineBackfillDispatcher.class);
+
   private final OfflineBatchExecutionRepository batchRepository;
-  private final OfflineBatchRuntimeService batchRuntimeService;
   private final OfflineCursorService cursorService;
-  private final OfflineExecutionOrchestrator orchestrator;
+  private final OfflineJobExecutionService executionService;
   private final OfflineSyncProperties properties;
-  @Scheduled(initialDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}", fixedDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}")
-  public void dispatch() { int limit = Math.max(1, properties.getControl().getScanBatchSize()); List<BatchExecution> pending = batchRepository.findPendingBackfills(limit); for (BatchExecution batch : pending) { try { if (batchRuntimeService.hasOccupyingBatch(batch.taskId())) continue; if (!cursorReady(batch)) continue; orchestrator.executePendingBackfill(batch.id()); } catch (RuntimeException exception) { LOG.warn("Offline backfill dispatch failed, batchId={}", batch.id(), exception); } } }
-  private boolean cursorReady(BatchExecution batch) { if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) return true; OfflineSyncCursor cursor = cursorService.find(batch.taskId(), range.cursorId()).orElse(null); return cursor != null && cursor.position().equals(range.afterExclusive()); }
+
+  @Scheduled(
+      initialDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}",
+      fixedDelayString = "${yak.sync.offline.control.reconcile-delay-millis:5000}")
+  public void dispatch() {
+    int limit = Math.max(1, properties.getControl().getScanBatchSize());
+    List<BatchExecution> pending = batchRepository.findPendingBackfills(limit);
+    for (BatchExecution batch : pending) {
+      try {
+        if (executionService.hasOccupyingBatch(batch.taskId())) continue;
+        if (!cursorReady(batch)) continue;
+        executionService.executePendingBackfill(batch.id());
+      } catch (RuntimeException exception) {
+        LOG.warn("Offline backfill dispatch failed, batchId={}", batch.id(), exception);
+      }
+    }
+  }
+
+  private boolean cursorReady(BatchExecution batch) {
+    if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) return true;
+    OfflineSyncCursor cursor = cursorService.find(batch.taskId(), range.cursorId()).orElse(null);
+    return cursor != null && cursor.position().equals(range.afterExclusive());
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
@@ -23,20 +23,166 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/** 离线同步执行门面。 */
-@ConditionalOnOfflineSyncEnabled @Service @RequiredArgsConstructor
+/** 离线同步执行门面；Controller、Schedule、Backfill Dispatcher、Reconciler 统一从这里进入 execution 子系统。 */
+@ConditionalOnOfflineSyncEnabled
+@Service
+@RequiredArgsConstructor
 public class OfflineJobExecutionService {
-  private final OfflineExecutionOrchestrator orchestrator;private final OfflineExecutionReadService readService;private final OfflineExecutionLogService logService;private final LinkUpClient linkUpClient;private final OfflineSyncViewMapper viewMapper;
-  public OfflineEngineHealthVO health(){return viewMapper.engineHealth(linkUpClient.node());}
-  public OfflineJobExecutionVO execute(Long id){return readService.toVO(orchestrator.execute(id,"MANUAL",null,1));}
-  public OfflineJobExecutionVO executeSnapshot(Long id,long version,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson){return executeSnapshot(id,version,configDigest,definitionSnapshotJson,logicalJobSpecJson,null);}
-  public OfflineJobExecutionVO executeSnapshot(Long id,long version,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson,String idempotencyKey){return readService.toVO(orchestrator.executeSnapshot(id,version,configDigest,definitionSnapshotJson,logicalJobSpecJson,idempotencyKey));}
-  public OfflineJobExecutionVO executeScheduled(Long id){return readService.toVO(orchestrator.execute(id,"SCHEDULE",null,1));}
-  public OfflineJobExecutionVO retry(Long id){return readService.toVO(orchestrator.retryFrom(readService.require(id)));}
-  public OfflineJobExecutionVO retryFrom(OfflineJobExecution previous){return readService.toVO(orchestrator.retryFrom(previous));}
-  public OfflineJobExecutionVO cancel(Long id){return readService.toVO(orchestrator.cancel(id));}
-  public OfflineJobExecutionVO cancelLatest(Long definitionId){return readService.toVO(orchestrator.cancelLatestBatch(definitionId));}
-  public OfflineBatchOperationVO batchExecute(OfflineBatchOperationDTO request){return batch(request,true);}public OfflineBatchOperationVO batchCancel(OfflineBatchOperationDTO request){return batch(request,false);}
-  public PagingData<OfflineJobExecutionVO> page(OfflineJobExecutionQueryDTO query){return readService.page(query);}public OfflineJobExecutionDetailVO detail(Long id){return readService.detail(id);}public JsonNode tableMetrics(Long id){return readService.tableMetrics(id);}public List<OfflineExecutionEventVO> events(Long id){return readService.events(id);}public String logs(Long id){return logService.text(readService.require(id));}public OfflineExecutionLogPageVO logs(Long id,String cursor,int limit){return logService.logs(readService.require(id),cursor,limit);}public void applySnapshot(OfflineJobExecution execution,LinkUpJobResponse response,String type){orchestrator.applySnapshot(execution,response,type);}public void markUnknown(OfflineJobExecution execution,String message){orchestrator.markUnknown(execution,message);}
-  private OfflineBatchOperationVO batch(OfflineBatchOperationDTO request,boolean execute){if(request==null||request.getJobDefinitionIds()==null||request.getJobDefinitionIds().isEmpty())throw new IllegalArgumentException("jobDefinitionIds 不能为空");int success=0;List<OfflineBatchOperationErrorVO> errors=new ArrayList<>();for(Long id:request.getJobDefinitionIds()){try{if(id==null||id<=0L)throw new IllegalArgumentException("任务定义 ID 不合法");if(execute)execute(id);else cancelLatest(id);success++;}catch(RuntimeException exception){errors.add(OfflineBatchOperationErrorVO.builder().jobDefinitionId(id).message(exception.getMessage()).build());}}return OfflineBatchOperationVO.builder().successCount(success).failedCount(errors.size()).errors(errors).build();}
+
+  private final OfflineExecutionOrchestrator orchestrator;
+  private final OfflineBatchRuntimeService batchRuntimeService;
+  private final OfflineExecutionReadService readService;
+  private final OfflineExecutionLogService logService;
+  private final LinkUpClient linkUpClient;
+  private final OfflineSyncViewMapper viewMapper;
+
+  public OfflineEngineHealthVO health() {
+    return viewMapper.engineHealth(linkUpClient.node());
+  }
+
+  public boolean hasOccupyingBatch(Long definitionId) {
+    return batchRuntimeService.hasOccupyingBatch(definitionId);
+  }
+
+  public OfflineJobExecutionVO execute(Long id) {
+    return readService.toVO(orchestrator.execute(id, "MANUAL", null, 1));
+  }
+
+  /** 工作流按发布时固定的任务版本快照执行。 */
+  public OfflineJobExecutionVO executeSnapshot(
+      Long id,
+      long version,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson) {
+    return executeSnapshot(
+        id,
+        version,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        null);
+  }
+
+  /** 工作流按发布快照和 Attempt 幂等键执行。 */
+  public OfflineJobExecutionVO executeSnapshot(
+      Long id,
+      long version,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      String idempotencyKey) {
+    return readService.toVO(
+        orchestrator.executeSnapshot(
+            id,
+            version,
+            configDigest,
+            definitionSnapshotJson,
+            logicalJobSpecJson,
+            idempotencyKey));
+  }
+
+  public OfflineJobExecutionVO executeScheduled(Long id) {
+    return executeScheduled(id, "SCHEDULE");
+  }
+
+  /** Schedule Handler 保留完整 trigger token，通过 Facade 进入 execution 子系统。 */
+  public OfflineJobExecutionVO executeScheduled(Long id, String triggerToken) {
+    return readService.toVO(orchestrator.execute(id, triggerToken, null, 1));
+  }
+
+  /** Backfill Dispatcher 只负责触发，不直接调用内部 Orchestrator。 */
+  public OfflineJobExecutionVO executePendingBackfill(Long batchId) {
+    return readService.toVO(orchestrator.executePendingBackfill(batchId));
+  }
+
+  public OfflineJobExecutionVO retry(Long id) {
+    return readService.toVO(orchestrator.retryFrom(readService.require(id)));
+  }
+
+  public OfflineJobExecutionVO retryFrom(OfflineJobExecution previous) {
+    return readService.toVO(orchestrator.retryFrom(previous));
+  }
+
+  public OfflineJobExecutionVO cancel(Long id) {
+    return readService.toVO(orchestrator.cancel(id));
+  }
+
+  /** Task 级停止只从 BatchExecution/latest Attempt 选择目标，不读取 Task.lastExecutionId。 */
+  public OfflineJobExecutionVO cancelLatest(Long definitionId) {
+    return readService.toVO(orchestrator.cancelLatestBatch(definitionId));
+  }
+
+  public OfflineBatchOperationVO batchExecute(OfflineBatchOperationDTO request) {
+    return batch(request, true);
+  }
+
+  public OfflineBatchOperationVO batchCancel(OfflineBatchOperationDTO request) {
+    return batch(request, false);
+  }
+
+  public PagingData<OfflineJobExecutionVO> page(OfflineJobExecutionQueryDTO query) {
+    return readService.page(query);
+  }
+
+  public OfflineJobExecutionDetailVO detail(Long id) {
+    return readService.detail(id);
+  }
+
+  public JsonNode tableMetrics(Long id) {
+    return readService.tableMetrics(id);
+  }
+
+  public List<OfflineExecutionEventVO> events(Long id) {
+    return readService.events(id);
+  }
+
+  /** 旧文本接口保留，并直接渲染新的统一时间线。 */
+  public String logs(Long id) {
+    return logService.text(readService.require(id));
+  }
+
+  public OfflineExecutionLogPageVO logs(Long id, String cursor, int limit) {
+    return logService.logs(readService.require(id), cursor, limit);
+  }
+
+  /** Reconciler 的状态同步入口；内部状态迁移仍由 Orchestrator 负责。 */
+  public void applySnapshot(OfflineJobExecution execution, LinkUpJobResponse response, String type) {
+    orchestrator.applySnapshot(execution, response, type);
+  }
+
+  /** Reconciler 的 UNKNOWN 收口入口。 */
+  public void markUnknown(OfflineJobExecution execution, String message) {
+    orchestrator.markUnknown(execution, message);
+  }
+
+  private OfflineBatchOperationVO batch(OfflineBatchOperationDTO request, boolean execute) {
+    if (request == null
+        || request.getJobDefinitionIds() == null
+        || request.getJobDefinitionIds().isEmpty()) {
+      throw new IllegalArgumentException("jobDefinitionIds 不能为空");
+    }
+
+    int success = 0;
+    List<OfflineBatchOperationErrorVO> errors = new ArrayList<>();
+    for (Long id : request.getJobDefinitionIds()) {
+      try {
+        if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法");
+        if (execute) execute(id); else cancelLatest(id);
+        success++;
+      } catch (RuntimeException exception) {
+        errors.add(
+            OfflineBatchOperationErrorVO.builder()
+                .jobDefinitionId(id)
+                .message(exception.getMessage())
+                .build());
+      }
+    }
+
+    return OfflineBatchOperationVO.builder()
+        .successCount(success)
+        .failedCount(errors.size())
+        .errors(errors)
+        .build();
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
@@ -1,9 +1,73 @@
 package io.yak.ops.business.sync.offline.schedule;
 
-import io.yak.framework.schedule.api.ScheduleExecutionContext;import io.yak.framework.schedule.api.ScheduleExecutionResult;import io.yak.framework.schedule.api.ScheduleHandler;import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;import io.yak.ops.business.sync.offline.domain.OfflineSchedule;import io.yak.ops.business.sync.offline.domain.compat.LegacyBatchTriggerCompatibilityMapper;import io.yak.ops.business.sync.offline.execution.OfflineBatchRuntimeService;import io.yak.ops.business.sync.offline.execution.OfflineExecutionOrchestrator;import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;import org.springframework.stereotype.Component;
-@ConditionalOnOfflineSyncEnabled @Component(OfflineScheduleEngineBridge.HANDLER)
+import io.yak.framework.schedule.api.ScheduleExecutionContext;
+import io.yak.framework.schedule.api.ScheduleExecutionResult;
+import io.yak.framework.schedule.api.ScheduleHandler;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.domain.compat.LegacyBatchTriggerCompatibilityMapper;
+import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnOfflineSyncEnabled
+@Component(OfflineScheduleEngineBridge.HANDLER)
 public class OfflineScheduleHandler implements ScheduleHandler {
-  private final OfflineJobDefinitionRepository definitionRepository;private final OfflineBatchRuntimeService batchRuntimeService;private final OfflineScheduleRepository scheduleRepository;private final OfflineExecutionOrchestrator orchestrator;private final OfflineScheduleEngineBridge engine;private final OfflineScheduleLifecycle lifecycle;
-  public OfflineScheduleHandler(OfflineJobDefinitionRepository definitionRepository,OfflineBatchRuntimeService batchRuntimeService,OfflineScheduleRepository scheduleRepository,OfflineExecutionOrchestrator orchestrator,OfflineScheduleEngineBridge engine,OfflineScheduleLifecycle lifecycle){this.definitionRepository=definitionRepository;this.batchRuntimeService=batchRuntimeService;this.scheduleRepository=scheduleRepository;this.orchestrator=orchestrator;this.engine=engine;this.lifecycle=lifecycle;}
-  @Override public ScheduleExecutionResult execute(ScheduleExecutionContext context){long definitionId=context.requiredLong("definitionId");OfflineJobDefinition definition=definitionRepository.findById(definitionId).orElse(null);if(definition==null){engine.deleteIfPresent(definitionId);return ScheduleExecutionResult.accepted(null,"离线同步任务已删除，清理残留调度计划");}OfflineSchedule schedule=scheduleRepository.findSchedule(definitionId);if(!"ONLINE".equalsIgnoreCase(definition.getReleaseState())||schedule==null||!schedule.enabled()){lifecycle.sync(definitionId);return ScheduleExecutionResult.accepted(null,"离线同步任务未启用调度，本次触发忽略");}if(batchRuntimeService.hasOccupyingBatch(definitionId)){lifecycle.refreshRuntimeState(definitionId,context.actualFireTime());return ScheduleExecutionResult.accepted(null,"任务已有运行中的 BatchExecution，本次调度触发跳过");}try{String triggerToken=LegacyBatchTriggerCompatibilityMapper.scheduleToken(context.key().value(),context.scheduledFireTime());OfflineJobExecution execution=orchestrator.execute(definitionId,triggerToken,null,1);return ScheduleExecutionResult.accepted(execution.getId()==null?null:String.valueOf(execution.getId()),"离线同步任务已提交 Link-Up 执行");}finally{lifecycle.refreshRuntimeState(definitionId,context.actualFireTime());}}
+
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineScheduleRepository scheduleRepository;
+  private final OfflineJobExecutionService executionService;
+  private final OfflineScheduleEngineBridge engine;
+  private final OfflineScheduleLifecycle lifecycle;
+
+  public OfflineScheduleHandler(
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineScheduleRepository scheduleRepository,
+      OfflineJobExecutionService executionService,
+      OfflineScheduleEngineBridge engine,
+      OfflineScheduleLifecycle lifecycle) {
+    this.definitionRepository = definitionRepository;
+    this.scheduleRepository = scheduleRepository;
+    this.executionService = executionService;
+    this.engine = engine;
+    this.lifecycle = lifecycle;
+  }
+
+  @Override
+  public ScheduleExecutionResult execute(ScheduleExecutionContext context) {
+    long definitionId = context.requiredLong("definitionId");
+    OfflineJobDefinition definition = definitionRepository.findById(definitionId).orElse(null);
+    if (definition == null) {
+      engine.deleteIfPresent(definitionId);
+      return ScheduleExecutionResult.accepted(null, "离线同步任务已删除，清理残留调度计划");
+    }
+
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
+    if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())
+        || schedule == null
+        || !schedule.enabled()) {
+      lifecycle.sync(definitionId);
+      return ScheduleExecutionResult.accepted(null, "离线同步任务未启用调度，本次触发忽略");
+    }
+
+    if (executionService.hasOccupyingBatch(definitionId)) {
+      lifecycle.refreshRuntimeState(definitionId, context.actualFireTime());
+      return ScheduleExecutionResult.accepted(null, "任务已有运行中的 BatchExecution，本次调度触发跳过");
+    }
+
+    try {
+      String triggerToken = LegacyBatchTriggerCompatibilityMapper.scheduleToken(
+          context.key().value(), context.scheduledFireTime());
+      OfflineJobExecutionVO execution =
+          executionService.executeScheduled(definitionId, triggerToken);
+      return ScheduleExecutionResult.accepted(
+          execution.getId() == null ? null : String.valueOf(execution.getId()),
+          "离线同步任务已提交 Link-Up 执行");
+    } finally {
+      lifecycle.refreshRuntimeState(definitionId, context.actualFireTime());
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baomidou.mybatisplus.annotation.TableName;
 import io.yak.framework.common.PageData;
+import io.yak.ops.business.sync.offline.backfill.OfflineBackfillController;
+import io.yak.ops.business.sync.offline.backfill.OfflineBackfillDispatcher;
+import io.yak.ops.business.sync.offline.backfill.OfflineBackfillService;
 import io.yak.ops.business.sync.offline.controller.OfflineControlPlaneController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobDefinitionController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobExecutionController;
@@ -11,8 +14,11 @@ import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionQuery;
+import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
+import io.yak.ops.business.sync.offline.reconcile.OfflineExecutionReconciler;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionControlRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
@@ -20,33 +26,101 @@ import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRe
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleHandler;
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 class OfflineSyncLayeringConventionTest {
 
+  private static final Set<String> EXECUTION_INTERNAL_IMPORTS = Set.of(
+      "io.yak.ops.business.sync.offline.execution.OfflineExecutionOrchestrator",
+      "io.yak.ops.business.sync.offline.execution.OfflineExecutionClaimService",
+      "io.yak.ops.business.sync.offline.execution.OfflineBatchRuntimeService",
+      "io.yak.ops.business.sync.offline.execution.query.",
+      "io.yak.ops.business.sync.offline.execution.adapter.");
+
+  private static final Set<String> EXECUTION_INTERNAL_FACADE_EXCEPTIONS = Set.of(
+      "definition/OfflineJobDefinitionService.java",
+      "backfill/OfflineBackfillService.java");
+
   @Test
-  void controllersDependOnServicesInsteadOfPersistenceOrEngineClients() {
+  void controllersDependOnlyOnStableApplicationFacades() {
+    Set<Class<?>> facades = Set.of(
+        OfflineJobDefinitionService.class,
+        OfflineJobExecutionService.class,
+        OfflineBackfillService.class);
+
     for (Class<?> type : List.of(
         OfflineJobDefinitionController.class,
         OfflineJobExecutionController.class,
-        OfflineControlPlaneController.class)) {
+        OfflineControlPlaneController.class,
+        OfflineBackfillController.class)) {
       for (Field field : type.getDeclaredFields()) {
-        String dependency = field.getType().getName();
-        assertThat(dependency)
-            .as("%s.%s must not bypass Service", type.getSimpleName(), field.getName())
-            .doesNotContain(".repository.")
-            .doesNotContain(".dao.")
-            .doesNotContain(".engine.");
+        assertThat(field.getType())
+            .as("%s.%s must depend on a stable Application Facade", type.getSimpleName(), field.getName())
+            .isIn(facades);
+      }
+    }
+  }
+
+  @Test
+  void backgroundEntrypointsReachExecutionThroughFacade() {
+    for (Class<?> type : List.of(
+        OfflineScheduleHandler.class,
+        OfflineBackfillDispatcher.class,
+        OfflineExecutionReconciler.class)) {
+      List<Class<?>> dependencies = Arrays.stream(type.getDeclaredFields())
+          .map(Field::getType)
+          .toList();
+
+      assertThat(dependencies)
+          .as("%s must enter execution through OfflineJobExecutionService", type.getSimpleName())
+          .contains(OfflineJobExecutionService.class);
+
+      for (Class<?> dependency : dependencies) {
+        String name = dependency.getName();
+        assertThat(name)
+            .as("%s must not depend on an execution internal component", type.getSimpleName())
+            .doesNotContain("OfflineExecutionOrchestrator")
+            .doesNotContain("OfflineExecutionClaimService")
+            .doesNotContain("OfflineBatchRuntimeService")
+            .doesNotContain(".execution.query.")
+            .doesNotContain(".execution.adapter.");
+      }
+    }
+  }
+
+  @Test
+  void nonFacadeProductionCodeDoesNotImportExecutionInternals() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> paths = Files.walk(root)) {
+      for (Path file : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = root.relativize(file).toString().replace('\\', '/');
+        if (relative.startsWith("execution/")
+            || EXECUTION_INTERNAL_FACADE_EXCEPTIONS.contains(relative)) {
+          continue;
+        }
+
+        String source = Files.readString(file);
+        for (String forbidden : EXECUTION_INTERNAL_IMPORTS) {
+          assertThat(source)
+              .as("%s must not import execution internal API %s", relative, forbidden)
+              .doesNotContain("import " + forbidden);
+        }
       }
     }
   }
@@ -115,6 +189,29 @@ class OfflineSyncLayeringConventionTest {
 
     Field batchId = OfflineJobExecutionPO.class.getDeclaredField("batchId");
     assertThat(batchId.getType()).isEqualTo(Long.class);
+  }
+
+  private Path productionRoot() {
+    Path moduleRoot = Path.of("src/main/java/io/yak/ops/business/sync/offline");
+    if (Files.isDirectory(moduleRoot)) return moduleRoot;
+
+    Path repositoryRoot = Path.of(
+        "yak-ops-business",
+        "yak-ops-business-sync",
+        "yak-ops-business-sync-offline",
+        "src",
+        "main",
+        "java",
+        "io",
+        "yak",
+        "ops",
+        "business",
+        "sync",
+        "offline");
+    assertThat(Files.isDirectory(repositoryRoot))
+        .as("offline-sync production source root must be available to architecture test")
+        .isTrue();
+    return repositoryRoot;
   }
 
   private void assertMethodsAvoid(Class<?> owner, String... forbidden) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
@@ -4,9 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baomidou.mybatisplus.annotation.TableName;
 import io.yak.framework.common.PageData;
-import io.yak.ops.business.sync.offline.backfill.OfflineBackfillController;
 import io.yak.ops.business.sync.offline.backfill.OfflineBackfillDispatcher;
 import io.yak.ops.business.sync.offline.backfill.OfflineBackfillService;
+import io.yak.ops.business.sync.offline.controller.OfflineBackfillController;
 import io.yak.ops.business.sync.offline.controller.OfflineControlPlaneController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobDefinitionController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobExecutionController;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcherTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcherTest.java
@@ -1,3 +1,85 @@
 package io.yak.ops.business.sync.offline.backfill;
-import static org.mockito.Mockito.never;import static org.mockito.Mockito.verify;import static org.mockito.Mockito.when;import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;import io.yak.ops.business.sync.offline.cursor.OfflineCursorService;import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;import io.yak.ops.business.sync.offline.domain.core.BatchExecution;import io.yak.ops.business.sync.offline.domain.core.BatchKey;import io.yak.ops.business.sync.offline.domain.core.BatchScope;import io.yak.ops.business.sync.offline.domain.core.BatchStatus;import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;import io.yak.ops.business.sync.offline.execution.OfflineBatchRuntimeService;import io.yak.ops.business.sync.offline.execution.OfflineExecutionOrchestrator;import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;import java.util.List;import java.util.Optional;import org.junit.jupiter.api.Test;import org.mockito.Mockito;
-class OfflineBackfillDispatcherTest {@Test void cursorRangeDispatchesOnlyWhenCursorMatchesAfterExclusive(){OfflineBatchExecutionRepository batches=Mockito.mock(OfflineBatchExecutionRepository.class);OfflineBatchRuntimeService runtime=Mockito.mock(OfflineBatchRuntimeService.class);OfflineCursorService cursors=Mockito.mock(OfflineCursorService.class);OfflineExecutionOrchestrator orchestrator=Mockito.mock(OfflineExecutionOrchestrator.class);OfflineBackfillDispatcher dispatcher=new OfflineBackfillDispatcher(batches,runtime,cursors,orchestrator,new OfflineSyncProperties());BatchExecution pending=pendingCursor("100","200");when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));when(runtime.hasOccupyingBatch(10L)).thenReturn(false);when(cursors.find(10L,"orders")).thenReturn(Optional.of(new OfflineSyncCursor(10L,"orders","updated_at","100",null,1L)));dispatcher.dispatch();verify(orchestrator).executePendingBackfill(77L);}@Test void nextCursorRangeStaysPendingUntilPredecessorAdvancesCursor(){OfflineBatchExecutionRepository batches=Mockito.mock(OfflineBatchExecutionRepository.class);OfflineBatchRuntimeService runtime=Mockito.mock(OfflineBatchRuntimeService.class);OfflineCursorService cursors=Mockito.mock(OfflineCursorService.class);OfflineExecutionOrchestrator orchestrator=Mockito.mock(OfflineExecutionOrchestrator.class);OfflineBackfillDispatcher dispatcher=new OfflineBackfillDispatcher(batches,runtime,cursors,orchestrator,new OfflineSyncProperties());BatchExecution pending=pendingCursor("200","300");when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));when(runtime.hasOccupyingBatch(10L)).thenReturn(false);when(cursors.find(10L,"orders")).thenReturn(Optional.of(new OfflineSyncCursor(10L,"orders","updated_at","100",null,1L)));dispatcher.dispatch();verify(orchestrator,never()).executePendingBackfill(77L);}private BatchExecution pendingCursor(String after,String through){BatchScope.CursorRange scope=BatchScope.cursorRange("orders",after,through);return new BatchExecution(77L,10L,BatchKey.backfill("bf",scope.fingerprint()),BatchTrigger.BACKFILL,scope,new ExecutionSnapshot("{}",1,new RetryPolicySnapshot(2,10),"digest","{\"kind\":\"BatchSyncJob\"}"),BatchStatus.PENDING,List.of());}}
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorService;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class OfflineBackfillDispatcherTest {
+
+  @Test
+  void cursorRangeDispatchesOnlyWhenCursorMatchesAfterExclusive() {
+    OfflineBatchExecutionRepository batches = Mockito.mock(OfflineBatchExecutionRepository.class);
+    OfflineCursorService cursors = Mockito.mock(OfflineCursorService.class);
+    OfflineJobExecutionService executionService = Mockito.mock(OfflineJobExecutionService.class);
+    OfflineBackfillDispatcher dispatcher =
+        new OfflineBackfillDispatcher(
+            batches, cursors, executionService, new OfflineSyncProperties());
+    BatchExecution pending = pendingCursor("100", "200");
+
+    when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));
+    when(executionService.hasOccupyingBatch(10L)).thenReturn(false);
+    when(cursors.find(10L, "orders"))
+        .thenReturn(
+            Optional.of(new OfflineSyncCursor(10L, "orders", "updated_at", "100", null, 1L)));
+
+    dispatcher.dispatch();
+
+    verify(executionService).executePendingBackfill(77L);
+  }
+
+  @Test
+  void nextCursorRangeStaysPendingUntilPredecessorAdvancesCursor() {
+    OfflineBatchExecutionRepository batches = Mockito.mock(OfflineBatchExecutionRepository.class);
+    OfflineCursorService cursors = Mockito.mock(OfflineCursorService.class);
+    OfflineJobExecutionService executionService = Mockito.mock(OfflineJobExecutionService.class);
+    OfflineBackfillDispatcher dispatcher =
+        new OfflineBackfillDispatcher(
+            batches, cursors, executionService, new OfflineSyncProperties());
+    BatchExecution pending = pendingCursor("200", "300");
+
+    when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));
+    when(executionService.hasOccupyingBatch(10L)).thenReturn(false);
+    when(cursors.find(10L, "orders"))
+        .thenReturn(
+            Optional.of(new OfflineSyncCursor(10L, "orders", "updated_at", "100", null, 1L)));
+
+    dispatcher.dispatch();
+
+    verify(executionService, never()).executePendingBackfill(77L);
+  }
+
+  private BatchExecution pendingCursor(String after, String through) {
+    BatchScope.CursorRange scope = BatchScope.cursorRange("orders", after, through);
+    return new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill("bf", scope.fingerprint()),
+        BatchTrigger.BACKFILL,
+        scope,
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(2, 10),
+            "digest",
+            "{\"kind\":\"BatchSyncJob\"}"),
+        BatchStatus.PENDING,
+        List.of());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionServiceEntryPointTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionServiceEntryPointTest.java
@@ -1,0 +1,86 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionLogService;
+import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionReadService;
+import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
+import org.junit.jupiter.api.Test;
+
+class OfflineJobExecutionServiceEntryPointTest {
+
+  @Test
+  void occupancyQueryDelegatesToBatchRuntimeTruth() {
+    Fixture fixture = fixture();
+    when(fixture.runtime.hasOccupyingBatch(10L)).thenReturn(true);
+
+    assertThat(fixture.service.hasOccupyingBatch(10L)).isTrue();
+
+    verify(fixture.runtime).hasOccupyingBatch(10L);
+  }
+
+  @Test
+  void scheduledExecutionPreservesScheduleTriggerToken() {
+    Fixture fixture = fixture();
+    String triggerToken = "SCHEDULE|schedule-10|2026-08-23T08:00:00";
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(21L);
+    OfflineJobExecutionVO view = mock(OfflineJobExecutionVO.class);
+
+    when(fixture.orchestrator.execute(10L, triggerToken, null, 1)).thenReturn(execution);
+    when(fixture.readService.toVO(execution)).thenReturn(view);
+
+    assertThat(fixture.service.executeScheduled(10L, triggerToken)).isSameAs(view);
+
+    verify(fixture.orchestrator).execute(10L, triggerToken, null, 1);
+    verify(fixture.readService).toVO(execution);
+  }
+
+  @Test
+  void pendingBackfillExecutionDelegatesToOrchestrator() {
+    Fixture fixture = fixture();
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(31L);
+    OfflineJobExecutionVO view = mock(OfflineJobExecutionVO.class);
+
+    when(fixture.orchestrator.executePendingBackfill(77L)).thenReturn(execution);
+    when(fixture.readService.toVO(execution)).thenReturn(view);
+
+    assertThat(fixture.service.executePendingBackfill(77L)).isSameAs(view);
+
+    verify(fixture.orchestrator).executePendingBackfill(77L);
+    verify(fixture.readService).toVO(execution);
+  }
+
+  private Fixture fixture() {
+    OfflineExecutionOrchestrator orchestrator = mock(OfflineExecutionOrchestrator.class);
+    OfflineBatchRuntimeService runtime = mock(OfflineBatchRuntimeService.class);
+    OfflineExecutionReadService readService = mock(OfflineExecutionReadService.class);
+    OfflineExecutionLogService logService = mock(OfflineExecutionLogService.class);
+    LinkUpClient linkUpClient = mock(LinkUpClient.class);
+    OfflineSyncViewMapper viewMapper = mock(OfflineSyncViewMapper.class);
+    return new Fixture(
+        new OfflineJobExecutionService(
+            orchestrator,
+            runtime,
+            readService,
+            logService,
+            linkUpClient,
+            viewMapper),
+        orchestrator,
+        runtime,
+        readService);
+  }
+
+  private record Fixture(
+      OfflineJobExecutionService service,
+      OfflineExecutionOrchestrator orchestrator,
+      OfflineBatchRuntimeService runtime,
+      OfflineExecutionReadService readService) {}
+}


### PR DESCRIPTION
## Summary

完成离线同步 **Stage 9 — Application Entry Consolidation**。

Stage 8 已经解决“类应该放在哪里”；Stage 9 进一步解决“谁可以调用谁”。本 PR 固定三个稳定 Application Facade，并收掉 Schedule / Backfill Dispatcher 对 execution 内部 Runtime / Orchestrator 的直接穿透。

```text
OfflineJobDefinitionService
OfflineJobExecutionService
OfflineBackfillService
```

本阶段不改变 Task / Batch / Attempt / Cursor 运行语义，不改 REST、数据库、Flyway，也不做内部类角色重命名或大类拆分。

## What changed

### 1. Execution Facade 补齐后台入口

`OfflineJobExecutionService` 新增窄入口：

```text
hasOccupyingBatch(definitionId)
executeScheduled(definitionId, triggerToken)
executePendingBackfill(batchId)
```

这些方法只做委托，不复制 Batch runtime、claim/reservation、Retry、UNKNOWN、Cancel 等内部规则。

### 2. Schedule Handler 不再穿透 execution internals

Before:

```text
OfflineScheduleHandler
  -> OfflineBatchRuntimeService
  -> OfflineExecutionOrchestrator
```

After:

```text
OfflineScheduleHandler
  -> OfflineJobExecutionService
```

Schedule trigger token 仍完整保留并传入 execution Facade，调度 fire-state/lifecycle 语义不变。

### 3. Backfill Dispatcher 不再穿透 execution internals

Before:

```text
OfflineBackfillDispatcher
  -> OfflineBatchRuntimeService
  -> OfflineExecutionOrchestrator
```

After:

```text
OfflineBackfillDispatcher
  -> OfflineJobExecutionService
```

PENDING Batch 扫描、Cursor readiness 和单 Task occupying slot 规则保持不变。

### 4. Reconciler 保持已有正确边界

`OfflineExecutionReconciler` 在 Stage 8 已经通过 `OfflineJobExecutionService` 执行 `applySnapshot / markUnknown / retryFrom`，Stage 9 不做无意义改写。

## Architecture guardrails

扩展 `OfflineSyncLayeringConventionTest`：

1. HTTP Controller 的业务依赖只能是三个稳定 Application Facade；
2. `OfflineScheduleHandler / OfflineBackfillDispatcher / OfflineExecutionReconciler` 进入 execution 时必须经过 `OfflineJobExecutionService`；
3. 非 execution 内部生产源码不得随意 import：
   - `OfflineExecutionOrchestrator`
   - `OfflineExecutionClaimService`
   - `OfflineBatchRuntimeService`
   - `execution.query.*`
   - `execution.adapter.*`

保留两个明确 Facade 内部例外：

```text
OfflineJobDefinitionService
OfflineBackfillService
```

它们当前分别需要 Batch runtime guard 和 BatchScope execution validation；Stage 9 不为了消灭 import 制造 Definition <-> Execution 循环依赖。

## Tests

- 新增 `OfflineJobExecutionServiceEntryPointTest`
  - occupancy query -> Batch Runtime
  - scheduled trigger token -> Orchestrator
  - pending Backfill -> Orchestrator
- 更新 `OfflineBackfillDispatcherTest`，验证 Dispatcher 只通过 execution Facade 触发运行；
- 更新 `OfflineSyncLayeringConventionTest`，把 Application Entry 规则变成持续架构护栏。

## Documentation

- 新增 `docs/offline-sync/architecture/STAGE9.md`
- 更新 offline-sync `README.md`
- Stage 状态更新为：

```text
Stage 8   COMPLETE  Package Restructuring
Stage 9   COMPLETE  Application Entry Consolidation
Stage 10  NEXT      Role Naming
```

## Non-goals

本 PR 不做：

- 不重命名 `Orchestrator / ClaimService / BatchRuntimeService`；
- 不拆 Execution / Claim / Backfill 大类；
- 不修改 REST path / DTO / VO；
- 不修改 DB / Flyway；
- 不改变 Retry / UNKNOWN / Cancel / Backfill / Schedule 语义；
- 不引入新的通用 ApplicationService / Facade 接口层。

这些角色命名变化留给 **Stage 10 — Role Naming**，大类职责拆分继续留给后续阶段。

## Scope safety

当前分支基于最新 `main`，compare 为 `ahead 9 / behind 0`；diff 仅包含 offline-sync Stage 9 文档、Facade 路由、架构测试和对应回归测试。