### PR TITLE
refactor(data-quality): 使用 YakOpsEmpty 优化问题贡献空状态

### DIFF
--- a/yak-ops-ui/src/components/YakOpsEmpty/index.tsx
+++ b/yak-ops-ui/src/components/YakOpsEmpty/index.tsx
@@ -6,7 +6,7 @@ export interface YakOpsEmptyProps
   width?: number | string;
   /** 插画高度 */
   height?: number | string;
-  /** 品牌主色 */
+  /** 唯一强调色 */
   primaryColor?: string;
   /** 无障碍标题 */
   title?: string;
@@ -14,28 +14,33 @@ export interface YakOpsEmptyProps
   description?: string;
 }
 
+/**
+ * Yak Ops 空状态插画。
+ *
+ * 只保留黑灰线稿与一个强调色问号，避免空状态本身抢占页面视觉焦点。
+ */
 const YakOpsEmpty: React.FC<YakOpsEmptyProps> = ({
-  width = 240,
-  height = 190,
-  primaryColor = '#ff527e',
+  width = 220,
+  height = 160,
+  primaryColor = 'var(--yak-brand-color, #fe2c55)',
   title = 'Yak Ops 暂无数据',
-  description = '一只小牦牛拿着扳手，正在检查空的服务器机柜',
+  description = '一只小牦牛蹲在打开的服务器抽屉旁，正在查看为什么没有数据',
   style,
   ...props
 }) => {
   const titleId = useId();
   const descriptionId = useId();
 
-  const lineColor = '#515151';
-  const mutedColor = '#c6cacd';
-  const panelColor = '#e8eaec';
-  const primarySoftColor = '#fff0f4';
+  const lineColor = '#55585f';
+  const secondaryLineColor = '#9a9da3';
+  const lightLineColor = '#d9dadd';
+  const softFill = '#f7f7f8';
 
   return (
     <svg
       width={width}
       height={height}
-      viewBox="0 0 240 190"
+      viewBox="0 0 220 160"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
@@ -47,304 +52,153 @@ const YakOpsEmpty: React.FC<YakOpsEmptyProps> = ({
       <title id={titleId}>{title}</title>
       <desc id={descriptionId}>{description}</desc>
 
-      <rect width="240" height="190" fill="transparent" />
-
-      {/* 背景装饰 */}
-      <circle cx="20" cy="101" r="3" fill={primarySoftColor} />
-      <circle cx="220" cy="74" r="3" fill={mutedColor} />
-      <circle cx="208" cy="31" r="2" fill={primaryColor} opacity="0.45" />
-
-      {/* 疑问气泡 */}
-      <circle cx="194" cy="45" r="27" fill={primarySoftColor} />
       <path
-        d="M190.5 44.5C190.5 40.9 192.8 38.5 196.3 38.5C199.7 38.5 202 40.6 202 43.4C202 45.8 200.7 47.1 198.5 48.5C196.4 49.8 195.5 51 195.5 53"
-        stroke={primaryColor}
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <circle cx="195.5" cy="59" r="2.5" fill={primaryColor} />
-
-      {/* 地面阴影 */}
-      <ellipse cx="124" cy="174" rx="91" ry="7" fill="#000" opacity="0.055" />
-
-      {/* 左牛角 */}
-      <path
-        d="M65 54C54 54 48 47 49 38C53 44 58 46 66 45"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-
-      {/* 右牛角 */}
-      <path
-        d="M91 54C102 54 108 47 107 38C103 44 98 46 90 45"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-
-      {/* 耳朵 */}
-      <path
-        d="M64 58C57 54 52 57 54 62C56 66 61 66 66 64"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M92 58C99 54 104 57 102 62C100 66 95 66 90 64"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
-
-      {/* 头部 */}
-      <path
-        d="M61 56C64 49 70 46 78 46C86 46 92 49 95 56L92 79C91 88 86 93 78 93C70 93 65 88 64 79L61 56Z"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
-
-      {/* 额头毛发 */}
-      <path
-        d="M68 50L72 56L77 49L81 56L87 50"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-
-      {/* 眼睛 */}
-      <circle cx="71" cy="66" r="2" fill={lineColor} />
-      <circle cx="85" cy="66" r="2" fill={lineColor} />
-
-      {/* 鼻口 */}
-      <ellipse
-        cx="78"
-        cy="78"
-        rx="11"
-        ry="8"
-        fill={panelColor}
-        stroke={lineColor}
-        strokeWidth="2"
-      />
-      <circle cx="74" cy="77" r="1.3" fill={lineColor} />
-      <circle cx="82" cy="77" r="1.3" fill={lineColor} />
-      <path
-        d="M75 82C77 84 79 84 81 82"
-        stroke={lineColor}
+        d="M33 139H189"
+        stroke={lightLineColor}
         strokeWidth="1.5"
         strokeLinecap="round"
       />
 
-      {/* 身体 */}
+      {/* 小牦牛：蹲下查看抽屉 */}
       <path
-        d="M61 93C66 88 71 87 78 87C88 87 95 91 100 99L107 124C109 134 103 142 93 143H64C53 142 48 134 50 124L55 101C56 97 58 95 61 93Z"
+        d="M79 76C65 79 55 88 53 101C51 113 57 121 70 123L96 125C105 125 111 120 112 111C113 100 109 88 101 81C94 76 87 74 79 76Z"
         fill="#fff"
         stroke={lineColor}
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
-
-      {/* 胸前标志 */}
-      <path
-        d="M70 104L78 99L86 104V114L78 119L70 114V104Z"
-        fill={primarySoftColor}
-        stroke={primaryColor}
         strokeWidth="1.8"
         strokeLinejoin="round"
       />
       <path
-        d="M74 108L78 111L83 106"
-        stroke={primaryColor}
-        strokeWidth="2"
+        d="M68 118C61 124 57 131 55 138H77C78 133 79 128 82 124"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M91 123C95 128 99 133 100 138H121C118 129 113 121 107 115"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
 
-      {/* 左手 */}
       <path
-        d="M57 101C49 106 45 114 45 123C45 128 48 131 52 130C56 129 58 124 59 118"
+        d="M68 54C71 46 78 42 87 43C96 43 103 48 105 56L102 73C101 81 96 85 87 85C78 85 73 81 71 73L68 54Z"
         fill="#fff"
         stroke={lineColor}
-        strokeWidth="2"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M72 51C63 50 60 44 62 37C65 42 69 44 74 43"
+        stroke={lineColor}
+        strokeWidth="1.8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-
-      {/* 右手 */}
       <path
-        d="M98 102C106 105 112 111 117 118C120 122 124 123 127 120C130 117 128 113 125 110C119 103 111 98 101 95"
-        fill="#fff"
+        d="M101 51C109 49 112 43 110 36C107 41 103 43 98 42"
         stroke={lineColor}
-        strokeWidth="2"
+        strokeWidth="1.8"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-
-      {/* 扳手 */}
       <path
-        d="M117 112L133 126"
-        stroke={lineColor}
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <path
-        d="M112 107C109 103 110 98 114 95L116 101L121 102L124 97C126 102 124 107 120 109"
-        fill={panelColor}
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <circle
-        cx="135"
-        cy="128"
-        r="4"
+        d="M70 57C65 54 61 56 63 60C65 63 68 63 72 62"
         fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-      />
-
-      {/* 腿 */}
-      <path
-        d="M64 142L62 161C62 165 65 168 69 168H75L76 143"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M88 143L89 161C89 165 92 168 96 168H102L98 141"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
-
-      {/* 脚 */}
-      <path d="M61 163H76V170H58C58 167 59 165 61 163Z" fill={lineColor} />
-      <path
-        d="M89 163H101C105 164 107 166 107 170H90L89 163Z"
-        fill={lineColor}
-      />
-
-      {/* 机柜顶部 */}
-      <path
-        d="M134 93L143 84H202L210 93H134Z"
-        fill={panelColor}
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
-
-      {/* 机柜主体 */}
-      <rect
-        x="134"
-        y="93"
-        width="76"
-        height="68"
-        rx="4"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="2"
-      />
-      <rect
-        x="143"
-        y="84"
-        width="59"
-        height="9"
-        fill={panelColor}
-        stroke={lineColor}
-        strokeWidth="2"
-      />
-
-      {/* 第一层服务器 */}
-      <rect
-        x="142"
-        y="101"
-        width="60"
-        height="17"
-        rx="2"
-        fill={panelColor}
         stroke={lineColor}
         strokeWidth="1.6"
+        strokeLinejoin="round"
       />
-      <circle cx="149" cy="109.5" r="2" fill={primaryColor} />
-      <circle cx="156" cy="109.5" r="2" fill={mutedColor} />
       <path
-        d="M181 109H195"
+        d="M102 57C107 54 111 56 109 60C107 63 104 63 101 62"
+        fill="#fff"
         stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinecap="round"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
       />
-
-      {/* 空抽屉 */}
       <path
-        d="M141 128H202V145H141V128Z"
+        d="M77 46L80 51L85 46L89 51L95 46"
+        stroke={lineColor}
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M78 63C80 64 82 64 84 63" stroke={lineColor} strokeWidth="1.7" strokeLinecap="round" />
+      <path d="M91 64C93 65 95 65 97 64" stroke={lineColor} strokeWidth="1.7" strokeLinecap="round" />
+      <path
+        d="M79 70C80 67 83 66 87 66C91 66 94 68 95 71C94 75 91 77 87 77C83 77 80 75 79 70Z"
+        fill={softFill}
+        stroke={lineColor}
+        strokeWidth="1.5"
+      />
+      <circle cx="84" cy="71" r="1" fill={lineColor} />
+      <circle cx="90" cy="71" r="1" fill={lineColor} />
+
+      <path
+        d="M64 89C61 97 61 105 66 111C69 114 73 113 75 110L80 98"
         fill="#fff"
         stroke={lineColor}
         strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
-        d="M141 145L148 154H195L202 145H141Z"
-        fill={panelColor}
+        d="M100 89C107 92 112 97 117 102C121 106 125 106 128 103C130 100 128 97 125 94C119 88 112 84 104 82"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M124 96L130 92" stroke={secondaryLineColor} strokeWidth="1.2" strokeLinecap="round" />
+
+      {/* 打开的空服务器抽屉 */}
+      <path
+        d="M135 94H180V135H135Z"
+        fill={softFill}
         stroke={lineColor}
         strokeWidth="1.8"
         strokeLinejoin="round"
       />
+      <path d="M158 94V135" stroke={secondaryLineColor} strokeWidth="1.3" />
       <path
-        d="M154 136H189"
-        stroke={mutedColor}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeDasharray="4 5"
-      />
-
-      {/* 终端符号 */}
-      <path
-        d="M150 108L153 110.5L150 113"
+        d="M134 94L145 82H189L180 94H134Z"
+        fill="#fff"
         stroke={lineColor}
-        strokeWidth="1.5"
-        strokeLinecap="round"
+        strokeWidth="1.8"
         strokeLinejoin="round"
       />
-
-      {/* 机柜脚 */}
+      <path d="M145 86H179" stroke={lightLineColor} strokeWidth="1.4" strokeLinecap="round" />
       <path
-        d="M142 161V168"
+        d="M134 110L118 116V132L134 135V110Z"
+        fill="#fff"
         stroke={lineColor}
-        strokeWidth="3"
-        strokeLinecap="round"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
       />
-      <path
-        d="M202 161V168"
-        stroke={lineColor}
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
+      <path d="M121 119H131" stroke={secondaryLineColor} strokeWidth="1.3" strokeLinecap="round" />
+      <circle cx="127" cy="126" r="1.5" fill={secondaryLineColor} />
+      <path d="M145 108H172" stroke={lightLineColor} strokeWidth="1.4" strokeLinecap="round" strokeDasharray="3 4" />
+      <path d="M145 115H166" stroke={lightLineColor} strokeWidth="1.4" strokeLinecap="round" strokeDasharray="3 4" />
 
-      {/* 状态装饰 */}
+      {/* 唯一强调色：疑问号 */}
+      <circle cx="40" cy="40" r="19" fill={softFill} stroke={lightLineColor} strokeWidth="1" />
       <path
-        d="M116 74C121 69 127 67 133 68"
-        stroke={mutedColor}
-        strokeWidth="2"
+        d="M35.5 35.5C35.5 31.7 38 29.5 41.6 29.5C45.2 29.5 47.5 31.5 47.5 34.4C47.5 37 46 38.4 43.7 39.8C41.4 41.2 40.5 42.8 40.5 45"
+        stroke={primaryColor}
+        strokeWidth="4"
         strokeLinecap="round"
-        strokeDasharray="3 5"
       />
+      <circle cx="40.5" cy="51" r="2.3" fill={primaryColor} />
       <path
-        d="M119 81C125 78 130 78 136 80"
-        stroke={mutedColor}
-        strokeWidth="2"
+        d="M49 55C54 59 59 60 64 60"
+        stroke={lightLineColor}
+        strokeWidth="1.3"
         strokeLinecap="round"
-        strokeDasharray="3 5"
+        strokeDasharray="2.5 4"
       />
     </svg>
   );

--- a/yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx
@@ -1,4 +1,5 @@
-import { YakButton, YakEmpty } from '@/components/ui';
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import { YakButton } from '@/components/ui';
 import type { QualityOverviewView } from '@/services/data-quality';
 import { BRAND_CSS_VARIABLES } from '@/styles/brand';
 import { history } from '@umijs/max';
@@ -319,11 +320,24 @@ export default function QualityRadarOverview({
                   ))}
                 </div>
               ) : (
-                <YakEmpty
-                  compact
-                  title="近 7 日暂无问题数据"
-                  description="统计周期内出现未通过或异常规则后，这里将展示问题贡献最高的质量维度"
-                />
+                <div className="flex min-h-[158px] flex-col items-center justify-center py-1 text-center">
+                  <YakOpsEmpty
+                    width={146}
+                    height={106}
+                    primaryColor="var(--yak-brand-color)"
+                    title="近 7 日暂无问题数据"
+                  />
+                  <div className="-mt-1 text-[13px] leading-5">
+                    <span className="text-[#667085]">近 7 日暂无问题数据，</span>
+                    <button
+                      type="button"
+                      onClick={() => history.push('/data-quality/execution')}
+                      className="border-0 bg-transparent p-0 font-medium text-[var(--yak-brand-color)] transition-opacity hover:opacity-75"
+                    >
+                      查看运行记录
+                    </button>
+                  </div>
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
## 改动说明

按最新截图把「问题贡献 TOP3」的空状态改成 Yak Ops 自有插画，并参考示例图收口排版：

- 使用 `YakOpsEmpty` 替换原来的通用文件夹空状态。
- `YakOpsEmpty` 本身同步简化为黑灰线稿，只保留一个品牌色问号作为视觉记忆点，去掉原来偏多的装饰色、状态点和机柜细节。
- 空状态改成“插画在上、文案在下”的居中布局，整体更接近参考图。
- 文案收口为「近 7 日暂无问题数据，查看运行记录」，其中“查看运行记录”为可点击动作，跳转到 `/data-quality/execution`。
- 保持原有问题贡献列表有数据时的展示逻辑不变。

## 影响范围

仅修改前端空状态展示：

- `yak-ops-ui/src/components/YakOpsEmpty/index.tsx`
- `yak-ops-ui/src/pages/data-quality/overview/components/QualityRadarOverview.tsx`

不涉及接口、统计口径、雷达图和趋势图逻辑。

## 验证建议

建议本地重点确认：

- 问题贡献 TOP3 无数据时显示 YakOpsEmpty；
- 插画尺寸与灰色卡片区域比例协调；
- 文案位于插画下方且“查看运行记录”可点击；
- 有问题贡献数据时原列表正常展示；
- 1080P / 2K 下空状态均保持居中。

当前未执行完整 `npm run lint` / `npm run tsc` 或浏览器回归。