### PR TITLE
style(workflow): unify workflow instance page layout

### DIFF
--- a/yak-ops-ui/src/pages/workflow/instances/index.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/services/workflow';
 import {
   CopyOutlined,
+  FilterOutlined,
   ReloadOutlined,
   SearchOutlined,
 } from '@ant-design/icons';
@@ -15,6 +16,7 @@ import {
   Button,
   ConfigProvider,
   DatePicker,
+  Divider,
   Empty,
   Input,
   Modal,
@@ -28,7 +30,7 @@ import {
 import type { ColumnsType } from 'antd/es/table';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
-import { RefreshCw, SlidersHorizontal } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState, type Key } from 'react';
 
 const { RangePicker } = DatePicker;
@@ -89,6 +91,7 @@ const WorkflowInstancesPage = () => {
   const [loading, setLoading] = useState(false);
   const [statusGroup, setStatusGroup] = useState<StatusGroup>('ALL');
   const [keyword, setKeyword] = useState('');
+  const [keywordDraft, setKeywordDraft] = useState('');
   const [dateRange, setDateRange] = useState<Dayjs[]>();
   const [instanceIdFilter, setInstanceIdFilter] = useState('');
   const [definitionIdFilter, setDefinitionIdFilter] = useState('');
@@ -97,6 +100,7 @@ const WorkflowInstancesPage = () => {
   const [pageSize, setPageSize] = useState(10);
   const [selectedKeys, setSelectedKeys] = useState<Key[]>([]);
   const [batchLoading, setBatchLoading] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const load = useCallback(async (showLoading = false) => {
     if (showLoading) setLoading(true);
@@ -161,6 +165,11 @@ const WorkflowInstancesPage = () => {
     setInstanceIdFilter('');
     setDefinitionIdFilter('');
     setTestRunFilter('ALL');
+    setPage(1);
+  };
+
+  const handleSearch = () => {
+    setKeyword(keywordDraft);
     setPage(1);
   };
 
@@ -261,123 +270,243 @@ const WorkflowInstancesPage = () => {
   ], []);
 
   const advancedFilters = (
-    <div className="w-[310px] space-y-3">
-      <div>
-        <div className="mb-1 text-[11px] text-[#667085]">实例 ID</div>
-        <Input allowClear size="small" value={instanceIdFilter} onChange={(event) => { setInstanceIdFilter(event.target.value); setPage(1); }} placeholder="精确定位运行实例" />
+    <div className="w-[360px]">
+      <div className="mb-4">
+        <div className="text-[14px] font-semibold text-[#101828]">高级搜索</div>
+        <div className="mt-1 text-[12px] text-[#98a2b3]">按实例标识、工作流定义和运行类型进一步筛选</div>
       </div>
-      <div>
-        <div className="mb-1 text-[11px] text-[#667085]">Definition ID</div>
-        <Input allowClear size="small" value={definitionIdFilter} onChange={(event) => { setDefinitionIdFilter(event.target.value); setPage(1); }} placeholder="Workflow Version / Runtime Definition" />
+      <div className="space-y-4">
+        <div>
+          <div className="mb-1.5 text-[12px] text-[#667085]">实例 ID</div>
+          <Input
+            allowClear
+            variant="filled"
+            value={instanceIdFilter}
+            onChange={(event) => { setInstanceIdFilter(event.target.value); setPage(1); }}
+            placeholder="精确定位运行实例"
+          />
+        </div>
+        <div>
+          <div className="mb-1.5 text-[12px] text-[#667085]">Definition ID</div>
+          <Input
+            allowClear
+            variant="filled"
+            value={definitionIdFilter}
+            onChange={(event) => { setDefinitionIdFilter(event.target.value); setPage(1); }}
+            placeholder="Workflow Version / Runtime Definition"
+          />
+        </div>
+        <div>
+          <div className="mb-1.5 text-[12px] text-[#667085]">运行类型</div>
+          <Select
+            className="w-full"
+            variant="filled"
+            value={testRunFilter}
+            onChange={(value) => { setTestRunFilter(value); setPage(1); }}
+            options={[
+              { value: 'ALL', label: '全部' },
+              { value: 'FALSE', label: '正式运行' },
+              { value: 'TRUE', label: '测试运行' },
+            ]}
+          />
+        </div>
       </div>
-      <div>
-        <div className="mb-1 text-[11px] text-[#667085]">运行类型</div>
-        <Select
-          size="small"
-          className="w-full"
-          variant='filled'
-          value={testRunFilter}
-          onChange={(value) => { setTestRunFilter(value); setPage(1); }}
-          options={[
-            { value: 'ALL', label: '全部' },
-            { value: 'FALSE', label: '正式运行' },
-            { value: 'TRUE', label: '测试运行' },
-          ]}
-        />
-      </div>
-      <div className="flex justify-end border-t border-[#f0f0f0] pt-2">
+      <div className="mt-5 flex justify-end border-t border-[#f0f0f0] pt-4">
         <YakButton disabled={advancedFilterCount === 0} onClick={resetAdvancedFilters}>重置</YakButton>
       </div>
     </div>
   );
 
   return (
-    <ConfigProvider theme={{ token: { borderRadius: 9, colorBorder: '#eaecf0' }, components: { Input: { activeShadow: 'none' } } }}>
+    <ConfigProvider
+      theme={{
+        token: {
+          borderRadius: 10,
+          colorBorder: '#f0f0f0',
+          colorBgContainer: '#ffffff',
+        },
+        components: {
+          Button: { borderRadius: 8 },
+          Input: { activeShadow: 'none' },
+          Select: { activeOutlineColor: 'transparent' },
+        },
+      }}
+    >
       <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4 text-[#161823]">
-        <div className="flex items-start justify-between">
-          <div>
-            <h1 className="m-0 text-[17px] font-semibold leading-8">工作流实例</h1>
-            <div className="text-[11px] text-[#98a2b3]">运行实例 DAG、失败恢复、节点重跑与 businessDate 运维补跑</div>
-          </div>
-          <div className="flex items-center gap-2">
-            {selectedKeys.length > 0 ? (
-              <Button icon={<RefreshCw size={13} />} loading={batchLoading} onClick={() => void batchRetry()}>
-                批量重试失败实例（{selectedKeys.length}）
-              </Button>
-            ) : null}
-            <Button icon={<ReloadOutlined spin={loading} />} loading={loading} onClick={() => void load(true)}>刷新</Button>
-          </div>
-        </div>
+        <h1 className="m-0 text-[17px] font-semibold leading-8">工作流实例</h1>
 
-        <div className="mt-4 flex min-h-[52px] items-center justify-between gap-3 border-y border-[#f0f0f0]">
-          <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
-            {statusTabs.map((item) => (
-              <button
-                key={item.value}
-                type="button"
-                onClick={() => { setStatusGroup(item.value); setPage(1); setSelectedKeys([]); }}
-                className={`h-8 rounded-md px-3.5 text-[13px] font-medium ${statusGroup === item.value ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,.08)]' : 'text-[#667085] hover:bg-white/70'}`}
-              >
-                {item.label}
-              </button>
-            ))}
+        <div className="mx-auto flex w-full max-w-full flex-1 flex-col">
+          <div className="mb-3">
+            <div className="border-b border-[#f0f0f0]">
+              <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
+                <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
+                  {statusTabs.map((item) => {
+                    const active = statusGroup === item.value;
+                    return (
+                      <button
+                        key={item.value}
+                        type="button"
+                        onClick={() => { setStatusGroup(item.value); setPage(1); setSelectedKeys([]); }}
+                        className={[
+                          'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
+                          active
+                            ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,.08)]'
+                            : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
+                        ].join(' ')}
+                      >
+                        {item.label}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
+                  <Input
+                    allowClear
+                    variant="filled"
+                    prefix={<SearchOutlined className="text-[#98a2b3]" />}
+                    placeholder="名称 / 实例 ID / businessDate"
+                    className="!h-9 !w-[260px] !min-w-[220px]"
+                    value={keywordDraft}
+                    onChange={(event) => setKeywordDraft(event.target.value)}
+                    onPressEnter={handleSearch}
+                  />
+                  <RangePicker
+                    allowClear
+                    variant="filled"
+                    value={dateRange as any}
+                    format="YYYY-MM-DD"
+                    placeholder={['开始日期', '结束日期']}
+                    className="!h-9 !w-[250px] !min-w-[230px]"
+                    onChange={(value) => { setDateRange(value ? value as unknown as Dayjs[] : undefined); setPage(1); }}
+                  />
+                  <YakButton className="!h-9 !px-4" onClick={handleSearch}>查询</YakButton>
+                  <Popover
+                    placement="bottomRight"
+                    trigger="click"
+                    open={advancedOpen}
+                    onOpenChange={setAdvancedOpen}
+                    content={advancedFilters}
+                  >
+                    <YakButton
+                      size="small"
+                      icon={<FilterOutlined />}
+                      className={[
+                        '!h-9 !px-3',
+                        advancedFilterCount > 0 ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]' : '',
+                      ].join(' ')}
+                    >
+                      高级搜索
+                      {advancedFilterCount > 0 ? (
+                        <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
+                          {advancedFilterCount}
+                        </span>
+                      ) : null}
+                    </YakButton>
+                  </Popover>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex min-h-[48px] items-center justify-between">
+              <div className="text-[12px] text-[#98a2b3]">
+                {selectedKeys.length > 0 ? `已选择 ${selectedKeys.length} 个可恢复实例` : ''}
+              </div>
+              <div className="flex items-center gap-2">
+                {selectedKeys.length > 0 ? (
+                  <YakButton
+                    className="!h-8"
+                    icon={<RefreshCw size={13} />}
+                    loading={batchLoading}
+                    onClick={() => void batchRetry()}
+                  >
+                    批量重试失败实例（{selectedKeys.length}）
+                  </YakButton>
+                ) : null}
+                <YakButton
+                  className="!h-8"
+                  icon={<ReloadOutlined spin={loading} />}
+                  loading={loading}
+                  onClick={() => void load(true)}
+                >
+                  刷新
+                </YakButton>
+              </div>
+            </div>
+
+            <div className="flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
+              <span><b>【实例运维】</b> 单节点 Retry 在原实例恢复；“从此节点重跑”创建新实例并复用成功祖先结果；指定 businessDate 重跑固定来源发布版本。</span>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Input
-              allowClear
-              variant="filled"
-              prefix={<SearchOutlined className="text-[#98a2b3]" />}
-              placeholder="名称 / 实例 ID / businessDate"
-              className="!w-[260px]"
-              value={keyword}
-              onChange={(event) => { setKeyword(event.target.value); setPage(1); }}
+
+          <Divider style={{ marginTop: 4, marginBottom: 16 }} />
+
+          <div className="flex-1">
+            <Table<WorkflowInstance>
+              rowKey="id"
+              bordered
+              size="small"
+              pagination={false}
+              loading={loading}
+              dataSource={pageData}
+              columns={columns}
+              rowSelection={{
+                selectedRowKeys: selectedKeys,
+                onChange: setSelectedKeys,
+                columnWidth: 48,
+                getCheckboxProps: (record) => ({
+                  disabled: !isRetryableInstance(record),
+                  title: isRetryableInstance(record) ? '加入批量失败恢复' : '当前实例没有可批量恢复的失败/阻断节点',
+                }),
+              }}
+              scroll={{ x: 1260 }}
+              locale={{
+                emptyText: (
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description={<span className="text-[12px] text-[#98a2b3]">暂无工作流实例</span>}
+                  />
+                ),
+              }}
+              className={[
+                'compact-workflow-instance-table',
+                '[&_.ant-table]:!text-[13px]',
+                '[&_.ant-table-container]:!border-[#eaecf0]',
+                '[&_.ant-table-cell]:!align-middle',
+                '[&_.ant-table-thead>tr>th]:!h-10',
+                '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
+                '[&_.ant-table-thead>tr>th]:!px-4',
+                '[&_.ant-table-thead>tr>th]:!py-2',
+                '[&_.ant-table-thead>tr>th]:!text-[12px]',
+                '[&_.ant-table-thead>tr>th]:!font-medium',
+                '[&_.ant-table-thead>tr>th]:!text-[#667085]',
+                '[&_.ant-table-thead>tr>th]:!border-[#eaecf0]',
+                '[&_.ant-table-tbody>tr>td]:!px-4',
+                '[&_.ant-table-tbody>tr>td]:!py-2.5',
+                '[&_.ant-table-tbody>tr>td]:!border-[#f0f2f5]',
+                '[&_.ant-table-tbody>tr>td]:!text-[#667085]',
+                '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
+                '[&_.ant-table-cell-fix-right]:!bg-white',
+                '[&_.ant-table-tbody>tr:hover_.ant-table-cell-fix-right]:!bg-[#fafbfc]',
+                '[&_.ant-checkbox-inner]:!h-4',
+                '[&_.ant-checkbox-inner]:!w-4',
+                '[&_.ant-table-placeholder>td]:!h-[240px]',
+              ].join(' ')}
             />
-            <RangePicker
-              allowClear
-              variant="filled"
-              value={dateRange as any}
-              onChange={(value) => { setDateRange(value ? value as unknown as Dayjs[] : undefined); setPage(1); }}
-            />
-            <Popover placement="bottomRight" trigger="click" content={advancedFilters}>
-              <Button icon={<SlidersHorizontal size={13} />}>
-                高级筛选{advancedFilterCount > 0 ? ` · ${advancedFilterCount}` : ''}
-              </Button>
-            </Popover>
           </div>
-        </div>
 
-        <div className="mt-3 flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
-          <span><b>【实例运维】</b> 单节点 Retry 在原实例恢复；“从此节点重跑”创建新实例并复用成功祖先结果；指定 businessDate 重跑固定来源发布版本。</span>
-        </div>
-
-        <div className="mt-4 flex-1">
-          <Table<WorkflowInstance>
-            rowKey="id"
-            bordered
-            size="small"
-            pagination={false}
-            loading={loading}
-            dataSource={pageData}
-            columns={columns}
-            rowSelection={{
-              selectedRowKeys: selectedKeys,
-              onChange: setSelectedKeys,
-              getCheckboxProps: (record) => ({
-                disabled: !isRetryableInstance(record),
-                title: isRetryableInstance(record) ? '加入批量失败恢复' : '当前实例没有可批量恢复的失败/阻断节点',
-              }),
-            }}
-            scroll={{ x: 1260 }}
-            locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无工作流实例" /> }}
-            className="[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-thead>tr>th]:!text-[#667085] [&_.ant-table-tbody>tr>td]:!py-2.5"
-          />
-        </div>
-
-        <div className="mt-auto flex min-h-[56px] items-center justify-between border-t border-[#eaecf0] bg-white py-3">
-          <div className="text-[12px] text-[#98a2b3]">当前筛选 {filtered.length} 条 · 可批量恢复 {filtered.filter(isRetryableInstance).length} 条</div>
-          <div className="flex items-center gap-3">
-            <Pagination size="small" total={filtered.length} current={page} pageSize={pageSize} showSizeChanger={false} onChange={setPage} />
-            <Select size="small" value={pageSize} className="w-[78px]" onChange={(value) => { setPageSize(value); setPage(1); }} options={[10, 20, 50].map((value) => ({ value, label: `${value} / 页` }))} />
+          <div className="sticky bottom-0 z-20 mt-auto flex min-h-[56px] items-center justify-between border border-t-0 border-[#e5e7eb] bg-white px-5 py-3 shadow-[0_-4px_12px_rgba(16,24,40,0.04)]">
+            <div className="text-[12px] text-[#98a2b3]">当前筛选 {filtered.length} 条 · 可批量恢复 {filtered.filter(isRetryableInstance).length} 条</div>
+            <div className="flex items-center gap-3">
+              <Pagination size="small" total={filtered.length} current={page} pageSize={pageSize} showSizeChanger={false} onChange={setPage} />
+              <Select
+                size="small"
+                value={pageSize}
+                className="w-[78px]"
+                onChange={(value) => { setPageSize(value); setPage(1); }}
+                options={[10, 20, 50].map((value) => ({ value, label: `${value} / 页` }))}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 改动说明

- 参考离线同步页面统一工作流实例页的整体布局、间距与视觉层级
- 统一状态 Tab、搜索区、日期筛选、查询按钮和高级搜索入口
- 将刷新 / 批量重试收敛到操作区，减少标题区视觉噪音
- 统一表格表头、单元格、Hover、空状态及固定操作列样式
- 统一底部分页栏的吸底、边框与阴影表现
- 保留现有实例筛选、自动刷新、批量失败恢复和运维跳转逻辑

## 影响范围

仅调整 `yak-ops-ui/src/pages/workflow/instances/index.tsx`，不涉及后端接口与工作流执行逻辑。

## 验证建议

- 检查全部 / 运行中 / 已完成 / 失败状态切换
- 检查名称、实例 ID、businessDate 搜索与日期筛选
- 检查高级搜索及筛选数量提示
- 检查可恢复实例勾选、批量重试、刷新与分页
- 检查空数据及窄屏横向滚动表现