### PR TITLE
refactor(ui): decouple authentication semantics from session

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -3,13 +3,15 @@ import type { Settings as LayoutSettings } from "@ant-design/pro-components";
 import { SettingDrawer } from "@ant-design/pro-components";
 import "@ant-design/v5-patch-for-react-19";
 import type { RunTimeLayoutConfig } from "@umijs/max";
-import { getLocale, history } from "@umijs/max";
+import { getLocale, history, useModel } from "@umijs/max";
+import { useEffect } from "react";
 
 import defaultSettings from "../config/defaultSettings";
 import { GlobalSearch, Knowledge } from "./components/RightContent";
 import SidebarMenuLink from "./components/SidebarMenuLink";
 import { getCurrentUser } from "./services/security/account";
 import { toCurrentUser } from "./services/security/currentIdentity";
+import { AUTHENTICATION_INVALIDATED_EVENT } from "./utils/security/authentication";
 import {
   getCurrentReturnTo,
   getSafeReturnTo,
@@ -34,6 +36,35 @@ const redirectAnonymousUser = () => {
   history.replace(`${loginPath}?returnTo=${encodeURIComponent(returnTo)}`);
 };
 
+const AuthenticationStateSync = () => {
+  const { setInitialState } = useModel("@@initialState");
+
+  useEffect(() => {
+    const clearAuthenticationState = () => {
+      void setInitialState((state) => ({
+        ...state,
+        currentUser: undefined,
+        currentProject: undefined,
+        securityProject: undefined,
+        currentUserLoadError: false,
+      }));
+    };
+
+    window.addEventListener(
+      AUTHENTICATION_INVALIDATED_EVENT,
+      clearAuthenticationState,
+    );
+    return () => {
+      window.removeEventListener(
+        AUTHENTICATION_INVALIDATED_EVENT,
+        clearAuthenticationState,
+      );
+    };
+  }, [setInitialState]);
+
+  return null;
+};
+
 /**
  * @see https://umijs.org/docs/api/runtime-config#getinitialstate
  * */
@@ -49,7 +80,7 @@ export async function getInitialState(): Promise<{
   syncDocumentLocale();
 
   const fetchUserInfo = async () => toCurrentUser(await getCurrentUser());
-  // Always probe the cookie-backed Session, including after a reload on login.
+  // Always probe cookie-backed authentication state, including after a reload on login.
   let currentUser: API.CurrentUser | undefined;
   let currentUserLoadError = false;
   try {
@@ -148,6 +179,7 @@ export const layout: RunTimeLayoutConfig = ({
       // if (initialState?.loading) return <PageLoading />;
       return (
         <>
+          <AuthenticationStateSync />
           {children}
           {isDev && (
             <SettingDrawer

--- a/yak-ops-ui/src/components/RightContent/AvatarDropdown.tsx
+++ b/yak-ops-ui/src/components/RightContent/AvatarDropdown.tsx
@@ -129,12 +129,13 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
       await logout();
     } finally {
       // Identity, grants and the selected Security project only live in memory.
-      // Clear them even if the server has already invalidated the Session.
+      // Clear them even if server-side authentication is already invalid.
       await setInitialState((state) => ({
         ...state,
         currentUser: undefined,
         currentProject: undefined,
         securityProject: undefined,
+        currentUserLoadError: false,
       }));
       history.replace('/login');
       setLoggingOut(false);

--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -23,6 +23,7 @@ export default function LoginPanel() {
         setInitialState((state: any) => ({
           ...state,
           currentUser: userInfo,
+          currentUserLoadError: false,
         }));
       });
     }

--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -25,10 +25,17 @@ describe('API response protocols', () => {
     );
   });
 
-  it('recognizes business session expiry without treating forbidden as anonymous', () => {
+  it('recognizes authentication failures without treating forbidden as anonymous', () => {
     expect(isUnauthenticatedResponse({ code: 401 }, 'yak-ops')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 401 }, 'security')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 403 }, 'security')).toBe(false);
+    expect(
+      isUnauthenticatedResponse(
+        { code: 999, message: 'UNAUTHENTICATED' },
+        'security',
+      ),
+    ).toBe(true);
+    // Keep parsing legacy backend messages while frontend state remains backend-neutral.
     expect(
       isUnauthenticatedResponse(
         { code: 999, message: 'session_expired' },

--- a/yak-ops-ui/src/services/security/account.ts
+++ b/yak-ops-ui/src/services/security/account.ts
@@ -3,9 +3,10 @@ import { securityGetData, securityPostData } from './client';
 /**
  * Yak Security AccountController contract.
  *
- * Authentication is backed by the server-side HTTP session. The shared
- * request client sends cookies with `credentials: "include"`; no bearer token
- * is returned or stored by this module.
+ * Authentication state is managed by the server and carried by cookies. The
+ * shared request client sends cookies with `credentials: "include"`; this
+ * module neither stores credentials nor depends on the server-side
+ * authentication implementation.
  */
 const ACCOUNT_API = '/api/v1/account';
 

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/dot-notation */
 import { openPrettyNotification } from "@/utils/prettyNotification";
+import { dispatchAuthenticationInvalidated } from "@/utils/security/authentication";
 import { history } from "umi";
 import { extend } from "umi-request";
 import {
@@ -23,8 +24,8 @@ const codeMessage: Record<number, string> = {
   202: "一个请求已经进入后台排队（异步任务）。",
   204: "删除数据成功。",
   400: "发出的请求有错误，服务器没有进行新建或修改数据的操作。",
-  401: "用户没有权限（令牌、用户名、密码错误）。",
-  403: "用户得到授权，但是访问是被禁止的。",
+  401: "当前请求未通过身份认证，请重新登录。",
+  403: "当前用户已登录，但没有访问该资源的权限。",
   404: "发出的请求针对的是不存在的记录，服务器没有进行操作。",
   406: "请求的格式不可得。",
   410: "请求的资源被永久删除，且不会再得到的。",
@@ -78,14 +79,14 @@ const notifyOnce = (
   openPrettyNotification(notification);
 };
 
-/** Re-arm expiry handling only after a new Session has been established. */
+/** Re-arm expiry handling only after authentication has been established. */
 export const resetAuthenticationFailure = () => {
   authenticationFailureHandled = false;
 };
 
-/** HTTP 401、业务未登录码与 Session 失效的唯一处理出口。 */
+/** HTTP 401 与业务未认证码的唯一处理出口。 */
 export const handleAuthenticationFailure = () => {
-  window.dispatchEvent(new Event("yak-security:session-expired"));
+  dispatchAuthenticationInvalidated();
   if (window.location.pathname.toLowerCase().startsWith("/login")) {
     return;
   }

--- a/yak-ops-ui/src/utils/security/authentication.ts
+++ b/yak-ops-ui/src/utils/security/authentication.ts
@@ -1,0 +1,6 @@
+export const AUTHENTICATION_INVALIDATED_EVENT =
+  'yak-security:authentication-invalidated';
+
+export const dispatchAuthenticationInvalidated = () => {
+  window.dispatchEvent(new Event(AUTHENTICATION_INVALIDATED_EVENT));
+};


### PR DESCRIPTION
## What

Phase 4 removes Servlet-Session-specific semantics from the Yak Ops frontend while keeping the existing cookie-based authentication contract unchanged.

- replace the frontend `yak-security:session-expired` event with a backend-neutral authentication invalidation event
- clear in-memory user, project and Security-project context when authentication becomes invalid
- reset `currentUserLoadError` after successful login and explicit logout so stale initialization failures do not leak into later auth state
- describe the account client as server-managed cookie authentication instead of HTTP Session authentication
- clarify 401 as unauthenticated and 403 as authenticated-but-forbidden
- keep legacy `SESSION_EXPIRED` / `SESSION_INVALID` response parsing only as server compatibility

## Authentication boundary

The frontend intentionally remains unaware of the server-side authentication implementation:

```text
Yak Ops UI
   ↓ cookie + credentials: include
Yak Security HTTP API
   ↓
server-side authentication backend
```

This PR does **not**:

- store tokens in `localStorage` or `sessionStorage`
- add an `Authorization: Bearer ...` header
- reference Sa-Token APIs or token formats
- change login/logout/current-user endpoint contracts
- change cookie transport behavior

## 401 / 403 behavior

- `401` / Yak Security unauthenticated business responses invalidate the in-memory authentication context, show the existing single expiry warning, preserve `returnTo`, and redirect to login
- `403` remains a permission failure and does not invalidate authentication or redirect to login

The response parser still recognizes historical `SESSION_EXPIRED` / `SESSION_INVALID` message values because they are wire-protocol compatibility values, not frontend Session state.

## Dependency

Builds on the already merged security migration work:

- `weifuwan/yak-framework#101`
- `weifuwan/yak-framework#102`
- `weifuwan/yak-ops#720`

## Validation

- branch is one commit ahead of current `main`
- 7 frontend files changed; no backend files changed
- existing response protocol test continues to assert that 401 is unauthenticated while 403 is not, and now also covers the generic `UNAUTHENTICATED` message
- GitHub currently reports no commit status checks for this branch
- the connector environment cannot resolve GitHub from the local container, so this PR does not claim a completed local `npm test`, `npm run tsc`, or build run
