### PR TITLE
feat(ui): add language-aware font switching

### DIFF
--- a/yak-ops-ui/config/config.ts
+++ b/yak-ops-ui/config/config.ts
@@ -80,7 +80,7 @@ export default defineConfig({
   /**
    * 一个全局的初始数据流，可以用它在插件之间共享数据
    * @description 可以用来存放一些全局的数据，比如用户信息，或者一些全局的状态，全局初始状态在整个 Umi 项目的最开始创建。
-   * @doc https://umijs.org/docs/max/data-flow#%E5%85%A8%E5%B1%80%E5%88%9D%E5%A7%8B%E6%95%B0%E6%8D%AE
+   * @doc https://umijs.org/docs/max/data-flow#%E5%85%A8%E5%B1%80%E5%88%9D%E5%A7%8B%E7%8A%B6%E6%80%81
    */
   initialState: {},
   /**

--- a/yak-ops-ui/config/config.ts
+++ b/yak-ops-ui/config/config.ts
@@ -80,7 +80,7 @@ export default defineConfig({
   /**
    * 一个全局的初始数据流，可以用它在插件之间共享数据
    * @description 可以用来存放一些全局的数据，比如用户信息，或者一些全局的状态，全局初始状态在整个 Umi 项目的最开始创建。
-   * @doc https://umijs.org/docs/max/data-flow#%E5%85%A8%E5%B1%80%E5%88%9D%E5%A7%8B%E7%8A%B6%E6%80%81
+   * @doc https://umijs.org/docs/max/data-flow#%E5%85%A8%E5%B1%80%E5%88%9D%E5%A7%8B%E6%95%B0%E6%8D%AE
    */
   initialState: {},
   /**
@@ -136,7 +136,7 @@ antd: {
         colorInfo: BRAND_COLOR,
         colorLink: BRAND_COLOR,
 
-        fontFamily: 'YakOps, Inter, "PingFang SC", "Microsoft YaHei", sans-serif',
+        fontFamily: 'var(--yak-font-family)',
       },
     },
   },

--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -3,7 +3,7 @@ import type { Settings as LayoutSettings } from "@ant-design/pro-components";
 import { SettingDrawer } from "@ant-design/pro-components";
 import "@ant-design/v5-patch-for-react-19";
 import type { RunTimeLayoutConfig } from "@umijs/max";
-import { history } from "@umijs/max";
+import { getLocale, history } from "@umijs/max";
 
 import defaultSettings from "../config/defaultSettings";
 import { GlobalSearch, Knowledge } from "./components/RightContent";
@@ -18,6 +18,14 @@ import {
 
 const isDev = process.env.NODE_ENV === "development";
 const loginPath = "/login";
+
+const syncDocumentLocale = () => {
+  const currentLocale = getLocale();
+  const locale = currentLocale.toLowerCase().startsWith("zh") ? "zh-CN" : "en-US";
+
+  document.documentElement.dataset.yakLocale = locale;
+  document.documentElement.lang = locale;
+};
 
 const redirectAnonymousUser = () => {
   if (isLoginPath(window.location.pathname)) return;
@@ -38,6 +46,8 @@ export async function getInitialState(): Promise<{
   currentUserLoadError?: boolean;
   fetchUserInfo?: () => Promise<API.CurrentUser | undefined>;
 }> {
+  syncDocumentLocale();
+
   const fetchUserInfo = async () => toCurrentUser(await getCurrentUser());
   // Always probe the cookie-backed Session, including after a reload on login.
   let currentUser: API.CurrentUser | undefined;

--- a/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
+++ b/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
@@ -12,7 +12,7 @@ function LanguageSwitcher() {
   const currentLocale = getSupportedLocale();
 
   const switchLocale = (locale: SupportedLocale) => {
-    if (locale === currentLocale) return;
+    if (locale === getLocale()) return;
 
     document.documentElement.dataset.yakLocale = locale;
     document.documentElement.lang = locale;

--- a/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
+++ b/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
@@ -1,29 +1,92 @@
 import { useSecurityProject } from "@/contexts/SecurityProjectContext";
-import { Dropdown, Empty } from "antd";
-import { ChevronDown } from "lucide-react";
+import { getLocale, setLocale } from "@umijs/max";
+import { Dropdown } from "antd";
+import { ChevronDown, Languages } from "lucide-react";
 
-export default function SecurityProjectSwitcher() {
-  const { projects, currentProject, selectProject } = useSecurityProject();
-  if (!projects.length) {
-    return <>暂无可用项目</>;
-  }
+type SupportedLocale = "zh-CN" | "en-US";
+
+const getSupportedLocale = (): SupportedLocale =>
+  getLocale().toLowerCase().startsWith("zh") ? "zh-CN" : "en-US";
+
+function LanguageSwitcher() {
+  const currentLocale = getSupportedLocale();
+
+  const switchLocale = (locale: SupportedLocale) => {
+    if (locale === currentLocale) return;
+
+    document.documentElement.dataset.yakLocale = locale;
+    document.documentElement.lang = locale;
+    setLocale(locale);
+  };
 
   return (
     <Dropdown
+      placement="bottomRight"
+      trigger={["click"]}
       menu={{
         selectable: true,
-        selectedKeys: currentProject ? [String(currentProject.id)] : [],
-        items: projects.map((project) => ({
-          key: String(project.id),
-          label: project.projectName,
-          onClick: () => selectProject(project),
-        })),
+        selectedKeys: [currentLocale],
+        items: [
+          {
+            key: "zh-CN",
+            label: "中文",
+            onClick: () => switchLocale("zh-CN"),
+          },
+          {
+            key: "en-US",
+            label: "English",
+            onClick: () => switchLocale("en-US"),
+          },
+        ],
       }}
     >
-      <button type="button" className="flex items-center gap-1 border-0 bg-transparent px-2 text-sm">
-        <span>{currentProject?.projectName}</span><ChevronDown className="h-3 w-3" />
+      <button
+        type="button"
+        aria-label="切换语言 / Switch language"
+        title="切换语言 / Switch language"
+        className="order-[-1] flex h-12 min-w-11 flex-col items-center justify-center border-0 bg-transparent px-2 text-[12px] text-[rgba(35,35,35,0.6)] transition-colors duration-150 hover:text-[rgba(35,35,35,0.9)]"
+      >
+        <span className="flex h-6 w-6 items-center justify-center text-[17px]">
+          <Languages className="h-[17px] w-[17px]" strokeWidth={1.8} />
+        </span>
+        <span className="mt-0.5 whitespace-nowrap text-[10px] leading-3">
+          {currentLocale === "zh-CN" ? "中文" : "EN"}
+        </span>
       </button>
     </Dropdown>
   );
 }
 
+export default function SecurityProjectSwitcher() {
+  const { projects, currentProject, selectProject } = useSecurityProject();
+
+  return (
+    <div className="contents">
+      <LanguageSwitcher />
+
+      {!projects.length ? (
+        <span className="whitespace-nowrap px-2 text-sm">暂无可用项目</span>
+      ) : (
+        <Dropdown
+          menu={{
+            selectable: true,
+            selectedKeys: currentProject ? [String(currentProject.id)] : [],
+            items: projects.map((project) => ({
+              key: String(project.id),
+              label: project.projectName,
+              onClick: () => selectProject(project),
+            })),
+          }}
+        >
+          <button
+            type="button"
+            className="flex items-center gap-1 border-0 bg-transparent px-2 text-sm"
+          >
+            <span>{currentProject?.projectName}</span>
+            <ChevronDown className="h-3 w-3" />
+          </button>
+        </Dropdown>
+      )}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -6,6 +6,22 @@
   src: url('@/assets/yak-ops.woff2') format('woff2');
 }
 
+@font-face {
+  font-family: 'YakOpsZh';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('@/assets/web.woff2') format('woff2');
+}
+
+:root {
+  --yak-font-family: 'YakOps', Inter, 'PingFang SC', 'Microsoft YaHei', sans-serif;
+}
+
+html[data-yak-locale='zh-CN'] {
+  --yak-font-family: 'YakOpsZh', 'YakOps', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+}
+
 html,
 body,
 #root {
@@ -13,11 +29,16 @@ body,
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: 'YakOps', Inter, 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  font-family: var(--yak-font-family);
+}
+
+.yak-login-page {
+  --yak-font-family: 'YakOps', Inter, 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  font-family: var(--yak-font-family);
 }
 
 .st-web-font {
-  font-family: YakOps;
+  font-family: var(--yak-font-family);
 }
 
 .colorWeak {

--- a/yak-ops-ui/src/pages/login/index.tsx
+++ b/yak-ops-ui/src/pages/login/index.tsx
@@ -3,7 +3,7 @@ import LoginPanel from "./LoginPanel";
 
 export default function LoginPage() {
   return (
-    <main className="h-screen overflow-y-auto bg-[#fbfbfa] text-[#171717]">
+    <main className="yak-login-page h-screen overflow-y-auto bg-[#fbfbfa] text-[#171717]">
       <div className="mx-auto flex min-h-screen w-full max-w-[1540px] flex-col px-6 py-4 sm:px-10 lg:px-12 lg:pb-6 lg:pt-5 xl:px-16">
         <header className="flex h-11 shrink-0 items-center">
           <img


### PR DESCRIPTION
## Summary
- register `yak-ops.woff2` as the English/default font and `web.woff2` as the Chinese font
- add a compact 中文 / EN language switch to the authenticated header using Umi locale APIs and Ant Design Dropdown
- synchronize the active Umi locale with a document-level font CSS variable so Ant Design components switch fonts as well
- keep the login page pinned to `yak-ops.woff2` regardless of the selected locale

## Notes
- the project already has Umi i18n enabled; this change limits the new header control to Chinese and English instead of exposing every locale currently present under `src/locales`
- locale switching keeps Umi's default reload behavior, so existing `umi_locale` persistence continues to work

## Validation
- reviewed the branch diff against `main`
- confirmed both font assets already exist under `yak-ops-ui/src/assets`
- local build was not run in the connector environment; CI status should be used for build verification