### PR TITLE
feat(security): enable Sa-Token authentication in Yak Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,6 @@ Existing database tables are not automatically dropped. Deployments that already
 
 ## Security note
 
+Yak Ops delegates login-state management to Yak Security and uses the Sa-Token backend by default. To temporarily roll back to the legacy Servlet Session backend, set `YAK_SECURITY_AUTHENTICATION_MODE=session` before startup. Business modules should continue to depend on Yak Security's current-user and permission abstractions instead of calling Sa-Token directly.
+
 Datasource connections, offline synchronization, and data-quality checks can access external systems. Production deployments should apply project permissions, network restrictions, audit rules, query limits, and secret management before granting access.

--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -46,6 +46,8 @@ yak:
     authentication-enabled: true
     audit-enabled: true
     application-name: ${YAK_SECURITY_APPLICATION_NAME:${spring.application.name}}
+    authentication:
+      mode: ${YAK_SECURITY_AUTHENTICATION_MODE:satoken}
     public-paths:
       - /api/test/ping
       - /yak-security/api/v1/account/login

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
@@ -1,5 +1,6 @@
 package io.yak.ops.boot;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,6 +20,9 @@ class YakOpsApplicationTests {
 
   @Autowired
   private MockMvc mockMvc;
+
+  @Autowired
+  private Environment environment;
 
   @Test
   void testControllerShouldReturnFrameworkResult() throws Exception {
@@ -33,5 +38,12 @@ class YakOpsApplicationTests {
     mockMvc.perform(get("/v3/api-docs/yak-ops"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.paths['/api/test/ping']").exists());
+  }
+
+  @Test
+  void shouldUseSaTokenAuthenticationByDefault() {
+    assertEquals(
+        "satoken",
+        environment.getProperty("yak.security.authentication.mode"));
   }
 }


### PR DESCRIPTION
## What

Enable the Sa-Token authentication backend for the Yak Ops host application now that the Framework foundation and login-flow changes have landed.

- default `yak.security.authentication.mode` to `satoken`
- keep `YAK_SECURITY_AUTHENTICATION_MODE=session` as an explicit rollback switch
- add a boot-level configuration regression test so the host cannot silently fall back to Session
- document the authentication boundary in the root README
- keep Yak Ops free of direct `StpUtil`, `StpLogic` and `SaSession` usage

## Architecture

Yak Ops remains a consumer of `yak-security-spring-boot-starter` only:

```text
Yak Ops business code
        ↓
Yak Security abstractions
        ↓
Sa-Token authentication backend
```

Authentication is owned by Yak Security; RBAC, project, resource and menu authorization stay on the existing Yak Security APIs.

## Framework dependency

This change relies on the already merged Yak Framework work:

- `weifuwan/yak-framework#101` — Sa-Token authentication foundation
- `weifuwan/yak-framework#102` — configurable Sa-Token login flow

Install/build the latest `yak-framework:1.0.0-SNAPSHOT` containing those changes before building this branch.

## Compatibility / rollback

Sa-Token is the Yak Ops default after this PR. A deployment can temporarily roll back without code changes:

```bash
YAK_SECURITY_AUTHENTICATION_MODE=session
```

The existing account API paths and authorization contracts are unchanged, and this PR does not modify the frontend.

## Scope notes

The assembled `yak-ops-boot` runtime does not contain a custom login/session implementation; authentication is provided by the Yak Security starter. No direct Sa-Token dependency or token handling is added to Yak Ops.

The connected GitHub code-search index is currently unavailable for this repository, so I do not claim an exhaustive indexed search across every historical/unassembled source module. The migration boundary is therefore intentionally enforced by keeping this PR host-configuration-only rather than introducing framework-specific calls into business code.

## Validation

- branch is one commit ahead of `main`
- only 3 files changed
- boot configuration test asserts `yak.security.authentication.mode=satoken` by default
- no GitHub Actions workflow is present in this repository
- local Maven execution is not available in the connector environment, so this PR does not claim a completed `mvn test` run
