### PR TITLE
refactor(data-quality): 重构运行记录详情页

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionDetailHeader.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionDetailHeader.tsx
@@ -1,0 +1,144 @@
+import { YakButton } from '@/components/ui';
+import type {
+  ExecutionWorkspaceListItem,
+  ExecutionWorkspaceView,
+} from '@/services/data-quality';
+import { Select, Tooltip } from 'antd';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Database,
+  RefreshCw,
+  ShieldCheck,
+  Table2,
+} from 'lucide-react';
+import { useMemo } from 'react';
+
+import { CheckResultTag, ExecutionStatusTag } from '../../../components/QualityStatus';
+import {
+  formatExecutionTime,
+  qualityExecutionTriggerLabel,
+} from '../utils';
+
+interface ExecutionDetailHeaderProps {
+  detail: ExecutionWorkspaceView;
+  historyRecords: ExecutionWorkspaceListItem[];
+  historyLoading: boolean;
+  refreshing: boolean;
+  onBack: () => void;
+  onRefresh: () => void;
+  onSelectExecution: (executionNo: string) => void;
+}
+
+export const ExecutionDetailHeader = ({
+  detail,
+  historyRecords,
+  historyLoading,
+  refreshing,
+  onBack,
+  onRefresh,
+  onSelectExecution,
+}: ExecutionDetailHeaderProps) => {
+  const historyOptions = useMemo(() => {
+    const records = historyRecords.some(
+      (record) => record.executionNo === detail.executionNo,
+    )
+      ? historyRecords
+      : [detail, ...historyRecords];
+
+    return records.map((record) => ({
+      value: record.executionNo,
+      label: `${formatExecutionTime(record.startedAt || record.queuedAt)} · ${record.monitorName}`,
+    }));
+  }, [detail, historyRecords]);
+
+  return (
+    <>
+      <div className="mb-2 flex h-10 items-center">
+        <YakButton
+          type="text"
+          icon={<ArrowLeft size={15} />}
+          className="!h-9 !px-1 !text-[14px] !font-semibold !text-[#30343b]"
+          onClick={onBack}
+        >
+          返回运行记录
+        </YakButton>
+      </div>
+
+      <section className="overflow-hidden rounded-lg bg-white">
+        <div className="grid min-h-[172px] gap-6 px-5 py-6 lg:px-6 xl:grid-cols-[104px_minmax(0,1fr)_330px] xl:items-center">
+          <div className="flex h-[104px] w-[104px] items-center justify-center rounded-xl bg-[#f7f7f8] text-[#fe2c55]">
+            <ShieldCheck size={42} strokeWidth={1.5} />
+          </div>
+
+          <div className="min-w-0">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h1 className="m-0 max-w-[560px] truncate text-[18px] font-semibold leading-7 text-[#161823]">
+                {detail.monitorName || '质量检测运行记录'}
+              </h1>
+              <ExecutionStatusTag value={detail.executionStatus} />
+              <CheckResultTag value={detail.checkResult} />
+            </div>
+
+            <div className="mt-1 truncate text-[12px] leading-5 text-[#98a2b3]">
+              {detail.executionNo}
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-[12px] text-[#667085]">
+              <span>{formatExecutionTime(detail.startedAt || detail.queuedAt)}</span>
+              <span>{qualityExecutionTriggerLabel(detail.triggerType)}</span>
+              <span>{detail.operator || 'system'}</span>
+            </div>
+
+            <div className="mt-3 flex min-w-0 flex-wrap items-center gap-2 text-[12px] text-[#667085]">
+              <span className="flex max-w-[280px] items-center gap-1.5 truncate">
+                <Database size={13} className="shrink-0 text-[#98a2b3]" />
+                <span className="truncate">{detail.dataSourceName || '数据源'}</span>
+              </span>
+              <ArrowRight size={13} className="shrink-0 text-[#c0c4cc]" />
+              <span className="flex max-w-[420px] items-center gap-1.5 truncate">
+                <Table2 size={13} className="shrink-0 text-[#98a2b3]" />
+                <span className="truncate">{detail.objectName || detail.tableName || '监控对象'}</span>
+              </span>
+            </div>
+          </div>
+
+          <div className="min-w-0 xl:justify-self-end">
+            <div className="mb-2 text-[11px] leading-4 text-[#98a2b3]">
+              切换同一监控的运行记录
+            </div>
+            <div className="flex gap-2">
+              <Select
+                showSearch
+                variant="filled"
+                value={detail.executionNo}
+                options={historyOptions}
+                optionFilterProp="label"
+                loading={historyLoading}
+                className="min-w-0 flex-1 xl:w-[278px]"
+                onChange={onSelectExecution}
+                notFoundContent="暂无历史运行记录"
+              />
+              <Tooltip title="刷新运行详情">
+                <YakButton
+                  iconOnly
+                  aria-label="刷新运行详情"
+                  icon={<RefreshCw size={14} />}
+                  loading={refreshing}
+                  onClick={onRefresh}
+                />
+              </Tooltip>
+            </div>
+          </div>
+        </div>
+
+        {detail.errorMessage ? (
+          <div className="mx-5 mb-5 rounded-md bg-[#fff5f5] px-4 py-3 text-[12px] leading-5 text-[#d92d20] lg:mx-6">
+            <span className="font-medium">执行异常：</span>
+            {detail.errorMessage}
+          </div>
+        ) : null}
+      </section>
+    </>
+  );
+};

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionHistoryTable.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionHistoryTable.tsx
@@ -1,0 +1,129 @@
+import { YakButton, YakEmpty } from '@/components/ui';
+import type { ExecutionWorkspaceListItem } from '@/services/data-quality';
+import { Table } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useMemo } from 'react';
+
+import {
+  CheckResultTag,
+  ExecutionStatusTag,
+} from '../../../components/QualityStatus';
+import { dataQualityTableClassName } from '../../../components/tableStyle';
+import {
+  formatExecutionDuration,
+  formatExecutionTime,
+  qualityExecutionIssueCount,
+} from '../utils';
+
+interface ExecutionHistoryTableProps {
+  records: ExecutionWorkspaceListItem[];
+  loading: boolean;
+  currentExecutionNo: string;
+  onOpen: (executionNo: string) => void;
+}
+
+export const ExecutionHistoryTable = ({
+  records,
+  loading,
+  currentExecutionNo,
+  onOpen,
+}: ExecutionHistoryTableProps) => {
+  const columns = useMemo<ColumnsType<ExecutionWorkspaceListItem>>(
+    () => [
+      {
+        title: '运行时间',
+        width: 190,
+        render: (_, record) => (
+          <div>
+            <div className="text-[12px] font-medium text-[#344054]">
+              {formatExecutionTime(record.startedAt || record.queuedAt)}
+            </div>
+            <div className="mt-1 max-w-[240px] truncate text-[11px] text-[#98a2b3]">
+              {record.executionNo}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '执行状态',
+        dataIndex: 'executionStatus',
+        width: 110,
+        render: (value) => <ExecutionStatusTag value={value} />,
+      },
+      {
+        title: '质量结果',
+        dataIndex: 'checkResult',
+        width: 110,
+        render: (value) => <CheckResultTag value={value} />,
+      },
+      {
+        title: '规则概况',
+        minWidth: 260,
+        render: (_, record) => (
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[12px]">
+            <span className="text-[#344054]">通过 {record.passedRules}</span>
+            <span className="text-[#b54708]">未通过 {record.failedRules}</span>
+            <span className="text-[#d92d20]">异常 {record.errorRules}</span>
+          </div>
+        ),
+      },
+      {
+        title: '问题数量',
+        width: 100,
+        align: 'right',
+        render: (_, record) => qualityExecutionIssueCount(record),
+      },
+      {
+        title: '耗时',
+        dataIndex: 'durationMs',
+        width: 110,
+        align: 'right',
+        render: formatExecutionDuration,
+      },
+      {
+        title: '操作',
+        width: 80,
+        fixed: 'right',
+        render: (_, record) => (
+          <YakButton
+            type="text"
+            size="small"
+            disabled={record.executionNo === currentExecutionNo}
+            onClick={() => onOpen(record.executionNo)}
+          >
+            查看
+          </YakButton>
+        ),
+      },
+    ],
+    [currentExecutionNo, onOpen],
+  );
+
+  if (!loading && !records.length) {
+    return (
+      <YakEmpty
+        compact
+        title="暂无历史运行记录"
+        description="当前监控还没有更多可查看的历史执行记录"
+      />
+    );
+  }
+
+  return (
+    <Table<ExecutionWorkspaceListItem>
+      rowKey="executionNo"
+      size="small"
+      loading={loading}
+      pagination={false}
+      scroll={{ x: 980 }}
+      className={dataQualityTableClassName(
+        '[&_.ant-table-container]:!border [&_.ant-table-container]:!border-solid',
+      )}
+      dataSource={records}
+      columns={columns}
+      rowClassName={(record) =>
+        record.executionNo === currentExecutionNo ? 'bg-[#fff8fa]' : ''
+      }
+    />
+  );
+};

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionLogPanel.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionLogPanel.tsx
@@ -1,0 +1,88 @@
+import { YakButton, YakEmpty } from '@/components/ui';
+import type { ExecutionLogLine, ExecutionLogView } from '@/services/data-quality';
+import { Spin } from 'antd';
+import { RefreshCw } from 'lucide-react';
+
+import { formatExecutionTime } from '../utils';
+import { ExecutionSectionCard } from './ExecutionSectionCard';
+
+const logLevelClass: Record<ExecutionLogLine['level'], string> = {
+  INFO: 'text-[#7fb3ff]',
+  WARN: 'text-[#f7c56b]',
+  ERROR: 'text-[#ff8585]',
+};
+
+interface ExecutionLogPanelProps {
+  logs?: ExecutionLogView;
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+export const ExecutionLogPanel = ({
+  logs,
+  loading,
+  onRefresh,
+}: ExecutionLogPanelProps) => (
+  <ExecutionSectionCard
+    title="原始日志"
+    extra={
+      <YakButton
+        size="small"
+        type="text"
+        icon={<RefreshCw size={13} />}
+        loading={loading}
+        className="!text-[#667085]"
+        onClick={onRefresh}
+      >
+        刷新
+      </YakButton>
+    }
+  >
+    <div className="px-5 pb-5 pt-1">
+      <div className="mb-3 text-[12px] leading-5 text-[#8a8f98]">
+        展示当前质量检测的执行过程，便于定位规则采集、比较和异常阶段。
+      </div>
+
+      <div className="overflow-hidden rounded-md bg-[#181a1f]">
+        {loading && !logs ? (
+          <div className="flex min-h-[420px] items-center justify-center">
+            <Spin size="small" />
+          </div>
+        ) : logs?.lines.length ? (
+          <div className="max-h-[680px] min-h-[420px] overflow-auto p-4 font-mono text-[12px] leading-5">
+            {logs.lines.map((line, index) => (
+              <div
+                key={`${line.timestamp || 'log'}-${line.stage}-${index}`}
+                className="flex gap-3 border-b border-white/[0.06] py-1.5 last:border-b-0"
+              >
+                <span className="w-[146px] shrink-0 text-[#7d8490]">
+                  {formatExecutionTime(line.timestamp)}
+                </span>
+                <span
+                  className={`w-12 shrink-0 font-semibold ${logLevelClass[line.level]}`}
+                >
+                  {line.level}
+                </span>
+                <span className="w-24 shrink-0 truncate text-[#9ca3af]">
+                  [{line.stage}]
+                </span>
+                <span className="min-w-0 whitespace-pre-wrap break-all text-[#d6d9df]">
+                  {line.message}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex min-h-[420px] items-center justify-center bg-[#181a1f]">
+            <YakEmpty
+              compact
+              title="暂无原始日志"
+              description="当前运行记录没有返回可展示的日志内容"
+              className="[&_div]:text-[#8a9099]"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  </ExecutionSectionCard>
+);

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionRuleTable.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionRuleTable.tsx
@@ -1,0 +1,140 @@
+import { YakEmpty } from '@/components/ui';
+import type { ExecutionWorkspaceRuleView } from '@/services/data-quality';
+import { Table, Tag, Typography } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useMemo } from 'react';
+
+import { CheckResultTag } from '../../../components/QualityStatus';
+import { dataQualityTableClassName } from '../../../components/tableStyle';
+import {
+  formatExecutionDuration,
+  qualityRuleScopeLabel,
+} from '../utils';
+
+interface ExecutionRuleTableProps {
+  records: ExecutionWorkspaceRuleView[];
+  issueMode?: boolean;
+}
+
+export const ExecutionRuleTable = ({
+  records,
+  issueMode = false,
+}: ExecutionRuleTableProps) => {
+  const columns = useMemo<ColumnsType<ExecutionWorkspaceRuleView>>(
+    () => [
+      {
+        title: '规则名称 / 模板',
+        width: 250,
+        render: (_, record) => (
+          <div className="min-w-0 py-0.5">
+            <div className="truncate font-medium text-[#30343b]">
+              {record.ruleName}
+            </div>
+            <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
+              {record.templateCode}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '关联范围',
+        dataIndex: 'scope',
+        width: 100,
+        render: (value) => (
+          <Tag className="!m-0 !border-0 !bg-[#fff0f3] !text-[11px] !text-[#fe2c55]">
+            {qualityRuleScopeLabel(value)}
+          </Tag>
+        ),
+      },
+      {
+        title: '质量维度',
+        dataIndex: 'dimension',
+        width: 110,
+      },
+      {
+        title: '检查字段',
+        dataIndex: 'columnName',
+        width: 140,
+        render: (value) => value || '整表',
+      },
+      {
+        title: '检查结果',
+        dataIndex: 'checkResult',
+        width: 110,
+        render: (value) => <CheckResultTag value={value} />,
+      },
+      {
+        title: '实际值 / 期望值',
+        width: 210,
+        render: (_, record) => (
+          <div className="space-y-1 text-[12px]">
+            <div className="text-[#344054]">
+              实际：{record.metricValue || '--'}
+            </div>
+            <div className="text-[#98a2b3]">
+              期望：{record.expectedValue || '--'}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '耗时',
+        dataIndex: 'durationMs',
+        width: 100,
+        align: 'right',
+        render: formatExecutionDuration,
+      },
+    ],
+    [],
+  );
+
+  if (!records.length) {
+    return (
+      <YakEmpty
+        compact
+        title={issueMode ? '本次运行没有问题规则' : '暂无规则检测结果'}
+        description={
+          issueMode
+            ? '本次运行的规则均未产生未通过或异常结果'
+            : '当前运行记录没有返回规则检测明细'
+        }
+      />
+    );
+  }
+
+  return (
+    <Table<ExecutionWorkspaceRuleView>
+      rowKey="id"
+      size="small"
+      pagination={false}
+      scroll={{ x: 1040 }}
+      className={dataQualityTableClassName(
+        '[&_.ant-table-container]:!border [&_.ant-table-container]:!border-solid',
+      )}
+      dataSource={records}
+      columns={columns}
+      expandable={{
+        expandedRowRender: (record) => (
+          <div className="space-y-3 px-2 py-2">
+            {(record.errorMessage || issueMode) && (
+              <div className="rounded-md bg-[#fff5f5] px-3 py-2 text-[12px] leading-5 text-[#d92d20]">
+                {record.errorMessage || '质量指标未满足预期阈值'}
+              </div>
+            )}
+            <div>
+              <div className="mb-2 text-[11px] font-medium text-[#8a8f98]">
+                执行 SQL
+              </div>
+              <Typography.Paragraph
+                copyable
+                className="!mb-0 max-h-[360px] overflow-auto whitespace-pre-wrap break-words rounded-md !bg-[#181a1f] !p-4 font-mono !text-[12px] !leading-5 !text-[#d6d9df]"
+              >
+                {record.executedSql || '未生成执行 SQL'}
+              </Typography.Paragraph>
+            </div>
+          </div>
+        ),
+      }}
+    />
+  );
+};

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionSectionCard.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/components/ExecutionSectionCard.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react';
+
+export const ExecutionSectionCard = ({
+  title,
+  extra,
+  children,
+  className = '',
+}: {
+  title: ReactNode;
+  extra?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) => (
+  <section className={`min-w-0 rounded-lg bg-white ${className}`}>
+    <div className="flex min-h-[52px] items-center justify-between gap-4 px-5">
+      <div className="text-[15px] font-semibold text-[#161823]">{title}</div>
+      {extra}
+    </div>
+    {children}
+  </section>
+);
+
+export const ExecutionMetricTile = ({
+  label,
+  value,
+  hint,
+  valueClassName = '',
+}: {
+  label: string;
+  value: ReactNode;
+  hint?: string;
+  valueClassName?: string;
+}) => (
+  <div className="rounded-md bg-[#f7f7f8] px-4 py-4">
+    <div className="text-[12px] leading-4 text-[#7c828c]">{label}</div>
+    <div
+      className={`mt-2 text-[20px] font-semibold leading-7 tracking-[-0.02em] text-[#161823] ${valueClassName}`}
+    >
+      {value}
+    </div>
+    {hint ? (
+      <div className="mt-1 text-[11px] leading-4 text-[#9aa0aa]">{hint}</div>
+    ) : null}
+  </div>
+);
+
+export const ExecutionInfoItem = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: ReactNode;
+}) => (
+  <div className="min-w-0">
+    <div className="text-[12px] leading-4 text-[#8a8f98]">{label}</div>
+    <div className="mt-2 truncate text-[14px] font-medium leading-5 text-[#161823]">
+      {value || '--'}
+    </div>
+  </div>
+);

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/hooks/useExecutionDetailPage.ts
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/hooks/useExecutionDetailPage.ts
@@ -1,0 +1,118 @@
+import {
+  getQualityExecutionLogs,
+  getQualityExecutionWorkspace,
+  listQualityExecutionWorkspace,
+  type ExecutionLogView,
+  type ExecutionWorkspaceListItem,
+  type ExecutionWorkspaceView,
+} from '@/services/data-quality';
+import { message } from 'antd';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export const useExecutionDetailPage = (executionNo: string) => {
+  const [detail, setDetail] = useState<ExecutionWorkspaceView>();
+  const [logs, setLogs] = useState<ExecutionLogView>();
+  const [historyRecords, setHistoryRecords] = useState<
+    ExecutionWorkspaceListItem[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
+  const loadDetail = useCallback(async () => {
+    if (!executionNo) return;
+    setLoading(true);
+    try {
+      setDetail(await getQualityExecutionWorkspace(executionNo));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '执行详情加载失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [executionNo]);
+
+  const loadLogs = useCallback(async () => {
+    if (!executionNo) return;
+    setLogsLoading(true);
+    try {
+      setLogs(await getQualityExecutionLogs(executionNo));
+    } catch (error) {
+      setLogs(undefined);
+      message.error(error instanceof Error ? error.message : '原始日志加载失败');
+    } finally {
+      setLogsLoading(false);
+    }
+  }, [executionNo]);
+
+  const loadHistory = useCallback(async (monitorId: number) => {
+    setHistoryLoading(true);
+    try {
+      const page = await listQualityExecutionWorkspace({
+        current: 1,
+        pageSize: 50,
+        monitorId,
+      });
+      setHistoryRecords(page.records || []);
+    } catch (error) {
+      setHistoryRecords([]);
+      message.error(
+        error instanceof Error ? error.message : '历史运行记录加载失败',
+      );
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadDetail();
+    void loadLogs();
+  }, [loadDetail, loadLogs]);
+
+  useEffect(() => {
+    if (!detail?.monitorId) {
+      setHistoryRecords([]);
+      return;
+    }
+    void loadHistory(detail.monitorId);
+  }, [detail?.monitorId, loadHistory]);
+
+  useEffect(() => {
+    if (!detail || !['WAITING', 'RUNNING'].includes(detail.executionStatus)) {
+      return;
+    }
+    const timer = window.setInterval(() => {
+      void loadDetail();
+      void loadLogs();
+    }, 3000);
+    return () => window.clearInterval(timer);
+  }, [detail, loadDetail, loadLogs]);
+
+  const issueRules = useMemo(
+    () =>
+      detail?.rules.filter((rule) =>
+        ['NOT_PASSED', 'ERROR'].includes(rule.checkResult),
+      ) || [],
+    [detail?.rules],
+  );
+
+  const refresh = useCallback(async () => {
+    await Promise.all([
+      loadDetail(),
+      loadLogs(),
+      detail?.monitorId ? loadHistory(detail.monitorId) : Promise.resolve(),
+    ]);
+  }, [detail?.monitorId, loadDetail, loadHistory, loadLogs]);
+
+  return {
+    detail,
+    logs,
+    historyRecords,
+    issueRules,
+    loading,
+    logsLoading,
+    historyLoading,
+    refreshing: loading || logsLoading || historyLoading,
+    refresh,
+    loadLogs,
+  };
+};

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/index.tsx
@@ -1,552 +1,242 @@
-import YakTab from '@/components/YakTab';
-import { API_SUCCESS_CODE } from '@/services/http/response';
+import { YakButton, YakEmpty, YakTab } from '@/components/ui';
 import { BRAND_THEME } from '@/styles/brand';
 import { history, useParams } from '@umijs/max';
+import { ConfigProvider, Spin } from 'antd';
+import { useMemo, useState } from 'react';
+
+import { ExecutionDetailHeader } from './components/ExecutionDetailHeader';
+import { ExecutionHistoryTable } from './components/ExecutionHistoryTable';
+import { ExecutionLogPanel } from './components/ExecutionLogPanel';
+import { ExecutionRuleTable } from './components/ExecutionRuleTable';
 import {
-  Button,
-  ConfigProvider,
-  Descriptions,
-  Empty,
-  Input,
-  Spin,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from 'antd';
-import type { ColumnsType } from 'antd/es/table';
-import dayjs from 'dayjs';
+  ExecutionInfoItem,
+  ExecutionMetricTile,
+  ExecutionSectionCard,
+} from './components/ExecutionSectionCard';
+import { useExecutionDetailPage } from './hooks/useExecutionDetailPage';
 import {
-  ArrowLeft,
-  ChevronLeft,
-  ChevronRight,
-  FileText,
-  RefreshCw,
-  Search,
-  ShieldCheck,
-} from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { CheckResultTag, ExecutionStatusTag } from '../../components/QualityStatus';
-import { dataQualityTableClassName } from '../../components/tableStyle';
-import { qualityExecutionWorkspaceApi } from '../service';
-import type {
-  ExecutionLogLine,
-  ExecutionLogView,
-  ExecutionWorkspaceListItem,
-  ExecutionWorkspaceRuleView,
-  ExecutionWorkspaceView,
-} from '../types';
-
-const unwrap = <T,>(response: {
-  code: number;
-  data: T;
-  message?: string;
-  msg?: string;
-}) => {
-  if (response.code !== API_SUCCESS_CODE) {
-    throw new Error(response.message || response.msg || '请求失败');
-  }
-  return response.data;
-};
-
-const formatTime = (value?: string) =>
-  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '--';
-
-const formatDuration = (value?: number) =>
-  value === undefined || value === null ? '--' : `${value} ms`;
-
-const triggerLabel = (value?: ExecutionWorkspaceView['triggerType']) =>
-  value === 'SCHEDULE' ? '调度触发' : '手动触发';
-
-const scopeLabel = (value: ExecutionWorkspaceRuleView['scope']) =>
-  value === 'TABLE' ? '表级' : '字段级';
-
-const logLevelClass: Record<ExecutionLogLine['level'], string> = {
-  INFO: 'text-[#245bdb]',
-  WARN: 'text-[#b54708]',
-  ERROR: 'text-[#d92d20]',
-};
+  type ExecutionDetailTabKey,
+  formatExecutionDuration,
+  formatExecutionTime,
+  qualityExecutionIssueCount,
+  qualityExecutionTriggerLabel,
+} from './utils';
 
 const ExecutionDetailPage = () => {
   const { executionNo = '' } = useParams<{ executionNo: string }>();
-  const [loading, setLoading] = useState(false);
-  const [historyLoading, setHistoryLoading] = useState(false);
-  const [detail, setDetail] = useState<ExecutionWorkspaceView>();
-  const [logs, setLogs] = useState<ExecutionLogView>();
-  const [historyRecords, setHistoryRecords] = useState<
-    ExecutionWorkspaceListItem[]
-  >([]);
-  const [historyKeyword, setHistoryKeyword] = useState('');
-  const [historyCollapsed, setHistoryCollapsed] = useState(false);
-  const [activeTab, setActiveTab] = useState('CURRENT');
+  const [activeTab, setActiveTab] =
+    useState<ExecutionDetailTabKey>('overview');
+  const {
+    detail,
+    logs,
+    historyRecords,
+    issueRules,
+    loading,
+    logsLoading,
+    historyLoading,
+    refreshing,
+    refresh,
+    loadLogs,
+  } = useExecutionDetailPage(executionNo);
 
-  const loadDetail = useCallback(async () => {
-    if (!executionNo) return;
-    setLoading(true);
-    try {
-      const [detailResponse, logsResponse] = await Promise.all([
-        qualityExecutionWorkspaceApi.detail(executionNo),
-        qualityExecutionWorkspaceApi.logs(executionNo),
-      ]);
-      setDetail(unwrap(detailResponse));
-      setLogs(unwrap(logsResponse));
-    } catch (error: any) {
-      message.error(error?.message || '执行详情加载失败');
-    } finally {
-      setLoading(false);
-    }
-  }, [executionNo]);
-
-  useEffect(() => {
-    void loadDetail();
-  }, [loadDetail]);
-
-  useEffect(() => {
-    if (!detail?.monitorId) return;
-    setHistoryLoading(true);
-    qualityExecutionWorkspaceApi
-      .page({ current: 1, pageSize: 50, monitorId: detail.monitorId })
-      .then((response) => setHistoryRecords(unwrap(response).records))
-      .catch((error) =>
-        message.error(error?.message || '历史运行记录加载失败'),
-      )
-      .finally(() => setHistoryLoading(false));
-  }, [detail?.monitorId]);
-
-  useEffect(() => {
-    if (!detail || !['WAITING', 'RUNNING'].includes(detail.executionStatus)) {
-      return;
-    }
-    const timer = window.setInterval(() => void loadDetail(), 3000);
-    return () => window.clearInterval(timer);
-  }, [detail, loadDetail]);
-
-  const filteredHistory = useMemo(() => {
-    const keyword = historyKeyword.trim().toLowerCase();
-    if (!keyword) return historyRecords;
-    return historyRecords.filter(
-      (record) =>
-        record.executionNo.toLowerCase().includes(keyword) ||
-        record.monitorName.toLowerCase().includes(keyword),
-    );
-  }, [historyKeyword, historyRecords]);
-
-  const issueRules = useMemo(
-    () =>
-      detail?.rules.filter((rule) =>
-        ['NOT_PASSED', 'ERROR'].includes(rule.checkResult),
-      ) || [],
-    [detail?.rules],
-  );
-
-  const ruleColumns = useMemo<ColumnsType<ExecutionWorkspaceRuleView>>(
+  const tabItems = useMemo(
     () => [
+      { key: 'overview', label: '总览' },
+      { key: 'history', label: `历史运行 (${historyRecords.length})` },
       {
-        title: '规则名称 / 模板',
-        width: 250,
-        render: (_, record) => (
-          <div className="min-w-0 py-0.5">
-            <div className="truncate font-medium text-[#172033]">
-              {record.ruleName}
-            </div>
-            <div className="mt-1 truncate text-[11px] text-[#98a2b3]">
-              {record.templateCode}
-            </div>
-          </div>
-        ),
+        key: 'issues',
+        label: `问题数据${issueRules.length ? ` (${issueRules.length})` : ''}`,
       },
-      {
-        title: '关联范围',
-        dataIndex: 'scope',
-        width: 100,
-        render: (value) => (
-          <Tag className="!m-0 !border-0 !bg-[#fff0f3] !text-[#fe2c55]">
-            {scopeLabel(value)}
-          </Tag>
-        ),
-      },
-      { title: '质量维度', dataIndex: 'dimension', width: 110 },
-      {
-        title: '检查字段',
-        dataIndex: 'columnName',
-        width: 140,
-        render: (value) => value || '整表',
-      },
-      {
-        title: '检查结果',
-        dataIndex: 'checkResult',
-        width: 110,
-        render: (value) => <CheckResultTag value={value} />,
-      },
-      {
-        title: '实际值 / 期望值',
-        width: 210,
-        render: (_, record) => (
-          <div className="space-y-1 text-xs">
-            <div>实际：{record.metricValue || '--'}</div>
-            <div className="text-[#98a2b3]">
-              期望：{record.expectedValue || '--'}
-            </div>
-          </div>
-        ),
-      },
-      {
-        title: '耗时',
-        dataIndex: 'durationMs',
-        width: 100,
-        render: formatDuration,
-      },
+      { key: 'logs', label: '原始日志' },
     ],
-    [],
+    [historyRecords.length, issueRules.length],
   );
 
-  const historyColumns = useMemo<ColumnsType<ExecutionWorkspaceListItem>>(
-    () => [
-      {
-        title: '校验状态',
-        dataIndex: 'executionStatus',
-        width: 110,
-        render: (value) => <ExecutionStatusTag value={value} />,
-      },
-      {
-        title: '运行时间',
-        width: 190,
-        render: (_, record) => formatTime(record.startedAt || record.queuedAt),
-      },
-      {
-        title: '质量结果',
-        dataIndex: 'checkResult',
-        width: 110,
-        render: (value) => <CheckResultTag value={value} />,
-      },
-      {
-        title: '规则概况',
-        width: 260,
-        render: (_, record) =>
-          `通过 ${record.passedRules} / 未通过 ${record.failedRules} / 异常 ${record.errorRules}`,
-      },
-      {
-        title: '问题数量',
-        width: 110,
-        render: (_, record) => record.failedRules + record.errorRules,
-      },
-      {
-        title: '操作',
-        width: 90,
-        render: (_, record) => (
-          <Button
-            type="link"
-            size="small"
-            onClick={() =>
-              history.push(`/data-quality/execution/${record.executionNo}`)
-            }
-          >
-            查看
-          </Button>
-        ),
-      },
-    ],
-    [],
-  );
-
-  const renderRuleTable = (
-    records: ExecutionWorkspaceRuleView[],
-    issueMode = false,
-  ) => (
-    <Table<ExecutionWorkspaceRuleView>
-      rowKey="id"
-      size="small"
-      bordered
-      pagination={false}
-      scroll={{ x: 1080 }}
-      className={dataQualityTableClassName()}
-      dataSource={records}
-      columns={ruleColumns}
-      expandable={{
-        expandedRowRender: (record) => (
-          <div className="space-y-3 px-2 py-1">
-            {(record.errorMessage || issueMode) && (
-              <Typography.Text type="danger">
-                {record.errorMessage || '质量指标未满足预期阈值'}
-              </Typography.Text>
-            )}
-            <Typography.Paragraph
-              copyable
-              className="!mb-0 whitespace-pre-wrap rounded bg-[#f8f9fb] p-3 font-mono text-xs"
-            >
-              {record.executedSql || '未生成执行 SQL'}
-            </Typography.Paragraph>
-          </div>
-        ),
-      }}
-    />
-  );
-
-  if (!detail && !loading) {
+  if (!detail && loading) {
     return (
       <ConfigProvider theme={BRAND_THEME}>
-        <div className="flex h-[calc(100vh-64px)] items-center justify-center bg-white">
-          <Empty description="执行记录不存在" />
+        <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f7f8]">
+          <Spin size="large" />
         </div>
       </ConfigProvider>
     );
   }
 
-  return (
-    <ConfigProvider theme={BRAND_THEME}>
-      <Spin spinning={loading && !detail}>
-        <div className="flex h-[calc(100vh-64px)] min-h-[680px] flex-col overflow-hidden bg-white">
-          <header className="shrink-0 border-b border-[#e8e9ec] px-4 py-3">
-            <button
-              type="button"
-              className="mb-2 flex cursor-pointer items-center gap-1 border-0 bg-transparent p-0 text-xs text-[#667085] hover:text-[#fe2c55]"
-              onClick={() => history.push('/data-quality/execution')}
-            >
-              <ArrowLeft size={14} />
-              返回运行记录
-            </button>
-
-            <div className="flex items-start justify-between gap-6">
-              <div className="flex min-w-0 items-start gap-3">
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[#fff0f3] text-[#fe2c55]">
-                  <ShieldCheck size={24} />
-                </div>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h1 className="m-0 truncate text-[18px] font-semibold text-[#161823]">
-                      {detail?.monitorName || executionNo}
-                    </h1>
-                    {detail && <ExecutionStatusTag value={detail.executionStatus} />}
-                    {detail && <CheckResultTag value={detail.checkResult} />}
-                  </div>
-                  <div className="mt-1 text-xs text-[#98a2b3]">
-                    执行编号：{detail?.executionNo || executionNo}
-                  </div>
-                </div>
-              </div>
-              <Button icon={<RefreshCw size={14} />} onClick={loadDetail}>
-                刷新
-              </Button>
-            </div>
-
-            {detail && (
-              <div className="mt-3 grid grid-cols-4 gap-x-8 gap-y-1 text-xs">
-                <div>运行时间：{formatTime(detail.startedAt || detail.queuedAt)}</div>
-                <div>数据源：{detail.dataSourceName}</div>
-                <div>触发方式：{triggerLabel(detail.triggerType)}</div>
-                <div>触发人：{detail.operator || 'system'}</div>
-                <div className="col-span-2 truncate">监控对象：{detail.objectName}</div>
-                <div>规则数量：{detail.totalRules}</div>
-                <div>执行耗时：{formatDuration(detail.durationMs)}</div>
-              </div>
-            )}
-          </header>
-
-          <div className="flex min-h-0 flex-1 overflow-hidden">
-            <aside
-              className="shrink-0 overflow-hidden border-r border-[#e8e9ec] bg-white transition-[width] duration-200"
-              style={{ width: historyCollapsed ? 0 : 320 }}
-            >
-              <div className="flex h-full w-[320px] flex-col">
-                <div className="shrink-0 border-b border-[#eceef0] p-3">
-                  <Input
-                    allowClear
-                    variant="filled"
-                    value={historyKeyword}
-                    onChange={(event) => setHistoryKeyword(event.target.value)}
-                    prefix={<Search size={14} className="text-[#98a2b3]" />}
-                    placeholder="搜索执行编号"
-                  />
-                </div>
-                <Spin spinning={historyLoading}>
-                  <div className="h-[calc(100vh-270px)] overflow-y-auto">
-                    {filteredHistory.length ? (
-                      filteredHistory.map((record) => {
-                        const active = record.executionNo === executionNo;
-                        return (
-                          <button
-                            key={record.executionNo}
-                            type="button"
-                            className={`block w-full cursor-pointer border-0 border-b border-[#f0f2f5] px-3 py-3 text-left ${
-                              active
-                                ? 'border-r-2 border-r-[#fe2c55] bg-[#fff7f8]'
-                                : 'bg-white hover:bg-[#fafbfc]'
-                            }`}
-                            onClick={() =>
-                              history.push(
-                                `/data-quality/execution/${record.executionNo}`,
-                              )
-                            }
-                          >
-                            <div className="flex items-center justify-between gap-2">
-                              <span className="truncate text-[11px] text-[#98a2b3]">
-                                {record.executionNo}
-                              </span>
-                              <ExecutionStatusTag value={record.executionStatus} />
-                            </div>
-                            <div className="mt-1 truncate text-[13px] font-medium text-[#172033]">
-                              {record.monitorName}
-                            </div>
-                            <div className="mt-1 text-xs text-[#667085]">
-                              {formatTime(record.startedAt || record.queuedAt)}
-                            </div>
-                            <div className="mt-1 text-xs text-[#98a2b3]">
-                              问题 {record.failedRules + record.errorRules} ·{' '}
-                              {formatDuration(record.durationMs)}
-                            </div>
-                          </button>
-                        );
-                      })
-                    ) : (
-                      <Empty
-                        image={Empty.PRESENTED_IMAGE_SIMPLE}
-                        description="暂无历史运行记录"
-                        className="mt-16"
-                      />
-                    )}
-                  </div>
-                </Spin>
-              </div>
-            </aside>
-
-            <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-              <button
-                type="button"
-                className="absolute left-0 top-1/2 z-20 flex h-8 w-4 -translate-y-1/2 cursor-pointer items-center justify-center rounded-r border border-l-0 border-[#dfe1e5] bg-white text-[#7b808a]"
-                onClick={() => setHistoryCollapsed(!historyCollapsed)}
-              >
-                {historyCollapsed ? (
-                  <ChevronRight size={13} />
-                ) : (
-                  <ChevronLeft size={13} />
-                )}
-              </button>
-
-              <YakTab
-                activeKey={activeTab}
-                onChange={setActiveTab}
-                className="min-h-0 flex-1 [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:overflow-auto"
-                items={[
-                  {
-                    key: 'CURRENT',
-                    label: '本次运行记录',
-                    children: detail ? (
-                      <div>
-                        <section className="border-b border-[#eceef0] px-5 py-4">
-                          <h2 className="m-0 mb-3 text-[15px] font-semibold text-[#161823]">
-                            监控信息
-                          </h2>
-                          <Descriptions
-                            size="small"
-                            column={2}
-                            items={[
-                              { key: 'name', label: '监控名称', children: detail.monitorName },
-                              { key: 'id', label: '监控 ID', children: detail.monitorId },
-                              { key: 'object', label: '数据范围', children: detail.objectName },
-                              { key: 'rules', label: '规则数量', children: detail.totalRules },
-                              { key: 'mode', label: '比较方式', children: '按规则阈值逐项比较' },
-                              { key: 'result', label: '质量结果', children: <CheckResultTag value={detail.checkResult} /> },
-                            ]}
-                          />
-                        </section>
-                        <section className="border-b border-[#eceef0] px-5 py-4">
-                          <h2 className="m-0 mb-3 text-[15px] font-semibold text-[#161823]">
-                            检测任务执行信息
-                          </h2>
-                          <Descriptions
-                            size="small"
-                            column={2}
-                            items={[
-                              { key: 'trigger', label: '检测触发方式', children: triggerLabel(detail.triggerType) },
-                              { key: 'queued', label: '入队时间', children: formatTime(detail.queuedAt) },
-                              { key: 'start', label: '实际开始时间', children: formatTime(detail.startedAt) },
-                              { key: 'finish', label: '实际结束时间', children: formatTime(detail.finishedAt) },
-                            ]}
-                          />
-                        </section>
-                        <section className="px-5 py-4">
-                          <h2 className="m-0 mb-3 text-[15px] font-semibold text-[#161823]">
-                            质量采集及比较状态结果
-                          </h2>
-                          {renderRuleTable(detail.rules)}
-                        </section>
-                      </div>
-                    ) : null,
-                  },
-                  {
-                    key: 'HISTORY',
-                    label: '历史运行记录',
-                    children: (
-                      <div className="p-4">
-                        <Table<ExecutionWorkspaceListItem>
-                          rowKey="executionNo"
-                          size="small"
-                          bordered
-                          loading={historyLoading}
-                          pagination={false}
-                          className={dataQualityTableClassName()}
-                          dataSource={historyRecords}
-                          columns={historyColumns}
-                        />
-                      </div>
-                    ),
-                  },
-                  {
-                    key: 'ISSUES',
-                    label: `问题数据处理${issueRules.length ? ` (${issueRules.length})` : ''}`,
-                    children: (
-                      <div className="p-4">
-                        {issueRules.length ? (
-                          renderRuleTable(issueRules, true)
-                        ) : (
-                          <Empty
-                            image={Empty.PRESENTED_IMAGE_SIMPLE}
-                            description="本次执行未产生待处理问题数据"
-                          />
-                        )}
-                      </div>
-                    ),
-                  },
-                  {
-                    key: 'LOGS',
-                    label: '原始日志',
-                    children: (
-                      <div className="min-h-[420px] bg-[#fbfcfe] p-4 font-mono text-xs leading-6">
-                        {logs?.lines.length ? (
-                          logs.lines.map((line, index) => (
-                            <div
-                              key={`${line.timestamp}-${line.stage}-${index}`}
-                              className="flex gap-3 border-b border-[#f0f2f5] py-1"
-                            >
-                              <span className="shrink-0 text-[#98a2b3]">
-                                {formatTime(line.timestamp)}
-                              </span>
-                              <span className={`w-12 shrink-0 ${logLevelClass[line.level]}`}>
-                                {line.level}
-                              </span>
-                              <span className="w-20 shrink-0 text-[#667085]">
-                                [{line.stage}]
-                              </span>
-                              <span className="min-w-0 whitespace-pre-wrap break-all text-[#344054]">
-                                {line.message}
-                              </span>
-                            </div>
-                          ))
-                        ) : (
-                          <Empty
-                            image={<FileText size={48} className="text-[#d0d5dd]" />}
-                            description="暂无原始日志"
-                          />
-                        )}
-                      </div>
-                    ),
-                  },
-                ]}
-              />
+  if (!detail) {
+    return (
+      <ConfigProvider theme={BRAND_THEME}>
+        <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f7f8]">
+          <div className="min-w-[360px] rounded-lg bg-white px-6 py-4">
+            <YakEmpty
+              title="执行记录不存在"
+              description="该运行记录可能已被删除，或当前账号无法访问"
+            />
+            <div className="flex justify-center pb-5">
+              <YakButton onClick={() => history.push('/data-quality/execution')}>
+                返回运行记录
+              </YakButton>
             </div>
           </div>
         </div>
-      </Spin>
+      </ConfigProvider>
+    );
+  }
+
+  const issueCount = qualityExecutionIssueCount(detail);
+
+  const overviewContent = (
+    <div className="space-y-3">
+      <div className="grid gap-3 xl:grid-cols-2">
+        <ExecutionSectionCard title="质量概览">
+          <div className="grid grid-cols-2 gap-3 p-5 sm:grid-cols-4 xl:grid-cols-2 2xl:grid-cols-4">
+            <ExecutionMetricTile
+              label="规则数量"
+              value={detail.totalRules}
+              hint="本次参与检测"
+            />
+            <ExecutionMetricTile
+              label="通过规则"
+              value={detail.passedRules}
+              hint="符合质量预期"
+            />
+            <ExecutionMetricTile
+              label="问题规则"
+              value={issueCount}
+              hint="未通过 + 异常"
+              valueClassName={issueCount ? '!text-[#d92d20]' : ''}
+            />
+            <ExecutionMetricTile
+              label="执行耗时"
+              value={formatExecutionDuration(detail.durationMs)}
+              hint="端到端检测耗时"
+            />
+          </div>
+        </ExecutionSectionCard>
+
+        <ExecutionSectionCard title="执行情况">
+          <div className="grid grid-cols-2 gap-x-10 gap-y-6 p-5">
+            <ExecutionInfoItem
+              label="数据源"
+              value={detail.dataSourceName}
+            />
+            <ExecutionInfoItem label="监控对象" value={detail.objectName} />
+            <ExecutionInfoItem
+              label="触发方式"
+              value={qualityExecutionTriggerLabel(detail.triggerType)}
+            />
+            <ExecutionInfoItem
+              label="触发人"
+              value={detail.operator || 'system'}
+            />
+            <ExecutionInfoItem
+              label="入队时间"
+              value={formatExecutionTime(detail.queuedAt)}
+            />
+            <ExecutionInfoItem
+              label="开始时间"
+              value={formatExecutionTime(detail.startedAt)}
+            />
+            <ExecutionInfoItem
+              label="结束时间"
+              value={formatExecutionTime(detail.finishedAt)}
+            />
+            <ExecutionInfoItem label="监控 ID" value={detail.monitorId} />
+          </div>
+        </ExecutionSectionCard>
+      </div>
+
+      <ExecutionSectionCard
+        title="规则检测结果"
+        extra={
+          <span className="text-[12px] text-[#8a8f98]">
+            共 {detail.rules.length} 条规则
+          </span>
+        }
+      >
+        <div className="px-5 pb-5 pt-1">
+          <ExecutionRuleTable records={detail.rules} />
+        </div>
+      </ExecutionSectionCard>
+    </div>
+  );
+
+  const historyContent = (
+    <ExecutionSectionCard
+      title="历史运行记录"
+      extra={
+        <span className="text-[12px] text-[#8a8f98]">
+          最近 {historyRecords.length} 条
+        </span>
+      }
+    >
+      <div className="px-5 pb-5 pt-1">
+        <ExecutionHistoryTable
+          records={historyRecords}
+          loading={historyLoading}
+          currentExecutionNo={detail.executionNo}
+          onOpen={(targetExecutionNo) =>
+            history.push(`/data-quality/execution/${targetExecutionNo}`)
+          }
+        />
+      </div>
+    </ExecutionSectionCard>
+  );
+
+  const issuesContent = (
+    <ExecutionSectionCard
+      title="问题数据处理"
+      extra={
+        <span className="text-[12px] text-[#8a8f98]">
+          {issueRules.length} 条待关注规则
+        </span>
+      }
+    >
+      <div className="px-5 pb-5 pt-1">
+        <ExecutionRuleTable records={issueRules} issueMode />
+      </div>
+    </ExecutionSectionCard>
+  );
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-64px)] bg-[#f7f7f8] text-[#161823]">
+        <div className="mx-auto w-full max-w-[1800px] px-4 pb-8 pt-0 lg:px-5">
+          <ExecutionDetailHeader
+            detail={detail}
+            historyRecords={historyRecords}
+            historyLoading={historyLoading}
+            refreshing={refreshing}
+            onBack={() => history.push('/data-quality/execution')}
+            onRefresh={() => void refresh()}
+            onSelectExecution={(targetExecutionNo) => {
+              if (targetExecutionNo !== detail.executionNo) {
+                history.push(`/data-quality/execution/${targetExecutionNo}`);
+              }
+            }}
+          />
+
+          <div className="px-5 lg:px-6">
+            <YakTab
+              activeKey={activeTab}
+              onChange={(key) => setActiveTab(key as ExecutionDetailTabKey)}
+              items={tabItems}
+            />
+          </div>
+
+          <div className="mt-3">
+            {activeTab === 'overview' ? overviewContent : null}
+            {activeTab === 'history' ? historyContent : null}
+            {activeTab === 'issues' ? issuesContent : null}
+            {activeTab === 'logs' ? (
+              <ExecutionLogPanel
+                logs={logs}
+                loading={logsLoading}
+                onRefresh={() => void loadLogs()}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
     </ConfigProvider>
   );
 };

--- a/yak-ops-ui/src/pages/data-quality/execution/detail/utils.ts
+++ b/yak-ops-ui/src/pages/data-quality/execution/detail/utils.ts
@@ -1,0 +1,43 @@
+import dayjs from 'dayjs';
+
+import type {
+  ExecutionWorkspaceRuleView,
+  ExecutionWorkspaceView,
+} from '../types';
+
+export type ExecutionDetailTabKey =
+  | 'overview'
+  | 'history'
+  | 'issues'
+  | 'logs';
+
+export const formatExecutionTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '--';
+
+export const formatExecutionDuration = (value?: number) => {
+  if (value === undefined || value === null) return '--';
+  if (value < 1000) return `${value} ms`;
+
+  const seconds = Math.floor(value / 1000);
+  if (seconds < 60) return `${seconds} 秒`;
+
+  const minutes = Math.floor(seconds / 60);
+  const restSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes} 分 ${restSeconds} 秒`;
+
+  const hours = Math.floor(minutes / 60);
+  const restMinutes = minutes % 60;
+  return `${hours} 小时 ${restMinutes} 分`;
+};
+
+export const qualityExecutionTriggerLabel = (
+  value?: ExecutionWorkspaceView['triggerType'],
+) => (value === 'SCHEDULE' ? '调度触发' : '手动触发');
+
+export const qualityRuleScopeLabel = (
+  value: ExecutionWorkspaceRuleView['scope'],
+) => (value === 'TABLE' ? '表级' : '字段级');
+
+export const qualityExecutionIssueCount = (
+  record?: Pick<ExecutionWorkspaceView, 'failedRules' | 'errorRules'>,
+) => (record?.failedRules || 0) + (record?.errorRules || 0);


### PR DESCRIPTION
## 背景

当前 `/data-quality/execution/:executionNo` 运行记录详情页信息层级较重：顶部基础信息横向堆叠、左侧常驻 320px 历史运行栏持续占用内容宽度，Tab 内容又紧贴分隔线，导致规则检测结果在常见桌面分辨率下显得拥挤。

本次参考现有离线同步详情页 `/sync/batch-link-up/:id/detail` 的页面结构和视觉节奏，对数据质量运行详情做一次页面级重构。

## 页面结构调整

新的详情页收口为：

```text
灰色页面背景
  └─ 返回运行记录
  └─ 白色 Hero 卡
       ├─ 监控名称 / 执行状态 / 质量结果
       ├─ 执行编号 / 时间 / 触发方式 / 操作人
       ├─ 数据源 -> 监控对象
       └─ 历史运行记录选择器 + 刷新
  └─ 独立 Tab
       ├─ 总览
       ├─ 历史运行
       ├─ 问题数据
       └─ 原始日志
  └─ 卡片化内容区
```

### 1. 移除常驻历史侧栏

原页面左侧固定 320px 历史记录栏删除，改为 Hero 区域的运行记录 Select：

- 保留同一监控历史运行快速切换能力
- Select 支持搜索
- 完整历史记录仍保留在“历史运行”Tab
- 右侧规则结果获得完整内容宽度

### 2. Hero 信息收口

参考离线同步详情页，将原顶部密集信息条改成白色 Hero 卡：

- 监控名称作为主标题
- 执行状态 / 质量结果紧跟标题
- 执行编号降为辅助信息
- 时间、触发方式、操作人统一为次级信息
- 数据源与监控对象使用轻量流向表达
- 异常信息独立使用 soft error 区域展示

### 3. 总览卡片化

“本次运行记录”不再使用两段 `Descriptions` 平铺，而是拆成：

- `质量概览`：规则数量、通过规则、问题规则、执行耗时
- `执行情况`：数据源、监控对象、触发方式、触发人、入队/开始/结束时间、监控 ID
- `规则检测结果`：独立全宽卡片承载规则表格

规则结果不再被左侧历史栏压缩。

### 4. 日志展示统一

原始日志改为与离线同步详情一致的深色 console 风格：

- 时间 / Level / Stage / Message 分层展示
- INFO / WARN / ERROR 保留不同文本提示色
- 独立刷新入口
- 日志加载失败不会阻断详情主体加载

### 5. 表格视觉收口

规则表和历史运行表继续复用 data-quality 现有表格规范：

- 去除额外 `bordered` 视觉噪音
- 保留统一圆角、浅灰表头、hover
- 规则展开区突出错误原因与执行 SQL
- SQL 使用深色代码区域并保留复制能力

## 工程结构

同步按照 `FRONTEND_CODE_STYLE.md` 收口页面职责：

```text
execution/detail/
├── index.tsx                         # Page：页面组装
├── utils.ts                          # 展示格式化纯函数
├── hooks/
│   └── useExecutionDetailPage.ts     # 异步加载 / 历史记录 / 轮询
└── components/
    ├── ExecutionDetailHeader.tsx
    ├── ExecutionSectionCard.tsx
    ├── ExecutionRuleTable.tsx
    ├── ExecutionHistoryTable.tsx
    └── ExecutionLogPanel.tsx
```

`index.tsx` 不再承担大段 columns、历史侧栏、轮询和日志渲染逻辑。

同时详情页由历史 `qualityExecutionWorkspaceApi` envelope 调用切换到已经存在的 `@/services/data-quality` 直接数据接口，不新增 API，也不修改后端契约。

## 兼容性

本 PR 不改变：

- `/data-quality/execution/:executionNo` 路由
- 执行详情接口
- 历史运行记录接口
- 原始日志接口
- 规则检测结果字段及语义
- WAITING / RUNNING 状态 3 秒自动刷新
- 历史执行记录跳转能力
- 问题规则筛选语义（`NOT_PASSED / ERROR`）

## 验证

已完成：

- [x] 分支基于最新 `main`
- [x] compare：1 commit / 8 frontend files / behind 0
- [x] 页面入口从 500+ 行收口，Page / Hook / Components 职责分离
- [x] 复用现有 `@/services/data-quality` 直接数据 Service
- [x] 保留详情、历史、问题规则、日志和自动轮询能力
- [x] 未修改后端、数据库和路由配置

建议本地重点验证：

- [ ] 打开 `/data-quality/execution/:executionNo`，确认 Hero、总览和规则结果正常展示
- [ ] 在顶部 Select 切换不同历史运行记录
- [ ] 验证“历史运行 / 问题数据 / 原始日志”Tab
- [ ] WAITING / RUNNING 记录确认 3 秒自动刷新
- [ ] 展开规则行确认错误信息和执行 SQL
- [ ] 1366 / 1440 / 1920 宽度下确认页面无横向布局挤压

当前连接环境不能执行完整本地 `yarn start / build`，因此不声明可执行构建已通过；PR 保持 Draft，等待本地页面验证。