### PR TITLE
refactor(workflow): simplify instance toolbar layout

### DIFF
--- a/yak-ops-ui/src/pages/workflow/instances/components/WorkflowInstanceList.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/components/WorkflowInstanceList.tsx
@@ -1,22 +1,16 @@
-import YakButton from '@/components/YakButton';
+import { YakButton, YakFilterSwitch } from '@/components/ui';
 import {
   batchRetryWorkflowInstances,
   getWorkflowInstances,
   isWorkflowTerminal,
   type WorkflowInstance,
 } from '@/services/workflow';
-import {
-  CopyOutlined,
-  FilterOutlined,
-  ReloadOutlined,
-  SearchOutlined,
-} from '@ant-design/icons';
+import { CopyOutlined, FilterOutlined, SearchOutlined } from '@ant-design/icons';
 import { history } from '@umijs/max';
 import {
   Button,
   ConfigProvider,
   DatePicker,
-  Divider,
   Empty,
   Input,
   Modal,
@@ -49,26 +43,46 @@ const statusLabel: Record<string, string> = {
   TIMED_OUT: '已超时',
 };
 
-const RUNNING_STATUSES = new Set(['CREATED', 'RUNNING', 'PAUSING', 'PAUSED', 'RESUMING']);
-const COMPLETED_STATUSES = new Set(['SUCCESS', 'SUCCESS_WITH_WARNINGS', 'WARNING', 'CANCELED']);
+const RUNNING_STATUSES = new Set([
+  'CREATED',
+  'RUNNING',
+  'PAUSING',
+  'PAUSED',
+  'RESUMING',
+]);
+const COMPLETED_STATUSES = new Set([
+  'SUCCESS',
+  'SUCCESS_WITH_WARNINGS',
+  'WARNING',
+  'CANCELED',
+]);
 const FAILED_STATUSES = new Set(['FAILED', 'TIMED_OUT']);
-const RETRYABLE_NODE_STATUSES = new Set(['FAILED', 'UPSTREAM_FAILED', 'SKIPPED', 'CANCELED']);
+const RETRYABLE_NODE_STATUSES = new Set([
+  'FAILED',
+  'UPSTREAM_FAILED',
+  'SKIPPED',
+  'CANCELED',
+]);
 
 type StatusGroup = 'ALL' | 'RUNNING' | 'COMPLETED' | 'FAILED';
 type TestRunFilter = 'ALL' | 'TRUE' | 'FALSE';
 
-const statusTabs: Array<{ label: string; value: StatusGroup }> = [
+const statusTabs = [
   { label: '全部实例', value: 'ALL' },
   { label: '运行中', value: 'RUNNING' },
   { label: '已完成', value: 'COMPLETED' },
   { label: '失败', value: 'FAILED' },
-];
+] as const;
 
-const formatTime = (value?: string) => value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
+const formatTime = (value?: string) =>
+  value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-';
 
 const formatDuration = (record: WorkflowInstance) => {
   if (!record.startedAt) return '-';
-  const seconds = Math.max(0, dayjs(record.endedAt || undefined).diff(dayjs(record.startedAt), 'second'));
+  const seconds = Math.max(
+    0,
+    dayjs(record.endedAt || undefined).diff(dayjs(record.startedAt), 'second'),
+  );
   if (seconds < 60) return `${seconds} 秒`;
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes} 分 ${seconds % 60} 秒`;
@@ -76,15 +90,19 @@ const formatDuration = (record: WorkflowInstance) => {
 };
 
 const statusBadgeClassName = (status: string) => {
-  if (FAILED_STATUSES.has(status)) return 'border-[#ffd6d6] bg-[#fff5f5] text-[#d92d20]';
-  if (status === 'RUNNING' || status === 'RESUMING') return 'border-[#d0d5dd] bg-[#f8f9fb] text-[#344054]';
+  if (FAILED_STATUSES.has(status)) {
+    return 'border-[#ffd6d6] bg-[#fff5f5] text-[#d92d20]';
+  }
+  if (status === 'RUNNING' || status === 'RESUMING') {
+    return 'border-[#d0d5dd] bg-[#f8f9fb] text-[#344054]';
+  }
   return 'border-[#eaecf0] bg-[#fafafa] text-[#667085]';
 };
 
 const isRetryableInstance = (instance: WorkflowInstance) =>
-  isWorkflowTerminal(instance.status)
-  && instance.status !== 'SUCCESS'
-  && instance.nodes.some((node) => RETRYABLE_NODE_STATUSES.has(node.status));
+  isWorkflowTerminal(instance.status) &&
+  instance.status !== 'SUCCESS' &&
+  instance.nodes.some((node) => RETRYABLE_NODE_STATUSES.has(node.status));
 
 const WorkflowInstancesPage = () => {
   const [instances, setInstances] = useState<WorkflowInstance[]>([]);
@@ -107,7 +125,11 @@ const WorkflowInstancesPage = () => {
     try {
       setInstances(await getWorkflowInstances());
     } catch (error) {
-      if (showLoading) message.error(error instanceof Error ? error.message : '工作流实例加载失败');
+      if (showLoading) {
+        message.error(
+          error instanceof Error ? error.message : '工作流实例加载失败',
+        );
+      }
     } finally {
       if (showLoading) setLoading(false);
     }
@@ -131,19 +153,48 @@ const WorkflowInstancesPage = () => {
     const instanceId = instanceIdFilter.trim().toLowerCase();
     const definitionId = definitionIdFilter.trim().toLowerCase();
     const [start, end] = dateRange || [];
+
     return instances.filter((record) => {
       if (!matchesGroup(record.status)) return false;
-      if (q && ![record.name, record.id, record.definitionId, String(record.input?.businessDate || '')]
-        .some((value) => value?.toLowerCase().includes(q))) return false;
-      if (instanceId && !record.id.toLowerCase().includes(instanceId)) return false;
-      if (definitionId && !record.definitionId?.toLowerCase().includes(definitionId)) return false;
+      if (
+        q &&
+        ![
+          record.name,
+          record.id,
+          record.definitionId,
+          String(record.input?.businessDate || ''),
+        ].some((value) => value?.toLowerCase().includes(q))
+      ) {
+        return false;
+      }
+      if (instanceId && !record.id.toLowerCase().includes(instanceId)) {
+        return false;
+      }
+      if (
+        definitionId &&
+        !record.definitionId?.toLowerCase().includes(definitionId)
+      ) {
+        return false;
+      }
       if (testRunFilter === 'TRUE' && !record.testRun) return false;
       if (testRunFilter === 'FALSE' && record.testRun) return false;
-      if (start && dayjs(record.startedAt).isBefore(start.startOf('day'))) return false;
-      if (end && dayjs(record.startedAt).isAfter(end.endOf('day'))) return false;
+      if (start && dayjs(record.startedAt).isBefore(start.startOf('day'))) {
+        return false;
+      }
+      if (end && dayjs(record.startedAt).isAfter(end.endOf('day'))) {
+        return false;
+      }
       return true;
     });
-  }, [dateRange, definitionIdFilter, instanceIdFilter, instances, keyword, statusGroup, testRunFilter]);
+  }, [
+    dateRange,
+    definitionIdFilter,
+    instanceIdFilter,
+    instances,
+    keyword,
+    statusGroup,
+    testRunFilter,
+  ]);
 
   useEffect(() => {
     const maxPage = Math.max(1, Math.ceil(filtered.length / pageSize));
@@ -161,6 +212,12 @@ const WorkflowInstancesPage = () => {
     testRunFilter === 'ALL' ? '' : testRunFilter,
   ].filter(Boolean).length;
 
+  const hasActiveFilters =
+    statusGroup !== 'ALL' ||
+    Boolean(keyword.trim()) ||
+    Boolean(dateRange?.length) ||
+    advancedFilterCount > 0;
+
   const resetAdvancedFilters = () => {
     setInstanceIdFilter('');
     setDefinitionIdFilter('');
@@ -168,9 +225,22 @@ const WorkflowInstancesPage = () => {
     setPage(1);
   };
 
-  const handleSearch = () => {
-    setKeyword(keywordDraft);
+  const resetAllFilters = () => {
+    setStatusGroup('ALL');
+    setKeyword('');
+    setKeywordDraft('');
+    setDateRange(undefined);
+    setInstanceIdFilter('');
+    setDefinitionIdFilter('');
+    setTestRunFilter('ALL');
+    setSelectedKeys([]);
     setPage(1);
+  };
+
+  const handleSearch = () => {
+    setKeyword(keywordDraft.trim());
+    setPage(1);
+    setSelectedKeys([]);
   };
 
   const openDetail = (record: WorkflowInstance) => {
@@ -190,7 +260,9 @@ const WorkflowInstancesPage = () => {
     if (!selectedKeys.length || batchLoading) return;
     setBatchLoading(true);
     try {
-      const result = await batchRetryWorkflowInstances(selectedKeys.map(String));
+      const result = await batchRetryWorkflowInstances(
+        selectedKeys.map(String),
+      );
       setSelectedKeys([]);
       await load(false);
       if (result.failedCount === 0) {
@@ -201,12 +273,21 @@ const WorkflowInstancesPage = () => {
           width: 680,
           content: (
             <div className="mt-3 max-h-[320px] space-y-2 overflow-auto">
-              {result.items.filter((item) => !item.accepted).map((item) => (
-                <div key={item.executionId} className="rounded-md border border-[#fecdca] bg-[#fff6f5] px-3 py-2 text-[12px]">
-                  <div className="font-mono text-[#b42318]">{item.executionId}</div>
-                  <div className="mt-1 text-[#667085]">{item.message || '重试失败'}</div>
-                </div>
-              ))}
+              {result.items
+                .filter((item) => !item.accepted)
+                .map((item) => (
+                  <div
+                    key={item.executionId}
+                    className="rounded-md border border-[#fecdca] bg-[#fff6f5] px-3 py-2 text-[12px]"
+                  >
+                    <div className="font-mono text-[#b42318]">
+                      {item.executionId}
+                    </div>
+                    <div className="mt-1 text-[#667085]">
+                      {item.message || '重试失败'}
+                    </div>
+                  </div>
+                ))}
             </div>
           ),
         });
@@ -218,63 +299,128 @@ const WorkflowInstancesPage = () => {
     }
   };
 
-  const columns = useMemo<ColumnsType<WorkflowInstance>>(() => [
-    {
-      title: '名称 / ID', dataIndex: 'name', width: 315,
-      render: (_: unknown, record) => (
-        <div className="min-w-0 py-0.5">
-          <div className="truncate text-[13px] font-medium text-[#344054]">{record.name || '-'}</div>
-          <div className="mt-0.5 flex items-center gap-1 text-[11px] text-[#98a2b3]">
-            <span className="truncate">{record.id}</span>
-            <Tooltip title="复制实例 ID">
-              <Button type="text" size="small" icon={<CopyOutlined />} className="!h-5 !w-5 !min-w-0 !p-0" onClick={(event) => { event.stopPropagation(); void copyId(record.id); }} />
-            </Tooltip>
+  const columns = useMemo<ColumnsType<WorkflowInstance>>(
+    () => [
+      {
+        title: '名称 / ID',
+        dataIndex: 'name',
+        width: 315,
+        render: (_: unknown, record) => (
+          <div className="min-w-0 py-0.5">
+            <div className="truncate text-[13px] font-medium text-[#344054]">
+              {record.name || '-'}
+            </div>
+            <div className="mt-0.5 flex items-center gap-1 text-[11px] text-[#98a2b3]">
+              <span className="truncate">{record.id}</span>
+              <Tooltip title="复制实例 ID">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<CopyOutlined />}
+                  className="!h-5 !w-5 !min-w-0 !p-0"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void copyId(record.id);
+                  }}
+                />
+              </Tooltip>
+            </div>
+            <div className="truncate text-[11px] text-[#b0b7c3]">
+              definition：{record.definitionId || '-'}
+            </div>
           </div>
-          <div className="truncate text-[11px] text-[#b0b7c3]">definition：{record.definitionId || '-'}</div>
-        </div>
-      ),
-    },
-    {
-      title: '状态', dataIndex: 'status', width: 120, align: 'center',
-      render: (status: string) => (
-        <span className={`inline-flex min-h-6 items-center rounded-md border px-2 text-[12px] font-medium ${statusBadgeClassName(status)}`}>
-          {statusLabel[status] || status}
-        </span>
-      ),
-    },
-    {
-      title: '调度上下文', width: 190,
-      render: (_: unknown, record) => (
-        <div className="text-[11px] leading-5 text-[#667085]">
-          <div><span className="text-[#98a2b3]">businessDate：</span>{String(record.input?.businessDate || '-')}</div>
-          <div><span className="text-[#98a2b3]">trigger：</span>{String(record.input?.triggerType || (record.testRun ? 'TEST' : 'MANUAL'))}</div>
-          <div><span className="text-[#98a2b3]">version：</span>{record.workflowVersionNo ? `V${record.workflowVersionNo}` : '-'}</div>
-        </div>
-      ),
-    },
-    {
-      title: '执行概况', width: 175,
-      render: (_: unknown, record) => (
-        <div className="text-[12px] leading-5 text-[#667085]">
-          <div>节点 / 连线：{record.nodeCount} / {record.edgeCount}</div>
-          <div>运行时长：{formatDuration(record)}</div>
-        </div>
-      ),
-    },
-    { title: '开始时间', dataIndex: 'startedAt', width: 170, render: formatTime },
-    { title: '结束时间', dataIndex: 'endedAt', width: 170, render: formatTime },
-    {
-      title: '操作', width: 88, fixed: 'right',
-      render: (_: unknown, record) => <Button type="link" size="small" className="!px-0 !text-[12px]" onClick={() => openDetail(record)}>运维</Button>,
-    },
-  ], []);
+        ),
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 120,
+        align: 'center',
+        render: (status: string) => (
+          <span
+            className={`inline-flex min-h-6 items-center rounded-md border px-2 text-[12px] font-medium ${statusBadgeClassName(status)}`}
+          >
+            {statusLabel[status] || status}
+          </span>
+        ),
+      },
+      {
+        title: '调度上下文',
+        width: 190,
+        render: (_: unknown, record) => (
+          <div className="text-[11px] leading-5 text-[#667085]">
+            <div>
+              <span className="text-[#98a2b3]">businessDate：</span>
+              {String(record.input?.businessDate || '-')}
+            </div>
+            <div>
+              <span className="text-[#98a2b3]">trigger：</span>
+              {String(
+                record.input?.triggerType ||
+                  (record.testRun ? 'TEST' : 'MANUAL'),
+              )}
+            </div>
+            <div>
+              <span className="text-[#98a2b3]">version：</span>
+              {record.workflowVersionNo ? `V${record.workflowVersionNo}` : '-'}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '执行概况',
+        width: 175,
+        render: (_: unknown, record) => (
+          <div className="text-[12px] leading-5 text-[#667085]">
+            <div>
+              节点 / 连线：{record.nodeCount} / {record.edgeCount}
+            </div>
+            <div>运行时长：{formatDuration(record)}</div>
+          </div>
+        ),
+      },
+      {
+        title: '开始时间',
+        dataIndex: 'startedAt',
+        width: 170,
+        render: formatTime,
+      },
+      {
+        title: '结束时间',
+        dataIndex: 'endedAt',
+        width: 170,
+        render: formatTime,
+      },
+      {
+        title: '操作',
+        width: 88,
+        fixed: 'right',
+        render: (_: unknown, record) => (
+          <Button
+            type="link"
+            size="small"
+            className="!px-0 !text-[12px]"
+            onClick={() => openDetail(record)}
+          >
+            运维
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
 
   const advancedFilters = (
     <div className="w-[360px]">
       <div className="mb-4">
-        <div className="text-[14px] font-semibold text-[#101828]">高级搜索</div>
-        <div className="mt-1 text-[12px] text-[#98a2b3]">按实例标识、工作流定义和运行类型进一步筛选</div>
+        <div className="text-[14px] font-semibold text-[#101828]">
+          高级搜索
+        </div>
+        <div className="mt-1 text-[12px] text-[#98a2b3]">
+          按实例标识、工作流定义和运行类型进一步筛选
+        </div>
       </div>
+
       <div className="space-y-4">
         <div>
           <div className="mb-1.5 text-[12px] text-[#667085]">实例 ID</div>
@@ -282,27 +428,43 @@ const WorkflowInstancesPage = () => {
             allowClear
             variant="filled"
             value={instanceIdFilter}
-            onChange={(event) => { setInstanceIdFilter(event.target.value); setPage(1); }}
+            onChange={(event) => {
+              setInstanceIdFilter(event.target.value);
+              setPage(1);
+              setSelectedKeys([]);
+            }}
             placeholder="精确定位运行实例"
           />
         </div>
+
         <div>
-          <div className="mb-1.5 text-[12px] text-[#667085]">Definition ID</div>
+          <div className="mb-1.5 text-[12px] text-[#667085]">
+            Definition ID
+          </div>
           <Input
             allowClear
             variant="filled"
             value={definitionIdFilter}
-            onChange={(event) => { setDefinitionIdFilter(event.target.value); setPage(1); }}
+            onChange={(event) => {
+              setDefinitionIdFilter(event.target.value);
+              setPage(1);
+              setSelectedKeys([]);
+            }}
             placeholder="Workflow Version / Runtime Definition"
           />
         </div>
+
         <div>
           <div className="mb-1.5 text-[12px] text-[#667085]">运行类型</div>
           <Select
             className="w-full"
             variant="filled"
             value={testRunFilter}
-            onChange={(value) => { setTestRunFilter(value); setPage(1); }}
+            onChange={(value) => {
+              setTestRunFilter(value);
+              setPage(1);
+              setSelectedKeys([]);
+            }}
             options={[
               { value: 'ALL', label: '全部' },
               { value: 'FALSE', label: '正式运行' },
@@ -311,8 +473,14 @@ const WorkflowInstancesPage = () => {
           />
         </div>
       </div>
+
       <div className="mt-5 flex justify-end border-t border-[#f0f0f0] pt-4">
-        <YakButton disabled={advancedFilterCount === 0} onClick={resetAdvancedFilters}>重置</YakButton>
+        <YakButton
+          disabled={advancedFilterCount === 0}
+          onClick={resetAdvancedFilters}
+        >
+          重置
+        </YakButton>
       </div>
     </div>
   );
@@ -333,115 +501,123 @@ const WorkflowInstancesPage = () => {
       }}
     >
       <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4 text-[#161823]">
-        <h1 className="m-0 text-[17px] font-semibold leading-8">工作流实例</h1>
+        <div className="mb-3">
+          <h1 className="m-0 text-[17px] font-semibold leading-7">
+            工作流实例
+          </h1>
+          <div className="mt-1 flex items-center gap-2 text-[12px] text-[#98a2b3]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[#34a853]" />
+            <span>自动更新 · 每 2.5 秒同步运行状态</span>
+          </div>
+        </div>
 
         <div className="mx-auto flex w-full max-w-full flex-1 flex-col">
-          <div className="mb-3">
-            <div className="border-b border-[#f0f0f0]">
-              <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-                <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
-                  {statusTabs.map((item) => {
-                    const active = statusGroup === item.value;
-                    return (
-                      <button
-                        key={item.value}
-                        type="button"
-                        onClick={() => { setStatusGroup(item.value); setPage(1); setSelectedKeys([]); }}
-                        className={[
-                          'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
-                          active
-                            ? 'bg-white text-[#ff4d4f] shadow-[0_1px_4px_rgba(16,24,40,.08)]'
-                            : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
-                        ].join(' ')}
-                      >
-                        {item.label}
-                      </button>
-                    );
-                  })}
-                </div>
+          <div className="flex min-h-[52px] items-center justify-between gap-4 border-b border-[#eceef2]">
+            <YakFilterSwitch
+              value={statusGroup}
+              options={statusTabs}
+              onChange={(value) => {
+                setStatusGroup(value);
+                setPage(1);
+                setSelectedKeys([]);
+              }}
+            />
 
-                <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
-                  <Input
-                    allowClear
-                    variant="filled"
-                    prefix={<SearchOutlined className="text-[#98a2b3]" />}
-                    placeholder="名称 / 实例 ID / businessDate"
-                    className="!h-9 !w-[260px] !min-w-[220px]"
-                    value={keywordDraft}
-                    onChange={(event) => setKeywordDraft(event.target.value)}
-                    onPressEnter={handleSearch}
-                  />
-                  <RangePicker
-                    allowClear
-                    variant="filled"
-                    value={dateRange as any}
-                    format="YYYY-MM-DD"
-                    placeholder={['开始日期', '结束日期']}
-                    className="!h-9 !w-[250px] !min-w-[230px]"
-                    onChange={(value) => { setDateRange(value ? value as unknown as Dayjs[] : undefined); setPage(1); }}
-                  />
-                  <YakButton className="!h-9 !px-4" onClick={handleSearch}>查询</YakButton>
-                  <Popover
-                    placement="bottomRight"
-                    trigger="click"
-                    open={advancedOpen}
-                    onOpenChange={setAdvancedOpen}
-                    content={advancedFilters}
-                  >
-                    <YakButton
-                      size="small"
-                      icon={<FilterOutlined />}
-                      className={[
-                        '!h-9 !px-3',
-                        advancedFilterCount > 0 ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]' : '',
-                      ].join(' ')}
-                    >
-                      高级搜索
-                      {advancedFilterCount > 0 ? (
-                        <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
-                          {advancedFilterCount}
-                        </span>
-                      ) : null}
-                    </YakButton>
-                  </Popover>
-                </div>
-              </div>
-            </div>
+            <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
+              <Input
+                allowClear
+                variant="filled"
+                prefix={<SearchOutlined className="text-[#98a2b3]" />}
+                placeholder="名称 / 实例 ID / businessDate"
+                className="!h-9 !w-[260px] !min-w-[220px]"
+                value={keywordDraft}
+                onChange={(event) => setKeywordDraft(event.target.value)}
+                onPressEnter={handleSearch}
+              />
 
-            <div className="flex min-h-[48px] items-center justify-between">
-              <div className="text-[12px] text-[#98a2b3]">
-                {selectedKeys.length > 0 ? `已选择 ${selectedKeys.length} 个可恢复实例` : ''}
-              </div>
-              <div className="flex items-center gap-2">
-                {selectedKeys.length > 0 ? (
-                  <YakButton
-                    className="!h-8"
-                    icon={<RefreshCw size={13} />}
-                    loading={batchLoading}
-                    onClick={() => void batchRetry()}
-                  >
-                    批量重试失败实例（{selectedKeys.length}）
-                  </YakButton>
-                ) : null}
+              <RangePicker
+                allowClear
+                variant="filled"
+                value={dateRange as any}
+                format="YYYY-MM-DD"
+                placeholder={['开始日期', '结束日期']}
+                className="!h-9 !w-[250px] !min-w-[230px]"
+                onChange={(value) => {
+                  setDateRange(
+                    value ? (value as unknown as Dayjs[]) : undefined,
+                  );
+                  setPage(1);
+                  setSelectedKeys([]);
+                }}
+              />
+
+              <YakButton className="!h-9 !px-4" onClick={handleSearch}>
+                查询
+              </YakButton>
+
+              {hasActiveFilters ? (
                 <YakButton
-                  className="!h-8"
-                  icon={<ReloadOutlined spin={loading} />}
-                  loading={loading}
-                  onClick={() => void load(true)}
+                  type="text"
+                  className="!h-9 !px-2 !text-[#777c86]"
+                  onClick={resetAllFilters}
                 >
-                  刷新
+                  重置
                 </YakButton>
-              </div>
-            </div>
+              ) : null}
 
-            <div className="flex min-h-9 items-center rounded-sm bg-[#f8f9fb] px-3 text-[12px] text-[#475467]">
-              <span><b>【实例运维】</b> 单节点 Retry 在原实例恢复；“从此节点重跑”创建新实例并复用成功祖先结果；指定 businessDate 重跑固定来源发布版本。</span>
+              <Popover
+                placement="bottomRight"
+                trigger="click"
+                open={advancedOpen}
+                onOpenChange={setAdvancedOpen}
+                content={advancedFilters}
+              >
+                <YakButton
+                  size="small"
+                  icon={<FilterOutlined />}
+                  className={[
+                    '!h-9 !px-3',
+                    advancedFilterCount > 0
+                      ? '!border-[#ffccc7] !bg-[#fff1f0] !text-[#ff4d4f]'
+                      : '',
+                  ].join(' ')}
+                >
+                  高级搜索
+                  {advancedFilterCount > 0 ? (
+                    <span className="ml-1.5 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#ff4d4f] px-1 text-[10px] leading-[18px] text-white">
+                      {advancedFilterCount}
+                    </span>
+                  ) : null}
+                </YakButton>
+              </Popover>
             </div>
           </div>
 
-          <Divider style={{ marginTop: 4, marginBottom: 16 }} />
+          {selectedKeys.length > 0 ? (
+            <div className="mt-2 flex min-h-10 items-center justify-between rounded-[10px] bg-[#fafbfc] px-3">
+              <span className="text-[12px] text-[#667085]">
+                已选择 {selectedKeys.length} 个可恢复实例
+              </span>
+              <YakButton
+                className="!h-8"
+                icon={<RefreshCw size={13} />}
+                loading={batchLoading}
+                onClick={() => void batchRetry()}
+              >
+                批量重试失败实例（{selectedKeys.length}）
+              </YakButton>
+            </div>
+          ) : null}
 
-          <div className="flex-1">
+          <div className="mt-2 flex min-h-9 items-center gap-2 rounded-[9px] bg-[#f8f9fb] px-3 text-[12px] text-[#667085]">
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#98a2b3]" />
+            <span>
+              <b className="font-medium text-[#344054]">实例恢复</b>
+              {' · '}单节点 Retry 在原实例恢复；“从此节点重跑”创建新实例并复用成功祖先结果；指定 businessDate 重跑固定来源发布版本。
+            </span>
+          </div>
+
+          <div className="mt-3 flex-1">
             <Table<WorkflowInstance>
               rowKey="id"
               bordered
@@ -456,7 +632,9 @@ const WorkflowInstancesPage = () => {
                 columnWidth: 48,
                 getCheckboxProps: (record) => ({
                   disabled: !isRetryableInstance(record),
-                  title: isRetryableInstance(record) ? '加入批量失败恢复' : '当前实例没有可批量恢复的失败/阻断节点',
+                  title: isRetryableInstance(record)
+                    ? '加入批量失败恢复'
+                    : '当前实例没有可批量恢复的失败/阻断节点',
                 }),
               }}
               scroll={{ x: 1260 }}
@@ -464,7 +642,11 @@ const WorkflowInstancesPage = () => {
                 emptyText: (
                   <Empty
                     image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    description={<span className="text-[12px] text-[#98a2b3]">暂无工作流实例</span>}
+                    description={
+                      <span className="text-[12px] text-[#98a2b3]">
+                        暂无工作流实例
+                      </span>
+                    }
                   />
                 ),
               }}
@@ -496,15 +678,31 @@ const WorkflowInstancesPage = () => {
           </div>
 
           <div className="sticky bottom-0 z-20 mt-auto flex min-h-[56px] items-center justify-between border border-t-0 border-[#e5e7eb] bg-white px-5 py-3 shadow-[0_-4px_12px_rgba(16,24,40,0.04)]">
-            <div className="text-[12px] text-[#98a2b3]">当前筛选 {filtered.length} 条 · 可批量恢复 {filtered.filter(isRetryableInstance).length} 条</div>
+            <div className="text-[12px] text-[#98a2b3]">
+              当前筛选 {filtered.length} 条 · 可批量恢复{' '}
+              {filtered.filter(isRetryableInstance).length} 条
+            </div>
             <div className="flex items-center gap-3">
-              <Pagination size="small" total={filtered.length} current={page} pageSize={pageSize} showSizeChanger={false} onChange={setPage} />
+              <Pagination
+                size="small"
+                total={filtered.length}
+                current={page}
+                pageSize={pageSize}
+                showSizeChanger={false}
+                onChange={setPage}
+              />
               <Select
                 size="small"
                 value={pageSize}
                 className="w-[78px]"
-                onChange={(value) => { setPageSize(value); setPage(1); }}
-                options={[10, 20, 50].map((value) => ({ value, label: `${value} / 页` }))}
+                onChange={(value) => {
+                  setPageSize(value);
+                  setPage(1);
+                }}
+                options={[10, 20, 50].map((value) => ({
+                  value,
+                  label: `${value} / 页`,
+                }))}
               />
             </div>
           </div>


### PR DESCRIPTION
## What changed

- remove the explicit `刷新` button from the workflow instance page; the existing 2.5s automatic polling remains unchanged
- replace the page-local gray status button group with the shared `YakFilterSwitch`
- rebuild the top area into a compact header + single filter row, matching the newer list-page interaction pattern
- add a subtle `自动更新 · 每 2.5 秒同步运行状态` hint so the removed manual refresh action is understandable
- show a lightweight `重置` action only when filters are active
- move batch retry into a contextual selection strip that only appears after retryable instances are selected
- soften the instance-recovery guidance into a compact info strip instead of a separate toolbar row
- remove the extra `Divider` so the task table follows the filter/info area naturally
- preserve search, date range, advanced filters, batch retry, auto polling, table actions and pagination behavior

## Validation

- branch is based on the current `main` and contains only the workflow instance list refactor
- explicit refresh UI/imports were removed while the existing polling loop remains
- no backend API or workflow execution semantics were changed
- full frontend lint/build and browser regression were not run in this execution environment