### PR TITLE
style(sync): use segmented status filters

### DIFF
--- a/yak-ops-ui/src/pages/batch-link-up/components/OfflineSyncFilterBar.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/OfflineSyncFilterBar.tsx
@@ -1,6 +1,6 @@
-import { YakButton, YakTab } from '@/components/ui';
+import { YakButton } from '@/components/ui';
 import { FilterOutlined, SearchOutlined } from '@ant-design/icons';
-import { DatePicker, Input, Popover, Select } from 'antd';
+import { DatePicker, Input, Popover, Segmented, Select } from 'antd';
 import { useState } from 'react';
 
 import { OFFLINE_SYNC_STATUS_TABS } from '../constants';
@@ -11,6 +11,28 @@ import type {
 } from '../types';
 
 const { RangePicker } = DatePicker;
+
+const STATUS_SEGMENT_CLASS = [
+  '!h-9 !rounded-[10px] !bg-[#f4f5f7] !p-[3px]',
+  '[&_.ant-segmented-group]:!h-[30px]',
+  '[&_.ant-segmented-group]:!gap-1',
+  '[&_.ant-segmented-item]:!min-w-[72px]',
+  '[&_.ant-segmented-item]:!rounded-[7px]',
+  '[&_.ant-segmented-item]:!px-0',
+  '[&_.ant-segmented-item]:!text-[13px]',
+  '[&_.ant-segmented-item]:!font-medium',
+  '[&_.ant-segmented-item]:!text-[#747985]',
+  '[&_.ant-segmented-item-label]:!min-h-0',
+  '[&_.ant-segmented-item-label]:!px-3',
+  '[&_.ant-segmented-item-label]:!leading-[30px]',
+  '[&_.ant-segmented-thumb]:!rounded-[7px]',
+  '[&_.ant-segmented-thumb]:!bg-white',
+  '[&_.ant-segmented-thumb]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
+  '[&_.ant-segmented-item-selected]:!bg-white',
+  '[&_.ant-segmented-item-selected]:!font-semibold',
+  '[&_.ant-segmented-item-selected]:!text-[#252832]',
+  '[&_.ant-segmented-item-selected]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
+].join(' ');
 
 interface OfflineSyncFilterBarProps {
   filterDraft: OfflineSyncSearchState;
@@ -51,199 +73,196 @@ const OfflineSyncFilterBar = ({
   };
 
   return (
-    <div className="border-b border-[#f0f0f0]">
-      <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-        <div className="h-9 shrink-0">
-          <YakTab
-            size="small"
-            activeKey={currentStatus}
-            items={OFFLINE_SYNC_STATUS_TABS.map((item) => ({
-              key: item.value,
-              label: item.label,
-            }))}
-            onChange={onStatusChange}
-          />
-        </div>
+    <div className="flex min-h-[44px] items-center justify-between gap-4">
+      <Segmented
+        size="small"
+        value={currentStatus}
+        options={OFFLINE_SYNC_STATUS_TABS.map((item) => ({
+          value: item.value,
+          label: item.label,
+        }))}
+        className={STATUS_SEGMENT_CLASS}
+        onChange={(value) => onStatusChange(String(value))}
+      />
 
-        <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
-          <Input
-            allowClear
-            variant="filled"
-            value={filterDraft.jobName}
-            prefix={<SearchOutlined className="text-[#98a2b3]" />}
-            placeholder="搜索任务名称"
-            className="!h-9 !w-[220px] !min-w-[180px]"
-            onChange={(event) =>
-              onDraftChange('jobName', event.target.value || undefined)
-            }
-            onPressEnter={onSearch}
-          />
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
+        <Input
+          allowClear
+          variant="filled"
+          value={filterDraft.jobName}
+          prefix={<SearchOutlined className="text-[#98a2b3]" />}
+          placeholder="搜索任务名称"
+          className="!h-9 !w-[220px] !min-w-[180px]"
+          onChange={(event) =>
+            onDraftChange('jobName', event.target.value || undefined)
+          }
+          onPressEnter={onSearch}
+        />
 
-          <Select
-            allowClear
-            showSearch
-            variant="filled"
-            value={filterDraft.sourceType}
-            options={connectorOptions}
-            placeholder="来源类型"
-            className="!h-9 !w-[150px] !min-w-[140px]"
-            optionFilterProp="value"
-            onChange={(value) => onQuickFilterChange('sourceType', value)}
-          />
+        <Select
+          allowClear
+          showSearch
+          variant="filled"
+          value={filterDraft.sourceType}
+          options={connectorOptions}
+          placeholder="来源类型"
+          className="!h-9 !w-[150px] !min-w-[140px]"
+          optionFilterProp="value"
+          onChange={(value) => onQuickFilterChange('sourceType', value)}
+        />
 
-          <RangePicker
-            allowClear
-            variant="filled"
-            value={filterDraft.createTime as never}
-            format="YYYY-MM-DD"
-            placeholder={['开始日期', '结束日期']}
-            className="!h-9 !w-[250px] !min-w-[230px]"
-            onChange={(value) =>
-              onQuickFilterChange(
-                'createTime',
-                (value || undefined) as unknown as OfflineSyncSearchState['createTime'],
-              )
-            }
-          />
+        <RangePicker
+          allowClear
+          variant="filled"
+          value={filterDraft.createTime as never}
+          format="YYYY-MM-DD"
+          placeholder={['开始日期', '结束日期']}
+          className="!h-9 !w-[250px] !min-w-[230px]"
+          onChange={(value) =>
+            onQuickFilterChange(
+              'createTime',
+              (value || undefined) as unknown as OfflineSyncSearchState['createTime'],
+            )
+          }
+        />
 
-          <YakButton className="!h-9 !px-4" onClick={onSearch}>
-            查询
-          </YakButton>
+        <YakButton className="!h-9 !px-4" onClick={onSearch}>
+          查询
+        </YakButton>
 
-          <YakButton type="text" className="!h-9 !px-2" onClick={onReset}>
-            重置
-          </YakButton>
+        <YakButton type="text" className="!h-9 !px-2" onClick={onReset}>
+          重置
+        </YakButton>
 
-          <Popover
-            trigger="click"
-            placement="bottomRight"
-            open={advancedOpen}
-            onOpenChange={setAdvancedOpen}
-            overlayClassName="sync-task-advanced-filter"
-            content={
-              <div className="w-[430px]">
-                <div className="mb-4">
-                  <div className="text-[14px] font-semibold text-[#101828]">
-                    高级搜索
-                  </div>
-                  <div className="mt-1 text-[12px] text-[#98a2b3]">
-                    按任务标识、目标类型和同步表信息进一步筛选
-                  </div>
+        <Popover
+          trigger="click"
+          placement="bottomRight"
+          open={advancedOpen}
+          onOpenChange={setAdvancedOpen}
+          overlayClassName="sync-task-advanced-filter"
+          content={
+            <div className="w-[430px]">
+              <div className="mb-4">
+                <div className="text-[14px] font-semibold text-[#101828]">
+                  高级搜索
                 </div>
-
-                <div className="grid grid-cols-2 gap-x-3 gap-y-4">
-                  <div>
-                    <div className="mb-1.5 text-[12px] text-[#667085]">
-                      任务 ID
-                    </div>
-                    <Input
-                      allowClear
-                      variant="filled"
-                      value={filterDraft.id}
-                      placeholder="请输入任务 ID"
-                      onChange={(event) =>
-                        onDraftChange('id', event.target.value || undefined)
-                      }
-                      onPressEnter={applyAdvancedFilters}
-                    />
-                  </div>
-
-                  <div>
-                    <div className="mb-1.5 text-[12px] text-[#667085]">
-                      目标类型
-                    </div>
-                    <Select
-                      allowClear
-                      showSearch
-                      variant="filled"
-                      value={filterDraft.sinkType}
-                      options={connectorOptions}
-                      placeholder="请选择目标类型"
-                      optionFilterProp="value"
-                      className="w-full"
-                      onChange={(value) => onDraftChange('sinkType', value)}
-                    />
-                  </div>
-
-                  <div>
-                    <div className="mb-1.5 text-[12px] text-[#667085]">
-                      来源表
-                    </div>
-                    <Input
-                      allowClear
-                      variant="filled"
-                      value={filterDraft.sourceTable}
-                      placeholder="请输入来源表"
-                      onChange={(event) =>
-                        onDraftChange(
-                          'sourceTable',
-                          event.target.value || undefined,
-                        )
-                      }
-                      onPressEnter={applyAdvancedFilters}
-                    />
-                  </div>
-
-                  <div>
-                    <div className="mb-1.5 text-[12px] text-[#667085]">
-                      目标表
-                    </div>
-                    <Input
-                      allowClear
-                      variant="filled"
-                      value={filterDraft.sinkTable}
-                      placeholder="请输入目标表"
-                      onChange={(event) =>
-                        onDraftChange(
-                          'sinkTable',
-                          event.target.value || undefined,
-                        )
-                      }
-                      onPressEnter={applyAdvancedFilters}
-                    />
-                  </div>
-                </div>
-
-                <div className="mt-5 flex items-center justify-end gap-2 border-t border-[#f0f0f0] pt-4">
-                  <YakButton
-                    size="small"
-                    onClick={() => {
-                      onAdvancedReset();
-                      setAdvancedOpen(false);
-                    }}
-                  >
-                    重置
-                  </YakButton>
-                  <YakButton
-                    type="primary"
-                    size="small"
-                    onClick={applyAdvancedFilters}
-                  >
-                    应用筛选
-                  </YakButton>
+                <div className="mt-1 text-[12px] text-[#98a2b3]">
+                  按任务标识、目标类型和同步表信息进一步筛选
                 </div>
               </div>
-            }
+
+              <div className="grid grid-cols-2 gap-x-3 gap-y-4">
+                <div>
+                  <div className="mb-1.5 text-[12px] text-[#667085]">
+                    任务 ID
+                  </div>
+                  <Input
+                    allowClear
+                    variant="filled"
+                    value={filterDraft.id}
+                    placeholder="请输入任务 ID"
+                    onChange={(event) =>
+                      onDraftChange('id', event.target.value || undefined)
+                    }
+                    onPressEnter={applyAdvancedFilters}
+                  />
+                </div>
+
+                <div>
+                  <div className="mb-1.5 text-[12px] text-[#667085]">
+                    目标类型
+                  </div>
+                  <Select
+                    allowClear
+                    showSearch
+                    variant="filled"
+                    value={filterDraft.sinkType}
+                    options={connectorOptions}
+                    placeholder="请选择目标类型"
+                    optionFilterProp="value"
+                    className="w-full"
+                    onChange={(value) => onDraftChange('sinkType', value)}
+                  />
+                </div>
+
+                <div>
+                  <div className="mb-1.5 text-[12px] text-[#667085]">
+                    来源表
+                  </div>
+                  <Input
+                    allowClear
+                    variant="filled"
+                    value={filterDraft.sourceTable}
+                    placeholder="请输入来源表"
+                    onChange={(event) =>
+                      onDraftChange(
+                        'sourceTable',
+                        event.target.value || undefined,
+                      )
+                    }
+                    onPressEnter={applyAdvancedFilters}
+                  />
+                </div>
+
+                <div>
+                  <div className="mb-1.5 text-[12px] text-[#667085]">
+                    目标表
+                  </div>
+                  <Input
+                    allowClear
+                    variant="filled"
+                    value={filterDraft.sinkTable}
+                    placeholder="请输入目标表"
+                    onChange={(event) =>
+                      onDraftChange(
+                        'sinkTable',
+                        event.target.value || undefined,
+                      )
+                    }
+                    onPressEnter={applyAdvancedFilters}
+                  />
+                </div>
+              </div>
+
+              <div className="mt-5 flex items-center justify-end gap-2 border-t border-[#f0f0f0] pt-4">
+                <YakButton
+                  size="small"
+                  onClick={() => {
+                    onAdvancedReset();
+                    setAdvancedOpen(false);
+                  }}
+                >
+                  重置
+                </YakButton>
+                <YakButton
+                  type="primary"
+                  size="small"
+                  onClick={applyAdvancedFilters}
+                >
+                  应用筛选
+                </YakButton>
+              </div>
+            </div>
+          }
+        >
+          <YakButton
+            size="small"
+            icon={<FilterOutlined />}
+            className={[
+              '!h-9 !px-3',
+              advancedFilterCount > 0
+                ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
+                : '',
+            ].join(' ')}
           >
-            <YakButton
-              size="small"
-              icon={<FilterOutlined />}
-              className={[
-                '!h-9 !px-3',
-                advancedFilterCount > 0
-                  ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
-                  : '',
-              ].join(' ')}
-            >
-              高级搜索
-              {advancedFilterCount > 0 ? (
-                <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
-                  {advancedFilterCount}
-                </span>
-              ) : null}
-            </YakButton>
-          </Popover>
-        </div>
+            高级搜索
+            {advancedFilterCount > 0 ? (
+              <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
+                {advancedFilterCount}
+              </span>
+            ) : null}
+          </YakButton>
+        </Popover>
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/realtime-sync/components/RealtimeSyncFilterBar.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/components/RealtimeSyncFilterBar.tsx
@@ -1,6 +1,6 @@
-import { YakButton, YakTab } from '@/components/ui';
+import { YakButton } from '@/components/ui';
 import { FilterOutlined, SearchOutlined } from '@ant-design/icons';
-import { Input, Popover, Select } from 'antd';
+import { Input, Popover, Segmented, Select } from 'antd';
 import { useState } from 'react';
 
 import {
@@ -12,6 +12,28 @@ import type {
   RealtimeFilterState,
   RealtimePageStateGroup,
 } from '../types';
+
+const STATUS_SEGMENT_CLASS = [
+  '!h-9 !rounded-[10px] !bg-[#f4f5f7] !p-[3px]',
+  '[&_.ant-segmented-group]:!h-[30px]',
+  '[&_.ant-segmented-group]:!gap-1',
+  '[&_.ant-segmented-item]:!min-w-[72px]',
+  '[&_.ant-segmented-item]:!rounded-[7px]',
+  '[&_.ant-segmented-item]:!px-0',
+  '[&_.ant-segmented-item]:!text-[13px]',
+  '[&_.ant-segmented-item]:!font-medium',
+  '[&_.ant-segmented-item]:!text-[#747985]',
+  '[&_.ant-segmented-item-label]:!min-h-0',
+  '[&_.ant-segmented-item-label]:!px-3',
+  '[&_.ant-segmented-item-label]:!leading-[30px]',
+  '[&_.ant-segmented-thumb]:!rounded-[7px]',
+  '[&_.ant-segmented-thumb]:!bg-white',
+  '[&_.ant-segmented-thumb]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
+  '[&_.ant-segmented-item-selected]:!bg-white',
+  '[&_.ant-segmented-item-selected]:!font-semibold',
+  '[&_.ant-segmented-item-selected]:!text-[#252832]',
+  '[&_.ant-segmented-item-selected]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
+].join(' ');
 
 interface RealtimeSyncFilterBarProps {
   filterDraft: RealtimeFilterState;
@@ -51,117 +73,114 @@ const RealtimeSyncFilterBar = ({
   };
 
   return (
-    <div className="border-b border-[#f0f0f0]">
-      <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-        <div className="h-9 shrink-0">
-          <YakTab
-            size="small"
-            activeKey={activeStateGroup}
-            items={REALTIME_SYNC_STATUS_TABS.map((item) => ({
-              key: item.value,
-              label: item.label,
-            }))}
-            onChange={(value) =>
-              onStateGroupChange(value as RealtimePageStateGroup)
-            }
-          />
-        </div>
+    <div className="flex min-h-[44px] items-center justify-between gap-4">
+      <Segmented
+        size="small"
+        value={activeStateGroup}
+        options={REALTIME_SYNC_STATUS_TABS.map((item) => ({
+          value: item.value,
+          label: item.label,
+        }))}
+        className={STATUS_SEGMENT_CLASS}
+        onChange={(value) =>
+          onStateGroupChange(value as RealtimePageStateGroup)
+        }
+      />
 
-        <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
-          <Input
-            allowClear
-            variant="filled"
-            value={filterDraft.keyword}
-            prefix={<SearchOutlined className="text-[#98a2b3]" />}
-            placeholder="搜索任务名称 / 描述"
-            className="!h-9 !w-[240px] !min-w-[190px]"
-            onChange={(event) =>
-              onDraftChange('keyword', event.target.value || undefined)
-            }
-            onPressEnter={() => void onSearch()}
-          />
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
+        <Input
+          allowClear
+          variant="filled"
+          value={filterDraft.keyword}
+          prefix={<SearchOutlined className="text-[#98a2b3]" />}
+          placeholder="搜索任务名称 / 描述"
+          className="!h-9 !w-[240px] !min-w-[190px]"
+          onChange={(event) =>
+            onDraftChange('keyword', event.target.value || undefined)
+          }
+          onPressEnter={() => void onSearch()}
+        />
 
-          <Select
-            allowClear
-            variant="filled"
-            value={filterDraft.releaseState}
-            options={REALTIME_SYNC_RELEASE_OPTIONS.map((item) => ({
-              ...item,
-            }))}
-            placeholder="发布状态"
-            className="!h-9 !w-[135px] !min-w-[125px]"
-            onChange={onReleaseStateChange}
-          />
+        <Select
+          allowClear
+          variant="filled"
+          value={filterDraft.releaseState}
+          options={REALTIME_SYNC_RELEASE_OPTIONS.map((item) => ({
+            ...item,
+          }))}
+          placeholder="发布状态"
+          className="!h-9 !w-[135px] !min-w-[125px]"
+          onChange={onReleaseStateChange}
+        />
 
-          <YakButton className="!h-9 !px-4" onClick={() => void onSearch()}>
-            查询
-          </YakButton>
+        <YakButton className="!h-9 !px-4" onClick={() => void onSearch()}>
+          查询
+        </YakButton>
 
-          <Popover
-            trigger="click"
-            placement="bottomRight"
-            open={advancedOpen}
-            onOpenChange={setAdvancedOpen}
-            content={
-              <div className="w-[320px]">
-                <div className="text-[14px] font-semibold text-[#101828]">
-                  高级搜索
-                </div>
-                <div className="mt-1 text-[12px] text-[#98a2b3]">
-                  按任务 ID 精确定位实时任务
-                </div>
-
-                <div className="mt-4">
-                  <div className="mb-1.5 text-[12px] text-[#667085]">
-                    任务 ID
-                  </div>
-                  <Input
-                    allowClear
-                    variant="filled"
-                    value={filterDraft.id}
-                    placeholder="请输入数字任务 ID"
-                    onChange={(event) =>
-                      onDraftChange('id', event.target.value || undefined)
-                    }
-                    onPressEnter={applyAdvancedFilter}
-                  />
-                </div>
-
-                <div className="mt-5 flex items-center justify-end gap-2 border-t border-[#f0f0f0] pt-4">
-                  <YakButton size="small" onClick={resetFilters}>
-                    重置全部
-                  </YakButton>
-                  <YakButton
-                    type="primary"
-                    danger
-                    size="small"
-                    onClick={applyAdvancedFilter}
-                  >
-                    应用筛选
-                  </YakButton>
-                </div>
+        <Popover
+          trigger="click"
+          placement="bottomRight"
+          open={advancedOpen}
+          onOpenChange={setAdvancedOpen}
+          content={
+            <div className="w-[320px]">
+              <div className="text-[14px] font-semibold text-[#101828]">
+                高级搜索
               </div>
-            }
+              <div className="mt-1 text-[12px] text-[#98a2b3]">
+                按任务 ID 精确定位实时任务
+              </div>
+
+              <div className="mt-4">
+                <div className="mb-1.5 text-[12px] text-[#667085]">
+                  任务 ID
+                </div>
+                <Input
+                  allowClear
+                  variant="filled"
+                  value={filterDraft.id}
+                  placeholder="请输入数字任务 ID"
+                  onChange={(event) =>
+                    onDraftChange('id', event.target.value || undefined)
+                  }
+                  onPressEnter={applyAdvancedFilter}
+                />
+              </div>
+
+              <div className="mt-5 flex items-center justify-end gap-2 border-t border-[#f0f0f0] pt-4">
+                <YakButton size="small" onClick={resetFilters}>
+                  重置全部
+                </YakButton>
+                <YakButton
+                  type="primary"
+                  danger
+                  size="small"
+                  onClick={applyAdvancedFilter}
+                >
+                  应用筛选
+                </YakButton>
+              </div>
+            </div>
+          }
+        >
+          <YakButton
+            size="small"
+            icon={<FilterOutlined />}
+            className={[
+              '!h-9 !px-3',
+              advancedFilterCount > 0
+                ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
+                : '',
+            ].join(' ')}
           >
-            <YakButton
-              size="small"
-              icon={<FilterOutlined />}
-              className={[
-                '!h-9 !px-3',
-                advancedFilterCount > 0
-                  ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
-                  : '',
-              ].join(' ')}
-            >
-              高级搜索
-              {advancedFilterCount > 0 ? (
-                <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
-                  {advancedFilterCount}
-                </span>
-              ) : null}
-            </YakButton>
-          </Popover>
-        </div>
+            高级搜索
+            {advancedFilterCount > 0 ? (
+              <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
+                {advancedFilterCount}
+              </span>
+            ) : null}
+          </YakButton>
+        </Popover>
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

- replace the left-side YakTab status filters on both offline sync and realtime sync with compact Segmented controls
- remove the extra bottom rule around the status filter area so the toolbar is visually lighter and no longer looks like a tab panel
- use the same neutral segmented treatment on both pages: soft gray track, white selected item, subtle shadow, compact 36px height
- keep the existing task status values and filtering behavior unchanged
- keep the right-side search / select / date / advanced-filter controls unchanged

## Why

These status choices are filter states rather than content navigation tabs. Segmented makes that relationship clearer and avoids the heavy underline/baseline treatment that was making the toolbar look boxed-in.

## Validation

- branch is based on the current `main`, ahead by 2 commits and behind by 0
- only the two filter-bar components are changed
- full frontend lint/build and browser regression were not run in this execution environment