### PR TITLE
fix(data-development): align datasource catalog boundary

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewService.java
@@ -3,7 +3,7 @@ package io.yak.ops.business.development.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview;
 import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview.ColumnMapping;
@@ -15,7 +15,6 @@ import io.yak.ops.business.lineage.LineageAssetType;
 import io.yak.ops.business.lineage.LineageDirection;
 import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.SqlProjectionLineageAnalyzer;
-import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,7 +35,7 @@ public class DevelopmentSqlLineagePreviewService {
   private final ObjectMapper objectMapper;
   private final TableIdentityResolver identityResolver = new TableIdentityResolver();
 
-  private DataSourceCatalogService dataSourceCatalogService;
+  private DataSourceCatalogReader dataSourceCatalogReader;
 
   public DevelopmentSqlLineagePreviewService(
       DevelopmentNodeRepository nodeRepository,
@@ -52,8 +51,8 @@ public class DevelopmentSqlLineagePreviewService {
   }
 
   @Autowired(required = false)
-  void setDataSourceCatalogService(DataSourceCatalogService dataSourceCatalogService) {
-    this.dataSourceCatalogService = dataSourceCatalogService;
+  void setDataSourceCatalogReader(DataSourceCatalogReader dataSourceCatalogReader) {
+    this.dataSourceCatalogReader = dataSourceCatalogReader;
   }
 
   public DevelopmentSqlLineagePreview preview(
@@ -331,8 +330,8 @@ public class DevelopmentSqlLineagePreviewService {
       String database,
       String schema,
       String table) {
-    DataSourceCatalogService catalogService = this.dataSourceCatalogService;
-    if (catalogService == null) return List.of();
+    DataSourceCatalogReader catalogReader = this.dataSourceCatalogReader;
+    if (catalogReader == null) return List.of();
 
     final Long numericDataSourceId;
     try {
@@ -341,37 +340,34 @@ public class DevelopmentSqlLineagePreviewService {
       return List.of();
     }
 
-    List<DataSourceCatalogColumnVO> columns = listColumns(
-        catalogService,
+    List<io.yak.ops.business.datasource.domain.catalog.CatalogColumn> columns = listColumns(
+        catalogReader,
         numericDataSourceId,
         database,
         schema,
         table);
     if (columns.isEmpty() && database == null && schema != null) {
-      columns = listColumns(catalogService, numericDataSourceId, schema, null, table);
+      columns = listColumns(catalogReader, numericDataSourceId, schema, null, table);
     }
 
     List<CatalogColumn> result = new ArrayList<>();
-    for (DataSourceCatalogColumnVO column : columns) {
-      if (column == null || column.getName() == null || column.getName().isBlank()) continue;
+    for (io.yak.ops.business.datasource.domain.catalog.CatalogColumn column : columns) {
+      if (column == null || column.name() == null || column.name().isBlank()) continue;
       result.add(new CatalogColumn(
-          column.getName(), column.getTypeName(), column.getOrdinalPosition()));
+          column.name(), column.typeName(), column.ordinalPosition()));
     }
     return List.copyOf(result);
   }
 
-  private List<DataSourceCatalogColumnVO> listColumns(
-      DataSourceCatalogService catalogService,
+  private List<io.yak.ops.business.datasource.domain.catalog.CatalogColumn> listColumns(
+      DataSourceCatalogReader catalogReader,
       Long dataSourceId,
       String database,
       String schema,
       String table) {
     try {
-      List<DataSourceCatalogColumnVO> columns = catalogService.listColumns(
-          dataSourceId,
-          database,
-          schema,
-          table);
+      List<io.yak.ops.business.datasource.domain.catalog.CatalogColumn> columns =
+          catalogReader.listColumns(dataSourceId, database, schema, table);
       return columns == null ? List.of() : columns;
     } catch (RuntimeException exception) {
       return List.of();
@@ -505,7 +501,6 @@ public class DevelopmentSqlLineagePreviewService {
     if (value == null || value.isBlank()) return null;
     return value.trim();
   }
-
 
   private static String firstNonBlank(String explicit, String persisted) {
     String normalized = normalizeContext(explicit);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/DevelopmentSqlLineageService.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.lineage.LineageAsset;
@@ -12,7 +13,6 @@ import io.yak.ops.business.lineage.LineageAssetType;
 import io.yak.ops.business.lineage.LineageMaintenanceService;
 import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.LineageService;
-import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -42,7 +42,7 @@ public class DevelopmentSqlLineageService {
   private final ObjectMapper objectMapper;
   private final TableIdentityResolver identityResolver = new TableIdentityResolver();
 
-  private DataSourceCatalogService dataSourceCatalogService;
+  private DataSourceCatalogReader dataSourceCatalogReader;
   private int lineageBatchSize = 200;
 
   public DevelopmentSqlLineageService(
@@ -63,8 +63,8 @@ public class DevelopmentSqlLineageService {
    * publish table-level facts and conservative column facts when Catalog metadata is unavailable.
    */
   @Autowired(required = false)
-  void setDataSourceCatalogService(DataSourceCatalogService dataSourceCatalogService) {
-    this.dataSourceCatalogService = dataSourceCatalogService;
+  void setDataSourceCatalogReader(DataSourceCatalogReader dataSourceCatalogReader) {
+    this.dataSourceCatalogReader = dataSourceCatalogReader;
   }
 
   @Value("${yak.lineage.write-batch-size:200}")
@@ -85,7 +85,7 @@ public class DevelopmentSqlLineageService {
     try {
       SqlTableLineageParser.ParseResult tables = tableParser.parse(revision.definition().content());
       try {
-        SqlColumnLineageParser.ParseResult columns = dataSourceCatalogService == null
+        SqlColumnLineageParser.ParseResult columns = dataSourceCatalogReader == null
             ? columnParser.parse(revision.definition().content())
             : columnParser.parse(revision.definition().content(), schemaProvider(context.dataSourceId()));
         return new PreparedLineage(context, tables, columns, null, null);
@@ -150,8 +150,8 @@ public class DevelopmentSqlLineageService {
       RuntimeException columnFailure) {}
 
   private SqlColumnLineageParser.SchemaProvider schemaProvider(String dataSourceId) {
-    DataSourceCatalogService catalogService = this.dataSourceCatalogService;
-    if (catalogService == null) {
+    DataSourceCatalogReader catalogReader = this.dataSourceCatalogReader;
+    if (catalogReader == null) {
       return SqlColumnLineageParser.SchemaProvider.none();
     }
 
@@ -166,15 +166,15 @@ public class DevelopmentSqlLineageService {
     Map<String, List<SqlColumnLineageParser.SchemaColumn>> cache = new LinkedHashMap<>();
     return table -> cache.computeIfAbsent(
         table.canonicalName(),
-        ignored -> loadSchemaColumns(catalogService, numericDataSourceId, table));
+        ignored -> loadSchemaColumns(catalogReader, numericDataSourceId, table));
   }
 
   private List<SqlColumnLineageParser.SchemaColumn> loadSchemaColumns(
-      DataSourceCatalogService catalogService,
+      DataSourceCatalogReader catalogReader,
       Long dataSourceId,
       SqlTableLineageParser.TableRef table) {
-    List<DataSourceCatalogColumnVO> columns = listColumns(
-        catalogService,
+    List<CatalogColumn> columns = listColumns(
+        catalogReader,
         dataSourceId,
         table.databaseName(),
         table.schemaName(),
@@ -186,7 +186,7 @@ public class DevelopmentSqlLineageService {
     // datasource-plugin details into the SQL parser.
     if (columns.isEmpty() && table.databaseName() == null && table.schemaName() != null) {
       columns = listColumns(
-          catalogService,
+          catalogReader,
           dataSourceId,
           table.schemaName(),
           null,
@@ -194,24 +194,24 @@ public class DevelopmentSqlLineageService {
     }
 
     List<SqlColumnLineageParser.SchemaColumn> result = new ArrayList<>();
-    for (DataSourceCatalogColumnVO column : columns) {
-      if (column == null || column.getName() == null || column.getName().isBlank()) continue;
+    for (CatalogColumn column : columns) {
+      if (column == null || column.name() == null || column.name().isBlank()) continue;
       result.add(new SqlColumnLineageParser.SchemaColumn(
-          column.getName(),
-          column.getOrdinalPosition()));
+          column.name(),
+          column.ordinalPosition()));
     }
     return List.copyOf(result);
   }
 
-  private List<DataSourceCatalogColumnVO> listColumns(
-      DataSourceCatalogService catalogService,
+  private List<CatalogColumn> listColumns(
+      DataSourceCatalogReader catalogReader,
       Long dataSourceId,
       String database,
       String schema,
       String table) {
     try {
-      List<DataSourceCatalogColumnVO> columns =
-          catalogService.listColumns(dataSourceId, database, schema, table);
+      List<CatalogColumn> columns =
+          catalogReader.listColumns(dataSourceId, database, schema, table);
       return columns == null ? List.of() : columns;
     } catch (RuntimeException exception) {
       LOGGER.debug(
@@ -307,7 +307,7 @@ public class DevelopmentSqlLineageService {
     properties.put("dataSourceId", dataSourceId);
     properties.put(
         "columnSchemaResolution",
-        dataSourceCatalogService == null ? "NONE" : "DATASOURCE_CATALOG");
+        dataSourceCatalogReader == null ? "NONE" : "DATASOURCE_CATALOG");
 
     if (tableFailure == null && tableParsed != null) {
       properties.put("parseStatus", "SUCCESS");

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/architecture/DataDevelopmentDatasourceBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/architecture/DataDevelopmentDatasourceBoundaryTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.development.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Prevents Data Development from coupling back to removed datasource transport/service APIs. */
+class DataDevelopmentDatasourceBoundaryTest {
+
+  @Test
+  void datasourceIntegrationUsesCurrentBusinessBoundary() throws IOException {
+    try (Stream<Path> paths = Files.walk(productionRoot())) {
+      for (Path source : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String text = Files.readString(source);
+        assertThat(text)
+            .as(relative(source))
+            .doesNotContain("io.yak.ops.business.datasource.service.")
+            .doesNotContain("io.yak.ops.common.bean.vo.datasource.DataSourceCatalog");
+      }
+    }
+  }
+
+  private String relative(Path source) {
+    return productionRoot().relativize(source).toString().replace('\\', '/');
+  }
+
+  private Path productionRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/development");
+    if (Files.isDirectory(local)) return local;
+    return Path.of(
+        "yak-ops-business", "yak-ops-business-data-development", "src", "main", "java",
+        "io", "yak", "ops", "business", "development");
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineagePreviewServiceTest.java
@@ -8,12 +8,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentSqlLineagePreview;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
-import io.yak.ops.business.datasource.service.DataSourceCatalogService;
 import io.yak.ops.business.lineage.LineageRelationType;
-import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
+import java.sql.Types;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -83,12 +84,12 @@ class DevelopmentSqlLineagePreviewServiceTest {
   @Test
   void includesCatalogDataTypesInColumnMappings() {
     DevelopmentSqlLineagePreviewService service = service(sqlNode(8L, "类型血缘"));
-    DataSourceCatalogService catalogService = mock(DataSourceCatalogService.class);
-    when(catalogService.listColumns(3L, null, "ods", "orders"))
+    DataSourceCatalogReader catalogReader = mock(DataSourceCatalogReader.class);
+    when(catalogReader.listColumns(3L, null, "ods", "orders"))
         .thenReturn(java.util.List.of(column("id", "BIGINT", 1)));
-    when(catalogService.listColumns(3L, null, "dws", "order_copy"))
+    when(catalogReader.listColumns(3L, null, "dws", "order_copy"))
         .thenReturn(java.util.List.of(column("id", "DECIMAL(20,0)", 1)));
-    service.setDataSourceCatalogService(catalogService);
+    service.setDataSourceCatalogReader(catalogReader);
 
     DevelopmentSqlLineagePreview preview = service.preview(
         8L,
@@ -168,8 +169,8 @@ class DevelopmentSqlLineagePreviewServiceTest {
         Instant.now());
   }
 
-  private static DataSourceCatalogColumnVO column(String name, String type, int ordinal) {
-    return new DataSourceCatalogColumnVO(
-        name, type, null, null, null, true, ordinal, false, null);
+  private static CatalogColumn column(String name, String type, int ordinal) {
+    return new CatalogColumn(
+        name, type, Types.VARCHAR, null, null, true, ordinal, false, null);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentSqlLineageServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -13,7 +14,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.yak.ops.business.datasource.service.DataSourceCatalogService;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
 import io.yak.ops.business.lineage.LineageAsset;
@@ -21,8 +23,8 @@ import io.yak.ops.business.lineage.LineageAssetType;
 import io.yak.ops.business.lineage.LineageMaintenanceService;
 import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.LineageService;
-import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
 import io.yak.ops.spi.task.model.TaskDefinition;
+import java.sql.Types;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -140,13 +142,13 @@ class DevelopmentSqlLineageServiceTest {
     when(maintenanceService.lockAndAcceptRevision(anyString(), anyInt())).thenReturn(true);
     SqlTableLineageParser tableParser = mock(SqlTableLineageParser.class);
     SqlColumnLineageParser columnParser = new SqlColumnLineageParser();
-    DataSourceCatalogService catalogService = mock(DataSourceCatalogService.class);
+    DataSourceCatalogReader catalogReader = mock(DataSourceCatalogReader.class);
     ObjectMapper objectMapper = new ObjectMapper();
     stubAssetRegistration(lineageService);
 
     DevelopmentSqlLineageService service = new DevelopmentSqlLineageService(
         lineageService, maintenanceService, tableParser, columnParser, objectMapper);
-    service.setDataSourceCatalogService(catalogService);
+    service.setDataSourceCatalogReader(catalogReader);
 
     String sql = "INSERT INTO dws.orders_copy SELECT * FROM ods.orders";
     SqlTableLineageParser.TableRef orders = table("ods.orders", "ods", "orders");
@@ -156,12 +158,12 @@ class DevelopmentSqlLineageServiceTest {
 
     // Simulate a MySQL/Doris style two-part name. The first schema.table interpretation returns no
     // metadata; the service retries the same qualifier as database.table.
-    when(catalogService.listColumns(12L, null, "ods", "orders")).thenReturn(List.of());
-    when(catalogService.listColumns(12L, "ods", null, "orders")).thenReturn(List.of(
+    when(catalogReader.listColumns(12L, null, "ods", "orders")).thenReturn(List.of());
+    when(catalogReader.listColumns(12L, "ods", null, "orders")).thenReturn(List.of(
         catalogColumn("id", 1),
         catalogColumn("amount", 2)));
-    when(catalogService.listColumns(12L, null, "dws", "orders_copy")).thenReturn(List.of());
-    when(catalogService.listColumns(12L, "dws", null, "orders_copy")).thenReturn(List.of(
+    when(catalogReader.listColumns(12L, null, "dws", "orders_copy")).thenReturn(List.of());
+    when(catalogReader.listColumns(12L, "dws", null, "orders_copy")).thenReturn(List.of(
         catalogColumn("order_id", 1),
         catalogColumn("order_amount", 2)));
 
@@ -286,11 +288,11 @@ class DevelopmentSqlLineageServiceTest {
         qualifiedName, qualifiedName, null, schema, table);
   }
 
-  private static DataSourceCatalogColumnVO catalogColumn(String name, int ordinal) {
-    return new DataSourceCatalogColumnVO(
+  private static CatalogColumn catalogColumn(String name, int ordinal) {
+    return new CatalogColumn(
         name,
         "VARCHAR",
-        null,
+        Types.VARCHAR,
         null,
         null,
         true,


### PR DESCRIPTION
## 背景

Datasource 模块角色化重构后，`yak-ops-business-data-development` 的 SQL 血缘链路仍残留已经移除的 `io.yak.ops.business.datasource.service.DataSourceCatalogService` 和旧 `DataSourceCatalogColumnVO`。这会在主代码编译阶段产生 `datasource.service` 包不存在及后续符号解析错误；对应测试也仍绑定旧 API，会继续阻塞 `testCompile`。

## 本次修改

- `DevelopmentSqlLineagePreviewService`
  - 迁移到当前 datasource 读侧边界 `DataSourceCatalogReader`；
  - 使用 datasource 领域 `CatalogColumn` record，并保持原有字段类型、ordinal、schema/database fallback 行为不变；
  - 保留 datasource 可关闭场景下的 optional 注入与无 Catalog 降级逻辑。
- `DevelopmentSqlLineageService`
  - 同步迁移 Catalog 读取边界；
  - 保持发布血缘、两段式表名兼容解析、Catalog 查询失败降级语义不变。
- 更新 `DevelopmentSqlLineagePreviewServiceTest`、`DevelopmentSqlLineageServiceTest` 到新 Catalog API。
- 顺手修复 `DevelopmentSqlLineageServiceTest` 已使用 `anyString()` 但缺少 Mockito 静态 import 的 testCompile 隐患。
- 新增 `DataDevelopmentDatasourceBoundaryTest`，扫描整个 Data Development 生产源码，禁止重新依赖已删除的 `datasource.service` 和旧 Catalog transport VO。

## 整个模块巡检结论

- `pom.xml` 已显式依赖 `yak-ops-business-datasource`，不是 Maven 漏依赖问题，因此不修改 POM。
- 最近完成的 `dataset/directory/editor/execution/node/release/task` role/package 重构已经有现有架构测试约束；本次没有发现需要回滚或重新搬包的稳定角色。
- legacy `service` island 中其他 SQL parser / data-service adapter 使用的是当前 API/SPI，没有发现同类 datasource service 引用。
- `SqlTableLineageParser`、`SqlColumnLineageParser`、`DerivedAwareSqlColumnLineageParser`、`DevelopmentDataServiceSqlCompiler` 中 `Statements#getStatements()` 当前属于 JSqlParser deprecated warning，不是本次编译失败根因；本 PR 不混入 parser API 升级，避免扩大行为变更范围。

## 验证

- 已对照当前 `main` 的 `DataSourceCatalogReader#listColumns(Long, String, String, String)` 与 `domain.catalog.CatalogColumn` 做静态 API 校验。
- `main...fix/data-development-datasource-boundary` 的有效 diff 仅涉及 5 个 `yak-ops-business-data-development` 文件，无 POM 或其他业务模块改动。
- 当前执行环境无法直接拉取仓库运行 Maven，因此不宣称本地测试已通过。

建议合并前执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-data-development -am test
```
