### PR TITLE
refactor(data-quality): 细化质量雷达卡片交互样式

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx
@@ -62,10 +62,10 @@ const QualityMetricCard = ({
     onClick={onActivate}
     className={[
       'absolute z-10 min-w-[136px] rounded-lg bg-white px-3 py-2.5 text-left',
-      'transition-[background-color,border-color] duration-150 hover:bg-[var(--yak-brand-color-soft)]',
+      'transition-[border-color] duration-150',
       'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--yak-brand-color-outline)]',
       active
-        ? 'border-2 border-solid border-[var(--yak-brand-color)]'
+        ? 'border border-solid border-[var(--yak-brand-color)]'
         : 'border border-solid border-[#e5e7eb] hover:border-[var(--yak-brand-color-border)]',
       position,
     ].join(' ')}
@@ -174,8 +174,8 @@ const QualityRadar = ({
                 cy={dataY}
                 r={3.5}
                 fill="#fff"
-                stroke="var(--yak-brand-color)"
-                strokeWidth="2"
+                stroke="#d9dde4"
+                strokeWidth="1.5"
               />
             ) : null}
           </g>


### PR DESCRIPTION
## 改动说明

按最新截图继续收口质量总览左上角雷达区域：

- 雷达数据点不再使用品牌红描边，统一回到中性灰，避免 100% 节点出现过强红点。
- 当前选中维度卡片的品牌色边框从 2px 调整为 1px，降低视觉重量。
- hover 不再填充浅红背景，只保留边框颜色变化，交互更轻、更干净。

## 影响范围

仅修改 `yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx`，不涉及接口、统计逻辑或其它页面。

## 验证建议

建议本地重点确认：
- 100% 雷达节点不再显示红点；
- 选中卡片仅 1px 品牌色边框；
- hover 时背景保持白色，仅 border 轻微变化；
- 点击切换维度行为保持不变。

当前未执行完整 `npm run lint` / `npm run tsc` 或浏览器回归。