### PR TITLE
feat(data-quality): 新增质量总览前端页面

### DIFF
--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -88,6 +88,7 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'workflow-instances', mode: 'public', path: '/workflow/instances', title: '工作流实例', component: './workflow/instances', iconKey: 'instance', menuGroup: 'workflow', order: 30 },
   { id: 'workflow-instance-detail', path: '/workflow/instances/:executionId', title: '工作流实例详情', component: './workflow/instances/detail', hidden: true, parentId: 'workflow-instances' },
   { id: 'resource-management', mode: 'one', permission: 'resource:view', path: '/resource-management', title: '文件资源', component: './resource-management', iconKey: 'database', menuGroup: 'resources', order: 10 },
+  { id: 'data-quality-overview', mode: 'any', permissions: ['quality:monitor:read', 'quality:execution:read', 'quality:template:read'], path: '/data-quality/overview', title: '质量总览', component: './data-quality/overview', iconKey: 'monitor', menuGroup: 'data-quality', order: 5 },
   { id: 'data-quality-table-config', mode: 'one', permission: 'quality:monitor:read', path: '/data-quality/table-config', title: '数据表监控', component: './data-quality/table-config', iconKey: 'quality', menuGroup: 'data-quality', order: 10 },
   { id: 'data-quality-monitor-create', path: '/data-quality/monitor/create', title: '新增监控', component: './data-quality/monitor/editor', hidden: true, parentId: 'data-quality-table-config' },
   { id: 'data-quality-monitor-detail', path: '/data-quality/monitor/:id', title: '规则管理', component: './data-quality/monitor/detail', hidden: true, parentId: 'data-quality-table-config' },

--- a/yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx
@@ -1,0 +1,133 @@
+import { YakButton, YakEmpty, YakTab } from '@/components/ui';
+import { CalendarDays, CircleHelp, Download } from 'lucide-react';
+import { Segmented, Tooltip, message } from 'antd';
+import dayjs from 'dayjs';
+import { useMemo, useState } from 'react';
+import type { QualityOverviewTab } from '../constants';
+
+type PeriodKey = 'yesterday' | '7d' | '30d';
+
+interface QualityMetricSectionProps {
+  title: string;
+  subtitle: string;
+  tabs: QualityOverviewTab[];
+  defaultTab: string;
+}
+
+const periodOptions = [
+  { label: '昨天', value: 'yesterday' },
+  { label: '近7天', value: '7d' },
+  { label: '近30天', value: '30d' },
+] as const;
+
+const resolveDateRange = (period: PeriodKey) => {
+  const end = dayjs().subtract(1, 'day');
+  if (period === 'yesterday') return [end, end] as const;
+  if (period === '7d') return [end.subtract(6, 'day'), end] as const;
+  return [end.subtract(29, 'day'), end] as const;
+};
+
+const MetricStrip = ({ tab }: { tab: QualityOverviewTab }) => (
+  <div className="overflow-x-auto border-y border-solid border-[#eceef2]">
+    <div
+      className="grid min-w-max"
+      style={{
+        gridTemplateColumns: `repeat(${tab.metrics.length}, minmax(150px, 1fr))`,
+      }}
+    >
+      {tab.metrics.map((metric, index) => (
+        <div
+          key={metric.label}
+          className={[
+            'min-h-[86px] bg-[#fafafa] px-4 py-3',
+            index ? 'border-l border-solid border-[#eceef2]' : '',
+          ].join(' ')}
+        >
+          <div className="flex items-center gap-1 text-[12px] font-medium text-[#4b5563]">
+            <span>{metric.label}</span>
+            {metric.tooltip ? (
+              <Tooltip title={metric.tooltip}>
+                <CircleHelp size={12} className="text-[#a6acb5]" />
+              </Tooltip>
+            ) : null}
+          </div>
+          <div className="mt-2 text-[18px] font-semibold leading-6 text-[#161823]">
+            {metric.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default function QualityMetricSection({
+  title,
+  subtitle,
+  tabs,
+  defaultTab,
+}: QualityMetricSectionProps) {
+  const [activeTab, setActiveTab] = useState(defaultTab);
+  const [period, setPeriod] = useState<PeriodKey>('yesterday');
+
+  const currentTab = useMemo(
+    () => tabs.find((tab) => tab.key === activeTab) ?? tabs[0],
+    [activeTab, tabs],
+  );
+  const range = resolveDateRange(period);
+  const rangeLabel = `${range[0].format('MM.DD')}-${range[1].format('MM.DD')}`;
+
+  return (
+    <section className="rounded-xl bg-white px-5 pb-6 pt-5 lg:px-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <h2 className="m-0 text-[18px] font-semibold text-[#161823]">
+              {title}
+            </h2>
+            <span className="text-[11px] text-[#98a2b3]">{subtitle}</span>
+          </div>
+          <YakTab
+            activeKey={activeTab}
+            onChange={setActiveTab}
+            className="mt-2 [&_.ant-tabs-nav]:!mb-0"
+            items={tabs.map((tab) => ({ key: tab.key, label: tab.label }))}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Segmented
+            size="small"
+            value={period}
+            options={periodOptions.map((item) => ({ ...item }))}
+            onChange={(value) => setPeriod(value as PeriodKey)}
+            className="!bg-[#f4f5f7]"
+          />
+          <YakButton
+            size="small"
+            icon={<CalendarDays size={14} />}
+            onClick={() => message.info('日期范围选择将在真实数据接入阶段开放')}
+          >
+            {rangeLabel}
+          </YakButton>
+          <YakButton
+            size="small"
+            icon={<Download size={14} />}
+            onClick={() => message.info('导出能力将在后端数据接入后开放')}
+          >
+            导出数据
+          </YakButton>
+        </div>
+      </div>
+
+      <MetricStrip tab={currentTab} />
+
+      <div className="flex min-h-[320px] items-center justify-center border-x border-b border-solid border-[#eceef2] bg-white">
+        <YakEmpty
+          compact
+          title={currentTab.emptyTitle}
+          description={currentTab.emptyDescription}
+        />
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx
@@ -1,0 +1,189 @@
+import { YakButton, YakEmpty } from '@/components/ui';
+import { history } from '@umijs/max';
+import { ArrowRight, CircleHelp } from 'lucide-react';
+import type { QualityRadarMetric } from '../constants';
+
+const RADAR_CENTER = 130;
+const RADAR_RADIUS = 92;
+const RADAR_ANGLES = [-90, -18, 54, 126, 198];
+
+const pointAt = (radius: number, angle: number) => {
+  const radians = (Math.PI / 180) * angle;
+  return [
+    RADAR_CENTER + Math.cos(radians) * radius,
+    RADAR_CENTER + Math.sin(radians) * radius,
+  ];
+};
+
+const polygonPoints = (radius: number) =>
+  RADAR_ANGLES.map((angle) => pointAt(radius, angle).join(',')).join(' ');
+
+const metricPositionClass = [
+  'left-1/2 top-0 -translate-x-1/2',
+  'right-0 top-[40%] -translate-y-1/2',
+  'right-[13%] bottom-[34px]',
+  'left-[13%] bottom-[34px]',
+  'left-0 top-[40%] -translate-y-1/2',
+];
+
+interface QualityRadarOverviewProps {
+  periodText: string;
+  metrics: QualityRadarMetric[];
+}
+
+const QualityMetricCard = ({
+  metric,
+  active,
+  position,
+}: {
+  metric: QualityRadarMetric;
+  active?: boolean;
+  position: string;
+}) => (
+  <div
+    className={[
+      'absolute z-10 min-w-[130px] rounded-lg bg-white px-3 py-2.5 shadow-[0_1px_2px_rgba(16,24,40,0.02)]',
+      active
+        ? 'border-2 border-solid border-[#4f7cff]'
+        : 'border border-solid border-[#e5e7eb]',
+      position,
+    ].join(' ')}
+  >
+    <div className="text-[12px] font-semibold text-[#252a34]">
+      {metric.label} {metric.value}
+    </div>
+    <div className="mt-1 text-[11px] leading-4 text-[#98a2b3]">
+      {metric.caption}
+    </div>
+  </div>
+);
+
+const QualityRadar = () => (
+  <svg
+    viewBox="0 0 260 260"
+    aria-label="数据质量五维雷达图"
+    className="absolute left-1/2 top-[47%] h-[250px] w-[250px] -translate-x-1/2 -translate-y-1/2"
+  >
+    {[1, 0.8, 0.6, 0.4, 0.2].map((ratio) => (
+      <polygon
+        key={ratio}
+        points={polygonPoints(RADAR_RADIUS * ratio)}
+        fill="none"
+        stroke="#e8ebf0"
+        strokeWidth="1"
+      />
+    ))}
+    {RADAR_ANGLES.map((angle) => {
+      const [x, y] = pointAt(RADAR_RADIUS, angle);
+      return (
+        <line
+          key={angle}
+          x1={RADAR_CENTER}
+          y1={RADAR_CENTER}
+          x2={x}
+          y2={y}
+          stroke="#eef0f3"
+          strokeWidth="1"
+        />
+      );
+    })}
+    {RADAR_ANGLES.map((angle) => {
+      const [x, y] = pointAt(RADAR_RADIUS, angle);
+      return (
+        <circle
+          key={`node-${angle}`}
+          cx={x}
+          cy={y}
+          r="4"
+          fill="#fff"
+          stroke="#d9dde4"
+          strokeWidth="1.5"
+        />
+      );
+    })}
+    <circle
+      cx={RADAR_CENTER}
+      cy={RADAR_CENTER}
+      r="4"
+      fill="#fff"
+      stroke="#4f7cff"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+export default function QualityRadarOverview({
+  periodText,
+  metrics,
+}: QualityRadarOverviewProps) {
+  return (
+    <section className="rounded-xl bg-white px-5 py-5 lg:px-6">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <h1 className="m-0 text-[18px] font-semibold text-[#161823]">
+          质量总览
+        </h1>
+        <span className="inline-flex items-center gap-1 text-[11px] text-[#98a2b3]">
+          <CircleHelp size={13} />
+          {periodText}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-8 xl:grid-cols-[520px_minmax(0,1fr)]">
+        <div className="min-w-0 overflow-x-auto">
+          <div className="relative mx-auto h-[350px] min-w-[500px] max-w-[520px]">
+            <QualityRadar />
+            {metrics.map((metric, index) => (
+              <QualityMetricCard
+                key={metric.key}
+                metric={metric}
+                active={index === 0}
+                position={metricPositionClass[index] ?? ''}
+              />
+            ))}
+            <div className="absolute bottom-0 left-1/2 flex -translate-x-1/2 items-center gap-4 whitespace-nowrap text-[11px] text-[#667085]">
+              <span className="flex items-center gap-1">
+                <span className="h-1.5 w-1.5 rounded-full bg-[#4f7cff]" />
+                当前指标
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="h-2 w-2 rounded-sm border border-solid border-[#d8dce3]" />
+                健康目标
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="min-w-0 pt-1">
+          <h2 className="m-0 text-[16px] font-semibold text-[#161823]">
+            质量分析
+          </h2>
+          <div className="mt-3 rounded-lg bg-[#f7f8fa] px-4 py-3 text-[12px] leading-6 text-[#7d8592]">
+            当前暂无质量执行数据。完成监控和规则运行后，这里将结合完整性、唯一性、有效性、准确性和及时性等指标，给出质量表现分析与优化建议。
+          </div>
+
+          <div className="mt-4 flex items-center justify-between gap-4">
+            <h3 className="m-0 text-[15px] font-semibold text-[#161823]">
+              问题贡献 TOP3
+            </h3>
+            <YakButton
+              type="text"
+              size="small"
+              className="!text-[12px] !text-[#667085]"
+              onClick={() => history.push('/data-quality/execution')}
+            >
+              查看运行记录 <ArrowRight size={13} />
+            </YakButton>
+          </div>
+
+          <div className="mt-2 flex min-h-[190px] items-center justify-center rounded-lg bg-[#f7f8fa]">
+            <YakEmpty
+              compact
+              title="近 7 日暂无问题数据"
+              description="完成一次质量监控后，这里将展示问题贡献最高的规则或数据对象"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/data-quality/overview/constants.ts
+++ b/yak-ops-ui/src/pages/data-quality/overview/constants.ts
@@ -1,0 +1,113 @@
+export interface QualityOverviewMetric {
+  label: string;
+  value: string;
+  tooltip?: string;
+}
+
+export interface QualityOverviewTab {
+  key: string;
+  label: string;
+  metrics: QualityOverviewMetric[];
+  emptyTitle: string;
+  emptyDescription: string;
+}
+
+export interface QualityRadarMetric {
+  key: string;
+  label: string;
+  value: string;
+  caption: string;
+}
+
+export const QUALITY_RADAR_METRICS: QualityRadarMetric[] = [
+  { key: 'completeness', label: '完整性', value: '0.0%', caption: '暂无可比数据' },
+  { key: 'uniqueness', label: '唯一性', value: '0.0%', caption: '暂无可比数据' },
+  { key: 'validity', label: '有效性', value: '0.0%', caption: '暂无可比数据' },
+  { key: 'accuracy', label: '准确性', value: '0.0%', caption: '暂无可比数据' },
+  { key: 'timeliness', label: '及时性', value: '0.0%', caption: '暂无可比数据' },
+];
+
+export const QUALITY_EXECUTION_TABS: QualityOverviewTab[] = [
+  {
+    key: 'execution',
+    label: '执行',
+    metrics: [
+      { label: '执行次数', value: '0' },
+      { label: '监控对象', value: '0' },
+      { label: '规则数', value: '0' },
+      { label: '通过规则', value: '0' },
+      { label: '未通过规则', value: '0' },
+      { label: '异常规则', value: '0' },
+      { label: '通过率', value: '0.0%', tooltip: '通过规则数 / 已执行规则数' },
+      { label: '平均耗时', value: '0 ms' },
+      { label: '问题数', value: '0', tooltip: '未通过规则与异常规则合计' },
+    ],
+    emptyTitle: '暂无质量执行数据',
+    emptyDescription: '完成一次质量监控执行后，这里将展示趋势和运行指标',
+  },
+  {
+    key: 'monitor',
+    label: '监控',
+    metrics: [
+      { label: '监控总数', value: '0' },
+      { label: '启用监控', value: '0' },
+      { label: '覆盖数据表', value: '0' },
+      { label: '今日新增', value: '0' },
+      { label: '正常监控', value: '0' },
+      { label: '异常监控', value: '0' },
+      { label: '问题监控', value: '0' },
+      { label: '最近运行', value: '--' },
+    ],
+    emptyTitle: '暂无监控趋势数据',
+    emptyDescription: '创建数据表监控后，这里将展示监控覆盖与运行变化',
+  },
+  {
+    key: 'rule',
+    label: '规则',
+    metrics: [
+      { label: '规则总数', value: '0' },
+      { label: '启用规则', value: '0' },
+      { label: '表级规则', value: '0' },
+      { label: '字段级规则', value: '0' },
+      { label: '系统模板', value: '0' },
+      { label: '自定义模板', value: '0' },
+      { label: '覆盖字段', value: '0' },
+      { label: '平均每表规则', value: '0' },
+    ],
+    emptyTitle: '暂无规则趋势数据',
+    emptyDescription: '配置质量规则后，这里将展示规则覆盖和使用情况',
+  },
+];
+
+export const QUALITY_ISSUE_TABS: QualityOverviewTab[] = [
+  {
+    key: 'issue',
+    label: '问题',
+    metrics: [
+      { label: '问题执行', value: '0' },
+      { label: '未通过规则', value: '0' },
+      { label: '异常规则', value: '0' },
+      { label: '涉及监控', value: '0' },
+      { label: '涉及数据表', value: '0' },
+      { label: '涉及字段', value: '0' },
+      { label: '问题率', value: '0.0%', tooltip: '问题规则数 / 已执行规则数' },
+      { label: '连续异常', value: '0' },
+    ],
+    emptyTitle: '暂无问题数据',
+    emptyDescription: '出现未通过或执行异常的质量规则后，这里将展示问题趋势',
+  },
+  {
+    key: 'dimension',
+    label: '维度',
+    metrics: [
+      { label: '完整性问题', value: '0' },
+      { label: '唯一性问题', value: '0' },
+      { label: '有效性问题', value: '0' },
+      { label: '准确性问题', value: '0' },
+      { label: '及时性问题', value: '0' },
+      { label: '自定义问题', value: '0' },
+    ],
+    emptyTitle: '暂无维度问题分布',
+    emptyDescription: '质量问题产生后，这里将按质量维度展示变化',
+  },
+];

--- a/yak-ops-ui/src/pages/data-quality/overview/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/index.tsx
@@ -1,0 +1,51 @@
+import { BRAND_THEME } from '@/styles/brand';
+import { ConfigProvider } from 'antd';
+import dayjs from 'dayjs';
+import { Info } from 'lucide-react';
+import QualityMetricSection from './components/QualityMetricSection';
+import QualityRadarOverview from './components/QualityRadarOverview';
+import {
+  QUALITY_EXECUTION_TABS,
+  QUALITY_ISSUE_TABS,
+  QUALITY_RADAR_METRICS,
+} from './constants';
+
+export default function DataQualityOverviewPage() {
+  const end = dayjs().subtract(1, 'day');
+  const start = end.subtract(6, 'day');
+  const overviewPeriod = `统计周期：${start.format('YYYY-MM-DD')} 至 ${end.format('YYYY-MM-DD')}（每日 12 点更新）`;
+  const dailyPeriod = `统计周期：${end.format('YYYY-MM-DD')}（每日 10 点更新前一日数据）`;
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-64px)] bg-[#f6f7f9] text-[#161823]">
+        <div className="mx-auto w-full max-w-[1900px] space-y-5 px-4 py-4 lg:px-5">
+          <QualityRadarOverview periodText={overviewPeriod} metrics={QUALITY_RADAR_METRICS} />
+          <QualityMetricSection
+            title="质量检测数据"
+            subtitle={dailyPeriod}
+            tabs={QUALITY_EXECUTION_TABS}
+            defaultTab="execution"
+          />
+          <QualityMetricSection
+            title="问题数据"
+            subtitle={overviewPeriod}
+            tabs={QUALITY_ISSUE_TABS}
+            defaultTab="issue"
+          />
+        </div>
+
+        <button
+          type="button"
+          className="fixed right-3 top-1/2 z-30 hidden -translate-y-1/2 flex-col items-center gap-1 rounded-l-lg border border-r-0 border-solid border-[#eceef2] bg-white px-2 py-3 text-[11px] tracking-[0.16em] text-[#667085] shadow-[0_4px_16px_rgba(16,24,40,0.05)] 2xl:flex"
+          title="当前为前端总览原型，指标口径将在数据接入阶段补充"
+        >
+          <Info size={13} />
+          {'数据指标说明'.split('').map((char, index) => (
+            <span key={`${char}-${index}`}>{char}</span>
+          ))}
+        </button>
+      </div>
+    </ConfigProvider>
+  );
+}


### PR DESCRIPTION
## 背景

参考用户提供的「抖音创作者中心 - 数据中心」页面布局，先实现 Yak Ops 数据质量模块的纯前端总览页，用于确认信息架构、视觉层级和后续接口口径。

本阶段只做前端骨架，不接后端聚合接口，也不伪造真实质量数据。

## 新页面

新增：

```text
/data-quality/overview
```

并在「数据质量」菜单下新增第一项：

```text
质量总览
数据表监控
运行记录
规则模板库
```

总览入口权限采用数据质量现有权限的 `any` 组合：

- `quality:monitor:read`
- `quality:execution:read`
- `quality:template:read`

只要具备任一数据质量读取权限即可看到总览，不新增新的安全权限码。

## 页面复刻思路

整体沿用参考页的三段结构，但全部替换为数据质量语义：

### 1. 质量总览

左侧复刻五维雷达视图：

- 完整性
- 唯一性
- 有效性
- 准确性
- 及时性

当前没有后端总览接口，因此指标统一显示 `0 / 0.0%` 和「暂无可比数据」，不伪造真实值。

右侧对应参考页的分析区域：

- 质量分析说明
- 问题贡献 TOP3
- 无数据占位
- 跳转运行记录入口

### 2. 质量检测数据

复刻参考页「作品数据」区域：

- `执行 / 监控 / 规则` Tab
- `昨天 / 近7天 / 近30天` 时间范围切换
- 日期范围按钮
- 导出数据按钮
- 横向指标带
- 大面积趋势区域空状态

当前指标骨架包括：执行次数、监控对象、规则数、通过规则、未通过规则、异常规则、通过率、平均耗时、问题数等。

### 3. 问题数据

复刻参考页下一段数据卡片：

- `问题 / 维度` Tab
- 问题执行、未通过规则、异常规则、涉及监控、涉及数据表、涉及字段、问题率、连续异常等指标
- 预留后续问题趋势和维度分布图区域

## 交互

当前纯前端阶段保留可交互骨架：

- Tab 可切换
- 时间范围可切换
- 日期范围按钮有明确占位提示
- 导出按钮有明确占位提示
- 问题 TOP3 可跳转 `/data-quality/execution`
- 右侧保留「数据指标说明」悬浮入口

## 工程结构

按照 `FRONTEND_CODE_STYLE.md` 进行模块内聚：

```text
pages/data-quality/overview/
├── index.tsx
├── constants.ts
└── components/
    ├── QualityRadarOverview.tsx
    └── QualityMetricSection.tsx
```

- Page 只负责组装
- 常量和展示数据定义集中在 `constants.ts`
- 雷达总览和指标区分别组件化
- 使用现有 `YakButton / YakTab / YakEmpty`
- 不新增 npm 依赖，雷达图使用轻量 SVG 实现

## 范围说明

本 PR **不包含**：

- 后端质量总览聚合接口
- 真实趋势图数据
- TOP3 聚合查询
- 导出接口
- 指标口径文档
- 数据权限聚合策略

后续可以在这个前端骨架稳定后，再逐项把真实数据接进来。

## 验证

- [x] 基于最新 `main`
- [x] compare：1 commit / 5 frontend files / behind 0
- [x] 仅新增数据质量总览页面和导航入口
- [x] 未修改后端、数据库、Flyway 或现有质量业务接口
- [x] 未新增第三方依赖
- [ ] 本地 `yarn start` 打开 `/data-quality/overview`
- [ ] 验证 1366 / 1440 / 1920 宽度布局
- [ ] 验证 Tab / 时间范围 / 跳转交互

当前连接环境未执行完整前端构建，因此 PR 保持 Draft，等待本地页面确认后再继续接真实数据。