### PR TITLE
feat(digital-screen): isolate draft and published versions (PR 2)

### DIFF
--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/application/DigitalScreenApplicationService.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/application/DigitalScreenApplicationService.java
@@ -2,9 +2,11 @@ package io.yak.ops.business.digitalscreen.application;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
-import io.yak.ops.business.digitalscreen.domain.DigitalScreenStatus;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenVersion;
+import io.yak.ops.business.digitalscreen.publication.DigitalScreenPublisher;
 import io.yak.ops.business.digitalscreen.repository.DigitalScreenRepository;
-import java.time.Instant;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenVersionRepository;
+import io.yak.ops.business.digitalscreen.version.DigitalScreenVersionReader;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Application service for mutable Digital Screen definitions. Versioning is intentionally deferred. */
+/** Stable Digital Screen application facade for draft editing and publication history. */
 @Service
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -24,6 +26,9 @@ public class DigitalScreenApplicationService {
   private static final String COPY_SUFFIX = " - 副本";
 
   private final DigitalScreenRepository repository;
+  private final DigitalScreenVersionRepository versionRepository;
+  private final DigitalScreenPublisher publisher;
+  private final DigitalScreenVersionReader versionReader;
 
   public List<DigitalScreen> list() {
     return repository.list();
@@ -31,6 +36,18 @@ public class DigitalScreenApplicationService {
 
   public DigitalScreen get(long id) {
     return repository.findById(id).orElseThrow(() -> notFound(id));
+  }
+
+  public List<DigitalScreenVersion> versions(long id) {
+    return versionReader.versions(id);
+  }
+
+  public DigitalScreenVersion version(long id, int versionNo) {
+    return versionReader.version(id, versionNo);
+  }
+
+  public DigitalScreenVersion published(long id) {
+    return versionReader.published(id);
   }
 
   @Transactional
@@ -56,16 +73,16 @@ public class DigitalScreenApplicationService {
     return repository.update(id, name, description, bindings);
   }
 
-  @Transactional
   public DigitalScreen publish(long id) {
-    get(id);
-    return repository.updateStatus(id, DigitalScreenStatus.PUBLISHED, Instant.now());
+    return publisher.publish(id);
   }
 
-  @Transactional
   public DigitalScreen offline(long id) {
-    get(id);
-    return repository.updateStatus(id, DigitalScreenStatus.DRAFT, null);
+    return publisher.offline(id);
+  }
+
+  public DigitalScreen rollback(long id, int versionNo) {
+    return publisher.rollback(id, versionNo);
   }
 
   @Transactional
@@ -81,6 +98,8 @@ public class DigitalScreenApplicationService {
 
   @Transactional
   public void delete(long id) {
+    get(id);
+    versionRepository.deleteByScreenId(id);
     if (!repository.deleteById(id)) throw notFound(id);
   }
 

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenController.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenController.java
@@ -10,6 +10,8 @@ import io.yak.ops.business.digitalscreen.controller.v1.converter.DigitalScreenVi
 import io.yak.ops.business.digitalscreen.controller.v1.dto.DigitalScreenRequests.CreateDigitalScreenRequest;
 import io.yak.ops.business.digitalscreen.controller.v1.dto.DigitalScreenRequests.UpdateDigitalScreenRequest;
 import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVO;
+import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVersionSummaryVO;
+import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVersionVO;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Digital Screen HTTP adapter. Runtime Dataset queries remain in the Dataset module. */
+/** Digital Screen HTTP adapter. Viewer endpoints expose immutable published snapshots. */
 @Tag(name = "数字化大屏接口")
 @RestController
 @Validated
@@ -42,10 +44,35 @@ public class DigitalScreenController {
     return Result.success(service.list().stream().map(viewConverter::screen).toList());
   }
 
-  @Operation(summary = "查询数字化大屏详情")
+  @Operation(summary = "查询数字化大屏当前 Draft")
   @GetMapping("/{screenId}")
   public Result<DigitalScreenVO> get(@PathVariable("screenId") long screenId) {
     return Result.success(viewConverter.screen(service.get(screenId)));
+  }
+
+  @Operation(summary = "查询数字化大屏当前已发布快照")
+  @GetMapping("/{screenId}/published")
+  public Result<DigitalScreenVersionVO> published(@PathVariable("screenId") long screenId) {
+    return Result.success(viewConverter.version(service.published(screenId)));
+  }
+
+  @Operation(summary = "查询数字化大屏发布版本历史")
+  @GetMapping("/{screenId}/versions")
+  public Result<List<DigitalScreenVersionSummaryVO>> versions(
+      @PathVariable("screenId") long screenId) {
+    DigitalScreenVO screen = viewConverter.screen(service.get(screenId));
+    int currentVersionNo = screen.publishedVersionNo() == null ? 0 : screen.publishedVersionNo();
+    return Result.success(service.versions(screenId).stream()
+        .map(version -> viewConverter.versionSummary(version, currentVersionNo))
+        .toList());
+  }
+
+  @Operation(summary = "查询数字化大屏指定发布版本")
+  @GetMapping("/{screenId}/versions/{versionNo}")
+  public Result<DigitalScreenVersionVO> version(
+      @PathVariable("screenId") long screenId,
+      @PathVariable("versionNo") int versionNo) {
+    return Result.success(viewConverter.version(service.version(screenId, versionNo)));
   }
 
   @Operation(summary = "创建数字化大屏")
@@ -55,7 +82,7 @@ public class DigitalScreenController {
     return Result.success(viewConverter.screen(service.create(requestConverter.create(request))));
   }
 
-  @Operation(summary = "更新数字化大屏定义")
+  @Operation(summary = "保存数字化大屏 Draft")
   @PutMapping("/{screenId}")
   public Result<DigitalScreenVO> update(
       @PathVariable("screenId") long screenId,
@@ -63,25 +90,33 @@ public class DigitalScreenController {
     return Result.success(viewConverter.screen(service.update(screenId, requestConverter.update(request))));
   }
 
-  @Operation(summary = "发布数字化大屏")
+  @Operation(summary = "把当前 Draft 发布为新的不可变版本")
   @PostMapping("/{screenId}/publish")
   public Result<DigitalScreenVO> publish(@PathVariable("screenId") long screenId) {
     return Result.success(viewConverter.screen(service.publish(screenId)));
   }
 
-  @Operation(summary = "取消发布数字化大屏")
+  @Operation(summary = "取消发布数字化大屏，历史版本继续保留")
   @PostMapping("/{screenId}/offline")
   public Result<DigitalScreenVO> offline(@PathVariable("screenId") long screenId) {
     return Result.success(viewConverter.screen(service.offline(screenId)));
   }
 
-  @Operation(summary = "复制数字化大屏")
+  @Operation(summary = "回滚历史版本并追加发布为新的版本")
+  @PostMapping("/{screenId}/versions/{versionNo}/rollback")
+  public Result<DigitalScreenVO> rollback(
+      @PathVariable("screenId") long screenId,
+      @PathVariable("versionNo") int versionNo) {
+    return Result.success(viewConverter.screen(service.rollback(screenId, versionNo)));
+  }
+
+  @Operation(summary = "复制数字化大屏 Draft，复制品不继承发布历史")
   @PostMapping("/{screenId}/duplicate")
   public Result<DigitalScreenVO> duplicate(@PathVariable("screenId") long screenId) {
     return Result.success(viewConverter.screen(service.duplicate(screenId)));
   }
 
-  @Operation(summary = "删除数字化大屏")
+  @Operation(summary = "删除数字化大屏及其发布版本历史")
   @DeleteMapping("/{screenId}")
   public Result<Boolean> delete(@PathVariable("screenId") long screenId) {
     service.delete(screenId);

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/converter/DigitalScreenViewConverter.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/converter/DigitalScreenViewConverter.java
@@ -1,7 +1,10 @@
 package io.yak.ops.business.digitalscreen.controller.v1.converter;
 
 import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVO;
+import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVersionSummaryVO;
+import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVersionVO;
 import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenVersion;
 import java.util.Locale;
 import org.springframework.stereotype.Component;
 
@@ -17,8 +20,39 @@ public class DigitalScreenViewConverter {
         source.templateVersion(),
         source.status().name().toLowerCase(Locale.ROOT),
         source.bindings(),
+        source.revision(),
+        source.publishedRevision(),
+        source.publishedVersionNo() > 0 ? source.publishedVersionNo() : null,
+        source.hasUnpublishedChanges(),
         source.publishedTime(),
         source.createTime(),
         source.updateTime());
+  }
+
+  public DigitalScreenVersionSummaryVO versionSummary(
+      DigitalScreenVersion source,
+      int currentVersionNo) {
+    return new DigitalScreenVersionSummaryVO(
+        Long.toString(source.id()),
+        source.versionNo(),
+        source.sourceRevision(),
+        source.name(),
+        source.publishedTime(),
+        source.versionNo() == currentVersionNo);
+  }
+
+  public DigitalScreenVersionVO version(DigitalScreenVersion source) {
+    return new DigitalScreenVersionVO(
+        Long.toString(source.id()),
+        Long.toString(source.screenId()),
+        source.versionNo(),
+        source.sourceRevision(),
+        source.name(),
+        source.description(),
+        source.templateId(),
+        source.templateVersion(),
+        source.bindings(),
+        source.publishedTime(),
+        source.createTime());
   }
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/vo/DigitalScreenViews.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/vo/DigitalScreenViews.java
@@ -16,8 +16,35 @@ public final class DigitalScreenViews {
       int templateVersion,
       String status,
       Map<String, Object> bindings,
+      long revision,
+      Long publishedRevision,
+      Integer publishedVersionNo,
+      boolean hasUnpublishedChanges,
       Instant publishedTime,
       Instant createTime,
       Instant updateTime) {
+  }
+
+  public record DigitalScreenVersionSummaryVO(
+      String id,
+      int versionNo,
+      long sourceRevision,
+      String name,
+      Instant publishedTime,
+      boolean current) {
+  }
+
+  public record DigitalScreenVersionVO(
+      String id,
+      String screenId,
+      int versionNo,
+      long sourceRevision,
+      String name,
+      String description,
+      String templateId,
+      int templateVersion,
+      Map<String, Object> bindings,
+      Instant publishedTime,
+      Instant createTime) {
   }
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/dao/mapper/DigitalScreenVersionMapper.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/dao/mapper/DigitalScreenVersionMapper.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.digitalscreen.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.digitalscreen.dao.model.DigitalScreenVersionPO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DigitalScreenVersionMapper extends BaseMapper<DigitalScreenVersionPO> {
+}

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/dao/model/DigitalScreenVersionPO.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/dao/model/DigitalScreenVersionPO.java
@@ -7,21 +7,18 @@ import java.sql.Timestamp;
 import lombok.Data;
 
 @Data
-@TableName("yak_digital_screen")
-public class DigitalScreenPO {
+@TableName("yak_digital_screen_version")
+public class DigitalScreenVersionPO {
   @TableId(type = IdType.AUTO)
   private Long id;
-  private String name;
-  private String description;
-  private String templateId;
-  private Integer templateVersion;
-  private String status;
+  private Long screenId;
+  private Integer versionNo;
+  private Long sourceRevision;
+  private String nameSnapshot;
+  private String descriptionSnapshot;
+  private String templateIdSnapshot;
+  private Integer templateVersionSnapshot;
   private String bindingsJson;
-  private Long revision;
-  private Long publishedRevision;
-  private Long publishedVersionId;
-  private Integer publishedVersionNo;
   private Timestamp publishedTime;
   private Timestamp createTime;
-  private Timestamp updateTime;
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/domain/DigitalScreen.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/domain/DigitalScreen.java
@@ -4,8 +4,9 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
-/** Persisted Digital Screen definition. Runtime Dataset values are intentionally excluded. */
+/** Persisted Digital Screen draft plus its current publication pointer. */
 public record DigitalScreen(
     long id,
     String name,
@@ -14,6 +15,10 @@ public record DigitalScreen(
     int templateVersion,
     DigitalScreenStatus status,
     Map<String, Object> bindings,
+    long revision,
+    Long publishedRevision,
+    Long publishedVersionId,
+    int publishedVersionNo,
     Instant publishedTime,
     Instant createTime,
     Instant updateTime) {
@@ -22,5 +27,10 @@ public record DigitalScreen(
     bindings = bindings == null
         ? Map.of()
         : Collections.unmodifiableMap(new LinkedHashMap<>(bindings));
+  }
+
+  public boolean hasUnpublishedChanges() {
+    return status == DigitalScreenStatus.PUBLISHED
+        && !Objects.equals(publishedRevision, revision);
   }
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/domain/DigitalScreenVersion.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/domain/DigitalScreenVersion.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.digitalscreen.domain;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Immutable snapshot created whenever a Digital Screen draft is published. */
+public record DigitalScreenVersion(
+    long id,
+    long screenId,
+    int versionNo,
+    long sourceRevision,
+    String name,
+    String description,
+    String templateId,
+    int templateVersion,
+    Map<String, Object> bindings,
+    Instant publishedTime,
+    Instant createTime) {
+
+  public DigitalScreenVersion {
+    bindings = bindings == null
+        ? Map.of()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(bindings));
+  }
+}

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/publication/DigitalScreenPublisher.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/publication/DigitalScreenPublisher.java
@@ -1,0 +1,79 @@
+package io.yak.ops.business.digitalscreen.publication;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenStatus;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenVersion;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenRepository;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenVersionRepository;
+import java.time.Instant;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Owns publish/offline/rollback transitions while keeping version history append-only. */
+@Service
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DigitalScreenPublisher {
+
+  private final DigitalScreenRepository screens;
+  private final DigitalScreenVersionRepository versions;
+
+  @Transactional
+  public DigitalScreen publish(long screenId) {
+    DigitalScreen draft = screens.lockById(screenId);
+    if (draft.status() == DigitalScreenStatus.PUBLISHED
+        && draft.publishedVersionId() != null
+        && Objects.equals(draft.publishedRevision(), draft.revision())) {
+      return draft;
+    }
+
+    Instant now = Instant.now();
+    int versionNo = versions.nextVersionNo(screenId);
+    DigitalScreenVersion version = versions.insert(draft, versionNo, now);
+    return screens.markPublished(
+        screenId,
+        version.id(),
+        version.versionNo(),
+        draft.revision(),
+        now);
+  }
+
+  @Transactional
+  public DigitalScreen offline(long screenId) {
+    screens.lockById(screenId);
+    return screens.offline(screenId);
+  }
+
+  @Transactional
+  public DigitalScreen rollback(long screenId, int versionNo) {
+    screens.lockById(screenId);
+    DigitalScreenVersion target = versions.findByVersionNo(screenId, versionNo)
+        .orElseThrow(() -> versionNotFound(screenId, versionNo));
+
+    DigitalScreen restored = screens.restoreDraft(
+        screenId,
+        target.name(),
+        target.description(),
+        target.templateId(),
+        target.templateVersion(),
+        target.bindings());
+
+    Instant now = Instant.now();
+    int nextVersionNo = versions.nextVersionNo(screenId);
+    DigitalScreenVersion rollbackVersion = versions.insert(restored, nextVersionNo, now);
+    return screens.markPublished(
+        screenId,
+        rollbackVersion.id(),
+        rollbackVersion.versionNo(),
+        restored.revision(),
+        now);
+  }
+
+  private IllegalArgumentException versionNotFound(long screenId, int versionNo) {
+    return new IllegalArgumentException(
+        "数字化大屏版本不存在：" + screenId + " / V" + versionNo);
+  }
+}

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenRepository.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenRepository.java
@@ -1,18 +1,19 @@
 package io.yak.ops.business.digitalscreen.repository;
 
 import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
-import io.yak.ops.business.digitalscreen.domain.DigitalScreenStatus;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-/** Persistence port for Digital Screen definitions. */
+/** Persistence port for the mutable Digital Screen draft and publication pointer. */
 public interface DigitalScreenRepository {
 
   List<DigitalScreen> list();
 
   Optional<DigitalScreen> findById(long id);
+
+  DigitalScreen lockById(long id);
 
   DigitalScreen insert(
       String name,
@@ -27,7 +28,22 @@ public interface DigitalScreenRepository {
       String description,
       Map<String, Object> bindings);
 
-  DigitalScreen updateStatus(long id, DigitalScreenStatus status, Instant publishedTime);
+  DigitalScreen restoreDraft(
+      long id,
+      String name,
+      String description,
+      String templateId,
+      int templateVersion,
+      Map<String, Object> bindings);
+
+  DigitalScreen markPublished(
+      long id,
+      long versionId,
+      int versionNo,
+      long publishedRevision,
+      Instant publishedTime);
+
+  DigitalScreen offline(long id);
 
   boolean deleteById(long id);
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenRepositoryAdapter.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
-/** MyBatis-Plus persistence adapter for Digital Screen definitions. */
+/** MyBatis-Plus adapter for the mutable Digital Screen draft and publication pointer. */
 @Repository
 @DependsOn("yakDigitalScreenFlyway")
 @ConditionalOnDataSourceEnabled
@@ -43,6 +43,16 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
   }
 
   @Override
+  public DigitalScreen lockById(long id) {
+    DigitalScreenPO row = mapper.selectOne(
+        Wrappers.<DigitalScreenPO>lambdaQuery()
+            .eq(DigitalScreenPO::getId, id)
+            .last("FOR UPDATE"));
+    if (row == null) throw notFound(id);
+    return toDomain(row);
+  }
+
+  @Override
   public DigitalScreen insert(
       String name,
       String description,
@@ -57,6 +67,8 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
     row.setTemplateVersion(templateVersion);
     row.setStatus(DigitalScreenStatus.DRAFT.name());
     row.setBindingsJson(bindingsCodec.encode(bindings));
+    row.setRevision(1L);
+    row.setPublishedVersionNo(0);
     row.setCreateTime(Timestamp.from(now));
     row.setUpdateTime(Timestamp.from(now));
     if (mapper.insert(row) != 1 || row.getId() == null) {
@@ -78,26 +90,69 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
             .set(DigitalScreenPO::getName, name)
             .set(DigitalScreenPO::getDescription, description)
             .set(DigitalScreenPO::getBindingsJson, bindingsCodec.encode(bindings))
-            .set(DigitalScreenPO::getUpdateTime, Timestamp.from(Instant.now())));
+            .set(DigitalScreenPO::getUpdateTime, Timestamp.from(Instant.now()))
+            .setSql("revision = revision + 1"));
     requireUpdated(updated, id);
     return required(id);
   }
 
   @Override
-  public DigitalScreen updateStatus(
+  public DigitalScreen restoreDraft(
       long id,
-      DigitalScreenStatus status,
+      String name,
+      String description,
+      String templateId,
+      int templateVersion,
+      Map<String, Object> bindings) {
+    int updated = mapper.update(
+        null,
+        Wrappers.<DigitalScreenPO>lambdaUpdate()
+            .eq(DigitalScreenPO::getId, id)
+            .set(DigitalScreenPO::getName, name)
+            .set(DigitalScreenPO::getDescription, description)
+            .set(DigitalScreenPO::getTemplateId, templateId)
+            .set(DigitalScreenPO::getTemplateVersion, templateVersion)
+            .set(DigitalScreenPO::getBindingsJson, bindingsCodec.encode(bindings))
+            .set(DigitalScreenPO::getUpdateTime, Timestamp.from(Instant.now()))
+            .setSql("revision = revision + 1"));
+    requireUpdated(updated, id);
+    return required(id);
+  }
+
+  @Override
+  public DigitalScreen markPublished(
+      long id,
+      long versionId,
+      int versionNo,
+      long publishedRevision,
       Instant publishedTime) {
     Instant now = Instant.now();
     int updated = mapper.update(
         null,
         Wrappers.<DigitalScreenPO>lambdaUpdate()
             .eq(DigitalScreenPO::getId, id)
-            .set(DigitalScreenPO::getStatus, status.name())
-            .set(
-                DigitalScreenPO::getPublishedTime,
-                publishedTime == null ? null : Timestamp.from(publishedTime))
+            .set(DigitalScreenPO::getStatus, DigitalScreenStatus.PUBLISHED.name())
+            .set(DigitalScreenPO::getPublishedVersionId, versionId)
+            .set(DigitalScreenPO::getPublishedVersionNo, versionNo)
+            .set(DigitalScreenPO::getPublishedRevision, publishedRevision)
+            .set(DigitalScreenPO::getPublishedTime, Timestamp.from(publishedTime))
             .set(DigitalScreenPO::getUpdateTime, Timestamp.from(now)));
+    requireUpdated(updated, id);
+    return required(id);
+  }
+
+  @Override
+  public DigitalScreen offline(long id) {
+    int updated = mapper.update(
+        null,
+        Wrappers.<DigitalScreenPO>lambdaUpdate()
+            .eq(DigitalScreenPO::getId, id)
+            .set(DigitalScreenPO::getStatus, DigitalScreenStatus.DRAFT.name())
+            .set(DigitalScreenPO::getPublishedVersionId, null)
+            .set(DigitalScreenPO::getPublishedVersionNo, 0)
+            .set(DigitalScreenPO::getPublishedRevision, null)
+            .set(DigitalScreenPO::getPublishedTime, null)
+            .set(DigitalScreenPO::getUpdateTime, Timestamp.from(Instant.now())));
     requireUpdated(updated, id);
     return required(id);
   }
@@ -120,14 +175,22 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
   }
 
   private DigitalScreen toDomain(DigitalScreenPO row) {
+    Long publishedVersionId = row.getPublishedVersionId();
+    DigitalScreenStatus status = publishedVersionId == null
+        ? DigitalScreenStatus.DRAFT
+        : DigitalScreenStatus.PUBLISHED;
     return new DigitalScreen(
         row.getId(),
         row.getName(),
         row.getDescription(),
         row.getTemplateId(),
         row.getTemplateVersion() == null ? 1 : row.getTemplateVersion(),
-        DigitalScreenStatus.valueOf(row.getStatus()),
+        status,
         bindingsCodec.decode(row.getBindingsJson()),
+        row.getRevision() == null ? 1L : row.getRevision(),
+        row.getPublishedRevision(),
+        publishedVersionId,
+        row.getPublishedVersionNo() == null ? 0 : row.getPublishedVersionNo(),
         instant(row.getPublishedTime()),
         instant(row.getCreateTime()),
         instant(row.getUpdateTime()));

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenVersionRepository.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenVersionRepository.java
@@ -1,0 +1,23 @@
+package io.yak.ops.business.digitalscreen.repository;
+
+import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenVersion;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/** Append-only persistence port for immutable published Digital Screen snapshots. */
+public interface DigitalScreenVersionRepository {
+
+  List<DigitalScreenVersion> list(long screenId);
+
+  Optional<DigitalScreenVersion> findById(long versionId);
+
+  Optional<DigitalScreenVersion> findByVersionNo(long screenId, int versionNo);
+
+  int nextVersionNo(long screenId);
+
+  DigitalScreenVersion insert(DigitalScreen draft, int versionNo, Instant publishedTime);
+
+  void deleteByScreenId(long screenId);
+}

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenVersionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenVersionRepositoryAdapter.java
@@ -1,0 +1,102 @@
+package io.yak.ops.business.digitalscreen.repository;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.digitalscreen.dao.mapper.DigitalScreenVersionMapper;
+import io.yak.ops.business.digitalscreen.dao.model.DigitalScreenVersionPO;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenVersion;
+import io.yak.ops.business.digitalscreen.repository.codec.DigitalScreenBindingsCodec;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis-Plus adapter for append-only Digital Screen published snapshots. */
+@Repository
+@DependsOn("yakDigitalScreenFlyway")
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DigitalScreenVersionRepositoryAdapter implements DigitalScreenVersionRepository {
+
+  private final DigitalScreenVersionMapper mapper;
+  private final DigitalScreenBindingsCodec bindingsCodec;
+
+  @Override
+  public List<DigitalScreenVersion> list(long screenId) {
+    return mapper.selectList(
+            Wrappers.<DigitalScreenVersionPO>lambdaQuery()
+                .eq(DigitalScreenVersionPO::getScreenId, screenId)
+                .orderByDesc(DigitalScreenVersionPO::getVersionNo))
+        .stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public Optional<DigitalScreenVersion> findById(long versionId) {
+    return Optional.ofNullable(mapper.selectById(versionId)).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DigitalScreenVersion> findByVersionNo(long screenId, int versionNo) {
+    return Optional.ofNullable(mapper.selectOne(
+            Wrappers.<DigitalScreenVersionPO>lambdaQuery()
+                .eq(DigitalScreenVersionPO::getScreenId, screenId)
+                .eq(DigitalScreenVersionPO::getVersionNo, versionNo)))
+        .map(this::toDomain);
+  }
+
+  @Override
+  public int nextVersionNo(long screenId) {
+    DigitalScreenVersionPO latest = mapper.selectOne(
+        Wrappers.<DigitalScreenVersionPO>lambdaQuery()
+            .eq(DigitalScreenVersionPO::getScreenId, screenId)
+            .orderByDesc(DigitalScreenVersionPO::getVersionNo)
+            .last("LIMIT 1"));
+    return latest == null || latest.getVersionNo() == null ? 1 : latest.getVersionNo() + 1;
+  }
+
+  @Override
+  public DigitalScreenVersion insert(DigitalScreen draft, int versionNo, Instant publishedTime) {
+    DigitalScreenVersionPO row = new DigitalScreenVersionPO();
+    row.setScreenId(draft.id());
+    row.setVersionNo(versionNo);
+    row.setSourceRevision(draft.revision());
+    row.setNameSnapshot(draft.name());
+    row.setDescriptionSnapshot(draft.description());
+    row.setTemplateIdSnapshot(draft.templateId());
+    row.setTemplateVersionSnapshot(draft.templateVersion());
+    row.setBindingsJson(bindingsCodec.encode(draft.bindings()));
+    row.setPublishedTime(Timestamp.from(publishedTime));
+    row.setCreateTime(Timestamp.from(publishedTime));
+    if (mapper.insert(row) != 1 || row.getId() == null) {
+      throw new IllegalStateException("创建数字化大屏发布版本失败");
+    }
+    return toDomain(row);
+  }
+
+  @Override
+  public void deleteByScreenId(long screenId) {
+    mapper.delete(Wrappers.<DigitalScreenVersionPO>lambdaQuery()
+        .eq(DigitalScreenVersionPO::getScreenId, screenId));
+  }
+
+  private DigitalScreenVersion toDomain(DigitalScreenVersionPO row) {
+    return new DigitalScreenVersion(
+        row.getId(),
+        row.getScreenId(),
+        row.getVersionNo(),
+        row.getSourceRevision(),
+        row.getNameSnapshot(),
+        row.getDescriptionSnapshot(),
+        row.getTemplateIdSnapshot(),
+        row.getTemplateVersionSnapshot() == null ? 1 : row.getTemplateVersionSnapshot(),
+        bindingsCodec.decode(row.getBindingsJson()),
+        row.getPublishedTime().toInstant(),
+        row.getCreateTime().toInstant());
+  }
+}

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/version/DigitalScreenVersionReader.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/version/DigitalScreenVersionReader.java
@@ -1,0 +1,56 @@
+package io.yak.ops.business.digitalscreen.version;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenVersion;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenRepository;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenVersionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Read role for immutable Digital Screen publication history. */
+@Service
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DigitalScreenVersionReader {
+
+  private final DigitalScreenRepository screens;
+  private final DigitalScreenVersionRepository versions;
+
+  public List<DigitalScreenVersion> versions(long screenId) {
+    requireScreen(screenId);
+    return versions.list(screenId);
+  }
+
+  public DigitalScreenVersion version(long screenId, int versionNo) {
+    requireScreen(screenId);
+    return versions.findByVersionNo(screenId, versionNo)
+        .orElseThrow(() -> versionNotFound(screenId, versionNo));
+  }
+
+  public DigitalScreenVersion published(long screenId) {
+    DigitalScreen screen = requireScreen(screenId);
+    if (screen.publishedVersionId() == null) {
+      throw new IllegalArgumentException("数字化大屏尚未发布：" + screenId);
+    }
+    DigitalScreenVersion version = versions.findById(screen.publishedVersionId())
+        .orElseThrow(() -> new IllegalStateException(
+            "数字化大屏当前发布版本不存在：" + screenId));
+    if (version.screenId() != screenId) {
+      throw new IllegalStateException("数字化大屏发布版本指针异常：" + screenId);
+    }
+    return version;
+  }
+
+  private DigitalScreen requireScreen(long screenId) {
+    return screens.findById(screenId)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "数字化大屏不存在或已被删除：" + screenId));
+  }
+
+  private IllegalArgumentException versionNotFound(long screenId, int versionNo) {
+    return new IllegalArgumentException(
+        "数字化大屏版本不存在：" + screenId + " / V" + versionNo);
+  }
+}

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V2__add_published_versions.sql
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V2__add_published_versions.sql
@@ -50,10 +50,10 @@ SELECT
 FROM yak_digital_screen
 WHERE status = 'PUBLISHED';
 
-UPDATE yak_digital_screen screen
-JOIN yak_digital_screen_version version
-  ON version.screen_id = screen.id AND version.version_no = 1
-SET screen.published_revision = screen.revision,
-    screen.published_version_id = version.id,
-    screen.published_version_no = 1
-WHERE screen.status = 'PUBLISHED';
+UPDATE yak_digital_screen s
+JOIN yak_digital_screen_version v
+  ON v.screen_id = s.id AND v.version_no = 1
+SET s.published_revision = s.revision,
+    s.published_version_id = v.id,
+    s.published_version_no = 1
+WHERE s.status = 'PUBLISHED';

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V2__add_published_versions.sql
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V2__add_published_versions.sql
@@ -1,0 +1,59 @@
+-- PR 2: split mutable Draft from immutable published snapshots.
+CREATE TABLE IF NOT EXISTS yak_digital_screen_version (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    screen_id BIGINT NOT NULL,
+    version_no INT NOT NULL,
+    source_revision BIGINT NOT NULL,
+    name_snapshot VARCHAR(200) NOT NULL,
+    description_snapshot VARCHAR(2000) NULL,
+    template_id_snapshot VARCHAR(128) NOT NULL,
+    template_version_snapshot INT NOT NULL DEFAULT 1,
+    bindings_json JSON NOT NULL,
+    published_time DATETIME(6) NOT NULL,
+    create_time DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_digital_screen_version_no (screen_id, version_no),
+    KEY idx_yak_digital_screen_version_time (screen_id, published_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE yak_digital_screen
+    ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 AFTER bindings_json,
+    ADD COLUMN published_revision BIGINT NULL AFTER revision,
+    ADD COLUMN published_version_id BIGINT NULL AFTER published_revision,
+    ADD COLUMN published_version_no INT NOT NULL DEFAULT 0 AFTER published_version_id,
+    ADD KEY idx_yak_digital_screen_published_version (published_version_id);
+
+-- Existing PR 1 rows that were already PUBLISHED become immutable V1 snapshots.
+INSERT INTO yak_digital_screen_version (
+    screen_id,
+    version_no,
+    source_revision,
+    name_snapshot,
+    description_snapshot,
+    template_id_snapshot,
+    template_version_snapshot,
+    bindings_json,
+    published_time,
+    create_time
+)
+SELECT
+    id,
+    1,
+    revision,
+    name,
+    description,
+    template_id,
+    template_version,
+    bindings_json,
+    COALESCE(published_time, update_time),
+    COALESCE(published_time, update_time)
+FROM yak_digital_screen
+WHERE status = 'PUBLISHED';
+
+UPDATE yak_digital_screen screen
+JOIN yak_digital_screen_version version
+  ON version.screen_id = screen.id AND version.version_no = 1
+SET screen.published_revision = screen.revision,
+    screen.published_version_id = version.id,
+    screen.published_version_no = 1
+WHERE screen.status = 'PUBLISHED';

--- a/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/application/DigitalScreenApplicationServiceTest.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/application/DigitalScreenApplicationServiceTest.java
@@ -1,14 +1,15 @@
 package io.yak.ops.business.digitalscreen.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
 import io.yak.ops.business.digitalscreen.domain.DigitalScreenStatus;
+import io.yak.ops.business.digitalscreen.publication.DigitalScreenPublisher;
 import io.yak.ops.business.digitalscreen.repository.DigitalScreenRepository;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenVersionRepository;
+import io.yak.ops.business.digitalscreen.version.DigitalScreenVersionReader;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -19,20 +20,26 @@ import org.mockito.MockitoAnnotations;
 
 class DigitalScreenApplicationServiceTest {
 
-  @Mock
-  private DigitalScreenRepository repository;
+  @Mock private DigitalScreenRepository repository;
+  @Mock private DigitalScreenVersionRepository versionRepository;
+  @Mock private DigitalScreenPublisher publisher;
+  @Mock private DigitalScreenVersionReader versionReader;
 
   private DigitalScreenApplicationService service;
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    service = new DigitalScreenApplicationService(repository);
+    service = new DigitalScreenApplicationService(
+        repository,
+        versionRepository,
+        publisher,
+        versionReader);
   }
 
   @Test
   void createNormalizesDefinitionAndStartsFromDraftPersistence() {
-    DigitalScreen created = screen(1L, "运营大屏", DigitalScreenStatus.DRAFT, null);
+    DigitalScreen created = screen(1L, "运营大屏", DigitalScreenStatus.DRAFT, 1L, null, 0);
     when(repository.insert("运营大屏", null, "operation-center", 1, Map.of()))
         .thenReturn(created);
 
@@ -47,26 +54,24 @@ class DigitalScreenApplicationServiceTest {
   }
 
   @Test
-  void publishAndOfflineKeepCurrentMutableLifecycleContract() {
-    DigitalScreen draft = screen(7L, "监控大屏", DigitalScreenStatus.DRAFT, null);
-    DigitalScreen published = screen(7L, "监控大屏", DigitalScreenStatus.PUBLISHED, Instant.now());
-    when(repository.findById(7L)).thenReturn(Optional.of(draft), Optional.of(published));
-    when(repository.updateStatus(eq(7L), eq(DigitalScreenStatus.PUBLISHED), any(Instant.class)))
-        .thenReturn(published);
-    when(repository.updateStatus(7L, DigitalScreenStatus.DRAFT, null)).thenReturn(draft);
-
-    assertThat(service.publish(7L).status()).isEqualTo(DigitalScreenStatus.PUBLISHED);
-    assertThat(service.offline(7L).status()).isEqualTo(DigitalScreenStatus.DRAFT);
-
-    verify(repository).updateStatus(eq(7L), eq(DigitalScreenStatus.PUBLISHED), any(Instant.class));
-    verify(repository).updateStatus(7L, DigitalScreenStatus.DRAFT, null);
-  }
-
-  @Test
-  void duplicateCopiesDefinitionThroughInsertSoRepositoryCreatesFreshDraft() {
+  void duplicateCopiesDraftButNeverPublicationHistory() {
     Map<String, Object> bindings = Map.of("metric-1", Map.of("datasetId", "12"));
-    DigitalScreen source = screen(9L, "院区运营大屏", DigitalScreenStatus.PUBLISHED, Instant.now(), bindings);
-    DigitalScreen copy = screen(10L, "院区运营大屏 - 副本", DigitalScreenStatus.DRAFT, null, bindings);
+    DigitalScreen source = screen(
+        9L,
+        "院区运营大屏",
+        DigitalScreenStatus.PUBLISHED,
+        4L,
+        3L,
+        2,
+        bindings);
+    DigitalScreen copy = screen(
+        10L,
+        "院区运营大屏 - 副本",
+        DigitalScreenStatus.DRAFT,
+        1L,
+        null,
+        0,
+        bindings);
     when(repository.findById(9L)).thenReturn(Optional.of(source));
     when(repository.insert(
         "院区运营大屏 - 副本",
@@ -78,6 +83,7 @@ class DigitalScreenApplicationServiceTest {
     DigitalScreen result = service.duplicate(9L);
 
     assertThat(result.status()).isEqualTo(DigitalScreenStatus.DRAFT);
+    assertThat(result.publishedVersionNo()).isZero();
     verify(repository).insert(
         "院区运营大屏 - 副本",
         source.description(),
@@ -86,19 +92,35 @@ class DigitalScreenApplicationServiceTest {
         source.bindings());
   }
 
-  private DigitalScreen screen(
-      long id,
-      String name,
-      DigitalScreenStatus status,
-      Instant publishedTime) {
-    return screen(id, name, status, publishedTime, Map.of());
+  @Test
+  void deleteRemovesImmutableHistoryBeforeScreenIdentity() {
+    DigitalScreen existing = screen(12L, "待删除", DigitalScreenStatus.PUBLISHED, 2L, 2L, 1);
+    when(repository.findById(12L)).thenReturn(Optional.of(existing));
+    when(repository.deleteById(12L)).thenReturn(true);
+
+    service.delete(12L);
+
+    verify(versionRepository).deleteByScreenId(12L);
+    verify(repository).deleteById(12L);
   }
 
   private DigitalScreen screen(
       long id,
       String name,
       DigitalScreenStatus status,
-      Instant publishedTime,
+      long revision,
+      Long publishedRevision,
+      int publishedVersionNo) {
+    return screen(id, name, status, revision, publishedRevision, publishedVersionNo, Map.of());
+  }
+
+  private DigitalScreen screen(
+      long id,
+      String name,
+      DigitalScreenStatus status,
+      long revision,
+      Long publishedRevision,
+      int publishedVersionNo,
       Map<String, Object> bindings) {
     Instant now = Instant.parse("2026-08-27T00:00:00Z");
     return new DigitalScreen(
@@ -109,7 +131,11 @@ class DigitalScreenApplicationServiceTest {
         1,
         status,
         bindings,
-        publishedTime,
+        revision,
+        publishedRevision,
+        publishedVersionNo > 0 ? 100L + publishedVersionNo : null,
+        publishedVersionNo,
+        publishedVersionNo > 0 ? now : null,
         now,
         now);
   }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenControllerContractTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -17,12 +18,28 @@ class DigitalScreenControllerContractTest {
   }
 
   @Test
-  void publishAndOfflineRoutesRemainExplicitLifecycleActions() throws Exception {
+  void viewerAndVersionHistoryUseExplicitPublishedSnapshotRoutes() throws Exception {
+    Method published = DigitalScreenController.class.getMethod("published", long.class);
+    Method versions = DigitalScreenController.class.getMethod("versions", long.class);
+    Method version = DigitalScreenController.class.getMethod("version", long.class, int.class);
+    assertThat(published.getAnnotation(GetMapping.class).value())
+        .containsExactly("/{screenId}/published");
+    assertThat(versions.getAnnotation(GetMapping.class).value())
+        .containsExactly("/{screenId}/versions");
+    assertThat(version.getAnnotation(GetMapping.class).value())
+        .containsExactly("/{screenId}/versions/{versionNo}");
+  }
+
+  @Test
+  void publishOfflineAndRollbackRemainExplicitLifecycleActions() throws Exception {
     Method publish = DigitalScreenController.class.getMethod("publish", long.class);
     Method offline = DigitalScreenController.class.getMethod("offline", long.class);
+    Method rollback = DigitalScreenController.class.getMethod("rollback", long.class, int.class);
     assertThat(publish.getAnnotation(PostMapping.class).value())
         .containsExactly("/{screenId}/publish");
     assertThat(offline.getAnnotation(PostMapping.class).value())
         .containsExactly("/{screenId}/offline");
+    assertThat(rollback.getAnnotation(PostMapping.class).value())
+        .containsExactly("/{screenId}/versions/{versionNo}/rollback");
   }
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/publication/DigitalScreenPublisherTest.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/publication/DigitalScreenPublisherTest.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.digitalscreen.publication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -58,7 +59,7 @@ class DigitalScreenPublisherTest {
     assertThat(publisher.publish(7L)).isSameAs(current);
 
     verify(versions, never()).nextVersionNo(7L);
-    verify(versions, never()).insert(any(), eq(4), any());
+    verify(versions, never()).insert(any(), anyInt(), any());
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/publication/DigitalScreenPublisherTest.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/publication/DigitalScreenPublisherTest.java
@@ -1,0 +1,135 @@
+package io.yak.ops.business.digitalscreen.publication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenStatus;
+import io.yak.ops.business.digitalscreen.domain.DigitalScreenVersion;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenRepository;
+import io.yak.ops.business.digitalscreen.repository.DigitalScreenVersionRepository;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class DigitalScreenPublisherTest {
+
+  @Mock private DigitalScreenRepository screens;
+  @Mock private DigitalScreenVersionRepository versions;
+
+  private DigitalScreenPublisher publisher;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    publisher = new DigitalScreenPublisher(screens, versions);
+  }
+
+  @Test
+  void publishAppendsImmutableSnapshotAndMovesPublishedPointer() {
+    DigitalScreen draft = screen(DigitalScreenStatus.DRAFT, 3L, null, 0, Map.of());
+    DigitalScreenVersion version = version(8L, 2, 3L, Map.of());
+    DigitalScreen published = screen(DigitalScreenStatus.PUBLISHED, 3L, 3L, 2, Map.of());
+    when(screens.lockById(7L)).thenReturn(draft);
+    when(versions.nextVersionNo(7L)).thenReturn(2);
+    when(versions.insert(eq(draft), eq(2), any(Instant.class))).thenReturn(version);
+    when(screens.markPublished(eq(7L), eq(8L), eq(2), eq(3L), any(Instant.class)))
+        .thenReturn(published);
+
+    DigitalScreen result = publisher.publish(7L);
+
+    assertThat(result.publishedVersionNo()).isEqualTo(2);
+    verify(versions).insert(eq(draft), eq(2), any(Instant.class));
+  }
+
+  @Test
+  void publishIsNoopWhenPublishedRevisionAlreadyMatchesDraft() {
+    DigitalScreen current = screen(DigitalScreenStatus.PUBLISHED, 5L, 5L, 3, Map.of());
+    when(screens.lockById(7L)).thenReturn(current);
+
+    assertThat(publisher.publish(7L)).isSameAs(current);
+
+    verify(versions, never()).nextVersionNo(7L);
+    verify(versions, never()).insert(any(), eq(4), any());
+  }
+
+  @Test
+  void rollbackRestoresSnapshotThenPublishesAsNewAppendOnlyVersion() {
+    Map<String, Object> oldBindings = Map.of("chart", Map.of("datasetId", "11"));
+    DigitalScreen current = screen(DigitalScreenStatus.PUBLISHED, 9L, 8L, 3, Map.of());
+    DigitalScreenVersion target = version(20L, 1, 2L, oldBindings);
+    DigitalScreen restored = screen(DigitalScreenStatus.PUBLISHED, 10L, 8L, 3, oldBindings);
+    DigitalScreenVersion rollbackVersion = version(23L, 4, 10L, oldBindings);
+    DigitalScreen published = screen(DigitalScreenStatus.PUBLISHED, 10L, 10L, 4, oldBindings);
+    when(screens.lockById(7L)).thenReturn(current);
+    when(versions.findByVersionNo(7L, 1)).thenReturn(Optional.of(target));
+    when(screens.restoreDraft(
+        7L,
+        target.name(),
+        target.description(),
+        target.templateId(),
+        target.templateVersion(),
+        target.bindings())).thenReturn(restored);
+    when(versions.nextVersionNo(7L)).thenReturn(4);
+    when(versions.insert(eq(restored), eq(4), any(Instant.class))).thenReturn(rollbackVersion);
+    when(screens.markPublished(eq(7L), eq(23L), eq(4), eq(10L), any(Instant.class)))
+        .thenReturn(published);
+
+    DigitalScreen result = publisher.rollback(7L, 1);
+
+    assertThat(result.publishedVersionNo()).isEqualTo(4);
+    assertThat(result.publishedRevision()).isEqualTo(10L);
+  }
+
+  private DigitalScreen screen(
+      DigitalScreenStatus status,
+      long revision,
+      Long publishedRevision,
+      int publishedVersionNo,
+      Map<String, Object> bindings) {
+    Instant now = Instant.parse("2026-08-27T00:00:00Z");
+    return new DigitalScreen(
+        7L,
+        "运营大屏",
+        "大屏说明",
+        "operation-center",
+        1,
+        status,
+        bindings,
+        revision,
+        publishedRevision,
+        publishedVersionNo > 0 ? 100L + publishedVersionNo : null,
+        publishedVersionNo,
+        publishedVersionNo > 0 ? now : null,
+        now,
+        now);
+  }
+
+  private DigitalScreenVersion version(
+      long id,
+      int versionNo,
+      long sourceRevision,
+      Map<String, Object> bindings) {
+    Instant now = Instant.parse("2026-08-27T00:00:00Z");
+    return new DigitalScreenVersion(
+        id,
+        7L,
+        versionNo,
+        sourceRevision,
+        "运营大屏",
+        "大屏说明",
+        "operation-center",
+        1,
+        bindings,
+        now,
+        now);
+  }
+}

--- a/yak-ops-ui/src/pages/digital-screen/editor/components/DigitalScreenEditorView.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/editor/components/DigitalScreenEditorView.tsx
@@ -10,10 +10,12 @@ import type {
   DigitalScreenBindings,
   DigitalScreenComponentBinding,
   DigitalScreenInstance,
+  DigitalScreenVersionSummary,
 } from '@/services/digital-screen';
-import { Input } from 'antd';
-import { ArrowLeft, Database, Eye, Save, Send } from 'lucide-react';
+import { Input, Popconfirm } from 'antd';
+import { ArrowLeft, CloudOff, Database, Eye, History, Save, Send } from 'lucide-react';
 import { DataBindingPanel } from './DataBindingPanel';
+import { VersionHistoryDrawer } from './VersionHistoryDrawer';
 
 interface ScreenRuntimeViewModel {
   data: ScreenDataOverrides;
@@ -31,9 +33,15 @@ interface DigitalScreenEditorViewProps {
   selectedComponentId?: string;
   datasets: PublishedDataset[];
   datasetsError: string;
+  versions: DigitalScreenVersionSummary[];
   isDatasetsLoading: boolean;
+  isVersionsLoading: boolean;
+  isVersionsOpen: boolean;
   isSaving: boolean;
   isPublishing: boolean;
+  isOfflining: boolean;
+  rollingBackVersionNo?: number;
+  isDirty: boolean;
   template?: ScreenTemplate;
   selectedComponent?: ScreenComponent;
   runtime: ScreenRuntimeViewModel;
@@ -46,7 +54,11 @@ interface DigitalScreenEditorViewProps {
   onDescriptionChange: (description: string) => void;
   onComponentSelect: (componentId: string) => void;
   onSave: () => void;
-  onTogglePublish: () => void;
+  onPublish: () => void;
+  onOffline: () => void;
+  onOpenVersions: () => void;
+  onCloseVersions: () => void;
+  onRollbackVersion: (versionNo: number) => void;
   onBindingChange: (binding?: DigitalScreenComponentBinding) => void;
 }
 
@@ -58,9 +70,15 @@ export function DigitalScreenEditorView({
   selectedComponentId,
   datasets,
   datasetsError,
+  versions,
   isDatasetsLoading,
+  isVersionsLoading,
+  isVersionsOpen,
   isSaving,
   isPublishing,
+  isOfflining,
+  rollingBackVersionNo,
+  isDirty,
   template,
   selectedComponent,
   runtime,
@@ -73,9 +91,20 @@ export function DigitalScreenEditorView({
   onDescriptionChange,
   onComponentSelect,
   onSave,
-  onTogglePublish,
+  onPublish,
+  onOffline,
+  onOpenVersions,
+  onCloseVersions,
+  onRollbackVersion,
   onBindingChange,
 }: DigitalScreenEditorViewProps) {
+  const hasSavedUnpublishedChanges = Boolean(screen.hasUnpublishedChanges);
+  const hasPendingPublish = isDirty || hasSavedUnpublishedChanges;
+  const isPublished = screen.status === 'published';
+  const statusLabel = isPublished
+    ? `${screen.publishedVersionNo ? `已发布 V${screen.publishedVersionNo}` : '已发布'}${hasPendingPublish ? ' · 有未发布更改' : ''}`
+    : '草稿';
+
   return (
     <div className="flex h-screen min-w-[1180px] flex-col overflow-hidden bg-[#f4f5f6] text-[#161823]">
       <header className="flex h-14 shrink-0 items-center justify-between border-b border-[#e5e7ea] bg-white px-4">
@@ -91,11 +120,13 @@ export function DigitalScreenEditorView({
           />
           <span className={[
             'ml-1 rounded-[4px] px-2 py-1 text-[11px] font-medium',
-            screen.status === 'published'
-              ? 'bg-[#edf8f2] text-[#27845a]'
+            isPublished
+              ? hasPendingPublish
+                ? 'bg-[#fff7e8] text-[#ad6800]'
+                : 'bg-[#edf8f2] text-[#27845a]'
               : 'bg-[#f2f3f4] text-[#7b818a]',
           ].join(' ')}>
-            {screen.status === 'published' ? '已发布' : '草稿'}
+            {statusLabel}
           </span>
           <span className="ml-1 text-[11px] text-[#98a2b3]">
             已绑定 {runtime.boundCount}/{bindableCount}
@@ -106,15 +137,34 @@ export function DigitalScreenEditorView({
         </div>
 
         <div className="flex items-center gap-2">
-          <YakButton icon={<Eye size={14} />} onClick={onPreview}>预览</YakButton>
-          <YakButton icon={<Save size={14} />} loading={isSaving} onClick={onSave}>保存</YakButton>
+          <YakButton icon={<History size={14} />} onClick={onOpenVersions}>版本历史</YakButton>
           <YakButton
-            type={screen.status === 'published' ? 'default' : 'primary'}
+            icon={<Eye size={14} />}
+            disabled={!isPublished}
+            onClick={onPreview}
+          >
+            线上预览
+          </YakButton>
+          <YakButton icon={<Save size={14} />} loading={isSaving} onClick={onSave}>保存</YakButton>
+          {isPublished ? (
+            <Popconfirm
+              title="确认取消发布？"
+              description="线上大屏会停止访问，但发布历史会继续保留。"
+              okText="取消发布"
+              cancelText="返回"
+              onConfirm={onOffline}
+            >
+              <YakButton icon={<CloudOff size={14} />} loading={isOfflining}>取消发布</YakButton>
+            </Popconfirm>
+          ) : null}
+          <YakButton
+            type="primary"
             icon={<Send size={14} />}
             loading={isPublishing}
-            onClick={onTogglePublish}
+            disabled={isPublished && !hasPendingPublish}
+            onClick={onPublish}
           >
-            {screen.status === 'published' ? '取消发布' : '发布'}
+            {isPublished ? '更新发布' : '发布'}
           </YakButton>
         </div>
       </header>
@@ -175,7 +225,7 @@ export function DigitalScreenEditorView({
               </div>
             </div>
             <div className="mt-2 text-[11px] leading-[18px] text-[#a3a8b0]">
-              布局由模板固定。点击左侧组件后，只配置它消费的数据，不修改模板设计。
+              布局由模板固定。编辑内容只写入 Draft，只有点击发布后才会生成新的线上快照。
             </div>
           </section>
 
@@ -201,6 +251,15 @@ export function DigitalScreenEditorView({
           </section>
         </aside>
       </div>
+
+      <VersionHistoryDrawer
+        open={isVersionsOpen}
+        versions={versions}
+        loading={isVersionsLoading}
+        rollingBackVersionNo={rollingBackVersionNo}
+        onClose={onCloseVersions}
+        onRollback={onRollbackVersion}
+      />
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/digital-screen/editor/components/VersionHistoryDrawer.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/editor/components/VersionHistoryDrawer.tsx
@@ -1,0 +1,83 @@
+import { YakButton } from '@/components/ui';
+import type { DigitalScreenVersionSummary } from '@/services/digital-screen';
+import { Drawer, Empty, Popconfirm, Spin } from 'antd';
+import { CheckCircle2, History, RotateCcw } from 'lucide-react';
+
+interface VersionHistoryDrawerProps {
+  open: boolean;
+  versions: DigitalScreenVersionSummary[];
+  loading: boolean;
+  rollingBackVersionNo?: number;
+  onClose: () => void;
+  onRollback: (versionNo: number) => void;
+}
+
+const formatDateTime = (value: string) => value.replace('T', ' ').slice(0, 19);
+
+export function VersionHistoryDrawer({
+  open,
+  versions,
+  loading,
+  rollingBackVersionNo,
+  onClose,
+  onRollback,
+}: VersionHistoryDrawerProps) {
+  return (
+    <Drawer
+      title={(
+        <div className="flex items-center gap-2 text-[14px] font-semibold text-[#161823]">
+          <History size={15} /> 发布版本
+        </div>
+      )}
+      width={420}
+      open={open}
+      onClose={onClose}
+    >
+      {loading ? (
+        <div className="flex h-[240px] items-center justify-center"><Spin size="small" /></div>
+      ) : versions.length ? (
+        <div className="space-y-3">
+          {versions.map((version) => (
+            <div key={version.id} className="rounded-[8px] border border-[#e7e9ec] p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[13px] font-semibold text-[#161823]">V{version.versionNo}</span>
+                    {version.current ? (
+                      <span className="inline-flex items-center gap-1 rounded-[4px] bg-[#edf8f2] px-1.5 py-0.5 text-[10px] font-medium text-[#27845a]">
+                        <CheckCircle2 size={10} /> 当前线上
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-1 truncate text-[12px] text-[#555b64]">{version.name}</div>
+                  <div className="mt-2 text-[10px] leading-5 text-[#98a2b3]">
+                    发布于 {formatDateTime(version.publishedAt)} · Draft R{version.sourceRevision}
+                  </div>
+                </div>
+                <Popconfirm
+                  title={`回滚到 V${version.versionNo}？`}
+                  description="会覆盖当前草稿，并把该快照追加发布为一个新的版本。"
+                  okText="回滚并发布"
+                  cancelText="取消"
+                  disabled={version.current}
+                  onConfirm={() => onRollback(version.versionNo)}
+                >
+                  <YakButton
+                    size="small"
+                    icon={<RotateCcw size={12} />}
+                    disabled={version.current}
+                    loading={rollingBackVersionNo === version.versionNo}
+                  >
+                    回滚
+                  </YakButton>
+                </Popconfirm>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="还没有发布版本" />
+      )}
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/pages/digital-screen/editor/hooks/useDigitalScreenEditor.ts
+++ b/yak-ops-ui/src/pages/digital-screen/editor/hooks/useDigitalScreenEditor.ts
@@ -2,17 +2,24 @@ import type { PublishedDataset } from '@/services/dataset';
 import { listPublishedDatasets } from '@/services/dataset';
 import {
   getDigitalScreen,
+  listDigitalScreenVersions,
   publishDigitalScreen,
+  rollbackDigitalScreen,
   unpublishDigitalScreen,
   updateDigitalScreen,
   type DigitalScreenBindings,
   type DigitalScreenComponentBinding,
   type DigitalScreenInstance,
+  type DigitalScreenVersionSummary,
 } from '@/services/digital-screen';
 import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import { message } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useScreenRuntimeData } from '../../runtime/hooks/useScreenRuntimeData';
+
+const sameBindings = (left: DigitalScreenBindings, right: DigitalScreenBindings) => (
+  JSON.stringify(left) === JSON.stringify(right)
+);
 
 export function useDigitalScreenEditor(id?: string) {
   const [screen, setScreen] = useState<DigitalScreenInstance>();
@@ -21,11 +28,16 @@ export function useDigitalScreenEditor(id?: string) {
   const [bindings, setBindings] = useState<DigitalScreenBindings>({});
   const [selectedComponentId, setSelectedComponentId] = useState<string>();
   const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
-  const [isDatasetsLoading, setIsDatasetsLoading] = useState(true);
   const [datasetsError, setDatasetsError] = useState('');
+  const [versions, setVersions] = useState<DigitalScreenVersionSummary[]>([]);
+  const [isDatasetsLoading, setIsDatasetsLoading] = useState(true);
+  const [isVersionsLoading, setIsVersionsLoading] = useState(false);
+  const [isVersionsOpen, setIsVersionsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
+  const [isOfflining, setIsOfflining] = useState(false);
+  const [rollingBackVersionNo, setRollingBackVersionNo] = useState<number>();
 
   const template = useMemo(
     () => (screen ? resolveScreenTemplateById(screen.templateId) : undefined),
@@ -36,6 +48,19 @@ export function useDigitalScreenEditor(id?: string) {
     [template, selectedComponentId],
   );
   const runtime = useScreenRuntimeData(template, bindings, datasets);
+  const isDirty = useMemo(() => {
+    if (!screen) return false;
+    return name.trim() !== screen.name
+      || (description.trim() || '') !== (screen.description || '')
+      || !sameBindings(bindings, screen.bindings || {});
+  }, [bindings, description, name, screen]);
+
+  const applyScreen = useCallback((detail: DigitalScreenInstance) => {
+    setScreen(detail);
+    setName(detail.name);
+    setDescription(detail.description || '');
+    setBindings(detail.bindings || {});
+  }, []);
 
   const loadScreen = useCallback(async () => {
     if (!id) {
@@ -44,15 +69,24 @@ export function useDigitalScreenEditor(id?: string) {
     }
     setIsLoading(true);
     try {
-      const detail = await getDigitalScreen(id);
-      setScreen(detail);
-      setName(detail.name);
-      setDescription(detail.description || '');
-      setBindings(detail.bindings || {});
+      applyScreen(await getDigitalScreen(id));
     } catch (error) {
       message.error(error instanceof Error ? error.message : '加载数字化大屏失败');
     } finally {
       setIsLoading(false);
+    }
+  }, [applyScreen, id]);
+
+  const loadVersions = useCallback(async () => {
+    if (!id) return;
+    setIsVersionsLoading(true);
+    try {
+      setVersions(await listDigitalScreenVersions(id));
+    } catch (error) {
+      setVersions([]);
+      message.error(error instanceof Error ? error.message : '加载发布版本失败');
+    } finally {
+      setIsVersionsLoading(false);
     }
   }, [id]);
 
@@ -90,18 +124,21 @@ export function useDigitalScreenEditor(id?: string) {
   }, [template, selectedComponentId]);
 
   const saveScreen = async (showSuccessMessage = true) => {
-    if (!id) return undefined;
+    if (!id || !screen) return undefined;
     if (!name.trim()) {
       message.warning('请输入大屏名称');
       return undefined;
+    }
+    if (!isDirty) {
+      if (showSuccessMessage) message.info('当前草稿已是最新');
+      return screen;
     }
 
     setIsSaving(true);
     try {
       const updated = await updateDigitalScreen(id, { name, description, bindings });
-      setScreen(updated);
-      setBindings(updated.bindings);
-      if (showSuccessMessage) message.success('大屏已保存');
+      applyScreen(updated);
+      if (showSuccessMessage) message.success('草稿已保存');
       return updated;
     } catch (error) {
       message.error(error instanceof Error ? error.message : '保存数字化大屏失败');
@@ -111,21 +148,55 @@ export function useDigitalScreenEditor(id?: string) {
     }
   };
 
-  const togglePublish = async () => {
+  const publishScreen = async () => {
     if (!id || !screen) return;
     setIsPublishing(true);
     try {
       const saved = await saveScreen(false);
       if (!saved) return;
-      const updated = saved.status === 'published'
-        ? await unpublishDigitalScreen(id)
-        : await publishDigitalScreen(id);
-      setScreen(updated);
-      message.success(updated.status === 'published' ? '大屏已发布' : '大屏已取消发布');
+      const updated = await publishDigitalScreen(id);
+      applyScreen(updated);
+      message.success(`大屏已发布${updated.publishedVersionNo ? ` · V${updated.publishedVersionNo}` : ''}`);
+      if (isVersionsOpen) void loadVersions();
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '更新发布状态失败');
+      message.error(error instanceof Error ? error.message : '发布数字化大屏失败');
     } finally {
       setIsPublishing(false);
+    }
+  };
+
+  const offlineScreen = async () => {
+    if (!id || !screen || screen.status !== 'published') return;
+    setIsOfflining(true);
+    try {
+      const updated = await unpublishDigitalScreen(id);
+      applyScreen(updated);
+      message.success('大屏已取消发布，历史版本已保留');
+      if (isVersionsOpen) void loadVersions();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '取消发布失败');
+    } finally {
+      setIsOfflining(false);
+    }
+  };
+
+  const openVersions = () => {
+    setIsVersionsOpen(true);
+    void loadVersions();
+  };
+
+  const rollbackVersion = async (versionNo: number) => {
+    if (!id) return;
+    setRollingBackVersionNo(versionNo);
+    try {
+      const updated = await rollbackDigitalScreen(id, versionNo);
+      applyScreen(updated);
+      message.success(`已回滚 V${versionNo}，并追加发布为 V${updated.publishedVersionNo}`);
+      await loadVersions();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '回滚发布版本失败');
+    } finally {
+      setRollingBackVersionNo(undefined);
     }
   };
 
@@ -155,10 +226,16 @@ export function useDigitalScreenEditor(id?: string) {
     selectedComponentId,
     datasets,
     datasetsError,
+    versions,
     isDatasetsLoading,
+    isVersionsLoading,
+    isVersionsOpen,
     isLoading,
     isSaving,
     isPublishing,
+    isOfflining,
+    rollingBackVersionNo,
+    isDirty,
     template,
     selectedComponent,
     runtime,
@@ -168,8 +245,12 @@ export function useDigitalScreenEditor(id?: string) {
     setName,
     setDescription,
     setSelectedComponentId,
+    setIsVersionsOpen,
     saveScreen,
-    togglePublish,
+    publishScreen,
+    offlineScreen,
+    openVersions,
+    rollbackVersion,
     updateSelectedBinding,
   };
 }

--- a/yak-ops-ui/src/pages/digital-screen/editor/index.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/editor/index.tsx
@@ -33,9 +33,15 @@ export default function DigitalScreenEditorPage() {
       selectedComponentId={editor.selectedComponentId}
       datasets={editor.datasets}
       datasetsError={editor.datasetsError}
+      versions={editor.versions}
       isDatasetsLoading={editor.isDatasetsLoading}
+      isVersionsLoading={editor.isVersionsLoading}
+      isVersionsOpen={editor.isVersionsOpen}
       isSaving={editor.isSaving}
       isPublishing={editor.isPublishing}
+      isOfflining={editor.isOfflining}
+      rollingBackVersionNo={editor.rollingBackVersionNo}
+      isDirty={editor.isDirty}
       template={editor.template}
       selectedComponent={editor.selectedComponent}
       runtime={editor.runtime}
@@ -48,7 +54,11 @@ export default function DigitalScreenEditorPage() {
       onDescriptionChange={editor.setDescription}
       onComponentSelect={editor.setSelectedComponentId}
       onSave={() => void editor.saveScreen()}
-      onTogglePublish={() => void editor.togglePublish()}
+      onPublish={() => void editor.publishScreen()}
+      onOffline={() => void editor.offlineScreen()}
+      onOpenVersions={editor.openVersions}
+      onCloseVersions={() => editor.setIsVersionsOpen(false)}
+      onRollbackVersion={(versionNo) => void editor.rollbackVersion(versionNo)}
       onBindingChange={editor.updateSelectedBinding}
     />
   );

--- a/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
+++ b/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
@@ -1,12 +1,11 @@
 import type { PublishedDataset } from '@/services/dataset';
 import { listPublishedDatasets } from '@/services/dataset';
 import {
-  getDigitalScreen,
+  getPublishedDigitalScreen,
   type DigitalScreenBindings,
   type DigitalScreenInstance,
 } from '@/services/digital-screen';
 import { resolveScreenTemplateById } from '@/services/screen-template-service';
-import { message } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { useScreenRuntimeData } from '../../runtime/hooks/useScreenRuntimeData';
 
@@ -15,6 +14,7 @@ const EMPTY_BINDINGS: DigitalScreenBindings = {};
 export function useDigitalScreenViewer(id?: string) {
   const [screen, setScreen] = useState<DigitalScreenInstance>();
   const [datasets, setDatasets] = useState<PublishedDataset[]>([]);
+  const [loadError, setLoadError] = useState('');
   const [dataError, setDataError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
 
@@ -24,9 +24,13 @@ export function useDigitalScreenViewer(id?: string) {
       return;
     }
     setIsLoading(true);
-    void getDigitalScreen(id)
+    setLoadError('');
+    void getPublishedDigitalScreen(id)
       .then(setScreen)
-      .catch((error) => message.error(error instanceof Error ? error.message : '加载数字化大屏失败'))
+      .catch((error) => {
+        setScreen(undefined);
+        setLoadError(error instanceof Error ? error.message : '加载已发布大屏失败');
+      })
       .finally(() => setIsLoading(false));
   }, [id]);
 
@@ -57,6 +61,7 @@ export function useDigitalScreenViewer(id?: string) {
     screen,
     template,
     runtime,
+    loadError,
     dataError,
     isLoading,
   };

--- a/yak-ops-ui/src/pages/digital-screen/viewer/index.tsx
+++ b/yak-ops-ui/src/pages/digital-screen/viewer/index.tsx
@@ -6,7 +6,7 @@ import { useDigitalScreenViewer } from './hooks/useDigitalScreenViewer';
 
 export default function DigitalScreenViewerPage() {
   const { id } = useParams<{ id: string }>();
-  const { screen, template, runtime, dataError, isLoading } = useDigitalScreenViewer(id);
+  const { screen, template, runtime, loadError, dataError, isLoading } = useDigitalScreenViewer(id);
 
   if (isLoading) {
     return (
@@ -19,7 +19,7 @@ export default function DigitalScreenViewerPage() {
   if (!screen || !template) {
     return (
       <div className="flex h-screen flex-col items-center justify-center bg-[#070b13] text-white/70">
-        <div className="text-[14px]">数字化大屏或模板不存在</div>
+        <div className="text-[14px]">{loadError || '数字化大屏尚未发布或模板不存在'}</div>
         <YakButton type="link" onClick={() => history.push('/digital-screen')}>返回大屏列表</YakButton>
       </div>
     );
@@ -67,7 +67,7 @@ export default function DigitalScreenViewerPage() {
       ) : null}
 
       <div className="absolute bottom-3 right-4 rounded-[4px] bg-black/35 px-2 py-1 text-[10px] text-white/35 opacity-0 transition-opacity group-hover:opacity-100">
-        {screen.name}
+        {screen.name} · V{screen.publishedVersionNo}
       </div>
     </div>
   );

--- a/yak-ops-ui/src/services/digital-screen/api.ts
+++ b/yak-ops-ui/src/services/digital-screen/api.ts
@@ -1,12 +1,21 @@
 import { httpScreenRepository } from './repository';
-import type { ScreenRepository } from './repository';
+import type { ScreenPublicationRepository, ScreenRepository } from './repository';
 import type { CreateDigitalScreenInput, UpdateDigitalScreenInput } from './types';
 
 /** Stable application-facing façade backed by the server-side Digital Screen repository. */
 export const screenRepository: ScreenRepository = httpScreenRepository;
+export const screenPublicationRepository: ScreenPublicationRepository = httpScreenRepository;
 
 export const listDigitalScreens = () => screenRepository.list();
 export const getDigitalScreen = (id: string) => screenRepository.get(id);
+export const getPublishedDigitalScreen = (id: string) => screenPublicationRepository.getPublished(id);
+export const listDigitalScreenVersions = (id: string) => screenPublicationRepository.listVersions(id);
+export const getDigitalScreenVersion = (id: string, versionNo: number) => (
+  screenPublicationRepository.getVersion(id, versionNo)
+);
+export const rollbackDigitalScreen = (id: string, versionNo: number) => (
+  screenPublicationRepository.rollback(id, versionNo)
+);
 export const createDigitalScreen = (input: CreateDigitalScreenInput) => screenRepository.create(input);
 export const updateDigitalScreen = (id: string, input: UpdateDigitalScreenInput) => screenRepository.update(id, input);
 export const publishDigitalScreen = (id: string) => screenRepository.publish(id);

--- a/yak-ops-ui/src/services/digital-screen/repository/http-screen-repository.ts
+++ b/yak-ops-ui/src/services/digital-screen/repository/http-screen-repository.ts
@@ -5,8 +5,11 @@ import type {
   DigitalScreenBindings,
   DigitalScreenInstance,
   DigitalScreenStatus,
+  DigitalScreenVersion,
+  DigitalScreenVersionSummary,
   UpdateDigitalScreenInput,
 } from '../types';
+import type { ScreenPublicationRepository } from './screen-publication-repository';
 import type { ScreenRepository } from './screen-repository';
 
 const DIGITAL_SCREEN_API = '/api/v1/digital-screens';
@@ -19,9 +22,36 @@ interface DigitalScreenWire {
   templateVersion: 1;
   status: DigitalScreenStatus;
   bindings?: DigitalScreenBindings | null;
+  revision: number;
+  publishedRevision?: number | null;
+  publishedVersionNo?: number | null;
+  hasUnpublishedChanges: boolean;
   publishedTime?: string | null;
   createTime: string;
   updateTime: string;
+}
+
+interface DigitalScreenVersionSummaryWire {
+  id: string;
+  versionNo: number;
+  sourceRevision: number;
+  name: string;
+  publishedTime: string;
+  current: boolean;
+}
+
+interface DigitalScreenVersionWire {
+  id: string;
+  screenId: string;
+  versionNo: number;
+  sourceRevision: number;
+  name: string;
+  description?: string | null;
+  templateId: string;
+  templateVersion: 1;
+  bindings?: DigitalScreenBindings | null;
+  publishedTime: string;
+  createTime: string;
 }
 
 const toInstance = (wire: DigitalScreenWire): DigitalScreenInstance => ({
@@ -32,12 +62,47 @@ const toInstance = (wire: DigitalScreenWire): DigitalScreenInstance => ({
   templateVersion: wire.templateVersion,
   status: wire.status,
   bindings: wire.bindings ?? {},
+  revision: wire.revision,
+  publishedRevision: wire.publishedRevision ?? undefined,
+  publishedVersionNo: wire.publishedVersionNo ?? undefined,
+  hasUnpublishedChanges: wire.hasUnpublishedChanges,
   publishedAt: wire.publishedTime || undefined,
   createdAt: wire.createTime,
   updatedAt: wire.updateTime,
 });
 
-class HttpScreenRepository implements ScreenRepository {
+const toVersion = (wire: DigitalScreenVersionWire): DigitalScreenVersion => ({
+  id: String(wire.id),
+  screenId: String(wire.screenId),
+  versionNo: wire.versionNo,
+  sourceRevision: wire.sourceRevision,
+  name: wire.name,
+  description: wire.description || undefined,
+  templateId: wire.templateId,
+  templateVersion: wire.templateVersion,
+  bindings: wire.bindings ?? {},
+  publishedAt: wire.publishedTime,
+  createdAt: wire.createTime,
+});
+
+const toPublishedInstance = (wire: DigitalScreenVersionWire): DigitalScreenInstance => ({
+  id: String(wire.screenId),
+  name: wire.name,
+  description: wire.description || undefined,
+  templateId: wire.templateId,
+  templateVersion: wire.templateVersion,
+  status: 'published',
+  bindings: wire.bindings ?? {},
+  revision: wire.sourceRevision,
+  publishedRevision: wire.sourceRevision,
+  publishedVersionNo: wire.versionNo,
+  hasUnpublishedChanges: false,
+  publishedAt: wire.publishedTime,
+  createdAt: wire.createTime,
+  updatedAt: wire.publishedTime,
+});
+
+class HttpScreenRepository implements ScreenRepository, ScreenPublicationRepository {
   async list() {
     const values = await HttpUtils.getData<DigitalScreenWire[]>(DIGITAL_SCREEN_API);
     return (values || []).map(toInstance);
@@ -45,6 +110,32 @@ class HttpScreenRepository implements ScreenRepository {
 
   async get(id: string) {
     return toInstance(await HttpUtils.getData<DigitalScreenWire>(`${DIGITAL_SCREEN_API}/${id}`));
+  }
+
+  async getPublished(id: string) {
+    return toPublishedInstance(await HttpUtils.getData<DigitalScreenVersionWire>(
+      `${DIGITAL_SCREEN_API}/${id}/published`,
+    ));
+  }
+
+  async listVersions(id: string) {
+    const values = await HttpUtils.getData<DigitalScreenVersionSummaryWire[]>(
+      `${DIGITAL_SCREEN_API}/${id}/versions`,
+    );
+    return (values || []).map((wire): DigitalScreenVersionSummary => ({
+      id: String(wire.id),
+      versionNo: wire.versionNo,
+      sourceRevision: wire.sourceRevision,
+      name: wire.name,
+      publishedAt: wire.publishedTime,
+      current: wire.current,
+    }));
+  }
+
+  async getVersion(id: string, versionNo: number) {
+    return toVersion(await HttpUtils.getData<DigitalScreenVersionWire>(
+      `${DIGITAL_SCREEN_API}/${id}/versions/${versionNo}`,
+    ));
   }
 
   async create(input: CreateDigitalScreenInput) {
@@ -88,6 +179,12 @@ class HttpScreenRepository implements ScreenRepository {
     ));
   }
 
+  async rollback(id: string, versionNo: number) {
+    return toInstance(await HttpUtils.postData<DigitalScreenWire>(
+      `${DIGITAL_SCREEN_API}/${id}/versions/${versionNo}/rollback`,
+    ));
+  }
+
   async duplicate(id: string) {
     return toInstance(await HttpUtils.postData<DigitalScreenWire>(
       `${DIGITAL_SCREEN_API}/${id}/duplicate`,
@@ -99,4 +196,4 @@ class HttpScreenRepository implements ScreenRepository {
   }
 }
 
-export const httpScreenRepository: ScreenRepository = new HttpScreenRepository();
+export const httpScreenRepository: ScreenRepository & ScreenPublicationRepository = new HttpScreenRepository();

--- a/yak-ops-ui/src/services/digital-screen/repository/index.ts
+++ b/yak-ops-ui/src/services/digital-screen/repository/index.ts
@@ -1,3 +1,4 @@
 export { httpScreenRepository } from './http-screen-repository';
 export { localScreenRepository } from './local-screen-repository';
+export type { ScreenPublicationRepository } from './screen-publication-repository';
 export type { ScreenRepository } from './screen-repository';

--- a/yak-ops-ui/src/services/digital-screen/repository/screen-publication-repository.ts
+++ b/yak-ops-ui/src/services/digital-screen/repository/screen-publication-repository.ts
@@ -1,0 +1,13 @@
+import type {
+  DigitalScreenInstance,
+  DigitalScreenVersion,
+  DigitalScreenVersionSummary,
+} from '../types';
+
+/** Read/history port for immutable Digital Screen publication snapshots. */
+export interface ScreenPublicationRepository {
+  getPublished(id: string): Promise<DigitalScreenInstance>;
+  listVersions(id: string): Promise<DigitalScreenVersionSummary[]>;
+  getVersion(id: string, versionNo: number): Promise<DigitalScreenVersion>;
+  rollback(id: string, versionNo: number): Promise<DigitalScreenInstance>;
+}

--- a/yak-ops-ui/src/services/digital-screen/types.ts
+++ b/yak-ops-ui/src/services/digital-screen/types.ts
@@ -23,9 +23,37 @@ export interface DigitalScreenInstance {
   templateVersion: 1;
   status: DigitalScreenStatus;
   bindings: DigitalScreenBindings;
+  /** Mutable Draft revision. Local repository compatibility keeps this optional. */
+  revision?: number;
+  publishedRevision?: number;
+  publishedVersionNo?: number;
+  hasUnpublishedChanges?: boolean;
   createdAt: string;
   updatedAt: string;
   publishedAt?: string;
+}
+
+export interface DigitalScreenVersionSummary {
+  id: string;
+  versionNo: number;
+  sourceRevision: number;
+  name: string;
+  publishedAt: string;
+  current: boolean;
+}
+
+export interface DigitalScreenVersion {
+  id: string;
+  screenId: string;
+  versionNo: number;
+  sourceRevision: number;
+  name: string;
+  description?: string;
+  templateId: string;
+  templateVersion: 1;
+  bindings: DigitalScreenBindings;
+  publishedAt: string;
+  createdAt: string;
 }
 
 export interface CreateDigitalScreenInput {


### PR DESCRIPTION
## 背景

PR 0（#835）完成前端职责边界，PR 1（#837）把 Digital Screen Definition 从 localStorage 后端化并已合并。本 PR 执行 PR 2：把“发布”从主表上的一个状态位升级成真正的 **Draft / PublishedVersion** 模型，确保编辑中的草稿不会影响正在播放的线上大屏。

核心原则：

```text
Editor -> Mutable Draft
             |
             | publish
             v
       Immutable ScreenVersion
             |
             v
      published_version_id
             |
Viewer <-----+
```

Viewer 从本 PR 开始只读取不可变 PublishedVersion，不再读取主表 Draft。

## 本 PR 做了什么

### 1. 新增不可变发布版本模型

新增：

- `DigitalScreenVersion`
- `DigitalScreenVersionPO`
- `DigitalScreenVersionMapper`
- `DigitalScreenVersionRepository`
- `DigitalScreenVersionRepositoryAdapter`

版本快照保存：

```text
screenId
versionNo
sourceRevision
name / description
templateId / templateVersion
bindings JSON
publishedTime
```

版本表只追加，不更新历史记录。

### 2. 主 Screen 变成 Draft + Published Pointer

`yak_digital_screen` 继续保存当前可编辑 Draft，并新增：

```text
revision
published_revision
published_version_id
published_version_no
```

`status` 现在表达“当前是否有线上版本”，而不是“当前 Draft 是否等于线上内容”。

因此已发布大屏继续编辑时：

- status 仍然是 `PUBLISHED`
- Viewer 继续播放旧 PublishedVersion
- Draft revision 继续增加
- `hasUnpublishedChanges = true`
- 再次点击发布后才生成新的版本并切换线上 pointer

### 3. V2 Flyway 增量迁移

没有修改 PR 1 的 V1 baseline，新增：

`V2__add_published_versions.sql`

迁移会：

1. 创建 `yak_digital_screen_version`
2. 为主表增加 revision / published pointer 字段
3. 把 PR 1 中已经处于 `PUBLISHED` 状态的历史数据自动转换成不可变 V1 快照
4. 回填 `published_version_id / published_version_no / published_revision`

这样已经跑过 PR 1 Flyway 的环境不会遇到 V1 checksum 变化。

### 4. 发布逻辑角色化

新增 `DigitalScreenPublisher`，只负责：

- publish
- offline
- rollback

发布流程：

```text
lock DigitalScreen row FOR UPDATE
        |
        v
current Draft revision
        |
        +-- 与 publishedRevision 相同 -> no-op
        |
        v
next versionNo
        |
        v
append immutable ScreenVersion
        |
        v
move published pointer
```

同一块大屏并发发布通过主 Screen 行锁串行化，避免应用层同时计算相同的 `nextVersionNo`。

### 5. 回滚采用“追加式回滚”

新增：

```text
POST /api/v1/digital-screens/{screenId}/versions/{versionNo}/rollback
```

例如当前线上是 V3，选择回滚 V1：

```text
V1 historical snapshot
       |
       v
restore into Draft
       |
       v
append V4
       |
       v
publish V4
```

不会修改 V1/V2/V3 历史行，因此审计链条保持不可变。

### 6. 新增版本读取角色

新增 `DigitalScreenVersionReader`，负责：

- 当前 PublishedVersion
- 历史版本列表
- 指定版本读取

新增 REST API：

```text
GET  /api/v1/digital-screens/{id}/published
GET  /api/v1/digital-screens/{id}/versions
GET  /api/v1/digital-screens/{id}/versions/{versionNo}
POST /api/v1/digital-screens/{id}/versions/{versionNo}/rollback
```

原 CRUD / publish / offline API 保持不变。

### 7. Viewer 正式只读 PublishedVersion

前端新增 `ScreenPublicationRepository`，职责与 Draft Repository 分开：

```text
ScreenRepository
  -> Draft CRUD

ScreenPublicationRepository
  -> getPublished
  -> listVersions
  -> getVersion
  -> rollback
```

`useDigitalScreenViewer` 已从：

```text
getDigitalScreen(id)
```

切为：

```text
getPublishedDigitalScreen(id)
```

因此 Draft 修改、保存都不会再直接影响线上 Viewer。

未发布或已取消发布的大屏访问 Viewer 时会明确提示没有可用的已发布快照。

### 8. 编辑器发布交互重新拆清

原逻辑在 `status=published` 时按钮只能“取消发布”，无法把新的 Draft 更新发布。

本 PR 改成独立动作：

- 版本历史
- 线上预览
- 保存
- 取消发布
- 发布 / 更新发布

状态也区分：

```text
草稿
已发布 V2
已发布 V2 · 有未发布更改
```

“线上预览”只打开 PublishedVersion；编辑区本身就是 Draft 实时预览。

### 9. 增加版本历史与回滚 UI

编辑器新增版本历史 Drawer：

- 展示 V1 / V2 / V3...
- 标识当前线上版本
- 展示对应 Draft revision 与发布时间
- 支持选择历史版本“回滚并发布”
- 回滚会明确提示覆盖当前 Draft，并追加一个新版本

### 10. 避免无意义版本

前端新增 Draft dirty 判断：

- 没有修改时点击“保存”不会重复提交
- 已发布且 Draft revision 与 publishedRevision 相同，不允许重复“更新发布”
- 后端 publish 也会再次做 revision no-op 防线

因此不会因为重复点击保存/发布制造大量空版本。

## 数据生命周期

### 第一次发布

```text
Draft R1
  -> publish
ScreenVersion V1(sourceRevision=R1)
publishedVersion = V1
```

### 发布后继续编辑

```text
Published: V1 / R1
Draft: R2

Viewer -> V1
Editor -> R2
hasUnpublishedChanges = true
```

### 更新发布

```text
Draft R2
  -> publish
ScreenVersion V2(sourceRevision=R2)
publishedVersion = V2
```

### 取消发布

只清空当前 published pointer，历史 V1/V2 保留；再次发布会继续生成 V3，而不是覆盖历史。

## 明确不在本 PR 范围

- 不做多人编辑 optimistic locking / 409 revision conflict
- 不做版本备注 / 发布说明
- 不做版本分页
- 不做定时发布 / 审批发布
- 不做 projectId
- 不做 Runtime Dataset 请求缓存 / 去重 / AbortController
- 不做组件联动 / 钻取

这些不会阻塞 Draft / PublishedVersion 的隔离语义。

## 测试与回归保护

新增/调整测试覆盖：

- 发布创建不可变版本并移动 pointer
- 相同 revision 重复发布 no-op
- 回滚历史版本时追加新版本
- duplicate 不继承发布历史
- delete 先清理版本历史
- Published / versions / rollback HTTP 路由契约

## 当前验证状态

- ✅ PR 1 #837 已合并
- ✅ 分支直接基于最新 `main`，当前 `behind=0`
- ✅ V1 Flyway 未修改，版本模型使用 V2 增量迁移
- ✅ 已有 PUBLISHED 数据提供 V1 backfill
- ✅ publish 使用 `FOR UPDATE` 串行化同 Screen 发布
- ✅ Viewer 已切到 `/published`，不再读取 Draft
- ✅ 最终 diff 仅涉及 Digital Screen 后端与前端
- ⚠️ 当前执行环境没有仓库 checkout，尚未实际执行 Maven / npm / 浏览器集成测试

## 合并前建议最小验证

后端：

```bash
mvn -pl yak-ops-business/yak-ops-business-digital-screen -am test
mvn -pl yak-ops-boot -am -DskipTests package
```

前端：

```bash
cd yak-ops-ui
npm run tsc
```

数据库建议分别验证两种环境：

1. 空库直接跑 V1 + V2
2. 已跑 PR 1 V1，且至少存在一条 `PUBLISHED` 大屏，再升级 V2，确认自动生成 V1 snapshot 与 pointer

浏览器最小回归：

1. 新建大屏，未发布时 Viewer 不展示 Draft
2. 发布 V1，Viewer 正常展示 V1
3. 编辑并保存 Draft，Viewer 仍保持 V1
4. 编辑器显示“已发布 V1 · 有未发布更改”
5. 更新发布生成 V2，Viewer 切换为 V2
6. 重复发布无改动，不新增 V3
7. 取消发布后 Viewer 不再可用，但历史 V1/V2 仍存在
8. 再发布生成 V3
9. 回滚 V1 后生成新的 V4，历史 V1/V2/V3 保持不变
10. metric / line / bar / pie / table 运行时数据仍通过 Dataset 服务加载
