### PR TITLE
style(dashboard): use YakFilterSwitch for lifecycle filters

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/components/DashboardPageHeader.tsx
+++ b/yak-ops-ui/src/pages/dashboard/components/DashboardPageHeader.tsx
@@ -1,4 +1,4 @@
-import { YakButton, YakTab } from '@/components/ui';
+import { YakButton, YakFilterSwitch } from '@/components/ui';
 import { Input, Select } from 'antd';
 import {
   CalendarDays,
@@ -62,24 +62,23 @@ const DashboardPageHeader = ({
         </div>
 
         <div className="flex min-w-0 flex-1 items-center justify-end gap-2 max-xl:flex-wrap">
-          <YakTab
-            size="small"
-            activeKey={status}
-            className="mr-1 !mb-0 [&_.ant-tabs-nav]:!mb-0"
-            items={DASHBOARD_STATUS_FILTERS.map((item) => ({
-              key: item.key,
+          <YakFilterSwitch
+            value={status}
+            options={DASHBOARD_STATUS_FILTERS.map((item) => ({
+              value: item.key,
               label: (
-                <span>
-                  {item.label}
+                <span className="inline-flex items-baseline gap-1">
+                  <span>{item.label}</span>
                   {item.key !== 'all' && statusCount(item.key) > 0 ? (
-                    <span className="ml-1 text-[10px] font-normal text-[#b0b5bd]">
+                    <span className="text-[10px] font-normal text-[#b0b5bd]">
                       {statusCount(item.key)}
                     </span>
                   ) : null}
                 </span>
               ),
             }))}
-            onChange={(key) => onStatusChange(key as DashboardStatusFilter)}
+            className="mr-1"
+            onChange={onStatusChange}
           />
 
           <Select<DashboardTimeRange>


### PR DESCRIPTION
## What changed

- replace the dashboard lifecycle `YakTab` filter with the shared `YakFilterSwitch`
- keep the existing `全部 / 已发布 / 有草稿 / 未发布` filter semantics unchanged
- preserve non-zero lifecycle counts in the switch labels
- keep the time range, keyword search, refresh and create-dashboard actions unchanged

## Why

The lifecycle choices are list filters rather than content-navigation tabs. Reusing `YakFilterSwitch` aligns the dashboard page with offline sync, realtime sync, release center, execution history and workflow instances, while removing the heavier underline/tab treatment.

## Validation

- branch is based on current `main`, ahead by one commit and behind by 0
- only `yak-ops-ui/src/pages/dashboard/components/DashboardPageHeader.tsx` is changed
- no query, API, pagination or dashboard lifecycle behavior changed
- full frontend lint/build and browser regression were not run in this execution environment