### PR TITLE
perf(sync): Stage 3.1 强化数据预览物理限流

### DIFF
--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -326,6 +326,13 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
 
   private String buildPreviewQuery(DataSourceCatalogReadRequest request, int limit) {
     String query = buildQuery(request);
+    if (!request.sqlMode()) {
+      return switch (connection.dbType()) {
+        case ORACLE, DAMENG -> query + " WHERE ROWNUM <= " + limit;
+        case MYSQL, POSTGRE_SQL, DORIS, KINGBASE -> query + " LIMIT " + limit;
+      };
+    }
+
     return switch (connection.dbType()) {
       case ORACLE, DAMENG ->
           "SELECT * FROM (" + query + ") yak_ops_preview WHERE ROWNUM <= " + limit;

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -192,10 +192,11 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   public DataSourceQueryResult preview(DataSourceCatalogReadRequest request, int limit) {
     DataSourceCatalogReadRequest value = requireRequest(request);
     int safeLimit = Math.max(1, Math.min(limit, 200));
-    String query = buildQuery(value);
+    String query = buildPreviewQuery(value, safeLimit);
     try (Connection opened = openConnection();
         PreparedStatement statement = opened.prepareStatement(query)) {
       statement.setQueryTimeout(queryTimeoutSeconds);
+      // Keep the JDBC-level cap as a second line of defense even though the SQL is already bounded.
       statement.setMaxRows(safeLimit);
       try (ResultSet resultSet = statement.executeQuery()) {
         ResultSetMetaData metadata = resultSet.getMetaData();
@@ -321,6 +322,16 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
       return stripTrailingSemicolon(resolveSql(request.query(), request));
     }
     return "SELECT * FROM " + buildTableReference(resolveTablePath(request.tablePath()));
+  }
+
+  private String buildPreviewQuery(DataSourceCatalogReadRequest request, int limit) {
+    String query = buildQuery(request);
+    return switch (connection.dbType()) {
+      case ORACLE, DAMENG ->
+          "SELECT * FROM (" + query + ") yak_ops_preview WHERE ROWNUM <= " + limit;
+      case MYSQL, POSTGRE_SQL, DORIS, KINGBASE ->
+          "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
+    };
   }
 
   private DataSourceCatalogReadRequest requireRequest(DataSourceCatalogReadRequest request) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
@@ -85,9 +85,7 @@ class GenericJdbcCatalogTypedRequestTest {
 
     ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
     verify(opened).prepareStatement(sqlCaptor.capture());
-    assertThat(sqlCaptor.getValue())
-        .isEqualTo(
-            "SELECT * FROM (SELECT * FROM `demo`.`orders`) yak_ops_preview LIMIT 20");
+    assertThat(sqlCaptor.getValue()).isEqualTo("SELECT * FROM `demo`.`orders` LIMIT 20");
     assertThat(result.getData()).hasSize(1);
     assertThat(result.getTotal()).isEqualTo(1L);
     assertThat(countCalls.get()).isZero();

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalogTypedRequestTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class GenericJdbcCatalogTypedRequestTest {
 
@@ -50,7 +51,7 @@ class GenericJdbcCatalogTypedRequestTest {
   }
 
   @Test
-  void previewDoesNotCountAndAppliesIndependentQueryTimeout() throws Exception {
+  void previewDoesNotCountAndAppliesSqlAndJdbcLimits() throws Exception {
     Connection opened = mock(Connection.class);
     PreparedStatement statement = mock(PreparedStatement.class);
     ResultSet resultSet = mock(ResultSet.class);
@@ -82,9 +83,84 @@ class GenericJdbcCatalogTypedRequestTest {
     DataSourceQueryResult result =
         catalog.preview(DataSourceCatalogReadRequest.table("orders", Map.of()), 20);
 
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(opened).prepareStatement(sqlCaptor.capture());
+    assertThat(sqlCaptor.getValue())
+        .isEqualTo(
+            "SELECT * FROM (SELECT * FROM `demo`.`orders`) yak_ops_preview LIMIT 20");
     assertThat(result.getData()).hasSize(1);
     assertThat(result.getTotal()).isEqualTo(1L);
     assertThat(countCalls.get()).isZero();
+    verify(statement).setQueryTimeout(13);
+    verify(statement).setMaxRows(20);
+  }
+
+  @Test
+  void customSqlPreviewAddsOuterLimitWithoutRewritingUserSql() throws Exception {
+    Connection opened = mock(Connection.class);
+    PreparedStatement statement = mock(PreparedStatement.class);
+    ResultSet resultSet = mock(ResultSet.class);
+    ResultSetMetaData metadata = mock(ResultSetMetaData.class);
+
+    when(opened.prepareStatement(anyString())).thenReturn(statement);
+    when(statement.executeQuery()).thenReturn(resultSet);
+    when(resultSet.getMetaData()).thenReturn(metadata);
+    when(metadata.getColumnCount()).thenReturn(0);
+    when(resultSet.next()).thenReturn(false);
+
+    GenericJdbcCatalog catalog =
+        new GenericJdbcCatalog(connection(), 5, 13) {
+          @Override
+          protected Connection openConnection() {
+            return opened;
+          }
+        };
+
+    catalog.preview(
+        DataSourceCatalogReadRequest.sql(
+            "select * from orders order by created_at desc limit 1000;", Map.of()),
+        20);
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(opened).prepareStatement(sqlCaptor.capture());
+    assertThat(sqlCaptor.getValue())
+        .isEqualTo(
+            "SELECT * FROM (select * from orders order by created_at desc limit 1000) "
+                + "yak_ops_preview LIMIT 20");
+  }
+
+  @Test
+  void oraclePreviewUsesRowNumGuard() throws Exception {
+    Connection opened = mock(Connection.class);
+    PreparedStatement statement = mock(PreparedStatement.class);
+    ResultSet resultSet = mock(ResultSet.class);
+    ResultSetMetaData metadata = mock(ResultSetMetaData.class);
+
+    when(opened.prepareStatement(anyString())).thenReturn(statement);
+    when(statement.executeQuery()).thenReturn(resultSet);
+    when(resultSet.getMetaData()).thenReturn(metadata);
+    when(metadata.getColumnCount()).thenReturn(0);
+    when(resultSet.next()).thenReturn(false);
+
+    GenericJdbcCatalog catalog =
+        new GenericJdbcCatalog(oracleConnection(), 5, 13) {
+          @Override
+          protected Connection openConnection() {
+            return opened;
+          }
+        };
+
+    catalog.preview(
+        DataSourceCatalogReadRequest.sql(
+            "select * from patient order by patient_id", Map.of()),
+        20);
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(opened).prepareStatement(sqlCaptor.capture());
+    assertThat(sqlCaptor.getValue())
+        .isEqualTo(
+            "SELECT * FROM (select * from patient order by patient_id) "
+                + "yak_ops_preview WHERE ROWNUM <= 20");
     verify(statement).setQueryTimeout(13);
     verify(statement).setMaxRows(20);
   }


### PR DESCRIPTION
## 背景

Stage 1 已经移除了数据预览自动 `COUNT(*)` 全表的行为，当前打开预览只请求前 20 条；Stage 2 / 3 又补了 query timeout 和可观测性。

但 JDBC 预览目前仍主要依赖 `PreparedStatement#setMaxRows(20)`。这能限制返回给 JVM 的 ResultSet 行数，却不等价于数据库执行计划一定在 SQL 层只处理 20 行。对于千万级大表，尤其 MySQL Connector/J 等可能默认缓冲结果集的场景，更稳妥的做法是把“预览最多 20 条”直接写进数据库实际执行的 SQL，同时保留 JDBC cap 和 query timeout 作为双保险。

## 本次改动

### 1. 表模式预览直接下推物理行数限制

简单表预览不再执行：

```sql
SELECT * FROM table
```

再只靠 `setMaxRows(20)` 截断，而是直接生成方言 SQL：

- MySQL / PostgreSQL / Doris / Kingbase：`SELECT * FROM ... LIMIT 20`
- Oracle / 达梦：`SELECT * FROM ... WHERE ROWNUM <= 20`

这样对于普通大表预览，限制能够直接进入数据库执行计划，不需要先产生一个无界结果集再依赖 JDBC 驱动截断。

### 2. 自定义 SQL 使用外层 Preview Guard

为了不直接改写用户 SQL 内部结构，自定义 SQL 统一包一层外部限制：

MySQL / PostgreSQL / Doris / Kingbase：

```sql
SELECT * FROM (
  <user sql>
) yak_ops_preview
LIMIT 20
```

Oracle / 达梦：

```sql
SELECT * FROM (
  <user sql>
) yak_ops_preview
WHERE ROWNUM <= 20
```

用户 SQL 尾部分号会继续沿用现有逻辑去除；即使用户 SQL 自己已经有 `LIMIT 1000`，外层仍会保证最终最多返回 20 条。

### 3. 保留 JDBC / timeout 双保险

SQL 已经物理限流后，仍保留：

- `statement.setMaxRows(20)`
- `statement.setQueryTimeout(...)`
- Java 侧最多读取 20 行

形成三层保护：

`SQL row limit -> JDBC maxRows -> Java row cap`

同时不会重新引入 `COUNT(*)`。

## 兼容性说明

- 不修改前端请求结构
- `/getTop20Data/{id}` 接口保持不变
- `/count/{id}` 仍然是显式调用才执行，不会被预览自动触发
- `count()` 自身仍使用原始查询，不受本次 preview limit 影响
- 覆盖当前 JDBC 数据源类型：MySQL、Oracle、PostgreSQL、Doris、KingbaseES、达梦

## 一个需要明确的边界

本 PR 解决的是“预览结果集无界”和普通表预览可能产生过大 JDBC 结果集的问题。

对于复杂自定义 SQL，例如包含 `GROUP BY / ORDER BY / JOIN / DISTINCT` 的查询，外层 `LIMIT / ROWNUM` 只能保证最终返回 20 行，数据库为了计算这 20 行仍可能扫描大量底层数据。此类场景继续由现有 query timeout 保护，不能把 SQL-level limit 理解成任意复杂 SQL 都只会扫描 20 行。

## 测试覆盖

补充/调整单元测试：

- 普通 MySQL 表预览实际 SQL 为 `... LIMIT 20`
- preview 不调用 `count()`
- JDBC `setMaxRows` 和独立 query timeout 继续生效
- 用户 SQL 自己带 `LIMIT 1000` 时仍会被外层限制到 20
- Oracle 自定义 SQL 使用 `ROWNUM <= 20`
- Stage 3 的 Oracle metadata scope 测试继续保留

## 验证

已补充针对性单元测试代码。当前执行环境无法完整 checkout 仓库实际跑 Maven，因此合并前建议最小补跑：

1. datasource JDBC plugin 单测
2. MySQL 千万级表点击“数据预览”，确认实际执行 SQL 带 `LIMIT 20`
3. Oracle 大表预览，确认实际执行 SQL 带 `ROWNUM <= 20`
4. 自定义 SQL（已有 LIMIT / ORDER BY）预览，确认最终最多返回 20 条
5. 浏览器 Network 确认打开数据预览仍只有 `/getTop20Data/{id}`，没有自动 `/count/{id}`
6. 用慢 SQL 验证 query timeout 仍能正常终止
