### PR TITLE
fix(datasource): align SQL statement audit status type

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/SqlStatementAuditRecord.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/SqlStatementAuditRecord.java
@@ -1,6 +1,6 @@
 package io.yak.ops.business.datasource.execution.audit;
 
-import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
 import io.yak.ops.core.execution.sql.SqlStatementType;
 import java.time.LocalDateTime;
 
@@ -11,7 +11,7 @@ public record SqlStatementAuditRecord(
     SqlStatementType statementType,
     String sqlFingerprint,
     String sqlPreview,
-    SqlExecutionStatus status,
+    SqlStatementStatus status,
     String resultType,
     long returnedRows,
     long affectedRows,

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/SqlStatementAuditRecordTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/SqlStatementAuditRecordTest.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.datasource.execution.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import org.junit.jupiter.api.Test;
+
+class SqlStatementAuditRecordTest {
+
+  @Test
+  void preservesStatementLevelStatus() {
+    SqlStatementAuditRecord record =
+        new SqlStatementAuditRecord(
+            "statement-1",
+            0,
+            null,
+            null,
+            null,
+            SqlStatementStatus.SUCCEEDED,
+            null,
+            0L,
+            0L,
+            false,
+            null,
+            null,
+            0L,
+            null);
+
+    assertThat(record.status()).isEqualTo(SqlStatementStatus.SUCCEEDED);
+  }
+}


### PR DESCRIPTION
## Summary

Fix the datasource SQL audit compile regression where a statement-level status was modeled as an execution-level status.

## Root cause

`SqlStatementExecutionAuditPO#getStatus()` returns `SqlStatementStatus`, while the Stage 2 audit read projection `SqlStatementAuditRecord.status` was accidentally declared as `SqlExecutionStatus`. `SqlExecutionAuditReader#statementRecord` therefore failed to compile with:

`SqlStatementStatus cannot be converted to SqlExecutionStatus`

## Changes

- change `SqlStatementAuditRecord.status` to `SqlStatementStatus`
- keep execution-level `SqlExecutionAuditRecord.status` as `SqlExecutionStatus`
- add a focused regression test that constructs a statement audit record with `SqlStatementStatus.SUCCEEDED`

## Verification

Statically re-checked the affected chain:

`SqlStatementExecutionAuditPO -> SqlExecutionAuditReader -> SqlStatementAuditRecord -> SqlExecutionAuditMapper`

Also reviewed the nearby execution runtime status/failure delegation and found no additional status-signature mismatch. The mapper already accepts `Enum<?>`, so no compatibility cast or transport change is required.

This repository currently has no GitHub Actions workflow to run a Maven build on the branch from the connector environment, so the PR intentionally remains Draft for local/full build verification.