### PR TITLE
feat(auth): enable login session governance

### DIFF
--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -38,6 +38,17 @@ springdoc:
     operations-sorter: alpha
     tags-sorter: alpha
 
+# Sa-Token 原生登录态治理。Yak Ops 不直接依赖 Sa-Token API，只通过配置控制行为。
+sa-token:
+  # 绝对登录有效期，单位秒；默认 24 小时。
+  timeout: ${YAK_SECURITY_LOGIN_TIMEOUT_SECONDS:86400}
+  # 是否允许同一账号多终端同时在线。
+  is-concurrent: ${YAK_SECURITY_LOGIN_CONCURRENT:true}
+  # 多终端登录时不共享 Token，便于独立失效和治理。
+  is-share: ${YAK_SECURITY_LOGIN_SHARE:false}
+  # 同一账号最大同时登录数量；-1 表示不限。
+  max-login-count: ${YAK_SECURITY_MAX_LOGIN_COUNT:5}
+
 yak:
   security:
     enabled: true
@@ -48,6 +59,17 @@ yak:
     application-name: ${YAK_SECURITY_APPLICATION_NAME:${spring.application.name}}
     authentication:
       mode: ${YAK_SECURITY_AUTHENTICATION_MODE:satoken}
+      # 本地默认内存；多实例生产环境设置为 redis。
+      storage: ${YAK_SECURITY_AUTHENTICATION_STORAGE:memory}
+      redis:
+        host: ${YAK_SECURITY_REDIS_HOST:127.0.0.1}
+        port: ${YAK_SECURITY_REDIS_PORT:6379}
+        password: ${YAK_SECURITY_REDIS_PASSWORD:}
+        database: ${YAK_SECURITY_REDIS_DATABASE:0}
+        max-total: ${YAK_SECURITY_REDIS_MAX_TOTAL:64}
+    # 无操作超时；Sa-Token 模式映射为 activeTimeout。
+    session:
+      timeout: ${YAK_SECURITY_SESSION_TIMEOUT:30m}
     public-paths:
       - /api/test/ping
       - /yak-security/api/v1/account/login

--- a/yak-ops-ui/src/pages/system/users/components/UserRowActions.tsx
+++ b/yak-ops-ui/src/pages/system/users/components/UserRowActions.tsx
@@ -4,6 +4,7 @@ import {
   EditOutlined,
   EyeOutlined,
   KeyOutlined,
+  LogoutOutlined,
   SafetyCertificateOutlined,
 } from '@ant-design/icons';
 import {
@@ -19,10 +20,9 @@ import { SECURITY_PERMISSIONS } from '@/constants/securityPermissions';
 import { usePermissionAccess } from '@/hooks/usePermissionAccess';
 import {
   deleteUser as deleteSystemUser,
+  forceLogoutUser,
   type SystemUser,
 } from '@/services/security/users';
-
-import { errorText } from '../shared';
 
 interface UserRowActionsProps {
   user: SystemUser;
@@ -34,7 +34,11 @@ interface UserRowActionsProps {
   onDeleted: () => void;
 }
 
-type ActionKey = 'assignRole' | 'resetPassword' | 'delete';
+type ActionKey =
+  | 'assignRole'
+  | 'resetPassword'
+  | 'forceLogout'
+  | 'delete';
 
 export default function UserRowActions({
   user,
@@ -58,14 +62,9 @@ export default function UserRowActions({
   const remove = async () => {
     if (!canDelete) return;
 
-    try {
-      await deleteSystemUser(user.id);
-      message.success('用户已删除');
-      onDeleted();
-    } catch (error) {
-      
-      throw error;
-    }
+    await deleteSystemUser(user.id);
+    message.success('用户已删除');
+    onDeleted();
   };
 
   const confirmDelete = () => {
@@ -92,6 +91,30 @@ export default function UserRowActions({
     });
   };
 
+  const confirmForceLogout = () => {
+    if (!canEdit || isCurrentUser) return;
+
+    Modal.confirm({
+      title: '强制下线用户',
+      content: (
+        <div>
+          确定让用户
+          <span className="mx-1 font-medium text-slate-900">
+            {user.realName || user.userName}
+          </span>
+          的全部登录终端立即失效吗？
+        </div>
+      ),
+      okText: '强制下线',
+      cancelText: '取消',
+      centered: true,
+      onOk: async () => {
+        await forceLogoutUser(user.id);
+        message.success('用户已强制下线');
+      },
+    });
+  };
+
   const menuItems: NonNullable<MenuProps['items']> = [];
 
   if (canAssignRole) {
@@ -107,6 +130,15 @@ export default function UserRowActions({
       key: 'resetPassword',
       icon: <KeyOutlined />,
       label: '重置密码',
+    });
+  }
+
+  if (canEdit) {
+    menuItems.push({
+      key: 'forceLogout',
+      icon: <LogoutOutlined />,
+      label: '强制下线',
+      disabled: isCurrentUser,
     });
   }
 
@@ -131,6 +163,9 @@ export default function UserRowActions({
         break;
       case 'resetPassword':
         if (canResetPassword) onResetPassword(user);
+        break;
+      case 'forceLogout':
+        confirmForceLogout();
         break;
       case 'delete':
         confirmDelete();

--- a/yak-ops-ui/src/services/security/users.ts
+++ b/yak-ops-ui/src/services/security/users.ts
@@ -159,6 +159,18 @@ export const deleteUser = (
   );
 
 /**
+ * 强制下线指定用户的全部登录终端。
+ */
+export const forceLogoutUser = (
+  userId: number,
+): Promise<void> =>
+  securityPostData<void>(
+    `${USER_API}/${encodeURIComponent(
+      String(userId),
+    )}/logout`,
+  );
+
+/**
  * 校验用户名、手机号或邮箱是否可用。
  */
 export const checkUserField = (


### PR DESCRIPTION
## Summary

- configure Sa-Token absolute lifetime, inactivity timeout, concurrent login, token sharing and maximum login count
- expose memory/Redis login-state storage through environment variables
- add a User Management “强制下线” action backed by Yak Security account-level logout
- keep cookie-based frontend authentication and the existing RBAC boundary unchanged

## Production

For multi-instance deployments configure shared login state, for example:

```bash
YAK_SECURITY_AUTHENTICATION_STORAGE=redis
YAK_SECURITY_REDIS_HOST=127.0.0.1
YAK_SECURITY_REDIS_PORT=6379
YAK_SECURITY_REDIS_PASSWORD=...
```

Defaults remain local-development friendly: memory storage, 30-minute inactivity timeout, 24-hour absolute lifetime, and at most 5 simultaneous login states.

## Dependency

Requires the matching `yak-framework` stage-5 PR: https://github.com/weifuwan/yak-framework/pull/105
