### PR TITLE
refactor(data-quality): 优化指标说明悬浮交互

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/overview/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/index.tsx
@@ -1,7 +1,6 @@
-import { BRAND_THEME } from '@/styles/brand';
-import { ConfigProvider, Drawer } from 'antd';
+import { BRAND_CSS_VARIABLES, BRAND_THEME } from '@/styles/brand';
+import { ConfigProvider, Popover } from 'antd';
 import { Info } from 'lucide-react';
-import { useState } from 'react';
 import QualityMetricSection from './components/QualityMetricSection';
 import QualityRadarOverview from './components/QualityRadarOverview';
 import {
@@ -12,13 +11,51 @@ import {
 import { useQualityOverviewPage } from './hooks/useQualityOverviewPage';
 import { formatPeriodText } from './utils';
 
+const MetricExplanationPanel = () => (
+  <div className="w-[420px] max-w-[calc(100vw-88px)] overflow-hidden rounded-xl bg-white">
+    <div className="flex items-center gap-3 border-b border-solid border-[#eef0f2] px-4 py-3.5">
+      <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-[var(--yak-brand-color-soft)] text-[var(--yak-brand-color)]">
+        <Info size={15} />
+      </span>
+      <div className="min-w-0">
+        <div className="text-[14px] font-semibold text-[#161823]">数据指标说明</div>
+        <div className="mt-0.5 text-[11px] text-[#98a2b3]">质量总览统计口径与指标含义</div>
+      </div>
+    </div>
+
+    <div className="max-h-[min(560px,68vh)] overflow-y-auto p-4">
+      <div className="rounded-lg bg-[#f7f8fa] px-3.5 py-3 text-[11px] leading-5 text-[#667085]">
+        默认统计到昨天，支持昨天、近 7 天、近 30 天及自定义日期范围；单次查询最长 90 天。
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-2.5">
+        {QUALITY_METRIC_EXPLANATIONS.map(([label, description]) => (
+          <div
+            key={label}
+            className="rounded-lg border border-solid border-[#eceef2] bg-white px-3 py-2.5"
+          >
+            <div className="text-[12px] font-semibold text-[#30343b]">{label}</div>
+            <div className="mt-1 text-[11px] leading-[18px] text-[#8a9099]">{description}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-3 rounded-lg border border-solid border-[#eceef2] px-3.5 py-3 text-[11px] leading-5 text-[#98a2b3]">
+        雷达图仅对已经产生规则执行事实的质量维度计算通过率；没有执行事实的维度显示为“--”，不会用 0% 冒充真实质量得分。
+      </div>
+    </div>
+  </div>
+);
+
 export default function DataQualityOverviewPage() {
   const overview = useQualityOverviewPage();
-  const [explanationOpen, setExplanationOpen] = useState(false);
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
-      <div className="min-h-[calc(100vh-64px)] bg-[#f6f7f9] text-[#161823]">
+      <div
+        className="min-h-[calc(100vh-64px)] bg-[#f6f7f9] text-[#161823]"
+        style={BRAND_CSS_VARIABLES}
+      >
         <div className="mx-auto w-full max-w-[1900px] space-y-5 px-4 py-4 lg:px-5">
           <QualityRadarOverview
             periodText={formatPeriodText(overview.radarRange)}
@@ -49,39 +86,26 @@ export default function DataQualityOverviewPage() {
           />
         </div>
 
-        <button
-          type="button"
-          onClick={() => setExplanationOpen(true)}
-          className="fixed right-3 top-1/2 z-30 hidden -translate-y-1/2 flex-col items-center gap-1 rounded-l-lg border border-r-0 border-solid border-[#eceef2] bg-white px-2 py-3 text-[11px] tracking-[0.16em] text-[#667085] shadow-[0_4px_16px_rgba(16,24,40,0.05)] transition-colors hover:text-[#30343b] 2xl:flex"
-          title="查看数据质量总览指标口径"
+        <Popover
+          trigger="hover"
+          placement="leftTop"
+          arrow={false}
+          mouseEnterDelay={0.12}
+          mouseLeaveDelay={0.15}
+          content={<MetricExplanationPanel />}
+          overlayInnerStyle={{ padding: 0, borderRadius: 12 }}
         >
-          <Info size={13} />
-          {'数据指标说明'.split('').map((char, index) => (
-            <span key={`${char}-${index}`}>{char}</span>
-          ))}
-        </button>
-
-        <Drawer
-          open={explanationOpen}
-          title="数据指标说明"
-          width={420}
-          onClose={() => setExplanationOpen(false)}
-        >
-          <div className="rounded-lg bg-[#f7f8fa] px-4 py-3 text-[12px] leading-6 text-[#667085]">
-            质量总览基于数据质量执行事实进行聚合。默认统计到昨天，支持昨天、近 7 天、近 30 天及自定义日期范围；单次查询最长 90 天。
-          </div>
-          <div className="mt-4 divide-y divide-[#eef0f2]">
-            {QUALITY_METRIC_EXPLANATIONS.map(([label, description]) => (
-              <div key={label} className="py-3">
-                <div className="text-[13px] font-medium text-[#30343b]">{label}</div>
-                <div className="mt-1 text-[12px] leading-5 text-[#8a9099]">{description}</div>
-              </div>
-            ))}
-          </div>
-          <div className="mt-4 rounded-lg border border-solid border-[#eceef2] px-4 py-3 text-[11px] leading-5 text-[#98a2b3]">
-            雷达图仅对已经产生规则执行事实的质量维度计算通过率。没有执行事实的维度显示为“--”，不会用 0% 冒充真实质量得分。
-          </div>
-        </Drawer>
+          <button
+            type="button"
+            aria-label="查看数据指标说明"
+            className="fixed right-0 top-[42%] z-30 hidden -translate-y-1/2 flex-col items-center gap-1.5 rounded-l-lg border border-r-0 border-solid border-[#eceef2] bg-white px-2 py-3 text-[11px] font-medium text-[#667085] shadow-[0_4px_16px_rgba(16,24,40,0.05)] transition-[border-color,color,background-color] hover:border-[var(--yak-brand-color-border)] hover:bg-[#fffafb] hover:text-[var(--yak-brand-color)] 2xl:flex"
+          >
+            <Info size={13} />
+            <span style={{ writingMode: 'vertical-rl' }} className="tracking-[0.12em]">
+              数据指标说明
+            </span>
+          </button>
+        </Popover>
       </div>
     </ConfigProvider>
   );


### PR DESCRIPTION
## 改动说明

按最新截图继续优化右侧「数据指标说明」的展示方式：

- 将原来的点击后打开 Drawer 改为 hover 触发的 Popover，更符合轻量说明场景。
- 右侧入口改成更窄的固定悬浮条，整体上移，避免一直占据页面正中区域。
- 文案使用真正的纵向排版，不再逐字拆开堆叠。
- Popover 改成白底轻量卡片，不再使用大面积深色块遮挡页面内容。
- 指标说明采用两列卡片布局，8 个指标在有限高度内即可快速扫读；内容过高时内部滚动。
- 补充统计周期说明和雷达图口径说明，同时复用 Yak Ops 品牌色作为轻量强调。

## 影响范围

仅修改：

- `yak-ops-ui/src/pages/data-quality/overview/index.tsx`

不涉及接口、统计逻辑、趋势图、筛选和导出。

## 验证建议

建议本地重点确认：

- 鼠标 hover 右侧「数据指标说明」后浮层稳定出现，移开后自然消失；
- 浮层位于入口左侧，不遮挡右侧悬浮控件；
- 两列指标说明在 2K / 1080P 下都能正常阅读；
- 页面滚动时右侧入口位置保持稳定；
- Drawer 不再出现。

当前未执行完整 `npm run lint` / `npm run tsc` 或浏览器回归。