### PR TITLE
refactor(ui): refresh data source management page

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/DataSourceCard.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceCard.tsx
@@ -1,7 +1,7 @@
 import { YakButton } from '@/components/ui';
 import type { DataSourceRecord } from '@/services/data-source';
 import { motion } from 'framer-motion';
-import { Pencil, Trash2, Unplug } from 'lucide-react';
+import { Clock3, Pencil, Trash2, Unplug } from 'lucide-react';
 
 import { environmentTagConfigMap, PAGE_ANIMATION } from '../constants';
 import DatabaseIcons from '../icon/DatabaseIcons';
@@ -47,33 +47,43 @@ const DataSourceCard = ({
     <motion.article
       variants={PAGE_ANIMATION.fadeUp}
       className={[
-        'group min-w-0 overflow-hidden rounded-[9px] border border-black/[0.075] bg-white',
-        'transition-[transform,border-color,box-shadow] duration-200',
-        'hover:-translate-y-0.5 hover:border-black/[0.11] hover:shadow-[0_10px_28px_rgba(22,24,35,0.07)]',
+        'group relative min-w-0 overflow-hidden rounded-[16px] border border-[rgba(31,35,41,0.075)] bg-white/[0.98]',
+        'shadow-[0_3px_10px_rgba(31,35,41,0.035),0_1px_2px_rgba(31,35,41,0.02)]',
+        'transition-[transform,border-color,box-shadow] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)]',
+        'hover:-translate-y-px hover:border-[rgba(31,35,41,0.11)] hover:shadow-[0_10px_24px_rgba(31,35,41,0.065),0_1px_2px_rgba(31,35,41,0.02)]',
         isListView
-          ? 'grid grid-cols-[minmax(360px,1.35fr)_minmax(360px,1fr)] max-xl:grid-cols-1'
+          ? 'grid grid-cols-[minmax(380px,1.5fr)_minmax(390px,1fr)] max-xl:grid-cols-1'
           : '',
       ]
         .filter(Boolean)
         .join(' ')}
     >
-      <div className="flex min-h-[92px] items-start justify-between gap-[15px] bg-[radial-gradient(circle_at_100%_0,rgba(88,110,255,0.08),transparent_37%),linear-gradient(110deg,#fbfcff_0%,#f7f8fc_100%)] px-[19px] pb-4 pt-[19px]">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="flex h-[47px] w-[47px] shrink-0 items-center justify-center rounded-xl border border-black/[0.055] bg-white shadow-[0_5px_14px_rgba(22,24,35,0.055)]">
-            <DatabaseIcons dbType={record.dbType} width="30" height="30" />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 [background-image:radial-gradient(circle,rgba(94,117,163,0.14)_0.7px,transparent_0.8px)] [background-size:8px_8px] [mask-image:linear-gradient(115deg,#000_0%,rgba(0,0,0,0.18)_40%,transparent_72%)]"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-16 -top-20 z-0 h-48 w-48 rounded-full bg-[#dce7ff]/35 blur-3xl transition-transform duration-300 group-hover:scale-110"
+      />
+
+      <div className="relative z-[1] flex min-h-[116px] items-start justify-between gap-4 px-[18px] pb-[17px] pt-[18px]">
+        <div className="flex min-w-0 items-start gap-[13px]">
+          <div className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-[14px] border border-[rgba(31,35,41,0.07)] bg-[linear-gradient(145deg,#ffffff_0%,#f5f7fa_100%)] shadow-[0_5px_14px_rgba(31,35,41,0.055)] transition-transform duration-[260ms] group-hover:scale-[1.025]">
+            <DatabaseIcons dbType={record.dbType} width="31" height="31" />
           </div>
 
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-center gap-2">
+          <div className="min-w-0 pt-0.5">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               <h3
                 title={record.name}
-                className="m-0 min-w-0 truncate text-[15px] font-semibold text-[#161823]"
+                className="m-0 max-w-[260px] truncate text-[15px] font-semibold leading-[22px] text-[#292c35]"
               >
                 {record.name || '未命名数据源'}
               </h3>
 
               <span
-                className="inline-flex h-5 shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-[7px] text-[9px] font-semibold"
+                className="inline-flex h-5 shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-[7px] text-[10px] font-semibold"
                 style={{
                   color: environmentConfig.color,
                   background: environmentConfig.backgroundColor,
@@ -86,7 +96,7 @@ const DataSourceCard = ({
 
             <p
               title={record.jdbcUrl}
-              className="mt-1.5 max-w-[410px] truncate text-[11px] text-black/[0.43]"
+              className="mb-0 mt-2 max-w-[460px] truncate rounded-[7px] bg-[#f7f8fa]/90 px-2 py-1 text-[11px] leading-[18px] text-[#858a94]"
             >
               {record.jdbcUrl || '暂未配置连接地址'}
             </p>
@@ -94,7 +104,7 @@ const DataSourceCard = ({
         </div>
 
         {actionAvailable ? (
-          <div className="pointer-events-none flex shrink-0 -translate-y-1 gap-1 opacity-0 transition-all duration-150 group-hover:pointer-events-auto group-hover:translate-y-0 group-hover:opacity-100">
+          <div className="flex shrink-0 -translate-y-1 gap-1 opacity-0 transition-all duration-150 group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:translate-y-0 group-focus-within:opacity-100">
             {permissions.canTest ? (
               <YakButton
                 type="text"
@@ -103,8 +113,8 @@ const DataSourceCard = ({
                 title="测试连接"
                 loading={testingId === currentId}
                 disabled={Boolean(testingId) && testingId !== currentId}
-                className="!h-[29px] !w-[29px] !rounded-[7px] !border !border-black/[0.07] !bg-white/90 !p-0 !text-black/[0.52] hover:!text-[#4058c8]"
-                icon={<Unplug size={15} strokeWidth={1.9} />}
+                className="!h-[30px] !w-[30px] !rounded-[8px] !border !border-[#e9ebef] !bg-white/90 !p-0 !text-[#7e838d] !shadow-[0_1px_3px_rgba(31,35,41,0.035)] hover:!text-[#4058c8]"
+                icon={<Unplug size={14} strokeWidth={1.9} />}
                 onClick={() => onTestConnection(record)}
               />
             ) : null}
@@ -117,8 +127,8 @@ const DataSourceCard = ({
                 title="编辑数据源"
                 loading={editingId === currentId}
                 disabled={Boolean(editingId) && editingId !== currentId}
-                className="!h-[29px] !w-[29px] !rounded-[7px] !border !border-black/[0.07] !bg-white/90 !p-0 !text-black/[0.52] hover:!text-[#4058c8]"
-                icon={<Pencil size={15} strokeWidth={1.9} />}
+                className="!h-[30px] !w-[30px] !rounded-[8px] !border !border-[#e9ebef] !bg-white/90 !p-0 !text-[#7e838d] !shadow-[0_1px_3px_rgba(31,35,41,0.035)] hover:!text-[#4058c8]"
+                icon={<Pencil size={14} strokeWidth={1.9} />}
                 onClick={() => onEdit(record)}
               />
             ) : null}
@@ -130,8 +140,8 @@ const DataSourceCard = ({
                 danger
                 iconOnly
                 title="删除数据源"
-                className="!h-[29px] !w-[29px] !rounded-[7px] !border !border-black/[0.07] !bg-white/90 !p-0"
-                icon={<Trash2 size={15} strokeWidth={1.9} />}
+                className="!h-[30px] !w-[30px] !rounded-[8px] !border !border-[#e9ebef] !bg-white/90 !p-0 !shadow-[0_1px_3px_rgba(31,35,41,0.035)]"
+                icon={<Trash2 size={14} strokeWidth={1.9} />}
                 onClick={() => onDelete(record)}
               />
             ) : null}
@@ -141,30 +151,31 @@ const DataSourceCard = ({
 
       <div
         className={[
-          'grid grid-cols-3 px-[19px] py-[15px]',
+          'relative z-[1] grid grid-cols-[1.05fr_0.8fr_1.15fr] border-t border-[#eef0f3] bg-white/75 px-[18px] py-[14px]',
           isListView
-            ? 'items-center border-l border-black/[0.055] max-xl:border-l-0 max-xl:border-t'
+            ? 'items-center border-l border-t-0 max-xl:border-l-0 max-xl:border-t'
             : '',
         ]
           .filter(Boolean)
           .join(' ')}
       >
-        <div className="flex min-w-0 flex-col gap-1.5">
-          <span className="text-[10px] text-black/[0.38]">连接状态</span>
+        <div className="flex min-w-0 flex-col gap-1.5 pr-3">
+          <span className="text-[10px] leading-4 text-[#a0a4ad]">连接状态</span>
           <DataSourceStatus status={record.connStatus} />
         </div>
 
-        <div className="flex min-w-0 flex-col gap-1.5 border-l border-black/[0.06] pl-3.5">
-          <span className="text-[10px] text-black/[0.38]">数据源类型</span>
-          <strong className="truncate text-[11px] font-semibold text-black/[0.78]">
+        <div className="flex min-w-0 flex-col gap-1.5 border-l border-[#eff0f2] px-3">
+          <span className="text-[10px] leading-4 text-[#a0a4ad]">数据源类型</span>
+          <strong className="truncate text-[11px] font-semibold leading-[18px] text-[#5c616b]">
             {String(record.dbType || '-')}
           </strong>
         </div>
 
-        <div className="flex min-w-0 flex-col gap-1.5 border-l border-black/[0.06] pl-3.5">
-          <span className="text-[10px] text-black/[0.38]">最近更新</span>
-          <strong className="truncate text-[11px] font-semibold text-black/[0.78]">
-            {record.updateTime || '-'}
+        <div className="flex min-w-0 flex-col gap-1.5 border-l border-[#eff0f2] pl-3">
+          <span className="text-[10px] leading-4 text-[#a0a4ad]">最近更新</span>
+          <strong className="flex min-w-0 items-center gap-1.5 truncate text-[11px] font-medium leading-[18px] text-[#737882]">
+            <Clock3 size={11} strokeWidth={1.8} className="shrink-0 text-[#9ca0a9]" />
+            <span className="truncate">{record.updateTime || '-'}</span>
           </strong>
         </div>
       </div>

--- a/yak-ops-ui/src/pages/data-source/components/DataSourcePageHeader.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourcePageHeader.tsx
@@ -1,5 +1,5 @@
 import { YakButton } from '@/components/ui';
-import { Plus } from 'lucide-react';
+import { Database, Plus } from 'lucide-react';
 
 interface DataSourcePageHeaderProps {
   canCreate: boolean;
@@ -10,17 +10,27 @@ const DataSourcePageHeader = ({
   canCreate,
   onCreate,
 }: DataSourcePageHeaderProps) => (
-  <header className="flex items-start justify-between gap-8">
-    <h1 className="m-0 text-2xl font-bold tracking-[-0.45px] text-[#161823]">
-      数据源管理
-    </h1>
+  <header className="flex items-center justify-between gap-8 max-md:items-start">
+    <div className="flex min-w-0 items-center gap-3.5">
+      <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[13px] border border-[rgba(31,35,41,0.07)] bg-[linear-gradient(145deg,#f7f9fc_0%,#eef2f7_100%)] text-[#4f5968] shadow-[0_4px_12px_rgba(31,35,41,0.04)]">
+        <Database size={21} strokeWidth={1.8} />
+      </span>
+
+      <div className="min-w-0">
+        <h1 className="m-0 text-xl font-semibold leading-7 tracking-[-0.35px] text-[#252832]">
+          数据源管理
+        </h1>
+        <p className="mb-0 mt-1 text-[13px] leading-5 text-[#9498a1]">
+          统一管理开发、测试与生产环境的数据连接
+        </p>
+      </div>
+    </div>
 
     {canCreate ? (
       <YakButton
         type="primary"
-        size="large"
         icon={<Plus size={16} strokeWidth={2.1} />}
-        className="!h-10 !shrink-0 !rounded-[7px] !px-[17px]"
+        className="!h-9 !shrink-0 !rounded-[10px] !px-4 !text-[13px]"
         onClick={onCreate}
       >
         新建数据源

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceSummaryCards.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceSummaryCards.tsx
@@ -11,40 +11,48 @@ interface SummaryItem {
     'total' | 'connected' | 'disconnected' | 'environmentCount'
   >;
   label: string;
+  description: string;
   icon: ReactNode;
   iconClassName: string;
-  itemClassName: string;
+  glowClassName: string;
 }
 
 const SUMMARY_ITEMS: SummaryItem[] = [
   {
     key: 'total',
     label: '全部数据源',
-    icon: <Database size={20} strokeWidth={1.8} />,
-    iconClassName: 'bg-[#edf0ff] text-[#4e62d6]',
-    itemClassName: '',
+    description: '当前已接入',
+    icon: <Database size={19} strokeWidth={1.85} />,
+    iconClassName:
+      'bg-[linear-gradient(145deg,#eef2ff_0%,#e4eaff_100%)] text-[#5669da]',
+    glowClassName: 'bg-[#7388ff]/10',
   },
   {
     key: 'connected',
     label: '连接正常',
-    icon: <CheckCircle2 size={20} strokeWidth={1.8} />,
-    iconClassName: 'bg-[#eef9f0] text-[#25a244]',
-    itemClassName: 'border-l border-black/[0.055]',
+    description: '可正常访问',
+    icon: <CheckCircle2 size={19} strokeWidth={1.85} />,
+    iconClassName:
+      'bg-[linear-gradient(145deg,#eef9f2_0%,#e2f5e8_100%)] text-[#28a251]',
+    glowClassName: 'bg-[#42ba6f]/10',
   },
   {
     key: 'disconnected',
     label: '连接异常',
-    icon: <XCircle size={20} strokeWidth={1.8} />,
-    iconClassName: 'bg-[#fff0f0] text-[#e85959]',
-    itemClassName:
-      'border-l border-black/[0.055] max-xl:border-l-0 max-xl:border-t',
+    description: '需要关注',
+    icon: <XCircle size={19} strokeWidth={1.85} />,
+    iconClassName:
+      'bg-[linear-gradient(145deg,#fff2f3_0%,#ffe7e9_100%)] text-[#e55763]',
+    glowClassName: 'bg-[#ef6570]/10',
   },
   {
     key: 'environmentCount',
     label: '运行环境',
-    icon: <Server size={20} strokeWidth={1.8} />,
-    iconClassName: 'bg-[#eef2f6] text-[#617084]',
-    itemClassName: 'border-l border-black/[0.055] max-xl:border-t',
+    description: '已覆盖环境',
+    icon: <Server size={19} strokeWidth={1.85} />,
+    iconClassName:
+      'bg-[linear-gradient(145deg,#f1f4f7_0%,#e8edf2_100%)] text-[#667487]',
+    glowClassName: 'bg-[#738196]/10',
   },
 ];
 
@@ -54,34 +62,49 @@ interface DataSourceSummaryCardsProps {
 
 const DataSourceSummaryCards = ({ summary }: DataSourceSummaryCardsProps) => (
   <motion.section
-    variants={PAGE_ANIMATION.fadeUp}
-    className="mt-[26px] grid grid-cols-4 overflow-hidden rounded-[9px] border border-black/[0.055] bg-[radial-gradient(circle_at_85%_10%,rgba(88,110,255,0.08),transparent_31%),linear-gradient(105deg,#fcfcff_0%,#f8f9ff_100%)] max-xl:grid-cols-2"
+    variants={PAGE_ANIMATION.cardStagger}
+    className="mt-5 grid grid-cols-1 gap-[14px] sm:grid-cols-2 xl:grid-cols-4"
   >
     {SUMMARY_ITEMS.map((item) => (
-      <div
+      <motion.div
         key={item.key}
-        className={[
-          'flex min-h-[92px] items-center gap-[13px] px-6 py-5',
-          item.itemClassName,
-        ]
-          .filter(Boolean)
-          .join(' ')}
+        variants={PAGE_ANIMATION.fadeUp}
+        className="group relative min-h-[104px] overflow-hidden rounded-[16px] border border-[rgba(31,35,41,0.075)] bg-white/[0.96] px-[18px] py-4 shadow-[0_3px_10px_rgba(31,35,41,0.04),0_1px_2px_rgba(31,35,41,0.02)] transition-[transform,border-color,box-shadow] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)] hover:-translate-y-px hover:border-[rgba(31,35,41,0.10)] hover:shadow-[0_8px_20px_rgba(31,35,41,0.065),0_1px_2px_rgba(31,35,41,0.02)]"
       >
         <span
+          aria-hidden="true"
           className={[
-            'flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px]',
-            item.iconClassName,
+            'pointer-events-none absolute -right-8 -top-10 h-28 w-28 rounded-full blur-2xl transition-transform duration-300 group-hover:scale-110',
+            item.glowClassName,
           ].join(' ')}
-        >
-          {item.icon}
-        </span>
-        <div className="flex min-w-0 flex-col">
-          <span className="text-xs text-black/[0.45]">{item.label}</span>
-          <strong className="mt-1.5 text-2xl font-bold leading-7 text-[#161823]">
+        />
+
+        <div className="relative flex items-start justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <span
+              className={[
+                'flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border border-white/80 shadow-[0_4px_10px_rgba(31,35,41,0.035)]',
+                item.iconClassName,
+              ].join(' ')}
+            >
+              {item.icon}
+            </span>
+
+            <div className="min-w-0">
+              <div className="truncate text-[13px] font-medium leading-5 text-[#626771]">
+                {item.label}
+              </div>
+              <div className="mt-0.5 truncate text-[11px] leading-[18px] text-[#a3a7af]">
+                {item.description}
+              </div>
+            </div>
+          </div>
+
+          <strong className="shrink-0 text-[28px] font-semibold leading-9 tracking-[-0.8px] text-[#252832]">
             {summary[item.key]}
           </strong>
         </div>
-      </div>
+      </motion.div>
     ))}
   </motion.section>
 );

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
@@ -37,14 +37,18 @@ const DataSourceToolbar = ({
 }: DataSourceToolbarProps) => (
   <motion.section
     variants={PAGE_ANIMATION.fadeUp}
-    className="mt-[26px] flex min-h-[62px] items-end justify-between gap-6 border-b border-black/[0.075] max-xl:flex-col max-xl:items-stretch max-xl:gap-3"
+    className="mt-[18px] flex min-h-[56px] items-end justify-between gap-6 border-b border-[#eceef1] max-xl:flex-col max-xl:items-stretch max-xl:gap-3"
   >
-    <div className="h-[35px]">
+    <div className="h-[34px]">
       <YakTab
         size="small"
         activeKey={environment || 'all'}
         className={[
+          '[&_.ant-tabs-tab]:!px-0',
+          '[&_.ant-tabs-tab]:!text-[13px]',
+          '[&_.ant-tabs-tab.ant-tabs-tab-active_.ant-tabs-tab-btn]:!font-semibold',
           '[&_.ant-tabs-tab.ant-tabs-tab-active_.ant-tabs-tab-btn]:!text-[#292c35]',
+          '[&_.ant-tabs-tab::after]:!h-0.5',
           '[&_.ant-tabs-tab::after]:!bg-[#252832]',
         ].join(' ')}
         items={DATA_SOURCE_ENVIRONMENT_TABS.map((item) => ({
@@ -60,7 +64,7 @@ const DataSourceToolbar = ({
       />
     </div>
 
-    <div className="flex items-center gap-2 pb-[11px] max-xl:justify-end max-xl:pb-3">
+    <div className="flex flex-wrap items-center justify-end gap-2 pb-[10px] max-xl:justify-start max-xl:pb-3">
       <Select
         allowClear
         variant="filled"
@@ -68,8 +72,11 @@ const DataSourceToolbar = ({
         className={[
           '!w-[132px]',
           '[&_.ant-select-selector]:!h-9',
-          '[&_.ant-select-selector]:!rounded-lg',
+          '[&_.ant-select-selector]:!rounded-[10px]',
+          '[&_.ant-select-selector]:!bg-[#f6f7f9]',
+          '[&_.ant-select-selection-item]:!text-[12px]',
           '[&_.ant-select-selection-item]:!leading-[36px]',
+          '[&_.ant-select-selection-placeholder]:!text-[12px]',
           '[&_.ant-select-selection-placeholder]:!leading-[36px]',
         ].join(' ')}
         placeholder="数据源类型"
@@ -82,35 +89,41 @@ const DataSourceToolbar = ({
         allowClear
         variant="filled"
         value={keyword}
-        prefix={<Search size={15} strokeWidth={1.8} />}
+        prefix={<Search size={15} strokeWidth={1.8} className="text-[#8f949e]" />}
         className={[
-          '!w-[300px]',
+          '!w-[292px] max-md:!w-[220px]',
           '[&.ant-input-affix-wrapper]:!h-9',
-          '[&.ant-input-affix-wrapper]:!rounded-lg',
-          '[&_.ant-input]:!text-xs',
+          '[&.ant-input-affix-wrapper]:!rounded-[10px]',
+          '[&.ant-input-affix-wrapper]:!bg-[#f6f7f9]',
+          '[&_.ant-input]:!text-[12px]',
         ].join(' ')}
         placeholder="搜索名称或连接地址"
         onChange={(event) => onKeywordChange(event.target.value)}
       />
 
       {hasActiveFilters ? (
-        <YakButton type="text" size="small" onClick={onReset}>
+        <YakButton
+          type="text"
+          size="small"
+          className="!h-9 !rounded-[9px] !px-2.5 !text-[12px] !text-[#777c86]"
+          onClick={onReset}
+        >
           重置
         </YakButton>
       ) : null}
 
-      <div className="flex overflow-hidden rounded-[7px] border border-black/[0.09] bg-white">
+      <div className="flex h-9 items-center gap-0.5 rounded-[10px] bg-[#f4f5f7] p-[3px]">
         <YakButton
           type="text"
           iconOnly
           title="卡片视图"
           className={[
-            '!h-[34px] !w-[34px] !rounded-none !border-0 !p-0',
+            '!h-[30px] !w-[30px] !rounded-[7px] !border-0 !p-0',
             viewMode === 'grid'
-              ? '!bg-[#f7f8fa] !text-[#252832]'
-              : '!bg-white !text-black/[0.53]',
+              ? '!bg-white !text-[#2d313a] !shadow-[0_1px_4px_rgba(31,35,41,0.10)]'
+              : '!bg-transparent !text-[#92969f] hover:!text-[#555b66]',
           ].join(' ')}
-          icon={<Grid2X2 size={16} strokeWidth={1.8} />}
+          icon={<Grid2X2 size={15} strokeWidth={1.8} />}
           onClick={() => onViewModeChange('grid')}
         />
 
@@ -119,12 +132,12 @@ const DataSourceToolbar = ({
           iconOnly
           title="列表视图"
           className={[
-            '!h-[34px] !w-[34px] !rounded-none !border-0 !border-l !border-l-black/[0.09] !p-0',
+            '!h-[30px] !w-[30px] !rounded-[7px] !border-0 !p-0',
             viewMode === 'list'
-              ? '!bg-[#f7f8fa] !text-[#252832]'
-              : '!bg-white !text-black/[0.53]',
+              ? '!bg-white !text-[#2d313a] !shadow-[0_1px_4px_rgba(31,35,41,0.10)]'
+              : '!bg-transparent !text-[#92969f] hover:!text-[#555b66]',
           ].join(' ')}
-          icon={<LayoutList size={17} strokeWidth={1.8} />}
+          icon={<LayoutList size={16} strokeWidth={1.8} />}
           onClick={() => onViewModeChange('list')}
         />
       </div>

--- a/yak-ops-ui/src/pages/data-source/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/index.tsx
@@ -126,104 +126,135 @@ const DataSourcePage = () => {
 
   return (
     <>
-      <div className="min-h-full bg-[#f7f8fa] text-[#161823]">
-        <motion.div
+      <div className="relative min-h-full overflow-hidden bg-[#f7f8fa] text-[#242731]">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -right-[120px] -top-[150px] h-[360px] w-[620px] rounded-full bg-[radial-gradient(ellipse_at_center,rgba(175,220,239,0.18)_0%,rgba(213,235,244,0.08)_48%,rgba(255,255,255,0)_74%)] blur-[24px]"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -bottom-[220px] -right-[170px] h-[430px] w-[620px] rounded-full bg-[radial-gradient(circle_at_center,rgba(230,238,181,0.20),rgba(255,255,255,0)_70%)] blur-[22px]"
+        />
+
+        <motion.main
           initial="hidden"
           animate="visible"
           variants={PAGE_ANIMATION.sectionStagger}
-          className="min-h-[calc(100vh-132px)] rounded-[10px] border border-black/[0.025] bg-white px-[34px] pb-[38px] pt-[30px] shadow-[0_2px_12px_rgba(22,24,35,0.025)] max-xl:px-[26px]"
+          className="relative z-10 px-4 pb-4 pt-4"
         >
-          <motion.div variants={PAGE_ANIMATION.fadeUp}>
+          <motion.section
+            variants={PAGE_ANIMATION.fadeUp}
+            className="rounded-[22px] border border-[#f1f1f1] bg-white/[0.76] px-[22px] pb-[22px] pt-6 backdrop-blur-[8px]"
+          >
             <DataSourcePageHeader
               canCreate={permissions.canCreate}
               onCreate={handleCreate}
             />
-          </motion.div>
+            <DataSourceSummaryCards summary={summary} />
+          </motion.section>
 
-          <DataSourceSummaryCards summary={summary} />
-
-          <DataSourceToolbar
-            environment={environment}
-            dbType={dbType}
-            keyword={keyword}
-            viewMode={viewMode}
-            hasActiveFilters={hasActiveFilters}
-            onEnvironmentChange={setEnvironment}
-            onDbTypeChange={setDbType}
-            onKeywordChange={setKeyword}
-            onViewModeChange={setViewMode}
-            onReset={resetFilters}
-          />
-
-          <motion.div
+          <motion.section
             variants={PAGE_ANIMATION.fadeUp}
-            className="mb-3 mt-[15px] text-[11px] text-black/40"
+            className="mt-4 min-h-[420px] rounded-[22px] border border-[#f1f1f1] bg-white/[0.82] px-[22px] pb-[22px] pt-5 backdrop-blur-[8px]"
           >
-            共找到
-            <strong className="mx-1 font-semibold text-black/75">
-              {pagination.total}
-            </strong>
-            个数据源
-            {hasActiveFilters ? ' · 当前为筛选结果' : null}
-          </motion.div>
-
-          <Spin spinning={loading}>
-            <motion.section
-              variants={PAGE_ANIMATION.cardStagger}
-              initial="hidden"
-              animate="visible"
-              className={
-                viewMode === 'list'
-                  ? 'grid grid-cols-1 gap-4'
-                  : 'grid grid-cols-[repeat(auto-fill,minmax(350px,1fr))] gap-4'
-              }
-            >
-              {records.map((record, index) => (
-                <DataSourceCard
-                  key={
-                    dataSourceRecordKey(record.id) ||
-                    `${record.name || 'data-source'}-${index}`
-                  }
-                  record={record}
-                  viewMode={viewMode}
-                  permissions={permissions}
-                  testingId={testingId}
-                  editingId={editingId}
-                  onEdit={(item) => void handleEdit(item)}
-                  onDelete={handleDelete}
-                  onTestConnection={(item) => void handleTestConnection(item)}
-                />
-              ))}
-            </motion.section>
-
-            {!loading && records.length === 0 ? (
-              <DataSourceEmptyState
-                filtered={hasActiveFilters}
-                canCreate={permissions.canCreate}
-                onReset={resetFilters}
-                onCreate={handleCreate}
-              />
-            ) : null}
-          </Spin>
-
-          {pagination.total > 0 ? (
-            <div className="mt-6 flex justify-end">
-              <Pagination
-                current={pagination.pageNo}
-                pageSize={pagination.pageSize}
-                total={pagination.total}
-                showSizeChanger
-                showQuickJumper
-                pageSizeOptions={DATA_SOURCE_PAGE_SIZE_OPTIONS}
-                disabled={loading}
-                showTotal={(total, range) =>
-                  `第 ${range[0]}-${range[1]} 条，共 ${total} 条`
-                }
-                onChange={changePage}
-              />
+            <div className="flex items-end justify-between gap-6">
+              <div>
+                <h2 className="m-0 text-[18px] font-semibold leading-7 tracking-[-0.3px] text-[#292c35]">
+                  数据源列表
+                </h2>
+                <p className="mb-0 mt-0.5 text-[12px] leading-5 text-[#9a9ea7]">
+                  按运行环境与类型筛选，快速检查连接状态
+                </p>
+              </div>
             </div>
-          ) : null}
-        </motion.div>
+
+            <DataSourceToolbar
+              environment={environment}
+              dbType={dbType}
+              keyword={keyword}
+              viewMode={viewMode}
+              hasActiveFilters={hasActiveFilters}
+              onEnvironmentChange={setEnvironment}
+              onDbTypeChange={setDbType}
+              onKeywordChange={setKeyword}
+              onViewModeChange={setViewMode}
+              onReset={resetFilters}
+            />
+
+            <motion.div
+              variants={PAGE_ANIMATION.fadeUp}
+              className="mb-3.5 mt-4 flex items-center gap-1 text-[11px] leading-5 text-[#9b9fa8]"
+            >
+              <span>共找到</span>
+              <strong className="font-semibold text-[#5f646e]">
+                {pagination.total}
+              </strong>
+              <span>个数据源</span>
+              {hasActiveFilters ? (
+                <span className="ml-1 rounded-full bg-[#f3f4f6] px-2 py-0.5 text-[10px] text-[#858a94]">
+                  筛选结果
+                </span>
+              ) : null}
+            </motion.div>
+
+            <Spin spinning={loading}>
+              <motion.section
+                variants={PAGE_ANIMATION.cardStagger}
+                initial="hidden"
+                animate="visible"
+                className={
+                  viewMode === 'list'
+                    ? 'grid grid-cols-1 gap-[14px]'
+                    : 'grid grid-cols-1 gap-[14px] md:grid-cols-2 2xl:grid-cols-3'
+                }
+              >
+                {records.map((record, index) => (
+                  <DataSourceCard
+                    key={
+                      dataSourceRecordKey(record.id) ||
+                      `${record.name || 'data-source'}-${index}`
+                    }
+                    record={record}
+                    viewMode={viewMode}
+                    permissions={permissions}
+                    testingId={testingId}
+                    editingId={editingId}
+                    onEdit={(item) => void handleEdit(item)}
+                    onDelete={handleDelete}
+                    onTestConnection={(item) => void handleTestConnection(item)}
+                  />
+                ))}
+              </motion.section>
+
+              {!loading && records.length === 0 ? (
+                <DataSourceEmptyState
+                  filtered={hasActiveFilters}
+                  canCreate={permissions.canCreate}
+                  onReset={resetFilters}
+                  onCreate={handleCreate}
+                />
+              ) : null}
+            </Spin>
+
+            {pagination.total > 0 ? (
+              <div className="mt-6 flex justify-end border-t border-[#f0f1f3] pt-4">
+                <Pagination
+                  current={pagination.pageNo}
+                  pageSize={pagination.pageSize}
+                  total={pagination.total}
+                  showSizeChanger
+                  showQuickJumper
+                  pageSizeOptions={DATA_SOURCE_PAGE_SIZE_OPTIONS}
+                  disabled={loading}
+                  showTotal={(total, range) =>
+                    `第 ${range[0]}-${range[1]} 条，共 ${total} 条`
+                  }
+                  onChange={changePage}
+                />
+              </div>
+            ) : null}
+          </motion.section>
+        </motion.main>
       </div>
 
       <AddOrEditDataSourceModal ref={modalRef} />


### PR DESCRIPTION
## What changed

- align the data-source page layout, spacing, panel treatment, and typography with the redesigned homepage
- split the page into a lightweight overview panel and a focused data-source list panel
- redesign summary metrics as independent cards with softer hierarchy and hover feedback
- polish environment tabs, type/search filters, reset action, and grid/list switcher
- redesign data-source cards with clearer connection info, URL treatment, metadata, actions, and responsive density
- keep existing create/edit/delete/test connection/filter/pagination behavior unchanged

## Validation

- TypeScript syntax/transpile check for all 5 changed TSX files: passed
- verified the branch is based on the latest `main` at PR creation and only changes the 5 data-source UI files
- full `npm run lint` / frontend build was not run locally because this execution environment cannot clone/install the repository dependencies