### PR TITLE
refactor(ui): simplify YakOpsEmpty caption

### DIFF
--- a/yak-ops-ui/src/components/YakOpsEmpty/index.tsx
+++ b/yak-ops-ui/src/components/YakOpsEmpty/index.tsx
@@ -11,9 +11,9 @@ export interface YakOpsEmptyProps
   height?: number | string;
   /** @deprecated PNG 插画不再支持动态强调色，仅保留用于兼容现有调用方。 */
   primaryColor?: string;
-  /** 空状态主文案，同时作为图片无障碍标题。 */
+  /** 空状态文案，同时作为图片无障碍标题。 */
   title?: string;
-  /** 空状态补充说明；传入后默认展示在插画下方。 */
+  /** 空状态补充说明，仅用于无障碍描述。 */
   description?: string;
   /** 是否展示插画下方的空状态文案，默认在传入 description 时开启。 */
   showCaption?: boolean;
@@ -22,8 +22,7 @@ export interface YakOpsEmptyProps
 /**
  * Yak Ops 空状态插画。
  *
- * 统一使用 public/empty.png，并在需要时展示简洁的空状态说明，
- * 避免页面只保留插画时显得过于单调。
+ * 统一使用 public/empty.png，并按需在插画下方展示一句空状态文案。
  */
 const YakOpsEmpty: React.FC<YakOpsEmptyProps> = ({
   width = 220,
@@ -51,15 +50,8 @@ const YakOpsEmpty: React.FC<YakOpsEmptyProps> = ({
       />
 
       {shouldShowCaption ? (
-        <div className="mt-2 max-w-[320px] px-3">
-          <div className="text-[13px] font-medium leading-5 text-[#667085]">
-            {title}
-          </div>
-          {description ? (
-            <div className="mt-1 text-[12px] leading-5 text-[#98a2b3]">
-              {description}
-            </div>
-          ) : null}
+        <div className="mt-2 max-w-[320px] px-3 text-[13px] leading-5 text-[#667085]">
+          {title}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

- simplify `YakOpsEmpty` to show only one visible sentence below the illustration
- keep `description` for accessibility text only, instead of rendering it as a second line
- preserve existing image sizing and empty-state behavior

## Verification

- compared against current `main`; only `yak-ops-ui/src/components/YakOpsEmpty/index.tsx` changes
- 1 commit, 1 file changed
- full frontend lint/typecheck/browser regression not run in this environment