### PR TITLE
refactor(data-quality): 对齐总览筛选控件样式

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx
@@ -2,7 +2,7 @@ import { YakButton, YakTab } from '@/components/ui';
 import type { QualityOverviewView } from '@/services/data-quality';
 import { DatePicker, Segmented, Spin, Tooltip, message } from 'antd';
 import dayjs from 'dayjs';
-import { CircleHelp, Download, RefreshCw } from 'lucide-react';
+import { CalendarDays, CircleHelp, Download } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { QualityOverviewTabDefinition } from '../constants';
 import {
@@ -28,7 +28,6 @@ interface QualityMetricSectionProps {
   overview?: QualityOverviewView;
   loading?: boolean;
   onRangeChange: (range: OverviewDateRange) => void;
-  onRefresh: () => void;
 }
 
 const periodOptions = [
@@ -39,6 +38,9 @@ const periodOptions = [
 
 const presetForRange = (range: OverviewDateRange): OverviewPeriodKey | undefined =>
   periodOptions.find((item) => rangeKey(resolvePresetRange(item.value)) === rangeKey(range))?.value;
+
+const compactRangeText = (range: OverviewDateRange) =>
+  `${dayjs(range.startDate).format('MM.DD')}-${dayjs(range.endDate).format('MM.DD')}`;
 
 const MetricStrip = ({ metrics }: { metrics: ReturnType<typeof buildMetrics> }) => (
   <div className="overflow-x-auto border-y border-solid border-[#eceef2]">
@@ -109,7 +111,6 @@ export default function QualityMetricSection({
   overview,
   loading = false,
   onRangeChange,
-  onRefresh,
 }: QualityMetricSectionProps) {
   const [activeTab, setActiveTab] = useState(defaultTab);
   const metrics = useMemo(
@@ -140,40 +141,48 @@ export default function QualityMetricSection({
             value={selectedPreset}
             options={periodOptions.map((item) => ({ ...item }))}
             onChange={(value) => onRangeChange(resolvePresetRange(value as OverviewPeriodKey))}
-            className="!bg-[#f4f5f7]"
+            className={[
+              '!h-8 !rounded-lg !bg-[#f3f4f6] !p-1',
+              '[&_.ant-segmented-group]:!h-6 [&_.ant-segmented-group]:!gap-1',
+              '[&_.ant-segmented-item]:!min-w-[68px] [&_.ant-segmented-item]:!rounded-md [&_.ant-segmented-item]:!text-[13px] [&_.ant-segmented-item]:!font-medium [&_.ant-segmented-item]:!text-[#667085]',
+              '[&_.ant-segmented-item-label]:!min-h-0 [&_.ant-segmented-item-label]:!px-3 [&_.ant-segmented-item-label]:!leading-6',
+              '[&_.ant-segmented-thumb]:!rounded-md [&_.ant-segmented-thumb]:!bg-white [&_.ant-segmented-thumb]:!shadow-[0_1px_3px_rgba(16,24,40,0.08)]',
+              '[&_.ant-segmented-item-selected]:!bg-white [&_.ant-segmented-item-selected]:!font-semibold [&_.ant-segmented-item-selected]:!text-[#161823] [&_.ant-segmented-item-selected]:!shadow-[0_1px_3px_rgba(16,24,40,0.08)]',
+            ].join(' ')}
           />
-          <RangePicker
-            size="small"
-            value={toPickerRange(range)}
-            format="MM.DD"
-            allowClear={false}
-            disabledDate={(current) => current.isAfter(dayjs().subtract(1, 'day'), 'day')}
-            onChange={(value) => {
-              const start = value?.[0];
-              const end = value?.[1];
-              if (!start || !end) return;
-              if (end.diff(start, 'day') > 89) {
-                message.warning('质量总览单次最多查询 90 天');
-                return;
-              }
-              onRangeChange({
-                startDate: start.format('YYYY-MM-DD'),
-                endDate: end.format('YYYY-MM-DD'),
-              });
-            }}
-            className="w-[150px]"
-          />
-          <YakButton
-            size="small"
-            icon={<RefreshCw size={14} />}
-            loading={loading}
-            onClick={onRefresh}
-          >
-            刷新
-          </YakButton>
+
+          <div className="group relative h-8 w-[142px] shrink-0">
+            <div className="pointer-events-none flex h-8 items-center justify-center gap-2 rounded-lg bg-[#f3f4f6] px-3 text-[13px] font-medium text-[#161823] transition-colors group-hover:bg-[#e9eaed] group-focus-within:ring-2 group-focus-within:ring-[rgba(254,44,85,0.12)]">
+              <CalendarDays size={15} strokeWidth={1.8} />
+              <span>{compactRangeText(range)}</span>
+            </div>
+            <RangePicker
+              size="small"
+              value={toPickerRange(range)}
+              format="MM.DD"
+              allowClear={false}
+              disabledDate={(current) => current.isAfter(dayjs().subtract(1, 'day'), 'day')}
+              onChange={(value) => {
+                const start = value?.[0];
+                const end = value?.[1];
+                if (!start || !end) return;
+                if (end.diff(start, 'day') > 89) {
+                  message.warning('质量总览单次最多查询 90 天');
+                  return;
+                }
+                onRangeChange({
+                  startDate: start.format('YYYY-MM-DD'),
+                  endDate: end.format('YYYY-MM-DD'),
+                });
+              }}
+              className="!absolute !inset-0 !h-8 !w-full !cursor-pointer !opacity-0"
+            />
+          </div>
+
           <YakButton
             size="small"
             icon={<Download size={14} />}
+            className="!h-8 !rounded-lg !border-0 !bg-[#f3f4f6] !px-3 !text-[13px] !font-semibold !text-[#161823] !shadow-none hover:!bg-[#e9eaed]"
             onClick={() => {
               if (!overview) {
                 message.info('当前统计周期暂无可导出的质量数据');

--- a/yak-ops-ui/src/pages/data-quality/overview/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/index.tsx
@@ -35,7 +35,6 @@ export default function DataQualityOverviewPage() {
             overview={overview.qualityOverview}
             loading={overview.qualityLoading}
             onRangeChange={overview.setQualityRange}
-            onRefresh={() => void overview.refresh(overview.qualityRange)}
           />
 
           <QualityMetricSection
@@ -47,7 +46,6 @@ export default function DataQualityOverviewPage() {
             overview={overview.issueOverview}
             loading={overview.issueLoading}
             onRangeChange={overview.setIssueRange}
-            onRefresh={() => void overview.refresh(overview.issueRange)}
           />
         </div>
 


### PR DESCRIPTION
## 改动说明

按最新截图继续收口数据质量总览中的筛选区域，目标是让「质量检测数据」和「问题数据」两张 card 的右上角控件与参考图保持同一套视觉语言：

- 「昨天 / 近7天 / 近30天」改成紧凑的浅灰分段容器，选中项使用白底、较高字重和轻微阴影。
- 日期范围改成独立的浅灰按钮式外观，左侧日历图标，文案收口为 `MM.DD-MM.DD`，继续保留原有日期选择能力和 90 天限制。
- 「导出数据」改成同尺寸、同圆角、同浅灰背景的紧凑按钮，和日期控件形成统一节奏。
- 删除「刷新」按钮；日期 / 快捷周期变化后仍沿用现有 range 状态驱动的数据刷新逻辑。
- 以上样式通过共享 `QualityMetricSection` 一次性作用到「质量检测数据」与「问题数据」两张 card。

## 影响范围

仅修改数据质量总览前端：

- `yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx`
- `yak-ops-ui/src/pages/data-quality/overview/index.tsx`

不涉及后端接口、统计口径和趋势图数据逻辑。

## 验证建议

合并前建议重点确认：

- 两张 card 的筛选区样式一致；
- 近 7 天 / 近 30 天等快捷切换仍正常；
- 自定义日期弹层仍可正常选择并限制最多 90 天；
- 删除刷新按钮后，切换时间范围仍会正常重新查询；
- CSV 导出仍可正常工作。

当前未执行完整 `npm run lint` / `npm run tsc` 或浏览器回归。