### PR TITLE
fix(ui): preserve original YakTab switch effect

### DIFF
--- a/yak-ops-ui/src/components/YakTab/index.less
+++ b/yak-ops-ui/src/components/YakTab/index.less
@@ -14,6 +14,7 @@
 
   > .ant-tabs-nav .ant-tabs-tab,
   > .ant-tabs-nav .ant-tabs-tab + .ant-tabs-tab {
+    position: relative;
     height: 35px;
     margin: 0 !important;
     padding: 0 0 8px;
@@ -21,6 +22,29 @@
     font-size: 13px;
     font-weight: 400;
     transition: color 0.2s ease;
+  }
+
+  // Keep the original DataCenter overviewTabs interaction: each tab owns its underline.
+  // Switching tabs shrinks the old underline and grows the new one in place,
+  // instead of sliding one shared Ant Design ink bar across tab positions.
+  > .ant-tabs-nav .ant-tabs-tab::after {
+    position: absolute;
+    right: 0;
+    bottom: -1px;
+    left: 0;
+    z-index: 1;
+    height: 2px;
+    border-radius: 999px;
+    background: #252832;
+    content: '';
+    pointer-events: none;
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  > .ant-tabs-nav .ant-tabs-tab.ant-tabs-tab-active::after {
+    transform: scaleX(1);
   }
 
   > .ant-tabs-nav .ant-tabs-tab:hover {
@@ -37,10 +61,9 @@
     text-shadow: none;
   }
 
+  // The shared Ant Design ink bar moves from one tab to another, so disable it.
   > .ant-tabs-nav .ant-tabs-ink-bar {
-    height: 2px !important;
-    background: #252832 !important;
-    border-radius: 999px;
+    display: none;
   }
 
   > .ant-tabs-nav .ant-tabs-extra-content {


### PR DESCRIPTION
## Summary
- correct the `YakTab` switch animation to match the original DataCenter `overviewTabs` behavior
- disable Ant Design's shared sliding ink bar
- give each tab its own underline indicator
- when switching, the old underline shrinks in place and the new underline grows in place; the indicator no longer moves/slides between tabs

## Scope
- only `yak-ops-ui/src/components/YakTab/index.less` changes
- all existing `YakTab` API and usages remain unchanged

## Why
The first YakTab refactor kept Ant Design's default shared ink-bar animation, which visually slides from one tab to another. The original `overviewTabs` implementation instead rendered an underline per tab with `scale-x-0 / scale-x-100`, so each underline independently disappears/appears in place. This fix restores that exact interaction model.
