### PR TITLE
perf(sync): Stage 3 增强 Catalog 可观测性与数据库专项优化

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogCacheInvalidationListener.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogCacheInvalidationListener.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.datasource.catalog;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.domain.DataSourceChangedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** Clears stale local Catalog metadata only after datasource mutations commit successfully. */
+@Slf4j
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataSourceCatalogCacheInvalidationListener {
+
+  private final DataSourceCatalogMetadataCache metadataCache;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onDataSourceChanged(DataSourceChangedEvent event) {
+    int invalidated = metadataCache.invalidate(event.dataSourceId());
+    if (invalidated > 0) {
+      log.debug(
+          "Invalidated datasource catalog cache dataSourceId={} entries={}",
+          event.dataSourceId(),
+          invalidated);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogDiagnostics.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogDiagnostics.java
@@ -1,0 +1,159 @@
+package io.yak.ops.business.datasource.catalog;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/** Lightweight in-process observability for physical datasource Catalog reads. */
+@Slf4j
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataSourceCatalogDiagnostics {
+
+  private final DataSourceProperties properties;
+  private final ConcurrentMap<String, OperationAccumulator> operations = new ConcurrentHashMap<>();
+  private final LongAdder cacheHits = new LongAdder();
+  private final LongAdder cacheMisses = new LongAdder();
+
+  public <T> T observe(
+      DataSourceDefinition definition,
+      String operation,
+      Supplier<T> action) {
+    long startedAt = System.nanoTime();
+    boolean failed = false;
+    try {
+      return action.get();
+    } catch (RuntimeException | Error exception) {
+      failed = true;
+      throw exception;
+    } finally {
+      long durationNanos = Math.max(0L, System.nanoTime() - startedAt);
+      record(definition, operation, durationNanos, failed);
+    }
+  }
+
+  public void recordCacheLookup(boolean hit) {
+    if (hit) {
+      cacheHits.increment();
+    } else {
+      cacheMisses.increment();
+    }
+  }
+
+  public Snapshot snapshot() {
+    long hits = cacheHits.sum();
+    long misses = cacheMisses.sum();
+    long lookups = hits + misses;
+    double hitRate = lookups == 0L ? 0D : (double) hits / lookups;
+    List<OperationSnapshot> operationSnapshots =
+        operations.entrySet().stream()
+            .map(entry -> entry.getValue().snapshot(entry.getKey()))
+            .sorted(Comparator.comparing(OperationSnapshot::operation))
+            .toList();
+    return new Snapshot(hits, misses, hitRate, operationSnapshots);
+  }
+
+  void reset() {
+    operations.clear();
+    cacheHits.reset();
+    cacheMisses.reset();
+  }
+
+  private void record(
+      DataSourceDefinition definition,
+      String operation,
+      long durationNanos,
+      boolean failed) {
+    String operationName = operation == null || operation.isBlank() ? "unknown" : operation;
+    long thresholdMs = Math.max(1L, properties.getCatalog().getSlowOperationThresholdMillis());
+    long durationMs = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+    boolean slow = durationMs >= thresholdMs;
+
+    operations
+        .computeIfAbsent(operationName, ignored -> new OperationAccumulator())
+        .record(durationNanos, failed, slow, durationMs);
+
+    if (slow) {
+      String dbType =
+          definition == null || definition.getDbType() == null
+              ? "UNKNOWN"
+              : definition.getDbType().name();
+      Long dataSourceId = definition == null ? null : definition.getId();
+      log.warn(
+          "Slow datasource catalog operation operation={} dataSourceId={} dbType={} durationMs={} thresholdMs={} failed={}",
+          operationName,
+          dataSourceId,
+          dbType,
+          durationMs,
+          thresholdMs,
+          failed);
+    }
+  }
+
+  public record Snapshot(
+      long cacheHits,
+      long cacheMisses,
+      double cacheHitRate,
+      List<OperationSnapshot> operations) {}
+
+  public record OperationSnapshot(
+      String operation,
+      long total,
+      long failures,
+      long slow,
+      long averageDurationMs,
+      long maxDurationMs,
+      Long lastSlowDurationMs,
+      LocalDateTime lastSlowTime) {}
+
+  private static final class OperationAccumulator {
+    private final LongAdder total = new LongAdder();
+    private final LongAdder failures = new LongAdder();
+    private final LongAdder slow = new LongAdder();
+    private final LongAdder totalNanos = new LongAdder();
+    private final AtomicLong maxNanos = new AtomicLong();
+    private final AtomicLong lastSlowDurationMs = new AtomicLong(-1L);
+    private final AtomicReference<LocalDateTime> lastSlowTime = new AtomicReference<>();
+
+    void record(long durationNanos, boolean failed, boolean isSlow, long durationMs) {
+      total.increment();
+      totalNanos.add(durationNanos);
+      maxNanos.accumulateAndGet(durationNanos, Math::max);
+      if (failed) failures.increment();
+      if (isSlow) {
+        slow.increment();
+        lastSlowDurationMs.set(durationMs);
+        lastSlowTime.set(LocalDateTime.now());
+      }
+    }
+
+    OperationSnapshot snapshot(String operation) {
+      long totalValue = total.sum();
+      long averageNanos = totalValue == 0L ? 0L : totalNanos.sum() / totalValue;
+      long lastSlow = lastSlowDurationMs.get();
+      return new OperationSnapshot(
+          operation,
+          totalValue,
+          failures.sum(),
+          slow.sum(),
+          TimeUnit.NANOSECONDS.toMillis(averageNanos),
+          TimeUnit.NANOSECONDS.toMillis(maxNanos.get()),
+          lastSlow < 0L ? null : lastSlow,
+          lastSlowTime.get());
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogMetadataCache.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogMetadataCache.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 
@@ -27,25 +29,42 @@ public class DataSourceCatalogMetadataCache {
   private final ConcurrentMap<CacheKey, CacheEntry<?>> entries = new ConcurrentHashMap<>();
 
   public <T> T getOrLoad(CacheKey key, int ttlSeconds, Supplier<T> loader) {
+    return getOrLoad(key, ttlSeconds, loader, ignored -> {});
+  }
+
+  public <T> T getOrLoad(
+      CacheKey key,
+      int ttlSeconds,
+      Supplier<T> loader,
+      Consumer<Boolean> lookupObserver) {
     Objects.requireNonNull(key, "cache key must not be null");
     Objects.requireNonNull(loader, "cache loader must not be null");
+    Objects.requireNonNull(lookupObserver, "cache lookup observer must not be null");
     if (ttlSeconds <= 0) {
+      lookupObserver.accept(false);
       return loader.get();
     }
 
-    CacheEntry<?> entry =
-        entries.compute(
-            key,
-            (ignored, current) -> {
-              long now = System.nanoTime();
-              if (current != null && current.expiresAtNanos() > now) {
-                return current;
-              }
-              T value = loader.get();
-              return new CacheEntry<>(
-                  value,
-                  now + TimeUnit.SECONDS.toNanos(Math.max(1L, ttlSeconds)));
-            });
+    AtomicBoolean hit = new AtomicBoolean(false);
+    CacheEntry<?> entry;
+    try {
+      entry =
+          entries.compute(
+              key,
+              (ignored, current) -> {
+                long now = System.nanoTime();
+                if (current != null && current.expiresAtNanos() > now) {
+                  hit.set(true);
+                  return current;
+                }
+                T value = loader.get();
+                return new CacheEntry<>(
+                    value,
+                    now + TimeUnit.SECONDS.toNanos(Math.max(1L, ttlSeconds)));
+              });
+    } finally {
+      lookupObserver.accept(hit.get());
+    }
 
     trimIfNecessary(System.nanoTime());
 
@@ -68,6 +87,14 @@ public class DataSourceCatalogMetadataCache {
         definition.getUpdateTime(),
         Objects.requireNonNull(kind, "cache kind must not be null"),
         normalizedQualifiers);
+  }
+
+  /** Remove all local metadata cache entries for one datasource. */
+  public int invalidate(Long dataSourceId) {
+    if (dataSourceId == null) return 0;
+    int before = entries.size();
+    entries.keySet().removeIf(key -> Objects.equals(dataSourceId, key.dataSourceId()));
+    return Math.max(0, before - entries.size());
   }
 
   void clear() {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogReader.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogReader.java
@@ -31,12 +31,14 @@ public class DataSourceCatalogReader {
   private final CatalogReadPolicy readPolicy;
   private final CatalogTableMatcher tableMatcher;
   private final DataSourceCatalogMetadataCache metadataCache;
+  private final DataSourceCatalogDiagnostics diagnostics;
 
   public List<String> listDatabases(Long dataSourceId) {
     DataSourceDefinition definition = dataSourceReader.require(dataSourceId);
     return cached(
         definition,
         "databases",
+        "listDatabases",
         () -> catalogGateway.listDatabases(definition, connectionTimeoutSeconds()));
   }
 
@@ -45,6 +47,7 @@ public class DataSourceCatalogReader {
     return cached(
         definition,
         "schemas",
+        "listSchemas",
         () -> catalogGateway.listSchemas(definition, database, connectionTimeoutSeconds()),
         database);
   }
@@ -59,6 +62,7 @@ public class DataSourceCatalogReader {
     return cached(
         definition,
         "tables",
+        "listTables",
         () -> catalogGateway.listTables(definition, query, connectionTimeoutSeconds()),
         query.database(),
         query.schema(),
@@ -83,6 +87,7 @@ public class DataSourceCatalogReader {
     return cached(
         definition,
         "table-search",
+        "searchTables",
         () -> catalogGateway.listTables(definition, query, connectionTimeoutSeconds()),
         query.database(),
         query.schema(),
@@ -100,6 +105,7 @@ public class DataSourceCatalogReader {
     return cached(
         definition,
         "columns",
+        "listColumns",
         () -> catalogGateway.listColumns(definition, path, connectionTimeoutSeconds()),
         path.database(),
         path.schema(),
@@ -121,48 +127,65 @@ public class DataSourceCatalogReader {
       Long dataSourceId,
       CatalogReadRequest request) {
     readPolicy.validateReadOnly(request);
-    return catalogGateway.describe(
-        dataSourceReader.require(dataSourceId),
-        request,
-        connectionTimeoutSeconds());
+    DataSourceDefinition definition = dataSourceReader.require(dataSourceId);
+    return diagnostics.observe(
+        definition,
+        "describe",
+        () -> catalogGateway.describe(definition, request, connectionTimeoutSeconds()));
   }
 
   public CatalogQueryResult preview(
       Long dataSourceId,
       CatalogReadRequest request) {
     readPolicy.validateReadOnly(request);
-    return catalogGateway.preview(
-        dataSourceReader.require(dataSourceId),
-        request,
-        PREVIEW_LIMIT,
-        connectionTimeoutSeconds());
+    DataSourceDefinition definition = dataSourceReader.require(dataSourceId);
+    return diagnostics.observe(
+        definition,
+        "preview",
+        () ->
+            catalogGateway.preview(
+                definition,
+                request,
+                PREVIEW_LIMIT,
+                connectionTimeoutSeconds()));
   }
 
   public Long count(
       Long dataSourceId,
       CatalogReadRequest request) {
     readPolicy.validateReadOnly(request);
-    return catalogGateway.count(
-        dataSourceReader.require(dataSourceId),
-        request,
-        connectionTimeoutSeconds());
+    DataSourceDefinition definition = dataSourceReader.require(dataSourceId);
+    return diagnostics.observe(
+        definition,
+        "count",
+        () -> catalogGateway.count(definition, request, connectionTimeoutSeconds()));
   }
 
   public String buildSqlTemplate(Long dataSourceId, String tablePath) {
-    return catalogGateway.buildSqlTemplate(
-        dataSourceReader.require(dataSourceId),
-        tablePath,
-        connectionTimeoutSeconds());
+    DataSourceDefinition definition = dataSourceReader.require(dataSourceId);
+    return diagnostics.observe(
+        definition,
+        "buildSqlTemplate",
+        () ->
+            catalogGateway.buildSqlTemplate(
+                definition,
+                tablePath,
+                connectionTimeoutSeconds()));
   }
 
   public String resolveSql(
       Long dataSourceId,
       CatalogReadRequest request) {
     readPolicy.requireSql(request);
-    return catalogGateway.resolveSql(
-        dataSourceReader.require(dataSourceId),
-        request,
-        connectionTimeoutSeconds());
+    DataSourceDefinition definition = dataSourceReader.require(dataSourceId);
+    return diagnostics.observe(
+        definition,
+        "resolveSql",
+        () -> catalogGateway.resolveSql(definition, request, connectionTimeoutSeconds()));
+  }
+
+  public DataSourceCatalogDiagnostics.Snapshot diagnostics() {
+    return diagnostics.snapshot();
   }
 
   private List<CatalogTable> listAllTables(Long dataSourceId) {
@@ -171,18 +194,21 @@ public class DataSourceCatalogReader {
     return cached(
         definition,
         "all-tables",
+        "listAllTables",
         () -> catalogGateway.listTables(definition, query, connectionTimeoutSeconds()));
   }
 
   private <T> T cached(
       DataSourceDefinition definition,
       String kind,
+      String operation,
       Supplier<T> loader,
       Object... qualifiers) {
     return metadataCache.getOrLoad(
         metadataCache.key(definition, kind, qualifiers),
         metadataCacheTtlSeconds(),
-        loader);
+        () -> diagnostics.observe(definition, operation, loader),
+        diagnostics::recordCacheLookup);
   }
 
   private int connectionTimeoutSeconds() {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceProperties.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/config/DataSourceProperties.java
@@ -122,6 +122,9 @@ public class DataSourceProperties {
     /** 下拉远程搜索一次最多返回的表数量。 */
     private int tableSearchLimit = 100;
 
+    /** 单次物理 Catalog 访问超过该阈值时记录慢操作；单位毫秒。 */
+    private long slowOperationThresholdMillis = 1000L;
+
     public int getConnectionTimeoutSeconds() {
       return connectionTimeoutSeconds;
     }
@@ -152,6 +155,14 @@ public class DataSourceProperties {
 
     public void setTableSearchLimit(int tableSearchLimit) {
       this.tableSearchLimit = tableSearchLimit;
+    }
+
+    public long getSlowOperationThresholdMillis() {
+      return slowOperationThresholdMillis;
+    }
+
+    public void setSlowOperationThresholdMillis(long slowOperationThresholdMillis) {
+      this.slowOperationThresholdMillis = slowOperationThresholdMillis;
     }
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceCatalogController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceCatalogController.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.datasource.controller.v1.converter.CatalogRequestConv
 import io.yak.ops.business.datasource.controller.v1.converter.CatalogViewConverter;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnOptionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogDiagnosticsVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogOptionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceQueryResultVO;
@@ -40,6 +41,8 @@ public class DataSourceCatalogController {
   private final CatalogRequestConverter requestConverter;
   private final CatalogViewConverter viewConverter;
 
+  @Operation(summary = "查询 Catalog 运行诊断") @GetMapping("/diagnostics")
+  public Result<DataSourceCatalogDiagnosticsVO> diagnostics() { return Result.success(viewConverter.diagnostics(catalogReader.diagnostics())); }
   @Operation(summary = "查询数据库列表") @GetMapping("/{id}/databases")
   public Result<List<String>> databases(@PathVariable("id") Long id) { return Result.success(catalogReader.listDatabases(id)); }
   @Operation(summary = "查询 Schema 列表") @GetMapping("/{id}/schemas")

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/converter/CatalogViewConverter.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/converter/CatalogViewConverter.java
@@ -1,11 +1,13 @@
 package io.yak.ops.business.datasource.controller.v1.converter;
 
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogDiagnostics;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
 import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
 import io.yak.ops.business.datasource.domain.catalog.CatalogTable;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnOptionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogColumnVO;
+import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogDiagnosticsVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogOptionVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourceCatalogTableVO;
 import io.yak.ops.common.bean.vo.datasource.DataSourcePreviewColumnVO;
@@ -20,5 +22,23 @@ public class CatalogViewConverter {
   public DataSourceCatalogColumnOptionVO columnOption(CatalogColumn value) { return new DataSourceCatalogColumnOptionVO(value.ordinalPosition(), value.name(), value.typeName(), value.ordinalPosition(), value.nullable() ? "YES" : "NO", value.remarks(), value.primaryKey() ? "PRI" : ""); }
   public DataSourceCatalogOptionVO option(CatalogTable value) { String label = isBlank(value.remarks()) ? value.name() : value.remarks(); return new DataSourceCatalogOptionVO(value.name(), label, value.remarks()); }
   public DataSourceQueryResultVO preview(CatalogQueryResult result) { var columns = result.columns().stream().map(column -> new DataSourcePreviewColumnVO(column.title(), column.dataIndex(), column.key(), column.ellipsis())).toList(); return new DataSourceQueryResultVO(columns, result.rows(), result.total()); }
+  public DataSourceCatalogDiagnosticsVO diagnostics(DataSourceCatalogDiagnostics.Snapshot snapshot) {
+    var operations = snapshot.operations().stream()
+        .map(operation -> new DataSourceCatalogDiagnosticsVO.OperationVO(
+            operation.operation(),
+            operation.total(),
+            operation.failures(),
+            operation.slow(),
+            operation.averageDurationMs(),
+            operation.maxDurationMs(),
+            operation.lastSlowDurationMs(),
+            operation.lastSlowTime()))
+        .toList();
+    return new DataSourceCatalogDiagnosticsVO(
+        snapshot.cacheHits(),
+        snapshot.cacheMisses(),
+        snapshot.cacheHitRate(),
+        operations);
+  }
   private boolean isBlank(String value) { return value == null || value.trim().isEmpty(); }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceChangedEvent.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/domain/DataSourceChangedEvent.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.datasource.domain;
+
+/** Published after a persisted datasource configuration is changed or removed. */
+public record DataSourceChangedEvent(Long dataSourceId) {
+
+  public DataSourceChangedEvent {
+    if (dataSourceId == null || dataSourceId <= 0L) {
+      throw new IllegalArgumentException("dataSourceId must be positive");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/management/DataSourceManager.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/management/DataSourceManager.java
@@ -3,12 +3,14 @@ package io.yak.ops.business.datasource.management;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.datasource.connection.DataSourceConnectionResolver;
 import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.domain.DataSourceChangedEvent;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.exception.DataSourceException;
 import io.yak.ops.business.datasource.query.DataSourceReader;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
 import io.yak.ops.common.enums.datasource.DataSourceErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class DataSourceManager {
   private final DataSourceRepository repository;
   private final DataSourceReader reader;
   private final DataSourceConnectionResolver connectionResolver;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(
       transactionManager = "opsDataSourceTransactionManager",
@@ -60,6 +63,7 @@ public class DataSourceManager {
     if (!repository.update(existing)) {
       throw new DataSourceException(DataSourceErrorCode.UPDATE_FAILED);
     }
+    eventPublisher.publishEvent(new DataSourceChangedEvent(id));
     return true;
   }
 
@@ -71,6 +75,7 @@ public class DataSourceManager {
     if (!repository.delete(existing.getId())) {
       throw new DataSourceException(DataSourceErrorCode.DELETE_FAILED);
     }
+    eventPublisher.publishEvent(new DataSourceChangedEvent(existing.getId()));
     return true;
   }
 

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogCacheInvalidationListenerTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogCacheInvalidationListenerTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.datasource.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.domain.DataSourceChangedEvent;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class DataSourceCatalogCacheInvalidationListenerTest {
+
+  @Test
+  void datasourceChangeRemovesOnlyMatchingCacheEntries() {
+    DataSourceCatalogMetadataCache cache = new DataSourceCatalogMetadataCache();
+    DataSourceDefinition first = definition(1L);
+    DataSourceDefinition second = definition(2L);
+
+    cache.getOrLoad(cache.key(first, "tables"), 60, () -> "first");
+    cache.getOrLoad(cache.key(second, "tables"), 60, () -> "second");
+    assertThat(cache.size()).isEqualTo(2);
+
+    new DataSourceCatalogCacheInvalidationListener(cache)
+        .onDataSourceChanged(new DataSourceChangedEvent(1L));
+
+    assertThat(cache.size()).isEqualTo(1);
+    assertThat(cache.invalidate(1L)).isZero();
+    assertThat(cache.invalidate(2L)).isEqualTo(1);
+  }
+
+  private DataSourceDefinition definition(Long id) {
+    DataSourceDefinition definition = mock(DataSourceDefinition.class);
+    when(definition.getId()).thenReturn(id);
+    when(definition.getUpdateTime()).thenReturn(LocalDateTime.of(2026, 8, 27, 14, 0));
+    return definition;
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogDiagnosticsTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogDiagnosticsTest.java
@@ -1,0 +1,50 @@
+package io.yak.ops.business.datasource.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.datasource.config.DataSourceProperties;
+import io.yak.ops.business.datasource.domain.DataSourceDefinition;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import org.junit.jupiter.api.Test;
+
+class DataSourceCatalogDiagnosticsTest {
+
+  @Test
+  void recordsSuccessFailureAndCacheLookupsWithoutSensitivePayloads() {
+    DataSourceProperties properties = new DataSourceProperties();
+    properties.getCatalog().setSlowOperationThresholdMillis(60_000L);
+    DataSourceCatalogDiagnostics diagnostics = new DataSourceCatalogDiagnostics(properties);
+    DataSourceDefinition definition = mock(DataSourceDefinition.class);
+    when(definition.getId()).thenReturn(7L);
+    when(definition.getDbType()).thenReturn(DataSourceDbType.MYSQL);
+
+    assertThat(diagnostics.observe(definition, "preview", () -> "ok")).isEqualTo("ok");
+    assertThatThrownBy(
+            () ->
+                diagnostics.observe(
+                    definition,
+                    "preview",
+                    () -> {
+                      throw new IllegalStateException("boom");
+                    }))
+        .isInstanceOf(IllegalStateException.class);
+    diagnostics.recordCacheLookup(true);
+    diagnostics.recordCacheLookup(false);
+
+    DataSourceCatalogDiagnostics.Snapshot snapshot = diagnostics.snapshot();
+    assertThat(snapshot.cacheHits()).isEqualTo(1L);
+    assertThat(snapshot.cacheMisses()).isEqualTo(1L);
+    assertThat(snapshot.cacheHitRate()).isEqualTo(0.5D);
+    assertThat(snapshot.operations())
+        .singleElement()
+        .satisfies(operation -> {
+          assertThat(operation.operation()).isEqualTo("preview");
+          assertThat(operation.total()).isEqualTo(2L);
+          assertThat(operation.failures()).isEqualTo(1L);
+          assertThat(operation.slow()).isZero();
+        });
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogReaderTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/catalog/DataSourceCatalogReaderTest.java
@@ -41,7 +41,8 @@ class DataSourceCatalogReaderTest {
             properties,
             policy,
             matcher,
-            new DataSourceCatalogMetadataCache());
+            new DataSourceCatalogMetadataCache(),
+            mock(DataSourceCatalogDiagnostics.class));
     CatalogReadRequest request =
         new CatalogReadRequest(ReadMode.SQL, null, "DELETE FROM patient", List.of());
     doThrow(
@@ -67,6 +68,7 @@ class DataSourceCatalogReaderTest {
     CatalogReadPolicy policy = mock(CatalogReadPolicy.class);
     CatalogTableMatcher matcher = mock(CatalogTableMatcher.class);
     DataSourceCatalogMetadataCache cache = new DataSourceCatalogMetadataCache();
+    DataSourceCatalogDiagnostics diagnostics = new DataSourceCatalogDiagnostics(properties);
     DataSourceCatalogReader reader =
         new DataSourceCatalogReader(
             dataSourceReader,
@@ -74,7 +76,8 @@ class DataSourceCatalogReaderTest {
             properties,
             policy,
             matcher,
-            cache);
+            cache,
+            diagnostics);
 
     DataSourceDefinition definition = mock(DataSourceDefinition.class);
     when(definition.getId()).thenReturn(1L);
@@ -92,6 +95,14 @@ class DataSourceCatalogReaderTest {
     assertThat(queryCaptor.getValue().keyword()).isEqualTo("patient");
     assertThat(queryCaptor.getValue().limit()).isEqualTo(50);
     assertThat(cache.size()).isEqualTo(1);
+    assertThat(reader.diagnostics().cacheMisses()).isEqualTo(1L);
+    assertThat(reader.diagnostics().cacheHits()).isEqualTo(1L);
+    assertThat(reader.diagnostics().operations())
+        .singleElement()
+        .satisfies(operation -> {
+          assertThat(operation.operation()).isEqualTo("searchTables");
+          assertThat(operation.total()).isEqualTo(1L);
+        });
     verify(dataSourceReader, times(2)).require(1L);
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/management/DataSourceManagerTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/management/DataSourceManagerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.datasource.connection.DataSourceConnectionResolver;
 import io.yak.ops.business.datasource.domain.ConnectionProfile;
+import io.yak.ops.business.datasource.domain.DataSourceChangedEvent;
 import io.yak.ops.business.datasource.domain.DataSourceDefinition;
 import io.yak.ops.business.datasource.query.DataSourceReader;
 import io.yak.ops.business.datasource.repository.DataSourceRepository;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class DataSourceManagerTest {
@@ -25,6 +27,7 @@ class DataSourceManagerTest {
   @Mock private DataSourceRepository repository;
   @Mock private DataSourceReader reader;
   @Mock private DataSourceConnectionResolver connectionResolver;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @Test
   void createBuildsAggregateFromNormalizedConnectionProfile() {
@@ -53,7 +56,46 @@ class DataSourceManagerTest {
     assertThat(captor.getValue().getConnStatus()).isEqualTo(DataSourceConnStatus.UNKNOWN);
   }
 
+  @Test
+  void updatePublishesDatasourceChangedEvent() {
+    DataSourceConfigurationCommand command =
+        new DataSourceConfigurationCommand(
+            "orders-db",
+            DataSourceDbType.MYSQL,
+            DataSourceEnvironment.PROD,
+            "updated",
+            "{\"host\":\"db.internal\"}");
+    ConnectionProfile stored =
+        new ConnectionProfile(
+            "jdbc:mysql://127.0.0.1/orders",
+            "{\"host\":\"127.0.0.1\"}",
+            "{\"host\":\"127.0.0.1\"}");
+    ConnectionProfile merged =
+        new ConnectionProfile(
+            "jdbc:mysql://db.internal/orders",
+            "{\"host\":\"db.internal\"}",
+            "{\"host\":\"db.internal\"}");
+    DataSourceDefinition existing =
+        DataSourceDefinition.create(
+            "orders-db",
+            DataSourceDbType.MYSQL,
+            stored,
+            DataSourceEnvironment.PROD,
+            null);
+    when(reader.require(42L)).thenReturn(existing);
+    when(connectionResolver.mergeStoredSecrets(existing, command.connectionJson()))
+        .thenReturn(merged);
+    when(repository.update(existing)).thenReturn(true);
+
+    assertThat(manager().update(42L, command)).isTrue();
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    assertThat(eventCaptor.getValue())
+        .isEqualTo(new DataSourceChangedEvent(42L));
+  }
+
   private DataSourceManager manager() {
-    return new DataSourceManager(repository, reader, connectionResolver);
+    return new DataSourceManager(repository, reader, connectionResolver, eventPublisher);
   }
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourceCatalogDiagnosticsVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/datasource/DataSourceCatalogDiagnosticsVO.java
@@ -1,0 +1,33 @@
+package io.yak.ops.common.bean.vo.datasource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** DataSource Catalog 运行诊断信息。 */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DataSourceCatalogDiagnosticsVO {
+
+  private long cacheHits;
+  private long cacheMisses;
+  private double cacheHitRate;
+  private List<OperationVO> operations;
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class OperationVO {
+    private String operation;
+    private long total;
+    private long failures;
+    private long slow;
+    private long averageDurationMs;
+    private long maxDurationMs;
+    private Long lastSlowDurationMs;
+    private LocalDateTime lastSlowTime;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -104,8 +104,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   public List<DataSourceTable> listTables(DataSourceCatalogQuery query) {
     DataSourceCatalogQuery value =
         query == null ? new DataSourceCatalogQuery(null, null, null) : query;
-    String database = firstNonBlank(value.getDatabase(), connection.database());
-    String schema = firstNonBlank(value.getSchema(), connection.schema());
+    String database = metadataCatalog(value.getDatabase());
+    String schema = metadataSchema(value.getSchema());
     String keyword = trimToNull(value.getKeyword());
     int limit =
         value.getLimit() == null
@@ -138,8 +138,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
 
   @Override
   public List<DataSourceColumn> listColumns(DataSourceTablePath tablePath) {
-    String database = firstNonBlank(tablePath.getDatabase(), connection.database());
-    String schema = firstNonBlank(tablePath.getSchema(), connection.schema());
+    String database = metadataCatalog(tablePath.getDatabase());
+    String schema = metadataSchema(tablePath.getSchema());
     try (Connection opened = openConnection()) {
       DatabaseMetaData metadata = opened.getMetaData();
       Set<String> primaryKeys = primaryKeys(metadata, database, schema, tablePath.getTable());
@@ -358,6 +358,26 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     }
     parts.add(quoteIdentifier(tablePath.getTable()));
     return String.join(".", parts);
+  }
+
+  private String metadataCatalog(String requestedDatabase) {
+    if (connection.dbType() == DataSourceDbType.ORACLE) {
+      // Oracle's JDBC catalog is not the service name. Supplying it can broaden or invalidate
+      // DatabaseMetaData lookups, so keep the catalog null and scope through schema instead.
+      return null;
+    }
+    return firstNonBlank(requestedDatabase, connection.database());
+  }
+
+  private String metadataSchema(String requestedSchema) {
+    String schema = firstNonBlank(requestedSchema, connection.schema());
+    if (connection.dbType() != DataSourceDbType.ORACLE) {
+      return schema;
+    }
+    if (isBlank(schema)) {
+      schema = trimToNull(connection.username());
+    }
+    return schema == null ? null : schema.toUpperCase(Locale.ROOT);
   }
 
   private String tableNamePattern(DatabaseMetaData metadata, String keyword) throws SQLException {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -105,7 +105,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     DataSourceCatalogQuery value =
         query == null ? new DataSourceCatalogQuery(null, null, null) : query;
     String database = metadataCatalog(value.getDatabase());
-    String schema = metadataSchema(value.getSchema());
+    String schema = metadataSchema(value.getSchema(), value.getLimit() != null);
     String keyword = trimToNull(value.getKeyword());
     int limit =
         value.getLimit() == null
@@ -139,7 +139,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   @Override
   public List<DataSourceColumn> listColumns(DataSourceTablePath tablePath) {
     String database = metadataCatalog(tablePath.getDatabase());
-    String schema = metadataSchema(tablePath.getSchema());
+    String schema = metadataSchema(tablePath.getSchema(), true);
     try (Connection opened = openConnection()) {
       DatabaseMetaData metadata = opened.getMetaData();
       Set<String> primaryKeys = primaryKeys(metadata, database, schema, tablePath.getTable());
@@ -369,12 +369,12 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     return firstNonBlank(requestedDatabase, connection.database());
   }
 
-  private String metadataSchema(String requestedSchema) {
+  private String metadataSchema(String requestedSchema, boolean narrowOracleDefault) {
     String schema = firstNonBlank(requestedSchema, connection.schema());
     if (connection.dbType() != DataSourceDbType.ORACLE) {
       return schema;
     }
-    if (isBlank(schema)) {
+    if (isBlank(schema) && narrowOracleDefault) {
       schema = trimToNull(connection.username());
     }
     return schema == null ? null : schema.toUpperCase(Locale.ROOT);

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
@@ -120,6 +120,31 @@ class GenericJdbcCatalogTypedRequestTest {
     verify(metadata).getTables(eq("demo"), isNull(), eq("%orders%"), any(String[].class));
   }
 
+  @Test
+  void oracleSearchUsesCurrentUserSchemaAndNoServiceNameCatalog() throws Exception {
+    Connection opened = mock(Connection.class);
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    ResultSet resultSet = mock(ResultSet.class);
+    when(opened.getMetaData()).thenReturn(metadata);
+    when(metadata.storesUpperCaseIdentifiers()).thenReturn(true);
+    when(metadata.getTables(isNull(), eq("APP_USER"), eq("%PATIENT%"), any(String[].class)))
+        .thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(false);
+
+    GenericJdbcCatalog catalog =
+        new GenericJdbcCatalog(oracleConnection(), 5, 13) {
+          @Override
+          protected Connection openConnection() {
+            return opened;
+          }
+        };
+
+    catalog.listTables(new DataSourceCatalogQuery(null, null, "patient", 100));
+
+    verify(metadata)
+        .getTables(isNull(), eq("APP_USER"), eq("%PATIENT%"), any(String[].class));
+  }
+
   private JdbcConnectionProperties connection() {
     return new JdbcConnectionProperties(
         DataSourceDbType.MYSQL,
@@ -128,6 +153,19 @@ class GenericJdbcCatalogTypedRequestTest {
         "test_user",
         null,
         "demo",
+        null,
+        Map.of(),
+        "{}");
+  }
+
+  private JdbcConnectionProperties oracleConnection() {
+    return new JdbcConnectionProperties(
+        DataSourceDbType.ORACLE,
+        "jdbc:oracle:thin:@//localhost:1521/ORCL",
+        "oracle.jdbc.OracleDriver",
+        "app_user",
+        null,
+        "ORCL",
         null,
         Map.of(),
         "{}");


### PR DESCRIPTION
## 背景

Stage 1 / Stage 2 已合并，离线同步已经解决预览重复 COUNT、任务列表 N+1、全量表 Catalog 拉取、元数据 TTL Cache 以及 connection/query timeout 拆分。

Stage 3 继续处理剩余的生产化问题：缓存虽然有 TTL，但数据源修改/删除后旧条目仍要等过期；Catalog 物理访问缺少可观测性，慢到底发生在 metadata、preview 还是 count 很难定位；Oracle 在大型账号/Schema 环境下，JDBC metadata 的 Catalog/Schema 语义也需要进一步收窄。

## 本次改动

### 1. Catalog 本地缓存主动失效

- `DataSourceManager` 在数据源更新、删除成功后发布 `DataSourceChangedEvent`
- 使用 `@TransactionalEventListener(AFTER_COMMIT)`，只在事务真正提交后清理缓存
- `DataSourceCatalogMetadataCache` 新增按 `dataSourceId` 主动失效能力
- 保留 Stage 2 的 `dataSourceId + updateTime` 版本化 key，主动失效与 TTL 形成双保险

这样数据源配置变更后，不需要再等待 60s TTL，也不会让旧版本缓存长期占用本地空间。

### 2. Catalog 物理访问可观测性

新增轻量级进程内诊断，不引入 Redis、Prometheus 或新的基础设施依赖：

- 统计物理 Catalog 操作的调用次数、失败次数
- 统计平均耗时、最大耗时
- 统计慢操作次数、最近一次慢操作耗时和时间
- 统计 metadata cache hit / miss / hit rate
- 只统计真正访问 Gateway/JDBC 的操作，缓存命中不会虚增物理调用次数

覆盖操作包括：

- `listDatabases / listSchemas / listTables / searchTables / listColumns`
- `describe / preview / count`
- `buildSqlTemplate / resolveSql`

新增只读诊断接口：

`GET /api/v1/data-source/catalog/diagnostics`

诊断结果只返回聚合计数和耗时，不返回 SQL、连接参数、账号密码或具体业务数据。

### 3. 慢 Catalog 访问日志

新增配置：

`yak.datasource.catalog.slow-operation-threshold-millis`

默认 `1000ms`。

超过阈值时记录 WARN，日志只包含：

- operation
- dataSourceId
- dbType
- durationMs
- thresholdMs
- failed

刻意不记录 SQL 和连接参数，避免性能诊断把敏感信息带入日志。

### 4. Oracle metadata 专项收窄

针对 Oracle JDBC metadata：

- 不再把 Oracle service/database 名称当作 JDBC `catalog` 参数
- bounded 交互式表搜索在未配置 Schema 时默认使用当前连接用户名作为 Schema，并统一为大写
- 字段 / 主键信息读取同样在缺少显式 Schema 时使用当前用户 Schema
- legacy 无界表浏览不强制默认到当前用户 Schema，避免一次性改变旧接口的浏览语义
- 显式配置 Schema 时始终优先尊重配置

这主要解决 Oracle 用户可见 Schema 很多时，交互式表搜索容易扫过宽 metadata 范围的问题。

## 测试覆盖

新增/补充针对性测试：

- metadata cache hit / miss 与物理 Gateway 调用次数一致
- 数据源变更事件只清理对应 datasource 的缓存
- update 成功后发布 `DataSourceChangedEvent`
- Catalog diagnostics 记录 success / failure / cache hit / cache miss
- Oracle bounded search 使用 `catalog=null + current-user schema`
- Stage 1 / Stage 2 原有 preview timeout、bounded search 行为继续保留

## 兼容性

- 不修改现有离线同步 REST 请求结构
- Stage 2 `/tables/search` 接口保持兼容
- 新增 diagnostics 接口，不影响现有调用方
- 不引入新的外部缓存或监控组件
- 本阶段主动失效是**单实例本地缓存失效**；多节点共享缓存/广播失效仍作为后续基础设施能力，不在本 PR 扩大范围

## 预期收益

Stage 3 之后，离线同步 Catalog 链路从“只是变快”进一步变成“可定位、可治理”：

- 数据源修改后旧 metadata 立即失效
- 能直接看到 cache 是否真正生效
- 能区分是 table metadata、column metadata、preview 还是 count 慢
- 慢远端数据库会留下安全的诊断记录
- Oracle 大 Catalog 的交互式检索范围进一步收窄

## 验证

已补充针对性测试代码。当前执行环境无法完整 checkout 仓库并实际执行 Maven/npm，因此完整验证仍需 CI / 本地补跑：

1. `yak-ops-business-datasource` 全量单测与 architecture tests
2. datasource JDBC plugin 单测
3. 修改一次数据源后立即再次查询表/字段，确认旧缓存已清理
4. 连续搜索相同表名两次，确认 diagnostics 中第一次 miss、第二次 hit，物理 `searchTables` 只计一次
5. 人为使用高延迟数据源，确认慢操作 WARN 能出现且不包含 SQL/密码/JDBC 敏感参数
6. Oracle 使用未配置 Schema 的账号测试 `/tables/search`，确认搜索范围落在当前用户 Schema；再用显式 Schema 验证仍按配置查询

## 后续

如果继续 Stage 4，建议再做多节点 cache invalidation / shared cache、Prometheus/Micrometer 指标适配，以及按数据库类型拆分更细的 Catalog 性能基线。