### PR TITLE
refactor(realtime-sync): establish stage 3 stable application entries

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/ComputeEnvironmentController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/ComputeEnvironmentController.java
@@ -9,7 +9,7 @@ import io.yak.ops.business.sync.realtime.controller.v1.dto.ComputeEnvironmentReq
 import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeRequestMapper;
 import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeViewMapper;
 import io.yak.ops.business.sync.realtime.controller.v1.vo.ComputeEnvironmentViews;
-import io.yak.ops.business.sync.realtime.service.ComputeEnvironmentService;
+import io.yak.ops.business.sync.realtime.environment.ComputeEnvironmentService;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,14 +55,26 @@ public class ComputeEnvironmentController {
   @PostMapping
   @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> create(@RequestBody ComputeEnvironmentRequests.SaveRequest request) {
-    return Result.success(service.create(request.name(), request.submitterType(), requestMapper.toRuntimeConfig(request.config()), request.enabled(), request.makeDefault()));
+    return Result.success(
+        service.create(
+            request.name(),
+            request.submitterType(),
+            requestMapper.toRuntimeConfig(request.config()),
+            request.enabled(),
+            request.makeDefault()));
   }
 
   @Operation(summary = "预检测未保存的运行环境")
   @PostMapping("/diagnose")
   @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<ComputeEnvironmentViews.Diagnosis> diagnosePreview(@RequestBody ComputeEnvironmentRequests.SaveRequest request) {
-    return Result.success(viewMapper.toView(service.diagnosePreview(request.name(), request.submitterType(), requestMapper.toRuntimeConfig(request.config()))));
+  public Result<ComputeEnvironmentViews.Diagnosis> diagnosePreview(
+      @RequestBody ComputeEnvironmentRequests.SaveRequest request) {
+    return Result.success(
+        viewMapper.toView(
+            service.diagnosePreview(
+                request.name(),
+                request.submitterType(),
+                requestMapper.toRuntimeConfig(request.config()))));
   }
 
   @Operation(summary = "检测已保存的运行环境")
@@ -75,15 +87,23 @@ public class ComputeEnvironmentController {
   @Operation(summary = "更新运行环境")
   @PutMapping("/{id}")
   @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Boolean> update(@PathVariable long id, @RequestBody ComputeEnvironmentRequests.SaveRequest request) {
-    service.update(id, request.name(), request.submitterType(), requestMapper.toRuntimeConfig(request.config()), request.enabled(), request.makeDefault());
+  public Result<Boolean> update(
+      @PathVariable long id, @RequestBody ComputeEnvironmentRequests.SaveRequest request) {
+    service.update(
+        id,
+        request.name(),
+        request.submitterType(),
+        requestMapper.toRuntimeConfig(request.config()),
+        request.enabled(),
+        request.makeDefault());
     return Result.success(true);
   }
 
   @Operation(summary = "启用或停用运行环境")
   @PutMapping("/{id}/enabled")
   @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Boolean> setEnabled(@PathVariable long id, @RequestBody ComputeEnvironmentRequests.EnabledRequest request) {
+  public Result<Boolean> setEnabled(
+      @PathVariable long id, @RequestBody ComputeEnvironmentRequests.EnabledRequest request) {
     service.setEnabled(id, request.enabled());
     return Result.success(true);
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
@@ -10,14 +10,11 @@ import io.yak.ops.business.sync.realtime.controller.v1.dto.RealtimeJobRequests;
 import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeRequestMapper;
 import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeViewMapper;
 import io.yak.ops.business.sync.realtime.controller.v1.vo.RealtimeViews;
+import io.yak.ops.business.sync.realtime.definition.RealtimeJobDefinitionService;
 import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
-import io.yak.ops.business.sync.realtime.service.RealtimeEventStreamService;
-import io.yak.ops.business.sync.realtime.service.RealtimeJobLifecycleCoordinator;
-import io.yak.ops.business.sync.realtime.service.RealtimeJobQueryService;
-import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
-import io.yak.ops.business.sync.realtime.service.RealtimeObservabilityService;
-import io.yak.ops.business.sync.realtime.service.RealtimeValidationService;
-import io.yak.ops.business.sync.realtime.service.RealtimeYamlCodec;
+import io.yak.ops.business.sync.realtime.execution.RealtimeJobExecutionService;
+import io.yak.ops.business.sync.realtime.execution.query.RealtimeJobQueryService;
+import io.yak.ops.business.sync.realtime.observability.RealtimeObservabilityService;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
@@ -39,119 +36,224 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/v1/realtime-sync")
 @RequiresPermission(RealtimePermissionCode.READ)
 public class RealtimeJobController {
-  private final RealtimeJobService service;
-  private final RealtimeValidationService validationService;
-  private final RealtimeJobLifecycleCoordinator lifecycleCoordinator;
-  private final RealtimeObservabilityService observabilityService;
+  private final RealtimeJobDefinitionService definitionService;
+  private final RealtimeJobExecutionService executionService;
   private final RealtimeJobQueryService queryService;
-  private final RealtimeEventStreamService eventStream;
+  private final RealtimeObservabilityService observabilityService;
   private final RealtimeRequestMapper requestMapper;
   private final RealtimeViewMapper viewMapper;
-  private final RealtimeYamlCodec yamlCodec;
 
   public RealtimeJobController(
-      RealtimeJobService service,
-      RealtimeValidationService validationService,
-      RealtimeJobLifecycleCoordinator lifecycleCoordinator,
-      RealtimeObservabilityService observabilityService,
+      RealtimeJobDefinitionService definitionService,
+      RealtimeJobExecutionService executionService,
       RealtimeJobQueryService queryService,
-      RealtimeEventStreamService eventStream,
+      RealtimeObservabilityService observabilityService,
       RealtimeRequestMapper requestMapper,
-      RealtimeViewMapper viewMapper,
-      RealtimeYamlCodec yamlCodec) {
-    this.service = service;
-    this.validationService = validationService;
-    this.lifecycleCoordinator = lifecycleCoordinator;
-    this.observabilityService = observabilityService;
+      RealtimeViewMapper viewMapper) {
+    this.definitionService = definitionService;
+    this.executionService = executionService;
     this.queryService = queryService;
-    this.eventStream = eventStream;
+    this.observabilityService = observabilityService;
     this.requestMapper = requestMapper;
     this.viewMapper = viewMapper;
-    this.yamlCodec = yamlCodec;
   }
 
-  @Operation(summary = "创建实时同步基础任务") @PostMapping @RequiresPermission(RealtimePermissionCode.CREATE)
-  public Result<Long> create(@Valid @RequestBody RealtimeJobRequests.CreateRequest request) { return Result.success(service.create(request.name(), request.description(), request.runtimeEnvironmentId())); }
+  @Operation(summary = "创建实时同步基础任务")
+  @PostMapping
+  @RequiresPermission(RealtimePermissionCode.CREATE)
+  public Result<Long> create(@Valid @RequestBody RealtimeJobRequests.CreateRequest request) {
+    return Result.success(
+        definitionService.create(
+            request.name(), request.description(), request.runtimeEnvironmentId()));
+  }
 
-  @Operation(summary = "新建实时同步草稿") @PostMapping("/draft") @RequiresPermission(RealtimePermissionCode.CREATE)
+  @Operation(summary = "新建实时同步草稿")
+  @PostMapping("/draft")
+  @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> draft(@Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
     CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
-    validationService.validateDefinition(spec, request.runtimeEnvironmentId());
-    return Result.success(service.save(null, request.name(), request.description(), spec, request.runtimeEnvironmentId()));
+    return Result.success(
+        definitionService.save(
+            null,
+            request.name(),
+            request.description(),
+            spec,
+            request.runtimeEnvironmentId()));
   }
 
-  @Operation(summary = "校验未保存的实时同步定义") @PostMapping("/spec/validate") @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<RealtimeViews.Validation> validateDefinition(@Valid @RequestBody RealtimeJobRequests.DefinitionValidationRequest request) {
-    return Result.success(viewMapper.toView(validationService.validateDefinition(requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
+  @Operation(summary = "校验未保存的实时同步定义")
+  @PostMapping("/spec/validate")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<RealtimeViews.Validation> validateDefinition(
+      @Valid @RequestBody RealtimeJobRequests.DefinitionValidationRequest request) {
+    return Result.success(
+        viewMapper.toView(
+            definitionService.validateDefinition(
+                requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
   }
 
-  @Operation(summary = "解析 Yak Realtime YAML") @PostMapping("/yaml/parse")
-  public Result<RealtimeViews.PipelineSpec> parseYaml(@Valid @RequestBody RealtimeJobRequests.YamlRequest request) {
-    return Result.success(viewMapper.toView(yamlCodec.parse(request.yaml())));
+  @Operation(summary = "解析 Yak Realtime YAML")
+  @PostMapping("/yaml/parse")
+  public Result<RealtimeViews.PipelineSpec> parseYaml(
+      @Valid @RequestBody RealtimeJobRequests.YamlRequest request) {
+    return Result.success(viewMapper.toView(definitionService.parseYaml(request.yaml())));
   }
 
-  @Operation(summary = "将实时同步 Spec 渲染为 Yak Realtime YAML") @PostMapping("/yaml/render")
-  public Result<Map<String, String>> renderYaml(@Valid @RequestBody RealtimeJobRequests.YamlRenderRequest request) {
-    return Result.success(Map.of("yaml", yamlCodec.render(requestMapper.toSpec(request.spec()))));
+  @Operation(summary = "将实时同步 Spec 渲染为 Yak Realtime YAML")
+  @PostMapping("/yaml/render")
+  public Result<Map<String, String>> renderYaml(
+      @Valid @RequestBody RealtimeJobRequests.YamlRenderRequest request) {
+    return Result.success(
+        Map.of("yaml", definitionService.renderYaml(requestMapper.toSpec(request.spec()))));
   }
 
-  @Operation(summary = "保存实时同步草稿") @PutMapping("/{id}") @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Long> save(@PathVariable long id, @Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
+  @Operation(summary = "保存实时同步草稿")
+  @PutMapping("/{id}")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Long> save(
+      @PathVariable long id, @Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
     CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
-    validationService.validateDefinition(spec, request.runtimeEnvironmentId());
-    return Result.success(service.save(id, request.name(), request.description(), spec, request.runtimeEnvironmentId()));
+    return Result.success(
+        definitionService.save(
+            id,
+            request.name(),
+            request.description(),
+            spec,
+            request.runtimeEnvironmentId()));
   }
 
-  @Operation(summary = "实时同步任务详情") @GetMapping("/{id}")
-  public Result<RealtimeViews.Job> detail(@PathVariable long id) { return Result.success(viewMapper.toView(service.get(id))); }
+  @Operation(summary = "实时同步任务详情")
+  @GetMapping("/{id}")
+  public Result<RealtimeViews.Job> detail(@PathVariable long id) {
+    return Result.success(viewMapper.toView(queryService.detail(id)));
+  }
 
-  @Operation(summary = "实时同步任务分页") @GetMapping
-  public Result<RealtimeViews.Page> page(@RequestParam(defaultValue = "1") int pageNo, @RequestParam(defaultValue = "20") int pageSize, @RequestParam(required = false) String keyword, @RequestParam(required = false) Long id, @RequestParam(required = false) String releaseState, @RequestParam(required = false) String stateGroup) { return Result.success(viewMapper.toView(queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup))); }
+  @Operation(summary = "实时同步任务分页")
+  @GetMapping
+  public Result<RealtimeViews.Page> page(
+      @RequestParam(defaultValue = "1") int pageNo,
+      @RequestParam(defaultValue = "20") int pageSize,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) Long id,
+      @RequestParam(required = false) String releaseState,
+      @RequestParam(required = false) String stateGroup) {
+    return Result.success(
+        viewMapper.toView(
+            queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup)));
+  }
 
-  @Operation(summary = "订阅实时同步任务状态") @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter stream() { return eventStream.subscribe(); }
+  @Operation(summary = "订阅实时同步任务状态")
+  @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter stream() {
+    return observabilityService.subscribe();
+  }
 
-  @Operation(summary = "发布当前定义版本") @PostMapping("/{id}/publish") @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<Boolean> publish(@PathVariable long id) { service.publish(id); return Result.success(true); }
+  @Operation(summary = "发布当前定义版本")
+  @PostMapping("/{id}/publish")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<Boolean> publish(@PathVariable long id) {
+    definitionService.publish(id);
+    return Result.success(true);
+  }
 
-  @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义") @PostMapping("/{id}/validate") @RequiresPermission(RealtimePermissionCode.UPDATE)
-  public Result<RealtimeViews.Validation> validate(@PathVariable long id) { return Result.success(viewMapper.toView(validationService.validate(id))); }
+  @Operation(summary = "使用任务绑定的 Flink CDC 运行环境校验当前定义")
+  @PostMapping("/{id}/validate")
+  @RequiresPermission(RealtimePermissionCode.UPDATE)
+  public Result<RealtimeViews.Validation> validate(@PathVariable long id) {
+    return Result.success(viewMapper.toView(definitionService.validate(id)));
+  }
 
-  @Operation(summary = "启动最新已发布实时同步版本") @PostMapping("/{id}/start") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> start(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.start(id, key))); }
+  @Operation(summary = "启动最新已发布实时同步版本")
+  @PostMapping("/{id}/start")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> start(
+      @PathVariable long id,
+      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
+    return Result.success(viewMapper.toView(executionService.start(id, key)));
+  }
 
-  @Operation(summary = "停止实时同步任务") @PostMapping("/{id}/stop") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<Boolean> stop(@PathVariable long id) { service.stop(id); return Result.success(true); }
+  @Operation(summary = "停止实时同步任务")
+  @PostMapping("/{id}/stop")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<Boolean> stop(@PathVariable long id) {
+    executionService.stop(id);
+    return Result.success(true);
+  }
 
-  @Operation(summary = "重启当前 SyncExecution（保持同一 DefinitionVersion）") @PostMapping("/{id}/restart-execution") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> restartExecution(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.restartExecution(id, key))); }
+  @Operation(summary = "重启当前 SyncExecution（保持同一 DefinitionVersion）")
+  @PostMapping("/{id}/restart-execution")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> restartExecution(
+      @PathVariable long id,
+      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
+    return Result.success(viewMapper.toView(executionService.restartExecution(id, key)));
+  }
 
-  @Operation(summary = "应用最新已发布 DefinitionVersion") @PostMapping("/{id}/apply-published-version") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> applyPublishedVersion(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.applyPublishedVersion(id, key))); }
+  @Operation(summary = "应用最新已发布 DefinitionVersion")
+  @PostMapping("/{id}/apply-published-version")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> applyPublishedVersion(
+      @PathVariable long id,
+      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
+    return Result.success(viewMapper.toView(executionService.applyPublishedVersion(id, key)));
+  }
 
   /** Compatibility endpoint. Semantics are RestartExecution and never upgrade to latest Published. */
   @Deprecated
-  @Operation(summary = "兼容入口：重启当前 SyncExecution") @PostMapping("/{id}/restart") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Deployment> restart(@PathVariable long id, @RequestHeader(value = "Idempotency-Key", required = false) String key) { return Result.success(viewMapper.toView(service.restartExecution(id, key))); }
+  @Operation(summary = "兼容入口：重启当前 SyncExecution")
+  @PostMapping("/{id}/restart")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Deployment> restart(
+      @PathVariable long id,
+      @RequestHeader(value = "Idempotency-Key", required = false) String key) {
+    return Result.success(viewMapper.toView(executionService.restartExecution(id, key)));
+  }
 
-  @Operation(summary = "立即对账实时同步任务") @PostMapping("/{id}/reconcile") @RequiresPermission(RealtimePermissionCode.EXECUTE)
-  public Result<RealtimeViews.Job> reconcile(@PathVariable long id) { return Result.success(viewMapper.toView(lifecycleCoordinator.reconcile(id))); }
+  @Operation(summary = "立即对账实时同步任务")
+  @PostMapping("/{id}/reconcile")
+  @RequiresPermission(RealtimePermissionCode.EXECUTE)
+  public Result<RealtimeViews.Job> reconcile(@PathVariable long id) {
+    return Result.success(viewMapper.toView(executionService.reconcile(id)));
+  }
 
-  @Operation(summary = "删除已停止的实时同步任务") @DeleteMapping("/{id}") @RequiresPermission(RealtimePermissionCode.DELETE)
-  public Result<Boolean> delete(@PathVariable long id) { lifecycleCoordinator.assertSafeToDelete(id); service.delete(id); return Result.success(true); }
+  @Operation(summary = "删除已停止的实时同步任务")
+  @DeleteMapping("/{id}")
+  @RequiresPermission(RealtimePermissionCode.DELETE)
+  public Result<Boolean> delete(@PathVariable long id) {
+    definitionService.delete(id);
+    return Result.success(true);
+  }
 
-  @Operation(summary = "查询任务状态事件") @GetMapping("/{id}/events")
-  public Result<List<RealtimeViews.Event>> events(@PathVariable long id) { return Result.success(service.events(id).stream().map(viewMapper::toView).toList()); }
+  @Operation(summary = "查询任务状态事件")
+  @GetMapping("/{id}/events")
+  public Result<List<RealtimeViews.Event>> events(@PathVariable long id) {
+    return Result.success(
+        observabilityService.events(id).stream().map(viewMapper::toView).toList());
+  }
 
-  @Operation(summary = "查询指定 Flink CDC 运行环境能力") @GetMapping("/runtime/capabilities")
-  public Result<JsonNode> capabilities(@RequestParam long environmentId) { return Result.success(service.capabilities(environmentId)); }
+  @Operation(summary = "查询指定 Flink CDC 运行环境能力")
+  @GetMapping("/runtime/capabilities")
+  public Result<JsonNode> capabilities(@RequestParam long environmentId) {
+    return Result.success(executionService.capabilities(environmentId));
+  }
 
-  @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics") @GetMapping("/{id}/observability")
-  public Result<RealtimeViews.Observability> observability(@PathVariable long id) { return Result.success(viewMapper.toView(observabilityService.snapshot(id))); }
+  @Operation(summary = "查询归一化运行概览、Checkpoint 和 Metrics")
+  @GetMapping("/{id}/observability")
+  public Result<RealtimeViews.Observability> observability(@PathVariable long id) {
+    return Result.success(viewMapper.toView(observabilityService.snapshot(id)));
+  }
 
-  @Operation(summary = "查询 Flink CDC 提交日志") @GetMapping("/{id}/logs/submission")
-  public Result<Map<String, String>> submissionLog(@PathVariable long id, @RequestParam(defaultValue = "500") int tail) { return Result.success(Map.of("logs", observabilityService.submissionLog(id, tail))); }
+  @Operation(summary = "查询 Flink CDC 提交日志")
+  @GetMapping("/{id}/logs/submission")
+  public Result<Map<String, String>> submissionLog(
+      @PathVariable long id, @RequestParam(defaultValue = "500") int tail) {
+    return Result.success(Map.of("logs", observabilityService.submissionLog(id, tail)));
+  }
 
-  @Operation(summary = "查询 Flink 运行异常历史") @GetMapping("/{id}/logs/runtime")
-  public Result<RealtimeViews.RuntimeLog> runtimeLog(@PathVariable long id, @RequestParam(defaultValue = "50") int maxExceptions) { return Result.success(viewMapper.toView(observabilityService.runtimeLog(id, maxExceptions))); }
+  @Operation(summary = "查询 Flink 运行异常历史")
+  @GetMapping("/{id}/logs/runtime")
+  public Result<RealtimeViews.RuntimeLog> runtimeLog(
+      @PathVariable long id, @RequestParam(defaultValue = "50") int maxExceptions) {
+    return Result.success(viewMapper.toView(observabilityService.runtimeLog(id, maxExceptions)));
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/definition/RealtimeJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/definition/RealtimeJobDefinitionService.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.sync.realtime.definition;
+
+import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
+import io.yak.ops.business.sync.realtime.domain.RealtimeValidationResult;
+import io.yak.ops.business.sync.realtime.execution.RealtimeJobExecutionService;
+import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
+import io.yak.ops.business.sync.realtime.service.RealtimeValidationService;
+import io.yak.ops.business.sync.realtime.service.RealtimeYamlCodec;
+import org.springframework.stereotype.Service;
+
+/** Stable application entry for realtime task definition use-cases. */
+@Service("realtimeJobDefinitionApplicationService")
+public class RealtimeJobDefinitionService {
+
+  private final RealtimeJobService jobs;
+  private final RealtimeValidationService validation;
+  private final RealtimeYamlCodec yaml;
+  private final RealtimeJobExecutionService executions;
+
+  public RealtimeJobDefinitionService(
+      RealtimeJobService jobs,
+      RealtimeValidationService validation,
+      RealtimeYamlCodec yaml,
+      RealtimeJobExecutionService executions) {
+    this.jobs = jobs;
+    this.validation = validation;
+    this.yaml = yaml;
+    this.executions = executions;
+  }
+
+  public long create(String name, String description, long runtimeEnvironmentId) {
+    return jobs.create(name, description, runtimeEnvironmentId);
+  }
+
+  public long save(
+      Long id,
+      String name,
+      String description,
+      CdcPipelineSpec spec,
+      long runtimeEnvironmentId) {
+    validation.validateDefinition(spec, runtimeEnvironmentId);
+    return jobs.save(id, name, description, spec, runtimeEnvironmentId);
+  }
+
+  public RealtimeValidationResult validateDefinition(
+      CdcPipelineSpec spec, long runtimeEnvironmentId) {
+    return validation.validateDefinition(spec, runtimeEnvironmentId);
+  }
+
+  public CdcPipelineSpec parseYaml(String source) {
+    return yaml.parse(source);
+  }
+
+  public String renderYaml(CdcPipelineSpec spec) {
+    return yaml.render(spec);
+  }
+
+  public void publish(long id) {
+    jobs.publish(id);
+  }
+
+  public RealtimeValidationResult validate(long id) {
+    return validation.validate(id);
+  }
+
+  public void delete(long id) {
+    executions.assertSafeToDelete(id);
+    jobs.delete(id);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/environment/ComputeEnvironmentService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/environment/ComputeEnvironmentService.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.sync.realtime.environment;
+
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironment.RuntimeConfig;
+import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentDiagnosis;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Stable application entry for realtime compute environment use-cases. */
+@Service("computeEnvironmentApplicationService")
+public class ComputeEnvironmentService {
+
+  private final io.yak.ops.business.sync.realtime.service.ComputeEnvironmentService environments;
+
+  public ComputeEnvironmentService(
+      io.yak.ops.business.sync.realtime.service.ComputeEnvironmentService environments) {
+    this.environments = environments;
+  }
+
+  public List<ComputeEnvironment> list() {
+    return environments.list();
+  }
+
+  public ComputeEnvironment get(long id) {
+    return environments.get(id);
+  }
+
+  public long create(
+      String name,
+      String submitterType,
+      RuntimeConfig config,
+      boolean enabled,
+      boolean makeDefault) {
+    return environments.create(name, submitterType, config, enabled, makeDefault);
+  }
+
+  public ComputeEnvironmentDiagnosis diagnose(long id) {
+    return environments.diagnose(id);
+  }
+
+  public ComputeEnvironmentDiagnosis diagnosePreview(
+      String name, String submitterType, RuntimeConfig config) {
+    return environments.diagnosePreview(name, submitterType, config);
+  }
+
+  public void update(
+      long id,
+      String name,
+      String submitterType,
+      RuntimeConfig config,
+      boolean enabled,
+      boolean makeDefault) {
+    environments.update(id, name, submitterType, config, enabled, makeDefault);
+  }
+
+  public void setEnabled(long id, boolean enabled) {
+    environments.setEnabled(id, enabled);
+  }
+
+  public void setDefault(long id) {
+    environments.setDefault(id);
+  }
+
+  public void delete(long id) {
+    environments.delete(id);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeJobExecutionService.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.sync.realtime.execution;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
+import io.yak.ops.business.sync.realtime.service.RealtimeJobLifecycleCoordinator;
+import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
+import org.springframework.stereotype.Service;
+
+/** Stable application entry for realtime execution lifecycle commands. */
+@Service("realtimeJobExecutionApplicationService")
+public class RealtimeJobExecutionService {
+
+  private final RealtimeJobService jobs;
+  private final RealtimeJobLifecycleCoordinator lifecycle;
+
+  public RealtimeJobExecutionService(
+      RealtimeJobService jobs, RealtimeJobLifecycleCoordinator lifecycle) {
+    this.jobs = jobs;
+    this.lifecycle = lifecycle;
+  }
+
+  public RealtimeJobView.Deployment start(long id, String idempotencyKey) {
+    return jobs.start(id, idempotencyKey);
+  }
+
+  public void stop(long id) {
+    jobs.stop(id);
+  }
+
+  public RealtimeJobView.Deployment restartExecution(long id, String idempotencyKey) {
+    return jobs.restartExecution(id, idempotencyKey);
+  }
+
+  public RealtimeJobView.Deployment applyPublishedVersion(long id, String idempotencyKey) {
+    return jobs.applyPublishedVersion(id, idempotencyKey);
+  }
+
+  public RealtimeJobView reconcile(long id) {
+    return lifecycle.reconcile(id);
+  }
+
+  public void assertSafeToDelete(long id) {
+    lifecycle.assertSafeToDelete(id);
+  }
+
+  public JsonNode capabilities(long runtimeEnvironmentId) {
+    return jobs.capabilities(runtimeEnvironmentId);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/query/RealtimeJobQueryService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/query/RealtimeJobQueryService.java
@@ -1,0 +1,35 @@
+package io.yak.ops.business.sync.realtime.execution.query;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobPage;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
+import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
+import org.springframework.stereotype.Service;
+
+/** Stable application entry for realtime task and execution read models. */
+@Service("realtimeJobQueryApplicationService")
+public class RealtimeJobQueryService {
+
+  private final io.yak.ops.business.sync.realtime.service.RealtimeJobQueryService query;
+  private final RealtimeJobService jobs;
+
+  public RealtimeJobQueryService(
+      io.yak.ops.business.sync.realtime.service.RealtimeJobQueryService query,
+      RealtimeJobService jobs) {
+    this.query = query;
+    this.jobs = jobs;
+  }
+
+  public RealtimeJobView detail(long id) {
+    return jobs.get(id);
+  }
+
+  public RealtimeJobPage page(
+      int pageNo,
+      int pageSize,
+      String keyword,
+      Long id,
+      String releaseState,
+      String stateGroup) {
+    return query.page(pageNo, pageSize, keyword, id, releaseState, stateGroup);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/observability/RealtimeObservabilityService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/observability/RealtimeObservabilityService.java
@@ -1,0 +1,48 @@
+package io.yak.ops.business.sync.realtime.observability;
+
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobEventView;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView;
+import io.yak.ops.business.sync.realtime.domain.RealtimeObservabilityView.RuntimeLog;
+import io.yak.ops.business.sync.realtime.service.RealtimeEventStreamService;
+import io.yak.ops.business.sync.realtime.service.RealtimeJobService;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** Stable application entry for realtime observability and event read-side use-cases. */
+@Service("realtimeObservabilityApplicationService")
+public class RealtimeObservabilityService {
+
+  private final io.yak.ops.business.sync.realtime.service.RealtimeObservabilityService observability;
+  private final RealtimeEventStreamService eventStream;
+  private final RealtimeJobService jobs;
+
+  public RealtimeObservabilityService(
+      io.yak.ops.business.sync.realtime.service.RealtimeObservabilityService observability,
+      RealtimeEventStreamService eventStream,
+      RealtimeJobService jobs) {
+    this.observability = observability;
+    this.eventStream = eventStream;
+    this.jobs = jobs;
+  }
+
+  public SseEmitter subscribe() {
+    return eventStream.subscribe();
+  }
+
+  public List<RealtimeJobEventView> events(long id) {
+    return jobs.events(id);
+  }
+
+  public RealtimeObservabilityView snapshot(long id) {
+    return observability.snapshot(id);
+  }
+
+  public String submissionLog(long id, int tailLines) {
+    return observability.submissionLog(id, tailLines);
+  }
+
+  public RuntimeLog runtimeLog(long id, int maxExceptions) {
+    return observability.runtimeLog(id, maxExceptions);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/RealtimeArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/RealtimeArchitectureTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.yak.ops.business.sync.realtime.controller.v1.ComputeEnvironmentController;
 import io.yak.ops.business.sync.realtime.controller.v1.RealtimeJobController;
+import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeRequestMapper;
+import io.yak.ops.business.sync.realtime.controller.v1.mapper.RealtimeViewMapper;
+import io.yak.ops.business.sync.realtime.definition.RealtimeJobDefinitionService;
 import io.yak.ops.business.sync.realtime.domain.DefinitionDigest;
 import io.yak.ops.business.sync.realtime.domain.DefinitionVersion;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobState;
@@ -12,6 +15,7 @@ import io.yak.ops.business.sync.realtime.domain.SyncDefinition;
 import io.yak.ops.business.sync.realtime.domain.SyncDefinitionDigestCalculator;
 import io.yak.ops.business.sync.realtime.domain.SyncExecution;
 import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
+import io.yak.ops.business.sync.realtime.execution.RealtimeJobExecutionService;
 import io.yak.ops.business.sync.realtime.repository.ComputeEnvironmentStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobListQuery;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
@@ -32,6 +36,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Service;
 
 class RealtimeArchitectureTest {
 
@@ -48,17 +53,55 @@ class RealtimeArchitectureTest {
   };
 
   @Test
+  void controllersUseDeclaredStableApplicationEntries() {
+    assertFieldTypesIn(
+        RealtimeJobController.class,
+        Set.of(
+            RealtimeJobDefinitionService.class,
+            RealtimeJobExecutionService.class,
+            io.yak.ops.business.sync.realtime.execution.query.RealtimeJobQueryService.class,
+            io.yak.ops.business.sync.realtime.observability.RealtimeObservabilityService.class,
+            RealtimeRequestMapper.class,
+            RealtimeViewMapper.class));
+
+    assertFieldTypesIn(
+        ComputeEnvironmentController.class,
+        Set.of(
+            io.yak.ops.business.sync.realtime.environment.ComputeEnvironmentService.class,
+            RealtimeRequestMapper.class,
+            RealtimeViewMapper.class));
+  }
+
+  @Test
+  void stableApplicationEntriesUseServiceStereotype() {
+    for (Class<?> facade :
+        new Class<?>[] {
+          RealtimeJobDefinitionService.class,
+          RealtimeJobExecutionService.class,
+          io.yak.ops.business.sync.realtime.execution.query.RealtimeJobQueryService.class,
+          io.yak.ops.business.sync.realtime.observability.RealtimeObservabilityService.class,
+          io.yak.ops.business.sync.realtime.environment.ComputeEnvironmentService.class
+        }) {
+      assertThat(facade.getAnnotation(Service.class))
+          .as("%s must remain a stable application facade", facade.getSimpleName())
+          .isNotNull();
+    }
+  }
+
+  @Test
   void controllersDependOnApplicationBoundariesInsteadOfPersistenceOrEnginePorts() {
     assertFieldsAvoid(
         RealtimeJobController.class,
         ".repository.",
         ".dao.",
+        ".service.",
         "RealtimeEngineGateway",
         "JdbcTemplate");
     assertFieldsAvoid(
         ComputeEnvironmentController.class,
         ".repository.",
         ".dao.",
+        ".service.",
         "RealtimeEngineGateway",
         "JdbcTemplate");
   }
@@ -72,7 +115,12 @@ class RealtimeArchitectureTest {
           RealtimeJobQueryService.class,
           RealtimeObservabilityService.class,
           RealtimeRuntimeResolver.class,
-          ComputeEnvironmentService.class
+          ComputeEnvironmentService.class,
+          RealtimeJobDefinitionService.class,
+          RealtimeJobExecutionService.class,
+          io.yak.ops.business.sync.realtime.execution.query.RealtimeJobQueryService.class,
+          io.yak.ops.business.sync.realtime.observability.RealtimeObservabilityService.class,
+          io.yak.ops.business.sync.realtime.environment.ComputeEnvironmentService.class
         }) {
       assertFieldsAvoid(type, ".dao.", ".dao.mapper.", ".dao.model.", "JdbcTemplate");
     }
@@ -190,6 +238,14 @@ class RealtimeArchitectureTest {
             .as("%s.%s must not depend on %s", type.getSimpleName(), field.getName(), value)
             .doesNotContain(value);
       }
+    }
+  }
+
+  private static void assertFieldTypesIn(Class<?> type, Set<Class<?>> allowedTypes) {
+    for (Field field : type.getDeclaredFields()) {
+      assertThat(field.getType())
+          .as("%s.%s must use a declared application/transport boundary", type.getSimpleName(), field.getName())
+          .isIn(allowedTypes);
     }
   }
 


### PR DESCRIPTION
## Summary

完成 Realtime Sync Apache-style 重构的 Stage 3：**Stable Application Entry**。

Stage 1 / Stage 2 已经合并到 `main`。本轮开始真正调整生产代码的调用边界，但不改变 Task / DefinitionVersion / SyncExecution 领域语义，也不重写 Start / Stop / Restart / Apply / Reconcile 核心实现。

目标是先把 Controller 与当前 `service/` 大桶隔离：HTTP inbound 只进入明确的 Application Facade，现有 `RealtimeJobService`、Validation、YAML、LifecycleCoordinator、EventStream 等继续作为迁移期内部实现，Stage 4/5 再按 Definition / Execution 子系统继续拆。

## Scope

相对 `main` 变更 8 个文件：

```text
src/main/java/io/yak/ops/business/sync/realtime/
├── controller/v1/
│   ├── RealtimeJobController.java
│   └── ComputeEnvironmentController.java
├── definition/
│   └── RealtimeJobDefinitionService.java        # new stable facade
├── execution/
│   ├── RealtimeJobExecutionService.java         # new stable facade
│   └── query/
│       └── RealtimeJobQueryService.java         # new stable facade
├── observability/
│   └── RealtimeObservabilityService.java        # new stable facade
└── environment/
    └── ComputeEnvironmentService.java           # new stable facade

src/test/java/io/yak/ops/business/sync/realtime/
└── RealtimeArchitectureTest.java
```

本轮没有修改：

```text
RealtimeJobService
RealtimeJobLifecycleCoordinator
SyncExecutionStateMachine
Repository / DAO
Flink / Flink CDC / SSH adapter
DB / Flyway
REST path / DTO / VO
```

## Stable application entries

Controller 现在固定进入 5 个稳定入口：

```text
RealtimeJobDefinitionService
RealtimeJobExecutionService
RealtimeJobQueryService
RealtimeObservabilityService
ComputeEnvironmentService
```

### RealtimeJobController

```text
RealtimeJobController
   ├── RealtimeJobDefinitionService
   ├── RealtimeJobExecutionService
   ├── RealtimeJobQueryService
   └── RealtimeObservabilityService
```

Controller 不再直接持有：

```text
RealtimeJobService
RealtimeValidationService
RealtimeJobLifecycleCoordinator
RealtimeEventStreamService
RealtimeYamlCodec
legacy RealtimeObservabilityService
legacy RealtimeJobQueryService
```

### ComputeEnvironmentController

```text
ComputeEnvironmentController
   └── environment.ComputeEnvironmentService
```

现有 `service.ComputeEnvironmentService` 暂时保留为内部实现，后续 Environment Stage 再迁出，不在本 PR 做 package big-bang move。

## Definition facade

`definition.RealtimeJobDefinitionService` 收口当前 Definition application use-cases：

```text
create
save draft
validate unsaved definition
parse / render Yak Realtime YAML
publish
validate persisted definition
delete metadata
```

`save` 保留原 Controller 行为：先执行 definition-level validation，再进入现有 `RealtimeJobService.save`。

`delete` 也保留原安全顺序：

```text
assertSafeToDelete
 -> delete metadata
```

安全检查通过 `RealtimeJobExecutionService` 进入现有 lifecycle boundary，Controller 不再直接依赖内部 Coordinator。

## Execution facade

`execution.RealtimeJobExecutionService` 收口：

```text
start
stop
restartExecution
applyPublishedVersion
reconcile
assertSafeToDelete
runtime capabilities
```

本 PR 只委托现有经过 Stage 2 测试锁定的实现，不改变：

- Idempotency-Key ownership；
- one Active / Uncertain Execution per Task；
- stop-during-start；
- UNKNOWN / CONFLICT；
- Restart same-version pinning；
- Apply command-time Published Version snapshot；
- runtime identity reconciliation。

## Query / Observability / Environment facades

### Query

`execution.query.RealtimeJobQueryService` 统一 Controller 的 detail + page read entry。

### Observability

`observability.RealtimeObservabilityService` 统一：

```text
SSE subscribe
events
observability snapshot
submission log
runtime exception log
```

read side 不拥有 execution command truth。

### Environment

`environment.ComputeEnvironmentService` 成为 Compute Environment 的稳定 Application Entry，现阶段委托已有实现，避免本轮顺手迁移整个 Environment 子系统。

## Architecture guardrail

增强 `RealtimeArchitectureTest`：

- `RealtimeJobController` 字段必须属于声明过的 Definition / Execution / Query / Observability Facade 或 transport mapper；
- `ComputeEnvironmentController` 只能依赖 Environment Facade + transport mapper；
- Controller 字段禁止重新依赖 `.service.` transitional package；
- Controller 继续禁止 Repository / DAO / Engine / JdbcTemplate；
- 5 个稳定 Facade 必须保持 `@Service` Application Boundary；
- 新 Facade 继续禁止直接依赖 DAO / Mapper PO / JdbcTemplate。

这意味着后续有人把 `RealtimeJobService` 或 `RealtimeJobLifecycleCoordinator` 重新注入 Controller，architecture test 会直接失败。

## Intentionally unchanged

本 PR 不改变：

- `Task != DefinitionVersion != SyncExecution`；
- Draft / Publish semantics；
- Start / Stop / RestartExecution / ApplyPublishedVersion / Reconcile behavior；
- Idempotency-Key / reservation / replacement intent；
- UNKNOWN / CONFLICT semantics；
- RuntimeEnvironmentSnapshot / runtime identity；
- REST endpoint / request / response contract；
- Yak Realtime YAML format；
- database / Flyway；
- Flink / SSH submission behavior。

也没有把现有 40KB `RealtimeJobService` 一次拆空：本轮只稳定入口，Stage 4/5 再迁移内部职责，避免 facade establishment 与 execution-core rewrite 混在同一个 PR。

## Validation

静态核对：

```text
base: main @ c34474a7c875e7ab33b7218cacf854fc2b9adb08
head: refactor/realtime-sync-stage3-stable-entry
ahead: 8
behind: 0
changed files: 8
new stable facades: 5
controller files: 2
architecture tests: 1
DB / Flyway changes: 0
```

尝试在当前执行环境 clone Stage 3 分支执行 Maven/JUnit，但执行环境无法解析 `github.com`，因此未能进行本地 Maven 编译；本 PR 不把静态检查宣称为测试通过。Draft PR 创建后等待仓库 GitHub checks/CI（如有）。

## Review focus

```text
[ ] Controller 已不再依赖 transitional service package
[ ] Facade 只转发现有 use-case，没有建立第二套运行真相
[ ] save/delete 的原有校验与安全顺序没有变化
[ ] Start/Stop/Restart/Apply/Reconcile 仍走原 implementation
[ ] Stage 2 safety baseline 不应因本 PR 语义变化而失效
[ ] 没有 REST / DB / Domain semantic change
[ ] 没有提前做 Stage 4/5 big-bang split
```

## Next

Stage 4 单独迁移 Definition 子系统内部职责：Draft / Publish / DefinitionVersion / Validation / Digest / YAML compatibility boundary。Stage 5 再处理 Execution Core，不在 Stage 3 混做。