### PR TITLE
refactor(resource): establish stage 2 architecture governance

### DIFF
--- a/yak-ops-business/yak-ops-business-resource/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-resource/ARCHITECTURE.md
@@ -1,0 +1,327 @@
+# Yak Ops Resource Architecture
+
+## 1. Architecture Goal
+
+`yak-ops-business-resource` 按 Resource 领域子系统组织代码，而不是按通用 `Controller -> Service -> ServiceImpl -> DAO` 技术分层组织。
+
+目标是让 package 本身回答：
+
+- 谁管理 Namespace？
+- 谁读写 Content？
+- 谁拥有 Storage 路由？
+- 谁把 Resource 解析给 Runtime？
+- 谁传播 commit 后变更？
+- 谁负责 Metadata persistence？
+
+这不是为了删除 `Service` 这个单词，而是为了让角色名称和依赖方向表达真实职责。
+
+## 2. Package Map
+
+```text
+io.yak.ops.business.resource
+|
++-- controller
+|   `-- v1
+|       |-- ResourcesController
+|       `-- mapper
+|           |-- ResourceRequestMapper
+|           `-- ResourceViewMapper
+|
++-- namespace
+|   |-- ResourceNamespaceManager
+|   |-- ResourceNamespaceReader
+|   |-- ResourceTreeReader
+|   |-- ResourceParentResolver
+|   |-- ResourceNamePolicy
+|   `-- ResourceNamespaceCommand
+|
++-- content
+|   |-- ResourceContentManager
+|   |-- ResourceContentReader
+|   |-- ResourceContentPolicy
+|   |-- ResourceChecksum
+|   |-- ResourceBinarySource
+|   `-- ResourceContentCommand
+|
++-- storage
+|   |-- ResourceStorageGateway
+|   |-- StorageOperatorGatewayAdapter
+|   |-- ResourceStorageRegistry
+|   |-- ResourceStorageLifecycle
+|   `-- ResourceStorageReader
+|
++-- resolution
+|   |-- ResourceDownloadProviderAdapter
+|   `-- ResourceResolverAdapter
+|
++-- sync
+|   `-- ResourceChangeDispatcher
+|
++-- repository
+|   |-- ResourceRepository
+|   `-- ResourceRepositoryAdapter
+|
++-- dao
+|   |-- ResourceDao
+|   |-- impl
+|   `-- mapper
+|
++-- domain
+|   |-- ResourceNode
+|   |-- ResourceNodeFactory
+|   |-- ResourcePath
+|   |-- ResourceRevision
+|   |-- ResourceContent
+|   |-- ResourceDownload
+|   |-- ResourceQuery
+|   |-- ResourceTreeNode
+|   `-- ResourceStoragePlugin
+|
++-- config
+`-- exception
+```
+
+## 3. Primary Corridors
+
+### 3.1 HTTP command/read corridor
+
+```text
+HTTP Request
+    -> ResourcesController
+    -> ResourceRequestMapper
+    -> Namespace / Content command or read role
+    -> Domain result
+    -> ResourceViewMapper
+    -> HTTP VO
+```
+
+Controller 不允许直接进入 Repository、DAO、Mapper 或 `StorageOperator`。
+
+### 3.2 Namespace command corridor
+
+```text
+ResourceNamespaceManager
+    -> ResourceParentResolver / ResourceNamePolicy
+    -> ResourceRepository
+    -> ResourceStorageGateway
+    -> ResourceStorageLifecycle
+    -> ResourceChangeDispatcher
+```
+
+Namespace Manager 不读写文件字节内容；它只编排目录/路径/身份和与这些变更相关的 Storage object lifecycle。
+
+### 3.3 Content command corridor
+
+```text
+ResourceContentManager
+    -> ResourceNamespaceReader / ParentResolver / NamePolicy
+    -> ResourceContentPolicy / ResourceChecksum
+    -> ResourceStorageGateway
+    -> ResourceRepository
+    -> ResourceStorageLifecycle
+    -> ResourceChangeDispatcher
+```
+
+Content Manager 不直接依赖 HTTP `MultipartFile`。Controller 使用 `ResourceBinarySource` 完成 transport adaptation。
+
+### 3.4 Read corridor
+
+```text
+ResourceNamespaceReader -> ResourceRepository
+ResourceTreeReader      -> ResourceRepository
+ResourceContentReader   -> NamespaceReader + ResourceStorageGateway
+ResourceStorageReader   -> ResourceStorageRegistry
+```
+
+Read role 不持有 mutation transaction。
+
+### 3.5 Storage corridor
+
+```text
+Namespace / Content
+        -> ResourceStorageGateway
+        -> StorageOperatorGatewayAdapter
+        -> ResourceStorageRegistry
+        -> StorageOperator SPI
+        -> Local / MinIO / HDFS / ...
+```
+
+`ResourceStorageGateway` 是 Resource business -> Storage SPI 的唯一业务能力入口。
+
+Registry 负责：
+
+- installed operator discovery；
+- type -> operator binding；
+- duplicate plugin detection；
+- default storage selection；
+- plugin domain view。
+
+Adapter 负责：
+
+- 把 Storage Plugin exception 转换为 Resource business exception；
+- 隐藏 `StorageOperator` 实例；
+- 暴露 Resource 需要的最小 create/write/open/move/delete contract。
+
+### 3.6 Resolution corridor
+
+```text
+External Task Runtime
+      -> ResourceResolver SPI
+      -> ResourceResolverAdapter
+      -> ResourceDownloadProvider SPI
+      -> ResourceDownloadProviderAdapter
+      -> NamespaceReader + ContentReader
+      -> StorageGateway
+```
+
+Resolution 是跨模块 adapter，不允许直接读 DAO / Repository internal implementation。
+
+### 3.7 Sync corridor
+
+```text
+Namespace / Content mutation
+      -> DB commit
+      -> ResourceChangeDispatcher
+      -> ResourceFileSyncProvider SPI
+```
+
+Sync 是 after-commit side effect。Provider failure 不反向污染 Resource transaction。
+
+## 4. Persistence Boundary
+
+```text
+Business Role
+    -> ResourceRepository
+    -> ResourceRepositoryAdapter
+    -> ResourceDao
+    -> ResourceMapper / MyBatis-Plus
+    -> ResourcePO
+    -> yak_ops_resource
+```
+
+约束：
+
+- `ResourceRepository` 只暴露 Domain；
+- Repository Adapter 是 PO/Domain translation owner；
+- DAO 只处理 Persistence contract；
+- `ResourcePO` 不得进入 Namespace / Content / Resolution / Controller；
+- 当前单表查询继续使用 MyBatis-Plus；没有复杂 join 时不为“架构感”额外引入 XML SQL。
+
+## 5. Truth Model
+
+```text
+Database / ResourceRepository
+    owns identity + namespace + current revision metadata
+
+Storage Plugin
+    owns physical bytes
+
+Resolution
+    owns temporary materialization only
+
+Sync Provider
+    owns external projection only
+```
+
+任何新增功能都必须先回答“这份状态的 Owner 是谁”，再决定 package。
+
+## 6. Consistency Workflows
+
+### 6.1 Create directory / upload / online create
+
+```text
+validate
+   -> Storage create/write
+   -> Repository insert
+       -> commit -> Sync
+       -> insert failure -> Storage cleanup compensation
+```
+
+### 6.2 Rename / move
+
+```text
+validate
+   -> Storage move
+   -> update Resource + descendants metadata
+       -> commit -> Sync
+       -> metadata failure -> Storage rollback attempt
+```
+
+### 6.3 Delete
+
+```text
+Repository delete Resource + descendants
+   -> commit
+   -> Storage delete best-effort
+   -> Sync best-effort
+```
+
+这些顺序不能由 Adapter 或 Controller 自行重排。
+
+## 7. Role Vocabulary
+
+| Role | Meaning |
+|---|---|
+| `Manager` | 一个业务子系统的 mutation lifecycle owner |
+| `Reader` | 无副作用 read-side entry |
+| `Resolver` | 把 identity/reference 解析为当前业务对象或运行时对象 |
+| `Policy` | 可测试的业务约束/决策，不拥有持久状态 |
+| `Gateway` | Resource-owned 外部能力 Port |
+| `Adapter` | Resource contract 与外部 SPI/transport/persistence 模型之间翻译 |
+| `Registry` | 已安装 plugin/capability 的运行时注册表 |
+| `Lifecycle` | 补偿、after-commit 等外部生命周期动作 |
+| `Dispatcher` | 把已完成业务变化分发给外部消费者 |
+| `Repository` | Domain persistence Port |
+| `Dao` | MyBatis/persistence data access |
+| `Mapper` | HTTP 或 Persistence 边界转换，不承载业务决策 |
+| `Command` | immutable mutation input，不是 HTTP DTO |
+
+禁止把多个职责重新塞进 `XxxSupport`、`XxxHelper`、`XxxUtils` 或新的大 `XxxServiceImpl`。
+
+## 8. Spring Stereotypes
+
+Resource 当前使用：
+
+- `@Component`：Manager / Reader / Policy / Resolver / Lifecycle / Dispatcher / SPI Adapter 等明确业务角色；
+- `@Repository`：Repository Adapter / DAO persistence role；
+- `@Configuration`：模块 wiring；
+- `@RestController` / `@RestControllerAdvice`：HTTP boundary。
+
+是否使用 `@Service` 不是架构目标。当前模块不需要用 `@Service` 来表达业务分层，角色名和 package 已经承担该语义。
+
+## 9. Public vs Internal Contracts
+
+### Stable external contracts
+
+- `/api/v1/resources/**` HTTP contract；
+- `StorageOperator` SPI；
+- `ResourceResolver` SPI；
+- `ResourceDownloadProvider` SPI；
+- `ResourceFileSyncProvider` SPI。
+
+### Resource-owned business contracts
+
+- `ResourceRepository`；
+- `ResourceStorageGateway`；
+- Namespace / Content command/read roles；
+- Domain value/read models。
+
+外部模块优先依赖既有跨模块 SPI，不应直接绑定 Resource 内部 Manager 实现。
+
+## 10. Architecture Governance
+
+Stage 2 使用 executable tests 固化：
+
+- top-level package dependency matrix；
+- actual package graph acyclic；
+- Controller/persistence/Storage SPI boundary；
+- `namespace/content -> storage` 只走 ResourceStorageGateway/Lifecycle；
+- `namespace/content -> sync` 只走 ResourceChangeDispatcher；
+- `resolution -> Resource read-side` 的窄入口；
+- Repository / DAO transport boundary；
+- Domain framework isolation；
+- broad bucket prohibition；
+- role stereotype consistency；
+- repository-wide CODE_STYLE single source。
+
+架构文档与 executable guard 必须同步更新，不能只改其中一边。

--- a/yak-ops-business/yak-ops-business-resource/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-resource/DEPENDENCIES.md
@@ -1,0 +1,245 @@
+# Yak Ops Resource Dependencies
+
+本文件定义 Resource 模块内部 package 依赖方向和高风险 corridor。实际 Java import graph 必须由 `ResourceDependencyBoundaryTest` 验证。
+
+## 1. Top-Level Dependency Matrix
+
+`io.yak.ops.business.resource.<package>` 的允许依赖如下：
+
+| Source | Allowed Resource packages |
+|---|---|
+| `controller` | `config`, `content`, `domain`, `exception`, `namespace`, `storage` |
+| `resolution` | `config`, `content`, `domain`, `namespace` |
+| `content` | `config`, `domain`, `exception`, `namespace`, `repository`, `storage`, `sync` |
+| `namespace` | `config`, `domain`, `exception`, `repository`, `storage`, `sync` |
+| `storage` | `config`, `domain`, `exception` |
+| `sync` | `config`, `domain` |
+| `repository` | `config`, `dao`, `domain` |
+| `domain` | none inside Resource |
+| `exception` | none inside Resource |
+| `dao` | none inside Resource |
+| `config` | none inside Resource |
+
+`controller/v1/mapper` 属于 `controller` top-level package。
+
+## 2. Intended Direction
+
+```text
+controller
+   +-> namespace
+   +-> content
+   +-> storage(read side)
+   +-> domain mapping
+
+resolution
+   +-> namespace(read side)
+   +-> content(read side)
+
+content
+   +-> namespace(read-side policies)
+   +-> repository
+   +-> storage
+   +-> sync
+
+namespace
+   +-> repository
+   +-> storage
+   +-> sync
+
+repository
+   +-> dao
+   +-> domain
+
+storage
+   +-> domain
+
+sync
+   +-> domain
+
+domain / exception / dao / config
+   -> no higher Resource package
+```
+
+实际图必须保持无环。
+
+## 3. Narrow Corridors
+
+### 3.1 Controller -> business roles
+
+Controller 可以依赖：
+
+```text
+ResourceNamespaceManager
+ResourceNamespaceReader
+ResourceTreeReader
+ResourceContentManager
+ResourceContentReader
+ResourceStorageReader
+ResourceRequestMapper
+ResourceViewMapper
+```
+
+Controller 不得依赖：
+
+```text
+ResourceRepository
+ResourceRepositoryAdapter
+ResourceDao
+ResourceMapper
+ResourceStorageGateway
+ResourceStorageRegistry
+StorageOperatorGatewayAdapter
+StorageOperator
+ResourceChangeDispatcher
+```
+
+HTTP Exception Advice 也属于 `controller` boundary，不属于业务 `exception` package。
+
+## 4. Content -> Namespace
+
+Content 子系统只允许使用 Namespace 的窄角色：
+
+```text
+ResourceNamespaceReader
+ResourceParentResolver
+ResourceNamePolicy
+```
+
+禁止 Content 直接调用 `ResourceNamespaceManager` 产生隐式复合 mutation。
+
+## 5. Namespace / Content -> Storage
+
+业务子系统只能通过 Resource-owned Storage contract：
+
+```text
+ResourceStorageGateway
+ResourceStorageLifecycle
+```
+
+不得直接 import：
+
+```text
+io.yak.ops.spi.storage.StorageOperator
+StoragePluginException
+StorageObjectMetadata
+```
+
+Storage SPI translation 只允许存在于 `storage` package。
+
+## 6. Namespace / Content -> Sync
+
+唯一允许的 mutation -> sync corridor：
+
+```text
+ResourceChangeDispatcher
+```
+
+Namespace / Content 不直接调用 `ResourceFileSyncProvider`。
+
+## 7. Resolution -> Resource
+
+Resolution 只通过 read-side 获取当前 Resource：
+
+```text
+ResourceDownloadProviderAdapter
+   -> ResourceNamespaceReader
+   -> ResourceContentReader
+
+ResourceResolverAdapter
+   -> ResourceDownloadProvider SPI
+```
+
+禁止 Resolution 依赖：
+
+```text
+ResourceNamespaceManager
+ResourceContentManager
+ResourceRepository
+ResourceDao
+ResourceStorageGateway
+```
+
+它是消费 adapter，不是 Resource command corridor。
+
+## 8. Repository -> DAO
+
+```text
+ResourceRepository
+     ^
+     |
+ResourceRepositoryAdapter
+     |
+     v
+ResourceDao -> ResourceMapper -> ResourcePO
+```
+
+- Repository contract 不暴露 DTO / VO / PO / MyBatis；
+- DAO 不暴露 HTTP DTO/VO；
+- Domain <-> PO 映射由 Repository Adapter 显式完成；
+- Namespace/Content/Resolution 不允许 import DAO/PO。
+
+## 9. Domain
+
+`domain` 允许：
+
+- JDK；
+- Resource 稳定 shared enum/value（例如 `ResourceNodeType`, `ResourceStorageType`）。
+
+`domain` 禁止：
+
+- Spring；
+- MyBatis / MyBatis-Plus；
+- HTTP DTO / VO；
+- Resource PO；
+- StorageOperator；
+- Controller / Manager / Repository implementation；
+- Lombok `@Data` 作为领域模型语义替代。
+
+## 10. Sync
+
+`sync` 可以依赖 Domain 生成传播上下文，并依赖跨模块 `ResourceFileSyncProvider` SPI。
+
+禁止：
+
+- Sync 反向调用 Namespace/Content Manager 修改 Resource truth；
+- Provider 实现被 Resource business role 直接感知；
+- Sync failure 参与数据库事务回滚。
+
+## 11. Config and Exception
+
+`config` 只负责 wiring、properties、Flyway/MyBatis configuration，不承载 Resource business decision。
+
+`exception` 只保留 Resource business exception 类型。HTTP exception translation 属于 Controller boundary，避免形成：
+
+```text
+controller -> domain/exception -> controller
+```
+
+这种 package cycle。
+
+## 12. Forbidden Buckets
+
+Production 下不得重新创建：
+
+```text
+service/
+common/
+helper/
+utils/
+util/
+base/
+persistence/
+```
+
+如果一个类无法放入 `namespace/content/storage/resolution/sync/repository/dao/domain/controller/config/exception`，应先重新定义其角色，而不是创建新的兜底包。
+
+## 13. Change Rule
+
+修改依赖方向时必须同时更新：
+
+1. `ARCHITECTURE.md`；
+2. 本文件；
+3. `ResourceDependencyBoundaryTest`；
+4. 对应行为测试。
+
+不得为了让架构测试通过而无理由扩大 Allowed Matrix。

--- a/yak-ops-business/yak-ops-business-resource/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-resource/DOMAIN.md
@@ -1,0 +1,339 @@
+# Yak Ops Resource Domain
+
+## 1. Core Model
+
+Resource 领域刻意区分“资源是谁”和“资源字节在哪里”。
+
+```text
+                         ResourceNode
+                    metadata / namespace truth
+                              |
+              +---------------+---------------+
+              |               |               |
+              v               v               v
+        ResourcePath    ResourceRevision   Storage Binding
+        parent/name       version          storageType
+        fullPath          checksum         storagePath
+        nodeType          fileSize
+                          contentType
+                              |
+                              v
+                       Physical Bytes
+                              |
+                              v
+                    ResourceStorageGateway
+                              |
+                              v
+                       StorageOperator SPI
+```
+
+数据库和 Storage Plugin 是两个不同的事实边界，不能互相替代。
+
+## 2. Truth Ownership
+
+| Truth | Owner | 说明 |
+|---|---|---|
+| Resource ID | Resource Metadata / Repository | 长生命周期业务身份 |
+| parentId / name / fullPath | Resource Namespace | 当前树结构与路径 |
+| FILE / DIRECTORY | Resource Namespace | 当前节点类型 |
+| storageType / storagePath | Resource Metadata | 物理对象定位 binding |
+| current version | Resource Revision Metadata | 当前 fencing/revision |
+| checksum / fileSize / contentType | Resource Revision Metadata | 当前内容描述 |
+| physical bytes | Storage Plugin | Local / MinIO / HDFS 等实际字节 |
+| installed storage capability | ResourceStorageRegistry | 已安装 StorageOperator 的运行时注册表 |
+| temporary resolved file | Resolution | 一次消费过程的临时物化结果 |
+| external Git/sync projection | Resource Sync Provider | Resource 真相的外部投影，不是 Owner |
+| HTTP DTO / VO | Controller Boundary | 传输模型，不是 Domain |
+
+## 3. ResourceNode
+
+`ResourceNode` 表示 Resource 当前 Metadata/Namespace 状态。
+
+核心属性分为四组：
+
+### Identity / Namespace
+
+```text
+id
+parentId
+name
+fullPath
+nodeType
+```
+
+### Storage Binding
+
+```text
+storageType
+storagePath
+```
+
+### Current Revision Metadata
+
+```text
+contentType
+suffix
+fileSize
+checksum
+version
+```
+
+### Projection / Audit Metadata
+
+```text
+gitSyncStatus
+createTime
+updateTime
+description
+```
+
+`ResourceNode` 不包含真实文件 bytes。
+
+## 4. ResourcePath
+
+`ResourcePath` 是 immutable value object，统一表达逻辑 Resource Path。
+
+规则：
+
+- 统一以 `/` 开头；
+- 非根路径去除尾部 `/`；
+- `child(name)` 只接收已通过 Name Policy 的名称；
+- `storagePath()` 把 `/jobs/demo.sql` 映射为 `jobs/demo.sql`；
+- `isDescendantOf` 用于防止把目录移动到自身后代；
+- suffix 从资源名称稳定推导。
+
+Resource Path 是 Namespace 语义，不由具体 Storage Plugin 决定。
+
+## 5. ResourceRevision
+
+`ResourceRevision` 表示 **当前 Revision**，而不是历史版本实体。
+
+```text
+ResourceRevision(
+    version,
+    checksum,
+    fileSize,
+    contentType)
+```
+
+### Revision identity rule
+
+```text
+same resourceId + higher version
+    = 同一个 Resource 的更新 revision
+
+NOT
+
+version 1/2/3/4/5
+    = 五个仍然可以任意读取的 immutable historical blobs
+```
+
+当前 `download(resourceId, requestedVersion)` 是 fencing：
+
+```text
+requestedVersion == currentVersion
+    -> 可以读取当前内容
+
+requestedVersion != currentVersion
+    -> version mismatch
+```
+
+如果未来需要历史版本，必须新增独立的 Version/Blob truth，而不能重新解释现在的 `version` 字段。
+
+## 6. Directory vs File
+
+### DIRECTORY
+
+拥有：
+
+- Namespace identity；
+- child relationship；
+- Storage directory binding；
+- move/delete lifecycle。
+
+不拥有：
+
+- downloadable content；
+- editable text content。
+
+### FILE
+
+在 Namespace identity 之外，还拥有当前内容 revision metadata，并可通过 Storage Gateway 读取/写入物理字节。
+
+## 7. ResourceContent and ResourceDownload
+
+`ResourceContent` 是在线文本读取的 read model：
+
+```text
+resourceId
+fullPath
+content
+skipLineNum
+lineCount
+hasMore
+```
+
+它不是持久化实体。
+
+`ResourceDownload` 是一次下载流：
+
+```text
+fileName
+contentType
+fileSize
+InputStream
+```
+
+它同样不是持久化实体，也不应该进入 Repository contract。
+
+## 8. ResourceStoragePlugin
+
+`ResourceStoragePlugin` 是 Storage Registry 的领域视图：
+
+```text
+type
+name
+active
+```
+
+它只描述已安装能力，不暴露 `StorageOperator` 对象本身。
+
+## 9. ResourceTreeNode
+
+`ResourceTreeNode` 是树查询 read model，用于在 Domain/Read Side 组合 Resource 层级。
+
+它不是第二份 Namespace Truth。真正的父子关系仍来自 Repository 中每个 `ResourceNode.parentId`。
+
+## 10. Command Ownership
+
+### Namespace Command
+
+`ResourceNamespaceManager` 拥有：
+
+- create directory；
+- rename / metadata update；
+- move；
+- recursive metadata delete。
+
+它可以编排 Repository、Storage Gateway、Storage Lifecycle 与 Change Dispatcher，但不直接操作 `StorageOperator`。
+
+### Content Command
+
+`ResourceContentManager` 拥有：
+
+- upload；
+- online create；
+- replace file；
+- update editable content。
+
+它维护当前 content revision metadata，但不拥有 Namespace 查询实现。
+
+## 11. Read Ownership
+
+```text
+ResourceNamespaceReader
+    -> identity / child list / page / require FILE
+
+ResourceTreeReader
+    -> tree projection
+
+ResourceContentReader
+    -> text content / download stream
+
+ResourceStorageReader
+    -> installed storage plugin views
+```
+
+Reader 不产生业务 mutation。
+
+## 12. Storage Consistency Semantics
+
+Resource 不是分布式事务系统，因此当前通过明确的顺序与补偿语义维持一致性。
+
+### Create / Upload
+
+```text
+validate
+  -> write Storage
+  -> insert Metadata
+      -> success: afterCommit Sync
+      -> failure: best-effort cleanup Storage object
+```
+
+### Move
+
+```text
+validate target
+  -> move Storage object
+  -> update Resource + descendants Metadata
+      -> success: afterCommit Sync
+      -> failure: best-effort move Storage back
+```
+
+### Delete
+
+```text
+delete Metadata in transaction
+  -> commit
+  -> delete Storage object best-effort
+  -> propagate Sync best-effort
+```
+
+这些顺序本身是 Domain Contract，不能在普通结构重构中改变。
+
+## 13. Resolution
+
+Resolution 是消费适配层，不是 Resource Domain Owner。
+
+```text
+ResourceResolver SPI
+        |
+        v
+ResourceResolverAdapter
+        |
+        v
+ResourceDownloadProvider SPI
+        |
+        v
+ResourceDownloadProviderAdapter
+        |
+        +-> ResourceNamespaceReader
+        +-> ResourceContentReader
+```
+
+它负责：
+
+- revision fencing；
+- stream -> local temp file；
+- SHA-256 verify；
+- failure cleanup；
+- 输出 `ResolvedResource`。
+
+临时文件生命周期不能反向修改 Resource Metadata。
+
+## 14. Sync
+
+`ResourceChangeDispatcher` 把已经提交的 Resource 变化转成跨模块 Sync Context。
+
+```text
+Resource truth committed
+       -> CREATED / UPDATED / MOVED / DELETED
+       -> ResourceFileSyncProvider(s)
+```
+
+Sync 失败不会改变 Resource 真相。
+
+## 15. Boundary Summary
+
+必须长期保持：
+
+```text
+ResourceNode != Physical Bytes
+ResourceRevision != Historical Version Store
+ResourceTreeNode != Namespace Truth
+ResolvedResource != ResourceNode
+Sync Projection != Resource Truth
+StorageOperator != Resource Business API
+DTO / VO != Domain
+PO != Domain
+```

--- a/yak-ops-business/yak-ops-business-resource/README.md
+++ b/yak-ops-business/yak-ops-business-resource/README.md
@@ -2,7 +2,19 @@
 
 文件资源模块负责 Resource Namespace、文件内容、存储插件路由、运行时资源解析，以及资源变更后的外部同步传播。
 
-当前代码按业务子系统组织，不再以通用 `service/impl` 作为业务入口：
+代码按业务子系统和明确角色组织，不以通用 `service/impl` 作为业务入口。
+
+## Read First
+
+开始修改 Resource 前建议按顺序阅读：
+
+1. [`REQUIREMENTS.md`](./REQUIREMENTS.md)：必须长期保持的业务行为；
+2. [`DOMAIN.md`](./DOMAIN.md)：Resource Truth Ownership、Revision 与一致性语义；
+3. [`ARCHITECTURE.md`](./ARCHITECTURE.md)：package map、角色与主要调用 corridor；
+4. [`DEPENDENCIES.md`](./DEPENDENCIES.md)：允许的依赖方向与 forbidden dependency；
+5. [`REVIEW.md`](./REVIEW.md)：PR 评审和最终一致性检查清单。
+
+## Architecture at a Glance
 
 ```text
 Controller
@@ -21,29 +33,100 @@ ResourceResolver SPI
    -> Namespace / Content Read Side
 ```
 
-## 运行真相
+主要 package：
 
-数据库中的 `yak_ops_resource` 是 Resource identity / namespace / current revision metadata 的事实来源；Local / MinIO / HDFS 等 Storage Plugin 只拥有物理文件字节。
+```text
+resource
+├── controller/v1/mapper
+├── namespace
+├── content
+├── storage
+├── resolution
+├── sync
+├── repository
+├── dao
+├── domain
+├── config
+└── exception
+```
 
-`version` 表示当前 Resource Revision，用于变更 fencing 与运行时版本校验。当前模块不是历史版本存储系统，因此 `version = 5` 不表示仍可读取 1~4 版本内容。
+## Truth Ownership
 
-## 一致性语义
+```text
+Database / ResourceRepository
+    owns Resource identity / namespace / current revision metadata
 
-当前重构保持既有行为：
+Storage Plugin
+    owns physical bytes
 
-- 创建目录、上传和在线创建：先写物理存储，再写元数据；元数据失败时补偿删除刚创建的物理对象。
-- Move：先移动物理对象，再批量更新当前资源及后代路径；元数据更新失败时尝试把 Storage 路径回滚。
-- 当前不支持跨 Storage Move。
-- Delete：先提交元数据删除；物理对象删除与外部 Resource Sync 在事务提交后执行，不让外部 I/O 延长数据库事务。
-- Resource Sync 是提交后的 best-effort propagation，不是 Resource Namespace 的第二状态来源。
-- Resource Resolver 会把资源物化到临时目录并校验 SHA-256 checksum；指定 version 时只允许读取当前匹配 revision。
+Resolution
+    owns temporary materialization only
 
-## 持久化
+Resource Sync
+    owns external propagation only
+```
 
-当前只维护一张业务表：
+`ResourceNode` 和物理文件不是同一份 Truth。
+
+`version` 表示当前 Resource Revision / fencing value，不是 historical version store。`version = 5` 不意味着 revision 1~4 仍然可以下载。
+
+## Role Vocabulary
+
+| Role | Responsibility |
+|---|---|
+| `Manager` | mutation lifecycle owner |
+| `Reader` | read-side entry，无业务 mutation |
+| `Resolver` | reference / runtime materialization |
+| `Policy` | 可测试约束和业务决策 |
+| `Gateway` | Resource-owned external capability Port |
+| `Adapter` | transport / persistence / SPI 边界翻译 |
+| `Registry` | installed plugin/capability registry |
+| `Lifecycle` | compensation / after-commit lifecycle |
+| `Dispatcher` | commit 后外部传播 |
+| `Repository` | Domain persistence Port |
+| `DAO` | MyBatis persistence access |
+| `Mapper` | HTTP 或 Persistence 模型转换 |
+| `Command` | immutable mutation input，不是 HTTP DTO |
+
+新增代码不要重新创建 `Support/Helper/Utils/Common/Base/ServiceImpl` 兜底角色。
+
+## Consistency Semantics
+
+当前必须保持：
+
+- 创建目录、上传、在线创建：先写物理 Storage，再写 Metadata；Metadata 创建失败时 best-effort 删除新 Storage Object；
+- Move：先移动 Storage Object，再批量更新当前 Resource 和 descendants Metadata；Metadata 失败时 best-effort 回滚 Storage Path；
+- 当前不支持 cross-storage move；
+- Delete：先提交 Metadata 删除，再 after-commit 删除 Storage Object；
+- Resource Sync 在 commit 后 best-effort 执行，Provider 失败不回滚 Resource Truth；
+- Resource Resolver 物化到临时目录并校验 SHA-256；指定 version 时只允许当前 matching revision。
+
+## Persistence
+
+当前 Resource Metadata 只维护：
 
 ```text
 yak_ops_resource
 ```
 
-资源模块复用 `yak.database` 对应的业务 DataSource、MyBatis SessionFactory 和事务管理器，并继续拥有独立的 `yak_resource_schema_history` Flyway 历史边界。
+资源模块复用 `yak.database` 对应的 Business DataSource、MyBatis SessionFactory 和 TransactionManager，并继续拥有独立的：
+
+```text
+yak_resource_schema_history
+```
+
+Flyway 历史边界。
+
+## Architecture Guards
+
+Resource 架构由以下测试作为 executable contract：
+
+```text
+ResourceArchitectureDocumentationTest
+ResourceDependencyBoundaryTest
+ResourceLayeringConventionTest
+ResourceCodeStyleConventionTest
+ResourceRoleConventionTest
+```
+
+架构约束需要变更时，代码、`ARCHITECTURE.md`、`DEPENDENCIES.md` 和对应测试必须一起修改，而不是单独放宽测试。

--- a/yak-ops-business/yak-ops-business-resource/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-resource/REQUIREMENTS.md
@@ -1,0 +1,220 @@
+# Yak Ops Resource Requirements
+
+本文件定义 `yak-ops-business-resource` 必须长期保持的业务行为与架构边界。它描述“Resource 模块负责什么、哪些语义不能被重构破坏”，不记录临时迁移步骤。
+
+## 1. Scope
+
+Resource 模块负责：
+
+- Resource Namespace：目录、文件身份、父子关系、名称、逻辑路径与树形查询；
+- Resource Content：上传、在线创建、替换、文本读取/编辑与下载；
+- Resource Storage Routing：按 `ResourceStorageType` 路由到已安装 Storage Plugin；
+- Resource Resolution：把资源物化为经过 checksum 校验的本地临时文件，供 Task Runtime 等外部消费者使用；
+- Resource Change Propagation：在业务事务提交后向可选 `ResourceFileSyncProvider` 传播资源变更；
+- Resource Metadata Persistence：维护 `yak_ops_resource` 当前元数据与 current revision。
+
+Resource 模块不负责：
+
+- 实现 Local / MinIO / HDFS 等具体存储系统；
+- 保存任意历史 Resource 内容版本；
+- 让 Git 或其它同步目标成为 Resource Namespace 的事实来源；
+- 跨存储类型移动资源；
+- 把外部 Storage I/O 纳入长数据库事务。
+
+## 2. Namespace
+
+### 2.1 Identity and hierarchy
+
+- `ResourceNode.id` 是 Resource 当前业务身份；
+- `parentId`、`name`、`fullPath` 和 `nodeType` 共同描述当前 Namespace 状态；
+- 根目录使用逻辑父标识 `0`，不作为普通可下载 Resource 存储对象；
+- 同一父目录下名称必须唯一；
+- 目录和文件均参与 Namespace，但文件内容能力只适用于 FILE 节点。
+
+### 2.2 Name and path safety
+
+- 资源名称不能为空；
+- 名称不能包含 `/`、`\\`、NUL、`.` 或 `..` 等路径穿越形式；
+- 逻辑路径统一以 `/` 开头；
+- Storage Path 由逻辑 Resource Path 稳定映射，不允许 Controller 或 Storage Plugin 自行定义另一套 Namespace。
+
+### 2.3 Move and rename
+
+- rename / move 必须校验目标父目录、同名冲突和后代循环；
+- 当前禁止跨 `ResourceStorageType` move；
+- 目录 move 必须同步更新所有后代的 `fullPath` 与 `storagePath`；
+- move 的现有一致性顺序必须保持：先完成物理 Storage Move，再提交 Metadata 更新；Metadata 更新失败时尝试回滚物理路径。
+
+### 2.4 Delete
+
+- 目录删除包含当前节点及所有后代 Metadata；
+- Metadata 删除事务先提交；
+- 物理对象删除在 commit 后执行；
+- commit 后 Storage 删除失败只能记录运行证据，不能把已提交的 Namespace Metadata 静默恢复成旧状态。
+
+## 3. Content
+
+### 3.1 Create and upload
+
+- 上传二进制文件和在线创建文本资源都必须先验证大小、名称和父目录；
+- 物理对象先写 Storage，Metadata 后写 Repository；
+- Metadata 创建失败时必须 best-effort 删除刚创建的物理对象，避免无主 Storage Object；
+- `MultipartFile` 只属于 HTTP 输入边界，不能进入 Repository 或 Domain contract。
+
+### 3.2 Replace and edit
+
+- 替换文件、在线编辑必须只作用于 FILE 节点；
+- 在线文本读写受 editable suffix 与 editable max bytes 策略限制；
+- 内容变更必须更新当前 size / checksum / contentType / revision 等现有 Metadata；
+- SHA-256 是当前 Resource 内容完整性校验算法。
+
+### 3.3 Read and download
+
+- 文本内容读取保留 `skipLineNum + limit` 语义和单次最大 2000 行约束；
+- 下载返回当前 Resource 的文件名、content type、size 与 InputStream；
+- Reader 不修改 Namespace、Revision 或外部同步状态。
+
+## 4. Storage
+
+### 4.1 Ownership
+
+Storage Plugin 只拥有物理字节和目录对象，不拥有 Resource identity / Namespace / revision truth。
+
+业务子系统必须通过：
+
+```text
+Namespace / Content
+        -> ResourceStorageGateway
+        -> StorageOperatorGatewayAdapter
+        -> ResourceStorageRegistry
+        -> StorageOperator SPI
+```
+
+调用 Storage。`namespace` 和 `content` 不得直接依赖 `StorageOperator`。
+
+### 4.2 Registry
+
+- 同一个 `ResourceStorageType` 只能注册一个 Storage Operator；
+- 未安装当前配置的 Storage Plugin 时必须明确失败；
+- `ResourceStorageReader` 只暴露当前已安装插件的 Resource 领域视图，不返回 HTTP VO 或 StorageOperator。
+
+## 5. Resource Revision
+
+`Resource.version` 的定义是 **current revision / fencing value**。
+
+```text
+resourceId = 42
+version    = 5
+```
+
+表示 Resource 42 当前处于 revision 5。
+
+它不意味着系统保存并可读取：
+
+```text
+revision 1
+revision 2
+revision 3
+revision 4
+```
+
+因此：
+
+- 当前模块不是 historical version store；
+- `ResourceDownloadProvider.download(id, version)` 只允许请求版本与当前 revision 相等；
+- requested revision 与 current revision 不一致必须明确失败；
+- 未来如需历史内容版本，必须单独设计 immutable Resource Version / Blob 模型，不得把当前字段语义偷偷扩展。
+
+## 6. Resolution
+
+`ResourceResolver` 是外部 Runtime 消费 Resource 的适配边界。
+
+必须保持：
+
+```text
+Resource id[/revision]
+      -> current metadata/content read side
+      -> temporary local directory
+      -> stream copy + SHA-256
+      -> checksum validation
+      -> ResolvedResource
+```
+
+- Resolution 不直接访问 DAO / Mapper；
+- Resolution 不拥有 Resource Metadata；
+- checksum 不匹配必须删除临时目录并失败；
+- 失败路径应 best-effort 清理临时目录；
+- 指定 revision 时沿用 current-revision fencing 语义。
+
+## 7. Resource Sync
+
+Resource Sync 是提交后的 **best-effort propagation**：
+
+```text
+Resource mutation transaction
+          -> commit
+          -> ResourceChangeDispatcher
+          -> ResourceFileSyncProvider(s)
+```
+
+必须保持：
+
+- CREATED / UPDATED / MOVED / DELETED 变更在 commit 后传播；
+- Provider 失败不能回滚已经提交的 Resource Metadata；
+- Sync Provider 不能成为 Namespace 或 Revision 的第二事实来源；
+- Sync Context 只携带传播所需的 Resource identity / path / storage / revision 信息。
+
+## 8. Persistence
+
+当前 Resource Metadata 只维护：
+
+```text
+yak_ops_resource
+```
+
+要求：
+
+- `ResourceRepository` 是业务持久化 Port，只暴露 Domain / shared `PageData`；
+- `ResourceRepositoryAdapter` 负责 Domain <-> PO 映射；
+- DAO / Mapper 不接收 HTTP DTO，也不返回 HTTP VO；
+- MyBatis-Plus 细节不能泄漏到 Namespace / Content / Resolution；
+- Resource 继续复用 Yak Business DataSource / SqlSessionFactory / TransactionManager；
+- Resource Flyway 继续使用独立 `yak_resource_schema_history` 历史边界。
+
+## 9. HTTP Compatibility
+
+架构治理不得顺手改变：
+
+- `/api/v1/resources/**` 路径；
+- 现有 Permission Code；
+- Request DTO / Response VO JSON contract；
+- `bizData + pagination` 分页输出；
+- 上传、下载和在线内容接口的现有 HTTP 语义。
+
+HTTP DTO / VO 映射只允许存在于 Controller Boundary。
+
+## 10. SPI Compatibility
+
+不得在纯架构重构中破坏：
+
+- `StorageOperator`；
+- `ResourceResolver`；
+- `ResourceDownloadProvider`；
+- `ResourceFileSyncProvider`；
+- 对应的 `ResolvedResource` / `ResourceDownloadResult` / Sync Context contract。
+
+Breaking SPI 变更必须独立版本化和迁移。
+
+## 11. Architecture Invariants
+
+长期必须满足：
+
+- package structure 表达 Namespace / Content / Storage / Resolution / Sync 职责；
+- production 不重新创建 `service/common/helper/utils/util/base/persistence` 业务大桶；
+- Controller 不直接访问 Repository / DAO / Storage SPI；
+- Namespace / Content 不直接访问 DAO / PO / HTTP model / StorageOperator；
+- Resolution 只通过 Resource read-side 与跨模块 SPI 工作；
+- Repository 下面才允许 PO / MyBatis；
+- Domain 不依赖 Spring Web、MyBatis、HTTP DTO/VO/PO；
+- Resource package dependency graph 必须保持无环；
+- 上述约束由 executable architecture tests 保护。

--- a/yak-ops-business/yak-ops-business-resource/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-resource/REVIEW.md
@@ -1,0 +1,209 @@
+# Yak Ops Resource Review Guide
+
+Resource 代码评审不只检查“能不能工作”，还要确认 Namespace、Content、Storage 和外部投影没有重新混成一套模糊状态。
+
+## 1. Truth Ownership
+
+每个 PR 先回答：新增状态由谁拥有？
+
+- Resource identity / parent / name / path -> Resource Namespace / Repository；
+- current revision / checksum / size / contentType -> Resource Metadata；
+- physical bytes -> Storage Plugin；
+- temporary local file -> Resolution；
+- Git / external sync state -> external projection。
+
+出现同一事实被两个组件都当成 authoritative source 时应阻止合并。
+
+## 2. Revision Review
+
+检查任何与 `version` 有关的代码：
+
+- 是否仍把它定义为 current revision / fencing？
+- 是否错误实现了“任意历史 version 都可下载”的假象？
+- requested version mismatch 是否明确失败？
+- 内容/路径 mutation 是否沿用当前 revision 递增语义？
+
+如果需求真的是历史版本，必须单独引入 immutable Version/Blob 设计，而不是扩展当前字段。
+
+## 3. Namespace Review
+
+目录/路径相关变更检查：
+
+- 同 parent name uniqueness 是否仍存在？
+- 名称是否经过 `ResourceNamePolicy`？
+- 路径是否通过 `ResourcePath` 计算？
+- move 是否禁止移动到自身/后代？
+- directory move 是否更新 descendants？
+- cross-storage move 是否仍明确拒绝？
+- Namespace Manager 是否绕过 Repository/Gateway 直接访问 DAO/StorageOperator？
+
+## 4. Content Review
+
+上传、替换、在线编辑检查：
+
+- `MultipartFile` 是否停在 Controller mapper/binary source boundary？
+- size/editable/content-type 约束是否由 Content Policy 统一处理？
+- SHA-256 是否仍是 checksum contract？
+- Content Manager 是否只通过 `ResourceStorageGateway` 读写 Storage？
+- Content Reader 是否保持无 mutation？
+- FILE/DIRECTORY capability 校验是否仍存在？
+
+## 5. Consistency Review
+
+### Create / Upload
+
+必须保持：
+
+```text
+Storage write -> Metadata insert
+Metadata failure -> best-effort Storage cleanup
+```
+
+### Move
+
+必须保持：
+
+```text
+Storage move -> Metadata/descendant update
+Metadata failure -> best-effort Storage rollback
+```
+
+### Delete
+
+必须保持：
+
+```text
+Metadata delete commit -> Storage delete afterCommit
+```
+
+不要在结构重构中擅自交换这些顺序。
+
+## 6. Storage Boundary Review
+
+检查 Namespace / Content：
+
+- 不允许 import `StorageOperator`；
+- 不允许直接 catch `StoragePluginException`；
+- 只能使用 `ResourceStorageGateway` / `ResourceStorageLifecycle`；
+- 新 Storage capability 应先扩展 Resource-owned Gateway，再由 Adapter 翻译到 SPI。
+
+检查 Registry：
+
+- duplicate type 是否仍失败；
+- default storage 是否有明确 resolution；
+- Reader 是否只返回 `ResourceStoragePlugin`，不泄漏 Operator。
+
+## 7. Resolution Review
+
+检查 `resolution`：
+
+- 是否只走 Namespace/Content read-side？
+- 是否绕过 read-side 直接访问 Repository/DAO？
+- revision fencing 是否存在？
+- stream copy 是否同步计算 SHA-256？
+- checksum mismatch 是否失败并清理 temp dir？
+- 失败路径是否 best-effort cleanup？
+- Resolution 是否意外产生 Resource mutation？
+
+## 8. Sync Review
+
+检查：
+
+- mutation 是否经 `ResourceChangeDispatcher`；
+- 是否在 transaction commit 后传播；
+- provider failure 是否只记录 warning/运行证据；
+- Sync Provider 是否试图成为 Resource Metadata owner；
+- Namespace/Content 是否直接依赖具体 Provider。
+
+## 9. Controller Review
+
+Controller 只做：
+
+- HTTP validation/annotation；
+- DTO -> Command/BinarySource mapping；
+- 调用明确的 Manager/Reader；
+- Domain -> VO mapping；
+- download stream -> response。
+
+Controller 不做：
+
+- Repository/DAO 查询；
+- StorageOperator 调用；
+- Path/revision 业务决策；
+- transaction choreography；
+- Sync provider 调度。
+
+HTTP Exception Advice 也属于 Controller boundary。
+
+## 10. Persistence Review
+
+- Repository contract 是否仍只暴露 Domain / shared `PageData`？
+- Repository Adapter 是否显式处理 Domain <-> PO translation？
+- DAO 是否没有 DTO/VO？
+- PO 是否没有进入业务子系统？
+- 新 SQL 是否真的需要 XML，而不是为了“分层完整”制造无价值抽象？
+- `yak_ops_resource` 与现有 Flyway history 是否未被结构重构误改？
+
+## 11. Package / Role Review
+
+看到新类时根据职责选择：
+
+| Role | Review question |
+|---|---|
+| Manager | 它是否真正拥有一个 mutation lifecycle？ |
+| Reader | 是否保持无副作用？ |
+| Resolver | 是否只做 reference/materialization resolution？ |
+| Policy | 是否只做约束/决策，不持有 mutable truth？ |
+| Gateway | 是否是 Resource-owned external capability Port？ |
+| Adapter | 是否只翻译边界模型？ |
+| Registry | 是否只管理已安装 capability？ |
+| Lifecycle | 是否只处理 compensation/afterCommit lifecycle？ |
+| Dispatcher | 是否只传播已完成变化？ |
+| Repository | 是否只表达 Domain persistence？ |
+
+出现 `Support/Helper/Utils/Common/Base/ServiceImpl` 时，应要求作者解释无法归类的真实原因。
+
+## 12. Compatibility Review
+
+Stage 2 / architecture-only PR 默认不得改变：
+
+- `/api/v1/resources/**`；
+- permission annotations/codes；
+- DTO/VO JSON；
+- `yak_ops_resource` schema；
+- Flyway baseline/history table；
+- StorageOperator SPI；
+- ResourceResolver / ResourceDownloadProvider / ResourceFileSyncProvider SPI；
+- upload/create/move/delete consistency order；
+- current revision semantics；
+- SHA-256 verification。
+
+## 13. Test Review
+
+至少检查：
+
+- focused behavior test；
+- `ResourceDependencyBoundaryTest`；
+- `ResourceLayeringConventionTest`；
+- `ResourceCodeStyleConventionTest`；
+- `ResourceRoleConventionTest`；
+- Controller contract test；
+- Domain revision/path tests；
+- Storage registry tests。
+
+架构测试失败时优先修设计，不要直接把 forbidden list 或 allowed matrix 放宽。
+
+## 14. Final Consistency Gate
+
+合并前确认以下五项表达同一套架构：
+
+```text
+Code
+  <-> REQUIREMENTS.md
+  <-> DOMAIN.md
+  <-> ARCHITECTURE.md
+  <-> DEPENDENCIES.md
+  <-> Executable Architecture Tests
+```
+
+任一处不一致都视为 Stage 2 未完成。

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourceExceptionHandler.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourceExceptionHandler.java
@@ -1,11 +1,11 @@
-package io.yak.ops.business.resource.exception;
+package io.yak.ops.business.resource.controller.v1;
 
 import io.yak.framework.common.ErrorCode;
 import io.yak.framework.common.Result;
 import io.yak.framework.security.common.enums.ResultCode;
 import io.yak.framework.security.exception.YakSecurityException;
 import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
-import io.yak.ops.business.resource.controller.v1.ResourcesController;
+import io.yak.ops.business.resource.exception.ResourceException;
 import io.yak.ops.common.enums.resource.ResourceErrorCode;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-/** 资源管理接口异常转换。 */
+/** Resource HTTP exception translation; business exceptions themselves remain in the exception package. */
 @Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice(basePackageClasses = ResourcesController.class)

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/domain/ResourceNode.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/domain/ResourceNode.java
@@ -3,10 +3,9 @@ package io.yak.ops.business.resource.domain;
 import io.yak.ops.common.enums.resource.ResourceNodeType;
 import io.yak.ops.common.enums.resource.ResourceStorageType;
 import java.time.LocalDateTime;
-import lombok.Data;
+import java.util.Objects;
 
-/** 资源目录或文件的业务领域对象，与 MyBatis PO 和 HTTP VO 解耦。 */
-@Data
+/** Resource directory/file metadata domain object, independent from persistence and HTTP models. */
 public class ResourceNode {
 
   private Long id;
@@ -25,4 +24,201 @@ public class ResourceNode {
   private String gitSyncStatus;
   private LocalDateTime createTime;
   private LocalDateTime updateTime;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getParentId() {
+    return parentId;
+  }
+
+  public void setParentId(Long parentId) {
+    this.parentId = parentId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getFullPath() {
+    return fullPath;
+  }
+
+  public void setFullPath(String fullPath) {
+    this.fullPath = fullPath;
+  }
+
+  public ResourceNodeType getNodeType() {
+    return nodeType;
+  }
+
+  public void setNodeType(ResourceNodeType nodeType) {
+    this.nodeType = nodeType;
+  }
+
+  public ResourceStorageType getStorageType() {
+    return storageType;
+  }
+
+  public void setStorageType(ResourceStorageType storageType) {
+    this.storageType = storageType;
+  }
+
+  public String getStoragePath() {
+    return storagePath;
+  }
+
+  public void setStoragePath(String storagePath) {
+    this.storagePath = storagePath;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public String getSuffix() {
+    return suffix;
+  }
+
+  public void setSuffix(String suffix) {
+    this.suffix = suffix;
+  }
+
+  public Long getFileSize() {
+    return fileSize;
+  }
+
+  public void setFileSize(Long fileSize) {
+    this.fileSize = fileSize;
+  }
+
+  public String getChecksum() {
+    return checksum;
+  }
+
+  public void setChecksum(String checksum) {
+    this.checksum = checksum;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Integer getVersion() {
+    return version;
+  }
+
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
+  public String getGitSyncStatus() {
+    return gitSyncStatus;
+  }
+
+  public void setGitSyncStatus(String gitSyncStatus) {
+    this.gitSyncStatus = gitSyncStatus;
+  }
+
+  public LocalDateTime getCreateTime() {
+    return createTime;
+  }
+
+  public void setCreateTime(LocalDateTime createTime) {
+    this.createTime = createTime;
+  }
+
+  public LocalDateTime getUpdateTime() {
+    return updateTime;
+  }
+
+  public void setUpdateTime(LocalDateTime updateTime) {
+    this.updateTime = updateTime;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (!(object instanceof ResourceNode other)) {
+      return false;
+    }
+    return Objects.equals(id, other.id)
+        && Objects.equals(parentId, other.parentId)
+        && Objects.equals(name, other.name)
+        && Objects.equals(fullPath, other.fullPath)
+        && nodeType == other.nodeType
+        && storageType == other.storageType
+        && Objects.equals(storagePath, other.storagePath)
+        && Objects.equals(contentType, other.contentType)
+        && Objects.equals(suffix, other.suffix)
+        && Objects.equals(fileSize, other.fileSize)
+        && Objects.equals(checksum, other.checksum)
+        && Objects.equals(description, other.description)
+        && Objects.equals(version, other.version)
+        && Objects.equals(gitSyncStatus, other.gitSyncStatus)
+        && Objects.equals(createTime, other.createTime)
+        && Objects.equals(updateTime, other.updateTime);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        parentId,
+        name,
+        fullPath,
+        nodeType,
+        storageType,
+        storagePath,
+        contentType,
+        suffix,
+        fileSize,
+        checksum,
+        description,
+        version,
+        gitSyncStatus,
+        createTime,
+        updateTime);
+  }
+
+  @Override
+  public String toString() {
+    return "ResourceNode{" +
+        "id=" + id +
+        ", parentId=" + parentId +
+        ", name='" + name + '\'' +
+        ", fullPath='" + fullPath + '\'' +
+        ", nodeType=" + nodeType +
+        ", storageType=" + storageType +
+        ", storagePath='" + storagePath + '\'' +
+        ", contentType='" + contentType + '\'' +
+        ", suffix='" + suffix + '\'' +
+        ", fileSize=" + fileSize +
+        ", checksum='" + checksum + '\'' +
+        ", description='" + description + '\'' +
+        ", version=" + version +
+        ", gitSyncStatus='" + gitSyncStatus + '\'' +
+        ", createTime=" + createTime +
+        ", updateTime=" + updateTime +
+        '}';
+  }
 }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/package-info.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/package-info.java
@@ -1,6 +1,9 @@
 /**
- * Business resource catalog, versions, references and lifecycle capabilities.
+ * Resource namespace, current revision metadata, content orchestration, storage routing, runtime
+ * resolution and post-commit change propagation.
  *
- * <p>Physical file storage is provided by {@code yak-framework}'s file abstraction.
+ * <p>The database owns Resource identity/namespace/current revision metadata. Physical bytes are
+ * owned by StorageOperator implementations and reached by Resource business roles only through the
+ * ResourceStorageGateway boundary.
  */
 package io.yak.ops.business.resource;

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
@@ -11,10 +11,9 @@ import io.yak.ops.common.bean.po.resource.ResourcePO;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Repository;
 
-/** MyBatis 持久化模型与资源领域模型之间的适配器。 */
+/** Explicit persistence adapter between Resource domain metadata and MyBatis persistence models. */
 @Repository
 @ConditionalOnResourceEnabled
 @RequiredArgsConstructor
@@ -42,7 +41,7 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
     if (resource == null) {
       return false;
     }
-    ResourcePO po = toPO(resource);
+    ResourcePO po = toPersistence(resource);
     boolean inserted = resourceDao.insert(po) > 0;
     if (inserted) {
       resource.setId(po.getId());
@@ -52,7 +51,7 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
 
   @Override
   public boolean update(ResourceNode resource) {
-    return resource != null && resourceDao.update(toPO(resource));
+    return resource != null && resourceDao.update(toPersistence(resource));
   }
 
   @Override
@@ -60,7 +59,7 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
     if (resources == null || resources.isEmpty()) {
       return true;
     }
-    return resourceDao.updateBatch(resources.stream().map(this::toPO).toList());
+    return resourceDao.updateBatch(resources.stream().map(this::toPersistence).toList());
   }
 
   @Override
@@ -108,13 +107,43 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
       return null;
     }
     ResourceNode domain = new ResourceNode();
-    BeanUtils.copyProperties(po, domain);
+    domain.setId(po.getId());
+    domain.setParentId(po.getParentId());
+    domain.setName(po.getName());
+    domain.setFullPath(po.getFullPath());
+    domain.setNodeType(po.getNodeType());
+    domain.setStorageType(po.getStorageType());
+    domain.setStoragePath(po.getStoragePath());
+    domain.setContentType(po.getContentType());
+    domain.setSuffix(po.getSuffix());
+    domain.setFileSize(po.getFileSize());
+    domain.setChecksum(po.getChecksum());
+    domain.setDescription(po.getDescription());
+    domain.setVersion(po.getVersion());
+    domain.setGitSyncStatus(po.getGitSyncStatus());
+    domain.setCreateTime(po.getCreateTime());
+    domain.setUpdateTime(po.getUpdateTime());
     return domain;
   }
 
-  ResourcePO toPO(ResourceNode domain) {
+  ResourcePO toPersistence(ResourceNode domain) {
     ResourcePO po = new ResourcePO();
-    BeanUtils.copyProperties(domain, po);
+    po.setId(domain.getId());
+    po.setParentId(domain.getParentId());
+    po.setName(domain.getName());
+    po.setFullPath(domain.getFullPath());
+    po.setNodeType(domain.getNodeType());
+    po.setStorageType(domain.getStorageType());
+    po.setStoragePath(domain.getStoragePath());
+    po.setContentType(domain.getContentType());
+    po.setSuffix(domain.getSuffix());
+    po.setFileSize(domain.getFileSize());
+    po.setChecksum(domain.getChecksum());
+    po.setDescription(domain.getDescription());
+    po.setVersion(domain.getVersion());
+    po.setGitSyncStatus(domain.getGitSyncStatus());
+    po.setCreateTime(domain.getCreateTime());
+    po.setUpdateTime(domain.getUpdateTime());
     return po;
   }
 }

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceArchitectureDocumentationTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceArchitectureDocumentationTest.java
@@ -1,0 +1,58 @@
+package io.yak.ops.business.resource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Keeps the permanent Resource architecture contract discoverable from the module README. */
+class ResourceArchitectureDocumentationTest {
+
+  private static final List<String> CONTRACT_DOCUMENTS =
+      List.of("REQUIREMENTS.md", "DOMAIN.md", "ARCHITECTURE.md", "DEPENDENCIES.md", "REVIEW.md");
+
+  @Test
+  void architectureContractDocumentsRemainPresentAndLinked() throws IOException {
+    Path module = moduleRoot();
+    String readme = Files.readString(module.resolve("README.md"), StandardCharsets.UTF_8);
+
+    for (String document : CONTRACT_DOCUMENTS) {
+      assertThat(Files.isRegularFile(module.resolve(document)))
+          .as("Resource architecture contract %s must exist", document)
+          .isTrue();
+      assertThat(readme)
+          .as("README must link Resource architecture contract %s", document)
+          .contains("./" + document);
+    }
+  }
+
+  @Test
+  void dependencyDocumentNamesExecutableGuards() throws IOException {
+    String dependencies = Files.readString(
+        moduleRoot().resolve("DEPENDENCIES.md"), StandardCharsets.UTF_8);
+    assertThat(dependencies)
+        .contains(
+            "ResourceDependencyBoundaryTest",
+            "ResourceStorageGateway",
+            "ResourceChangeDispatcher");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isRegularFile(local.resolve("README.md"))
+        && Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/resource"))) {
+      return local;
+    }
+    Path repositoryRelative = Path.of("yak-ops-business", "yak-ops-business-resource")
+        .toAbsolutePath()
+        .normalize();
+    assertThat(Files.isDirectory(repositoryRelative))
+        .as("Unable to locate Resource module root from %s", local)
+        .isTrue();
+    return repositoryRelative;
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceCodeStyleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceCodeStyleConventionTest.java
@@ -1,0 +1,151 @@
+package io.yak.ops.business.resource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Enforces repository-wide code-style rules that are architecture-significant for Resource. */
+class ResourceCodeStyleConventionTest {
+
+  private static final Pattern WILDCARD_IMPORT =
+      Pattern.compile("(?m)^import\\s+(?:static\\s+)?[^;]+\\*;");
+  private static final Pattern FIELD_INJECTION = Pattern.compile(
+      "(?m)@(Autowired|Resource|Inject)\\s*\\R\\s*"
+          + "(?:private|protected|public)\\s+[^\\n(]+;");
+  private static final Pattern SERVICE_STEREOTYPE =
+      Pattern.compile("(?m)^import\\s+org\\.springframework\\.stereotype\\.Service;|@Service\\b");
+
+  @Test
+  void productionSourceFollowsRepositoryCodeStyle() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = normalize(root.relativize(file));
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(WILDCARD_IMPORT.matcher(source).find())
+            .as("%s must not use wildcard imports", relative)
+            .isFalse();
+        assertThat(FIELD_INJECTION.matcher(source).find())
+            .as("%s must use constructor injection", relative)
+            .isFalse();
+        assertThat(source)
+            .as("%s must not use low-signal implementation shortcuts", relative)
+            .doesNotContain("System.out.", "System.err.", "BeanUtils.copyProperties");
+      }
+    }
+  }
+
+  @Test
+  void resourceDoesNotUseGenericServiceStereotype() throws IOException {
+    try (Stream<Path> files = Files.walk(productionRoot())) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(SERVICE_STEREOTYPE.matcher(source).find())
+            .as("Resource roles use explicit package/class vocabulary instead of @Service: %s", file)
+            .isFalse();
+      }
+    }
+  }
+
+  @Test
+  void coreDomainRemainsFrameworkAndTransportFree() throws IOException {
+    Path domain = productionRoot().resolve("domain");
+    try (Stream<Path> files = Files.walk(domain)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(source)
+            .as("Resource Domain must remain transport/framework free: %s", file)
+            .doesNotContain(
+                "org.springframework.",
+                "com.baomidou.mybatisplus.",
+                "jakarta.servlet.",
+                "io.yak.ops.common.bean.dto.",
+                "io.yak.ops.common.bean.vo.",
+                "io.yak.ops.common.bean.po.",
+                "io.yak.ops.spi.storage.StorageOperator",
+                "lombok.Data",
+                "@Data");
+      }
+    }
+  }
+
+  @Test
+  void storageOperatorOnlyAppearsInsideStorageBoundary() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Path relative = root.relativize(file);
+        if (relative.getNameCount() > 0 && relative.getName(0).toString().equals("storage")) {
+          continue;
+        }
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(source)
+            .as("StorageOperator SPI may only be translated in Resource storage boundary: %s", relative)
+            .doesNotContain(
+                "io.yak.ops.spi.storage.StorageOperator",
+                "io.yak.ops.spi.storage.StoragePluginException");
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() {
+    Path root = productionRoot();
+    for (String forbidden :
+        List.of("service", "common", "helper", "utils", "util", "base", "persistence")) {
+      assertThat(Files.exists(root.resolve(forbidden)))
+          .as("Broad Resource business bucket '%s' must not exist", forbidden)
+          .isFalse();
+    }
+  }
+
+  @Test
+  void repositoryUsesSingleRootCodeStyleDocument() throws IOException {
+    Path module = moduleRoot();
+    Path repository = module.getParent().getParent();
+    assertThat(Files.isRegularFile(repository.resolve("CODE_STYLE.md")))
+        .as("Yak Ops root CODE_STYLE.md must exist")
+        .isTrue();
+    assertThat(Files.exists(module.resolve("CODE_STYLE.md")))
+        .as("Resource must not maintain a module-local CODE_STYLE.md")
+        .isFalse();
+
+    long count;
+    try (Stream<Path> paths = Files.walk(repository, 6)) {
+      count = paths.filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().equals("CODE_STYLE.md"))
+          .count();
+    }
+    assertThat(count).as("Yak Ops must keep one repository-wide CODE_STYLE.md").isEqualTo(1L);
+  }
+
+  private Path productionRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/resource");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/resource"))) {
+      return local;
+    }
+    Path repositoryRelative = Path.of("yak-ops-business", "yak-ops-business-resource")
+        .toAbsolutePath()
+        .normalize();
+    assertThat(Files.isDirectory(
+            repositoryRelative.resolve("src/main/java/io/yak/ops/business/resource")))
+        .as("Unable to locate Resource module root from %s", local)
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace(java.io.File.separatorChar, '/');
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceDependencyBoundaryTest.java
@@ -1,0 +1,276 @@
+package io.yak.ops.business.resource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Source-level guard for Resource subsystem direction and narrow integration corridors. */
+class ResourceDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.resource";
+  private static final Pattern RESOURCE_IMPORT = Pattern.compile(
+      "(?m)^import\\s+(?:static\\s+)?("
+          + Pattern.quote(BASE)
+          + "\\.([A-Za-z0-9_]+)\\.[^;]+);");
+
+  private static final Map<String, Set<String>> ALLOWED_TOP_LEVEL_DEPENDENCIES =
+      Map.ofEntries(
+          Map.entry(
+              "controller",
+              Set.of("config", "content", "domain", "exception", "namespace", "storage")),
+          Map.entry("resolution", Set.of("config", "content", "domain", "namespace")),
+          Map.entry(
+              "content",
+              Set.of("config", "domain", "exception", "namespace", "repository", "storage", "sync")),
+          Map.entry(
+              "namespace",
+              Set.of("config", "domain", "exception", "repository", "storage", "sync")),
+          Map.entry("storage", Set.of("config", "domain", "exception")),
+          Map.entry("sync", Set.of("config", "domain")),
+          Map.entry("repository", Set.of("config", "dao", "domain")),
+          Map.entry("domain", Set.of()),
+          Map.entry("exception", Set.of()),
+          Map.entry("dao", Set.of()),
+          Map.entry("config", Set.of()));
+
+  @Test
+  void topLevelPackagesFollowDeclaredDependencyGraph() throws IOException {
+    for (Dependency dependency : resourceDependencies()) {
+      Set<String> allowed =
+          ALLOWED_TOP_LEVEL_DEPENDENCIES.getOrDefault(dependency.sourcePackage(), Set.of());
+      assertThat(allowed)
+          .as("%s imports %s", dependency.relativePath(), dependency.importedType())
+          .contains(dependency.targetPackage());
+    }
+  }
+
+  @Test
+  void declaredAndActualGraphsRemainAcyclic() throws IOException {
+    assertAcyclic(ALLOWED_TOP_LEVEL_DEPENDENCIES, "declared Resource dependency graph");
+
+    Map<String, Set<String>> actual = new HashMap<>();
+    ALLOWED_TOP_LEVEL_DEPENDENCIES.keySet()
+        .forEach(key -> actual.put(key, new HashSet<>()));
+    for (Dependency dependency : resourceDependencies()) {
+      actual.computeIfAbsent(dependency.sourcePackage(), ignored -> new HashSet<>())
+          .add(dependency.targetPackage());
+    }
+    assertAcyclic(actual, "actual Resource import graph");
+  }
+
+  @Test
+  void contentOnlyUsesNarrowNamespaceRoles() throws IOException {
+    assertExactCorridor(
+        "content",
+        "namespace",
+        Set.of(
+            BASE + ".namespace.ResourceNamePolicy",
+            BASE + ".namespace.ResourceNamespaceReader",
+            BASE + ".namespace.ResourceParentResolver"));
+  }
+
+  @Test
+  void businessStorageCorridorsStayResourceOwned() throws IOException {
+    Set<String> businessStorageTypes = Set.of(
+        BASE + ".storage.ResourceStorageGateway",
+        BASE + ".storage.ResourceStorageLifecycle");
+    assertExactCorridor("namespace", "storage", businessStorageTypes);
+    assertExactCorridor("content", "storage", businessStorageTypes);
+    assertExactCorridor(
+        "controller",
+        "storage",
+        Set.of(BASE + ".storage.ResourceStorageReader"));
+  }
+
+  @Test
+  void resourceMutationOnlyReachesSyncThroughDispatcher() throws IOException {
+    Set<String> dispatcher = Set.of(BASE + ".sync.ResourceChangeDispatcher");
+    assertExactCorridor("namespace", "sync", dispatcher);
+    assertExactCorridor("content", "sync", dispatcher);
+  }
+
+  @Test
+  void resolutionOnlyUsesResourceReadSide() throws IOException {
+    assertExactCorridor(
+        "resolution",
+        "content",
+        Set.of(BASE + ".content.ResourceContentReader"));
+    assertExactCorridor(
+        "resolution",
+        "namespace",
+        Set.of(BASE + ".namespace.ResourceNamespaceReader"));
+
+    for (Dependency dependency : resourceDependencies()) {
+      if (!dependency.sourcePackage().equals("resolution")) {
+        continue;
+      }
+      assertThat(dependency.targetPackage())
+          .as("Resolution is a consumer adapter: %s", dependency)
+          .isNotIn("dao", "repository", "storage", "sync");
+      assertThat(dependency.importedType())
+          .doesNotContain("ResourceNamespaceManager", "ResourceContentManager");
+    }
+  }
+
+  @Test
+  void controllerNeverEntersPersistenceStorageOrSyncInternals() throws IOException {
+    for (Dependency dependency : resourceDependencies()) {
+      if (!dependency.sourcePackage().equals("controller")) {
+        continue;
+      }
+      assertThat(dependency.targetPackage())
+          .as("Controller boundary: %s", dependency)
+          .isNotIn("dao", "repository", "resolution", "sync");
+      assertThat(dependency.importedType())
+          .doesNotContain(
+              "ResourceStorageGateway",
+              "ResourceStorageRegistry",
+              "StorageOperatorGatewayAdapter");
+    }
+  }
+
+  @Test
+  void lowerPackagesNeverPointBackToApplicationRoles() throws IOException {
+    for (Dependency dependency : resourceDependencies()) {
+      if (Set.of("domain", "exception", "dao", "config")
+          .contains(dependency.sourcePackage())) {
+        throw new AssertionError(
+            "Bottom Resource package must not import application package: " + dependency);
+      }
+      if (dependency.sourcePackage().equals("repository")) {
+        assertThat(dependency.targetPackage())
+            .as("Repository must remain below business roles: %s", dependency)
+            .isIn("config", "dao", "domain");
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() {
+    Path root = productionRoot();
+    for (String forbidden :
+        Set.of("service", "common", "helper", "utils", "util", "base", "persistence")) {
+      assertThat(Files.exists(root.resolve(forbidden)))
+          .as("Broad Resource business bucket '%s' must not exist", forbidden)
+          .isFalse();
+    }
+  }
+
+  private void assertExactCorridor(String source, String target, Set<String> allowedTypes)
+      throws IOException {
+    for (Dependency dependency : resourceDependencies()) {
+      if (!dependency.sourcePackage().equals(source)
+          || !dependency.targetPackage().equals(target)) {
+        continue;
+      }
+      assertThat(allowedTypes)
+          .as("Unexpected %s -> %s corridor in %s", source, target, dependency.relativePath())
+          .contains(dependency.importedType());
+    }
+  }
+
+  private void assertAcyclic(Map<String, Set<String>> graph, String label) {
+    Set<String> nodes = new HashSet<>(graph.keySet());
+    graph.values().forEach(nodes::addAll);
+    Map<String, Integer> indegree = new HashMap<>();
+    Map<String, Set<String>> reverse = new HashMap<>();
+    nodes.forEach(node -> indegree.put(node, 0));
+
+    for (Map.Entry<String, Set<String>> entry : graph.entrySet()) {
+      for (String target : entry.getValue()) {
+        indegree.compute(entry.getKey(), (ignored, value) -> value + 1);
+        reverse.computeIfAbsent(target, ignored -> new HashSet<>()).add(entry.getKey());
+      }
+    }
+
+    ArrayDeque<String> ready = new ArrayDeque<>();
+    indegree.forEach((node, degree) -> {
+      if (degree == 0) {
+        ready.add(node);
+      }
+    });
+
+    int visited = 0;
+    while (!ready.isEmpty()) {
+      String node = ready.removeFirst();
+      visited++;
+      for (String dependent : reverse.getOrDefault(node, Set.of())) {
+        int degree = indegree.compute(dependent, (ignored, value) -> value - 1);
+        if (degree == 0) {
+          ready.add(dependent);
+        }
+      }
+    }
+    assertThat(visited).as("%s must remain acyclic", label).isEqualTo(nodes.size());
+  }
+
+  private List<Dependency> resourceDependencies() throws IOException {
+    Path root = productionRoot();
+    List<Dependency> result = new ArrayList<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Path relative = root.relativize(file);
+        if (relative.getNameCount() < 2) {
+          continue;
+        }
+        String sourcePackage = relative.getName(0).toString();
+        Matcher matcher = RESOURCE_IMPORT.matcher(Files.readString(file, StandardCharsets.UTF_8));
+        while (matcher.find()) {
+          String importedType = matcher.group(1);
+          String targetPackage = matcher.group(2);
+          if (!sourcePackage.equals(targetPackage)) {
+            result.add(new Dependency(
+                sourcePackage,
+                targetPackage,
+                importedType,
+                normalize(relative)));
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private Path productionRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/resource");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/resource"))) {
+      return local;
+    }
+    Path repositoryRelative = Path.of("yak-ops-business", "yak-ops-business-resource")
+        .toAbsolutePath()
+        .normalize();
+    assertThat(Files.isDirectory(
+            repositoryRelative.resolve("src/main/java/io/yak/ops/business/resource")))
+        .as("Unable to locate Resource module root from %s", local)
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace(java.io.File.separatorChar, '/');
+  }
+
+  private record Dependency(
+      String sourcePackage,
+      String targetPackage,
+      String importedType,
+      String relativePath) {}
+}

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceLayeringConventionTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baomidou.mybatisplus.annotation.TableName;
 import io.yak.framework.common.PageData;
+import io.yak.ops.business.resource.content.ResourceBinarySource;
 import io.yak.ops.business.resource.content.ResourceContentManager;
+import io.yak.ops.business.resource.controller.v1.ResourceExceptionHandler;
 import io.yak.ops.business.resource.controller.v1.ResourcesController;
 import io.yak.ops.business.resource.dao.ResourceDao;
 import io.yak.ops.business.resource.domain.ResourceQuery;
@@ -63,7 +65,7 @@ class ResourceLayeringConventionTest {
   }
 
   @Test
-  void namespaceAndContentDoNotInjectDaoPoOrHttpModels() {
+  void namespaceAndContentDoNotInjectDaoPoHttpOrStorageOperator() {
     for (Class<?> type : List.of(ResourceNamespaceManager.class, ResourceContentManager.class)) {
       for (Field field : type.getDeclaredFields()) {
         String fieldType = field.getGenericType().getTypeName();
@@ -91,6 +93,17 @@ class ResourceLayeringConventionTest {
   }
 
   @Test
+  void multipartFileStopsAtHttpRequestMapperBoundary() {
+    for (Method method : ResourceBinarySource.class.getDeclaredMethods()) {
+      String signature = method.getGenericReturnType().getTypeName();
+      for (Type parameter : method.getGenericParameterTypes()) {
+        signature += "|" + parameter.getTypeName();
+      }
+      assertThat(signature).doesNotContain("org.springframework.web.multipart.MultipartFile");
+    }
+  }
+
+  @Test
   void resourceStorageGatewayDoesNotExposeStorageOperator() {
     for (Method method : ResourceStorageGateway.class.getDeclaredMethods()) {
       String signature = method.getGenericReturnType().getTypeName();
@@ -102,10 +115,18 @@ class ResourceLayeringConventionTest {
   }
 
   @Test
-  void broadServiceAndUtilBucketsAreRemoved() {
+  void httpExceptionAdviceLivesAtControllerBoundary() {
+    assertThat(ResourceExceptionHandler.class.getPackageName())
+        .startsWith("io.yak.ops.business.resource.controller.");
+  }
+
+  @Test
+  void broadBusinessBucketsAreRemoved() {
     Path root = moduleRoot().resolve("src/main/java/io/yak/ops/business/resource");
-    assertThat(Files.exists(root.resolve("service"))).isFalse();
-    assertThat(Files.exists(root.resolve("util"))).isFalse();
+    for (String forbidden :
+        List.of("service", "common", "helper", "utils", "util", "base", "persistence")) {
+      assertThat(Files.exists(root.resolve(forbidden))).isFalse();
+    }
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceRoleConventionTest.java
@@ -1,0 +1,79 @@
+package io.yak.ops.business.resource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.resource.content.ResourceChecksum;
+import io.yak.ops.business.resource.content.ResourceContentManager;
+import io.yak.ops.business.resource.content.ResourceContentPolicy;
+import io.yak.ops.business.resource.content.ResourceContentReader;
+import io.yak.ops.business.resource.controller.v1.ResourceExceptionHandler;
+import io.yak.ops.business.resource.controller.v1.ResourcesController;
+import io.yak.ops.business.resource.controller.v1.mapper.ResourceRequestMapper;
+import io.yak.ops.business.resource.controller.v1.mapper.ResourceViewMapper;
+import io.yak.ops.business.resource.namespace.ResourceNamePolicy;
+import io.yak.ops.business.resource.namespace.ResourceNamespaceManager;
+import io.yak.ops.business.resource.namespace.ResourceNamespaceReader;
+import io.yak.ops.business.resource.namespace.ResourceParentResolver;
+import io.yak.ops.business.resource.namespace.ResourceTreeReader;
+import io.yak.ops.business.resource.repository.ResourceRepositoryAdapter;
+import io.yak.ops.business.resource.resolution.ResourceDownloadProviderAdapter;
+import io.yak.ops.business.resource.resolution.ResourceResolverAdapter;
+import io.yak.ops.business.resource.storage.ResourceStorageLifecycle;
+import io.yak.ops.business.resource.storage.ResourceStorageReader;
+import io.yak.ops.business.resource.storage.ResourceStorageRegistry;
+import io.yak.ops.business.resource.storage.StorageOperatorGatewayAdapter;
+import io.yak.ops.business.resource.sync.ResourceChangeDispatcher;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+class ResourceRoleConventionTest {
+
+  @Test
+  void businessRolesRemainExplicitComponentsInsteadOfGenericServices() {
+    for (Class<?> role : List.of(
+        ResourceNamespaceManager.class,
+        ResourceNamespaceReader.class,
+        ResourceTreeReader.class,
+        ResourceParentResolver.class,
+        ResourceNamePolicy.class,
+        ResourceContentManager.class,
+        ResourceContentReader.class,
+        ResourceContentPolicy.class,
+        ResourceChecksum.class,
+        ResourceStorageLifecycle.class,
+        ResourceStorageReader.class,
+        ResourceStorageRegistry.class,
+        StorageOperatorGatewayAdapter.class,
+        ResourceDownloadProviderAdapter.class,
+        ResourceResolverAdapter.class,
+        ResourceChangeDispatcher.class,
+        ResourceRequestMapper.class,
+        ResourceViewMapper.class)) {
+      assertThat(role.getAnnotation(Component.class))
+          .as("%s must remain an explicit Resource component role", role.getSimpleName())
+          .isNotNull();
+      assertThat(role.getAnnotation(Service.class))
+          .as("%s must not collapse back into a generic @Service layer", role.getSimpleName())
+          .isNull();
+    }
+  }
+
+  @Test
+  void persistenceAdapterRemainsRepositoryRole() {
+    assertThat(ResourceRepositoryAdapter.class.getAnnotation(Repository.class)).isNotNull();
+    assertThat(ResourceRepositoryAdapter.class.getAnnotation(Service.class)).isNull();
+  }
+
+  @Test
+  void httpRolesRemainAtControllerBoundary() {
+    assertThat(ResourcesController.class.getAnnotation(RestController.class)).isNotNull();
+    assertThat(ResourceExceptionHandler.class.getAnnotation(RestControllerAdvice.class)).isNotNull();
+    assertThat(ResourceExceptionHandler.class.getPackageName())
+        .startsWith("io.yak.ops.business.resource.controller.");
+  }
+}


### PR DESCRIPTION
## Summary

Complete Resource Stage 2 architecture governance after the domain-oriented Stage 1 refactor in #700.

Stage 1 established the `namespace / content / storage / resolution / sync / repository / dao / domain` package shape. This PR turns that shape into a permanent architecture contract: requirements, truth ownership, dependency direction, review vocabulary and executable guards. It also closes the remaining HTTP/domain package cycle and removes a couple of implementation shortcuts that would undermine the new boundaries.

## What this PR completes

### 1. Permanent Resource contracts

Adds:

- `REQUIREMENTS.md`
- `DOMAIN.md`
- `ARCHITECTURE.md`
- `DEPENDENCIES.md`
- `REVIEW.md`
- README read-first links and role vocabulary

The documents explicitly define:

```text
Database / ResourceRepository
    owns Resource identity / namespace / current revision metadata

Storage Plugin
    owns physical bytes

Resolution
    owns temporary materialization only

Resource Sync
    owns external propagation only
```

`Resource.version` remains a **current revision / fencing value**, not a historical version store. A resource at `version = 5` does not imply versions 1-4 remain downloadable.

### 2. Close the remaining package cycle

The HTTP `ResourceExceptionHandler` previously lived under `resource.exception` while importing `ResourcesController`, creating an `exception -> controller` edge even though Controller also depends on Resource business exceptions.

This PR moves the HTTP advice to:

```text
controller/v1/ResourceExceptionHandler
```

The business `ResourceException` remains in `resource.exception`. Handler behavior and HTTP contract are unchanged.

### 3. Keep Domain and persistence boundaries explicit

`ResourceNode` no longer relies on Lombok `@Data`; the domain object now exposes its Java contract explicitly without framework/transport annotations.

`ResourceRepositoryAdapter` no longer uses `BeanUtils.copyProperties`. Domain <-> `ResourcePO` translation is explicit field mapping owned by the persistence adapter.

No table, DAO contract or Resource business behavior changes are intended.

### 4. Executable dependency governance

Adds `ResourceDependencyBoundaryTest` to lock:

- declared top-level dependency matrix
- actual Resource package graph must remain acyclic
- `content -> namespace` only through `ResourceNamespaceReader`, `ResourceParentResolver`, `ResourceNamePolicy`
- `namespace/content -> storage` only through `ResourceStorageGateway` / `ResourceStorageLifecycle`
- `namespace/content -> sync` only through `ResourceChangeDispatcher`
- Resolution only enters Resource through read-side roles
- Controller cannot enter Repository / DAO / Storage internals
- lower packages cannot point back to application roles
- `service/common/helper/utils/util/base/persistence` buckets cannot return

### 5. Layering, role and code-style guards

Adds/strengthens:

- `ResourceLayeringConventionTest`
- `ResourceCodeStyleConventionTest`
- `ResourceRoleConventionTest`
- `ResourceArchitectureDocumentationTest`

They protect:

- Repository contract stays Domain-only
- DAO stays HTTP-model-free
- `MultipartFile` stops at the HTTP request mapper / `ResourceBinarySource` boundary
- `StorageOperator` SPI is translated only inside `storage`
- Resource Domain stays Spring/MyBatis/HTTP/PO free
- Resource roles remain explicit `Manager / Reader / Policy / Resolver / Gateway / Adapter / Registry / Lifecycle / Dispatcher` components instead of rebuilding a generic `@Service` layer
- HTTP exception advice stays in Controller boundary
- module docs remain present and linked from README
- repository-wide `CODE_STYLE.md` remains the single style source

## Behavior intentionally unchanged

This remains architecture governance, not a feature rewrite. It keeps:

- `/api/v1/resources/**` paths and permissions
- current DTO / VO JSON contracts
- `yak_ops_resource` schema and Resource Flyway history
- Local / MinIO / HDFS `StorageOperator` SPI
- `ResourceResolver`, `ResourceDownloadProvider`, `ResourceFileSyncProvider` SPI contracts
- create/upload ordering: Storage first, Metadata second, cleanup compensation on metadata failure
- move ordering: Storage move first, Metadata/descendant update second, rollback attempt on metadata failure
- cross-storage move unsupported
- delete ordering: Metadata commit first, Storage delete after commit
- Resource Sync after-commit best-effort semantics
- current revision increment/fencing semantics
- SHA-256 checksum and resolver verification semantics

## Final architecture direction

```text
Controller
   -> Namespace / Content / Storage Read Side

Namespace / Content
   -> Domain
   -> ResourceRepository -> DAO
   -> ResourceStorageGateway -> StorageOperator SPI
   -> ResourceChangeDispatcher -> ResourceFileSyncProvider SPI

ResourceResolver SPI
   -> Resolution Adapter
   -> Namespace / Content Read Side
```

## Validation note

The branch is rebased on the latest `main` and squashed to one targeted commit.

A full Maven run is **not claimed from the current tool environment** because the normal private Yak Framework build dependency path is unavailable here. The authoritative verification should run in the normal project environment, for example:

```bash
mvn -pl yak-ops-business/yak-ops-business-resource -am test
```
