### PR TITLE
refactor(ui): redesign data development welcome as IDE

### DIFF
--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentEditorWorkspace.tsx
@@ -1,9 +1,15 @@
 import { Button } from 'antd';
-import { Boxes, Database, Plus, RefreshCw, Sparkles } from 'lucide-react';
+import { Boxes, RefreshCw } from 'lucide-react';
 import { Component, type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { isDevelopmentTaskNode } from '../node-model';
-import type { DevelopmentDirectory, DevelopmentId, DevelopmentResourceNode } from '../types';
+import type {
+  DevelopmentDirectory,
+  DevelopmentId,
+  DevelopmentNodeType,
+  DevelopmentResourceNode,
+} from '../types';
+import DevelopmentWelcome from './DevelopmentWelcome';
 import DevelopmentWorkbench from './workbench/DevelopmentWorkbench';
 
 interface DevelopmentEditorWorkspaceProps {
@@ -11,52 +17,114 @@ interface DevelopmentEditorWorkspaceProps {
   directories: DevelopmentDirectory[];
   selectedNodeId?: DevelopmentId;
   onNodeFocus: (nodeId?: DevelopmentId) => void;
+  onCreateNode: (type: DevelopmentNodeType) => void;
   onNodesChanged?: () => void | Promise<void>;
 }
 
-class ResourceEditorBoundary extends Component<{ resourceKey: DevelopmentId; children: ReactNode }, { error?: string }> {
+class ResourceEditorBoundary extends Component<
+  { resourceKey: DevelopmentId; children: ReactNode },
+  { error?: string }
+> {
   state = {};
+
   static getDerivedStateFromError(error: unknown) {
-    return { error: error instanceof Error ? error.message : '资源编辑器发生未知错误' };
+    return {
+      error: error instanceof Error ? error.message : '资源编辑器发生未知错误',
+    };
   }
+
   componentDidUpdate(previous: { resourceKey: DevelopmentId }) {
-    if (previous.resourceKey !== this.props.resourceKey && this.state.error) this.setState({ error: undefined });
+    if (previous.resourceKey !== this.props.resourceKey && this.state.error) {
+      this.setState({ error: undefined });
+    }
   }
+
   render() {
     if (!this.state.error) return this.props.children;
-    return <div className="flex flex-1 items-center justify-center bg-white"><div className="text-center"><Boxes className="mx-auto text-[#98a2b3]" /><div className="mt-3 text-sm">资源编辑器加载异常</div><div className="mt-2 text-xs text-[#98a2b3]">{this.state.error}</div><Button className="mt-4" size="small" icon={<RefreshCw size={13} />} onClick={() => this.setState({ error: undefined })}>重新渲染</Button></div></div>;
-  }
-}
 
-function EmptyDevelopmentWorkspace() {
-  return (
-    <main className="flex min-w-0 flex-1 items-center justify-center bg-white">
-      <div className="w-[400px] text-center">
-        <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-2xl bg-[#fff1f4] text-[#fe2c55]"><Sparkles size={20} /></div>
-        <h2 className="mt-5 text-[16px] font-semibold text-[#161823]">开始你的数据开发</h2>
-        <p className="mt-2 text-[12px] leading-5 text-[#8b93a6]">SQL、Python、Shell、数据集都可以在统一工作台中创建、编辑和调试。</p>
-        <div className="mt-6 flex justify-center gap-3">
-          <button className="flex h-9 items-center gap-2 rounded-lg bg-[#fe2c55] px-4 text-sm text-white"><Plus size={14}/>创建 SQL</button>
-          <button className="flex h-9 items-center gap-2 rounded-lg border border-[#e4e7ec] px-4 text-sm text-[#344054]"><Database size={14}/>创建数据集</button>
+    return (
+      <div className="flex flex-1 items-center justify-center bg-white">
+        <div className="text-center">
+          <Boxes className="mx-auto text-[#98a2b3]" />
+          <div className="mt-3 text-sm">资源编辑器加载异常</div>
+          <div className="mt-2 text-xs text-[#98a2b3]">{this.state.error}</div>
+          <Button
+            className="mt-4"
+            size="small"
+            icon={<RefreshCw size={13} />}
+            onClick={() => this.setState({ error: undefined })}
+          >
+            重新渲染
+          </Button>
         </div>
       </div>
-    </main>
-  );
+    );
+  }
 }
 
-export default function DevelopmentEditorWorkspace({ nodes, directories, selectedNodeId, onNodeFocus, onNodesChanged }: DevelopmentEditorWorkspaceProps) {
-  const [focusedNodeId, setFocusedNodeId] = useState<DevelopmentId | undefined>(selectedNodeId);
-  useEffect(() => {
-    if (selectedNodeId && nodes.some((node) => node.id === selectedNodeId)) setFocusedNodeId(selectedNodeId);
-  }, [nodes, selectedNodeId]);
-  const effectiveNodeId = selectedNodeId && nodes.some((node) => node.id === selectedNodeId) ? selectedNodeId : focusedNodeId;
-  const selectedResource = useMemo(() => nodes.find((node) => node.id === effectiveNodeId), [effectiveNodeId, nodes]);
-  const workbenchNodes = useMemo(() => nodes.filter((node) => isDevelopmentTaskNode(node) || node.type === 'DATA_SERVICE' || node.type === 'DATASET'), [nodes]);
-  const handleNodeFocus = (nodeId?: DevelopmentId) => { setFocusedNodeId(nodeId); onNodeFocus(nodeId); };
+export default function DevelopmentEditorWorkspace({
+  nodes,
+  directories,
+  selectedNodeId,
+  onNodeFocus,
+  onCreateNode,
+  onNodesChanged,
+}: DevelopmentEditorWorkspaceProps) {
+  const [focusedNodeId, setFocusedNodeId] = useState<DevelopmentId | undefined>(
+    selectedNodeId,
+  );
 
-  if (!selectedResource) return <EmptyDevelopmentWorkspace />;
-  if (isDevelopmentTaskNode(selectedResource) || selectedResource.type === 'DATA_SERVICE' || selectedResource.type === 'DATASET') {
-    return <ResourceEditorBoundary resourceKey={selectedResource.id}><DevelopmentWorkbench nodes={workbenchNodes} directories={directories} selectedNodeId={selectedResource.id} onNodeFocus={handleNodeFocus} onNodesChanged={onNodesChanged} /></ResourceEditorBoundary>;
+  useEffect(() => {
+    if (selectedNodeId && nodes.some((node) => node.id === selectedNodeId)) {
+      setFocusedNodeId(selectedNodeId);
+    }
+  }, [nodes, selectedNodeId]);
+
+  const effectiveNodeId =
+    selectedNodeId && nodes.some((node) => node.id === selectedNodeId)
+      ? selectedNodeId
+      : focusedNodeId;
+  const selectedResource = useMemo(
+    () => nodes.find((node) => node.id === effectiveNodeId),
+    [effectiveNodeId, nodes],
+  );
+  const workbenchNodes = useMemo(
+    () =>
+      nodes.filter(
+        (node) =>
+          isDevelopmentTaskNode(node) ||
+          node.type === 'DATA_SERVICE' ||
+          node.type === 'DATASET',
+      ),
+    [nodes],
+  );
+
+  const handleNodeFocus = (nodeId?: DevelopmentId) => {
+    setFocusedNodeId(nodeId);
+    onNodeFocus(nodeId);
+  };
+
+  if (!selectedResource) {
+    return <DevelopmentWelcome onCreateNode={onCreateNode} />;
   }
+
+  if (
+    isDevelopmentTaskNode(selectedResource) ||
+    selectedResource.type === 'DATA_SERVICE' ||
+    selectedResource.type === 'DATASET'
+  ) {
+    return (
+      <ResourceEditorBoundary resourceKey={selectedResource.id}>
+        <DevelopmentWorkbench
+          nodes={workbenchNodes}
+          directories={directories}
+          selectedNodeId={selectedResource.id}
+          onNodeFocus={handleNodeFocus}
+          onNodesChanged={onNodesChanged}
+        />
+      </ResourceEditorBoundary>
+    );
+  }
+
   return null;
 }

--- a/yak-ops-ui/src/pages/data-development/components/DevelopmentWelcome.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/DevelopmentWelcome.tsx
@@ -1,0 +1,144 @@
+import {
+  Code2,
+  Database,
+  Network,
+  Sparkles,
+  TerminalSquare,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import JavaIcon from '../icon/JavaIcon';
+import PythonIcon from '../icon/PythonIcon';
+import type { DevelopmentNodeType } from '../types';
+
+interface DevelopmentWelcomeProps {
+  onCreateNode: (type: DevelopmentNodeType) => void;
+}
+
+interface QuickStartItem {
+  type: DevelopmentNodeType;
+  label: string;
+  description: string;
+  icon: ReactNode;
+}
+
+const QUICK_START_ITEMS: QuickStartItem[] = [
+  {
+    type: 'SQL',
+    label: '新建 SQL',
+    description: '编写、运行并调试 SQL',
+    icon: <Code2 size={15} strokeWidth={1.8} />,
+  },
+  {
+    type: 'PYTHON',
+    label: '新建 Python',
+    description: '创建 Python 开发任务',
+    icon: <PythonIcon size={15} />,
+  },
+  {
+    type: 'SHELL',
+    label: '新建 Shell',
+    description: '创建 Shell 脚本任务',
+    icon: <TerminalSquare size={15} strokeWidth={1.8} />,
+  },
+  {
+    type: 'JAVA',
+    label: '新建 Java',
+    description: '创建 Java 开发任务',
+    icon: <JavaIcon size={15} />,
+  },
+  {
+    type: 'DATASET',
+    label: '新建数据集',
+    description: '沉淀可复用的数据结果',
+    icon: <Database size={15} strokeWidth={1.8} />,
+  },
+  {
+    type: 'DATA_SERVICE',
+    label: '新建数据服务',
+    description: '把开发结果发布为数据服务',
+    icon: <Network size={15} strokeWidth={1.8} />,
+  },
+];
+
+const DevelopmentWelcome = ({ onCreateNode }: DevelopmentWelcomeProps) => (
+  <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+    <div className="flex h-9 shrink-0 items-end border-b border-[#e4e7ec] bg-[#f5f5f6]">
+      <div className="flex h-9 items-center gap-2 border-r border-[#e4e7ec] bg-white px-3.5 text-[12px] font-medium text-[#344054]">
+        <Sparkles size={13} className="text-[#fe2c55]" />
+        欢迎
+      </div>
+    </div>
+
+    <div className="relative min-h-0 flex-1 overflow-auto bg-white">
+      <div className="mx-auto grid w-full max-w-[960px] grid-cols-1 gap-10 px-10 pb-16 pt-14 xl:grid-cols-[minmax(0,1.15fr)_minmax(280px,.85fr)] xl:gap-16 xl:px-14 xl:pt-[11vh]">
+        <section>
+          <div className="text-[30px] font-semibold tracking-[-0.02em] text-[#161823]">
+            Yak Ops
+          </div>
+          <div className="mt-1 text-[18px] font-medium text-[#667085]">
+            数据开发工作台
+          </div>
+          <p className="mt-4 max-w-[520px] text-[13px] leading-6 text-[#8b93a6]">
+            从左侧打开开发节点，或创建一个任务开始编码。所有资源会在同一个工作台中以编辑器标签页打开。
+          </p>
+
+          <div className="mt-9 text-[13px] font-semibold text-[#344054]">快速开始</div>
+          <div className="mt-3 grid max-w-[620px] grid-cols-1 gap-x-8 gap-y-1 lg:grid-cols-2">
+            {QUICK_START_ITEMS.map((item) => (
+              <button
+                key={item.type}
+                type="button"
+                className="group flex min-h-11 items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[#f7f8fa]"
+                onClick={() => onCreateNode(item.type)}
+              >
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[#fff1f4] text-[#fe2c55] transition-colors group-hover:bg-[#ffe7ed]">
+                  {item.icon}
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-[13px] font-medium text-[#344054] group-hover:text-[#161823]">
+                    {item.label}
+                  </span>
+                  <span className="mt-0.5 block truncate text-[11px] text-[#98a2b3]">
+                    {item.description}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <aside className="pt-1">
+          <div className="text-[13px] font-semibold text-[#344054]">工作台</div>
+          <div className="mt-4 space-y-5 text-[12px] leading-5 text-[#667085]">
+            <div>
+              <div className="font-medium text-[#475467]">统一编辑</div>
+              <div className="mt-1 text-[#98a2b3]">
+                SQL、Python、Shell、Java、数据集和数据服务在同一开发目录中管理。
+              </div>
+            </div>
+            <div>
+              <div className="font-medium text-[#475467]">多标签工作区</div>
+              <div className="mt-1 text-[#98a2b3]">
+                打开的资源会保留为编辑器标签，可以像 IDE 一样连续切换和开发。
+              </div>
+            </div>
+            <div>
+              <div className="font-medium text-[#475467]">从目录开始</div>
+              <div className="mt-1 text-[#98a2b3]">
+                也可以直接从左侧开发目录选择已有节点，进入对应编辑器继续工作。
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div className="absolute inset-x-0 bottom-0 flex h-6 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-2.5 text-[10px] text-[#8b93a6]">
+        <span>Yak Ops · Data Development</span>
+        <span>就绪</span>
+      </div>
+    </div>
+  </main>
+);
+
+export default DevelopmentWelcome;

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -372,6 +372,10 @@ export default function DataDevelopmentPage() {
             directories={directories}
             selectedNodeId={selectedResourceNodeId}
             onNodeFocus={(nodeId) => setSelectedNodeKey(nodeId ? nodeKey(nodeId) : undefined)}
+            onCreateNode={(type) => {
+              setCreateType(type);
+              setCreateOpen(true);
+            }}
             onNodesChanged={loadTree}
           />
         </div>


### PR DESCRIPTION
## Summary
- replace the old centered marketing-style empty state with an IDE-style welcome workspace
- add a lightweight editor tab strip with a `欢迎` tab so the empty state visually belongs to the same editor system
- rewrite the welcome copy to be shorter and task-oriented: open a node from the left tree or create a development resource
- add functional quick-start actions for SQL, Python, Shell, Java, Dataset and Data Service
- keep the visual language aligned with Yak Ops light theme instead of copying VS Code dark mode directly
- add a small IDE-style status bar at the bottom of the empty workspace

## UX direction
The key change is structural rather than decorative: the right side is now treated as an editor workspace from the first screen, instead of a large blank canvas with a floating CTA card.

## Scope
- frontend only
- no backend API or editor lifecycle changes
- existing create modal and resource creation flow are reused
- 3 files changed, with one new reusable `DevelopmentWelcome` component

## Validation
- branch is based on latest `main`
- changes are squashed into one commit
- existing `DevelopmentWorkbench` API remains unchanged
