### PR TITLE
refactor(auth): remove legacy session compatibility

### DIFF
--- a/yak-ops-boot/src/main/resources/application.yml
+++ b/yak-ops-boot/src/main/resources/application.yml
@@ -58,7 +58,8 @@ yak:
     audit-enabled: true
     application-name: ${YAK_SECURITY_APPLICATION_NAME:${spring.application.name}}
     authentication:
-      mode: ${YAK_SECURITY_AUTHENTICATION_MODE:satoken}
+      # Sa-Token 无操作超时。
+      idle-timeout: ${YAK_SECURITY_AUTHENTICATION_IDLE_TIMEOUT:30m}
       # 本地默认内存；多实例生产环境设置为 redis。
       storage: ${YAK_SECURITY_AUTHENTICATION_STORAGE:memory}
       redis:
@@ -67,9 +68,6 @@ yak:
         password: ${YAK_SECURITY_REDIS_PASSWORD:}
         database: ${YAK_SECURITY_REDIS_DATABASE:0}
         max-total: ${YAK_SECURITY_REDIS_MAX_TOTAL:64}
-    # 无操作超时；Sa-Token 模式映射为 activeTimeout。
-    session:
-      timeout: ${YAK_SECURITY_SESSION_TIMEOUT:30m}
     public-paths:
       - /api/test/ping
       - /yak-security/api/v1/account/login

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
@@ -1,6 +1,7 @@
 package io.yak.ops.boot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -41,9 +42,14 @@ class YakOpsApplicationTests {
   }
 
   @Test
-  void shouldUseSaTokenAuthenticationByDefault() {
+  void shouldUseSingleSaTokenAuthenticationConfiguration() {
     assertEquals(
-        "satoken",
-        environment.getProperty("yak.security.authentication.mode"));
+        "30m",
+        environment.getProperty("yak.security.authentication.idle-timeout"));
+    assertEquals(
+        "memory",
+        environment.getProperty("yak.security.authentication.storage"));
+    assertNull(environment.getProperty("yak.security.authentication.mode"));
+    assertNull(environment.getProperty("yak.security.session.timeout"));
   }
 }


### PR DESCRIPTION
## Summary

Stage 6 aligns Yak Ops with the Sa-Token-only Yak Security backend.

- remove `yak.security.authentication.mode` and the `YAK_SECURITY_AUTHENTICATION_MODE` rollback switch
- remove the legacy `yak.security.session.timeout` configuration
- configure inactivity timeout through `yak.security.authentication.idle-timeout`
- keep Stage 5 memory/Redis storage and Sa-Token concurrency governance unchanged
- update the boot regression test to assert the legacy authentication/session properties are absent

## Configuration

```yaml
yak:
  security:
    authentication:
      idle-timeout: ${YAK_SECURITY_AUTHENTICATION_IDLE_TIMEOUT:30m}
      storage: ${YAK_SECURITY_AUTHENTICATION_STORAGE:memory}
```

Native Sa-Token settings (`timeout`, `is-concurrent`, `is-share`, `max-login-count`) stay unchanged.

## Dependency

Requires the matching Yak Framework Stage 6 PR:
https://github.com/weifuwan/yak-framework/pull/106

The frontend remains cookie-based and does not need an authentication protocol change.
