### PR TITLE
perf(sync): 优化离线同步预览与任务查询性能

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/DataSourceDao.java
@@ -19,6 +19,8 @@ public interface DataSourceDao {
 
   DataSourcePO selectById(Long projectId, Long id);
 
+  List<DataSourcePO> selectByIds(List<Long> ids);
+
   IPage<DataSourcePO> selectPage(PageQuery query);
 
   DataSourceSummaryRow selectSummary();

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
@@ -79,6 +79,18 @@ public class DataSourceDaoImpl implements DataSourceDao {
   }
 
   @Override
+  public List<DataSourcePO> selectByIds(List<Long> ids) {
+    if (ids == null || ids.isEmpty()) return List.of();
+    List<Long> normalizedIds = ids.stream().filter(Objects::nonNull).distinct().toList();
+    if (normalizedIds.isEmpty()) return List.of();
+    Long projectId = currentProjectId();
+    return dataSourceMapper.selectList(
+        Wrappers.<DataSourcePO>lambdaQuery()
+            .eq(projectId != null, DataSourcePO::getProjectId, projectId)
+            .in(DataSourcePO::getId, normalizedIds));
+  }
+
+  @Override
   public IPage<DataSourcePO> selectPage(PageQuery query) {
     PageQuery condition = query == null
         ? new PageQuery(currentProjectId(), 1, 10, null, null, null, null, null)

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
@@ -10,7 +10,10 @@ import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
@@ -33,12 +36,14 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
 
   @Override
   public Optional<OfflineJobDefinition> findById(Long id) {
-    return Optional.ofNullable(toDomain(dao.selectById(id), false));
+    return Optional.ofNullable(toDomain(dao.selectById(id), Map.of()));
   }
 
   @Override
   public Optional<OfflineJobDefinition> findForViewById(Long id) {
-    return Optional.ofNullable(toDomain(dao.selectById(id), true));
+    OfflineJobDefinitionPO po = dao.selectById(id);
+    if (po == null) return Optional.empty();
+    return Optional.of(toDomain(po, dataSourceNames(List.of(po))));
   }
 
   @Override
@@ -82,19 +87,24 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
             q.current(), q.pageSize(), q.id(), q.jobName(), q.status(),
             q.sourceType(), q.sinkType(), q.sourceTable(), q.sinkTable(),
             q.createTimeStart(), q.createTimeEnd()));
-    List<OfflineJobDefinition> records = page.getRecords().stream()
-        .map(po -> toDomain(po, includeDisplayNames))
+    List<OfflineJobDefinitionPO> pageRecords = page.getRecords();
+    Map<Long, String> dataSourceNames =
+        includeDisplayNames ? dataSourceNames(pageRecords) : Map.of();
+    List<OfflineJobDefinition> records = pageRecords.stream()
+        .map(po -> toDomain(po, dataSourceNames))
         .toList();
     return new PageData<>(records, page.getTotal(), page.getPages(), page.getCurrent(), page.getSize());
   }
 
-  private OfflineJobDefinition toDomain(OfflineJobDefinitionPO po, boolean includeDisplayNames) {
+  private OfflineJobDefinition toDomain(
+      OfflineJobDefinitionPO po,
+      Map<Long, String> dataSourceNames) {
     if (po == null) return null;
     OfflineJobDefinition value = new OfflineJobDefinition();
     BeanUtils.copyProperties(po, value);
-    if (includeDisplayNames) {
-      value.setSourceDatasourceName(dataSourceName(po.getSourceDatasourceId()));
-      value.setSinkDatasourceName(dataSourceName(po.getSinkDatasourceId()));
+    if (!dataSourceNames.isEmpty()) {
+      value.setSourceDatasourceName(dataSourceNames.get(po.getSourceDatasourceId()));
+      value.setSinkDatasourceName(dataSourceNames.get(po.getSinkDatasourceId()));
     }
     return value;
   }
@@ -105,9 +115,26 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
     return po;
   }
 
-  private String dataSourceName(Long id) {
-    if (id == null) return null;
-    DataSourcePO dataSource = dataSourceDao.selectById(id);
-    return dataSource == null ? null : dataSource.getName();
+  private Map<Long, String> dataSourceNames(List<OfflineJobDefinitionPO> definitions) {
+    if (definitions == null || definitions.isEmpty()) return Map.of();
+    LinkedHashSet<Long> ids = new LinkedHashSet<>();
+    for (OfflineJobDefinitionPO definition : definitions) {
+      if (definition == null) continue;
+      if (definition.getSourceDatasourceId() != null) {
+        ids.add(definition.getSourceDatasourceId());
+      }
+      if (definition.getSinkDatasourceId() != null) {
+        ids.add(definition.getSinkDatasourceId());
+      }
+    }
+    if (ids.isEmpty()) return Map.of();
+
+    Map<Long, String> names = new LinkedHashMap<>();
+    for (DataSourcePO dataSource : dataSourceDao.selectByIds(List.copyOf(ids))) {
+      if (dataSource != null && dataSource.getId() != null) {
+        names.put(dataSource.getId(), dataSource.getName());
+      }
+    }
+    return names;
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapterTest.java
@@ -1,14 +1,18 @@
 package io.yak.ops.business.sync.offline.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -38,15 +42,10 @@ class OfflineJobDefinitionRepositoryAdapterTest {
   @Test
   void displayReadEnrichesDatasourceNames() {
     OfflineJobDefinitionPO po = definition();
-    DataSourcePO source = new DataSourcePO();
-    source.setId(1L);
-    source.setName("source-mysql");
-    DataSourcePO sink = new DataSourcePO();
-    sink.setId(2L);
-    sink.setName("sink-mysql");
+    DataSourcePO source = dataSource(1L, "source-mysql");
+    DataSourcePO sink = dataSource(2L, "sink-mysql");
     when(dao.selectById(42L)).thenReturn(po);
-    when(dataSourceDao.selectById(1L)).thenReturn(source);
-    when(dataSourceDao.selectById(2L)).thenReturn(sink);
+    when(dataSourceDao.selectByIds(List.of(1L, 2L))).thenReturn(List.of(source, sink));
 
     OfflineJobDefinition result =
         new OfflineJobDefinitionRepositoryAdapter(dao, dataSourceDao)
@@ -55,6 +54,30 @@ class OfflineJobDefinitionRepositoryAdapterTest {
 
     assertThat(result.getSourceDatasourceName()).isEqualTo("source-mysql");
     assertThat(result.getSinkDatasourceName()).isEqualTo("sink-mysql");
+    verify(dataSourceDao).selectByIds(List.of(1L, 2L));
+  }
+
+  @Test
+  void displayPageLoadsDatasourceNamesInOneBatch() {
+    OfflineJobDefinitionPO first = definition();
+    OfflineJobDefinitionPO second = definition();
+    second.setId(43L);
+    second.setSinkDatasourceId(3L);
+
+    Page<OfflineJobDefinitionPO> page = Page.of(1, 10);
+    page.setRecords(List.of(first, second));
+    page.setTotal(2L);
+    when(dao.selectPage(any())).thenReturn(page);
+    when(dataSourceDao.selectByIds(List.of(1L, 2L, 3L)))
+        .thenReturn(
+            List.of(
+                dataSource(1L, "source-mysql"),
+                dataSource(2L, "sink-mysql"),
+                dataSource(3L, "archive-mysql")));
+
+    new OfflineJobDefinitionRepositoryAdapter(dao, dataSourceDao).pageForView(null);
+
+    verify(dataSourceDao).selectByIds(List.of(1L, 2L, 3L));
   }
 
   private OfflineJobDefinitionPO definition() {
@@ -64,5 +87,12 @@ class OfflineJobDefinitionRepositoryAdapterTest {
     po.setSourceDatasourceId(1L);
     po.setSinkDatasourceId(2L);
     return po;
+  }
+
+  private DataSourcePO dataSource(Long id, String name) {
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setId(id);
+    dataSource.setName(name);
+    return dataSource;
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -155,6 +155,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     String query = resolveSql(value.query(), value);
     try (Connection opened = openConnection();
         PreparedStatement statement = opened.prepareStatement(stripTrailingSemicolon(query))) {
+      statement.setQueryTimeout(timeoutSeconds);
       ResultSetMetaData metadata = statement.getMetaData();
       if (metadata != null) return columnsFromMetadata(metadata);
       statement.setMaxRows(1);
@@ -173,6 +174,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     String query = buildQuery(value);
     try (Connection opened = openConnection();
         PreparedStatement statement = opened.prepareStatement(query)) {
+      statement.setQueryTimeout(timeoutSeconds);
       statement.setMaxRows(safeLimit);
       try (ResultSet resultSet = statement.executeQuery()) {
         ResultSetMetaData metadata = resultSet.getMetaData();
@@ -185,7 +187,9 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
           }
           rows.add(row);
         }
-        return new DataSourceQueryResult(columns, rows, count(value));
+        // Preview is intentionally bounded and must not trigger an implicit full COUNT scan.
+        // The count endpoint remains available when an exact cardinality is explicitly required.
+        return new DataSourceQueryResult(columns, rows, rows.size());
       }
     } catch (Exception exception) {
       throw catalogError("查询预览数据失败", exception);
@@ -197,9 +201,11 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     String query = buildQuery(requireRequest(request));
     String countSql = "SELECT COUNT(*) FROM (" + query + ") yak_ops_count";
     try (Connection opened = openConnection();
-        PreparedStatement statement = opened.prepareStatement(countSql);
-        ResultSet resultSet = statement.executeQuery()) {
-      return resultSet.next() ? resultSet.getLong(1) : 0L;
+        PreparedStatement statement = opened.prepareStatement(countSql)) {
+      statement.setQueryTimeout(timeoutSeconds);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        return resultSet.next() ? resultSet.getLong(1) : 0L;
+      }
     } catch (Exception exception) {
       throw catalogError("统计查询结果失败", exception);
     }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
@@ -1,10 +1,20 @@
 package io.yak.ops.plugin.database.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
+import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class GenericJdbcCatalogTypedRequestTest {
@@ -30,6 +40,46 @@ class GenericJdbcCatalogTypedRequestTest {
                 DataSourceCatalogReadRequest.Mode.SQL, null, null, Map.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("query");
+  }
+
+  @Test
+  void previewDoesNotCountAndAppliesQueryTimeout() throws Exception {
+    Connection opened = mock(Connection.class);
+    PreparedStatement statement = mock(PreparedStatement.class);
+    ResultSet resultSet = mock(ResultSet.class);
+    ResultSetMetaData metadata = mock(ResultSetMetaData.class);
+    AtomicInteger countCalls = new AtomicInteger();
+
+    when(opened.prepareStatement(anyString())).thenReturn(statement);
+    when(statement.executeQuery()).thenReturn(resultSet);
+    when(resultSet.getMetaData()).thenReturn(metadata);
+    when(metadata.getColumnCount()).thenReturn(1);
+    when(metadata.getColumnLabel(1)).thenReturn("id");
+    when(resultSet.next()).thenReturn(true, false);
+    when(resultSet.getObject(1)).thenReturn(7L);
+
+    GenericJdbcCatalog catalog =
+        new GenericJdbcCatalog(connection(), 5) {
+          @Override
+          protected Connection openConnection() {
+            return opened;
+          }
+
+          @Override
+          public long count(DataSourceCatalogReadRequest request) {
+            countCalls.incrementAndGet();
+            return 99L;
+          }
+        };
+
+    DataSourceQueryResult result =
+        catalog.preview(DataSourceCatalogReadRequest.table("orders", Map.of()), 20);
+
+    assertThat(result.getData()).hasSize(1);
+    assertThat(result.getTotal()).isEqualTo(1L);
+    assertThat(countCalls.get()).isZero();
+    verify(statement).setQueryTimeout(5);
+    verify(statement).setMaxRows(20);
   }
 
   private JdbcConnectionProperties connection() {

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTablePreviewModal.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SingleTablePreviewModal.tsx
@@ -91,7 +91,6 @@ export default function SingleTablePreviewModal({
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [preview, setPreview] = useState<DataSourcePreviewResult>(emptyPreview);
-  const [total, setTotal] = useState(0);
   const requestSequence = useRef(0);
 
   const requestBody = useMemo(
@@ -117,27 +116,22 @@ export default function SingleTablePreviewModal({
     setLoading(true);
     setErrorMessage('');
     setPreview(emptyPreview);
-    setTotal(0);
 
     try {
-      const [previewResponse, countResponse] = await Promise.all([
-        dataSourceCatalogApi.getTop20Data(dataSourceId, requestBody),
-        dataSourceCatalogApi.count(dataSourceId, requestBody),
-      ]);
+      const previewResponse = await dataSourceCatalogApi.getTop20Data(
+        dataSourceId,
+        requestBody,
+      );
 
       if (sequence !== requestSequence.current) return;
 
       if (previewResponse?.code !== API_SUCCESS_CODE) {
         throw new Error(responseMessage(previewResponse, '获取预览数据失败'));
       }
-      if (countResponse?.code !== API_SUCCESS_CODE) {
-        throw new Error(responseMessage(countResponse, '统计数据量失败'));
-      }
 
       const nextPreview =
         (previewResponse?.data as DataSourcePreviewResult | undefined) ||
         emptyPreview;
-      const nextTotal = Number(countResponse?.data ?? nextPreview.total ?? 0);
 
       setPreview({
         columns: Array.isArray(nextPreview.columns) ? nextPreview.columns : [],
@@ -146,11 +140,9 @@ export default function SingleTablePreviewModal({
           ? Number(nextPreview.total)
           : 0,
       });
-      setTotal(Number.isFinite(nextTotal) ? nextTotal : 0);
     } catch (error: any) {
       if (sequence !== requestSequence.current) return;
       setPreview(emptyPreview);
-      setTotal(0);
       setErrorMessage(error?.message || '获取数据预览失败');
     } finally {
       if (sequence === requestSequence.current) {
@@ -238,12 +230,6 @@ export default function SingleTablePreviewModal({
         <Tag bordered={false}>{readMode === 'sql' ? 'SQL 查询' : '数据表'}</Tag>
         <div className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#344054]">
           {previewTarget}
-        </div>
-        <div className="text-[12px] text-[#667085]">
-          总记录数：
-          <span className="ml-1 font-semibold text-[#161823]">
-            {total.toLocaleString()}
-          </span>
         </div>
         <div className="text-[12px] text-[#667085]">
           本次预览：


### PR DESCRIPTION
## 背景

离线同步单表配置和任务列表存在几处可直接收敛的查询放大问题：数据预览会重复执行精确 COUNT，Catalog JDBC 查询缺少 statement 级超时，任务列表补充数据源名称时存在 N+1。

## 本次改动

- 数据预览只请求前 20 条数据，不再打开弹窗时额外请求精确 COUNT
- JDBC Catalog `preview` 不再隐式执行 `count()`，避免预览触发全量扫描和额外连接
- `describe` / `preview` / `count` 设置 JDBC `queryTimeout`，避免连接成功后 SQL 无边界执行
- DataSource DAO 增加 project-scoped 批量 ID 查询
- 离线同步任务详情/分页统一批量补充 Source / Sink 数据源名称，消除分页 N+1
- 增加测试覆盖：预览不触发 count 且设置 query timeout；任务分页只做一次批量数据源名称查询

## 预期收益

以一次单表预览为例，原链路是 `preview + preview 内部 count + 前端 count`，现在收敛为单次 bounded preview；任务列表的数据源名称查询由最多 `2 * pageSize` 次单条查询收敛为 1 次批量查询。

## 验证

- 已补充针对性单元测试代码
- 当前执行环境无法拉取完整仓库并实际运行 Maven/npm，因此完整编译、测试和浏览器回归仍需 CI / 本地补跑

建议最小补跑：

1. datasource JDBC plugin 单测
2. offline-sync repository 单测
3. yak-ops-ui typecheck/lint（至少覆盖 batch-link-up）
4. 浏览器打开单表“数据预览”，确认 Network 中不再自动请求 `/count/{id}`，且 20 条预览正常
5. 离线同步任务列表分页，确认数据源名称展示正常

## 后续可继续

本 PR 先做 Stage 1 的低风险高收益项。表列表全量加载、Catalog 元数据缓存、服务端搜索/分页可以放到后续 Stage 2。