### PR TITLE
fix(login): reject failed requests before completing authentication

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -80,11 +80,17 @@ export async function getInitialState(): Promise<{
   syncDocumentLocale();
 
   const fetchUserInfo = async () => toCurrentUser(await getCurrentUser());
-  // Always probe cookie-backed authentication state, including after a reload on login.
+  const onLoginPage = isLoginPath(window.location.pathname);
+
+  // Probe cookie-backed authentication state on every route. The login page uses
+  // a silent probe so an expired session or an unavailable backend does not show
+  // an unrelated current-user notification before the user submits the form.
   let currentUser: API.CurrentUser | undefined;
   let currentUserLoadError = false;
   try {
-    currentUser = await fetchUserInfo();
+    currentUser = onLoginPage
+      ? toCurrentUser(await getCurrentUser({ skipErrorHandler: true }))
+      : await fetchUserInfo();
   } catch (error) {
     currentUserLoadError = true;
 
@@ -92,7 +98,7 @@ export async function getInitialState(): Promise<{
     // 避免一直停留在初始化动画。
     redirectAnonymousUser();
   }
-  if (currentUser && isLoginPath(window.location.pathname)) {
+  if (currentUser && onLoginPage) {
     const requested = new URLSearchParams(window.location.search).get(
       "returnTo"
     );

--- a/yak-ops-ui/src/pages/login/LoginPanel.tsx
+++ b/yak-ops-ui/src/pages/login/LoginPanel.tsx
@@ -1,10 +1,11 @@
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 import YakButton from "@/components/YakButton";
 import { login } from "@/services/security/account";
+import { notifyOnce } from "@/utils/notifyOnce";
 import { resetAuthenticationFailure } from "@/utils/request";
 import { getSafeReturnTo } from "@/utils/security/redirect";
 import { history, useIntl, useModel } from "@umijs/max";
-import { App, Form, Input, Popover, type InputProps } from "antd";
+import { Form, Input, Popover, type InputProps } from "antd";
 import { useForm } from "antd/es/form/Form";
 import { useState } from "react";
 import { flushSync } from "react-dom";
@@ -132,7 +133,6 @@ export default function LoginPanel() {
   const [form] = useForm();
 
   const { initialState, setInitialState } = useModel("@@initialState");
-  const { message } = App.useApp();
   const intl = useIntl();
 
   const fetchUserInfo = async () => {
@@ -163,26 +163,38 @@ export default function LoginPanel() {
     userPassword: string;
   }) => {
     try {
-      await form.validateFields();
       setLoading(true);
 
       await login({
         userName: values.userName,
         pw: values.userPassword,
       });
+
+      const userInfo = await fetchUserInfo();
+      if (!userInfo) {
+        notifyOnce("login-current-user-missing", {
+          type: "error",
+          title: "登录未完成",
+          description: "登录请求已提交，但未能加载当前用户信息。",
+          meta: "请稍后重试",
+        });
+        return;
+      }
+
       resetAuthenticationFailure();
-      message.success(
-        intl.formatMessage({
+      notifyOnce("login-success", {
+        type: "success",
+        title: intl.formatMessage({
           id: "pages.login.success",
           defaultMessage: "登录成功！",
         }),
-      );
-
-      const userInfo = await fetchUserInfo();
-      if (!userInfo) throw new Error("登录后无法加载当前用户");
+        description: "正在进入 Yak Ops",
+        meta: "身份验证完成",
+        duration: 2,
+      });
       redirectAfterLogin();
     } catch (_error) {
-      // Request handling already surfaces authentication errors to the user.
+      // Global request handling surfaces HTTP, business and network failures once.
     } finally {
       setLoading(false);
     }

--- a/yak-ops-ui/src/services/security/account.ts
+++ b/yak-ops-ui/src/services/security/account.ts
@@ -1,4 +1,8 @@
-import { securityGetData, securityPostData } from './client';
+import {
+  securityGetData,
+  securityPostData,
+  type SecurityRequestOptions,
+} from './client';
 
 /**
  * Yak Security AccountController contract.
@@ -24,8 +28,10 @@ export const login = (body: AccountLoginDTO): Promise<void> =>
 export const googleLogin = (credential: string): Promise<void> =>
   securityPostData<void>('/api/v1/auth/google/login', { credential });
 
-export const getCurrentUser = (): Promise<API.CurrentUserVO> =>
-  securityGetData<API.CurrentUserVO>(`${ACCOUNT_API}/current`);
+export const getCurrentUser = (
+  options?: SecurityRequestOptions,
+): Promise<API.CurrentUserVO> =>
+  securityGetData<API.CurrentUserVO>(`${ACCOUNT_API}/current`, options);
 
 export const logout = (): Promise<void> =>
   securityPostData<void>(`${ACCOUNT_API}/logout`);

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -71,6 +71,12 @@ export const handleAuthenticationFailure = (
 ) => {
   dispatchAuthenticationInvalidated();
   if (window.location.pathname.toLowerCase().startsWith("/login")) {
+    notifyOnce("login-authentication", {
+      type: "error",
+      title: "登录失败",
+      description: reason,
+      meta: "请检查账号密码或稍后重试",
+    });
     return;
   }
   if (authenticationFailureHandled) return;
@@ -87,12 +93,12 @@ export const handleAuthenticationFailure = (
 
 /** 业务异常的唯一展示出口。 */
 const handleBusinessError = (error: BizError) => {
+  if (error.skipErrorHandler) return;
+
   if (isUnauthenticatedResponse(error.response, error.protocol)) {
     handleAuthenticationFailure(error.message);
     return;
   }
-
-  if (error.skipErrorHandler) return;
 
   notifyOnce(`business:${error.protocol}:${error.code}:${error.message}`, {
     type: "error",
@@ -102,7 +108,16 @@ const handleBusinessError = (error: BizError) => {
   });
 };
 
-/** 唯一错误出口 */
+const shouldSkipErrorHandler = (error: any): boolean => {
+  const requestOptions =
+    error?.request?.options ??
+    error?.requestOptions ??
+    error?.options ??
+    error?.request;
+  return Boolean(requestOptions?.skipErrorHandler);
+};
+
+/** 唯一错误出口。展示完成后仍必须拒绝 Promise，避免失败请求继续执行成功链路。 */
 const errorHandler = (error: any): Response | undefined => {
   const { response } = error;
 
@@ -111,6 +126,8 @@ const errorHandler = (error: any): Response | undefined => {
     handleBusinessError(error);
     throw error;
   }
+
+  const skipErrorHandler = shouldSkipErrorHandler(error);
 
   // HTTP 异常。umi-request 会把 JSON 错误体放在 error.data 中，优先展示
   // 后端真实 msg/message，而不是用通用 HTTP 状态文案覆盖它。
@@ -126,48 +143,52 @@ const errorHandler = (error: any): Response | undefined => {
     const payloadUnauthenticated =
       isApiResponse(payload) && isUnauthenticatedResponse(payload, protocol);
     if (status === 401 || payloadUnauthenticated) {
-      handleAuthenticationFailure(errorText);
-      return response;
+      if (!skipErrorHandler) handleAuthenticationFailure(errorText);
+      throw error;
     }
 
-    notifyOnce(`http:${status}:${url || ""}:${errorText}`, {
-      type: "error",
-      title: `请求错误 ${status}`,
-      description: (
-        <div>
-          <div>{errorText}</div>
-          {url ? (
-            <div
-              style={{
-                marginTop: 6,
-                fontSize: 12,
-                color: "rgba(23, 32, 51, 0.45)",
-              }}
-            >
-              {url}
-            </div>
-          ) : null}
-        </div>
-      ),
-      meta: status === 403 ? "权限不足" : "服务端返回异常",
-      duration: 3.5,
-    });
+    if (!skipErrorHandler) {
+      notifyOnce(`http:${status}:${url || ""}:${errorText}`, {
+        type: "error",
+        title: `请求错误 ${status}`,
+        description: (
+          <div>
+            <div>{errorText}</div>
+            {url ? (
+              <div
+                style={{
+                  marginTop: 6,
+                  fontSize: 12,
+                  color: "rgba(23, 32, 51, 0.45)",
+                }}
+              >
+                {url}
+              </div>
+            ) : null}
+          </div>
+        ),
+        meta: status === 403 ? "权限不足" : "服务端返回异常",
+        duration: 3.5,
+      });
+    }
 
-    return response;
+    throw error;
   }
 
   // Abort is caller-controlled (navigation, timeout, stale request), not a network fault.
   if (error?.name === "AbortError" || error?.type === "aborted") throw error;
 
   // 网络异常
-  notifyOnce("network", {
-    type: "warning",
-    title: "网络异常",
-    description: "当前无法连接到服务器，请检查网络或稍后再试。",
-    meta: "连接中断",
-  });
+  if (!skipErrorHandler) {
+    notifyOnce("network", {
+      type: "warning",
+      title: "网络异常",
+      description: "当前无法连接到服务器，请检查网络或稍后再试。",
+      meta: "连接中断",
+    });
+  }
 
-  return response;
+  throw error;
 };
 
 function createClient() {
@@ -211,7 +232,7 @@ request.interceptors.response.use(async (response: Response, options: any) => {
       extractErrorMessage(res, "登录状态失效"),
       res.code,
       res,
-      true,
+      options?.skipErrorHandler,
       protocol
     );
   }


### PR DESCRIPTION
## 背景

登录页当前存在一条错误的成功链路：请求层虽然已经展示 HTTP/网络异常，但随后返回 `response`，导致调用方的 Promise 继续按成功处理。`LoginPanel` 又在 `/login` 返回后、`/current` 完成前提前展示“登录成功”，因此会出现：

```text
POST /account/login -> 504
  -> 全局错误通知
  -> Promise 仍继续
  -> 提前展示登录成功
  -> GET /account/current
  -> 再次失败
```

另外，登录页仍残留 `message.success`，与项目已经统一的 `notifyOnce` 通知出口不一致；登录页初始化的 `/current` 探测失败时也会产生与当前操作无关的通知。

## 修复内容

### 1. 失败请求必须保持 rejected

调整 `src/utils/request.tsx`：

- `BizError`、HTTP 异常和网络异常展示/处理完成后统一 `throw error`；
- 不再通过 `return response` 把失败请求恢复成 fulfilled Promise；
- 401/未认证响应也会拒绝当前调用，登录失败后不会继续执行 `/current`；
- `skipErrorHandler` 同时覆盖业务、HTTP 与网络异常，只抑制统一 UI/认证副作用，不吞掉异常；
- 登录页收到真实认证失败时统一使用 `notifyOnce("login-authentication")` 展示“登录失败”。

### 2. 登录完成顺序改为身份确认后再成功

登录流程调整为：

```text
POST /account/login
  -> GET /account/current
  -> 写入 initialState.currentUser
  -> resetAuthenticationFailure
  -> notifyOnce(login-success)
  -> redirect
```

只有当前用户信息成功加载并写入状态后，才展示“登录成功”。

当登录接口失败时：

```text
POST /account/login -> reject
  -> 全局 notifyOnce
  -> 停止流程
  -X-> GET /account/current
  -X-> 成功通知
  -X-> 页面跳转
```

### 3. 统一通知出口

- 删除登录页的 `App.useApp()` / `message.success`；
- 成功、认证失败和“当前用户信息缺失”都统一通过 `notifyOnce`；
- Success 通知只在完整身份状态建立后出现。

### 4. 登录页初始化探测保持静默

`getCurrentUser` 现在可接收 `SecurityRequestOptions`。应用初始化仍会探测 Cookie Session，以保留“已登录用户访问 `/login` 自动跳转”的行为，但登录路由上的初始探测使用：

```ts
getCurrentUser({ skipErrorHandler: true })
```

探测失败仍然 reject 并由 `getInitialState` 处理，但不会在用户尚未提交表单时弹出 `/current` 错误通知。

## 两次接口是否仍然存在

成功登录时仍然会依次调用：

```text
POST /account/login
GET  /account/current
```

这是当前后端 contract 的正常两阶段流程：第一个接口建立 Cookie Session，第二个接口加载当前身份、角色和权限。

本 PR 修复的是失败后仍继续第二阶段，而不是把正确的两阶段认证强行合并为一个接口。

## 变更文件

```text
yak-ops-ui/src/utils/request.tsx
yak-ops-ui/src/services/security/account.ts
yak-ops-ui/src/app.tsx
yak-ops-ui/src/pages/login/LoginPanel.tsx
```

不修改后端接口、Cookie 机制、路由 contract 或登录页视觉样式。

## 验证

独立验证流程覆盖：

- 请求错误处理段不再存在 `return response`；
- HTTP、业务、网络失败均保持 `throw`；
- 登录顺序固定为 `login -> current -> reset -> success -> redirect`；
- 登录页不再引用 `App.useApp` / `message.success`；
- 初始 `/current` 使用静默选项；
- UI TypeScript 检查；
- UI production build。

本地建议回归：

```bash
cd yak-ops-ui
npm ci
npm run tsc
npm run build
```

手工场景：

1. 后端不可用时点击登录：只显示一次失败通知，不显示成功，不请求登录后的 `/current`；
2. 用户名或密码错误：显示一次“登录失败”，保持登录页；
3. 登录成功但 `/current` 失败：不显示成功、不跳转；
4. 登录和 `/current` 均成功：只显示一次成功通知并进入目标页面；
5. 直接打开登录页且旧 Session 无效：初始 `/current` 探测静默。