### PR TITLE
refactor(dataset): close stage 2 architecture governance

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-dataset/ARCHITECTURE.md
@@ -1,0 +1,245 @@
+# Dataset Architecture
+
+本文件描述 Dataset 当前长期架构。需求看 `REQUIREMENTS.md`，领域事实看 `DOMAIN.md`，依赖矩阵看 `DEPENDENCIES.md`，统一规范看 [`../../CODE_STYLE.md`](../../CODE_STYLE.md)。
+
+## 1. Principles
+
+1. `Dataset / DatasetVersion / DatasetField` ownership 显式分离；
+2. package 表达业务子系统，不恢复通用 `service/`；
+3. 三个稳定 `@Service` facade 只负责 Application API；
+4. 内部角色使用 Reader / Manager / Publisher / Coordinator / Adapter 等明确名称；
+5. 外部模块能力停在 Dataset-owned Gateway/Adapter 或明确 Runtime Adapter；
+6. DatasetVersion append-only；
+7. Query 和 Lineage 永远消费 exact version snapshot；
+8. Repository / DAO 保持 persistence boundary；
+9. 文档依赖图必须和 executable guard 一致。
+
+## 2. Package Map
+
+```text
+io.yak.ops.business.dataset
+├── controller
+├── definition
+├── publication
+├── schema
+├── query
+│   └── adapter
+├── observability
+├── development
+├── lineage
+├── gateway
+│   ├── taskcatalog
+│   ├── datasource
+│   └── lineage
+├── repository
+├── dao
+├── config
+└── root public API / domain values
+```
+
+root package 暂时同时承载历史兼容的 public records/enums 和三个稳定 facade。Stage 2 dependency graph 只把明确的业务子 package 当作内部节点；root public contract 由 facade/architecture tests 单独保护。
+
+## 3. Stable Facades
+
+当前只有：
+
+```text
+DatasetService
+DatasetQueryService
+DevelopmentDatasetFacade
+```
+
+`DatasetService` 面向 HTTP、Analysis 和 release 等兼容调用者；内部委托 Definition / Publication / Development。
+
+`DatasetQueryService` 面向 Dashboard/Chart 等查询消费者；内部委托 Query Coordinator 和 Observability Reader。
+
+`DevelopmentDatasetFacade` 是 Data Development Dataset Node 的稳定跨模块 API。
+
+Facade 不直接依赖 Repository / DAO / TaskCatalogService / Datasource implementation / LineageService。
+
+## 4. Definition
+
+```text
+DatasetReader
+DatasetManager
+DatasetBindingPolicy
+```
+
+- Reader：Dataset identity/current version/schema read side；
+- Manager：ONLINE/OFFLINE lifecycle；
+- BindingPolicy：Analysis 对当前 ONLINE schema 的绑定校验。
+
+Status 变化通过 `DatasetLineageRefreshPublisher` 请求派生血缘刷新，但 Lineage 不反向进入 Definition Reader。
+
+## 5. Publication
+
+```text
+DatasetPublisher
+    -> DatasetReader
+    -> DatasetTaskCatalogGateway
+    -> DatasetSchemaDiscovery
+    -> DatasetFieldNormalizer
+    -> DatasetVersionWriter
+    -> DatasetLineageRefreshPublisher
+```
+
+主路径：
+
+```text
+validate exact upstream source
+ -> freeze exact revision/schema
+ -> append immutable DatasetVersion
+ -> update currentVersionId
+ -> after-commit lineage refresh request
+```
+
+`DatasetVersionWriter` 只负责 append version + move pointer，不负责 source validation。
+
+## 6. Schema
+
+```text
+DatasetSchemaDiscovery
+DatasetFieldNormalizer
+DatasetFieldIdentity
+DatasetFieldSpec
+```
+
+Schema Discovery 通过 Dataset-owned TaskCatalog/SQL gateway 获取来源 evidence。
+
+FieldNormalizer 负责稳定 field contract；FieldIdentity 集中 deterministic fieldId 规则。
+
+Preview 不写持久化 field identity。
+
+## 7. Query Runtime
+
+```text
+DatasetQueryService @Service
+ -> DatasetQueryCoordinator
+      -> DatasetRepository
+      -> DatasetSourceQueryRegistry
+      -> exact source adapter
+      -> DatasetQueryPerformanceRecorder
+```
+
+Adapters：
+
+```text
+QUERY_REVISION -> QueryRevisionDatasetSourceAdapter
+SQL_QUERY      -> SqlQueryDatasetSourceAdapter
+```
+
+Query adapters 本身就是 Runtime boundary，可以直接调用 `io.yak.ops.core.execution.sql.*`；业务 Coordinator 不直接依赖 Core SQL Runtime。
+
+## 8. Observability
+
+```text
+DatasetQueryPerformanceBuffer
+DatasetQueryPerformanceRecorder
+DatasetQueryPerformanceReader
+```
+
+Buffer 为 bounded process-local evidence，不承担业务持久化。
+
+## 9. Development
+
+```text
+DevelopmentDatasetFacade @Service
+ -> DevelopmentDatasetManager
+      -> DatasetReader
+      -> DatasetPublisher
+      -> DatasetSchemaDiscovery
+      -> DatasetVersionWriter
+      -> DatasetRepository
+      -> DatasetLineageRefreshPublisher
+```
+
+Manager 拥有 DevelopmentNode -> stable Dataset identity 的 Dataset-side lifecycle。
+
+## 10. Lineage
+
+```text
+DatasetLineageRefreshPublisher
+    -> Spring event
+
+DatasetLineageRefreshListener
+    -> DatasetLineageSnapshotReader
+    -> DatasetLineageTransactionRunner
+         -> DatasetLineageSynchronizer
+              -> DatasetLineageSourceResolver
+              -> DatasetProjectionAnalyzerGateway
+              -> DatasetLineageGraphGateway
+```
+
+`DatasetLineageSnapshotReader` 直接读取 Repository，是为了保持 Lineage derived projection 在 Definition 下游，避免 `definition <-> lineage` package cycle。
+
+Lineage 是 AFTER_COMMIT + REQUIRES_NEW 的 best-effort projection。
+
+## 11. Gateways
+
+Task Catalog：
+
+```text
+DatasetTaskCatalogGateway
+ <- TaskCatalogDatasetAdapter
+ <- TaskCatalogService/domain
+```
+
+Datasource Schema SQL：
+
+```text
+DatasetSchemaSqlGateway
+ <- DataSourceSchemaSqlAdapter
+ <- Datasource execution SPI
+```
+
+Datasource Catalog（optional lineage evidence）：
+
+```text
+DatasetCatalogGateway
+ <- DataSourceDatasetCatalogAdapter
+ <- DataSourceCatalogReader
+```
+
+Lineage：
+
+```text
+DatasetProjectionAnalyzerGateway
+ <- LineageProjectionAnalyzerAdapter
+ <- SqlProjectionLineageAnalyzer
+
+DatasetLineageGraphGateway
+ <- LineageGraphDatasetAdapter
+ <- LineageService / LineageMaintenanceService
+```
+
+## 12. Persistence
+
+```text
+Application role
+ -> DatasetRepository
+ -> DatasetRepositoryAdapter
+ -> DatasetDao
+ -> mapper / PO / MyBatis
+```
+
+Repository contract 只暴露 Dataset-owned domain/value，不暴露 Controller DTO/VO、PO、Mapper 或 MyBatis 类型。
+
+## 13. Config
+
+`DatasetPersistenceConfiguration` 只负责 Dataset Flyway 和共享业务数据库 wiring。
+
+它可以复用 Datasource 模块的 `BusinessDatabaseConfiguration / ConditionalOnDataSourceEnabled / DataSourceProperties`，但不能反向手工创建 Dataset business role Bean。
+
+## 14. Change Rule
+
+新增依赖前依次回答：
+
+1. 属于哪个 Dataset 子系统？
+2. 它拥有 truth 还是只读取/投影？
+3. 是否已有 Reader/Publisher/Gateway/Repository 可表达？
+4. 新 import 是否符合 `DEPENDENCIES.md`？
+5. 是否会让 exact DatasetVersion 漂移到 current upstream state？
+6. 是否会形成 package cycle？
+7. 哪个行为测试和架构测试保护它？
+
+答不清楚时不要创建新的 Helper/Common/ServiceImpl。

--- a/yak-ops-business/yak-ops-business-dataset/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-dataset/DEPENDENCIES.md
@@ -1,0 +1,209 @@
+# Dataset Dependencies
+
+本文件定义 Dataset production package 的允许依赖方向、窄 corridor 与外部模块入口。原则：**显式、窄、无环**。
+
+## 1. Top-level Package Matrix
+
+root public contract 不作为内部图节点；以下是明确业务子 package：
+
+| Source | Allowed Dataset packages |
+| --- | --- |
+| `controller` | none |
+| `definition` | `lineage`, `repository` |
+| `development` | `definition`, `gateway`, `lineage`, `publication`, `repository`, `schema` |
+| `publication` | `definition`, `gateway`, `lineage`, `repository`, `schema` |
+| `schema` | `gateway`, `repository` |
+| `query` | `gateway`, `observability`, `repository` |
+| `observability` | none |
+| `lineage` | `gateway`, `repository` |
+| `gateway` | none |
+| `repository` | `dao` |
+| `dao` | none |
+| `config` | none |
+
+同一 top-level package 内部可协作。声明图和实际 import 图都必须无环。
+
+## 2. Root Public Contract
+
+root package 中三个稳定 facade：
+
+```text
+DatasetService
+DatasetQueryService
+DevelopmentDatasetFacade
+```
+
+以及现有 public Dataset records/enums 是兼容 API，不进入内部 cycle graph。
+
+Facade 可以依赖内部 Application role，但内部 role 不应为了方便回调 facade。
+
+## 3. Definition -> Lineage
+
+Definition 进入 Lineage 只允许：
+
+```text
+DatasetManager
+ -> DatasetLineageRefreshPublisher
+```
+
+Lineage 不允许反向 import `definition.*`。
+
+Lineage 读取 Dataset current snapshot 通过：
+
+```text
+DatasetLineageSnapshotReader
+ -> DatasetRepository
+```
+
+这样避免 `definition <-> lineage` cycle。
+
+## 4. Publication Corridors
+
+Publication 可以进入：
+
+```text
+DatasetReader
+DatasetTaskCatalogGateway
+DatasetSchemaDiscovery / DatasetFieldNormalizer
+DatasetRepository
+DatasetLineageRefreshPublisher
+```
+
+Publication 不直接依赖 TaskCatalogService、Datasource execution SPI、LineageService/Analyzer。
+
+## 5. Development Corridors
+
+`DevelopmentDatasetManager` 是组合型 Dataset-side role，可以复用 Definition / Publication / Schema / Repository / Lineage refresh。
+
+Data Development 模块本身只能通过 `DevelopmentDatasetFacade` 进入 Dataset；不能跨模块直接依赖 `development.DatasetManager`、Repository 或 DAO。
+
+## 6. Query Corridors
+
+Query Coordinator：
+
+```text
+DatasetQueryCoordinator
+ -> DatasetRepository
+ -> DatasetSourceQueryRegistry
+ -> DatasetQueryPerformanceRecorder
+```
+
+Query 的 TaskCatalog 访问只允许 `QueryRevisionDatasetSourceAdapter -> DatasetTaskCatalogGateway`。
+
+Source adapters 可直接依赖 `io.yak.ops.core.execution.sql.*`；它们本身就是 Dataset Query Runtime adapter 边界。Coordinator / Registry / Compiler 不允许直接依赖 Core SQL Runtime。
+
+## 7. Schema Corridors
+
+Schema 只通过 Dataset-owned Gateway 使用外部来源：
+
+```text
+DatasetSchemaDiscovery
+ -> DatasetTaskCatalogGateway
+ -> DatasetSchemaSqlGateway
+```
+
+`DatasetFieldNormalizer` 只可向下依赖 DatasetRepository 和 FieldIdentity。
+
+## 8. Lineage Corridors
+
+Lineage projection 只通过：
+
+```text
+DatasetLineageSourceResolver -> DatasetTaskCatalogGateway
+DatasetLineageSynchronizer   -> DatasetProjectionAnalyzerGateway
+DatasetLineageSynchronizer   -> DatasetLineageGraphGateway
+DatasetLineageSnapshotReader -> DatasetRepository
+```
+
+Lineage 不直接依赖 TaskCatalogService、DataSourceCatalogReader、SqlProjectionLineageAnalyzer、LineageService 或 LineageMaintenanceService。
+
+## 9. External Module Boundaries
+
+外部实现只允许从以下文件进入：
+
+### Task Catalog
+
+```text
+gateway/taskcatalog/TaskCatalogDatasetAdapter.java
+ -> io.yak.ops.business.taskcatalog.*
+```
+
+### Datasource Catalog
+
+```text
+gateway/datasource/DataSourceDatasetCatalogAdapter.java
+ -> io.yak.ops.business.datasource.catalog.DataSourceCatalogReader
+```
+
+### Datasource SQL SPI
+
+```text
+gateway/datasource/DataSourceSchemaSqlAdapter.java
+ -> io.yak.ops.spi.datasource.execution.*
+```
+
+### Shared Lineage
+
+```text
+gateway/lineage/LineageProjectionAnalyzerAdapter.java
+ -> io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer
+
+gateway/lineage/LineageGraphDatasetAdapter.java
+ -> io.yak.ops.business.lineage.Lineage*
+```
+
+### Core SQL Runtime
+
+```text
+query/adapter/QueryRevisionDatasetSourceAdapter.java
+query/adapter/SqlQueryDatasetSourceAdapter.java
+ -> io.yak.ops.core.execution.sql.*
+```
+
+### Infrastructure Config
+
+```text
+config/DatasetPersistenceConfiguration.java
+ -> io.yak.ops.business.datasource.config.*
+```
+
+这是共享 business database / feature configuration wiring，不是 Dataset 业务能力调用。
+
+## 10. Persistence Boundary
+
+```text
+Business role
+ -> DatasetRepository
+ -> DatasetRepositoryAdapter
+ -> DatasetDao
+ -> PO / Mapper / MyBatis
+```
+
+Repository contract 不暴露：
+
+- Controller DTO/VO；
+- DAO PO/Mapper；
+- MyBatis 类型；
+- 外部 TaskCatalog/Datasource/Lineage 对象；
+- stable facade 类型。
+
+## 11. No Cycles
+
+不允许通过以下方式掩盖 cycle：
+
+- `@Lazy`；
+- ApplicationContext lookup；
+- 静态 Service Locator；
+- 把接口随意搬到 `common/helper/base`；
+- 直接扩大 dependency-test 白名单。
+
+发现新环先明确能力 owner，再建立窄 Reader/Gateway/Publisher corridor。
+
+## 12. Adding a Dependency
+
+新增不在矩阵中的 import 时：
+
+1. 先判断类是否放错 package；
+2. 判断现有 facade/Reader/Gateway/Repository 是否可表达；
+3. 判断是否缺 Dataset-owned narrow contract；
+4. 只有架构真的变化时，才同步更新本文件和 executable dependency test。

--- a/yak-ops-business/yak-ops-business-dataset/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-dataset/DOMAIN.md
@@ -1,0 +1,200 @@
+# Dataset Domain
+
+本文件定义 Dataset 当前领域事实、生命周期与 truth ownership。历史重构过程不属于 Domain contract。
+
+## 1. Core Identity
+
+```text
+Dataset
+    != DatasetVersion
+    != DatasetField
+    != Dataset Query
+    != Query Performance
+    != Dataset Lineage
+```
+
+字段相似不代表可以共用一个通用状态对象。
+
+## 2. Dataset
+
+`Dataset` 是长期稳定的业务身份，拥有 name / description / status / currentVersionId 等 identity-level 状态。
+
+`currentVersionId` 是**选择指针**，不是“版本内容”。
+
+因此：
+
+- Dataset 上线/下线不修改历史版本；
+- 更新 currentVersionId 不修改旧版本；
+- 同一个 DevelopmentNode 重复保存保持同一个 Dataset identity。
+
+## 3. DatasetVersion
+
+`DatasetVersion` 是 immutable source snapshot。
+
+QUERY_REVISION 版本冻结：
+
+```text
+sourceTaskAssetId
+sourceTaskRevisionId
+sourceTaskRevisionNo
+schema snapshot
+```
+
+SQL_QUERY 版本冻结：
+
+```text
+dataSourceId
+SQL
+schema snapshot
+```
+
+版本创建后，上游 TaskAsset current revision、Data Development editor、Datasource metadata 后续变化都不能改写该版本。
+
+## 4. DatasetField
+
+`DatasetField` 属于某个确定 DatasetVersion 的 schema contract。
+
+fieldId 是 Dataset 下游绑定的稳定标识；physicalName 是该版本实际输出字段身份。
+
+硬规则：
+
+- preview field 没有持久化身份；
+- 保存版本时分配 fieldId；
+- compatible physical field 应复用已有 fieldId；
+- fieldId 不能因为 displayName/description 改变而无故漂移；
+- DatasetField 不属于 Dataset identity 本身，而属于 version schema。
+
+## 5. Publication
+
+Publication 的领域顺序：
+
+```text
+exact source evidence
+ -> normalized schema
+ -> append DatasetVersion
+ -> move currentVersionId
+```
+
+不存在“修改 V3 使它变成 V4”。
+
+Release publish 在 current TaskRevision 未变化时保持幂等。
+
+## 6. Current Source vs Version Snapshot
+
+```text
+current upstream source
+    !=
+existing DatasetVersion source snapshot
+```
+
+例如：
+
+```text
+TaskRevision V10 -> DatasetVersion 3
+TaskRevision later becomes V11
+```
+
+查询/血缘读取 DatasetVersion 3 时仍必须使用 V10。
+
+## 7. Query Truth
+
+一次 Dataset Query 的业务 truth 是：
+
+```text
+Dataset identity
++ exact DatasetVersion
++ request
++ source adapter execution result
+```
+
+Query Runtime 不允许：
+
+- 指定 V1 后偷偷改用 current V2；
+- QUERY_REVISION 重新解析 TaskAsset current revision；
+- SQL_QUERY 回读 editor current SQL；
+- sourceType 未接入时猜测另一个 adapter。
+
+## 8. Query Performance
+
+`DatasetQueryPerformance` 是 observability evidence。
+
+```text
+Query Performance != Query Result != Dataset truth
+```
+
+诊断记录只用于解释 latency/rows/truncation，不参与 Dataset/Version 生命周期。
+
+## 9. DevelopmentNode Binding
+
+Data Development Dataset Node 与 Dataset 的长期关系：
+
+```text
+DevelopmentNode
+    -> stable Dataset identity
+        -> version history
+```
+
+保存同一节点的新 SQL/schema 应追加 DatasetVersion，而不是创建另一个 Dataset identity。
+
+## 10. Lineage Projection
+
+Dataset Lineage 是从当前 immutable DatasetVersion 派生的 graph projection。
+
+```text
+DatasetVersion truth
+      |
+      v
+Derived lineage evidence
+```
+
+Lineage 不允许反向成为 DatasetVersion 的配置来源。
+
+派生失败语义必须区分：
+
+```text
+SKIPPED     = analyzer/capability unavailable or no analyzable SQL
+FAILED      = analysis attempted but failed
+PARTIAL     = only part of projection resolved
+UNRESOLVED  = no useful mapping resolved
+SUCCESS     = mapping resolved without unresolved references
+```
+
+这些状态是 lineage evidence，不是 DatasetStatus。
+
+## 11. External Ownership
+
+Dataset 不拥有：
+
+- Task Catalog current Task truth；
+- Datasource connection/catalog truth；
+- shared Lineage graph truth；
+- Core SQL Execution Runtime。
+
+这些能力只能从 Dataset 明确边界进入；Dataset 内部只能保存自己需要的 immutable snapshot/value。
+
+## 12. Repository Truth
+
+Repository 负责 Dataset aggregate 的持久化 contract：
+
+```text
+Dataset identity
+DatasetVersion append
+DatasetField schema
+currentVersion pointer
+```
+
+Repository 不拥有 Publication policy、Query routing 或 Lineage behavior。
+
+## 13. Domain Gap Rule
+
+出现以下需求时先报告 Domain Gap：
+
+- 修改已经发布的 DatasetVersion 内容；
+- 一个版本动态跟随 current TaskRevision；
+- fieldId 根据 displayName 自动重建；
+- Query 指定版本但允许自动漂移；
+- Lineage 结果反向决定 DatasetVersion；
+- DevelopmentNode 同时绑定多个“当前 Dataset identity”；
+- Query Performance 变成业务状态机。
+
+模型表达不了的需求，先更新 Domain/Requirement 与测试，不通过隐藏 flag 绕过。

--- a/yak-ops-business/yak-ops-business-dataset/README.md
+++ b/yak-ops-business/yak-ops-business-dataset/README.md
@@ -1,0 +1,127 @@
+# Yak Ops Dataset
+
+Dataset 是 Yak Ops 的稳定数据消费契约层：把上游确定的数据来源冻结成不可变 `DatasetVersion`，向 Analysis / Dashboard / Chart / Data Development 提供稳定 schema、查询运行时和派生血缘。
+
+核心关系：
+
+```text
+Upstream source snapshot
+        -> DatasetVersion (immutable)
+        -> Dataset.currentVersionId
+        -> Dataset Query / downstream binding
+```
+
+## Read First
+
+本目录只维护**当前有效 contract**。历史 Stage / Wave / 重构过程通过 Git / PR 追溯。
+
+建议按顺序阅读：
+
+| Document | Answers |
+| --- | --- |
+| [`REQUIREMENTS.md`](./REQUIREMENTS.md) | Dataset 必须保持哪些行为 |
+| [`DOMAIN.md`](./DOMAIN.md) | Dataset / Version / Field / Query / Lineage 的真相边界 |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 代码角色和调用主路径 |
+| [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package 允许依赖谁、外部模块从哪里进入 |
+| [`../../CODE_STYLE.md`](../../CODE_STYLE.md) | Yak Ops 仓库统一工程规范 |
+| [`REVIEW.md`](./REVIEW.md) | Dataset PR 如何 Review |
+
+## Stable Application APIs
+
+Dataset 目前保留三个稳定 `@Service` facade：
+
+```text
+DatasetService
+DatasetQueryService
+DevelopmentDatasetFacade
+```
+
+它们面向 HTTP 或跨模块调用者；内部业务角色使用 Manager / Reader / Publisher / Coordinator / Adapter 等明确职责，不建立通用 `service/` 大桶。
+
+## Package Shape
+
+```text
+dataset/
+├── controller
+├── definition
+├── publication
+├── schema
+├── query
+│   └── adapter
+├── observability
+├── development
+├── lineage
+├── gateway
+│   ├── taskcatalog
+│   ├── datasource
+│   └── lineage
+├── repository
+├── dao
+├── config
+└── root public contract/domain values
+```
+
+## Truth Ownership
+
+```text
+Dataset                  = stable business identity
+DatasetVersion           = immutable source snapshot
+Dataset.currentVersionId = selected-version pointer
+DatasetField             = one version's schema contract
+Dataset Query            = execution against an exact version
+Query Performance        = observability evidence
+Dataset Lineage          = derived projection
+```
+
+硬规则：
+
+```text
+Dataset != DatasetVersion != DatasetField
+current upstream source != existing DatasetVersion snapshot
+preview schema != persisted version schema
+lineage / performance != Dataset business truth
+```
+
+## Main Boundaries
+
+Publication：
+
+```text
+DatasetPublisher
+ -> exact upstream snapshot
+ -> schema discovery/normalization
+ -> append immutable DatasetVersion
+ -> move currentVersionId
+ -> request derived lineage refresh
+```
+
+Query：
+
+```text
+DatasetQueryService
+ -> DatasetQueryCoordinator
+ -> exact DatasetVersion
+ -> DatasetSourceQueryRegistry
+ -> source adapter
+ -> DatasetQueryResult
+```
+
+Data Development：
+
+```text
+Data Development
+ -> DevelopmentDatasetFacade
+ -> DevelopmentDatasetManager
+ -> stable Dataset identity + immutable versions
+```
+
+Lineage：
+
+```text
+Dataset commit
+ -> AFTER_COMMIT event
+ -> REQUIRES_NEW lineage projection
+ -> exact current DatasetVersion source
+```
+
+完整依赖矩阵和外部 corridor 见 `DEPENDENCIES.md`。

--- a/yak-ops-business/yak-ops-business-dataset/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-dataset/REQUIREMENTS.md
@@ -1,0 +1,134 @@
+# Dataset Requirements
+
+本文件定义 Dataset 当前必须保持的行为 contract。领域不变量看 `DOMAIN.md`，代码职责看 `ARCHITECTURE.md`，依赖方向看 `DEPENDENCIES.md`。
+
+## 1. Dataset Identity
+
+- `Dataset` 是稳定业务身份；
+- 上游来源变化不能通过覆盖旧 `DatasetVersion` 表达；
+- `currentVersionId` 只负责选择当前版本；
+- DevelopmentNode 重复保存必须继续绑定同一个 Dataset identity。
+
+## 2. Immutable Version Publication
+
+发布 QUERY_REVISION Dataset 时必须：
+
+1. 来源必须是 Data Development 的 ONLINE SQL TaskAsset；
+2. 固定当前 exact TaskRevision id / revisionNo；
+3. 发现或接收字段 schema；
+4. append 新的 immutable `DatasetVersion`；
+5. 更新 `currentVersionId`；
+6. 事务提交后请求派生血缘刷新。
+
+同一个 current TaskRevision 的 release publish 保持幂等，不重复追加版本。
+
+## 3. SQL_QUERY Version
+
+Data Development 的 standalone Dataset 必须把：
+
+```text
+dataSourceId + SQL + field contract
+```
+
+冻结在 DatasetVersion 中。
+
+再次保存相同 datasource / SQL / schema 时只允许更新 Dataset 可变 metadata；来源或 schema 变化时追加新版本。
+
+## 4. Schema Contract
+
+- preview schema 不拥有持久化 fieldId；
+- 版本保存时才分配稳定 fieldId；
+- compatible physical field 跨版本保持稳定 fieldId；
+- 输出字段名必须继续满足当前安全 identifier 约束；
+- 重复字段、非法字段、不可识别 result set 必须显式失败；
+- schema discovery 只能执行只读 SQL。
+
+## 5. Dataset Lifecycle
+
+- Dataset 支持 ONLINE / OFFLINE；
+- status 改变只修改 Dataset identity 状态，不重写任何 DatasetVersion；
+- status 改变后请求派生血缘刷新；
+- OFFLINE Dataset 不能通过 Query Runtime 查询。
+
+## 6. Query Runtime
+
+Dataset 查询必须绑定 exact DatasetVersion：
+
+- 未指定 versionNo -> 使用当前 `currentVersionId`；
+- 指定 versionNo -> 使用该 exact immutable version；
+- 不能因为 currentVersion 后续变化而漂移；
+- sourceType 必须有显式 `DatasetSourceQueryAdapter`；
+- QUERY_REVISION 必须解析版本中固定的 TaskRevision；
+- SQL_QUERY 必须使用版本中固定的 dataSourceId + SQL；
+- SQL 保持单条、只读、安全字段/filter/limit 规则；
+- Query Performance 记录失败或缺失不能改变查询业务真相。
+
+## 7. Analysis Binding
+
+Analysis 绑定 Dataset 时必须：
+
+- Dataset 为 ONLINE；
+- Dataset 存在 current version；
+- 所有 fieldId 都属于当前 schema；
+- 空/未知 fieldId 显式拒绝。
+
+现有 `DatasetService.validateAnalysisBinding(...)` 跨模块 contract 保持兼容。
+
+## 8. Data Development Boundary
+
+`DevelopmentDatasetFacade` 是 Data Development 的稳定入口。
+
+必须保持现有：
+
+- find by developmentNodeId；
+- standalone SQL preview / previewQuery / save；
+- legacy TaskAsset preview / save；
+- public nested record shape。
+
+Data Development 不直接调用 Dataset Repository / DAO / internal Manager。
+
+## 9. Derived Lineage
+
+Dataset lineage 是派生投影，不是 Dataset transaction truth。
+
+必须保持：
+
+```text
+Dataset transaction commit
+ -> AFTER_COMMIT refresh
+ -> REQUIRES_NEW lineage transaction
+```
+
+- QUERY_REVISION 解析 exact source revision；
+- SQL_QUERY 不依赖 TaskCatalog；
+- analyzer 不可用 -> SKIPPED；
+- analyzer 异常 -> FAILED evidence；
+- parse failure 仍保留 Dataset / DatasetField structural assets；
+- Datasource Catalog 仅用于提高 schema/ordinal 解析精度；
+- lineage refresh 失败不能回滚已经提交的 Dataset。
+
+## 10. Observability
+
+Query Performance 只保存进程内诊断窗口：
+
+- newest first；
+- bounded window；
+- 支持 datasetId / queryId 过滤；
+- 不成为 Dataset、Version 或 QueryResult 的业务状态。
+
+## 11. Compatibility
+
+纯架构治理不得顺手改变：
+
+- `/api/v1/datasets/**` route；
+- HTTP DTO / VO JSON shape；
+- `DatasetService` public methods / compatibility records；
+- `DatasetQueryService` public API；
+- `DevelopmentDatasetFacade` public API；
+- Dataset database schema / Flyway；
+- DAO / Repository contract；
+- persisted sourceType/status values；
+- SQL runtime behavior；
+- Lineage shared graph API。
+
+如需改变以上 contract，应独立更新 Requirement / Domain / migration，而不是混入治理 PR。

--- a/yak-ops-business/yak-ops-business-dataset/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-dataset/REVIEW.md
@@ -1,0 +1,178 @@
+# Dataset Review
+
+> 本文件定义 Dataset PR 如何 Review。Reviewer / AI 是裁判，不在 Review 中自行补需求或创造新领域语义。
+
+## Review 前必读
+
+```text
+REQUIREMENTS.md
+DOMAIN.md
+ARCHITECTURE.md
+DEPENDENCIES.md
+../../CODE_STYLE.md
+PR diff / tests
+```
+
+## 1. Requirement Alignment
+
+先检查是否改变：
+
+- Dataset identity / ONLINE-OFFLINE lifecycle；
+- immutable DatasetVersion publication；
+- currentVersionId pointer；
+- stable fieldId；
+- exact-version query；
+- DevelopmentNode stable Dataset binding；
+- Analysis binding；
+- derived lineage；
+- HTTP / public facade compatibility。
+
+未定义的新需求报告 `Requirement Gap`，不要混进重构。
+
+## 2. Domain Compliance
+
+重点检查：
+
+- Dataset / Version / Field 是否混淆；
+- 旧 DatasetVersion 是否被覆盖；
+- exact TaskRevision / SQL snapshot 是否被 current source 替代；
+- preview field 是否提前拥有持久化 fieldId；
+- 指定 query version 是否漂移；
+- DevelopmentNode 是否错误创建第二个 Dataset identity；
+- Query Performance 是否成为业务状态；
+- Lineage 是否反向成为 Dataset truth。
+
+违反现有规则：`Domain Violation`。模型表达不了真实需求：`Domain Gap`。
+
+## 3. Architecture Alignment
+
+检查：
+
+- 只有 `DatasetService / DatasetQueryService / DevelopmentDatasetFacade` 使用稳定 `@Service`；
+- internal role 是否保持 Reader/Manager/Publisher/Coordinator/Adapter 等明确职责；
+- 是否重新创建 `service/common/helper/utils/base`；
+- Facade 是否直接依赖 Repository/DAO/外部实现；
+- business role 是否绕过 Gateway；
+- Repository/DAO 是否保持 persistence boundary；
+- Lineage 是否重新反向依赖 Definition；
+- Config 是否开始手工装配业务角色形成 cycle。
+
+## 4. Dependency Alignment
+
+任何新增内部 import 都检查 `DEPENDENCIES.md` 与 `DatasetDependencyBoundaryTest`。
+
+重点 corridor：
+
+```text
+definition -> DatasetLineageRefreshPublisher
+publication -> DatasetReader / Schema / TaskCatalogGateway / LineageRefreshPublisher
+query -> Observability / Repository / TaskCatalogGateway
+lineage -> Dataset-owned Lineage/TaskCatalog Gateways + Repository
+development -> declared Dataset roles only
+```
+
+外部 TaskCatalog/Datasource/Lineage/Core SQL Runtime 只能从声明的 Adapter/Config 文件进入。
+
+## 5. Correctness / Safety
+
+高风险场景：
+
+- 发布时 exact revision 变化；
+- release 重试导致重复版本；
+- append version 后 current pointer 错配；
+- stable fieldId 漂移；
+- read-only SQL 校验失效；
+- query version drift；
+- source adapter 选错；
+- Dataset OFFLINE 仍可查询；
+- DevelopmentNode 重复保存创建新 Dataset；
+- lineage parse failure 删除结构资产；
+- AFTER_COMMIT lineage failure 反噬 Dataset transaction；
+- optional analyzer/catalog 缺失导致模块启动失败。
+
+## 6. Compatibility
+
+检查是否破坏：
+
+- `/api/v1/datasets/**`；
+- DTO / VO JSON；
+- `DatasetService` API；
+- `DatasetQueryService` API；
+- `DevelopmentDatasetFacade` API / nested records；
+- Analysis binding call；
+- DB/Flyway/DAO/Repository；
+- persisted sourceType/status；
+- shared Lineage contract；
+- Data Development / Dashboard / Chart 调用。
+
+架构治理默认不做 breaking change。
+
+## 7. Tests / Guardrails
+
+P0/P1 问题都回答：哪个测试应该挡住？
+
+重点：
+
+```text
+DatasetArchitectureTest
+DatasetDependencyBoundaryTest
+DatasetCodeStyleConventionTest
+DatasetRoleConventionTest
+DatasetPublisherTest
+DatasetSchemaDiscoveryTest
+DatasetQueryCoordinatorTest
+QueryRevisionDatasetSourceAdapterTest
+DevelopmentDatasetManagerTest
+DatasetBindingPolicyTest
+DatasetLineageSynchronizerTest
+DatasetLineageRefreshListenerTest
+```
+
+架构 corridor 变化时，代码、`DEPENDENCIES.md` 和 executable guard 必须同 PR 更新。
+
+## 严重级别
+
+```text
+P0 Blocker
+- Dataset SQL 产生破坏性写入
+- immutable version 被错误覆盖造成不可恢复数据问题
+- 明确敏感数据泄漏
+
+P1 Must Fix
+- Requirement / Domain violation
+- exact source/version drift
+- duplicate/wrong version pointer
+- field identity / query / lineage transaction correctness
+- compatibility break
+- package cycle / external boundary 绕过造成真实架构风险
+
+P2 Suggestion
+- 不影响正确性的可维护性、性能、可观测性建议
+```
+
+## 固定输出
+
+```text
+# Review Result
+Conclusion: PASS | CHANGES_REQUIRED
+
+## P0 Blocker
+无 / 问题列表
+
+## P1 Must Fix
+无 / 问题列表
+
+## P2 Suggestion
+无 / 建议列表
+
+## Requirement Gap
+无 / 说明
+
+## Domain Gap
+无 / 说明
+
+## Missing Tests
+无 / 说明
+```
+
+有 P0/P1 -> `CHANGES_REQUIRED`；只有 P2 可以 `PASS`。

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/lineage/DatasetLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/lineage/DatasetLineageRefreshListener.java
@@ -1,6 +1,5 @@
 package io.yak.ops.business.dataset.lineage;
 
-import io.yak.ops.business.dataset.definition.DatasetReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -14,12 +13,13 @@ public class DatasetLineageRefreshListener {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DatasetLineageRefreshListener.class);
 
-  private final DatasetReader reader;
+  private final DatasetLineageSnapshotReader snapshotReader;
   private final DatasetLineageTransactionRunner transactionRunner;
 
   public DatasetLineageRefreshListener(
-      DatasetReader reader, DatasetLineageTransactionRunner transactionRunner) {
-    this.reader = reader;
+      DatasetLineageSnapshotReader snapshotReader,
+      DatasetLineageTransactionRunner transactionRunner) {
+    this.snapshotReader = snapshotReader;
     this.transactionRunner = transactionRunner;
   }
 
@@ -31,7 +31,7 @@ public class DatasetLineageRefreshListener {
       return;
     }
     try {
-      transactionRunner.sync(reader.require(event.datasetId()));
+      transactionRunner.sync(snapshotReader.require(event.datasetId()));
     } catch (RuntimeException exception) {
       LOGGER.warn(
           "Dataset lineage refresh failed after commit for dataset {}: {}",

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/lineage/DatasetLineageSnapshotReader.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/lineage/DatasetLineageSnapshotReader.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.dataset.lineage;
+
+import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.DatasetDetail;
+import io.yak.ops.business.dataset.DatasetField;
+import io.yak.ops.business.dataset.DatasetVersion;
+import io.yak.ops.business.dataset.repository.DatasetRepository;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Reads the current persisted Dataset snapshot required by derived-lineage projection. */
+@Component
+public class DatasetLineageSnapshotReader {
+
+  private final DatasetRepository repository;
+
+  public DatasetLineageSnapshotReader(DatasetRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public DatasetDetail require(long datasetId) {
+    if (datasetId <= 0L) {
+      throw new IllegalArgumentException("datasetId 必须大于 0");
+    }
+    Dataset dataset =
+        repository
+            .findDataset(datasetId)
+            .orElseThrow(() -> new IllegalArgumentException("Dataset 不存在：" + datasetId));
+
+    DatasetVersion currentVersion = null;
+    List<DatasetField> fields = List.of();
+    if (dataset.currentVersionId() != null) {
+      currentVersion =
+          repository
+              .findVersion(dataset.currentVersionId())
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Dataset 当前版本不存在：datasetId="
+                              + datasetId
+                              + ", versionId="
+                              + dataset.currentVersionId()));
+      fields = repository.listFields(currentVersion.id());
+    }
+    return new DatasetDetail(dataset, currentVersion, repository.listVersions(datasetId), fields);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetArchitectureTest.java
@@ -16,6 +16,7 @@ import io.yak.ops.business.dataset.gateway.lineage.LineageProjectionAnalyzerAdap
 import io.yak.ops.business.dataset.gateway.taskcatalog.TaskCatalogDatasetAdapter;
 import io.yak.ops.business.dataset.lineage.DatasetLineageRefreshListener;
 import io.yak.ops.business.dataset.lineage.DatasetLineageRefreshPublisher;
+import io.yak.ops.business.dataset.lineage.DatasetLineageSnapshotReader;
 import io.yak.ops.business.dataset.lineage.DatasetLineageSourceResolver;
 import io.yak.ops.business.dataset.lineage.DatasetLineageSynchronizer;
 import io.yak.ops.business.dataset.lineage.DatasetLineageTransactionRunner;
@@ -43,7 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
-/** Lightweight Stage-1 architecture checks; full dependency governance belongs to Stage 2. */
+/** Lightweight layering checks that complement the source-level dependency and style guards. */
 class DatasetArchitectureTest {
 
   @Test
@@ -90,6 +91,7 @@ class DatasetArchitectureTest {
             DatasetQueryPerformanceReader.class,
             DevelopmentDatasetManager.class,
             DatasetLineageRefreshPublisher.class,
+            DatasetLineageSnapshotReader.class,
             DatasetLineageSourceResolver.class,
             DatasetLineageSynchronizer.class,
             DatasetLineageTransactionRunner.class,
@@ -145,9 +147,9 @@ class DatasetArchitectureTest {
   }
 
   @Test
-  void legacyServiceBucketIsRetiredFromProduction() {
+  void genericServiceBucketCannotReturn() {
     assertThat(Files.exists(productionRoot().resolve("service")))
-        .as("Dataset production service/ bucket must be retired after Stage 1")
+        .as("Dataset production service/ bucket must remain retired")
         .isFalse();
   }
 

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetCodeStyleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetCodeStyleConventionTest.java
@@ -1,0 +1,137 @@
+package io.yak.ops.business.dataset.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Enforces low-ambiguity repository-wide CODE_STYLE rules for Dataset production code. */
+class DatasetCodeStyleConventionTest {
+
+  private static final Pattern WILDCARD_IMPORT =
+      Pattern.compile("(?m)^import\\s+(?:static\\s+)?[^;]+\\*;");
+  private static final Pattern FIELD_INJECTION =
+      Pattern.compile("@(Autowired|Resource|Inject)\\b");
+  private static final Pattern MIGRATION_MARKER =
+      Pattern.compile("(?i)\\b(Stage|Wave|Phase)\\s*[-:]?\\s*\\d+\\b");
+  private static final Pattern ENUM_NAME_EQUALS =
+      Pattern.compile("\\.name\\(\\)\\.equals(?:IgnoreCase)?\\s*\\(");
+  private static final Pattern REVERSE_ENUM_NAME_EQUALS =
+      Pattern.compile("\"[A-Z][A-Z0-9_]*\"\\.equals(?:IgnoreCase)?\\s*\\([^;]*\\.name\\(\\)");
+
+  private static final Set<String> SERVICE_FACADE_FILES =
+      Set.of("DatasetService.java", "DatasetQueryService.java", "DevelopmentDatasetFacade.java");
+
+  @Test
+  void productionSourceFollowsRepositoryCodeStyle() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = normalize(root.relativize(file));
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(WILDCARD_IMPORT.matcher(source).find())
+            .as("%s must not use wildcard imports", relative)
+            .isFalse();
+        assertThat(FIELD_INJECTION.matcher(source).find())
+            .as("%s must use constructor injection / explicit provider boundaries", relative)
+            .isFalse();
+        assertThat(source)
+            .as("%s must not write directly to stdout/stderr", relative)
+            .doesNotContain("System.out.", "System.err.");
+        assertThat(source)
+            .as("%s must not use BeanUtils.copyProperties for Dataset boundaries", relative)
+            .doesNotContain("BeanUtils.copyProperties");
+        assertThat(MIGRATION_MARKER.matcher(source).find())
+            .as("%s production comments/messages must describe current contracts", relative)
+            .isFalse();
+        assertThat(ENUM_NAME_EQUALS.matcher(source).find())
+            .as("%s must compare typed enums before persistence/transport boundaries", relative)
+            .isFalse();
+        assertThat(REVERSE_ENUM_NAME_EQUALS.matcher(source).find())
+            .as("%s must not downgrade typed enums to strings", relative)
+            .isFalse();
+      }
+    }
+  }
+
+  @Test
+  void serviceStereotypeIsReservedForThreeStableFacades() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        if (!source.contains("@Service")
+            && !source.contains("org.springframework.stereotype.Service")) {
+          continue;
+        }
+        assertThat(root.relativize(file).getNameCount())
+            .as("@Service must stay in Dataset root facade package: %s", file)
+            .isEqualTo(1);
+        assertThat(SERVICE_FACADE_FILES)
+            .as("Unexpected Dataset @Service: %s", file)
+            .contains(file.getFileName().toString());
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() {
+    Path root = productionRoot();
+    for (String forbidden : List.of("service", "common", "helper", "utils", "util", "base")) {
+      assertThat(Files.exists(root.resolve(forbidden)))
+          .as("Broad Dataset business bucket '%s' must not exist", forbidden)
+          .isFalse();
+    }
+  }
+
+  @Test
+  void repositoryUsesSingleRootCodeStyleDocument() throws IOException {
+    Path module = moduleRoot();
+    Path repository = module.getParent().getParent();
+    assertThat(Files.isRegularFile(repository.resolve("CODE_STYLE.md")))
+        .as("Yak Ops root CODE_STYLE.md must exist")
+        .isTrue();
+    assertThat(Files.exists(module.resolve("CODE_STYLE.md")))
+        .as("Dataset must not maintain a module-local CODE_STYLE.md")
+        .isFalse();
+
+    long count;
+    try (Stream<Path> paths = Files.walk(repository, 6)) {
+      count =
+          paths.filter(Files::isRegularFile)
+              .filter(path -> path.getFileName().toString().equals("CODE_STYLE.md"))
+              .count();
+    }
+    assertThat(count)
+        .as("Yak Ops must keep one repository-wide CODE_STYLE.md")
+        .isEqualTo(1L);
+  }
+
+  private Path productionRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/dataset");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/dataset"))) {
+      return local;
+    }
+    Path repositoryRelative =
+        Path.of("yak-ops-business", "yak-ops-business-dataset").toAbsolutePath().normalize();
+    assertThat(Files.isDirectory(repositoryRelative.resolve("src/main/java/io/yak/ops/business/dataset")))
+        .as("Unable to locate Dataset module root from %s", local)
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetDependencyBoundaryTest.java
@@ -1,0 +1,300 @@
+package io.yak.ops.business.dataset.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Source-level guard for the permanent Dataset package graph and external boundaries. */
+class DatasetDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.dataset";
+  private static final Pattern DATASET_IMPORT =
+      Pattern.compile(
+          "(?m)^import\\s+(?:static\\s+)?("
+              + Pattern.quote(BASE)
+              + "\\.([A-Za-z0-9_]+)\\.[^;]+);");
+  private static final Pattern EXTERNAL_IMPORT =
+      Pattern.compile(
+          "(?m)^import\\s+(io\\.yak\\.ops\\.(?:business\\.(?:taskcatalog|datasource|lineage)|spi\\.datasource\\.execution|core\\.execution\\.sql)\\.[^;]+);");
+
+  private static final Map<String, Set<String>> ALLOWED_TOP_LEVEL_DEPENDENCIES =
+      Map.ofEntries(
+          Map.entry("controller", Set.of()),
+          Map.entry("definition", Set.of("lineage", "repository")),
+          Map.entry(
+              "development",
+              Set.of("definition", "gateway", "lineage", "publication", "repository", "schema")),
+          Map.entry("publication", Set.of("definition", "gateway", "lineage", "repository", "schema")),
+          Map.entry("schema", Set.of("gateway", "repository")),
+          Map.entry("query", Set.of("gateway", "observability", "repository")),
+          Map.entry("observability", Set.of()),
+          Map.entry("lineage", Set.of("gateway", "repository")),
+          Map.entry("gateway", Set.of()),
+          Map.entry("repository", Set.of("dao")),
+          Map.entry("dao", Set.of()),
+          Map.entry("config", Set.of()));
+
+  @Test
+  void topLevelPackagesFollowDeclaredDependencyGraph() throws IOException {
+    for (Dependency dependency : datasetDependencies()) {
+      Set<String> allowed =
+          ALLOWED_TOP_LEVEL_DEPENDENCIES.getOrDefault(dependency.sourcePackage(), Set.of());
+      assertThat(allowed)
+          .as("%s imports %s", dependency.relativePath(), dependency.importedType())
+          .contains(dependency.targetPackage());
+    }
+  }
+
+  @Test
+  void declaredAndActualGraphsRemainAcyclic() throws IOException {
+    assertAcyclic(ALLOWED_TOP_LEVEL_DEPENDENCIES, "declared Dataset dependency graph");
+
+    Map<String, Set<String>> actual = new HashMap<>();
+    ALLOWED_TOP_LEVEL_DEPENDENCIES.keySet()
+        .forEach(key -> actual.put(key, new HashSet<>()));
+    for (Dependency dependency : datasetDependencies()) {
+      actual.computeIfAbsent(dependency.sourcePackage(), ignored -> new HashSet<>())
+          .add(dependency.targetPackage());
+    }
+    assertAcyclic(actual, "actual Dataset import graph");
+  }
+
+  @Test
+  void narrowCrossSubsystemCorridorsDoNotExpand() throws IOException {
+    assertExactCorridor(
+        "definition",
+        "lineage",
+        Set.of(BASE + ".lineage.DatasetLineageRefreshPublisher"));
+    assertExactCorridor(
+        "publication",
+        "definition",
+        Set.of(BASE + ".definition.DatasetReader"));
+    assertExactCorridor(
+        "publication",
+        "lineage",
+        Set.of(BASE + ".lineage.DatasetLineageRefreshPublisher"));
+    assertExactCorridor(
+        "query",
+        "observability",
+        Set.of(BASE + ".observability.DatasetQueryPerformanceRecorder"));
+
+    assertThat(crossing("lineage", "definition"))
+        .as("Lineage must not point back to Definition")
+        .isEmpty();
+  }
+
+  @Test
+  void gatewayUsageStaysDatasetOwned() throws IOException {
+    for (Dependency dependency : crossing("publication", "gateway")) {
+      assertThat(dependency.importedType())
+          .as("Publication must use Dataset-owned TaskCatalog gateway")
+          .startsWith(BASE + ".gateway.taskcatalog.DatasetTaskCatalogGateway");
+    }
+    for (Dependency dependency : crossing("schema", "gateway")) {
+      assertThat(dependency.importedType())
+          .as("Schema must use Dataset-owned gateways")
+          .matches(
+              Pattern.quote(BASE + ".gateway.taskcatalog.DatasetTaskCatalogGateway")
+                  + ".*|"
+                  + Pattern.quote(BASE + ".gateway.datasource.DatasetSchemaSqlGateway")
+                  + ".*");
+    }
+    for (Dependency dependency : crossing("lineage", "gateway")) {
+      assertThat(dependency.importedType())
+          .as("Lineage must use Dataset-owned gateways")
+          .matches(
+              Pattern.quote(BASE + ".gateway.taskcatalog.DatasetTaskCatalogGateway")
+                  + ".*|"
+                  + Pattern.quote(BASE + ".gateway.lineage.DatasetProjectionAnalyzerGateway")
+                  + ".*|"
+                  + Pattern.quote(BASE + ".gateway.lineage.DatasetLineageGraphGateway")
+                  + ".*");
+    }
+  }
+
+  @Test
+  void externalModuleImportsAreIsolatedToDeclaredAdapters() throws IOException {
+    for (ExternalDependency dependency : externalDependencies()) {
+      String type = dependency.importedType();
+      String path = dependency.relativePath();
+      if (type.startsWith("io.yak.ops.business.taskcatalog.")) {
+        assertThat(path).isEqualTo("gateway/taskcatalog/TaskCatalogDatasetAdapter.java");
+      } else if (type.startsWith("io.yak.ops.business.datasource.catalog.")) {
+        assertThat(path).isEqualTo("gateway/datasource/DataSourceDatasetCatalogAdapter.java");
+      } else if (type.startsWith("io.yak.ops.business.datasource.config.")) {
+        assertThat(path).isEqualTo("config/DatasetPersistenceConfiguration.java");
+      } else if (type.startsWith("io.yak.ops.spi.datasource.execution.")) {
+        assertThat(path).isEqualTo("gateway/datasource/DataSourceSchemaSqlAdapter.java");
+      } else if (type.startsWith("io.yak.ops.business.lineage.")) {
+        assertThat(path)
+            .isIn(
+                "gateway/lineage/LineageProjectionAnalyzerAdapter.java",
+                "gateway/lineage/LineageGraphDatasetAdapter.java");
+      } else if (type.startsWith("io.yak.ops.core.execution.sql.")) {
+        assertThat(path)
+            .isIn(
+                "query/adapter/QueryRevisionDatasetSourceAdapter.java",
+                "query/adapter/SqlQueryDatasetSourceAdapter.java");
+      }
+    }
+  }
+
+  @Test
+  void bottomLayersDoNotPointBackToApplicationSubsystems() throws IOException {
+    for (Dependency dependency : datasetDependencies()) {
+      if (dependency.sourcePackage().equals("dao")) {
+        throw new AssertionError("Dataset DAO must not import upper Dataset packages: " + dependency);
+      }
+      if (dependency.sourcePackage().equals("repository")) {
+        assertThat(dependency.targetPackage())
+            .as("Repository must remain below application roles: %s", dependency)
+            .isEqualTo("dao");
+      }
+      if (dependency.sourcePackage().equals("config")) {
+        throw new AssertionError("Dataset config must not import Dataset business roles: " + dependency);
+      }
+    }
+  }
+
+  private void assertExactCorridor(String source, String target, Set<String> allowedTypes)
+      throws IOException {
+    for (Dependency dependency : crossing(source, target)) {
+      assertThat(allowedTypes)
+          .as("Unexpected %s -> %s corridor in %s", source, target, dependency.relativePath())
+          .contains(dependency.importedType());
+    }
+  }
+
+  private List<Dependency> crossing(String source, String target) throws IOException {
+    return datasetDependencies().stream()
+        .filter(dependency -> dependency.sourcePackage().equals(source))
+        .filter(dependency -> dependency.targetPackage().equals(target))
+        .toList();
+  }
+
+  private void assertAcyclic(Map<String, Set<String>> graph, String label) {
+    Set<String> nodes = new HashSet<>(graph.keySet());
+    graph.values().forEach(nodes::addAll);
+    Map<String, Integer> outgoing = new HashMap<>();
+    Map<String, Set<String>> reverse = new HashMap<>();
+    nodes.forEach(node -> outgoing.put(node, 0));
+
+    for (Map.Entry<String, Set<String>> entry : graph.entrySet()) {
+      for (String target : entry.getValue()) {
+        outgoing.compute(entry.getKey(), (ignored, value) -> value + 1);
+        reverse.computeIfAbsent(target, ignored -> new HashSet<>()).add(entry.getKey());
+      }
+    }
+
+    ArrayDeque<String> ready = new ArrayDeque<>();
+    outgoing.forEach(
+        (node, degree) -> {
+          if (degree == 0) {
+            ready.add(node);
+          }
+        });
+
+    int visited = 0;
+    while (!ready.isEmpty()) {
+      String node = ready.removeFirst();
+      visited++;
+      for (String dependent : reverse.getOrDefault(node, Set.of())) {
+        int degree = outgoing.compute(dependent, (ignored, value) -> value - 1);
+        if (degree == 0) {
+          ready.add(dependent);
+        }
+      }
+    }
+
+    assertThat(visited).as("%s must remain acyclic", label).isEqualTo(nodes.size());
+  }
+
+  private List<Dependency> datasetDependencies() throws IOException {
+    Path root = productionRoot();
+    List<Dependency> result = new ArrayList<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Path relative = root.relativize(file);
+        if (relative.getNameCount() < 2) {
+          continue;
+        }
+        String sourcePackage = relative.getName(0).toString();
+        Matcher matcher = DATASET_IMPORT.matcher(Files.readString(file, StandardCharsets.UTF_8));
+        while (matcher.find()) {
+          String importedType = matcher.group(1);
+          String targetPackage = matcher.group(2);
+          if (!sourcePackage.equals(targetPackage)) {
+            result.add(
+                new Dependency(
+                    sourcePackage, targetPackage, importedType, normalize(relative)));
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private List<ExternalDependency> externalDependencies() throws IOException {
+    Path root = productionRoot();
+    List<ExternalDependency> result = new ArrayList<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Path relative = root.relativize(file);
+        Matcher matcher = EXTERNAL_IMPORT.matcher(Files.readString(file, StandardCharsets.UTF_8));
+        while (matcher.find()) {
+          result.add(new ExternalDependency(normalize(relative), matcher.group(1)));
+        }
+      }
+    }
+    return result;
+  }
+
+  private Path productionRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/dataset");
+    if (Files.isDirectory(local)) {
+      return local;
+    }
+    Path repositoryRelative =
+        Path.of(
+            "yak-ops-business",
+            "yak-ops-business-dataset",
+            "src",
+            "main",
+            "java",
+            "io",
+            "yak",
+            "ops",
+            "business",
+            "dataset");
+    assertThat(Files.isDirectory(repositoryRelative))
+        .as("Unable to locate Dataset production source root")
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+
+  private record Dependency(
+      String sourcePackage,
+      String targetPackage,
+      String importedType,
+      String relativePath) {}
+
+  private record ExternalDependency(String relativePath, String importedType) {}
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetRoleConventionTest.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.dataset.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.dataset.DatasetQueryService;
+import io.yak.ops.business.dataset.DatasetService;
+import io.yak.ops.business.dataset.DevelopmentDatasetFacade;
+import io.yak.ops.business.dataset.definition.DatasetBindingPolicy;
+import io.yak.ops.business.dataset.definition.DatasetManager;
+import io.yak.ops.business.dataset.definition.DatasetReader;
+import io.yak.ops.business.dataset.development.DevelopmentDatasetManager;
+import io.yak.ops.business.dataset.gateway.datasource.DataSourceDatasetCatalogAdapter;
+import io.yak.ops.business.dataset.gateway.datasource.DataSourceSchemaSqlAdapter;
+import io.yak.ops.business.dataset.gateway.lineage.LineageGraphDatasetAdapter;
+import io.yak.ops.business.dataset.gateway.lineage.LineageProjectionAnalyzerAdapter;
+import io.yak.ops.business.dataset.gateway.taskcatalog.TaskCatalogDatasetAdapter;
+import io.yak.ops.business.dataset.lineage.DatasetLineageRefreshListener;
+import io.yak.ops.business.dataset.lineage.DatasetLineageRefreshPublisher;
+import io.yak.ops.business.dataset.lineage.DatasetLineageSnapshotReader;
+import io.yak.ops.business.dataset.lineage.DatasetLineageSourceResolver;
+import io.yak.ops.business.dataset.lineage.DatasetLineageSynchronizer;
+import io.yak.ops.business.dataset.lineage.DatasetLineageTransactionRunner;
+import io.yak.ops.business.dataset.observability.DatasetQueryPerformanceReader;
+import io.yak.ops.business.dataset.observability.DatasetQueryPerformanceRecorder;
+import io.yak.ops.business.dataset.publication.DatasetPublisher;
+import io.yak.ops.business.dataset.publication.DatasetVersionWriter;
+import io.yak.ops.business.dataset.query.DatasetQueryCompiler;
+import io.yak.ops.business.dataset.query.DatasetQueryCoordinator;
+import io.yak.ops.business.dataset.query.DatasetSourceQueryRegistry;
+import io.yak.ops.business.dataset.query.adapter.QueryRevisionDatasetSourceAdapter;
+import io.yak.ops.business.dataset.query.adapter.SqlQueryDatasetSourceAdapter;
+import io.yak.ops.business.dataset.schema.DatasetFieldIdentity;
+import io.yak.ops.business.dataset.schema.DatasetFieldNormalizer;
+import io.yak.ops.business.dataset.schema.DatasetSchemaDiscovery;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+class DatasetRoleConventionTest {
+
+  @Test
+  void stableApplicationFacadesRemainServices() {
+    for (Class<?> facade :
+        List.of(DatasetService.class, DatasetQueryService.class, DevelopmentDatasetFacade.class)) {
+      assertThat(facade.getAnnotation(Service.class))
+          .as("%s must remain a stable Dataset application facade", facade.getSimpleName())
+          .isNotNull();
+    }
+  }
+
+  @Test
+  void internalRolesRemainExplicitComponents() {
+    for (Class<?> role :
+        List.of(
+            DatasetReader.class,
+            DatasetManager.class,
+            DatasetBindingPolicy.class,
+            DatasetPublisher.class,
+            DatasetVersionWriter.class,
+            DatasetSchemaDiscovery.class,
+            DatasetFieldNormalizer.class,
+            DatasetFieldIdentity.class,
+            DatasetQueryCoordinator.class,
+            DatasetSourceQueryRegistry.class,
+            DatasetQueryCompiler.class,
+            QueryRevisionDatasetSourceAdapter.class,
+            SqlQueryDatasetSourceAdapter.class,
+            DatasetQueryPerformanceRecorder.class,
+            DatasetQueryPerformanceReader.class,
+            DevelopmentDatasetManager.class,
+            DatasetLineageRefreshPublisher.class,
+            DatasetLineageSnapshotReader.class,
+            DatasetLineageSourceResolver.class,
+            DatasetLineageSynchronizer.class,
+            DatasetLineageTransactionRunner.class,
+            DatasetLineageRefreshListener.class,
+            TaskCatalogDatasetAdapter.class,
+            DataSourceSchemaSqlAdapter.class,
+            DataSourceDatasetCatalogAdapter.class,
+            LineageProjectionAnalyzerAdapter.class,
+            LineageGraphDatasetAdapter.class)) {
+      assertThat(role.getAnnotation(Component.class))
+          .as("%s must remain an explicit internal Dataset role", role.getSimpleName())
+          .isNotNull();
+      assertThat(role.getAnnotation(Service.class))
+          .as("%s must not masquerade as a stable Application Service", role.getSimpleName())
+          .isNull();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/lineage/DatasetLineageRefreshListenerTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/lineage/DatasetLineageRefreshListenerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import io.yak.ops.business.dataset.Dataset;
 import io.yak.ops.business.dataset.DatasetDetail;
 import io.yak.ops.business.dataset.DatasetStatus;
-import io.yak.ops.business.dataset.definition.DatasetReader;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -17,32 +16,32 @@ class DatasetLineageRefreshListenerTest {
 
   @Test
   void refreshLoadsCommittedSnapshotAndSynchronizesLineage() {
-    DatasetReader reader = mock(DatasetReader.class);
+    DatasetLineageSnapshotReader snapshotReader = mock(DatasetLineageSnapshotReader.class);
     DatasetLineageTransactionRunner transactionRunner =
         mock(DatasetLineageTransactionRunner.class);
     DatasetLineageRefreshListener listener =
-        new DatasetLineageRefreshListener(reader, transactionRunner);
+        new DatasetLineageRefreshListener(snapshotReader, transactionRunner);
 
     Dataset dataset =
         new Dataset(
             21L, "sales", null, DatasetStatus.ONLINE, null, Instant.EPOCH, Instant.EPOCH);
     DatasetDetail detail = new DatasetDetail(dataset, null, List.of(), List.of());
-    when(reader.require(21L)).thenReturn(detail);
+    when(snapshotReader.require(21L)).thenReturn(detail);
 
     listener.refresh(new DatasetLineageRefreshRequested(21L));
 
-    verify(reader).require(21L);
+    verify(snapshotReader).require(21L);
     verify(transactionRunner).sync(detail);
   }
 
   @Test
   void lineageFailureDoesNotEscapeAfterDatasetCommit() {
-    DatasetReader reader = mock(DatasetReader.class);
+    DatasetLineageSnapshotReader snapshotReader = mock(DatasetLineageSnapshotReader.class);
     DatasetLineageTransactionRunner transactionRunner =
         mock(DatasetLineageTransactionRunner.class);
     DatasetLineageRefreshListener listener =
-        new DatasetLineageRefreshListener(reader, transactionRunner);
-    when(reader.require(21L)).thenThrow(new IllegalStateException("lineage read failed"));
+        new DatasetLineageRefreshListener(snapshotReader, transactionRunner);
+    when(snapshotReader.require(21L)).thenThrow(new IllegalStateException("lineage read failed"));
 
     assertDoesNotThrow(() -> listener.refresh(new DatasetLineageRefreshRequested(21L)));
   }

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/lineage/DatasetLineageSnapshotReaderTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/lineage/DatasetLineageSnapshotReaderTest.java
@@ -1,0 +1,69 @@
+package io.yak.ops.business.dataset.lineage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.DatasetField;
+import io.yak.ops.business.dataset.DatasetFieldDataType;
+import io.yak.ops.business.dataset.DatasetFieldRole;
+import io.yak.ops.business.dataset.DatasetSourceType;
+import io.yak.ops.business.dataset.DatasetStatus;
+import io.yak.ops.business.dataset.DatasetVersion;
+import io.yak.ops.business.dataset.repository.DatasetRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class DatasetLineageSnapshotReaderTest {
+
+  @Test
+  void readsCurrentPersistedVersionAndSchemaWithoutDefinitionDependency() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    DatasetLineageSnapshotReader reader = new DatasetLineageSnapshotReader(repository);
+    Dataset dataset =
+        new Dataset(
+            21L,
+            "sales",
+            null,
+            DatasetStatus.ONLINE,
+            31L,
+            Instant.EPOCH,
+            Instant.EPOCH);
+    DatasetVersion version =
+        new DatasetVersion(
+            31L,
+            21L,
+            3,
+            DatasetSourceType.QUERY_REVISION,
+            11L,
+            71L,
+            5,
+            "[]",
+            Instant.EPOCH);
+    DatasetField field =
+        new DatasetField(
+            "amount",
+            31L,
+            "amount",
+            "amount",
+            DatasetFieldDataType.NUMBER,
+            true,
+            null,
+            DatasetFieldRole.MEASURE,
+            1);
+
+    when(repository.findDataset(21L)).thenReturn(Optional.of(dataset));
+    when(repository.findVersion(31L)).thenReturn(Optional.of(version));
+    when(repository.listVersions(21L)).thenReturn(List.of(version));
+    when(repository.listFields(31L)).thenReturn(List.of(field));
+
+    var detail = reader.require(21L);
+
+    assertThat(detail.currentVersion()).isEqualTo(version);
+    assertThat(detail.fields()).containsExactly(field);
+    assertThat(detail.versions()).containsExactly(version);
+  }
+}


### PR DESCRIPTION
## Summary

完成 Dataset Stage 2：在 Stage 1 role-oriented architecture 合并后，对真实 import graph 做治理收口，先修实际 package cycle，再补长期文档与 executable architecture/code-style/role guards。

本 PR 不继续大拆业务代码，核心目标是让 Stage 1 的结构以后不会退化。

统一遵循仓库根 `CODE_STYLE.md`：

```text
Correctness / Safety
  > Explicit ownership
  > Simple control flow
  > Testability
  > Reuse
  > Brevity
```

## Stage 1 baseline

Stage 1 已确定：

```text
Dataset                  = stable business identity
DatasetVersion           = immutable source snapshot
Dataset.currentVersionId = selected-version pointer
DatasetField             = one version's schema contract
Dataset Query            = execution against an exact version
Query Performance        = observability evidence
Dataset Lineage          = derived projection
```

并保留三个稳定 `@Service` facade：

```text
DatasetService
DatasetQueryService
DevelopmentDatasetFacade
```

Stage 2 不改变这些业务/API contract。

## Real import audit: one package cycle found and fixed

Stage 1 后真实源码图中存在：

```text
definition.DatasetManager
    -> lineage.DatasetLineageRefreshPublisher

lineage.DatasetLineageRefreshListener
    -> definition.DatasetReader
```

因此形成：

```text
definition <-> lineage
```

Stage 2 没有把这个环写进 dependency whitelist，而是修掉。

新增：

```text
lineage/DatasetLineageSnapshotReader
```

现在：

```text
DatasetLineageRefreshListener
    -> DatasetLineageSnapshotReader
    -> DatasetRepository
```

因此依赖方向变成：

```text
definition -> lineage -> repository
```

Lineage 作为 derived projection 自己读取当前 persisted Dataset snapshot，不再反向进入 Definition。

行为不变：AFTER_COMMIT listener 仍然读取已经提交的 current DatasetVersion/schema，再进入 REQUIRES_NEW lineage transaction。

## Permanent documentation

新增：

```text
README.md
REQUIREMENTS.md
DOMAIN.md
ARCHITECTURE.md
DEPENDENCIES.md
REVIEW.md
```

统一引用仓库根：

```text
../../CODE_STYLE.md
```

Dataset 不维护模块私有 CODE_STYLE 副本。

### DOMAIN contract

重点固定：

```text
Dataset != DatasetVersion != DatasetField
current upstream source != existing DatasetVersion snapshot
preview schema != persisted version schema
Query Performance != Query Result truth
Dataset Lineage != DatasetVersion truth
```

QUERY_REVISION 必须继续 pin exact TaskRevision id/no；SQL_QUERY 必须继续 pin exact datasourceId + SQL。

## Permanent package graph

内部 top-level matrix：

```text
controller   -> none
definition   -> lineage, repository
development  -> definition, gateway, lineage, publication, repository, schema
publication  -> definition, gateway, lineage, repository, schema
schema       -> gateway, repository
query        -> gateway, observability, repository
observability-> none
lineage      -> gateway, repository
gateway      -> none
repository   -> dao
dao          -> none
config       -> none
```

root package 中的 stable facade/public records/enums 作为兼容 public contract 单独治理，不作为内部 cycle graph 节点。

## DatasetDependencyBoundaryTest

新增源码扫描 guard：

```text
DatasetDependencyBoundaryTest
```

保护：

- declared top-level graph is acyclic
- actual import graph is acyclic
- every actual internal import obeys the matrix
- `definition -> lineage` 只能使用 DatasetLineageRefreshPublisher
- Lineage 不能重新 import Definition
- Publication -> Definition/Lineage corridor 保持窄
- Query -> Observability corridor 保持窄
- Schema/Publication/Lineage 只能使用 Dataset-owned Gateway
- Repository 只向下进入 DAO
- Config 不反向依赖 Dataset business role

## External module corridors

外部实现依赖被锁到明确文件：

### TaskCatalog

```text
gateway/taskcatalog/TaskCatalogDatasetAdapter
    -> io.yak.ops.business.taskcatalog.*
```

### Datasource Catalog

```text
gateway/datasource/DataSourceDatasetCatalogAdapter
    -> DataSourceCatalogReader
```

### Datasource SQL SPI

```text
gateway/datasource/DataSourceSchemaSqlAdapter
    -> io.yak.ops.spi.datasource.execution.*
```

### Shared Lineage

```text
gateway/lineage/LineageProjectionAnalyzerAdapter
    -> SqlProjectionLineageAnalyzer

gateway/lineage/LineageGraphDatasetAdapter
    -> LineageService / LineageMaintenanceService / typed values
```

### Core SQL Runtime

```text
query/adapter/QueryRevisionDatasetSourceAdapter
query/adapter/SqlQueryDatasetSourceAdapter
    -> io.yak.ops.core.execution.sql.*
```

这里 Query adapter 本身就是 Source Runtime boundary，因此不为 Core SQL Runtime 再创建一层无价值包装。

### Infrastructure Config

```text
config/DatasetPersistenceConfiguration
    -> datasource.config.*
```

仅用于 business database / feature configuration wiring，不是 Dataset 业务调用。

## DatasetCodeStyleConventionTest

新增：

```text
DatasetCodeStyleConventionTest
```

自动保护：

```text
single root CODE_STYLE.md
no wildcard import
no field injection / @Autowired shortcut
no System.out/System.err
no BeanUtils.copyProperties
no Stage/Wave/Phase production migration markers
no enum .name().equals(...) business comparison
no service/common/helper/utils/util/base business buckets
```

`@Service` 只允许三个稳定 facade：

```text
DatasetService
DatasetQueryService
DevelopmentDatasetFacade
```

## DatasetRoleConventionTest

新增：

```text
DatasetRoleConventionTest
```

明确：

- 三个 public facade 保持 `@Service`
- Definition / Publication / Schema / Query / Observability / Development / Lineage 内部角色保持 `@Component`
- TaskCatalog / Datasource / Lineage external adapters 保持 `@Component`
- internal role 不重新伪装成 generic Application Service

现有 `DatasetArchitectureTest` 也改成长期 layering guard，并纳入 `DatasetLineageSnapshotReader`。

## Cycle-fix regression

新增：

```text
DatasetLineageSnapshotReaderTest
```

证明 Lineage 直接从 Repository 读取：

```text
Dataset
current DatasetVersion
current DatasetField schema
version history
```

不需要 Definition dependency。

`DatasetLineageRefreshListenerTest` 也切到新的 Lineage-owned SnapshotReader，同时继续保证 lineage failure 不逃出已经提交的 Dataset transaction。

## Intentionally unchanged

本 PR 不改变：

- `/api/v1/datasets/**` routes
- Dataset HTTP DTO / VO shape
- `DatasetService` public API / compatibility records
- `DatasetQueryService` public API
- `DevelopmentDatasetFacade` public API / nested records
- Analysis binding contract
- Dataset DB / Flyway / DAO / Repository contract
- DatasetStatus / DatasetSourceType persisted values
- immutable DatasetVersion semantics
- currentVersionId behavior
- stable fieldId behavior
- SQL safety/query runtime semantics
- Query Performance semantics
- shared Lineage graph contract
- AFTER_COMMIT + REQUIRES_NEW lineage behavior

## Scope / validation reality

Stage 2 started from merged Stage 1:

```text
main @ f12222d1cb330eb2176a065527a7ec56665c4ef7
```

During implementation main advanced by 2 Resource-only commits; they do not touch Dataset files. This PR targets current `main` directly.

Current Stage 2 scope before PR creation:

```text
14 changed files
production Java behavior files: 2
  - DatasetLineageRefreshListener
  - DatasetLineageSnapshotReader
Controller changes: 0
POM changes: 0
Repository / DAO changes: 0
Flyway / SQL changes: 0
```

A full Maven/JUnit run was not executed in the current environment, so this PR does not claim a green build. Use repository CI / local module tests before marking ready.

## Review focus

```text
[ ] definition <-> lineage cycle is actually removed
[ ] Lineage SnapshotReader reads current persisted version/schema through Repository
[ ] dependency matrix matches real imports and stays acyclic
[ ] external TaskCatalog/Datasource/Lineage/Core SQL dependencies stay in declared adapters
[ ] exactly three stable @Service facades remain
[ ] DatasetVersion remains immutable / append-only
[ ] exact query/source version semantics are unchanged
[ ] DevelopmentNode stable Dataset identity is unchanged
[ ] lineage remains derived AFTER_COMMIT best-effort projection
[ ] no REST / DB / Flyway behavior change
```