### PR TITLE
feat: add floating labels to login inputs

### DIFF
--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -2,10 +2,70 @@ import { login } from "@/services/security/account";
 import { resetAuthenticationFailure } from "@/utils/request";
 import { getSafeReturnTo } from "@/utils/security/redirect";
 import { history, useIntl, useModel } from "@umijs/max";
-import { App, Button, Form, Input } from "antd";
+import { App, Button, Form, Input, type InputProps } from "antd";
 import { useForm } from "antd/es/form/Form";
 import { useState } from "react";
 import { flushSync } from "react-dom";
+
+type FloatingInputProps = InputProps & {
+  label: string;
+  password?: boolean;
+};
+
+function FloatingInput({
+  label,
+  password = false,
+  onBlur,
+  onFocus,
+  value,
+  ...inputProps
+}: FloatingInputProps) {
+  const [focused, setFocused] = useState(false);
+  const floating = focused || String(value ?? "").length > 0;
+
+  const handleFocus: InputProps["onFocus"] = (event) => {
+    setFocused(true);
+    onFocus?.(event);
+  };
+
+  const handleBlur: InputProps["onBlur"] = (event) => {
+    setFocused(false);
+    onBlur?.(event);
+  };
+
+  const className = password
+    ? "!h-11 !rounded-full !border-[#dededb] !bg-white !px-4 !shadow-none hover:!border-[#bdbdb8] focus-within:!border-[#171717] [&>input.ant-input]:!bg-white [&>input.ant-input]:!text-[15px]"
+    : "!h-11 !rounded-full !border-[#dededb] !bg-white !px-4 !text-[15px] !shadow-none hover:!border-[#bdbdb8] focus:!border-[#171717]";
+
+  const controlProps: InputProps = {
+    ...inputProps,
+    value,
+    className,
+    placeholder: "",
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+  };
+
+  return (
+    <div className="relative">
+      {password ? (
+        <Input.Password {...controlProps} />
+      ) : (
+        <Input {...controlProps} />
+      )}
+      <label
+        htmlFor={inputProps.id}
+        className={`pointer-events-none absolute left-4 z-10 bg-white px-1 transition-all duration-200 ease-out ${
+          floating
+            ? "top-0 -translate-y-1/2 text-[12px] font-medium text-[#333]"
+            : "top-1/2 -translate-y-1/2 text-[15px] text-[#aaa]"
+        }`}
+      >
+        {label}
+      </label>
+    </div>
+  );
+}
 
 export default function LoginPanel() {
   const [loading, setLoading] = useState(false);
@@ -78,28 +138,14 @@ export default function LoginPanel() {
       >
         <Form.Item
           className="!mb-5"
-          label={
-            <span className="text-[13px] font-medium text-[#333]">
-              Username
-            </span>
-          }
           name="userName"
           rules={[{ required: true, message: "请输入用户名" }]}
         >
-          <Input
-            className="!h-11 !rounded-full !border-[#dededb] !bg-white !px-4 !text-[15px] !shadow-none placeholder:!text-[#aaa] hover:!border-[#bdbdb8] focus:!border-[#171717]"
-            placeholder="Enter your username"
-            autoComplete="username"
-          />
+          <FloatingInput label="Username" autoComplete="username" />
         </Form.Item>
 
         <Form.Item
           className="!mb-6"
-          label={
-            <span className="text-[13px] font-medium text-[#333]">
-              Password
-            </span>
-          }
           name="userPassword"
           rules={[
             {
@@ -108,9 +154,9 @@ export default function LoginPanel() {
             },
           ]}
         >
-          <Input.Password
-            className="!h-11 !rounded-full !border-[#dededb] !bg-white !px-4 !shadow-none hover:!border-[#bdbdb8] focus-within:!border-[#171717] [&>input.ant-input]:!bg-white [&>input.ant-input]:!text-[15px]"
-            placeholder="Enter your password"
+          <FloatingInput
+            label="Password"
+            password
             autoComplete="current-password"
           />
         </Form.Item>


### PR DESCRIPTION
## 变更内容

- 登录页 Username / Password 输入框改为浮动标签交互
- 未输入时标签位于输入框内部；聚焦后平滑缩小并移动到上边框
- 已有输入值时，即使失焦标签也保持浮起
- 保留 Yak Ops 现有输入框颜色、border、圆角、hover / focus 样式
- Password 仍保留现有密码显隐能力

## 变更范围

仅修改登录页 Input 展示与交互，不调整登录逻辑、页面布局、按钮或其他功能。

## 校验

- 已确认分支仅修改 `yak-ops-ui/src/pages/login/LoginPanel.tsx`
- 未在本地执行前端构建/测试（本次通过 GitHub 连接器直接提交代码）