### PR TITLE
fix(datasource): avoid audit mapper bean name conflict

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/SqlExecutionAuditController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/SqlExecutionAuditController.java
@@ -6,7 +6,7 @@ import io.yak.framework.common.PagingData;
 import io.yak.framework.common.Result;
 import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
-import io.yak.ops.business.datasource.controller.v1.mapper.SqlExecutionAuditMapper;
+import io.yak.ops.business.datasource.controller.v1.mapper.SqlExecutionAuditViewMapper;
 import io.yak.ops.business.datasource.execution.audit.SqlExecutionAuditReader;
 import io.yak.ops.common.bean.dto.observability.SqlExecutionAuditQueryDTO;
 import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditDetailVO;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SqlExecutionAuditController {
 
   private final SqlExecutionAuditReader auditReader;
-  private final SqlExecutionAuditMapper auditMapper;
+  private final SqlExecutionAuditViewMapper auditMapper;
 
   @Operation(summary = "分页查询 SQL 执行历史")
   @PostMapping("/page")

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/mapper/SqlExecutionAuditViewMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/mapper/SqlExecutionAuditViewMapper.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 /** Maps SQL execution audit transport models to/from typed read-side projections. */
 @Component
 @ConditionalOnDataSourceEnabled
-public class SqlExecutionAuditMapper {
+public class SqlExecutionAuditViewMapper {
 
   public SqlExecutionAuditCriteria criteria(SqlExecutionAuditQueryDTO dto) {
     SqlExecutionAuditQueryDTO source = dto == null ? new SqlExecutionAuditQueryDTO() : dto;

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceBeanNameConventionTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceBeanNameConventionTest.java
@@ -1,0 +1,54 @@
+package io.yak.ops.business.datasource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class DataSourceBeanNameConventionTest {
+
+  @Test
+  void controllerMappersDoNotReusePersistenceMapperSimpleNames() throws IOException {
+    Set<String> persistenceNames = javaSimpleNames(productionRoot().resolve("dao/mapper"));
+    Set<String> controllerNames = javaSimpleNames(productionRoot().resolve("controller/v1/mapper"));
+    Set<String> duplicates = new LinkedHashSet<>(controllerNames);
+    duplicates.retainAll(persistenceNames);
+
+    assertThat(duplicates)
+        .as("controller mapper simple names must not collide with MyBatis mapper bean names")
+        .isEmpty();
+  }
+
+  private Set<String> javaSimpleNames(Path directory) throws IOException {
+    if (!Files.isDirectory(directory)) return Set.of();
+    try (Stream<Path> paths = Files.list(directory)) {
+      return paths
+          .filter(path -> path.getFileName().toString().endsWith(".java"))
+          .map(path -> path.getFileName().toString())
+          .map(name -> name.substring(0, name.length() - ".java".length()))
+          .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+  }
+
+  private Path productionRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/datasource");
+    if (Files.isDirectory(local)) return local;
+    return Path.of(
+        "yak-ops-business",
+        "yak-ops-business-datasource",
+        "src",
+        "main",
+        "java",
+        "io",
+        "yak",
+        "ops",
+        "business",
+        "datasource");
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/controller/v1/mapper/SqlExecutionAuditViewMapperTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/controller/v1/mapper/SqlExecutionAuditViewMapperTest.java
@@ -12,9 +12,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class SqlExecutionAuditMapperTest {
+class SqlExecutionAuditViewMapperTest {
 
-  private final SqlExecutionAuditMapper mapper = new SqlExecutionAuditMapper();
+  private final SqlExecutionAuditViewMapper mapper = new SqlExecutionAuditViewMapper();
 
   @Test
   void mapsTransportFiltersToTypedCriteria() {


### PR DESCRIPTION
## 背景

应用启动时 Spring/MyBatis 扫描到两个默认 Bean 名都为 `sqlExecutionAuditMapper` 的组件：

- `io.yak.ops.business.datasource.dao.mapper.SqlExecutionAuditMapper`：MyBatis `@Mapper`
- `io.yak.ops.business.datasource.controller.v1.mapper.SqlExecutionAuditMapper`：HTTP DTO/VO 转换 `@Component`

两者职责完全不同，但默认 BeanName 相同，导致 `ConflictingBeanDefinitionException`，ApplicationContext 在初始化阶段直接失败。

## 本次修改

- 将 Controller 侧 transport mapper 重命名为 `SqlExecutionAuditViewMapper`，明确它是 API view/transport 映射角色，而不是持久化 Mapper；
- `SqlExecutionAuditController` 同步使用新的 `SqlExecutionAuditViewMapper`；
- 对应测试同步重命名，映射逻辑和接口行为不变；
- 新增 `DataSourceBeanNameConventionTest`，扫描 datasource 模块的 `dao/mapper` 与 `controller/v1/mapper`，禁止简单类名重复，避免未来再次出现 MyBatis Mapper 与 Spring Component 默认 BeanName 冲突。

## 巡检结论

当前 datasource DAO mapper 为 `DataSourceMapper`、`SqlExecutionAuditMapper`、`SqlStatementExecutionAuditMapper`；Controller mapper 中只有原 `SqlExecutionAuditMapper` 与 DAO 侧重名。本次重命名后该冲突集合为空，没有发现第二个同类 BeanName 冲突。

## 变更范围

- 1 个 Controller 引用调整；
- 1 个 transport mapper rename；
- 1 个对应测试 rename；
- 1 个架构回归测试；
- 不修改数据库、不修改 MyBatis XML、不修改 POM、不改业务接口。

## 验证

已基于最新 `main`（包含 #714）核对源码和 Bean 扫描边界，分支相对 `main` 只有 1 个 commit。

当前执行环境无法直接启动完整 YakOpsApplication，因此不宣称启动已实测通过。建议合并前本地执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-datasource -am test
```

随后启动 `YakOpsApplication`，确认不再出现 `sqlExecutionAuditMapper` 的 `ConflictingBeanDefinitionException`。
