### PR TITLE
refactor(job): establish stage 1 task runtime truth

### DIFF
--- a/yak-ops-business/yak-ops-business-job/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-job/ARCHITECTURE.md
@@ -1,0 +1,93 @@
+# Job Architecture
+
+Job 采用“发现、快照、执行、运行上下文”四个明确角色，不以调度为中心。
+
+## Stage 1 结构
+
+```text
+controller
+    -> task registry / env service
+
+task
+├── discovery
+│   TaskProvider / TaskRegistration / TaskRegistry
+│
+├── execution
+│   TaskExecutionGateway / TaskExecutor
+│
+├── runtime
+│   AbstractTaskExecutorAdapter
+│   SQL / Python / Java / Shell adapters
+│
+└── sync adapter
+    SyncTaskExecutorAdapter / OfflineSyncTaskRunner
+
+env
+├── SystemEnvVarService
+└── TaskEnvironmentResolver
+```
+
+现阶段仍保留 `task` 单包以控制改动；Stage 2 再做物理 package 收敛。
+
+## Discovery
+
+`InMemoryTaskRegistry` 只能依赖 `TaskProvider`：
+
+```text
+Business source
+    -> TaskProvider
+    -> TaskRegistration
+    -> TaskRegistry
+```
+
+Offline Sync 在 Stage 1 先通过 `OfflineSyncTaskProvider` 隔离直接依赖；是否把 Provider/Executor Adapter 物理移回 Offline Sync 模块，留到 Stage 2 做 Maven 依赖反转。
+
+## Execution
+
+```text
+caller
+  -> TaskExecutionGateway
+  -> TaskExecutor by type
+```
+
+Gateway 只负责路由和输入防御。
+
+Plugin Task 的公共生命周期由 `AbstractTaskExecutorAdapter` 负责：
+
+```text
+snapshot validation
+ -> Task Plugin lookup
+ -> plugin validation
+ -> TaskExecutionContext
+ -> idempotency
+ -> async execution
+ -> status / cancel / result conversion
+```
+
+SQL 不再复制这套生命周期，只负责贡献 `DataSourceExecutionProvider` / `SqlExecutionRuntime` Capability。
+
+SYNC 是外部业务 Runtime Adapter，不强行继承 Plugin Runtime。
+
+## Environment
+
+```text
+TaskExecutionContextFactory
+    -> TaskEnvironmentResolver
+```
+
+Factory 不依赖环境变量 CRUD/DAO 细节。`SystemEnvVarService` 是当前 Resolver 实现和设置页稳定入口。
+
+## 角色词汇
+
+```text
+Provider   暴露业务能力
+Registry   聚合与查找
+Gateway    稳定外部入口/路由
+Executor   执行一种 Task Type
+Adapter    翻译外部 Runtime / Plugin
+Resolver   解析运行上下文
+Factory    构造上下文对象
+Service    稳定应用入口
+```
+
+Stage 1 不为了去 Service 改名；Stage 2 再补依赖矩阵、角色约束和完整架构测试。

--- a/yak-ops-business/yak-ops-business-job/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-job/DOMAIN.md
@@ -1,0 +1,56 @@
+# Job Domain
+
+核心关系：
+
+```text
+TaskDefinition != TaskVersionSnapshot != TaskExecution
+```
+
+当前类名 `TaskDefinition` 为兼容名称；在 Job 领域里它只表示“可发现的任务描述”，不是可执行定义本体。
+
+## Truth Ownership
+
+```text
+TaskDefinition        = Job 可发现的任务描述
+TaskVersionSnapshot   = 一次运行固定的不可变输入
+TaskExecution         = Job 对一次执行的统一观察视图
+TaskProvider          = 业务域到 Job 的发现边界
+TaskExecutor          = 一种 Task Type 的执行能力
+Business Module       = 业务任务定义与业务执行真相 Owner
+Scheduler             = 业务时间触发 Owner
+```
+
+## 硬规则
+
+1. Job 不拥有业务 Task Definition，只持有描述和执行快照。
+2. 有版本能力的 Task 必须执行固定 Snapshot，不能运行时漂移到最新版本。
+3. `TaskRegistration` 中 descriptor 与 snapshot 必须引用同一 Task ID 和 Task Type。
+4. `TaskRegistry` 只聚合 `TaskProvider`，不直接知道 Offline Sync、Data Development 等业务实现。
+5. `TaskExecutionGateway` 只做路由，不实现 SQL/SYNC 等业务逻辑。
+6. Plugin Task 共用一套本地执行生命周期；Task Type 只贡献 Capability。
+7. SYNC 执行事实属于 Offline Sync，Job 只转换为统一 `TaskExecution` 视图。
+8. `TaskExecution` 是统一观察模型，不是所有业务执行记录的持久化 Owner。
+9. Environment 是 Runtime Context，不是 Task 或 Execution 真相。
+10. Job 不注册业务 Schedule，不维护 Cron 生命周期。
+
+## Snapshot Contract
+
+```text
+Workflow publish / manual prepare
+    -> TaskVersionSnapshot
+    -> execution
+```
+
+`version > 0` 的业务版本必须携带对应的不可变 definition/config snapshot。`version = 0` 可以表示当前编辑器等临时运行，但调用方必须显式构造这份快照。
+
+## Discovery Contract
+
+业务 Provider 交付：
+
+```text
+TaskRegistration
+├── TaskDefinition
+└── TaskVersionSnapshot
+```
+
+Job 只负责聚合、冲突检查和查找，不重新解释业务发布状态。

--- a/yak-ops-business/yak-ops-business-job/README.md
+++ b/yak-ops-business/yak-ops-business-job/README.md
@@ -1,41 +1,32 @@
 # yak-ops-business-job
 
-Yak Ops 的通用任务发现与执行路由模块，主要服务于 Workflow 等上层能力。
+`yak-ops-business-job` 是 Yak Ops 的通用 **Task Discovery + Snapshot + Execution Routing** 模块，主要服务 Workflow、Data Development 等上层运行入口。
 
-## 职责边界
+它不拥有业务任务定义，也不负责 Cron / Schedule 生命周期。
 
-本模块负责：
-
-- 统一任务发现与 `TaskRegistry`；
-- SQL / Python / Sync 等任务执行适配；
-- Workflow 运行期间对任务执行状态的查询、取消和结果转换；
-- `SYNC` 任务通过 `OfflineJobExecutionService` 复用离线同步业务执行能力。
-
-本模块 **不负责业务任务的时间调度**，也不注册 Yak Schedule 计划。
-
-## 调度归属
-
-Yak Ops 的业务时间调度已经统一下沉到各业务域：
+核心关系：
 
 ```text
-Business definition
-      -> XxxScheduleEngineBridge
-      -> YakScheduleGateway
-      -> Yak Schedule
-      -> XxxScheduleHandler
-      -> Business execution
+TaskDefinition (discovery descriptor)
+        -> TaskVersionSnapshot
+        -> TaskExecution
 ```
 
-当前：
+其中：
 
-- Offline Sync：由 `yak-ops-business-sync-offline` 的 `OfflineScheduleEngineBridge / Lifecycle / Reconciler / Handler` 负责；
-- Workflow：由 Workflow 模块自己的调度生命周期负责；
-- Data Quality：由 Quality 模块自己的调度生命周期负责。
+- `TaskProvider`：业务域向 Job 暴露可执行任务；
+- `TaskRegistry`：聚合 Provider 并校验任务 ID 冲突；
+- `TaskExecutionGateway`：按 Task Type 路由到 `TaskExecutor`；
+- Plugin Task Executor：SQL / Python / Java / Shell 复用统一执行生命周期；
+- SYNC：通过 Offline Sync 业务运行时执行，Job 不拥有其执行事实；
+- `TaskEnvironmentResolver`：向运行上下文提供全局环境变量。
 
-因此 `yak-ops-business-job` 不应再维护独立的 `JobScheduleRegistrar`、周期扫描器或同名业务 `ScheduleHandler`。
+业务时间调度继续由各业务域自己管理，不在 Job 模块注册计划或维护调度状态。
 
-## Offline Sync 依赖说明
+架构约束：
 
-本模块仍依赖 `yak-ops-business-sync-offline`，是因为 Workflow 的 `SYNC` Task Runner 会调用 `OfflineJobExecutionService` 执行业务任务。
+- [REQUIREMENTS.md](REQUIREMENTS.md)
+- [DOMAIN.md](DOMAIN.md)
+- [ARCHITECTURE.md](ARCHITECTURE.md)
 
-这个依赖仅用于 **执行路由**，不用于 Cron 注册、计划同步或调度生命周期管理。
+仓库级代码规范统一看 `../../CODE_STYLE.md`。

--- a/yak-ops-business/yak-ops-business-job/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-job/REQUIREMENTS.md
@@ -1,0 +1,60 @@
+# Job Requirements
+
+本文件只回答：Job 模块需要提供什么能力。
+
+## 模块定位
+
+Job 是业务无关的任务发现与执行路由层。业务域负责定义任务和拥有业务执行事实；Job 负责把这些能力统一暴露给 Workflow、Data Development 等调用方。
+
+## 核心能力
+
+### Task Discovery
+
+业务域通过 `TaskProvider` 暴露任务。Job 不应在 Registry 中直接扫描某个业务 Service。
+
+每个被发现任务至少包含：
+
+```text
+TaskDefinition         = 可选择的任务描述
+TaskVersionSnapshot    = 被固定的执行输入
+```
+
+Registry 必须拒绝重复 Task ID，并保证描述与快照属于同一个 Task。
+
+### Task Execution
+
+调用方统一通过：
+
+```text
+TaskExecutionGateway
+    -> TaskExecutor
+    -> TaskExecution
+```
+
+Job 根据 Task Type 路由，不复制各业务域的执行状态机。
+
+SQL / Python / Java / Shell 这类 Task Plugin 应共享同一套本地执行生命周期：校验、幂等、运行句柄、状态、取消和结果转换只实现一次。
+
+SYNC 属于外部业务运行时：Job 只做适配，不拥有 Offline Sync 的 Execution 真相。
+
+### Immutable Snapshot
+
+有版本能力的任务执行时必须使用已经固定的 `TaskVersionSnapshot`。运行期间不能回读当前草稿或最新版本替换它。
+
+### Runtime Context
+
+Task Runtime Context 可以包含参数、Trigger、全局环境变量及任务类型能力。环境变量通过窄接口提供，执行层不依赖设置页面的 CRUD 实现。
+
+## 非职责
+
+Job 不负责：
+
+- Cron / Schedule 注册与生命周期；
+- Offline Sync / Data Development 等业务任务定义；
+- Workflow 编排；
+- 业务 Execution 持久化；
+- 把所有 Task Type 的业务逻辑集中到一个超级 Service。
+
+## 兼容要求
+
+Stage 1 保持现有 REST、Task SPI、Workflow 调用方式、Offline Sync 执行行为和环境变量 API 不变；不新增数据库迁移。

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/env/SystemEnvVarService.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/env/SystemEnvVarService.java
@@ -15,21 +15,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Manages application-level environment variables stored in {@code yak_system_env_var}.
+ * Stable application facade for application-level environment variables.
  *
- * <p>On startup, all rows are loaded into an in-memory cache. Mutations update both the
- * cache and the database so that subsequent task executions immediately pick up the
- * latest values without restarting the application.
- *
- * <p>The merge priority (highest first) is:
- * <ol>
- *   <li>Task-level {@code envVars} specified in the task config</li>
- *   <li>Application-level env vars managed by this service</li>
- *   <li>OS-level environment variables from {@code System.getenv()}</li>
- * </ol>
+ * <p>The same component implements {@link TaskEnvironmentResolver}, so task execution depends only
+ * on the narrow runtime read contract rather than on settings CRUD behavior.</p>
  */
 @Service
-public class SystemEnvVarService {
+public class SystemEnvVarService implements TaskEnvironmentResolver {
 
   private static final Logger log = LoggerFactory.getLogger(SystemEnvVarService.class);
 
@@ -54,19 +46,15 @@ public class SystemEnvVarService {
     return Collections.unmodifiableMap(new LinkedHashMap<>(cache));
   }
 
-  /**
-   * Returns a merged environment variable map suitable for task execution.
-   *
-   * <p>OS-level environment variables form the base; application-level variables
-   * override them.
-   */
+  /** OS environment is the base; application-level values override it. */
+  @Override
   public Map<String, String> resolveMergedEnv() {
     Map<String, String> merged = new LinkedHashMap<>(System.getenv());
     merged.putAll(cache);
     return Collections.unmodifiableMap(merged);
   }
 
-  /** Sets (or updates) an application-level environment variable. */
+  /** Sets or updates an application-level environment variable. */
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public void set(String key, String value) {
     String normalizedKey = normalizeKey(key);
@@ -87,7 +75,10 @@ public class SystemEnvVarService {
     }
 
     cache.put(normalizedKey, normalizedValue);
-    log.info("Application environment variable set: {} = {}", normalizedKey, maskSensitive(normalizedKey, normalizedValue));
+    log.info(
+        "Application environment variable set: {} = {}",
+        normalizedKey,
+        maskSensitive(normalizedKey, normalizedValue));
   }
 
   /** Removes an application-level environment variable. */
@@ -102,12 +93,10 @@ public class SystemEnvVarService {
     return affected > 0;
   }
 
-  /** Batch-saves environment variables, replacing all existing application-level variables. */
+  /** Batch-saves environment variables using the same validation and persistence semantics as set. */
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public void batchSave(Map<String, String> variables) {
-    if (variables == null || variables.isEmpty()) {
-      return;
-    }
+    if (variables == null || variables.isEmpty()) return;
     for (Map.Entry<String, String> entry : variables.entrySet()) {
       set(entry.getKey(), entry.getValue());
     }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/env/TaskEnvironmentResolver.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/env/TaskEnvironmentResolver.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.job.env;
+
+import java.util.Map;
+
+/** Resolves the global environment visible to task runtime contexts. */
+public interface TaskEnvironmentResolver {
+
+  Map<String, String> resolveMergedEnv();
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/package-info.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/package-info.java
@@ -1,4 +1,6 @@
 /**
- * Yak Ops 业务调度聚合、计划注册和触发入口。
+ * Yak Ops 通用任务发现、不可变快照与执行路由模块。
+ *
+ * <p>业务时间调度由各业务域自己负责；本模块不拥有 Cron / Schedule 生命周期。</p>
  */
 package io.yak.ops.business.job;

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/AbstractTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/AbstractTaskExecutorAdapter.java
@@ -24,18 +24,15 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 
 /**
- * Template-method base class for task executor adapters that delegate to the
- * shared Task Runtime / TaskPlugin contract.
+ * Shared local runtime for TaskPlugin-backed task types.
  *
- * <p>Subclasses only specify <em>what</em> task type they handle and
- * <em>how</em> the execution context should be configured. All orchestration
- * (idempotency, lifecycle, conversion, error handling) lives here exactly once.</p>
+ * <p>Task-type adapters only declare type identity and contribute capabilities. Idempotency,
+ * execution handles, asynchronous lifecycle, status/cancel and result conversion are owned here.
  */
 abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
 
@@ -61,40 +58,51 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     this.workerExecutor = Executors.newVirtualThreadPerTaskExecutor();
   }
 
-  // ── Template hooks ────────────────────────────────────────────────
-
-  /**
-   * The task type this adapter handles, e.g. "PYTHON", "JAVA", "SHELL".
-   * Also serves as the {@link TaskExecutor#taskType()} implementation.
-   */
   @Override
   public abstract String taskType();
 
-  /** Prefix for generated execution IDs, e.g. "python", "java", "shell". */
   protected abstract String executionIdPrefix();
 
-  /** Human-readable display name for log/error messages, e.g. "Python". */
   protected abstract String displayName();
 
-  /**
-   * Configure the execution context with task-type-specific capabilities.
-   *
-   * <p>The default injects {@link ResourceResolver} conditionally when the
-   * definition carries a {@code resourceId} reference. Override for types
-   * that always (or never) require a resolver.</p>
-   */
+  /** Contributes task-type-specific runtime capabilities. */
   protected void configureContext(
       DefaultTaskExecutionContext.Builder builder,
       String definitionJson) {
+    if (resourceResolverProvider == null) return;
     if (hasResourceReference(definitionJson, objectMapper)) {
       ResourceResolver resolver = resourceResolverProvider.getIfAvailable();
-      if (resolver != null) {
-        builder.capability(ResourceResolver.class, resolver);
-      }
+      if (resolver != null) builder.capability(ResourceResolver.class, resolver);
     }
   }
 
-  // ── TaskExecutor implementation ───────────────────────────────────
+  protected String snapshotRequiredMessage() {
+    return "Task version snapshot must not be null";
+  }
+
+  protected String snapshotTypeMismatchMessage(TaskVersionSnapshot snapshot) {
+    return displayName() + " executor cannot execute task type: " + snapshot.type();
+  }
+
+  protected String missingDefinitionSnapshotMessage(TaskVersionSnapshot snapshot) {
+    return displayName() + " task missing immutable definitionSnapshot: " + snapshot.taskId();
+  }
+
+  protected String executionNotFoundMessage(String executionId) {
+    return displayName() + " task execution not found: " + executionId;
+  }
+
+  protected String pluginNotExecutableMessage() {
+    return displayName() + " Task Plugin does not support execution";
+  }
+
+  protected String validationFailureMessage(TaskValidationResult validation) {
+    return summarizeIssues(validation, displayName() + " task validation failed");
+  }
+
+  protected String executionFailureMessage(Throwable throwable) {
+    return safeMessage(throwable, displayName() + " execution failed");
+  }
 
   @Override
   public TaskExecution start(
@@ -125,9 +133,9 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     validateDefinition(plugin, definition);
 
     TaskExecutionContext context = contextFactory.create(
-        safeTrigger, input,
+        safeTrigger,
+        input,
         builder -> configureContext(builder, snapshot.definitionSnapshotJson()));
-
     io.yak.ops.plugin.task.api.TaskExecutor pluginExecutor =
         plugin.createExecutor(definition, context);
 
@@ -139,9 +147,12 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
 
     try {
       workerExecutor.submit(() -> runExecution(executionId, handle));
-    } catch (RuntimeException e) {
+    } catch (RuntimeException exception) {
       TaskExecution failed = new TaskExecution(
-          executionId, "FAILED", safeMessage(e, displayName() + " execution failed"), Map.of());
+          executionId,
+          "FAILED",
+          executionFailureMessage(exception),
+          Map.of());
       handle.snapshot().set(failed);
       return failed;
     }
@@ -150,8 +161,7 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
 
   @Override
   public TaskExecution status(String executionId) {
-    ExecutionHandle handle = requireHandle(executionId);
-    return handle.snapshot().get();
+    return requireHandle(executionId).snapshot().get();
   }
 
   @Override
@@ -164,8 +174,10 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     handle.snapshot().updateAndGet(existing -> existing.terminal()
         ? existing
         : new TaskExecution(
-            executionId, "CANCELED",
-            displayName() + " execution cancelled", existing.output()));
+            executionId,
+            "CANCELED",
+            displayName() + " execution cancelled",
+            existing.output()));
   }
 
   @PreDestroy
@@ -173,32 +185,34 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     workerExecutor.shutdownNow();
   }
 
-  // ── Protected accessors for subclasses ────────────────────────────
-
-  /** Access the ResourceResolver provider, e.g. for always-required injection. */
   protected ResourceResolver resourceResolver() {
-    return resourceResolverProvider.getIfAvailable();
+    return resourceResolverProvider == null ? null : resourceResolverProvider.getIfAvailable();
   }
-
-  // ── Internal orchestration ────────────────────────────────────────
 
   private void runExecution(String executionId, ExecutionHandle handle) {
     try {
       TaskExecutionResult result = handle.executor().execute();
       TaskExecution completed = convert(executionId, result);
-      handle.snapshot().updateAndGet(c -> c.terminal() ? c : completed);
+      handle.snapshot().updateAndGet(current -> current.terminal() ? current : completed);
       if (completed.terminal() && !"SUCCEEDED".equals(completed.status())) {
-        log.warn("{} task execution ended [{}] status={} message={}",
-            displayName(), executionId, completed.status(), completed.errorMessage());
+        log.warn(
+            "{} task execution ended [{}] status={} message={}",
+            displayName(),
+            executionId,
+            completed.status(),
+            completed.errorMessage());
       } else {
         log.info("{} task execution completed [{}] status={}",
             displayName(), executionId, completed.status());
       }
-    } catch (Exception e) {
-      log.error("{} task execution exception [{}]", displayName(), executionId, e);
+    } catch (Exception exception) {
+      log.error("{} task execution exception [{}]", displayName(), executionId, exception);
       TaskExecution failed = new TaskExecution(
-          executionId, "FAILED", safeMessage(e, displayName() + " execution failed"), Map.of());
-      handle.snapshot().updateAndGet(c -> c.terminal() ? c : failed);
+          executionId,
+          "FAILED",
+          executionFailureMessage(exception),
+          Map.of());
+      handle.snapshot().updateAndGet(current -> current.terminal() ? current : failed);
     }
   }
 
@@ -216,13 +230,10 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     return new TaskExecution(executionId, status, errorMessage, result.output());
   }
 
-  // ── Helpers ───────────────────────────────────────────────────────
-
   private TaskPlugin requireExecutablePlugin() {
     TaskPlugin plugin = pluginRegistry.require(taskType());
     if (!plugin.descriptor().executable()) {
-      throw new IllegalStateException(
-          displayName() + " Task Plugin does not support execution");
+      throw new IllegalStateException(pluginNotExecutableMessage());
     }
     return plugin;
   }
@@ -230,8 +241,7 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
   private TaskDefinition extractDefinition(TaskVersionSnapshot snapshot) {
     String json = snapshot.definitionSnapshotJson();
     if (json == null || json.isBlank()) {
-      throw new IllegalArgumentException(
-          displayName() + " task missing immutable definitionSnapshot: " + snapshot.taskId());
+      throw new IllegalArgumentException(missingDefinitionSnapshotMessage(snapshot));
     }
     try {
       TaskDefinition definition = objectMapper.readValue(json, TaskDefinition.class);
@@ -241,35 +251,28 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
                 + taskType() + ", definition=" + definition.taskType());
       }
       return definition;
-    } catch (JsonProcessingException e) {
+    } catch (JsonProcessingException exception) {
       throw new IllegalArgumentException(
-          displayName() + " task definitionSnapshot is not valid JSON", e);
+          displayName() + " task definitionSnapshot is not valid JSON", exception);
     }
   }
 
   private void validateDefinition(TaskPlugin plugin, TaskDefinition definition) {
     TaskValidationResult validation = plugin.validate(definition);
-    String summary = summarizeIssues(validation,
-        displayName() + " task validation failed");
+    String summary = validationFailureMessage(validation);
     if (summary != null) throw new IllegalArgumentException(summary);
   }
 
   private void requireSnapshot(TaskVersionSnapshot snapshot) {
-    if (snapshot == null) {
-      throw new IllegalArgumentException("Task version snapshot must not be null");
-    }
+    if (snapshot == null) throw new IllegalArgumentException(snapshotRequiredMessage());
     if (!taskType().equalsIgnoreCase(snapshot.type())) {
-      throw new IllegalArgumentException(
-          displayName() + " executor cannot execute task type: " + snapshot.type());
+      throw new IllegalArgumentException(snapshotTypeMismatchMessage(snapshot));
     }
   }
 
   private ExecutionHandle requireHandle(String executionId) {
     ExecutionHandle handle = executions.get(executionId);
-    if (handle == null) {
-      throw new IllegalArgumentException(
-          displayName() + " task execution not found: " + executionId);
-    }
+    if (handle == null) throw new IllegalArgumentException(executionNotFoundMessage(executionId));
     return handle;
   }
 
@@ -277,8 +280,6 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     if (key == null || key.isBlank()) return null;
     return key.trim();
   }
-
-  // ── Inner types ───────────────────────────────────────────────────
 
   protected record ExecutionHandle(
       io.yak.ops.plugin.task.api.TaskExecutor executor,

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/InMemoryTaskRegistry.java
@@ -1,9 +1,5 @@
 package io.yak.ops.business.job.task;
 
-import io.yak.framework.common.PageData;
-import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
-import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
-import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -17,18 +13,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class InMemoryTaskRegistry implements TaskRegistry {
 
-  private static final int PAGE_SIZE = 200;
-  private static final String RELEASE_STATE_ONLINE = "ONLINE";
-
-  private final ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider;
   private final ObjectProvider<TaskProvider> taskProviderProvider;
   private final ConcurrentMap<String, TaskDefinition> tasks = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, TaskVersionSnapshot> snapshots = new ConcurrentHashMap<>();
 
-  public InMemoryTaskRegistry(
-      ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider,
-      ObjectProvider<TaskProvider> taskProviderProvider) {
-    this.definitionServiceProvider = definitionServiceProvider;
+  public InMemoryTaskRegistry(ObjectProvider<TaskProvider> taskProviderProvider) {
     this.taskProviderProvider = taskProviderProvider;
   }
 
@@ -64,8 +53,12 @@ public class InMemoryTaskRegistry implements TaskRegistry {
   private void refresh() {
     Map<String, TaskDefinition> taskSnapshot = new LinkedHashMap<>();
     Map<String, TaskVersionSnapshot> versionSnapshot = new LinkedHashMap<>();
-    appendOfflineSyncTasks(taskSnapshot, versionSnapshot);
-    appendProvidedTasks(taskSnapshot, versionSnapshot);
+
+    for (TaskProvider provider : taskProviderProvider.orderedStream().toList()) {
+      for (TaskRegistration registration : provider.registrations()) {
+        putTask(taskSnapshot, versionSnapshot, registration);
+      }
+    }
 
     tasks.clear();
     tasks.putAll(taskSnapshot);
@@ -73,88 +66,17 @@ public class InMemoryTaskRegistry implements TaskRegistry {
     snapshots.putAll(versionSnapshot);
   }
 
-  private void appendOfflineSyncTasks(
-      Map<String, TaskDefinition> taskSnapshot,
-      Map<String, TaskVersionSnapshot> versionSnapshot) {
-    OfflineJobDefinitionService service = definitionServiceProvider.getIfAvailable();
-    if (service == null) return;
-
-    int pageNo = 1;
-    while (true) {
-      PageData<OfflineJobDefinition> page = service.pageDomain(
-          new OfflineDefinitionQuery(
-              pageNo,
-              PAGE_SIZE,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null));
-      for (OfflineJobDefinition definition : page.records()) {
-        if (!isWorkflowEligible(definition)) continue;
-        try {
-          OfflineJobDefinition current = service.require(definition.getId());
-          String logicalJobSpec = service.resolveLogicalJobSpec(current);
-          String id = String.valueOf(current.getId());
-          String name = current.getJobName();
-          putTask(
-              taskSnapshot,
-              versionSnapshot,
-              new TaskDefinition(id, name, "SYNC"),
-              new TaskVersionSnapshot(
-                  id,
-                  name,
-                  "SYNC",
-                  Math.max(1, current.getVersion() == null ? 1 : current.getVersion()),
-                  current.getConfigDigest(),
-                  current.getDefinitionJson(),
-                  logicalJobSpec));
-        } catch (RuntimeException ignored) {
-          // 草稿、被删除或没有可执行 JobSpec 的同步任务不进入工作流任务列表。
-        }
-      }
-      if (pageNo >= page.pages()) break;
-      pageNo++;
-    }
-  }
-
-  private void appendProvidedTasks(
-      Map<String, TaskDefinition> taskSnapshot,
-      Map<String, TaskVersionSnapshot> versionSnapshot) {
-    for (TaskProvider provider : taskProviderProvider.orderedStream().toList()) {
-      for (TaskDefinition task : provider.list()) {
-        if (task == null || task.id() == null || task.id().isBlank()) continue;
-        TaskVersionSnapshot snapshot = provider.snapshot(task.id());
-        putTask(taskSnapshot, versionSnapshot, task, snapshot);
-      }
-    }
-  }
-
   private void putTask(
       Map<String, TaskDefinition> taskSnapshot,
       Map<String, TaskVersionSnapshot> versionSnapshot,
-      TaskDefinition task,
-      TaskVersionSnapshot snapshot) {
-    if (snapshot == null || !task.id().equals(snapshot.taskId())) {
-      throw new IllegalStateException("任务定义与版本快照不匹配：" + task.id());
-    }
+      TaskRegistration registration) {
+    TaskDefinition task = registration.definition();
+    TaskVersionSnapshot snapshot = registration.snapshot();
     TaskDefinition existing = taskSnapshot.putIfAbsent(task.id(), task);
     if (existing != null) {
       throw new IllegalStateException(
           "重复的工作流任务 ID：" + task.id() + "，类型=" + existing.type() + "/" + task.type());
     }
     versionSnapshot.put(task.id(), snapshot);
-  }
-
-  static boolean isWorkflowEligible(OfflineJobDefinition definition) {
-    return definition != null
-        && definition.getId() != null
-        && definition.getJobName() != null
-        && RELEASE_STATE_ONLINE.equalsIgnoreCase(definition.getReleaseState())
-        && !Boolean.TRUE.equals(definition.getScheduleEnabled());
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/OfflineSyncTaskProvider.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/OfflineSyncTaskProvider.java
@@ -1,0 +1,123 @@
+package io.yak.ops.business.job.task;
+
+import io.yak.framework.common.PageData;
+import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/** Adapts workflow-eligible Offline Sync definitions into the generic TaskProvider contract. */
+@Component
+public class OfflineSyncTaskProvider implements TaskProvider {
+
+  private static final int PAGE_SIZE = 200;
+  private static final String RELEASE_STATE_ONLINE = "ONLINE";
+
+  private final ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider;
+
+  public OfflineSyncTaskProvider(
+      ObjectProvider<OfflineJobDefinitionService> definitionServiceProvider) {
+    this.definitionServiceProvider = definitionServiceProvider;
+  }
+
+  @Override
+  public List<TaskDefinition> list() {
+    return registrations().stream().map(TaskRegistration::definition).toList();
+  }
+
+  @Override
+  public TaskVersionSnapshot snapshot(String taskId) {
+    OfflineJobDefinition current = service().require(parseTaskId(taskId));
+    if (!isWorkflowEligible(current)) {
+      throw new IllegalArgumentException("离线同步任务当前不可用于工作流：" + taskId);
+    }
+    return registration(current).snapshot();
+  }
+
+  @Override
+  public List<TaskRegistration> registrations() {
+    OfflineJobDefinitionService service = definitionServiceProvider.getIfAvailable();
+    if (service == null) return List.of();
+
+    List<TaskRegistration> registrations = new ArrayList<>();
+    int pageNo = 1;
+    while (true) {
+      PageData<OfflineJobDefinition> page = service.pageDomain(query(pageNo));
+      for (OfflineJobDefinition definition : page.records()) {
+        if (!isWorkflowEligible(definition)) continue;
+        try {
+          registrations.add(registration(service.require(definition.getId())));
+        } catch (RuntimeException ignored) {
+          // Draft/deleted definitions or definitions without executable JobSpec are not discoverable.
+        }
+      }
+      if (pageNo >= page.pages()) break;
+      pageNo++;
+    }
+    return List.copyOf(registrations);
+  }
+
+  private TaskRegistration registration(OfflineJobDefinition definition) {
+    if (!isWorkflowEligible(definition)) {
+      throw new IllegalArgumentException("离线同步任务当前不可用于工作流：" + definition.getId());
+    }
+    String logicalJobSpec = service().resolveLogicalJobSpec(definition);
+    String id = String.valueOf(definition.getId());
+    String name = definition.getJobName();
+    TaskDefinition descriptor = new TaskDefinition(id, name, "SYNC");
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        id,
+        name,
+        "SYNC",
+        Math.max(1, definition.getVersion() == null ? 1 : definition.getVersion()),
+        definition.getConfigDigest(),
+        definition.getDefinitionJson(),
+        logicalJobSpec);
+    return new TaskRegistration(descriptor, snapshot);
+  }
+
+  private OfflineDefinitionQuery query(int pageNo) {
+    return new OfflineDefinitionQuery(
+        pageNo,
+        PAGE_SIZE,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
+  }
+
+  private OfflineJobDefinitionService service() {
+    OfflineJobDefinitionService service = definitionServiceProvider.getIfAvailable();
+    if (service == null) {
+      throw new IllegalStateException("离线同步能力未启用");
+    }
+    return service;
+  }
+
+  private Long parseTaskId(String taskId) {
+    if (taskId == null || taskId.isBlank()) throw new IllegalArgumentException("taskId 不能为空");
+    try {
+      long value = Long.parseLong(taskId.trim());
+      if (value <= 0L) throw new NumberFormatException("not positive");
+      return value;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("SYNC taskId 不合法：" + taskId, exception);
+    }
+  }
+
+  static boolean isWorkflowEligible(OfflineJobDefinition definition) {
+    return definition != null
+        && definition.getId() != null
+        && definition.getJobName() != null
+        && RELEASE_STATE_ONLINE.equalsIgnoreCase(definition.getReleaseState())
+        && !Boolean.TRUE.equals(definition.getScheduleEnabled());
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SqlTaskExecutorAdapter.java
@@ -1,42 +1,22 @@
 package io.yak.ops.business.job.task;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
-import io.yak.ops.plugin.task.api.TaskExecutionContext;
-import io.yak.ops.plugin.task.api.TaskExecutionResult;
-import io.yak.ops.plugin.task.api.TaskPlugin;
+import io.yak.ops.plugin.task.api.DefaultTaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskValidationIssue;
 import io.yak.ops.plugin.task.api.TaskValidationResult;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
-import io.yak.ops.spi.task.model.TaskDefinition;
-import io.yak.ops.spi.task.model.TaskExecutionStatus;
-import io.yak.ops.spi.task.model.TaskExecutionTrigger;
-import jakarta.annotation.PreDestroy;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-/** Executes SQL revisions through the shared Task Runtime and TaskPlugin contract. */
+/** SQL TaskPlugin adapter; SQL contributes capabilities while shared runtime owns execution lifecycle. */
 @Service
-public class SqlTaskExecutorAdapter implements TaskExecutor {
+public class SqlTaskExecutorAdapter extends AbstractTaskExecutorAdapter {
 
-  private final TaskPluginRegistry pluginRegistry;
   private final ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider;
   private final ObjectProvider<SqlExecutionRuntime> sqlExecutionRuntime;
-  private final ObjectMapper objectMapper;
-  private final TaskExecutionContextFactory contextFactory;
-  private final ExecutorService workerExecutor;
-  private final ConcurrentMap<String, ExecutionHandle> executions = new ConcurrentHashMap<>();
-  private final ConcurrentMap<String, String> idempotencyIndex = new ConcurrentHashMap<>();
 
   @Autowired
   public SqlTaskExecutorAdapter(
@@ -45,12 +25,9 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
       ObjectProvider<SqlExecutionRuntime> sqlExecutionRuntime,
       ObjectMapper objectMapper,
       TaskExecutionContextFactory contextFactory) {
-    this.pluginRegistry = pluginRegistry;
+    super(pluginRegistry, null, objectMapper, contextFactory);
     this.dataSourceExecutionProvider = dataSourceExecutionProvider;
     this.sqlExecutionRuntime = sqlExecutionRuntime;
-    this.objectMapper = objectMapper;
-    this.contextFactory = contextFactory;
-    this.workerExecutor = Executors.newVirtualThreadPerTaskExecutor();
   }
 
   /** Backward-compatible constructor for existing adapter-level tests and embedders. */
@@ -59,12 +36,7 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
       ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider,
       ObjectMapper objectMapper,
       TaskExecutionContextFactory contextFactory) {
-    this(
-        pluginRegistry,
-        dataSourceExecutionProvider,
-        null,
-        objectMapper,
-        contextFactory);
+    this(pluginRegistry, dataSourceExecutionProvider, null, objectMapper, contextFactory);
   }
 
   @Override
@@ -73,184 +45,69 @@ public class SqlTaskExecutorAdapter implements TaskExecutor {
   }
 
   @Override
-  public TaskExecution start(
-      TaskVersionSnapshot snapshot,
-      String idempotencyKey,
-      Map<String, Object> input) {
-    return start(snapshot, TaskExecutionTrigger.WORKFLOW, idempotencyKey, input);
+  protected String executionIdPrefix() {
+    return "sql";
   }
 
   @Override
-  public synchronized TaskExecution start(
-      TaskVersionSnapshot snapshot,
-      TaskExecutionTrigger trigger,
-      String idempotencyKey,
-      Map<String, Object> input) {
-    requireSqlSnapshot(snapshot);
-    TaskExecutionTrigger safeTrigger =
-        trigger == null ? TaskExecutionTrigger.WORKFLOW : trigger;
-    String safeIdempotencyKey = normalizeIdempotencyKey(idempotencyKey);
-    if (safeIdempotencyKey != null) {
-      String existingExecutionId = idempotencyIndex.get(safeIdempotencyKey);
-      if (existingExecutionId != null) {
-        return status(existingExecutionId);
-      }
-    }
+  protected String displayName() {
+    return "SQL";
+  }
 
-    TaskDefinition definition = immutableDefinition(snapshot);
-    TaskPlugin plugin = pluginRegistry.require("SQL");
-    if (!plugin.descriptor().executable()) {
-      throw new IllegalStateException("SQL Task Plugin 暂不支持执行");
-    }
-    validate(plugin, definition);
-
-    DataSourceExecutionProvider provider = dataSourceExecutionProvider.getIfAvailable();
+  @Override
+  protected void configureContext(
+      DefaultTaskExecutionContext.Builder builder,
+      String definitionJson) {
+    DataSourceExecutionProvider provider =
+        dataSourceExecutionProvider == null ? null : dataSourceExecutionProvider.getIfAvailable();
     SqlExecutionRuntime runtime =
         sqlExecutionRuntime == null ? null : sqlExecutionRuntime.getIfAvailable();
-    TaskExecutionContext context = contextFactory.create(safeTrigger, input,
-        builder -> {
-          if (provider != null) {
-            builder.capability(DataSourceExecutionProvider.class, provider);
-          }
-          if (runtime != null) {
-            builder.capability(SqlExecutionRuntime.class, runtime);
-          }
-        });
-    io.yak.ops.plugin.task.api.TaskExecutor pluginExecutor =
-        plugin.createExecutor(definition, context);
-
-    String executionId = "sql-" + UUID.randomUUID();
-    TaskExecution initial = new TaskExecution(executionId, "RUNNING", null, Map.of());
-    ExecutionHandle handle = new ExecutionHandle(pluginExecutor, new AtomicReference<>(initial));
-    executions.put(executionId, handle);
-    if (safeIdempotencyKey != null) {
-      idempotencyIndex.put(safeIdempotencyKey, executionId);
-    }
-
-    try {
-      workerExecutor.submit(() -> execute(executionId, handle));
-    } catch (RuntimeException exception) {
-      TaskExecution failed = new TaskExecution(
-          executionId,
-          "FAILED",
-          safeMessage(exception),
-          Map.of());
-      handle.snapshot().set(failed);
-      return failed;
-    }
-    return initial;
+    if (provider != null) builder.capability(DataSourceExecutionProvider.class, provider);
+    if (runtime != null) builder.capability(SqlExecutionRuntime.class, runtime);
   }
 
   @Override
-  public TaskExecution status(String executionId) {
-    ExecutionHandle handle = executions.get(executionId);
-    if (handle == null) {
-      throw new IllegalArgumentException("SQL 任务执行不存在：" + executionId);
-    }
-    return handle.snapshot().get();
+  protected String snapshotRequiredMessage() {
+    return "任务版本快照不能为空";
   }
 
   @Override
-  public void cancel(String executionId) {
-    ExecutionHandle handle = executions.get(executionId);
-    if (handle == null) {
-      throw new IllegalArgumentException("SQL 任务执行不存在：" + executionId);
-    }
-    TaskExecution current = handle.snapshot().get();
-    if (current.terminal()) return;
-
-    handle.executor().cancel();
-    handle.snapshot().updateAndGet(existing -> existing.terminal()
-        ? existing
-        : new TaskExecution(executionId, "CANCELED", "SQL execution cancelled", existing.output()));
+  protected String snapshotTypeMismatchMessage(TaskVersionSnapshot snapshot) {
+    return "SQL 执行器不能执行任务类型：" + snapshot.type();
   }
 
-  @PreDestroy
-  void shutdown() {
-    workerExecutor.shutdownNow();
+  @Override
+  protected String missingDefinitionSnapshotMessage(TaskVersionSnapshot snapshot) {
+    return "SQL 任务缺少不可变 definitionSnapshot，拒绝回退到当前草稿或最新版本："
+        + snapshot.taskId();
   }
 
-  private void execute(String executionId, ExecutionHandle handle) {
-    try {
-      TaskExecutionResult result = handle.executor().execute();
-      TaskExecution completed = convert(executionId, result);
-      handle.snapshot().updateAndGet(current -> current.terminal() ? current : completed);
-    } catch (Exception exception) {
-      TaskExecution failed = new TaskExecution(
-          executionId,
-          "FAILED",
-          safeMessage(exception),
-          Map.of());
-      handle.snapshot().updateAndGet(current -> current.terminal() ? current : failed);
-    }
+  @Override
+  protected String executionNotFoundMessage(String executionId) {
+    return "SQL 任务执行不存在：" + executionId;
   }
 
-  private TaskExecution convert(String executionId, TaskExecutionResult result) {
-    String status = switch (result.status()) {
-      case PENDING -> "PENDING";
-      case RUNNING -> "RUNNING";
-      case SUCCESS -> "SUCCEEDED";
-      case FAILED -> "FAILED";
-      case CANCELLED -> "CANCELED";
-      case TIMEOUT -> "TIMED_OUT";
-    };
-    String errorMessage = result.status() == TaskExecutionStatus.SUCCESS ? null : result.message();
-    return new TaskExecution(executionId, status, errorMessage, result.output());
+  @Override
+  protected String pluginNotExecutableMessage() {
+    return "SQL Task Plugin 暂不支持执行";
   }
 
-  private TaskDefinition immutableDefinition(TaskVersionSnapshot snapshot) {
-    String definitionJson = snapshot.definitionSnapshotJson();
-    if (definitionJson == null || definitionJson.isBlank()) {
-      throw new IllegalArgumentException(
-          "SQL 任务缺少不可变 definitionSnapshot，拒绝回退到当前草稿或最新版本：" + snapshot.taskId());
-    }
-    try {
-      TaskDefinition definition = objectMapper.readValue(definitionJson, TaskDefinition.class);
-      if (!"SQL".equalsIgnoreCase(definition.taskType())) {
-        throw new IllegalArgumentException(
-            "SQL 任务快照类型不匹配：snapshot=SQL, definition=" + definition.taskType());
-      }
-      return definition;
-    } catch (JsonProcessingException exception) {
-      throw new IllegalArgumentException("SQL 任务不可变 definitionSnapshot 不是合法 JSON", exception);
-    }
-  }
-
-  private void requireSqlSnapshot(TaskVersionSnapshot snapshot) {
-    if (snapshot == null) {
-      throw new IllegalArgumentException("任务版本快照不能为空");
-    }
-    if (!"SQL".equalsIgnoreCase(snapshot.type())) {
-      throw new IllegalArgumentException("SQL 执行器不能执行任务类型：" + snapshot.type());
-    }
-  }
-
-  private void validate(TaskPlugin plugin, TaskDefinition definition) {
-    TaskValidationResult validation = plugin.validate(definition);
-    if (validation.valid()) return;
-    String summary = validation.issues().stream()
+  @Override
+  protected String validationFailureMessage(TaskValidationResult validation) {
+    if (validation.valid()) return null;
+    return validation.issues().stream()
         .map(TaskValidationIssue::message)
         .limit(3)
         .reduce((left, right) -> left + "；" + right)
         .orElse("SQL 任务定义校验失败");
-    throw new IllegalArgumentException(summary);
   }
 
-  private String normalizeIdempotencyKey(String idempotencyKey) {
-    if (idempotencyKey == null || idempotencyKey.isBlank()) return null;
-    return idempotencyKey.trim();
-  }
-
-  private String safeMessage(Throwable throwable) {
+  @Override
+  protected String executionFailureMessage(Throwable throwable) {
     String message = throwable == null ? null : throwable.getMessage();
     if (message == null || message.isBlank()) {
       return throwable == null ? "SQL execution failed" : throwable.getClass().getSimpleName();
     }
     return message.length() > 500 ? message.substring(0, 500) : message;
-  }
-
-  private record ExecutionHandle(
-      io.yak.ops.plugin.task.api.TaskExecutor executor,
-      AtomicReference<TaskExecution> snapshot) {
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskDefinition.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskDefinition.java
@@ -1,6 +1,11 @@
 package io.yak.ops.business.job.task;
 
-/** 工作流可引用的最小任务定义。 */
+/**
+ * Workflow-visible task descriptor.
+ *
+ * <p>The historical class name is kept for compatibility. This value describes a discoverable task;
+ * the immutable executable truth is {@link TaskVersionSnapshot}.</p>
+ */
 public record TaskDefinition(
     String id,
     String name,

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionContextFactory.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskExecutionContextFactory.java
@@ -1,60 +1,32 @@
 package io.yak.ops.business.job.task;
 
-import io.yak.ops.business.job.env.SystemEnvVarService;
+import io.yak.ops.business.job.env.TaskEnvironmentResolver;
 import io.yak.ops.plugin.task.api.DefaultTaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
-/**
- * Central factory for creating {@link TaskExecutionContext} instances.
- *
- * <p>Automatically resolves and injects merged global environment variables
- * (OS-level + application-level from the Settings page) so that every task
- * adapter receives them without depending on {@link SystemEnvVarService} directly.
- *
- * <p>Usage in task adapters:
- * <pre>{@code
- *   TaskExecutionContext context = contextFactory.create(trigger, input);
- *
- *   // With a capability (e.g. DataSourceExecutionProvider for SQL):
- *   TaskExecutionContext context = contextFactory.create(trigger, input,
- *       builder -> builder.capability(DataSourceExecutionProvider.class, provider));
- * }</pre>
- */
+/** Builds task runtime context from trigger, parameters, environment and type-specific capabilities. */
 @Service
 public class TaskExecutionContextFactory {
 
-  private final SystemEnvVarService envVarService;
+  private final TaskEnvironmentResolver environmentResolver;
 
-  public TaskExecutionContextFactory(SystemEnvVarService envVarService) {
-    this.envVarService = envVarService;
+  public TaskExecutionContextFactory(TaskEnvironmentResolver environmentResolver) {
+    this.environmentResolver = environmentResolver;
   }
 
-  /**
-   * Create a context with trigger, parameters, and automatically resolved global env vars.
-   */
   public TaskExecutionContext create(
       TaskExecutionTrigger trigger,
       Map<String, Object> input) {
     return DefaultTaskExecutionContext.builder()
         .trigger(trigger)
         .parameters(input)
-        .globalEnvVars(envVarService.resolveMergedEnv())
+        .globalEnvVars(environmentResolver.resolveMergedEnv())
         .build();
   }
 
-  /**
-   * Create a context with a customiser callback for registering capabilities
-   * or overriding defaults.
-   *
-   * <p>Example:
-   * <pre>{@code
-   *   contextFactory.create(trigger, input, builder ->
-   *       builder.capability(DataSourceExecutionProvider.class, provider));
-   * }</pre>
-   */
   public TaskExecutionContext create(
       TaskExecutionTrigger trigger,
       Map<String, Object> input,
@@ -62,10 +34,8 @@ public class TaskExecutionContextFactory {
     DefaultTaskExecutionContext.Builder builder = DefaultTaskExecutionContext.builder()
         .trigger(trigger)
         .parameters(input)
-        .globalEnvVars(envVarService.resolveMergedEnv());
-    if (customiser != null) {
-      customiser.accept(builder);
-    }
+        .globalEnvVars(environmentResolver.resolveMergedEnv());
+    if (customiser != null) customiser.accept(builder);
     return builder.build();
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskProvider.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskProvider.java
@@ -2,10 +2,23 @@ package io.yak.ops.business.job.task;
 
 import java.util.List;
 
-/** Supplies workflow-visible tasks without making the Job module depend on concrete business domains. */
+/** Supplies workflow-visible tasks without making the Registry depend on concrete business domains. */
 public interface TaskProvider {
 
   List<TaskDefinition> list();
 
   TaskVersionSnapshot snapshot(String taskId);
+
+  /**
+   * Supplies descriptor + immutable snapshot as one consistent registration.
+   *
+   * <p>Existing providers remain source-compatible. Null/incomplete descriptors keep the previous
+   * registry behavior and are ignored; a real descriptor/snapshot mismatch fails explicitly.</p>
+   */
+  default List<TaskRegistration> registrations() {
+    return list().stream()
+        .filter(task -> task != null && task.id() != null && !task.id().isBlank())
+        .map(task -> new TaskRegistration(task, snapshot(task.id())))
+        .toList();
+  }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskRegistration.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/TaskRegistration.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.job.task;
+
+/** One discoverable task paired with the immutable snapshot that will be executed. */
+public record TaskRegistration(
+    TaskDefinition definition,
+    TaskVersionSnapshot snapshot) {
+
+  public TaskRegistration {
+    if (definition == null) throw new IllegalArgumentException("task definition 不能为空");
+    if (snapshot == null) throw new IllegalArgumentException("task snapshot 不能为空");
+    if (definition.id() == null || definition.id().isBlank()) {
+      throw new IllegalArgumentException("task definition id 不能为空");
+    }
+    if (definition.type() == null || definition.type().isBlank()) {
+      throw new IllegalArgumentException("task definition type 不能为空");
+    }
+    if (!definition.id().equals(snapshot.taskId())) {
+      throw new IllegalArgumentException("任务定义与版本快照 ID 不匹配：" + definition.id());
+    }
+    if (!definition.type().equalsIgnoreCase(snapshot.type())) {
+      throw new IllegalArgumentException("任务定义与版本快照类型不匹配：" + definition.id());
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/InMemoryTaskRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/InMemoryTaskRegistryTest.java
@@ -1,36 +1,52 @@
 package io.yak.ops.business.job.task;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 
 class InMemoryTaskRegistryTest {
 
   @Test
-  void shouldOnlyExposeOnlineTasksWithoutEnabledSchedule() {
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", false))).isTrue();
+  void aggregatesOnlyTaskProviderRegistrations() {
+    TaskProvider provider = mock(TaskProvider.class);
+    when(provider.registrations()).thenReturn(List.of(registration("task-1", "SQL", 3L)));
+    InMemoryTaskRegistry registry = new InMemoryTaskRegistry(providers(provider));
 
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("OFFLINE", false))).isFalse();
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(task("ONLINE", true))).isFalse();
+    assertThat(registry.list()).containsExactly(new TaskDefinition("task-1", "Task task-1", "SQL"));
+    assertThat(registry.snapshot("task-1").version()).isEqualTo(3L);
   }
 
   @Test
-  void shouldRejectIncompleteTaskMetadata() {
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(null)).isFalse();
-    OfflineJobDefinition incomplete = new OfflineJobDefinition();
-    incomplete.setJobName("未完成任务");
-    incomplete.setReleaseState("ONLINE");
-    incomplete.setScheduleEnabled(false);
-    assertThat(InMemoryTaskRegistry.isWorkflowEligible(incomplete)).isFalse();
+  void rejectsDuplicateTaskIdsAcrossProviders() {
+    TaskProvider first = mock(TaskProvider.class);
+    TaskProvider second = mock(TaskProvider.class);
+    when(first.registrations()).thenReturn(List.of(registration("same", "SQL", 1L)));
+    when(second.registrations()).thenReturn(List.of(registration("same", "SYNC", 2L)));
+    InMemoryTaskRegistry registry = new InMemoryTaskRegistry(providers(first, second));
+
+    assertThatThrownBy(registry::list)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("重复的工作流任务 ID");
   }
 
-  private OfflineJobDefinition task(String releaseState, boolean scheduleEnabled) {
-    OfflineJobDefinition definition = new OfflineJobDefinition();
-    definition.setId(1001L);
-    definition.setJobName("用户数据同步");
-    definition.setReleaseState(releaseState);
-    definition.setScheduleEnabled(scheduleEnabled);
-    return definition;
+  private TaskRegistration registration(String id, String type, long version) {
+    TaskDefinition definition = new TaskDefinition(id, "Task " + id, type);
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        id, definition.name(), type, version, "digest", "{}", "{}");
+    return new TaskRegistration(definition, snapshot);
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("unchecked")
+  private final ObjectProvider<TaskProvider> providers(TaskProvider... values) {
+    ObjectProvider<TaskProvider> provider = mock(ObjectProvider.class);
+    when(provider.orderedStream()).thenAnswer(ignored -> Stream.of(values));
+    return provider;
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/OfflineSyncTaskProviderTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/OfflineSyncTaskProviderTest.java
@@ -1,0 +1,35 @@
+package io.yak.ops.business.job.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncTaskProviderTest {
+
+  @Test
+  void exposesOnlyOnlineTasksWithoutEnabledBusinessSchedule() {
+    assertThat(OfflineSyncTaskProvider.isWorkflowEligible(task("ONLINE", false))).isTrue();
+    assertThat(OfflineSyncTaskProvider.isWorkflowEligible(task("OFFLINE", false))).isFalse();
+    assertThat(OfflineSyncTaskProvider.isWorkflowEligible(task("ONLINE", true))).isFalse();
+  }
+
+  @Test
+  void rejectsIncompleteTaskMetadata() {
+    assertThat(OfflineSyncTaskProvider.isWorkflowEligible(null)).isFalse();
+    OfflineJobDefinition incomplete = new OfflineJobDefinition();
+    incomplete.setJobName("未完成任务");
+    incomplete.setReleaseState("ONLINE");
+    incomplete.setScheduleEnabled(false);
+    assertThat(OfflineSyncTaskProvider.isWorkflowEligible(incomplete)).isFalse();
+  }
+
+  private OfflineJobDefinition task(String releaseState, boolean scheduleEnabled) {
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(1001L);
+    definition.setJobName("用户数据同步");
+    definition.setReleaseState(releaseState);
+    definition.setScheduleEnabled(scheduleEnabled);
+    return definition;
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/TaskRuntimeDomainTruthTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/task/TaskRuntimeDomainTruthTest.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.job.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class TaskRuntimeDomainTruthTest {
+
+  @Test
+  void registrationRequiresDescriptorAndSnapshotToRepresentSameTask() {
+    TaskDefinition definition = new TaskDefinition("task-1", "SQL", "SQL");
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        "task-1", "SQL", "SQL", 7L, "digest", "{}", "{}");
+
+    TaskRegistration registration = new TaskRegistration(definition, snapshot);
+
+    assertEquals("task-1", registration.definition().id());
+    assertEquals(7L, registration.snapshot().version());
+  }
+
+  @Test
+  void registrationRejectsSnapshotDrift() {
+    TaskDefinition definition = new TaskDefinition("task-1", "SQL", "SQL");
+    TaskVersionSnapshot wrongTask = new TaskVersionSnapshot(
+        "task-2", "SQL", "SQL", 7L, "digest", "{}", "{}");
+    TaskVersionSnapshot wrongType = new TaskVersionSnapshot(
+        "task-1", "SYNC", "SYNC", 7L, "digest", "{}", "{}");
+
+    assertThrows(IllegalArgumentException.class, () -> new TaskRegistration(definition, wrongTask));
+    assertThrows(IllegalArgumentException.class, () -> new TaskRegistration(definition, wrongType));
+  }
+}


### PR DESCRIPTION
## Summary

Stage 1 refactor for `yak-ops-business-job`.

This PR establishes the module as a generic **Task Discovery + Immutable Snapshot + Execution Routing + Runtime Context** layer rather than a business scheduling module.

Core truth:

```text
TaskDefinition(discovery descriptor)
    != TaskVersionSnapshot
    != TaskExecution
```

The public compatibility name `TaskDefinition` is kept for now; Stage 1 only clarifies its semantic role.

## 1. Registry no longer knows Offline Sync business services

`InMemoryTaskRegistry` previously mixed generic provider aggregation with direct Offline Sync paging/filtering/snapshot construction.

It now depends only on:

```text
TaskProvider
    -> TaskRegistration
       ├── TaskDefinition
       └── TaskVersionSnapshot
```

`TaskRegistration` validates that descriptor and snapshot represent the same task ID/type.

Existing providers remain source-compatible through a default `registrations()` implementation, including the old tolerance for null/incomplete descriptors.

Offline Sync discovery moves behind `OfflineSyncTaskProvider`, which owns:

- ONLINE + schedule-disabled eligibility;
- Offline definition paging;
- current definition resolution;
- logical JobSpec resolution;
- SYNC immutable snapshot construction.

This keeps the existing Job -> Offline module dependency for Stage 1, but removes the concrete Offline business knowledge from the Registry. Physical dependency inversion is intentionally deferred to Stage 2.

## 2. SQL reuses the shared Plugin Task runtime

`SqlTaskExecutorAdapter` previously duplicated most of `AbstractTaskExecutorAdapter`:

- idempotency index;
- execution handle map;
- virtual-thread lifecycle;
- Task Plugin lookup/validation;
- immutable definition decoding;
- status/cancel;
- result conversion.

SQL now extends the shared runtime and only contributes SQL-specific capabilities:

```text
DataSourceExecutionProvider
SqlExecutionRuntime
```

SQL compatibility hooks preserve the previous SQL-specific error messages, validation summary, execution-failure message and missing-snapshot behavior.

Python / Java / Shell keep their existing shared runtime semantics; this PR does not change their behavior.

## 3. Runtime environment gets a narrow read boundary

Adds:

```text
TaskEnvironmentResolver
```

`TaskExecutionContextFactory` now depends on that runtime-facing contract instead of on the full `SystemEnvVarService` CRUD implementation.

`SystemEnvVarService` remains the stable settings-page application service and implements the resolver contract. REST/database behavior is unchanged.

## 4. Stage 1 domain / architecture contracts

Adds:

```text
REQUIREMENTS.md
DOMAIN.md
ARCHITECTURE.md
```

and aligns `README.md` / `package-info.java` with the real module responsibility.

The contracts explicitly state:

```text
Task Registry != Task Source Truth
Task Execution Gateway != Execution Engine
Task Runtime != Scheduler
Job module != Offline Sync owner
Environment != Execution Truth
```

The module still does not own Cron / Schedule lifecycle.

## Tests

Adds/updates focused coverage for:

- Provider-only registry aggregation;
- duplicate Task ID rejection across providers;
- Offline Sync workflow eligibility;
- descriptor/snapshot consistency via `TaskRegistration`;
- existing SQL executor tests continue to exercise immutable snapshot, manual trigger and idempotency behavior.

## Behavior intentionally unchanged

This PR does not intentionally change:

- `/api/v1/tasks` or `/api/v1/system/env-vars` contracts;
- database schema / persistence configuration;
- Workflow caller contracts;
- `TaskRegistry`, `TaskProvider`, `TaskExecutor`, `TaskExecutionGateway` public entry shapes;
- Offline Sync execution ownership or `OfflineJobExecutionService` behavior;
- SQL / Python / Java / Shell Task Plugin behavior;
- manual/workflow trigger semantics;
- Task execution idempotency / status / cancel semantics;
- business scheduling ownership.

## Validation

Branch is based on current `main` (`15ce68d7`) and squashed to one targeted commit. Current compare is isolated to `yak-ops-business-job`, ahead 1 / behind 0.

A full Maven run is **not claimed from the current connector environment**. Recommended verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-job -am test
```

## Stage 2 follow-up

Stage 2 can then make the Stage 1 semantic boundaries physical and enforceable:

- `discovery / execution / runtime / adapter / environment` package split;
- move Offline Sync Provider/Executor adapter back behind the business-module boundary if the Maven graph allows it;
- `@Service` allowlist and role stereotypes;
- `DEPENDENCIES.md / REVIEW.md`;
- package dependency matrix / no-cycle guards / code-style guards.