### PR TITLE
refactor(offline-sync): complete Stage 12 dependency boundary governance

### DIFF
--- a/docs/offline-sync/architecture/STAGE12.md
+++ b/docs/offline-sync/architecture/STAGE12.md
@@ -1,0 +1,370 @@
+# Offline Sync Stage 12 — Dependency Boundary Governance
+
+## Goal
+
+Stage 12 在 Stage 8-11 已经完成的目录、入口、角色和职责拆分之上，固定 **top-level package 的依赖方向**。
+
+本阶段解决的问题不是“类还能不能继续拆”，而是：
+
+```text
+哪个子系统可以依赖哪个子系统？
+跨子系统调用时，允许穿过哪一扇门？
+内部 Manager / Adapter 是否会重新泄漏成公共 API？
+整个 offline package 能否保持无环？
+```
+
+Stage 12 不追求一套脱离现状的纯理论分层。规则先从当前业务语义出发，再把合法协作收敛成明确的 Gateway / Validator / Repository contract。
+
+## Dependency principles
+
+### 1. Stable domain and persistence direction
+
+```text
+Application / Runtime
+        |
+        v
+   Repository contract
+        |
+        v
+       DAO
+
+Domain <---------------- business/runtime
+```
+
+硬规则：
+
+- `domain` 不反向依赖 Application、Engine、Repository、DAO；
+- `dao` 不依赖业务子系统；
+- `repository` adapter 只依赖 `domain / dao / config`；
+- `engine` 不依赖 Definition / Execution / Backfill / Schedule；
+- Controller 不直接依赖 Repository / DAO / Engine。
+
+### 2. Cross-subsystem calls use named corridors
+
+跨子系统不是禁止协作，而是禁止“随便 import 一个内部类”。
+
+Stage 12 新增三条稳定边界：
+
+```text
+OfflineCursorGateway
+OfflineExecutionScopeValidator
+OfflineScheduleExecutionGateway
+```
+
+它们表达调用方真正需要的最小能力，而不是把实现类暴露出去。
+
+## Changes
+
+### Cursor boundary
+
+Before:
+
+```text
+BackfillPlanner ------> OfflineCursorManager
+BackfillDispatcher ---> OfflineCursorManager
+BatchRuntime ---------> OfflineCursorManager
+ScopeAdapter ---------> OfflineCursorManager
+```
+
+After:
+
+```text
+BackfillPlanner ------+
+BackfillDispatcher ---+
+BatchRuntime ---------+--> OfflineCursorGateway
+ScopeAdapter ---------+            |
+                                   v
+                         OfflineCursorManager
+```
+
+`OfflineCursorManager` 继续负责 Cursor route、position、stateVersion 和 success-only CAS；跨子系统代码只认识 `OfflineCursorGateway`。
+
+### Backfill -> Execution scope boundary
+
+Before:
+
+```text
+OfflineBackfillPlanner
+    -> execution.adapter.OfflineBatchScopeExecutionAdapter
+```
+
+After:
+
+```text
+OfflineBackfillPlanner
+    -> OfflineExecutionScopeValidator
+             |
+             v
+OfflineBatchScopeExecutionAdapter
+```
+
+Backfill 只需要回答：
+
+> 这个 frozen logical JobSpec 是否可以应用当前 BatchScope？
+
+它不需要知道 execution 子系统具体使用哪个 Adapter、如何修改 JobSpec。
+
+### Schedule -> Execution inversion
+
+Stage 11 仍存在：
+
+```text
+Definition -> Schedule -> Execution -> Definition
+```
+
+虽然每一条依赖都有业务理由，但 top-level package 已形成环。
+
+Stage 12 将 Schedule 的执行需求定义为调用方拥有的 Port：
+
+```text
+schedule.OfflineScheduleExecutionGateway
+```
+
+由 `OfflineJobExecutionService` 实现：
+
+```text
+OfflineScheduleHandler
+        |
+        v
+OfflineScheduleExecutionGateway   <--- defined by schedule
+        ^
+        |
+OfflineJobExecutionService        <--- implementation by execution
+```
+
+Schedule Handler 不再 import `execution.*`，也不再接触 `OfflineJobExecutionVO`；它只拿到本次提交的 `executionId`。
+
+这样原来的：
+
+```text
+Definition -> Schedule -> Execution -> Definition
+```
+
+变成：
+
+```text
+Execution -> Definition -> Schedule
+Execution -------> Schedule Port
+```
+
+实际 package graph 可以保持无环。
+
+### Definition runtime guard
+
+Before:
+
+```text
+OfflineJobDefinitionService
+    -> OfflineBatchRuntime
+```
+
+Definition 只需要判断：
+
+```text
+Task 当前是否存在 occupying Batch？
+```
+
+而这个事实已经由 `OfflineBatchExecutionRepository.hasOccupyingBatch()` 定义为 Batch runtime truth。
+
+After:
+
+```text
+OfflineJobDefinitionService
+    -> OfflineBatchExecutionRepository
+```
+
+因此 Definition 不再为了一个 runtime guard 依赖整个 Execution 内部 Runtime 组件，同时没有退回到 Task `last-*` projection。
+
+## Top-level dependency matrix
+
+Stage 12 的可执行白名单：
+
+| Source package | Allowed offline dependencies |
+| --- | --- |
+| `controller` | `config`, `definition`, `execution`, `backfill` |
+| `backfill` | `config`, `cursor`, `definition`, `domain`, `execution`, `repository` |
+| `reconcile` | `config`, `domain`, `engine`, `execution`, `repository` |
+| `execution` | `config`, `cursor`, `definition`, `domain`, `engine`, `mapping`, `repository`, `schedule` |
+| `definition` | `config`, `domain`, `engine`, `mapping`, `repository`, `schedule` |
+| `schedule` | `config`, `domain`, `repository` |
+| `cursor` | `config`, `domain`, `repository` |
+| `mapping` | `domain`, `engine` |
+| `repository` | `config`, `dao`, `domain` |
+| `dao` | `config` |
+| `engine` | `config` |
+| `domain` | none |
+| `config` | none |
+
+同一个 top-level package 内部可以自由组织子 package，例如：
+
+```text
+execution
+├── query
+└── adapter
+```
+
+但这不意味着其他子系统可以直接穿透 `execution.query` 或 `execution.adapter`。
+
+## Named corridors
+
+### Into execution
+
+允许的跨包 execution import 被限制为：
+
+```text
+controller
+    -> OfflineJobExecutionService
+
+backfill
+    -> OfflineJobExecutionService
+    -> OfflineExecutionScopeValidator
+
+reconcile
+    -> OfflineJobExecutionService
+
+schedule
+    -> no execution import
+
+definition
+    -> no execution import
+```
+
+### Into cursor
+
+Cursor 对外只有：
+
+```text
+OfflineCursorGateway
+```
+
+跨子系统禁止 import `OfflineCursorManager`。
+
+### Into schedule
+
+当前显式走廊：
+
+```text
+definition
+    -> OfflineScheduleLifecycle
+    -> OfflineScheduleSupport
+
+execution
+    -> OfflineScheduleExecutionGateway
+```
+
+Stage 12 不为了“接口化一切”给每一个现有组件再套一层 Port；只有跨包依赖已经造成扩散或循环时才增加边界。
+
+## Architecture tests
+
+### OfflineSyncLayeringConventionTest
+
+继续守护 Stage 7-11 的历史契约：
+
+- Controller -> stable Application Facade；
+- `@Service` 只保留给三个 Application Service；
+- Coordinator / Manager / Runtime / Query / Planner 的职责拆分；
+- 后台入口不穿透 execution internals；
+- Stage 10 旧角色名不回流；
+- Repository / DAO transport boundary。
+
+Stage 12 同时验证：
+
+```text
+OfflineCursorManager implements OfflineCursorGateway
+OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeValidator
+OfflineJobExecutionService implements OfflineScheduleExecutionGateway
+```
+
+### OfflineSyncDependencyBoundaryTest
+
+Stage 12 新增独立的依赖治理测试，职责只有三个：
+
+1. 扫描生产源码的 offline 内部 import，验证 top-level package 白名单；
+2. 根据真实 import 生成 package graph，并验证 graph 无环；
+3. 验证 execution / cursor / schedule 的跨子系统 import 只能经过声明过的 corridor。
+
+这意味着未来新代码如果出现：
+
+```text
+schedule -> execution.OfflineExecutionCoordinator
+backfill -> execution.adapter.OfflineBatchScopeExecutionAdapter
+execution -> cursor.OfflineCursorManager
+repository -> execution.*
+domain -> repository.*
+```
+
+测试会直接失败。
+
+## Resulting graph
+
+当前主要依赖方向可以概括为：
+
+```text
+controller
+   |
+   +---------> definition ---------> schedule
+   |                |                  |
+   |                +-----> engine     +-----> repository
+   |                +-----> mapping             |
+   |                +-----> repository           v
+   |                                           dao
+   +---------> execution ---------> definition
+   |                |
+   |                +-----> engine
+   |                +-----> cursor -------> repository
+   |                +-----> mapping
+   |                +-----> repository
+   |                `-----> schedule port
+   |
+   `---------> backfill ----------> execution corridor
+                    |
+                    +-----> cursor gateway
+                    +-----> definition
+                    `-----> repository
+
+reconcile ----------> execution facade / engine / repository
+
+domain               # leaf business model
+config                # leaf module configuration
+```
+
+依赖图允许多个上层子系统共享 Domain / Repository contract，但不允许底层反向认识上层流程组件。
+
+## Runtime invariants preserved
+
+Stage 12 不改变：
+
+- `Task != Batch != Attempt`；
+- Batch 是 runtime truth；
+- Task `last-*` 只是 projection；
+- Retry 只在原 Batch 内追加 Attempt；
+- UNKNOWN 禁止盲 Retry；
+- terminal Batch 禁止追加 Attempt；
+- Backfill 物化 Batch group；
+- Cursor 只在 SUCCEEDED CursorRange Batch 后 CAS 推进；
+- batchless legacy execution 只读；
+- Snapshot 不持久化运行时数据源凭据；
+- REST / DTO / VO / DB / Flyway / Link-Up API contract。
+
+## Non-goals
+
+Stage 12 不做：
+
+- 不继续拆 Stage 11 的核心类；
+- 不把所有内部协作都接口化；
+- 不移动 Domain / Repository / DAO package；
+- 不引入新的 Shared Kernel；
+- 不改变业务事务和状态机；
+- 不使用 package graph 规则代替领域测试。
+
+原则仍然是：
+
+> **只有跨边界的能力才需要稳定门；子系统内部保持直接、清晰。**
+
+## Next
+
+```text
+Stage 13 — Architecture Guardrails
+```
+
+Stage 13 应对 Stage 7-12 已形成的架构 contract 做最终固化：整理架构测试入口、Review checklist、文档索引和 CI 可见性，避免后续演进重新退回“service 大平层 + 随意穿透”的状态。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/README.md
@@ -14,7 +14,8 @@
 - [Stage 8 Package Restructuring](../../../docs/offline-sync/architecture/STAGE8.md) — 业务子系统目录归位
 - [Stage 9 Application Entry Consolidation](../../../docs/offline-sync/architecture/STAGE9.md) — Application 入口边界
 - [Stage 10 Role Naming](../../../docs/offline-sync/architecture/STAGE10.md) — 角色命名约定
-- [Stage 11 Core Responsibility Decomposition](../../../docs/offline-sync/architecture/STAGE11.md) — 当前核心职责拆分
+- [Stage 11 Core Responsibility Decomposition](../../../docs/offline-sync/architecture/STAGE11.md) — 核心职责拆分
+- [Stage 12 Dependency Boundary Governance](../../../docs/offline-sync/architecture/STAGE12.md) — 当前 package 依赖规则
 
 ```text
 OfflineSyncTask
@@ -34,11 +35,11 @@ BatchExecution
 
 ## 架构职责治理
 
-**Stage 11 已完成：Core Responsibility Decomposition。**
+**Stage 12 已完成：Dependency Boundary Governance。**
 
-Stage 8 解决“类放在哪里”，Stage 9 解决“谁可以调用谁”，Stage 10 解决“类名是什么角色”，Stage 11 开始把核心热点按独立变化原因真正拆开。
+Stage 8-11 已经依次解决目录、入口、角色和职责热点；Stage 12 固定 top-level package 的依赖方向，并把跨子系统调用收敛成明确 corridor。
 
-三个稳定 Application Facade 继续保留：
+三个稳定 Application Facade：
 
 ```text
 OfflineJobDefinitionService
@@ -57,11 +58,29 @@ OfflineExecutionStateManager         # 状态 / Retry / Event / Task projection
 OfflineBatchRuntime                  # Batch runtime truth
 OfflineExecutionQuery                # execution read model
 OfflineExecutionLogQuery             # unified log query
-OfflineCursorManager                 # cursor route + CAS advancement
+OfflineCursorManager                 # cursor 内部实现
 OfflineBackfillPlanner               # Scope / Cursor / Snapshot planning
 ```
 
 `@Service` 仍只表达稳定 Application 入口；内部 Coordinator / Manager / Runtime / Query / Planner / Factory 使用 `@Component`。
+
+## 显式跨子系统边界
+
+Stage 12 新增三条窄边界：
+
+```text
+OfflineCursorGateway
+OfflineExecutionScopeValidator
+OfflineScheduleExecutionGateway
+```
+
+含义：
+
+- Cursor 子系统之外只能依赖 `OfflineCursorGateway`，不能直接依赖 `OfflineCursorManager`；
+- Backfill 做 execution scope 前置校验时只依赖 `OfflineExecutionScopeValidator`，不直接依赖 `execution.adapter`；
+- Schedule Handler 只依赖自己定义的 `OfflineScheduleExecutionGateway`，不 import `execution.*`；该 Gateway 由 `OfflineJobExecutionService` 实现。
+
+因此跨子系统调用不再等于“知道对方内部哪个类能用”。
 
 ## Application Entry
 
@@ -73,7 +92,23 @@ Controller
    `-> OfflineBackfillService
 ```
 
-Schedule Handler、Backfill Dispatcher、Execution Reconciler 进入 execution 子系统时仍然统一通过 `OfflineJobExecutionService`，不会直接穿透内部组件。
+后台入口：
+
+```text
+OfflineBackfillDispatcher
+    -> OfflineJobExecutionService
+
+OfflineExecutionReconciler
+    -> OfflineJobExecutionService
+
+OfflineScheduleHandler
+    -> OfflineScheduleExecutionGateway
+         ^
+         |
+       implemented by OfflineJobExecutionService
+```
+
+Schedule 不再直接依赖 execution package，因此 `definition -> schedule -> execution -> definition` 的 top-level 循环已经消失。
 
 ## Execution 内部链路
 
@@ -102,7 +137,28 @@ OfflineJobExecutionService
 - `OfflineExecutionStateManager` 负责 Attempt 状态、metrics、Retry window、Event、Task last-* projection；
 - `OfflineExecutionClaimManager` 负责创建新 Batch；
 - `OfflineExistingBatchClaimManager` 负责 Retry / PENDING Backfill 在已有 Batch 上创建 Attempt；
-- `OfflineExecutionAttemptFactory` 统一构造 persistence Attempt。
+- `OfflineExecutionAttemptFactory` 统一构造 persistence Attempt；
+- `OfflineBatchRuntime` 通过 `OfflineCursorGateway` 通知 Cursor success hook，不直接依赖 CursorManager。
+
+## Definition / Schedule 边界
+
+Definition 的运行中保护只需要判断 Task 是否存在 occupying Batch。
+
+Stage 12 后：
+
+```text
+OfflineJobDefinitionService
+    -> OfflineBatchExecutionRepository.hasOccupyingBatch()
+```
+
+不再为了一个 runtime guard 反向依赖 `OfflineBatchRuntime`。这里仍然读取 Batch runtime truth，没有退回 Task `last-*` projection。
+
+Definition 继续通过明确的 schedule corridor 使用：
+
+```text
+OfflineScheduleSupport
+OfflineScheduleLifecycle
+```
 
 ## Backfill / Cursor
 
@@ -113,17 +169,61 @@ Backfill Request
        -> Scope normalize
        -> existing Batch reuse
        -> shared ExecutionSnapshot
-       -> Cursor validation
-       -> execution-scope validation
+       -> OfflineCursorGateway
+       -> OfflineExecutionScopeValidator
   -> PENDING Batch group materialization
   -> OfflineBackfillDispatcher
-  -> OfflineJobExecutionService
+       -> OfflineCursorGateway
+       -> OfflineJobExecutionService
   -> Attempt 1
 ```
 
 `OfflineBackfillService` 只负责 Application command、Task lock 和 Batch materialization；规划逻辑集中在 `OfflineBackfillPlanner`。
 
-`OfflineCursorManager` 管理 Cursor route + position + stateVersion，只在对应 `CursorRange` Batch `SUCCEEDED` 后由 `OfflineBatchRuntime` 触发 CAS 推进。
+`OfflineCursorManager` 管理 Cursor route + position + stateVersion，只在对应 `CursorRange` Batch `SUCCEEDED` 后通过 Gateway 被 `OfflineBatchRuntime` 触发 CAS 推进。
+
+## Top-level package 依赖
+
+当前允许的 offline 内部依赖：
+
+| Source | Allowed |
+| --- | --- |
+| `controller` | `config`, `definition`, `execution`, `backfill` |
+| `backfill` | `config`, `cursor`, `definition`, `domain`, `execution`, `repository` |
+| `reconcile` | `config`, `domain`, `engine`, `execution`, `repository` |
+| `execution` | `config`, `cursor`, `definition`, `domain`, `engine`, `mapping`, `repository`, `schedule` |
+| `definition` | `config`, `domain`, `engine`, `mapping`, `repository`, `schedule` |
+| `schedule` | `config`, `domain`, `repository` |
+| `cursor` | `config`, `domain`, `repository` |
+| `mapping` | `domain`, `engine` |
+| `repository` | `config`, `dao`, `domain` |
+| `dao` | `config` |
+| `engine` | `config` |
+| `domain` | none |
+| `config` | none |
+
+同一 top-level package 内的子 package 属于同一个子系统，例如 `execution.query` 和 `execution.adapter`；但它们不自动成为跨子系统 API。
+
+## 工程依赖约束
+
+当前架构护栏要求：
+
+- Controller 只依赖三个稳定 Application Facade；
+- Backfill Dispatcher / Execution Reconciler 进入 execution 只依赖 `OfflineJobExecutionService`；
+- Schedule Handler 只依赖 `OfflineScheduleExecutionGateway`，不依赖 execution package；
+- Definition 不依赖 execution package；
+- Backfill 不直接依赖 `execution.adapter`；
+- 跨子系统 Cursor 调用只依赖 `OfflineCursorGateway`；
+- execution 内部角色不作为跨子系统公共 API；
+- `OfflineExecutionCoordinator` 必须通过 `OfflineExecutionStateManager` 应用状态；
+- `OfflineExecutionClaimManager` 组合 `OfflineExistingBatchClaimManager + OfflineExecutionAttemptFactory`；
+- `OfflineBackfillService` 组合 `OfflineBackfillPlanner`；
+- Repository adapter 只依赖 `domain / dao / config`；
+- DAO 不反向依赖业务子系统；
+- Domain 不依赖 Application / Engine / Persistence；
+- 实际源码生成的 top-level package graph 必须无环。
+
+`OfflineSyncLayeringConventionTest` 守护 Stage 7-11 的角色/分层契约；`OfflineSyncDependencyBoundaryTest` 专门守护 Stage 12 的 package dependency graph 和 corridor。
 
 ## Link-Up 边界
 
@@ -137,42 +237,6 @@ Yak Ops -> DELETE /api/v1/jobs/{jobId}
 ```
 
 Batch Snapshot 只保存不含凭据的 logical JobSpec；数据源凭据在 Attempt submit boundary 才解析。
-
-## 调度与运行边界
-
-```text
-Offline Job Definition
-  -> OfflineScheduleEngineBridge
-  -> Yak Schedule / Quartz
-  -> OfflineScheduleHandler
-  -> OfflineJobExecutionService
-  -> OfflineExecutionCoordinator
-  -> BatchExecution / ExecutionAttempt
-  -> Link-Up
-```
-
-Yak Schedule 只负责“什么时候触发”。Task 是否已有运行占用、是否能创建新 Batch，只读取 `OfflineBatchRuntime` 的 Batch runtime truth；Schedule Handler 不直接持有 Runtime / Coordinator。
-
-Link-Up 状态对账和失败重试由 `reconcile.OfflineExecutionReconciler` 负责；Reconciler 通过 `OfflineJobExecutionService` 应用 execution 状态规则。Wave 1 前 `batch_id = NULL` 的 execution 是只读历史，不参与 Reconcile / Retry / Cancel。
-
-## 工程依赖约束
-
-当前架构护栏要求：
-
-- Controller 只依赖三个稳定 Application Facade；
-- Schedule Handler / Backfill Dispatcher / Execution Reconciler 进入 execution 时只依赖 `OfflineJobExecutionService`；
-- execution 内部角色不作为跨子系统公共 API；
-- `OfflineExecutionCoordinator` 必须通过 `OfflineExecutionStateManager` 应用状态，不直接持有 Definition/Event Repository；
-- `OfflineExecutionClaimManager` 组合 `OfflineExistingBatchClaimManager + OfflineExecutionAttemptFactory`；
-- `OfflineBackfillService` 组合 `OfflineBackfillPlanner`，不直接持有 CursorManager / ScheduleRepository / ScopeExecutionAdapter；
-- `@Service` 保留给三个 Application Facade；内部角色使用 `@Component`；
-- Definition / Execution / Backfill 使用 Domain，不直接操作 MyBatis PO；
-- Repository 接口只暴露 Domain；PO 与 DAO 仅存在于持久化适配层；
-- Task runtime occupancy 只由 Batch Repository / Runtime 提供；
-- Query 只负责读取/展示，不承担 Batch/Attempt 状态命令；
-- Link-Up 协议对象不直接暴露为 HTTP Domain。
-
-这些边界由 `OfflineSyncLayeringConventionTest` 持续守护。
 
 ## 数据表
 
@@ -193,5 +257,6 @@ Stage 8   COMPLETE  Package Restructuring
 Stage 9   COMPLETE  Application Entry Consolidation
 Stage 10  COMPLETE  Role Naming
 Stage 11  COMPLETE  Core Responsibility Decomposition
-Stage 12  NEXT      Dependency Boundary Governance
+Stage 12  COMPLETE  Dependency Boundary Governance
+Stage 13  NEXT      Architecture Guardrails
 ```

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcher.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcher.java
@@ -2,7 +2,7 @@ package io.yak.ops.business.sync.offline.backfill;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
 import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchScope;
@@ -24,7 +24,7 @@ public class OfflineBackfillDispatcher {
   private static final Logger LOG = LoggerFactory.getLogger(OfflineBackfillDispatcher.class);
 
   private final OfflineBatchExecutionRepository batchRepository;
-  private final OfflineCursorManager cursorManager;
+  private final OfflineCursorGateway cursorGateway;
   private final OfflineJobExecutionService executionService;
   private final OfflineSyncProperties properties;
 
@@ -47,7 +47,7 @@ public class OfflineBackfillDispatcher {
 
   private boolean cursorReady(BatchExecution batch) {
     if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) return true;
-    OfflineSyncCursor cursor = cursorManager.find(batch.taskId(), range.cursorId()).orElse(null);
+    OfflineSyncCursor cursor = cursorGateway.find(batch.taskId(), range.cursorId()).orElse(null);
     return cursor != null && cursor.position().equals(range.afterExclusive());
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlanner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlanner.java
@@ -2,7 +2,7 @@ package io.yak.ops.business.sync.offline.backfill;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
 import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
@@ -13,7 +13,7 @@ import io.yak.ops.business.sync.offline.domain.core.BatchScope;
 import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
 import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
 import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
-import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
+import io.yak.ops.business.sync.offline.execution.OfflineExecutionScopeValidator;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
@@ -42,8 +42,8 @@ public class OfflineBackfillPlanner {
   private final OfflineJobDefinitionService definitionService;
   private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineScheduleRepository scheduleRepository;
-  private final OfflineCursorManager cursorManager;
-  private final OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+  private final OfflineCursorGateway cursorGateway;
+  private final OfflineExecutionScopeValidator scopeValidator;
   private final OfflineSyncProperties properties;
 
   public PreparedRequest prepare(OfflineBackfillRequestDTO request) {
@@ -162,7 +162,7 @@ public class OfflineBackfillPlanner {
         }
       }
 
-      OfflineSyncCursor existingCursor = cursorManager.find(taskId, entry.getKey()).orElse(null);
+      OfflineSyncCursor existingCursor = cursorGateway.find(taskId, entry.getKey()).orElse(null);
       if (existingCursor != null
           && hasMissing
           && !existingCursor.position().equals(first.afterExclusive())) {
@@ -173,7 +173,7 @@ public class OfflineBackfillPlanner {
               "Cursor 已离开本 Backfill 起点，禁止追加会改变 Cursor 顺序的新 Batch：" + entry.getKey());
         }
       }
-      cursorManager.initializeIfAbsent(
+      cursorGateway.initializeIfAbsent(
           taskId, entry.getKey(), sourceColumn, first.afterExclusive());
     }
   }
@@ -183,7 +183,7 @@ public class OfflineBackfillPlanner {
       List<ScopePlan> plans,
       String logicalJobSpec) {
     for (ScopePlan plan : plans) {
-      scopeExecutionAdapter.apply(taskId, logicalJobSpec, plan.scope());
+      scopeValidator.validate(taskId, logicalJobSpec, plan.scope());
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorGateway.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.sync.offline.cursor;
+
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import java.util.Optional;
+
+/** Cursor 子系统对其他离线同步子系统暴露的稳定边界。 */
+public interface OfflineCursorGateway {
+
+  OfflineSyncCursor initializeIfAbsent(
+      long taskId, String cursorId, String sourceColumn, String initialPosition);
+
+  Optional<OfflineSyncCursor> find(long taskId, String cursorId);
+
+  String requireSourceColumn(long taskId, String cursorId);
+
+  AdvanceResult advanceAfterSucceededBatch(BatchExecution batch);
+
+  enum AdvanceResult {
+    NOT_CURSOR_SCOPE,
+    NOT_SUCCEEDED,
+    NOT_INITIALIZED,
+    ADVANCED,
+    ALREADY_ADVANCED,
+    STALE
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManager.java
@@ -11,33 +11,42 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/** Wave 5 Cursor boundary：只有 SUCCEEDED Batch 才能推进 Task Cursor。 */
+/** Cursor 子系统内部实现；跨子系统只暴露 OfflineCursorGateway。 */
 @ConditionalOnOfflineSyncEnabled
 @Component
 @RequiredArgsConstructor
-public class OfflineCursorManager {
+public class OfflineCursorManager implements OfflineCursorGateway {
 
   private final OfflineSyncCursorRepository repository;
 
-  public OfflineSyncCursor initializeIfAbsent(long taskId, String cursorId, String sourceColumn, String initialPosition) {
+  @Override
+  public OfflineSyncCursor initializeIfAbsent(
+      long taskId, String cursorId, String sourceColumn, String initialPosition) {
     return repository.initializeIfAbsent(taskId, cursorId, sourceColumn, initialPosition);
   }
 
+  @Override
   public Optional<OfflineSyncCursor> find(long taskId, String cursorId) {
     return repository.find(taskId, cursorId);
   }
 
+  @Override
   public String requireSourceColumn(long taskId, String cursorId) {
     return find(taskId, cursorId)
         .orElseThrow(() -> new IllegalStateException("Cursor 尚未初始化：" + cursorId))
         .sourceColumn();
   }
 
+  @Override
   public AdvanceResult advanceAfterSucceededBatch(BatchExecution batch) {
     Objects.requireNonNull(batch, "BatchExecution 不能为空");
-    if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) return AdvanceResult.NOT_CURSOR_SCOPE;
+    if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) {
+      return AdvanceResult.NOT_CURSOR_SCOPE;
+    }
     if (batch.status() != BatchStatus.SUCCEEDED) return AdvanceResult.NOT_SUCCEEDED;
-    if (batch.id() == null || batch.id() <= 0L) throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    if (batch.id() == null || batch.id() <= 0L) {
+      throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    }
 
     OfflineSyncCursor current = repository.find(batch.taskId(), range.cursorId()).orElse(null);
     if (current == null) return AdvanceResult.NOT_INITIALIZED;
@@ -48,16 +57,9 @@ public class OfflineCursorManager {
       return AdvanceResult.ADVANCED;
     }
     OfflineSyncCursor reread = repository.find(batch.taskId(), range.cursorId()).orElse(null);
-    if (reread != null && reread.position().equals(range.throughInclusive())) return AdvanceResult.ALREADY_ADVANCED;
+    if (reread != null && reread.position().equals(range.throughInclusive())) {
+      return AdvanceResult.ALREADY_ADVANCED;
+    }
     return AdvanceResult.STALE;
-  }
-
-  public enum AdvanceResult {
-    NOT_CURSOR_SCOPE,
-    NOT_SUCCEEDED,
-    NOT_INITIALIZED,
-    ADVANCED,
-    ALREADY_ADVANCED,
-    STALE
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
@@ -8,8 +8,8 @@ import io.yak.ops.business.sync.offline.definition.OfflineDefinitionSupport.Draf
 import io.yak.ops.business.sync.offline.definition.OfflineDefinitionSupport.PreparedDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
-import io.yak.ops.business.sync.offline.execution.OfflineBatchRuntime;
 import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.business.sync.offline.schedule.OfflineScheduleLifecycle;
@@ -30,7 +30,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class OfflineJobDefinitionService {
   private final OfflineJobDefinitionRepository definitionRepository;
-  private final OfflineBatchRuntime batchRuntime;
+  private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineDefinitionSupport support;
   private final OfflineScheduleSupport scheduleSupport;
@@ -71,9 +71,9 @@ public class OfflineJobDefinitionService {
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public boolean online(Long id) { OfflineJobDefinition definition = require(id); resolveLogicalJobSpec(definition); definition.setReleaseState("ONLINE"); definition.setUpdateTime(LocalDateTime.now()); boolean updated = definitionRepository.update(definition); if (updated) scheduleLifecycle.sync(id); return updated; }
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
-  public boolean offline(Long id) { OfflineJobDefinition definition = require(id); if (batchRuntime.hasOccupyingBatch(id)) throw new IllegalStateException("运行中的 BatchExecution 不能下线，请先停止任务"); definition.setReleaseState("OFFLINE"); definition.setUpdateTime(LocalDateTime.now()); boolean updated = definitionRepository.update(definition); if (updated) scheduleLifecycle.sync(id); return updated; }
+  public boolean offline(Long id) { OfflineJobDefinition definition = require(id); if (batchRepository.hasOccupyingBatch(id)) throw new IllegalStateException("运行中的 BatchExecution 不能下线，请先停止任务"); definition.setReleaseState("OFFLINE"); definition.setUpdateTime(LocalDateTime.now()); boolean updated = definitionRepository.update(definition); if (updated) scheduleLifecycle.sync(id); return updated; }
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
-  public boolean delete(Long id) { OfflineJobDefinition definition = require(id); if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("已上线任务不能删除，请先下线"); if (batchRuntime.hasOccupyingBatch(id)) throw new IllegalStateException("运行中的 BatchExecution 不能删除"); scheduleLifecycle.remove(id); return definitionRepository.delete(id); }
+  public boolean delete(Long id) { OfflineJobDefinition definition = require(id); if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("已上线任务不能删除，请先下线"); if (batchRepository.hasOccupyingBatch(id)) throw new IllegalStateException("运行中的 BatchExecution 不能删除"); scheduleLifecycle.remove(id); return definitionRepository.delete(id); }
   public OfflineJobDefinition require(Long id) { if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法"); return definitionRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("离线同步任务不存在：" + id)); }
-  private void ensureEditable(OfflineJobDefinition definition) { if (definition == null) return; if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("已上线任务不能修改，请先下线"); if (batchRuntime.hasOccupyingBatch(definition.getId())) throw new IllegalStateException("运行中的 BatchExecution 不能修改"); }
+  private void ensureEditable(OfflineJobDefinition definition) { if (definition == null) return; if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("已上线任务不能修改，请先下线"); if (batchRepository.hasOccupyingBatch(definition.getId())) throw new IllegalStateException("运行中的 BatchExecution 不能修改"); }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineBatchRuntime.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineBatchRuntime.java
@@ -1,7 +1,7 @@
 package io.yak.ops.business.sync.offline.execution;
 
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OfflineBatchRuntime {
   private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineJobExecutionRepository executionRepository;
-  private final OfflineCursorManager cursorManager;
+  private final OfflineCursorGateway cursorGateway;
 
   public boolean hasOccupyingBatch(Long taskId) { return batchRepository.hasOccupyingBatch(positive(taskId, "TaskId")); }
   public Optional<BatchExecution> findLatestOccupyingBatch(Long taskId) { return batchRepository.findLatestOccupyingByTaskId(positive(taskId, "TaskId")); }
@@ -55,10 +55,10 @@ public class OfflineBatchRuntime {
     List<OfflineJobExecution> attempts = executionRepository.findByBatchId(batchId); if (attempts.isEmpty()) return;
     OfflineJobExecution latest = attempts.stream().max(Comparator.comparingInt((OfflineJobExecution value) -> number(value.getAttemptNo(), 1)).thenComparingLong(value -> number(value.getId(), 0L))).orElseThrow();
     BatchStatus target = deriveStatus(latest);
-    if (batch.status() == target) { if (target == BatchStatus.SUCCEEDED) cursorManager.advanceAfterSucceededBatch(batch); return; }
+    if (batch.status() == target) { if (target == BatchStatus.SUCCEEDED) cursorGateway.advanceAfterSucceededBatch(batch); return; }
     BatchExecution updated = new BatchExecution(batch.id(), batch.taskId(), batch.batchKey(), batch.trigger(), batch.batchScope(), batch.snapshot(), target, batch.attempts());
     if (!batchRepository.update(updated)) throw new IllegalStateException("更新 BatchExecution runtime status 失败：" + batch.id());
-    if (target == BatchStatus.SUCCEEDED) cursorManager.advanceAfterSucceededBatch(updated);
+    if (target == BatchStatus.SUCCEEDED) cursorGateway.advanceAfterSucceededBatch(updated);
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionScopeValidator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionScopeValidator.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+
+/** Backfill 等子系统在物化 Batch 前使用的 execution scope 校验边界。 */
+public interface OfflineExecutionScopeValidator {
+
+  void validate(long taskId, String logicalJobSpecJson, BatchScope scope);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionLogQuery;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionQuery;
 import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleExecutionGateway;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationErrorVO;
@@ -23,11 +24,11 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/** 离线同步执行门面；Controller、Schedule、Backfill Dispatcher、Reconciler 统一从这里进入 execution 子系统。 */
+/** 离线同步执行门面；Controller、Backfill Dispatcher、Reconciler 统一从这里进入 execution 子系统。 */
 @ConditionalOnOfflineSyncEnabled
 @Service
 @RequiredArgsConstructor
-public class OfflineJobExecutionService {
+public class OfflineJobExecutionService implements OfflineScheduleExecutionGateway {
 
   private final OfflineExecutionCoordinator coordinator;
   private final OfflineBatchRuntime batchRuntime;
@@ -40,6 +41,7 @@ public class OfflineJobExecutionService {
     return viewMapper.engineHealth(linkUpClient.node());
   }
 
+  @Override
   public boolean hasOccupyingBatch(Long definitionId) {
     return batchRuntime.hasOccupyingBatch(definitionId);
   }
@@ -86,9 +88,16 @@ public class OfflineJobExecutionService {
     return executeScheduled(id, "SCHEDULE");
   }
 
-  /** Schedule Handler 保留完整 trigger token，通过 Facade 进入 execution 子系统。 */
+  /** 保留完整 schedule trigger token 的执行入口。 */
   public OfflineJobExecutionVO executeScheduled(Long id, String triggerToken) {
     return executionQuery.toVO(coordinator.execute(id, triggerToken, null, 1));
+  }
+
+  /** Schedule 子系统只通过窄 Gateway 获取 executionId，不依赖 execution VO。 */
+  @Override
+  public Long submitScheduled(Long definitionId, String triggerToken) {
+    OfflineJobExecutionVO execution = executeScheduled(definitionId, triggerToken);
+    return execution == null ? null : execution.getId();
   }
 
   /** Backfill Dispatcher 只负责触发，不直接调用内部 Coordinator。 */

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
-import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
 import io.yak.ops.business.sync.offline.domain.core.BatchScope;
 import io.yak.ops.business.sync.offline.engine.ConnectorIdResolver;
+import io.yak.ops.business.sync.offline.execution.OfflineExecutionScopeValidator;
 import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,14 +18,21 @@ import org.springframework.util.StringUtils;
 /** Applies a frozen BatchScope to the frozen logical JobSpec immediately before credential resolution. */
 @ConditionalOnOfflineSyncEnabled
 @Component
-public class OfflineBatchScopeExecutionAdapter {
+public class OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeValidator {
   private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
   private final ObjectMapper objectMapper;
-  private final OfflineCursorManager cursorManager;
+  private final OfflineCursorGateway cursorGateway;
 
-  public OfflineBatchScopeExecutionAdapter(@Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper, OfflineCursorManager cursorManager) {
+  public OfflineBatchScopeExecutionAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineCursorGateway cursorGateway) {
     this.objectMapper = objectMapper;
-    this.cursorManager = cursorManager;
+    this.cursorGateway = cursorGateway;
+  }
+
+  @Override
+  public void validate(long taskId, String logicalJobSpecJson, BatchScope scope) {
+    apply(taskId, logicalJobSpecJson, scope);
   }
 
   public String apply(long taskId, String logicalJobSpecJson, BatchScope scope) {
@@ -56,7 +64,7 @@ public class OfflineBatchScopeExecutionAdapter {
       return column + " IN (" + values + ")";
     }
     if (scope instanceof BatchScope.CursorRange range) {
-      String column = safeColumn(cursorManager.requireSourceColumn(taskId, range.cursorId()));
+      String column = safeColumn(cursorGateway.requireSourceColumn(taskId, range.cursorId()));
       return column + " > " + literal(range.afterExclusive()) + " AND " + column + " <= " + literal(range.throughInclusive());
     }
     throw new IllegalArgumentException("不支持的 BatchScope：" + scope.getClass().getName());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleExecutionGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleExecutionGateway.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.sync.offline.schedule;
+
+/** Schedule 子系统触发离线执行时使用的稳定边界。 */
+public interface OfflineScheduleExecutionGateway {
+
+  boolean hasOccupyingBatch(Long definitionId);
+
+  Long submitScheduled(Long definitionId, String triggerToken);
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleHandler.java
@@ -7,10 +7,8 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
 import io.yak.ops.business.sync.offline.domain.compat.LegacyBatchTriggerCompatibilityMapper;
-import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
-import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
 import org.springframework.stereotype.Component;
 
 @ConditionalOnOfflineSyncEnabled
@@ -19,19 +17,19 @@ public class OfflineScheduleHandler implements ScheduleHandler {
 
   private final OfflineJobDefinitionRepository definitionRepository;
   private final OfflineScheduleRepository scheduleRepository;
-  private final OfflineJobExecutionService executionService;
+  private final OfflineScheduleExecutionGateway executionGateway;
   private final OfflineScheduleEngineBridge engine;
   private final OfflineScheduleLifecycle lifecycle;
 
   public OfflineScheduleHandler(
       OfflineJobDefinitionRepository definitionRepository,
       OfflineScheduleRepository scheduleRepository,
-      OfflineJobExecutionService executionService,
+      OfflineScheduleExecutionGateway executionGateway,
       OfflineScheduleEngineBridge engine,
       OfflineScheduleLifecycle lifecycle) {
     this.definitionRepository = definitionRepository;
     this.scheduleRepository = scheduleRepository;
-    this.executionService = executionService;
+    this.executionGateway = executionGateway;
     this.engine = engine;
     this.lifecycle = lifecycle;
   }
@@ -53,7 +51,7 @@ public class OfflineScheduleHandler implements ScheduleHandler {
       return ScheduleExecutionResult.accepted(null, "离线同步任务未启用调度，本次触发忽略");
     }
 
-    if (executionService.hasOccupyingBatch(definitionId)) {
+    if (executionGateway.hasOccupyingBatch(definitionId)) {
       lifecycle.refreshRuntimeState(definitionId, context.actualFireTime());
       return ScheduleExecutionResult.accepted(null, "任务已有运行中的 BatchExecution，本次调度触发跳过");
     }
@@ -61,10 +59,9 @@ public class OfflineScheduleHandler implements ScheduleHandler {
     try {
       String triggerToken = LegacyBatchTriggerCompatibilityMapper.scheduleToken(
           context.key().value(), context.scheduledFireTime());
-      OfflineJobExecutionVO execution =
-          executionService.executeScheduled(definitionId, triggerToken);
+      Long executionId = executionGateway.submitScheduled(definitionId, triggerToken);
       return ScheduleExecutionResult.accepted(
-          execution.getId() == null ? null : String.valueOf(execution.getId()),
+          executionId == null ? null : String.valueOf(executionId),
           "离线同步任务已提交 Link-Up 执行");
     } finally {
       lifecycle.refreshRuntimeState(definitionId, context.actualFireTime());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncDependencyBoundaryTest.java
@@ -1,0 +1,218 @@
+package io.yak.ops.business.sync.offline.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Stage 12：离线同步 top-level package 依赖图与跨子系统 corridor 护栏。 */
+class OfflineSyncDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.sync.offline.";
+  private static final Pattern OFFLINE_IMPORT = Pattern.compile(
+      "(?m)^import\\s+(?:static\\s+)?(io\\.yak\\.ops\\.business\\.sync\\.offline\\.([A-Za-z0-9_]+)\\.[^;]+);");
+
+  private static final Map<String, Set<String>> ALLOWED_TOP_LEVEL_DEPENDENCIES = Map.ofEntries(
+      Map.entry("controller", Set.of("config", "definition", "execution", "backfill")),
+      Map.entry("backfill", Set.of("config", "cursor", "definition", "domain", "execution", "repository")),
+      Map.entry("reconcile", Set.of("config", "domain", "engine", "execution", "repository")),
+      Map.entry("execution", Set.of("config", "cursor", "definition", "domain", "engine", "mapping", "repository", "schedule")),
+      Map.entry("definition", Set.of("config", "domain", "engine", "mapping", "repository", "schedule")),
+      Map.entry("schedule", Set.of("config", "domain", "repository")),
+      Map.entry("cursor", Set.of("config", "domain", "repository")),
+      Map.entry("mapping", Set.of("domain", "engine")),
+      Map.entry("repository", Set.of("config", "dao", "domain")),
+      Map.entry("dao", Set.of("config")),
+      Map.entry("engine", Set.of("config")),
+      Map.entry("domain", Set.of()),
+      Map.entry("config", Set.of()));
+
+  private static final Map<String, Set<String>> EXECUTION_CORRIDORS = Map.ofEntries(
+      Map.entry("controller", Set.of(BASE + "execution.OfflineJobExecutionService")),
+      Map.entry(
+          "backfill",
+          Set.of(
+              BASE + "execution.OfflineJobExecutionService",
+              BASE + "execution.OfflineExecutionScopeValidator")),
+      Map.entry("reconcile", Set.of(BASE + "execution.OfflineJobExecutionService")));
+
+  private static final Map<String, Set<String>> SCHEDULE_CORRIDORS = Map.ofEntries(
+      Map.entry(
+          "definition",
+          Set.of(
+              BASE + "schedule.OfflineScheduleLifecycle",
+              BASE + "schedule.OfflineScheduleSupport")),
+      Map.entry("execution", Set.of(BASE + "schedule.OfflineScheduleExecutionGateway")));
+
+  @Test
+  void topLevelPackagesFollowDeclaredDependencyGraph() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if (dependency.sourcePackage().equals(dependency.targetPackage())) continue;
+      Set<String> allowed = ALLOWED_TOP_LEVEL_DEPENDENCIES.get(dependency.sourcePackage());
+      assertThat(allowed)
+          .as("%s must have a declared dependency rule", dependency.sourcePackage())
+          .isNotNull();
+      assertThat(allowed)
+          .as(
+              "%s must not depend on %s via %s",
+              dependency.relativePath(), dependency.targetPackage(), dependency.importName())
+          .contains(dependency.targetPackage());
+    }
+  }
+
+  @Test
+  void topLevelPackageDependencyGraphIsAcyclic() throws IOException {
+    Map<String, Set<String>> graph = new HashMap<>();
+    for (String source : ALLOWED_TOP_LEVEL_DEPENDENCIES.keySet()) {
+      graph.put(source, new HashSet<>());
+    }
+    for (Dependency dependency : dependencies()) {
+      if (!dependency.sourcePackage().equals(dependency.targetPackage())) {
+        graph.computeIfAbsent(dependency.sourcePackage(), ignored -> new HashSet<>())
+            .add(dependency.targetPackage());
+      }
+    }
+
+    for (String start : graph.keySet()) {
+      assertThat(reaches(start, start, graph, new HashSet<>(), true))
+          .as("offline-sync top-level package dependency graph must be acyclic; cycle starts at %s", start)
+          .isFalse();
+    }
+  }
+
+  @Test
+  void executionCrossPackageImportsUseDeclaredCorridors() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if (!"execution".equals(dependency.targetPackage())
+          || "execution".equals(dependency.sourcePackage())) {
+        continue;
+      }
+      Set<String> allowed = EXECUTION_CORRIDORS.getOrDefault(dependency.sourcePackage(), Set.of());
+      assertThat(allowed)
+          .as(
+              "%s must enter execution through a declared corridor instead of %s",
+              dependency.relativePath(), dependency.importName())
+          .contains(dependency.importName());
+    }
+  }
+
+  @Test
+  void cursorCrossPackageImportsUseGatewayOnly() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if (!"cursor".equals(dependency.targetPackage())
+          || "cursor".equals(dependency.sourcePackage())) {
+        continue;
+      }
+      assertThat(dependency.importName())
+          .as("%s must use OfflineCursorGateway", dependency.relativePath())
+          .isEqualTo(BASE + "cursor.OfflineCursorGateway");
+    }
+  }
+
+  @Test
+  void scheduleCrossPackageImportsUseDeclaredCorridors() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if (!"schedule".equals(dependency.targetPackage())
+          || "schedule".equals(dependency.sourcePackage())) {
+        continue;
+      }
+      Set<String> allowed = SCHEDULE_CORRIDORS.getOrDefault(dependency.sourcePackage(), Set.of());
+      assertThat(allowed)
+          .as(
+              "%s must enter schedule through a declared corridor instead of %s",
+              dependency.relativePath(), dependency.importName())
+          .contains(dependency.importName());
+    }
+  }
+
+  @Test
+  void domainAndPersistenceBottomLayersDoNotPointBackUp() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if ("domain".equals(dependency.sourcePackage())) {
+        assertThat(dependency.targetPackage())
+            .as("Domain must remain independent: %s", dependency.relativePath())
+            .isEqualTo("domain");
+      }
+      if ("dao".equals(dependency.sourcePackage())) {
+        assertThat(dependency.targetPackage())
+            .as("DAO must not depend on business packages: %s", dependency.relativePath())
+            .isIn("dao", "config");
+      }
+      if ("repository".equals(dependency.sourcePackage())) {
+        assertThat(dependency.targetPackage())
+            .as("Repository adapter must point only to persistence/domain/config: %s", dependency.relativePath())
+            .isIn("repository", "dao", "domain", "config");
+      }
+    }
+  }
+
+  private boolean reaches(
+      String current,
+      String target,
+      Map<String, Set<String>> graph,
+      Set<String> visited,
+      boolean first) {
+    if (!first && current.equals(target)) return true;
+    if (!visited.add(current)) return false;
+    for (String next : graph.getOrDefault(current, Set.of())) {
+      if (reaches(next, target, graph, new HashSet<>(visited), false)) return true;
+    }
+    return false;
+  }
+
+  private List<Dependency> dependencies() throws IOException {
+    Path root = productionRoot();
+    List<Dependency> result = new ArrayList<>();
+    try (Stream<Path> paths = Files.walk(root)) {
+      for (Path file : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = root.relativize(file).toString().replace('\\', '/');
+        String sourcePackage = relative.substring(0, relative.indexOf('/'));
+        Matcher matcher = OFFLINE_IMPORT.matcher(Files.readString(file));
+        while (matcher.find()) {
+          result.add(new Dependency(relative, sourcePackage, matcher.group(2), matcher.group(1)));
+        }
+      }
+    }
+    return result;
+  }
+
+  private Path productionRoot() {
+    Path moduleRoot = Path.of("src/main/java/io/yak/ops/business/sync/offline");
+    if (Files.isDirectory(moduleRoot)) return moduleRoot;
+
+    Path repositoryRoot = Path.of(
+        "yak-ops-business",
+        "yak-ops-business-sync",
+        "yak-ops-business-sync-offline",
+        "src",
+        "main",
+        "java",
+        "io",
+        "yak",
+        "ops",
+        "business",
+        "sync",
+        "offline");
+    assertThat(Files.isDirectory(repositoryRoot))
+        .as("offline-sync production source root must be available to dependency test")
+        .isTrue();
+    return repositoryRoot;
+  }
+
+  private record Dependency(
+      String relativePath,
+      String sourcePackage,
+      String targetPackage,
+      String importName) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineSyncLayeringConventionTest.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.sync.offline.controller.OfflineBackfillController;
 import io.yak.ops.business.sync.offline.controller.OfflineControlPlaneController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobDefinitionController;
 import io.yak.ops.business.sync.offline.controller.OfflineJobExecutionController;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
 import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
 import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
 import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
@@ -22,6 +23,7 @@ import io.yak.ops.business.sync.offline.execution.OfflineBatchRuntime;
 import io.yak.ops.business.sync.offline.execution.OfflineExecutionAttemptFactory;
 import io.yak.ops.business.sync.offline.execution.OfflineExecutionClaimManager;
 import io.yak.ops.business.sync.offline.execution.OfflineExecutionCoordinator;
+import io.yak.ops.business.sync.offline.execution.OfflineExecutionScopeValidator;
 import io.yak.ops.business.sync.offline.execution.OfflineExecutionStateManager;
 import io.yak.ops.business.sync.offline.execution.OfflineExistingBatchClaimManager;
 import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
@@ -36,6 +38,7 @@ import io.yak.ops.business.sync.offline.repository.OfflineExecutionIdempotencyRe
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleExecutionGateway;
 import io.yak.ops.business.sync.offline.schedule.OfflineScheduleHandler;
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
@@ -67,10 +70,6 @@ class OfflineSyncLayeringConventionTest {
       "io.yak.ops.business.sync.offline.execution.OfflineBatchRuntime",
       "io.yak.ops.business.sync.offline.execution.query.",
       "io.yak.ops.business.sync.offline.execution.adapter.");
-
-  private static final Set<String> EXECUTION_INTERNAL_FACADE_EXCEPTIONS = Set.of(
-      "definition/OfflineJobDefinitionService.java",
-      "backfill/OfflineBackfillPlanner.java");
 
   private static final Set<String> LEGACY_ROLE_NAMES = Set.of(
       "OfflineExecutionOrchestrator",
@@ -152,42 +151,38 @@ class OfflineSyncLayeringConventionTest {
   }
 
   @Test
-  void backgroundEntrypointsReachExecutionThroughFacade() {
-    for (Class<?> type : List.of(
-        OfflineScheduleHandler.class,
-        OfflineBackfillDispatcher.class,
-        OfflineExecutionReconciler.class)) {
-      List<Class<?>> dependencies = fieldTypes(type);
-
-      assertThat(dependencies)
-          .as("%s must enter execution through OfflineJobExecutionService", type.getSimpleName())
-          .contains(OfflineJobExecutionService.class);
-
-      for (Class<?> dependency : dependencies) {
-        String name = dependency.getName();
-        assertThat(name)
-            .as("%s must not depend on an execution internal component", type.getSimpleName())
-            .doesNotContain("OfflineExecutionCoordinator")
-            .doesNotContain("OfflineExecutionClaimManager")
-            .doesNotContain("OfflineExistingBatchClaimManager")
-            .doesNotContain("OfflineExecutionStateManager")
-            .doesNotContain("OfflineBatchRuntime")
-            .doesNotContain(".execution.query.")
-            .doesNotContain(".execution.adapter.");
-      }
-    }
+  void stageTwelveExplicitBoundariesAreImplemented() {
+    assertThat(OfflineCursorGateway.class.isAssignableFrom(OfflineCursorManager.class)).isTrue();
+    assertThat(OfflineExecutionScopeValidator.class.isAssignableFrom(OfflineBatchScopeExecutionAdapter.class))
+        .isTrue();
+    assertThat(OfflineScheduleExecutionGateway.class.isAssignableFrom(OfflineJobExecutionService.class))
+        .isTrue();
   }
 
   @Test
-  void nonFacadeProductionCodeDoesNotImportExecutionInternals() throws IOException {
+  void backgroundEntrypointsUseOnlyDeclaredExecutionCorridors() {
+    for (Class<?> type : List.of(OfflineBackfillDispatcher.class, OfflineExecutionReconciler.class)) {
+      List<Class<?>> dependencies = fieldTypes(type);
+      assertThat(dependencies)
+          .as("%s must enter execution through OfflineJobExecutionService", type.getSimpleName())
+          .contains(OfflineJobExecutionService.class);
+      assertNoExecutionInternals(type, dependencies);
+    }
+
+    List<Class<?>> scheduleDependencies = fieldTypes(OfflineScheduleHandler.class);
+    assertThat(scheduleDependencies)
+        .contains(OfflineScheduleExecutionGateway.class)
+        .doesNotContain(OfflineJobExecutionService.class);
+    assertNoExecutionInternals(OfflineScheduleHandler.class, scheduleDependencies);
+  }
+
+  @Test
+  void nonExecutionProductionCodeDoesNotImportExecutionInternals() throws IOException {
     Path root = productionRoot();
     try (Stream<Path> paths = Files.walk(root)) {
       for (Path file : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
         String relative = root.relativize(file).toString().replace('\\', '/');
-        if (relative.startsWith("execution/")
-            || EXECUTION_INTERNAL_FACADE_EXCEPTIONS.contains(relative)) {
-          continue;
-        }
+        if (relative.startsWith("execution/")) continue;
 
         String source = Files.readString(file);
         for (String forbidden : EXECUTION_INTERNAL_IMPORTS) {
@@ -280,6 +275,21 @@ class OfflineSyncLayeringConventionTest {
 
     Field batchId = OfflineJobExecutionPO.class.getDeclaredField("batchId");
     assertThat(batchId.getType()).isEqualTo(Long.class);
+  }
+
+  private void assertNoExecutionInternals(Class<?> owner, List<Class<?>> dependencies) {
+    for (Class<?> dependency : dependencies) {
+      String name = dependency.getName();
+      assertThat(name)
+          .as("%s must not depend on an execution internal component", owner.getSimpleName())
+          .doesNotContain("OfflineExecutionCoordinator")
+          .doesNotContain("OfflineExecutionClaimManager")
+          .doesNotContain("OfflineExistingBatchClaimManager")
+          .doesNotContain("OfflineExecutionStateManager")
+          .doesNotContain("OfflineBatchRuntime")
+          .doesNotContain(".execution.query.")
+          .doesNotContain(".execution.adapter.");
+    }
   }
 
   private List<Class<?>> fieldTypes(Class<?> type) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcherTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillDispatcherTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
 import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchKey;
@@ -26,11 +26,10 @@ class OfflineBackfillDispatcherTest {
   @Test
   void cursorRangeDispatchesOnlyWhenCursorMatchesAfterExclusive() {
     OfflineBatchExecutionRepository batches = Mockito.mock(OfflineBatchExecutionRepository.class);
-    OfflineCursorManager cursors = Mockito.mock(OfflineCursorManager.class);
+    OfflineCursorGateway cursors = Mockito.mock(OfflineCursorGateway.class);
     OfflineJobExecutionService executionService = Mockito.mock(OfflineJobExecutionService.class);
     OfflineBackfillDispatcher dispatcher =
-        new OfflineBackfillDispatcher(
-            batches, cursors, executionService, new OfflineSyncProperties());
+        new OfflineBackfillDispatcher(batches, cursors, executionService, new OfflineSyncProperties());
     BatchExecution pending = pendingCursor("100", "200");
 
     when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));
@@ -47,11 +46,10 @@ class OfflineBackfillDispatcherTest {
   @Test
   void nextCursorRangeStaysPendingUntilPredecessorAdvancesCursor() {
     OfflineBatchExecutionRepository batches = Mockito.mock(OfflineBatchExecutionRepository.class);
-    OfflineCursorManager cursors = Mockito.mock(OfflineCursorManager.class);
+    OfflineCursorGateway cursors = Mockito.mock(OfflineCursorGateway.class);
     OfflineJobExecutionService executionService = Mockito.mock(OfflineJobExecutionService.class);
     OfflineBackfillDispatcher dispatcher =
-        new OfflineBackfillDispatcher(
-            batches, cursors, executionService, new OfflineSyncProperties());
+        new OfflineBackfillDispatcher(batches, cursors, executionService, new OfflineSyncProperties());
     BatchExecution pending = pendingCursor("200", "300");
 
     when(batches.findPendingBackfills(100)).thenReturn(List.of(pending));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlannerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/backfill/OfflineBackfillPlannerTest.java
@@ -4,12 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
-import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
 import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
@@ -19,7 +20,7 @@ import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
 import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
 import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
 import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
-import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
+import io.yak.ops.business.sync.offline.execution.OfflineExecutionScopeValidator;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
@@ -39,8 +40,8 @@ class OfflineBackfillPlannerTest {
   @Mock private OfflineJobDefinitionService definitionService;
   @Mock private OfflineBatchExecutionRepository batchRepository;
   @Mock private OfflineScheduleRepository scheduleRepository;
-  @Mock private OfflineCursorManager cursorManager;
-  @Mock private OfflineBatchScopeExecutionAdapter scopeExecutionAdapter;
+  @Mock private OfflineCursorGateway cursorGateway;
+  @Mock private OfflineExecutionScopeValidator scopeValidator;
 
   private OfflineBackfillPlanner planner;
 
@@ -50,8 +51,8 @@ class OfflineBackfillPlannerTest {
         definitionService,
         batchRepository,
         scheduleRepository,
-        cursorManager,
-        scopeExecutionAdapter,
+        cursorGateway,
+        scopeValidator,
         new OfflineSyncProperties());
   }
 
@@ -65,12 +66,8 @@ class OfflineBackfillPlannerTest {
     OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
     request.setRequestId("backfill-august");
     request.setScopes(List.of(
-        window(
-            LocalDateTime.of(2026, 8, 1, 0, 0),
-            LocalDateTime.of(2026, 8, 2, 0, 0)),
-        window(
-            LocalDateTime.of(2026, 8, 2, 0, 0),
-            LocalDateTime.of(2026, 8, 3, 0, 0))));
+        window(LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 2, 0, 0)),
+        window(LocalDateTime.of(2026, 8, 2, 0, 0), LocalDateTime.of(2026, 8, 3, 0, 0))));
 
     OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
     OfflineBackfillPlanner.Plan plan = planner.plan(10L, definition, prepared);
@@ -78,8 +75,7 @@ class OfflineBackfillPlannerTest {
     assertThat(plan.scopes()).hasSize(2);
     assertThat(plan.snapshot().logicalJobSpec())
         .isEqualTo("{\"kind\":\"BatchSyncJob\"}");
-    verify(scopeExecutionAdapter, org.mockito.Mockito.times(2))
-        .apply(anyLong(), any(), any());
+    verify(scopeValidator, org.mockito.Mockito.times(2)).validate(anyLong(), any(), any());
   }
 
   @Test
@@ -88,7 +84,7 @@ class OfflineBackfillPlannerTest {
     when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
     when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any()))
         .thenReturn(Optional.empty());
-    when(cursorManager.find(10L, "orders")).thenReturn(Optional.empty());
+    when(cursorGateway.find(10L, "orders")).thenReturn(Optional.empty());
     OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
     request.setRequestId("cursor-bf");
     request.setScopes(List.of(
@@ -98,7 +94,7 @@ class OfflineBackfillPlannerTest {
     OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
     planner.plan(10L, definition, prepared);
 
-    verify(cursorManager).initializeIfAbsent(10L, "orders", "updated_at", "100");
+    verify(cursorGateway).initializeIfAbsent(10L, "orders", "updated_at", "100");
   }
 
   @Test
@@ -118,7 +114,7 @@ class OfflineBackfillPlannerTest {
     assertThatThrownBy(() -> planner.plan(10L, definition, prepared))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("连续");
-    verify(scopeExecutionAdapter, never()).apply(anyLong(), any(), any());
+    verify(scopeValidator, never()).validate(anyLong(), any(), any());
   }
 
   @Test
@@ -127,14 +123,13 @@ class OfflineBackfillPlannerTest {
     when(definitionService.resolveLogicalJobSpec(definition)).thenReturn("{}");
     when(batchRepository.findByTaskIdAndBatchKey(anyLong(), any()))
         .thenReturn(Optional.empty());
-    when(scopeExecutionAdapter.apply(anyLong(), any(), any()))
-        .thenThrow(new IllegalStateException("Wave 5 scoped Batch V1 仅支持单表 source"));
+    doThrow(new IllegalStateException("Wave 5 scoped Batch V1 仅支持单表 source"))
+        .when(scopeValidator)
+        .validate(anyLong(), any(), any());
     OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
     request.setRequestId("invalid-scope");
     request.setScopes(List.of(
-        window(
-            LocalDateTime.of(2026, 8, 1, 0, 0),
-            LocalDateTime.of(2026, 8, 2, 0, 0))));
+        window(LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 2, 0, 0))));
 
     OfflineBackfillPlanner.PreparedRequest prepared = planner.prepare(request);
 
@@ -162,7 +157,8 @@ class OfflineBackfillPlannerTest {
         snapshot,
         BatchStatus.SUCCEEDED,
         List.of());
-    when(batchRepository.findByTaskIdAndBatchKey(10L, BatchKey.backfill("existing", scope.fingerprint())))
+    when(batchRepository.findByTaskIdAndBatchKey(
+            10L, BatchKey.backfill("existing", scope.fingerprint())))
         .thenReturn(Optional.of(existing));
     OfflineBackfillRequestDTO request = new OfflineBackfillRequestDTO();
     request.setRequestId("existing");
@@ -196,10 +192,7 @@ class OfflineBackfillPlannerTest {
   }
 
   private OfflineBackfillScopeDTO cursor(
-      String cursorId,
-      String column,
-      String after,
-      String through) {
+      String cursorId, String column, String after, String through) {
     OfflineBackfillScopeDTO scope = new OfflineBackfillScopeDTO();
     scope.setType("CURSOR_RANGE");
     scope.setCursorId(cursorId);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManagerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManagerTest.java
@@ -1,10 +1,75 @@
 package io.yak.ops.business.sync.offline.cursor;
 
-import static org.assertj.core.api.Assertions.assertThat;import static org.mockito.ArgumentMatchers.any;import static org.mockito.Mockito.never;import static org.mockito.Mockito.verify;import static org.mockito.Mockito.when;
-import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;import io.yak.ops.business.sync.offline.domain.core.BatchExecution;import io.yak.ops.business.sync.offline.domain.core.BatchKey;import io.yak.ops.business.sync.offline.domain.core.BatchScope;import io.yak.ops.business.sync.offline.domain.core.BatchStatus;import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;import io.yak.ops.business.sync.offline.repository.OfflineSyncCursorRepository;import java.util.List;import java.util.Optional;import org.junit.jupiter.api.Test;import org.mockito.Mockito;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineSyncCursorRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
 class OfflineCursorManagerTest {
-  @Test void advancesOnlyFromSucceededCursorRangeBatch(){OfflineSyncCursorRepository repository=Mockito.mock(OfflineSyncCursorRepository.class);OfflineCursorManager manager=new OfflineCursorManager(repository);OfflineSyncCursor current=new OfflineSyncCursor(10L,"orders-updated","updated_at","100",null,1L);when(repository.find(10L,"orders-updated")).thenReturn(Optional.of(current));when(repository.advance(current,"100","200",77L)).thenReturn(true);assertThat(manager.advanceAfterSucceededBatch(batch(BatchStatus.SUCCEEDED,"100","200"))).isEqualTo(OfflineCursorManager.AdvanceResult.ADVANCED);verify(repository).advance(current,"100","200",77L);}
-  @Test void failedBatchNeverAdvancesCursor(){OfflineSyncCursorRepository repository=Mockito.mock(OfflineSyncCursorRepository.class);OfflineCursorManager manager=new OfflineCursorManager(repository);assertThat(manager.advanceAfterSucceededBatch(batch(BatchStatus.FAILED,"100","200"))).isEqualTo(OfflineCursorManager.AdvanceResult.NOT_SUCCEEDED);verify(repository,never()).advance(any(),any(),any(),org.mockito.ArgumentMatchers.anyLong());}
-  @Test void staleSucceededBatchCannotMoveCursorBackwardOrSkipPosition(){OfflineSyncCursorRepository repository=Mockito.mock(OfflineSyncCursorRepository.class);OfflineCursorManager manager=new OfflineCursorManager(repository);OfflineSyncCursor current=new OfflineSyncCursor(10L,"orders-updated","updated_at","250",70L,3L);when(repository.find(10L,"orders-updated")).thenReturn(Optional.of(current));assertThat(manager.advanceAfterSucceededBatch(batch(BatchStatus.SUCCEEDED,"100","200"))).isEqualTo(OfflineCursorManager.AdvanceResult.STALE);verify(repository,never()).advance(any(),any(),any(),org.mockito.ArgumentMatchers.anyLong());}
-  private BatchExecution batch(BatchStatus status,String after,String through){return new BatchExecution(77L,10L,BatchKey.backfill("bf-1",BatchScope.cursorRange("orders-updated",after,through).fingerprint()),BatchTrigger.BACKFILL,BatchScope.cursorRange("orders-updated",after,through),new ExecutionSnapshot("{}",1,new RetryPolicySnapshot(2,10),"digest","{\"kind\":\"BatchSyncJob\"}"),status,List.of());}
+
+  @Test
+  void advancesOnlyFromSucceededCursorRangeBatch() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorManager manager = new OfflineCursorManager(repository);
+    OfflineSyncCursor current =
+        new OfflineSyncCursor(10L, "orders-updated", "updated_at", "100", null, 1L);
+    when(repository.find(10L, "orders-updated")).thenReturn(Optional.of(current));
+    when(repository.advance(current, "100", "200", 77L)).thenReturn(true);
+
+    assertThat(manager.advanceAfterSucceededBatch(batch(BatchStatus.SUCCEEDED, "100", "200")))
+        .isEqualTo(OfflineCursorGateway.AdvanceResult.ADVANCED);
+    verify(repository).advance(current, "100", "200", 77L);
+  }
+
+  @Test
+  void failedBatchNeverAdvancesCursor() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorManager manager = new OfflineCursorManager(repository);
+
+    assertThat(manager.advanceAfterSucceededBatch(batch(BatchStatus.FAILED, "100", "200")))
+        .isEqualTo(OfflineCursorGateway.AdvanceResult.NOT_SUCCEEDED);
+    verify(repository, never()).advance(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  @Test
+  void staleSucceededBatchCannotMoveCursorBackwardOrSkipPosition() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorManager manager = new OfflineCursorManager(repository);
+    OfflineSyncCursor current =
+        new OfflineSyncCursor(10L, "orders-updated", "updated_at", "250", 70L, 3L);
+    when(repository.find(10L, "orders-updated")).thenReturn(Optional.of(current));
+
+    assertThat(manager.advanceAfterSucceededBatch(batch(BatchStatus.SUCCEEDED, "100", "200")))
+        .isEqualTo(OfflineCursorGateway.AdvanceResult.STALE);
+    verify(repository, never()).advance(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  private BatchExecution batch(BatchStatus status, String after, String through) {
+    return new BatchExecution(
+        77L,
+        10L,
+        BatchKey.backfill(
+            "bf-1", BatchScope.cursorRange("orders-updated", after, through).fingerprint()),
+        BatchTrigger.BACKFILL,
+        BatchScope.cursorRange("orders-updated", after, through),
+        new ExecutionSnapshot(
+            "{}", 1, new RetryPolicySnapshot(2, 10), "digest", "{\"kind\":\"BatchSyncJob\"}"),
+        status,
+        List.of());
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceRuntimeTruthTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceRuntimeTruthTest.java
@@ -1,3 +1,78 @@
 package io.yak.ops.business.sync.offline.definition;
-import static org.assertj.core.api.Assertions.assertThat;import static org.assertj.core.api.Assertions.assertThatThrownBy;import static org.mockito.Mockito.mock;import static org.mockito.Mockito.never;import static org.mockito.Mockito.verify;import static org.mockito.Mockito.when;import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;import io.yak.ops.business.sync.offline.execution.OfflineBatchRuntime;import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;import io.yak.ops.business.sync.offline.schedule.OfflineScheduleLifecycle;import io.yak.ops.business.sync.offline.schedule.OfflineScheduleSupport;import java.util.Optional;import org.junit.jupiter.api.Test;
-class OfflineJobDefinitionServiceRuntimeTruthTest {@Test void offlineUsesBatchTruthAndIgnoresStaleTaskStatusProjection(){OfflineJobDefinitionRepository definitions=mock(OfflineJobDefinitionRepository.class);OfflineBatchRuntime runtime=mock(OfflineBatchRuntime.class);OfflineScheduleRepository schedules=mock(OfflineScheduleRepository.class);OfflineScheduleLifecycle lifecycle=mock(OfflineScheduleLifecycle.class);OfflineJobDefinitionService service=service(definitions,runtime,schedules,lifecycle);OfflineJobDefinition definition=new OfflineJobDefinition();definition.setId(10L);definition.setReleaseState("ONLINE");definition.setLastJobStatus("RUNNING");when(definitions.findById(10L)).thenReturn(Optional.of(definition));when(runtime.hasOccupyingBatch(10L)).thenReturn(false);when(definitions.update(definition)).thenReturn(true);assertThat(service.offline(10L)).isTrue();assertThat(definition.getReleaseState()).isEqualTo("OFFLINE");verify(runtime).hasOccupyingBatch(10L);verify(lifecycle).sync(10L);}@Test void deleteIsBlockedByOccupyingBatchEvenWhenTaskProjectionLooksTerminal(){OfflineJobDefinitionRepository definitions=mock(OfflineJobDefinitionRepository.class);OfflineBatchRuntime runtime=mock(OfflineBatchRuntime.class);OfflineScheduleRepository schedules=mock(OfflineScheduleRepository.class);OfflineScheduleLifecycle lifecycle=mock(OfflineScheduleLifecycle.class);OfflineJobDefinitionService service=service(definitions,runtime,schedules,lifecycle);OfflineJobDefinition definition=new OfflineJobDefinition();definition.setId(10L);definition.setReleaseState("OFFLINE");definition.setLastJobStatus("SUCCEEDED");when(definitions.findById(10L)).thenReturn(Optional.of(definition));when(runtime.hasOccupyingBatch(10L)).thenReturn(true);assertThatThrownBy(()->service.delete(10L)).isInstanceOf(IllegalStateException.class).hasMessageContaining("BatchExecution");verify(runtime).hasOccupyingBatch(10L);verify(lifecycle,never()).remove(10L);}private OfflineJobDefinitionService service(OfflineJobDefinitionRepository definitions,OfflineBatchRuntime runtime,OfflineScheduleRepository schedules,OfflineScheduleLifecycle lifecycle){return new OfflineJobDefinitionService(definitions,runtime,schedules,mock(OfflineDefinitionSupport.class),mock(OfflineScheduleSupport.class),lifecycle,mock(OfflineSyncViewMapper.class));}}
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleLifecycle;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleSupport;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OfflineJobDefinitionServiceRuntimeTruthTest {
+
+  @Test
+  void offlineUsesBatchTruthAndIgnoresStaleTaskStatusProjection() {
+    OfflineJobDefinitionRepository definitions = mock(OfflineJobDefinitionRepository.class);
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineScheduleRepository schedules = mock(OfflineScheduleRepository.class);
+    OfflineScheduleLifecycle lifecycle = mock(OfflineScheduleLifecycle.class);
+    OfflineJobDefinitionService service = service(definitions, batches, schedules, lifecycle);
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState("ONLINE");
+    definition.setLastJobStatus("RUNNING");
+    when(definitions.findById(10L)).thenReturn(Optional.of(definition));
+    when(batches.hasOccupyingBatch(10L)).thenReturn(false);
+    when(definitions.update(definition)).thenReturn(true);
+
+    assertThat(service.offline(10L)).isTrue();
+    assertThat(definition.getReleaseState()).isEqualTo("OFFLINE");
+    verify(batches).hasOccupyingBatch(10L);
+    verify(lifecycle).sync(10L);
+  }
+
+  @Test
+  void deleteIsBlockedByOccupyingBatchEvenWhenTaskProjectionLooksTerminal() {
+    OfflineJobDefinitionRepository definitions = mock(OfflineJobDefinitionRepository.class);
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineScheduleRepository schedules = mock(OfflineScheduleRepository.class);
+    OfflineScheduleLifecycle lifecycle = mock(OfflineScheduleLifecycle.class);
+    OfflineJobDefinitionService service = service(definitions, batches, schedules, lifecycle);
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setReleaseState("OFFLINE");
+    definition.setLastJobStatus("SUCCEEDED");
+    when(definitions.findById(10L)).thenReturn(Optional.of(definition));
+    when(batches.hasOccupyingBatch(10L)).thenReturn(true);
+
+    assertThatThrownBy(() -> service.delete(10L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("BatchExecution");
+    verify(batches).hasOccupyingBatch(10L);
+    verify(lifecycle, never()).remove(10L);
+  }
+
+  private OfflineJobDefinitionService service(
+      OfflineJobDefinitionRepository definitions,
+      OfflineBatchExecutionRepository batches,
+      OfflineScheduleRepository schedules,
+      OfflineScheduleLifecycle lifecycle) {
+    return new OfflineJobDefinitionService(
+        definitions,
+        batches,
+        schedules,
+        mock(OfflineDefinitionSupport.class),
+        mock(OfflineScheduleSupport.class),
+        lifecycle,
+        mock(OfflineSyncViewMapper.class));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineBatchRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineBatchRuntimeTest.java
@@ -1,3 +1,179 @@
 package io.yak.ops.business.sync.offline.execution;
-import static org.assertj.core.api.Assertions.assertThat;import static org.mockito.ArgumentMatchers.any;import static org.mockito.Mockito.inOrder;import static org.mockito.Mockito.mock;import static org.mockito.Mockito.verify;import static org.mockito.Mockito.when;import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;import io.yak.ops.business.sync.offline.domain.compat.LegacyOfflineExecutionCompatibilityMapper;import io.yak.ops.business.sync.offline.domain.core.BatchExecution;import io.yak.ops.business.sync.offline.domain.core.BatchKey;import io.yak.ops.business.sync.offline.domain.core.BatchScope;import io.yak.ops.business.sync.offline.domain.core.BatchStatus;import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;import java.time.LocalDateTime;import java.util.List;import java.util.Optional;import org.junit.jupiter.api.Test;import org.mockito.ArgumentCaptor;import org.mockito.InOrder;
-class OfflineBatchRuntimeTest {@Test void latestAttemptIsTheOnlySourceOfBatchRuntimeTruth(){OfflineBatchExecutionRepository batches=mock(OfflineBatchExecutionRepository.class);OfflineJobExecutionRepository attempts=mock(OfflineJobExecutionRepository.class);OfflineCursorManager cursors=mock(OfflineCursorManager.class);OfflineBatchRuntime runtime=new OfflineBatchRuntime(batches,attempts,cursors);BatchExecution batch=batch(77L,BatchStatus.PENDING,List.of(),BatchScope.fullSelection());OfflineJobExecution oldSucceeded=attempt(501L,77L,1,"SUCCEEDED");OfflineJobExecution latestRunning=attempt(502L,77L,2,"RUNNING");when(batches.findById(77L)).thenReturn(Optional.of(batch));when(attempts.findByBatchId(77L)).thenReturn(List.of(oldSucceeded,latestRunning));when(batches.update(any(BatchExecution.class))).thenReturn(true);runtime.refreshBatch(77L);ArgumentCaptor<BatchExecution> captured=ArgumentCaptor.forClass(BatchExecution.class);verify(batches).update(captured.capture());assertThat(captured.getValue().status()).isEqualTo(BatchStatus.RUNNING);}@Test void failedAttemptWithRetryReservationWindowMeansWaitingRetry(){OfflineBatchExecutionRepository batches=mock(OfflineBatchExecutionRepository.class);OfflineJobExecutionRepository attempts=mock(OfflineJobExecutionRepository.class);OfflineBatchRuntime runtime=new OfflineBatchRuntime(batches,attempts,mock(OfflineCursorManager.class));BatchExecution batch=batch(77L,BatchStatus.RUNNING,List.of(),BatchScope.fullSelection());OfflineJobExecution failed=attempt(501L,77L,1,"FAILED");failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));when(batches.findById(77L)).thenReturn(Optional.of(batch));when(attempts.findByBatchId(77L)).thenReturn(List.of(failed));when(batches.update(any(BatchExecution.class))).thenReturn(true);runtime.refreshBatch(77L);ArgumentCaptor<BatchExecution> captured=ArgumentCaptor.forClass(BatchExecution.class);verify(batches).update(captured.capture());assertThat(captured.getValue().status()).isEqualTo(BatchStatus.WAITING_RETRY);}@Test void persistsAttemptBeforeRefreshingBatchTruth(){OfflineBatchExecutionRepository batches=mock(OfflineBatchExecutionRepository.class);OfflineJobExecutionRepository attempts=mock(OfflineJobExecutionRepository.class);OfflineBatchRuntime runtime=new OfflineBatchRuntime(batches,attempts,mock(OfflineCursorManager.class));BatchExecution batch=batch(77L,BatchStatus.PENDING,List.of(),BatchScope.fullSelection());OfflineJobExecution running=attempt(501L,77L,1,"RUNNING");when(attempts.update(running)).thenReturn(true);when(batches.findById(77L)).thenReturn(Optional.of(batch));when(attempts.findByBatchId(77L)).thenReturn(List.of(running));when(batches.update(any(BatchExecution.class))).thenReturn(true);runtime.persistAttempt(running);InOrder order=inOrder(attempts,batches);order.verify(attempts).update(running);order.verify(batches).findById(77L);order.verify(attempts).findByBatchId(77L);order.verify(batches).update(any(BatchExecution.class));}@Test void succeededCursorBatchAdvancesCursorOnlyAfterBatchStatusIsPersisted(){OfflineBatchExecutionRepository batches=mock(OfflineBatchExecutionRepository.class);OfflineJobExecutionRepository attempts=mock(OfflineJobExecutionRepository.class);OfflineCursorManager cursors=mock(OfflineCursorManager.class);OfflineBatchRuntime runtime=new OfflineBatchRuntime(batches,attempts,cursors);BatchScope.CursorRange range=BatchScope.cursorRange("orders-cursor","100","200");BatchExecution batch=batch(77L,BatchStatus.RUNNING,List.of(),range);OfflineJobExecution succeeded=attempt(501L,77L,1,"SUCCEEDED");when(batches.findById(77L)).thenReturn(Optional.of(batch));when(attempts.findByBatchId(77L)).thenReturn(List.of(succeeded));when(batches.update(any(BatchExecution.class))).thenReturn(true);runtime.refreshBatch(77L);InOrder order=inOrder(batches,cursors);order.verify(batches).update(any(BatchExecution.class));order.verify(cursors).advanceAfterSucceededBatch(any(BatchExecution.class));}@Test void unknownAttemptKeepsBatchInUnknownInsteadOfFailed(){OfflineBatchRuntime runtime=new OfflineBatchRuntime(mock(OfflineBatchExecutionRepository.class),mock(OfflineJobExecutionRepository.class),mock(OfflineCursorManager.class));assertThat(runtime.deriveStatus(attempt(501L,77L,1,"UNKNOWN"))).isEqualTo(BatchStatus.UNKNOWN);}@Test void cancelWaitingRetryUsesSameCasReservationAsAutomaticRetry(){OfflineBatchExecutionRepository batches=mock(OfflineBatchExecutionRepository.class);OfflineJobExecutionRepository attempts=mock(OfflineJobExecutionRepository.class);OfflineBatchRuntime runtime=new OfflineBatchRuntime(batches,attempts,mock(OfflineCursorManager.class));OfflineJobExecution failed=attempt(501L,77L,1,"FAILED");failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));BatchExecution waiting=batch(77L,BatchStatus.WAITING_RETRY,List.of(LegacyOfflineExecutionCompatibilityMapper.toAttempt(failed)),BatchScope.fullSelection());when(attempts.findById(501L)).thenReturn(Optional.of(failed));when(attempts.reserveRetry(501L)).thenReturn(true);when(batches.update(any(BatchExecution.class))).thenReturn(true);OfflineJobExecution result=runtime.cancelWaitingRetry(waiting);assertThat(result).isSameAs(failed);assertThat(failed.getNextRetryTime()).isNull();assertThat(failed.getRetryCreated()).isTrue();verify(attempts).reserveRetry(501L);ArgumentCaptor<BatchExecution> captured=ArgumentCaptor.forClass(BatchExecution.class);verify(batches).update(captured.capture());assertThat(captured.getValue().status()).isEqualTo(BatchStatus.CANCELED);}private BatchExecution batch(long id,BatchStatus status,List<io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt> attempts,BatchScope scope){return new BatchExecution(id,10L,new BatchKey("manual:test"),BatchTrigger.MANUAL,scope,new ExecutionSnapshot("{}",1,new RetryPolicySnapshot(3,30),"digest","{\"kind\":\"BatchSyncJob\"}"),status,attempts);}private OfflineJobExecution attempt(long id,long batchId,int attemptNo,String status){OfflineJobExecution execution=new OfflineJobExecution();execution.setId(id);execution.setJobDefinitionId(10L);execution.setBatchId(batchId);execution.setAttemptNo(attemptNo);execution.setTriggerType(attemptNo==1?"MANUAL":"RETRY");execution.setIdempotencyKey("attempt-"+id);execution.setExternalExecutionId("external-"+id);execution.setStatus(status);execution.setRetryCreated(false);execution.setCreateTime(LocalDateTime.of(2026,8,23,10,attemptNo));return execution;}}
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.compat.LegacyOfflineExecutionCompatibilityMapper;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+class OfflineBatchRuntimeTest {
+
+  @Test
+  void latestAttemptIsTheOnlySourceOfBatchRuntimeTruth() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineCursorGateway cursors = mock(OfflineCursorGateway.class);
+    OfflineBatchRuntime runtime = new OfflineBatchRuntime(batches, attempts, cursors);
+    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of(), BatchScope.fullSelection());
+    OfflineJobExecution oldSucceeded = attempt(501L, 77L, 1, "SUCCEEDED");
+    OfflineJobExecution latestRunning = attempt(502L, 77L, 2, "RUNNING");
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(oldSucceeded, latestRunning));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    runtime.refreshBatch(77L);
+
+    ArgumentCaptor<BatchExecution> captured = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batches).update(captured.capture());
+    assertThat(captured.getValue().status()).isEqualTo(BatchStatus.RUNNING);
+  }
+
+  @Test
+  void failedAttemptWithRetryReservationWindowMeansWaitingRetry() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchRuntime runtime = new OfflineBatchRuntime(batches, attempts, mock(OfflineCursorGateway.class));
+    BatchExecution batch = batch(77L, BatchStatus.RUNNING, List.of(), BatchScope.fullSelection());
+    OfflineJobExecution failed = attempt(501L, 77L, 1, "FAILED");
+    failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(failed));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    runtime.refreshBatch(77L);
+
+    ArgumentCaptor<BatchExecution> captured = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batches).update(captured.capture());
+    assertThat(captured.getValue().status()).isEqualTo(BatchStatus.WAITING_RETRY);
+  }
+
+  @Test
+  void persistsAttemptBeforeRefreshingBatchTruth() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchRuntime runtime = new OfflineBatchRuntime(batches, attempts, mock(OfflineCursorGateway.class));
+    BatchExecution batch = batch(77L, BatchStatus.PENDING, List.of(), BatchScope.fullSelection());
+    OfflineJobExecution running = attempt(501L, 77L, 1, "RUNNING");
+    when(attempts.update(running)).thenReturn(true);
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(running));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    runtime.persistAttempt(running);
+
+    InOrder order = inOrder(attempts, batches);
+    order.verify(attempts).update(running);
+    order.verify(batches).findById(77L);
+    order.verify(attempts).findByBatchId(77L);
+    order.verify(batches).update(any(BatchExecution.class));
+  }
+
+  @Test
+  void succeededCursorBatchAdvancesCursorOnlyAfterBatchStatusIsPersisted() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineCursorGateway cursors = mock(OfflineCursorGateway.class);
+    OfflineBatchRuntime runtime = new OfflineBatchRuntime(batches, attempts, cursors);
+    BatchScope.CursorRange range = BatchScope.cursorRange("orders-cursor", "100", "200");
+    BatchExecution batch = batch(77L, BatchStatus.RUNNING, List.of(), range);
+    OfflineJobExecution succeeded = attempt(501L, 77L, 1, "SUCCEEDED");
+    when(batches.findById(77L)).thenReturn(Optional.of(batch));
+    when(attempts.findByBatchId(77L)).thenReturn(List.of(succeeded));
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    runtime.refreshBatch(77L);
+
+    InOrder order = inOrder(batches, cursors);
+    order.verify(batches).update(any(BatchExecution.class));
+    order.verify(cursors).advanceAfterSucceededBatch(any(BatchExecution.class));
+  }
+
+  @Test
+  void unknownAttemptKeepsBatchInUnknownInsteadOfFailed() {
+    OfflineBatchRuntime runtime = new OfflineBatchRuntime(
+        mock(OfflineBatchExecutionRepository.class),
+        mock(OfflineJobExecutionRepository.class),
+        mock(OfflineCursorGateway.class));
+    assertThat(runtime.deriveStatus(attempt(501L, 77L, 1, "UNKNOWN")))
+        .isEqualTo(BatchStatus.UNKNOWN);
+  }
+
+  @Test
+  void cancelWaitingRetryUsesSameCasReservationAsAutomaticRetry() {
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineJobExecutionRepository attempts = mock(OfflineJobExecutionRepository.class);
+    OfflineBatchRuntime runtime = new OfflineBatchRuntime(batches, attempts, mock(OfflineCursorGateway.class));
+    OfflineJobExecution failed = attempt(501L, 77L, 1, "FAILED");
+    failed.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
+    BatchExecution waiting = batch(
+        77L,
+        BatchStatus.WAITING_RETRY,
+        List.of(LegacyOfflineExecutionCompatibilityMapper.toAttempt(failed)),
+        BatchScope.fullSelection());
+    when(attempts.findById(501L)).thenReturn(Optional.of(failed));
+    when(attempts.reserveRetry(501L)).thenReturn(true);
+    when(batches.update(any(BatchExecution.class))).thenReturn(true);
+
+    OfflineJobExecution result = runtime.cancelWaitingRetry(waiting);
+
+    assertThat(result).isSameAs(failed);
+    assertThat(failed.getNextRetryTime()).isNull();
+    assertThat(failed.getRetryCreated()).isTrue();
+    verify(attempts).reserveRetry(501L);
+    ArgumentCaptor<BatchExecution> captured = ArgumentCaptor.forClass(BatchExecution.class);
+    verify(batches).update(captured.capture());
+    assertThat(captured.getValue().status()).isEqualTo(BatchStatus.CANCELED);
+  }
+
+  private BatchExecution batch(
+      long id,
+      BatchStatus status,
+      List<io.yak.ops.business.sync.offline.domain.core.ExecutionAttempt> attempts,
+      BatchScope scope) {
+    return new BatchExecution(
+        id,
+        10L,
+        new BatchKey("manual:test"),
+        BatchTrigger.MANUAL,
+        scope,
+        new ExecutionSnapshot(
+            "{}", 1, new RetryPolicySnapshot(3, 30), "digest", "{\"kind\":\"BatchSyncJob\"}"),
+        status,
+        attempts);
+  }
+
+  private OfflineJobExecution attempt(long id, long batchId, int attemptNo, String status) {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(id);
+    execution.setJobDefinitionId(10L);
+    execution.setBatchId(batchId);
+    execution.setAttemptNo(attemptNo);
+    execution.setTriggerType(attemptNo == 1 ? "MANUAL" : "RETRY");
+    execution.setIdempotencyKey("attempt-" + id);
+    execution.setExternalExecutionId("external-" + id);
+    execution.setStatus(status);
+    execution.setRetryCreated(false);
+    execution.setCreateTime(LocalDateTime.of(2026, 8, 23, 10, attemptNo));
+    return execution;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionServiceEntryPointTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionServiceEntryPointTest.java
@@ -43,6 +43,23 @@ class OfflineJobExecutionServiceEntryPointTest {
   }
 
   @Test
+  void scheduleGatewayReturnsOnlyExecutionIdentity() {
+    Fixture fixture = fixture();
+    String triggerToken = "SCHEDULE|schedule-10|2026-08-23T08:00:00";
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(21L);
+    OfflineJobExecutionVO view = mock(OfflineJobExecutionVO.class);
+    when(view.getId()).thenReturn(21L);
+    when(fixture.coordinator.execute(10L, triggerToken, null, 1)).thenReturn(execution);
+    when(fixture.executionQuery.toVO(execution)).thenReturn(view);
+
+    assertThat(fixture.service.submitScheduled(10L, triggerToken)).isEqualTo(21L);
+
+    verify(fixture.coordinator).execute(10L, triggerToken, null, 1);
+    verify(view).getId();
+  }
+
+  @Test
   void pendingBackfillExecutionDelegatesToCoordinator() {
     Fixture fixture = fixture();
     OfflineJobExecution execution = new OfflineJobExecution();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapterTest.java
@@ -1,3 +1,59 @@
 package io.yak.ops.business.sync.offline.execution.adapter;
-import static org.assertj.core.api.Assertions.assertThat;import static org.assertj.core.api.Assertions.assertThatThrownBy;import static org.mockito.Mockito.mock;import static org.mockito.Mockito.when;import com.fasterxml.jackson.databind.ObjectMapper;import io.yak.ops.business.sync.offline.cursor.OfflineCursorManager;import io.yak.ops.business.sync.offline.domain.core.BatchScope;import java.time.LocalDateTime;import org.junit.jupiter.api.Test;
-class OfflineBatchScopeExecutionAdapterTest {private final OfflineCursorManager cursorManager=mock(OfflineCursorManager.class);private final OfflineBatchScopeExecutionAdapter adapter=new OfflineBatchScopeExecutionAdapter(new ObjectMapper(),cursorManager);@Test void dataWindowProjectsToWhereConditionWithoutChangingDomainScope(){String scoped=adapter.apply(10L,logicalJobSpec("tenant_id = 7"),BatchScope.dataWindow(LocalDateTime.of(2026,8,1,0,0),LocalDateTime.of(2026,8,2,0,0)));assertThat(scoped).contains("tenant_id = 7");assertThat(scoped).contains("updated_at >= '2026-08-01 00:00'");assertThat(scoped).contains("updated_at < '2026-08-02 00:00'");}@Test void cursorRangeUsesCursorRouteInsteadOfTreatingCursorIdAsColumn(){when(cursorManager.requireSourceColumn(10L,"orders-watermark")).thenReturn("updated_at");String scoped=adapter.apply(10L,logicalJobSpec(null),BatchScope.cursorRange("orders-watermark","100","200"));assertThat(scoped).contains("updated_at > '100'");assertThat(scoped).contains("updated_at <= '200'");}@Test void scopedBatchRejectsMultiTableJobSpecInsteadOfGuessingRoute(){String logical="{\"source\":{\"connectorId\":\"jdbc\",\"options\":{\"table_list\":[{\"table_path\":\"a\"},{\"table_path\":\"b\"}],\"partition_column\":\"updated_at\"}},\"sink\":{}}";assertThatThrownBy(()->adapter.apply(10L,logical,BatchScope.partitions(java.util.List.of("p1")))).isInstanceOf(IllegalStateException.class).hasMessageContaining("单表");}private String logicalJobSpec(String whereCondition){String where=whereCondition==null?"":",\"where_condition\":\""+whereCondition+"\"";return "{\"kind\":\"BatchSyncJob\",\"source\":{\"connectorId\":\"jdbc\",\"options\":{\"table_path\":\"orders\",\"partition_column\":\"updated_at\""+where+"}},\"sink\":{}}";}}
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class OfflineBatchScopeExecutionAdapterTest {
+
+  private final OfflineCursorGateway cursorGateway = mock(OfflineCursorGateway.class);
+  private final OfflineBatchScopeExecutionAdapter adapter =
+      new OfflineBatchScopeExecutionAdapter(new ObjectMapper(), cursorGateway);
+
+  @Test
+  void dataWindowProjectsToWhereConditionWithoutChangingDomainScope() {
+    String scoped = adapter.apply(
+        10L,
+        logicalJobSpec("tenant_id = 7"),
+        BatchScope.dataWindow(
+            LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 2, 0, 0)));
+    assertThat(scoped).contains("tenant_id = 7");
+    assertThat(scoped).contains("updated_at >= '2026-08-01 00:00'");
+    assertThat(scoped).contains("updated_at < '2026-08-02 00:00'");
+  }
+
+  @Test
+  void cursorRangeUsesCursorRouteInsteadOfTreatingCursorIdAsColumn() {
+    when(cursorGateway.requireSourceColumn(10L, "orders-watermark")).thenReturn("updated_at");
+    String scoped = adapter.apply(
+        10L,
+        logicalJobSpec(null),
+        BatchScope.cursorRange("orders-watermark", "100", "200"));
+    assertThat(scoped).contains("updated_at > '100'");
+    assertThat(scoped).contains("updated_at <= '200'");
+  }
+
+  @Test
+  void scopedBatchRejectsMultiTableJobSpecInsteadOfGuessingRoute() {
+    String logical =
+        "{\"source\":{\"connectorId\":\"jdbc\",\"options\":{\"table_list\":[{\"table_path\":\"a\"},{\"table_path\":\"b\"}],\"partition_column\":\"updated_at\"}},\"sink\":{}}";
+    assertThatThrownBy(
+            () -> adapter.validate(10L, logical, BatchScope.partitions(java.util.List.of("p1"))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("单表");
+  }
+
+  private String logicalJobSpec(String whereCondition) {
+    String where = whereCondition == null ? "" : ",\"where_condition\":\"" + whereCondition + "\"";
+    return "{\"kind\":\"BatchSyncJob\",\"source\":{\"connectorId\":\"jdbc\",\"options\":{\"table_path\":\"orders\",\"partition_column\":\"updated_at\""
+        + where
+        + "}},\"sink\":{}}";
+  }
+}


### PR DESCRIPTION
## Summary

完成离线同步 **Stage 12 — Dependency Boundary Governance**。

Stage 8-11 已经依次解决目录归位、Application Entry、角色命名和核心职责拆分；Stage 12 固定 top-level package 的依赖方向，并把跨子系统调用收敛成明确的 Gateway / Validator corridor。

本 PR 不改变 Task / Batch / Attempt / Cursor 运行语义，不改 REST、数据库、Flyway 或 Link-Up API。

## 1. Explicit cross-subsystem boundaries

新增三条窄边界：

```text
OfflineCursorGateway
OfflineExecutionScopeValidator
OfflineScheduleExecutionGateway
```

### Cursor

Before:

```text
BackfillPlanner / BackfillDispatcher / BatchRuntime / ScopeAdapter
    -> OfflineCursorManager
```

After:

```text
cross-subsystem caller
    -> OfflineCursorGateway
         -> OfflineCursorManager
```

`OfflineCursorManager` 继续是 Cursor 内部实现；其他子系统不再直接依赖 Manager。

### Backfill -> Execution scope

Before:

```text
OfflineBackfillPlanner
    -> execution.adapter.OfflineBatchScopeExecutionAdapter
```

After:

```text
OfflineBackfillPlanner
    -> OfflineExecutionScopeValidator
         -> OfflineBatchScopeExecutionAdapter
```

Backfill 只依赖“能否应用 BatchScope”这项能力，不认识具体 Adapter。

### Schedule -> Execution

Before:

```text
OfflineScheduleHandler
    -> OfflineJobExecutionService
```

这与现有 `Execution -> Definition -> Schedule` 一起形成 top-level package 环。

After:

```text
OfflineScheduleHandler
    -> schedule.OfflineScheduleExecutionGateway
         ^
         |
OfflineJobExecutionService implements gateway
```

Schedule Handler 不再 import `execution.*`，也不接触 `OfflineJobExecutionVO`；只获得 `executionId`。

## 2. Remove Definition -> Execution internal dependency

Before:

```text
OfflineJobDefinitionService
    -> OfflineBatchRuntime
```

Definition 实际只需要 occupancy guard，而 `OfflineBatchExecutionRepository.hasOccupyingBatch()` 已经是 Batch runtime truth contract。

After:

```text
OfflineJobDefinitionService
    -> OfflineBatchExecutionRepository
```

因此 Definition 不再反向依赖 Execution internal，同时仍然严格基于 Batch truth，不读取 Task `last-*` projection。

## 3. Top-level package dependency governance

新增 `OfflineSyncDependencyBoundaryTest`，扫描生产源码 internal imports 并验证：

1. top-level package 依赖必须在白名单内；
2. 根据真实 import 生成的 package graph 必须无环；
3. execution / cursor / schedule 的跨子系统调用必须经过声明过的 corridor；
4. Domain / DAO / Repository 底层不能反向依赖业务流程组件。

当前白名单：

| Source | Allowed |
| --- | --- |
| `controller` | `config`, `definition`, `execution`, `backfill` |
| `backfill` | `config`, `cursor`, `definition`, `domain`, `execution`, `repository` |
| `reconcile` | `config`, `domain`, `engine`, `execution`, `repository` |
| `execution` | `config`, `cursor`, `definition`, `domain`, `engine`, `mapping`, `repository`, `schedule` |
| `definition` | `config`, `domain`, `engine`, `mapping`, `repository`, `schedule` |
| `schedule` | `config`, `domain`, `repository` |
| `cursor` | `config`, `domain`, `repository` |
| `mapping` | `domain`, `engine` |
| `repository` | `config`, `dao`, `domain` |
| `dao` | `config` |
| `engine` | `config` |
| `domain` | none |
| `config` | none |

同 top-level package 内的 `execution.query / execution.adapter` 仍属于 execution 子系统，但不自动成为跨子系统 API。

## 4. Exact corridors

### Into execution

```text
controller -> OfflineJobExecutionService
backfill   -> OfflineJobExecutionService
backfill   -> OfflineExecutionScopeValidator
reconcile  -> OfflineJobExecutionService
schedule   -> no execution import
definition -> no execution import
```

### Into cursor

跨子系统只有：

```text
OfflineCursorGateway
```

### Into schedule

当前显式走廊：

```text
definition -> OfflineScheduleLifecycle / OfflineScheduleSupport
execution  -> OfflineScheduleExecutionGateway
```

Stage 12 不做“接口化一切”；只有跨边界能力已经导致泄漏或循环时才增加稳定门。

## 5. Existing architecture guardrails aligned

更新 `OfflineSyncLayeringConventionTest`：

- 保留 Stage 7-11 的 Application Facade / Role / Decomposition / Persistence contract；
- Schedule Handler 改为验证 `OfflineScheduleExecutionGateway`；
- Backfill Dispatcher / Reconciler 仍只通过 `OfflineJobExecutionService` 进入 execution；
- 非 execution 生产源码不允许直接 import execution internal；
- 验证三个 Stage 12 boundary 的 implementation relationship。

## 6. Tests aligned with boundary types

同步更新：

- `OfflineJobDefinitionServiceRuntimeTruthTest`
- `OfflineBatchRuntimeTest`
- `OfflineCursorManagerTest`
- `OfflineBatchScopeExecutionAdapterTest`
- `OfflineBackfillPlannerTest`
- `OfflineBackfillDispatcherTest`
- `OfflineJobExecutionServiceEntryPointTest`

测试不再为了方便 mock 跨子系统具体 Manager / Adapter，而是 mock Gateway / Validator contract。

## Runtime invariants preserved

本 PR 不改变：

- `Task != Batch != Attempt`；
- Batch 是 runtime truth；
- Task `last-*` 只是 projection；
- Retry 只在原 Batch 内追加 Attempt；
- UNKNOWN 禁止盲 Retry；
- terminal Batch 禁止追加 Attempt；
- Backfill 物化 Batch group；
- Cursor 只在 SUCCEEDED CursorRange Batch 后 CAS 推进；
- batchless legacy execution 只读；
- Snapshot 不持久化运行时数据源凭据。

## Documentation

- 新增 `docs/offline-sync/architecture/STAGE12.md`
- 更新 offline-sync `README.md`
- Stage 状态：

```text
Stage 11  COMPLETE  Core Responsibility Decomposition
Stage 12  COMPLETE  Dependency Boundary Governance
Stage 13  NEXT      Architecture Guardrails
```

## Non-goals

本 PR 不做：

- 不继续拆 Stage 11 核心类；
- 不把所有内部协作都接口化；
- 不移动 Domain / Repository / DAO package；
- 不引入 Shared Kernel；
- 不修改状态机、事务边界、REST、DTO/VO、DB/Flyway、Link-Up API。

## Validation note

当前分支基于 Stage 11 合并后的 `main`，最终 compare 为 `ahead 22 / behind 0`，变更仅涉及 offline-sync Stage 12 implementation / tests / architecture docs。

本轮主要通过静态源码审查、定向单测调整和新增 package graph test 完成约束；PR 保持 Draft，继续等待 GitHub CI/check 返回，不把未实际执行的本地 Maven 测试宣称为通过。

下一步：**Stage 13 — Architecture Guardrails**。