### PR TITLE
refactor(home): unify empty states with YakOpsEmpty

### DIFF
--- a/yak-ops-ui/src/pages/home/components/DataCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter.tsx
@@ -1,3 +1,4 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import YakTab from '@/components/YakTab';
 import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
@@ -332,59 +333,82 @@ function TrendChart({ values, labels, name }: TrendChartProps) {
   );
 }
 
-function LatestTaskCard({ task }: { task?: HomeLatestTask }) {
+function LatestTaskCard({
+  task,
+  loading,
+  failed,
+}: {
+  task?: HomeLatestTask;
+  loading: boolean;
+  failed: boolean;
+}) {
   return (
     <aside className="w-full shrink-0 lg:w-[220px] lg:border-r lg:border-[#edf0f3] lg:pr-5">
       <div className="mb-2 text-[13px] font-semibold leading-5 text-[#353842]">
         最新任务
       </div>
 
-      <button
-        type="button"
-        onClick={() => goToDetail(task?.detailPath)}
-        className="group relative h-[266px] w-full overflow-hidden rounded-[10px] border border-[#e8ebef] bg-[linear-gradient(150deg,#6c737d_0%,#9197a0_48%,#c0c4ca_100%)] text-left text-white transition-[border-color,transform] duration-200 hover:-translate-y-px hover:border-[#dfe3e8] lg:w-[198px]"
-      >
-        <div className="pointer-events-none absolute inset-0 opacity-[0.18] [background-image:linear-gradient(rgba(255,255,255,.28)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.22)_1px,transparent_1px)] [background-size:22px_22px]" />
-        <div className="pointer-events-none absolute -right-9 top-10 h-32 w-32 rounded-full border border-white/20" />
-        <div className="pointer-events-none absolute -right-2 top-16 h-24 w-24 rounded-full border border-white/20" />
+      {task ? (
+        <button
+          type="button"
+          onClick={() => goToDetail(task.detailPath)}
+          className="group relative h-[266px] w-full overflow-hidden rounded-[10px] border border-[#e8ebef] bg-[linear-gradient(150deg,#6c737d_0%,#9197a0_48%,#c0c4ca_100%)] text-left text-white transition-[border-color,transform] duration-200 hover:-translate-y-px hover:border-[#dfe3e8] lg:w-[198px]"
+        >
+          <div className="pointer-events-none absolute inset-0 opacity-[0.18] [background-image:linear-gradient(rgba(255,255,255,.28)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.22)_1px,transparent_1px)] [background-size:22px_22px]" />
+          <div className="pointer-events-none absolute -right-9 top-10 h-32 w-32 rounded-full border border-white/20" />
+          <div className="pointer-events-none absolute -right-2 top-16 h-24 w-24 rounded-full border border-white/20" />
 
-        <div className="absolute left-4 top-3 z-10">
-          <div className="text-[12px] font-semibold text-white/95">{taskTypeLabel(task?.taskType)}</div>
-          <div className="mt-0.5 text-[11px] text-white/80">{formatCardDuration(task?.durationMs)}</div>
-        </div>
-
-        <Copy
-          size={14}
-          strokeWidth={1.8}
-          className="absolute right-3 top-3 z-10 text-white/90"
-        />
-
-        <div className="absolute inset-x-0 top-[50px] z-10 flex justify-center">
-          <div className="relative flex h-[122px] w-[122px] items-center justify-center">
-            <span className="absolute h-[112px] w-[112px] rounded-full border border-white/25" />
-            <span className="absolute h-[82px] w-[82px] rounded-full border border-white/18" />
-            <span className="absolute h-[52px] w-[52px] rounded-full bg-white/12 backdrop-blur-[2px]" />
-            <Database size={52} strokeWidth={1.15} className="relative text-white/95" />
+          <div className="absolute left-4 top-3 z-10">
+            <div className="text-[12px] font-semibold text-white/95">{taskTypeLabel(task.taskType)}</div>
+            <div className="mt-0.5 text-[11px] text-white/80">{formatCardDuration(task.durationMs)}</div>
           </div>
-        </div>
 
-        <div className="absolute inset-x-0 bottom-[70px] z-10 px-4">
-          <div className="truncate text-[12px] font-medium text-white/95">
-            {task?.taskName || '暂无运行任务'}
-          </div>
-        </div>
+          <Copy
+            size={14}
+            strokeWidth={1.8}
+            className="absolute right-3 top-3 z-10 text-white/90"
+          />
 
-        <div className="absolute inset-x-0 bottom-0 z-10 h-[70px] bg-black/20 px-4 backdrop-blur-[12px]">
-          <div className="flex h-1/2 items-center justify-between border-b border-white/12">
-            <span className="text-[11px] text-white/78">运行次数</span>
-            <strong className="text-[12px] font-semibold">{task?.runCount ?? 0}</strong>
+          <div className="absolute inset-x-0 top-[50px] z-10 flex justify-center">
+            <div className="relative flex h-[122px] w-[122px] items-center justify-center">
+              <span className="absolute h-[112px] w-[112px] rounded-full border border-white/25" />
+              <span className="absolute h-[82px] w-[82px] rounded-full border border-white/18" />
+              <span className="absolute h-[52px] w-[52px] rounded-full bg-white/12 backdrop-blur-[2px]" />
+              <Database size={52} strokeWidth={1.15} className="relative text-white/95" />
+            </div>
           </div>
-          <div className="flex h-1/2 items-center justify-between">
-            <span className="text-[11px] text-white/78">异常</span>
-            <strong className="text-[12px] font-semibold">{task?.exceptionCount ?? 0}</strong>
+
+          <div className="absolute inset-x-0 bottom-[70px] z-10 px-4">
+            <div className="truncate text-[12px] font-medium text-white/95">
+              {task.taskName}
+            </div>
           </div>
+
+          <div className="absolute inset-x-0 bottom-0 z-10 h-[70px] bg-black/20 px-4 backdrop-blur-[12px]">
+            <div className="flex h-1/2 items-center justify-between border-b border-white/12">
+              <span className="text-[11px] text-white/78">运行次数</span>
+              <strong className="text-[12px] font-semibold">{task.runCount}</strong>
+            </div>
+            <div className="flex h-1/2 items-center justify-between">
+              <span className="text-[11px] text-white/78">异常</span>
+              <strong className="text-[12px] font-semibold">{task.exceptionCount}</strong>
+            </div>
+          </div>
+        </button>
+      ) : loading || failed ? (
+        <div className="flex h-[266px] w-full items-center justify-center rounded-[10px] border border-[#e8ebef] bg-[#fafbfc] text-[11px] text-[#9da1a8] lg:w-[198px]">
+          {loading ? '任务数据加载中...' : '任务数据加载失败'}
         </div>
-      </button>
+      ) : (
+        <div className="flex h-[266px] w-full items-center justify-center rounded-[10px] border border-[#e8ebef] bg-[#fafbfc] lg:w-[198px]">
+          <YakOpsEmpty
+            width={150}
+            height={100}
+            title="暂无运行任务"
+            showCaption
+          />
+        </div>
+      )}
     </aside>
   );
 }
@@ -501,14 +525,38 @@ function OverviewMetrics({ metrics }: { metrics: OverviewMetric[] }) {
   );
 }
 
-function RecentTasksPanel({ items }: { items: HomeRecentTask[] }) {
+function RecentTasksPanel({
+  items,
+  loading,
+  failed,
+}: {
+  items: HomeRecentTask[];
+  loading: boolean;
+  failed: boolean;
+}) {
+  if (loading || failed) {
+    return (
+      <div className="flex min-h-[263px] items-center justify-center text-[12px] text-[#9da1a8]">
+        {loading ? '近期任务加载中...' : '近期任务加载失败'}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex min-h-[263px] items-center justify-center">
+        <YakOpsEmpty
+          width={160}
+          height={108}
+          title="暂无近期任务"
+          showCaption
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-[263px] pt-2">
-      {items.length === 0 && (
-        <div className="flex min-h-[240px] items-center justify-center text-[12px] text-[#9da1a8]">
-          暂无近期任务
-        </div>
-      )}
       {items.map((item) => (
         <button
           key={`${item.taskType}-${item.taskId}`}
@@ -561,32 +609,38 @@ function RecentTasksPanel({ items }: { items: HomeRecentTask[] }) {
 
 function EmptySchedulePanel({ periodLabel }: { periodLabel: string }) {
   return (
-    <div className="flex min-h-[263px] items-center justify-center pb-4">
-      <div className="text-center">
-        <div className="relative mx-auto flex h-[78px] w-[112px] items-center justify-center">
-          <span className="absolute left-[19px] top-[5px] flex h-7 w-7 items-center justify-center rounded-full bg-[#d9e7ff] text-[#4b7df3]">
-            <CircleHelp size={18} strokeWidth={2.1} />
-          </span>
-          <span className="absolute bottom-2 left-[38px] h-[40px] w-[54px] rounded-[12px] border border-[#dfe3e9] bg-[#fafbfc]" />
-          <RadioTower
-            size={45}
-            strokeWidth={1.25}
-            className="absolute bottom-[7px] right-[22px] text-[#9ba2ad]"
-          />
-        </div>
-        <div className="mt-1 text-[12px] text-[#8a8f98]">
-          {periodLabel}暂无调度数据
-        </div>
-        <div className="mt-1 text-[11px] text-[#b0b4bb]">
-          当前周期内没有可展示的调度记录
-        </div>
-      </div>
+    <div className="flex min-h-[263px] items-center justify-center">
+      <YakOpsEmpty
+        width={160}
+        height={108}
+        title={`${periodLabel}暂无调度数据`}
+        showCaption
+      />
     </div>
   );
 }
 
-function SchedulePanel({ items, periodLabel }: { items: HomeScheduleItem[]; periodLabel: string }) {
+function SchedulePanel({
+  items,
+  periodLabel,
+  loading,
+  failed,
+}: {
+  items: HomeScheduleItem[];
+  periodLabel: string;
+  loading: boolean;
+  failed: boolean;
+}) {
+  if (loading || failed) {
+    return (
+      <div className="flex min-h-[263px] items-center justify-center text-[12px] text-[#9da1a8]">
+        {loading ? '调度数据加载中...' : '调度数据加载失败'}
+      </div>
+    );
+  }
+
   if (items.length === 0) return <EmptySchedulePanel periodLabel={periodLabel} />;
+
   return (
     <div className="min-h-[263px] pt-2">
       {items.map((item) => (
@@ -645,6 +699,12 @@ export default function DataCenter() {
   const [overview, setOverview] = useState<HomeDataCenterOverview>();
   const [recentTasks, setRecentTasks] = useState<HomeRecentTask[]>([]);
   const [scheduleItems, setScheduleItems] = useState<HomeScheduleItem[]>([]);
+  const [overviewLoading, setOverviewLoading] = useState(true);
+  const [overviewFailed, setOverviewFailed] = useState(false);
+  const [recentLoading, setRecentLoading] = useState(false);
+  const [recentFailed, setRecentFailed] = useState(false);
+  const [scheduleLoading, setScheduleLoading] = useState(false);
+  const [scheduleFailed, setScheduleFailed] = useState(false);
   const fallbackPeriod = useMemo(() => buildPeriod(periodKey), [periodKey]);
   const periodLabel = periodOptions.find((item) => item.key === periodKey)!.label;
   const overviewMetrics = useMemo(
@@ -654,10 +714,17 @@ export default function DataCenter() {
 
   useEffect(() => {
     let active = true;
+    setOverviewLoading(true);
+    setOverviewFailed(false);
     void homeDataCenterApi.overview(periodKey).then((response) => {
-      if (active) setOverview(response.data);
+      if (!active) return;
+      setOverview(response.data);
+      setOverviewLoading(false);
     }).catch(() => {
-      if (active) setOverview(undefined);
+      if (!active) return;
+      setOverview(undefined);
+      setOverviewLoading(false);
+      setOverviewFailed(true);
     });
     return () => { active = false; };
   }, [periodKey]);
@@ -665,10 +732,17 @@ export default function DataCenter() {
   useEffect(() => {
     if (activeTab !== 'recent') return undefined;
     let active = true;
+    setRecentLoading(true);
+    setRecentFailed(false);
     void homeDataCenterApi.recent().then((response) => {
-      if (active) setRecentTasks(response.data?.items || []);
+      if (!active) return;
+      setRecentTasks(response.data?.items || []);
+      setRecentLoading(false);
     }).catch(() => {
-      if (active) setRecentTasks([]);
+      if (!active) return;
+      setRecentTasks([]);
+      setRecentLoading(false);
+      setRecentFailed(true);
     });
     return () => { active = false; };
   }, [activeTab]);
@@ -676,10 +750,17 @@ export default function DataCenter() {
   useEffect(() => {
     if (activeTab !== 'schedule') return undefined;
     let active = true;
+    setScheduleLoading(true);
+    setScheduleFailed(false);
     void homeDataCenterApi.schedule(periodKey).then((response) => {
-      if (active) setScheduleItems(response.data?.items || []);
+      if (!active) return;
+      setScheduleItems(response.data?.items || []);
+      setScheduleLoading(false);
     }).catch(() => {
-      if (active) setScheduleItems([]);
+      if (!active) return;
+      setScheduleItems([]);
+      setScheduleLoading(false);
+      setScheduleFailed(true);
     });
     return () => { active = false; };
   }, [activeTab, periodKey]);
@@ -692,6 +773,7 @@ export default function DataCenter() {
     : formatDate(fallbackPeriod.end);
   const trendLabels = overview?.trend?.labels || [];
   const trendValues = overview?.trend?.values || [];
+  const hasTrendData = trendValues.some((value) => value > 0);
 
   return (
     <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
@@ -716,7 +798,11 @@ export default function DataCenter() {
       </header>
 
       <div className="mt-4 flex flex-col gap-5 lg:flex-row lg:gap-6">
-        <LatestTaskCard task={overview?.latestTask} />
+        <LatestTaskCard
+          task={overview?.latestTask}
+          loading={overviewLoading}
+          failed={overviewFailed}
+        />
 
         <div className="min-w-0 flex-1">
           <YakTab
@@ -738,20 +824,46 @@ export default function DataCenter() {
                 <span className="h-2 w-2 rounded-full bg-[#5b8cff]" />
                 运行次数
               </div>
-              <TrendChart
-                key={`trend-${periodKey}`}
-                values={trendValues}
-                labels={trendLabels}
-                name="运行次数"
-              />
+              {overviewLoading || overviewFailed ? (
+                <div className="flex h-[152px] items-center justify-center text-[12px] text-[#9da1a8]">
+                  {overviewLoading ? '运行数据加载中...' : '运行数据加载失败'}
+                </div>
+              ) : hasTrendData ? (
+                <TrendChart
+                  key={`trend-${periodKey}`}
+                  values={trendValues}
+                  labels={trendLabels}
+                  name="运行次数"
+                />
+              ) : (
+                <div className="flex h-[152px] items-center justify-center">
+                  <YakOpsEmpty
+                    width={120}
+                    height={80}
+                    title={`${periodLabel}暂无运行数据`}
+                    showCaption
+                  />
+                </div>
+              )}
               <OverviewMetrics metrics={overviewMetrics} />
             </div>
           )}
 
-          {activeTab === 'recent' && <RecentTasksPanel items={recentTasks} />}
+          {activeTab === 'recent' && (
+            <RecentTasksPanel
+              items={recentTasks}
+              loading={recentLoading}
+              failed={recentFailed}
+            />
+          )}
 
           {activeTab === 'schedule' && (
-            <SchedulePanel items={scheduleItems} periodLabel={periodLabel} />
+            <SchedulePanel
+              items={scheduleItems}
+              periodLabel={periodLabel}
+              loading={scheduleLoading}
+              failed={scheduleFailed}
+            />
           )}
         </div>
       </div>

--- a/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
@@ -1,3 +1,4 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
 import ReactECharts from 'echarts-for-react';
@@ -123,14 +124,22 @@ function OverviewMetric({ label, value }: { label: string; value: string }) {
 }
 
 function TrendEmpty({ state }: { state: DataServiceOverviewState }) {
-  const text = state.loading
-    ? '数据加载中...'
-    : state.failed
-      ? '数据服务概览加载失败'
-      : '近 7 日暂无 API 调用';
+  if (state.loading || state.failed) {
+    return (
+      <div className="flex h-[126px] items-center justify-center text-[11px] text-[#a0a4ac]">
+        {state.loading ? '数据加载中...' : '数据服务概览加载失败'}
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-[126px] items-center justify-center text-[11px] text-[#a0a4ac]">
-      {text}
+    <div className="flex h-[126px] items-center justify-center">
+      <YakOpsEmpty
+        width={116}
+        height={78}
+        title="近 7 日暂无 API 调用"
+        showCaption
+      />
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
@@ -1,7 +1,8 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
 import ReactECharts from 'echarts-for-react';
-import { Activity, GitBranch } from 'lucide-react';
+import { Activity } from 'lucide-react';
 import { useMemo } from 'react';
 
 import {
@@ -91,20 +92,22 @@ function LineagePreview({ state }: { state: HomeAssetOverviewState }) {
           option={graphOption}
           style={{ width: '100%', height: '276px' }}
         />
+      ) : state.loading || state.failed || unavailable ? (
+        <div className="relative flex h-full items-center justify-center text-[11px] text-[#a0a4ac]">
+          {state.loading
+            ? '血缘加载中...'
+            : state.failed
+              ? '血缘数据加载失败'
+              : '血缘数据暂不可用'}
+        </div>
       ) : (
-        <div className="relative flex h-full flex-col items-center justify-center text-[#a0a4ac]">
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-[#8b93a0] shadow-sm">
-            <GitBranch size={18} strokeWidth={1.7} />
-          </span>
-          <span className="mt-3 text-[11px]">
-            {state.loading
-              ? '血缘加载中...'
-              : state.failed
-                ? '血缘数据加载失败'
-                : unavailable
-                  ? '血缘数据暂不可用'
-                  : '暂无血缘关系'}
-          </span>
+        <div className="relative flex h-full items-center justify-center">
+          <YakOpsEmpty
+            width={160}
+            height={108}
+            title="暂无血缘关系"
+            showCaption
+          />
         </div>
       )}
       <div className="absolute bottom-3 left-3 rounded-full border border-[#e6e8ec] bg-white/90 px-2.5 py-1 text-[9px] text-[#999da5] shadow-sm backdrop-blur">
@@ -190,15 +193,22 @@ export function DataLineageOverview({
                   <LineageUpdate key={item.id} item={item} />
                 ))}
               </div>
-            ) : (
+            ) : state.loading || state.failed || lineage?.assetCount == null ? (
               <div className="flex min-h-[118px] items-center justify-center text-[10px] text-[#a0a4ac]">
                 {state.loading
                   ? '数据加载中...'
                   : state.failed
                     ? '数据加载失败'
-                    : lineage?.assetCount == null
-                      ? '数据暂不可用'
-                      : '暂无最近关系'}
+                    : '数据暂不可用'}
+              </div>
+            ) : (
+              <div className="flex min-h-[118px] items-center justify-center">
+                <YakOpsEmpty
+                  width={100}
+                  height={66}
+                  title="暂无最近关系"
+                  showCaption
+                />
               </div>
             )}
           </div>

--- a/yak-ops-ui/src/pages/home/components/HomeQualityOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeQualityOverview.tsx
@@ -1,3 +1,4 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { BRAND_COLOR } from '@/styles/brand';
 import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
@@ -284,6 +285,7 @@ function QualityRadarPanel({ state }: { state: QualityOverviewState }) {
     [data?.dimensions],
   );
   const option = useMemo(() => buildRadarOption(dimensions), [dimensions]);
+  const showEmpty = !state.loading && !state.failed && data?.passRate == null;
 
   return (
     <div className="min-w-0 rounded-[16px] border border-[#eef0f3] bg-[#fafbfc] px-4 pb-4 pt-4">
@@ -318,11 +320,22 @@ function QualityRadarPanel({ state }: { state: QualityOverviewState }) {
       </div>
 
       <div className="min-h-[270px]">
-        <ReactECharts
-          option={option}
-          notMerge
-          style={{ width: '100%', height: '278px' }}
-        />
+        {showEmpty ? (
+          <div className="flex h-[278px] items-center justify-center">
+            <YakOpsEmpty
+              width={160}
+              height={108}
+              title="暂无质量执行数据"
+              showCaption
+            />
+          </div>
+        ) : (
+          <ReactECharts
+            option={option}
+            notMerge
+            style={{ width: '100%', height: '278px' }}
+          />
+        )}
       </div>
 
       <div className="grid grid-cols-4 gap-3 border-t border-[#e6e9ee] pt-3.5">
@@ -417,24 +430,22 @@ function RecentIssues({ state }: { state: QualityOverviewState }) {
             <RecentIssueRow key={issue.id} issue={issue} />
           ))}
         </div>
+      ) : state.loading || state.failed || state.data?.recentIssueCount == null ? (
+        <div className="flex min-h-[318px] items-center justify-center text-[11px] text-[#858b94]">
+          {state.loading
+            ? '质量问题加载中...'
+            : state.failed
+              ? '质量数据加载失败'
+              : '质量数据暂不可用'}
+        </div>
       ) : (
-        <div className="flex min-h-[318px] flex-col items-center justify-center text-center">
-          {state.loading ? (
-            <span className="text-[11px] text-[#858b94]">质量问题加载中...</span>
-          ) : state.failed ? (
-            <span className="text-[11px] text-[#858b94]">质量数据加载失败</span>
-          ) : state.data?.recentIssueCount == null ? (
-            <span className="text-[11px] text-[#858b94]">质量数据暂不可用</span>
-          ) : (
-            <>
-              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[#eaf7ef] text-[#3d9667]">
-                <CheckCircle2 size={18} strokeWidth={2} />
-              </span>
-              <strong className="mt-3 text-[13px] font-medium text-[#4f5560]">
-                近 7 日暂无质量问题
-              </strong>
-            </>
-          )}
+        <div className="flex min-h-[318px] items-center justify-center">
+          <YakOpsEmpty
+            width={170}
+            height={114}
+            title="近 7 日暂无质量问题"
+            showCaption
+          />
         </div>
       )}
     </div>

--- a/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
@@ -1,3 +1,4 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { listDigitalScreens, type DigitalScreenInstance } from '@/services/digital-screen';
 import {
   fetchDashboardOverview,
@@ -286,13 +287,18 @@ export default function HomeVisualizationOverview() {
             <VisualizationCard key={`${item.kind}-${item.id}`} item={item} />
           ))}
         </div>
-      ) : (
+      ) : loading || allFailed ? (
         <div className="flex min-h-[176px] items-center justify-center text-[11px] text-[#a0a4ac]">
-          {loading
-            ? '可视化数据加载中...'
-            : allFailed
-              ? '可视化数据加载失败'
-              : '暂无仪表盘或数字大屏'}
+          {loading ? '可视化数据加载中...' : '可视化数据加载失败'}
+        </div>
+      ) : (
+        <div className="flex min-h-[176px] items-center justify-center">
+          <YakOpsEmpty
+            width={150}
+            height={100}
+            title="暂无仪表盘或数字大屏"
+            showCaption
+          />
         </div>
       )}
     </section>

--- a/yak-ops-ui/src/pages/home/components/ScheduleCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/ScheduleCenter.tsx
@@ -1,3 +1,4 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { history } from '@umijs/max';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
@@ -267,7 +268,14 @@ export default function ScheduleCenter() {
           ))}
 
           {calendar && calendar.overview.length === 0 && (
-            <div className="py-1 text-[11px] text-[#a0a4ac]">本月暂无调度配置</div>
+            <div className="flex min-h-[126px] items-center justify-center">
+              <YakOpsEmpty
+                width={116}
+                height={78}
+                title="本月暂无调度配置"
+                showCaption
+              />
+            </div>
           )}
         </div>
       </div>

--- a/yak-ops-ui/src/pages/home/components/homeAssetOverviewShared.tsx
+++ b/yak-ops-ui/src/pages/home/components/homeAssetOverviewShared.tsx
@@ -1,3 +1,4 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { ChevronRight } from 'lucide-react';
 
 import type { HomeAssetOverview } from './service';
@@ -107,15 +108,17 @@ export function EmptyList({
   unavailable: boolean;
   text: string;
 }) {
+  if (loading || failed || unavailable) {
+    return (
+      <div className="flex min-h-[214px] items-center justify-center text-[11px] text-[#a0a4ac]">
+        {loading ? '数据加载中...' : failed ? '数据加载失败' : '数据暂不可用'}
+      </div>
+    );
+  }
+
   return (
-    <div className="flex min-h-[214px] items-center justify-center text-[11px] text-[#a0a4ac]">
-      {loading
-        ? '数据加载中...'
-        : failed
-          ? '数据加载失败'
-          : unavailable
-            ? '数据暂不可用'
-            : text}
+    <div className="flex min-h-[214px] items-center justify-center">
+      <YakOpsEmpty width={150} height={100} title={text} showCaption />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- unify the visible empty-data states on `/home` with the shared `YakOpsEmpty` component
- keep each empty state to one short sentence below the illustration
- preserve loading / failed / unavailable states as text so requests do not flash a false empty state
- add explicit loading/failure state handling to the Data Center tabs where empty arrays previously appeared before requests finished

## Covered areas

- 数据中心：最新任务、运行趋势、近期任务、调度数据
- 调度中心：月度调度总览
- 数据集：最近更新、已上线数据集（through the shared `EmptyList`）
- 数据血缘：血缘预览、最近关系
- 数据质量：质量维度无执行数据、近 7 日无质量问题
- 数据服务：近 7 日无 API 调用趋势
- 可视化：无仪表盘 / 数字大屏

## Verification

- rebased/squashed onto the latest `main`; branch is ahead by 1 and behind by 0
- compared against `main`; only 7 files under `yak-ops-ui/src/pages/home/components` are changed
- manually re-read the two largest edits (`DataCenter.tsx` and `HomeQualityOverview.tsx`) after the final rebase
- full frontend lint/typecheck/browser regression not run in this environment