### PR TITLE
refactor(offline-sync): complete Stage 11 responsibility decomposition

### DIFF
--- a/docs/offline-sync/architecture/STAGE11.md
+++ b/docs/offline-sync/architecture/STAGE11.md
@@ -1,0 +1,261 @@
+# Offline Sync Stage 11 — Core Responsibility Decomposition
+
+## Goal
+
+Stage 11 在 Stage 8-10 已经稳定的目录、入口和角色命名之上，开始拆真正的职责热点。
+
+目标不是让类变得越小越好，而是让每个核心组件只有一个主要变化原因：
+
+```text
+ExecutionCoordinator      -> 流程协调
+ExecutionStateManager     -> 状态应用 / Event / Retry / Task projection
+ExecutionClaimManager     -> 新 Batch admission
+ExistingBatchClaimManager -> 已有 Batch continuation admission
+ExecutionAttemptFactory   -> frozen Batch -> Attempt persistence model
+BackfillService           -> Application command + Batch materialization
+BackfillPlanner           -> Scope / Cursor / Snapshot / execution-scope planning
+```
+
+Stage 11 不改变 Task / Batch / Attempt / Cursor 领域语义，不改变 REST、数据库或 Link-Up 协议。
+
+## 1. Execution Coordinator
+
+### Before
+
+`OfflineExecutionCoordinator` 同时承担：
+
+- claim；
+- scoped JobSpec；
+- Link-Up submit/cancel；
+- Attempt 状态迁移；
+- metrics 映射；
+- retry window 计算；
+- Event 记录；
+- Task last-* projection；
+- UNKNOWN / terminal state application。
+
+因此一个引擎流程类同时知道 Definition Repository、Execution Event Repository、RetryPolicy 和 Task projection。
+
+### After
+
+```text
+OfflineExecutionCoordinator
+  -> OfflineExecutionClaimManager
+  -> OfflineBatchScopeExecutionAdapter
+  -> LinkUpClient
+  -> OfflineExecutionStateManager
+```
+
+Coordinator 只决定流程顺序：
+
+```text
+claim
+ -> resolve scoped JobSpec
+ -> probe Link-Up
+ -> submit/cancel
+ -> delegate state application
+```
+
+`OfflineExecutionStateManager` 独立负责：
+
+- CREATED/SUBMITTING/FAILED/UNKNOWN 状态应用；
+- Link-Up snapshot -> Attempt metrics；
+- frozen RetryPolicy -> nextRetryTime；
+- Attempt Event；
+- Task last-* 查询投影；
+- late Attempt 不覆盖 latest Attempt projection。
+
+这样引擎流程变化和状态规则变化不再修改同一个类。
+
+## 2. Claim decomposition
+
+### Stable distinction
+
+Stage 11 不再按 MANUAL / WORKFLOW / RETRY / BACKFILL 把所有 claim 规则塞进一个 Manager，而是按是否创建新 Batch 分界：
+
+```text
+OfflineExecutionClaimManager
+  = new Batch + Attempt 1
+
+OfflineExistingBatchClaimManager
+  = existing Batch -> new Attempt
+```
+
+### New Batch admission
+
+`OfflineExecutionClaimManager` 继续负责：
+
+- Manual / Schedule 初始运行；
+- Workflow snapshot/idempotency；
+- BatchKey；
+- frozen ExecutionSnapshot；
+- Batch insert；
+- Attempt 1 insert。
+
+### Existing Batch continuation
+
+`OfflineExistingBatchClaimManager` 负责：
+
+- Retry 来源 Attempt 校验；
+- UNKNOWN 禁止盲重试；
+- latest Attempt 校验；
+- frozen maxAttempts；
+- retry CAS reservation；
+- PENDING Backfill reservation；
+- existing Batch -> next Attempt。
+
+Retry 和 PENDING Backfill 放在同一组件，不是因为触发来源相同，而是因为二者共享同一个稳定边界：**已有 Batch 上创建 Attempt，不能创建新 Batch。**
+
+### Attempt factory
+
+`OfflineExecutionAttemptFactory` 统一负责：
+
+```text
+BatchExecution.snapshot
+ + attemptNo
+ + triggerType
+ + retryFromExecutionId
+ + idempotencyKey
+ -> OfflineJobExecution persistence Attempt
+```
+
+避免 Initial / Retry / Backfill 三条路径分别复制 persistence model 构造规则。
+
+`OfflineExecutionClaim` 是 claim 阶段向 Coordinator 交付的值对象，不是新的业务 Service。
+
+## 3. Backfill decomposition
+
+### Before
+
+`OfflineBackfillService` 同时承担：
+
+- Request 校验；
+- Scope normalization；
+- Cursor range continuity；
+- Cursor route initialization；
+- existing Backfill reuse；
+- shared Snapshot；
+- RetryPolicy freeze；
+- BatchScope -> JobSpec validation；
+- Batch materialization。
+
+### After
+
+```text
+OfflineBackfillService
+  -> lock Task
+  -> require Definition
+  -> OfflineBackfillPlanner
+  -> materialize PENDING Batch group
+```
+
+`OfflineBackfillPlanner` 负责：
+
+- Request / Scope normalization；
+- existing Batch lookup + idempotent reuse；
+- shared ExecutionSnapshot；
+- Cursor continuity / route；
+- execution-scope validation。
+
+`OfflineBackfillService` 保持 Application Service 身份，只负责事务入口与 Batch group 持久化。
+
+## 4. Public boundary remains unchanged
+
+Stage 9 的 Application Entry 继续成立：
+
+```text
+Controller
+  -> OfflineJobDefinitionService
+  -> OfflineJobExecutionService
+  -> OfflineBackfillService
+```
+
+Schedule Handler / Backfill Dispatcher / Reconciler 仍然只通过 `OfflineJobExecutionService` 进入 execution。
+
+Stage 11 新增的：
+
+```text
+OfflineExecutionStateManager
+OfflineExistingBatchClaimManager
+OfflineExecutionAttemptFactory
+OfflineBackfillPlanner
+```
+
+全部是内部组件，不是新的跨模块 API。
+
+## 5. Runtime invariants preserved
+
+Stage 11 必须继续满足：
+
+- `Task != Batch != Attempt`；
+- Retry 只在原 Batch 内创建新 Attempt；
+- UNKNOWN 不能自动 Retry；
+- terminal Batch 不能追加 Attempt；
+- Task occupancy 只读 Batch runtime truth；
+- Backfill 物化 Batch group，不创建新 Task；
+- Cursor 只在对应 Batch `SUCCEEDED` 后 CAS 推进；
+- Task last-* 只是 projection；
+- batchless legacy execution 只读；
+- Snapshot 不保存运行时数据源凭据。
+
+## 6. Test responsibility alignment
+
+Stage 11 同步调整测试结构：
+
+```text
+OfflineExecutionCoordinatorTest
+  -> 流程委托 / scope / engine boundary
+
+OfflineExecutionStateManagerTest
+  -> Retry / UNKNOWN / Event / Task projection
+
+OfflineExecutionClaimManagerTest
+  -> new Batch admission / workflow idempotency
+
+OfflineExistingBatchClaimManagerTest
+  -> Retry / pending Backfill continuation admission
+
+OfflineExecutionAttemptFactoryTest
+  -> frozen Batch -> Attempt fields
+
+OfflineBackfillServiceTest
+  -> Batch group materialization
+
+OfflineBackfillPlannerTest
+  -> Scope / Cursor / Snapshot / execution validation
+```
+
+测试边界与生产职责保持一致，避免一个大测试类再次成为所有运行规则的集合。
+
+## 7. Architecture guardrails
+
+`OfflineSyncLayeringConventionTest` 增加 Stage 11 约束：
+
+- Coordinator 必须通过 `OfflineExecutionStateManager` 应用状态；
+- Coordinator 不再持有 Definition Repository / Event Repository；
+- ClaimManager 必须组合 `OfflineExistingBatchClaimManager + OfflineExecutionAttemptFactory`；
+- BackfillService 必须组合 `OfflineBackfillPlanner`；
+- BackfillService 不再直接持有 CursorManager / ScheduleRepository / ScopeExecutionAdapter；
+- 新拆出的组件保持内部 `@Component`，不能升级成新的 Application Service；
+- Stage 9 Application Entry 规则继续生效。
+
+## 8. Non-goals
+
+Stage 11 不做：
+
+- 不修改 REST path / DTO / VO；
+- 不修改 Repository / DAO / PO contract；
+- 不修改 Flyway / DB；
+- 不修改 Link-Up API；
+- 不重新设计 Batch/Attempt 状态机；
+- 不引入 `CommonService / HelperService / Utils`；
+- 不为了继续降低 LOC 再机械拆 StateManager / Planner；
+- 不在本阶段移动 persistence/domain package。
+
+## Next
+
+```text
+Stage 12 — Dependency Boundary Governance
+```
+
+Stage 12 在当前职责稳定后，进一步固定 definition / execution / backfill / cursor / schedule / engine / persistence 之间允许的依赖方向。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -13,7 +13,8 @@
 - [Architecture Responsibility Inventory](../../../docs/offline-sync/architecture/README.md) — Stage 7 职责盘点
 - [Stage 8 Package Restructuring](../../../docs/offline-sync/architecture/STAGE8.md) — 业务子系统目录归位
 - [Stage 9 Application Entry Consolidation](../../../docs/offline-sync/architecture/STAGE9.md) — Application 入口边界
-- [Stage 10 Role Naming](../../../docs/offline-sync/architecture/STAGE10.md) — 当前角色命名约定
+- [Stage 10 Role Naming](../../../docs/offline-sync/architecture/STAGE10.md) — 角色命名约定
+- [Stage 11 Core Responsibility Decomposition](../../../docs/offline-sync/architecture/STAGE11.md) — 当前核心职责拆分
 
 ```text
 OfflineSyncTask
@@ -33,30 +34,11 @@ BatchExecution
 
 ## 架构职责治理
 
-**Stage 10 已完成：Role Naming。**
+**Stage 11 已完成：Core Responsibility Decomposition。**
 
-Stage 8 解决“类放在哪里”，Stage 9 解决“谁可以调用谁”，Stage 10 进一步让类名直接表达运行角色。当前生产目录继续按业务子系统组织：
+Stage 8 解决“类放在哪里”，Stage 9 解决“谁可以调用谁”，Stage 10 解决“类名是什么角色”，Stage 11 开始把核心热点按独立变化原因真正拆开。
 
-```text
-offline
-├── controller
-├── definition
-├── execution
-│   ├── query
-│   └── adapter
-├── backfill
-├── cursor
-├── schedule
-├── reconcile
-├── mapping
-├── domain
-├── engine
-├── repository
-├── dao
-└── config
-```
-
-三个稳定 Application Facade 保留 `Service`：
+三个稳定 Application Facade 继续保留：
 
 ```text
 OfflineJobDefinitionService
@@ -64,18 +46,22 @@ OfflineJobExecutionService
 OfflineBackfillService
 ```
 
-execution 内部角色使用明确名称：
+内部专业角色：
 
 ```text
-OfflineExecutionCoordinator   # 流程协调
-OfflineExecutionClaimManager  # Batch/Attempt claim + reservation
-OfflineBatchRuntime           # Batch runtime truth
-OfflineExecutionQuery         # execution read model
-OfflineExecutionLogQuery      # unified log query
-OfflineCursorManager          # cursor route + CAS advancement
+OfflineExecutionCoordinator          # 执行流程协调
+OfflineExecutionClaimManager         # 新 Batch admission
+OfflineExistingBatchClaimManager     # 已有 Batch -> Retry / Backfill Attempt
+OfflineExecutionAttemptFactory       # frozen Batch -> persistence Attempt
+OfflineExecutionStateManager         # 状态 / Retry / Event / Task projection
+OfflineBatchRuntime                  # Batch runtime truth
+OfflineExecutionQuery                # execution read model
+OfflineExecutionLogQuery             # unified log query
+OfflineCursorManager                 # cursor route + CAS advancement
+OfflineBackfillPlanner               # Scope / Cursor / Snapshot planning
 ```
 
-`Service` 表达稳定 Application 入口；`Coordinator / Manager / Runtime / Query / Dispatcher / Reconciler / Adapter / Mapper` 表达内部专业角色。内部 Coordinator / Manager / Runtime 使用 `@Component`，不再用 `@Service` 混淆 Application Service 语义。
+`@Service` 仍只表达稳定 Application 入口；内部 Coordinator / Manager / Runtime / Query / Planner / Factory 使用 `@Component`。
 
 ## Application Entry
 
@@ -87,9 +73,7 @@ Controller
    `-> OfflineBackfillService
 ```
 
-Schedule Handler、Backfill Dispatcher、Execution Reconciler 进入 execution 子系统时统一通过 `OfflineJobExecutionService`，不直接依赖 execution 内部角色。
-
-Facade 内部可以协调专业组件；Stage 10 只改变角色命名，不复制业务规则，也不改变 Stage 9 的入口边界。
+Schedule Handler、Backfill Dispatcher、Execution Reconciler 进入 execution 子系统时仍然统一通过 `OfflineJobExecutionService`，不会直接穿透内部组件。
 
 ## Execution 内部链路
 
@@ -98,16 +82,48 @@ OfflineJobExecutionService
         |
         +-> OfflineExecutionCoordinator
         |       |
-        |       `-> OfflineExecutionClaimManager
-        |               |
-        |               `-> OfflineBatchRuntime
+        |       +-> OfflineExecutionClaimManager
+        |       |       |
+        |       |       +-> OfflineExecutionAttemptFactory
+        |       |       `-> OfflineExistingBatchClaimManager
+        |       |
+        |       +-> OfflineBatchScopeExecutionAdapter
+        |       +-> LinkUpClient
+        |       `-> OfflineExecutionStateManager
         |
         +-> OfflineExecutionQuery
         +-> OfflineExecutionLogQuery
         `-> OfflineBatchRuntime
 ```
 
-`OfflineExecutionCoordinator` 仍负责 Attempt 提交、取消、状态落库和执行流程协调；真正的大类职责拆分留给 Stage 11。
+职责边界：
+
+- `OfflineExecutionCoordinator` 只决定 claim -> scoped JobSpec -> engine -> state application 的流程顺序；
+- `OfflineExecutionStateManager` 负责 Attempt 状态、metrics、Retry window、Event、Task last-* projection；
+- `OfflineExecutionClaimManager` 负责创建新 Batch；
+- `OfflineExistingBatchClaimManager` 负责 Retry / PENDING Backfill 在已有 Batch 上创建 Attempt；
+- `OfflineExecutionAttemptFactory` 统一构造 persistence Attempt。
+
+## Backfill / Cursor
+
+```text
+Backfill Request
+  -> OfflineBackfillService
+  -> OfflineBackfillPlanner
+       -> Scope normalize
+       -> existing Batch reuse
+       -> shared ExecutionSnapshot
+       -> Cursor validation
+       -> execution-scope validation
+  -> PENDING Batch group materialization
+  -> OfflineBackfillDispatcher
+  -> OfflineJobExecutionService
+  -> Attempt 1
+```
+
+`OfflineBackfillService` 只负责 Application command、Task lock 和 Batch materialization；规划逻辑集中在 `OfflineBackfillPlanner`。
+
+`OfflineCursorManager` 管理 Cursor route + position + stateVersion，只在对应 `CursorRange` Batch `SUCCEEDED` 后由 `OfflineBatchRuntime` 触发 CAS 推进。
 
 ## Link-Up 边界
 
@@ -139,34 +155,21 @@ Yak Schedule 只负责“什么时候触发”。Task 是否已有运行占用�
 
 Link-Up 状态对账和失败重试由 `reconcile.OfflineExecutionReconciler` 负责；Reconciler 通过 `OfflineJobExecutionService` 应用 execution 状态规则。Wave 1 前 `batch_id = NULL` 的 execution 是只读历史，不参与 Reconcile / Retry / Cancel。
 
-## Backfill / Cursor
-
-```text
-Backfill Request
-  -> OfflineBackfillService
-  -> PENDING Batch group
-  -> OfflineBackfillDispatcher
-  -> OfflineJobExecutionService
-  -> OfflineExecutionCoordinator
-  -> Attempt 1
-```
-
-`OfflineCursorManager` 管理 Cursor route + position + stateVersion，只在对应 `CursorRange` Batch `SUCCEEDED` 后由 `OfflineBatchRuntime` 触发 CAS 推进。
-
 ## 工程依赖约束
 
-Stage 10 在 Stage 9 Application Entry 护栏之上增加角色命名约束：
+当前架构护栏要求：
 
-- Controller 只依赖三个稳定 Application Facade，不直接依赖 Repository、DAO、Engine Client 或 execution 内部组件。
-- Schedule Handler / Backfill Dispatcher / Execution Reconciler 进入 execution 时只依赖 `OfflineJobExecutionService`。
-- `OfflineExecutionCoordinator / OfflineExecutionClaimManager / OfflineBatchRuntime / execution.query.* / execution.adapter.*` 不作为跨子系统公共 API。
-- `@Service` 保留给三个 Application Facade；内部角色使用 `@Component`。
-- 生产源码不重新使用 Stage 10 已淘汰的旧角色名。
-- Definition / Execution / Backfill 使用 Domain，不直接操作 MyBatis PO。
-- Repository 接口只暴露 Domain；PO 与 DAO 仅存在于持久化适配层。
-- Task runtime occupancy 只由 Batch Repository / Runtime 提供；Attempt Repository 不提供 `hasActiveExecution`。
-- 新 Attempt 创建时必须已经绑定 Batch；不提供 retroactive `bindBatch`。
-- Query 负责读取/展示，不承担 Batch/Attempt 状态命令。
+- Controller 只依赖三个稳定 Application Facade；
+- Schedule Handler / Backfill Dispatcher / Execution Reconciler 进入 execution 时只依赖 `OfflineJobExecutionService`；
+- execution 内部角色不作为跨子系统公共 API；
+- `OfflineExecutionCoordinator` 必须通过 `OfflineExecutionStateManager` 应用状态，不直接持有 Definition/Event Repository；
+- `OfflineExecutionClaimManager` 组合 `OfflineExistingBatchClaimManager + OfflineExecutionAttemptFactory`；
+- `OfflineBackfillService` 组合 `OfflineBackfillPlanner`，不直接持有 CursorManager / ScheduleRepository / ScopeExecutionAdapter；
+- `@Service` 保留给三个 Application Facade；内部角色使用 `@Component`；
+- Definition / Execution / Backfill 使用 Domain，不直接操作 MyBatis PO；
+- Repository 接口只暴露 Domain；PO 与 DAO 仅存在于持久化适配层；
+- Task runtime occupancy 只由 Batch Repository / Runtime 提供；
+- Query 只负责读取/展示，不承担 Batch/Attempt 状态命令；
 - Link-Up 协议对象不直接暴露为 HTTP Domain。
 
 这些边界由 `OfflineSyncLayeringConventionTest` 持续守护。
@@ -189,5 +192,6 @@ Stage 7   COMPLETE  Service Responsibility Inventory
 Stage 8   COMPLETE  Package Restructuring
 Stage 9   COMPLETE  Application Entry Consolidation
 Stage 10  COMPLETE  Role Naming
-Stage 11  NEXT      Core Responsibility Decomposition
+Stage 11  COMPLETE  Core Responsibility Decomposition
+Stage 12  NEXT      Dependency Boundary Governance
 ```

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlanner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlanner.java
@@ -1,0 +1,253 @@
+package io.yak.ops.business.sync.offline.backfill;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillScopeDTO;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Backfill 的 Scope、Cursor、Snapshot 与执行边界规划，不负责 Batch 持久化。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@RequiredArgsConstructor
+public class OfflineBackfillPlanner {
+
+  private static final Pattern SAFE_IDENTIFIER =
+      Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
+
+  private final OfflineJobDefinitionService definitionService;
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineScheduleRepository scheduleRepository;
+  private final OfflineCursorManager cursorManager;
+  private final OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+  private final OfflineSyncProperties properties;
+
+  public PreparedRequest prepare(OfflineBackfillRequestDTO request) {
+    if (request == null) throw new IllegalArgumentException("Backfill request 不能为空");
+    String requestId = requireText(request.getRequestId(), "requestId 不能为空");
+    if (request.getScopes() == null || request.getScopes().isEmpty()) {
+      throw new IllegalArgumentException("scopes 不能为空");
+    }
+    return new PreparedRequest(requestId, List.copyOf(request.getScopes()));
+  }
+
+  public Plan plan(long taskId, OfflineJobDefinition definition, PreparedRequest request) {
+    List<ScopePlan> scopes = normalizeScopes(request.scopes());
+    Map<String, BatchExecution> existingByFingerprint = new LinkedHashMap<>();
+    boolean hasMissing = false;
+
+    for (ScopePlan plan : scopes) {
+      BatchKey key = BatchKey.backfill(request.requestId(), plan.scope().fingerprint());
+      BatchExecution existing = batchRepository.findByTaskIdAndBatchKey(taskId, key).orElse(null);
+      if (existing == null) {
+        hasMissing = true;
+      } else {
+        validateExisting(existing, plan.scope());
+        existingByFingerprint.put(plan.scope().fingerprint(), existing);
+      }
+    }
+
+    if (hasMissing && !"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
+      throw new IllegalStateException("请先上线任务，再创建新的 Backfill Batch");
+    }
+
+    ExecutionSnapshot sharedSnapshot =
+        sharedSnapshot(existingByFingerprint.values().stream().toList());
+    if (sharedSnapshot == null) sharedSnapshot = freezeSnapshot(definition);
+
+    validateCursorPlans(taskId, scopes, existingByFingerprint, hasMissing);
+    validateExecutionScopes(taskId, scopes, sharedSnapshot.logicalJobSpec());
+    return new Plan(
+        request.requestId(),
+        scopes,
+        Collections.unmodifiableMap(new LinkedHashMap<>(existingByFingerprint)),
+        sharedSnapshot);
+  }
+
+  private List<ScopePlan> normalizeScopes(List<OfflineBackfillScopeDTO> values) {
+    LinkedHashMap<String, ScopePlan> unique = new LinkedHashMap<>();
+    for (OfflineBackfillScopeDTO value : values) {
+      if (value == null) throw new IllegalArgumentException("scope 不能为空");
+      String type = requireText(value.getType(), "scope.type 不能为空").toUpperCase(Locale.ROOT);
+      ScopePlan plan = switch (type) {
+        case "FULL_SELECTION" -> new ScopePlan(BatchScope.fullSelection(), null);
+        case "DATA_WINDOW" -> {
+          if (value.getStartInclusive() == null || value.getEndExclusive() == null) {
+            throw new IllegalArgumentException("DATA_WINDOW 需要 startInclusive / endExclusive");
+          }
+          yield new ScopePlan(
+              BatchScope.dataWindow(value.getStartInclusive(), value.getEndExclusive()), null);
+        }
+        case "PARTITION_SCOPE", "PARTITIONS" -> {
+          if (value.getPartitions() == null || value.getPartitions().isEmpty()) {
+            throw new IllegalArgumentException("PARTITION_SCOPE 需要 partitions");
+          }
+          yield new ScopePlan(BatchScope.partitions(value.getPartitions()), null);
+        }
+        case "CURSOR_RANGE" -> {
+          String cursorId = requireText(value.getCursorId(), "CURSOR_RANGE cursorId 不能为空");
+          String sourceColumn =
+              safeColumn(requireText(value.getCursorColumn(), "CURSOR_RANGE cursorColumn 不能为空"));
+          yield new ScopePlan(
+              BatchScope.cursorRange(
+                  cursorId,
+                  requireText(value.getAfterExclusive(), "CURSOR_RANGE afterExclusive 不能为空"),
+                  requireText(value.getThroughInclusive(), "CURSOR_RANGE throughInclusive 不能为空")),
+              sourceColumn);
+        }
+        default -> throw new IllegalArgumentException("未知 Backfill scope.type：" + type);
+      };
+
+      String fingerprint = plan.scope().fingerprint();
+      ScopePlan duplicate = unique.get(fingerprint);
+      if (duplicate != null && !Objects.equals(duplicate.cursorColumn(), plan.cursorColumn())) {
+        throw new IllegalArgumentException("相同 BatchScope 不能绑定不同 cursorColumn");
+      }
+      unique.putIfAbsent(fingerprint, plan);
+    }
+    return List.copyOf(unique.values());
+  }
+
+  private void validateCursorPlans(
+      long taskId,
+      List<ScopePlan> plans,
+      Map<String, BatchExecution> existingByFingerprint,
+      boolean hasMissing) {
+    Map<String, List<ScopePlan>> byCursor = new LinkedHashMap<>();
+    for (ScopePlan plan : plans) {
+      if (plan.scope() instanceof BatchScope.CursorRange range) {
+        byCursor.computeIfAbsent(range.cursorId(), ignored -> new ArrayList<>()).add(plan);
+      }
+    }
+
+    for (Map.Entry<String, List<ScopePlan>> entry : byCursor.entrySet()) {
+      List<ScopePlan> cursorPlans = entry.getValue();
+      BatchScope.CursorRange first = (BatchScope.CursorRange) cursorPlans.get(0).scope();
+      String sourceColumn = cursorPlans.get(0).cursorColumn();
+      for (int index = 1; index < cursorPlans.size(); index++) {
+        ScopePlan previousPlan = cursorPlans.get(index - 1);
+        ScopePlan currentPlan = cursorPlans.get(index);
+        BatchScope.CursorRange previous = (BatchScope.CursorRange) previousPlan.scope();
+        BatchScope.CursorRange current = (BatchScope.CursorRange) currentPlan.scope();
+        if (!Objects.equals(sourceColumn, currentPlan.cursorColumn())) {
+          throw new IllegalArgumentException(
+              "同一个 cursorId 不能绑定多个 sourceColumn：" + entry.getKey());
+        }
+        if (!previous.throughInclusive().equals(current.afterExclusive())) {
+          throw new IllegalArgumentException("同一 Cursor 的 Backfill ranges 必须连续：" + entry.getKey());
+        }
+      }
+
+      OfflineSyncCursor existingCursor = cursorManager.find(taskId, entry.getKey()).orElse(null);
+      if (existingCursor != null
+          && hasMissing
+          && !existingCursor.position().equals(first.afterExclusive())) {
+        boolean allCursorBatchesAlreadyExist = cursorPlans.stream()
+            .allMatch(plan -> existingByFingerprint.containsKey(plan.scope().fingerprint()));
+        if (!allCursorBatchesAlreadyExist) {
+          throw new IllegalStateException(
+              "Cursor 已离开本 Backfill 起点，禁止追加会改变 Cursor 顺序的新 Batch：" + entry.getKey());
+        }
+      }
+      cursorManager.initializeIfAbsent(
+          taskId, entry.getKey(), sourceColumn, first.afterExclusive());
+    }
+  }
+
+  private void validateExecutionScopes(
+      long taskId,
+      List<ScopePlan> plans,
+      String logicalJobSpec) {
+    for (ScopePlan plan : plans) {
+      scopeExecutionAdapter.apply(taskId, logicalJobSpec, plan.scope());
+    }
+  }
+
+  private ExecutionSnapshot sharedSnapshot(List<BatchExecution> existing) {
+    if (existing.isEmpty()) return null;
+    ExecutionSnapshot snapshot = existing.get(0).snapshot();
+    for (BatchExecution batch : existing) {
+      if (!snapshot.equals(batch.snapshot())) {
+        throw new IllegalStateException("同一 Backfill request 已存在不一致的 ExecutionSnapshot");
+      }
+    }
+    return snapshot;
+  }
+
+  private ExecutionSnapshot freezeSnapshot(OfflineJobDefinition definition) {
+    String logicalJobSpec = definitionService.resolveLogicalJobSpec(definition);
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definition.getId());
+    int maxAttempts = schedule == null
+        ? properties.getControl().getDefaultMaxAttempts()
+        : schedule.retryMaxAttempts();
+    int backoff = schedule == null
+        ? properties.getControl().getDefaultRetryBackoffSeconds()
+        : schedule.retryBackoffSeconds();
+    return new ExecutionSnapshot(
+        requireText(definition.getDefinitionJson(), "definitionSnapshot 不能为空"),
+        Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
+        new RetryPolicySnapshot(Math.max(1, maxAttempts), Math.max(0, backoff)),
+        requireText(definition.getConfigDigest(), "configDigest 不能为空"),
+        logicalJobSpec);
+  }
+
+  private void validateExisting(BatchExecution batch, BatchScope scope) {
+    if (batch.trigger() != BatchTrigger.BACKFILL) {
+      throw new IllegalStateException("Backfill BatchKey 已被非 BACKFILL Batch 占用");
+    }
+    if (!batch.batchScope().fingerprint().equals(scope.fingerprint())) {
+      throw new IllegalStateException("Backfill BatchKey 与 BatchScope 不一致");
+    }
+  }
+
+  private String safeColumn(String value) {
+    if (!SAFE_IDENTIFIER.matcher(value).matches()) {
+      throw new IllegalArgumentException("cursorColumn 不是安全标识符：" + value);
+    }
+    return value;
+  }
+
+  private String requireText(String value, String message) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  public record PreparedRequest(String requestId, List<OfflineBackfillScopeDTO> scopes) {}
+
+  public record ScopePlan(BatchScope scope, String cursorColumn) {}
+
+  public record Plan(
+      String requestId,
+      List<ScopePlan> scopes,
+      Map<String, BatchExecution> existingByFingerprint,
+      ExecutionSnapshot snapshot) {
+
+    public BatchExecution existing(ScopePlan scope) {
+      return existingByFingerprint.get(scope.scope().fingerprint());
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillService.java
@@ -1,96 +1,78 @@
 package io.yak.ops.business.sync.offline.backfill;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
 import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
-import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
-import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchKey;
-import io.yak.ops.business.sync.offline.domain.core.BatchScope;
 import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
 import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
-import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
-import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
-import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
-import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillScopeDTO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
-/** Wave 5 Backfill command：一次请求物化一组共享 Snapshot 的 BatchExecution。 */
+/** Backfill Application Service：锁定 Task，并按 Planner 结果物化 PENDING Batch group。 */
 @ConditionalOnOfflineSyncEnabled
 @Service
 @RequiredArgsConstructor
 public class OfflineBackfillService {
-  private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
+
   private final OfflineJobDefinitionService definitionService;
   private final OfflineJobDefinitionRepository definitionRepository;
   private final OfflineBatchExecutionRepository batchRepository;
-  private final OfflineScheduleRepository scheduleRepository;
-  private final OfflineCursorManager cursorManager;
-  private final OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
-  private final OfflineSyncProperties properties;
+  private final OfflineBackfillPlanner planner;
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public OfflineBackfillVO submit(Long taskId, OfflineBackfillRequestDTO request) {
-    long id = positive(taskId, "TaskId"); if (request == null) throw new IllegalArgumentException("Backfill request 不能为空");
-    String requestId = requireText(request.getRequestId(), "requestId 不能为空"); if (request.getScopes() == null || request.getScopes().isEmpty()) throw new IllegalArgumentException("scopes 不能为空");
-    definitionRepository.lock(id); OfflineJobDefinition definition = definitionService.require(id);
-    List<ScopePlan> plans = normalizeScopes(request.getScopes()); Map<String, BatchExecution> existingByFingerprint = new LinkedHashMap<>(); boolean hasMissing = false;
-    for (ScopePlan plan : plans) { BatchKey key = BatchKey.backfill(requestId, plan.scope().fingerprint()); BatchExecution existing = batchRepository.findByTaskIdAndBatchKey(id, key).orElse(null); if (existing == null) hasMissing = true; else { validateExisting(existing, plan.scope()); existingByFingerprint.put(plan.scope().fingerprint(), existing); } }
-    if (hasMissing && !"ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("请先上线任务，再创建新的 Backfill Batch");
-    ExecutionSnapshot sharedSnapshot = sharedSnapshot(existingByFingerprint.values().stream().toList()); if (sharedSnapshot == null) sharedSnapshot = freezeSnapshot(definition);
-    validateCursorPlans(id, plans, existingByFingerprint, hasMissing); validateExecutionScopes(id, plans, sharedSnapshot.logicalJobSpec());
-    List<Long> batchIds = new ArrayList<>(); int created = 0; int reused = 0;
-    for (ScopePlan plan : plans) { BatchExecution existing = existingByFingerprint.get(plan.scope().fingerprint()); if (existing != null) { batchIds.add(existing.id()); reused++; continue; } BatchExecution saved = batchRepository.insert(new BatchExecution(null, id, BatchKey.backfill(requestId, plan.scope().fingerprint()), BatchTrigger.BACKFILL, plan.scope(), sharedSnapshot, BatchStatus.PENDING, List.of())); batchIds.add(saved.id()); created++; }
-    return OfflineBackfillVO.builder().jobDefinitionId(id).requestId(requestId).batchIds(List.copyOf(batchIds)).createdCount(created).reusedCount(reused).build();
+    long id = positive(taskId, "TaskId");
+    OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
+
+    definitionRepository.lock(id);
+    OfflineJobDefinition definition = definitionService.require(id);
+    OfflineBackfillPlanner.Plan plan = planner.plan(id, definition, prepared);
+
+    List<Long> batchIds = new ArrayList<>();
+    int created = 0;
+    int reused = 0;
+    for (OfflineBackfillPlanner.ScopePlan scopePlan : plan.scopes()) {
+      BatchExecution existing = plan.existing(scopePlan);
+      if (existing != null) {
+        batchIds.add(existing.id());
+        reused++;
+        continue;
+      }
+
+      BatchExecution saved = batchRepository.insert(
+          new BatchExecution(
+              null,
+              id,
+              BatchKey.backfill(plan.requestId(), scopePlan.scope().fingerprint()),
+              BatchTrigger.BACKFILL,
+              scopePlan.scope(),
+              plan.snapshot(),
+              BatchStatus.PENDING,
+              List.of()));
+      batchIds.add(saved.id());
+      created++;
+    }
+
+    return OfflineBackfillVO.builder()
+        .jobDefinitionId(id)
+        .requestId(plan.requestId())
+        .batchIds(List.copyOf(batchIds))
+        .createdCount(created)
+        .reusedCount(reused)
+        .build();
   }
 
-  private List<ScopePlan> normalizeScopes(List<OfflineBackfillScopeDTO> values) {
-    LinkedHashMap<String, ScopePlan> unique = new LinkedHashMap<>();
-    for (OfflineBackfillScopeDTO value : values) { if (value == null) throw new IllegalArgumentException("scope 不能为空"); String type = requireText(value.getType(), "scope.type 不能为空").toUpperCase(Locale.ROOT);
-      ScopePlan plan = switch (type) {
-        case "FULL_SELECTION" -> new ScopePlan(BatchScope.fullSelection(), null);
-        case "DATA_WINDOW" -> { if (value.getStartInclusive() == null || value.getEndExclusive() == null) throw new IllegalArgumentException("DATA_WINDOW 需要 startInclusive / endExclusive"); yield new ScopePlan(BatchScope.dataWindow(value.getStartInclusive(), value.getEndExclusive()), null); }
-        case "PARTITION_SCOPE", "PARTITIONS" -> { if (value.getPartitions() == null || value.getPartitions().isEmpty()) throw new IllegalArgumentException("PARTITION_SCOPE 需要 partitions"); yield new ScopePlan(BatchScope.partitions(value.getPartitions()), null); }
-        case "CURSOR_RANGE" -> { String cursorId = requireText(value.getCursorId(), "CURSOR_RANGE cursorId 不能为空"); String sourceColumn = safeColumn(requireText(value.getCursorColumn(), "CURSOR_RANGE cursorColumn 不能为空")); yield new ScopePlan(BatchScope.cursorRange(cursorId, requireText(value.getAfterExclusive(), "CURSOR_RANGE afterExclusive 不能为空"), requireText(value.getThroughInclusive(), "CURSOR_RANGE throughInclusive 不能为空")), sourceColumn); }
-        default -> throw new IllegalArgumentException("未知 Backfill scope.type：" + type);
-      };
-      String fingerprint = plan.scope().fingerprint(); ScopePlan duplicate = unique.get(fingerprint); if (duplicate != null && !Objects.equals(duplicate.cursorColumn(), plan.cursorColumn())) throw new IllegalArgumentException("相同 BatchScope 不能绑定不同 cursorColumn"); unique.putIfAbsent(fingerprint, plan);
-    }
-    return List.copyOf(unique.values());
+  private long positive(Long value, String field) {
+    if (value == null || value <= 0L) throw new IllegalArgumentException(field + " 必须大于 0");
+    return value;
   }
-
-  private void validateCursorPlans(long taskId, List<ScopePlan> plans, Map<String, BatchExecution> existingByFingerprint, boolean hasMissing) {
-    Map<String, List<ScopePlan>> byCursor = new LinkedHashMap<>(); for (ScopePlan plan : plans) if (plan.scope() instanceof BatchScope.CursorRange range) byCursor.computeIfAbsent(range.cursorId(), ignored -> new ArrayList<>()).add(plan);
-    for (Map.Entry<String, List<ScopePlan>> entry : byCursor.entrySet()) { List<ScopePlan> cursorPlans = entry.getValue(); BatchScope.CursorRange first = (BatchScope.CursorRange) cursorPlans.get(0).scope(); String sourceColumn = cursorPlans.get(0).cursorColumn();
-      for (int index = 1; index < cursorPlans.size(); index++) { ScopePlan previousPlan = cursorPlans.get(index - 1); ScopePlan currentPlan = cursorPlans.get(index); BatchScope.CursorRange previous = (BatchScope.CursorRange) previousPlan.scope(); BatchScope.CursorRange current = (BatchScope.CursorRange) currentPlan.scope(); if (!Objects.equals(sourceColumn, currentPlan.cursorColumn())) throw new IllegalArgumentException("同一个 cursorId 不能绑定多个 sourceColumn：" + entry.getKey()); if (!previous.throughInclusive().equals(current.afterExclusive())) throw new IllegalArgumentException("同一 Cursor 的 Backfill ranges 必须连续：" + entry.getKey()); }
-      OfflineSyncCursor existingCursor = cursorManager.find(taskId, entry.getKey()).orElse(null); if (existingCursor != null && hasMissing && !existingCursor.position().equals(first.afterExclusive())) { boolean allCursorBatchesAlreadyExist = cursorPlans.stream().allMatch(plan -> existingByFingerprint.containsKey(plan.scope().fingerprint())); if (!allCursorBatchesAlreadyExist) throw new IllegalStateException("Cursor 已离开本 Backfill 起点，禁止追加会改变 Cursor 顺序的新 Batch：" + entry.getKey()); }
-      cursorManager.initializeIfAbsent(taskId, entry.getKey(), sourceColumn, first.afterExclusive());
-    }
-  }
-  private void validateExecutionScopes(long taskId, List<ScopePlan> plans, String logicalJobSpec) { for (ScopePlan plan : plans) scopeExecutionAdapter.apply(taskId, logicalJobSpec, plan.scope()); }
-  private ExecutionSnapshot sharedSnapshot(List<BatchExecution> existing) { if (existing.isEmpty()) return null; ExecutionSnapshot snapshot = existing.get(0).snapshot(); for (BatchExecution batch : existing) if (!snapshot.equals(batch.snapshot())) throw new IllegalStateException("同一 Backfill request 已存在不一致的 ExecutionSnapshot"); return snapshot; }
-  private ExecutionSnapshot freezeSnapshot(OfflineJobDefinition definition) { String logicalJobSpec = definitionService.resolveLogicalJobSpec(definition); OfflineSchedule schedule = scheduleRepository.findSchedule(definition.getId()); int maxAttempts = schedule == null ? properties.getControl().getDefaultMaxAttempts() : schedule.retryMaxAttempts(); int backoff = schedule == null ? properties.getControl().getDefaultRetryBackoffSeconds() : schedule.retryBackoffSeconds(); return new ExecutionSnapshot(requireText(definition.getDefinitionJson(), "definitionSnapshot 不能为空"), Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()), new RetryPolicySnapshot(Math.max(1, maxAttempts), Math.max(0, backoff)), requireText(definition.getConfigDigest(), "configDigest 不能为空"), logicalJobSpec); }
-  private void validateExisting(BatchExecution batch, BatchScope scope) { if (batch.trigger() != BatchTrigger.BACKFILL) throw new IllegalStateException("Backfill BatchKey 已被非 BACKFILL Batch 占用"); if (!batch.batchScope().fingerprint().equals(scope.fingerprint())) throw new IllegalStateException("Backfill BatchKey 与 BatchScope 不一致"); }
-  private String safeColumn(String value) { if (!SAFE_IDENTIFIER.matcher(value).matches()) throw new IllegalArgumentException("cursorColumn 不是安全标识符：" + value); return value; }
-  private long positive(Long value, String field) { if (value == null || value <= 0L) throw new IllegalArgumentException(field + " 必须大于 0"); return value; }
-  private String requireText(String value, String message) { if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message); return value.trim(); }
-  private record ScopePlan(BatchScope scope, String cursorColumn) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionAttemptFactory.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionAttemptFactory.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 将冻结 Batch 物化为一次新的 persistence Attempt。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@RequiredArgsConstructor
+public class OfflineExecutionAttemptFactory {
+
+  private final OfflineSyncProperties properties;
+
+  public OfflineJobExecution create(
+      BatchExecution batch,
+      int attemptNo,
+      String triggerType,
+      Long retryFromExecutionId,
+      String idempotencyKey) {
+    LocalDateTime now = LocalDateTime.now();
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setJobDefinitionId(batch.taskId());
+    execution.setBatchId(batch.id());
+    execution.setDefinitionVersion(batch.snapshot().definitionRevision());
+    execution.setEngineBaseUrl(properties.getEngine().getBaseUrl());
+    execution.setExternalExecutionId("yak-offline-" + UUID.randomUUID());
+    execution.setIdempotencyKey(requireText(idempotencyKey, "idempotencyKey 不能为空"));
+    execution.setStatus(OfflineExecutionStatus.CREATED.name());
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(Math.max(1, attemptNo));
+    execution.setTriggerType(requireText(triggerType, "triggerType 不能为空"));
+    execution.setRetryFromExecutionId(retryFromExecutionId);
+    execution.setCancellationRequested(false);
+    execution.setRetryCreated(false);
+    execution.setConfigDigest(batch.snapshot().configDigest());
+    execution.setDefinitionSnapshotJson(batch.snapshot().definitionSnapshot());
+    execution.setSubmittedConfig(batch.snapshot().logicalJobSpec());
+    execution.setSourceRecordCount(0L);
+    execution.setSinkSuccessRecordCount(0L);
+    execution.setSourceReadBytes(0L);
+    execution.setSinkWrittenBytes(0L);
+    execution.setQps(0D);
+    execution.setDurationMillis(0L);
+    execution.setCreateTime(now);
+    execution.setUpdateTime(now);
+    return execution;
+  }
+
+  private String requireText(String value, String message) {
+    if (!StringUtils.hasText(value)) throw new IllegalStateException(message);
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaim.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaim.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+
+/** Claim 阶段冻结后交给 Coordinator 的执行证据。 */
+public final class OfflineExecutionClaim {
+
+  private final OfflineJobDefinition definition;
+  private final String logicalJobSpecJson;
+  private final OfflineJobExecution execution;
+  private final boolean reused;
+
+  public OfflineExecutionClaim(
+      OfflineJobDefinition definition,
+      String logicalJobSpecJson,
+      OfflineJobExecution execution) {
+    this(definition, logicalJobSpecJson, execution, false);
+  }
+
+  public OfflineExecutionClaim(
+      OfflineJobDefinition definition,
+      String logicalJobSpecJson,
+      OfflineJobExecution execution,
+      boolean reused) {
+    this.definition = definition;
+    this.logicalJobSpecJson = logicalJobSpecJson;
+    this.execution = execution;
+    this.reused = reused;
+  }
+
+  public OfflineJobDefinition getDefinition() {
+    return definition;
+  }
+
+  public String getLogicalJobSpecJson() {
+    return logicalJobSpecJson;
+  }
+
+  public OfflineJobExecution getExecution() {
+    return execution;
+  }
+
+  public boolean isReused() {
+    return reused;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManager.java
@@ -3,7 +3,6 @@ package io.yak.ops.business.sync.offline.execution;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
 import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
-import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
@@ -20,8 +19,6 @@ import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionReposito
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
-import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -29,10 +26,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-/** 固定 Link-Up 地址下原子创建 ExecutionAttempt。 */
+/** 新 Batch admission：Manual / Schedule / Workflow Snapshot 创建 Batch + Attempt 1。 */
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineExecutionClaimManager {
+
   private final OfflineJobDefinitionService definitionService;
   private final OfflineJobDefinitionRepository definitionRepository;
   private final OfflineJobExecutionRepository executionRepository;
@@ -40,49 +38,262 @@ public class OfflineExecutionClaimManager {
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineBatchRuntime batchRuntime;
   private final OfflineSyncProperties properties;
-  public OfflineExecutionClaimManager(OfflineJobDefinitionService definitionService, OfflineJobDefinitionRepository definitionRepository, OfflineJobExecutionRepository executionRepository, OfflineBatchExecutionRepository batchRepository, OfflineScheduleRepository scheduleRepository, OfflineBatchRuntime batchRuntime, OfflineSyncProperties properties) { this.definitionService=definitionService; this.definitionRepository=definitionRepository; this.executionRepository=executionRepository; this.batchRepository=batchRepository; this.scheduleRepository=scheduleRepository; this.batchRuntime=batchRuntime; this.properties=properties; }
+  private final OfflineExecutionAttemptFactory attemptFactory;
+  private final OfflineExistingBatchClaimManager existingBatchClaimManager;
 
-  @Transactional(transactionManager="offlineSyncTransactionManager", rollbackFor=Exception.class)
-  public ClaimResult claim(Long definitionId,String triggerType,Long retryFromExecutionId,int attemptNo) {
-    Mapping trigger=LegacyBatchTriggerCompatibilityMapper.parse(triggerType); if(retryFromExecutionId!=null||attemptNo>1||"RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) throw new IllegalArgumentException("Retry 必须通过 Batch 内 claimRetry 创建新 Attempt");
-    definitionRepository.lock(definitionId); OfflineJobDefinition definition=definitionService.require(definitionId); if(!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("请先上线任务，再执行运行操作");
-    return createInitialClaim(definition,Math.max(1,definition.getVersion()==null?1:definition.getVersion()),definition.getConfigDigest(),definition.getDefinitionJson(),definitionService.resolveLogicalJobSpec(definition),trigger,null);
+  public OfflineExecutionClaimManager(
+      OfflineJobDefinitionService definitionService,
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineJobExecutionRepository executionRepository,
+      OfflineBatchExecutionRepository batchRepository,
+      OfflineScheduleRepository scheduleRepository,
+      OfflineBatchRuntime batchRuntime,
+      OfflineSyncProperties properties,
+      OfflineExecutionAttemptFactory attemptFactory,
+      OfflineExistingBatchClaimManager existingBatchClaimManager) {
+    this.definitionService = definitionService;
+    this.definitionRepository = definitionRepository;
+    this.executionRepository = executionRepository;
+    this.batchRepository = batchRepository;
+    this.scheduleRepository = scheduleRepository;
+    this.batchRuntime = batchRuntime;
+    this.properties = properties;
+    this.attemptFactory = attemptFactory;
+    this.existingBatchClaimManager = existingBatchClaimManager;
   }
 
-  @Transactional(transactionManager="offlineSyncTransactionManager", rollbackFor=Exception.class)
-  public ClaimResult claimSnapshot(Long definitionId,long definitionVersion,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson,String triggerType){return claimSnapshot(definitionId,definitionVersion,configDigest,definitionSnapshotJson,logicalJobSpecJson,triggerType,null);}
-  @Transactional(transactionManager="offlineSyncTransactionManager", rollbackFor=Exception.class)
-  public ClaimResult claimSnapshot(Long definitionId,long definitionVersion,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson,String triggerType,String idempotencyKey){
-    if(!StringUtils.hasText(logicalJobSpecJson)) throw new IllegalArgumentException("任务版本快照缺少 JobSpec"); Mapping trigger=LegacyBatchTriggerCompatibilityMapper.parse(triggerType); if("RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) throw new IllegalArgumentException("Retry 不能通过 claimSnapshot 创建新 Batch");
-    definitionRepository.lock(definitionId); OfflineJobDefinition current=definitionService.require(definitionId); String normalizedKey=StringUtils.hasText(idempotencyKey)?idempotencyKey.trim():null;
-    if(normalizedKey!=null){OfflineJobExecution existing=executionRepository.findByIdempotencyKey(normalizedKey).orElse(null); if(existing!=null){BatchExecution existingBatch=validateIdempotentReuse(existing,definitionId,definitionVersion,configDigest,definitionSnapshotJson,logicalJobSpecJson); return new ClaimResult(current,existingBatch.snapshot().logicalJobSpec(),existing,true);}}
-    return createInitialClaim(current,Math.max(1L,definitionVersion),configDigest,definitionSnapshotJson,logicalJobSpecJson,trigger,normalizedKey);
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineExecutionClaim claim(
+      Long definitionId,
+      String triggerType,
+      Long retryFromExecutionId,
+      int attemptNo) {
+    Mapping trigger = LegacyBatchTriggerCompatibilityMapper.parse(triggerType);
+    if (retryFromExecutionId != null
+        || attemptNo > 1
+        || "RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) {
+      throw new IllegalArgumentException("Retry 必须通过 Batch 内 claimRetry 创建新 Attempt");
+    }
+
+    definitionRepository.lock(definitionId);
+    OfflineJobDefinition definition = definitionService.require(definitionId);
+    if (!"ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
+      throw new IllegalStateException("请先上线任务，再执行运行操作");
+    }
+    return createInitialClaim(
+        definition,
+        Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
+        definition.getConfigDigest(),
+        definition.getDefinitionJson(),
+        definitionService.resolveLogicalJobSpec(definition),
+        trigger,
+        null);
   }
 
-  @Transactional(transactionManager="offlineSyncTransactionManager", rollbackFor=Exception.class)
-  public ClaimResult claimRetry(Long retryFromExecutionId){
-    if(retryFromExecutionId==null||retryFromExecutionId<=0L) throw new IllegalArgumentException("重试来源实例不能为空"); OfflineJobExecution previous=executionRepository.findById(retryFromExecutionId).orElseThrow(()->new IllegalArgumentException("重试来源实例不存在："+retryFromExecutionId)); Long batchId=previous.getBatchId(); if(batchId==null||batchId<=0L) throw new IllegalStateException("旧执行实例未绑定 Batch，仅支持历史查询，不能按领域规则 Retry");
-    BatchExecution batch=batchRepository.findById(batchId).orElseThrow(()->new IllegalStateException("Retry 所属 BatchExecution 不存在："+batchId)); if(!Objects.equals(previous.getJobDefinitionId(),batch.taskId())) throw new IllegalStateException("Retry 来源 Attempt 与 Batch 的 Task 不一致"); if(batch.status().isTerminal()) throw new IllegalStateException("Batch 已进入终态，不能追加 Retry Attempt");
-    OfflineExecutionStatus previousStatus=parseStatus(previous.getStatus()); if(previousStatus==OfflineExecutionStatus.UNKNOWN) throw new IllegalStateException("执行结果为 UNKNOWN，必须先 reconcile，禁止盲目 Retry"); if(previousStatus!=OfflineExecutionStatus.FAILED) throw new IllegalStateException("只有明确 FAILED 的 Attempt 才能 Retry");
-    List<OfflineJobExecution> attempts=executionRepository.findByBatchId(batchId); if(attempts.isEmpty()) throw new IllegalStateException("Batch 缺少 Attempt 历史，不能 Retry"); int previousAttemptNo=positive(previous.getAttemptNo(),"attemptNo"); int nextAttemptNo=previousAttemptNo+1;
-    OfflineJobExecution existingNext=attempts.stream().filter(attempt->value(attempt.getAttemptNo(),1)==nextAttemptNo).filter(attempt->Objects.equals(attempt.getRetryFromExecutionId(),previous.getId())).findFirst().orElse(null); if(existingNext!=null){batchRuntime.refreshBatch(batchId); return new ClaimResult(null,batch.snapshot().logicalJobSpec(),existingNext,true);}
-    OfflineJobExecution latest=attempts.stream().max(Comparator.comparingInt((OfflineJobExecution attempt)->value(attempt.getAttemptNo(),1)).thenComparingLong(attempt->value(attempt.getId(),0L))).orElseThrow(()->new IllegalStateException("Batch 缺少最新 Attempt")); if(!Objects.equals(latest.getId(),previous.getId())) throw new IllegalStateException("只能从 Batch 最新 Attempt 创建 Retry");
-    RetryPolicySnapshot retryPolicy=batch.snapshot().retryPolicy(); if(nextAttemptNo>retryPolicy.maxAttempts()) throw new IllegalStateException("Retry 已达到 Batch 冻结的最大 Attempt 数"); if(!executionRepository.reserveRetry(previous.getId())) throw new IllegalStateException("Retry 已被其他请求保留或已经创建");
-    OfflineJobExecution execution=newAttempt(batch,nextAttemptNo,"RETRY",previous.getId(),retryIdempotencyKey(batch.id(),nextAttemptNo)); if(!executionRepository.insert(execution)||execution.getId()==null) throw new IllegalStateException("创建 Retry Attempt 失败"); batchRuntime.refreshBatch(batchId); return new ClaimResult(null,batch.snapshot().logicalJobSpec(),execution,false);
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineExecutionClaim claimSnapshot(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      String triggerType) {
+    return claimSnapshot(
+        definitionId,
+        definitionVersion,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        triggerType,
+        null);
   }
 
-  @Transactional(transactionManager="offlineSyncTransactionManager", rollbackFor=Exception.class)
-  public ClaimResult claimPendingBackfill(Long batchId){
-    if(batchId==null||batchId<=0L) throw new IllegalArgumentException("BatchExecutionId 必须大于 0"); BatchExecution initial=batchRepository.findById(batchId).orElseThrow(()->new IllegalArgumentException("Backfill BatchExecution 不存在："+batchId)); if(initial.trigger()!=BatchTrigger.BACKFILL) throw new IllegalStateException("只有 BACKFILL Batch 可以通过 pending dispatcher 创建 Attempt 1");
-    definitionRepository.lock(initial.taskId()); BatchExecution batch=batchRepository.findById(batchId).orElseThrow(()->new IllegalStateException("Backfill BatchExecution 已不存在："+batchId)); List<OfflineJobExecution> existingAttempts=executionRepository.findByBatchId(batchId); OfflineJobExecution existingInitial=existingAttempts.stream().filter(attempt->value(attempt.getAttemptNo(),1)==1).findFirst().orElse(null); if(existingInitial!=null){batchRuntime.refreshBatch(batchId); return new ClaimResult(null,batch.snapshot().logicalJobSpec(),existingInitial,true);} if(batch.status()!=BatchStatus.PENDING) throw new IllegalStateException("Backfill Batch 已不处于 PENDING："+batch.status()); if(batchRuntime.hasOccupyingBatch(batch.taskId())) throw new IllegalStateException("Task 已有 occupying Batch，Backfill 保持排队"); if(!batchRepository.reservePendingBackfill(batchId)) throw new IllegalStateException("Backfill Batch 已被其他 dispatcher reservation");
-    OfflineJobExecution execution=newAttempt(batch,1,"BACKFILL",null,"offline-backfill:"+batchId+":1"); if(!executionRepository.insert(execution)||execution.getId()==null) throw new IllegalStateException("创建 Backfill Attempt 1 失败"); batchRuntime.refreshBatch(batchId); return new ClaimResult(null,batch.snapshot().logicalJobSpec(),execution,false);
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineExecutionClaim claimSnapshot(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      String triggerType,
+      String idempotencyKey) {
+    if (!StringUtils.hasText(logicalJobSpecJson)) {
+      throw new IllegalArgumentException("任务版本快照缺少 JobSpec");
+    }
+    Mapping trigger = LegacyBatchTriggerCompatibilityMapper.parse(triggerType);
+    if ("RETRY".equalsIgnoreCase(trigger.legacyTriggerType())) {
+      throw new IllegalArgumentException("Retry 不能通过 claimSnapshot 创建新 Batch");
+    }
+
+    definitionRepository.lock(definitionId);
+    OfflineJobDefinition current = definitionService.require(definitionId);
+    String normalizedKey = StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : null;
+    if (normalizedKey != null) {
+      OfflineJobExecution existing =
+          executionRepository.findByIdempotencyKey(normalizedKey).orElse(null);
+      if (existing != null) {
+        BatchExecution existingBatch = validateIdempotentReuse(
+            existing,
+            definitionId,
+            definitionVersion,
+            configDigest,
+            definitionSnapshotJson,
+            logicalJobSpecJson);
+        return new OfflineExecutionClaim(
+            current,
+            existingBatch.snapshot().logicalJobSpec(),
+            existing,
+            true);
+      }
+    }
+
+    return createInitialClaim(
+        current,
+        Math.max(1L, definitionVersion),
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        trigger,
+        normalizedKey);
   }
 
-  private ClaimResult createInitialClaim(OfflineJobDefinition definition,long definitionVersion,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson,Mapping trigger,String idempotencyKey){Long definitionId=definition.getId(); if(batchRuntime.hasOccupyingBatch(definitionId)) throw new IllegalStateException("任务已有运行中的 BatchExecution，不能重复提交"); String normalizedIdempotencyKey=StringUtils.hasText(idempotencyKey)?idempotencyKey.trim():UUID.randomUUID().toString(); Long batchId=createBatch(definitionId,definitionVersion,configDigest,definitionSnapshotJson,logicalJobSpecJson,trigger,normalizedIdempotencyKey); BatchExecution batch=batchRepository.findById(batchId).orElseThrow(()->new IllegalStateException("创建后无法读取 BatchExecution："+batchId)); OfflineJobExecution execution=newAttempt(batch,1,trigger.legacyTriggerType(),null,normalizedIdempotencyKey); if(!executionRepository.insert(execution)||execution.getId()==null) throw new IllegalStateException("创建离线同步执行实例失败"); batchRuntime.refreshBatch(batchId); return new ClaimResult(definition,batch.snapshot().logicalJobSpec(),execution,false);}
-  private Long createBatch(Long definitionId,long definitionVersion,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson,Mapping trigger,String idempotencyKey){BatchScope scope=BatchScope.fullSelection(); BatchTrigger batchTrigger=Objects.requireNonNull(trigger.batchTrigger(),"初始执行必须包含 BatchTrigger"); BatchKey batchKey=trigger.batchKey(); if(batchKey==null){batchKey=switch(batchTrigger){case MANUAL->BatchKey.manual(idempotencyKey);case WORKFLOW->BatchKey.workflow(idempotencyKey);case BACKFILL->BatchKey.backfill(idempotencyKey,scope.fingerprint());case SCHEDULE->throw new IllegalArgumentException("SCHEDULE trigger 必须携带 scheduleId + plannedFireTime");};} RetryPolicySnapshot retryPolicy=freezeRetryPolicy(definitionId); ExecutionSnapshot snapshot=new ExecutionSnapshot(requireText(definitionSnapshotJson,"definitionSnapshot 不能为空"),(int)Math.min(Integer.MAX_VALUE,Math.max(1L,definitionVersion)),retryPolicy,requireText(configDigest,"configDigest 不能为空"),requireText(logicalJobSpecJson,"logicalJobSpec 不能为空")); BatchExecution batch=new BatchExecution(null,definitionId,batchKey,batchTrigger,scope,snapshot,BatchStatus.PENDING,List.of()); BatchExecution saved=batchRepository.insert(batch); if(saved.id()==null) throw new IllegalStateException("创建 BatchExecution 后缺少 ID"); return saved.id();}
-  private OfflineJobExecution newAttempt(BatchExecution batch,int attemptNo,String triggerType,Long retryFromExecutionId,String idempotencyKey){LocalDateTime now=LocalDateTime.now(); OfflineJobExecution execution=new OfflineJobExecution(); execution.setJobDefinitionId(batch.taskId()); execution.setBatchId(batch.id()); execution.setDefinitionVersion(batch.snapshot().definitionRevision()); execution.setEngineBaseUrl(properties.getEngine().getBaseUrl()); execution.setExternalExecutionId("yak-offline-"+UUID.randomUUID()); execution.setIdempotencyKey(requireText(idempotencyKey,"idempotencyKey 不能为空")); execution.setStatus(OfflineExecutionStatus.CREATED.name()); execution.setStateVersion(1L); execution.setAttemptNo(Math.max(1,attemptNo)); execution.setTriggerType(requireText(triggerType,"triggerType 不能为空")); execution.setRetryFromExecutionId(retryFromExecutionId); execution.setCancellationRequested(false); execution.setRetryCreated(false); execution.setConfigDigest(batch.snapshot().configDigest()); execution.setDefinitionSnapshotJson(batch.snapshot().definitionSnapshot()); execution.setSubmittedConfig(batch.snapshot().logicalJobSpec()); execution.setSourceRecordCount(0L); execution.setSinkSuccessRecordCount(0L); execution.setSourceReadBytes(0L); execution.setSinkWrittenBytes(0L); execution.setQps(0D); execution.setDurationMillis(0L); execution.setCreateTime(now); execution.setUpdateTime(now); return execution;}
-  private RetryPolicySnapshot freezeRetryPolicy(Long definitionId){OfflineSchedule schedule=scheduleRepository.findSchedule(definitionId); int maxAttempts=schedule==null?properties.getControl().getDefaultMaxAttempts():schedule.retryMaxAttempts(); int backoffSeconds=schedule==null?properties.getControl().getDefaultRetryBackoffSeconds():schedule.retryBackoffSeconds(); return new RetryPolicySnapshot(Math.max(1,maxAttempts),Math.max(0,backoffSeconds));}
-  private String retryIdempotencyKey(Long batchId,int attemptNo){return "offline-retry:"+batchId+":"+attemptNo;} private OfflineExecutionStatus parseStatus(String status){try{return OfflineExecutionStatus.parse(status);}catch(IllegalArgumentException exception){throw new IllegalStateException("Retry 来源 Attempt 状态不合法："+status,exception);}} private int positive(Integer value,String field){if(value==null||value<1)throw new IllegalStateException(field+" 必须大于 0");return value;} private String requireText(String value,String message){if(!StringUtils.hasText(value))throw new IllegalStateException(message);return value.trim();} private int value(Integer value,int fallback){return value==null?fallback:value;} private long value(Long value,long fallback){return value==null?fallback:value;}
-  private BatchExecution validateIdempotentReuse(OfflineJobExecution existing,Long definitionId,long definitionVersion,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson){Long batchId=existing.getBatchId(); if(batchId==null||batchId<=0L) throw new IllegalStateException("幂等键命中 Wave 1 前历史执行，未绑定 Batch，仅支持查询："+existing.getIdempotencyKey()); BatchExecution batch=batchRepository.findById(batchId).orElseThrow(()->new IllegalStateException("幂等 Attempt 绑定的 BatchExecution 不存在："+batchId)); ExecutionSnapshot snapshot=batch.snapshot(); int version=(int)Math.min(Integer.MAX_VALUE,Math.max(1L,definitionVersion)); boolean same=Objects.equals(existing.getJobDefinitionId(),batch.taskId())&&Objects.equals(batch.taskId(),definitionId)&&snapshot.definitionRevision()==version&&Objects.equals(snapshot.configDigest(),configDigest)&&Objects.equals(snapshot.definitionSnapshot(),definitionSnapshotJson)&&Objects.equals(snapshot.logicalJobSpec(),logicalJobSpecJson); if(!same)throw new IllegalStateException("幂等键已被不同 Batch 快照占用："+existing.getIdempotencyKey()); return batch;}
-  public static final class ClaimResult{private final OfflineJobDefinition definition;private final String logicalJobSpecJson;private final OfflineJobExecution execution;private final boolean reused;public ClaimResult(OfflineJobDefinition definition,String logicalJobSpecJson,OfflineJobExecution execution){this(definition,logicalJobSpecJson,execution,false);}public ClaimResult(OfflineJobDefinition definition,String logicalJobSpecJson,OfflineJobExecution execution,boolean reused){this.definition=definition;this.logicalJobSpecJson=logicalJobSpecJson;this.execution=execution;this.reused=reused;}public OfflineJobDefinition getDefinition(){return definition;}public String getLogicalJobSpecJson(){return logicalJobSpecJson;}public OfflineJobExecution getExecution(){return execution;}public boolean isReused(){return reused;}}
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineExecutionClaim claimRetry(Long retryFromExecutionId) {
+    return existingBatchClaimManager.claimRetry(retryFromExecutionId);
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineExecutionClaim claimPendingBackfill(Long batchId) {
+    return existingBatchClaimManager.claimPendingBackfill(batchId);
+  }
+
+  private OfflineExecutionClaim createInitialClaim(
+      OfflineJobDefinition definition,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      Mapping trigger,
+      String idempotencyKey) {
+    Long definitionId = definition.getId();
+    if (batchRuntime.hasOccupyingBatch(definitionId)) {
+      throw new IllegalStateException("任务已有运行中的 BatchExecution，不能重复提交");
+    }
+
+    String normalizedIdempotencyKey =
+        StringUtils.hasText(idempotencyKey) ? idempotencyKey.trim() : UUID.randomUUID().toString();
+    Long batchId = createBatch(
+        definitionId,
+        definitionVersion,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        trigger,
+        normalizedIdempotencyKey);
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("创建后无法读取 BatchExecution：" + batchId));
+
+    OfflineJobExecution execution = attemptFactory.create(
+        batch,
+        1,
+        trigger.legacyTriggerType(),
+        null,
+        normalizedIdempotencyKey);
+    if (!executionRepository.insert(execution) || execution.getId() == null) {
+      throw new IllegalStateException("创建离线同步执行实例失败");
+    }
+    batchRuntime.refreshBatch(batchId);
+    return new OfflineExecutionClaim(
+        definition,
+        batch.snapshot().logicalJobSpec(),
+        execution,
+        false);
+  }
+
+  private Long createBatch(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      Mapping trigger,
+      String idempotencyKey) {
+    BatchScope scope = BatchScope.fullSelection();
+    BatchTrigger batchTrigger =
+        Objects.requireNonNull(trigger.batchTrigger(), "初始执行必须包含 BatchTrigger");
+    BatchKey batchKey = trigger.batchKey();
+    if (batchKey == null) {
+      batchKey = switch (batchTrigger) {
+        case MANUAL -> BatchKey.manual(idempotencyKey);
+        case WORKFLOW -> BatchKey.workflow(idempotencyKey);
+        case BACKFILL -> BatchKey.backfill(idempotencyKey, scope.fingerprint());
+        case SCHEDULE ->
+            throw new IllegalArgumentException("SCHEDULE trigger 必须携带 scheduleId + plannedFireTime");
+      };
+    }
+
+    RetryPolicySnapshot retryPolicy = freezeRetryPolicy(definitionId);
+    ExecutionSnapshot snapshot = new ExecutionSnapshot(
+        requireText(definitionSnapshotJson, "definitionSnapshot 不能为空"),
+        (int) Math.min(Integer.MAX_VALUE, Math.max(1L, definitionVersion)),
+        retryPolicy,
+        requireText(configDigest, "configDigest 不能为空"),
+        requireText(logicalJobSpecJson, "logicalJobSpec 不能为空"));
+    BatchExecution batch = new BatchExecution(
+        null,
+        definitionId,
+        batchKey,
+        batchTrigger,
+        scope,
+        snapshot,
+        BatchStatus.PENDING,
+        List.of());
+    BatchExecution saved = batchRepository.insert(batch);
+    if (saved.id() == null) throw new IllegalStateException("创建 BatchExecution 后缺少 ID");
+    return saved.id();
+  }
+
+  private RetryPolicySnapshot freezeRetryPolicy(Long definitionId) {
+    OfflineSchedule schedule = scheduleRepository.findSchedule(definitionId);
+    int maxAttempts = schedule == null
+        ? properties.getControl().getDefaultMaxAttempts()
+        : schedule.retryMaxAttempts();
+    int backoffSeconds = schedule == null
+        ? properties.getControl().getDefaultRetryBackoffSeconds()
+        : schedule.retryBackoffSeconds();
+    return new RetryPolicySnapshot(Math.max(1, maxAttempts), Math.max(0, backoffSeconds));
+  }
+
+  private BatchExecution validateIdempotentReuse(
+      OfflineJobExecution existing,
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson) {
+    Long batchId = existing.getBatchId();
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalStateException(
+          "幂等键命中 Wave 1 前历史执行，未绑定 Batch，仅支持查询：" + existing.getIdempotencyKey());
+    }
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("幂等 Attempt 绑定的 BatchExecution 不存在：" + batchId));
+    ExecutionSnapshot snapshot = batch.snapshot();
+    int version = (int) Math.min(Integer.MAX_VALUE, Math.max(1L, definitionVersion));
+    boolean same = Objects.equals(existing.getJobDefinitionId(), batch.taskId())
+        && Objects.equals(batch.taskId(), definitionId)
+        && snapshot.definitionRevision() == version
+        && Objects.equals(snapshot.configDigest(), configDigest)
+        && Objects.equals(snapshot.definitionSnapshot(), definitionSnapshotJson)
+        && Objects.equals(snapshot.logicalJobSpec(), logicalJobSpecJson);
+    if (!same) {
+      throw new IllegalStateException("幂等键已被不同 Batch 快照占用：" + existing.getIdempotencyKey());
+    }
+    return batch;
+  }
+
+  private String requireText(String value, String message) {
+    if (!StringUtils.hasText(value)) throw new IllegalStateException(message);
+    return value.trim();
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinator.java
@@ -5,54 +5,244 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
-import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
-import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
-import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
-import io.yak.ops.business.sync.offline.execution.OfflineExecutionClaimManager.ClaimResult;
 import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
-import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
-import java.time.Instant;import java.time.LocalDateTime;import java.time.ZoneId;import java.util.Comparator;import java.util.List;import java.util.Objects;
-import org.springframework.beans.factory.annotation.Qualifier;import org.springframework.stereotype.Component;import org.springframework.util.StringUtils;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
-/** 离线 Attempt 提交、取消和状态落库；BatchExecution 是运行真相边界。 */
-@ConditionalOnOfflineSyncEnabled @Component
+/** Execution 流程协调：claim -> scoped JobSpec -> Link-Up -> state application。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
 public class OfflineExecutionCoordinator {
-  private final OfflineJobDefinitionService definitionService;private final OfflineExecutionClaimManager claimManager;private final OfflineJobDefinitionRepository definitionRepository;private final OfflineJobExecutionRepository executionRepository;private final OfflineBatchExecutionRepository batchRepository;private final OfflineBatchRuntime batchRuntime;private final OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;private final OfflineExecutionEventRepository eventRepository;private final LinkUpClient linkUpClient;private final ObjectMapper objectMapper;
-  public OfflineExecutionCoordinator(OfflineJobDefinitionService definitionService,OfflineExecutionClaimManager claimManager,OfflineJobDefinitionRepository definitionRepository,OfflineJobExecutionRepository executionRepository,OfflineBatchExecutionRepository batchRepository,OfflineBatchRuntime batchRuntime,OfflineBatchScopeExecutionAdapter scopeExecutionAdapter,OfflineExecutionEventRepository eventRepository,LinkUpClient linkUpClient,@Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper){this.definitionService=definitionService;this.claimManager=claimManager;this.definitionRepository=definitionRepository;this.executionRepository=executionRepository;this.batchRepository=batchRepository;this.batchRuntime=batchRuntime;this.scopeExecutionAdapter=scopeExecutionAdapter;this.eventRepository=eventRepository;this.linkUpClient=linkUpClient;this.objectMapper=objectMapper;}
-  public OfflineJobExecution execute(Long definitionId,String triggerType,Long retryFromExecutionId,int attemptNo){ClaimResult claim=claimManager.claim(definitionId,triggerType,retryFromExecutionId,attemptNo);return submitClaim(claim,resolveScopedExecutionJobSpec(claim));}
-  public OfflineJobExecution executeSnapshot(Long definitionId,long definitionVersion,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson){return executeSnapshot(definitionId,definitionVersion,configDigest,definitionSnapshotJson,logicalJobSpecJson,null);}
-  public OfflineJobExecution executeSnapshot(Long definitionId,long definitionVersion,String configDigest,String definitionSnapshotJson,String logicalJobSpecJson,String idempotencyKey){ClaimResult claim=claimManager.claimSnapshot(definitionId,definitionVersion,configDigest,definitionSnapshotJson,logicalJobSpecJson,"WORKFLOW",idempotencyKey);return submitClaim(claim,resolveScopedExecutionJobSpec(claim));}
-  public OfflineJobExecution executePendingBackfill(Long batchId){ClaimResult claim=claimManager.claimPendingBackfill(batchId);OfflineJobExecution execution=claim.getExecution();if(claim.isReused()&&!OfflineExecutionStatus.CREATED.name().equalsIgnoreCase(execution.getStatus()))return execution;return submitClaim(claim,resolveScopedExecutionJobSpec(claim));}
-  private String resolveScopedExecutionJobSpec(ClaimResult claim){OfflineJobExecution execution=claim.getExecution();String logicalJobSpec=claim.getLogicalJobSpecJson();Long batchId=execution.getBatchId();if(batchId!=null&&batchId>0L){BatchExecution batch=batchRepository.findById(batchId).orElseThrow(()->new IllegalStateException("Attempt 绑定的 BatchExecution 不存在："+batchId));logicalJobSpec=scopeExecutionAdapter.apply(batch.taskId(),logicalJobSpec,batch.batchScope());}return definitionService.resolveExecutionJobSpec(logicalJobSpec);}
-  private OfflineJobExecution submitClaim(ClaimResult claim,String resolvedExecutionJobSpec){OfflineJobExecution execution=claim.getExecution();record(execution,null,execution.getStatus(),"EXECUTION_CREATED","使用 application.yml 中的固定 Link-Up 地址",null);try{LinkUpNodeResponse node=linkUpClient.node();execution.setWorkerInstanceId(node.getInstanceId());execution.setUpdateTime(LocalDateTime.now());batchRuntime.persistAttempt(execution);JsonNode jobSpec=readJobSpec(resolvedExecutionJobSpec);transition(execution,OfflineExecutionStatus.SUBMITTED,"SUBMITTING","正在向 Link-Up 提交 JobSpec",null);LinkUpJobResponse response=linkUpClient.submit(execution.getExternalExecutionId(),execution.getIdempotencyKey(),execution.getDefinitionVersion(),jobSpec);applySnapshot(execution,response,"SUBMITTED");return execution;}catch(LinkUpRequestException exception){markTerminal(execution,OfflineExecutionStatus.FAILED,exception.getCode()+"："+exception.getMessage(),null,exception.getStatusCode()==429||exception.getStatusCode()>=500);throw exception;}catch(LinkUpTransportException exception){if(exception.isUncertain()){String previous=execution.getStatus();execution.setStatus(OfflineExecutionStatus.UNKNOWN.name());execution.setErrorMessage(exception.getMessage());execution.setNextRetryTime(null);execution.setEndTime(null);execution.setLastSyncTime(LocalDateTime.now());execution.setUpdateTime(LocalDateTime.now());batchRuntime.persistAttempt(execution);projectTaskLastState(execution,OfflineExecutionStatus.UNKNOWN.name());record(execution,previous,OfflineExecutionStatus.UNKNOWN.name(),"SUBMIT_UNCERTAIN",exception.getMessage(),null);return execution;}markTerminal(execution,OfflineExecutionStatus.FAILED,exception.getMessage(),null,true);throw exception;}catch(RuntimeException exception){markTerminal(execution,OfflineExecutionStatus.FAILED,exception.getMessage(),null,false);throw exception;}}
-  public OfflineJobExecution retryFrom(OfflineJobExecution previous){if(previous==null||previous.getId()==null)throw new IllegalArgumentException("重试来源实例不能为空");ClaimResult claim=claimManager.claimRetry(previous.getId());OfflineJobExecution execution=claim.getExecution();if(claim.isReused()&&!OfflineExecutionStatus.CREATED.name().equalsIgnoreCase(execution.getStatus()))return execution;return submitClaim(claim,resolveScopedExecutionJobSpec(claim));}
-  public OfflineJobExecution cancelLatestBatch(Long definitionId){BatchExecution batch=batchRuntime.requireLatestOccupyingBatch(definitionId);if(batch.status()==BatchStatus.WAITING_RETRY){OfflineJobExecution latest=batchRuntime.cancelWaitingRetry(batch);projectTaskLastState(latest,BatchStatus.CANCELED.name());record(latest,latest.getStatus(),latest.getStatus(),"BATCH_CANCELLED_WAITING_RETRY","已取消 Batch 的 Retry 等待，不再创建新的 Attempt",null);return latest;}return cancel(batchRuntime.requireLatestAttempt(batch).getId());}
-  public OfflineJobExecution cancel(Long id){OfflineJobExecution execution=require(id);ensureLatestAttemptForCancel(execution);if(!OfflineExecutionStatus.isActive(execution.getStatus()))throw new IllegalStateException("当前执行实例已结束，无需停止");execution.setCancellationRequested(true);execution.setUpdateTime(LocalDateTime.now());batchRuntime.persistAttempt(execution);record(execution,execution.getStatus(),execution.getStatus(),"CANCEL_REQUESTED","Yak Ops 已记录取消意图",null);if(StringUtils.hasText(execution.getEngineJobId()))applySnapshot(execution,linkUpClient.cancel(execution.getEngineJobId()),"CANCEL_ACCEPTED");return execution;}
-  public void applySnapshot(OfflineJobExecution execution,LinkUpJobResponse response,String eventType){if(execution==null||response==null)return;requireRuntimeBatch(execution,"对账");String previous=execution.getStatus();OfflineExecutionStatus next=StringUtils.hasText(response.getStatus())?OfflineExecutionStatus.parse(response.getStatus()):OfflineExecutionStatus.parse(execution.getStatus());execution.setEngineJobId(first(response.getJobId(),execution.getEngineJobId()));execution.setWorkerInstanceId(first(response.getWorkerInstanceId(),execution.getWorkerInstanceId()));execution.setStatus(next.name());execution.setStateVersion(Math.max(value(execution.getStateVersion(),0L),value(response.getStateVersion(),0L)));execution.setCancellationRequested(Boolean.TRUE.equals(response.getCancellationRequested())||Boolean.TRUE.equals(execution.getCancellationRequested()));execution.setEngineSnapshotJson(write(response));execution.setErrorMessage(response.getErrorMessage());applyMetrics(execution,response);execution.setDurationMillis(value(response.getDurationMillis(),0L));execution.setStartTime(time(response.getStartTimeMillis()));execution.setEndTime(time(response.getEndTimeMillis()));execution.setLastSyncTime(LocalDateTime.now());execution.setUpdateTime(LocalDateTime.now());configureRetry(execution,next,retryable(response,next));batchRuntime.persistAttempt(execution);projectTaskLastState(execution,next.name());if(!next.name().equals(previous))record(execution,previous,next.name(),eventType,response.getErrorMessage(),execution.getEngineSnapshotJson());}
-  private void applyMetrics(OfflineJobExecution execution,LinkUpJobResponse response){JsonNode metrics=response.getMetrics();JsonNode commitSummary=response.getCommitSummary();long sourceRecordCount=number(metrics,"sourceRecordCount",0L);long sinkAttemptedRecordCount=number(metrics,"sinkAttemptedRecordCount",0L);long sinkSuccessRecordCount=number(metrics,"sinkSuccessRecordCount",0L);long sinkCommittedRecordCount=number(commitSummary,"successfullyCommittedRecordCount",sinkSuccessRecordCount);double sourceAverageQps=decimal(metrics,"sourceAverageQps",0D);double sinkAverageQps=decimal(metrics,"sinkAverageQps",0D);execution.setSourceRecordCount(sourceRecordCount);execution.setSinkAttemptedRecordCount(sinkAttemptedRecordCount);execution.setSinkSuccessRecordCount(sinkSuccessRecordCount);execution.setSinkCommittedRecordCount(sinkCommittedRecordCount);execution.setSourceReadBytes(number(metrics,"sourceReadBytes",0L));execution.setSinkWrittenBytes(number(metrics,"sinkWrittenBytes",0L));execution.setSourceAverageQps(sourceAverageQps);execution.setSinkAverageQps(sinkAverageQps);execution.setFailedRecordCount(number(metrics,"failedRecordCount",0L));execution.setSkippedRecordCount(number(metrics,"skippedRecordCount",0L));execution.setDatabaseCommitMillis(number(metrics,"databaseCommitMillis",0L));execution.setSqlExecutionMillis(number(metrics,"sqlExecutionMillis",0L));execution.setQps(sourceAverageQps>0D?sourceAverageQps:sinkAverageQps);}
-  public void markUnknown(OfflineJobExecution execution,String message){if(execution==null||!OfflineExecutionStatus.isActive(execution.getStatus()))return;requireRuntimeBatch(execution,"UNKNOWN 对账");if(OfflineExecutionStatus.UNKNOWN.name().equalsIgnoreCase(execution.getStatus()))return;String previous=execution.getStatus();execution.setStatus(OfflineExecutionStatus.UNKNOWN.name());execution.setStateVersion(value(execution.getStateVersion(),0L)+1L);execution.setErrorMessage(message);execution.setNextRetryTime(null);execution.setEndTime(null);execution.setLastSyncTime(LocalDateTime.now());execution.setUpdateTime(LocalDateTime.now());batchRuntime.persistAttempt(execution);projectTaskLastState(execution,OfflineExecutionStatus.UNKNOWN.name());record(execution,previous,OfflineExecutionStatus.UNKNOWN.name(),"UNKNOWN",message,null);}
-  public OfflineJobExecution require(Long id){if(id==null||id<=0L)throw new IllegalArgumentException("任务实例 ID 不合法");return executionRepository.findById(id).orElseThrow(()->new IllegalArgumentException("离线同步任务实例不存在："+id));}
-  private void markTerminal(OfflineJobExecution execution,OfflineExecutionStatus status,String message,String payload,boolean retryable){String previous=execution.getStatus();execution.setStatus(status.name());execution.setStateVersion(value(execution.getStateVersion(),0L)+1L);execution.setErrorMessage(message);execution.setEndTime(LocalDateTime.now());execution.setLastSyncTime(LocalDateTime.now());execution.setUpdateTime(LocalDateTime.now());configureRetry(execution,status,retryable);batchRuntime.persistAttempt(execution);projectTaskLastState(execution,status.name());record(execution,previous,status.name(),status.name(),message,payload);}
-  private void projectTaskLastState(OfflineJobExecution execution,String fallbackStatus){Long batchId=execution.getBatchId();if(batchId==null||batchId<=0L)return;String projectedStatus=fallbackStatus;List<OfflineJobExecution> attempts=executionRepository.findByBatchId(batchId);if(!attempts.isEmpty()){OfflineJobExecution latest=attempts.stream().max(Comparator.comparingInt((OfflineJobExecution value)->value(value.getAttemptNo(),1)).thenComparingLong(value->value(value.getId(),0L))).orElseThrow();if(!Objects.equals(latest.getId(),execution.getId()))return;}BatchExecution batch=batchRepository.findById(batchId).orElse(null);if(batch!=null)projectedStatus=batch.status().name();OfflineJobDefinition definition=definitionRepository.findById(execution.getJobDefinitionId()).orElse(null);if(definition==null)return;definition.setLastExecutionId(execution.getId());definition.setLastEngineJobId(execution.getEngineJobId());definition.setLastJobStatus(projectedStatus);definition.setLastErrorMessage(execution.getErrorMessage());definition.setLastDurationMillis(execution.getDurationMillis());definition.setLastReadRowCount(execution.getSourceRecordCount());definition.setLastQps(execution.getQps());definition.setLastSyncBytes(Math.max(value(execution.getSourceReadBytes(),0L),value(execution.getSinkWrittenBytes(),0L)));definition.setLastStartTime(execution.getStartTime());definition.setLastEndTime(execution.getEndTime());definition.setUpdateTime(LocalDateTime.now());definitionRepository.update(definition);}
-  private void transition(OfflineJobExecution execution,OfflineExecutionStatus target,String type,String message,String payload){String previous=execution.getStatus();execution.setStatus(target.name());execution.setStateVersion(value(execution.getStateVersion(),0L)+1L);execution.setUpdateTime(LocalDateTime.now());batchRuntime.persistAttempt(execution);record(execution,previous,target.name(),type,message,payload);}
-  private void configureRetry(OfflineJobExecution execution,OfflineExecutionStatus status,boolean retryable){execution.setNextRetryTime(null);if(!retryable||status!=OfflineExecutionStatus.FAILED)return;RetryPolicySnapshot retryPolicy=frozenRetryPolicy(execution);if(retryPolicy==null)return;if(value(execution.getAttemptNo(),1)<retryPolicy.maxAttempts())execution.setNextRetryTime(LocalDateTime.now().plusSeconds(Math.max(0,retryPolicy.backoffSeconds())));}
-  private RetryPolicySnapshot frozenRetryPolicy(OfflineJobExecution execution){Long batchId=execution.getBatchId();if(batchId==null||batchId<=0L)return null;BatchExecution batch=batchRepository.findById(batchId).orElse(null);if(batch==null||!Objects.equals(execution.getJobDefinitionId(),batch.taskId()))return null;return batch.snapshot().retryPolicy();}
-  private void ensureLatestAttemptForCancel(OfflineJobExecution execution){Long batchId=execution.getBatchId();if(batchId==null||batchId<=0L)throw new IllegalStateException("Wave 1 前历史执行未绑定 Batch，仅支持查询，不能执行取消命令");BatchExecution batch=batchRepository.findById(batchId).orElseThrow(()->new IllegalStateException("Attempt 绑定的 BatchExecution 不存在："+batchId));Long latestId=batch.latestAttempt().map(attempt->attempt.id()).orElse(null);if(!Objects.equals(latestId,execution.getId()))throw new IllegalStateException("只能停止 Batch 的 latest Attempt");}
-  private Long requireRuntimeBatch(OfflineJobExecution execution,String operation){Long batchId=execution.getBatchId();if(batchId==null||batchId<=0L)throw new IllegalStateException("Wave 1 前历史执行未绑定 Batch，仅支持查询，不能参与"+operation);return batchId;}
-  private boolean retryable(LinkUpJobResponse response,OfflineExecutionStatus status){if(status!=OfflineExecutionStatus.FAILED)return false;String code=response==null?null:response.getErrorCode();if(!StringUtils.hasText(code))return true;String normalized=code.toUpperCase(java.util.Locale.ROOT);return !(normalized.contains("CONFIG")||normalized.contains("VALIDATION")||normalized.contains("IDEMPOTENCY")||normalized.contains("BAD_REQUEST")||normalized.contains("UNSUPPORTED"));}
-  private JsonNode readJobSpec(String value){if(!StringUtils.hasText(value))throw new IllegalStateException("任务缺少 Link-Up JobSpec");try{JsonNode node=objectMapper.readTree(value);if(node==null||!node.isObject())throw new IllegalStateException("Link-Up JobSpec 不是 JSON 对象");return node;}catch(JsonProcessingException exception){throw new IllegalStateException("Link-Up JobSpec 已损坏",exception);}}
-  private void record(OfflineJobExecution execution,String from,String to,String type,String message,String payload){eventRepository.append(OfflineExecutionEvent.builder().executionId(execution.getId()).stateVersion(value(execution.getStateVersion(),0L)).fromStatus(from).toStatus(to).eventType(type).message(message).payloadJson(payload).createTime(LocalDateTime.now()).build());}
-  private String write(Object value){try{return objectMapper.writeValueAsString(value);}catch(JsonProcessingException exception){throw new IllegalStateException("序列化 Link-Up 执行快照失败",exception);}}private long number(JsonNode node,String field,long fallback){JsonNode value=node==null?null:node.get(field);return value==null||!value.isNumber()?fallback:value.asLong(fallback);}private double decimal(JsonNode node,String field,double fallback){JsonNode value=node==null?null:node.get(field);return value==null||!value.isNumber()?fallback:value.asDouble(fallback);}private LocalDateTime time(Long millis){return millis==null||millis<=0L?null:LocalDateTime.ofInstant(Instant.ofEpochMilli(millis),ZoneId.systemDefault());}private String first(String value,String fallback){return StringUtils.hasText(value)?value:fallback;}private int value(Integer value,int fallback){return value==null?fallback:value;}private long value(Long value,long fallback){return value==null?fallback:value;}
+
+  private final OfflineJobDefinitionService definitionService;
+  private final OfflineExecutionClaimManager claimManager;
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineBatchRuntime batchRuntime;
+  private final OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+  private final OfflineExecutionStateManager stateManager;
+  private final LinkUpClient linkUpClient;
+  private final ObjectMapper objectMapper;
+
+  public OfflineExecutionCoordinator(
+      OfflineJobDefinitionService definitionService,
+      OfflineExecutionClaimManager claimManager,
+      OfflineJobExecutionRepository executionRepository,
+      OfflineBatchExecutionRepository batchRepository,
+      OfflineBatchRuntime batchRuntime,
+      OfflineBatchScopeExecutionAdapter scopeExecutionAdapter,
+      OfflineExecutionStateManager stateManager,
+      LinkUpClient linkUpClient,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.definitionService = definitionService;
+    this.claimManager = claimManager;
+    this.executionRepository = executionRepository;
+    this.batchRepository = batchRepository;
+    this.batchRuntime = batchRuntime;
+    this.scopeExecutionAdapter = scopeExecutionAdapter;
+    this.stateManager = stateManager;
+    this.linkUpClient = linkUpClient;
+    this.objectMapper = objectMapper;
+  }
+
+  public OfflineJobExecution execute(
+      Long definitionId,
+      String triggerType,
+      Long retryFromExecutionId,
+      int attemptNo) {
+    OfflineExecutionClaim claim =
+        claimManager.claim(definitionId, triggerType, retryFromExecutionId, attemptNo);
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
+  }
+
+  public OfflineJobExecution executeSnapshot(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson) {
+    return executeSnapshot(
+        definitionId,
+        definitionVersion,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        null);
+  }
+
+  public OfflineJobExecution executeSnapshot(
+      Long definitionId,
+      long definitionVersion,
+      String configDigest,
+      String definitionSnapshotJson,
+      String logicalJobSpecJson,
+      String idempotencyKey) {
+    OfflineExecutionClaim claim = claimManager.claimSnapshot(
+        definitionId,
+        definitionVersion,
+        configDigest,
+        definitionSnapshotJson,
+        logicalJobSpecJson,
+        "WORKFLOW",
+        idempotencyKey);
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
+  }
+
+  public OfflineJobExecution executePendingBackfill(Long batchId) {
+    OfflineExecutionClaim claim = claimManager.claimPendingBackfill(batchId);
+    OfflineJobExecution execution = claim.getExecution();
+    if (claim.isReused()
+        && !OfflineExecutionStatus.CREATED.name().equalsIgnoreCase(execution.getStatus())) {
+      return execution;
+    }
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
+  }
+
+  public OfflineJobExecution retryFrom(OfflineJobExecution previous) {
+    if (previous == null || previous.getId() == null) {
+      throw new IllegalArgumentException("重试来源实例不能为空");
+    }
+    OfflineExecutionClaim claim = claimManager.claimRetry(previous.getId());
+    OfflineJobExecution execution = claim.getExecution();
+    if (claim.isReused()
+        && !OfflineExecutionStatus.CREATED.name().equalsIgnoreCase(execution.getStatus())) {
+      return execution;
+    }
+    return submitClaim(claim, resolveScopedExecutionJobSpec(claim));
+  }
+
+  public OfflineJobExecution cancelLatestBatch(Long definitionId) {
+    BatchExecution batch = batchRuntime.requireLatestOccupyingBatch(definitionId);
+    if (batch.status() == BatchStatus.WAITING_RETRY) {
+      OfflineJobExecution latest = batchRuntime.cancelWaitingRetry(batch);
+      stateManager.markWaitingRetryCanceled(latest);
+      return latest;
+    }
+    return cancel(batchRuntime.requireLatestAttempt(batch).getId());
+  }
+
+  public OfflineJobExecution cancel(Long id) {
+    OfflineJobExecution execution = require(id);
+    ensureLatestAttemptForCancel(execution);
+    if (!OfflineExecutionStatus.isActive(execution.getStatus())) {
+      throw new IllegalStateException("当前执行实例已结束，无需停止");
+    }
+    stateManager.markCancellationRequested(execution);
+    if (StringUtils.hasText(execution.getEngineJobId())) {
+      stateManager.applySnapshot(
+          execution,
+          linkUpClient.cancel(execution.getEngineJobId()),
+          "CANCEL_ACCEPTED");
+    }
+    return execution;
+  }
+
+  public void applySnapshot(
+      OfflineJobExecution execution,
+      LinkUpJobResponse response,
+      String eventType) {
+    stateManager.applySnapshot(execution, response, eventType);
+  }
+
+  public void markUnknown(OfflineJobExecution execution, String message) {
+    stateManager.markUnknown(execution, message);
+  }
+
+  public OfflineJobExecution require(Long id) {
+    if (id == null || id <= 0L) throw new IllegalArgumentException("任务实例 ID 不合法");
+    return executionRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务实例不存在：" + id));
+  }
+
+  private String resolveScopedExecutionJobSpec(OfflineExecutionClaim claim) {
+    OfflineJobExecution execution = claim.getExecution();
+    String logicalJobSpec = claim.getLogicalJobSpecJson();
+    Long batchId = execution.getBatchId();
+    if (batchId != null && batchId > 0L) {
+      BatchExecution batch = batchRepository.findById(batchId)
+          .orElseThrow(() -> new IllegalStateException("Attempt 绑定的 BatchExecution 不存在：" + batchId));
+      logicalJobSpec = scopeExecutionAdapter.apply(
+          batch.taskId(),
+          logicalJobSpec,
+          batch.batchScope());
+    }
+    return definitionService.resolveExecutionJobSpec(logicalJobSpec);
+  }
+
+  private OfflineJobExecution submitClaim(
+      OfflineExecutionClaim claim,
+      String resolvedExecutionJobSpec) {
+    OfflineJobExecution execution = claim.getExecution();
+    stateManager.recordCreated(execution);
+    try {
+      LinkUpNodeResponse node = linkUpClient.node();
+      stateManager.bindWorker(execution, node.getInstanceId());
+
+      JsonNode jobSpec = readJobSpec(resolvedExecutionJobSpec);
+      stateManager.markSubmitting(execution);
+      LinkUpJobResponse response = linkUpClient.submit(
+          execution.getExternalExecutionId(),
+          execution.getIdempotencyKey(),
+          execution.getDefinitionVersion(),
+          jobSpec);
+      stateManager.applySnapshot(execution, response, "SUBMITTED");
+      return execution;
+    } catch (LinkUpRequestException exception) {
+      stateManager.markFailed(
+          execution,
+          exception.getCode() + "：" + exception.getMessage(),
+          exception.getStatusCode() == 429 || exception.getStatusCode() >= 500);
+      throw exception;
+    } catch (LinkUpTransportException exception) {
+      if (exception.isUncertain()) {
+        stateManager.markSubmitUncertain(execution, exception.getMessage());
+        return execution;
+      }
+      stateManager.markFailed(execution, exception.getMessage(), true);
+      throw exception;
+    } catch (RuntimeException exception) {
+      stateManager.markFailed(execution, exception.getMessage(), false);
+      throw exception;
+    }
+  }
+
+  private void ensureLatestAttemptForCancel(OfflineJobExecution execution) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalStateException(
+          "Wave 1 前历史执行未绑定 Batch，仅支持查询，不能执行取消命令");
+    }
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Attempt 绑定的 BatchExecution 不存在：" + batchId));
+    Long latestId = batch.latestAttempt().map(attempt -> attempt.id()).orElse(null);
+    if (!Objects.equals(latestId, execution.getId())) {
+      throw new IllegalStateException("只能停止 Batch 的 latest Attempt");
+    }
+  }
+
+  private JsonNode readJobSpec(String value) {
+    if (!StringUtils.hasText(value)) throw new IllegalStateException("任务缺少 Link-Up JobSpec");
+    try {
+      JsonNode node = objectMapper.readTree(value);
+      if (node == null || !node.isObject()) {
+        throw new IllegalStateException("Link-Up JobSpec 不是 JSON 对象");
+      }
+      return node;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Link-Up JobSpec 已损坏", exception);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionStateManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionStateManager.java
@@ -1,0 +1,389 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** ExecutionAttempt 状态应用、Retry 计算、事件记录和 Task last-* 投影。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineExecutionStateManager {
+
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineExecutionEventRepository eventRepository;
+  private final OfflineBatchRuntime batchRuntime;
+  private final ObjectMapper objectMapper;
+
+  public OfflineExecutionStateManager(
+      OfflineJobDefinitionRepository definitionRepository,
+      OfflineJobExecutionRepository executionRepository,
+      OfflineBatchExecutionRepository batchRepository,
+      OfflineExecutionEventRepository eventRepository,
+      OfflineBatchRuntime batchRuntime,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.definitionRepository = definitionRepository;
+    this.executionRepository = executionRepository;
+    this.batchRepository = batchRepository;
+    this.eventRepository = eventRepository;
+    this.batchRuntime = batchRuntime;
+    this.objectMapper = objectMapper;
+  }
+
+  public void recordCreated(OfflineJobExecution execution) {
+    record(
+        execution,
+        null,
+        execution.getStatus(),
+        "EXECUTION_CREATED",
+        "使用 application.yml 中的固定 Link-Up 地址",
+        null);
+  }
+
+  public void bindWorker(OfflineJobExecution execution, String instanceId) {
+    execution.setWorkerInstanceId(instanceId);
+    execution.setUpdateTime(LocalDateTime.now());
+    batchRuntime.persistAttempt(execution);
+  }
+
+  public void markSubmitting(OfflineJobExecution execution) {
+    transition(
+        execution,
+        OfflineExecutionStatus.SUBMITTED,
+        "SUBMITTING",
+        "正在向 Link-Up 提交 JobSpec",
+        null);
+  }
+
+  public void markSubmitUncertain(OfflineJobExecution execution, String message) {
+    String previous = execution.getStatus();
+    execution.setStatus(OfflineExecutionStatus.UNKNOWN.name());
+    execution.setErrorMessage(message);
+    execution.setNextRetryTime(null);
+    execution.setEndTime(null);
+    execution.setLastSyncTime(LocalDateTime.now());
+    execution.setUpdateTime(LocalDateTime.now());
+    batchRuntime.persistAttempt(execution);
+    projectTaskLastState(execution, OfflineExecutionStatus.UNKNOWN.name());
+    record(
+        execution,
+        previous,
+        OfflineExecutionStatus.UNKNOWN.name(),
+        "SUBMIT_UNCERTAIN",
+        message,
+        null);
+  }
+
+  public void markFailed(OfflineJobExecution execution, String message, boolean retryable) {
+    markTerminal(execution, OfflineExecutionStatus.FAILED, message, null, retryable);
+  }
+
+  public void markCancellationRequested(OfflineJobExecution execution) {
+    execution.setCancellationRequested(true);
+    execution.setUpdateTime(LocalDateTime.now());
+    batchRuntime.persistAttempt(execution);
+    record(
+        execution,
+        execution.getStatus(),
+        execution.getStatus(),
+        "CANCEL_REQUESTED",
+        "Yak Ops 已记录取消意图",
+        null);
+  }
+
+  public void markWaitingRetryCanceled(OfflineJobExecution execution) {
+    projectTaskLastState(execution, BatchStatus.CANCELED.name());
+    record(
+        execution,
+        execution.getStatus(),
+        execution.getStatus(),
+        "BATCH_CANCELLED_WAITING_RETRY",
+        "已取消 Batch 的 Retry 等待，不再创建新的 Attempt",
+        null);
+  }
+
+  public void applySnapshot(
+      OfflineJobExecution execution,
+      LinkUpJobResponse response,
+      String eventType) {
+    if (execution == null || response == null) return;
+    requireRuntimeBatch(execution, "对账");
+
+    String previous = execution.getStatus();
+    OfflineExecutionStatus next = StringUtils.hasText(response.getStatus())
+        ? OfflineExecutionStatus.parse(response.getStatus())
+        : OfflineExecutionStatus.parse(execution.getStatus());
+
+    execution.setEngineJobId(first(response.getJobId(), execution.getEngineJobId()));
+    execution.setWorkerInstanceId(first(response.getWorkerInstanceId(), execution.getWorkerInstanceId()));
+    execution.setStatus(next.name());
+    execution.setStateVersion(
+        Math.max(value(execution.getStateVersion(), 0L), value(response.getStateVersion(), 0L)));
+    execution.setCancellationRequested(
+        Boolean.TRUE.equals(response.getCancellationRequested())
+            || Boolean.TRUE.equals(execution.getCancellationRequested()));
+    execution.setEngineSnapshotJson(write(response));
+    execution.setErrorMessage(response.getErrorMessage());
+    applyMetrics(execution, response);
+    execution.setDurationMillis(value(response.getDurationMillis(), 0L));
+    execution.setStartTime(time(response.getStartTimeMillis()));
+    execution.setEndTime(time(response.getEndTimeMillis()));
+    execution.setLastSyncTime(LocalDateTime.now());
+    execution.setUpdateTime(LocalDateTime.now());
+    configureRetry(execution, next, retryable(response, next));
+    batchRuntime.persistAttempt(execution);
+    projectTaskLastState(execution, next.name());
+
+    if (!next.name().equals(previous)) {
+      record(
+          execution,
+          previous,
+          next.name(),
+          eventType,
+          response.getErrorMessage(),
+          execution.getEngineSnapshotJson());
+    }
+  }
+
+  public void markUnknown(OfflineJobExecution execution, String message) {
+    if (execution == null || !OfflineExecutionStatus.isActive(execution.getStatus())) return;
+    requireRuntimeBatch(execution, "UNKNOWN 对账");
+    if (OfflineExecutionStatus.UNKNOWN.name().equalsIgnoreCase(execution.getStatus())) return;
+
+    String previous = execution.getStatus();
+    execution.setStatus(OfflineExecutionStatus.UNKNOWN.name());
+    execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
+    execution.setErrorMessage(message);
+    execution.setNextRetryTime(null);
+    execution.setEndTime(null);
+    execution.setLastSyncTime(LocalDateTime.now());
+    execution.setUpdateTime(LocalDateTime.now());
+    batchRuntime.persistAttempt(execution);
+    projectTaskLastState(execution, OfflineExecutionStatus.UNKNOWN.name());
+    record(
+        execution,
+        previous,
+        OfflineExecutionStatus.UNKNOWN.name(),
+        "UNKNOWN",
+        message,
+        null);
+  }
+
+  private void markTerminal(
+      OfflineJobExecution execution,
+      OfflineExecutionStatus status,
+      String message,
+      String payload,
+      boolean retryable) {
+    String previous = execution.getStatus();
+    execution.setStatus(status.name());
+    execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
+    execution.setErrorMessage(message);
+    execution.setEndTime(LocalDateTime.now());
+    execution.setLastSyncTime(LocalDateTime.now());
+    execution.setUpdateTime(LocalDateTime.now());
+    configureRetry(execution, status, retryable);
+    batchRuntime.persistAttempt(execution);
+    projectTaskLastState(execution, status.name());
+    record(execution, previous, status.name(), status.name(), message, payload);
+  }
+
+  private void transition(
+      OfflineJobExecution execution,
+      OfflineExecutionStatus target,
+      String type,
+      String message,
+      String payload) {
+    String previous = execution.getStatus();
+    execution.setStatus(target.name());
+    execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
+    execution.setUpdateTime(LocalDateTime.now());
+    batchRuntime.persistAttempt(execution);
+    record(execution, previous, target.name(), type, message, payload);
+  }
+
+  private void applyMetrics(OfflineJobExecution execution, LinkUpJobResponse response) {
+    JsonNode metrics = response.getMetrics();
+    JsonNode commitSummary = response.getCommitSummary();
+    long sourceRecordCount = number(metrics, "sourceRecordCount", 0L);
+    long sinkAttemptedRecordCount = number(metrics, "sinkAttemptedRecordCount", 0L);
+    long sinkSuccessRecordCount = number(metrics, "sinkSuccessRecordCount", 0L);
+    long sinkCommittedRecordCount = number(
+        commitSummary, "successfullyCommittedRecordCount", sinkSuccessRecordCount);
+    double sourceAverageQps = decimal(metrics, "sourceAverageQps", 0D);
+    double sinkAverageQps = decimal(metrics, "sinkAverageQps", 0D);
+
+    execution.setSourceRecordCount(sourceRecordCount);
+    execution.setSinkAttemptedRecordCount(sinkAttemptedRecordCount);
+    execution.setSinkSuccessRecordCount(sinkSuccessRecordCount);
+    execution.setSinkCommittedRecordCount(sinkCommittedRecordCount);
+    execution.setSourceReadBytes(number(metrics, "sourceReadBytes", 0L));
+    execution.setSinkWrittenBytes(number(metrics, "sinkWrittenBytes", 0L));
+    execution.setSourceAverageQps(sourceAverageQps);
+    execution.setSinkAverageQps(sinkAverageQps);
+    execution.setFailedRecordCount(number(metrics, "failedRecordCount", 0L));
+    execution.setSkippedRecordCount(number(metrics, "skippedRecordCount", 0L));
+    execution.setDatabaseCommitMillis(number(metrics, "databaseCommitMillis", 0L));
+    execution.setSqlExecutionMillis(number(metrics, "sqlExecutionMillis", 0L));
+    execution.setQps(sourceAverageQps > 0D ? sourceAverageQps : sinkAverageQps);
+  }
+
+  private void configureRetry(
+      OfflineJobExecution execution,
+      OfflineExecutionStatus status,
+      boolean retryable) {
+    execution.setNextRetryTime(null);
+    if (!retryable || status != OfflineExecutionStatus.FAILED) return;
+    RetryPolicySnapshot retryPolicy = frozenRetryPolicy(execution);
+    if (retryPolicy == null) return;
+    if (value(execution.getAttemptNo(), 1) < retryPolicy.maxAttempts()) {
+      execution.setNextRetryTime(
+          LocalDateTime.now().plusSeconds(Math.max(0, retryPolicy.backoffSeconds())));
+    }
+  }
+
+  private RetryPolicySnapshot frozenRetryPolicy(OfflineJobExecution execution) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) return null;
+    BatchExecution batch = batchRepository.findById(batchId).orElse(null);
+    if (batch == null || !Objects.equals(execution.getJobDefinitionId(), batch.taskId())) return null;
+    return batch.snapshot().retryPolicy();
+  }
+
+  private void projectTaskLastState(OfflineJobExecution execution, String fallbackStatus) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) return;
+
+    String projectedStatus = fallbackStatus;
+    List<OfflineJobExecution> attempts = executionRepository.findByBatchId(batchId);
+    if (!attempts.isEmpty()) {
+      OfflineJobExecution latest = attempts.stream()
+          .max(
+              Comparator.comparingInt((OfflineJobExecution value) -> value(value.getAttemptNo(), 1))
+                  .thenComparingLong(value -> value(value.getId(), 0L)))
+          .orElseThrow();
+      if (!Objects.equals(latest.getId(), execution.getId())) return;
+    }
+
+    BatchExecution batch = batchRepository.findById(batchId).orElse(null);
+    if (batch != null) projectedStatus = batch.status().name();
+    OfflineJobDefinition definition =
+        definitionRepository.findById(execution.getJobDefinitionId()).orElse(null);
+    if (definition == null) return;
+
+    definition.setLastExecutionId(execution.getId());
+    definition.setLastEngineJobId(execution.getEngineJobId());
+    definition.setLastJobStatus(projectedStatus);
+    definition.setLastErrorMessage(execution.getErrorMessage());
+    definition.setLastDurationMillis(execution.getDurationMillis());
+    definition.setLastReadRowCount(execution.getSourceRecordCount());
+    definition.setLastQps(execution.getQps());
+    definition.setLastSyncBytes(
+        Math.max(value(execution.getSourceReadBytes(), 0L), value(execution.getSinkWrittenBytes(), 0L)));
+    definition.setLastStartTime(execution.getStartTime());
+    definition.setLastEndTime(execution.getEndTime());
+    definition.setUpdateTime(LocalDateTime.now());
+    definitionRepository.update(definition);
+  }
+
+  private Long requireRuntimeBatch(OfflineJobExecution execution, String operation) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalStateException(
+          "Wave 1 前历史执行未绑定 Batch，仅支持查询，不能参与" + operation);
+    }
+    return batchId;
+  }
+
+  private boolean retryable(LinkUpJobResponse response, OfflineExecutionStatus status) {
+    if (status != OfflineExecutionStatus.FAILED) return false;
+    String code = response == null ? null : response.getErrorCode();
+    if (!StringUtils.hasText(code)) return true;
+    String normalized = code.toUpperCase(Locale.ROOT);
+    return !(normalized.contains("CONFIG")
+        || normalized.contains("VALIDATION")
+        || normalized.contains("IDEMPOTENCY")
+        || normalized.contains("BAD_REQUEST")
+        || normalized.contains("UNSUPPORTED"));
+  }
+
+  private void record(
+      OfflineJobExecution execution,
+      String from,
+      String to,
+      String type,
+      String message,
+      String payload) {
+    eventRepository.append(
+        OfflineExecutionEvent.builder()
+            .executionId(execution.getId())
+            .stateVersion(value(execution.getStateVersion(), 0L))
+            .fromStatus(from)
+            .toStatus(to)
+            .eventType(type)
+            .message(message)
+            .payloadJson(payload)
+            .createTime(LocalDateTime.now())
+            .build());
+  }
+
+  private String write(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 Link-Up 执行快照失败", exception);
+    }
+  }
+
+  private long number(JsonNode node, String field, long fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || !value.isNumber() ? fallback : value.asLong(fallback);
+  }
+
+  private double decimal(JsonNode node, String field, double fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || !value.isNumber() ? fallback : value.asDouble(fallback);
+  }
+
+  private LocalDateTime time(Long millis) {
+    return millis == null || millis <= 0L
+        ? null
+        : LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault());
+  }
+
+  private String first(String value, String fallback) {
+    return StringUtils.hasText(value) ? value : fallback;
+  }
+
+  private int value(Integer value, int fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExistingBatchClaimManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExistingBatchClaimManager.java
@@ -1,0 +1,174 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 已有 Batch 上的 Attempt admission：Retry 和 PENDING Backfill。 */
+@ConditionalOnOfflineSyncEnabled
+@Component
+@RequiredArgsConstructor
+public class OfflineExistingBatchClaimManager {
+
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineBatchRuntime batchRuntime;
+  private final OfflineExecutionAttemptFactory attemptFactory;
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineExecutionClaim claimRetry(Long retryFromExecutionId) {
+    if (retryFromExecutionId == null || retryFromExecutionId <= 0L) {
+      throw new IllegalArgumentException("重试来源实例不能为空");
+    }
+    OfflineJobExecution previous = executionRepository.findById(retryFromExecutionId)
+        .orElseThrow(() -> new IllegalArgumentException("重试来源实例不存在：" + retryFromExecutionId));
+    Long batchId = previous.getBatchId();
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalStateException("旧执行实例未绑定 Batch，仅支持历史查询，不能按领域规则 Retry");
+    }
+
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Retry 所属 BatchExecution 不存在：" + batchId));
+    if (!Objects.equals(previous.getJobDefinitionId(), batch.taskId())) {
+      throw new IllegalStateException("Retry 来源 Attempt 与 Batch 的 Task 不一致");
+    }
+    if (batch.status().isTerminal()) {
+      throw new IllegalStateException("Batch 已进入终态，不能追加 Retry Attempt");
+    }
+
+    OfflineExecutionStatus previousStatus = parseStatus(previous.getStatus());
+    if (previousStatus == OfflineExecutionStatus.UNKNOWN) {
+      throw new IllegalStateException("执行结果为 UNKNOWN，必须先 reconcile，禁止盲目 Retry");
+    }
+    if (previousStatus != OfflineExecutionStatus.FAILED) {
+      throw new IllegalStateException("只有明确 FAILED 的 Attempt 才能 Retry");
+    }
+
+    List<OfflineJobExecution> attempts = executionRepository.findByBatchId(batchId);
+    if (attempts.isEmpty()) {
+      throw new IllegalStateException("Batch 缺少 Attempt 历史，不能 Retry");
+    }
+    int previousAttemptNo = positive(previous.getAttemptNo(), "attemptNo");
+    int nextAttemptNo = previousAttemptNo + 1;
+
+    OfflineJobExecution existingNext = attempts.stream()
+        .filter(attempt -> value(attempt.getAttemptNo(), 1) == nextAttemptNo)
+        .filter(attempt -> Objects.equals(attempt.getRetryFromExecutionId(), previous.getId()))
+        .findFirst()
+        .orElse(null);
+    if (existingNext != null) {
+      batchRuntime.refreshBatch(batchId);
+      return new OfflineExecutionClaim(null, batch.snapshot().logicalJobSpec(), existingNext, true);
+    }
+
+    OfflineJobExecution latest = attempts.stream()
+        .max(
+            Comparator.comparingInt((OfflineJobExecution attempt) -> value(attempt.getAttemptNo(), 1))
+                .thenComparingLong(attempt -> value(attempt.getId(), 0L)))
+        .orElseThrow(() -> new IllegalStateException("Batch 缺少最新 Attempt"));
+    if (!Objects.equals(latest.getId(), previous.getId())) {
+      throw new IllegalStateException("只能从 Batch 最新 Attempt 创建 Retry");
+    }
+
+    RetryPolicySnapshot retryPolicy = batch.snapshot().retryPolicy();
+    if (nextAttemptNo > retryPolicy.maxAttempts()) {
+      throw new IllegalStateException("Retry 已达到 Batch 冻结的最大 Attempt 数");
+    }
+    if (!executionRepository.reserveRetry(previous.getId())) {
+      throw new IllegalStateException("Retry 已被其他请求保留或已经创建");
+    }
+
+    OfflineJobExecution execution = attemptFactory.create(
+        batch,
+        nextAttemptNo,
+        "RETRY",
+        previous.getId(),
+        "offline-retry:" + batch.id() + ":" + nextAttemptNo);
+    if (!executionRepository.insert(execution) || execution.getId() == null) {
+      throw new IllegalStateException("创建 Retry Attempt 失败");
+    }
+    batchRuntime.refreshBatch(batchId);
+    return new OfflineExecutionClaim(null, batch.snapshot().logicalJobSpec(), execution, false);
+  }
+
+  @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
+  public OfflineExecutionClaim claimPendingBackfill(Long batchId) {
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    }
+    BatchExecution initial = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalArgumentException("Backfill BatchExecution 不存在：" + batchId));
+    if (initial.trigger() != BatchTrigger.BACKFILL) {
+      throw new IllegalStateException("只有 BACKFILL Batch 可以通过 pending dispatcher 创建 Attempt 1");
+    }
+
+    definitionRepository.lock(initial.taskId());
+    BatchExecution batch = batchRepository.findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Backfill BatchExecution 已不存在：" + batchId));
+    List<OfflineJobExecution> existingAttempts = executionRepository.findByBatchId(batchId);
+    OfflineJobExecution existingInitial = existingAttempts.stream()
+        .filter(attempt -> value(attempt.getAttemptNo(), 1) == 1)
+        .findFirst()
+        .orElse(null);
+    if (existingInitial != null) {
+      batchRuntime.refreshBatch(batchId);
+      return new OfflineExecutionClaim(null, batch.snapshot().logicalJobSpec(), existingInitial, true);
+    }
+    if (batch.status() != BatchStatus.PENDING) {
+      throw new IllegalStateException("Backfill Batch 已不处于 PENDING：" + batch.status());
+    }
+    if (batchRuntime.hasOccupyingBatch(batch.taskId())) {
+      throw new IllegalStateException("Task 已有 occupying Batch，Backfill 保持排队");
+    }
+    if (!batchRepository.reservePendingBackfill(batchId)) {
+      throw new IllegalStateException("Backfill Batch 已被其他 dispatcher reservation");
+    }
+
+    OfflineJobExecution execution = attemptFactory.create(
+        batch,
+        1,
+        "BACKFILL",
+        null,
+        "offline-backfill:" + batchId + ":1");
+    if (!executionRepository.insert(execution) || execution.getId() == null) {
+      throw new IllegalStateException("创建 Backfill Attempt 1 失败");
+    }
+    batchRuntime.refreshBatch(batchId);
+    return new OfflineExecutionClaim(null, batch.snapshot().logicalJobSpec(), execution, false);
+  }
+
+  private OfflineExecutionStatus parseStatus(String status) {
+    try {
+      return OfflineExecutionStatus.parse(status);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalStateException("Retry 来源 Attempt 状态不合法：" + status, exception);
+    }
+  }
+
+  private int positive(Integer value, String field) {
+    if (value == null || value < 1) throw new IllegalStateException(field + " 必须大于 0");
+    return value;
+  }
+
+  private int value(Integer value, int fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.baomidou.mybatisplus.annotation.TableName;
 import io.yak.framework.common.PageData;
 import io.yak.ops.business.sync.offline.backfill.OfflineBackfillDispatcher;
+import io.yak.ops.business.sync.offline.backfill.OfflineBackfillPlanner;
 import io.yak.ops.business.sync.offline.backfill.OfflineBackfillService;
 import io.yak.ops.business.sync.offline.controller.OfflineBackfillController;
 import io.yak.ops.business.sync.offline.controller.OfflineControlPlaneController;
@@ -18,9 +19,13 @@ import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
 import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.execution.OfflineBatchRuntime;
+import io.yak.ops.business.sync.offline.execution.OfflineExecutionAttemptFactory;
 import io.yak.ops.business.sync.offline.execution.OfflineExecutionClaimManager;
 import io.yak.ops.business.sync.offline.execution.OfflineExecutionCoordinator;
+import io.yak.ops.business.sync.offline.execution.OfflineExecutionStateManager;
+import io.yak.ops.business.sync.offline.execution.OfflineExistingBatchClaimManager;
 import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
+import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionLogQuery;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionQuery;
 import io.yak.ops.business.sync.offline.reconcile.OfflineExecutionReconciler;
@@ -56,13 +61,16 @@ class OfflineSyncLayeringConventionTest {
   private static final Set<String> EXECUTION_INTERNAL_IMPORTS = Set.of(
       "io.yak.ops.business.sync.offline.execution.OfflineExecutionCoordinator",
       "io.yak.ops.business.sync.offline.execution.OfflineExecutionClaimManager",
+      "io.yak.ops.business.sync.offline.execution.OfflineExistingBatchClaimManager",
+      "io.yak.ops.business.sync.offline.execution.OfflineExecutionAttemptFactory",
+      "io.yak.ops.business.sync.offline.execution.OfflineExecutionStateManager",
       "io.yak.ops.business.sync.offline.execution.OfflineBatchRuntime",
       "io.yak.ops.business.sync.offline.execution.query.",
       "io.yak.ops.business.sync.offline.execution.adapter.");
 
   private static final Set<String> EXECUTION_INTERNAL_FACADE_EXCEPTIONS = Set.of(
       "definition/OfflineJobDefinitionService.java",
-      "backfill/OfflineBackfillService.java");
+      "backfill/OfflineBackfillPlanner.java");
 
   private static final Set<String> LEGACY_ROLE_NAMES = Set.of(
       "OfflineExecutionOrchestrator",
@@ -106,10 +114,14 @@ class OfflineSyncLayeringConventionTest {
     for (Class<?> internal : List.of(
         OfflineExecutionCoordinator.class,
         OfflineExecutionClaimManager.class,
+        OfflineExistingBatchClaimManager.class,
+        OfflineExecutionAttemptFactory.class,
+        OfflineExecutionStateManager.class,
         OfflineBatchRuntime.class,
         OfflineCursorManager.class,
         OfflineExecutionQuery.class,
-        OfflineExecutionLogQuery.class)) {
+        OfflineExecutionLogQuery.class,
+        OfflineBackfillPlanner.class)) {
       assertThat(internal.getAnnotation(Component.class))
           .as("%s must remain an internal role component", internal.getSimpleName())
           .isNotNull();
@@ -120,14 +132,32 @@ class OfflineSyncLayeringConventionTest {
   }
 
   @Test
+  void stageElevenCoreResponsibilitiesStayDecomposed() {
+    List<Class<?>> coordinatorDependencies = fieldTypes(OfflineExecutionCoordinator.class);
+    assertThat(coordinatorDependencies)
+        .contains(OfflineExecutionStateManager.class)
+        .doesNotContain(OfflineJobDefinitionRepository.class, OfflineExecutionEventRepository.class);
+
+    List<Class<?>> claimDependencies = fieldTypes(OfflineExecutionClaimManager.class);
+    assertThat(claimDependencies)
+        .contains(OfflineExistingBatchClaimManager.class, OfflineExecutionAttemptFactory.class);
+
+    List<Class<?>> backfillDependencies = fieldTypes(OfflineBackfillService.class);
+    assertThat(backfillDependencies)
+        .contains(OfflineBackfillPlanner.class)
+        .doesNotContain(
+            OfflineCursorManager.class,
+            OfflineScheduleRepository.class,
+            OfflineBatchScopeExecutionAdapter.class);
+  }
+
+  @Test
   void backgroundEntrypointsReachExecutionThroughFacade() {
     for (Class<?> type : List.of(
         OfflineScheduleHandler.class,
         OfflineBackfillDispatcher.class,
         OfflineExecutionReconciler.class)) {
-      List<Class<?>> dependencies = Arrays.stream(type.getDeclaredFields())
-          .map(Field::getType)
-          .toList();
+      List<Class<?>> dependencies = fieldTypes(type);
 
       assertThat(dependencies)
           .as("%s must enter execution through OfflineJobExecutionService", type.getSimpleName())
@@ -139,6 +169,8 @@ class OfflineSyncLayeringConventionTest {
             .as("%s must not depend on an execution internal component", type.getSimpleName())
             .doesNotContain("OfflineExecutionCoordinator")
             .doesNotContain("OfflineExecutionClaimManager")
+            .doesNotContain("OfflineExistingBatchClaimManager")
+            .doesNotContain("OfflineExecutionStateManager")
             .doesNotContain("OfflineBatchRuntime")
             .doesNotContain(".execution.query.")
             .doesNotContain(".execution.adapter.");
@@ -248,6 +280,10 @@ class OfflineSyncLayeringConventionTest {
 
     Field batchId = OfflineJobExecutionPO.class.getDeclaredField("batchId");
     assertThat(batchId.getType()).isEqualTo(Long.class);
+  }
+
+  private List<Class<?>> fieldTypes(Class<?> type) {
+    return Arrays.stream(type.getDeclaredFields()).map(Field::getType).toList();
   }
 
   private Path productionRoot() {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlannerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlannerTest.java
@@ -1,0 +1,211 @@
+package io.yak.ops.business.sync.offline.backfill;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillScopeDTO;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineBackfillPlannerTest {
+
+  @Mock private OfflineJobDefinitionService definitionService;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineScheduleRepository scheduleRepository;
+  @Mock private OfflineCursorManager cursorManager;
+  @Mock private OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+
+  private OfflineBackfillPlanner planner;
+
+  @BeforeEach
+  void setUp() {
+    planner = new OfflineBackfillPlanner(
+        definitionService,
+        batchRepository,
+        scheduleRepository,
+        cursorManager,
+        scopeExecutionAdapter,
+        new OfflineSyncProperties());
+  }
+
+  @Test
+  void plansMultipleScopesWithOneFrozenSnapshot() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.resolveLogicalJobSpec(definition))
+        .thenReturn("{\"kind\":\"BatchSyncJob\"}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any()))
+        .thenReturn(Optional.empty());
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("backfill-august");
+    request.setScopes(List.of(
+        window(
+            LocalDateTime.of(2026, 8, 1, 0, 0),
+            LocalDateTime.of(2026, 8, 2, 0, 0)),
+        window(
+            LocalDateTime.of(2026, 8, 2, 0, 0),
+            LocalDateTime.of(2026, 8, 3, 0, 0))));
+
+    OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
+    OfflineBackfillPlanner.Plan plan = planner.plan(10L, definition, prepared);
+
+    assertThat(plan.scopes()).hasSize(2);
+    assertThat(plan.snapshot().logicalJobSpec())
+        .isEqualTo("{\"kind\":\"BatchSyncJob\"}");
+    verify(scopeExecutionAdapter, org.mockito.Mockito.times(2))
+        .apply(anyLong(), any(), any());
+  }
+
+  @Test
+  void continuousCursorRangesInitializeOneRoute() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any()))
+        .thenReturn(Optional.empty());
+    when(cursorManager.find(10L, "orders")).thenReturn(Optional.empty());
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("cursor-bf");
+    request.setScopes(List.of(
+        cursor("orders", "updated_at", "100", "200"),
+        cursor("orders", "updated_at", "200", "300")));
+
+    OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
+    planner.plan(10L, definition, prepared);
+
+    verify(cursorManager).initializeIfAbsent(10L, "orders", "updated_at", "100");
+  }
+
+  @Test
+  void cursorGapFailsBeforeExecutionScopeValidation() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any()))
+        .thenReturn(Optional.empty());
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("cursor-gap");
+    request.setScopes(List.of(
+        cursor("orders", "updated_at", "100", "200"),
+        cursor("orders", "updated_at", "250", "300")));
+
+    OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
+
+    assertThatThrownBy(() -> planner.plan(10L, definition, prepared))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("连续");
+    verify(scopeExecutionAdapter, never()).apply(anyLong(), any(), any());
+  }
+
+  @Test
+  void invalidExecutionProjectionFailsBeforeMaterialization() {
+    OfflineJobDefinition definition = definition("ONLINE");
+    when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
+    when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any()))
+        .thenReturn(Optional.empty());
+    when(scopeExecutionAdapter.apply(anyLong(), any(), any()))
+        .thenThrow(new IllegalStateException("Wave 5 scoped Batch V1 仅支持单表 source"));
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("invalid-scope");
+    request.setScopes(List.of(
+        window(
+            LocalDateTime.of(2026, 8, 1, 0, 0),
+            LocalDateTime.of(2026, 8, 2, 0, 0))));
+
+    OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
+
+    assertThatThrownBy(() -> planner.plan(10L, definition, prepared))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("单表");
+  }
+
+  @Test
+  void fullyExistingRequestReusesFrozenSnapshotEvenWhenTaskIsOffline() {
+    OfflineJobDefinition definition = definition("OFFLINE");
+    BatchScope scope = BatchScope.fullSelection();
+    ExecutionSnapshot snapshot = new ExecutionSnapshot(
+        "{\"definition\":\"frozen\"}",
+        7,
+        new RetryPolicySnapshot(2, 10),
+        "digest-7",
+        "{\"kind\":\"BatchSyncJob\"}");
+    BatchExecution existing = new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill("existing", scope.fingerprint()),
+        BatchTrigger.BACKFILL,
+        scope,
+        snapshot,
+        BatchStatus.SUCCEEDED,
+        List.of());
+    when(batchRepository.findByTaskIdAndBatchKey(10L, BatchKey.backfill("existing", scope.fingerprint())))
+        .thenReturn(Optional.of(existing));
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    request.setRequestId("existing");
+    OfflineBackfillScopeDTO full = new OfflineBackfillScopeDTO();
+    full.setType("FULL_SELECTION");
+    request.setScopes(List.of(full));
+
+    OfflineBackfillPlanner.Plan plan = planner.plan(10L, definition, planner.prepare(request));
+
+    assertThat(plan.snapshot()).isEqualTo(snapshot);
+    assertThat(plan.existing(plan.scopes().get(0))).isSameAs(existing);
+    verify(definitionService, never()).resolveLogicalJobSpec(definition);
+  }
+
+  private OfflineJobDefinition definition(String releaseState) {
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState(releaseState);
+    definition.setDefinitionJson("{\"definition\":1}");
+    definition.setVersion(7);
+    definition.setConfigDigest("digest-7");
+    return definition;
+  }
+
+  private OfflineBackfillScopeDTO window(LocalDateTime start, LocalDateTime end) {
+    OfflineBackfillScopeDTO scope = new OfflineBackfillScopeDTO();
+    scope.setType("DATA_WINDOW");
+    scope.setStartInclusive(start);
+    scope.setEndExclusive(end);
+    return scope;
+  }
+
+  private OfflineBackfillScopeDTO cursor(
+      String cursorId,
+      String column,
+      String after,
+      String through) {
+    OfflineBackfillScopeDTO scope = new OfflineBackfillScopeDTO();
+    scope.setType("CURSOR_RANGE");
+    scope.setCursorId(cursorId);
+    scope.setCursorColumn(column);
+    scope.setAfterExclusive(after);
+    scope.setThroughInclusive(through);
+    return scope;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillServiceTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillServiceTest.java
@@ -1,3 +1,166 @@
 package io.yak.ops.business.sync.offline.backfill;
-import static org.assertj.core.api.Assertions.assertThat;import static org.assertj.core.api.Assertions.assertThatThrownBy;import static org.mockito.ArgumentMatchers.any;import static org.mockito.ArgumentMatchers.anyLong;import static org.mockito.Mockito.never;import static org.mockito.Mockito.verify;import static org.mockito.Mockito.when;import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;import io.yak.ops.business.sync.offline.domain.core.BatchExecution;import io.yak.ops.business.sync.offline.domain.core.BatchStatus;import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillScopeDTO;import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;import java.time.LocalDateTime;import java.util.List;import java.util.Optional;import java.util.concurrent.atomic.AtomicLong;import org.junit.jupiter.api.BeforeEach;import org.junit.jupiter.api.Test;import org.junit.jupiter.api.extension.ExtendWith;import org.mockito.ArgumentCaptor;import org.mockito.Mock;import org.mockito.junit.jupiter.MockitoExtension;
-@ExtendWith(MockitoExtension.class)class OfflineBackfillServiceTest {@Mock private OfflineJobDefinitionService definitionService;@Mock private OfflineJobDefinitionRepository definitionRepository;@Mock private OfflineBatchExecutionRepository batchRepository;@Mock private OfflineScheduleRepository scheduleRepository;@Mock private OfflineCursorManager cursorManager;@Mock private OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;private OfflineBackfillService service;@BeforeEach void setUp(){service=new OfflineBackfillService(definitionService,definitionRepository,batchRepository,scheduleRepository,cursorManager,scopeExecutionAdapter,new OfflineSyncProperties());}@Test void oneBackfillRequestMaterializesBatchGroupWithSharedSnapshot(){OfflineJobDefinition definition=definition("ONLINE");when(definitionService.require(10L)).thenReturn(definition);when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{\"kind\":\"BatchSyncJob\"}");when(batchRepository.findByTaskIdAndBatchKey(anyLong(),any())).thenReturn(Optional.empty());AtomicLong sequence=new AtomicLong(100L);when(batchRepository.insert(any(BatchExecution.class))).thenAnswer(invocation->persisted(invocation.getArgument(0),sequence.incrementAndGet()));OfflineBackfillRequestDTO request=new OfflineBackfillRequestDTO();request.setRequestId("backfill-august");request.setScopes(List.of(window(LocalDateTime.of(2026,8,1,0,0),LocalDateTime.of(2026,8,2,0,0)),window(LocalDateTime.of(2026,8,2,0,0),LocalDateTime.of(2026,8,3,0,0))));OfflineBackfillVO result=service.submit(10L,request);assertThat(result.getCreatedCount()).isEqualTo(2);assertThat(result.getReusedCount()).isZero();assertThat(result.getBatchIds()).containsExactly(101L,102L);ArgumentCaptor<BatchExecution> captor=ArgumentCaptor.forClass(BatchExecution.class);verify(batchRepository,org.mockito.Mockito.times(2)).insert(captor.capture());List<BatchExecution>batches=captor.getAllValues();assertThat(batches).allMatch(batch->batch.trigger()==BatchTrigger.BACKFILL);assertThat(batches).allMatch(batch->batch.status()==BatchStatus.PENDING);assertThat(batches.get(0).snapshot()).isEqualTo(batches.get(1).snapshot());verify(scopeExecutionAdapter,org.mockito.Mockito.times(2)).apply(anyLong(),any(),any());verify(definitionRepository).lock(10L);}@Test void cursorBackfillRequiresContinuousRangesAndInitializesRoute(){OfflineJobDefinition definition=definition("ONLINE");when(definitionService.require(10L)).thenReturn(definition);when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");when(batchRepository.findByTaskIdAndBatchKey(anyLong(),any())).thenReturn(Optional.empty());AtomicLong sequence=new AtomicLong(100L);when(batchRepository.insert(any(BatchExecution.class))).thenAnswer(invocation->persisted(invocation.getArgument(0),sequence.incrementAndGet()));OfflineBackfillRequestDTO request=new OfflineBackfillRequestDTO();request.setRequestId("cursor-bf");request.setScopes(List.of(cursor("orders","updated_at","100","200"),cursor("orders","updated_at","200","300")));service.submit(10L,request);verify(cursorManager).initializeIfAbsent(10L,"orders","updated_at","100");}@Test void cursorBackfillRejectsGapBeforeCreatingAnyBatch(){OfflineJobDefinition definition=definition("ONLINE");when(definitionService.require(10L)).thenReturn(definition);when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");when(batchRepository.findByTaskIdAndBatchKey(anyLong(),any())).thenReturn(Optional.empty());OfflineBackfillRequestDTO request=new OfflineBackfillRequestDTO();request.setRequestId("cursor-gap");request.setScopes(List.of(cursor("orders","updated_at","100","200"),cursor("orders","updated_at","250","300")));assertThatThrownBy(()->service.submit(10L,request)).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("连续");verify(batchRepository,never()).insert(any(BatchExecution.class));}@Test void invalidScopeProjectionIsRejectedBeforePendingBatchIsPersisted(){OfflineJobDefinition definition=definition("ONLINE");when(definitionService.require(10L)).thenReturn(definition);when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");when(batchRepository.findByTaskIdAndBatchKey(anyLong(),any())).thenReturn(Optional.empty());when(scopeExecutionAdapter.apply(anyLong(),any(),any())).thenThrow(new IllegalStateException("Wave 5 scoped Batch V1 仅支持单表 source"));OfflineBackfillRequestDTO request=new OfflineBackfillRequestDTO();request.setRequestId("invalid-scope");request.setScopes(List.of(window(LocalDateTime.of(2026,8,1,0,0),LocalDateTime.of(2026,8,2,0,0))));assertThatThrownBy(()->service.submit(10L,request)).isInstanceOf(IllegalStateException.class).hasMessageContaining("单表");verify(batchRepository,never()).insert(any(BatchExecution.class));}private OfflineJobDefinition definition(String releaseState){OfflineJobDefinition definition=new OfflineJobDefinition();definition.setId(10L);definition.setReleaseState(releaseState);definition.setDefinitionJson("{\"definition\":1}");definition.setVersion(7);definition.setConfigDigest("digest-7");return definition;}private OfflineBackfillScopeDTO window(LocalDateTime start,LocalDateTime end){OfflineBackfillScopeDTO scope=new OfflineBackfillScopeDTO();scope.setType("DATA_WINDOW");scope.setStartInclusive(start);scope.setEndExclusive(end);return scope;}private OfflineBackfillScopeDTO cursor(String cursorId,String column,String after,String through){OfflineBackfillScopeDTO scope=new OfflineBackfillScopeDTO();scope.setType("CURSOR_RANGE");scope.setCursorId(cursorId);scope.setCursorColumn(column);scope.setAfterExclusive(after);scope.setThroughInclusive(through);return scope;}private BatchExecution persisted(BatchExecution batch,long id){return new BatchExecution(id,batch.taskId(),batch.batchKey(),batch.trigger(),batch.batchScope(),batch.snapshot(),batch.status(),batch.attempts());}}
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineBackfillServiceTest {
+
+  @Mock private OfflineJobDefinitionService definitionService;
+  @Mock private OfflineJobDefinitionRepository definitionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineBackfillPlanner planner;
+
+  private OfflineBackfillService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new OfflineBackfillService(
+        definitionService,
+        definitionRepository,
+        batchRepository,
+        planner);
+  }
+
+  @Test
+  void materializesPlannerScopesWithSharedSnapshot() {
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    OfflineBackfillPlanner.PreparedRequest prepared =
+        new OfflineBackfillPlanner.PreparedRequest("backfill-august", List.of());
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    OfflineBackfillPlanner.ScopePlan first = new OfflineBackfillPlanner.ScopePlan(
+        BatchScope.dataWindow(
+            LocalDateTime.of(2026, 8, 1, 0, 0),
+            LocalDateTime.of(2026, 8, 2, 0, 0)),
+        null);
+    OfflineBackfillPlanner.ScopePlan second = new OfflineBackfillPlanner.ScopePlan(
+        BatchScope.dataWindow(
+            LocalDateTime.of(2026, 8, 2, 0, 0),
+            LocalDateTime.of(2026, 8, 3, 0, 0)),
+        null);
+    ExecutionSnapshot snapshot = snapshot();
+    OfflineBackfillPlanner.Plan plan = new OfflineBackfillPlanner.Plan(
+        "backfill-august",
+        List.of(first, second),
+        Map.of(),
+        snapshot);
+
+    when(planner.prepare(request)).thenReturn(prepared);
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(planner.plan(10L, definition, prepared)).thenReturn(plan);
+    AtomicLong sequence = new AtomicLong(100L);
+    when(batchRepository.insert(any(BatchExecution.class)))
+        .thenAnswer(invocation -> persisted(invocation.getArgument(0), sequence.incrementAndGet()));
+
+    OfflineBackfillVO result = service.submit(10L, request);
+
+    assertThat(result.getCreatedCount()).isEqualTo(2);
+    assertThat(result.getReusedCount()).isZero();
+    assertThat(result.getBatchIds()).containsExactly(101L, 102L);
+    ArgumentCaptor<BatchExecution> captor = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batchRepository, org.mockito.Mockito.times(2)).insert(captor.capture());
+    assertThat(captor.getAllValues()).allMatch(batch -> batch.trigger() == BatchTrigger.BACKFILL);
+    assertThat(captor.getAllValues()).allMatch(batch -> batch.status() == BatchStatus.PENDING);
+    assertThat(captor.getAllValues()).allMatch(batch -> batch.snapshot().equals(snapshot));
+    verify(definitionRepository).lock(10L);
+    verify(planner).plan(10L, definition, prepared);
+  }
+
+  @Test
+  void reusesExistingPlannerBatchWithoutCreatingDuplicate() {
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    OfflineBackfillPlanner.PreparedRequest prepared =
+        new OfflineBackfillPlanner.PreparedRequest("backfill-existing", List.of());
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    OfflineBackfillPlanner.ScopePlan scope =
+        new OfflineBackfillPlanner.ScopePlan(BatchScope.fullSelection(), null);
+    BatchExecution existing = new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill("backfill-existing", scope.scope().fingerprint()),
+        BatchTrigger.BACKFILL,
+        scope.scope(),
+        snapshot(),
+        BatchStatus.SUCCEEDED,
+        List.of());
+    OfflineBackfillPlanner.Plan plan = new OfflineBackfillPlanner.Plan(
+        "backfill-existing",
+        List.of(scope),
+        Map.of(scope.scope().fingerprint(), existing),
+        existing.snapshot());
+
+    when(planner.prepare(request)).thenReturn(prepared);
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(planner.plan(10L, definition, prepared)).thenReturn(plan);
+
+    OfflineBackfillVO result = service.submit(10L, request);
+
+    assertThat(result.getCreatedCount()).isZero();
+    assertThat(result.getReusedCount()).isEqualTo(1);
+    assertThat(result.getBatchIds()).containsExactly(77L);
+    verify(batchRepository, never()).insert(any(BatchExecution.class));
+  }
+
+  @Test
+  void requestValidationHappensBeforeTaskLock() {
+    OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
+    when(planner.prepare(request)).thenThrow(new IllegalArgumentException("scopes 不能为空"));
+
+    assertThatThrownBy(() -> service.submit(10L, request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("scopes");
+
+    verify(definitionRepository, never()).lock(10L);
+  }
+
+  private ExecutionSnapshot snapshot() {
+    return new ExecutionSnapshot(
+        "{\"definition\":1}",
+        7,
+        new RetryPolicySnapshot(2, 10),
+        "digest-7",
+        "{\"kind\":\"BatchSyncJob\"}");
+  }
+
+  private BatchExecution persisted(BatchExecution batch, long id) {
+    return new BatchExecution(
+        id,
+        batch.taskId(),
+        batch.batchKey(),
+        batch.trigger(),
+        batch.batchScope(),
+        batch.snapshot(),
+        batch.status(),
+        batch.attempts());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionAttemptFactoryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionAttemptFactoryTest.java
@@ -1,0 +1,56 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineExecutionAttemptFactoryTest {
+
+  @Test
+  void createsAttemptFromFrozenBatchSnapshot() {
+    OfflineExecutionAttemptFactory factory =
+        new OfflineExecutionAttemptFactory(new OfflineSyncProperties());
+    BatchExecution batch = new BatchExecution(
+        77L,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot(
+            "{\"definition\":\"frozen\"}",
+            3,
+            new RetryPolicySnapshot(3, 30),
+            "frozen-digest",
+            "{\"job\":\"batch-frozen\"}"),
+        BatchStatus.WAITING_RETRY,
+        List.of());
+
+    OfflineJobExecution execution =
+        factory.create(batch, 2, "RETRY", 99L, "offline-retry:77:2");
+
+    assertThat(execution.getJobDefinitionId()).isEqualTo(10L);
+    assertThat(execution.getBatchId()).isEqualTo(77L);
+    assertThat(execution.getDefinitionVersion()).isEqualTo(3);
+    assertThat(execution.getStatus()).isEqualTo("CREATED");
+    assertThat(execution.getAttemptNo()).isEqualTo(2);
+    assertThat(execution.getTriggerType()).isEqualTo("RETRY");
+    assertThat(execution.getRetryFromExecutionId()).isEqualTo(99L);
+    assertThat(execution.getIdempotencyKey()).isEqualTo("offline-retry:77:2");
+    assertThat(execution.getConfigDigest()).isEqualTo("frozen-digest");
+    assertThat(execution.getDefinitionSnapshotJson())
+        .isEqualTo("{\"definition\":\"frozen\"}");
+    assertThat(execution.getSubmittedConfig())
+        .isEqualTo("{\"job\":\"batch-frozen\"}");
+    assertThat(execution.getExternalExecutionId()).startsWith("yak-offline-");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManagerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManagerTest.java
@@ -1,20 +1,251 @@
 package io.yak.ops.business.sync.offline.execution;
 
-import static org.assertj.core.api.Assertions.assertThat;import static org.assertj.core.api.Assertions.assertThatThrownBy;import static org.mockito.ArgumentMatchers.any;import static org.mockito.Mockito.inOrder;import static org.mockito.Mockito.never;import static org.mockito.Mockito.verify;import static org.mockito.Mockito.verifyNoInteractions;import static org.mockito.Mockito.when;
-import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;import io.yak.ops.business.sync.offline.domain.core.BatchExecution;import io.yak.ops.business.sync.offline.domain.core.BatchKey;import io.yak.ops.business.sync.offline.domain.core.BatchScope;import io.yak.ops.business.sync.offline.domain.core.BatchStatus;import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;import io.yak.ops.business.sync.offline.execution.OfflineExecutionClaimManager.ClaimResult;import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;import java.util.List;import java.util.Optional;import java.util.concurrent.atomic.AtomicReference;import org.junit.jupiter.api.BeforeEach;import org.junit.jupiter.api.Test;import org.junit.jupiter.api.extension.ExtendWith;import org.mockito.InOrder;import org.mockito.Mock;import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 class OfflineExecutionClaimManagerTest {
-  @Mock private OfflineJobDefinitionService definitionService;@Mock private OfflineJobDefinitionRepository definitionRepository;@Mock private OfflineJobExecutionRepository executionRepository;@Mock private OfflineBatchExecutionRepository batchRepository;@Mock private OfflineScheduleRepository scheduleRepository;@Mock private OfflineBatchRuntime batchRuntime;private OfflineExecutionClaimManager manager;
-  @BeforeEach void setUp(){manager=new OfflineExecutionClaimManager(definitionService,definitionRepository,executionRepository,batchRepository,scheduleRepository,batchRuntime,new OfflineSyncProperties());}
-  @Test void shouldPersistCreatedExecutionBeforeAnyEngineProbe(){OfflineJobDefinition definition=definition();when(definitionService.require(10L)).thenReturn(definition);when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{\"job\":\"spec\"}");stubBatchInsert(77L);stubExecutionInsert(99L);ClaimResult result=manager.claim(10L,"WORKFLOW",null,1);assertThat(result.getExecution().getId()).isEqualTo(99L);assertThat(result.getExecution().getBatchId()).isEqualTo(77L);assertThat(result.getExecution().getStatus()).isEqualTo("CREATED");verify(definitionRepository).lock(10L);verify(batchRuntime).hasOccupyingBatch(10L);verify(batchRepository).insert(any(BatchExecution.class));verify(executionRepository).insert(result.getExecution());verify(batchRuntime).refreshBatch(77L);}
-  @Test void shouldPersistWorkflowAttemptAsSnapshotIdempotencyKey(){OfflineJobDefinition definition=definition();when(definitionService.require(10L)).thenReturn(definition);when(executionRepository.findByIdempotencyKey("attempt-123")).thenReturn(Optional.empty());stubBatchInsert(78L);stubExecutionInsert(100L);ClaimResult result=manager.claimSnapshot(10L,3L,"digest","{}","{\"job\":\"spec\"}","WORKFLOW","attempt-123");assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("attempt-123");assertThat(result.getExecution().getBatchId()).isEqualTo(78L);assertThat(result.getExecution().getTriggerType()).isEqualTo("WORKFLOW");assertThat(result.isReused()).isFalse();verify(definitionRepository).lock(10L);verify(batchRuntime).hasOccupyingBatch(10L);verify(batchRepository).insert(any(BatchExecution.class));verify(batchRuntime).refreshBatch(78L);}
-  @Test void shouldReuseWorkflowAttemptFromBatchSnapshotInsteadOfAttemptCompatibilityCopies(){OfflineJobDefinition definition=definition();when(definitionService.require(10L)).thenReturn(definition);OfflineJobExecution existing=new OfflineJobExecution();existing.setId(101L);existing.setJobDefinitionId(10L);existing.setBatchId(77L);existing.setDefinitionVersion(999);existing.setConfigDigest("stale-attempt-digest");existing.setDefinitionSnapshotJson("{\"stale\":true}");existing.setSubmittedConfig("{\"job\":\"stale-attempt-copy\"}");existing.setIdempotencyKey("attempt-123");existing.setStatus("SUBMITTED");when(executionRepository.findByIdempotencyKey("attempt-123")).thenReturn(Optional.of(existing));when(batchRepository.findById(77L)).thenReturn(Optional.of(workflowBatch()));ClaimResult result=manager.claimSnapshot(10L,3L,"digest","{}","{\"job\":\"spec\"}","WORKFLOW","attempt-123");assertThat(result.getExecution()).isSameAs(existing);assertThat(result.getLogicalJobSpecJson()).isEqualTo("{\"job\":\"spec\"}");assertThat(result.isReused()).isTrue();verify(batchRuntime,never()).hasOccupyingBatch(10L);verify(batchRepository,never()).insert(any(BatchExecution.class));verify(executionRepository,never()).insert(any(OfflineJobExecution.class));}
-  @Test void shouldRejectLegacyIdempotencyReuseWithoutBatchIdentity(){OfflineJobDefinition definition=definition();when(definitionService.require(10L)).thenReturn(definition);OfflineJobExecution history=new OfflineJobExecution();history.setId(101L);history.setJobDefinitionId(10L);history.setIdempotencyKey("attempt-123");history.setStatus("SUCCEEDED");when(executionRepository.findByIdempotencyKey("attempt-123")).thenReturn(Optional.of(history));assertThatThrownBy(()->manager.claimSnapshot(10L,3L,"digest","{}","{\"job\":\"spec\"}","WORKFLOW","attempt-123")).isInstanceOf(IllegalStateException.class).hasMessageContaining("未绑定 Batch").hasMessageContaining("仅支持查询");verify(batchRepository,never()).insert(any(BatchExecution.class));verify(executionRepository,never()).insert(any(OfflineJobExecution.class));}
-  @Test void retryReadsLogicalJobSpecFromBatchSnapshotNotLegacyAttemptCopy(){OfflineJobExecution previous=failedAttempt(99L,77L,1,"{\"job\":\"stale-attempt-copy\"}");BatchExecution batch=frozenBatch(77L,3,BatchStatus.WAITING_RETRY);when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));when(executionRepository.reserveRetry(99L)).thenReturn(true);stubExecutionInsert(100L);ClaimResult result=manager.claimRetry(99L);OfflineJobExecution retry=result.getExecution();assertThat(retry.getBatchId()).isEqualTo(77L);assertThat(retry.getAttemptNo()).isEqualTo(2);assertThat(retry.getRetryFromExecutionId()).isEqualTo(99L);assertThat(retry.getTriggerType()).isEqualTo("RETRY");assertThat(retry.getDefinitionVersion()).isEqualTo(3);assertThat(retry.getConfigDigest()).isEqualTo("frozen-digest");assertThat(retry.getDefinitionSnapshotJson()).isEqualTo("{\"definition\":\"frozen\"}");assertThat(retry.getSubmittedConfig()).isEqualTo("{\"job\":\"batch-frozen\"}");assertThat(retry.getIdempotencyKey()).isEqualTo("offline-retry:77:2");InOrder order=inOrder(executionRepository);order.verify(executionRepository).reserveRetry(99L);order.verify(executionRepository).insert(retry);verify(batchRuntime).refreshBatch(77L);verifyNoInteractions(definitionService,definitionRepository,scheduleRepository);}
-  @Test void pendingBackfillReservationPrecedesAttemptOneInsertAndUsesFrozenSnapshot(){BatchExecution pending=new BatchExecution(77L,10L,BatchKey.backfill("bf-1",BatchScope.partitions(List.of("2026-08-01")).fingerprint()),BatchTrigger.BACKFILL,BatchScope.partitions(List.of("2026-08-01")),snapshot(3),BatchStatus.PENDING,List.of());when(batchRepository.findById(77L)).thenReturn(Optional.of(pending));when(executionRepository.findByBatchId(77L)).thenReturn(List.of());when(batchRuntime.hasOccupyingBatch(10L)).thenReturn(false);when(batchRepository.reservePendingBackfill(77L)).thenReturn(true);stubExecutionInsert(501L);ClaimResult result=manager.claimPendingBackfill(77L);assertThat(result.getExecution().getAttemptNo()).isEqualTo(1);assertThat(result.getExecution().getTriggerType()).isEqualTo("BACKFILL");assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("offline-backfill:77:1");InOrder order=inOrder(batchRepository,executionRepository);order.verify(batchRepository).reservePendingBackfill(77L);order.verify(executionRepository).insert(result.getExecution());verify(definitionRepository).lock(10L);verifyNoInteractions(definitionService,scheduleRepository);verify(batchRuntime).refreshBatch(77L);}
-  @Test void shouldRejectUnknownWithoutBlindRetry(){OfflineJobExecution previous=failedAttempt(99L,77L,1,"{}");previous.setStatus("UNKNOWN");when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L,3,BatchStatus.UNKNOWN)));assertThatThrownBy(()->manager.claimRetry(99L)).isInstanceOf(IllegalStateException.class).hasMessageContaining("UNKNOWN").hasMessageContaining("reconcile");verify(executionRepository,never()).reserveRetry(99L);}
-  @Test void shouldRespectFrozenRetryMaxAttempts(){OfflineJobExecution previous=failedAttempt(99L,77L,1,"{}");when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(77L,1,BatchStatus.WAITING_RETRY)));when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));assertThatThrownBy(()->manager.claimRetry(99L)).isInstanceOf(IllegalStateException.class).hasMessageContaining("最大 Attempt");verify(executionRepository,never()).reserveRetry(99L);}
-  @Test void shouldRejectLegacyRetryWithoutBatchIdentity(){OfflineJobExecution previous=failedAttempt(99L,null,1,"{}");when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));assertThatThrownBy(()->manager.claimRetry(99L)).isInstanceOf(IllegalStateException.class).hasMessageContaining("未绑定 Batch").hasMessageContaining("历史查询");}
-  private OfflineJobDefinition definition(){OfflineJobDefinition definition=new OfflineJobDefinition();definition.setId(10L);definition.setReleaseState("ONLINE");definition.setVersion(3);definition.setConfigDigest("digest");definition.setDefinitionJson("{}");return definition;}private OfflineJobExecution failedAttempt(Long id,Long batchId,int attemptNo,String submittedConfig){OfflineJobExecution execution=new OfflineJobExecution();execution.setId(id);execution.setJobDefinitionId(10L);execution.setBatchId(batchId);execution.setAttemptNo(attemptNo);execution.setStatus("FAILED");execution.setSubmittedConfig(submittedConfig);execution.setRetryCreated(false);return execution;}private BatchExecution workflowBatch(){return new BatchExecution(77L,10L,BatchKey.workflow("attempt-123"),BatchTrigger.WORKFLOW,BatchScope.fullSelection(),new ExecutionSnapshot("{}",3,new RetryPolicySnapshot(1,0),"digest","{\"job\":\"spec\"}"),BatchStatus.RUNNING,List.of());}private BatchExecution frozenBatch(long id,int maxAttempts,BatchStatus status){return new BatchExecution(id,10L,new BatchKey("manual:test"),BatchTrigger.MANUAL,BatchScope.fullSelection(),snapshot(maxAttempts),status,List.of());}private ExecutionSnapshot snapshot(int maxAttempts){return new ExecutionSnapshot("{\"definition\":\"frozen\"}",3,new RetryPolicySnapshot(maxAttempts,30),"frozen-digest","{\"job\":\"batch-frozen\"}");}
-  private void stubBatchInsert(long id){AtomicReference<BatchExecution> saved=new AtomicReference<>();when(batchRepository.insert(any(BatchExecution.class))).thenAnswer(invocation->{BatchExecution batch=invocation.getArgument(0);BatchExecution inserted=new BatchExecution(id,batch.taskId(),batch.batchKey(),batch.trigger(),batch.batchScope(),batch.snapshot(),batch.status(),batch.attempts());saved.set(inserted);return inserted;});when(batchRepository.findById(id)).thenAnswer(ignored->Optional.ofNullable(saved.get()));}private void stubExecutionInsert(long id){when(executionRepository.insert(any(OfflineJobExecution.class))).thenAnswer(invocation->{OfflineJobExecution execution=invocation.getArgument(0);execution.setId(id);return true;});}
+
+  @Mock private OfflineJobDefinitionService definitionService;
+  @Mock private OfflineJobDefinitionRepository definitionRepository;
+  @Mock private OfflineJobExecutionRepository executionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineScheduleRepository scheduleRepository;
+  @Mock private OfflineBatchRuntime batchRuntime;
+  @Mock private OfflineExecutionAttemptFactory attemptFactory;
+  @Mock private OfflineExistingBatchClaimManager existingBatchClaimManager;
+
+  private OfflineExecutionClaimManager manager;
+
+  @BeforeEach
+  void setUp() {
+    manager = new OfflineExecutionClaimManager(
+        definitionService,
+        definitionRepository,
+        executionRepository,
+        batchRepository,
+        scheduleRepository,
+        batchRuntime,
+        new OfflineSyncProperties(),
+        attemptFactory,
+        existingBatchClaimManager);
+  }
+
+  @Test
+  void initialClaimCreatesBatchThenAttemptThroughFactory() {
+    OfflineJobDefinition definition = definition();
+    OfflineJobExecution execution = execution();
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(definitionService.resolveLogicalJobSpec(definition))
+        .thenReturn("{\"job\":\"spec\"}");
+    stubBatchInsert(77L);
+    when(attemptFactory.create(any(BatchExecution.class), eq(1), eq("WORKFLOW"), eq(null), anyString()))
+        .thenReturn(execution);
+    when(executionRepository.insert(execution))
+        .thenAnswer(ignored -> {
+          execution.setId(99L);
+          return true;
+        });
+
+    OfflineExecutionClaim result = manager.claim(10L, "WORKFLOW", null, 1);
+
+    assertThat(result.getExecution().getId()).isEqualTo(99L);
+    verify(definitionRepository).lock(10L);
+    verify(batchRuntime).hasOccupyingBatch(10L);
+    verify(batchRepository).insert(any(BatchExecution.class));
+    verify(attemptFactory)
+        .create(any(BatchExecution.class), eq(1), eq("WORKFLOW"), eq(null), anyString());
+    verify(executionRepository).insert(execution);
+    verify(batchRuntime).refreshBatch(77L);
+    verifyNoInteractions(existingBatchClaimManager);
+  }
+
+  @Test
+  void workflowSnapshotKeepsAttemptIdempotencyKey() {
+    OfflineJobDefinition definition = definition();
+    OfflineJobExecution execution = execution();
+    when(definitionService.require(10L)).thenReturn(definition);
+    when(executionRepository.findByIdempotencyKey("attempt-123")).thenReturn(Optional.empty());
+    stubBatchInsert(78L);
+    when(attemptFactory.create(
+            any(BatchExecution.class),
+            eq(1),
+            eq("WORKFLOW"),
+            eq(null),
+            eq("attempt-123")))
+        .thenReturn(execution);
+    when(executionRepository.insert(execution))
+        .thenAnswer(ignored -> {
+          execution.setId(100L);
+          return true;
+        });
+
+    OfflineExecutionClaim result = manager.claimSnapshot(
+        10L,
+        3L,
+        "digest",
+        "{}",
+        "{\"job\":\"spec\"}",
+        "WORKFLOW",
+        "attempt-123");
+
+    assertThat(result.isReused()).isFalse();
+    verify(attemptFactory)
+        .create(any(BatchExecution.class), 1, "WORKFLOW", null, "attempt-123");
+    verify(batchRuntime).refreshBatch(78L);
+  }
+
+  @Test
+  void workflowIdempotencyReuseReadsFrozenBatchSnapshot() {
+    OfflineJobDefinition definition = definition();
+    when(definitionService.require(10L)).thenReturn(definition);
+    OfflineJobExecution existing = execution();
+    existing.setId(101L);
+    existing.setJobDefinitionId(10L);
+    existing.setBatchId(77L);
+    existing.setIdempotencyKey("attempt-123");
+    existing.setStatus("SUBMITTED");
+    when(executionRepository.findByIdempotencyKey("attempt-123"))
+        .thenReturn(Optional.of(existing));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(workflowBatch()));
+
+    OfflineExecutionClaim result = manager.claimSnapshot(
+        10L,
+        3L,
+        "digest",
+        "{}",
+        "{\"job\":\"spec\"}",
+        "WORKFLOW",
+        "attempt-123");
+
+    assertThat(result.getExecution()).isSameAs(existing);
+    assertThat(result.getLogicalJobSpecJson()).isEqualTo("{\"job\":\"spec\"}");
+    assertThat(result.isReused()).isTrue();
+    verify(batchRuntime, never()).hasOccupyingBatch(10L);
+    verify(attemptFactory, never()).create(any(), any(Integer.class), anyString(), any(), anyString());
+  }
+
+  @Test
+  void legacyIdempotencyReuseWithoutBatchIdentityIsRejected() {
+    OfflineJobDefinition definition = definition();
+    when(definitionService.require(10L)).thenReturn(definition);
+    OfflineJobExecution history = execution();
+    history.setId(101L);
+    history.setJobDefinitionId(10L);
+    history.setIdempotencyKey("attempt-123");
+    history.setStatus("SUCCEEDED");
+    when(executionRepository.findByIdempotencyKey("attempt-123"))
+        .thenReturn(Optional.of(history));
+
+    assertThatThrownBy(
+            () -> manager.claimSnapshot(
+                10L,
+                3L,
+                "digest",
+                "{}",
+                "{\"job\":\"spec\"}",
+                "WORKFLOW",
+                "attempt-123"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("未绑定 Batch")
+        .hasMessageContaining("仅支持查询");
+  }
+
+  @Test
+  void existingBatchClaimsDelegateToSpecializedManager() {
+    OfflineExecutionClaim retry = new OfflineExecutionClaim(null, "retry", execution());
+    OfflineExecutionClaim backfill = new OfflineExecutionClaim(null, "backfill", execution());
+    when(existingBatchClaimManager.claimRetry(99L)).thenReturn(retry);
+    when(existingBatchClaimManager.claimPendingBackfill(77L)).thenReturn(backfill);
+
+    assertThat(manager.claimRetry(99L)).isSameAs(retry);
+    assertThat(manager.claimPendingBackfill(77L)).isSameAs(backfill);
+
+    verify(existingBatchClaimManager).claimRetry(99L);
+    verify(existingBatchClaimManager).claimPendingBackfill(77L);
+  }
+
+  private OfflineJobDefinition definition() {
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState("ONLINE");
+    definition.setVersion(3);
+    definition.setConfigDigest("digest");
+    definition.setDefinitionJson("{}");
+    return definition;
+  }
+
+  private OfflineJobExecution execution() {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setStatus("CREATED");
+    return execution;
+  }
+
+  private BatchExecution workflowBatch() {
+    return new BatchExecution(
+        77L,
+        10L,
+        BatchKey.workflow("attempt-123"),
+        BatchTrigger.WORKFLOW,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot(
+            "{}",
+            3,
+            new RetryPolicySnapshot(1, 0),
+            "digest",
+            "{\"job\":\"spec\"}"),
+        BatchStatus.RUNNING,
+        List.of());
+  }
+
+  private void stubBatchInsert(long id) {
+    AtomicReference<BatchExecution> saved = new AtomicReference<>();
+    when(batchRepository.insert(any(BatchExecution.class)))
+        .thenAnswer(invocation -> {
+          BatchExecution batch = invocation.getArgument(0);
+          BatchExecution inserted = new BatchExecution(
+              id,
+              batch.taskId(),
+              batch.batchKey(),
+              batch.trigger(),
+              batch.batchScope(),
+              batch.snapshot(),
+              batch.status(),
+              batch.attempts());
+          saved.set(inserted);
+          return inserted;
+        });
+    when(batchRepository.findById(id)).thenAnswer(ignored -> Optional.ofNullable(saved.get()));
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinatorTest.java
@@ -1,18 +1,189 @@
 package io.yak.ops.business.sync.offline.execution;
 
-import static org.assertj.core.api.Assertions.assertThat;import static org.assertj.core.api.Assertions.assertThatThrownBy;import static org.mockito.ArgumentMatchers.any;import static org.mockito.Mockito.atLeastOnce;import static org.mockito.Mockito.never;import static org.mockito.Mockito.verify;import static org.mockito.Mockito.verifyNoInteractions;import static org.mockito.Mockito.when;
-import com.fasterxml.jackson.databind.ObjectMapper;import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;import io.yak.ops.business.sync.offline.domain.core.BatchExecution;import io.yak.ops.business.sync.offline.domain.core.BatchKey;import io.yak.ops.business.sync.offline.domain.core.BatchScope;import io.yak.ops.business.sync.offline.domain.core.BatchStatus;import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;import io.yak.ops.business.sync.offline.engine.LinkUpClient;import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;import io.yak.ops.business.sync.offline.execution.OfflineExecutionClaimManager.ClaimResult;import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;import java.net.ConnectException;import java.util.List;import java.util.Optional;import org.junit.jupiter.api.BeforeEach;import org.junit.jupiter.api.Test;import org.junit.jupiter.api.extension.ExtendWith;import org.mockito.Mock;import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
+import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.net.ConnectException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 class OfflineExecutionCoordinatorTest {
-  @Mock private OfflineJobDefinitionService definitionService;@Mock private OfflineExecutionClaimManager claimManager;@Mock private OfflineJobDefinitionRepository definitionRepository;@Mock private OfflineJobExecutionRepository executionRepository;@Mock private OfflineBatchExecutionRepository batchRepository;@Mock private OfflineBatchRuntime batchRuntime;@Mock private OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;@Mock private OfflineExecutionEventRepository eventRepository;@Mock private LinkUpClient linkUpClient;private OfflineExecutionCoordinator coordinator;
-  @BeforeEach void setUp(){coordinator=new OfflineExecutionCoordinator(definitionService,claimManager,definitionRepository,executionRepository,batchRepository,batchRuntime,scopeExecutionAdapter,eventRepository,linkUpClient,new ObjectMapper());}
-  @Test void shouldScheduleFailedRetryFromFrozenBatchPolicyAndDualWriteBatchTruth(){OfflineJobDefinition definition=new OfflineJobDefinition();definition.setId(10L);OfflineJobExecution execution=execution(99L,"CREATED");BatchExecution batch=frozenBatch(BatchStatus.RUNNING,BatchScope.fullSelection());when(claimManager.claim(10L,"WORKFLOW",null,1)).thenReturn(new ClaimResult(definition,"{}",execution));when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));when(scopeExecutionAdapter.apply(10L,"{}",batch.batchScope())).thenReturn("{}");when(definitionService.resolveExecutionJobSpec("{}")).thenReturn("{}");when(definitionRepository.findById(10L)).thenReturn(Optional.of(definition));when(linkUpClient.node()).thenThrow(new LinkUpTransportException("无法连接 Link-Up Server：http://127.0.0.1:18080",new ConnectException(),false));assertThatThrownBy(()->coordinator.execute(10L,"WORKFLOW",null,1)).isInstanceOf(LinkUpTransportException.class);assertThat(execution.getStatus()).isEqualTo("FAILED");assertThat(execution.getNextRetryTime()).isNotNull();verify(batchRuntime,atLeastOnce()).persistAttempt(execution);verify(batchRepository,atLeastOnce()).findById(77L);verify(scopeExecutionAdapter).apply(10L,"{}",batch.batchScope());verify(eventRepository,atLeastOnce()).append(any());}
-  @Test void retryKeepsOriginalBatchScopeAtSubmissionBoundary(){OfflineJobExecution previous=execution(98L,"FAILED");OfflineJobExecution retry=execution(99L,"CREATED");retry.setAttemptNo(2);BatchScope.CursorRange range=BatchScope.cursorRange("orders","100","200");BatchExecution batch=frozenBatch(BatchStatus.RUNNING,range);when(claimManager.claimRetry(98L)).thenReturn(new ClaimResult(null,"logical",retry));when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));when(scopeExecutionAdapter.apply(10L,"logical",range)).thenReturn("scoped");when(definitionService.resolveExecutionJobSpec("scoped")).thenReturn("{}");when(linkUpClient.node()).thenThrow(new LinkUpTransportException("engine down",new ConnectException(),false));assertThatThrownBy(()->coordinator.retryFrom(previous)).isInstanceOf(LinkUpTransportException.class);verify(scopeExecutionAdapter).apply(10L,"logical",range);}
-  @Test void reusedSubmittedBackfillDoesNotSubmitAgain(){OfflineJobExecution existing=execution(99L,"SUBMITTED");when(claimManager.claimPendingBackfill(77L)).thenReturn(new ClaimResult(null,"logical",existing,true));assertThat(coordinator.executePendingBackfill(77L)).isSameAs(existing);verifyNoInteractions(scopeExecutionAdapter,linkUpClient);}
-  @Test void shouldMoveUncertainExecutionToUnknownAndDualWriteBatchTruth(){OfflineJobExecution execution=execution(99L,"RUNNING");execution.setStateVersion(3L);execution.setNextRetryTime(java.time.LocalDateTime.now().plusMinutes(1));execution.setEndTime(java.time.LocalDateTime.now());when(definitionRepository.findById(10L)).thenReturn(Optional.empty());coordinator.markUnknown(execution,"状态无法确认");assertThat(execution.getStatus()).isEqualTo("UNKNOWN");assertThat(execution.getNextRetryTime()).isNull();assertThat(execution.getEndTime()).isNull();verify(batchRuntime).persistAttempt(execution);verify(eventRepository).append(any());}
-  @Test void oldAttemptLateEventDoesNotOverwriteTaskLastProjection(){OfflineJobExecution oldAttempt=execution(99L,"RUNNING");oldAttempt.setAttemptNo(1);OfflineJobExecution latestAttempt=execution(100L,"RUNNING");latestAttempt.setAttemptNo(2);when(executionRepository.findByBatchId(77L)).thenReturn(List.of(oldAttempt,latestAttempt));coordinator.markUnknown(oldAttempt,"旧 Attempt 晚到对账结果");verify(batchRuntime).persistAttempt(oldAttempt);verify(definitionRepository,never()).findById(10L);verify(definitionRepository,never()).update(any(OfflineJobDefinition.class));}
-  @Test void shouldCancelWaitingRetryFromBatchTruthWithoutReadingTaskLastExecution(){BatchExecution waiting=frozenBatch(BatchStatus.WAITING_RETRY,BatchScope.fullSelection());OfflineJobExecution latest=execution(99L,"FAILED");latest.setStateVersion(4L);when(batchRuntime.requireLatestOccupyingBatch(10L)).thenReturn(waiting);when(batchRuntime.cancelWaitingRetry(waiting)).thenReturn(latest);when(definitionRepository.findById(10L)).thenReturn(Optional.empty());assertThat(coordinator.cancelLatestBatch(10L)).isSameAs(latest);verify(batchRuntime).requireLatestOccupyingBatch(10L);verify(batchRuntime).cancelWaitingRetry(waiting);verifyNoInteractions(definitionService);verify(eventRepository).append(any());}
-  @Test void batchlessLegacyExecutionIsHistoryOnlyAndCannotBeCanceled(){OfflineJobExecution history=execution(99L,"RUNNING");history.setBatchId(null);when(executionRepository.findById(99L)).thenReturn(Optional.of(history));assertThatThrownBy(()->coordinator.cancel(99L)).isInstanceOf(IllegalStateException.class).hasMessageContaining("未绑定 Batch").hasMessageContaining("仅支持查询");verify(batchRuntime,never()).persistAttempt(any(OfflineJobExecution.class));verifyNoInteractions(linkUpClient);}
-  @Test void batchlessLegacyExecutionCannotEnterUnknownReconcile(){OfflineJobExecution history=execution(99L,"RUNNING");history.setBatchId(null);assertThatThrownBy(()->coordinator.markUnknown(history,"legacy timeout")).isInstanceOf(IllegalStateException.class).hasMessageContaining("未绑定 Batch").hasMessageContaining("仅支持查询");verify(batchRuntime,never()).persistAttempt(any(OfflineJobExecution.class));verify(definitionRepository,never()).update(any(OfflineJobDefinition.class));}
-  private OfflineJobExecution execution(long id,String status){OfflineJobExecution execution=new OfflineJobExecution();execution.setId(id);execution.setJobDefinitionId(10L);execution.setBatchId(77L);execution.setStatus(status);execution.setStateVersion(1L);execution.setAttemptNo(1);return execution;}private BatchExecution frozenBatch(BatchStatus status,BatchScope scope){return new BatchExecution(77L,10L,new BatchKey("manual:test"),BatchTrigger.MANUAL,scope,new ExecutionSnapshot("{}",1,new RetryPolicySnapshot(3,30),"digest","logical"),status,List.of());}
+
+  @Mock private OfflineJobDefinitionService definitionService;
+  @Mock private OfflineExecutionClaimManager claimManager;
+  @Mock private OfflineJobExecutionRepository executionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineBatchRuntime batchRuntime;
+  @Mock private OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+  @Mock private OfflineExecutionStateManager stateManager;
+  @Mock private LinkUpClient linkUpClient;
+
+  private OfflineExecutionCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    coordinator = new OfflineExecutionCoordinator(
+        definitionService,
+        claimManager,
+        executionRepository,
+        batchRepository,
+        batchRuntime,
+        scopeExecutionAdapter,
+        stateManager,
+        linkUpClient,
+        new ObjectMapper());
+  }
+
+  @Test
+  void transportFailureDelegatesStateDecisionWithoutOwningRetryPolicy() {
+    OfflineJobExecution execution = execution(99L, "CREATED");
+    BatchExecution batch = frozenBatch(BatchStatus.RUNNING, BatchScope.fullSelection());
+    when(claimManager.claim(10L, "WORKFLOW", null, 1))
+        .thenReturn(new OfflineExecutionClaim(null, "{}", execution));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+    when(scopeExecutionAdapter.apply(10L, "{}", batch.batchScope())).thenReturn("{}");
+    when(definitionService.resolveExecutionJobSpec("{}")).thenReturn("{}");
+    when(linkUpClient.node())
+        .thenThrow(
+            new LinkUpTransportException(
+                "无法连接 Link-Up Server：http://127.0.0.1:18080",
+                new ConnectException(),
+                false));
+
+    assertThatThrownBy(() -> coordinator.execute(10L, "WORKFLOW", null, 1))
+        .isInstanceOf(LinkUpTransportException.class);
+
+    verify(stateManager).recordCreated(execution);
+    verify(stateManager)
+        .markFailed(execution, "无法连接 Link-Up Server：http://127.0.0.1:18080", true);
+    verify(scopeExecutionAdapter).apply(10L, "{}", batch.batchScope());
+  }
+
+  @Test
+  void retryKeepsOriginalBatchScopeAtSubmissionBoundary() {
+    OfflineJobExecution previous = execution(98L, "FAILED");
+    OfflineJobExecution retry = execution(99L, "CREATED");
+    retry.setAttemptNo(2);
+    BatchScope.CursorRange range = BatchScope.cursorRange("orders", "100", "200");
+    BatchExecution batch = frozenBatch(BatchStatus.RUNNING, range);
+    when(claimManager.claimRetry(98L))
+        .thenReturn(new OfflineExecutionClaim(null, "logical", retry));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+    when(scopeExecutionAdapter.apply(10L, "logical", range)).thenReturn("scoped");
+    when(definitionService.resolveExecutionJobSpec("scoped")).thenReturn("{}");
+    when(linkUpClient.node())
+        .thenThrow(new LinkUpTransportException("engine down", new ConnectException(), false));
+
+    assertThatThrownBy(() -> coordinator.retryFrom(previous))
+        .isInstanceOf(LinkUpTransportException.class);
+
+    verify(scopeExecutionAdapter).apply(10L, "logical", range);
+    verify(stateManager).markFailed(retry, "engine down", true);
+  }
+
+  @Test
+  void reusedSubmittedBackfillDoesNotSubmitAgain() {
+    OfflineJobExecution existing = execution(99L, "SUBMITTED");
+    when(claimManager.claimPendingBackfill(77L))
+        .thenReturn(new OfflineExecutionClaim(null, "logical", existing, true));
+
+    assertThat(coordinator.executePendingBackfill(77L)).isSameAs(existing);
+
+    verifyNoInteractions(scopeExecutionAdapter, linkUpClient, stateManager);
+  }
+
+  @Test
+  void waitingRetryCancelUsesBatchTruthThenDelegatesProjection() {
+    BatchExecution waiting = frozenBatch(BatchStatus.WAITING_RETRY, BatchScope.fullSelection());
+    OfflineJobExecution latest = execution(99L, "FAILED");
+    when(batchRuntime.requireLatestOccupyingBatch(10L)).thenReturn(waiting);
+    when(batchRuntime.cancelWaitingRetry(waiting)).thenReturn(latest);
+
+    assertThat(coordinator.cancelLatestBatch(10L)).isSameAs(latest);
+
+    verify(batchRuntime).requireLatestOccupyingBatch(10L);
+    verify(batchRuntime).cancelWaitingRetry(waiting);
+    verify(stateManager).markWaitingRetryCanceled(latest);
+  }
+
+  @Test
+  void batchlessLegacyExecutionIsHistoryOnlyAndCannotBeCanceled() {
+    OfflineJobExecution history = execution(99L, "RUNNING");
+    history.setBatchId(null);
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(history));
+
+    assertThatThrownBy(() -> coordinator.cancel(99L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("未绑定 Batch")
+        .hasMessageContaining("仅支持查询");
+
+    verify(stateManager, never()).markCancellationRequested(history);
+    verifyNoInteractions(linkUpClient);
+  }
+
+  @Test
+  void reconcilerStateEntrypointsDelegateToStateManager() {
+    OfflineJobExecution execution = execution(99L, "RUNNING");
+    LinkUpJobResponse response = new LinkUpJobResponse();
+
+    coordinator.applySnapshot(execution, response, "RECONCILED");
+    coordinator.markUnknown(execution, "状态无法确认");
+
+    verify(stateManager).applySnapshot(execution, response, "RECONCILED");
+    verify(stateManager).markUnknown(execution, "状态无法确认");
+  }
+
+  private OfflineJobExecution execution(long id, String status) {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(id);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(77L);
+    execution.setStatus(status);
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(1);
+    return execution;
+  }
+
+  private BatchExecution frozenBatch(BatchStatus status, BatchScope scope) {
+    return new BatchExecution(
+        77L,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        scope,
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(3, 30),
+            "digest",
+            "logical"),
+        status,
+        List.of());
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionStateManagerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionStateManagerTest.java
@@ -1,0 +1,160 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineExecutionStateManagerTest {
+
+  @Mock private OfflineJobDefinitionRepository definitionRepository;
+  @Mock private OfflineJobExecutionRepository executionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineExecutionEventRepository eventRepository;
+  @Mock private OfflineBatchRuntime batchRuntime;
+
+  private OfflineExecutionStateManager stateManager;
+
+  @BeforeEach
+  void setUp() {
+    stateManager = new OfflineExecutionStateManager(
+        definitionRepository,
+        executionRepository,
+        batchRepository,
+        eventRepository,
+        batchRuntime,
+        new ObjectMapper());
+  }
+
+  @Test
+  void failedAttemptSchedulesRetryFromFrozenBatchPolicy() {
+    OfflineJobExecution execution = execution(99L, "SUBMITTED");
+    BatchExecution batch = frozenBatch(BatchStatus.FAILED);
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(execution));
+    when(definitionRepository.findById(10L)).thenReturn(Optional.of(definition));
+
+    stateManager.markFailed(execution, "engine down", true);
+
+    assertThat(execution.getStatus()).isEqualTo("FAILED");
+    assertThat(execution.getNextRetryTime()).isNotNull();
+    verify(batchRuntime).persistAttempt(execution);
+    verify(definitionRepository).update(definition);
+    verify(eventRepository).append(any());
+  }
+
+  @Test
+  void unknownClearsRetryWindowAndEndTime() {
+    OfflineJobExecution execution = execution(99L, "RUNNING");
+    execution.setStateVersion(3L);
+    execution.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
+    execution.setEndTime(LocalDateTime.now());
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(execution));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(frozenBatch(BatchStatus.UNKNOWN)));
+    when(definitionRepository.findById(10L)).thenReturn(Optional.empty());
+
+    stateManager.markUnknown(execution, "状态无法确认");
+
+    assertThat(execution.getStatus()).isEqualTo("UNKNOWN");
+    assertThat(execution.getNextRetryTime()).isNull();
+    assertThat(execution.getEndTime()).isNull();
+    verify(batchRuntime).persistAttempt(execution);
+    verify(eventRepository).append(any());
+  }
+
+  @Test
+  void oldAttemptLateEventDoesNotOverwriteTaskProjection() {
+    OfflineJobExecution oldAttempt = execution(99L, "RUNNING");
+    oldAttempt.setAttemptNo(1);
+    OfflineJobExecution latestAttempt = execution(100L, "RUNNING");
+    latestAttempt.setAttemptNo(2);
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(oldAttempt, latestAttempt));
+
+    stateManager.markUnknown(oldAttempt, "旧 Attempt 晚到对账结果");
+
+    verify(batchRuntime).persistAttempt(oldAttempt);
+    verify(definitionRepository, never()).findById(10L);
+    verify(definitionRepository, never()).update(any(OfflineJobDefinition.class));
+  }
+
+  @Test
+  void cancellationIntentIsPersistedAndRecorded() {
+    OfflineJobExecution execution = execution(99L, "RUNNING");
+
+    stateManager.markCancellationRequested(execution);
+
+    assertThat(execution.getCancellationRequested()).isTrue();
+    verify(batchRuntime).persistAttempt(execution);
+    verify(eventRepository).append(any());
+  }
+
+  @Test
+  void batchlessLegacyExecutionCannotEnterUnknownReconcile() {
+    OfflineJobExecution history = execution(99L, "RUNNING");
+    history.setBatchId(null);
+
+    assertThatThrownBy(() -> stateManager.markUnknown(history, "legacy timeout"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("未绑定 Batch")
+        .hasMessageContaining("仅支持查询");
+
+    verifyNoInteractions(batchRuntime, eventRepository, definitionRepository);
+  }
+
+  private OfflineJobExecution execution(long id, String status) {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(id);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(77L);
+    execution.setStatus(status);
+    execution.setStateVersion(1L);
+    execution.setAttemptNo(1);
+    return execution;
+  }
+
+  private BatchExecution frozenBatch(BatchStatus status) {
+    return new BatchExecution(
+        77L,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(3, 30),
+            "digest",
+            "logical"),
+        status,
+        List.of());
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExistingBatchClaimManagerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExistingBatchClaimManagerTest.java
@@ -1,0 +1,193 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineExistingBatchClaimManagerTest {
+
+  @Mock private OfflineJobDefinitionRepository definitionRepository;
+  @Mock private OfflineJobExecutionRepository executionRepository;
+  @Mock private OfflineBatchExecutionRepository batchRepository;
+  @Mock private OfflineBatchRuntime batchRuntime;
+
+  private OfflineExistingBatchClaimManager manager;
+
+  @BeforeEach
+  void setUp() {
+    manager = new OfflineExistingBatchClaimManager(
+        definitionRepository,
+        executionRepository,
+        batchRepository,
+        batchRuntime,
+        new OfflineExecutionAttemptFactory(new OfflineSyncProperties()));
+  }
+
+  @Test
+  void retryUsesFrozenBatchAndReservesBeforeAttemptInsert() {
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1);
+    BatchExecution batch = frozenBatch(77L, 3, BatchStatus.WAITING_RETRY);
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));
+    when(executionRepository.reserveRetry(99L)).thenReturn(true);
+    when(executionRepository.insert(any(OfflineJobExecution.class)))
+        .thenAnswer(invocation -> {
+          OfflineJobExecution execution = invocation.getArgument(0);
+          execution.setId(100L);
+          return true;
+        });
+
+    OfflineExecutionClaim result = manager.claimRetry(99L);
+    OfflineJobExecution retry = result.getExecution();
+
+    assertThat(result.getLogicalJobSpecJson()).isEqualTo("{\"job\":\"batch-frozen\"}");
+    assertThat(retry.getBatchId()).isEqualTo(77L);
+    assertThat(retry.getAttemptNo()).isEqualTo(2);
+    assertThat(retry.getRetryFromExecutionId()).isEqualTo(99L);
+    assertThat(retry.getTriggerType()).isEqualTo("RETRY");
+    assertThat(retry.getIdempotencyKey()).isEqualTo("offline-retry:77:2");
+
+    InOrder order = inOrder(executionRepository);
+    order.verify(executionRepository).reserveRetry(99L);
+    order.verify(executionRepository).insert(retry);
+    verify(batchRuntime).refreshBatch(77L);
+    verifyNoInteractions(definitionRepository);
+  }
+
+  @Test
+  void pendingBackfillReservesBatchBeforeAttemptOneInsert() {
+    BatchExecution pending = new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill(
+            "bf-1", BatchScope.partitions(List.of("2026-08-01")).fingerprint()),
+        BatchTrigger.BACKFILL,
+        BatchScope.partitions(List.of("2026-08-01")),
+        snapshot(3),
+        BatchStatus.PENDING,
+        List.of());
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(pending));
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of());
+    when(batchRuntime.hasOccupyingBatch(10L)).thenReturn(false);
+    when(batchRepository.reservePendingBackfill(77L)).thenReturn(true);
+    when(executionRepository.insert(any(OfflineJobExecution.class)))
+        .thenAnswer(invocation -> {
+          OfflineJobExecution execution = invocation.getArgument(0);
+          execution.setId(501L);
+          return true;
+        });
+
+    OfflineExecutionClaim result = manager.claimPendingBackfill(77L);
+
+    assertThat(result.getExecution().getAttemptNo()).isEqualTo(1);
+    assertThat(result.getExecution().getTriggerType()).isEqualTo("BACKFILL");
+    assertThat(result.getExecution().getIdempotencyKey()).isEqualTo("offline-backfill:77:1");
+    InOrder order = inOrder(batchRepository, executionRepository);
+    order.verify(batchRepository).reservePendingBackfill(77L);
+    order.verify(executionRepository).insert(result.getExecution());
+    verify(definitionRepository).lock(10L);
+    verify(batchRuntime).refreshBatch(77L);
+  }
+
+  @Test
+  void unknownAttemptCannotBlindRetry() {
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1);
+    previous.setStatus("UNKNOWN");
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+    when(batchRepository.findById(77L))
+        .thenReturn(Optional.of(frozenBatch(77L, 3, BatchStatus.UNKNOWN)));
+
+    assertThatThrownBy(() -> manager.claimRetry(99L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("UNKNOWN")
+        .hasMessageContaining("reconcile");
+
+    verify(executionRepository, never()).reserveRetry(99L);
+  }
+
+  @Test
+  void retryRespectsFrozenMaxAttempts() {
+    OfflineJobExecution previous = failedAttempt(99L, 77L, 1);
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+    when(batchRepository.findById(77L))
+        .thenReturn(Optional.of(frozenBatch(77L, 1, BatchStatus.WAITING_RETRY)));
+    when(executionRepository.findByBatchId(77L)).thenReturn(List.of(previous));
+
+    assertThatThrownBy(() -> manager.claimRetry(99L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("最大 Attempt");
+
+    verify(executionRepository, never()).reserveRetry(99L);
+  }
+
+  @Test
+  void legacyAttemptWithoutBatchIsHistoryOnly() {
+    OfflineJobExecution previous = failedAttempt(99L, null, 1);
+    when(executionRepository.findById(99L)).thenReturn(Optional.of(previous));
+
+    assertThatThrownBy(() -> manager.claimRetry(99L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("未绑定 Batch")
+        .hasMessageContaining("历史查询");
+  }
+
+  private OfflineJobExecution failedAttempt(Long id, Long batchId, int attemptNo) {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(id);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(batchId);
+    execution.setAttemptNo(attemptNo);
+    execution.setStatus("FAILED");
+    execution.setRetryCreated(false);
+    return execution;
+  }
+
+  private BatchExecution frozenBatch(long id, int maxAttempts, BatchStatus status) {
+    return new BatchExecution(
+        id,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        snapshot(maxAttempts),
+        status,
+        List.of());
+  }
+
+  private ExecutionSnapshot snapshot(int maxAttempts) {
+    return new ExecutionSnapshot(
+        "{\"definition\":\"frozen\"}",
+        3,
+        new RetryPolicySnapshot(maxAttempts, 30),
+        "frozen-digest",
+        "{\"job\":\"batch-frozen\"}");
+  }
+}


### PR DESCRIPTION
## Summary

完成离线同步 **Stage 11 — Core Responsibility Decomposition**。

Stage 8-10 已经依次解决目录、Application Entry 和角色命名；Stage 11 开始拆真正的职责热点。本 PR 不以减少 LOC 为目标，只拆独立变化原因，并保持 Task / Batch / Attempt / Cursor 运行语义不变。

## Execution decomposition

### Coordinator

`OfflineExecutionCoordinator` 不再同时承担状态机、Retry 计算、Event 和 Task projection。

现在只负责：

```text
claim
 -> scoped JobSpec
 -> Link-Up submit/cancel
 -> state application
```

新增 `OfflineExecutionStateManager`，集中负责：

- CREATED / SUBMITTING / FAILED / UNKNOWN 状态应用；
- Link-Up snapshot -> Attempt metrics；
- frozen RetryPolicy -> nextRetryTime；
- Attempt Event；
- Task last-* projection；
- late Attempt 不覆盖 latest Attempt projection。

Coordinator 已不再持有 `OfflineJobDefinitionRepository` / `OfflineExecutionEventRepository`。

## Claim decomposition

Claim 不再按触发来源全部堆在一个类，而是按“是否创建新 Batch”分界：

```text
OfflineExecutionClaimManager
  = new Batch + Attempt 1

OfflineExistingBatchClaimManager
  = existing Batch -> Retry / Backfill Attempt
```

新增 `OfflineExecutionAttemptFactory`，统一负责：

```text
frozen Batch
 + attemptNo
 + triggerType
 + retryFromExecutionId
 + idempotencyKey
 -> OfflineJobExecution persistence Attempt
```

新增 `OfflineExecutionClaim` 作为 claim 阶段交给 Coordinator 的值对象，替代原 `ClaimManager` 内部嵌套结果类型。

### Existing Batch rules preserved

`OfflineExistingBatchClaimManager` 保留原有：

- UNKNOWN 禁止盲 Retry；
- terminal Batch 禁止追加 Attempt；
- latest Attempt 校验；
- frozen maxAttempts；
- retry CAS reservation；
- PENDING Backfill reservation；
- existing Batch snapshot 是 Retry/Backfill Attempt 的唯一配置来源。

## Backfill decomposition

`OfflineBackfillService` 从规划 + 物化的大类收敛为 Application command：

```text
lock Task
 -> require Definition
 -> OfflineBackfillPlanner
 -> materialize PENDING Batch group
```

新增 `OfflineBackfillPlanner`，负责：

- request / scope normalization；
- existing Batch lookup + idempotent reuse；
- shared ExecutionSnapshot；
- Cursor continuity / route initialization；
- BatchScope -> execution JobSpec validation。

`OfflineBackfillService` 不再直接持有 `OfflineCursorManager / OfflineScheduleRepository / OfflineBatchScopeExecutionAdapter`。

## Application Entry remains unchanged

Stage 9 的稳定入口完全不变：

```text
OfflineJobDefinitionService
OfflineJobExecutionService
OfflineBackfillService
```

Schedule Handler / Backfill Dispatcher / Execution Reconciler 仍只通过 `OfflineJobExecutionService` 进入 execution。

Stage 11 新组件全部是内部 `@Component`，不是新的跨模块 API。

## Tests realigned by responsibility

新增 / 调整：

```text
OfflineExecutionCoordinatorTest
  -> flow delegation / scope / engine boundary

OfflineExecutionStateManagerTest
  -> Retry / UNKNOWN / Event / Task projection

OfflineExecutionClaimManagerTest
  -> new Batch admission / workflow idempotency

OfflineExistingBatchClaimManagerTest
  -> Retry / pending Backfill continuation

OfflineExecutionAttemptFactoryTest
  -> frozen Batch -> Attempt fields

OfflineBackfillServiceTest
  -> Batch materialization

OfflineBackfillPlannerTest
  -> Scope / Cursor / Snapshot / execution validation
```

## Architecture guardrails

扩展 `OfflineSyncLayeringConventionTest`：

1. Coordinator 必须组合 `OfflineExecutionStateManager`；
2. Coordinator 不再持有 Definition/Event Repository；
3. ClaimManager 必须组合 `OfflineExistingBatchClaimManager + OfflineExecutionAttemptFactory`；
4. BackfillService 必须组合 `OfflineBackfillPlanner`；
5. BackfillService 不再直接持有 CursorManager / ScheduleRepository / ScopeExecutionAdapter；
6. 新拆组件必须保持内部 `@Component`；
7. Stage 9 Application Entry 与 Stage 10 Role Naming 护栏继续生效。

## Runtime invariants preserved

本 PR 不改变：

- `Task != Batch != Attempt`；
- Retry 只在原 Batch 内创建 Attempt；
- UNKNOWN 禁止自动 Retry；
- terminal Batch 禁止追加 Attempt；
- occupancy 只读 Batch runtime truth；
- Backfill 物化 Batch group；
- Cursor success-only CAS；
- Task last-* 只是 projection；
- batchless legacy execution 只读；
- Snapshot 不保存运行时数据源凭据。

## Documentation

- 新增 `docs/offline-sync/architecture/STAGE11.md`
- 更新 offline-sync `README.md`
- Stage 状态：

```text
Stage 10  COMPLETE  Role Naming
Stage 11  COMPLETE  Core Responsibility Decomposition
Stage 12  NEXT      Dependency Boundary Governance
```

## Non-goals

本 PR 不做：

- 不修改 REST path / DTO / VO；
- 不修改 Repository / DAO / PO contract；
- 不修改 DB / Flyway；
- 不修改 Link-Up API；
- 不重新设计 Batch/Attempt 状态机；
- 不引入 CommonService / HelperService / Utils；
- 不机械继续拆 StateManager / Planner；
- 不移动 persistence/domain package。

## Validation note

当前分支基于 Stage 10 合并后的 `main`，最终 compare 为 `ahead 18 / behind 0`，diff 仅涉及 offline-sync Stage 11 实现、测试、架构护栏和文档。

当前执行环境无法解析 `github.com`，因此无法在本地 clone 后执行 Maven。PR 保持 Draft；新增的定向测试与架构测试用于 GitHub/CI 回归，未把未执行的测试宣称为通过。

下一步：**Stage 12 — Dependency Boundary Governance**。