### PR TITLE
feat: add WeChat QR help to login

### DIFF
--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -2,10 +2,12 @@ import { login } from "@/services/security/account";
 import { resetAuthenticationFailure } from "@/utils/request";
 import { getSafeReturnTo } from "@/utils/security/redirect";
 import { history, useIntl, useModel } from "@umijs/max";
-import { App, Button, Form, Input, type InputProps } from "antd";
+import { App, Button, Form, Input, Popover, type InputProps } from "antd";
 import { useForm } from "antd/es/form/Form";
 import { useState } from "react";
 import { flushSync } from "react-dom";
+
+const WECHAT_QR_CODE_SRC = "/wechat-official-account-qr.png";
 
 type FloatingInputProps = InputProps & {
   label: string;
@@ -63,6 +65,41 @@ function FloatingInput({
       >
         {label}
       </label>
+    </div>
+  );
+}
+
+function WeChatQrHelp() {
+  const [qrCodeAvailable, setQrCodeAvailable] = useState(true);
+
+  const qrCodeContent = (
+    <div className="flex w-[176px] flex-col items-center gap-2 p-1">
+      {qrCodeAvailable ? (
+        <img
+          src={WECHAT_QR_CODE_SRC}
+          alt="微信公众号二维码"
+          className="h-40 w-40 rounded-xl object-cover"
+          onError={() => setQrCodeAvailable(false)}
+        />
+      ) : (
+        <div className="flex h-40 w-40 items-center justify-center rounded-xl border border-dashed border-[#dededb] bg-[#fafafa] px-5 text-center text-[12px] leading-5 text-[#999]">
+          微信公众号二维码待上传
+        </div>
+      )}
+      <span className="text-center text-[11px] leading-5 text-[#888]">
+        微信扫码获取账号 / 密码
+      </span>
+    </div>
+  );
+
+  return (
+    <div className="mt-3 text-center text-[11px] leading-5 text-[#8c8c88]">
+      获取账号 / 密码，请扫描{" "}
+      <Popover placement="right" trigger="hover" content={qrCodeContent}>
+        <span className="cursor-help font-medium text-[#555] underline decoration-[#d6d6d1] underline-offset-2 transition-colors hover:text-[#171717]">
+          微信公众号二维码
+        </span>
+      </Popover>
     </div>
   );
 }
@@ -170,6 +207,8 @@ export default function LoginPanel() {
         >
           Log in
         </Button>
+
+        <WeChatQrHelp />
       </Form>
     </div>
   );


### PR DESCRIPTION
## 变更内容

- 在登录按钮下方新增账号 / 密码获取说明：`获取账号 / 密码，请扫描微信公众号二维码`
- 鼠标悬停在“微信公众号二维码”文字上时，在右侧展示二维码 Popover
- Popover 风格沿用 Yak-Ops 当前登录页的黑白灰、圆角与边框体系
- 二维码下方补充“微信扫码获取账号 / 密码”说明
- 二维码资源尚未上传时显示轻量占位，不出现破图

## 二维码资源

后续将实际公众号二维码图片放到：

`yak-ops-ui/public/wechat-official-account-qr.png`

页面会自动读取 `/wechat-official-account-qr.png`，无需再改交互代码。

## 变更范围

仅修改 `yak-ops-ui/src/pages/login/LoginPanel.tsx`，不调整登录逻辑、Input 交互、页面布局或其他功能。

## 校验

- 分支相对 `main` 仅 1 个 commit
- 仅修改 1 个文件
- 未在本地执行前端构建 / 测试（本次通过 GitHub 连接器直接提交代码）