### PR TITLE
feat(home): 接入数据服务真实指标（Stage 6）

### DIFF
--- a/yak-ops-ui/src/pages/home/HomeDataServiceOverview.tsx
+++ b/yak-ops-ui/src/pages/home/HomeDataServiceOverview.tsx
@@ -1,0 +1,250 @@
+import { history } from '@umijs/max';
+import type { EChartsOption } from 'echarts';
+import ReactECharts from 'echarts-for-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  fetchDataServiceOverview,
+  type DataServiceOverview,
+} from '../data-service/overview/overview-service';
+import { SectionHeader } from './homeAssetOverviewShared';
+
+interface DataServiceOverviewState {
+  data?: DataServiceOverview;
+  loading: boolean;
+  failed: boolean;
+}
+
+const COUNT_FORMATTER = new Intl.NumberFormat('zh-CN');
+
+const formatMetric = (value?: number | null) =>
+  value == null ? '--' : COUNT_FORMATTER.format(value);
+
+const formatRate = (data?: DataServiceOverview) =>
+  !data || data.totalCalls <= 0 ? '--' : `${data.successRate.toFixed(1)}%`;
+
+function useDataServiceOverview(): DataServiceOverviewState {
+  const [state, setState] = useState<DataServiceOverviewState>({
+    loading: true,
+    failed: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+    fetchDataServiceOverview('7d')
+      .then((response) => {
+        if (!active) return;
+        if (!response.data) {
+          setState({ loading: false, failed: true });
+          return;
+        }
+        setState({ data: response.data, loading: false, failed: false });
+      })
+      .catch(() => {
+        if (active) setState({ loading: false, failed: true });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}
+
+function buildTrendOption(data?: DataServiceOverview): EChartsOption {
+  const trend = data?.trend || [];
+  return {
+    animation: true,
+    animationDuration: 520,
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: '#fff',
+      borderColor: '#e8ebef',
+      textStyle: {
+        color: '#4b5059',
+        fontSize: 10,
+      },
+    },
+    grid: {
+      top: 10,
+      left: 8,
+      right: 8,
+      bottom: 22,
+      containLabel: false,
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: trend.map((item) => item.time),
+      axisLine: {
+        show: false,
+      },
+      axisTick: {
+        show: false,
+      },
+      axisLabel: {
+        interval: 3,
+        color: '#a0a4ac',
+        fontSize: 9,
+        formatter: (value: string) => value.slice(0, 5),
+      },
+    },
+    yAxis: {
+      type: 'value',
+      minInterval: 1,
+      axisLine: {
+        show: false,
+      },
+      axisTick: {
+        show: false,
+      },
+      axisLabel: {
+        show: false,
+      },
+      splitLine: {
+        lineStyle: {
+          color: '#f1f3f6',
+        },
+      },
+    },
+    series: [
+      {
+        name: '调用量',
+        type: 'line',
+        smooth: 0.38,
+        symbol: 'none',
+        data: trend.map((item) => item.calls),
+        lineStyle: {
+          width: 2,
+          color: '#6490ee',
+        },
+        areaStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              {
+                offset: 0,
+                color: 'rgba(100,144,238,0.18)',
+              },
+              {
+                offset: 1,
+                color: 'rgba(100,144,238,0.01)',
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}
+
+function OverviewMetric({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="min-w-0 px-4 first:pl-0 last:pr-0">
+      <div className="truncate text-[11px] text-[#92969f]">{label}</div>
+      <strong className="mt-1 block truncate text-[24px] font-semibold tracking-[-0.6px] text-[#30343d]">
+        {value}
+      </strong>
+    </div>
+  );
+}
+
+function TrendEmpty({ state }: { state: DataServiceOverviewState }) {
+  const text = state.loading
+    ? '数据加载中...'
+    : state.failed
+      ? '数据服务概览加载失败'
+      : '近 7 日暂无 API 调用';
+  return (
+    <div className="flex h-[126px] items-center justify-center text-[11px] text-[#a0a4ac]">
+      {text}
+    </div>
+  );
+}
+
+export default function HomeDataServiceOverview() {
+  const state = useDataServiceOverview();
+  const data = state.data;
+  const trendOption = useMemo(() => buildTrendOption(data), [data]);
+  const hasCalls = (data?.totalCalls || 0) > 0;
+  const topApi = data?.hotApis?.[0];
+
+  return (
+    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <SectionHeader
+        title="数据服务"
+        description="近 7 日真实 API 调用与运行状态"
+        onMore={() => history.push('/data-service/overview')}
+      />
+
+      <div className="mt-5">
+        <div className="grid grid-cols-2 divide-x divide-[#eef0f3] lg:grid-cols-4">
+          <OverviewMetric label="API 总数" value={formatMetric(data?.apiTotal)} />
+          <OverviewMetric label="运行中" value={formatMetric(data?.runningApis)} />
+          <OverviewMetric label="近 7 日调用" value={formatMetric(data?.totalCalls)} />
+          <OverviewMetric label="成功率" value={formatRate(data)} />
+        </div>
+
+        <div className="mt-5 flex items-center justify-between gap-3 text-[10px] text-[#9da1a9]">
+          <span>调用趋势</span>
+          {data ? (
+            <span className="truncate text-right">
+              平均耗时 {formatMetric(data.averageDurationMs)} ms · 失败 {formatMetric(data.failureCalls)} 次
+            </span>
+          ) : (
+            <span>{state.failed ? '暂不可用' : '--'}</span>
+          )}
+        </div>
+
+        <div className="mt-1 h-[126px]">
+          {hasCalls ? (
+            <ReactECharts
+              option={trendOption}
+              style={{
+                width: '100%',
+                height: '126px',
+              }}
+              notMerge
+              lazyUpdate
+            />
+          ) : (
+            <TrendEmpty state={state} />
+          )}
+        </div>
+
+        <div className="mt-2 flex min-h-[30px] items-center justify-between gap-3 border-t border-[#f0f1f3] pt-3 text-[10px]">
+          <span className="shrink-0 text-[#9da1a9]">调用最多</span>
+          {topApi ? (
+            <button
+              type="button"
+              onClick={() => history.push('/data-service/overview')}
+              className="min-w-0 border-0 bg-transparent p-0 text-right text-[#646a74] transition-colors hover:text-[#343842]"
+            >
+              <span className="block truncate">
+                {topApi.name || topApi.path || `API #${topApi.apiId}`}
+                <strong className="ml-1 font-semibold text-[#454a54]">
+                  {formatMetric(topApi.calls)} 次
+                </strong>
+              </span>
+            </button>
+          ) : (
+            <span className="truncate text-right text-[#a0a4ac]">
+              {state.loading ? '加载中...' : state.failed ? '暂不可用' : '暂无调用'}
+            </span>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
@@ -1,6 +1,4 @@
 import { history } from '@umijs/max';
-import type { EChartsOption } from 'echarts';
-import ReactECharts from 'echarts-for-react';
 import {
   ChevronRight,
   Clock3,
@@ -13,12 +11,13 @@ import {
   DatasetOverview,
   useHomeAssetOverview,
 } from './HomeAssetOverview';
+import HomeDataServiceOverview from './HomeDataServiceOverview';
 import QualityOverview from './HomeQualityOverview';
 
 /**
  * 首页业务总览。
  *
- * 数据集、血缘与数据质量已接入真实统计；数据服务和仪表盘继续按后续阶段替换 mock。
+ * 数据集、血缘、数据质量与数据服务已接入真实统计；仪表盘继续按后续阶段替换 mock。
  */
 
 interface SectionHeaderProps {
@@ -57,131 +56,6 @@ function SectionHeader({
         </button>
       ) : null}
     </header>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* 数据服务                                                                   */
-/* -------------------------------------------------------------------------- */
-
-const serviceTrendOption: EChartsOption = {
-  animation: true,
-  animationDuration: 720,
-  grid: {
-    top: 12,
-    left: 8,
-    right: 8,
-    bottom: 20,
-    containLabel: false,
-  },
-  tooltip: {
-    trigger: 'axis',
-  },
-  xAxis: {
-    type: 'category',
-    boundaryGap: false,
-    data: ['08-20', '08-21', '08-22', '08-23', '08-24', '08-25', '08-26'],
-    axisLine: {
-      show: false,
-    },
-    axisTick: {
-      show: false,
-    },
-    axisLabel: {
-      color: '#a0a4ac',
-      fontSize: 9,
-    },
-  },
-  yAxis: {
-    type: 'value',
-    show: false,
-  },
-  series: [
-    {
-      name: '调用量',
-      type: 'line',
-      smooth: 0.42,
-      symbol: 'none',
-      data: [9800, 11420, 10860, 13600, 12180, 14920, 12860],
-      lineStyle: {
-        width: 2,
-        color: '#6490ee',
-      },
-      areaStyle: {
-        color: {
-          type: 'linear',
-          x: 0,
-          y: 0,
-          x2: 0,
-          y2: 1,
-          colorStops: [
-            {
-              offset: 0,
-              color: 'rgba(100,144,238,0.18)',
-            },
-            {
-              offset: 1,
-              color: 'rgba(100,144,238,0.01)',
-            },
-          ],
-        },
-      },
-    },
-  ],
-};
-
-const serviceMetrics = [
-  {
-    label: 'API 总数',
-    value: '32',
-  },
-  {
-    label: '已发布',
-    value: '26',
-  },
-  {
-    label: '今日调用',
-    value: '12,860',
-  },
-  {
-    label: '成功率',
-    value: '99.2%',
-  },
-];
-
-function DataServiceOverview() {
-  return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
-      <SectionHeader
-        title="数据服务"
-        description="近 7 日 API 服务运行情况"
-        onMore={() => history.push('/data-service/overview')}
-      />
-
-      <div className="mt-5">
-        <div className="grid grid-cols-2 divide-x divide-[#eef0f3] lg:grid-cols-4">
-          {serviceMetrics.map((item) => (
-            <div key={item.label} className="px-4 first:pl-0 last:pr-0">
-              <div className="text-[11px] text-[#92969f]">{item.label}</div>
-
-              <strong className="mt-1 block text-[24px] font-semibold tracking-[-0.6px] text-[#30343d]">
-                {item.value}
-              </strong>
-            </div>
-          ))}
-        </div>
-
-        <div className="mt-5 h-[126px]">
-          <ReactECharts
-            option={serviceTrendOption}
-            style={{
-              width: '100%',
-              height: '126px',
-            }}
-          />
-        </div>
-      </div>
-    </section>
   );
 }
 
@@ -380,7 +254,7 @@ export default function HomeWorkbench() {
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.32fr)_minmax(400px,0.68fr)]">
         <QualityOverview />
-        <DataServiceOverview />
+        <HomeDataServiceOverview />
       </div>
 
       <DataLineageOverview state={assetOverviewState} />
@@ -389,7 +263,7 @@ export default function HomeWorkbench() {
 
       <div className="flex items-center justify-center gap-2 py-2 text-[10px] text-[#aaadb4]">
         <Sparkles size={11} strokeWidth={1.8} />
-        数据集、血缘与数据质量已接入真实数据，数据服务和仪表盘将在后续阶段接入
+        数据集、血缘、数据质量与数据服务已接入真实数据，仪表盘将在后续阶段接入
       </div>
     </div>
   );


### PR DESCRIPTION
## 背景

首页真实数据改造 Stage 6：将“数据服务”总览从前端 Mock 切换为现有 Data Service 可观测数据。Stage 4 的数据集/血缘和 Stage 5 的数据质量已经接入真实数据；本 PR 不处理仪表盘。

## 本次改动

### 数据服务真实指标

删除首页原有固定值：

```text
API 总数 32
已发布 26
今日调用 12,860
成功率 99.2%
```

改为直接复用现有数据服务运行概览：

```text
GET /api/v1/data-service/overview?range=7d
```

首页展示：

- **API 总数**：当前 Data Service Definition 数量
- **运行中**：`settings.enabled = true` 的数据服务数量
- **近 7 日调用**：近 7 日真实调用日志数量
- **成功率**：近 7 日真实成功调用占比；没有调用时首页展示 `--`
- **调用趋势**：使用后端真实 7d trend bucket，不在前端制造趋势数据
- **平均耗时 / 失败次数**：来自同一真实运行概览
- **调用最多 API**：使用现有 `hotApis` 第一名

### 为什么调整两个文案

原 Mock 卡片中的“已发布”和“今日调用”没有对应到首页当前可直接复用的精确统计口径，因此没有继续保留旧标签：

- “已发布”调整为领域中可证明的 **运行中**（enabled runtime state）
- “今日调用”调整为与当前请求范围一致的 **近 7 日调用**

不使用近 24 小时冒充自然日，也不额外扫描/推断数据来填满旧设计。

## 数据来源

本阶段不新增后端接口，因为现有 Data Service 已经有完整真实读链路：

```text
DataServiceOverviewController
  -> DataServiceOverviewReader
      -> DataServiceReader.list()
      -> DataServiceCallLogRepository.between(start, end)
```

现有 `DataServiceOverviewReader` 已返回：

- apiTotal / runningApis / stoppedApis
- totalCalls / successCalls / failureCalls / successRate
- averageDurationMs / totalRows
- trend
- hotApis
- recentFailures

因此 Stage 6 直接复用业务模块自己的真实 contract，不再复制一套 Home 后端聚合逻辑。

## 前端行为

新增 `HomeDataServiceOverview.tsx`：

- 加载 `7d` 真实运行概览
- 请求失败时指标显示 `--`，首页不白屏
- 真实值为 `0` 时继续显示 `0`
- 无调用数据时成功率展示 `--`，趋势区域展示空状态
- 趋势图直接消费后端 6 小时 bucket；横轴只稀疏显示日期标签，不改变真实数据点
- 保留“查看更多”进入现有 `/data-service/overview`

`HomeWorkbench.tsx` 删除 Data Service Mock 常量和固定 ECharts 数据，改为独立真实组件。

## 变更范围

本 PR 为 frontend-only：

- `yak-ops-ui/src/pages/home/HomeDataServiceOverview.tsx`（新增）
- `yak-ops-ui/src/pages/home/HomeWorkbench.tsx`

未修改 Data Service 后端、数据库、Flyway、调用日志写入或运行概览接口。

## 验证

- 分支基于已合并 Stage 5 的最新 `main`
- compare：1 commit / 2 frontend files / behind 0
- 已核对 `DataServiceOverviewReader` 使用 `DataServiceReader.list()` 与 `DataServiceCallLogRepository.between(...)` 真实数据源
- 已核对现有数据服务运行概览页面使用同一 API contract
- 首页 Data Service 区域不再包含固定业务 Mock 数值

当前工具执行环境没有完整本地 npm 依赖环境，因此未宣称 `npm run lint`、`npm run build` 或浏览器 E2E 已通过；请以正常开发环境/CI 为最终构建验证。

## 后续

Stage 7：仪表盘 / 数字大屏真实总览。