### PR TITLE
style(ui): remove YakFilterSwitch selected border

### DIFF
--- a/yak-ops-ui/src/components/YakFilterSwitch/index.tsx
+++ b/yak-ops-ui/src/components/YakFilterSwitch/index.tsx
@@ -45,10 +45,10 @@ export default function YakFilterSwitch<Value extends string = string>({
             aria-pressed={active}
             className={[
               'flex h-8 items-center justify-center rounded-[8px] px-3.5 text-[13px] leading-none',
-              'transition-[background-color,color,box-shadow] duration-150 ease-out',
+              'transition-[background-color,color] duration-150 ease-out',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(254,44,85,0.14)]',
               active
-                ? 'bg-[#f2f3f5] font-semibold text-[#242731] shadow-[inset_0_0_0_1px_rgba(31,35,41,0.04)]'
+                ? 'bg-[#f2f3f5] font-semibold text-[#242731]'
                 : 'bg-transparent font-medium text-[#777c86] hover:bg-[#f7f8fa] hover:text-[#3f444e]',
             ].join(' ')}
             onClick={() => {


### PR DESCRIPTION
## What changed

- remove the inset 1px border-like shadow from the selected `YakFilterSwitch` item
- keep the selected state indicated only by the soft gray background and stronger text
- simplify the transition to background/text color only
- preserve hover, focus-visible, value switching, and all existing usages

## Validation

- only `yak-ops-ui/src/components/YakFilterSwitch/index.tsx` is changed
- no behavior or API changes
- full frontend lint/build and browser regression were not run in this execution environment