### PR TITLE
feat(home): 接入可视化真实指标（Stage 7）

### DIFF
--- a/yak-ops-ui/src/pages/home/HomeVisualizationOverview.tsx
+++ b/yak-ops-ui/src/pages/home/HomeVisualizationOverview.tsx
@@ -1,0 +1,294 @@
+import { history } from '@umijs/max';
+import {
+  Clock3,
+  LayoutDashboard,
+  Monitor,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { fetchDashboards } from '../dashboard/dashboard-service';
+import type { DashboardSummary } from '../dashboard/model';
+import type { DigitalScreenInstance } from '../digital-screen/model';
+import { fetchDigitalScreens } from '../digital-screen/screen-service';
+import {
+  formatMetric,
+  relativeTime,
+  SectionHeader,
+} from './homeAssetOverviewShared';
+
+interface VisualizationState {
+  dashboards?: DashboardSummary[];
+  screens?: DigitalScreenInstance[];
+  dashboardLoading: boolean;
+  screenLoading: boolean;
+  dashboardFailed: boolean;
+  screenFailed: boolean;
+}
+
+type VisualizationKind = 'dashboard' | 'screen';
+
+interface VisualizationItem {
+  id: string;
+  kind: VisualizationKind;
+  name: string;
+  description: string;
+  updatedAt?: string;
+  status: 'published' | 'draft' | 'changed';
+  statusLabel: string;
+  path: string;
+}
+
+const timestamp = (value?: string) => {
+  if (!value) return 0;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const dashboardItem = (value: DashboardSummary): VisualizationItem => {
+  const published = Boolean(value.publishedVersionId);
+  const hasUnpublishedChanges = published
+    && value.currentVersionNo > value.publishedVersionNo;
+  return {
+    id: value.id,
+    kind: 'dashboard',
+    name: value.name,
+    description: value.description || `Dashboard · v${value.currentVersionNo}`,
+    updatedAt: value.updateTime || value.publishedTime || value.createTime,
+    status: hasUnpublishedChanges ? 'changed' : published ? 'published' : 'draft',
+    statusLabel: hasUnpublishedChanges ? '有未发布更新' : published ? '已发布' : '草稿',
+    path: published && !hasUnpublishedChanges
+      ? `/dashboard/${value.id}`
+      : `/dashboard/${value.id}/edit`,
+  };
+};
+
+const screenItem = (value: DigitalScreenInstance): VisualizationItem => ({
+  id: value.id,
+  kind: 'screen',
+  name: value.name,
+  description: value.description || `数字大屏 · ${value.templateId}`,
+  updatedAt: value.updatedAt || value.publishedAt || value.createdAt,
+  status: value.status === 'published' ? 'published' : 'draft',
+  statusLabel: value.status === 'published' ? '已发布' : '草稿',
+  path: value.status === 'published'
+    ? `/digital-screen/${value.id}`
+    : `/digital-screen/${value.id}/edit`,
+});
+
+const statusClassName = (status: VisualizationItem['status']) => {
+  if (status === 'published') return 'bg-[#eef8f2] text-[#43815f]';
+  if (status === 'changed') return 'bg-[#fff7e9] text-[#a46d25]';
+  return 'bg-[#f3f4f6] text-[#7d828b]';
+};
+
+function useVisualizationOverview(): VisualizationState {
+  const [state, setState] = useState<VisualizationState>({
+    dashboardLoading: true,
+    screenLoading: true,
+    dashboardFailed: false,
+    screenFailed: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    fetchDashboards()
+      .then((dashboards) => {
+        if (!active) return;
+        setState((current) => ({
+          ...current,
+          dashboards,
+          dashboardLoading: false,
+          dashboardFailed: false,
+        }));
+      })
+      .catch(() => {
+        if (!active) return;
+        setState((current) => ({
+          ...current,
+          dashboardLoading: false,
+          dashboardFailed: true,
+        }));
+      });
+
+    fetchDigitalScreens()
+      .then((screens) => {
+        if (!active) return;
+        setState((current) => ({
+          ...current,
+          screens,
+          screenLoading: false,
+          screenFailed: false,
+        }));
+      })
+      .catch(() => {
+        if (!active) return;
+        setState((current) => ({
+          ...current,
+          screenLoading: false,
+          screenFailed: true,
+        }));
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}
+
+function OverviewMetric({
+  label,
+  value,
+  route,
+}: {
+  label: string;
+  value?: number;
+  route: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => history.push(route)}
+      className="group min-w-0 border-0 bg-transparent px-4 py-1 text-left first:pl-0 last:pr-0"
+    >
+      <div className="truncate text-[11px] text-[#92969f] transition-colors group-hover:text-[#6d737d]">
+        {label}
+      </div>
+      <strong className="mt-1 block truncate text-[24px] font-semibold tracking-[-0.6px] text-[#30343d]">
+        {formatMetric(value)}
+      </strong>
+    </button>
+  );
+}
+
+function VisualizationPreview({ kind }: { kind: VisualizationKind }) {
+  const Icon = kind === 'dashboard' ? LayoutDashboard : Monitor;
+  return (
+    <div className="relative flex h-[112px] items-center justify-center overflow-hidden bg-[linear-gradient(145deg,#f4f6fb_0%,#edf1f8_100%)]">
+      <div className="absolute inset-3 rounded-[10px] border border-white/90 bg-white/55 shadow-[0_5px_18px_rgba(31,35,41,0.04)]" />
+      <div className="relative z-10 flex flex-col items-center gap-2 text-[#7783ad]">
+        <span className="flex h-10 w-10 items-center justify-center rounded-[11px] bg-white/85 shadow-sm">
+          <Icon size={19} strokeWidth={1.7} />
+        </span>
+        <span className="text-[9px] font-medium tracking-[0.08em] text-[#9aa1b6]">
+          {kind === 'dashboard' ? 'DASHBOARD' : 'DIGITAL SCREEN'}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function VisualizationCard({ item }: { item: VisualizationItem }) {
+  return (
+    <button
+      type="button"
+      onClick={() => history.push(item.path)}
+      className="group overflow-hidden rounded-[14px] border border-[#eceef2] bg-white text-left transition-[box-shadow,transform,border-color] duration-200 hover:-translate-y-0.5 hover:border-[#dfe2e8] hover:shadow-[0_10px_28px_rgba(31,35,41,0.075)]"
+    >
+      <VisualizationPreview kind={item.kind} />
+
+      <div className="px-4 pb-4 pt-3.5">
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <strong className="block truncate text-[13px] font-semibold text-[#373b44]">
+              {item.name}
+            </strong>
+            <p className="mt-1 truncate text-[10px] text-[#92969f]">
+              {item.description}
+            </p>
+          </div>
+          <span className={`shrink-0 rounded-full px-2 py-0.5 text-[9px] ${statusClassName(item.status)}`}>
+            {item.statusLabel}
+          </span>
+        </div>
+
+        <div className="mt-3 flex items-center justify-between gap-2 text-[10px] text-[#a0a4ac]">
+          <span>{item.kind === 'dashboard' ? '仪表盘' : '数字大屏'}</span>
+          <span className="flex min-w-0 items-center gap-1">
+            <Clock3 size={11} strokeWidth={1.8} />
+            <span className="truncate">{relativeTime(item.updatedAt)}</span>
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export default function HomeVisualizationOverview() {
+  const state = useVisualizationOverview();
+  const dashboards = state.dashboards;
+  const screens = state.screens;
+
+  const publishedDashboards = dashboards?.filter((item) => item.publishedVersionId).length;
+  const publishedScreens = screens?.filter((item) => item.status === 'published').length;
+
+  const recentItems = useMemo(() => {
+    const items = [
+      ...(dashboards || []).map(dashboardItem),
+      ...(screens || []).map(screenItem),
+    ];
+    return items
+      .sort((left, right) => timestamp(right.updatedAt) - timestamp(left.updatedAt))
+      .slice(0, 4);
+  }, [dashboards, screens]);
+
+  const loading = state.dashboardLoading || state.screenLoading;
+  const allFailed = state.dashboardFailed && state.screenFailed;
+
+  return (
+    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-6 pt-5">
+      <SectionHeader
+        title="可视化"
+        description="仪表盘与数字大屏的发布状态和最近更新"
+      />
+
+      <div className="mt-5 grid grid-cols-2 divide-x divide-[#eef0f3] lg:grid-cols-4">
+        <OverviewMetric
+          label="仪表盘"
+          value={state.dashboardFailed ? undefined : dashboards?.length}
+          route="/dashboard"
+        />
+        <OverviewMetric
+          label="已发布仪表盘"
+          value={state.dashboardFailed ? undefined : publishedDashboards}
+          route="/dashboard"
+        />
+        <OverviewMetric
+          label="数字大屏"
+          value={state.screenFailed ? undefined : screens?.length}
+          route="/digital-screen"
+        />
+        <OverviewMetric
+          label="已发布大屏"
+          value={state.screenFailed ? undefined : publishedScreens}
+          route="/digital-screen"
+        />
+      </div>
+
+      <div className="mt-6 flex items-center justify-between border-t border-[#f0f1f3] pt-4">
+        <strong className="text-[12px] font-semibold text-[#444851]">最近更新</strong>
+        <span className="text-[10px] text-[#9ca0a8]">
+          {state.dashboardFailed || state.screenFailed ? '部分数据暂不可用' : '按更新时间排序'}
+        </span>
+      </div>
+
+      {recentItems.length > 0 ? (
+        <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {recentItems.map((item) => (
+            <VisualizationCard key={`${item.kind}-${item.id}`} item={item} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex min-h-[176px] items-center justify-center text-[11px] text-[#a0a4ac]">
+          {loading
+            ? '可视化数据加载中...'
+            : allFailed
+              ? '可视化数据加载失败'
+              : '暂无仪表盘或数字大屏'}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/HomeWorkbench.tsx
@@ -1,10 +1,4 @@
-import { history } from '@umijs/max';
-import {
-  ChevronRight,
-  Clock3,
-  LayoutDashboard,
-  Sparkles,
-} from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 
 import {
   DataLineageOverview,
@@ -13,238 +7,13 @@ import {
 } from './HomeAssetOverview';
 import HomeDataServiceOverview from './HomeDataServiceOverview';
 import QualityOverview from './HomeQualityOverview';
+import HomeVisualizationOverview from './HomeVisualizationOverview';
 
 /**
  * 首页业务总览。
  *
- * 数据集、血缘、数据质量与数据服务已接入真实统计；仪表盘继续按后续阶段替换 mock。
+ * 数据集、血缘、数据质量、数据服务与可视化均接入当前真实数据源。
  */
-
-interface SectionHeaderProps {
-  title: string;
-  description?: string;
-  onMore?: () => void;
-}
-
-function SectionHeader({
-  title,
-  description,
-  onMore,
-}: SectionHeaderProps) {
-  return (
-    <header className="flex items-start justify-between gap-4">
-      <div className="min-w-0">
-        <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
-          {title}
-        </h2>
-
-        {description ? (
-          <p className="mt-1 text-[12px] leading-5 text-[#92969f]">
-            {description}
-          </p>
-        ) : null}
-      </div>
-
-      {onMore ? (
-        <button
-          type="button"
-          onClick={onMore}
-          className="mt-0.5 flex shrink-0 items-center gap-0.5 border-0 bg-transparent p-0 text-[12px] text-[#747982] transition-colors hover:text-[#252832]"
-        >
-          查看更多
-          <ChevronRight size={14} strokeWidth={1.8} />
-        </button>
-      ) : null}
-    </header>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* 仪表盘                                                                     */
-/* -------------------------------------------------------------------------- */
-
-const dashboardItems = [
-  {
-    id: 'sales',
-    title: '销售经营分析',
-    description: '销售额、订单量、区域与渠道经营分析',
-    time: '20 分钟前更新',
-    type: 'sales',
-  },
-  {
-    id: 'user',
-    title: '用户增长分析',
-    description: '新增用户、活跃度与留存趋势',
-    time: '2 小时前更新',
-    type: 'user',
-  },
-  {
-    id: 'monitor',
-    title: '数据平台运行监控',
-    description: '任务运行、失败率与资源使用情况',
-    time: '今天 08:20 更新',
-    type: 'monitor',
-  },
-];
-
-function DashboardPreview({ type }: { type: string }) {
-  if (type === 'sales') {
-    return (
-      <div className="absolute inset-0 p-4">
-        <div className="grid grid-cols-3 gap-2">
-          {[64, 42, 78].map((width, index) => (
-            <div
-              key={`${width}-${index}`}
-              className="h-7 rounded-[5px] bg-white/80 shadow-sm"
-            >
-              <div className="px-2 pt-1.5">
-                <div className="h-1 w-7 rounded-full bg-[#d4dcf6]" />
-                <div
-                  className="mt-1 h-1.5 rounded-full bg-[#8fa4ea]"
-                  style={{
-                    width: `${width}%`,
-                  }}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="mt-3 flex h-[82px] items-end gap-2 rounded-[7px] bg-white/70 px-3 pb-2 pt-3">
-          {[25, 42, 34, 62, 49, 76, 67, 89, 72, 94].map(
-            (height, index) => (
-              <span
-                key={`${height}-${index}`}
-                className="flex-1 rounded-t-[2px] bg-[#9caee8]"
-                style={{
-                  height: `${height}%`,
-                }}
-              />
-            ),
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  if (type === 'user') {
-    return (
-      <div className="absolute inset-0 p-4">
-        <div className="flex gap-2">
-          <div className="h-9 flex-1 rounded-[6px] bg-white/80 shadow-sm" />
-          <div className="h-9 flex-1 rounded-[6px] bg-white/80 shadow-sm" />
-        </div>
-
-        <svg
-          viewBox="0 0 320 100"
-          className="mt-3 h-[88px] w-full rounded-[8px] bg-white/70"
-          aria-hidden="true"
-        >
-          <path
-            d="M8 78 C38 65 52 72 76 55 C105 35 121 58 149 45 C177 31 195 42 218 25 C244 9 266 37 312 15"
-            fill="none"
-            stroke="#8099e7"
-            strokeWidth="3"
-          />
-
-          <path
-            d="M8 78 C38 65 52 72 76 55 C105 35 121 58 149 45 C177 31 195 42 218 25 C244 9 266 37 312 15 L312 98 L8 98 Z"
-            fill="rgba(128,153,231,0.10)"
-          />
-        </svg>
-      </div>
-    );
-  }
-
-  return (
-    <div className="absolute inset-0 p-4">
-      <div className="grid grid-cols-2 gap-2">
-        <div className="flex h-[48px] items-center gap-2 rounded-[6px] bg-white/80 px-3 shadow-sm">
-          <span className="h-6 w-6 rounded-full border-[5px] border-[#88a0e8] border-r-[#d8def2]" />
-          <span className="h-1.5 flex-1 rounded-full bg-[#d5dbed]" />
-        </div>
-
-        <div className="flex h-[48px] items-end gap-1 rounded-[6px] bg-white/80 px-3 pb-2 pt-2 shadow-sm">
-          {[44, 70, 52, 82, 63].map((height, index) => (
-            <span
-              key={`${height}-${index}`}
-              className="flex-1 rounded-t-sm bg-[#91a5e6]"
-              style={{
-                height: `${height}%`,
-              }}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="mt-3 grid grid-cols-4 gap-2">
-        {[1, 2, 3, 4].map((item) => (
-          <div
-            key={item}
-            className="h-[60px] rounded-[6px] bg-white/75 shadow-sm"
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function DashboardOverview() {
-  return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-6 pt-5">
-      <SectionHeader
-        title="仪表盘"
-        description="最近更新的业务分析与平台监控看板"
-        onMore={() => history.push('/dashboard')}
-      />
-
-      <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {dashboardItems.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => history.push('/dashboard')}
-            className="group overflow-hidden rounded-[14px] border border-[#eceef2] bg-white text-left transition-[box-shadow,transform,border-color] duration-200 hover:-translate-y-0.5 hover:border-[#e0e3e9] hover:shadow-[0_10px_28px_rgba(31,35,41,0.075)]"
-          >
-            <div className="relative h-[164px] overflow-hidden bg-[linear-gradient(145deg,#f4f6fb_0%,#edf1fa_100%)]">
-              <DashboardPreview type={item.type} />
-
-              <div className="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-[8px] border border-white/80 bg-white/85 text-[#6674a8] opacity-0 shadow-sm backdrop-blur transition-opacity group-hover:opacity-100">
-                <ChevronRight size={14} strokeWidth={1.8} />
-              </div>
-            </div>
-
-            <div className="px-4 pb-4 pt-3.5">
-              <div className="flex items-center gap-2">
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] bg-[#f2f4fb] text-[#737fae]">
-                  <LayoutDashboard size={14} strokeWidth={1.8} />
-                </span>
-
-                <strong className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#373b44]">
-                  {item.title}
-                </strong>
-              </div>
-
-              <p className="mt-2 truncate text-[11px] text-[#92969f]">
-                {item.description}
-              </p>
-
-              <div className="mt-3 flex items-center gap-1 text-[10px] text-[#a0a4ac]">
-                <Clock3 size={11} strokeWidth={1.8} />
-                {item.time}
-              </div>
-            </div>
-          </button>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/* 首页                                                                       */
-/* -------------------------------------------------------------------------- */
-
 export default function HomeWorkbench() {
   const assetOverviewState = useHomeAssetOverview();
 
@@ -259,11 +28,11 @@ export default function HomeWorkbench() {
 
       <DataLineageOverview state={assetOverviewState} />
 
-      <DashboardOverview />
+      <HomeVisualizationOverview />
 
       <div className="flex items-center justify-center gap-2 py-2 text-[10px] text-[#aaadb4]">
         <Sparkles size={11} strokeWidth={1.8} />
-        数据集、血缘、数据质量与数据服务已接入真实数据，仪表盘将在后续阶段接入
+        首页业务总览已接入当前真实数据源
       </div>
     </div>
   );


### PR DESCRIPTION
## 背景

首页真实数据改造 Stage 7：将首页最后一块“仪表盘” Mock 总览替换为当前真实的可视化数据，并同时纳入数字大屏。Stage 4～6 的数据集、血缘、数据质量和数据服务已经完成真实数据接入。

## 本次改动

### 1. 仪表盘真实数据

直接复用现有 Dashboard 列表接口：

```text
GET /api/v1/dashboards
```

首页展示：

- 仪表盘总数
- 已发布仪表盘数（`publishedVersionId != null`）
- 最近更新的真实仪表盘
- 当前发布状态：草稿 / 已发布 / 有未发布更新
- 实际名称、描述、更新时间

Dashboard 后端当前已经通过 `DashboardController -> DashboardService -> DashboardReader/Repository` 提供真实列表和发布版本信息，因此本阶段不新增重复的 Home 后端聚合接口。

### 2. 数字大屏真实数据

数字大屏当前产品实现的 source of truth 仍是 `screen-service.ts` 中的浏览器 `localStorage`：

```text
yak-ops:digital-screens:v1
```

首页直接复用 `fetchDigitalScreens()`，与数字大屏列表页读取同一份真实当前数据，展示：

- 数字大屏总数
- 已发布大屏数
- 最近更新的大屏
- 草稿 / 已发布状态
- 名称、描述、模板和更新时间

这里没有为了首页制造一套假的服务器数据，也没有在 Stage 7 顺手把数字大屏整体改造成后端持久化。当前限制是：数字大屏统计仍然是当前浏览器范围内的数据；未来若数字大屏迁移到服务端，只需要替换 `screen-service` 数据源，首页组件不用推翻。

### 3. 最近更新

仪表盘和数字大屏合并成“可视化”总览：

- 按真实 `updateTime / updatedAt` 排序
- 展示最近 4 项
- 仪表盘已发布且无新草稿时进入 Viewer，否则进入 Editor
- 数字大屏已发布时进入 Viewer，否则进入 Editor
- Dashboard 与 Digital Screen 请求相互独立，单侧失败时另一侧仍可展示

### 4. 不展示伪造的“图表数”

当前 Dashboard 列表接口不直接返回 widget/chart 总数。为了统计全局图表数，需要逐个加载 Dashboard 详情，形成不必要的 N+1 请求。

因此 Stage 7 不用其他字段冒充“图表数”，也不为了填满首页强行增加重聚合接口；首页改为展示能够直接证明的“仪表盘总数 / 已发布仪表盘 / 数字大屏 / 已发布大屏”。

## 前端结构

新增：

```text
yak-ops-ui/src/pages/home/HomeVisualizationOverview.tsx
```

`HomeWorkbench.tsx` 删除原来固定的三张 Mock 仪表盘卡片和装饰性假数据，替换为：

```tsx
<HomeVisualizationOverview />
```

卡片中的预览区域仅作为 Dashboard / Digital Screen 类型识别，不展示或暗示不存在的业务数值。

## 数据语义

- 查询成功且没有记录：展示 `0`
- 数据源加载失败：对应指标展示 `--`
- Dashboard 和 Digital Screen 单独失败，互不阻断
- 最近更新列表只使用实际存在的资产，不填充示例资产

## 变更范围

本 PR 为 frontend-only：

- `yak-ops-ui/src/pages/home/HomeVisualizationOverview.tsx`（新增）
- `yak-ops-ui/src/pages/home/HomeWorkbench.tsx`

未修改 Dashboard 后端、数据库、Flyway，也未改变 Digital Screen 当前 localStorage 持久化模型。

## 验证

- 分支基于已合并 Stage 6 的最新 `main`
- compare：1 commit / 2 frontend files / behind 0
- 已核对 Dashboard 列表真实接口及 `publishedVersionId / publishedVersionNo / updateTime` contract
- 已核对 Digital Screen 列表真实使用 `fetchDigitalScreens()` / localStorage
- 首页已删除原三条固定 Dashboard Mock 记录

当前工具执行环境没有完整本地 npm 依赖环境，因此未宣称 `npm run lint`、`npm run build` 或浏览器 E2E 已通过；请以正常开发环境/CI 为最终构建验证。

## 阶段结果

Stage 7 完成后，首页业务总览中的数据集、数据血缘、数据质量、数据服务、仪表盘和数字大屏都已经接入当前各模块真实 source of truth。