### PR TITLE
fix(ui): finish non-primary Button normalization

### DIFF
--- a/yak-ops-ui/src/pages/system/users/components/UserRowActions.tsx
+++ b/yak-ops-ui/src/pages/system/users/components/UserRowActions.tsx
@@ -178,10 +178,10 @@ export default function UserRowActions({
   return (
     <Space size={2}>
       <Button
-        type="link"
+        type="text"
         size="small"
         icon={<EyeOutlined />}
-        className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+        className="!px-1.5 !text-[#667085]"
         onClick={() => onDetail(user)}
       >
         详情
@@ -189,10 +189,10 @@ export default function UserRowActions({
 
       {canEdit && (
         <Button
-          type="link"
+          type="text"
           size="small"
           icon={<EditOutlined />}
-          className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+          className="!px-1.5 !text-[#667085]"
           onClick={() => onEdit(user)}
         >
           编辑
@@ -209,9 +209,9 @@ export default function UserRowActions({
           }}
         >
           <Button
-            type="link"
+            type="text"
             size="small"
-            className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+            className="!px-1.5 !text-[#667085]"
           >
             更多
             <DownOutlined className="ml-1 text-[10px]" />


### PR DESCRIPTION
## Summary
- follow up the source-level Button refactor after #734 was merged
- normalize the remaining system user row action buttons to `type="text"` + `!text-[#667085]`
- keep primary/destructive confirmation semantics and existing behavior unchanged

## Context
#734 already removed the global Button override and converted the broader set of non-primary Ant Design `<Button>` usages at source level. This PR only carries the remaining source-level cleanup that landed after that merge.

## Scope
- frontend only
- no global Button CSS
- native lowercase `<button>` elements are unchanged
