### PR TITLE
refactor(ui): 收口系统管理入口（Project Space PR0）

### DIFF
--- a/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
+++ b/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
@@ -1,3 +1,4 @@
+import { productFeatures } from "@/config/productFeatures";
 import { useSecurityProject } from "@/contexts/SecurityProjectContext";
 import { getLocale, setLocale } from "@umijs/max";
 import { Dropdown } from "antd";
@@ -57,36 +58,41 @@ function LanguageSwitcher() {
   );
 }
 
-export default function SecurityProjectSwitcher() {
+function ProjectSwitcher() {
   const { projects, currentProject, selectProject } = useSecurityProject();
 
+  if (!projects.length) {
+    return <span className="whitespace-nowrap px-2 text-sm">暂无可用项目</span>;
+  }
+
+  return (
+    <Dropdown
+      menu={{
+        selectable: true,
+        selectedKeys: currentProject ? [String(currentProject.id)] : [],
+        items: projects.map((project) => ({
+          key: String(project.id),
+          label: project.projectName,
+          onClick: () => selectProject(project),
+        })),
+      }}
+    >
+      <button
+        type="button"
+        className="flex items-center gap-1 border-0 bg-transparent px-2 text-sm"
+      >
+        <span>{currentProject?.projectName}</span>
+        <ChevronDown className="h-3 w-3" />
+      </button>
+    </Dropdown>
+  );
+}
+
+export default function SecurityProjectSwitcher() {
   return (
     <div className="contents">
       <LanguageSwitcher />
-
-      {!projects.length ? (
-        <span className="whitespace-nowrap px-2 text-sm">暂无可用项目</span>
-      ) : (
-        <Dropdown
-          menu={{
-            selectable: true,
-            selectedKeys: currentProject ? [String(currentProject.id)] : [],
-            items: projects.map((project) => ({
-              key: String(project.id),
-              label: project.projectName,
-              onClick: () => selectProject(project),
-            })),
-          }}
-        >
-          <button
-            type="button"
-            className="flex items-center gap-1 border-0 bg-transparent px-2 text-sm"
-          >
-            <span>{currentProject?.projectName}</span>
-            <ChevronDown className="h-3 w-3" />
-          </button>
-        </Dropdown>
-      )}
+      {productFeatures.projectSpace ? <ProjectSwitcher /> : null}
     </div>
   );
 }

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -2,6 +2,7 @@ import {
   type PermissionRequirement,
   satisfiesPermissionRequirement,
 } from '../utils/security/permission';
+import { productFeatures } from './productFeatures';
 
 export type NavigationIconKey =
   | 'home' | 'database' | 'sync' | 'realtime' | 'client' | 'connector'
@@ -95,13 +96,13 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'data-quality-execution-detail', path: '/data-quality/execution/:executionNo', title: '运行记录详情', component: './data-quality/execution/detail', hidden: true, parentId: 'data-quality-execution' },
   { id: 'data-quality-rule-template', mode: 'one', permission: 'quality:template:read', path: '/data-quality/rule-template', title: '规则模板库', component: './data-quality/rule-template', iconKey: 'quality', menuGroup: 'data-quality', order: 30 },
   { id: 'system-users', mode: 'one', permission: 'security:user:read', path: '/system/users', title: '用户管理', component: './system/users', iconKey: 'system', menuGroup: 'system', order: 10 },
-  { id: 'system-roles', mode: 'one', permission: 'security:role:read', path: '/system/roles', title: '角色管理', component: './system/roles', iconKey: 'system', menuGroup: 'system', order: 20 },
-  { id: 'system-permissions', mode: 'one', permission: 'security:permission:read', path: '/system/permissions', title: '权限管理', component: './system/permissions', iconKey: 'system', menuGroup: 'system', order: 30 },
-  { id: 'system-departments', mode: 'one', permission: 'security:department:read', path: '/system/departments', title: '部门管理', component: './system/departments', iconKey: 'system', menuGroup: 'system', order: 40 },
-  { id: 'system-security-projects', mode: 'one', permission: 'security:project:read', path: '/system/projects', title: 'Security 授权项目', component: './system/security-projects', iconKey: 'system', menuGroup: 'system', order: 50 },
-  { id: 'system-resource-permissions', mode: 'one', permission: 'security:resource-permission:read', path: '/system/resource-permissions', title: '资源授权', component: './system/resource-permissions', iconKey: 'system', menuGroup: 'system', order: 60 },
-  { id: 'system-configs', mode: 'one', permission: 'security:config:read', path: '/system/configs', title: '系统配置', component: './system/configs', iconKey: 'system', menuGroup: 'system', order: 70 },
-  { id: 'system-operation-logs', mode: 'one', permission: 'security:operation-log:read', path: '/system/oplogs', title: '操作日志', component: './system/oplogs', iconKey: 'system', menuGroup: 'system', order: 80 },
+  { id: 'system-departments', mode: 'one', permission: 'security:department:read', path: '/system/departments', title: '部门管理', component: './system/departments', iconKey: 'system', menuGroup: 'system', order: 20 },
+  { id: 'system-roles', mode: 'one', permission: 'security:role:read', path: '/system/roles', title: '角色与权限', component: './system/roles', iconKey: 'system', menuGroup: 'system', order: 30 },
+  { id: 'system-permissions', mode: 'one', permission: 'security:permission:read', path: '/system/permissions', title: '权限管理', component: './system/permissions', iconKey: 'system', menuGroup: 'system', hidden: true, order: 31 },
+  { id: 'system-security-projects', mode: 'one', permission: 'security:project:read', path: '/system/projects', title: '项目空间', component: './system/security-projects', iconKey: 'system', menuGroup: 'system', hidden: !productFeatures.projectSpace, order: 40 },
+  { id: 'system-resource-permissions', mode: 'one', permission: 'security:resource-permission:read', path: '/system/resource-permissions', title: '资源授权', component: './system/resource-permissions', iconKey: 'system', menuGroup: 'system', hidden: !productFeatures.resourceAuthorization, order: 50 },
+  { id: 'system-configs', mode: 'one', permission: 'security:config:read', path: '/system/configs', title: '系统配置', component: './system/configs', iconKey: 'system', menuGroup: 'system', hidden: !productFeatures.systemConfig, order: 60 },
+  { id: 'system-operation-logs', mode: 'one', permission: 'security:operation-log:read', path: '/system/oplogs', title: '操作日志', component: './system/oplogs', iconKey: 'system', menuGroup: 'system', order: 70 },
   { id: 'system-messages', mode: 'public', path: '/system/messages', title: '消息中心', component: './system/messages', iconKey: 'system', hidden: true, order: 90 },
 ];
 

--- a/yak-ops-ui/src/config/productFeatures.ts
+++ b/yak-ops-ui/src/config/productFeatures.ts
@@ -1,0 +1,17 @@
+/**
+ * Yak Ops product rollout gates.
+ *
+ * These capabilities already exist at the framework/API layer but are not yet
+ * complete product experiences in Yak Ops. Keep the implementation addressable
+ * while removing unfinished entry points from the default navigation.
+ */
+export const productFeatures = {
+  projectSpace: false,
+  resourceAuthorization: false,
+  systemConfig: false,
+} as const;
+
+export type ProductFeature = keyof typeof productFeatures;
+
+export const isProductFeatureEnabled = (feature: ProductFeature): boolean =>
+  productFeatures[feature];

--- a/yak-ops-ui/src/config/systemNavigation.test.ts
+++ b/yak-ops-ui/src/config/systemNavigation.test.ts
@@ -1,0 +1,53 @@
+import { appRoutes, getMainNavigationGroups } from './navigation';
+import { productFeatures } from './productFeatures';
+
+const systemPermissions = [
+  'security:user:read',
+  'security:department:read',
+  'security:role:read',
+  'security:permission:read',
+  'security:project:read',
+  'security:resource-permission:read',
+  'security:config:read',
+  'security:operation-log:read',
+];
+
+describe('system management rollout', () => {
+  it('keeps the default sidebar focused on current Yak Ops product capabilities', () => {
+    const systemGroup = getMainNavigationGroups(systemPermissions).find(
+      (group) => group.id === 'system',
+    );
+
+    expect(systemGroup?.routes.map((route) => route.id)).toEqual([
+      'system-users',
+      'system-departments',
+      'system-roles',
+      'system-operation-logs',
+    ]);
+    expect(systemGroup?.routes.map((route) => route.title)).toEqual([
+      '用户管理',
+      '部门管理',
+      '角色与权限',
+      '操作日志',
+    ]);
+  });
+
+  it('keeps unfinished framework capabilities addressable but hidden by rollout gates', () => {
+    expect(productFeatures).toEqual({
+      projectSpace: false,
+      resourceAuthorization: false,
+      systemConfig: false,
+    });
+
+    const route = (id: string) =>
+      appRoutes.find((candidate) => candidate.id === id);
+
+    expect(route('system-permissions')?.hidden).toBe(true);
+    expect(route('system-security-projects')).toMatchObject({
+      title: '项目空间',
+      hidden: true,
+    });
+    expect(route('system-resource-permissions')?.hidden).toBe(true);
+    expect(route('system-configs')?.hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## 背景

Yak Security 已提供项目、资源授权、系统配置等通用能力，但 Yak Ops 当前业务模块尚未完整接入 `projectId` / 资源级数据权限。继续把这些能力作为默认产品入口暴露，会让菜单表达超过当前真实能力。

本 PR 作为 Project Space 改造的 **PR0**，只做产品入口收口，不改数据库、不改业务表、不删除 Yak Security 后端能力。

## 改动

- 系统管理默认菜单收口为：
  - 用户管理
  - 部门管理
  - 角色与权限
  - 操作日志
- 将原「角色管理」产品名称调整为「角色与权限」；原独立「权限管理」路由继续保留，但不再作为一级菜单展示。
- 将「Security 授权项目」产品命名调整为「项目空间」，默认隐藏。
- 默认隐藏「资源授权」和「系统配置」入口，但保留现有路由与实现，方便后续分阶段继续改造。
- 隐藏右上角项目切换器；语言切换能力继续保留。
- 增加 `productFeatures` 集中 rollout gate：
  - `projectSpace`
  - `resourceAuthorization`
  - `systemConfig`
- 增加系统管理导航测试，锁定 PR0 默认菜单和隐藏能力。

## 边界

本 PR **不做**：

- 不给业务表增加 `project_id`；
- 不修改 Yak Security 项目/资源授权/系统配置后端接口；
- 不删除现有项目空间、资源授权、系统配置页面；
- 不改变现有 RBAC 权限判断语义；
- 不开启多项目切换。

后续 PR1 将先定义 `PROJECT_SCOPE` 与项目数据归属边界，再进入统一项目上下文和业务模块迁移。

## 验证

- 新增 Jest 测试覆盖系统管理默认菜单和 rollout gate。
- 建议 CI 执行：`npm test -- systemNavigation.test.ts`、`npm run tsc`、`npm run biome:lint`。
