### PR TITLE
refactor(job): establish stage 2 role architecture

### DIFF
--- a/yak-ops-business/yak-ops-business-job/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-job/ARCHITECTURE.md
@@ -1,93 +1,110 @@
 # Job Architecture
 
-Job 采用“发现、快照、执行、运行上下文”四个明确角色，不以调度为中心。
+本文件定义 `yak-ops-business-job` 的长期代码边界。
 
-## Stage 1 结构
+## Package Map
 
 ```text
-controller
-    -> task registry / env service
-
-task
-├── discovery
-│   TaskProvider / TaskRegistration / TaskRegistry
-│
-├── execution
-│   TaskExecutionGateway / TaskExecutor
-│
-├── runtime
-│   AbstractTaskExecutorAdapter
-│   SQL / Python / Java / Shell adapters
-│
-└── sync adapter
-    SyncTaskExecutorAdapter / OfflineSyncTaskRunner
-
-env
-├── SystemEnvVarService
-└── TaskEnvironmentResolver
+io.yak.ops.business.job
+├── controller       # HTTP inbound
+├── task             # stable cross-module contracts + TaskExecutionGateway
+├── discovery        # TaskProvider aggregation
+├── runtime          # shared Plugin execution lifecycle/context
+├── adapter
+│   └── plugin       # SQL / Python / Java / Shell capability adapters
+├── environment      # env CRUD facade + runtime resolver
+├── dao              # persistence primitives
+└── config           # module configuration
 ```
 
-现阶段仍保留 `task` 单包以控制改动；Stage 2 再做物理 package 收敛。
+禁止重新创建 `service / common / helper / utils` 作为业务大桶。
+
+## Stable Contract Package
+
+`task` 是跨模块稳定入口，只允许承载：
+
+```text
+TaskDefinition
+TaskVersionSnapshot
+TaskRegistration
+TaskExecution
+TaskProvider
+TaskRegistry
+TaskExecutor
+TaskExecutionGateway
+```
+
+以及暂时保留的 deprecated SYNC compatibility corridor。
+
+`task` 不允许 import Offline Sync、Workflow、Data Development 等具体业务实现。
 
 ## Discovery
 
-`InMemoryTaskRegistry` 只能依赖 `TaskProvider`：
-
 ```text
-Business source
-    -> TaskProvider
-    -> TaskRegistration
-    -> TaskRegistry
+Business TaskProvider(s)
+        ↓
+InMemoryTaskRegistry
+        ↓
+TaskRegistry
 ```
 
-Offline Sync 在 Stage 1 先通过 `OfflineSyncTaskProvider` 隔离直接依赖；是否把 Provider/Executor Adapter 物理移回 Offline Sync 模块，留到 Stage 2 做 Maven 依赖反转。
+`discovery` 只做聚合、去重和快照索引，不知道任务来自哪个业务域。
 
 ## Execution
 
 ```text
-caller
+Caller
   -> TaskExecutionGateway
-  -> TaskExecutor by type
+  -> TaskExecutor
 ```
 
-Gateway 只负责路由和输入防御。
+`TaskExecutionGateway` 是稳定 Application Service。它按 Type 路由，不管理 Task Plugin 生命周期。
 
-Plugin Task 的公共生命周期由 `AbstractTaskExecutorAdapter` 负责：
+Plugin 类型走：
 
 ```text
-snapshot validation
- -> Task Plugin lookup
- -> plugin validation
- -> TaskExecutionContext
- -> idempotency
- -> async execution
- -> status / cancel / result conversion
+adapter.plugin
+     ↓
+runtime.AbstractTaskExecutorAdapter
+     ↓
+TaskPlugin
 ```
 
-SQL 不再复制这套生命周期，只负责贡献 `DataSourceExecutionProvider` / `SqlExecutionRuntime` Capability。
-
-SYNC 是外部业务 Runtime Adapter，不强行继承 Plugin Runtime。
+`runtime` 拥有幂等、ExecutionHandle、虚拟线程、状态/取消和结果转换；Adapter 只贡献 Capability。
 
 ## Environment
 
+`SystemEnvVarService` 是设置页面稳定 Facade；`TaskEnvironmentResolver` 是 Runtime 读取边界。`TaskExecutionContextFactory` 只能依赖 Resolver。
+
+## Business Runtime Extension
+
+Job Core 不依赖 Offline Sync。Offline Sync 自己实现 `TaskProvider / TaskExecutor` 并由应用组合层自动发现。
+
+允许方向：
+
 ```text
-TaskExecutionContextFactory
-    -> TaskEnvironmentResolver
+Offline Sync -> job.task contract
 ```
 
-Factory 不依赖环境变量 CRUD/DAO 细节。`SystemEnvVarService` 是当前 Resolver 实现和设置页稳定入口。
-
-## 角色词汇
+禁止方向：
 
 ```text
-Provider   暴露业务能力
-Registry   聚合与查找
-Gateway    稳定外部入口/路由
-Executor   执行一种 Task Type
-Adapter    翻译外部 Runtime / Plugin
-Resolver   解析运行上下文
-Factory    构造上下文对象
-Service    稳定应用入口
+job.* -> business.sync.offline implementation
 ```
 
-Stage 1 不为了去 Service 改名；Stage 2 再补依赖矩阵、角色约束和完整架构测试。
+## Spring Roles
+
+生产代码中的 `@Service` 只允许：
+
+```text
+task/TaskExecutionGateway.java
+environment/SystemEnvVarService.java
+```
+
+Registry、Factory、Adapter 等专业角色使用 `@Component` 或 plain object。
+
+## Persistence
+
+Controller 不直接访问 DAO。Runtime / Adapter / Discovery 不访问 Job DAO。只有 `environment` 当前通过 DAO 持久化应用环境变量。
+
+结构规则由 architecture tests 持续执行。

--- a/yak-ops-business/yak-ops-business-job/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-job/DEPENDENCIES.md
@@ -1,0 +1,60 @@
+# Job Dependencies
+
+本文件定义 Job 内部与跨模块的允许依赖方向。
+
+## Internal Graph
+
+```text
+controller  -> task / environment
+discovery   -> task
+adapter     -> runtime / task
+runtime     -> task / environment
+environment -> dao
+task        -> no Job implementation package
+dao         -> persistence primitives only
+```
+
+依赖图必须保持无环。
+
+## External Corridors
+
+Job 可以依赖通用基础能力：
+
+```text
+core / spi / plugin-task-api / datasource capability
+```
+
+Job Core 不允许直接依赖具体业务域：
+
+```text
+business.sync.offline
+business.workflow
+business.development
+```
+
+业务域接入 Job 的正确方向是：
+
+```text
+Business Module
+      -> job.task.TaskProvider
+      -> job.task.TaskExecutor
+```
+
+当前 Offline Sync 就按这个方向提供 SYNC discovery / execution。
+
+## Persistence
+
+- Controller 不访问 DAO；
+- Discovery / Runtime / Adapter 不访问 DAO；
+- `environment` 可以通过 `SystemEnvVarDao` 持久化应用环境变量；
+- Task contract 不依赖 MyBatis、PO、Repository 实现。
+
+## Scheduler Boundary
+
+Job 不依赖 Yak Schedule 业务生命周期，不允许出现 Job 自己的 Cron Registrar、Schedule Handler 或计划状态 owner。
+
+## Compatibility
+
+Deprecated `SyncTaskRunner / SyncTaskExecution / SyncTaskExecutorAdapter` 仅允许留在 `task`，不得注册 Spring Bean，也不得被新的生产代码引用。
+
+依赖规则以 `JobDependencyBoundaryTest` 为可执行准绳。

--- a/yak-ops-business/yak-ops-business-job/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-job/DOMAIN.md
@@ -1,56 +1,78 @@
 # Job Domain
 
-核心关系：
+> `REQUIREMENTS.md` 定义能力；本文件定义不能被实现细节破坏的事实。
+
+## 核心模型
+
+```text
+TaskDefinition (discovery descriptor)
+        │ freeze
+        ▼
+TaskVersionSnapshot (immutable execution input)
+        │ run
+        ▼
+TaskExecution (one runtime attempt view)
+```
+
+硬规则：
 
 ```text
 TaskDefinition != TaskVersionSnapshot != TaskExecution
 ```
 
-当前类名 `TaskDefinition` 为兼容名称；在 Job 领域里它只表示“可发现的任务描述”，不是可执行定义本体。
-
 ## Truth Ownership
 
 ```text
-TaskDefinition        = Job 可发现的任务描述
-TaskVersionSnapshot   = 一次运行固定的不可变输入
-TaskExecution         = Job 对一次执行的统一观察视图
-TaskProvider          = 业务域到 Job 的发现边界
-TaskExecutor          = 一种 Task Type 的执行能力
-Business Module       = 业务任务定义与业务执行真相 Owner
-Scheduler             = 业务时间触发 Owner
+Business Domain        = Task Definition / Release / business execution truth
+Job TaskRegistry       = discoverable-task projection
+TaskVersionSnapshot    = one execution's frozen input
+TaskExecutionGateway   = type router
+TaskExecutor           = task-type execution capability
+TaskExecution          = common runtime view
+Scheduler              = business-owned timing lifecycle
 ```
 
-## 硬规则
+## Hard Rules
 
-1. Job 不拥有业务 Task Definition，只持有描述和执行快照。
-2. 有版本能力的 Task 必须执行固定 Snapshot，不能运行时漂移到最新版本。
-3. `TaskRegistration` 中 descriptor 与 snapshot 必须引用同一 Task ID 和 Task Type。
-4. `TaskRegistry` 只聚合 `TaskProvider`，不直接知道 Offline Sync、Data Development 等业务实现。
-5. `TaskExecutionGateway` 只做路由，不实现 SQL/SYNC 等业务逻辑。
-6. Plugin Task 共用一套本地执行生命周期；Task Type 只贡献 Capability。
-7. SYNC 执行事实属于 Offline Sync，Job 只转换为统一 `TaskExecution` 视图。
-8. `TaskExecution` 是统一观察模型，不是所有业务执行记录的持久化 Owner。
-9. Environment 是 Runtime Context，不是 Task 或 Execution 真相。
-10. Job 不注册业务 Schedule，不维护 Cron 生命周期。
+1. Registry 不是 Task Source Truth，只聚合 `TaskProvider`。
+2. `TaskRegistration` 的 descriptor / snapshot 必须属于同一 Task ID 和 Type。
+3. 有版本任务必须执行固定 Snapshot，禁止运行时回读当前配置。
+4. `version=0` 表示未发布/无版本能力的兼容运行，不等于 Published Revision。
+5. Gateway 只做路由；具体引擎和业务生命周期属于 `TaskExecutor` owner。
+6. 同一种 Task Type 在一个应用中只能有一个 Executor。
+7. Plugin Task 的幂等、状态、取消、异步生命周期只实现一套。
+8. SQL / Python / Java / Shell Adapter 只贡献 Capability，不复制 Runtime。
+9. SYNC 的定义和执行事实归 Offline Sync；Offline 通过 Job contract 反向注册能力。
+10. Runtime Context 只依赖 `TaskEnvironmentResolver`，不依赖设置页面 CRUD。
+11. Job 不注册 Cron，不维护业务 Schedule 状态。
+12. 结构重构不得顺手改变 API、快照、状态或取消语义。
 
-## Snapshot Contract
+## Plugin Runtime
 
 ```text
-Workflow publish / manual prepare
-    -> TaskVersionSnapshot
-    -> execution
+TaskVersionSnapshot
+  -> definition decode
+  -> TaskPlugin validation
+  -> TaskExecutionContext
+  -> capability contribution
+  -> plugin executor
+  -> TaskExecution
 ```
 
-`version > 0` 的业务版本必须携带对应的不可变 definition/config snapshot。`version = 0` 可以表示当前编辑器等临时运行，但调用方必须显式构造这份快照。
+`AbstractTaskExecutorAdapter` 拥有公共生命周期；Task Type Adapter 不重新实现 execution map、idempotency index、线程生命周期和状态转换。
 
-## Discovery Contract
-
-业务 Provider 交付：
+## External Business Runtime
 
 ```text
-TaskRegistration
-├── TaskDefinition
-└── TaskVersionSnapshot
+Job contract
+   ↑ implements
+Offline Sync
+   ├── OfflineSyncTaskProvider
+   └── OfflineSyncTaskExecutor
 ```
 
-Job 只负责聚合、冲突检查和查找，不重新解释业务发布状态。
+依赖方向表达的是“业务域向通用 Runtime 注册能力”，不是 Job 获得 Offline 领域所有权。
+
+## Compatibility Corridor
+
+`SyncTaskRunner / SyncTaskExecution / SyncTaskExecutorAdapter` 仅保留给旧 Workflow 测试/构造器，必须无 Spring Bean 注册，并标记为待删除兼容类型。生产 SYNC 运行不得经过该 corridor。

--- a/yak-ops-business/yak-ops-business-job/README.md
+++ b/yak-ops-business/yak-ops-business-job/README.md
@@ -1,32 +1,50 @@
 # yak-ops-business-job
 
-`yak-ops-business-job` 是 Yak Ops 的通用 **Task Discovery + Snapshot + Execution Routing** 模块，主要服务 Workflow、Data Development 等上层运行入口。
+`yak-ops-business-job` 是 Yak Ops 的通用任务运行中枢：负责 **Task Discovery、不可变 Snapshot、Execution Routing 和 Runtime Context**。
 
 它不拥有业务任务定义，也不负责 Cron / Schedule 生命周期。
 
-核心关系：
-
 ```text
-TaskDefinition (discovery descriptor)
-        -> TaskVersionSnapshot
-        -> TaskExecution
+Business TaskProvider
+        ↓
+TaskRegistry
+        ↓
+TaskVersionSnapshot
+        ↓
+TaskExecutionGateway
+        ↓
+TaskExecutor
 ```
 
-其中：
+核心约束：
 
-- `TaskProvider`：业务域向 Job 暴露可执行任务；
-- `TaskRegistry`：聚合 Provider 并校验任务 ID 冲突；
-- `TaskExecutionGateway`：按 Task Type 路由到 `TaskExecutor`；
-- Plugin Task Executor：SQL / Python / Java / Shell 复用统一执行生命周期；
-- SYNC：通过 Offline Sync 业务运行时执行，Job 不拥有其执行事实；
-- `TaskEnvironmentResolver`：向运行上下文提供全局环境变量。
+- `TaskDefinition != TaskVersionSnapshot != TaskExecution`；
+- 业务域通过 `TaskProvider / TaskExecutor` 接入，Job Core 不直接依赖具体业务模块；
+- SQL / Python / Java / Shell 复用统一 Plugin Runtime，只贡献各自 Capability；
+- Offline Sync 自己提供 `SYNC` Provider / Executor，执行事实仍归 Offline Sync；
+- `TaskExecutionGateway` 只路由，不实现具体引擎；
+- Runtime 只通过 `TaskEnvironmentResolver` 读取环境能力；
+- 调度生命周期归各业务域，不归 Job。
 
-业务时间调度继续由各业务域自己管理，不在 Job 模块注册计划或维护调度状态。
+代码结构：
 
-架构约束：
+```text
+task         稳定跨模块契约 + Execution Gateway
+discovery    Provider 聚合
+runtime      Plugin 执行生命周期 / Context
+adapter      Task Type 能力适配
+environment  环境变量管理与 Runtime Resolver
+controller   HTTP 入口
+dao          持久化
+config       配置
+```
+
+架构文档：
 
 - [REQUIREMENTS.md](REQUIREMENTS.md)
 - [DOMAIN.md](DOMAIN.md)
 - [ARCHITECTURE.md](ARCHITECTURE.md)
+- [DEPENDENCIES.md](DEPENDENCIES.md)
+- [REVIEW.md](REVIEW.md)
 
-仓库级代码规范统一看 `../../CODE_STYLE.md`。
+仓库级写法统一遵循 `../../CODE_STYLE.md`。

--- a/yak-ops-business/yak-ops-business-job/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-job/REQUIREMENTS.md
@@ -1,60 +1,74 @@
 # Job Requirements
 
-本文件只回答：Job 模块需要提供什么能力。
+本文件只回答“Job 模块需要提供什么能力”。领域硬规则看 `DOMAIN.md`，代码边界看 `ARCHITECTURE.md`。
 
 ## 模块定位
 
-Job 是业务无关的任务发现与执行路由层。业务域负责定义任务和拥有业务执行事实；Job 负责把这些能力统一暴露给 Workflow、Data Development 等调用方。
+Job 是业务无关的 Task Runtime Hub。业务域拥有任务定义和业务执行事实，Job 提供统一发现、快照和执行路由。
 
-## 核心能力
+## 必须提供
 
 ### Task Discovery
 
-业务域通过 `TaskProvider` 暴露任务。Job 不应在 Registry 中直接扫描某个业务 Service。
+业务域通过 `TaskProvider` 提供可执行任务。Registry 聚合 Provider，拒绝重复 Task ID，但不读取具体业务表或业务 Service。
 
-每个被发现任务至少包含：
-
-```text
-TaskDefinition         = 可选择的任务描述
-TaskVersionSnapshot    = 被固定的执行输入
-```
-
-Registry 必须拒绝重复 Task ID，并保证描述与快照属于同一个 Task。
-
-### Task Execution
-
-调用方统一通过：
+`TaskRegistration` 必须同时交付：
 
 ```text
-TaskExecutionGateway
-    -> TaskExecutor
-    -> TaskExecution
+TaskDefinition        # 发现描述
+TaskVersionSnapshot   # 可执行快照
 ```
 
-Job 根据 Task Type 路由，不复制各业务域的执行状态机。
-
-SQL / Python / Java / Shell 这类 Task Plugin 应共享同一套本地执行生命周期：校验、幂等、运行句柄、状态、取消和结果转换只实现一次。
-
-SYNC 属于外部业务运行时：Job 只做适配，不拥有 Offline Sync 的 Execution 真相。
+二者的 Task ID / Type 必须一致。
 
 ### Immutable Snapshot
 
-有版本能力的任务执行时必须使用已经固定的 `TaskVersionSnapshot`。运行期间不能回读当前草稿或最新版本替换它。
+有版本能力的任务运行时必须使用调用方固定的 `TaskVersionSnapshot`。不得在执行时回读当前 Draft / Latest Version。
 
-### Runtime Context
+没有版本能力的兼容任务可使用 `version=0`，但这不能伪装成 Published Revision。
 
-Task Runtime Context 可以包含参数、Trigger、全局环境变量及任务类型能力。环境变量通过窄接口提供，执行层不依赖设置页面的 CRUD 实现。
+### Execution Routing
+
+`TaskExecutionGateway` 按 Task Type 路由到唯一 `TaskExecutor`，统一暴露：
+
+```text
+start / status / cancel
+```
+
+Gateway 不拥有具体执行引擎。
+
+### Plugin Runtime
+
+SQL / Python / Java / Shell 等 TaskPlugin 类型共享一套本地执行生命周期：
+
+```text
+snapshot validation
+-> plugin validation
+-> context/capability assembly
+-> idempotency
+-> async execution
+-> status/cancel/result conversion
+```
+
+具体 Adapter 只贡献自己的 Capability。
+
+### Business-owned Runtime
+
+SYNC 等拥有独立业务运行时的类型，由对应业务模块实现 Job 的 `TaskProvider / TaskExecutor` 契约。Job 不反向依赖业务实现。
+
+### Runtime Environment
+
+任务运行上下文只依赖 `TaskEnvironmentResolver` 获取全局环境变量。环境变量 CRUD 不是 Runtime 的依赖面。
 
 ## 非职责
 
 Job 不负责：
 
-- Cron / Schedule 注册与生命周期；
-- Offline Sync / Data Development 等业务任务定义；
-- Workflow 编排；
-- 业务 Execution 持久化；
-- 把所有 Task Type 的业务逻辑集中到一个超级 Service。
+- Cron / Schedule 注册和生命周期；
+- Offline Sync / Data Development / Workflow 的业务定义；
+- 业务执行记录的最终事实；
+- Task Plugin 内部业务规则。
 
 ## 兼容要求
 
-Stage 1 保持现有 REST、Task SPI、Workflow 调用方式、Offline Sync 执行行为和环境变量 API 不变；不新增数据库迁移。
+重构不得偷偷改变现有 `/api/v1/tasks`、`/api/v1/system/env-vars`、Task Gateway、Snapshot、幂等、状态和取消语义。

--- a/yak-ops-business/yak-ops-business-job/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-job/REVIEW.md
@@ -1,0 +1,65 @@
+# Job Review
+
+Review Job 改动时重点看边界，不以“有没有 Service”作为目标。
+
+## Domain
+
+确认：
+
+- `TaskDefinition / TaskVersionSnapshot / TaskExecution` 没有重新混成一个对象；
+- 有版本任务仍执行固定 Snapshot；
+- Registry 没有成为业务 Task Source Truth；
+- Job 没有获得具体业务执行事实或调度所有权。
+
+## Roles
+
+确认：
+
+- `TaskExecutionGateway` 只路由；
+- Registry 只聚合 Provider；
+- Plugin Adapter 只贡献 Capability；
+- 公共执行生命周期只在 `runtime` 实现一套；
+- Runtime 通过 `TaskEnvironmentResolver` 获取环境。
+
+出现新的 `*Service` 前先判断它是否真的是稳定 Application Facade。Parser / Adapter / Registry / Factory / Resolver 不应为了注入方便标成 Service。
+
+## Dependencies
+
+重点拒绝：
+
+```text
+job -> concrete business module
+controller -> dao
+runtime -> dao
+adapter -> dao
+new service/common/helper/utils bucket
+```
+
+业务域扩展 Job 应实现 `job.task` contract，而不是让 Job import 业务 Service。
+
+## Compatibility
+
+若涉及现有调用链，检查：
+
+- REST contract；
+- Task Type normalization；
+- Snapshot semantics；
+- idempotency key；
+- status / cancel / result mapping；
+- Plugin validation error semantics。
+
+Deprecated SYNC corridor 只能缩小，不能新增消费者。
+
+## Review Output
+
+推荐在 PR 中简短说明：
+
+```text
+Domain Impact:
+Architecture Impact:
+Behavior Compatibility:
+Tests:
+Known Debt:
+```
+
+`REQUIREMENTS.md / DOMAIN.md / ARCHITECTURE.md / DEPENDENCIES.md` 与 architecture tests 是判定基准。

--- a/yak-ops-business/yak-ops-business-job/pom.xml
+++ b/yak-ops-business/yak-ops-business-job/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-business-sync-offline</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/JavaTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/JavaTaskExecutorAdapter.java
@@ -1,15 +1,17 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.adapter.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.runtime.AbstractTaskExecutorAdapter;
+import io.yak.ops.business.job.runtime.TaskExecutionContextFactory;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.plugin.task.api.DefaultTaskExecutionContext;
 import io.yak.ops.spi.resource.ResourceResolver;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 /** Executes Java JAR revisions through the shared Task Runtime and TaskPlugin contract. */
-@Service
+@Component
 public class JavaTaskExecutorAdapter extends AbstractTaskExecutorAdapter {
 
   private static final String TYPE = "JAVA";

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/PythonTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/PythonTaskExecutorAdapter.java
@@ -1,14 +1,16 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.adapter.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.runtime.AbstractTaskExecutorAdapter;
+import io.yak.ops.business.job.runtime.TaskExecutionContextFactory;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.spi.resource.ResourceResolver;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 /** Executes Python revisions through the shared Task Runtime and TaskPlugin contract. */
-@Service
+@Component
 public class PythonTaskExecutorAdapter extends AbstractTaskExecutorAdapter {
 
   private static final String TYPE = "PYTHON";

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/ShellTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/ShellTaskExecutorAdapter.java
@@ -1,14 +1,16 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.adapter.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.runtime.AbstractTaskExecutorAdapter;
+import io.yak.ops.business.job.runtime.TaskExecutionContextFactory;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.spi.resource.ResourceResolver;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 /** Executes Shell revisions through the shared Task Runtime and TaskPlugin contract. */
-@Service
+@Component
 public class ShellTaskExecutorAdapter extends AbstractTaskExecutorAdapter {
 
   private static final String TYPE = "SHELL";

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapter.java
@@ -1,6 +1,9 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.adapter.plugin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.runtime.AbstractTaskExecutorAdapter;
+import io.yak.ops.business.job.runtime.TaskExecutionContextFactory;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.core.execution.sql.SqlExecutionRuntime;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.plugin.task.api.DefaultTaskExecutionContext;
@@ -9,10 +12,10 @@ import io.yak.ops.plugin.task.api.TaskValidationResult;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-/** SQL TaskPlugin adapter; SQL contributes capabilities while shared runtime owns execution lifecycle. */
-@Service
+/** SQL TaskPlugin adapter; SQL contributes capabilities while shared runtime owns lifecycle. */
+@Component
 public class SqlTaskExecutorAdapter extends AbstractTaskExecutorAdapter {
 
   private final ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider;
@@ -30,8 +33,8 @@ public class SqlTaskExecutorAdapter extends AbstractTaskExecutorAdapter {
     this.sqlExecutionRuntime = sqlExecutionRuntime;
   }
 
-  /** Backward-compatible constructor for existing adapter-level tests and embedders. */
-  SqlTaskExecutorAdapter(
+  /** Backward-compatible constructor for focused adapter tests and embedders. */
+  public SqlTaskExecutorAdapter(
       TaskPluginRegistry pluginRegistry,
       ObjectProvider<DataSourceExecutionProvider> dataSourceExecutionProvider,
       ObjectMapper objectMapper,

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/controller/v1/SystemEnvVarController.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/controller/v1/SystemEnvVarController.java
@@ -3,7 +3,7 @@ package io.yak.ops.business.job.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
-import io.yak.ops.business.job.env.SystemEnvVarService;
+import io.yak.ops.business.job.environment.SystemEnvVarService;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,7 +34,6 @@ public class SystemEnvVarController {
     Map<String, String> appVars = service.getAll();
     Map<String, String> systemEnv = System.getenv();
 
-    // Merge: app vars first, then system-only vars.
     Map<String, EnvVarEntry> result = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : appVars.entrySet()) {
       result.put(entry.getKey(), new EnvVarEntry(entry.getKey(), entry.getValue(), "app"));
@@ -59,6 +58,5 @@ public class SystemEnvVarController {
     return Result.success(null);
   }
 
-  /** DTO for environment variable listing with source distinction. */
   public record EnvVarEntry(String key, String value, String source) {}
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/discovery/InMemoryTaskRegistry.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/discovery/InMemoryTaskRegistry.java
@@ -1,5 +1,10 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.discovery;
 
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskProvider;
+import io.yak.ops.business.job.task.TaskRegistration;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -7,10 +12,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-/** Workflow task registry. Concrete business domains contribute tasks through {@link TaskProvider}. */
-@Service
+/** Aggregates task registrations contributed by business-owned {@link TaskProvider}s. */
+@Component
 public class InMemoryTaskRegistry implements TaskRegistry {
 
   private final ObjectProvider<TaskProvider> taskProviderProvider;

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/env/TaskEnvironmentResolver.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/env/TaskEnvironmentResolver.java
@@ -1,9 +1,0 @@
-package io.yak.ops.business.job.env;
-
-import java.util.Map;
-
-/** Resolves the global environment visible to task runtime contexts. */
-public interface TaskEnvironmentResolver {
-
-  Map<String, String> resolveMergedEnv();
-}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/environment/SystemEnvVarService.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/environment/SystemEnvVarService.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.job.env;
+package io.yak.ops.business.job.environment;
 
 import io.yak.ops.business.job.dao.SystemEnvVarDao;
 import io.yak.ops.common.bean.po.job.SystemEnvVarPO;
@@ -14,12 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Stable application facade for application-level environment variables.
- *
- * <p>The same component implements {@link TaskEnvironmentResolver}, so task execution depends only
- * on the narrow runtime read contract rather than on settings CRUD behavior.</p>
- */
+/** Stable application facade for application-level environment variables. */
 @Service
 public class SystemEnvVarService implements TaskEnvironmentResolver {
 
@@ -41,12 +36,10 @@ public class SystemEnvVarService implements TaskEnvironmentResolver {
     log.info("Loaded {} application environment variable(s) from database", cache.size());
   }
 
-  /** Returns an unmodifiable snapshot of all application-level environment variables. */
   public Map<String, String> getAll() {
     return Collections.unmodifiableMap(new LinkedHashMap<>(cache));
   }
 
-  /** OS environment is the base; application-level values override it. */
   @Override
   public Map<String, String> resolveMergedEnv() {
     Map<String, String> merged = new LinkedHashMap<>(System.getenv());
@@ -54,7 +47,6 @@ public class SystemEnvVarService implements TaskEnvironmentResolver {
     return Collections.unmodifiableMap(merged);
   }
 
-  /** Sets or updates an application-level environment variable. */
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public void set(String key, String value) {
     String normalizedKey = normalizeKey(key);
@@ -81,7 +73,6 @@ public class SystemEnvVarService implements TaskEnvironmentResolver {
         maskSensitive(normalizedKey, normalizedValue));
   }
 
-  /** Removes an application-level environment variable. */
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public boolean remove(String key) {
     String normalizedKey = normalizeKey(key);
@@ -93,7 +84,6 @@ public class SystemEnvVarService implements TaskEnvironmentResolver {
     return affected > 0;
   }
 
-  /** Batch-saves environment variables using the same validation and persistence semantics as set. */
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
   public void batchSave(Map<String, String> variables) {
     if (variables == null || variables.isEmpty()) return;

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/environment/TaskEnvironmentResolver.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/environment/TaskEnvironmentResolver.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.job.environment;
+
+import java.util.Map;
+
+/** Runtime-facing read boundary for merged task environment variables. */
+public interface TaskEnvironmentResolver {
+
+  Map<String, String> resolveMergedEnv();
+}

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/AbstractTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/AbstractTaskExecutorAdapter.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.runtime;
 
 import static io.yak.ops.plugin.task.api.ScriptTaskSupport.hasResourceReference;
 import static io.yak.ops.plugin.task.api.ScriptTaskSupport.safeMessage;
@@ -6,6 +6,9 @@ import static io.yak.ops.plugin.task.api.ScriptTaskSupport.summarizeIssues;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutor;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.plugin.task.api.DefaultTaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
@@ -28,13 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 
-/**
- * Shared local runtime for TaskPlugin-backed task types.
- *
- * <p>Task-type adapters only declare type identity and contribute capabilities. Idempotency,
- * execution handles, asynchronous lifecycle, status/cancel and result conversion are owned here.
- */
-abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
+/** Shared local runtime for TaskPlugin-backed task types. */
+public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
 
   protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -181,7 +179,7 @@ abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
   }
 
   @PreDestroy
-  void shutdown() {
+  public void shutdown() {
     workerExecutor.shutdownNow();
   }
 

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/TaskExecutionContextFactory.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/TaskExecutionContextFactory.java
@@ -1,14 +1,14 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.runtime;
 
-import io.yak.ops.business.job.env.TaskEnvironmentResolver;
+import io.yak.ops.business.job.environment.TaskEnvironmentResolver;
 import io.yak.ops.plugin.task.api.DefaultTaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.Map;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-/** Builds task runtime context from trigger, parameters, environment and type-specific capabilities. */
-@Service
+/** Creates runtime contexts without depending on environment-management CRUD. */
+@Component
 public class TaskExecutionContextFactory {
 
   private final TaskEnvironmentResolver environmentResolver;
@@ -35,7 +35,9 @@ public class TaskExecutionContextFactory {
         .trigger(trigger)
         .parameters(input)
         .globalEnvVars(environmentResolver.resolveMergedEnv());
-    if (customiser != null) customiser.accept(builder);
+    if (customiser != null) {
+      customiser.accept(builder);
+    }
     return builder.build();
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskExecution.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskExecution.java
@@ -3,7 +3,8 @@ package io.yak.ops.business.job.task;
 import java.util.Locale;
 import java.util.Map;
 
-/** 工作流观察同步任务执行时使用的最小状态视图。 */
+/** Legacy compatibility view; production execution uses {@link TaskExecution}. */
+@Deprecated(forRemoval = true)
 public record SyncTaskExecution(
     String executionId,
     String status,

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskExecutorAdapter.java
@@ -1,10 +1,13 @@
 package io.yak.ops.business.job.task;
 
 import java.util.Map;
-import org.springframework.stereotype.Service;
 
-/** Keeps the existing offline-sync runner behind the generic task execution contract. */
-@Service
+/**
+ * Compatibility adapter for legacy Workflow tests/constructors.
+ *
+ * <p>Production SYNC execution is contributed by Offline Sync directly through {@link TaskExecutor}.
+ */
+@Deprecated(forRemoval = true)
 public class SyncTaskExecutorAdapter implements TaskExecutor {
 
   private final SyncTaskRunner runner;

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskRunner.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/task/SyncTaskRunner.java
@@ -1,25 +1,15 @@
 package io.yak.ops.business.job.task;
 
-/** 工作流调用现有数据同步执行链路的最小适配边界。 */
+/** Legacy Workflow-test compatibility boundary; production SYNC uses {@link TaskExecutor}. */
+@Deprecated(forRemoval = true)
 public interface SyncTaskRunner {
 
   SyncTaskExecution start(String taskId);
 
-  /**
-   * 按工作流发布时固定的任务版本快照启动。
-   *
-   * <p>默认实现保持其它 Runner/测试桩兼容；离线同步 Runner 会覆盖并使用快照配置执行。</p>
-   */
   default SyncTaskExecution start(TaskVersionSnapshot snapshot) {
     return start(snapshot.taskId());
   }
 
-  /**
-   * 按工作流 Attempt 启动任务。
-   *
-   * <p>{@code idempotencyKey} 由工作流当前 attemptId 提供。支持远端幂等的 Runner 应覆盖该方法，
-   * 将同一个 Attempt 的重复启动请求收敛为同一次远端执行；旧 Runner 默认仍按快照启动。</p>
-   */
   default SyncTaskExecution start(TaskVersionSnapshot snapshot, String idempotencyKey) {
     return start(snapshot);
   }

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapterTest.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.adapter.plugin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -8,7 +8,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.job.env.SystemEnvVarService;
+import io.yak.ops.business.job.environment.SystemEnvVarService;
+import io.yak.ops.business.job.runtime.TaskExecutionContextFactory;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionResult;

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/architecture/JobArchitectureDocumentationTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/architecture/JobArchitectureDocumentationTest.java
@@ -1,0 +1,40 @@
+package io.yak.ops.business.job.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JobArchitectureDocumentationTest {
+
+  private static final List<String> REQUIRED = List.of(
+      "README.md",
+      "REQUIREMENTS.md",
+      "DOMAIN.md",
+      "ARCHITECTURE.md",
+      "DEPENDENCIES.md",
+      "REVIEW.md");
+
+  @Test
+  void architectureDocumentsArePresentAndLinkedFromReadme() throws IOException {
+    Path root = moduleRoot();
+    String readme = Files.readString(root.resolve("README.md"));
+    for (String document : REQUIRED) {
+      assertThat(Files.isRegularFile(root.resolve(document))).as(document).isTrue();
+      if (!"README.md".equals(document)) {
+        assertThat(readme).as("README must link %s", document).contains(document);
+      }
+    }
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of(".");
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/job"))) return local;
+    Path repository = Path.of("yak-ops-business", "yak-ops-business-job");
+    assertThat(Files.isDirectory(repository)).isTrue();
+    return repository;
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/architecture/JobDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/architecture/JobDependencyBoundaryTest.java
@@ -1,0 +1,153 @@
+package io.yak.ops.business.job.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class JobDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.job.";
+  private static final Pattern JOB_IMPORT = Pattern.compile(
+      "(?m)^import\\s+(?:static\\s+)?io\\.yak\\.ops\\.business\\.job\\.([A-Za-z0-9_]+)\\.[^;]+;");
+
+  private static final Map<String, Set<String>> ALLOWED = Map.ofEntries(
+      Map.entry("controller", Set.of("task", "environment")),
+      Map.entry("discovery", Set.of("task")),
+      Map.entry("adapter", Set.of("runtime", "task")),
+      Map.entry("runtime", Set.of("task", "environment")),
+      Map.entry("environment", Set.of("dao")),
+      Map.entry("task", Set.of()),
+      Map.entry("dao", Set.of()),
+      Map.entry("config", Set.of()));
+
+  @Test
+  void topLevelPackagesFollowDeclaredAcyclicGraph() throws IOException {
+    Map<String, Set<String>> graph = new HashMap<>();
+    ALLOWED.keySet().forEach(key -> graph.put(key, new LinkedHashSet<>()));
+
+    for (Dependency dependency : dependencies()) {
+      if (dependency.source().equals(dependency.target())) continue;
+      assertThat(ALLOWED.get(dependency.source()))
+          .as("missing dependency rule for %s", dependency.source())
+          .isNotNull()
+          .contains(dependency.target());
+      graph.get(dependency.source()).add(dependency.target());
+    }
+
+    Set<String> visited = new HashSet<>();
+    Set<String> visiting = new HashSet<>();
+    Deque<String> path = new ArrayDeque<>();
+    for (String node : graph.keySet()) detectCycle(node, graph, visited, visiting, path);
+  }
+
+  @Test
+  void coreDoesNotDependOnConcreteTaskBusinessDomains() throws IOException {
+    for (Path source : productionJavaFiles()) {
+      String text = Files.readString(source);
+      assertThat(text)
+          .as(relative(source))
+          .doesNotContain("import io.yak.ops.business.sync.offline")
+          .doesNotContain("import io.yak.ops.business.workflow")
+          .doesNotContain("import io.yak.ops.business.development");
+    }
+  }
+
+  @Test
+  void controllerAndRuntimeDoNotReachPersistenceDirectly() throws IOException {
+    for (String role : List.of("controller", "discovery", "runtime", "adapter")) {
+      Path directory = productionRoot().resolve(role);
+      if (!Files.exists(directory)) continue;
+      try (Stream<Path> paths = Files.walk(directory)) {
+        for (Path source : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+          assertThat(Files.readString(source))
+              .as(relative(source))
+              .doesNotContain("import io.yak.ops.business.job.dao");
+        }
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotReturn() {
+    for (String bucket : List.of(
+        "service", "common", "helper", "helpers", "utils", "util", "base", "support")) {
+      assertThat(Files.exists(productionRoot().resolve(bucket))).as(bucket).isFalse();
+    }
+  }
+
+  private List<Dependency> dependencies() throws IOException {
+    List<Dependency> result = new ArrayList<>();
+    for (Path source : productionJavaFiles()) {
+      String relative = relative(source);
+      String from = topLevel(relative);
+      Matcher matcher = JOB_IMPORT.matcher(Files.readString(source));
+      while (matcher.find()) {
+        result.add(new Dependency(relative, from, matcher.group(1)));
+      }
+    }
+    return result;
+  }
+
+  private void detectCycle(
+      String node,
+      Map<String, Set<String>> graph,
+      Set<String> visited,
+      Set<String> visiting,
+      Deque<String> path) {
+    if (visited.contains(node)) return;
+    if (!visiting.add(node)) {
+      List<String> cycle = new ArrayList<>(path);
+      cycle.add(node);
+      throw new AssertionError("Job package cycle: " + cycle);
+    }
+    path.addLast(node);
+    for (String next : graph.getOrDefault(node, Set.of())) {
+      detectCycle(next, graph, visited, visiting, path);
+    }
+    path.removeLast();
+    visiting.remove(node);
+    visited.add(node);
+  }
+
+  private List<Path> productionJavaFiles() throws IOException {
+    try (Stream<Path> paths = Files.walk(productionRoot())) {
+      return paths.filter(path -> path.toString().endsWith(".java")).toList();
+    }
+  }
+
+  private String relative(Path source) {
+    return productionRoot().relativize(source).toString().replace('\\', '/');
+  }
+
+  private String topLevel(String relative) {
+    int slash = relative.indexOf('/');
+    return slash < 0 ? "root" : relative.substring(0, slash);
+  }
+
+  private Path productionRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/job");
+    if (Files.isDirectory(local)) return local;
+    Path repository = Path.of(
+        "yak-ops-business", "yak-ops-business-job", "src", "main", "java",
+        "io", "yak", "ops", "business", "job");
+    assertThat(Files.isDirectory(repository)).isTrue();
+    return repository;
+  }
+
+  private record Dependency(String path, String source, String target) {}
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/architecture/JobRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/architecture/JobRoleConventionTest.java
@@ -1,0 +1,78 @@
+package io.yak.ops.business.job.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class JobRoleConventionTest {
+
+  private static final Set<String> SERVICE_ALLOWLIST = Set.of(
+      "task/TaskExecutionGateway.java",
+      "environment/SystemEnvVarService.java");
+
+  @Test
+  void serviceAnnotationIsReservedForStableApplicationFacades() throws IOException {
+    Set<String> actual = new LinkedHashSet<>();
+    for (Path source : productionJavaFiles()) {
+      String text = Files.readString(source);
+      if (text.contains("\n@Service\n")) actual.add(relative(source));
+    }
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(SERVICE_ALLOWLIST);
+  }
+
+  @Test
+  void professionalRolesUseComponentOrPlainObjects() throws IOException {
+    assertComponent("discovery/InMemoryTaskRegistry.java");
+    assertComponent("runtime/TaskExecutionContextFactory.java");
+    assertComponent("adapter/plugin/SqlTaskExecutorAdapter.java");
+    assertComponent("adapter/plugin/PythonTaskExecutorAdapter.java");
+    assertComponent("adapter/plugin/JavaTaskExecutorAdapter.java");
+    assertComponent("adapter/plugin/ShellTaskExecutorAdapter.java");
+  }
+
+  @Test
+  void legacySyncCorridorCannotBecomeProductionSpringBeans() throws IOException {
+    for (String path : Set.of(
+        "task/SyncTaskRunner.java",
+        "task/SyncTaskExecution.java",
+        "task/SyncTaskExecutorAdapter.java")) {
+      String text = Files.readString(productionRoot().resolve(path));
+      assertThat(text)
+          .as(path)
+          .contains("@Deprecated")
+          .doesNotContain("@Service")
+          .doesNotContain("@Component");
+    }
+  }
+
+  private void assertComponent(String path) throws IOException {
+    String text = Files.readString(productionRoot().resolve(path));
+    assertThat(text).as(path).contains("@Component").doesNotContain("@Service");
+  }
+
+  private java.util.List<Path> productionJavaFiles() throws IOException {
+    try (Stream<Path> paths = Files.walk(productionRoot())) {
+      return paths.filter(path -> path.toString().endsWith(".java")).toList();
+    }
+  }
+
+  private String relative(Path source) {
+    return productionRoot().relativize(source).toString().replace('\\', '/');
+  }
+
+  private Path productionRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/job");
+    if (Files.isDirectory(local)) return local;
+    Path repository = Path.of(
+        "yak-ops-business", "yak-ops-business-job", "src", "main", "java",
+        "io", "yak", "ops", "business", "job");
+    assertThat(Files.isDirectory(repository)).isTrue();
+    return repository;
+  }
+}

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/discovery/InMemoryTaskRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/discovery/InMemoryTaskRegistryTest.java
@@ -1,10 +1,14 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.job.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskProvider;
+import io.yak.ops.business.job.task.TaskRegistration;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -46,7 +50,7 @@ class InMemoryTaskRegistryTest {
   @SuppressWarnings("unchecked")
   private final ObjectProvider<TaskProvider> providers(TaskProvider... values) {
     ObjectProvider<TaskProvider> provider = mock(ObjectProvider.class);
-    when(provider.orderedStream()).thenAnswer(ignored -> Stream.of(values));
+    when(provider.orderedStream()).thenAnswer(ignored -> java.util.stream.Stream.of(values));
     return provider;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/DEPENDENCIES.md
@@ -1,12 +1,8 @@
 # Offline Sync Dependencies
 
-本文件定义离线同步 package 的**依赖方向与跨子系统入口**。原则只有三个：**显式、窄、无环**。
+本文件定义离线同步的依赖方向。原则：**显式、窄、无环**。
 
-架构职责看 `ARCHITECTURE.md`；若本文件与代码冲突，应先判断代码是否越界，不要直接放宽规则。
-
-## Top-level Dependency Graph
-
-允许的内部依赖如下：
+## Internal Graph
 
 | Source | Allowed |
 | --- | --- |
@@ -24,100 +20,76 @@
 | `domain` | none |
 | `config` | none |
 
-同一 top-level package 内的子包属于同一子系统，例如 `execution.query`、`execution.adapter`；但它们不会自动成为其他子系统的公共 API。
+同一 top-level package 的子包属于同一子系统，但不会自动成为其他子系统的公共 API。
 
-## Declared Corridors
-
-跨子系统依赖不能因为某个类是 `public` 就直接 import。当前 corridor：
-
-### Enter Execution
+## Internal Corridors
 
 ```text
 controller -> OfflineJobExecutionService
-backfill   -> OfflineJobExecutionService
-backfill   -> OfflineExecutionScopeValidator
+backfill   -> OfflineJobExecutionService / OfflineExecutionScopeValidator
 reconcile  -> OfflineJobExecutionService
-```
 
-除这些入口外，其他子系统不得直接依赖 `OfflineExecutionCoordinator / ClaimManager / BatchRuntime / execution.query / execution.adapter` 等内部实现。
+any        -> OfflineCursorGateway
 
-### Enter Cursor
-
-```text
-any subsystem -> OfflineCursorGateway
-```
-
-`OfflineCursorManager` 是 cursor 内部实现，不是跨包 API。
-
-### Enter Schedule
-
-```text
-definition -> OfflineScheduleLifecycle
-           -> OfflineScheduleSupport
-
+definition -> OfflineScheduleLifecycle / OfflineScheduleSupport
 execution  -> OfflineScheduleExecutionGateway
 ```
 
-Schedule 不能反向 import execution implementation。`OfflineScheduleExecutionGateway` 由 execution 侧实现，但接口属于 schedule 边界。
+内部 Manager / Coordinator / query / adapter 不能因为 `public` 就成为跨子系统入口。
 
-## Bottom-layer Rules
+## Job Task Extension Corridor
+
+Offline Sync 作为业务 owner，可以向通用 Job Runtime 注册能力：
 
 ```text
-Domain       -> no upper-layer dependency
-DAO          -> config only
-Repository   -> domain + dao + config
-Engine       -> config only
+definition/OfflineSyncTaskProvider
+    -> job.task.TaskProvider / TaskRegistration / TaskVersionSnapshot
+
+execution/adapter/OfflineSyncTaskExecutor
+    -> job.task.TaskExecutor / TaskExecution / TaskVersionSnapshot
 ```
 
-具体约束：
+这是**业务域实现通用扩展契约**，不是 Job 获得 Offline 领域所有权。
 
-- Domain 不知道 Spring Controller、Repository Adapter、Link-Up、Quartz、MyBatis、DTO/VO/PO。
-- DAO 不知道业务 Service / Manager / Coordinator。
-- Repository contract 使用 Domain 类型；PO / MyBatis 细节停在 adapter / DAO。
-- Engine package 封装 Link-Up 协议，不把外部 DTO 变成 Core Domain。
-- Credential 只在 outbound submit boundary 解析，不向 Domain / Snapshot 泄漏。
+允许：
+
+```text
+offline -> io.yak.ops.business.job.task.* (declared contract only)
+```
+
+禁止：
+
+```text
+offline -> job.discovery / job.runtime / job.adapter / job.environment
+```
+
+该 corridor 由 `OfflineJobTaskExtensionBoundaryTest` 固化。
+
+## Bottom Layers
+
+```text
+Domain     -> no upper-layer dependency
+DAO        -> config only
+Repository -> domain + dao + config
+Engine     -> config only
+```
+
+Domain 不知道 Spring Controller、MyBatis、Job Runtime、Yak Schedule 或 Link-Up DTO；Credential 只在 outbound submit boundary 解析。
 
 ## No Cycles
 
-Top-level package dependency graph 必须无环。
-
-出现类似：
-
-```text
-definition -> schedule -> execution -> definition
-```
-
-不要靠 Spring lazy、事件总线或接口搬家掩盖循环。先重新确认职责 owner，并设计窄 corridor。
+Top-level dependency graph 必须无环。遇到循环先确认职责 owner，再设计窄 Facade / Gateway，不使用 lazy、反射或通用 Context 掩盖耦合。
 
 ## Dependency Injection
 
-依赖通过构造器显式注入。业务类不要：
-
-- 在方法内部查 Spring Bean；
-- 使用全局静态可变对象共享业务状态；
-- 为了绕开依赖规则使用反射；
-- 把多个依赖塞进 `Context/Common/Helper` 对象隐藏真实耦合。
-
-构造器依赖过多是职责过宽的信号，应优先拆角色或收窄 Gateway。
+依赖通过构造器显式注入。构造器依赖过多通常表示职责过宽，应优先拆角色。
 
 ## Guardrails
-
-当前主要由两类测试守护：
 
 ```text
 OfflineSyncLayeringConventionTest
 OfflineSyncDependencyBoundaryTest
+OfflineJobTaskExtensionBoundaryTest
 ```
 
-它们负责检查稳定入口、角色约定、top-level dependency graph、无环和 corridor。
-
-## Adding a New Dependency
-
-当一个新 import 不在允许图中时，不要第一反应修改白名单。按顺序判断：
-
-1. **类放错 package 了吗？** —— 先归位。
-2. **已有 Facade / Gateway 能表达需求吗？** —— 优先复用。
-3. **确实缺一个边界吗？** —— 在能力 owner 一侧定义最小接口。
-4. **架构真的改变了吗？** —— 同一 PR 更新本文件和 architecture test。
-
-只有第 4 种情况才应该扩大 dependency graph。
+新增依赖时先判断：类是否放错包、是否已有稳定入口、是否真的需要新 corridor。只有架构确实变化时，才同时修改本文件与测试。

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-job</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.yak.framework</groupId>
             <artifactId>yak-schedule-api</artifactId>
             <version>${yak-framework.version}</version>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineSyncTaskProvider.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineSyncTaskProvider.java
@@ -1,15 +1,18 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.sync.offline.definition;
 
 import io.yak.framework.common.PageData;
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskProvider;
+import io.yak.ops.business.job.task.TaskRegistration;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
-import io.yak.ops.business.sync.offline.service.OfflineJobDefinitionService;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 
-/** Adapts workflow-eligible Offline Sync definitions into the generic TaskProvider contract. */
+/** Exposes workflow-eligible Offline Sync definitions through the generic Job task contract. */
 @Component
 public class OfflineSyncTaskProvider implements TaskProvider {
 
@@ -96,9 +99,7 @@ public class OfflineSyncTaskProvider implements TaskProvider {
 
   private OfflineJobDefinitionService service() {
     OfflineJobDefinitionService service = definitionServiceProvider.getIfAvailable();
-    if (service == null) {
-      throw new IllegalStateException("离线同步能力未启用");
-    }
+    if (service == null) throw new IllegalStateException("离线同步能力未启用");
     return service;
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineSyncTaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineSyncTaskExecutor.java
@@ -1,67 +1,61 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.sync.offline.execution.adapter;
 
-import io.yak.ops.business.sync.offline.service.OfflineJobExecutionService;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutor;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-/** 使用现有离线同步执行服务实现工作流 SYNC 任务执行。 */
-@Service
-public class OfflineSyncTaskRunner implements SyncTaskRunner {
+/** Adapts the Offline Sync-owned execution lifecycle to the generic Job task runtime contract. */
+@Component
+public class OfflineSyncTaskExecutor implements TaskExecutor {
 
   private final ObjectProvider<OfflineJobExecutionService> executionServiceProvider;
 
-  public OfflineSyncTaskRunner(
+  public OfflineSyncTaskExecutor(
       ObjectProvider<OfflineJobExecutionService> executionServiceProvider) {
     this.executionServiceProvider = executionServiceProvider;
   }
 
   @Override
-  public SyncTaskExecution start(String taskId) {
-    OfflineJobExecutionVO execution = service().execute(parseId(taskId, "taskId"));
-    return toExecution(execution);
+  public String taskType() {
+    return "SYNC";
   }
 
   @Override
-  public SyncTaskExecution start(TaskVersionSnapshot snapshot) {
-    return startSnapshot(snapshot, null);
-  }
-
-  @Override
-  public SyncTaskExecution start(TaskVersionSnapshot snapshot, String idempotencyKey) {
-    return startSnapshot(snapshot, idempotencyKey);
-  }
-
-  private SyncTaskExecution startSnapshot(
+  public TaskExecution start(
       TaskVersionSnapshot snapshot,
-      String idempotencyKey) {
-    if (snapshot == null) {
-      throw new IllegalArgumentException("任务版本快照不能为空");
-    }
+      String idempotencyKey,
+      Map<String, Object> input) {
+    if (snapshot == null) throw new IllegalArgumentException("任务版本快照不能为空");
     if (!"SYNC".equalsIgnoreCase(snapshot.type())) {
       throw new IllegalArgumentException("仅支持 SYNC 任务版本快照：" + snapshot.taskId());
     }
+
+    OfflineJobExecutionVO execution;
     if (snapshot.version() <= 0L
         || snapshot.definitionSnapshotJson() == null
         || snapshot.executionConfigSnapshotJson() == null) {
-      // 没有版本能力的兼容 TaskRegistry 仍走原执行入口。
-      return start(snapshot.taskId());
+      execution = service().execute(parseId(snapshot.taskId(), "taskId"));
+    } else {
+      execution = service().executeSnapshot(
+          parseId(snapshot.taskId(), "taskId"),
+          snapshot.version(),
+          snapshot.configDigest(),
+          snapshot.definitionSnapshotJson(),
+          snapshot.executionConfigSnapshotJson(),
+          idempotencyKey);
     }
-    OfflineJobExecutionVO execution = service().executeSnapshot(
-        parseId(snapshot.taskId(), "taskId"),
-        snapshot.version(),
-        snapshot.configDigest(),
-        snapshot.definitionSnapshotJson(),
-        snapshot.executionConfigSnapshotJson(),
-        idempotencyKey);
     return toExecution(execution);
   }
 
   @Override
-  public SyncTaskExecution status(String executionId) {
+  public TaskExecution status(String executionId) {
     OfflineJobExecutionDetailVO detail = service().detail(parseId(executionId, "executionId"));
     OfflineJobExecutionVO execution = detail.getSummary() != null
         ? detail.getSummary()
@@ -85,7 +79,7 @@ public class OfflineSyncTaskRunner implements SyncTaskRunner {
     return service;
   }
 
-  private SyncTaskExecution toExecution(OfflineJobExecutionVO execution) {
+  private TaskExecution toExecution(OfflineJobExecutionVO execution) {
     Map<String, Object> output = new LinkedHashMap<>();
     put(output, "engineJobId", execution.getEngineJobId());
     put(output, "externalExecutionId", execution.getExternalExecutionId());
@@ -93,7 +87,7 @@ public class OfflineSyncTaskRunner implements SyncTaskRunner {
     put(output, "sinkCommittedRecordCount", execution.getSinkCommittedRecordCount());
     put(output, "failedRecordCount", execution.getFailedRecordCount());
     put(output, "durationMillis", execution.getDurationMillis());
-    return new SyncTaskExecution(
+    return new TaskExecution(
         String.valueOf(execution.getId()),
         execution.getStatus(),
         execution.getErrorMessage(),
@@ -101,17 +95,13 @@ public class OfflineSyncTaskRunner implements SyncTaskRunner {
   }
 
   private void put(Map<String, Object> target, String key, Object value) {
-    if (value != null) {
-      target.put(key, value);
-    }
+    if (value != null) target.put(key, value);
   }
 
   private Long parseId(String value, String name) {
     try {
       long parsed = Long.parseLong(value);
-      if (parsed <= 0L) {
-        throw new NumberFormatException(value);
-      }
+      if (parsed <= 0L) throw new NumberFormatException(value);
       return parsed;
     } catch (RuntimeException exception) {
       throw new IllegalArgumentException(name + " 不合法：" + value, exception);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineJobTaskExtensionBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineJobTaskExtensionBoundaryTest.java
@@ -1,0 +1,52 @@
+package io.yak.ops.business.sync.offline.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class OfflineJobTaskExtensionBoundaryTest {
+
+  private static final Map<String, Set<String>> ALLOWED = Map.of(
+      "definition/OfflineSyncTaskProvider.java", Set.of(
+          "io.yak.ops.business.job.task.TaskDefinition",
+          "io.yak.ops.business.job.task.TaskProvider",
+          "io.yak.ops.business.job.task.TaskRegistration",
+          "io.yak.ops.business.job.task.TaskVersionSnapshot"),
+      "execution/adapter/OfflineSyncTaskExecutor.java", Set.of(
+          "io.yak.ops.business.job.task.TaskExecution",
+          "io.yak.ops.business.job.task.TaskExecutor",
+          "io.yak.ops.business.job.task.TaskVersionSnapshot"));
+
+  @Test
+  void offlineEntersJobOnlyThroughDeclaredTaskExtensionContracts() throws IOException {
+    try (Stream<Path> paths = Files.walk(productionRoot())) {
+      for (Path source : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = productionRoot().relativize(source).toString().replace('\\', '/');
+        for (String line : Files.readAllLines(source)) {
+          String trimmed = line.trim();
+          if (!trimmed.startsWith("import io.yak.ops.business.job.")) continue;
+          String imported = trimmed.substring("import ".length(), trimmed.length() - 1);
+          assertThat(ALLOWED.getOrDefault(relative, Set.of()))
+              .as("%s must not depend on Job implementation via %s", relative, imported)
+              .contains(imported);
+        }
+      }
+    }
+  }
+
+  private Path productionRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/sync/offline");
+    if (Files.isDirectory(local)) return local;
+    Path repository = Path.of(
+        "yak-ops-business", "yak-ops-business-sync", "yak-ops-business-sync-offline",
+        "src", "main", "java", "io", "yak", "ops", "business", "sync", "offline");
+    assertThat(Files.isDirectory(repository)).isTrue();
+    return repository;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineSyncTaskProviderTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineSyncTaskProviderTest.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.job.task;
+package io.yak.ops.business.sync.offline.definition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,14 +8,14 @@ import org.junit.jupiter.api.Test;
 class OfflineSyncTaskProviderTest {
 
   @Test
-  void exposesOnlyOnlineTasksWithoutEnabledBusinessSchedule() {
+  void shouldOnlyExposeOnlineTasksWithoutEnabledSchedule() {
     assertThat(OfflineSyncTaskProvider.isWorkflowEligible(task("ONLINE", false))).isTrue();
     assertThat(OfflineSyncTaskProvider.isWorkflowEligible(task("OFFLINE", false))).isFalse();
     assertThat(OfflineSyncTaskProvider.isWorkflowEligible(task("ONLINE", true))).isFalse();
   }
 
   @Test
-  void rejectsIncompleteTaskMetadata() {
+  void shouldRejectIncompleteTaskMetadata() {
     assertThat(OfflineSyncTaskProvider.isWorkflowEligible(null)).isFalse();
     OfflineJobDefinition incomplete = new OfflineJobDefinition();
     incomplete.setJobName("未完成任务");


### PR DESCRIPTION
## Summary

Stage 2 turns the Stage 1 Task Runtime truth into physical package ownership and executable architecture rules.

Core contract remains:

```text
TaskDefinition != TaskVersionSnapshot != TaskExecution
```

## What changed

### Role-owned Job packages

Implementation classes move out of the broad `task` package:

```text
task         stable cross-module contracts + TaskExecutionGateway
discovery    TaskProvider aggregation
runtime      shared Plugin execution lifecycle / context
adapter      task-type capability adapters
environment  environment CRUD facade + runtime resolver
```

`TaskExecutionGateway` and `SystemEnvVarService` remain the only Job `@Service` application facades. Registry, ContextFactory and task-type adapters are professional `@Component` roles.

### Offline Sync dependency inversion

Job no longer depends on `yak-ops-business-sync-offline`.

Offline Sync now implements the Job extension contracts itself:

```text
OfflineSyncTaskProvider -> TaskProvider
OfflineSyncTaskExecutor -> TaskExecutor
```

The provider lives with Offline definition ownership; the executor lives under `execution/adapter` and delegates to the current `OfflineJobExecutionService` facade.

This also removes the stale Stage 1 imports of the old Offline `.service.*` packages.

SYNC behavior remains compatible: workflow eligibility, immutable snapshot execution, idempotency key forwarding, status/cancel mapping and output fields are preserved.

### Compatibility corridor

`SyncTaskRunner / SyncTaskExecution / SyncTaskExecutorAdapter` remain temporarily for existing Workflow compatibility constructors/tests only. They are now deprecated plain types with no Spring registration. Production SYNC discovery/execution does not use them.

### Documentation and guardrails

Job now has the full long-term contract set:

```text
README.md
REQUIREMENTS.md
DOMAIN.md
ARCHITECTURE.md
DEPENDENCIES.md
REVIEW.md
```

Adds executable guards for:

- document completeness;
- top-level dependency graph and cycles;
- Job Core not depending on concrete business modules;
- Controller/Runtime/Adapter not reaching DAO;
- no `service/common/helper/utils` buckets;
- exact `@Service` allowlist;
- deprecated SYNC corridor staying non-Spring;
- Offline Sync entering Job only through declared `job.task` extension contracts.

## Behavior intentionally unchanged

No intentional changes to REST, database schema, Task snapshot semantics, Plugin execution lifecycle, idempotency, status/cancel behavior, or Offline business execution ownership.

## Validation

Branch is based on the Stage 1 merge on current `main` and is 2 commits ahead / 0 behind. Changes are limited to Job plus the Offline Sync files required for the dependency inversion and its architecture contract.

A full Maven run is not claimed from the current connector environment. Recommended verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-job,yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am test
```

## Known follow-up

Once Workflow test/compatibility constructors are generalized to `TaskExecutor`/`TaskExecutionGateway`, the three deprecated SYNC compatibility types in Job can be removed completely.