### PR TITLE
fix(datasource): align tests with domain boundaries

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntimeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.yak.ops.business.datasource.gateway.adapter.SpiSqlExecutionGateway;
 import io.yak.ops.core.execution.sql.*;
 import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
 import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
@@ -24,7 +25,9 @@ class ObservableSqlExecutionRuntimeTest {
         DataSourceExecutionProvider provider = dataSourceId -> request ->
                 DataSourceSqlResult.resultSet(List.of(), List.of(), false);
         DefaultSqlExecutionRuntime delegate =
-                new DefaultSqlExecutionRuntime(provider, new DefaultSqlExecutionPolicy());
+                new DefaultSqlExecutionRuntime(
+                        new SpiSqlExecutionGateway(provider),
+                        new DefaultSqlExecutionPolicy());
 
         try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
             context.getBeanFactory().registerSingleton("defaultSqlExecutionRuntime", delegate);
@@ -130,7 +133,9 @@ class ObservableSqlExecutionRuntimeTest {
                         ? DataSourceSqlResult.resultSet(List.of(), List.of(), false)
                         : DataSourceSqlResult.updateCount(1L);
         DefaultSqlExecutionRuntime delegate =
-                new DefaultSqlExecutionRuntime(provider, new DefaultSqlExecutionPolicy());
+                new DefaultSqlExecutionRuntime(
+                        new SpiSqlExecutionGateway(provider),
+                        new DefaultSqlExecutionPolicy());
         return new RuntimePair(delegate, new ObservableSqlExecutionRuntime(delegate, List.of(observer)));
     }
 

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/gateway/adapter/SpiDataSourceCatalogGatewayTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.datasource.domain.ConnectionProfile;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
 import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
@@ -16,6 +17,7 @@ import io.yak.ops.business.datasource.domain.catalog.CatalogTable;
 import io.yak.ops.business.datasource.domain.catalog.CatalogTableQuery;
 import io.yak.ops.business.datasource.plugin.DataSourcePluginRegistry;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
 import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourceCatalog;
 import io.yak.ops.spi.datasource.DataSourceConnection;
@@ -91,9 +93,11 @@ class SpiDataSourceCatalogGatewayTest {
   }
 
   private DataSourceDefinition configuredDataSource() {
-    DataSourceDefinition dataSource = new DataSourceDefinition();
-    dataSource.setDbType(DataSourceDbType.MYSQL);
-    dataSource.setConnectionParams("{\"database\":\"orders_db\"}");
-    return dataSource;
+    return DataSourceDefinition.create(
+        "orders-db",
+        DataSourceDbType.MYSQL,
+        ConnectionProfile.of(null, "{\"database\":\"orders_db\"}"),
+        DataSourceEnvironment.TEST,
+        null);
   }
 }


### PR DESCRIPTION
## 背景

Datasource 的领域聚合和 SQL execution gateway 边界已经完成重构，但模块内仍有两组测试停留在旧构造方式，导致 `yak-ops-business-datasource` 在 `testCompile` 阶段失败。

## 本次修改

- `SpiDataSourceCatalogGatewayTest`
  - 不再直接 `new DataSourceDefinition()` + setter；
  - 按当前聚合 API 使用 `DataSourceDefinition.create(...)` + `ConnectionProfile` 构造测试数据；
  - 保持原 Catalog Gateway 测试语义不变。
- `ObservableSqlExecutionRuntimeTest`
  - 不再把 `DataSourceExecutionProvider` 直接传入 `DefaultSqlExecutionRuntime`；
  - 通过 `SpiSqlExecutionGateway` 适配到当前 Business `SqlExecutionGateway` 边界；
  - 与现有 `DefaultSqlExecutionRuntimeTest` / transaction cancellation test 的写法保持一致。

## 模块巡检

- 对照当前 `DataSourceDefinition`、`ConnectionProfile`、`DefaultSqlExecutionRuntime`、`SpiSqlExecutionGateway` API 检查相关测试；
- `DataSourceDefinitionTest` 已使用 aggregate `create`，`DataSourceConnectionTesterTest` 已使用 `restore`；
- `DefaultSqlExecutionRuntimeTest`、`DefaultSqlExecutionTransactionCancellationTest` 已正确走 `SpiSqlExecutionGateway`；
- catalog / management / repository / plugin gateway 等重点测试未发现同类旧构造残留；
- 本 PR 不修改生产代码、不修改 POM，也不混入非编译阻塞的格式或 deprecated warning 清理。

## 变更范围

当前分支相对最新 `main` 只有 1 个 commit、2 个 datasource 测试文件变更。

## 验证

当前执行环境没有直接运行该仓库 Maven 测试，因此不宣称测试已经通过。建议合并前执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-datasource -am test
```
