### PR TITLE
style(data-development): reuse YakFilterSwitch for release and execution filters

### DIFF
--- a/yak-ops-ui/src/pages/data-development/executions/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/executions/index.tsx
@@ -1,3 +1,4 @@
+import { YakFilterSwitch } from '@/components/ui';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import { history } from '@umijs/max';
 import {
@@ -31,12 +32,12 @@ import type {
 
 const { RangePicker } = DatePicker;
 
-const statusTabs: Array<{ label: string; value?: DevelopmentTaskExecutionStatus }> = [
-  { label: '全部记录' },
+const statusTabs = [
+  { label: '全部记录', value: 'ALL' },
   { label: '运行中', value: 'RUNNING' },
   { label: '成功', value: 'SUCCESS' },
   { label: '失败', value: 'FAILED' },
-];
+] as const;
 
 const taskTypeOptions = [
   { label: 'SQL', value: 'SQL' },
@@ -280,26 +281,17 @@ const ExecutionHistoryPage = () => {
 
         <div className="mt-3 border-b border-[#f0f0f0]">
           <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-            <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
-              {statusTabs.map((item) => {
-                const active = status === item.value;
-                return (
-                  <button
-                    key={item.label}
-                    type="button"
-                    onClick={() => applyStatus(item.value)}
-                    className={[
-                      'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
-                      active
-                        ? 'bg-white text-[#fe2c55] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
-                        : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
-                    ].join(' ')}
-                  >
-                    {item.label}
-                  </button>
-                );
-              })}
-            </div>
+            <YakFilterSwitch
+              value={status || 'ALL'}
+              options={statusTabs}
+              onChange={(value) =>
+                applyStatus(
+                  value === 'ALL'
+                    ? undefined
+                    : (value as DevelopmentTaskExecutionStatus),
+                )
+              }
+            />
 
             <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
               <Input

--- a/yak-ops-ui/src/pages/data-development/releases/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/releases/index.tsx
@@ -1,3 +1,4 @@
+import { YakFilterSwitch } from '@/components/ui';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import {
@@ -378,30 +379,24 @@ const ReleaseCenterPage = () => {
 
         <div className="mt-3 border-b border-[#f0f0f0]">
           <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-            <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
-              {statusTabs.map((item) => {
-                const active = status === item.value;
-                return (
-                  <button
-                    key={item.value}
-                    type="button"
-                    onClick={() => {
-                      setStatus(item.value);
-                      setPageNo(1);
-                    }}
-                    className={[
-                      'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
-                      active
-                        ? 'bg-white text-[#fe2c55] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
-                        : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
-                    ].join(' ')}
-                  >
-                    {item.label}
-                    <span className="ml-1 text-[11px] opacity-70">{tabCount(item.value)}</span>
-                  </button>
-                );
-              })}
-            </div>
+            <YakFilterSwitch
+              value={status}
+              options={statusTabs.map((item) => ({
+                value: item.value,
+                label: (
+                  <span className="inline-flex items-baseline gap-1">
+                    <span>{item.label}</span>
+                    <span className="text-[11px] opacity-60">
+                      {tabCount(item.value)}
+                    </span>
+                  </span>
+                ),
+              }))}
+              onChange={(value) => {
+                setStatus(value);
+                setPageNo(1);
+              }}
+            />
 
             <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
               <Input


### PR DESCRIPTION
## What changed

- replace the custom status switcher in Data Development `发布中心` with the shared `YakFilterSwitch`
- replace the custom status switcher in Data Development `运行记录` with the shared `YakFilterSwitch`
- preserve release counts (`全部任务 / 已上线 / 已下线`) inside the unified switch labels
- map the execution page's `全部记录` UI value to the existing undefined-status query semantics without changing backend filtering behavior
- keep the surrounding search, type, trigger, date, refresh, table and pagination behavior unchanged

## Why

These pages were still using their own gray-track button groups while offline sync and realtime sync had already converged on `YakFilterSwitch`. Reusing the same component removes the heavy boxed treatment and keeps list-status filters visually consistent across Yak Ops.

## Validation

- branch is based on current `main`
- only `data-development/releases/index.tsx` and `data-development/executions/index.tsx` are changed
- compared the final diffs to confirm the changes are limited to the status filter UI/imports and the `ALL` adapter for execution history
- full frontend lint/build and browser regression were not run in this execution environment