### PR TITLE
refactor(offline-sync): align code with apache style guide

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineDefinitionSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineDefinitionSupport.java
@@ -12,6 +12,7 @@ import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -21,52 +22,376 @@ import org.springframework.util.StringUtils;
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineDefinitionSupport {
+
   private final LinkUpJobSpecFactory jobSpecFactory;
   private final ObjectMapper objectMapper;
-  public OfflineDefinitionSupport(LinkUpJobSpecFactory jobSpecFactory, @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) { this.jobSpecFactory = jobSpecFactory; this.objectMapper = objectMapper; }
+
+  public OfflineDefinitionSupport(
+      LinkUpJobSpecFactory jobSpecFactory,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.jobSpecFactory = jobSpecFactory;
+    this.objectMapper = objectMapper;
+  }
+
   public PreparedDefinition prepare(OfflineJobDefinitionDTO dto) {
-    ObjectNode request = object(dto); JsonNode basic = request.path("basic"); String name = requiredText(basic, "jobName", "任务名称不能为空"); String mode = mode(basic);
-    JsonNode buildRequest = OfflineDefinitionModelAdapter.forJobSpec(request, objectMapper); LinkUpJobSpecFactory.BuildResult result = jobSpecFactory.build(buildRequest);
-    DataSourcePO source = result.getSourceDataSource(); DataSourcePO sink = result.getSinkDataSource();
-    return new PreparedDefinition(request, name.trim(), trim(text(basic, "jobDesc", null)), mode, write(request), result.getJobSpecJson(), id(source), id(sink), displayType(source, result.getSourceConnectorId()), displayType(sink, result.getSinkConnectorId()), result.getSourceTable(), result.getSinkTable(), digest(result.getJobSpecJson()));
+    ObjectNode request = normalizeRequest(dto);
+    JsonNode basic = request.path("basic");
+    String jobName = requiredText(basic, "jobName", "任务名称不能为空").trim();
+    String mode = mode(basic);
+
+    JsonNode buildRequest = OfflineDefinitionModelAdapter.forJobSpec(request, objectMapper);
+    LinkUpJobSpecFactory.BuildResult result = jobSpecFactory.build(buildRequest);
+    DataSourcePO source = result.getSourceDataSource();
+    DataSourcePO sink = result.getSinkDataSource();
+
+    return new PreparedDefinition(
+        request,
+        jobName,
+        trim(text(basic, "jobDesc", null)),
+        mode,
+        write(request),
+        result.getJobSpecJson(),
+        id(source),
+        id(sink),
+        displayType(source, result.getSourceConnectorId()),
+        displayType(sink, result.getSinkConnectorId()),
+        result.getSourceTable(),
+        result.getSinkTable(),
+        digest(result.getJobSpecJson()));
   }
+
   public DraftDefinition prepareDraft(OfflineJobDefinitionDTO dto) {
-    ObjectNode request = object(dto); JsonNode basic = request.path("basic");
-    return new DraftDefinition(request, requiredText(basic, "jobName", "任务名称不能为空").trim(), trim(text(basic, "jobDesc", null)), mode(basic), write(request), endpointType(request.path("source"), "来源类型不能为空"), endpointType(request.path("sink"), "目标类型不能为空"));
+    ObjectNode request = normalizeRequest(dto);
+    JsonNode basic = request.path("basic");
+
+    return new DraftDefinition(
+        request,
+        requiredText(basic, "jobName", "任务名称不能为空").trim(),
+        trim(text(basic, "jobDesc", null)),
+        mode(basic),
+        write(request),
+        endpointType(request.path("source"), "来源类型不能为空"),
+        endpointType(request.path("sink"), "目标类型不能为空"));
   }
-  public String buildJobSpec(OfflineJobDefinitionDTO dto) { return prepare(dto).getJobSpecJson(); }
-  public String resolveExecutionJobSpec(String logicalJobSpec) { return jobSpecFactory.resolveForExecution(logicalJobSpec); }
+
+  public String buildJobSpec(OfflineJobDefinitionDTO dto) {
+    return prepare(dto).getJobSpecJson();
+  }
+
+  public String resolveExecutionJobSpec(String logicalJobSpec) {
+    return jobSpecFactory.resolveForExecution(logicalJobSpec);
+  }
+
   public JsonNode editDetail(OfflineJobDefinition definition) {
-    JsonNode parsed = read(definition.getDefinitionJson()); ObjectNode detail = parsed != null && parsed.isObject() ? (ObjectNode) parsed.deepCopy() : objectMapper.createObjectNode();
-    detail.put("id", definition.getId()); ObjectNode state = detail.with("state"); state.put("releaseState", definition.getReleaseState()); state.put("lastJobStatus", definition.getLastJobStatus()); state.put("lastErrorMessage", definition.getLastErrorMessage());
-    state.set("lastExecutionId", objectMapper.valueToTree(definition.getLastExecutionId())); state.put("lastEngineJobId", definition.getLastEngineJobId()); state.put("draft", !StringUtils.hasText(definition.getJobSpecJson())); return detail;
+    JsonNode parsed = read(definition.getDefinitionJson());
+    ObjectNode detail =
+        parsed != null && parsed.isObject()
+            ? (ObjectNode) parsed.deepCopy()
+            : objectMapper.createObjectNode();
+
+    detail.put("id", definition.getId());
+    ObjectNode state = detail.with("state");
+    state.put("releaseState", definition.getReleaseState());
+    state.put("lastJobStatus", definition.getLastJobStatus());
+    state.put("lastErrorMessage", definition.getLastErrorMessage());
+    state.set("lastExecutionId", objectMapper.valueToTree(definition.getLastExecutionId()));
+    state.put("lastEngineJobId", definition.getLastEngineJobId());
+    state.put("draft", !StringUtils.hasText(definition.getJobSpecJson()));
+    return detail;
   }
-  private ObjectNode object(OfflineJobDefinitionDTO dto) {
-    if (dto == null) throw new IllegalArgumentException("任务定义不能为空"); JsonNode value = objectMapper.valueToTree(dto); if (!value.isObject()) throw new IllegalArgumentException("任务定义格式不正确");
-    ObjectNode request = (ObjectNode) value; requireObject(request.path("basic"), "basic 配置不能为空"); normalizeEndpoint(request, "source"); normalizeEndpoint(request, "sink"); normalizeChannel(request); OfflineDefinitionModelAdapter.sanitizeForPersistence(request); return request;
+
+  private ObjectNode normalizeRequest(OfflineJobDefinitionDTO dto) {
+    if (dto == null) {
+      throw new IllegalArgumentException("任务定义不能为空");
+    }
+
+    JsonNode value = objectMapper.valueToTree(dto);
+    if (!value.isObject()) {
+      throw new IllegalArgumentException("任务定义格式不正确");
+    }
+
+    ObjectNode request = (ObjectNode) value;
+    requireObject(request.path("basic"), "basic 配置不能为空");
+    normalizeEndpoint(request, "source");
+    normalizeEndpoint(request, "sink");
+    normalizeChannel(request);
+    OfflineDefinitionModelAdapter.sanitizeForPersistence(request);
+    return request;
   }
-  private void normalizeEndpoint(ObjectNode request, String field) { requireObject(request.get(field), field + " 配置不能为空"); }
-  private void normalizeChannel(ObjectNode request) { JsonNode value = request.get("channel"); ObjectNode channel; if (value == null || value.isNull()) channel = request.putObject("channel"); else { requireObject(value, "channel 配置必须是 JSON 对象"); channel = (ObjectNode) value; } if (!channel.hasNonNull("parallelism")) channel.put("parallelism", 1); if (!channel.hasNonNull("speedLimitEnabled")) channel.put("speedLimitEnabled", false); if (!channel.hasNonNull("recordsPerSecond")) channel.put("recordsPerSecond", 10000L); if (!channel.hasNonNull("dirtyDataPolicy")) channel.put("dirtyDataPolicy", "STOP"); if (!channel.hasNonNull("dirtyDataLimit")) channel.put("dirtyDataLimit", 0L); }
-  private String mode(JsonNode basic) { String value = text(basic, "mode", "GUIDE_SINGLE"); if (!"GUIDE_SINGLE".equals(value) && !"GUIDE_MULTI".equals(value)) throw new IllegalArgumentException("离线同步仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 模式"); return value; }
-  private String endpointType(JsonNode endpoint, String message) { String value = text(endpoint, "dbType", null); if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message); return value.trim(); }
-  private void requireObject(JsonNode node, String message) { if (node == null || !node.isObject()) throw new IllegalArgumentException(message); }
-  private JsonNode read(String value) { if (!StringUtils.hasText(value)) return objectMapper.createObjectNode(); try { return objectMapper.readTree(value); } catch (JsonProcessingException exception) { throw new IllegalStateException("任务定义 JSON 已损坏", exception); } }
-  private String write(JsonNode value) { try { return objectMapper.writeValueAsString(value); } catch (JsonProcessingException exception) { throw new IllegalStateException("序列化任务定义失败", exception); } }
-  private String digest(String value) { try { return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8))); } catch (Exception exception) { throw new IllegalStateException("生成 JobSpec 摘要失败", exception); } }
-  private String requiredText(JsonNode node, String field, String message) { String value = text(node, field, null); if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message); return value; }
-  private String text(JsonNode node, String field, String fallback) { JsonNode value = node == null ? null : node.get(field); return value == null || value.isNull() || !value.isValueNode() ? fallback : value.asText(fallback); }
-  private String trim(String value) { return StringUtils.hasText(value) ? value.trim() : null; }
-  private Long id(DataSourcePO dataSource) { return dataSource == null ? null : dataSource.getId(); }
-  private String displayType(DataSourcePO dataSource, String connectorId) { return dataSource != null && dataSource.getDbType() != null ? dataSource.getDbType().name() : connectorId; }
+
+  private void normalizeEndpoint(ObjectNode request, String field) {
+    requireObject(request.get(field), field + " 配置不能为空");
+  }
+
+  private void normalizeChannel(ObjectNode request) {
+    JsonNode value = request.get("channel");
+    ObjectNode channel;
+    if (value == null || value.isNull()) {
+      channel = request.putObject("channel");
+    } else {
+      requireObject(value, "channel 配置必须是 JSON 对象");
+      channel = (ObjectNode) value;
+    }
+
+    putDefault(channel, "parallelism", 1);
+    putDefault(channel, "speedLimitEnabled", false);
+    putDefault(channel, "recordsPerSecond", 10000L);
+    putDefault(channel, "dirtyDataPolicy", "STOP");
+    putDefault(channel, "dirtyDataLimit", 0L);
+  }
+
+  private void putDefault(ObjectNode target, String field, int value) {
+    if (!target.hasNonNull(field)) {
+      target.put(field, value);
+    }
+  }
+
+  private void putDefault(ObjectNode target, String field, long value) {
+    if (!target.hasNonNull(field)) {
+      target.put(field, value);
+    }
+  }
+
+  private void putDefault(ObjectNode target, String field, boolean value) {
+    if (!target.hasNonNull(field)) {
+      target.put(field, value);
+    }
+  }
+
+  private void putDefault(ObjectNode target, String field, String value) {
+    if (!target.hasNonNull(field)) {
+      target.put(field, value);
+    }
+  }
+
+  private String mode(JsonNode basic) {
+    String value = text(basic, "mode", "GUIDE_SINGLE");
+    if (!"GUIDE_SINGLE".equals(value) && !"GUIDE_MULTI".equals(value)) {
+      throw new IllegalArgumentException("离线同步仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 模式");
+    }
+    return value;
+  }
+
+  private String endpointType(JsonNode endpoint, String message) {
+    String value = text(endpoint, "dbType", null);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(message);
+    }
+    return value.trim();
+  }
+
+  private void requireObject(JsonNode node, String message) {
+    if (node == null || !node.isObject()) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  private JsonNode read(String value) {
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("任务定义 JSON 已损坏", exception);
+    }
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化任务定义失败", exception);
+    }
+  }
+
+  private String digest(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("生成 JobSpec 摘要失败", exception);
+    }
+  }
+
+  private String requiredText(JsonNode node, String field, String message) {
+    String value = text(node, field, null);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(message);
+    }
+    return value;
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || value.isNull() || !value.isValueNode()
+        ? fallback
+        : value.asText(fallback);
+  }
+
+  private String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private Long id(DataSourcePO dataSource) {
+    return dataSource == null ? null : dataSource.getId();
+  }
+
+  private String displayType(DataSourcePO dataSource, String connectorId) {
+    return dataSource != null && dataSource.getDbType() != null
+        ? dataSource.getDbType().name()
+        : connectorId;
+  }
 
   public static final class DraftDefinition {
-    private final ObjectNode request; private final String jobName; private final String jobDesc; private final String mode; private final String definitionJson; private final String sourceType; private final String sinkType;
-    public DraftDefinition(ObjectNode request, String jobName, String jobDesc, String mode, String definitionJson, String sourceType, String sinkType) { this.request=request; this.jobName=jobName; this.jobDesc=jobDesc; this.mode=mode; this.definitionJson=definitionJson; this.sourceType=sourceType; this.sinkType=sinkType; }
-    public ObjectNode getRequest(){return request;} public String getJobName(){return jobName;} public String getJobDesc(){return jobDesc;} public String getMode(){return mode;} public String getDefinitionJson(){return definitionJson;} public String getSourceType(){return sourceType;} public String getSinkType(){return sinkType;}
+    private final ObjectNode request;
+    private final String jobName;
+    private final String jobDesc;
+    private final String mode;
+    private final String definitionJson;
+    private final String sourceType;
+    private final String sinkType;
+
+    public DraftDefinition(
+        ObjectNode request,
+        String jobName,
+        String jobDesc,
+        String mode,
+        String definitionJson,
+        String sourceType,
+        String sinkType) {
+      this.request = request;
+      this.jobName = jobName;
+      this.jobDesc = jobDesc;
+      this.mode = mode;
+      this.definitionJson = definitionJson;
+      this.sourceType = sourceType;
+      this.sinkType = sinkType;
+    }
+
+    public ObjectNode getRequest() {
+      return request;
+    }
+
+    public String getJobName() {
+      return jobName;
+    }
+
+    public String getJobDesc() {
+      return jobDesc;
+    }
+
+    public String getMode() {
+      return mode;
+    }
+
+    public String getDefinitionJson() {
+      return definitionJson;
+    }
+
+    public String getSourceType() {
+      return sourceType;
+    }
+
+    public String getSinkType() {
+      return sinkType;
+    }
   }
+
   public static final class PreparedDefinition {
-    private final ObjectNode request; private final String jobName; private final String jobDesc; private final String mode; private final String definitionJson; private final String jobSpecJson; private final Long sourceDatasourceId; private final Long sinkDatasourceId; private final String sourceType; private final String sinkType; private final String sourceTable; private final String sinkTable; private final String digest;
-    public PreparedDefinition(ObjectNode request,String jobName,String jobDesc,String mode,String definitionJson,String jobSpecJson,Long sourceDatasourceId,Long sinkDatasourceId,String sourceType,String sinkType,String sourceTable,String sinkTable,String digest){this.request=request;this.jobName=jobName;this.jobDesc=jobDesc;this.mode=mode;this.definitionJson=definitionJson;this.jobSpecJson=jobSpecJson;this.sourceDatasourceId=sourceDatasourceId;this.sinkDatasourceId=sinkDatasourceId;this.sourceType=sourceType;this.sinkType=sinkType;this.sourceTable=sourceTable;this.sinkTable=sinkTable;this.digest=digest;}
-    public ObjectNode getRequest(){return request;} public String getJobName(){return jobName;} public String getJobDesc(){return jobDesc;} public String getMode(){return mode;} public String getDefinitionJson(){return definitionJson;} public String getJobSpecJson(){return jobSpecJson;} public Long getSourceDatasourceId(){return sourceDatasourceId;} public Long getSinkDatasourceId(){return sinkDatasourceId;} public String getSourceType(){return sourceType;} public String getSinkType(){return sinkType;} public String getSourceTable(){return sourceTable;} public String getSinkTable(){return sinkTable;} public String getDigest(){return digest;}
+    private final ObjectNode request;
+    private final String jobName;
+    private final String jobDesc;
+    private final String mode;
+    private final String definitionJson;
+    private final String jobSpecJson;
+    private final Long sourceDatasourceId;
+    private final Long sinkDatasourceId;
+    private final String sourceType;
+    private final String sinkType;
+    private final String sourceTable;
+    private final String sinkTable;
+    private final String digest;
+
+    public PreparedDefinition(
+        ObjectNode request,
+        String jobName,
+        String jobDesc,
+        String mode,
+        String definitionJson,
+        String jobSpecJson,
+        Long sourceDatasourceId,
+        Long sinkDatasourceId,
+        String sourceType,
+        String sinkType,
+        String sourceTable,
+        String sinkTable,
+        String digest) {
+      this.request = request;
+      this.jobName = jobName;
+      this.jobDesc = jobDesc;
+      this.mode = mode;
+      this.definitionJson = definitionJson;
+      this.jobSpecJson = jobSpecJson;
+      this.sourceDatasourceId = sourceDatasourceId;
+      this.sinkDatasourceId = sinkDatasourceId;
+      this.sourceType = sourceType;
+      this.sinkType = sinkType;
+      this.sourceTable = sourceTable;
+      this.sinkTable = sinkTable;
+      this.digest = digest;
+    }
+
+    public ObjectNode getRequest() {
+      return request;
+    }
+
+    public String getJobName() {
+      return jobName;
+    }
+
+    public String getJobDesc() {
+      return jobDesc;
+    }
+
+    public String getMode() {
+      return mode;
+    }
+
+    public String getDefinitionJson() {
+      return definitionJson;
+    }
+
+    public String getJobSpecJson() {
+      return jobSpecJson;
+    }
+
+    public Long getSourceDatasourceId() {
+      return sourceDatasourceId;
+    }
+
+    public Long getSinkDatasourceId() {
+      return sinkDatasourceId;
+    }
+
+    public String getSourceType() {
+      return sourceType;
+    }
+
+    public String getSinkType() {
+      return sinkType;
+    }
+
+    public String getSourceTable() {
+      return sourceTable;
+    }
+
+    public String getSinkTable() {
+      return sinkTable;
+    }
+
+    public String getDigest() {
+      return digest;
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
@@ -24,11 +24,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-/** 离线同步当前定义管理，不维护独立版本表。 */
+/** 离线同步当前定义的稳定 Application Facade，不维护独立版本表。 */
 @ConditionalOnOfflineSyncEnabled
 @Service
 @RequiredArgsConstructor
 public class OfflineJobDefinitionService {
+
   private final OfflineJobDefinitionRepository definitionRepository;
   private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineScheduleRepository scheduleRepository;
@@ -38,42 +39,264 @@ public class OfflineJobDefinitionService {
   private final OfflineSyncViewMapper viewMapper;
   private final AtomicLong idSequence = new AtomicLong(System.currentTimeMillis() * 1000L);
 
-  public Long nextId() { long floor = System.currentTimeMillis() * 1000L; long value = idSequence.updateAndGet(current -> Math.max(current + 1, floor)); while (definitionRepository.findById(value).isPresent()) value = idSequence.incrementAndGet(); return value; }
+  public Long nextId() {
+    long floor = System.currentTimeMillis() * 1000L;
+    long value = idSequence.updateAndGet(current -> Math.max(current + 1, floor));
+    while (definitionRepository.findById(value).isPresent()) {
+      value = idSequence.incrementAndGet();
+    }
+    return value;
+  }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public Long saveDraft(OfflineJobDefinitionDTO dto) {
-    if (dto == null) throw new IllegalArgumentException("任务定义不能为空"); Long id = dto.getId(); if (id == null || id <= 0L) { id = nextId(); dto.setId(id); }
-    OfflineJobDefinition existing = definitionRepository.findById(id).orElse(null); ensureEditable(existing); if (existing != null && StringUtils.hasText(existing.getJobSpecJson())) throw new IllegalStateException("已生成可执行配置的任务不能退回草稿");
-    DraftDefinition draft = support.prepareDraft(dto); if (definitionRepository.existsByName(draft.getJobName(), id)) throw new IllegalArgumentException("离线同步任务名称已存在：" + draft.getJobName());
-    LocalDateTime now = LocalDateTime.now(); OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
-    definition.setId(id); definition.setJobName(draft.getJobName()); definition.setJobDesc(draft.getJobDesc()); definition.setMode(draft.getMode()); definition.setDefinitionJson(draft.getDefinitionJson()); definition.setJobSpecJson(null); definition.setConfigDigest(null); definition.setReleaseState("OFFLINE"); definition.setSourceType(draft.getSourceType()); definition.setSinkType(draft.getSinkType()); definition.setSourceDatasourceId(null); definition.setSinkDatasourceId(null); definition.setSourceTable(null); definition.setSinkTable(null); definition.setVersion(0); definition.setCreateTime(existing == null ? now : existing.getCreateTime()); definition.setUpdateTime(now);
-    if (existing == null) definitionRepository.insert(definition); else definitionRepository.update(definition); scheduleRepository.saveSchedule(scheduleSupport.prepare(id, draft.getRequest().get("schedule"))); scheduleLifecycle.sync(id); return id;
+    Long id = ensureDefinitionId(dto);
+    OfflineJobDefinition existing = definitionRepository.findById(id).orElse(null);
+    ensureEditable(existing);
+    ensureCanSaveDraft(existing);
+
+    DraftDefinition draft = support.prepareDraft(dto);
+    ensureUniqueName(draft.getJobName(), id);
+
+    OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
+    applyDraft(definition, existing, id, draft);
+    persist(existing, definition);
+    saveScheduleAndSync(id, draft.getRequest().get("schedule"));
+    return id;
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
   public Long saveGuide(OfflineJobDefinitionDTO dto) {
-    if (dto == null) throw new IllegalArgumentException("任务定义不能为空"); Long id = dto.getId(); if (id == null || id <= 0L) { id = nextId(); dto.setId(id); }
-    OfflineJobDefinition existing = definitionRepository.findById(id).orElse(null); ensureEditable(existing); PreparedDefinition prepared = support.prepare(dto); if (definitionRepository.existsByName(prepared.getJobName(), id)) throw new IllegalArgumentException("离线同步任务名称已存在：" + prepared.getJobName());
-    LocalDateTime now = LocalDateTime.now(); OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
-    definition.setId(id); definition.setJobName(prepared.getJobName()); definition.setJobDesc(prepared.getJobDesc()); definition.setMode(prepared.getMode()); definition.setDefinitionJson(prepared.getDefinitionJson()); definition.setJobSpecJson(prepared.getJobSpecJson()); definition.setConfigDigest(prepared.getDigest()); definition.setReleaseState(existing == null ? "OFFLINE" : existing.getReleaseState()); definition.setSourceType(prepared.getSourceType()); definition.setSinkType(prepared.getSinkType()); definition.setSourceDatasourceId(prepared.getSourceDatasourceId()); definition.setSinkDatasourceId(prepared.getSinkDatasourceId()); definition.setSourceTable(prepared.getSourceTable()); definition.setSinkTable(prepared.getSinkTable()); definition.setVersion((existing == null || existing.getVersion() == null ? 0 : Math.max(0, existing.getVersion())) + 1); definition.setCreateTime(existing == null ? now : existing.getCreateTime()); definition.setUpdateTime(now);
-    if (existing == null) definitionRepository.insert(definition); else definitionRepository.update(definition); scheduleRepository.saveSchedule(scheduleSupport.prepare(id, prepared.getRequest().get("schedule"))); scheduleLifecycle.sync(id); return id;
+    Long id = ensureDefinitionId(dto);
+    OfflineJobDefinition existing = definitionRepository.findById(id).orElse(null);
+    ensureEditable(existing);
+
+    PreparedDefinition prepared = support.prepare(dto);
+    ensureUniqueName(prepared.getJobName(), id);
+
+    OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
+    applyPrepared(definition, existing, id, prepared);
+    persist(existing, definition);
+    saveScheduleAndSync(id, prepared.getRequest().get("schedule"));
+    return id;
   }
 
-  public String buildGuideConfig(OfflineJobDefinitionDTO dto) { return support.buildJobSpec(dto); }
-  public String resolveLogicalJobSpec(OfflineJobDefinition definition) { if (definition == null || !StringUtils.hasText(definition.getJobSpecJson())) throw new IllegalStateException("任务仍是草稿，请完成配置并保存"); return definition.getJobSpecJson(); }
-  public String resolveExecutionJobSpec(OfflineJobDefinition definition) { return resolveExecutionJobSpec(resolveLogicalJobSpec(definition)); }
-  public String resolveExecutionJobSpec(String logicalJobSpecJson) { if (!StringUtils.hasText(logicalJobSpecJson)) throw new IllegalStateException("任务版本快照缺少 JobSpec"); return support.resolveExecutionJobSpec(logicalJobSpecJson); }
-  public OfflineJobDefinitionVO get(Long id) { if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法"); return viewMapper.definition(definitionRepository.findForViewById(id).orElseThrow(() -> new IllegalArgumentException("离线同步任务不存在：" + id))); }
-  public JsonNode getEditDetail(Long id) { return support.editDetail(require(id)); }
-  public PageData<OfflineJobDefinition> pageDomain(OfflineDefinitionQuery query) { return definitionRepository.page(query); }
-  public PagingData<OfflineJobDefinitionVO> page(OfflineJobDefinitionQueryDTO queryDTO) { OfflineJobDefinitionQueryDTO query = queryDTO == null ? new OfflineJobDefinitionQueryDTO() : queryDTO; OfflineDefinitionQuery domainQuery = new OfflineDefinitionQuery(query.getCurrent(), query.getPageSize(), query.getId(), query.getJobName(), query.getStatus(), query.getSourceType(), query.getSinkType(), query.getSourceTable(), query.getSinkTable(), query.getCreateTimeStart(), query.getCreateTimeEnd()); return PagingData.from(definitionRepository.pageForView(domainQuery).map(viewMapper::definition)); }
+  public String buildGuideConfig(OfflineJobDefinitionDTO dto) {
+    return support.buildJobSpec(dto);
+  }
+
+  public String resolveLogicalJobSpec(OfflineJobDefinition definition) {
+    if (definition == null || !StringUtils.hasText(definition.getJobSpecJson())) {
+      throw new IllegalStateException("任务仍是草稿，请完成配置并保存");
+    }
+    return definition.getJobSpecJson();
+  }
+
+  public String resolveExecutionJobSpec(OfflineJobDefinition definition) {
+    return resolveExecutionJobSpec(resolveLogicalJobSpec(definition));
+  }
+
+  public String resolveExecutionJobSpec(String logicalJobSpecJson) {
+    if (!StringUtils.hasText(logicalJobSpecJson)) {
+      throw new IllegalStateException("任务版本快照缺少 JobSpec");
+    }
+    return support.resolveExecutionJobSpec(logicalJobSpecJson);
+  }
+
+  public OfflineJobDefinitionVO get(Long id) {
+    validateId(id);
+    OfflineJobDefinition definition = definitionRepository
+        .findForViewById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务不存在：" + id));
+    return viewMapper.definition(definition);
+  }
+
+  public JsonNode getEditDetail(Long id) {
+    return support.editDetail(require(id));
+  }
+
+  public PageData<OfflineJobDefinition> pageDomain(OfflineDefinitionQuery query) {
+    return definitionRepository.page(query);
+  }
+
+  public PagingData<OfflineJobDefinitionVO> page(OfflineJobDefinitionQueryDTO queryDTO) {
+    OfflineJobDefinitionQueryDTO query =
+        queryDTO == null ? new OfflineJobDefinitionQueryDTO() : queryDTO;
+    OfflineDefinitionQuery domainQuery = new OfflineDefinitionQuery(
+        query.getCurrent(),
+        query.getPageSize(),
+        query.getId(),
+        query.getJobName(),
+        query.getStatus(),
+        query.getSourceType(),
+        query.getSinkType(),
+        query.getSourceTable(),
+        query.getSinkTable(),
+        query.getCreateTimeStart(),
+        query.getCreateTimeEnd());
+    return PagingData.from(definitionRepository.pageForView(domainQuery).map(viewMapper::definition));
+  }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
-  public boolean online(Long id) { OfflineJobDefinition definition = require(id); resolveLogicalJobSpec(definition); definition.setReleaseState("ONLINE"); definition.setUpdateTime(LocalDateTime.now()); boolean updated = definitionRepository.update(definition); if (updated) scheduleLifecycle.sync(id); return updated; }
+  public boolean online(Long id) {
+    OfflineJobDefinition definition = require(id);
+    resolveLogicalJobSpec(definition);
+
+    definition.setReleaseState("ONLINE");
+    definition.setUpdateTime(LocalDateTime.now());
+    boolean updated = definitionRepository.update(definition);
+    if (updated) {
+      scheduleLifecycle.sync(id);
+    }
+    return updated;
+  }
+
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
-  public boolean offline(Long id) { OfflineJobDefinition definition = require(id); if (batchRepository.hasOccupyingBatch(id)) throw new IllegalStateException("运行中的 BatchExecution 不能下线，请先停止任务"); definition.setReleaseState("OFFLINE"); definition.setUpdateTime(LocalDateTime.now()); boolean updated = definitionRepository.update(definition); if (updated) scheduleLifecycle.sync(id); return updated; }
+  public boolean offline(Long id) {
+    OfflineJobDefinition definition = require(id);
+    ensureNoOccupyingBatch(id, "运行中的 BatchExecution 不能下线，请先停止任务");
+
+    definition.setReleaseState("OFFLINE");
+    definition.setUpdateTime(LocalDateTime.now());
+    boolean updated = definitionRepository.update(definition);
+    if (updated) {
+      scheduleLifecycle.sync(id);
+    }
+    return updated;
+  }
+
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
-  public boolean delete(Long id) { OfflineJobDefinition definition = require(id); if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("已上线任务不能删除，请先下线"); if (batchRepository.hasOccupyingBatch(id)) throw new IllegalStateException("运行中的 BatchExecution 不能删除"); scheduleLifecycle.remove(id); return definitionRepository.delete(id); }
-  public OfflineJobDefinition require(Long id) { if (id == null || id <= 0L) throw new IllegalArgumentException("任务定义 ID 不合法"); return definitionRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("离线同步任务不存在：" + id)); }
-  private void ensureEditable(OfflineJobDefinition definition) { if (definition == null) return; if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) throw new IllegalStateException("已上线任务不能修改，请先下线"); if (batchRepository.hasOccupyingBatch(definition.getId())) throw new IllegalStateException("运行中的 BatchExecution 不能修改"); }
+  public boolean delete(Long id) {
+    OfflineJobDefinition definition = require(id);
+    if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
+      throw new IllegalStateException("已上线任务不能删除，请先下线");
+    }
+    ensureNoOccupyingBatch(id, "运行中的 BatchExecution 不能删除");
+
+    scheduleLifecycle.remove(id);
+    return definitionRepository.delete(id);
+  }
+
+  public OfflineJobDefinition require(Long id) {
+    validateId(id);
+    return definitionRepository
+        .findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务不存在：" + id));
+  }
+
+  private Long ensureDefinitionId(OfflineJobDefinitionDTO dto) {
+    if (dto == null) {
+      throw new IllegalArgumentException("任务定义不能为空");
+    }
+    Long id = dto.getId();
+    if (id == null || id <= 0L) {
+      id = nextId();
+      dto.setId(id);
+    }
+    return id;
+  }
+
+  private void ensureCanSaveDraft(OfflineJobDefinition existing) {
+    if (existing != null && StringUtils.hasText(existing.getJobSpecJson())) {
+      throw new IllegalStateException("已生成可执行配置的任务不能退回草稿");
+    }
+  }
+
+  private void ensureUniqueName(String jobName, Long id) {
+    if (definitionRepository.existsByName(jobName, id)) {
+      throw new IllegalArgumentException("离线同步任务名称已存在：" + jobName);
+    }
+  }
+
+  private void applyDraft(
+      OfflineJobDefinition definition,
+      OfflineJobDefinition existing,
+      Long id,
+      DraftDefinition draft) {
+    LocalDateTime now = LocalDateTime.now();
+    definition.setId(id);
+    definition.setJobName(draft.getJobName());
+    definition.setJobDesc(draft.getJobDesc());
+    definition.setMode(draft.getMode());
+    definition.setDefinitionJson(draft.getDefinitionJson());
+    definition.setJobSpecJson(null);
+    definition.setConfigDigest(null);
+    definition.setReleaseState("OFFLINE");
+    definition.setSourceType(draft.getSourceType());
+    definition.setSinkType(draft.getSinkType());
+    definition.setSourceDatasourceId(null);
+    definition.setSinkDatasourceId(null);
+    definition.setSourceTable(null);
+    definition.setSinkTable(null);
+    definition.setVersion(0);
+    definition.setCreateTime(existing == null ? now : existing.getCreateTime());
+    definition.setUpdateTime(now);
+  }
+
+  private void applyPrepared(
+      OfflineJobDefinition definition,
+      OfflineJobDefinition existing,
+      Long id,
+      PreparedDefinition prepared) {
+    LocalDateTime now = LocalDateTime.now();
+    definition.setId(id);
+    definition.setJobName(prepared.getJobName());
+    definition.setJobDesc(prepared.getJobDesc());
+    definition.setMode(prepared.getMode());
+    definition.setDefinitionJson(prepared.getDefinitionJson());
+    definition.setJobSpecJson(prepared.getJobSpecJson());
+    definition.setConfigDigest(prepared.getDigest());
+    definition.setReleaseState(existing == null ? "OFFLINE" : existing.getReleaseState());
+    definition.setSourceType(prepared.getSourceType());
+    definition.setSinkType(prepared.getSinkType());
+    definition.setSourceDatasourceId(prepared.getSourceDatasourceId());
+    definition.setSinkDatasourceId(prepared.getSinkDatasourceId());
+    definition.setSourceTable(prepared.getSourceTable());
+    definition.setSinkTable(prepared.getSinkTable());
+    definition.setVersion(nextVersion(existing));
+    definition.setCreateTime(existing == null ? now : existing.getCreateTime());
+    definition.setUpdateTime(now);
+  }
+
+  private int nextVersion(OfflineJobDefinition existing) {
+    if (existing == null || existing.getVersion() == null) {
+      return 1;
+    }
+    return Math.max(0, existing.getVersion()) + 1;
+  }
+
+  private void persist(OfflineJobDefinition existing, OfflineJobDefinition definition) {
+    if (existing == null) {
+      definitionRepository.insert(definition);
+    } else {
+      definitionRepository.update(definition);
+    }
+  }
+
+  private void saveScheduleAndSync(Long id, JsonNode schedule) {
+    scheduleRepository.saveSchedule(scheduleSupport.prepare(id, schedule));
+    scheduleLifecycle.sync(id);
+  }
+
+  private void ensureEditable(OfflineJobDefinition definition) {
+    if (definition == null) {
+      return;
+    }
+    if ("ONLINE".equalsIgnoreCase(definition.getReleaseState())) {
+      throw new IllegalStateException("已上线任务不能修改，请先下线");
+    }
+    ensureNoOccupyingBatch(definition.getId(), "运行中的 BatchExecution 不能修改");
+  }
+
+  private void ensureNoOccupyingBatch(Long id, String message) {
+    if (batchRepository.hasOccupyingBatch(id)) {
+      throw new IllegalStateException(message);
+    }
+  }
+
+  private void validateId(Long id) {
+    if (id == null || id <= 0L) {
+      throw new IllegalArgumentException("任务定义 ID 不合法");
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
@@ -15,11 +15,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** Applies a frozen BatchScope to the frozen logical JobSpec immediately before credential resolution. */
+/** Applies a frozen BatchScope to the frozen logical JobSpec before credential resolution. */
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeValidator {
-  private static final Pattern SAFE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
+
+  private static final Pattern SAFE_IDENTIFIER =
+      Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
+
   private final ObjectMapper objectMapper;
   private final OfflineCursorGateway cursorGateway;
 
@@ -36,61 +39,147 @@ public class OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeV
   }
 
   public String apply(long taskId, String logicalJobSpecJson, BatchScope scope) {
-    if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
-    if (!StringUtils.hasText(logicalJobSpecJson)) throw new IllegalArgumentException("logicalJobSpec 不能为空");
-    if (scope == null || scope instanceof BatchScope.FullSelection) return logicalJobSpecJson.trim();
+    validateInput(taskId, logicalJobSpecJson);
+    if (scope == null || scope instanceof BatchScope.FullSelection) {
+      return logicalJobSpecJson.trim();
+    }
+
     ObjectNode root = parseObject(logicalJobSpecJson);
+    ObjectNode options = requireScopedSourceOptions(root);
+    String predicate = predicate(taskId, options, scope);
+    mergeWhereCondition(options, predicate);
+    return write(root);
+  }
+
+  private void validateInput(long taskId, String logicalJobSpecJson) {
+    if (taskId <= 0L) {
+      throw new IllegalArgumentException("TaskId 必须大于 0");
+    }
+    if (!StringUtils.hasText(logicalJobSpecJson)) {
+      throw new IllegalArgumentException("logicalJobSpec 不能为空");
+    }
+  }
+
+  private ObjectNode requireScopedSourceOptions(ObjectNode root) {
     ObjectNode source = requireObject(root.get("source"), "scoped Batch 缺少 source JobSpec");
-    if (!ConnectorIdResolver.isJdbc(text(source, "connectorId"))) throw new IllegalStateException("Wave 5 scoped Batch V1 仅支持 JDBC source");
+    if (!ConnectorIdResolver.isJdbc(text(source, "connectorId"))) {
+      throw new IllegalStateException("Wave 5 scoped Batch V1 仅支持 JDBC source");
+    }
+
     ObjectNode options = requireObject(source.get("options"), "scoped Batch 缺少 source.options");
-    if (!StringUtils.hasText(text(options, "table_path")) || (options.has("table_list") && options.path("table_list").size() > 0)) {
+    boolean singleTable =
+        StringUtils.hasText(text(options, "table_path"))
+            && (!options.has("table_list") || options.path("table_list").isEmpty());
+    if (!singleTable) {
       throw new IllegalStateException("Wave 5 scoped Batch V1 仅支持单表 source");
     }
-    if (StringUtils.hasText(text(options, "query"))) throw new IllegalStateException("自定义 source query 暂不支持叠加 BatchScope，请使用表 + whereCondition");
-    String predicate = predicate(taskId, options, scope);
+    if (StringUtils.hasText(text(options, "query"))) {
+      throw new IllegalStateException("自定义 source query 暂不支持叠加 BatchScope，请使用表 + whereCondition");
+    }
+    return options;
+  }
+
+  private void mergeWhereCondition(ObjectNode options, String predicate) {
     String existing = text(options, "where_condition");
-    options.put("where_condition", StringUtils.hasText(existing) ? "(" + existing.trim() + ") AND (" + predicate + ")" : predicate);
-    return write(root);
+    String scoped =
+        StringUtils.hasText(existing)
+            ? "(" + existing.trim() + ") AND (" + predicate + ")"
+            : predicate;
+    options.put("where_condition", scoped);
   }
 
   private String predicate(long taskId, ObjectNode options, BatchScope scope) {
     if (scope instanceof BatchScope.DataWindow window) {
-      String column = safeColumn(requiredText(options, "partition_column", "DataWindow 需要 source.options.partition_column"));
-      return column + " >= " + literal(time(window.startInclusive())) + " AND " + column + " < " + literal(time(window.endExclusive()));
+      String column = safeColumn(
+          requiredText(
+              options,
+              "partition_column",
+              "DataWindow 需要 source.options.partition_column"));
+      return column
+          + " >= "
+          + literal(time(window.startInclusive()))
+          + " AND "
+          + column
+          + " < "
+          + literal(time(window.endExclusive()));
     }
+
     if (scope instanceof BatchScope.PartitionScope partitions) {
-      String column = safeColumn(requiredText(options, "partition_column", "PartitionScope 需要 source.options.partition_column"));
-      String values = partitions.partitions().stream().map(this::literal).reduce((left, right) -> left + ", " + right).orElseThrow();
+      String column = safeColumn(
+          requiredText(
+              options,
+              "partition_column",
+              "PartitionScope 需要 source.options.partition_column"));
+      String values = partitions.partitions().stream()
+          .map(this::literal)
+          .reduce((left, right) -> left + ", " + right)
+          .orElseThrow();
       return column + " IN (" + values + ")";
     }
+
     if (scope instanceof BatchScope.CursorRange range) {
       String column = safeColumn(cursorGateway.requireSourceColumn(taskId, range.cursorId()));
-      return column + " > " + literal(range.afterExclusive()) + " AND " + column + " <= " + literal(range.throughInclusive());
+      return column
+          + " > "
+          + literal(range.afterExclusive())
+          + " AND "
+          + column
+          + " <= "
+          + literal(range.throughInclusive());
     }
+
     throw new IllegalArgumentException("不支持的 BatchScope：" + scope.getClass().getName());
   }
 
   private String safeColumn(String value) {
     String normalized = value.trim();
-    if (!SAFE_IDENTIFIER.matcher(normalized).matches()) throw new IllegalArgumentException("Scope source column 不是安全标识符：" + normalized);
+    if (!SAFE_IDENTIFIER.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("Scope source column 不是安全标识符：" + normalized);
+    }
     return normalized;
   }
-  private String literal(String value) { return "'" + value.replace("'", "''") + "'"; }
-  private String time(LocalDateTime value) { return value.toString().replace('T', ' '); }
-  private ObjectNode parseObject(String json) {
-    try { return requireObject(objectMapper.readTree(json), "logicalJobSpec 必须是 JSON 对象"); }
-    catch (JsonProcessingException exception) { throw new IllegalArgumentException("logicalJobSpec JSON 已损坏", exception); }
+
+  private String literal(String value) {
+    return "'" + value.replace("'", "''") + "'";
   }
+
+  private String time(LocalDateTime value) {
+    return value.toString().replace('T', ' ');
+  }
+
+  private ObjectNode parseObject(String json) {
+    try {
+      return requireObject(objectMapper.readTree(json), "logicalJobSpec 必须是 JSON 对象");
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("logicalJobSpec JSON 已损坏", exception);
+    }
+  }
+
   private ObjectNode requireObject(JsonNode value, String message) {
-    if (value == null || !value.isObject()) throw new IllegalStateException(message);
+    if (value == null || !value.isObject()) {
+      throw new IllegalStateException(message);
+    }
     return (ObjectNode) value;
   }
+
   private String requiredText(JsonNode node, String field, String message) {
-    String value = text(node, field); if (!StringUtils.hasText(value)) throw new IllegalStateException(message); return value.trim();
+    String value = text(node, field);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalStateException(message);
+    }
+    return value.trim();
   }
-  private String text(JsonNode node, String field) { JsonNode value = node == null ? null : node.get(field); return value == null || value.isNull() ? null : value.asText(null); }
+
+  private String text(JsonNode node, String field) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || value.isNull() ? null : value.asText(null);
+  }
+
   private String write(JsonNode value) {
-    try { return objectMapper.writeValueAsString(value); }
-    catch (JsonProcessingException exception) { throw new IllegalStateException("序列化 scoped logical JobSpec 失败", exception); }
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化 scoped logical JobSpec 失败", exception);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionLogQuery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionLogQuery.java
@@ -13,20 +13,438 @@ import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportExcep
 import io.yak.ops.business.sync.offline.repository.OfflineExecutionEventRepository;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogEntryVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
-import java.time.Instant;import java.time.LocalDateTime;import java.time.ZoneId;import java.time.format.DateTimeFormatter;import java.util.ArrayList;import java.util.Comparator;import java.util.List;import java.util.Locale;
-import org.springframework.stereotype.Component;import org.springframework.util.StringUtils;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /** 将 Yak Ops 状态事件和 Link-Up 物理日志合并成统一时间线。 */
-@ConditionalOnOfflineSyncEnabled @Component
+@ConditionalOnOfflineSyncEnabled
+@Component
 public class OfflineExecutionLogQuery {
-  private static final DateTimeFormatter FORMAT=DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"); private final OfflineExecutionEventRepository eventRepository;private final LinkUpClient linkUpClient;
-  public OfflineExecutionLogQuery(OfflineExecutionEventRepository eventRepository,LinkUpClient linkUpClient){this.eventRepository=eventRepository;this.linkUpClient=linkUpClient;}
-  public String text(OfflineJobExecution execution){String cursor="0:0";String warning=null;StringBuilder result=new StringBuilder("# Yak Ops + Link-Up Unified Timeline\n");result.append("executionId: ").append(execution==null?"-":execution.getId()).append('\n').append("externalExecutionId: ").append(execution==null?"-":text(execution.getExternalExecutionId())).append('\n').append("engineJobId: ").append(execution==null?"-":text(execution.getEngineJobId())).append("\n\n");for(int pageIndex=0;pageIndex<100;pageIndex++){OfflineExecutionLogPageVO page=logs(execution,cursor,1000);warning=page.getWarning();if(page.getItems()!=null)for(OfflineExecutionLogEntryVO item:page.getItems())appendTextLine(result,item);if(page.isCompleted()||!StringUtils.hasText(page.getNextCursor())||page.getNextCursor().equals(cursor))break;cursor=page.getNextCursor();}if(StringUtils.hasText(warning))result.append("\n- WARN [YAK_OPS] [LOG_AGGREGATION] ").append(warning).append('\n');return result.toString();}
-  public OfflineExecutionLogPageVO logs(OfflineJobExecution execution,String cursorValue,int limit){if(execution==null||execution.getId()==null)throw new IllegalArgumentException("离线同步执行实例不能为空");if(limit<1||limit>1000)throw new IllegalArgumentException("日志 limit 必须在 1 到 1000 之间");Cursor cursor=Cursor.parse(cursorValue);List<OfflineExecutionEvent> events=eventRepository.listAfter(execution.getId(),cursor.yakEventId,limit);List<OfflineExecutionLogEntryVO> yakItems=new ArrayList<>();for(OfflineExecutionEvent event:events)yakItems.add(toYakOpsEntry(execution,event));List<OfflineExecutionLogEntryVO> linkItems=new ArrayList<>();LinkUpJobLogPageResponse linkResponse=null;boolean linkUpAvailable=true;String warning=null;if(StringUtils.hasText(execution.getEngineJobId())){try{linkResponse=linkUpClient.logs(execution.getEngineJobId(),cursor.linkCursor,limit);if(linkResponse!=null&&linkResponse.getItems()!=null)for(LinkUpJobLogEntry entry:linkResponse.getItems())linkItems.add(toLinkUpEntry(execution,linkResponse,entry));}catch(LinkUpRequestException exception){linkUpAvailable=false;warning=exception.getStatusCode()==404||exception.getStatusCode()==405?"Link-Up 不支持任务日志接口，或该任务日志已不在 Worker 历史中":"Link-Up 日志请求失败："+exception.getMessage();}catch(LinkUpTransportException|LinkUpProtocolException exception){linkUpAvailable=false;warning="暂时无法读取 Link-Up 日志："+exception.getMessage();}}
-    List<OfflineExecutionLogEntryVO> merged=new ArrayList<>();merged.addAll(yakItems);merged.addAll(linkItems);merged.sort(logComparator());List<OfflineExecutionLogEntryVO> selected=new ArrayList<>(merged.subList(0,Math.min(limit,merged.size())));int selectedYakCount=count(selected,"YAK_OPS");int selectedLinkCount=count(selected,"LINK_UP");long nextYakEventId=cursor.yakEventId;if(selectedYakCount>0)nextYakEventId=yakItems.get(selectedYakCount-1).getSequence();long nextLinkCursor=cursor.linkCursor;if(selectedLinkCount<linkItems.size())nextLinkCursor=linkItems.get(selectedLinkCount).getSequence();else if(linkResponse!=null)nextLinkCursor=value(linkResponse.getNextCursor(),cursor.linkCursor);boolean terminal=!OfflineExecutionStatus.isActive(execution.getStatus());boolean yakCompleted=selectedYakCount==yakItems.size()&&events.size()<limit;boolean linkCompleted;if(!StringUtils.hasText(execution.getEngineJobId()))linkCompleted=true;else if(!linkUpAvailable)linkCompleted=terminal;else linkCompleted=selectedLinkCount==linkItems.size()&&linkResponse!=null&&Boolean.TRUE.equals(linkResponse.getCompleted());return OfflineExecutionLogPageVO.builder().items(selected).nextCursor(Cursor.encode(nextYakEventId,nextLinkCursor)).completed(terminal&&yakCompleted&&linkCompleted).linkUpAvailable(linkUpAvailable).warning(warning).build();}
-  private Comparator<OfflineExecutionLogEntryVO> logComparator(){return Comparator.comparing(OfflineExecutionLogEntryVO::getTimestampMillis,Comparator.nullsLast(Long::compareTo)).thenComparing(OfflineExecutionLogEntryVO::getSource,Comparator.nullsLast(String::compareTo)).thenComparingLong(OfflineExecutionLogEntryVO::getSequence);}private int count(List<OfflineExecutionLogEntryVO> items,String source){int result=0;for(OfflineExecutionLogEntryVO item:items)if(source.equals(item.getSource()))result++;return result;}private void appendTextLine(StringBuilder result,OfflineExecutionLogEntryVO item){result.append(StringUtils.hasText(item.getTimestamp())?item.getTimestamp():"-").append(' ').append(StringUtils.hasText(item.getLevel())?item.getLevel():"INFO").append(" [").append(StringUtils.hasText(item.getSource())?item.getSource():"UNKNOWN").append(']');if(StringUtils.hasText(item.getStage()))result.append(" [").append(item.getStage()).append(']');result.append(' ').append(StringUtils.hasText(item.getMessage())?item.getMessage():"-").append('\n');}
-  private OfflineExecutionLogEntryVO toYakOpsEntry(OfflineJobExecution execution,OfflineExecutionEvent event){Long timestampMillis=epochMillis(event.getCreateTime());String transition=text(event.getFromStatus())+" -> "+text(event.getToStatus());String message=StringUtils.hasText(event.getMessage())?transition+" | "+event.getMessage():transition;return OfflineExecutionLogEntryVO.builder().sequence(value(event.getId(),0L)).timestampMillis(timestampMillis).timestamp(format(timestampMillis)).source("YAK_OPS").level(level(event.getToStatus())).stage(event.getEventType()).externalExecutionId(execution.getExternalExecutionId()).engineJobId(execution.getEngineJobId()).message(message).build();}
-  private OfflineExecutionLogEntryVO toLinkUpEntry(OfflineJobExecution execution,LinkUpJobLogPageResponse response,LinkUpJobLogEntry entry){Long timestampMillis=entry==null?null:entry.getTimestampMillis();String logger=entry==null?null:entry.getLogger();String message=entry==null?null:entry.getMessage();return OfflineExecutionLogEntryVO.builder().sequence(entry==null?0L:value(entry.getSequence(),0L)).timestampMillis(timestampMillis).timestamp(format(timestampMillis)).source("LINK_UP").level(entry==null||!StringUtils.hasText(entry.getLevel())?"INFO":entry.getLevel().toUpperCase(Locale.ROOT)).stage(linkStage(logger,message)).externalExecutionId(firstText(response==null?null:response.getExternalExecutionId(),execution.getExternalExecutionId())).engineJobId(firstText(response==null?null:response.getJobId(),execution.getEngineJobId())).runId(response==null?null:response.getRunId()).thread(entry==null?null:entry.getThread()).logger(logger).message(message).build();}
-  private String linkStage(String logger,String message){String normalizedLogger=logger==null?"":logger.toLowerCase(Locale.ROOT);String normalizedMessage=message==null?"":message.toLowerCase(Locale.ROOT);if(normalizedMessage.contains("catalog sql")||normalizedMessage.contains("create table")||normalizedLogger.contains("catalog"))return "SCHEMA";if(normalizedLogger.contains("taskexecutor"))return "TASK";if(normalizedLogger.contains("jobexecution"))return "JOB";if(normalizedLogger.contains("split"))return "SPLIT";return "ENGINE";}private String level(String status){if(!StringUtils.hasText(status))return "INFO";String normalized=status.trim().toUpperCase(Locale.ROOT);if("FAILED".equals(normalized)||"LOST".equals(normalized))return "ERROR";if("CANCELED".equals(normalized)||"CANCELLED".equals(normalized))return "WARN";return "INFO";}private Long epochMillis(LocalDateTime value){return value==null?null:value.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();}private String format(Long timestampMillis){return timestampMillis==null?null:FORMAT.format(Instant.ofEpochMilli(timestampMillis).atZone(ZoneId.systemDefault()));}private String text(String value){return StringUtils.hasText(value)?value:"-";}private String firstText(String first,String second){return StringUtils.hasText(first)?first:second;}private long value(Long value,long fallback){return value==null?fallback:value;}
-  private static final class Cursor{private final long yakEventId;private final long linkCursor;private Cursor(long yakEventId,long linkCursor){this.yakEventId=yakEventId;this.linkCursor=linkCursor;}private static Cursor parse(String value){if(!StringUtils.hasText(value))return new Cursor(0L,0L);String[] parts=value.trim().split(":",-1);if(parts.length!=2)throw new IllegalArgumentException("日志 cursor 格式不正确");try{long yakEventId=Long.parseLong(parts[0]);long linkCursor=Long.parseLong(parts[1]);if(yakEventId<0L||linkCursor<0L)throw new IllegalArgumentException("日志 cursor 不能为负数");return new Cursor(yakEventId,linkCursor);}catch(NumberFormatException exception){throw new IllegalArgumentException("日志 cursor 格式不正确",exception);}}private static String encode(long yakEventId,long linkCursor){return yakEventId+":"+linkCursor;}}
+
+  private static final int MAX_TEXT_PAGES = 100;
+  private static final int MAX_PAGE_SIZE = 1000;
+  private static final String SOURCE_YAK_OPS = "YAK_OPS";
+  private static final String SOURCE_LINK_UP = "LINK_UP";
+  private static final DateTimeFormatter FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+  private final OfflineExecutionEventRepository eventRepository;
+  private final LinkUpClient linkUpClient;
+
+  public OfflineExecutionLogQuery(
+      OfflineExecutionEventRepository eventRepository,
+      LinkUpClient linkUpClient) {
+    this.eventRepository = eventRepository;
+    this.linkUpClient = linkUpClient;
+  }
+
+  public String text(OfflineJobExecution execution) {
+    String cursor = Cursor.start().encode();
+    String warning = null;
+    StringBuilder result = new StringBuilder("# Yak Ops + Link-Up Unified Timeline\n");
+    appendHeader(result, execution);
+
+    for (int pageIndex = 0; pageIndex < MAX_TEXT_PAGES; pageIndex++) {
+      OfflineExecutionLogPageVO page = logs(execution, cursor, MAX_PAGE_SIZE);
+      warning = page.getWarning();
+      appendPage(result, page);
+
+      if (isLastPage(page, cursor)) {
+        break;
+      }
+      cursor = page.getNextCursor();
+    }
+
+    if (StringUtils.hasText(warning)) {
+      result.append("\n- WARN [YAK_OPS] [LOG_AGGREGATION] ")
+          .append(warning)
+          .append('\n');
+    }
+    return result.toString();
+  }
+
+  public OfflineExecutionLogPageVO logs(
+      OfflineJobExecution execution,
+      String cursorValue,
+      int limit) {
+    validateRequest(execution, limit);
+    Cursor cursor = Cursor.parse(cursorValue);
+
+    List<OfflineExecutionEvent> events =
+        eventRepository.listAfter(execution.getId(), cursor.yakEventId(), limit);
+    List<OfflineExecutionLogEntryVO> yakItems = toYakOpsEntries(execution, events);
+    LinkUpLogBatch linkUp = fetchLinkUpLogs(execution, cursor.linkCursor(), limit);
+
+    List<OfflineExecutionLogEntryVO> selected =
+        mergeAndSelect(yakItems, linkUp.items(), limit);
+    int selectedYakCount = countSource(selected, SOURCE_YAK_OPS);
+    int selectedLinkCount = countSource(selected, SOURCE_LINK_UP);
+
+    long nextYakEventId = nextYakEventId(cursor, yakItems, selectedYakCount);
+    long nextLinkCursor = nextLinkCursor(cursor, linkUp, selectedLinkCount);
+    boolean completed = isCompleted(
+        execution,
+        events,
+        yakItems,
+        selectedYakCount,
+        linkUp,
+        selectedLinkCount,
+        limit);
+
+    return OfflineExecutionLogPageVO.builder()
+        .items(selected)
+        .nextCursor(Cursor.encode(nextYakEventId, nextLinkCursor))
+        .completed(completed)
+        .linkUpAvailable(linkUp.available())
+        .warning(linkUp.warning())
+        .build();
+  }
+
+  private void validateRequest(OfflineJobExecution execution, int limit) {
+    if (execution == null || execution.getId() == null) {
+      throw new IllegalArgumentException("离线同步执行实例不能为空");
+    }
+    if (limit < 1 || limit > MAX_PAGE_SIZE) {
+      throw new IllegalArgumentException("日志 limit 必须在 1 到 1000 之间");
+    }
+  }
+
+  private List<OfflineExecutionLogEntryVO> toYakOpsEntries(
+      OfflineJobExecution execution,
+      List<OfflineExecutionEvent> events) {
+    List<OfflineExecutionLogEntryVO> items = new ArrayList<>(events.size());
+    for (OfflineExecutionEvent event : events) {
+      items.add(toYakOpsEntry(execution, event));
+    }
+    return items;
+  }
+
+  private LinkUpLogBatch fetchLinkUpLogs(
+      OfflineJobExecution execution,
+      long cursor,
+      int limit) {
+    if (!StringUtils.hasText(execution.getEngineJobId())) {
+      return LinkUpLogBatch.notRequired();
+    }
+
+    try {
+      LinkUpJobLogPageResponse response =
+          linkUpClient.logs(execution.getEngineJobId(), cursor, limit);
+      List<OfflineExecutionLogEntryVO> items = new ArrayList<>();
+      if (response != null && response.getItems() != null) {
+        for (LinkUpJobLogEntry entry : response.getItems()) {
+          items.add(toLinkUpEntry(execution, response, entry));
+        }
+      }
+      return new LinkUpLogBatch(items, response, true, null);
+    } catch (LinkUpRequestException exception) {
+      String warning =
+          exception.getStatusCode() == 404 || exception.getStatusCode() == 405
+              ? "Link-Up 不支持任务日志接口，或该任务日志已不在 Worker 历史中"
+              : "Link-Up 日志请求失败：" + exception.getMessage();
+      return LinkUpLogBatch.unavailable(warning);
+    } catch (LinkUpTransportException | LinkUpProtocolException exception) {
+      return LinkUpLogBatch.unavailable("暂时无法读取 Link-Up 日志：" + exception.getMessage());
+    }
+  }
+
+  private List<OfflineExecutionLogEntryVO> mergeAndSelect(
+      List<OfflineExecutionLogEntryVO> yakItems,
+      List<OfflineExecutionLogEntryVO> linkItems,
+      int limit) {
+    List<OfflineExecutionLogEntryVO> merged = new ArrayList<>(yakItems.size() + linkItems.size());
+    merged.addAll(yakItems);
+    merged.addAll(linkItems);
+    merged.sort(logComparator());
+    return new ArrayList<>(merged.subList(0, Math.min(limit, merged.size())));
+  }
+
+  private long nextYakEventId(
+      Cursor cursor,
+      List<OfflineExecutionLogEntryVO> yakItems,
+      int selectedYakCount) {
+    if (selectedYakCount == 0) {
+      return cursor.yakEventId();
+    }
+    return yakItems.get(selectedYakCount - 1).getSequence();
+  }
+
+  private long nextLinkCursor(
+      Cursor cursor,
+      LinkUpLogBatch linkUp,
+      int selectedLinkCount) {
+    if (selectedLinkCount < linkUp.items().size()) {
+      return linkUp.items().get(selectedLinkCount).getSequence();
+    }
+    if (linkUp.response() != null) {
+      return value(linkUp.response().getNextCursor(), cursor.linkCursor());
+    }
+    return cursor.linkCursor();
+  }
+
+  private boolean isCompleted(
+      OfflineJobExecution execution,
+      List<OfflineExecutionEvent> events,
+      List<OfflineExecutionLogEntryVO> yakItems,
+      int selectedYakCount,
+      LinkUpLogBatch linkUp,
+      int selectedLinkCount,
+      int limit) {
+    boolean terminal = !OfflineExecutionStatus.isActive(execution.getStatus());
+    boolean yakCompleted = selectedYakCount == yakItems.size() && events.size() < limit;
+    boolean linkCompleted = linkCompleted(execution, terminal, linkUp, selectedLinkCount);
+    return terminal && yakCompleted && linkCompleted;
+  }
+
+  private boolean linkCompleted(
+      OfflineJobExecution execution,
+      boolean terminal,
+      LinkUpLogBatch linkUp,
+      int selectedLinkCount) {
+    if (!StringUtils.hasText(execution.getEngineJobId())) {
+      return true;
+    }
+    if (!linkUp.available()) {
+      return terminal;
+    }
+    return selectedLinkCount == linkUp.items().size()
+        && linkUp.response() != null
+        && Boolean.TRUE.equals(linkUp.response().getCompleted());
+  }
+
+  private boolean isLastPage(OfflineExecutionLogPageVO page, String currentCursor) {
+    return page.isCompleted()
+        || !StringUtils.hasText(page.getNextCursor())
+        || page.getNextCursor().equals(currentCursor);
+  }
+
+  private void appendHeader(StringBuilder result, OfflineJobExecution execution) {
+    result.append("executionId: ")
+        .append(execution == null ? "-" : execution.getId())
+        .append('\n')
+        .append("externalExecutionId: ")
+        .append(execution == null ? "-" : text(execution.getExternalExecutionId()))
+        .append('\n')
+        .append("engineJobId: ")
+        .append(execution == null ? "-" : text(execution.getEngineJobId()))
+        .append("\n\n");
+  }
+
+  private void appendPage(StringBuilder result, OfflineExecutionLogPageVO page) {
+    if (page.getItems() == null) {
+      return;
+    }
+    for (OfflineExecutionLogEntryVO item : page.getItems()) {
+      appendTextLine(result, item);
+    }
+  }
+
+  private Comparator<OfflineExecutionLogEntryVO> logComparator() {
+    return Comparator
+        .comparing(
+            OfflineExecutionLogEntryVO::getTimestampMillis,
+            Comparator.nullsLast(Long::compareTo))
+        .thenComparing(
+            OfflineExecutionLogEntryVO::getSource,
+            Comparator.nullsLast(String::compareTo))
+        .thenComparingLong(OfflineExecutionLogEntryVO::getSequence);
+  }
+
+  private int countSource(List<OfflineExecutionLogEntryVO> items, String source) {
+    int result = 0;
+    for (OfflineExecutionLogEntryVO item : items) {
+      if (source.equals(item.getSource())) {
+        result++;
+      }
+    }
+    return result;
+  }
+
+  private void appendTextLine(StringBuilder result, OfflineExecutionLogEntryVO item) {
+    result.append(StringUtils.hasText(item.getTimestamp()) ? item.getTimestamp() : "-")
+        .append(' ')
+        .append(StringUtils.hasText(item.getLevel()) ? item.getLevel() : "INFO")
+        .append(" [")
+        .append(StringUtils.hasText(item.getSource()) ? item.getSource() : "UNKNOWN")
+        .append(']');
+    if (StringUtils.hasText(item.getStage())) {
+      result.append(" [").append(item.getStage()).append(']');
+    }
+    result.append(' ')
+        .append(StringUtils.hasText(item.getMessage()) ? item.getMessage() : "-")
+        .append('\n');
+  }
+
+  private OfflineExecutionLogEntryVO toYakOpsEntry(
+      OfflineJobExecution execution,
+      OfflineExecutionEvent event) {
+    Long timestampMillis = epochMillis(event.getCreateTime());
+    String transition = text(event.getFromStatus()) + " -> " + text(event.getToStatus());
+    String message =
+        StringUtils.hasText(event.getMessage())
+            ? transition + " | " + event.getMessage()
+            : transition;
+
+    return OfflineExecutionLogEntryVO.builder()
+        .sequence(value(event.getId(), 0L))
+        .timestampMillis(timestampMillis)
+        .timestamp(format(timestampMillis))
+        .source(SOURCE_YAK_OPS)
+        .level(level(event.getToStatus()))
+        .stage(event.getEventType())
+        .externalExecutionId(execution.getExternalExecutionId())
+        .engineJobId(execution.getEngineJobId())
+        .message(message)
+        .build();
+  }
+
+  private OfflineExecutionLogEntryVO toLinkUpEntry(
+      OfflineJobExecution execution,
+      LinkUpJobLogPageResponse response,
+      LinkUpJobLogEntry entry) {
+    Long timestampMillis = entry == null ? null : entry.getTimestampMillis();
+    String logger = entry == null ? null : entry.getLogger();
+    String message = entry == null ? null : entry.getMessage();
+
+    return OfflineExecutionLogEntryVO.builder()
+        .sequence(entry == null ? 0L : value(entry.getSequence(), 0L))
+        .timestampMillis(timestampMillis)
+        .timestamp(format(timestampMillis))
+        .source(SOURCE_LINK_UP)
+        .level(
+            entry == null || !StringUtils.hasText(entry.getLevel())
+                ? "INFO"
+                : entry.getLevel().toUpperCase(Locale.ROOT))
+        .stage(linkStage(logger, message))
+        .externalExecutionId(
+            firstText(
+                response == null ? null : response.getExternalExecutionId(),
+                execution.getExternalExecutionId()))
+        .engineJobId(
+            firstText(
+                response == null ? null : response.getJobId(),
+                execution.getEngineJobId()))
+        .runId(response == null ? null : response.getRunId())
+        .thread(entry == null ? null : entry.getThread())
+        .logger(logger)
+        .message(message)
+        .build();
+  }
+
+  private String linkStage(String logger, String message) {
+    String normalizedLogger = logger == null ? "" : logger.toLowerCase(Locale.ROOT);
+    String normalizedMessage = message == null ? "" : message.toLowerCase(Locale.ROOT);
+    if (normalizedMessage.contains("catalog sql")
+        || normalizedMessage.contains("create table")
+        || normalizedLogger.contains("catalog")) {
+      return "SCHEMA";
+    }
+    if (normalizedLogger.contains("taskexecutor")) {
+      return "TASK";
+    }
+    if (normalizedLogger.contains("jobexecution")) {
+      return "JOB";
+    }
+    if (normalizedLogger.contains("split")) {
+      return "SPLIT";
+    }
+    return "ENGINE";
+  }
+
+  private String level(String status) {
+    if (!StringUtils.hasText(status)) {
+      return "INFO";
+    }
+    String normalized = status.trim().toUpperCase(Locale.ROOT);
+    if ("FAILED".equals(normalized) || "LOST".equals(normalized)) {
+      return "ERROR";
+    }
+    if ("CANCELED".equals(normalized) || "CANCELLED".equals(normalized)) {
+      return "WARN";
+    }
+    return "INFO";
+  }
+
+  private Long epochMillis(LocalDateTime value) {
+    return value == null
+        ? null
+        : value.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+  }
+
+  private String format(Long timestampMillis) {
+    return timestampMillis == null
+        ? null
+        : FORMAT.format(Instant.ofEpochMilli(timestampMillis).atZone(ZoneId.systemDefault()));
+  }
+
+  private String text(String value) {
+    return StringUtils.hasText(value) ? value : "-";
+  }
+
+  private String firstText(String first, String second) {
+    return StringUtils.hasText(first) ? first : second;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private record LinkUpLogBatch(
+      List<OfflineExecutionLogEntryVO> items,
+      LinkUpJobLogPageResponse response,
+      boolean available,
+      String warning) {
+
+    private static LinkUpLogBatch notRequired() {
+      return new LinkUpLogBatch(List.of(), null, true, null);
+    }
+
+    private static LinkUpLogBatch unavailable(String warning) {
+      return new LinkUpLogBatch(List.of(), null, false, warning);
+    }
+  }
+
+  private record Cursor(long yakEventId, long linkCursor) {
+
+    private static Cursor start() {
+      return new Cursor(0L, 0L);
+    }
+
+    private static Cursor parse(String value) {
+      if (!StringUtils.hasText(value)) {
+        return start();
+      }
+
+      String[] parts = value.trim().split(":", -1);
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("日志 cursor 格式不正确");
+      }
+      try {
+        long yakEventId = Long.parseLong(parts[0]);
+        long linkCursor = Long.parseLong(parts[1]);
+        if (yakEventId < 0L || linkCursor < 0L) {
+          throw new IllegalArgumentException("日志 cursor 不能为负数");
+        }
+        return new Cursor(yakEventId, linkCursor);
+      } catch (NumberFormatException exception) {
+        throw new IllegalArgumentException("日志 cursor 格式不正确", exception);
+      }
+    }
+
+    private String encode() {
+      return encode(yakEventId, linkCursor);
+    }
+
+    private static String encode(long yakEventId, long linkCursor) {
+      return yakEventId + ":" + linkCursor;
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionQuery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionQuery.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.sync.offline.execution.query;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.framework.common.PageData;
@@ -19,23 +20,195 @@ import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** 执行实例、指标和状态事件读模型。 */
+/** 执行实例、指标和状态事件 read model。 */
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineExecutionQuery {
-  private static final DateTimeFormatter FORMAT=DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-  private final OfflineJobExecutionRepository executionRepository; private final OfflineExecutionEventRepository eventRepository; private final LinkUpClient linkUpClient; private final ObjectMapper objectMapper; private final OfflineSyncViewMapper viewMapper;
-  public OfflineExecutionQuery(OfflineJobExecutionRepository executionRepository,OfflineExecutionEventRepository eventRepository,LinkUpClient linkUpClient,@Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,OfflineSyncViewMapper viewMapper){this.executionRepository=executionRepository;this.eventRepository=eventRepository;this.linkUpClient=linkUpClient;this.objectMapper=objectMapper;this.viewMapper=viewMapper;}
-  public OfflineJobExecution require(Long id){if(id==null||id<=0L)throw new IllegalArgumentException("任务实例 ID 不合法");return executionRepository.findById(id).orElseThrow(()->new IllegalArgumentException("离线同步任务实例不存在："+id));}
-  public PagingData<OfflineJobExecutionVO> page(OfflineJobExecutionQueryDTO queryDTO){OfflineJobExecutionQueryDTO query=queryDTO==null?new OfflineJobExecutionQueryDTO():queryDTO;PageData<OfflineJobExecution> page=executionRepository.page(new io.yak.ops.business.sync.offline.domain.OfflineExecutionQuery(query.getCurrent(),query.getPageSize(),query.getJobDefinitionId(),query.getStatus()));return PagingData.from(page.map(viewMapper::execution));}
-  public OfflineJobExecutionDetailVO detail(Long id){OfflineJobExecution execution=require(id);OfflineJobExecutionVO summary=viewMapper.execution(execution);OfflineJobExecutionDetailVO detail=OfflineJobExecutionDetailVO.builder().execution(summary).summary(summary).build();if(StringUtils.hasText(execution.getEngineSnapshotJson())){try{JsonNode snapshot=objectMapper.readTree(execution.getEngineSnapshotJson());detail.setJob(snapshot);detail.setPipelines(snapshot.path("pipelines"));detail.setTasks(snapshot.path("tasks"));detail.setMetrics(snapshot.path("metrics"));}catch(Exception ignored){}}return detail;}
-  public JsonNode tableMetrics(Long id){OfflineJobExecution execution=require(id);if(!OfflineExecutionStatus.isActive(execution.getStatus())){JsonNode snapshotPipelines=snapshotPipelines(execution);if(snapshotPipelines.isArray()&&!snapshotPipelines.isEmpty())return OfflinePipelineMetricsMapper.flatten(objectMapper,snapshotPipelines);}if(!StringUtils.hasText(execution.getEngineJobId()))throw new IllegalStateException("当前执行实例尚未获得 Link-Up jobId");return OfflinePipelineMetricsMapper.flatten(objectMapper,linkUpClient.pipelines(execution.getEngineJobId()));}
-  public List<OfflineExecutionEventVO> events(Long executionId){return eventRepository.list(executionId).stream().map(viewMapper::event).toList();}
-  public String logs(Long id){OfflineJobExecution execution=require(id);StringBuilder log=new StringBuilder("# Yak Ops Offline Sync\n");log.append("definitionId: ").append(execution.getJobDefinitionId()).append('\n').append("executionId: ").append(execution.getId()).append('\n').append("definitionVersion: ").append(value(execution.getDefinitionVersion())).append('\n').append("externalExecutionId: ").append(text(execution.getExternalExecutionId())).append('\n').append("engineBaseUrl: ").append(text(execution.getEngineBaseUrl())).append('\n').append("workerInstanceId: ").append(text(execution.getWorkerInstanceId())).append('\n').append("engineJobId: ").append(text(execution.getEngineJobId())).append('\n').append("status: ").append(text(execution.getStatus())).append('\n').append("attemptNo: ").append(value(execution.getAttemptNo())).append('\n').append("sourceRecordCount: ").append(value(execution.getSourceRecordCount())).append('\n').append("sinkAttemptedRecordCount: ").append(value(execution.getSinkAttemptedRecordCount())).append('\n').append("sinkSuccessRecordCount: ").append(value(execution.getSinkSuccessRecordCount())).append('\n').append("sinkCommittedRecordCount: ").append(value(execution.getSinkCommittedRecordCount())).append('\n').append("sourceAverageQps: ").append(decimal(execution.getSourceAverageQps())).append('\n').append("sinkAverageQps: ").append(decimal(execution.getSinkAverageQps())).append('\n').append("durationMillis: ").append(value(execution.getDurationMillis())).append('\n');if(StringUtils.hasText(execution.getErrorMessage()))log.append("error: ").append(execution.getErrorMessage()).append('\n');log.append("\n# State Events\n");for(OfflineExecutionEvent event:eventRepository.list(id)){log.append(format(event.getCreateTime())).append(" [").append(event.getEventType()).append("] ").append(text(event.getFromStatus())).append(" -> ").append(text(event.getToStatus()));if(StringUtils.hasText(event.getMessage()))log.append(" | ").append(event.getMessage());log.append('\n');}return log.toString();}
-  public OfflineJobExecutionVO toVO(OfflineJobExecution execution){return viewMapper.execution(execution);} private JsonNode snapshotPipelines(OfflineJobExecution execution){if(execution==null||!StringUtils.hasText(execution.getEngineSnapshotJson()))return objectMapper.createArrayNode();try{JsonNode snapshot=objectMapper.readTree(execution.getEngineSnapshotJson());JsonNode pipelines=snapshot.path("pipelines");return pipelines.isArray()?pipelines:objectMapper.createArrayNode();}catch(Exception ignored){return objectMapper.createArrayNode();}}
-  private String format(LocalDateTime value){return value==null?null:value.format(FORMAT);}private String text(String value){return StringUtils.hasText(value)?value:"-";}private String decimal(Double value){return value==null?"0":String.format(java.util.Locale.ROOT,"%.3f",value);}private long value(Long value){return value==null?0L:value;}private int value(Integer value){return value==null?0:value;}
+
+  private static final Logger LOG = LoggerFactory.getLogger(OfflineExecutionQuery.class);
+  private static final DateTimeFormatter FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  private final OfflineJobExecutionRepository executionRepository;
+  private final OfflineExecutionEventRepository eventRepository;
+  private final LinkUpClient linkUpClient;
+  private final ObjectMapper objectMapper;
+  private final OfflineSyncViewMapper viewMapper;
+
+  public OfflineExecutionQuery(
+      OfflineJobExecutionRepository executionRepository,
+      OfflineExecutionEventRepository eventRepository,
+      LinkUpClient linkUpClient,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineSyncViewMapper viewMapper) {
+    this.executionRepository = executionRepository;
+    this.eventRepository = eventRepository;
+    this.linkUpClient = linkUpClient;
+    this.objectMapper = objectMapper;
+    this.viewMapper = viewMapper;
+  }
+
+  public OfflineJobExecution require(Long id) {
+    if (id == null || id <= 0L) {
+      throw new IllegalArgumentException("任务实例 ID 不合法");
+    }
+    return executionRepository
+        .findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("离线同步任务实例不存在：" + id));
+  }
+
+  public PagingData<OfflineJobExecutionVO> page(OfflineJobExecutionQueryDTO queryDTO) {
+    OfflineJobExecutionQueryDTO query =
+        queryDTO == null ? new OfflineJobExecutionQueryDTO() : queryDTO;
+    PageData<OfflineJobExecution> page = executionRepository.page(
+        new io.yak.ops.business.sync.offline.domain.OfflineExecutionQuery(
+            query.getCurrent(),
+            query.getPageSize(),
+            query.getJobDefinitionId(),
+            query.getStatus()));
+    return PagingData.from(page.map(viewMapper::execution));
+  }
+
+  public OfflineJobExecutionDetailVO detail(Long id) {
+    OfflineJobExecution execution = require(id);
+    OfflineJobExecutionVO summary = viewMapper.execution(execution);
+    OfflineJobExecutionDetailVO detail =
+        OfflineJobExecutionDetailVO.builder().execution(summary).summary(summary).build();
+
+    JsonNode snapshot = readEngineSnapshot(execution);
+    if (snapshot != null) {
+      detail.setJob(snapshot);
+      detail.setPipelines(snapshot.path("pipelines"));
+      detail.setTasks(snapshot.path("tasks"));
+      detail.setMetrics(snapshot.path("metrics"));
+    }
+    return detail;
+  }
+
+  public JsonNode tableMetrics(Long id) {
+    OfflineJobExecution execution = require(id);
+    if (!OfflineExecutionStatus.isActive(execution.getStatus())) {
+      JsonNode snapshotPipelines = snapshotPipelines(execution);
+      if (snapshotPipelines.isArray() && !snapshotPipelines.isEmpty()) {
+        return OfflinePipelineMetricsMapper.flatten(objectMapper, snapshotPipelines);
+      }
+    }
+
+    if (!StringUtils.hasText(execution.getEngineJobId())) {
+      throw new IllegalStateException("当前执行实例尚未获得 Link-Up jobId");
+    }
+    return OfflinePipelineMetricsMapper.flatten(
+        objectMapper, linkUpClient.pipelines(execution.getEngineJobId()));
+  }
+
+  public List<OfflineExecutionEventVO> events(Long executionId) {
+    return eventRepository.list(executionId).stream().map(viewMapper::event).toList();
+  }
+
+  public String logs(Long id) {
+    OfflineJobExecution execution = require(id);
+    StringBuilder log = new StringBuilder("# Yak Ops Offline Sync\n");
+    appendExecutionSummary(log, execution);
+    appendStateEvents(log, id);
+    return log.toString();
+  }
+
+  public OfflineJobExecutionVO toVO(OfflineJobExecution execution) {
+    return viewMapper.execution(execution);
+  }
+
+  private void appendExecutionSummary(StringBuilder log, OfflineJobExecution execution) {
+    log.append("definitionId: ").append(execution.getJobDefinitionId()).append('\n')
+        .append("executionId: ").append(execution.getId()).append('\n')
+        .append("definitionVersion: ").append(value(execution.getDefinitionVersion())).append('\n')
+        .append("externalExecutionId: ").append(text(execution.getExternalExecutionId())).append('\n')
+        .append("engineBaseUrl: ").append(text(execution.getEngineBaseUrl())).append('\n')
+        .append("workerInstanceId: ").append(text(execution.getWorkerInstanceId())).append('\n')
+        .append("engineJobId: ").append(text(execution.getEngineJobId())).append('\n')
+        .append("status: ").append(text(execution.getStatus())).append('\n')
+        .append("attemptNo: ").append(value(execution.getAttemptNo())).append('\n')
+        .append("sourceRecordCount: ").append(value(execution.getSourceRecordCount())).append('\n')
+        .append("sinkAttemptedRecordCount: ")
+        .append(value(execution.getSinkAttemptedRecordCount()))
+        .append('\n')
+        .append("sinkSuccessRecordCount: ").append(value(execution.getSinkSuccessRecordCount())).append('\n')
+        .append("sinkCommittedRecordCount: ")
+        .append(value(execution.getSinkCommittedRecordCount()))
+        .append('\n')
+        .append("sourceAverageQps: ").append(decimal(execution.getSourceAverageQps())).append('\n')
+        .append("sinkAverageQps: ").append(decimal(execution.getSinkAverageQps())).append('\n')
+        .append("durationMillis: ").append(value(execution.getDurationMillis())).append('\n');
+
+    if (StringUtils.hasText(execution.getErrorMessage())) {
+      log.append("error: ").append(execution.getErrorMessage()).append('\n');
+    }
+  }
+
+  private void appendStateEvents(StringBuilder log, Long executionId) {
+    log.append("\n# State Events\n");
+    for (OfflineExecutionEvent event : eventRepository.list(executionId)) {
+      log.append(format(event.getCreateTime()))
+          .append(" [")
+          .append(event.getEventType())
+          .append("] ")
+          .append(text(event.getFromStatus()))
+          .append(" -> ")
+          .append(text(event.getToStatus()));
+      if (StringUtils.hasText(event.getMessage())) {
+        log.append(" | ").append(event.getMessage());
+      }
+      log.append('\n');
+    }
+  }
+
+  private JsonNode snapshotPipelines(OfflineJobExecution execution) {
+    JsonNode snapshot = readEngineSnapshot(execution);
+    if (snapshot == null) {
+      return objectMapper.createArrayNode();
+    }
+    JsonNode pipelines = snapshot.path("pipelines");
+    return pipelines.isArray() ? pipelines : objectMapper.createArrayNode();
+  }
+
+  private JsonNode readEngineSnapshot(OfflineJobExecution execution) {
+    if (execution == null || !StringUtils.hasText(execution.getEngineSnapshotJson())) {
+      return null;
+    }
+    try {
+      return objectMapper.readTree(execution.getEngineSnapshotJson());
+    } catch (JsonProcessingException exception) {
+      LOG.warn(
+          "Failed to parse offline execution engine snapshot, executionId={}",
+          execution.getId(),
+          exception);
+      return null;
+    }
+  }
+
+  private String format(LocalDateTime value) {
+    return value == null ? null : value.format(FORMAT);
+  }
+
+  private String text(String value) {
+    return StringUtils.hasText(value) ? value : "-";
+  }
+
+  private String decimal(Double value) {
+    return value == null ? "0" : String.format(Locale.ROOT, "%.3f", value);
+  }
+
+  private long value(Long value) {
+    return value == null ? 0L : value;
+  }
+
+  private int value(Integer value) {
+    return value == null ? 0 : value;
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflinePipelineMetricsMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflinePipelineMetricsMapper.java
@@ -3,65 +3,140 @@ package io.yak.ops.business.sync.offline.execution.query;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /** 将 Link-Up Pipeline 嵌套指标转换为 Yak Ops 页面使用的表级扁平指标。 */
 final class OfflinePipelineMetricsMapper {
+
   private OfflinePipelineMetricsMapper() {}
 
   static JsonNode flatten(ObjectMapper objectMapper, JsonNode payload) {
     ArrayNode result = objectMapper.createArrayNode();
     JsonNode pipelines = pipelines(payload);
-    if (!pipelines.isArray()) return result;
+    if (!pipelines.isArray()) {
+      return result;
+    }
+
     int index = 0;
     for (JsonNode pipeline : pipelines) {
-      JsonNode source = pipeline.path("source");
-      JsonNode sink = pipeline.path("sink");
-      JsonNode tableDdl = pipeline.path("tableDdl");
-      ObjectNode row = result.addObject();
-      row.put("id", text(pipeline, "pipelineId", text(pipeline, "dataSetId", String.valueOf(index))));
-      row.put("pipelineId", text(pipeline, "pipelineId", null));
-      row.put("dataSetId", text(pipeline, "dataSetId", null));
-      row.put("status", text(pipeline, "status", "UNKNOWN"));
-      row.put("sourceTable", text(source, "table", text(pipeline, "dataSetId", "-")));
-      row.put("sinkTable", text(sink, "table", "-"));
-      row.put("sourceConnector", text(source, "connector", null));
-      row.put("sinkConnector", text(sink, "connector", null));
-      row.put("sourceTaskCount", number(source, "taskCount", 0L));
-      row.put("sinkTaskCount", number(sink, "taskCount", 0L));
-      row.put("readRowCount", number(source, "recordCount", 0L));
-      row.put("writeRowCount", number(sink, "successRecordCount", 0L));
-      row.put("sinkAttemptedRecordCount", number(sink, "attemptedRecordCount", 0L));
-      row.put("sinkCommittedRecordCount", number(sink, "committedRecordCount", number(sink, "successRecordCount", 0L)));
-      row.put("failedRecordCount", number(sink, "failedRecordCount", 0L));
-      row.put("unknownStateRecordCount", number(sink, "unknownStateRecordCount", 0L));
-      row.put("readQps", decimal(source, "averageQps", 0D));
-      row.put("writeQps", decimal(sink, "averageQps", 0D));
-      row.put("sourceReadBytes", number(source, "readBytes", 0L));
-      row.put("sinkWrittenBytes", number(sink, "writtenBytes", 0L));
-      if (tableDdl.isObject()) {
-        row.set("tableDdl", tableDdl.deepCopy()); putNullable(row, "ddlDialect", text(tableDdl, "dialect", null));
-        putNullable(row, "createTableSql", text(tableDdl, "createTableSql", null)); row.put("ddlExecuted", bool(tableDdl, "executed", false));
-        putNullable(row, "ddlStatus", text(tableDdl, "status", null)); putNullable(row, "ddlReason", text(tableDdl, "reason", null));
-        row.put("ddlDurationMillis", number(tableDdl, "durationMillis", 0L)); putNullable(row, "ddlErrorCode", text(tableDdl, "errorCode", null));
-        putNullable(row, "ddlErrorMessage", text(tableDdl, "errorMessage", null));
-      } else {
-        row.putNull("tableDdl"); row.putNull("ddlDialect"); row.putNull("createTableSql"); row.put("ddlExecuted", false);
-        row.putNull("ddlStatus"); row.putNull("ddlReason"); row.put("ddlDurationMillis", 0L); row.putNull("ddlErrorCode"); row.putNull("ddlErrorMessage");
-      }
+      result.add(mapPipeline(objectMapper, pipeline, index));
       index++;
     }
     return result;
   }
-  private static JsonNode pipelines(JsonNode payload) {
-    if (payload == null || payload.isNull() || payload.isMissingNode()) return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
-    if (payload.isArray()) return payload; if (payload.path("pipelines").isArray()) return payload.path("pipelines");
-    JsonNode data = payload.path("data"); if (data.isArray()) return data; if (data.path("pipelines").isArray()) return data.path("pipelines");
-    return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
+
+  private static ObjectNode mapPipeline(
+      ObjectMapper objectMapper,
+      JsonNode pipeline,
+      int index) {
+    JsonNode source = pipeline.path("source");
+    JsonNode sink = pipeline.path("sink");
+    ObjectNode row = objectMapper.createObjectNode();
+
+    row.put(
+        "id",
+        text(pipeline, "pipelineId", text(pipeline, "dataSetId", String.valueOf(index))));
+    row.put("pipelineId", text(pipeline, "pipelineId", null));
+    row.put("dataSetId", text(pipeline, "dataSetId", null));
+    row.put("status", text(pipeline, "status", "UNKNOWN"));
+    row.put("sourceTable", text(source, "table", text(pipeline, "dataSetId", "-")));
+    row.put("sinkTable", text(sink, "table", "-"));
+    row.put("sourceConnector", text(source, "connector", null));
+    row.put("sinkConnector", text(sink, "connector", null));
+    row.put("sourceTaskCount", number(source, "taskCount", 0L));
+    row.put("sinkTaskCount", number(sink, "taskCount", 0L));
+    row.put("readRowCount", number(source, "recordCount", 0L));
+    row.put("writeRowCount", number(sink, "successRecordCount", 0L));
+    row.put("sinkAttemptedRecordCount", number(sink, "attemptedRecordCount", 0L));
+    row.put(
+        "sinkCommittedRecordCount",
+        number(sink, "committedRecordCount", number(sink, "successRecordCount", 0L)));
+    row.put("failedRecordCount", number(sink, "failedRecordCount", 0L));
+    row.put("unknownStateRecordCount", number(sink, "unknownStateRecordCount", 0L));
+    row.put("readQps", decimal(source, "averageQps", 0D));
+    row.put("writeQps", decimal(sink, "averageQps", 0D));
+    row.put("sourceReadBytes", number(source, "readBytes", 0L));
+    row.put("sinkWrittenBytes", number(sink, "writtenBytes", 0L));
+    writeTableDdl(row, pipeline.path("tableDdl"));
+    return row;
   }
-  private static void putNullable(ObjectNode target, String field, String value) { if (value == null) target.putNull(field); else target.put(field, value); }
-  private static String text(JsonNode node, String field, String fallback) { JsonNode value = node == null ? null : node.get(field); if (value == null || value.isNull() || !value.isValueNode()) return fallback; String text = value.asText(); return text == null || text.trim().isEmpty() ? fallback : text; }
-  private static long number(JsonNode node, String field, long fallback) { JsonNode value = node == null ? null : node.get(field); return value == null || !value.isNumber() ? fallback : value.asLong(fallback); }
-  private static double decimal(JsonNode node, String field, double fallback) { JsonNode value = node == null ? null : node.get(field); return value == null || !value.isNumber() ? fallback : value.asDouble(fallback); }
-  private static boolean bool(JsonNode node, String field, boolean fallback) { JsonNode value = node == null ? null : node.get(field); return value == null || !value.isBoolean() ? fallback : value.asBoolean(fallback); }
+
+  private static void writeTableDdl(ObjectNode row, JsonNode tableDdl) {
+    if (!tableDdl.isObject()) {
+      row.putNull("tableDdl");
+      row.putNull("ddlDialect");
+      row.putNull("createTableSql");
+      row.put("ddlExecuted", false);
+      row.putNull("ddlStatus");
+      row.putNull("ddlReason");
+      row.put("ddlDurationMillis", 0L);
+      row.putNull("ddlErrorCode");
+      row.putNull("ddlErrorMessage");
+      return;
+    }
+
+    row.set("tableDdl", tableDdl.deepCopy());
+    putNullable(row, "ddlDialect", text(tableDdl, "dialect", null));
+    putNullable(row, "createTableSql", text(tableDdl, "createTableSql", null));
+    row.put("ddlExecuted", bool(tableDdl, "executed", false));
+    putNullable(row, "ddlStatus", text(tableDdl, "status", null));
+    putNullable(row, "ddlReason", text(tableDdl, "reason", null));
+    row.put("ddlDurationMillis", number(tableDdl, "durationMillis", 0L));
+    putNullable(row, "ddlErrorCode", text(tableDdl, "errorCode", null));
+    putNullable(row, "ddlErrorMessage", text(tableDdl, "errorMessage", null));
+  }
+
+  private static JsonNode pipelines(JsonNode payload) {
+    if (payload == null || payload.isNull() || payload.isMissingNode()) {
+      return MissingNode.getInstance();
+    }
+    if (payload.isArray()) {
+      return payload;
+    }
+    if (payload.path("pipelines").isArray()) {
+      return payload.path("pipelines");
+    }
+
+    JsonNode data = payload.path("data");
+    if (data.isArray()) {
+      return data;
+    }
+    if (data.path("pipelines").isArray()) {
+      return data.path("pipelines");
+    }
+    return MissingNode.getInstance();
+  }
+
+  private static void putNullable(ObjectNode target, String field, String value) {
+    if (value == null) {
+      target.putNull(field);
+    } else {
+      target.put(field, value);
+    }
+  }
+
+  private static String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return fallback;
+    }
+    String text = value.asText();
+    return text == null || text.trim().isEmpty() ? fallback : text;
+  }
+
+  private static long number(JsonNode node, String field, long fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || !value.isNumber() ? fallback : value.asLong(fallback);
+  }
+
+  private static double decimal(JsonNode node, String field, double fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || !value.isNumber() ? fallback : value.asDouble(fallback);
+  }
+
+  private static boolean bool(JsonNode node, String field, boolean fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || !value.isBoolean() ? fallback : value.asBoolean(fallback);
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/mapping/OfflineSyncViewMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/mapping/OfflineSyncViewMapper.java
@@ -16,63 +16,152 @@ import org.springframework.stereotype.Component;
 /** 纯输出模型转换；不访问数据库、不承担业务判断。 */
 @Component
 public class OfflineSyncViewMapper {
-  private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-  public OfflineJobDefinitionVO definition(OfflineJobDefinition d) {
-    boolean scheduled = Boolean.TRUE.equals(d.getScheduleEnabled());
-    return OfflineJobDefinitionVO.builder().id(d.getId()).jobName(d.getJobName()).jobDesc(d.getJobDesc())
-        .jobType("BATCH").mode(d.getMode()).releaseState(d.getReleaseState()).sourceType(d.getSourceType())
-        .sinkType(d.getSinkType()).sourceDatasourceId(d.getSourceDatasourceId()).sinkDatasourceId(d.getSinkDatasourceId())
-        .sourceDatasourceName(d.getSourceDatasourceName()).sinkDatasourceName(d.getSinkDatasourceName())
-        .sourceTable(d.getSourceTable()).sinkTable(d.getSinkTable()).lastJobStatus(d.getLastJobStatus())
-        .lastErrorMessage(d.getLastErrorMessage()).instanceId(d.getLastExecutionId()).engineJobId(d.getLastEngineJobId())
-        .runMode(scheduled ? "SCHEDULE" : "MANUAL").duration(seconds(d.getLastDurationMillis()))
-        .readRowCount(value(d.getLastReadRowCount())).qps(value(d.getLastQps())).syncSize(formatBytes(d.getLastSyncBytes()))
-        .cronExpression(d.getCronExpression()).scheduleStatus(scheduled ? "NORMAL" : "PAUSED")
-        .lastScheduleTime(format(d.getScheduleLastFireTime() == null ? d.getLastStartTime() : d.getScheduleLastFireTime()))
-        .nextScheduleTime(format(d.getScheduleNextFireTime())).createTime(format(d.getCreateTime())).updateTime(format(d.getUpdateTime())).build();
+  private static final DateTimeFormatter FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  public OfflineJobDefinitionVO definition(OfflineJobDefinition definition) {
+    boolean scheduled = Boolean.TRUE.equals(definition.getScheduleEnabled());
+    return OfflineJobDefinitionVO.builder()
+        .id(definition.getId())
+        .jobName(definition.getJobName())
+        .jobDesc(definition.getJobDesc())
+        .jobType("BATCH")
+        .mode(definition.getMode())
+        .releaseState(definition.getReleaseState())
+        .sourceType(definition.getSourceType())
+        .sinkType(definition.getSinkType())
+        .sourceDatasourceId(definition.getSourceDatasourceId())
+        .sinkDatasourceId(definition.getSinkDatasourceId())
+        .sourceDatasourceName(definition.getSourceDatasourceName())
+        .sinkDatasourceName(definition.getSinkDatasourceName())
+        .sourceTable(definition.getSourceTable())
+        .sinkTable(definition.getSinkTable())
+        .lastJobStatus(definition.getLastJobStatus())
+        .lastErrorMessage(definition.getLastErrorMessage())
+        .instanceId(definition.getLastExecutionId())
+        .engineJobId(definition.getLastEngineJobId())
+        .runMode(scheduled ? "SCHEDULE" : "MANUAL")
+        .duration(seconds(definition.getLastDurationMillis()))
+        .readRowCount(value(definition.getLastReadRowCount()))
+        .qps(value(definition.getLastQps()))
+        .syncSize(formatBytes(definition.getLastSyncBytes()))
+        .cronExpression(definition.getCronExpression())
+        .scheduleStatus(scheduled ? "NORMAL" : "PAUSED")
+        .lastScheduleTime(
+            format(
+                definition.getScheduleLastFireTime() == null
+                    ? definition.getLastStartTime()
+                    : definition.getScheduleLastFireTime()))
+        .nextScheduleTime(format(definition.getScheduleNextFireTime()))
+        .createTime(format(definition.getCreateTime()))
+        .updateTime(format(definition.getUpdateTime()))
+        .build();
   }
 
   public OfflineJobExecutionVO execution(OfflineJobExecution execution) {
-    return OfflineJobExecutionVO.builder().id(execution.getId()).jobDefinitionId(execution.getJobDefinitionId())
-        .definitionVersion(execution.getDefinitionVersion()).engineBaseUrl(execution.getEngineBaseUrl())
-        .engineJobId(execution.getEngineJobId()).externalExecutionId(execution.getExternalExecutionId())
-        .workerInstanceId(execution.getWorkerInstanceId()).status(execution.getStatus()).stateVersion(value(execution.getStateVersion()))
-        .attemptNo(value(execution.getAttemptNo())).triggerType(execution.getTriggerType()).retryFromExecutionId(execution.getRetryFromExecutionId())
-        .cancellationRequested(Boolean.TRUE.equals(execution.getCancellationRequested())).errorMessage(execution.getErrorMessage())
-        .sourceRecordCount(value(execution.getSourceRecordCount())).sinkAttemptedRecordCount(value(execution.getSinkAttemptedRecordCount()))
-        .sinkSuccessRecordCount(value(execution.getSinkSuccessRecordCount())).sinkCommittedRecordCount(value(execution.getSinkCommittedRecordCount()))
-        .sourceReadBytes(value(execution.getSourceReadBytes())).sinkWrittenBytes(value(execution.getSinkWrittenBytes()))
-        .sourceAverageQps(value(execution.getSourceAverageQps())).sinkAverageQps(value(execution.getSinkAverageQps()))
-        .failedRecordCount(value(execution.getFailedRecordCount())).skippedRecordCount(value(execution.getSkippedRecordCount()))
-        .databaseCommitMillis(value(execution.getDatabaseCommitMillis())).sqlExecutionMillis(value(execution.getSqlExecutionMillis()))
-        .qps(value(execution.getQps())).durationMillis(value(execution.getDurationMillis())).createTime(format(execution.getCreateTime()))
-        .startTime(format(execution.getStartTime())).endTime(format(execution.getEndTime())).nextRetryTime(format(execution.getNextRetryTime()))
-        .lastSyncTime(format(execution.getLastSyncTime())).updateTime(format(execution.getUpdateTime())).build();
+    return OfflineJobExecutionVO.builder()
+        .id(execution.getId())
+        .jobDefinitionId(execution.getJobDefinitionId())
+        .definitionVersion(execution.getDefinitionVersion())
+        .engineBaseUrl(execution.getEngineBaseUrl())
+        .engineJobId(execution.getEngineJobId())
+        .externalExecutionId(execution.getExternalExecutionId())
+        .workerInstanceId(execution.getWorkerInstanceId())
+        .status(execution.getStatus())
+        .stateVersion(value(execution.getStateVersion()))
+        .attemptNo(value(execution.getAttemptNo()))
+        .triggerType(execution.getTriggerType())
+        .retryFromExecutionId(execution.getRetryFromExecutionId())
+        .cancellationRequested(Boolean.TRUE.equals(execution.getCancellationRequested()))
+        .errorMessage(execution.getErrorMessage())
+        .sourceRecordCount(value(execution.getSourceRecordCount()))
+        .sinkAttemptedRecordCount(value(execution.getSinkAttemptedRecordCount()))
+        .sinkSuccessRecordCount(value(execution.getSinkSuccessRecordCount()))
+        .sinkCommittedRecordCount(value(execution.getSinkCommittedRecordCount()))
+        .sourceReadBytes(value(execution.getSourceReadBytes()))
+        .sinkWrittenBytes(value(execution.getSinkWrittenBytes()))
+        .sourceAverageQps(value(execution.getSourceAverageQps()))
+        .sinkAverageQps(value(execution.getSinkAverageQps()))
+        .failedRecordCount(value(execution.getFailedRecordCount()))
+        .skippedRecordCount(value(execution.getSkippedRecordCount()))
+        .databaseCommitMillis(value(execution.getDatabaseCommitMillis()))
+        .sqlExecutionMillis(value(execution.getSqlExecutionMillis()))
+        .qps(value(execution.getQps()))
+        .durationMillis(value(execution.getDurationMillis()))
+        .createTime(format(execution.getCreateTime()))
+        .startTime(format(execution.getStartTime()))
+        .endTime(format(execution.getEndTime()))
+        .nextRetryTime(format(execution.getNextRetryTime()))
+        .lastSyncTime(format(execution.getLastSyncTime()))
+        .updateTime(format(execution.getUpdateTime()))
+        .build();
   }
 
   public OfflineExecutionEventVO event(OfflineExecutionEvent event) {
-    return OfflineExecutionEventVO.builder().id(event.getId()).executionId(event.getExecutionId()).stateVersion(event.getStateVersion())
-        .fromStatus(event.getFromStatus()).toStatus(event.getToStatus()).eventType(event.getEventType()).message(event.getMessage())
-        .payloadJson(event.getPayloadJson()).createTime(event.getCreateTime()).build();
+    return OfflineExecutionEventVO.builder()
+        .id(event.getId())
+        .executionId(event.getExecutionId())
+        .stateVersion(event.getStateVersion())
+        .fromStatus(event.getFromStatus())
+        .toStatus(event.getToStatus())
+        .eventType(event.getEventType())
+        .message(event.getMessage())
+        .payloadJson(event.getPayloadJson())
+        .createTime(event.getCreateTime())
+        .build();
   }
 
   public OfflineEngineHealthVO engineHealth(LinkUpNodeResponse node) {
-    return OfflineEngineHealthVO.builder().nodeId(node.getNodeId()).nodeName(node.getNodeName()).instanceId(node.getInstanceId())
-        .version(node.getVersion()).status(node.getStatus()).startedAtMillis(node.getStartedAtMillis()).offlineOnly(node.getOfflineOnly())
-        .maxConcurrentJobs(node.getMaxConcurrentJobs()).maxQueuedJobs(node.getMaxQueuedJobs()).runningJobs(node.getRunningJobs())
-        .queuedJobs(node.getQueuedJobs()).activeJobs(node.getActiveJobs()).lifecycle(node.getLifecycle()).build();
+    return OfflineEngineHealthVO.builder()
+        .nodeId(node.getNodeId())
+        .nodeName(node.getNodeName())
+        .instanceId(node.getInstanceId())
+        .version(node.getVersion())
+        .status(node.getStatus())
+        .startedAtMillis(node.getStartedAtMillis())
+        .offlineOnly(node.getOfflineOnly())
+        .maxConcurrentJobs(node.getMaxConcurrentJobs())
+        .maxQueuedJobs(node.getMaxQueuedJobs())
+        .runningJobs(node.getRunningJobs())
+        .queuedJobs(node.getQueuedJobs())
+        .activeJobs(node.getActiveJobs())
+        .lifecycle(node.getLifecycle())
+        .build();
   }
 
-  private String format(LocalDateTime value) { return value == null ? null : value.format(FORMAT); }
-  private long seconds(Long millis) { return millis == null ? 0L : Math.max(0L, millis / 1000L); }
-  private long value(Long value) { return value == null ? 0L : value; }
-  private int value(Integer value) { return value == null ? 0 : value; }
-  private double value(Double value) { return value == null ? 0D : value; }
+  private String format(LocalDateTime value) {
+    return value == null ? null : value.format(FORMAT);
+  }
+
+  private long seconds(Long millis) {
+    return millis == null ? 0L : Math.max(0L, millis / 1000L);
+  }
+
+  private long value(Long value) {
+    return value == null ? 0L : value;
+  }
+
+  private int value(Integer value) {
+    return value == null ? 0 : value;
+  }
+
+  private double value(Double value) {
+    return value == null ? 0D : value;
+  }
+
   private String formatBytes(Long bytes) {
-    if (bytes == null || bytes <= 0L) return "-";
-    double size = bytes; String[] units = {"B", "KB", "MB", "GB", "TB"}; int unit = 0;
-    while (size >= 1024D && unit < units.length - 1) { size /= 1024D; unit++; }
+    if (bytes == null || bytes <= 0L) {
+      return "-";
+    }
+
+    double size = bytes;
+    String[] units = {"B", "KB", "MB", "GB", "TB"};
+    int unit = 0;
+    while (size >= 1024D && unit < units.length - 1) {
+      size /= 1024D;
+      unit++;
+    }
     return String.format(Locale.ROOT, "%.2f %s", size, units[unit]);
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleSupport.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.sync.offline.schedule;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
@@ -14,6 +15,7 @@ import org.springframework.util.StringUtils;
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineScheduleSupport {
+
   private final ObjectMapper objectMapper;
 
   public OfflineScheduleSupport(@Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
@@ -23,44 +25,88 @@ public class OfflineScheduleSupport {
   public OfflineSchedule prepare(Long definitionId, JsonNode schedule) {
     String cron = firstText(schedule, "cron", "cronExpression");
     boolean enabled = enabled(schedule, cron);
-    if (enabled && !StringUtils.hasText(cron)) throw new IllegalArgumentException("启用调度时必须填写 Cron 表达式");
-    if (StringUtils.hasText(cron)) cron = normalizeQuartzCron(cron);
+    if (enabled && !StringUtils.hasText(cron)) {
+      throw new IllegalArgumentException("启用调度时必须填写 Cron 表达式");
+    }
+    if (StringUtils.hasText(cron)) {
+      cron = normalizeQuartzCron(cron);
+    }
+
     int attempts = Math.max(1, maxAttempts(schedule));
     int backoff = Math.max(1, backoffSeconds(schedule));
-    return new OfflineSchedule(definitionId, cron, enabled, attempts, backoff, null, null, writeNullable(schedule));
+    return new OfflineSchedule(
+        definitionId,
+        cron,
+        enabled,
+        attempts,
+        backoff,
+        null,
+        null,
+        writeNullable(schedule));
   }
 
   String normalizeQuartzCron(String value) {
     CronExpression.parse(value);
     String[] fields = value.trim().replaceAll("\\s+", " ").split(" ");
-    if (fields.length >= 6) {
-      if ("*".equals(fields[3]) && !"?".equals(fields[5])) fields[3] = "?";
-      else if (!"?".equals(fields[3]) && "*".equals(fields[5])) fields[5] = "?";
+    if (fields.length < 6) {
+      return String.join(" ", Arrays.asList(fields));
+    }
+
+    if ("*".equals(fields[3]) && !"?".equals(fields[5])) {
+      fields[3] = "?";
+    } else if (!"?".equals(fields[3]) && "*".equals(fields[5])) {
+      fields[5] = "?";
     }
     return String.join(" ", Arrays.asList(fields));
   }
 
   private boolean enabled(JsonNode node, String cron) {
-    if (node == null || node.isNull()) return false;
-    if (node.hasNonNull("enabled")) return node.path("enabled").asBoolean(false);
+    if (node == null || node.isNull()) {
+      return false;
+    }
+    if (node.hasNonNull("enabled")) {
+      return node.path("enabled").asBoolean(false);
+    }
+
     String type = text(node, "scheduleRunType");
-    return StringUtils.hasText(type) ? !"pause".equalsIgnoreCase(type) && !"paused".equalsIgnoreCase(type) : StringUtils.hasText(cron);
+    if (StringUtils.hasText(type)) {
+      return !"pause".equalsIgnoreCase(type) && !"paused".equalsIgnoreCase(type);
+    }
+    return StringUtils.hasText(cron);
   }
 
   private int maxAttempts(JsonNode node) {
-    if (node == null || node.isNull()) return 1;
-    if (node.hasNonNull("retryOnFailure")) return node.path("retryOnFailure").asBoolean() ? 2 : 1;
-    if (!node.path("autoRetry").asBoolean(true)) return 1;
+    if (node == null || node.isNull()) {
+      return 1;
+    }
+    if (node.hasNonNull("retryOnFailure")) {
+      return node.path("retryOnFailure").asBoolean() ? 2 : 1;
+    }
+    if (!node.path("autoRetry").asBoolean(true)) {
+      return 1;
+    }
+
     int configured = node.path("retryPolicy").path("maxAttempts").asInt(0);
-    return configured > 0 ? configured : Math.max(1, node.path("retryTimes").asInt(0) + 1);
+    if (configured > 0) {
+      return configured;
+    }
+    return Math.max(1, node.path("retryTimes").asInt(0) + 1);
   }
 
   private int backoffSeconds(JsonNode node) {
-    if (node == null || node.isNull()) return 60;
-    int value = node.path("retryPolicy").path("backoffSeconds").asInt(0);
-    if (value > 0) return value;
-    value = node.path("retryIntervalSeconds").asInt(0);
-    if (value > 0) return value;
+    if (node == null || node.isNull()) {
+      return 60;
+    }
+
+    int configured = node.path("retryPolicy").path("backoffSeconds").asInt(0);
+    if (configured > 0) {
+      return configured;
+    }
+
+    configured = node.path("retryIntervalSeconds").asInt(0);
+    if (configured > 0) {
+      return configured;
+    }
     return Math.max(1, node.path("retryInterval").asInt(1)) * 60;
   }
 
@@ -70,14 +116,21 @@ public class OfflineScheduleSupport {
   }
 
   private String text(JsonNode node, String field) {
-    if (node == null || !node.hasNonNull(field)) return null;
+    if (node == null || !node.hasNonNull(field)) {
+      return null;
+    }
     String value = node.path(field).asText(null);
     return StringUtils.hasText(value) ? value.trim() : null;
   }
 
   private String writeNullable(JsonNode node) {
-    if (node == null || node.isNull()) return null;
-    try { return objectMapper.writeValueAsString(node); }
-    catch (Exception exception) { throw new IllegalStateException("序列化调度配置失败", exception); }
+    if (node == null || node.isNull()) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化调度配置失败", exception);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/query/OfflinePipelineMetricsMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/query/OfflinePipelineMetricsMapperTest.java
@@ -1,7 +1,100 @@
 package io.yak.ops.business.sync.offline.execution.query;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;import static org.junit.jupiter.api.Assertions.assertFalse;import static org.junit.jupiter.api.Assertions.assertTrue;import com.fasterxml.jackson.databind.JsonNode;import com.fasterxml.jackson.databind.ObjectMapper;import org.junit.jupiter.api.Test;
-class OfflinePipelineMetricsMapperTest {private final ObjectMapper objectMapper=new ObjectMapper();
-  @Test void flattensSourceSinkAndTableDdl() throws Exception {JsonNode payload=objectMapper.readTree("""[{"pipelineId":"pipeline-test1.t_test_1w","dataSetId":"test1.t_test_1w","status":"SUCCEEDED","source":{"connector":"jdbc","table":"test1.t_test_1w","taskCount":1,"recordCount":10000,"readBytes":1024,"averageQps":14144.27157},"sink":{"connector":"jdbc","table":"test1234123","taskCount":1,"attemptedRecordCount":10000,"successRecordCount":10000,"committedRecordCount":10000,"failedRecordCount":0,"unknownStateRecordCount":0,"writtenBytes":2048,"averageQps":3369.27223},"tableDdl":{"dialect":"MYSQL","sourceTable":"test1.t_test_1w","targetTable":"test1234123","createTableSql":"CREATE TABLE `test1234123` (`id` BIGINT NOT NULL);","executed":true,"status":"SUCCEEDED","reason":"TARGET_TABLE_CREATED","durationMillis":12}}]""");JsonNode result=OfflinePipelineMetricsMapper.flatten(objectMapper,payload);assertEquals(1,result.size());JsonNode row=result.get(0);assertEquals("test1.t_test_1w",row.path("sourceTable").asText());assertEquals("test1234123",row.path("sinkTable").asText());assertEquals(10000L,row.path("readRowCount").asLong());assertEquals(10000L,row.path("writeRowCount").asLong());assertEquals(10000L,row.path("sinkAttemptedRecordCount").asLong());assertEquals(10000L,row.path("sinkCommittedRecordCount").asLong());assertEquals(14144.27157D,row.path("readQps").asDouble(),0.00001D);assertEquals(3369.27223D,row.path("writeQps").asDouble(),0.00001D);assertEquals(1024L,row.path("sourceReadBytes").asLong());assertEquals(2048L,row.path("sinkWrittenBytes").asLong());assertEquals("SUCCEEDED",row.path("status").asText());assertEquals("MYSQL",row.path("ddlDialect").asText());assertTrue(row.path("ddlExecuted").asBoolean());assertEquals("SUCCEEDED",row.path("ddlStatus").asText());assertEquals("TARGET_TABLE_CREATED",row.path("ddlReason").asText());assertEquals(12L,row.path("ddlDurationMillis").asLong());}
-  @Test void acceptsWrappedPipelinePayloadWithoutDdl() throws Exception {JsonNode payload=objectMapper.readTree("""{"pipelines":[{"dataSetId":"orders","source":{"recordCount":3},"sink":{"successRecordCount":2}}]}""");JsonNode result=OfflinePipelineMetricsMapper.flatten(objectMapper,payload);assertEquals(1,result.size());assertEquals("orders",result.get(0).path("sourceTable").asText());assertEquals(3L,result.get(0).path("readRowCount").asLong());assertEquals(2L,result.get(0).path("writeRowCount").asLong());assertFalse(result.get(0).path("ddlExecuted").asBoolean());assertTrue(result.get(0).path("createTableSql").isNull());}
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class OfflinePipelineMetricsMapperTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void flattensSourceSinkAndTableDdl() throws Exception {
+    JsonNode payload = objectMapper.readTree(
+        """
+        [{
+          "pipelineId":"pipeline-test1.t_test_1w",
+          "dataSetId":"test1.t_test_1w",
+          "status":"SUCCEEDED",
+          "source":{
+            "connector":"jdbc",
+            "table":"test1.t_test_1w",
+            "taskCount":1,
+            "recordCount":10000,
+            "readBytes":1024,
+            "averageQps":14144.27157
+          },
+          "sink":{
+            "connector":"jdbc",
+            "table":"test1234123",
+            "taskCount":1,
+            "attemptedRecordCount":10000,
+            "successRecordCount":10000,
+            "committedRecordCount":10000,
+            "failedRecordCount":0,
+            "unknownStateRecordCount":0,
+            "writtenBytes":2048,
+            "averageQps":3369.27223
+          },
+          "tableDdl":{
+            "dialect":"MYSQL",
+            "sourceTable":"test1.t_test_1w",
+            "targetTable":"test1234123",
+            "createTableSql":"CREATE TABLE `test1234123` (`id` BIGINT NOT NULL);",
+            "executed":true,
+            "status":"SUCCEEDED",
+            "reason":"TARGET_TABLE_CREATED",
+            "durationMillis":12
+          }
+        }]
+        """);
+
+    JsonNode result = OfflinePipelineMetricsMapper.flatten(objectMapper, payload);
+
+    assertEquals(1, result.size());
+    JsonNode row = result.get(0);
+    assertEquals("test1.t_test_1w", row.path("sourceTable").asText());
+    assertEquals("test1234123", row.path("sinkTable").asText());
+    assertEquals(10000L, row.path("readRowCount").asLong());
+    assertEquals(10000L, row.path("writeRowCount").asLong());
+    assertEquals(10000L, row.path("sinkAttemptedRecordCount").asLong());
+    assertEquals(10000L, row.path("sinkCommittedRecordCount").asLong());
+    assertEquals(14144.27157D, row.path("readQps").asDouble(), 0.00001D);
+    assertEquals(3369.27223D, row.path("writeQps").asDouble(), 0.00001D);
+    assertEquals(1024L, row.path("sourceReadBytes").asLong());
+    assertEquals(2048L, row.path("sinkWrittenBytes").asLong());
+    assertEquals("SUCCEEDED", row.path("status").asText());
+    assertEquals("MYSQL", row.path("ddlDialect").asText());
+    assertTrue(row.path("ddlExecuted").asBoolean());
+    assertEquals("SUCCEEDED", row.path("ddlStatus").asText());
+    assertEquals("TARGET_TABLE_CREATED", row.path("ddlReason").asText());
+    assertEquals(12L, row.path("ddlDurationMillis").asLong());
+  }
+
+  @Test
+  void acceptsWrappedPipelinePayloadWithoutDdl() throws Exception {
+    JsonNode payload = objectMapper.readTree(
+        """
+        {
+          "pipelines":[{
+            "dataSetId":"orders",
+            "source":{"recordCount":3},
+            "sink":{"successRecordCount":2}
+          }]
+        }
+        """);
+
+    JsonNode result = OfflinePipelineMetricsMapper.flatten(objectMapper, payload);
+
+    assertEquals(1, result.size());
+    assertEquals("orders", result.get(0).path("sourceTable").asText());
+    assertEquals(3L, result.get(0).path("readRowCount").asLong());
+    assertEquals(2L, result.get(0).path("writeRowCount").asLong());
+    assertFalse(result.get(0).path("ddlExecuted").asBoolean());
+    assertTrue(result.get(0).path("createTableSql").isNull());
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/mapping/OfflineSyncViewMapperTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/mapping/OfflineSyncViewMapperTest.java
@@ -1,3 +1,45 @@
 package io.yak.ops.business.sync.offline.mapping;
-import static org.assertj.core.api.Assertions.assertThat;import com.fasterxml.jackson.databind.ObjectMapper;import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;import org.junit.jupiter.api.Test;
-class OfflineSyncViewMapperTest {@Test void engineHealthKeepsLinkUpResponseFields(){LinkUpNodeResponse node=new LinkUpNodeResponse();node.setNodeId("node-1");node.setNodeName("link-up");node.setInstanceId("instance-1");node.setVersion("1.0.0");node.setStatus("UP");node.setStartedAtMillis(1000L);node.setOfflineOnly(true);node.setMaxConcurrentJobs(4);node.setMaxQueuedJobs(20);node.setRunningJobs(2);node.setQueuedJobs(3);node.setActiveJobs(5);node.setLifecycle(new ObjectMapper().createObjectNode().put("phase","READY"));OfflineEngineHealthVO result=new OfflineSyncViewMapper().engineHealth(node);assertThat(result.getNodeId()).isEqualTo("node-1");assertThat(result.getNodeName()).isEqualTo("link-up");assertThat(result.getInstanceId()).isEqualTo("instance-1");assertThat(result.getVersion()).isEqualTo("1.0.0");assertThat(result.getStatus()).isEqualTo("UP");assertThat(result.getStartedAtMillis()).isEqualTo(1000L);assertThat(result.getOfflineOnly()).isTrue();assertThat(result.getMaxConcurrentJobs()).isEqualTo(4);assertThat(result.getMaxQueuedJobs()).isEqualTo(20);assertThat(result.getRunningJobs()).isEqualTo(2);assertThat(result.getQueuedJobs()).isEqualTo(3);assertThat(result.getActiveJobs()).isEqualTo(5);assertThat(result.getLifecycle().path("phase").asText()).isEqualTo("READY");}}
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncViewMapperTest {
+
+  @Test
+  void engineHealthKeepsLinkUpResponseFields() {
+    LinkUpNodeResponse node = new LinkUpNodeResponse();
+    node.setNodeId("node-1");
+    node.setNodeName("link-up");
+    node.setInstanceId("instance-1");
+    node.setVersion("1.0.0");
+    node.setStatus("UP");
+    node.setStartedAtMillis(1000L);
+    node.setOfflineOnly(true);
+    node.setMaxConcurrentJobs(4);
+    node.setMaxQueuedJobs(20);
+    node.setRunningJobs(2);
+    node.setQueuedJobs(3);
+    node.setActiveJobs(5);
+    node.setLifecycle(new ObjectMapper().createObjectNode().put("phase", "READY"));
+
+    OfflineEngineHealthVO result = new OfflineSyncViewMapper().engineHealth(node);
+
+    assertThat(result.getNodeId()).isEqualTo("node-1");
+    assertThat(result.getNodeName()).isEqualTo("link-up");
+    assertThat(result.getInstanceId()).isEqualTo("instance-1");
+    assertThat(result.getVersion()).isEqualTo("1.0.0");
+    assertThat(result.getStatus()).isEqualTo("UP");
+    assertThat(result.getStartedAtMillis()).isEqualTo(1000L);
+    assertThat(result.getOfflineOnly()).isTrue();
+    assertThat(result.getMaxConcurrentJobs()).isEqualTo(4);
+    assertThat(result.getMaxQueuedJobs()).isEqualTo(20);
+    assertThat(result.getRunningJobs()).isEqualTo(2);
+    assertThat(result.getQueuedJobs()).isEqualTo(3);
+    assertThat(result.getActiveJobs()).isEqualTo(5);
+    assertThat(result.getLifecycle().path("phase").asText()).isEqualTo("READY");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleSupportTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/schedule/OfflineScheduleSupportTest.java
@@ -1,3 +1,41 @@
 package io.yak.ops.business.sync.offline.schedule;
-import static org.assertj.core.api.Assertions.assertThat;import com.fasterxml.jackson.databind.ObjectMapper;import com.fasterxml.jackson.databind.node.ObjectNode;import io.yak.ops.business.sync.offline.domain.OfflineSchedule;import org.junit.jupiter.api.Test;
-class OfflineScheduleSupportTest {private final ObjectMapper objectMapper=new ObjectMapper();private final OfflineScheduleSupport support=new OfflineScheduleSupport(objectMapper);@Test void shouldNormalizeCronAndLeaveNextFireTimeToYakSchedule(){ObjectNode config=objectMapper.createObjectNode();config.put("enabled",true);config.put("cron","0 5 9 * * *");config.put("retryTimes",2);config.put("retryIntervalSeconds",30);OfflineSchedule schedule=support.prepare(42L,config);assertThat(schedule.cronExpression()).isEqualTo("0 5 9 ? * *");assertThat(schedule.enabled()).isTrue();assertThat(schedule.retryMaxAttempts()).isEqualTo(3);assertThat(schedule.retryBackoffSeconds()).isEqualTo(30);assertThat(schedule.nextFireTime()).isNull();}@Test void shouldNormalizeDayOfWeekCronForQuartz(){ObjectNode config=objectMapper.createObjectNode();config.put("enabled",true);config.put("cronExpression","0 0 12 * * MON");assertThat(support.prepare(42L,config).cronExpression()).isEqualTo("0 0 12 ? * MON");}}
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.domain.OfflineSchedule;
+import org.junit.jupiter.api.Test;
+
+class OfflineScheduleSupportTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final OfflineScheduleSupport support = new OfflineScheduleSupport(objectMapper);
+
+  @Test
+  void shouldNormalizeCronAndLeaveNextFireTimeToYakSchedule() {
+    ObjectNode config = objectMapper.createObjectNode();
+    config.put("enabled", true);
+    config.put("cron", "0 5 9 * * *");
+    config.put("retryTimes", 2);
+    config.put("retryIntervalSeconds", 30);
+
+    OfflineSchedule schedule = support.prepare(42L, config);
+
+    assertThat(schedule.cronExpression()).isEqualTo("0 5 9 ? * *");
+    assertThat(schedule.enabled()).isTrue();
+    assertThat(schedule.retryMaxAttempts()).isEqualTo(3);
+    assertThat(schedule.retryBackoffSeconds()).isEqualTo(30);
+    assertThat(schedule.nextFireTime()).isNull();
+  }
+
+  @Test
+  void shouldNormalizeDayOfWeekCronForQuartz() {
+    ObjectNode config = objectMapper.createObjectNode();
+    config.put("enabled", true);
+    config.put("cronExpression", "0 0 12 * * MON");
+
+    assertThat(support.prepare(42L, config).cronExpression())
+        .isEqualTo("0 0 12 ? * MON");
+  }
+}


### PR DESCRIPTION
## Summary

按 offline-sync 当前 [`CODE_STYLE.md`](yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/CODE_STYLE.md) 对模块中仍残留的压缩式 / 难读 Java 代码做一次 targeted refactor。

本 PR 的目标不是全模块 formatter，也不是继续做架构拆分类重构；只处理目前最明显违背“简单、明确、角色化、可测试、可演进”的代码热点，并保持现有 public contract 与运行语义不变。

## Scope

本次调整 8 个生产类：

```text
definition/OfflineDefinitionSupport
definition/OfflineJobDefinitionService
execution/adapter/OfflineBatchScopeExecutionAdapter
execution/query/OfflineExecutionQuery
execution/query/OfflineExecutionLogQuery
execution/query/OfflinePipelineMetricsMapper
mapping/OfflineSyncViewMapper
schedule/OfflineScheduleSupport
```

同步整理 3 个对应的压缩式测试：

```text
OfflinePipelineMetricsMapperTest
OfflineSyncViewMapperTest
OfflineScheduleSupportTest
```

## Code style alignment

### Flat application flow

`OfflineJobDefinitionService` 保持稳定 Application Facade 身份，但把 `saveDraft / saveGuide / online / offline / delete` 从多语句单行代码整理为可顺读流程，并提炼有业务含义的 private step：

```text
ensureDefinitionId
ensureEditable
ensureUniqueName
applyDraft / applyPrepared
persist
saveScheduleAndSync
ensureNoOccupyingBatch
```

没有增加新的 Service / Helper / Common 层。

### Explicit definition support

`OfflineDefinitionSupport` 保持窄 support 角色：

- request normalize 明确成独立步骤；
- channel default 写入有统一入口；
- JSON read/write 继续保留原异常 cause；
- SHA-256 digest 从宽泛 `catch (Exception)` 收窄为 `NoSuchAlgorithmException`。

### Read model main path

`OfflineExecutionQuery`：

- page / detail / tableMetrics / logs 主路径恢复正常结构；
- snapshot 解析集中到 `readEngineSnapshot`；
- 原 `catch (Exception ignored)` 不再静默吞掉解析失败；
- 保持原降级行为，但通过参数化 warning 日志记录 `executionId`，不打印 snapshot payload / secret。

`OfflineExecutionLogQuery`：

统一日志分页主路径明确为：

```text
Yak Ops events
  + Link-Up logs
  -> merge / sort / select
  -> advance two-source cursor
  -> derive completed
```

Cursor 和 Link-Up fetch result 使用私有 record 表达，不引入额外公共抽象。

### Boundary / mapper readability

- `OfflinePipelineMetricsMapper` 将 pipeline 行映射和 DDL 映射拆成独立步骤；
- `OfflineSyncViewMapper` 保持纯 Mapper，只恢复可读 builder 结构；
- `OfflineBatchScopeExecutionAdapter` 把 input validation、source restriction、predicate、where merge 分开，Scope 行为不变；
- `OfflineScheduleSupport` 使用 early return / guard clause，并把 JSON 序列化异常收窄到 `JsonProcessingException`。

## Intentionally unchanged

本 PR 不改变：

- Task / Batch / Attempt / Cursor 领域语义；
- Retry / UNKNOWN / Cancel / Backfill 行为；
- Schedule BatchKey / Cron / Retry policy contract；
- scoped Batch JDBC-only / single-table / predicate 规则；
- unified log cursor 和 merge contract；
- Pipeline Metrics / View VO 字段；
- REST / DTO / VO API；
- Repository / DAO contracts；
- DB / Flyway；
- Link-Up API。

也没有继续拆 `OfflineExecutionCoordinator / OfflineExecutionStateManager / OfflineBackfillPlanner` 等已经具有明确角色的核心组件，避免把本 PR 扩成 big-bang cleanup。

## Tests

现有定向回归测试继续覆盖本次改动相关 contract：

- `OfflineJobDefinitionServiceRuntimeTruthTest`
- `OfflineExecutionLogQueryTest`
- `OfflineBatchScopeExecutionAdapterTest`
- `OfflinePipelineMetricsMapperTest`
- `OfflineSyncViewMapperTest`
- `OfflineScheduleSupportTest`
- architecture / dependency guardrails

其中三个原本压缩成单行的测试仅做可读性整理，断言语义不变。

## Review focus

建议按 `CODE_STYLE.md` 检查：

```text
[ ] subsystem / role 没有变化
[ ] public main path 可以顺着读
[ ] private method 表达真实步骤而不是 Helper 化
[ ] exception 不再被无意义吞掉
[ ] runtime truth owner 没有变化
[ ] dependency corridor 没有变化
[ ] 没有 REST / DB / Domain semantic change
```

## Validation

创建 PR 前：

```text
base: main @ d578e47520326c49164263f1fb7d120cc6c5516f
ahead: 1
behind: 0
commit: b72a54c6aa28db5b63f4db79aea8b112b9291fdf
changed files: 11
```

本轮通过 GitHub diff 与现有测试 contract 做了静态核对；当前会话没有实际执行本地 Maven，因此不把测试宣称为已通过，PR 保持 Draft 等待 CI/check 结果。