### PR TITLE
perf(digital-screen): optimize runtime execution (PR 4)

### DIFF
--- a/yak-ops-ui/src/pages/digital-screen/runtime/README.md
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/README.md
@@ -41,7 +41,8 @@ ScreenTemplate + bindings + Datasets
 - A refresh keeps the last successful component data visible while new data is loading.
 - Component/query failures remain isolated to the affected components.
 - Production Viewer refreshes every 30 seconds while the page is visible; background tabs pause polling and refresh once when visible again.
-- Editor remains event-driven and does not poll automatically.
+- Viewer loads metadata only for Dataset ids referenced by the current PublishedVersion instead of expanding the complete online Dataset catalog.
+- Editor remains event-driven and keeps the full Dataset catalog because the binding panel needs it.
 
 All timing/concurrency defaults live in `policy.ts` and can be overridden through `useScreenRuntime` options.
 

--- a/yak-ops-ui/src/pages/digital-screen/runtime/README.md
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/README.md
@@ -1,36 +1,53 @@
 # Digital Screen Runtime
 
-`runtime` owns execution of a saved Digital Screen definition. Screen persistence and Draft/PublishedVersion lifecycle stay in `services/digital-screen`; Dataset HTTP stays in `services/dataset`.
+`runtime` owns execution of a saved Digital Screen definition. Persistence belongs to
+`services/digital-screen`; rendering primitives belong to `components/screen-engine`.
 
-## Roles
+## Execution pipeline
 
 ```text
-Screen definition + Dataset catalog
-              |
-              v
-          planner.ts
-              |
-       Runtime candidates
-              |
-              v
-           query.ts
-              |
-              v
-  Runtime Component Registry
-   - bindable capability
-   - query contract
-   - data adapter
-              |
-              v
-       useScreenRuntime
-              |
-              v
-        ScreenRuntime.tsx
-              |
-              v
- generic screen-engine renderer
+ScreenTemplate + bindings + Datasets
+               |
+               v
+             Planner
+               |
+               v
+      ScreenRuntimeCandidate[]
+               |
+               v
+        Runtime Executor
+        /      |       \
+ Query Key   Cache   Concurrency
+    |          |          |
+    +----------+----------+
+               |
+               v
+          Dataset API
+               |
+               v
+       Component Adapter
+               |
+               v
+        ScreenRenderer
 ```
 
-`components/screen-engine/runtime` owns the React Renderer Registry. It only answers “how does this component render?” and intentionally knows nothing about Dataset bindings.
+## PR 4 runtime policy
 
-PR 3 registers all current component types explicitly and removes the legacy adapter/render switches. PR 4 may optimize the planner/executor with request deduplication, caching, cancellation and refresh policies without changing Viewer or component plugins.
+- Stable query keys include Dataset id/version and the complete query payload.
+- Candidates with the same key share one network request, even when component types differ.
+- Raw Dataset query results are cached per runtime session for 10 seconds by default.
+- At most 4 unique Dataset queries run concurrently by default.
+- Every execution owns an `AbortController`; changing bindings/template or leaving the page cancels stale requests.
+- A refresh keeps the last successful component data visible while new data is loading.
+- Component/query failures remain isolated to the affected components.
+- Production Viewer refreshes every 30 seconds while the page is visible; background tabs pause polling and refresh once when visible again.
+- Editor remains event-driven and does not poll automatically.
+
+All timing/concurrency defaults live in `policy.ts` and can be overridden through `useScreenRuntime` options.
+
+## Boundaries
+
+Runtime plugins answer: can a component bind/query, how is its query built, and how is raw Dataset data adapted.
+Renderer plugins answer only: how is a component drawn.
+
+PR 4 intentionally does **not** add global filters, component linkage, drill-down or cross-component interaction. Those are PR 5 concerns.

--- a/yak-ops-ui/src/pages/digital-screen/runtime/concurrency.test.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/concurrency.test.ts
@@ -1,0 +1,31 @@
+import { mapWithConcurrency } from './concurrency';
+
+describe('mapWithConcurrency', () => {
+  it('never exceeds the configured active worker count', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    const results = await mapWithConcurrency([1, 2, 3, 4], 2, async (value) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return value * 2;
+    });
+
+    expect(results).toEqual([2, 4, 6, 8]);
+    expect(maxActive).toBe(2);
+  });
+
+  it('stops before starting work when already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(mapWithConcurrency(
+      [1],
+      1,
+      async (value) => value,
+      controller.signal,
+    )).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/yak-ops-ui/src/pages/digital-screen/runtime/concurrency.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/concurrency.ts
@@ -1,0 +1,40 @@
+export const createScreenRuntimeAbortError = () => {
+  const error = new Error('Screen runtime query aborted');
+  error.name = 'AbortError';
+  return error;
+};
+
+export const isScreenRuntimeAbortError = (error: unknown) => Boolean(
+  error
+  && typeof error === 'object'
+  && (
+    (error as { name?: string }).name === 'AbortError'
+    || (error as { type?: string }).type === 'aborted'
+  )
+);
+
+/** Executes work with a bounded number of workers while preserving result order. */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+  signal?: AbortSignal,
+): Promise<R[]> {
+  if (!items.length) return [];
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workerCount = Math.min(Math.max(1, Math.floor(limit)), items.length);
+
+  const runWorker = async () => {
+    while (true) {
+      if (signal?.aborted) throw createScreenRuntimeAbortError();
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+  return results;
+}

--- a/yak-ops-ui/src/pages/digital-screen/runtime/executor.test.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/executor.test.ts
@@ -1,0 +1,130 @@
+import type { ScreenComponent, ScreenTemplate } from '@/components/screen-engine';
+import type { DatasetQueryResult, PublishedDataset } from '@/services/dataset';
+import type { DigitalScreenBindings } from '@/services/digital-screen';
+import { ScreenRuntimeExecutor } from './executor';
+import { planScreenRuntimeQueries } from './planner';
+
+const component = (type: ScreenComponent['type'], id: string) => ({
+  id,
+  type,
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 100,
+}) as ScreenComponent;
+
+const dataset: PublishedDataset = {
+  id: '12',
+  name: '销售 Dataset',
+  description: '',
+  status: 'ONLINE',
+  sourceTaskId: '1',
+  sourceTaskName: 'task',
+  currentVersionNo: 3,
+  updatedAt: '2026-08-27T00:00:00Z',
+  fields: [
+    {
+      key: 'region',
+      label: '区域',
+      physicalName: 'region',
+      dataType: 'string',
+      role: 'dimension',
+      nullable: false,
+    },
+    {
+      key: 'amount',
+      label: '金额',
+      physicalName: 'amount',
+      dataType: 'number',
+      role: 'metric',
+      nullable: false,
+    },
+  ],
+};
+
+const queryResult: DatasetQueryResult = {
+  datasetId: '12',
+  datasetVersionId: '30',
+  datasetVersionNo: 3,
+  bindings: [
+    {
+      key: 'region',
+      fieldId: 'region',
+      displayName: '区域',
+      dataType: 'STRING',
+      aggregation: null,
+    },
+    {
+      key: 'amount_SUM',
+      fieldId: 'amount',
+      displayName: '金额',
+      dataType: 'NUMBER',
+      aggregation: 'SUM',
+    },
+  ],
+  columns: [],
+  rows: [['华东', 10]],
+  returnedRows: 1,
+  truncated: false,
+  elapsedMillis: 8,
+};
+
+const binding = {
+  datasetId: '12',
+  dimensions: ['region'],
+  metrics: [{ field: 'amount', aggregation: 'SUM' as const }],
+};
+
+const runtimePlan = () => {
+  const template = {
+    components: [component('line', 'line'), component('bar', 'bar')],
+  } as ScreenTemplate;
+  const bindings: DigitalScreenBindings = { line: binding, bar: binding };
+  return planScreenRuntimeQueries(template, bindings, [dataset]);
+};
+
+describe('ScreenRuntimeExecutor', () => {
+  it('deduplicates identical raw Dataset queries and reuses the cached result', async () => {
+    const query = jest.fn(async () => queryResult);
+    const executor = new ScreenRuntimeExecutor(query);
+    const candidates = runtimePlan();
+
+    const first = await executor.execute(candidates, {
+      cacheTtlMs: 10_000,
+      maxConcurrency: 4,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(first.stats).toEqual({
+      candidateCount: 2,
+      uniqueQueryCount: 1,
+      deduplicatedCount: 1,
+      networkQueryCount: 1,
+      cacheHitQueryCount: 0,
+    });
+    expect(first.data.line).toEqual(first.data.bar);
+
+    const second = await executor.execute(candidates, {
+      cacheTtlMs: 10_000,
+      maxConcurrency: 4,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(second.stats.networkQueryCount).toBe(0);
+    expect(second.stats.cacheHitQueryCount).toBe(1);
+  });
+
+  it('isolates one grouped query failure to the components using that query', async () => {
+    const executor = new ScreenRuntimeExecutor(async () => {
+      throw new Error('query failed');
+    });
+
+    const result = await executor.execute(runtimePlan(), {
+      cacheTtlMs: 10_000,
+      maxConcurrency: 4,
+    });
+
+    expect(result.errors).toEqual({ line: 'query failed', bar: 'query failed' });
+    expect(result.data).toEqual({});
+  });
+});

--- a/yak-ops-ui/src/pages/digital-screen/runtime/executor.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/executor.ts
@@ -1,0 +1,170 @@
+import type { ScreenDataOverrides } from '@/components/screen-engine';
+import type {
+  DatasetQueryPayload,
+  DatasetQueryResult,
+  PublishedDataset,
+} from '@/services/dataset';
+import {
+  createScreenRuntimeAbortError,
+  isScreenRuntimeAbortError,
+  mapWithConcurrency,
+} from './concurrency';
+import type {
+  ScreenRuntimeCandidate,
+  ScreenRuntimeExecutionStats,
+} from './model';
+import { ScreenRuntimeQueryCache } from './query-cache';
+import {
+  queryScreenDatasetResult,
+  toScreenComponentData,
+  type ScreenRuntimeQueryOptions,
+} from './query';
+
+interface ScreenRuntimeQueryGroup {
+  queryKey: string;
+  dataset: PublishedDataset;
+  payload: DatasetQueryPayload;
+  candidates: ScreenRuntimeCandidate[];
+}
+
+interface ScreenRuntimeGroupResult {
+  group: ScreenRuntimeQueryGroup;
+  result?: DatasetQueryResult;
+  error?: unknown;
+  source: 'cache' | 'network';
+}
+
+export interface ScreenRuntimeExecutionOptions {
+  cacheTtlMs: number;
+  maxConcurrency: number;
+  signal?: AbortSignal;
+}
+
+export interface ScreenRuntimeExecutionResult {
+  data: ScreenDataOverrides;
+  errors: Record<string, string>;
+  stats: ScreenRuntimeExecutionStats;
+}
+
+export type ScreenRuntimeDatasetQuery = (
+  dataset: PublishedDataset,
+  payload: DatasetQueryPayload,
+  options?: ScreenRuntimeQueryOptions,
+) => Promise<DatasetQueryResult>;
+
+const groupCandidates = (candidates: ScreenRuntimeCandidate[]) => {
+  const groups = new Map<string, ScreenRuntimeQueryGroup>();
+  candidates.forEach((candidate) => {
+    const current = groups.get(candidate.queryKey);
+    if (current) {
+      current.candidates.push(candidate);
+      return;
+    }
+    groups.set(candidate.queryKey, {
+      queryKey: candidate.queryKey,
+      dataset: candidate.dataset,
+      payload: candidate.payload,
+      candidates: [candidate],
+    });
+  });
+  return [...groups.values()];
+};
+
+const errorMessage = (error: unknown) => (
+  error instanceof Error ? error.message : 'Dataset 查询失败'
+);
+
+/**
+ * Executes one runtime plan with query-level dedupe, bounded concurrency and a short-lived raw cache.
+ * The executor is intentionally instantiated per useScreenRuntime hook, so cache lifetime follows the page.
+ */
+export class ScreenRuntimeExecutor {
+  constructor(
+    private readonly query: ScreenRuntimeDatasetQuery = queryScreenDatasetResult,
+    private readonly cache = new ScreenRuntimeQueryCache(),
+  ) {}
+
+  async execute(
+    candidates: ScreenRuntimeCandidate[],
+    options: ScreenRuntimeExecutionOptions,
+  ): Promise<ScreenRuntimeExecutionResult> {
+    const groups = groupCandidates(candidates);
+    if (!groups.length) {
+      return {
+        data: {},
+        errors: {},
+        stats: {
+          candidateCount: 0,
+          uniqueQueryCount: 0,
+          deduplicatedCount: 0,
+          networkQueryCount: 0,
+          cacheHitQueryCount: 0,
+        },
+      };
+    }
+
+    const groupResults = await mapWithConcurrency(
+      groups,
+      options.maxConcurrency,
+      async (group): Promise<ScreenRuntimeGroupResult> => {
+        if (options.signal?.aborted) throw createScreenRuntimeAbortError();
+        const cached = this.cache.get(group.queryKey, options.cacheTtlMs);
+        if (cached) return { group, result: cached, source: 'cache' };
+
+        try {
+          const result = await this.query(
+            group.dataset,
+            group.payload,
+            { signal: options.signal },
+          );
+          if (options.signal?.aborted) throw createScreenRuntimeAbortError();
+          this.cache.set(group.queryKey, result);
+          return { group, result, source: 'network' };
+        } catch (error) {
+          if (options.signal?.aborted || isScreenRuntimeAbortError(error)) {
+            throw createScreenRuntimeAbortError();
+          }
+          return { group, error, source: 'network' };
+        }
+      },
+      options.signal,
+    );
+
+    const data: ScreenDataOverrides = {};
+    const errors: Record<string, string> = {};
+
+    groupResults.forEach(({ group, result, error }) => {
+      if (error || !result) {
+        group.candidates.forEach(({ component }) => {
+          errors[component.id] = errorMessage(error);
+        });
+        return;
+      }
+
+      group.candidates.forEach(({ component, binding, dataset }) => {
+        try {
+          const adapted = toScreenComponentData(component, binding, dataset, result);
+          if (adapted) data[component.id] = adapted;
+        } catch (adapterError) {
+          errors[component.id] = errorMessage(adapterError);
+        }
+      });
+    });
+
+    return {
+      data,
+      errors,
+      stats: {
+        candidateCount: candidates.length,
+        uniqueQueryCount: groups.length,
+        deduplicatedCount: Math.max(0, candidates.length - groups.length),
+        networkQueryCount: groupResults.filter((item) => item.source === 'network').length,
+        cacheHitQueryCount: groupResults.filter((item) => item.source === 'cache').length,
+      },
+    };
+  }
+
+  dispose() {
+    this.cache.clear();
+  }
+}

--- a/yak-ops-ui/src/pages/digital-screen/runtime/hooks/useScreenRuntime.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/hooks/useScreenRuntime.ts
@@ -1,84 +1,189 @@
-import type { ScreenDataOverrides, ScreenTemplate } from '@/components/screen-engine';
+import type { ScreenTemplate } from '@/components/screen-engine';
 import type { PublishedDataset } from '@/services/dataset';
 import type { DigitalScreenBindings } from '@/services/digital-screen';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ScreenRuntimeDataState, ScreenRuntimeState } from '../model';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { isScreenRuntimeAbortError } from '../concurrency';
+import { ScreenRuntimeExecutor } from '../executor';
+import type {
+  ScreenRuntimeDataState,
+  ScreenRuntimeExecutionStats,
+  ScreenRuntimeState,
+} from '../model';
 import {
   countBoundScreenComponents,
   planScreenRuntimeQueries,
 } from '../planner';
-import { queryScreenComponentData } from '../query';
+import {
+  resolveScreenRuntimePolicy,
+  type ScreenRuntimePolicyOptions,
+} from '../policy';
+
+const EMPTY_STATS: ScreenRuntimeExecutionStats = {
+  candidateCount: 0,
+  uniqueQueryCount: 0,
+  deduplicatedCount: 0,
+  networkQueryCount: 0,
+  cacheHitQueryCount: 0,
+};
 
 const EMPTY_STATE: ScreenRuntimeDataState = {
   data: {},
   loadingIds: [],
   errors: {},
+  stats: EMPTY_STATS,
 };
 
-/** Coordinates runtime query lifecycle. Query semantics live in plugins/planner, not this hook. */
+const runtimeErrorMessage = (error: unknown) => (
+  error instanceof Error ? error.message : 'Dataset 查询失败'
+);
+
+/**
+ * Coordinates a screen runtime session. Query grouping/cache/concurrency live in the executor;
+ * this hook only owns React lifecycle, cancellation, refresh cadence and stale-result protection.
+ */
 export function useScreenRuntime(
   template: ScreenTemplate | undefined,
   bindings: DigitalScreenBindings,
   datasets: PublishedDataset[],
+  options?: ScreenRuntimePolicyOptions,
 ): ScreenRuntimeState {
   const [state, setState] = useState<ScreenRuntimeDataState>(EMPTY_STATE);
+  const [refreshTick, setRefreshTick] = useState(0);
   const sequence = useRef(0);
+  const previousPlanKey = useRef('');
+  const executor = useMemo(() => new ScreenRuntimeExecutor(), []);
+  const policy = useMemo(() => resolveScreenRuntimePolicy(options), [
+    options?.cacheTtlMs,
+    options?.debounceMs,
+    options?.maxConcurrency,
+    options?.refreshIntervalMs,
+  ]);
   const bindingKey = useMemo(() => JSON.stringify(bindings), [bindings]);
   const datasetKey = useMemo(
-    () => datasets.map((dataset) => `${dataset.id}:${dataset.currentVersionNo ?? ''}`).join('|'),
+    () => datasets
+      .map((dataset) => `${dataset.id}:${dataset.currentVersionNo ?? ''}:${dataset.updatedAt ?? ''}`)
+      .join('|'),
     [datasets],
   );
+  const planKey = `${template?.id ?? ''}:${template?.version ?? ''}|${bindingKey}|${datasetKey}`;
+
+  const refresh = useCallback(() => {
+    setRefreshTick((current) => current + 1);
+  }, []);
+
+  useEffect(() => () => executor.dispose(), [executor]);
+
+  useEffect(() => {
+    if (!template || policy.refreshIntervalMs <= 0 || typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const refreshWhenVisible = () => {
+      if (typeof document === 'undefined' || document.visibilityState !== 'hidden') refresh();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+    const timer = window.setInterval(refreshWhenVisible, policy.refreshIntervalMs);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+
+    return () => {
+      window.clearInterval(timer);
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+      }
+    };
+  }, [policy.refreshIntervalMs, refresh, template]);
 
   useEffect(() => {
     if (!template) {
+      previousPlanKey.current = '';
       setState(EMPTY_STATE);
       return undefined;
     }
 
     const candidates = planScreenRuntimeQueries(template, bindings, datasets);
     if (!candidates.length) {
+      previousPlanKey.current = planKey;
       setState(EMPTY_STATE);
       return undefined;
     }
 
     const requestId = ++sequence.current;
-    setState({
-      data: {},
-      loadingIds: candidates.map(({ component }) => component.id),
+    const controller = new AbortController();
+    const samePlan = previousPlanKey.current === planKey;
+    previousPlanKey.current = planKey;
+    const loadingIds = candidates.map(({ component }) => component.id);
+
+    setState((current) => ({
+      data: samePlan ? current.data : {},
+      loadingIds,
       errors: {},
-    });
+      lastUpdatedAt: samePlan ? current.lastUpdatedAt : undefined,
+      stats: samePlan ? current.stats : EMPTY_STATS,
+    }));
 
-    const timer = window.setTimeout(async () => {
-      const results = await Promise.allSettled(candidates.map(async ({ component, binding, dataset }) => ({
-        componentId: component.id,
-        data: await queryScreenComponentData(component, binding, dataset),
-      })));
-      if (requestId !== sequence.current) return;
-
-      const data: ScreenDataOverrides = {};
-      const errors: Record<string, string> = {};
-      results.forEach((result, index) => {
-        const componentId = candidates[index].component.id;
-        if (result.status === 'fulfilled') {
-          if (result.value.data) data[result.value.componentId] = result.value.data;
-          return;
-        }
-        errors[componentId] = result.reason instanceof Error
-          ? result.reason.message
-          : 'Dataset 查询失败';
+    const timer = window.setTimeout(() => {
+      void executor.execute(candidates, {
+        cacheTtlMs: policy.cacheTtlMs,
+        maxConcurrency: policy.maxConcurrency,
+        signal: controller.signal,
+      }).then((result) => {
+        if (requestId !== sequence.current || controller.signal.aborted) return;
+        setState((current) => ({
+          // Timed refreshes keep the last good value for a component whose new request failed.
+          data: samePlan ? { ...current.data, ...result.data } : result.data,
+          loadingIds: [],
+          errors: result.errors,
+          lastUpdatedAt: Date.now(),
+          stats: result.stats,
+        }));
+      }).catch((error) => {
+        if (
+          requestId !== sequence.current
+          || controller.signal.aborted
+          || isScreenRuntimeAbortError(error)
+        ) return;
+        const message = runtimeErrorMessage(error);
+        setState((current) => ({
+          ...current,
+          loadingIds: [],
+          errors: Object.fromEntries(loadingIds.map((componentId) => [componentId, message])),
+        }));
       });
-      setState({ data, loadingIds: [], errors });
-    }, 180);
+    }, policy.debounceMs);
 
     return () => {
       window.clearTimeout(timer);
+      controller.abort();
       if (sequence.current === requestId) sequence.current += 1;
     };
-  }, [bindingKey, datasetKey, template]);
+  }, [
+    bindings,
+    datasets,
+    executor,
+    planKey,
+    policy.cacheTtlMs,
+    policy.debounceMs,
+    policy.maxConcurrency,
+    refreshTick,
+    template,
+  ]);
 
+  const loadingCount = state.loadingIds.length;
   return {
     ...state,
-    loadingCount: state.loadingIds.length,
+    loadingCount,
     boundCount: countBoundScreenComponents(template, bindings),
+    isRefreshing: loadingCount > 0 && Object.keys(state.data).length > 0,
+    refresh,
   };
 }

--- a/yak-ops-ui/src/pages/digital-screen/runtime/hooks/useScreenRuntime.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/hooks/useScreenRuntime.ts
@@ -57,13 +57,9 @@ export function useScreenRuntime(
   const [refreshTick, setRefreshTick] = useState(0);
   const sequence = useRef(0);
   const previousPlanKey = useRef('');
+  const executionActive = useRef(false);
   const executor = useMemo(() => new ScreenRuntimeExecutor(), []);
-  const policy = useMemo(() => resolveScreenRuntimePolicy(options), [
-    options?.cacheTtlMs,
-    options?.debounceMs,
-    options?.maxConcurrency,
-    options?.refreshIntervalMs,
-  ]);
+  const policy = resolveScreenRuntimePolicy(options);
   const bindingKey = useMemo(() => JSON.stringify(bindings), [bindings]);
   const datasetKey = useMemo(
     () => datasets
@@ -85,10 +81,11 @@ export function useScreenRuntime(
     }
 
     const refreshWhenVisible = () => {
+      if (executionActive.current) return;
       if (typeof document === 'undefined' || document.visibilityState !== 'hidden') refresh();
     };
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') refresh();
+      if (document.visibilityState === 'visible') refreshWhenVisible();
     };
     const timer = window.setInterval(refreshWhenVisible, policy.refreshIntervalMs);
     if (typeof document !== 'undefined') {
@@ -105,6 +102,7 @@ export function useScreenRuntime(
 
   useEffect(() => {
     if (!template) {
+      executionActive.current = false;
       previousPlanKey.current = '';
       setState(EMPTY_STATE);
       return undefined;
@@ -112,6 +110,7 @@ export function useScreenRuntime(
 
     const candidates = planScreenRuntimeQueries(template, bindings, datasets);
     if (!candidates.length) {
+      executionActive.current = false;
       previousPlanKey.current = planKey;
       setState(EMPTY_STATE);
       return undefined;
@@ -121,6 +120,7 @@ export function useScreenRuntime(
     const controller = new AbortController();
     const samePlan = previousPlanKey.current === planKey;
     previousPlanKey.current = planKey;
+    executionActive.current = true;
     const loadingIds = candidates.map(({ component }) => component.id);
 
     setState((current) => ({
@@ -138,6 +138,7 @@ export function useScreenRuntime(
         signal: controller.signal,
       }).then((result) => {
         if (requestId !== sequence.current || controller.signal.aborted) return;
+        executionActive.current = false;
         setState((current) => ({
           // Timed refreshes keep the last good value for a component whose new request failed.
           data: samePlan ? { ...current.data, ...result.data } : result.data,
@@ -152,6 +153,7 @@ export function useScreenRuntime(
           || controller.signal.aborted
           || isScreenRuntimeAbortError(error)
         ) return;
+        executionActive.current = false;
         const message = runtimeErrorMessage(error);
         setState((current) => ({
           ...current,
@@ -164,6 +166,7 @@ export function useScreenRuntime(
     return () => {
       window.clearTimeout(timer);
       controller.abort();
+      executionActive.current = false;
       if (sequence.current === requestId) sequence.current += 1;
     };
   }, [

--- a/yak-ops-ui/src/pages/digital-screen/runtime/model.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/model.ts
@@ -2,7 +2,11 @@ import type {
   ScreenComponent,
   ScreenDataOverrides,
 } from '@/components/screen-engine';
-import type { DatasetQueryResult, PublishedDataset } from '@/services/dataset';
+import type {
+  DatasetQueryPayload,
+  DatasetQueryResult,
+  PublishedDataset,
+} from '@/services/dataset';
 import type {
   DigitalScreenBindings,
   DigitalScreenComponentBinding,
@@ -19,17 +23,33 @@ export interface ScreenRuntimeCandidate {
   component: ScreenComponent;
   binding: DigitalScreenComponentBinding;
   dataset: PublishedDataset;
+  payload: DatasetQueryPayload;
+  /** Stable identity used for request grouping and short-lived raw-result caching. */
+  queryKey: string;
+}
+
+export interface ScreenRuntimeExecutionStats {
+  candidateCount: number;
+  uniqueQueryCount: number;
+  deduplicatedCount: number;
+  networkQueryCount: number;
+  cacheHitQueryCount: number;
 }
 
 export interface ScreenRuntimeDataState {
   data: ScreenDataOverrides;
   loadingIds: string[];
   errors: Record<string, string>;
+  lastUpdatedAt?: number;
+  stats: ScreenRuntimeExecutionStats;
 }
 
 export interface ScreenRuntimeState extends ScreenRuntimeDataState {
   loadingCount: number;
   boundCount: number;
+  /** True when old data remains visible while a refresh is running. */
+  isRefreshing: boolean;
+  refresh: () => void;
 }
 
 export interface ScreenRuntimePlanInput {

--- a/yak-ops-ui/src/pages/digital-screen/runtime/planner.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/planner.ts
@@ -2,12 +2,14 @@ import type { ScreenTemplate } from '@/components/screen-engine';
 import type { PublishedDataset } from '@/services/dataset';
 import type { DigitalScreenBindings } from '@/services/digital-screen';
 import {
+  buildScreenDatasetQueryPayload,
   canQueryScreenComponent,
   isBindableScreenComponent,
 } from './binding';
 import type { ScreenRuntimeCandidate } from './model';
+import { createScreenRuntimeQueryKey } from './query-key';
 
-/** Builds execution candidates only. Request merging/caching belongs to PR 4. */
+/** Builds executable candidates, including the stable query identity used by PR 4's executor. */
 export const planScreenRuntimeQueries = (
   template: ScreenTemplate | undefined,
   bindings: DigitalScreenBindings,
@@ -19,7 +21,15 @@ export const planScreenRuntimeQueries = (
     const binding = bindings[component.id];
     if (!binding || !canQueryScreenComponent(component, binding)) return [];
     const dataset = datasetMap.get(binding.datasetId);
-    return dataset ? [{ component, binding, dataset }] : [];
+    if (!dataset) return [];
+    const payload = buildScreenDatasetQueryPayload(component, binding);
+    return [{
+      component,
+      binding,
+      dataset,
+      payload,
+      queryKey: createScreenRuntimeQueryKey(dataset, payload),
+    }];
   });
 };
 

--- a/yak-ops-ui/src/pages/digital-screen/runtime/planner.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/planner.ts
@@ -33,9 +33,19 @@ export const planScreenRuntimeQueries = (
   });
 };
 
-export const collectBoundDatasetIds = (bindings: DigitalScreenBindings) => (
-  [...new Set(Object.values(bindings).map((binding) => binding.datasetId).filter(Boolean))]
-);
+/** Dataset ids the planner could execute once metadata is available. */
+export const collectScreenRuntimeDatasetIds = (
+  template: ScreenTemplate | undefined,
+  bindings: DigitalScreenBindings,
+) => {
+  if (!template) return [];
+  return [...new Set(template.components.flatMap((component) => {
+    const binding = bindings[component.id];
+    return binding && canQueryScreenComponent(component, binding)
+      ? [binding.datasetId]
+      : [];
+  }))];
+};
 
 export const countBoundScreenComponents = (
   template: ScreenTemplate | undefined,

--- a/yak-ops-ui/src/pages/digital-screen/runtime/planner.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/planner.ts
@@ -33,6 +33,10 @@ export const planScreenRuntimeQueries = (
   });
 };
 
+export const collectBoundDatasetIds = (bindings: DigitalScreenBindings) => (
+  [...new Set(Object.values(bindings).map((binding) => binding.datasetId).filter(Boolean))]
+);
+
 export const countBoundScreenComponents = (
   template: ScreenTemplate | undefined,
   bindings: DigitalScreenBindings,

--- a/yak-ops-ui/src/pages/digital-screen/runtime/policy.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/policy.ts
@@ -1,0 +1,42 @@
+export interface ScreenRuntimePolicyOptions {
+  debounceMs?: number;
+  cacheTtlMs?: number;
+  maxConcurrency?: number;
+  refreshIntervalMs?: number;
+}
+
+export interface ScreenRuntimePolicy {
+  debounceMs: number;
+  cacheTtlMs: number;
+  maxConcurrency: number;
+  refreshIntervalMs: number;
+}
+
+export const SCREEN_RUNTIME_DEFAULT_POLICY: ScreenRuntimePolicy = {
+  debounceMs: 180,
+  cacheTtlMs: 10_000,
+  maxConcurrency: 4,
+  refreshIntervalMs: 0,
+};
+
+/** Production viewers refresh query data periodically; editors stay event-driven by default. */
+export const SCREEN_RUNTIME_VIEWER_REFRESH_INTERVAL_MS = 30_000;
+
+const finiteOr = (value: number | undefined, fallback: number) => (
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback
+);
+
+export const resolveScreenRuntimePolicy = (
+  options?: ScreenRuntimePolicyOptions,
+): ScreenRuntimePolicy => ({
+  debounceMs: Math.max(0, finiteOr(options?.debounceMs, SCREEN_RUNTIME_DEFAULT_POLICY.debounceMs)),
+  cacheTtlMs: Math.max(0, finiteOr(options?.cacheTtlMs, SCREEN_RUNTIME_DEFAULT_POLICY.cacheTtlMs)),
+  maxConcurrency: Math.min(
+    16,
+    Math.max(1, Math.floor(finiteOr(options?.maxConcurrency, SCREEN_RUNTIME_DEFAULT_POLICY.maxConcurrency))),
+  ),
+  refreshIntervalMs: Math.max(
+    0,
+    finiteOr(options?.refreshIntervalMs, SCREEN_RUNTIME_DEFAULT_POLICY.refreshIntervalMs),
+  ),
+});

--- a/yak-ops-ui/src/pages/digital-screen/runtime/query-cache.test.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/query-cache.test.ts
@@ -1,0 +1,26 @@
+import type { DatasetQueryResult } from '@/services/dataset';
+import { ScreenRuntimeQueryCache } from './query-cache';
+
+const result = { datasetId: '1' } as DatasetQueryResult;
+
+describe('ScreenRuntimeQueryCache', () => {
+  it('expires entries by the caller supplied TTL', () => {
+    const cache = new ScreenRuntimeQueryCache();
+    cache.set('query', result, 1_000);
+
+    expect(cache.get('query', 100, 1_050)).toBe(result);
+    expect(cache.get('query', 100, 1_101)).toBeUndefined();
+  });
+
+  it('bounds cache size with LRU eviction', () => {
+    const cache = new ScreenRuntimeQueryCache(2);
+    cache.set('a', result, 1);
+    cache.set('b', result, 2);
+    expect(cache.get('a', 100, 3)).toBe(result);
+    cache.set('c', result, 4);
+
+    expect(cache.get('b', 100, 5)).toBeUndefined();
+    expect(cache.get('a', 100, 5)).toBe(result);
+    expect(cache.get('c', 100, 5)).toBe(result);
+  });
+});

--- a/yak-ops-ui/src/pages/digital-screen/runtime/query-cache.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/query-cache.ts
@@ -1,0 +1,45 @@
+import type { DatasetQueryResult } from '@/services/dataset';
+
+interface CacheEntry {
+  result: DatasetQueryResult;
+  storedAt: number;
+}
+
+/** Small per-runtime LRU cache of raw Dataset query results. */
+export class ScreenRuntimeQueryCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  constructor(private readonly maxEntries = 100) {}
+
+  get(key: string, maxAgeMs: number, now = Date.now()) {
+    if (maxAgeMs <= 0) return undefined;
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (now - entry.storedAt > maxAgeMs) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    // Touch the entry so Map insertion order acts as a compact LRU queue.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.result;
+  }
+
+  set(key: string, result: DatasetQueryResult, now = Date.now()) {
+    this.entries.delete(key);
+    this.entries.set(key, { result, storedAt: now });
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      this.entries.delete(oldestKey);
+    }
+  }
+
+  clear() {
+    this.entries.clear();
+  }
+
+  get size() {
+    return this.entries.size;
+  }
+}

--- a/yak-ops-ui/src/pages/digital-screen/runtime/query-key.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/query-key.ts
@@ -1,0 +1,22 @@
+import type { DatasetQueryPayload, PublishedDataset } from '@/services/dataset';
+
+const normalizeForStableJson = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(normalizeForStableJson);
+  if (!value || typeof value !== 'object') return value;
+  return Object.keys(value as Record<string, unknown>)
+    .sort()
+    .reduce<Record<string, unknown>>((result, key) => {
+      result[key] = normalizeForStableJson((value as Record<string, unknown>)[key]);
+      return result;
+    }, {});
+};
+
+export const stableRuntimeStringify = (value: unknown) => (
+  JSON.stringify(normalizeForStableJson(value))
+);
+
+/** Query identity deliberately excludes component type so line/bar can share the same raw result. */
+export const createScreenRuntimeQueryKey = (
+  dataset: PublishedDataset,
+  payload: DatasetQueryPayload,
+) => `${dataset.id}@${dataset.currentVersionNo ?? 'current'}:${stableRuntimeStringify(payload)}`;

--- a/yak-ops-ui/src/pages/digital-screen/runtime/query.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/query.ts
@@ -1,6 +1,7 @@
 import type { ScreenComponent } from '@/components/screen-engine';
 import {
   queryDataset,
+  type DatasetQueryPayload,
   type DatasetQueryResult,
   type PublishedDataset,
 } from '@/services/dataset';
@@ -11,6 +12,10 @@ import {
 } from './binding';
 import { screenRuntimeComponentRegistry } from './registry/builtin-plugins';
 
+export interface ScreenRuntimeQueryOptions {
+  signal?: AbortSignal;
+}
+
 export const toScreenComponentData = (
   component: ScreenComponent,
   binding: DigitalScreenComponentBinding,
@@ -18,15 +23,24 @@ export const toScreenComponentData = (
   result: DatasetQueryResult,
 ) => screenRuntimeComponentRegistry.adaptData(component, binding, { dataset, result });
 
+export const queryScreenDatasetResult = (
+  dataset: PublishedDataset,
+  payload: DatasetQueryPayload,
+  options?: ScreenRuntimeQueryOptions,
+) => queryDataset(dataset.id, payload, { signal: options?.signal });
+
+/** Compatibility helper for direct component callers. Runtime execution should use the batch executor. */
 export const queryScreenComponentData = async (
   component: ScreenComponent,
   binding: DigitalScreenComponentBinding,
   dataset: PublishedDataset,
+  options?: ScreenRuntimeQueryOptions,
 ) => {
   if (!canQueryScreenComponent(component, binding)) return undefined;
-  const result = await queryDataset(
-    dataset.id,
+  const result = await queryScreenDatasetResult(
+    dataset,
     buildScreenDatasetQueryPayload(component, binding),
+    options,
   );
   return toScreenComponentData(component, binding, dataset, result);
 };

--- a/yak-ops-ui/src/pages/digital-screen/runtime/runtime.test.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/runtime.test.ts
@@ -52,4 +52,16 @@ describe('digital screen runtime roles', () => {
     expect(planScreenRuntimeQueries(template, bindings, datasets).map((item) => item.component.id))
       .toEqual(['bound']);
   });
+
+  it('assigns the same query key to different component types with an identical Dataset query', () => {
+    const template = {
+      components: [component('line', 'line'), component('bar', 'bar')],
+    } as ScreenTemplate;
+    const bindings: DigitalScreenBindings = { line: binding, bar: binding };
+    const datasets = [{ id: '12', currentVersionNo: 3 }] as PublishedDataset[];
+    const plan = planScreenRuntimeQueries(template, bindings, datasets);
+
+    expect(plan).toHaveLength(2);
+    expect(plan[0].queryKey).toBe(plan[1].queryKey);
+  });
 });

--- a/yak-ops-ui/src/pages/digital-screen/runtime/runtime.test.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/runtime.test.ts
@@ -7,7 +7,7 @@ import {
   isBindableScreenComponent,
 } from './binding';
 import {
-  collectBoundDatasetIds,
+  collectScreenRuntimeDatasetIds,
   planScreenRuntimeQueries,
 } from './planner';
 import { screenRuntimeComponentRegistry } from './registry/builtin-plugins';
@@ -68,13 +68,21 @@ describe('digital screen runtime roles', () => {
     expect(plan[0].queryKey).toBe(plan[1].queryKey);
   });
 
-  it('collects only unique Dataset ids referenced by the screen bindings', () => {
+  it('collects only Dataset ids for queryable components in the active template', () => {
+    const template = {
+      components: [
+        component('line', 'line'),
+        component('bar', 'bar'),
+        component('map', 'map'),
+      ],
+    } as ScreenTemplate;
     const bindings: DigitalScreenBindings = {
       line: binding,
       bar: binding,
-      pie: { ...binding, datasetId: '99' },
+      map: { ...binding, datasetId: '77' },
+      removed: { ...binding, datasetId: '99' },
     };
 
-    expect(collectBoundDatasetIds(bindings)).toEqual(['12', '99']);
+    expect(collectScreenRuntimeDatasetIds(template, bindings)).toEqual(['12']);
   });
 });

--- a/yak-ops-ui/src/pages/digital-screen/runtime/runtime.test.ts
+++ b/yak-ops-ui/src/pages/digital-screen/runtime/runtime.test.ts
@@ -6,7 +6,10 @@ import {
   canQueryScreenComponent,
   isBindableScreenComponent,
 } from './binding';
-import { planScreenRuntimeQueries } from './planner';
+import {
+  collectBoundDatasetIds,
+  planScreenRuntimeQueries,
+} from './planner';
 import { screenRuntimeComponentRegistry } from './registry/builtin-plugins';
 
 const component = (type: ScreenComponent['type'], id = type) => ({
@@ -63,5 +66,15 @@ describe('digital screen runtime roles', () => {
 
     expect(plan).toHaveLength(2);
     expect(plan[0].queryKey).toBe(plan[1].queryKey);
+  });
+
+  it('collects only unique Dataset ids referenced by the screen bindings', () => {
+    const bindings: DigitalScreenBindings = {
+      line: binding,
+      bar: binding,
+      pie: { ...binding, datasetId: '99' },
+    };
+
+    expect(collectBoundDatasetIds(bindings)).toEqual(['12', '99']);
   });
 });

--- a/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
+++ b/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
@@ -8,7 +8,7 @@ import {
 import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import { useEffect, useMemo, useState } from 'react';
 import { useScreenRuntime } from '../../runtime/hooks/useScreenRuntime';
-import { collectBoundDatasetIds } from '../../runtime/planner';
+import { collectScreenRuntimeDatasetIds } from '../../runtime/planner';
 import { SCREEN_RUNTIME_VIEWER_REFRESH_INTERVAL_MS } from '../../runtime/policy';
 
 const EMPTY_BINDINGS: DigitalScreenBindings = {};
@@ -39,14 +39,18 @@ export function useDigitalScreenViewer(id?: string) {
       .finally(() => setIsLoading(false));
   }, [id]);
 
-  const boundDatasetIds = useMemo(
-    () => collectBoundDatasetIds(screen?.bindings ?? EMPTY_BINDINGS),
+  const template = useMemo(
+    () => (screen ? resolveScreenTemplateById(screen.templateId) : undefined),
     [screen],
   );
-  const boundDatasetKey = boundDatasetIds.join('|');
+  const runtimeDatasetIds = useMemo(
+    () => collectScreenRuntimeDatasetIds(template, screen?.bindings ?? EMPTY_BINDINGS),
+    [screen, template],
+  );
+  const runtimeDatasetKey = runtimeDatasetIds.join('|');
 
   useEffect(() => {
-    if (!boundDatasetIds.length) {
+    if (!runtimeDatasetIds.length) {
       setDatasets([]);
       setDataError('');
       return undefined;
@@ -54,7 +58,7 @@ export function useDigitalScreenViewer(id?: string) {
 
     const controller = new AbortController();
     setDataError('');
-    void getPublishedDatasetsByIds(boundDatasetIds, { signal: controller.signal })
+    void getPublishedDatasetsByIds(runtimeDatasetIds, { signal: controller.signal })
       .then((values) => {
         if (!controller.signal.aborted) setDatasets(values);
       })
@@ -65,12 +69,8 @@ export function useDigitalScreenViewer(id?: string) {
       });
 
     return () => controller.abort();
-  }, [boundDatasetIds, boundDatasetKey]);
+  }, [runtimeDatasetIds, runtimeDatasetKey]);
 
-  const template = useMemo(
-    () => (screen ? resolveScreenTemplateById(screen.templateId) : undefined),
-    [screen],
-  );
   const runtime = useScreenRuntime(
     template,
     screen?.bindings ?? EMPTY_BINDINGS,

--- a/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
+++ b/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
@@ -1,5 +1,5 @@
 import type { PublishedDataset } from '@/services/dataset';
-import { getPublishedDatasetsByIds } from '@/services/dataset';
+import { resolvePublishedDatasetsByIds } from '@/services/dataset';
 import {
   getPublishedDigitalScreen,
   type DigitalScreenBindings,
@@ -58,9 +58,14 @@ export function useDigitalScreenViewer(id?: string) {
 
     const controller = new AbortController();
     setDataError('');
-    void getPublishedDatasetsByIds(runtimeDatasetIds, { signal: controller.signal })
-      .then((values) => {
-        if (!controller.signal.aborted) setDatasets(values);
+    void resolvePublishedDatasetsByIds(runtimeDatasetIds, { signal: controller.signal })
+      .then(({ datasets: values, errors }) => {
+        if (controller.signal.aborted) return;
+        setDatasets(values);
+        const messages = Object.values(errors);
+        setDataError(messages.length
+          ? `${messages.length} 个绑定 Dataset 元数据加载失败：${messages[0]}`
+          : '');
       })
       .catch((error) => {
         if (controller.signal.aborted) return;
@@ -69,7 +74,7 @@ export function useDigitalScreenViewer(id?: string) {
       });
 
     return () => controller.abort();
-  }, [runtimeDatasetIds, runtimeDatasetKey]);
+  }, [runtimeDatasetKey]);
 
   const runtime = useScreenRuntime(
     template,

--- a/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
+++ b/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
@@ -8,8 +8,12 @@ import {
 import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import { useEffect, useMemo, useState } from 'react';
 import { useScreenRuntime } from '../../runtime/hooks/useScreenRuntime';
+import { SCREEN_RUNTIME_VIEWER_REFRESH_INTERVAL_MS } from '../../runtime/policy';
 
 const EMPTY_BINDINGS: DigitalScreenBindings = {};
+const VIEWER_RUNTIME_OPTIONS = {
+  refreshIntervalMs: SCREEN_RUNTIME_VIEWER_REFRESH_INTERVAL_MS,
+} as const;
 
 export function useDigitalScreenViewer(id?: string) {
   const [screen, setScreen] = useState<DigitalScreenInstance>();
@@ -55,7 +59,12 @@ export function useDigitalScreenViewer(id?: string) {
     () => (screen ? resolveScreenTemplateById(screen.templateId) : undefined),
     [screen],
   );
-  const runtime = useScreenRuntime(template, screen?.bindings ?? EMPTY_BINDINGS, datasets);
+  const runtime = useScreenRuntime(
+    template,
+    screen?.bindings ?? EMPTY_BINDINGS,
+    datasets,
+    VIEWER_RUNTIME_OPTIONS,
+  );
 
   return {
     screen,

--- a/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
+++ b/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
@@ -1,5 +1,5 @@
 import type { PublishedDataset } from '@/services/dataset';
-import { listPublishedDatasets } from '@/services/dataset';
+import { getPublishedDatasetsByIds } from '@/services/dataset';
 import {
   getPublishedDigitalScreen,
   type DigitalScreenBindings,
@@ -8,6 +8,7 @@ import {
 import { resolveScreenTemplateById } from '@/services/screen-template-service';
 import { useEffect, useMemo, useState } from 'react';
 import { useScreenRuntime } from '../../runtime/hooks/useScreenRuntime';
+import { collectBoundDatasetIds } from '../../runtime/planner';
 import { SCREEN_RUNTIME_VIEWER_REFRESH_INTERVAL_MS } from '../../runtime/policy';
 
 const EMPTY_BINDINGS: DigitalScreenBindings = {};
@@ -38,22 +39,33 @@ export function useDigitalScreenViewer(id?: string) {
       .finally(() => setIsLoading(false));
   }, [id]);
 
+  const boundDatasetIds = useMemo(
+    () => collectBoundDatasetIds(screen?.bindings ?? EMPTY_BINDINGS),
+    [screen],
+  );
+  const boundDatasetKey = boundDatasetIds.join('|');
+
   useEffect(() => {
-    let active = true;
+    if (!boundDatasetIds.length) {
+      setDatasets([]);
+      setDataError('');
+      return undefined;
+    }
+
+    const controller = new AbortController();
     setDataError('');
-    void listPublishedDatasets()
+    void getPublishedDatasetsByIds(boundDatasetIds, { signal: controller.signal })
       .then((values) => {
-        if (active) setDatasets(values);
+        if (!controller.signal.aborted) setDatasets(values);
       })
       .catch((error) => {
-        if (!active) return;
+        if (controller.signal.aborted) return;
         setDatasets([]);
-        setDataError(error instanceof Error ? error.message : '加载 Dataset 失败');
+        setDataError(error instanceof Error ? error.message : '加载大屏绑定 Dataset 失败');
       });
-    return () => {
-      active = false;
-    };
-  }, []);
+
+    return () => controller.abort();
+  }, [boundDatasetIds, boundDatasetKey]);
 
   const template = useMemo(
     () => (screen ? resolveScreenTemplateById(screen.templateId) : undefined),

--- a/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
+++ b/yak-ops-ui/src/pages/digital-screen/viewer/hooks/useDigitalScreenViewer.ts
@@ -74,7 +74,7 @@ export function useDigitalScreenViewer(id?: string) {
       });
 
     return () => controller.abort();
-  }, [runtimeDatasetKey]);
+  }, [runtimeDatasetIds, runtimeDatasetKey]);
 
   const runtime = useScreenRuntime(
     template,

--- a/yak-ops-ui/src/services/dataset/api.ts
+++ b/yak-ops-ui/src/services/dataset/api.ts
@@ -59,6 +59,11 @@ export interface DatasetRequestOptions {
 
 export type DatasetQueryOptions = DatasetRequestOptions;
 
+export interface PublishedDatasetBatchResult {
+  datasets: PublishedDataset[];
+  errors: Record<string, string>;
+}
+
 const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
     throw new Error(response?.message || response?.msg || fallback);
@@ -155,24 +160,47 @@ export const getPublishedDataset = async (
   return toDataset(detail);
 };
 
-/** Viewer-oriented batch lookup: only resolve the Dataset ids referenced by the screen. */
+/**
+ * Viewer-oriented tolerant lookup: keep healthy Dataset metadata available while surfacing
+ * failures for the specific ids that could not be resolved.
+ */
+export const resolvePublishedDatasetsByIds = async (
+  datasetIds: string[],
+  options?: DatasetRequestOptions,
+): Promise<PublishedDatasetBatchResult> => {
+  const uniqueIds = [...new Set(datasetIds.filter(Boolean))];
+  if (!uniqueIds.length) return { datasets: [], errors: {} };
+
+  const details = await Promise.allSettled(
+    uniqueIds.map((datasetId) => getPublishedDataset(datasetId, options)),
+  );
+  const datasets: PublishedDataset[] = [];
+  const errors: Record<string, string> = {};
+
+  details.forEach((result, index) => {
+    const datasetId = uniqueIds[index];
+    if (result.status === 'fulfilled') {
+      datasets.push(result.value);
+      return;
+    }
+    errors[datasetId] = result.reason instanceof Error
+      ? result.reason.message
+      : `Dataset ${datasetId} 元数据加载失败`;
+  });
+
+  return { datasets, errors };
+};
+
+/** Compatibility convenience for callers that only need successfully resolved metadata. */
 export const getPublishedDatasetsByIds = async (
   datasetIds: string[],
   options?: DatasetRequestOptions,
 ): Promise<PublishedDataset[]> => {
-  const uniqueIds = [...new Set(datasetIds.filter(Boolean))];
-  if (!uniqueIds.length) return [];
-  const details = await Promise.allSettled(
-    uniqueIds.map((datasetId) => getPublishedDataset(datasetId, options)),
-  );
-  const available = details
-    .filter((item): item is PromiseFulfilledResult<PublishedDataset> => item.status === 'fulfilled')
-    .map((item) => item.value);
-  if (!available.length) {
-    const rejected = details.find((item): item is PromiseRejectedResult => item.status === 'rejected');
-    throw rejected?.reason instanceof Error ? rejected.reason : new Error('读取大屏绑定 Dataset 失败');
+  const result = await resolvePublishedDatasetsByIds(datasetIds, options);
+  if (!result.datasets.length && Object.keys(result.errors).length) {
+    throw new Error(Object.values(result.errors)[0] || '读取大屏绑定 Dataset 失败');
   }
-  return available;
+  return result.datasets;
 };
 
 export const queryDataset = async (

--- a/yak-ops-ui/src/services/dataset/api.ts
+++ b/yak-ops-ui/src/services/dataset/api.ts
@@ -52,10 +52,12 @@ interface DatasetDetailWire {
   fields: DatasetFieldWire[];
 }
 
-export interface DatasetQueryOptions {
-  /** Allows runtime callers to cancel stale Dataset requests without changing the backend contract. */
+export interface DatasetRequestOptions {
+  /** Allows callers to cancel stale Dataset requests without changing the backend contract. */
   signal?: AbortSignal;
 }
+
+export type DatasetQueryOptions = DatasetRequestOptions;
 
 const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
@@ -63,6 +65,10 @@ const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   }
   return response.data;
 };
+
+const requestOptions = (options?: DatasetRequestOptions) => (
+  options?.signal ? { signal: options.signal } : undefined
+);
 
 const fieldType = (value: DatasetFieldWire['dataType']): DatasetFieldType => {
   switch (value) {
@@ -102,6 +108,18 @@ const toDataset = (detail: DatasetDetailWire): PublishedDataset => {
   };
 };
 
+const fetchDatasetDetail = async (
+  datasetId: string,
+  fallback: string,
+  options?: DatasetRequestOptions,
+) => unwrap(
+  await HttpUtils.get<DatasetDetailWire>(
+    `${DATASET_API}/${datasetId}`,
+    requestOptions(options),
+  ),
+  fallback,
+);
+
 export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => {
   const list = unwrap(
     await HttpUtils.get<DatasetSummaryWire[]>(DATASET_API),
@@ -110,8 +128,8 @@ export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => {
   const online = (list || []).filter((dataset) => dataset.status === 'ONLINE' && dataset.currentVersionId);
   if (!online.length) return [];
   const details = await Promise.allSettled(
-    online.map(async (dataset) => unwrap(
-      await HttpUtils.get<DatasetDetailWire>(`${DATASET_API}/${dataset.id}`),
+    online.map((dataset) => fetchDatasetDetail(
+      String(dataset.id),
       `查询 Dataset ${dataset.name} 详情失败`,
     )),
   );
@@ -125,6 +143,38 @@ export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => {
   return available;
 };
 
+/** Fetches one currently published Dataset without first loading the entire Dataset catalog. */
+export const getPublishedDataset = async (
+  datasetId: string,
+  options?: DatasetRequestOptions,
+): Promise<PublishedDataset> => {
+  const detail = await fetchDatasetDetail(datasetId, `查询 Dataset ${datasetId} 详情失败`, options);
+  if (detail.dataset.status !== 'ONLINE' || !detail.currentVersion) {
+    throw new Error(`Dataset ${datasetId} 当前未发布`);
+  }
+  return toDataset(detail);
+};
+
+/** Viewer-oriented batch lookup: only resolve the Dataset ids referenced by the screen. */
+export const getPublishedDatasetsByIds = async (
+  datasetIds: string[],
+  options?: DatasetRequestOptions,
+): Promise<PublishedDataset[]> => {
+  const uniqueIds = [...new Set(datasetIds.filter(Boolean))];
+  if (!uniqueIds.length) return [];
+  const details = await Promise.allSettled(
+    uniqueIds.map((datasetId) => getPublishedDataset(datasetId, options)),
+  );
+  const available = details
+    .filter((item): item is PromiseFulfilledResult<PublishedDataset> => item.status === 'fulfilled')
+    .map((item) => item.value);
+  if (!available.length) {
+    const rejected = details.find((item): item is PromiseRejectedResult => item.status === 'rejected');
+    throw rejected?.reason instanceof Error ? rejected.reason : new Error('读取大屏绑定 Dataset 失败');
+  }
+  return available;
+};
+
 export const queryDataset = async (
   datasetId: string,
   payload: DatasetQueryPayload,
@@ -133,7 +183,7 @@ export const queryDataset = async (
   await HttpUtils.post<DatasetQueryResult>(
     `${DATASET_API}/${datasetId}/query`,
     payload,
-    options?.signal ? { signal: options.signal } : undefined,
+    requestOptions(options),
   ),
   'Dataset 查询失败',
 );

--- a/yak-ops-ui/src/services/dataset/api.ts
+++ b/yak-ops-ui/src/services/dataset/api.ts
@@ -52,6 +52,11 @@ interface DatasetDetailWire {
   fields: DatasetFieldWire[];
 }
 
+export interface DatasetQueryOptions {
+  /** Allows runtime callers to cancel stale Dataset requests without changing the backend contract. */
+  signal?: AbortSignal;
+}
+
 const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
     throw new Error(response?.message || response?.msg || fallback);
@@ -123,8 +128,13 @@ export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => {
 export const queryDataset = async (
   datasetId: string,
   payload: DatasetQueryPayload,
+  options?: DatasetQueryOptions,
 ): Promise<DatasetQueryResult> => unwrap(
-  await HttpUtils.post<DatasetQueryResult>(`${DATASET_API}/${datasetId}/query`, payload),
+  await HttpUtils.post<DatasetQueryResult>(
+    `${DATASET_API}/${datasetId}/query`,
+    payload,
+    options?.signal ? { signal: options.signal } : undefined,
+  ),
   'Dataset 查询失败',
 );
 


### PR DESCRIPTION
## 背景

PR 3（#839）已经把 Digital Screen Runtime 拆成 Planner / Runtime Plugin Registry / Renderer Registry，但执行层仍然是：

```text
每个组件各发一个 Dataset 请求
+ Promise.allSettled 全并发
+ 无 cache
+ 无 request dedupe
+ 无 AbortController
+ Viewer 不自动刷新
```

本 PR 执行 PR 4：只治理 **Runtime 执行性能、生命周期和故障隔离**，不进入 PR 5 的全局筛选、组件联动和钻取。

## 核心执行链路

```text
ScreenTemplate + bindings + Datasets
               |
               v
             Planner
               |
               v
      ScreenRuntimeCandidate[]
               |
               v
       Stable QueryKey
               |
               v
      group identical query
               |
       +-------+--------+
       |                |
   TTL Cache       bounded queue
       |                |
       +-------+--------+
               |
               v
          Dataset API
          AbortSignal
               |
               v
     raw DatasetQueryResult
               |
               v
    component-specific adapter
               |
               v
       ScreenDataOverrides
```

## 1. Query-level request dedupe

Planner 现在为每个 candidate 预先生成：

```ts
payload
queryKey
```

QueryKey 包含：

```text
Dataset id
Dataset version
完整 DatasetQueryPayload
```

并使用稳定 JSON 序列化。

**组件类型不进入 QueryKey。**

因此例如：

```text
Line A ─┐
        ├─ 同 Dataset + 同 dimensions + 同 metrics -> 1 次 Dataset Query
Bar B  ─┘
```

拿到同一份原始 `DatasetQueryResult` 后，再分别通过 line / bar adapter 转换。

这样去重发生在正确的层级：**去重原始 Dataset Query，而不是错误地缓存组件/ECharts 数据。**

## 2. 新增 Runtime Executor

新增：

```text
runtime/executor.ts
```

职责：

- candidate 按 queryKey 分组
- cache lookup
- 唯一 query 并发调度
- Dataset Query
- AbortSignal 透传
- 原始结果分发给各组件 adapter
- component/query error 隔离
- execution stats

`useScreenRuntime` 不再直接 `Promise.allSettled(candidates.map(...))`。

## 3. Runtime 生命周期级 TTL Cache

新增：

```text
runtime/query-cache.ts
```

默认策略：

```text
TTL = 10 秒
max entries = 100
```

缓存内容：

```text
queryKey -> raw DatasetQueryResult
```

不是：

```text
queryKey -> ScreenComponentData / ECharts option
```

Cache 是 **每个 useScreenRuntime 实例独立持有**，不是全局 singleton：

```text
进入大屏 -> 创建 Runtime Executor + Cache
离开大屏 -> dispose + clear cache
```

避免不同大屏、不同页面之间出现难以控制的共享缓存状态。

## 4. Dataset 查询并发控制

新增：

```text
runtime/concurrency.ts
```

默认：

```text
maxConcurrency = 4
```

只限制唯一 Query Group，不是组件数量。

例如：

```text
20 个组件
-> 去重后 8 个 unique query
-> 同时最多执行 4 个
```

其余排队。

策略可通过 `useScreenRuntime(..., options)` 调整，最大值防御性限制为 16。

## 5. AbortController 真正进入 Dataset 请求链路

`services/dataset/queryDataset` 新增可选：

```ts
{ signal?: AbortSignal }
```

并直接透传已有 `HttpUtils -> request` 请求栈。

现有 request error handler 已明确把 Abort 识别为调用方主动取消，不会弹“网络异常”。

现在以下场景会取消 stale request：

- 修改组件 binding
- 切换模板 / Runtime plan
- Viewer / Editor 卸载
- 路由离开

因此旧请求即使后返回，也不会覆盖新配置的数据。

## 6. 自动刷新不会把慢查询反复打断

Viewer 默认：

```text
refreshInterval = 30 秒
```

但如果 30 秒到达时上一轮 Runtime execution 仍在运行：

```text
skip this refresh
```

不会：

```text
abort slow query
-> restart
-> 30s 后再 abort
-> 永远跑不完
```

真正导致旧结果失效的 binding/template/navigation 变化才会 Abort。

## 7. Page Visibility 感知

Viewer 自动刷新规则：

```text
页面可见 -> 每 30 秒刷新
页面隐藏 -> 暂停刷新
重新可见 -> 立即尝试刷新一次
```

如果重新可见时已有 query 正在执行，则跳过重叠刷新。

Editor 默认：

```text
refreshInterval = 0
```

继续保持事件驱动，不主动轮询 Dataset。

## 8. stale-while-refresh，刷新不再闪空屏

原 Runtime 每次执行都会：

```ts
data: {}
loadingIds: [...]
```

所以自动刷新时图表可能先空一下再恢复。

现在同一个 Runtime plan 刷新时：

```text
旧成功数据继续显示
        |
        +-- 新数据成功 -> 覆盖
        |
        +-- 某组件失败 -> 保留旧值 + 记录该组件 error
```

只有真正切换 binding / Dataset version / template plan 时才清理旧数据。

## 9. Viewer 不再加载全部在线 Dataset

这是 PR 4 检查时发现的另一个实际性能问题。

原 Viewer：

```text
GET /datasets
      |
      v
所有 ONLINE Dataset
      |
      v
N 次 GET /datasets/{id}
      |
      v
再从中找当前大屏需要的 Dataset
```

医院 Dataset 多时，播放一块大屏也会展开整个 Dataset catalog。

现在 Viewer：

```text
PublishedVersion
   + active template
   + bindings
        |
        v
Runtime Planner canQuery 规则
        |
        v
真正会执行的 Dataset ids (K)
        |
        v
仅 K 次 GET /datasets/{id}
```

Editor **仍保留全量 Dataset 列表**，因为绑定面板确实需要让用户选择 Dataset。

## 10. 过滤历史脏 binding

Viewer 的 Dataset metadata lookup 与 Planner 使用同一套 `canQueryScreenComponent` 语义。

因此下面这些不会再产生无意义 detail 请求：

- 已从模板删除的组件遗留 binding
- map / ticker / text 的历史 binding
- dimensions / metrics 不满足组件查询要求的 binding

## 11. Dataset 元数据部分失败不会拖垮整屏

针对 Viewer 的 Dataset metadata batch 读取新增 tolerant result：

```ts
{
  datasets: PublishedDataset[];
  errors: Record<datasetId, string>;
}
```

例如 3 个绑定 Dataset：

```text
A -> success
B -> success
C -> failed
```

结果：

```text
A/B 组件继续正常运行
C 不执行 query
Viewer 显示 Dataset metadata failure 提示
```

不会因为单个 Dataset 元数据异常把整个大屏的正常组件全部清空，也不会静默失败。

## 12. Runtime execution diagnostics

`ScreenRuntimeState` 新增执行统计：

```text
candidateCount
uniqueQueryCount
deduplicatedCount
networkQueryCount
cacheHitQueryCount
lastUpdatedAt
isRefreshing
refresh()
```

当前没有额外做 Debug UI，但运行时诊断数据已经准备好，后续需要时可以接入开发者面板或监控。

## 默认 Runtime Policy

集中在：

```text
runtime/policy.ts
```

默认：

```ts
{
  debounceMs: 180,
  cacheTtlMs: 10_000,
  maxConcurrency: 4,
  refreshIntervalMs: 0,
}
```

Viewer 单独覆盖：

```text
refreshIntervalMs = 30_000
```

## 新增测试

新增：

```text
runtime/concurrency.test.ts
runtime/query-cache.test.ts
runtime/executor.test.ts
```

并扩展：

```text
runtime/runtime.test.ts
```

覆盖：

- 并发数不会超过上限
- AbortSignal 在执行前取消
- TTL cache 命中 / 过期
- LRU eviction
- line / bar 相同 query key
- 两个组件共享一次 raw Dataset Query
- 第二次执行命中 cache
- grouped query failure 隔离
- Viewer Dataset id 仅收集 active template 中真正 queryable 的绑定

## 明确不在本 PR 范围

- 不做全局筛选器
- 不做组件联动
- 不做下钻 / drill-down
- 不做 cross-filter
- 不做 Runtime 全局 singleton cache
- 不做 Redis / 服务端 query cache
- 不改 Dataset 后端查询语义
- 不改 Digital Screen Draft / PublishedVersion
- 不改数据库

上述交互能力继续放在 PR 5。

## 当前验证状态

- ✅ PR 3 #839 已合并
- ✅ 本分支直接基于 PR 3 merge 后的最新 `main`
- ✅ 当前 `behind=0`
- ✅ 最终 diff 仅涉及 Digital Screen frontend runtime / Viewer / Dataset frontend service
- ✅ 没有后端 / Flyway / DB 改动
- ✅ queryDataset 原有两参数调用保持兼容，AbortSignal 为可选第三参数
- ✅ Editor 仍加载完整 Published Dataset catalog
- ✅ Viewer 改为仅加载 Runtime 真正使用的 Dataset metadata
- ✅ 自动刷新不会与仍在执行的慢 query 重叠
- ✅ PR 5 的 filter / linkage / drill-down 未提前混入
- ⚠️ 当前执行环境无法 checkout GitHub 仓库，因此未实际执行 `npm run tsc` / Jest / 浏览器回归

## 合并前建议最小验证

```bash
cd yak-ops-ui
npm run tsc
npm run jest -- \
  src/pages/digital-screen/runtime/runtime.test.ts \
  src/pages/digital-screen/runtime/executor.test.ts \
  src/pages/digital-screen/runtime/query-cache.test.ts \
  src/pages/digital-screen/runtime/concurrency.test.ts \
  src/components/screen-engine/runtime/renderer-registry.test.tsx
```

浏览器 Network 面板建议验证：

1. Editor 给 line / bar 绑定完全相同的 Dataset + dimensions + metrics，确认同轮只发 1 个 `/query`
2. 快速连续切换 binding，旧 query 应被取消且不能覆盖新数据
3. Viewer 打开时只请求当前 PublishedVersion 真正绑定的 Dataset detail，不再展开所有 ONLINE Dataset
4. Viewer 保持打开约 30 秒，确认发生下一轮数据刷新
5. 切到后台超过 30 秒，确认后台不持续轮询；切回前台触发刷新
6. 制造一个超过刷新间隔的慢 query，确认不会每 30 秒被 abort/restart
7. 刷新期间图表保持上一份成功数据，不出现先清空再恢复
8. 让一个 Dataset 查询失败，其他 Dataset 组件继续正常刷新
9. 让一个绑定 Dataset metadata 加载失败，其他 Dataset 组件仍正常显示并能看到失败提示
10. table（limit=100）和 chart（limit=200）保持不同 query key，不应错误去重
