### PR TITLE
feat(project-space): migrate datasource, resource and dataset ownership (PR3)

### DIFF
--- a/docs/project-space/PR3_BACKFILL.md
+++ b/docs/project-space/PR3_BACKFILL.md
@@ -1,0 +1,79 @@
+# Project Space PR3 回填与验收
+
+PR3 只扩展 DataSource、Resource、Dataset 三个聚合根。数据库列先保持 nullable，接口先进入 `PROJECT_OPTIONAL`，完成备份、回填和双项目隔离验证后，后续 Contract PR 才切换 `PROJECT_REQUIRED` 与 `NOT NULL`。
+
+## 回填前提
+
+1. Yak Security 中已经存在用于承接历史数据的默认 Project；
+2. 默认 Project 已配置负责人和现有用户成员关系；
+3. 已记录默认 Project 的真实 ID，禁止假设它等于 `1`；
+4. 已备份业务库与 Resource 物理存储目录。
+
+以下 SQL 中的 `:default_project_id` 必须由部署人员替换为真实 ID：
+
+```sql
+UPDATE yak_ops_data_source
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+
+UPDATE yak_ops_resource
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+
+UPDATE yak_dataset
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+```
+
+## Resource 物理路径
+
+新建的项目资源使用 `projects/{projectId}/...` 物理命名空间，逻辑路径仍保持 `/目录/文件`。历史 Resource 回填 `project_id` 后，其已有 `storage_path` 不应只靠 SQL 批量改写；需要根据实际存储插件执行文件移动，并在同一维护窗口更新 `storage_path`。
+
+建议流程：
+
+```text
+停止 Resource 写入
+  -> 导出 id/project_id/storage_type/storage_path/full_path
+  -> 按存储插件移动到 projects/{projectId}/...
+  -> 更新 storage_path
+  -> 校验 checksum 与下载
+  -> 恢复写入
+```
+
+## 验收 SQL
+
+```sql
+SELECT COUNT(*) AS unowned_datasource
+FROM yak_ops_data_source
+WHERE project_id IS NULL;
+
+SELECT COUNT(*) AS unowned_resource
+FROM yak_ops_resource
+WHERE project_id IS NULL;
+
+SELECT COUNT(*) AS unowned_dataset
+FROM yak_dataset
+WHERE project_id IS NULL;
+
+SELECT project_id, name, COUNT(*) AS duplicate_count
+FROM yak_ops_data_source
+GROUP BY project_id, name
+HAVING COUNT(*) > 1;
+
+SELECT project_id, parent_id, name, COUNT(*) AS duplicate_count
+FROM yak_ops_resource
+GROUP BY project_id, parent_id, name
+HAVING COUNT(*) > 1;
+```
+
+## 双项目接口验收
+
+使用 Project A 和 Project B 分别创建同名数据源、同路径资源与数据集，验证：
+
+- 列表、详情、编辑、删除、连接测试和下载只看到当前项目；
+- 直接替换 URL 中的其他项目对象 ID 返回 `PROJECT_NOT_FOUND`；
+- Dataset 不能读取其他项目的数据源或 TaskAsset；
+- Dataset 查询性能诊断不会返回其他项目的 trace；
+- 不在 rollout 表中的 Workflow、Sync、Quality 等接口仍保持旧语义。
+
+所有 null 归属、物理路径和双项目用例通过后，才允许进入 Contract 收口。

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetQueryService.java
@@ -1,9 +1,14 @@
 package io.yak.ops.business.dataset;
 
+import io.yak.ops.business.dataset.definition.DatasetReader;
 import io.yak.ops.business.dataset.observability.DatasetQueryPerformanceReader;
 import io.yak.ops.business.dataset.query.DatasetQueryCoordinator;
+import io.yak.ops.core.project.CurrentProject;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Stable application entry point used by Dashboard/Chart consumers. */
@@ -12,12 +17,29 @@ public class DatasetQueryService {
 
   private final DatasetQueryCoordinator coordinator;
   private final DatasetQueryPerformanceReader performanceReader;
+  private final DatasetReader datasetReader;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public DatasetQueryService(
+      DatasetQueryCoordinator coordinator,
+      DatasetQueryPerformanceReader performanceReader,
+      DatasetReader datasetReader,
+      CurrentProject currentProject) {
+    this.coordinator = coordinator;
+    this.performanceReader = performanceReader;
+    this.datasetReader = datasetReader;
+    this.currentProject = currentProject;
+  }
 
   public DatasetQueryService(
       DatasetQueryCoordinator coordinator,
       DatasetQueryPerformanceReader performanceReader) {
-    this.coordinator = coordinator;
-    this.performanceReader = performanceReader;
+    this(
+        coordinator,
+        performanceReader,
+        null,
+        Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   public DatasetQueryResult query(long datasetId, DatasetQueryRequest request) {
@@ -25,11 +47,28 @@ public class DatasetQueryService {
   }
 
   public List<DatasetQueryPerformance> recentPerformance(Set<Long> datasetIds, int limit) {
-    return performanceReader.recent(datasetIds, limit);
+    return recentPerformance(datasetIds, Set.of(), limit);
   }
 
   public List<DatasetQueryPerformance> recentPerformance(
       Set<Long> datasetIds, Set<String> queryIds, int limit) {
-    return performanceReader.recent(datasetIds, queryIds, limit);
+    ScopedDatasetIds scope = scopedDatasetIds(datasetIds);
+    if (scope.projectScoped() && scope.datasetIds().isEmpty()) return List.of();
+    return performanceReader.recent(scope.datasetIds(), queryIds, limit);
   }
+
+  private ScopedDatasetIds scopedDatasetIds(Set<Long> requested) {
+    if (!currentProject.isPresent() || datasetReader == null) {
+      return new ScopedDatasetIds(requested == null ? Set.of() : requested, false);
+    }
+    Set<Long> allowed = new HashSet<>();
+    for (Dataset dataset : datasetReader.list()) allowed.add(dataset.id());
+    if (requested == null || requested.isEmpty()) {
+      return new ScopedDatasetIds(Set.copyOf(allowed), true);
+    }
+    allowed.retainAll(requested);
+    return new ScopedDatasetIds(Set.copyOf(allowed), true);
+  }
+
+  private record ScopedDatasetIds(Set<Long> datasetIds, boolean projectScoped) {}
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/DatasetController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/DatasetController.java
@@ -14,6 +14,8 @@ import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetDetailVO
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetQueryPerformanceVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetQueryResultVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.HashSet;
 import java.util.List;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/datasets")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DatasetController {
 
   private final DatasetService datasetService;

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/DatasetDao.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/DatasetDao.java
@@ -16,17 +16,31 @@ public interface DatasetDao {
 
   int updateCurrentVersion(long datasetId, long versionId);
 
+  int updateCurrentVersion(Long projectId, long datasetId, long versionId);
+
   int updateStatus(long datasetId, String status);
+
+  int updateStatus(Long projectId, long datasetId, String status);
 
   int updateMetadata(long datasetId, String name, String description);
 
+  int updateMetadata(Long projectId, long datasetId, String name, String description);
+
   DatasetPO selectDataset(long datasetId);
+
+  DatasetPO selectDataset(Long projectId, long datasetId);
 
   DatasetPO selectDatasetBySourceTaskAssetId(long sourceTaskAssetId);
 
+  DatasetPO selectDatasetBySourceTaskAssetId(Long projectId, long sourceTaskAssetId);
+
   DatasetPO selectDatasetByDevelopmentNodeId(long developmentNodeId);
 
+  DatasetPO selectDatasetByDevelopmentNodeId(Long projectId, long developmentNodeId);
+
   List<DatasetPO> selectDatasets();
+
+  List<DatasetPO> selectDatasets(Long projectId);
 
   DatasetVersionPO selectVersion(long versionId);
 

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/impl/DatasetDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/impl/DatasetDaoImpl.java
@@ -48,9 +48,15 @@ public class DatasetDaoImpl implements DatasetDao {
 
   @Override
   public int updateCurrentVersion(long datasetId, long versionId) {
+    return updateCurrentVersion(null, datasetId, versionId);
+  }
+
+  @Override
+  public int updateCurrentVersion(Long projectId, long datasetId, long versionId) {
     return datasetMapper.update(
         null,
         Wrappers.<DatasetPO>lambdaUpdate()
+            .eq(projectId != null, DatasetPO::getProjectId, projectId)
             .eq(DatasetPO::getId, datasetId)
             .set(DatasetPO::getCurrentVersionId, versionId)
             .set(DatasetPO::getUpdateTime, Timestamp.from(Instant.now())));
@@ -58,9 +64,15 @@ public class DatasetDaoImpl implements DatasetDao {
 
   @Override
   public int updateStatus(long datasetId, String status) {
+    return updateStatus(null, datasetId, status);
+  }
+
+  @Override
+  public int updateStatus(Long projectId, long datasetId, String status) {
     return datasetMapper.update(
         null,
         Wrappers.<DatasetPO>lambdaUpdate()
+            .eq(projectId != null, DatasetPO::getProjectId, projectId)
             .eq(DatasetPO::getId, datasetId)
             .set(DatasetPO::getStatus, status)
             .set(DatasetPO::getUpdateTime, Timestamp.from(Instant.now())));
@@ -68,9 +80,16 @@ public class DatasetDaoImpl implements DatasetDao {
 
   @Override
   public int updateMetadata(long datasetId, String name, String description) {
+    return updateMetadata(null, datasetId, name, description);
+  }
+
+  @Override
+  public int updateMetadata(
+      Long projectId, long datasetId, String name, String description) {
     return datasetMapper.update(
         null,
         Wrappers.<DatasetPO>lambdaUpdate()
+            .eq(projectId != null, DatasetPO::getProjectId, projectId)
             .eq(DatasetPO::getId, datasetId)
             .set(DatasetPO::getName, name)
             .set(DatasetPO::getDescription, description)
@@ -79,11 +98,25 @@ public class DatasetDaoImpl implements DatasetDao {
 
   @Override
   public DatasetPO selectDataset(long datasetId) {
-    return datasetMapper.selectById(datasetId);
+    return selectDataset(null, datasetId);
+  }
+
+  @Override
+  public DatasetPO selectDataset(Long projectId, long datasetId) {
+    if (projectId == null) return datasetMapper.selectById(datasetId);
+    return datasetMapper.selectOne(
+        Wrappers.<DatasetPO>lambdaQuery()
+            .eq(DatasetPO::getProjectId, projectId)
+            .eq(DatasetPO::getId, datasetId));
   }
 
   @Override
   public DatasetPO selectDatasetBySourceTaskAssetId(long sourceTaskAssetId) {
+    return selectDatasetBySourceTaskAssetId(null, sourceTaskAssetId);
+  }
+
+  @Override
+  public DatasetPO selectDatasetBySourceTaskAssetId(Long projectId, long sourceTaskAssetId) {
     List<Object> values = versionMapper.selectObjs(
         Wrappers.<DatasetVersionPO>query()
             .select("dataset_id")
@@ -97,6 +130,7 @@ public class DatasetDaoImpl implements DatasetDao {
     if (datasetIds.isEmpty()) return null;
     return datasetMapper.selectList(
         Wrappers.<DatasetPO>lambdaQuery()
+            .eq(projectId != null, DatasetPO::getProjectId, projectId)
             .in(DatasetPO::getId, datasetIds)
             .isNull(DatasetPO::getDevelopmentNodeId)
             .orderByDesc(DatasetPO::getUpdateTime)
@@ -108,15 +142,27 @@ public class DatasetDaoImpl implements DatasetDao {
 
   @Override
   public DatasetPO selectDatasetByDevelopmentNodeId(long developmentNodeId) {
+    return selectDatasetByDevelopmentNodeId(null, developmentNodeId);
+  }
+
+  @Override
+  public DatasetPO selectDatasetByDevelopmentNodeId(Long projectId, long developmentNodeId) {
     return datasetMapper.selectOne(
         Wrappers.<DatasetPO>lambdaQuery()
+            .eq(projectId != null, DatasetPO::getProjectId, projectId)
             .eq(DatasetPO::getDevelopmentNodeId, developmentNodeId));
   }
 
   @Override
   public List<DatasetPO> selectDatasets() {
+    return selectDatasets(null);
+  }
+
+  @Override
+  public List<DatasetPO> selectDatasets(Long projectId) {
     return datasetMapper.selectList(
         Wrappers.<DatasetPO>lambdaQuery()
+            .eq(projectId != null, DatasetPO::getProjectId, projectId)
             .orderByDesc(DatasetPO::getUpdateTime)
             .orderByDesc(DatasetPO::getId));
   }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/mapper/DatasetOverviewMapper.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/mapper/DatasetOverviewMapper.java
@@ -25,7 +25,22 @@ public interface DatasetOverviewMapper {
 
   @Select("""
       SELECT
+          (SELECT COUNT(*) FROM yak_dataset WHERE project_id = #{projectId}) AS datasetCount,
+          (SELECT COUNT(*)
+             FROM yak_dataset
+            WHERE project_id = #{projectId}
+              AND create_time >= #{from}
+              AND create_time < #{to}) AS createdCount
+      """)
+  DatasetOverviewSummaryPO selectSummaryByProject(
+      @Param("projectId") Long projectId,
+      @Param("from") Timestamp from,
+      @Param("to") Timestamp to);
+
+  @Select("""
+      SELECT
           id,
+          project_id AS projectId,
           development_node_id AS developmentNodeId,
           name,
           description,
@@ -42,6 +57,26 @@ public interface DatasetOverviewMapper {
   @Select("""
       SELECT
           id,
+          project_id AS projectId,
+          development_node_id AS developmentNodeId,
+          name,
+          description,
+          status,
+          current_version_id AS currentVersionId,
+          create_time AS createTime,
+          update_time AS updateTime
+      FROM yak_dataset
+      WHERE project_id = #{projectId}
+      ORDER BY update_time DESC, id DESC
+      LIMIT #{limit}
+      """)
+  List<DatasetPO> selectRecentByProject(
+      @Param("projectId") Long projectId, @Param("limit") int limit);
+
+  @Select("""
+      SELECT
+          id,
+          project_id AS projectId,
           development_node_id AS developmentNodeId,
           name,
           description,
@@ -55,4 +90,24 @@ public interface DatasetOverviewMapper {
       LIMIT #{limit}
       """)
   List<DatasetPO> selectRecentOnline(@Param("limit") int limit);
+
+  @Select("""
+      SELECT
+          id,
+          project_id AS projectId,
+          development_node_id AS developmentNodeId,
+          name,
+          description,
+          status,
+          current_version_id AS currentVersionId,
+          create_time AS createTime,
+          update_time AS updateTime
+      FROM yak_dataset
+      WHERE project_id = #{projectId}
+        AND status = 'ONLINE'
+      ORDER BY update_time DESC, id DESC
+      LIMIT #{limit}
+      """)
+  List<DatasetPO> selectRecentOnlineByProject(
+      @Param("projectId") Long projectId, @Param("limit") int limit);
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/model/DatasetPO.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/model/DatasetPO.java
@@ -13,6 +13,7 @@ public class DatasetPO {
 
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private Long developmentNodeId;
   private String name;
   private String description;

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/gateway/taskcatalog/TaskCatalogDatasetAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/gateway/taskcatalog/TaskCatalogDatasetAdapter.java
@@ -3,8 +3,13 @@ package io.yak.ops.business.dataset.gateway.taskcatalog;
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
 import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskAssetStatus;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Converts Task Catalog domain objects into Dataset-owned immutable source snapshots. */
@@ -12,14 +17,23 @@ import org.springframework.stereotype.Component;
 public class TaskCatalogDatasetAdapter implements DatasetTaskCatalogGateway {
 
   private final TaskCatalogService taskCatalogService;
+  private final CurrentProject currentProject;
 
-  public TaskCatalogDatasetAdapter(TaskCatalogService taskCatalogService) {
+  @Autowired
+  public TaskCatalogDatasetAdapter(
+      TaskCatalogService taskCatalogService, CurrentProject currentProject) {
     this.taskCatalogService = taskCatalogService;
+    this.currentProject = currentProject;
+  }
+
+  TaskCatalogDatasetAdapter(TaskCatalogService taskCatalogService) {
+    this(taskCatalogService, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
   public DatasetTaskAssetSnapshot get(long assetId) {
     TaskAsset asset = taskCatalogService.get(assetId);
+    requireCurrentProject(asset);
     long revisionId =
         asset.currentRevision() == null ? 0L : asset.currentRevision().taskRevisionId();
     int revisionNo = asset.currentRevision() == null ? 0 : asset.currentRevision().revisionNo();
@@ -52,5 +66,14 @@ public class TaskCatalogDatasetAdapter implements DatasetTaskCatalogGateway {
         resolved.revision().definition().taskType(),
         resolved.revision().definition().content(),
         resolved.revision().definition().configJson());
+  }
+
+  private void requireCurrentProject(TaskAsset asset) {
+    currentProject.current().ifPresent(
+        context -> {
+          if (asset.projectId() != null && !asset.projectId().equals(context.projectId())) {
+            throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+          }
+        });
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetOverviewRepositoryAdapter.java
@@ -5,35 +5,68 @@ import io.yak.ops.business.dataset.DatasetStatus;
 import io.yak.ops.business.dataset.dao.mapper.DatasetOverviewMapper;
 import io.yak.ops.business.dataset.dao.model.DatasetOverviewSummaryPO;
 import io.yak.ops.business.dataset.dao.model.DatasetPO;
+import io.yak.ops.core.project.CurrentProject;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /** MyBatis adapter for bounded Dataset overview projections. */
 @Repository
-@RequiredArgsConstructor
 public class DatasetOverviewRepositoryAdapter implements DatasetOverviewRepository {
 
   private final DatasetOverviewMapper mapper;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public DatasetOverviewRepositoryAdapter(
+      DatasetOverviewMapper mapper, CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.currentProject = currentProject;
+  }
+
+  DatasetOverviewRepositoryAdapter(DatasetOverviewMapper mapper) {
+    this(mapper, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public Summary summarize(Instant from, Instant to) {
+    Long projectId = currentProjectId();
     DatasetOverviewSummaryPO value =
-        mapper.selectSummary(Timestamp.from(from), Timestamp.from(to));
+        projectId == null
+            ? mapper.selectSummary(Timestamp.from(from), Timestamp.from(to))
+            : mapper.selectSummaryByProject(
+                projectId, Timestamp.from(from), Timestamp.from(to));
     if (value == null) return new Summary(0L, 0L);
     return new Summary(number(value.getDatasetCount()), number(value.getCreatedCount()));
   }
 
   @Override
   public List<Dataset> listRecent(int limit) {
-    return mapper.selectRecent(normalizeLimit(limit)).stream().map(this::toDomain).toList();
+    int normalized = normalizeLimit(limit);
+    Long projectId = currentProjectId();
+    List<DatasetPO> rows =
+        projectId == null
+            ? mapper.selectRecent(normalized)
+            : mapper.selectRecentByProject(projectId, normalized);
+    return rows.stream().map(this::toDomain).toList();
   }
 
   @Override
   public List<Dataset> listRecentOnline(int limit) {
-    return mapper.selectRecentOnline(normalizeLimit(limit)).stream().map(this::toDomain).toList();
+    int normalized = normalizeLimit(limit);
+    Long projectId = currentProjectId();
+    List<DatasetPO> rows =
+        projectId == null
+            ? mapper.selectRecentOnline(normalized)
+            : mapper.selectRecentOnlineByProject(projectId, normalized);
+    return rows.stream().map(this::toDomain).toList();
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
   }
 
   private Dataset toDomain(DatasetPO value) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapter.java
@@ -14,20 +14,35 @@ import io.yak.ops.business.dataset.dao.model.DatasetFieldPO;
 import io.yak.ops.business.dataset.dao.model.DatasetPO;
 import io.yak.ops.business.dataset.dao.model.DatasetVersionPO;
 import io.yak.ops.business.dataset.repository.support.DatasetJsonCodec;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /** Dataset aggregate persistence adapter. Domain/PO conversion is isolated here. */
 @Repository
-@RequiredArgsConstructor
 public class DatasetRepositoryAdapter implements DatasetRepository {
 
   private final DatasetDao datasetDao;
   private final DatasetJsonCodec jsonCodec;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public DatasetRepositoryAdapter(
+      DatasetDao datasetDao, DatasetJsonCodec jsonCodec, CurrentProject currentProject) {
+    this.datasetDao = datasetDao;
+    this.jsonCodec = jsonCodec;
+    this.currentProject = currentProject;
+  }
+
+  DatasetRepositoryAdapter(DatasetDao datasetDao, DatasetJsonCodec jsonCodec) {
+    this(datasetDao, jsonCodec, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public long insertDataset(String name, String description) {
@@ -42,6 +57,7 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
 
   private long insertDataset(Long developmentNodeId, String name, String description) {
     DatasetPO po = new DatasetPO();
+    po.setProjectId(currentProjectId());
     po.setDevelopmentNodeId(developmentNodeId);
     po.setName(name);
     po.setDescription(description);
@@ -55,6 +71,10 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
   @Override
   public long appendVersion(DatasetVersionDraft draft) {
     if (draft == null) throw new IllegalArgumentException("DatasetVersionDraft 不能为空");
+    Long projectId = currentProjectId();
+    if (projectId != null && datasetDao.selectDataset(projectId, draft.datasetId()) == null) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
     DatasetVersionPO version = new DatasetVersionPO();
     version.setDatasetId(draft.datasetId());
     version.setVersionNo(draft.versionNo());
@@ -91,39 +111,70 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
 
   @Override
   public void updateCurrentVersion(long datasetId, long versionId) {
-    requireSingle(datasetDao.updateCurrentVersion(datasetId, versionId), datasetId);
+    Long projectId = currentProjectId();
+    requireSingle(
+        projectId == null
+            ? datasetDao.updateCurrentVersion(datasetId, versionId)
+            : datasetDao.updateCurrentVersion(projectId, datasetId, versionId),
+        datasetId);
   }
 
   @Override
   public void updateStatus(long datasetId, DatasetStatus status) {
-    requireSingle(datasetDao.updateStatus(datasetId, status.name()), datasetId);
+    Long projectId = currentProjectId();
+    requireSingle(
+        projectId == null
+            ? datasetDao.updateStatus(datasetId, status.name())
+            : datasetDao.updateStatus(projectId, datasetId, status.name()),
+        datasetId);
   }
 
   @Override
   public void updateMetadata(long datasetId, String name, String description) {
-    requireSingle(datasetDao.updateMetadata(datasetId, name, description), datasetId);
+    Long projectId = currentProjectId();
+    requireSingle(
+        projectId == null
+            ? datasetDao.updateMetadata(datasetId, name, description)
+            : datasetDao.updateMetadata(projectId, datasetId, name, description),
+        datasetId);
   }
 
   @Override
   public Optional<Dataset> findDataset(long datasetId) {
-    return Optional.ofNullable(datasetDao.selectDataset(datasetId)).map(this::toDomain);
+    Long projectId = currentProjectId();
+    DatasetPO row =
+        projectId == null
+            ? datasetDao.selectDataset(datasetId)
+            : datasetDao.selectDataset(projectId, datasetId);
+    return Optional.ofNullable(row).map(this::toDomain);
   }
 
   @Override
   public Optional<Dataset> findDatasetBySourceTaskAssetId(long sourceTaskAssetId) {
-    return Optional.ofNullable(datasetDao.selectDatasetBySourceTaskAssetId(sourceTaskAssetId))
-        .map(this::toDomain);
+    Long projectId = currentProjectId();
+    DatasetPO row =
+        projectId == null
+            ? datasetDao.selectDatasetBySourceTaskAssetId(sourceTaskAssetId)
+            : datasetDao.selectDatasetBySourceTaskAssetId(projectId, sourceTaskAssetId);
+    return Optional.ofNullable(row).map(this::toDomain);
   }
 
   @Override
   public Optional<Dataset> findDatasetByDevelopmentNodeId(long developmentNodeId) {
-    return Optional.ofNullable(datasetDao.selectDatasetByDevelopmentNodeId(developmentNodeId))
-        .map(this::toDomain);
+    Long projectId = currentProjectId();
+    DatasetPO row =
+        projectId == null
+            ? datasetDao.selectDatasetByDevelopmentNodeId(developmentNodeId)
+            : datasetDao.selectDatasetByDevelopmentNodeId(projectId, developmentNodeId);
+    return Optional.ofNullable(row).map(this::toDomain);
   }
 
   @Override
   public List<Dataset> listDatasets() {
-    return datasetDao.selectDatasets().stream().map(this::toDomain).toList();
+    Long projectId = currentProjectId();
+    List<DatasetPO> rows =
+        projectId == null ? datasetDao.selectDatasets() : datasetDao.selectDatasets(projectId);
+    return rows.stream().map(this::toDomain).toList();
   }
 
   @Override
@@ -144,6 +195,10 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
   @Override
   public int nextVersionNo(long datasetId) {
     return datasetDao.selectNextVersionNo(datasetId);
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
   }
 
   private Dataset toDomain(DatasetPO po) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V3__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V3__expand_project_scope.sql
@@ -1,0 +1,6 @@
+-- Project Space expand migration for Dataset aggregate roots.
+-- DatasetVersion and DatasetField continue to inherit ownership through dataset_id.
+ALTER TABLE yak_dataset
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id,
+    ADD KEY idx_yak_dataset_project_status_update (project_id, status, update_time),
+    ADD KEY idx_yak_dataset_project_development_node (project_id, development_node_id);

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceCatalogController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceCatalogController.java
@@ -15,6 +15,8 @@ import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceQueryResultVO;
 import io.yak.ops.common.constant.datasource.DataSourceConstants;
 import io.yak.ops.common.constant.datasource.DataSourcePermissionCode;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping(DataSourceConstants.API_PREFIX + "/catalog")
 @RequiresPermission(DataSourcePermissionCode.READ)
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DataSourceCatalogController {
   private final DataSourceCatalogReader catalogReader;
   private final CatalogRequestConverter requestConverter;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceController.java
@@ -19,6 +19,8 @@ import io.yak.ops.common.bean.vo.datasource.DataSourceSummaryVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceVO;
 import io.yak.ops.common.constant.datasource.DataSourceConstants;
 import io.yak.ops.common.constant.datasource.DataSourcePermissionCode;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping(DataSourceConstants.API_PREFIX)
 @RequiresPermission(DataSourcePermissionCode.READ)
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DataSourceController {
   private final DataSourceManager manager;
   private final DataSourceReader reader;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
@@ -17,25 +17,51 @@ public interface DataSourceDao {
 
   DataSourcePO selectById(Long id);
 
+  DataSourcePO selectById(Long projectId, Long id);
+
   IPage<DataSourcePO> selectPage(PageQuery query);
 
   DataSourceSummaryRow selectSummary();
 
+  DataSourceSummaryRow selectSummary(Long projectId);
+
   List<DataSourcePO> selectAll(DataSourceDbType dbType);
+
+  List<DataSourcePO> selectAll(Long projectId, DataSourceDbType dbType);
 
   boolean existsByName(String name, Long excludeId);
 
+  boolean existsByName(Long projectId, String name, Long excludeId);
+
   boolean deleteById(Long id);
+
+  boolean deleteById(Long projectId, Long id);
 
   boolean updateConnectionStatus(Long id, DataSourceConnStatus connStatus);
 
+  boolean updateConnectionStatus(
+      Long projectId, Long id, DataSourceConnStatus connStatus);
+
   /** DAO 自有分页条件，不依赖 HTTP DTO。 */
   record PageQuery(
+      Long projectId,
       int pageNo,
       int pageSize,
       String name,
       String keyword,
       DataSourceDbType dbType,
       DataSourceEnvironment environment,
-      DataSourceConnStatus connStatus) {}
+      DataSourceConnStatus connStatus) {
+
+    public PageQuery(
+        int pageNo,
+        int pageSize,
+        String name,
+        String keyword,
+        DataSourceDbType dbType,
+        DataSourceEnvironment environment,
+        DataSourceConnStatus connStatus) {
+      this(null, pageNo, pageSize, name, keyword, dbType, environment, connStatus);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
@@ -36,13 +36,23 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public DataSourcePO selectById(Long id) {
-    return id == null ? null : dataSourceMapper.selectById(id);
+    return selectById(null, id);
+  }
+
+  @Override
+  public DataSourcePO selectById(Long projectId, Long id) {
+    if (id == null) return null;
+    if (projectId == null) return dataSourceMapper.selectById(id);
+    return dataSourceMapper.selectOne(
+        Wrappers.<DataSourcePO>lambdaQuery()
+            .eq(DataSourcePO::getProjectId, projectId)
+            .eq(DataSourcePO::getId, id));
   }
 
   @Override
   public IPage<DataSourcePO> selectPage(PageQuery query) {
     PageQuery condition =
-        query == null ? new PageQuery(1, 10, null, null, null, null, null) : query;
+        query == null ? new PageQuery(null, 1, 10, null, null, null, null, null) : query;
     Page<DataSourcePO> page =
         Page.of(Math.max(1, condition.pageNo()), Math.max(1, condition.pageSize()));
     return dataSourceMapper.selectPage(
@@ -58,9 +68,22 @@ public class DataSourceDaoImpl implements DataSourceDao {
   }
 
   @Override
+  public DataSourceSummaryRow selectSummary(Long projectId) {
+    return projectId == null
+        ? dataSourceMapper.selectSummary()
+        : dataSourceMapper.selectSummaryByProject(projectId);
+  }
+
+  @Override
   public List<DataSourcePO> selectAll(DataSourceDbType dbType) {
+    return selectAll(null, dbType);
+  }
+
+  @Override
+  public List<DataSourcePO> selectAll(Long projectId, DataSourceDbType dbType) {
     return dataSourceMapper.selectList(
         Wrappers.<DataSourcePO>lambdaQuery()
+            .eq(projectId != null, DataSourcePO::getProjectId, projectId)
             .eq(dbType != null, DataSourcePO::getDbType, dbType)
             .orderByAsc(DataSourcePO::getName)
             .orderByAsc(DataSourcePO::getId));
@@ -68,10 +91,16 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public boolean existsByName(String name, Long excludeId) {
+    return existsByName(null, name, excludeId);
+  }
+
+  @Override
+  public boolean existsByName(Long projectId, String name, Long excludeId) {
     if (!StringUtils.hasText(name)) return false;
     Long count =
         dataSourceMapper.selectCount(
             Wrappers.<DataSourcePO>lambdaQuery()
+                .eq(projectId != null, DataSourcePO::getProjectId, projectId)
                 .eq(DataSourcePO::getName, name)
                 .ne(excludeId != null, DataSourcePO::getId, excludeId));
     return count != null && count > 0;
@@ -79,17 +108,35 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public boolean deleteById(Long id) {
-    return id != null && dataSourceMapper.deleteById(id) > 0;
+    return deleteById(null, id);
+  }
+
+  @Override
+  public boolean deleteById(Long projectId, Long id) {
+    if (id == null) return false;
+    if (projectId == null) return dataSourceMapper.deleteById(id) > 0;
+    return dataSourceMapper.delete(
+            Wrappers.<DataSourcePO>lambdaQuery()
+                .eq(DataSourcePO::getProjectId, projectId)
+                .eq(DataSourcePO::getId, id))
+        > 0;
   }
 
   @Override
   public boolean updateConnectionStatus(Long id, DataSourceConnStatus connStatus) {
+    return updateConnectionStatus(null, id, connStatus);
+  }
+
+  @Override
+  public boolean updateConnectionStatus(
+      Long projectId, Long id, DataSourceConnStatus connStatus) {
     return id != null
         && connStatus != null
         && dataSourceMapper.update(
                 null,
                 Wrappers.<DataSourcePO>lambdaUpdate()
                     .set(DataSourcePO::getConnStatus, connStatus)
+                    .eq(projectId != null, DataSourcePO::getProjectId, projectId)
                     .eq(DataSourcePO::getId, id))
             > 0;
   }
@@ -105,6 +152,7 @@ public class DataSourceDaoImpl implements DataSourceDao {
                   .like(DataSourcePO::getJdbcUrl, query.keyword()));
     }
     return wrapper
+        .eq(query.projectId() != null, DataSourcePO::getProjectId, query.projectId())
         .like(StringUtils.hasText(query.name()), DataSourcePO::getName, query.name())
         .eq(query.dbType() != null, DataSourcePO::getDbType, query.dbType())
         .eq(query.environment() != null, DataSourcePO::getEnvironment, query.environment())

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/DataSourceMapper.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/mapper/DataSourceMapper.java
@@ -4,9 +4,12 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 /** 数据源 MyBatis 映射接口。 */
 @Mapper
 public interface DataSourceMapper extends BaseMapper<DataSourcePO> {
   DataSourceSummaryRow selectSummary();
+
+  DataSourceSummaryRow selectSummaryByProject(@Param("projectId") Long projectId);
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceDefinition.java
@@ -19,6 +19,7 @@ import lombok.ToString;
 @ToString
 public class DataSourceDefinition {
   private Long id;
+  private Long projectId;
   private String name;
   private DataSourceDbType dbType;
   @ToString.Exclude private String jdbcUrl;
@@ -48,7 +49,7 @@ public class DataSourceDefinition {
     return definition;
   }
 
-  /** Rehydrates an aggregate from persistence without replaying business state transitions. */
+  /** 保留旧持久化重建签名，供未接入 Project Space 的调用方继续使用。 */
   public static DataSourceDefinition restore(
       Long id,
       String name,
@@ -61,8 +62,38 @@ public class DataSourceDefinition {
       String originalJson,
       LocalDateTime createTime,
       LocalDateTime updateTime) {
+    return restore(
+        id,
+        null,
+        name,
+        dbType,
+        jdbcUrl,
+        environment,
+        connStatus,
+        remark,
+        connectionParams,
+        originalJson,
+        createTime,
+        updateTime);
+  }
+
+  /** Rehydrates an aggregate from persistence without replaying business state transitions. */
+  public static DataSourceDefinition restore(
+      Long id,
+      Long projectId,
+      String name,
+      DataSourceDbType dbType,
+      String jdbcUrl,
+      DataSourceEnvironment environment,
+      DataSourceConnStatus connStatus,
+      String remark,
+      String connectionParams,
+      String originalJson,
+      LocalDateTime createTime,
+      LocalDateTime updateTime) {
     DataSourceDefinition definition = new DataSourceDefinition();
     definition.id = id;
+    definition.projectId = projectId;
     definition.name = name;
     definition.dbType = dbType;
     definition.jdbcUrl = jdbcUrl;
@@ -74,6 +105,17 @@ public class DataSourceDefinition {
     definition.createTime = createTime;
     definition.updateTime = updateTime;
     return definition;
+  }
+
+  /** 在持久化前绑定可信 Project Space；已经归属其他项目时拒绝覆盖。 */
+  public void assignProject(Long projectId) {
+    if (projectId == null || projectId <= 0L) {
+      throw new IllegalArgumentException("projectId 必须大于 0");
+    }
+    if (this.projectId != null && !this.projectId.equals(projectId)) {
+      throw new IllegalStateException("数据源不允许跨 Project Space 迁移");
+    }
+    this.projectId = projectId;
   }
 
   /**

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
@@ -12,42 +12,64 @@ import io.yak.ops.business.datasource.domain.DataSourceSummary;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /** MyBatis persistence adapter; persistence rehydration is explicit and cannot mutate aggregates via setters. */
 @Repository
 @ConditionalOnDataSourceEnabled
-@RequiredArgsConstructor
 public class DataSourceRepositoryAdapter implements DataSourceRepository {
 
   private final DataSourceDao dao;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public DataSourceRepositoryAdapter(DataSourceDao dao, CurrentProject currentProject) {
+    this.dao = dao;
+    this.currentProject = currentProject;
+  }
+
+  DataSourceRepositoryAdapter(DataSourceDao dao) {
+    this(dao, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public Optional<DataSourceDefinition> findById(Long id) {
-    return Optional.ofNullable(toDomain(dao.selectById(id)));
+    Long projectId = currentProjectId();
+    DataSourcePO row = projectId == null ? dao.selectById(id) : dao.selectById(projectId, id);
+    return Optional.ofNullable(toDomain(row));
   }
 
   @Override
   public boolean insert(DataSourceDefinition definition) {
+    currentProject.current().ifPresent(context -> definition.assignProject(context.projectId()));
     return dao.addDataSource(toPO(definition)) > 0;
   }
 
   @Override
   public boolean update(DataSourceDefinition definition) {
+    ensureCurrentProject(definition.getProjectId());
     return dao.editDataSource(toPO(definition)) > 0;
   }
 
   @Override
   public boolean delete(Long id) {
-    return dao.deleteById(id);
+    Long projectId = currentProjectId();
+    return projectId == null ? dao.deleteById(id) : dao.deleteById(projectId, id);
   }
 
   @Override
   public boolean existsByName(String name, Long excludeId) {
-    return dao.existsByName(name, excludeId);
+    Long projectId = currentProjectId();
+    return projectId == null
+        ? dao.existsByName(name, excludeId)
+        : dao.existsByName(projectId, name, excludeId);
   }
 
   @Override
@@ -57,6 +79,7 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
     IPage<DataSourcePO> page =
         dao.selectPage(
             new PageQuery(
+                currentProjectId(),
                 condition.pageNo(),
                 condition.pageSize(),
                 condition.name(),
@@ -75,12 +98,17 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
 
   @Override
   public List<DataSourceDefinition> findAll(DataSourceDbType dbType) {
-    return dao.selectAll(dbType).stream().map(this::toDomain).toList();
+    Long projectId = currentProjectId();
+    List<DataSourcePO> rows =
+        projectId == null ? dao.selectAll(dbType) : dao.selectAll(projectId, dbType);
+    return rows.stream().map(this::toDomain).toList();
   }
 
   @Override
   public DataSourceSummary summary() {
-    DataSourceSummaryRow row = dao.selectSummary();
+    Long projectId = currentProjectId();
+    DataSourceSummaryRow row =
+        projectId == null ? dao.selectSummary() : dao.selectSummary(projectId);
     return row == null
         ? DataSourceSummary.empty()
         : new DataSourceSummary(
@@ -93,13 +121,30 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
 
   @Override
   public boolean updateConnectionStatus(Long id, DataSourceConnStatus status) {
-    return dao.updateConnectionStatus(id, status);
+    Long projectId = currentProjectId();
+    return projectId == null
+        ? dao.updateConnectionStatus(id, status)
+        : dao.updateConnectionStatus(projectId, id, status);
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private void ensureCurrentProject(Long ownerProjectId) {
+    currentProject.current().ifPresent(
+        context -> {
+          if (!Objects.equals(context.projectId(), ownerProjectId)) {
+            throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+          }
+        });
   }
 
   private DataSourceDefinition toDomain(DataSourcePO po) {
     if (po == null) return null;
     return DataSourceDefinition.restore(
         po.getId(),
+        po.getProjectId(),
         po.getName(),
         po.getDbType(),
         po.getJdbcUrl(),
@@ -115,6 +160,7 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
   private DataSourcePO toPO(DataSourceDefinition definition) {
     DataSourcePO po = new DataSourcePO();
     po.setId(definition.getId());
+    po.setProjectId(definition.getProjectId());
     po.setName(definition.getName());
     po.setDbType(definition.getDbType());
     po.setJdbcUrl(definition.getJdbcUrl());

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V9__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V9__expand_project_scope.sql
@@ -1,0 +1,8 @@
+-- Project Space expand migration for datasource roots.
+-- The column remains nullable until historical rows are backfilled and optional mode is retired.
+ALTER TABLE yak_ops_data_source
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id,
+    DROP INDEX uk_yak_ops_data_source_name,
+    ADD UNIQUE KEY uk_yak_ops_data_source_project_name (project_id, name),
+    ADD KEY idx_yak_ops_data_source_project_update (project_id, update_time),
+    ADD KEY idx_yak_ops_data_source_project_status (project_id, conn_status);

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/DataSourceMapper.xml
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/DataSourceMapper.xml
@@ -4,14 +4,25 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.yak.ops.business.datasource.dao.mapper.DataSourceMapper">
 
+    <sql id="summaryColumns">
+        COUNT(*) AS total,
+        COALESCE(SUM(CASE WHEN conn_status = 'CONNECTED' THEN 1 ELSE 0 END), 0) AS connected,
+        COALESCE(SUM(CASE WHEN conn_status = 'DISCONNECTED' THEN 1 ELSE 0 END), 0) AS disconnected,
+        COALESCE(SUM(CASE WHEN conn_status = 'UNKNOWN' THEN 1 ELSE 0 END), 0) AS unknown,
+        COUNT(DISTINCT environment) AS environment_count
+    </sql>
+
     <select id="selectSummary"
             resultType="io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow">
-        SELECT COUNT(*) AS total,
-               COALESCE(SUM(CASE WHEN conn_status = 'CONNECTED' THEN 1 ELSE 0 END), 0) AS connected,
-               COALESCE(SUM(CASE WHEN conn_status = 'DISCONNECTED' THEN 1 ELSE 0 END), 0) AS disconnected,
-               COALESCE(SUM(CASE WHEN conn_status = 'UNKNOWN' THEN 1 ELSE 0 END), 0) AS unknown,
-               COUNT(DISTINCT environment) AS environment_count
+        SELECT <include refid="summaryColumns"/>
         FROM yak_ops_data_source
+    </select>
+
+    <select id="selectSummaryByProject"
+            resultType="io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow">
+        SELECT <include refid="summaryColumns"/>
+        FROM yak_ops_data_source
+        WHERE project_id = #{projectId}
     </select>
 
 </mapper>

--- a/yak-ops-business/yak-ops-business-resource/pom.xml
+++ b/yak-ops-business/yak-ops-business-resource/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/content/ResourceContentManager.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/content/ResourceContentManager.java
@@ -6,6 +6,7 @@ import io.yak.ops.business.resource.domain.ResourceNode;
 import io.yak.ops.business.resource.domain.ResourceNodeFactory;
 import io.yak.ops.business.resource.domain.ResourcePath;
 import io.yak.ops.business.resource.domain.ResourceRevision;
+import io.yak.ops.business.resource.domain.ResourceStoragePath;
 import io.yak.ops.business.resource.exception.ResourceException;
 import io.yak.ops.business.resource.namespace.ResourceNamePolicy;
 import io.yak.ops.business.resource.namespace.ResourceNamespaceReader;
@@ -57,7 +58,7 @@ public class ResourceContentManager {
     String name = names.normalize(sourceName);
     ensureNameAvailable(parent.id(), name, null);
     ResourcePath fullPath = new ResourcePath(parent.fullPath()).child(name);
-    String storagePath = fullPath.storagePath();
+    String storagePath = ResourceStoragePath.forProject(parent.projectId(), fullPath);
     String contentType = policy.contentType(source.contentType());
     String checksumValue = checksum.sha256(source);
 
@@ -76,6 +77,7 @@ public class ResourceContentManager {
               source.size(),
               checksumValue,
               description);
+      resource.setProjectId(parent.projectId());
       insert(resource);
       changes.dispatchAfterCommit(resource, ResourceFileSyncAction.CREATED, null);
       return resource;
@@ -97,7 +99,7 @@ public class ResourceContentManager {
     policy.ensureEditableName(name);
     ensureNameAvailable(parent.id(), name, null);
     ResourcePath fullPath = new ResourcePath(parent.fullPath()).child(name);
-    String storagePath = fullPath.storagePath();
+    String storagePath = ResourceStoragePath.forProject(parent.projectId(), fullPath);
     String contentType = policy.contentType(command.contentType());
 
     storage.write(
@@ -121,6 +123,7 @@ public class ResourceContentManager {
               (long) content.length,
               checksum.sha256(content),
               command.description());
+      resource.setProjectId(parent.projectId());
       insert(resource);
       changes.dispatchAfterCommit(resource, ResourceFileSyncAction.CREATED, null);
       return resource;
@@ -238,9 +241,7 @@ public class ResourceContentManager {
   }
 
   private int lineCount(String content) {
-    if (content == null || content.isEmpty()) {
-      return 0;
-    }
+    if (content == null || content.isEmpty()) return 0;
     return (int) content.lines().count();
   }
 }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
@@ -25,6 +25,8 @@ import io.yak.ops.common.bean.vo.resource.ResourceContentVO;
 import io.yak.ops.common.bean.vo.resource.ResourceStoragePluginVO;
 import io.yak.ops.common.bean.vo.resource.ResourceVO;
 import io.yak.ops.common.constant.resource.ResourcePermissionCode;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -57,6 +59,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/resources")
 @RequiresPermission(ResourcePermissionCode.READ)
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class ResourcesController {
 
   private final ResourceNamespaceManager namespaceManager;

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/ResourceDao.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/ResourceDao.java
@@ -14,15 +14,28 @@ public interface ResourceDao {
 
   ResourcePO selectById(Long id);
 
+  ResourcePO selectById(Long projectId, Long id);
+
   ResourcePO selectByFullPath(String fullPath);
+
+  ResourcePO selectByFullPath(Long projectId, String fullPath);
 
   boolean existsByParentAndName(Long parentId, String name, Long excludeId);
 
+  boolean existsByParentAndName(
+      Long projectId, Long parentId, String name, Long excludeId);
+
   List<ResourcePO> selectChildren(Long parentId, String keyword);
+
+  List<ResourcePO> selectChildren(Long projectId, Long parentId, String keyword);
 
   List<ResourcePO> selectAll();
 
+  List<ResourcePO> selectAll(Long projectId);
+
   List<ResourcePO> selectDescendants(String fullPath);
+
+  List<ResourcePO> selectDescendants(Long projectId, String fullPath);
 
   IPage<ResourcePO> selectPage(PageQuery query);
 
@@ -30,11 +43,24 @@ public interface ResourceDao {
 
   boolean deleteBatch(List<Long> ids);
 
+  boolean deleteBatch(Long projectId, List<Long> ids);
+
   /** DAO 自有分页条件，不依赖 HTTP DTO。 */
   record PageQuery(
+      Long projectId,
       int pageNo,
       int pageSize,
       Long parentId,
       String keyword,
-      ResourceNodeType nodeType) {}
+      ResourceNodeType nodeType) {
+
+    public PageQuery(
+        int pageNo,
+        int pageSize,
+        Long parentId,
+        String keyword,
+        ResourceNodeType nodeType) {
+      this(null, pageNo, pageSize, parentId, keyword, nodeType);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
@@ -34,23 +34,45 @@ public class ResourceDaoImpl implements ResourceDao {
 
   @Override
   public ResourcePO selectById(Long id) {
-    return id == null ? null : resourceMapper.selectById(id);
+    return selectById(null, id);
+  }
+
+  @Override
+  public ResourcePO selectById(Long projectId, Long id) {
+    if (id == null) return null;
+    if (projectId == null) return resourceMapper.selectById(id);
+    return resourceMapper.selectOne(
+        Wrappers.<ResourcePO>lambdaQuery()
+            .eq(ResourcePO::getProjectId, projectId)
+            .eq(ResourcePO::getId, id));
   }
 
   @Override
   public ResourcePO selectByFullPath(String fullPath) {
-    if (!StringUtils.hasText(fullPath)) {
-      return null;
-    }
+    return selectByFullPath(null, fullPath);
+  }
+
+  @Override
+  public ResourcePO selectByFullPath(Long projectId, String fullPath) {
+    if (!StringUtils.hasText(fullPath)) return null;
     return resourceMapper.selectOne(
-        Wrappers.<ResourcePO>lambdaQuery().eq(ResourcePO::getFullPath, fullPath));
+        Wrappers.<ResourcePO>lambdaQuery()
+            .eq(projectId != null, ResourcePO::getProjectId, projectId)
+            .eq(ResourcePO::getFullPath, fullPath));
   }
 
   @Override
   public boolean existsByParentAndName(Long parentId, String name, Long excludeId) {
+    return existsByParentAndName(null, parentId, name, excludeId);
+  }
+
+  @Override
+  public boolean existsByParentAndName(
+      Long projectId, Long parentId, String name, Long excludeId) {
     Long count =
         resourceMapper.selectCount(
             Wrappers.<ResourcePO>lambdaQuery()
+                .eq(projectId != null, ResourcePO::getProjectId, projectId)
                 .eq(ResourcePO::getParentId, parentId == null ? 0L : parentId)
                 .eq(ResourcePO::getName, name)
                 .ne(excludeId != null, ResourcePO::getId, excludeId));
@@ -59,8 +81,14 @@ public class ResourceDaoImpl implements ResourceDao {
 
   @Override
   public List<ResourcePO> selectChildren(Long parentId, String keyword) {
+    return selectChildren(null, parentId, keyword);
+  }
+
+  @Override
+  public List<ResourcePO> selectChildren(Long projectId, Long parentId, String keyword) {
     return resourceMapper.selectList(
         Wrappers.<ResourcePO>lambdaQuery()
+            .eq(projectId != null, ResourcePO::getProjectId, projectId)
             .eq(ResourcePO::getParentId, parentId == null ? 0L : parentId)
             .and(
                 StringUtils.hasText(keyword),
@@ -75,30 +103,41 @@ public class ResourceDaoImpl implements ResourceDao {
 
   @Override
   public List<ResourcePO> selectAll() {
+    return selectAll(null);
+  }
+
+  @Override
+  public List<ResourcePO> selectAll(Long projectId) {
     return resourceMapper.selectList(
         Wrappers.<ResourcePO>lambdaQuery()
+            .eq(projectId != null, ResourcePO::getProjectId, projectId)
             .orderByAsc(ResourcePO::getFullPath)
             .orderByAsc(ResourcePO::getId));
   }
 
   @Override
   public List<ResourcePO> selectDescendants(String fullPath) {
-    if (!StringUtils.hasText(fullPath)) {
-      return Collections.emptyList();
-    }
+    return selectDescendants(null, fullPath);
+  }
+
+  @Override
+  public List<ResourcePO> selectDescendants(Long projectId, String fullPath) {
+    if (!StringUtils.hasText(fullPath)) return Collections.emptyList();
     return resourceMapper.selectList(
         Wrappers.<ResourcePO>lambdaQuery()
+            .eq(projectId != null, ResourcePO::getProjectId, projectId)
             .likeRight(ResourcePO::getFullPath, fullPath + "/")
             .orderByAsc(ResourcePO::getFullPath));
   }
 
   @Override
   public IPage<ResourcePO> selectPage(PageQuery query) {
-    PageQuery condition = query == null ? new PageQuery(1, 20, null, null, null) : query;
+    PageQuery condition = query == null ? new PageQuery(null, 1, 20, null, null, null) : query;
     Page<ResourcePO> page =
         Page.of(Math.max(1, condition.pageNo()), Math.max(1, condition.pageSize()));
     LambdaQueryWrapper<ResourcePO> wrapper = Wrappers.lambdaQuery();
     wrapper
+        .eq(condition.projectId() != null, ResourcePO::getProjectId, condition.projectId())
         .eq(condition.parentId() != null, ResourcePO::getParentId, condition.parentId())
         .and(
             StringUtils.hasText(condition.keyword()),
@@ -115,19 +154,26 @@ public class ResourceDaoImpl implements ResourceDao {
 
   @Override
   public boolean updateBatch(List<ResourcePO> resources) {
-    if (resources == null || resources.isEmpty()) {
-      return true;
-    }
+    if (resources == null || resources.isEmpty()) return true;
     for (ResourcePO resource : resources) {
-      if (resourceMapper.updateById(resource) <= 0) {
-        return false;
-      }
+      if (resourceMapper.updateById(resource) <= 0) return false;
     }
     return true;
   }
 
   @Override
   public boolean deleteBatch(List<Long> ids) {
-    return ids != null && !ids.isEmpty() && resourceMapper.deleteByIds(ids) == ids.size();
+    return deleteBatch(null, ids);
+  }
+
+  @Override
+  public boolean deleteBatch(Long projectId, List<Long> ids) {
+    if (ids == null || ids.isEmpty()) return false;
+    if (projectId == null) return resourceMapper.deleteByIds(ids) == ids.size();
+    return resourceMapper.delete(
+            Wrappers.<ResourcePO>lambdaQuery()
+                .eq(ResourcePO::getProjectId, projectId)
+                .in(ResourcePO::getId, ids))
+        == ids.size();
   }
 }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/domain/ResourceNode.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/domain/ResourceNode.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 public class ResourceNode {
 
   private Long id;
+  private Long projectId;
   private Long parentId;
   private String name;
   private String fullPath;
@@ -31,6 +32,17 @@ public class ResourceNode {
 
   public void setId(Long id) {
     this.id = id;
+  }
+
+  public Long getProjectId() {
+    return projectId;
+  }
+
+  public void setProjectId(Long projectId) {
+    if (projectId != null && projectId <= 0L) {
+      throw new IllegalArgumentException("projectId must be positive");
+    }
+    this.projectId = projectId;
   }
 
   public Long getParentId() {
@@ -162,6 +174,7 @@ public class ResourceNode {
       return false;
     }
     return Objects.equals(id, other.id)
+        && Objects.equals(projectId, other.projectId)
         && Objects.equals(parentId, other.parentId)
         && Objects.equals(name, other.name)
         && Objects.equals(fullPath, other.fullPath)
@@ -183,6 +196,7 @@ public class ResourceNode {
   public int hashCode() {
     return Objects.hash(
         id,
+        projectId,
         parentId,
         name,
         fullPath,
@@ -204,6 +218,7 @@ public class ResourceNode {
   public String toString() {
     return "ResourceNode{" +
         "id=" + id +
+        ", projectId=" + projectId +
         ", parentId=" + parentId +
         ", name='" + name + '\'' +
         ", fullPath='" + fullPath + '\'' +

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/domain/ResourceStoragePath.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/domain/ResourceStoragePath.java
@@ -1,0 +1,14 @@
+package io.yak.ops.business.resource.domain;
+
+/** Builds physical storage paths without leaking Project Space prefixes into logical paths. */
+public final class ResourceStoragePath {
+
+  private static final String PROJECT_ROOT = "projects/";
+
+  private ResourceStoragePath() {}
+
+  public static String forProject(Long projectId, ResourcePath logicalPath) {
+    String path = logicalPath.storagePath();
+    return projectId == null ? path : PROJECT_ROOT + projectId + "/" + path;
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceNamespaceManager.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceNamespaceManager.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
 import io.yak.ops.business.resource.domain.ResourceNode;
 import io.yak.ops.business.resource.domain.ResourceNodeFactory;
 import io.yak.ops.business.resource.domain.ResourcePath;
+import io.yak.ops.business.resource.domain.ResourceStoragePath;
 import io.yak.ops.business.resource.exception.ResourceException;
 import io.yak.ops.business.resource.repository.ResourceRepository;
 import io.yak.ops.business.resource.storage.ResourceStorageGateway;
@@ -42,7 +43,7 @@ public class ResourceNamespaceManager {
     String name = names.normalize(command.name());
     ensureNameAvailable(parent.id(), name, null);
     ResourcePath fullPath = new ResourcePath(parent.fullPath()).child(name);
-    String storagePath = fullPath.storagePath();
+    String storagePath = ResourceStoragePath.forProject(parent.projectId(), fullPath);
 
     storage.createDirectory(parent.storageType(), storagePath);
     try {
@@ -59,6 +60,7 @@ public class ResourceNamespaceManager {
               0L,
               null,
               command.description());
+      resource.setProjectId(parent.projectId());
       insert(resource);
       changes.dispatchAfterCommit(resource, ResourceFileSyncAction.CREATED, null);
       return resource;
@@ -137,6 +139,10 @@ public class ResourceNamespaceManager {
     if (targetParent.storageType() != resource.getStorageType()) {
       throw new ResourceException(ResourceErrorCode.CROSS_STORAGE_MOVE_UNSUPPORTED);
     }
+    if (resource.getProjectId() != null
+        && !resource.getProjectId().equals(targetParent.projectId())) {
+      throw new ResourceException(ResourceErrorCode.INVALID_MOVE_TARGET);
+    }
 
     ResourcePath oldPath = new ResourcePath(resource.getFullPath());
     ResourcePath newPath = new ResourcePath(targetParent.fullPath()).child(targetName);
@@ -150,7 +156,7 @@ public class ResourceNamespaceManager {
     }
 
     String oldStoragePath = resource.getStoragePath();
-    String newStoragePath = newPath.storagePath();
+    String newStoragePath = ResourceStoragePath.forProject(resource.getProjectId(), newPath);
     storage.move(resource.getStorageType(), oldStoragePath, newStoragePath, false);
 
     List<ResourceNode> updates = new ArrayList<>();
@@ -165,7 +171,9 @@ public class ResourceNamespaceManager {
       for (ResourceNode descendant : repository.findDescendants(oldPath.value())) {
         String suffix = descendant.getFullPath().substring(oldPath.value().length());
         descendant.setFullPath(newPath.value() + suffix);
-        descendant.setStoragePath(new ResourcePath(descendant.getFullPath()).storagePath());
+        descendant.setStoragePath(
+            ResourceStoragePath.forProject(
+                descendant.getProjectId(), new ResourcePath(descendant.getFullPath())));
         bumpNamespaceRevision(descendant);
         updates.add(descendant);
       }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceParentResolver.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceParentResolver.java
@@ -8,22 +8,39 @@ import io.yak.ops.business.resource.storage.ResourceStorageGateway;
 import io.yak.ops.common.enums.resource.ResourceErrorCode;
 import io.yak.ops.common.enums.resource.ResourceNodeType;
 import io.yak.ops.common.enums.resource.ResourceStorageType;
-import lombok.RequiredArgsConstructor;
+import io.yak.ops.core.project.CurrentProject;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Resolves the logical parent and the storage binding inherited by new or moved resources. */
 @Component
 @ConditionalOnResourceEnabled
-@RequiredArgsConstructor
 public class ResourceParentResolver {
 
   private final ResourceRepository repository;
   private final ResourceStorageGateway storage;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public ResourceParentResolver(
+      ResourceRepository repository,
+      ResourceStorageGateway storage,
+      CurrentProject currentProject) {
+    this.repository = repository;
+    this.storage = storage;
+    this.currentProject = currentProject;
+  }
+
+  ResourceParentResolver(ResourceRepository repository, ResourceStorageGateway storage) {
+    this(repository, storage, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   public Parent resolve(Long parentId) {
     long normalized = normalize(parentId);
     if (normalized == 0L) {
-      return new Parent(0L, "/", storage.defaultType());
+      Long projectId = currentProject.current().map(context -> context.projectId()).orElse(null);
+      return new Parent(0L, "/", storage.defaultType(), projectId);
     }
     ResourceNode parent =
         repository.findById(normalized)
@@ -31,13 +48,14 @@ public class ResourceParentResolver {
     if (parent.getNodeType() != ResourceNodeType.DIRECTORY) {
       throw new ResourceException(ResourceErrorCode.PARENT_NOT_DIRECTORY);
     }
-    return new Parent(parent.getId(), parent.getFullPath(), parent.getStorageType());
+    return new Parent(
+        parent.getId(), parent.getFullPath(), parent.getStorageType(), parent.getProjectId());
   }
 
   public long normalize(Long parentId) {
     return parentId == null || parentId <= 0L ? 0L : parentId;
   }
 
-  public record Parent(Long id, String fullPath, ResourceStorageType storageType) {
-  }
+  public record Parent(
+      Long id, String fullPath, ResourceStorageType storageType, Long projectId) {}
 }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
@@ -8,78 +8,121 @@ import io.yak.ops.business.resource.dao.ResourceDao.PageQuery;
 import io.yak.ops.business.resource.domain.ResourceNode;
 import io.yak.ops.business.resource.domain.ResourceQuery;
 import io.yak.ops.common.bean.po.resource.ResourcePO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /** Explicit persistence adapter between Resource domain metadata and MyBatis persistence models. */
 @Repository
 @ConditionalOnResourceEnabled
-@RequiredArgsConstructor
 public class ResourceRepositoryAdapter implements ResourceRepository {
 
   private final ResourceDao resourceDao;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public ResourceRepositoryAdapter(ResourceDao resourceDao, CurrentProject currentProject) {
+    this.resourceDao = resourceDao;
+    this.currentProject = currentProject;
+  }
+
+  ResourceRepositoryAdapter(ResourceDao resourceDao) {
+    this(resourceDao, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public Optional<ResourceNode> findById(Long id) {
-    return Optional.ofNullable(resourceDao.selectById(id)).map(this::toDomain);
+    Long projectId = currentProjectId();
+    ResourcePO row =
+        projectId == null ? resourceDao.selectById(id) : resourceDao.selectById(projectId, id);
+    return Optional.ofNullable(row).map(this::toDomain);
   }
 
   @Override
   public Optional<ResourceNode> findByFullPath(String fullPath) {
-    return Optional.ofNullable(resourceDao.selectByFullPath(fullPath)).map(this::toDomain);
+    Long projectId = currentProjectId();
+    ResourcePO row =
+        projectId == null
+            ? resourceDao.selectByFullPath(fullPath)
+            : resourceDao.selectByFullPath(projectId, fullPath);
+    return Optional.ofNullable(row).map(this::toDomain);
   }
 
   @Override
   public boolean existsByParentAndName(Long parentId, String name, Long excludeId) {
-    return resourceDao.existsByParentAndName(parentId, name, excludeId);
+    Long projectId = currentProjectId();
+    return projectId == null
+        ? resourceDao.existsByParentAndName(parentId, name, excludeId)
+        : resourceDao.existsByParentAndName(projectId, parentId, name, excludeId);
   }
 
   @Override
   public boolean insert(ResourceNode resource) {
-    if (resource == null) {
-      return false;
-    }
+    if (resource == null) return false;
+    currentProject.current().ifPresent(
+        context -> {
+          ensureCurrentProject(resource.getProjectId());
+          resource.setProjectId(context.projectId());
+        });
     ResourcePO po = toPersistence(resource);
     boolean inserted = resourceDao.insert(po) > 0;
-    if (inserted) {
-      resource.setId(po.getId());
-    }
+    if (inserted) resource.setId(po.getId());
     return inserted;
   }
 
   @Override
   public boolean update(ResourceNode resource) {
-    return resource != null && resourceDao.update(toPersistence(resource));
+    if (resource == null) return false;
+    ensureCurrentProject(resource.getProjectId());
+    return resourceDao.update(toPersistence(resource));
   }
 
   @Override
   public boolean updateBatch(List<ResourceNode> resources) {
-    if (resources == null || resources.isEmpty()) {
-      return true;
-    }
+    if (resources == null || resources.isEmpty()) return true;
+    resources.forEach(resource -> ensureCurrentProject(resource.getProjectId()));
     return resourceDao.updateBatch(resources.stream().map(this::toPersistence).toList());
   }
 
   @Override
   public boolean deleteBatch(List<Long> ids) {
-    return resourceDao.deleteBatch(ids);
+    Long projectId = currentProjectId();
+    return projectId == null
+        ? resourceDao.deleteBatch(ids)
+        : resourceDao.deleteBatch(projectId, ids);
   }
 
   @Override
   public List<ResourceNode> findChildren(Long parentId, String keyword) {
-    return resourceDao.selectChildren(parentId, keyword).stream().map(this::toDomain).toList();
+    Long projectId = currentProjectId();
+    List<ResourcePO> rows =
+        projectId == null
+            ? resourceDao.selectChildren(parentId, keyword)
+            : resourceDao.selectChildren(projectId, parentId, keyword);
+    return rows.stream().map(this::toDomain).toList();
   }
 
   @Override
   public List<ResourceNode> findAll() {
-    return resourceDao.selectAll().stream().map(this::toDomain).toList();
+    Long projectId = currentProjectId();
+    List<ResourcePO> rows =
+        projectId == null ? resourceDao.selectAll() : resourceDao.selectAll(projectId);
+    return rows.stream().map(this::toDomain).toList();
   }
 
   @Override
   public List<ResourceNode> findDescendants(String fullPath) {
-    return resourceDao.selectDescendants(fullPath).stream().map(this::toDomain).toList();
+    Long projectId = currentProjectId();
+    List<ResourcePO> rows =
+        projectId == null
+            ? resourceDao.selectDescendants(fullPath)
+            : resourceDao.selectDescendants(projectId, fullPath);
+    return rows.stream().map(this::toDomain).toList();
   }
 
   @Override
@@ -89,6 +132,7 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
         : query;
     IPage<ResourcePO> page = resourceDao.selectPage(
         new PageQuery(
+            currentProjectId(),
             condition.pageNo(),
             condition.pageSize(),
             condition.parentId(),
@@ -102,12 +146,24 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
         page.getSize());
   }
 
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private void ensureCurrentProject(Long ownerProjectId) {
+    currentProject.current().ifPresent(
+        context -> {
+          if (ownerProjectId != null && !Objects.equals(context.projectId(), ownerProjectId)) {
+            throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+          }
+        });
+  }
+
   ResourceNode toDomain(ResourcePO po) {
-    if (po == null) {
-      return null;
-    }
+    if (po == null) return null;
     ResourceNode domain = new ResourceNode();
     domain.setId(po.getId());
+    domain.setProjectId(po.getProjectId());
     domain.setParentId(po.getParentId());
     domain.setName(po.getName());
     domain.setFullPath(po.getFullPath());
@@ -129,6 +185,7 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
   ResourcePO toPersistence(ResourceNode domain) {
     ResourcePO po = new ResourcePO();
     po.setId(domain.getId());
+    po.setProjectId(domain.getProjectId());
     po.setParentId(domain.getParentId());
     po.setName(domain.getName());
     po.setFullPath(domain.getFullPath());

--- a/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V2__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V2__expand_project_scope.sql
@@ -1,0 +1,8 @@
+-- Project Space expand migration for resource nodes.
+-- Every node owns project_id because tree, path, download and delete queries run independently.
+ALTER TABLE yak_ops_resource
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id,
+    DROP INDEX uk_yak_resource_parent_name,
+    ADD UNIQUE KEY uk_yak_resource_project_parent_name (project_id, parent_id, name),
+    ADD KEY idx_yak_resource_project_path (project_id, full_path(255)),
+    ADD KEY idx_yak_resource_project_parent_type (project_id, parent_id, node_type);

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/datasource/DataSourcePO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/datasource/DataSourcePO.java
@@ -19,6 +19,9 @@ public class DataSourcePO {
   @TableId(type = IdType.AUTO)
   private Long id;
 
+  /** 所属 Project Space；兼容期允许历史数据为空。 */
+  private Long projectId;
+
   /** 数据源名称。 */
   private String name;
 

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/resource/ResourcePO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/resource/ResourcePO.java
@@ -15,6 +15,7 @@ public class ResourcePO {
 
   @TableId(type = IdType.ASSIGN_ID)
   private Long id;
+  private Long projectId;
   private Long parentId;
   private String name;
   private String fullPath;

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -16,8 +16,14 @@ const rules: ProjectRequestRule[] = [
 describe('Project Space request context', () => {
   afterEach(() => clearStoredProjectId());
 
-  it('keeps all current routes legacy-global before a module opts into migration', () => {
-    expect(resolveProjectRequestMode('/api/v1/data-source')).toBe('LEGACY_GLOBAL');
+  it('opts the first migrated business routes into optional project context', () => {
+    expect(resolveProjectRequestMode('/api/v1/data-source')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/resources/tree')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/datasets/1')).toBe('PROJECT_OPTIONAL');
+  });
+
+  it('keeps modules outside the rollout table legacy-global', () => {
+    expect(resolveProjectRequestMode('/api/v1/workflows')).toBe('LEGACY_GLOBAL');
   });
 
   it('uses the most specific project-aware route rule', () => {
@@ -26,15 +32,15 @@ describe('Project Space request context', () => {
   });
 
   it('never attaches a project header to a legacy-global route', () => {
-    const headers = applyCurrentProjectHeader('/api/v1/data-source', {}, '7');
+    const headers = applyCurrentProjectHeader('/api/v1/workflows', {}, '7');
     expect(headers).toEqual({});
   });
 
-  it('attaches the stored project only after a route opts into project migration', () => {
+  it('attaches the stored project to migrated routes', () => {
     storeProjectId(7);
     expect(readStoredProjectId()).toBe('7');
 
-    const headers = applyCurrentProjectHeader('/api/v1/data-source/1', {}, undefined, rules);
+    const headers = applyCurrentProjectHeader('/api/v1/data-source/1', {});
     expect(headers).toEqual({ [PROJECT_ID_HEADER]: '7' });
   });
 

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -11,15 +11,12 @@ export type ProjectRequestRule = {
   mode: Exclude<ProjectMigrationMode, 'LEGACY_GLOBAL'>;
 };
 
-/**
- * Project-aware API rollout table.
- *
- * PR2 intentionally keeps this empty: all current business modules are still
- * LEGACY_GLOBAL. PR3+ will add a route only after its backend has entered
- * PROJECT_OPTIONAL/PROJECT_REQUIRED, so old modules never change semantics by
- * merely receiving the new infrastructure.
- */
-export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [];
+/** Project-aware API rollout table kept in lockstep with backend @ProjectScope adoption. */
+export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
+  { prefix: '/api/v1/data-source', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/resources', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/datasets', mode: 'PROJECT_OPTIONAL' },
+];
 
 const normalizePath = (url: string): string => {
   try {


### PR DESCRIPTION
## 背景

PR1 已固定 Project Space 数据边界，PR2 已建立可信 `CurrentProject`、成员校验、`@ProjectScope` 与前端 Project Header 通道。本 PR 进入第一批真实业务数据迁移：

```text
DataSource
  -> File Resource
  -> Dataset
```

本 PR 当前以 Draft 形式持续收口，采用 **Expand -> Backfill -> Contract**，不会在未完成历史数据核验前直接把 `project_id` 收紧为 `NOT NULL`。

## 当前已提交

### DataSource

- `yak_ops_data_source` 增加 nullable `project_id`；
- 名称唯一约束由全局调整为 `(project_id, name)`；
- 数据源列表、详情、统计、名称校验、删除和连接状态更新在存在可信项目上下文时自动附加项目条件；
- 新建数据源在请求已绑定项目时写入可信 `project_id`，不读取请求体中的项目字段；
- 数据源管理和 Catalog Controller 进入 `PROJECT_OPTIONAL`。

## 本 Draft 后续提交

- File Resource：节点级 `project_id`、项目内父子/路径隔离、物理存储命名空间；
- Dataset：根记录 `project_id`、Repository/Overview/性能诊断隔离、来源资源同项目校验；
- 前端：只对完成迁移的 API 家族注入 Project Header；
- 历史数据回填 Runbook、验证 SQL 和切换 `PROJECT_REQUIRED` 的验收条件；
- 针对 Repository/DAO/Controller 的项目隔离测试。

## 兼容边界

- 当前仍为 `PROJECT_OPTIONAL`；无 Header 时保留旧全局读取语义；
- 不迁移 Sync、Workflow、Quality、Analysis、Dashboard、Data Service、Lineage；
- 不开放项目切换器和项目空间菜单；
- 不建立业务库到 Yak Security Project 的物理外键；
- 不在本 Draft 初始提交中执行 `NOT NULL` 收口。

## 验证状态

- GitHub Actions：等待 Draft PR workflow；
- 完整 Maven / npm / 数据库迁移验证：待本 PR 的三个模块提交完成后统一执行并回填结果。