### PR TITLE
fix: center login validation message

### DIFF
--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -84,9 +84,9 @@ function FloatingInput({
 
 function ValidationMessage({ children }: { children: string }) {
   return (
-    <span className="inline-flex items-start gap-1.5">
-      <ExclamationCircleOutlined className="mt-[2px] shrink-0 text-[12px]" />
-      <span>{children}</span>
+    <span className="inline-flex h-[18px] items-center gap-1.5 align-middle leading-[18px]">
+      <ExclamationCircleOutlined className="flex shrink-0 items-center text-[12px] leading-none [&_svg]:block" />
+      <span className="leading-[18px]">{children}</span>
     </span>
   );
 }


### PR DESCRIPTION
## 变更内容

- 修复登录页校验提示图标与文字没有上下居中的问题
- 将错误提示容器改为 `items-center`，移除图标手工 `margin-top` 偏移
- 固定提示行高度 / line-height，保证图标与中文提示视觉中心一致

## 变更范围

仅修改：

`yak-ops-ui/src/pages/login/LoginPanel.tsx`

## 校验

- 相对 `main` 仅 1 个 commit
- 仅修改 1 个文件
- 实际代码 diff 仅 6 行（+3 / -3）
- 未在本地执行 build / lint（本次通过 GitHub 连接器直接提交代码）