### PR TITLE
fix(data-quality): 修复运行记录页数据源树运行时崩溃

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/table-config/components/DataSourceTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/components/DataSourceTreePane.tsx
@@ -14,8 +14,12 @@ import { useMemo, type PointerEvent as ReactPointerEvent } from 'react';
 import type { QualityDataSourceNode } from '../types';
 import { groupQualityDataSourceNodes } from '../utils';
 
+const EMPTY_SOURCE_NODES: QualityDataSourceNode[] = [];
+
 interface DataSourceTreePaneProps {
-  sourceNodes: QualityDataSourceNode[];
+  sourceNodes?: QualityDataSourceNode[];
+  /** Compatibility with callers that still use the pre-refactor prop name. */
+  treeData?: QualityDataSourceNode[];
   treeLoading: boolean;
   selectedNodeKey?: string;
   leftWidth: number;
@@ -35,6 +39,7 @@ interface QualityTreeDataNode extends DataNode {
 
 const DataSourceTreePane = ({
   sourceNodes,
+  treeData: legacyTreeData,
   treeLoading,
   selectedNodeKey,
   leftWidth,
@@ -43,9 +48,12 @@ const DataSourceTreePane = ({
   onResizeStart,
   onCollapsedChange,
 }: DataSourceTreePaneProps) => {
+  const resolvedSourceNodes =
+    sourceNodes ?? legacyTreeData ?? EMPTY_SOURCE_NODES;
+
   const treeData = useMemo<QualityTreeDataNode[]>(
     () =>
-      groupQualityDataSourceNodes(sourceNodes).map((group) => ({
+      groupQualityDataSourceNodes(resolvedSourceNodes).map((group) => ({
         key: `type:${group.dataSourceType}`,
         title: group.dataSourceType,
         kind: 'group',
@@ -60,7 +68,7 @@ const DataSourceTreePane = ({
           isLeaf: true,
         })),
       })),
-    [sourceNodes],
+    [resolvedSourceNodes],
   );
 
   const renderTitle: TreeProps['titleRender'] = (rawNode) => {

--- a/yak-ops-ui/src/pages/data-quality/table-config/hooks/useDataSourceTree.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/hooks/useDataSourceTree.tsx
@@ -160,6 +160,8 @@ export const useDataSourceTree = () => {
     selectedSourceNode,
     selectedNodeKey,
     sourceNodes,
+    // Compatibility alias for execution pages that still use the pre-refactor name.
+    treeData: sourceNodes,
     treeLoading,
     leftWidth,
     collapsed,

--- a/yak-ops-ui/src/pages/data-quality/table-config/utils.test.ts
+++ b/yak-ops-ui/src/pages/data-quality/table-config/utils.test.ts
@@ -88,6 +88,10 @@ describe('quality table registry helpers', () => {
     ]);
   });
 
+  it('returns no groups when source nodes are missing', () => {
+    expect(groupQualityDataSourceNodes()).toEqual([]);
+  });
+
   it('restores and clamps the source tree width', () => {
     expect(parseQualitySourceTreeWidth()).toBe(
       QUALITY_SOURCE_TREE_DEFAULT_WIDTH,

--- a/yak-ops-ui/src/pages/data-quality/table-config/utils.ts
+++ b/yak-ops-ui/src/pages/data-quality/table-config/utils.ts
@@ -41,7 +41,7 @@ export const buildQualityDataSourceNodes = (
     .filter((item): item is QualityDataSourceNode => Boolean(item));
 
 export const groupQualityDataSourceNodes = (
-  nodes: QualityDataSourceNode[],
+  nodes: QualityDataSourceNode[] = [],
 ): QualityDataSourceGroup[] => {
   const groupMap = new Map<string, QualityDataSourceNode[]>();
   nodes.forEach((node) => {


### PR DESCRIPTION
## 问题

访问 `/data-quality/execution` 时页面运行时报错：

```text
TypeError: Cannot read properties of undefined (reading 'forEach')
at groupQualityDataSourceNodes
```

## 根因

`data-quality` 表注册页重构后，`useDataSourceTree()` 的数据源节点字段统一为 `sourceNodes`，`DataSourceTreePane` 也切换到新的 `sourceNodes` prop。

但运行记录页仍然保留旧字段名 `treeData`。因此旧调用链拿到 `undefined`，最终传入 `groupQualityDataSourceNodes()` 后在 `forEach` 处导致整页崩溃。

## 修复

- `useDataSourceTree()` 为旧调用保留 `treeData: sourceNodes` 兼容出口
- `DataSourceTreePane` 优先使用新 `sourceNodes`，同时兼容旧 `treeData`
- 两者均不存在时统一使用空数组，页面进入正常空状态而不是白屏
- `groupQualityDataSourceNodes()` 增加默认空数组参数
- 增加空数据分组测试，锁定防御行为

这样 `/data-quality/table-config` 继续保持新契约，`/data-quality/execution` 的历史调用也能恢复真实数据源树。

## 验证

- [x] 分支基于最新 `main`
- [x] compare：1 commit / 4 files / behind 0
- [x] 运行记录页旧 `treeData` 调用可映射到真实 `sourceNodes`
- [x] 新 `sourceNodes` 调用保持不变
- [x] 空节点输入不再触发 `forEach` 运行时异常
- [ ] 本地访问 `/data-quality/execution`，确认数据源树、筛选与运行记录正常加载

本 PR 只修复数据源树契约兼容和运行时防御，不调整运行记录业务查询语义。