### PR TITLE
refactor(lineage): finalize architecture contract

### DIFF
--- a/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
@@ -1,82 +1,112 @@
 # Lineage Architecture
 
-本文件定义 Lineage 的**长期架构 contract**：package 表达职责，稳定 Service 只作为应用入口，专业能力以角色命名，外部技术停在边界。
+本文定义 Lineage 当前有效的长期架构 contract：package 表达职责，稳定 Service 作为应用入口，专业能力以角色命名，外部技术停在边界。
 
-需求看 `REQUIREMENTS.md`，领域硬规则看 `DOMAIN.md`，依赖矩阵看 `DEPENDENCIES.md`，仓库风格看根目录 `CODE_STYLE.md`。
+需求看 [`REQUIREMENTS.md`](./REQUIREMENTS.md)，领域硬规则看 [`DOMAIN.md`](./DOMAIN.md)，依赖矩阵看 [`DEPENDENCIES.md`](./DEPENDENCIES.md)，评审标准看 [`REVIEW.md`](./REVIEW.md)。
 
 ## Design Principles
 
-1. **Domain first.** Asset / Relation / Evidence / Graph 不被 HTTP、MyBatis、Flink/Spark/Hadoop 类型污染。
-2. **Stable entry, specialized roles.** Controller 只进入稳定应用 Service；内部用 Analyzer / Collector / Resolver / Converter / Repository 等角色表达职责。
-3. **One lineage model.** 不为 Flink、Spark、Hadoop、Dataset、SQL Task 各建一套 Asset/Relation。
-4. **External technology stops at boundary.** Parser、SDK、CLI、HTTP client、MyBatis PO 不能穿透到 Core Domain。
-5. **Dependency ownership is explicit.** Driver、vendor runtime、UI runtime 与 parser plugin 由实际装配者持有，不挂在 Lineage POM 里“顺便带上”。
-6. **Read does not mutate.** Graph/query side 不因读取失败反向改写领域事实。
-7. **Structure change is not behavior change.** package、POM、class split 与 REST / DB / Flyway / Domain semantic change 分开评审。
-8. **Architecture is executable.** 文档 contract 必须由 architecture/dependency tests 持续保护。
+1. **Domain first.** Asset、Relation、Evidence、Graph 不被 HTTP、MyBatis 或平台 SDK 污染。
+2. **Stable entry, specialized roles.** Controller 和邻接模块进入稳定 Service 或明确的 Analyzer contract。
+3. **One lineage model.** Dataset、SQL Task、Flink、Spark、Hadoop 不各建一套 Asset/Relation。
+4. **External technology stops at boundary.** Parser、SDK、CLI、HTTP client、PO 不能穿透到 Domain。
+5. **Read does not mutate.** Graph/query side 不因读取失败反向改写领域事实。
+6. **Active structure is exact.** 文档和测试只声明真实存在的 package，不用未来占位白名单制造虚假架构。
+7. **Architecture is executable.** Package、公共 API、Maven、代码风格和文档 contract 都由测试保护。
 
-## Package Map
+## Active Package Map
 
 ```text
 io.yak.ops.business.lineage
-├── controller          # HTTP inbound + DTO/VO/converter
-├── service             # stable application facades
-├── domain              # framework-free core domain / value objects
 ├── analysis
 │   └── sql             # source-neutral SQL projection contract
-├── collector           # platform/source ingestion roles when real collectors exist
-├── repository          # persistence contracts + adapters
-│   └── support         # persistence-only codecs/mapping helpers
-├── dao                 # MyBatis primitives / mapper / PO
-└── config              # Lineage wiring + narrow external infrastructure corridor
+├── config              # persistence enablement and Spring wiring
+├── controller
+│   └── v1              # HTTP inbound + DTO/VO/converter
+├── dao
+│   ├── impl
+│   ├── mapper
+│   └── model           # MyBatis primitives and PO
+├── domain              # framework-free facts and value objects
+├── repository
+│   └── support         # persistence contract, adapter and codecs
+└── service             # stable query/write/maintenance facades
 ```
 
-`common / helper / utils / base` 不能成为新的业务大桶。根包也不能重新承担兼容层。需要新 top-level package 时，必须先说明它代表的稳定角色并同步更新文档与护栏。
+这七个 top-level package 是精确集合。新增或删除 package 必须同步修改架构文档与 dependency guard。
+
+`common / helper / utils / base` 不能成为新业务大桶。根包也不能承担兼容层。
 
 ## Application Boundary
 
-当前稳定入口是：
+当前稳定应用入口是：
 
 ```text
 LineageController
     ├── LineageQueryService
     └── LineageWriteService
 
-internal publishers / cross-module adapters
+neighboring module adapters / internal publishers
     ├── LineageQueryService
     ├── LineageWriteService
     └── LineageMaintenanceService
 ```
 
-Query 只负责资产定位、搜索和有界图遍历；Write 负责资产/关系注册与批量写入；Maintenance 负责 evidence replacement、清理和 revision guard。调用方按用例依赖，不再进入一个同时承担读写的宽 Service。
+职责固定：
 
-稳定入口使用 `@Service`。内部专业角色优先使用 `@Component`、`@Repository` 或普通对象，不通过增加更多 `*Service` 掩盖职责不清。
+- Query：资产定位、搜索和有界图遍历；
+- Write：资产/关系注册与批量写入；
+- Maintenance：evidence replacement、清理和 revision guard。
 
-## Role Vocabulary
+`@Service` 只用于这三个稳定入口。Analyzer、RepositoryAdapter、DAO、Converter 等角色不通过 `*Service` 掩盖职责。
 
-- **Service**：跨 HTTP / module caller 的稳定应用入口，负责事务边界和用例编排；
-- **Analyzer**：输入事实并产生分析结果，不拥有持久化 truth；
-- **Collector**：从运行平台或外部来源采集 lineage evidence；
-- **Resolver**：把外部引用解析为统一领域引用；
-- **Mapper / Converter**：边界表示转换，不承载业务状态机；
-- **Repository**：领域持久化 contract；
-- **RepositoryAdapter**：把领域模型翻译为 DAO/PO；
-- **DAO**：数据库读写 primitive，不承载应用编排；
-- **Configuration**：装配本模块及窄外部基础设施 corridor，不承载业务用例。
+## Public API Boundary
+
+邻接业务模块可直接 import 的类型根只有：
+
+```text
+io.yak.ops.business.lineage.analysis.sql.SqlProjectionLineageAnalyzer
+
+io.yak.ops.business.lineage.domain.LineageAsset
+io.yak.ops.business.lineage.domain.LineageAssetType
+io.yak.ops.business.lineage.domain.LineageDirection
+io.yak.ops.business.lineage.domain.LineageGraph
+io.yak.ops.business.lineage.domain.LineageRelation
+io.yak.ops.business.lineage.domain.LineageRelationType
+
+io.yak.ops.business.lineage.service.LineageQueryService
+io.yak.ops.business.lineage.service.LineageWriteService
+io.yak.ops.business.lineage.service.LineageMaintenanceService
+```
+
+公开嵌套命令、结果和 scope 跟随所属 Service/Analyzer 类型根。
+
+以下 package/type 即使因 Spring、MyBatis 或 Java 编译需要声明为 `public`，也仍是模块内部实现：
+
+```text
+controller/*
+config/*
+dao/*
+repository/*
+domain/LineageAssetDraft
+domain/LineageRelationDraft
+```
+
+跨模块调用方必须通过自身 Gateway/Adapter 隔离 Lineage contract，不能把 Lineage 类型扩散到自己的核心 Domain。
 
 ## Domain Boundary
 
-`domain/` 只能依赖 JDK 与必要的通用值类型，不依赖：
+`domain/` 只保存资产、关系、图和必要值对象，不依赖：
 
 ```text
 Spring MVC / Spring Service
 MyBatis / Mapper / PO
 Controller DTO / VO
-Repository implementation
-Flink / Spark / Hadoop SDK
+Repository / DAO
+SQL parser / platform SDK
 ```
 
-Asset / Relation / Graph 位于 `domain/`；稳定应用入口位于 `service/`。Domain 不依赖 Service、Repository、Controller、Analyzer 或平台 SDK。
+Draft 是 Repository/Service 写入过程的内部表达，不属于邻接模块公共 API。
 
 ## Analysis Boundary
 
@@ -93,136 +123,110 @@ analysis/sql/SqlProjectionLineageAnalyzer
 ```text
 data-development
 └── lineage/analysis/DevelopmentSqlProjectionLineageAnalyzer
-        -> SQL lineage parser
-        -> shared analysis/sql contract
+        -> local SQL lineage parser
+        -> shared Analyzer contract
 ```
 
-Dataset 通过自身 `LineageProjectionAnalyzerAdapter` 和 `ObjectProvider` 使用该 contract。这样保持：
+依赖方向固定：
 
 ```text
-Dataset -> Lineage contract
-Data Development -> Lineage contract
+Dataset -> Lineage Analyzer contract
+Data Development -> Lineage Analyzer contract
 Lineage -X-> Data Development parser implementation
 ```
-
-## Collector Boundary
-
-当前没有为 Flink / Spark / Hadoop 创建空 Collector 层。只有出现真实平台事件、SDK 或采集协议时，才新增：
-
-```text
-collector/<platform>/<RoleImplementation>
-```
-
-平台实现必须：
-
-- 产出统一 Asset / Relation evidence；
-- 通过稳定写入/维护边界落图；
-- 把 SDK、事件结构和连接细节留在 adapter 内；
-- 不创建 `flink/domain`、`spark/service` 等平行业务层。
 
 ## Persistence Boundary
 
 ```text
-Service / role component
-        ↓
+Service
+   ↓
 LineageRepository
-        ↓
+   ↓
 LineageRepositoryAdapter
-        ↓
+   ↓
 LineageDao
-        ↓
+   ↓
 Mapper / PO / MyBatis / DB
 ```
 
 固定规则：
 
 - Repository contract 不暴露 DAO model、Mapper、Controller DTO/VO；
-- Service 不直接依赖 DAO / Mapper / PO；
-- DAO 不反向依赖 Service / Controller / Repository / Domain orchestration；
-- Repository adapter 是 Domain ↔ Persistence 的转换位置；
-- `LineageJsonCodec` 等持久化表示 helper 留在 `repository.support`。
+- Service 不直接依赖 DAO、Mapper、PO 或 persistence config；
+- DAO 不反向依赖 Service、Repository 或 Domain orchestration；
+- RepositoryAdapter 是 Domain 与 Persistence 的转换位置；
+- JSON/compatibility codec 留在 `repository.support`。
 
 ## Persistence Configuration Corridor
 
-Lineage 使用共享业务数据库，但不允许 Datasource 模块散落到 DAO、Repository 或 Service：
+Lineage 通过自己的条件注解表达装配语义：
 
 ```text
-config/ConditionalOnLineagePersistence
-    -> datasource.config.ConditionalOnDataSourceEnabled
+ConditionalOnLineagePersistence
+    -> ConditionalOnDataSourceEnabled
 
-config/LineagePersistenceConfiguration
-    -> datasource.config.BusinessDatabaseConfiguration
-    -> datasource.config.DataSourceProperties
+LineagePersistenceConfiguration
+    -> BusinessDatabaseConfiguration
+    -> DataSourceProperties
 ```
 
-`LineageDaoImpl` 只使用 `ConditionalOnLineagePersistence`。因此未来 Datasource 开关或配置方式变化时，适配点留在 `config`，不会扩散到持久化 primitive。
+只有上述 `config` 文件可以直接 import Datasource 模块。DAO 只依赖 Lineage-owned condition，不感知 Datasource 的 enablement 类型。
 
-该 corridor 由源码级测试精确匹配文件和 imported type；新增外部 business import 默认失败。
+## Extension Protocol
 
-## Maven Assembly Boundary
-
-Lineage Maven module 保持自包含的业务实现，但不承担整个应用的运行时装配：
-
-| Capability | Owner |
-| --- | --- |
-| HTTP endpoint / validation | Lineage Web + Validation dependencies |
-| Transaction annotation | `spring-tx` |
-| Mapper / MyBatis API | MyBatis-Plus starter |
-| Migration API and Lineage migration bean | `flyway-core` |
-| OpenAPI source annotations | `swagger-annotations-jakarta` |
-| Shared MyBatis SQL parser runtime | Datasource module |
-| MySQL Flyway vendor runtime | Datasource module |
-| JDBC database drivers | Explicit application/plugin assembly, not Lineage |
-| Swagger UI/runtime | Explicit application assembly, not Lineage |
-
-`yak-ops-business-datasource` 在 Lineage POM 中是 optional：Lineage 编译仍能使用明确的配置 corridor，但下游必须显式选择 Datasource，不会因为使用血缘查询 contract 就被动继承数据库运行时。
-
-该表只定义 Lineage 的所有权边界，不宣称本阶段已经统一仓库内其他业务模块的历史 POM；其他模块若因自身持久化仍直接声明 runtime，后续按各自模块独立治理。
-
-以下依赖不得回到 Lineage POM：
+当前没有活动的 Collector package。未来引入 Flink、Spark、Hadoop 或其他来源时，只有真实采集协议和调用链已经存在，才新增：
 
 ```text
-spring-boot-starter-jdbc
-springdoc-openapi-starter-webmvc-ui
-mybatis-plus-jsqlparser-4.9
-flyway-mysql
-mysql-connector-j
+collector/<platform>/<RoleImplementation>
 ```
+
+首个 Collector PR 必须同时：
+
+1. 定义 evidence ownership、重放和 replacement 语义；
+2. 将 SDK/event 类型限制在 adapter 内；
+3. 复用现有 Domain 与 Write/Maintenance 边界；
+4. 更新精确 package 集合和依赖图；
+5. 评估是否需要新增公共 contract；
+6. 增加真实行为、失败和重复事件测试。
+
+禁止提前创建空 Collector、空 Resolver 或 `flink/domain`、`spark/service` 等平行业务层。
 
 ## Root Package Rule
 
-`io.yak.ops.business.lineage` 根包必须保持空白，不放 production Java 类型。公开 contract 也必须归属明确角色包：
+`io.yak.ops.business.lineage` 根包必须保持空白，不放 production Java 类型。
+
+架构测试使用结构规则阻止任何 `io.yak.ops.business.lineage.<UppercaseType>` 引用回流，不再维护按类名枚举的临时黑名单。
+
+## Executable Guards
 
 ```text
-domain/*
-service/*
-analysis/sql/*
+LineageArchitectureTest
+  -> reflection-visible layering and domain serialization rules
+
+LineageDependencyBoundaryTest
+  -> exact active package set
+  -> declared/actual graph acyclic
+  -> package corridors and root-package structural ban
+
+LineageMavenDependencyBoundaryTest
+  -> direct dependency set and runtime capability owner
+
+LineagePublicApiBoundaryTest
+  -> exact cross-module type roots and signature purity
+
+LineageCodeStyleConventionTest
+  -> package/path, public type/file and role placement conventions
+
+LineageDocumentationContractTest
+  -> exact document set, cross-links and final-contract vocabulary
 ```
-
-不保留旧根包兼容 wrapper。仓库级源码扫描会阻止旧 Service、Domain 和 Analyzer import 回流。
-
-## Executable Graph
-
-最终 top-level package 图由测试锁定并保持无环：
-
-```text
-controller -> service -> analysis / collector / repository / domain
-collector  -> analysis / domain
-analysis   -> domain
-repository -> dao / domain
-dao        -> config
-config     -> external persistence corridor only
-domain     -> no Lineage application/infrastructure package
-```
-
-文档中的允许边不代表必须提前创建实现；例如 Collector 仍然只在真实采集需求出现时新增。
 
 ## Change Rules
 
 1. 一个 PR 一个主要边界或行为关注点；
-2. package、POM 与 behavior change 尽量分开；
-3. 新入口稳定后不长期保留 production 双入口；
-4. Maven 子模块拆分必须由真实依赖隔离需求驱动，不为目录美观提前拆 jar；
-5. 新 dependency 必须同时符合 `ARCHITECTURE.md + DEPENDENCIES.md`；
-6. Collector / Resolver 等角色只因真实用例出现，不提前制造空抽象；
-7. dependency guard 的白名单只能因真实架构变化收窄或经评审调整，不能为了让测试通过随意扩大。
+2. package move 与行为修改分开；
+3. 新入口稳定后不保留 production 双入口；
+4. 新 package、新公共类型和新 Maven dependency 必须有明确真实调用方；
+5. Maven 子模块拆分由 SDK 隔离、依赖冲突、可选装载或独立发布需求驱动；
+6. 架构真的变化时，同一个 PR 同时修改代码、文档和 guard；
+7. 不允许为了让测试通过而扩大白名单或降低精确检查。

--- a/yak-ops-business/yak-ops-business-lineage/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-lineage/DEPENDENCIES.md
@@ -1,178 +1,210 @@
 # Lineage Dependencies
 
-本文定义 Lineage 的 package 依赖方向、跨模块 corridor 与 Maven 运行时归属。
+本文定义 Lineage 当前有效的 package、跨模块和 Maven 依赖方向。它描述真实结构，不把未来扩展当作活动白名单。
 
-## Final Dependency Graph
-
-长期方向保持单向、可解释，并由源码测试验证无环：
+## Active Dependency Graph
 
 ```text
 controller
-    ↓
-service
-    ├──────────────→ analysis ─────→ domain
-    ├──────────────→ collector ────→ domain
-    │                    └─────────→ analysis
-    ├──────────────→ repository ───→ domain
-    │                    ↓
-    │                   dao ───────→ config
+    ├──────────────→ service
     └──────────────→ domain
 
-config -> declared external persistence corridor only
+service
+    ├──────────────→ analysis
+    ├──────────────→ repository
+    └──────────────→ domain
+
+analysis ──────────→ domain
+repository ────────→ dao
+repository ────────→ domain
+dao ───────────────→ config
+
+config
+domain
 ```
 
 允许矩阵：
 
 | Source | May depend on |
 | --- | --- |
-| `controller` | `service`, `domain`, transport-local converter/dto/vo |
-| `service` | `domain`, `analysis`, `collector`, `repository` |
+| `controller` | `service`, `domain`, transport-local dto/vo/converter |
+| `service` | `analysis`, `repository`, `domain` |
 | `analysis` | `domain` |
-| `collector` | `domain`, `analysis` |
-| `repository` | `domain`, `dao`, `repository.support` |
-| `dao` | `config`, DAO-local mapper/model/support |
-| `config` | declared external persistence configuration only |
+| `repository` | `dao`, `domain`, `repository.support` |
+| `dao` | `config`, DAO-local mapper/model |
+| `config` | no other Lineage top-level package |
 | `domain` | no Lineage application/infrastructure package |
 
-目标图不得形成 `domain -> repository -> service`、`dao -> repository`、`collector -> service` 或其他反向依赖。
+实际 top-level package 集合必须与矩阵键完全一致，且声明图和 import 图都必须无环。
 
-## Current Structure
+## Public API Corridors
+
+邻接业务模块只允许直接编译依赖以下类型根：
 
 ```text
-controller -> service -> repository -> domain
-                              └-----> dao -> config
+analysis.sql.SqlProjectionLineageAnalyzer
 
-analysis/sql
-  -> source-neutral SQL projection contract
+domain.LineageAsset
+domain.LineageAssetType
+domain.LineageDirection
+domain.LineageGraph
+domain.LineageRelation
+domain.LineageRelationType
+
+service.LineageQueryService
+service.LineageWriteService
+service.LineageMaintenanceService
 ```
 
-根包没有 production Java 类型。Service 不直接依赖 DAO/Mapper/PO，跨模块调用方不能引用旧根包 Service、Domain 或 Analyzer。
+允许嵌套类型跟随所属根类型，例如 `LineageWriteService.RegisterAssetCommand`。
 
-## SQL Analysis Corridors
+禁止跨模块 import：
 
-共享 contract：
+```text
+controller/*
+config/*
+dao/*
+repository/*
+domain.LineageAssetDraft
+domain.LineageRelationDraft
+```
+
+当前真实 corridor：
+
+```text
+Data Development lineage/analysis
+    -> SqlProjectionLineageAnalyzer
+
+Dataset gateway/lineage
+    -> Analyzer + Query/Write/Maintenance Service + selected Domain
+
+Analysis gateway/lineage
+    -> Query/Write/Maintenance Service + selected Domain
+
+Dashboard gateway/lineage
+    -> Query/Write/Maintenance Service + selected Domain
+```
+
+邻接模块应继续通过自身 Gateway/Adapter 使用这些类型，不把 Lineage 依赖散落到 Controller、DAO 或核心 Domain。
+
+## SQL Analysis Corridor
 
 ```text
 io.yak.ops.business.lineage.analysis.sql.SqlProjectionLineageAnalyzer
 ```
 
-允许的真实实现与消费边界：
+固定方向：
 
 ```text
-Data Development lineage/analysis implementation
-    -> shared SQL analysis contract
-
-Dataset gateway/lineage adapter
-    -> shared SQL analysis contract
+Data Development implementation -> shared contract
+Dataset adapter                 -> shared contract
+Lineage                          -X-> Data Development parser
 ```
 
-Lineage 模块不能为了复用 parser 反向依赖 Data Development。Dataset 也不能直接依赖 Data Development parser；它只依赖自身 Gateway 和共享 contract。
+共享 contract 不携带 Spring、Repository、DAO、Parser SDK 或调用方 Domain 类型。
 
-## Persistence Configuration Corridor
+## Persistence Corridor
 
-Lineage 唯一允许的外部 business-module import 是 Datasource 配置 corridor：
+```text
+Service -> LineageRepository -> LineageRepositoryAdapter -> LineageDao
+```
+
+固定限制：
+
+```text
+controller -X-> repository / dao
+service    -X-> dao / mapper / PO / config
+analysis   -X-> Spring / service / repository / dao / config
+repository -X-> controller / DTO / VO
+dao        -X-> controller / service / analysis / repository / domain orchestration
+domain     -X-> Spring / MyBatis / controller / service / repository / dao / analysis
+```
+
+## External Business Corridor
+
+Lineage 只允许通过两个配置文件直接进入 Datasource：
 
 ```text
 config/ConditionalOnLineagePersistence.java
-  -> io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled
+    -> ConditionalOnDataSourceEnabled
 
 config/LineagePersistenceConfiguration.java
-  -> io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration
-  -> io.yak.ops.business.datasource.config.DataSourceProperties
+    -> BusinessDatabaseConfiguration
+    -> DataSourceProperties
 ```
 
-DAO、Repository、Service、Controller、Domain、Analysis 不得直接 import Datasource。`LineageDaoImpl` 通过 Lineage 自己的 `ConditionalOnLineagePersistence` 接收装配条件。
+DAO 和 Repository 不能直接 import `io.yak.ops.business.datasource.*`。
 
-该列表是精确白名单，不是 package 前缀放行。新增类型必须说明为何不能通过现有配置边界表达。
+## Maven Boundary
 
-## Collector Corridors
+Lineage 保持单一 Maven module，不提前拆 `lineage-core / lineage-api / lineage-flink / lineage-spark`。
 
-当前没有 Collector production implementation，也不以空目录或空接口模拟未来架构。
+直接依赖只承担源码编译和 Lineage 自身实现所需能力：
 
-出现 Flink / Spark / Hadoop 等真实采集能力时，平台依赖只能进入对应 `collector/<platform>` adapter。Collector 不得把 SDK 类型暴露给 Domain、Service 或 Repository contract，也不得反向调用稳定 Service 形成环。
+- Datasource 作为 optional persistence provider；
+- Spring Web/Validation 用于当前 HTTP contract；
+- Spring TX 用于稳定 Service transaction boundary；
+- MyBatis-Plus starter 用于 DAO；
+- Flyway Core 用于模块 migration；
+- Swagger annotations 用于源码注解；
+- Jackson/Lombok/Test 依赖按当前实现保留。
 
-## Forbidden Shortcuts
+数据库 driver、Flyway database extension 和 JSqlParser runtime 由 Datasource/应用装配侧提供，不通过 Lineage 向所有消费者传播。
 
-以下依赖不允许出现：
+拆分 Maven artifact 只能由真实需求驱动，例如：
+
+- 平台 SDK 体积或依赖冲突；
+- 可选装载；
+- 独立发布；
+- 需要在无 Spring/无 Persistence 环境复用 contract。
+
+## Extension Corridor
+
+当前没有 `collector` top-level package，也没有活动依赖边。
+
+首个真实 Collector 进入时，同一个 PR 必须明确并更新：
 
 ```text
-controller -> repository / dao / mapper / PO
-service -> dao / mapper / PO
-analysis -> service / repository / dao / controller / Spring
-collector -> service / repository / dao
-dao -> controller / service / repository / domain orchestration
-repository -> controller / DTO / VO
-domain -> Spring / MyBatis / repository / controller / analysis
-non-config package -> Datasource business module
+new package
+new dependency edge
+evidence ownership
+platform SDK boundary
+public API impact
+behavior tests
+documentation and executable guards
 ```
 
-HTTP transport mapping 留在 `controller`；持久化兼容转换留在 `repository`/`dao`；外部平台 SDK 留在 `analysis`/`collector` 的边界实现。
+不能先扩白名单，再等待未来实现补齐。
 
-## Maven Direct Dependency Surface
+## Root Package Rule
 
-Lineage POM 的直接依赖集合由 `LineageMavenDependencyBoundaryTest` 精确锁定：
+以下结构永久禁止：
 
 ```text
-Yak Ops:
-  yak-ops-common
-  yak-ops-business-datasource (optional)
-
-Framework/API:
-  spring-boot-starter-web
-  spring-boot-starter-validation
-  spring-tx
-  mybatis-plus-spring-boot3-starter
-  swagger-annotations-jakarta
-  flyway-core
-  lombok (optional)
-  spring-boot-starter-test (test)
+io.yak.ops.business.lineage.LineageService
+io.yak.ops.business.lineage.LineageAsset
+io.yak.ops.business.lineage.<any production type>
 ```
 
-新增直接 dependency 必须同步说明 capability owner、scope 和传递影响。
-
-## Runtime Ownership
-
-运行时依赖按实际装配职责归属：
-
-```text
-Datasource module
-  -> mybatis-plus-jsqlparser-4.9 (runtime)
-  -> flyway-mysql (runtime)
-
-Explicit application/plugin assembly
-  -> concrete JDBC drivers
-  -> Springdoc UI runtime
-
-Lineage
-  -X-> database driver
-  -X-> Flyway vendor module
-  -X-> Springdoc UI runtime
-  -X-> direct JSqlParser runtime
-```
-
-Lineage 对 Datasource 的依赖为 optional。仓库内任何直接依赖 Lineage 的 POM，必须同时显式依赖 Datasource；测试会扫描全部项目 POM，防止偶然依赖传递装配。
-
-这里约束的是 Lineage 依赖面，不把其他业务模块已有的数据库依赖重复声明纳入本阶段；它们由各模块后续独立治理。
-
-## Maven Module Boundary
-
-保持单一 `yak-ops-business-lineage` Maven module，不提前拆 `lineage-core / lineage-api / lineage-flink / lineage-spark`。
-
-只有出现真实的编译期隔离需求，例如某个平台 SDK 体积大、依赖冲突明显、需要独立发布或可选装载时，才考虑拆 Maven artifact。先把 Java 与 Maven 依赖方向锁清楚，再决定物理 jar 边界。
+根包类型禁令是结构规则，不再依赖有限的旧类名列表。公开 contract 必须归属 `analysis`、`domain` 或 `service` 的明确角色路径。
 
 ## Governance
 
-`LineageArchitectureTest` 保护反射可见的层次语义；`LineageDependencyBoundaryTest` 与 `LineageMavenDependencyBoundaryTest` 保护：
+- `LineageDependencyBoundaryTest`：精确 package 集合、依赖图、Datasource corridor、根包禁令；
+- `LineageMavenDependencyBoundaryTest`：直接依赖集合、runtime provider、消费方显式装配；
+- `LineagePublicApiBoundaryTest`：跨模块类型根和公开方法签名；
+- `LineageCodeStyleConventionTest`：package/path、文件/类型和角色位置；
+- `LineageDocumentationContractTest`：文档集合、链接和最终 contract。
 
-- 根包保持空白；
-- top-level package 必须经过声明；
-- 声明图和实际 import 图都保持无环；
-- 稳定 Service 与 Analysis role 集合固定；
-- Analysis 保持 source-neutral；
-- Datasource import 只进入精确的 config corridor；
-- DAO 使用 Lineage-owned persistence condition；
-- Controller、Service、Repository、DAO、Domain 不发生反向穿透；
-- 旧根包 contract 与业务大桶不能回流；
-- Lineage POM 直接依赖集合固定；
-- JSqlParser 与 Flyway vendor 由 Datasource 提供，driver/UI 不由 Lineage 传播；
-- Lineage 消费方显式装配 Datasource。
+新增 import 或 dependency 之前，先回答：
+
+```text
+Dependency Impact Analysis
+- New edge:
+- Owner of the target truth:
+- Existing corridor or new corridor:
+- Public API impact:
+- Cycle impact:
+- Maven/runtime impact:
+- Documentation and guard updated: yes/no
+```

--- a/yak-ops-business/yak-ops-business-lineage/README.md
+++ b/yak-ops-business/yak-ops-business-lineage/README.md
@@ -1,78 +1,86 @@
 # Lineage
 
-Lineage 是 Yak Ops 的统一元数据血缘模块，负责维护可稳定寻址的元数据资产、带来源证据的有向关系，以及受限深度的上下游图查询。
+Lineage 是 Yak Ops 的统一元数据血缘模块，负责维护可稳定寻址的资产、带来源证据的有向关系，以及有边界的上下游图查询。
 
 ## Read First
 
-本目录只维护**当前有效 contract**，历史迁移过程以 Git / PR 为准。
+本目录只维护当前有效 contract。历史迁移过程以 Git 和 Pull Request 为准，不进入长期架构文档。
 
 | Document | Answers |
 | --- | --- |
-| [`REQUIREMENTS.md`](./REQUIREMENTS.md) | 模块需要提供什么能力、哪些事情不在这里做 |
-| [`DOMAIN.md`](./DOMAIN.md) | Asset / Relation / Evidence / Graph 的领域语义 |
-| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 长期 package、角色与持久化边界 |
-| [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package、跨模块 corridor 与 Maven 依赖归属 |
-| [`CODE_STYLE.md`](../../CODE_STYLE.md) | Yak Ops 仓库统一工程与代码规范 |
-| [`REVIEW.md`](./REVIEW.md) | Lineage PR 的评审标准 |
+| [`REQUIREMENTS.md`](./REQUIREMENTS.md) | 模块提供什么能力，哪些事情不属于 Lineage |
+| [`DOMAIN.md`](./DOMAIN.md) | Asset、Relation、Evidence、Graph 的领域语义 |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 当前 package、公共入口与持久化边界 |
+| [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package、Maven 与跨模块依赖方向 |
+| [`REVIEW.md`](./REVIEW.md) | Lineage 变更的评审和拒绝标准 |
+| [`CODE_STYLE.md`](../../CODE_STYLE.md) | Yak Ops 仓库统一工程规范 |
 
 ## Current Contract
 
-当前生产代码形成两条明确路径：
-
 ```text
-HTTP / module caller
-   -> query / write / maintenance service
-   -> repository
-   -> dao
-   -> shared business database
-
-Dataset / Data Development
-   -> analysis/sql/SqlProjectionLineageAnalyzer
+HTTP / neighboring module
+          ↓
+Query / Write / Maintenance Service
+          ↓
+      Repository
+          ↓
+         DAO
+          ↓
+ MyBatis / Flyway / business database
 ```
 
-Asset / Relation / Graph 位于 `domain`，稳定应用入口位于 `service`，共享 SQL 分析契约位于 `analysis/sql`。具体 SQL parser 实现在 Data Development 的 Lineage 角色包中，Dataset 只通过自身 Gateway Adapter 使用该 contract。
-
-`io.yak.ops.business.lineage` 根包不承载 production Java 类型，也不作为兼容大桶。
-
-## Persistence Contract
+SQL projection analysis 是独立的 source-neutral contract：
 
 ```text
-LineageRepository
-   -> LineageRepositoryAdapter
-   -> LineageDao
-   -> Mapper / PO / XML
+analysis/sql/SqlProjectionLineageAnalyzer
 ```
 
-Datasource 模块只允许从 `config` corridor 进入 Lineage：
+具体 SQL parser 实现由拥有 parser 的 Data Development 模块提供；Dataset 只通过自身 Gateway Adapter 使用共享 contract。
+
+## Active Package Shape
+
+当前生产代码只允许以下七个 top-level package：
 
 ```text
-ConditionalOnLineagePersistence
-LineagePersistenceConfiguration
+io.yak.ops.business.lineage
+├── analysis            # source-neutral analysis contracts
+├── config              # persistence enablement and wiring
+├── controller          # HTTP inbound + DTO/VO mapping
+├── dao                 # MyBatis primitives, mapper and PO
+├── domain              # framework-free lineage facts
+├── repository          # domain persistence contract + adapter
+└── service             # stable query/write/maintenance entries
 ```
 
-DAO 依赖 Lineage 自己的条件注解，不直接感知 Datasource 模块。Repository contract 不暴露 PO、Mapper、HTTP DTO 或 MyBatis 类型。
+根包不放 production Java 类型。`common / helper / utils / base` 不能成为新的业务大桶。
 
-## Maven Contract
+## Public API
 
-Lineage 只声明自身编译所需的 API 和实现边界：Web/Validation、Spring Transaction、MyBatis、Flyway Core、Swagger annotations。
-
-以下运行时能力不由 Lineage 向下游传播：
+邻接业务模块只允许编译依赖以下类型根：
 
 ```text
-Datasource module            -> MyBatis JSqlParser + Flyway MySQL runtime
-explicit app/plugin assembly -> JDBC drivers + Springdoc UI
+analysis.sql.SqlProjectionLineageAnalyzer
+
+domain.LineageAsset
+domain.LineageAssetType
+domain.LineageDirection
+domain.LineageGraph
+domain.LineageRelation
+domain.LineageRelationType
+
+service.LineageQueryService
+service.LineageWriteService
+service.LineageMaintenanceService
 ```
 
-本阶段只锁定 Lineage 的直接依赖面，不顺手统一其他业务模块已有的持久化 POM。
-
-Lineage 对 Datasource 的 Maven 依赖是 optional。任何直接消费 Lineage 的应用或业务模块，都必须显式声明 Datasource，而不能依赖传递引入。
+上述 Service 与 Analyzer 的公开嵌套类型也属于对应类型根。`LineageAssetDraft`、`LineageRelationDraft`、Repository、DAO、Config、Controller 均为模块内部实现，不是跨模块 contract。
 
 ## Core Model
 
 ```text
 LineageAsset
     │
-    │ source -> target
+    │ upstream source -> downstream target
     ▼
 LineageRelation
     │
@@ -81,30 +89,31 @@ LineageRelation
 LineageGraph = root + direction + bounded depth + assets + relations
 ```
 
-关系方向固定为**上游资产 -> 下游资产**。`READS_FROM / WRITES_TO / DERIVES_FROM / CONSUMES / CONTAINS` 描述下游如何使用、派生或包含上游。
+关系方向始终是上游资产指向下游资产。查询层不能为了页面展示反转领域事实。
 
-## Package Shape
+## Extension Protocol
+
+当前没有活动的 `collector` package，也没有 Flink、Spark、Hadoop 占位接口。
+
+当真实平台事件、SDK 或采集协议出现时，新增 Collector 的同一个 PR 必须同时完成：
+
+- 明确 Collector 的输入、输出和 evidence ownership；
+- 将平台 SDK 限制在 adapter 边界；
+- 复用统一 Domain 与稳定写入入口；
+- 更新精确 package 图、依赖图、公共 API 与架构测试；
+- 增加真实行为测试，而不是只创建空目录或空接口。
+
+## Architecture Guards
+
+长期 contract 由以下测试保护：
 
 ```text
-io.yak.ops.business.lineage
-├── controller          # HTTP inbound + transport mapping
-├── service             # stable query / write / maintenance facades
-├── domain              # framework-free lineage domain/value objects
-├── analysis
-│   └── sql             # source-neutral SQL analysis contract
-├── collector           # real platform/source collectors when required
-├── repository          # persistence contracts + domain/DAO adapter
-│   └── support         # persistence-only codecs
-├── dao                 # MyBatis primitives / mapper / PO
-└── config              # persistence wiring + external infrastructure corridor
+LineageArchitectureTest
+LineageDependencyBoundaryTest
+LineageMavenDependencyBoundaryTest
+LineagePublicApiBoundaryTest
+LineageCodeStyleConventionTest
+LineageDocumentationContractTest
 ```
 
-技术名称不直接决定业务层级。未来 Flink、Spark、Hadoop 等能力只有在存在真实采集链路时，才进入 `collector/<platform>`；它们复用统一 Domain 和稳定写入边界，不复制 Service / DAO / Domain。
-
-## Evolution Rule
-
-后续演进遵守三条底线：
-
-1. package、POM 与业务行为修改分开评审；
-2. 外部模块依赖只能进入文档和测试声明的窄 corridor；
-3. 新 dependency 必须有真实 owner，不能为了临时编译把驱动、UI 或平台 SDK 塞进 Lineage。
+新增 package、跨模块类型或 Maven dependency 时，代码、文档和对应 guard 必须在同一个 PR 中一起变化。

--- a/yak-ops-business/yak-ops-business-lineage/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-lineage/REQUIREMENTS.md
@@ -9,57 +9,97 @@ Lineage 负责：
 - 注册、更新并查询统一的 `LineageAsset`；
 - 注册带类型、来源证据、置信度与观测时间的有向 `LineageRelation`；
 - 支持批量写入并对同批输入做稳定去重；
-- 以指定根资产查询 upstream / downstream / both 血缘图；
+- 以指定根资产查询 upstream、downstream 或 both 血缘图；
 - 对自动生成血缘按 evidence scope 做安全替换和清理；
-- 提供 source-neutral 的 SQL projection lineage 分析 contract，供数据开发、Dataset 等调用方复用；
-- 为未来 Flink / Spark / Hadoop 等来源保留角色化接入边界。
+- 提供 source-neutral 的 SQL projection lineage 分析 contract；
+- 为真实平台来源提供统一 Domain 与稳定写入边界。
 
 ## Stable Behavior
 
-当前 HTTP、数据库与 Flyway contract 在纯结构重构中保持不变。
+当前 HTTP、数据库与 Flyway contract 在纯架构调整中保持不变。
 
 图查询继续保持：
 
 - 根资产必须存在；
 - `depth` 有明确上限，当前最大值为 10；
 - 遍历过程中节点与关系去重；
-- 上下游方向由关系的 source / target 决定，不在查询层反转领域语义。
+- 上下游方向由关系的 source/target 决定，不在查询层反转领域语义。
 
 关系写入继续保持：
 
-- source / target 必须是有效资产；
+- source/target 必须是有效资产；
 - 不允许资产指向自身；
 - `confidence` 必须在 `[0, 1]`；
-- evidence 字段用于追踪生成来源，不把来源实现细节变成资产身份。
+- evidence 用于追踪生成来源，不把实现细节变成资产身份。
 
 ## Replacement Safety
 
 自动生成血缘允许按 `sourceType + sourceId` 替换，但清理旧资产必须同时满足 ownership、无残留边、无子节点等安全条件。
 
-旧 revision 在新 revision 已提交后不能覆盖新结果。并发发布的正确性属于 Lineage contract，不应下沉为 Controller 或 SQL 拼接约定。
+旧 revision 在新 revision 已提交后不能覆盖新结果。并发发布正确性属于 Lineage contract，不下沉为 Controller 或 SQL 拼接约定。
 
 ## Analysis Boundary
 
-`SqlProjectionLineageAnalyzer` 是 source-neutral contract。Lineage core 不绑定数据开发模块或某个具体 SQL parser；解析器实现应停留在调用方或明确的 adapter/analysis 实现边界。
+`SqlProjectionLineageAnalyzer` 是 source-neutral contract。Lineage 不绑定 Data Development 或某个具体 SQL parser；实现停留在拥有 parser 的邻接模块。
 
-未来新增 Flink / Spark / Hadoop 血缘时，应优先回答“它承担什么角色”，再决定 package 和依赖，而不是按技术栈复制一套完整业务结构。
+## Public Contract
+
+邻接业务模块只允许使用：
+
+- `analysis.sql.SqlProjectionLineageAnalyzer`；
+- 公开的 Asset/Relation/Graph 只读领域类型及枚举；
+- `LineageQueryService`；
+- `LineageWriteService`；
+- `LineageMaintenanceService`；
+- 上述入口所属的公开嵌套命令、结果和 scope。
+
+以下内容不是跨模块 contract：
+
+- Controller DTO/VO；
+- Repository、RepositoryAdapter；
+- DAO、Mapper、PO；
+- Persistence Config；
+- `LineageAssetDraft`、`LineageRelationDraft`。
+
+调用方应通过自身 Gateway/Adapter 隔离 Lineage 类型，避免将邻接上下文 contract 扩散进自身核心 Domain。
+
+## Platform Extension
+
+当前没有活动的 Collector package，也不为 Flink、Spark、Hadoop 创建占位接口。
+
+出现真实平台事件或 SDK 时，需要先明确：
+
+- evidence owner；
+- 事件重放与重复处理；
+- replacement scope；
+- SDK/event 到统一 Domain 的转换；
+- 失败与恢复；
+- 是否真的需要新增公共 contract 或 Maven artifact。
+
+只有这些条件明确并存在真实调用链，才新增角色 package 和实现。
 
 ## Non-goals
 
 Lineage 不负责：
 
-- 调度 Flink / Spark / Hadoop 作业；
+- 调度 Flink、Spark、Hadoop 作业；
 - 成为数据开发、离线同步、实时同步的第二套任务状态中心；
-- 在 Core Domain 中直接依赖 MyBatis、Spring MVC、Flink/Spark/Hadoop SDK；
-- 为每个来源维护独立的 Asset / Relation 模型；
-- 在结构重构 PR 中顺便修改 REST path、表结构或既有迁移脚本。
+- 在 Domain 中直接依赖 MyBatis、Spring MVC 或平台 SDK；
+- 为每个来源维护独立的 Asset/Relation 模型；
+- 用空 package、空接口或未来白名单表达尚未实现的架构；
+- 向邻接模块公开 Repository、DAO、Config、Controller 或 Draft；
+- 在结构调整中顺便修改 REST path、表结构或既有迁移脚本。
 
 ## Acceptance
 
-Lineage 的结构改造至少需要满足：
+Lineage 变更至少满足：
 
 - 业务行为测试继续通过；
-- architecture / dependency guard 继续通过；
-- HTTP DTO / VO 不进入 Repository/DAO contract；
+- 活动 package 集合与依赖图精确匹配；
+- 声明图和实际 import 图无环；
+- 公共 API 仅包含已声明类型根；
+- HTTP DTO/VO 不进入 Repository/DAO contract；
 - DAO/PO 不进入稳定 Service 与 Domain contract；
+- Maven runtime capability 由正确模块提供；
+- Java source、文档和架构 guard 同步更新；
 - 新依赖方向与 `ARCHITECTURE.md + DEPENDENCIES.md` 一致。

--- a/yak-ops-business/yak-ops-business-lineage/REVIEW.md
+++ b/yak-ops-business/yak-ops-business-lineage/REVIEW.md
@@ -1,118 +1,113 @@
 # Lineage Review Guide
 
-Lineage PR 评审优先看**领域语义、依赖方向和运行时 owner 有没有被破坏**，不是只看代码能否编译。
+Lineage PR 评审优先看领域语义、公共 API 和依赖方向是否被破坏，而不是只看代码能否编译。
 
 ## Scope
 
-- 这个 PR 是否只有一个主要关注点？
-- 纯结构/POM 调整是否偷改了 REST、DB schema、Flyway migration 或业务语义？
-- package、dependency ownership 与 behavior change 是否可以拆开？
+- PR 是否只有一个主要关注点？
+- 纯结构调整是否偷改 REST、DB schema、Flyway 或业务语义？
+- Package move、公共 API 变化和行为变化是否可以拆开？
+- 新抽象是否有真实调用方，还是为了“看起来完整”提前占位？
 
 ## Domain
 
 - Asset identity 是否仍然统一，不因技术来源产生第二套模型？
 - Relation 是否始终表达 upstream source -> downstream target？
 - Evidence 是否只说明来源，不冒充 Asset identity？
-- replacement / revision ordering 是否保持保守和并发安全？
+- Replacement / revision ordering 是否保持保守和并发安全？
 - Graph/query 是否仍然是只读、有边界的 projection？
+- Draft 是否继续停留在模块内部写入过程？
 
 ## Roles
 
-- 新类名是否能直接说明角色？
-- `Service` 是否只用于稳定应用入口，而不是所有 Spring Bean？
-- Analyzer / Collector / Resolver / Converter / Repository / DAO / Configuration 是否各自停在正确边界？
-- SQL Analyzer contract 是否位于 `analysis/sql`，具体 parser 实现是否留在拥有 parser 的 adapter 模块？
-- Flink / Spark / Hadoop 是否作为真实 Collector 实现接入，而不是复制一套业务层？
-- 是否为了“看起来完整”提前新增了没有调用方的 Collector / Resolver 空抽象？
+- `Service` 是否只用于 Query、Write、Maintenance 三个稳定应用入口？
+- Analyzer、Converter、RepositoryAdapter、DAO 是否停在正确 package？
+- SQL Analyzer contract 是否保持 source-neutral？
+- 是否创建了没有真实调用链的 Collector、Resolver 或技术栈平行业务层？
+- 新平台实现是否复用统一 Domain 与写入边界？
+
+## Public API
+
+邻接模块新增 Lineage import 时必须检查：
+
+- 是否属于声明的 Analyzer、Domain 或 Service 类型根？
+- 是否可以通过调用方自己的 Gateway/Adapter 缩小扩散范围？
+- 是否意外依赖 Repository、DAO、Config、Controller 或 Draft？
+- 稳定 Service 的公开方法签名是否泄漏实现类型？
+- 新公共类型是否同时更新 `ARCHITECTURE.md`、`DEPENDENCIES.md` 和 `LineagePublicApiBoundaryTest`？
+
+仅仅因为 Java 类型声明为 `public`，不代表它自动成为跨模块 contract。
 
 ## Dependencies
 
-- Controller 是否只走稳定 Service 和 transport mapping？
-- Service 是否绕过 Repository 直接访问 DAO/Mapper/PO？
-- Analysis contract 是否依赖 Spring、Repository、DAO、Controller 或具体 parser？
+- 活动 top-level package 是否仍与精确矩阵一致？
+- Controller 是否只进入 Service/Domain？
+- Service 是否绕过 Repository 直接访问 DAO、Mapper、PO 或 Config？
+- Analysis 是否依赖 Spring、Repository、DAO、Controller 或具体 parser？
 - Repository contract 是否暴露 HTTP 或 persistence implementation types？
-- DAO 是否反向依赖应用层或直接 import Datasource？
-- Domain 是否出现 Spring/MyBatis/平台 SDK？
-- top-level package 图是否仍然符合声明且无环？
-- 根包是否重新出现 production Java 类型？
-- 是否新增了 `common/helper/utils/base` 之类的大桶？
+- DAO 是否反向依赖应用层或 Domain orchestration？
+- Domain 是否出现 Spring、MyBatis 或平台 SDK？
+- 根包是否重新出现 production 类型或全限定引用？
+- 是否新增 `common/helper/utils/base` 大桶？
+- 声明图和实际 import 图是否继续无环？
 
 ## Persistence
 
-- Domain ↔ PO 转换是否停在 RepositoryAdapter？
+- Domain 与 PO 转换是否停在 RepositoryAdapter？
 - MyBatis Mapper/XML 是否只承担数据库 primitive？
-- JSON/compatibility codec 是否位于 persistence boundary，而不是 Core Domain？
-- Datasource import 是否只存在于两个声明的 `config` 文件？
-- DAO 是否通过 `ConditionalOnLineagePersistence` 接收装配条件？
-- 是否顺手改变了 Flyway location、history table、baseline 或 bean name？
+- JSON/compatibility codec 是否位于 `repository.support`？
+- DAO 是否只使用 `ConditionalOnLineagePersistence`？
+- Datasource import 是否仍只存在于两个声明的 Config corridor 文件？
 
-## Maven Ownership
+## Maven
 
-新增或调整依赖时必须回答：
-
-```text
-Dependency Impact Analysis
-- Capability owner:
-- Compile API or runtime adapter:
-- Direct / optional / runtime / test scope:
-- Does it propagate to Lineage consumers:
-- Existing owner module/plugin:
-- POM guard updated: yes/no
-```
-
-Lineage POM 默认拒绝重新加入：
-
-```text
-spring-boot-starter-jdbc
-springdoc-openapi-starter-webmvc-ui
-mybatis-plus-jsqlparser-4.9
-flyway-mysql
-mysql-connector-j
-```
-
-检查运行时 owner：
-
-- MyBatis JSqlParser 与 Flyway MySQL 由 Datasource 提供；
-- JDBC driver 与 OpenAPI UI 属于显式应用/插件装配，不属于 Lineage；
-- 不借 Lineage PR 顺手改写其他业务模块的历史 POM；
-- 直接消费 Lineage 的模块必须显式依赖 Datasource。
+- Lineage POM 是否新增了调用方不需要的 runtime 实现？
+- Driver、Flyway database extension、JSqlParser 等能力是否放在真正的装配 owner？
+- 消费 Lineage 的模块是否显式声明自身运行所需 provider？
+- 是否因为目录美观而提前拆 Maven artifact？
+- 新依赖是否同步更新 Maven boundary test？
 
 ## Compatibility
 
-纯架构/POM PR 默认要求：
+纯架构 PR 默认要求：
 
 ```text
 REST contract unchanged
 DB schema unchanged
-Flyway migration and history semantics unchanged
+Flyway unchanged
 Asset/Relation semantics unchanged
 existing behavior tests unchanged or strengthened
 ```
 
-任何例外都必须在 PR body 中单独说明原因与迁移策略。
+任何例外都必须在 PR 正文中单独说明原因、影响面和迁移策略。
 
 ## Tests
 
 至少检查：
 
-- `LineageArchitectureTest`；
-- `LineageDependencyBoundaryTest`；
-- `LineageMavenDependencyBoundaryTest`；
-- 被修改用例对应的 behavior test；
-- 受 POM scope 调整影响的 Datasource / Boot 装配；
-- 如果调整 dependency allowlist，文档是否同步且理由是否真实。
+- `LineageArchitectureTest`
+- `LineageDependencyBoundaryTest`
+- `LineageMavenDependencyBoundaryTest`
+- `LineagePublicApiBoundaryTest`
+- `LineageCodeStyleConventionTest`
+- `LineageDocumentationContractTest`
+- 被修改用例对应的 behavior test
+- 跨模块调用方联合编译
+
+新增真实 Collector 时，还必须覆盖重复事件、失败重试、replacement、ownership 和平台事件转换。
 
 ## Reject Signals
 
 以下情况默认要求拆分或返工：
 
-- 为了让测试通过直接扩大 package 或 POM 白名单；
-- 一个 PR 同时大规模 move package、改表、改接口、改领域行为；
-- 新增 `FlinkLineageService / SparkLineageService / HadoopLineageService` 但职责只是同一用例的技术分叉；
-- 创建没有真实调用方的 Collector/Resolver 层，只为填满目录；
+- 为了让测试通过直接扩大 package、public API 或 dependency 白名单；
+- 声明不存在的活动 package，等待未来代码补齐；
+- 一个 PR 同时大规模移动代码、改表、改接口和改领域行为；
 - Controller 直接操作 Repository/DAO；
+- Service 公开方法暴露 Repository、DAO、Config、PO 或 Draft；
 - Analysis contract 携带 Spring、Parser SDK 或持久化类型；
-- DAO 直接依赖 Datasource 模块；
-- 把 driver、vendor runtime 或 UI starter 放回 Lineage POM；
-- Domain 开始携带 Mapper/PO/HTTP DTO；
+- Domain 携带 Mapper、PO、HTTP DTO 或平台 SDK；
+- 新增 `FlinkLineageService / SparkLineageService / HadoopLineageService` 复制同一业务层；
+- 创建没有真实调用方的 Collector/Resolver 空抽象；
+- 运行时 driver/extension 被重新塞回 Lineage 并传递给所有消费者；
 - 只有 Markdown 约定，没有可执行架构护栏。

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageCodeStyleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageCodeStyleConventionTest.java
@@ -1,0 +1,169 @@
+package io.yak.ops.business.lineage.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Lightweight source conventions for the Lineage module. */
+class LineageCodeStyleConventionTest {
+
+  private static final Pattern PUBLIC_TOP_LEVEL_TYPE =
+      Pattern.compile(
+          "(?m)^public\\s+(?:(?:abstract|final|sealed|non-sealed)\\s+)*"
+              + "(?:@interface|class|interface|record|enum)\\s+([A-Za-z_$][A-Za-z0-9_$]*)");
+
+  @Test
+  void javaSourcesUseStableTextConventions() throws IOException {
+    for (Path source : moduleJavaFiles()) {
+      String text = Files.readString(source, StandardCharsets.UTF_8);
+      String relative = normalize(moduleRoot().relativize(source));
+
+      assertThat(text).as(relative).doesNotContain("\t");
+      assertThat(text.endsWith("\n")).as("%s must end with a newline", relative).isTrue();
+
+      String[] lines = text.split("\\R", -1);
+      for (int index = 0; index < lines.length; index++) {
+        assertThat(lines[index])
+            .as("%s:%s has trailing whitespace", relative, index + 1)
+            .isEqualTo(lines[index].stripTrailing());
+      }
+
+      boolean wildcardImport =
+          text.lines()
+              .map(String::trim)
+              .anyMatch(
+                  line ->
+                      (line.startsWith("import ") || line.startsWith("import static "))
+                          && line.endsWith(".*;"));
+      assertThat(wildcardImport).as("%s must not use wildcard imports", relative).isFalse();
+    }
+  }
+
+  @Test
+  void packageDeclarationsMatchSourcePaths() throws IOException {
+    assertPackages(
+        mainJavaRoot(),
+        "io.yak.ops.business.lineage");
+    assertPackages(
+        testJavaRoot(),
+        "io.yak.ops.business.lineage");
+  }
+
+  @Test
+  void publicProductionTypeMatchesItsFileName() throws IOException {
+    for (Path source : javaFiles(mainJavaRoot())) {
+      String text = Files.readString(source, StandardCharsets.UTF_8);
+      Matcher matcher = PUBLIC_TOP_LEVEL_TYPE.matcher(text);
+      List<String> publicTypes = new ArrayList<>();
+      while (matcher.find()) publicTypes.add(matcher.group(1));
+
+      String filename = source.getFileName().toString();
+      String expected = filename.substring(0, filename.length() - ".java".length());
+      assertThat(publicTypes)
+          .as("One public top-level type must match %s", normalize(source))
+          .containsExactly(expected);
+    }
+  }
+
+  @Test
+  void roleNamesStayInTheirOwningPackages() throws IOException {
+    Path root = mainJavaRoot();
+    for (Path source : javaFiles(root)) {
+      String relative = normalize(root.relativize(source));
+      String filename = source.getFileName().toString();
+
+      if (filename.endsWith("Controller.java")) {
+        assertThat(relative).startsWith("controller/");
+      }
+      if (filename.endsWith("Service.java")) {
+        assertThat(relative).startsWith("service/");
+      }
+      if (filename.endsWith("Analyzer.java")) {
+        assertThat(relative).startsWith("analysis/");
+      }
+      if (filename.endsWith("Repository.java")
+          || filename.endsWith("RepositoryAdapter.java")
+          || filename.endsWith("Codec.java")) {
+        assertThat(relative).startsWith("repository/");
+      }
+      if (filename.endsWith("Dao.java") || filename.endsWith("DaoImpl.java")) {
+        assertThat(relative).startsWith("dao/");
+      }
+      if (filename.endsWith("Mapper.java")) {
+        assertThat(
+                relative.startsWith("dao/mapper/")
+                    || relative.startsWith("controller/v1/converter/"))
+            .as("Mapper role is misplaced: %s", relative)
+            .isTrue();
+      }
+      if (filename.endsWith("Configuration.java") || filename.startsWith("ConditionalOn")) {
+        assertThat(relative).startsWith("config/");
+      }
+    }
+  }
+
+  private void assertPackages(Path root, String basePackage) throws IOException {
+    for (Path source : javaFiles(root)) {
+      Path relative = root.relativize(source);
+      Path parent = relative.getParent();
+      String suffix =
+          parent == null ? "" : "." + normalize(parent).replace('/', '.');
+      String expected = "package " + basePackage + suffix + ";";
+      String text = Files.readString(source, StandardCharsets.UTF_8);
+      String firstNonBlank =
+          text.lines().filter(line -> !line.isBlank()).findFirst().orElse("");
+
+      assertThat(firstNonBlank)
+          .as("Package declaration must match %s", normalize(relative))
+          .isEqualTo(expected);
+    }
+  }
+
+  private List<Path> moduleJavaFiles() throws IOException {
+    List<Path> result = new ArrayList<>();
+    result.addAll(javaFiles(mainJavaRoot()));
+    result.addAll(javaFiles(testJavaRoot()));
+    return result;
+  }
+
+  private List<Path> javaFiles(Path root) throws IOException {
+    if (!Files.isDirectory(root)) return List.of();
+    try (Stream<Path> files = Files.walk(root)) {
+      return files.filter(path -> path.toString().endsWith(".java")).sorted().toList();
+    }
+  }
+
+  private Path moduleRoot() {
+    Path current = Paths.get(".").toAbsolutePath().normalize();
+    if (Files.isDirectory(current.resolve("src/main/java"))) return current;
+
+    Path repositoryRelative =
+        current.resolve("yak-ops-business/yak-ops-business-lineage").normalize();
+    assertThat(Files.isDirectory(repositoryRelative.resolve("src/main/java")))
+        .as("Unable to locate Lineage module from %s", current)
+        .isTrue();
+    return repositoryRelative;
+  }
+
+  private Path mainJavaRoot() {
+    return moduleRoot().resolve("src/main/java/io/yak/ops/business/lineage");
+  }
+
+  private Path testJavaRoot() {
+    return moduleRoot().resolve("src/test/java/io/yak/ops/business/lineage");
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDependencyBoundaryTest.java
@@ -16,11 +16,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-/** Source-level guard for the permanent Lineage package roles and dependency boundaries. */
+/** Source-level guard for the final Lineage package roles and dependency boundaries. */
 class LineageDependencyBoundaryTest {
 
   private static final String BASE = "io.yak.ops.business.lineage";
@@ -28,9 +29,8 @@ class LineageDependencyBoundaryTest {
   private static final Map<String, Set<String>> ALLOWED_TOP_LEVEL_DEPENDENCIES =
       Map.ofEntries(
           Map.entry("controller", Set.of("domain", "service")),
-          Map.entry("service", Set.of("analysis", "collector", "domain", "repository")),
+          Map.entry("service", Set.of("analysis", "domain", "repository")),
           Map.entry("analysis", Set.of("domain")),
-          Map.entry("collector", Set.of("analysis", "domain")),
           Map.entry("repository", Set.of("dao", "domain")),
           Map.entry("dao", Set.of("config")),
           Map.entry("domain", Set.of()),
@@ -57,6 +57,9 @@ class LineageDependencyBoundaryTest {
           Set.of(
               "io.yak.ops.business.datasource.config.BusinessDatabaseConfiguration",
               "io.yak.ops.business.datasource.config.DataSourceProperties"));
+
+  private static final Pattern ROOT_TYPE_REFERENCE =
+      Pattern.compile("\\bio\\.yak\\.ops\\.business\\.lineage\\.[A-Z][A-Za-z0-9_$]*");
 
   @Test
   void rootPackageMustRemainEmpty() throws IOException {
@@ -106,24 +109,25 @@ class LineageDependencyBoundaryTest {
   }
 
   @Test
-  void productionTopLevelPackagesMustBeDeclared() throws IOException {
-    Set<String> actual = new HashSet<>();
+  void productionTopLevelPackagesMustMatchContract() throws IOException {
+    Set<String> actual = new LinkedHashSet<>();
     try (Stream<Path> paths = Files.list(productionRoot())) {
       paths.filter(Files::isDirectory)
           .map(path -> path.getFileName().toString())
           .forEach(actual::add);
     }
 
-    assertThat(DECLARED_TOP_LEVEL_PACKAGES)
-        .as("New top-level Lineage packages require an architecture contract update")
-        .containsAll(actual);
+    assertThat(actual)
+        .as("Active Lineage packages must match the executable architecture contract exactly")
+        .containsExactlyInAnyOrderElementsOf(DECLARED_TOP_LEVEL_PACKAGES);
   }
 
   @Test
   void topLevelImportsFollowDeclaredDependencyGraph() throws IOException {
     for (Dependency dependency : packageDependencies()) {
-      assertThat(ALLOWED_TOP_LEVEL_DEPENDENCIES.getOrDefault(
-              dependency.sourcePackage(), Set.of()))
+      assertThat(
+              ALLOWED_TOP_LEVEL_DEPENDENCIES.getOrDefault(
+                  dependency.sourcePackage(), Set.of()))
           .as("%s imports %s", dependency.relativePath(), dependency.importedType())
           .contains(dependency.targetPackage());
     }
@@ -185,6 +189,7 @@ class LineageDependencyBoundaryTest {
     assertNoImports(
         "service",
         BASE + ".dao.",
+        BASE + ".config.",
         "com.baomidou.mybatisplus",
         "JdbcTemplate");
   }
@@ -199,7 +204,6 @@ class LineageDependencyBoundaryTest {
         BASE + ".service.",
         BASE + ".repository.",
         BASE + ".dao.",
-        BASE + ".collector.",
         BASE + ".config.");
   }
 
@@ -219,7 +223,6 @@ class LineageDependencyBoundaryTest {
         BASE + ".controller.",
         BASE + ".service.",
         BASE + ".analysis.",
-        BASE + ".collector.",
         BASE + ".repository.",
         BASE + ".domain.");
   }
@@ -234,16 +237,13 @@ class LineageDependencyBoundaryTest {
         BASE + ".service.",
         BASE + ".repository.",
         BASE + ".dao.",
-        BASE + ".analysis.",
-        BASE + ".collector.");
+        BASE + ".analysis.");
   }
 
   @Test
   void serviceStereotypeCannotLeakIntoInfrastructureOrDomain() throws IOException {
-    for (String packageName :
-        Set.of("analysis", "collector", "config", "dao", "domain", "repository")) {
+    for (String packageName : Set.of("analysis", "config", "dao", "domain", "repository")) {
       Path root = productionRoot().resolve(packageName);
-      if (!Files.isDirectory(root)) continue;
       for (Path file : javaFiles(root)) {
         String source = Files.readString(file, StandardCharsets.UTF_8);
         assertThat(source)
@@ -254,29 +254,13 @@ class LineageDependencyBoundaryTest {
   }
 
   @Test
-  void legacyRootContractsCannotReturnAcrossProductionSources() throws IOException {
-    Set<String> forbiddenImports =
-        Set.of(
-            "import " + BASE + ".LineageService;",
-            "import " + BASE + ".LineageMaintenanceService;",
-            "import " + BASE + ".LineageAsset;",
-            "import " + BASE + ".LineageAssetDraft;",
-            "import " + BASE + ".LineageAssetType;",
-            "import " + BASE + ".LineageDirection;",
-            "import " + BASE + ".LineageGraph;",
-            "import " + BASE + ".LineageRelation;",
-            "import " + BASE + ".LineageRelationDraft;",
-            "import " + BASE + ".LineageRelationType;",
-            "import " + BASE + ".SqlProjectionLineageAnalyzer;");
-
+  void rootPackageTypesCannotReturnAcrossProductionSources() throws IOException {
     try (Stream<Path> files = Files.walk(repositoryRoot())) {
       for (Path file : files.filter(this::isProductionJava).toList()) {
         String source = Files.readString(file, StandardCharsets.UTF_8);
-        for (String forbiddenImport : forbiddenImports) {
-          assertThat(source)
-              .as("Legacy Lineage root contract in %s", normalize(file))
-              .doesNotContain(forbiddenImport);
-        }
+        assertThat(ROOT_TYPE_REFERENCE.matcher(source).find())
+            .as("Lineage root-package type reference in %s", normalize(file))
+            .isFalse();
       }
     }
   }
@@ -384,8 +368,6 @@ class LineageDependencyBoundaryTest {
 
   private void assertNoImports(String packageName, String... forbiddenTokens) throws IOException {
     Path root = productionRoot().resolve(packageName);
-    if (!Files.isDirectory(root)) return;
-
     for (Path file : javaFiles(root)) {
       String source = Files.readString(file, StandardCharsets.UTF_8);
       String imports =
@@ -402,6 +384,7 @@ class LineageDependencyBoundaryTest {
 
   private Set<Path> javaFiles(Path root) throws IOException {
     Set<Path> result = new LinkedHashSet<>();
+    if (!Files.isDirectory(root)) return result;
     try (Stream<Path> files = Files.walk(root)) {
       files.filter(path -> path.toString().endsWith(".java")).forEach(result::add);
     }

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDocumentationContractTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineageDocumentationContractTest.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.lineage.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Keeps the Lineage documentation set aligned with the final architecture contract. */
+class LineageDocumentationContractTest {
+
+  private static final Set<String> MODULE_DOCUMENTS =
+      Set.of(
+          "ARCHITECTURE.md",
+          "DEPENDENCIES.md",
+          "DOMAIN.md",
+          "README.md",
+          "REQUIREMENTS.md",
+          "REVIEW.md");
+
+  private static final Map<String, Set<String>> REQUIRED_MARKERS =
+      Map.of(
+          "README.md",
+          Set.of("Active Package Shape", "Public API", "Architecture Guards"),
+          "ARCHITECTURE.md",
+          Set.of("Active Package Map", "Public API Boundary", "Extension Protocol"),
+          "DEPENDENCIES.md",
+          Set.of("Active Dependency Graph", "Public API Corridors", "Maven Boundary"),
+          "REQUIREMENTS.md",
+          Set.of("Public Contract", "Non-goals", "Acceptance"),
+          "REVIEW.md",
+          Set.of("Public API", "Reject Signals"),
+          "DOMAIN.md",
+          Set.of("Asset", "Relation", "Graph"));
+
+  @Test
+  void moduleDocumentationSetIsExplicit() throws IOException {
+    Set<String> actual = new LinkedHashSet<>();
+    try (Stream<Path> files = Files.list(moduleRoot())) {
+      files.filter(Files::isRegularFile)
+          .map(path -> path.getFileName().toString())
+          .filter(name -> name.endsWith(".md"))
+          .forEach(actual::add);
+    }
+
+    assertThat(actual)
+        .as("Lineage documentation files form one maintained contract")
+        .containsExactlyInAnyOrderElementsOf(MODULE_DOCUMENTS);
+  }
+
+  @Test
+  void readmeLinksEveryCompanionDocument() throws IOException {
+    String readme = read("README.md");
+    for (String document : MODULE_DOCUMENTS) {
+      if ("README.md".equals(document)) continue;
+      assertThat(readme)
+          .as("README must link %s", document)
+          .contains("(./" + document + ")");
+    }
+  }
+
+  @Test
+  void documentsDescribeTheFinalContractInsteadOfMigrationStages() throws IOException {
+    for (String document : MODULE_DOCUMENTS) {
+      String content = read(document);
+      assertThat(content).as(document).startsWith("# ");
+      assertThat(content).as(document).doesNotContain(
+          "Stage 1",
+          "Stage 2",
+          "Stage 3",
+          "Stage 4",
+          "Stage 5",
+          "Stage 6",
+          "阶段 1",
+          "阶段 2",
+          "阶段 3",
+          "阶段 4",
+          "阶段 5",
+          "阶段 6");
+
+      for (String marker : REQUIRED_MARKERS.getOrDefault(document, Set.of())) {
+        assertThat(content).as("%s must describe %s", document, marker).contains(marker);
+      }
+    }
+  }
+
+  private String read(String filename) throws IOException {
+    return Files.readString(moduleRoot().resolve(filename), StandardCharsets.UTF_8);
+  }
+
+  private Path moduleRoot() {
+    Path current = Paths.get(".").toAbsolutePath().normalize();
+    if (Files.isRegularFile(current.resolve("README.md"))
+        && Files.isDirectory(current.resolve("src/main/java"))) {
+      return current;
+    }
+
+    Path repositoryRelative =
+        current.resolve("yak-ops-business/yak-ops-business-lineage").normalize();
+    assertThat(Files.isDirectory(repositoryRelative))
+        .as("Unable to locate Lineage module from %s", current)
+        .isTrue();
+    return repositoryRelative;
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineagePublicApiBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/architecture/LineagePublicApiBoundaryTest.java
@@ -1,0 +1,167 @@
+package io.yak.ops.business.lineage.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.lineage.analysis.sql.SqlProjectionLineageAnalyzer;
+import io.yak.ops.business.lineage.service.LineageMaintenanceService;
+import io.yak.ops.business.lineage.service.LineageQueryService;
+import io.yak.ops.business.lineage.service.LineageWriteService;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Locks the Lineage types that neighboring business modules may compile against. */
+class LineagePublicApiBoundaryTest {
+
+  private static final String BASE = "io.yak.ops.business.lineage";
+
+  private static final Set<String> EXPORTED_TYPE_ROOTS =
+      Set.of(
+          BASE + ".analysis.sql.SqlProjectionLineageAnalyzer",
+          BASE + ".domain.LineageAsset",
+          BASE + ".domain.LineageAssetType",
+          BASE + ".domain.LineageDirection",
+          BASE + ".domain.LineageGraph",
+          BASE + ".domain.LineageRelation",
+          BASE + ".domain.LineageRelationType",
+          BASE + ".service.LineageMaintenanceService",
+          BASE + ".service.LineageQueryService",
+          BASE + ".service.LineageWriteService");
+
+  private static final Set<Class<?>> STABLE_ENTRY_TYPES =
+      Set.of(
+          SqlProjectionLineageAnalyzer.class,
+          LineageMaintenanceService.class,
+          LineageQueryService.class,
+          LineageWriteService.class);
+
+  private static final Set<String> FORBIDDEN_SIGNATURE_TOKENS =
+      Set.of(
+          BASE + ".config.",
+          BASE + ".controller.",
+          BASE + ".dao.",
+          BASE + ".repository.",
+          BASE + ".domain.LineageAssetDraft",
+          BASE + ".domain.LineageRelationDraft");
+
+  @Test
+  void neighboringProductionModulesUseOnlyDeclaredPublicTypes() throws IOException {
+    Map<String, Set<String>> consumers = externalLineageImports();
+
+    for (Map.Entry<String, Set<String>> entry : consumers.entrySet()) {
+      String imported = entry.getKey();
+      assertThat(imported)
+          .as("Wildcard imports cannot define a stable Lineage API: %s", entry.getValue())
+          .doesNotEndWith(".*");
+      assertThat(isDeclaredPublicType(imported))
+          .as("Undeclared Lineage API import %s used by %s", imported, entry.getValue())
+          .isTrue();
+    }
+  }
+
+  @Test
+  void declaredPublicTypeRootsExistAndArePublic() throws ClassNotFoundException {
+    for (String typeName : EXPORTED_TYPE_ROOTS) {
+      Class<?> type = Class.forName(typeName);
+      assertThat(Modifier.isPublic(type.getModifiers()))
+          .as("Declared Lineage API type must be public: %s", typeName)
+          .isTrue();
+    }
+  }
+
+  @Test
+  void stableEntryMethodsDoNotExposeImplementationTypes() {
+    for (Class<?> entryType : STABLE_ENTRY_TYPES) {
+      for (Method method : entryType.getDeclaredMethods()) {
+        if (!Modifier.isPublic(method.getModifiers())) continue;
+        String signature = method.toGenericString();
+        for (String forbidden : FORBIDDEN_SIGNATURE_TOKENS) {
+          assertThat(signature)
+              .as("Implementation type leaked from %s", signature)
+              .doesNotContain(forbidden);
+        }
+      }
+    }
+  }
+
+  @Test
+  void draftModelsRemainModuleInternal() throws IOException {
+    Map<String, Set<String>> consumers = externalLineageImports();
+    assertThat(consumers)
+        .doesNotContainKeys(
+            BASE + ".domain.LineageAssetDraft",
+            BASE + ".domain.LineageRelationDraft");
+  }
+
+  private boolean isDeclaredPublicType(String imported) {
+    return EXPORTED_TYPE_ROOTS.stream()
+        .anyMatch(root -> imported.equals(root) || imported.startsWith(root + "."));
+  }
+
+  private Map<String, Set<String>> externalLineageImports() throws IOException {
+    Path repository = repositoryRoot();
+    Path lineageModule =
+        repository.resolve("yak-ops-business/yak-ops-business-lineage").normalize();
+    Map<String, Set<String>> result = new LinkedHashMap<>();
+
+    try (Stream<Path> files = Files.walk(repository)) {
+      for (Path source : files.filter(this::isProductionJava).toList()) {
+        if (source.normalize().startsWith(lineageModule)) continue;
+        for (String line : Files.readAllLines(source, StandardCharsets.UTF_8)) {
+          String imported = importedType(line);
+          if (imported == null || !imported.startsWith(BASE + ".")) continue;
+          result
+              .computeIfAbsent(imported, ignored -> new LinkedHashSet<>())
+              .add(normalize(repository.relativize(source)));
+        }
+      }
+    }
+    return result;
+  }
+
+  private String importedType(String line) {
+    String value = line.trim();
+    String prefix;
+    if (value.startsWith("import static ")) {
+      prefix = "import static ";
+    } else if (value.startsWith("import ")) {
+      prefix = "import ";
+    } else {
+      return null;
+    }
+    if (!value.endsWith(";")) return null;
+    return value.substring(prefix.length(), value.length() - 1);
+  }
+
+  private boolean isProductionJava(Path path) {
+    String normalized = normalize(path);
+    return normalized.endsWith(".java")
+        && normalized.contains("/src/main/java/")
+        && !normalized.contains("/target/");
+  }
+
+  private Path repositoryRoot() {
+    Path current = Paths.get(".").toAbsolutePath().normalize();
+    if (Files.isDirectory(current.resolve("yak-ops-business"))) return current;
+
+    Path candidate = current.resolve("../..").normalize();
+    assertThat(Files.isDirectory(candidate.resolve("yak-ops-business")))
+        .as("Unable to locate repository root from %s", current)
+        .isTrue();
+    return candidate;
+  }
+
+  private String normalize(Path path) {
+    return path.toString().replace('\\', '/');
+  }
+}


### PR DESCRIPTION
## 背景

这是 Lineage 架构改造的最终收尾。本阶段不再移动 production 代码或修改业务行为，而是清理最后的过渡性声明，并把当前真实结构、跨模块公共 API、代码约定和文档集合固化为可执行 contract。

## 本次改动

### 1. 活动 package 与未来扩展彻底分离

当前生产代码只有以下七个 top-level package：

```text
analysis
config
controller
dao
domain
repository
service
```

本 PR 从活动依赖图和白名单中移除尚不存在的 `collector`。未来只有出现真实平台事件、SDK、evidence ownership 和调用链时，才允许在同一个 PR 中新增 Collector package、依赖边、行为测试和文档。

`LineageDependencyBoundaryTest` 由“声明集合包含当前目录”收紧为“声明集合与当前目录精确一致”。

### 2. 根包禁令从临时类名清单升级为结构规则

删除针对旧 `LineageService / LineageAsset / ...` 的有限黑名单，改为阻止任意：

```text
io.yak.ops.business.lineage.<UppercaseType>
```

这样以后即使出现新的根包类型名称，也无法绕过护栏。根包继续保持无 production Java 类型。

### 3. 锁定跨模块公共 API

新增 `LineagePublicApiBoundaryTest`，将邻接业务模块可编译依赖的类型根固定为：

```text
analysis.sql.SqlProjectionLineageAnalyzer

domain.LineageAsset
domain.LineageAssetType
domain.LineageDirection
domain.LineageGraph
domain.LineageRelation
domain.LineageRelationType

service.LineageQueryService
service.LineageWriteService
service.LineageMaintenanceService
```

公开嵌套命令、结果和 scope 跟随所属类型根。

明确禁止跨模块依赖：

```text
controller/*
config/*
dao/*
repository/*
domain.LineageAssetDraft
domain.LineageRelationDraft
```

同时检查稳定 Service/Analyzer 的公开方法签名不能泄漏 Repository、DAO、Config、Controller 或 Draft。

### 4. 增加代码结构约定

新增 `LineageCodeStyleConventionTest`，保护：

- UTF-8 Java source 的 final newline、tab、trailing whitespace；
- 禁止 wildcard import；
- package declaration 与源码路径一致；
- production public top-level type 与文件名一致；
- Controller、Service、Analyzer、Repository、DAO、Mapper、Configuration 等角色停在正确 package。

### 5. 文档成为可执行 contract

新增 `LineageDocumentationContractTest`：

- 模块文档固定为 README、REQUIREMENTS、DOMAIN、ARCHITECTURE、DEPENDENCIES、REVIEW；
- README 必须链接所有 companion documents；
- 文档必须描述当前长期 contract，不能继续保留迁移阶段术语；
- Active Package、Public API、Extension Protocol、Maven Boundary 等关键章节必须存在。

同步重写以上五份边界文档，使它们只描述当前真实结构，并明确未来 Collector 的接入协议。

## 保持不变

- REST 路径、DTO/VO 和响应语义；
- Asset、Relation、Evidence、Graph 领域语义；
- Query、Write、Maintenance 行为；
- Repository、DAO、Mapper、SQL；
- 数据库表、Flyway 和业务数据源装配；
- Maven POM 与 module 布局；
- SQL Analyzer 行为。

本 PR 没有修改 production Java。

## 验证

已完成并通过临时 GitHub Actions 验证：

- 当前 package 精确集合检查；
- 全仓 production Java 根包类型引用扫描；
- 全仓跨模块 Lineage import 审计；
- 公共 API 精确 allowlist；
- Java source 文本规范检查；
- 文档集合与迁移术语检查；
- architecture test 文件集合检查；
- `git diff --check`；
- Java 21 下使用 JUnit/AssertJ 与最小 contract stubs 编译全部 architecture guard。

临时审计和验证 workflow 已从最终分支移除，不进入 PR diff。

完整 Maven reactor 仍建议在正常开发环境执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-lineage -am test
```

## 最终状态

合并后，Lineage 的长期护栏为：

```text
LineageArchitectureTest
LineageDependencyBoundaryTest
LineageMavenDependencyBoundaryTest
LineagePublicApiBoundaryTest
LineageCodeStyleConventionTest
LineageDocumentationContractTest
```

后续架构变化必须同时修改真实代码、文档与对应 guard，不再依赖阶段性白名单。