### PR TITLE
feat(home): 接入数据资产与血缘真实指标（Stage 4）

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeAssetOverviewController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeAssetOverviewController.java
@@ -1,0 +1,24 @@
+package io.yak.ops.boot.home;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.boot.home.HomeAssetOverviewService.OverviewResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 首页数据资产与血缘总览接口。 */
+@RestController
+@RequestMapping("/api/v1/home/assets")
+public class HomeAssetOverviewController {
+
+  private final HomeAssetOverviewService service;
+
+  public HomeAssetOverviewController(HomeAssetOverviewService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/overview")
+  public Result<OverviewResponse> overview() {
+    return Result.success(service.overview());
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeAssetOverviewService.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeAssetOverviewService.java
@@ -1,0 +1,277 @@
+package io.yak.ops.boot.home;
+
+import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.DatasetStatus;
+import io.yak.ops.business.dataset.DatasetService;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.query.LineageQueryService;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** 首页数据资产与血缘只读聚合。 */
+@Service
+public class HomeAssetOverviewService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HomeAssetOverviewService.class);
+  private static final int DATASET_LIST_LIMIT = 5;
+  private static final int LINEAGE_RELATION_LIMIT = 6;
+  private static final int LINEAGE_ACTIVITY_LIMIT = 3;
+
+  private final ObjectProvider<DatasetService> datasetServiceProvider;
+  private final ObjectProvider<LineageQueryService> lineageQueryServiceProvider;
+
+  public HomeAssetOverviewService(
+      ObjectProvider<DatasetService> datasetServiceProvider,
+      ObjectProvider<LineageQueryService> lineageQueryServiceProvider) {
+    this.datasetServiceProvider = datasetServiceProvider;
+    this.lineageQueryServiceProvider = lineageQueryServiceProvider;
+  }
+
+  public OverviewResponse overview() {
+    DayRange today = DayRange.today();
+    List<Dataset> datasets = loadDatasets();
+    LineageQueryService.Overview lineage = loadLineage(today);
+    return new OverviewResponse(datasetOverview(datasets, lineage, today), lineageOverview(lineage));
+  }
+
+  private List<Dataset> loadDatasets() {
+    DatasetService service = datasetServiceProvider.getIfAvailable();
+    if (service == null) return null;
+    try {
+      return service.list();
+    } catch (RuntimeException exception) {
+      LOGGER.warn("加载首页数据集总览失败", exception);
+      return null;
+    }
+  }
+
+  private LineageQueryService.Overview loadLineage(DayRange today) {
+    LineageQueryService service = lineageQueryServiceProvider.getIfAvailable();
+    if (service == null) return null;
+    try {
+      return service.overview(today.start(), today.end(), LINEAGE_RELATION_LIMIT);
+    } catch (RuntimeException exception) {
+      LOGGER.warn("加载首页血缘总览失败", exception);
+      return null;
+    }
+  }
+
+  private DatasetOverview datasetOverview(
+      List<Dataset> datasets, LineageQueryService.Overview lineage, DayRange today) {
+    Long datasetCount = datasets == null ? null : (long) datasets.size();
+    Long todayCreatedCount =
+        datasets == null
+            ? null
+            : datasets.stream()
+                .map(Dataset::createTime)
+                .filter(value -> inRange(value, today))
+                .count();
+    Long tableAssetCount = lineage == null ? null : lineage.tableAssetCount();
+    Long columnAssetCount = lineage == null ? null : lineage.columnAssetCount();
+
+    return new DatasetOverview(
+        datasetCount,
+        tableAssetCount,
+        columnAssetCount,
+        todayCreatedCount,
+        recentDatasets(datasets),
+        onlineDatasets(datasets));
+  }
+
+  private List<DatasetItem> recentDatasets(List<Dataset> datasets) {
+    if (datasets == null || datasets.isEmpty()) return List.of();
+    return datasets.stream()
+        .sorted(datasetUpdatedComparator())
+        .limit(DATASET_LIST_LIMIT)
+        .map(this::datasetItem)
+        .toList();
+  }
+
+  private List<DatasetItem> onlineDatasets(List<Dataset> datasets) {
+    if (datasets == null || datasets.isEmpty()) return List.of();
+    return datasets.stream()
+        .filter(dataset -> dataset.status() == DatasetStatus.ONLINE)
+        .sorted(datasetUpdatedComparator())
+        .limit(DATASET_LIST_LIMIT)
+        .map(this::datasetItem)
+        .toList();
+  }
+
+  private Comparator<Dataset> datasetUpdatedComparator() {
+    return Comparator.comparing(
+            this::datasetUpdatedAt,
+            Comparator.nullsLast(Comparator.reverseOrder()))
+        .thenComparing(Dataset::id, Comparator.reverseOrder());
+  }
+
+  private Instant datasetUpdatedAt(Dataset dataset) {
+    return dataset.updateTime() == null ? dataset.createTime() : dataset.updateTime();
+  }
+
+  private DatasetItem datasetItem(Dataset dataset) {
+    return new DatasetItem(
+        String.valueOf(dataset.id()),
+        defaultText(dataset.name(), "未命名数据集"),
+        dataset.description(),
+        dataset.status() == null ? "UNKNOWN" : dataset.status().name(),
+        toText(datasetUpdatedAt(dataset)));
+  }
+
+  private LineageOverview lineageOverview(LineageQueryService.Overview lineage) {
+    if (lineage == null) {
+      return new LineageOverview(null, null, null, null, List.of(), List.of(), List.of());
+    }
+
+    Map<Long, LineageAsset> assetsById = new LinkedHashMap<>();
+    for (LineageAsset asset : lineage.nodes()) {
+      if (asset != null) assetsById.put(asset.id(), asset);
+    }
+
+    List<LineageNode> nodes =
+        assetsById.values().stream()
+            .map(
+                asset ->
+                    new LineageNode(
+                        String.valueOf(asset.id()),
+                        assetName(asset),
+                        asset.assetType().name(),
+                        asset.sourceType()))
+            .toList();
+
+    List<LineageEdge> edges = new ArrayList<>();
+    List<LineageActivity> activities = new ArrayList<>();
+    for (LineageRelation relation : lineage.relations()) {
+      LineageAsset source = assetsById.get(relation.sourceAssetId());
+      LineageAsset target = assetsById.get(relation.targetAssetId());
+      if (source == null || target == null) continue;
+
+      String relationId = String.valueOf(relation.id());
+      String relationType = relation.relationType().name();
+      edges.add(
+          new LineageEdge(
+              relationId,
+              String.valueOf(source.id()),
+              String.valueOf(target.id()),
+              relationType));
+      if (activities.size() < LINEAGE_ACTIVITY_LIMIT) {
+        activities.add(
+            new LineageActivity(
+                relationId,
+                assetName(source),
+                assetName(target),
+                relationType,
+                toText(relationOccurredAt(relation))));
+      }
+    }
+
+    return new LineageOverview(
+        lineage.assetCount(),
+        lineage.relationCount(),
+        lineage.updatedAssetCount(),
+        lineage.datasetAssetCount(),
+        List.copyOf(nodes),
+        List.copyOf(edges),
+        List.copyOf(activities));
+  }
+
+  private Instant relationOccurredAt(LineageRelation relation) {
+    if (relation.updateTime() != null) return relation.updateTime();
+    if (relation.observedAt() != null) return relation.observedAt();
+    return relation.createTime();
+  }
+
+  private String assetName(LineageAsset asset) {
+    return firstText(
+        asset.name(),
+        asset.tableName(),
+        asset.columnName(),
+        asset.assetKey(),
+        "未命名资产");
+  }
+
+  private boolean inRange(Instant value, DayRange range) {
+    return value != null && !value.isBefore(range.start()) && value.isBefore(range.end());
+  }
+
+  private static String firstText(String... values) {
+    for (String value : values) {
+      if (value != null && !value.isBlank()) return value;
+    }
+    return "";
+  }
+
+  private static String defaultText(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private static String toText(Instant value) {
+    return value == null ? null : value.toString();
+  }
+
+  public record OverviewResponse(DatasetOverview dataset, LineageOverview lineage) {
+  }
+
+  public record DatasetOverview(
+      Long datasetCount,
+      Long tableAssetCount,
+      Long columnAssetCount,
+      Long todayCreatedCount,
+      List<DatasetItem> recentDatasets,
+      List<DatasetItem> onlineDatasets) {
+  }
+
+  public record DatasetItem(
+      String id,
+      String name,
+      String description,
+      String status,
+      String updatedAt) {
+  }
+
+  public record LineageOverview(
+      Long assetCount,
+      Long relationCount,
+      Long todayUpdatedCount,
+      Long datasetAssetCount,
+      List<LineageNode> nodes,
+      List<LineageEdge> edges,
+      List<LineageActivity> recentActivities) {
+  }
+
+  public record LineageNode(String id, String name, String assetType, String sourceType) {
+  }
+
+  public record LineageEdge(
+      String id, String sourceAssetId, String targetAssetId, String relationType) {
+  }
+
+  public record LineageActivity(
+      String id,
+      String sourceName,
+      String targetName,
+      String relationType,
+      String occurredAt) {
+  }
+
+  private record DayRange(Instant start, Instant end) {
+
+    static DayRange today() {
+      ZoneId zone = ZoneId.systemDefault();
+      LocalDate today = LocalDate.now(zone);
+      Instant start = today.atStartOfDay(zone).toInstant();
+      Instant end = today.plusDays(1).atStartOfDay(zone).toInstant();
+      return new DayRange(start, end);
+    }
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeAssetOverviewServiceTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeAssetOverviewServiceTest.java
@@ -1,0 +1,200 @@
+package io.yak.ops.boot.home;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.DatasetStatus;
+import io.yak.ops.business.dataset.DatasetService;
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
+import io.yak.ops.business.lineage.query.LineageQueryService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class HomeAssetOverviewServiceTest {
+
+  @Test
+  void shouldAggregateDatasetAndLineageOverviewFromPublicReadServices() {
+    DatasetService datasetService = mock(DatasetService.class);
+    LineageQueryService lineageQueryService = mock(LineageQueryService.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<DatasetService> datasetProvider = mock(ObjectProvider.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<LineageQueryService> lineageProvider = mock(ObjectProvider.class);
+    when(datasetProvider.getIfAvailable()).thenReturn(datasetService);
+    when(lineageProvider.getIfAvailable()).thenReturn(lineageQueryService);
+
+    ZoneId zone = ZoneId.systemDefault();
+    Instant todayStart = LocalDate.now(zone).atStartOfDay(zone).toInstant();
+    Instant recentTime = todayStart.plusSeconds(3_600);
+    when(datasetService.list())
+        .thenReturn(
+            List.of(
+                new Dataset(
+                    2L,
+                    "订单分析数据集",
+                    "订单主题分析",
+                    DatasetStatus.ONLINE,
+                    22L,
+                    recentTime,
+                    recentTime.plusSeconds(60)),
+                new Dataset(
+                    1L,
+                    "客户画像数据集",
+                    null,
+                    DatasetStatus.OFFLINE,
+                    11L,
+                    todayStart.minusSeconds(86_400),
+                    todayStart.minusSeconds(120))));
+
+    LineageAsset source = asset(11L, "ods_order", LineageAssetType.TABLE, recentTime);
+    LineageAsset target = asset(12L, "dwd_order_detail", LineageAssetType.TABLE, recentTime);
+    LineageRelation relation = relation(21L, source.id(), target.id(), recentTime);
+    when(lineageQueryService.overview(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.eq(6)))
+        .thenReturn(
+            new LineageQueryService.Overview(
+                42L,
+                9L,
+                5L,
+                8L,
+                20L,
+                3L,
+                List.of(source, target),
+                List.of(relation)));
+
+    HomeAssetOverviewService.OverviewResponse response =
+        new HomeAssetOverviewService(datasetProvider, lineageProvider).overview();
+
+    assertThat(response.dataset().datasetCount()).isEqualTo(2L);
+    assertThat(response.dataset().tableAssetCount()).isEqualTo(8L);
+    assertThat(response.dataset().columnAssetCount()).isEqualTo(20L);
+    assertThat(response.dataset().todayCreatedCount()).isEqualTo(1L);
+    assertThat(response.dataset().recentDatasets())
+        .extracting(HomeAssetOverviewService.DatasetItem::name)
+        .containsExactly("订单分析数据集", "客户画像数据集");
+    assertThat(response.dataset().onlineDatasets())
+        .extracting(HomeAssetOverviewService.DatasetItem::name)
+        .containsExactly("订单分析数据集");
+
+    assertThat(response.lineage().assetCount()).isEqualTo(42L);
+    assertThat(response.lineage().relationCount()).isEqualTo(9L);
+    assertThat(response.lineage().todayUpdatedCount()).isEqualTo(5L);
+    assertThat(response.lineage().datasetAssetCount()).isEqualTo(3L);
+    assertThat(response.lineage().nodes())
+        .extracting(HomeAssetOverviewService.LineageNode::name)
+        .containsExactly("ods_order", "dwd_order_detail");
+    assertThat(response.lineage().edges()).hasSize(1);
+    assertThat(response.lineage().recentActivities())
+        .singleElement()
+        .satisfies(
+            activity -> {
+              assertThat(activity.sourceName()).isEqualTo("ods_order");
+              assertThat(activity.targetName()).isEqualTo("dwd_order_detail");
+              assertThat(activity.relationType()).isEqualTo("DERIVES_FROM");
+            });
+  }
+
+  @Test
+  void shouldExposeUnavailableMetricsWithoutInventingZeroes() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<DatasetService> datasetProvider = mock(ObjectProvider.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<LineageQueryService> lineageProvider = mock(ObjectProvider.class);
+    when(datasetProvider.getIfAvailable()).thenReturn(null);
+    when(lineageProvider.getIfAvailable()).thenReturn(null);
+
+    HomeAssetOverviewService.OverviewResponse response =
+        new HomeAssetOverviewService(datasetProvider, lineageProvider).overview();
+
+    assertThat(response.dataset().datasetCount()).isNull();
+    assertThat(response.dataset().tableAssetCount()).isNull();
+    assertThat(response.dataset().columnAssetCount()).isNull();
+    assertThat(response.dataset().todayCreatedCount()).isNull();
+    assertThat(response.dataset().recentDatasets()).isEmpty();
+    assertThat(response.dataset().onlineDatasets()).isEmpty();
+    assertThat(response.lineage().assetCount()).isNull();
+    assertThat(response.lineage().relationCount()).isNull();
+    assertThat(response.lineage().todayUpdatedCount()).isNull();
+    assertThat(response.lineage().datasetAssetCount()).isNull();
+    assertThat(response.lineage().nodes()).isEmpty();
+    assertThat(response.lineage().edges()).isEmpty();
+    assertThat(response.lineage().recentActivities()).isEmpty();
+  }
+
+  @Test
+  void shouldKeepLineageAvailableWhenDatasetQueryFails() {
+    DatasetService datasetService = mock(DatasetService.class);
+    LineageQueryService lineageQueryService = mock(LineageQueryService.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<DatasetService> datasetProvider = mock(ObjectProvider.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<LineageQueryService> lineageProvider = mock(ObjectProvider.class);
+    when(datasetProvider.getIfAvailable()).thenReturn(datasetService);
+    when(lineageProvider.getIfAvailable()).thenReturn(lineageQueryService);
+    when(datasetService.list()).thenThrow(new IllegalStateException("dataset unavailable"));
+    when(lineageQueryService.overview(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.eq(6)))
+        .thenReturn(
+            new LineageQueryService.Overview(
+                1L, 0L, 0L, 1L, 0L, 0L, List.of(), List.of()));
+
+    HomeAssetOverviewService.OverviewResponse response =
+        new HomeAssetOverviewService(datasetProvider, lineageProvider).overview();
+
+    assertThat(response.dataset().datasetCount()).isNull();
+    assertThat(response.dataset().tableAssetCount()).isEqualTo(1L);
+    assertThat(response.lineage().assetCount()).isEqualTo(1L);
+  }
+
+  private LineageAsset asset(
+      long id, String name, LineageAssetType assetType, Instant updatedAt) {
+    return new LineageAsset(
+        id,
+        assetType.name().toLowerCase() + ":" + name,
+        assetType,
+        name,
+        "TEST",
+        String.valueOf(id),
+        null,
+        null,
+        null,
+        null,
+        assetType == LineageAssetType.TABLE ? name : null,
+        assetType == LineageAssetType.COLUMN ? name : null,
+        null,
+        updatedAt.minusSeconds(60),
+        updatedAt);
+  }
+
+  private LineageRelation relation(
+      long id, long sourceAssetId, long targetAssetId, Instant occurredAt) {
+    return new LineageRelation(
+        id,
+        sourceAssetId,
+        targetAssetId,
+        LineageRelationType.DERIVES_FROM,
+        "TEST",
+        "case",
+        null,
+        BigDecimal.ONE,
+        "v1",
+        occurredAt,
+        null,
+        occurredAt.minusSeconds(60),
+        occurredAt);
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-lineage/ARCHITECTURE.md
@@ -26,7 +26,8 @@ io.yak.ops.business.lineage
 ├── query
 │   ├── LineageQueryService
 │   ├── LineageAssetReader
-│   └── LineageGraphReader
+│   ├── LineageGraphReader
+│   └── LineageOverviewReader
 ├── registration
 │   ├── LineageRegistrationService
 │   ├── LineageAssetRegistrar
@@ -45,7 +46,7 @@ io.yak.ops.business.lineage
 
 ### Query
 
-`LineageQueryService` 只保留只读事务与稳定入口；`LineageAssetReader` 负责资产定位/搜索，`LineageGraphReader` 负责有界图遍历。
+`LineageQueryService` 只保留只读事务与稳定入口；`LineageAssetReader` 负责资产定位/搜索，`LineageGraphReader` 负责有界图遍历，`LineageOverviewReader` 负责首页等轻量消费者需要的数量统计和有界最近关系读取。
 
 ### Registration
 
@@ -93,7 +94,7 @@ role facade
     ↓
 role component
     ↓
-LineageRepository
+LineageRepository / LineageOverviewRepository
     ↓
 LineageRepositoryAdapter
     ↓
@@ -102,7 +103,7 @@ LineageDao
 Mapper / PO / DB
 ```
 
-Facade 和内部角色不直接访问 DAO、Mapper、PO 或 persistence config。RepositoryAdapter 是 Domain 与 Persistence 的转换位置。
+Facade 和内部角色不直接访问 DAO、Mapper、PO 或 persistence config。RepositoryAdapter 是 Domain 与 Persistence 的转换位置；`LineageOverviewRepository` 只承载轻量统计和最近关系投影，不成为跨模块 contract。
 
 ## Persistence Configuration Corridor
 

--- a/yak-ops-business/yak-ops-business-lineage/README.md
+++ b/yak-ops-business/yak-ops-business-lineage/README.md
@@ -32,7 +32,8 @@ HTTP / neighboring module
 ```text
 query/LineageQueryService
   ├── LineageAssetReader
-  └── LineageGraphReader
+  ├── LineageGraphReader
+  └── LineageOverviewReader
 
 registration/LineageRegistrationService
   ├── LineageAssetRegistrar

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/LineageDao.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/LineageDao.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.lineage.dao;
 
 import io.yak.ops.business.lineage.dao.model.LineageAssetPO;
 import io.yak.ops.business.lineage.dao.model.LineageRelationPO;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 
@@ -29,6 +30,14 @@ public interface LineageDao {
   LineageAssetPO selectAssetByKey(String assetKey);
 
   List<LineageAssetPO> selectAssets(AssetSearch query);
+
+  long countAssets(String assetType);
+
+  long countAssetsUpdatedBetween(Timestamp start, Timestamp end);
+
+  long countRelations();
+
+  List<LineageRelationPO> selectRecentRelations(int limit);
 
   List<LineageAssetPO> selectAssetsByIds(Set<Long> assetIds);
 

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.lineage.dao.mapper.LineageRelationMapper;
 import io.yak.ops.business.lineage.dao.mapper.LineageWriteMapper;
 import io.yak.ops.business.lineage.dao.model.LineageAssetPO;
 import io.yak.ops.business.lineage.dao.model.LineageRelationPO;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -109,15 +110,52 @@ public class LineageDaoImpl implements LineageDao {
         Wrappers.<LineageAssetPO>lambdaQuery()
             .and(
                 StringUtils.hasText(condition.keyword()),
-                nested -> nested.like(LineageAssetPO::getName, condition.keyword())
-                    .or().like(LineageAssetPO::getAssetKey, condition.keyword())
-                    .or().like(LineageAssetPO::getTableName, condition.keyword())
-                    .or().like(LineageAssetPO::getColumnName, condition.keyword()))
-            .eq(StringUtils.hasText(condition.assetType()),
-                LineageAssetPO::getAssetType, condition.assetType())
+                nested ->
+                    nested
+                        .like(LineageAssetPO::getName, condition.keyword())
+                        .or()
+                        .like(LineageAssetPO::getAssetKey, condition.keyword())
+                        .or()
+                        .like(LineageAssetPO::getTableName, condition.keyword())
+                        .or()
+                        .like(LineageAssetPO::getColumnName, condition.keyword()))
+            .eq(
+                StringUtils.hasText(condition.assetType()),
+                LineageAssetPO::getAssetType,
+                condition.assetType())
             .orderByDesc(LineageAssetPO::getUpdateTime)
             .orderByDesc(LineageAssetPO::getId)
             .last("LIMIT " + Math.max(1, condition.limit())));
+  }
+
+  @Override
+  public long countAssets(String assetType) {
+    return assetMapper.selectCount(
+        Wrappers.<LineageAssetPO>lambdaQuery()
+            .eq(StringUtils.hasText(assetType), LineageAssetPO::getAssetType, assetType));
+  }
+
+  @Override
+  public long countAssetsUpdatedBetween(Timestamp start, Timestamp end) {
+    return assetMapper.selectCount(
+        Wrappers.<LineageAssetPO>lambdaQuery()
+            .ge(LineageAssetPO::getUpdateTime, start)
+            .lt(LineageAssetPO::getUpdateTime, end));
+  }
+
+  @Override
+  public long countRelations() {
+    return relationMapper.selectCount(null);
+  }
+
+  @Override
+  public List<LineageRelationPO> selectRecentRelations(int limit) {
+    return relationMapper.selectList(
+        Wrappers.<LineageRelationPO>lambdaQuery()
+            .orderByDesc(LineageRelationPO::getUpdateTime)
+            .orderByDesc(LineageRelationPO::getObservedAt)
+            .orderByDesc(LineageRelationPO::getId)
+            .last("LIMIT " + Math.max(1, limit)));
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/query/LineageOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/query/LineageOverviewReader.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.lineage.query;
+
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.repository.LineageOverviewRepository;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/** Builds bounded aggregate data for lightweight lineage overview consumers. */
+@Component
+public class LineageOverviewReader {
+
+  static final int MAX_RELATION_LIMIT = 20;
+
+  private final LineageOverviewRepository repository;
+
+  public LineageOverviewReader(LineageOverviewRepository repository) {
+    this.repository = repository;
+  }
+
+  public LineageQueryService.Overview overview(
+      Instant updatedFrom, Instant updatedTo, int relationLimit) {
+    if (updatedFrom == null || updatedTo == null || !updatedFrom.isBefore(updatedTo)) {
+      throw new IllegalArgumentException("血缘更新时间范围无效");
+    }
+    if (relationLimit < 1 || relationLimit > MAX_RELATION_LIMIT) {
+      throw new IllegalArgumentException(
+          "relationLimit 必须在 1 到 " + MAX_RELATION_LIMIT + " 之间");
+    }
+
+    List<LineageRelation> relations = repository.findRecentRelations(relationLimit);
+    Set<Long> endpointIds = new LinkedHashSet<>();
+    for (LineageRelation relation : relations) {
+      endpointIds.add(relation.sourceAssetId());
+      endpointIds.add(relation.targetAssetId());
+    }
+    List<LineageAsset> nodes = repository.findAssetsByIds(endpointIds);
+
+    return new LineageQueryService.Overview(
+        repository.countAssets(null),
+        repository.countRelations(),
+        repository.countAssetsUpdatedBetween(updatedFrom, updatedTo),
+        repository.countAssets(LineageAssetType.TABLE),
+        repository.countAssets(LineageAssetType.COLUMN),
+        repository.countAssets(LineageAssetType.DATASET),
+        nodes,
+        relations);
+  }
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/query/LineageQueryService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/query/LineageQueryService.java
@@ -4,7 +4,10 @@ import io.yak.ops.business.lineage.domain.LineageAsset;
 import io.yak.ops.business.lineage.domain.LineageAssetType;
 import io.yak.ops.business.lineage.domain.LineageDirection;
 import io.yak.ops.business.lineage.domain.LineageGraph;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,14 +18,30 @@ public class LineageQueryService {
   public static final int MAX_GRAPH_DEPTH = LineageGraphReader.MAX_GRAPH_DEPTH;
   public static final int MAX_ASSET_SEARCH_LIMIT =
       LineageAssetReader.MAX_ASSET_SEARCH_LIMIT;
+  public static final int MAX_OVERVIEW_RELATION_LIMIT =
+      LineageOverviewReader.MAX_RELATION_LIMIT;
 
   private final LineageAssetReader assetReader;
   private final LineageGraphReader graphReader;
+  private final LineageOverviewReader overviewReader;
 
+  /**
+   * Compatibility constructor for direct unit construction that does not use overview queries.
+   * Spring uses the role-complete constructor below.
+   */
   public LineageQueryService(
       LineageAssetReader assetReader, LineageGraphReader graphReader) {
+    this(assetReader, graphReader, null);
+  }
+
+  @Autowired
+  public LineageQueryService(
+      LineageAssetReader assetReader,
+      LineageGraphReader graphReader,
+      LineageOverviewReader overviewReader) {
     this.assetReader = assetReader;
     this.graphReader = graphReader;
+    this.overviewReader = overviewReader;
   }
 
   @Transactional(value = "yakBusinessTransactionManager", readOnly = true)
@@ -46,6 +65,14 @@ public class LineageQueryService {
   }
 
   @Transactional(value = "yakBusinessTransactionManager", readOnly = true)
+  public Overview overview(Instant updatedFrom, Instant updatedTo, int relationLimit) {
+    if (overviewReader == null) {
+      throw new IllegalStateException("LineageOverviewReader 未装配");
+    }
+    return overviewReader.overview(updatedFrom, updatedTo, relationLimit);
+  }
+
+  @Transactional(value = "yakBusinessTransactionManager", readOnly = true)
   public LineageGraph upstream(long assetId, int depth) {
     return graphReader.graph(assetId, LineageDirection.UPSTREAM, depth);
   }
@@ -58,5 +85,16 @@ public class LineageQueryService {
   @Transactional(value = "yakBusinessTransactionManager", readOnly = true)
   public LineageGraph graph(long assetId, LineageDirection direction, int depth) {
     return graphReader.graph(assetId, direction, depth);
+  }
+
+  public record Overview(
+      long assetCount,
+      long relationCount,
+      long updatedAssetCount,
+      long tableAssetCount,
+      long columnAssetCount,
+      long datasetAssetCount,
+      List<LineageAsset> nodes,
+      List<LineageRelation> relations) {
   }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageOverviewRepository.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageOverviewRepository.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.lineage.repository;
+
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+/** Read projection contract used by the bounded lineage overview. */
+public interface LineageOverviewRepository {
+
+  long countAssets(LineageAssetType assetType);
+
+  long countAssetsUpdatedBetween(Instant start, Instant end);
+
+  long countRelations();
+
+  List<LineageRelation> findRecentRelations(int limit);
+
+  List<LineageAsset> findAssetsByIds(Set<Long> assetIds);
+}

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.lineage.domain.LineageRelationDraft;
 import io.yak.ops.business.lineage.domain.LineageRelationType;
 import io.yak.ops.business.lineage.repository.support.LineageJsonCodec;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +23,8 @@ import org.springframework.stereotype.Repository;
 /** Persistence adapter translating lineage domain models to database rows. */
 @Repository
 @RequiredArgsConstructor
-public class LineageRepositoryAdapter implements LineageRepository {
+public class LineageRepositoryAdapter
+    implements LineageRepository, LineageOverviewRepository {
 
   private final LineageDao lineageDao;
   private final LineageJsonCodec jsonCodec;
@@ -100,6 +102,26 @@ public class LineageRepositoryAdapter implements LineageRepository {
     return lineageDao.selectAssets(new LineageDao.AssetSearch(keyword, type, limit)).stream()
         .map(this::toAsset)
         .toList();
+  }
+
+  @Override
+  public long countAssets(LineageAssetType assetType) {
+    return lineageDao.countAssets(assetType == null ? null : assetType.name());
+  }
+
+  @Override
+  public long countAssetsUpdatedBetween(Instant start, Instant end) {
+    return lineageDao.countAssetsUpdatedBetween(Timestamp.from(start), Timestamp.from(end));
+  }
+
+  @Override
+  public long countRelations() {
+    return lineageDao.countRelations();
+  }
+
+  @Override
+  public List<LineageRelation> findRecentRelations(int limit) {
+    return lineageDao.selectRecentRelations(limit).stream().map(this::toRelation).toList();
   }
 
   @Override
@@ -185,7 +207,7 @@ public class LineageRepositoryAdapter implements LineageRepository {
         instant(row.getUpdateTime()));
   }
 
-  private static java.time.Instant instant(Timestamp value) {
+  private static Instant instant(Timestamp value) {
     return value == null ? null : value.toInstant();
   }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/query/LineageOverviewReaderTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/query/LineageOverviewReaderTest.java
@@ -1,0 +1,145 @@
+package io.yak.ops.business.lineage.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelation;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
+import io.yak.ops.business.lineage.repository.LineageOverviewRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class LineageOverviewReaderTest {
+
+  @Test
+  void summarizesCountsAndKeepsRecentRelationsBounded() {
+    Instant now = Instant.parse("2026-08-26T02:00:00Z");
+    LineageAsset table = asset(1L, "ods_order", LineageAssetType.TABLE, now);
+    LineageAsset column = asset(2L, "order_id", LineageAssetType.COLUMN, now);
+    LineageAsset dataset = asset(3L, "订单数据集", LineageAssetType.DATASET, now);
+    LineageRelation first = relation(11L, table.id(), dataset.id(), now.minusSeconds(60));
+    LineageRelation second = relation(12L, column.id(), dataset.id(), now);
+    FakeOverviewRepository repository =
+        new FakeOverviewRepository(List.of(table, column, dataset), List.of(first, second));
+
+    LineageOverviewReader reader = new LineageOverviewReader(repository);
+    LineageQueryService.Overview overview =
+        reader.overview(
+            Instant.parse("2026-08-26T00:00:00Z"),
+            Instant.parse("2026-08-27T00:00:00Z"),
+            1);
+
+    assertEquals(3L, overview.assetCount());
+    assertEquals(2L, overview.relationCount());
+    assertEquals(3L, overview.updatedAssetCount());
+    assertEquals(1L, overview.tableAssetCount());
+    assertEquals(1L, overview.columnAssetCount());
+    assertEquals(1L, overview.datasetAssetCount());
+    assertEquals(1, overview.relations().size());
+    assertEquals(12L, overview.relations().get(0).id());
+    assertEquals(Set.of(2L, 3L), overview.nodes().stream().map(LineageAsset::id).collect(java.util.stream.Collectors.toSet()));
+  }
+
+  @Test
+  void rejectsInvalidOverviewWindowAndLimit() {
+    LineageOverviewReader reader =
+        new LineageOverviewReader(new FakeOverviewRepository(List.of(), List.of()));
+    Instant point = Instant.parse("2026-08-26T00:00:00Z");
+
+    assertThrows(IllegalArgumentException.class, () -> reader.overview(point, point, 1));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> reader.overview(point, point.plusSeconds(60), 0));
+  }
+
+  private static LineageAsset asset(
+      long id, String name, LineageAssetType type, Instant updatedAt) {
+    return new LineageAsset(
+        id,
+        type.name().toLowerCase() + ":" + id,
+        type,
+        name,
+        "TEST",
+        String.valueOf(id),
+        null,
+        null,
+        null,
+        null,
+        type == LineageAssetType.TABLE ? name : null,
+        type == LineageAssetType.COLUMN ? name : null,
+        null,
+        updatedAt.minusSeconds(60),
+        updatedAt);
+  }
+
+  private static LineageRelation relation(
+      long id, long sourceAssetId, long targetAssetId, Instant updatedAt) {
+    return new LineageRelation(
+        id,
+        sourceAssetId,
+        targetAssetId,
+        LineageRelationType.DERIVES_FROM,
+        "TEST",
+        "case",
+        null,
+        BigDecimal.ONE,
+        "v1",
+        updatedAt,
+        null,
+        updatedAt.minusSeconds(60),
+        updatedAt);
+  }
+
+  private static final class FakeOverviewRepository implements LineageOverviewRepository {
+    private final List<LineageAsset> assets;
+    private final List<LineageRelation> relations;
+
+    private FakeOverviewRepository(
+        List<LineageAsset> assets, List<LineageRelation> relations) {
+      this.assets = assets;
+      this.relations = relations;
+    }
+
+    @Override
+    public long countAssets(LineageAssetType assetType) {
+      return assets.stream()
+          .filter(asset -> assetType == null || asset.assetType() == assetType)
+          .count();
+    }
+
+    @Override
+    public long countAssetsUpdatedBetween(Instant start, Instant end) {
+      return assets.stream()
+          .filter(asset -> asset.updateTime() != null)
+          .filter(asset -> !asset.updateTime().isBefore(start) && asset.updateTime().isBefore(end))
+          .count();
+    }
+
+    @Override
+    public long countRelations() {
+      return relations.size();
+    }
+
+    @Override
+    public List<LineageRelation> findRecentRelations(int limit) {
+      return relations.stream()
+          .sorted(
+              Comparator.comparing(LineageRelation::updateTime)
+                  .reversed()
+                  .thenComparing(LineageRelation::id, Comparator.reverseOrder()))
+          .limit(limit)
+          .toList();
+    }
+
+    @Override
+    public List<LineageAsset> findAssetsByIds(Set<Long> assetIds) {
+      return assets.stream().filter(asset -> assetIds.contains(asset.id())).toList();
+    }
+  }
+}

--- a/yak-ops-ui/src/pages/home/HomeAssetOverview.tsx
+++ b/yak-ops-ui/src/pages/home/HomeAssetOverview.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+import type { HomeAssetOverviewState } from './homeAssetOverviewShared';
+import { homeAssetOverviewApi } from './service';
+
+export type { HomeAssetOverviewState } from './homeAssetOverviewShared';
+export { DatasetOverview } from './HomeDatasetOverview';
+export { DataLineageOverview } from './HomeLineageOverview';
+
+export function useHomeAssetOverview(): HomeAssetOverviewState {
+  const [state, setState] = useState<HomeAssetOverviewState>({
+    loading: true,
+    failed: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+    homeAssetOverviewApi
+      .overview()
+      .then((response) => {
+        if (!active) return;
+        if (!response.data) {
+          setState({ loading: false, failed: true });
+          return;
+        }
+        setState({ data: response.data, loading: false, failed: false });
+      })
+      .catch(() => {
+        if (active) setState({ loading: false, failed: true });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/yak-ops-ui/src/pages/home/HomeDatasetOverview.tsx
+++ b/yak-ops-ui/src/pages/home/HomeDatasetOverview.tsx
@@ -1,0 +1,228 @@
+import { history } from '@umijs/max';
+import { Boxes, ChevronRight, Database, Table2 } from 'lucide-react';
+
+import {
+  EmptyList,
+  formatMetric,
+  type HomeAssetOverviewState,
+  relativeTime,
+  SectionHeader,
+} from './homeAssetOverviewShared';
+import type { HomeAssetDatasetItem } from './service';
+
+const datasetStatusLabel = (status?: string) => {
+  if (status?.toUpperCase() === 'ONLINE') return '已上线';
+  if (status?.toUpperCase() === 'OFFLINE') return '已下线';
+  return status || '状态未知';
+};
+
+function AssetOverviewColumn({ state }: { state: HomeAssetOverviewState }) {
+  const dataset = state.data?.dataset;
+  const metrics = [
+    {
+      label: '数据集',
+      value: dataset?.datasetCount,
+      icon: <Database size={17} strokeWidth={1.8} />,
+    },
+    {
+      label: '血缘表',
+      value: dataset?.tableAssetCount,
+      icon: <Table2 size={17} strokeWidth={1.8} />,
+    },
+    {
+      label: '血缘字段',
+      value: dataset?.columnAssetCount,
+      icon: <Boxes size={17} strokeWidth={1.8} />,
+    },
+  ];
+
+  return (
+    <div className="min-w-0 lg:pr-6">
+      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
+        <strong className="text-[13px] font-semibold text-[#343842]">
+          数据概览
+        </strong>
+        <span className="text-[11px] text-[#9da1a9]">已纳入血缘</span>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        {metrics.map((item) => (
+          <button
+            key={item.label}
+            type="button"
+            onClick={() => history.push('/data-analysis/data-catalog')}
+            className="group flex w-full items-center gap-3 border-0 bg-transparent p-0 text-left"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#f2f5ff] text-[#637be7] transition-colors group-hover:bg-[#eaf0ff]">
+              {item.icon}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-[11px] leading-5 text-[#92969f]">
+                {item.label}
+              </span>
+              <strong className="mt-0.5 block text-[22px] font-semibold leading-7 tracking-[-0.6px] text-[#2f333c]">
+                {formatMetric(item.value)}
+              </strong>
+            </span>
+            <ChevronRight
+              size={14}
+              strokeWidth={1.8}
+              className="text-[#c1c4ca] opacity-0 transition-all group-hover:translate-x-0.5 group-hover:opacity-100"
+            />
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-5 rounded-[10px] bg-[#f7f8fa] px-3 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] text-[#8e939c]">今日新增</span>
+          <span className="text-[10px] text-[#a0a4ac]">
+            {state.failed ? '加载失败' : '实时统计'}
+          </span>
+        </div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <strong className="text-[18px] font-semibold text-[#343842]">
+            {formatMetric(dataset?.todayCreatedCount)}
+          </strong>
+          <span className="text-[10px] text-[#a0a4ac]">个数据集</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DatasetRow({ item }: { item: HomeAssetDatasetItem }) {
+  return (
+    <button
+      type="button"
+      onClick={() => history.push('/data-analysis/data-catalog')}
+      className="group flex w-full items-center gap-3 rounded-[8px] border-0 bg-transparent px-1 py-[11px] text-left transition-colors hover:bg-[#f7f8fa]"
+    >
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#f1f4f8] text-[#69717e]">
+        <Table2 size={15} strokeWidth={1.8} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <strong className="block truncate text-[12px] font-medium leading-5 text-[#3d414a]">
+          {item.name}
+        </strong>
+        <span className="mt-0.5 block truncate text-[10px] leading-4 text-[#9ca0a8]">
+          {datasetStatusLabel(item.status)} · #{item.id}
+        </span>
+      </span>
+      <span className="shrink-0 text-[10px] text-[#a0a4ac]">
+        {relativeTime(item.updatedAt)}
+      </span>
+    </button>
+  );
+}
+
+function RecentDatasetColumn({ state }: { state: HomeAssetOverviewState }) {
+  const items = state.data?.dataset?.recentDatasets || [];
+  return (
+    <div className="min-w-0 border-t border-[#eef0f3] py-5 lg:border-l lg:border-t-0 lg:px-6 lg:py-0">
+      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
+        <strong className="text-[13px] font-semibold text-[#343842]">
+          最近更新
+        </strong>
+        <span className="text-[11px] text-[#9da1a9]">按更新时间</span>
+      </div>
+
+      {items.length > 0 ? (
+        <div className="mt-1">
+          {items.map((item) => (
+            <DatasetRow key={item.id} item={item} />
+          ))}
+        </div>
+      ) : (
+        <EmptyList
+          loading={state.loading}
+          failed={state.failed}
+          unavailable={state.data?.dataset?.datasetCount == null}
+          text="暂无数据集"
+        />
+      )}
+    </div>
+  );
+}
+
+function OnlineDatasetColumn({ state }: { state: HomeAssetOverviewState }) {
+  const items = state.data?.dataset?.onlineDatasets || [];
+  return (
+    <div className="min-w-0 border-t border-[#eef0f3] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
+      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
+        <strong className="text-[13px] font-semibold text-[#343842]">
+          已上线数据集
+        </strong>
+        <span className="text-[11px] text-[#9da1a9]">按更新时间</span>
+      </div>
+
+      {items.length > 0 ? (
+        <div className="mt-1">
+          {items.map((item, index) => {
+            const rankClassName =
+              index === 0
+                ? 'bg-[#ff4d68]'
+                : index === 1
+                  ? 'bg-[#ff8c31]'
+                  : index === 2
+                    ? 'bg-[#e9b919]'
+                    : 'bg-[#999da5]';
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => history.push('/data-analysis/data-catalog')}
+                className="group flex w-full items-center gap-3 rounded-[8px] border-0 bg-transparent px-1 py-[11px] text-left transition-colors hover:bg-[#f7f8fa]"
+              >
+                <span
+                  className={`flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] text-[10px] font-semibold text-white ${rankClassName}`}
+                >
+                  {index + 1}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[12px] text-[#454952]">
+                  {item.name}
+                </span>
+                <span className="shrink-0 text-[10px] text-[#999da5]">
+                  {relativeTime(item.updatedAt)}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <EmptyList
+          loading={state.loading}
+          failed={state.failed}
+          unavailable={state.data?.dataset?.datasetCount == null}
+          text="暂无上线数据集"
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={() => history.push('/data-analysis/data-catalog')}
+        className="mx-auto mt-3 flex items-center gap-0.5 border-0 bg-transparent px-3 py-1 text-[11px] text-[#868b94] transition-colors hover:text-[#343842]"
+      >
+        查看全部
+        <ChevronRight size={12} strokeWidth={1.8} />
+      </button>
+    </div>
+  );
+}
+
+export function DatasetOverview({ state }: { state: HomeAssetOverviewState }) {
+  return (
+    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-6 pt-5">
+      <SectionHeader
+        title="数据集"
+        description="统一查看数据集，以及已纳入血缘的表和字段规模"
+        onMore={() => history.push('/data-analysis/data-catalog')}
+      />
+      <div className="mt-5 grid grid-cols-1 lg:grid-cols-[0.76fr_1.15fr_1fr]">
+        <AssetOverviewColumn state={state} />
+        <RecentDatasetColumn state={state} />
+        <OnlineDatasetColumn state={state} />
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/HomeLineageOverview.tsx
+++ b/yak-ops-ui/src/pages/home/HomeLineageOverview.tsx
@@ -1,0 +1,209 @@
+import { history } from '@umijs/max';
+import type { EChartsOption } from 'echarts';
+import ReactECharts from 'echarts-for-react';
+import { Activity, GitBranch } from 'lucide-react';
+import { useMemo } from 'react';
+
+import {
+  assetTypeColor,
+  compactName,
+  formatMetric,
+  type HomeAssetOverviewState,
+  relativeTime,
+  relationTypeLabel,
+  SectionHeader,
+} from './homeAssetOverviewShared';
+import type { HomeLineageActivity } from './service';
+
+function buildLineageGraphOption(
+  state: HomeAssetOverviewState,
+): EChartsOption {
+  const nodes = state.data?.lineage?.nodes || [];
+  const edges = state.data?.lineage?.edges || [];
+  return {
+    animationDuration: 520,
+    animationDurationUpdate: 420,
+    tooltip: {
+      trigger: 'item',
+    },
+    series: [
+      {
+        type: 'graph',
+        layout: 'force',
+        roam: false,
+        draggable: false,
+        data: nodes.map((node) => ({
+          id: node.id,
+          name: compactName(node.name),
+          value: node.assetType,
+          symbolSize: node.assetType === 'COLUMN' ? 28 : 36,
+          itemStyle: {
+            color: assetTypeColor(node.assetType),
+            borderColor: '#ffffff',
+            borderWidth: 2,
+            shadowBlur: 8,
+            shadowColor: 'rgba(31,35,41,0.10)',
+          },
+          label: {
+            show: true,
+            position: 'bottom',
+            color: '#5f646e',
+            fontSize: 9,
+            distance: 5,
+          },
+        })),
+        links: edges.map((edge) => ({
+          id: edge.id,
+          source: edge.sourceAssetId,
+          target: edge.targetAssetId,
+          value: relationTypeLabel(edge.relationType),
+        })),
+        force: {
+          repulsion: 150,
+          edgeLength: [70, 120],
+          gravity: 0.08,
+        },
+        edgeSymbol: ['none', 'arrow'],
+        edgeSymbolSize: 6,
+        lineStyle: {
+          color: '#cbd2dc',
+          width: 1.4,
+          curveness: 0.08,
+        },
+        emphasis: {
+          focus: 'adjacency',
+        },
+      },
+    ],
+  };
+}
+
+function LineagePreview({ state }: { state: HomeAssetOverviewState }) {
+  const graphOption = useMemo(() => buildLineageGraphOption(state), [state]);
+  const hasGraph = (state.data?.lineage?.nodes.length || 0) > 0;
+  const unavailable = state.data?.lineage?.assetCount == null;
+
+  return (
+    <div className="relative h-[276px] overflow-hidden rounded-[14px] border border-[#eef0f3] bg-[#fafbfc]">
+      <div className="absolute inset-0 opacity-[0.5] [background-image:radial-gradient(circle,#dfe2e7_0.7px,transparent_0.8px)] [background-size:12px_12px]" />
+      {hasGraph ? (
+        <ReactECharts
+          option={graphOption}
+          style={{ width: '100%', height: '276px' }}
+        />
+      ) : (
+        <div className="relative flex h-full flex-col items-center justify-center text-[#a0a4ac]">
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-[#8b93a0] shadow-sm">
+            <GitBranch size={18} strokeWidth={1.7} />
+          </span>
+          <span className="mt-3 text-[11px]">
+            {state.loading
+              ? '血缘加载中...'
+              : state.failed
+                ? '血缘数据加载失败'
+                : unavailable
+                  ? '血缘数据暂不可用'
+                  : '暂无血缘关系'}
+          </span>
+        </div>
+      )}
+      <div className="absolute bottom-3 left-3 rounded-full border border-[#e6e8ec] bg-white/90 px-2.5 py-1 text-[9px] text-[#999da5] shadow-sm backdrop-blur">
+        最近血缘关系
+      </div>
+    </div>
+  );
+}
+
+function LineageMetric({
+  label,
+  value,
+}: {
+  label: string;
+  value?: number | null;
+}) {
+  return (
+    <div>
+      <div className="text-[10px] text-[#989ca4]">{label}</div>
+      <strong className="mt-1 block text-[20px] font-semibold text-[#3c4049]">
+        {formatMetric(value)}
+      </strong>
+    </div>
+  );
+}
+
+function LineageUpdate({ item }: { item: HomeLineageActivity }) {
+  return (
+    <button
+      type="button"
+      onClick={() => history.push('/data-analysis/lineage')}
+      className="group flex w-full items-center gap-2 border-0 bg-transparent p-0 text-left"
+    >
+      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#8394e8]" />
+      <span className="min-w-0 flex-1">
+        <strong className="block truncate text-[11px] font-medium text-[#555a64]">
+          {item.sourceName} → {item.targetName}
+        </strong>
+        <span className="mt-0.5 block text-[9px] text-[#a1a5ad]">
+          {relationTypeLabel(item.relationType)}
+        </span>
+      </span>
+      <span className="shrink-0 text-[9px] text-[#a1a5ad]">
+        {relativeTime(item.occurredAt)}
+      </span>
+    </button>
+  );
+}
+
+export function DataLineageOverview({
+  state,
+}: {
+  state: HomeAssetOverviewState;
+}) {
+  const lineage = state.data?.lineage;
+  const activities = lineage?.recentActivities || [];
+  return (
+    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <SectionHeader
+        title="数据血缘"
+        description="观察最近血缘关系与资产规模"
+        onMore={() => history.push('/data-analysis/lineage')}
+      />
+
+      <div className="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_220px]">
+        <LineagePreview state={state} />
+        <div className="flex flex-col">
+          <div className="grid grid-cols-2 gap-x-5 gap-y-5">
+            <LineageMetric label="数据节点" value={lineage?.assetCount} />
+            <LineageMetric label="血缘关系" value={lineage?.relationCount} />
+            <LineageMetric label="今日更新" value={lineage?.todayUpdatedCount} />
+            <LineageMetric label="数据集节点" value={lineage?.datasetAssetCount} />
+          </div>
+
+          <div className="mt-6 border-t border-[#eef0f3] pt-4">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium text-[#525761]">
+              <Activity size={13} strokeWidth={1.8} />
+              最近关系
+            </div>
+            {activities.length > 0 ? (
+              <div className="mt-3 space-y-3">
+                {activities.map((item) => (
+                  <LineageUpdate key={item.id} item={item} />
+                ))}
+              </div>
+            ) : (
+              <div className="flex min-h-[118px] items-center justify-center text-[10px] text-[#a0a4ac]">
+                {state.loading
+                  ? '数据加载中...'
+                  : state.failed
+                    ? '数据加载失败'
+                    : lineage?.assetCount == null
+                      ? '数据暂不可用'
+                      : '暂无最近关系'}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
@@ -2,29 +2,25 @@ import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
 import ReactECharts from 'echarts-for-react';
 import {
-  Activity,
   AlertTriangle,
-  BarChart3,
-  Boxes,
   CheckCircle2,
   ChevronRight,
   Clock3,
-  Cloud,
-  Database,
-  GitBranch,
   LayoutDashboard,
-  Monitor,
-  ShieldCheck,
   Sparkles,
-  Table2,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
+
+import {
+  DataLineageOverview,
+  DatasetOverview,
+  useHomeAssetOverview,
+} from './HomeAssetOverview';
 
 /**
  * 首页业务总览。
  *
- * 当前阶段只确定布局与信息表达方式，数据均为前端 mock。
- * 后续接口落地后，再逐块替换为真实数据。
+ * 数据集与血缘已接入真实统计；其他模块仍按后续阶段逐步替换 mock。
  */
 
 interface SectionHeaderProps {
@@ -63,279 +59,6 @@ function SectionHeader({
         </button>
       ) : null}
     </header>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* 数据集                                                                     */
-/* -------------------------------------------------------------------------- */
-
-const assetOverview = [
-  {
-    label: '数据集',
-    value: '86',
-    icon: <Database size={17} strokeWidth={1.8} />,
-  },
-  {
-    label: '数据表',
-    value: '326',
-    icon: <Table2 size={17} strokeWidth={1.8} />,
-  },
-  {
-    label: '字段',
-    value: '8,239',
-    icon: <Boxes size={17} strokeWidth={1.8} />,
-  },
-];
-
-const recentDatasets = [
-  {
-    name: '用户订单主题数据集',
-    table: 'dws_user_order',
-    time: '12 分钟前',
-  },
-  {
-    name: '商品销售分析数据集',
-    table: 'ads_goods_sale',
-    time: '36 分钟前',
-  },
-  {
-    name: '客户画像主题数据集',
-    table: 'dws_customer_profile',
-    time: '1 小时前',
-  },
-  {
-    name: '订单履约明细数据集',
-    table: 'dwd_order_fulfillment',
-    time: '3 小时前',
-  },
-  {
-    name: '渠道经营分析数据集',
-    table: 'ads_channel_analysis',
-    time: '昨天 18:24',
-  },
-];
-
-const hotDatasets = [
-  {
-    rank: 1,
-    name: '用户订单主题数据集',
-    count: '3,286',
-  },
-  {
-    rank: 2,
-    name: '销售经营分析数据集',
-    count: '2,764',
-  },
-  {
-    rank: 3,
-    name: '客户画像主题数据集',
-    count: '1,932',
-  },
-  {
-    rank: 4,
-    name: '商品库存分析数据集',
-    count: '1,486',
-  },
-  {
-    rank: 5,
-    name: '渠道转化分析数据集',
-    count: '1,125',
-  },
-];
-
-function AssetOverviewColumn() {
-  return (
-    <div className="min-w-0 lg:pr-6">
-      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
-        <strong className="text-[13px] font-semibold text-[#343842]">
-          数据概览
-        </strong>
-
-        <span className="text-[11px] text-[#9da1a9]">
-          数据资产
-        </span>
-      </div>
-
-      <div className="mt-4 space-y-4">
-        {assetOverview.map((item) => (
-          <button
-            key={item.label}
-            type="button"
-            onClick={() => history.push('/data-analysis/data-catalog')}
-            className="group flex w-full items-center gap-3 border-0 bg-transparent p-0 text-left"
-          >
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#f2f5ff] text-[#637be7] transition-colors group-hover:bg-[#eaf0ff]">
-              {item.icon}
-            </span>
-
-            <span className="min-w-0 flex-1">
-              <span className="block text-[11px] leading-5 text-[#92969f]">
-                {item.label}
-              </span>
-
-              <strong className="mt-0.5 block text-[22px] font-semibold leading-7 tracking-[-0.6px] text-[#2f333c]">
-                {item.value}
-              </strong>
-            </span>
-
-            <ChevronRight
-              size={14}
-              strokeWidth={1.8}
-              className="text-[#c1c4ca] opacity-0 transition-all group-hover:translate-x-0.5 group-hover:opacity-100"
-            />
-          </button>
-        ))}
-      </div>
-
-      <div className="mt-5 rounded-[10px] bg-[#f7f8fa] px-3 py-3">
-        <div className="flex items-center justify-between">
-          <span className="text-[11px] text-[#8e939c]">
-            今日新增
-          </span>
-
-          <span className="text-[11px] font-medium text-[#4f8b69]">
-            +12.6%
-          </span>
-        </div>
-
-        <div className="mt-1 flex items-baseline gap-2">
-          <strong className="text-[18px] font-semibold text-[#343842]">
-            7
-          </strong>
-          <span className="text-[10px] text-[#a0a4ac]">
-            个数据资产
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function RecentDatasetColumn() {
-  return (
-    <div className="min-w-0 border-t border-[#eef0f3] py-5 lg:border-l lg:border-t-0 lg:px-6 lg:py-0">
-      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
-        <strong className="text-[13px] font-semibold text-[#343842]">
-          最近更新
-        </strong>
-
-        <span className="text-[11px] text-[#9da1a9]">
-          近 24 小时
-        </span>
-      </div>
-
-      <div className="mt-1">
-        {recentDatasets.map((item) => (
-          <button
-            key={item.table}
-            type="button"
-            onClick={() => history.push('/data-analysis/data-catalog')}
-            className="group flex w-full items-center gap-3 rounded-[8px] border-0 bg-transparent px-1 py-[11px] text-left transition-colors hover:bg-[#f7f8fa]"
-          >
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#f1f4f8] text-[#69717e]">
-              <Table2 size={15} strokeWidth={1.8} />
-            </span>
-
-            <span className="min-w-0 flex-1">
-              <strong className="block truncate text-[12px] font-medium leading-5 text-[#3d414a]">
-                {item.name}
-              </strong>
-
-              <span className="mt-0.5 block truncate text-[10px] leading-4 text-[#9ca0a8]">
-                {item.table}
-              </span>
-            </span>
-
-            <span className="shrink-0 text-[10px] text-[#a0a4ac]">
-              {item.time}
-            </span>
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function HotDatasetColumn() {
-  return (
-    <div className="min-w-0 border-t border-[#eef0f3] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
-      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
-        <strong className="text-[13px] font-semibold text-[#343842]">
-          热门数据集
-        </strong>
-
-        <span className="text-[11px] text-[#9da1a9]">
-          访问排行
-        </span>
-      </div>
-
-      <div className="mt-1">
-        {hotDatasets.map((item) => {
-          const rankClassName =
-            item.rank === 1
-              ? 'bg-[#ff4d68]'
-              : item.rank === 2
-                ? 'bg-[#ff8c31]'
-                : item.rank === 3
-                  ? 'bg-[#e9b919]'
-                  : 'bg-[#999da5]';
-
-          return (
-            <button
-              key={item.rank}
-              type="button"
-              onClick={() => history.push('/data-analysis/data-catalog')}
-              className="group flex w-full items-center gap-3 rounded-[8px] border-0 bg-transparent px-1 py-[11px] text-left transition-colors hover:bg-[#f7f8fa]"
-            >
-              <span
-                className={`flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] text-[10px] font-semibold text-white ${rankClassName}`}
-              >
-                {item.rank}
-              </span>
-
-              <span className="min-w-0 flex-1 truncate text-[12px] text-[#454952]">
-                {item.name}
-              </span>
-
-              <span className="shrink-0 text-[10px] text-[#999da5]">
-                访问
-                <strong className="ml-1 font-semibold text-[#676c76]">
-                  {item.count}
-                </strong>
-              </span>
-            </button>
-          );
-        })}
-      </div>
-
-      <button
-        type="button"
-        onClick={() => history.push('/data-analysis/data-catalog')}
-        className="mx-auto mt-3 flex items-center gap-0.5 border-0 bg-transparent px-3 py-1 text-[11px] text-[#868b94] transition-colors hover:text-[#343842]"
-      >
-        查看全部
-        <ChevronRight size={12} strokeWidth={1.8} />
-      </button>
-    </div>
-  );
-}
-
-function DatasetOverview() {
-  return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-6 pt-5">
-      <SectionHeader
-        title="数据集"
-        description="统一查看数据资产规模、最近更新与热门数据集"
-        onMore={() => history.push('/data-analysis/data-catalog')}
-      />
-
-      <div className="mt-5 grid grid-cols-1 lg:grid-cols-[0.76fr_1.15fr_1fr]">
-        <AssetOverviewColumn />
-        <RecentDatasetColumn />
-        <HotDatasetColumn />
-      </div>
-    </section>
   );
 }
 
@@ -454,23 +177,10 @@ function QualityOverview() {
           </div>
 
           <div className="mt-6 grid grid-cols-2 gap-x-5 gap-y-4">
-            <QualityMetric
-              label="监控表"
-              value="38"
-            />
-            <QualityMetric
-              label="今日检测"
-              value="126"
-            />
-            <QualityMetric
-              label="异常表"
-              value="3"
-              warning
-            />
-            <QualityMetric
-              label="规则"
-              value="84"
-            />
+            <QualityMetric label="监控表" value="38" />
+            <QualityMetric label="今日检测" value="126" />
+            <QualityMetric label="异常表" value="3" warning />
+            <QualityMetric label="规则" value="84" />
           </div>
         </div>
 
@@ -551,9 +261,7 @@ function QualityMetric({
 }) {
   return (
     <div>
-      <div className="text-[10px] leading-4 text-[#999da5]">
-        {label}
-      </div>
+      <div className="text-[10px] leading-4 text-[#999da5]">{label}</div>
 
       <strong
         className={`mt-0.5 block text-[18px] font-semibold leading-6 ${
@@ -667,13 +375,8 @@ function DataServiceOverview() {
       <div className="mt-5">
         <div className="grid grid-cols-2 divide-x divide-[#eef0f3] lg:grid-cols-4">
           {serviceMetrics.map((item) => (
-            <div
-              key={item.label}
-              className="px-4 first:pl-0 last:pr-0"
-            >
-              <div className="text-[11px] text-[#92969f]">
-                {item.label}
-              </div>
+            <div key={item.label} className="px-4 first:pl-0 last:pr-0">
+              <div className="text-[11px] text-[#92969f]">{item.label}</div>
 
               <strong className="mt-1 block text-[24px] font-semibold tracking-[-0.6px] text-[#30343d]">
                 {item.value}
@@ -693,236 +396,6 @@ function DataServiceOverview() {
         </div>
       </div>
     </section>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* 数据血缘                                                                   */
-/* -------------------------------------------------------------------------- */
-
-interface LineageNodeProps {
-  title: string;
-  subtitle: string;
-  className: string;
-  icon: ReactNode;
-}
-
-function LineageNode({
-  title,
-  subtitle,
-  className,
-  icon,
-}: LineageNodeProps) {
-  return (
-    <div
-      className={`absolute z-10 flex h-[62px] w-[154px] items-center gap-2.5 rounded-[12px] border border-[#e9ebef] bg-white px-3 shadow-[0_6px_18px_rgba(31,35,41,0.055)] ${className}`}
-    >
-      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#f1f4ff] text-[#6b78dc]">
-        {icon}
-      </span>
-
-      <span className="min-w-0">
-        <strong className="block truncate text-[11px] font-semibold text-[#3d414a]">
-          {title}
-        </strong>
-
-        <span className="mt-0.5 block truncate text-[9px] text-[#9ca0a8]">
-          {subtitle}
-        </span>
-      </span>
-    </div>
-  );
-}
-
-function LineagePreview() {
-  return (
-    <div className="relative h-[276px] overflow-hidden rounded-[14px] border border-[#eef0f3] bg-[#fafbfc]">
-      <div className="absolute inset-0 opacity-[0.5] [background-image:radial-gradient(circle,#dfe2e7_0.7px,transparent_0.8px)] [background-size:12px_12px]" />
-
-      <svg
-        viewBox="0 0 760 276"
-        preserveAspectRatio="none"
-        className="absolute inset-0 h-full w-full"
-        aria-hidden="true"
-      >
-        <path
-          d="M160 138 C250 138 250 82 330 82"
-          fill="none"
-          stroke="#d3d8e1"
-          strokeWidth="1.6"
-        />
-
-        <path
-          d="M160 138 C250 138 250 194 330 194"
-          fill="none"
-          stroke="#d3d8e1"
-          strokeWidth="1.6"
-        />
-
-        <path
-          d="M484 82 C570 82 570 138 640 138"
-          fill="none"
-          stroke="#d3d8e1"
-          strokeWidth="1.6"
-        />
-
-        <path
-          d="M484 194 C570 194 570 138 640 138"
-          fill="none"
-          stroke="#d3d8e1"
-          strokeWidth="1.6"
-        />
-
-        <circle cx="160" cy="138" r="3" fill="#9eabd2" />
-        <circle cx="330" cy="82" r="3" fill="#9eabd2" />
-        <circle cx="330" cy="194" r="3" fill="#9eabd2" />
-        <circle cx="484" cy="82" r="3" fill="#9eabd2" />
-        <circle cx="484" cy="194" r="3" fill="#9eabd2" />
-        <circle cx="640" cy="138" r="3" fill="#9eabd2" />
-      </svg>
-
-      <LineageNode
-        title="ods_order"
-        subtitle="ODS · MySQL"
-        className="left-[20px] top-1/2 -translate-y-1/2"
-        icon={<Database size={15} strokeWidth={1.8} />}
-      />
-
-      <LineageNode
-        title="dwd_order_detail"
-        subtitle="DWD · Spark SQL"
-        className="left-[43%] top-[18%] -translate-x-1/2"
-        icon={<GitBranch size={15} strokeWidth={1.8} />}
-      />
-
-      <LineageNode
-        title="dwd_user"
-        subtitle="DWD · Flink SQL"
-        className="left-[43%] bottom-[17%] -translate-x-1/2"
-        icon={<GitBranch size={15} strokeWidth={1.8} />}
-      />
-
-      <LineageNode
-        title="ads_sales"
-        subtitle="ADS · Dashboard"
-        className="right-[20px] top-1/2 -translate-y-1/2"
-        icon={<BarChart3 size={15} strokeWidth={1.8} />}
-      />
-
-      <div className="absolute bottom-3 left-3 rounded-full border border-[#e6e8ec] bg-white/90 px-2.5 py-1 text-[9px] text-[#999da5] shadow-sm backdrop-blur">
-        示例血缘关系
-      </div>
-    </div>
-  );
-}
-
-function DataLineageOverview() {
-  return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
-      <SectionHeader
-        title="数据血缘"
-        description="观察核心数据链路与上下游关系"
-        onMore={() => history.push('/data-analysis/lineage')}
-      />
-
-      <div className="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_220px]">
-        <LineagePreview />
-
-        <div className="flex flex-col">
-          <div className="grid grid-cols-2 gap-x-5 gap-y-5">
-            <LineageMetric
-              label="数据节点"
-              value="1,286"
-            />
-
-            <LineageMetric
-              label="血缘关系"
-              value="3,642"
-            />
-
-            <LineageMetric
-              label="今日更新"
-              value="28"
-            />
-
-            <LineageMetric
-              label="核心链路"
-              value="16"
-            />
-          </div>
-
-          <div className="mt-6 border-t border-[#eef0f3] pt-4">
-            <div className="flex items-center gap-1.5 text-[11px] font-medium text-[#525761]">
-              <Activity size={13} strokeWidth={1.8} />
-              最近解析
-            </div>
-
-            <div className="mt-3 space-y-3">
-              <LineageUpdate
-                name="订单主题链路"
-                time="10 分钟前"
-              />
-
-              <LineageUpdate
-                name="客户画像链路"
-                time="42 分钟前"
-              />
-
-              <LineageUpdate
-                name="销售经营链路"
-                time="2 小时前"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function LineageMetric({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
-  return (
-    <div>
-      <div className="text-[10px] text-[#989ca4]">
-        {label}
-      </div>
-
-      <strong className="mt-1 block text-[20px] font-semibold text-[#3c4049]">
-        {value}
-      </strong>
-    </div>
-  );
-}
-
-function LineageUpdate({
-  name,
-  time,
-}: {
-  name: string;
-  time: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => history.push('/data-analysis/lineage')}
-      className="group flex w-full items-center gap-2 border-0 bg-transparent p-0 text-left"
-    >
-      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#8394e8]" />
-
-      <span className="min-w-0 flex-1 truncate text-[11px] text-[#555a64]">
-        {name}
-      </span>
-
-      <span className="shrink-0 text-[9px] text-[#a1a5ad]">
-        {time}
-      </span>
-    </button>
   );
 }
 
@@ -954,11 +427,7 @@ const dashboardItems = [
   },
 ];
 
-function DashboardPreview({
-  type,
-}: {
-  type: string;
-}) {
+function DashboardPreview({ type }: { type: string }) {
   if (type === 'sales') {
     return (
       <div className="absolute inset-0 p-4">
@@ -1081,20 +550,14 @@ function DashboardOverview() {
               <DashboardPreview type={item.type} />
 
               <div className="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-[8px] border border-white/80 bg-white/85 text-[#6674a8] opacity-0 shadow-sm backdrop-blur transition-opacity group-hover:opacity-100">
-                <ChevronRight
-                  size={14}
-                  strokeWidth={1.8}
-                />
+                <ChevronRight size={14} strokeWidth={1.8} />
               </div>
             </div>
 
             <div className="px-4 pb-4 pt-3.5">
               <div className="flex items-center gap-2">
                 <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] bg-[#f2f4fb] text-[#737fae]">
-                  <LayoutDashboard
-                    size={14}
-                    strokeWidth={1.8}
-                  />
+                  <LayoutDashboard size={14} strokeWidth={1.8} />
                 </span>
 
                 <strong className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#373b44]">
@@ -1123,22 +586,24 @@ function DashboardOverview() {
 /* -------------------------------------------------------------------------- */
 
 export default function HomeWorkbench() {
+  const assetOverviewState = useHomeAssetOverview();
+
   return (
     <div className="mt-4 space-y-4">
-      <DatasetOverview />
+      <DatasetOverview state={assetOverviewState} />
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.32fr)_minmax(400px,0.68fr)]">
         <QualityOverview />
         <DataServiceOverview />
       </div>
 
-      <DataLineageOverview />
+      <DataLineageOverview state={assetOverviewState} />
 
       <DashboardOverview />
 
       <div className="flex items-center justify-center gap-2 py-2 text-[10px] text-[#aaadb4]">
         <Sparkles size={11} strokeWidth={1.8} />
-        当前总览使用模拟数据，后续逐模块接入真实统计接口
+        数据集与血缘已接入真实数据，其余总览将在后续阶段逐步接入
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/home/homeAssetOverviewShared.tsx
+++ b/yak-ops-ui/src/pages/home/homeAssetOverviewShared.tsx
@@ -1,0 +1,121 @@
+import { ChevronRight } from 'lucide-react';
+
+import type { HomeAssetOverview } from './service';
+
+export interface HomeAssetOverviewState {
+  data?: HomeAssetOverview;
+  loading: boolean;
+  failed: boolean;
+}
+
+interface SectionHeaderProps {
+  title: string;
+  description?: string;
+  onMore?: () => void;
+}
+
+const COUNT_FORMATTER = new Intl.NumberFormat('zh-CN');
+
+export const formatMetric = (value?: number | null) =>
+  value == null ? '--' : COUNT_FORMATTER.format(value);
+
+export const compactName = (value: string) =>
+  value.length > 16 ? `${value.slice(0, 13)}...` : value;
+
+export const relativeTime = (value?: string | null) => {
+  if (!value) return '--';
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return value;
+
+  const minutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days} 天前`;
+  return new Date(timestamp).toLocaleDateString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+export const relationTypeLabel = (relationType?: string) => {
+  const labels: Record<string, string> = {
+    READS_FROM: '读取',
+    WRITES_TO: '写入',
+    DERIVES_FROM: '派生',
+    CONSUMES: '消费',
+    CONTAINS: '包含',
+  };
+  return labels[relationType?.toUpperCase() || ''] || relationType || '关系';
+};
+
+export const assetTypeColor = (assetType?: string) => {
+  const colors: Record<string, string> = {
+    TABLE: '#6f83d9',
+    COLUMN: '#8ca0d9',
+    SQL_TASK: '#cf7e6b',
+    DATASET: '#5b9b83',
+    DATASET_FIELD: '#76aa98',
+    CHART: '#d29359',
+    DASHBOARD: '#8a72c7',
+  };
+  return colors[assetType?.toUpperCase() || ''] || '#87909d';
+};
+
+export function SectionHeader({
+  title,
+  description,
+  onMore,
+}: SectionHeaderProps) {
+  return (
+    <header className="flex items-start justify-between gap-4">
+      <div className="min-w-0">
+        <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+          {title}
+        </h2>
+        {description ? (
+          <p className="mt-1 text-[12px] leading-5 text-[#92969f]">
+            {description}
+          </p>
+        ) : null}
+      </div>
+
+      {onMore ? (
+        <button
+          type="button"
+          onClick={onMore}
+          className="mt-0.5 flex shrink-0 items-center gap-0.5 border-0 bg-transparent p-0 text-[12px] text-[#747982] transition-colors hover:text-[#252832]"
+        >
+          查看更多
+          <ChevronRight size={14} strokeWidth={1.8} />
+        </button>
+      ) : null}
+    </header>
+  );
+}
+
+export function EmptyList({
+  loading,
+  failed,
+  unavailable,
+  text,
+}: {
+  loading: boolean;
+  failed: boolean;
+  unavailable: boolean;
+  text: string;
+}) {
+  return (
+    <div className="flex min-h-[214px] items-center justify-center text-[11px] text-[#a0a4ac]">
+      {loading
+        ? '数据加载中...'
+        : failed
+          ? '数据加载失败'
+          : unavailable
+            ? '数据暂不可用'
+            : text}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/home/service.ts
+++ b/yak-ops-ui/src/pages/home/service.ts
@@ -83,7 +83,62 @@ export interface HomeScheduleResponse {
   items: HomeScheduleItem[];
 }
 
+export interface HomeAssetDatasetItem {
+  id: string;
+  name: string;
+  description?: string | null;
+  status: string;
+  updatedAt?: string | null;
+}
+
+export interface HomeAssetDatasetOverview {
+  datasetCount: number | null;
+  tableAssetCount: number | null;
+  columnAssetCount: number | null;
+  todayCreatedCount: number | null;
+  recentDatasets: HomeAssetDatasetItem[];
+  onlineDatasets: HomeAssetDatasetItem[];
+}
+
+export interface HomeLineageNode {
+  id: string;
+  name: string;
+  assetType: string;
+  sourceType?: string | null;
+}
+
+export interface HomeLineageEdge {
+  id: string;
+  sourceAssetId: string;
+  targetAssetId: string;
+  relationType: string;
+}
+
+export interface HomeLineageActivity {
+  id: string;
+  sourceName: string;
+  targetName: string;
+  relationType: string;
+  occurredAt?: string | null;
+}
+
+export interface HomeAssetLineageOverview {
+  assetCount: number | null;
+  relationCount: number | null;
+  todayUpdatedCount: number | null;
+  datasetAssetCount: number | null;
+  nodes: HomeLineageNode[];
+  edges: HomeLineageEdge[];
+  recentActivities: HomeLineageActivity[];
+}
+
+export interface HomeAssetOverview {
+  dataset: HomeAssetDatasetOverview;
+  lineage: HomeAssetLineageOverview;
+}
+
 const PREFIX = '/api/v1/home/data-center';
+const ASSET_PREFIX = '/api/v1/home/assets';
 
 export const homeDataCenterApi = {
   overview: (
@@ -100,4 +155,9 @@ export const homeDataCenterApi = {
     HttpUtils.get<HomeScheduleResponse>(
       `${PREFIX}/schedule?period=${encodeURIComponent(period)}`,
     ),
+};
+
+export const homeAssetOverviewApi = {
+  overview: (): Promise<ApiResponse<HomeAssetOverview>> =>
+    HttpUtils.get<HomeAssetOverview>(`${ASSET_PREFIX}/overview`),
 };


### PR DESCRIPTION
## 背景

首页真实数据改造 Stage 4：将“数据集”和“数据血缘”总览从前端 Mock 切换为真实数据。数据质量、数据服务和仪表盘继续留给后续阶段，本 PR 不扩展范围。

## 本次改动

### 数据集总览

- 数据集总数：来自 `DatasetService`
- 今日新增：按数据集 `createTime` 在本地自然日范围统计
- 最近更新：按 `updateTime / createTime` 倒序展示
- 已上线数据集：筛选 `DatasetStatus.ONLINE` 后按更新时间展示
- 血缘表 / 血缘字段：分别统计 Lineage `TABLE / COLUMN` 资产

当前系统没有可证明的数据集访问日志，因此不再把第三列伪装成“热门数据集”，改为真实可验证的“已上线数据集”。“血缘表 / 血缘字段”也明确表达它们是已经进入血缘图的资产数量，不冒充完整物理目录统计。

### 数据血缘总览

- 数据节点总数
- 血缘关系总数
- 今日更新资产数
- 数据集节点数
- 最近关系的真实 ECharts 图预览
- 最近血缘关系活动列表

统计使用数据库 `COUNT` 和有界最近关系查询，不通过加载完整血缘图后在内存计算。

### 新增接口

```text
GET /api/v1/home/assets/overview
```

接口按 Dataset / Lineage 两个能力域分别聚合；一侧失败时不会阻断另一侧结果。

## 架构边界

- Boot 聚合层只依赖稳定的 `DatasetService` 和 `LineageQueryService`
- 不跨模块访问 Dataset / Lineage DAO、Mapper 或 PO
- Lineage 统计能力保留在 Query Service → Repository → DAO 单向读链路
- 未新增 Maven 依赖、数据库表或 Flyway migration

## 数据语义

- 查询成功且无记录：返回 `0`
- 模块不可用或查询失败：对应字段返回 `null`
- 前端使用 `value == null ? '--' : value`，真实零不会被误显示为 `--`
- 单个能力域失败时，首页不会白屏，另一个能力域仍可展示

## 验证

已完成：

- 前端严格 TSX 类型检查（最小依赖桩）
- Boot 聚合代码 Java 21 结构/语法编译（边界桩）
- Lineage Service / Repository / DAO Java 21 结构/语法编译（边界桩）
- Boot → Lineage 公开类型依赖检查
- UTF-8、final newline、tab、trailing whitespace 检查
- 分支相对最新 `main` 的提交与文件范围检查：1 个提交，未落后

当前执行环境无法拉取完整仓库依赖，因此未宣称完整 Maven reactor、`npm run build` 或浏览器 E2E 已通过；以正常开发环境和 CI 结果为准。

## 后续

Stage 5：数据质量真实指标，包括监控表、规则执行和真实异常口径。