### PR TITLE
refactor(lineage): move core models into domain package

### DIFF
--- a/yak-ops-business/yak-ops-business-lineage/README.md
+++ b/yak-ops-business/yak-ops-business-lineage/README.md
@@ -17,9 +17,9 @@ Lineage 是 Yak Ops 的统一元数据血缘模块，负责维护可稳定寻址
 
 ## Current Contract
 
-当前生产代码已经具备 `controller -> application service -> repository -> dao` 的基础分层，也已经把 MyBatis PO 与 HTTP DTO 隔离在边界之外；但领域模型、稳定 Service 和分析接口仍有一部分平铺在 `io.yak.ops.business.lineage` 根包。
+当前生产代码已经具备 `controller -> application service -> repository -> dao` 的基础分层，并把 MyBatis PO 与 HTTP DTO 隔离在边界之外。Stage 2 已将 Asset / Relation / Graph 及相关枚举、Draft 收拢到 `io.yak.ops.business.lineage.domain`；稳定 Service 和 SQL 分析接口仍暂时保留在根包。
 
-Stage 1 只建立长期架构合同和可执行护栏，**不修改 REST、数据库、Flyway、领域行为与持久化语义**。后续阶段会按合同逐步消除根包过渡债务，而不是一次性重写。
+Stage 1 建立长期架构合同和可执行护栏，Stage 2 只完成 Domain package 迁移与引用修复，**不修改 REST、数据库、Flyway、领域行为与持久化语义**。后续阶段继续按合同消除剩余根包过渡债务，而不是一次性重写。
 
 ## Core Model
 

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/LineageService.java
@@ -1,6 +1,14 @@
 package io.yak.ops.business.lineage;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetDraft;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageDirection;
+import io.yak.ops.business.lineage.domain.LineageGraph;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.domain.LineageRelationDraft;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
 import io.yak.ops.business.lineage.repository.LineageRepository;
 import java.math.BigDecimal;
 import java.time.Instant;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/LineageController.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/LineageController.java
@@ -3,8 +3,6 @@ package io.yak.ops.business.lineage.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
-import io.yak.ops.business.lineage.LineageAssetType;
-import io.yak.ops.business.lineage.LineageDirection;
 import io.yak.ops.business.lineage.LineageService;
 import io.yak.ops.business.lineage.controller.v1.converter.LineageRequestConverter;
 import io.yak.ops.business.lineage.controller.v1.converter.LineageViewConverter;
@@ -13,6 +11,8 @@ import io.yak.ops.business.lineage.controller.v1.dto.LineageRequests.RegisterRel
 import io.yak.ops.business.lineage.controller.v1.vo.LineageViews.AssetView;
 import io.yak.ops.business.lineage.controller.v1.vo.LineageViews.GraphView;
 import io.yak.ops.business.lineage.controller.v1.vo.LineageViews.RelationView;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageDirection;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/converter/LineageViewConverter.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/converter/LineageViewConverter.java
@@ -1,11 +1,11 @@
 package io.yak.ops.business.lineage.controller.v1.converter;
 
-import io.yak.ops.business.lineage.LineageAsset;
-import io.yak.ops.business.lineage.LineageGraph;
-import io.yak.ops.business.lineage.LineageRelation;
 import io.yak.ops.business.lineage.controller.v1.vo.LineageViews.AssetView;
 import io.yak.ops.business.lineage.controller.v1.vo.LineageViews.GraphView;
 import io.yak.ops.business.lineage.controller.v1.vo.LineageViews.RelationView;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageGraph;
+import io.yak.ops.business.lineage.domain.LineageRelation;
 import java.util.List;
 import org.springframework.stereotype.Component;
 

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/dto/LineageRequests.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/dto/LineageRequests.java
@@ -1,8 +1,8 @@
 package io.yak.ops.business.lineage.controller.v1.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.ops.business.lineage.LineageAssetType;
-import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/vo/LineageViews.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/vo/LineageViews.java
@@ -1,9 +1,9 @@
 package io.yak.ops.business.lineage.controller.v1.vo;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.yak.ops.business.lineage.LineageAssetType;
-import io.yak.ops.business.lineage.LineageDirection;
-import io.yak.ops.business.lineage.LineageRelationType;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageDirection;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAsset.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAsset.java
@@ -1,9 +1,11 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
 
-/** Validated domain write model for registering a metadata asset. */
-public record LineageAssetDraft(
+/** Stable identity for an object participating in the Yak Ops metadata graph. */
+public record LineageAsset(
+    long id,
     String assetKey,
     LineageAssetType assetType,
     String name,
@@ -15,5 +17,7 @@ public record LineageAssetDraft(
     String schemaName,
     String tableName,
     String columnName,
-    JsonNode properties) {
+    JsonNode properties,
+    Instant createTime,
+    Instant updateTime) {
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAssetDraft.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAssetDraft.java
@@ -1,11 +1,9 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.time.Instant;
 
-/** Stable identity for an object participating in the Yak Ops metadata graph. */
-public record LineageAsset(
-    long id,
+/** Validated domain write model for registering a metadata asset. */
+public record LineageAssetDraft(
     String assetKey,
     LineageAssetType assetType,
     String name,
@@ -17,7 +15,5 @@ public record LineageAsset(
     String schemaName,
     String tableName,
     String columnName,
-    JsonNode properties,
-    Instant createTime,
-    Instant updateTime) {
+    JsonNode properties) {
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAssetType.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAssetType.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 /** First-stage asset types shared by data development, catalog and BI consumption. */
 public enum LineageAssetType {

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageDirection.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageDirection.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 public enum LineageDirection {
   UPSTREAM,

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageGraph.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageGraph.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 import java.util.List;
 

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelation.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelation.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelationDraft.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelationDraft.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelationType.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelationType.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.lineage;
+package io.yak.ops.business.lineage.domain;
 
 /**
  * Typed metadata relationships. Every edge is persisted from upstream asset to downstream asset.

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepository.java
@@ -1,10 +1,10 @@
 package io.yak.ops.business.lineage.repository;
 
-import io.yak.ops.business.lineage.LineageAsset;
-import io.yak.ops.business.lineage.LineageAssetDraft;
-import io.yak.ops.business.lineage.LineageAssetType;
-import io.yak.ops.business.lineage.LineageRelation;
-import io.yak.ops.business.lineage.LineageRelationDraft;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetDraft;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.domain.LineageRelationDraft;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
@@ -1,14 +1,14 @@
 package io.yak.ops.business.lineage.repository;
 
-import io.yak.ops.business.lineage.LineageAsset;
-import io.yak.ops.business.lineage.LineageAssetDraft;
-import io.yak.ops.business.lineage.LineageAssetType;
-import io.yak.ops.business.lineage.LineageRelation;
-import io.yak.ops.business.lineage.LineageRelationDraft;
-import io.yak.ops.business.lineage.LineageRelationType;
 import io.yak.ops.business.lineage.dao.LineageDao;
 import io.yak.ops.business.lineage.dao.model.LineageAssetPO;
 import io.yak.ops.business.lineage.dao.model.LineageRelationPO;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetDraft;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.domain.LineageRelationDraft;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
 import io.yak.ops.business.lineage.repository.support.LineageJsonCodec;
 import java.sql.Timestamp;
 import java.util.LinkedHashMap;

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageArchitectureTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.yak.ops.business.lineage.controller.v1.LineageController;
 import io.yak.ops.business.lineage.dao.LineageDao;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageRelation;
 import io.yak.ops.business.lineage.repository.LineageRepository;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageMaintenanceServiceTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageMaintenanceServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
 import io.yak.ops.business.lineage.repository.LineageRepository;
 import java.time.Instant;
 import java.util.Optional;

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageServiceTest.java
@@ -4,6 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.yak.ops.business.lineage.dao.support.LineageBatchSupport;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetDraft;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageGraph;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.domain.LineageRelationDraft;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
 import io.yak.ops.business.lineage.repository.LineageRepository;
 import java.time.Instant;
 import java.util.LinkedHashMap;

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageViewMapperTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/LineageViewMapperTest.java
@@ -2,14 +2,18 @@ package io.yak.ops.business.lineage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.yak.ops.business.lineage.controller.v1.mapper.LineageViewMapper;
+import io.yak.ops.business.lineage.controller.v1.converter.LineageViewConverter;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
 import java.math.BigDecimal;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class LineageViewMapperTest {
 
-  private final LineageViewMapper mapper = new LineageViewMapper();
+  private final LineageViewConverter converter = new LineageViewConverter();
 
   @Test
   void httpViewsKeepLongIdentifiersAsStrings() {
@@ -32,7 +36,7 @@ class LineageViewMapperTest {
         Instant.EPOCH,
         Instant.EPOCH);
 
-    var view = mapper.asset(asset);
+    var view = converter.asset(asset);
 
     assertEquals(String.valueOf(assetId), view.id());
     assertEquals(String.valueOf(parentId), view.parentAssetId());
@@ -55,7 +59,7 @@ class LineageViewMapperTest {
         Instant.EPOCH,
         Instant.EPOCH);
 
-    var view = mapper.relation(relation);
+    var view = converter.relation(relation);
 
     assertEquals("9007199254740995", view.id());
     assertEquals("9007199254740993", view.sourceAssetId());

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
@@ -30,15 +30,7 @@ class LineageDependencyBoundaryTest {
 
   private static final Set<String> TRANSITIONAL_ROOT_TYPES =
       Set.of(
-          "LineageAsset.java",
-          "LineageAssetDraft.java",
-          "LineageAssetType.java",
-          "LineageDirection.java",
-          "LineageGraph.java",
           "LineageMaintenanceService.java",
-          "LineageRelation.java",
-          "LineageRelationDraft.java",
-          "LineageRelationType.java",
           "LineageService.java",
           "SqlProjectionLineageAnalyzer.java");
 
@@ -103,7 +95,7 @@ class LineageDependencyBoundaryTest {
   }
 
   @Test
-  void futureDomainPackageMustRemainFrameworkAndPersistenceFree() throws IOException {
+  void domainPackageMustRemainFrameworkAndPersistenceFree() throws IOException {
     assertNoImports(
         "domain",
         "org.springframework",


### PR DESCRIPTION
## 背景

这是 Lineage 架构演进的 **Stage 2**。Stage 1 已在 #747 建立长期 package contract 与依赖护栏；本阶段开始消除根包中的领域模型债务。

## 本次改动

- 将 8 个核心血缘模型迁移到 `io.yak.ops.business.lineage.domain`
  - `LineageAsset`
  - `LineageAssetDraft`
  - `LineageAssetType`
  - `LineageDirection`
  - `LineageGraph`
  - `LineageRelation`
  - `LineageRelationDraft`
  - `LineageRelationType`
- 同步更新 Application Service、Controller、HTTP Converter/DTO/VO、Repository Adapter 与测试引用
- 收紧 architecture guard：核心模型必须由 `domain` package 持有，根包过渡债务由 11 个类型缩减为 3 个
- 更新 README、架构、依赖与评审文档，记录 Domain move 已完成

## 边界

本 PR 仅做结构迁移，不改变运行行为：

- 不修改 REST 路径、请求或响应语义
- 不修改数据库表、Flyway 或持久化语义
- 不改变 Asset / Relation / Graph 的领域含义
- 暂不拆分 Query / Write Service
- 暂不迁移 Analyzer / Collector

## 验证

- 已核对本 PR 相对 Stage 1 仅包含 Domain move 与配套引用/文档更新
- 已检查生产代码对旧根包模型的引用迁移
- 已更新领域无框架依赖、根包债务冻结等 architecture tests
- GitHub CI 结果以本 Draft PR checks 为准

## 后续

Stage 3 将拆分稳定的 Query / Write Service facade，并继续消除根包中的 Service 债务。