### PR TITLE
feat(project-space): migrate production task domains (PR4)

### DIFF
--- a/docs/project-space/PR4_BACKFILL.md
+++ b/docs/project-space/PR4_BACKFILL.md
@@ -1,0 +1,238 @@
+# Project Space PR4 回填与切换手册
+
+> 适用范围：Data Development、Task Catalog、Offline Sync、Realtime Sync、Workflow。  
+> 当前阶段：`PROJECT_OPTIONAL` + nullable `project_id`。  
+> 目标：在切换 `PROJECT_REQUIRED` 和 `NOT NULL` 之前，安全完成历史数据归属与双项目隔离验收。
+
+## 1. 执行原则
+
+- 不在 Flyway 中硬编码默认项目 ID；默认空间来自 Yak Security Project。
+- 先备份，再统计，再回填，再验证；所有更新都只处理 `project_id IS NULL`。
+- 根对象先回填，运行态和投影数据再从根对象继承。
+- 来源关系不清晰的数据必须人工确认，不能为了消除 NULL 随意归入某个项目。
+- 本手册中的 `:default_project_id` 是执行工具的绑定变量，不是字面 SQL。
+
+建议先记录待回填数量：
+
+```sql
+SELECT 'yak_dev_directory', COUNT(*) FROM yak_dev_directory WHERE project_id IS NULL
+UNION ALL SELECT 'yak_dev_node', COUNT(*) FROM yak_dev_node WHERE project_id IS NULL
+UNION ALL SELECT 'yak_task_asset', COUNT(*) FROM yak_task_asset WHERE project_id IS NULL
+UNION ALL SELECT 'yak_offline_job_definition', COUNT(*) FROM yak_offline_job_definition WHERE project_id IS NULL
+UNION ALL SELECT 'yak_realtime_job_definition', COUNT(*) FROM yak_realtime_job_definition WHERE project_id IS NULL
+UNION ALL SELECT 'yak_workflow_definition', COUNT(*) FROM yak_workflow_definition WHERE project_id IS NULL;
+```
+
+## 2. Data Development
+
+目录和已有节点先归入默认空间：
+
+```sql
+UPDATE yak_dev_directory
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+
+UPDATE yak_dev_node
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+```
+
+运行记录与血缘 Outbox 必须从节点继承：
+
+```sql
+UPDATE yak_dev_task_execution e
+JOIN yak_dev_node n ON n.id = e.node_id
+SET e.project_id = n.project_id
+WHERE e.project_id IS NULL;
+
+UPDATE yak_dev_lineage_outbox o
+JOIN yak_dev_node n ON n.id = o.node_id
+SET o.project_id = n.project_id
+WHERE o.project_id IS NULL;
+```
+
+校验：
+
+```sql
+SELECT e.id, e.node_id, e.project_id, n.project_id AS node_project_id
+FROM yak_dev_task_execution e
+JOIN yak_dev_node n ON n.id = e.node_id
+WHERE e.project_id IS NULL OR e.project_id <> n.project_id;
+
+SELECT o.task_id, o.node_id, o.project_id, n.project_id AS node_project_id
+FROM yak_dev_lineage_outbox o
+JOIN yak_dev_node n ON n.id = o.node_id
+WHERE o.project_id IS NULL OR o.project_id <> n.project_id;
+```
+
+## 3. Task Catalog
+
+Task Catalog 是源任务投影，优先从 Data Development 节点恢复项目：
+
+```sql
+UPDATE yak_task_asset a
+JOIN yak_dev_node n
+  ON a.source = 'DATA_DEVELOPMENT'
+ AND a.source_ref = CAST(n.id AS CHAR)
+SET a.project_id = n.project_id
+WHERE a.project_id IS NULL;
+```
+
+其他来源必须按各自 Source Truth 回填。只有确认历史资产全部属于默认空间后，才执行兜底：
+
+```sql
+UPDATE yak_task_asset
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+```
+
+不要在未核对 `source/source_ref` 的情况下直接执行兜底。
+
+## 4. Offline Sync
+
+定义属于项目；Batch 和 Execution 从定义继承：
+
+```sql
+UPDATE yak_offline_job_definition
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+
+UPDATE yak_offline_batch_execution b
+JOIN yak_offline_job_definition d ON d.id = b.job_definition_id
+SET b.project_id = d.project_id
+WHERE b.project_id IS NULL;
+
+UPDATE yak_offline_job_execution e
+JOIN yak_offline_job_definition d ON d.id = e.job_definition_id
+SET e.project_id = d.project_id
+WHERE e.project_id IS NULL;
+```
+
+校验运行态与定义一致：
+
+```sql
+SELECT e.id, e.job_definition_id, e.project_id, d.project_id AS definition_project_id
+FROM yak_offline_job_execution e
+JOIN yak_offline_job_definition d ON d.id = e.job_definition_id
+WHERE e.project_id IS NULL OR e.project_id <> d.project_id;
+```
+
+还必须检查每个定义引用的 Source/Sink DataSource 与定义属于同一项目。
+
+## 5. Realtime Sync
+
+Compute Environment 和 Runtime Lease 继续是全局平台能力；任务定义与 Deployment 属于项目：
+
+```sql
+UPDATE yak_realtime_job_definition
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+
+UPDATE yak_realtime_job_deployment p
+JOIN yak_realtime_job_definition d ON d.id = p.definition_id
+SET p.project_id = d.project_id
+WHERE p.project_id IS NULL;
+```
+
+校验：
+
+```sql
+SELECT p.id, p.definition_id, p.project_id, d.project_id AS definition_project_id
+FROM yak_realtime_job_deployment p
+JOIN yak_realtime_job_definition d ON d.id = p.definition_id
+WHERE p.project_id IS NULL OR p.project_id <> d.project_id;
+```
+
+## 6. Workflow
+
+工作流定义先归入默认空间；Schedule、Backfill、Trigger 和 Execution 从所属定义继承：
+
+```sql
+UPDATE yak_workflow_definition
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+
+UPDATE yak_workflow_schedule s
+JOIN yak_workflow_definition d ON d.id = s.workflow_id
+SET s.project_id = d.project_id
+WHERE s.project_id IS NULL;
+
+UPDATE yak_workflow_backfill b
+JOIN yak_workflow_definition d ON d.id = b.workflow_id
+SET b.project_id = d.project_id
+WHERE b.project_id IS NULL;
+
+UPDATE yak_workflow_schedule_trigger t
+JOIN yak_workflow_definition d ON d.id = t.workflow_id
+SET t.project_id = d.project_id
+WHERE t.project_id IS NULL;
+
+UPDATE yak_workflow_execution e
+JOIN yak_workflow_version v ON v.id = e.definition_id
+JOIN yak_workflow_definition d ON d.id = v.workflow_id
+SET e.project_id = d.project_id
+WHERE e.project_id IS NULL;
+```
+
+重启/重跑实例可从来源执行继承：
+
+```sql
+UPDATE yak_workflow_execution e
+JOIN yak_workflow_execution source ON source.id = e.source_execution_id
+SET e.project_id = source.project_id
+WHERE e.project_id IS NULL
+  AND source.project_id IS NOT NULL;
+```
+
+仍为空的 Ad-hoc/Test Run 必须先核对来源。确认它们属于默认空间后才兜底：
+
+```sql
+UPDATE yak_workflow_execution
+SET project_id = :default_project_id
+WHERE project_id IS NULL;
+```
+
+## 7. 全局一致性检查
+
+```sql
+SELECT 'yak_dev_directory' AS table_name, COUNT(*) AS null_count
+FROM yak_dev_directory WHERE project_id IS NULL
+UNION ALL SELECT 'yak_dev_node', COUNT(*) FROM yak_dev_node WHERE project_id IS NULL
+UNION ALL SELECT 'yak_dev_task_execution', COUNT(*) FROM yak_dev_task_execution WHERE project_id IS NULL
+UNION ALL SELECT 'yak_dev_lineage_outbox', COUNT(*) FROM yak_dev_lineage_outbox WHERE project_id IS NULL
+UNION ALL SELECT 'yak_task_asset', COUNT(*) FROM yak_task_asset WHERE project_id IS NULL
+UNION ALL SELECT 'yak_offline_job_definition', COUNT(*) FROM yak_offline_job_definition WHERE project_id IS NULL
+UNION ALL SELECT 'yak_offline_batch_execution', COUNT(*) FROM yak_offline_batch_execution WHERE project_id IS NULL
+UNION ALL SELECT 'yak_offline_job_execution', COUNT(*) FROM yak_offline_job_execution WHERE project_id IS NULL
+UNION ALL SELECT 'yak_realtime_job_definition', COUNT(*) FROM yak_realtime_job_definition WHERE project_id IS NULL
+UNION ALL SELECT 'yak_realtime_job_deployment', COUNT(*) FROM yak_realtime_job_deployment WHERE project_id IS NULL
+UNION ALL SELECT 'yak_workflow_definition', COUNT(*) FROM yak_workflow_definition WHERE project_id IS NULL
+UNION ALL SELECT 'yak_workflow_execution', COUNT(*) FROM yak_workflow_execution WHERE project_id IS NULL
+UNION ALL SELECT 'yak_workflow_schedule', COUNT(*) FROM yak_workflow_schedule WHERE project_id IS NULL
+UNION ALL SELECT 'yak_workflow_schedule_trigger', COUNT(*) FROM yak_workflow_schedule_trigger WHERE project_id IS NULL
+UNION ALL SELECT 'yak_workflow_backfill', COUNT(*) FROM yak_workflow_backfill WHERE project_id IS NULL;
+```
+
+所有结果必须为 `0`，并且父子项目不一致查询必须返回空集。
+
+## 8. 双项目验收
+
+准备 Project A、Project B，各放一组同名对象，至少验证：
+
+1. 两个项目可创建同名目录、离线任务、实时任务和工作流。
+2. A 的列表、详情、编辑、删除、执行、重试、日志和调度记录均看不到 B。
+3. 修改 URL、任务 ID、Execution ID、Schedule ID、Trigger ID 访问 B 时返回不存在或被拒绝。
+4. Offline/Realtime 任务不能引用另一项目的 DataSource。
+5. Workflow 不能引用另一项目的 TaskAsset，调度与 Backfill 不能绑定另一项目的 Workflow。
+6. 后台重试、Reconcile、Schedule Trigger 和 Outbox 消费后，运行记录仍保留正确 `project_id`。
+
+## 9. Contract 切换
+
+只有在以下条件全部满足后才能进入收口 PR：
+
+- 上述 NULL 和父子不一致检查全部通过；
+- 双项目接口与后台任务验收通过；
+- 所有 PR4 Controller 切换为 `PROJECT_REQUIRED`；
+- 前端已能稳定选择并保存当前项目；
+- 再把根对象和运行态表的 `project_id` 修改为 `NOT NULL`；
+- 项目空间菜单和项目切换器仍应等 PR5 全模块完成后再开放。

--- a/docs/project-space/PR4_SCOPE.md
+++ b/docs/project-space/PR4_SCOPE.md
@@ -1,0 +1,51 @@
+# Project Space PR4：数据生产链迁移
+
+> 状态：Draft rollout baseline
+
+PR4 将以下数据生产链统一接入 PR2 的可信 `CurrentProject`：
+
+```text
+Data Development
+  -> Task Catalog
+  -> Offline Sync
+  -> Realtime Sync
+  -> Workflow
+```
+
+## 目标
+
+- 项目业务根对象直接保存 `project_id`；
+- 异步执行、调度和部署记录直接保存 `project_id`；
+- 从属版本、节点、事件通过父聚合继承项目；
+- 创建归属只读取服务端可信项目上下文；
+- 列表、详情、编辑、删除、发布、执行和运行记录查询均按项目隔离；
+- Workflow、同步任务和开发任务不得引用其他项目的业务资源；
+- 继续采用 `Expand -> Backfill -> Contract`，本阶段不直接收紧为 `NOT NULL`。
+
+## 本 PR 数据边界
+
+| 模块 | PROJECT_ROOT / PROJECT_PROJECTION | PROJECT_RUNTIME | INHERITED / GLOBAL |
+|---|---|---|---|
+| Data Development | directory、node | task execution、lineage outbox | draft、revision |
+| Task Catalog | task asset（来源投影） | - | revision snapshot |
+| Offline Sync | job definition | batch execution、job execution | execution event |
+| Realtime Sync | job definition | deployment | definition version、job event；compute environment 与 runtime lease 保持 GLOBAL |
+| Workflow | workflow definition | schedule、execution、schedule trigger、backfill | version、node execution、attempt |
+
+## 兼容策略
+
+- Controller 在 Expand 阶段使用 `PROJECT_OPTIONAL`；
+- 有合法 Project Header 时，所有项目化查询和写入使用可信项目条件；
+- 无 Header 时仅保留历史兼容读取，禁止继续创建无归属的新根对象；
+- 前端只为已经完成后端隔离的 API 家族开启 Project Header；
+- 项目空间菜单和右上角切换器继续隐藏；
+- 完成历史数据回填与双项目验收后，再切换 `PROJECT_REQUIRED`。
+
+## 验收门槛
+
+1. Project A 无法通过修改 ID 读取、编辑、运行或删除 Project B 的任务；
+2. Project A 的同步任务不能引用 Project B 的 DataSource；
+3. Project A 的 Workflow 不能编排 Project B 的 TaskAsset；
+4. Scheduler、重试、部署 reconcile 和后台 outbox 消费能从持久化记录恢复 `project_id`；
+5. 历史记录全部回填默认空间，项目化根表和运行态表不存在空项目；
+6. 同一名称可以在不同项目内创建，同一项目内仍保持唯一。

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDataServiceNodeController.java
@@ -11,6 +11,8 @@ import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService
 import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService.DataServiceNodeContext;
 import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService.PreviewResult;
 import io.yak.ops.business.development.service.DevelopmentDataServiceNodeService.SaveDraftCommand;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -31,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "数据开发 Data Service Node 接口")
 @RestController
 @RequestMapping("/api/v1/data-development/nodes")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DevelopmentDataServiceNodeController {
 
   private final DevelopmentDataServiceNodeService service;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDatasetNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDatasetNodeController.java
@@ -7,6 +7,8 @@ import io.yak.ops.business.dataset.DevelopmentDatasetFacade.FieldDraft;
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade.PreviewResult;
 import io.yak.ops.business.development.dataset.DevelopmentDatasetNodeService;
 import io.yak.ops.business.development.dataset.DevelopmentDatasetNodeService.DatasetNodeContext;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "数据开发 Dataset Node 接口")
 @RestController
 @RequestMapping("/api/v1/data-development/nodes")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DevelopmentDatasetNodeController {
 
   private final DevelopmentDatasetNodeService service;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentDirectoryController.java
@@ -7,6 +7,8 @@ import io.yak.ops.business.development.api.DevelopmentDirectoryApi.CreateRequest
 import io.yak.ops.business.development.api.DevelopmentDirectoryApi.RenameRequest;
 import io.yak.ops.business.development.directory.DevelopmentDirectoryService;
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "数据开发目录接口")
 @RestController
 @RequestMapping("/api/v1/data-development/directories")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DevelopmentDirectoryController {
 
   private final DevelopmentDirectoryService service;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
@@ -8,6 +8,8 @@ import io.yak.ops.business.development.api.DevelopmentNodeApi.CreateRequest;
 import io.yak.ops.business.development.api.DevelopmentNodeApi.RenameRequest;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.node.DevelopmentNodeService;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "数据开发节点接口")
 @RestController
 @RequestMapping("/api/v1/data-development/nodes")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DevelopmentNodeController {
 
   private final DevelopmentNodeService service;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentReleaseController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentReleaseController.java
@@ -7,6 +7,8 @@ import io.yak.ops.business.development.release.DevelopmentReleaseService;
 import io.yak.ops.business.development.release.model.DevelopmentReleaseDetail;
 import io.yak.ops.business.development.release.model.DevelopmentReleasePage;
 import io.yak.ops.business.development.release.model.DevelopmentReleaseSummary;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "数据开发发布中心接口")
 @RestController
 @RequestMapping("/api/v1/data-development/releases")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DevelopmentReleaseController {
 
   private final DevelopmentReleaseService service;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskController.java
@@ -17,6 +17,8 @@ import io.yak.ops.business.development.execution.model.DevelopmentTaskRunResult;
 import io.yak.ops.business.development.node.DevelopmentNodeService;
 import io.yak.ops.business.development.service.DevelopmentSqlLineagePreviewService;
 import io.yak.ops.business.development.task.DevelopmentTaskService;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "数据开发任务接口")
 @RestController
 @RequestMapping("/api/v1/data-development/nodes")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DevelopmentTaskController {
 
   private final DevelopmentTaskService service;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskExecutionController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentTaskExecutionController.java
@@ -6,6 +6,8 @@ import io.yak.framework.common.Result;
 import io.yak.ops.business.development.execution.DevelopmentTaskExecutionService;
 import io.yak.ops.business.development.execution.model.DevelopmentTaskExecutionDetail;
 import io.yak.ops.business.development.execution.model.DevelopmentTaskExecutionPage;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import java.time.LocalDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "数据开发运行记录接口")
 @RestController
 @RequestMapping("/api/v1/data-development/executions")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class DevelopmentTaskExecutionController {
 
   private final DevelopmentTaskExecutionService service;

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DevelopmentTaskExecutionService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/execution/DevelopmentTaskExecutionService.java
@@ -6,6 +6,9 @@ import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.execution.model.DevelopmentTaskExecutionDetail;
 import io.yak.ops.business.development.execution.model.DevelopmentTaskExecutionPage;
 import io.yak.ops.business.development.execution.model.DevelopmentTaskExecutionSummary;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.sql.Timestamp;
@@ -15,6 +18,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
@@ -30,10 +36,20 @@ public class DevelopmentTaskExecutionService {
 
   private final JdbcTemplate jdbcTemplate;
   private final ObjectMapper objectMapper;
+  private final CurrentProject currentProject;
 
-  public DevelopmentTaskExecutionService(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+  @Autowired
+  public DevelopmentTaskExecutionService(
+      JdbcTemplate jdbcTemplate,
+      ObjectMapper objectMapper,
+      CurrentProject currentProject) {
     this.jdbcTemplate = jdbcTemplate;
     this.objectMapper = objectMapper;
+    this.currentProject = currentProject;
+  }
+
+  public DevelopmentTaskExecutionService(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+    this(jdbcTemplate, objectMapper, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   public long createPending(
@@ -42,19 +58,22 @@ public class DevelopmentTaskExecutionService {
       String content,
       String configJson,
       String operatorName) {
+    ensureCurrentProject(node.projectId());
     String sql = "INSERT INTO yak_dev_task_execution "
-        + "(node_id, task_name, task_type, trigger_type, status, operator_name, content, config_json, "
-        + "start_time, create_time, update_time) VALUES (?, ?, ?, 'MANUAL', 'PENDING', ?, ?, ?, NOW(6), NOW(6), NOW(6))";
+        + "(project_id, node_id, task_name, task_type, trigger_type, status, operator_name, content, config_json, "
+        + "start_time, create_time, update_time) VALUES (?, ?, ?, ?, 'MANUAL', 'PENDING', ?, ?, ?, NOW(6), NOW(6), NOW(6))";
     KeyHolder keyHolder = new GeneratedKeyHolder();
     jdbcTemplate.update(
         connection -> {
           PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
-          statement.setLong(1, node.id());
-          statement.setString(2, node.name());
-          statement.setString(3, normalizeUpper(taskType));
-          statement.setString(4, normalizeOperator(operatorName));
-          statement.setString(5, content == null ? "" : content);
-          statement.setString(6, configJson == null || configJson.isBlank() ? "{}" : configJson);
+          if (node.projectId() == null) statement.setObject(1, null);
+          else statement.setLong(1, node.projectId());
+          statement.setLong(2, node.id());
+          statement.setString(3, node.name());
+          statement.setString(4, normalizeUpper(taskType));
+          statement.setString(5, normalizeOperator(operatorName));
+          statement.setString(6, content == null ? "" : content);
+          statement.setString(7, configJson == null || configJson.isBlank() ? "{}" : configJson);
           return statement;
         },
         keyHolder);
@@ -64,7 +83,7 @@ public class DevelopmentTaskExecutionService {
   }
 
   public void markRunning(long id, String runtimeExecutionId) {
-    jdbcTemplate.update(
+    updateById(
         "UPDATE yak_dev_task_execution SET runtime_execution_id = ?, status = 'RUNNING', update_time = NOW(6) WHERE id = ?",
         runtimeExecutionId,
         id);
@@ -76,14 +95,18 @@ public class DevelopmentTaskExecutionService {
       long durationMs,
       String errorMessage,
       Map<String, Object> output) {
-    jdbcTemplate.update(
-        "UPDATE yak_dev_task_execution SET status = ?, duration_ms = ?, error_message = ?, output_json = ?, "
-            + "end_time = NOW(6), update_time = NOW(6) WHERE id = ?",
-        normalizeUpper(status),
-        Math.max(0L, durationMs),
-        trim(errorMessage, 1000),
-        serializeOutput(output),
-        id);
+    Long projectId = currentProjectId();
+    String sql = "UPDATE yak_dev_task_execution SET status = ?, duration_ms = ?, error_message = ?, output_json = ?, "
+        + "end_time = NOW(6), update_time = NOW(6) WHERE id = ?"
+        + (projectId == null ? "" : " AND project_id = ?");
+    List<Object> args = new ArrayList<>();
+    args.add(normalizeUpper(status));
+    args.add(Math.max(0L, durationMs));
+    args.add(trim(errorMessage, 1000));
+    args.add(serializeOutput(output));
+    args.add(id);
+    if (projectId != null) args.add(projectId);
+    jdbcTemplate.update(sql, args.toArray());
   }
 
   public DevelopmentTaskExecutionPage page(
@@ -136,10 +159,15 @@ public class DevelopmentTaskExecutionService {
   }
 
   public DevelopmentTaskExecutionDetail get(long id) {
+    Long projectId = currentProjectId();
+    String sql = "SELECT id, node_id, task_name, task_type, trigger_type, runtime_execution_id, status, operator_name, "
+        + "duration_ms, error_message, content, config_json, output_json, start_time, end_time "
+        + "FROM yak_dev_task_execution WHERE id = ?"
+        + (projectId == null ? "" : " AND project_id = ?")
+        + " LIMIT 1";
+    Object[] args = projectId == null ? new Object[] {id} : new Object[] {id, projectId};
     List<DevelopmentTaskExecutionDetail> records = jdbcTemplate.query(
-        "SELECT id, node_id, task_name, task_type, trigger_type, runtime_execution_id, status, operator_name, "
-            + "duration_ms, error_message, content, config_json, output_json, start_time, end_time "
-            + "FROM yak_dev_task_execution WHERE id = ? LIMIT 1",
+        sql,
         (rs, rowNum) -> new DevelopmentTaskExecutionDetail(
             rs.getLong("id"),
             rs.getLong("node_id"),
@@ -156,9 +184,18 @@ public class DevelopmentTaskExecutionService {
             parseOutput(rs.getString("output_json")),
             toLocalDateTime(rs.getTimestamp("start_time")),
             toLocalDateTime(rs.getTimestamp("end_time"))),
-        id);
+        args);
     if (records.isEmpty()) throw new IllegalArgumentException("运行记录不存在：" + id);
     return records.get(0);
+  }
+
+  private void updateById(String baseSql, Object firstArgument, long id) {
+    Long projectId = currentProjectId();
+    if (projectId == null) {
+      jdbcTemplate.update(baseSql, firstArgument, id);
+      return;
+    }
+    jdbcTemplate.update(baseSql + " AND project_id = ?", firstArgument, id, projectId);
   }
 
   private String buildWhere(
@@ -170,6 +207,11 @@ public class DevelopmentTaskExecutionService {
       LocalDateTime endTime,
       List<Object> args) {
     StringBuilder where = new StringBuilder(" WHERE 1 = 1");
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      where.append(" AND project_id = ?");
+      args.add(projectId);
+    }
     String normalizedKeyword = trim(keyword, 200);
     if (normalizedKeyword != null && !normalizedKeyword.isBlank()) {
       where.append(" AND (task_name LIKE ? OR runtime_execution_id LIKE ? OR operator_name LIKE ?)");
@@ -190,6 +232,19 @@ public class DevelopmentTaskExecutionService {
       args.add(Timestamp.valueOf(endTime));
     }
     return where.toString();
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private void ensureCurrentProject(Long ownerProjectId) {
+    currentProject.current().ifPresent(
+        context -> {
+          if (!Objects.equals(context.projectId(), ownerProjectId)) {
+            throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+          }
+        });
   }
 
   private void appendEquals(StringBuilder where, List<Object> args, String column, String value) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/lineage/DevelopmentLineageOutbox.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/lineage/DevelopmentLineageOutbox.java
@@ -15,40 +15,64 @@ public class DevelopmentLineageOutbox {
   }
 
   public void enqueue(long nodeId, long revisionId) {
-    jdbc.update("INSERT IGNORE INTO yak_dev_lineage_outbox "
-        + "(task_id,node_id,revision_id,status,attempts,next_attempt_time,create_time,update_time) "
-        + "VALUES (?,?,?,'PENDING',0,NOW(6),NOW(6),NOW(6))",
-        UUID.randomUUID().toString(), nodeId, revisionId);
+    jdbc.update(
+        "INSERT IGNORE INTO yak_dev_lineage_outbox "
+            + "(task_id,project_id,node_id,revision_id,status,attempts,next_attempt_time,create_time,update_time) "
+            + "SELECT ?,project_id,id,?,'PENDING',0,NOW(6),NOW(6),NOW(6) FROM yak_dev_node WHERE id=?",
+        UUID.randomUUID().toString(),
+        revisionId,
+        nodeId);
   }
 
   public List<Task> due(int limit) {
-    return jdbc.query("SELECT task_id,node_id,revision_id,attempts FROM yak_dev_lineage_outbox "
+    return jdbc.query(
+        "SELECT task_id,project_id,node_id,revision_id,attempts FROM yak_dev_lineage_outbox "
             + "WHERE (status IN ('PENDING','FAILED') AND next_attempt_time<=NOW(6)) "
             + "OR (status='RUNNING' AND update_time<DATE_SUB(NOW(6), INTERVAL 10 MINUTE)) "
             + "ORDER BY create_time LIMIT ?",
-        (rs, row) -> new Task(rs.getString(1), rs.getLong(2), rs.getLong(3), rs.getInt(4)), limit);
+        (rs, row) ->
+            new Task(
+                rs.getString("task_id"),
+                rs.getObject("project_id") == null ? null : rs.getLong("project_id"),
+                rs.getLong("node_id"),
+                rs.getLong("revision_id"),
+                rs.getInt("attempts")),
+        limit);
   }
 
   public boolean claim(Task task) {
-    return jdbc.update("UPDATE yak_dev_lineage_outbox SET status='RUNNING',attempts=attempts+1,"
+    return jdbc.update(
+        "UPDATE yak_dev_lineage_outbox SET status='RUNNING',attempts=attempts+1,"
             + "update_time=NOW(6) WHERE task_id=? AND revision_id=? AND (status IN ('PENDING','FAILED') "
             + "OR (status='RUNNING' AND update_time<DATE_SUB(NOW(6), INTERVAL 10 MINUTE)))",
-        task.taskId(), task.revisionId()) == 1;
+        task.taskId(),
+        task.revisionId()) == 1;
   }
 
   public void complete(Task task) {
-    jdbc.update("UPDATE yak_dev_lineage_outbox SET status='SUCCEEDED',last_error=NULL,update_time=NOW(6) "
-        + "WHERE task_id=? AND revision_id=? AND status='RUNNING'", task.taskId(), task.revisionId());
+    jdbc.update(
+        "UPDATE yak_dev_lineage_outbox SET status='SUCCEEDED',last_error=NULL,update_time=NOW(6) "
+            + "WHERE task_id=? AND revision_id=? AND status='RUNNING'",
+        task.taskId(),
+        task.revisionId());
   }
 
   public void fail(Task task, Throwable failure) {
     long delay = Math.min(3600, 1L << Math.min(12, task.attempts()));
     String message = failure.getMessage() == null ? failure.getClass().getSimpleName() : failure.getMessage();
-    jdbc.update("UPDATE yak_dev_lineage_outbox SET status='FAILED',last_error=?,"
+    jdbc.update(
+        "UPDATE yak_dev_lineage_outbox SET status='FAILED',last_error=?,"
             + "next_attempt_time=DATE_ADD(NOW(6), INTERVAL ? SECOND),update_time=NOW(6) "
             + "WHERE task_id=? AND revision_id=? AND status='RUNNING'",
-        message.substring(0, Math.min(2000, message.length())), delay, task.taskId(), task.revisionId());
+        message.substring(0, Math.min(2000, message.length())),
+        delay,
+        task.taskId(),
+        task.revisionId());
   }
 
-  public record Task(String taskId, long nodeId, long revisionId, int attempts) {}
+  public record Task(String taskId, Long projectId, long nodeId, long revisionId, int attempts) {
+    public Task(String taskId, long nodeId, long revisionId, int attempts) {
+      this(taskId, null, nodeId, revisionId, attempts);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
@@ -5,9 +5,11 @@ import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import io.yak.ops.business.development.dao.mapper.DevelopmentDirectoryMapper;
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.common.bean.po.development.DevelopmentDirectoryPO;
+import io.yak.ops.core.project.CurrentProject;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /** MyBatis adapter for hierarchical data-development directories. */
@@ -17,15 +19,24 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
   private static final long ROOT_PARENT_ID = 0L;
 
   private final DevelopmentDirectoryMapper mapper;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public DevelopmentDirectoryRepositoryAdapter(
+      DevelopmentDirectoryMapper mapper, CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.currentProject = currentProject;
+  }
 
   public DevelopmentDirectoryRepositoryAdapter(DevelopmentDirectoryMapper mapper) {
-    this.mapper = mapper;
+    this(mapper, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
   public DevelopmentDirectory insert(Long parentId, String name) {
     Instant now = Instant.now();
     DevelopmentDirectoryPO po = new DevelopmentDirectoryPO();
+    po.setProjectId(currentProjectId());
     po.setParentId(toStoredParentId(parentId));
     po.setName(name);
     po.setCreateTime(now);
@@ -36,13 +47,21 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public Optional<DevelopmentDirectory> findById(Long id) {
-    return Optional.ofNullable(mapper.selectById(id)).map(this::toDomain);
+    Long projectId = currentProjectId();
+    return Optional.ofNullable(
+            mapper.selectOne(
+                new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                    .eq(DevelopmentDirectoryPO::getId, id)
+                    .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)))
+        .map(this::toDomain);
   }
 
   @Override
   public List<DevelopmentDirectory> list() {
+    Long projectId = currentProjectId();
     return mapper.selectList(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
                 .orderByAsc(DevelopmentDirectoryPO::getName)
                 .orderByAsc(DevelopmentDirectoryPO::getId))
         .stream()
@@ -52,8 +71,10 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public boolean existsByName(Long parentId, String name) {
+    Long projectId = currentProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
                 .eq(DevelopmentDirectoryPO::getParentId, toStoredParentId(parentId))
                 .eq(DevelopmentDirectoryPO::getName, name))
         > 0L;
@@ -61,18 +82,22 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public boolean hasChildren(Long id) {
+    Long projectId = currentProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
                 .eq(DevelopmentDirectoryPO::getParentId, id))
         > 0L;
   }
 
   @Override
   public boolean updateName(Long id, String name) {
+    Long projectId = currentProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentDirectoryPO>()
                 .eq(DevelopmentDirectoryPO::getId, id)
+                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
                 .set(DevelopmentDirectoryPO::getName, name)
                 .set(DevelopmentDirectoryPO::getUpdateTime, Instant.now()))
         > 0;
@@ -80,7 +105,16 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public boolean deleteById(Long id) {
-    return mapper.deleteById(id) > 0;
+    Long projectId = currentProjectId();
+    return mapper.delete(
+            new LambdaQueryWrapper<DevelopmentDirectoryPO>()
+                .eq(DevelopmentDirectoryPO::getId, id)
+                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId))
+        > 0;
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
   }
 
   private Long toStoredParentId(Long parentId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -5,11 +5,13 @@ import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import io.yak.ops.business.development.dao.mapper.DevelopmentNodeMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.common.bean.po.development.DevelopmentNodePO;
+import io.yak.ops.core.project.CurrentProject;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -21,10 +23,21 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   private final DevelopmentNodeMapper mapper;
   private final JdbcTemplate jdbcTemplate;
+  private final CurrentProject currentProject;
 
-  public DevelopmentNodeRepositoryAdapter(DevelopmentNodeMapper mapper, JdbcTemplate jdbcTemplate) {
+  @Autowired
+  public DevelopmentNodeRepositoryAdapter(
+      DevelopmentNodeMapper mapper,
+      JdbcTemplate jdbcTemplate,
+      CurrentProject currentProject) {
     this.mapper = mapper;
     this.jdbcTemplate = jdbcTemplate;
+    this.currentProject = currentProject;
+  }
+
+  public DevelopmentNodeRepositoryAdapter(
+      DevelopmentNodeMapper mapper, JdbcTemplate jdbcTemplate) {
+    this(mapper, jdbcTemplate, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
@@ -38,7 +51,7 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
     DevelopmentNodePO po = new DevelopmentNodePO();
     po.setName(name);
     po.setType(type);
-    po.setProjectId(projectId);
+    po.setProjectId(currentProjectId() == null ? projectId : currentProjectId());
     po.setDirectoryId(toStoredDirectoryId(directoryId));
     po.setConfigured(configured);
     po.setDeleted(false);
@@ -50,17 +63,24 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public Optional<DevelopmentNode> findById(Long id) {
-    return Optional.ofNullable(mapper.selectById(id))
+    Long projectId = currentProjectId();
+    return Optional.ofNullable(
+            mapper.selectOne(
+                new LambdaQueryWrapper<DevelopmentNodePO>()
+                    .eq(DevelopmentNodePO::getId, id)
+                    .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)))
         .map(po -> toDomain(po, hasUnpublishedChanges(po.getId())));
   }
 
   @Override
   public List<DevelopmentNode> list() {
+    Long projectId = currentProjectId();
     List<DevelopmentNodePO> nodes = mapper.selectList(
         new LambdaQueryWrapper<DevelopmentNodePO>()
+            .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
             .orderByAsc(DevelopmentNodePO::getName)
             .orderByAsc(DevelopmentNodePO::getId));
-    Map<Long, Boolean> pendingPublishByNodeId = loadPendingPublishByNodeId();
+    Map<Long, Boolean> pendingPublishByNodeId = loadPendingPublishByNodeId(projectId);
     return nodes.stream()
         .map(po -> toDomain(po, Boolean.TRUE.equals(pendingPublishByNodeId.get(po.getId()))))
         .toList();
@@ -68,8 +88,10 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public boolean existsByName(Long directoryId, String name) {
+    Long projectId = currentProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentNodePO>()
+                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
                 .eq(DevelopmentNodePO::getDirectoryId, toStoredDirectoryId(directoryId))
                 .eq(DevelopmentNodePO::getName, name))
         > 0L;
@@ -77,18 +99,22 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public boolean existsInDirectory(Long directoryId) {
+    Long projectId = currentProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentNodePO>()
+                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
                 .eq(DevelopmentNodePO::getDirectoryId, toStoredDirectoryId(directoryId)))
         > 0L;
   }
 
   @Override
   public boolean updateName(Long id, String name) {
+    Long projectId = currentProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentNodePO>()
                 .eq(DevelopmentNodePO::getId, id)
+                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
                 .set(DevelopmentNodePO::getName, name)
                 .set(DevelopmentNodePO::getUpdateTime, Instant.now()))
         > 0;
@@ -96,10 +122,12 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public boolean updateConfigured(Long id, boolean configured) {
+    Long projectId = currentProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentNodePO>()
                 .eq(DevelopmentNodePO::getId, id)
+                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
                 .set(DevelopmentNodePO::getConfigured, configured)
                 .set(DevelopmentNodePO::getUpdateTime, Instant.now()))
         > 0;
@@ -107,37 +135,53 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public boolean updateUpdatedBy(Long id, String updatedBy) {
+    Long projectId = currentProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentNodePO>()
                 .eq(DevelopmentNodePO::getId, id)
+                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
                 .set(DevelopmentNodePO::getUpdatedBy, updatedBy))
         > 0;
   }
 
   @Override
   public boolean deleteById(Long id) {
-    return mapper.deleteById(id) > 0;
+    Long projectId = currentProjectId();
+    return mapper.delete(
+            new LambdaQueryWrapper<DevelopmentNodePO>()
+                .eq(DevelopmentNodePO::getId, id)
+                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId))
+        > 0;
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
   }
 
   private Long toStoredDirectoryId(Long directoryId) {
     return directoryId == null || directoryId <= 0L ? ROOT_DIRECTORY_ID : directoryId;
   }
 
-  private Map<Long, Boolean> loadPendingPublishByNodeId() {
+  private Map<Long, Boolean> loadPendingPublishByNodeId(Long projectId) {
     Map<Long, Boolean> result = new HashMap<>();
+    String sql = "SELECT d.node_id, d.draft_revision, MAX(r.source_draft_revision) AS published_draft_revision "
+        + "FROM yak_dev_task_draft d "
+        + "JOIN yak_dev_node n ON n.id = d.node_id "
+        + "LEFT JOIN yak_dev_task_revision r ON r.node_id = d.node_id "
+        + (projectId == null ? "" : "WHERE n.project_id = ? ")
+        + "GROUP BY d.node_id, d.draft_revision";
+    Object[] args = projectId == null ? new Object[0] : new Object[] {projectId};
     jdbcTemplate.query(
-        "SELECT d.node_id, d.draft_revision, MAX(r.source_draft_revision) AS published_draft_revision "
-            + "FROM yak_dev_task_draft d "
-            + "LEFT JOIN yak_dev_task_revision r ON r.node_id = d.node_id "
-            + "GROUP BY d.node_id, d.draft_revision",
+        sql,
         rs -> {
           long nodeId = rs.getLong("node_id");
           long draftRevision = rs.getLong("draft_revision");
           long publishedDraftRevision = rs.getLong("published_draft_revision");
           boolean hasPublishedRevision = !rs.wasNull();
           result.put(nodeId, !hasPublishedRevision || draftRevision > publishedDraftRevision);
-        });
+        },
+        args);
     return result;
   }
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V14__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V14__expand_project_scope.sql
@@ -1,0 +1,19 @@
+-- Project Space expand migration for Data Development roots and runtime facts.
+-- Columns remain nullable until the default-space backfill and PROJECT_REQUIRED cutover complete.
+ALTER TABLE yak_dev_directory
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    DROP INDEX uk_yak_dev_directory_sibling,
+    ADD UNIQUE KEY uk_yak_dev_directory_project_sibling (project_id, parent_id, name),
+    ADD KEY idx_yak_dev_directory_project_parent (project_id, parent_id);
+
+ALTER TABLE yak_dev_node
+    ADD KEY idx_yak_dev_node_project_directory (project_id, directory_id, name);
+
+ALTER TABLE yak_dev_task_execution
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_dev_task_execution_project_time (project_id, start_time),
+    ADD KEY idx_yak_dev_task_execution_project_status (project_id, status, start_time);
+
+ALTER TABLE yak_dev_lineage_outbox
+    ADD COLUMN project_id BIGINT NULL AFTER task_id,
+    ADD KEY idx_yak_dev_lineage_outbox_project_due (project_id, status, next_attempt_time);

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryProjectScopeTest.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.development.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.development.dao.mapper.DevelopmentDirectoryMapper;
+import io.yak.ops.business.development.domain.DevelopmentDirectory;
+import io.yak.ops.common.bean.po.development.DevelopmentDirectoryPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DevelopmentDirectoryRepositoryProjectScopeTest {
+
+  @Mock private DevelopmentDirectoryMapper mapper;
+
+  @Test
+  void insertUsesTrustedCurrentProject() {
+    when(mapper.insert(any(DevelopmentDirectoryPO.class)))
+        .thenAnswer(
+            invocation -> {
+              DevelopmentDirectoryPO po = invocation.getArgument(0);
+              po.setId(11L);
+              return 1;
+            });
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    DevelopmentDirectoryRepositoryAdapter repository =
+        new DevelopmentDirectoryRepositoryAdapter(mapper, currentProject);
+
+    DevelopmentDirectory created = repository.insert(null, "jobs");
+
+    assertThat(created.id()).isEqualTo(11L);
+    ArgumentCaptor<DevelopmentDirectoryPO> captor =
+        ArgumentCaptor.forClass(DevelopmentDirectoryPO.class);
+    org.mockito.Mockito.verify(mapper).insert(captor.capture());
+    assertThat(captor.getValue().getProjectId()).isEqualTo(7L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
@@ -11,32 +11,61 @@ import io.yak.ops.business.datasource.dao.model.DataSourceSummaryRow;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.enums.datasource.DataSourceConnStatus;
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 /** 基于 MyBatis-Plus 的数据源数据访问实现。 */
 @Repository
 @ConditionalOnDataSourceEnabled
-@RequiredArgsConstructor
 public class DataSourceDaoImpl implements DataSourceDao {
 
   private final DataSourceMapper dataSourceMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public DataSourceDaoImpl(DataSourceMapper dataSourceMapper, CurrentProject currentProject) {
+    this.dataSourceMapper = dataSourceMapper;
+    this.currentProject = currentProject;
+  }
+
+  public DataSourceDaoImpl(DataSourceMapper dataSourceMapper) {
+    this(dataSourceMapper, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public int addDataSource(DataSourcePO dataSourcePO) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (dataSourcePO.getProjectId() != null
+          && !Objects.equals(projectId, dataSourcePO.getProjectId())) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      dataSourcePO.setProjectId(projectId);
+    }
     return dataSourceMapper.insert(dataSourcePO);
   }
 
   @Override
   public int editDataSource(DataSourcePO dataSourcePO) {
-    return dataSourceMapper.updateById(dataSourcePO);
+    Long projectId = currentProjectId();
+    if (projectId == null) return dataSourceMapper.updateById(dataSourcePO);
+    dataSourcePO.setProjectId(projectId);
+    return dataSourceMapper.update(
+        dataSourcePO,
+        Wrappers.<DataSourcePO>lambdaUpdate()
+            .eq(DataSourcePO::getProjectId, projectId)
+            .eq(DataSourcePO::getId, dataSourcePO.getId()));
   }
 
   @Override
   public DataSourcePO selectById(Long id) {
-    return selectById(null, id);
+    return selectById(currentProjectId(), id);
   }
 
   @Override
@@ -51,8 +80,17 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public IPage<DataSourcePO> selectPage(PageQuery query) {
-    PageQuery condition =
-        query == null ? new PageQuery(null, 1, 10, null, null, null, null, null) : query;
+    PageQuery condition = query == null
+        ? new PageQuery(currentProjectId(), 1, 10, null, null, null, null, null)
+        : new PageQuery(
+            query.projectId() == null ? currentProjectId() : query.projectId(),
+            query.pageNo(),
+            query.pageSize(),
+            query.name(),
+            query.keyword(),
+            query.dbType(),
+            query.environment(),
+            query.connStatus());
     Page<DataSourcePO> page =
         Page.of(Math.max(1, condition.pageNo()), Math.max(1, condition.pageSize()));
     return dataSourceMapper.selectPage(
@@ -64,7 +102,7 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public DataSourceSummaryRow selectSummary() {
-    return dataSourceMapper.selectSummary();
+    return selectSummary(currentProjectId());
   }
 
   @Override
@@ -76,7 +114,7 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public List<DataSourcePO> selectAll(DataSourceDbType dbType) {
-    return selectAll(null, dbType);
+    return selectAll(currentProjectId(), dbType);
   }
 
   @Override
@@ -91,7 +129,7 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public boolean existsByName(String name, Long excludeId) {
-    return existsByName(null, name, excludeId);
+    return existsByName(currentProjectId(), name, excludeId);
   }
 
   @Override
@@ -108,7 +146,7 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public boolean deleteById(Long id) {
-    return deleteById(null, id);
+    return deleteById(currentProjectId(), id);
   }
 
   @Override
@@ -124,7 +162,7 @@ public class DataSourceDaoImpl implements DataSourceDao {
 
   @Override
   public boolean updateConnectionStatus(Long id, DataSourceConnStatus connStatus) {
-    return updateConnectionStatus(null, id, connStatus);
+    return updateConnectionStatus(currentProjectId(), id, connStatus);
   }
 
   @Override
@@ -139,6 +177,10 @@ public class DataSourceDaoImpl implements DataSourceDao {
                     .eq(projectId != null, DataSourcePO::getProjectId, projectId)
                     .eq(DataSourcePO::getId, id))
             > 0;
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
   }
 
   private LambdaQueryWrapper<DataSourcePO> queryWrapper(PageQuery query) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineBackfillController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineBackfillController.java
@@ -1,4 +1,31 @@
 package io.yak.ops.business.sync.offline.controller;
-import io.yak.framework.common.Result;import io.yak.ops.business.sync.offline.backfill.OfflineBackfillService;import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;import jakarta.validation.Valid;import lombok.RequiredArgsConstructor;import org.springframework.web.bind.annotation.PathVariable;import org.springframework.web.bind.annotation.PostMapping;import org.springframework.web.bind.annotation.RequestBody;import org.springframework.web.bind.annotation.RestController;
-@ConditionalOnOfflineSyncEnabled @RestController @RequiredArgsConstructor
-public class OfflineBackfillController {private final OfflineBackfillService backfillService;@PostMapping("/api/v1/job/batch-execution/{jobDefineId}/backfill") public Result<OfflineBackfillVO> backfill(@PathVariable Long jobDefineId,@Valid @RequestBody OfflineBackfillRequestDTO requestDTO){return Result.success(backfillService.submit(jobDefineId,requestDTO));}}
+
+import io.yak.framework.common.Result;
+import io.yak.ops.business.sync.offline.backfill.OfflineBackfillService;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineBackfillRequestDTO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineBackfillVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequiredArgsConstructor
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
+public class OfflineBackfillController {
+
+  private final OfflineBackfillService backfillService;
+
+  @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/backfill")
+  public Result<OfflineBackfillVO> backfill(
+      @PathVariable Long jobDefineId,
+      @Valid @RequestBody OfflineBackfillRequestDTO requestDTO) {
+    return Result.success(backfillService.submit(jobDefineId, requestDTO));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineControlPlaneController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineControlPlaneController.java
@@ -1,4 +1,29 @@
 package io.yak.ops.business.sync.offline.controller;
-import io.yak.framework.common.Result;import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;import java.util.List;import lombok.RequiredArgsConstructor;import org.springframework.web.bind.annotation.GetMapping;import org.springframework.web.bind.annotation.PathVariable;import org.springframework.web.bind.annotation.RequestMapping;import org.springframework.web.bind.annotation.RestController;
-@ConditionalOnOfflineSyncEnabled @RestController @RequestMapping("/api/v1/job/batch-control") @RequiredArgsConstructor
-public class OfflineControlPlaneController {private final OfflineJobExecutionService service;@GetMapping("/executions/{executionId}/events") public Result<List<OfflineExecutionEventVO>> events(@PathVariable Long executionId){return Result.success(service.events(executionId));}}
+
+import io.yak.framework.common.Result;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequestMapping("/api/v1/job/batch-control")
+@RequiredArgsConstructor
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
+public class OfflineControlPlaneController {
+
+  private final OfflineJobExecutionService service;
+
+  @GetMapping("/executions/{executionId}/events")
+  public Result<List<OfflineExecutionEventVO>> events(@PathVariable Long executionId) {
+    return Result.success(service.events(executionId));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobDefinitionController.java
@@ -1,18 +1,75 @@
 package io.yak.ops.business.sync.offline.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;import io.yak.framework.common.PagingData;import io.yak.framework.common.Result;import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;import jakarta.validation.Valid;import lombok.RequiredArgsConstructor;import org.springframework.web.bind.annotation.DeleteMapping;import org.springframework.web.bind.annotation.GetMapping;import org.springframework.web.bind.annotation.PathVariable;import org.springframework.web.bind.annotation.PostMapping;import org.springframework.web.bind.annotation.PutMapping;import org.springframework.web.bind.annotation.RequestBody;import org.springframework.web.bind.annotation.RequestMapping;import org.springframework.web.bind.annotation.RestController;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.framework.common.PagingData;
+import io.yak.framework.common.Result;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionQueryDTO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineJobDefinitionVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@ConditionalOnOfflineSyncEnabled @RestController @RequestMapping("/api/v1/job/batch-definition") @RequiredArgsConstructor
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequestMapping("/api/v1/job/batch-definition")
+@RequiredArgsConstructor
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class OfflineJobDefinitionController {
+
   private final OfflineJobDefinitionService service;
-  @GetMapping("/get-unique-id") public Result<Long> nextId(){return Result.success(service.nextId());}
-  @PostMapping("/draft") public Result<Long> saveDraft(@RequestBody OfflineJobDefinitionDTO requestDTO){return Result.success(service.saveDraft(requestDTO));}
-  @PostMapping({"/guide-single/saveOrUpdate","/guide-multi/saveOrUpdate"}) public Result<Long> saveGuide(@RequestBody OfflineJobDefinitionDTO requestDTO){return Result.success(service.saveGuide(requestDTO));}
-  @PostMapping({"/guide-single/build-config","/guide-multi/build-config","/build-job-spec"}) public Result<String> buildGuideConfig(@RequestBody OfflineJobDefinitionDTO requestDTO){return Result.success(service.buildGuideConfig(requestDTO));}
-  @GetMapping("/{id}") public Result<OfflineJobDefinitionVO> get(@PathVariable Long id){return Result.success(service.get(id));}
-  @GetMapping("/{id}/edit-detail") public Result<JsonNode> editDetail(@PathVariable Long id){return Result.success(service.getEditDetail(id));}
-  @PostMapping("/page") public Result<PagingData<OfflineJobDefinitionVO>> page(@Valid @RequestBody(required=false) OfflineJobDefinitionQueryDTO queryDTO){return Result.success(service.page(queryDTO));}
-  @PutMapping("/{id}/online") public Result<Boolean> online(@PathVariable Long id){return Result.success(service.online(id));}
-  @PutMapping("/{id}/offline") public Result<Boolean> offline(@PathVariable Long id){return Result.success(service.offline(id));}
-  @DeleteMapping("/{id}") public Result<Boolean> delete(@PathVariable Long id){return Result.success(service.delete(id));}
+
+  @GetMapping("/get-unique-id")
+  public Result<Long> nextId() { return Result.success(service.nextId()); }
+
+  @PostMapping("/draft")
+  public Result<Long> saveDraft(@RequestBody OfflineJobDefinitionDTO requestDTO) {
+    return Result.success(service.saveDraft(requestDTO));
+  }
+
+  @PostMapping({"/guide-single/saveOrUpdate", "/guide-multi/saveOrUpdate"})
+  public Result<Long> saveGuide(@RequestBody OfflineJobDefinitionDTO requestDTO) {
+    return Result.success(service.saveGuide(requestDTO));
+  }
+
+  @PostMapping({"/guide-single/build-config", "/guide-multi/build-config", "/build-job-spec"})
+  public Result<String> buildGuideConfig(@RequestBody OfflineJobDefinitionDTO requestDTO) {
+    return Result.success(service.buildGuideConfig(requestDTO));
+  }
+
+  @GetMapping("/{id}")
+  public Result<OfflineJobDefinitionVO> get(@PathVariable Long id) {
+    return Result.success(service.get(id));
+  }
+
+  @GetMapping("/{id}/edit-detail")
+  public Result<JsonNode> editDetail(@PathVariable Long id) {
+    return Result.success(service.getEditDetail(id));
+  }
+
+  @PostMapping("/page")
+  public Result<PagingData<OfflineJobDefinitionVO>> page(
+      @Valid @RequestBody(required = false) OfflineJobDefinitionQueryDTO queryDTO) {
+    return Result.success(service.page(queryDTO));
+  }
+
+  @PutMapping("/{id}/online")
+  public Result<Boolean> online(@PathVariable Long id) { return Result.success(service.online(id)); }
+
+  @PutMapping("/{id}/offline")
+  public Result<Boolean> offline(@PathVariable Long id) { return Result.success(service.offline(id)); }
+
+  @DeleteMapping("/{id}")
+  public Result<Boolean> delete(@PathVariable Long id) { return Result.success(service.delete(id)); }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
@@ -12,23 +12,83 @@ import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;import org.springframework.web.bind.annotation.PathVariable;import org.springframework.web.bind.annotation.PostMapping;import org.springframework.web.bind.annotation.RequestBody;import org.springframework.web.bind.annotation.RequestParam;import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /** 离线执行命令和执行历史查询接口。 */
-@ConditionalOnOfflineSyncEnabled @RestController @RequiredArgsConstructor
+@ConditionalOnOfflineSyncEnabled
+@RestController
+@RequiredArgsConstructor
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class OfflineJobExecutionController {
+
   private final OfflineJobExecutionService service;
-  @GetMapping({"/api/v1/job/batch-execution/health","/api/v1/executor/health"}) public Result<OfflineEngineHealthVO> health(){return Result.success(service.health());}
-  @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/execute") public Result<OfflineJobExecutionVO> execute(@PathVariable Long jobDefineId){return Result.success(service.execute(jobDefineId));}
-  @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/cancel") public Result<OfflineJobExecutionVO> cancel(@PathVariable Long jobInstanceId){return Result.success(service.cancel(jobInstanceId));}
-  @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/retry") public Result<OfflineJobExecutionVO> retry(@PathVariable Long jobInstanceId){return Result.success(service.retry(jobInstanceId));}
-  @PostMapping({"/api/v1/job/batch-execution/batch-execute","/api/v1/executor/batch-execute"}) public Result<OfflineBatchOperationVO> batchExecute(@Valid @RequestBody OfflineBatchOperationDTO requestDTO){return Result.success(service.batchExecute(requestDTO));}
-  @PostMapping({"/api/v1/job/batch-execution/batch-pause","/api/v1/executor/batch-pause"}) public Result<OfflineBatchOperationVO> batchPause(@Valid @RequestBody OfflineBatchOperationDTO requestDTO){return Result.success(service.batchCancel(requestDTO));}
-  @PostMapping("/api/v1/job/batch-instance/page") public Result<PagingData<OfflineJobExecutionVO>> instancePage(@Valid @RequestBody(required=false) OfflineJobExecutionQueryDTO queryDTO){return Result.success(service.page(queryDTO));}
-  @GetMapping("/api/v1/job/batch-instance/{id}") public Result<OfflineJobExecutionDetailVO> instance(@PathVariable Long id){return Result.success(service.detail(id));}
-  @GetMapping("/api/v1/job/batch-instance/{id}/table-metrics") public Result<JsonNode> tableMetrics(@PathVariable Long id){return Result.success(service.tableMetrics(id));}
-  @GetMapping("/api/v1/job/batch-instance/{id}/log") public Result<String> instanceLog(@PathVariable Long id){return Result.success(service.logs(id));}
-  @GetMapping("/api/v1/job/batch-instance/{id}/logs") public Result<OfflineExecutionLogPageVO> instanceLogs(@PathVariable Long id,@RequestParam(defaultValue="0:0") String cursor,@RequestParam(defaultValue="500") int limit){return Result.success(service.logs(id,cursor,limit));}
+
+  @GetMapping({"/api/v1/job/batch-execution/health", "/api/v1/executor/health"})
+  @ProjectScope(ProjectMigrationMode.LEGACY_GLOBAL)
+  public Result<OfflineEngineHealthVO> health() { return Result.success(service.health()); }
+
+  @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/execute")
+  public Result<OfflineJobExecutionVO> execute(@PathVariable Long jobDefineId) {
+    return Result.success(service.execute(jobDefineId));
+  }
+
+  @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/cancel")
+  public Result<OfflineJobExecutionVO> cancel(@PathVariable Long jobInstanceId) {
+    return Result.success(service.cancel(jobInstanceId));
+  }
+
+  @PostMapping("/api/v1/job/batch-execution/{jobInstanceId}/retry")
+  public Result<OfflineJobExecutionVO> retry(@PathVariable Long jobInstanceId) {
+    return Result.success(service.retry(jobInstanceId));
+  }
+
+  @PostMapping({"/api/v1/job/batch-execution/batch-execute", "/api/v1/executor/batch-execute"})
+  public Result<OfflineBatchOperationVO> batchExecute(
+      @Valid @RequestBody OfflineBatchOperationDTO requestDTO) {
+    return Result.success(service.batchExecute(requestDTO));
+  }
+
+  @PostMapping({"/api/v1/job/batch-execution/batch-pause", "/api/v1/executor/batch-pause"})
+  public Result<OfflineBatchOperationVO> batchPause(
+      @Valid @RequestBody OfflineBatchOperationDTO requestDTO) {
+    return Result.success(service.batchCancel(requestDTO));
+  }
+
+  @PostMapping("/api/v1/job/batch-instance/page")
+  public Result<PagingData<OfflineJobExecutionVO>> instancePage(
+      @Valid @RequestBody(required = false) OfflineJobExecutionQueryDTO queryDTO) {
+    return Result.success(service.page(queryDTO));
+  }
+
+  @GetMapping("/api/v1/job/batch-instance/{id}")
+  public Result<OfflineJobExecutionDetailVO> instance(@PathVariable Long id) {
+    return Result.success(service.detail(id));
+  }
+
+  @GetMapping("/api/v1/job/batch-instance/{id}/table-metrics")
+  public Result<JsonNode> tableMetrics(@PathVariable Long id) {
+    return Result.success(service.tableMetrics(id));
+  }
+
+  @GetMapping("/api/v1/job/batch-instance/{id}/log")
+  public Result<String> instanceLog(@PathVariable Long id) {
+    return Result.success(service.logs(id));
+  }
+
+  @GetMapping("/api/v1/job/batch-instance/{id}/logs")
+  public Result<OfflineExecutionLogPageVO> instanceLogs(
+      @PathVariable Long id,
+      @RequestParam(defaultValue = "0:0") String cursor,
+      @RequestParam(defaultValue = "500") int limit) {
+    return Result.success(service.logs(id, cursor, limit));
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineBatchExecutionDaoImpl.java
@@ -4,31 +4,58 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineBatchExecutionDao;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineBatchExecutionMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
 import io.yak.ops.common.bean.po.sync.offline.OfflineBatchExecutionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 /** 基于 MyBatis-Plus 的离线同步业务批次数据访问实现。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
-@RequiredArgsConstructor
 public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
 
   private final OfflineBatchExecutionMapper mapper;
+  private final OfflineJobDefinitionMapper definitionMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public OfflineBatchExecutionDaoImpl(
+      OfflineBatchExecutionMapper mapper,
+      OfflineJobDefinitionMapper definitionMapper,
+      CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.definitionMapper = definitionMapper;
+    this.currentProject = currentProject;
+  }
+
+  public OfflineBatchExecutionDaoImpl(OfflineBatchExecutionMapper mapper) {
+    this(mapper, null, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public OfflineBatchExecutionPO selectById(Long id) {
-    return mapper.selectById(id);
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(OfflineBatchExecutionPO::getId, id)
+            .eq(projectId != null, OfflineBatchExecutionPO::getProjectId, projectId));
   }
 
   @Override
   public OfflineBatchExecutionPO selectByTaskIdAndBatchKey(Long taskId, String batchKey) {
     if (taskId == null || taskId <= 0L || !StringUtils.hasText(batchKey)) return null;
+    Long projectId = currentProjectId();
     return mapper.selectOne(
         Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineBatchExecutionPO::getProjectId, projectId)
             .eq(OfflineBatchExecutionPO::getJobDefinitionId, taskId)
             .eq(OfflineBatchExecutionPO::getBatchKey, batchKey.trim())
             .last("LIMIT 1"));
@@ -37,19 +64,22 @@ public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
   @Override
   public boolean existsByTaskIdAndStatuses(Long taskId, List<String> statuses) {
     if (taskId == null || taskId <= 0L || statuses == null || statuses.isEmpty()) return false;
+    Long projectId = currentProjectId();
     return mapper.selectCount(
         Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineBatchExecutionPO::getProjectId, projectId)
             .eq(OfflineBatchExecutionPO::getJobDefinitionId, taskId)
             .in(OfflineBatchExecutionPO::getStatus, statuses)) > 0L;
   }
 
   @Override
   public OfflineBatchExecutionPO selectLatestByTaskIdAndStatuses(
-      Long taskId,
-      List<String> statuses) {
+      Long taskId, List<String> statuses) {
     if (taskId == null || taskId <= 0L || statuses == null || statuses.isEmpty()) return null;
+    Long projectId = currentProjectId();
     return mapper.selectOne(
         Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineBatchExecutionPO::getProjectId, projectId)
             .eq(OfflineBatchExecutionPO::getJobDefinitionId, taskId)
             .in(OfflineBatchExecutionPO::getStatus, statuses)
             .orderByDesc(OfflineBatchExecutionPO::getId)
@@ -58,8 +88,10 @@ public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
 
   @Override
   public List<OfflineBatchExecutionPO> selectPendingBackfills(int limit) {
+    Long projectId = currentProjectId();
     return mapper.selectList(
         Wrappers.<OfflineBatchExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineBatchExecutionPO::getProjectId, projectId)
             .eq(OfflineBatchExecutionPO::getTriggerType, "BACKFILL")
             .eq(OfflineBatchExecutionPO::getStatus, "PENDING")
             .orderByAsc(OfflineBatchExecutionPO::getId)
@@ -69,10 +101,12 @@ public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
   @Override
   public boolean reservePendingBackfill(Long batchId, LocalDateTime updateTime) {
     if (batchId == null || batchId <= 0L) return false;
+    Long projectId = currentProjectId();
     return mapper.update(
         null,
         Wrappers.<OfflineBatchExecutionPO>lambdaUpdate()
             .eq(OfflineBatchExecutionPO::getId, batchId)
+            .eq(projectId != null, OfflineBatchExecutionPO::getProjectId, projectId)
             .eq(OfflineBatchExecutionPO::getTriggerType, "BACKFILL")
             .eq(OfflineBatchExecutionPO::getStatus, "PENDING")
             .set(OfflineBatchExecutionPO::getStatus, "RUNNING")
@@ -81,11 +115,36 @@ public class OfflineBatchExecutionDaoImpl implements OfflineBatchExecutionDao {
 
   @Override
   public boolean insert(OfflineBatchExecutionPO batchPO) {
+    batchPO.setProjectId(resolveProjectId(batchPO.getProjectId(), batchPO.getJobDefinitionId()));
     return mapper.insert(batchPO) > 0;
   }
 
   @Override
   public boolean updateById(OfflineBatchExecutionPO batchPO) {
-    return mapper.updateById(batchPO) > 0;
+    Long projectId = currentProjectId();
+    if (projectId == null) return mapper.updateById(batchPO) > 0;
+    batchPO.setProjectId(projectId);
+    return mapper.update(
+        batchPO,
+        Wrappers.<OfflineBatchExecutionPO>lambdaUpdate()
+            .eq(OfflineBatchExecutionPO::getId, batchPO.getId())
+            .eq(OfflineBatchExecutionPO::getProjectId, projectId)) > 0;
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private Long resolveProjectId(Long storedProjectId, Long definitionId) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (storedProjectId != null && !Objects.equals(projectId, storedProjectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      return projectId;
+    }
+    if (storedProjectId != null || definitionMapper == null || definitionId == null) return storedProjectId;
+    OfflineJobDefinitionPO definition = definitionMapper.selectById(definitionId);
+    return definition == null ? null : definition.getProjectId();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoImpl.java
@@ -13,17 +13,20 @@ import io.yak.ops.business.sync.offline.dao.mapper.OfflineWriteMapper;
 import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 /** 基于 MyBatis-Plus 的离线同步任务定义数据访问实现。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
-@RequiredArgsConstructor
 public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
 
   private static final List<String> ACTIVE_STATUSES =
@@ -33,37 +36,77 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
   private final OfflineJobExecutionMapper executionMapper;
   private final OfflineExecutionEventMapper eventMapper;
   private final OfflineWriteMapper writeMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public OfflineJobDefinitionDaoImpl(
+      OfflineJobDefinitionMapper mapper,
+      OfflineJobExecutionMapper executionMapper,
+      OfflineExecutionEventMapper eventMapper,
+      OfflineWriteMapper writeMapper,
+      CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.executionMapper = executionMapper;
+    this.eventMapper = eventMapper;
+    this.writeMapper = writeMapper;
+    this.currentProject = currentProject;
+  }
+
+  public OfflineJobDefinitionDaoImpl(
+      OfflineJobDefinitionMapper mapper,
+      OfflineJobExecutionMapper executionMapper,
+      OfflineExecutionEventMapper eventMapper,
+      OfflineWriteMapper writeMapper) {
+    this(mapper, executionMapper, eventMapper, writeMapper,
+        Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public OfflineJobDefinitionPO selectById(Long id) {
-    return mapper.selectById(id);
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<OfflineJobDefinitionPO>lambdaQuery()
+            .eq(OfflineJobDefinitionPO::getId, id)
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId));
   }
 
   @Override
   public boolean insert(OfflineJobDefinitionPO definitionPO) {
+    bindCurrentProject(definitionPO);
     return mapper.insert(definitionPO) > 0;
   }
 
   @Override
   public boolean updateById(OfflineJobDefinitionPO definitionPO) {
-    return mapper.updateById(definitionPO) > 0;
+    Long projectId = currentProjectId();
+    if (projectId == null) return mapper.updateById(definitionPO) > 0;
+    bindCurrentProject(definitionPO);
+    return mapper.update(
+        definitionPO,
+        Wrappers.<OfflineJobDefinitionPO>lambdaUpdate()
+            .eq(OfflineJobDefinitionPO::getId, definitionPO.getId())
+            .eq(OfflineJobDefinitionPO::getProjectId, projectId)) > 0;
   }
 
   @Override
   public boolean deleteById(Long id) {
+    Long projectId = currentProjectId();
+    if (projectId != null && selectById(id) == null) return false;
     List<Long> executionIds = executionMapper.selectObjs(
             Wrappers.<OfflineJobExecutionPO>query()
                 .select("id")
-                .eq("job_definition_id", id))
+                .eq("job_definition_id", id)
+                .eq(projectId != null, "project_id", projectId))
         .stream()
         .filter(Number.class::isInstance)
         .map(Number.class::cast)
         .map(Number::longValue)
         .toList();
-
-    boolean deleted = mapper.deleteById(id) > 0;
+    boolean deleted = mapper.delete(
+        Wrappers.<OfflineJobDefinitionPO>lambdaQuery()
+            .eq(OfflineJobDefinitionPO::getId, id)
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId)) > 0;
     if (!deleted) return false;
-
     if (!executionIds.isEmpty()) {
       eventMapper.delete(
           Wrappers.<OfflineExecutionEventPO>lambdaQuery()
@@ -71,14 +114,17 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
     }
     executionMapper.delete(
         Wrappers.<OfflineJobExecutionPO>lambdaQuery()
-            .eq(OfflineJobExecutionPO::getJobDefinitionId, id));
+            .eq(OfflineJobExecutionPO::getJobDefinitionId, id)
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId));
     return true;
   }
 
   @Override
   public boolean existsByName(String jobName, Long excludeId) {
+    Long projectId = currentProjectId();
     LambdaQueryWrapper<OfflineJobDefinitionPO> query =
         new LambdaQueryWrapper<OfflineJobDefinitionPO>()
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId)
             .eq(OfflineJobDefinitionPO::getJobName, jobName);
     if (excludeId != null) query.ne(OfflineJobDefinitionPO::getId, excludeId);
     return mapper.selectCount(query) > 0L;
@@ -89,7 +135,10 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
     PageQuery condition = query == null
         ? new PageQuery(1, 10, null, null, null, null, null, null, null, null, null)
         : query;
-    LambdaQueryWrapper<OfflineJobDefinitionPO> wrapper = new LambdaQueryWrapper<>();
+    Long projectId = currentProjectId();
+    LambdaQueryWrapper<OfflineJobDefinitionPO> wrapper =
+        new LambdaQueryWrapper<OfflineJobDefinitionPO>()
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId);
     if (StringUtils.hasText(condition.jobName())) {
       wrapper.like(OfflineJobDefinitionPO::getJobName, condition.jobName().trim());
     }
@@ -98,11 +147,8 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
     }
     if (StringUtils.hasText(condition.status())) {
       String status = normalizeStatus(condition.status());
-      if ("RUNNING".equals(status)) {
-        wrapper.in(OfflineJobDefinitionPO::getLastJobStatus, ACTIVE_STATUSES);
-      } else {
-        wrapper.eq(OfflineJobDefinitionPO::getLastJobStatus, status);
-      }
+      if ("RUNNING".equals(status)) wrapper.in(OfflineJobDefinitionPO::getLastJobStatus, ACTIVE_STATUSES);
+      else wrapper.eq(OfflineJobDefinitionPO::getLastJobStatus, status);
     }
     addLike(wrapper, OfflineJobDefinitionPO::getSourceType, condition.sourceType());
     addLike(wrapper, OfflineJobDefinitionPO::getSinkType, condition.sinkType());
@@ -117,20 +163,22 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
     wrapper.orderByDesc(OfflineJobDefinitionPO::getUpdateTime)
         .orderByDesc(OfflineJobDefinitionPO::getId);
     return mapper.selectPage(
-        new Page<>(Math.max(1, condition.current()), Math.max(1, condition.pageSize())),
-        wrapper);
+        new Page<>(Math.max(1, condition.current()), Math.max(1, condition.pageSize())), wrapper);
   }
 
   @Override
   public List<OfflineJobDefinitionPO> selectWithCron() {
+    Long projectId = currentProjectId();
     return mapper.selectList(
         new LambdaQueryWrapper<OfflineJobDefinitionPO>()
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId)
             .isNotNull(OfflineJobDefinitionPO::getCronExpression)
             .orderByAsc(OfflineJobDefinitionPO::getId));
   }
 
   @Override
   public Long lockById(Long id) {
+    if (currentProjectId() != null && selectById(id) == null) return null;
     return writeMapper.lockDefinition(id);
   }
 
@@ -144,10 +192,12 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
       int retryBackoffSeconds,
       LocalDateTime nextFireTime,
       LocalDateTime updateTime) {
+    Long projectId = currentProjectId();
     return mapper.update(
         null,
         Wrappers.<OfflineJobDefinitionPO>lambdaUpdate()
             .eq(OfflineJobDefinitionPO::getId, id)
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId)
             .set(OfflineJobDefinitionPO::getScheduleJson, scheduleJson)
             .set(OfflineJobDefinitionPO::getScheduleEnabled, enabled)
             .set(OfflineJobDefinitionPO::getCronExpression, cronExpression)
@@ -159,14 +209,13 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
 
   @Override
   public void updateScheduleRuntime(
-      Long id,
-      LocalDateTime lastFireTime,
-      LocalDateTime nextFireTime,
-      LocalDateTime updateTime) {
+      Long id, LocalDateTime lastFireTime, LocalDateTime nextFireTime, LocalDateTime updateTime) {
+    Long projectId = currentProjectId();
     mapper.update(
         null,
         Wrappers.<OfflineJobDefinitionPO>lambdaUpdate()
             .eq(OfflineJobDefinitionPO::getId, id)
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId)
             .set(OfflineJobDefinitionPO::getScheduleLastFireTime, lastFireTime)
             .set(OfflineJobDefinitionPO::getScheduleNextFireTime, nextFireTime)
             .set(OfflineJobDefinitionPO::getUpdateTime, updateTime));
@@ -174,10 +223,12 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
 
   @Override
   public void clearSchedule(Long id, LocalDateTime updateTime) {
+    Long projectId = currentProjectId();
     mapper.update(
         null,
         Wrappers.<OfflineJobDefinitionPO>lambdaUpdate()
             .eq(OfflineJobDefinitionPO::getId, id)
+            .eq(projectId != null, OfflineJobDefinitionPO::getProjectId, projectId)
             .set(OfflineJobDefinitionPO::getScheduleJson, null)
             .set(OfflineJobDefinitionPO::getScheduleEnabled, false)
             .set(OfflineJobDefinitionPO::getCronExpression, null)
@@ -186,6 +237,20 @@ public class OfflineJobDefinitionDaoImpl implements OfflineJobDefinitionDao {
             .set(OfflineJobDefinitionPO::getScheduleLastFireTime, null)
             .set(OfflineJobDefinitionPO::getScheduleNextFireTime, null)
             .set(OfflineJobDefinitionPO::getUpdateTime, updateTime));
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private void bindCurrentProject(OfflineJobDefinitionPO definitionPO) {
+    Long projectId = currentProjectId();
+    if (projectId == null) return;
+    if (definitionPO.getProjectId() != null
+        && !Objects.equals(projectId, definitionPO.getProjectId())) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+    definitionPO.setProjectId(projectId);
   }
 
   private <T> void addLike(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobExecutionDaoImpl.java
@@ -6,36 +6,63 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineJobExecutionDao;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 /** 基于 MyBatis-Plus 的 ExecutionAttempt 持久化 DAO。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
-@RequiredArgsConstructor
 public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
 
   private static final List<String> ACTIVE_STATUSES =
       List.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING", "UNKNOWN");
 
   private final OfflineJobExecutionMapper mapper;
+  private final OfflineJobDefinitionMapper definitionMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public OfflineJobExecutionDaoImpl(
+      OfflineJobExecutionMapper mapper,
+      OfflineJobDefinitionMapper definitionMapper,
+      CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.definitionMapper = definitionMapper;
+    this.currentProject = currentProject;
+  }
+
+  public OfflineJobExecutionDaoImpl(OfflineJobExecutionMapper mapper) {
+    this(mapper, null, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public OfflineJobExecutionPO selectById(Long id) {
-    return mapper.selectById(id);
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(OfflineJobExecutionPO::getId, id)
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId));
   }
 
   @Override
   public OfflineJobExecutionPO selectByIdempotencyKey(String idempotencyKey) {
     if (!StringUtils.hasText(idempotencyKey)) return null;
+    Long projectId = currentProjectId();
     return mapper.selectOne(
         Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId)
             .eq(OfflineJobExecutionPO::getIdempotencyKey, idempotencyKey.trim())
             .last("LIMIT 1"));
   }
@@ -43,8 +70,10 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   @Override
   public List<OfflineJobExecutionPO> selectByBatchId(Long batchId) {
     if (batchId == null || batchId <= 0L) return List.of();
+    Long projectId = currentProjectId();
     return mapper.selectList(
         Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId)
             .eq(OfflineJobExecutionPO::getBatchId, batchId)
             .orderByAsc(OfflineJobExecutionPO::getAttemptNo)
             .orderByAsc(OfflineJobExecutionPO::getId));
@@ -52,18 +81,28 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
 
   @Override
   public boolean insert(OfflineJobExecutionPO executionPO) {
+    executionPO.setProjectId(resolveProjectId(executionPO.getProjectId(), executionPO.getJobDefinitionId()));
     return mapper.insert(executionPO) > 0;
   }
 
   @Override
   public boolean updateById(OfflineJobExecutionPO executionPO) {
-    return mapper.updateById(executionPO) > 0;
+    Long projectId = currentProjectId();
+    if (projectId == null) return mapper.updateById(executionPO) > 0;
+    executionPO.setProjectId(projectId);
+    return mapper.update(
+        executionPO,
+        Wrappers.<OfflineJobExecutionPO>lambdaUpdate()
+            .eq(OfflineJobExecutionPO::getId, executionPO.getId())
+            .eq(OfflineJobExecutionPO::getProjectId, projectId)) > 0;
   }
 
   @Override
   public List<OfflineJobExecutionPO> selectActiveExecutions(int limit) {
+    Long projectId = currentProjectId();
     return mapper.selectList(
         Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId)
             .isNotNull(OfflineJobExecutionPO::getBatchId)
             .in(OfflineJobExecutionPO::getStatus, ACTIVE_STATUSES)
             .orderByAsc(OfflineJobExecutionPO::getId)
@@ -72,8 +111,10 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
 
   @Override
   public List<OfflineJobExecutionPO> selectRetryCandidates(LocalDateTime now, int limit) {
+    Long projectId = currentProjectId();
     return mapper.selectList(
         Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId)
             .eq(OfflineJobExecutionPO::getStatus, "FAILED")
             .eq(OfflineJobExecutionPO::getRetryCreated, false)
             .isNotNull(OfflineJobExecutionPO::getBatchId)
@@ -86,10 +127,12 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   @Override
   public boolean reserveRetry(Long executionId, LocalDateTime updateTime) {
     if (executionId == null || executionId <= 0L) return false;
+    Long projectId = currentProjectId();
     return mapper.update(
         null,
         Wrappers.<OfflineJobExecutionPO>lambdaUpdate()
             .eq(OfflineJobExecutionPO::getId, executionId)
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId)
             .eq(OfflineJobExecutionPO::getStatus, "FAILED")
             .eq(OfflineJobExecutionPO::getRetryCreated, false)
             .isNotNull(OfflineJobExecutionPO::getBatchId)
@@ -101,7 +144,10 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
   @Override
   public IPage<OfflineJobExecutionPO> selectPage(PageQuery query) {
     PageQuery condition = query == null ? new PageQuery(1, 10, null, null) : query;
-    LambdaQueryWrapper<OfflineJobExecutionPO> wrapper = new LambdaQueryWrapper<>();
+    Long projectId = currentProjectId();
+    LambdaQueryWrapper<OfflineJobExecutionPO> wrapper =
+        new LambdaQueryWrapper<OfflineJobExecutionPO>()
+            .eq(projectId != null, OfflineJobExecutionPO::getProjectId, projectId);
     if (condition.jobDefinitionId() != null && condition.jobDefinitionId() > 0L) {
       wrapper.eq(OfflineJobExecutionPO::getJobDefinitionId, condition.jobDefinitionId());
     }
@@ -112,7 +158,23 @@ public class OfflineJobExecutionDaoImpl implements OfflineJobExecutionDao {
     }
     wrapper.orderByDesc(OfflineJobExecutionPO::getId);
     return mapper.selectPage(
-        new Page<>(Math.max(1, condition.current()), Math.max(1, condition.pageSize())),
-        wrapper);
+        new Page<>(Math.max(1, condition.current()), Math.max(1, condition.pageSize())), wrapper);
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private Long resolveProjectId(Long storedProjectId, Long definitionId) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (storedProjectId != null && !Objects.equals(projectId, storedProjectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      return projectId;
+    }
+    if (storedProjectId != null || definitionMapper == null || definitionId == null) return storedProjectId;
+    OfflineJobDefinitionPO definition = definitionMapper.selectById(definitionId);
+    return definition == null ? null : definition.getProjectId();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V6__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V6__expand_project_scope.sql
@@ -1,0 +1,18 @@
+-- Project Space expand migration for Offline Sync roots and runtime facts.
+-- project_id stays nullable until default-space backfill and PROJECT_REQUIRED cutover complete.
+ALTER TABLE yak_offline_job_definition
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    DROP INDEX uk_yak_offline_job_name,
+    ADD UNIQUE KEY uk_yak_offline_project_job_name (project_id, job_name),
+    ADD KEY idx_yak_offline_project_release (project_id, release_state, update_time),
+    ADD KEY idx_yak_offline_project_schedule (project_id, schedule_enabled, cron_expression);
+
+ALTER TABLE yak_offline_batch_execution
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_offline_batch_project_status (project_id, status, update_time),
+    ADD KEY idx_yak_offline_batch_project_task (project_id, job_definition_id, id);
+
+ALTER TABLE yak_offline_job_execution
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_offline_execution_project_status (project_id, status, last_sync_time),
+    ADD KEY idx_yak_offline_execution_project_task (project_id, job_definition_id, id);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoProjectScopeTest.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.sync.offline.dao.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineExecutionEventMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineWriteMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineJobDefinitionDaoProjectScopeTest {
+
+  @Mock private OfflineJobDefinitionMapper mapper;
+  @Mock private OfflineJobExecutionMapper executionMapper;
+  @Mock private OfflineExecutionEventMapper eventMapper;
+  @Mock private OfflineWriteMapper writeMapper;
+
+  @Test
+  void insertBindsDefinitionToCurrentProject() {
+    when(mapper.insert(any(OfflineJobDefinitionPO.class))).thenReturn(1);
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    OfflineJobDefinitionDaoImpl dao =
+        new OfflineJobDefinitionDaoImpl(
+            mapper, executionMapper, eventMapper, writeMapper, currentProject);
+    OfflineJobDefinitionPO definition = new OfflineJobDefinitionPO();
+    definition.setId(11L);
+    definition.setJobName("orders-sync");
+
+    assertThat(dao.insert(definition)).isTrue();
+
+    ArgumentCaptor<OfflineJobDefinitionPO> captor =
+        ArgumentCaptor.forClass(OfflineJobDefinitionPO.class);
+    org.mockito.Mockito.verify(mapper).insert(captor.capture());
+    assertThat(captor.getValue().getProjectId()).isEqualTo(7L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/pom.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/controller/v1/RealtimeJobController.java
@@ -15,6 +15,8 @@ import io.yak.ops.business.sync.realtime.domain.CdcPipelineSpec;
 import io.yak.ops.business.sync.realtime.execution.RealtimeJobExecutionService;
 import io.yak.ops.business.sync.realtime.execution.query.RealtimeJobQueryService;
 import io.yak.ops.business.sync.realtime.observability.RealtimeObservabilityService;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +37,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RestController
 @RequestMapping("/api/v1/realtime-sync")
 @RequiresPermission(RealtimePermissionCode.READ)
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class RealtimeJobController {
   private final RealtimeJobDefinitionService definitionService;
   private final RealtimeJobExecutionService executionService;
@@ -62,9 +65,8 @@ public class RealtimeJobController {
   @PostMapping
   @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> create(@Valid @RequestBody RealtimeJobRequests.CreateRequest request) {
-    return Result.success(
-        definitionService.create(
-            request.name(), request.description(), request.runtimeEnvironmentId()));
+    return Result.success(definitionService.create(
+        request.name(), request.description(), request.runtimeEnvironmentId()));
   }
 
   @Operation(summary = "新建实时同步草稿")
@@ -72,13 +74,8 @@ public class RealtimeJobController {
   @RequiresPermission(RealtimePermissionCode.CREATE)
   public Result<Long> draft(@Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
     CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
-    return Result.success(
-        definitionService.save(
-            null,
-            request.name(),
-            request.description(),
-            spec,
-            request.runtimeEnvironmentId()));
+    return Result.success(definitionService.save(
+        null, request.name(), request.description(), spec, request.runtimeEnvironmentId()));
   }
 
   @Operation(summary = "校验未保存的实时同步定义")
@@ -86,10 +83,8 @@ public class RealtimeJobController {
   @RequiresPermission(RealtimePermissionCode.UPDATE)
   public Result<RealtimeViews.Validation> validateDefinition(
       @Valid @RequestBody RealtimeJobRequests.DefinitionValidationRequest request) {
-    return Result.success(
-        viewMapper.toView(
-            definitionService.validateDefinition(
-                requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
+    return Result.success(viewMapper.toView(definitionService.validateDefinition(
+        requestMapper.toSpec(request.spec()), request.runtimeEnvironmentId())));
   }
 
   @Operation(summary = "解析 Yak Realtime YAML")
@@ -103,8 +98,7 @@ public class RealtimeJobController {
   @PostMapping("/yaml/render")
   public Result<Map<String, String>> renderYaml(
       @Valid @RequestBody RealtimeJobRequests.YamlRenderRequest request) {
-    return Result.success(
-        Map.of("yaml", definitionService.renderYaml(requestMapper.toSpec(request.spec()))));
+    return Result.success(Map.of("yaml", definitionService.renderYaml(requestMapper.toSpec(request.spec()))));
   }
 
   @Operation(summary = "保存实时同步草稿")
@@ -113,13 +107,8 @@ public class RealtimeJobController {
   public Result<Long> save(
       @PathVariable long id, @Valid @RequestBody RealtimeJobRequests.SaveRequest request) {
     CdcPipelineSpec spec = requestMapper.toSpec(request.spec());
-    return Result.success(
-        definitionService.save(
-            id,
-            request.name(),
-            request.description(),
-            spec,
-            request.runtimeEnvironmentId()));
+    return Result.success(definitionService.save(
+        id, request.name(), request.description(), spec, request.runtimeEnvironmentId()));
   }
 
   @Operation(summary = "实时同步任务详情")
@@ -137,16 +126,13 @@ public class RealtimeJobController {
       @RequestParam(required = false) Long id,
       @RequestParam(required = false) String releaseState,
       @RequestParam(required = false) String stateGroup) {
-    return Result.success(
-        viewMapper.toView(
-            queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup)));
+    return Result.success(viewMapper.toView(
+        queryService.page(pageNo, pageSize, keyword, id, releaseState, stateGroup)));
   }
 
   @Operation(summary = "订阅实时同步任务状态")
   @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter stream() {
-    return observabilityService.subscribe();
-  }
+  public SseEmitter stream() { return observabilityService.subscribe(); }
 
   @Operation(summary = "发布当前定义版本")
   @PostMapping("/{id}/publish")
@@ -198,7 +184,6 @@ public class RealtimeJobController {
     return Result.success(viewMapper.toView(executionService.applyPublishedVersion(id, key)));
   }
 
-  /** Compatibility endpoint. Semantics are RestartExecution and never upgrade to latest Published. */
   @Deprecated
   @Operation(summary = "兼容入口：重启当前 SyncExecution")
   @PostMapping("/{id}/restart")
@@ -227,8 +212,7 @@ public class RealtimeJobController {
   @Operation(summary = "查询任务状态事件")
   @GetMapping("/{id}/events")
   public Result<List<RealtimeViews.Event>> events(@PathVariable long id) {
-    return Result.success(
-        observabilityService.events(id).stream().map(viewMapper::toView).toList());
+    return Result.success(observabilityService.events(id).stream().map(viewMapper::toView).toList());
   }
 
   @Operation(summary = "查询指定 Flink CDC 运行环境能力")

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoImpl.java
@@ -11,7 +11,11 @@ import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO;
 import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO;
 import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobEventPO;
 import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobListRow;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
@@ -25,6 +29,23 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
   private final RealtimeJobEventMapper eventMapper;
   private final RealtimeJobCommandMapper commandMapper;
   private final RealtimeJobQueryMapper queryMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public RealtimeJobDaoImpl(
+      RealtimeJobDefinitionMapper definitionMapper,
+      RealtimeJobDeploymentMapper deploymentMapper,
+      RealtimeJobEventMapper eventMapper,
+      RealtimeJobCommandMapper commandMapper,
+      RealtimeJobQueryMapper queryMapper,
+      CurrentProject currentProject) {
+    this.definitionMapper = definitionMapper;
+    this.deploymentMapper = deploymentMapper;
+    this.eventMapper = eventMapper;
+    this.commandMapper = commandMapper;
+    this.queryMapper = queryMapper;
+    this.currentProject = currentProject;
+  }
 
   public RealtimeJobDaoImpl(
       RealtimeJobDefinitionMapper definitionMapper,
@@ -32,15 +53,18 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       RealtimeJobEventMapper eventMapper,
       RealtimeJobCommandMapper commandMapper,
       RealtimeJobQueryMapper queryMapper) {
-    this.definitionMapper = definitionMapper;
-    this.deploymentMapper = deploymentMapper;
-    this.eventMapper = eventMapper;
-    this.commandMapper = commandMapper;
-    this.queryMapper = queryMapper;
+    this(
+        definitionMapper,
+        deploymentMapper,
+        eventMapper,
+        commandMapper,
+        queryMapper,
+        Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
   public long insertDefinition(RealtimeJobDefinitionPO definition) {
+    bindCurrentProject(definition);
     definitionMapper.insert(definition);
     if (definition.getId() == null) throw new IllegalStateException("新增实时任务未返回主键");
     return definition.getId();
@@ -54,10 +78,12 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       String specJson,
       String digest,
       long environmentId) {
+    Long projectId = currentProjectId();
     return definitionMapper.update(
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, id)
+            .eq(projectId != null, RealtimeJobDefinitionPO::getProjectId, projectId)
             .set(RealtimeJobDefinitionPO::getJobName, name)
             .set(RealtimeJobDefinitionPO::getDescription, description)
             .set(RealtimeJobDefinitionPO::getRuntimeEnvironmentId, environmentId)
@@ -69,10 +95,12 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public int publish(long id, int expectedDefinitionVersion, String expectedDigest) {
+    Long projectId = currentProjectId();
     return definitionMapper.update(
         null,
         Wrappers.<RealtimeJobDefinitionPO>lambdaUpdate()
             .eq(RealtimeJobDefinitionPO::getId, id)
+            .eq(projectId != null, RealtimeJobDefinitionPO::getProjectId, projectId)
             .eq(RealtimeJobDefinitionPO::getDefinitionVersion, expectedDefinitionVersion)
             .eq(RealtimeJobDefinitionPO::getConfigDigest, expectedDigest)
             .set(RealtimeJobDefinitionPO::getReleaseState, "PUBLISHED")
@@ -81,18 +109,29 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public Optional<RealtimeJobDefinitionPO> findDefinition(long id) {
-    return Optional.ofNullable(definitionMapper.selectById(id));
+    Long projectId = currentProjectId();
+    return Optional.ofNullable(
+        definitionMapper.selectOne(
+            Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
+                .eq(RealtimeJobDefinitionPO::getId, id)
+                .eq(projectId != null, RealtimeJobDefinitionPO::getProjectId, projectId)));
   }
 
   @Override
   public Optional<RealtimeJobDefinitionPO> lockDefinition(long id) {
-    return Optional.ofNullable(commandMapper.lockDefinition(id));
+    Long projectId = currentProjectId();
+    return Optional.ofNullable(
+        projectId == null
+            ? commandMapper.lockDefinition(id)
+            : commandMapper.lockDefinitionByProject(id, projectId));
   }
 
   @Override
   public Optional<RealtimeJobDeploymentPO> deploymentByIdempotencyKey(String key) {
+    Long projectId = currentProjectId();
     return deploymentMapper.selectList(
             Wrappers.<RealtimeJobDeploymentPO>lambdaQuery()
+                .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
                 .eq(RealtimeJobDeploymentPO::getIdempotencyKey, key)
                 .last("LIMIT 1"))
         .stream()
@@ -101,8 +140,10 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public Optional<RealtimeJobDeploymentPO> latestDeployment(long definitionId) {
+    Long projectId = currentProjectId();
     return deploymentMapper.selectList(
             Wrappers.<RealtimeJobDeploymentPO>lambdaQuery()
+                .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
                 .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
                 .orderByDesc(RealtimeJobDeploymentPO::getId)
                 .last("LIMIT 1"))
@@ -112,11 +153,17 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public Optional<RealtimeJobDeploymentPO> findDeployment(long deploymentId) {
-    return Optional.ofNullable(deploymentMapper.selectById(deploymentId));
+    Long projectId = currentProjectId();
+    return Optional.ofNullable(
+        deploymentMapper.selectOne(
+            Wrappers.<RealtimeJobDeploymentPO>lambdaQuery()
+                .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)));
   }
 
   @Override
   public long insertDeployment(RealtimeJobDeploymentPO deployment) {
+    deployment.setProjectId(resolveDeploymentProject(deployment));
     deploymentMapper.insert(deployment);
     if (deployment.getId() == null) throw new IllegalStateException("新增部署未返回主键");
     return deployment.getId();
@@ -125,11 +172,13 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
   @Override
   public void bindDeploymentDefinitionVersion(
       long deploymentId, long definitionVersionId, int sourceDraftRevision) {
+    Long projectId = currentProjectId();
     int updated =
         deploymentMapper.update(
             null,
             Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
                 .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
                 .eq(RealtimeJobDeploymentPO::getStatus, "SUBMITTING")
                 .isNull(RealtimeJobDeploymentPO::getDefinitionVersionId)
                 .set(RealtimeJobDeploymentPO::getDefinitionVersionId, definitionVersionId)
@@ -142,11 +191,13 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
   @Override
   public int markDeploymentRunning(
       long definitionId, long deploymentId, String engineJobId, String runtimeRevision) {
+    Long projectId = currentProjectId();
     return deploymentMapper.update(
         null,
         Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
             .eq(RealtimeJobDeploymentPO::getId, deploymentId)
             .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+            .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
             .eq(RealtimeJobDeploymentPO::getDesiredState, "RUNNING")
             .eq(RealtimeJobDeploymentPO::getObservedState, "STARTING")
             .set(RealtimeJobDeploymentPO::getGatewayJobId, engineJobId)
@@ -160,10 +211,12 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public void bindDeploymentForStop(long deploymentId, String engineJobId, String runtimeRevision) {
+    Long projectId = currentProjectId();
     deploymentMapper.update(
         null,
         Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
             .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+            .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
             .set(RealtimeJobDeploymentPO::getGatewayJobId, engineJobId)
             .set(RealtimeJobDeploymentPO::getRuntimeVersion, runtimeRevision)
             .set(RealtimeJobDeploymentPO::getRuntimeRevision, runtimeRevision)
@@ -181,11 +234,13 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       String message) {
     String desiredState = stopRequested ? "STOPPED" : (uncertain ? "RUNNING" : "STOPPED");
     String observedState = uncertain ? "UNKNOWN" : "FAILED";
+    Long projectId = currentProjectId();
     deploymentMapper.update(
         null,
         Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
             .eq(RealtimeJobDeploymentPO::getId, deploymentId)
             .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+            .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
             .set(RealtimeJobDeploymentPO::getDesiredState, desiredState)
             .set(RealtimeJobDeploymentPO::getObservedState, observedState)
             .set(RealtimeJobDeploymentPO::getStatus, observedState)
@@ -196,12 +251,14 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
   @Override
   public void markStopping(long definitionId, Long deploymentId) {
     if (deploymentId == null) return;
+    Long projectId = currentProjectId();
     int updated =
         deploymentMapper.update(
             null,
             Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
                 .eq(RealtimeJobDeploymentPO::getId, deploymentId)
                 .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+                .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
                 .set(RealtimeJobDeploymentPO::getDesiredState, "STOPPED")
                 .set(RealtimeJobDeploymentPO::getObservedState, "STOPPING")
                 .set(RealtimeJobDeploymentPO::getStatus, "STOPPING"));
@@ -217,12 +274,14 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       String commandType,
       long targetDefinitionVersionId,
       String idempotencyKey) {
+    Long projectId = currentProjectId();
     int updated =
         deploymentMapper.update(
             null,
             Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
                 .eq(RealtimeJobDeploymentPO::getId, deploymentId)
                 .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+                .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
                 .eq(RealtimeJobDeploymentPO::getDesiredState, "RUNNING")
                 .eq(RealtimeJobDeploymentPO::getObservedState, "RUNNING")
                 .eq(RealtimeJobDeploymentPO::getResultUncertain, false)
@@ -242,11 +301,13 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public void clearReplacementIntent(long deploymentId, String idempotencyKey) {
+    Long projectId = currentProjectId();
     int updated =
         deploymentMapper.update(
             null,
             Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
                 .eq(RealtimeJobDeploymentPO::getId, deploymentId)
+                .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
                 .eq(RealtimeJobDeploymentPO::getReplacementIdempotencyKey, idempotencyKey)
                 .set(RealtimeJobDeploymentPO::getReplacementCommandType, null)
                 .set(RealtimeJobDeploymentPO::getReplacementTargetDefinitionVersionId, null)
@@ -264,20 +325,28 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       String deploymentState,
       String engineJobId,
       String error) {
-    if (deploymentId != null) {
-      commandMapper.reconcileDeployment(
-          deploymentId, observedState, deploymentState, engineJobId, error);
+    if (deploymentId == null) return;
+    Long projectId = currentProjectId();
+    int updated = projectId == null
+        ? commandMapper.reconcileDeployment(
+            deploymentId, observedState, deploymentState, engineJobId, error)
+        : commandMapper.reconcileDeploymentByProject(
+            deploymentId, projectId, observedState, deploymentState, engineJobId, error);
+    if (projectId != null && updated != 1) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
     }
   }
 
   @Override
   public void markTerminalFailure(long definitionId, Long deploymentId, String message) {
     if (deploymentId == null) return;
+    Long projectId = currentProjectId();
     deploymentMapper.update(
         null,
         Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
             .eq(RealtimeJobDeploymentPO::getId, deploymentId)
             .eq(RealtimeJobDeploymentPO::getDefinitionId, definitionId)
+            .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
             .set(RealtimeJobDeploymentPO::getDesiredState, "STOPPED")
             .set(RealtimeJobDeploymentPO::getObservedState, "FAILED")
             .set(RealtimeJobDeploymentPO::getStatus, "FAILED")
@@ -286,28 +355,36 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public List<RealtimeJobDeploymentPO> reconcileExecutions() {
-    return commandMapper.reconcileExecutions();
+    Long projectId = currentProjectId();
+    return projectId == null
+        ? commandMapper.reconcileExecutions()
+        : commandMapper.reconcileExecutionsByProject(projectId);
   }
 
   @Override
   public int deleteDefinition(long id) {
+    Long projectId = currentProjectId();
     int deleted =
         definitionMapper.delete(
-            Wrappers.<RealtimeJobDefinitionPO>lambdaQuery().eq(RealtimeJobDefinitionPO::getId, id));
+            Wrappers.<RealtimeJobDefinitionPO>lambdaQuery()
+                .eq(RealtimeJobDefinitionPO::getId, id)
+                .eq(projectId != null, RealtimeJobDefinitionPO::getProjectId, projectId));
     if (deleted != 1) return deleted;
-
-    // Audit-safe deletion remains a separate GAP; this change does not pretend to solve it.
     eventMapper.delete(
         Wrappers.<RealtimeJobEventPO>lambdaQuery()
             .eq(RealtimeJobEventPO::getDefinitionId, id));
     deploymentMapper.delete(
         Wrappers.<RealtimeJobDeploymentPO>lambdaQuery()
-            .eq(RealtimeJobDeploymentPO::getDefinitionId, id));
+            .eq(RealtimeJobDeploymentPO::getDefinitionId, id)
+            .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId));
     return deleted;
   }
 
   @Override
   public void insertEvent(RealtimeJobEventPO event) {
+    if (currentProjectId() != null && findDefinition(event.getDefinitionId()).isEmpty()) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
     eventMapper.insert(event);
   }
 
@@ -318,6 +395,7 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public List<RealtimeJobEventPO> events(long definitionId) {
+    if (currentProjectId() != null && findDefinition(definitionId).isEmpty()) return List.of();
     return eventMapper.selectList(
         Wrappers.<RealtimeJobEventPO>lambdaQuery()
             .eq(RealtimeJobEventPO::getDefinitionId, definitionId)
@@ -327,10 +405,12 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public int bindRuntimeIdentity(String idempotencyKey, String runtimeJobName) {
+    Long projectId = currentProjectId();
     return deploymentMapper.update(
         null,
         Wrappers.<RealtimeJobDeploymentPO>lambdaUpdate()
             .eq(RealtimeJobDeploymentPO::getIdempotencyKey, idempotencyKey)
+            .eq(projectId != null, RealtimeJobDeploymentPO::getProjectId, projectId)
             .isNull(RealtimeJobDeploymentPO::getGatewayJobId)
             .eq(RealtimeJobDeploymentPO::getRuntimeIdentityState, "REQUIRED")
             .and(
@@ -351,7 +431,10 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
 
   @Override
   public long countPage(String keyword, Long id, String releaseState, String stateGroup) {
-    return queryMapper.count(keyword, id, releaseState, stateGroup);
+    Long projectId = currentProjectId();
+    return projectId == null
+        ? queryMapper.count(keyword, id, releaseState, stateGroup)
+        : queryMapper.countByProject(projectId, keyword, id, releaseState, stateGroup);
   }
 
   @Override
@@ -362,6 +445,41 @@ public class RealtimeJobDaoImpl implements RealtimeJobDao {
       String stateGroup,
       int limit,
       int offset) {
-    return queryMapper.page(keyword, id, releaseState, stateGroup, limit, offset);
+    Long projectId = currentProjectId();
+    return projectId == null
+        ? queryMapper.page(keyword, id, releaseState, stateGroup, limit, offset)
+        : queryMapper.pageByProject(
+            projectId, keyword, id, releaseState, stateGroup, limit, offset);
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private void bindCurrentProject(RealtimeJobDefinitionPO definition) {
+    Long projectId = currentProjectId();
+    if (projectId == null) return;
+    if (definition.getProjectId() != null
+        && !Objects.equals(projectId, definition.getProjectId())) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+    definition.setProjectId(projectId);
+  }
+
+  private Long resolveDeploymentProject(RealtimeJobDeploymentPO deployment) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (deployment.getProjectId() != null
+          && !Objects.equals(projectId, deployment.getProjectId())) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      if (findDefinition(deployment.getDefinitionId()).isEmpty()) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      return projectId;
+    }
+    if (deployment.getProjectId() != null) return deployment.getProjectId();
+    RealtimeJobDefinitionPO definition = definitionMapper.selectById(deployment.getDefinitionId());
+    return definition == null ? null : definition.getProjectId();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeJobCommandMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeJobCommandMapper.java
@@ -9,10 +9,21 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface RealtimeJobCommandMapper {
   RealtimeJobDefinitionPO lockDefinition(@Param("id") long id);
+  RealtimeJobDefinitionPO lockDefinitionByProject(
+      @Param("id") long id, @Param("projectId") long projectId);
   List<RealtimeJobDeploymentPO> reconcileExecutions();
+  List<RealtimeJobDeploymentPO> reconcileExecutionsByProject(
+      @Param("projectId") long projectId);
   int tryAcquireLease(@Param("owner") String owner, @Param("leaseSeconds") int leaseSeconds);
   int reconcileDeployment(
       @Param("deploymentId") long deploymentId,
+      @Param("observedState") String observedState,
+      @Param("deploymentState") String deploymentState,
+      @Param("engineJobId") String engineJobId,
+      @Param("error") String error);
+  int reconcileDeploymentByProject(
+      @Param("deploymentId") long deploymentId,
+      @Param("projectId") long projectId,
       @Param("observedState") String observedState,
       @Param("deploymentState") String deploymentState,
       @Param("engineJobId") String engineJobId,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeJobQueryMapper.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/mapper/RealtimeJobQueryMapper.java
@@ -13,7 +13,23 @@ public interface RealtimeJobQueryMapper {
       @Param("releaseState") String releaseState,
       @Param("stateGroup") String stateGroup);
 
+  long countByProject(
+      @Param("projectId") long projectId,
+      @Param("keyword") String keyword,
+      @Param("id") Long id,
+      @Param("releaseState") String releaseState,
+      @Param("stateGroup") String stateGroup);
+
   List<RealtimeJobListRow> page(
+      @Param("keyword") String keyword,
+      @Param("id") Long id,
+      @Param("releaseState") String releaseState,
+      @Param("stateGroup") String stateGroup,
+      @Param("limit") int limit,
+      @Param("offset") int offset);
+
+  List<RealtimeJobListRow> pageByProject(
+      @Param("projectId") long projectId,
       @Param("keyword") String keyword,
       @Param("id") Long id,
       @Param("releaseState") String releaseState,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDefinitionPO.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDefinitionPO.java
@@ -6,17 +6,13 @@ import com.baomidou.mybatisplus.annotation.TableName;
 import java.time.LocalDateTime;
 import lombok.Data;
 
-/**
- * Physical persistence row for RealtimeSyncTask/current Draft.
- *
- * <p>desiredState/observedState/lastError are retained only because existing schemas still contain
- * those columns. Wave 6 application code does not read or dual-write them as runtime truth.
- */
+/** Physical persistence row for RealtimeSyncTask/current Draft. */
 @Data
 @TableName("yak_realtime_job_definition")
 public class RealtimeJobDefinitionPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private String jobName;
   private String description;
   private Long runtimeEnvironmentId;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/java/io/yak/ops/business/sync/realtime/dao/model/RealtimeJobDeploymentPO.java
@@ -6,18 +6,13 @@ import com.baomidou.mybatisplus.annotation.TableName;
 import java.time.LocalDateTime;
 import lombok.Data;
 
-/**
- * Physical persistence row for SyncExecution.
- *
- * <p>The table keeps its legacy "deployment" name for schema compatibility. desiredState and
- * observedState are authoritative lifecycle columns. status is only a physical compatibility mirror,
- * and configDigest stores the ExecutionArtifactDigest.
- */
+/** Physical persistence row for a realtime SyncExecution. */
 @Data
 @TableName("yak_realtime_job_deployment")
 public class RealtimeJobDeploymentPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private Long definitionId;
   private Long definitionVersionId;
   private Integer definitionVersion;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V2__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/db/migration/yak-realtime-sync/V2__expand_project_scope.sql
@@ -1,0 +1,12 @@
+-- Project Space expand migration for Realtime Sync roots and runtime facts.
+-- Compute Environment and Runtime Lease remain GLOBAL.
+ALTER TABLE yak_realtime_job_definition
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    DROP INDEX uk_realtime_name,
+    ADD UNIQUE KEY uk_realtime_project_name (project_id, job_name),
+    ADD KEY idx_realtime_project_state (project_id, release_state, update_time);
+
+ALTER TABLE yak_realtime_job_deployment
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_realtime_deployment_project_state (project_id, observed_state, update_time),
+    ADD KEY idx_realtime_deployment_project_definition (project_id, definition_id, id);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobCommandMapper.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobCommandMapper.xml
@@ -4,6 +4,11 @@
   <select id="lockDefinition" resultType="io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO">
     SELECT * FROM yak_realtime_job_definition WHERE id = #{id} FOR UPDATE
   </select>
+  <select id="lockDefinitionByProject" resultType="io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO">
+    SELECT * FROM yak_realtime_job_definition
+    WHERE id = #{id} AND project_id = #{projectId}
+    FOR UPDATE
+  </select>
   <select id="reconcileExecutions"
           resultType="io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO">
     SELECT p.*
@@ -13,6 +18,20 @@
       FROM yak_realtime_job_deployment p2
       WHERE p2.definition_id = p.definition_id
     )
+      AND p.observed_state IN ('STARTING','RUNNING','STOPPING','UNKNOWN','CONFLICT')
+    ORDER BY p.definition_id ASC
+  </select>
+  <select id="reconcileExecutionsByProject"
+          resultType="io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDeploymentPO">
+    SELECT p.*
+    FROM yak_realtime_job_deployment p
+    WHERE p.project_id = #{projectId}
+      AND p.id = (
+        SELECT MAX(p2.id)
+        FROM yak_realtime_job_deployment p2
+        WHERE p2.definition_id = p.definition_id
+          AND p2.project_id = #{projectId}
+      )
       AND p.observed_state IN ('STARTING','RUNNING','STOPPING','UNKNOWN','CONFLICT')
     ORDER BY p.definition_id ASC
   </select>
@@ -30,5 +49,15 @@
         result_uncertain = CASE WHEN #{observedState} = 'UNKNOWN' THEN result_uncertain ELSE 0 END,
         error_message = #{error}
     WHERE id = #{deploymentId}
+  </update>
+  <update id="reconcileDeploymentByProject">
+    UPDATE yak_realtime_job_deployment
+    SET observed_state = #{observedState},
+        status = #{deploymentState},
+        gateway_job_id = COALESCE(gateway_job_id, #{engineJobId}),
+        result_uncertain = CASE WHEN #{observedState} = 'UNKNOWN' THEN result_uncertain ELSE 0 END,
+        error_message = #{error}
+    WHERE id = #{deploymentId}
+      AND project_id = #{projectId}
   </update>
 </mapper>

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/main/resources/mapper/realtime/RealtimeJobQueryMapper.xml
@@ -7,70 +7,92 @@
   </sql>
 
   <sql id="filters">
-    <where>
-      <if test="keyword != null and keyword != ''">
-        AND (d.job_name LIKE #{keyword} OR d.description LIKE #{keyword})
-      </if>
-      <if test="id != null">AND d.id = #{id}</if>
-      <if test="releaseState != null and releaseState != ''">AND d.release_state = #{releaseState}</if>
-      <if test="stateGroup == 'RUNNING'">
-        AND p.observed_state IN ('STARTING','RUNNING','STOPPING')
-      </if>
-      <if test="stateGroup == 'STOPPED'">
-        AND (p.id IS NULL OR p.observed_state = 'STOPPED')
-      </if>
-      <if test="stateGroup == 'ABNORMAL'">
-        AND p.observed_state IN ('FAILED','UNKNOWN','CONFLICT')
-      </if>
-    </where>
+    <if test="keyword != null and keyword != ''">
+      AND (d.job_name LIKE #{keyword} OR d.description LIKE #{keyword})
+    </if>
+    <if test="id != null">AND d.id = #{id}</if>
+    <if test="releaseState != null and releaseState != ''">AND d.release_state = #{releaseState}</if>
+    <if test="stateGroup == 'RUNNING'">
+      AND p.observed_state IN ('STARTING','RUNNING','STOPPING')
+    </if>
+    <if test="stateGroup == 'STOPPED'">
+      AND (p.id IS NULL OR p.observed_state = 'STOPPED')
+    </if>
+    <if test="stateGroup == 'ABNORMAL'">
+      AND p.observed_state IN ('FAILED','UNKNOWN','CONFLICT')
+    </if>
+  </sql>
+
+  <sql id="columns">
+    d.id,
+    d.job_name,
+    d.description,
+    d.runtime_environment_id,
+    d.spec_json,
+    d.release_state,
+    CASE WHEN p.id IS NULL THEN 'STOPPED' ELSE p.desired_state END AS desired_state,
+    CASE WHEN p.id IS NULL THEN 'STOPPED' ELSE p.observed_state END AS observed_state,
+    d.definition_version,
+    d.published_version,
+    CASE
+      WHEN p.id IS NOT NULL
+       AND p.desired_state = 'RUNNING'
+       AND p.observed_state = 'RUNNING'
+       AND p.definition_version_id IS NOT NULL
+       AND d.published_definition_version_id IS NOT NULL
+       AND p.definition_version_id &lt;&gt; d.published_definition_version_id
+      THEN TRUE ELSE FALSE
+    END AS published_update_available,
+    d.config_digest,
+    p.error_message AS last_error,
+    d.create_time,
+    d.update_time,
+    p.id AS deployment_id,
+    p.definition_version AS deployment_definition_version,
+    p.spec_summary AS deployment_spec_summary,
+    p.config_digest AS deployment_config_digest,
+    p.idempotency_key AS deployment_idempotency_key,
+    p.gateway_job_id AS deployment_gateway_job_id,
+    p.runtime_revision AS deployment_runtime_revision,
+    p.runtime_environment_snapshot_json AS deployment_runtime_environment_snapshot_json,
+    p.status AS deployment_status,
+    p.result_uncertain AS deployment_result_uncertain,
+    p.error_message AS deployment_error_message,
+    p.create_time AS deployment_create_time,
+    p.update_time AS deployment_update_time
   </sql>
 
   <select id="count" resultType="long">
     SELECT COUNT(*)
     FROM yak_realtime_job_definition d
     <include refid="latestExecutionJoin"/>
+    WHERE 1 = 1
+    <include refid="filters"/>
+  </select>
+
+  <select id="countByProject" resultType="long">
+    SELECT COUNT(*)
+    FROM yak_realtime_job_definition d
+    <include refid="latestExecutionJoin"/>
+    WHERE d.project_id = #{projectId}
     <include refid="filters"/>
   </select>
 
   <select id="page" resultType="io.yak.ops.business.sync.realtime.dao.model.RealtimeJobListRow">
-    SELECT d.id,
-           d.job_name,
-           d.description,
-           d.runtime_environment_id,
-           d.spec_json,
-           d.release_state,
-           CASE WHEN p.id IS NULL THEN 'STOPPED' ELSE p.desired_state END AS desired_state,
-           CASE WHEN p.id IS NULL THEN 'STOPPED' ELSE p.observed_state END AS observed_state,
-           d.definition_version,
-           d.published_version,
-           CASE
-             WHEN p.id IS NOT NULL
-              AND p.desired_state = 'RUNNING'
-              AND p.observed_state = 'RUNNING'
-              AND p.definition_version_id IS NOT NULL
-              AND d.published_definition_version_id IS NOT NULL
-              AND p.definition_version_id &lt;&gt; d.published_definition_version_id
-             THEN TRUE ELSE FALSE
-           END AS published_update_available,
-           d.config_digest,
-           p.error_message AS last_error,
-           d.create_time,
-           d.update_time,
-           p.id AS deployment_id,
-           p.definition_version AS deployment_definition_version,
-           p.spec_summary AS deployment_spec_summary,
-           p.config_digest AS deployment_config_digest,
-           p.idempotency_key AS deployment_idempotency_key,
-           p.gateway_job_id AS deployment_gateway_job_id,
-           p.runtime_revision AS deployment_runtime_revision,
-           p.runtime_environment_snapshot_json AS deployment_runtime_environment_snapshot_json,
-           p.status AS deployment_status,
-           p.result_uncertain AS deployment_result_uncertain,
-           p.error_message AS deployment_error_message,
-           p.create_time AS deployment_create_time,
-           p.update_time AS deployment_update_time
+    SELECT <include refid="columns"/>
     FROM yak_realtime_job_definition d
     <include refid="latestExecutionJoin"/>
+    WHERE 1 = 1
+    <include refid="filters"/>
+    ORDER BY d.update_time DESC, d.id DESC
+    LIMIT #{limit} OFFSET #{offset}
+  </select>
+
+  <select id="pageByProject" resultType="io.yak.ops.business.sync.realtime.dao.model.RealtimeJobListRow">
+    SELECT <include refid="columns"/>
+    FROM yak_realtime_job_definition d
+    <include refid="latestExecutionJoin"/>
+    WHERE d.project_id = #{projectId}
     <include refid="filters"/>
     ORDER BY d.update_time DESC, d.id DESC
     LIMIT #{limit} OFFSET #{offset}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-realtime/src/test/java/io/yak/ops/business/sync/realtime/dao/impl/RealtimeJobDaoProjectScopeTest.java
@@ -1,0 +1,59 @@
+package io.yak.ops.business.sync.realtime.dao.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobCommandMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDefinitionMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobDeploymentMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobEventMapper;
+import io.yak.ops.business.sync.realtime.dao.mapper.RealtimeJobQueryMapper;
+import io.yak.ops.business.sync.realtime.dao.model.RealtimeJobDefinitionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RealtimeJobDaoProjectScopeTest {
+
+  @Mock private RealtimeJobDefinitionMapper definitionMapper;
+  @Mock private RealtimeJobDeploymentMapper deploymentMapper;
+  @Mock private RealtimeJobEventMapper eventMapper;
+  @Mock private RealtimeJobCommandMapper commandMapper;
+  @Mock private RealtimeJobQueryMapper queryMapper;
+
+  @Test
+  void insertDefinitionUsesCurrentProject() {
+    when(definitionMapper.insert(any(RealtimeJobDefinitionPO.class)))
+        .thenAnswer(
+            invocation -> {
+              RealtimeJobDefinitionPO po = invocation.getArgument(0);
+              po.setId(11L);
+              return 1;
+            });
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    RealtimeJobDaoImpl dao =
+        new RealtimeJobDaoImpl(
+            definitionMapper,
+            deploymentMapper,
+            eventMapper,
+            commandMapper,
+            queryMapper,
+            currentProject);
+    RealtimeJobDefinitionPO definition = new RealtimeJobDefinitionPO();
+    definition.setJobName("orders-cdc");
+
+    assertThat(dao.insertDefinition(definition)).isEqualTo(11L);
+
+    ArgumentCaptor<RealtimeJobDefinitionPO> captor =
+        ArgumentCaptor.forClass(RealtimeJobDefinitionPO.class);
+    org.mockito.Mockito.verify(definitionMapper).insert(captor.capture());
+    assertThat(captor.getValue().getProjectId()).isEqualTo(7L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/pom.xml
+++ b/yak-ops-business/yak-ops-business-task-catalog/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
 

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
@@ -6,6 +6,8 @@ import io.yak.framework.common.Result;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/task-catalog/assets")
 @ConditionalOnDataSourceEnabled
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class TaskCatalogController {
 
   private final TaskCatalogService service;

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
@@ -147,8 +147,12 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
     String sql = "UPDATE yak_task_asset SET project_id = ?, name = ?, task_type = ?, update_time = NOW(6) "
         + "WHERE source = ? AND source_ref = ?"
         + (currentProjectId == null ? "" : " AND (project_id = ? OR project_id IS NULL)");
-    List<Object> args = new ArrayList<>(
-        List.of(effectiveProjectId, name, taskType, source.name(), sourceRef));
+    List<Object> args = new ArrayList<>();
+    args.add(effectiveProjectId);
+    args.add(name);
+    args.add(taskType);
+    args.add(source.name());
+    args.add(sourceRef);
     if (currentProjectId != null) args.add(currentProjectId);
     return jdbcTemplate.update(sql, args.toArray()) > 0;
   }

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
@@ -2,6 +2,9 @@ package io.yak.ops.business.taskcatalog.repository;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskAssetStatus;
 import io.yak.ops.spi.task.model.TaskRevisionRef;
@@ -11,8 +14,10 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -28,10 +33,18 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
           + "FROM yak_task_asset";
 
   private final JdbcTemplate jdbcTemplate;
+  private final CurrentProject currentProject;
 
+  @Autowired
   public JdbcTaskAssetRepository(
-      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      CurrentProject currentProject) {
     this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.currentProject = currentProject;
+  }
+
+  public JdbcTaskAssetRepository(DataSource dataSource) {
+    this(dataSource, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
@@ -43,6 +56,7 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
       String taskType,
       long revisionId,
       int revisionNo) {
+    Long effectiveProjectId = effectiveProjectId(projectId);
     jdbcTemplate.update(
         """
         INSERT INTO yak_task_asset (
@@ -60,7 +74,7 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
         """,
         source.name(),
         sourceRef,
-        projectId,
+        effectiveProjectId,
         name,
         taskType,
         revisionId,
@@ -71,21 +85,24 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
 
   @Override
   public Optional<TaskAsset> findById(long assetId) {
-    List<TaskAsset> values = jdbcTemplate.query(
-        SELECT_COLUMNS + " WHERE id = ? LIMIT 1",
-        JdbcTaskAssetRepository::mapRow,
-        assetId);
-    return values.stream().findFirst();
+    Long projectId = currentProjectId();
+    String sql = SELECT_COLUMNS + " WHERE id = ?"
+        + (projectId == null ? "" : " AND project_id = ?")
+        + " LIMIT 1";
+    Object[] args = projectId == null ? new Object[] {assetId} : new Object[] {assetId, projectId};
+    return jdbcTemplate.query(sql, JdbcTaskAssetRepository::mapRow, args).stream().findFirst();
   }
 
   @Override
   public Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef) {
-    List<TaskAsset> values = jdbcTemplate.query(
-        SELECT_COLUMNS + " WHERE source = ? AND source_ref = ? LIMIT 1",
-        JdbcTaskAssetRepository::mapRow,
-        source.name(),
-        sourceRef);
-    return values.stream().findFirst();
+    Long projectId = currentProjectId();
+    String sql = SELECT_COLUMNS + " WHERE source = ? AND source_ref = ?"
+        + (projectId == null ? "" : " AND project_id = ?")
+        + " LIMIT 1";
+    Object[] args = projectId == null
+        ? new Object[] {source.name(), sourceRef}
+        : new Object[] {source.name(), sourceRef, projectId};
+    return jdbcTemplate.query(sql, JdbcTaskAssetRepository::mapRow, args).stream().findFirst();
   }
 
   @Override
@@ -95,6 +112,11 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
       String keyword) {
     StringBuilder sql = new StringBuilder(SELECT_COLUMNS).append(" WHERE 1 = 1");
     List<Object> args = new ArrayList<>();
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      sql.append(" AND project_id = ?");
+      args.add(projectId);
+    }
     if (source != null) {
       sql.append(" AND source = ?");
       args.add(source.name());
@@ -120,14 +142,15 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
       Long projectId,
       String name,
       String taskType) {
-    return jdbcTemplate.update(
-        "UPDATE yak_task_asset SET project_id = ?, name = ?, task_type = ?, update_time = NOW(6) "
-            + "WHERE source = ? AND source_ref = ?",
-        projectId,
-        name,
-        taskType,
-        source.name(),
-        sourceRef) > 0;
+    Long effectiveProjectId = effectiveProjectId(projectId);
+    Long currentProjectId = currentProjectId();
+    String sql = "UPDATE yak_task_asset SET project_id = ?, name = ?, task_type = ?, update_time = NOW(6) "
+        + "WHERE source = ? AND source_ref = ?"
+        + (currentProjectId == null ? "" : " AND (project_id = ? OR project_id IS NULL)");
+    List<Object> args = new ArrayList<>(
+        List.of(effectiveProjectId, name, taskType, source.name(), sourceRef));
+    if (currentProjectId != null) args.add(currentProjectId);
+    return jdbcTemplate.update(sql, args.toArray()) > 0;
   }
 
   @Override
@@ -135,11 +158,29 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
       TaskAssetSource source,
       String sourceRef,
       TaskAssetStatus status) {
-    return jdbcTemplate.update(
-        "UPDATE yak_task_asset SET status = ?, update_time = NOW(6) WHERE source = ? AND source_ref = ?",
-        status.name(),
-        source.name(),
-        sourceRef) > 0;
+    Long projectId = currentProjectId();
+    String sql = "UPDATE yak_task_asset SET status = ?, update_time = NOW(6) WHERE source = ? AND source_ref = ?"
+        + (projectId == null ? "" : " AND project_id = ?");
+    Object[] args = projectId == null
+        ? new Object[] {status.name(), source.name(), sourceRef}
+        : new Object[] {status.name(), source.name(), sourceRef, projectId};
+    return jdbcTemplate.update(sql, args) > 0;
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private Long effectiveProjectId(Long sourceProjectId) {
+    return currentProject.current()
+        .map(
+            context -> {
+              if (sourceProjectId != null && !Objects.equals(context.projectId(), sourceProjectId)) {
+                throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+              }
+              return context.projectId();
+            })
+        .orElse(sourceProjectId);
   }
 
   private static TaskAsset mapRow(ResultSet resultSet, int rowNum) throws SQLException {

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V3__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V3__expand_project_scope.sql
@@ -1,0 +1,3 @@
+-- Task Catalog is a project projection: project_id remains sourced from the publishing domain.
+ALTER TABLE yak_task_asset
+    ADD KEY idx_yak_task_asset_project_catalog (project_id, status, source, task_type, update_time);

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-job</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowBackfillController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowBackfillController.java
@@ -3,11 +3,13 @@ package io.yak.ops.business.workflow.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
-import io.yak.ops.business.workflow.backfill.WorkflowBackfillQuery;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillManager;
+import io.yak.ops.business.workflow.backfill.WorkflowBackfillQuery;
 import io.yak.ops.common.bean.dto.workflow.WorkflowBackfillCreateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillPreviewVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/workflows/backfills")
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class WorkflowBackfillController {
   private final WorkflowBackfillManager service;
   private final WorkflowBackfillQuery query;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -9,6 +9,8 @@ import io.yak.ops.business.workflow.execution.WorkflowLauncher;
 import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
 import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.MediaType;
@@ -24,6 +26,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Tag(name = "工作流接口")
 @RestController
 @RequestMapping("/api/v1/workflows")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class WorkflowController {
 
   private final WorkflowRuntime workflowRuntimeService;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
@@ -11,6 +11,8 @@ import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "工作流定义接口")
 @RestController
 @RequestMapping("/api/v1/workflows/definitions")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class WorkflowDefinitionController {
 
   private final WorkflowDefinitionManager definitionService;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowInstanceOperationsController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowInstanceOperationsController.java
@@ -9,6 +9,8 @@ import io.yak.ops.common.bean.dto.workflow.WorkflowBusinessDateRerunDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowBatchRetryVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceOperationsVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "工作流实例运维")
 @RestController
 @RequestMapping("/api/v1/workflows/instances")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class WorkflowInstanceOperationsController {
   private final WorkflowExecutionManager operations;
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleCommandController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleCommandController.java
@@ -9,6 +9,8 @@ import io.yak.ops.business.workflow.schedule.WorkflowScheduleRevision;
 import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleCreateDTO;
 import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleUpdateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/workflows/schedules")
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class WorkflowScheduleCommandController {
   private final WorkflowScheduleCreateCommand creator;
   private final WorkflowScheduleRevision revision;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleQueryController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleQueryController.java
@@ -7,6 +7,8 @@ import io.yak.ops.business.workflow.schedule.WorkflowScheduleQuery;
 import io.yak.ops.business.workflow.schedule.trigger.WorkflowScheduleTriggerQuery;
 import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleTriggerVO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/workflows/schedules")
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class WorkflowScheduleQueryController {
   private final WorkflowScheduleQuery query;
   private final WorkflowScheduleTriggerQuery triggerQuery;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowBackfillDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowBackfillDaoImpl.java
@@ -3,39 +3,78 @@ package io.yak.ops.business.workflow.dao.impl;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.workflow.dao.WorkflowBackfillDao;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowBackfillMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
 import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
 /** 基于 MyBatis-Plus 的 Backfill 批次 DAO。 */
 @Repository
-@RequiredArgsConstructor
 @DependsOn("workflowFlyway")
-@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public class WorkflowBackfillDaoImpl implements WorkflowBackfillDao {
   private final WorkflowBackfillMapper mapper;
+  private final WorkflowDefinitionMapper definitionMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public WorkflowBackfillDaoImpl(
+      WorkflowBackfillMapper mapper,
+      WorkflowDefinitionMapper definitionMapper,
+      CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.definitionMapper = definitionMapper;
+    this.currentProject = currentProject;
+  }
+
+  public WorkflowBackfillDaoImpl(WorkflowBackfillMapper mapper) {
+    this(mapper, null, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public int insert(WorkflowBackfillPO backfill) {
+    backfill.setProjectId(resolveProjectId(backfill.getProjectId(), backfill.getWorkflowId()));
     return mapper.insert(backfill);
   }
 
   @Override
   public int update(WorkflowBackfillPO backfill) {
-    return mapper.updateById(backfill);
+    Long projectId = currentProjectId();
+    if (projectId == null) return mapper.updateById(backfill);
+    backfill.setProjectId(resolveProjectId(backfill.getProjectId(), backfill.getWorkflowId()));
+    return mapper.update(
+        backfill,
+        Wrappers.<WorkflowBackfillPO>lambdaUpdate()
+            .eq(WorkflowBackfillPO::getId, backfill.getId())
+            .eq(WorkflowBackfillPO::getProjectId, projectId));
   }
 
   @Override
   public WorkflowBackfillPO select(String id) {
-    return mapper.selectById(id);
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<WorkflowBackfillPO>lambdaQuery()
+            .eq(WorkflowBackfillPO::getId, id)
+            .eq(projectId != null, WorkflowBackfillPO::getProjectId, projectId));
   }
 
   @Override
   public List<WorkflowBackfillPO> selectList(String workflowId, String scheduleId) {
-    var query = Wrappers.<WorkflowBackfillPO>lambdaQuery();
+    Long projectId = currentProjectId();
+    var query = Wrappers.<WorkflowBackfillPO>lambdaQuery()
+        .eq(projectId != null, WorkflowBackfillPO::getProjectId, projectId);
     if (workflowId != null && !workflowId.isBlank()) {
       query.eq(WorkflowBackfillPO::getWorkflowId, workflowId.trim());
     }
@@ -43,5 +82,32 @@ public class WorkflowBackfillDaoImpl implements WorkflowBackfillDao {
       query.eq(WorkflowBackfillPO::getScheduleId, scheduleId.trim());
     }
     return mapper.selectList(query.orderByDesc(WorkflowBackfillPO::getCreateTime));
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private Long resolveProjectId(Long storedProjectId, String workflowId) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (storedProjectId != null && !Objects.equals(storedProjectId, projectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      if (definitionMapper != null && !workflowOwned(workflowId, projectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      return projectId;
+    }
+    if (storedProjectId != null || definitionMapper == null) return storedProjectId;
+    WorkflowDefinitionPO definition = definitionMapper.selectById(workflowId);
+    return definition == null ? null : definition.getProjectId();
+  }
+
+  private boolean workflowOwned(String workflowId, Long projectId) {
+    return definitionMapper.selectCount(
+        Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(WorkflowDefinitionPO::getId, workflowId)
+            .eq(WorkflowDefinitionPO::getProjectId, projectId)) > 0L;
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowCatalogDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowCatalogDaoImpl.java
@@ -8,8 +8,12 @@ import io.yak.ops.business.workflow.dao.mapper.WorkflowVersionMapper;
 import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
@@ -17,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** 基于 MyBatis-Plus 的工作流定义与版本 DAO。 */
 @Repository
-@RequiredArgsConstructor
 @DependsOn("workflowFlyway")
 @ConditionalOnProperty(
     prefix = "yak.database",
@@ -28,16 +31,43 @@ public class WorkflowCatalogDaoImpl implements WorkflowCatalogDao {
   private final WorkflowDefinitionMapper definitionMapper;
   private final WorkflowVersionMapper versionMapper;
   private final WorkflowScheduleMapper scheduleMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public WorkflowCatalogDaoImpl(
+      WorkflowDefinitionMapper definitionMapper,
+      WorkflowVersionMapper versionMapper,
+      WorkflowScheduleMapper scheduleMapper,
+      CurrentProject currentProject) {
+    this.definitionMapper = definitionMapper;
+    this.versionMapper = versionMapper;
+    this.scheduleMapper = scheduleMapper;
+    this.currentProject = currentProject;
+  }
+
+  public WorkflowCatalogDaoImpl(
+      WorkflowDefinitionMapper definitionMapper,
+      WorkflowVersionMapper versionMapper,
+      WorkflowScheduleMapper scheduleMapper) {
+    this(
+        definitionMapper,
+        versionMapper,
+        scheduleMapper,
+        Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public List<WorkflowDefinitionPO> selectDefinitions() {
+    Long projectId = currentProjectId();
     return definitionMapper.selectList(
         Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(projectId != null, WorkflowDefinitionPO::getProjectId, projectId)
             .orderByDesc(WorkflowDefinitionPO::getUpdateTime));
   }
 
   @Override
   public List<WorkflowVersionPO> selectPublishedVersions(String workflowId) {
+    if (!accessible(workflowId)) return List.of();
     return versionMapper.selectList(
         Wrappers.<WorkflowVersionPO>lambdaQuery()
             .eq(WorkflowVersionPO::getWorkflowId, workflowId)
@@ -47,47 +77,89 @@ public class WorkflowCatalogDaoImpl implements WorkflowCatalogDao {
 
   @Override
   public WorkflowVersionPO selectVersionById(String versionId) {
-    return versionMapper.selectById(versionId);
+    WorkflowVersionPO version = versionMapper.selectById(versionId);
+    if (version == null || currentProjectId() == null) return version;
+    return accessible(version.getWorkflowId()) ? version : null;
   }
 
   @Override
   public int upsertDefinition(WorkflowDefinitionPO definition) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      WorkflowDefinitionPO existing = definitionMapper.selectById(definition.getId());
+      if (existing != null
+          && existing.getProjectId() != null
+          && !Objects.equals(existing.getProjectId(), projectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      definition.setProjectId(projectId);
+    }
     return definitionMapper.upsert(definition);
   }
 
   @Override
   public int insertVersion(WorkflowVersionPO version) {
+    requireAccessible(version.getWorkflowId());
     return versionMapper.insert(version);
   }
 
   @Override
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public int deleteDefinition(String workflowId) {
+    Long projectId = currentProjectId();
+    if (projectId != null && !accessible(workflowId)) return 0;
     List<String> scheduleIds = scheduleMapper.selectObjs(
             Wrappers.<WorkflowSchedulePO>query()
                 .select("id")
-                .eq("workflow_id", workflowId))
+                .eq("workflow_id", workflowId)
+                .eq(projectId != null, "project_id", projectId))
         .stream()
         .filter(String.class::isInstance)
         .map(String.class::cast)
         .toList();
 
-    int deleted = definitionMapper.deleteById(workflowId);
+    int deleted = definitionMapper.delete(
+        Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(WorkflowDefinitionPO::getId, workflowId)
+            .eq(projectId != null, WorkflowDefinitionPO::getProjectId, projectId));
     if (deleted != 1 || scheduleIds.isEmpty()) return deleted;
 
     scheduleMapper.delete(
         Wrappers.<WorkflowSchedulePO>lambdaQuery()
-            .in(WorkflowSchedulePO::getId, scheduleIds));
+            .in(WorkflowSchedulePO::getId, scheduleIds)
+            .eq(projectId != null, WorkflowSchedulePO::getProjectId, projectId));
     return deleted;
   }
 
   @Override
   public int initializeEngineDefinition(String versionId, String engineDefinitionJson) {
+    if (selectVersionById(versionId) == null) return 0;
     return versionMapper.initializeEngineDefinition(versionId, engineDefinitionJson);
   }
 
   @Override
   public int initializeRuntimeMetadata(String versionId, String runtimeMetadataJson) {
+    if (selectVersionById(versionId) == null) return 0;
     return versionMapper.initializeRuntimeMetadata(versionId, runtimeMetadataJson);
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private boolean accessible(String workflowId) {
+    Long projectId = currentProjectId();
+    if (projectId == null) return true;
+    if (workflowId == null || workflowId.isBlank()) return false;
+    return definitionMapper.selectCount(
+        Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(WorkflowDefinitionPO::getId, workflowId)
+            .eq(WorkflowDefinitionPO::getProjectId, projectId)) > 0L;
+  }
+
+  private void requireAccessible(String workflowId) {
+    if (!accessible(workflowId)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
@@ -2,21 +2,28 @@ package io.yak.ops.business.workflow.dao.impl;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowExecutionMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowNodeAttemptMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowNodeExecutionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowVersionMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowNodeAttemptPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowNodeExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowVersionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
 /** 基于 MyBatis-Plus 的工作流执行 DAO。 */
 @Repository
-@RequiredArgsConstructor
 @DependsOn("workflowFlyway")
 @ConditionalOnProperty(
     prefix = "yak.database",
@@ -24,17 +31,57 @@ import org.springframework.stereotype.Repository;
     havingValue = "true",
     matchIfMissing = true)
 public class WorkflowExecutionDaoImpl implements WorkflowExecutionDao {
+  private static final List<String> ACTIVE_STATUSES =
+      List.of("CREATED", "RUNNING", "PAUSING", "PAUSED", "RESUMING");
+
   private final WorkflowExecutionMapper executionMapper;
   private final WorkflowNodeExecutionMapper nodeExecutionMapper;
   private final WorkflowNodeAttemptMapper nodeAttemptMapper;
+  private final WorkflowDefinitionMapper definitionMapper;
+  private final WorkflowVersionMapper versionMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public WorkflowExecutionDaoImpl(
+      WorkflowExecutionMapper executionMapper,
+      WorkflowNodeExecutionMapper nodeExecutionMapper,
+      WorkflowNodeAttemptMapper nodeAttemptMapper,
+      WorkflowDefinitionMapper definitionMapper,
+      WorkflowVersionMapper versionMapper,
+      CurrentProject currentProject) {
+    this.executionMapper = executionMapper;
+    this.nodeExecutionMapper = nodeExecutionMapper;
+    this.nodeAttemptMapper = nodeAttemptMapper;
+    this.definitionMapper = definitionMapper;
+    this.versionMapper = versionMapper;
+    this.currentProject = currentProject;
+  }
+
+  public WorkflowExecutionDaoImpl(
+      WorkflowExecutionMapper executionMapper,
+      WorkflowNodeExecutionMapper nodeExecutionMapper,
+      WorkflowNodeAttemptMapper nodeAttemptMapper) {
+    this(
+        executionMapper,
+        nodeExecutionMapper,
+        nodeAttemptMapper,
+        null,
+        null,
+        Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public WorkflowExecutionPO selectExecution(String executionId) {
-    return executionMapper.selectById(executionId);
+    Long projectId = currentProjectId();
+    return executionMapper.selectOne(
+        Wrappers.<WorkflowExecutionPO>lambdaQuery()
+            .eq(WorkflowExecutionPO::getId, executionId)
+            .eq(projectId != null, WorkflowExecutionPO::getProjectId, projectId));
   }
 
   @Override
   public List<WorkflowNodeExecutionPO> selectNodeExecutions(String executionId) {
+    if (!executionAccessible(executionId)) return List.of();
     return nodeExecutionMapper.selectList(
         Wrappers.<WorkflowNodeExecutionPO>lambdaQuery()
             .eq(WorkflowNodeExecutionPO::getWorkflowExecutionId, executionId)
@@ -43,6 +90,7 @@ public class WorkflowExecutionDaoImpl implements WorkflowExecutionDao {
 
   @Override
   public List<WorkflowNodeAttemptPO> selectNodeAttempts(String executionId) {
+    if (!executionAccessible(executionId)) return List.of();
     return nodeAttemptMapper.selectList(
         Wrappers.<WorkflowNodeAttemptPO>lambdaQuery()
             .eq(WorkflowNodeAttemptPO::getWorkflowExecutionId, executionId)
@@ -52,51 +100,134 @@ public class WorkflowExecutionDaoImpl implements WorkflowExecutionDao {
 
   @Override
   public int upsertExecution(WorkflowExecutionPO execution) {
+    execution.setProjectId(resolveProjectId(execution));
     return executionMapper.upsert(execution);
   }
 
   @Override
   public int upsertNodeExecution(WorkflowNodeExecutionPO nodeExecution) {
+    requireExecution(nodeExecution.getWorkflowExecutionId());
     return nodeExecutionMapper.upsert(nodeExecution);
   }
 
   @Override
   public int upsertNodeAttempt(WorkflowNodeAttemptPO attempt) {
+    requireExecution(attempt.getWorkflowExecutionId());
     return nodeAttemptMapper.upsert(attempt);
   }
 
   @Override
   public int updateExecution(WorkflowExecutionPO execution) {
-    return executionMapper.updateById(execution);
+    Long projectId = currentProjectId();
+    if (projectId == null) return executionMapper.updateById(execution);
+    execution.setProjectId(projectId);
+    return executionMapper.update(
+        execution,
+        Wrappers.<WorkflowExecutionPO>lambdaUpdate()
+            .eq(WorkflowExecutionPO::getId, execution.getId())
+            .eq(WorkflowExecutionPO::getProjectId, projectId));
   }
 
   @Override
   public List<String> selectExecutionIds() {
-    return executionMapper.selectExecutionIds();
+    Long projectId = currentProjectId();
+    if (projectId == null) return executionMapper.selectExecutionIds();
+    return executionMapper.selectObjs(
+            Wrappers.<WorkflowExecutionPO>lambdaQuery()
+                .select(WorkflowExecutionPO::getId)
+                .eq(WorkflowExecutionPO::getProjectId, projectId)
+                .orderByDesc(WorkflowExecutionPO::getCreatedAt))
+        .stream()
+        .map(String::valueOf)
+        .toList();
   }
 
   @Override
   public List<String> selectRecoverableExecutionIds() {
-    return executionMapper.selectRecoverableExecutionIds();
+    Long projectId = currentProjectId();
+    if (projectId == null) return executionMapper.selectRecoverableExecutionIds();
+    return executionMapper.selectObjs(
+            Wrappers.<WorkflowExecutionPO>lambdaQuery()
+                .select(WorkflowExecutionPO::getId)
+                .eq(WorkflowExecutionPO::getProjectId, projectId)
+                .in(WorkflowExecutionPO::getStatus, ACTIVE_STATUSES)
+                .orderByAsc(WorkflowExecutionPO::getCreatedAt))
+        .stream()
+        .map(String::valueOf)
+        .toList();
   }
 
   @Override
   public long countActiveExecutions(String workflowId) {
+    Long projectId = currentProjectId();
+    if (projectId != null && !workflowAccessible(workflowId, projectId)) return 0L;
     return executionMapper.countActiveExecutions(workflowId);
   }
 
   @Override
   public String selectEffectiveRuntimeMetadata(String executionId) {
+    if (!executionAccessible(executionId)) return null;
     return executionMapper.selectEffectiveRuntimeMetadata(executionId);
   }
 
   @Override
   public WorkflowNodeAttemptPO selectAttempt(String attemptId) {
-    return nodeAttemptMapper.selectById(attemptId);
+    WorkflowNodeAttemptPO attempt = nodeAttemptMapper.selectById(attemptId);
+    if (attempt == null || !executionAccessible(attempt.getWorkflowExecutionId())) return null;
+    return attempt;
   }
 
   @Override
   public int bindExternalExecution(String attemptId, String externalExecutionId) {
+    if (selectAttempt(attemptId) == null) return 0;
     return nodeAttemptMapper.bindExternalExecution(attemptId, externalExecutionId);
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private boolean executionAccessible(String executionId) {
+    return currentProjectId() == null || selectExecution(executionId) != null;
+  }
+
+  private void requireExecution(String executionId) {
+    if (!executionAccessible(executionId)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+  }
+
+  private Long resolveProjectId(WorkflowExecutionPO execution) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (execution.getProjectId() != null
+          && !Objects.equals(execution.getProjectId(), projectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      return projectId;
+    }
+    if (execution.getProjectId() != null) return execution.getProjectId();
+    if (execution.getSourceExecutionId() != null) {
+      WorkflowExecutionPO source = executionMapper.selectById(execution.getSourceExecutionId());
+      if (source != null && source.getProjectId() != null) return source.getProjectId();
+    }
+    if (versionMapper != null && definitionMapper != null) {
+      WorkflowVersionPO version = versionMapper.selectById(execution.getDefinitionId());
+      if (version != null && version.getWorkflowId() != null) {
+        WorkflowDefinitionPO definition = definitionMapper.selectById(version.getWorkflowId());
+        if (definition != null) return definition.getProjectId();
+      }
+      WorkflowDefinitionPO definition = definitionMapper.selectById(execution.getDefinitionId());
+      if (definition != null) return definition.getProjectId();
+    }
+    return null;
+  }
+
+  private boolean workflowAccessible(String workflowId, Long projectId) {
+    if (definitionMapper == null) return true;
+    return definitionMapper.selectCount(
+        Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(WorkflowDefinitionPO::getId, workflowId)
+            .eq(WorkflowDefinitionPO::getProjectId, projectId)) > 0L;
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleDaoImpl.java
@@ -2,18 +2,23 @@ package io.yak.ops.business.workflow.dao.impl;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleDao;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.time.Instant;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
 /** 基于 MyBatis-Plus 的工作流调度定义 DAO。 */
 @Repository
-@RequiredArgsConstructor
 @DependsOn("workflowFlyway")
 @ConditionalOnProperty(
     prefix = "yak.database",
@@ -22,10 +27,28 @@ import org.springframework.stereotype.Repository;
     matchIfMissing = true)
 public class WorkflowScheduleDaoImpl implements WorkflowScheduleDao {
   private final WorkflowScheduleMapper mapper;
+  private final WorkflowDefinitionMapper definitionMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public WorkflowScheduleDaoImpl(
+      WorkflowScheduleMapper mapper,
+      WorkflowDefinitionMapper definitionMapper,
+      CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.definitionMapper = definitionMapper;
+    this.currentProject = currentProject;
+  }
+
+  public WorkflowScheduleDaoImpl(WorkflowScheduleMapper mapper) {
+    this(mapper, null, Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public List<WorkflowSchedulePO> selectSchedules(String workflowId, String status) {
-    var query = Wrappers.<WorkflowSchedulePO>lambdaQuery();
+    Long projectId = currentProjectId();
+    var query = Wrappers.<WorkflowSchedulePO>lambdaQuery()
+        .eq(projectId != null, WorkflowSchedulePO::getProjectId, projectId);
     if (workflowId != null && !workflowId.isBlank()) {
       query.eq(WorkflowSchedulePO::getWorkflowId, workflowId.trim());
     }
@@ -37,31 +60,76 @@ public class WorkflowScheduleDaoImpl implements WorkflowScheduleDao {
 
   @Override
   public WorkflowSchedulePO selectSchedule(String id) {
-    return mapper.selectById(id);
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<WorkflowSchedulePO>lambdaQuery()
+            .eq(WorkflowSchedulePO::getId, id)
+            .eq(projectId != null, WorkflowSchedulePO::getProjectId, projectId));
   }
 
   @Override
   public int insertSchedule(WorkflowSchedulePO schedule) {
+    schedule.setProjectId(resolveProjectId(schedule.getProjectId(), schedule.getWorkflowId()));
     return mapper.insert(schedule);
   }
 
   @Override
   public int updateSchedule(WorkflowSchedulePO schedule) {
-    return mapper.updateById(schedule);
+    Long projectId = currentProjectId();
+    if (projectId == null) return mapper.updateById(schedule);
+    schedule.setProjectId(resolveProjectId(schedule.getProjectId(), schedule.getWorkflowId()));
+    return mapper.update(
+        schedule,
+        Wrappers.<WorkflowSchedulePO>lambdaUpdate()
+            .eq(WorkflowSchedulePO::getId, schedule.getId())
+            .eq(WorkflowSchedulePO::getProjectId, projectId));
   }
 
   @Override
   public int updateRuntimeState(String id, Instant lastFireTime, Instant nextFireTime) {
+    Long projectId = currentProjectId();
     return mapper.update(
         null,
         Wrappers.<WorkflowSchedulePO>lambdaUpdate()
             .eq(WorkflowSchedulePO::getId, id)
+            .eq(projectId != null, WorkflowSchedulePO::getProjectId, projectId)
             .set(WorkflowSchedulePO::getLastFireTime, lastFireTime)
             .set(WorkflowSchedulePO::getNextFireTime, nextFireTime));
   }
 
   @Override
   public int deleteSchedule(String id) {
-    return mapper.deleteById(id);
+    Long projectId = currentProjectId();
+    return mapper.delete(
+        Wrappers.<WorkflowSchedulePO>lambdaQuery()
+            .eq(WorkflowSchedulePO::getId, id)
+            .eq(projectId != null, WorkflowSchedulePO::getProjectId, projectId));
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private Long resolveProjectId(Long storedProjectId, String workflowId) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (storedProjectId != null && !Objects.equals(storedProjectId, projectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      if (definitionMapper != null && !workflowOwned(workflowId, projectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      return projectId;
+    }
+    if (storedProjectId != null || definitionMapper == null) return storedProjectId;
+    WorkflowDefinitionPO definition = definitionMapper.selectById(workflowId);
+    return definition == null ? null : definition.getProjectId();
+  }
+
+  private boolean workflowOwned(String workflowId, Long projectId) {
+    return definitionMapper.selectCount(
+        Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(WorkflowDefinitionPO::getId, workflowId)
+            .eq(WorkflowDefinitionPO::getProjectId, projectId)) > 0L;
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowScheduleTriggerDaoImpl.java
@@ -2,35 +2,80 @@ package io.yak.ops.business.workflow.dao.impl;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowBackfillMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowExecutionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
 import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleTriggerMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.po.workflow.WorkflowScheduleTriggerPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.time.Instant;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
 /** 基于 MyBatis-Plus 的工作流调度 Trigger Ledger DAO。 */
 @Repository
-@RequiredArgsConstructor
 @DependsOn("workflowFlyway")
-@ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDao {
   private static final List<String> PENDING =
       List.of("RECEIVED", "WAITING", "LAUNCHING", "REACTIVATING", "RUNNING");
+
   private final WorkflowScheduleTriggerMapper mapper;
+  private final WorkflowScheduleMapper scheduleMapper;
+  private final WorkflowDefinitionMapper definitionMapper;
+  private final WorkflowExecutionMapper executionMapper;
+  private final WorkflowBackfillMapper backfillMapper;
+  private final CurrentProject currentProject;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public WorkflowScheduleTriggerDaoImpl(
+      WorkflowScheduleTriggerMapper mapper,
+      WorkflowScheduleMapper scheduleMapper,
+      WorkflowDefinitionMapper definitionMapper,
+      WorkflowExecutionMapper executionMapper,
+      WorkflowBackfillMapper backfillMapper,
+      CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.scheduleMapper = scheduleMapper;
+    this.definitionMapper = definitionMapper;
+    this.executionMapper = executionMapper;
+    this.backfillMapper = backfillMapper;
+    this.currentProject = currentProject;
+  }
+
+  public WorkflowScheduleTriggerDaoImpl(WorkflowScheduleTriggerMapper mapper) {
+    this(
+        mapper,
+        null,
+        null,
+        null,
+        null,
+        Optional::<io.yak.ops.core.project.ProjectContext>empty);
+  }
 
   @Override
   public WorkflowScheduleTriggerPO claim(WorkflowScheduleTriggerPO trigger) {
-    // Stage 4 历史记录没有原生 dedupeKey 语义；先按旧事实键匹配，避免迁移时数据库时区
-    // 影响 DATETIME -> epoch 的字符串结果。Backfill 必须跳过此兼容查询，才能重补同一逻辑时间。
+    bindProject(trigger);
     if (trigger.getBackfillId() == null || trigger.getBackfillId().isBlank()) {
       WorkflowScheduleTriggerPO legacy = selectBySchedulePlan(
           trigger.getScheduleId(), trigger.getPlannedFireTime());
       if (legacy != null) return legacy;
     }
-
     mapper.insertIgnore(trigger);
     WorkflowScheduleTriggerPO stored = selectByDedupeKey(trigger.getDedupeKey());
     if (stored == null) {
@@ -42,59 +87,81 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
   @Override
   public WorkflowScheduleTriggerPO selectByDedupeKey(String dedupeKey) {
     if (dedupeKey == null || dedupeKey.isBlank()) return null;
-    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .eq(WorkflowScheduleTriggerPO::getDedupeKey, dedupeKey.trim()));
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getDedupeKey, dedupeKey.trim()));
   }
 
-  /** 兼容 Stage 4 查询，只返回正常计划/Misfire，不把 Backfill 混进来。 */
   @Override
-  public WorkflowScheduleTriggerPO selectBySchedulePlan(String scheduleId, Instant plannedFireTime) {
-    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
-        .eq(WorkflowScheduleTriggerPO::getPlannedFireTime, plannedFireTime)
-        .isNull(WorkflowScheduleTriggerPO::getBackfillId)
-        .last("LIMIT 1"));
+  public WorkflowScheduleTriggerPO selectBySchedulePlan(
+      String scheduleId, Instant plannedFireTime) {
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
+            .eq(WorkflowScheduleTriggerPO::getPlannedFireTime, plannedFireTime)
+            .isNull(WorkflowScheduleTriggerPO::getBackfillId)
+            .last("LIMIT 1"));
   }
 
   @Override
   public WorkflowScheduleTriggerPO selectByExecutionId(String executionId) {
     if (executionId == null || executionId.isBlank()) return null;
-    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .eq(WorkflowScheduleTriggerPO::getWorkflowExecutionId, executionId).last("LIMIT 1"));
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getWorkflowExecutionId, executionId)
+            .last("LIMIT 1"));
   }
 
   @Override
   public WorkflowScheduleTriggerPO selectNextWaiting(String workflowId) {
-    return mapper.selectOne(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
-        .eq(WorkflowScheduleTriggerPO::getStatus, "WAITING")
-        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime)
-        .orderByAsc(WorkflowScheduleTriggerPO::getCreateTime).last("LIMIT 1"));
+    Long projectId = currentProjectId();
+    return mapper.selectOne(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
+            .eq(WorkflowScheduleTriggerPO::getStatus, "WAITING")
+            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime)
+            .orderByAsc(WorkflowScheduleTriggerPO::getCreateTime)
+            .last("LIMIT 1"));
   }
 
   @Override
   public List<WorkflowScheduleTriggerPO> selectPending() {
-    return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .in(WorkflowScheduleTriggerPO::getStatus, PENDING)
-        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
+    Long projectId = currentProjectId();
+    return mapper.selectList(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .in(WorkflowScheduleTriggerPO::getStatus, PENDING)
+            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
-  /** Schedule 停用只取消正常 Cron/Misfire 队列，Backfill 批次独立继续。 */
   @Override
   public List<WorkflowScheduleTriggerPO> selectQueuedBySchedule(String scheduleId) {
-    return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
-        .isNull(WorkflowScheduleTriggerPO::getBackfillId)
-        .in(WorkflowScheduleTriggerPO::getStatus, List.of("RECEIVED", "WAITING"))
-        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
+    Long projectId = currentProjectId();
+    return mapper.selectList(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId)
+            .isNull(WorkflowScheduleTriggerPO::getBackfillId)
+            .in(WorkflowScheduleTriggerPO::getStatus, List.of("RECEIVED", "WAITING"))
+            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
   @Override
   public List<WorkflowScheduleTriggerPO> selectByBackfillId(String backfillId) {
     if (backfillId == null || backfillId.isBlank()) return List.of();
-    return mapper.selectList(Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
-        .eq(WorkflowScheduleTriggerPO::getBackfillId, backfillId.trim())
-        .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
+    Long projectId = currentProjectId();
+    return mapper.selectList(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getBackfillId, backfillId.trim())
+            .orderByAsc(WorkflowScheduleTriggerPO::getPlannedFireTime));
   }
 
   @Override
@@ -104,7 +171,9 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
       String backfillId,
       String status,
       int limit) {
-    var query = Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery();
+    Long projectId = currentProjectId();
+    var query = Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+        .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId);
     if (scheduleId != null && !scheduleId.isBlank()) {
       query.eq(WorkflowScheduleTriggerPO::getScheduleId, scheduleId.trim());
     }
@@ -119,31 +188,145 @@ public class WorkflowScheduleTriggerDaoImpl implements WorkflowScheduleTriggerDa
     }
     int safeLimit = Math.max(1, Math.min(limit, 1000));
     return mapper.selectList(
-        query.orderByDesc(WorkflowScheduleTriggerPO::getPlannedFireTime).last("LIMIT " + safeLimit));
+        query.orderByDesc(WorkflowScheduleTriggerPO::getPlannedFireTime)
+            .last("LIMIT " + safeLimit));
   }
 
   @Override
   public int update(WorkflowScheduleTriggerPO trigger) {
-    return mapper.updateById(trigger);
+    Long projectId = currentProjectId();
+    if (projectId == null) return mapper.updateById(trigger);
+    bindProject(trigger);
+    return mapper.update(
+        trigger,
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaUpdate()
+            .eq(WorkflowScheduleTriggerPO::getId, trigger.getId())
+            .eq(WorkflowScheduleTriggerPO::getProjectId, projectId));
   }
 
   @Override
   public int bindPreparedExecution(
-      String triggerId,
-      String executionId,
-      String executionStatus) {
-    return mapper.bindPreparedExecution(triggerId, executionId, executionStatus);
+      String triggerId, String executionId, String executionStatus) {
+    Long projectId = currentProjectId();
+    return mapper.update(
+        null,
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaUpdate()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getTriggerId, triggerId)
+            .eq(WorkflowScheduleTriggerPO::getStatus, "LAUNCHING")
+            .isNull(WorkflowScheduleTriggerPO::getWorkflowExecutionId)
+            .set(WorkflowScheduleTriggerPO::getWorkflowExecutionId, executionId)
+            .set(WorkflowScheduleTriggerPO::getExecutionStatus, executionStatus)
+            .set(WorkflowScheduleTriggerPO::getMessage, "WorkflowExecution 已首次持久化")
+            .set(WorkflowScheduleTriggerPO::getUpdateTime, Instant.now()));
   }
 
   @Override
   public void lockWorkflow(String workflowId) {
+    requireWorkflow(workflowId);
     String locked = mapper.lockWorkflow(workflowId);
     if (locked == null) throw new IllegalArgumentException("工作流不存在：" + workflowId);
   }
 
-  @Override public long countActiveExecutions(String workflowId) { return mapper.countActiveExecutions(workflowId); }
-  @Override public long countLaunchingTriggers(String workflowId) { return mapper.countLaunchingTriggers(workflowId); }
-  @Override public long countWaitingTriggers(String workflowId) { return mapper.countWaitingTriggers(workflowId); }
-  @Override public String selectWorkflowIdByExecution(String executionId) { return mapper.selectWorkflowIdByExecution(executionId); }
-  @Override public String selectExecutionIdByTrigger(String triggerId) { return mapper.selectExecutionIdByTrigger(triggerId); }
+  @Override
+  public long countActiveExecutions(String workflowId) {
+    requireWorkflow(workflowId);
+    return mapper.countActiveExecutions(workflowId);
+  }
+
+  @Override
+  public long countLaunchingTriggers(String workflowId) {
+    Long projectId = currentProjectId();
+    return mapper.selectCount(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
+            .in(WorkflowScheduleTriggerPO::getStatus, List.of("LAUNCHING", "REACTIVATING")));
+  }
+
+  @Override
+  public long countWaitingTriggers(String workflowId) {
+    Long projectId = currentProjectId();
+    return mapper.selectCount(
+        Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+            .eq(projectId != null, WorkflowScheduleTriggerPO::getProjectId, projectId)
+            .eq(WorkflowScheduleTriggerPO::getWorkflowId, workflowId)
+            .eq(WorkflowScheduleTriggerPO::getStatus, "WAITING"));
+  }
+
+  @Override
+  public String selectWorkflowIdByExecution(String executionId) {
+    Long projectId = currentProjectId();
+    if (projectId != null && executionMapper != null) {
+      WorkflowExecutionPO execution = executionMapper.selectOne(
+          Wrappers.<WorkflowExecutionPO>lambdaQuery()
+              .eq(WorkflowExecutionPO::getId, executionId)
+              .eq(WorkflowExecutionPO::getProjectId, projectId));
+      if (execution == null) return null;
+    }
+    return mapper.selectWorkflowIdByExecution(executionId);
+  }
+
+  @Override
+  public String selectExecutionIdByTrigger(String triggerId) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      WorkflowScheduleTriggerPO trigger = mapper.selectOne(
+          Wrappers.<WorkflowScheduleTriggerPO>lambdaQuery()
+              .eq(WorkflowScheduleTriggerPO::getProjectId, projectId)
+              .eq(WorkflowScheduleTriggerPO::getTriggerId, triggerId)
+              .last("LIMIT 1"));
+      if (trigger == null) return null;
+      if (trigger.getWorkflowExecutionId() != null) return trigger.getWorkflowExecutionId();
+    }
+    return mapper.selectExecutionIdByTrigger(triggerId);
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  }
+
+  private void bindProject(WorkflowScheduleTriggerPO trigger) {
+    Long projectId = currentProjectId();
+    if (projectId != null) {
+      if (trigger.getProjectId() != null
+          && !Objects.equals(trigger.getProjectId(), projectId)) {
+        throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      }
+      requireWorkflow(trigger.getWorkflowId());
+      trigger.setProjectId(projectId);
+      return;
+    }
+    if (trigger.getProjectId() != null) return;
+    if (scheduleMapper != null && trigger.getScheduleId() != null) {
+      WorkflowSchedulePO schedule = scheduleMapper.selectById(trigger.getScheduleId());
+      if (schedule != null && schedule.getProjectId() != null) {
+        trigger.setProjectId(schedule.getProjectId());
+        return;
+      }
+    }
+    if (backfillMapper != null && trigger.getBackfillId() != null) {
+      WorkflowBackfillPO backfill = backfillMapper.selectById(trigger.getBackfillId());
+      if (backfill != null && backfill.getProjectId() != null) {
+        trigger.setProjectId(backfill.getProjectId());
+        return;
+      }
+    }
+    if (definitionMapper != null && trigger.getWorkflowId() != null) {
+      WorkflowDefinitionPO definition = definitionMapper.selectById(trigger.getWorkflowId());
+      if (definition != null) trigger.setProjectId(definition.getProjectId());
+    }
+  }
+
+  private void requireWorkflow(String workflowId) {
+    Long projectId = currentProjectId();
+    if (projectId == null || definitionMapper == null) return;
+    long count = definitionMapper.selectCount(
+        Wrappers.<WorkflowDefinitionPO>lambdaQuery()
+            .eq(WorkflowDefinitionPO::getId, workflowId)
+            .eq(WorkflowDefinitionPO::getProjectId, projectId));
+    if (count == 0L) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowScheduleTriggerMapper.java
@@ -12,12 +12,12 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
 
   @Insert("""
       INSERT IGNORE INTO yak_workflow_schedule_trigger
-        (id, schedule_id, workflow_id, backfill_id, trigger_id, dedupe_key, trigger_source,
+        (id, project_id, schedule_id, workflow_id, backfill_id, trigger_id, dedupe_key, trigger_source,
          planned_fire_time, actual_fire_time, business_date, execution_strategy, misfire_strategy,
          status, workflow_execution_id, execution_status, message, error_message,
          launched_at, completed_at, create_time, update_time)
       VALUES
-        (#{id}, #{scheduleId}, #{workflowId}, #{backfillId}, #{triggerId}, #{dedupeKey}, #{triggerSource},
+        (#{id}, #{projectId}, #{scheduleId}, #{workflowId}, #{backfillId}, #{triggerId}, #{dedupeKey}, #{triggerSource},
          #{plannedFireTime}, #{actualFireTime}, #{businessDate}, #{executionStrategy}, #{misfireStrategy},
          #{status}, #{workflowExecutionId}, #{executionStatus}, #{message}, #{errorMessage},
          #{launchedAt}, #{completedAt}, #{createTime}, #{updateTime})
@@ -51,7 +51,6 @@ public interface WorkflowScheduleTriggerMapper extends BaseMapper<WorkflowSchedu
       """)
   long countActiveExecutions(@Param("workflowId") String workflowId);
 
-  /** LAUNCHING 与 REACTIVATING 都是尚未由 Execution DB 完整体现的 durable 并发占位。 */
   @Select("""
       SELECT COUNT(*)
       FROM yak_workflow_schedule_trigger

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V2__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V2__expand_project_scope.sql
@@ -1,0 +1,25 @@
+-- Project Space expand migration for Workflow roots and durable runtime facts.
+-- project_id remains nullable until default-space backfill and PROJECT_REQUIRED cutover complete.
+ALTER TABLE yak_workflow_definition
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_workflow_definition_project_status (project_id, status, update_time);
+
+ALTER TABLE yak_workflow_execution
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_workflow_execution_project_status (project_id, status, updated_at),
+    ADD KEY idx_yak_workflow_execution_project_definition (project_id, definition_id, created_at);
+
+ALTER TABLE yak_workflow_schedule
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_workflow_schedule_project_status (project_id, status, next_fire_time),
+    ADD KEY idx_yak_workflow_schedule_project_workflow (project_id, workflow_id, update_time);
+
+ALTER TABLE yak_workflow_schedule_trigger
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_workflow_trigger_project_status (project_id, status, planned_fire_time),
+    ADD KEY idx_yak_workflow_trigger_project_workflow (project_id, workflow_id, create_time);
+
+ALTER TABLE yak_workflow_backfill
+    ADD COLUMN project_id BIGINT NULL AFTER id,
+    ADD KEY idx_yak_workflow_backfill_project_status (project_id, status, create_time),
+    ADD KEY idx_yak_workflow_backfill_project_workflow (project_id, workflow_id, create_time);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowDefinitionMapper.xml
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowDefinitionMapper.xml
@@ -4,13 +4,14 @@
 
   <insert id="upsert" parameterType="io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO">
     INSERT INTO yak_workflow_definition
-      (id, name, description, status, draft_revision, latest_version_no, active_version_id,
+      (id, project_id, name, description, status, draft_revision, latest_version_no, active_version_id,
        draft_json, latest_execution_id, latest_execution_status, create_time, update_time)
     VALUES
-      (#{id}, #{name}, #{description}, #{status}, #{draftRevision}, #{latestVersionNo},
+      (#{id}, #{projectId}, #{name}, #{description}, #{status}, #{draftRevision}, #{latestVersionNo},
        #{activeVersionId}, #{draftJson}, #{latestExecutionId}, #{latestExecutionStatus},
        #{createTime}, #{updateTime})
     ON DUPLICATE KEY UPDATE
+      project_id = COALESCE(VALUES(project_id), project_id),
       name = VALUES(name),
       description = VALUES(description),
       status = VALUES(status),

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
@@ -4,12 +4,13 @@
 
   <insert id="upsert" parameterType="io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO">
     INSERT INTO yak_workflow_execution
-      (id, definition_id, source_execution_id, status, input_json, scheduling_stopped,
+      (id, project_id, definition_id, source_execution_id, status, input_json, scheduling_stopped,
        run_started_at, paused_at, paused_duration_ms, created_at, updated_at, ended_at)
     VALUES
-      (#{id}, #{definitionId}, #{sourceExecutionId}, #{status}, #{inputJson}, #{schedulingStopped},
+      (#{id}, #{projectId}, #{definitionId}, #{sourceExecutionId}, #{status}, #{inputJson}, #{schedulingStopped},
        #{runStartedAt}, #{pausedAt}, #{pausedDurationMs}, #{createdAt}, #{updatedAt}, #{endedAt})
     ON DUPLICATE KEY UPDATE
+      project_id = COALESCE(VALUES(project_id), project_id),
       definition_id = VALUES(definition_id),
       source_execution_id = VALUES(source_execution_id),
       status = VALUES(status),

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dao/impl/WorkflowCatalogDaoProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/dao/impl/WorkflowCatalogDaoProjectScopeTest.java
@@ -1,0 +1,64 @@
+package io.yak.ops.business.workflow.dao.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.mapper.WorkflowDefinitionMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
+import io.yak.ops.business.workflow.dao.mapper.WorkflowVersionMapper;
+import io.yak.ops.common.bean.po.workflow.WorkflowDefinitionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowCatalogDaoProjectScopeTest {
+
+  @Mock private WorkflowDefinitionMapper definitionMapper;
+  @Mock private WorkflowVersionMapper versionMapper;
+  @Mock private WorkflowScheduleMapper scheduleMapper;
+
+  @Test
+  void upsertBindsDefinitionToCurrentProject() {
+    when(definitionMapper.upsert(any(WorkflowDefinitionPO.class))).thenReturn(1);
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    WorkflowCatalogDaoImpl dao =
+        new WorkflowCatalogDaoImpl(
+            definitionMapper, versionMapper, scheduleMapper, currentProject);
+    WorkflowDefinitionPO definition = new WorkflowDefinitionPO();
+    definition.setId("wf-1");
+    definition.setName("daily-orders");
+
+    assertThat(dao.upsertDefinition(definition)).isEqualTo(1);
+
+    ArgumentCaptor<WorkflowDefinitionPO> captor =
+        ArgumentCaptor.forClass(WorkflowDefinitionPO.class);
+    org.mockito.Mockito.verify(definitionMapper).upsert(captor.capture());
+    assertThat(captor.getValue().getProjectId()).isEqualTo(7L);
+  }
+
+  @Test
+  void upsertRejectsExistingDefinitionFromAnotherProject() {
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    WorkflowCatalogDaoImpl dao =
+        new WorkflowCatalogDaoImpl(
+            definitionMapper, versionMapper, scheduleMapper, currentProject);
+    WorkflowDefinitionPO existing = new WorkflowDefinitionPO();
+    existing.setId("wf-1");
+    existing.setProjectId(9L);
+    when(definitionMapper.selectById("wf-1")).thenReturn(existing);
+    WorkflowDefinitionPO update = new WorkflowDefinitionPO();
+    update.setId("wf-1");
+
+    assertThatThrownBy(() -> dao.upsertDefinition(update))
+        .isInstanceOf(ProjectContextException.class);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDirectoryPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/development/DevelopmentDirectoryPO.java
@@ -12,6 +12,7 @@ import lombok.Data;
 public class DevelopmentDirectoryPO {
   @TableId(type = IdType.ASSIGN_ID)
   private Long id;
+  private Long projectId;
   private Long parentId;
   private String name;
   private Instant createTime;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineBatchExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineBatchExecutionPO.java
@@ -13,29 +13,19 @@ import lombok.ToString;
 public class OfflineBatchExecutionPO {
   @TableId(type = IdType.AUTO)
   private Long id;
-
+  private Long projectId;
   private Long jobDefinitionId;
   private String batchKey;
   private String triggerType;
   private String batchScopeType;
-
-  @ToString.Exclude
-  private String batchScopeValue;
-
+  @ToString.Exclude private String batchScopeValue;
   private String batchScopeFingerprint;
-
-  @ToString.Exclude
-  private String definitionSnapshotJson;
-
+  @ToString.Exclude private String definitionSnapshotJson;
   private Integer definitionRevision;
   private Integer retryMaxAttempts;
   private Integer retryBackoffSeconds;
   private String configDigest;
-
-  /** Wave 5 后由 Batch Snapshot 持有的不含凭据逻辑 JobSpec；旧 Batch 迁移期允许为空。 */
-  @ToString.Exclude
-  private String logicalJobSpecJson;
-
+  @ToString.Exclude private String logicalJobSpecJson;
   private String status;
   private LocalDateTime createTime;
   private LocalDateTime updateTime;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 public class OfflineJobDefinitionPO {
   @TableId(type = IdType.INPUT)
   private Long id;
+  private Long projectId;
   private String jobName;
   @TableField(updateStrategy = FieldStrategy.ALWAYS) private String jobDesc;
   private String mode;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobExecutionPO.java
@@ -7,17 +7,13 @@ import java.time.LocalDateTime;
 import lombok.Data;
 import lombok.ToString;
 
-/**
- * ExecutionAttempt 持久化兼容模型。
- *
- * <p>表名继续沿用 yak_offline_job_execution。batch_id 为空只表示 Wave 1 前历史记录；
- * definition/config/submittedConfig 等字段是历史审计兼容副本，运行真相在 BatchExecution。
- */
+/** ExecutionAttempt 持久化兼容模型。 */
 @Data
 @TableName("yak_offline_job_execution")
 public class OfflineJobExecutionPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private Long jobDefinitionId;
   private Long batchId;
   private Integer definitionVersion;
@@ -35,16 +31,9 @@ public class OfflineJobExecutionPO {
   private Boolean retryCreated;
   private LocalDateTime nextRetryTime;
   private String configDigest;
-
-  @ToString.Exclude
-  private String definitionSnapshotJson;
-
-  @ToString.Exclude
-  private String submittedConfig;
-
-  @ToString.Exclude
-  private String engineSnapshotJson;
-
+  @ToString.Exclude private String definitionSnapshotJson;
+  @ToString.Exclude private String submittedConfig;
+  @ToString.Exclude private String engineSnapshotJson;
   private String errorMessage;
   private Long sourceRecordCount;
   private Long sinkAttemptedRecordCount;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowBackfillPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowBackfillPO.java
@@ -13,6 +13,7 @@ import lombok.Data;
 public class WorkflowBackfillPO {
   @TableId(type = IdType.INPUT)
   private String id;
+  private Long projectId;
   private String workflowId;
   private String workflowVersionId;
   private Integer workflowVersionNo;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowDefinitionPO.java
@@ -12,6 +12,7 @@ import lombok.Data;
 public class WorkflowDefinitionPO {
   @TableId(type = IdType.INPUT)
   private String id;
+  private Long projectId;
   private String name;
   private String description;
   private String status;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowExecutionPO.java
@@ -12,6 +12,7 @@ import lombok.Data;
 public class WorkflowExecutionPO {
   @TableId(type = IdType.INPUT)
   private String id;
+  private Long projectId;
   private String definitionId;
   private String sourceExecutionId;
   private String status;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowSchedulePO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowSchedulePO.java
@@ -12,6 +12,7 @@ import lombok.Data;
 public class WorkflowSchedulePO {
   @TableId(type = IdType.INPUT)
   private String id;
+  private Long projectId;
   private String workflowId;
   private String name;
   private String triggerType;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowScheduleTriggerPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/workflow/WorkflowScheduleTriggerPO.java
@@ -13,6 +13,7 @@ import lombok.Data;
 public class WorkflowScheduleTriggerPO {
   @TableId(type = IdType.INPUT)
   private String id;
+  private Long projectId;
   private String scheduleId;
   private String workflowId;
   private String backfillId;

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -16,14 +16,21 @@ const rules: ProjectRequestRule[] = [
 describe('Project Space request context', () => {
   afterEach(() => clearStoredProjectId());
 
-  it('opts the first migrated business routes into optional project context', () => {
+  it('opts migrated resource and production routes into optional project context', () => {
     expect(resolveProjectRequestMode('/api/v1/data-source')).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/resources/tree')).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/datasets/1')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/data-development/nodes')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/task-catalog/assets')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/job/batch-definition/page')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/job/batch-instance/11')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/realtime-sync/11')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/workflows/definitions')).toBe('PROJECT_OPTIONAL');
   });
 
-  it('keeps modules outside the rollout table legacy-global', () => {
-    expect(resolveProjectRequestMode('/api/v1/workflows')).toBe('LEGACY_GLOBAL');
+  it('keeps platform-global capabilities outside the rollout table', () => {
+    expect(resolveProjectRequestMode('/api/v1/compute-environments')).toBe('LEGACY_GLOBAL');
+    expect(resolveProjectRequestMode('/api/v1/quality/templates')).toBe('LEGACY_GLOBAL');
   });
 
   it('uses the most specific project-aware route rule', () => {
@@ -32,7 +39,7 @@ describe('Project Space request context', () => {
   });
 
   it('never attaches a project header to a legacy-global route', () => {
-    const headers = applyCurrentProjectHeader('/api/v1/workflows', {}, '7');
+    const headers = applyCurrentProjectHeader('/api/v1/compute-environments', {}, '7');
     expect(headers).toEqual({});
   });
 
@@ -40,7 +47,7 @@ describe('Project Space request context', () => {
     storeProjectId(7);
     expect(readStoredProjectId()).toBe('7');
 
-    const headers = applyCurrentProjectHeader('/api/v1/data-source/1', {});
+    const headers = applyCurrentProjectHeader('/api/v1/workflows/definitions', {});
     expect(headers).toEqual({ [PROJECT_ID_HEADER]: '7' });
   });
 

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -16,6 +16,15 @@ export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
   { prefix: '/api/v1/data-source', mode: 'PROJECT_OPTIONAL' },
   { prefix: '/api/v1/resources', mode: 'PROJECT_OPTIONAL' },
   { prefix: '/api/v1/datasets', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/data-development', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/task-catalog', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/job/batch-definition', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/job/batch-execution', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/job/batch-instance', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/job/batch-control', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/executor', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/realtime-sync', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/workflows', mode: 'PROJECT_OPTIONAL' },
 ];
 
 const normalizePath = (url: string): string => {


### PR DESCRIPTION
## 背景

PR3 已将 DataSource、File Resource、Dataset 纳入 Project Space。本 PR 进入 PR4，按数据生产链继续迁移：

```text
Data Development
  -> Task Catalog
  -> Offline Sync
  -> Realtime Sync
  -> Workflow
```

本 PR 继续采用 **Expand -> Backfill -> Contract**。当前统一保持 `PROJECT_OPTIONAL` 与 nullable `project_id`，不会在历史数据回填和双项目验收完成前直接切换 `PROJECT_REQUIRED` 或 `NOT NULL`。

## 本 PR 已完成

### 1. Data Development

- `yak_dev_directory` 增加 `project_id`，目录同级名称唯一约束调整为项目维度；
- `yak_dev_node` 的已有 `project_id` 正式接入可信 `CurrentProject`；
- 目录和节点的列表、详情、重命名、删除、名称检查按项目过滤；
- `yak_dev_task_execution` 保存项目，分页、详情和状态更新按项目约束；
- `yak_dev_lineage_outbox` 保存来源项目，后台消费不再依赖原 HTTP 上下文；
- Data Development 业务 Controller 进入 `PROJECT_OPTIONAL`；Editor Settings 继续保持平台全局能力。

### 2. Task Catalog

- Task Catalog 明确为 `PROJECT_PROJECTION`；
- 发布和元数据同步时从源任务复制项目归属，并校验可信当前项目；
- 资产列表、详情、状态和元数据更新按项目过滤；
- 增加项目目录索引；
- Task Catalog Controller 进入 `PROJECT_OPTIONAL`。

### 3. Offline Sync

- `yak_offline_job_definition`、`yak_offline_batch_execution`、`yak_offline_job_execution` 增加 `project_id`；
- 任务名称唯一约束调整为 `(project_id, job_name)`；
- 定义、Batch、Attempt 的 CRUD、分页、重试候选、Backfill 与运行状态更新按项目约束；
- 异步创建 Batch/Attempt 时可从任务定义恢复项目；
- DataSource DAO 的直接读取也会尊重可信 `CurrentProject`，避免同步任务绕过 PR3 的 Repository 边界；
- Offline 业务 Controller 进入 `PROJECT_OPTIONAL`；纯 Cron 预览和 Engine Health 继续保持全局语义。

### 4. Realtime Sync

- `yak_realtime_job_definition`、`yak_realtime_job_deployment` 增加 `project_id`；
- 任务名称唯一约束调整为 `(project_id, job_name)`；
- 定义、Deployment、分页、事件、启停、版本替换与即时 Reconcile 按项目约束；
- 后台 Deployment 创建可从定义恢复项目；
- 全局 Reconcile Lease 继续扫描全部项目，Compute Environment 与 Runtime Lease 保持平台全局；
- Realtime Job Controller 进入 `PROJECT_OPTIONAL`。

### 5. Workflow

- `yak_workflow_definition`、`yak_workflow_execution`、`yak_workflow_schedule`、`yak_workflow_schedule_trigger`、`yak_workflow_backfill` 增加 `project_id`；
- Workflow Version、Node Execution、Node Attempt 继续从父聚合继承，不重复维护可写项目字段；
- Definition、Execution、Schedule、Trigger Ledger、Backfill 的查询和变更按项目约束；
- Execution 可从 Workflow Version/Definition 或来源 Execution 恢复项目；
- Schedule Trigger 可从 Schedule、Backfill 或 Workflow Definition 恢复项目；
- 所有 Workflow 业务 Controller 进入 `PROJECT_OPTIONAL`。

### 6. 前端与迁移手册

- 前端只对已迁移 API 家族注入 `X-YAK-SECURITY-PROJECT-ID`；
- Compute Environment、Quality 等尚未迁移或全局能力继续保持 `LEGACY_GLOBAL`；
- 新增 `docs/project-space/PR4_BACKFILL.md`，覆盖根数据、运行态和投影数据的回填 SQL、父子一致性检查、双项目验收和 Contract 切换条件；
- Flyway 只做 Expand，不硬编码默认项目，也不自动回填历史业务数据。

## 测试补充

新增项目归属单元测试：

- Data Development Directory 创建写入可信项目；
- Offline Definition 创建写入可信项目；
- Realtime Definition 创建写入可信项目；
- Workflow Definition 创建写入可信项目，并拒绝更新其他项目的同 ID 定义；
- UI Project Request Rules 覆盖 Data Development、Task Catalog、Offline、Realtime、Workflow，并验证全局 API 不注入项目头。

## 当前边界

- 当前仍为 `PROJECT_OPTIONAL`；无 Project Header 时保留迁移期兼容读取语义；
- 不开放项目空间菜单和右上角项目切换器；
- 不迁移 Quality、Analysis、Dashboard、Data Service 和 Lineage 图存储；
- 不建立业务库到 Yak Security Project 的物理外键；
- 不在本 PR 中执行 `project_id NOT NULL` 收口；
- 跨项目共享仍不支持。

## 验证状态

- 当前 Head 未发现 GitHub Actions workflow run；
- 本会话环境无法拉取仓库，因此完整 Maven、npm、Flyway 和双项目数据库集成测试尚未实际执行；
- 合并前必须按 `PR4_BACKFILL.md` 补跑模块测试、Flyway 升级、父子项目一致性检查和 Project A/B 隔离验证。

## 合并前最小门禁

```text
Maven:
  data-development
  task-catalog
  sync-offline
  sync-realtime
  workflow
  boot

UI:
  projectContext.test.ts
  typecheck / build

Database:
  全新库执行全部 Flyway
  PR3 数据库增量执行 PR4 Flyway
  回填后 project_id NULL = 0
  父子项目不一致 = 0

API:
  Project A/B 同名对象可创建
  列表、详情、修改、删除、执行、重试、日志、调度均不可跨项目
```