### PR TITLE
refactor(quality): close stage 2 architecture governance

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-quality/ARCHITECTURE.md
@@ -1,0 +1,262 @@
+# Data Quality Architecture
+
+本文件描述 Data Quality **当前长期架构**。它只记录现在有效的 package、角色、truth ownership 和调用边界，不记录 Stage / Wave 迁移过程。
+
+需求看 `REQUIREMENTS.md`，领域规则看 `DOMAIN.md`，依赖矩阵看 `DEPENDENCIES.md`，统一工程规范看仓库根目录 [`../../CODE_STYLE.md`](../../CODE_STYLE.md)。
+
+## 1. Principles
+
+1. **业务子系统优先。** package 本身表达架构，而不是统一堆进 service/impl。
+2. **角色名表达职责。** Manager / Reader / Policy / Factory / Dispatcher / Worker / Recorder / Gateway / Adapter 不互相冒充。
+3. **Command 与 Read Side 分开。** Reader/Projector 不修改 Monitor/Execution 生命周期。
+4. **执行快照冻结。** Worker 消费 enqueue-time `QualityExecutionPlan`，不回读 current Monitor 改写本次执行。
+5. **外部能力停在 Gateway。** Datasource typed Catalog 通过 Quality-owned Gateway 进入。
+6. **Persistence 走 Repository port。** Application role 不直接依赖 DAO/PO/MyBatis。
+7. **Schedule 是投影。** MonitorSettings 是业务配置 truth，Yak Schedule 只负责触发。
+8. **架构规则可执行。** dependency/corridor/code-style tests 与文档共同维护。
+
+## 2. Package Map
+
+```text
+io.yak.ops.business.quality
+├── controller
+│   └── v1/mapper          # HTTP inbound / DTO-VO mapping
+├── asset                  # table registration + candidate/read policy
+├── monitor                # monitor/rule/settings lifecycle
+├── execution              # admission / plan / dispatch / worker
+├── alert                  # alert evidence recorder
+├── schedule               # schedule lifecycle / framework bridge / callback
+├── template               # built-in/custom template + folder
+├── workspace              # report/workspace/log read side
+├── gateway
+│   └── datasource         # Quality-owned Datasource port + adapter
+├── repository             # narrow persistence ports + adapters
+├── dao                    # MyBatis persistence primitives
+├── domain
+│   └── execution          # immutable execution snapshot
+└── config                 # properties / condition / wiring
+```
+
+production 不创建 `service / common / helper / utils / base` 业务大桶。
+
+## 3. Application Entry
+
+Quality 当前**没有额外的通用 `@Service` facade**。
+
+Controller 直接进入已经声明的专业 Application role：
+
+```text
+QualityTableAssetController
+    -> QualityTableAssetManager
+    -> QualityTableAssetReader
+    -> QualityTableCandidateReader
+
+QualityMonitorController
+    -> QualityMonitorManager
+    -> QualityMonitorReader
+
+QualityExecutionController
+    -> QualityExecutionManager
+    -> QualityExecutionReader
+
+CustomTemplateController
+    -> CustomTemplateManager / Reader
+    -> TemplateFolderManager / Reader
+
+QualityWorkspaceController
+    -> QualityWorkspaceReader
+
+QualityExecutionWorkspaceController
+    -> QualityExecutionWorkspaceReader
+    -> QualityExecutionLogProjector
+```
+
+这不是“没有 Application 层”，而是 Application role 已经通过 Manager/Reader 等明确命名表达，不需要再包装一层无业务价值的 Service。
+
+## 4. Asset Subsystem
+
+```text
+Controller
+ -> QualityTableAssetManager / Reader / CandidateReader
+        |
+        +-> QualityTableTargetPolicy
+        +-> QualityTableAssetRepository
+        `-> QualityDataCatalogGateway
+```
+
+角色：
+
+- `QualityTableAssetManager`：注册/取消注册生命周期；
+- `QualityTableAssetReader`：已注册资产 read model；
+- `QualityTableCandidateReader`：Datasource 物理表候选列表；
+- `QualityTableTargetPolicy`：database/schema/table identity 与字符串标准化规则；
+- `QualityDataCatalogGateway`：Quality 所需的 Datasource 最小能力。
+
+Manager 不把 Reader 当 Helper，Reader 也不拥有注册状态变化。
+
+## 5. Monitor Subsystem
+
+```text
+QualityMonitorManager
+    ├── QualityMonitorPolicy
+    ├── QualityRulePolicy
+    ├── QualityMonitorSettingsPolicy
+    ├── QualityMonitorRepository
+    ├── QualityExecutionRepository   # active-execution safety
+    `── QualityScheduleLifecycle
+
+QualityMonitorReader
+    `── QualityMonitorRepository
+```
+
+Manager 拥有 Monitor/Rule/Settings 的事务性生命周期；Policy 只做 deterministic validate/normalize；Reader 只查询。
+
+## 6. Execution Subsystem
+
+高风险主路径保持显式：
+
+```text
+QualityExecutionManager
+    -> lock/validate admission
+    -> insert WAITING Execution
+    -> QualityExecutionPlanFactory
+    -> immutable QualityExecutionPlan
+    -> QualityExecutionDispatcher
+         -> afterCommit
+         -> qualityExecutionTaskExecutor
+         -> QualityExecutionWorker
+              -> QualitySqlCompiler
+              -> QualityMetricEvaluator
+              -> QualityDataCatalogGateway
+              -> QualityExecutionRepository
+              -> QualityMonitorRepository
+              -> QualityAlertRecorder
+```
+
+角色：
+
+- `Manager`：受理 manual/scheduled execution；
+- `PlanFactory`：冻结本次执行需要的 Monitor/Rule/Settings 快照；
+- `Dispatcher`：事务提交后分发，不拥有最终结果；
+- `Worker`：执行规则并提交 execution evidence；
+- `Compiler` / `Evaluator`：规则 SQL 和 metric 判断；
+- `Reader`：查询 Execution；
+- `Receipt`：受理结果值对象。
+
+## 7. Schedule Subsystem
+
+```text
+Monitor Manager
+    -> QualityScheduleLifecycle
+          -> QualityScheduleEngineBridge
+          -> QualityMonitorRepository
+
+Yak Schedule callback
+    -> QualityScheduleHandler
+          -> validate current Monitor/Settings
+          -> QualityExecutionManager.runScheduled
+          -> refresh runtime projection
+```
+
+`QualityMonitorSettingsPolicy` 可以使用 `QualityScheduleCalculator` 计算/验证 cron 表达，但 schedule package 不反向调用 Monitor Manager。
+
+`QualityScheduleReconciler` 负责从业务配置恢复 framework projection；它不拥有 Monitor 配置 truth。
+
+## 8. Alert Subsystem
+
+```text
+QualityExecutionWorker
+    -> QualityAlertRecorder
+         -> QualityAlertRepository
+```
+
+Recorder 是 best-effort notification evidence boundary。Alert 写入失败只记录日志，不改写已经确认的 Execution result。
+
+## 9. Template Subsystem
+
+```text
+QualityTemplateReader
+CustomTemplateManager / Reader / Policy
+TemplateFolderManager / Reader
+        -> narrow template repositories
+```
+
+Template Policy 负责自定义 SQL 和参数 schema 的 validate/normalize；Template Manager/Folder Manager 负责生命周期；Reader 不写状态。
+
+## 10. Workspace Read Side
+
+```text
+QualityWorkspaceReader
+    -> QualityMonitorReader
+    -> QualityWorkspaceRepository
+
+QualityExecutionWorkspaceReader
+    -> QualityExecutionWorkspaceRepository
+
+QualityExecutionLogProjector
+    -> persisted Execution / RuleExecution values only
+```
+
+Workspace 只做查询与 projection，不能出现 Monitor save/delete、Execution run 或 Schedule sync。
+
+## 11. Datasource Boundary
+
+Quality 与 Datasource 的唯一实现级连接点：
+
+```text
+QualityDataCatalogGateway               # Quality-owned port
+        ^
+        |
+DataSourceQualityCatalogAdapter         # only external adapter
+        |
+        v
+Datasource DataSourceCatalogReader
+```
+
+只有该 Adapter 可以 import `io.yak.ops.business.datasource.*`。
+
+Asset / Execution 不允许为了方便直接调用 Datasource Reader、Repository、DAO、Plugin 或 Controller。
+
+## 12. Persistence Boundary
+
+```text
+Application role
+    -> Quality*Repository interface
+    -> Repository Adapter
+    -> Quality*Dao
+    -> PO / Mapper XML / MyBatis
+```
+
+Repository port 不暴露 DTO/VO/PO/MyBatis。
+
+目前较大的 `QualityRepositoryAdapter` 仍是 persistence adapter，不是 Application Service；它实现多个窄 port 是当前持久化实现选择。若未来需要拆分，应按 persistence responsibility 独立重构，不改变 port contract。
+
+## 13. Truth Ownership
+
+```text
+TableAsset                 = registered physical quality target
+Monitor + Rules + Settings = current monitor definition truth
+QualityExecutionPlan       = immutable enqueue-time execution truth
+Execution                  = execution lifecycle/result evidence
+RuleExecution              = per-rule evidence
+Monitor last-*             = execution projection
+AlertEvent                 = notification evidence
+Yak Schedule               = trigger projection
+Datasource Catalog         = physical metadata evidence
+```
+
+出现两个角色同时“决定”同一个 truth 时，先修 ownership，不要通过事件、静态工具或新的 Context 掩盖冲突。
+
+## 14. Change Rule
+
+新增或移动代码前依次回答：
+
+1. 属于哪个 Quality subsystem？
+2. 角色是什么？Manager/Reader/Policy/Worker/Gateway 是否准确？
+3. 它拥有哪个 truth，还是只读取/投影？
+4. 新 import 是否符合 `DEPENDENCIES.md`？
+5. 是否跨 Datasource？如果是，为什么 QualityDataCatalogGateway 不够？
+6. 是否让 Worker 回读 current Monitor 改写 frozen plan？
+7. 哪个 behavior test 与 architecture test 会保护这次改动？
+
+答不清楚时不要创建新的 Helper/Common/ServiceImpl。

--- a/yak-ops-business/yak-ops-business-quality/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-quality/DEPENDENCIES.md
@@ -1,0 +1,209 @@
+# Data Quality Dependencies
+
+本文件定义 Data Quality package 的**允许依赖方向、跨子系统 corridor 和跨模块边界**。原则：**显式、窄、无环**。
+
+架构角色看 `ARCHITECTURE.md`；统一工程规则看仓库根目录 [`../../CODE_STYLE.md`](../../CODE_STYLE.md)。如果代码与本文件冲突，先判断代码是否越界，不要直接扩大白名单。
+
+## 1. Top-level Dependency Matrix
+
+Quality production 内部允许的 top-level 依赖：
+
+| Source | Allowed Quality packages |
+| --- | --- |
+| `controller` | `asset`, `config`, `domain`, `execution`, `monitor`, `template`, `workspace` |
+| `workspace` | `config`, `domain`, `monitor`, `repository` |
+| `monitor` | `config`, `domain`, `repository`, `schedule` |
+| `schedule` | `config`, `domain`, `execution`, `repository` |
+| `execution` | `alert`, `config`, `domain`, `gateway`, `repository` |
+| `alert` | `config`, `domain`, `repository` |
+| `asset` | `config`, `domain`, `gateway`, `repository` |
+| `template` | `config`, `domain`, `repository` |
+| `gateway` | `config` |
+| `repository` | `config`, `dao`, `domain` |
+| `dao` | none |
+| `domain` | none |
+| `config` | none |
+
+同一 top-level package 内部可以互相协作，但不会因此自动成为其他 package 的公共 API。
+
+声明图和实际源码图都必须无环。
+
+## 2. Controller Corridors
+
+Controller 只能进入显式 Application role，不允许直接调用 Repository / DAO / Gateway / Schedule engine。
+
+当前可用角色族：
+
+```text
+asset      -> Manager / Reader / CandidateReader
+monitor    -> Manager / Reader
+execution  -> Manager / Reader
+workspace  -> Reader / Projector
+template   -> Manager / Reader
+```
+
+Controller transport mapper 只负责 DTO/VO 与 Quality command/domain/read values 的边界转换。
+
+## 3. Monitor -> Schedule
+
+Monitor 跨入 Schedule 只允许：
+
+```text
+QualityMonitorManager
+    -> QualityScheduleLifecycle
+
+QualityMonitorSettingsPolicy
+    -> QualityScheduleCalculator
+```
+
+Monitor 不直接依赖 ScheduleHandler、EngineBridge 或 Reconciler。
+
+## 4. Schedule -> Execution
+
+Schedule callback 进入 Execution 只允许：
+
+```text
+QualityScheduleHandler
+    -> QualityExecutionManager
+```
+
+Schedule 不能直接：
+
+- insert/update Execution；
+- 调用 Worker；
+- 调用 Dispatcher；
+- 自己复制 execution admission 规则。
+
+## 5. Workspace -> Monitor
+
+Workspace 读取 Monitor 当前定义只允许：
+
+```text
+QualityWorkspaceReader
+    -> QualityMonitorReader
+```
+
+其他 workspace projection 优先直接依赖自己的 read Repository；Workspace 不进入 Monitor Manager。
+
+## 6. Execution -> Alert
+
+Execution 触发告警只允许：
+
+```text
+QualityExecutionWorker
+    -> QualityAlertRecorder
+```
+
+Execution 不直接写 Alert DAO/PO；Alert 也不反向调用 Execution Manager/Worker。
+
+## 7. Quality-owned Datasource Gateway
+
+Asset / Execution 使用 Datasource 能力时只依赖：
+
+```text
+QualityDataCatalogGateway
+```
+
+当前允许：
+
+```text
+asset     -> QualityDataCatalogGateway
+execution -> QualityDataCatalogGateway
+```
+
+禁止 business role 直接 import：
+
+```text
+io.yak.ops.business.datasource.controller.*
+io.yak.ops.business.datasource.repository.*
+io.yak.ops.business.datasource.dao.*
+io.yak.ops.business.datasource.plugin.*
+```
+
+### External Datasource corridor
+
+Quality 对 Datasource 模块只有两个明确入口：
+
+```text
+config/QualityConfiguration
+    -> datasource.config.BusinessDatabaseConfiguration
+       # infrastructure wiring only
+
+gateway/datasource/DataSourceQualityCatalogAdapter
+    -> datasource.catalog.DataSourceCatalogReader
+    -> datasource.domain.catalog.CatalogReadRequest
+       # typed Catalog capability only
+```
+
+不得扩大为 Quality business package 直接依赖 Datasource implementation。
+
+## 8. Persistence Boundary
+
+```text
+Manager / Reader / Worker / Policy owner
+    -> narrow Quality*Repository port
+    -> RepositoryAdapter
+    -> DAO / PO / Mapper XML
+```
+
+底层规则：
+
+```text
+Domain     -> no Quality upper-layer dependency
+DAO        -> no Quality business dependency
+Repository -> config + dao + domain only
+```
+
+Repository contract 不暴露：
+
+- Quality HTTP DTO/VO；
+- Quality PO；
+- MyBatis `IPage` / Mapper；
+- Datasource DTO/VO/PO。
+
+分页 Repository 继续使用 shared `io.yak.framework.common.PageData<T>`。
+
+## 9. Config Boundary
+
+`config` 只负责：
+
+- feature condition；
+- properties；
+- Flyway；
+- executor；
+- MapperScan；
+- infrastructure configuration import。
+
+业务角色不由 `QualityConfiguration` 手工 new / `@Bean` 反向装配。
+
+因此禁止重新建立：
+
+```text
+config -> execution/monitor/asset/template/workspace
+         -> config
+```
+
+内部专业角色应使用正常 constructor injection + `@Component`。
+
+## 10. No Cycles
+
+不允许通过以下方式掩盖 package cycle：
+
+- `@Lazy`；
+- ApplicationContext lookup；
+- 静态 Service Locator；
+- 把接口随意移动到第三个 `common` package；
+- 扩大 dependency-test 白名单。
+
+发现环时先明确能力 owner，再建立窄 Gateway / Reader / Lifecycle corridor。
+
+## 11. Adding a New Dependency
+
+新增一个 import 不在允许矩阵时按顺序判断：
+
+1. **类是否放错 package？**
+2. **已有 Manager / Reader / Gateway / Repository 是否能表达？**
+3. **是否缺一个由能力 owner 定义的窄 contract？**
+4. **架构是否真的改变？**
+
+只有第 4 种情况才在同一个 PR 更新 `ARCHITECTURE.md`、本文件和 executable dependency test。

--- a/yak-ops-business/yak-ops-business-quality/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-quality/DOMAIN.md
@@ -1,0 +1,225 @@
+# Data Quality Domain
+
+本文件定义 Data Quality **当前领域事实、生命周期和 truth ownership**。历史重构过程不属于 Domain contract。
+
+## 1. Core Identity
+
+Quality 中需要长期区分的对象：
+
+```text
+TableAsset
+    != Monitor
+    != QualityExecutionPlan
+    != Execution
+    != RuleExecution
+    != AlertEvent
+```
+
+它们不能因为字段相似而合并成一个通用 Job/Task 状态对象。
+
+## 2. TableAsset
+
+`TableAsset` 表示已经被 Data Quality 注册并认可的物理表身份。
+
+它保存 Quality 需要的物理目标描述，但真实物理元数据在注册/候选读取时来自 Datasource typed Catalog boundary。
+
+硬规则：
+
+- 注册目标必须能由 Datasource Catalog 发现；
+- database / schema / table 共同参与物理目标 identity；
+- 已被 Monitor 使用的 TableAsset 不能直接取消注册；
+- TableAsset 不是 Datasource aggregate 的副本，也不能成为新的 datasource truth owner。
+
+## 3. Monitor Definition Truth
+
+当前质量监控定义由以下事实共同组成：
+
+```text
+Monitor
++ Rules
++ MonitorSettings
+```
+
+Monitor 拥有：目标表、owner、enabled 等长期配置。
+
+Rules 拥有：template、rule type/scope、column、operator、threshold、自定义 SQL 等规则配置。
+
+MonitorSettings 拥有：MANUAL/SCHEDULE、调度表达、RuleFailureAction、通知配置和 alert level。
+
+Monitor 的 last-result / last-execution 等字段是运行结果投影，不是新执行计划的配置来源。
+
+## 4. Execution Admission
+
+一次新执行只有在 admission 成功后成立。
+
+当前安全顺序：
+
+```text
+lock Monitor
+ -> require existing/enabled Monitor
+ -> require enabled Rule
+ -> reject active Execution collision
+ -> insert WAITING Execution
+ -> freeze QualityExecutionPlan
+ -> afterCommit dispatch
+```
+
+同一 Monitor 最多一个 active Execution。
+
+没有成功提交持久化事务，就不能把 Worker 当成已受理执行。
+
+## 5. QualityExecutionPlan
+
+`QualityExecutionPlan` 是 enqueue 时冻结的**不可变执行快照**。
+
+```text
+current Monitor / Rules / Settings
+        |
+        | enqueue
+        v
+QualityExecutionPlan (immutable)
+        |
+        v
+Worker
+```
+
+它不是 current Monitor 的引用，也不是 DTO。
+
+一旦生成：
+
+- Monitor 后续改名、换 owner、修改目标或禁用，不能改写已入队计划；
+- Rule 后续新增/删除/改阈值，不能改写已入队计划；
+- Settings 后续修改 STOP/CONTINUE、通知配置，不能改写已入队计划；
+- Worker 不回读 current Monitor 重新决定本次规则集合。
+
+如果未来某个需求需要“执行中动态读取最新规则”，必须作为新的 Domain Gap 明确设计，不能用一次 repository query 偷偷绕过 snapshot 语义。
+
+## 6. Execution Evidence
+
+`Execution` 表示一次质量检查的持久化业务事实。
+
+`RuleExecution` 表示本次 Execution 中一条规则的实际执行证据。
+
+执行状态和检查结果由执行流程写入；Workspace/Controller/Alert 只能读取或投影，不能成为第二 owner。
+
+硬规则：
+
+- WAITING 记录必须先于异步 Worker；
+- Worker 开始后通过 repository CAS/transition 更新为运行态；
+- final CheckResult 由实际规则结果推导；
+- ERROR evidence 不能被当成 PASSED；
+- RuleFailureAction.STOP 下未执行规则必须留下 `NOT_RUN` evidence，而不是静默消失；
+- queue rejection 必须留下可查询的 ERROR 结果；
+- 一个旧 Worker/重复 dispatch 不能创建第二份同一 Execution truth。
+
+## 7. Rule Result Semantics
+
+当前规则结果保持互斥语义：
+
+```text
+PASSED       = 已执行且满足规则
+NOT_PASSED   = 已执行但不满足规则
+ERROR        = 规则本身执行异常
+RUNNING      = 运行中投影
+NOT_RUN      = 因执行策略未执行
+```
+
+`NOT_RUN != ERROR != NOT_PASSED`。
+
+不要为了统计简单把这些状态折叠成一个 boolean success。
+
+## 8. STOP / CONTINUE
+
+`RuleFailureAction` 属于 enqueue-time plan。
+
+- `CONTINUE`：按当前执行计划继续后续规则；
+- `STOP`：发现前序非 PASSED 结果后停止真实执行，剩余规则记录为 NOT_RUN。
+
+这条策略不能在 Worker 中回读 current MonitorSettings 重新决定。
+
+## 9. Schedule Truth
+
+Quality Schedule 的业务真相属于：
+
+```text
+Monitor.enabled
++ MonitorSettings.runMode / schedule fields
+```
+
+Yak Schedule 只是 runtime trigger projection。
+
+因此：
+
+- 保存/修改 MonitorSettings 后由 `QualityScheduleLifecycle` 同步外部调度；
+- Schedule 丢失或应用重启可以从业务表恢复；
+- framework snapshot 的 `nextFireTime` 可以投影回 MonitorSettings.nextRunTime；
+- framework 不能反向成为 Monitor 是否启用调度的配置 owner；
+- Schedule Handler 接受触发后仍必须走 `QualityExecutionManager` admission。
+
+## 10. Alert Truth
+
+`AlertEvent` 是通知/告警证据，不是 Execution 结果。
+
+```text
+Execution final result
+      |
+      v
+QualityAlertRecorder
+      |
+      v
+AlertEvent
+```
+
+Alert 记录失败不能把已经确认的 Execution 结果改成另一状态。
+
+## 11. Template Domain
+
+QualityTemplate / CustomTemplate / TemplateFolder 是规则定义支持域，不拥有 Monitor runtime truth。
+
+- built-in Template 为内置可读定义；
+- CustomTemplate 拥有自定义 SQL、check method/type、parameter schema、folder 等自定义定义；
+- TemplateFolder 只拥有模板组织结构；
+- Monitor Rule 在保存时经过 Policy 标准化，不能直接把 HTTP DTO 当作持久化/执行模型。
+
+## 12. Datasource Boundary
+
+Quality 不拥有 Datasource 连接、Plugin 或 Catalog truth。
+
+跨模块只允许：
+
+```text
+Quality role
+ -> QualityDataCatalogGateway
+ -> DataSourceQualityCatalogAdapter
+ -> Datasource typed Catalog API
+```
+
+Quality Core Domain 不知道 Datasource DTO/VO/PO、Repository、DAO 或 Plugin Registry。
+
+`QualityQueryResult` 中的动态 row map 是外部 SQL preview 的边界表示；它不能扩展为 Quality 长期业务模型。
+
+## 13. Persistence Boundary
+
+Application 角色依赖窄 Repository port，而不是 DAO。
+
+```text
+Business role
+ -> Quality*Repository
+ -> RepositoryAdapter
+ -> Quality*Dao / PO
+```
+
+Repository contract 使用 Domain / Query model 和 shared `PageData`；HTTP DTO/VO、PO、MyBatis 类型不允许泄漏到业务角色。
+
+## 14. Domain Gap Rule
+
+出现以下需求时先报告 Domain Gap，而不是增加隐藏 flag：
+
+- 同 Monitor 多并发执行；
+- queued Execution 自动切换到最新 Monitor 定义；
+- 执行中动态修改规则集合；
+- Alert delivery 反向决定 Execution result；
+- Quality 自己成为 Datasource metadata owner；
+- 新的规则状态被强塞进现有 PASSED/NOT_PASSED/ERROR/NOT_RUN。
+
+现有领域表达不了的需求，应先更新本文件和行为测试，再修改实现。

--- a/yak-ops-business/yak-ops-business-quality/README.md
+++ b/yak-ops-business/yak-ops-business-quality/README.md
@@ -1,27 +1,95 @@
 # Yak Ops Data Quality
 
-数据质量模块遵循 Yak Ops 统一业务分层：
+Data Quality 是 Yak Ops 的数据质量控制面，负责数据表资产注册、质量监控定义、规则/模板管理、手动与调度执行、告警证据和质量工作台查询。
+
+当前核心执行关系：
 
 ```text
-Controller -> DTO -> Service -> Domain
-           -> Repository -> Adapter -> DAO
-           -> BaseMapper / Mapper XML -> PO -> MySQL
+Table Asset
+    -> Monitor + Rules + Settings
+    -> enqueue immutable QualityExecutionPlan
+    -> Execution + RuleExecution evidence
 ```
 
-分页统一遵循：
+## Read First
+
+本目录只维护**当前有效 contract**。历史 Stage / Wave / 重构过程通过 Git / PR 追溯。
+
+建议按顺序阅读：
+
+| Document | Answers |
+| --- | --- |
+| [`REQUIREMENTS.md`](./REQUIREMENTS.md) | 模块必须提供哪些行为 |
+| [`DOMAIN.md`](./DOMAIN.md) | 哪些业务事实和生命周期不能违反 |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 代码放哪里、各角色如何协作 |
+| [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package 可以依赖谁、跨边界走哪里 |
+| [`../../CODE_STYLE.md`](../../CODE_STYLE.md) | Yak Ops 统一工程与角色规范 |
+| [`REVIEW.md`](./REVIEW.md) | Quality PR 按什么标准评审 |
+
+## Package Shape
 
 ```text
-DAO / Mapper             Repository / Service             HTTP
-持久化查询  -> Adapter -> PageData<Domain> -> View ->     现有分页 VO / PagingData
+quality/
+├── controller       # HTTP inbound + transport mapper
+├── asset            # registered quality table lifecycle / candidate read
+├── monitor          # monitor/rule/settings lifecycle and policy
+├── execution        # execution admission / immutable plan / dispatch / worker
+├── alert            # alert evidence recording
+├── schedule         # Yak Schedule projection and callback boundary
+├── template         # built-in/custom template and folder lifecycle
+├── workspace        # workspace/report/log read-side projection
+├── gateway          # Quality-owned external capability ports + adapters
+├── repository       # business persistence ports + adapters
+├── dao              # MyBatis persistence primitives
+├── domain           # framework-free business values / execution snapshot
+└── config           # module wiring and properties
 ```
 
-约束：
+production 不再维护 `quality/service/**`。Quality 当前也不引入一个新的通用 `@Service` facade；Controller 直接进入声明过的 Manager / Reader / Projector 角色。
 
-- Repository 对外分页统一使用 `io.yak.framework.common.PageData<T>`，不暴露 MyBatis `IPage`。
-- Data Quality 不再维护 `QualityDomain.Page` 等模块私有普通分页容器。
-- Repository Adapter 负责根据 `total/current/pageSize` 计算完整的 `pages` 元数据并构造 `PageData`。
-- Service 继续按现有 VO 契约输出 `records/total/current/pageSize` 等质量模块接口字段，不修改 HTTP JSON。
-- DAO / Mapper 仍可使用持久化层自己的分页参数、limit/offset 和 MyBatis 能力。
-- 新增分页功能不得再创建普通 `Page/XxxPage` 类型，应直接复用 `PageData<T>`；只有包含独立业务语义的分页类型才允许例外。
+## Truth Ownership
 
-全局分页边界规范由 Yak Framework `docs/pagination-conventions.md` 定义。
+```text
+TableAsset                  = 已注册的数据质量物理表事实
+Monitor + Rules + Settings  = 当前质量监控定义事实
+QualityExecutionPlan        = enqueue 时冻结的不可变执行快照
+Execution                   = 一次质量检查的持久化执行事实
+RuleExecution               = 单条规则的执行证据
+Yak Schedule                = 时间触发投影，不是 Monitor 配置真相
+AlertEvent                  = 告警/通知证据，不是 Execution 状态真相
+```
+
+已入队或运行中的执行不得通过回读当前 Monitor / Rule / Settings 改写自己的执行快照。
+
+## Main Boundaries
+
+Datasource：
+
+```text
+Quality business role
+    -> QualityDataCatalogGateway
+    -> DataSourceQualityCatalogAdapter
+    -> DataSourceCatalogReader
+```
+
+Persistence：
+
+```text
+Manager / Reader / Worker
+    -> narrow Repository port
+    -> RepositoryAdapter
+    -> DAO / PO / MyBatis
+```
+
+Execution：
+
+```text
+QualityExecutionManager
+    -> QualityExecutionPlanFactory
+    -> immutable QualityExecutionPlan
+    -> QualityExecutionDispatcher (afterCommit)
+    -> QualityExecutionWorker
+    -> QualityAlertRecorder
+```
+
+完整依赖矩阵和窄 corridor 见 `DEPENDENCIES.md`。

--- a/yak-ops-business/yak-ops-business-quality/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-quality/REQUIREMENTS.md
@@ -1,0 +1,160 @@
+# Data Quality Requirements
+
+本文件定义 Data Quality **当前必须保持的行为 contract**。它描述业务能力和兼容要求，不记录历史 Stage / Wave。
+
+领域不变量看 `DOMAIN.md`，代码职责看 `ARCHITECTURE.md`，依赖方向看 `DEPENDENCIES.md`，统一工程规范看仓库根目录 [`../../CODE_STYLE.md`](../../CODE_STYLE.md)。
+
+## 1. Table Asset
+
+Data Quality 必须以已注册的物理表作为质量监控目标。
+
+- 注册前必须通过 Datasource 的 typed Catalog 能力确认物理表仍真实存在；
+- Datasource 插件返回的 database / schema / table type / remarks 是注册时物理元数据的权威来源；
+- 客户端不能通过注册请求伪造物理表类型或备注覆盖 Datasource 事实；
+- 候选表列表必须排除已经注册的目标；
+- 已被质量监控引用的 Table Asset 不能直接取消注册；
+- Data Quality 不直接依赖 Datasource HTTP DTO/VO、DAO、Repository 或 Plugin Registry。
+
+## 2. Monitor / Rule / Settings
+
+质量监控由 Monitor、Rules 和 MonitorSettings 共同定义。
+
+必须保持：
+
+- 监控目标必须符合当前已注册表和目标唯一性约束；
+- Monitor 名称、负责人、数据源和物理表身份必须经过现有 Policy 校验；
+- Rule 的 scope、类型、阈值、区间、自定义 SQL 等继续由 Quality-owned Policy 标准化和验证；
+- MonitorSettings 继续支持 MANUAL / SCHEDULE 两种运行方式；
+- 调度周期、时间、weekday、cron、失败动作、通知渠道和通知目标继续由 Settings Policy 统一标准化；
+- MANUAL 模式不保留无效调度参数；
+- 非消息类通知在启用时必须具备可用通知目标；
+- 删除 Monitor 前必须确认没有活动执行。
+
+## 3. Execution Admission
+
+手动执行和调度执行进入同一 Quality Execution 生命周期。
+
+执行受理必须：
+
+1. 锁定 Monitor；
+2. 确认 Monitor 存在且 enabled；
+3. 至少存在一条 enabled Rule；
+4. 同一 Monitor 不存在另一个 active Execution；
+5. 持久化 WAITING Execution；
+6. 在受理时构造 immutable `QualityExecutionPlan`；
+7. 只在事务提交成功后分发 Worker。
+
+当前不允许同一 Monitor 并发创建多个活动执行。
+
+## 4. Frozen Execution Plan
+
+`QualityExecutionPlan` 是 enqueue-time immutable snapshot。
+
+它必须冻结一次执行真正需要的：
+
+- Monitor identity / datasource / physical target；
+- Rule snapshot；
+- Rule failure action；
+- notification configuration；
+- alert level。
+
+Execution 一旦受理，后续修改当前 Monitor / Rule / Settings 不能改变已入队或运行中的执行计划。
+
+Worker 只能消费收到的 `QualityExecutionPlan` 和外部执行证据，不得重新读取 current Monitor 作为规则/目标配置来源。
+
+## 5. Rule Execution
+
+Worker 必须逐条产生 RuleExecution evidence。
+
+- SQL/metric 计算继续通过现有 `QualitySqlCompiler` / `QualityMetricEvaluator`；
+- 数据读取只通过 `QualityDataCatalogGateway`；
+- Quality SQL 保持现有只读、单查询约束；
+- 每条规则记录执行结果、metric、expected value、SQL/error 和 duration 等当前审计字段；
+- 单条规则异常记录为 ERROR evidence，不能丢失后继续伪装 PASSED；
+- `RuleFailureAction.STOP` 下，前序规则出现非 PASSED 后，剩余规则必须记录为 `NOT_RUN`；
+- `CONTINUE` 下按现有规则继续执行后续检查。
+
+## 6. Execution Completion
+
+Execution 的最终结果必须来自本次执行实际 RuleExecution 结果，而不是 UI 投影或 Alert 状态。
+
+当前结果语义保持：
+
+- 没有错误且没有未通过规则 -> PASSED；
+- 存在未通过规则且没有 ERROR -> NOT_PASSED；
+- 存在执行错误或 Worker 异常 -> ERROR；
+- 执行中的运行态继续使用现有 WAITING / RUNNING 与 `CheckResult.RUNNING` 语义。
+
+Worker 顶层异常必须将 Execution 收口为失败证据，并更新 Monitor 的 last-result projection。
+
+## 7. Dispatch Safety
+
+Execution dispatch 必须在数据库事务提交后进行。
+
+- 未提交成功的 Execution 不得进入异步 Worker；
+- ThreadPool 拒绝任务时，必须把已受理的 Execution 收口为 ERROR，而不是永久停留 WAITING；
+- queue rejection 同时更新 Monitor last-result projection；
+- dispatch/worker 不能变成 Monitor/Rule 当前定义的第二 truth owner。
+
+## 8. Schedule
+
+业务表中的 Monitor + MonitorSettings 是调度配置事实来源；Yak Schedule 是运行时触发投影。
+
+必须保持：
+
+- MANUAL 或 disabled Monitor 不保留活动调度；
+- SCHEDULE 模式通过 QualityScheduleLifecycle 同步到 Yak Schedule；
+- Schedule Handler 只负责验证当前是否允许触发并调用 `QualityExecutionManager`；
+- Schedule callback 不直接写 Execution 表或绕过 execution admission；
+- Monitor 删除时清理残留 schedule；
+- nextRunTime 是运行投影，不取代 MonitorSettings 的配置事实。
+
+## 9. Alert Evidence
+
+Alert 不是 Execution 状态机。
+
+- PASSED / RUNNING / NOT_RUN 不产生失败告警；
+- 需要通知时记录 AlertEvent evidence；
+- MESSAGE 渠道与其他通知渠道继续保持现有 delivery status 语义；
+- 告警记录失败不得反向修改已经确认的 Execution 结果；
+- 日志与告警不能成为 Monitor / Execution 的业务 truth。
+
+## 10. Template / Folder
+
+内置模板与自定义模板保持独立生命周期。
+
+- built-in template 继续只读；
+- custom template 名称/code/folder/SQL/参数 schema/Set Flag 继续遵守现有约束；
+- 自定义 SQL 继续执行已有单 SELECT / normalization 规则；
+- folder 名称、父子关系和循环约束继续保持；
+- copy/create/update/delete 不改变现有 HTTP contract。
+
+## 11. Workspace / Read Side
+
+Workspace、Execution Workspace、structured log 都是 read-side projection。
+
+- Reader / Projector 不拥有 Monitor 或 Execution command transition；
+- 查询继续使用 Repository Domain contract；
+- 分页 Repository 统一使用 `io.yak.framework.common.PageData<T>`；
+- HTTP paging shape 保持现有 DTO/VO contract；
+- structured log 从 persisted execution evidence 确定性投影，不成为新的持久化 truth。
+
+## 12. Compatibility
+
+Stage 2 治理不得顺手改变：
+
+- `/api/v1/data-quality/**` 现有 endpoint；
+- request DTO / response VO JSON shape；
+- permission code；
+- Quality database table / Flyway；
+- shared `PageData` repository boundary；
+- Datasource Plugin SPI；
+- Yak Schedule framework contract；
+- manual / scheduled execution semantics；
+- single active execution per Monitor；
+- after-commit dispatch；
+- STOP -> remaining NOT_RUN；
+- queue-full failure semantics；
+- alert recording semantics。
+
+真正需要改变以上 contract 时，应独立提出 Requirement / Domain / Migration 变更，不应混进纯架构治理 PR。

--- a/yak-ops-business/yak-ops-business-quality/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-quality/REVIEW.md
@@ -1,0 +1,221 @@
+# Data Quality Review
+
+> 本文件定义 Data Quality PR **如何 Review**。Reviewer / AI 是裁判，不在 Review 中自行补需求或创造新领域语义。
+
+## Review 前必读
+
+```text
+REQUIREMENTS.md  -> 模块必须提供什么
+DOMAIN.md        -> 哪些业务事实不能违反
+ARCHITECTURE.md  -> 角色和 truth ownership
+DEPENDENCIES.md  -> package graph / corridor
+../../CODE_STYLE.md -> Yak Ops 统一工程规则
+PR diff / tests  -> 实际改了什么
+```
+
+## 1. Requirement Alignment
+
+先检查是否改变当前需求 contract：
+
+- Table Asset 注册是否仍以 Datasource Catalog 事实为准？
+- Monitor / Rule / Settings save/delete 行为是否变化？
+- manual / schedule execution 行为是否变化？
+- single active execution 是否变化？
+- after-commit dispatch 是否变化？
+- STOP/CONTINUE、NOT_RUN、queue rejection 是否变化？
+- Template / Folder / Workspace / Alert 行为是否变化？
+- REST / permission / paging contract 是否变化？
+
+需求文档未定义的新能力报告：
+
+```text
+Requirement Gap
+```
+
+不要通过“顺手重构”偷偷加入。
+
+## 2. Domain Compliance
+
+重点检查：
+
+- TableAsset / Monitor / QualityExecutionPlan / Execution / RuleExecution 是否混淆；
+- 已入队 Execution 是否回读 current Monitor/Rule/Settings 改写 frozen plan；
+- 同 Monitor 是否可能产生多个 active Execution；
+- disabled / no-enabled-rule Monitor 是否仍能执行；
+- WAITING 记录是否可能在事务失败后仍被 Worker 执行；
+- ERROR / NOT_PASSED / NOT_RUN 是否被错误折叠；
+- STOP 后剩余 Rule 是否静默消失而没有 NOT_RUN evidence；
+- AlertEvent 是否反向成为 Execution result owner；
+- Yak Schedule 是否反向成为 MonitorSettings 配置 owner；
+- Datasource metadata 是否被客户端字段覆盖；
+- Workspace / Projector 是否开始修改 command truth。
+
+违反当前规则：
+
+```text
+Domain Violation
+```
+
+当前模型无法表达真实需求：
+
+```text
+Domain Gap
+```
+
+## 3. Architecture Alignment
+
+检查代码是否仍符合 `ARCHITECTURE.md`：
+
+- Controller 是否进入明确 Manager / Reader / Projector；
+- 是否重新创建 `service/common/helper/utils/base`；
+- Manager 是否把 Reader 当 Helper；
+- Reader 是否拥有 create/update/delete/run；
+- Policy 是否只做 deterministic validate/normalize；
+- Dispatcher 是否只负责 dispatch，不拥有最终执行状态；
+- Worker 是否只消费 frozen plan 和执行证据；
+- Gateway 是否停住 Datasource 外部类型；
+- Repository/DAO 是否保持 persistence boundary；
+- config 是否重新反向装配业务角色形成 cycle。
+
+当前 Quality 不需要一个通用 `@Service` facade。新增 `@Service` 必须有明确新的稳定 Application API 设计，而不是为了“符合三层架构”。
+
+## 4. Dependency Alignment
+
+任何新增内部 import 都检查 `DEPENDENCIES.md` 和 `QualityDependencyBoundaryTest`。
+
+重点 corridor：
+
+```text
+monitor -> QualityScheduleLifecycle / QualityScheduleCalculator
+schedule -> QualityExecutionManager
+workspace -> QualityMonitorReader
+execution -> QualityAlertRecorder
+asset/execution -> QualityDataCatalogGateway
+```
+
+Datasource 外部依赖只允许：
+
+```text
+QualityConfiguration -> BusinessDatabaseConfiguration
+DataSourceQualityCatalogAdapter -> typed Datasource Catalog API
+```
+
+不要第一反应扩大白名单；先判断类是否放错 package 或缺少 Quality-owned port。
+
+## 5. Correctness
+
+必须给出可触发场景，不因为“代码看起来复杂”就报告问题。
+
+高风险区域：
+
+- Monitor lock 与 active-execution admission；
+- Execution insert 和 afterCommit dispatch 顺序；
+- ThreadPool queue rejection；
+- Worker 重复执行 / mark-running guard；
+- RuleFailureAction.STOP；
+- final CheckResult 汇总；
+- SQL compiler 的 read-only / identifier / WHERE 安全；
+- Datasource plugin 返回元数据变化；
+- Table Asset register/unregister 引用关系；
+- Schedule save/pause/delete/reconcile；
+- current Monitor edit 与 queued plan snapshot；
+- Alert 记录异常；
+- pagination / workspace report 边界值。
+
+## 6. Compatibility
+
+检查是否破坏：
+
+- `/api/v1/data-quality/**` URL；
+- DTO / VO JSON shape；
+- permission codes；
+- `yak_quality_*` tables / Flyway history；
+- MyBatis Mapper XML；
+- persisted enum/status values；
+- shared `PageData` Repository paging；
+- existing Monitor/Rule/Execution/Alert data；
+- Datasource Plugin/Catalog typed contract；
+- Yak Schedule key/handler contract。
+
+架构整理默认不做 DB、REST、Domain semantic breaking change。
+
+## 7. Safety
+
+优先于整洁度检查：
+
+- 重复 Execution；
+- transaction rollback 后仍 dispatch；
+- queue full 永久 WAITING；
+- Worker 使用 current Monitor 漂移；
+- SQL 失去只读限制；
+- Datasource identity 错配；
+- 删除仍被 Monitor 引用的 TableAsset；
+- schedule callback 绕过 admission；
+- Alert 失败覆盖执行真相；
+- 日志/异常输出不应泄漏未来可能引入的敏感连接配置。
+
+## 8. Tests / Guardrails
+
+每个 P0/P1 问题都回答：
+
+```text
+现有哪个 behavior test 或 architecture test 应该挡住？
+```
+
+重点 guard：
+
+- `QualityLayeringConventionTest`
+- `QualityDependencyBoundaryTest`
+- `QualityCodeStyleConventionTest`
+- Asset / Monitor / Execution / Schedule / Template 的行为测试
+- controller contract tests
+
+修改 architecture corridor 时，文档与 executable test 必须在同一 PR 更新。
+
+## 严重级别
+
+```text
+P0 Blocker
+- 数据质量 SQL 产生破坏性写入
+- 重复执行导致严重运行风险
+- 明确敏感数据泄漏或不可恢复的数据破坏
+
+P1 Must Fix
+- Requirement / Domain violation
+- Monitor/Execution truth ownership 错误
+- transaction / queue / concurrency / schedule / snapshot 错误
+- 明确 API / DB compatibility break
+- architecture boundary 被绕过并造成真实耦合风险
+
+P2 Suggestion
+- 有明确收益但不影响正确性的可维护性、性能、可观测性建议
+```
+
+纯个人格式偏好不作为阻塞项；违反根 `CODE_STYLE.md` 且会造成角色/边界歧义时可以报告。
+
+## 固定输出
+
+```text
+# Review Result
+Conclusion: PASS | CHANGES_REQUIRED
+
+## P0 Blocker
+无 / 问题列表
+
+## P1 Must Fix
+无 / 问题列表
+
+## P2 Suggestion
+无 / 建议列表
+
+## Requirement Gap
+无 / 说明
+
+## Domain Gap
+无 / 说明
+
+## Missing Tests
+无 / 说明
+```
+
+有 P0/P1 -> `CHANGES_REQUIRED`；只有 P2 可以 `PASS`。

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/asset/QualityTableAssetManager.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/asset/QualityTableAssetManager.java
@@ -17,57 +17,66 @@ import org.springframework.transaction.annotation.Transactional;
 public class QualityTableAssetManager {
   private final QualityTableAssetRepository repository;
   private final QualityDataCatalogGateway catalogGateway;
+  private final QualityTableTargetPolicy targetPolicy;
 
   public QualityTableAssetManager(
       QualityTableAssetRepository repository,
-      QualityDataCatalogGateway catalogGateway) {
+      QualityDataCatalogGateway catalogGateway,
+      QualityTableTargetPolicy targetPolicy) {
     this.repository = repository;
     this.catalogGateway = catalogGateway;
+    this.targetPolicy = targetPolicy;
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public RegisterResult register(QualityTableAssetCommand.Register command, String operator) {
-    if (command.dataSourceId() == null) throw new IllegalArgumentException("数据源编号无效");
-    QualityTableCandidateReader.validateDataSourceId(command.dataSourceId());
-    String selectedDatabase = QualityTableCandidateReader.trimToNull(command.databaseName());
-    List<QualityPhysicalTable> physicalTables = catalogGateway.listTables(
-        command.dataSourceId(), selectedDatabase, null, null);
+    if (command.dataSourceId() == null) {
+      throw new IllegalArgumentException("数据源编号无效");
+    }
+    targetPolicy.requireDataSourceId(command.dataSourceId());
+    String selectedDatabase = targetPolicy.trimToNull(command.databaseName());
+    List<QualityPhysicalTable> physicalTables =
+        catalogGateway.listTables(command.dataSourceId(), selectedDatabase, null, null);
 
     Map<String, QualityPhysicalTable> physicalTableMap = new LinkedHashMap<>();
     for (QualityPhysicalTable table : physicalTables) {
-      String key = QualityTableCandidateReader.targetKey(
-          QualityTableCandidateReader.firstNonBlank(table.databaseName(), selectedDatabase),
-          table.schemaName(), table.tableName());
+      String key =
+          targetPolicy.targetKey(
+              targetPolicy.firstNonBlank(table.databaseName(), selectedDatabase),
+              table.schemaName(),
+              table.tableName());
       physicalTableMap.putIfAbsent(key, table);
     }
 
     Map<String, QualityTableAssetCommand.Item> requestedTables = new LinkedHashMap<>();
     for (QualityTableAssetCommand.Item item : command.tables()) {
-      String database = QualityTableCandidateReader.firstNonBlank(item.databaseName(), selectedDatabase);
+      String database = targetPolicy.firstNonBlank(item.databaseName(), selectedDatabase);
       requestedTables.putIfAbsent(
-          QualityTableCandidateReader.targetKey(database, item.schemaName(), item.tableName()), item);
+          targetPolicy.targetKey(database, item.schemaName(), item.tableName()), item);
     }
 
     String registeredBy = normalizeOperator(operator);
-    List<TableAssetSpec> writes = requestedTables.entrySet().stream()
-        .map(entry -> {
-          QualityTableAssetCommand.Item requested = entry.getValue();
-          QualityPhysicalTable physical = physicalTableMap.get(entry.getKey());
-          if (physical == null) {
-            throw new IllegalArgumentException(
-                "数据表已不存在或无法通过数据源插件发现：" + requested.tableName());
-          }
-          return new TableAssetSpec(
-              command.dataSourceId(),
-              requireText(command.dataSourceName(), "数据源名称不能为空"),
-              QualityTableCandidateReader.firstNonBlank(physical.databaseName(), selectedDatabase),
-              QualityTableCandidateReader.trimToNull(physical.schemaName()),
-              physical.tableName(),
-              QualityTableCandidateReader.trimToNull(physical.tableType()),
-              QualityTableCandidateReader.trimToNull(physical.remarks()),
-              registeredBy);
-        })
-        .toList();
+    List<TableAssetSpec> writes =
+        requestedTables.entrySet().stream()
+            .map(
+                entry -> {
+                  QualityTableAssetCommand.Item requested = entry.getValue();
+                  QualityPhysicalTable physical = physicalTableMap.get(entry.getKey());
+                  if (physical == null) {
+                    throw new IllegalArgumentException(
+                        "数据表已不存在或无法通过数据源插件发现：" + requested.tableName());
+                  }
+                  return new TableAssetSpec(
+                      command.dataSourceId(),
+                      requireText(command.dataSourceName(), "数据源名称不能为空"),
+                      targetPolicy.firstNonBlank(physical.databaseName(), selectedDatabase),
+                      targetPolicy.trimToNull(physical.schemaName()),
+                      physical.tableName(),
+                      targetPolicy.trimToNull(physical.tableType()),
+                      targetPolicy.trimToNull(physical.remarks()),
+                      registeredBy);
+                })
+            .toList();
 
     int registered = repository.registerTableAssets(writes);
     return new RegisterResult(command.tables().size(), registered);
@@ -75,7 +84,9 @@ public class QualityTableAssetManager {
 
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public boolean unregister(long id) {
-    if (id <= 0L) throw new IllegalArgumentException("注册表编号无效");
+    if (id <= 0L) {
+      throw new IllegalArgumentException("注册表编号无效");
+    }
     if (repository.countMonitorsForTableAsset(id) > 0) {
       throw new IllegalStateException("当前数据表已配置质量监控，请先删除监控后再取消注册");
     }
@@ -85,14 +96,16 @@ public class QualityTableAssetManager {
     return true;
   }
 
-  private static String normalizeOperator(String operator) {
-    String normalized = QualityTableCandidateReader.trimToNull(operator);
+  private String normalizeOperator(String operator) {
+    String normalized = targetPolicy.trimToNull(operator);
     return normalized == null ? "system" : normalized;
   }
 
-  private static String requireText(String value, String message) {
-    String normalized = QualityTableCandidateReader.trimToNull(value);
-    if (normalized == null) throw new IllegalArgumentException(message);
+  private String requireText(String value, String message) {
+    String normalized = targetPolicy.trimToNull(value);
+    if (normalized == null) {
+      throw new IllegalArgumentException(message);
+    }
     return normalized;
   }
 

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/asset/QualityTableCandidateReader.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/asset/QualityTableCandidateReader.java
@@ -6,7 +6,6 @@ import io.yak.ops.business.quality.gateway.datasource.QualityDataCatalogGateway.
 import io.yak.ops.business.quality.repository.QualityTableAssetRepository;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
@@ -18,12 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class QualityTableCandidateReader {
   private final QualityTableAssetRepository repository;
   private final QualityDataCatalogGateway catalogGateway;
+  private final QualityTableTargetPolicy targetPolicy;
 
   public QualityTableCandidateReader(
       QualityTableAssetRepository repository,
-      QualityDataCatalogGateway catalogGateway) {
+      QualityDataCatalogGateway catalogGateway,
+      QualityTableTargetPolicy targetPolicy) {
     this.repository = repository;
     this.catalogGateway = catalogGateway;
+    this.targetPolicy = targetPolicy;
   }
 
   @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
@@ -34,53 +36,47 @@ public class QualityTableCandidateReader {
       String keyword,
       int current,
       int pageSize) {
-    validateDataSourceId(dataSourceId);
+    targetPolicy.requireDataSourceId(dataSourceId);
     int safeCurrent = Math.max(1, current);
     int safePageSize = Math.max(1, Math.min(pageSize, 100));
-    Set<String> registeredTargets = repository.listTableAssetTargets(dataSourceId, databaseName).stream()
-        .map(target -> targetKey(target.databaseName(), target.schemaName(), target.tableName()))
-        .collect(Collectors.toSet());
-    List<QualityPhysicalTable> available = catalogGateway
-        .listTables(dataSourceId, databaseName, schemaName, trimToNull(keyword)).stream()
-        .map(table -> normalize(table, databaseName))
-        .filter(table -> !registeredTargets.contains(targetKey(
-            table.databaseName(), table.schemaName(), table.tableName())))
-        .sorted(Comparator.comparing(QualityPhysicalTable::tableName, String.CASE_INSENSITIVE_ORDER))
-        .toList();
+    Set<String> registeredTargets =
+        repository.listTableAssetTargets(dataSourceId, databaseName).stream()
+            .map(
+                target ->
+                    targetPolicy.targetKey(
+                        target.databaseName(), target.schemaName(), target.tableName()))
+            .collect(Collectors.toSet());
+    List<QualityPhysicalTable> available =
+        catalogGateway.listTables(
+                dataSourceId,
+                databaseName,
+                schemaName,
+                targetPolicy.trimToNull(keyword))
+            .stream()
+            .map(table -> normalize(table, databaseName))
+            .filter(
+                table ->
+                    !registeredTargets.contains(
+                        targetPolicy.targetKey(
+                            table.databaseName(), table.schemaName(), table.tableName())))
+            .sorted(
+                Comparator.comparing(
+                    QualityPhysicalTable::tableName, String.CASE_INSENSITIVE_ORDER))
+            .toList();
     int fromIndex = Math.min((safeCurrent - 1) * safePageSize, available.size());
     int toIndex = Math.min(fromIndex + safePageSize, available.size());
-    return new CandidatePage(available.subList(fromIndex, toIndex), available.size(), safeCurrent, safePageSize);
+    return new CandidatePage(
+        available.subList(fromIndex, toIndex), available.size(), safeCurrent, safePageSize);
   }
 
-  private QualityPhysicalTable normalize(QualityPhysicalTable table, String selectedDatabase) {
+  private QualityPhysicalTable normalize(
+      QualityPhysicalTable table, String selectedDatabase) {
     return new QualityPhysicalTable(
-        firstNonBlank(table.databaseName(), selectedDatabase),
-        trimToNull(table.schemaName()), table.tableName(),
-        trimToNull(table.tableType()), trimToNull(table.remarks()));
-  }
-
-  static void validateDataSourceId(long dataSourceId) {
-    if (dataSourceId <= 0L) throw new IllegalArgumentException("数据源编号无效");
-  }
-
-  static String targetKey(String databaseName, String schemaName, String tableName) {
-    return String.join("\u0001", normalizeKeyPart(databaseName), normalizeKeyPart(schemaName), normalizeKeyPart(tableName));
-  }
-
-  static String firstNonBlank(String first, String second) {
-    String normalized = trimToNull(first);
-    return normalized == null ? trimToNull(second) : normalized;
-  }
-
-  static String trimToNull(String value) {
-    if (value == null) return null;
-    String trimmed = value.trim();
-    return trimmed.isEmpty() ? null : trimmed;
-  }
-
-  private static String normalizeKeyPart(String value) {
-    String normalized = trimToNull(value);
-    return normalized == null ? "" : normalized.toLowerCase(Locale.ROOT);
+        targetPolicy.firstNonBlank(table.databaseName(), selectedDatabase),
+        targetPolicy.trimToNull(table.schemaName()),
+        table.tableName(),
+        targetPolicy.trimToNull(table.tableType()),
+        targetPolicy.trimToNull(table.remarks()));
   }
 
   public record CandidatePage(

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/asset/QualityTableTargetPolicy.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/asset/QualityTableTargetPolicy.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.quality.asset;
+
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+
+/** Owns normalization and identity rules shared by quality table asset commands and reads. */
+@Component
+@ConditionalOnQualityEnabled
+public class QualityTableTargetPolicy {
+
+  public void requireDataSourceId(long dataSourceId) {
+    if (dataSourceId <= 0L) {
+      throw new IllegalArgumentException("数据源编号无效");
+    }
+  }
+
+  public String targetKey(String databaseName, String schemaName, String tableName) {
+    return String.join(
+        "\u0001",
+        normalizeKeyPart(databaseName),
+        normalizeKeyPart(schemaName),
+        normalizeKeyPart(tableName));
+  }
+
+  public String firstNonBlank(String first, String second) {
+    String normalized = trimToNull(first);
+    return normalized == null ? trimToNull(second) : normalized;
+  }
+
+  public String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private String normalizeKeyPart(String value) {
+    String normalized = trimToNull(value);
+    return normalized == null ? "" : normalized.toLowerCase(Locale.ROOT);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
@@ -1,9 +1,6 @@
 package io.yak.ops.business.quality.config;
 
 import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
-import io.yak.ops.business.quality.execution.QualityMetricEvaluator;
-import io.yak.ops.business.quality.execution.QualitySqlCompiler;
-import io.yak.ops.business.quality.gateway.datasource.QualityDataCatalogGateway;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
@@ -35,18 +32,6 @@ public class QualityConfiguration {
         .baselineOnMigrate(true)
         .placeholderReplacement(false)
         .load();
-  }
-
-  @Bean
-  public QualityMetricEvaluator qualityMetricEvaluator() {
-    return new QualityMetricEvaluator();
-  }
-
-  @Bean
-  public QualitySqlCompiler qualitySqlCompiler(
-      QualityDataCatalogGateway catalogGateway,
-      QualityMetricEvaluator evaluator) {
-    return new QualitySqlCompiler(catalogGateway, evaluator);
   }
 
   @Bean(name = "qualityExecutionTaskExecutor", destroyMethod = "shutdown")

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityMetricEvaluator.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityMetricEvaluator.java
@@ -1,8 +1,13 @@
 package io.yak.ops.business.quality.execution;
 
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.common.enums.quality.QualityEnums.ComparisonOperator;
 import java.math.BigDecimal;
+import org.springframework.stereotype.Component;
 
+/** Evaluates compiled quality metrics against the frozen rule thresholds. */
+@Component
+@ConditionalOnQualityEnabled
 public class QualityMetricEvaluator {
 
   public boolean passes(
@@ -15,8 +20,10 @@ public class QualityMetricEvaluator {
     return switch (operator) {
       case GT -> first.compareTo(expected) > 0;
       case GTE -> first.compareTo(expected) >= 0;
-      case EQ -> first.compareTo(expected) == 0
-          && (measurement.valueEnd() == null || measurement.valueEnd().compareTo(expected) == 0);
+      case EQ ->
+          first.compareTo(expected) == 0
+              && (measurement.valueEnd() == null
+                  || measurement.valueEnd().compareTo(expected) == 0);
       case LTE -> first.compareTo(expected) <= 0;
       case LT -> first.compareTo(expected) < 0;
       case BETWEEN -> {
@@ -40,15 +47,22 @@ public class QualityMetricEvaluator {
   }
 
   public static String format(BigDecimal value) {
-    if (value == null) return "--";
+    if (value == null) {
+      return "--";
+    }
     BigDecimal normalized = value.stripTrailingZeros();
-    return normalized.scale() < 0 ? normalized.setScale(0).toPlainString() : normalized.toPlainString();
+    return normalized.scale() < 0
+        ? normalized.setScale(0).toPlainString()
+        : normalized.toPlainString();
   }
 
   private static BigDecimal required(BigDecimal value, String message) {
-    if (value == null) throw new IllegalArgumentException(message);
+    if (value == null) {
+      throw new IllegalArgumentException(message);
+    }
     return value;
   }
 
-  public record MetricMeasurement(BigDecimal value, BigDecimal valueEnd, String displayValue) {}
+  public record MetricMeasurement(
+      BigDecimal value, BigDecimal valueEnd, String displayValue) {}
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualitySqlCompiler.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualitySqlCompiler.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.quality.execution;
 
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.RuleSnapshot;
 import io.yak.ops.business.quality.execution.QualityMetricEvaluator.MetricMeasurement;
@@ -12,15 +13,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
 
+/** Compiles frozen quality rule snapshots into read-only datasource SQL. */
+@Component
+@ConditionalOnQualityEnabled
 public class QualitySqlCompiler {
-  private static final Pattern SELECT_TEMPLATE = Pattern.compile("(?is)^\\s*SELECT\\s+(.+?)\\s+FROM\\s+(.+?)\\s*$");
+  private static final Pattern SELECT_TEMPLATE =
+      Pattern.compile("(?is)^\\s*SELECT\\s+(.+?)\\s+FROM\\s+(.+?)\\s*$");
   private static final Pattern READ_ONLY_SELECT = Pattern.compile("(?is)^\\s*SELECT\\b.*");
-  private static final Pattern UNSAFE_FILTER = Pattern.compile("(?is)(;|--|/\\*|\\*/|\\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE)\\b)");
+  private static final Pattern UNSAFE_FILTER =
+      Pattern.compile(
+          "(?is)(;|--|/\\*|\\*/|\\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE)\\b)");
+
   private final QualityDataCatalogGateway catalogGateway;
   private final QualityMetricEvaluator evaluator;
 
-  public QualitySqlCompiler(QualityDataCatalogGateway catalogGateway, QualityMetricEvaluator evaluator) {
+  public QualitySqlCompiler(
+      QualityDataCatalogGateway catalogGateway, QualityMetricEvaluator evaluator) {
     this.catalogGateway = catalogGateway;
     this.evaluator = evaluator;
   }
@@ -31,15 +41,39 @@ public class QualitySqlCompiler {
     String column = context.columnReference();
     String table = context.tableReference();
     return switch (rule.ruleType()) {
-      case TABLE_ROW_COUNT -> scalar("SELECT COUNT(*) AS metric_value FROM " + table + where, rule.operator(), rule.threshold(), rule.thresholdEnd(), "行");
-      case COLUMN_NOT_NULL -> scalar(
-          "SELECT CASE WHEN COUNT(*) = 0 THEN 100 ELSE ROUND(SUM(CASE WHEN " + requiredColumn(column)
-              + " IS NOT NULL THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 6) END AS metric_value FROM " + table + where,
-          rule.operator(), rule.threshold(), rule.thresholdEnd(), "%");
-      case COLUMN_UNIQUE -> scalar(
-          "SELECT CASE WHEN COUNT(" + requiredColumn(column) + ") = 0 THEN 100 ELSE ROUND(COUNT(DISTINCT " + column
-              + ") * 100.0 / COUNT(" + column + "), 6) END AS metric_value FROM " + table + where,
-          rule.operator(), rule.threshold(), rule.thresholdEnd(), "%");
+      case TABLE_ROW_COUNT ->
+          scalar(
+              "SELECT COUNT(*) AS metric_value FROM " + table + where,
+              rule.operator(),
+              rule.threshold(),
+              rule.thresholdEnd(),
+              "行");
+      case COLUMN_NOT_NULL ->
+          scalar(
+              "SELECT CASE WHEN COUNT(*) = 0 THEN 100 ELSE ROUND(SUM(CASE WHEN "
+                  + requiredColumn(column)
+                  + " IS NOT NULL THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 6) END AS metric_value FROM "
+                  + table
+                  + where,
+              rule.operator(),
+              rule.threshold(),
+              rule.thresholdEnd(),
+              "%");
+      case COLUMN_UNIQUE ->
+          scalar(
+              "SELECT CASE WHEN COUNT("
+                  + requiredColumn(column)
+                  + ") = 0 THEN 100 ELSE ROUND(COUNT(DISTINCT "
+                  + column
+                  + ") * 100.0 / COUNT("
+                  + column
+                  + "), 6) END AS metric_value FROM "
+                  + table
+                  + where,
+              rule.operator(),
+              rule.threshold(),
+              rule.thresholdEnd(),
+              "%");
       case COLUMN_RANGE -> rangeRule(table, where, requiredColumn(column), rule);
       case COLUMN_ENUM -> enumRule(table, where, requiredColumn(column), rule);
       case CUSTOM_SQL -> customSql(monitor, context, rule);
@@ -47,88 +81,176 @@ public class QualitySqlCompiler {
   }
 
   public MetricMeasurement measure(QualityQueryResult result) {
-    if (result == null || result.rows().isEmpty()) throw new IllegalArgumentException("质量检查 SQL 没有返回指标数据");
+    if (result == null || result.rows().isEmpty()) {
+      throw new IllegalArgumentException("质量检查 SQL 没有返回指标数据");
+    }
     Map<String, Object> row = result.rows().get(0);
-    if (row == null || row.isEmpty()) throw new IllegalArgumentException("质量检查 SQL 返回了空指标行");
+    if (row == null || row.isEmpty()) {
+      throw new IllegalArgumentException("质量检查 SQL 返回了空指标行");
+    }
     BigDecimal value = decimal(firstValue(row, "metric_value"));
     return new MetricMeasurement(value, null, QualityMetricEvaluator.format(value));
   }
 
-  private CompiledRule rangeRule(String table, String where, String column, RuleSnapshot rule) {
+  private CompiledRule rangeRule(
+      String table, String where, String column, RuleSnapshot rule) {
     BigDecimal minimum = required(rule.threshold(), "字段数值范围缺少最小值");
     BigDecimal maximum = required(rule.thresholdEnd(), "字段数值范围缺少最大值");
-    if (minimum.compareTo(maximum) > 0) throw new IllegalArgumentException("字段数值范围最小值不能大于最大值");
-    String condition = column + " < " + literal(minimum) + " OR " + column + " > " + literal(maximum);
-    String sql = "SELECT COALESCE(SUM(CASE WHEN " + condition + " THEN 1 ELSE 0 END), 0) AS metric_value FROM " + table + where;
-    return new CompiledRule(sql, ComparisonOperator.EQ, BigDecimal.ZERO, null,
-        "字段值位于 " + QualityMetricEvaluator.format(minimum) + " ~ " + QualityMetricEvaluator.format(maximum), "条");
+    if (minimum.compareTo(maximum) > 0) {
+      throw new IllegalArgumentException("字段数值范围最小值不能大于最大值");
+    }
+    String condition =
+        column + " < " + literal(minimum) + " OR " + column + " > " + literal(maximum);
+    String sql =
+        "SELECT COALESCE(SUM(CASE WHEN "
+            + condition
+            + " THEN 1 ELSE 0 END), 0) AS metric_value FROM "
+            + table
+            + where;
+    return new CompiledRule(
+        sql,
+        ComparisonOperator.EQ,
+        BigDecimal.ZERO,
+        null,
+        "字段值位于 "
+            + QualityMetricEvaluator.format(minimum)
+            + " ~ "
+            + QualityMetricEvaluator.format(maximum),
+        "条");
   }
 
-  private CompiledRule enumRule(String table, String where, String column, RuleSnapshot rule) {
-    List<String> values = rule.enumValues() == null ? List.of() : rule.enumValues().stream()
-        .map(QualitySqlCompiler::trimToNull).filter(value -> value != null).distinct().toList();
-    if (values.isEmpty()) throw new IllegalArgumentException("字段枚举值规则至少需要一个允许值");
-    String allowed = values.stream().map(QualitySqlCompiler::stringLiteral).reduce((left, right) -> left + ", " + right).orElseThrow();
-    String sql = "SELECT COALESCE(SUM(CASE WHEN " + column + " IS NOT NULL AND " + column + " NOT IN (" + allowed
-        + ") THEN 1 ELSE 0 END), 0) AS metric_value FROM " + table + where;
-    return new CompiledRule(sql, ComparisonOperator.EQ, BigDecimal.ZERO, null, "字段值属于 [" + String.join(", ", values) + "]", "条");
+  private CompiledRule enumRule(
+      String table, String where, String column, RuleSnapshot rule) {
+    List<String> values =
+        rule.enumValues() == null
+            ? List.of()
+            : rule.enumValues().stream()
+                .map(QualitySqlCompiler::trimToNull)
+                .filter(value -> value != null)
+                .distinct()
+                .toList();
+    if (values.isEmpty()) {
+      throw new IllegalArgumentException("字段枚举值规则至少需要一个允许值");
+    }
+    String allowed =
+        values.stream()
+            .map(QualitySqlCompiler::stringLiteral)
+            .reduce((left, right) -> left + ", " + right)
+            .orElseThrow();
+    String sql =
+        "SELECT COALESCE(SUM(CASE WHEN "
+            + column
+            + " IS NOT NULL AND "
+            + column
+            + " NOT IN ("
+            + allowed
+            + ") THEN 1 ELSE 0 END), 0) AS metric_value FROM "
+            + table
+            + where;
+    return new CompiledRule(
+        sql,
+        ComparisonOperator.EQ,
+        BigDecimal.ZERO,
+        null,
+        "字段值属于 [" + String.join(", ", values) + "]",
+        "条");
   }
 
-  private CompiledRule customSql(MonitorSnapshot monitor, TableContext context, RuleSnapshot rule) {
+  private CompiledRule customSql(
+      MonitorSnapshot monitor, TableContext context, RuleSnapshot rule) {
     String sql = trimToNull(rule.customSql());
-    if (sql == null) throw new IllegalArgumentException("自定义 SQL 规则没有可执行 SQL");
+    if (sql == null) {
+      throw new IllegalArgumentException("自定义 SQL 规则没有可执行 SQL");
+    }
     String filter = trimToNull(monitor.whereClause());
-    sql = sql.replace("${table}", context.tableReference())
-        .replace("${where}", filter == null ? "1 = 1" : filter)
-        .replace("${column}", context.columnReference() == null ? "" : context.columnReference()).trim();
-    if (sql.endsWith(";")) sql = sql.substring(0, sql.length() - 1).trim();
-    if (!READ_ONLY_SELECT.matcher(sql).matches() || sql.indexOf(';') >= 0) throw new IllegalArgumentException("自定义 SQL 仅允许执行单条 SELECT 查询");
+    sql =
+        sql.replace("${table}", context.tableReference())
+            .replace("${where}", filter == null ? "1 = 1" : filter)
+            .replace(
+                "${column}",
+                context.columnReference() == null ? "" : context.columnReference())
+            .trim();
+    if (sql.endsWith(";")) {
+      sql = sql.substring(0, sql.length() - 1).trim();
+    }
+    if (!READ_ONLY_SELECT.matcher(sql).matches() || sql.indexOf(';') >= 0) {
+      throw new IllegalArgumentException("自定义 SQL 仅允许执行单条 SELECT 查询");
+    }
     return scalar(sql, rule.operator(), rule.threshold(), rule.thresholdEnd(), null);
   }
 
-  private CompiledRule scalar(String sql, ComparisonOperator operator, BigDecimal threshold, BigDecimal thresholdEnd, String unit) {
+  private CompiledRule scalar(
+      String sql,
+      ComparisonOperator operator,
+      BigDecimal threshold,
+      BigDecimal thresholdEnd,
+      String unit) {
     ComparisonOperator normalized = operator == null ? ComparisonOperator.EQ : operator;
     BigDecimal expected = required(threshold, "规则阈值不能为空");
-    return new CompiledRule(sql, normalized, expected, thresholdEnd,
-        evaluator.expectedValue(normalized, expected, thresholdEnd, unit), unit);
+    return new CompiledRule(
+        sql,
+        normalized,
+        expected,
+        thresholdEnd,
+        evaluator.expectedValue(normalized, expected, thresholdEnd, unit),
+        unit);
   }
 
   private TableContext tableContext(MonitorSnapshot monitor, String columnName) {
     String template = catalogGateway.buildSqlTemplate(monitor.dataSourceId(), tablePath(monitor));
     Matcher matcher = SELECT_TEMPLATE.matcher(template == null ? "" : template);
-    if (!matcher.matches()) throw new IllegalArgumentException("数据源插件返回了无法识别的 SQL 模板");
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException("数据源插件返回了无法识别的 SQL 模板");
+    }
     String selectedColumns = matcher.group(1).trim();
     String tableReference = matcher.group(2).trim();
     String columnReference = null;
-    if (columnName != null && !columnName.isBlank()) columnReference = quoteIdentifier(columnName, quoteCharacter(selectedColumns));
+    if (columnName != null && !columnName.isBlank()) {
+      columnReference = quoteIdentifier(columnName, quoteCharacter(selectedColumns));
+    }
     return new TableContext(tableReference, columnReference);
   }
 
   private String tablePath(MonitorSnapshot monitor) {
     List<String> parts = new ArrayList<>();
-    if (hasText(monitor.databaseName())) parts.add(monitor.databaseName().trim());
-    if (hasText(monitor.schemaName()) && !monitor.schemaName().trim().equals(monitor.databaseName())) parts.add(monitor.schemaName().trim());
+    if (hasText(monitor.databaseName())) {
+      parts.add(monitor.databaseName().trim());
+    }
+    if (hasText(monitor.schemaName())
+        && !monitor.schemaName().trim().equals(monitor.databaseName())) {
+      parts.add(monitor.schemaName().trim());
+    }
     parts.add(monitor.tableName());
     return String.join(".", parts);
   }
 
   private String whereClause(String filter) {
     String normalized = trimToNull(filter);
-    if (normalized == null) return "";
-    if (UNSAFE_FILTER.matcher(normalized).find()) throw new IllegalArgumentException("数据范围仅允许填写安全的 WHERE 条件片段");
+    if (normalized == null) {
+      return "";
+    }
+    if (UNSAFE_FILTER.matcher(normalized).find()) {
+      throw new IllegalArgumentException("数据范围仅允许填写安全的 WHERE 条件片段");
+    }
     return " WHERE (" + normalized + ")";
   }
 
   private Character quoteCharacter(String selectedColumns) {
     String trimmed = selectedColumns == null ? "" : selectedColumns.trim();
-    if (!trimmed.isEmpty() && (trimmed.charAt(0) == '`' || trimmed.charAt(0) == '"')) return trimmed.charAt(0);
+    if (!trimmed.isEmpty() && (trimmed.charAt(0) == '`' || trimmed.charAt(0) == '"')) {
+      return trimmed.charAt(0);
+    }
     return null;
   }
 
   private String quoteIdentifier(String identifier, Character quote) {
-    if (identifier == null || identifier.isBlank()) throw new IllegalArgumentException("字段名称不能为空");
+    if (identifier == null || identifier.isBlank()) {
+      throw new IllegalArgumentException("字段名称不能为空");
+    }
     if (quote == null) {
-      if (!identifier.matches("[A-Za-z_][A-Za-z0-9_$]*")) throw new IllegalArgumentException("字段名称包含不安全字符：" + identifier);
+      if (!identifier.matches("[A-Za-z_][A-Za-z0-9_$]*")) {
+        throw new IllegalArgumentException("字段名称包含不安全字符：" + identifier);
+      }
       return identifier;
     }
     String marker = String.valueOf(quote);
@@ -137,30 +259,71 @@ public class QualitySqlCompiler {
 
   private Object firstValue(Map<String, Object> row, String preferredKey) {
     for (Map.Entry<String, Object> entry : row.entrySet()) {
-      if (entry.getKey() != null && entry.getKey().equalsIgnoreCase(preferredKey)) return entry.getValue();
+      if (entry.getKey() != null && entry.getKey().equalsIgnoreCase(preferredKey)) {
+        return entry.getValue();
+      }
     }
     return row.values().iterator().next();
   }
 
   private BigDecimal decimal(Object value) {
-    if (value == null) throw new IllegalArgumentException("质量指标为空，可能是检查对象没有有效数据");
-    if (value instanceof BigDecimal decimal) return decimal.stripTrailingZeros();
-    if (value instanceof Number number) return new BigDecimal(number.toString()).stripTrailingZeros();
-    try { return new BigDecimal(String.valueOf(value).trim()).stripTrailingZeros(); }
-    catch (NumberFormatException exception) { throw new IllegalArgumentException("质量检查结果不是可比较的数值：" + value, exception); }
+    if (value == null) {
+      throw new IllegalArgumentException("质量指标为空，可能是检查对象没有有效数据");
+    }
+    if (value instanceof BigDecimal decimal) {
+      return decimal.stripTrailingZeros();
+    }
+    if (value instanceof Number number) {
+      return new BigDecimal(number.toString()).stripTrailingZeros();
+    }
+    try {
+      return new BigDecimal(String.valueOf(value).trim()).stripTrailingZeros();
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("质量检查结果不是可比较的数值：" + value, exception);
+    }
   }
 
   private static String requiredColumn(String column) {
-    if (column == null || column.isBlank()) throw new IllegalArgumentException("当前规则必须选择字段");
+    if (column == null || column.isBlank()) {
+      throw new IllegalArgumentException("当前规则必须选择字段");
+    }
     return column;
   }
 
-  private static BigDecimal required(BigDecimal value, String message) { if (value == null) throw new IllegalArgumentException(message); return value; }
-  private static String literal(BigDecimal value) { return value.stripTrailingZeros().toPlainString(); }
-  private static String stringLiteral(String value) { return "'" + value.replace("'", "''") + "'"; }
-  private static boolean hasText(String value) { return value != null && !value.isBlank(); }
-  private static String trimToNull(String value) { if (value == null) return null; String v = value.trim(); return v.isEmpty() ? null : v; }
+  private static BigDecimal required(BigDecimal value, String message) {
+    if (value == null) {
+      throw new IllegalArgumentException(message);
+    }
+    return value;
+  }
 
-  public record CompiledRule(String sql, ComparisonOperator operator, BigDecimal threshold, BigDecimal thresholdEnd, String expectedValue, String unit) {}
+  private static String literal(BigDecimal value) {
+    return value.stripTrailingZeros().toPlainString();
+  }
+
+  private static String stringLiteral(String value) {
+    return "'" + value.replace("'", "''") + "'";
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  public record CompiledRule(
+      String sql,
+      ComparisonOperator operator,
+      BigDecimal threshold,
+      BigDecimal thresholdEnd,
+      String expectedValue,
+      String unit) {}
+
   private record TableContext(String tableReference, String columnReference) {}
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityExecutionLogProjector.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityExecutionLogProjector.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.quality.domain.QualityDomain.Execution;
 import io.yak.ops.business.quality.domain.QualityDomain.RuleExecution;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
 import io.yak.ops.common.enums.quality.QualityEnums.LogLevel;
+import io.yak.ops.common.enums.quality.QualityEnums.TriggerType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,49 +16,81 @@ public class QualityExecutionLogProjector {
 
   public StructuredLog project(Execution execution) {
     List<LogLine> lines = new ArrayList<>();
-    lines.add(new LogLine(
-        execution.queuedAt(), LogLevel.INFO, "DISPATCH",
-        "执行任务已创建，触发方式："
-            + (execution.triggerType().name().equals("SCHEDULE") ? "调度触发" : "手动触发")
-            + "，操作人：" + safe(execution.operator())));
+    lines.add(
+        new LogLine(
+            execution.queuedAt(),
+            LogLevel.INFO,
+            "DISPATCH",
+            "执行任务已创建，触发方式："
+                + (execution.triggerType() == TriggerType.SCHEDULE ? "调度触发" : "手动触发")
+                + "，操作人："
+                + safe(execution.operator())));
 
     if (execution.startedAt() != null) {
-      lines.add(new LogLine(
-          execution.startedAt(), LogLevel.INFO, "EXECUTION",
-          "开始执行质量检查，共 " + execution.totalRules() + " 条规则"));
+      lines.add(
+          new LogLine(
+              execution.startedAt(),
+              LogLevel.INFO,
+              "EXECUTION",
+              "开始执行质量检查，共 " + execution.totalRules() + " 条规则"));
     }
 
     for (RuleExecution rule : execution.rules()) {
-      lines.add(new LogLine(
-          fallback(rule.createdAt(), execution.startedAt(), execution.queuedAt()),
-          logLevel(rule.checkResult()), "RULE", ruleMessage(rule)));
+      lines.add(
+          new LogLine(
+              fallback(rule.createdAt(), execution.startedAt(), execution.queuedAt()),
+              logLevel(rule.checkResult()),
+              "RULE",
+              ruleMessage(rule)));
     }
 
     if (hasText(execution.errorMessage())) {
-      lines.add(new LogLine(
-          fallback(execution.finishedAt(), execution.startedAt(), execution.queuedAt()),
-          LogLevel.ERROR, "EXECUTION", execution.errorMessage()));
+      lines.add(
+          new LogLine(
+              fallback(execution.finishedAt(), execution.startedAt(), execution.queuedAt()),
+              LogLevel.ERROR,
+              "EXECUTION",
+              execution.errorMessage()));
     }
 
     if (execution.finishedAt() != null) {
-      lines.add(new LogLine(
-          execution.finishedAt(),
-          execution.checkResult() == CheckResult.PASSED ? LogLevel.INFO : LogLevel.WARN,
-          "FINISH",
-          "执行结束：通过 " + execution.passedRules() + "，未通过 " + execution.failedRules()
-              + "，异常 " + execution.errorRules() + "，耗时 "
-              + (execution.durationMs() == null ? 0 : execution.durationMs()) + " ms"));
+      lines.add(
+          new LogLine(
+              execution.finishedAt(),
+              execution.checkResult() == CheckResult.PASSED ? LogLevel.INFO : LogLevel.WARN,
+              "FINISH",
+              "执行结束：通过 "
+                  + execution.passedRules()
+                  + "，未通过 "
+                  + execution.failedRules()
+                  + "，异常 "
+                  + execution.errorRules()
+                  + "，耗时 "
+                  + (execution.durationMs() == null ? 0 : execution.durationMs())
+                  + " ms"));
     }
     return new StructuredLog(execution.executionNo(), lines);
   }
 
   private static String ruleMessage(RuleExecution rule) {
-    StringBuilder message = new StringBuilder().append("规则「").append(rule.ruleName()).append("」")
-        .append(resultLabel(rule.checkResult()));
-    if (hasText(rule.metricValue())) message.append("，实际值：").append(rule.metricValue());
-    if (hasText(rule.expectedValue())) message.append("，期望值：").append(rule.expectedValue());
-    if (rule.durationMs() != null) message.append("，耗时：").append(rule.durationMs()).append(" ms");
-    if (hasText(rule.errorMessage())) message.append("，错误：").append(rule.errorMessage());
+    StringBuilder message =
+        new StringBuilder()
+            .append("规则「")
+            .append(rule.ruleName())
+            .append("」")
+            .append(resultLabel(rule.checkResult()));
+    if (hasText(rule.metricValue())) {
+      message.append("，实际值：").append(rule.metricValue());
+    }
+    if (hasText(rule.expectedValue())) {
+      message.append("，期望值：").append(rule.expectedValue());
+    }
+    if (rule.durationMs() != null) {
+      message.append("，耗时：").append(rule.durationMs()).append(" ms");
+    }
+    if (hasText(rule.errorMessage())) {
+      message.append("，错误：").append(rule.errorMessage());
+    }
     return message.toString();
   }
 
@@ -79,28 +112,28 @@ public class QualityExecutionLogProjector {
     };
   }
 
+  private static LocalDateTime fallback(LocalDateTime... values) {
+    for (LocalDateTime value : values) {
+      if (value != null) {
+        return value;
+      }
+    }
+    return LocalDateTime.now();
+  }
+
+  private static String safe(String value) {
+    return value == null || value.isBlank() ? "system" : value;
+  }
+
   private static boolean hasText(String value) {
     return value != null && !value.isBlank();
   }
 
-  private static String safe(String value) {
-    return hasText(value) ? value : "system";
-  }
-
-  private static LocalDateTime fallback(LocalDateTime... values) {
-    for (LocalDateTime value : values) if (value != null) return value;
-    return LocalDateTime.now();
-  }
+  public record LogLine(LocalDateTime time, LogLevel level, String stage, String message) {}
 
   public record StructuredLog(String executionNo, List<LogLine> lines) {
     public StructuredLog {
       lines = lines == null ? List.of() : List.copyOf(lines);
     }
   }
-
-  public record LogLine(
-      LocalDateTime time,
-      LogLevel level,
-      String stage,
-      String message) {}
 }

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityCodeStyleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityCodeStyleConventionTest.java
@@ -1,0 +1,147 @@
+package io.yak.ops.business.quality.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Enforces low-ambiguity repository-wide CODE_STYLE rules for Data Quality production code. */
+class QualityCodeStyleConventionTest {
+
+  private static final Pattern WILDCARD_IMPORT =
+      Pattern.compile("(?m)^import\\s+(?:static\\s+)?[^;]+\\*;");
+  private static final Pattern FIELD_INJECTION =
+      Pattern.compile("@(Autowired|Resource|Inject)\\b");
+  private static final Pattern MIGRATION_MARKER =
+      Pattern.compile("(?i)\\b(Stage|Wave|Phase)\\s*[-:]?\\s*\\d+\\b");
+  private static final Pattern ENUM_NAME_EQUALS =
+      Pattern.compile("\\.name\\(\\)\\.equals(?:IgnoreCase)?\\s*\\(");
+  private static final Pattern REVERSE_ENUM_NAME_EQUALS =
+      Pattern.compile("\"[A-Z][A-Z0-9_]*\"\\.equals(?:IgnoreCase)?\\s*\\([^;]*\\.name\\(\\)");
+
+  @Test
+  void productionSourceFollowsRepositoryCodeStyle() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = normalize(root.relativize(file));
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(WILDCARD_IMPORT.matcher(source).find())
+            .as("%s must not use wildcard imports", relative)
+            .isFalse();
+        assertThat(FIELD_INJECTION.matcher(source).find())
+            .as("%s must use constructor injection", relative)
+            .isFalse();
+        assertThat(source)
+            .as("%s must not write directly to stdout/stderr", relative)
+            .doesNotContain("System.out.", "System.err.");
+        assertThat(source)
+            .as("%s must not use BeanUtils.copyProperties for Quality boundaries", relative)
+            .doesNotContain("BeanUtils.copyProperties");
+        assertThat(MIGRATION_MARKER.matcher(source).find())
+            .as("%s production comments must describe current contracts, not migration stages", relative)
+            .isFalse();
+        assertThat(ENUM_NAME_EQUALS.matcher(source).find())
+            .as("%s must compare typed enums before persistence/transport boundaries", relative)
+            .isFalse();
+        assertThat(REVERSE_ENUM_NAME_EQUALS.matcher(source).find())
+            .as("%s must not downgrade typed enums to strings", relative)
+            .isFalse();
+      }
+    }
+  }
+
+  @Test
+  void serviceStereotypeDoesNotReturnAsGenericApplicationLayer() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(source)
+            .as("Quality uses explicit Manager/Reader/Policy roles; @Service must not return in %s", file)
+            .doesNotContain("@Service", "org.springframework.stereotype.Service");
+      }
+    }
+  }
+
+  @Test
+  void coreDomainRemainsFrameworkFree() throws IOException {
+    Path domain = productionRoot().resolve("domain");
+    try (Stream<Path> files = Files.walk(domain)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(source)
+            .as("Quality Domain must remain framework-free: %s", file)
+            .doesNotContain(
+                "org.springframework.",
+                "com.baomidou.mybatisplus.",
+                "io.yak.ops.common.bean.dto.",
+                "io.yak.ops.common.bean.vo.",
+                "io.yak.ops.common.bean.po.",
+                "lombok.Data",
+                "@Data");
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() {
+    Path root = productionRoot();
+    for (String forbidden : List.of("service", "common", "helper", "utils", "util", "base")) {
+      assertThat(Files.exists(root.resolve(forbidden)))
+          .as("Broad Quality business bucket '%s' must not exist", forbidden)
+          .isFalse();
+    }
+  }
+
+  @Test
+  void repositoryUsesSingleRootCodeStyleDocument() throws IOException {
+    Path module = moduleRoot();
+    Path repository = module.getParent().getParent();
+    assertThat(Files.isRegularFile(repository.resolve("CODE_STYLE.md")))
+        .as("Yak Ops root CODE_STYLE.md must exist")
+        .isTrue();
+    assertThat(Files.exists(module.resolve("CODE_STYLE.md")))
+        .as("Quality must not maintain a module-local CODE_STYLE.md")
+        .isFalse();
+
+    long count;
+    try (Stream<Path> paths = Files.walk(repository, 6)) {
+      count =
+          paths.filter(Files::isRegularFile)
+              .filter(path -> path.getFileName().toString().equals("CODE_STYLE.md"))
+              .count();
+    }
+    assertThat(count)
+        .as("Yak Ops must keep one repository-wide CODE_STYLE.md")
+        .isEqualTo(1L);
+  }
+
+  private Path productionRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/quality");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/quality"))) {
+      return local;
+    }
+
+    Path repositoryRelative =
+        Path.of("yak-ops-business", "yak-ops-business-quality").toAbsolutePath().normalize();
+    assertThat(Files.isDirectory(repositoryRelative.resolve("src/main/java/io/yak/ops/business/quality")))
+        .as("Unable to locate Data Quality module root from %s", local)
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityDependencyBoundaryTest.java
@@ -1,0 +1,293 @@
+package io.yak.ops.business.quality.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Source-level guard for the final Data Quality package graph and narrow corridors. */
+class QualityDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.quality";
+  private static final Pattern QUALITY_IMPORT =
+      Pattern.compile(
+          "(?m)^import\\s+(?:static\\s+)?("
+              + Pattern.quote(BASE)
+              + "\\.([A-Za-z0-9_]+)\\.[^;]+);");
+  private static final Pattern DATASOURCE_IMPORT =
+      Pattern.compile(
+          "(?m)^import\\s+(io\\.yak\\.ops\\.business\\.datasource\\.[^;]+);");
+
+  private static final Map<String, Set<String>> ALLOWED_TOP_LEVEL_DEPENDENCIES =
+      Map.ofEntries(
+          Map.entry(
+              "controller",
+              Set.of("asset", "config", "domain", "execution", "monitor", "template", "workspace")),
+          Map.entry("workspace", Set.of("config", "domain", "monitor", "repository")),
+          Map.entry("monitor", Set.of("config", "domain", "repository", "schedule")),
+          Map.entry("schedule", Set.of("config", "domain", "execution", "repository")),
+          Map.entry("execution", Set.of("alert", "config", "domain", "gateway", "repository")),
+          Map.entry("alert", Set.of("config", "domain", "repository")),
+          Map.entry("asset", Set.of("config", "domain", "gateway", "repository")),
+          Map.entry("template", Set.of("config", "domain", "repository")),
+          Map.entry("gateway", Set.of("config")),
+          Map.entry("repository", Set.of("config", "dao", "domain")),
+          Map.entry("dao", Set.of()),
+          Map.entry("domain", Set.of()),
+          Map.entry("config", Set.of()));
+
+  @Test
+  void topLevelPackagesFollowDeclaredDependencyGraph() throws IOException {
+    for (Dependency dependency : qualityDependencies()) {
+      Set<String> allowed =
+          ALLOWED_TOP_LEVEL_DEPENDENCIES.getOrDefault(dependency.sourcePackage(), Set.of());
+      assertThat(allowed)
+          .as("%s imports %s", dependency.relativePath(), dependency.importedType())
+          .contains(dependency.targetPackage());
+    }
+  }
+
+  @Test
+  void declaredTopLevelDependencyGraphIsAcyclic() {
+    assertAcyclic(ALLOWED_TOP_LEVEL_DEPENDENCIES, "declared Quality dependency graph");
+  }
+
+  @Test
+  void actualTopLevelDependencyGraphIsAcyclic() throws IOException {
+    Map<String, Set<String>> graph = new HashMap<>();
+    ALLOWED_TOP_LEVEL_DEPENDENCIES.keySet().forEach(key -> graph.put(key, new HashSet<>()));
+    for (Dependency dependency : qualityDependencies()) {
+      graph.computeIfAbsent(dependency.sourcePackage(), ignored -> new HashSet<>())
+          .add(dependency.targetPackage());
+    }
+    assertAcyclic(graph, "actual Quality import graph");
+  }
+
+  @Test
+  void crossSubsystemCorridorsStayNarrow() throws IOException {
+    assertExactCorridor(
+        "monitor",
+        "schedule",
+        Set.of(
+            BASE + ".schedule.QualityScheduleLifecycle",
+            BASE + ".schedule.QualityScheduleCalculator"));
+    assertExactCorridor(
+        "schedule",
+        "execution",
+        Set.of(BASE + ".execution.QualityExecutionManager"));
+    assertExactCorridor(
+        "workspace",
+        "monitor",
+        Set.of(BASE + ".monitor.QualityMonitorReader"));
+    assertExactCorridor(
+        "execution",
+        "alert",
+        Set.of(BASE + ".alert.QualityAlertRecorder"));
+
+    assertGatewayCorridor("asset");
+    assertGatewayCorridor("execution");
+  }
+
+  @Test
+  void datasourceDependencyIsIsolatedBehindDeclaredBoundaries() throws IOException {
+    Map<String, Set<String>> allowed =
+        Map.of(
+            "config/QualityConfiguration.java",
+            Set.of(
+                "io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration"),
+            "gateway/datasource/DataSourceQualityCatalogAdapter.java",
+            Set.of(
+                "io.yak.ops.business.datasource.catalog.DataSourceCatalogReader",
+                "io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest",
+                "io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.ReadMode"));
+
+    for (ExternalDependency dependency : datasourceDependencies()) {
+      assertThat(allowed)
+          .as("Unexpected Datasource dependency from %s", dependency.relativePath())
+          .containsKey(dependency.relativePath());
+      assertThat(allowed.get(dependency.relativePath()))
+          .as("Unexpected Datasource type imported by %s", dependency.relativePath())
+          .contains(dependency.importedType());
+    }
+  }
+
+  @Test
+  void bottomLayersDoNotPointBackToApplicationSubsystems() throws IOException {
+    for (Dependency dependency : qualityDependencies()) {
+      if (dependency.sourcePackage().equals("domain")) {
+        throw new AssertionError("Quality Domain must not import upper Quality packages: " + dependency);
+      }
+      if (dependency.sourcePackage().equals("dao")) {
+        throw new AssertionError("Quality DAO must not import Quality business packages: " + dependency);
+      }
+      if (dependency.sourcePackage().equals("repository")) {
+        assertThat(dependency.targetPackage())
+            .as("Repository must remain below application roles: %s", dependency)
+            .isIn("config", "dao", "domain");
+      }
+      if (dependency.sourcePackage().equals("config")) {
+        throw new AssertionError("Quality config must not import Quality business roles: " + dependency);
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() {
+    Path root = productionRoot();
+    for (String forbidden : Set.of("service", "common", "helper", "utils", "util", "base")) {
+      assertThat(Files.exists(root.resolve(forbidden)))
+          .as("Broad Quality business bucket '%s' must not exist", forbidden)
+          .isFalse();
+    }
+  }
+
+  private void assertExactCorridor(String source, String target, Set<String> allowedTypes)
+      throws IOException {
+    for (Dependency dependency : crossing(source, target)) {
+      assertThat(allowedTypes)
+          .as("Unexpected %s -> %s corridor in %s", source, target, dependency.relativePath())
+          .contains(dependency.importedType());
+    }
+  }
+
+  private void assertGatewayCorridor(String source) throws IOException {
+    String allowedPrefix = BASE + ".gateway.datasource.QualityDataCatalogGateway";
+    for (Dependency dependency : crossing(source, "gateway")) {
+      assertThat(dependency.importedType())
+          .as("%s must use the Quality-owned Datasource gateway", dependency.relativePath())
+          .startsWith(allowedPrefix);
+    }
+  }
+
+  private List<Dependency> crossing(String source, String target) throws IOException {
+    return qualityDependencies().stream()
+        .filter(dependency -> dependency.sourcePackage().equals(source))
+        .filter(dependency -> dependency.targetPackage().equals(target))
+        .toList();
+  }
+
+  private void assertAcyclic(Map<String, Set<String>> graph, String label) {
+    Set<String> nodes = new HashSet<>(graph.keySet());
+    graph.values().forEach(nodes::addAll);
+    Map<String, Integer> indegree = new HashMap<>();
+    Map<String, Set<String>> reverse = new HashMap<>();
+    nodes.forEach(node -> indegree.put(node, 0));
+
+    for (Map.Entry<String, Set<String>> entry : graph.entrySet()) {
+      for (String target : entry.getValue()) {
+        indegree.compute(entry.getKey(), (ignored, value) -> value + 1);
+        reverse.computeIfAbsent(target, ignored -> new HashSet<>()).add(entry.getKey());
+      }
+    }
+
+    ArrayDeque<String> ready = new ArrayDeque<>();
+    indegree.forEach(
+        (node, degree) -> {
+          if (degree == 0) {
+            ready.add(node);
+          }
+        });
+
+    int visited = 0;
+    while (!ready.isEmpty()) {
+      String node = ready.removeFirst();
+      visited++;
+      for (String dependent : reverse.getOrDefault(node, Set.of())) {
+        int degree = indegree.compute(dependent, (ignored, value) -> value - 1);
+        if (degree == 0) {
+          ready.add(dependent);
+        }
+      }
+    }
+
+    assertThat(visited).as("%s must remain acyclic", label).isEqualTo(nodes.size());
+  }
+
+  private List<Dependency> qualityDependencies() throws IOException {
+    Path root = productionRoot();
+    List<Dependency> result = new ArrayList<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Path relative = root.relativize(file);
+        if (relative.getNameCount() < 2) {
+          continue;
+        }
+        String sourcePackage = relative.getName(0).toString();
+        Matcher matcher = QUALITY_IMPORT.matcher(Files.readString(file, StandardCharsets.UTF_8));
+        while (matcher.find()) {
+          String importedType = matcher.group(1);
+          String targetPackage = matcher.group(2);
+          if (!sourcePackage.equals(targetPackage)) {
+            result.add(
+                new Dependency(
+                    sourcePackage, targetPackage, importedType, normalize(relative)));
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private List<ExternalDependency> datasourceDependencies() throws IOException {
+    Path root = productionRoot();
+    List<ExternalDependency> result = new ArrayList<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Path relative = root.relativize(file);
+        Matcher matcher = DATASOURCE_IMPORT.matcher(Files.readString(file, StandardCharsets.UTF_8));
+        while (matcher.find()) {
+          result.add(new ExternalDependency(normalize(relative), matcher.group(1)));
+        }
+      }
+    }
+    return result;
+  }
+
+  private Path productionRoot() {
+    Path moduleLocal = Path.of("src/main/java/io/yak/ops/business/quality");
+    if (Files.isDirectory(moduleLocal)) {
+      return moduleLocal;
+    }
+    Path repositoryRelative =
+        Path.of(
+            "yak-ops-business",
+            "yak-ops-business-quality",
+            "src",
+            "main",
+            "java",
+            "io",
+            "yak",
+            "ops",
+            "business",
+            "quality");
+    assertThat(Files.isDirectory(repositoryRelative))
+        .as("Unable to locate Data Quality production source root")
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+
+  private record Dependency(
+      String sourcePackage,
+      String targetPackage,
+      String importedType,
+      String relativePath) {}
+
+  private record ExternalDependency(String relativePath, String importedType) {}
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityRoleConventionTest.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.quality.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.quality.alert.QualityAlertRecorder;
+import io.yak.ops.business.quality.asset.QualityTableAssetManager;
+import io.yak.ops.business.quality.asset.QualityTableAssetReader;
+import io.yak.ops.business.quality.asset.QualityTableCandidateReader;
+import io.yak.ops.business.quality.asset.QualityTableTargetPolicy;
+import io.yak.ops.business.quality.execution.QualityExecutionDispatcher;
+import io.yak.ops.business.quality.execution.QualityExecutionManager;
+import io.yak.ops.business.quality.execution.QualityExecutionPlanFactory;
+import io.yak.ops.business.quality.execution.QualityExecutionReader;
+import io.yak.ops.business.quality.execution.QualityExecutionWorker;
+import io.yak.ops.business.quality.execution.QualityMetricEvaluator;
+import io.yak.ops.business.quality.execution.QualitySqlCompiler;
+import io.yak.ops.business.quality.gateway.datasource.DataSourceQualityCatalogAdapter;
+import io.yak.ops.business.quality.monitor.QualityMonitorManager;
+import io.yak.ops.business.quality.monitor.QualityMonitorPolicy;
+import io.yak.ops.business.quality.monitor.QualityMonitorReader;
+import io.yak.ops.business.quality.monitor.QualityMonitorSettingsPolicy;
+import io.yak.ops.business.quality.monitor.QualityRulePolicy;
+import io.yak.ops.business.quality.schedule.QualityScheduleCalculator;
+import io.yak.ops.business.quality.schedule.QualityScheduleEngineBridge;
+import io.yak.ops.business.quality.schedule.QualityScheduleHandler;
+import io.yak.ops.business.quality.schedule.QualityScheduleLifecycle;
+import io.yak.ops.business.quality.schedule.QualityScheduleReconciler;
+import io.yak.ops.business.quality.template.CustomTemplateManager;
+import io.yak.ops.business.quality.template.CustomTemplatePolicy;
+import io.yak.ops.business.quality.template.CustomTemplateReader;
+import io.yak.ops.business.quality.template.QualityTemplateReader;
+import io.yak.ops.business.quality.template.TemplateFolderManager;
+import io.yak.ops.business.quality.template.TemplateFolderReader;
+import io.yak.ops.business.quality.workspace.QualityExecutionLogProjector;
+import io.yak.ops.business.quality.workspace.QualityExecutionWorkspaceReader;
+import io.yak.ops.business.quality.workspace.QualityWorkspaceReader;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+class QualityRoleConventionTest {
+
+  @Test
+  void internalApplicationRolesStayExplicitComponents() {
+    for (Class<?> role :
+        List.of(
+            QualityTableAssetManager.class,
+            QualityTableAssetReader.class,
+            QualityTableCandidateReader.class,
+            QualityTableTargetPolicy.class,
+            QualityMonitorManager.class,
+            QualityMonitorReader.class,
+            QualityMonitorPolicy.class,
+            QualityRulePolicy.class,
+            QualityMonitorSettingsPolicy.class,
+            QualityExecutionManager.class,
+            QualityExecutionReader.class,
+            QualityExecutionPlanFactory.class,
+            QualityExecutionDispatcher.class,
+            QualityExecutionWorker.class,
+            QualityMetricEvaluator.class,
+            QualitySqlCompiler.class,
+            QualityAlertRecorder.class,
+            QualityScheduleCalculator.class,
+            QualityScheduleEngineBridge.class,
+            QualityScheduleHandler.class,
+            QualityScheduleLifecycle.class,
+            QualityScheduleReconciler.class,
+            CustomTemplateManager.class,
+            CustomTemplateReader.class,
+            CustomTemplatePolicy.class,
+            QualityTemplateReader.class,
+            TemplateFolderManager.class,
+            TemplateFolderReader.class,
+            QualityWorkspaceReader.class,
+            QualityExecutionWorkspaceReader.class,
+            QualityExecutionLogProjector.class,
+            DataSourceQualityCatalogAdapter.class)) {
+      assertThat(role.getAnnotation(Component.class))
+          .as("%s must remain an explicit internal component role", role.getSimpleName())
+          .isNotNull();
+      assertThat(role.getAnnotation(Service.class))
+          .as("%s must not masquerade as a generic Application Service", role.getSimpleName())
+          .isNull();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/asset/QualityTableAssetManagerTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/asset/QualityTableAssetManagerTest.java
@@ -25,7 +25,9 @@ class QualityTableAssetManagerTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    manager = new QualityTableAssetManager(repository, catalogGateway);
+    manager =
+        new QualityTableAssetManager(
+            repository, catalogGateway, new QualityTableTargetPolicy());
   }
 
   @Test
@@ -34,12 +36,16 @@ class QualityTableAssetManagerTest {
         .thenReturn(List.of(table("user_info", "插件中的用户表描述")));
     when(repository.registerTableAssets(anyList())).thenReturn(1);
 
-    var result = manager.register(
-        new QualityTableAssetCommand.Register(
-            1L, "测试数据源", "demo",
-            List.of(new QualityTableAssetCommand.Item(
-                "demo", null, "user_info", "CLIENT_VALUE", "客户端描述"))),
-        "tester");
+    var result =
+        manager.register(
+            new QualityTableAssetCommand.Register(
+                1L,
+                "测试数据源",
+                "demo",
+                List.of(
+                    new QualityTableAssetCommand.Item(
+                        "demo", null, "user_info", "CLIENT_VALUE", "客户端描述"))),
+            "tester");
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<TableAssetSpec>> captor = ArgumentCaptor.forClass(List.class);

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/asset/QualityTableCandidateReaderTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/asset/QualityTableCandidateReaderTest.java
@@ -21,7 +21,9 @@ class QualityTableCandidateReaderTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    reader = new QualityTableCandidateReader(repository, catalogGateway);
+    reader =
+        new QualityTableCandidateReader(
+            repository, catalogGateway, new QualityTableTargetPolicy());
   }
 
   @Test
@@ -29,15 +31,17 @@ class QualityTableCandidateReaderTest {
     when(repository.listTableAssetTargets(1L, "demo"))
         .thenReturn(List.of(new TableAssetTarget("demo", null, "registered_table")));
     when(catalogGateway.listTables(1L, "demo", null, null))
-        .thenReturn(List.of(
-            table("registered_table", "已注册"),
-            table("order_info", "订单表"),
-            table("user_info", "用户表")));
+        .thenReturn(
+            List.of(
+                table("registered_table", "已注册"),
+                table("order_info", "订单表"),
+                table("user_info", "用户表")));
 
     var result = reader.candidates(1L, "demo", null, null, 1, 20);
 
     assertThat(result.total()).isEqualTo(2);
-    assertThat(result.records()).extracting(QualityPhysicalTable::tableName)
+    assertThat(result.records())
+        .extracting(QualityPhysicalTable::tableName)
         .containsExactly("order_info", "user_info");
   }
 


### PR DESCRIPTION
## Summary

完成 Data Quality Stage 2 治理收口。Stage 1 已经把旧 `quality/service/**` 拆成明确的 Manager / Reader / Policy / Execution / Gateway / Repository 角色；本 PR 不继续做大规模业务拆分，而是把当前结构固化成**长期 contract + executable architecture guards**，并修复治理审计中发现的两个真实结构问题。

本 PR 遵循仓库根 `CODE_STYLE.md`：

```text
Correctness / Safety
  > Explicit ownership
  > Simple control flow
  > Testability
  > Reuse
  > Brevity
```

## Permanent Quality contract

新增：

```text
REQUIREMENTS.md
DOMAIN.md
ARCHITECTURE.md
DEPENDENCIES.md
REVIEW.md
```

并重写模块 `README.md` 作为当前文档入口，统一引用仓库根：

```text
../../CODE_STYLE.md
```

Quality 不创建模块私有 CODE_STYLE 副本。

## Truth ownership

当前长期模型明确为：

```text
TableAsset                  = registered physical quality target
Monitor + Rules + Settings  = current monitor definition truth
QualityExecutionPlan        = immutable enqueue-time execution snapshot
Execution                   = persisted execution lifecycle/result evidence
RuleExecution               = per-rule evidence
AlertEvent                  = notification evidence
Yak Schedule                = trigger projection
Datasource Catalog          = physical metadata evidence
```

关键 contract：已入队/运行中的 Execution 只消费冻结的 `QualityExecutionPlan`，不能回读 current Monitor / Rule / Settings 改写本次执行。

## Architecture shape

```text
quality/
├── controller
├── asset
├── monitor
├── execution
├── alert
├── schedule
├── template
├── workspace
├── gateway/datasource
├── repository
├── dao
├── domain/execution
└── config
```

Quality 当前没有额外通用 `@Service` facade；Controller 进入显式的 Manager / Reader / Projector 角色。

## Fix 1: Reader must not be used as a Helper

治理审计发现：

```text
QualityTableAssetManager
  -> QualityTableCandidateReader static normalization helpers
```

这让 Command Manager 反向把 read-side Reader 当工具类使用。

新增：

```text
QualityTableTargetPolicy
```

现在：

```text
QualityTableAssetManager  ─┐
                           ├-> QualityTableTargetPolicy
QualityTableCandidateReader┘
```

Policy 统一拥有 datasource id、database/schema/table identity、trim/normalization 规则；Manager/Reader 各守自身角色。

Datasource 插件元数据权威性、候选列表、注册/取消注册行为不变。

## Fix 2: remove config <-> execution package cycle

原 `QualityConfiguration` 手工声明：

```text
@Bean QualityMetricEvaluator
@Bean QualitySqlCompiler
```

因此源码图存在：

```text
config -> execution
execution -> config.ConditionalOnQualityEnabled
```

Stage 2 不把这个环写进白名单，而是修掉：

- `QualityMetricEvaluator` -> explicit execution `@Component`
- `QualitySqlCompiler` -> explicit execution `@Component`
- `QualityConfiguration` 只保留 Flyway / executor / properties / MapperScan / infrastructure wiring

最终内部 dependency graph 保持无环。

## Typed execution projection cleanup

`QualityExecutionLogProjector` 原来通过：

```java
execution.triggerType().name().equals("SCHEDULE")
```

判断触发类型。

改为 typed enum comparison：

```java
execution.triggerType() == TriggerType.SCHEDULE
```

持久化/传输边界之外不把明确 enum 降级成 magic string。

## Executable dependency governance

新增：

```text
QualityDependencyBoundaryTest
```

保护：

```text
declared top-level dependency matrix
actual import graph is acyclic
monitor -> schedule corridor
schedule -> execution corridor
workspace -> monitor corridor
execution -> alert corridor
asset/execution -> QualityDataCatalogGateway
bottom-layer direction
no broad business bucket
```

### Datasource external corridor

Quality 对 Datasource 只允许：

```text
config/QualityConfiguration
  -> BusinessDatabaseConfiguration
     # infrastructure wiring only

gateway/datasource/DataSourceQualityCatalogAdapter
  -> DataSourceCatalogReader
  -> CatalogReadRequest
     # typed catalog capability only
```

Asset / Execution 等业务角色只能依赖 Quality-owned `QualityDataCatalogGateway`。

## Repository-wide code style guard

新增：

```text
QualityCodeStyleConventionTest
```

保护：

```text
single root CODE_STYLE.md
no wildcard import
no System.out/System.err
constructor injection only
no Stage/Wave/Phase migration markers in production
no enum .name().equals(...) business comparison
no BeanUtils.copyProperties
Core Domain remains Spring/MyBatis/DTO/VO/PO free
no service/common/helper/utils/util/base business buckets
no generic @Service layer returning to Quality
```

## Role guard

新增：

```text
QualityRoleConventionTest
```

明确 Manager / Reader / Policy / Factory / Dispatcher / Worker / Recorder / Gateway Adapter 等内部专业角色必须保持 `@Component`，不能重新伪装成通用 `@Service`。

## Execution safety documented, not changed

Stage 2 文档与 guard 固化现有流程：

```text
lock Monitor
 -> validate enabled monitor / enabled rules / no active execution
 -> insert WAITING Execution
 -> freeze immutable QualityExecutionPlan
 -> transaction commit
 -> dispatch worker
 -> per-rule evidence
 -> final Execution result
 -> alert evidence
```

继续保持：

- one active Execution per Monitor
- after-commit dispatch
- queue rejection -> ERROR instead of permanent WAITING
- RuleFailureAction.STOP -> remaining rules NOT_RUN
- Quality SQL read-only / single-query constraints
- schedule callback -> QualityExecutionManager admission
- AlertEvent is evidence, not Execution truth

## Intentionally unchanged

本 PR 不改变：

- `/api/v1/data-quality/**` endpoints
- request DTO / response VO JSON shape
- permission codes
- database / Flyway / physical schema
- DAO / Mapper XML contract
- shared PageData repository paging
- Monitor/Rule/Settings business semantics
- manual/scheduled execution behavior
- Datasource Plugin SPI / typed catalog behavior
- Yak Schedule framework contract
- alert delivery semantics

## Validation before Draft PR

```text
base: main @ 7a3f3626e8817b982e2cc8e0ec4c92afb364c8be
branch: refactor/quality-stage2-governance
ahead: 18
behind: 0
changed files: 18
Controller files changed: 0
DAO / SQL / Flyway changes: 0
```

已静态复核 package graph、Datasource corridor、config/execution cycle、role stereotypes 与文档一致性。

当前执行环境没有实际运行完整 Maven/JUnit，因此不把静态审计宣称为测试通过；以 GitHub checks/CI 实际结果为准。

## Review focus

```text
[ ] QualityExecutionPlan 仍是 enqueue-time immutable snapshot
[ ] config -> execution cycle 已真正消失，而不是测试白名单放行
[ ] Manager 不再借 Reader 当 Helper
[ ] dependency matrix 与真实 imports 一致且无环
[ ] Datasource 业务能力只从 QualityDataCatalogGateway 进入
[ ] schedule callback 仍走 QualityExecutionManager admission
[ ] queue rejection / STOP / alert semantics 没变化
[ ] no REST / DB / Flyway behavior change
```