### PR TITLE
feat(home): 接入数据质量真实指标（Stage 5）

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeQualityOverviewController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeQualityOverviewController.java
@@ -1,0 +1,27 @@
+package io.yak.ops.boot.home;
+
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.boot.home.HomeQualityOverviewService.OverviewResponse;
+import io.yak.ops.business.quality.QualityPermissionCode;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 首页数据质量总览接口。 */
+@RestController
+@RequestMapping("/api/v1/home/quality")
+@RequiresPermission(QualityPermissionCode.EXECUTION_READ)
+public class HomeQualityOverviewController {
+
+  private final HomeQualityOverviewService service;
+
+  public HomeQualityOverviewController(HomeQualityOverviewService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/overview")
+  public Result<OverviewResponse> overview() {
+    return Result.success(service.overview());
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeQualityOverviewService.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeQualityOverviewService.java
@@ -1,0 +1,103 @@
+package io.yak.ops.boot.home;
+
+import io.yak.ops.business.quality.workspace.QualityOverviewReader;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+/** 首页数据质量只读聚合。 */
+@Service
+public class HomeQualityOverviewService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HomeQualityOverviewService.class);
+
+  private final ObjectProvider<QualityOverviewReader> readerProvider;
+
+  public HomeQualityOverviewService(ObjectProvider<QualityOverviewReader> readerProvider) {
+    this.readerProvider = readerProvider;
+  }
+
+  public OverviewResponse overview() {
+    QualityOverviewReader reader = readerProvider.getIfAvailable();
+    if (reader == null) return unavailable();
+    try {
+      return response(reader.overview());
+    } catch (RuntimeException exception) {
+      LOGGER.warn("加载首页数据质量总览失败", exception);
+      return unavailable();
+    }
+  }
+
+  private OverviewResponse response(QualityOverviewReader.Overview overview) {
+    return new OverviewResponse(
+        overview.rangeStart(),
+        overview.rangeEnd(),
+        overview.passRate(),
+        overview.monitoredTableCount(),
+        overview.enabledRuleCount(),
+        overview.todayExecutionCount(),
+        overview.todayIssueTableCount(),
+        overview.recentIssueCount(),
+        overview.dimensions().stream()
+            .map(item -> new DimensionView(
+                item.dimension(), item.total(), item.issues(), item.passRate()))
+            .toList(),
+        overview.recentIssues().stream()
+            .map(item -> new IssueView(
+                item.id(),
+                item.executionNo(),
+                item.monitorId(),
+                item.monitorName(),
+                item.objectName(),
+                item.tableName(),
+                item.ruleName(),
+                item.dimension(),
+                item.columnName(),
+                item.checkResult(),
+                item.queuedAt()))
+            .toList());
+  }
+
+  private OverviewResponse unavailable() {
+    return new OverviewResponse(
+        null, null, null, null, null, null, null, null, List.of(), List.of());
+  }
+
+  public record OverviewResponse(
+      LocalDate rangeStart,
+      LocalDate rangeEnd,
+      Double passRate,
+      Long monitoredTableCount,
+      Long enabledRuleCount,
+      Long todayExecutionCount,
+      Long todayIssueTableCount,
+      Long recentIssueCount,
+      List<DimensionView> dimensions,
+      List<IssueView> recentIssues) {
+  }
+
+  public record DimensionView(
+      String dimension,
+      long total,
+      long issues,
+      Double passRate) {
+  }
+
+  public record IssueView(
+      String id,
+      String executionNo,
+      String monitorId,
+      String monitorName,
+      String objectName,
+      String tableName,
+      String ruleName,
+      String dimension,
+      String columnName,
+      String checkResult,
+      LocalDateTime queuedAt) {
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeQualityOverviewServiceTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeQualityOverviewServiceTest.java
@@ -1,0 +1,105 @@
+package io.yak.ops.boot.home;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.workspace.QualityOverviewReader;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class HomeQualityOverviewServiceTest {
+
+  @Test
+  void shouldExposeRealQualityOverviewValues() {
+    QualityOverviewReader reader = mock(QualityOverviewReader.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<QualityOverviewReader> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(reader);
+
+    LocalDate today = LocalDate.now();
+    LocalDateTime issueTime = today.atTime(10, 30);
+    when(reader.overview())
+        .thenReturn(new QualityOverviewReader.Overview(
+            today.minusDays(6),
+            today,
+            97.5D,
+            8L,
+            24L,
+            6L,
+            1L,
+            2L,
+            List.of(new QualityOverviewReader.DimensionHealth("完整性", 12L, 1L, 91.67D)),
+            List.of(new QualityOverviewReader.RecentIssue(
+                "91",
+                "quality-1",
+                "11",
+                "订单质量监控",
+                "warehouse.dwd_order",
+                "dwd_order",
+                "订单号不能为空",
+                "完整性",
+                "order_id",
+                "NOT_PASSED",
+                issueTime))));
+
+    HomeQualityOverviewService.OverviewResponse response =
+        new HomeQualityOverviewService(provider).overview();
+
+    assertThat(response.passRate()).isEqualTo(97.5D);
+    assertThat(response.monitoredTableCount()).isEqualTo(8L);
+    assertThat(response.enabledRuleCount()).isEqualTo(24L);
+    assertThat(response.todayExecutionCount()).isEqualTo(6L);
+    assertThat(response.todayIssueTableCount()).isEqualTo(1L);
+    assertThat(response.recentIssueCount()).isEqualTo(2L);
+    assertThat(response.dimensions()).singleElement()
+        .satisfies(item -> {
+          assertThat(item.dimension()).isEqualTo("完整性");
+          assertThat(item.passRate()).isEqualTo(91.67D);
+        });
+    assertThat(response.recentIssues()).singleElement()
+        .satisfies(item -> {
+          assertThat(item.executionNo()).isEqualTo("quality-1");
+          assertThat(item.ruleName()).isEqualTo("订单号不能为空");
+          assertThat(item.queuedAt()).isEqualTo(issueTime);
+        });
+  }
+
+  @Test
+  void shouldExposeUnavailableStateWithoutInventingZeroes() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<QualityOverviewReader> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(null);
+
+    HomeQualityOverviewService.OverviewResponse response =
+        new HomeQualityOverviewService(provider).overview();
+
+    assertThat(response.passRate()).isNull();
+    assertThat(response.monitoredTableCount()).isNull();
+    assertThat(response.enabledRuleCount()).isNull();
+    assertThat(response.todayExecutionCount()).isNull();
+    assertThat(response.todayIssueTableCount()).isNull();
+    assertThat(response.recentIssueCount()).isNull();
+    assertThat(response.dimensions()).isEmpty();
+    assertThat(response.recentIssues()).isEmpty();
+  }
+
+  @Test
+  void shouldKeepHomepageAvailableWhenQualityQueryFails() {
+    QualityOverviewReader reader = mock(QualityOverviewReader.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<QualityOverviewReader> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(reader);
+    when(reader.overview()).thenThrow(new IllegalStateException("quality unavailable"));
+
+    HomeQualityOverviewService.OverviewResponse response =
+        new HomeQualityOverviewService(provider).overview();
+
+    assertThat(response.passRate()).isNull();
+    assertThat(response.monitoredTableCount()).isNull();
+    assertThat(response.recentIssues()).isEmpty();
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/QualityAnalyticsDao.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/QualityAnalyticsDao.java
@@ -1,5 +1,8 @@
 package io.yak.ops.business.quality.dao;
 
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.DimensionRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.IssueRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.StatsRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.ColumnReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.DimensionReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.OperationLogRow;
@@ -9,7 +12,7 @@ import io.yak.ops.common.bean.po.quality.QualityQueryPO.WorkspaceStatsRow;
 import java.util.List;
 import java.util.Map;
 
-/** 质量工作台聚合查询数据访问边界。 */
+/** 质量工作台与首页聚合查询数据访问边界。 */
 public interface QualityAnalyticsDao {
   WorkspaceStatsRow selectStats(long monitorId);
   ReportOverviewRow selectOverview(Map<String, Object> params);
@@ -18,4 +21,8 @@ public interface QualityAnalyticsDao {
   List<ColumnReportRow> selectColumns(Map<String, Object> params);
   long countOperationLogs(long monitorId);
   List<OperationLogRow> selectOperationLogs(Map<String, Object> params);
+
+  StatsRow selectHomeOverviewStats(Map<String, Object> params);
+  List<DimensionRow> selectHomeOverviewDimensions(Map<String, Object> params);
+  List<IssueRow> selectHomeOverviewIssues(Map<String, Object> params);
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityAnalyticsDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityAnalyticsDaoImpl.java
@@ -2,7 +2,11 @@ package io.yak.ops.business.quality.dao.impl;
 
 import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.dao.QualityAnalyticsDao;
+import io.yak.ops.business.quality.dao.mapper.QualityOverviewMapper;
 import io.yak.ops.business.quality.dao.mapper.QualityQueryMapper;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.DimensionRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.IssueRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.StatsRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.ColumnReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.DimensionReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.OperationLogRow;
@@ -21,6 +25,7 @@ import org.springframework.stereotype.Repository;
 @DependsOn("qualityFlyway")
 public class QualityAnalyticsDaoImpl implements QualityAnalyticsDao {
   private final QualityQueryMapper queryMapper;
+  private final QualityOverviewMapper overviewMapper;
 
   @Override public WorkspaceStatsRow selectStats(long monitorId) { return queryMapper.selectWorkspaceStats(monitorId); }
   @Override public ReportOverviewRow selectOverview(Map<String, Object> params) { return queryMapper.selectReportOverview(params); }
@@ -29,4 +34,8 @@ public class QualityAnalyticsDaoImpl implements QualityAnalyticsDao {
   @Override public List<ColumnReportRow> selectColumns(Map<String, Object> params) { return queryMapper.selectColumnReport(params); }
   @Override public long countOperationLogs(long monitorId) { return queryMapper.countOperationLogs(monitorId); }
   @Override public List<OperationLogRow> selectOperationLogs(Map<String, Object> params) { return queryMapper.selectOperationLogs(params); }
+
+  @Override public StatsRow selectHomeOverviewStats(Map<String, Object> params) { return overviewMapper.selectStats(params); }
+  @Override public List<DimensionRow> selectHomeOverviewDimensions(Map<String, Object> params) { return overviewMapper.selectDimensions(params); }
+  @Override public List<IssueRow> selectHomeOverviewIssues(Map<String, Object> params) { return overviewMapper.selectRecentIssues(params); }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityOverviewMapper.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityOverviewMapper.java
@@ -1,0 +1,19 @@
+package io.yak.ops.business.quality.dao.mapper;
+
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.DimensionRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.IssueRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.StatsRow;
+import java.util.List;
+import java.util.Map;
+import org.apache.ibatis.annotations.Mapper;
+
+/** 首页数据质量总览聚合查询。 */
+@Mapper
+public interface QualityOverviewMapper {
+
+  StatsRow selectStats(Map<String, Object> params);
+
+  List<DimensionRow> selectDimensions(Map<String, Object> params);
+
+  List<IssueRow> selectRecentIssues(Map<String, Object> params);
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/model/QualityOverviewPO.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/model/QualityOverviewPO.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.quality.dao.model;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 首页质量总览使用的只读持久化投影。 */
+public final class QualityOverviewPO {
+
+  private QualityOverviewPO() {
+  }
+
+  @Data
+  public static class StatsRow {
+    private Long monitoredTableCount;
+    private Long enabledRuleCount;
+    private Long todayExecutionCount;
+    private Long todayIssueTableCount;
+    private Long recentExecutedRuleCount;
+    private Long recentPassedRuleCount;
+    private Long recentIssueRuleCount;
+  }
+
+  @Data
+  public static class DimensionRow {
+    private String dimension;
+    private Long totalCount;
+    private Long passedCount;
+    private Long issueCount;
+  }
+
+  @Data
+  public static class IssueRow {
+    private Long ruleExecutionId;
+    private String executionNo;
+    private Long monitorId;
+    private String monitorName;
+    private String objectName;
+    private String tableName;
+    private String ruleName;
+    private String dimension;
+    private String columnName;
+    private String checkResult;
+    private LocalDateTime queuedAt;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityOverviewRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityOverviewRepository.java
@@ -1,0 +1,52 @@
+package io.yak.ops.business.quality.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 首页数据质量总览读模型 Repository。 */
+public interface QualityOverviewRepository {
+
+  OverviewStats stats(
+      LocalDateTime todayStart,
+      LocalDateTime todayEnd,
+      LocalDateTime rangeStart,
+      LocalDateTime rangeEnd);
+
+  List<DimensionSummary> dimensions(LocalDateTime rangeStart, LocalDateTime rangeEnd);
+
+  List<IssueSummary> recentIssues(
+      LocalDateTime rangeStart,
+      LocalDateTime rangeEnd,
+      int limit);
+
+  record OverviewStats(
+      long monitoredTableCount,
+      long enabledRuleCount,
+      long todayExecutionCount,
+      long todayIssueTableCount,
+      long recentExecutedRuleCount,
+      long recentPassedRuleCount,
+      long recentIssueRuleCount) {
+  }
+
+  record DimensionSummary(
+      String dimension,
+      long total,
+      long passed,
+      long issues) {
+  }
+
+  record IssueSummary(
+      long id,
+      String executionNo,
+      long monitorId,
+      String monitorName,
+      String objectName,
+      String tableName,
+      String ruleName,
+      String dimension,
+      String columnName,
+      String checkResult,
+      LocalDateTime queuedAt) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityOverviewRepositoryAdapter.java
@@ -1,0 +1,108 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.dao.QualityAnalyticsDao;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.DimensionRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.IssueRow;
+import io.yak.ops.business.quality.dao.model.QualityOverviewPO.StatsRow;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+
+/** 首页质量总览持久化适配器。 */
+@Repository
+@RequiredArgsConstructor
+@ConditionalOnQualityEnabled
+@DependsOn("qualityFlyway")
+public class QualityOverviewRepositoryAdapter implements QualityOverviewRepository {
+
+  private final QualityAnalyticsDao analyticsDao;
+
+  @Override
+  public OverviewStats stats(
+      LocalDateTime todayStart,
+      LocalDateTime todayEnd,
+      LocalDateTime rangeStart,
+      LocalDateTime rangeEnd) {
+    StatsRow row = analyticsDao.selectHomeOverviewStats(
+        params(todayStart, todayEnd, rangeStart, rangeEnd));
+    if (row == null) {
+      return new OverviewStats(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+    return new OverviewStats(
+        nvl(row.getMonitoredTableCount()),
+        nvl(row.getEnabledRuleCount()),
+        nvl(row.getTodayExecutionCount()),
+        nvl(row.getTodayIssueTableCount()),
+        nvl(row.getRecentExecutedRuleCount()),
+        nvl(row.getRecentPassedRuleCount()),
+        nvl(row.getRecentIssueRuleCount()));
+  }
+
+  @Override
+  public List<DimensionSummary> dimensions(LocalDateTime rangeStart, LocalDateTime rangeEnd) {
+    return analyticsDao.selectHomeOverviewDimensions(params(null, null, rangeStart, rangeEnd)).stream()
+        .map(this::dimension)
+        .toList();
+  }
+
+  @Override
+  public List<IssueSummary> recentIssues(
+      LocalDateTime rangeStart,
+      LocalDateTime rangeEnd,
+      int limit) {
+    Map<String, Object> params = params(null, null, rangeStart, rangeEnd);
+    params.put("limit", Math.max(1, limit));
+    return analyticsDao.selectHomeOverviewIssues(params).stream()
+        .map(this::issue)
+        .toList();
+  }
+
+  private DimensionSummary dimension(DimensionRow row) {
+    return new DimensionSummary(
+        text(row.getDimension(), "其他"),
+        nvl(row.getTotalCount()),
+        nvl(row.getPassedCount()),
+        nvl(row.getIssueCount()));
+  }
+
+  private IssueSummary issue(IssueRow row) {
+    return new IssueSummary(
+        nvl(row.getRuleExecutionId()),
+        text(row.getExecutionNo(), ""),
+        nvl(row.getMonitorId()),
+        text(row.getMonitorName(), "未命名质量监控"),
+        text(row.getObjectName(), row.getTableName()),
+        text(row.getTableName(), ""),
+        text(row.getRuleName(), "未命名规则"),
+        text(row.getDimension(), "其他"),
+        row.getColumnName(),
+        text(row.getCheckResult(), "NOT_PASSED"),
+        row.getQueuedAt());
+  }
+
+  private Map<String, Object> params(
+      LocalDateTime todayStart,
+      LocalDateTime todayEnd,
+      LocalDateTime rangeStart,
+      LocalDateTime rangeEnd) {
+    Map<String, Object> params = new LinkedHashMap<>();
+    if (todayStart != null) params.put("todayStart", todayStart);
+    if (todayEnd != null) params.put("todayEnd", todayEnd);
+    params.put("rangeStart", rangeStart);
+    params.put("rangeEnd", rangeEnd);
+    return params;
+  }
+
+  private static long nvl(Long value) {
+    return value == null ? 0L : value;
+  }
+
+  private static String text(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityOverviewReader.java
@@ -1,0 +1,125 @@
+package io.yak.ops.business.quality.workspace;
+
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.repository.QualityOverviewRepository;
+import io.yak.ops.business.quality.repository.QualityOverviewRepository.DimensionSummary;
+import io.yak.ops.business.quality.repository.QualityOverviewRepository.IssueSummary;
+import io.yak.ops.business.quality.repository.QualityOverviewRepository.OverviewStats;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 首页数据质量健康度、关键指标和问题列表读模型。 */
+@Component
+@ConditionalOnQualityEnabled
+public class QualityOverviewReader {
+
+  private static final int RANGE_DAYS = 7;
+  private static final int RECENT_ISSUE_LIMIT = 3;
+
+  private final QualityOverviewRepository repository;
+
+  public QualityOverviewReader(QualityOverviewRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public Overview overview() {
+    LocalDate today = LocalDate.now();
+    LocalDate rangeStartDate = today.minusDays(RANGE_DAYS - 1L);
+    LocalDateTime todayStart = today.atStartOfDay();
+    LocalDateTime rangeStart = rangeStartDate.atStartOfDay();
+    LocalDateTime rangeEnd = today.plusDays(1).atStartOfDay();
+
+    OverviewStats stats = repository.stats(todayStart, rangeEnd, rangeStart, rangeEnd);
+    List<DimensionHealth> dimensions = repository.dimensions(rangeStart, rangeEnd).stream()
+        .filter(item -> item.total() > 0L)
+        .map(this::dimension)
+        .toList();
+    List<RecentIssue> recentIssues = repository.recentIssues(
+            rangeStart, rangeEnd, RECENT_ISSUE_LIMIT).stream()
+        .map(this::issue)
+        .toList();
+
+    return new Overview(
+        rangeStartDate,
+        today,
+        rate(stats.recentPassedRuleCount(), stats.recentExecutedRuleCount()),
+        stats.monitoredTableCount(),
+        stats.enabledRuleCount(),
+        stats.todayExecutionCount(),
+        stats.todayIssueTableCount(),
+        stats.recentIssueRuleCount(),
+        dimensions,
+        recentIssues);
+  }
+
+  private DimensionHealth dimension(DimensionSummary item) {
+    return new DimensionHealth(
+        item.dimension(),
+        item.total(),
+        item.issues(),
+        rate(item.passed(), item.total()));
+  }
+
+  private RecentIssue issue(IssueSummary item) {
+    return new RecentIssue(
+        String.valueOf(item.id()),
+        item.executionNo(),
+        String.valueOf(item.monitorId()),
+        item.monitorName(),
+        item.objectName(),
+        item.tableName(),
+        item.ruleName(),
+        item.dimension(),
+        item.columnName(),
+        item.checkResult(),
+        item.queuedAt());
+  }
+
+  private static Double rate(long passed, long total) {
+    if (total <= 0L) return null;
+    return Math.round((passed * 10000D) / total) / 100D;
+  }
+
+  public record Overview(
+      LocalDate rangeStart,
+      LocalDate rangeEnd,
+      Double passRate,
+      long monitoredTableCount,
+      long enabledRuleCount,
+      long todayExecutionCount,
+      long todayIssueTableCount,
+      long recentIssueCount,
+      List<DimensionHealth> dimensions,
+      List<RecentIssue> recentIssues) {
+
+    public Overview {
+      dimensions = dimensions == null ? List.of() : List.copyOf(dimensions);
+      recentIssues = recentIssues == null ? List.of() : List.copyOf(recentIssues);
+    }
+  }
+
+  public record DimensionHealth(
+      String dimension,
+      long total,
+      long issues,
+      Double passRate) {
+  }
+
+  public record RecentIssue(
+      String id,
+      String executionNo,
+      String monitorId,
+      String monitorName,
+      String objectName,
+      String tableName,
+      String ruleName,
+      String dimension,
+      String columnName,
+      String checkResult,
+      LocalDateTime queuedAt) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.yak.ops.business.quality.dao.mapper.QualityOverviewMapper">
+
+  <sql id="DimensionExpression">
+    COALESCE(
+      NULLIF(r.quality_dimension, ''),
+      CASE re.rule_type
+        WHEN 'TABLE_ROW_COUNT' THEN '完整性'
+        WHEN 'COLUMN_NOT_NULL' THEN '完整性'
+        WHEN 'COLUMN_UNIQUE' THEN '唯一性'
+        WHEN 'COLUMN_RANGE' THEN '有效性'
+        WHEN 'COLUMN_ENUM' THEN '准确性'
+        WHEN 'CUSTOM_SQL' THEN '自定义'
+        ELSE '其他'
+      END)
+  </sql>
+
+  <select id="selectStats" resultType="io.yak.ops.business.quality.dao.model.QualityOverviewPO$StatsRow">
+    SELECT
+      (SELECT COUNT(DISTINCT CONCAT(
+          m.data_source_id, '|', COALESCE(m.database_name, ''), '|',
+          COALESCE(m.schema_name, ''), '|', m.table_name))
+       FROM yak_quality_monitor m
+       WHERE m.deleted = 0 AND m.enabled = 1) AS monitored_table_count,
+      (SELECT COUNT(*)
+       FROM yak_quality_rule r
+       INNER JOIN yak_quality_monitor m ON m.id = r.monitor_id
+       WHERE r.deleted = 0 AND r.enabled = 1
+         AND m.deleted = 0 AND m.enabled = 1) AS enabled_rule_count,
+      (SELECT COUNT(*)
+       FROM yak_quality_execution e
+       WHERE e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}) AS today_execution_count,
+      (SELECT COUNT(DISTINCT e.monitor_id)
+       FROM yak_quality_execution e
+       WHERE e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}
+         AND e.check_result IN ('NOT_PASSED', 'ERROR')) AS today_issue_table_count,
+      (SELECT COUNT(*)
+       FROM yak_quality_rule_execution re
+       INNER JOIN yak_quality_execution e ON e.id = re.execution_id
+       WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+         AND re.check_result IN ('PASSED', 'NOT_PASSED', 'ERROR')) AS recent_executed_rule_count,
+      (SELECT COUNT(*)
+       FROM yak_quality_rule_execution re
+       INNER JOIN yak_quality_execution e ON e.id = re.execution_id
+       WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+         AND re.check_result = 'PASSED') AS recent_passed_rule_count,
+      (SELECT COUNT(*)
+       FROM yak_quality_rule_execution re
+       INNER JOIN yak_quality_execution e ON e.id = re.execution_id
+       WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+         AND re.check_result IN ('NOT_PASSED', 'ERROR')) AS recent_issue_rule_count
+  </select>
+
+  <select id="selectDimensions" resultType="io.yak.ops.business.quality.dao.model.QualityOverviewPO$DimensionRow">
+    SELECT
+      <include refid="DimensionExpression"/> AS dimension,
+      COUNT(*) AS total_count,
+      SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END) AS passed_count,
+      SUM(CASE WHEN re.check_result IN ('NOT_PASSED', 'ERROR') THEN 1 ELSE 0 END) AS issue_count
+    FROM yak_quality_rule_execution re
+    INNER JOIN yak_quality_execution e ON e.id = re.execution_id
+    LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
+    WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+      AND re.check_result IN ('PASSED', 'NOT_PASSED', 'ERROR')
+    GROUP BY <include refid="DimensionExpression"/>
+    ORDER BY FIELD(dimension, '完整性', '准确性', '唯一性', '有效性', '一致性', '时效性', '自定义', '其他'), dimension
+  </select>
+
+  <select id="selectRecentIssues" resultType="io.yak.ops.business.quality.dao.model.QualityOverviewPO$IssueRow">
+    SELECT
+      re.id AS rule_execution_id,
+      e.execution_no,
+      e.monitor_id,
+      e.monitor_name,
+      e.object_name,
+      e.table_name,
+      re.rule_name,
+      <include refid="DimensionExpression"/> AS dimension,
+      re.column_name,
+      re.check_result,
+      e.queued_at
+    FROM yak_quality_rule_execution re
+    INNER JOIN yak_quality_execution e ON e.id = re.execution_id
+    LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
+    WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+      AND re.check_result IN ('NOT_PASSED', 'ERROR')
+    ORDER BY e.queued_at DESC, e.id DESC, re.id ASC
+    LIMIT #{limit}
+  </select>
+</mapper>

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityLayeringConventionTest.java
@@ -15,6 +15,7 @@ import io.yak.ops.business.quality.repository.QualityAlertRepository;
 import io.yak.ops.business.quality.repository.QualityExecutionRepository;
 import io.yak.ops.business.quality.repository.QualityExecutionWorkspaceRepository;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.business.quality.repository.QualityOverviewRepository;
 import io.yak.ops.business.quality.repository.QualityTableAssetRepository;
 import io.yak.ops.business.quality.repository.QualityTemplateRepository;
 import io.yak.ops.business.quality.repository.QualityWorkspaceRepository;
@@ -45,6 +46,7 @@ class QualityLayeringConventionTest {
         QualityAlertRepository.class,
         CustomTemplateRepository.class,
         QualityWorkspaceRepository.class,
+        QualityOverviewRepository.class,
         QualityExecutionWorkspaceRepository.class));
   }
 

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityRoleConventionTest.java
@@ -33,6 +33,7 @@ import io.yak.ops.business.quality.template.TemplateFolderManager;
 import io.yak.ops.business.quality.template.TemplateFolderReader;
 import io.yak.ops.business.quality.workspace.QualityExecutionLogProjector;
 import io.yak.ops.business.quality.workspace.QualityExecutionWorkspaceReader;
+import io.yak.ops.business.quality.workspace.QualityOverviewReader;
 import io.yak.ops.business.quality.workspace.QualityWorkspaceReader;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,7 @@ class QualityRoleConventionTest {
             TemplateFolderManager.class,
             TemplateFolderReader.class,
             QualityWorkspaceReader.class,
+            QualityOverviewReader.class,
             QualityExecutionWorkspaceReader.class,
             QualityExecutionLogProjector.class,
             DataSourceQualityCatalogAdapter.class)) {

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/workspace/QualityOverviewReaderTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/workspace/QualityOverviewReaderTest.java
@@ -1,0 +1,104 @@
+package io.yak.ops.business.quality.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.quality.repository.QualityOverviewRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class QualityOverviewReaderTest {
+
+  @Test
+  void shouldBuildOverviewFromPersistedQualityEvidence() {
+    LocalDateTime issueTime = LocalDateTime.now().minusHours(1);
+    QualityOverviewRepository repository = new StubRepository(
+        new QualityOverviewRepository.OverviewStats(4L, 12L, 8L, 2L, 10L, 8L, 2L),
+        List.of(
+            new QualityOverviewRepository.DimensionSummary("完整性", 4L, 3L, 1L),
+            new QualityOverviewRepository.DimensionSummary("唯一性", 6L, 5L, 1L)),
+        List.of(
+            new QualityOverviewRepository.IssueSummary(
+                91L,
+                "quality-20260826-1",
+                11L,
+                "订单完整性监控",
+                "warehouse.dwd_order",
+                "dwd_order",
+                "订单号不能为空",
+                "完整性",
+                "order_id",
+                "NOT_PASSED",
+                issueTime)));
+
+    QualityOverviewReader.Overview overview = new QualityOverviewReader(repository).overview();
+
+    assertThat(overview.rangeStart()).isEqualTo(LocalDate.now().minusDays(6));
+    assertThat(overview.rangeEnd()).isEqualTo(LocalDate.now());
+    assertThat(overview.passRate()).isEqualTo(80D);
+    assertThat(overview.monitoredTableCount()).isEqualTo(4L);
+    assertThat(overview.enabledRuleCount()).isEqualTo(12L);
+    assertThat(overview.todayExecutionCount()).isEqualTo(8L);
+    assertThat(overview.todayIssueTableCount()).isEqualTo(2L);
+    assertThat(overview.recentIssueCount()).isEqualTo(2L);
+    assertThat(overview.dimensions())
+        .extracting(QualityOverviewReader.DimensionHealth::passRate)
+        .containsExactly(75D, 83.33D);
+    assertThat(overview.recentIssues())
+        .singleElement()
+        .satisfies(issue -> {
+          assertThat(issue.executionNo()).isEqualTo("quality-20260826-1");
+          assertThat(issue.ruleName()).isEqualTo("订单号不能为空");
+          assertThat(issue.dimension()).isEqualTo("完整性");
+          assertThat(issue.checkResult()).isEqualTo("NOT_PASSED");
+          assertThat(issue.queuedAt()).isEqualTo(issueTime);
+        });
+  }
+
+  @Test
+  void shouldKeepPassRateUnavailableWhenNoRulesWereExecuted() {
+    QualityOverviewRepository repository = new StubRepository(
+        new QualityOverviewRepository.OverviewStats(0L, 0L, 0L, 0L, 0L, 0L, 0L),
+        List.of(),
+        List.of());
+
+    QualityOverviewReader.Overview overview = new QualityOverviewReader(repository).overview();
+
+    assertThat(overview.passRate()).isNull();
+    assertThat(overview.monitoredTableCount()).isZero();
+    assertThat(overview.todayExecutionCount()).isZero();
+    assertThat(overview.dimensions()).isEmpty();
+    assertThat(overview.recentIssues()).isEmpty();
+  }
+
+  private record StubRepository(
+      OverviewStats stats,
+      List<DimensionSummary> dimensions,
+      List<IssueSummary> recentIssues) implements QualityOverviewRepository {
+
+    @Override
+    public OverviewStats stats(
+        LocalDateTime todayStart,
+        LocalDateTime todayEnd,
+        LocalDateTime rangeStart,
+        LocalDateTime rangeEnd) {
+      return stats;
+    }
+
+    @Override
+    public List<DimensionSummary> dimensions(
+        LocalDateTime rangeStart,
+        LocalDateTime rangeEnd) {
+      return dimensions;
+    }
+
+    @Override
+    public List<IssueSummary> recentIssues(
+        LocalDateTime rangeStart,
+        LocalDateTime rangeEnd,
+        int limit) {
+      return recentIssues.stream().limit(limit).toList();
+    }
+  }
+}

--- a/yak-ops-ui/src/pages/home/HomeQualityOverview.tsx
+++ b/yak-ops-ui/src/pages/home/HomeQualityOverview.tsx
@@ -1,0 +1,416 @@
+import { history } from '@umijs/max';
+import type { EChartsOption } from 'echarts';
+import ReactECharts from 'echarts-for-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  homeQualityOverviewApi,
+  type HomeQualityDimension,
+  type HomeQualityIssue,
+  type HomeQualityOverview,
+} from './service';
+
+interface QualityOverviewState {
+  data?: HomeQualityOverview;
+  loading: boolean;
+  failed: boolean;
+}
+
+const COUNT_FORMATTER = new Intl.NumberFormat('zh-CN');
+
+const formatMetric = (value?: number | null) =>
+  value == null ? '--' : COUNT_FORMATTER.format(value);
+
+const formatRate = (value?: number | null) =>
+  value == null ? '--' : value.toFixed(1);
+
+const relativeTime = (value?: string | null) => {
+  if (!value) return '--';
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return value;
+  const minutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days} 天前`;
+  return new Date(timestamp).toLocaleDateString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+const objectLabel = (issue: HomeQualityIssue) =>
+  issue.objectName || issue.tableName || issue.monitorName;
+
+const healthState = (passRate?: number | null) => {
+  if (passRate == null) {
+    return {
+      label: '暂无质量执行数据',
+      className: 'text-[#92969f]',
+      icon: null,
+    };
+  }
+  if (passRate >= 95) {
+    return {
+      label: '整体质量健康',
+      className: 'text-[#3c9766]',
+      icon: <CheckCircle2 size={13} strokeWidth={2} />,
+    };
+  }
+  if (passRate >= 80) {
+    return {
+      label: '质量表现需关注',
+      className: 'text-[#c4842c]',
+      icon: <AlertTriangle size={13} strokeWidth={1.9} />,
+    };
+  }
+  return {
+    label: '质量问题较多',
+    className: 'text-[#dc5964]',
+    icon: <AlertTriangle size={13} strokeWidth={1.9} />,
+  };
+};
+
+function useQualityOverview(): QualityOverviewState {
+  const [state, setState] = useState<QualityOverviewState>({
+    loading: true,
+    failed: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+    homeQualityOverviewApi
+      .overview()
+      .then((response) => {
+        if (!active) return;
+        if (!response.data) {
+          setState({ loading: false, failed: true });
+          return;
+        }
+        setState({ data: response.data, loading: false, failed: false });
+      })
+      .catch(() => {
+        if (active) setState({ loading: false, failed: true });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}
+
+function SectionHeader() {
+  return (
+    <header className="flex items-start justify-between gap-4">
+      <div className="min-w-0">
+        <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+          数据质量
+        </h2>
+        <p className="mt-1 text-[12px] leading-5 text-[#92969f]">
+          近 7 日规则执行健康度与最近质量问题
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => history.push('/data-quality/table-config')}
+        className="mt-0.5 flex shrink-0 items-center gap-0.5 border-0 bg-transparent p-0 text-[12px] text-[#747982] transition-colors hover:text-[#252832]"
+      >
+        查看更多
+        <ChevronRight size={14} strokeWidth={1.8} />
+      </button>
+    </header>
+  );
+}
+
+function QualityMetric({
+  label,
+  value,
+  warning = false,
+}: {
+  label: string;
+  value?: number | null;
+  warning?: boolean;
+}) {
+  return (
+    <div>
+      <div className="text-[10px] leading-4 text-[#999da5]">{label}</div>
+      <strong
+        className={`mt-0.5 block text-[18px] font-semibold leading-6 ${
+          warning && (value ?? 0) > 0 ? 'text-[#dc5964]' : 'text-[#40444d]'
+        }`}
+      >
+        {formatMetric(value)}
+      </strong>
+    </div>
+  );
+}
+
+function buildRadarOption(dimensions: HomeQualityDimension[]): EChartsOption {
+  return {
+    animation: true,
+    animationDuration: 650,
+    tooltip: {
+      trigger: 'item',
+      formatter: () =>
+        dimensions
+          .map((item) => `${item.dimension}：${formatRate(item.passRate)}%`)
+          .join('<br/>'),
+    },
+    radar: {
+      center: ['50%', '51%'],
+      radius: '66%',
+      splitNumber: 4,
+      indicator: dimensions.map((item) => ({ name: item.dimension, max: 100 })),
+      axisName: {
+        color: '#7f848d',
+        fontSize: 10,
+      },
+      axisLine: {
+        lineStyle: {
+          color: '#e3e6eb',
+        },
+      },
+      splitLine: {
+        lineStyle: {
+          color: '#e9ebef',
+        },
+      },
+      splitArea: {
+        areaStyle: {
+          color: ['#ffffff', '#fafbfc'],
+        },
+      },
+    },
+    series: [
+      {
+        type: 'radar',
+        symbol: 'circle',
+        symbolSize: 4,
+        data: [
+          {
+            value: dimensions.map((item) => item.passRate ?? 0),
+            name: '规则通过率',
+            lineStyle: {
+              width: 2,
+              color: '#6685ed',
+            },
+            itemStyle: {
+              color: '#6685ed',
+            },
+            areaStyle: {
+              color: 'rgba(102,133,237,0.13)',
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function DimensionBars({ dimensions }: { dimensions: HomeQualityDimension[] }) {
+  return (
+    <div className="flex h-[250px] flex-col justify-center gap-5 px-3">
+      {dimensions.map((item) => (
+        <div key={item.dimension}>
+          <div className="flex items-center justify-between text-[10px]">
+            <span className="text-[#777c85]">{item.dimension}</span>
+            <strong className="font-semibold text-[#4c515a]">
+              {formatRate(item.passRate)}%
+            </strong>
+          </div>
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[#eef0f4]">
+            <div
+              className="h-full rounded-full bg-[#7f94e8] transition-[width] duration-500"
+              style={{ width: `${Math.max(0, Math.min(100, item.passRate ?? 0))}%` }}
+            />
+          </div>
+          <div className="mt-1 text-[9px] text-[#a2a6ae]">
+            {formatMetric(item.total)} 次规则检查 · {formatMetric(item.issues)} 项问题
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DimensionHealth({ state }: { state: QualityOverviewState }) {
+  const dimensions = (state.data?.dimensions || []).filter(
+    (item) => item.passRate != null,
+  );
+  const option = useMemo(() => buildRadarOption(dimensions), [dimensions]);
+
+  if (dimensions.length >= 3) {
+    return (
+      <div className="min-h-[250px]">
+        <ReactECharts
+          option={option}
+          style={{ width: '100%', height: '260px' }}
+        />
+      </div>
+    );
+  }
+
+  if (dimensions.length > 0) {
+    return <DimensionBars dimensions={dimensions} />;
+  }
+
+  return (
+    <div className="flex h-[250px] items-center justify-center text-[11px] text-[#a0a4ac]">
+      {state.loading
+        ? '质量维度加载中...'
+        : state.failed
+          ? '质量维度加载失败'
+          : state.data?.passRate == null
+            ? '近 7 日暂无规则执行数据'
+            : '暂无质量维度数据'}
+    </div>
+  );
+}
+
+function RecentIssueRow({ issue }: { issue: HomeQualityIssue }) {
+  const isError = issue.checkResult?.toUpperCase() === 'ERROR';
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        history.push(
+          `/data-quality/execution/${encodeURIComponent(issue.executionNo)}`,
+        )
+      }
+      className="group flex w-full items-center gap-3 border-0 bg-transparent py-3 text-left"
+    >
+      <span
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] ${
+          isError
+            ? 'bg-[#fff4e8] text-[#d98932]'
+            : 'bg-[#fff2f3] text-[#e35d69]'
+        }`}
+      >
+        <AlertTriangle size={14} strokeWidth={1.8} />
+      </span>
+
+      <span className="min-w-0 flex-1">
+        <strong className="block truncate text-[12px] font-medium text-[#41454e]">
+          {issue.ruleName}
+        </strong>
+        <span className="mt-1 block truncate text-[10px] text-[#9ca0a8]">
+          {objectLabel(issue)} · {issue.dimension}
+          {issue.columnName ? ` · ${issue.columnName}` : ''}
+        </span>
+      </span>
+
+      <span className="shrink-0 text-[10px] text-[#9ca0a8]">
+        {relativeTime(issue.queuedAt)}
+      </span>
+
+      <ChevronRight
+        size={13}
+        strokeWidth={1.8}
+        className="shrink-0 text-[#b8bbc1] transition-transform group-hover:translate-x-0.5"
+      />
+    </button>
+  );
+}
+
+function RecentIssues({ state }: { state: QualityOverviewState }) {
+  const issues = state.data?.recentIssues || [];
+  return (
+    <div className="min-w-0 border-t border-[#eef0f3] pt-4 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
+      <div className="flex items-center justify-between gap-3">
+        <strong className="text-[13px] font-semibold text-[#40444d]">
+          最近问题
+        </strong>
+        <span className="flex shrink-0 items-center gap-1 text-[10px] text-[#a0a4ac]">
+          <AlertTriangle
+            size={11}
+            strokeWidth={1.8}
+            className="text-[#e46a73]"
+          />
+          {formatMetric(state.data?.recentIssueCount)} 项近 7 日问题
+        </span>
+      </div>
+
+      {issues.length > 0 ? (
+        <div className="mt-3 divide-y divide-[#f0f1f3]">
+          {issues.map((issue) => (
+            <RecentIssueRow key={issue.id} issue={issue} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex min-h-[190px] items-center justify-center text-[10px] text-[#a0a4ac]">
+          {state.loading
+            ? '质量问题加载中...'
+            : state.failed
+              ? '质量数据加载失败'
+              : state.data?.recentIssueCount == null
+                ? '质量数据暂不可用'
+                : '近 7 日暂无质量问题'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function QualityOverview() {
+  const state = useQualityOverview();
+  const data = state.data;
+  const health = healthState(data?.passRate);
+
+  return (
+    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <SectionHeader />
+
+      <div className="mt-4 grid min-h-[300px] grid-cols-1 gap-5 lg:grid-cols-[180px_250px_minmax(0,1fr)]">
+        <div className="flex flex-col justify-center">
+          <div className="text-[11px] font-medium text-[#8f949d]">
+            近 7 日规则通过率
+          </div>
+
+          <div className="mt-1 flex items-end gap-1">
+            <strong className="text-[42px] font-semibold leading-[48px] tracking-[-1.5px] text-[#2f333c]">
+              {formatRate(data?.passRate)}
+            </strong>
+            {data?.passRate != null ? (
+              <span className="mb-1.5 text-[12px] text-[#9ca0a8]">%</span>
+            ) : null}
+          </div>
+
+          <div
+            className={`mt-1 flex items-center gap-1.5 text-[11px] font-medium ${health.className}`}
+          >
+            {health.icon}
+            {state.loading
+              ? '质量数据加载中...'
+              : state.failed
+                ? '质量数据加载失败'
+                : health.label}
+          </div>
+
+          <div className="mt-6 grid grid-cols-2 gap-x-5 gap-y-4">
+            <QualityMetric label="监控表" value={data?.monitoredTableCount} />
+            <QualityMetric label="今日检测" value={data?.todayExecutionCount} />
+            <QualityMetric
+              label="问题表"
+              value={data?.todayIssueTableCount}
+              warning
+            />
+            <QualityMetric label="启用规则" value={data?.enabledRuleCount} />
+          </div>
+        </div>
+
+        <DimensionHealth state={state} />
+        <RecentIssues state={state} />
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
@@ -2,25 +2,23 @@ import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
 import ReactECharts from 'echarts-for-react';
 import {
-  AlertTriangle,
-  CheckCircle2,
   ChevronRight,
   Clock3,
   LayoutDashboard,
   Sparkles,
 } from 'lucide-react';
-import type { ReactNode } from 'react';
 
 import {
   DataLineageOverview,
   DatasetOverview,
   useHomeAssetOverview,
 } from './HomeAssetOverview';
+import QualityOverview from './HomeQualityOverview';
 
 /**
  * 首页业务总览。
  *
- * 数据集与血缘已接入真实统计；其他模块仍按后续阶段逐步替换 mock。
+ * 数据集、血缘与数据质量已接入真实统计；数据服务和仪表盘继续按后续阶段替换 mock。
  */
 
 interface SectionHeaderProps {
@@ -59,218 +57,6 @@ function SectionHeader({
         </button>
       ) : null}
     </header>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* 数据质量                                                                   */
-/* -------------------------------------------------------------------------- */
-
-const qualityRadarOption: EChartsOption = {
-  animation: true,
-  animationDuration: 760,
-  tooltip: {
-    trigger: 'item',
-  },
-  radar: {
-    center: ['50%', '51%'],
-    radius: '67%',
-    splitNumber: 4,
-    indicator: [
-      { name: '完整性', max: 100 },
-      { name: '唯一性', max: 100 },
-      { name: '一致性', max: 100 },
-      { name: '准确性', max: 100 },
-      { name: '及时性', max: 100 },
-    ],
-    axisName: {
-      color: '#7f848d',
-      fontSize: 11,
-    },
-    axisLine: {
-      lineStyle: {
-        color: '#e3e6eb',
-      },
-    },
-    splitLine: {
-      lineStyle: {
-        color: '#e9ebef',
-      },
-    },
-    splitArea: {
-      areaStyle: {
-        color: ['#ffffff', '#fafbfc'],
-      },
-    },
-  },
-  series: [
-    {
-      type: 'radar',
-      symbol: 'circle',
-      symbolSize: 4,
-      data: [
-        {
-          value: [98, 95, 93, 97, 91],
-          name: '质量评分',
-          lineStyle: {
-            width: 2,
-            color: '#6685ed',
-          },
-          itemStyle: {
-            color: '#6685ed',
-          },
-          areaStyle: {
-            color: 'rgba(102,133,237,0.13)',
-          },
-        },
-      ],
-    },
-  ],
-};
-
-const qualityIssues = [
-  {
-    table: 'ods_user_profile',
-    issue: '手机号字段完整性异常',
-    time: '10:24',
-  },
-  {
-    table: 'dwd_order_detail',
-    issue: '订单编号唯一性异常',
-    time: '09:42',
-  },
-  {
-    table: 'dws_goods_sale',
-    issue: '销售金额一致性异常',
-    time: '08:17',
-  },
-];
-
-function QualityOverview() {
-  return (
-    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
-      <SectionHeader
-        title="数据质量"
-        description="关注质量健康度与需要处理的异常"
-        onMore={() => history.push('/data-quality/table-config')}
-      />
-
-      <div className="mt-4 grid min-h-[300px] grid-cols-1 gap-5 lg:grid-cols-[180px_250px_minmax(0,1fr)]">
-        <div className="flex flex-col justify-center">
-          <div className="text-[11px] font-medium text-[#8f949d]">
-            综合质量分
-          </div>
-
-          <div className="mt-1 flex items-end gap-1">
-            <strong className="text-[42px] font-semibold leading-[48px] tracking-[-1.5px] text-[#2f333c]">
-              96.8
-            </strong>
-
-            <span className="mb-1.5 text-[12px] text-[#9ca0a8]">
-              /100
-            </span>
-          </div>
-
-          <div className="mt-1 flex items-center gap-1.5 text-[11px] font-medium text-[#3c9766]">
-            <CheckCircle2 size={13} strokeWidth={2} />
-            整体质量健康
-          </div>
-
-          <div className="mt-6 grid grid-cols-2 gap-x-5 gap-y-4">
-            <QualityMetric label="监控表" value="38" />
-            <QualityMetric label="今日检测" value="126" />
-            <QualityMetric label="异常表" value="3" warning />
-            <QualityMetric label="规则" value="84" />
-          </div>
-        </div>
-
-        <div className="min-h-[250px]">
-          <ReactECharts
-            option={qualityRadarOption}
-            style={{
-              width: '100%',
-              height: '260px',
-            }}
-          />
-        </div>
-
-        <div className="min-w-0 border-t border-[#eef0f3] pt-4 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
-          <div className="flex items-center justify-between">
-            <strong className="text-[13px] font-semibold text-[#40444d]">
-              最近异常
-            </strong>
-
-            <span className="flex items-center gap-1 text-[10px] text-[#a0a4ac]">
-              <AlertTriangle
-                size={11}
-                strokeWidth={1.8}
-                className="text-[#e46a73]"
-              />
-              3 项待关注
-            </span>
-          </div>
-
-          <div className="mt-3 divide-y divide-[#f0f1f3]">
-            {qualityIssues.map((item) => (
-              <button
-                key={`${item.table}-${item.issue}`}
-                type="button"
-                onClick={() => history.push('/data-quality/execution')}
-                className="group flex w-full items-center gap-3 border-0 bg-transparent py-3 text-left"
-              >
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#fff2f3] text-[#e35d69]">
-                  <AlertTriangle size={14} strokeWidth={1.8} />
-                </span>
-
-                <span className="min-w-0 flex-1">
-                  <strong className="block truncate text-[12px] font-medium text-[#41454e]">
-                    {item.issue}
-                  </strong>
-
-                  <span className="mt-1 block truncate text-[10px] text-[#9ca0a8]">
-                    {item.table}
-                  </span>
-                </span>
-
-                <span className="shrink-0 text-[10px] text-[#9ca0a8]">
-                  {item.time}
-                </span>
-
-                <ChevronRight
-                  size={13}
-                  strokeWidth={1.8}
-                  className="shrink-0 text-[#b8bbc1] transition-transform group-hover:translate-x-0.5"
-                />
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function QualityMetric({
-  label,
-  value,
-  warning = false,
-}: {
-  label: string;
-  value: string;
-  warning?: boolean;
-}) {
-  return (
-    <div>
-      <div className="text-[10px] leading-4 text-[#999da5]">{label}</div>
-
-      <strong
-        className={`mt-0.5 block text-[18px] font-semibold leading-6 ${
-          warning ? 'text-[#dc5964]' : 'text-[#40444d]'
-        }`}
-      >
-        {value}
-      </strong>
-    </div>
   );
 }
 
@@ -603,7 +389,7 @@ export default function HomeWorkbench() {
 
       <div className="flex items-center justify-center gap-2 py-2 text-[10px] text-[#aaadb4]">
         <Sparkles size={11} strokeWidth={1.8} />
-        数据集与血缘已接入真实数据，其余总览将在后续阶段逐步接入
+        数据集、血缘与数据质量已接入真实数据，数据服务和仪表盘将在后续阶段接入
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/home/service.ts
+++ b/yak-ops-ui/src/pages/home/service.ts
@@ -137,8 +137,43 @@ export interface HomeAssetOverview {
   lineage: HomeAssetLineageOverview;
 }
 
+export interface HomeQualityDimension {
+  dimension: string;
+  total: number;
+  issues: number;
+  passRate: number | null;
+}
+
+export interface HomeQualityIssue {
+  id: string;
+  executionNo: string;
+  monitorId: string;
+  monitorName: string;
+  objectName?: string | null;
+  tableName?: string | null;
+  ruleName: string;
+  dimension: string;
+  columnName?: string | null;
+  checkResult: string;
+  queuedAt?: string | null;
+}
+
+export interface HomeQualityOverview {
+  rangeStart?: string | null;
+  rangeEnd?: string | null;
+  passRate: number | null;
+  monitoredTableCount: number | null;
+  enabledRuleCount: number | null;
+  todayExecutionCount: number | null;
+  todayIssueTableCount: number | null;
+  recentIssueCount: number | null;
+  dimensions: HomeQualityDimension[];
+  recentIssues: HomeQualityIssue[];
+}
+
 const PREFIX = '/api/v1/home/data-center';
 const ASSET_PREFIX = '/api/v1/home/assets';
+const QUALITY_PREFIX = '/api/v1/home/quality';
 
 export const homeDataCenterApi = {
   overview: (
@@ -160,4 +195,9 @@ export const homeDataCenterApi = {
 export const homeAssetOverviewApi = {
   overview: (): Promise<ApiResponse<HomeAssetOverview>> =>
     HttpUtils.get<HomeAssetOverview>(`${ASSET_PREFIX}/overview`),
+};
+
+export const homeQualityOverviewApi = {
+  overview: (): Promise<ApiResponse<HomeQualityOverview>> =>
+    HttpUtils.get<HomeQualityOverview>(`${QUALITY_PREFIX}/overview`),
 };


### PR DESCRIPTION
## 背景

首页真实数据改造 Stage 5：将“数据质量”总览从前端 Mock 切换为真实质量执行数据。数据集与血缘已经在 Stage 4 接入真实数据；本 PR 不处理数据服务和仪表盘。

## 本次改动

### 首页数据质量总览

原来的 `96.8`、固定五维雷达图、`38 / 126 / 3 / 84` 和三条异常记录全部删除，改为真实统计：

- **近 7 日规则通过率**：`PASSED / (PASSED + NOT_PASSED + ERROR)`；没有实际执行规则时返回 `null`，前端展示 `--`
- **监控表**：当前启用且未删除的质量监控所覆盖的物理表去重数
- **今日检测**：当天 `[00:00, 次日 00:00)` 内产生的质量执行次数
- **问题表**：当天检查结果为 `NOT_PASSED / ERROR` 的监控表去重数
- **启用规则**：启用监控下启用且未删除的质量规则数
- **近 7 日问题数**：近 7 日真实 `NOT_PASSED / ERROR` 规则执行数量

### 质量维度

雷达图不再固定伪造“完整性 / 唯一性 / 一致性 / 准确性 / 及时性”五个值，而是按实际规则执行记录动态聚合当前存在的质量维度。

- 3 个及以上真实维度：展示 ECharts 雷达图
- 1～2 个真实维度：展示通过率进度条
- 没有执行证据：展示空状态，不补 0、不制造维度

维度来源优先使用规则的 `quality_dimension`；历史规则无法关联时，按稳定 `rule_type` 映射到完整性、唯一性、有效性、准确性、自定义等已有领域维度。

### 最近问题

首页展示近 7 日最近 3 条真实规则问题，包括：

- 规则名称
- 监控对象 / 数据表
- 质量维度 / 字段
- `NOT_PASSED` 或 `ERROR`
- 发生时间

点击后跳转到对应质量执行详情。

## 后端实现

新增只读链路：

```text
HomeQualityOverviewController
  -> HomeQualityOverviewService
  -> QualityOverviewReader
  -> QualityOverviewRepository
  -> QualityAnalyticsDao
  -> QualityOverviewMapper
  -> quality tables
```

新增接口：

```text
GET /api/v1/home/quality/overview
```

接口要求 `quality:execution:read` 权限，避免首页聚合接口绕过原有质量执行权限。

Quality 模块继续遵守现有角色化架构：新增的是 `workspace/QualityOverviewReader`，没有重新引入通用 `service` package，也没有让 Boot 直接访问 Quality DAO / Mapper / PO。

## 数据语义

- 查询成功且没有业务数据：真实计数返回 `0`
- 近 7 日没有实际规则执行：通过率返回 `null`
- Quality 模块不可用或查询异常：首页接口对应指标返回 `null`，不伪装成 `0`
- 前端对 `null` 使用 `--`，真实 `0` 保持展示为 `0`
- 数据服务与仪表盘的 Mock 本 PR 不改动

## 测试与护栏

新增：

- `QualityOverviewReaderTest`：覆盖真实通过率、维度通过率、最近问题与无执行数据语义
- `HomeQualityOverviewServiceTest`：覆盖正常聚合、模块不可用和查询异常
- `QualityRoleConventionTest`：将 `QualityOverviewReader` 锁定为显式 `@Component` Reader 角色
- `QualityLayeringConventionTest`：保护 `QualityOverviewRepository` 不泄漏 DTO / VO / PO / MyBatis 类型

Stage 5 分支已整理为单提交。PR 创建时 `main` 同步合并了 #759；该变更位于数据源 Maven 依赖，与本 PR 文件范围无重叠，GitHub 当前判定可自动合并。

当前工具执行环境无法联网拉取完整 Maven / npm 依赖，因此没有宣称完整 reactor、`npm run build` 或浏览器 E2E 已通过；建议在正常开发环境或 CI 中继续执行完整构建验证。

## 后续

Stage 6：数据服务真实指标与近 7 日调用趋势。