### PR TITLE
test(project-space): harden PR3 scoped repository boundaries

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/gateway/taskcatalog/TaskCatalogDatasetAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/gateway/taskcatalog/TaskCatalogDatasetAdapter.java
@@ -26,7 +26,7 @@ public class TaskCatalogDatasetAdapter implements DatasetTaskCatalogGateway {
     this.currentProject = currentProject;
   }
 
-  TaskCatalogDatasetAdapter(TaskCatalogService taskCatalogService) {
+  public TaskCatalogDatasetAdapter(TaskCatalogService taskCatalogService) {
     this(taskCatalogService, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetOverviewRepositoryAdapter.java
@@ -27,7 +27,7 @@ public class DatasetOverviewRepositoryAdapter implements DatasetOverviewReposito
     this.currentProject = currentProject;
   }
 
-  DatasetOverviewRepositoryAdapter(DatasetOverviewMapper mapper) {
+  public DatasetOverviewRepositoryAdapter(DatasetOverviewMapper mapper) {
     this(mapper, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapter.java
@@ -40,7 +40,7 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
     this.currentProject = currentProject;
   }
 
-  DatasetRepositoryAdapter(DatasetDao datasetDao, DatasetJsonCodec jsonCodec) {
+  public DatasetRepositoryAdapter(DatasetDao datasetDao, DatasetJsonCodec jsonCodec) {
     this(datasetDao, jsonCodec, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapterProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapterProjectScopeTest.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.dataset.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.dao.DatasetDao;
+import io.yak.ops.business.dataset.dao.model.DatasetPO;
+import io.yak.ops.business.dataset.repository.support.DatasetJsonCodec;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DatasetRepositoryAdapterProjectScopeTest {
+
+  @Mock private DatasetDao datasetDao;
+  @Mock private DatasetJsonCodec jsonCodec;
+
+  @Test
+  void listUsesCurrentProjectAsRepositoryBoundary() {
+    DatasetPO po = new DatasetPO();
+    po.setId(11L);
+    po.setProjectId(7L);
+    po.setName("sales");
+    po.setStatus("ONLINE");
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    when(datasetDao.selectDatasets(7L)).thenReturn(List.of(po));
+
+    List<Dataset> result =
+        new DatasetRepositoryAdapter(datasetDao, jsonCodec, currentProject).listDatasets();
+
+    assertThat(result).extracting(Dataset::id).containsExactly(11L);
+    verify(datasetDao).selectDatasets(7L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
@@ -35,7 +35,7 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
     this.currentProject = currentProject;
   }
 
-  DataSourceRepositoryAdapter(DataSourceDao dao) {
+  public DataSourceRepositoryAdapter(DataSourceDao dao) {
     this(dao, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapterTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.datasource.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.datasource.dao.DataSourceDao;
@@ -11,6 +12,9 @@ import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -40,6 +44,22 @@ class DataSourceRepositoryAdapterTest {
     assertThat(result.getEnvironment()).isEqualTo(DataSourceEnvironment.PROD);
     assertThat(result.getConnStatus()).isEqualTo(DataSourceConnStatus.CONNECTED);
     assertThat(result.getConnectionParams()).contains("127.0.0.1");
+  }
+
+  @Test
+  void usesProjectQualifiedLookupWhenContextIsBound() {
+    DataSourcePO po = new DataSourcePO();
+    po.setId(42L);
+    po.setProjectId(7L);
+    po.setName("orders-db");
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    when(dao.selectById(7L, 42L)).thenReturn(po);
+
+    DataSourceDefinition result =
+        new DataSourceRepositoryAdapter(dao, currentProject).findById(42L).orElseThrow();
+
+    assertThat(result.getProjectId()).isEqualTo(7L);
+    verify(dao).selectById(7L, 42L);
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
@@ -55,10 +55,13 @@ public class ResourceDaoImpl implements ResourceDao {
   @Override
   public ResourcePO selectByFullPath(Long projectId, String fullPath) {
     if (!StringUtils.hasText(fullPath)) return null;
-    return resourceMapper.selectOne(
+    LambdaQueryWrapper<ResourcePO> query =
         Wrappers.<ResourcePO>lambdaQuery()
             .eq(projectId != null, ResourcePO::getProjectId, projectId)
-            .eq(ResourcePO::getFullPath, fullPath));
+            .eq(ResourcePO::getFullPath, fullPath)
+            .orderByAsc(ResourcePO::getId);
+    if (projectId != null) return resourceMapper.selectOne(query);
+    return resourceMapper.selectList(query).stream().findFirst().orElse(null);
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceNamespaceManager.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceNamespaceManager.java
@@ -16,6 +16,7 @@ import io.yak.ops.spi.resource.ResourceFileSyncAction;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -111,9 +112,7 @@ public class ResourceNamespaceManager {
     List<ResourceNode> descendants = repository.findDescendants(resource.getFullPath());
     List<Long> ids = new ArrayList<>(descendants.size() + 1);
     ids.add(resource.getId());
-    for (ResourceNode descendant : descendants) {
-      ids.add(descendant.getId());
-    }
+    for (ResourceNode descendant : descendants) ids.add(descendant.getId());
     if (!repository.deleteBatch(ids)) {
       throw new ResourceException(ResourceErrorCode.DELETE_FAILED);
     }
@@ -139,8 +138,7 @@ public class ResourceNamespaceManager {
     if (targetParent.storageType() != resource.getStorageType()) {
       throw new ResourceException(ResourceErrorCode.CROSS_STORAGE_MOVE_UNSUPPORTED);
     }
-    if (resource.getProjectId() != null
-        && !resource.getProjectId().equals(targetParent.projectId())) {
+    if (!Objects.equals(resource.getProjectId(), targetParent.projectId())) {
       throw new ResourceException(ResourceErrorCode.INVALID_MOVE_TARGET);
     }
 

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceParentResolver.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceParentResolver.java
@@ -32,7 +32,7 @@ public class ResourceParentResolver {
     this.currentProject = currentProject;
   }
 
-  ResourceParentResolver(ResourceRepository repository, ResourceStorageGateway storage) {
+  public ResourceParentResolver(ResourceRepository repository, ResourceStorageGateway storage) {
     this(repository, storage, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
@@ -31,7 +31,7 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
     this.currentProject = currentProject;
   }
 
-  ResourceRepositoryAdapter(ResourceDao resourceDao) {
+  public ResourceRepositoryAdapter(ResourceDao resourceDao) {
     this(resourceDao, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapterTest.java
@@ -15,6 +15,9 @@ import io.yak.ops.business.resource.domain.ResourceQuery;
 import io.yak.ops.common.bean.po.resource.ResourcePO;
 import io.yak.ops.common.enums.resource.ResourceNodeType;
 import io.yak.ops.common.enums.resource.ResourceStorageType;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -51,6 +54,21 @@ class ResourceRepositoryAdapterTest {
     verify(resourceDao).insert(captor.capture());
     assertThat(captor.getValue().getFullPath()).isEqualTo("/README.md");
     assertThat(captor.getValue().getNodeType()).isEqualTo(ResourceNodeType.FILE);
+  }
+
+  @Test
+  void projectContextQualifiesResourceLookup() {
+    ResourcePO po = new ResourcePO();
+    po.setId(9L);
+    po.setProjectId(7L);
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    when(resourceDao.selectById(7L, 9L)).thenReturn(po);
+
+    ResourceNode result =
+        new ResourceRepositoryAdapter(resourceDao, currentProject).findById(9L).orElseThrow();
+
+    assertThat(result.getProjectId()).isEqualTo(7L);
+    verify(resourceDao).selectById(7L, 9L);
   }
 
   @Test


### PR DESCRIPTION
## 背景

PR #774 已经合并。本 Draft 补充 PR3 在合并后产生的最后一组兼容性与项目隔离测试，避免这些修正停留在原分支上。

## 变更

- 保留 Repository/Adapter 旧构造函数的 public 可见性，避免现有跨包测试和兼容调用编译失败；
- 补充 DataSource、Resource、Dataset Repository 在绑定 `CurrentProject` 后使用项目条件的单元测试；
- Resource 兼容模式下按逻辑路径查询时，允许不同项目存在相同 `full_path`，并稳定返回首条历史数据；
- Resource move 使用 `Objects.equals` 严格校验源节点与目标父目录的项目归属。

## 验证状态

- 当前 GitHub 未发现对应 workflow run；
- Maven、npm 和数据库集成测试尚未在本会话环境中执行；
- 合并前至少应补跑：Datasource、Resource、Dataset 三个模块测试，以及 UI `projectContext.test.ts`。

## 关联

- 主迁移 PR：#774
- 本 PR 只做 PR3 的兼容性和测试收口，不继续扩大业务模块范围。