### PR TITLE
fix(datasource): restore pagination interceptor compile dependency

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/pom.xml
+++ b/yak-ops-business/yak-ops-business-datasource/pom.xml
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>


### PR DESCRIPTION
## 问题

启动/编译 `yak-ops-business-datasource` 时，`BusinessDatabaseConfiguration` 无法解析：

```text
com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor
```

对应报错：

```text
java: 找不到符号
  符号:   类 PaginationInnerInterceptor
  位置: 程序包 com.baomidou.mybatisplus.extension.plugins.inner
```

## 根因

`BusinessDatabaseConfiguration` 在生产源码中直接 import 并实例化 `PaginationInnerInterceptor`：

```java
interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
```

当前使用的 MyBatis-Plus 3.5.16 将该类放在：

```text
com.baomidou:mybatis-plus-jsqlparser-4.9
```

但 Datasource POM 将该依赖声明成了：

```xml
<scope>runtime</scope>
```

Maven 的 runtime 依赖不会进入主源码编译 classpath，因此 javac 无法解析该类型。这个问题由近期 Maven runtime ownership 调整引入。

## 修复

删除 `mybatis-plus-jsqlparser-4.9` 的 `runtime` scope，使其恢复为 Maven 默认的 `compile` scope：

```xml
<dependency>
    <groupId>com.baomidou</groupId>
    <artifactId>mybatis-plus-jsqlparser-4.9</artifactId>
</dependency>
```

该依赖仍会进入运行时 classpath，同时现在也能为 `BusinessDatabaseConfiguration` 提供编译期类型。

`flyway-mysql` 继续保持 runtime scope，因为生产源码没有直接引用其实现类型。

## 变更范围

仅修改：

```text
yak-ops-business/yak-ops-business-datasource/pom.xml
```

总差异为删除 1 行，不修改 Java 代码、数据库配置、分页行为或其他模块依赖。

## 验证

在独立验证分支中使用 Java 21 + MyBatis-Plus 3.5.16 完成以下检查并全部通过：

- 校验 Datasource POM 中 `mybatis-plus-jsqlparser-4.9` 的有效 scope 为 `compile`；
- 使用完全相同的 `PaginationInnerInterceptor` import 构造最小 Java 编译用例；
- 将依赖设为 runtime 时，稳定复现编译失败；
- 使用本 PR 的 compile scope 时，最小用例成功编译。

验证工作流：

```text
Validate Datasource Pagination Compile Scope / success
```

本地建议回归：

```bash
mvn -pl yak-ops-business/yak-ops-business-datasource -am -DskipTests compile
```

随后重新启动 Yak Ops，原 `PaginationInnerInterceptor` 缺失错误应消失。