### PR TITLE
refactor(lineage): establish stage 1 architecture contract

### DIFF
--- a/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
@@ -1,0 +1,153 @@
+# Lineage Architecture
+
+本文件定义 Lineage 的**长期架构 contract**：package 表达职责，稳定 Service 只作为应用入口，专业能力以角色命名，外部技术停在边界。
+
+需求看 `REQUIREMENTS.md`，领域硬规则看 `DOMAIN.md`，依赖矩阵看 `DEPENDENCIES.md`，仓库风格看根目录 `CODE_STYLE.md`。
+
+## Design Principles
+
+1. **Domain first.** Asset / Relation / Evidence / Graph 不被 HTTP、MyBatis、Flink/Spark/Hadoop 类型污染。
+2. **Stable entry, specialized roles.** Controller 只进入稳定应用 Service；内部用 Analyzer / Collector / Resolver / Mapper / Repository 等角色表达职责。
+3. **One lineage model.** 不为 Flink、Spark、Hadoop、Dataset、SQL Task 各建一套 Asset/Relation。
+4. **External technology stops at boundary.** Parser、SDK、CLI、HTTP client、MyBatis PO 不能穿透到 Core Domain。
+5. **Read does not mutate.** Graph/query side 不因读取失败反向改写领域事实。
+6. **Structure change is not behavior change.** package move、class split 与 REST / DB / Flyway / Domain semantic change 分开评审。
+7. **Architecture is executable.** 文档 contract 必须由 architecture/dependency tests 持续保护。
+
+## Target Package Map
+
+```text
+io.yak.ops.business.lineage
+├── controller          # HTTP inbound + DTO/VO/converter
+├── service             # stable application facades
+├── domain              # framework-free core domain / value objects
+├── analysis            # source-neutral analysis contracts + implementations
+├── collector           # platform/source ingestion roles
+├── repository          # persistence contracts + adapters
+│   └── support         # persistence-only codecs/mapping helpers
+├── dao                 # MyBatis primitives / mapper / PO
+└── config              # module configuration
+```
+
+`common / helper / utils / base` 不能成为新的业务大桶。需要新 top-level package 时，必须先更新架构文档并说明它代表的稳定业务角色。
+
+## Application Boundary
+
+当前稳定入口仍是：
+
+```text
+LineageController
+    └── LineageService
+
+internal publishers
+    ├── LineageService
+    └── LineageMaintenanceService
+```
+
+Stage 1 不改 production API。后续 Service 收敛的目标是：
+
+```text
+LineageController
+    ├── LineageQueryService
+    └── LineageWriteService
+
+internal publishers
+    ├── LineageWriteService
+    └── LineageMaintenanceService
+```
+
+稳定入口使用 `@Service`。内部专业角色优先使用 `@Component`、`@Repository` 或普通对象，不通过增加更多 `*Service` 掩盖职责不清。
+
+## Role Vocabulary
+
+- **Service**：跨 HTTP / module caller 的稳定应用入口，负责事务边界和用例编排；
+- **Analyzer**：输入事实并产生分析结果，不拥有持久化 truth；
+- **Collector**：从 Flink / Spark / Hadoop 等来源获取 lineage evidence；
+- **Resolver**：把外部引用解析为统一领域引用；
+- **Mapper / Converter**：边界表示转换，不承载业务状态机；
+- **Repository**：领域持久化 contract；
+- **RepositoryAdapter**：把领域模型翻译为 DAO/PO；
+- **DAO**：数据库读写 primitive，不承载应用编排。
+
+## Domain Boundary
+
+未来 `domain/` 只能依赖 JDK 与必要的通用值类型，不依赖：
+
+```text
+Spring MVC / Spring Service
+MyBatis / Mapper / PO
+Controller DTO / VO
+Repository implementation
+Flink / Spark / Hadoop SDK
+```
+
+当前 Asset / Relation / Graph 等仍位于根包，这是**显式过渡债务**，不是推荐的新代码位置。
+
+## Analysis / Collector Boundary
+
+SQL projection 分析已经具备 source-neutral contract。后续实现按角色归位：
+
+```text
+analysis/
+└── sql/
+    └── ...SqlProjectionLineageAnalyzer
+
+collector/
+├── flink/
+├── spark/
+└── hadoop/
+```
+
+技术实现复用统一 Domain，不允许出现 `flink/domain`、`spark/domain` 等平行领域模型。
+
+## Persistence Boundary
+
+```text
+Service / role component
+        ↓
+LineageRepository
+        ↓
+LineageRepositoryAdapter
+        ↓
+LineageDao
+        ↓
+Mapper / PO / MyBatis / DB
+```
+
+固定规则：
+
+- Repository contract 不暴露 DAO model、Mapper、Controller DTO/VO；
+- Service 不直接依赖 DAO / Mapper / PO；
+- DAO 不反向依赖 Service / Controller / Repository；
+- Repository adapter 是 Domain ↔ Persistence 的转换位置；
+- `LineageJsonCodec` 等持久化表示 helper 留在 `repository.support`。
+
+## Transitional Root Debt
+
+Stage 1 明确冻结以下根包 production 类型：
+
+```text
+LineageAsset
+LineageAssetDraft
+LineageAssetType
+LineageDirection
+LineageGraph
+LineageMaintenanceService
+LineageRelation
+LineageRelationDraft
+LineageRelationType
+LineageService
+SqlProjectionLineageAnalyzer
+```
+
+在后续 Domain / Service / Analysis 阶段完成前，不允许继续向根包增加新的 production 类型。新增能力应直接进入长期角色 package，或在对应重构阶段更新 contract。
+
+## Change Rules
+
+1. 一个 PR 一个主要边界或行为关注点；
+2. Stage 1 不改 REST、DB schema、Flyway 和领域语义；
+3. package move 与 behavior change 尽量分开；
+4. 新入口稳定后不长期保留 production 双入口；
+5. Maven 子模块拆分必须由真实依赖隔离需求驱动，不为目录美观提前拆 jar；
+6. 新 dependency 必须同时符合 `ARCHITECTURE.md + DEPENDENCIES.md`；
+7. dependency guard 的白名单只能因真实架构变化收窄或经评审调整，不能为了让测试通过随意扩大。

--- a/yak-ops-business/yak-ops-business-lineage/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-lineage/DEPENDENCIES.md
@@ -1,0 +1,96 @@
+# Lineage Dependencies
+
+本文定义 Lineage 的 package 依赖方向与当前过渡 corridor。
+
+## Target Dependency Graph
+
+长期方向保持单向、可解释：
+
+```text
+controller
+    ↓
+service
+    ├──────────────→ analysis ─────→ domain
+    ├──────────────→ collector ────→ domain
+    │                    └─────────→ analysis
+    ├──────────────→ repository ───→ domain
+    │                    ↓
+    │                   dao
+    └──────────────→ domain
+
+config  <- infrastructure-only configuration
+```
+
+建议依赖矩阵：
+
+| Source | May depend on |
+| --- | --- |
+| `controller` | `service`, transport-local mapper/dto/vo |
+| `service` | `domain`, `analysis`, `collector`, `repository` |
+| `analysis` | `domain` |
+| `collector` | `domain`, `analysis` |
+| `repository` | `domain`, `dao`, `config`, `repository.support` |
+| `dao` | `config`, DAO-local mapper/model/support |
+| `domain` | no Lineage application/infrastructure package |
+| `config` | configuration-only dependencies |
+
+目标图不得形成 `domain -> repository -> service`、`dao -> repository` 或其他反向依赖。
+
+## Current Transitional Corridors
+
+Stage 1 不移动 production class，因此当前存在两个明确债务：
+
+```text
+controller -> root LineageService
+root LineageService / LineageMaintenanceService -> repository
+repository adapter -> root Asset / Relation domain records
+```
+
+根包同时放着 Domain、Service 和 Analyzer，使完整 package graph 暂时无法表达为无环图。这个状态被 `LineageDependencyBoundaryTest` 显式冻结：**债务可以减少，不能继续增长**。
+
+后续顺序：
+
+```text
+Domain move
+  -> Service facade split
+  -> Analyzer / Collector role placement
+  -> tighten dependency matrix
+```
+
+## Forbidden Shortcuts
+
+以下依赖不允许出现：
+
+```text
+controller -> repository / dao / mapper / PO
+service -> dao / mapper / PO
+repository -> controller / DTO / VO
+dao -> controller / service / repository / domain orchestration
+domain -> Spring / MyBatis / repository / controller
+```
+
+HTTP transport mapping 留在 `controller`；持久化兼容转换留在 `repository`/`dao`；外部平台 SDK 留在 `analysis`/`collector` 的边界实现。
+
+## External Module Dependencies
+
+Lineage 当前可以依赖 Yak Ops 公共能力与 datasource 业务模块，但不能为了 SQL lineage 直接反向依赖 data-development 的具体 parser/runtime 实现。
+
+跨业务模块复用 Lineage 时，优先依赖稳定公开 contract，不允许调用对方 DAO 或内部实现类。
+
+## Maven Boundary
+
+Stage 1 保持单一 `yak-ops-business-lineage` Maven module，不提前拆 `lineage-core / lineage-api / lineage-flink / lineage-spark`。
+
+只有当出现真实的编译期隔离需求，例如某个平台 SDK 体积大、依赖冲突明显、需要独立发布或可选装载时，才考虑拆 Maven artifact。先把 Java 依赖方向拆清楚，再决定物理 jar 边界。
+
+## Governance
+
+`LineageArchitectureTest` 保护反射可见的层次语义；`LineageDependencyBoundaryTest` 扫描 production source，保护：
+
+- 根包过渡债务不增长；
+- top-level package 必须经过声明；
+- Controller 不穿透持久化；
+- Repository 不依赖 HTTP contract；
+- DAO 不反向依赖上层；
+- 未来 Domain package 保持 framework/persistence free；
+- `common/helper/utils/base` 业务大桶不能回流。

--- a/yak-ops-business/yak-ops-business-lineage/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-lineage/DOMAIN.md
@@ -1,0 +1,98 @@
+# Lineage Domain
+
+本文定义 Lineage 的核心领域语义。结构重构不能因为类移动或角色拆分改变这些含义。
+
+## Asset
+
+`LineageAsset` 是参与元数据图的稳定对象身份。
+
+当前支持的类型包括：
+
+```text
+TABLE
+COLUMN
+SQL_TASK
+DATASET
+DATASET_FIELD
+CHART
+DASHBOARD
+```
+
+`assetKey` 是业务可稳定寻址的键；`id` 是持久化标识。`sourceType/sourceId` 表达资产的来源或 ownership 线索，不等价于通用 Asset identity。
+
+表、字段类资产可以携带 `dataSourceId / databaseName / schemaName / tableName / columnName`；`parentAssetId` 表达层级包含关系的父资产引用。扩展属性通过 `properties` 承载，但不能替代需要稳定查询和约束的核心字段。
+
+## Relation
+
+`LineageRelation` 是从 upstream source asset 指向 downstream target asset 的有向边。
+
+```text
+sourceAssetId  ───────────────>  targetAssetId
+       upstream                    downstream
+```
+
+当前关系类型：
+
+- `READS_FROM`
+- `WRITES_TO`
+- `DERIVES_FROM`
+- `CONSUMES`
+- `CONTAINS`
+
+关系类型描述 target 如何使用、派生或包含 source。调用方不能通过交换 source/target 来表达相反语义。
+
+## Evidence
+
+关系可以携带：
+
+```text
+sourceType
+sourceId
+expression
+confidence
+version
+observedAt
+properties
+```
+
+`sourceType + sourceId` 是自动生成血缘的重要 evidence scope，用于替换同一来源重新计算出的关系。`version` 用于区分来源版本；`observedAt` 表达观测时间；`confidence` 范围固定为 `[0, 1]`。
+
+Evidence 说明“为什么存在这条边”，不负责重新定义 Asset identity。
+
+## Graph
+
+`LineageGraph` 是一次有边界的图查询结果，而不是新的持久化事实。
+
+```text
+root
++ direction(UPSTREAM / DOWNSTREAM / BOTH)
++ requested depth
++ deduplicated assets
++ deduplicated relations
+```
+
+当前最大遍历深度为 10。图读取不能修改关系或资产状态。
+
+## Replacement
+
+自动生成来源重新发布血缘时采用 evidence-scoped replacement：
+
+```text
+beginReplacement
+  -> capture old evidence endpoints
+  -> delete old evidence relations
+  -> publish new assets / relations
+  -> delete only unreferenced assets owned by the caller
+```
+
+清理必须保守。无法证明 ownership 或仍被其他边/子资产引用时，宁可保留资产，也不能误删其他来源共享的元数据。
+
+## Revision Ordering
+
+同一资产来源存在 revision 时，新 revision 已提交后，旧 revision 不能覆盖新结果。revision ordering 是领域安全规则，不应依赖请求恰好串行。
+
+## SQL Projection Contract
+
+`SqlProjectionLineageAnalyzer` 负责把只读 SQL projection 映射到物理来源字段，输出 source table、source column、output column、mapping kind、表达式与 ordinal 等信息。
+
+核心模块只拥有 contract。Schema provider 和具体 parser 是边界实现；无法解析的引用通过 unresolved count 暴露，而不是静默制造错误的物理字段血缘。

--- a/yak-ops-business/yak-ops-business-lineage/README.md
+++ b/yak-ops-business/yak-ops-business-lineage/README.md
@@ -1,0 +1,62 @@
+# Lineage
+
+Lineage 是 Yak Ops 的统一元数据血缘模块，负责维护可稳定寻址的元数据资产、带来源证据的有向关系，以及受限深度的上下游图查询。
+
+## Read First
+
+本目录只维护**当前有效 contract**，历史迁移过程以 Git / PR 为准。
+
+| Document | Answers |
+| --- | --- |
+| [`REQUIREMENTS.md`](./REQUIREMENTS.md) | 模块需要提供什么能力、哪些事情不在这里做 |
+| [`DOMAIN.md`](./DOMAIN.md) | Asset / Relation / Evidence / Graph 的领域语义 |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 长期 package、角色与持久化边界 |
+| [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package 可以依赖谁、当前过渡债务是什么 |
+| [`CODE_STYLE.md`](../../CODE_STYLE.md) | Yak Ops 仓库统一工程与代码规范 |
+| [`REVIEW.md`](./REVIEW.md) | Lineage PR 的评审标准 |
+
+## Current Contract
+
+当前生产代码已经具备 `controller -> application service -> repository -> dao` 的基础分层，也已经把 MyBatis PO 与 HTTP DTO 隔离在边界之外；但领域模型、稳定 Service 和分析接口仍有一部分平铺在 `io.yak.ops.business.lineage` 根包。
+
+Stage 1 只建立长期架构合同和可执行护栏，**不修改 REST、数据库、Flyway、领域行为与持久化语义**。后续阶段会按合同逐步消除根包过渡债务，而不是一次性重写。
+
+## Core Model
+
+```text
+LineageAsset
+    │
+    │ source -> target
+    ▼
+LineageRelation
+    │
+    └── evidence(sourceType + sourceId + version + observedAt)
+
+LineageGraph = root + direction + bounded depth + assets + relations
+```
+
+关系方向固定为**上游资产 -> 下游资产**。`READS_FROM / WRITES_TO / DERIVES_FROM / CONSUMES / CONTAINS` 描述下游如何使用、派生或包含上游。
+
+## Planned Package Shape
+
+```text
+io.yak.ops.business.lineage
+├── controller          # HTTP inbound + transport mapping
+├── service             # stable application facades
+├── domain              # framework-free lineage domain/value objects
+├── analysis            # source-neutral lineage analysis roles
+├── collector           # Flink/Spark/Hadoop 等来源的采集角色
+├── repository          # persistence contracts + adapters
+├── dao                 # MyBatis persistence primitives / PO
+└── config              # module configuration
+```
+
+技术名称不直接决定业务层级。Flink、Spark、Hadoop 等实现应挂在明确角色下面，例如 `collector/flink`，而不是各自形成一套 Service / DAO / Domain。
+
+## Evolution Rule
+
+后续重构遵守三条底线：
+
+1. package move 与业务行为修改分开；
+2. 新入口稳定后不长期保留 production 双入口；
+3. 架构文档、dependency test 与实际代码一起演进，不能为了让测试通过无条件扩大依赖白名单。

--- a/yak-ops-business/yak-ops-business-lineage/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-lineage/REQUIREMENTS.md
@@ -1,0 +1,65 @@
+# Lineage Requirements
+
+本文描述 Lineage 模块需要长期保持的业务能力与边界，不记录阶段性实现方案。
+
+## Responsibilities
+
+Lineage 负责：
+
+- 注册、更新并查询统一的 `LineageAsset`；
+- 注册带类型、来源证据、置信度与观测时间的有向 `LineageRelation`；
+- 支持批量写入并对同批输入做稳定去重；
+- 以指定根资产查询 upstream / downstream / both 血缘图；
+- 对自动生成血缘按 evidence scope 做安全替换和清理；
+- 提供 source-neutral 的 SQL projection lineage 分析 contract，供数据开发、Dataset 等调用方复用；
+- 为未来 Flink / Spark / Hadoop 等来源保留角色化接入边界。
+
+## Stable Behavior
+
+当前 HTTP、数据库与 Flyway contract 在纯结构重构中保持不变。
+
+图查询继续保持：
+
+- 根资产必须存在；
+- `depth` 有明确上限，当前最大值为 10；
+- 遍历过程中节点与关系去重；
+- 上下游方向由关系的 source / target 决定，不在查询层反转领域语义。
+
+关系写入继续保持：
+
+- source / target 必须是有效资产；
+- 不允许资产指向自身；
+- `confidence` 必须在 `[0, 1]`；
+- evidence 字段用于追踪生成来源，不把来源实现细节变成资产身份。
+
+## Replacement Safety
+
+自动生成血缘允许按 `sourceType + sourceId` 替换，但清理旧资产必须同时满足 ownership、无残留边、无子节点等安全条件。
+
+旧 revision 在新 revision 已提交后不能覆盖新结果。并发发布的正确性属于 Lineage contract，不应下沉为 Controller 或 SQL 拼接约定。
+
+## Analysis Boundary
+
+`SqlProjectionLineageAnalyzer` 是 source-neutral contract。Lineage core 不绑定数据开发模块或某个具体 SQL parser；解析器实现应停留在调用方或明确的 adapter/analysis 实现边界。
+
+未来新增 Flink / Spark / Hadoop 血缘时，应优先回答“它承担什么角色”，再决定 package 和依赖，而不是按技术栈复制一套完整业务结构。
+
+## Non-goals
+
+Lineage 不负责：
+
+- 调度 Flink / Spark / Hadoop 作业；
+- 成为数据开发、离线同步、实时同步的第二套任务状态中心；
+- 在 Core Domain 中直接依赖 MyBatis、Spring MVC、Flink/Spark/Hadoop SDK；
+- 为每个来源维护独立的 Asset / Relation 模型；
+- 在结构重构 PR 中顺便修改 REST path、表结构或既有迁移脚本。
+
+## Acceptance
+
+Lineage 的结构改造至少需要满足：
+
+- 业务行为测试继续通过；
+- architecture / dependency guard 继续通过；
+- HTTP DTO / VO 不进入 Repository/DAO contract；
+- DAO/PO 不进入稳定 Service 与 Domain contract；
+- 新依赖方向与 `ARCHITECTURE.md + DEPENDENCIES.md` 一致。

--- a/yak-ops-business/yak-ops-business-lineage/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-lineage/REVIEW.md
@@ -1,0 +1,73 @@
+# Lineage Review Guide
+
+Lineage PR 评审优先看**领域语义和依赖方向有没有被破坏**，不是只看代码能否编译。
+
+## Scope
+
+- 这个 PR 是否只有一个主要关注点？
+- 纯结构调整是否偷改了 REST、DB schema、Flyway 或业务语义？
+- package move 与 behavior change 是否可以拆开？
+
+## Domain
+
+- Asset identity 是否仍然统一，不因技术来源产生第二套模型？
+- Relation 是否始终表达 upstream source -> downstream target？
+- Evidence 是否只说明来源，不冒充 Asset identity？
+- replacement / revision ordering 是否保持保守和并发安全？
+- Graph/query 是否仍然是只读、有边界的 projection？
+
+## Roles
+
+- 新类名是否能直接说明角色？
+- `Service` 是否只用于稳定应用入口，而不是所有 Spring Bean？
+- Analyzer / Collector / Resolver / Mapper / Repository / DAO 是否各自停在正确边界？
+- Flink / Spark / Hadoop 是否作为角色实现接入，而不是复制一套业务层？
+
+## Dependencies
+
+- Controller 是否只走稳定 Service？
+- Service 是否绕过 Repository 直接访问 DAO/Mapper/PO？
+- Repository contract 是否暴露 HTTP 或 persistence implementation types？
+- DAO 是否反向依赖应用层？
+- Domain 是否出现 Spring/MyBatis/平台 SDK？
+- 是否新增了 `common/helper/utils/base` 之类的大桶？
+
+## Persistence
+
+- Domain ↔ PO 转换是否停在 RepositoryAdapter？
+- MyBatis Mapper/XML 是否只承担数据库 primitive？
+- JSON/compatibility codec 是否位于 persistence boundary，而不是 Core Domain？
+
+## Compatibility
+
+纯架构 PR 默认要求：
+
+```text
+REST contract unchanged
+DB schema unchanged
+Flyway unchanged
+Asset/Relation semantics unchanged
+existing behavior tests unchanged or strengthened
+```
+
+任何例外都必须在 PR body 中单独说明原因与迁移策略。
+
+## Tests
+
+至少检查：
+
+- `LineageArchitectureTest`；
+- `LineageDependencyBoundaryTest`；
+- 被修改用例对应的 behavior test；
+- 如果调整 dependency allowlist，文档是否同步且理由是否真实。
+
+## Reject Signals
+
+以下情况默认要求拆分或返工：
+
+- 为了让测试通过直接扩大依赖白名单；
+- 一个 PR 同时大规模 move package、改表、改接口、改领域行为；
+- 新增 `FlinkLineageService / SparkLineageService / HadoopLineageService` 但职责只是同一用例的技术分叉；
+- Controller 直接操作 Repository/DAO；
+- Domain 开始携带 Mapper/PO/HTTP DTO；
+- 只有 Markdown 约定，没有可执行架构护栏。

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
@@ -18,7 +18,15 @@ class LineageDependencyBoundaryTest {
   private static final String BASE = "io.yak.ops.business.lineage";
 
   private static final Set<String> DECLARED_TOP_LEVEL_PACKAGES =
-      Set.of("analysis", "collector", "config", "controller", "dao", "domain", "repository", "service");
+      Set.of(
+          "analysis",
+          "collector",
+          "config",
+          "controller",
+          "dao",
+          "domain",
+          "repository",
+          "service");
 
   private static final Set<String> TRANSITIONAL_ROOT_TYPES =
       Set.of(
@@ -110,7 +118,8 @@ class LineageDependencyBoundaryTest {
 
   @Test
   void serviceStereotypeCannotLeakIntoInfrastructureOrDomain() throws IOException {
-    for (String packageName : Set.of("analysis", "collector", "config", "dao", "domain", "repository")) {
+    for (String packageName :
+        Set.of("analysis", "collector", "config", "dao", "domain", "repository")) {
       Path root = productionRoot().resolve(packageName);
       if (!Files.isDirectory(root)) continue;
       for (Path file : javaFiles(root)) {
@@ -138,10 +147,14 @@ class LineageDependencyBoundaryTest {
 
     for (Path file : javaFiles(root)) {
       String source = Files.readString(file, StandardCharsets.UTF_8);
+      String imports =
+          source.lines()
+              .filter(line -> line.startsWith("import "))
+              .reduce("", (left, right) -> left + right + "\n");
       for (String token : forbiddenTokens) {
-        assertThat(source)
+        assertThat(imports)
             .as("Forbidden dependency '%s' in %s", token, normalize(file))
-            .doesNotContain("import " + token);
+            .doesNotContain(token);
       }
     }
   }
@@ -164,7 +177,9 @@ class LineageDependencyBoundaryTest {
             "yak-ops-business-lineage",
             "src/main/java/io/yak/ops/business/lineage");
     assertThat(Files.isDirectory(repositoryRelative))
-        .as("Unable to locate Lineage production source root from %s", Paths.get(".").toAbsolutePath())
+        .as(
+            "Unable to locate Lineage production source root from %s",
+            Paths.get(".").toAbsolutePath())
         .isTrue();
     return repositoryRelative;
   }

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
@@ -1,0 +1,175 @@
+package io.yak.ops.business.lineage.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Source-level guard for the staged Lineage package migration and long-term boundaries. */
+class LineageDependencyBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.lineage";
+
+  private static final Set<String> DECLARED_TOP_LEVEL_PACKAGES =
+      Set.of("analysis", "collector", "config", "controller", "dao", "domain", "repository", "service");
+
+  private static final Set<String> TRANSITIONAL_ROOT_TYPES =
+      Set.of(
+          "LineageAsset.java",
+          "LineageAssetDraft.java",
+          "LineageAssetType.java",
+          "LineageDirection.java",
+          "LineageGraph.java",
+          "LineageMaintenanceService.java",
+          "LineageRelation.java",
+          "LineageRelationDraft.java",
+          "LineageRelationType.java",
+          "LineageService.java",
+          "SqlProjectionLineageAnalyzer.java");
+
+  @Test
+  void transitionalRootPackageDebtCannotGrow() throws IOException {
+    Set<String> actual = new HashSet<>();
+    try (Stream<Path> files = Files.list(productionRoot())) {
+      files.filter(Files::isRegularFile)
+          .filter(path -> path.toString().endsWith(".java"))
+          .map(path -> path.getFileName().toString())
+          .forEach(actual::add);
+    }
+
+    assertThat(actual)
+        .as("Root-package debt is transitional: move/remove existing types, do not add new ones")
+        .containsExactlyInAnyOrderElementsOf(TRANSITIONAL_ROOT_TYPES);
+  }
+
+  @Test
+  void productionTopLevelPackagesMustBeDeclared() throws IOException {
+    Set<String> actual = new HashSet<>();
+    try (Stream<Path> paths = Files.list(productionRoot())) {
+      paths.filter(Files::isDirectory)
+          .map(path -> path.getFileName().toString())
+          .forEach(actual::add);
+    }
+
+    assertThat(DECLARED_TOP_LEVEL_PACKAGES)
+        .as("New top-level Lineage packages require an architecture contract update")
+        .containsAll(actual);
+  }
+
+  @Test
+  void controllerCannotReachPersistenceImplementation() throws IOException {
+    assertNoImports(
+        "controller",
+        BASE + ".repository.",
+        BASE + ".dao.",
+        "com.baomidou.mybatisplus",
+        "JdbcTemplate");
+  }
+
+  @Test
+  void repositoryCannotReachHttpContracts() throws IOException {
+    assertNoImports(
+        "repository",
+        BASE + ".controller.",
+        ".controller.v1.dto.",
+        ".controller.v1.vo.");
+  }
+
+  @Test
+  void daoCannotPointBackToApplicationRoles() throws IOException {
+    assertNoImports(
+        "dao",
+        BASE + ".controller.",
+        BASE + ".service.",
+        BASE + ".analysis.",
+        BASE + ".collector.",
+        BASE + ".repository.",
+        BASE + ".domain.");
+  }
+
+  @Test
+  void futureDomainPackageMustRemainFrameworkAndPersistenceFree() throws IOException {
+    assertNoImports(
+        "domain",
+        "org.springframework",
+        "com.baomidou.mybatisplus",
+        BASE + ".controller.",
+        BASE + ".service.",
+        BASE + ".repository.",
+        BASE + ".dao.",
+        BASE + ".analysis.",
+        BASE + ".collector.");
+  }
+
+  @Test
+  void serviceStereotypeCannotLeakIntoInfrastructureOrDomain() throws IOException {
+    for (String packageName : Set.of("analysis", "collector", "config", "dao", "domain", "repository")) {
+      Path root = productionRoot().resolve(packageName);
+      if (!Files.isDirectory(root)) continue;
+      for (Path file : javaFiles(root)) {
+        String source = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(source)
+            .as("@Service is reserved for stable application facades: %s", normalize(file))
+            .doesNotContain("@Service");
+      }
+    }
+  }
+
+  @Test
+  void broadBusinessBucketsCannotAppear() {
+    Path root = productionRoot();
+    for (String forbidden : Set.of("common", "helper", "utils", "base")) {
+      assertThat(Files.exists(root.resolve(forbidden)))
+          .as("Broad business bucket '%s' must not exist under Lineage", forbidden)
+          .isFalse();
+    }
+  }
+
+  private void assertNoImports(String packageName, String... forbiddenTokens) throws IOException {
+    Path root = productionRoot().resolve(packageName);
+    if (!Files.isDirectory(root)) return;
+
+    for (Path file : javaFiles(root)) {
+      String source = Files.readString(file, StandardCharsets.UTF_8);
+      for (String token : forbiddenTokens) {
+        assertThat(source)
+            .as("Forbidden dependency '%s' in %s", token, normalize(file))
+            .doesNotContain("import " + token);
+      }
+    }
+  }
+
+  private Set<Path> javaFiles(Path root) throws IOException {
+    Set<Path> result = new HashSet<>();
+    try (Stream<Path> files = Files.walk(root)) {
+      files.filter(path -> path.toString().endsWith(".java")).forEach(result::add);
+    }
+    return result;
+  }
+
+  private Path productionRoot() {
+    Path moduleLocal = Paths.get("src/main/java/io/yak/ops/business/lineage");
+    if (Files.isDirectory(moduleLocal)) return moduleLocal;
+
+    Path repositoryRelative =
+        Paths.get(
+            "yak-ops-business",
+            "yak-ops-business-lineage",
+            "src/main/java/io/yak/ops/business/lineage");
+    assertThat(Files.isDirectory(repositoryRelative))
+        .as("Unable to locate Lineage production source root from %s", Paths.get(".").toAbsolutePath())
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+}


### PR DESCRIPTION
## Summary

Establish the Stage 1 architecture contract for `yak-ops-business-lineage` without changing production behavior.

This PR aligns Lineage with the architecture-governance style already used by Offline/Realtime Sync: package responsibilities are documented, current structural debt is made explicit, and source-level dependency guards prevent that debt from growing before the next migration stages.

## What changed

- add `README.md` as the Lineage documentation entry point
- add `REQUIREMENTS.md` for module scope and non-goals
- add `DOMAIN.md` for Asset / Relation / Evidence / Graph semantics
- add `ARCHITECTURE.md` for the long-term package map and role vocabulary
- add `DEPENDENCIES.md` for target dependency direction and transitional corridors
- add `REVIEW.md` for Lineage-specific review rules
- add `LineageDependencyBoundaryTest`
  - freezes the current root-package migration debt
  - requires top-level packages to be architecture-declared
  - prevents Controller -> persistence shortcuts
  - prevents Repository -> HTTP contract dependencies
  - prevents DAO -> application-layer back references
  - protects the future `domain` package from Spring/MyBatis/persistence dependencies
  - prevents broad `common/helper/utils/base` business buckets
  - reserves `@Service` for stable application facades

## Intentionally unchanged

- REST API contract
- production Java behavior
- database schema
- Flyway migrations
- persistence semantics
- Maven module layout

Stage 1 does **not** move `LineageAsset`, `LineageRelation`, `LineageService`, or `SqlProjectionLineageAnalyzer`. Those root-package types are explicitly recorded as transitional debt so later stages can move/split them in isolated PRs.

## Follow-up stages

1. move Asset / Relation / Graph into `domain`
2. split stable query/write/maintenance Service facades
3. place Analyzer / Collector implementations by role
4. tighten persistence and Maven dependency boundaries
5. remove transitional root-package allowlist and lock the final acyclic package graph

## Validation

- reviewed `main...refactor/lineage-stage1-architecture-contract`: 7 added files only
- no production source, POM, SQL, or Flyway diff
- local Maven execution was not available in the execution environment because external GitHub DNS access is disabled; repository CI is expected to provide the executable validation
