### PR TITLE
refactor(home): move runtime overview behind domain read models

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterService.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterService.java
@@ -1,79 +1,58 @@
 package io.yak.ops.boot.home;
 
-import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import io.yak.ops.business.quality.dao.mapper.QualityExecutionMapper;
-import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
-import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
-import io.yak.ops.business.workflow.dao.mapper.WorkflowExecutionMapper;
-import io.yak.ops.business.workflow.dao.mapper.WorkflowScheduleMapper;
-import io.yak.ops.common.bean.po.quality.QualityExecutionPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
-import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
-import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
-import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
+import io.yak.ops.business.quality.workspace.QualityExecutionOverviewReader;
+import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionOverviewReader;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionOverviewReader;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
-/** 首页数据中心运行统计聚合服务。 */
+/** 首页数据中心只读聚合；领域运行语义由各业务 Reader 自己拥有。 */
 @Service
-@RequiredArgsConstructor
 public class HomeDataCenterService {
 
+  private static final Logger LOG = LoggerFactory.getLogger(HomeDataCenterService.class);
   private static final DateTimeFormatter DAY_LABEL = DateTimeFormatter.ofPattern("MM-dd");
-  private static final Set<String> WORKFLOW_RUNNING =
-      Set.of("CREATED", "RUNNING", "PAUSING", "PAUSED", "RESUMING");
-  private static final Set<String> WORKFLOW_SUCCESS =
-      Set.of("SUCCESS", "SUCCESS_WITH_WARNINGS", "WARNING");
-  private static final Set<String> WORKFLOW_FAILED = Set.of("FAILED", "TIMED_OUT");
-  private static final Set<String> QUALITY_RUNNING = Set.of("QUEUED", "RUNNING");
-  private static final Set<String> QUALITY_SUCCESS = Set.of("SUCCESS", "SUCCEEDED", "COMPLETED");
-  private static final Set<String> QUALITY_FAILED = Set.of("FAILED", "ERROR", "TIMED_OUT");
-  private static final Set<String> OFFLINE_RUNNING = Set.of("CREATED", "SUBMITTED", "QUEUED", "RUNNING");
-  private static final Set<String> OFFLINE_SUCCESS = Set.of("SUCCEEDED", "SUCCESS", "FINISHED", "COMPLETED");
-  private static final Set<String> OFFLINE_FAILED = Set.of("FAILED", "LOST");
+  private static final int RECENT_TASK_LIMIT = 5;
+  private static final int SCHEDULE_SOURCE_LIMIT = 20;
 
-  private final ObjectProvider<OfflineJobExecutionMapper> offlineExecutionMapperProvider;
-  private final ObjectProvider<OfflineJobDefinitionMapper> offlineDefinitionMapperProvider;
-  private final ObjectProvider<WorkflowExecutionMapper> workflowExecutionMapperProvider;
-  private final ObjectProvider<WorkflowScheduleMapper> workflowScheduleMapperProvider;
-  private final ObjectProvider<QualityExecutionMapper> qualityExecutionMapperProvider;
+  private final ObjectProvider<OfflineExecutionOverviewReader> offlineReaderProvider;
+  private final ObjectProvider<WorkflowExecutionOverviewReader> workflowReaderProvider;
+  private final ObjectProvider<QualityExecutionOverviewReader> qualityReaderProvider;
+
+  public HomeDataCenterService(
+      ObjectProvider<OfflineExecutionOverviewReader> offlineReaderProvider,
+      ObjectProvider<WorkflowExecutionOverviewReader> workflowReaderProvider,
+      ObjectProvider<QualityExecutionOverviewReader> qualityReaderProvider) {
+    this.offlineReaderProvider = offlineReaderProvider;
+    this.workflowReaderProvider = workflowReaderProvider;
+    this.qualityReaderProvider = qualityReaderProvider;
+  }
 
   public OverviewResponse overview(String periodValue) {
     PeriodRange range = PeriodRange.resolve(periodValue);
     PeriodRange previous = range.previous();
+    List<SourceOverview> current = sourceOverviews(range);
+    List<SourceOverview> previousSnapshots = sourceOverviews(previous);
 
-    List<RuntimeExecution> current = executions(range.start(), range.end());
-    List<RuntimeExecution> previousExecutions = executions(previous.start(), previous.end());
-
-    Metrics currentMetrics = metrics(current, range.end());
-    Metrics previousMetrics = metrics(previousExecutions, previous.end());
-    LatestTask latestTask = latestTask(current);
-
+    Metrics currentMetrics = mergeMetrics(current);
+    Metrics previousMetrics = mergeMetrics(previousSnapshots);
     return new OverviewResponse(
-        new PeriodView(range.start().toLocalDate().toString(), range.end().minusNanos(1).toLocalDate().toString()),
-        latestTask,
-        trend(range, current),
+        period(range),
+        latestTask(current),
+        mergeTrend(range, current),
         currentMetrics,
         compare(currentMetrics, previousMetrics));
   }
@@ -81,317 +60,397 @@ public class HomeDataCenterService {
   public RecentResponse recent() {
     LocalDateTime end = LocalDateTime.now().plusNanos(1);
     LocalDateTime start = end.minusDays(7);
-    List<RuntimeExecution> all = executions(start, end);
+    List<SourceTask> items = new ArrayList<>();
+    items.addAll(offlineRecentTasks(start, end));
+    items.addAll(workflowRecentTasks(start, end));
+    items.addAll(qualityRecentTasks(start, end));
+    items.sort(Comparator.comparing(SourceTask::lastRunTime).reversed());
 
-    Map<String, List<RuntimeExecution>> grouped =
-        all.stream().collect(Collectors.groupingBy(RuntimeExecution::taskKey));
-
-    List<RecentTask> items = new ArrayList<>();
-      List<RecentTask> finalItems = items;
-      grouped.values().forEach(group -> {
-      RuntimeExecution latest = group.stream().max(Comparator.comparing(RuntimeExecution::occurredAt)).orElse(null);
-      if (latest == null) return;
-      long success = group.stream().filter(RuntimeExecution::success).count();
-      long failed = group.stream().filter(RuntimeExecution::failed).count();
-      finalItems.add(new RecentTask(
-          latest.taskId(),
-          latest.taskType(),
-          latest.taskName(),
-          latest.occurredAt().toString(),
-          group.size(),
-          success,
-          failed,
-          latest.durationMs(),
-          latest.status(),
-          detailPath(latest)));
-    });
-
-    items.sort(Comparator.comparing(RecentTask::lastRunTime).reversed());
-    if (items.size() > 5) items = new ArrayList<>(items.subList(0, 5));
-    return new RecentResponse(items);
+    return new RecentResponse(items.stream()
+        .limit(RECENT_TASK_LIMIT)
+        .map(this::recentTask)
+        .toList());
   }
 
   public ScheduleResponse schedules(String periodValue) {
     PeriodRange range = PeriodRange.resolve(periodValue);
-    List<ScheduleItem> items = new ArrayList<>();
-
-    OfflineJobDefinitionMapper offlineMapper = offlineDefinitionMapperProvider.getIfAvailable();
-    if (offlineMapper != null) {
-      List<OfflineJobDefinitionPO> definitions = offlineMapper.selectList(
-          new LambdaQueryWrapper<OfflineJobDefinitionPO>()
-              .eq(OfflineJobDefinitionPO::getScheduleEnabled, true)
-              .orderByDesc(OfflineJobDefinitionPO::getScheduleNextFireTime)
-              .last("LIMIT 20"));
-      for (OfflineJobDefinitionPO definition : definitions) {
-        items.add(new ScheduleItem(
-            String.valueOf(definition.getId()),
-            "OFFLINE_SYNC",
-            defaultText(definition.getJobName(), "离线同步任务"),
-            definition.getCronExpression(),
-            "ENABLED",
-            toText(definition.getScheduleLastFireTime()),
-            toText(definition.getScheduleNextFireTime()),
-            "/sync/batch-link-up/" + definition.getId() + "/detail"));
-      }
-    }
-
-    WorkflowScheduleMapper workflowMapper = workflowScheduleMapperProvider.getIfAvailable();
-    if (workflowMapper != null) {
-      List<WorkflowSchedulePO> schedules = workflowMapper.selectList(
-          new LambdaQueryWrapper<WorkflowSchedulePO>()
-              .orderByDesc(WorkflowSchedulePO::getNextFireTime)
-              .last("LIMIT 20"));
-      for (WorkflowSchedulePO schedule : schedules) {
-        items.add(new ScheduleItem(
-            schedule.getId(),
-            "WORKFLOW",
-            defaultText(schedule.getName(), "工作流调度"),
-            schedule.getCronExpression(),
-            defaultText(schedule.getStatus(), "UNKNOWN"),
-            toText(schedule.getLastFireTime()),
-            toText(schedule.getNextFireTime()),
-            "/workflow/schedules"));
-      }
-    }
-
+    List<SourceSchedule> items = new ArrayList<>();
+    items.addAll(offlineSchedules());
+    items.addAll(workflowSchedules());
     items.sort(Comparator.comparing(
-        ScheduleItem::nextScheduleTime,
+        SourceSchedule::nextScheduleTime,
         Comparator.nullsLast(Comparator.naturalOrder())));
-    if (items.size() > 8) items = new ArrayList<>(items.subList(0, 8));
-    return new ScheduleResponse(
-        new PeriodView(range.start().toLocalDate().toString(), range.end().minusNanos(1).toLocalDate().toString()),
-        items.size(),
-        items);
+
+    List<ScheduleItem> result = items.stream().limit(8).map(this::scheduleItem).toList();
+    return new ScheduleResponse(period(range), result.size(), result);
   }
 
-  private List<RuntimeExecution> executions(LocalDateTime start, LocalDateTime end) {
-    List<RuntimeExecution> result = new ArrayList<>();
-    result.addAll(offlineExecutions(start, end));
-    result.addAll(workflowExecutions(start, end));
-    result.addAll(qualityExecutions(start, end));
-    result.sort(Comparator.comparing(RuntimeExecution::occurredAt));
-    return result;
+  private List<SourceOverview> sourceOverviews(PeriodRange range) {
+    boolean hourly = range.days() == 1;
+    return List.of(
+        offlineOverview(range.start(), range.end(), hourly),
+        workflowOverview(range.start(), range.end(), hourly),
+        qualityOverview(range.start(), range.end(), hourly));
   }
 
-  private List<RuntimeExecution> offlineExecutions(LocalDateTime start, LocalDateTime end) {
-    OfflineJobExecutionMapper mapper = offlineExecutionMapperProvider.getIfAvailable();
-    if (mapper == null) return List.of();
-
-    List<OfflineJobExecutionPO> rows = mapper.selectList(
-        new LambdaQueryWrapper<OfflineJobExecutionPO>()
-            .ge(OfflineJobExecutionPO::getCreateTime, start)
-            .lt(OfflineJobExecutionPO::getCreateTime, end)
-            .orderByAsc(OfflineJobExecutionPO::getCreateTime));
-
-    OfflineJobDefinitionMapper definitionMapper = offlineDefinitionMapperProvider.getIfAvailable();
-    Map<Long, String> names = new HashMap<>();
-    if (definitionMapper != null) {
-      Set<Long> ids = rows.stream()
-          .map(OfflineJobExecutionPO::getJobDefinitionId)
-          .filter(Objects::nonNull)
-          .collect(Collectors.toSet());
-      if (!ids.isEmpty()) {
-        names = definitionMapper.selectBatchIds(ids).stream()
-            .collect(Collectors.toMap(OfflineJobDefinitionPO::getId, OfflineJobDefinitionPO::getJobName, (a, b) -> a));
-      }
-    }
-
-    Map<Long, String> finalNames = names;
-    return rows.stream().map(row -> {
-      String status = normalize(row.getStatus());
-      LocalDateTime occurredAt = firstNonNull(row.getStartTime(), row.getCreateTime(), row.getUpdateTime());
-      return new RuntimeExecution(
+  private SourceOverview offlineOverview(
+      LocalDateTime start, LocalDateTime end, boolean hourly) {
+    OfflineExecutionOverviewReader reader = offlineReaderProvider.getIfAvailable();
+    if (reader == null) return SourceOverview.empty("OFFLINE_SYNC");
+    try {
+      OfflineExecutionOverviewReader.Overview overview = reader.overview(start, end, hourly);
+      return new SourceOverview(
           "OFFLINE_SYNC",
-          String.valueOf(row.getJobDefinitionId()),
-          defaultText(finalNames.get(row.getJobDefinitionId()), "离线同步任务 #" + row.getJobDefinitionId()),
-          status,
-          occurredAt,
-          row.getEndTime(),
-          zero(row.getDurationMillis()),
-          zero(row.getSinkSuccessRecordCount()),
-          "SCHEDULE".equalsIgnoreCase(row.getTriggerType()),
-          OFFLINE_SUCCESS.contains(status),
-          OFFLINE_FAILED.contains(status),
-          OFFLINE_RUNNING.contains(status),
-          row.getErrorMessage(),
-          String.valueOf(row.getId()));
-    }).toList();
+          sourceMetrics(overview.metrics()),
+          overview.trend().stream()
+              .map(item -> new SourceTrend(item.bucket(), item.count()))
+              .toList(),
+          offlineExecution(overview.latest()));
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页离线同步运行读模型失败", exception);
+      return SourceOverview.empty("OFFLINE_SYNC");
+    }
   }
 
-  private List<RuntimeExecution> workflowExecutions(LocalDateTime start, LocalDateTime end) {
-    WorkflowExecutionMapper mapper = workflowExecutionMapperProvider.getIfAvailable();
-    if (mapper == null) return List.of();
-    ZoneId zone = ZoneId.systemDefault();
-    Instant startInstant = start.atZone(zone).toInstant();
-    Instant endInstant = end.atZone(zone).toInstant();
-
-    List<WorkflowExecutionPO> rows = mapper.selectList(
-        new LambdaQueryWrapper<WorkflowExecutionPO>()
-            .ge(WorkflowExecutionPO::getCreatedAt, startInstant)
-            .lt(WorkflowExecutionPO::getCreatedAt, endInstant)
-            .orderByAsc(WorkflowExecutionPO::getCreatedAt));
-
-    return rows.stream().map(row -> {
-      String status = normalize(row.getStatus());
-      Instant started = firstNonNull(row.getRunStartedAt(), row.getCreatedAt(), row.getUpdatedAt());
-      long duration = row.getEndedAt() == null || started == null
-          ? 0L
-          : Math.max(0L, Duration.between(started, row.getEndedAt()).toMillis());
-      return new RuntimeExecution(
+  private SourceOverview workflowOverview(
+      LocalDateTime start, LocalDateTime end, boolean hourly) {
+    WorkflowExecutionOverviewReader reader = workflowReaderProvider.getIfAvailable();
+    if (reader == null) return SourceOverview.empty("WORKFLOW");
+    try {
+      WorkflowExecutionOverviewReader.Overview overview = reader.overview(start, end, hourly);
+      return new SourceOverview(
           "WORKFLOW",
-          defaultText(row.getDefinitionId(), row.getId()),
-          defaultText(row.getWorkflowName(), "工作流 #" + row.getDefinitionId()),
-          status,
-          LocalDateTime.ofInstant(started == null ? Instant.EPOCH : started, zone),
-          row.getEndedAt() == null ? null : LocalDateTime.ofInstant(row.getEndedAt(), zone),
-          duration,
-          0L,
-          false,
-          WORKFLOW_SUCCESS.contains(status),
-          WORKFLOW_FAILED.contains(status),
-          WORKFLOW_RUNNING.contains(status),
-          null,
-          row.getId());
-    }).toList();
+          sourceMetrics(overview.metrics()),
+          overview.trend().stream()
+              .map(item -> new SourceTrend(item.bucket(), item.count()))
+              .toList(),
+          workflowExecution(overview.latest()));
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页工作流运行读模型失败", exception);
+      return SourceOverview.empty("WORKFLOW");
+    }
   }
 
-  private List<RuntimeExecution> qualityExecutions(LocalDateTime start, LocalDateTime end) {
-    QualityExecutionMapper mapper = qualityExecutionMapperProvider.getIfAvailable();
-    if (mapper == null) return List.of();
-
-    List<QualityExecutionPO> rows = mapper.selectList(
-        new LambdaQueryWrapper<QualityExecutionPO>()
-            .ge(QualityExecutionPO::getQueuedAt, start)
-            .lt(QualityExecutionPO::getQueuedAt, end)
-            .orderByAsc(QualityExecutionPO::getQueuedAt));
-
-    return rows.stream().map(row -> {
-      String status = normalize(row.getExecutionStatus());
-      LocalDateTime occurredAt = firstNonNull(row.getStartedAt(), row.getQueuedAt(), row.getCreatedAt());
-      // 质量检查结果 FAIL 仅表示发现质量问题；技术执行成功仍计入成功任务。
-      boolean success = QUALITY_SUCCESS.contains(status);
-      return new RuntimeExecution(
+  private SourceOverview qualityOverview(
+      LocalDateTime start, LocalDateTime end, boolean hourly) {
+    QualityExecutionOverviewReader reader = qualityReaderProvider.getIfAvailable();
+    if (reader == null) return SourceOverview.empty("DATA_QUALITY");
+    try {
+      QualityExecutionOverviewReader.Overview overview = reader.overview(start, end, hourly);
+      return new SourceOverview(
           "DATA_QUALITY",
-          String.valueOf(row.getMonitorId()),
-          defaultText(row.getMonitorName(), "数据质量任务 #" + row.getMonitorId()),
-          status,
-          occurredAt,
-          row.getFinishedAt(),
-          zero(row.getDurationMs()),
-          0L,
-          "SCHEDULE".equalsIgnoreCase(row.getTriggerType()),
-          success,
-          QUALITY_FAILED.contains(status),
-          QUALITY_RUNNING.contains(status),
-          row.getErrorMessage(),
-          row.getExecutionNo());
-    }).toList();
+          sourceMetrics(overview.metrics()),
+          overview.trend().stream()
+              .map(item -> new SourceTrend(item.bucket(), item.count()))
+              .toList(),
+          qualityExecution(overview.latest()));
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页数据质量运行读模型失败", exception);
+      return SourceOverview.empty("DATA_QUALITY");
+    }
   }
 
-  private Metrics metrics(List<RuntimeExecution> executions, LocalDateTime end) {
-    long success = executions.stream().filter(RuntimeExecution::success).count();
-    long failed = executions.stream().filter(RuntimeExecution::failed).count();
-    long schedule = executions.stream().filter(RuntimeExecution::scheduled).count();
-    long processed = executions.stream()
-        .filter(item -> "OFFLINE_SYNC".equals(item.taskType()))
-        .mapToLong(RuntimeExecution::processedRecords)
-        .sum();
-    List<Long> durations = executions.stream()
-        .filter(item -> !item.running() && item.durationMs() > 0)
-        .map(RuntimeExecution::durationMs)
-        .toList();
-    long avgDuration = durations.isEmpty()
+  private SourceMetrics sourceMetrics(OfflineExecutionOverviewReader.Metrics metrics) {
+    return new SourceMetrics(
+        metrics.successCount(), metrics.runningCount(), metrics.failedCount(),
+        metrics.scheduleCount(), metrics.processedRecords(), metrics.durationTotalMs(),
+        metrics.durationSampleCount());
+  }
+
+  private SourceMetrics sourceMetrics(WorkflowExecutionOverviewReader.Metrics metrics) {
+    return new SourceMetrics(
+        metrics.successCount(), metrics.runningCount(), metrics.failedCount(),
+        metrics.scheduleCount(), metrics.processedRecords(), metrics.durationTotalMs(),
+        metrics.durationSampleCount());
+  }
+
+  private SourceMetrics sourceMetrics(QualityExecutionOverviewReader.Metrics metrics) {
+    return new SourceMetrics(
+        metrics.successCount(), metrics.runningCount(), metrics.failedCount(),
+        metrics.scheduleCount(), metrics.processedRecords(), metrics.durationTotalMs(),
+        metrics.durationSampleCount());
+  }
+
+  private Metrics mergeMetrics(List<SourceOverview> overviews) {
+    long success = 0L;
+    long running = 0L;
+    long failed = 0L;
+    long schedule = 0L;
+    long processed = 0L;
+    long durationTotal = 0L;
+    long durationSamples = 0L;
+    for (SourceOverview overview : overviews) {
+      SourceMetrics metrics = overview.metrics();
+      success += metrics.successCount();
+      running += metrics.runningCount();
+      failed += metrics.failedCount();
+      schedule += metrics.scheduleCount();
+      processed += metrics.processedRecords();
+      durationTotal += metrics.durationTotalMs();
+      durationSamples += metrics.durationSampleCount();
+    }
+    long avgDuration = durationSamples == 0L
         ? 0L
-        : Math.round(durations.stream().mapToLong(Long::longValue).average().orElse(0D));
-    long running = runningAt(end);
+        : Math.round(durationTotal / (double) durationSamples);
     return new Metrics(success, running, failed, schedule, processed, avgDuration);
   }
 
-  private long runningAt(LocalDateTime point) {
-    long count = 0L;
-
-    OfflineJobExecutionMapper offline = offlineExecutionMapperProvider.getIfAvailable();
-    if (offline != null) {
-      count += offline.selectCount(
-          new LambdaQueryWrapper<OfflineJobExecutionPO>()
-              .le(OfflineJobExecutionPO::getCreateTime, point)
-              .and(wrapper -> wrapper.isNull(OfflineJobExecutionPO::getEndTime)
-                  .or().gt(OfflineJobExecutionPO::getEndTime, point)));
-    }
-
-    WorkflowExecutionMapper workflow = workflowExecutionMapperProvider.getIfAvailable();
-    if (workflow != null) {
-      Instant instant = point.atZone(ZoneId.systemDefault()).toInstant();
-      count += workflow.selectCount(
-          new LambdaQueryWrapper<WorkflowExecutionPO>()
-              .le(WorkflowExecutionPO::getCreatedAt, instant)
-              .and(wrapper -> wrapper.isNull(WorkflowExecutionPO::getEndedAt)
-                  .or().gt(WorkflowExecutionPO::getEndedAt, instant)));
-    }
-
-    QualityExecutionMapper quality = qualityExecutionMapperProvider.getIfAvailable();
-    if (quality != null) {
-      count += quality.selectCount(
-          new LambdaQueryWrapper<QualityExecutionPO>()
-              .le(QualityExecutionPO::getQueuedAt, point)
-              .and(wrapper -> wrapper.isNull(QualityExecutionPO::getFinishedAt)
-                  .or().gt(QualityExecutionPO::getFinishedAt, point)));
-    }
-    return count;
-  }
-
-  private Trend trend(PeriodRange range, List<RuntimeExecution> executions) {
-    if (range.days() == 1) {
-      List<String> labels = List.of("00:00", "04:00", "08:00", "12:00", "16:00", "20:00", "24:00");
-      long[] buckets = new long[7];
-      for (RuntimeExecution execution : executions) {
-        int index = Math.min(5, Math.max(0, execution.occurredAt().getHour() / 4));
-        buckets[index]++;
+  private Trend mergeTrend(PeriodRange range, List<SourceOverview> overviews) {
+    Map<LocalDateTime, Long> counts = new LinkedHashMap<>();
+    for (SourceOverview overview : overviews) {
+      for (SourceTrend item : overview.trend()) {
+        counts.merge(item.bucket(), item.count(), Long::sum);
       }
-      // 最后一个点保持 0，用于保留现有 24:00 坐标与折线收尾。
-      List<Long> values = new ArrayList<>();
-      for (long bucket : buckets) values.add(bucket);
+    }
+
+    List<String> labels = new ArrayList<>();
+    List<Long> values = new ArrayList<>();
+    if (range.days() == 1) {
+      for (int hour = 0; hour <= 24; hour += 4) {
+        labels.add(String.format(Locale.ROOT, "%02d:00", hour));
+        values.add(hour == 24
+            ? 0L
+            : counts.getOrDefault(range.start().toLocalDate().atTime(hour, 0), 0L));
+      }
       return new Trend(labels, values);
     }
 
-    Map<LocalDate, Long> counts = executions.stream().collect(Collectors.groupingBy(
-        item -> item.occurredAt().toLocalDate(), LinkedHashMap::new, Collectors.counting()));
-    List<String> labels = new ArrayList<>();
-    List<Long> values = new ArrayList<>();
     for (int i = 0; i < range.days(); i++) {
       LocalDate day = range.start().toLocalDate().plusDays(i);
       labels.add(DAY_LABEL.format(day));
-      values.add(counts.getOrDefault(day, 0L));
+      values.add(counts.getOrDefault(day.atStartOfDay(), 0L));
     }
     return new Trend(labels, values);
   }
 
-  private LatestTask latestTask(List<RuntimeExecution> current) {
-    RuntimeExecution latest = current.stream()
-        .max(Comparator.comparing(RuntimeExecution::occurredAt))
+  private LatestTask latestTask(List<SourceOverview> current) {
+    SourceExecution latest = current.stream()
+        .map(SourceOverview::latest)
+        .filter(item -> item != null && item.occurredAt() != null)
+        .max(Comparator.comparing(SourceExecution::occurredAt))
         .orElseGet(this::latestExecutionAcrossAll);
     if (latest == null) return null;
 
-    LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
-    List<RuntimeExecution> recentRuns = executions(sevenDaysAgo, LocalDateTime.now().plusNanos(1)).stream()
-        .filter(item -> item.taskKey().equals(latest.taskKey()))
-        .toList();
-    long exceptions = recentRuns.stream().filter(RuntimeExecution::failed).count();
+    LocalDateTime end = LocalDateTime.now().plusNanos(1);
+    SourceTask activity = taskSummary(latest.taskType(), latest.taskId(), end.minusDays(7), end);
     return new LatestTask(
         latest.taskId(),
         latest.taskType(),
         latest.taskName(),
         latest.durationMs(),
-        recentRuns.size(),
-        exceptions,
+        activity == null ? 0L : activity.runCount(),
+        activity == null ? 0L : activity.failedCount(),
         latest.status(),
-        detailPath(latest));
+        detailPath(latest.taskType(), latest.taskId(), latest.executionId()));
   }
 
-  private RuntimeExecution latestExecutionAcrossAll() {
+  private SourceExecution latestExecutionAcrossAll() {
     LocalDateTime end = LocalDateTime.now().plusNanos(1);
-    List<RuntimeExecution> candidates = executions(end.minusDays(90), end);
-    return candidates.stream().max(Comparator.comparing(RuntimeExecution::occurredAt)).orElse(null);
+    LocalDateTime start = end.minusDays(90);
+    List<SourceExecution> candidates = new ArrayList<>();
+
+    OfflineExecutionOverviewReader offline = offlineReaderProvider.getIfAvailable();
+    if (offline != null) {
+      try {
+        SourceExecution item = offlineExecution(offline.latest(start, end));
+        if (item != null) candidates.add(item);
+      } catch (RuntimeException exception) {
+        LOG.warn("加载首页离线同步最近运行失败", exception);
+      }
+    }
+
+    WorkflowExecutionOverviewReader workflow = workflowReaderProvider.getIfAvailable();
+    if (workflow != null) {
+      try {
+        SourceExecution item = workflowExecution(workflow.latest(start, end));
+        if (item != null) candidates.add(item);
+      } catch (RuntimeException exception) {
+        LOG.warn("加载首页工作流最近运行失败", exception);
+      }
+    }
+
+    QualityExecutionOverviewReader quality = qualityReaderProvider.getIfAvailable();
+    if (quality != null) {
+      try {
+        SourceExecution item = qualityExecution(quality.latest(start, end));
+        if (item != null) candidates.add(item);
+      } catch (RuntimeException exception) {
+        LOG.warn("加载首页质量最近运行失败", exception);
+      }
+    }
+
+    return candidates.stream()
+        .filter(item -> item.occurredAt() != null)
+        .max(Comparator.comparing(SourceExecution::occurredAt))
+        .orElse(null);
+  }
+
+  private SourceTask taskSummary(
+      String taskType, String taskId, LocalDateTime start, LocalDateTime end) {
+    try {
+      return switch (taskType) {
+        case "OFFLINE_SYNC" -> {
+          OfflineExecutionOverviewReader reader = offlineReaderProvider.getIfAvailable();
+          yield reader == null ? null : offlineTask(reader.taskSummary(taskId, start, end));
+        }
+        case "WORKFLOW" -> {
+          WorkflowExecutionOverviewReader reader = workflowReaderProvider.getIfAvailable();
+          yield reader == null ? null : workflowTask(reader.taskSummary(taskId, start, end));
+        }
+        case "DATA_QUALITY" -> {
+          QualityExecutionOverviewReader reader = qualityReaderProvider.getIfAvailable();
+          yield reader == null ? null : qualityTask(reader.taskSummary(taskId, start, end));
+        }
+        default -> null;
+      };
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页任务运行摘要失败: taskType={}, taskId={}", taskType, taskId, exception);
+      return null;
+    }
+  }
+
+  private List<SourceTask> offlineRecentTasks(LocalDateTime start, LocalDateTime end) {
+    OfflineExecutionOverviewReader reader = offlineReaderProvider.getIfAvailable();
+    if (reader == null) return List.of();
+    try {
+      return reader.recentTasks(start, end, RECENT_TASK_LIMIT).stream()
+          .map(this::offlineTask)
+          .toList();
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页离线同步近期任务失败", exception);
+      return List.of();
+    }
+  }
+
+  private List<SourceTask> workflowRecentTasks(LocalDateTime start, LocalDateTime end) {
+    WorkflowExecutionOverviewReader reader = workflowReaderProvider.getIfAvailable();
+    if (reader == null) return List.of();
+    try {
+      return reader.recentTasks(start, end, RECENT_TASK_LIMIT).stream()
+          .map(this::workflowTask)
+          .toList();
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页工作流近期任务失败", exception);
+      return List.of();
+    }
+  }
+
+  private List<SourceTask> qualityRecentTasks(LocalDateTime start, LocalDateTime end) {
+    QualityExecutionOverviewReader reader = qualityReaderProvider.getIfAvailable();
+    if (reader == null) return List.of();
+    try {
+      return reader.recentTasks(start, end, RECENT_TASK_LIMIT).stream()
+          .map(this::qualityTask)
+          .toList();
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页质量近期任务失败", exception);
+      return List.of();
+    }
+  }
+
+  private List<SourceSchedule> offlineSchedules() {
+    OfflineExecutionOverviewReader reader = offlineReaderProvider.getIfAvailable();
+    if (reader == null) return List.of();
+    try {
+      return reader.schedules(SCHEDULE_SOURCE_LIMIT).stream()
+          .map(item -> new SourceSchedule(
+              "OFFLINE_SYNC",
+              item.taskId(),
+              item.taskName(),
+              item.cronExpression(),
+              item.status(),
+              item.lastScheduleTime(),
+              item.nextScheduleTime()))
+          .toList();
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页离线同步调度摘要失败", exception);
+      return List.of();
+    }
+  }
+
+  private List<SourceSchedule> workflowSchedules() {
+    WorkflowExecutionOverviewReader reader = workflowReaderProvider.getIfAvailable();
+    if (reader == null) return List.of();
+    try {
+      return reader.schedules(SCHEDULE_SOURCE_LIMIT).stream()
+          .map(item -> new SourceSchedule(
+              "WORKFLOW",
+              item.taskId(),
+              item.taskName(),
+              item.cronExpression(),
+              item.status(),
+              item.lastScheduleTime(),
+              item.nextScheduleTime()))
+          .toList();
+    } catch (RuntimeException exception) {
+      LOG.warn("加载首页工作流调度摘要失败", exception);
+      return List.of();
+    }
+  }
+
+  private SourceExecution offlineExecution(OfflineExecutionOverviewReader.Execution item) {
+    return item == null ? null : new SourceExecution(
+        "OFFLINE_SYNC", item.taskId(), item.taskName(), item.status(),
+        item.occurredAt(), item.durationMs(), item.executionId());
+  }
+
+  private SourceExecution workflowExecution(WorkflowExecutionOverviewReader.Execution item) {
+    return item == null ? null : new SourceExecution(
+        "WORKFLOW", item.taskId(), item.taskName(), item.status(),
+        item.occurredAt(), item.durationMs(), item.executionId());
+  }
+
+  private SourceExecution qualityExecution(QualityExecutionOverviewReader.Execution item) {
+    return item == null ? null : new SourceExecution(
+        "DATA_QUALITY", item.taskId(), item.taskName(), item.status(),
+        item.occurredAt(), item.durationMs(), item.executionId());
+  }
+
+  private SourceTask offlineTask(OfflineExecutionOverviewReader.TaskSummary item) {
+    return item == null ? null : new SourceTask(
+        "OFFLINE_SYNC", item.taskId(), item.taskName(), item.lastRunTime(), item.runCount(),
+        item.successCount(), item.failedCount(), item.lastDurationMs(), item.lastStatus(),
+        item.executionId());
+  }
+
+  private SourceTask workflowTask(WorkflowExecutionOverviewReader.TaskSummary item) {
+    return item == null ? null : new SourceTask(
+        "WORKFLOW", item.taskId(), item.taskName(), item.lastRunTime(), item.runCount(),
+        item.successCount(), item.failedCount(), item.lastDurationMs(), item.lastStatus(),
+        item.executionId());
+  }
+
+  private SourceTask qualityTask(QualityExecutionOverviewReader.TaskSummary item) {
+    return item == null ? null : new SourceTask(
+        "DATA_QUALITY", item.taskId(), item.taskName(), item.lastRunTime(), item.runCount(),
+        item.successCount(), item.failedCount(), item.lastDurationMs(), item.lastStatus(),
+        item.executionId());
+  }
+
+  private RecentTask recentTask(SourceTask item) {
+    return new RecentTask(
+        item.taskId(),
+        item.taskType(),
+        item.taskName(),
+        item.lastRunTime().toString(),
+        item.runCount(),
+        item.successCount(),
+        item.failedCount(),
+        item.lastDurationMs(),
+        item.lastStatus(),
+        detailPath(item.taskType(), item.taskId(), item.executionId()));
+  }
+
+  private ScheduleItem scheduleItem(SourceSchedule item) {
+    return new ScheduleItem(
+        item.taskId(),
+        item.taskType(),
+        item.taskName(),
+        item.cronExpression(),
+        item.status(),
+        text(item.lastScheduleTime()),
+        text(item.nextScheduleTime()),
+        detailPath(item.taskType(), item.taskId(), null));
   }
 
   private MetricCompare compare(Metrics current, Metrics previous) {
@@ -411,39 +470,25 @@ public class HomeDataCenterService {
         .divide(BigDecimal.valueOf(previous), 1, RoundingMode.HALF_UP);
   }
 
-  private String detailPath(RuntimeExecution execution) {
-    return switch (execution.taskType()) {
-      case "OFFLINE_SYNC" -> "/sync/batch-link-up/" + execution.taskId() + "/detail";
-      case "WORKFLOW" -> "/workflow/instances";
-      case "DATA_QUALITY" -> "/data-quality/execution/" + execution.executionId();
+  private String detailPath(String taskType, String taskId, String executionId) {
+    return switch (taskType) {
+      case "OFFLINE_SYNC" -> "/sync/batch-link-up/" + taskId + "/detail";
+      case "WORKFLOW" -> executionId == null ? "/workflow/schedules" : "/workflow/instances";
+      case "DATA_QUALITY" -> executionId == null
+          ? "/data-quality/overview"
+          : "/data-quality/execution/" + executionId;
       default -> "/home";
     };
   }
 
-  private static String normalize(String value) {
-    return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
+  private PeriodView period(PeriodRange range) {
+    return new PeriodView(
+        range.start().toLocalDate().toString(),
+        range.end().minusNanos(1).toLocalDate().toString());
   }
 
-  private static long zero(Long value) {
-    return value == null ? 0L : value;
-  }
-
-  private static String defaultText(String value, String fallback) {
-    return value == null || value.isBlank() ? fallback : value;
-  }
-
-  private static String toText(LocalDateTime value) {
+  private static String text(LocalDateTime value) {
     return value == null ? null : value.toString();
-  }
-
-  private static String toText(Instant value) {
-    return value == null ? null : LocalDateTime.ofInstant(value, ZoneId.systemDefault()).toString();
-  }
-
-  @SafeVarargs
-  private static <T> T firstNonNull(T... values) {
-    for (T value : values) if (value != null) return value;
-    return null;
   }
 
   public record OverviewResponse(
@@ -509,25 +554,60 @@ public class HomeDataCenterService {
       String nextScheduleTime,
       String detailPath) {}
 
-  private record RuntimeExecution(
+  private record SourceOverview(
+      String taskType,
+      SourceMetrics metrics,
+      List<SourceTrend> trend,
+      SourceExecution latest) {
+    static SourceOverview empty(String taskType) {
+      return new SourceOverview(taskType, SourceMetrics.empty(), List.of(), null);
+    }
+  }
+
+  private record SourceMetrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long durationTotalMs,
+      long durationSampleCount) {
+    static SourceMetrics empty() {
+      return new SourceMetrics(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+  }
+
+  private record SourceTrend(LocalDateTime bucket, long count) {}
+
+  private record SourceExecution(
       String taskType,
       String taskId,
       String taskName,
       String status,
       LocalDateTime occurredAt,
-      LocalDateTime endedAt,
       long durationMs,
-      long processedRecords,
-      boolean scheduled,
-      boolean success,
-      boolean failed,
-      boolean running,
-      String errorMessage,
-      String executionId) {
-    String taskKey() {
-      return taskType + ":" + taskId;
-    }
-  }
+      String executionId) {}
+
+  private record SourceTask(
+      String taskType,
+      String taskId,
+      String taskName,
+      LocalDateTime lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String executionId) {}
+
+  private record SourceSchedule(
+      String taskType,
+      String taskId,
+      String taskName,
+      String cronExpression,
+      String status,
+      LocalDateTime lastScheduleTime,
+      LocalDateTime nextScheduleTime) {}
 
   private record PeriodRange(LocalDateTime start, LocalDateTime end, int days) {
     static PeriodRange resolve(String value) {

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/architecture/HomeReadModelBoundaryTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/architecture/HomeReadModelBoundaryTest.java
@@ -1,0 +1,49 @@
+package io.yak.ops.boot.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class HomeReadModelBoundaryTest {
+
+  @Test
+  void dataCenterMustComposeDomainReadersInsteadOfPersistenceInternals() throws IOException {
+    String source = Files.readString(homeDataCenterSource(), StandardCharsets.UTF_8);
+
+    assertThat(source)
+        .contains(
+            "OfflineExecutionOverviewReader",
+            "WorkflowExecutionOverviewReader",
+            "QualityExecutionOverviewReader")
+        .doesNotContain(
+            ".dao.mapper.",
+            ".bean.po.",
+            "LambdaQueryWrapper",
+            "JdbcTemplate");
+  }
+
+  private Path homeDataCenterSource() {
+    Path local = Path.of("src/main/java/io/yak/ops/boot/home/HomeDataCenterService.java");
+    if (Files.isRegularFile(local)) return local;
+
+    Path repositoryRelative = Path.of(
+        "yak-ops-boot",
+        "src",
+        "main",
+        "java",
+        "io",
+        "yak",
+        "ops",
+        "boot",
+        "home",
+        "HomeDataCenterService.java");
+    assertThat(Files.isRegularFile(repositoryRelative))
+        .as("HomeDataCenterService source must be available")
+        .isTrue();
+    return repositoryRelative;
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeDataCenterServiceTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeDataCenterServiceTest.java
@@ -1,0 +1,151 @@
+package io.yak.ops.boot.home;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.workspace.QualityExecutionOverviewReader;
+import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionOverviewReader;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionOverviewReader;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class HomeDataCenterServiceTest {
+
+  @Test
+  void shouldMergeDomainReadModelsWithoutAveragingAverages() {
+    OfflineExecutionOverviewReader offline = mock(OfflineExecutionOverviewReader.class);
+    WorkflowExecutionOverviewReader workflow = mock(WorkflowExecutionOverviewReader.class);
+    QualityExecutionOverviewReader quality = mock(QualityExecutionOverviewReader.class);
+    HomeDataCenterService service = service(offline, workflow, quality);
+
+    LocalDate yesterday = LocalDate.now().minusDays(1);
+    LocalDateTime bucket = yesterday.atStartOfDay();
+    LocalDateTime offlineTime = yesterday.atTime(10, 0);
+    LocalDateTime workflowTime = yesterday.atTime(20, 0);
+
+    when(offline.overview(any(), any(), anyBoolean()))
+        .thenReturn(
+            new OfflineExecutionOverviewReader.Overview(
+                new OfflineExecutionOverviewReader.Metrics(2, 1, 1, 3, 100, 1000, 2),
+                List.of(new OfflineExecutionOverviewReader.TrendPoint(bucket, 2)),
+                new OfflineExecutionOverviewReader.Execution(
+                    "10", "离线任务", "SUCCEEDED", offlineTime, 500, "1001")),
+            offlineEmpty());
+    when(workflow.overview(any(), any(), anyBoolean()))
+        .thenReturn(
+            new WorkflowExecutionOverviewReader.Overview(
+                new WorkflowExecutionOverviewReader.Metrics(3, 2, 1, 0, 0, 900, 3),
+                List.of(new WorkflowExecutionOverviewReader.TrendPoint(bucket, 3)),
+                new WorkflowExecutionOverviewReader.Execution(
+                    "wf-1", "工作流", "SUCCESS", workflowTime, 300, "exec-1")),
+            workflowEmpty());
+    when(quality.overview(any(), any(), anyBoolean()))
+        .thenReturn(
+            new QualityExecutionOverviewReader.Overview(
+                new QualityExecutionOverviewReader.Metrics(1, 1, 0, 2, 0, 100, 1),
+                List.of(new QualityExecutionOverviewReader.TrendPoint(bucket, 1)),
+                null),
+            qualityEmpty());
+    when(workflow.taskSummary(any(), any(), any()))
+        .thenReturn(new WorkflowExecutionOverviewReader.TaskSummary(
+            "wf-1", "工作流", workflowTime, 7, 6, 1, 300, "SUCCESS", "exec-1"));
+
+    HomeDataCenterService.OverviewResponse response = service.overview("7d");
+
+    assertThat(response.metrics().successCount()).isEqualTo(6);
+    assertThat(response.metrics().runningCount()).isEqualTo(4);
+    assertThat(response.metrics().failedCount()).isEqualTo(2);
+    assertThat(response.metrics().scheduleCount()).isEqualTo(5);
+    assertThat(response.metrics().processedRecords()).isEqualTo(100);
+    assertThat(response.metrics().avgDurationMs()).isEqualTo(333);
+    assertThat(response.trend().values()).contains(6L);
+    assertThat(response.latestTask().taskType()).isEqualTo("WORKFLOW");
+    assertThat(response.latestTask().runCount()).isEqualTo(7);
+    assertThat(response.latestTask().exceptionCount()).isEqualTo(1);
+    assertThat(response.latestTask().detailPath()).isEqualTo("/workflow/instances");
+  }
+
+  @Test
+  void shouldKeepDataCenterAvailableWhenOneDomainReaderFails() {
+    OfflineExecutionOverviewReader offline = mock(OfflineExecutionOverviewReader.class);
+    WorkflowExecutionOverviewReader workflow = mock(WorkflowExecutionOverviewReader.class);
+    QualityExecutionOverviewReader quality = mock(QualityExecutionOverviewReader.class);
+    HomeDataCenterService service = service(offline, workflow, quality);
+
+    when(offline.overview(any(), any(), anyBoolean()))
+        .thenThrow(new IllegalStateException("offline unavailable"));
+    when(workflow.overview(any(), any(), anyBoolean()))
+        .thenReturn(
+            new WorkflowExecutionOverviewReader.Overview(
+                new WorkflowExecutionOverviewReader.Metrics(2, 0, 0, 0, 0, 0, 0),
+                List.of(),
+                null),
+            workflowEmpty());
+    when(quality.overview(any(), any(), anyBoolean()))
+        .thenReturn(qualityEmpty(), qualityEmpty());
+
+    HomeDataCenterService.OverviewResponse response = service.overview("7d");
+
+    assertThat(response.metrics().successCount()).isEqualTo(2);
+    assertThat(response.metrics().failedCount()).isZero();
+  }
+
+  @Test
+  void shouldPreserveLegacyScheduleDetailPaths() {
+    OfflineExecutionOverviewReader offline = mock(OfflineExecutionOverviewReader.class);
+    WorkflowExecutionOverviewReader workflow = mock(WorkflowExecutionOverviewReader.class);
+    QualityExecutionOverviewReader quality = mock(QualityExecutionOverviewReader.class);
+    HomeDataCenterService service = service(offline, workflow, quality);
+
+    LocalDateTime now = LocalDateTime.now();
+    when(offline.schedules(anyInt())).thenReturn(List.of(
+        new OfflineExecutionOverviewReader.ScheduleSummary(
+            "11", "离线调度", "0 0 * * * ?", "ENABLED", now.minusDays(1), now.plusHours(2))));
+    when(workflow.schedules(anyInt())).thenReturn(List.of(
+        new WorkflowExecutionOverviewReader.ScheduleSummary(
+            "schedule-1", "工作流调度", "0 0 * * * ?", "ONLINE", now.minusDays(1), now.plusHours(1))));
+
+    HomeDataCenterService.ScheduleResponse response = service.schedules("7d");
+
+    assertThat(response.items()).hasSize(2);
+    assertThat(response.items().get(0).taskType()).isEqualTo("WORKFLOW");
+    assertThat(response.items().get(0).detailPath()).isEqualTo("/workflow/schedules");
+    assertThat(response.items().get(1).detailPath()).isEqualTo("/sync/batch-link-up/11/detail");
+  }
+
+  @SuppressWarnings("unchecked")
+  private HomeDataCenterService service(
+      OfflineExecutionOverviewReader offline,
+      WorkflowExecutionOverviewReader workflow,
+      QualityExecutionOverviewReader quality) {
+    ObjectProvider<OfflineExecutionOverviewReader> offlineProvider = mock(ObjectProvider.class);
+    ObjectProvider<WorkflowExecutionOverviewReader> workflowProvider = mock(ObjectProvider.class);
+    ObjectProvider<QualityExecutionOverviewReader> qualityProvider = mock(ObjectProvider.class);
+    when(offlineProvider.getIfAvailable()).thenReturn(offline);
+    when(workflowProvider.getIfAvailable()).thenReturn(workflow);
+    when(qualityProvider.getIfAvailable()).thenReturn(quality);
+    return new HomeDataCenterService(offlineProvider, workflowProvider, qualityProvider);
+  }
+
+  private OfflineExecutionOverviewReader.Overview offlineEmpty() {
+    return new OfflineExecutionOverviewReader.Overview(
+        new OfflineExecutionOverviewReader.Metrics(0, 0, 0, 0, 0, 0, 0), List.of(), null);
+  }
+
+  private WorkflowExecutionOverviewReader.Overview workflowEmpty() {
+    return new WorkflowExecutionOverviewReader.Overview(
+        new WorkflowExecutionOverviewReader.Metrics(0, 0, 0, 0, 0, 0, 0), List.of(), null);
+  }
+
+  private QualityExecutionOverviewReader.Overview qualityEmpty() {
+    return new QualityExecutionOverviewReader.Overview(
+        new QualityExecutionOverviewReader.Metrics(0, 0, 0, 0, 0, 0, 0), List.of(), null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionOverviewRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionOverviewRepository.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.quality.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 数据质量 execution 运行总览持久化读模型 contract。 */
+public interface QualityExecutionOverviewRepository {
+
+  Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend);
+
+  Execution latest(LocalDateTime start, LocalDateTime end);
+
+  TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end);
+
+  List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit);
+
+  record Overview(Metrics metrics, List<TrendPoint> trend, Execution latest) {
+    public Overview {
+      trend = trend == null ? List.of() : List.copyOf(trend);
+    }
+  }
+
+  record Metrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long durationTotalMs,
+      long durationSampleCount) {
+    public static Metrics empty() {
+      return new Metrics(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+
+    public Metrics withRunning(long value) {
+      return new Metrics(
+          successCount,
+          value,
+          failedCount,
+          scheduleCount,
+          processedRecords,
+          durationTotalMs,
+          durationSampleCount);
+    }
+  }
+
+  record TrendPoint(LocalDateTime bucket, long count) {}
+
+  record Execution(
+      String taskId,
+      String taskName,
+      String status,
+      LocalDateTime occurredAt,
+      long durationMs,
+      String executionId) {}
+
+  record TaskSummary(
+      String taskId,
+      String taskName,
+      LocalDateTime lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String executionId) {}
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionOverviewRepositoryAdapter.java
@@ -1,0 +1,242 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** MySQL-backed data-quality execution overview projection. */
+@Repository
+@ConditionalOnQualityEnabled
+public class QualityExecutionOverviewRepositoryAdapter
+    implements QualityExecutionOverviewRepository {
+
+  private static final String SUCCESS_STATUSES = "'SUCCESS','SUCCEEDED','COMPLETED'";
+  private static final String FAILED_STATUSES = "'FAILED','ERROR','TIMED_OUT'";
+  private static final String RUNNING_STATUSES = "'QUEUED','RUNNING'";
+
+  private final JdbcTemplate jdbc;
+
+  public QualityExecutionOverviewRepositoryAdapter(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.jdbc = new JdbcTemplate(dataSource);
+  }
+
+  @Override
+  public Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend) {
+    return new Overview(metrics(start, end), trend(start, end, hourlyTrend), latest(start, end));
+  }
+
+  @Override
+  public Execution latest(LocalDateTime start, LocalDateTime end) {
+    String sql = """
+        SELECT CAST(e.monitor_id AS CHAR) AS task_id,
+               e.monitor_name AS task_name,
+               e.execution_status AS status,
+               COALESCE(e.started_at, e.queued_at, e.created_at) AS occurred_at,
+               COALESCE(e.duration_ms, 0) AS duration_ms,
+               e.execution_no AS execution_id
+          FROM yak_quality_execution e
+         WHERE e.queued_at >= ? AND e.queued_at < ?
+         ORDER BY COALESCE(e.started_at, e.queued_at, e.created_at) DESC, e.id DESC
+         LIMIT 1
+        """;
+    List<Execution> rows = jdbc.query(sql, this::execution, start, end);
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  @Override
+  public TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end) {
+    if (taskId == null || taskId.isBlank()) return null;
+    long id;
+    try {
+      id = Long.parseLong(taskId);
+    } catch (NumberFormatException ignored) {
+      return null;
+    }
+    String sql = """
+        SELECT e.monitor_id AS task_id,
+               MAX(e.monitor_name) AS task_name,
+               COUNT(*) AS run_count,
+               SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END) AS success_count,
+               SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
+               MAX(COALESCE(e.started_at, e.queued_at, e.created_at)) AS last_run_time
+          FROM yak_quality_execution e
+         WHERE e.queued_at >= ? AND e.queued_at < ?
+           AND e.monitor_id = ?
+         GROUP BY e.monitor_id
+        """.formatted(SUCCESS_STATUSES, FAILED_STATUSES);
+    List<TaskAggregate> aggregates = jdbc.query(sql, this::taskAggregate, start, end, id);
+    if (aggregates.isEmpty()) return null;
+    return summary(aggregates.get(0), latestForTask(id, start, end));
+  }
+
+  @Override
+  public List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit) {
+    int boundedLimit = Math.max(1, Math.min(limit, 20));
+    String sql = """
+        SELECT e.monitor_id AS task_id,
+               MAX(e.monitor_name) AS task_name,
+               COUNT(*) AS run_count,
+               SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END) AS success_count,
+               SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
+               MAX(COALESCE(e.started_at, e.queued_at, e.created_at)) AS last_run_time
+          FROM yak_quality_execution e
+         WHERE e.queued_at >= ? AND e.queued_at < ?
+         GROUP BY e.monitor_id
+         ORDER BY last_run_time DESC
+         LIMIT %d
+        """.formatted(SUCCESS_STATUSES, FAILED_STATUSES, boundedLimit);
+    List<TaskAggregate> aggregates = jdbc.query(sql, this::taskAggregate, start, end);
+    List<TaskSummary> result = new ArrayList<>(aggregates.size());
+    for (TaskAggregate aggregate : aggregates) {
+      result.add(summary(aggregate, latestForTask(aggregate.taskId(), start, end)));
+    }
+    return List.copyOf(result);
+  }
+
+  private Metrics metrics(LocalDateTime start, LocalDateTime end) {
+    String sql = """
+        SELECT COALESCE(SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END), 0) AS success_count,
+               COALESCE(SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END), 0) AS failed_count,
+               COALESCE(SUM(CASE WHEN UPPER(e.trigger_type) = 'SCHEDULE' THEN 1 ELSE 0 END), 0) AS schedule_count,
+               COALESCE(SUM(CASE WHEN UPPER(e.execution_status) NOT IN (%s)
+                                  AND COALESCE(e.duration_ms, 0) > 0 THEN e.duration_ms ELSE 0 END), 0) AS duration_total_ms,
+               COALESCE(SUM(CASE WHEN UPPER(e.execution_status) NOT IN (%s)
+                                  AND COALESCE(e.duration_ms, 0) > 0 THEN 1 ELSE 0 END), 0) AS duration_sample_count
+          FROM yak_quality_execution e
+         WHERE e.queued_at >= ? AND e.queued_at < ?
+        """.formatted(
+            SUCCESS_STATUSES, FAILED_STATUSES, RUNNING_STATUSES, RUNNING_STATUSES);
+    Metrics aggregate = jdbc.queryForObject(
+        sql,
+        (rs, rowNum) -> new Metrics(
+            rs.getLong("success_count"),
+            0L,
+            rs.getLong("failed_count"),
+            rs.getLong("schedule_count"),
+            0L,
+            rs.getLong("duration_total_ms"),
+            rs.getLong("duration_sample_count")),
+        start,
+        end);
+    return (aggregate == null ? Metrics.empty() : aggregate).withRunning(runningAt(end));
+  }
+
+  private long runningAt(LocalDateTime point) {
+    String sql = """
+        SELECT COUNT(*)
+          FROM yak_quality_execution e
+         WHERE e.queued_at <= ?
+           AND (e.finished_at IS NULL OR e.finished_at > ?)
+        """;
+    Long value = jdbc.queryForObject(sql, Long.class, point, point);
+    return value == null ? 0L : value;
+  }
+
+  private List<TrendPoint> trend(LocalDateTime start, LocalDateTime end, boolean hourly) {
+    String occurredAt = "COALESCE(e.started_at, e.queued_at, e.created_at)";
+    String bucketHour = hourly ? "FLOOR(HOUR(" + occurredAt + ") / 4) * 4" : "0";
+    String sql = "SELECT DATE(" + occurredAt + ") AS bucket_date, "
+        + bucketHour + " AS bucket_hour, COUNT(*) AS total "
+        + "FROM yak_quality_execution e "
+        + "WHERE e.queued_at >= ? AND e.queued_at < ? "
+        + "GROUP BY bucket_date, bucket_hour ORDER BY bucket_date, bucket_hour";
+    return jdbc.query(
+        sql,
+        (rs, rowNum) -> new TrendPoint(
+            date(rs, "bucket_date").atTime(rs.getInt("bucket_hour"), 0),
+            rs.getLong("total")),
+        start,
+        end);
+  }
+
+  private Execution latestForTask(long taskId, LocalDateTime start, LocalDateTime end) {
+    String sql = """
+        SELECT CAST(e.monitor_id AS CHAR) AS task_id,
+               e.monitor_name AS task_name,
+               e.execution_status AS status,
+               COALESCE(e.started_at, e.queued_at, e.created_at) AS occurred_at,
+               COALESCE(e.duration_ms, 0) AS duration_ms,
+               e.execution_no AS execution_id
+          FROM yak_quality_execution e
+         WHERE e.queued_at >= ? AND e.queued_at < ?
+           AND e.monitor_id = ?
+         ORDER BY COALESCE(e.started_at, e.queued_at, e.created_at) DESC, e.id DESC
+         LIMIT 1
+        """;
+    List<Execution> rows = jdbc.query(sql, this::execution, start, end, taskId);
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  private Execution execution(ResultSet rs, int rowNum) throws SQLException {
+    String taskId = rs.getString("task_id");
+    return new Execution(
+        taskId,
+        text(rs.getString("task_name"), "数据质量任务 #" + taskId),
+        normalize(rs.getString("status")),
+        localDateTime(rs, "occurred_at"),
+        rs.getLong("duration_ms"),
+        rs.getString("execution_id"));
+  }
+
+  private TaskAggregate taskAggregate(ResultSet rs, int rowNum) throws SQLException {
+    return new TaskAggregate(
+        rs.getLong("task_id"),
+        rs.getString("task_name"),
+        rs.getLong("run_count"),
+        rs.getLong("success_count"),
+        rs.getLong("failed_count"),
+        localDateTime(rs, "last_run_time"));
+  }
+
+  private TaskSummary summary(TaskAggregate aggregate, Execution last) {
+    String taskId = String.valueOf(aggregate.taskId());
+    return new TaskSummary(
+        taskId,
+        text(aggregate.taskName(), "数据质量任务 #" + taskId),
+        aggregate.lastRunTime(),
+        aggregate.runCount(),
+        aggregate.successCount(),
+        aggregate.failedCount(),
+        last == null ? 0L : last.durationMs(),
+        last == null ? "UNKNOWN" : last.status(),
+        last == null ? null : last.executionId());
+  }
+
+  private static LocalDate date(ResultSet rs, String column) throws SQLException {
+    Date value = rs.getDate(column);
+    return value == null ? LocalDate.of(1970, 1, 1) : value.toLocalDate();
+  }
+
+  private static LocalDateTime localDateTime(ResultSet rs, String column) throws SQLException {
+    Timestamp value = rs.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static String text(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private record TaskAggregate(
+      long taskId,
+      String taskName,
+      long runCount,
+      long successCount,
+      long failedCount,
+      LocalDateTime lastRunTime) {}
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityExecutionOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityExecutionOverviewReader.java
@@ -1,0 +1,106 @@
+package io.yak.ops.business.quality.workspace;
+
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.repository.QualityExecutionOverviewRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** 数据质量 execution 运行统计 Reader；持久化细节停在 Repository adapter。 */
+@Component
+@ConditionalOnQualityEnabled
+public class QualityExecutionOverviewReader {
+
+  private final QualityExecutionOverviewRepository repository;
+
+  public QualityExecutionOverviewReader(QualityExecutionOverviewRepository repository) {
+    this.repository = repository;
+  }
+
+  public Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend) {
+    return overview(repository.overview(start, end, hourlyTrend));
+  }
+
+  public Execution latest(LocalDateTime start, LocalDateTime end) {
+    return execution(repository.latest(start, end));
+  }
+
+  public TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end) {
+    return task(repository.taskSummary(taskId, start, end));
+  }
+
+  public List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit) {
+    return repository.recentTasks(start, end, limit).stream().map(this::task).toList();
+  }
+
+  private Overview overview(QualityExecutionOverviewRepository.Overview value) {
+    return value == null
+        ? new Overview(Metrics.empty(), List.of(), null)
+        : new Overview(
+            metrics(value.metrics()),
+            value.trend().stream()
+                .map(item -> new TrendPoint(item.bucket(), item.count()))
+                .toList(),
+            execution(value.latest()));
+  }
+
+  private Metrics metrics(QualityExecutionOverviewRepository.Metrics value) {
+    if (value == null) return Metrics.empty();
+    return new Metrics(
+        value.successCount(), value.runningCount(), value.failedCount(), value.scheduleCount(),
+        value.processedRecords(), value.durationTotalMs(), value.durationSampleCount());
+  }
+
+  private Execution execution(QualityExecutionOverviewRepository.Execution value) {
+    return value == null ? null : new Execution(
+        value.taskId(), value.taskName(), value.status(), value.occurredAt(),
+        value.durationMs(), value.executionId());
+  }
+
+  private TaskSummary task(QualityExecutionOverviewRepository.TaskSummary value) {
+    return value == null ? null : new TaskSummary(
+        value.taskId(), value.taskName(), value.lastRunTime(), value.runCount(),
+        value.successCount(), value.failedCount(), value.lastDurationMs(), value.lastStatus(),
+        value.executionId());
+  }
+
+  public record Overview(Metrics metrics, List<TrendPoint> trend, Execution latest) {
+    public Overview {
+      trend = trend == null ? List.of() : List.copyOf(trend);
+    }
+  }
+
+  public record Metrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long durationTotalMs,
+      long durationSampleCount) {
+    static Metrics empty() {
+      return new Metrics(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+  }
+
+  public record TrendPoint(LocalDateTime bucket, long count) {}
+
+  public record Execution(
+      String taskId,
+      String taskName,
+      String status,
+      LocalDateTime occurredAt,
+      long durationMs,
+      String executionId) {}
+
+  public record TaskSummary(
+      String taskId,
+      String taskName,
+      LocalDateTime lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String executionId) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionOverviewReader.java
@@ -1,0 +1,129 @@
+package io.yak.ops.business.sync.offline.execution.query;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.repository.OfflineExecutionOverviewRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** 离线同步 execution 运行统计 Reader；持久化细节停在 Repository adapter。 */
+@Component
+@ConditionalOnOfflineSyncEnabled
+public class OfflineExecutionOverviewReader {
+
+  private final OfflineExecutionOverviewRepository repository;
+
+  public OfflineExecutionOverviewReader(OfflineExecutionOverviewRepository repository) {
+    this.repository = repository;
+  }
+
+  public Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend) {
+    return overview(repository.overview(start, end, hourlyTrend));
+  }
+
+  public Execution latest(LocalDateTime start, LocalDateTime end) {
+    return execution(repository.latest(start, end));
+  }
+
+  public TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end) {
+    return task(repository.taskSummary(taskId, start, end));
+  }
+
+  public List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit) {
+    return repository.recentTasks(start, end, limit).stream().map(this::task).toList();
+  }
+
+  public List<ScheduleSummary> schedules(int limit) {
+    return repository.schedules(limit).stream().map(this::schedule).toList();
+  }
+
+  private Overview overview(OfflineExecutionOverviewRepository.Overview value) {
+    return value == null
+        ? new Overview(Metrics.empty(), List.of(), null)
+        : new Overview(
+            metrics(value.metrics()),
+            value.trend().stream()
+                .map(item -> new TrendPoint(item.bucket(), item.count()))
+                .toList(),
+            execution(value.latest()));
+  }
+
+  private Metrics metrics(OfflineExecutionOverviewRepository.Metrics value) {
+    if (value == null) return Metrics.empty();
+    return new Metrics(
+        value.successCount(),
+        value.runningCount(),
+        value.failedCount(),
+        value.scheduleCount(),
+        value.processedRecords(),
+        value.durationTotalMs(),
+        value.durationSampleCount());
+  }
+
+  private Execution execution(OfflineExecutionOverviewRepository.Execution value) {
+    return value == null ? null : new Execution(
+        value.taskId(), value.taskName(), value.status(), value.occurredAt(),
+        value.durationMs(), value.executionId());
+  }
+
+  private TaskSummary task(OfflineExecutionOverviewRepository.TaskSummary value) {
+    return value == null ? null : new TaskSummary(
+        value.taskId(), value.taskName(), value.lastRunTime(), value.runCount(),
+        value.successCount(), value.failedCount(), value.lastDurationMs(), value.lastStatus(),
+        value.executionId());
+  }
+
+  private ScheduleSummary schedule(OfflineExecutionOverviewRepository.ScheduleSummary value) {
+    return new ScheduleSummary(
+        value.taskId(), value.taskName(), value.cronExpression(), value.status(),
+        value.lastScheduleTime(), value.nextScheduleTime());
+  }
+
+  public record Overview(Metrics metrics, List<TrendPoint> trend, Execution latest) {
+    public Overview {
+      trend = trend == null ? List.of() : List.copyOf(trend);
+    }
+  }
+
+  public record Metrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long durationTotalMs,
+      long durationSampleCount) {
+    static Metrics empty() {
+      return new Metrics(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+  }
+
+  public record TrendPoint(LocalDateTime bucket, long count) {}
+
+  public record Execution(
+      String taskId,
+      String taskName,
+      String status,
+      LocalDateTime occurredAt,
+      long durationMs,
+      String executionId) {}
+
+  public record TaskSummary(
+      String taskId,
+      String taskName,
+      LocalDateTime lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String executionId) {}
+
+  public record ScheduleSummary(
+      String taskId,
+      String taskName,
+      String cronExpression,
+      String status,
+      LocalDateTime lastScheduleTime,
+      LocalDateTime nextScheduleTime) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionOverviewRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionOverviewRepository.java
@@ -1,0 +1,77 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 离线同步运行总览持久化读模型 contract。 */
+public interface OfflineExecutionOverviewRepository {
+
+  Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend);
+
+  Execution latest(LocalDateTime start, LocalDateTime end);
+
+  TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end);
+
+  List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit);
+
+  List<ScheduleSummary> schedules(int limit);
+
+  record Overview(Metrics metrics, List<TrendPoint> trend, Execution latest) {
+    public Overview {
+      trend = trend == null ? List.of() : List.copyOf(trend);
+    }
+  }
+
+  record Metrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long durationTotalMs,
+      long durationSampleCount) {
+    public static Metrics empty() {
+      return new Metrics(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+
+    public Metrics withRunning(long value) {
+      return new Metrics(
+          successCount,
+          value,
+          failedCount,
+          scheduleCount,
+          processedRecords,
+          durationTotalMs,
+          durationSampleCount);
+    }
+  }
+
+  record TrendPoint(LocalDateTime bucket, long count) {}
+
+  record Execution(
+      String taskId,
+      String taskName,
+      String status,
+      LocalDateTime occurredAt,
+      long durationMs,
+      String executionId) {}
+
+  record TaskSummary(
+      String taskId,
+      String taskName,
+      LocalDateTime lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String executionId) {}
+
+  record ScheduleSummary(
+      String taskId,
+      String taskName,
+      String cronExpression,
+      String status,
+      LocalDateTime lastScheduleTime,
+      LocalDateTime nextScheduleTime) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionOverviewRepositoryAdapter.java
@@ -1,0 +1,301 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.core.project.CurrentProject;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** MySQL-backed offline execution overview projection. */
+@Repository
+@ConditionalOnOfflineSyncEnabled
+public class OfflineExecutionOverviewRepositoryAdapter
+    implements OfflineExecutionOverviewRepository {
+
+  private static final String SUCCESS_STATUSES =
+      "'SUCCEEDED','SUCCESS','FINISHED','COMPLETED'";
+  private static final String FAILED_STATUSES = "'FAILED','LOST'";
+  private static final String RUNNING_STATUSES =
+      "'CREATED','SUBMITTED','QUEUED','RUNNING'";
+
+  private final JdbcTemplate jdbc;
+  private final CurrentProject currentProject;
+
+  public OfflineExecutionOverviewRepositoryAdapter(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      CurrentProject currentProject) {
+    this.jdbc = new JdbcTemplate(dataSource);
+    this.currentProject = currentProject;
+  }
+
+  @Override
+  public Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend) {
+    return new Overview(metrics(start, end), trend(start, end, hourlyTrend), latest(start, end));
+  }
+
+  @Override
+  public Execution latest(LocalDateTime start, LocalDateTime end) {
+    Scope scope = scope("e");
+    String sql = """
+        SELECT e.job_definition_id AS task_id,
+               d.job_name AS task_name,
+               e.status,
+               COALESCE(e.start_time, e.create_time, e.update_time) AS occurred_at,
+               COALESCE(e.duration_millis, 0) AS duration_ms,
+               CAST(e.id AS CHAR) AS execution_id
+          FROM yak_offline_job_execution e
+          LEFT JOIN yak_offline_job_definition d ON d.id = e.job_definition_id
+         WHERE e.create_time >= ? AND e.create_time < ?
+        """ + scope.sql()
+        + " ORDER BY COALESCE(e.start_time, e.create_time, e.update_time) DESC, e.id DESC LIMIT 1";
+    List<Execution> rows = jdbc.query(sql, this::execution, args(scope, start, end));
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  @Override
+  public TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end) {
+    if (taskId == null || taskId.isBlank()) return null;
+    long id;
+    try {
+      id = Long.parseLong(taskId);
+    } catch (NumberFormatException ignored) {
+      return null;
+    }
+
+    Scope scope = scope("e");
+    String sql = """
+        SELECT e.job_definition_id AS task_id,
+               MAX(d.job_name) AS task_name,
+               COUNT(*) AS run_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS success_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
+               MAX(COALESCE(e.start_time, e.create_time, e.update_time)) AS last_run_time
+          FROM yak_offline_job_execution e
+          LEFT JOIN yak_offline_job_definition d ON d.id = e.job_definition_id
+         WHERE e.create_time >= ? AND e.create_time < ?
+           AND e.job_definition_id = ?
+        """.formatted(SUCCESS_STATUSES, FAILED_STATUSES)
+        + scope.sql()
+        + " GROUP BY e.job_definition_id";
+    List<TaskAggregate> aggregates =
+        jdbc.query(sql, this::taskAggregate, args(scope, start, end, id));
+    if (aggregates.isEmpty()) return null;
+    return summary(aggregates.get(0), latestForTask(id, start, end));
+  }
+
+  @Override
+  public List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit) {
+    int boundedLimit = Math.max(1, Math.min(limit, 20));
+    Scope scope = scope("e");
+    String sql = """
+        SELECT e.job_definition_id AS task_id,
+               MAX(d.job_name) AS task_name,
+               COUNT(*) AS run_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS success_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
+               MAX(COALESCE(e.start_time, e.create_time, e.update_time)) AS last_run_time
+          FROM yak_offline_job_execution e
+          LEFT JOIN yak_offline_job_definition d ON d.id = e.job_definition_id
+         WHERE e.create_time >= ? AND e.create_time < ?
+        """.formatted(SUCCESS_STATUSES, FAILED_STATUSES)
+        + scope.sql()
+        + " GROUP BY e.job_definition_id ORDER BY last_run_time DESC LIMIT " + boundedLimit;
+    List<TaskAggregate> aggregates = jdbc.query(sql, this::taskAggregate, args(scope, start, end));
+    List<TaskSummary> result = new ArrayList<>(aggregates.size());
+    for (TaskAggregate aggregate : aggregates) {
+      result.add(summary(aggregate, latestForTask(aggregate.taskId(), start, end)));
+    }
+    return List.copyOf(result);
+  }
+
+  @Override
+  public List<ScheduleSummary> schedules(int limit) {
+    int boundedLimit = Math.max(1, Math.min(limit, 50));
+    Scope scope = scope("d");
+    String sql = """
+        SELECT CAST(d.id AS CHAR) AS task_id,
+               d.job_name AS task_name,
+               d.cron_expression,
+               d.schedule_last_fire_time,
+               d.schedule_next_fire_time
+          FROM yak_offline_job_definition d
+         WHERE d.schedule_enabled = 1
+        """ + scope.sql()
+        + " ORDER BY d.schedule_next_fire_time DESC LIMIT " + boundedLimit;
+    return jdbc.query(
+        sql,
+        (rs, rowNum) -> new ScheduleSummary(
+            rs.getString("task_id"),
+            text(rs.getString("task_name"), "离线同步任务"),
+            rs.getString("cron_expression"),
+            "ENABLED",
+            localDateTime(rs, "schedule_last_fire_time"),
+            localDateTime(rs, "schedule_next_fire_time")),
+        scope.params().toArray());
+  }
+
+  private Metrics metrics(LocalDateTime start, LocalDateTime end) {
+    Scope scope = scope("e");
+    String sql = """
+        SELECT COALESCE(SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END), 0) AS success_count,
+               COALESCE(SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END), 0) AS failed_count,
+               COALESCE(SUM(CASE WHEN UPPER(e.trigger_type) = 'SCHEDULE' THEN 1 ELSE 0 END), 0) AS schedule_count,
+               COALESCE(SUM(COALESCE(e.sink_success_record_count, 0)), 0) AS processed_records,
+               COALESCE(SUM(CASE WHEN UPPER(e.status) NOT IN (%s) AND COALESCE(e.duration_millis, 0) > 0 THEN e.duration_millis ELSE 0 END), 0) AS duration_total_ms,
+               COALESCE(SUM(CASE WHEN UPPER(e.status) NOT IN (%s) AND COALESCE(e.duration_millis, 0) > 0 THEN 1 ELSE 0 END), 0) AS duration_sample_count
+          FROM yak_offline_job_execution e
+         WHERE e.create_time >= ? AND e.create_time < ?
+        """.formatted(
+            SUCCESS_STATUSES, FAILED_STATUSES, RUNNING_STATUSES, RUNNING_STATUSES)
+        + scope.sql();
+    Metrics aggregate = jdbc.queryForObject(
+        sql,
+        (rs, rowNum) -> new Metrics(
+            rs.getLong("success_count"),
+            0L,
+            rs.getLong("failed_count"),
+            rs.getLong("schedule_count"),
+            rs.getLong("processed_records"),
+            rs.getLong("duration_total_ms"),
+            rs.getLong("duration_sample_count")),
+        args(scope, start, end));
+    return (aggregate == null ? Metrics.empty() : aggregate).withRunning(runningAt(end));
+  }
+
+  private long runningAt(LocalDateTime point) {
+    Scope scope = scope("e");
+    String sql = """
+        SELECT COUNT(*)
+          FROM yak_offline_job_execution e
+         WHERE e.create_time <= ?
+           AND (e.end_time IS NULL OR e.end_time > ?)
+        """ + scope.sql();
+    Long value = jdbc.queryForObject(sql, Long.class, args(scope, point, point));
+    return value == null ? 0L : value;
+  }
+
+  private List<TrendPoint> trend(LocalDateTime start, LocalDateTime end, boolean hourly) {
+    Scope scope = scope("e");
+    String bucketHour = hourly
+        ? "FLOOR(HOUR(COALESCE(e.start_time, e.create_time, e.update_time)) / 4) * 4"
+        : "0";
+    String sql = "SELECT DATE(COALESCE(e.start_time, e.create_time, e.update_time)) AS bucket_date, "
+        + bucketHour + " AS bucket_hour, COUNT(*) AS total "
+        + "FROM yak_offline_job_execution e "
+        + "WHERE e.create_time >= ? AND e.create_time < ? "
+        + scope.sql()
+        + " GROUP BY bucket_date, bucket_hour ORDER BY bucket_date, bucket_hour";
+    return jdbc.query(
+        sql,
+        (rs, rowNum) -> new TrendPoint(
+            date(rs, "bucket_date").atTime(rs.getInt("bucket_hour"), 0),
+            rs.getLong("total")),
+        args(scope, start, end));
+  }
+
+  private Execution latestForTask(long taskId, LocalDateTime start, LocalDateTime end) {
+    Scope scope = scope("e");
+    String sql = """
+        SELECT e.job_definition_id AS task_id,
+               d.job_name AS task_name,
+               e.status,
+               COALESCE(e.start_time, e.create_time, e.update_time) AS occurred_at,
+               COALESCE(e.duration_millis, 0) AS duration_ms,
+               CAST(e.id AS CHAR) AS execution_id
+          FROM yak_offline_job_execution e
+          LEFT JOIN yak_offline_job_definition d ON d.id = e.job_definition_id
+         WHERE e.create_time >= ? AND e.create_time < ?
+           AND e.job_definition_id = ?
+        """ + scope.sql()
+        + " ORDER BY COALESCE(e.start_time, e.create_time, e.update_time) DESC, e.id DESC LIMIT 1";
+    List<Execution> rows = jdbc.query(sql, this::execution, args(scope, start, end, taskId));
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  private Execution execution(ResultSet rs, int rowNum) throws SQLException {
+    String taskId = rs.getString("task_id");
+    return new Execution(
+        taskId,
+        text(rs.getString("task_name"), "离线同步任务 #" + taskId),
+        normalize(rs.getString("status")),
+        localDateTime(rs, "occurred_at"),
+        rs.getLong("duration_ms"),
+        rs.getString("execution_id"));
+  }
+
+  private TaskAggregate taskAggregate(ResultSet rs, int rowNum) throws SQLException {
+    return new TaskAggregate(
+        rs.getLong("task_id"),
+        rs.getString("task_name"),
+        rs.getLong("run_count"),
+        rs.getLong("success_count"),
+        rs.getLong("failed_count"),
+        localDateTime(rs, "last_run_time"));
+  }
+
+  private TaskSummary summary(TaskAggregate aggregate, Execution last) {
+    String taskId = String.valueOf(aggregate.taskId());
+    return new TaskSummary(
+        taskId,
+        text(aggregate.taskName(), "离线同步任务 #" + taskId),
+        aggregate.lastRunTime(),
+        aggregate.runCount(),
+        aggregate.successCount(),
+        aggregate.failedCount(),
+        last == null ? 0L : last.durationMs(),
+        last == null ? "UNKNOWN" : last.status(),
+        last == null ? null : last.executionId());
+  }
+
+  private Scope scope(String alias) {
+    Long projectId = currentProject.current().map(context -> context.projectId()).orElse(null);
+    return projectId == null
+        ? new Scope("", List.of())
+        : new Scope(" AND " + alias + ".project_id = ?", List.of(projectId));
+  }
+
+  private Object[] args(Scope scope, Object... values) {
+    List<Object> args = new ArrayList<>(values.length + scope.params().size());
+    for (Object value : values) args.add(value);
+    args.addAll(scope.params());
+    return args.toArray();
+  }
+
+  private static LocalDate date(ResultSet rs, String column) throws SQLException {
+    Date value = rs.getDate(column);
+    return value == null ? LocalDate.of(1970, 1, 1) : value.toLocalDate();
+  }
+
+  private static LocalDateTime localDateTime(ResultSet rs, String column) throws SQLException {
+    Timestamp value = rs.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static String text(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private record TaskAggregate(
+      long taskId,
+      String taskName,
+      long runCount,
+      long successCount,
+      long failedCount,
+      LocalDateTime lastRunTime) {}
+
+  private record Scope(String sql, List<Object> params) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V7__add_execution_overview_indexes.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V7__add_execution_overview_indexes.sql
@@ -1,0 +1,11 @@
+-- 首页/运行总览按 execution create_time 做时间窗口聚合。
+ALTER TABLE yak_offline_job_execution
+    ADD KEY idx_yak_offline_execution_created (create_time, id),
+    ADD KEY idx_yak_offline_execution_project_created (project_id, create_time, id);
+
+-- 首页 legacy schedule summary 同时覆盖全局读与 Project Space 内读取。
+ALTER TABLE yak_offline_job_definition
+    ADD KEY idx_yak_offline_schedule_next
+      (schedule_enabled, schedule_next_fire_time),
+    ADD KEY idx_yak_offline_project_schedule_next
+      (project_id, schedule_enabled, schedule_next_fire_time);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionOverviewReader.java
@@ -1,0 +1,128 @@
+package io.yak.ops.business.workflow.execution;
+
+import io.yak.ops.business.workflow.repository.WorkflowExecutionOverviewRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/** Workflow execution statistics Reader; persistence stays behind Repository. */
+@Component
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowExecutionOverviewReader {
+
+  private final WorkflowExecutionOverviewRepository repository;
+
+  public WorkflowExecutionOverviewReader(WorkflowExecutionOverviewRepository repository) {
+    this.repository = repository;
+  }
+
+  public Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend) {
+    return overview(repository.overview(start, end, hourlyTrend));
+  }
+
+  public Execution latest(LocalDateTime start, LocalDateTime end) {
+    return execution(repository.latest(start, end));
+  }
+
+  public TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end) {
+    return task(repository.taskSummary(taskId, start, end));
+  }
+
+  public List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit) {
+    return repository.recentTasks(start, end, limit).stream().map(this::task).toList();
+  }
+
+  public List<ScheduleSummary> schedules(int limit) {
+    return repository.schedules(limit).stream().map(this::schedule).toList();
+  }
+
+  private Overview overview(WorkflowExecutionOverviewRepository.Overview value) {
+    return value == null
+        ? new Overview(Metrics.empty(), List.of(), null)
+        : new Overview(
+            metrics(value.metrics()),
+            value.trend().stream()
+                .map(item -> new TrendPoint(item.bucket(), item.count()))
+                .toList(),
+            execution(value.latest()));
+  }
+
+  private Metrics metrics(WorkflowExecutionOverviewRepository.Metrics value) {
+    if (value == null) return Metrics.empty();
+    return new Metrics(
+        value.successCount(), value.runningCount(), value.failedCount(), value.scheduleCount(),
+        value.processedRecords(), value.durationTotalMs(), value.durationSampleCount());
+  }
+
+  private Execution execution(WorkflowExecutionOverviewRepository.Execution value) {
+    return value == null ? null : new Execution(
+        value.taskId(), value.taskName(), value.status(), value.occurredAt(),
+        value.durationMs(), value.executionId());
+  }
+
+  private TaskSummary task(WorkflowExecutionOverviewRepository.TaskSummary value) {
+    return value == null ? null : new TaskSummary(
+        value.taskId(), value.taskName(), value.lastRunTime(), value.runCount(),
+        value.successCount(), value.failedCount(), value.lastDurationMs(), value.lastStatus(),
+        value.executionId());
+  }
+
+  private ScheduleSummary schedule(WorkflowExecutionOverviewRepository.ScheduleSummary value) {
+    return new ScheduleSummary(
+        value.taskId(), value.taskName(), value.cronExpression(), value.status(),
+        value.lastScheduleTime(), value.nextScheduleTime());
+  }
+
+  public record Overview(Metrics metrics, List<TrendPoint> trend, Execution latest) {
+    public Overview {
+      trend = trend == null ? List.of() : List.copyOf(trend);
+    }
+  }
+
+  public record Metrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long durationTotalMs,
+      long durationSampleCount) {
+    static Metrics empty() {
+      return new Metrics(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+  }
+
+  public record TrendPoint(LocalDateTime bucket, long count) {}
+
+  public record Execution(
+      String taskId,
+      String taskName,
+      String status,
+      LocalDateTime occurredAt,
+      long durationMs,
+      String executionId) {}
+
+  public record TaskSummary(
+      String taskId,
+      String taskName,
+      LocalDateTime lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String executionId) {}
+
+  public record ScheduleSummary(
+      String taskId,
+      String taskName,
+      String cronExpression,
+      String status,
+      LocalDateTime lastScheduleTime,
+      LocalDateTime nextScheduleTime) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowExecutionOverviewRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowExecutionOverviewRepository.java
@@ -1,0 +1,77 @@
+package io.yak.ops.business.workflow.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** Workflow execution overview persistence read contract. */
+public interface WorkflowExecutionOverviewRepository {
+
+  Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend);
+
+  Execution latest(LocalDateTime start, LocalDateTime end);
+
+  TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end);
+
+  List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit);
+
+  List<ScheduleSummary> schedules(int limit);
+
+  record Overview(Metrics metrics, List<TrendPoint> trend, Execution latest) {
+    public Overview {
+      trend = trend == null ? List.of() : List.copyOf(trend);
+    }
+  }
+
+  record Metrics(
+      long successCount,
+      long runningCount,
+      long failedCount,
+      long scheduleCount,
+      long processedRecords,
+      long durationTotalMs,
+      long durationSampleCount) {
+    public static Metrics empty() {
+      return new Metrics(0L, 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+
+    public Metrics withRunning(long value) {
+      return new Metrics(
+          successCount,
+          value,
+          failedCount,
+          scheduleCount,
+          processedRecords,
+          durationTotalMs,
+          durationSampleCount);
+    }
+  }
+
+  record TrendPoint(LocalDateTime bucket, long count) {}
+
+  record Execution(
+      String taskId,
+      String taskName,
+      String status,
+      LocalDateTime occurredAt,
+      long durationMs,
+      String executionId) {}
+
+  record TaskSummary(
+      String taskId,
+      String taskName,
+      LocalDateTime lastRunTime,
+      long runCount,
+      long successCount,
+      long failedCount,
+      long lastDurationMs,
+      String lastStatus,
+      String executionId) {}
+
+  record ScheduleSummary(
+      String taskId,
+      String taskName,
+      String cronExpression,
+      String status,
+      LocalDateTime lastScheduleTime,
+      LocalDateTime nextScheduleTime) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowExecutionOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowExecutionOverviewRepositoryAdapter.java
@@ -1,0 +1,319 @@
+package io.yak.ops.business.workflow.repository;
+
+import io.yak.ops.core.project.CurrentProject;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** MySQL-backed Workflow execution overview projection. */
+@Repository
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowExecutionOverviewRepositoryAdapter
+    implements WorkflowExecutionOverviewRepository {
+
+  private static final String SUCCESS_STATUSES =
+      "'SUCCESS','SUCCESS_WITH_WARNINGS','WARNING'";
+  private static final String FAILED_STATUSES = "'FAILED','TIMED_OUT'";
+  private static final String RUNNING_STATUSES =
+      "'CREATED','RUNNING','PAUSING','PAUSED','RESUMING'";
+
+  private final JdbcTemplate jdbc;
+  private final CurrentProject currentProject;
+
+  public WorkflowExecutionOverviewRepositoryAdapter(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      CurrentProject currentProject) {
+    this.jdbc = new JdbcTemplate(dataSource);
+    this.currentProject = currentProject;
+  }
+
+  @Override
+  public Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend) {
+    return new Overview(metrics(start, end), trend(start, end, hourlyTrend), latest(start, end));
+  }
+
+  @Override
+  public Execution latest(LocalDateTime start, LocalDateTime end) {
+    Scope scope = scope("e");
+    String sql = """
+        SELECT COALESCE(NULLIF(e.definition_id, ''), e.id) AS task_id,
+               e.workflow_name AS task_name,
+               e.status,
+               COALESCE(e.run_started_at, e.created_at, e.updated_at) AS occurred_at,
+               CASE
+                 WHEN e.ended_at IS NULL THEN 0
+                 ELSE GREATEST(0, TIMESTAMPDIFF(MICROSECOND,
+                      COALESCE(e.run_started_at, e.created_at, e.updated_at), e.ended_at) / 1000)
+               END AS duration_ms,
+               e.id AS execution_id
+          FROM yak_workflow_execution e
+         WHERE e.created_at >= ? AND e.created_at < ?
+        """ + scope.sql()
+        + " ORDER BY COALESCE(e.run_started_at, e.created_at, e.updated_at) DESC, e.id DESC LIMIT 1";
+    List<Execution> rows = jdbc.query(sql, this::execution, args(scope, start, end));
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  @Override
+  public TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end) {
+    if (taskId == null || taskId.isBlank()) return null;
+    Scope scope = scope("e");
+    String sql = """
+        SELECT COALESCE(NULLIF(e.definition_id, ''), e.id) AS task_id,
+               MAX(e.workflow_name) AS task_name,
+               COUNT(*) AS run_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS success_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
+               MAX(COALESCE(e.run_started_at, e.created_at, e.updated_at)) AS last_run_time
+          FROM yak_workflow_execution e
+         WHERE e.created_at >= ? AND e.created_at < ?
+           AND COALESCE(NULLIF(e.definition_id, ''), e.id) = ?
+        """.formatted(SUCCESS_STATUSES, FAILED_STATUSES)
+        + scope.sql()
+        + " GROUP BY COALESCE(NULLIF(e.definition_id, ''), e.id)";
+    List<TaskAggregate> aggregates =
+        jdbc.query(sql, this::taskAggregate, args(scope, start, end, taskId));
+    if (aggregates.isEmpty()) return null;
+    return summary(aggregates.get(0), latestForTask(taskId, start, end));
+  }
+
+  @Override
+  public List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit) {
+    int boundedLimit = Math.max(1, Math.min(limit, 20));
+    Scope scope = scope("e");
+    String sql = """
+        SELECT COALESCE(NULLIF(e.definition_id, ''), e.id) AS task_id,
+               MAX(e.workflow_name) AS task_name,
+               COUNT(*) AS run_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS success_count,
+               SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
+               MAX(COALESCE(e.run_started_at, e.created_at, e.updated_at)) AS last_run_time
+          FROM yak_workflow_execution e
+         WHERE e.created_at >= ? AND e.created_at < ?
+        """.formatted(SUCCESS_STATUSES, FAILED_STATUSES)
+        + scope.sql()
+        + " GROUP BY COALESCE(NULLIF(e.definition_id, ''), e.id)"
+        + " ORDER BY last_run_time DESC LIMIT " + boundedLimit;
+    List<TaskAggregate> aggregates = jdbc.query(sql, this::taskAggregate, args(scope, start, end));
+    List<TaskSummary> result = new ArrayList<>(aggregates.size());
+    for (TaskAggregate aggregate : aggregates) {
+      result.add(summary(aggregate, latestForTask(aggregate.taskId(), start, end)));
+    }
+    return List.copyOf(result);
+  }
+
+  @Override
+  public List<ScheduleSummary> schedules(int limit) {
+    int boundedLimit = Math.max(1, Math.min(limit, 50));
+    Scope scope = scope("s");
+    String sql = """
+        SELECT s.id AS task_id,
+               s.name AS task_name,
+               s.cron_expression,
+               s.status,
+               s.last_fire_time,
+               s.next_fire_time
+          FROM yak_workflow_schedule s
+         WHERE 1 = 1
+        """ + scope.sql()
+        + " ORDER BY s.next_fire_time DESC LIMIT " + boundedLimit;
+    return jdbc.query(
+        sql,
+        (rs, rowNum) -> new ScheduleSummary(
+            rs.getString("task_id"),
+            text(rs.getString("task_name"), "工作流调度"),
+            rs.getString("cron_expression"),
+            normalize(rs.getString("status")),
+            localDateTime(rs, "last_fire_time"),
+            localDateTime(rs, "next_fire_time")),
+        scope.params().toArray());
+  }
+
+  private Metrics metrics(LocalDateTime start, LocalDateTime end) {
+    Scope scope = scope("e");
+    String duration = "GREATEST(0, TIMESTAMPDIFF(MICROSECOND, "
+        + "COALESCE(e.run_started_at, e.created_at, e.updated_at), e.ended_at) / 1000)";
+    String sql = ("""
+        SELECT COALESCE(SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END), 0) AS success_count,
+               COALESCE(SUM(CASE WHEN UPPER(e.status) IN (%s) THEN 1 ELSE 0 END), 0) AS failed_count,
+               COALESCE(SUM(CASE WHEN UPPER(e.status) NOT IN (%s)
+                                  AND e.ended_at IS NOT NULL
+                                  AND %s > 0 THEN %s ELSE 0 END), 0) AS duration_total_ms,
+               COALESCE(SUM(CASE WHEN UPPER(e.status) NOT IN (%s)
+                                  AND e.ended_at IS NOT NULL
+                                  AND %s > 0 THEN 1 ELSE 0 END), 0) AS duration_sample_count
+          FROM yak_workflow_execution e
+         WHERE e.created_at >= ? AND e.created_at < ?
+        """).formatted(
+            SUCCESS_STATUSES,
+            FAILED_STATUSES,
+            RUNNING_STATUSES,
+            duration,
+            duration,
+            RUNNING_STATUSES,
+            duration)
+        + scope.sql();
+    Metrics aggregate = jdbc.queryForObject(
+        sql,
+        (rs, rowNum) -> new Metrics(
+            rs.getLong("success_count"),
+            0L,
+            rs.getLong("failed_count"),
+            0L,
+            0L,
+            rs.getLong("duration_total_ms"),
+            rs.getLong("duration_sample_count")),
+        args(scope, start, end));
+    return (aggregate == null ? Metrics.empty() : aggregate).withRunning(runningAt(end));
+  }
+
+  private long runningAt(LocalDateTime point) {
+    Scope scope = scope("e");
+    String sql = """
+        SELECT COUNT(*)
+          FROM yak_workflow_execution e
+         WHERE e.created_at <= ?
+           AND (e.ended_at IS NULL OR e.ended_at > ?)
+        """ + scope.sql();
+    Long value = jdbc.queryForObject(sql, Long.class, args(scope, point, point));
+    return value == null ? 0L : value;
+  }
+
+  private List<TrendPoint> trend(LocalDateTime start, LocalDateTime end, boolean hourly) {
+    Scope scope = scope("e");
+    String occurredAt = "COALESCE(e.run_started_at, e.created_at, e.updated_at)";
+    String bucketHour = hourly ? "FLOOR(HOUR(" + occurredAt + ") / 4) * 4" : "0";
+    String sql = "SELECT DATE(" + occurredAt + ") AS bucket_date, "
+        + bucketHour + " AS bucket_hour, COUNT(*) AS total "
+        + "FROM yak_workflow_execution e "
+        + "WHERE e.created_at >= ? AND e.created_at < ? "
+        + scope.sql()
+        + " GROUP BY bucket_date, bucket_hour ORDER BY bucket_date, bucket_hour";
+    return jdbc.query(
+        sql,
+        (rs, rowNum) -> new TrendPoint(
+            date(rs, "bucket_date").atTime(rs.getInt("bucket_hour"), 0),
+            rs.getLong("total")),
+        args(scope, start, end));
+  }
+
+  private Execution latestForTask(String taskId, LocalDateTime start, LocalDateTime end) {
+    Scope scope = scope("e");
+    String sql = """
+        SELECT COALESCE(NULLIF(e.definition_id, ''), e.id) AS task_id,
+               e.workflow_name AS task_name,
+               e.status,
+               COALESCE(e.run_started_at, e.created_at, e.updated_at) AS occurred_at,
+               CASE
+                 WHEN e.ended_at IS NULL THEN 0
+                 ELSE GREATEST(0, TIMESTAMPDIFF(MICROSECOND,
+                      COALESCE(e.run_started_at, e.created_at, e.updated_at), e.ended_at) / 1000)
+               END AS duration_ms,
+               e.id AS execution_id
+          FROM yak_workflow_execution e
+         WHERE e.created_at >= ? AND e.created_at < ?
+           AND COALESCE(NULLIF(e.definition_id, ''), e.id) = ?
+        """ + scope.sql()
+        + " ORDER BY COALESCE(e.run_started_at, e.created_at, e.updated_at) DESC, e.id DESC LIMIT 1";
+    List<Execution> rows = jdbc.query(sql, this::execution, args(scope, start, end, taskId));
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  private Execution execution(ResultSet rs, int rowNum) throws SQLException {
+    String taskId = rs.getString("task_id");
+    return new Execution(
+        taskId,
+        text(rs.getString("task_name"), "工作流 #" + taskId),
+        normalize(rs.getString("status")),
+        localDateTime(rs, "occurred_at"),
+        rs.getLong("duration_ms"),
+        rs.getString("execution_id"));
+  }
+
+  private TaskAggregate taskAggregate(ResultSet rs, int rowNum) throws SQLException {
+    return new TaskAggregate(
+        rs.getString("task_id"),
+        rs.getString("task_name"),
+        rs.getLong("run_count"),
+        rs.getLong("success_count"),
+        rs.getLong("failed_count"),
+        localDateTime(rs, "last_run_time"));
+  }
+
+  private TaskSummary summary(TaskAggregate aggregate, Execution last) {
+    return new TaskSummary(
+        aggregate.taskId(),
+        text(aggregate.taskName(), "工作流 #" + aggregate.taskId()),
+        aggregate.lastRunTime(),
+        aggregate.runCount(),
+        aggregate.successCount(),
+        aggregate.failedCount(),
+        last == null ? 0L : last.durationMs(),
+        last == null ? "UNKNOWN" : last.status(),
+        last == null ? null : last.executionId());
+  }
+
+  private Scope scope(String alias) {
+    Long projectId = currentProject.current().map(context -> context.projectId()).orElse(null);
+    return projectId == null
+        ? new Scope("", List.of())
+        : new Scope(" AND " + alias + ".project_id = ?", List.of(projectId));
+  }
+
+  private Object[] args(Scope scope, Object... values) {
+    List<Object> args = new ArrayList<>(values.length + scope.params().size());
+    for (Object value : values) {
+      if (value instanceof LocalDateTime localDateTime) {
+        args.add(Timestamp.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant()));
+      } else {
+        args.add(value);
+      }
+    }
+    args.addAll(scope.params());
+    return args.toArray();
+  }
+
+  private static LocalDate date(ResultSet rs, String column) throws SQLException {
+    Date value = rs.getDate(column);
+    return value == null ? LocalDate.of(1970, 1, 1) : value.toLocalDate();
+  }
+
+  private static LocalDateTime localDateTime(ResultSet rs, String column) throws SQLException {
+    Timestamp value = rs.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private static String text(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private record TaskAggregate(
+      String taskId,
+      String taskName,
+      long runCount,
+      long successCount,
+      long failedCount,
+      LocalDateTime lastRunTime) {}
+
+  private record Scope(String sql, List<Object> params) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__add_execution_overview_indexes.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V3__add_execution_overview_indexes.sql
@@ -1,0 +1,8 @@
+-- Workflow 首页聚合在 Project Space 内按 created_at 扫描时间窗口。
+ALTER TABLE yak_workflow_execution
+    ADD KEY idx_yak_workflow_execution_project_created (project_id, created_at);
+
+-- Legacy 首页 schedule summary 同时覆盖全局读与 Project Space 内读取。
+ALTER TABLE yak_workflow_schedule
+    ADD KEY idx_yak_workflow_schedule_next_fire_only (next_fire_time),
+    ADD KEY idx_yak_workflow_schedule_project_next_fire (project_id, next_fire_time);


### PR DESCRIPTION
## Summary

- refactor `HomeDataCenterService` from direct cross-domain Mapper/PO access to domain-owned execution overview Readers
- establish `Reader -> Repository -> RepositoryAdapter` boundaries for Offline Sync, Workflow and Data Quality runtime projections
- push count/sum/duration/trend/task grouping into bounded SQL aggregation instead of loading whole execution windows into JVM memory
- inherit `CurrentProject` for Offline Sync and Workflow read models, avoiding Home-level persistence reads that bypass project scope
- isolate each domain read failure so one unavailable runtime module does not take down the whole Data Center section
- add targeted indexes for overview time windows and legacy schedule summaries

## Architecture

Before:

```text
HomeDataCenterService
  -> Offline Mapper / PO
  -> Workflow Mapper / PO
  -> Quality Mapper / PO
  -> Java List / Stream aggregation
```

After:

```text
HomeDataCenterService
  -> OfflineExecutionOverviewReader
       -> OfflineExecutionOverviewRepository
            -> RepositoryAdapter / SQL
  -> WorkflowExecutionOverviewReader
       -> WorkflowExecutionOverviewRepository
            -> RepositoryAdapter / SQL
  -> QualityExecutionOverviewReader
       -> QualityExecutionOverviewRepository
            -> RepositoryAdapter / SQL
```

`HomeDataCenterService` now owns only cross-domain composition: metric merging, trend merging, latest/recent task selection and the existing homepage response projection.

## Performance

The old implementation materialized all executions in the selected window and repeatedly scanned them in Java for current metrics, previous-period comparison, trends, latest task and recent tasks.

This PR changes those reads to database-side aggregation and bounded result sets:

- metrics: `COUNT/SUM/CASE`
- trend: day / 4-hour buckets in SQL
- recent tasks: grouped + bounded per source, then global top 5
- latest task: `ORDER BY ... LIMIT 1`
- schedules: bounded source reads before global top 8

JVM memory for the runtime overview is therefore bounded by trend points/task summaries instead of the number of execution rows in the period.

## Compatibility

No intentional HTTP or frontend contract change:

- `/api/v1/home/data-center/overview`
- `/api/v1/home/data-center/recent`
- `/api/v1/home/data-center/schedule`

Preserved semantics include:

- `yesterday / 7d / 30d` natural-day ranges ending yesterday
- existing per-domain success / failed / running status semantics
- point-in-time `runningCount`
- Quality `FAIL` remaining a quality issue rather than a technical execution failure
- 4-hour yesterday trend and daily multi-day trend
- last-7-day latest task activity summary and 90-day fallback lookup
- legacy detail paths, including `/workflow/schedules` for workflow schedule rows
- Workflow time-window parameter conversion through the JVM system timezone, matching the previous `LocalDateTime -> Instant` query behavior

## Failure isolation

Offline Sync, Workflow and Data Quality overview reads are independently guarded. If one Reader is unavailable or throws, Home keeps the other domains' projections instead of failing the entire Data Center response.

## Database migrations

Offline Sync:

- execution `create_time` index
- `(project_id, create_time)` execution index
- global and project-scoped schedule summary indexes

Workflow:

- `(project_id, created_at)` execution index
- global and project-scoped `next_fire_time` schedule indexes

Data Quality already has the queued-time index used by this projection, so no extra Quality migration is added.

## Tests / guards

Added:

- `HomeDataCenterServiceTest`
  - cross-domain metric/trend merge and weighted duration average
  - single-domain failure isolation
  - legacy schedule detail-path compatibility
- `HomeReadModelBoundaryTest`
  - prevents `HomeDataCenterService` from reintroducing Mapper/PO/JdbcTemplate/LambdaQueryWrapper persistence access

## Validation status

- [x] final branch rebased onto current `main` (`6a3bd1a`), ahead 1 / behind 0
- [x] final diff contains only 14 backend/test/Flyway files; no frontend or Controller changes
- [x] manually reviewed old/new period, status, running-count, trend, schedule and detail-path semantics
- [ ] full Maven compile/tests and real MySQL Flyway integration were not executed in the current tool environment; these should be run before merge
- [ ] on a production-scale database, review `EXPLAIN` for the 30-day overview and migration DDL duration/locking before rollout

## Out of scope

- homepage lifecycle / system-map UX and Attention Center (planned PR 3)
- changing the public Home API response model
- migrating the legacy Data Center schedule tab to the newer unified Schedule Center contract