### PR TITLE
refactor(realtime-sync): align module with permanent code style

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/definition/RealtimeDefinitionValidator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/definition/RealtimeDefinitionValidator.java
@@ -19,6 +19,7 @@ import jakarta.validation.Validator;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
@@ -179,7 +180,8 @@ public class RealtimeDefinitionValidator {
   private boolean isPhysicalTable(DataSourceCatalogTableVO table) {
     return table != null
         && table.getName() != null
-        && (table.getType() == null || !table.getType().toUpperCase().contains("VIEW"));
+        && (table.getType() == null
+            || !table.getType().toUpperCase(Locale.ROOT).contains("VIEW"));
   }
 
   private String violationMessage(ConstraintViolation<CdcPipelineSpec> violation) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecution.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecution.java
@@ -7,9 +7,9 @@ import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
  * Lifecycle core of one realtime-sync execution.
  *
  * <p>One execution represents exactly one run. STOPPED and FAILED executions are historical facts
- * and are never resurrected. During Stage-6 migration {@code definitionVersionId} may be null only
- * when reading a legacy historical deployment created before immutable DefinitionVersion evidence
- * existed. Newly created executions are bound to a DefinitionVersion before external submission.
+ * and are never resurrected. {@code definitionVersionId} may be absent only for legacy historical
+ * records created before immutable DefinitionVersion evidence existed; every new execution must be
+ * bound to one immutable DefinitionVersion before external submission.
  */
 public record SyncExecution(
     long id,
@@ -22,13 +22,21 @@ public record SyncExecution(
     String errorMessage) {
 
   public SyncExecution {
-    if (id <= 0) throw new IllegalArgumentException("ExecutionId 必须大于 0");
-    if (taskId <= 0) throw new IllegalArgumentException("TaskId 必须大于 0");
+    if (id <= 0) {
+      throw new IllegalArgumentException("ExecutionId 必须大于 0");
+    }
+    if (taskId <= 0) {
+      throw new IllegalArgumentException("TaskId 必须大于 0");
+    }
     if (definitionVersionId != null && definitionVersionId <= 0) {
       throw new IllegalArgumentException("DefinitionVersionId 必须大于 0");
     }
-    if (desiredState == null) throw new IllegalArgumentException("Execution DesiredState 不能为空");
-    if (observedState == null) throw new IllegalArgumentException("Execution ObservedState 不能为空");
+    if (desiredState == null) {
+      throw new IllegalArgumentException("Execution DesiredState 不能为空");
+    }
+    if (observedState == null) {
+      throw new IllegalArgumentException("Execution ObservedState 不能为空");
+    }
     if (engineExecutionRef == null) {
       throw new IllegalArgumentException("EngineExecutionRef 不能为空");
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachine.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachine.java
@@ -48,14 +48,22 @@ public class SyncExecutionStateMachine {
     // STOPPED / FAILED intentionally have no outgoing transitions. A later run is a new execution.
   }
 
-  public void requireTransition(SyncExecution execution, String targetValue) {
-    if (execution == null) throw new IllegalArgumentException("SyncExecution 不能为空");
-    ObservedState target = ObservedState.valueOf(targetValue);
+  public void requireTransition(SyncExecution execution, ObservedState target) {
+    if (execution == null) {
+      throw new IllegalArgumentException("SyncExecution 不能为空");
+    }
     requireTransition(execution.observedState(), target);
   }
 
+  /** Compatibility overload for persistence/protocol callers that still carry state text. */
+  public void requireTransition(SyncExecution execution, String targetValue) {
+    requireTransition(execution, ObservedState.valueOf(targetValue));
+  }
+
   public void requireTransition(ObservedState from, ObservedState target) {
-    if (from == target) return;
+    if (from == target) {
+      return;
+    }
     if (!transitions.getOrDefault(from, EnumSet.noneOf(ObservedState.class)).contains(target)) {
       throw new IllegalStateException("非法 SyncExecution 状态迁移：" + from + " -> " + target);
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkCdcEngineGateway.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.sync.realtime.engine;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -53,6 +54,9 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
           "CANCELLING");
   private static final Set<String> TERMINAL_STATES =
       Set.of("FINISHED", "CANCELED", "FAILED", "SUSPENDED");
+  private static final String DELIVERY_SEMANTICS = "at-least-once";
+  private static final int SUBMISSION_ERROR_TAIL_LINES = 20;
+  private static final int DESTROY_WAIT_SECONDS = 5;
 
   private final HttpClient client;
   private final ObjectMapper json;
@@ -102,7 +106,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     result.put("restTransport", "DIRECT");
     result.put("submissionMode", ssh ? "SSH" : "LOCAL");
     result.put("submissionEndpoint", ssh ? sshRunner.endpoint(environment) : "local");
-    result.put("deliverySemantics", "at-least-once");
+    result.put("deliverySemantics", DELIVERY_SEMANTICS);
     result.put("checkpointsApi", true);
     result.put("metricsApi", true);
     result.put("checkpointConfiguration", false);
@@ -132,7 +136,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       }
     }
     health(environment);
-    return new ValidationResult(true, "at-least-once");
+    return new ValidationResult(true, DELIVERY_SEMANTICS);
   }
 
   @Override
@@ -149,8 +153,9 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       writePrivate(submissionLog, "");
 
       URI rest = restUri(environment);
+      boolean ssh = sshSubmission(environment);
       CommandResult result;
-      if (sshSubmission(environment)) {
+      if (ssh) {
         SshFlinkCdcCommandRunner.ExecutionResult sshResult =
             sshRunner.submit(
                 environment,
@@ -171,8 +176,8 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       output = sanitizeOutput(output, request);
       writePrivate(submissionLog, output);
       if (result.exitCode() != 0) {
-        String excerpt = tail(output, 20);
-        String prefix = sshSubmission(environment) ? "SSH Flink CDC" : "Flink CDC";
+        String excerpt = tail(output, SUBMISSION_ERROR_TAIL_LINES);
+        String prefix = ssh ? "SSH Flink CDC" : "Flink CDC";
         throw failure(
             prefix
                 + " 提交失败，exitCode="
@@ -188,7 +193,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       }
       String jobId = matcher.group(1).toLowerCase(Locale.ROOT);
       Files.copy(submissionLog, submitLog(jobId), StandardCopyOption.REPLACE_EXISTING);
-      return new DeployResult(jobId, "at-least-once");
+      return new DeployResult(jobId, DELIVERY_SEMANTICS);
     } catch (RealtimeEngineException exception) {
       throw exception;
     } catch (InterruptedException exception) {
@@ -227,7 +232,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     Duration timeout = properties.getSubmitTimeout();
     if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
       process.destroyForcibly();
-      process.waitFor(5, TimeUnit.SECONDS);
+      process.waitFor(DESTROY_WAIT_SECONDS, TimeUnit.SECONDS);
       throw failure("Flink CDC 提交超时，结果不确定，请在 Flink UI 中核对", true, null, null);
     }
     return new CommandResult(process.exitValue(), false);
@@ -262,7 +267,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
   @Override
   public void stop(ComputeEnvironmentSnapshot environment, String jobId) {
     requireJobId(jobId);
-    send(environment, "/jobs/" + jobId, "PATCH", true, true);
+    send(environment, "/jobs/" + jobId, RestMethod.PATCH, true, true);
   }
 
   private String resolveSecrets(RealtimeDeployRequest request) {
@@ -326,19 +331,20 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     }
   }
 
+  /** Returns null only when Flink explicitly reports 404 and allowNotFound is true. */
   private JsonNode getJson(
       ComputeEnvironmentSnapshot environment,
       String path,
       boolean uncertain,
       boolean allowNotFound) {
-    Response response = send(environment, path, "GET", uncertain, allowNotFound);
+    Response response = send(environment, path, RestMethod.GET, uncertain, allowNotFound);
     return response == null ? null : response.body();
   }
 
   private Response send(
       ComputeEnvironmentSnapshot environment,
       String path,
-      String method,
+      RestMethod method,
       boolean uncertain,
       boolean allowNotFound) {
     try {
@@ -347,9 +353,10 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
               .timeout(properties.getRequestTimeout())
               .header("Accept", "application/json");
       HttpRequest request =
-          "PATCH".equals(method)
-              ? builder.method("PATCH", HttpRequest.BodyPublishers.noBody()).build()
-              : builder.GET().build();
+          switch (method) {
+            case GET -> builder.GET().build();
+            case PATCH -> builder.method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
+          };
       HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
       if (allowNotFound && response.statusCode() == 404) {
         return null;
@@ -358,7 +365,7 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
       if (response.statusCode() < 200 || response.statusCode() >= 300) {
         throw failure("Flink REST HTTP " + response.statusCode(), uncertain, response.statusCode(), null);
       }
-      return new Response(response.statusCode(), body);
+      return new Response(body);
     } catch (HttpTimeoutException exception) {
       throw failure("Flink REST 请求超时", uncertain, null, exception);
     } catch (InterruptedException exception) {
@@ -370,9 +377,12 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
   }
 
   private JsonNode parse(String value, boolean uncertain) {
+    if (value == null || value.isBlank()) {
+      return json.createObjectNode();
+    }
     try {
-      return value == null || value.isBlank() ? json.createObjectNode() : json.readTree(value);
-    } catch (Exception exception) {
+      return json.readTree(value);
+    } catch (JsonProcessingException exception) {
       throw failure("Flink REST 返回了无效 JSON", uncertain, null, exception);
     }
   }
@@ -471,7 +481,12 @@ public class FlinkCdcEngineGateway implements RealtimeEngineGateway {
     return new RealtimeEngineException(message, uncertain, status, cause);
   }
 
+  private enum RestMethod {
+    GET,
+    PATCH
+  }
+
   private record CommandResult(int exitCode, boolean uncertain) {}
 
-  private record Response(int status, JsonNode body) {}
+  private record Response(JsonNode body) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkObservabilityClient.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.sync.realtime.engine;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.sync.realtime.config.RealtimeSyncProperties;
@@ -36,6 +37,7 @@ import org.springframework.stereotype.Component;
 public class FlinkObservabilityClient {
 
   private static final Pattern JOB_ID = Pattern.compile("(?i)[0-9a-f]{32}");
+  private static final int MAX_RUNTIME_EXCEPTIONS = 100;
   private static final String METRIC_IDS =
       String.join(
           ",",
@@ -123,7 +125,7 @@ public class FlinkObservabilityClient {
   public RuntimeLog runtimeLog(
       ComputeEnvironmentSnapshot environment, String jobId, int maxExceptions) {
     requireJobId(jobId);
-    int limit = Math.max(1, Math.min(maxExceptions, 100));
+    int limit = Math.max(1, Math.min(maxExceptions, MAX_RUNTIME_EXCEPTIONS));
     JsonNode body =
         getJson(environment, "/jobs/" + jobId + "/exceptions?maxExceptions=" + limit, true);
     if (body == null) {
@@ -229,9 +231,10 @@ public class FlinkObservabilityClient {
       } catch (RealtimeEngineException ignored) {
         continue;
       }
-      String name = String.valueOf(text(vertex, "name")).toLowerCase(Locale.ROOT);
-      boolean source = name.contains("source");
-      boolean sink = name.contains("sink");
+      String vertexName = text(vertex, "name");
+      String normalizedName = vertexName == null ? "" : vertexName.toLowerCase(Locale.ROOT);
+      boolean source = normalizedName.contains("source");
+      boolean sink = normalizedName.contains("sink");
 
       if (source) {
         recordsRead = add(recordsRead, sum(metrics, "numRecordsOut"));
@@ -369,6 +372,7 @@ public class FlinkObservabilityClient {
     }
   }
 
+  /** Returns null only when Flink explicitly reports 404 and allowNotFound is true. */
   private JsonNode getJson(
       ComputeEnvironmentSnapshot environment, String path, boolean allowNotFound) {
     try {
@@ -385,9 +389,7 @@ public class FlinkObservabilityClient {
       if (response.statusCode() < 200 || response.statusCode() >= 300) {
         throw failure("Flink REST HTTP " + response.statusCode(), true, null);
       }
-      return response.body() == null || response.body().isBlank()
-          ? json.createObjectNode()
-          : json.readTree(response.body());
+      return parseJson(response.body());
     } catch (HttpTimeoutException exception) {
       throw failure("Flink REST 请求超时", true, exception);
     } catch (InterruptedException exception) {
@@ -395,6 +397,17 @@ public class FlinkObservabilityClient {
       throw failure("Flink REST 请求被中断", true, exception);
     } catch (IOException exception) {
       throw failure("Flink REST 连接失败", true, exception);
+    }
+  }
+
+  private JsonNode parseJson(String body) {
+    if (body == null || body.isBlank()) {
+      return json.createObjectNode();
+    }
+    try {
+      return json.readTree(body);
+    } catch (JsonProcessingException exception) {
+      throw failure("Flink REST 返回了无效 JSON", true, exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkRuntimeEnvironmentProbe.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/FlinkRuntimeEnvironmentProbe.java
@@ -29,6 +29,8 @@ public class FlinkRuntimeEnvironmentProbe {
 
   private static final Pattern VERSION =
       Pattern.compile("(?i)(?:version[^0-9]*)?([0-9]+\\.[0-9]+(?:\\.[0-9]+)?(?:[-+][A-Za-z0-9._-]+)?)");
+  private static final int VERSION_COMMAND_TIMEOUT_SECONDS = 8;
+  private static final int MAX_DIAGNOSTIC_MESSAGE_LENGTH = 300;
 
   private final RealtimeEngineGateway gateway;
   private final RealtimeSyncProperties properties;
@@ -45,7 +47,6 @@ public class FlinkRuntimeEnvironmentProbe {
     if (environment == null || environment.config() == null) {
       throw new IllegalArgumentException("运行环境配置不能为空");
     }
-    RuntimeConfig config = environment.config();
     List<Check> checks = new ArrayList<>();
     LocalDateTime checkedAt = LocalDateTime.now();
 
@@ -67,17 +68,15 @@ public class FlinkRuntimeEnvironmentProbe {
       checks.add(fail("FLINK_REST", "Flink REST", safeMessage(exception, "无法连接 Flink REST")));
     }
 
+    ProbeVersions versions;
     if (ComputeEnvironment.SUBMITTER_SSH.equals(environment.submitterType())) {
-      SshProbeVersions versions = diagnoseSsh(environment, checks);
-      detectedFlinkVersion = firstNonBlank(versions.flinkVersion(), detectedFlinkVersion);
-      detectedCdcVersion = versions.cdcVersion();
-      detectedJavaVersion = versions.javaVersion();
+      versions = diagnoseSsh(environment, checks);
     } else {
-      SshProbeVersions versions = diagnoseLocal(environment, checks);
-      detectedFlinkVersion = firstNonBlank(versions.flinkVersion(), detectedFlinkVersion);
-      detectedCdcVersion = versions.cdcVersion();
-      detectedJavaVersion = versions.javaVersion();
+      versions = diagnoseLocal(environment, checks);
     }
+    detectedFlinkVersion = firstNonBlank(versions.flinkVersion(), detectedFlinkVersion);
+    detectedCdcVersion = versions.cdcVersion();
+    detectedJavaVersion = versions.javaVersion();
 
     String status = overallStatus(checks);
     boolean ready = !ComputeEnvironmentDiagnosis.STATUS_FAILED.equals(status);
@@ -95,7 +94,7 @@ public class FlinkRuntimeEnvironmentProbe {
         List.copyOf(checks));
   }
 
-  private SshProbeVersions diagnoseLocal(
+  private ProbeVersions diagnoseLocal(
       ComputeEnvironmentSnapshot environment, List<Check> checks) {
     RuntimeConfig config = environment.config();
     Path cdc = Path.of(config.flinkCdcHome(), "bin", "flink-cdc.sh").toAbsolutePath().normalize();
@@ -105,7 +104,7 @@ public class FlinkRuntimeEnvironmentProbe {
     if (!Files.isRegularFile(cdc) || !Files.isExecutable(cdc)) {
       checks.add(fail("FLINK_CDC_CLI", "Flink CDC CLI", "文件不存在或不可执行：" + cdc));
     } else {
-      CommandOutput output = run(List.of(cdc.toString(), "--version"), 8);
+      CommandOutput output = runVersionCommand(List.of(cdc.toString(), "--version"));
       cdcVersion = extractVersion(output.output());
       checks.add(
           versionCheck(
@@ -116,7 +115,7 @@ public class FlinkRuntimeEnvironmentProbe {
     if (!Files.isRegularFile(flink) || !Files.isExecutable(flink)) {
       checks.add(fail("FLINK_CLI", "Flink CLI", "文件不存在或不可执行：" + flink));
     } else {
-      CommandOutput output = run(List.of(flink.toString(), "--version"), 8);
+      CommandOutput output = runVersionCommand(List.of(flink.toString(), "--version"));
       flinkVersion = extractVersion(output.output());
       checks.add(
           versionCheck("FLINK_CLI", "Flink CLI", output, flinkVersion, config.flinkVersion()));
@@ -128,9 +127,9 @@ public class FlinkRuntimeEnvironmentProbe {
             : "java";
     if (StringUtils.hasText(config.javaHome()) && !Files.isExecutable(Path.of(javaExecutable))) {
       checks.add(fail("JAVA", "Java", "JAVA_HOME/bin/java 不存在或不可执行"));
-      return new SshProbeVersions(flinkVersion, cdcVersion, null);
+      return new ProbeVersions(flinkVersion, cdcVersion, null);
     }
-    CommandOutput javaOutput = run(List.of(javaExecutable, "-version"), 8);
+    CommandOutput javaOutput = runVersionCommand(List.of(javaExecutable, "-version"));
     String javaVersion = extractVersion(javaOutput.output());
     if (!javaOutput.success()) {
       checks.add(fail("JAVA", "Java", nonBlank(javaOutput.output(), "无法执行 java -version")));
@@ -139,10 +138,10 @@ public class FlinkRuntimeEnvironmentProbe {
     } else {
       checks.add(pass("JAVA", "Java", "检测到 Java " + javaVersion));
     }
-    return new SshProbeVersions(flinkVersion, cdcVersion, javaVersion);
+    return new ProbeVersions(flinkVersion, cdcVersion, javaVersion);
   }
 
-  private SshProbeVersions diagnoseSsh(
+  private ProbeVersions diagnoseSsh(
       ComputeEnvironmentSnapshot environment, List<Check> checks) {
     RuntimeConfig config = environment.config();
     SshConfig ssh = config.ssh();
@@ -200,14 +199,14 @@ public class FlinkRuntimeEnvironmentProbe {
           probe.tempWritable()
               ? pass("REMOTE_TEMP", "远端临时目录", "mktemp 可创建并清理临时文件")
               : fail("REMOTE_TEMP", "远端临时目录", "无法创建远端临时 pipeline 文件"));
-      return new SshProbeVersions(flinkVersion, cdcVersion, javaVersion);
+      return new ProbeVersions(flinkVersion, cdcVersion, javaVersion);
     } catch (RuntimeException exception) {
       checks.add(fail("SSH", "SSH 连接", safeMessage(exception, "SSH 连接或认证失败")));
       checks.add(warn("FLINK_CDC_CLI", "Flink CDC CLI", "SSH 未连接，未执行远端检查"));
       checks.add(warn("FLINK_CLI", "Flink CLI", "SSH 未连接，未执行远端检查"));
       checks.add(warn("JAVA", "Java", "SSH 未连接，未执行远端检查"));
       checks.add(warn("REMOTE_TEMP", "远端临时目录", "SSH 未连接，未执行远端检查"));
-      return new SshProbeVersions(null, null, null);
+      return new ProbeVersions(null, null, null);
     }
   }
 
@@ -218,7 +217,7 @@ public class FlinkRuntimeEnvironmentProbe {
       Files.createDirectories(work);
       marker = Files.createTempFile(work, ".yak-env-probe-", ".tmp");
       return pass("WORK_DIRECTORY", "Yak Ops 工作目录", "可读写：" + work);
-    } catch (Exception exception) {
+    } catch (IOException | RuntimeException exception) {
       return fail("WORK_DIRECTORY", "Yak Ops 工作目录", safeMessage(exception, "工作目录不可写"));
     } finally {
       if (marker != null) {
@@ -267,11 +266,11 @@ public class FlinkRuntimeEnvironmentProbe {
     return pass(key, label, "检测到 " + detected);
   }
 
-  private CommandOutput run(List<String> command, int timeoutSeconds) {
+  private CommandOutput runVersionCommand(List<String> command) {
     Process process = null;
     try {
       process = new ProcessBuilder(command).redirectErrorStream(true).start();
-      if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+      if (!process.waitFor(VERSION_COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         process.destroyForcibly();
         return new CommandOutput(false, "版本检测超时");
       }
@@ -280,20 +279,30 @@ public class FlinkRuntimeEnvironmentProbe {
       return new CommandOutput(process.exitValue() == 0, output);
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
-      if (process != null) process.destroyForcibly();
+      if (process != null) {
+        process.destroyForcibly();
+      }
       return new CommandOutput(false, "版本检测被中断");
     } catch (IOException exception) {
-      if (process != null) process.destroyForcibly();
+      if (process != null) {
+        process.destroyForcibly();
+      }
       return new CommandOutput(false, "无法执行命令：" + exception.getMessage());
     }
   }
 
   private String extractVersion(String output) {
-    if (!StringUtils.hasText(output)) return null;
+    if (!StringUtils.hasText(output)) {
+      return null;
+    }
     for (String line : output.lines().toList()) {
-      if (!line.toLowerCase(Locale.ROOT).contains("version")) continue;
+      if (!line.toLowerCase(Locale.ROOT).contains("version")) {
+        continue;
+      }
       Matcher matcher = VERSION.matcher(line);
-      if (matcher.find()) return matcher.group(1);
+      if (matcher.find()) {
+        return matcher.group(1);
+      }
     }
     Matcher matcher = VERSION.matcher(output);
     return matcher.find() ? matcher.group(1) : null;
@@ -305,7 +314,9 @@ public class FlinkRuntimeEnvironmentProbe {
 
   private String overviewMessage(JsonNode overview, String version) {
     List<String> parts = new ArrayList<>();
-    if (StringUtils.hasText(version)) parts.add("Flink " + version);
+    if (StringUtils.hasText(version)) {
+      parts.add("Flink " + version);
+    }
     addNumber(parts, overview, "taskmanagers", "TaskManagers");
     if (overview != null && overview.has("slots-available") && overview.has("slots-total")) {
       parts.add(
@@ -350,7 +361,9 @@ public class FlinkRuntimeEnvironmentProbe {
   }
 
   private String text(JsonNode node, String field) {
-    if (node == null || node.path(field).isMissingNode() || node.path(field).isNull()) return null;
+    if (node == null || node.path(field).isMissingNode() || node.path(field).isNull()) {
+      return null;
+    }
     String value = node.path(field).asText(null);
     return StringUtils.hasText(value) ? value.trim() : null;
   }
@@ -360,9 +373,13 @@ public class FlinkRuntimeEnvironmentProbe {
   }
 
   private String nonBlank(String value, String fallback) {
-    if (!StringUtils.hasText(value)) return fallback;
+    if (!StringUtils.hasText(value)) {
+      return fallback;
+    }
     String firstLine = value.lines().findFirst().orElse(value).trim();
-    return firstLine.length() > 300 ? firstLine.substring(0, 300) : firstLine;
+    return firstLine.length() > MAX_DIAGNOSTIC_MESSAGE_LENGTH
+        ? firstLine.substring(0, MAX_DIAGNOSTIC_MESSAGE_LENGTH)
+        : firstLine;
   }
 
   private String safeMessage(Throwable exception, String fallback) {
@@ -383,5 +400,5 @@ public class FlinkRuntimeEnvironmentProbe {
 
   private record CommandOutput(boolean success, String output) {}
 
-  private record SshProbeVersions(String flinkVersion, String cdcVersion, String javaVersion) {}
+  private record ProbeVersions(String flinkVersion, String cdcVersion, String javaVersion) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeDataSourceResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeDataSourceResolver.java
@@ -39,16 +39,16 @@ public class RealtimeDataSourceResolver {
   }
 
   /** Resolves credentials only for the lifetime of one Flink CDC CLI submission. */
-  public RealtimeDeployRequest.CredentialBinding[] resolveCredentials(CdcPipelineSpec spec) {
+  public RealtimeDeployRequest.CredentialBindings resolveCredentials(CdcPipelineSpec spec) {
     DataSourceDefinition source = find(spec.sourceDataSourceRef(), "Source");
     DataSourceDefinition sink = find(spec.sinkDataSourceRef(), "Sink");
     requireRole(source, Role.SOURCE);
     requireRole(sink, Role.SINK);
+
     RealtimeDeployRequest.CredentialBinding sourceCredential = credential(source, Role.SOURCE);
     try {
-      return new RealtimeDeployRequest.CredentialBinding[] {
-        sourceCredential, credential(sink, Role.SINK)
-      };
+      return new RealtimeDeployRequest.CredentialBindings(
+          sourceCredential, credential(sink, Role.SINK));
     } catch (RuntimeException exception) {
       sourceCredential.close();
       throw exception;
@@ -75,7 +75,6 @@ public class RealtimeDataSourceResolver {
 
   private ResolvedCdcPipeline.Endpoint endpoint(DataSourceDefinition definition, Role role) {
     DataSourceConnection connection = connection(definition, role);
-
     HostPort hostPort = hostPort(connection.normalizedJson(), connection.jdbcUrl());
     return new ResolvedCdcPipeline.Endpoint(
         definition.getId(),
@@ -129,7 +128,7 @@ public class RealtimeDataSourceResolver {
         return new HostPort(host, port);
       }
     } catch (Exception ignored) {
-      // Fall through to JDBC URL parsing. No connection values are logged.
+      // JDBC URL is the compatibility fallback; connection values must never be logged here.
     }
 
     String uriText = jdbcUrl == null ? "" : jdbcUrl.replaceFirst("^jdbc:", "");
@@ -139,7 +138,7 @@ public class RealtimeDataSourceResolver {
         return new HostPort(uri.getHost(), uri.getPort());
       }
     } catch (IllegalArgumentException ignored) {
-      // Produce a role-neutral validation error below.
+      // Produce one role-neutral validation error below without exposing connection values.
     }
     throw new IllegalArgumentException("无法从数据源连接参数解析 host/port");
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeDeployRequest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/engine/RealtimeDeployRequest.java
@@ -17,8 +17,17 @@ public final class RealtimeDeployRequest implements AutoCloseable {
       CredentialBinding sink) {
     this.pipelineYaml = pipelineYaml;
     this.idempotencyKey = idempotencyKey;
-    this.source = source;
-    this.sink = sink;
+    this.source = requireCredential(source, "Source");
+    this.sink = requireCredential(sink, "Sink");
+  }
+
+  public RealtimeDeployRequest(
+      String pipelineYaml, String idempotencyKey, CredentialBindings credentials) {
+    this(
+        pipelineYaml,
+        idempotencyKey,
+        requireBindings(credentials).source(),
+        credentials.sink());
   }
 
   public String pipelineYaml() {
@@ -48,6 +57,28 @@ public final class RealtimeDeployRequest implements AutoCloseable {
     return "RealtimeDeployRequest[pipelineYaml=******, idempotencyKey="
         + idempotencyKey
         + ", source=******, sink=******]";
+  }
+
+  private static CredentialBindings requireBindings(CredentialBindings credentials) {
+    if (credentials == null) {
+      throw new IllegalArgumentException("CredentialBindings 不能为空");
+    }
+    return credentials;
+  }
+
+  private static CredentialBinding requireCredential(CredentialBinding credential, String role) {
+    if (credential == null) {
+      throw new IllegalArgumentException(role + " CredentialBinding 不能为空");
+    }
+    return credential;
+  }
+
+  /** Named source/sink pair used only while preparing one external submission. */
+  public record CredentialBindings(CredentialBinding source, CredentialBinding sink) {
+    public CredentialBindings {
+      requireCredential(source, "Source");
+      requireCredential(sink, "Sink");
+    }
   }
 
   public static final class CredentialBinding implements AutoCloseable {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionIntent.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionIntent.java
@@ -6,11 +6,19 @@ enum RealtimeExecutionIntent {
   RESTART_EXECUTION("RESTART_EXECUTION_REQUESTED", "重启当前运行版本"),
   APPLY_PUBLISHED_VERSION("APPLY_PUBLISHED_VERSION_REQUESTED", "应用已发布版本");
 
-  final String eventType;
-  final String messagePrefix;
+  private final String eventType;
+  private final String messagePrefix;
 
   RealtimeExecutionIntent(String eventType, String messagePrefix) {
     this.eventType = eventType;
     this.messagePrefix = messagePrefix;
+  }
+
+  String eventType() {
+    return eventType;
+  }
+
+  String messagePrefix() {
+    return messagePrefix;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionPreparation.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionPreparation.java
@@ -17,6 +17,7 @@ import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentR
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.Objects;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,8 @@ import org.springframework.stereotype.Component;
 /** Resolves and freezes the DefinitionVersion, runtime environment and compiled execution artifact. */
 @Component
 public class RealtimeExecutionPreparation {
+
+  private static final String ARTIFACT_DIGEST_ALGORITHM = "SHA-256";
 
   private final RealtimeJobStore store;
   private final CdcPipelineSpecValidator specValidator;
@@ -116,20 +119,19 @@ public class RealtimeExecutionPreparation {
   String artifactDigest(RealtimeExecutionPrepared prepared) {
     try {
       byte[] bytes =
-          MessageDigest.getInstance("SHA-256")
+          MessageDigest.getInstance(ARTIFACT_DIGEST_ALGORITHM)
               .digest(prepared.compiled().yaml().getBytes(StandardCharsets.UTF_8));
       return HexFormat.of().formatHex(bytes);
-    } catch (Exception exception) {
-      throw new IllegalStateException("无法计算 SHA-256 摘要", exception);
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("运行环境不支持 SHA-256 摘要", exception);
     }
   }
 
   RealtimeEngineGateway.DeployResult deploy(RealtimeExecutionPrepared prepared, String key) {
-    RealtimeDeployRequest.CredentialBinding[] credentials =
+    RealtimeDeployRequest.CredentialBindings credentials =
         dataSourceResolver.resolveCredentials(prepared.spec());
     try (RealtimeDeployRequest request =
-        new RealtimeDeployRequest(
-            prepared.compiled().yaml(), key, credentials[0], credentials[1])) {
+        new RealtimeDeployRequest(prepared.compiled().yaml(), key, credentials)) {
       return gateway.deploy(prepared.runtimeEnvironment(), request);
     }
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionReplacementManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionReplacementManager.java
@@ -1,10 +1,12 @@
 package io.yak.ops.business.sync.realtime.execution;
 
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.domain.SyncExecution;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
 import java.util.Objects;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -30,15 +32,15 @@ public class RealtimeExecutionReplacementManager {
 
   RealtimeJobView.Deployment restartExecution(long taskId, String requestedKey) {
     String key = reservations.normalizeKey(requestedKey);
-    RealtimeJobView.Deployment existing = reservations.idempotentView(taskId, key);
-    if (existing != null) {
-      return existing;
+    Optional<RealtimeJobView.Deployment> existing = reservations.idempotentView(taskId, key);
+    if (existing.isPresent()) {
+      return existing.orElseThrow();
     }
 
-    DeploymentRow pending = reservations.pendingReplacement(taskId);
-    if (pending != null) {
+    Optional<DeploymentRow> pending = reservations.pendingReplacement(taskId);
+    if (pending.isPresent()) {
       return resumeReplacement(
-          taskId, key, pending, RealtimeExecutionIntent.RESTART_EXECUTION);
+          taskId, key, pending.orElseThrow(), RealtimeExecutionIntent.RESTART_EXECUTION);
     }
 
     DeploymentRow currentRow =
@@ -69,15 +71,15 @@ public class RealtimeExecutionReplacementManager {
 
   RealtimeJobView.Deployment applyPublishedVersion(long taskId, String requestedKey) {
     String key = reservations.normalizeKey(requestedKey);
-    RealtimeJobView.Deployment existing = reservations.idempotentView(taskId, key);
-    if (existing != null) {
-      return existing;
+    Optional<RealtimeJobView.Deployment> existing = reservations.idempotentView(taskId, key);
+    if (existing.isPresent()) {
+      return existing.orElseThrow();
     }
 
-    DeploymentRow pending = reservations.pendingReplacement(taskId);
-    if (pending != null) {
+    Optional<DeploymentRow> pending = reservations.pendingReplacement(taskId);
+    if (pending.isPresent()) {
       return resumeReplacement(
-          taskId, key, pending, RealtimeExecutionIntent.APPLY_PUBLISHED_VERSION);
+          taskId, key, pending.orElseThrow(), RealtimeExecutionIntent.APPLY_PUBLISHED_VERSION);
     }
 
     DeploymentRow currentRow =
@@ -149,17 +151,17 @@ public class RealtimeExecutionReplacementManager {
       String stoppedMessage) {
     DeploymentRow latest = states.requireCurrentExecutionRow(taskId, source.id());
     SyncExecution execution = latest.execution();
-    String observed = execution.observedState().name();
+    ObservedState observed = execution.observedState();
 
-    if ("UNKNOWN".equals(observed) || "CONFLICT".equals(observed)) {
+    if (observed == ObservedState.UNKNOWN || observed == ObservedState.CONFLICT) {
       throw new IllegalStateException("版本替换 Execution 状态不确定，请先执行状态对账");
     }
-    if ("STOPPING".equals(observed)) {
+    if (observed == ObservedState.STOPPING) {
       if (!StringUtils.hasText(latest.engineJobId())) {
         throw new IllegalStateException("版本替换 Execution 缺少 EngineExecutionRef，请先执行状态对账");
       }
       states.stopBoundJob(taskId, latest.id(), latest.engineJobId(), stoppedMessage);
-    } else if (!"STOPPED".equals(observed)) {
+    } else if (observed != ObservedState.STOPPED) {
       throw new IllegalStateException("版本替换命令只能从 STOPPING/STOPPED 状态继续，请先执行状态对账");
     }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionReservationManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionReservationManager.java
@@ -1,5 +1,7 @@
 package io.yak.ops.business.sync.realtime.execution;
 
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.domain.SyncExecution;
 import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
@@ -7,6 +9,7 @@ import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.PublishedDefinitionRow;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -17,6 +20,9 @@ import org.springframework.util.StringUtils;
 /** Owns command keys, single-execution claims and replacement-stop reservations. */
 @Component
 public class RealtimeExecutionReservationManager {
+
+  private static final int MAX_IDEMPOTENCY_KEY_LENGTH = 128;
+  private static final String IDEMPOTENCY_KEY_PATTERN = "[A-Za-z0-9._:-]+";
 
   private final RealtimeJobStore store;
   private final SyncExecutionStateMachine stateMachine;
@@ -37,15 +43,14 @@ public class RealtimeExecutionReservationManager {
   String normalizeKey(String requestedKey) {
     String key =
         StringUtils.hasText(requestedKey) ? requestedKey.trim() : UUID.randomUUID().toString();
-    if (key.length() > 128 || !key.matches("[A-Za-z0-9._:-]+")) {
+    if (key.length() > MAX_IDEMPOTENCY_KEY_LENGTH || !key.matches(IDEMPOTENCY_KEY_PATTERN)) {
       throw new IllegalArgumentException("Idempotency-Key 格式无效");
     }
     return key;
   }
 
-  RealtimeJobView.Deployment idempotentView(long taskId, String key) {
-    DeploymentRow existing = idempotentDeployment(taskId, key);
-    return existing == null ? null : store.deploymentView(existing);
+  Optional<RealtimeJobView.Deployment> idempotentView(long taskId, String key) {
+    return idempotentDeployment(taskId, key).map(store::deploymentView);
   }
 
   RealtimeJobView.Deployment requireIdempotentView(long taskId, String key) {
@@ -76,9 +81,9 @@ public class RealtimeExecutionReservationManager {
             status -> {
               DefinitionRow locked = store.lockDefinition(taskId);
 
-              DeploymentRow duplicate = idempotentDeployment(taskId, key);
-              if (duplicate != null) {
-                return new StartReservation(duplicate.id(), false);
+              Optional<DeploymentRow> duplicate = idempotentDeployment(taskId, key);
+              if (duplicate.isPresent()) {
+                return new StartReservation(duplicate.orElseThrow().id(), false);
               }
 
               PublishedDefinitionRow currentTarget;
@@ -121,10 +126,10 @@ public class RealtimeExecutionReservationManager {
               store.event(
                   taskId,
                   created,
-                  intent.eventType,
+                  intent.eventType(),
                   null,
-                  "STARTING",
-                  intent.messagePrefix
+                  ObservedState.STARTING.name(),
+                  intent.messagePrefix()
                       + " DefinitionVersion v"
                       + prepared.definitionVersion().versionNo()
                       + "，通过运行环境「"
@@ -140,9 +145,8 @@ public class RealtimeExecutionReservationManager {
     return reservation;
   }
 
-  DeploymentRow pendingReplacement(long taskId) {
-    DeploymentRow latest = store.latestDeployment(taskId).orElse(null);
-    return latest != null && latest.replacementPending() ? latest : null;
+  Optional<DeploymentRow> pendingReplacement(long taskId) {
+    return store.latestDeployment(taskId).filter(DeploymentRow::replacementPending);
   }
 
   DeploymentRow requireStableRunningExecutionRow(long taskId, String action) {
@@ -193,7 +197,7 @@ public class RealtimeExecutionReservationManager {
                   || !StringUtils.hasText(latest.engineJobId())) {
                 throw new IllegalStateException("当前 SyncExecution 缺少 EngineExecutionRef，请先执行状态对账");
               }
-              stateMachine.requireTransition(execution, "STOPPING");
+              stateMachine.requireTransition(execution, ObservedState.STOPPING);
               store.reserveReplacementStop(
                   taskId, latest.id(), intent.name(), targetDefinitionVersionId, key);
               store.event(
@@ -201,7 +205,7 @@ public class RealtimeExecutionReservationManager {
                   latest.id(),
                   eventType,
                   execution.observedState().name(),
-                  "STOPPING",
+                  ObservedState.STOPPING.name(),
                   message);
               return latest;
             });
@@ -219,11 +223,9 @@ public class RealtimeExecutionReservationManager {
     }
   }
 
-  private DeploymentRow idempotentDeployment(long taskId, String key) {
-    DeploymentRow existing = store.deploymentByIdempotencyKey(key).orElse(null);
-    if (existing != null) {
-      requireIdempotencyOwner(taskId, existing);
-    }
+  private Optional<DeploymentRow> idempotentDeployment(long taskId, String key) {
+    Optional<DeploymentRow> existing = store.deploymentByIdempotencyKey(key);
+    existing.ifPresent(deployment -> requireIdempotencyOwner(taskId, deployment));
     return existing;
   }
 
@@ -254,8 +256,8 @@ public class RealtimeExecutionReservationManager {
     if (execution.terminal()) {
       throw new IllegalStateException("当前 SyncExecution 已结束，请直接启动已发布版本");
     }
-    if (!"RUNNING".equals(execution.desiredState().name())
-        || !"RUNNING".equals(execution.observedState().name())
+    if (execution.desiredState() != DesiredState.RUNNING
+        || execution.observedState() != ObservedState.RUNNING
         || execution.resultUncertain()) {
       throw new IllegalStateException(
           action

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionStarter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionStarter.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.sync.realtime.execution;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineException;
 import io.yak.ops.business.sync.realtime.engine.RealtimeEngineGateway;
+import java.util.Optional;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 
@@ -25,15 +26,14 @@ public class RealtimeExecutionStarter {
 
   RealtimeJobView.Deployment start(long taskId, String requestedKey) {
     String key = reservations.normalizeKey(requestedKey);
-    RealtimeJobView.Deployment existing = reservations.idempotentView(taskId, key);
-    if (existing != null) {
-      return existing;
+    Optional<RealtimeJobView.Deployment> existing = reservations.idempotentView(taskId, key);
+    if (existing.isPresent()) {
+      return existing.orElseThrow();
     }
 
     RealtimeExecutionPrepared prepared = preparation.preparePublished(taskId);
     preparation.validate(prepared);
-    return startPrepared(
-        taskId, key, prepared, true, RealtimeExecutionIntent.START);
+    return startPrepared(taskId, key, prepared, true, RealtimeExecutionIntent.START);
   }
 
   RealtimeJobView.Deployment startPrepared(
@@ -42,9 +42,9 @@ public class RealtimeExecutionStarter {
       RealtimeExecutionPrepared prepared,
       boolean requireCurrentPublished,
       RealtimeExecutionIntent intent) {
-    RealtimeJobView.Deployment existing = reservations.idempotentView(taskId, key);
-    if (existing != null) {
-      return existing;
+    Optional<RealtimeJobView.Deployment> existing = reservations.idempotentView(taskId, key);
+    if (existing.isPresent()) {
+      return existing.orElseThrow();
     }
 
     RealtimeExecutionReservationManager.StartReservation reservation;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionStateManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/execution/RealtimeExecutionStateManager.java
@@ -1,6 +1,8 @@
 package io.yak.ops.business.sync.realtime.execution;
 
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobView;
 import io.yak.ops.business.sync.realtime.domain.SyncExecution;
 import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
@@ -18,6 +20,9 @@ import org.springframework.util.StringUtils;
 /** Owns SyncExecution state commits and exact external-stop handling. */
 @Component
 public class RealtimeExecutionStateManager {
+
+  private static final int STOP_POLL_ATTEMPTS = 20;
+  private static final long STOP_POLL_INTERVAL_MILLIS = 250L;
 
   private final RealtimeJobStore store;
   private final SyncExecutionStateMachine stateMachine;
@@ -50,9 +55,9 @@ public class RealtimeExecutionStateManager {
               DeploymentRow row = requireCurrentExecutionRow(taskId, deploymentId);
               SyncExecution execution = row.execution();
 
-              if (execution.desiredState().name().equals("RUNNING")
-                  && execution.observedState().name().equals("STARTING")) {
-                stateMachine.requireTransition(execution, "RUNNING");
+              if (execution.desiredState() == DesiredState.RUNNING
+                  && execution.observedState() == ObservedState.STARTING) {
+                stateMachine.requireTransition(execution, ObservedState.RUNNING);
                 store.markDeploymentRunning(
                     taskId,
                     deploymentId,
@@ -62,15 +67,15 @@ public class RealtimeExecutionStateManager {
                     taskId,
                     deploymentId,
                     "STARTED",
-                    "STARTING",
-                    "RUNNING",
+                    ObservedState.STARTING.name(),
+                    ObservedState.RUNNING.name(),
                     "Flink 已接受任务");
                 return false;
               }
 
-              String from = execution.observedState().name();
-              if (!"STOPPING".equals(from)) {
-                stateMachine.requireTransition(execution, "STOPPING");
+              ObservedState from = execution.observedState();
+              if (from != ObservedState.STOPPING) {
+                stateMachine.requireTransition(execution, ObservedState.STOPPING);
                 store.markStopping(taskId, deploymentId);
               }
               store.bindDeploymentForStop(
@@ -81,8 +86,8 @@ public class RealtimeExecutionStateManager {
                   taskId,
                   deploymentId,
                   "START_CANCEL_PENDING",
-                  from,
-                  "STOPPING",
+                  from.name(),
+                  ObservedState.STOPPING.name(),
                   "启动提交已返回，但期间 Execution 停止意图已生效，立即取消该 Flink 任务");
               return true;
             });
@@ -104,8 +109,9 @@ public class RealtimeExecutionStateManager {
           store.lockDefinition(taskId);
           DeploymentRow row = requireCurrentExecutionRow(taskId, deploymentId);
           SyncExecution execution = row.execution();
-          boolean stopRequested = execution.desiredState().name().equals("STOPPED");
-          String target = exception.uncertain() ? "UNKNOWN" : "FAILED";
+          boolean stopRequested = execution.desiredState() == DesiredState.STOPPED;
+          ObservedState target =
+              exception.uncertain() ? ObservedState.UNKNOWN : ObservedState.FAILED;
           stateMachine.requireTransition(execution, target);
           store.markDeployFailure(
               taskId,
@@ -118,7 +124,7 @@ public class RealtimeExecutionStateManager {
               deploymentId,
               exception.uncertain() ? "START_UNCERTAIN" : "START_FAILED",
               execution.observedState().name(),
-              target,
+              target.name(),
               exception.getMessage());
         });
   }
@@ -136,19 +142,19 @@ public class RealtimeExecutionStateManager {
               if (execution.terminal()) {
                 return new StopReservation(deployment, true, false);
               }
-              if (execution.desiredState().name().equals("STOPPED")
-                  && execution.observedState().name().equals("STOPPING")) {
+              if (execution.desiredState() == DesiredState.STOPPED
+                  && execution.observedState() == ObservedState.STOPPING) {
                 return new StopReservation(deployment, false, true);
               }
 
-              stateMachine.requireTransition(execution, "STOPPING");
+              stateMachine.requireTransition(execution, ObservedState.STOPPING);
               store.markStopping(taskId, deployment.id());
               store.event(
                   taskId,
                   deployment.id(),
                   "STOP_REQUESTED",
                   execution.observedState().name(),
-                  "STOPPING",
+                  ObservedState.STOPPING.name(),
                   "已请求停止当前 SyncExecution");
               return new StopReservation(deployment, false, false);
             });
@@ -200,14 +206,20 @@ public class RealtimeExecutionStateManager {
           store.lockDefinition(taskId);
           DeploymentRow row = requireCurrentExecutionRow(taskId, deploymentId);
           SyncExecution execution = row.execution();
-          stateMachine.requireTransition(execution, "UNKNOWN");
-          store.reconcile(taskId, deploymentId, "UNKNOWN", "UNKNOWN", jobId, message);
+          stateMachine.requireTransition(execution, ObservedState.UNKNOWN);
+          store.reconcile(
+              taskId,
+              deploymentId,
+              ObservedState.UNKNOWN.name(),
+              ObservedState.UNKNOWN.name(),
+              jobId,
+              message);
           store.event(
               taskId,
               deploymentId,
               "STOP_UNCERTAIN",
               execution.observedState().name(),
-              "UNKNOWN",
+              ObservedState.UNKNOWN.name(),
               message);
         });
   }
@@ -219,25 +231,31 @@ public class RealtimeExecutionStateManager {
           store.lockDefinition(taskId);
           DeploymentRow row = requireCurrentExecutionRow(taskId, deploymentId);
           SyncExecution execution = row.execution();
-          if (execution.desiredState().name().equals("STOPPED")
-              && execution.observedState().name().equals("STOPPED")) {
+          if (execution.desiredState() == DesiredState.STOPPED
+              && execution.observedState() == ObservedState.STOPPED) {
             return;
           }
-          stateMachine.requireTransition(execution, "STOPPED");
-          store.reconcile(taskId, deploymentId, "STOPPED", "STOPPED", jobId, null);
+          stateMachine.requireTransition(execution, ObservedState.STOPPED);
+          store.reconcile(
+              taskId,
+              deploymentId,
+              ObservedState.STOPPED.name(),
+              ObservedState.STOPPED.name(),
+              jobId,
+              null);
           store.event(
               taskId,
               deploymentId,
               "STOPPED",
               execution.observedState().name(),
-              "STOPPED",
+              ObservedState.STOPPED.name(),
               message);
         });
   }
 
   private void waitForRuntimeStop(
       ComputeEnvironmentSnapshot runtimeEnvironment, String jobId) {
-    for (int attempt = 0; attempt < 20; attempt++) {
+    for (int attempt = 0; attempt < STOP_POLL_ATTEMPTS; attempt++) {
       RuntimeStatus status = gateway.status(runtimeEnvironment, jobId);
       if (status.state() == RuntimeStatus.State.TERMINATED
           || status.state() == RuntimeStatus.State.NONE) {
@@ -247,7 +265,7 @@ public class RealtimeExecutionStateManager {
         throw new RealtimeEngineException("Flink 停止状态未知，等待后续对账", true, null, null);
       }
       try {
-        Thread.sleep(250);
+        Thread.sleep(STOP_POLL_INTERVAL_MILLIS);
       } catch (InterruptedException exception) {
         Thread.currentThread().interrupt();
         throw new RealtimeEngineException("等待 Flink 停止时被中断", true, null, exception);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/reconcile/RealtimeReconcileCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/reconcile/RealtimeReconcileCoordinator.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.sync.realtime.environment.RealtimeRuntimeResolver;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DefinitionRow;
 import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentRow;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
@@ -75,10 +76,11 @@ public class RealtimeReconcileCoordinator {
 
     String jobId = deployment.engineJobId();
     if (!hasText(jobId)) {
-      jobId = identityRecovery.recoverJobId(definition, deployment);
-      if (!hasText(jobId)) {
+      Optional<String> recovered = identityRecovery.recoverJobId(definition, deployment);
+      if (recovered.isEmpty()) {
         return store.view(taskId);
       }
+      jobId = recovered.orElseThrow();
       deployment = store.latestDeployment(taskId).orElse(deployment);
     }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/reconcile/RealtimeRuntimeIdentityRecovery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/reconcile/RealtimeRuntimeIdentityRecovery.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.sync.realtime.repository.RealtimeJobStore.DeploymentR
 import io.yak.ops.business.sync.realtime.repository.RealtimeRuntimeIdentityStore;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -45,29 +46,29 @@ public class RealtimeRuntimeIdentityRecovery {
     this.transactions = new TransactionTemplate(transactionManager);
   }
 
-  String recoverJobId(DefinitionRow definition, DeploymentRow deployment) {
-    String runtimeName = identityStore.findByDeploymentId(deployment.id()).orElse(null);
-    if (!hasText(runtimeName)) {
+  Optional<String> recoverJobId(DefinitionRow definition, DeploymentRow deployment) {
+    Optional<String> runtimeName = identityStore.findByDeploymentId(deployment.id()).filter(this::hasText);
+    if (runtimeName.isEmpty()) {
       if (graceExpired(deployment)) {
         stateReconciler.settleMissing(
             definition.id(), deployment, "Gateway 尚未绑定 runtime identity，确认 CLI 未开始提交");
       }
-      return null;
+      return Optional.empty();
     }
 
     ComputeEnvironmentSnapshot runtimeEnvironment =
         runtimeResolver.deployment(definition, deployment);
-    List<String> matches = discovery.findJobIds(runtimeEnvironment, runtimeName);
+    List<String> matches = discovery.findJobIds(runtimeEnvironment, runtimeName.orElseThrow());
     if (matches.size() > 1) {
       stateReconciler.markConflict(definition.id(), deployment, matches.size());
-      return null;
+      return Optional.empty();
     }
     if (matches.isEmpty()) {
       if (graceExpired(deployment)) {
         stateReconciler.settleMissing(
             definition.id(), deployment, "恢复窗口内未发现匹配的 Flink runtime job");
       }
-      return null;
+      return Optional.empty();
     }
 
     String recoveredJobId = matches.get(0);
@@ -94,7 +95,7 @@ public class RealtimeRuntimeIdentityRecovery {
               execution.observedState().name(),
               "已通过 runtime job identity 找回 Flink JobId：" + recoveredJobId);
         });
-    return recoveredJobId;
+    return Optional.of(recoveredJobId);
   }
 
   private boolean graceExpired(DeploymentRow deployment) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/reconcile/RealtimeRuntimeStateReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/reconcile/RealtimeRuntimeStateReconciler.java
@@ -1,6 +1,8 @@
 package io.yak.ops.business.sync.realtime.reconcile;
 
 import io.yak.ops.business.sync.realtime.domain.ComputeEnvironmentSnapshot;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DeploymentState;
+import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.DesiredState;
 import io.yak.ops.business.sync.realtime.domain.RealtimeJobState.ObservedState;
 import io.yak.ops.business.sync.realtime.domain.SyncExecution;
 import io.yak.ops.business.sync.realtime.domain.SyncExecutionStateMachine;
@@ -61,15 +63,21 @@ public class RealtimeRuntimeStateReconciler {
                 transition(
                     taskId,
                     latest,
-                    "UNKNOWN",
-                    "UNKNOWN",
+                    ObservedState.UNKNOWN,
+                    DeploymentState.UNKNOWN,
                     jobId,
                     "Flink 当前运行状态未知");
                 return false;
               }
-              if (execution.desiredState().name().equals("RUNNING")) {
+              if (execution.desiredState() == DesiredState.RUNNING) {
                 if (runtime.state() == RuntimeStatus.State.RUNNING) {
-                  transition(taskId, latest, "RUNNING", "RUNNING", jobId, null);
+                  transition(
+                      taskId,
+                      latest,
+                      ObservedState.RUNNING,
+                      DeploymentState.RUNNING,
+                      jobId,
+                      null);
                 } else {
                   failExpectedRunning(
                       taskId,
@@ -81,7 +89,13 @@ public class RealtimeRuntimeStateReconciler {
                 return false;
               }
               if (runtime.state() == RuntimeStatus.State.RUNNING) {
-                transition(taskId, latest, "STOPPING", "STOPPING", jobId, null);
+                transition(
+                    taskId,
+                    latest,
+                    ObservedState.STOPPING,
+                    DeploymentState.STOPPING,
+                    jobId,
+                    null);
                 return true;
               }
               toStopped(taskId, latest, jobId, "Flink 已确认无活动任务");
@@ -107,7 +121,7 @@ public class RealtimeRuntimeStateReconciler {
             return;
           }
           SyncExecution execution = latest.execution();
-          if (execution.desiredState().name().equals("RUNNING")) {
+          if (execution.desiredState() == DesiredState.RUNNING) {
             failExpectedRunning(taskId, latest, "提交结果不确定，" + reason);
           } else {
             toStopped(taskId, latest, null, reason + "，已确认停止");
@@ -124,9 +138,18 @@ public class RealtimeRuntimeStateReconciler {
             return;
           }
           SyncExecution execution = latest.execution();
-          String target = execution.observedState() == ObservedState.STOPPING ? "UNKNOWN" : "CONFLICT";
+          ObservedState target =
+              execution.observedState() == ObservedState.STOPPING
+                  ? ObservedState.UNKNOWN
+                  : ObservedState.CONFLICT;
           String message = "runtime job identity 匹配到 " + count + " 个 Flink Job，拒绝自动绑定";
-          transition(taskId, latest, target, "UNKNOWN", null, message);
+          transition(
+              taskId,
+              latest,
+              target,
+              DeploymentState.UNKNOWN,
+              null,
+              message);
         });
   }
 
@@ -143,13 +166,13 @@ public class RealtimeRuntimeStateReconciler {
             if (execution.terminal() || execution.observedState() == ObservedState.UNKNOWN) {
               return;
             }
-            stateMachine.requireTransition(execution, "UNKNOWN");
+            stateMachine.requireTransition(execution, ObservedState.UNKNOWN);
             String message = "Flink 状态不可用" + (detail == null ? "" : "：" + detail);
             store.reconcile(
                 taskId,
                 deployment.id(),
-                "UNKNOWN",
-                "UNKNOWN",
+                ObservedState.UNKNOWN.name(),
+                DeploymentState.UNKNOWN.name(),
                 deployment.engineJobId(),
                 message);
             store.event(
@@ -157,7 +180,7 @@ public class RealtimeRuntimeStateReconciler {
                 deployment.id(),
                 "FLINK_UNAVAILABLE",
                 execution.observedState().name(),
-                "UNKNOWN",
+                ObservedState.UNKNOWN.name(),
                 message);
           });
     } catch (RuntimeException exception) {
@@ -173,42 +196,54 @@ public class RealtimeRuntimeStateReconciler {
           if (latest == null || latest.id() != deploymentId) {
             return;
           }
-          transition(taskId, latest, "UNKNOWN", "UNKNOWN", jobId, message);
+          transition(
+              taskId,
+              latest,
+              ObservedState.UNKNOWN,
+              DeploymentState.UNKNOWN,
+              jobId,
+              message);
         });
   }
 
   private void transition(
       long taskId,
       DeploymentRow deployment,
-      String observed,
-      String deploymentState,
+      ObservedState observed,
+      DeploymentState deploymentState,
       String jobId,
       String error) {
     SyncExecution execution = deployment.execution();
     stateMachine.requireTransition(execution, observed);
-    store.reconcile(taskId, deployment.id(), observed, deploymentState, jobId, error);
-    if (!observed.equals(execution.observedState().name())
+    store.reconcile(
+        taskId,
+        deployment.id(),
+        observed.name(),
+        deploymentState.name(),
+        jobId,
+        error);
+    if (observed != execution.observedState()
         || !Objects.equals(error, execution.errorMessage())) {
       store.event(
           taskId,
           deployment.id(),
           "STATE_RECONCILED",
           execution.observedState().name(),
-          observed,
+          observed.name(),
           error == null ? "Flink 状态已对账" : error);
     }
   }
 
   private void failExpectedRunning(long taskId, DeploymentRow deployment, String message) {
     SyncExecution execution = deployment.execution();
-    stateMachine.requireTransition(execution, "FAILED");
+    stateMachine.requireTransition(execution, ObservedState.FAILED);
     store.markTerminalFailure(taskId, deployment.id(), message);
     store.event(
         taskId,
         deployment.id(),
         "FLINK_JOB_LOST",
         execution.observedState().name(),
-        "FAILED",
+        ObservedState.FAILED.name(),
         message);
   }
 
@@ -216,14 +251,32 @@ public class RealtimeRuntimeStateReconciler {
     ObservedState from = deployment.execution().observedState();
     if (from == ObservedState.STARTING || from == ObservedState.RUNNING) {
       stateMachine.requireTransition(from, ObservedState.STOPPING);
-      store.reconcile(taskId, deployment.id(), "STOPPING", "STOPPING", jobId, null);
+      store.reconcile(
+          taskId,
+          deployment.id(),
+          ObservedState.STOPPING.name(),
+          DeploymentState.STOPPING.name(),
+          jobId,
+          null);
       from = ObservedState.STOPPING;
     }
     if (from != ObservedState.STOPPED) {
       stateMachine.requireTransition(from, ObservedState.STOPPED);
     }
-    store.reconcile(taskId, deployment.id(), "STOPPED", "STOPPED", jobId, null);
-    store.event(taskId, deployment.id(), "STOPPED", from.name(), "STOPPED", message);
+    store.reconcile(
+        taskId,
+        deployment.id(),
+        ObservedState.STOPPED.name(),
+        DeploymentState.STOPPED.name(),
+        jobId,
+        null);
+    store.event(
+        taskId,
+        deployment.id(),
+        "STOPPED",
+        from.name(),
+        ObservedState.STOPPED.name(),
+        message);
   }
 
   private boolean sameDeployment(DeploymentRow expected, DeploymentRow current) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/architecture/RealtimeCodeStyleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/architecture/RealtimeCodeStyleConventionTest.java
@@ -1,0 +1,144 @@
+package io.yak.ops.business.sync.realtime.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Source-level guard for low-ambiguity rules from CODE_STYLE.md. */
+class RealtimeCodeStyleConventionTest {
+
+  private static final Pattern WILDCARD_IMPORT =
+      Pattern.compile("(?m)^import\\s+(?:static\\s+)?[^;]+\\.\\*;");
+  private static final Pattern STRING_STATE_COMPARISON =
+      Pattern.compile(
+          "(?:desiredState|observedState)\\(\\)\\.name\\(\\)\\.equals\\(|"
+              + "\\\"[A-Z_]+\\\"\\.equals\\([^\\n]*(?:desiredState|observedState)\\(\\)\\.name\\(\\)\\)");
+  private static final Pattern MIGRATION_STAGE_COMMENT =
+      Pattern.compile("(?i)\\b(?:stage|wave)[ -]?[0-9]+\\b");
+
+  @Test
+  void productionSourcesAvoidAmbiguousJavaShortcuts() throws IOException {
+    List<Violation> violations = new ArrayList<>();
+    for (SourceFile file : productionSources()) {
+      reject(violations, file, WILDCARD_IMPORT, "wildcard import");
+      rejectLiteral(violations, file, "System.out", "System.out");
+      rejectLiteral(violations, file, "System.err", "System.err");
+      rejectLiteral(violations, file, "@Autowired", "field/framework injection shortcut");
+      rejectLiteral(violations, file, "@Resource", "field/framework injection shortcut");
+      rejectLiteral(violations, file, "@Inject", "field/framework injection shortcut");
+    }
+
+    assertThat(violations)
+        .as("Realtime production code must keep dependencies and diagnostics explicit")
+        .isEmpty();
+  }
+
+  @Test
+  void executionStateComparisonsStayTyped() throws IOException {
+    List<Violation> violations = new ArrayList<>();
+    for (SourceFile file : productionSources()) {
+      reject(
+          violations,
+          file,
+          STRING_STATE_COMPARISON,
+          "string comparison of DesiredState/ObservedState");
+    }
+
+    assertThat(violations)
+        .as("Execution lifecycle decisions must compare domain enums, not enum names")
+        .isEmpty();
+  }
+
+  @Test
+  void submissionCredentialsUseNamedBindingsInsteadOfArrayPositions() throws IOException {
+    List<Violation> violations = new ArrayList<>();
+    for (SourceFile file : productionSources()) {
+      rejectLiteral(
+          violations,
+          file,
+          "CredentialBinding[]",
+          "positional source/sink credential array");
+    }
+
+    assertThat(violations)
+        .as("Source/sink credential ownership must remain explicit at the Engine boundary")
+        .isEmpty();
+  }
+
+  @Test
+  void productionCommentsDescribeCurrentInvariantsNotMigrationStages() throws IOException {
+    List<Violation> violations = new ArrayList<>();
+    for (SourceFile file : productionSources()) {
+      reject(violations, file, MIGRATION_STAGE_COMMENT, "historical Stage/Wave marker");
+    }
+
+    assertThat(violations)
+        .as("Production comments must explain current why/invariant/danger, not migration history")
+        .isEmpty();
+  }
+
+  private void reject(
+      List<Violation> violations, SourceFile file, Pattern pattern, String description) {
+    if (pattern.matcher(file.source()).find()) {
+      violations.add(new Violation(file.relativePath(), description));
+    }
+  }
+
+  private void rejectLiteral(
+      List<Violation> violations, SourceFile file, String fragment, String description) {
+    if (file.source().contains(fragment)) {
+      violations.add(new Violation(file.relativePath(), description));
+    }
+  }
+
+  private List<SourceFile> productionSources() throws IOException {
+    Path root = productionRoot();
+    List<SourceFile> result = new ArrayList<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        result.add(
+            new SourceFile(
+                normalize(root.relativize(file)),
+                Files.readString(file, StandardCharsets.UTF_8)));
+      }
+    }
+    return result;
+  }
+
+  private Path productionRoot() {
+    Path moduleLocal = Paths.get("src/main/java/io/yak/ops/business/sync/realtime");
+    if (Files.isDirectory(moduleLocal)) {
+      return moduleLocal;
+    }
+
+    Path repositoryRelative =
+        Paths.get(
+            "yak-ops-business",
+            "yak-ops-business-sync",
+            "yak-ops-business-sync-realtime",
+            "src/main/java/io/yak/ops/business/sync/realtime");
+    assertThat(Files.isDirectory(repositoryRelative))
+        .as(
+            "Unable to locate realtime-sync production source root from %s",
+            Paths.get(".").toAbsolutePath())
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+
+  private record SourceFile(String relativePath, String source) {}
+
+  private record Violation(String relativePath, String description) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/architecture/RealtimeSyncDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/architecture/RealtimeSyncDependencyBoundaryTest.java
@@ -155,7 +155,7 @@ class RealtimeSyncDependencyBoundaryTest {
   @Test
   void broadBusinessBucketsCannotReturn() {
     Path root = productionRoot();
-    for (String forbidden : Set.of("service", "common", "helper", "utils")) {
+    for (String forbidden : Set.of("service", "common", "helper", "utils", "base")) {
       assertThat(Files.exists(root.resolve(forbidden)))
           .as("Broad business bucket '%s' must not exist under realtime-sync", forbidden)
           .isFalse();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/domain/SyncExecutionStateMachineTest.java
@@ -17,15 +17,25 @@ class SyncExecutionStateMachineTest {
     SyncExecution failed = execution(DesiredState.STOPPED, ObservedState.FAILED);
     SyncExecution stopped = execution(DesiredState.STOPPED, ObservedState.STOPPED);
 
-    assertThatThrownBy(() -> stateMachine.requireTransition(failed, "STARTING"))
+    assertThatThrownBy(
+            () -> stateMachine.requireTransition(failed, ObservedState.STARTING))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("FAILED -> STARTING");
-    assertThatThrownBy(() -> stateMachine.requireTransition(stopped, "STARTING"))
+    assertThatThrownBy(
+            () -> stateMachine.requireTransition(stopped, ObservedState.STARTING))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("STOPPED -> STARTING");
 
     assertThatCode(() -> stateMachine.requireNewExecutionAllowed(failed)).doesNotThrowAnyException();
     assertThatCode(() -> stateMachine.requireNewExecutionAllowed(stopped)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void stringCompatibilityOverloadKeepsExistingTransitionContract() {
+    SyncExecution starting = execution(DesiredState.RUNNING, ObservedState.STARTING);
+
+    assertThatCode(() -> stateMachine.requireTransition(starting, "RUNNING"))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/RealtimeDeployRequestTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/engine/RealtimeDeployRequestTest.java
@@ -7,14 +7,19 @@ import org.junit.jupiter.api.Test;
 class RealtimeDeployRequestTest {
 
   @Test
-  void redactsAndClearsSubmissionCredentials() {
+  void namedBindingsRemainRedactedAndAreClearedWithRequest() {
     RealtimeDeployRequest.CredentialBinding source =
         new RealtimeDeployRequest.CredentialBinding("reader", "source-secret");
     RealtimeDeployRequest.CredentialBinding sink =
         new RealtimeDeployRequest.CredentialBinding("writer", "sink-secret");
+    RealtimeDeployRequest.CredentialBindings credentials =
+        new RealtimeDeployRequest.CredentialBindings(source, sink);
     RealtimeDeployRequest request =
-        new RealtimeDeployRequest("password: ${SECRET:source.password}", "key", source, sink);
+        new RealtimeDeployRequest(
+            "password: ${SECRET:source.password}", "key", credentials);
 
+    assertThat(request.source()).isSameAs(source);
+    assertThat(request.sink()).isSameAs(sink);
     assertThat(request.toString()).doesNotContain("source-secret", "sink-secret");
     assertThat(source.toString()).doesNotContain("source-secret");
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeJobService.java
@@ -20,11 +20,11 @@ import java.util.List;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
- * Test-scope source-compatible adapter for pre-Stage5 behavioral regression tests.
+ * Test-scope source-compatible adapter for the long-lived execution regression suite.
  *
  * <p>This class is not production code and is not a Spring bean. Every command delegates to the
- * real decomposed Execution Core so Stage 2/Wave 5 assertions remain unchanged while the legacy
- * production RealtimeJobService is removed.
+ * real decomposed Execution Core so historical behavioral assertions continue to exercise the
+ * current production path without reintroducing a production compatibility facade.
  */
 final class RealtimeJobService {
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeReconcileSafetyBaselineTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/service/RealtimeReconcileSafetyBaselineTest.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
 /**
- * Stage 2 regression baseline for reconciliation.
+ * Regression baseline for reconciliation uncertainty.
  *
  * <p>The reconciler must converge to explicit UNKNOWN / CONFLICT states when external truth cannot
  * be identified safely. It must never guess a Flink JobId or turn runtime uncertainty into a false


### PR DESCRIPTION
## Summary

基于 Stage 9 已固化的 `CODE_STYLE.md`，对 Realtime Sync 做一次**全模块代码风格与表达质量审计**。

这不是机械格式化，也不是为了让每个文件都产生 diff。原则仍然是：

```text
Correctness / Safety
  > Explicit ownership
  > Simple control flow
  > Testability
  > Reuse
  > Brevity
```

因此本 PR 只修改审计中发现的真实问题；已经符合规范的 Controller、DAO、Repository contract、Environment lifecycle、YAML codec、Pipeline compiler、SSH command boundary 等代码不制造无意义变更。

## Scope

本轮重点覆盖：

```text
Definition
Domain
Execution
Reconcile
Engine / Observability / Probe
Architecture / Code-style guards
Regression tests
```

不改变 REST / DB / Flyway / physical schema。

## 1. Typed execution lifecycle

Execution / Reconcile 之前仍有多处：

```java
desiredState().name().equals("RUNNING")
"STOPPING".equals(observedState().name())
```

这会把明确的 Domain enum 降级成字符串协议。

本 PR 改为直接使用：

```java
DesiredState.RUNNING
ObservedState.STARTING
ObservedState.RUNNING
ObservedState.STOPPING
ObservedState.STOPPED
ObservedState.UNKNOWN
ObservedState.CONFLICT
```

`SyncExecutionStateMachine` 新增 typed transition API；String overload 仅作为 compatibility boundary 保留。

持久化/event 需要字符串时，才在边界 `.name()`。

### Intentionally preserved

状态迁移集合不变：

```text
UNKNOWN != FAILED
CONFLICT != FAILED
STOPPED / FAILED remain terminal
RestartExecution != ApplyPublishedVersion
```

## 2. Explicit absence with Optional

把两个内部“null 表示未命中”的流程改为显式 Optional：

```text
Execution idempotency lookup
Runtime identity JobId recovery
```

因此调用点可以直接表达：

```text
hit -> return existing
empty -> continue command/reconcile flow
```

而不是通过 nullable value + hasText/null check 猜语义。

注意：`Optional.empty()` 只表示“当前没有返回值”，不会替代 `UNKNOWN / CONFLICT` 领域状态。Runtime uncertainty 的状态副作用仍由 Reconcile Core 明确提交。

## 3. Explicit Engine credential ownership

原先 submission credentials 使用：

```java
CredentialBinding[]
credentials[0] // source
credentials[1] // sink
```

source/sink ownership 依赖数组下标隐式约定。

改为：

```text
CredentialBindings
├── source
└── sink
```

并继续保持：

```text
submission-scoped lifetime
try-with-resources
char[] zeroize
redacted toString/logging
no persistence
```

旧的 `(source, sink)` request constructor 保留，避免无意义破坏现有调用/测试 contract。

## 4. Execution command readability

保持 Start 高风险顺序直接可读：

```text
normalize idempotency key
 -> idempotent fast return
 -> prepare immutable DefinitionVersion/environment/artifact
 -> validate
 -> DB reservation / prepared-version re-check
 -> external submit
 -> commit result
```

同时：

- Restart 固定当前 Execution 的 DefinitionVersion；
- Apply 固定命令开始时 Published DefinitionVersion；
- replacement pending 使用原 Idempotency-Key 恢复；
- stop-during-start 仍绑定并取消精确 JobId；
- uncertain external result 仍进入 UNKNOWN / 后续 Reconcile。

## 5. Reconcile state convergence

`RealtimeRuntimeStateReconciler` 之前的 transition helper 同时用 String 承担：

```text
SyncExecution observed state
Deployment compatibility state
```

现在分别使用：

```text
ObservedState
DeploymentState
```

只有 Repository compatibility write 才转换为 String。

Runtime identity recovery 也改成 `Optional<String>`，让未找到 / 多匹配 / grace-window 与成功恢复的调用分支更清楚。

## 6. Engine boundary cleanup

### FlinkCdcEngineGateway

- REST method 从 String 改为内部 enum；
- delivery semantics、submission log tail、destroy wait 使用命名常量；
- JSON parse 只捕获 `JsonProcessingException`；
- 404 nullable 语义写成明确 boundary contract；
- deploy 中 LOCAL / SSH choice 只计算一次。

提交协议、临时 YAML、安全清理、redaction、jobId parsing 都不改变。

### FlinkObservabilityClient

- invalid JSON 与网络 IOException 分开；
- invalid Flink response 不再误报成“连接失败”；
- runtime exception limit 使用命名常量；
- vertex name null handling 显式化。

Observability 仍是 read-only，不写 Execution state。

### FlinkRuntimeEnvironmentProbe

- version command timeout / diagnostic message limit 使用命名常量；
- `SshProbeVersions` 改为更准确的 `ProbeVersions`（LOCAL/SSH 共用）；
- 收敛 local/ssh version result 赋值；
- 展开关键异常/cleanup guard，便于 review。

## 7. Definition / Domain comments

- Definition physical-table type normalization 使用 `Locale.ROOT`；
- `SyncExecution` 删除历史 Stage migration 注释，只保留当前 invariant；
- test-scope compatibility fixture 说明改成“为什么现在仍存在”，不依赖 Stage/Wave 历史。

## 8. New permanent style guard

新增：

```text
RealtimeCodeStyleConventionTest
```

直接扫描整个 realtime production Java source，锁住低争议、可执行的永久规则：

```text
no wildcard import
no System.out / System.err
no @Autowired / @Resource / @Inject shortcut
no string comparison of DesiredState / ObservedState
no positional CredentialBinding[] source/sink contract
no Stage/Wave migration markers in production comments
```

同时补齐现有 `RealtimeSyncDependencyBoundaryTest`：

```text
service / common / helper / utils / base
```

都不能重新成为 production 业务大桶。

## Tests updated

- `SyncExecutionStateMachineTest`
  - 新代码走 typed transition；
  - String compatibility overload 仍被覆盖。
- `RealtimeDeployRequestTest`
  - named credential bindings；
  - redaction / zeroize contract 继续锁定。
- 现有 Start / Stop / Restart / Apply / Reconcile safety baseline 保持不删除、不弱化。

## Full-module audit result

审计了最终 package 结构：

```text
controller
definition
execution/query
reconcile
observability
environment
engine
repository/support
dao
domain
config
```

本轮没有为了“所有代码”强行修改已符合规范的文件。尤其：

- Controller 仍只进入 stable Application Facade；
- Environment Manager role 清楚，transaction/lifecycle guard 清楚；
- RealtimeYamlCodec 已使用明确 record DTO，不需要再拆；
- PipelineYamlCompiler 保持 password-free artifact boundary；
- SSH runner 的 shell/probe/submit 逻辑属于同一 external boundary，未过度拆分；
- Repository/DAO contract 没有反向依赖 Application。

## Intentionally unchanged

本 PR 不改变：

- REST path / HTTP DTO / VO；
- DB / Flyway / schema；
- Task / DefinitionVersion / SyncExecution 模型关系；
- Published Version immutable contract；
- Idempotency-Key ownership；
- single Active/Uncertain invariant；
- Start reservation-before-submit；
- Restart/Apply target pinning；
- stop-during-start；
- UNKNOWN / CONFLICT semantics；
- runtime identity persistence/recovery rules；
- RuntimeEnvironmentSnapshot freeze semantics；
- sensitive configuration lifetime/redaction boundary；
- Flink CDC CLI / SSH submission behavior。

## Branch validation before PR

```text
base: main @ e0832ed6fe3fe5a26a86deb9cef6134de769d8d1
branch: refactor/realtime-sync-code-style-cleanup
ahead: 23
behind: 0
changed files: 23
DB/Flyway changes: 0
REST contract changes: 0
```

已做静态 source audit，包括：

```text
no @Autowired
no Stage migration marker in production
no CredentialBinding[] positional contract
no string RUNNING equality pattern found
no System.out
```

当前执行环境没有完整本地仓库构建能力，因此没有把静态审计宣称为 Maven/JUnit 已通过；以 GitHub checks/CI（如仓库配置）为准。

## Review focus

```text
[ ] typed state comparison 没有改变允许的 lifecycle transition
[ ] idempotent fast-path 仍在 prepare/submit 之前
[ ] Restart / Apply target pinning 不漂移
[ ] UNKNOWN / CONFLICT 没有被转成 FAILED
[ ] Runtime identity recovery Optional 不吞掉 reconcile side effect
[ ] named CredentialBindings 不扩大 credential lifetime
[ ] Engine JSON error classification 不改变 uncertainty safety
[ ] style guard 没有编码个人审美，只保护 CODE_STYLE.md 的明确规则
[ ] Controller/Repository/DAO/Environment 没有被无意义重写
[ ] REST / DB / Flyway / runtime behavior contract 保持不变
```