### PR TITLE
refactor(ui): pin data source pagination to page footer

### DIFF
--- a/yak-ops-ui/src/pages/data-source/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/index.tsx
@@ -126,12 +126,12 @@ const DataSourcePage = () => {
 
   return (
     <>
-      <div className="min-h-full bg-[#f7f8fa] text-[#242731]">
+      <div className="min-h-[calc(100dvh-56px)] bg-[#f7f8fa] text-[#242731]">
         <motion.main
           initial="hidden"
           animate="visible"
           variants={PAGE_ANIMATION.sectionStagger}
-          className="px-4 pb-4 pt-4"
+          className="flex min-h-[calc(100dvh-56px)] flex-col px-4 pb-4 pt-4"
         >
           <motion.section
             variants={PAGE_ANIMATION.fadeUp}
@@ -195,25 +195,28 @@ const DataSourcePage = () => {
                 />
               ) : null}
             </Spin>
-
-            {pagination.total > 0 ? (
-              <div className="mt-5 flex justify-end border-t border-[#eef0f2] pt-4">
-                <Pagination
-                  current={pagination.pageNo}
-                  pageSize={pagination.pageSize}
-                  total={pagination.total}
-                  showSizeChanger
-                  showQuickJumper
-                  pageSizeOptions={DATA_SOURCE_PAGE_SIZE_OPTIONS}
-                  disabled={loading}
-                  showTotal={(total, range) =>
-                    `第 ${range[0]}-${range[1]} 条，共 ${total} 条`
-                  }
-                  onChange={changePage}
-                />
-              </div>
-            ) : null}
           </motion.section>
+
+          {pagination.total > 0 ? (
+            <motion.footer
+              variants={PAGE_ANIMATION.fadeUp}
+              className="mt-auto flex shrink-0 justify-end pt-4"
+            >
+              <Pagination
+                current={pagination.pageNo}
+                pageSize={pagination.pageSize}
+                total={pagination.total}
+                showSizeChanger
+                showQuickJumper
+                pageSizeOptions={DATA_SOURCE_PAGE_SIZE_OPTIONS}
+                disabled={loading}
+                showTotal={(total, range) =>
+                  `第 ${range[0]}-${range[1]} 条，共 ${total} 条`
+                }
+                onChange={changePage}
+              />
+            </motion.footer>
+          ) : null}
         </motion.main>
       </div>
 


### PR DESCRIPTION
## What changed

- remove the detached white area below the data-source panel by making the page own the remaining viewport background
- move pagination out of the white data-source card and anchor it to the bottom of the page layout
- keep the data-source content panel compact around the actual records instead of stretching it just to hold pagination
- preserve the existing create/edit/delete/test connection/filter/view-mode/pagination behavior

## Validation

- branch is based on the current `main` and contains a single commit
- only `yak-ops-ui/src/pages/data-source/index.tsx` is changed
- full frontend lint/build and browser regression were not run in this execution environment