### PR TITLE
fix(ui): 精简请求错误通知并收口单层边框

### DIFF
--- a/yak-ops-ui/src/utils/index.less
+++ b/yak-ops-ui/src/utils/index.less
@@ -1,14 +1,9 @@
 .pretty-notification-wrapper {
   background: transparent !important;
+  border: 0 !important;
+  border-radius: 18px !important;
   box-shadow: none !important;
   padding: 0 !important;
-
-  .ant-notification-notice {
-    background: transparent !important;
-    box-shadow: none !important;
-    padding: 0 !important;
-    border-radius: 18px !important;
-  }
 
   .ant-notification-notice-content {
     background: transparent !important;
@@ -29,6 +24,15 @@
     top: 14px !important;
     right: 14px !important;
   }
+}
+
+// Ant Design wraps every notice in an extra shadow container. The custom card
+// below already owns the border/radius/shadow, so flatten that framework layer
+// to avoid the doubled outline visible around the notification.
+.ant-notification-notice-wrapper:has(> .pretty-notification-wrapper) {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
 }
 
 .pretty-notification-card {

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -148,6 +148,21 @@ const errorHandler = (error: any): Response | undefined => {
       throw error;
     }
 
+    // Proxy errors often include the request URL in the error body already.
+    // Compare without the protocol so `localhost/...` and `http://localhost/...`
+    // are treated as the same endpoint instead of rendering two near-identical lines.
+    const normalizedRequestUrl = url
+      ?.replace(/^https?:\/\//i, "")
+      .toLowerCase();
+    const normalizedErrorText = errorText
+      .replace(/https?:\/\//gi, "")
+      .toLowerCase();
+    const shouldShowRequestUrl = Boolean(
+      url &&
+        normalizedRequestUrl &&
+        !normalizedErrorText.includes(normalizedRequestUrl)
+    );
+
     if (!skipErrorHandler) {
       notifyOnce(`http:${status}:${url || ""}:${errorText}`, {
         type: "error",
@@ -155,7 +170,7 @@ const errorHandler = (error: any): Response | undefined => {
         description: (
           <div>
             <div>{errorText}</div>
-            {url ? (
+            {shouldShowRequestUrl ? (
               <div
                 style={{
                   marginTop: 6,
@@ -168,7 +183,7 @@ const errorHandler = (error: any): Response | undefined => {
             ) : null}
           </div>
         ),
-        meta: status === 403 ? "权限不足" : "服务端返回异常",
+        meta: status === 403 ? "权限不足" : undefined,
         duration: 3.5,
       });
     }


### PR DESCRIPTION
## 改动说明

针对截图里的两个问题做了小范围收口：

- HTTP / 代理异常的错误正文已经包含请求地址时，不再额外重复展示同一个 URL；同时移除普通 HTTP 异常底部重复的“服务端返回异常”文案，403 仍保留“权限不足”提示。
- 去掉 Ant Design Notification 外层自带的边框 / 阴影层，只保留 `pretty-notification-card` 自己的一层 border、radius 和 shadow，避免出现双层边框。

## 影响范围

仅调整统一通知组件相关的请求错误展示与样式，不改请求处理、异常抛出和认证逻辑。

## 验证

- 已检查 `main...fix/notification-content-border` diff，仅修改 `yak-ops-ui/src/utils/request.tsx` 与 `yak-ops-ui/src/utils/index.less`。
- 未在本地启动前端或执行完整 `npm run lint` / 浏览器回归，建议合并前在登录页复现一次 504 proxy error，确认单 URL、单边框效果。