### PR TITLE
refactor(ui): standardize non-primary Ant Design buttons

### DIFF
--- a/yak-ops-ui/src/components/SqlCodeEditor/index.tsx
+++ b/yak-ops-ui/src/components/SqlCodeEditor/index.tsx
@@ -680,7 +680,7 @@ export default function SqlCodeEditor({
           <Button
             type="text"
             size="small"
-            className="sql-code-editor__expand-btn"
+            className="sql-code-editor__expand-btn !text-[#667085]"
             icon={<Maximize2 size={14} />}
             aria-label="展开 SQL 编辑器"
             title="展开编辑"
@@ -701,7 +701,13 @@ export default function SqlCodeEditor({
           onCancel={handleCancelFullscreen}
           footer={
             <div className="sql-code-editor-modal__footer">
-              <Button onClick={handleCancelFullscreen}>取消</Button>
+              <Button
+                type="text"
+                className="!text-[#667085]"
+                onClick={handleCancelFullscreen}
+              >
+                取消
+              </Button>
               <Button type="primary" onClick={handleApplyFullscreen}>
                 应用
               </Button>

--- a/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
+++ b/yak-ops-ui/src/components/analysis/AnalysisPreview.tsx
@@ -464,7 +464,7 @@ function AnalysisPreviewContent({
       <div className={`${className} flex items-center justify-center px-5 text-center`} style={themedStyle}>
         <div>
           <div className="text-[11px] text-[#b42318]">{error}</div>
-          <Button size="small" type="text" className="mt-2 !h-7 !text-[10px]" onClick={retry}>
+          <Button size="small" type="text" className="mt-2 !h-7 !text-[10px] !text-[#667085]" onClick={retry}>
             重新查询
           </Button>
         </div>

--- a/yak-ops-ui/src/components/analysis/analysis-error-boundary.tsx
+++ b/yak-ops-ui/src/components/analysis/analysis-error-boundary.tsx
@@ -52,7 +52,8 @@ export class AnalysisErrorBoundary extends Component<Props, State> {
           </div>
           <Button
             size="small"
-            className="mt-3 !h-7 !rounded-[6px]"
+            type="text"
+            className="mt-3 !h-7 !rounded-[6px] !text-[#667085]"
             icon={<RotateCcw size={11} />}
             onClick={this.retry}
           >

--- a/yak-ops-ui/src/components/security/AssignmentDrawer/index.tsx
+++ b/yak-ops-ui/src/components/security/AssignmentDrawer/index.tsx
@@ -135,6 +135,8 @@ export default function AssignmentDrawer(
       extra={
         <Space>
           <Button
+            type="text"
+            className="!text-[#667085]"
             disabled={submitting}
             onClick={onClose}
           >
@@ -167,6 +169,7 @@ export default function AssignmentDrawer(
           <Button
             type="text"
             size="small"
+            className="!text-[#667085]"
             onClick={() => setSelected([])}
           >
             清空

--- a/yak-ops-ui/src/global.less
+++ b/yak-ops-ui/src/global.less
@@ -203,51 +203,6 @@ ol {
   background: rgba(0, 0, 0, 0.55)
 }
 
-// Global Ant Design secondary actions use the same lightweight text-button
-// language as the compact refresh action: no outlined white box by default,
-// with a neutral hover surface. Explicit primary/link/text hierarchy is kept.
-.ant-btn-default {
-  background: transparent !important;
-  border-color: transparent !important;
-  box-shadow: none !important;
-}
-
-.ant-btn-default:not(.ant-btn-dangerous) {
-  color: #344054 !important;
-}
-
-.ant-btn-default:not(:disabled):not(.ant-btn-disabled):not(.ant-btn-dangerous):hover,
-.ant-btn-default:not(:disabled):not(.ant-btn-disabled):not(.ant-btn-dangerous):active {
-  color: #161823 !important;
-  border-color: transparent !important;
-}
-
-.ant-btn-default:not(:disabled):not(.ant-btn-disabled):hover {
-  background: #f5f5f6 !important;
-}
-
-.ant-btn-default:not(:disabled):not(.ant-btn-disabled):active {
-  background: #eaecf0 !important;
-}
-
-.ant-btn-default.ant-btn-dangerous:not(:disabled):not(.ant-btn-disabled):hover,
-.ant-btn-default.ant-btn-dangerous:not(:disabled):not(.ant-btn-disabled):active {
-  border-color: transparent !important;
-  background: rgba(254, 44, 85, 0.06) !important;
-}
-
-.ant-btn-default:focus-visible {
-  outline: 2px solid rgba(254, 44, 85, 0.16);
-  outline-offset: 1px;
-}
-
-.ant-btn-default:disabled,
-.ant-btn-default.ant-btn-disabled {
-  background: transparent !important;
-  border-color: transparent !important;
-  box-shadow: none !important;
-}
-
 // Data development tree: keep the compact, polished density used by Chat2DB.
 .development-tree.ant-tree {
   font-size: 13px;

--- a/yak-ops-ui/src/pages/alarm/components/AddOrEditChannelModal.tsx
+++ b/yak-ops-ui/src/pages/alarm/components/AddOrEditChannelModal.tsx
@@ -18,9 +18,6 @@ import {
 
 const {TextArea} = Input;
 
-/**
- * 解析通道配置 JSON。
- */
 function parseConfigJson(
   configJson?: string,
 ): Record<string, unknown> {
@@ -45,9 +42,6 @@ function parseConfigJson(
   }
 }
 
-/**
- * 将后端动态表单校验规则转换为 Ant Design Form Rule。
- */
 function toAntdRules(
   rules?: FormFieldRule[],
 ): Rule[] | undefined {
@@ -80,9 +74,6 @@ function toAntdRules(
   });
 }
 
-/**
- * 根据后端下发的字段类型渲染表单控件。
- */
 function renderFormControl(field: FormFieldConfig) {
   switch (field.type) {
     case 'PASSWORD':
@@ -154,9 +145,6 @@ interface ChannelTypeSelectorProps {
   onSelect: (type: ChannelTypeVO) => void;
 }
 
-/**
- * 新建通道时的类型选择区域。
- */
 const ChannelTypeSelector: React.FC<ChannelTypeSelectorProps> = ({
                                                                    channelTypes,
                                                                    loading,
@@ -298,9 +286,6 @@ const AddOrEditChannelModal =
     const isCreateMode =
       operateType === AlarmOperateType.Create;
 
-    /**
-     * 清空抽屉内部状态。
-     */
     const resetState = () => {
       setCurrentRecord(undefined);
       setSelectedType(null);
@@ -312,9 +297,6 @@ const AddOrEditChannelModal =
       configForm.resetFields();
     };
 
-    /**
-     * 关闭抽屉。
-     */
     const handleClose = () => {
       if (confirmLoading || testing) {
         return;
@@ -323,10 +305,6 @@ const AddOrEditChannelModal =
       setOpen(false);
     };
 
-    /**
-     * 抽屉关闭动画完成后再清空表单。
-     * 避免关闭过程中内容突然消失。
-     */
     const handleAfterOpenChange = (
       nextOpen: boolean,
     ) => {
@@ -335,9 +313,6 @@ const AddOrEditChannelModal =
       }
     };
 
-    /**
-     * 获取后端 SPI 下发的通道类型。
-     */
     const ensureChannelTypes =
       async (): Promise<ChannelTypeVO[]> => {
         if (channelTypes.length > 0) {
@@ -388,9 +363,6 @@ const AddOrEditChannelModal =
 
         const types = await ensureChannelTypes();
 
-        /**
-         * 编辑模式直接进入配置表单。
-         */
         if (
           nextOperateType ===
           AlarmOperateType.Edit &&
@@ -435,9 +407,6 @@ const AddOrEditChannelModal =
           return;
         }
 
-        /**
-         * 新建模式先选择通道类型。
-         */
         setSelectedType(null);
         setShowFormStep(false);
       },
@@ -445,9 +414,6 @@ const AddOrEditChannelModal =
       close: handleClose,
     }));
 
-    /**
-     * 选择通道类型。
-     */
     const handleSelectType = (
       type: ChannelTypeVO,
     ) => {
@@ -462,9 +428,6 @@ const AddOrEditChannelModal =
       setShowFormStep(true);
     };
 
-    /**
-     * 返回通道类型选择。
-     */
     const handlePrevious = () => {
       if (confirmLoading || testing) {
         return;
@@ -477,9 +440,6 @@ const AddOrEditChannelModal =
       configForm.resetFields();
     };
 
-    /**
-     * 新建通道时设置动态字段默认值。
-     */
     useEffect(() => {
       if (
         !showFormStep ||
@@ -512,9 +472,6 @@ const AddOrEditChannelModal =
       showFormStep,
     ]);
 
-    /**
-     * 测试通道配置。
-     */
     const handleTest = async () => {
       if (!selectedType) {
         message.error('请先选择告警通道类型');
@@ -560,9 +517,6 @@ const AddOrEditChannelModal =
       }
     };
 
-    /**
-     * 保存通道。
-     */
     const handleSubmit = async () => {
       if (!selectedType) {
         message.error('请先选择告警通道类型');
@@ -675,7 +629,6 @@ const AddOrEditChannelModal =
         }}
       >
         <div className="flex h-full min-h-0 flex-col bg-white">
-          {/* 自定义抽屉头部 */}
           <header
             className={[
               'flex min-h-[76px] shrink-0',
@@ -749,13 +702,14 @@ const AddOrEditChannelModal =
                 <>
                   <Button
                     size="small"
+                    type="text"
                     icon={
                       <FlaskConical className="h-3.5 w-3.5"/>
                     }
                     loading={testing}
                     disabled={confirmLoading}
                     onClick={handleTest}
-                    className="rounded-lg"
+                    className="rounded-lg !text-[#667085]"
                   >
                     <span className="hidden sm:inline">
                       测试
@@ -803,13 +757,11 @@ const AddOrEditChannelModal =
             </div>
           </header>
 
-          {/* 抽屉内容 */}
           <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
             <Spin spinning={loadingTypes}>
               {showFormStep &&
               selectedType ? (
                 <>
-                  {/* 基本信息 */}
                   <section className="border-b border-slate-100 pb-6">
                     <div className="mb-5">
                       <h3 className="m-0 text-sm font-semibold text-slate-950">
@@ -890,7 +842,6 @@ const AddOrEditChannelModal =
                     </Form>
                   </section>
 
-                  {/* 动态通道配置 */}
                   <section className="pt-6">
                     <div className="mb-5 flex items-start justify-between gap-4">
                       <div>

--- a/yak-ops-ui/src/pages/alarm/components/ChannelTab.tsx
+++ b/yak-ops-ui/src/pages/alarm/components/ChannelTab.tsx
@@ -279,7 +279,7 @@ const ChannelTab: React.FC<ChannelTabProps> = ({keyword = ''}) => {
                         icon={<ThunderboltOutlined/>}
                         loading={testing}
                         onClick={() => handleTest(channel)}
-                        className="text-slate-500"
+                        className="!text-[#667085]"
                       >
                         测试
                       </Button>
@@ -289,7 +289,7 @@ const ChannelTab: React.FC<ChannelTabProps> = ({keyword = ''}) => {
                         size="small"
                         icon={<EditOutlined/>}
                         onClick={() => handleEdit(channel)}
-                        className="text-slate-500"
+                        className="!text-[#667085]"
                       >
                         编辑
                       </Button>
@@ -299,6 +299,7 @@ const ChannelTab: React.FC<ChannelTabProps> = ({keyword = ''}) => {
                         size="small"
                         danger
                         icon={<DeleteOutlined/>}
+                        className="!text-[#667085]"
                         onClick={() => handleDelete(channel)}
                       >
                         删除

--- a/yak-ops-ui/src/pages/batch-link-up/FilterConditions.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/FilterConditions.tsx
@@ -127,6 +127,7 @@ export const FilterConditions: React.FC<FilterConditionsProps> = ({
               <Button
                 size="small"
                 type="text"
+                className="!text-[#667085]"
                 onClick={() => toggleLogicalOperator(index)}
                 style={{
                   minWidth: 30,
@@ -135,14 +136,26 @@ export const FilterConditions: React.FC<FilterConditionsProps> = ({
                 {condition.logicalOperator}
               </Button>
             )}
-            <Button size="small" type="text" danger onClick={() => removeCondition(index)}>
+            <Button
+              size="small"
+              type="text"
+              danger
+              className="!text-[#667085]"
+              onClick={() => removeCondition(index)}
+            >
               删除
             </Button>
           </div>
         );
       })}
 
-      <Button size="small" type="dashed" onClick={addCondition} style={{ width: 'fit-content' }}>
+      <Button
+        size="small"
+        type="text"
+        className="!text-[#667085]"
+        onClick={addCondition}
+        style={{ width: 'fit-content' }}
+      >
         + 添加条件
       </Button>
     </div>

--- a/yak-ops-ui/src/pages/batch-link-up/FilterTimeConditions.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/FilterTimeConditions.tsx
@@ -107,6 +107,7 @@ export const FilterTimeConditions: React.FC<FilterConditionsProps> = ({
               <Button
                 size="small"
                 type="text"
+                className="!text-[#667085]"
                 onClick={() => toggleLogicalOperator(index)}
                 style={{
                   minWidth: 30,
@@ -115,14 +116,26 @@ export const FilterTimeConditions: React.FC<FilterConditionsProps> = ({
                 {condition.logicalOperator}
               </Button>
             )}
-            <Button size="small" type="text" danger onClick={() => removeCondition(index)}>
+            <Button
+              size="small"
+              type="text"
+              danger
+              className="!text-[#667085]"
+              onClick={() => removeCondition(index)}
+            >
               删除
             </Button>
           </div>
         );
       })}
 
-      <Button size="small" type="dashed" onClick={addCondition} style={{ width: 'fit-content' }}>
+      <Button
+        size="small"
+        type="text"
+        className="!text-[#667085]"
+        onClick={addCondition}
+        style={{ width: 'fit-content' }}
+      >
         + 添加时间条件
       </Button>
     </div>

--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskModal.tsx
@@ -247,9 +247,10 @@ export default function CreateSyncTaskDrawer({
         extra={
           <div className="flex shrink-0 items-center gap-2">
             <Button
+              type="text"
               disabled={submitting}
               onClick={handleCancel}
-              className="!h-9 !rounded-lg !px-4 !font-medium"
+              className="!h-9 !rounded-lg !px-4 !font-medium !text-[#667085]"
             >
               取消
             </Button>

--- a/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/ActionColumn.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/ActionColumn.tsx
@@ -266,10 +266,10 @@ const ActionColumn: React.FC<ActionColumnProps> = ({ record, cbk, goDetail }) =>
         >
           <Button
             size="small"
-            color="danger"
-            variant="filled"
+            type="text"
+            danger
             icon={<PauseCircleOutlined />}
-            className="!h-7 !rounded-md !px-2.5 !text-xs"
+            className="!h-7 !rounded-md !px-2.5 !text-xs !text-[#667085]"
             onClick={stopPropagation}
           >
             停止
@@ -295,13 +295,12 @@ const ActionColumn: React.FC<ActionColumnProps> = ({ record, cbk, goDetail }) =>
           >
             <Button
               size="small"
-              color={canRun ? 'primary' : 'default'}
-              variant="filled"
+              type="text"
               loading={runLoading}
               aria-disabled={!canRun}
               icon={<PlayCircleOutlined />}
               className={[
-                '!h-7 !rounded-md !px-2.5 !text-xs',
+                '!h-7 !rounded-md !px-2.5 !text-xs !text-[#667085]',
                 !canRun ? '!cursor-not-allowed !text-[#98a2b3]' : '',
               ].join(' ')}
               onClick={stopPropagation}
@@ -319,8 +318,7 @@ const ActionColumn: React.FC<ActionColumnProps> = ({ record, cbk, goDetail }) =>
       >
         <Button
           size="small"
-          color="default"
-          variant="text"
+          type="text"
           className="!h-7 !rounded-md !px-2 !text-xs !text-[#667085]"
           onClick={stopPropagation}
         >

--- a/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/AdvancedSearchForm.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/SyncTaskList/components/AdvancedSearchForm.tsx
@@ -243,8 +243,9 @@ const AdvancedSearchForm: React.FC<AdvancedSearchFormProps> = ({
                 </Button>
 
                 <Button
+                  type="text"
                   onClick={handleReset}
-                  className="h-8 rounded-full border-slate-200 px-5 text-slate-600 hover:!border-slate-300 hover:!text-slate-900"
+                  className="h-8 rounded-full px-5 !text-[#667085]"
                 >
                   {intl.formatMessage({
                     id: "pages.job.search.button.reset",

--- a/yak-ops-ui/src/pages/client/components/ClientDetailPanel.tsx
+++ b/yak-ops-ui/src/pages/client/components/ClientDetailPanel.tsx
@@ -149,15 +149,14 @@ const ClientDetailPanel: React.FC<Props> = ({
             </div>
 
             <Button
+              type="text"
               icon={<ReloadOutlined/>}
               loading={metricsLoading}
               onClick={() => onRefresh(selectedClientId)}
               className="
-        h-10 rounded-full border-[#E4E7EC] px-4
-        text-[13px] font-medium text-[#475467]
-        shadow-[0_2px_8px_rgba(16,24,40,0.04)]
+        h-10 rounded-full px-4
+        text-[13px] font-medium !text-[#667085]
         transition-all duration-200
-        hover:!border-[#CBD5E1] hover:!text-[#344054]
       "
             >
               刷新指标

--- a/yak-ops-ui/src/pages/client/components/ClientListPanel.tsx
+++ b/yak-ops-ui/src/pages/client/components/ClientListPanel.tsx
@@ -131,7 +131,7 @@ const ClientListPanel: React.FC<Props> = ({
                       danger
                       icon={<DeleteOutlined/>}
                       loading={deleting}
-                      className="!flex !h-7 !w-7 !items-center !justify-center !rounded-lg hover:!bg-[#FFF1F0]"
+                      className="!flex !h-7 !w-7 !items-center !justify-center !rounded-lg !text-[#667085] hover:!bg-[#FFF1F0]"
                     />
                   </Tooltip>
                 </Popconfirm>

--- a/yak-ops-ui/src/pages/data-development/components/ResourcePicker.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/ResourcePicker.tsx
@@ -209,9 +209,9 @@ export default function ResourcePicker({
       {/* Breadcrumb */}
       <div className="mb-2 flex items-center gap-1 text-[12px]">
         <Button
-          type="link"
+          type="text"
           size="small"
-          className="px-1"
+          className="px-1 !text-[#667085]"
           disabled={breadcrumbs.length === 0}
           onClick={() => handleBreadcrumbClick(-1)}
         >
@@ -221,9 +221,9 @@ export default function ResourcePicker({
           <span key={String(bc.id)} className="flex items-center gap-1">
             <span className="text-[#98a2b3]">/</span>
             <Button
-              type="link"
+              type="text"
               size="small"
-              className="px-1"
+              className="px-1 !text-[#667085]"
               disabled={index === breadcrumbs.length - 1}
               onClick={() => handleBreadcrumbClick(index)}
             >

--- a/yak-ops-ui/src/pages/data-development/editors/java/JavaEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/java/JavaEditor.tsx
@@ -174,7 +174,9 @@ export const JavaEditor = ({ node }: DevelopmentEditorContext) => {
                 </div>
                 <Button
                   size="small"
+                  type="text"
                   danger
+                  className="!text-[#667085]"
                   icon={<Trash2 size={14} />}
                   onClick={() => handleRemoveResource(index)}
                 />
@@ -185,9 +187,9 @@ export const JavaEditor = ({ node }: DevelopmentEditorContext) => {
 
         {/* 添加 JAR 按钮 */}
         <Button
-          type="dashed"
+          type="text"
           icon={<Plus size={14} />}
-          className="w-full"
+          className="w-full !text-[#667085]"
           onClick={() => setPickerOpen(true)}
         >
           添加 JAR 文件

--- a/yak-ops-ui/src/pages/data-development/editors/python/PythonEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/python/PythonEditor.tsx
@@ -194,12 +194,16 @@ export const PythonEditor = ({
                 </div>
                 <Button
                   size="small"
+                  type="text"
+                  className="!text-[#667085]"
                   icon={<Upload size={14} />}
                   onClick={() => setPickerOpen(true)}
                 />
                 <Button
                   size="small"
+                  type="text"
                   danger
+                  className="!text-[#667085]"
                   icon={<Trash2 size={14} />}
                   onClick={handleClearResource}
                 />

--- a/yak-ops-ui/src/pages/data-development/editors/shell/ShellEditor.tsx
+++ b/yak-ops-ui/src/pages/data-development/editors/shell/ShellEditor.tsx
@@ -194,12 +194,16 @@ export const ShellEditor = ({
                 </div>
                 <Button
                   size="small"
+                  type="text"
+                  className="!text-[#667085]"
                   icon={<Upload size={14} />}
                   onClick={() => setPickerOpen(true)}
                 />
                 <Button
                   size="small"
+                  type="text"
                   danger
+                  className="!text-[#667085]"
                   icon={<Trash2 size={14} />}
                   onClick={handleClearResource}
                 />

--- a/yak-ops-ui/src/pages/data-quality/execution/components/ExecutionRecordTable.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/components/ExecutionRecordTable.tsx
@@ -144,8 +144,9 @@ const ExecutionRecordTable = ({
         render: (_, record) => (
           <div className="flex items-center">
             <Button
-              type="link"
+              type="text"
               size="small"
+              className="!text-[#667085]"
               onClick={(event) => {
                 event.stopPropagation();
                 onOpenExecution(record.executionNo);
@@ -154,8 +155,9 @@ const ExecutionRecordTable = ({
               详情
             </Button>
             <Button
-              type="link"
+              type="text"
               size="small"
+              className="!text-[#667085]"
               onClick={(event) => {
                 event.stopPropagation();
                 onOpenMonitor(record.monitorId);
@@ -278,8 +280,9 @@ const ExecutionRecordTable = ({
         render: (_, record) => (
           <div className="flex items-center">
             <Button
-              type="link"
+              type="text"
               size="small"
+              className="!text-[#667085]"
               onClick={(event) => {
                 event.stopPropagation();
                 onOpenExecution(record.executionNo);
@@ -288,8 +291,9 @@ const ExecutionRecordTable = ({
               详情
             </Button>
             <Button
-              type="link"
+              type="text"
               size="small"
+              className="!text-[#667085]"
               onClick={(event) => {
                 event.stopPropagation();
                 onOpenMonitor(record.monitorId);

--- a/yak-ops-ui/src/pages/data-quality/execution/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/index.tsx
@@ -388,7 +388,12 @@ const ExecutionPage = () => {
       </div>
 
       <div className="mt-4 flex justify-end gap-2 border-t border-[#f0f1f3] pt-3">
-        <Button size="small" onClick={reset}>
+        <Button
+          size="small"
+          type="text"
+          className="!text-[#667085]"
+          onClick={reset}
+        >
           重置
         </Button>
         <Button size="small" type="primary" onClick={applyAdvancedSearch}>
@@ -462,7 +467,13 @@ const ExecutionPage = () => {
                     }}
                   />
 
-                  <Button onClick={applySearch}>查询</Button>
+                  <Button
+                    type="text"
+                    className="!text-[#667085]"
+                    onClick={applySearch}
+                  >
+                    查询
+                  </Button>
 
                   <Popover
                     trigger="click"
@@ -471,13 +482,19 @@ const ExecutionPage = () => {
                     onOpenChange={setAdvancedOpen}
                     content={advancedSearchContent}
                   >
-                    <Button icon={<ListFilter size={14} />}>
+                    <Button
+                      type="text"
+                      className="!text-[#667085]"
+                      icon={<ListFilter size={14} />}
+                    >
                       高级筛选
                       {advancedFilterCount ? ` (${advancedFilterCount})` : ''}
                     </Button>
                   </Popover>
 
                   <Button
+                    type="text"
+                    className="!text-[#667085]"
                     aria-label="刷新"
                     icon={<RefreshCw size={14} />}
                     onClick={() => void load(current, pageSize)}

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/MonitorListTab.tsx
@@ -234,11 +234,11 @@ const MonitorListTab = ({
       render: () => (
         <div className="flex items-center gap-3">
           <Button
-            type="link"
+            type="text"
             size="small"
             loading={running}
             onClick={onRun}
-            className="!h-auto !p-0"
+            className="!h-auto !p-0 !text-[#667085]"
           >
             {running ? '提交中' : '测试运行'}
           </Button>
@@ -249,7 +249,7 @@ const MonitorListTab = ({
               size="small"
               aria-label="更多操作"
               icon={<MoreHorizontal size={15} />}
-              className="!h-7 !w-7 !px-0"
+              className="!h-7 !w-7 !px-0 !text-[#667085]"
             />
           </Dropdown>
         </div>
@@ -289,7 +289,12 @@ const MonitorListTab = ({
       </div>
 
       <div className="mt-4 flex justify-end gap-2 border-t border-[#f0f1f3] pt-3">
-        <Button size="small" onClick={resetFilters}>
+        <Button
+          size="small"
+          type="text"
+          className="!text-[#667085]"
+          onClick={resetFilters}
+        >
           重置
         </Button>
 
@@ -355,7 +360,13 @@ const MonitorListTab = ({
             className="w-[160px]"
           />
 
-          <Button onClick={applyFilters}>查询</Button>
+          <Button
+            type="text"
+            className="!text-[#667085]"
+            onClick={applyFilters}
+          >
+            查询
+          </Button>
 
           <Popover
             trigger="click"
@@ -364,7 +375,13 @@ const MonitorListTab = ({
             onOpenChange={setAdvancedOpen}
             content={advancedSearchContent}
           >
-            <Button icon={<ListFilter size={14} />}>高级搜索</Button>
+            <Button
+              type="text"
+              className="!text-[#667085]"
+              icon={<ListFilter size={14} />}
+            >
+              高级搜索
+            </Button>
           </Popover>
         </div>
       </div>

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/QualityReportTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/QualityReportTab.tsx
@@ -175,8 +175,9 @@ const QualityReportTab = ({
       width: 100,
       render: () => (
         <Button
-          type="link"
+          type="text"
           size="small"
+          className="!text-[#667085]"
           onClick={() => message.info('趋势明细已在运行记录中保留')}
         >
           查看详情

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/RuleManagementTab.tsx
@@ -323,7 +323,12 @@ const RuleManagementTab = ({
       </div>
 
       <div className="mt-4 flex justify-end gap-2 border-t border-[#f0f1f3] pt-3">
-        <Button size="small" onClick={reset}>
+        <Button
+          size="small"
+          type="text"
+          className="!text-[#667085]"
+          onClick={reset}
+        >
           重置
         </Button>
         <Button
@@ -455,9 +460,10 @@ const RuleManagementTab = ({
 
             <Dropdown menu={moreMenu} trigger={['click']}>
               <Button
+                type="text"
                 aria-label="更多操作"
                 icon={<MoreHorizontal size={15} />}
-                className="!h-8 !w-8 !px-0"
+                className="!h-8 !w-8 !px-0 !text-[#667085]"
               />
             </Dropdown>
           </div>
@@ -506,7 +512,13 @@ const RuleManagementTab = ({
               className="w-[160px]"
             />
 
-            <Button onClick={applyFilters}>查询</Button>
+            <Button
+              type="text"
+              className="!text-[#667085]"
+              onClick={applyFilters}
+            >
+              查询
+            </Button>
 
             <Popover
               trigger="click"
@@ -515,7 +527,13 @@ const RuleManagementTab = ({
               onOpenChange={setAdvancedOpen}
               content={advancedSearchContent}
             >
-              <Button icon={<ListFilter size={14} />}>高级搜索</Button>
+              <Button
+                type="text"
+                className="!text-[#667085]"
+                icon={<ListFilter size={14} />}
+              >
+                高级搜索
+              </Button>
             </Popover>
           </div>
         </div>

--- a/yak-ops-ui/src/pages/data-quality/monitor/detail/WorkspaceHeader.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/detail/WorkspaceHeader.tsx
@@ -47,9 +47,9 @@ const WorkspaceHeader = ({
               {monitor?.tableName || "规则管理"}
             </h1>
             <Button
-              type="link"
+              type="text"
               size="small"
-              className="!h-6 !px-0 !text-xs"
+              className="!h-6 !px-0 !text-xs !text-[#667085]"
               onClick={onBack}
             >
               返回数据表监控 <ExternalLink size={12} />

--- a/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/AddOrEditDataSourceModal.tsx
@@ -209,7 +209,12 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
     if (!showFormStep) {
       return (
         <div className="flex justify-end">
-          <Button disabled={busy} onClick={handleClose}>
+          <Button
+            type="text"
+            className="!text-[#667085]"
+            disabled={busy}
+            onClick={handleClose}
+          >
             取消
           </Button>
         </div>
@@ -220,11 +225,21 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
       <div className="flex items-center justify-between gap-3">
         <div>
           {isCreateMode && !hideBackButton ? (
-            <Button disabled={busy} onClick={handleBackToTypeSelection}>
+            <Button
+              type="text"
+              className="!text-[#667085]"
+              disabled={busy}
+              onClick={handleBackToTypeSelection}
+            >
               上一步
             </Button>
           ) : (
-            <Button disabled={busy} onClick={handleClose}>
+            <Button
+              type="text"
+              className="!text-[#667085]"
+              disabled={busy}
+              onClick={handleClose}
+            >
               取消
             </Button>
           )}
@@ -232,6 +247,8 @@ const AddOrEditDataSourceModal = forwardRef<DataSourceModalRef>((_, ref) => {
 
         <div className="flex items-center gap-2">
           <Button
+            type="text"
+            className="!text-[#667085]"
             loading={testing}
             disabled={submitting}
             onClick={() => void handleTestConnection()}

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceCard.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceCard.tsx
@@ -138,18 +138,17 @@ const DataSourceCard: React.FC<DataSourceCardProps> = ({
 
         <Button
           block
-          type="default"
+          type="text"
           className={[
-            "group/detail relative h-[42px] overflow-hidden rounded-full p-0",
-            "border border-[#D9D9D9] bg-white font-bold",
+            "group/detail relative h-[42px] overflow-hidden rounded-full p-0 !text-[#667085]",
+            "font-bold",
             "transition-all duration-300 ease-out",
-            "hover:!border-[hsl(231_48%_48%)]",
           ].join(" ")}
           onClick={() => onEdit(record)}
         >
           <span
             className={[
-              "absolute inset-0 z-[1] flex items-center justify-center rounded-full bg-white",
+              "absolute inset-0 z-[1] flex items-center justify-center rounded-full",
               "transition-all duration-300 ease-out",
               "group-hover/detail:translate-y-1.5 group-hover/detail:opacity-0",
             ].join(" ")}
@@ -160,7 +159,7 @@ const DataSourceCard: React.FC<DataSourceCardProps> = ({
           <span
             className={[
               "absolute inset-0 z-[2] flex items-center justify-center gap-2 rounded-full",
-              "bg-[hsl(231_48%_48%)] text-white opacity-0",
+              "bg-[#f5f5f6] text-[#344054] opacity-0",
               "transition-all duration-300 ease-out",
               "group-hover/detail:opacity-100",
             ].join(" ")}

--- a/yak-ops-ui/src/pages/data-source/components/DriverManager/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DriverManager/index.tsx
@@ -88,7 +88,8 @@ const DriverManager = ({
 
         <Upload {...uploadProps}>
           <Button
-            className="shrink-0"
+            type="text"
+            className="shrink-0 !text-[#667085]"
             icon={<UploadOutlined />}
             loading={uploading}
             disabled={disabled}

--- a/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DynamicDataSourceForm/index.tsx
@@ -381,7 +381,8 @@ const DynamicDataSourceForm = ({
           </div>
           <Button
             size="small"
-            className="shrink-0"
+            type="text"
+            className="shrink-0 !text-[#667085]"
             onClick={() => {
               if (installRequired) {
                 void installPlugin().then((installed) => {


### PR DESCRIPTION
## Summary
- remove the global Ant Design default-button CSS override introduced previously
- convert source-level non-primary Ant Design `<Button>` usages to `type="text"` with `!text-[#667085]`
- keep explicit `type="primary"` buttons unchanged
- preserve existing loading, icon, danger, disabled and click behavior
- leave native lowercase `<button>` elements unchanged

## Scope
- frontend only
- source-level button styling only; no global AntD Button override

## Validation
- work in progress: continuing repository-wide source scan before marking ready
