### PR TITLE
refactor(ui): 重构 YakOpsEmpty 空状态插画

### DIFF
--- a/yak-ops-ui/src/components/YakOpsEmpty/index.tsx
+++ b/yak-ops-ui/src/components/YakOpsEmpty/index.tsx
@@ -17,30 +17,31 @@ export interface YakOpsEmptyProps
 /**
  * Yak Ops 空状态插画。
  *
- * 只保留黑灰线稿与一个强调色问号，避免空状态本身抢占页面视觉焦点。
+ * 用一个更有动作感的“探身检查空服务器抽屉”场景表达暂无数据：
+ * 角色整体保持黑灰线稿，只把疑问号留给品牌强调色。
  */
 const YakOpsEmpty: React.FC<YakOpsEmptyProps> = ({
   width = 220,
-  height = 160,
+  height = 150,
   primaryColor = 'var(--yak-brand-color, #fe2c55)',
   title = 'Yak Ops 暂无数据',
-  description = '一只小牦牛蹲在打开的服务器抽屉旁，正在查看为什么没有数据',
+  description = '一只小牦牛探身查看打开的服务器抽屉，正在寻找缺失的数据',
   style,
   ...props
 }) => {
   const titleId = useId();
   const descriptionId = useId();
 
-  const lineColor = '#55585f';
-  const secondaryLineColor = '#9a9da3';
-  const lightLineColor = '#d9dadd';
-  const softFill = '#f7f7f8';
+  const lineColor = '#565b62';
+  const secondaryLineColor = '#9ca1a8';
+  const lightLineColor = '#d9dde2';
+  const softFill = '#f7f8f9';
 
   return (
     <svg
       width={width}
       height={height}
-      viewBox="0 0 220 160"
+      viewBox="0 0 220 150"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
@@ -52,154 +53,192 @@ const YakOpsEmpty: React.FC<YakOpsEmptyProps> = ({
       <title id={titleId}>{title}</title>
       <desc id={descriptionId}>{description}</desc>
 
+      {/* 地面 */}
       <path
-        d="M33 139H189"
+        d="M29 132H194"
         stroke={lightLineColor}
-        strokeWidth="1.5"
+        strokeWidth="1.4"
         strokeLinecap="round"
       />
 
-      {/* 小牦牛：蹲下查看抽屉 */}
+      {/* 唯一强调色：疑问气泡 */}
+      <circle cx="36" cy="31" r="16" fill={softFill} stroke={lightLineColor} />
       <path
-        d="M79 76C65 79 55 88 53 101C51 113 57 121 70 123L96 125C105 125 111 120 112 111C113 100 109 88 101 81C94 76 87 74 79 76Z"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M68 118C61 124 57 131 55 138H77C78 133 79 128 82 124"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M91 123C95 128 99 133 100 138H121C118 129 113 121 107 115"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-
-      <path
-        d="M68 54C71 46 78 42 87 43C96 43 103 48 105 56L102 73C101 81 96 85 87 85C78 85 73 81 71 73L68 54Z"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M72 51C63 50 60 44 62 37C65 42 69 44 74 43"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M101 51C109 49 112 43 110 36C107 41 103 43 98 42"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M70 57C65 54 61 56 63 60C65 63 68 63 72 62"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.6"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M102 57C107 54 111 56 109 60C107 63 104 63 101 62"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.6"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M77 46L80 51L85 46L89 51L95 46"
-        stroke={lineColor}
-        strokeWidth="1.7"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path d="M78 63C80 64 82 64 84 63" stroke={lineColor} strokeWidth="1.7" strokeLinecap="round" />
-      <path d="M91 64C93 65 95 65 97 64" stroke={lineColor} strokeWidth="1.7" strokeLinecap="round" />
-      <path
-        d="M79 70C80 67 83 66 87 66C91 66 94 68 95 71C94 75 91 77 87 77C83 77 80 75 79 70Z"
-        fill={softFill}
-        stroke={lineColor}
-        strokeWidth="1.5"
-      />
-      <circle cx="84" cy="71" r="1" fill={lineColor} />
-      <circle cx="90" cy="71" r="1" fill={lineColor} />
-
-      <path
-        d="M64 89C61 97 61 105 66 111C69 114 73 113 75 110L80 98"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M100 89C107 92 112 97 117 102C121 106 125 106 128 103C130 100 128 97 125 94C119 88 112 84 104 82"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path d="M124 96L130 92" stroke={secondaryLineColor} strokeWidth="1.2" strokeLinecap="round" />
-
-      {/* 打开的空服务器抽屉 */}
-      <path
-        d="M135 94H180V135H135Z"
-        fill={softFill}
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinejoin="round"
-      />
-      <path d="M158 94V135" stroke={secondaryLineColor} strokeWidth="1.3" />
-      <path
-        d="M134 94L145 82H189L180 94H134Z"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinejoin="round"
-      />
-      <path d="M145 86H179" stroke={lightLineColor} strokeWidth="1.4" strokeLinecap="round" />
-      <path
-        d="M134 110L118 116V132L134 135V110Z"
-        fill="#fff"
-        stroke={lineColor}
-        strokeWidth="1.8"
-        strokeLinejoin="round"
-      />
-      <path d="M121 119H131" stroke={secondaryLineColor} strokeWidth="1.3" strokeLinecap="round" />
-      <circle cx="127" cy="126" r="1.5" fill={secondaryLineColor} />
-      <path d="M145 108H172" stroke={lightLineColor} strokeWidth="1.4" strokeLinecap="round" strokeDasharray="3 4" />
-      <path d="M145 115H166" stroke={lightLineColor} strokeWidth="1.4" strokeLinecap="round" strokeDasharray="3 4" />
-
-      {/* 唯一强调色：疑问号 */}
-      <circle cx="40" cy="40" r="19" fill={softFill} stroke={lightLineColor} strokeWidth="1" />
-      <path
-        d="M35.5 35.5C35.5 31.7 38 29.5 41.6 29.5C45.2 29.5 47.5 31.5 47.5 34.4C47.5 37 46 38.4 43.7 39.8C41.4 41.2 40.5 42.8 40.5 45"
+        d="M31.5 27.5C31.5 24.2 33.7 22.2 37 22.2C40.4 22.2 42.5 24 42.5 26.7C42.5 29.1 41.1 30.4 39 31.7C36.9 33 36 34.4 36 36.4"
         stroke={primaryColor}
-        strokeWidth="4"
+        strokeWidth="3.5"
         strokeLinecap="round"
       />
-      <circle cx="40.5" cy="51" r="2.3" fill={primaryColor} />
+      <circle cx="36" cy="41.4" r="2" fill={primaryColor} />
+
+      {/* 小牦牛：身体前倾，重心压向右侧 */}
       <path
-        d="M49 55C54 59 59 60 64 60"
-        stroke={lightLineColor}
-        strokeWidth="1.3"
-        strokeLinecap="round"
-        strokeDasharray="2.5 4"
+        d="M70 75C60 82 56 95 60 106C64 116 75 121 88 119L109 116C116 115 119 108 116 101L105 82C99 73 80 69 70 75Z"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinejoin="round"
       />
+
+      {/* 后腿蹲姿 */}
+      <path
+        d="M71 112C63 116 58 123 57 131H78C79 125 82 120 87 116"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M94 117C99 121 102 126 103 131H122C120 123 115 116 110 112"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* 头部稍微前倾，视线朝向抽屉 */}
+      <g transform="rotate(7 82 57)">
+        <path
+          d="M62 51C65 43 72 39 81 39C91 39 98 44 101 52L98 68C97 77 91 82 82 82C73 82 67 77 66 68L62 51Z"
+          fill="#fff"
+          stroke={lineColor}
+          strokeWidth="1.8"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M66 49C57 48 54 42 56 35C59 40 63 42 68 41"
+          stroke={lineColor}
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M98 49C106 47 109 41 107 34C104 39 100 41 95 40"
+          stroke={lineColor}
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M65 55C60 52 56 54 58 59C60 62 63 62 67 61"
+          fill="#fff"
+          stroke={lineColor}
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M99 55C104 52 108 54 106 59C104 62 101 62 98 61"
+          fill="#fff"
+          stroke={lineColor}
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M71 43L75 48L80 42L84 48L90 43"
+          stroke={lineColor}
+          strokeWidth="1.7"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M72 61C74 60 76 60 78 61"
+          stroke={lineColor}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M87 61C90 60 92 60 94 61"
+          stroke={lineColor}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M75 69C77 66 80 65 84 65C88 65 91 67 92 70C91 74 88 76 84 76C80 76 77 74 75 69Z"
+          fill={softFill}
+          stroke={lineColor}
+          strokeWidth="1.45"
+        />
+        <circle cx="81" cy="70" r="1" fill={lineColor} />
+        <circle cx="87" cy="70" r="1" fill={lineColor} />
+      </g>
+
+      {/* 左手搭在额头上，像在认真寻找 */}
+      <path
+        d="M72 79C65 73 62 66 64 60C66 55 70 54 73 57C76 60 74 64 73 67"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M72 57C78 55 83 55 88 57"
+        stroke={lineColor}
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      <path d="M76 55L77 60" stroke={secondaryLineColor} strokeWidth="1.1" strokeLinecap="round" />
+      <path d="M80 55L81 60" stroke={secondaryLineColor} strokeWidth="1.1" strokeLinecap="round" />
+
+      {/* 右手扶住拉出的服务器抽屉 */}
+      <path
+        d="M103 83C111 84 119 89 125 96C128 99 131 100 134 98C137 96 136 92 133 90C126 83 117 78 107 76"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M130 93L137 90" stroke={secondaryLineColor} strokeWidth="1.2" strokeLinecap="round" />
+
+      {/* 服务器机柜：结构简洁，抽屉向人物方向拉出 */}
+      <path
+        d="M143 78H187V129H143Z"
+        fill={softFill}
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path d="M165 78V129" stroke={secondaryLineColor} strokeWidth="1.2" />
+      <path
+        d="M141 78L151 67H194L187 78H141Z"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path d="M151 71H184" stroke={lightLineColor} strokeWidth="1.3" strokeLinecap="round" />
+
+      {/* 拉出的空抽屉 */}
+      <path
+        d="M143 96L121 103V118L143 123V96Z"
+        fill="#fff"
+        stroke={lineColor}
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path d="M125 106H137" stroke={secondaryLineColor} strokeWidth="1.2" strokeLinecap="round" />
+      <circle cx="134" cy="114" r="1.4" fill={secondaryLineColor} />
+
+      {/* 空状态细节 */}
+      <path d="M151 94H178" stroke={lightLineColor} strokeWidth="1.3" strokeLinecap="round" strokeDasharray="3 4" />
+      <path d="M151 101H173" stroke={lightLineColor} strokeWidth="1.3" strokeLinecap="round" strokeDasharray="3 4" />
+      <path d="M151 108H180" stroke={lightLineColor} strokeWidth="1.3" strokeLinecap="round" strokeDasharray="3 4" />
+
+      {/* 视线 / 动作提示，只用灰色辅助线 */}
+      <path d="M111 69C118 67 124 68 130 71" stroke={lightLineColor} strokeWidth="1.2" strokeLinecap="round" strokeDasharray="2 4" />
+      <path d="M116 74C123 73 129 75 134 79" stroke={lightLineColor} strokeWidth="1.2" strokeLinecap="round" strokeDasharray="2 4" />
+
+      {/* 一根松开的线缆，让场景更有“排查问题”的感觉 */}
+      <path
+        d="M185 103C195 105 197 115 190 119C186 121 184 125 187 129"
+        stroke={secondaryLineColor}
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+      <circle cx="188" cy="131" r="1.5" fill={secondaryLineColor} />
     </svg>
   );
 };


### PR DESCRIPTION
## 改动说明

这次不再做局部微调，直接把 `YakOpsEmpty` 重新设计了一版，重点解决当前角色“站着发呆、动作不够自然”的问题：

- 角色姿态改成前倾探身查看服务器抽屉，整体重心向右，画面更有动作感。
- 一只手搭在额头上像在认真寻找，另一只手扶住抽屉，不再是僵硬站立造型。
- 头部增加轻微倾斜，视线明确朝向空服务器抽屉，场景叙事更完整。
- 服务器机柜继续保持极简，只保留抽屉、空槽和一根松开的线缆作为“排查问题”的提示。
- 去掉多余彩色装饰，整张图继续保持黑灰线稿，只保留疑问号使用 Yak Ops 品牌色。
- 默认画布从 `220x160` 收到 `220x150`，构图更紧凑，也更适合当前空状态卡片。

## 影响范围

仅修改：

- `yak-ops-ui/src/components/YakOpsEmpty/index.tsx`

现有调用方式和 props 保持兼容，不涉及数据质量接口、统计逻辑或页面交互。

## 验证建议

建议本地重点确认：

- 在「问题贡献 TOP3」空状态中角色不再显得呆板；
- 146x106 等缩小尺寸下线条仍清晰；
- 疑问号是整张插画唯一品牌色；
- 1080P / 2K 下插画与下方文案比例协调；
- 其它复用 `YakOpsEmpty` 的位置无尺寸回归。

当前未执行完整 `npm run lint` / `npm run tsc` 或浏览器回归。