### PR TITLE
refactor: unify data quality empty states

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/execution/components/ExecutionRecordTable.tsx
+++ b/yak-ops-ui/src/pages/data-quality/execution/components/ExecutionRecordTable.tsx
@@ -1,5 +1,6 @@
 import YakButton from '@/components/YakButton';
-import { Empty, Table, Tag } from "antd";
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import { Table, Tag } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import dayjs from "dayjs";
 import { useMemo, type MouseEvent } from "react";
@@ -312,7 +313,14 @@ const ExecutionRecordTable = ({
   );
 
   const emptyText = (
-    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无运行记录" />
+    <div className="flex min-h-[220px] items-center justify-center">
+      <YakOpsEmpty
+        width={176}
+        height={120}
+        title="暂无运行记录"
+        description="当前筛选条件下暂无数据质量运行记录"
+      />
+    </div>
   );
   const tableClassName = dataQualityTableClassName(
     "[&_.ant-table-container]:!rounded-none [&_.ant-table-container]:!border-x-0"

--- a/yak-ops-ui/src/pages/data-quality/overview/components/QualityTrendChart.tsx
+++ b/yak-ops-ui/src/pages/data-quality/overview/components/QualityTrendChart.tsx
@@ -1,4 +1,4 @@
-import { YakEmpty } from '@/components/ui';
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import type {
   QualityOverviewTrendPoint,
   QualityOverviewView,
@@ -58,11 +58,14 @@ const DimensionBars = ({ overview }: { overview?: QualityOverviewView }) => {
   const max = Math.max(1, ...rows.map((item) => item.issues));
   if (!rows.length) {
     return (
-      <YakEmpty
-        compact
-        title="暂无维度问题分布"
-        description="统计周期内出现质量问题后，这里会展示各质量维度的问题贡献"
-      />
+      <div className="flex min-h-[320px] items-center justify-center">
+        <YakOpsEmpty
+          width={180}
+          height={124}
+          title="暂无维度问题分布"
+          description="统计周期内出现质量问题后，这里会展示各质量维度的问题贡献"
+        />
+      </div>
     );
   }
   return (
@@ -100,12 +103,16 @@ export default function QualityTrendChart({
   const values = trend.flatMap((point) => series.map((item) => item.value(point)));
   const hasData = values.some((value) => value > 0);
   if (!trend.length || !hasData) {
+    const emptyTitle = section === 'issue' ? '暂无问题趋势数据' : '暂无质量趋势数据';
     return (
-      <YakEmpty
-        compact
-        title={section === 'issue' ? '暂无问题趋势数据' : '暂无质量趋势数据'}
-        description="当前统计周期没有可绘制的数据，切换时间范围后可重新查询"
-      />
+      <div className="flex min-h-[320px] items-center justify-center">
+        <YakOpsEmpty
+          width={180}
+          height={124}
+          title={emptyTitle}
+          description="当前统计周期没有可绘制的数据，切换时间范围后可重新查询"
+        />
+      </div>
     );
   }
 

--- a/yak-ops-ui/src/pages/data-quality/rule-template/index.tsx
+++ b/yak-ops-ui/src/pages/data-quality/rule-template/index.tsx
@@ -1,3 +1,4 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import YakTab from '@/components/YakTab';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import {
@@ -9,7 +10,6 @@ import {
   Button,
   ConfigProvider,
   Dropdown,
-  Empty,
   Form,
   Input,
   Modal,
@@ -779,14 +779,22 @@ const TemplateLibraryPage = () => {
                       dataSource={data.records}
                       locale={{
                         emptyText: (
-                          <Empty
-                            image={Empty.PRESENTED_IMAGE_SIMPLE}
-                            description={
-                              activeTab === 'CUSTOM'
-                                ? '当前目录暂无自定义模板'
-                                : '暂无系统模板'
-                            }
-                          />
+                          <div className="flex min-h-[220px] items-center justify-center">
+                            <YakOpsEmpty
+                              width={176}
+                              height={120}
+                              title={
+                                activeTab === 'CUSTOM'
+                                  ? '当前目录暂无自定义模板'
+                                  : '暂无系统模板'
+                              }
+                              description={
+                                activeTab === 'CUSTOM'
+                                  ? '当前筛选条件下没有可展示的自定义规则模板'
+                                  : '当前筛选条件下没有可展示的系统规则模板'
+                              }
+                            />
+                          </div>
                         ),
                       }}
                       columns={[

--- a/yak-ops-ui/src/pages/data-quality/table-config/components/DataSourceTreePane.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/components/DataSourceTreePane.tsx
@@ -1,4 +1,4 @@
-import { YakEmpty } from '@/components/ui';
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import type { DataNode } from 'antd/es/tree';
 import type { TreeProps } from 'antd';
 import { Spin, Tooltip, Tree } from 'antd';
@@ -159,11 +159,14 @@ const DataSourceTreePane = ({
                   className="data-source-tree bg-transparent"
                 />
               ) : (
-                <YakEmpty
-                  compact
-                  title="暂无数据源"
-                  description="请先在数据源管理中创建可用数据源"
-                />
+                <div className="flex min-h-[180px] items-center justify-center">
+                  <YakOpsEmpty
+                    width={132}
+                    height={90}
+                    title="暂无数据源"
+                    description="请先在数据源管理中创建可用数据源"
+                  />
+                </div>
               )}
             </Spin>
           </div>

--- a/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredQualityTableTable.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredQualityTableTable.tsx
@@ -1,4 +1,5 @@
-import { YakButton, YakEmpty } from '@/components/ui';
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import { YakButton } from '@/components/ui';
 import type { TableAssetView } from '@/services/data-quality';
 import { Pagination, Spin, Table, Tag, Tooltip } from 'antd';
 
@@ -38,11 +39,14 @@ const RegisteredQualityTableTable = ({
           className={dataQualityTableClassName()}
           locale={{
             emptyText: (
-              <YakEmpty
-                compact
-                title="暂无已注册数据表"
-                description="点击右上角注册数据表后开始配置质量监控"
-              />
+              <div className="flex min-h-[220px] items-center justify-center">
+                <YakOpsEmpty
+                  width={176}
+                  height={120}
+                  title="暂无已注册数据表"
+                  description="点击右上角注册数据表后开始配置质量监控"
+                />
+              </div>
             ),
           }}
           columns={[

--- a/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredTablePanel.tsx
+++ b/yak-ops-ui/src/pages/data-quality/table-config/components/RegisteredTablePanel.tsx
@@ -1,4 +1,5 @@
-import { YakButton, YakEmpty } from '@/components/ui';
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import { YakButton } from '@/components/ui';
 import type { TableAssetView } from '@/services/data-quality';
 import { Input } from 'antd';
 import { Search } from 'lucide-react';
@@ -80,7 +81,9 @@ const RegisteredTablePanel = ({
 
       {!dataSourceId ? (
         <div className="flex min-h-0 flex-1 items-center justify-center">
-          <YakEmpty
+          <YakOpsEmpty
+            width={180}
+            height={124}
             title="请选择数据源"
             description="从左侧选择数据源后查看并注册质量监控表"
           />


### PR DESCRIPTION
## Summary

- replace empty-data states across the four visible Data Quality pages with `YakOpsEmpty`
- cover quality overview trend/dimension empty states, data source and registered-table states, execution records, and rule templates
- preserve existing loading, filtering, pagination, navigation, and CRUD behavior
- keep the existing `YakOpsEmpty` issue-contributor state in the quality overview unchanged

## Pages

- 质量总览 (`/data-quality/overview`)
- 数据表监控 (`/data-quality/table-config`)
- 运行记录 (`/data-quality/execution`)
- 规则模板库 (`/data-quality/rule-template`)

## Verification

- compared the branch against `main`; only 6 files under `yak-ops-ui/src/pages/data-quality` are changed
- verified the rule-template table empty-state JSX and imports after the large-file edit
- loading states remain handled by the existing `Spin` / `Table loading` paths, so loading is not rendered as an empty state
- full frontend lint/typecheck/browser regression not run in this environment

## Note

This PR is intentionally based on `main` and does not duplicate the separate `YakOpsEmpty` PNG implementation change. Once that component change lands, these states will automatically render the shared `public/empty.png` asset.