### PR TITLE
refactor(ui): unify Ant Design default buttons as text actions

### DIFF
--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -203,6 +203,51 @@ ol {
   background: rgba(0, 0, 0, 0.55)
 }
 
+// Global Ant Design secondary actions use the same lightweight text-button
+// language as the compact refresh action: no outlined white box by default,
+// with a neutral hover surface. Explicit primary/link/text hierarchy is kept.
+.ant-btn-default {
+  background: transparent !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.ant-btn-default:not(.ant-btn-dangerous) {
+  color: #344054 !important;
+}
+
+.ant-btn-default:not(:disabled):not(.ant-btn-disabled):not(.ant-btn-dangerous):hover,
+.ant-btn-default:not(:disabled):not(.ant-btn-disabled):not(.ant-btn-dangerous):active {
+  color: #161823 !important;
+  border-color: transparent !important;
+}
+
+.ant-btn-default:not(:disabled):not(.ant-btn-disabled):hover {
+  background: #f5f5f6 !important;
+}
+
+.ant-btn-default:not(:disabled):not(.ant-btn-disabled):active {
+  background: #eaecf0 !important;
+}
+
+.ant-btn-default.ant-btn-dangerous:not(:disabled):not(.ant-btn-disabled):hover,
+.ant-btn-default.ant-btn-dangerous:not(:disabled):not(.ant-btn-disabled):active {
+  border-color: transparent !important;
+  background: rgba(254, 44, 85, 0.06) !important;
+}
+
+.ant-btn-default:focus-visible {
+  outline: 2px solid rgba(254, 44, 85, 0.16);
+  outline-offset: 1px;
+}
+
+.ant-btn-default:disabled,
+.ant-btn-default.ant-btn-disabled {
+  background: transparent !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
 // Data development tree: keep the compact, polished density used by Chat2DB.
 .development-tree.ant-tree {
   font-size: 13px;


### PR DESCRIPTION
## Summary
- globally restyle Ant Design default buttons to use the same lightweight text-button visual language as the compact refresh action
- remove the default white fill, border, and shadow from secondary/default buttons
- use neutral hover/active surfaces while keeping button labels dark
- keep destructive default buttons borderless with a very light brand-red hover surface
- preserve explicit primary, link, and text button hierarchy

## Scope
- frontend only
- only `yak-ops-ui/src/global.less` changes
- no button click behavior or business logic changes
- current and future default Ant Design `<Button>` usage picks up the style automatically

## Validation
- branch is based on latest `main`
- one commit, one file changed
- primary actions remain unchanged
