### PR TITLE
test(realtime-sync): lock stage 2 execution safety baseline

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionCommandSafetyBaselineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeExecutionCommandSafetyBaselineTest.java
@@ -1,0 +1,425 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.MatchMode;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.RestartPolicy;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.SchemaEvolution;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.SinkTuning;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec.TableRoute;
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpecValidator;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler;
+import io.yak.ops.business.sync.realtime.engine.PipelineYamlCompiler.CompiledPipeline;
+import io.yak.ops.business.sync.realtime.engine.RealtimeConnectorCapabilityResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeDataSourceResolver;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineException;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.RuntimeStatus;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway.ValidationResult;
+import io.yak.ops.business.sync.realtime.engine.ResolvedCdcPipeline;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+/**
+ * Stage 2 regression baseline for execution commands.
+ *
+ * <p>These tests intentionally exercise the current public application boundary before Stage 3
+ * starts splitting RealtimeJobService. They protect safety semantics, not the current class layout.
+ */
+class RealtimeExecutionCommandSafetyBaselineTest {
+
+  private static final long TASK_ID = 7L;
+  private static final long OTHER_TASK_ID = 8L;
+  private static final long EXECUTION_ID = 19L;
+  private static final long V3_ID = 31L;
+  private static final long V4_ID = 32L;
+  private static final String FLINK_JOB_ID = "0123456789abcdef0123456789abcdef";
+
+  private RealtimeJobStore store;
+  private RealtimeDataSourceResolver dataSourceResolver;
+  private PipelineYamlCompiler compiler;
+  private RealtimeEngineGateway gateway;
+  private RealtimeRuntimeResolver runtimeResolver;
+  private RealtimeJobService service;
+  private CdcPipelineSpec spec;
+  private ComputeEnvironmentSnapshot environment;
+  private DefinitionRow task;
+  private PublishedDefinitionRow published;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    CdcPipelineSpecValidator specValidator = mock(CdcPipelineSpecValidator.class);
+    dataSourceResolver = mock(RealtimeDataSourceResolver.class);
+    RealtimeConnectorCapabilityResolver capabilityResolver =
+        mock(RealtimeConnectorCapabilityResolver.class);
+    compiler = mock(PipelineYamlCompiler.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenAnswer(ignored -> new SimpleTransactionStatus());
+
+    environment = environment();
+    spec = spec();
+    task = task();
+    published = version(V4_ID, 4);
+
+    ObjectMapper json = new ObjectMapper();
+    ObjectNode capabilities = json.createObjectNode().put("runtimeVersion", "flink-cdc-cli-3.6.0");
+    ResolvedCdcPipeline resolved = mock(ResolvedCdcPipeline.class);
+
+    when(store.definition(TASK_ID)).thenReturn(Optional.of(task));
+    when(store.publishedDefinition(TASK_ID)).thenReturn(Optional.of(published));
+    when(store.deploymentByIdempotencyKey(any())).thenReturn(Optional.empty());
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.empty());
+    when(store.lockDefinition(TASK_ID)).thenReturn(task);
+    when(runtimeResolver.environment(anyLong(), eq(true))).thenReturn(environment);
+    when(runtimeResolver.deployment(any(), any())).thenReturn(environment);
+    when(dataSourceResolver.resolve(spec)).thenReturn(resolved);
+    when(gateway.capabilities(environment)).thenReturn(capabilities);
+    when(gateway.validate(eq(environment), any()))
+        .thenReturn(new ValidationResult(true, "exactly-once"));
+    when(compiler.compile(any(), eq(spec), eq(resolved)))
+        .thenReturn(new CompiledPipeline("pipeline: baseline", "baseline"));
+
+    service =
+        new RealtimeJobService(
+            store,
+            json,
+            specValidator,
+            new SyncExecutionStateMachine(),
+            dataSourceResolver,
+            capabilityResolver,
+            compiler,
+            gateway,
+            runtimeResolver,
+            transactionManager);
+  }
+
+  @Test
+  void sameIdempotencyKeyReturnsExistingExecutionWithoutResubmitting() {
+    DeploymentRow existing =
+        execution(
+            TASK_ID,
+            V4_ID,
+            "same-key",
+            FLINK_JOB_ID,
+            DesiredState.RUNNING,
+            ObservedState.RUNNING,
+            false,
+            null,
+            null,
+            null);
+    when(store.deploymentByIdempotencyKey("same-key")).thenReturn(Optional.of(existing));
+
+    assertThatCode(() -> service.start(TASK_ID, "same-key")).doesNotThrowAnyException();
+
+    verify(store).deploymentView(existing);
+    verify(store, never()).publishedDefinition(TASK_ID);
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).validate(any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
+  void idempotencyKeyOwnedByAnotherTaskIsRejectedBeforeAnySubmit() {
+    DeploymentRow foreign =
+        execution(
+            OTHER_TASK_ID,
+            V4_ID,
+            "shared-key",
+            FLINK_JOB_ID,
+            DesiredState.RUNNING,
+            ObservedState.RUNNING,
+            false,
+            null,
+            null,
+            null);
+    when(store.deploymentByIdempotencyKey("shared-key")).thenReturn(Optional.of(foreign));
+
+    assertThatThrownBy(() -> service.start(TASK_ID, "shared-key"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("幂等键已被其他实时任务使用");
+
+    verify(store, never()).publishedDefinition(TASK_ID);
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
+  void unknownExecutionBlocksAnotherStartAtApplicationBoundary() {
+    DeploymentRow unknown =
+        execution(
+            TASK_ID,
+            V3_ID,
+            "old-key",
+            null,
+            DesiredState.RUNNING,
+            ObservedState.UNKNOWN,
+            true,
+            null,
+            null,
+            null);
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(unknown));
+
+    assertThatThrownBy(() -> service.start(TASK_ID, "start-after-unknown"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
+  void conflictExecutionBlocksAnotherStartAtApplicationBoundary() {
+    DeploymentRow conflict =
+        execution(
+            TASK_ID,
+            V3_ID,
+            "old-key",
+            null,
+            DesiredState.RUNNING,
+            ObservedState.CONFLICT,
+            false,
+            null,
+            null,
+            null);
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(conflict));
+
+    assertThatThrownBy(() -> service.start(TASK_ID, "start-after-conflict"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("请勿重复启动");
+
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
+  void stopWithUnknownRuntimePreservesUnknownAndNeverPretendsStopped() {
+    DeploymentRow running =
+        execution(
+            TASK_ID,
+            V3_ID,
+            "running-key",
+            FLINK_JOB_ID,
+            DesiredState.RUNNING,
+            ObservedState.RUNNING,
+            false,
+            null,
+            null,
+            null);
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(running));
+    when(gateway.status(environment, FLINK_JOB_ID))
+        .thenReturn(new RuntimeStatus(FLINK_JOB_ID, RuntimeStatus.State.UNKNOWN));
+
+    assertThatThrownBy(() -> service.stop(TASK_ID))
+        .isInstanceOf(RealtimeEngineException.class)
+        .hasMessageContaining("Flink 状态未知");
+
+    verify(store).markStopping(TASK_ID, EXECUTION_ID);
+    verify(store)
+        .reconcile(
+            TASK_ID,
+            EXECUTION_ID,
+            "UNKNOWN",
+            "UNKNOWN",
+            FLINK_JOB_ID,
+            "Flink 状态未知，无法确认停止结果");
+    verify(store, never())
+        .reconcile(TASK_ID, EXECUTION_ID, "STOPPED", "STOPPED", FLINK_JOB_ID, null);
+  }
+
+  @Test
+  void pendingReplacementRequiresItsOriginalIdempotencyKey() {
+    DeploymentRow pendingApply = pendingApply("apply-original");
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(pendingApply));
+
+    assertThatThrownBy(() -> service.applyPublishedVersion(TASK_ID, "apply-other"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("使用原 Idempotency-Key");
+
+    verify(store, never()).definitionVersion(anyLong(), anyLong());
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
+  void pendingApplyCannotBeResumedAsRestartEvenWithTheSameKey() {
+    DeploymentRow pendingApply = pendingApply("apply-original");
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(pendingApply));
+
+    assertThatThrownBy(() -> service.restartExecution(TASK_ID, "apply-original"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("另一种版本替换命令");
+
+    verify(store, never()).definitionVersion(anyLong(), anyLong());
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+    verify(gateway, never()).deploy(any(), any());
+  }
+
+  @Test
+  void restartPinsTheCurrentExecutionVersionInsteadOfReadingLatestPublishedVersion() {
+    DeploymentRow runningV3 =
+        execution(
+            TASK_ID,
+            V3_ID,
+            "running-v3",
+            FLINK_JOB_ID,
+            DesiredState.RUNNING,
+            ObservedState.RUNNING,
+            false,
+            null,
+            null,
+            null);
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(runningV3));
+    when(store.definitionVersion(TASK_ID, V3_ID))
+        .thenThrow(new IllegalStateException("same-version-target-reached"));
+
+    assertThatThrownBy(() -> service.restartExecution(TASK_ID, "restart-pin"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("same-version-target-reached");
+
+    verify(store).definitionVersion(TASK_ID, V3_ID);
+    verify(store, never()).publishedDefinition(TASK_ID);
+    verify(store, never()).insertDeployment(any(), any(), any(), any(), any(), any());
+  }
+
+  private DeploymentRow pendingApply(String key) {
+    return execution(
+        TASK_ID,
+        V3_ID,
+        "running-v3",
+        FLINK_JOB_ID,
+        DesiredState.STOPPED,
+        ObservedState.STOPPED,
+        false,
+        "APPLY_PUBLISHED_VERSION",
+        V4_ID,
+        key);
+  }
+
+  private DeploymentRow execution(
+      long taskId,
+      long definitionVersionId,
+      String idempotencyKey,
+      String engineJobId,
+      DesiredState desired,
+      ObservedState observed,
+      boolean uncertain,
+      String replacementCommand,
+      Long replacementTarget,
+      String replacementKey) {
+    LocalDateTime now = LocalDateTime.now();
+    return new DeploymentRow(
+        EXECUTION_ID,
+        taskId,
+        definitionVersionId,
+        3,
+        spec,
+        "baseline",
+        "d".repeat(64),
+        idempotencyKey,
+        engineJobId,
+        environment.runtimeRevision(),
+        environment,
+        "FLINK_CDC",
+        desired.name(),
+        observed.name(),
+        observed.name(),
+        uncertain,
+        null,
+        replacementCommand,
+        replacementTarget,
+        replacementKey,
+        now,
+        now);
+  }
+
+  private DefinitionRow task() {
+    return new DefinitionRow(
+        TASK_ID,
+        "orders-sync",
+        null,
+        spec,
+        environment.id(),
+        "PUBLISHED",
+        "STOPPED",
+        "STOPPED",
+        4,
+        4,
+        V4_ID,
+        "c".repeat(64),
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private PublishedDefinitionRow version(long id, int versionNo) {
+    return new PublishedDefinitionRow(
+        id,
+        TASK_ID,
+        versionNo,
+        versionNo,
+        spec,
+        environment.id(),
+        "a".repeat(64),
+        "b".repeat(64));
+  }
+
+  private static ComputeEnvironmentSnapshot environment() {
+    return new ComputeEnvironmentSnapshot(
+        3L,
+        "test-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
+        2);
+  }
+
+  private static CdcPipelineSpec spec() {
+    return new CdcPipelineSpec(
+        1L,
+        2L,
+        List.of(
+            new TableRoute("orders", "ods_orders", MatchMode.EXACT, List.of("id"))),
+        "initial",
+        SchemaEvolution.EVOLVE,
+        1,
+        60_000,
+        new RestartPolicy("fixed-delay", 3, 10_000),
+        new SinkTuning(3, 1_000, 2_000, 16_777_216, 128, true));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeReconcileSafetyBaselineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeReconcileSafetyBaselineTest.java
@@ -1,0 +1,217 @@
+package io.yak.ops.business.sync.realtime.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import io.yak.ops.business.sync.realtime.engine.FlinkJobDiscoveryClient;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineException;
+import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import io.yak.ops.business.sync.realtime.repository.RealtimeRuntimeIdentityStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+/**
+ * Stage 2 regression baseline for reconciliation.
+ *
+ * <p>The reconciler must converge to explicit UNKNOWN / CONFLICT states when external truth cannot
+ * be identified safely. It must never guess a Flink JobId or turn runtime uncertainty into a false
+ * terminal result.
+ */
+class RealtimeReconcileSafetyBaselineTest {
+
+  private static final long TASK_ID = 7L;
+  private static final long EXECUTION_ID = 19L;
+  private static final long DEFINITION_VERSION_ID = 31L;
+  private static final String RUNTIME_NAME = "yak-rt-orders-v3-e19";
+  private static final String FLINK_JOB_ID = "0123456789abcdef0123456789abcdef";
+
+  private RealtimeJobStore store;
+  private RealtimeRuntimeIdentityStore identityStore;
+  private FlinkJobDiscoveryClient discovery;
+  private RealtimeEngineGateway gateway;
+  private RealtimeRuntimeResolver runtimeResolver;
+  private RealtimeJobLifecycleCoordinator coordinator;
+  private ComputeEnvironmentSnapshot environment;
+  private DefinitionRow task;
+
+  @BeforeEach
+  void setUp() {
+    store = mock(RealtimeJobStore.class);
+    identityStore = mock(RealtimeRuntimeIdentityStore.class);
+    discovery = mock(FlinkJobDiscoveryClient.class);
+    gateway = mock(RealtimeEngineGateway.class);
+    runtimeResolver = mock(RealtimeRuntimeResolver.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenAnswer(ignored -> new SimpleTransactionStatus());
+
+    environment = environment();
+    task = task();
+    when(store.definition(TASK_ID)).thenReturn(Optional.of(task));
+    when(store.lockDefinition(TASK_ID)).thenReturn(task);
+    when(runtimeResolver.deployment(any(), any())).thenReturn(environment);
+
+    RealtimeSyncProperties properties = new RealtimeSyncProperties();
+    properties.setReconcileFailureThreshold(3);
+    coordinator =
+        new RealtimeJobLifecycleCoordinator(
+            store,
+            identityStore,
+            discovery,
+            gateway,
+            runtimeResolver,
+            new SyncExecutionStateMachine(),
+            properties,
+            10,
+            transactionManager);
+  }
+
+  @Test
+  void multipleRuntimeIdentityMatchesBecomeConflictInsteadOfGuessingAJobId() {
+    DeploymentRow starting = execution(null, "RUNNING", "STARTING", "SUBMITTING", false);
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(starting));
+    when(identityStore.findByDeploymentId(EXECUTION_ID)).thenReturn(Optional.of(RUNTIME_NAME));
+    when(discovery.findJobIds(environment, RUNTIME_NAME))
+        .thenReturn(List.of("job-a", "job-b"));
+
+    coordinator.reconcile(TASK_ID);
+
+    verify(store)
+        .reconcile(
+            TASK_ID,
+            EXECUTION_ID,
+            "CONFLICT",
+            "UNKNOWN",
+            null,
+            "runtime job identity 匹配到 2 个 Flink Job，拒绝自动绑定");
+    verify(gateway, never()).status(any(), anyString());
+    verify(gateway, never()).stop(any(), anyString());
+  }
+
+  @Test
+  void stoppingExecutionWithMultipleMatchesStaysUnknownInsteadOfEnteringConflict() {
+    DeploymentRow stopping = execution(null, "STOPPED", "STOPPING", "STOPPING", false);
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(stopping));
+    when(identityStore.findByDeploymentId(EXECUTION_ID)).thenReturn(Optional.of(RUNTIME_NAME));
+    when(discovery.findJobIds(environment, RUNTIME_NAME))
+        .thenReturn(List.of("job-a", "job-b"));
+
+    coordinator.reconcile(TASK_ID);
+
+    verify(store)
+        .reconcile(
+            TASK_ID,
+            EXECUTION_ID,
+            "UNKNOWN",
+            "UNKNOWN",
+            null,
+            "runtime job identity 匹配到 2 个 Flink Job，拒绝自动绑定");
+    verify(gateway, never()).status(any(), anyString());
+  }
+
+  @Test
+  void repeatedEngineFailuresEventuallyMarkRunningExecutionUnknownNotFailed() {
+    DeploymentRow running =
+        execution(FLINK_JOB_ID, "RUNNING", "RUNNING", "RUNNING", false);
+    when(store.reconcileCandidates()).thenReturn(List.of(running));
+    when(store.latestDeployment(TASK_ID)).thenReturn(Optional.of(running));
+    when(gateway.status(environment, FLINK_JOB_ID))
+        .thenThrow(new RealtimeEngineException("REST unavailable", true, null, null));
+
+    coordinator.reconcileAll();
+    coordinator.reconcileAll();
+    coordinator.reconcileAll();
+
+    verify(gateway, times(3)).status(environment, FLINK_JOB_ID);
+    verify(store)
+        .reconcile(
+            TASK_ID,
+            EXECUTION_ID,
+            "UNKNOWN",
+            "UNKNOWN",
+            FLINK_JOB_ID,
+            "Flink 状态不可用：REST unavailable");
+    verify(store, never()).markTerminalFailure(TASK_ID, EXECUTION_ID, "REST unavailable");
+  }
+
+  private DefinitionRow task() {
+    return new DefinitionRow(
+        TASK_ID,
+        "orders-sync",
+        null,
+        null,
+        environment.id(),
+        "PUBLISHED",
+        "RUNNING",
+        "RUNNING",
+        3,
+        3,
+        "c".repeat(64),
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private DeploymentRow execution(
+      String engineJobId,
+      String desiredState,
+      String observedState,
+      String status,
+      boolean uncertain) {
+    LocalDateTime now = LocalDateTime.now();
+    return new DeploymentRow(
+        EXECUTION_ID,
+        TASK_ID,
+        DEFINITION_VERSION_ID,
+        3,
+        null,
+        "baseline",
+        "d".repeat(64),
+        "exec-key",
+        engineJobId,
+        environment.runtimeRevision(),
+        environment,
+        "FLINK_CDC",
+        desiredState,
+        observedState,
+        status,
+        uncertain,
+        null,
+        now,
+        now);
+  }
+
+  private static ComputeEnvironmentSnapshot environment() {
+    return new ComputeEnvironmentSnapshot(
+        3L,
+        "test-env",
+        ComputeEnvironment.ENGINE_FLINK_CDC,
+        ComputeEnvironment.DEPLOYMENT_REMOTE,
+        ComputeEnvironment.SUBMITTER_LOCAL,
+        new RuntimeConfig(
+            "http://127.0.0.1:8081",
+            "/opt/flink",
+            "/opt/flink-cdc",
+            null,
+            "1.20.5",
+            "3.6.0"),
+        2);
+  }
+}


### PR DESCRIPTION
## Summary

完成 Realtime Sync Apache-style 重构的 Stage 2：**Safety Regression Baseline**。

Stage 1 `#679` 已合并，本 PR 现在直接基于 `main`。本轮只新增测试，不修改 Java production code、REST、DB、Flyway 或 runtime behavior。目标是在 Stage 3 开始拆 `RealtimeJobService` / `service/` 之前，把最容易造成重复 Flink Job、错误终态和版本漂移的行为先锁死。

## Scope

只新增 2 个测试文件：

```text
yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/
└── src/test/java/io/yak/ops/business/sync/realtime/service/
    ├── RealtimeExecutionCommandSafetyBaselineTest.java
    └── RealtimeReconcileSafetyBaselineTest.java
```

## Why a dedicated Stage 2

Realtime Sync 当前已经有不少测试，但高风险行为分散在 `RealtimeExecutionPathTest`、`RealtimeJobServiceConcurrencyTest`、`RealtimeReplacementRecoveryTest`、`RealtimeJobLifecycleCoordinatorTest` 等文件中。

Stage 2 不重复已有 Happy Path，而是补齐后续架构拆分前必须稳定的事故级 contract：

```text
Idempotency-Key ownership
UNKNOWN / CONFLICT single-execution safety
stop result uncertainty
Restart same-version pinning
replacement command recovery identity
runtime identity ambiguity
engine outage reconciliation
```

这些测试保护的是领域/运行语义，不保护当前 `RealtimeJobService` 的类布局；Stage 3 拆 Application Facade / Coordinator / Manager 时可以迁移测试入口，但不能改变这些行为。

## Execution command baseline

`RealtimeExecutionCommandSafetyBaselineTest` 新增 8 个场景。

### Idempotency

1. **相同 Idempotency-Key 返回已有 Execution**
   - 不重新读取 Published Version；
   - 不创建第二条 Execution；
   - 不再次 validate / deploy Flink。

2. **Idempotency-Key 不允许跨 Task 复用**
   - key 已属于其他实时任务时直接拒绝；
   - 外部提交前失败。

### Active / uncertain execution

3. **UNKNOWN 阻止第二次 Start**
4. **CONFLICT 阻止第二次 Start**

两者都锁定 `Task != SyncExecution`：只要当前 Execution 仍 Active / Uncertain，就不能创建第二实例。

### Stop uncertainty

5. **Flink RuntimeStatus.UNKNOWN 不能伪装成 STOPPED**
   - 先记录停止意图；
   - 最终本地 Execution 收敛为 `UNKNOWN`；
   - 明确禁止写入假 `STOPPED`。

### Restart / Apply recovery

6. **Pending replacement 只能用原 Idempotency-Key 恢复**
7. **Apply 的 key 不能拿来恢复 Restart 命令**
8. **Restart 固定当前 Execution 的 DefinitionVersion**
   - Restart lookup 使用 running Execution 的 `DefinitionVersionId`；
   - 不读取 current Published Version 隐式升级。

## Reconcile baseline

`RealtimeReconcileSafetyBaselineTest` 新增 3 个场景。

### Runtime identity ambiguity

9. **一个 runtime identity 匹配多个 Flink Job 时进入 CONFLICT**
   - 不猜 JobId；
   - 不继续 status / stop 任意一个候选 Job。

10. **STOPPING 时多匹配保持 UNKNOWN**
    - 不制造不允许的 `STOPPING -> CONFLICT` 语义；
    - 等待后续人工/外部事实收敛。

### Engine outage

11. **连续 Flink REST 失败达到阈值后进入 UNKNOWN，而不是 FAILED**
    - 外部运行时不可达不等于任务执行失败；
    - 保留后续 Reconcile 恢复空间；
    - 不写 terminal failure。

## Protected contracts

```text
Task != DefinitionVersion != SyncExecution
UNKNOWN != FAILED
CONFLICT cannot guess
one Active / Uncertain Execution per Task
RestartExecution keeps the current Execution version
Apply/Restart are different commands
Idempotency-Key has one Task owner
runtime identity ambiguity never chooses an arbitrary Flink Job
engine availability failure is not business execution failure
```

## Intentionally unchanged

本 PR 不改变：

- Start / Stop / RestartExecution / ApplyPublishedVersion / Reconcile production implementation；
- Task / DefinitionVersion / SyncExecution model；
- Idempotency reservation implementation；
- RuntimeEnvironmentSnapshot；
- Flink / Flink CDC / SSH adapter；
- REST / DTO / VO；
- Repository / DAO contract；
- DB / Flyway；
- Yak YAML；
- package / class names。

## Validation

Stage 2 分支相对 Stage 1 contract head：

```text
commits: 2
changed files: 2
new tests: 11
production files: 0
```

Stage 1 已通过 PR #679 合并进 `main`，因此本 PR 已 retarget 到 `main`，最终 Review 应只看到 Stage 2 的测试增量。

尝试在当前执行环境 clone 分支执行 Maven/JUnit，但执行环境无法解析 `github.com`，因此未能进行本地 Maven 运行；本 PR 不把静态检查宣称为测试通过。GitHub 当前也尚未返回本 PR head 的 workflow run。

## Review focus

```text
[ ] 测试锁的是行为 contract，而不是 RealtimeJobService 私有实现
[ ] 相同 key 不会触发第二次 external submit
[ ] UNKNOWN / CONFLICT 不会创建第二 Execution
[ ] Stop uncertainty 不会被写成 STOPPED
[ ] Restart 不会隐式升级到 current Published Version
[ ] Apply / Restart recovery identity 不会串命令
[ ] 多 runtime match 不会猜任意 JobId
[ ] Flink unavailable 不会被误判业务 FAILED
[ ] 没有 production behavior change
```

## Next

Stage 3 再单独开始稳定 Application Entry，优先拆分当前职责过宽的 `RealtimeJobService`，形成 Definition / Execution 等明确入口。Stage 3 必须以本 PR 的安全基线为回归护栏，不在拆结构时顺手改变运行语义。