### PR TITLE
fix(data-quality): 修复质量总览聚合 SQL 与错误提示

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
@@ -109,18 +109,25 @@
 
   <select id="selectDimensions" resultType="io.yak.ops.business.quality.dao.model.QualityOverviewPO$DimensionRow">
     SELECT
-      <include refid="DimensionExpression"/> AS dimension,
-      COUNT(*) AS total_count,
-      SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END) AS passed_count,
-      SUM(CASE WHEN re.check_result IN ('NOT_PASSED', 'ERROR') THEN 1 ELSE 0 END) AS issue_count
-    FROM yak_quality_rule_execution re
-    INNER JOIN yak_quality_execution e ON e.id = re.execution_id
-    LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
-    WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
-      AND re.check_result IN ('PASSED', 'NOT_PASSED', 'ERROR')
-    GROUP BY <include refid="DimensionExpression"/>
+      dimension_stats.dimension,
+      dimension_stats.total_count,
+      dimension_stats.passed_count,
+      dimension_stats.issue_count
+    FROM (
+      SELECT
+        <include refid="DimensionExpression"/> AS dimension,
+        COUNT(*) AS total_count,
+        SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END) AS passed_count,
+        SUM(CASE WHEN re.check_result IN ('NOT_PASSED', 'ERROR') THEN 1 ELSE 0 END) AS issue_count
+      FROM yak_quality_rule_execution re
+      INNER JOIN yak_quality_execution e ON e.id = re.execution_id
+      LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
+      WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+        AND re.check_result IN ('PASSED', 'NOT_PASSED', 'ERROR')
+      GROUP BY <include refid="DimensionExpression"/>
+    ) dimension_stats
     ORDER BY
-      CASE <include refid="DimensionExpression"/>
+      CASE dimension_stats.dimension
         WHEN '完整性' THEN 1
         WHEN '准确性' THEN 2
         WHEN '唯一性' THEN 3
@@ -130,7 +137,7 @@
         WHEN '自定义' THEN 7
         ELSE 99
       END,
-      <include refid="DimensionExpression"/>
+      dimension_stats.dimension
   </select>
 
   <select id="selectAnalyticsTrend" resultType="io.yak.ops.business.quality.dao.model.QualityOverviewPO$TrendRow">

--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -44,6 +44,27 @@ describe('API response protocols', () => {
     expect(extractUnknownErrorMessage({}, 'fallback')).toBe('fallback');
   });
 
+  it('does not expose HTML error pages or oversized diagnostics to users', () => {
+    const htmlError =
+      '<!doctype html><html><head><title>HTTP Status 500 - Internal Server Error</title></head><body>stack trace</body></html>';
+
+    expect(extractUnknownErrorMessage(htmlError, '服务器发生错误')).toBe(
+      '服务器发生错误',
+    );
+    expect(
+      extractUnknownErrorMessage({ message: htmlError }, '请求失败'),
+    ).toBe('请求失败');
+    expect(
+      extractErrorMessage(
+        { code: 500, msg: htmlError, message: '数据查询失败' },
+        '操作失败',
+      ),
+    ).toBe('数据查询失败');
+    expect(extractUnknownErrorMessage('x'.repeat(300))).toBe(
+      `${'x'.repeat(239)}…`,
+    );
+  });
+
   it('recognizes authentication failures without treating forbidden as anonymous', () => {
     expect(isUnauthenticatedResponse({ code: 401 }, 'yak-ops')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 401 }, 'security')).toBe(true);

--- a/yak-ops-ui/src/services/http/response.ts
+++ b/yak-ops-ui/src/services/http/response.ts
@@ -33,6 +33,19 @@ const unauthenticatedMessages = new Set([
   'LOGIN_EXPIRED',
 ]);
 
+const MAX_ERROR_MESSAGE_LENGTH = 240;
+const htmlDocumentPattern = /<(?:!doctype\s+html|html|head|body|title|style|script)\b/i;
+
+const normalizeDisplayErrorText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+
+  const text = value.trim().replace(/\s+/g, ' ');
+  if (!text || htmlDocumentPattern.test(text)) return undefined;
+  if (text.length <= MAX_ERROR_MESSAGE_LENGTH) return text;
+
+  return `${text.slice(0, MAX_ERROR_MESSAGE_LENGTH - 1).trimEnd()}…`;
+};
+
 const normalizeUnauthenticatedMessage = (message: string) =>
   message.trim().toUpperCase().replace(/[\s-]+/g, '_');
 
@@ -54,12 +67,15 @@ export const isSuccessfulResponse = (
 export const extractErrorMessage = (
   response: Partial<ApiResponse> | null | undefined,
   fallback = '操作失败',
-): string => response?.msg?.trim() || response?.message?.trim() || fallback;
+): string =>
+  normalizeDisplayErrorText(response?.msg) ||
+  normalizeDisplayErrorText(response?.message) ||
+  fallback;
 
 /**
- * Extract a useful server error from both the standard API envelope and common
- * HTTP error payloads. This prevents a real backend reason from being replaced
- * by a generic 4xx/5xx status description in the request error handler.
+ * Extract a user-facing server error from both the standard API envelope and
+ * common HTTP error payloads. HTML error pages and oversized diagnostics are
+ * transport details, not UI copy, so they are filtered or shortened here.
  */
 export const extractUnknownErrorMessage = (
   payload: unknown,
@@ -69,17 +85,14 @@ export const extractUnknownErrorMessage = (
     return extractErrorMessage(payload, fallback);
   }
 
-  if (typeof payload === 'string' && payload.trim()) {
-    return payload.trim();
-  }
+  const directMessage = normalizeDisplayErrorText(payload);
+  if (directMessage) return directMessage;
 
   if (payload && typeof payload === 'object') {
     const source = payload as Record<string, unknown>;
     for (const key of ['msg', 'message', 'error', 'detail']) {
-      const value = source[key];
-      if (typeof value === 'string' && value.trim()) {
-        return value.trim();
-      }
+      const message = normalizeDisplayErrorText(source[key]);
+      if (message) return message;
     }
   }
 

--- a/yak-ops-ui/src/utils/request.tsx
+++ b/yak-ops-ui/src/utils/request.tsx
@@ -30,6 +30,30 @@ const codeMessage: Record<number, string> = {
   504: "网关超时。",
 };
 
+const getHttpErrorPresentation = (status: number) => {
+  if (status >= 500) {
+    return {
+      title: "服务暂时不可用",
+      meta: `HTTP ${status} · 请稍后重试`,
+    };
+  }
+
+  switch (status) {
+    case 400:
+      return { title: "请求参数有误", meta: "请检查输入内容" };
+    case 403:
+      return { title: "无权访问", meta: "权限不足" };
+    case 404:
+      return { title: "资源不存在", meta: "请确认资源仍然存在" };
+    case 405:
+      return { title: "请求方式不支持", meta: "请刷新页面后重试" };
+    case 422:
+      return { title: "数据校验未通过", meta: "请检查输入内容" };
+    default:
+      return { title: "请求失败", meta: `HTTP ${status}` };
+  }
+};
+
 export class BizError extends Error {
   code?: number;
   response?: ApiResponse<any>;
@@ -131,7 +155,8 @@ const errorHandler = (error: any): Response | undefined => {
   const skipErrorHandler = shouldSkipErrorHandler(error);
 
   // HTTP 异常。umi-request 会把 JSON 错误体放在 error.data 中，优先展示
-  // 后端真实 msg/message，而不是用通用 HTTP 状态文案覆盖它。
+  // 后端真实 msg/message；HTML 错误页等 transport diagnostics 会在
+  // services/http/response 边界被过滤，避免技术细节直接进入用户通知。
   if (response?.status) {
     const { status, url } = response;
     const protocol = protocolForUrl(url);
@@ -148,42 +173,13 @@ const errorHandler = (error: any): Response | undefined => {
       throw error;
     }
 
-    // Proxy errors often include the request URL in the error body already.
-    // Compare without the protocol so `localhost/...` and `http://localhost/...`
-    // are treated as the same endpoint instead of rendering two near-identical lines.
-    const normalizedRequestUrl = url
-      ?.replace(/^https?:\/\//i, "")
-      .toLowerCase();
-    const normalizedErrorText = errorText
-      .replace(/https?:\/\//gi, "")
-      .toLowerCase();
-    const shouldShowRequestUrl = Boolean(
-      url &&
-        normalizedRequestUrl &&
-        !normalizedErrorText.includes(normalizedRequestUrl)
-    );
-
     if (!skipErrorHandler) {
+      const presentation = getHttpErrorPresentation(status);
       notifyOnce(`http:${status}:${url || ""}:${errorText}`, {
         type: "error",
-        title: `请求错误 ${status}`,
-        description: (
-          <div>
-            <div>{errorText}</div>
-            {shouldShowRequestUrl ? (
-              <div
-                style={{
-                  marginTop: 6,
-                  fontSize: 12,
-                  color: "rgba(23, 32, 51, 0.45)",
-                }}
-              >
-                {url}
-              </div>
-            ) : null}
-          </div>
-        ),
-        meta: status === 403 ? "权限不足" : undefined,
+        title: presentation.title,
+        description: errorText,
+        meta: presentation.meta,
         duration: 3.5,
       });
     }


### PR DESCRIPTION
## 背景

质量总览接入真实数据后，在 MySQL 8 开启 `ONLY_FULL_GROUP_BY` 时，维度聚合查询会返回 500；同时前端把 Tomcat HTML 错误页和请求 URL 直接展示在通知中，用户体验较差。

## 根因

`QualityOverviewMapper.selectDimensions` 在 `GROUP BY` 之后的 `ORDER BY` 再次展开 `r.quality_dimension` / `re.rule_type` 原始表达式。MySQL `ONLY_FULL_GROUP_BY` 会把它判定为未按分组结果排序，从而抛出 `SQLSyntaxErrorException`。

## 修复

### 后端

- 维度统计先在派生表中完成 `dimension` 聚合；
- 外层只基于 `dimension_stats.dimension` 排序；
- 不修改统计口径，不关闭 `ONLY_FULL_GROUP_BY`，不调整数据库全局配置。

### 前端

- HTTP 错误解析边界过滤 HTML 错误页，不再把 `<!doctype html>...` 直接展示给用户；
- 超长服务端诊断信息限制为 240 字符；
- 正常 JSON `msg/message` 仍优先展示；
- 5xx 通知改成「服务暂时不可用」，不再在卡片中展示技术 URL；
- 400/403/404/405/422 使用更贴近用户语义的标题和提示；
- 新增响应解析测试，覆盖 HTML error page、HTML envelope message 和超长文本。

## 边界

- 不修改 Data Quality 执行状态、规则语义或接口 JSON contract；
- 不新增 Flyway；
- 不修改 MySQL `sql_mode`；
- 不处理日志中 Mapper 重复扫描等既有 warning；
- Sa-Token `/error` 二次异常是原始 500 转发后的连锁现象，本 PR 通过修复根因和避免前端泄露 HTML 处理当前问题，不扩大到 Security Framework。

## 验证建议

- [ ] 本地 MySQL 8 保持 `ONLY_FULL_GROUP_BY`，访问 `/data-quality/overview`
- [ ] 验证昨天 / 近7天 / 近30天均可正常返回
- [ ] 验证维度雷达与问题维度区域正常加载
- [ ] 人为制造 500，前端只显示友好短提示，不展示 HTML / URL
- [ ] `yarn test response.test.ts`
- [ ] Data Quality 定向 Maven 测试

当前分支基于最新 `main`，保持 Draft，建议本地完成 MySQL + 浏览器联调后再转 Ready。