### PR TITLE
refactor(dashboard): establish stage 2 architecture governance

### DIFF
--- a/yak-ops-business/yak-ops-business-dashboard/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-dashboard/ARCHITECTURE.md
@@ -1,0 +1,257 @@
+# Dashboard Architecture
+
+## Architecture principle
+
+Package names describe business capability and role. Dashboard uses explicit boundaries rather than a generic Service/Support layer.
+
+```text
+HTTP
+  -> DashboardService facade
+      -> Definition / Version / Publication
+          -> shared Read side
+          -> Composition
+          -> Dashboard-owned gateways
+          -> Repositories
+              -> DAO
+
+Committed Dashboard change
+  -> Change fact
+  -> after-commit Lineage listener
+      -> effective snapshot reader
+      -> Lineage synchronizer
+          -> DashboardLineageGraphGateway
+              -> Lineage adapter
+```
+
+## Package roles
+
+### Root facade
+
+`DashboardService` is the stable application/HTTP compatibility facade. It delegates to explicit internal roles and should not absorb their implementation logic.
+
+### `definition`
+
+Owns stable Dashboard identity mutation use cases.
+
+- `DashboardManager`: create/delete identity lifecycle.
+
+Definition uses the shared `read` role for identity/current reads and the neutral `change` fact for derived projection notification. It may delegate version append during initial V1 creation without making Version depend back on Definition.
+
+### `read`
+
+`DashboardReader` is the shared read-side entry for Dashboard identity and current detail.
+
+It depends only on Domain and Repository ports, so Definition, Version, Publication and the stable facade can reuse it without creating package cycles.
+
+### `change`
+
+`DashboardChangedEvent` is the committed mutation fact consumed by derived projections. It is a tiny framework-free value and does not depend on Definition, Version, Publication or Lineage.
+
+### `version`
+
+Owns immutable version lifecycle.
+
+- `DashboardVersionAppender`: append snapshot then move current pointer.
+- `DashboardVersionManager`: save and restore use cases.
+- `DashboardVersionReader`: version history and immutable snapshot reads.
+
+This package may use shared `read` and `change` roles. It must not implement publication semantics.
+
+### `publication`
+
+Owns the published pointer and effective-snapshot selection.
+
+- `DashboardPublisher`: move published pointer to current.
+- `DashboardEffectiveSnapshotReader`: choose published when present, otherwise current for downstream effective projection.
+
+Publication uses shared `read`, Repository ports and the neutral change fact. It must not mutate immutable versions.
+
+### `composition`
+
+Owns normalization of candidate Dashboard composition.
+
+- `DashboardCompositionNormalizer`: orchestration only.
+- `DashboardWidgetPolicy`: widget identity/content-mode rules.
+- `DashboardLayoutPolicy`: grid constraints.
+- `DashboardFilterPolicy`: global-filter/binding rules.
+- `DashboardInteractionPolicy`: interaction graph rules.
+- `DashboardJsonPolicy`: dynamic JSON shape/size boundary.
+
+Composition may enter Analysis only through `DashboardAnalysisGateway`.
+
+### `gateway/analysis`
+
+Dashboard-owned port for validating reusable Analysis references.
+
+```text
+Dashboard composition
+  -> DashboardAnalysisGateway
+  -> AnalysisDashboardAdapter
+  -> AnalysisReferenceService
+```
+
+Only the adapter knows the Analysis module API.
+
+### `reference`
+
+Hosts Dashboard's implementation of the Analysis deletion guard. It asks `DashboardReferenceRepository` about historical references rather than reaching into DAO directly.
+
+### `lineage`
+
+Owns derived lineage projection, not Dashboard command truth.
+
+- `DashboardLineageRefreshListener`: after-commit trigger and failure isolation.
+- `DashboardLineageSynchronizer`: independent-transaction projection convergence.
+- `DashboardInlineLineageExtractor`: best-effort inline payload interpretation.
+
+The listener consumes the neutral `change` fact and effective publication read-side. Lineage enters the shared graph only through `DashboardLineageGraphGateway`.
+
+### `gateway/lineage`
+
+Dashboard-owned graph contract and adapter.
+
+Only `LineageDashboardAdapter` may translate to Lineage module types and ObjectMapper/JsonNode infrastructure required by that external contract.
+
+### `repository`
+
+Business persistence ports are split by role:
+
+- `DashboardRepository`: identity and current/published pointers;
+- `DashboardVersionRepository`: immutable version snapshots;
+- `DashboardReferenceRepository`: historical Analysis reference query.
+
+Adapters translate to DAO/PO and may use the persistence codec.
+
+### `repository/codec`
+
+`DashboardJsonCodec` owns persistence serialization for Dashboard JSON columns. JSON persistence details do not leak into application/domain APIs.
+
+### `dao`
+
+Database-facing persistence implementation. DAO may expose PO/MyBatis details internally but not upward through repository contracts.
+
+### `domain`
+
+Framework-free Dashboard semantic values and snapshots.
+
+Domain does not depend on Spring, HTTP, MyBatis, DAO, Repository adapters, Analysis implementation APIs or Lineage implementation APIs.
+
+### `controller/v1`
+
+HTTP transport boundary. DTO/VO/mappers remain here. Controller enters the application through `DashboardService` and never through repositories, DAOs or gateway adapters.
+
+### `config`
+
+Infrastructure wiring only.
+
+## Save flow
+
+```text
+HTTP request
+ -> DashboardService.saveVersion
+ -> DashboardVersionManager
+ -> DashboardReader
+ -> DashboardCompositionNormalizer
+ -> policies / Analysis gateway
+ -> DashboardVersionAppender
+ -> DashboardVersionRepository.appendVersion
+ -> DashboardRepository.updateCurrentVersion
+ -> publish DashboardChangedEvent
+ -> commit
+ -> after-commit lineage projection
+```
+
+## Create flow
+
+```text
+normalize candidate
+ -> create Dashboard identity
+ -> append V1
+ -> move current pointer to V1
+ -> publish change fact
+ -> commit
+```
+
+## Restore flow
+
+```text
+read historical immutable snapshot Vn
+ -> convert snapshot to candidate DashboardDraft
+ -> normalize
+ -> append next version Vm
+ -> current = Vm
+ -> published unchanged
+```
+
+No historical version row is reactivated or mutated.
+
+## Publish flow
+
+```text
+require Dashboard through shared read side
+ -> require current version
+ -> if current == published: no-op
+ -> update published pointer to current
+ -> publish change fact
+ -> commit
+```
+
+## Lineage flow
+
+```text
+DashboardChangedEvent AFTER_COMMIT
+ -> deleted? clear evidence
+ -> otherwise DashboardEffectiveSnapshotReader
+      published if present
+      else current
+ -> DashboardLineageSynchronizer (REQUIRES_NEW)
+ -> DashboardLineageGraphGateway
+ -> LineageDashboardAdapter
+ -> shared Lineage graph
+```
+
+Failure after the Dashboard commit is logged and isolated.
+
+## Persistence flow
+
+```text
+Application role
+ -> Repository port
+ -> Repository adapter
+ -> DAO
+ -> MyBatis / Dashboard tables
+```
+
+Repository adapters own persistence mapping. Application roles do not know PO/Mapper/JdbcTemplate.
+
+## Acyclic application graph
+
+The shared `read` and `change` packages are intentionally lower-level than Definition/Version/Publication:
+
+```text
+definition -> read / change / version-appender
+version    -> read / change
+publication-> read / change
+read       -> repository / domain
+change     -> JDK only
+```
+
+Version does not depend on Definition, which closes the Stage 1 `definition <-> version` package cycle.
+
+## Architecture exclusions
+
+Do not introduce top-level production buckets such as:
+
+```text
+service/
+common/
+helper/
+helpers/
+utils/
+util/
+base/
+persistence/
+support/
+```
+
+A new class must state the Dashboard capability and role it belongs to.

--- a/yak-ops-business/yak-ops-business-dashboard/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-dashboard/DEPENDENCIES.md
@@ -1,0 +1,184 @@
+# Dashboard Dependency Contract
+
+## Direction
+
+Dependencies point from transport/application orchestration toward explicit business/persistence ports. Cross-module dependencies pass through Dashboard-owned gateways.
+
+## Package matrix
+
+| Source | Allowed direct Dashboard dependencies |
+| --- | --- |
+| root `DashboardService` | `definition`, `read`, `version`, `publication`, `domain` |
+| `controller` | root stable facade, controller DTO/VO/mapper, domain types needed by transport mappers |
+| `definition` | `read`, `change`, `domain`, `composition`, version appender, `repository` ports |
+| `read` | `domain`, `repository` ports |
+| `change` | JDK only |
+| `version` | `read`, `change`, `domain`, `composition`, `repository` ports |
+| `publication` | `read`, `change`, `domain`, `repository` ports |
+| `composition` | `domain`, `gateway.analysis` port |
+| `reference` | `repository` reference port plus external Analysis deletion extension contract |
+| `lineage` | `change`, `domain`, `publication` effective read-side, `gateway.lineage` port |
+| `gateway.analysis` | Dashboard-owned port; adapter may call Analysis stable reference facade |
+| `gateway.lineage` | Dashboard-owned port; adapter may call Lineage module APIs |
+| `repository` | `domain`, `dao`, `repository.codec`, infrastructure annotations |
+| `repository.codec` | Jackson persistence infrastructure only |
+| `dao` | DAO/PO/Mapper/MyBatis + datasource infrastructure |
+| `domain` | JDK only |
+| `config` | wiring/infrastructure only |
+
+The matrix describes permitted direction, not permission for every class to depend on every package in its row. Keep dependencies narrower when possible.
+
+## Stable facade corridor
+
+HTTP and compatibility callers enter through:
+
+```text
+DashboardController
+    -> DashboardService
+```
+
+Controller must not inject repositories, DAOs, cross-module gateways or lineage internals.
+
+## Shared read and change roles
+
+`DashboardReader` lives in `read` rather than Definition because Version and Publication also need Dashboard identity/current reads. `DashboardChangedEvent` lives in neutral `change` for the same reason.
+
+This deliberately prevents:
+
+```text
+definition -> version
+version    -> definition
+```
+
+from becoming a package cycle.
+
+`read` depends only on Repository/Domain. `change` is framework-free and depends only on JDK types.
+
+## Analysis corridor
+
+Composition cannot import the Analysis module directly.
+
+The only Dashboard business corridor is:
+
+```text
+composition
+ -> DashboardAnalysisGateway
+ -> AnalysisDashboardAdapter
+ -> AnalysisReferenceService
+```
+
+Only `gateway/analysis/AnalysisDashboardAdapter` may import Analysis application/reference implementation types for reusable widget validation.
+
+Dashboard's Analysis deletion guard is the inverse extension mechanism already defined by Analysis. The guard implementation may implement `AnalysisDeletionGuard`, but it must query Dashboard history through `DashboardReferenceRepository`, not DAO.
+
+## Lineage corridor
+
+Dashboard lineage business code cannot import `LineageService`, `LineageMaintenanceService`, Lineage PO/model types or ObjectMapper for graph translation.
+
+The only graph corridor is:
+
+```text
+lineage
+ -> DashboardLineageGraphGateway
+ -> LineageDashboardAdapter
+ -> Lineage module
+```
+
+Only `gateway/lineage/LineageDashboardAdapter` may know the Lineage module API and graph JSON translation infrastructure.
+
+## Repository corridor
+
+Application packages use repository interfaces only.
+
+```text
+application role
+ -> DashboardRepository / DashboardVersionRepository / DashboardReferenceRepository
+ -> adapter
+ -> DashboardDao
+```
+
+Repository interfaces must not expose:
+
+- `DashboardPO` or other DAO models;
+- MyBatis Mapper types;
+- `JdbcTemplate`;
+- controller DTO/VO;
+- serialized JSON strings as the business representation of version composition.
+
+## Domain purity
+
+`domain` must not import:
+
+- Spring;
+- Jackson transport/persistence infrastructure;
+- MyBatis;
+- Dashboard DAO/repository adapters;
+- controller DTO/VO;
+- Analysis module APIs;
+- Lineage module APIs.
+
+Domain types remain plain Java records/enums/value objects.
+
+## Version and publication separation
+
+`version` owns append/read/restore. It must not update the published pointer.
+
+`publication` owns published-pointer transition and effective-snapshot selection. It must not append or mutate historical version rows.
+
+This separation protects:
+
+```text
+current != published
+```
+
+as a first-class Dashboard invariant.
+
+## Effective projection corridor
+
+Derived consumers that need the effective Dashboard snapshot should use `DashboardEffectiveSnapshotReader` rather than reproducing:
+
+```text
+published if present else current
+```
+
+in multiple places.
+
+Lineage currently uses this read-side policy.
+
+## Datasource dependency
+
+Dashboard retains a direct Maven dependency on `yak-ops-business-datasource` because persistence/configuration reuses:
+
+- conditional datasource enablement;
+- business DataSource wiring;
+- Flyway/MyBatis infrastructure.
+
+This is an infrastructure dependency. It must not leak into Dashboard domain/composition/version/publication business semantics beyond configuration/conditional annotations already required for module activation.
+
+## Dataset dependency
+
+Dashboard does not currently require a direct Dataset business dependency. `activeDatasetId` remains optional metadata and inline lineage parsing is projection-only evidence.
+
+Do not add Dataset validation as a side effect of architecture refactoring.
+
+## Forbidden broad buckets
+
+Do not reintroduce top-level production packages named:
+
+```text
+service
+common
+helper
+helpers
+utils
+util
+base
+persistence
+support
+```
+
+Use the role vocabulary from repository `CODE_STYLE.md` and the Dashboard architecture instead.
+
+## Acyclic rule
+
+The Dashboard package graph must remain acyclic. A new import that creates a cycle is an architecture defect even when compilation succeeds.

--- a/yak-ops-business/yak-ops-business-dashboard/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-dashboard/DOMAIN.md
@@ -1,0 +1,198 @@
+# Dashboard Domain
+
+## Aggregate truth
+
+Dashboard is a versioned composition aggregate with two levels of truth:
+
+```text
+DashboardAsset
+    = stable identity
+      + current-version pointer
+      + published-version pointer
+      + current-list projection fields
+
+DashboardVersionSnapshot
+    = immutable composition truth for one version
+```
+
+`DashboardAsset.name` and `description` follow the current-version projection for list/read convenience. They do not replace the name/description snapshot stored on historical DashboardVersion rows.
+
+## DashboardAsset
+
+`DashboardAsset` owns:
+
+- Dashboard ID;
+- current version ID/no;
+- published version ID/no;
+- published time;
+- current projected name/description;
+- create/update timestamps.
+
+It does not own mutable widget/filter/interaction collections.
+
+## DashboardVersion
+
+`DashboardVersion` is immutable after append.
+
+It owns version metadata:
+
+- version identity;
+- Dashboard identity;
+- monotonically selected version number under the current repository strategy;
+- name/description snapshot;
+- optional active Dataset ID metadata;
+- create time.
+
+`DashboardVersionSnapshot` completes that truth with:
+
+- theme;
+- widget snapshots;
+- global-filter snapshots;
+- interaction snapshots.
+
+### Append-only invariant
+
+For a live Dashboard:
+
+```text
+save candidate
+    != mutate current row
+
+save candidate
+    = append next immutable version
+```
+
+Historical rows may only disappear when their owning Dashboard is deleted according to existing persistence semantics.
+
+## DashboardDraft
+
+`DashboardDraft` is a candidate composition used to create the next immutable DashboardVersion.
+
+Unlike the former Analysis `Draft` terminology, Dashboard Draft has a real relationship to version creation: it is normalized input before append. It is not itself persistent lifecycle state and there is no `DRAFT` database status row.
+
+## Current pointer
+
+`currentVersionId` identifies the current editable Dashboard snapshot.
+
+Moving current does not make that version published.
+
+## Published pointer
+
+`publishedVersionId` identifies the externally effective published snapshot.
+
+Publishing changes the pointer only:
+
+```text
+publishedVersionId = currentVersionId
+```
+
+It does not mutate the version snapshot.
+
+Current and published may diverge for an arbitrary number of new draft versions.
+
+## Restore invariant
+
+Restore is copy-forward, not pointer rewind.
+
+```text
+V1 -> V2 -> V3(current)
+restore V1
+        ↓
+append V4(copy of V1 composition)
+current -> V4
+```
+
+If published is V2, restore must leave published at V2 until an explicit publish occurs.
+
+The deprecated `activateVersion` name is compatibility vocabulary only; its domain meaning is restore-as-new-version.
+
+## Composition
+
+### Widget
+
+A widget contains layout plus exactly one content binding:
+
+```text
+reusable Analysis reference
+OR
+inline Analysis payload
+```
+
+A linked widget freezes the Analysis ID reference in the DashboardVersion. It does **not** freeze the referenced Analysis definition.
+
+An inline widget freezes its inline payload directly in the DashboardVersion.
+
+### Layout
+
+Layout belongs to the DashboardVersion. The current contract uses a 24-column grid and the existing dimension/min-size constraints.
+
+### Global filters
+
+Global filters, filter keys, default values and widget-field bindings belong to the DashboardVersion snapshot.
+
+A filter binding references a widget key and a field ID. Dashboard owns the binding relation, not the field's Dataset schema truth.
+
+### Interactions
+
+Interactions belong to the version snapshot and connect an existing source widget/field to an existing target filter.
+
+## activeDatasetId
+
+`activeDatasetId` is currently optional version metadata.
+
+It is not proof that a Dataset is ONLINE, that a Dataset version exists, or that every field binding belongs to that Dataset. No such new invariant is introduced by this refactor.
+
+## Analysis ownership
+
+Analysis owns reusable analytical definitions.
+
+Dashboard owns:
+
+- an Analysis ID reference frozen into a DashboardVersion; or
+- an inline payload frozen into a DashboardVersion.
+
+Dashboard does not become a second Analysis-definition owner.
+
+### Historical deletion restriction
+
+Dashboard's historical version truth means an old Analysis reference remains meaningful even when the current Dashboard version no longer uses it.
+
+Therefore the existing deletion invariant remains:
+
+```text
+any historical DashboardVersion references Analysis X
+    => Analysis X is not deletable
+```
+
+## Lineage ownership
+
+Lineage owns graph truth.
+
+Dashboard Lineage owns only the deterministic/best-effort projection logic from committed Dashboard state.
+
+The effective lineage snapshot rule is:
+
+```text
+published exists -> project published
+otherwise         -> project current
+```
+
+Projection happens after commit and in an independent transaction. Projection failure does not roll back already committed Dashboard truth.
+
+## Inline lineage parsing
+
+Inline Analysis JSON is not promoted into a second Dashboard analysis domain model.
+
+`DashboardInlineLineageExtractor` may interpret known fields for derived lineage evidence. Parse status such as success/partial/unresolved describes projection evidence, not Dashboard lifecycle state.
+
+## Persistence truth
+
+Database rows own durable Dashboard identity, pointers and immutable version snapshots.
+
+Repository adapters translate between persistence rows/JSON columns and Dashboard domain values. PO/Mapper/MyBatis types are not domain contracts.
+
+## Known domain gap: version allocation concurrency
+
+The current flow obtains `nextVersionNo` and then appends. The unique `(dashboard_id, version_no)` database key protects duplicate durable numbers, but the application does not yet define a richer retry/CAS allocator contract.
+
+This is intentionally documented as a future domain/concurrency concern. Architecture governance must not pretend the gap is solved.

--- a/yak-ops-business/yak-ops-business-dashboard/README.md
+++ b/yak-ops-business/yak-ops-business-dashboard/README.md
@@ -1,0 +1,127 @@
+# Yak Ops Business Dashboard
+
+`yak-ops-business-dashboard` owns versioned Dashboard composition in Yak Ops.
+
+Read these contracts before changing the module:
+
+- [REQUIREMENTS.md](REQUIREMENTS.md) — supported behavior and non-goals.
+- [DOMAIN.md](DOMAIN.md) — truth ownership and lifecycle invariants.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — package roles and execution flows.
+- [DEPENDENCIES.md](DEPENDENCIES.md) — allowed dependency corridors.
+- [REVIEW.md](REVIEW.md) — review checklist for future changes.
+- [`../../CODE_STYLE.md`](../../CODE_STYLE.md) — repository-wide engineering style.
+
+## Core model
+
+```text
+Dashboard identity
+    ├── currentVersionId   -> current editable snapshot
+    └── publishedVersionId -> externally effective snapshot
+
+DashboardVersion
+    ├── theme snapshot
+    ├── widget snapshots
+    ├── global-filter snapshots
+    └── interaction snapshots
+```
+
+A Dashboard is not a mutable layout row. Saving composition appends a new immutable `DashboardVersion` and moves the current pointer. Publishing moves only the published pointer. Restoring an old version copies that historical snapshot into a **new** version.
+
+## Truth ownership
+
+```text
+Dashboard
+    owns identity + current/published pointers
+
+DashboardVersion
+    owns immutable composition snapshot
+
+Analysis
+    owns reusable Analysis definitions
+
+Lineage
+    owns lineage graph truth
+
+Dashboard lineage subsystem
+    owns best-effort projection of committed Dashboard state
+```
+
+A linked widget freezes an `analysisId` reference, not a copy of the Analysis definition. An inline widget freezes its inline payload inside the Dashboard version.
+
+## Package map
+
+```text
+io.yak.ops.business.dashboard
+├── DashboardService          stable compatibility facade
+├── definition                identity mutation
+├── read                      shared Dashboard identity/current read side
+├── change                    committed Dashboard change fact
+├── version                   append/read/restore immutable versions
+├── publication               publish pointer + effective snapshot selection
+├── composition               widget/layout/filter/interaction/json policies
+├── gateway/analysis          Dashboard-owned Analysis reference corridor
+├── gateway/lineage           Dashboard-owned Lineage graph corridor
+├── reference                 historical Analysis deletion restriction
+├── lineage                   derived lineage projection
+├── repository                business persistence ports/adapters
+├── repository/codec          persistence JSON conversion
+├── dao                       MyBatis persistence implementation
+├── domain                    framework-free Dashboard model
+├── controller/v1             HTTP boundary
+└── config                    infrastructure wiring
+```
+
+`read` and `change` are deliberately neutral packages shared by Definition, Version, Publication and Lineage. They prevent application capability packages from depending back on each other and keep the package graph acyclic.
+
+## Key lifecycle
+
+```text
+create
+  -> create Dashboard identity
+  -> append V1
+  -> current = V1
+
+save
+  -> normalize composition
+  -> append V(n+1)
+  -> current = V(n+1)
+
+publish
+  -> published = current
+
+restore V2 while current is V7
+  -> copy V2 snapshot
+  -> append V8
+  -> current = V8
+  -> published remains unchanged
+```
+
+`currentVersion` and `publishedVersion` are intentionally independent. Editing a newer draft must not change the published snapshot.
+
+## Cross-module boundaries
+
+Dashboard business roles do not call Analysis or Lineage implementation APIs directly.
+
+```text
+Composition
+    -> DashboardAnalysisGateway
+    -> AnalysisDashboardAdapter
+    -> AnalysisReferenceService
+
+Lineage projection
+    -> DashboardLineageGraphGateway
+    -> LineageDashboardAdapter
+    -> Lineage module
+```
+
+The direct Maven datasource dependency remains an infrastructure dependency for DataSource/Flyway/MyBatis enablement. It is not a Dashboard domain dependency.
+
+## Validation
+
+Authoritative module verification in a normal project environment:
+
+```bash
+mvn -pl yak-ops-business/yak-ops-business-dashboard -am test
+```
+
+Architecture tests under `src/test/java/io/yak/ops/business/dashboard/architecture` protect the package graph, gateway corridors, role stereotypes, documentation, persistence boundary and low-ambiguity code-style rules.

--- a/yak-ops-business/yak-ops-business-dashboard/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-dashboard/REQUIREMENTS.md
@@ -1,0 +1,162 @@
+# Dashboard Requirements
+
+## Purpose
+
+Dashboard provides persistent, versioned BI composition. It composes reusable Analysis references and optional inline analysis payloads into layouts, filters and interactions while keeping editing and published state independent.
+
+## Supported use cases
+
+The module supports:
+
+- list Dashboard identities;
+- read the current Dashboard detail;
+- create a Dashboard and append version V1;
+- append a new Dashboard version;
+- list version history;
+- read an immutable version snapshot;
+- publish the current version;
+- read the published snapshot;
+- restore a historical snapshot as a new version;
+- delete a Dashboard and its owned version history;
+- reject Analysis deletion while any historical DashboardVersion still references it;
+- project the effective Dashboard snapshot into Lineage after commit.
+
+The existing deprecated `activateVersion` API remains a compatibility alias for restore. It must not reactivate an old version row.
+
+## Composition contract
+
+A Dashboard version may contain:
+
+- name and description snapshot;
+- optional `activeDatasetId` metadata;
+- optional theme JSON object;
+- widgets;
+- global filters and widget-field bindings;
+- interactions.
+
+### Widget binding
+
+Every widget must choose exactly one content mode:
+
+```text
+analysisId XOR inlineAnalysis
+```
+
+A reusable `analysisId` must reference an existing Analysis. An inline payload is stored as part of the immutable DashboardVersion snapshot.
+
+### Existing validation limits
+
+Stage 1 behavior remains the contract:
+
+- at most 200 widgets;
+- 24-column layout grid;
+- `x` in 0..23;
+- positive width/height within existing limits;
+- widget must not overflow the 24-column grid;
+- at most 20 global filters;
+- at most 200 filter bindings;
+- at most 100 interactions;
+- existing JSON object/scalar and serialized-size validation remains unchanged.
+
+## Version requirements
+
+DashboardVersion is append-only for the lifetime of a Dashboard.
+
+Saving composition must:
+
+```text
+normalize candidate composition
+ -> allocate next version number using current repository strategy
+ -> append immutable version snapshot
+ -> move currentVersion pointer
+```
+
+Existing historical version rows must not be mutated by save or restore.
+
+### Restore
+
+Restoring historical V2 while current is V7 must produce V8. It must not point `currentVersionId` back to the old V2 row.
+
+### Current and published pointers
+
+`currentVersionId` represents the latest editable snapshot.
+
+`publishedVersionId` represents the externally effective published snapshot.
+
+They may intentionally differ, for example:
+
+```text
+current   = V8
+published = V5
+```
+
+Saving V9 must not change `publishedVersionId`.
+
+## Publication requirements
+
+Publishing must move the published pointer to the current immutable version. It must not copy, rewrite or renumber that version.
+
+Publishing when current and published already point to the same version remains idempotent from the Dashboard business perspective.
+
+## Analysis reference requirements
+
+Reusable Analysis definitions remain owned by `yak-ops-business-analysis`.
+
+Dashboard owns only the reference embedded in each version snapshot. A DashboardVersion that stores `analysisId = 10` does not freeze the current Analysis definition as a Dashboard-owned copy.
+
+Historical references matter for deletion safety: if any historical DashboardVersion references Analysis 10, Dashboard's `AnalysisDeletionGuard` integration must continue to block deletion of Analysis 10.
+
+## Inline analysis requirements
+
+Inline Analysis is a Dashboard-owned opaque JSON payload frozen inside the version snapshot.
+
+Dashboard validation checks its configured JSON shape/size but does not introduce Dataset lifecycle/schema ownership.
+
+Lineage may perform best-effort parsing of known inline fields (`datasetId`, dimensions, metrics, filters, sorts). Failure to understand an inline payload must not corrupt Dashboard truth.
+
+## Lineage requirements
+
+Lineage is a derived projection of committed Dashboard state.
+
+After Dashboard mutation commits:
+
+- use the published snapshot when a published version exists;
+- otherwise use the current draft snapshot;
+- synchronize in an independent transaction;
+- isolate projection failure from the already committed Dashboard business operation;
+- preserve `DASHBOARD_BINDING` evidence semantics and existing asset/relation keys.
+
+Lineage never becomes Dashboard command truth.
+
+## Persistence requirements
+
+The existing six Dashboard tables and Flyway baseline remain authoritative persistence for this stage:
+
+- `yak_dashboard`;
+- `yak_dashboard_version`;
+- `yak_dashboard_widget`;
+- `yak_dashboard_filter`;
+- `yak_dashboard_filter_binding`;
+- `yak_dashboard_interaction`.
+
+Repository contracts expose Dashboard domain/JDK values. DAO/PO/MyBatis details stay below repository adapters.
+
+## HTTP compatibility
+
+Stage 2 does not change `/api/v1/dashboards/**`, request/response JSON fields, long-ID serialization, or the deprecated activate route.
+
+## Explicit non-goals
+
+This architecture governance does **not** add:
+
+- a Dashboard execution engine;
+- Dataset query execution;
+- automatic Dataset ONLINE/schema validation for `activeDatasetId`;
+- an Analysis definition copy/version inside Dashboard;
+- in-place historical version editing;
+- publish-time version copying;
+- a new Dashboard status state machine;
+- stronger version-number concurrency/CAS semantics;
+- synchronous Lineage truth.
+
+The current `nextVersionNo -> appendVersion` strategy is a known concurrency boundary. Stronger allocation/retry/CAS behavior is a separate domain change and must not be smuggled into an architecture-only refactor.

--- a/yak-ops-business/yak-ops-business-dashboard/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-dashboard/REVIEW.md
@@ -1,0 +1,68 @@
+# Dashboard Review Checklist
+
+Use this checklist for Dashboard changes.
+
+## Truth ownership
+
+- Does Dashboard remain the sole owner of Dashboard identity/current/published pointers?
+- Does an immutable DashboardVersion remain the owner of its composition snapshot?
+- Is Analysis still the owner of reusable Analysis definitions?
+- Is Lineage still derived projection rather than command truth?
+
+## Version lifecycle
+
+- Does save append a new version instead of mutating history?
+- Does restore copy-forward into a new version rather than rewind the current pointer to an old row?
+- Can current and published pointers still differ safely?
+- Does save avoid moving the published pointer?
+- Does publish only move the published pointer?
+- Is `activateVersion` kept as compatibility vocabulary only?
+
+## Composition
+
+- Does each widget still choose exactly one of `analysisId` / `inlineAnalysis`?
+- Are layout/filter/interaction rules owned by explicit policies?
+- Is dynamic JSON handling contained at the JSON policy/persistence/adapter boundaries?
+- Did the change avoid inventing Dataset lifecycle/schema ownership for `activeDatasetId`?
+
+## Cross-module boundaries
+
+- Does Analysis access go through `DashboardAnalysisGateway`?
+- Is Analysis implementation knowledge confined to `AnalysisDashboardAdapter`?
+- Does Lineage access go through `DashboardLineageGraphGateway`?
+- Is Lineage implementation knowledge confined to `LineageDashboardAdapter`?
+- Does the Analysis deletion guard query `DashboardReferenceRepository` rather than DAO?
+
+## Persistence
+
+- Do application roles depend on repository ports instead of DAO/PO/Mapper?
+- Do repository contracts expose only Dashboard domain/JDK values?
+- Are JSON columns translated by the persistence codec/adapter rather than leaked upward?
+- Are schema/Flyway changes intentionally scoped rather than mixed into architecture cleanup?
+
+## Projection
+
+- Is Dashboard lineage triggered after commit?
+- Does it use `DashboardEffectiveSnapshotReader` instead of duplicating effective-snapshot logic?
+- Does projection run independently from the already committed Dashboard transaction?
+- Does projection failure remain isolated and observable through logs?
+- Does inline parse uncertainty remain projection evidence rather than Dashboard state?
+
+## Compatibility
+
+- Are `/api/v1/dashboards/**` paths unchanged unless the PR explicitly declares an API change?
+- Are request/response JSON and long-ID behavior preserved?
+- Is the deprecated activate route preserved when compatibility is required?
+
+## Concurrency
+
+- Did the PR accidentally claim the `nextVersionNo -> appendVersion` concurrency gap is solved?
+- If changing version allocation, is that change isolated, documented as domain behavior and protected by concurrency tests?
+
+## Architecture
+
+- Does the package name communicate capability and role?
+- Is the package graph acyclic?
+- Did a generic `service/common/helper/utils/base/support` bucket reappear?
+- Are `@Service`, `@Component`, `@Repository` and `@Configuration` used according to repository `CODE_STYLE.md`?
+- Which behavior test and architecture test protect the change?

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/DashboardService.java
@@ -1,13 +1,13 @@
 package io.yak.ops.business.dashboard;
 
 import io.yak.ops.business.dashboard.definition.DashboardManager;
-import io.yak.ops.business.dashboard.definition.DashboardReader;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
 import io.yak.ops.business.dashboard.domain.DashboardVersion;
 import io.yak.ops.business.dashboard.domain.DashboardVersionDetail;
 import io.yak.ops.business.dashboard.publication.DashboardPublisher;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.version.DashboardVersionManager;
 import io.yak.ops.business.dashboard.version.DashboardVersionReader;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/change/DashboardChangedEvent.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/change/DashboardChangedEvent.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.dashboard.definition;
+package io.yak.ops.business.dashboard.change;
 
 /** Committed Dashboard mutation fact consumed by derived projections. */
 public record DashboardChangedEvent(long dashboardId, boolean deleted) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/definition/DashboardManager.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/definition/DashboardManager.java
@@ -1,8 +1,10 @@
 package io.yak.ops.business.dashboard.definition;
 
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.composition.DashboardCompositionNormalizer;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.version.DashboardVersionAppender;
 import org.springframework.context.ApplicationEventPublisher;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListener.java
@@ -1,6 +1,6 @@
 package io.yak.ops.business.dashboard.lineage;
 
-import io.yak.ops.business.dashboard.definition.DashboardChangedEvent;
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
 import io.yak.ops.business.dashboard.publication.DashboardEffectiveSnapshotReader;
 import io.yak.ops.business.dashboard.publication.DashboardEffectiveSnapshotReader.EffectiveSnapshot;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/publication/DashboardEffectiveSnapshotReader.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/publication/DashboardEffectiveSnapshotReader.java
@@ -1,8 +1,8 @@
 package io.yak.ops.business.dashboard.publication;
 
-import io.yak.ops.business.dashboard.definition.DashboardReader;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardVersionRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/publication/DashboardPublisher.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/publication/DashboardPublisher.java
@@ -1,10 +1,10 @@
 package io.yak.ops.business.dashboard.publication;
 
-import io.yak.ops.business.dashboard.definition.DashboardChangedEvent;
-import io.yak.ops.business.dashboard.definition.DashboardReader;
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.repository.DashboardVersionRepository;
 import java.util.Objects;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/read/DashboardReader.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/read/DashboardReader.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.dashboard.definition;
+package io.yak.ops.business.dashboard.read;
 
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
@@ -10,7 +10,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Read-side entry for Dashboard identity and the current draft snapshot. */
+/** Shared read-side entry for Dashboard identity and the current draft snapshot. */
 @Component
 public class DashboardReader {
 

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/version/DashboardVersionManager.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/version/DashboardVersionManager.java
@@ -1,8 +1,7 @@
 package io.yak.ops.business.dashboard.version;
 
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.composition.DashboardCompositionNormalizer;
-import io.yak.ops.business.dashboard.definition.DashboardChangedEvent;
-import io.yak.ops.business.dashboard.definition.DashboardReader;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
 import io.yak.ops.business.dashboard.domain.DashboardVersionDetail;
@@ -10,6 +9,7 @@ import io.yak.ops.business.dashboard.domain.FilterBindingSpec;
 import io.yak.ops.business.dashboard.domain.GlobalFilterSpec;
 import io.yak.ops.business.dashboard.domain.InteractionSpec;
 import io.yak.ops.business.dashboard.domain.WidgetSpec;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import java.util.List;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/version/DashboardVersionReader.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/version/DashboardVersionReader.java
@@ -1,10 +1,10 @@
 package io.yak.ops.business.dashboard.version;
 
-import io.yak.ops.business.dashboard.definition.DashboardReader;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardVersion;
 import io.yak.ops.business.dashboard.domain.DashboardVersionDetail;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardVersionRepository;
 import java.util.List;
 import org.springframework.stereotype.Component;

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardArchitectureDocumentationTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardArchitectureDocumentationTest.java
@@ -1,0 +1,69 @@
+package io.yak.ops.business.dashboard.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DashboardArchitectureDocumentationTest {
+
+  private static final List<String> CONTRACTS = List.of(
+      "README.md",
+      "REQUIREMENTS.md",
+      "DOMAIN.md",
+      "ARCHITECTURE.md",
+      "DEPENDENCIES.md",
+      "REVIEW.md");
+
+  @Test
+  void architectureContractsExistAndAreLinkedFromReadme() throws IOException {
+    Path module = moduleRoot();
+    String readme = Files.readString(module.resolve("README.md"));
+
+    for (String contract : CONTRACTS) {
+      assertThat(module.resolve(contract)).exists();
+      if (!contract.equals("README.md")) {
+        assertThat(readme).contains(contract);
+      }
+    }
+    assertThat(readme).contains("CODE_STYLE.md");
+  }
+
+  @Test
+  void domainContractLocksVersionAndOwnershipSemantics() throws IOException {
+    String domain = Files.readString(moduleRoot().resolve("DOMAIN.md"));
+
+    assertThat(domain)
+        .contains("currentVersionId")
+        .contains("publishedVersionId")
+        .containsIgnoringCase("append-only")
+        .contains("Restore is copy-forward")
+        .contains("Analysis owns reusable analytical definitions")
+        .contains("Lineage owns graph truth")
+        .contains("version allocation concurrency");
+  }
+
+  @Test
+  void dependencyContractNamesTheTwoCrossModuleGateways() throws IOException {
+    String dependencies = Files.readString(moduleRoot().resolve("DEPENDENCIES.md"));
+
+    assertThat(dependencies)
+        .contains("DashboardAnalysisGateway")
+        .contains("AnalysisDashboardAdapter")
+        .contains("DashboardLineageGraphGateway")
+        .contains("LineageDashboardAdapter")
+        .contains("DashboardReferenceRepository")
+        .contains("acyclic");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("README.md");
+    if (Files.isRegularFile(local)) {
+      return Path.of(".");
+    }
+    return Path.of("yak-ops-business", "yak-ops-business-dashboard");
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardCodeStyleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardCodeStyleConventionTest.java
@@ -1,0 +1,102 @@
+package io.yak.ops.business.dashboard.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class DashboardCodeStyleConventionTest {
+
+  @Test
+  void productionJavaDoesNotUseWildcardImportsOrConsoleOutput() throws IOException {
+    for (Path source : productionJavaFiles()) {
+      String text = Files.readString(source);
+      assertThat(text).as(source.toString())
+          .doesNotContain("import java.*;")
+          .doesNotContain("import org.springframework.*;")
+          .doesNotContain("System.out.")
+          .doesNotContain("System.err.")
+          .doesNotContain("BeanUtils.copyProperties");
+      assertThat(text.lines().filter(line -> line.startsWith("import ") && line.contains(".*;")).count())
+          .as("wildcard imports in " + source)
+          .isZero();
+    }
+  }
+
+  @Test
+  void productionUsesConstructorInjectionInsteadOfAutowiredFields() throws IOException {
+    for (Path source : productionJavaFiles()) {
+      String text = Files.readString(source);
+      List<String> lines = text.lines().toList();
+      for (int index = 0; index < lines.size(); index++) {
+        if (!lines.get(index).trim().equals("@Autowired")) continue;
+        String next = nextNonBlank(lines, index + 1);
+        assertThat(next)
+            .as("@Autowired must not annotate a field in " + source)
+            .contains("(");
+      }
+    }
+  }
+
+  @Test
+  void domainRemainsFrameworkFree() throws IOException {
+    Path domain = productionRoot().resolve("domain");
+    try (Stream<Path> paths = Files.walk(domain)) {
+      for (Path source : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String text = Files.readString(source);
+        assertThat(text).as(source.toString())
+            .doesNotContain("org.springframework")
+            .doesNotContain("com.baomidou.mybatisplus")
+            .doesNotContain("jakarta.validation")
+            .doesNotContain("com.fasterxml.jackson")
+            .doesNotContain("io.yak.ops.business.dashboard.dao")
+            .doesNotContain("io.yak.ops.business.dashboard.controller")
+            .doesNotContain("io.yak.ops.business.analysis")
+            .doesNotContain("io.yak.ops.business.lineage");
+      }
+    }
+  }
+
+  @Test
+  void repositoryCodeStyleHasSingleRepositoryWideSource() {
+    Path root = repositoryRoot();
+    assertThat(root.resolve("CODE_STYLE.md")).exists();
+    assertThat(moduleRoot().resolve("CODE_STYLE.md")).doesNotExist();
+  }
+
+  private List<Path> productionJavaFiles() throws IOException {
+    try (Stream<Path> paths = Files.walk(productionRoot())) {
+      return paths.filter(path -> path.toString().endsWith(".java")).toList();
+    }
+  }
+
+  private String nextNonBlank(List<String> lines, int start) {
+    for (int index = start; index < lines.size(); index++) {
+      if (!lines.get(index).isBlank()) return lines.get(index).trim();
+    }
+    return "";
+  }
+
+  private Path productionRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/dashboard");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/dashboard");
+    if (Files.isDirectory(local)) return Path.of(".");
+    return Path.of("yak-ops-business", "yak-ops-business-dashboard");
+  }
+
+  private Path repositoryRoot() {
+    Path module = moduleRoot().toAbsolutePath().normalize();
+    if (module.getFileName() != null && module.getFileName().toString().equals("yak-ops-business-dashboard")) {
+      Path business = module.getParent();
+      if (business != null && business.getParent() != null) return business.getParent();
+    }
+    return Path.of(".").toAbsolutePath().normalize();
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardDependencyBoundaryTest.java
@@ -1,0 +1,179 @@
+package io.yak.ops.business.dashboard.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class DashboardDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.dashboard";
+
+  @Test
+  void dashboardPackageGraphIsAcyclic() throws IOException {
+    Map<String, Set<String>> graph = packageGraph();
+    Set<String> visited = new HashSet<>();
+    Set<String> visiting = new LinkedHashSet<>();
+    Deque<String> path = new ArrayDeque<>();
+
+    for (String node : graph.keySet()) {
+      detectCycle(node, graph, visited, visiting, path);
+    }
+  }
+
+  @Test
+  void controllerCannotEnterPersistenceGatewaysOrLineageInternals() throws IOException {
+    assertPackageDoesNotImport("controller",
+        BASE + ".repository",
+        BASE + ".dao",
+        BASE + ".gateway",
+        BASE + ".lineage");
+  }
+
+  @Test
+  void compositionEntersAnalysisOnlyThroughDashboardOwnedGateway() throws IOException {
+    assertPackageDoesNotImport("composition", "io.yak.ops.business.analysis");
+
+    for (Path source : productionJavaFiles()) {
+      String relative = relative(source);
+      String text = Files.readString(source);
+      if (text.contains("import io.yak.ops.business.analysis.AnalysisReferenceService")) {
+        assertThat(relative).isEqualTo("gateway/analysis/AnalysisDashboardAdapter.java");
+      }
+    }
+  }
+
+  @Test
+  void lineageEntersSharedGraphOnlyThroughDashboardOwnedGateway() throws IOException {
+    assertPackageDoesNotImport("lineage", "io.yak.ops.business.lineage");
+
+    for (Path source : productionJavaFiles()) {
+      String relative = relative(source);
+      String text = Files.readString(source);
+      if (text.contains("import io.yak.ops.business.lineage.")) {
+        assertThat(relative).isEqualTo("gateway/lineage/LineageDashboardAdapter.java");
+      }
+    }
+  }
+
+  @Test
+  void applicationRolesCannotReachDaoDirectly() throws IOException {
+    for (String role : List.of("definition", "version", "publication", "composition", "reference", "lineage")) {
+      assertPackageDoesNotImport(role, BASE + ".dao");
+    }
+  }
+
+  @Test
+  void referenceGuardCannotReachDaoDirectly() throws IOException {
+    Path guard = productionRoot().resolve("reference/DashboardAnalysisDeletionGuard.java");
+    String text = Files.readString(guard);
+    assertThat(text)
+        .contains("DashboardReferenceRepository")
+        .doesNotContain("DashboardDao");
+  }
+
+  @Test
+  void versionAndPublicationResponsibilitiesDoNotCross() throws IOException {
+    assertPackageDoesNotImport("version", BASE + ".publication.DashboardPublisher");
+    String publisher = Files.readString(productionRoot().resolve("publication/DashboardPublisher.java"));
+    assertThat(publisher)
+        .doesNotContain("appendVersion(")
+        .doesNotContain("nextVersionNo(");
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() {
+    for (String bucket : List.of(
+        "service", "common", "helper", "helpers", "utils", "util", "base", "persistence", "support")) {
+      assertThat(Files.exists(productionRoot().resolve(bucket))).as(bucket).isFalse();
+    }
+    assertThat(Files.exists(productionRoot().resolve("repository/support"))).isFalse();
+  }
+
+  private void assertPackageDoesNotImport(String packageName, String... forbidden) throws IOException {
+    Path directory = productionRoot().resolve(packageName);
+    if (!Files.exists(directory)) return;
+    try (Stream<Path> paths = Files.walk(directory)) {
+      for (Path source : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String text = Files.readString(source);
+        for (String value : forbidden) {
+          assertThat(text).as(source.toString()).doesNotContain("import " + value);
+        }
+      }
+    }
+  }
+
+  private Map<String, Set<String>> packageGraph() throws IOException {
+    Map<String, Set<String>> graph = new LinkedHashMap<>();
+    for (Path source : productionJavaFiles()) {
+      String from = topLevelPackage(relative(source));
+      graph.computeIfAbsent(from, ignored -> new LinkedHashSet<>());
+      for (String line : Files.readAllLines(source)) {
+        String trimmed = line.trim();
+        if (!trimmed.startsWith("import " + BASE)) continue;
+        String imported = trimmed.substring("import ".length(), trimmed.length() - 1);
+        String suffix = imported.substring(BASE.length());
+        String first = suffix.startsWith(".") ? suffix.substring(1).split("\\.")[0] : "";
+        String to = first.isEmpty() || Character.isUpperCase(first.charAt(0)) ? "root" : first;
+        if (!to.equals(from)) graph.get(from).add(to);
+      }
+    }
+    return graph;
+  }
+
+  private String topLevelPackage(String relative) {
+    int slash = relative.indexOf('/');
+    return slash < 0 ? "root" : relative.substring(0, slash);
+  }
+
+  private void detectCycle(
+      String node,
+      Map<String, Set<String>> graph,
+      Set<String> visited,
+      Set<String> visiting,
+      Deque<String> path) {
+    if (visited.contains(node)) return;
+    if (!visiting.add(node)) {
+      List<String> cycle = new ArrayList<>(path);
+      cycle.add(node);
+      throw new AssertionError("Dashboard package cycle: " + cycle);
+    }
+    path.addLast(node);
+    for (String target : graph.getOrDefault(node, Set.of())) {
+      if (graph.containsKey(target)) detectCycle(target, graph, visited, visiting, path);
+    }
+    path.removeLast();
+    visiting.remove(node);
+    visited.add(node);
+  }
+
+  private List<Path> productionJavaFiles() throws IOException {
+    try (Stream<Path> paths = Files.walk(productionRoot())) {
+      return paths.filter(path -> path.toString().endsWith(".java")).toList();
+    }
+  }
+
+  private String relative(Path source) {
+    return productionRoot().relativize(source).toString().replace('\\', '/');
+  }
+
+  private Path productionRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/dashboard");
+    if (Files.isDirectory(local)) return local;
+    return Path.of(
+        "yak-ops-business", "yak-ops-business-dashboard", "src", "main", "java",
+        "io", "yak", "ops", "business", "dashboard");
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardLayeringConventionTest.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.dashboard.gateway.analysis.DashboardAnalysisGateway;
 import io.yak.ops.business.dashboard.gateway.lineage.DashboardLineageGraphGateway;
 import io.yak.ops.business.dashboard.lineage.DashboardLineageSynchronizer;
 import io.yak.ops.business.dashboard.publication.DashboardPublisher;
+import io.yak.ops.business.dashboard.repository.DashboardReferenceRepository;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.repository.DashboardVersionRepository;
 import io.yak.ops.business.dashboard.version.DashboardVersionManager;
@@ -33,7 +34,7 @@ class DashboardLayeringConventionTest {
   void stableFacadeOnlyCoordinatesExplicitApplicationRoles() {
     for (Field field : DashboardService.class.getDeclaredFields()) {
       assertThat(field.getType().getName())
-          .matches("io\\.yak\\.ops\\.business\\.dashboard\\.(definition|version|publication)\\..+");
+          .matches("io\\.yak\\.ops\\.business\\.dashboard\\.(definition|read|version|publication)\\..+");
     }
   }
 
@@ -63,7 +64,10 @@ class DashboardLayeringConventionTest {
 
   @Test
   void repositoryContractsDoNotExposeDaoOrHttpTypes() {
-    for (Class<?> contract : List.of(DashboardRepository.class, DashboardVersionRepository.class)) {
+    for (Class<?> contract : List.of(
+        DashboardRepository.class,
+        DashboardVersionRepository.class,
+        DashboardReferenceRepository.class)) {
       for (Method method : contract.getDeclaredMethods()) {
         assertThat(method.toGenericString())
             .doesNotContain(".dao.", "com.baomidou.mybatisplus", "controller.v1", "JdbcTemplate");

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardRoleConventionTest.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.dashboard.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.dashboard.DashboardService;
+import io.yak.ops.business.dashboard.composition.DashboardCompositionNormalizer;
+import io.yak.ops.business.dashboard.composition.DashboardFilterPolicy;
+import io.yak.ops.business.dashboard.composition.DashboardInteractionPolicy;
+import io.yak.ops.business.dashboard.composition.DashboardJsonPolicy;
+import io.yak.ops.business.dashboard.composition.DashboardLayoutPolicy;
+import io.yak.ops.business.dashboard.composition.DashboardWidgetPolicy;
+import io.yak.ops.business.dashboard.definition.DashboardManager;
+import io.yak.ops.business.dashboard.gateway.analysis.AnalysisDashboardAdapter;
+import io.yak.ops.business.dashboard.gateway.lineage.LineageDashboardAdapter;
+import io.yak.ops.business.dashboard.lineage.DashboardInlineLineageExtractor;
+import io.yak.ops.business.dashboard.lineage.DashboardLineageRefreshListener;
+import io.yak.ops.business.dashboard.lineage.DashboardLineageSynchronizer;
+import io.yak.ops.business.dashboard.publication.DashboardEffectiveSnapshotReader;
+import io.yak.ops.business.dashboard.publication.DashboardPublisher;
+import io.yak.ops.business.dashboard.read.DashboardReader;
+import io.yak.ops.business.dashboard.repository.DashboardReferenceRepositoryAdapter;
+import io.yak.ops.business.dashboard.repository.DashboardRepositoryAdapter;
+import io.yak.ops.business.dashboard.repository.DashboardVersionRepositoryAdapter;
+import io.yak.ops.business.dashboard.repository.codec.DashboardJsonCodec;
+import io.yak.ops.business.dashboard.version.DashboardVersionAppender;
+import io.yak.ops.business.dashboard.version.DashboardVersionManager;
+import io.yak.ops.business.dashboard.version.DashboardVersionReader;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+
+class DashboardRoleConventionTest {
+
+  @Test
+  void onlyStableFacadeUsesServiceStereotypeAmongDashboardApplicationRoles() {
+    assertThat(DashboardService.class.isAnnotationPresent(Service.class)).isTrue();
+
+    for (Class<?> type : internalRoles()) {
+      assertThat(type.isAnnotationPresent(Service.class)).as(type.getName()).isFalse();
+    }
+  }
+
+  @Test
+  void internalApplicationRolesUseComponentStereotype() {
+    for (Class<?> type : internalRoles()) {
+      assertThat(type.isAnnotationPresent(Component.class)).as(type.getName()).isTrue();
+    }
+  }
+
+  @Test
+  void persistenceAdaptersUseRepositoryStereotype() {
+    for (Class<?> type : List.of(
+        DashboardRepositoryAdapter.class,
+        DashboardVersionRepositoryAdapter.class,
+        DashboardReferenceRepositoryAdapter.class)) {
+      assertThat(type.isAnnotationPresent(Repository.class)).as(type.getName()).isTrue();
+      assertThat(type.isAnnotationPresent(Service.class)).as(type.getName()).isFalse();
+    }
+  }
+
+  private List<Class<?>> internalRoles() {
+    return List.of(
+        DashboardManager.class,
+        DashboardReader.class,
+        DashboardVersionAppender.class,
+        DashboardVersionManager.class,
+        DashboardVersionReader.class,
+        DashboardPublisher.class,
+        DashboardEffectiveSnapshotReader.class,
+        DashboardCompositionNormalizer.class,
+        DashboardWidgetPolicy.class,
+        DashboardLayoutPolicy.class,
+        DashboardFilterPolicy.class,
+        DashboardInteractionPolicy.class,
+        DashboardJsonPolicy.class,
+        AnalysisDashboardAdapter.class,
+        LineageDashboardAdapter.class,
+        DashboardLineageRefreshListener.class,
+        DashboardLineageSynchronizer.class,
+        DashboardInlineLineageExtractor.class,
+        DashboardJsonCodec.class);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/definition/DashboardManagerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/definition/DashboardManagerTest.java
@@ -5,10 +5,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.composition.DashboardCompositionNormalizer;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.version.DashboardVersionAppender;
 import java.util.List;

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListenerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListenerTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.yak.ops.business.dashboard.definition.DashboardChangedEvent;
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardVersion;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/publication/DashboardPublisherTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/publication/DashboardPublisherTest.java
@@ -5,12 +5,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.yak.ops.business.dashboard.definition.DashboardChangedEvent;
-import io.yak.ops.business.dashboard.definition.DashboardReader;
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardVersion;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.repository.DashboardVersionRepository;
 import java.time.Instant;

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/version/DashboardVersionManagerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/version/DashboardVersionManagerTest.java
@@ -5,12 +5,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.composition.DashboardCompositionNormalizer;
-import io.yak.ops.business.dashboard.definition.DashboardChangedEvent;
-import io.yak.ops.business.dashboard.definition.DashboardReader;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
+import io.yak.ops.business.dashboard.read.DashboardReader;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;


### PR DESCRIPTION
## Summary

Complete `yak-ops-business-dashboard` Stage 2 architecture governance after Stage 1 PR #705 established the domain-oriented Dashboard structure.

This PR turns the Stage 1 package shape into a durable contract through module documentation and executable architecture guards. During the governance pass it also closes one package-level cycle left by Stage 1 without changing Dashboard behavior.

## 1. Durable Dashboard contracts

Adds:

- `README.md`
- `REQUIREMENTS.md`
- `DOMAIN.md`
- `ARCHITECTURE.md`
- `DEPENDENCIES.md`
- `REVIEW.md`

The contracts make the core truth model explicit:

```text
Dashboard
    owns stable identity + current/published pointers

DashboardVersion
    owns immutable composition snapshot

Analysis
    owns reusable Analysis definitions

Lineage
    owns lineage graph truth
```

They also lock the lifecycle rules:

```text
save
    = append new immutable version + move current pointer

publish
    = move published pointer to current

restore historical Vn
    = copy-forward into a new version
    != point current back to old Vn
```

A linked widget freezes `analysisId`, not an Analysis-definition copy. An inline widget freezes its inline payload in the DashboardVersion.

## 2. Close the remaining Stage 1 package cycle

The Stage 1 implementation had this package-level relationship:

```text
definition -> version
version    -> definition
```

`DashboardManager` needs `DashboardVersionAppender` for V1 creation, while Version roles needed `DashboardReader` and `DashboardChangedEvent` from `definition`.

Stage 2 moves these two neutral shared roles to explicit lower-level packages:

```text
definition/DashboardReader
    -> read/DashboardReader

definition/DashboardChangedEvent
    -> change/DashboardChangedEvent
```

The resulting direction is:

```text
definition -> read / change / version-appender
version    -> read / change
publication-> read / change
read       -> repository / domain
change     -> JDK only
```

This preserves behavior while making the Dashboard package graph acyclic and enforceable.

## 3. Version and publication governance

The documents and tests lock the difference between current and published truth:

```text
currentVersionId
    = current editable snapshot

publishedVersionId
    = externally effective published snapshot
```

Saving a newer Dashboard version must not move the published pointer. Publishing must not append or mutate historical version rows.

The existing `nextVersionNo -> appendVersion` concurrency strategy is explicitly documented as a known domain gap; this PR does not claim to solve it or introduce CAS/retry behavior.

## 4. Cross-module corridors

The architecture contract locks the two outbound business corridors:

```text
Composition
    -> DashboardAnalysisGateway
    -> AnalysisDashboardAdapter
    -> AnalysisReferenceService

Lineage projection
    -> DashboardLineageGraphGateway
    -> LineageDashboardAdapter
    -> Lineage module
```

Dashboard business roles cannot call Analysis or Lineage implementation services directly.

The inverse Analysis deletion guard remains routed through `DashboardReferenceRepository`, preserving the existing rule that any historical DashboardVersion reference blocks Analysis deletion.

## 5. Executable architecture governance

Adds:

- `DashboardDependencyBoundaryTest`
- `DashboardCodeStyleConventionTest`
- `DashboardRoleConventionTest`
- `DashboardArchitectureDocumentationTest`

and strengthens the existing `DashboardLayeringConventionTest`.

The guards protect:

- Dashboard package graph remains acyclic;
- Controller cannot enter Repository / DAO / Gateway / Lineage internals;
- Composition cannot bypass `DashboardAnalysisGateway`;
- Lineage cannot bypass `DashboardLineageGraphGateway`;
- Definition/Version/Publication/Composition/Reference/Lineage cannot reach DAO directly;
- Version and Publication responsibilities remain separate;
- Repository contracts include `DashboardReferenceRepository` and stay persistence-model free;
- broad `service/common/helper/helpers/utils/util/base/persistence/support` buckets cannot return;
- Domain stays Spring/Jackson/MyBatis/HTTP/cross-module free;
- no wildcard imports, field injection, console output or `BeanUtils.copyProperties`;
- repository-wide `CODE_STYLE.md` remains the single style source.

## 6. Role vocabulary

`@Service` remains reserved for the stable `DashboardService` application facade.

Internal Dashboard roles remain explicit `@Component` types such as:

- Manager / Reader;
- Appender;
- Publisher;
- Normalizer / Policy;
- Extractor / Synchronizer;
- Gateway Adapter / Codec.

Persistence adapters remain `@Repository`.

## Behavior intentionally unchanged

This remains architecture governance, not a feature rewrite. It preserves:

- `/api/v1/dashboards/**` REST paths;
- request/response JSON contracts;
- deprecated `/activate/{versionNo}` compatibility route;
- the six Dashboard tables and Flyway baseline;
- append-only DashboardVersion semantics;
- current/published pointer semantics;
- restore-as-new-version behavior;
- existing widget/layout/filter/interaction validation limits;
- `activeDatasetId` as optional metadata without new Dataset validation;
- historical Analysis reference deletion restriction;
- effective Lineage rule: published when present, otherwise current;
- after-commit / `REQUIRES_NEW` / best-effort Lineage projection;
- existing Lineage evidence, asset keys and relation-version semantics.

## Validation note

The branch is based directly on current `main` and squashed to one targeted commit.

A full Maven run is **not claimed from the current tool environment**. Final verification should run in the normal project environment, for example:

```bash
mvn -pl yak-ops-business/yak-ops-business-dashboard -am test
```
