### PR TITLE
fix(ui): 修复大屏模板设置页旧 service 引用

### DIFF
--- a/yak-ops-ui/src/pages/settings/components/ScreenTemplateSettingsPanel.tsx
+++ b/yak-ops-ui/src/pages/settings/components/ScreenTemplateSettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { ScreenRenderer } from '@/components/screen-engine';
 import type { ScreenTemplate } from '@/components/screen-engine';
-import { fetchDigitalScreens } from '@/pages/digital-screen/screen-service';
+import { listDigitalScreens } from '@/services/digital-screen';
 import {
   copyManagedScreenTemplate,
   deleteCustomScreenTemplate,
@@ -92,7 +92,7 @@ export default function ScreenTemplateSettingsPanel() {
   };
 
   const usageCount = async (templateId: string) => {
-    const screens = await fetchDigitalScreens();
+    const screens = await listDigitalScreens();
     return screens.filter((screen) => screen.templateId === templateId).length;
   };
 


### PR DESCRIPTION
## 问题

前端执行 `yarn start` 时，Umi/Mako 在准备阶段报错：

```text
Can't resolve '@/pages/digital-screen/screen-service'
```

错误来源：

```text
src/pages/settings/components/ScreenTemplateSettingsPanel.tsx
```

## 根因

PR #786 对 `digital-screen` 按前端规范做了结构收口，数字大屏实例能力已经迁移到统一 Service：

```text
@/services/digital-screen
```

数字大屏列表页当前也通过 `listDigitalScreens()` 读取实例，但设置页的“大屏模板使用保护”仍保留旧的 page-local `screen-service` 引用，导致构建阶段无法解析模块。

## 修复

- `@/pages/digital-screen/screen-service` -> `@/services/digital-screen`
- `fetchDigitalScreens()` -> `listDigitalScreens()`
- 保持模板使用数量判断逻辑不变

## 验证

- [x] 分支基于最新 `main`
- [x] compare：1 commit / 1 file / 2 additions / 2 deletions
- [x] 新 import 与当前 `useDigitalScreenList` 使用的统一 Service 保持一致
- [x] `listDigitalScreens()` 的返回结构仍包含 `templateId`，原使用数量统计语义不变
- [ ] 本地执行 `yarn start`，确认 Umi/Mako prepare 阶段完整通过

本 PR 只修复此次启动阻断，不顺手扩大前端重构范围。