### PR TITLE
style(sync): replace segmented status filters with compact switch

### DIFF
--- a/yak-ops-ui/src/components/YakFilterSwitch/index.tsx
+++ b/yak-ops-ui/src/components/YakFilterSwitch/index.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+
+export interface YakFilterSwitchOption<Value extends string = string> {
+  value: Value;
+  label: ReactNode;
+}
+
+export interface YakFilterSwitchProps<Value extends string = string> {
+  value: Value;
+  options: readonly YakFilterSwitchOption<Value>[];
+  onChange: (value: Value) => void;
+  className?: string;
+}
+
+/**
+ * Compact choice group for list filters.
+ *
+ * Unlike a content tab or Ant Design Segmented, the control has no shared
+ * track. Only the selected option is surfaced, which keeps dense filter bars
+ * lightweight while preserving clear state feedback.
+ */
+export default function YakFilterSwitch<Value extends string = string>({
+  value,
+  options,
+  onChange,
+  className,
+}: YakFilterSwitchProps<Value>) {
+  return (
+    <div
+      role="group"
+      className={[
+        'inline-flex h-9 shrink-0 items-center gap-1',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            className={[
+              'flex h-8 items-center justify-center rounded-[8px] px-3.5 text-[13px] leading-none',
+              'transition-[background-color,color,box-shadow] duration-150 ease-out',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,0.14)]',
+              active
+                ? 'bg-[#f2f3f5] font-semibold text-[#242731] shadow-[inset_0_0_0_1px_rgba(31,35,41,0.04)]'
+                : 'bg-transparent font-medium text-[#777c86] hover:bg-[#f7f8fa] hover:text-[#3f444e]',
+            ].join(' ')}
+            onClick={() => {
+              if (!active) onChange(option.value);
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/yak-ops-ui/src/components/ui/index.ts
+++ b/yak-ops-ui/src/components/ui/index.ts
@@ -1,5 +1,10 @@
 export { default as YakButton } from '../YakButton';
 export type { YakButtonProps } from '../YakButton';
 export { default as YakEmpty } from '../YakEmpty';
+export { default as YakFilterSwitch } from '../YakFilterSwitch';
+export type {
+  YakFilterSwitchOption,
+  YakFilterSwitchProps,
+} from '../YakFilterSwitch';
 export { default as YakTab } from '../YakTab';
 export type { YakTabProps } from '../YakTab';

--- a/yak-ops-ui/src/pages/batch-link-up/components/OfflineSyncFilterBar.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/OfflineSyncFilterBar.tsx
@@ -1,6 +1,6 @@
-import { YakButton } from '@/components/ui';
+import { YakButton, YakFilterSwitch } from '@/components/ui';
 import { FilterOutlined, SearchOutlined } from '@ant-design/icons';
-import { DatePicker, Input, Popover, Segmented, Select } from 'antd';
+import { DatePicker, Input, Popover, Select } from 'antd';
 import { useState } from 'react';
 
 import { OFFLINE_SYNC_STATUS_TABS } from '../constants';
@@ -11,28 +11,6 @@ import type {
 } from '../types';
 
 const { RangePicker } = DatePicker;
-
-const STATUS_SEGMENT_CLASS = [
-  '!h-9 !rounded-[10px] !bg-[#f4f5f7] !p-[3px]',
-  '[&_.ant-segmented-group]:!h-[30px]',
-  '[&_.ant-segmented-group]:!gap-1',
-  '[&_.ant-segmented-item]:!min-w-[72px]',
-  '[&_.ant-segmented-item]:!rounded-[7px]',
-  '[&_.ant-segmented-item]:!px-0',
-  '[&_.ant-segmented-item]:!text-[13px]',
-  '[&_.ant-segmented-item]:!font-medium',
-  '[&_.ant-segmented-item]:!text-[#747985]',
-  '[&_.ant-segmented-item-label]:!min-h-0',
-  '[&_.ant-segmented-item-label]:!px-3',
-  '[&_.ant-segmented-item-label]:!leading-[30px]',
-  '[&_.ant-segmented-thumb]:!rounded-[7px]',
-  '[&_.ant-segmented-thumb]:!bg-white',
-  '[&_.ant-segmented-thumb]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
-  '[&_.ant-segmented-item-selected]:!bg-white',
-  '[&_.ant-segmented-item-selected]:!font-semibold',
-  '[&_.ant-segmented-item-selected]:!text-[#252832]',
-  '[&_.ant-segmented-item-selected]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
-].join(' ');
 
 interface OfflineSyncFilterBarProps {
   filterDraft: OfflineSyncSearchState;
@@ -74,15 +52,10 @@ const OfflineSyncFilterBar = ({
 
   return (
     <div className="flex min-h-[44px] items-center justify-between gap-4">
-      <Segmented
-        size="small"
+      <YakFilterSwitch
         value={currentStatus}
-        options={OFFLINE_SYNC_STATUS_TABS.map((item) => ({
-          value: item.value,
-          label: item.label,
-        }))}
-        className={STATUS_SEGMENT_CLASS}
-        onChange={(value) => onStatusChange(String(value))}
+        options={OFFLINE_SYNC_STATUS_TABS}
+        onChange={onStatusChange}
       />
 
       <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">

--- a/yak-ops-ui/src/pages/realtime-sync/components/RealtimeSyncFilterBar.tsx
+++ b/yak-ops-ui/src/pages/realtime-sync/components/RealtimeSyncFilterBar.tsx
@@ -1,6 +1,6 @@
-import { YakButton } from '@/components/ui';
+import { YakButton, YakFilterSwitch } from '@/components/ui';
 import { FilterOutlined, SearchOutlined } from '@ant-design/icons';
-import { Input, Popover, Segmented, Select } from 'antd';
+import { Input, Popover, Select } from 'antd';
 import { useState } from 'react';
 
 import {
@@ -12,28 +12,6 @@ import type {
   RealtimeFilterState,
   RealtimePageStateGroup,
 } from '../types';
-
-const STATUS_SEGMENT_CLASS = [
-  '!h-9 !rounded-[10px] !bg-[#f4f5f7] !p-[3px]',
-  '[&_.ant-segmented-group]:!h-[30px]',
-  '[&_.ant-segmented-group]:!gap-1',
-  '[&_.ant-segmented-item]:!min-w-[72px]',
-  '[&_.ant-segmented-item]:!rounded-[7px]',
-  '[&_.ant-segmented-item]:!px-0',
-  '[&_.ant-segmented-item]:!text-[13px]',
-  '[&_.ant-segmented-item]:!font-medium',
-  '[&_.ant-segmented-item]:!text-[#747985]',
-  '[&_.ant-segmented-item-label]:!min-h-0',
-  '[&_.ant-segmented-item-label]:!px-3',
-  '[&_.ant-segmented-item-label]:!leading-[30px]',
-  '[&_.ant-segmented-thumb]:!rounded-[7px]',
-  '[&_.ant-segmented-thumb]:!bg-white',
-  '[&_.ant-segmented-thumb]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
-  '[&_.ant-segmented-item-selected]:!bg-white',
-  '[&_.ant-segmented-item-selected]:!font-semibold',
-  '[&_.ant-segmented-item-selected]:!text-[#252832]',
-  '[&_.ant-segmented-item-selected]:!shadow-[0_1px_4px_rgba(31,35,41,0.10)]',
-].join(' ');
 
 interface RealtimeSyncFilterBarProps {
   filterDraft: RealtimeFilterState;
@@ -74,17 +52,10 @@ const RealtimeSyncFilterBar = ({
 
   return (
     <div className="flex min-h-[44px] items-center justify-between gap-4">
-      <Segmented
-        size="small"
+      <YakFilterSwitch
         value={activeStateGroup}
-        options={REALTIME_SYNC_STATUS_TABS.map((item) => ({
-          value: item.value,
-          label: item.label,
-        }))}
-        className={STATUS_SEGMENT_CLASS}
-        onChange={(value) =>
-          onStateGroupChange(value as RealtimePageStateGroup)
-        }
+        options={REALTIME_SYNC_STATUS_TABS}
+        onChange={onStateGroupChange}
       />
 
       <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">


### PR DESCRIPTION
## What changed

- replace Ant Design `Segmented` on offline-sync and realtime-sync status filters with a small Yak Ops-owned `YakFilterSwitch`
- remove the large shared gray track that made the status area look heavy and boxed-in
- render only the selected state as a soft neutral chip; inactive states stay transparent and gain a light hover surface
- keep the switch compact at 36px overall height so it aligns with the search/filter controls without visually competing with them
- reuse the same filter switch across both sync pages through `@/components/ui`
- preserve all existing status values and filtering behavior

## Visual intent

The status control is treated as a lightweight filter group rather than navigation tabs or a system Segmented control. The selected item gets a subtle gray surface and stronger text, while the group itself has no enclosing background or underline.

## Validation

- branch is based on current `main`, ahead only and with no drift
- changes are limited to the shared filter-switch component/export and the two sync filter bars
- full frontend lint/build and browser regression were not run in this execution environment