### PR TITLE
refactor(lineage): tighten persistence and Maven boundaries

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/pom.xml
+++ b/yak-ops-business/yak-ops-business-datasource/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
@@ -63,6 +68,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-mysql</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
@@ -10,9 +10,10 @@
 2. **Stable entry, specialized roles.** Controller 只进入稳定应用 Service；内部用 Analyzer / Collector / Resolver / Converter / Repository 等角色表达职责。
 3. **One lineage model.** 不为 Flink、Spark、Hadoop、Dataset、SQL Task 各建一套 Asset/Relation。
 4. **External technology stops at boundary.** Parser、SDK、CLI、HTTP client、MyBatis PO 不能穿透到 Core Domain。
-5. **Read does not mutate.** Graph/query side 不因读取失败反向改写领域事实。
-6. **Structure change is not behavior change.** package move、class split 与 REST / DB / Flyway / Domain semantic change 分开评审。
-7. **Architecture is executable.** 文档 contract 必须由 architecture/dependency tests 持续保护。
+5. **Dependency ownership is explicit.** Driver、vendor runtime、UI runtime 与 parser plugin 由实际装配者持有，不挂在 Lineage POM 里“顺便带上”。
+6. **Read does not mutate.** Graph/query side 不因读取失败反向改写领域事实。
+7. **Structure change is not behavior change.** package、POM、class split 与 REST / DB / Flyway / Domain semantic change 分开评审。
+8. **Architecture is executable.** 文档 contract 必须由 architecture/dependency tests 持续保护。
 
 ## Package Map
 
@@ -27,7 +28,7 @@ io.yak.ops.business.lineage
 ├── repository          # persistence contracts + adapters
 │   └── support         # persistence-only codecs/mapping helpers
 ├── dao                 # MyBatis primitives / mapper / PO
-└── config              # module configuration
+└── config              # Lineage wiring + narrow external infrastructure corridor
 ```
 
 `common / helper / utils / base` 不能成为新的业务大桶。根包也不能重新承担兼容层。需要新 top-level package 时，必须先说明它代表的稳定角色并同步更新文档与护栏。
@@ -60,7 +61,8 @@ Query 只负责资产定位、搜索和有界图遍历；Write 负责资产/关�
 - **Mapper / Converter**：边界表示转换，不承载业务状态机；
 - **Repository**：领域持久化 contract；
 - **RepositoryAdapter**：把领域模型翻译为 DAO/PO；
-- **DAO**：数据库读写 primitive，不承载应用编排。
+- **DAO**：数据库读写 primitive，不承载应用编排；
+- **Configuration**：装配本模块及窄外部基础设施 corridor，不承载业务用例。
 
 ## Domain Boundary
 
@@ -136,9 +138,56 @@ Mapper / PO / MyBatis / DB
 
 - Repository contract 不暴露 DAO model、Mapper、Controller DTO/VO；
 - Service 不直接依赖 DAO / Mapper / PO；
-- DAO 不反向依赖 Service / Controller / Repository；
+- DAO 不反向依赖 Service / Controller / Repository / Domain orchestration；
 - Repository adapter 是 Domain ↔ Persistence 的转换位置；
 - `LineageJsonCodec` 等持久化表示 helper 留在 `repository.support`。
+
+## Persistence Configuration Corridor
+
+Lineage 使用共享业务数据库，但不允许 Datasource 模块散落到 DAO、Repository 或 Service：
+
+```text
+config/ConditionalOnLineagePersistence
+    -> datasource.config.ConditionalOnDataSourceEnabled
+
+config/LineagePersistenceConfiguration
+    -> datasource.config.BusinessDatabaseConfiguration
+    -> datasource.config.DataSourceProperties
+```
+
+`LineageDaoImpl` 只使用 `ConditionalOnLineagePersistence`。因此未来 Datasource 开关或配置方式变化时，适配点留在 `config`，不会扩散到持久化 primitive。
+
+该 corridor 由源码级测试精确匹配文件和 imported type；新增外部 business import 默认失败。
+
+## Maven Assembly Boundary
+
+Lineage Maven module 保持自包含的业务实现，但不承担整个应用的运行时装配：
+
+| Capability | Owner |
+| --- | --- |
+| HTTP endpoint / validation | Lineage Web + Validation dependencies |
+| Transaction annotation | `spring-tx` |
+| Mapper / MyBatis API | MyBatis-Plus starter |
+| Migration API and Lineage migration bean | `flyway-core` |
+| OpenAPI source annotations | `swagger-annotations-jakarta` |
+| Shared MyBatis SQL parser runtime | Datasource module |
+| MySQL Flyway vendor runtime | Datasource module |
+| JDBC database drivers | Explicit application/plugin assembly, not Lineage |
+| Swagger UI/runtime | Explicit application assembly, not Lineage |
+
+`yak-ops-business-datasource` 在 Lineage POM 中是 optional：Lineage 编译仍能使用明确的配置 corridor，但下游必须显式选择 Datasource，不会因为使用血缘查询 contract 就被动继承数据库运行时。
+
+该表只定义 Lineage 的所有权边界，不宣称本阶段已经统一仓库内其他业务模块的历史 POM；其他模块若因自身持久化仍直接声明 runtime，后续按各自模块独立治理。
+
+以下依赖不得回到 Lineage POM：
+
+```text
+spring-boot-starter-jdbc
+springdoc-openapi-starter-webmvc-ui
+mybatis-plus-jsqlparser-4.9
+flyway-mysql
+mysql-connector-j
+```
 
 ## Root Package Rule
 
@@ -152,10 +201,26 @@ analysis/sql/*
 
 不保留旧根包兼容 wrapper。仓库级源码扫描会阻止旧 Service、Domain 和 Analyzer import 回流。
 
+## Executable Graph
+
+最终 top-level package 图由测试锁定并保持无环：
+
+```text
+controller -> service -> analysis / collector / repository / domain
+collector  -> analysis / domain
+analysis   -> domain
+repository -> dao / domain
+dao        -> config
+config     -> external persistence corridor only
+domain     -> no Lineage application/infrastructure package
+```
+
+文档中的允许边不代表必须提前创建实现；例如 Collector 仍然只在真实采集需求出现时新增。
+
 ## Change Rules
 
 1. 一个 PR 一个主要边界或行为关注点；
-2. package move 与 behavior change 尽量分开；
+2. package、POM 与 behavior change 尽量分开；
 3. 新入口稳定后不长期保留 production 双入口；
 4. Maven 子模块拆分必须由真实依赖隔离需求驱动，不为目录美观提前拆 jar；
 5. 新 dependency 必须同时符合 `ARCHITECTURE.md + DEPENDENCIES.md`；

--- a/yak-ops-business/yak-ops-business-lineage/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-lineage/DEPENDENCIES.md
@@ -1,10 +1,10 @@
 # Lineage Dependencies
 
-本文定义 Lineage 的 package 依赖方向与跨模块 corridor。
+本文定义 Lineage 的 package 依赖方向、跨模块 corridor 与 Maven 运行时归属。
 
-## Target Dependency Graph
+## Final Dependency Graph
 
-长期方向保持单向、可解释：
+长期方向保持单向、可解释，并由源码测试验证无环：
 
 ```text
 controller
@@ -15,32 +15,32 @@ service
     │                    └─────────→ analysis
     ├──────────────→ repository ───→ domain
     │                    ↓
-    │                   dao
+    │                   dao ───────→ config
     └──────────────→ domain
 
-config  <- infrastructure-only configuration
+config -> declared external persistence corridor only
 ```
 
-建议依赖矩阵：
+允许矩阵：
 
 | Source | May depend on |
 | --- | --- |
-| `controller` | `service`, transport-local converter/dto/vo |
+| `controller` | `service`, `domain`, transport-local converter/dto/vo |
 | `service` | `domain`, `analysis`, `collector`, `repository` |
-| `analysis` | JDK, `domain` when a shared domain value is required |
-| `collector` | `domain`, `analysis`, stable service contract |
-| `repository` | `domain`, `dao`, `config`, `repository.support` |
+| `analysis` | `domain` |
+| `collector` | `domain`, `analysis` |
+| `repository` | `domain`, `dao`, `repository.support` |
 | `dao` | `config`, DAO-local mapper/model/support |
+| `config` | declared external persistence configuration only |
 | `domain` | no Lineage application/infrastructure package |
-| `config` | configuration-only dependencies |
 
-目标图不得形成 `domain -> repository -> service`、`dao -> repository` 或其他反向依赖。
+目标图不得形成 `domain -> repository -> service`、`dao -> repository`、`collector -> service` 或其他反向依赖。
 
 ## Current Structure
 
 ```text
 controller -> service -> repository -> domain
-                              └-----> dao
+                              └-----> dao -> config
 
 analysis/sql
   -> source-neutral SQL projection contract
@@ -68,11 +68,28 @@ Dataset gateway/lineage adapter
 
 Lineage 模块不能为了复用 parser 反向依赖 Data Development。Dataset 也不能直接依赖 Data Development parser；它只依赖自身 Gateway 和共享 contract。
 
+## Persistence Configuration Corridor
+
+Lineage 唯一允许的外部 business-module import 是 Datasource 配置 corridor：
+
+```text
+config/ConditionalOnLineagePersistence.java
+  -> io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled
+
+config/LineagePersistenceConfiguration.java
+  -> io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration
+  -> io.yak.ops.business.datasource.config.DataSourceProperties
+```
+
+DAO、Repository、Service、Controller、Domain、Analysis 不得直接 import Datasource。`LineageDaoImpl` 通过 Lineage 自己的 `ConditionalOnLineagePersistence` 接收装配条件。
+
+该列表是精确白名单，不是 package 前缀放行。新增类型必须说明为何不能通过现有配置边界表达。
+
 ## Collector Corridors
 
 当前没有 Collector production implementation，也不以空目录或空接口模拟未来架构。
 
-出现 Flink / Spark / Hadoop 等真实采集能力时，平台依赖只能进入对应 `collector/<platform>` adapter。Collector 不得把 SDK 类型暴露给 Domain、Service 或 Repository contract。
+出现 Flink / Spark / Hadoop 等真实采集能力时，平台依赖只能进入对应 `collector/<platform>` adapter。Collector 不得把 SDK 类型暴露给 Domain、Service 或 Repository contract，也不得反向调用稳定 Service 形成环。
 
 ## Forbidden Shortcuts
 
@@ -82,37 +99,80 @@ Lineage 模块不能为了复用 parser 反向依赖 Data Development。Dataset 
 controller -> repository / dao / mapper / PO
 service -> dao / mapper / PO
 analysis -> service / repository / dao / controller / Spring
-repository -> controller / DTO / VO
+collector -> service / repository / dao
 dao -> controller / service / repository / domain orchestration
+repository -> controller / DTO / VO
 domain -> Spring / MyBatis / repository / controller / analysis
+non-config package -> Datasource business module
 ```
 
 HTTP transport mapping 留在 `controller`；持久化兼容转换留在 `repository`/`dao`；外部平台 SDK 留在 `analysis`/`collector` 的边界实现。
 
-## External Module Dependencies
+## Maven Direct Dependency Surface
 
-跨业务模块复用 Lineage 时，依赖稳定公开 contract，不调用对方 DAO 或内部实现类。
+Lineage POM 的直接依赖集合由 `LineageMavenDependencyBoundaryTest` 精确锁定：
 
-具体 SQL parser 由 Data Development 持有；Lineage 只持有 source-neutral Analyzer contract。未来平台采集器同样由 adapter 所在模块持有技术实现，统一回到 Lineage Domain 和写入边界。
+```text
+Yak Ops:
+  yak-ops-common
+  yak-ops-business-datasource (optional)
 
-## Maven Boundary
+Framework/API:
+  spring-boot-starter-web
+  spring-boot-starter-validation
+  spring-tx
+  mybatis-plus-spring-boot3-starter
+  swagger-annotations-jakarta
+  flyway-core
+  lombok (optional)
+  spring-boot-starter-test (test)
+```
+
+新增直接 dependency 必须同步说明 capability owner、scope 和传递影响。
+
+## Runtime Ownership
+
+运行时依赖按实际装配职责归属：
+
+```text
+Datasource module
+  -> mybatis-plus-jsqlparser-4.9 (runtime)
+  -> flyway-mysql (runtime)
+
+Explicit application/plugin assembly
+  -> concrete JDBC drivers
+  -> Springdoc UI runtime
+
+Lineage
+  -X-> database driver
+  -X-> Flyway vendor module
+  -X-> Springdoc UI runtime
+  -X-> direct JSqlParser runtime
+```
+
+Lineage 对 Datasource 的依赖为 optional。仓库内任何直接依赖 Lineage 的 POM，必须同时显式依赖 Datasource；测试会扫描全部项目 POM，防止偶然依赖传递装配。
+
+这里约束的是 Lineage 依赖面，不把其他业务模块已有的数据库依赖重复声明纳入本阶段；它们由各模块后续独立治理。
+
+## Maven Module Boundary
 
 保持单一 `yak-ops-business-lineage` Maven module，不提前拆 `lineage-core / lineage-api / lineage-flink / lineage-spark`。
 
-只有当出现真实的编译期隔离需求，例如某个平台 SDK 体积大、依赖冲突明显、需要独立发布或可选装载时，才考虑拆 Maven artifact。先把 Java 依赖方向拆清楚，再决定物理 jar 边界。
+只有出现真实的编译期隔离需求，例如某个平台 SDK 体积大、依赖冲突明显、需要独立发布或可选装载时，才考虑拆 Maven artifact。先把 Java 与 Maven 依赖方向锁清楚，再决定物理 jar 边界。
 
 ## Governance
 
-`LineageArchitectureTest` 保护反射可见的层次语义；`LineageDependencyBoundaryTest` 扫描 production source，保护：
+`LineageArchitectureTest` 保护反射可见的层次语义；`LineageDependencyBoundaryTest` 与 `LineageMavenDependencyBoundaryTest` 保护：
 
 - 根包保持空白；
 - top-level package 必须经过声明；
-- 稳定 Service 集合固定；
-- SQL Analyzer contract 只能位于 `analysis/sql`；
-- Analysis 保持 source-neutral、无 Spring/持久化依赖；
-- Controller 不穿透持久化；
-- Repository 不依赖 HTTP contract；
-- DAO 不反向依赖上层；
-- Domain 保持 framework/persistence free；
-- 旧根包 Service、Domain 和 Analyzer import 不能回流；
-- `common/helper/utils/base` 业务大桶不能回流。
+- 声明图和实际 import 图都保持无环；
+- 稳定 Service 与 Analysis role 集合固定；
+- Analysis 保持 source-neutral；
+- Datasource import 只进入精确的 config corridor；
+- DAO 使用 Lineage-owned persistence condition；
+- Controller、Service、Repository、DAO、Domain 不发生反向穿透；
+- 旧根包 contract 与业务大桶不能回流；
+- Lineage POM 直接依赖集合固定；
+- JSqlParser 与 Flyway vendor 由 Datasource 提供，driver/UI 不由 Lineage 传播；
+- Lineage 消费方显式装配 Datasource。

--- a/yak-ops-business/yak-ops-business-lineage/README.md
+++ b/yak-ops-business/yak-ops-business-lineage/README.md
@@ -11,33 +11,61 @@ Lineage 是 Yak Ops 的统一元数据血缘模块，负责维护可稳定寻址
 | [`REQUIREMENTS.md`](./REQUIREMENTS.md) | 模块需要提供什么能力、哪些事情不在这里做 |
 | [`DOMAIN.md`](./DOMAIN.md) | Asset / Relation / Evidence / Graph 的领域语义 |
 | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 长期 package、角色与持久化边界 |
-| [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package 可以依赖谁、跨模块 corridor 是什么 |
+| [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package、跨模块 corridor 与 Maven 依赖归属 |
 | [`CODE_STYLE.md`](../../CODE_STYLE.md) | Yak Ops 仓库统一工程与代码规范 |
 | [`REVIEW.md`](./REVIEW.md) | Lineage PR 的评审标准 |
 
 ## Current Contract
 
-当前生产代码已形成：
+当前生产代码形成两条明确路径：
 
 ```text
-controller
+HTTP / module caller
    -> query / write / maintenance service
    -> repository
    -> dao
+   -> shared business database
 
-analysis/sql
-   -> source-neutral SQL projection analysis contract
+Dataset / Data Development
+   -> analysis/sql/SqlProjectionLineageAnalyzer
 ```
 
-共享分析契约的完整角色路径是：
+Asset / Relation / Graph 位于 `domain`，稳定应用入口位于 `service`，共享 SQL 分析契约位于 `analysis/sql`。具体 SQL parser 实现在 Data Development 的 Lineage 角色包中，Dataset 只通过自身 Gateway Adapter 使用该 contract。
+
+`io.yak.ops.business.lineage` 根包不承载 production Java 类型，也不作为兼容大桶。
+
+## Persistence Contract
 
 ```text
-analysis/sql/SqlProjectionLineageAnalyzer
+LineageRepository
+   -> LineageRepositoryAdapter
+   -> LineageDao
+   -> Mapper / PO / XML
 ```
 
-Asset / Relation / Graph 位于 `domain`，稳定应用入口位于 `service`。具体 SQL parser 实现在 Data Development 的 Lineage 角色包中，Dataset 只通过自身 Gateway Adapter 使用该 contract。
+Datasource 模块只允许从 `config` corridor 进入 Lineage：
 
-`io.yak.ops.business.lineage` 根包不再承载 production Java 类型，也不作为兼容大桶。
+```text
+ConditionalOnLineagePersistence
+LineagePersistenceConfiguration
+```
+
+DAO 依赖 Lineage 自己的条件注解，不直接感知 Datasource 模块。Repository contract 不暴露 PO、Mapper、HTTP DTO 或 MyBatis 类型。
+
+## Maven Contract
+
+Lineage 只声明自身编译所需的 API 和实现边界：Web/Validation、Spring Transaction、MyBatis、Flyway Core、Swagger annotations。
+
+以下运行时能力不由 Lineage 向下游传播：
+
+```text
+Datasource module            -> MyBatis JSqlParser + Flyway MySQL runtime
+explicit app/plugin assembly -> JDBC drivers + Springdoc UI
+```
+
+本阶段只锁定 Lineage 的直接依赖面，不顺手统一其他业务模块已有的持久化 POM。
+
+Lineage 对 Datasource 的 Maven 依赖是 optional。任何直接消费 Lineage 的应用或业务模块，都必须显式声明 Datasource，而不能依赖传递引入。
 
 ## Core Model
 
@@ -65,17 +93,18 @@ io.yak.ops.business.lineage
 ├── analysis
 │   └── sql             # source-neutral SQL analysis contract
 ├── collector           # real platform/source collectors when required
-├── repository          # persistence contracts + adapters
-├── dao                 # MyBatis persistence primitives / PO
-└── config              # module configuration
+├── repository          # persistence contracts + domain/DAO adapter
+│   └── support         # persistence-only codecs
+├── dao                 # MyBatis primitives / mapper / PO
+└── config              # persistence wiring + external infrastructure corridor
 ```
 
 技术名称不直接决定业务层级。未来 Flink、Spark、Hadoop 等能力只有在存在真实采集链路时，才进入 `collector/<platform>`；它们复用统一 Domain 和稳定写入边界，不复制 Service / DAO / Domain。
 
 ## Evolution Rule
 
-后续重构遵守三条底线：
+后续演进遵守三条底线：
 
-1. package move 与业务行为修改分开；
-2. 新入口稳定后不长期保留 production 双入口；
-3. 架构文档、dependency test 与实际代码一起演进，不能为了让测试通过无条件扩大依赖白名单。
+1. package、POM 与业务行为修改分开评审；
+2. 外部模块依赖只能进入文档和测试声明的窄 corridor；
+3. 新 dependency 必须有真实 owner，不能为了临时编译把驱动、UI 或平台 SDK 塞进 Lineage。

--- a/yak-ops-business/yak-ops-business-lineage/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-lineage/REVIEW.md
@@ -1,12 +1,12 @@
 # Lineage Review Guide
 
-Lineage PR 评审优先看**领域语义和依赖方向有没有被破坏**，不是只看代码能否编译。
+Lineage PR 评审优先看**领域语义、依赖方向和运行时 owner 有没有被破坏**，不是只看代码能否编译。
 
 ## Scope
 
 - 这个 PR 是否只有一个主要关注点？
-- 纯结构调整是否偷改了 REST、DB schema、Flyway 或业务语义？
-- package move 与 behavior change 是否可以拆开？
+- 纯结构/POM 调整是否偷改了 REST、DB schema、Flyway migration 或业务语义？
+- package、dependency ownership 与 behavior change 是否可以拆开？
 
 ## Domain
 
@@ -20,19 +20,20 @@ Lineage PR 评审优先看**领域语义和依赖方向有没有被破坏**，�
 
 - 新类名是否能直接说明角色？
 - `Service` 是否只用于稳定应用入口，而不是所有 Spring Bean？
-- Analyzer / Collector / Resolver / Converter / Repository / DAO 是否各自停在正确边界？
+- Analyzer / Collector / Resolver / Converter / Repository / DAO / Configuration 是否各自停在正确边界？
 - SQL Analyzer contract 是否位于 `analysis/sql`，具体 parser 实现是否留在拥有 parser 的 adapter 模块？
 - Flink / Spark / Hadoop 是否作为真实 Collector 实现接入，而不是复制一套业务层？
 - 是否为了“看起来完整”提前新增了没有调用方的 Collector / Resolver 空抽象？
 
 ## Dependencies
 
-- Controller 是否只走稳定 Service？
+- Controller 是否只走稳定 Service 和 transport mapping？
 - Service 是否绕过 Repository 直接访问 DAO/Mapper/PO？
 - Analysis contract 是否依赖 Spring、Repository、DAO、Controller 或具体 parser？
 - Repository contract 是否暴露 HTTP 或 persistence implementation types？
-- DAO 是否反向依赖应用层？
+- DAO 是否反向依赖应用层或直接 import Datasource？
 - Domain 是否出现 Spring/MyBatis/平台 SDK？
+- top-level package 图是否仍然符合声明且无环？
 - 根包是否重新出现 production Java 类型？
 - 是否新增了 `common/helper/utils/base` 之类的大桶？
 
@@ -41,15 +42,49 @@ Lineage PR 评审优先看**领域语义和依赖方向有没有被破坏**，�
 - Domain ↔ PO 转换是否停在 RepositoryAdapter？
 - MyBatis Mapper/XML 是否只承担数据库 primitive？
 - JSON/compatibility codec 是否位于 persistence boundary，而不是 Core Domain？
+- Datasource import 是否只存在于两个声明的 `config` 文件？
+- DAO 是否通过 `ConditionalOnLineagePersistence` 接收装配条件？
+- 是否顺手改变了 Flyway location、history table、baseline 或 bean name？
+
+## Maven Ownership
+
+新增或调整依赖时必须回答：
+
+```text
+Dependency Impact Analysis
+- Capability owner:
+- Compile API or runtime adapter:
+- Direct / optional / runtime / test scope:
+- Does it propagate to Lineage consumers:
+- Existing owner module/plugin:
+- POM guard updated: yes/no
+```
+
+Lineage POM 默认拒绝重新加入：
+
+```text
+spring-boot-starter-jdbc
+springdoc-openapi-starter-webmvc-ui
+mybatis-plus-jsqlparser-4.9
+flyway-mysql
+mysql-connector-j
+```
+
+检查运行时 owner：
+
+- MyBatis JSqlParser 与 Flyway MySQL 由 Datasource 提供；
+- JDBC driver 与 OpenAPI UI 属于显式应用/插件装配，不属于 Lineage；
+- 不借 Lineage PR 顺手改写其他业务模块的历史 POM；
+- 直接消费 Lineage 的模块必须显式依赖 Datasource。
 
 ## Compatibility
 
-纯架构 PR 默认要求：
+纯架构/POM PR 默认要求：
 
 ```text
 REST contract unchanged
 DB schema unchanged
-Flyway unchanged
+Flyway migration and history semantics unchanged
 Asset/Relation semantics unchanged
 existing behavior tests unchanged or strengthened
 ```
@@ -62,19 +97,22 @@ existing behavior tests unchanged or strengthened
 
 - `LineageArchitectureTest`；
 - `LineageDependencyBoundaryTest`；
+- `LineageMavenDependencyBoundaryTest`；
 - 被修改用例对应的 behavior test；
-- 跨模块 Analyzer 实现/消费方是否同步编译；
+- 受 POM scope 调整影响的 Datasource / Boot 装配；
 - 如果调整 dependency allowlist，文档是否同步且理由是否真实。
 
 ## Reject Signals
 
 以下情况默认要求拆分或返工：
 
-- 为了让测试通过直接扩大依赖白名单；
+- 为了让测试通过直接扩大 package 或 POM 白名单；
 - 一个 PR 同时大规模 move package、改表、改接口、改领域行为；
 - 新增 `FlinkLineageService / SparkLineageService / HadoopLineageService` 但职责只是同一用例的技术分叉；
 - 创建没有真实调用方的 Collector/Resolver 层，只为填满目录；
 - Controller 直接操作 Repository/DAO；
 - Analysis contract 携带 Spring、Parser SDK 或持久化类型；
+- DAO 直接依赖 Datasource 模块；
+- 把 driver、vendor runtime 或 UI starter 放回 Lineage POM；
 - Domain 开始携带 Mapper/PO/HTTP DTO；
 - 只有 Markdown 约定，没有可执行架构护栏。

--- a/yak-ops-business/yak-ops-business-lineage/pom.xml
+++ b/yak-ops-business/yak-ops-business-lineage/pom.xml
@@ -16,6 +16,10 @@
     <name>Yak Ops Business Lineage</name>
     <description>Unified metadata assets, typed relations and lineage graph traversal</description>
 
+    <properties>
+        <swagger-annotations.version>2.2.22</swagger-annotations.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
@@ -24,6 +28,7 @@
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -35,33 +40,21 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
         </dependency>
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.baomidou</groupId>
-            <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+            <version>${swagger-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-mysql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/config/ConditionalOnLineagePersistence.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/config/ConditionalOnLineagePersistence.java
@@ -1,0 +1,16 @@
+package io.yak.ops.business.lineage.config;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Keeps the Datasource enablement contract at the Lineage persistence boundary. */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ConditionalOnDataSourceEnabled
+public @interface ConditionalOnLineagePersistence {
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/config/LineagePersistenceConfiguration.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/config/LineagePersistenceConfiguration.java
@@ -1,7 +1,6 @@
 package io.yak.ops.business.lineage.config;
 
 import io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration;
-import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.config.DataSourceProperties;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
@@ -14,7 +13,7 @@ import org.springframework.context.annotation.Import;
 
 /** Lineage persistence and Flyway configuration. */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnDataSourceEnabled
+@ConditionalOnLineagePersistence
 @EnableConfigurationProperties(DataSourceProperties.class)
 @Import(BusinessDatabaseConfiguration.class)
 public class LineagePersistenceConfiguration {

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
@@ -1,7 +1,7 @@
 package io.yak.ops.business.lineage.dao.impl;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
-import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.lineage.config.ConditionalOnLineagePersistence;
 import io.yak.ops.business.lineage.dao.LineageDao;
 import io.yak.ops.business.lineage.dao.mapper.LineageAssetMapper;
 import io.yak.ops.business.lineage.dao.mapper.LineageQueryMapper;
@@ -22,7 +22,7 @@ import org.springframework.util.StringUtils;
 /** MyBatis-Plus DAO with XML reserved for complex/atomic SQL. */
 @Repository
 @DependsOn("yakLineageFlyway")
-@ConditionalOnDataSourceEnabled
+@ConditionalOnLineagePersistence
 @RequiredArgsConstructor
 public class LineageDaoImpl implements LineageDao {
 

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
@@ -7,7 +7,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -18,16 +25,19 @@ class LineageDependencyBoundaryTest {
 
   private static final String BASE = "io.yak.ops.business.lineage";
 
+  private static final Map<String, Set<String>> ALLOWED_TOP_LEVEL_DEPENDENCIES =
+      Map.ofEntries(
+          Map.entry("controller", Set.of("domain", "service")),
+          Map.entry("service", Set.of("analysis", "collector", "domain", "repository")),
+          Map.entry("analysis", Set.of("domain")),
+          Map.entry("collector", Set.of("analysis", "domain")),
+          Map.entry("repository", Set.of("dao", "domain")),
+          Map.entry("dao", Set.of("config")),
+          Map.entry("domain", Set.of()),
+          Map.entry("config", Set.of()));
+
   private static final Set<String> DECLARED_TOP_LEVEL_PACKAGES =
-      Set.of(
-          "analysis",
-          "collector",
-          "config",
-          "controller",
-          "dao",
-          "domain",
-          "repository",
-          "service");
+      ALLOWED_TOP_LEVEL_DEPENDENCIES.keySet();
 
   private static final Set<String> STABLE_SERVICE_TYPES =
       Set.of(
@@ -37,6 +47,16 @@ class LineageDependencyBoundaryTest {
 
   private static final Set<String> ANALYSIS_ROLE_TYPES =
       Set.of("sql/SqlProjectionLineageAnalyzer.java");
+
+  private static final Map<String, Set<String>> EXTERNAL_BUSINESS_CORRIDORS =
+      Map.of(
+          "config/ConditionalOnLineagePersistence.java",
+          Set.of(
+              "io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled"),
+          "config/LineagePersistenceConfiguration.java",
+          Set.of(
+              "io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration",
+              "io.yak.ops.business.datasource.config.DataSourceProperties"));
 
   @Test
   void rootPackageMustRemainEmpty() throws IOException {
@@ -97,6 +117,57 @@ class LineageDependencyBoundaryTest {
     assertThat(DECLARED_TOP_LEVEL_PACKAGES)
         .as("New top-level Lineage packages require an architecture contract update")
         .containsAll(actual);
+  }
+
+  @Test
+  void topLevelImportsFollowDeclaredDependencyGraph() throws IOException {
+    for (Dependency dependency : packageDependencies()) {
+      assertThat(ALLOWED_TOP_LEVEL_DEPENDENCIES.getOrDefault(
+              dependency.sourcePackage(), Set.of()))
+          .as("%s imports %s", dependency.relativePath(), dependency.importedType())
+          .contains(dependency.targetPackage());
+    }
+  }
+
+  @Test
+  void declaredAndActualPackageGraphsRemainAcyclic() throws IOException {
+    assertAcyclic(ALLOWED_TOP_LEVEL_DEPENDENCIES, "declared Lineage dependency graph");
+
+    Map<String, Set<String>> actual = new HashMap<>();
+    DECLARED_TOP_LEVEL_PACKAGES.forEach(key -> actual.put(key, new HashSet<>()));
+    for (Dependency dependency : packageDependencies()) {
+      actual.computeIfAbsent(dependency.sourcePackage(), ignored -> new HashSet<>())
+          .add(dependency.targetPackage());
+    }
+    assertAcyclic(actual, "actual Lineage import graph");
+  }
+
+  @Test
+  void externalBusinessImportsStayInPersistenceConfigurationCorridor() throws IOException {
+    assertThat(externalBusinessImports())
+        .as("Lineage may reach Datasource only through its persistence configuration corridor")
+        .containsExactlyInAnyOrderEntriesOf(EXTERNAL_BUSINESS_CORRIDORS);
+  }
+
+  @Test
+  void persistenceImplementationUsesLineageOwnedCondition() throws IOException {
+    String configuration =
+        Files.readString(
+            productionRoot().resolve("config/LineagePersistenceConfiguration.java"),
+            StandardCharsets.UTF_8);
+    String dao =
+        Files.readString(
+            productionRoot().resolve("dao/impl/LineageDaoImpl.java"),
+            StandardCharsets.UTF_8);
+
+    assertThat(configuration)
+        .contains("@ConditionalOnLineagePersistence")
+        .doesNotContain("@ConditionalOnDataSourceEnabled");
+    assertThat(dao)
+        .contains("import " + BASE + ".config.ConditionalOnLineagePersistence;")
+        .contains("@ConditionalOnLineagePersistence")
+        .doesNotContain("io.yak.ops.business.datasource.")
+        .doesNotContain("@ConditionalOnDataSourceEnabled");
   }
 
   @Test
@@ -220,6 +291,97 @@ class LineageDependencyBoundaryTest {
     }
   }
 
+  private List<Dependency> packageDependencies() throws IOException {
+    Path root = productionRoot();
+    List<Dependency> result = new ArrayList<>();
+    for (Path source : javaFiles(root)) {
+      Path relative = root.relativize(source);
+      if (relative.getNameCount() < 2) continue;
+      String sourcePackage = relative.getName(0).toString();
+      for (String line : Files.readAllLines(source, StandardCharsets.UTF_8)) {
+        String imported = importedType(line);
+        if (imported == null || !imported.startsWith(BASE + ".")) continue;
+        String suffix = imported.substring((BASE + ".").length());
+        int separator = suffix.indexOf('.');
+        String targetPackage = separator < 0 ? "root" : suffix.substring(0, separator);
+        if (!sourcePackage.equals(targetPackage)) {
+          result.add(
+              new Dependency(
+                  sourcePackage,
+                  targetPackage,
+                  imported,
+                  normalize(relative)));
+        }
+      }
+    }
+    return result;
+  }
+
+  private Map<String, Set<String>> externalBusinessImports() throws IOException {
+    Path root = productionRoot();
+    Map<String, Set<String>> result = new LinkedHashMap<>();
+    for (Path source : javaFiles(root)) {
+      for (String line : Files.readAllLines(source, StandardCharsets.UTF_8)) {
+        String imported = importedType(line);
+        if (imported == null
+            || !imported.startsWith("io.yak.ops.business.")
+            || imported.startsWith(BASE + ".")) {
+          continue;
+        }
+        result.computeIfAbsent(normalize(root.relativize(source)), ignored -> new LinkedHashSet<>())
+            .add(imported);
+      }
+    }
+    return result;
+  }
+
+  private String importedType(String line) {
+    String value = line.trim();
+    String prefix;
+    if (value.startsWith("import static ")) {
+      prefix = "import static ";
+    } else if (value.startsWith("import ")) {
+      prefix = "import ";
+    } else {
+      return null;
+    }
+    if (!value.endsWith(";")) return null;
+    return value.substring(prefix.length(), value.length() - 1);
+  }
+
+  private void assertAcyclic(Map<String, Set<String>> graph, String label) {
+    Set<String> nodes = new HashSet<>(graph.keySet());
+    graph.values().forEach(nodes::addAll);
+    Map<String, Integer> outgoing = new HashMap<>();
+    Map<String, Set<String>> reverse = new HashMap<>();
+    nodes.forEach(node -> outgoing.put(node, 0));
+
+    for (Map.Entry<String, Set<String>> entry : graph.entrySet()) {
+      for (String target : entry.getValue()) {
+        outgoing.compute(entry.getKey(), (ignored, value) -> value + 1);
+        reverse.computeIfAbsent(target, ignored -> new HashSet<>()).add(entry.getKey());
+      }
+    }
+
+    ArrayDeque<String> ready = new ArrayDeque<>();
+    outgoing.forEach(
+        (node, degree) -> {
+          if (degree == 0) ready.add(node);
+        });
+
+    int visited = 0;
+    while (!ready.isEmpty()) {
+      String node = ready.removeFirst();
+      visited++;
+      for (String dependent : reverse.getOrDefault(node, Set.of())) {
+        int degree = outgoing.compute(dependent, (ignored, value) -> value - 1);
+        if (degree == 0) ready.add(dependent);
+      }
+    }
+
+    assertThat(visited).as("%s must remain acyclic", label).isEqualTo(nodes.size());
+  }
+
   private void assertNoImports(String packageName, String... forbiddenTokens) throws IOException {
     Path root = productionRoot().resolve(packageName);
     if (!Files.isDirectory(root)) return;
@@ -239,7 +401,7 @@ class LineageDependencyBoundaryTest {
   }
 
   private Set<Path> javaFiles(Path root) throws IOException {
-    Set<Path> result = new HashSet<>();
+    Set<Path> result = new LinkedHashSet<>();
     try (Stream<Path> files = Files.walk(root)) {
       files.filter(path -> path.toString().endsWith(".java")).forEach(result::add);
     }
@@ -283,5 +445,12 @@ class LineageDependencyBoundaryTest {
 
   private String normalize(Path path) {
     return path.toString().replace('\\', '/');
+  }
+
+  private record Dependency(
+      String sourcePackage,
+      String targetPackage,
+      String importedType,
+      String relativePath) {
   }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageMavenDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageMavenDependencyBoundaryTest.java
@@ -1,0 +1,180 @@
+package io.yak.ops.business.lineage.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/** Executable contract for Lineage direct dependencies and runtime-adapter ownership. */
+class LineageMavenDependencyBoundaryTest {
+
+  private static final String LINEAGE = "yak-ops-business-lineage";
+  private static final String DATASOURCE = "yak-ops-business-datasource";
+
+  @Test
+  void lineageDirectDependencySurfaceIsExact() throws Exception {
+    assertThat(dependencies(lineagePom()))
+        .containsExactlyInAnyOrder(
+            dependency("io.yak.ops", "yak-ops-common"),
+            optional("io.yak.ops", DATASOURCE),
+            dependency("org.springframework.boot", "spring-boot-starter-web"),
+            dependency("org.springframework.boot", "spring-boot-starter-validation"),
+            dependency("org.springframework", "spring-tx"),
+            dependency("com.baomidou", "mybatis-plus-spring-boot3-starter"),
+            dependency("io.swagger.core.v3", "swagger-annotations-jakarta"),
+            dependency("org.flywaydb", "flyway-core"),
+            optional("org.projectlombok", "lombok"),
+            testDependency("org.springframework.boot", "spring-boot-starter-test"));
+  }
+
+  @Test
+  void sharedDatabaseModuleOwnsMybatisAndFlywayRuntimeAdapters() throws Exception {
+    Set<Dependency> dependencies = dependencies(datasourcePom());
+
+    assertThat(dependencies)
+        .contains(
+            runtimeDependency("com.baomidou", "mybatis-plus-jsqlparser-4.9"),
+            runtimeDependency("org.flywaydb", "flyway-mysql"));
+  }
+
+  @Test
+  void everyDirectLineageConsumerOwnsDatasourceAssemblyExplicitly() throws Exception {
+    Set<String> consumers = new LinkedHashSet<>();
+    try (Stream<Path> paths = Files.walk(repositoryRoot())) {
+      for (Path pom : paths.filter(this::isProjectPom).toList()) {
+        Set<Dependency> dependencies = dependencies(pom);
+        if (!contains(dependencies, "io.yak.ops", LINEAGE)) continue;
+
+        String relative = normalize(repositoryRoot().relativize(pom));
+        consumers.add(relative);
+        assertThat(contains(dependencies, "io.yak.ops", DATASOURCE))
+            .as("%s must assemble Datasource explicitly because Lineage keeps it optional", relative)
+            .isTrue();
+      }
+    }
+
+    assertThat(consumers)
+        .as("The explicit assembly rule must exercise real Lineage consumers")
+        .isNotEmpty();
+  }
+
+  private boolean contains(Set<Dependency> dependencies, String groupId, String artifactId) {
+    return dependencies.stream()
+        .anyMatch(
+            dependency ->
+                dependency.groupId().equals(groupId)
+                    && dependency.artifactId().equals(artifactId));
+  }
+
+  private Set<Dependency> dependencies(Path pom) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    Document document = factory.newDocumentBuilder().parse(pom.toFile());
+    Element dependencies = directChild(document.getDocumentElement(), "dependencies");
+    if (dependencies == null) return Set.of();
+
+    Set<Dependency> result = new LinkedHashSet<>();
+    NodeList children = dependencies.getChildNodes();
+    for (int index = 0; index < children.getLength(); index++) {
+      Node child = children.item(index);
+      if (!(child instanceof Element element) || !"dependency".equals(localName(element))) {
+        continue;
+      }
+      result.add(
+          new Dependency(
+              directChildText(element, "groupId"),
+              directChildText(element, "artifactId"),
+              defaultValue(directChildText(element, "scope"), "compile"),
+              Boolean.parseBoolean(defaultValue(directChildText(element, "optional"), "false"))));
+    }
+    return result;
+  }
+
+  private Element directChild(Element parent, String name) {
+    NodeList children = parent.getChildNodes();
+    for (int index = 0; index < children.getLength(); index++) {
+      Node child = children.item(index);
+      if (child instanceof Element element && name.equals(localName(element))) return element;
+    }
+    return null;
+  }
+
+  private String directChildText(Element parent, String name) {
+    Element child = directChild(parent, name);
+    return child == null ? null : child.getTextContent().trim();
+  }
+
+  private String localName(Element element) {
+    return element.getLocalName() == null ? element.getNodeName() : element.getLocalName();
+  }
+
+  private String defaultValue(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private Dependency dependency(String groupId, String artifactId) {
+    return new Dependency(groupId, artifactId, "compile", false);
+  }
+
+  private Dependency optional(String groupId, String artifactId) {
+    return new Dependency(groupId, artifactId, "compile", true);
+  }
+
+  private Dependency runtimeDependency(String groupId, String artifactId) {
+    return new Dependency(groupId, artifactId, "runtime", false);
+  }
+
+  private Dependency testDependency(String groupId, String artifactId) {
+    return new Dependency(groupId, artifactId, "test", false);
+  }
+
+  private boolean isProjectPom(Path path) {
+    String normalized = normalize(path);
+    return path.getFileName().toString().equals("pom.xml")
+        && !normalized.contains("/target/")
+        && !normalized.contains("/.deps/");
+  }
+
+  private Path lineagePom() {
+    return repositoryRoot()
+        .resolve("yak-ops-business/yak-ops-business-lineage/pom.xml");
+  }
+
+  private Path datasourcePom() {
+    return repositoryRoot()
+        .resolve("yak-ops-business/yak-ops-business-datasource/pom.xml");
+  }
+
+  private Path repositoryRoot() {
+    Path current = Paths.get(".").toAbsolutePath().normalize();
+    if (Files.isDirectory(current.resolve("yak-ops-business"))) return current;
+
+    Path candidate = current.resolve("../..").normalize();
+    assertThat(Files.isDirectory(candidate.resolve("yak-ops-business")))
+        .as("Unable to locate repository root from %s", current)
+        .isTrue();
+    return candidate;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+
+  private record Dependency(
+      String groupId,
+      String artifactId,
+      String scope,
+      boolean optional) {
+  }
+}


### PR DESCRIPTION
## 背景

这是 Lineage 架构演进的 **Stage 5**。Stage 1 建立架构 contract，Stage 2 收拢 Domain，Stage 3 拆分 Query / Write / Maintenance Service，Stage 4 将 SQL Analyzer 按角色归位；本阶段继续收紧持久化配置 corridor 和 Maven 依赖面，避免运行时实现依赖通过 Lineage 被动传播。

## 本次改动

### 1. 建立 Lineage 自己的持久化条件

新增：

```text
io.yak.ops.business.lineage.config.ConditionalOnLineagePersistence
```

该注解在 `config` 边界适配 Datasource 的 enablement contract。`LineageDaoImpl` 与 `LineagePersistenceConfiguration` 统一使用 Lineage-owned condition，DAO 不再直接 import Datasource 模块。

允许的外部 business import 被收敛为两个精确文件：

```text
config/ConditionalOnLineagePersistence.java
  -> ConditionalOnDataSourceEnabled

config/LineagePersistenceConfiguration.java
  -> BusinessDatabaseConfiguration
  -> DataSourceProperties
```

### 2. 锁定最终 package 依赖图

`LineageDependencyBoundaryTest` 新增：

- top-level package 精确依赖矩阵；
- 声明图与实际 import 图无环检查；
- Datasource 外部 import 精确 corridor；
- DAO 必须使用 Lineage-owned persistence condition；
- 旧根包、反向依赖和业务大桶继续禁止回流。

最终方向：

```text
controller -> service -> analysis / collector / repository / domain
analysis   -> domain
collector  -> analysis / domain
repository -> dao / domain
dao        -> config
config     -> declared external persistence corridor only
```

### 3. 收紧 Lineage Maven 直接依赖

Lineage POM：

- `yak-ops-business-datasource` 改为 optional；
- 直接声明 `spring-tx`；
- 使用 `swagger-annotations-jakarta` 保留源码注解能力；
- 删除不应由 Lineage 向下游传播的运行时依赖：
  - `spring-boot-starter-jdbc`
  - `springdoc-openapi-starter-webmvc-ui`
  - `mybatis-plus-jsqlparser-4.9`
  - `flyway-mysql`
  - `mysql-connector-j`

Datasource POM：

- 提供 `mybatis-plus-jsqlparser-4.9` runtime；
- 将 `flyway-mysql` 明确为 runtime。

本阶段只治理 Lineage 的依赖面，不顺手统一其他业务模块已有的持久化 POM。

### 4. 增加 Maven 依赖护栏

新增 `LineageMavenDependencyBoundaryTest`，保护：

- Lineage 直接依赖集合保持精确；
- Datasource 提供 JSqlParser 与 Flyway MySQL runtime；
- 仓库内任何直接消费 Lineage 的 POM 都显式声明 Datasource；
- 不再依赖偶然的 Maven 传递装配。

### 5. 同步架构文档

更新 Lineage 的：

- `README.md`
- `ARCHITECTURE.md`
- `DEPENDENCIES.md`
- `REVIEW.md`

文档明确 package 图、持久化配置 corridor、Maven capability owner 和 Review 拒绝信号。

## 保持不变

- REST 路径、请求和响应语义；
- Asset / Relation / Graph 领域语义；
- Repository / DAO 的持久化行为；
- Mapper、XML、数据库表和 SQL；
- Flyway location、history table、baseline 和 bean name；
- SQL Analyzer 行为；
- Maven module 布局。

## 验证

已完成：

- 9 个既有文件与 Stage 4 基线 blob 逐一校验；
- 11 个目标文件的 Git blob SHA 逐一反校验；
- 两个 POM 的 XML 解析；
- Lineage 直接依赖集合精确校验；
- Datasource runtime scope 校验；
- 全部业务模块与 Boot 的 Lineage/Datasource 直接依赖反向检查；
- 新架构测试源码 Java 21 语法编译；
- 新持久化条件与配置的边界桩编译；
- UTF-8、final newline、tab 和 trailing whitespace 检查；
- 提交级 diff 校验：相对最新 `main` 仅 1 个提交、11 个预期文件、无落后提交。

当前执行环境无法拉取完整仓库及 Maven 依赖，因此完整 reactor 测试留给正常开发环境或 CI：

```bash
mvn -pl \
yak-ops-business/yak-ops-business-lineage,\
yak-ops-business/yak-ops-business-datasource,\
yak-ops-boot \
-am test
```

## 后续

Stage 6 可以移除剩余过渡白名单并锁定最终公开 surface；其他业务模块中重复的 JDBC / Flyway / Springdoc 依赖应按各自模块独立治理，不与 Lineage PR 混做。