### PR TITLE
refactor(data-development): establish stage 1 domain truth

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-data-development/ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# Data Development Architecture
+
+本文件定义 Data Development 的长期角色边界，并记录 Stage 1 的兼容入口。需求语义看 `REQUIREMENTS.md`，领域硬规则看 `DOMAIN.md`。
+
+## 设计原则
+
+1. **先有 Truth Owner，再拆 package。** 不为了 DDD 或“去 Service”制造空壳层。
+2. **Service 只做稳定入口。** 内部复杂行为使用明确角色名。
+3. **角色名表达职责。** Manager / Publisher / Validator / Normalizer / Coordinator / Resolver / Parser / Analyzer / Query / Gateway / Worker 不互相冒充。
+4. **Draft / Revision / Execution 分离。** 任何结构都不能把三种生命周期重新揉回一个对象。
+5. **外部系统停在边界。** Task Runtime、Task Catalog、Lineage、DataSource Catalog 都通过明确依赖进入。
+6. **派生事实不反向拥有业务真相。** Lineage、read model、execution history 都不能成为 Task Revision owner。
+7. **结构重构不偷改 REST / DB。** Stage 1 只调整内部职责和领域表达。
+
+## Stage 1 Package Map
+
+```text
+io.yak.ops.business.development
+├── controller          # HTTP inbound
+├── task                # Task authoring domain roles（Stage 1 新边界）
+├── domain              # Node / Draft / Revision / execution views / value semantics
+├── repository          # Data Development persistence contracts + adapters
+├── dao                 # MyBatis persistence primitives
+├── service             # 兼容入口 + 尚未迁移的历史实现
+└── config              # module configuration
+```
+
+`service` 在 Stage 1 仍然存在，但它是**迁移中的兼容区域**：允许保留稳定 Facade 和尚未迁移的旧实现，不再把新的 Parser / Validator / Manager / Coordinator 一律放入该 package。
+
+Stage 2 目标会按业务子系统继续收敛：
+
+```text
+node / task / dataservice / release / lineage / editor / repository / dao / config
+```
+
+不是为了目录一致强行一次搬完。
+
+## Task Stable Entry
+
+Stage 1 保留：
+
+```text
+DevelopmentTaskController / API
+        -> DevelopmentTaskService
+```
+
+`DevelopmentTaskService` 是兼容 Application Facade，内部职责拆为：
+
+```text
+DevelopmentTaskService
+├── DevelopmentTaskNodeResolver
+├── DevelopmentTaskDefinitionNormalizer
+├── DevelopmentTaskDraftManager
+├── DevelopmentTaskValidator
+├── TaskDefinitionDigestCalculator
+├── DevelopmentTaskPublisher
+└── DevelopmentTaskRevisionReader
+```
+
+职责：
+
+- `NodeResolver`：Node identity lookup 与 executable capability gate；
+- `DefinitionNormalizer`：TaskDefinition 唯一规范化入口；
+- `DraftManager`：Draft read/save/lock 与 optimistic storage；
+- `Validator`：Task Plugin publish validation；
+- `DigestCalculator`：发布定义 digest；
+- `Publisher`：不可变 Revision append/reuse + Task Catalog projection；
+- `RevisionReader`：历史 Revision read side；
+- `DevelopmentTaskService`：事务边界、异常兼容和跨角色编排。
+
+## Editor Run
+
+Stage 1 仍保留 `DevelopmentTaskRunService` 作为现有入口，但它不再拥有第二套 Node / TaskDefinition 规则：
+
+```text
+DevelopmentTaskRunService
+├── DevelopmentTaskNodeResolver
+├── DevelopmentTaskDefinitionNormalizer
+├── TaskExecutionGateway
+└── DevelopmentTaskExecutionService
+```
+
+后续 Stage 2 可以继续收敛为 `ExecutionCoordinator / Starter / Recorder / Query`，但本 PR 不为了改名而改名。
+
+## Role Vocabulary
+
+```text
+Manager       管一个业务对象的生命周期
+Coordinator   编排多个专业角色或外部边界
+Publisher     发布不可变版本 / 事件 / projection
+Validator     执行业务能力校验
+Normalizer    把输入收敛为唯一逻辑表示
+Compiler      从逻辑表示生成另一种运行表示
+Parser        解析语法或协议
+Analyzer      基于解析结果产生静态事实
+Resolver      解析引用、身份或上下文
+Reader/Query  只读
+Gateway       外部系统边界
+Worker        异步消费
+Reconciler    本地意图与外部事实收敛
+Repository    领域持久化 contract
+```
+
+如果一个类同时承担三种以上角色，应优先拆职责，而不是继续扩大 `*Service`。
+
+## Domain / Persistence Boundary
+
+```text
+domain
+   ↑
+task roles
+   ↓
+repository contracts
+   ↓
+repository adapters / dao
+```
+
+Stage 1 允许 `domain` 继续保留现有 JSON serialization annotation 以保证接口兼容，但不新增 Spring Service、MyBatis Mapper、Task Runtime Client 或 Lineage Client 依赖。
+
+`task` package 不直接依赖 Controller / DAO；持久化通过 Repository contract。
+
+## External Corridors
+
+允许的主要外部方向：
+
+```text
+Task Publisher     -> Task Catalog
+Editor Run         -> shared Task Runtime
+SQL publish        -> durable lineage outbox -> Lineage subsystem
+Data Service       -> DataSource / Data Service Runtime boundaries
+```
+
+这些 corridor 是明确依赖，不等于把对方领域模型复制到 Data Development。
+
+## Behavior Compatibility
+
+Stage 1 必须保持：
+
+- Controller 路径和 DTO 不变；
+- DB schema 不变；
+- Draft optimistic revision 不变；
+- Published Revision append-only / reuse 语义不变；
+- Task Catalog projection 不变；
+- Editor Run snapshot 语义不变；
+- SQL lineage outbox 不变。
+
+## Stage 2
+
+Stage 2 再处理：
+
+- `service` 大桶中的 Data Service / Release / Lineage / Execution 角色化；
+- `DEPENDENCIES.md` / `REVIEW.md` / README 收口；
+- `@Service` allowlist；
+- top-level dependency matrix；
+- architecture / dependency executable guards；
+- 更彻底的 package move。
+
+Stage 2 的目标是让 package 本身表达业务架构，而不是让 Stage 1 为追求目录漂亮一次性改变所有代码。

--- a/yak-ops-business/yak-ops-business-data-development/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-data-development/DOMAIN.md
@@ -1,0 +1,146 @@
+# Data Development Domain
+
+> `REQUIREMENTS.md` 定义“需要什么”；本文件定义“哪些领域事实不能被实现细节破坏”；`ARCHITECTURE.md` 定义这些事实由哪些代码角色负责。
+
+## 核心模型
+
+```text
+DevelopmentNode
+├── executable node
+│     │
+│     ▼
+│  DevelopmentTaskDraft (mutable)
+│     │ publish
+│     ▼
+│  DevelopmentTaskRevision (immutable)
+│     │ project
+│     └──────────────> Task Catalog
+│
+│  current editor definition
+│     │ run
+│     ▼
+│  DevelopmentTaskExecution
+│
+└── output node
+      ├── DATASET
+      └── DATA_SERVICE
+             │
+             ├── DevelopmentDataServiceDraft
+             └── DevelopmentDataServiceRevision
+```
+
+核心关系：
+
+```text
+Node != Draft != Revision != Execution
+```
+
+## Truth Ownership
+
+```text
+DevelopmentNode             = 工作区长期身份与位置
+DevelopmentTaskDraft        = 当前可编辑定义
+DevelopmentTaskRevision     = 不可变发布版本
+DevelopmentTaskExecution    = 编辑器运行历史
+Task Catalog                = 发布状态 / 跨模块任务资产投影
+Data Service Revision       = Data Service 不可变发布事实
+Lineage subsystem           = Lineage Asset / Relation 最终事实
+Task Runtime                = 外部执行事实
+```
+
+Task Catalog 不能反向成为 Data Development Revision 的存储真相；Lineage 也不能成为 Task 发布状态的真相。
+
+## 12 条硬规则
+
+1. **Node 是身份，不是版本。** 编辑定义和发布内容不能继续堆进 `DevelopmentNode`。
+2. **Node Type 能力必须显式声明。** 是否支持 Task Lifecycle 只由 `DevelopmentNodeType.supportsTaskLifecycle()` 决定。
+3. **Draft 可变但有版本。** 每次保存通过 `draftRevision` 做 optimistic concurrency check。
+4. **Published Revision 不可变。** 发布后只能新增 Revision 或切换 Catalog 指针，不能修改历史 Revision。
+5. **Draft、Revision、Execution 必须分离。** 运行或发布不能偷读错误的生命周期对象。
+6. **Editor Run 不等于 Publish。** 编辑器运行使用临时 `TaskVersionSnapshot(version=0)`，不能隐式发布。
+7. **TaskDefinition 只有一套规范化规则。** Node Type 对齐、schemaVersion、content 和 configJson normalization 不能在多个 Service 各复制一份。
+8. **Publish 校验由 Task Plugin 提供能力事实。** Data Development 负责协调，不复制插件内部 SQL/SHELL/HTTP 规则。
+9. **相同 Draft + 相同 Digest 重复发布必须幂等。** 可以重复修复 Task Catalog projection，但不能重复插入等价 Revision。
+10. **DATASET / DATA_SERVICE 不是 executable Task。** 输出节点不得为了复用 Service 而进入 Task Draft / Revision 生命周期。
+11. **Lineage 是派生事实。** SQL Revision 是证据来源；Asset / Relation 的最终 owner 是 Lineage 模块。
+12. **结构重构不能偷改行为。** package move、角色拆分、领域语义变更、REST/DB 变更必须分开处理。
+
+## Task Definition Contract
+
+`TaskDefinition` 是 Data Development 与 Task Plugin / Task Runtime 共享的逻辑定义表示。
+
+进入 Draft、Publish、Editor Run 前必须统一规范化：
+
+```text
+taskType       -> trim + upper-case + equals Node.type
+schemaVersion  -> > 0
+content        -> null becomes empty string
+configJson     -> JSON Object + canonical serialization
+```
+
+同一规则不得在 `DevelopmentTaskService`、`DevelopmentTaskRunService`、Controller 等位置重复实现。
+
+## Publish Contract
+
+```text
+require executable Node
+    -> lock Draft
+    -> verify expected draftRevision
+    -> normalize TaskDefinition
+    -> Task Plugin validation
+    -> calculate Definition Digest
+    -> reuse or append immutable Revision
+    -> reconcile Task Catalog projection
+    -> enqueue SQL lineage evidence work
+```
+
+`DevelopmentTaskRevision.represents(draftRevision, checksum)` 表达“现有不可变版本是否已经代表当前 Draft”的领域判断。
+
+## Data Service Contract
+
+Data Service Definition 可以自己持有发布不变量，例如 `validatePublishable()`。
+
+它与普通 Task 的关系是相邻能力，不是继承关系：
+
+```text
+Task Revision        -> shared Task Runtime
+Data Service Revision -> Data Service Runtime
+```
+
+后续结构调整应继续强化这个边界，而不是把两者重新塞回一个通用 Service。
+
+## Lineage Boundary
+
+```text
+SQL DevelopmentTaskRevision
+    -> parser / analyzer
+    -> lineage evidence
+    -> yak-ops-business-lineage
+```
+
+Data Development 可以持有 Parser、Analyzer、Outbox、Worker 等角色，但不得复制 Lineage Asset / Relation 的领域所有权。
+
+## 修改代码前后
+
+涉及领域行为的修改，先写：
+
+```text
+Domain Impact Analysis
+- Aggregate / truth owner:
+- Draft / Revision / Execution impact:
+- Invariant impact:
+- Runtime / Catalog / Lineage boundary impact:
+- Domain Gap: yes/no
+```
+
+结构调整完成后确认：
+
+```text
+Domain Compliance Report
+- Rule preserved/implemented:
+- Behavior compatibility:
+- Tests:
+- Known gaps:
+```
+
+Stage 2 会继续用依赖测试把这些 contract 固化；Stage 1 不通过删除现有行为测试来换取重构通过。

--- a/yak-ops-business/yak-ops-business-data-development/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-data-development/REQUIREMENTS.md
@@ -1,0 +1,104 @@
+# Data Development Requirements
+
+本文件定义 Data Development 的长期需求语义。它回答“这个模块需要提供什么能力”，不承担代码分层说明。
+
+领域硬规则看 `DOMAIN.md`，角色和依赖边界看 `ARCHITECTURE.md`。
+
+## 模块定位
+
+Data Development 是数据开发工作台的 authoring context。它负责组织开发节点、维护可编辑定义、发布不可变版本，并把可执行任务交给共享 Task Runtime，把发布状态投影到 Task Catalog，把 SQL 血缘证据交给 Lineage 子系统。
+
+它不是调度引擎、数据目录、血缘图谱或 Task Runtime 的替代实现。
+
+## 核心能力
+
+### 1. 开发节点
+
+- `DevelopmentNode` 是工作区中的长期身份，负责名称、类型、项目/目录位置和配置状态。
+- 节点类型必须显式声明能力；不能通过 `PROCESSING / OUTPUT` 分类推断是否允许进入任务生命周期。
+- SQL / SHELL / HTTP / PYTHON / JAVA 可以进入 Task Draft -> Revision 生命周期。
+- DATASET / DATA_SERVICE 是输出型节点，不复用 Task Draft -> Revision 生命周期。
+
+### 2. Task Authoring
+
+可执行节点必须支持：
+
+```text
+DevelopmentNode
+    -> mutable DevelopmentTaskDraft
+    -> immutable DevelopmentTaskRevision
+```
+
+要求：
+
+- Draft 使用独立的 `draftRevision` 做并发控制；
+- 保存 Draft 必须校验 Node Type 与 TaskDefinition Type 一致；
+- `configJson` 在进入持久化前规范化为 JSON Object；
+- Publish 必须基于明确的 Draft Revision；
+- Publish 必须执行对应 Task Plugin 的校验；
+- 相同 Draft Revision + 相同 Definition Digest 重复发布时复用已有 Revision；
+- Published Revision 不可被后续编辑覆盖。
+
+### 3. Editor Run
+
+编辑器运行当前内容时，不要求先 Publish。
+
+```text
+current editor definition
+    -> TaskVersionSnapshot(version = 0)
+    -> shared Task Runtime
+    -> DevelopmentTaskExecution history
+```
+
+Editor Run 与 Published Revision 是两个概念。运行当前编辑器内容不能隐式创建 Published Revision，也不能修改 Task Catalog 的发布指针。
+
+### 4. Release Projection
+
+发布后的 Data Development Task 通过 Task Catalog 暴露上线、下线和历史版本切换能力。
+
+Task Catalog 是发布状态和跨模块任务资产入口；`DevelopmentTaskRevision` 仍然是 Data Development 内部不可变版本事实。
+
+### 5. Data Service
+
+DATA_SERVICE 使用独立的 Draft / Revision / Runtime contract，不得伪装成通用 Task Node。
+
+Data Service 发布前至少要保证：
+
+- Runtime 支持的 HTTP method；
+- 有明确 DataSource；
+- SQL 非空；
+- Response Contract 已确认；
+- Request Contract 满足当前 Runtime 能力。
+
+### 6. Lineage
+
+SQL Task Revision 发布后可以异步生成表级和字段级 lineage evidence。
+
+Data Development 只拥有“哪个 Revision 产生了什么解析证据”的责任；Lineage Asset / Relation 的最终事实由 `yak-ops-business-lineage` 持有。
+
+Lineage 解析或写入失败不能回滚已经成功提交的业务发布；可靠处理通过 durable outbox / worker 完成。
+
+## 兼容要求
+
+Stage 1 重构必须保持：
+
+- `/api/v1/development/**` 现有 REST contract；
+- 现有数据库表和 Flyway migration；
+- Draft optimistic revision 语义；
+- Revision number / checksum 语义；
+- Task Catalog publish / online / offline 行为；
+- Editor Run 走共享 Task Runtime；
+- SQL lineage outbox 行为。
+
+## Stage 1 非目标
+
+本阶段不处理：
+
+- 全量删除 `service` package；
+- 重写 Data Service / Release / Lineage 全部实现；
+- 新增数据库模型；
+- 修改 API v1；
+- 改造共享 Task Runtime；
+- 抽取 Data Development 与 Offline/Realtime Sync 的 Shared Kernel。
+
+Stage 1 的重点是先建立 Domain Truth，并让 Task 主链开始按明确角色组织。

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 
-/** Lightweight tree node metadata for data-development resources. */
+/** Stable workspace identity for one data-development resource. */
 public record DevelopmentNode(
     @JsonSerialize(using = ToStringSerializer.class) Long id,
     String name,
@@ -28,5 +28,23 @@ public record DevelopmentNode(
       Instant createTime,
       Instant updateTime) {
     this(id, name, type, projectId, directoryId, configured, createTime, updateTime, null, false);
+  }
+
+  /** Resolves the domain node type instead of spreading string parsing across application services. */
+  public DevelopmentNodeType nodeType() {
+    return DevelopmentNodeType.tryParse(type)
+        .orElseThrow(() -> new IllegalArgumentException("未知数据开发节点类型：" + type));
+  }
+
+  public boolean supportsTaskLifecycle() {
+    return nodeType().supportsTaskLifecycle();
+  }
+
+  /** Guards the mutable Draft -> immutable Revision lifecycle at the domain identity boundary. */
+  public void requireTaskLifecycle() {
+    if (!supportsTaskLifecycle()) {
+      throw new IllegalArgumentException(
+          "当前节点不是可执行开发任务，不能进入草稿/发布生命周期：" + type);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskDraft.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskDraft.java
@@ -12,4 +12,9 @@ public record DevelopmentTaskDraft(
     long draftRevision,
     Instant createTime,
     Instant updateTime) {
+
+  /** Publish commands must pin the exact mutable revision they were prepared against. */
+  public boolean matchesRevision(long expectedRevision) {
+    return draftRevision == expectedRevision;
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRevision.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentTaskRevision.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.time.Instant;
+import java.util.Objects;
 
 /** Immutable published task revision. */
 public record DevelopmentTaskRevision(
@@ -14,4 +15,9 @@ public record DevelopmentTaskRevision(
     TaskDefinition definition,
     String checksum,
     Instant createTime) {
+
+  /** True when this immutable revision already represents the exact normalized draft snapshot. */
+  public boolean represents(long draftRevision, String definitionChecksum) {
+    return sourceDraftRevision == draftRevision && Objects.equals(checksum, definitionChecksum);
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskRunService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskRunService.java
@@ -1,11 +1,12 @@
 package io.yak.ops.business.development.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRunResult;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.development.task.DevelopmentTaskDefinitionNormalizer;
+import io.yak.ops.business.development.task.DevelopmentTaskNodeResolver;
 import io.yak.ops.business.job.task.TaskExecution;
 import io.yak.ops.business.job.task.TaskExecutionGateway;
 import io.yak.ops.business.job.task.TaskVersionSnapshot;
@@ -16,23 +17,42 @@ import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Executes the current editor definition through the shared Task Runtime. */
 @Service
 public class DevelopmentTaskRunService {
 
-  private final DevelopmentNodeRepository nodeRepository;
+  private final DevelopmentTaskNodeResolver nodes;
+  private final DevelopmentTaskDefinitionNormalizer definitions;
   private final TaskExecutionGateway taskExecutionGateway;
   private final DevelopmentTaskExecutionService executionService;
   private final ObjectMapper objectMapper;
 
+  /** Keeps focused tests and existing non-Spring callers source compatible. */
   public DevelopmentTaskRunService(
       DevelopmentNodeRepository nodeRepository,
       TaskExecutionGateway taskExecutionGateway,
       DevelopmentTaskExecutionService executionService,
       ObjectMapper objectMapper) {
-    this.nodeRepository = nodeRepository;
+    this(
+        new DevelopmentTaskNodeResolver(nodeRepository),
+        new DevelopmentTaskDefinitionNormalizer(objectMapper),
+        taskExecutionGateway,
+        executionService,
+        objectMapper);
+  }
+
+  @Autowired
+  public DevelopmentTaskRunService(
+      DevelopmentTaskNodeResolver nodes,
+      DevelopmentTaskDefinitionNormalizer definitions,
+      TaskExecutionGateway taskExecutionGateway,
+      DevelopmentTaskExecutionService executionService,
+      ObjectMapper objectMapper) {
+    this.nodes = nodes;
+    this.definitions = definitions;
     this.taskExecutionGateway = taskExecutionGateway;
     this.executionService = executionService;
     this.objectMapper = objectMapper;
@@ -55,17 +75,16 @@ public class DevelopmentTaskRunService {
       String content,
       String configJson,
       String operatorName) {
-    DevelopmentNode node = requireNode(nodeId);
+    DevelopmentNode node = nodes.requireNode(nodeId);
     TaskDefinition definition =
-        normalizeDefinition(node, taskType, schemaVersion, content, configJson);
+        definitions.normalize(node, taskType, schemaVersion, content, configJson);
     if (!taskExecutionGateway.supports(definition.taskType())) {
       throw new DevelopmentTaskValidationException(
           "当前未安装 " + definition.taskType() + " Task Runtime，无法运行",
-          List.of(
-              new TaskValidationIssue(
-                  "TASK_RUNTIME_NOT_INSTALLED",
-                  "taskType",
-                  "Task runtime is not installed: " + definition.taskType())));
+          List.of(new TaskValidationIssue(
+              "TASK_RUNTIME_NOT_INSTALLED",
+              "taskType",
+              "Task runtime is not installed: " + definition.taskType())));
     }
 
     long started = System.nanoTime();
@@ -77,12 +96,11 @@ public class DevelopmentTaskRunService {
         operatorName);
     try {
       TaskVersionSnapshot snapshot = currentDraftSnapshot(node, definition);
-      TaskExecution execution =
-          taskExecutionGateway.start(
-              snapshot,
-              TaskExecutionTrigger.MANUAL,
-              null,
-              Map.of("nodeId", String.valueOf(nodeId)));
+      TaskExecution execution = taskExecutionGateway.start(
+          snapshot,
+          TaskExecutionTrigger.MANUAL,
+          null,
+          Map.of("nodeId", String.valueOf(nodeId)));
       executionService.markRunning(historyId, execution.executionId());
 
       TaskExecution completed = awaitTerminal(snapshot.type(), execution);
@@ -117,11 +135,10 @@ public class DevelopmentTaskRunService {
           Map.of());
       throw new DevelopmentTaskValidationException(
           message,
-          List.of(
-              new TaskValidationIssue(
-                  "TASK_RUNTIME_VALIDATION_FAILED",
-                  "definition",
-                  message)));
+          List.of(new TaskValidationIssue(
+              "TASK_RUNTIME_VALIDATION_FAILED",
+              "definition",
+              message)));
     } catch (Exception exception) {
       String message = safeMessage(exception);
       long durationMs = elapsedMillis(started);
@@ -187,48 +204,6 @@ public class DevelopmentTaskRunService {
       case "TIMED_OUT" -> TaskExecutionStatus.TIMEOUT;
       default -> TaskExecutionStatus.FAILED;
     };
-  }
-
-  private DevelopmentNode requireNode(Long nodeId) {
-    if (nodeId == null || nodeId <= 0L) throw new IllegalArgumentException("节点 ID 非法");
-    return nodeRepository
-        .findById(nodeId)
-        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + nodeId));
-  }
-
-  private TaskDefinition normalizeDefinition(
-      DevelopmentNode node,
-      String taskType,
-      int schemaVersion,
-      String content,
-      String configJson) {
-    if (taskType == null || taskType.isBlank()) {
-      throw new IllegalArgumentException("taskType 不能为空");
-    }
-    String normalizedType = taskType.trim().toUpperCase(Locale.ROOT);
-    if (!normalizedType.equals(node.type().trim().toUpperCase(Locale.ROOT))) {
-      throw new IllegalArgumentException(
-          "任务类型与节点类型不一致：node=" + node.type() + ", definition=" + normalizedType);
-    }
-    if (schemaVersion <= 0) throw new IllegalArgumentException("schemaVersion 必须大于 0");
-    return new TaskDefinition(
-        normalizedType,
-        schemaVersion,
-        content == null ? "" : content,
-        normalizeConfigJson(configJson));
-  }
-
-  private String normalizeConfigJson(String configJson) {
-    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
-    try {
-      JsonNode node = objectMapper.readTree(raw);
-      if (node == null || !node.isObject()) {
-        throw new IllegalArgumentException("configJson 必须是 JSON Object");
-      }
-      return objectMapper.writeValueAsString(node);
-    } catch (JsonProcessingException exception) {
-      throw new IllegalArgumentException("configJson 不是合法 JSON", exception);
-    }
   }
 
   private long elapsedMillis(long started) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentTaskService.java
@@ -1,52 +1,43 @@
 package io.yak.ops.business.development.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
-import io.yak.ops.business.development.domain.DevelopmentNodeType;
 import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskDraftRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.business.development.task.DevelopmentTaskDefinitionNormalizer;
+import io.yak.ops.business.development.task.DevelopmentTaskDraftManager;
+import io.yak.ops.business.development.task.DevelopmentTaskNodeResolver;
+import io.yak.ops.business.development.task.DevelopmentTaskPublisher;
+import io.yak.ops.business.development.task.DevelopmentTaskRevisionReader;
+import io.yak.ops.business.development.task.DevelopmentTaskValidation;
+import io.yak.ops.business.development.task.DevelopmentTaskValidator;
+import io.yak.ops.business.development.task.TaskDefinitionDigestCalculator;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
-import io.yak.ops.plugin.task.api.TaskPlugin;
-import io.yak.ops.plugin.task.api.TaskValidationIssue;
-import io.yak.ops.plugin.task.api.TaskValidationResult;
-import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskDefinition;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
 import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Authoring lifecycle: mutable draft -> validated immutable published revision -> Task Catalog. */
+/** Stable task-authoring facade; specialized roles own Draft, validation, publication and reads. */
 @Service
 public class DevelopmentTaskService {
 
-  private final DevelopmentNodeRepository nodeRepository;
-  private final DevelopmentTaskDraftRepository draftRepository;
-  private final DevelopmentTaskRevisionRepository revisionRepository;
-  private final TaskCatalogService taskCatalogService;
-  private final TaskPluginRegistry pluginRegistry;
-  private final ObjectMapper objectMapper;
+  private final DevelopmentTaskNodeResolver nodes;
+  private final DevelopmentTaskDefinitionNormalizer definitions;
+  private final DevelopmentTaskDraftManager drafts;
+  private final DevelopmentTaskValidator validator;
+  private final TaskDefinitionDigestCalculator digests;
+  private final DevelopmentTaskPublisher publisher;
+  private final DevelopmentTaskRevisionReader revisions;
   private final DevelopmentLineageOutbox outbox;
 
-  /**
-   * Keeps focused unit tests and non-Spring callers source compatible.
-   *
-   * <p>Production wiring uses the annotated constructor below so durable SQL-lineage work is persisted with
-   * a successful publish.
-   */
+  /** Keeps focused unit tests and non-Spring callers source compatible. */
   public DevelopmentTaskService(
       DevelopmentNodeRepository nodeRepository,
       DevelopmentTaskDraftRepository draftRepository,
@@ -64,7 +55,7 @@ public class DevelopmentTaskService {
         null);
   }
 
-  @Autowired
+  /** Keeps the previous full constructor source compatible during Stage 1. */
   public DevelopmentTaskService(
       DevelopmentNodeRepository nodeRepository,
       DevelopmentTaskDraftRepository draftRepository,
@@ -73,19 +64,40 @@ public class DevelopmentTaskService {
       TaskPluginRegistry pluginRegistry,
       ObjectMapper objectMapper,
       DevelopmentLineageOutbox outbox) {
-    this.nodeRepository = nodeRepository;
-    this.draftRepository = draftRepository;
-    this.revisionRepository = revisionRepository;
-    this.taskCatalogService = taskCatalogService;
-    this.pluginRegistry = pluginRegistry;
-    this.objectMapper = objectMapper;
+    this(
+        new DevelopmentTaskNodeResolver(nodeRepository),
+        new DevelopmentTaskDefinitionNormalizer(objectMapper),
+        new DevelopmentTaskDraftManager(draftRepository, nodeRepository, pluginRegistry),
+        new DevelopmentTaskValidator(pluginRegistry),
+        new TaskDefinitionDigestCalculator(),
+        new DevelopmentTaskPublisher(revisionRepository, nodeRepository, taskCatalogService),
+        new DevelopmentTaskRevisionReader(revisionRepository),
+        outbox);
+  }
+
+  @Autowired
+  public DevelopmentTaskService(
+      DevelopmentTaskNodeResolver nodes,
+      DevelopmentTaskDefinitionNormalizer definitions,
+      DevelopmentTaskDraftManager drafts,
+      DevelopmentTaskValidator validator,
+      TaskDefinitionDigestCalculator digests,
+      DevelopmentTaskPublisher publisher,
+      DevelopmentTaskRevisionReader revisions,
+      DevelopmentLineageOutbox outbox) {
+    this.nodes = nodes;
+    this.definitions = definitions;
+    this.drafts = drafts;
+    this.validator = validator;
+    this.digests = digests;
+    this.publisher = publisher;
+    this.revisions = revisions;
     this.outbox = outbox;
   }
 
   public DevelopmentTaskDraft getDraft(Long nodeId) {
-    DevelopmentNode node = requireTaskNode(nodeId);
-    return draftRepository.findByNodeId(nodeId)
-        .orElseGet(() -> emptyDraft(node));
+    DevelopmentNode node = nodes.requireTaskNode(nodeId);
+    return drafts.get(node);
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
@@ -96,29 +108,20 @@ public class DevelopmentTaskService {
       String content,
       String configJson,
       Long baseRevision) {
-    DevelopmentNode node = requireTaskNode(nodeId);
-    TaskDefinition definition = normalizeDefinition(
-        node,
-        taskType,
-        schemaVersion,
-        content,
-        configJson);
+    DevelopmentNode node = nodes.requireTaskNode(nodeId);
+    TaskDefinition definition =
+        definitions.normalize(node, taskType, schemaVersion, content, configJson);
     long expectedRevision = baseRevision == null ? 0L : baseRevision;
-
-    DevelopmentTaskDraft saved = draftRepository.save(nodeId, definition, expectedRevision)
+    return drafts.save(node, definition, expectedRevision)
         .orElseThrow(() -> new DevelopmentDraftConflictException(
             "草稿已被其他会话更新，请刷新后重新保存（当前基线：" + expectedRevision + "）"));
-    nodeRepository.updateConfigured(nodeId, true);
-    return saved;
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public DevelopmentTaskRevision publish(Long nodeId, long expectedDraftRevision) {
-    DevelopmentNode node = requireTaskNode(nodeId);
-    DevelopmentTaskDraft draft = draftRepository.findByNodeIdForUpdate(nodeId)
-        .orElseThrow(() -> new IllegalArgumentException("节点尚未保存草稿：" + nodeId));
-
-    if (draft.draftRevision() != expectedDraftRevision) {
+    DevelopmentNode node = nodes.requireTaskNode(nodeId);
+    DevelopmentTaskDraft draft = drafts.lockForPublish(node);
+    if (!draft.matchesRevision(expectedDraftRevision)) {
       throw new DevelopmentDraftConflictException(
           "发布失败：草稿版本已变化，期望 "
               + expectedDraftRevision
@@ -126,40 +129,19 @@ public class DevelopmentTaskService {
               + draft.draftRevision());
     }
 
-    TaskDefinition definition = normalizeDefinition(
+    TaskDefinition definition = definitions.normalize(
         node,
         draft.definition().taskType(),
         draft.definition().schemaVersion(),
         draft.definition().content(),
         draft.definition().configJson());
-    validateForPublish(definition);
-
-    String checksum = checksum(definition);
-    DevelopmentTaskRevision latest = revisionRepository.findLatestByNodeId(nodeId).orElse(null);
-    DevelopmentTaskRevision published;
-    if (latest != null
-        && latest.sourceDraftRevision() == draft.draftRevision()
-        && Objects.equals(latest.checksum(), checksum)) {
-      published = latest;
-    } else {
-      int revisionNo = revisionRepository.nextRevisionNo(nodeId);
-      published = revisionRepository.insert(
-          nodeId,
-          revisionNo,
-          draft.draftRevision(),
-          definition,
-          checksum);
+    DevelopmentTaskValidation validation = validator.validateForPublish(definition);
+    if (!validation.valid()) {
+      throw new DevelopmentTaskValidationException(validation.message(), validation.issues());
     }
 
-    nodeRepository.updateConfigured(nodeId, true);
-    taskCatalogService.publish(
-        TaskAssetSource.DATA_DEVELOPMENT,
-        String.valueOf(node.id()),
-        node.projectId(),
-        node.name(),
-        definition.taskType(),
-        published.id(),
-        published.revisionNo());
+    DevelopmentTaskRevision published =
+        publisher.publish(node, draft, definition, digests.calculate(definition));
     if (outbox != null && "SQL".equalsIgnoreCase(definition.taskType())) {
       outbox.enqueue(node.id(), published.id());
     }
@@ -167,116 +149,10 @@ public class DevelopmentTaskService {
   }
 
   public List<DevelopmentTaskRevisionSummary> listRevisions(Long nodeId) {
-    requireTaskNode(nodeId);
-    return revisionRepository.listByNodeId(nodeId);
+    return revisions.list(nodes.requireTaskNode(nodeId));
   }
 
   public DevelopmentTaskRevision getRevision(Long nodeId, int revisionNo) {
-    requireTaskNode(nodeId);
-    if (revisionNo <= 0) throw new IllegalArgumentException("revisionNo 必须大于 0");
-    return revisionRepository.findByRevisionNo(nodeId, revisionNo)
-        .orElseThrow(() -> new IllegalArgumentException(
-            "发布版本不存在：nodeId=" + nodeId + ", revisionNo=" + revisionNo));
-  }
-
-  private DevelopmentNode requireTaskNode(Long nodeId) {
-    if (nodeId == null || nodeId <= 0L) throw new IllegalArgumentException("节点 ID 非法");
-    DevelopmentNode node = nodeRepository.findById(nodeId)
-        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + nodeId));
-    DevelopmentNodeType nodeType = DevelopmentNodeType.tryParse(node.type())
-        .orElseThrow(() -> new IllegalArgumentException("未知数据开发节点类型：" + node.type()));
-    if (!nodeType.supportsTaskLifecycle()) {
-      throw new IllegalArgumentException(
-          "当前节点不是可执行开发任务，不能进入草稿/发布生命周期：" + node.type());
-    }
-    return node;
-  }
-
-  private DevelopmentTaskDraft emptyDraft(DevelopmentNode node) {
-    int schemaVersion = pluginRegistry.find(node.type())
-        .map(plugin -> plugin.descriptor().schemaVersion())
-        .orElse(1);
-    return new DevelopmentTaskDraft(
-        node.id(),
-        new TaskDefinition(node.type(), schemaVersion, "", "{}"),
-        0L,
-        null,
-        null);
-  }
-
-  private TaskDefinition normalizeDefinition(
-      DevelopmentNode node,
-      String taskType,
-      int schemaVersion,
-      String content,
-      String configJson) {
-    if (taskType == null || taskType.isBlank()) {
-      throw new IllegalArgumentException("taskType 不能为空");
-    }
-    String normalizedType = taskType.trim().toUpperCase(Locale.ROOT);
-    if (!normalizedType.equals(node.type().trim().toUpperCase(Locale.ROOT))) {
-      throw new IllegalArgumentException(
-          "任务类型与节点类型不一致：node=" + node.type() + ", definition=" + normalizedType);
-    }
-    if (schemaVersion <= 0) {
-      throw new IllegalArgumentException("schemaVersion 必须大于 0");
-    }
-
-    return new TaskDefinition(
-        normalizedType,
-        schemaVersion,
-        content == null ? "" : content,
-        normalizeConfigJson(configJson));
-  }
-
-  private String normalizeConfigJson(String configJson) {
-    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
-    try {
-      JsonNode node = objectMapper.readTree(raw);
-      if (node == null || !node.isObject()) {
-        throw new IllegalArgumentException("configJson 必须是 JSON Object");
-      }
-      return objectMapper.writeValueAsString(node);
-    } catch (JsonProcessingException exception) {
-      throw new IllegalArgumentException("configJson 不是合法 JSON", exception);
-    }
-  }
-
-  private void validateForPublish(TaskDefinition definition) {
-    TaskPlugin plugin = pluginRegistry.find(definition.taskType())
-        .orElseThrow(() -> new DevelopmentTaskValidationException(
-            "当前未安装 " + definition.taskType() + " Task Plugin，无法发布",
-            List.of(new TaskValidationIssue(
-                "TASK_PLUGIN_NOT_INSTALLED",
-                "taskType",
-                "Task plugin is not installed: " + definition.taskType()))));
-
-    TaskValidationResult validation = plugin.validate(definition);
-    if (!validation.valid()) {
-      String summary = validation.issues().stream()
-          .map(TaskValidationIssue::message)
-          .limit(3)
-          .reduce((left, right) -> left + "；" + right)
-          .orElse("任务定义校验失败");
-      throw new DevelopmentTaskValidationException(summary, validation.issues());
-    }
-  }
-
-  private String checksum(TaskDefinition definition) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      updateDigest(digest, definition.taskType());
-      updateDigest(digest, Integer.toString(definition.schemaVersion()));
-      updateDigest(digest, definition.content());
-      updateDigest(digest, definition.configJson());
-      return HexFormat.of().formatHex(digest.digest());
-    } catch (NoSuchAlgorithmException impossible) {
-      throw new IllegalStateException("SHA-256 is unavailable", impossible);
-    }
-  }
-
-  private void updateDigest(MessageDigest digest, String value) {
-    if (value != null) digest.update(value.getBytes(StandardCharsets.UTF_8));
-    digest.update((byte) 0);
+    return revisions.get(nodes.requireTaskNode(nodeId), revisionNo);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskDefinitionNormalizer.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskDefinitionNormalizer.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.development.task;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+
+/** Single normalization rule for TaskDefinition used by save, publish and editor run. */
+@Component
+public class DevelopmentTaskDefinitionNormalizer {
+
+  private final ObjectMapper objectMapper;
+
+  public DevelopmentTaskDefinitionNormalizer(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public TaskDefinition normalize(
+      DevelopmentNode node,
+      String taskType,
+      int schemaVersion,
+      String content,
+      String configJson) {
+    if (taskType == null || taskType.isBlank()) {
+      throw new IllegalArgumentException("taskType 不能为空");
+    }
+    String normalizedType = taskType.trim().toUpperCase(Locale.ROOT);
+    if (!normalizedType.equals(node.type().trim().toUpperCase(Locale.ROOT))) {
+      throw new IllegalArgumentException(
+          "任务类型与节点类型不一致：node=" + node.type() + ", definition=" + normalizedType);
+    }
+    if (schemaVersion <= 0) {
+      throw new IllegalArgumentException("schemaVersion 必须大于 0");
+    }
+    return new TaskDefinition(
+        normalizedType,
+        schemaVersion,
+        content == null ? "" : content,
+        normalizeConfigJson(configJson));
+  }
+
+  private String normalizeConfigJson(String configJson) {
+    String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
+    try {
+      JsonNode node = objectMapper.readTree(raw);
+      if (node == null || !node.isObject()) {
+        throw new IllegalArgumentException("configJson 必须是 JSON Object");
+      }
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("configJson 不是合法 JSON", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskDraftManager.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskDraftManager.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.development.task;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskDraftRepository;
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** Owns mutable task Draft persistence; the facade owns transaction and conflict translation. */
+@Component
+public class DevelopmentTaskDraftManager {
+
+  private final DevelopmentTaskDraftRepository draftRepository;
+  private final DevelopmentNodeRepository nodeRepository;
+  private final TaskPluginRegistry pluginRegistry;
+
+  public DevelopmentTaskDraftManager(
+      DevelopmentTaskDraftRepository draftRepository,
+      DevelopmentNodeRepository nodeRepository,
+      TaskPluginRegistry pluginRegistry) {
+    this.draftRepository = draftRepository;
+    this.nodeRepository = nodeRepository;
+    this.pluginRegistry = pluginRegistry;
+  }
+
+  public DevelopmentTaskDraft get(DevelopmentNode node) {
+    return draftRepository.findByNodeId(node.id())
+        .orElseGet(() -> emptyDraft(node));
+  }
+
+  /** Empty means the optimistic expected revision no longer matches persisted Draft state. */
+  public Optional<DevelopmentTaskDraft> save(
+      DevelopmentNode node,
+      TaskDefinition definition,
+      long expectedRevision) {
+    Optional<DevelopmentTaskDraft> saved =
+        draftRepository.save(node.id(), definition, expectedRevision);
+    saved.ifPresent(ignored -> nodeRepository.updateConfigured(node.id(), true));
+    return saved;
+  }
+
+  public DevelopmentTaskDraft lockForPublish(DevelopmentNode node) {
+    return draftRepository.findByNodeIdForUpdate(node.id())
+        .orElseThrow(() -> new IllegalArgumentException("节点尚未保存草稿：" + node.id()));
+  }
+
+  private DevelopmentTaskDraft emptyDraft(DevelopmentNode node) {
+    int schemaVersion = pluginRegistry.find(node.type())
+        .map(plugin -> plugin.descriptor().schemaVersion())
+        .orElse(1);
+    return new DevelopmentTaskDraft(
+        node.id(),
+        new TaskDefinition(node.type(), schemaVersion, "", "{}"),
+        0L,
+        null,
+        null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskNodeResolver.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskNodeResolver.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.development.task;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import org.springframework.stereotype.Component;
+
+/** Resolves DevelopmentNode identity and applies lifecycle capability gates. */
+@Component
+public class DevelopmentTaskNodeResolver {
+
+  private final DevelopmentNodeRepository nodeRepository;
+
+  public DevelopmentTaskNodeResolver(DevelopmentNodeRepository nodeRepository) {
+    this.nodeRepository = nodeRepository;
+  }
+
+  public DevelopmentNode requireNode(Long nodeId) {
+    if (nodeId == null || nodeId <= 0L) {
+      throw new IllegalArgumentException("节点 ID 非法");
+    }
+    return nodeRepository.findById(nodeId)
+        .orElseThrow(() -> new IllegalArgumentException("节点不存在：" + nodeId));
+  }
+
+  public DevelopmentNode requireTaskNode(Long nodeId) {
+    DevelopmentNode node = requireNode(nodeId);
+    node.requireTaskLifecycle();
+    return node;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskPublisher.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskPublisher.java
@@ -1,0 +1,60 @@
+package io.yak.ops.business.development.task;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskDraft;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import org.springframework.stereotype.Component;
+
+/** Appends/reuses immutable Task Revision and reconciles the Task Catalog publication projection. */
+@Component
+public class DevelopmentTaskPublisher {
+
+  private final DevelopmentTaskRevisionRepository revisionRepository;
+  private final DevelopmentNodeRepository nodeRepository;
+  private final TaskCatalogService taskCatalogService;
+
+  public DevelopmentTaskPublisher(
+      DevelopmentTaskRevisionRepository revisionRepository,
+      DevelopmentNodeRepository nodeRepository,
+      TaskCatalogService taskCatalogService) {
+    this.revisionRepository = revisionRepository;
+    this.nodeRepository = nodeRepository;
+    this.taskCatalogService = taskCatalogService;
+  }
+
+  public DevelopmentTaskRevision publish(
+      DevelopmentNode node,
+      DevelopmentTaskDraft draft,
+      TaskDefinition definition,
+      String checksum) {
+    DevelopmentTaskRevision latest = revisionRepository.findLatestByNodeId(node.id()).orElse(null);
+    DevelopmentTaskRevision published;
+    if (latest != null && latest.represents(draft.draftRevision(), checksum)) {
+      published = latest;
+    } else {
+      int revisionNo = revisionRepository.nextRevisionNo(node.id());
+      published = revisionRepository.insert(
+          node.id(),
+          revisionNo,
+          draft.draftRevision(),
+          definition,
+          checksum);
+    }
+
+    nodeRepository.updateConfigured(node.id(), true);
+    taskCatalogService.publish(
+        TaskAssetSource.DATA_DEVELOPMENT,
+        String.valueOf(node.id()),
+        node.projectId(),
+        node.name(),
+        definition.taskType(),
+        published.id(),
+        published.revisionNo());
+    return published;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskRevisionReader.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskRevisionReader.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.development.task;
+
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.domain.DevelopmentTaskRevisionSummary;
+import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Read side for immutable DevelopmentTaskRevision history. */
+@Component
+public class DevelopmentTaskRevisionReader {
+
+  private final DevelopmentTaskRevisionRepository revisionRepository;
+
+  public DevelopmentTaskRevisionReader(DevelopmentTaskRevisionRepository revisionRepository) {
+    this.revisionRepository = revisionRepository;
+  }
+
+  public List<DevelopmentTaskRevisionSummary> list(DevelopmentNode node) {
+    return revisionRepository.listByNodeId(node.id());
+  }
+
+  public DevelopmentTaskRevision get(DevelopmentNode node, int revisionNo) {
+    if (revisionNo <= 0) {
+      throw new IllegalArgumentException("revisionNo 必须大于 0");
+    }
+    return revisionRepository.findByRevisionNo(node.id(), revisionNo)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "发布版本不存在：nodeId=" + node.id() + ", revisionNo=" + revisionNo));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskValidation.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskValidation.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.development.task;
+
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import java.util.List;
+
+/** Internal validation decision kept separate from the legacy application exception type. */
+public record DevelopmentTaskValidation(
+    boolean valid,
+    String message,
+    List<TaskValidationIssue> issues) {
+
+  public DevelopmentTaskValidation {
+    issues = issues == null ? List.of() : List.copyOf(issues);
+  }
+
+  public static DevelopmentTaskValidation ok() {
+    return new DevelopmentTaskValidation(true, null, List.of());
+  }
+
+  public static DevelopmentTaskValidation invalid(
+      String message,
+      List<TaskValidationIssue> issues) {
+    return new DevelopmentTaskValidation(false, message, issues);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskValidator.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskValidator.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.development.task;
+
+import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.TaskValidationIssue;
+import io.yak.ops.plugin.task.api.TaskValidationResult;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Delegates publish capability validation to the installed Task Plugin. */
+@Component
+public class DevelopmentTaskValidator {
+
+  private final TaskPluginRegistry pluginRegistry;
+
+  public DevelopmentTaskValidator(TaskPluginRegistry pluginRegistry) {
+    this.pluginRegistry = pluginRegistry;
+  }
+
+  public DevelopmentTaskValidation validateForPublish(TaskDefinition definition) {
+    TaskPlugin plugin = pluginRegistry.find(definition.taskType()).orElse(null);
+    if (plugin == null) {
+      return DevelopmentTaskValidation.invalid(
+          "当前未安装 " + definition.taskType() + " Task Plugin，无法发布",
+          List.of(new TaskValidationIssue(
+              "TASK_PLUGIN_NOT_INSTALLED",
+              "taskType",
+              "Task plugin is not installed: " + definition.taskType())));
+    }
+
+    TaskValidationResult validation = plugin.validate(definition);
+    if (validation.valid()) {
+      return DevelopmentTaskValidation.ok();
+    }
+    String summary = validation.issues().stream()
+        .map(TaskValidationIssue::message)
+        .limit(3)
+        .reduce((left, right) -> left + "；" + right)
+        .orElse("任务定义校验失败");
+    return DevelopmentTaskValidation.invalid(summary, validation.issues());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/TaskDefinitionDigestCalculator.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/TaskDefinitionDigestCalculator.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.development.task;
+
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import org.springframework.stereotype.Component;
+
+/** Calculates the stable digest used to identify an immutable normalized TaskDefinition snapshot. */
+@Component
+public class TaskDefinitionDigestCalculator {
+
+  public String calculate(TaskDefinition definition) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      updateDigest(digest, definition.taskType());
+      updateDigest(digest, Integer.toString(definition.schemaVersion()));
+      updateDigest(digest, definition.content());
+      updateDigest(digest, definition.configJson());
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (NoSuchAlgorithmException impossible) {
+      throw new IllegalStateException("SHA-256 is unavailable", impossible);
+    }
+  }
+
+  private void updateDigest(MessageDigest digest, String value) {
+    if (value != null) {
+      digest.update(value.getBytes(StandardCharsets.UTF_8));
+    }
+    digest.update((byte) 0);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentNodeModelTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentNodeModelTest.java
@@ -2,8 +2,10 @@ package io.yak.ops.business.development.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class DevelopmentNodeModelTest {
@@ -36,5 +38,21 @@ class DevelopmentNodeModelTest {
     assertFalse(DevelopmentNodeType.DATA_SERVICE.isProcessing());
     assertTrue(DevelopmentNodeType.DATASET.isOutput());
     assertTrue(DevelopmentNodeType.DATA_SERVICE.isOutput());
+  }
+
+  @Test
+  void nodeOwnsTaskLifecycleCapabilityGate() {
+    Instant now = Instant.parse("2026-08-24T00:00:00Z");
+    DevelopmentNode sql = new DevelopmentNode(1L, "SQL", "sql", null, null, true, now, now);
+    DevelopmentNode dataset =
+        new DevelopmentNode(2L, "Dataset", "DATASET", null, null, true, now, now);
+
+    assertEquals(DevelopmentNodeType.SQL, sql.nodeType());
+    assertTrue(sql.supportsTaskLifecycle());
+    sql.requireTaskLifecycle();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, dataset::requireTaskLifecycle);
+    assertTrue(exception.getMessage().contains("不是可执行开发任务"));
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentTaskDomainTruthTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/domain/DevelopmentTaskDomainTruthTest.java
@@ -1,0 +1,26 @@
+package io.yak.ops.business.development.domain;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentTaskDomainTruthTest {
+
+  @Test
+  void draftAndPublishedRevisionKeepDifferentIdentitySemantics() {
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
+    DevelopmentTaskDraft draft =
+        new DevelopmentTaskDraft(1L, definition, 7L, Instant.now(), Instant.now());
+    DevelopmentTaskRevision revision =
+        new DevelopmentTaskRevision(9L, 1L, 2, 7L, definition, "abc", Instant.now());
+
+    assertTrue(draft.matchesRevision(7L));
+    assertFalse(draft.matchesRevision(6L));
+    assertTrue(revision.represents(7L, "abc"));
+    assertFalse(revision.represents(7L, "changed"));
+    assertFalse(revision.represents(8L, "abc"));
+  }
+}


### PR DESCRIPTION
## Summary

Stage 1 refactor for `yak-ops-business-data-development`.

This PR does **not** remove `service` for the sake of removing it. It first establishes the module's domain truth and extracts the central Task authoring path into role-oriented components, following the same direction used by Offline/Realtime Sync.

Core lifecycle:

```text
DevelopmentNode
    -> mutable DevelopmentTaskDraft
    -> immutable DevelopmentTaskRevision
    -> Task Catalog projection

current editor definition
    -> TaskVersionSnapshot(version = 0)
    -> shared Task Runtime
    -> DevelopmentTaskExecution history
```

The central rule is now explicit: **Node != Draft != Revision != Execution**.

## Stage 1 scope

### 1. Domain truth

`DevelopmentNode` now owns node-type interpretation and the explicit Task lifecycle capability gate instead of spreading string parsing across services.

`DevelopmentTaskDraft` exposes exact draft-revision matching, and `DevelopmentTaskRevision` exposes the idempotent immutable-snapshot identity rule:

```text
same sourceDraftRevision + same normalized definition checksum
    -> reuse existing immutable Revision
```

No database model changes are introduced.

### 2. Task authoring roles

`DevelopmentTaskService` remains the stable application/compatibility facade, while internal responsibilities move to explicit roles:

```text
DevelopmentTaskService
├── DevelopmentTaskNodeResolver
├── DevelopmentTaskDefinitionNormalizer
├── DevelopmentTaskDraftManager
├── DevelopmentTaskValidator
├── TaskDefinitionDigestCalculator
├── DevelopmentTaskPublisher
└── DevelopmentTaskRevisionReader
```

Responsibilities are intentionally narrow:

- `NodeResolver` — node lookup + executable capability gate
- `DefinitionNormalizer` — the single TaskDefinition normalization rule
- `DraftManager` — mutable Draft read/save/lock
- `Validator` — Task Plugin publish validation
- `DigestCalculator` — immutable definition digest
- `Publisher` — append/reuse immutable Revision + reconcile Task Catalog projection
- `RevisionReader` — immutable Revision read side
- `DevelopmentTaskService` — transaction boundary, compatibility exception translation and orchestration

Existing constructors are retained for focused tests/non-Spring callers.

### 3. Editor Run reuses the same rules

`DevelopmentTaskRunService` no longer carries a second copy of node lookup and TaskDefinition normalization logic. It reuses:

```text
DevelopmentTaskNodeResolver
DevelopmentTaskDefinitionNormalizer
```

Editor Run semantics remain unchanged: it executes a temporary version-0 snapshot through the shared Task Runtime and records execution history; it does not implicitly publish a Revision.

### 4. Architecture documents

Adds the three Stage 1 contracts:

- `REQUIREMENTS.md` — required capability/behavior
- `DOMAIN.md` — truth ownership and hard invariants
- `ARCHITECTURE.md` — role boundaries and Stage 1 compatibility structure

The docs explicitly keep DATASET / DATA_SERVICE outside the generic executable Task lifecycle and keep Lineage as a derived-evidence boundary rather than Data Development runtime truth.

## Behavior intentionally unchanged

This refactor does not change:

- `/api/v1/development/**` REST contracts
- database schema / Flyway migrations
- Draft optimistic revision behavior
- Task Plugin validation semantics
- Revision checksum algorithm
- append/reuse publication semantics
- Task Catalog publication projection
- editor manual-run snapshot semantics
- SQL lineage outbox behavior

It also intentionally does **not** fully dismantle the current `service` package. Data Service, Release, Lineage and the rest of Execution role cleanup belong to Stage 2 so package moves are not mixed with unrelated domain/runtime changes.

## Tests

Existing `DevelopmentTaskServiceTest` and `DevelopmentTaskRunServiceTest` continue to exercise the compatibility facades and main behavior path.

Adds/extends focused domain tests for:

- Node-owned Task lifecycle capability gate
- Draft revision identity
- immutable Revision representation identity

## Validation note

The branch was rebased onto current `main` (`2ed6cb37`) after the Dashboard Stage 2 merge, so this PR remains isolated to Data Development changes.

A full Maven run is **not claimed from the current tool environment** because the execution container cannot resolve `github.com` for an authoritative checkout/dependency run. The PR is intentionally opened as Draft so normal repository CI/project-environment verification can run before review.

Recommended local verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
```

## Stage 2 follow-up

Stage 2 will continue the role-oriented migration for Data Service / Release / Lineage / Execution, add `DEPENDENCIES.md` / `REVIEW.md` / README alignment, and introduce executable architecture/dependency guards instead of broad `service/common/helper/utils` buckets.