### PR TITLE
feat(ui): soften home header transition

### DIFF
--- a/yak-ops-ui/src/pages/home/index.tsx
+++ b/yak-ops-ui/src/pages/home/index.tsx
@@ -9,6 +9,7 @@ import {
   Workflow,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { fetchDataSourceSummary } from '@/pages/data-source/service';
 import DataCenter from './DataCenter';
 import HomeWorkbench from './HomeWorkbench';
@@ -327,6 +328,41 @@ function HomeSecondaryPanels() {
   );
 }
 
+function HomeHeaderBlend() {
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      aria-hidden="true"
+      className="
+        pointer-events-none fixed inset-x-0 top-0 z-[5] h-[176px]
+        overflow-hidden
+        [mask-image:linear-gradient(to_bottom,#000_0%,#000_56%,transparent_100%)]
+      "
+    >
+      <div
+        className="
+          absolute inset-0 bg-white/[0.12] backdrop-blur-[10px]
+        "
+      />
+      <div
+        className="
+          absolute -right-[4%] -top-[160px] h-[360px] w-[72%]
+          bg-[radial-gradient(ellipse_at_center,rgba(159,215,239,0.30)_0%,rgba(187,224,240,0.13)_46%,rgba(255,255,255,0)_74%)]
+          blur-[28px]
+        "
+      />
+      <div
+        className="
+          absolute inset-x-0 top-0 h-[128px]
+          bg-gradient-to-b from-white/55 via-white/20 to-transparent
+        "
+      />
+    </div>,
+    document.body,
+  );
+}
+
 /* =========================================================
  * Page
  * ========================================================= */
@@ -383,6 +419,8 @@ export default function CreatorWorkbenchPage() {
         relative min-h-screen w-full overflow-hidden bg-[#f7f8fa] text-[#242731]
       "
     >
+      <HomeHeaderBlend />
+
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div
           className="


### PR DESCRIPTION
## 调整说明

参考抖音创作者中心首页顶部的视觉处理，优化 Yak Ops 首页与全局 Header 之间的衔接：

- 在首页增加一层仅首页生效的顶部柔光/虚化层
- 使用轻量 backdrop blur + 右上角浅蓝径向光晕，弱化 Header 与首页背景的硬切换
- 底部通过 mask 渐隐，避免新增明显分界线
- 通过 Portal 挂载到页面顶层，不改动全局 Header 和其他业务页面样式

## 影响范围

仅 `yak-ops-ui/src/pages/home/index.tsx`，其他页面不受影响。

## 验证

- 已检查提交 diff，仅新增首页顶部视觉层
- 未在本地启动完整前端环境进行截图验证，建议 Draft 阶段结合实际页面再微调虚化强度与高度