### PR TITLE
docs(realtime-sync): freeze stage 1 architecture contract

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/ARCHITECTURE.md
@@ -1,0 +1,304 @@
+# Realtime Sync Architecture
+
+本文件定义 Realtime Sync 本轮重构需要收敛到的**长期架构 contract**。它描述目标边界、稳定入口、运行真相与迁移约束，不记录 Stage / Wave 过程；历史迁移过程以 Git / PR 为准。
+
+需求语义看 `REQUIREMENTS.md`，领域硬规则看 `DOMAIN.md`，Review 标准看 `REVIEW.md`。
+
+> 当前代码仍存在顶层 `service/` 大桶以及职责过宽的 `RealtimeJobService`。这些属于待迁移的工程结构，不代表目标架构。后续重构必须在不改变现有业务 contract 的前提下逐步向本文件收敛。
+
+## 设计原则
+
+1. **业务子系统优先，技术分层第二。** package 本身应能表达 Realtime Sync 的业务架构。
+2. **稳定入口，隐藏内部角色。** Controller 和后台入口只依赖明确的 Application Facade / Gateway。
+3. **名字表达角色。** `Service / Coordinator / Manager / Runtime / Resolver / Query / Reconciler / Gateway / Adapter` 不互相冒充。
+4. **运行真相只有一个主人。** Task 管长期定义上下文，DefinitionVersion 管不可变发布版本，SyncExecution 管实际运行生命周期。
+5. **外部系统停在边界。** Flink、Flink CDC CLI、SSH、HTTP DTO、MyBatis、Credential 不进入 Core Domain。
+6. **查询与命令分离。** Observability / Query 读取事实与投影，不反向拥有 Execution command 语义。
+7. **重构不偷偷改业务语义。** package move、rename、class split 与 REST / DB / Domain behavior change 分开进行。
+8. **架构规则最终可执行。** 稳定后用 architecture tests 守住 package dependency graph 与跨子系统 corridor。
+
+## Target Package Map
+
+目标结构：
+
+```text
+io.yak.ops.business.sync.realtime
+├── controller          # HTTP inbound + API DTO / VO / mapper
+├── definition          # Draft / Publish / immutable DefinitionVersion
+├── execution           # Start / Stop / Restart / Apply execution lifecycle
+│   ├── query           # execution/task read model where execution ownership is relevant
+│   └── adapter         # execution-boundary projection / preparation
+├── reconcile           # runtime identity recovery + external state convergence
+├── observability       # events / logs / checkpoint / metrics read side
+├── environment         # Compute Environment application boundary
+├── engine              # Flink / Flink CDC / SSH outbound boundary
+├── repository          # domain persistence contracts + adapters
+├── dao                 # MyBatis persistence primitives
+├── domain              # framework-free core domain / value objects
+└── config              # module configuration
+```
+
+不要把现有 `service/` 平移成新的 `common / helper / utils` 大桶。新增或迁移一个类前，先回答：它属于哪个业务子系统，它是什么角色，它允许从哪里被调用。
+
+### Transitional packages
+
+当前以下结构允许在迁移期间继续存在：
+
+```text
+service/
+```
+
+但规则是：
+
+- 不再向 `service/` 增加新的宽泛业务角色；
+- 后续 PR 应按职责迁出，而不是一次 big-bang rename；
+- 迁出类完成后删除旧入口，不长期保留双路运行语义；
+- transitional package 不是稳定 API，不能据此设计新的跨包依赖。
+
+## Core Domain Model
+
+领域主线固定为：
+
+```text
+RealtimeSyncTask
+      │ publish
+      ▼
+DefinitionVersion (immutable)
+      │ start / restart / apply
+      ▼
+SyncExecution
+      │
+      ▼
+Engine Adapter
+```
+
+核心关系：
+
+```text
+Task != DefinitionVersion != SyncExecution
+```
+
+运行时配置：
+
+```text
+SyncDefinition
+├── SourceEndpoint
+├── SinkEndpoint
+├── SyncRoute[]
+├── SyncPolicy
+└── ExecutionPolicy
+```
+
+`SyncDefinition` 是唯一配置事实；Wizard、Yak YAML、HTTP DTO、DB JSON、Flink YAML 都只是 Adapter / Projection。
+
+## Truth Ownership
+
+```text
+RealtimeSyncTask        = long-lived task identity + current draft/published references
+DefinitionVersion       = immutable published definition truth
+SyncExecution           = desired/observed lifecycle + runtime execution truth
+RuntimeEnvironmentSnapshot = execution-time compute environment truth
+Runtime Identity        = external job recovery identity
+Task last/latest-*      = query projection / compatibility only
+Flink Job               = external runtime evidence
+```
+
+如果一个状态可以同时由 Task 字段、Deployment compatibility mirror 和 SyncExecution 决定，必须以 `SyncExecution` 为运行真相，并把其他字段限制为 compatibility / projection。
+
+## Stable Application Entries
+
+目标稳定入口按 use-case 划分：
+
+```text
+RealtimeJobDefinitionService
+RealtimeJobExecutionService
+RealtimeJobQueryService
+RealtimeObservabilityService
+ComputeEnvironmentService
+```
+
+预期入口关系：
+
+```text
+RealtimeJobController
+   ├── RealtimeJobDefinitionService
+   ├── RealtimeJobExecutionService
+   ├── RealtimeJobQueryService
+   └── RealtimeObservabilityService
+
+ComputeEnvironmentController
+   └── ComputeEnvironmentService
+```
+
+`@Service` 最终只用于这种稳定 Application Facade。内部专业角色使用更准确的角色名和 `@Component` / 普通对象。
+
+当前 `RealtimeJobService`、`RealtimeJobLifecycleCoordinator`、Validation / YAML / EventStream 等仍需按职责迁移；本文件不要求在一个 PR 中一次拆完。
+
+## Definition Subsystem
+
+Definition 子系统负责：
+
+```text
+Create Task Shell
+ -> Save Draft
+ -> Validate Definition
+ -> Publish immutable DefinitionVersion
+```
+
+核心约束：
+
+- Draft 可以继续编辑；
+- Published Version 不可变；
+- 运行中的 SyncExecution 不读取 current Draft；
+- `DefinitionDigest`、source config digest、artifact digest 分属不同语义；
+- Wizard / Yak YAML 只转换同一个 `SyncDefinition`，不得建立第二套业务定义；
+- Compatibility mapper 必须停在拥有兼容协议的边界，不长期留在 Core Domain。
+
+## Execution Core
+
+Execution 子系统负责命令生命周期：
+
+```text
+Start
+Stop
+RestartExecution
+ApplyPublishedVersion
+```
+
+目标协作模型：
+
+```text
+RealtimeJobExecutionService
+        |
+        +-> Execution Coordinator
+        +-> Claim / Reservation Manager
+        +-> State Manager
+        +-> Replacement Manager
+        +-> Runtime Resolver
+        +-> Engine Gateway
+        `-> Repository contracts
+```
+
+实际类名在拆分 PR 中以职责为准，但必须保留以下 contract：
+
+- 同一 Task 最多一个 Active / Uncertain Execution；
+- Start 先 reservation，再外部 submit；
+- Idempotency-Key race 可恢复；
+- prepared version 在提交前重新校验；
+- Stop during Start 不能留下失控外部 Job；
+- RestartExecution 固定原 DefinitionVersion；
+- ApplyPublishedVersion 固定命令开始时的 Published Version；
+- `UNKNOWN / CONFLICT` 先 reconcile，不猜测失败。
+
+## Reconcile Subsystem
+
+Realtime Sync 的外部 Flink Job 是长生命周期事实，Reconcile 是一级业务子系统，不是附属定时任务。
+
+```text
+Local SyncExecution
+        +
+Runtime Identity
+        +
+Flink Runtime Evidence
+        |
+        ▼
+Reconcile
+        |
+        ▼
+Converged SyncExecution state
+```
+
+Reconcile 负责：
+
+- 提交结果不确定后的 runtime identity recovery；
+- `UNKNOWN / CONFLICT` 状态收敛；
+- 外部 JobId / 状态恢复；
+- 多实例 reconcile lease；
+- 只根据精确 runtime identity / environment snapshot 对账，不按用户可见任务名猜测外部 Job。
+
+## Query / Observability
+
+Query / Observability 是 read side：
+
+```text
+Task / Definition / Execution persistence
+        +
+Flink REST evidence
+        |
+        ▼
+Read Model / Observability View
+```
+
+包括：
+
+- 任务分页与详情；
+- Execution 状态投影；
+- Event Stream；
+- submission logs；
+- runtime exception history；
+- checkpoints；
+- metrics。
+
+read side 可以组合多个事实来源，但不得拥有 Start / Stop / Retry / Reconcile 的 command 状态迁移。
+
+## Environment / Engine Boundary
+
+Compute Environment 是邻接上下文，不是 SyncDefinition 的内部字段集合。
+
+```text
+Execution
+   |
+RuntimeEnvironmentSnapshot
+   |
+Engine Gateway
+   |
+   +-> Flink REST
+   +-> Flink CDC CLI
+   `-> LOCAL / SSH execution adapter
+```
+
+边界规则：
+
+- Execution 保存运行环境 Snapshot，不跟随后续环境修改漂移；
+- Credential 只在提交边界短暂解析与使用；
+- Pipeline YAML 只作为提交 artifact，不能成为长期业务真相；
+- SSH password 不由 Realtime Sync 托管；
+- Flink / SSH DTO、Process/HTTP 实现、secret 不进入 Core Domain。
+
+## Persistence Boundary
+
+目标依赖方向：
+
+```text
+Domain       -> no framework / persistence / engine dependency
+Repository   -> Domain contracts + DAO adapter
+DAO          -> persistence primitives
+Engine       -> external protocol boundary
+```
+
+Repository contract 不暴露 MyBatis PO / Mapper / Controller DTO；DAO 不依赖 Application Service；Core Domain 不依赖 Spring/Jackson/MyBatis/Flink/SSH。
+
+## Migration Rules
+
+后续结构改造必须遵守：
+
+1. **先锁行为，再移动代码。** Start / Stop / Restart / Apply / Reconcile 的安全测试先于大规模拆分。
+2. **一个 PR 一个主要边界。** definition、execution、reconcile、observability、environment 分开迁移。
+3. **不做双真相兼容层。** 新入口稳定后删除旧运行入口，不让两套 service 同时决定状态。
+4. **不借重构改 REST / DB / Domain semantics。** 真正需要行为变化时单独走 Requirement / Domain review。
+5. **不提前抽 realtime/offline Shared Sync Kernel。** 两个模块可以共享工程思想，但 Core Domain 独立演进。
+6. **现有 architecture test 是安全网，不是最终 dependency contract。** package 收敛后再增加完整 dependency graph / corridor guardrails。
+
+## Change Rule
+
+新增或移动代码前，依次回答：
+
+1. 它属于 Definition、Execution、Reconcile、Observability、Environment、Engine 还是 Persistence？
+2. 它是什么角色？名字是否表达职责？
+3. 谁是它的稳定调用入口？
+4. 它读取或修改的 truth 属于 Task、DefinitionVersion、SyncExecution、Environment Snapshot 还是外部 Runtime Evidence？
+5. 是否跨子系统？如果是，应该通过哪个 Facade / Gateway？
+6. 是否把 Flink / SSH / Credential / DTO / PO 泄漏进 Core Domain？
+7. 哪个测试能证明迁移没有改变现有 contract？
+
+答不清楚时，不要创建新的 `Helper / Common / Utils / Base`；先把边界设计清楚。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/DOMAIN.md
@@ -2,7 +2,7 @@
 
 > 本文件只保留**实现必须遵守的硬规则**，不记录设计过程。历史演进看 Git / PR。
 >
-> `REQUIREMENTS.md` 定义“需要什么”；`DOMAIN.md` 定义“不能违反什么”；`REVIEW.md` 定义“怎么判卷”。
+> `REQUIREMENTS.md` 定义“需要什么”；`DOMAIN.md` 定义“不能违反什么”；`ARCHITECTURE.md` 定义“代码边界如何收敛”；`REVIEW.md` 定义“怎么判卷”。
 
 ## 核心模型
 
@@ -65,6 +65,29 @@ ApplyPublishedVersion  -> captured Published Version -> new Execution
 Stop / Reconcile       -> SyncExecution lifecycle
 ```
 
+## Runtime Truth
+
+命令侧运行真相固定为：
+
+```text
+RealtimeSyncTask
+    │ publish reference
+    ▼
+DefinitionVersion
+    │ execution reference
+    ▼
+SyncExecution
+```
+
+```text
+Task desired/observed/lastError = compatibility only
+Deployment.status               = compatibility mirror only
+Flink runtime state             = external evidence
+SyncExecution                   = local runtime truth
+```
+
+任何结构重构都不能把运行真相重新搬回 Task、Controller、Engine Adapter 或查询投影。
+
 ## 遗留兼容字段
 
 这些名字可以暂时存在，但**不是领域语义**：
@@ -80,6 +103,8 @@ HTTP /restart                   = restartExecution 的兼容 alias
 ```
 
 禁止用 `definition_version / published_version` 判断真正的 Version identity。
+
+Compatibility 如果必须继续存在，应停在拥有旧协议或旧持久化格式的边界；不得为了结构迁移把 compatibility mapper / facade 扩散回 Core Domain。
 
 ## 安全能力必须保留
 
@@ -99,6 +124,29 @@ secret-free persistence / log redaction
 multi-instance reconcile lease
 ```
 
+这些不是实现细节，可以在重构中换角色或换 package，但不能被删除、弱化或绕过。
+
+## Architecture Boundary
+
+领域模型与工程结构的关系以 `ARCHITECTURE.md` 为准。长期方向固定为业务子系统优先：
+
+```text
+Definition
+Execution
+Reconcile
+Observability
+Environment
+Engine / Persistence boundaries
+```
+
+允许后续 PR 移动类、重命名角色、拆分过宽 Service，但必须满足：
+
+- 不新增第二套 SyncDefinition / Execution 模型；
+- 不改变 Published Version immutable contract；
+- 不把 Query / Observability 变成 command truth owner；
+- 不把 Flink / SSH / Credential / HTTP DTO / MyBatis PO 引入 Core Domain；
+- 不为了和 offline-sync 目录一致提前抽 Shared Sync Kernel。
+
 ## 修改代码前后
 
 修改前先确认 `REQUIREMENTS.md` 中已有对应能力，再写一个短块：
@@ -107,8 +155,18 @@ multi-instance reconcile lease
 Domain Impact Analysis
 - Aggregate(s):
 - Invariant/lifecycle impact:
-- Layer:
+- Layer / subsystem:
 - Domain Gap: yes/no
+```
+
+涉及 package / role / dependency 调整时，再回答：
+
+```text
+Architecture Impact Analysis
+- Target subsystem:
+- Stable entry / gateway:
+- Runtime truth owner:
+- Dependency direction changed: yes/no
 ```
 
 修改后写：
@@ -139,7 +197,9 @@ Framework-free core domain smoke
 
 完整 Maven/JUnit 深层回归依赖 private `yak-framework`；配置 `YAK_FRAMEWORK_TOKEN` 后自动启用。
 
-**不要因为功能被护栏拦住就删护栏。** 如果规则真的变化，同一个 PR 中同步修改 `DOMAIN.md`、`DECISIONS.md`（如需要）和对应测试/guard。
+**不要因为功能或结构调整被护栏拦住就删护栏。** 如果规则真的变化，同一个 PR 中同步修改当前 contract 文档和对应测试 / guardrail。
+
+当前 `RealtimeArchitectureTest` 是迁移期间的基础安全网；完整 package dependency graph 与 explicit corridor guardrails 在目标 package 结构稳定后补齐，不应在结构尚未收敛时提前把临时依赖固化成永久白名单。
 
 ## 已知独立 Gap
 
@@ -152,4 +212,4 @@ Compute Environment physical context cleanup
 API v2 / physical schema naming cleanup
 ```
 
-更多当前模型说明见 `docs/realtime-sync/domain/README.md`；关键决策原因见 `docs/realtime-sync/domain/DECISIONS.md`。
+这些 Gap 需要单独做 Requirement / Domain 设计，不在纯架构重构中顺手解决。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/README.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/README.md
@@ -1,12 +1,76 @@
 # Realtime Sync
 
-> 开发 / AI 修改本模块前：先读 [`REQUIREMENTS.md`](./REQUIREMENTS.md) 和 [`DOMAIN.md`](./DOMAIN.md)。  
-> Review 本模块代码：按 [`REVIEW.md`](./REVIEW.md) 执行。  
-> 当前领域规则以 `DOMAIN.md` 为准；本 README 维护运行环境与运维约束。
+Realtime Sync 是 Yak Ops 的持续数据同步控制面，负责定义同步任务、发布不可变版本、控制运行实例，并查看运行状态和基础可观测信息。
+
+## Read First
+
+本目录只维护**当前有效 contract**，历史设计与迁移过程以 Git / PR 为准。
+
+建议按顺序阅读：
+
+| Document | Answers |
+| --- | --- |
+| [`REQUIREMENTS.md`](./REQUIREMENTS.md) | 模块需要什么 |
+| [`DOMAIN.md`](./DOMAIN.md) | 哪些领域规则不能违反 |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 代码要收敛到什么边界、角色如何协作 |
+| [`REVIEW.md`](./REVIEW.md) | PR 按什么标准判卷 |
+
+当前 `service/` package 与职责较宽的 `RealtimeJobService` 属于待迁移工程结构。后续重构以 `ARCHITECTURE.md` 为目标，但不得借结构调整改变现有 REST / DB / Domain runtime behavior。
+
+## Core Model
+
+```text
+RealtimeSyncTask
+      │ publish
+      ▼
+DefinitionVersion (immutable)
+      │ start / restart / apply
+      ▼
+SyncExecution
+```
+
+核心关系：
+
+```text
+Task != DefinitionVersion != SyncExecution
+```
+
+`SyncDefinition` 是唯一配置事实；Wizard、Yak YAML、HTTP DTO、DB JSON、Flink YAML 都只是 Adapter / Projection。
+
+## Runtime Truth
+
+```text
+RealtimeSyncTask            = long-lived task identity + draft/published references
+DefinitionVersion           = immutable published definition truth
+SyncExecution               = execution lifecycle truth
+RuntimeEnvironmentSnapshot  = execution-time environment truth
+Runtime Identity            = external recovery identity
+Task latest/last-*          = projection / compatibility only
+Flink Job                    = external runtime evidence
+```
+
+运行状态不能重新回到 Task compatibility 字段；`UNKNOWN / CONFLICT` 不能当成 FAILED 猜测处理，必须先 Reconcile。
+
+## Compute Environment
 
 实时同步控制面以 **Compute Environment** 作为唯一运行时配置来源。任务在创建时必须绑定一个已启用的运行环境；每次部署都会保存不可变的运行环境快照，后续修改默认环境或环境配置不会把历史部署重定向到其他 Flink 集群。
 
-## 基线约束
+在 **设置 → 计算引擎** 中维护 Flink CDC 运行环境。当前支持两种提交方式：
+
+- `LOCAL`：Yak Ops 与 Flink CDC CLI 位于同一执行环境，通过本地 `ProcessBuilder` 调用 `flink-cdc.sh`。
+- `SSH`：Yak Ops 可以运行在 Windows 或其他机器，通过本机 OpenSSH 客户端连接 Linux 执行节点，在远端调用 `flink-cdc.sh`。
+
+运行环境保存：
+
+- Flink REST URL；
+- Flink Home / Flink CDC Home / Java Home；
+- Flink / Flink CDC 版本；
+- `LOCAL` 或 `SSH` 提交方式；
+- SSH 提交节点配置（SSH 模式）。
+
+应用级 `yak.sync.realtime` 配置只负责控制面自身行为，例如工作目录、HTTP/提交超时、日志上限和 reconcile 参数。任务生命周期不再通过 application.yml 猜测运行环境。
+
+## Baseline
 
 实时同步当前只维护一个 Flyway 基线：
 
@@ -25,24 +89,7 @@ db/migration/yak-realtime-sync/V1__create_realtime_sync.sql
 
 Pipeline YAML 只在发布/启动时根据任务 Spec 编译，并在提交边界短暂存在。数据库保存结构化 Spec、摘要、部署环境快照和运行标识，不保存带凭据的提交 YAML。
 
-## 运行环境
-
-在 **设置 → 计算引擎** 中维护 Flink CDC 运行环境。当前支持两种提交方式：
-
-- `LOCAL`：Yak Ops 与 Flink CDC CLI 位于同一执行环境，通过本地 `ProcessBuilder` 调用 `flink-cdc.sh`。
-- `SSH`：Yak Ops 可以运行在 Windows 或其他机器，通过本机 OpenSSH 客户端连接 Linux 执行节点，在远端调用 `flink-cdc.sh`。
-
-运行环境保存：
-
-- Flink REST URL；
-- Flink Home / Flink CDC Home / Java Home；
-- Flink / Flink CDC 版本；
-- `LOCAL` 或 `SSH` 提交方式；
-- SSH 提交节点配置（SSH 模式）。
-
-应用级 `yak.sync.realtime` 配置只负责控制面自身行为，例如工作目录、HTTP/提交超时、日志上限和 reconcile 参数。任务生命周期不再通过 application.yml 猜测运行环境。
-
-## SSH 模式
+## SSH Mode
 
 推荐使用 OpenSSH key 或 ssh-agent，Yak Ops 不保存 SSH 登录密码。SSH 用户不需要 root 权限，但至少需要：
 
@@ -63,21 +110,23 @@ Windows / Yak Ops
                                      └─ Flink cluster
 ```
 
-## Pipeline YAML 安全边界
+## Pipeline YAML Security Boundary
 
 SSH 模式不会在 Yak Ops 本地创建包含数据源密码的 Pipeline YAML 文件：
 
 ```text
-Yak Ops 内存中的 Pipeline YAML
+Yak Ops memory Pipeline YAML
   -> OpenSSH stdin
-  -> Linux mktemp 临时文件（umask 077）
+  -> Linux mktemp temporary file (umask 077)
   -> flink-cdc.sh
-  -> trap 自动删除远端临时文件
+  -> trap cleanup
 ```
 
 LOCAL 模式只在应用工作目录创建提交期临时 YAML，提交结束后立即删除。两种模式都只长期保留脱敏后的提交 stdout/stderr。
 
-## Runtime identity 与状态恢复
+Credential 只允许在提交边界短暂解析和使用；不得长期进入 SyncDefinition、DefinitionVersion、RuntimeEnvironmentSnapshot 或日志。
+
+## Runtime Identity And Recovery
 
 每次部署在进入 Flink CDC CLI 之前都会持久化确定性的 runtime job name：
 
@@ -85,11 +134,11 @@ LOCAL 模式只在应用工作目录创建提交期临时 YAML，提交结束后
 REQUIRED -> BOUND -> CLI submit
 ```
 
-如果提交结果不确定或 Yak Ops 在 JobId 落库前退出，reconcile 会使用该 runtime identity 精确查找 Flink Job。新基线不存在旧部署的 `LEGACY` 分支，也不会按用户可见任务名猜测 JobId。
+如果提交结果不确定或 Yak Ops 在 JobId 落库前退出，Reconcile 使用该 runtime identity 精确查找 Flink Job。新基线不存在旧部署的 `LEGACY` 分支，也不会按用户可见任务名猜测 JobId。
 
 多实例 reconcile 通过 `yak_realtime_runtime_lease` 抢占租约，确保同一时刻只有一个实例执行全局对账。
 
-## 可观测性
+## Observability
 
 当前页面统一使用：
 
@@ -99,13 +148,32 @@ REQUIRED -> BOUND -> CLI submit
 
 旧的 `/logs`、`/checkpoints`、`/metrics` 兼容接口不再作为当前 API 使用。
 
-## 不包含的能力
+Observability 属于 read side：可以组合本地持久化与 Flink REST 事实，但不能拥有 Start / Stop / Restart / Apply / Reconcile 的状态迁移。
 
-当前 SSH 模式只解决远程执行 Flink CDC CLI，不包含：
+## Out Of Scope
 
+当前模块不负责：
+
+- 启动、扩缩容或管理 Flink Cluster 生命周期；
 - SSH 隧道代理 Flink REST；
 - Runtime Agent / 常驻远端进程；
 - SSH 密码托管；
-- JobManager/TaskManager 日志文件通过 SSH 下载。
+- JobManager/TaskManager 日志文件通过 SSH 下载；
+- 通用工作流编排；
+- 通用 ETL / 任意复杂转换引擎；
+- 数据血缘计算；
+- Connector 工程的构建和部署管理。
 
 如果 Yak Ops 无法直接访问 Flink REST，应通过内网网络、反向代理或安全网关解决 REST 可达性。
+
+## Engineering Rule
+
+新增或移动代码前至少回答：
+
+1. 属于 Definition、Execution、Reconcile、Observability、Environment、Engine 还是 Persistence？
+2. 是什么 role？
+3. 谁拥有它读写的 runtime truth？
+4. 允许从哪个 Facade / Gateway 进入？
+5. 哪个测试证明改动没有破坏现有 contract？
+
+答不清楚时，先看 `DOMAIN.md + ARCHITECTURE.md`，不要创建新的 `Common / Helper / Utils` 大桶。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/REVIEW.md
@@ -9,9 +9,12 @@
 ```text
 REQUIREMENTS.md  -> 模块需要什么
 DOMAIN.md        -> 实现不能违反什么
+ARCHITECTURE.md  -> 代码边界与角色要收敛到哪里
 REVIEW.md        -> 按什么标准判卷
 PR diff / tests  -> 实际改了什么
 ```
+
+如果 PR 是纯 package move / rename / class split，也必须同时检查 Domain 和 Architecture；“只是重构”不能成为绕过运行安全规则的理由。
 
 ## Review 顺序
 
@@ -58,7 +61,39 @@ Domain Violation
 Domain Gap
 ```
 
-### 3. Correctness
+### 3. Architecture Alignment
+
+检查 `ARCHITECTURE.md`。当前允许 `service/` 作为迁移期 package，但新的代码和拆分方向必须向业务子系统收敛。
+
+重点关注：
+
+- 新类是否能明确归属 Definition / Execution / Reconcile / Observability / Environment / Engine / Persistence；
+- 是否继续向顶层 `service/` 增加宽泛职责；
+- Controller 是否依赖稳定 Application Facade，而不是内部 Coordinator / Manager / Repository / Engine；
+- `@Service` 是否被滥用于内部专业角色；
+- Query / Observability 是否开始承担 command 状态迁移；
+- Reconcile 是否仍使用明确 runtime identity / environment snapshot，而不是猜外部 Job；
+- Repository contract 是否泄漏 DAO / PO / Controller DTO；
+- Domain 是否依赖 Spring / Jackson / MyBatis / Flink / SSH；
+- Compatibility mapper / facade 是否重新进入 Core Domain；
+- 是否为了减少重复提前抽 realtime/offline Shared Sync Kernel；
+- package move 是否同时改变 REST / DB / Domain behavior，导致 PR 难以独立 review / rollback。
+
+出现明确违反目标架构且会形成新的长期耦合时，报告：
+
+```text
+Architecture Violation
+```
+
+如果当前目标架构无法表达真实需求，先报告：
+
+```text
+Architecture Gap
+```
+
+不要通过新增 `Helper / Common / Utils / Base` 绕过边界。
+
+### 4. Correctness
 
 检查真实错误，不做泛泛而谈：
 
@@ -72,7 +107,7 @@ Domain Gap
 - Start / Stop / Reconcile / Restart / Apply 的竞态；
 - 快照、版本、外部 JobId 是否可能错配。
 
-### 4. Compatibility
+### 5. Compatibility
 
 检查是否破坏：
 
@@ -83,9 +118,9 @@ Domain Gap
 - 前端调用；
 - 已存在运行实例或版本记录。
 
-破坏性变更必须有明确迁移方案，禁止 Big-Bang 修改。
+破坏性变更必须有明确迁移方案，禁止借架构重构做 Big-Bang contract change。
 
-### 5. Safety
+### 6. Safety
 
 重点检查：
 
@@ -94,10 +129,12 @@ Domain Gap
 - `UNKNOWN / CONFLICT`；
 - runtime identity 恢复；
 - RuntimeEnvironmentSnapshot；
+- replacement-stop reservation；
+- prepared version re-check；
 - 密码 / Secret 是否落库或进日志；
 - 提交临时文件是否安全清理。
 
-### 6. Tests / Guardrails
+### 7. Tests / Guardrails
 
 每个 P0 / P1 问题都回答：
 
@@ -105,7 +142,53 @@ Domain Gap
 现有哪个测试应该挡住？
 ```
 
-如果没有，指出缺失测试。优先补能锁住领域行为的回归测试，不为了覆盖率堆测试。
+如果没有，指出缺失测试。优先补能锁住领域行为和架构边界的回归测试，不为了覆盖率堆测试。
+
+迁移期间：
+
+- `RealtimeArchitectureTest` 继续作为基础边界安全网；
+- Domain guardrail 不得因为 package move 被删除；
+- 当 Definition / Execution / Reconcile 等目标 package 稳定后，再逐步补完整 dependency graph / corridor tests；
+- 不要提前把临时 `service/` 依赖写成永久 architecture whitelist。
+
+## Refactor PR Rules
+
+纯结构重构默认遵守：
+
+```text
+一个 PR 一个主要边界
+package move / class split / behavior change 尽量分开
+不顺手改 REST / DB / Flyway / Domain semantics
+不长期保留新旧双入口
+先有行为回归测试，再拆 Execution 高风险路径
+```
+
+好的重构 PR 应让 reviewer 快速回答：
+
+```text
+为什么拆？
+目标 subsystem / role 是什么？
+runtime truth owner 有没有变化？
+public contract 有没有变化？
+哪个测试证明行为没变？
+```
+
+### Domain / Architecture Impact block
+
+涉及核心结构调整的 PR 建议在描述中包含：
+
+```text
+Domain Impact Analysis
+- Aggregate(s):
+- Invariant/lifecycle impact:
+- Domain Gap: yes/no
+
+Architecture Impact Analysis
+- Target subsystem:
+- Stable entry / gateway:
+- Runtime truth owner:
+- Dependency direction changed: yes/no
+```
 
 ## 严重级别
 
@@ -121,13 +204,14 @@ P1 Must Fix
 - 违反 REQUIREMENTS.md / DOMAIN.md
 - 明确并发、幂等、事务、兼容性缺陷
 - 高概率导致运行故障
+- 引入明确的长期架构越界并破坏稳定边界
 
 P2 Suggestion
 - 有明确收益的可维护性、性能或测试改进
-- 不阻塞合并
+- 非阻塞架构收敛建议
 ```
 
-纯命名、格式、个人风格偏好不要作为问题提交，除非会造成真实歧义或风险。
+纯命名、格式、个人风格偏好不要作为问题提交，除非会造成真实歧义或边界风险。
 
 ## 每个问题必须有证据
 
@@ -136,8 +220,8 @@ P2 Suggestion
 ```text
 位置：文件 / 行或方法
 级别：P0 / P1 / P2
-依据：Requirement / Domain rule / correctness fact
-场景：什么输入或并发顺序会触发
+依据：Requirement / Domain / Architecture / correctness fact
+场景：什么输入、依赖关系或并发顺序会触发
 风险：会造成什么结果
 建议：修复方向，不必替作者重写整段代码
 测试：应补或应命中的测试
@@ -167,6 +251,9 @@ Conclusion: PASS | CHANGES_REQUIRED
 ## Domain Gap
 无 / 说明
 
+## Architecture Gap
+无 / 说明
+
 ## Missing Tests
 无 / 说明
 ```
@@ -176,4 +263,4 @@ Conclusion: PASS | CHANGES_REQUIRED
 - 有 P0 / P1 -> `CHANGES_REQUIRED`。
 - 只有 P2 -> 可以 `PASS`，P2 不阻塞。
 - 没发现真实问题 -> 直接 `PASS`，不要为了显得有价值硬凑问题。
-- Review 结论只基于当前需求、领域规则、代码事实和可复现风险，不猜未来需求。
+- Review 结论只基于当前需求、领域规则、架构 contract、代码事实和可复现风险，不猜未来需求。


### PR DESCRIPTION
## Summary

完成 Realtime Sync Apache-style 重构的 Stage 1：**Contract Freeze**。

本 PR 只调整实时同步模块长期文档，不修改 Java、REST、DB、Flyway 或 runtime behavior。目标是在开始拆 `service/`、`RealtimeJobService` 和执行链路之前，先把需求、领域、目标架构与 Review 规则对齐，避免后续重构过程中重新发明边界或把临时结构固化成永久架构。

## Scope

本次只变更 4 个文档：

```text
yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/
├── ARCHITECTURE.md   # new
├── DOMAIN.md
├── README.md
└── REVIEW.md
```

`REQUIREMENTS.md` 当前已经是干净的现行需求 contract，本轮不为凑改动重复改写。

## Architecture contract

新增 `ARCHITECTURE.md`，明确 Realtime Sync 后续工程结构向业务子系统收敛：

```text
controller
definition
execution
  ├── query
  └── adapter
reconcile
observability
environment
engine
repository
dao
domain
config
```

当前顶层 `service/` 与职责较宽的 `RealtimeJobService` 被明确标记为 **transitional engineering structure**，不是未来稳定架构。

### Stable application entries

目标 Application Facade：

```text
RealtimeJobDefinitionService
RealtimeJobExecutionService
RealtimeJobQueryService
RealtimeObservabilityService
ComputeEnvironmentService
```

后续 Controller / background entry 应通过稳定 Facade / Gateway 进入，不直接依赖内部 Coordinator / Manager / Repository / Engine 实现。

### Truth ownership

架构文档与现有 Domain contract 对齐：

```text
RealtimeSyncTask        = long-lived task context
DefinitionVersion       = immutable published definition truth
SyncExecution           = runtime lifecycle truth
RuntimeEnvironmentSnapshot = execution-time environment truth
Runtime Identity        = external recovery identity
Flink Job               = external runtime evidence
```

核心关系保持：

```text
Task != DefinitionVersion != SyncExecution
```

## Domain cleanup

`DOMAIN.md` 本轮不改变 12 条核心领域规则，只做 contract 收敛：

- 增加 `ARCHITECTURE.md` 在文档体系中的职责；
- 明确 Runtime Truth 与 compatibility mirror 的边界；
- 明确 Compatibility 只能停在旧协议 / 持久化边界；
- 增加 Architecture Impact Analysis；
- 删除已经失效的 `docs/realtime-sync/domain/*` 引用；
- 明确现有 `RealtimeArchitectureTest` 是迁移期安全网，完整 package dependency graph / corridor guardrails 等结构稳定后再固化。

## README cleanup

README 调整为模块入口 + 运维约束：

```text
REQUIREMENTS.md -> what
DOMAIN.md       -> invariants
ARCHITECTURE.md -> target boundaries
REVIEW.md       -> review rules
```

保留并重新整理现有：

- Compute Environment；
- LOCAL / SSH；
- Flyway baseline；
- Pipeline YAML secret boundary；
- runtime identity / reconcile；
- observability；
- out-of-scope。

## Review contract

`REVIEW.md` 新增 Architecture Alignment：

- 新类必须有明确 subsystem / role；
- 不继续向 `service/` 增加宽泛职责；
- Controller 只面向稳定 Application Boundary；
- Query / Observability 不承担 command truth；
- Reconcile 不按任务名猜 Flink Job；
- Repository 不泄漏 DAO / PO / Controller DTO；
- Domain 不依赖 Spring / Jackson / MyBatis / Flink / SSH；
- 不通过 `Helper / Common / Utils / Base` 绕过边界；
- 不提前抽 realtime/offline Shared Sync Kernel；
- package move / class split / behavior change 尽量分 PR。

同时增加 `Architecture Gap` 与 refactor PR 自查规则。

## Intentionally unchanged

本 PR **不改变**：

- Task / DefinitionVersion / SyncExecution 领域语义；
- Draft / Publish / Start / Stop / RestartExecution / ApplyPublishedVersion / Reconcile 行为；
- Idempotency-Key / reservation / stop-during-start / UNKNOWN / CONFLICT contract；
- RuntimeEnvironmentSnapshot / runtime identity；
- REST API / DTO / VO；
- DB / Flyway；
- Yak YAML contract；
- Flink / Flink CDC / SSH 实现；
- Repository / DAO contract；
- Java package 或类名。

## Validation

创建 PR 前静态核对：

```text
base: main @ c81433b96cfe2016fb7edf696b522ff446009a36
branch: docs/realtime-sync-stage1-contract-freeze
ahead: 4
behind: 0
changed files: 4
document files: 4
Java changes: 0
SQL / Flyway changes: 0
```

本轮为纯文档 contract freeze，不声称执行 Maven/JUnit。

## Next

Stage 2 再单独补 Start / Stop / Restart / Apply / Reconcile / Idempotency / UNKNOWN / CONFLICT 等高风险行为回归基线；在行为锁死之前，不开始大规模拆 `RealtimeJobService`。