### PR TITLE
fix(data-service): Stage 1 runtime reliability plane

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/README.md
+++ b/yak-ops-business/yak-ops-business-data-service/README.md
@@ -11,6 +11,7 @@
 | [ARCHITECTURE.md](ARCHITECTURE.md) | 包职责、角色协作、关键流程和扩展边界 |
 | [DEPENDENCIES.md](DEPENDENCIES.md) | 顶层 package 依赖矩阵、允许/禁止的 corridor |
 | [REVIEW.md](REVIEW.md) | 修改本模块时的设计与 Review Checklist |
+| [RUNTIME_RELIABILITY.md](RUNTIME_RELIABILITY.md) | Stage 1 调用结果/审计隔离、版本化缓存和服务级日志读取契约 |
 | [../../CODE_STYLE.md](../../CODE_STYLE.md) | 仓库统一 Java / Role-oriented 工程约定 |
 
 ## 能力地图
@@ -67,6 +68,8 @@ dataservice
 5. `API_KEY` 的 raw secret 只在 create/rotate 成功时返回一次；数据库只保存 hash + prefix。
 6. 数据服务只允许单条只读 SELECT，物理执行统一走 `yak-ops-core` 的 `SqlExecutionRuntime`。
 7. Data Development 等上游模块只能实现 `publication.source.DataServiceSourceProvider`，不能依赖 Data Service 内部 Manager/Repository/Runtime。
+8. Invocation audit 是 evidence：日志持久化故障不能改变已经确定的业务调用结果或覆盖原始异常。
+9. Node-local Cache identity 必须带 persisted runtime generation，防止 republish 后跨节点误用旧代际结果。
 
 ## 修改入口
 
@@ -80,5 +83,7 @@ dataservice
 5. Tests / Guards  -> 是否有对应行为和架构护栏？
 6. REVIEW.md       -> 合并前逐项检查。
 ```
+
+涉及调用审计、Cache identity 或服务级调用日志读取时，同时查看 `RUNTIME_RELIABILITY.md`。
 
 如果需求无法由当前模型表达，先报告 `Requirement Gap` / `Domain Gap`，不要用临时 Map key、boolean、PO 字段或 Controller DTO 绕过模型。

--- a/yak-ops-business/yak-ops-business-data-service/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-data-service/REQUIREMENTS.md
@@ -86,6 +86,7 @@ Source Provider
 - 服务停用、删除、重新发布关键 Runtime 配置时必须使本机旧状态失效。
 - Circuit 打开时返回 503。
 - Cache key 必须覆盖 compiled SQL 和绑定值；分页控制也必须进入 key，避免页间串数据。
+- Cache identity 还必须包含服务端持久化的 Runtime generation / Source Revision 身份；即使另一 JVM 未收到本地 invalidation，也不能让新 Revision 命中旧 Revision 的缓存结果。
 - 本地 Metrics 可以用于运行诊断，但不能反向覆盖持久化业务状态。
 
 ## 7. Documentation / OpenAPI
@@ -100,7 +101,7 @@ Source Provider
 
 ## 8. Observability
 
-每次真实调用必须能记录：
+正常情况下，每次真实调用必须能记录：
 
 - Data Service ID / 名称 / Path 快照；
 - Caller 类型；
@@ -111,6 +112,13 @@ Source Provider
 - row count；
 - error message；
 - create time。
+
+调用审计是 evidence，不是业务结果 Truth：
+
+- 调用日志持久化失败不能把已经成功的查询变成失败响应；
+- 调用日志持久化失败不能覆盖原始 SQL / 鉴权 / 限流异常；
+- 审计故障允许降级为内部告警/日志，业务调用语义保持原状；
+- 单个服务详情的调用记录必须支持按 Data Service ID 有界读取，不能依赖“读取全局最近日志后在浏览器过滤”。
 
 运行概览需要支持 `24h / 7d / 30d`，至少提供 API 数量、启停数量、调用量、成功率、平均耗时、返回行数、趋势、热点 API 和近期失败。
 

--- a/yak-ops-business/yak-ops-business-data-service/RUNTIME_RELIABILITY.md
+++ b/yak-ops-business/yak-ops-business-data-service/RUNTIME_RELIABILITY.md
@@ -1,0 +1,112 @@
+# Data Service Stage 1: Runtime Reliability Plane
+
+Stage 1 不引入 Project/RBAC，也不把当前 JVM-local Runtime 强行改造成分布式系统。目标是先保证：**业务调用结果、审计证据、缓存代际和详情查询互不拖垮。**
+
+## 1. Invocation result 与 Audit evidence 解耦
+
+```text
+DataServiceInvoker
+   |
+   +-- authorize / compile / query / runtime protection
+   |        |
+   |        v
+   |   business result / original failure
+   |
+   +-- best-effort invocation audit
+```
+
+固定规则：
+
+- SQL 查询已经成功时，调用日志 INSERT 失败不能把 HTTP 调用改成失败；
+- SQL / 401 / 429 / 503 等原始异常已经产生时，审计失败不能替换原始异常；
+- Recorder 仍保持同步 evidence 写入，以保留当前日志时序和落库语义，但 Invoker 对 Recorder 故障做最终隔离；
+- 审计失败仅写内部 warning，不记录 raw API key，也不把请求参数重新输出到应用日志。
+
+这一步解决的是 **failure isolation**，不是异步日志吞吐。后续如果需要高吞吐审计队列，应单独设计 bounded queue / durable outbox，不在本阶段偷换调用日志语义。
+
+## 2. Version-safe local cache identity
+
+当前 Cache 仍是 Caffeine/JVM-local，但 Cache Key 不能只包含 SQL 和 bindings：
+
+```text
+cache key
+  = persisted runtime namespace
+  + compiled SQL
+  + bindings
+  + pagination identity
+```
+
+persisted runtime namespace 至少覆盖：
+
+- stable Data Service ID；
+- sourceType/sourceRef；
+- sourceRevisionId/sourceRevisionNo；
+- persisted definition update generation。
+
+因此：
+
+```text
+Revision R1 on Pod B
+   !=
+Revision R2 on Pod A/Pod B
+```
+
+即使 Pod B 没收到 Pod A 的本地 `invalidate()`，当它下一次从 DB 读取到新 generation 后也不会命中旧 generation 的缓存结果。
+
+这不是分布式缓存；它只是让当前 local cache 在多实例部署时具备更安全的版本隔离。
+
+## 3. Service-scoped invocation log read
+
+详情页禁止继续使用：
+
+```text
+GET all recent logs
+  -> browser filter(apiId)
+```
+
+Stage 1 增加：
+
+```text
+GET /api/v1/data-service/{id}/logs?limit=50
+```
+
+Repository 使用：
+
+```text
+WHERE api_id = ?
+ORDER BY create_time DESC, id DESC
+LIMIT ?
+```
+
+并增加索引：
+
+```text
+(api_id, create_time, id)
+```
+
+详情页同时改用 `GET /api/v1/data-service/{id}`，不再先加载所有 Data Service 再 `find(id)`。
+
+## 4. Stage 1 tests
+
+关键行为测试必须覆盖：
+
+- audit repository/recorder failure 不影响成功 invocation；
+- audit failure 不覆盖原始 datasource failure；
+- audit failure 不覆盖原始 authorization failure；
+- persisted runtime generation 变化会产生不同 cache namespace/key；
+- 原有 local cache reuse / circuit breaker 行为保持不变。
+
+## 5. Explicit non-goals
+
+本阶段不做：
+
+- Data Service Project/RBAC；
+- Redis/global cache；
+- distributed rate limit；
+- cluster metrics aggregation；
+- cross-node invalidation bus；
+- invocation log retention / rollup；
+- sensitive parameter masking；
+- async/durable audit pipeline。
+
+这些分别进入后续 Governance / Cluster Runtime 阶段。

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceRuntimeController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceRuntimeController.java
@@ -55,6 +55,14 @@ public class DataServiceRuntimeController {
   @GetMapping("/logs/recent")
   public Result<List<InvocationRecord>> logs() { return Result.success(callLogReader.recent()); }
 
+  @Operation(summary = "查询指定数据服务最近调用记录")
+  @GetMapping("/{id}/logs")
+  public Result<List<InvocationRecord>> logsByApi(
+      @PathVariable("id") Long id,
+      @RequestParam(value = "limit", defaultValue = "50") int limit) {
+    return Result.success(callLogReader.recentByApi(id, limit));
+  }
+
   @Operation(summary = "调用已发布的数据服务")
   @GetMapping("/runtime/{*servicePath}")
   public Result<DataServiceQueryResponse> invoke(@PathVariable("servicePath") String servicePath,

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.dataservice.access.DataServiceRateLimitException;
 import io.yak.ops.business.dataservice.access.DataServiceUnauthorizedException;
 import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
 import io.yak.ops.business.dataservice.domain.DataServiceQueryResponse;
+import io.yak.ops.business.dataservice.domain.SourceReference;
 import io.yak.ops.business.dataservice.domain.access.AccessContext;
 import io.yak.ops.business.dataservice.query.DataServiceReader;
 import io.yak.ops.business.dataservice.runtime.LocalDataServiceRuntime;
@@ -14,6 +15,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -21,6 +24,7 @@ import org.springframework.util.StringUtils;
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataServiceInvoker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataServiceInvoker.class);
   private static final int DEFAULT_PAGE_SIZE = 20;
   private final DataServiceReader reader;
   private final DataServiceAuthorizer authorizer;
@@ -40,7 +44,7 @@ public class DataServiceInvoker {
     try {
       access = authorizer.authorize(definition, rawApiKey);
     } catch (DataServiceUnauthorizedException | DataServiceRateLimitException exception) {
-      recorder.record(definition, parameters, false, 0L, 0, safeMessage(exception), AccessContext.rejectedApiKey());
+      audit(definition, parameters, false, 0L, 0, safeMessage(exception), AccessContext.rejectedApiKey());
       throw exception;
     }
     return execute(definition, parameters, access, true);
@@ -61,18 +65,62 @@ public class DataServiceInvoker {
           bindings.add("__yak_page_size=" + pagination.pageSize());
           bindings.add("__yak_return_total=" + pagination.returnTotalNum());
         }
-        String cacheKey = runtime.cacheKey(compiled.sql(), bindings);
+        String cacheKey = runtime.cacheKey(runtimeNamespace(definition), compiled.sql(), bindings);
         response = runtime.execute(definition.id(), definition.runtimePolicy(), cacheKey,
             () -> queryExecutor.execute(definition, compiled, pagination));
       } else {
         response = queryExecutor.execute(definition, compiled, pagination);
       }
-      recorder.record(definition, parameters, true, response.durationMs(), response.rowCount(), null, access);
+      audit(definition, parameters, true, response.durationMs(), response.rowCount(), null, access);
       return response;
     } catch (RuntimeException exception) {
-      recorder.record(definition, parameters, false, elapsedMs(started), 0, safeMessage(exception), access);
+      audit(definition, parameters, false, elapsedMs(started), 0, safeMessage(exception), access);
       throw exception;
     }
+  }
+
+  /**
+   * Invocation audit is evidence, not the business result. A logging outage must never turn a
+   * successful query into a failed API call or replace the original invocation exception.
+   */
+  private void audit(
+      DataServiceDefinition definition,
+      Map<String, String> parameters,
+      boolean success,
+      long durationMs,
+      int rowCount,
+      String errorMessage,
+      AccessContext access) {
+    try {
+      recorder.record(definition, parameters, success, durationMs, rowCount, errorMessage, access);
+    } catch (RuntimeException auditFailure) {
+      LOGGER.warn(
+          "Data Service invocation audit failed: apiId={}, success={}, cause={}",
+          definition == null ? null : definition.id(),
+          success,
+          safeMessage(auditFailure));
+    }
+  }
+
+  /**
+   * Persisted generation namespace protects node-local caches after republish/settings updates even
+   * when another JVM did not receive the local invalidation call.
+   */
+  String runtimeNamespace(DataServiceDefinition definition) {
+    SourceReference source = definition.sourceReference();
+    return new StringBuilder("api=")
+        .append(definition.id())
+        .append("|source=")
+        .append(source.sourceType())
+        .append(':')
+        .append(source.sourceRef())
+        .append("|revision=")
+        .append(source.sourceRevisionId())
+        .append(':')
+        .append(source.sourceRevisionNo())
+        .append("|generation=")
+        .append(definition.updateTime())
+        .toString();
   }
 
   private DataServicePagination pagination(DataServiceDefinition definition, Map<String, String> parameters) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceCallLogReader.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceCallLogReader.java
@@ -11,6 +11,14 @@ import org.springframework.stereotype.Component;
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataServiceCallLogReader {
+  private static final int DEFAULT_RECENT_LIMIT = 200;
   private final DataServiceCallLogRepository repository;
-  public List<InvocationRecord> recent() { return repository.recent(200); }
+
+  public List<InvocationRecord> recent() {
+    return repository.recent(DEFAULT_RECENT_LIMIT);
+  }
+
+  public List<InvocationRecord> recentByApi(Long apiId, int limit) {
+    return repository.recentByApi(apiId, Math.max(1, Math.min(200, limit)));
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceCallLogRepository.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceCallLogRepository.java
@@ -10,5 +10,7 @@ public interface DataServiceCallLogRepository {
 
   List<InvocationRecord> recent(int limit);
 
+  List<InvocationRecord> recentByApi(Long apiId, int limit);
+
   List<InvocationRecord> between(LocalDateTime from, LocalDateTime to);
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceCallLogRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceCallLogRepositoryAdapter.java
@@ -26,9 +26,24 @@ public class DataServiceCallLogRepositoryAdapter implements DataServiceCallLogRe
 
   @Override
   public List<InvocationRecord> recent(int limit) {
-    int size = Math.max(1, Math.min(1_000, limit));
+    int size = normalizeLimit(limit);
     return mapper.selectList(
             Wrappers.<DataServiceCallLogPO>lambdaQuery()
+                .orderByDesc(DataServiceCallLogPO::getCreateTime)
+                .orderByDesc(DataServiceCallLogPO::getId)
+                .last("LIMIT " + size))
+        .stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public List<InvocationRecord> recentByApi(Long apiId, int limit) {
+    if (apiId == null || apiId <= 0L) {
+      throw new IllegalArgumentException("数据服务 ID 必须大于 0");
+    }
+    int size = normalizeLimit(limit);
+    return mapper.selectList(
+            Wrappers.<DataServiceCallLogPO>lambdaQuery()
+                .eq(DataServiceCallLogPO::getApiId, apiId)
                 .orderByDesc(DataServiceCallLogPO::getCreateTime)
                 .orderByDesc(DataServiceCallLogPO::getId)
                 .last("LIMIT " + size))
@@ -44,6 +59,10 @@ public class DataServiceCallLogRepositoryAdapter implements DataServiceCallLogRe
                 .orderByAsc(DataServiceCallLogPO::getCreateTime)
                 .orderByAsc(DataServiceCallLogPO::getId))
         .stream().map(this::toDomain).toList();
+  }
+
+  private int normalizeLimit(int limit) {
+    return Math.max(1, Math.min(1_000, limit));
   }
 
   private InvocationRecord toDomain(DataServiceCallLogPO po) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/LocalDataServiceRuntime.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/LocalDataServiceRuntime.java
@@ -68,8 +68,15 @@ public class LocalDataServiceRuntime {
     return response;
   }
 
-  public String cacheKey(String compiledSql, List<Object> bindings) {
-    StringBuilder raw = new StringBuilder(compiledSql == null ? "" : compiledSql).append('\u001f');
+  /**
+   * Cache identity includes a persisted runtime namespace so a republish/settings generation cannot
+   * accidentally reuse an older node-local cache entry when cross-node invalidation is unavailable.
+   */
+  public String cacheKey(String namespace, String compiledSql, List<Object> bindings) {
+    StringBuilder raw = new StringBuilder(namespace == null ? "" : namespace)
+        .append('\u001d')
+        .append(compiledSql == null ? "" : compiledSql)
+        .append('\u001f');
     if (bindings != null) {
       for (Object value : bindings) {
         raw.append(value == null ? "<null>" : value.getClass().getName() + ':' + value).append('\u001e');
@@ -81,6 +88,11 @@ public class LocalDataServiceRuntime {
     } catch (Exception exception) {
       throw new IllegalStateException("无法生成数据服务缓存 Key", exception);
     }
+  }
+
+  /** Compatibility overload for callers/tests that do not yet supply a runtime generation. */
+  public String cacheKey(String compiledSql, List<Object> bindings) {
+    return cacheKey("", compiledSql, bindings);
   }
 
   public DataServiceRuntimeSnapshot snapshot(Long apiId, RuntimePolicy policy) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V11__add_data_service_api_log_index.sql
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V11__add_data_service_api_log_index.sql
@@ -1,0 +1,3 @@
+-- Support detail-page reads: WHERE api_id = ? ORDER BY create_time DESC, id DESC LIMIT ?.
+ALTER TABLE yak_ops_data_service_call_log
+    ADD KEY idx_yak_ops_data_service_log_api_time_id (api_id, create_time, id);

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServiceRuntimeControllerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/controller/v1/DataServiceRuntimeControllerTest.java
@@ -1,0 +1,25 @@
+package io.yak.ops.business.dataservice.controller.v1;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.yak.ops.business.dataservice.execution.DataServiceInvoker;
+import io.yak.ops.business.dataservice.observability.DataServiceCallLogReader;
+import io.yak.ops.business.dataservice.runtime.DataServiceRuntimePolicyManager;
+import org.junit.jupiter.api.Test;
+
+class DataServiceRuntimeControllerTest {
+
+  @Test
+  void serviceLogsDelegateToBoundedServiceReader() {
+    DataServiceCallLogReader reader = mock(DataServiceCallLogReader.class);
+    DataServiceRuntimeController controller = new DataServiceRuntimeController(
+        mock(DataServiceRuntimePolicyManager.class),
+        mock(DataServiceInvoker.class),
+        reader);
+
+    controller.logsByApi(7L, 50);
+
+    verify(reader).recentByApi(7L, 50);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -63,21 +64,21 @@ class DataServiceInvokerTest {
         false,
         1,
         8L);
-    when(executor.execute(eq(definition), any(), eq(null))).thenReturn(response);
+    when(executor.execute(eq(definition), any(), isNull())).thenReturn(response);
     doThrow(new IllegalStateException("audit db down"))
         .when(recorder)
-        .record(eq(definition), any(), eq(true), anyLong(), eq(1), eq(null), any());
+        .record(eq(definition), any(), eq(true), anyLong(), eq(1), isNull(), any());
 
     DataServiceQueryResponse result = invoker.invoke("orders", Map.of("id", "1"), null);
 
     assertThat(result.rows()).containsExactly(Map.of("id", 1L));
-    verify(executor).execute(eq(definition), any(), eq(null));
+    verify(executor).execute(eq(definition), any(), isNull());
   }
 
   @Test
   void invocationFailureIsNotReplacedByAuditStorageFailure() {
     IllegalStateException queryFailure = new IllegalStateException("datasource down");
-    when(executor.execute(eq(definition), any(), eq(null))).thenThrow(queryFailure);
+    when(executor.execute(eq(definition), any(), isNull())).thenThrow(queryFailure);
     doThrow(new IllegalStateException("audit db down"))
         .when(recorder)
         .record(eq(definition), any(), eq(false), anyLong(), eq(0), eq("datasource down"), any());

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
@@ -1,0 +1,128 @@
+package io.yak.ops.business.dataservice.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.access.DataServiceAuthorizer;
+import io.yak.ops.business.dataservice.access.DataServiceUnauthorizedException;
+import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
+import io.yak.ops.business.dataservice.domain.DataServiceQueryResponse;
+import io.yak.ops.business.dataservice.domain.DataServiceSettings;
+import io.yak.ops.business.dataservice.domain.PublishedRuntimeSnapshot;
+import io.yak.ops.business.dataservice.domain.RuntimePolicy;
+import io.yak.ops.business.dataservice.domain.SourceReference;
+import io.yak.ops.business.dataservice.domain.access.AccessContext;
+import io.yak.ops.business.dataservice.domain.access.AuthMode;
+import io.yak.ops.business.dataservice.query.DataServiceReader;
+import io.yak.ops.business.dataservice.runtime.LocalDataServiceRuntime;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DataServiceInvokerTest {
+
+  private DataServiceReader reader;
+  private DataServiceAuthorizer authorizer;
+  private DataServiceQueryExecutor executor;
+  private DataServiceInvocationRecorder recorder;
+  private DataServiceInvoker invoker;
+  private DataServiceDefinition definition;
+
+  @BeforeEach
+  void setUp() {
+    reader = mock(DataServiceReader.class);
+    authorizer = mock(DataServiceAuthorizer.class);
+    executor = mock(DataServiceQueryExecutor.class);
+    recorder = mock(DataServiceInvocationRecorder.class);
+    invoker = new DataServiceInvoker(
+        reader,
+        authorizer,
+        new DataServiceSqlCompiler(),
+        executor,
+        new LocalDataServiceRuntime(),
+        recorder);
+    definition = definition();
+    when(reader.requireByPath("/orders")).thenReturn(definition);
+    when(authorizer.authorize(definition, null)).thenReturn(AccessContext.publicAccess());
+  }
+
+  @Test
+  void successfulInvocationIsNotFailedByAuditStorageOutage() {
+    DataServiceQueryResponse response = new DataServiceQueryResponse(
+        List.of("id"),
+        List.of(Map.of("id", 1L)),
+        false,
+        1,
+        8L);
+    when(executor.execute(eq(definition), any(), eq(null))).thenReturn(response);
+    doThrow(new IllegalStateException("audit db down"))
+        .when(recorder)
+        .record(eq(definition), any(), eq(true), any(Long.class), eq(1), eq(null), any());
+
+    DataServiceQueryResponse result = invoker.invoke("orders", Map.of("id", "1"), null);
+
+    assertThat(result.rows()).containsExactly(Map.of("id", 1L));
+    verify(executor).execute(eq(definition), any(), eq(null));
+  }
+
+  @Test
+  void invocationFailureIsNotReplacedByAuditStorageFailure() {
+    IllegalStateException queryFailure = new IllegalStateException("datasource down");
+    when(executor.execute(eq(definition), any(), eq(null))).thenThrow(queryFailure);
+    doThrow(new IllegalStateException("audit db down"))
+        .when(recorder)
+        .record(eq(definition), any(), eq(false), any(Long.class), eq(0), eq("datasource down"), any());
+
+    assertThatThrownBy(() -> invoker.invoke("/orders", Map.of("id", "1"), null))
+        .isSameAs(queryFailure);
+  }
+
+  @Test
+  void authorizationFailureKeepsItsOriginalHttpSemanticWhenAuditFails() {
+    DataServiceUnauthorizedException unauthorized =
+        new DataServiceUnauthorizedException("invalid api key");
+    when(authorizer.authorize(definition, "bad-key")).thenThrow(unauthorized);
+    doThrow(new IllegalStateException("audit db down"))
+        .when(recorder)
+        .record(eq(definition), any(), eq(false), eq(0L), eq(0), eq("invalid api key"), any());
+
+    assertThatThrownBy(() -> invoker.invoke("/orders", Map.of("id", "1"), "bad-key"))
+        .isSameAs(unauthorized);
+  }
+
+  @Test
+  void runtimeNamespaceChangesWhenPersistedGenerationChanges() {
+    DataServiceDefinition newer = DataServiceDefinition.restore(
+        7L,
+        definition.settings(),
+        definition.runtimeSnapshot(),
+        new SourceReference("TEST", "orders", 102L, 2),
+        definition.runtimePolicy(),
+        AuthMode.NONE,
+        LocalDateTime.of(2026, 8, 28, 10, 0),
+        LocalDateTime.of(2026, 8, 28, 10, 10));
+
+    assertThat(invoker.runtimeNamespace(definition))
+        .isNotEqualTo(invoker.runtimeNamespace(newer));
+  }
+
+  private DataServiceDefinition definition() {
+    return DataServiceDefinition.restore(
+        7L,
+        new DataServiceSettings("Orders", "/orders", 100, 30, true, null, false),
+        new PublishedRuntimeSnapshot(9L, "select id from orders where id = :id"),
+        new SourceReference("TEST", "orders", 101L, 1),
+        new RuntimePolicy(false, 60, 100, false, 5, 30),
+        AuthMode.NONE,
+        LocalDateTime.of(2026, 8, 28, 10, 0),
+        LocalDateTime.of(2026, 8, 28, 10, 0));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.dataservice.execution;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -65,7 +66,7 @@ class DataServiceInvokerTest {
     when(executor.execute(eq(definition), any(), eq(null))).thenReturn(response);
     doThrow(new IllegalStateException("audit db down"))
         .when(recorder)
-        .record(eq(definition), any(), eq(true), any(Long.class), eq(1), eq(null), any());
+        .record(eq(definition), any(), eq(true), anyLong(), eq(1), eq(null), any());
 
     DataServiceQueryResponse result = invoker.invoke("orders", Map.of("id", "1"), null);
 
@@ -79,7 +80,7 @@ class DataServiceInvokerTest {
     when(executor.execute(eq(definition), any(), eq(null))).thenThrow(queryFailure);
     doThrow(new IllegalStateException("audit db down"))
         .when(recorder)
-        .record(eq(definition), any(), eq(false), any(Long.class), eq(0), eq("datasource down"), any());
+        .record(eq(definition), any(), eq(false), anyLong(), eq(0), eq("datasource down"), any());
 
     assertThatThrownBy(() -> invoker.invoke("/orders", Map.of("id", "1"), null))
         .isSameAs(queryFailure);

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceCallLogReaderTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceCallLogReaderTest.java
@@ -1,0 +1,29 @@
+package io.yak.ops.business.dataservice.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.domain.InvocationRecord;
+import io.yak.ops.business.dataservice.repository.DataServiceCallLogRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataServiceCallLogReaderTest {
+
+  @Test
+  void readsOnlyTheRequestedServiceWithBoundedLimit() {
+    DataServiceCallLogRepository repository = mock(DataServiceCallLogRepository.class);
+    InvocationRecord record = new InvocationRecord(
+        1L, 7L, "Orders", "/orders", "PUBLIC", null, null, null,
+        "{}", true, 10L, 1, null, LocalDateTime.now());
+    when(repository.recentByApi(7L, 200)).thenReturn(List.of(record));
+
+    DataServiceCallLogReader reader = new DataServiceCallLogReader(repository);
+
+    assertThat(reader.recentByApi(7L, 999)).containsExactly(record);
+    verify(repository).recentByApi(7L, 200);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/runtime/LocalDataServiceRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/runtime/LocalDataServiceRuntimeTest.java
@@ -27,6 +27,18 @@ class LocalDataServiceRuntimeTest {
   }
 
   @Test
+  void runtimeGenerationParticipatesInCacheIdentity() {
+    LocalDataServiceRuntime runtime = new LocalDataServiceRuntime();
+
+    String revisionOne = runtime.cacheKey("api=1|revision=10:1", "select ?", List.of(7));
+    String revisionTwo = runtime.cacheKey("api=1|revision=11:2", "select ?", List.of(7));
+
+    assertThat(revisionOne).isNotEqualTo(revisionTwo);
+    assertThat(revisionOne)
+        .isEqualTo(runtime.cacheKey("api=1|revision=10:1", "select ?", List.of(7)));
+  }
+
+  @Test
   void circuitOpensAfterConfiguredFailures() {
     LocalDataServiceRuntime runtime = new LocalDataServiceRuntime();
     RuntimePolicy policy = new RuntimePolicy(false, 60, 20, true, 1, 30);

--- a/yak-ops-ui/src/pages/data-service/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/detail/index.tsx
@@ -1,4 +1,19 @@
 import YakTab from '@/components/YakTab';
+import {
+  DATA_SERVICE_NODE_SOURCE,
+  LEGACY_DATA_DEVELOPMENT_RELEASE_SOURCE,
+  getDataService,
+  getDataServiceRuntime,
+  listDataServiceDataSources,
+  listDataServiceKeys,
+  listDataServiceLogs,
+  type DataServiceApi,
+  type DataServiceApiKey,
+  type DataServiceCallLog,
+  type DataServiceRuntimeStatus,
+  type DataSourceOption,
+} from '@/services/data-service';
+import { BRAND_THEME } from '@/styles/brand';
 import { history, useParams } from '@umijs/max';
 import {
   Button,
@@ -12,23 +27,6 @@ import {
 } from 'antd';
 import { ArrowLeft, PlayCircle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
-
-import { BRAND_THEME } from '@/styles/brand';
-
-import {
-  DATA_SERVICE_NODE_SOURCE,
-  LEGACY_DATA_DEVELOPMENT_RELEASE_SOURCE,
-  fetchDataServiceKeys,
-  fetchDataServiceLogs,
-  fetchDataServiceRuntime,
-  fetchDataServices,
-  fetchDataSourceOptions,
-  type DataServiceApi,
-  type DataServiceApiKey,
-  type DataServiceCallLog,
-  type DataServiceRuntimeStatus,
-  type DataSourceOption,
-} from '../service';
 
 type DetailTabKey = 'overview' | 'access' | 'runtime' | 'logs';
 
@@ -156,18 +154,18 @@ export default function DataServiceDetailPage() {
 
     setLoading(true);
     try {
-      const [servicesResponse, dataSourceResponse, runtimeResponse, keyResponse, logResponse] = await Promise.all([
-        fetchDataServices(),
-        fetchDataSourceOptions(),
-        fetchDataServiceRuntime(apiId),
-        fetchDataServiceKeys(apiId),
-        fetchDataServiceLogs(),
+      const [serviceResponse, dataSourceResponse, runtimeResponse, keyResponse, logResponse] = await Promise.all([
+        getDataService(apiId),
+        listDataServiceDataSources(),
+        getDataServiceRuntime(apiId),
+        listDataServiceKeys(apiId),
+        listDataServiceLogs(apiId, 50),
       ]);
-      setService((servicesResponse.data || []).find((item) => Number(item.id) === apiId));
-      setDataSources(dataSourceResponse.data || []);
-      setRuntime(runtimeResponse.data);
-      setKeys(keyResponse.data || []);
-      setLogs(logResponse.data || []);
+      setService(serviceResponse);
+      setDataSources(dataSourceResponse);
+      setRuntime(runtimeResponse);
+      setKeys(keyResponse);
+      setLogs(logResponse);
     } catch (error: any) {
       message.error(error?.message || '加载 API 详情失败');
     } finally {
@@ -187,11 +185,6 @@ export default function DataServiceDetailPage() {
     return dataSources.find((item) => String(item.value) === String(service.dataSourceId))?.label
       || `#${service.dataSourceId}`;
   }, [dataSources, service?.dataSourceId]);
-
-  const serviceLogs = useMemo(
-    () => logs.filter((item) => Number(item.apiId) === apiId).slice(0, 50),
-    [apiId, logs],
-  );
 
   const activeKeys = useMemo(
     () => keys.filter((item) => item.enabled).length,
@@ -363,12 +356,12 @@ export default function DataServiceDetailPage() {
   const logsContent = (
     <SectionCard title="调用记录">
       <div className="p-5">
-        {serviceLogs.length ? (
+        {logs.length ? (
           <Table<DataServiceCallLog>
             rowKey="id"
             size="small"
             columns={logColumns}
-            dataSource={serviceLogs}
+            dataSource={logs}
             pagination={false}
             scroll={{ x: 760 }}
             className="[&_.ant-table-container]:!rounded-md [&_.ant-table-container]:!border [&_.ant-table-container]:!border-solid [&_.ant-table-container]:!border-[#eceef1] [&_.ant-table-thead>tr>th]:!h-10 [&_.ant-table-thead>tr>th]:!bg-[#f7f7f8] [&_.ant-table-thead>tr>th]:!text-[12px] [&_.ant-table-tbody>tr>td]:!py-3 [&_.ant-table-tbody>tr>td]:!text-[12px]"

--- a/yak-ops-ui/src/pages/data-service/service.ts
+++ b/yak-ops-ui/src/pages/data-service/service.ts
@@ -1,8 +1,8 @@
 /**
  * @deprecated New data-service code should import from `@/services/data-service`.
  *
- * Detail, debug, overview and log pages still use the historical response
- * envelope. Keep this facade until those routes are migrated independently.
+ * Debug, overview and log pages still use the historical response envelope.
+ * Keep this facade until those routes are migrated independently.
  */
 export * from '@/services/data-service/legacy';
 export {

--- a/yak-ops-ui/src/services/data-service/api.ts
+++ b/yak-ops-ui/src/services/data-service/api.ts
@@ -38,6 +38,9 @@ const queryString = (params: object) => {
 export const listDataServices = (): Promise<DataServiceApi[]> =>
   HttpUtils.getData<DataServiceApi[]>(DATA_SERVICE_API_PREFIX);
 
+export const getDataService = (id: number): Promise<DataServiceApi> =>
+  HttpUtils.getData<DataServiceApi>(`${DATA_SERVICE_API_PREFIX}/${id}`);
+
 export const listDataServiceSources = ({
   sourceType,
   pageNo = 1,
@@ -203,6 +206,14 @@ export const testDataService = (
 export const listRecentDataServiceLogs = (): Promise<DataServiceCallLog[]> =>
   HttpUtils.getData<DataServiceCallLog[]>(
     `${DATA_SERVICE_API_PREFIX}/logs/recent`,
+  );
+
+export const listDataServiceLogs = (
+  id: number,
+  limit = 50,
+): Promise<DataServiceCallLog[]> =>
+  HttpUtils.getData<DataServiceCallLog[]>(
+    `${DATA_SERVICE_API_PREFIX}/${id}/logs${queryString({ limit })}`,
   );
 
 export const listDataServiceDataSources = (): Promise<DataSourceOption[]> =>


### PR DESCRIPTION
## Summary

Implements **Data Service Stage 1: Runtime Reliability Plane**. This PR intentionally does not introduce Data Service Project/RBAC or distributed Runtime infrastructure.

### 1. Invocation result / audit failure isolation
- `DataServiceInvoker` now treats invocation audit as best-effort evidence
- successful SQL/API responses are no longer turned into failures when call-log persistence fails
- datasource/query failures keep their original exception even if audit persistence also fails
- 401/429 authorization/rate-limit failures keep their original HTTP semantics even if audit fails
- audit-failure warning logs contain only API ID / success state / failure message, not request params or raw API keys

### 2. Version-safe node-local cache identity
- add persisted runtime namespace to cache identity
- namespace covers stable API ID, source type/ref, source revision ID/no and persisted definition update generation
- SQL, bindings and pagination identity remain part of the cache key
- this does **not** make cache distributed; it prevents a node that missed local invalidation from reusing an older generation after it reads the new persisted definition
- preserve the previous `cacheKey(sql, bindings)` overload for source compatibility

### 3. Service-scoped invocation logs
- add `GET /api/v1/data-service/{id}/logs?limit=50`
- add repository `recentByApi(apiId, limit)`
- add Flyway V11 index `(api_id, create_time, id)` for detail reads
- global `/logs/recent` stays unchanged for the logs/overview surface

### 4. Data Service detail read-path hardening
- detail page now uses typed `@/services/data-service` APIs
- fetches `GET /data-service/{id}` instead of loading all services and `find(id)`
- fetches `GET /data-service/{id}/logs?limit=50` instead of loading global recent logs and filtering in the browser
- removes Data Service detail from the legacy response-envelope facade scope
- visual layout and interaction remain unchanged

### 5. Tests / contracts
Added focused coverage for:
- successful invocation surviving audit-store outage
- datasource failure not being replaced by audit failure
- authorization failure not being replaced by audit failure
- persisted runtime generation changing cache namespace/key
- bounded service-scoped call-log reads
- service-scoped runtime controller log delegation
- existing cache reuse / circuit behavior remains covered

Documentation:
- add `RUNTIME_RELIABILITY.md`
- update `REQUIREMENTS.md` with audit isolation + cache generation + scoped log requirements
- update module README with the Stage 1 contract

## Explicit non-goals

This PR does **not** implement:
- Data Service Project/RBAC governance
- Redis/distributed cache
- global distributed rate limit
- cluster-wide Runtime metrics
- cross-node invalidation bus
- call-log retention/rollup
- sensitive parameter masking
- async/durable audit pipeline

Those remain follow-up Stage 2/3 work.

## Validation status

Focused tests were added, but Maven/npm were **not executed in this environment** because the current runtime cannot clone the GitHub repository locally. Do not treat the tests as passing until CI/local verification runs.

Recommended minimum verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-data-service -am test

cd yak-ops-ui
npm run tsc
npm run biome:lint -- src/pages/data-service src/services/data-service
```

Database:

```text
Run Flyway V11 and confirm:
idx_yak_ops_data_service_log_api_time_id (api_id, create_time, id)
```

Manual smoke:
- invoke an enabled API successfully while call-log insert is forced to fail; business response should still succeed
- force datasource/query failure while call-log insert also fails; original datasource error should be preserved
- invalid API key while call-log insert fails should remain 401
- republish service and verify cache key generation changes
- open `/data-service/api/{id}` and verify Network only requests current service + current service logs, not all services/all recent logs
- existing API marketplace/debug/overview/log pages remain usable
