### PR TITLE
fix(ui): 移除数据源状态组件失效样式引用

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/DataSourceStatus.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceStatus.tsx
@@ -8,8 +8,6 @@ import {
 import { Tag, Tooltip } from 'antd';
 import type { ReactNode } from 'react';
 
-import '../index.enhancements.less';
-
 interface DataSourceStatusProps {
   status?: DataSourceConnectionStatus;
 }


### PR DESCRIPTION
## 问题

前端启动/构建时报错：

```text
Module not found: Can't resolve '../index.enhancements.less'
```

错误来源：

```text
src/pages/data-source/components/DataSourceStatus.tsx
```

## 根因

`data-source` 按 `FRONTEND_CODE_STYLE.md` 完成结构重构后，`index.enhancements.less` 已不再存在，但 `DataSourceStatus.tsx` 仍保留旧的样式 import。

当前 `DataSourceStatus` 的视觉样式已经通过 Ant Design `Tag` 和组件内联 `style` 完成，不依赖该 less 文件，因此该 import 属于无效遗留引用。

## 修复

删除：

```ts
import '../index.enhancements.less';
```

不新增空 less 文件，不改变现有状态映射、Tooltip、Tag 样式或业务逻辑。

## 验证

- [x] 分支基于最新 `main`
- [x] compare：1 commit / 1 file / 0 additions / 2 deletions
- [x] `DataSourceStatus.tsx` 不存在对该 less 文件中 class 的引用
- [x] `data-source` 当前目录中不存在 `index.enhancements.less`
- [ ] 本地重新执行 `yarn start`，确认继续通过后续模块解析

本 PR 仅修复本次启动阻断，不扩大数据源模块改造范围。