### PR TITLE
refactor(ui): simplify data source management layout

### DIFF
--- a/yak-ops-ui/src/pages/data-source/components/DataSourcePageHeader.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourcePageHeader.tsx
@@ -10,20 +10,14 @@ const DataSourcePageHeader = ({
   canCreate,
   onCreate,
 }: DataSourcePageHeaderProps) => (
-  <header className="flex items-center justify-between gap-8 max-md:items-start">
-    <div className="flex min-w-0 items-center gap-3.5">
-      <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[13px] border border-[rgba(31,35,41,0.07)] bg-[linear-gradient(145deg,#f7f9fc_0%,#eef2f7_100%)] text-[#4f5968] shadow-[0_4px_12px_rgba(31,35,41,0.04)]">
-        <Database size={21} strokeWidth={1.8} />
+  <header className="flex items-center justify-between gap-6">
+    <div className="flex min-w-0 items-center gap-3">
+      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] border border-[rgba(31,35,41,0.07)] bg-[#f7f8fa] text-[#4f5968]">
+        <Database size={19} strokeWidth={1.85} />
       </span>
-
-      <div className="min-w-0">
-        <h1 className="m-0 text-xl font-semibold leading-7 tracking-[-0.35px] text-[#252832]">
-          数据源管理
-        </h1>
-        <p className="mb-0 mt-1 text-[13px] leading-5 text-[#9498a1]">
-          统一管理开发、测试与生产环境的数据连接
-        </p>
-      </div>
+      <h1 className="m-0 text-xl font-semibold leading-7 tracking-[-0.35px] text-[#252832]">
+        数据源管理
+      </h1>
     </div>
 
     {canCreate ? (

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceSummaryCards.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceSummaryCards.tsx
@@ -11,48 +11,34 @@ interface SummaryItem {
     'total' | 'connected' | 'disconnected' | 'environmentCount'
   >;
   label: string;
-  description: string;
   icon: ReactNode;
   iconClassName: string;
-  glowClassName: string;
 }
 
 const SUMMARY_ITEMS: SummaryItem[] = [
   {
     key: 'total',
     label: '全部数据源',
-    description: '当前已接入',
-    icon: <Database size={19} strokeWidth={1.85} />,
-    iconClassName:
-      'bg-[linear-gradient(145deg,#eef2ff_0%,#e4eaff_100%)] text-[#5669da]',
-    glowClassName: 'bg-[#7388ff]/10',
+    icon: <Database size={18} strokeWidth={1.85} />,
+    iconClassName: 'bg-[#eef2ff] text-[#5669da]',
   },
   {
     key: 'connected',
     label: '连接正常',
-    description: '可正常访问',
-    icon: <CheckCircle2 size={19} strokeWidth={1.85} />,
-    iconClassName:
-      'bg-[linear-gradient(145deg,#eef9f2_0%,#e2f5e8_100%)] text-[#28a251]',
-    glowClassName: 'bg-[#42ba6f]/10',
+    icon: <CheckCircle2 size={18} strokeWidth={1.85} />,
+    iconClassName: 'bg-[#eef9f2] text-[#28a251]',
   },
   {
     key: 'disconnected',
     label: '连接异常',
-    description: '需要关注',
-    icon: <XCircle size={19} strokeWidth={1.85} />,
-    iconClassName:
-      'bg-[linear-gradient(145deg,#fff2f3_0%,#ffe7e9_100%)] text-[#e55763]',
-    glowClassName: 'bg-[#ef6570]/10',
+    icon: <XCircle size={18} strokeWidth={1.85} />,
+    iconClassName: 'bg-[#fff1f2] text-[#e55763]',
   },
   {
     key: 'environmentCount',
     label: '运行环境',
-    description: '已覆盖环境',
-    icon: <Server size={19} strokeWidth={1.85} />,
-    iconClassName:
-      'bg-[linear-gradient(145deg,#f1f4f7_0%,#e8edf2_100%)] text-[#667487]',
-    glowClassName: 'bg-[#738196]/10',
+    icon: <Server size={18} strokeWidth={1.85} />,
+    iconClassName: 'bg-[#f0f3f6] text-[#667487]',
   },
 ];
 
@@ -63,47 +49,28 @@ interface DataSourceSummaryCardsProps {
 const DataSourceSummaryCards = ({ summary }: DataSourceSummaryCardsProps) => (
   <motion.section
     variants={PAGE_ANIMATION.cardStagger}
-    className="mt-5 grid grid-cols-1 gap-[14px] sm:grid-cols-2 xl:grid-cols-4"
+    className="mt-5 grid grid-cols-2 gap-x-6 border-y border-[#eef0f2] lg:grid-cols-4 lg:gap-x-8"
   >
     {SUMMARY_ITEMS.map((item) => (
       <motion.div
         key={item.key}
         variants={PAGE_ANIMATION.fadeUp}
-        className="group relative min-h-[104px] overflow-hidden rounded-[16px] border border-[rgba(31,35,41,0.075)] bg-white/[0.96] px-[18px] py-4 shadow-[0_3px_10px_rgba(31,35,41,0.04),0_1px_2px_rgba(31,35,41,0.02)] transition-[transform,border-color,box-shadow] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)] hover:-translate-y-px hover:border-[rgba(31,35,41,0.10)] hover:shadow-[0_8px_20px_rgba(31,35,41,0.065),0_1px_2px_rgba(31,35,41,0.02)]"
+        className="flex min-h-[74px] min-w-0 items-center gap-3 py-4"
       >
         <span
-          aria-hidden="true"
           className={[
-            'pointer-events-none absolute -right-8 -top-10 h-28 w-28 rounded-full blur-2xl transition-transform duration-300 group-hover:scale-110',
-            item.glowClassName,
+            'flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px]',
+            item.iconClassName,
           ].join(' ')}
-        />
-
-        <div className="relative flex items-start justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-3">
-            <span
-              className={[
-                'flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border border-white/80 shadow-[0_4px_10px_rgba(31,35,41,0.035)]',
-                item.iconClassName,
-              ].join(' ')}
-            >
-              {item.icon}
-            </span>
-
-            <div className="min-w-0">
-              <div className="truncate text-[13px] font-medium leading-5 text-[#626771]">
-                {item.label}
-              </div>
-              <div className="mt-0.5 truncate text-[11px] leading-[18px] text-[#a3a7af]">
-                {item.description}
-              </div>
-            </div>
-          </div>
-
-          <strong className="shrink-0 text-[28px] font-semibold leading-9 tracking-[-0.8px] text-[#252832]">
-            {summary[item.key]}
-          </strong>
-        </div>
+        >
+          {item.icon}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#686d76]">
+          {item.label}
+        </span>
+        <strong className="shrink-0 text-[24px] font-semibold leading-8 tracking-[-0.6px] text-[#252832]">
+          {summary[item.key]}
+        </strong>
       </motion.div>
     ))}
   </motion.section>

--- a/yak-ops-ui/src/pages/data-source/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/index.tsx
@@ -126,47 +126,23 @@ const DataSourcePage = () => {
 
   return (
     <>
-      <div className="relative min-h-full overflow-hidden bg-[#f7f8fa] text-[#242731]">
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -right-[120px] -top-[150px] h-[360px] w-[620px] rounded-full bg-[radial-gradient(ellipse_at_center,rgba(175,220,239,0.18)_0%,rgba(213,235,244,0.08)_48%,rgba(255,255,255,0)_74%)] blur-[24px]"
-        />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -bottom-[220px] -right-[170px] h-[430px] w-[620px] rounded-full bg-[radial-gradient(circle_at_center,rgba(230,238,181,0.20),rgba(255,255,255,0)_70%)] blur-[22px]"
-        />
-
+      <div className="min-h-full bg-[#f7f8fa] text-[#242731]">
         <motion.main
           initial="hidden"
           animate="visible"
           variants={PAGE_ANIMATION.sectionStagger}
-          className="relative z-10 px-4 pb-4 pt-4"
+          className="px-4 pb-4 pt-4"
         >
           <motion.section
             variants={PAGE_ANIMATION.fadeUp}
-            className="rounded-[22px] border border-[#f1f1f1] bg-white/[0.76] px-[22px] pb-[22px] pt-6 backdrop-blur-[8px]"
+            className="rounded-[18px] border border-[#eef0f2] bg-white px-6 pb-5 pt-5 shadow-[0_2px_10px_rgba(31,35,41,0.025)] max-md:px-4"
           >
             <DataSourcePageHeader
               canCreate={permissions.canCreate}
               onCreate={handleCreate}
             />
-            <DataSourceSummaryCards summary={summary} />
-          </motion.section>
 
-          <motion.section
-            variants={PAGE_ANIMATION.fadeUp}
-            className="mt-4 min-h-[420px] rounded-[22px] border border-[#f1f1f1] bg-white/[0.82] px-[22px] pb-[22px] pt-5 backdrop-blur-[8px]"
-          >
-            <div className="flex items-end justify-between gap-6">
-              <div>
-                <h2 className="m-0 text-[18px] font-semibold leading-7 tracking-[-0.3px] text-[#292c35]">
-                  数据源列表
-                </h2>
-                <p className="mb-0 mt-0.5 text-[12px] leading-5 text-[#9a9ea7]">
-                  按运行环境与类型筛选，快速检查连接状态
-                </p>
-              </div>
-            </div>
+            <DataSourceSummaryCards summary={summary} />
 
             <DataSourceToolbar
               environment={environment}
@@ -181,22 +157,6 @@ const DataSourcePage = () => {
               onReset={resetFilters}
             />
 
-            <motion.div
-              variants={PAGE_ANIMATION.fadeUp}
-              className="mb-3.5 mt-4 flex items-center gap-1 text-[11px] leading-5 text-[#9b9fa8]"
-            >
-              <span>共找到</span>
-              <strong className="font-semibold text-[#5f646e]">
-                {pagination.total}
-              </strong>
-              <span>个数据源</span>
-              {hasActiveFilters ? (
-                <span className="ml-1 rounded-full bg-[#f3f4f6] px-2 py-0.5 text-[10px] text-[#858a94]">
-                  筛选结果
-                </span>
-              ) : null}
-            </motion.div>
-
             <Spin spinning={loading}>
               <motion.section
                 variants={PAGE_ANIMATION.cardStagger}
@@ -204,8 +164,8 @@ const DataSourcePage = () => {
                 animate="visible"
                 className={
                   viewMode === 'list'
-                    ? 'grid grid-cols-1 gap-[14px]'
-                    : 'grid grid-cols-1 gap-[14px] md:grid-cols-2 2xl:grid-cols-3'
+                    ? 'mt-4 grid grid-cols-1 gap-[14px]'
+                    : 'mt-4 grid grid-cols-1 gap-[14px] md:grid-cols-2 2xl:grid-cols-3'
                 }
               >
                 {records.map((record, index) => (
@@ -237,7 +197,7 @@ const DataSourcePage = () => {
             </Spin>
 
             {pagination.total > 0 ? (
-              <div className="mt-6 flex justify-end border-t border-[#f0f1f3] pt-4">
+              <div className="mt-5 flex justify-end border-t border-[#eef0f2] pt-4">
                 <Pagination
                   current={pagination.pageNo}
                   pageSize={pagination.pageSize}


### PR DESCRIPTION
## What changed

- merge the data-source header, summary, filters, cards, and pagination into one continuous surface instead of two stacked page blocks
- remove the redundant header subtitle, the “数据源列表” heading/description, and the extra result-count copy
- flatten the four summary metrics from standalone cards into a lightweight inline statistics row with no secondary descriptions
- remove the fixed list-area min-height so the page follows the actual data height and no longer leaves a large blank area under a small result set
- keep create/edit/delete/test connection/filter/view-mode/pagination behavior unchanged

## Validation

- TypeScript `transpileModule` syntax check passed for all 3 changed TSX files
- branch is rebased onto the latest `main` at PR creation and contains a single commit touching only the data-source UI files
- full frontend lint/build and browser regression were not run in this execution environment