### PR TITLE
fix(data-quality): 补齐总览指标区左右边框

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx
@@ -43,7 +43,7 @@ const compactRangeText = (range: OverviewDateRange) =>
   `${dayjs(range.startDate).format('MM.DD')}-${dayjs(range.endDate).format('MM.DD')}`;
 
 const MetricStrip = ({ metrics }: { metrics: ReturnType<typeof buildMetrics> }) => (
-  <div className="overflow-x-auto border-y border-solid border-[#eceef2]">
+  <div className="overflow-x-auto border border-solid border-[#eceef2]">
     <div
       className="grid min-w-max"
       style={{ gridTemplateColumns: `repeat(${metrics.length}, minmax(150px, 1fr))` }}


### PR DESCRIPTION
## 改动说明

按最新截图继续补齐质量总览卡片里的边框细节：

- `MetricStrip` 原来只保留上下边框，导致指标条左右两侧与下方趋势图外框没有完全闭合。
- 现在改为完整 `1px` 外框，左右边框与下方趋势图的 `border-x / border-b` 连成一个连续框体。
- 不改指标列之间的分隔线，也不改趋势图、筛选、Tab、数据逻辑。
- 因为 `QualityMetricSection` 为「质量检测数据」和「问题数据」共用，所以两张 card 会同步生效。

## 影响范围

仅修改：

- `yak-ops-ui/src/pages/data-quality/overview/components/QualityMetricSection.tsx`

## 验证建议

合并前本地确认：

- 指标条左侧 / 右侧边框均补齐；
- 与下方趋势图边框衔接自然，没有双线；
- 「质量检测数据」和「问题数据」两张 card 的边框表现一致。

当前未执行完整 `npm run lint` / `npm run tsc` 或浏览器回归。