### PR TITLE
refactor(analysis): establish stage 2 architecture governance

### DIFF
--- a/yak-ops-business/yak-ops-business-analysis/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-analysis/ARCHITECTURE.md
@@ -1,0 +1,184 @@
+# Analysis Architecture
+
+## 1. Purpose
+
+Analysis 是 reusable analytical definition control plane，不是 query execution runtime。
+
+架构目标：让 Definition、Query Semantics、Visualization、Dataset Binding、Reference、Lineage Projection 和 Persistence 各自拥有明确角色。
+
+## 2. Package Map
+
+```text
+io.yak.ops.business.analysis
+├── AnalysisService
+├── AnalysisReferenceService
+├── AnalysisDeletionGuard
+├── controller/v1
+│   ├── dto
+│   ├── vo
+│   └── mapper
+├── definition
+├── domain
+├── query
+├── visualization
+├── reference
+├── lineage
+├── gateway
+│   ├── dataset
+│   └── lineage
+├── repository
+│   └── codec
+├── dao
+└── config
+```
+
+根 package 的三个 public type 是稳定兼容边界。新的实现角色必须进入明确 subsystem。
+
+## 3. Stable Facades
+
+### AnalysisService
+
+保留给 HTTP 与已有 application caller：
+
+```text
+AnalysisService
+    -> AnalysisManager
+    -> AnalysisReader
+```
+
+它不拥有另一套 lifecycle，不直接依赖 Repository/DAO/Dataset/Lineage。
+
+### AnalysisReferenceService
+
+提供下游模块最小引用能力：
+
+```text
+requireExists(analysisId)
+```
+
+Dashboard 不需要通过完整 AnalysisService 获取内部定义来做引用校验。
+
+### AnalysisDeletionGuard
+
+稳定 cross-domain extension point。Dashboard 等 owner 可以阻止删除仍被引用的 Analysis。
+
+## 4. Definition
+
+`definition` 拥有当前 Analysis command/read lifecycle：
+
+```text
+AnalysisManager
+AnalysisReader
+AnalysisDefinitionNormalizer
+AnalysisSaveCommand
+AnalysisChangedEvent
+```
+
+Create/update 流程：
+
+```text
+validate command
+    -> normalize query
+    -> normalize visual config
+    -> validate Dataset binding
+    -> persist current definition
+    -> publish AnalysisChangedEvent
+```
+
+Delete 流程：
+
+```text
+require current Analysis
+    -> deletion guards
+    -> delete metadata
+    -> publish deleted fact
+```
+
+## 5. Query And Visualization
+
+`query` 只表达 declarative analysis semantics 和标准化角色。
+
+```text
+AnalysisQueryNormalizer
+    -> AnalysisChartBindingPolicy
+```
+
+`visualization` 拥有 chart type、chart binding constraint 和 chart-local visual defaults。
+
+没有 Analysis Runtime/Engine package；真正查询 Dataset 的能力不在本模块。
+
+## 6. Dataset Boundary
+
+Analysis-owned Port：
+
+```text
+AnalysisDatasetGateway
+```
+
+Adapter：
+
+```text
+DatasetAnalysisAdapter
+    -> DatasetBindingPolicy
+```
+
+只有 adapter 可以理解 Dataset 模块的具体 API。Definition 只依赖自己的 Gateway。
+
+## 7. Reference Boundary
+
+```text
+AnalysisReferenceService
+    -> AnalysisReferenceReader
+    -> AnalysisReader
+```
+
+Reference 是窄 read-side，不产生 mutation。
+
+## 8. Lineage Projection
+
+```text
+AnalysisChangedEvent
+    -> AnalysisLineageRefreshListener   (AFTER_COMMIT)
+    -> AnalysisLineageSynchronizer      (REQUIRES_NEW)
+    -> AnalysisLineageGraphGateway
+    -> LineageAnalysisAdapter
+    -> shared Lineage module
+```
+
+`AnalysisFieldUsageExtractor` 负责把 QuerySpec 转成稳定 usage evidence。
+
+Synchronizer 只依赖 Analysis-owned gateway，不依赖 LineageService、LineageMaintenanceService、LineageAsset 或 ObjectMapper。
+
+## 9. Persistence
+
+```text
+Definition / Reader
+    -> AnalysisRepository
+    -> AnalysisRepositoryAdapter
+    -> AnalysisDao
+    -> AnalysisMapper / AnalysisPO
+    -> MySQL
+```
+
+`AnalysisJsonCodec` 位于 `repository/codec`，负责 JSON column representation。
+
+Application/Domain 不读取或写入 `query_spec_json` / `visual_config_json` 字符串。
+
+## 10. Infrastructure Dependency
+
+Analysis 复用业务 DataSource 与 `ConditionalOnDataSourceEnabled` 等基础设施 wiring；这不表示 Analysis 拥有 Datasource 业务领域。
+
+`AnalysisPersistenceConfiguration` 当前仍依赖 Dataset Flyway 初始化顺序，这是部署/初始化约束，不是 Dataset truth ownership。
+
+## 11. Stereotypes
+
+- `@Service`：仅稳定 `AnalysisService` / `AnalysisReferenceService`；
+- `@Component`：Manager、Reader、Normalizer、Policy、Collector、Extractor、Synchronizer、Gateway Adapter、Codec、HTTP Mapper；
+- `@Repository`：Repository/DAO persistence adapter；
+- Domain/value object：不使用 Spring stereotype。
+
+## 12. Compatibility Rule
+
+架构重构默认保持 REST、DB、Dataset binding、Dashboard reference、Lineage evidence 和 query semantic 行为。
+
+如果要新增 Analysis Version、Execution 或 Runtime，必须作为独立领域设计，而不是扩张现有 Manager/Normalizer。

--- a/yak-ops-business/yak-ops-business-analysis/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-analysis/DEPENDENCIES.md
@@ -1,0 +1,177 @@
+# Analysis Dependencies
+
+本文定义 Analysis production package 的允许依赖方向。根 package 的 `AnalysisService / AnalysisReferenceService / AnalysisDeletionGuard` 是兼容 API，不作为内部 subsystem bucket。
+
+## 1. Top-level Matrix
+
+| Source | Allowed Analysis packages |
+|---|---|
+| `controller` | `domain`, `query`, `visualization` + root stable facade |
+| `definition` | `domain`, `gateway`, `query`, `repository`, `visualization` + root deletion extension point |
+| `domain` | `query`, `visualization` |
+| `query` | `visualization` |
+| `visualization` | none |
+| `reference` | `definition` |
+| `lineage` | `definition`, `domain`, `gateway`, `query` |
+| `gateway` | none inside Analysis |
+| `repository` | `dao`, `domain`, `query`, `visualization` |
+| `dao` | none above persistence |
+| `config` | none inside Analysis |
+
+目标图必须保持无环。
+
+## 2. Primary Direction
+
+```text
+Controller
+    -> stable facade
+    -> Definition
+    -> Repository
+    -> DAO
+
+Definition
+    -> Query / Visualization
+    -> AnalysisDatasetGateway
+
+Lineage
+    -> Definition read/change facts
+    -> AnalysisLineageGraphGateway
+```
+
+低层不能反向进入 Controller/Manager。
+
+## 3. Dataset Corridor
+
+唯一业务 corridor：
+
+```text
+AnalysisDefinitionNormalizer
+    -> AnalysisDatasetGateway
+    -> DatasetAnalysisAdapter
+    -> DatasetBindingPolicy
+```
+
+禁止 Definition/Query/Controller/Repository 直接依赖：
+
+```text
+DatasetService
+DatasetRepository
+DatasetDao
+Dataset internal implementation
+```
+
+Dataset adapter 可以依赖 Dataset owner 暴露的稳定 binding capability。
+
+## 4. Lineage Corridor
+
+唯一业务 corridor：
+
+```text
+AnalysisLineageSynchronizer
+    -> AnalysisLineageGraphGateway
+    -> LineageAnalysisAdapter
+    -> Lineage module
+```
+
+禁止 Synchronizer/Definition/Controller 直接依赖：
+
+```text
+LineageService
+LineageMaintenanceService
+LineageAsset
+Lineage mapper/repository
+```
+
+Lineage adapter 是共享 Lineage model/protocol 转换边界。
+
+## 5. Query / Visualization Direction
+
+```text
+query -> visualization
+visualization -> nothing above
+```
+
+`AnalysisQueryNormalizer` 可以调用 `AnalysisChartBindingPolicy`，但 Visualization 不应反向依赖 Query。
+
+Semantic value object 不依赖 Spring、MyBatis、HTTP DTO/VO 或 persistence model。
+
+## 6. Reference Direction
+
+```text
+AnalysisReferenceService
+    -> reference.AnalysisReferenceReader
+    -> definition.AnalysisReader
+```
+
+Reference read-side 不依赖 Manager，也不拥有 mutation。
+
+## 7. Persistence Direction
+
+```text
+AnalysisRepository (Domain contract)
+    <- Definition / Reader
+
+AnalysisRepositoryAdapter
+    -> DAO
+    -> PO / Mapper
+```
+
+Repository contract 不允许出现：
+
+```text
+controller DTO / VO
+AnalysisPO
+Mapper
+MyBatis type
+JSON storage string as business contract
+```
+
+`AnalysisJsonCodec` 只能属于 persistence boundary。
+
+## 8. Controller Boundary
+
+Controller 与 HTTP Mapper 不直接进入：
+
+```text
+repository
+dao
+gateway adapter
+lineage synchronizer
+Dataset / Lineage implementation
+```
+
+Controller 通过 root stable `AnalysisService` 进入 use-case。
+
+## 9. Datasource Infrastructure
+
+Analysis POM 当前直接依赖 `yak-ops-business-datasource`，因为 config / DAO / repository adapter 复用业务 DataSource enablement 与 wiring。
+
+这条依赖只属于 infrastructure；不得扩散为 Definition/Query/Domain 对 Datasource business service 的依赖。
+
+## 10. Forbidden Buckets
+
+production 不重新引入：
+
+```text
+service/
+support/
+common/
+helper/
+utils/
+util/
+base/
+persistence/
+```
+
+稳定 Facade 是明确命名的 root class，不需要一个通用 `service` package。
+
+## 11. Change Rule
+
+如果确实需要改变以上 dependency graph：
+
+1. 先确认新的 truth owner；
+2. 修改 `ARCHITECTURE.md` / 本文；
+3. 修改 executable architecture tests；
+4. 再修改生产代码。
+
+不能只删除或放宽 guard 让新依赖“通过”。

--- a/yak-ops-business/yak-ops-business-analysis/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-analysis/DOMAIN.md
@@ -1,0 +1,162 @@
+# Analysis Domain
+
+## 1. Core Model
+
+```text
+AnalysisAsset
+    = identity
+    + current AnalysisDefinition
+    + create/update time
+
+AnalysisDefinition
+    = name / description
+    + datasetId
+    + chartType
+    + AnalysisQuerySpec
+    + AnalysisVisualConfig
+```
+
+`AnalysisAsset` 表示已经持久化的当前 reusable Analysis；`AnalysisDefinition` 表示标准化后准备持久化的当前定义。
+
+## 2. Truth Ownership
+
+| Truth | Owner |
+|---|---|
+| Analysis identity / current definition | Analysis |
+| Analysis name / description | Analysis |
+| Dataset reference chosen by Analysis | Analysis |
+| Dataset lifecycle / current version / fields | Dataset |
+| Query semantic bindings | Analysis |
+| Physical SQL/query execution | Dataset Query capability |
+| Chart type / chart-local visual config | Analysis |
+| Dashboard layout / widget placement / Dashboard version | Dashboard |
+| Lineage graph / asset/relation persistence | Lineage |
+| Analysis -> Lineage projection input | Analysis |
+
+只有一个 owner 的 truth 才能稳定演进。Adapter、Controller、Dashboard、Lineage projection 都不能反向成为 Analysis Definition owner。
+
+## 3. Definition Is Not Draft Lifecycle
+
+当前领域关系是：
+
+```text
+AnalysisDefinition
+    -> persist/update
+    -> current AnalysisAsset
+```
+
+不是：
+
+```text
+Draft -> Publish -> Version
+```
+
+历史名字 `AnalysisDraft` 已被移除，就是为了避免错误暗示。
+
+如果未来需要历史版本，需要单独设计 `AnalysisVersion` 的 identity、immutable snapshot、发布/切换和引用冻结语义，不能复用当前 `AnalysisDefinition` 假装实现。
+
+## 4. Query Semantics
+
+`AnalysisQuerySpec` 描述 Analysis 如何消费 Dataset：
+
+```text
+dimensions
+metrics(fieldId, aggregation)
+filters(fieldId, operator, value)
+sorts(fieldId, aggregation, direction)
+limit
+timeoutSeconds
+```
+
+它不是 SQL，也不是 execution plan。
+
+Query semantic value object 位于 `query`，Query normalizer 负责 canonical form，Chart binding policy 负责 chart cardinality constraint。
+
+## 5. Visualization
+
+`AnalysisChartType` 与 `AnalysisVisualConfig` 属于 reusable Analysis definition。
+
+它们只描述 chart-local presentation；Dashboard theme、布局、坐标、widget size 与交互不属于 Analysis。
+
+## 6. Dataset Binding
+
+Analysis 只持有 `datasetId` 和引用的 fieldId。
+
+```text
+AnalysisDefinitionNormalizer
+    -> AnalysisDatasetGateway
+    -> Dataset owner
+```
+
+Analysis 不复制 Dataset Status、Version、Field metadata 作为自己的 truth。
+
+Dataset binding 校验是 command-time invariant，不意味着 Analysis 获得 Dataset lifecycle ownership。
+
+## 7. Reference And Deletion
+
+`AnalysisReferenceService` 是给下游模块的窄 read contract：确认一个 Analysis reference 当前是否存在。
+
+`AnalysisDeletionGuard` 是下游引用阻止删除的扩展点：
+
+```text
+Analysis delete
+    -> all deletion guards
+    -> delete only when every guard accepts
+```
+
+Guard 可以阻止 command，但不能修改 Analysis Definition。
+
+## 8. Change Fact
+
+`AnalysisChangedEvent` 是 Analysis mutation 已发生的事实通知：
+
+```text
+REFRESH / DELETE semantic fact
+```
+
+它不是 Lineage command，也不包含 Lineage 内部类型。Definition 因此不依赖 Lineage implementation。
+
+## 9. Lineage Is Derived Projection
+
+```text
+committed Analysis truth
+      ↓
+AnalysisChangedEvent
+      ↓ after commit
+AnalysisLineageSynchronizer
+      ↓
+AnalysisLineageGraphGateway
+      ↓
+Lineage graph
+```
+
+Lineage projection 可以重建/收敛；Analysis business truth 不依赖某次 projection 是否成功。
+
+字段 usage 是 Analysis QuerySpec 的确定性派生：
+
+```text
+fieldId -> DIMENSION / METRIC / FILTER / SORT
+```
+
+它用于 Lineage evidence，但不是新的可变业务实体。
+
+## 10. Persistence Representation
+
+`yak_analysis` 当前持久化 current definition。
+
+`query_spec_json` 和 `visual_config_json` 是 persistence representation，不是 Repository API。JSON codec 属于 Repository boundary。
+
+## 11. Explicit Non-entities
+
+当前不存在这些 Analysis Domain Entity：
+
+```text
+AnalysisVersion
+AnalysisExecution
+AnalysisAttempt
+AnalysisResult
+AnalysisSchedule
+AnalysisRuntime
+```
+
+如果新需求需要它们，应先定义 owner、identity、lifecycle 与和现有 AnalysisDefinition 的关系。

--- a/yak-ops-business/yak-ops-business-analysis/README.md
+++ b/yak-ops-business/yak-ops-business-analysis/README.md
@@ -1,0 +1,129 @@
+# Yak Ops Analysis
+
+Analysis 模块负责**可复用分析定义**：把一个 Dataset 的字段以维度、指标、过滤、排序和图表语义组合成可被 Dashboard 引用的 Analysis。
+
+Analysis 不拥有 Dataset 数据/Schema/Version，不拥有 Dashboard 布局，也不拥有 Lineage 图真相，更不是 Query Runtime。
+
+## Read First
+
+修改 Analysis 前建议按顺序阅读：
+
+1. [`REQUIREMENTS.md`](./REQUIREMENTS.md)：长期必须保持的业务行为与非目标；
+2. [`DOMAIN.md`](./DOMAIN.md)：Analysis Truth Ownership 与核心对象关系；
+3. [`ARCHITECTURE.md`](./ARCHITECTURE.md)：package、角色和主要调用链；
+4. [`DEPENDENCIES.md`](./DEPENDENCIES.md)：允许的依赖方向和跨模块 corridor；
+5. [`REVIEW.md`](./REVIEW.md)：PR 评审与最终一致性检查。
+
+## Architecture at a Glance
+
+```text
+Controller
+    -> AnalysisService (stable facade)
+        -> AnalysisManager / AnalysisReader
+
+AnalysisManager
+    -> AnalysisDefinitionNormalizer
+        -> AnalysisQueryNormalizer
+        -> AnalysisVisualPolicy
+        -> AnalysisDatasetGateway
+    -> AnalysisRepository
+    -> AnalysisChangedEvent
+
+AnalysisChangedEvent -- after commit --> AnalysisLineageRefreshListener
+    -> AnalysisLineageSynchronizer
+    -> AnalysisLineageGraphGateway
+    -> Lineage adapter
+```
+
+主要 package：
+
+```text
+analysis
+├── controller/v1
+├── definition
+├── domain
+├── query
+├── visualization
+├── reference
+├── lineage
+├── gateway/dataset
+├── gateway/lineage
+├── repository/codec
+├── dao
+└── config
+```
+
+仓库根部保留 `AnalysisService`、`AnalysisReferenceService`、`AnalysisDeletionGuard` 作为兼容边界，不把新的业务实现继续堆在根 package。
+
+## Truth Ownership
+
+```text
+Analysis
+    owns current reusable analytical definition
+
+Dataset
+    owns lifecycle / current version / schema / query capability
+
+Dashboard
+    owns layout / widget placement / dashboard versions
+
+Lineage
+    owns lineage graph
+
+Analysis lineage code
+    owns only the derived projection from committed Analysis truth
+```
+
+`AnalysisDefinition` 是当前可复用定义，不是 Draft 生命周期；当前没有 `AnalysisVersion`、Publish/Online 状态、Execution Instance 或 Query Result truth。
+
+## Role Vocabulary
+
+| Role | Responsibility |
+|---|---|
+| `Service` | 对外稳定 compatibility facade |
+| `Manager` | create/update/delete 生命周期 |
+| `Reader` | 当前 Analysis read side |
+| `Normalizer` | 输入标准化与组合 |
+| `Policy` | 图表/视觉等业务约束 |
+| `Collector` / `Extractor` | 确定性语义提取 |
+| `Gateway` | Analysis-owned 跨模块 Port |
+| `Adapter` | Dataset/Lineage/持久化边界翻译 |
+| `Synchronizer` | 让派生 Lineage 投影收敛 |
+| `Repository` | Analysis Domain 持久化 Port |
+| `DAO` | MyBatis persistence access |
+| `Codec` | `query_spec_json` / `visual_config_json` 边界编解码 |
+| `Mapper` | HTTP request/view 转换 |
+
+新增代码不要重新创建 `service/support/helper/utils/common/base` 兜底角色。
+
+## Stable Semantics
+
+- Query 默认 `limit = 500`、`timeoutSeconds = 30`；最大分别为 `1000`、`120`；
+- Filter 最多 50 个，Sort 最多 5 个；
+- METRIC / PIE / BAR / LINE / TABLE 的维度指标约束保持不变；
+- Dataset binding 由 Dataset owner 校验 ONLINE、current version 和 field identity；
+- Dashboard 可以通过 `AnalysisDeletionGuard` 阻止删除被引用 Analysis，但不能修改 Analysis truth；
+- Analysis mutation commit 后再刷新 Lineage；Lineage 失败只记录，不回滚已提交 Analysis；
+- Lineage evidence 继续使用 `ANALYSIS_BINDING`。
+
+## Persistence
+
+当前 Analysis 只维护：
+
+```text
+yak_analysis
+```
+
+`query_spec_json` 与 `visual_config_json` 是 Analysis 当前定义的持久化表示。Repository 对 Application 暴露 Domain，不暴露 JSON 字符串、PO 或 Mapper。
+
+## Architecture Guards
+
+```text
+AnalysisDependencyBoundaryTest
+AnalysisLayeringConventionTest
+AnalysisCodeStyleConventionTest
+AnalysisRoleConventionTest
+AnalysisArchitectureDocumentationTest
+```
+
+架构需要变化时，应同时修改代码、文档和 executable guard，不单独放宽测试。

--- a/yak-ops-business/yak-ops-business-analysis/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-analysis/REQUIREMENTS.md
@@ -1,0 +1,162 @@
+# Analysis Requirements
+
+本文记录 `yak-ops-business-analysis` 当前必须长期保持的业务 contract。它描述行为，不描述某一次重构过程。
+
+## 1. Scope
+
+Analysis 是一个**可复用分析定义**。一个 Analysis 指向一个 Dataset，并声明：
+
+- 使用哪些 dimension；
+- 使用哪些 metric 与 aggregation；
+- 使用哪些 filter / sort；
+- 使用哪种 chart type；
+- chart-local visual config；
+- query limit / timeout 语义。
+
+Analysis 可以被 Dashboard 引用。
+
+## 2. Definition Lifecycle
+
+当前只存在“当前定义”生命周期：
+
+```text
+create
+update
+read/list
+delete
+```
+
+创建和更新必须先完成定义标准化与 Dataset binding 校验，再写入 `yak_analysis`。
+
+删除前必须执行所有 `AnalysisDeletionGuard`。任一 guard 拒绝时不得删除 Analysis。
+
+当前**没有**：
+
+```text
+Draft -> Publish
+AnalysisVersion
+Online / Offline
+ExecutionInstance
+QueryResult state
+```
+
+不要为了代码结构对称而引入不存在的状态机。
+
+## 3. Dataset Binding
+
+Analysis 只保存 Dataset reference，不拥有 Dataset truth。
+
+保存 Analysis 时：
+
+- `datasetId > 0`；
+- Dataset 必须满足 Dataset owner 定义的可绑定条件；
+- 当前条件包括 ONLINE、存在 current version、引用 fieldId 属于当前 schema；
+- Analysis 通过 `AnalysisDatasetGateway` 请求校验，不直接读取 Dataset Repository/DAO。
+
+Dataset 后续生命周期与版本策略仍由 Dataset 模块负责。
+
+## 4. Query Semantics
+
+`AnalysisQuerySpec` 是声明式语义，不是 SQL、执行计划或 Runtime execution。
+
+标准化规则保持：
+
+```text
+limit default           = 500
+limit max               = 1000
+timeoutSeconds default  = 30
+timeoutSeconds max      = 120
+filters max             = 50
+sorts max               = 5
+fieldId max length      = 64
+single string filter    <= 4000 chars
+```
+
+Dimension fieldId 不允许重复。Metric 按 `fieldId + aggregation` 不允许重复。
+
+Sort 必须引用已经存在于 dimensions 或 metrics 中的字段；维度排序不能指定 aggregation；未指定方向时默认 ASC。
+
+SQL 特定语义属于 Dataset Query Runtime，不进入 Analysis semantic operator。
+
+## 5. Chart Binding
+
+必须保持：
+
+- `METRIC`：0 dimension，且恰好 1 metric；
+- `PIE`：恰好 1 dimension + 1 metric；
+- `BAR` / `LINE`：至少 1 dimension + 1 metric；
+- `TABLE`：dimension 与 metric 至少存在一种。
+
+## 6. Visual Configuration
+
+VisualConfig 只描述 Analysis 图表自身展示语义，不描述 Dashboard layout。
+
+未提供 VisualConfig 时保持当前默认：
+
+- PIE 默认显示 legend；
+- LINE 默认 smooth；
+- BAR / LINE 默认显示 grid/axis 类展示；
+- data label 默认关闭。
+
+Dashboard 的位置、尺寸、主题、交互和 Dashboard Version 不进入 Analysis。
+
+## 7. Reference Contract
+
+跨模块只需要确认 Analysis 是否存在时，通过稳定窄接口 `AnalysisReferenceService`。
+
+Dashboard 等下游模块不能为了引用校验直接依赖 Analysis Repository/DAO。
+
+## 8. Lineage Projection
+
+Analysis create/update/delete 成功后发布 Analysis-owned change fact。
+
+Lineage 刷新必须在业务事务 commit 后发生：
+
+```text
+Analysis mutation
+    -> DB commit
+    -> AnalysisLineageRefreshListener
+    -> AnalysisLineageSynchronizer
+```
+
+Lineage projection 使用独立事务收敛；刷新失败不得把已经提交的 Analysis 业务结果回滚。
+
+必须保持：
+
+- evidence source：`ANALYSIS_BINDING`；
+- Analysis Chart asset key：`chart:analysis:{analysisId}`；
+- Dataset asset key：`dataset:{datasetId}`；
+- DatasetField asset key：`dataset-field:{datasetId}:{fieldId}`；
+- Dataset -> Chart：`CONSUMES`；
+- DatasetField -> Chart：`CONSUMES`；
+- field usage role：DIMENSION / METRIC / FILTER / SORT；
+- metric/sort aggregation evidence 可追踪。
+
+Lineage graph 是 Lineage 模块的 truth；Analysis 只维护派生投影输入与收敛逻辑。
+
+## 9. Persistence Compatibility
+
+保持：
+
+- 表：`yak_analysis`；
+- 字段：`dataset_id`、`chart_type`、`query_spec_json`、`visual_config_json` 等现有 schema；
+- Flyway baseline 不在架构治理中重写；
+- Repository 不向 Application 暴露 PO / JSON string / MyBatis 类型。
+
+## 10. HTTP Compatibility
+
+保持 `/api/v1/analyses/**` 路径、现有 request/response 字段和 long-id 字符串序列化语义。
+
+## 11. Non-goals
+
+本模块不拥有：
+
+- Dataset schema/version/query execution；
+- SQL compiler/runtime；
+- Dashboard layout/version；
+- Lineage graph truth；
+- Workflow execution；
+- Analysis historical version store；
+- Analysis execution/result cache state。
+
+新增以上能力前应先形成明确需求与新的 Domain Contract，而不是塞入现有 Manager/Normalizer。

--- a/yak-ops-business/yak-ops-business-analysis/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-analysis/REVIEW.md
@@ -1,0 +1,96 @@
+# Analysis Review Contract
+
+Analysis PR 评审重点不是“类名是否更漂亮”，而是 Definition、Dataset、Dashboard、Lineage 的 truth 是否仍然只有一个 owner。
+
+## Requirement
+
+- 新功能是否仍属于 reusable Analysis Definition？
+- 是否无意引入了 Version / Publish / Execution / Result state？
+- REST / DB / Query semantics 变化是否被明确写成需求，而不是混在重构里？
+
+## Domain
+
+- `AnalysisDefinition` 是否仍表达 current definition？
+- `AnalysisQuerySpec` 是否仍是 declarative semantics，而不是 SQL/runtime state？
+- Dataset schema/version 是否仍由 Dataset owner 管理？
+- Dashboard layout/version 是否仍留在 Dashboard？
+- Lineage graph 是否仍由 Lineage owner 管理？
+
+## Definition Lifecycle
+
+- create/update 是否先 normalize + Dataset binding validate 再 persist？
+- delete 是否执行全部 deletion guard？
+- Manager 是否只拥有 mutation lifecycle，没有吞掉 Query/Dataset/Lineage 实现？
+- Reader 是否保持 read-only role？
+
+## Query / Visualization
+
+- limit/timeout/filter/sort 约束是否被行为测试保护？
+- 新 chart type 是否明确其 dimension/metric cardinality？
+- Visual config 是否只描述 chart-local 语义？
+- 是否把 Dashboard layout 偷偷放进 AnalysisVisualConfig？
+
+## Dataset Boundary
+
+- Definition 是否只依赖 `AnalysisDatasetGateway`？
+- Dataset 具体类型是否只停在 `gateway/dataset` adapter？
+- 是否复制 Dataset status/version/field metadata 成 Analysis truth？
+
+## Reference / Delete
+
+- 下游引用校验是否使用 `AnalysisReferenceService` 等窄 contract？
+- Dashboard 删除约束是否通过 `AnalysisDeletionGuard` 表达？
+- Guard 是否只阻止删除，而不是反向修改 Analysis？
+
+## Lineage
+
+- 刷新是否仍为 AFTER_COMMIT？
+- Projection failure 是否仍与已提交 Analysis 隔离？
+- Synchronizer 是否只依赖 `AnalysisLineageGraphGateway`？
+- `ANALYSIS_BINDING` evidence 与 asset key 是否兼容？
+- field usage role/aggregation evidence 是否保持确定性？
+
+## Persistence
+
+- Repository contract 是否只暴露 Analysis Domain？
+- JSON/PO/MyBatis 是否停在 Repository/DAO boundary？
+- 是否无意修改 `yak_analysis` schema 或 Flyway history？
+- Datasource 依赖是否只用于 infrastructure wiring？
+
+## Package / Role
+
+- 新类是否进入准确 subsystem？
+- `@Service` 是否只用于稳定 Facade？
+- 内部角色是否使用 Manager/Reader/Normalizer/Policy/Gateway/Adapter/Synchronizer 等明确词汇？
+- 是否重新出现 `service/support/helper/utils/common/base`？
+- dependency graph 是否保持无环？
+
+## Compatibility
+
+至少确认：
+
+```text
+/api/v1/analyses/**
+request/response JSON
+long id serialization
+yak_analysis
+Dataset binding rules
+query defaults/limits
+chart rules
+visual defaults
+Dashboard deletion guard
+Lineage evidence and relation semantics
+```
+
+## Tests
+
+结构调整至少同时需要：
+
+- 相关行为回归测试；
+- `AnalysisDependencyBoundaryTest`；
+- `AnalysisLayeringConventionTest`；
+- `AnalysisCodeStyleConventionTest`；
+- `AnalysisRoleConventionTest`；
+- `AnalysisArchitectureDocumentationTest`。
+
+如果某条规则只能靠“大家记住不要这么写”，应优先把它变成可执行 guard。

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisArchitectureDocumentationTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisArchitectureDocumentationTest.java
@@ -1,0 +1,65 @@
+package io.yak.ops.business.analysis.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Keeps the durable Analysis architecture contract present and discoverable. */
+class AnalysisArchitectureDocumentationTest {
+
+  private static final List<String> DOCUMENTS = List.of(
+      "README.md",
+      "REQUIREMENTS.md",
+      "DOMAIN.md",
+      "ARCHITECTURE.md",
+      "DEPENDENCIES.md",
+      "REVIEW.md");
+
+  @Test
+  void architectureDocumentsRemainPresent() {
+    for (String document : DOCUMENTS) {
+      assertThat(Files.isRegularFile(moduleRoot().resolve(document)))
+          .as("Analysis architecture document %s must exist", document)
+          .isTrue();
+    }
+  }
+
+  @Test
+  void readmeLinksTheDurableContracts() throws IOException {
+    String readme = read("README.md");
+    for (String document : List.of(
+        "REQUIREMENTS.md", "DOMAIN.md", "ARCHITECTURE.md", "DEPENDENCIES.md", "REVIEW.md")) {
+      assertThat(readme).as("README must link %s", document).contains(document);
+    }
+  }
+
+  @Test
+  void contractsStateTheCriticalOwnershipRules() throws IOException {
+    assertThat(read("REQUIREMENTS.md"))
+        .contains("AnalysisQuerySpec", "AnalysisDatasetGateway", "ANALYSIS_BINDING")
+        .contains("AnalysisVersion", "ExecutionInstance");
+    assertThat(read("DOMAIN.md"))
+        .contains("AnalysisDefinition", "Dataset", "Dashboard", "Lineage");
+    assertThat(read("DEPENDENCIES.md"))
+        .contains("AnalysisDatasetGateway", "AnalysisLineageGraphGateway", "无环");
+  }
+
+  private String read(String file) throws IOException {
+    return Files.readString(moduleRoot().resolve(file), StandardCharsets.UTF_8);
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/analysis"))) return local;
+    Path repositoryRelative = Path.of("yak-ops-business", "yak-ops-business-analysis")
+        .toAbsolutePath()
+        .normalize();
+    assertThat(Files.isDirectory(repositoryRelative)).isTrue();
+    return repositoryRelative;
+  }
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisCodeStyleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisCodeStyleConventionTest.java
@@ -1,0 +1,136 @@
+package io.yak.ops.business.analysis.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Low-ambiguity repository-wide code-style rules for Analysis production code. */
+class AnalysisCodeStyleConventionTest {
+
+  private static final Pattern WILDCARD_IMPORT =
+      Pattern.compile("(?m)^import\\s+(?:static\\s+)?[^;]+\\*;");
+  private static final Pattern FIELD_INJECTION = Pattern.compile(
+      "(?m)@(Autowired|Resource|Inject)\\s*\\R\\s*"
+          + "(?:private|protected|public)\\s+[^\\n(]+;");
+  private static final Pattern SERVICE_CLASS = Pattern.compile(
+      "(?s)@Service\\s*(?:\\R|@[^\\R]+\\R)*public\\s+class\\s+([A-Za-z0-9_]+)");
+  private static final Set<String> STABLE_SERVICES =
+      Set.of("AnalysisService", "AnalysisReferenceService");
+
+  @Test
+  void productionSourceFollowsRepositoryStyle() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        String relative = root.relativize(file).toString();
+        assertThat(WILDCARD_IMPORT.matcher(source).find())
+            .as("%s must not use wildcard imports", relative)
+            .isFalse();
+        assertThat(FIELD_INJECTION.matcher(source).find())
+            .as("%s must use constructor injection", relative)
+            .isFalse();
+        assertThat(source)
+            .as("%s must avoid low-signal shortcuts", relative)
+            .doesNotContain("System.out.", "System.err.", "BeanUtils.copyProperties");
+      }
+    }
+  }
+
+  @Test
+  void serviceStereotypeIsReservedForStableFacades() throws IOException {
+    Set<String> found = new HashSet<>();
+    try (Stream<Path> files = Files.walk(productionRoot())) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Matcher matcher = SERVICE_CLASS.matcher(Files.readString(file, StandardCharsets.UTF_8));
+        if (!matcher.find()) continue;
+        String className = matcher.group(1);
+        found.add(className);
+        assertThat(STABLE_SERVICES)
+            .as("@Service must be a stable Analysis facade: %s", file)
+            .contains(className);
+      }
+    }
+    assertThat(found).containsExactlyInAnyOrderElementsOf(STABLE_SERVICES);
+  }
+
+  @Test
+  void domainAndSemanticValueObjectsRemainFrameworkFree() throws IOException {
+    assertFrameworkFreeDirectory(productionRoot().resolve("domain"));
+
+    for (String relative : List.of(
+        "query/AnalysisAggregation.java",
+        "query/AnalysisFilterBinding.java",
+        "query/AnalysisFilterOperator.java",
+        "query/AnalysisMetricBinding.java",
+        "query/AnalysisQuerySpec.java",
+        "query/AnalysisSortBinding.java",
+        "query/AnalysisSortDirection.java",
+        "visualization/AnalysisChartType.java",
+        "visualization/AnalysisVisualConfig.java")) {
+      assertFrameworkFree(productionRoot().resolve(relative));
+    }
+  }
+
+  @Test
+  void repositoryUsesSingleRootCodeStyleDocument() throws IOException {
+    Path module = moduleRoot();
+    Path repository = module.getParent().getParent();
+    assertThat(Files.isRegularFile(repository.resolve("CODE_STYLE.md")))
+        .as("Yak Ops root CODE_STYLE.md must exist")
+        .isTrue();
+    assertThat(Files.exists(module.resolve("CODE_STYLE.md")))
+        .as("Analysis must not maintain a module-local CODE_STYLE.md")
+        .isFalse();
+
+    long count;
+    try (Stream<Path> paths = Files.walk(repository, 6)) {
+      count = paths.filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().equals("CODE_STYLE.md"))
+          .count();
+    }
+    assertThat(count).as("Yak Ops keeps one repository-wide CODE_STYLE.md").isEqualTo(1L);
+  }
+
+  private void assertFrameworkFreeDirectory(Path root) throws IOException {
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        assertFrameworkFree(file);
+      }
+    }
+  }
+
+  private void assertFrameworkFree(Path file) throws IOException {
+    String source = Files.readString(file, StandardCharsets.UTF_8);
+    assertThat(source)
+        .as("Analysis semantic value must remain framework-free: %s", file)
+        .doesNotContain(
+            "org.springframework.",
+            "com.baomidou.mybatisplus.",
+            "io.yak.ops.business.analysis.controller.",
+            "io.yak.ops.business.analysis.dao.",
+            "io.yak.ops.common.bean.po.",
+            "lombok.Data",
+            "@Data");
+  }
+
+  private Path productionRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/analysis");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/analysis"))) return local;
+    return Path.of("yak-ops-business", "yak-ops-business-analysis").toAbsolutePath().normalize();
+  }
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisDependencyBoundaryTest.java
@@ -1,0 +1,222 @@
+package io.yak.ops.business.analysis.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Source-level guard for Analysis package direction and cross-module corridors. */
+class AnalysisDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.analysis";
+  private static final Pattern ANALYSIS_IMPORT = Pattern.compile(
+      "(?m)^import\\s+(?:static\\s+)?("
+          + Pattern.quote(BASE)
+          + "\\.([A-Za-z0-9_]+)\\.[^;]+);");
+
+  private static final Map<String, Set<String>> ALLOWED = Map.ofEntries(
+      Map.entry("controller", Set.of("domain", "query", "visualization")),
+      Map.entry("definition", Set.of("domain", "gateway", "query", "repository", "visualization")),
+      Map.entry("domain", Set.of("query", "visualization")),
+      Map.entry("query", Set.of("visualization")),
+      Map.entry("visualization", Set.of()),
+      Map.entry("reference", Set.of("definition")),
+      Map.entry("lineage", Set.of("definition", "domain", "gateway", "query")),
+      Map.entry("gateway", Set.of()),
+      Map.entry("repository", Set.of("dao", "domain", "query", "visualization")),
+      Map.entry("dao", Set.of()),
+      Map.entry("config", Set.of()));
+
+  @Test
+  void topLevelPackagesFollowDeclaredGraph() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      assertThat(ALLOWED.getOrDefault(dependency.sourcePackage(), Set.of()))
+          .as("%s imports %s", dependency.relativePath(), dependency.importedType())
+          .contains(dependency.targetPackage());
+    }
+  }
+
+  @Test
+  void declaredAndActualGraphsRemainAcyclic() throws IOException {
+    assertAcyclic(ALLOWED, "declared Analysis dependency graph");
+
+    java.util.Map<String, Set<String>> actual = new java.util.HashMap<>();
+    ALLOWED.keySet().forEach(key -> actual.put(key, new HashSet<>()));
+    for (Dependency dependency : dependencies()) {
+      actual.computeIfAbsent(dependency.sourcePackage(), ignored -> new HashSet<>())
+          .add(dependency.targetPackage());
+    }
+    assertAcyclic(actual, "actual Analysis import graph");
+  }
+
+  @Test
+  void highRiskCorridorsStayNarrow() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if (dependency.sourcePackage().equals("definition")
+          && dependency.targetPackage().equals("gateway")) {
+        assertThat(dependency.importedType())
+            .as("Definition may enter Dataset only through AnalysisDatasetGateway")
+            .isEqualTo(BASE + ".gateway.dataset.AnalysisDatasetGateway");
+      }
+      if (dependency.sourcePackage().equals("lineage")
+          && dependency.targetPackage().equals("gateway")) {
+        assertThat(dependency.importedType())
+            .as("Lineage projection may enter shared Lineage only through its owner-defined port")
+            .startsWith(BASE + ".gateway.lineage.AnalysisLineageGraphGateway");
+      }
+      if (dependency.sourcePackage().equals("reference")
+          && dependency.targetPackage().equals("definition")) {
+        assertThat(dependency.importedType())
+            .as("Reference read-side must stay narrow")
+            .isEqualTo(BASE + ".definition.AnalysisReader");
+      }
+    }
+  }
+
+  @Test
+  void controllerNeverEntersPersistenceGatewaysOrProjectionInternals() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if (!dependency.sourcePackage().equals("controller")) continue;
+      assertThat(dependency.targetPackage())
+          .as("Controller boundary: %s", dependency)
+          .isNotIn("repository", "dao", "gateway", "lineage");
+    }
+  }
+
+  @Test
+  void datasetAndLineageImplementationsStayBehindGatewayAdapters() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = normalize(root.relativize(file));
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        if (source.contains("io.yak.ops.business.dataset.")) {
+          assertThat(relative)
+              .as("Dataset implementation type leaked outside gateway adapter: %s", relative)
+              .startsWith("gateway/dataset/");
+        }
+        if (source.contains("io.yak.ops.business.lineage.")) {
+          assertThat(relative)
+              .as("Lineage implementation type leaked outside gateway adapter: %s", relative)
+              .startsWith("gateway/lineage/");
+        }
+      }
+    }
+  }
+
+  @Test
+  void lowLevelPackagesDoNotPointBackToApplicationRoles() throws IOException {
+    for (Dependency dependency : dependencies()) {
+      if (dependency.sourcePackage().equals("dao")
+          || dependency.sourcePackage().equals("visualization")
+          || dependency.sourcePackage().equals("gateway")
+          || dependency.sourcePackage().equals("config")) {
+        throw new AssertionError("Low-level Analysis package must not import upper package: " + dependency);
+      }
+      if (dependency.sourcePackage().equals("repository")) {
+        assertThat(dependency.targetPackage())
+            .as("Repository must remain below application roles: %s", dependency)
+            .isIn("dao", "domain", "query", "visualization");
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() throws IOException {
+    Set<String> forbidden = Set.of(
+        "service", "support", "common", "helper", "utils", "util", "base", "persistence");
+    try (Stream<Path> paths = Files.walk(productionRoot())) {
+      for (Path path : paths.filter(Files::isDirectory).toList()) {
+        Path name = path.getFileName();
+        if (name != null) {
+          assertThat(forbidden)
+              .as("Broad Analysis business bucket must not exist: %s", path)
+              .doesNotContain(name.toString());
+        }
+      }
+    }
+  }
+
+  private List<Dependency> dependencies() throws IOException {
+    Path root = productionRoot();
+    List<Dependency> result = new ArrayList<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        Path relative = root.relativize(file);
+        if (relative.getNameCount() < 2) continue; // root stable compatibility API
+        String sourcePackage = relative.getName(0).toString();
+        Matcher matcher = ANALYSIS_IMPORT.matcher(Files.readString(file, StandardCharsets.UTF_8));
+        while (matcher.find()) {
+          String importedType = matcher.group(1);
+          String targetPackage = matcher.group(2);
+          if (!sourcePackage.equals(targetPackage)) {
+            result.add(new Dependency(
+                sourcePackage, targetPackage, importedType, normalize(relative)));
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private void assertAcyclic(Map<String, Set<String>> graph, String label) {
+    Set<String> visited = new HashSet<>();
+    Set<String> visiting = new HashSet<>();
+    for (String node : graph.keySet()) {
+      visit(node, graph, visiting, visited, label);
+    }
+  }
+
+  private void visit(
+      String node,
+      Map<String, Set<String>> graph,
+      Set<String> visiting,
+      Set<String> visited,
+      String label) {
+    if (visited.contains(node)) return;
+    assertThat(visiting.add(node)).as("%s has a cycle through %s", label, node).isTrue();
+    for (String target : graph.getOrDefault(node, Set.of())) {
+      visit(target, graph, visiting, visited, label);
+    }
+    visiting.remove(node);
+    visited.add(node);
+  }
+
+  private Path productionRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/analysis");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/analysis"))) return local;
+    Path repositoryRelative = Path.of("yak-ops-business", "yak-ops-business-analysis")
+        .toAbsolutePath()
+        .normalize();
+    assertThat(Files.isDirectory(
+            repositoryRelative.resolve("src/main/java/io/yak/ops/business/analysis")))
+        .as("Unable to locate Analysis module root from %s", local)
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace(java.io.File.separatorChar, '/');
+  }
+
+  private record Dependency(
+      String sourcePackage,
+      String targetPackage,
+      String importedType,
+      String relativePath) {}
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisRoleConventionTest.java
@@ -1,0 +1,74 @@
+package io.yak.ops.business.analysis.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.analysis.AnalysisReferenceService;
+import io.yak.ops.business.analysis.AnalysisService;
+import io.yak.ops.business.analysis.controller.v1.mapper.AnalysisRequestMapper;
+import io.yak.ops.business.analysis.controller.v1.mapper.AnalysisViewMapper;
+import io.yak.ops.business.analysis.definition.AnalysisDefinitionNormalizer;
+import io.yak.ops.business.analysis.definition.AnalysisManager;
+import io.yak.ops.business.analysis.definition.AnalysisReader;
+import io.yak.ops.business.analysis.gateway.dataset.DatasetAnalysisAdapter;
+import io.yak.ops.business.analysis.gateway.lineage.LineageAnalysisAdapter;
+import io.yak.ops.business.analysis.lineage.AnalysisFieldUsageExtractor;
+import io.yak.ops.business.analysis.lineage.AnalysisLineageRefreshListener;
+import io.yak.ops.business.analysis.lineage.AnalysisLineageSynchronizer;
+import io.yak.ops.business.analysis.query.AnalysisFieldReferenceCollector;
+import io.yak.ops.business.analysis.query.AnalysisQueryNormalizer;
+import io.yak.ops.business.analysis.reference.AnalysisReferenceReader;
+import io.yak.ops.business.analysis.repository.AnalysisRepositoryAdapter;
+import io.yak.ops.business.analysis.repository.codec.AnalysisJsonCodec;
+import io.yak.ops.business.analysis.visualization.AnalysisChartBindingPolicy;
+import io.yak.ops.business.analysis.visualization.AnalysisVisualPolicy;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+
+class AnalysisRoleConventionTest {
+
+  @Test
+  void stableApplicationFacadesRemainServices() {
+    for (Class<?> role : List.of(AnalysisService.class, AnalysisReferenceService.class)) {
+      assertThat(role.getAnnotation(Service.class))
+          .as("%s is a stable Analysis facade", role.getSimpleName())
+          .isNotNull();
+    }
+  }
+
+  @Test
+  void internalRolesRemainExplicitComponents() {
+    for (Class<?> role : List.of(
+        AnalysisManager.class,
+        AnalysisReader.class,
+        AnalysisDefinitionNormalizer.class,
+        AnalysisQueryNormalizer.class,
+        AnalysisFieldReferenceCollector.class,
+        AnalysisChartBindingPolicy.class,
+        AnalysisVisualPolicy.class,
+        AnalysisReferenceReader.class,
+        AnalysisFieldUsageExtractor.class,
+        AnalysisLineageRefreshListener.class,
+        AnalysisLineageSynchronizer.class,
+        DatasetAnalysisAdapter.class,
+        LineageAnalysisAdapter.class,
+        AnalysisJsonCodec.class,
+        AnalysisRequestMapper.class,
+        AnalysisViewMapper.class)) {
+      assertThat(role.getAnnotation(Component.class))
+          .as("%s must remain an explicit internal component role", role.getSimpleName())
+          .isNotNull();
+      assertThat(role.getAnnotation(Service.class))
+          .as("%s must not masquerade as generic Application Service", role.getSimpleName())
+          .isNull();
+    }
+  }
+
+  @Test
+  void persistenceAdapterRemainsRepositoryRole() {
+    assertThat(AnalysisRepositoryAdapter.class.getAnnotation(Repository.class)).isNotNull();
+    assertThat(AnalysisRepositoryAdapter.class.getAnnotation(Service.class)).isNull();
+  }
+}


### PR DESCRIPTION
## Summary

Complete `yak-ops-business-analysis` Stage 2 architecture governance after Stage 1 PR #703 established the domain-oriented package shape.

This PR does not add Analysis features. It turns the Stage 1 structure into a durable architecture contract through module documents and executable guards.

## What this PR establishes

### 1. Durable module contracts

Adds:

- `README.md`
- `REQUIREMENTS.md`
- `DOMAIN.md`
- `ARCHITECTURE.md`
- `DEPENDENCIES.md`
- `REVIEW.md`

They make the ownership boundary explicit:

```text
Analysis
    owns current reusable analytical definition

Dataset
    owns lifecycle / current version / schema / query capability

Dashboard
    owns layout / widget placement / dashboard versions

Lineage
    owns lineage graph
```

The documents also lock the current non-goals: Analysis still has no `AnalysisVersion`, Draft/Publish lifecycle, Execution Instance, Runtime, or Query Result truth.

### 2. Dependency graph governance

Adds `AnalysisDependencyBoundaryTest` to enforce an acyclic package graph and narrow high-risk corridors.

Key corridors are now executable contracts:

```text
Definition
    -> AnalysisDatasetGateway
    -> DatasetAnalysisAdapter

Lineage projection
    -> AnalysisLineageGraphGateway
    -> LineageAnalysisAdapter

Reference
    -> AnalysisReader
```

Dataset and Lineage implementation types are only allowed inside their corresponding gateway adapters.

Controller cannot enter Repository / DAO / Gateway / Lineage internals.

Generic business buckets such as `service/support/helper/utils/common/base/persistence` cannot reappear.

### 3. Role and stereotype governance

Adds `AnalysisRoleConventionTest`.

`@Service` remains reserved for the two stable compatibility facades:

- `AnalysisService`
- `AnalysisReferenceService`

Internal roles remain explicit `@Component` types such as Manager, Reader, Normalizer, Policy, Collector, Extractor, Synchronizer, Adapter, Codec and HTTP Mapper.

Persistence adapter remains `@Repository`.

### 4. Code-style governance

Adds `AnalysisCodeStyleConventionTest` to protect low-ambiguity repository rules:

- no wildcard imports
- constructor injection instead of field injection
- no `System.out` / `System.err`
- no `BeanUtils.copyProperties`
- Analysis Domain and semantic value objects remain framework-free
- root `CODE_STYLE.md` remains the single repository-wide style document

### 5. Documentation governance

Adds `AnalysisArchitectureDocumentationTest` so the long-term module contracts remain present, linked from README and explicit about the critical ownership rules.

Existing `AnalysisLayeringConventionTest` continues to protect Repository, Controller, stable facade and Gateway boundaries from Stage 1.

## Behavior intentionally unchanged

This PR does **not** change production behavior or database/API contracts. It preserves:

- `/api/v1/analyses/**`
- existing request/response JSON and long-id string serialization
- `yak_analysis` and current Flyway baseline
- Dataset binding semantics
- query defaults and validation limits
- METRIC / PIE / BAR / LINE / TABLE binding rules
- visual defaults
- `AnalysisReferenceService`
- `AnalysisDeletionGuard`
- after-commit Lineage refresh and failure isolation
- `ANALYSIS_BINDING` evidence and current asset/relation keys

## Dependency audit note

The direct Maven dependency on `yak-ops-business-datasource` is intentionally retained because Analysis infrastructure currently reuses datasource enablement, business DataSource wiring and DAO/repository conditional configuration. The new dependency contract explicitly prevents that infrastructure dependency from leaking into Analysis Definition/Query/Domain business roles.

## Validation note

The branch is based directly on current `main` and contains one targeted commit.

A full Maven run is **not claimed from this tool environment**. Final verification should run in the normal project environment, for example:

```bash
mvn -pl yak-ops-business/yak-ops-business-analysis -am test
```
