### PR TITLE
refactor(ui): unify notifications and auth failure handling

### DIFF
--- a/yak-ops-ui/src/global.tsx
+++ b/yak-ops-ui/src/global.tsx
@@ -1,5 +1,5 @@
-import { useIntl } from '@umijs/max';
-import { Button, message, notification } from 'antd';
+import { getIntl } from '@umijs/max';
+import { closeNotification, notifyOnce } from './utils/notifyOnce';
 import defaultSettings from '../config/defaultSettings';
 import '../tailwind.css';
 import './styles/fonts.less';
@@ -27,7 +27,13 @@ const clearCache = () => {
 if (pwa) {
   // Notify user if offline now
   window.addEventListener('sw.offline', () => {
-    message.warning(useIntl().formatMessage({ id: 'app.pwa.offline' }));
+    const intl = getIntl();
+    notifyOnce('pwa:offline', {
+      type: 'warning',
+      title: intl.formatMessage({ id: 'app.pwa.offline' }),
+      description: '当前设备处于离线状态，请检查网络连接。',
+      meta: '网络离线',
+    });
   });
 
   // Pop up a prompt on the page asking the user if they want to use the latest version
@@ -57,26 +63,22 @@ if (pwa) {
       window.location.reload();
       return true;
     };
-    const key = `open${Date.now()}`;
-    const btn = (
-      <Button
-        type="primary"
-        onClick={() => {
-          notification.destroy(key);
-          reloadSW();
-        }}
-      >
-        {useIntl().formatMessage({ id: 'app.pwa.serviceworker.updated.ok' })}
-      </Button>
-    );
-    notification.open({
-      message: useIntl().formatMessage({ id: 'app.pwa.serviceworker.updated' }),
-      description: useIntl().formatMessage({
+
+    const intl = getIntl();
+    const key = 'pwa:update';
+    notifyOnce(key, {
+      type: 'info',
+      title: intl.formatMessage({ id: 'app.pwa.serviceworker.updated' }),
+      description: intl.formatMessage({
         id: 'app.pwa.serviceworker.updated.hint',
       }),
-      btn,
+      btnText: intl.formatMessage({ id: 'app.pwa.serviceworker.updated.ok' }),
+      onClick: () => {
+        closeNotification(key);
+        void reloadSW();
+      },
+      duration: 0,
       key,
-      onClose: async () => null,
     });
   });
 } else if ('serviceWorker' in navigator && isHttps) {

--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -1,6 +1,7 @@
 import {
   API_SUCCESS_CODE,
   extractErrorMessage,
+  extractUnknownErrorMessage,
   isApiResponse,
   isSuccessfulResponse,
   isUnauthenticatedResponse,
@@ -25,9 +26,28 @@ describe('API response protocols', () => {
     );
   });
 
+  it('preserves useful backend messages from HTTP error payloads', () => {
+    expect(
+      extractUnknownErrorMessage({
+        code: 500,
+        data: null,
+        msg: '数据库连接失败',
+      }),
+    ).toBe('数据库连接失败');
+    expect(extractUnknownErrorMessage({ message: '服务不可用' })).toBe(
+      '服务不可用',
+    );
+    expect(extractUnknownErrorMessage({ detail: '参数格式错误' })).toBe(
+      '参数格式错误',
+    );
+    expect(extractUnknownErrorMessage('纯文本错误')).toBe('纯文本错误');
+    expect(extractUnknownErrorMessage({}, 'fallback')).toBe('fallback');
+  });
+
   it('recognizes authentication failures without treating forbidden as anonymous', () => {
     expect(isUnauthenticatedResponse({ code: 401 }, 'yak-ops')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 401 }, 'security')).toBe(true);
+    expect(isUnauthenticatedResponse({ code: 2001 }, 'security')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 403 }, 'security')).toBe(false);
     expect(
       isUnauthenticatedResponse(
@@ -35,13 +55,24 @@ describe('API response protocols', () => {
         'security',
       ),
     ).toBe(true);
-    // Keep parsing legacy backend messages while frontend state remains backend-neutral.
     expect(
       isUnauthenticatedResponse(
-        { code: 999, message: 'session_expired' },
+        { code: 999, message: 'session-expired' },
         'security',
       ),
     ).toBe(true);
+    expect(
+      isUnauthenticatedResponse(
+        { code: 999, message: 'token expired' },
+        'security',
+      ),
+    ).toBe(true);
+    expect(
+      isUnauthenticatedResponse(
+        { code: 999, message: 'validation failed' },
+        'security',
+      ),
+    ).toBe(false);
   });
 
   it('routes only security endpoints to the security protocol', () => {

--- a/yak-ops-ui/src/services/http/response.ts
+++ b/yak-ops-ui/src/services/http/response.ts
@@ -28,7 +28,13 @@ const unauthenticatedMessages = new Set([
   'UNAUTHENTICATED',
   'SESSION_EXPIRED',
   'SESSION_INVALID',
+  'TOKEN_EXPIRED',
+  'TOKEN_INVALID',
+  'LOGIN_EXPIRED',
 ]);
+
+const normalizeUnauthenticatedMessage = (message: string) =>
+  message.trim().toUpperCase().replace(/[\s-]+/g, '_');
 
 export const protocolForUrl = (url?: string): ApiProtocol =>
   url?.includes('/yak-security/') ? 'security' : 'yak-ops';
@@ -50,6 +56,36 @@ export const extractErrorMessage = (
   fallback = '操作失败',
 ): string => response?.msg?.trim() || response?.message?.trim() || fallback;
 
+/**
+ * Extract a useful server error from both the standard API envelope and common
+ * HTTP error payloads. This prevents a real backend reason from being replaced
+ * by a generic 4xx/5xx status description in the request error handler.
+ */
+export const extractUnknownErrorMessage = (
+  payload: unknown,
+  fallback = '请求失败',
+): string => {
+  if (isApiResponse(payload)) {
+    return extractErrorMessage(payload, fallback);
+  }
+
+  if (typeof payload === 'string' && payload.trim()) {
+    return payload.trim();
+  }
+
+  if (payload && typeof payload === 'object') {
+    const source = payload as Record<string, unknown>;
+    for (const key of ['msg', 'message', 'error', 'detail']) {
+      const value = source[key];
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim();
+      }
+    }
+  }
+
+  return fallback;
+};
+
 export const isUnauthenticatedResponse = (
   response: Partial<ApiResponse> | null | undefined,
   protocol: ApiProtocol,
@@ -59,6 +95,6 @@ export const isUnauthenticatedResponse = (
     (typeof response?.code === 'number' &&
       protocolRules[protocol].unauthenticated.includes(response.code)) ||
     (typeof message === 'string' &&
-      unauthenticatedMessages.has(message.trim().toUpperCase()))
+      unauthenticatedMessages.has(normalizeUnauthenticatedMessage(message)))
   );
 };

--- a/yak-ops-ui/src/utils/notifyOnce.ts
+++ b/yak-ops-ui/src/utils/notifyOnce.ts
@@ -1,0 +1,42 @@
+import { notification } from 'antd';
+import { openPrettyNotification } from './prettyNotification';
+
+type PrettyNotificationOptions = Parameters<typeof openPrettyNotification>[0];
+
+const DEFAULT_DEDUPE_MS = 1200;
+const recentNotifications = new Map<string, number>();
+
+/**
+ * Unified UI notification gateway.
+ *
+ * Repeated requests often fail at the same time (for example after a session
+ * expires). Deduplicating by a stable key avoids flooding the screen while
+ * keeping the original backend error visible.
+ */
+export const notifyOnce = (
+  key: string,
+  options: PrettyNotificationOptions,
+  dedupeMs = DEFAULT_DEDUPE_MS,
+): boolean => {
+  const now = Date.now();
+  const lastShown = recentNotifications.get(key) ?? 0;
+  if (now - lastShown < dedupeMs) return false;
+
+  recentNotifications.set(key, now);
+  openPrettyNotification({
+    ...options,
+    key: options.key ?? key,
+  });
+
+  globalThis.setTimeout(() => {
+    if (recentNotifications.get(key) === now) {
+      recentNotifications.delete(key);
+    }
+  }, dedupeMs);
+
+  return true;
+};
+
+export const closeNotification = (key?: string) => {
+  notification.destroy(key);
+};

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -1,17 +1,9 @@
 /* eslint-disable @typescript-eslint/dot-notation */
-import { openPrettyNotification } from "@/utils/prettyNotification";
+import { extractErrorMessage, extractUnknownErrorMessage, isApiResponse, isSuccessfulResponse, isUnauthenticatedResponse, protocolForUrl, type ApiProtocol, type ApiResponse } from "@/services/http/response";
+import { notifyOnce } from "@/utils/notifyOnce";
 import { dispatchAuthenticationInvalidated } from "@/utils/security/authentication";
 import { history } from "umi";
 import { extend } from "umi-request";
-import {
-  extractErrorMessage,
-  isApiResponse,
-  isSuccessfulResponse,
-  isUnauthenticatedResponse,
-  protocolForUrl,
-  type ApiProtocol,
-  type ApiResponse,
-} from "@/services/http/response";
 
 export type { ApiProtocol, ApiResponse } from "@/services/http/response";
 
@@ -27,6 +19,7 @@ const codeMessage: Record<number, string> = {
   401: "当前请求未通过身份认证，请重新登录。",
   403: "当前用户已登录，但没有访问该资源的权限。",
   404: "发出的请求针对的是不存在的记录，服务器没有进行操作。",
+  405: "请求方法不被当前接口允许，请检查请求方式。",
   406: "请求的格式不可得。",
   410: "请求的资源被永久删除，且不会再得到的。",
   422: "当创建一个对象时，发生一个验证错误。",
@@ -66,18 +59,6 @@ export const goLogin = () => {
 };
 
 let authenticationFailureHandled = false;
-const recentNotifications = new Map<string, number>();
-
-const notifyOnce = (
-  key: string,
-  notification: Parameters<typeof openPrettyNotification>[0]
-) => {
-  const now = Date.now();
-  const lastShown = recentNotifications.get(key) || 0;
-  if (now - lastShown < 1000) return;
-  recentNotifications.set(key, now);
-  openPrettyNotification(notification);
-};
 
 /** Re-arm expiry handling only after authentication has been established. */
 export const resetAuthenticationFailure = () => {
@@ -85,7 +66,9 @@ export const resetAuthenticationFailure = () => {
 };
 
 /** HTTP 401 与业务未认证码的唯一处理出口。 */
-export const handleAuthenticationFailure = () => {
+export const handleAuthenticationFailure = (
+  reason = "当前登录信息已过期，请重新登录后继续操作。"
+) => {
   dispatchAuthenticationInvalidated();
   if (window.location.pathname.toLowerCase().startsWith("/login")) {
     return;
@@ -96,7 +79,7 @@ export const handleAuthenticationFailure = () => {
   notifyOnce("authentication", {
     type: "warning",
     title: "登录状态失效",
-    description: "当前登录信息已过期，请重新登录后继续操作。",
+    description: reason,
     meta: "即将跳转登录页",
   });
   goLogin();
@@ -105,7 +88,7 @@ export const handleAuthenticationFailure = () => {
 /** 业务异常的唯一展示出口。 */
 const handleBusinessError = (error: BizError) => {
   if (isUnauthenticatedResponse(error.response, error.protocol)) {
-    handleAuthenticationFailure();
+    handleAuthenticationFailure(error.message);
     return;
   }
 
@@ -129,18 +112,25 @@ const errorHandler = (error: any): Response | undefined => {
     throw error;
   }
 
-  // HTTP 异常
+  // HTTP 异常。umi-request 会把 JSON 错误体放在 error.data 中，优先展示
+  // 后端真实 msg/message，而不是用通用 HTTP 状态文案覆盖它。
   if (response?.status) {
     const { status, url } = response;
+    const protocol = protocolForUrl(url);
+    const payload: unknown = error?.data;
+    const fallback = codeMessage[status] || response.statusText || "请求失败";
+    const errorText = extractUnknownErrorMessage(payload, fallback);
 
-    if (status === 401) {
-      handleAuthenticationFailure();
+    // 401 明确代表未认证；另外兼容网关把 Sa-Token 未登录响应包装成
+    // 其他 HTTP 状态的情况。403/405 本身不等于登录失效。
+    const payloadUnauthenticated =
+      isApiResponse(payload) && isUnauthenticatedResponse(payload, protocol);
+    if (status === 401 || payloadUnauthenticated) {
+      handleAuthenticationFailure(errorText);
       return response;
     }
 
-    const errorText = codeMessage[status] || response.statusText || "请求失败";
-
-    notifyOnce(`http:${status}:${url || ""}`, {
+    notifyOnce(`http:${status}:${url || ""}:${errorText}`, {
       type: "error",
       title: `请求错误 ${status}`,
       description: (
@@ -159,7 +149,7 @@ const errorHandler = (error: any): Response | undefined => {
           ) : null}
         </div>
       ),
-      meta: "服务端返回异常",
+      meta: status === 403 ? "权限不足" : "服务端返回异常",
       duration: 3.5,
     });
 


### PR DESCRIPTION
## What changed

- add a shared `notifyOnce` gateway and remove the duplicate request-layer notification implementation
- migrate PWA offline/update prompts away from direct Ant Design `message` / `notification` calls
- preserve backend error details by preferring `msg`, `message`, `error` or `detail` from HTTP error payloads
- add an explicit HTTP 405 fallback message
- unify HTTP 401 and Sa-Token unauthenticated business responses into one authentication-failure path
- invalidate frontend authentication state and redirect to `/login` with the current location preserved as `returnTo`
- keep 403 and 405 as normal error notifications unless the response payload explicitly identifies an unauthenticated/session-expired state
- recognize common session/token expiry markers such as `SESSION_EXPIRED`, `TOKEN_EXPIRED` and normalized variants
- add response parsing/authentication tests

## Behavior

| Response | Behavior |
| --- | --- |
| HTTP 401 | notify once, invalidate auth state, redirect to login |
| Sa-Token unauthenticated code/message | same as 401 |
| HTTP 403 | show backend permission error, no login redirect |
| HTTP 405 | show backend/method error, no login redirect |
| 403/405 carrying an explicit unauthenticated payload | treat as authentication expiry and redirect |
| 4xx/5xx JSON with `msg/message/error/detail` | show the backend reason instead of a generic status message |

## Notes

The request layer remains the single place responsible for HTTP/business error presentation. Repeated concurrent failures are deduplicated by a stable notification key so session expiry or backend outages do not flood the UI.