### PR TITLE
feat(project-space): establish trusted project context infrastructure (PR2)

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.OptionalLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -23,7 +23,7 @@ import org.springframework.util.StringUtils;
  * data and never injects a default project into legacy global queries.</p>
  */
 @Component
-public class ProjectCompatibilityCoordinator implements ApplicationRunner {
+public class ProjectCompatibilityCoordinator {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ProjectCompatibilityCoordinator.class);
@@ -41,8 +41,12 @@ public class ProjectCompatibilityCoordinator implements ApplicationRunner {
     this.userService = userService;
   }
 
-  @Override
-  public void run(ApplicationArguments args) {
+  /**
+   * Runs only after Spring Boot runners have completed, so Yak Security's optional administrator
+   * bootstrap has already had a chance to create the configured owner.
+   */
+  @EventListener(ApplicationReadyEvent.class)
+  public void bootstrapDefaultProjectAfterStartup() {
     if (!properties.getCompatibility().isBootstrapDefaultProject()) {
       return;
     }
@@ -78,7 +82,8 @@ public class ProjectCompatibilityCoordinator implements ApplicationRunner {
       throw new IllegalStateException("Default Project Space owner does not exist: " + ownerUsername);
     }
 
-    List<Long> userIds = userService.getAllUserBriefList().stream()
+    List<UserBriefVO> users = userService.getAllUserBriefList();
+    List<Long> userIds = (users == null ? Collections.<UserBriefVO>emptyList() : users).stream()
         .map(UserBriefVO::getId)
         .filter(id -> id != null && id > 0)
         .distinct()

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
@@ -1,0 +1,114 @@
+package io.yak.ops.boot.project;
+
+import io.yak.framework.security.common.dto.project.ProjectSaveDTO;
+import io.yak.framework.security.common.vo.project.ProjectBriefVO;
+import io.yak.framework.security.common.vo.project.ProjectVO;
+import io.yak.framework.security.common.vo.user.UserBriefVO;
+import io.yak.framework.security.service.ProjectService;
+import io.yak.framework.security.service.UserService;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Coordinates the opt-in default Project Space used by later Expand/Backfill/Contract migrations.
+ *
+ * <p>The bootstrap is disabled by default. Merely adding PR2 therefore never mutates Yak Security
+ * data and never injects a default project into legacy global queries.</p>
+ */
+@Component
+public class ProjectCompatibilityCoordinator implements ApplicationRunner {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ProjectCompatibilityCoordinator.class);
+
+  private final ProjectSpaceProperties properties;
+  private final ProjectService projectService;
+  private final UserService userService;
+
+  public ProjectCompatibilityCoordinator(
+      ProjectSpaceProperties properties,
+      ProjectService projectService,
+      UserService userService) {
+    this.properties = properties;
+    this.projectService = projectService;
+    this.userService = userService;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (!properties.getCompatibility().isBootstrapDefaultProject()) {
+      return;
+    }
+    long projectId = ensureDefaultProject();
+    LOGGER.info("Project Space compatibility default project is ready: projectId={}", projectId);
+  }
+
+  /** Returns the configured compatibility project when it already exists. */
+  public OptionalLong findDefaultProjectId() {
+    String name = normalizedProjectName();
+    return projectService.getProjectBriefList().stream()
+        .filter(project -> name.equals(project.getProjectName()))
+        .map(ProjectBriefVO::getId)
+        .filter(id -> id != null && id > 0)
+        .mapToLong(Long::longValue)
+        .findFirst();
+  }
+
+  /** Creates the compatibility project only when the explicit bootstrap switch is enabled. */
+  public synchronized long ensureDefaultProject() {
+    OptionalLong existing = findDefaultProjectId();
+    if (existing.isPresent()) {
+      return existing.getAsLong();
+    }
+    if (!properties.getCompatibility().isBootstrapDefaultProject()) {
+      throw new IllegalStateException(
+          "Default Project Space bootstrap is disabled; enable yak.project-space.compatibility.bootstrap-default-project explicitly");
+    }
+
+    String ownerUsername = properties.getCompatibility().getDefaultOwnerUsername();
+    UserBriefVO owner = userService.getUserBriefByUsername(ownerUsername);
+    if (owner == null || owner.getId() == null) {
+      throw new IllegalStateException("Default Project Space owner does not exist: " + ownerUsername);
+    }
+
+    List<Long> userIds = userService.getAllUserBriefList().stream()
+        .map(UserBriefVO::getId)
+        .filter(id -> id != null && id > 0)
+        .distinct()
+        .toList();
+
+    ProjectSaveDTO input = new ProjectSaveDTO();
+    input.setProjectName(normalizedProjectName());
+    input.setDescription("Yak Ops Project Space compatibility default project");
+    input.setRunning(Boolean.TRUE);
+    input.setOwnerIdList(Collections.singletonList(owner.getId()));
+    input.setUserIdList(userIds);
+
+    try {
+      ProjectVO created = projectService.createProject(input, ownerUsername);
+      return created.getId();
+    } catch (RuntimeException exception) {
+      // Multi-instance startup can race on project creation. Re-read once before surfacing the error.
+      OptionalLong concurrent = findDefaultProjectId();
+      if (concurrent.isPresent()) {
+        return concurrent.getAsLong();
+      }
+      throw exception;
+    }
+  }
+
+  private String normalizedProjectName() {
+    String name = properties.getCompatibility().getDefaultProjectName();
+    if (!StringUtils.hasText(name)) {
+      throw new IllegalStateException("Default Project Space name must not be blank");
+    }
+    return name.trim();
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectContextExceptionHandler.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectContextExceptionHandler.java
@@ -1,0 +1,29 @@
+package io.yak.ops.boot.project;
+
+import io.yak.framework.common.Result;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** Converts Project Space failures into stable HTTP and business error semantics. */
+@RestControllerAdvice(basePackages = "io.yak.ops")
+public class ProjectContextExceptionHandler {
+
+  @ExceptionHandler(ProjectContextException.class)
+  public ResponseEntity<Result<Void>> handle(ProjectContextException exception) {
+    ProjectContextError error = exception.getError();
+    Result<Void> body = Result.fail(error.getCode(), error.name() + ": " + error.getMessage());
+    return ResponseEntity.status(statusOf(error)).body(body);
+  }
+
+  private HttpStatus statusOf(ProjectContextError error) {
+    return switch (error) {
+      case PROJECT_REQUIRED -> HttpStatus.BAD_REQUEST;
+      case PROJECT_NOT_FOUND -> HttpStatus.NOT_FOUND;
+      case PROJECT_UNAVAILABLE -> HttpStatus.FORBIDDEN;
+    };
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectContextRuntime.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectContextRuntime.java
@@ -1,0 +1,26 @@
+package io.yak.ops.boot.project;
+
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** Request-thread implementation of {@link CurrentProject}. */
+@Component
+public class ProjectContextRuntime implements CurrentProject {
+
+  private final ThreadLocal<ProjectContext> holder = new ThreadLocal<>();
+
+  @Override
+  public Optional<ProjectContext> current() {
+    return Optional.ofNullable(holder.get());
+  }
+
+  void bind(ProjectContext context) {
+    holder.set(context);
+  }
+
+  void clear() {
+    holder.remove();
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectScopeInterceptor.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectScopeInterceptor.java
@@ -1,0 +1,98 @@
+package io.yak.ops.boot.project;
+
+import io.yak.framework.security.extend.CurrentUserProvider;
+import io.yak.ops.core.project.ProjectAccessGuard;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
+import io.yak.ops.core.project.ProjectHeaders;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** Establishes trusted CurrentProject only for endpoints that have entered Project Space rollout. */
+@Component
+public class ProjectScopeInterceptor implements HandlerInterceptor {
+
+  private final ProjectContextRuntime currentProject;
+  private final ProjectAccessGuard accessGuard;
+  private final CurrentUserProvider currentUserProvider;
+
+  public ProjectScopeInterceptor(
+      ProjectContextRuntime currentProject,
+      ProjectAccessGuard accessGuard,
+      CurrentUserProvider currentUserProvider) {
+    this.currentProject = currentProject;
+    this.accessGuard = accessGuard;
+    this.currentUserProvider = currentUserProvider;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    currentProject.clear();
+    if (!(handler instanceof HandlerMethod handlerMethod)) {
+      return true;
+    }
+
+    ProjectMigrationMode mode = resolveMode(handlerMethod);
+    if (mode == ProjectMigrationMode.LEGACY_GLOBAL) {
+      return true;
+    }
+
+    Long projectId = parseProjectId(request.getHeader(ProjectHeaders.PROJECT_ID), mode);
+    if (projectId == null) {
+      return true;
+    }
+
+    String username = currentUserProvider.getCurrentUser(request);
+    ProjectContext context = accessGuard.requireAccessible(projectId, username);
+    currentProject.bind(context);
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      Object handler,
+      Exception exception) {
+    currentProject.clear();
+  }
+
+  ProjectMigrationMode resolveMode(HandlerMethod handlerMethod) {
+    ProjectScope methodScope =
+        AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getMethod(), ProjectScope.class);
+    if (methodScope != null) {
+      return methodScope.value();
+    }
+
+    ProjectScope typeScope =
+        AnnotatedElementUtils.findMergedAnnotation(handlerMethod.getBeanType(), ProjectScope.class);
+    return typeScope == null ? ProjectMigrationMode.LEGACY_GLOBAL : typeScope.value();
+  }
+
+  private Long parseProjectId(String rawProjectId, ProjectMigrationMode mode) {
+    if (!StringUtils.hasText(rawProjectId)) {
+      if (mode == ProjectMigrationMode.PROJECT_REQUIRED) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_REQUIRED);
+      }
+      return null;
+    }
+
+    try {
+      long projectId = Long.parseLong(rawProjectId.trim());
+      if (projectId <= 0) {
+        throw new NumberFormatException("project ID must be positive");
+      }
+      return projectId;
+    } catch (NumberFormatException exception) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND, exception);
+    }
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectScopeInterceptor.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectScopeInterceptor.java
@@ -45,12 +45,24 @@ public class ProjectScopeInterceptor implements HandlerInterceptor {
       return true;
     }
 
-    Long projectId = parseProjectId(request.getHeader(ProjectHeaders.PROJECT_ID), mode);
+    String rawProjectId = request.getHeader(ProjectHeaders.PROJECT_ID);
+    if (!StringUtils.hasText(rawProjectId) && mode == ProjectMigrationMode.PROJECT_OPTIONAL) {
+      return true;
+    }
+
+    // Authentication remains the outer boundary. If this interceptor happens to run before the
+    // Yak Security authentication interceptor, an anonymous request must still receive the normal
+    // authentication response instead of leaking Project Space validation semantics first.
+    String username = currentUserProvider.getCurrentUser(request);
+    if (!StringUtils.hasText(username)) {
+      return true;
+    }
+
+    Long projectId = parseProjectId(rawProjectId, mode);
     if (projectId == null) {
       return true;
     }
 
-    String username = currentUserProvider.getCurrentUser(request);
     ProjectContext context = accessGuard.requireAccessible(projectId, username);
     currentProject.bind(context);
     return true;

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectSpaceProperties.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectSpaceProperties.java
@@ -1,0 +1,47 @@
+package io.yak.ops.boot.project;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** Compatibility settings used while business data is moved into the default Project Space. */
+@Component
+@ConfigurationProperties(prefix = "yak.project-space")
+public class ProjectSpaceProperties {
+
+  private final Compatibility compatibility = new Compatibility();
+
+  public Compatibility getCompatibility() {
+    return compatibility;
+  }
+
+  public static class Compatibility {
+
+    private boolean bootstrapDefaultProject;
+    private String defaultProjectName = "默认空间";
+    private String defaultOwnerUsername = "root";
+
+    public boolean isBootstrapDefaultProject() {
+      return bootstrapDefaultProject;
+    }
+
+    public void setBootstrapDefaultProject(boolean bootstrapDefaultProject) {
+      this.bootstrapDefaultProject = bootstrapDefaultProject;
+    }
+
+    public String getDefaultProjectName() {
+      return defaultProjectName;
+    }
+
+    public void setDefaultProjectName(String defaultProjectName) {
+      this.defaultProjectName = defaultProjectName;
+    }
+
+    public String getDefaultOwnerUsername() {
+      return defaultOwnerUsername;
+    }
+
+    public void setDefaultOwnerUsername(String defaultOwnerUsername) {
+      this.defaultOwnerUsername = defaultOwnerUsername;
+    }
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectSpaceWebConfiguration.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectSpaceWebConfiguration.java
@@ -1,0 +1,21 @@
+package io.yak.ops.boot.project;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** Registers Project Space request context infrastructure without changing legacy endpoints. */
+@Configuration
+public class ProjectSpaceWebConfiguration implements WebMvcConfigurer {
+
+  private final ProjectScopeInterceptor projectScopeInterceptor;
+
+  public ProjectSpaceWebConfiguration(ProjectScopeInterceptor projectScopeInterceptor) {
+    this.projectScopeInterceptor = projectScopeInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(projectScopeInterceptor).addPathPatterns("/api/**");
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/YakSecurityProjectAccessGuard.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/YakSecurityProjectAccessGuard.java
@@ -1,0 +1,66 @@
+package io.yak.ops.boot.project;
+
+import io.yak.framework.security.common.vo.project.ProjectVO;
+import io.yak.framework.security.common.vo.user.UserBriefVO;
+import io.yak.framework.security.service.ProjectService;
+import io.yak.framework.security.service.UserService;
+import io.yak.ops.core.project.ProjectAccessGuard;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Resolves Project Space access from Yak Security project membership. */
+@Component
+public class YakSecurityProjectAccessGuard implements ProjectAccessGuard {
+
+  private final ProjectService projectService;
+  private final UserService userService;
+
+  public YakSecurityProjectAccessGuard(ProjectService projectService, UserService userService) {
+    this.projectService = projectService;
+    this.userService = userService;
+  }
+
+  @Override
+  public ProjectContext requireAccessible(Long projectId, String username) {
+    if (projectId == null || projectId <= 0 || !StringUtils.hasText(username)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+
+    if (!projectService.checkProjectExist(projectId)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+
+    UserBriefVO user = userService.getUserBriefByUsername(username);
+    if (user == null || user.getId() == null) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+
+    ProjectVO project = projectService.getProjectDetailByProjectId(projectId);
+    if (!isMember(project, user.getId())) {
+      // Deliberately return the same outward error as a missing project to avoid project-ID enumeration.
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+
+    if (!Boolean.TRUE.equals(project.getRunning())) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_UNAVAILABLE);
+    }
+
+    return new ProjectContext(project.getId(), project.getProjectName());
+  }
+
+  private boolean isMember(ProjectVO project, Long userId) {
+    return containsUser(project == null ? null : project.getOwnerList(), userId)
+        || containsUser(project == null ? null : project.getUserList(), userId);
+  }
+
+  private boolean containsUser(List<UserBriefVO> users, Long userId) {
+    List<UserBriefVO> safeUsers = users == null ? Collections.emptyList() : users;
+    return safeUsers.stream().anyMatch(user -> Objects.equals(userId, user.getId()));
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectScopeInterceptorTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectScopeInterceptorTest.java
@@ -57,16 +57,30 @@ class ProjectScopeInterceptorTest {
   }
 
   @Test
-  void requiredEndpointRejectsMissingProject() throws Exception {
+  void requiredEndpointRejectsMissingProjectForAuthenticatedUser() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    when(currentUserProvider.getCurrentUser(request)).thenReturn("alice");
+
     ProjectContextException error =
         assertThrows(
             ProjectContextException.class,
             () -> interceptor.preHandle(
-                new MockHttpServletRequest(),
+                request,
                 new MockHttpServletResponse(),
                 handler("required")));
 
     assertEquals(ProjectContextError.PROJECT_REQUIRED, error.getError());
+    verifyNoInteractions(accessGuard);
+  }
+
+  @Test
+  void anonymousRequiredRequestDefersToAuthenticationBoundary() throws Exception {
+    MockHttpServletRequest request = requestWithProject("7");
+
+    interceptor.preHandle(request, new MockHttpServletResponse(), handler("required"));
+
+    assertFalse(currentProject.isPresent());
+    verifyNoInteractions(accessGuard);
   }
 
   @Test

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectScopeInterceptorTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectScopeInterceptorTest.java
@@ -1,0 +1,111 @@
+package io.yak.ops.boot.project;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.security.extend.CurrentUserProvider;
+import io.yak.ops.core.project.ProjectAccessGuard;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
+import io.yak.ops.core.project.ProjectHeaders;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+
+class ProjectScopeInterceptorTest {
+
+  private ProjectContextRuntime currentProject;
+  private ProjectAccessGuard accessGuard;
+  private CurrentUserProvider currentUserProvider;
+  private ProjectScopeInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    currentProject = new ProjectContextRuntime();
+    accessGuard = mock(ProjectAccessGuard.class);
+    currentUserProvider = mock(CurrentUserProvider.class);
+    interceptor = new ProjectScopeInterceptor(currentProject, accessGuard, currentUserProvider);
+  }
+
+  @Test
+  void keepsLegacyEndpointsGlobalEvenWhenHeaderExists() throws Exception {
+    MockHttpServletRequest request = requestWithProject("7");
+
+    interceptor.preHandle(request, new MockHttpServletResponse(), handler("legacy"));
+
+    assertFalse(currentProject.isPresent());
+    verifyNoInteractions(accessGuard, currentUserProvider);
+  }
+
+  @Test
+  void optionalEndpointAcceptsMissingProjectDuringBackfill() throws Exception {
+    interceptor.preHandle(
+        new MockHttpServletRequest(), new MockHttpServletResponse(), handler("optional"));
+
+    assertFalse(currentProject.isPresent());
+    verifyNoInteractions(accessGuard, currentUserProvider);
+  }
+
+  @Test
+  void requiredEndpointRejectsMissingProject() throws Exception {
+    ProjectContextException error =
+        assertThrows(
+            ProjectContextException.class,
+            () -> interceptor.preHandle(
+                new MockHttpServletRequest(),
+                new MockHttpServletResponse(),
+                handler("required")));
+
+    assertEquals(ProjectContextError.PROJECT_REQUIRED, error.getError());
+  }
+
+  @Test
+  void bindsAuthorizedProjectAndClearsItAfterRequest() throws Exception {
+    MockHttpServletRequest request = requestWithProject("7");
+    when(currentUserProvider.getCurrentUser(request)).thenReturn("alice");
+    when(accessGuard.requireAccessible(7L, "alice"))
+        .thenReturn(new ProjectContext(7L, "Project A"));
+
+    interceptor.preHandle(request, new MockHttpServletResponse(), handler("required"));
+    assertEquals(7L, currentProject.requireProjectId());
+
+    interceptor.afterCompletion(
+        request, new MockHttpServletResponse(), handler("required"), null);
+    assertFalse(currentProject.isPresent());
+  }
+
+  private MockHttpServletRequest requestWithProject(String projectId) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(ProjectHeaders.PROJECT_ID, projectId);
+    return request;
+  }
+
+  private HandlerMethod handler(String methodName) throws Exception {
+    Method method = TestController.class.getDeclaredMethod(methodName);
+    return new HandlerMethod(new TestController(), method);
+  }
+
+  private static class TestController {
+
+    void legacy() {
+    }
+
+    @ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
+    void optional() {
+    }
+
+    @ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)
+    void required() {
+    }
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/CurrentProject.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/CurrentProject.java
@@ -1,0 +1,22 @@
+package io.yak.ops.core.project;
+
+import java.util.Optional;
+
+/** Read-only access to the trusted Project Space bound to the current request. */
+public interface CurrentProject {
+
+  Optional<ProjectContext> current();
+
+  default boolean isPresent() {
+    return current().isPresent();
+  }
+
+  default ProjectContext require() {
+    return current().orElseThrow(
+        () -> new ProjectContextException(ProjectContextError.PROJECT_REQUIRED));
+  }
+
+  default Long requireProjectId() {
+    return require().projectId();
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectAccessGuard.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectAccessGuard.java
@@ -1,0 +1,8 @@
+package io.yak.ops.core.project;
+
+/** Resolves and authorizes a requested Yak Security project for an authenticated user. */
+@FunctionalInterface
+public interface ProjectAccessGuard {
+
+  ProjectContext requireAccessible(Long projectId, String username);
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectContext.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectContext.java
@@ -1,0 +1,16 @@
+package io.yak.ops.core.project;
+
+/**
+ * Trusted project context resolved for the current request.
+ *
+ * @param projectId Yak Security project ID
+ * @param projectName project display name
+ */
+public record ProjectContext(Long projectId, String projectName) {
+
+  public ProjectContext {
+    if (projectId == null || projectId <= 0) {
+      throw new IllegalArgumentException("projectId must be a positive number");
+    }
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectContextError.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectContextError.java
@@ -1,0 +1,24 @@
+package io.yak.ops.core.project;
+
+/** Stable Project Space context failures shared by web and business layers. */
+public enum ProjectContextError {
+  PROJECT_REQUIRED(40010, "当前操作需要选择项目空间"),
+  PROJECT_NOT_FOUND(40410, "项目空间不存在或当前用户不可访问"),
+  PROJECT_UNAVAILABLE(40310, "项目空间当前不可用");
+
+  private final int code;
+  private final String message;
+
+  ProjectContextError(int code, String message) {
+    this.code = code;
+    this.message = message;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectContextException.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectContextException.java
@@ -1,0 +1,21 @@
+package io.yak.ops.core.project;
+
+/** Exception raised when a trusted Project Space context cannot be established. */
+public class ProjectContextException extends RuntimeException {
+
+  private final ProjectContextError error;
+
+  public ProjectContextException(ProjectContextError error) {
+    super(error == null ? "Project Space context error" : error.getMessage());
+    this.error = error == null ? ProjectContextError.PROJECT_NOT_FOUND : error;
+  }
+
+  public ProjectContextException(ProjectContextError error, Throwable cause) {
+    super(error == null ? "Project Space context error" : error.getMessage(), cause);
+    this.error = error == null ? ProjectContextError.PROJECT_NOT_FOUND : error;
+  }
+
+  public ProjectContextError getError() {
+    return error;
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectHeaders.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectHeaders.java
@@ -1,0 +1,10 @@
+package io.yak.ops.core.project;
+
+/** Shared HTTP header names used by Project Space infrastructure. */
+public final class ProjectHeaders {
+
+  public static final String PROJECT_ID = "X-YAK-SECURITY-PROJECT-ID";
+
+  private ProjectHeaders() {
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectMigrationMode.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectMigrationMode.java
@@ -1,0 +1,14 @@
+package io.yak.ops.core.project;
+
+/**
+ * Rollout state for one project-aware web capability.
+ *
+ * <p>LEGACY_GLOBAL keeps current global semantics. PROJECT_OPTIONAL accepts a trusted project when
+ * supplied while compatibility data is still being backfilled. PROJECT_REQUIRED rejects requests
+ * without a trusted project context.</p>
+ */
+public enum ProjectMigrationMode {
+  LEGACY_GLOBAL,
+  PROJECT_OPTIONAL,
+  PROJECT_REQUIRED
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectScope.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectScope.java
@@ -1,0 +1,14 @@
+package io.yak.ops.core.project;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Marks a controller or endpoint as participating in the Project Space rollout. */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProjectScope {
+
+  ProjectMigrationMode value() default ProjectMigrationMode.PROJECT_REQUIRED;
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/package-info.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/package-info.java
@@ -1,0 +1,2 @@
+/** Trusted Project Space context and staged migration contracts. */
+package io.yak.ops.core.project;

--- a/yak-ops-core/src/test/java/io/yak/ops/core/project/CurrentProjectTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/project/CurrentProjectTest.java
@@ -1,0 +1,28 @@
+package io.yak.ops.core.project;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CurrentProjectTest {
+
+  @Test
+  void requiresTrustedContextWhenProjectIsAbsent() {
+    CurrentProject currentProject = Optional::empty;
+
+    ProjectContextException error =
+        assertThrows(ProjectContextException.class, currentProject::requireProjectId);
+
+    assertEquals(ProjectContextError.PROJECT_REQUIRED, error.getError());
+  }
+
+  @Test
+  void exposesBoundProjectId() {
+    CurrentProject currentProject =
+        () -> Optional.of(new ProjectContext(7L, "Project A"));
+
+    assertEquals(7L, currentProject.requireProjectId());
+  }
+}

--- a/yak-ops-ui/src/contexts/SecurityProjectContext.tsx
+++ b/yak-ops-ui/src/contexts/SecurityProjectContext.tsx
@@ -3,13 +3,17 @@ import type { ReactNode } from 'react';
 import { createContext, useContext, useEffect, useMemo } from 'react';
 import { getCurrentUser } from '@/services/security/account';
 import { toCurrentUser } from '@/services/security/currentIdentity';
+import {
+  clearStoredProjectId,
+  readStoredProjectId,
+  storeProjectId,
+} from '@/utils/security/projectContext';
 
-const STORAGE_KEY = 'yak-security.current-project-id';
 export const SECURITY_SESSION_EXPIRED_EVENT = 'yak-security:session-expired';
 
 export const chooseSecurityProject = (
   projects: API.ProjectBrief[],
-  persistedId: string | null,
+  persistedId: string | null | undefined,
 ): API.ProjectBrief | undefined => projects.find((project) => String(project.id) === persistedId) ?? projects[0];
 
 type SecurityProjectValue = {
@@ -29,21 +33,21 @@ export function SecurityProjectProvider({ children }: { children: ReactNode }) {
 
   const selectProject = (project: API.ProjectBrief) => {
     if (!projects.some((candidate) => candidate.id === project.id)) return;
-    localStorage.setItem(STORAGE_KEY, String(project.id));
+    storeProjectId(project.id);
     setInitialState((state) => ({ ...state, currentProject: project, securityProject: project }));
   };
 
   const clearProject = () => {
-    localStorage.removeItem(STORAGE_KEY);
+    clearStoredProjectId();
     setInitialState((state) => ({ ...state, currentProject: undefined, securityProject: undefined }));
   };
 
   const refreshProjects = async () => {
     const currentUser = toCurrentUser(await getCurrentUser());
     const nextProjects = currentUser.projectList ?? [];
-    const selected = chooseSecurityProject(nextProjects, localStorage.getItem(STORAGE_KEY));
-    if (selected) localStorage.setItem(STORAGE_KEY, String(selected.id));
-    else localStorage.removeItem(STORAGE_KEY);
+    const selected = chooseSecurityProject(nextProjects, readStoredProjectId());
+    if (selected) storeProjectId(selected.id);
+    else clearStoredProjectId();
     setInitialState((state) => ({
       ...state,
       currentUser,
@@ -53,7 +57,7 @@ export function SecurityProjectProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
-    const selected = chooseSecurityProject(projects, localStorage.getItem(STORAGE_KEY));
+    const selected = chooseSecurityProject(projects, readStoredProjectId());
     if (selected) {
       if (selected.id !== currentProject?.id) selectProject(selected);
     } else if (currentProject) {
@@ -63,7 +67,7 @@ export function SecurityProjectProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const clearSession = () => {
-      localStorage.removeItem(STORAGE_KEY);
+      clearStoredProjectId();
       setInitialState((state) => ({
         ...state,
         currentUser: undefined,

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -2,6 +2,7 @@
 import { extractErrorMessage, extractUnknownErrorMessage, isApiResponse, isSuccessfulResponse, isUnauthenticatedResponse, protocolForUrl, type ApiProtocol, type ApiResponse } from "@/services/http/response";
 import { notifyOnce } from "@/utils/notifyOnce";
 import { dispatchAuthenticationInvalidated } from "@/utils/security/authentication";
+import { applyCurrentProjectHeader } from "@/utils/security/projectContext";
 import { history } from "umi";
 import { extend } from "umi-request";
 
@@ -201,7 +202,7 @@ function createClient() {
 const request = createClient();
 
 request.interceptors.request.use((url: string, options: any) => {
-  const headers = options.headers || {};
+  const headers = applyCurrentProjectHeader(url, options.headers || {});
 
   return {
     url,

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -1,0 +1,45 @@
+import {
+  PROJECT_ID_HEADER,
+  applyCurrentProjectHeader,
+  clearStoredProjectId,
+  readStoredProjectId,
+  resolveProjectRequestMode,
+  storeProjectId,
+  type ProjectRequestRule,
+} from './projectContext';
+
+const rules: ProjectRequestRule[] = [
+  { prefix: '/api/v1/data-source', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/data-source/admin', mode: 'PROJECT_REQUIRED' },
+];
+
+describe('Project Space request context', () => {
+  afterEach(() => clearStoredProjectId());
+
+  it('keeps all current routes legacy-global before a module opts into migration', () => {
+    expect(resolveProjectRequestMode('/api/v1/data-source')).toBe('LEGACY_GLOBAL');
+  });
+
+  it('uses the most specific project-aware route rule', () => {
+    expect(resolveProjectRequestMode('/api/v1/data-source/1', rules)).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/data-source/admin/1', rules)).toBe('PROJECT_REQUIRED');
+  });
+
+  it('never attaches a project header to a legacy-global route', () => {
+    const headers = applyCurrentProjectHeader('/api/v1/data-source', {}, '7');
+    expect(headers).toEqual({});
+  });
+
+  it('attaches the stored project only after a route opts into project migration', () => {
+    storeProjectId(7);
+    expect(readStoredProjectId()).toBe('7');
+
+    const headers = applyCurrentProjectHeader('/api/v1/data-source/1', {}, undefined, rules);
+    expect(headers).toEqual({ [PROJECT_ID_HEADER]: '7' });
+  });
+
+  it('drops invalid persisted project identifiers', () => {
+    storeProjectId('not-a-project');
+    expect(readStoredProjectId()).toBeUndefined();
+  });
+});

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -1,0 +1,90 @@
+export const PROJECT_ID_HEADER = 'X-YAK-SECURITY-PROJECT-ID';
+export const CURRENT_PROJECT_STORAGE_KEY = 'yak-security.current-project-id';
+
+export type ProjectMigrationMode =
+  | 'LEGACY_GLOBAL'
+  | 'PROJECT_OPTIONAL'
+  | 'PROJECT_REQUIRED';
+
+export type ProjectRequestRule = {
+  prefix: string;
+  mode: Exclude<ProjectMigrationMode, 'LEGACY_GLOBAL'>;
+};
+
+/**
+ * Project-aware API rollout table.
+ *
+ * PR2 intentionally keeps this empty: all current business modules are still
+ * LEGACY_GLOBAL. PR3+ will add a route only after its backend has entered
+ * PROJECT_OPTIONAL/PROJECT_REQUIRED, so old modules never change semantics by
+ * merely receiving the new infrastructure.
+ */
+export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [];
+
+const normalizePath = (url: string): string => {
+  try {
+    return new URL(url, 'http://yak-ops.local').pathname.replace(/\/+$/, '') || '/';
+  } catch {
+    return url.split(/[?#]/, 1)[0].replace(/\/+$/, '') || '/';
+  }
+};
+
+export const resolveProjectRequestMode = (
+  url: string,
+  rules: readonly ProjectRequestRule[] = PROJECT_REQUEST_RULES,
+): ProjectMigrationMode => {
+  const path = normalizePath(url);
+  const matched = rules
+    .filter(({ prefix }) => {
+      const normalizedPrefix = normalizePath(prefix);
+      return path === normalizedPrefix || path.startsWith(`${normalizedPrefix}/`);
+    })
+    .sort((left, right) => normalizePath(right.prefix).length - normalizePath(left.prefix).length)[0];
+
+  return matched?.mode ?? 'LEGACY_GLOBAL';
+};
+
+const normalizeProjectId = (value: unknown): string | undefined => {
+  const normalized = String(value ?? '').trim();
+  if (!/^\d+$/.test(normalized) || Number(normalized) <= 0) return undefined;
+  return normalized;
+};
+
+export const readStoredProjectId = (): string | undefined => {
+  if (typeof window === 'undefined') return undefined;
+  return normalizeProjectId(window.localStorage.getItem(CURRENT_PROJECT_STORAGE_KEY));
+};
+
+export const storeProjectId = (projectId: unknown): void => {
+  if (typeof window === 'undefined') return;
+  const normalized = normalizeProjectId(projectId);
+  if (normalized) window.localStorage.setItem(CURRENT_PROJECT_STORAGE_KEY, normalized);
+  else window.localStorage.removeItem(CURRENT_PROJECT_STORAGE_KEY);
+};
+
+export const clearStoredProjectId = (): void => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(CURRENT_PROJECT_STORAGE_KEY);
+};
+
+export const applyCurrentProjectHeader = (
+  url: string,
+  headers: HeadersInit | undefined,
+  projectId = readStoredProjectId(),
+  rules: readonly ProjectRequestRule[] = PROJECT_REQUEST_RULES,
+): HeadersInit => {
+  const mode = resolveProjectRequestMode(url, rules);
+  const normalizedProjectId = normalizeProjectId(projectId);
+  if (mode === 'LEGACY_GLOBAL' || !normalizedProjectId) return headers ?? {};
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    const next = new Headers(headers);
+    next.set(PROJECT_ID_HEADER, normalizedProjectId);
+    return next;
+  }
+
+  return {
+    ...(headers ?? {}),
+    [PROJECT_ID_HEADER]: normalizedProjectId,
+  };
+};


### PR DESCRIPTION
## 背景

PR0 已收口未成熟的产品入口，PR1 已固定 `PROJECT_SCOPE` 数据边界。本 PR 进入 Project Space **PR2：上下文基础设施**。

本阶段仍然不批量改业务表，也不让现有模块突然变成多项目模式。目标是先把后续 PR3～PR5 都会复用的可信项目上下文、成员校验、迁移状态和前端 Header 通道搭起来。

## 本 PR 做了什么

### 1. Core：定义稳定的 Project Space 合同

新增 `io.yak.ops.core.project`：

- `ProjectContext`：服务端解析后的可信项目上下文；
- `CurrentProject`：业务模块读取当前项目的统一入口；
- `ProjectAccessGuard`：项目访问校验边界；
- `ProjectMigrationMode`：`LEGACY_GLOBAL / PROJECT_OPTIONAL / PROJECT_REQUIRED`；
- `@ProjectScope`：Controller / endpoint 分阶段接入项目上下文；
- `ProjectContextError / ProjectContextException`：固定 `PROJECT_REQUIRED / PROJECT_NOT_FOUND / PROJECT_UNAVAILABLE` 语义；
- `ProjectHeaders`：统一 `X-YAK-SECURITY-PROJECT-ID`。

业务模块后续只依赖 `yak-ops-core` 的合同，不直接耦合 Yak Security 的 Project VO/Service。

### 2. Boot：接入 Yak Security 的可信项目校验

新增 Project Space Web 基础设施：

- 从 Yak Security `CurrentUserProvider` 获取已经认证的用户名；
- 校验 Project 是否存在；
- 校验当前用户是否是项目成员/负责人；
- 对非成员统一返回 `PROJECT_NOT_FOUND`，避免 Project ID 枚举；
- 校验 Project 是否处于运行状态；
- 通过 request-thread `CurrentProject` 绑定项目上下文；
- 请求结束后强制清理 ThreadLocal，避免线程池复用造成上下文串线；
- 稳定映射：
  - `PROJECT_REQUIRED` -> HTTP 400
  - `PROJECT_NOT_FOUND` -> HTTP 404
  - `PROJECT_UNAVAILABLE` -> HTTP 403

### 3. 分阶段迁移，不改变旧模块语义

`ProjectScopeInterceptor` 只处理显式标记 `@ProjectScope` 的接口：

```text
无注解 / LEGACY_GLOBAL
  -> 完全保持当前全局语义

PROJECT_OPTIONAL
  -> 有 Project Header 时建立可信上下文
  -> 无 Header 仍允许兼容期访问

PROJECT_REQUIRED
  -> 必须存在合法 CurrentProject
```

**PR2 没有给任何现有业务 Controller 加 `@ProjectScope`。**

因此 DataSource、Resource、Dataset、Sync、Workflow 等当前接口行为不会因为合并 PR2 而改变。

### 4. 默认空间兼容协调器

新增 `ProjectCompatibilityCoordinator`：

- 支持后续 Expand -> Backfill -> Contract 迁移查询默认项目 ID；
- 可以显式开启默认空间 bootstrap；
- bootstrap 默认关闭，合并 PR2 不会自动修改 Yak Security 数据；
- 显式开启时，可创建“默认空间”、指定负责人，并把现有用户加入该空间；
- 多实例同时启动时会在创建冲突后重新读取，降低重复 bootstrap 风险。

配置前缀：

```yaml
yak:
  project-space:
    compatibility:
      bootstrap-default-project: false
      default-project-name: 默认空间
      default-owner-username: root
```

### 5. UI：统一 Project Header 通道，但保持 dormant

新增 `projectContext.ts`：

- 统一 Current Project localStorage 读写；
- 统一 `X-YAK-SECURITY-PROJECT-ID` 注入；
- 前端同样使用 `LEGACY_GLOBAL / PROJECT_OPTIONAL / PROJECT_REQUIRED` 路由迁移规则；
- 通用 request interceptor 已接入该能力。

当前 `PROJECT_REQUEST_RULES` **为空**，所以现有任何 API 都不会新增 Project Header，也不会改变当前请求语义。

PR3 开始迁移 DataSource / Resource / Dataset 时，再同步把对应 API 路径加入 PROJECT_OPTIONAL/REQUIRED。

## 测试

新增：

- `CurrentProjectTest`
  - 无项目时 `requireProjectId()` 返回 `PROJECT_REQUIRED`
  - 已绑定项目时读取正确 project ID
- `ProjectScopeInterceptorTest`
  - legacy 接口忽略 Project Header
  - optional 接口允许无项目
  - required 接口拒绝无项目
  - 授权项目绑定后会在请求结束清理
- `projectContext.test.ts`
  - 当前默认路由保持 `LEGACY_GLOBAL`
  - 支持按路径进入 optional / required
  - legacy 不注入 Header
  - project-aware route 才注入已保存项目
  - 无效 project ID 不进入请求头

## 边界

本 PR **不做**：

- 不给任何业务表增加 `project_id`；
- 不修改 DataSource / Resource / Dataset 等业务 SQL；
- 不给现有业务 Controller 开启 `@ProjectScope`；
- 不开放项目空间菜单或右上角项目切换器；
- 不开启细粒度资源授权；
- 不默认创建“默认空间”。

## 下一步 PR3

PR3 按 PR1 约定开始第一批真实业务迁移：

```text
DataSource
  -> File Resource
  -> Dataset
```

届时使用本 PR 的 `CurrentProject + @ProjectScope(PROJECT_OPTIONAL)` 做 Expand 阶段，再完成历史数据 Backfill，验收后进入 `PROJECT_REQUIRED`。