### PR TITLE
refactor(ui): extend data source white surface to footer

### DIFF
--- a/yak-ops-ui/src/pages/data-source/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/index.tsx
@@ -126,7 +126,7 @@ const DataSourcePage = () => {
 
   return (
     <>
-      <div className="min-h-[calc(100dvh-56px)] bg-[#f7f8fa] text-[#242731]">
+      <div className="min-h-[calc(100dvh-56px)] bg-white text-[#242731]">
         <motion.main
           initial="hidden"
           animate="visible"


### PR DESCRIPTION
## What changed

- make the data-source page background white so the area below the compact data-source panel no longer turns gray
- keep pagination pinned to the bottom while letting it sit on the same white page surface
- preserve the compact data-source content panel and all existing create/edit/delete/test/filter/view-mode/pagination behavior

## Validation

- branch is based on the current `main`
- only `yak-ops-ui/src/pages/data-source/index.tsx` is changed
- full frontend lint/build and browser regression were not run in this execution environment