### PR TITLE
feat(data-service): Stage 3 cluster runtime hardening

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-data-service/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Data Service Architecture
 
-> 本文是 `yak-ops-business-data-service` 的长期架构契约，描述职责归属、依赖方向和运行边界。历史迁移过程看 Git / PR。通用 Role Vocabulary 与 Java 规范遵循仓库根目录 [`CODE_STYLE.md`](../../CODE_STYLE.md)。Project/RBAC 与公网调用边界详见 `PROJECT_GOVERNANCE.md`。
+> 本文是 `yak-ops-business-data-service` 的长期架构契约。Project/RBAC 与公网调用边界详见 `PROJECT_GOVERNANCE.md`；多实例运行边界详见 `CLUSTER_RUNTIME.md`。
 
 ## 1. 模块定位
 
@@ -12,10 +12,11 @@ Data Service 位于“已发布数据资产”与“在线查询调用”之间�
 - 从 versioned Source Provider 发布/重新发布不可变 Revision；
 - 固定 SQL + Datasource Runtime Snapshot；
 - 单条只读 SELECT 编译与调用；
-- API Key 生命周期、鉴权和本地限流；
-- 单节点 Cache / Circuit Breaker / Runtime Metrics；
+- API Key 生命周期、鉴权和集群共享限流；
+- node-local Cache / Circuit Breaker；
+- cluster invocation metric projection；
 - API contract documentation / OpenAPI；
-- invocation audit / overview；
+- sanitized invocation audit / overview / retention / hourly rollup；
 - Yak Ops Management Plane 的 Project ownership 与 RBAC。
 
 不负责：
@@ -24,23 +25,25 @@ Data Service 位于“已发布数据资产”与“在线查询调用”之间�
 - Datasource connection/catalog/plugin 生命周期；
 - Offline/Realtime Sync orchestration；
 - 任意 DML/DDL；
-- 全局分布式缓存/限流；
-- 血缘、质量、指标计算；
+- shared result cache / distributed circuit state；
+- API Gateway；
+- 血缘、质量计算；
 - 用 Yak Project Header 替代 Public Runtime 的 NONE/API_KEY 鉴权。
 
 ## 2. 设计原则
 
 1. **Package 表达能力，Class 表达角色。** 不恢复 `controller -> service -> serviceImpl -> dao` 默认模板。
 2. **发布与调用分离。** Publication 解析上游 Revision；Runtime invocation 读取已经持久化的 Snapshot。
-3. **稳定身份与不可变 Revision 分离。** Republish 更新同一 Data Service 的 SourceReference/RuntimeSnapshot，不创建新服务身份。
+3. **稳定身份与不可变 Revision 分离。** Republish 更新同一 Data Service，不创建第二个身份。
 4. **Domain 是业务事实，PO/HTTP model 是边界表示。** 业务角色不直接操作 MyBatis Mapper/PO。
-5. **持久化策略与本地状态分离。** RuntimePolicy 在 DB；Cache/Circuit/Metrics 在 JVM。
-6. **SQL Trust Boundary 在服务端。** SQL/dataSourceId 只能来自 Source Provider，HTTP settings 更新不能注入执行定义。
-7. **安全 Secret 最小暴露。** raw API key 只在 create/rotate 返回一次，之后只使用 hash + prefix。
+5. **Truth 分层。** Definition/Policy、cluster coordination/evidence、node-local resilience 不能混为一个 Runtime 状态。
+6. **SQL Trust Boundary 在服务端。** SQL/dataSourceId 只能来自 Source Provider。
+7. **安全 Secret 最小暴露。** raw API key 只在 create/rotate 返回一次；audit 参数在落库前脱敏。
 8. **读写角色分开。** Manager/Publisher 管 command，Reader 管 query/projection。
-9. **管理面与调用面分离。** Console Management 使用 Project + RBAC；外部 Invocation 使用全局 path + NONE/API_KEY。
-10. **依赖图无环。** 不通过白名单接受 Query↔Execution、Runtime↔Execution 等反向依赖。
-11. **结构重构默认不改行为。** REST、DB、HTTP status、SqlExecution contract 变化必须先更新 Requirements/Domain。
+9. **管理面与调用面分离。** Console 使用 Project + RBAC；外部 Invocation 使用全局 path + NONE/API_KEY。
+10. **热路径最小化。** Result Cache/Circuit 留在节点内；历史清理不进入 invocation 热路径。
+11. **依赖图无环。** 不用新增 package edge 掩盖职责混乱。
+12. **结构重构默认不改行为。** REST、HTTP status、SqlExecution contract 的变化先更新 Requirements/Domain。
 
 ## 3. 总体架构
 
@@ -53,12 +56,10 @@ Data Development / other published source
                   v
          +------------------+
          |   Publication    |
-         | Publisher/Reader |
-         | SourceRegistry   |
          +--------+---------+
                   |
                   v
- DataServiceDefinition(projectId)
+DataServiceDefinition(projectId, runtimeGeneration)
       +-----------+-----------+
       |           |           |
       v           v           v
@@ -76,15 +77,19 @@ Data Development / other published source
                   v
               Datasource
 
-Invocation -> Recorder -> CallLogRepository(projectId snapshot) -> Observability
+Invocation
+  +--> shared API-key minute window
+  +--> node-local Cache/Circuit
+  +--> sanitized audit -> raw log -> hourly rollup
+                                  |
+                                  +--> cluster runtime metrics
 ```
 
-入口明确分成两个平面：
+入口仍明确分成两个平面：
 
 ```text
 Yak Ops User
-   -> Project membership
-   -> Data Service RBAC
+   -> Project membership + Data Service RBAC
    -> Management Controllers
    -> project-scoped Repository
 
@@ -99,23 +104,19 @@ External Client
 
 ```text
 dataservice
-├── controller
-│   └── v1                 # Console management + isolated public invocation boundary
-├── publication
-│   └── source             # publish / republish / source extension contract
+├── controller             # Console management + isolated public invocation boundary
+├── publication/source     # publish / republish / source extension contract
 ├── management             # stable aggregate command lifecycle
 ├── query                  # Data Service read side / projection
-├── access                 # API Key lifecycle / authorize / local rate limit
-├── execution              # SQL compiler / invoker / physical query coordinator
-├── runtime                # local resilience + persisted policy commands
+├── access                 # API Key lifecycle / authorize / cluster rate-limit coordinator
+├── execution              # compiler / invoker / physical query / audit sanitizer+recorder
+├── runtime                # node-local cache/circuit + cluster metric projection facade
 ├── documentation          # docs persistence / merge / OpenAPI rendering
-├── observability          # logs and overview read side
-├── domain
-│   ├── access
-│   └── documentation      # business facts / values
-├── repository             # persistence ports + Project-aware adapters
+├── observability          # logs / overview / bounded retention-rollup maintenance
+├── domain                 # business facts / values
+├── repository             # persistence + cluster-coordination ports/adapters
 ├── dao                    # MyBatis mapper / PO
-└── config                 # module wiring / conditional configuration
+└── config                 # module wiring / conditions
 ```
 
 禁止重新创建 `service / common / helper / utils / util / base` 这类模糊业务桶。
@@ -124,112 +125,57 @@ dataservice
 
 | Role | 本模块职责 | 例子 |
 | --- | --- | --- |
-| `Manager` | Aggregate command / lifecycle / transactional mutation | `DataServiceManager`, `DataServiceApiKeyManager` |
-| `Publisher` | 把可信 Source Revision 发布成 Data Service snapshot | `DataServicePublisher` |
-| `Reader` | read-side 查询和 projection | `DataServiceReader`, `DataServiceOverviewReader` |
-| `Registry` | Source extension discovery / uniqueness / lookup | `DataServiceSourceRegistry` |
-| `Authorizer` | 每次请求访问判定 | `DataServiceAuthorizer` |
-| `RateLimiter` | 当前进程限流状态 | `DataServiceRateLimiter` |
-| `Compiler` | 只读 SQL 校验和 named binding 编译 | `DataServiceSqlCompiler` |
-| `Invoker` | 一次 Data Service 调用流程编排 | `DataServiceInvoker` |
-| `Executor` | 已编译 SQL 的物理执行 | `DataServiceQueryExecutor` |
-| `Runtime` | process-local resilience / metrics | `LocalDataServiceRuntime` |
-| `Recorder` | 调用完成后的审计写入 | `DataServiceInvocationRecorder` |
-| `Repository` | Domain persistence port | `DataServiceRepository` |
-| `Adapter` | Domain ↔ persistence / Project translation | `DataServiceRepositoryAdapter` |
-| `Renderer` | typed contract -> presentation artifact | `OpenApiRenderer` |
-| `Factory` | read-side projection construction | `DataServiceViewFactory` |
+| `Manager` | Aggregate command / lifecycle | `DataServiceManager`, `DataServiceApiKeyManager` |
+| `Publisher` | Source Revision -> Data Service snapshot | `DataServicePublisher` |
+| `Reader` | read-side 查询/projection | `DataServiceReader`, `DataServiceOverviewReader` |
+| `Registry` | Source extension discovery | `DataServiceSourceRegistry` |
+| `Authorizer` | 每次调用访问判定 | `DataServiceAuthorizer` |
+| `RateLimiter` | 调用共享 minute-window coordination | `DataServiceRateLimiter` |
+| `Compiler` | SELECT 校验和 named binding | `DataServiceSqlCompiler` |
+| `Invoker` | 一次在线调用编排 | `DataServiceInvoker` |
+| `Executor` | 已编译 SQL 物理执行 | `DataServiceQueryExecutor` |
+| `Runtime` | node-local resilience | `LocalDataServiceRuntime` |
+| `Recorder` | sanitized 调用审计写入 | `DataServiceInvocationRecorder` |
+| `Repository` | Domain / coordination persistence port | `DataServiceRepository`, `DataServiceRateLimitRepository` |
+| `Adapter` | persistence translation / SQL coordination | `*RepositoryAdapter` |
+| `Renderer` | typed contract -> artifact | `OpenApiRenderer` |
+| `Factory` | read-side projection | `DataServiceViewFactory` |
 
-当前模块没有通用 Service facade。未来如果真的需要稳定 Application Service，必须先更新 `DEPENDENCIES.md` 和 Architecture Guard，而不是新增 `XxxServiceImpl`。
+## 6. Definition / Publication / Runtime Generation
 
-## 6. Definition 与 Publication
+初次发布绑定 CurrentProject；source-managed ownership 规则延续 Stage 2。
 
-### 6.1 初次发布
-
-```text
-PROJECT_REQUIRED HTTP publish request
-       |
-       +-- Project membership
-       +-- data-service:publish
-       v
-PublicationReader.normalizeIdentity
-       |
-       v
-SourceRegistry.require
-       |
-       v
-SourceProvider.resolve
-       |
-       +-- validate ONLINE / revision / datasource / SELECT
-       v
-DataServiceManager.savePublished
-       |
-       +-- bind CurrentProject.projectId
-       v
-Project-scoped Repository
-```
-
-Source Provider 是**扩展 contract**，不是 Data Service 的内部 Repository。
-
-### 6.2 Source-managed ownership
-
-Provider `managesServiceDefinition=true`：
+`runtimeGeneration` 是 Data Service 持久化在线代际：
 
 ```text
-Source owns:
-name/path/maxRows/timeout/pagination/description/contract
-
-Data Service owns:
-projectId/enabled/auth/API keys/runtime policy/runtime local state
+create -> generation 1
+settings/auth/policy/enable/republish mutation
+       -> generation + 1
 ```
 
-这条边界用于避免一个已发布 Revision 在 Data Development 和 Data Service 两侧同时被编辑成不同定义。
+Cache namespace 还包含 Source Revision 与影响执行/缓存的 settings/policy shape，因此并发管理请求即便观察到同一旧 generation，也不能让不同最终配置误用同一 Cache entry。
 
-Data Development source-managed API 的 Project ownership 必须与 owning Data Development Node 对齐；兼容迁移优先从 Source Node 推断，不允许把同一 authoring/runtime projection 拆到两个 Project。
-
-### 6.3 Republish
+Republish 保持：
 
 ```text
 same Data Service ID
 same Project ownership
-      |
-resolve latest immutable source revision
-      |
-      +-- replace SourceReference
-      +-- replace PublishedRuntimeSnapshot
-      +-- refresh source-owned settings/docs
-      +-- preserve AuthMode
-      +-- preserve RuntimePolicy
-      v
-invalidate local runtime state
+preserved AuthMode / RuntimePolicy
+new SourceReference / RuntimeSnapshot
+new runtimeGeneration
 ```
 
 ## 7. Management Plane
 
-Console 管理入口统一 `PROJECT_REQUIRED`，并按动作使用显式权限：
+Console 管理入口统一 `PROJECT_REQUIRED`，并按动作使用：
 
 ```text
-READ      -> marketplace / detail / docs / OpenAPI
-PUBLISH   -> sources / publish / republish / publication state
-MANAGE    -> settings / enable-disable / editable docs
-DELETE    -> delete
-ACCESS    -> auth mode / API key lifecycle
-RUNTIME   -> runtime policy / console test
-OBSERVE   -> overview / invocation logs
+READ / PUBLISH / MANAGE / DELETE / ACCESS / RUNTIME / OBSERVE
 ```
 
-Repository 的 Console 方法必须绑定 `CurrentProject`：
+管理 Repository 的 ID/path/source/list/save/delete 绑定 `CurrentProject`。API Key / Documentation 不重复保存 projectId，但 Console 读写必须先经过父 Data Service ownership。
 
-```text
-findById
-findByPath
-findBySource
-findAll
-save
-delete
-```
-
-API Key / Documentation 不重复持久化 projectId，但任何 Console mutation/read 必须先经过父 Data Service 的 Project ownership。
+首页系统 Cockpit 的全局 Data Service count 是一个显式只读 aggregate corridor：只返回数量，不暴露 API identity/path/SQL/source，因此不能被 Console management 复用。
 
 ## 8. Public Invocation Plane
 
@@ -242,198 +188,167 @@ DataServiceInvocationController
        v
 DataServiceInvoker
        |
-       +-- DataServiceReader.requireByPath
-       |       |
-       |       v
-       |  Repository.findByRuntimePath   # sole global Data Service read corridor
-       |
-       +-- require enabled definition
-       +-- DataServiceAuthorizer: NONE / API_KEY
-       +-- pagination normalization
-       +-- DataServiceSqlCompiler: SELECT + named bindings
-       +-- LocalDataServiceRuntime: cache/circuit
-       +-- DataServiceQueryExecutor
-       |       |
-       |       v
-       |   SqlExecutionRuntime
-       |
-       +-- DataServiceInvocationRecorder(projectId snapshot)
+       +-- global DataServiceReader.requireByPath
+       +-- NONE / API_KEY authorization
+       +-- cluster shared rate-limit admission
+       +-- pagination / SQL compile
+       +-- node-local Cache/Circuit
+       +-- SqlExecutionRuntime
+       +-- sanitized best-effort audit
 ```
 
-`DataServiceInvocationController` 故意没有 Yak `@ProjectScope` / `@RequiresPermission`。外部调用方不需要也不能使用 `X-YAK-SECURITY-PROJECT-ID` 选择服务；Path 因此继续跨 Project 全局唯一。
+Public Controller 故意没有 Yak `@ProjectScope` / `@RequiresPermission`。Path 跨 Project 全局唯一。
 
-Console test 调用真实 Datasource，但有意绕过外部 cache/circuit 行为，用于检查当前数据源和 SQL；它属于 Management Plane，需要 RUNTIME 权限和当前 Project。
+## 9. Cluster-wide rate-limit corridor
 
-## 9. SQL read-side corridor
-
-`DataServiceView` 需要展示 SQL parameter names，但 Query 不能反向依赖 Execution implementation。
+调用限流不再使用 JVM `ConcurrentHashMap`。
 
 ```text
-query.DataServiceParameterNameReader  <--- port
-              ^
-              |
-execution.DataServiceSqlCompiler      <--- implementation
+DataServiceAuthorizer
+   -> DataServiceRateLimiter
+   -> DataServiceRateLimitRepository
+   -> MySQL CAS window(apiKeyId, epochMinute)
 ```
 
-因此 dependency direction 保持 `execution -> query`，不存在 `query -> execution` 环。
+Repository Adapter 的 compare-and-set 保证多实例共享一份 count。协调存储异常时 fail closed。
 
-`DataServiceQueryResponse` 放在 Domain，因为它同时被 Execution、Runtime 和 HTTP boundary 使用，是 runtime-neutral value，不属于 Execution implementation。
+Key rotate / disable / delete 通过 `rateLimiter.invalidate(keyId)` 清理共享窗口；旧分钟窗口由维护任务处理，不扫描调用热路径。
 
-## 10. Runtime Truth
+未来接 Redis 时只替换 Repository Adapter；Authorizer/API Key Domain 不变。
+
+## 10. Node-local Cache / Circuit
+
+`LocalDataServiceRuntime` 继续拥有 Caffeine Cache 与 Circuit state：
 
 ```text
-Persisted:
-DataServiceDefinition.runtimePolicy
-        |
-        v
-LocalDataServiceRuntime
-        |
-        +-- Cache
-        +-- Circuit state
-        +-- Metrics
-
-Restart / another JVM -> local state can differ
+Persisted RuntimePolicy + runtimeGeneration
+          |
+          v
+LocalDataServiceRuntime per instance
+          +-- Caffeine
+          +-- Circuit
 ```
 
-RuntimeManager 负责 Policy command + invalidation；LocalRuntime 不直接操作 Repository。
+不要求跨节点主动 invalidation 才能保证正确性。每次请求重新读取持久化 Definition，cache namespace 已带 durable generation + runtime shape，新代际无法命中旧 entry。
 
-当前 Cache/Circuit/Metrics 是 node-local。未来若引入 Redis/global quota，需要新增明确的 distributed Runtime port，不得把当前内存 Map 伪装成集群事实。
+这是**version-safe local cache**，不是 shared cache。
 
-## 11. Access Security
+## 11. Cluster Runtime Metrics
+
+Runtime status 的调用规模来自 durable evidence：
 
 ```text
-create/rotate (Management Plane)
-  -> verify parent API in CurrentProject
-  -> SecureRandom raw key
-  -> SHA-256 hash persisted
-  -> prefix persisted
-  -> raw key returned once
-
-invoke (Public Invocation Plane)
-  -> global path resolves API
-  -> hash incoming X-API-Key
-  -> repository lookup
-  -> enabled / expiry
-  -> local rate limit
-  -> mark last used
+raw call log (recent)
+      +
+hourly rollup (older)
+      |
+      v
+DataServiceRuntimeMetricsRepository
 ```
 
-Controller、日志、Domain 持久化都不保存 raw secret。Public Invocation 的 Key lookup 属于已解析 API 的访问执行过程，不读取 Yak Project Header。
+集群指标：total/success/failure/successRate/average/last success/failure。
 
-## 12. Documentation
+P95 使用最近 raw duration 的有界样本；不是全历史精确 histogram。
+
+同一个 Runtime DTO 中 Cache/Circuit 仍来自当前节点，因此返回 `metricsScope=CLUSTER_INVOCATION_LOCAL_RESILIENCE`，明确两层 evidence 的差异。
+
+## 12. Audit Security / Reliability
+
+`DataServiceInvocationRecorder` 的职责顺序是：
 
 ```text
-Published SQL
-   |
-   +-- parameterNames -------------------+
-   |                                     |
-Saved documentation ---------------------+
-                                         v
-                               DocumentationReader
-                                         |
-                                         v
-                                     OpenAPI
+request parameters
+  -> DataServiceAuditSanitizer
+  -> JSON serialize
+  -> length bound
+  -> InvocationRecord
+  -> Repository
 ```
 
-SQL parameter names 是事实，description/example 是人工/上游元数据。文档不能创造不存在的 SQL 参数。
+Secret/PII 不能先序列化再靠 UI 隐藏。
 
-Documentation projection 自身不重复保存 Project identity；Console 入口先验证父 API ownership。
+Stage 1 的可靠性规则保持：audit persistence failure 不能把成功查询变成失败，也不能覆盖原始 SQL/auth/rate-limit 异常。
 
-## 13. Observability
+## 13. Observability Lifecycle
 
-`DataServiceInvocationRecorder` 写入完成后的调用事实；`DataServiceCallLogReader` 和 `DataServiceOverviewReader` 只做 read-side。
+Raw call log 默认保留 30 天；hourly rollup 默认保留 365 天。
 
-Invocation Record 快照 `projectId`，因此 API 删除后历史 evidence 仍能归属 Project。Console 的日志、Overview、热点 API、失败记录全部按 CurrentProject 聚合。
+维护按小时、有界执行：
 
-Observability 不参与调用成功与否的业务判定，不拥有 Runtime state machine；audit persistence failure 不能覆盖业务成功或原始调用异常。
+```text
+Transaction
+  INSERT ... SELECT raw hour -> hourly rollup
+  DELETE same raw hour
+Commit
+```
+
+任何一步失败整个小时回滚，防止双算或丢数。过期 rate-limit window 也由该维护角色统一清理。
 
 ## 14. Persistence Boundary
 
 允许：
 
 ```text
-Management Business Role
-   -> Repository
-   -> CurrentProject predicate
-   -> DAO Mapper / PO
-
-Public Invocation
-   -> DataServiceReader.requireByPath
-   -> Repository.findByRuntimePath
+Business Role
+  -> Repository port
+  -> RepositoryAdapter
+  -> Mapper/PO or JdbcTemplate
 ```
 
-禁止：
+`JdbcTemplate` 只能存在于 repository adapter 等明确 persistence boundary，用于 CAS / aggregation / transactional maintenance 等不适合简单 Mapper CRUD 的 SQL。
 
-```text
-Controller   -> Mapper / PO
-Publisher    -> Mapper / PO
-Manager      -> Mapper / PO
-Execution    -> Mapper / PO
-Runtime      -> Mapper / PO
-Domain       -> Mapper / PO
-Management   -> findByRuntimePath
-Invocation   -> Yak Project Header selector
-```
-
-PO 字段可以为了 ORM 使用 setter；Domain 通过 constructor/behavior 表达状态。
+禁止：Controller/Access/Execution/Runtime/Observability 业务角色直接拥有 JdbcTemplate/Mapper/PO。
 
 ## 15. Cross-module Boundary
 
-允许上游模块依赖：
+上游模块只依赖：
 
 ```text
 io.yak.ops.business.dataservice.publication.source.DataServiceSourceProvider
 ```
 
-Data Service 不反向依赖 Data Development implementation。
-
-Data Service 的物理 SQL 能力只依赖 `yak-ops-core` execution contract；Project management 只依赖 `yak-ops-core` 的 Project scope/current-project contract，不依赖 Yak Security implementation。
+Data Service 不反向依赖 Data Development implementation。物理 SQL 只走 `yak-ops-core` execution contract；Project scope 只依赖 core Project contract。
 
 ## 16. Failure Semantics
 
-- invalid source / invalid settings / invalid SQL -> 业务参数错误；
-- missing/invalid Console Project -> Project contract error；
-- missing Console permission -> RBAC forbidden；
-- missing/invalid Public API key -> 401；
-- local rate limit -> 429；
-- circuit open -> 503；
-- datasource/query failure -> 调用失败并尽力记录 audit；
-- audit persistence failure 不改变已经确定的调用结果；
-- documentation error 不改变已发布 SQL；
-- observability read failure 不应被解释成 Data Service definition state。
+- invalid source/settings/SQL -> 参数/业务错误；
+- missing Console Project / permission -> Project/RBAC error；
+- invalid Public API key -> 401；
+- shared RPM exceeded -> 429；
+- shared rate-limit storage unavailable -> fail closed；
+- node-local circuit open -> 503；
+- datasource/query failure -> 原始调用失败；
+- audit persistence failure -> 不改变已确定调用结果；
+- maintenance failure -> 保留该小时 raw evidence，下一轮可重试。
 
 ## 17. Architecture Guards
 
 ```text
 DataServiceDependencyBoundaryTest
-  -> package graph / persistence / cross-module corridors
-
 DataServiceCodeStyleConventionTest
-  -> role-oriented source conventions / secret boundaries
-
 DataServiceGovernanceContractTest
-  -> Management Controllers are PROJECT_REQUIRED
-  -> Public Invocation Controller has no Project/RBAC annotation
-  -> permission vocabulary remains explicit
-  -> only findByRuntimePath is a deliberate global runtime corridor
+DataServiceClusterRuntimeContractTest
 ```
 
-Project compatibility backfill 另由 Boot contract test 守住：source-managed API 先继承 Data Development node Project，再对 legacy global rows 使用 compatibility Project。
+Stage 3 Guard 锁定：
+
+- Rate Limit 不得退回 per-JVM Map；
+- Cache 可以 local，但 namespace 必须带 durable generation/runtime shape；
+- Audit 必须先 sanitize；
+- Rollup + raw delete 必须共享 transaction boundary；
+- Cluster invocation metrics 与 local resilience 必须显式区分。
 
 ## 18. 修改协议
-
-新能力进入前回答：
 
 ```text
 Architecture Impact
 - capability owner package:
 - command/read/runtime role:
 - management vs invocation plane:
-- persisted truth vs process-local state:
+- persisted / cluster-coordination / node-local truth:
 - project ownership impact:
-- new package dependency edge:
-- SourceProvider / SqlExecution boundary impact:
+- new dependency edge:
 - REST/DB compatibility impact:
 ```
 
-如果引入新的顶层 package edge，需要同步更新 `DEPENDENCIES.md` 和可执行 Guard；不允许只修改测试白名单而不说明职责变化。
+如果引入新的顶层 package edge，需要同步更新 `DEPENDENCIES.md` 和可执行 Guard；不允许只改测试白名单。

--- a/yak-ops-business/yak-ops-business-data-service/CLUSTER_RUNTIME.md
+++ b/yak-ops-business/yak-ops-business-data-service/CLUSTER_RUNTIME.md
@@ -1,0 +1,178 @@
+# Data Service Cluster Runtime
+
+Stage 3 把 Data Service 从“单 JVM 运行保护”推进到“多实例语义正确”。本阶段刻意不引入新的 Redis / Gateway 基础设施：共享 Truth 使用现有 MySQL，数据面 Cache / Circuit 继续保持 node-local，并通过清晰 Port 保留未来替换空间。
+
+## Runtime truth layers
+
+```text
+Persisted Data Service Truth
+  definition / runtime policy / runtime_generation
+
+Cluster Coordination Truth
+  API Key minute windows
+  invocation audit
+  hourly invocation rollup
+
+Node-local Resilience
+  Caffeine result cache
+  Circuit breaker state
+  cache hit / circuit reject counters
+```
+
+不能把三类状态混成一个“Runtime”。
+
+## 1. Cluster-wide API Key rate limit
+
+`rate_limit_per_minute` 现在表示整个 Yak Ops 集群共享的硬上限，而不是“每个 Pod 各一份额度”。
+
+```text
+Pod A ─┐
+Pod B ─┼─> yak_ops_data_service_rate_window
+Pod C ─┘       (api_key_id, epoch_minute)
+```
+
+共享窗口采用 MySQL compare-and-set：
+
+1. 不存在窗口时尝试插入 `request_count=1`；并发插入只允许一个成功。
+2. 已存在时读取 count。
+3. `count >= limit` 直接拒绝。
+4. 否则执行 `UPDATE ... WHERE request_count = observedCount`。
+5. CAS 冲突重新读取，直到成功或达到有界重试上限。
+
+这保证多个实例并发调用同一 Key 时，共享同一份 RPM 配额。
+
+共享限流存储异常时选择 **fail closed**：不能因为协调存储不可用而绕过用户配置的访问上限。
+
+Key rotate / disable / delete 会删除该 Key 的共享窗口；历史过期窗口由维护任务统一清理，不进入调用热路径。
+
+## 2. Version-safe node-local cache
+
+Stage 3 不把结果 Cache 迁到 MySQL，也不伪装成分布式 Cache。Caffeine 仍然是每个实例独立的高速本地缓存。
+
+跨节点正确性由 cache namespace 保证：
+
+```text
+api identity
++ source revision
++ persisted runtime_generation
++ maxRows / pagination
++ cache policy shape
++ compiled SQL
++ bindings
+```
+
+`runtime_generation` 是持久化单调代际，替代 Stage 1 使用 `updateTime` 作为 generation 的做法，避免时间戳精度碰撞。
+
+同时把影响执行/缓存语义的 settings / policy 纳入 namespace。即便两个并发管理请求碰巧从同一 generation 开始写，也不会让不同 Runtime shape 共享缓存结果。
+
+因此：
+
+- 其他节点没有收到主动 invalidate，也不能命中新代际下的旧结果；
+- 本地旧 entry 可以自然等 TTL/LRU 回收，不影响正确性；
+- 未来接 Redis 时可以替换 cache port，而不用改变 Invocation contract。
+
+## 3. Cluster invocation metrics vs local resilience
+
+Runtime 状态接口现在明确分成两类指标。
+
+### Cluster invocation evidence
+
+来自所有实例共同写入的持久化调用证据：
+
+- total calls
+- success calls
+- failure calls
+- success rate
+- average duration
+- recent bounded P95 sample
+- last success / failure
+
+这些指标不再依赖请求恰好落在哪一个 Pod。
+
+### Node-local resilience evidence
+
+仍然只表示当前实例：
+
+- cache entries
+- cache hits / hit rate
+- circuit state / open-until
+- circuit rejected
+
+API 返回 `metricsScope=CLUSTER_INVOCATION_LOCAL_RESILIENCE`，明确提醒调用方不能把本地 Cache/Circuit 当成集群状态。
+
+P95 当前使用最近 raw audit 的有界 duration sample，不宣称是长期 rollup 的精确全历史 P95。
+
+## 4. Invocation evidence lifecycle
+
+原始调用日志不能无限增长。
+
+默认策略：
+
+```text
+Raw invocation logs: 30 days
+Hourly rollup:        365 days
+```
+
+维护过程按完整小时处理，并且每个小时在一个数据库事务内完成：
+
+```text
+INSERT ... SELECT -> hourly rollup
+          +
+DELETE raw rows for same hour
+```
+
+如果事务失败，两步一起回滚，不会产生“rollup 已计数、raw 还存在”的双算状态，也不会只删除原始日志而丢失聚合数据。
+
+每轮维护最多处理有限小时桶，避免历史数据较多时长事务一次吞掉全部积压。
+
+配置：
+
+```text
+yak.data-service.observability.raw-retention-days=30
+yak.data-service.observability.rollup-retention-days=365
+yak.data-service.observability.max-hourly-buckets-per-run=168
+yak.data-service.observability.maintenance-cron=0 20 3 * * *
+```
+
+## 5. Audit masking
+
+请求参数在 JSON 序列化、长度截断和数据库持久化**之前**完成脱敏。
+
+默认规则：
+
+| 参数名特征 | 落库行为 |
+| --- | --- |
+| password / passwd / pwd | `[REDACTED]` |
+| secret / token / authorization | `[REDACTED]` |
+| apiKey / accessKey / credential | `[REDACTED]` |
+| mobile / phone / tel | 保留前 3 后 4 |
+| idCard / identity / 身份证 | 保留前 6 后 4 |
+| email / mail | 仅保留首字符和域名 |
+| 其他字段 | 原值，继续受 4000 字符 audit 上限保护 |
+
+API Key raw secret 本来就不进入 `AccessContext`；Stage 3 的 sanitizer 再保证普通请求参数中伪装成 key/token/password 的值也不会被写入调用日志。
+
+## 6. Non-goals
+
+Stage 3 不做：
+
+- Redis shared result cache；
+- distributed circuit-breaker state machine；
+- API Gateway；
+- 精确全历史 P95 histogram；
+- 无限期调用日志保存；
+- 将 raw request body 全量持久化。
+
+当前目标是：**多实例部署时访问限制和业务指标语义正确，同时本地 resilience 明确保持本地。**
+
+## 7. Upgrade path
+
+未来引入 Redis / Gateway / Metrics backend 时，优先替换：
+
+```text
+DataServiceRateLimitRepository
+DataServiceRuntimeMetricsRepository
+LocalDataServiceRuntime cache/circuit implementation
+```
+
+Invocation、Publication、Project Governance、API Key Domain 不需要为基础设施切换重新建模。

--- a/yak-ops-business/yak-ops-business-data-service/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-data-service/DEPENDENCIES.md
@@ -1,46 +1,39 @@
 # Data Service Dependency Contract
 
-> 本文件定义 `yak-ops-business-data-service` 生产代码的**允许依赖方向**。它不是当前 import 的截图，而是长期架构约束；对应规则由 `src/test/.../architecture` 下的 executable guard 校验。
+> 本文件定义 `yak-ops-business-data-service` 生产代码的**允许依赖方向**。对应规则由 `src/test/.../architecture` 下 executable guard 校验。
 
 ## 1. 原则
 
 1. 顶层 package graph 必须无环。
 2. Domain 不依赖 Spring、MyBatis、HTTP、Repository、Runtime 或上游业务模块。
-3. MyBatis Mapper/PO 只允许出现在 `dao` 与 `repository` persistence corridor。
+3. Mapper/PO/JdbcTemplate 只能存在于 `dao` / `repository` persistence corridor。
 4. Controller 不直接访问 Repository/DAO/PO。
-5. Publication/Management/Execution/Access/Runtime 等业务角色依赖 Repository port，不依赖 Mapper。
-6. `publication.source` 是跨模块 Source Provider 的公开 extension contract，保持 JDK-only。
+5. Publication/Management/Execution/Access/Runtime/Observability 业务角色依赖 Repository port，不依赖持久化实现。
+6. `publication.source` 是跨模块 Source Provider 的 JDK-only extension contract。
 7. Data Service 不反向依赖 Data Development implementation。
-8. SQL 物理执行只走 `yak-ops-core` `SqlExecutionRuntime`，不访问 Datasource DAO/Mapper。
-9. Project-aware management persistence 只通过 `yak-ops-core` `CurrentProject` 获取受信 Project identity。
-10. Public Invocation 只能通过显式 `findByRuntimePath` global read corridor 绕开 CurrentProject；其他 repository read/write 不允许退化成 global。
+8. SQL 物理执行只走 `yak-ops-core` `SqlExecutionRuntime`。
+9. Project-aware management 只通过 `yak-ops-core` `CurrentProject` 获取受信 Project identity。
+10. Global read / coordination 必须是显式窄 corridor，不能把 management repository 退化成 global。
 11. 不通过 `service/common/helper/utils/util/base` 等模糊 package 绕过依赖矩阵。
 
 ## 2. 顶层依赖图
 
 ```text
 controller
-   |
-   +--> publication --> documentation --> execution --> access --> query --> repository --> dao
-   |        |                 |              |            |           |          |
-   |        +--> management --+              +--> runtime-+           |          +--> domain
-   |        +--> query                       +--> query               +--> domain
-   |        +--> execution                   +--> repository
-   |
-   +--> management --> access/runtime/query/repository
-   +--> execution  --> access/runtime/query/repository
-   +--> documentation --> execution/query/repository
-   +--> observability --> query/repository
-   +--> access --> query/repository
-   +--> runtime --> query/repository
-   +--> query --> repository
+   +--> publication / management / documentation / execution / observability / query / runtime / access
 
-all business packages may depend on domain where required
-repository -> core CurrentProject for management ownership predicates
-config and domain have no internal outward dependencies
+publication --> documentation / execution / management / query
+management  --> access / domain / query / repository / runtime
+documentation --> domain / execution / query / repository
+execution   --> access / domain / query / repository / runtime
+observability --> domain / query / repository
+access      --> domain / query / repository
+runtime     --> domain / query / repository
+query       --> domain / repository
+repository  --> dao / domain
 ```
 
-图中省略同 package import 和 `domain` 边，以避免噪声。
+`repository` 还可以依赖基础设施 contract，例如 `CurrentProject` 与 DataSource/transaction support；其他业务 package 不直接依赖 ORM/SQL persistence type。
 
 ## 3. Allowed Top-level Matrix
 
@@ -60,111 +53,76 @@ config and domain have no internal outward dependencies
 | `config` | none |
 | `domain` | none |
 
-同一顶层 package 内部引用不计作跨包 edge。
+## 4. Query / Runtime cycle avoidance
 
-## 4. 为什么 Query 不依赖 Execution
+`query.DataServiceParameterNameReader` 是 Query 需要的窄 port，`execution.DataServiceSqlCompiler` 提供实现，避免 `query -> execution -> query`。
 
-`DataServiceViewFactory` 需要从 SQL 提取 parameter names，但如果直接 import `DataServiceSqlCompiler`，就会形成：
+`DataServiceQueryResponse` 位于 Domain，避免 `execution -> runtime -> execution`。
 
-```text
-query -> execution -> query
-```
+## 5. Persistence / Project corridor
 
-因此定义窄 port：
-
-```text
-query.DataServiceParameterNameReader
-             ^
-             |
-execution.DataServiceSqlCompiler
-```
-
-`query` 只认识自己需要的 read capability，Execution 提供实现。
-
-## 5. 为什么 Runtime 不依赖 Execution
-
-Execution 需要 Runtime 做 cache/circuit，而 Runtime 也需要缓存查询结果。如果查询结果类型归 `execution`，会形成：
-
-```text
-execution -> runtime -> execution
-```
-
-因此 `DataServiceQueryResponse` 是 `domain` 下的 runtime-neutral value：
-
-```text
-execution -> domain <- runtime
-execution -> runtime
-```
-
-## 6. Persistence / Project Corridor
-
-唯一允许的业务到 ORM 路径：
+普通 Management persistence：
 
 ```text
 Business Role
-    |
-    v
-Repository interface
-    |
-    v
-RepositoryAdapter
-    |
-    +--> CurrentProject (management ownership)
-    |
-    v
-DAO Mapper / PO
+  -> Repository port
+  -> RepositoryAdapter
+  -> CurrentProject predicate
+  -> Mapper/PO or JdbcTemplate
 ```
 
-允许：
+`findById/findByPath/findBySource/findAll/save/delete` 必须绑定 CurrentProject。
+
+两个平台级 global read 是显式例外：
 
 ```text
-repository/DataServiceRepositoryAdapter
-  -> dao.mapper.DataServiceApiMapper
-  -> dao.model.DataServiceApiPO
-  -> io.yak.ops.core.project.CurrentProject
-```
-
-Management repository methods：
-
-```text
-findById
-findByPath
-findBySource
-findAll
-save
-delete
-```
-
-都必须绑定 `CurrentProject`。
-
-Public Runtime 唯一例外：
-
-```text
-DataServiceInvocationController
-  -> DataServiceInvoker
+Public Invocation
   -> DataServiceReader.requireByPath
   -> DataServiceRepository.findByRuntimePath
+
+Home Cockpit aggregate
+  -> DataServiceReader.count
+  -> DataServiceRepository.count
 ```
 
-该 corridor 不读取 Yak Project Header，因为外部调用地址没有 Project namespace；它从全局唯一 path resolve 出 `DataServiceDefinition(projectId)` 后，再按 NONE/API_KEY 执行。
+`count` 只返回数量，不暴露 API identity/path/SQL/source；不能被 Management 页面当成 global catalog corridor。
 
-禁止：
+## 6. Stage 3 cluster coordination corridor
+
+多实例共享状态仍走业务 port，不让 Access/Runtime/Observability 直接持有 JDBC：
 
 ```text
-controller -> dao/repository
-publication -> dao
-management -> dao
-execution -> dao
-runtime -> dao
-access -> dao
-documentation -> dao
-observability -> dao
-domain -> repository/dao
-management page -> findByRuntimePath
-external invocation -> CurrentProject selector
+access.DataServiceRateLimiter
+  -> DataServiceRateLimitRepository
+  -> DataServiceRateLimitRepositoryAdapter
+  -> MySQL CAS window
+
+runtime.DataServiceRuntimePolicyManager
+  -> DataServiceRuntimeMetricsRepository
+  -> DataServiceRuntimeMetricsRepositoryAdapter
+  -> raw audit + hourly rollup
+
+observability.DataServiceObservabilityMaintenance
+  -> DataServiceObservabilityMaintenanceRepository
+  -> Adapter / TransactionTemplate
+  -> rollup + raw delete
 ```
 
-`repository` 可以使用 MyBatis type，因为 Adapter 就是 persistence boundary；其他业务 package 不可以。
+Repository Adapter 可以使用 `JdbcTemplate` / `TransactionTemplate`，因为 CAS、union aggregation、`INSERT ... SELECT` rollup 属于明确 persistence responsibility。
+
+禁止把这些基础设施 type 上移到：
+
+```text
+controller
+publication
+management
+execution
+runtime
+access
+documentation
+observability
+domain
+```
 
 ## 7. Source Provider Corridor
 
@@ -174,80 +132,40 @@ external invocation -> CurrentProject selector
 io.yak.ops.business.dataservice.publication.source.DataServiceSourceProvider
 ```
 
-该 contract 当前只依赖 JDK type：`Instant / List / record`。
+允许：`Data Development -> DataServiceSourceProvider`。
 
-允许：
+禁止：Data Service 反向依赖 Data Development implementation；Provider 反向依赖 Data Service repository/manager/runtime。
 
-```text
-Data Development
-  -> DataServiceSourceProvider
-```
-
-禁止：
-
-```text
-Data Service -> Data Development implementation
-Data Development provider -> Data Service repository/manager/runtime
-publication.source -> query/repository/management/execution/access/runtime
-```
-
-Provider 负责返回**不可变、可发布的来源事实**，而不是进入 Data Service 内部执行链路。
-
-Source-managed Data Service 的 owner-context permission 由上游 authoring context 负责；Data Service 的 Project/RBAC 不能成为绕过 authoring ownership 的新 corridor。
+Source-managed definition 的 owner-context permission 由上游 authoring context 负责，Data Service Project/RBAC 不能绕过。
 
 ## 8. Datasource / Core Corridor
 
-Data Service 当前允许的跨模块基础依赖：
+允许的基础跨模块依赖：
 
 ```text
 io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled
 io.yak.ops.core.execution.sql.*
-io.yak.ops.core.project.CurrentProject
-io.yak.ops.core.project.ProjectScope
-io.yak.ops.core.project.ProjectMigrationMode
+io.yak.ops.core.project.*
 ```
 
-`ConditionalOnDataSourceEnabled` 只是模块启用条件；物理 SQL 通过 core contract 执行；Project types 只承担 Management Plane 的受信 scope contract。
+物理 SQL 通过 core execution contract；Project type 只承担受信 Management scope。
 
-禁止 Data Service 生产代码依赖：
-
-```text
-io.yak.ops.business.datasource.dao.*
-io.yak.ops.business.datasource.repository.*
-io.yak.ops.business.datasource.gateway.adapter.*
-io.yak.ops.business.datasource.plugin.*
-io.yak.ops.business.development.*
-```
-
-如未来需要新的 Datasource Business Port，应先在 Datasource 定义稳定 contract，再更新本文件和 Guard。
+禁止 Data Service 生产代码依赖 Datasource DAO/Repository/Gateway implementation 或 Data Development implementation。
 
 ## 9. HTTP Boundary
 
-Management Controller 可以使用：
+Management Controller 可以使用 MVC、`Result`、`@ProjectScope(PROJECT_REQUIRED)`、action-specific permission、capability-owned input/view。
 
-- `Result`；
-- Spring MVC annotation；
-- `@ProjectScope(PROJECT_REQUIRED)`；
-- capability-owned input/view records；
-- Domain query result / audit projection；
-- action-specific Yak Security permission annotation。
+`DataServiceInvocationController` 是 Public Invocation Controller：禁止添加 Yak Project Scope / Console RBAC。
 
-`DataServiceInvocationController` 是唯一 Public Invocation Controller：禁止添加 Yak Project Scope 或 Console RBAC；外部鉴权只来自已发布的 NONE/API_KEY contract。
-
-Controller 不应：
-
-- 构造 MyBatis Wrapper；
-- import Mapper / PO；
-- 编译 SQL；
-- 直接读写 Repository；
-- 实现 API Key hash、rate-limit、circuit 等业务规则。
+Controller 不应构造 MyBatis Wrapper、访问 Mapper/PO/Repository、编译 SQL、实现 Key hash/rate-limit/circuit/rollup 规则。
 
 ## 10. Domain Boundary
 
-`domain/**` 只表达 business fact/value：
+Domain 只表达业务事实：
 
 ```text
-DataServiceDefinition(projectId)
+DataServiceDefinition(projectId, runtimeGeneration)
 DataServiceSettings
 PublishedRuntimeSnapshot
 SourceReference
@@ -258,39 +176,13 @@ DataServiceDocumentation
 InvocationRecord(projectId snapshot)
 ```
 
-Domain 不依赖：
-
-```text
-Spring
-MyBatis
-Controller
-Repository
-DAO
-Publication
-Execution
-Runtime
-Access implementation
-Data Development / Datasource implementation
-```
-
-`domain.access` / `domain.documentation` 仍属于顶层 `domain`，不是新的依赖层。
+Domain 不依赖 Spring/MyBatis/Controller/Repository/DAO/Publication/Execution/Runtime implementation。
 
 ## 11. No Service Facade by Default
 
-当前没有通用 `DataServiceService` facade。Controller 进入明确 capability role。
-
-如果未来确实需要 application facade：
-
-1. 明确它解决的跨能力稳定 API 问题；
-2. 不把业务逻辑重新搬进一个大类；
-3. 更新 Architecture/Dependencies；
-4. 显式调整 Guard allowlist。
-
-禁止仅因为“Controller 注入项多”就恢复 `XxxService / XxxServiceImpl`。
+当前没有通用 `DataServiceService` facade。新增 Application facade 必须先证明跨 capability 稳定 API 的必要性，并同步更新 Architecture/Dependencies/Guard。
 
 ## 12. Dependency Change Protocol
-
-引入新的 import edge 前在 PR 描述中写：
 
 ```text
 Dependency Impact
@@ -298,8 +190,8 @@ Dependency Impact
 - target package:
 - why current owner cannot handle it:
 - cycle check:
-- persistence / source / datasource / project corridor impact:
+- persistence / source / datasource / project / cluster-coordination impact:
 - DEPENDENCIES.md updated: yes/no
 ```
 
-Guard 失败时先检查职责是否放错；不要默认扩大 `ALLOWED_DEPENDENCIES`。
+Guard 失败时优先检查职责是否放错，不默认扩大 allowlist。

--- a/yak-ops-business/yak-ops-business-data-service/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-data-service/DOMAIN.md
@@ -7,6 +7,7 @@
 ```text
 DataServiceDefinition (Aggregate Root)
 ├── projectId
+├── runtimeGeneration
 ├── DataServiceSettings
 ├── PublishedRuntimeSnapshot
 ├── SourceReference
@@ -20,15 +21,16 @@ Documentation
 └── DataServiceDocumentation
 
 Observability
-└── InvocationRecord(projectId snapshot)
+├── InvocationRecord(projectId snapshot)
+└── hourly invocation rollup
 
 Invocation Result
 └── DataServiceQueryResponse
 ```
 
-## 2. 三层 Truth
+## 2. 四层 Truth
 
-Data Service 最重要的领域边界不是“Controller/Service/DAO”，而是三种不同生命周期的事实。
+Data Service 最重要的领域边界不是“Controller/Service/DAO”，而是不同生命周期的事实。
 
 ### 2.1 Upstream Revision Truth
 
@@ -47,7 +49,7 @@ immutable source revision
         +-- request/response contract
 ```
 
-它决定**发布时应该复制什么**，但不是 Data Service Runtime 的在线查询入口。
+它决定发布时应该复制什么，但不是 Runtime 的在线查询入口。
 
 ### 2.2 Persisted Data Service Truth
 
@@ -59,22 +61,38 @@ immutable source revision
 - `SourceReference`：来源类型、引用、固定 Revision。
 - `RuntimePolicy`：Cache/Circuit 的持久化策略。
 - `AuthMode`：NONE/API_KEY。
+- `runtimeGeneration`：单调持久化 Runtime 代际；每次会影响在线行为的 Aggregate 变更都推进代际。
 
 运行调用读取这里的持久化快照，不在每次请求时重新解析上游 Source。
 
 `projectId` 是 Console ownership，不进入 Public Runtime URL。外部调用通过全局唯一 path 找到 Definition 后，自然获得该服务的 Project identity；调用方不能通过 Project Header 选择或覆盖服务归属。
 
-### 2.3 Process-local Runtime Truth
+### 2.3 Cluster coordination / evidence truth
+
+多实例之间需要共享的运行事实通过明确 persistence port 表达：
+
+```text
+API Key minute-window usage
+Invocation audit evidence
+Hourly invocation rollup
+```
+
+- API Key minute-window usage 是集群配额事实，不属于单个 JVM。
+- Invocation / hourly rollup 是跨实例可聚合的调用 evidence。
+- 它们不能反向成为 Data Service Definition 或 RuntimePolicy 的 owner。
+
+### 2.4 Process-local resilience truth
 
 `LocalDataServiceRuntime` 维护：
 
 ```text
-Cache entries
+Caffeine cache entries
 Circuit state
-Runtime metrics
+Local cache-hit evidence
+Local circuit-rejected evidence
 ```
 
-这些状态只对当前 JVM 节点成立，不持久化，不代表集群全局事实。
+这些状态只对当前 JVM 成立。它们不持久化，也不代表集群全局 resilience 状态。
 
 ## 3. DataServiceDefinition 不变量
 
@@ -87,19 +105,21 @@ Runtime metrics
 7. republish 不能重置 `AuthMode`、`RuntimePolicy` 或 Project ownership。
 8. 服务侧 settings 更新不能改 SQL/dataSourceId/source revision/projectId。
 9. enable/disable 只改变服务可调用性。
-10. Aggregate 通过领域行为变更，不把 PO setter 暴露为业务 API。
-11. PO/Mapper 不是业务事实，持久化重建由 Repository Adapter 负责。
+10. `runtimeGeneration` 必须是正数，在线行为发生变更时推进；旧代际不能继续复用新请求的 cache identity。
+11. Aggregate 通过领域行为变更，不把 PO setter 暴露为业务 API。
+12. PO/Mapper 不是业务事实，持久化重建由 Repository Adapter 负责。
 
 ## 4. Publication 生命周期
 
 ```text
                 publish
-ONLINE Source -------------> DataServiceDefinition(projectId)
+ONLINE Source -------------> DataServiceDefinition(projectId, generation=1)
                                   |
                                   | republish newer Revision
                                   v
                          same Data Service ID
                          same Project ownership
+                         newer runtimeGeneration
                          new SourceReference
                          new RuntimeSnapshot
                          preserved Auth/Policy
@@ -114,7 +134,7 @@ Source Revision owns:
 name / path / maxRows / timeout / pagination / description / contract
 
 Data Service owns:
-projectId / enabled / auth / API keys / runtime policy / local runtime state
+projectId / enabled / auth / API keys / runtime policy / runtimeGeneration
 ```
 
 客户端不能用 publish/update 请求覆盖 Source-owned 字段。
@@ -147,9 +167,9 @@ prefix ----------------------------> persisted for identification/audit
 - raw secret 永不写 PO、日志、Domain `toString()` 或普通响应。
 - API_KEY 模式必须至少有一个 enabled 且未过期的 Key。
 - 最后一个有效 Key 不能被 disable/delete。
-- rotate 替换 hash/prefix，并使本机旧 rate-limit bucket 失效。
+- rotate 替换 hash/prefix，并清理该 Key 的共享 minute-window usage。
 - successful authorize 更新 `lastUsedAt`。
-- rate limit bucket 是进程本地状态，不是 Aggregate。
+- `rateLimitPerMinute` 是集群共享配额策略；当前 minute-window usage 是 cluster coordination truth，不是 API Key Aggregate 字段。
 - Console Key lifecycle 必须先通过父 Data Service 的 CurrentProject ownership；不能只凭 keyId 修改另一 Project 的 Key。
 - Public Invocation 的 Key 查找属于已解析 Data Service 的访问执行过程，不依赖 Yak Console Project Header。
 
@@ -164,8 +184,10 @@ named parameter validation
    v
 CompiledSql(sql + bindings)
    |
+   +--> cluster API Key admission
+   |
    v
-Local Runtime protection
+Node-local Runtime protection
    |
    v
 SqlExecutionRuntime
@@ -179,7 +201,7 @@ SqlExecutionRuntime
 - `SqlExecutionRuntime` 是唯一物理 SQL 调用入口。
 - Public Invocation 只允许通过全局 path resolve corridor 读取 Definition；所有 Console ID/source/list read 都是 Project-scoped。
 
-## 7. Runtime Policy 与 State
+## 7. Runtime Policy / Cache / Metrics
 
 `RuntimePolicy` 是持久化业务策略：
 
@@ -192,19 +214,27 @@ failureThreshold
 recoverySeconds
 ```
 
-`LocalDataServiceRuntime` 根据 Policy 构造本地状态：
+`LocalDataServiceRuntime` 根据 Policy 构造当前实例的 Cache/Circuit。
+
+Cache correctness 不要求共享 Cache Truth。每次请求的 cache namespace 至少覆盖：
 
 ```text
-RuntimePolicy change
-       |
-       v
-invalidate cache / reset affected circuit
-       |
-       v
-new local state follows persisted policy
+stable API identity
+source revision
+runtimeGeneration
+runtime-affecting settings/policy
+compiled SQL
+bindings/pagination
 ```
 
-本机 Metrics 只用于诊断，不写回 Aggregate。
+因此另一实例即使没有收到主动 invalidate，也不能让新代际命中旧结果。
+
+Runtime status 明确混合两种 evidence：
+
+- total/success/failure/average/last activity：来自持久化 audit + rollup 的集群调用 evidence；
+- cache entries/hits、circuit state/rejected：当前实例 resilience evidence。
+
+返回模型必须显式标识 metric scope，禁止把两者当成同一层 Truth。
 
 ## 8. Documentation 不变量
 
@@ -215,23 +245,11 @@ new local state follows persisted policy
 - response field docs；
 - update time。
 
-当前 SQL 参数名是 parameter docs 的事实来源：
-
-```text
-current SQL names + saved docs
-          |
-          v
-merge descriptions/examples by name
-          |
-          v
-current parameter contract
-```
-
-删除的 SQL 参数不能继续出现在当前文档；新增参数必须出现，即使只有默认 type。
+当前 SQL 参数名是 parameter docs 的事实来源。删除的 SQL 参数不能继续出现在当前文档；新增参数必须出现，即使只有默认 type。
 
 Documentation 自身不重复存 Project identity；Console reader/manager 必须先通过父 Data Service ownership，再读写文档 projection。
 
-## 9. InvocationRecord
+## 9. InvocationRecord / Audit Lifecycle
 
 `InvocationRecord` 是调用审计事实，而不是执行生命周期 Aggregate。
 
@@ -240,11 +258,21 @@ Documentation 自身不重复存 Project identity；Console reader/manager 必�
 - Project ID；
 - 服务身份/名称/Path；
 - Caller/API Key identification；
-- 参数 JSON；
+- **脱敏后的**参数 JSON；
 - success/duration/rows/error；
 - 时间。
 
-Project ID 必须在 Invocation 时从 resolved Data Service Definition 快照下来。历史记录不因 Data Service 后续改名、删除或 Key rotate 而重写，因此 Overview/Logs 在服务删除后仍能按 Project 归属查询。
+Project ID 必须在 Invocation 时从 resolved Data Service Definition 快照下来。历史记录不因 Data Service 后续改名、删除或 Key rotate 而重写。
+
+Secret / personal identifier 必须在 JSON 序列化前处理；Audit Repository 不应收到 raw password/token/credential。
+
+Raw evidence 有有限生命周期。完整小时在同一事务内：
+
+```text
+raw rows -> hourly aggregate -> delete same raw hour
+```
+
+事务失败必须同时保留/回滚两边，不能产生双算或丢数。
 
 ## 10. Management vs Invocation boundary
 
@@ -267,18 +295,18 @@ Project Header 不是 Public Invocation authorization input，也不能被外部
 ## 11. Persistence Projection
 
 ```text
-Database PO
+Database PO / coordination table
    |
    v
 Repository Adapter
    |
    v
-Domain
+Domain / capability port
 ```
 
 允许 `dao/model` 使用 Lombok bean/setter 适配 ORM；Domain 不因此恢复为 `@Data` 贫血 Bean。
 
-管理 Repository 的 `findById/findByPath/findBySource/findAll/save/delete` 必须绑定 CurrentProject。`findByRuntimePath` 是唯一显式 global read corridor，且只服务 Invocation Plane。
+管理 Repository 的 `findById/findByPath/findBySource/findAll/save/delete` 必须绑定 CurrentProject。Public path lookup 和平台级 count 是显式窄 global corridor；共享 rate-window / rollup 属于 Runtime/Observability coordination corridor，不得被 Controller 直接访问。
 
 ## 12. 修改协议
 
@@ -287,7 +315,7 @@ Domain Impact Analysis
 - Aggregate/value object:
 - Truth owner:
 - invariant/lifecycle impact:
-- process-local vs persisted impact:
+- node-local vs cluster/persisted impact:
 - Project/Invocation plane impact:
 - Domain Gap: yes/no
 

--- a/yak-ops-business/yak-ops-business-data-service/README.md
+++ b/yak-ops-business/yak-ops-business-data-service/README.md
@@ -12,7 +12,8 @@
 | [DEPENDENCIES.md](DEPENDENCIES.md) | 顶层 package 依赖矩阵、允许/禁止的 corridor |
 | [REVIEW.md](REVIEW.md) | 修改本模块时的设计与 Review Checklist |
 | [RUNTIME_RELIABILITY.md](RUNTIME_RELIABILITY.md) | Stage 1 调用结果/审计隔离、版本化缓存和服务级日志读取契约 |
-| [PROJECT_GOVERNANCE.md](PROJECT_GOVERNANCE.md) | Management Plane Project/RBAC 与 Public Invocation Plane 的强边界 |
+| [PROJECT_GOVERNANCE.md](PROJECT_GOVERNANCE.md) | Stage 2 Management Plane Project/RBAC 与 Public Invocation Plane 的强边界 |
+| [CLUSTER_RUNTIME.md](CLUSTER_RUNTIME.md) | Stage 3 集群限流、Runtime 指标、缓存代际、日志生命周期与审计脱敏 |
 | [../../CODE_STYLE.md](../../CODE_STYLE.md) | 仓库统一 Java / Role-oriented 工程约定 |
 
 ## 能力地图
@@ -43,19 +44,19 @@ Access  Runtime  Documentation
 
 ```text
 dataservice
-├── access          # API Key lifecycle / authorization / local rate limit
+├── access          # API Key lifecycle / authorization / cluster-wide rate limit
 ├── config          # module wiring / conditions
 ├── controller      # HTTP boundary only
 ├── dao             # MyBatis persistence projection
 ├── documentation   # contract docs / OpenAPI projection
 ├── domain          # business facts and value objects
-├── execution       # invocation / SQL compilation / physical query orchestration
+├── execution       # invocation / SQL compilation / physical query orchestration / audit masking
 ├── management      # stable Data Service lifecycle commands
-├── observability   # call-log / overview read side
+├── observability   # call-log / overview / retention-rollup maintenance
 ├── publication     # source discovery / publish / republish
 ├── query           # Data Service read side and HTTP projection factory
-├── repository      # domain persistence ports + adapters
-└── runtime         # process-local cache / circuit / metrics + persisted policy management
+├── repository      # domain persistence + cluster coordination/metric ports and adapters
+└── runtime         # node-local cache/circuit + persisted policy + cluster invocation projection
 ```
 
 生产代码不使用 `service / service.impl / common / helper / utils / util / base` 作为默认业务桶。
@@ -65,13 +66,14 @@ dataservice
 1. SQL 和 `dataSourceId` 只能来自服务端解析到的已发布 Source Revision，不能由 Data Service HTTP 更新接口直接提交。
 2. `DataServiceDefinition` 是稳定服务身份和持久化配置的业务事实；MyBatis PO 只是数据库投影。
 3. `PublishedRuntimeSnapshot` 是已发布 SQL + Datasource 的持久化快照；不是本机运行状态。
-4. `RuntimePolicy` 是持久化策略 Truth；`LocalDataServiceRuntime` 的 Cache/Circuit/Metrics 只代表当前进程。
-5. `API_KEY` 的 raw secret 只在 create/rotate 成功时返回一次；数据库只保存 hash + prefix。
+4. `RuntimePolicy` 是持久化策略 Truth；`LocalDataServiceRuntime` 的 Cache/Circuit 只代表当前实例，调用规模指标来自集群持久化 evidence。
+5. `API_KEY` 的 raw secret 只在 create/rotate 成功时返回一次；数据库只保存 hash + prefix；RPM 配额由共享持久化窗口在整个集群执行。
 6. 数据服务只允许单条只读 SELECT，物理执行统一走 `yak-ops-core` 的 `SqlExecutionRuntime`。
 7. Data Development 等上游模块只能实现 `publication.source.DataServiceSourceProvider`，不能依赖 Data Service 内部 Manager/Repository/Runtime。
-8. Invocation audit 是 evidence：日志持久化故障不能改变已经确定的业务调用结果或覆盖原始异常。
-9. Node-local Cache identity 必须带 persisted runtime generation，防止 republish 后跨节点误用旧代际结果。
+8. Invocation audit 是 evidence：日志持久化故障不能改变已经确定的业务调用结果或覆盖原始异常；请求参数必须先脱敏再落库。
+9. Node-local Cache identity 必须带 persisted `runtime_generation` 和 Runtime shape，防止 republish/并发设置更新后跨节点误用旧结果。
 10. Yak Ops Management Plane 必须同时通过 Project Space 和 RBAC；外部 `/runtime/{servicePath}` 不接收 Yak Project Header，只按全局 runtime path + NONE/API_KEY 调用。
+11. Raw invocation log 有明确 retention，并在事务内按小时 rollup；长期统计不能依赖无限增长的 raw 表。
 
 ## 修改入口
 
@@ -86,6 +88,6 @@ dataservice
 6. REVIEW.md       -> 合并前逐项检查。
 ```
 
-涉及调用审计、Cache identity 或服务级调用日志读取时查看 `RUNTIME_RELIABILITY.md`；涉及 Project ownership、RBAC 或外部 Invocation 边界时查看 `PROJECT_GOVERNANCE.md`。
+涉及调用审计、Cache identity 或服务级调用日志读取时查看 `RUNTIME_RELIABILITY.md`；涉及 Project ownership、RBAC 或外部 Invocation 边界时查看 `PROJECT_GOVERNANCE.md`；涉及多实例限流、指标、rollup 或敏感参数时查看 `CLUSTER_RUNTIME.md`。
 
 如果需求无法由当前模型表达，先报告 `Requirement Gap` / `Domain Gap`，不要用临时 Map key、boolean、PO 字段或 Controller DTO 绕过模型。

--- a/yak-ops-business/yak-ops-business-data-service/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-data-service/REQUIREMENTS.md
@@ -11,8 +11,9 @@ Data Service 将已发布的数据定义转化为稳定、可调用、可保护�
 - 稳定服务身份与上游 Revision 更新之间的解耦；
 - SQL / Datasource 来源可信；
 - 调用参数安全绑定；
-- API Key 鉴权和调用方识别；
-- 缓存、熔断等单节点 Runtime 保护；
+- API Key 鉴权、调用方识别和集群共享调用配额；
+- Cache / Circuit 等低延迟 Runtime 保护；
+- 多实例调用指标、审计生命周期和敏感参数保护；
 - 文档、OpenAPI、调用日志和运行概览；
 - 不绕过 Datasource 的统一 SQL Execution。
 
@@ -23,6 +24,7 @@ Data Service 将已发布的数据定义转化为稳定、可调用、可保护�
 - 启用/停用不能改变已发布 SQL、Datasource 或 Source Revision。
 - 删除服务时必须清理其 API Key，并移除当前节点的 Runtime state。
 - Runtime/Access 配置可以独立调整，不要求重新发布上游 Revision。
+- Data Service 必须维护持久化的单调 Runtime generation，用于区分不同发布/配置代际。
 
 ## 3. Publication
 
@@ -64,9 +66,11 @@ Source Provider
 - raw secret 永不落库；持久化只保存不可逆 hash 和可识别 prefix。
 - Key 可以设置名称、每分钟调用上限、过期时间和 enabled 状态。
 - 已启用 `API_KEY` 时不能禁用或删除最后一个有效 Key。
-- 鉴权失败返回 401；超过本节点限流返回 429。
+- 鉴权失败返回 401；超过调用上限返回 429。
+- `rateLimitPerMinute` 必须表示**整个 Yak Ops 集群共享的每 Key 固定窗口配额**，不能按 JVM/Pod 各自放大。
+- 共享限流协调存储不可用时必须 fail closed，不能静默绕过配额。
+- Key rotate / disable / delete 必须使对应共享限流窗口失效；过期窗口清理由维护任务处理，不能把扫描清理放在调用热路径。
 - 成功鉴权后调用日志需要记录 Key ID / Name / Prefix 快照，不记录 raw secret。
-- 当前 rate limit 是**进程本地 fixed-window 保护**，不是多节点全局配额 Truth。
 - Console 管理 API Key 时必须先确认父 Data Service 属于 CurrentProject；keyId 不能绕过 Project ownership。
 
 ## 6. Runtime Resilience
@@ -82,13 +86,15 @@ Source Provider
 
 要求：
 
-- Cache、Circuit state、Runtime metrics 当前均为单进程状态。
-- Runtime Policy 变化时必须清理受影响的本地缓存/熔断状态。
-- 服务停用、删除、重新发布关键 Runtime 配置时必须使本机旧状态失效。
+- Result Cache 与 Circuit state 可以保持 node-local，以避免把请求数据面强耦合到共享协调存储。
+- Runtime Policy 变化时必须清理当前节点受影响的缓存/熔断状态。
+- 服务停用、删除、重新发布关键 Runtime 配置时必须使当前节点旧状态失效。
 - Circuit 打开时返回 503。
 - Cache key 必须覆盖 compiled SQL 和绑定值；分页控制也必须进入 key，避免页间串数据。
-- Cache identity 还必须包含服务端持久化的 Runtime generation / Source Revision 身份；即使另一 JVM 未收到本地 invalidation，也不能让新 Revision 命中旧 Revision 的缓存结果。
-- 本地 Metrics 可以用于运行诊断，但不能反向覆盖持久化业务状态。
+- Cache identity 必须包含持久化 `runtime_generation`、Source Revision 以及影响执行/缓存的 Runtime shape；即使另一 JVM 未收到主动 invalidation，也不能命中新代际下的旧结果。
+- Runtime generation 必须是持久化单调值，不能依赖时间戳精度作为唯一代际标识。
+- Runtime 状态接口必须区分**集群调用指标**与**当前实例 resilience evidence**；不能把 node-local cache/circuit 冒充集群状态。
+- 集群调用指标至少覆盖 total/success/failure、success rate、average duration、最近成功/失败；P95 如果基于有限样本，必须明确是 bounded recent sample，而不是宣称全历史精确分位数。
 
 ## 7. Documentation / OpenAPI
 
@@ -107,7 +113,7 @@ Source Provider
 - Data Service ID / Project ID / 名称 / Path 快照；
 - Caller 类型；
 - API Key ID / 名称 / Prefix（如果存在）；
-- 请求参数 JSON（受长度限制）；
+- 请求参数 JSON（受长度限制且在持久化前脱敏）；
 - 成功/失败；
 - duration；
 - row count；
@@ -119,8 +125,17 @@ Source Provider
 - 调用日志持久化失败不能把已经成功的查询变成失败响应；
 - 调用日志持久化失败不能覆盖原始 SQL / 鉴权 / 限流异常；
 - 审计故障允许降级为内部告警/日志，业务调用语义保持原状；
+- password/token/authorization/API Key/credential 等 Secret 参数必须在 JSON 序列化前完全脱敏；手机号、证件号、邮箱等常见个人标识必须按规则掩码；
 - 单个服务详情的调用记录必须支持按 Data Service ID 有界读取，不能依赖“读取全局最近日志后在浏览器过滤”；
 - Console 的日志、Overview、热点和失败聚合必须只读取 CurrentProject 的调用 evidence。
+
+调用证据必须有生命周期：
+
+- raw invocation log 有有限 retention，默认 30 天；
+- 超过 raw retention 的完整小时必须先聚合到 hourly rollup，再删除对应 raw 行；
+- 同一小时的 rollup 与 raw delete 必须在同一事务中完成，避免双算或证据丢失；
+- hourly rollup 也必须有有限 retention，默认 365 天；
+- 单轮维护必须有上限，不能用一个长事务一次处理全部历史积压。
 
 运行概览需要支持 `24h / 7d / 30d`，至少提供 API 数量、启停数量、调用量、成功率、平均耗时、返回行数、趋势、热点 API 和近期失败。
 
@@ -141,7 +156,7 @@ Invocation Plane -> global service path + NONE/API_KEY
 - Project membership 与 RBAC 是两个独立 gate，不能用其中一个替代另一个；
 - `/api/v1/data-service/runtime/{servicePath}` 是 Public Invocation Plane，不要求也不信任 Yak Project Header；
 - Public Invocation 只能通过全局唯一 runtime path 找到服务，再按已发布 `NONE/API_KEY` 契约鉴权；
-- Repository 只能为 Public Invocation 保留一个明确的 global-by-path read corridor，其他 management read/write 必须使用 CurrentProject；
+- Repository 只允许明确声明的全局窄 corridor，例如 Public Invocation 的 global-by-path 和首页只读 count；其他 management read/write 必须使用 CurrentProject；
 - Source-managed Data Service 仍必须从 owning authoring context 发起定义变更，Project/RBAC 不能绕过该 owner boundary。
 
 ## 10. 模块边界
@@ -151,10 +166,11 @@ Invocation Plane -> global service path + NONE/API_KEY
 - Data Service definition；
 - Source publication / republish；
 - Data Service invocation；
-- API Key / auth / local rate limit；
-- local cache / circuit / metrics；
+- API Key / auth / cluster-wide rate limit；
+- node-local cache / circuit；
+- cluster invocation metric projection；
 - API documentation / OpenAPI；
-- invocation audit / overview；
+- sanitized invocation audit / overview / retention / hourly rollup；
 - Data Service Management Plane 的 Project ownership / RBAC boundary。
 
 本模块不负责：
@@ -163,8 +179,9 @@ Invocation Plane -> global service path + NONE/API_KEY
 - Datasource connection/catalog/plugin 管理；
 - Offline / Realtime Sync 调度；
 - 任意 DML/DDL；
-- 分布式缓存 Truth；
-- 多节点全局限流；
+- shared result-cache Truth；
+- distributed circuit-breaker state machine；
+- API Gateway；
 - 数据血缘或质量计算；
 - 用 Project Header 替代 Public Runtime API Key 鉴权。
 
@@ -175,7 +192,7 @@ Invocation Plane -> global service path + NONE/API_KEY
 ```text
 /api/v1/data-service REST 路径
 /api/v1/data-service/runtime/{servicePath} 外部调用地址
-现有主要 JSON shape
+现有主要 JSON shape（允许向 Runtime status 增加兼容字段）
 yak_ops_data_service_* 表的既有业务字段与 Flyway 历史
 yak-ops-core SqlExecutionRuntime contract
 Datasource Plugin / Catalog contract
@@ -183,7 +200,7 @@ Data Development SourceProvider 业务语义
 401 / 429 / 503 HTTP 状态语义
 ```
 
-Project cutover 可以通过 Expand + Backfill 增加 `project_id`，但不能把动态 compatibility Project ID 硬编码进静态 Flyway。
+Project cutover 可以通过 Expand + Backfill 增加 `project_id`，Stage 3 可以通过新 Flyway 增加 Runtime coordination / rollup 表，但不能改写已有 Flyway 历史。
 
 ## 12. 需求变更协议
 

--- a/yak-ops-business/yak-ops-business-data-service/RUNTIME_RELIABILITY.md
+++ b/yak-ops-business/yak-ops-business-data-service/RUNTIME_RELIABILITY.md
@@ -2,6 +2,8 @@
 
 Stage 1 不引入 Project/RBAC，也不把当前 JVM-local Runtime 强行改造成分布式系统。目标是先保证：**业务调用结果、审计证据、缓存代际和详情查询互不拖垮。**
 
+> Stage 3 已把本文最初的“definition update generation”升级为持久化单调 `runtime_generation`，并加入集群限流、集群调用指标、日志生命周期和审计脱敏。最新多实例契约见 [`CLUSTER_RUNTIME.md`](CLUSTER_RUNTIME.md)。
+
 ## 1. Invocation result 与 Audit evidence 解耦
 
 ```text
@@ -22,11 +24,11 @@ DataServiceInvoker
 - Recorder 仍保持同步 evidence 写入，以保留当前日志时序和落库语义，但 Invoker 对 Recorder 故障做最终隔离；
 - 审计失败仅写内部 warning，不记录 raw API key，也不把请求参数重新输出到应用日志。
 
-这一步解决的是 **failure isolation**，不是异步日志吞吐。后续如果需要高吞吐审计队列，应单独设计 bounded queue / durable outbox，不在本阶段偷换调用日志语义。
+这一步解决的是 **failure isolation**，不是异步日志吞吐。
 
 ## 2. Version-safe local cache identity
 
-当前 Cache 仍是 Caffeine/JVM-local，但 Cache Key 不能只包含 SQL 和 bindings：
+Cache 仍是 Caffeine/JVM-local，但 Cache Key 不能只包含 SQL 和 bindings：
 
 ```text
 cache key
@@ -36,24 +38,25 @@ cache key
   + pagination identity
 ```
 
-persisted runtime namespace 至少覆盖：
+当前 persisted runtime namespace 覆盖：
 
 - stable Data Service ID；
 - sourceType/sourceRef；
 - sourceRevisionId/sourceRevisionNo；
-- persisted definition update generation。
+- persisted monotonic `runtime_generation`；
+- 影响执行/缓存的 settings 与 cache policy shape。
 
 因此：
 
 ```text
-Revision R1 on Pod B
+Revision / Generation old on Pod B
    !=
-Revision R2 on Pod A/Pod B
+Revision / Generation new on Pod A/Pod B
 ```
 
-即使 Pod B 没收到 Pod A 的本地 `invalidate()`，当它下一次从 DB 读取到新 generation 后也不会命中旧 generation 的缓存结果。
+即使 Pod B 没收到 Pod A 的本地 `invalidate()`，当它下一次从 DB 读取到新 Definition 后也不会命中旧代际缓存结果。
 
-这不是分布式缓存；它只是让当前 local cache 在多实例部署时具备更安全的版本隔离。
+这不是分布式缓存；它让 local cache 在多实例部署时具备版本隔离正确性。
 
 ## 3. Service-scoped invocation log read
 
@@ -78,35 +81,18 @@ ORDER BY create_time DESC, id DESC
 LIMIT ?
 ```
 
-并增加索引：
-
-```text
-(api_id, create_time, id)
-```
-
-详情页同时改用 `GET /api/v1/data-service/{id}`，不再先加载所有 Data Service 再 `find(id)`。
+并增加 `(api_id, create_time, id)` 索引。详情页同时改用 `GET /api/v1/data-service/{id}`，不再先加载所有 Data Service 再 `find(id)`。
 
 ## 4. Stage 1 tests
 
-关键行为测试必须覆盖：
+关键行为测试覆盖：
 
 - audit repository/recorder failure 不影响成功 invocation；
 - audit failure 不覆盖原始 datasource failure；
 - audit failure 不覆盖原始 authorization failure；
-- persisted runtime generation 变化会产生不同 cache namespace/key；
+- persisted runtime generation 变化产生不同 cache namespace/key；
 - 原有 local cache reuse / circuit breaker 行为保持不变。
 
-## 5. Explicit non-goals
+## 5. Stage evolution
 
-本阶段不做：
-
-- Data Service Project/RBAC；
-- Redis/global cache；
-- distributed rate limit；
-- cluster metrics aggregation；
-- cross-node invalidation bus；
-- invocation log retention / rollup；
-- sensitive parameter masking；
-- async/durable audit pipeline。
-
-这些分别进入后续 Governance / Cluster Runtime 阶段。
+Stage 1 当时明确不做 Project/RBAC、distributed rate limit、cluster metrics、retention/rollup、parameter masking。它们后续分别由 Stage 2 `PROJECT_GOVERNANCE.md` 与 Stage 3 `CLUSTER_RUNTIME.md` 接管。

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiter.java
@@ -1,33 +1,52 @@
 package io.yak.ops.business.dataservice.access;
 
 import io.yak.ops.business.dataservice.domain.access.DataServiceApiKey;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
+import java.time.Clock;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.stereotype.Component;
 
-/** Process-local per-key fixed-window limiter. It does not represent persisted access policy truth. */
+/**
+ * Cluster-wide per-key fixed-window limiter backed by shared persistence.
+ *
+ * <p>The API Key policy remains persisted on the key aggregate; this role only coordinates the
+ * current minute usage across Yak Ops instances.
+ */
 @Component
 public class DataServiceRateLimiter {
-  private final ConcurrentHashMap<Long, RateWindow> windows = new ConcurrentHashMap<>();
+
+  private final DataServiceRateLimitRepository repository;
+  private final Clock clock;
   private final AtomicLong checks = new AtomicLong();
 
+  public DataServiceRateLimiter(DataServiceRateLimitRepository repository) {
+    this(repository, Clock.systemUTC());
+  }
+
+  DataServiceRateLimiter(DataServiceRateLimitRepository repository, Clock clock) {
+    this.repository = Objects.requireNonNull(repository, "repository");
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
   public void acquire(DataServiceApiKey key) {
-    long currentMinute = System.currentTimeMillis() / 60_000L;
-    RateWindow window = windows.compute(key.id(), (id, current) ->
-        current == null || current.minute() != currentMinute
-            ? new RateWindow(currentMinute, new AtomicInteger()) : current);
-    int used = window.count().incrementAndGet();
+    Objects.requireNonNull(key, "api key");
+    long currentMinute = clock.instant().getEpochSecond() / 60L;
+    boolean admitted = repository.tryAcquire(
+        key.id(), currentMinute, key.rateLimitPerMinute());
+
     if ((checks.incrementAndGet() & 255L) == 0L) {
-      windows.entrySet().removeIf(entry -> entry.getValue().minute() < currentMinute - 1L);
+      repository.deleteBefore(currentMinute - 2L);
     }
-    if (used > key.rateLimitPerMinute()) {
+
+    if (!admitted) {
       throw new DataServiceRateLimitException(
           "API Key 已超过每分钟 " + key.rateLimitPerMinute() + " 次调用限制",
           key.id(), key.name(), key.keyPrefix());
     }
   }
 
-  public void invalidate(Long keyId) { if (keyId != null) windows.remove(keyId); }
-  private record RateWindow(long minute, AtomicInteger count) {}
+  public void invalidate(Long keyId) {
+    repository.deleteForKey(keyId);
+  }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiter.java
@@ -4,21 +4,20 @@ import io.yak.ops.business.dataservice.domain.access.DataServiceApiKey;
 import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
 import java.time.Clock;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.stereotype.Component;
 
 /**
  * Cluster-wide per-key fixed-window limiter backed by shared persistence.
  *
  * <p>The API Key policy remains persisted on the key aggregate; this role only coordinates the
- * current minute usage across Yak Ops instances.
+ * current minute usage across Yak Ops instances. Old-window cleanup is owned by scheduled
+ * observability maintenance, never by the latency-sensitive invocation path.
  */
 @Component
 public class DataServiceRateLimiter {
 
   private final DataServiceRateLimitRepository repository;
   private final Clock clock;
-  private final AtomicLong checks = new AtomicLong();
 
   public DataServiceRateLimiter(DataServiceRateLimitRepository repository) {
     this(repository, Clock.systemUTC());
@@ -34,11 +33,6 @@ public class DataServiceRateLimiter {
     long currentMinute = clock.instant().getEpochSecond() / 60L;
     boolean admitted = repository.tryAcquire(
         key.id(), currentMinute, key.rateLimitPerMinute());
-
-    if ((checks.incrementAndGet() & 255L) == 0L) {
-      repository.deleteBefore(currentMinute - 2L);
-    }
-
     if (!admitted) {
       throw new DataServiceRateLimitException(
           "API Key 已超过每分钟 " + key.rateLimitPerMinute() + " 次调用限制",

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceApiPO.java
@@ -29,6 +29,7 @@ public class DataServiceApiPO {
   private Boolean circuitBreakerEnabled;
   private Integer circuitFailureThreshold;
   private Integer circuitRecoverySeconds;
+  private Long runtimeGeneration;
   private String description;
   private String sourceType;
   private String sourceRef;

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/DataServiceDefinition.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/DataServiceDefinition.java
@@ -13,6 +13,7 @@ public final class DataServiceDefinition {
   private SourceReference sourceReference;
   private RuntimePolicy runtimePolicy;
   private AuthMode authMode;
+  private long runtimeGeneration;
   private LocalDateTime createTime;
   private LocalDateTime updateTime;
 
@@ -43,6 +44,7 @@ public final class DataServiceDefinition {
     definition.sourceReference = requireSource(sourceReference);
     definition.runtimePolicy = runtimePolicy == null ? RuntimePolicy.defaults(true) : runtimePolicy;
     definition.authMode = AuthMode.NONE;
+    definition.runtimeGeneration = 1L;
     definition.createTime = now;
     definition.updateTime = now;
     return definition;
@@ -62,6 +64,7 @@ public final class DataServiceDefinition {
     return restore(
         id,
         null,
+        1L,
         settings,
         runtimeSnapshot,
         sourceReference,
@@ -81,6 +84,30 @@ public final class DataServiceDefinition {
       AuthMode authMode,
       LocalDateTime createTime,
       LocalDateTime updateTime) {
+    return restore(
+        id,
+        projectId,
+        1L,
+        settings,
+        runtimeSnapshot,
+        sourceReference,
+        runtimePolicy,
+        authMode,
+        createTime,
+        updateTime);
+  }
+
+  public static DataServiceDefinition restore(
+      Long id,
+      Long projectId,
+      Long runtimeGeneration,
+      DataServiceSettings settings,
+      PublishedRuntimeSnapshot runtimeSnapshot,
+      SourceReference sourceReference,
+      RuntimePolicy runtimePolicy,
+      AuthMode authMode,
+      LocalDateTime createTime,
+      LocalDateTime updateTime) {
     DataServiceDefinition definition = new DataServiceDefinition();
     definition.id = id;
     definition.projectId = normalizeProjectId(projectId);
@@ -89,6 +116,7 @@ public final class DataServiceDefinition {
     definition.sourceReference = requireSource(sourceReference);
     definition.runtimePolicy = runtimePolicy == null ? RuntimePolicy.defaults(false) : runtimePolicy;
     definition.authMode = authMode == null ? AuthMode.NONE : authMode;
+    definition.runtimeGeneration = normalizeGeneration(runtimeGeneration);
     definition.createTime = createTime;
     definition.updateTime = updateTime;
     return definition;
@@ -96,7 +124,7 @@ public final class DataServiceDefinition {
 
   public void updateSettings(DataServiceSettings settings, LocalDateTime now) {
     this.settings = requireSettings(settings);
-    this.updateTime = now;
+    touch(now);
   }
 
   public void republish(
@@ -107,7 +135,7 @@ public final class DataServiceDefinition {
     this.settings = requireSettings(settings);
     this.runtimeSnapshot = requireRuntime(runtimeSnapshot);
     this.sourceReference = requireSource(sourceReference);
-    this.updateTime = now;
+    touch(now);
   }
 
   public void setEnabled(boolean enabled, LocalDateTime now) {
@@ -115,22 +143,31 @@ public final class DataServiceDefinition {
     this.settings = new DataServiceSettings(
         current.name(), current.path(), current.maxRows(), current.timeoutSeconds(), enabled,
         current.description(), current.paginationEnabled());
-    this.updateTime = now;
+    touch(now);
   }
 
   public void setAuthMode(AuthMode mode, LocalDateTime now) {
     this.authMode = mode == null ? AuthMode.NONE : mode;
-    this.updateTime = now;
+    touch(now);
   }
 
   public void updateRuntimePolicy(RuntimePolicy policy, LocalDateTime now) {
     if (policy == null) throw new IllegalArgumentException("Runtime policy must not be null");
     this.runtimePolicy = policy;
+    touch(now);
+  }
+
+  private void touch(LocalDateTime now) {
+    this.runtimeGeneration = runtimeGeneration == Long.MAX_VALUE ? 1L : runtimeGeneration + 1L;
     this.updateTime = now;
   }
 
   private static Long normalizeProjectId(Long value) {
     return value == null || value <= 0L ? null : value;
+  }
+
+  private static long normalizeGeneration(Long value) {
+    return value == null || value <= 0L ? 1L : value;
   }
 
   private static DataServiceSettings requireSettings(DataServiceSettings value) {
@@ -155,6 +192,7 @@ public final class DataServiceDefinition {
   public SourceReference sourceReference() { return sourceReference; }
   public RuntimePolicy runtimePolicy() { return runtimePolicy; }
   public AuthMode authMode() { return authMode; }
+  public long runtimeGeneration() { return runtimeGeneration; }
   public LocalDateTime createTime() { return createTime; }
   public LocalDateTime updateTime() { return updateTime; }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceAuditSanitizer.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceAuditSanitizer.java
@@ -1,0 +1,76 @@
+package io.yak.ops.business.dataservice.execution;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Masks sensitive request values before invocation evidence is serialized or persisted. */
+@Component
+public class DataServiceAuditSanitizer {
+
+  static final String REDACTED = "[REDACTED]";
+
+  public Map<String, String> sanitize(Map<String, String> parameters) {
+    if (parameters == null || parameters.isEmpty()) return Map.of();
+    Map<String, String> result = new LinkedHashMap<>();
+    parameters.forEach((name, value) -> result.put(name, sanitizeValue(name, value)));
+    return result;
+  }
+
+  String sanitizeValue(String name, String value) {
+    if (value == null) return null;
+    String normalized = normalize(name);
+    if (isSecret(normalized)) return REDACTED;
+    if (normalized.contains("mobile") || normalized.contains("phone") || normalized.contains("tel")) {
+      return maskPhone(value);
+    }
+    if (normalized.contains("idcard") || normalized.contains("identity") || normalized.contains("身份证")) {
+      return maskIdentity(value);
+    }
+    if (normalized.contains("email") || normalized.contains("mail")) {
+      return maskEmail(value);
+    }
+    return value;
+  }
+
+  private boolean isSecret(String normalized) {
+    return normalized.contains("password")
+        || normalized.contains("passwd")
+        || normalized.equals("pwd")
+        || normalized.contains("secret")
+        || normalized.contains("token")
+        || normalized.contains("authorization")
+        || normalized.contains("apikey")
+        || normalized.contains("accesskey")
+        || normalized.contains("credential");
+  }
+
+  private String normalize(String name) {
+    if (name == null) return "";
+    return name.toLowerCase(Locale.ROOT).replaceAll("[\\s_\\-.]", "");
+  }
+
+  private String maskPhone(String value) {
+    String trimmed = value.trim();
+    if (trimmed.length() <= 7) return REDACTED;
+    return trimmed.substring(0, Math.min(3, trimmed.length()))
+        + "****"
+        + trimmed.substring(trimmed.length() - 4);
+  }
+
+  private String maskIdentity(String value) {
+    String trimmed = value.trim();
+    if (trimmed.length() <= 10) return REDACTED;
+    return trimmed.substring(0, 6) + "********" + trimmed.substring(trimmed.length() - 4);
+  }
+
+  private String maskEmail(String value) {
+    String trimmed = value.trim();
+    int at = trimmed.indexOf('@');
+    if (at <= 0 || at == trimmed.length() - 1) return REDACTED;
+    String local = trimmed.substring(0, at);
+    String prefix = local.isEmpty() ? "*" : local.substring(0, 1);
+    return prefix + "***@" + trimmed.substring(at + 1);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvocationRecorder.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvocationRecorder.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/** Persists bounded invocation audit evidence; it does not own Data Service runtime truth. */
+/** Persists bounded, sanitized invocation audit evidence; it does not own runtime truth. */
 @Component
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -19,6 +19,7 @@ public class DataServiceInvocationRecorder {
 
   private final DataServiceCallLogRepository repository;
   private final ObjectMapper objectMapper;
+  private final DataServiceAuditSanitizer sanitizer;
 
   public void record(
       DataServiceDefinition definition,
@@ -29,6 +30,7 @@ public class DataServiceInvocationRecorder {
       String errorMessage,
       AccessContext access) {
     AccessContext caller = access == null ? AccessContext.publicAccess() : access;
+    Map<String, String> safeParameters = sanitizer.sanitize(parameters);
     repository.save(new InvocationRecord(
         null,
         definition.projectId(),
@@ -39,7 +41,7 @@ public class DataServiceInvocationRecorder {
         caller.apiKeyId(),
         caller.apiKeyName(),
         caller.apiKeyPrefix(),
-        limit(json(parameters == null ? Map.of() : parameters), 4_000),
+        limit(json(safeParameters), 4_000),
         success,
         durationMs,
         rowCount,

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
@@ -103,8 +103,8 @@ public class DataServiceInvoker {
   }
 
   /**
-   * Persisted generation namespace protects node-local caches after republish/settings updates even
-   * when another JVM did not receive the local invalidation call.
+   * Persisted monotonic generation protects node-local caches after republish/settings updates even
+   * when another JVM did not receive an explicit local invalidation call.
    */
   String runtimeNamespace(DataServiceDefinition definition) {
     SourceReference source = definition.sourceReference();
@@ -119,7 +119,7 @@ public class DataServiceInvoker {
         .append(':')
         .append(source.sourceRevisionNo())
         .append("|generation=")
-        .append(definition.updateTime())
+        .append(definition.runtimeGeneration())
         .toString();
   }
 

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.dataservice.access.DataServiceRateLimitException;
 import io.yak.ops.business.dataservice.access.DataServiceUnauthorizedException;
 import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
 import io.yak.ops.business.dataservice.domain.DataServiceQueryResponse;
+import io.yak.ops.business.dataservice.domain.RuntimePolicy;
 import io.yak.ops.business.dataservice.domain.SourceReference;
 import io.yak.ops.business.dataservice.domain.access.AccessContext;
 import io.yak.ops.business.dataservice.query.DataServiceReader;
@@ -103,11 +104,13 @@ public class DataServiceInvoker {
   }
 
   /**
-   * Persisted monotonic generation protects node-local caches after republish/settings updates even
-   * when another JVM did not receive an explicit local invalidation call.
+   * Persisted monotonic generation is the primary cross-node cache namespace. Runtime-affecting
+   * settings/policy are also included so concurrent admin writes that observed the same generation
+   * still cannot reuse one another's cached results.
    */
   String runtimeNamespace(DataServiceDefinition definition) {
     SourceReference source = definition.sourceReference();
+    RuntimePolicy policy = definition.runtimePolicy();
     return new StringBuilder("api=")
         .append(definition.id())
         .append("|source=")
@@ -120,6 +123,16 @@ public class DataServiceInvoker {
         .append(source.sourceRevisionNo())
         .append("|generation=")
         .append(definition.runtimeGeneration())
+        .append("|maxRows=")
+        .append(definition.settings().maxRows())
+        .append("|pagination=")
+        .append(definition.settings().paginationEnabled())
+        .append("|cache=")
+        .append(policy.cacheEnabled())
+        .append(':')
+        .append(policy.cacheTtlSeconds())
+        .append(':')
+        .append(policy.cacheMaxEntries())
         .toString();
   }
 

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
@@ -1,0 +1,72 @@
+package io.yak.ops.business.dataservice.observability;
+
+import io.yak.ops.business.dataservice.repository.DataServiceObservabilityMaintenanceRepository;
+import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Bounded lifecycle maintenance for invocation evidence and shared minute windows. */
+@Slf4j
+@Component
+@ConditionalOnDataSourceEnabled
+public class DataServiceObservabilityMaintenance {
+
+  private final DataServiceObservabilityMaintenanceRepository repository;
+  private final DataServiceRateLimitRepository rateLimitRepository;
+  private final int rawRetentionDays;
+  private final int rollupRetentionDays;
+  private final int maxHourlyBucketsPerRun;
+
+  public DataServiceObservabilityMaintenance(
+      DataServiceObservabilityMaintenanceRepository repository,
+      DataServiceRateLimitRepository rateLimitRepository,
+      @Value("${yak.data-service.observability.raw-retention-days:30}") int rawRetentionDays,
+      @Value("${yak.data-service.observability.rollup-retention-days:365}") int rollupRetentionDays,
+      @Value("${yak.data-service.observability.max-hourly-buckets-per-run:168}")
+          int maxHourlyBucketsPerRun) {
+    this.repository = repository;
+    this.rateLimitRepository = rateLimitRepository;
+    this.rawRetentionDays = Math.max(1, rawRetentionDays);
+    this.rollupRetentionDays = Math.max(this.rawRetentionDays, rollupRetentionDays);
+    this.maxHourlyBucketsPerRun = Math.max(1, Math.min(744, maxHourlyBucketsPerRun));
+  }
+
+  @Scheduled(cron = "${yak.data-service.observability.maintenance-cron:0 20 3 * * *}")
+  public void maintain() {
+    maintainAt(LocalDateTime.now());
+  }
+
+  void maintainAt(LocalDateTime now) {
+    LocalDateTime rawCutoff = now.minusDays(rawRetentionDays);
+    int buckets = 0;
+    int rawRows = 0;
+    while (buckets < maxHourlyBucketsPerRun) {
+      var oldest = repository.oldestRawHourBefore(rawCutoff);
+      if (oldest.isEmpty()) break;
+      rawRows += repository.rollupAndDeleteHour(oldest.get());
+      buckets++;
+    }
+
+    int expiredRollups = repository.deleteRollupsBefore(now.minusDays(rollupRetentionDays));
+    long currentMinute = java.time.ZoneOffset.UTC
+        .getRules()
+        .getOffset(now)
+        .getTotalSeconds();
+    // LocalDateTime has no zone truth; rate-window cleanup only needs a conservative old epoch.
+    long minuteFloor = System.currentTimeMillis() / 60_000L;
+    int expiredRateWindows = rateLimitRepository.deleteBefore(minuteFloor - 2L);
+
+    if (buckets > 0 || expiredRollups > 0 || expiredRateWindows > 0) {
+      log.info(
+          "Data Service observability maintenance complete: hourlyBuckets={}, rawRows={}, expiredRollups={}, expiredRateWindows={}",
+          buckets,
+          rawRows,
+          expiredRollups,
+          expiredRateWindows);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -42,7 +43,9 @@ public class DataServiceObservabilityMaintenance {
   }
 
   void maintainAt(LocalDateTime now) {
-    LocalDateTime rawCutoff = now.minusDays(rawRetentionDays);
+    // Only roll a complete hour whose end is outside the raw-retention window. Keeping the
+    // boundary hour raw avoids dropping still-retained rows from 30d overview queries.
+    LocalDateTime rawCutoff = now.minusDays(rawRetentionDays).truncatedTo(ChronoUnit.HOURS);
     int buckets = 0;
     int rawRows = 0;
     while (buckets < maxHourlyBucketsPerRun) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.dataservice.repository.DataServiceObservabilityMainte
 import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -52,12 +53,7 @@ public class DataServiceObservabilityMaintenance {
     }
 
     int expiredRollups = repository.deleteRollupsBefore(now.minusDays(rollupRetentionDays));
-    long currentMinute = java.time.ZoneOffset.UTC
-        .getRules()
-        .getOffset(now)
-        .getTotalSeconds();
-    // LocalDateTime has no zone truth; rate-window cleanup only needs a conservative old epoch.
-    long minuteFloor = System.currentTimeMillis() / 60_000L;
+    long minuteFloor = now.toEpochSecond(ZoneOffset.UTC) / 60L;
     int expiredRateWindows = rateLimitRepository.deleteBefore(minuteFloor - 2L);
 
     if (buckets > 0 || expiredRollups > 0 || expiredRateWindows > 0) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenance.java
@@ -4,7 +4,7 @@ import io.yak.ops.business.dataservice.repository.DataServiceObservabilityMainte
 import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -53,7 +53,7 @@ public class DataServiceObservabilityMaintenance {
     }
 
     int expiredRollups = repository.deleteRollupsBefore(now.minusDays(rollupRetentionDays));
-    long minuteFloor = now.toEpochSecond(ZoneOffset.UTC) / 60L;
+    long minuteFloor = now.atZone(ZoneId.systemDefault()).toEpochSecond() / 60L;
     int expiredRateWindows = rateLimitRepository.deleteBefore(minuteFloor - 2L);
 
     if (buckets > 0 || expiredRollups > 0 || expiredRateWindows > 0) {

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceObservabilityMaintenanceRepository.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceObservabilityMaintenanceRepository.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.dataservice.repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/** Persistence boundary for raw invocation retention and hourly rollup maintenance. */
+public interface DataServiceObservabilityMaintenanceRepository {
+
+  Optional<LocalDateTime> oldestRawHourBefore(LocalDateTime cutoff);
+
+  /** Rolls one closed UTC/local-database hour into aggregate storage and deletes the raw rows atomically. */
+  int rollupAndDeleteHour(LocalDateTime bucketStart);
+
+  int deleteRollupsBefore(LocalDateTime cutoff);
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceObservabilityMaintenanceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceObservabilityMaintenanceRepositoryAdapter.java
@@ -1,0 +1,99 @@
+package io.yak.ops.business.dataservice.repository;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/** MySQL maintenance adapter; each hour is rolled up and deleted in one transaction. */
+@Repository
+@ConditionalOnDataSourceEnabled
+public class DataServiceObservabilityMaintenanceRepositoryAdapter
+    implements DataServiceObservabilityMaintenanceRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final TransactionTemplate transactionTemplate;
+
+  public DataServiceObservabilityMaintenanceRepositoryAdapter(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      @Qualifier("yakBusinessTransactionManager") PlatformTransactionManager transactionManager) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+  }
+
+  @Override
+  public Optional<LocalDateTime> oldestRawHourBefore(LocalDateTime cutoff) {
+    LocalDateTime oldest = jdbcTemplate.query(
+        "SELECT MIN(create_time) FROM yak_ops_data_service_call_log WHERE create_time < ?",
+        resultSet -> resultSet.next() ? resultSet.getObject(1, LocalDateTime.class) : null,
+        cutoff);
+    return Optional.ofNullable(oldest).map(value -> value.truncatedTo(ChronoUnit.HOURS));
+  }
+
+  @Override
+  public int rollupAndDeleteHour(LocalDateTime bucketStart) {
+    if (bucketStart == null) return 0;
+    LocalDateTime start = bucketStart.truncatedTo(ChronoUnit.HOURS);
+    LocalDateTime end = start.plusHours(1);
+    Integer deleted = transactionTemplate.execute(status -> {
+      jdbcTemplate.update(
+          """
+          INSERT INTO yak_ops_data_service_call_log_hourly
+          (project_id, api_id, bucket_hour, service_name, service_path,
+           total_calls, success_calls, failure_calls, total_duration_ms, total_rows,
+           first_call_at, last_call_at, last_success_at, last_failure_at, update_time)
+          SELECT project_id,
+                 api_id,
+                 ?,
+                 MAX(service_name),
+                 MAX(service_path),
+                 COUNT(*),
+                 COALESCE(SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END), 0),
+                 COALESCE(SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END), 0),
+                 COALESCE(SUM(GREATEST(duration_ms, 0)), 0),
+                 COALESCE(SUM(GREATEST(row_count, 0)), 0),
+                 MIN(create_time),
+                 MAX(create_time),
+                 MAX(CASE WHEN success = 1 THEN create_time END),
+                 MAX(CASE WHEN success = 0 THEN create_time END),
+                 CURRENT_TIMESTAMP(3)
+          FROM yak_ops_data_service_call_log
+          WHERE create_time >= ? AND create_time < ?
+          GROUP BY project_id, api_id
+          ON DUPLICATE KEY UPDATE
+            service_name = VALUES(service_name),
+            service_path = VALUES(service_path),
+            total_calls = VALUES(total_calls),
+            success_calls = VALUES(success_calls),
+            failure_calls = VALUES(failure_calls),
+            total_duration_ms = VALUES(total_duration_ms),
+            total_rows = VALUES(total_rows),
+            first_call_at = VALUES(first_call_at),
+            last_call_at = VALUES(last_call_at),
+            last_success_at = VALUES(last_success_at),
+            last_failure_at = VALUES(last_failure_at),
+            update_time = CURRENT_TIMESTAMP(3)
+          """,
+          start,
+          start,
+          end);
+      return jdbcTemplate.update(
+          "DELETE FROM yak_ops_data_service_call_log WHERE create_time >= ? AND create_time < ?",
+          start,
+          end);
+    });
+    return deleted == null ? 0 : deleted;
+  }
+
+  @Override
+  public int deleteRollupsBefore(LocalDateTime cutoff) {
+    return jdbcTemplate.update(
+        "DELETE FROM yak_ops_data_service_call_log_hourly WHERE bucket_hour < ?", cutoff);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRateLimitRepository.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRateLimitRepository.java
@@ -1,0 +1,14 @@
+package io.yak.ops.business.dataservice.repository;
+
+/** Shared persistence boundary for cluster-wide API Key fixed-window rate limiting. */
+public interface DataServiceRateLimitRepository {
+
+  /** Returns true when one request is admitted into the shared minute window. */
+  boolean tryAcquire(Long apiKeyId, long windowMinute, int limitPerMinute);
+
+  /** Removes all windows for one key after rotate/delete so stale counters cannot leak. */
+  void deleteForKey(Long apiKeyId);
+
+  /** Bounded maintenance hook for old fixed-window rows. */
+  int deleteBefore(long windowMinute);
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRateLimitRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRateLimitRepositoryAdapter.java
@@ -1,0 +1,89 @@
+package io.yak.ops.business.dataservice.repository;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** MySQL CAS adapter that enforces one shared fixed-window counter across all Yak Ops instances. */
+@Slf4j
+@Repository
+@ConditionalOnDataSourceEnabled
+public class DataServiceRateLimitRepositoryAdapter implements DataServiceRateLimitRepository {
+
+  private static final int MAX_CAS_ATTEMPTS = 32;
+  private final JdbcTemplate jdbcTemplate;
+
+  public DataServiceRateLimitRepositoryAdapter(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+  }
+
+  @Override
+  public boolean tryAcquire(Long apiKeyId, long windowMinute, int limitPerMinute) {
+    if (apiKeyId == null || apiKeyId <= 0L) {
+      throw new IllegalArgumentException("API Key ID 必须大于 0");
+    }
+    if (limitPerMinute <= 0) {
+      throw new IllegalArgumentException("API Key 每分钟限流必须大于 0");
+    }
+
+    for (int attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      Integer current = currentCount(apiKeyId, windowMinute);
+      if (current == null) {
+        try {
+          jdbcTemplate.update(
+              "INSERT INTO yak_ops_data_service_rate_window "
+                  + "(api_key_id, window_minute, request_count, update_time) "
+                  + "VALUES (?, ?, 1, CURRENT_TIMESTAMP(3))",
+              apiKeyId,
+              windowMinute);
+          return true;
+        } catch (DuplicateKeyException concurrentInsert) {
+          continue;
+        }
+      }
+
+      if (current >= limitPerMinute) return false;
+      int updated = jdbcTemplate.update(
+          "UPDATE yak_ops_data_service_rate_window "
+              + "SET request_count = request_count + 1, update_time = CURRENT_TIMESTAMP(3) "
+              + "WHERE api_key_id = ? AND window_minute = ? AND request_count = ?",
+          apiKeyId,
+          windowMinute,
+          current);
+      if (updated == 1) return true;
+    }
+
+    log.warn(
+        "Data Service shared rate-limit CAS contention exceeded: apiKeyId={}, windowMinute={}",
+        apiKeyId,
+        windowMinute);
+    throw new IllegalStateException("数据服务全局限流状态竞争过高，请稍后重试");
+  }
+
+  @Override
+  public void deleteForKey(Long apiKeyId) {
+    if (apiKeyId == null) return;
+    jdbcTemplate.update(
+        "DELETE FROM yak_ops_data_service_rate_window WHERE api_key_id = ?", apiKeyId);
+  }
+
+  @Override
+  public int deleteBefore(long windowMinute) {
+    return jdbcTemplate.update(
+        "DELETE FROM yak_ops_data_service_rate_window WHERE window_minute < ?", windowMinute);
+  }
+
+  private Integer currentCount(Long apiKeyId, long windowMinute) {
+    return jdbcTemplate.query(
+        "SELECT request_count FROM yak_ops_data_service_rate_window "
+            + "WHERE api_key_id = ? AND window_minute = ?",
+        resultSet -> resultSet.next() ? resultSet.getInt(1) : null,
+        apiKeyId,
+        windowMinute);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRepositoryAdapter.java
@@ -143,8 +143,8 @@ public class DataServiceRepositoryAdapter implements DataServiceRepository {
         value(po.getCacheMaxEntries(), 200), Boolean.TRUE.equals(po.getCircuitBreakerEnabled()),
         value(po.getCircuitFailureThreshold(), 5), value(po.getCircuitRecoverySeconds(), 30));
     return DataServiceDefinition.restore(
-        po.getId(), po.getProjectId(), settings, runtime, source, policy, AuthMode.parse(po.getAuthMode()),
-        po.getCreateTime(), po.getUpdateTime());
+        po.getId(), po.getProjectId(), po.getRuntimeGeneration(), settings, runtime, source, policy,
+        AuthMode.parse(po.getAuthMode()), po.getCreateTime(), po.getUpdateTime());
   }
 
   private DataServiceApiPO toPo(DataServiceDefinition definition) {
@@ -170,6 +170,7 @@ public class DataServiceRepositoryAdapter implements DataServiceRepository {
     po.setCircuitBreakerEnabled(policy.circuitBreakerEnabled());
     po.setCircuitFailureThreshold(policy.failureThreshold());
     po.setCircuitRecoverySeconds(policy.recoverySeconds());
+    po.setRuntimeGeneration(definition.runtimeGeneration());
     SourceReference source = definition.sourceReference();
     po.setSourceType(source.sourceType());
     po.setSourceRef(source.sourceRef());

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepository.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepository.java
@@ -1,6 +1,6 @@
 package io.yak.ops.business.dataservice.repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 /** Cluster-wide invocation metric projection built from durable audit evidence and rollups. */
@@ -14,6 +14,6 @@ public interface DataServiceRuntimeMetricsRepository {
       long failureCalls,
       long totalDurationMs,
       List<Long> recentDurationsMs,
-      LocalDateTime lastSuccessAt,
-      LocalDateTime lastFailureAt) {}
+      Instant lastSuccessAt,
+      Instant lastFailureAt) {}
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepository.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepository.java
@@ -1,0 +1,19 @@
+package io.yak.ops.business.dataservice.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** Cluster-wide invocation metric projection built from durable audit evidence and rollups. */
+public interface DataServiceRuntimeMetricsRepository {
+
+  Metrics load(Long apiId, int durationSampleSize);
+
+  record Metrics(
+      long totalCalls,
+      long successCalls,
+      long failureCalls,
+      long totalDurationMs,
+      List<Long> recentDurationsMs,
+      LocalDateTime lastSuccessAt,
+      LocalDateTime lastFailureAt) {}
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepositoryAdapter.java
@@ -2,7 +2,8 @@ package io.yak.ops.business.dataservice.repository;
 
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.core.project.CurrentProject;
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -63,8 +64,8 @@ public class DataServiceRuntimeMetricsRepositoryAdapter
             resultSet.getLong("success_calls"),
             resultSet.getLong("failure_calls"),
             resultSet.getLong("total_duration_ms"),
-            resultSet.getObject("last_success_at", LocalDateTime.class),
-            resultSet.getObject("last_failure_at", LocalDateTime.class)),
+            instant(resultSet.getTimestamp("last_success_at")),
+            instant(resultSet.getTimestamp("last_failure_at"))),
         projectId,
         apiId,
         projectId,
@@ -90,13 +91,17 @@ public class DataServiceRuntimeMetricsRepositoryAdapter
         value.lastFailureAt());
   }
 
+  private static Instant instant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+
   private record Aggregate(
       long totalCalls,
       long successCalls,
       long failureCalls,
       long totalDurationMs,
-      LocalDateTime lastSuccessAt,
-      LocalDateTime lastFailureAt) {
+      Instant lastSuccessAt,
+      Instant lastFailureAt) {
     static Aggregate empty() { return new Aggregate(0L, 0L, 0L, 0L, null, null); }
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceRuntimeMetricsRepositoryAdapter.java
@@ -1,0 +1,102 @@
+package io.yak.ops.business.dataservice.repository;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.project.CurrentProject;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** MySQL projection over raw invocation evidence plus hourly rollups. */
+@Repository
+@ConditionalOnDataSourceEnabled
+public class DataServiceRuntimeMetricsRepositoryAdapter
+    implements DataServiceRuntimeMetricsRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final CurrentProject currentProject;
+
+  public DataServiceRuntimeMetricsRepositoryAdapter(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      CurrentProject currentProject) {
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.currentProject = currentProject;
+  }
+
+  @Override
+  public Metrics load(Long apiId, int durationSampleSize) {
+    if (apiId == null || apiId <= 0L) throw new IllegalArgumentException("数据服务 ID 必须大于 0");
+    Long projectId = currentProject.requireProjectId();
+    Aggregate aggregate = jdbcTemplate.queryForObject(
+        """
+        SELECT
+          COALESCE(SUM(metrics.total_calls), 0) AS total_calls,
+          COALESCE(SUM(metrics.success_calls), 0) AS success_calls,
+          COALESCE(SUM(metrics.failure_calls), 0) AS failure_calls,
+          COALESCE(SUM(metrics.total_duration_ms), 0) AS total_duration_ms,
+          MAX(metrics.last_success_at) AS last_success_at,
+          MAX(metrics.last_failure_at) AS last_failure_at
+        FROM (
+          SELECT COUNT(*) AS total_calls,
+                 COALESCE(SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END), 0) AS success_calls,
+                 COALESCE(SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END), 0) AS failure_calls,
+                 COALESCE(SUM(GREATEST(duration_ms, 0)), 0) AS total_duration_ms,
+                 MAX(CASE WHEN success = 1 THEN create_time END) AS last_success_at,
+                 MAX(CASE WHEN success = 0 THEN create_time END) AS last_failure_at
+          FROM yak_ops_data_service_call_log
+          WHERE project_id = ? AND api_id = ?
+          UNION ALL
+          SELECT COALESCE(SUM(total_calls), 0),
+                 COALESCE(SUM(success_calls), 0),
+                 COALESCE(SUM(failure_calls), 0),
+                 COALESCE(SUM(total_duration_ms), 0),
+                 MAX(last_success_at),
+                 MAX(last_failure_at)
+          FROM yak_ops_data_service_call_log_hourly
+          WHERE project_id = ? AND api_id = ?
+        ) metrics
+        """,
+        (resultSet, rowNum) -> new Aggregate(
+            resultSet.getLong("total_calls"),
+            resultSet.getLong("success_calls"),
+            resultSet.getLong("failure_calls"),
+            resultSet.getLong("total_duration_ms"),
+            resultSet.getObject("last_success_at", LocalDateTime.class),
+            resultSet.getObject("last_failure_at", LocalDateTime.class)),
+        projectId,
+        apiId,
+        projectId,
+        apiId);
+
+    int sampleSize = Math.max(1, Math.min(1_024, durationSampleSize));
+    List<Long> durations = jdbcTemplate.query(
+        "SELECT duration_ms FROM yak_ops_data_service_call_log "
+            + "WHERE project_id = ? AND api_id = ? "
+            + "ORDER BY create_time DESC, id DESC LIMIT " + sampleSize,
+        (resultSet, rowNum) -> Math.max(0L, resultSet.getLong(1)),
+        projectId,
+        apiId);
+
+    Aggregate value = aggregate == null ? Aggregate.empty() : aggregate;
+    return new Metrics(
+        value.totalCalls(),
+        value.successCalls(),
+        value.failureCalls(),
+        value.totalDurationMs(),
+        List.copyOf(durations),
+        value.lastSuccessAt(),
+        value.lastFailureAt());
+  }
+
+  private record Aggregate(
+      long totalCalls,
+      long successCalls,
+      long failureCalls,
+      long totalDurationMs,
+      LocalDateTime lastSuccessAt,
+      LocalDateTime lastFailureAt) {
+    static Aggregate empty() { return new Aggregate(0L, 0L, 0L, 0L, null, null); }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/DataServiceRuntimePolicyManager.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/DataServiceRuntimePolicyManager.java
@@ -4,8 +4,11 @@ import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
 import io.yak.ops.business.dataservice.domain.RuntimePolicy;
 import io.yak.ops.business.dataservice.query.DataServiceReader;
 import io.yak.ops.business.dataservice.repository.DataServiceRepository;
+import io.yak.ops.business.dataservice.repository.DataServiceRuntimeMetricsRepository;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,13 +18,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DataServiceRuntimePolicyManager {
 
+  private static final int P95_SAMPLE_SIZE = 256;
   private final DataServiceReader reader;
   private final DataServiceRepository repository;
   private final LocalDataServiceRuntime runtime;
+  private final DataServiceRuntimeMetricsRepository metricsRepository;
 
   public DataServiceRuntimeSnapshot snapshot(Long apiId) {
     DataServiceDefinition definition = reader.require(apiId);
-    return runtime.snapshot(definition.id(), definition.runtimePolicy());
+    return clusterSnapshot(definition);
   }
 
   @Transactional
@@ -31,11 +36,53 @@ public class DataServiceRuntimePolicyManager {
     definition.updateRuntimePolicy(policy, LocalDateTime.now());
     DataServiceDefinition saved = repository.save(definition);
     runtime.invalidate(apiId);
-    return runtime.snapshot(saved.id(), saved.runtimePolicy());
+    return clusterSnapshot(saved);
   }
 
   public void invalidate(Long apiId) { runtime.invalidate(apiId); }
   public void remove(Long apiId) { runtime.remove(apiId); }
+
+  private DataServiceRuntimeSnapshot clusterSnapshot(DataServiceDefinition definition) {
+    DataServiceRuntimeSnapshot local = runtime.snapshot(definition.id(), definition.runtimePolicy());
+    DataServiceRuntimeMetricsRepository.Metrics metrics =
+        metricsRepository.load(definition.id(), P95_SAMPLE_SIZE);
+    long total = metrics.totalCalls();
+    long success = metrics.successCalls();
+    long average = total == 0L ? 0L : metrics.totalDurationMs() / total;
+    double successRate = total == 0L ? 1D : (double) success / total;
+
+    return new DataServiceRuntimeSnapshot(
+        local.apiId(),
+        local.cacheEnabled(),
+        local.cacheTtlSeconds(),
+        local.cacheMaxEntries(),
+        local.cacheEntries(),
+        local.circuitBreakerEnabled(),
+        local.failureThreshold(),
+        local.recoverySeconds(),
+        local.circuitState(),
+        local.circuitOpenUntil(),
+        total,
+        success,
+        metrics.failureCalls(),
+        local.cacheHits(),
+        local.circuitRejected(),
+        successRate,
+        local.cacheHitRate(),
+        average,
+        p95(metrics.recentDurationsMs()),
+        metrics.lastSuccessAt(),
+        metrics.lastFailureAt(),
+        "CLUSTER_INVOCATION_LOCAL_RESILIENCE");
+  }
+
+  private long p95(List<Long> durations) {
+    if (durations == null || durations.isEmpty()) return 0L;
+    List<Long> sorted = new ArrayList<>(durations);
+    sorted.sort(Long::compareTo);
+    int index = Math.min(sorted.size() - 1, (int) Math.ceil(sorted.size() * 0.95D) - 1);
+    return sorted.get(Math.max(0, index));
+  }
 
   private RuntimePolicy normalize(RuntimePolicyInput input) {
     if (input == null) throw new IllegalArgumentException("Runtime 配置不能为空");

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/DataServiceRuntimeSnapshot.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/DataServiceRuntimeSnapshot.java
@@ -2,7 +2,7 @@ package io.yak.ops.business.dataservice.runtime;
 
 import java.time.Instant;
 
-/** Process-local runtime evidence exposed for observability. */
+/** Runtime status: cluster invocation metrics plus node-local cache/circuit evidence. */
 public record DataServiceRuntimeSnapshot(
     Long apiId,
     boolean cacheEnabled,
@@ -24,4 +24,5 @@ public record DataServiceRuntimeSnapshot(
     long averageDurationMs,
     long p95DurationMs,
     Instant lastSuccessAt,
-    Instant lastFailureAt) {}
+    Instant lastFailureAt,
+    String metricsScope) {}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/LocalDataServiceRuntime.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/runtime/LocalDataServiceRuntime.java
@@ -185,7 +185,7 @@ public class LocalDataServiceRuntime {
           breaker.state(), breaker.openUntil(), metric.totalCalls(), metric.successCalls(),
           metric.failureCalls(), metric.cacheHits(), metric.circuitRejected(), metric.successRate(),
           metric.cacheHitRate(), metric.averageDurationMs(), metric.p95DurationMs(),
-          metric.lastSuccessAt(), metric.lastFailureAt());
+          metric.lastSuccessAt(), metric.lastFailureAt(), "LOCAL");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V13__harden_data_service_cluster_runtime.sql
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V13__harden_data_service_cluster_runtime.sql
@@ -1,0 +1,43 @@
+-- Data Service Stage 3: cluster-safe rate limiting, monotonic runtime generation and observability lifecycle.
+
+ALTER TABLE yak_ops_data_service_api
+    ADD COLUMN runtime_generation BIGINT UNSIGNED NOT NULL DEFAULT 1
+        COMMENT 'Monotonic runtime cache namespace generation' AFTER circuit_recovery_seconds;
+
+CREATE TABLE IF NOT EXISTS yak_ops_data_service_rate_window (
+    api_key_id BIGINT UNSIGNED NOT NULL COMMENT 'Data Service API Key ID',
+    window_minute BIGINT NOT NULL COMMENT 'UTC epoch minute',
+    request_count INT NOT NULL DEFAULT 0 COMMENT 'Cluster-wide calls admitted in this window',
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT 'Last update time',
+    PRIMARY KEY (api_key_id, window_minute),
+    KEY idx_yak_ops_data_service_rate_window_minute (window_minute)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops Data Service cluster rate-limit windows';
+
+CREATE TABLE IF NOT EXISTS yak_ops_data_service_call_log_hourly (
+    project_id BIGINT UNSIGNED NOT NULL COMMENT 'Project Space ID',
+    api_id BIGINT UNSIGNED NOT NULL COMMENT 'Data Service API ID',
+    bucket_hour DATETIME NOT NULL COMMENT 'UTC hour bucket',
+    service_name VARCHAR(256) NOT NULL COMMENT 'Service name snapshot',
+    service_path VARCHAR(512) NOT NULL COMMENT 'Service path snapshot',
+    total_calls BIGINT NOT NULL DEFAULT 0,
+    success_calls BIGINT NOT NULL DEFAULT 0,
+    failure_calls BIGINT NOT NULL DEFAULT 0,
+    total_duration_ms BIGINT NOT NULL DEFAULT 0,
+    total_rows BIGINT NOT NULL DEFAULT 0,
+    first_call_at DATETIME(3) DEFAULT NULL,
+    last_call_at DATETIME(3) DEFAULT NULL,
+    last_success_at DATETIME(3) DEFAULT NULL,
+    last_failure_at DATETIME(3) DEFAULT NULL,
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (project_id, api_id, bucket_hour),
+    KEY idx_yak_ops_data_service_rollup_project_hour (project_id, bucket_hour),
+    KEY idx_yak_ops_data_service_rollup_api_hour (project_id, api_id, bucket_hour)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops Data Service hourly invocation rollup';

--- a/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V13__harden_data_service_cluster_runtime.sql
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-datasource/V13__harden_data_service_cluster_runtime.sql
@@ -1,4 +1,4 @@
--- Data Service Stage 3: cluster-safe rate limiting, monotonic runtime generation and observability lifecycle.
+-- Data Service cluster runtime: shared rate limiting, monotonic cache generation and audit lifecycle.
 
 ALTER TABLE yak_ops_data_service_api
     ADD COLUMN runtime_generation BIGINT UNSIGNED NOT NULL DEFAULT 1
@@ -6,7 +6,7 @@ ALTER TABLE yak_ops_data_service_api
 
 CREATE TABLE IF NOT EXISTS yak_ops_data_service_rate_window (
     api_key_id BIGINT UNSIGNED NOT NULL COMMENT 'Data Service API Key ID',
-    window_minute BIGINT NOT NULL COMMENT 'UTC epoch minute',
+    window_minute BIGINT NOT NULL COMMENT 'Epoch minute shared across instances',
     request_count INT NOT NULL DEFAULT 0 COMMENT 'Cluster-wide calls admitted in this window',
     update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
         ON UPDATE CURRENT_TIMESTAMP(3) COMMENT 'Last update time',
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS yak_ops_data_service_rate_window (
 CREATE TABLE IF NOT EXISTS yak_ops_data_service_call_log_hourly (
     project_id BIGINT UNSIGNED NOT NULL COMMENT 'Project Space ID',
     api_id BIGINT UNSIGNED NOT NULL COMMENT 'Data Service API ID',
-    bucket_hour DATETIME NOT NULL COMMENT 'UTC hour bucket',
+    bucket_hour DATETIME NOT NULL COMMENT 'Application/database local hour bucket',
     service_name VARCHAR(256) NOT NULL COMMENT 'Service name snapshot',
     service_path VARCHAR(512) NOT NULL COMMENT 'Service path snapshot',
     total_calls BIGINT NOT NULL DEFAULT 0,

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiterTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiterTest.java
@@ -1,0 +1,65 @@
+package io.yak.ops.business.dataservice.access;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.domain.access.DataServiceApiKey;
+import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class DataServiceRateLimiterTest {
+
+  private static final Instant NOW = Instant.parse("2026-08-28T04:50:00Z");
+
+  @Test
+  void delegatesAdmissionToSharedRepositoryWindow() {
+    DataServiceRateLimitRepository repository = mock(DataServiceRateLimitRepository.class);
+    DataServiceRateLimiter limiter = new DataServiceRateLimiter(
+        repository, Clock.fixed(NOW, ZoneOffset.UTC));
+    DataServiceApiKey key = key(60);
+    long minute = NOW.getEpochSecond() / 60L;
+    when(repository.tryAcquire(9L, minute, 60)).thenReturn(true);
+
+    limiter.acquire(key);
+
+    verify(repository).tryAcquire(9L, minute, 60);
+  }
+
+  @Test
+  void rejectsWhenClusterWindowAlreadyReachedTheConfiguredLimit() {
+    DataServiceRateLimitRepository repository = mock(DataServiceRateLimitRepository.class);
+    DataServiceRateLimiter limiter = new DataServiceRateLimiter(
+        repository, Clock.fixed(NOW, ZoneOffset.UTC));
+    DataServiceApiKey key = key(2);
+    long minute = NOW.getEpochSecond() / 60L;
+    when(repository.tryAcquire(9L, minute, 2)).thenReturn(false);
+
+    assertThatThrownBy(() -> limiter.acquire(key))
+        .isInstanceOf(DataServiceRateLimitException.class)
+        .hasMessageContaining("每分钟 2 次");
+  }
+
+  @Test
+  void invalidationClearsSharedWindowsForRotatedOrDeletedKey() {
+    DataServiceRateLimitRepository repository = mock(DataServiceRateLimitRepository.class);
+    DataServiceRateLimiter limiter = new DataServiceRateLimiter(
+        repository, Clock.fixed(NOW, ZoneOffset.UTC));
+
+    limiter.invalidate(9L);
+
+    verify(repository).deleteForKey(9L);
+  }
+
+  private DataServiceApiKey key(int rateLimit) {
+    LocalDateTime time = LocalDateTime.of(2026, 8, 28, 12, 50);
+    return new DataServiceApiKey(
+        9L, 7L, "consumer-a", "yak_ds_abcd", "hash", true,
+        rateLimit, null, null, time, time);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceClusterRuntimeContractTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceClusterRuntimeContractTest.java
@@ -1,0 +1,84 @@
+package io.yak.ops.business.dataservice.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class DataServiceClusterRuntimeContractTest {
+
+  @Test
+  void rateLimitIsSharedPersistenceInsteadOfPerJvmMap() throws Exception {
+    String limiter = read("access/DataServiceRateLimiter.java");
+    String adapter = read("repository/DataServiceRateLimitRepositoryAdapter.java");
+
+    assertThat(limiter)
+        .contains("DataServiceRateLimitRepository")
+        .doesNotContain("ConcurrentHashMap");
+    assertThat(adapter)
+        .contains("request_count = request_count + 1")
+        .contains("AND request_count = ?")
+        .contains("DuplicateKeyException");
+  }
+
+  @Test
+  void cacheStaysNodeLocalButNamespaceUsesDurableGenerationAndRuntimeShape() throws Exception {
+    String runtime = read("runtime/LocalDataServiceRuntime.java");
+    String invoker = read("execution/DataServiceInvoker.java");
+
+    assertThat(runtime)
+        .contains("Caffeine")
+        .contains("\"LOCAL\"");
+    assertThat(invoker)
+        .contains("definition.runtimeGeneration()")
+        .contains("definition.settings().maxRows()")
+        .contains("policy.cacheTtlSeconds()")
+        .doesNotContain(".append(definition.updateTime())");
+  }
+
+  @Test
+  void auditIsSanitizedBeforePersistence() throws Exception {
+    String recorder = read("execution/DataServiceInvocationRecorder.java");
+    String sanitizer = read("execution/DataServiceAuditSanitizer.java");
+
+    assertThat(recorder).contains("sanitizer.sanitize(parameters)");
+    assertThat(sanitizer)
+        .contains("[REDACTED]")
+        .contains("password")
+        .contains("authorization")
+        .contains("maskPhone")
+        .contains("maskIdentity")
+        .contains("maskEmail");
+  }
+
+  @Test
+  void rawAuditRollupAndDeletionShareOneTransactionBoundary() throws Exception {
+    String adapter = read("repository/DataServiceObservabilityMaintenanceRepositoryAdapter.java");
+
+    assertThat(adapter)
+        .contains("TransactionTemplate")
+        .contains("yak_ops_data_service_call_log_hourly")
+        .contains("INSERT INTO")
+        .contains("DELETE FROM yak_ops_data_service_call_log")
+        .contains("transactionTemplate.execute");
+  }
+
+  @Test
+  void runtimeStatusSeparatesClusterInvocationFromLocalResilience() throws Exception {
+    String manager = read("runtime/DataServiceRuntimePolicyManager.java");
+    assertThat(manager)
+        .contains("DataServiceRuntimeMetricsRepository")
+        .contains("CLUSTER_INVOCATION_LOCAL_RESILIENCE")
+        .contains("local.cacheEntries()")
+        .contains("metrics.totalCalls()");
+  }
+
+  private String read(String relative) throws Exception {
+    Path local = Path.of("src/main/java/io/yak/ops/business/dataservice").resolve(relative);
+    if (Files.isRegularFile(local)) return Files.readString(local);
+    return Files.readString(Path.of(
+        "yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice")
+        .resolve(relative));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceAuditSanitizerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceAuditSanitizerTest.java
@@ -1,0 +1,39 @@
+package io.yak.ops.business.dataservice.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DataServiceAuditSanitizerTest {
+
+  private final DataServiceAuditSanitizer sanitizer = new DataServiceAuditSanitizer();
+
+  @Test
+  void masksSecretsAndCommonPersonalIdentifiersBeforePersistence() {
+    Map<String, String> result = sanitizer.sanitize(Map.of(
+        "password", "s3cr3t",
+        "access_token", "token-value",
+        "mobile", "13812345678",
+        "id_card", "510123199001011234",
+        "email", "someone@example.com",
+        "status", "ACTIVE"));
+
+    assertThat(result.get("password")).isEqualTo(DataServiceAuditSanitizer.REDACTED);
+    assertThat(result.get("access_token")).isEqualTo(DataServiceAuditSanitizer.REDACTED);
+    assertThat(result.get("mobile")).isEqualTo("138****5678");
+    assertThat(result.get("id_card")).isEqualTo("510123********1234");
+    assertThat(result.get("email")).isEqualTo("s***@example.com");
+    assertThat(result.get("status")).isEqualTo("ACTIVE");
+  }
+
+  @Test
+  void shortSensitiveValuesAreNeverPartiallyLeaked() {
+    assertThat(sanitizer.sanitizeValue("phone", "12345"))
+        .isEqualTo(DataServiceAuditSanitizer.REDACTED);
+    assertThat(sanitizer.sanitizeValue("identity", "123456"))
+        .isEqualTo(DataServiceAuditSanitizer.REDACTED);
+    assertThat(sanitizer.sanitizeValue("authorization", "Bearer abc"))
+        .isEqualTo(DataServiceAuditSanitizer.REDACTED);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
@@ -104,14 +104,17 @@ class DataServiceInvokerTest {
   void runtimeNamespaceChangesWhenPersistedGenerationChanges() {
     DataServiceDefinition newer = DataServiceDefinition.restore(
         7L,
+        3L,
+        12L,
         definition.settings(),
         definition.runtimeSnapshot(),
-        new SourceReference("TEST", "orders", 102L, 2),
+        definition.sourceReference(),
         definition.runtimePolicy(),
         AuthMode.NONE,
         LocalDateTime.of(2026, 8, 28, 10, 0),
-        LocalDateTime.of(2026, 8, 28, 10, 10));
+        LocalDateTime.of(2026, 8, 28, 10, 0));
 
+    assertThat(definition.runtimeGeneration()).isEqualTo(11L);
     assertThat(invoker.runtimeNamespace(definition))
         .isNotEqualTo(invoker.runtimeNamespace(newer));
   }
@@ -119,6 +122,8 @@ class DataServiceInvokerTest {
   private DataServiceDefinition definition() {
     return DataServiceDefinition.restore(
         7L,
+        3L,
+        11L,
         new DataServiceSettings("Orders", "/orders", 100, 30, true, null, false),
         new PublishedRuntimeSnapshot(9L, "select id from orders where id = :id"),
         new SourceReference("TEST", "orders", 101L, 1),

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenanceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenanceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 import io.yak.ops.business.dataservice.repository.DataServiceObservabilityMaintenanceRepository;
 import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -40,6 +40,7 @@ class DataServiceObservabilityMaintenanceTest {
     order.verify(repository).oldestRawHourBefore(rawCutoff);
     order.verify(repository).rollupAndDeleteHour(second);
     verify(repository).deleteRollupsBefore(now.minusDays(365));
-    verify(rateRepository).deleteBefore(now.toEpochSecond(ZoneOffset.UTC) / 60L - 2L);
+    verify(rateRepository).deleteBefore(
+        now.atZone(ZoneId.systemDefault()).toEpochSecond() / 60L - 2L);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenanceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenanceTest.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.dataservice.observability;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.repository.DataServiceObservabilityMaintenanceRepository;
+import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class DataServiceObservabilityMaintenanceTest {
+
+  @Test
+  void rollsOnlyBoundedOldHoursThenExpiresRollupsAndRateWindows() {
+    DataServiceObservabilityMaintenanceRepository repository =
+        mock(DataServiceObservabilityMaintenanceRepository.class);
+    DataServiceRateLimitRepository rateRepository = mock(DataServiceRateLimitRepository.class);
+    DataServiceObservabilityMaintenance maintenance =
+        new DataServiceObservabilityMaintenance(repository, rateRepository, 30, 365, 2);
+    LocalDateTime now = LocalDateTime.of(2026, 8, 28, 4, 50);
+    LocalDateTime first = LocalDateTime.of(2026, 6, 1, 1, 0);
+    LocalDateTime second = LocalDateTime.of(2026, 6, 1, 2, 0);
+    LocalDateTime rawCutoff = now.minusDays(30);
+
+    when(repository.oldestRawHourBefore(rawCutoff))
+        .thenReturn(Optional.of(first), Optional.of(second));
+    when(repository.rollupAndDeleteHour(first)).thenReturn(12);
+    when(repository.rollupAndDeleteHour(second)).thenReturn(8);
+
+    maintenance.maintainAt(now);
+
+    InOrder order = inOrder(repository);
+    order.verify(repository).oldestRawHourBefore(rawCutoff);
+    order.verify(repository).rollupAndDeleteHour(first);
+    order.verify(repository).oldestRawHourBefore(rawCutoff);
+    order.verify(repository).rollupAndDeleteHour(second);
+    verify(repository).deleteRollupsBefore(now.minusDays(365));
+    verify(rateRepository).deleteBefore(now.toEpochSecond(ZoneOffset.UTC) / 60L - 2L);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenanceTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/observability/DataServiceObservabilityMaintenanceTest.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.dataservice.repository.DataServiceObservabilityMainte
 import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -16,7 +17,7 @@ import org.mockito.InOrder;
 class DataServiceObservabilityMaintenanceTest {
 
   @Test
-  void rollsOnlyBoundedOldHoursThenExpiresRollupsAndRateWindows() {
+  void rollsOnlyBoundedFullyExpiredHoursThenExpiresRollupsAndRateWindows() {
     DataServiceObservabilityMaintenanceRepository repository =
         mock(DataServiceObservabilityMaintenanceRepository.class);
     DataServiceRateLimitRepository rateRepository = mock(DataServiceRateLimitRepository.class);
@@ -25,7 +26,7 @@ class DataServiceObservabilityMaintenanceTest {
     LocalDateTime now = LocalDateTime.of(2026, 8, 28, 4, 50);
     LocalDateTime first = LocalDateTime.of(2026, 6, 1, 1, 0);
     LocalDateTime second = LocalDateTime.of(2026, 6, 1, 2, 0);
-    LocalDateTime rawCutoff = now.minusDays(30);
+    LocalDateTime rawCutoff = now.minusDays(30).truncatedTo(ChronoUnit.HOURS);
 
     when(repository.oldestRawHourBefore(rawCutoff))
         .thenReturn(Optional.of(first), Optional.of(second));

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/runtime/DataServiceRuntimePolicyManagerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/runtime/DataServiceRuntimePolicyManagerTest.java
@@ -1,0 +1,79 @@
+package io.yak.ops.business.dataservice.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
+import io.yak.ops.business.dataservice.domain.DataServiceSettings;
+import io.yak.ops.business.dataservice.domain.PublishedRuntimeSnapshot;
+import io.yak.ops.business.dataservice.domain.RuntimePolicy;
+import io.yak.ops.business.dataservice.domain.SourceReference;
+import io.yak.ops.business.dataservice.domain.access.AuthMode;
+import io.yak.ops.business.dataservice.query.DataServiceReader;
+import io.yak.ops.business.dataservice.repository.DataServiceRepository;
+import io.yak.ops.business.dataservice.repository.DataServiceRuntimeMetricsRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataServiceRuntimePolicyManagerTest {
+
+  @Test
+  void snapshotUsesClusterInvocationTotalsButKeepsNodeLocalCacheAndCircuitEvidence() {
+    DataServiceReader reader = mock(DataServiceReader.class);
+    DataServiceRepository repository = mock(DataServiceRepository.class);
+    LocalDataServiceRuntime localRuntime = mock(LocalDataServiceRuntime.class);
+    DataServiceRuntimeMetricsRepository metricsRepository =
+        mock(DataServiceRuntimeMetricsRepository.class);
+    DataServiceRuntimePolicyManager manager = new DataServiceRuntimePolicyManager(
+        reader, repository, localRuntime, metricsRepository);
+    DataServiceDefinition definition = definition();
+    when(reader.require(7L)).thenReturn(definition);
+    when(localRuntime.snapshot(7L, definition.runtimePolicy())).thenReturn(
+        new DataServiceRuntimeSnapshot(
+            7L, true, 60, 200, 12L,
+            true, 5, 30, "OPEN", Instant.parse("2026-08-28T05:01:00Z"),
+            3L, 2L, 1L, 2L, 1L, 0.66D, 0.5D, 4L, 9L,
+            Instant.parse("2026-08-28T04:49:00Z"),
+            Instant.parse("2026-08-28T04:50:00Z"),
+            "LOCAL"));
+    when(metricsRepository.load(7L, 256)).thenReturn(
+        new DataServiceRuntimeMetricsRepository.Metrics(
+            100L, 90L, 10L, 5_000L,
+            List.of(10L, 20L, 30L, 40L),
+            Instant.parse("2026-08-28T04:58:00Z"),
+            Instant.parse("2026-08-28T04:57:00Z")));
+
+    DataServiceRuntimeSnapshot snapshot = manager.snapshot(7L);
+
+    assertThat(snapshot.totalCalls()).isEqualTo(100L);
+    assertThat(snapshot.successCalls()).isEqualTo(90L);
+    assertThat(snapshot.failureCalls()).isEqualTo(10L);
+    assertThat(snapshot.successRate()).isEqualTo(0.9D);
+    assertThat(snapshot.averageDurationMs()).isEqualTo(50L);
+    assertThat(snapshot.p95DurationMs()).isEqualTo(40L);
+    assertThat(snapshot.lastSuccessAt()).isEqualTo(Instant.parse("2026-08-28T04:58:00Z"));
+
+    assertThat(snapshot.cacheEntries()).isEqualTo(12L);
+    assertThat(snapshot.cacheHits()).isEqualTo(2L);
+    assertThat(snapshot.circuitState()).isEqualTo("OPEN");
+    assertThat(snapshot.circuitRejected()).isEqualTo(1L);
+    assertThat(snapshot.metricsScope()).isEqualTo("CLUSTER_INVOCATION_LOCAL_RESILIENCE");
+  }
+
+  private DataServiceDefinition definition() {
+    return DataServiceDefinition.restore(
+        7L,
+        3L,
+        11L,
+        new DataServiceSettings("Orders", "/orders", 100, 30, true, null, false),
+        new PublishedRuntimeSnapshot(9L, "select id from orders"),
+        new SourceReference("TEST", "orders", 101L, 1),
+        new RuntimePolicy(true, 60, 200, true, 5, 30),
+        AuthMode.NONE,
+        LocalDateTime.of(2026, 8, 28, 12, 0),
+        LocalDateTime.of(2026, 8, 28, 12, 40));
+  }
+}

--- a/yak-ops-ui/src/services/data-service/types.ts
+++ b/yak-ops-ui/src/services/data-service/types.ts
@@ -99,6 +99,10 @@ export interface DataServiceRuntimeConfig {
   recoverySeconds: number;
 }
 
+export type DataServiceRuntimeMetricsScope =
+  | 'LOCAL'
+  | 'CLUSTER_INVOCATION_LOCAL_RESILIENCE';
+
 export interface DataServiceRuntimeStatus extends DataServiceRuntimeConfig {
   apiId: number;
   cacheEntries: number;
@@ -115,6 +119,7 @@ export interface DataServiceRuntimeStatus extends DataServiceRuntimeConfig {
   p95DurationMs: number;
   lastSuccessAt?: string | null;
   lastFailureAt?: string | null;
+  metricsScope?: DataServiceRuntimeMetricsScope;
 }
 
 export interface DataServiceParameterDoc {


### PR DESCRIPTION
## Summary

Implements **Data Service Stage 3: Cluster Runtime & Scale-out Hardening** on top of merged Stage 2 (#848).

This stage deliberately does **not** add Redis or an API Gateway just to make the module look distributed. Yak Ops currently has no reusable Redis runtime substrate for Data Service, so the design uses existing MySQL for shared coordination / durable metrics while keeping latency-sensitive result cache and circuit state node-local.

```text
Persisted Definition / RuntimePolicy / runtime_generation
              |
              +--> Cluster coordination/evidence (MySQL)
              |      - API-key minute windows
              |      - invocation audit
              |      - hourly rollup
              |
              +--> Node-local resilience
                     - Caffeine result cache
                     - circuit breaker
```

### 1. Cluster-wide API Key rate limiting

Replaces the per-JVM `ConcurrentHashMap` fixed-window limiter with a shared persistence port:

```text
DataServiceRateLimiter
  -> DataServiceRateLimitRepository
  -> MySQL CAS window(api_key_id, epoch_minute)
```

- concurrent instances consume one shared RPM budget
- first caller inserts count=1; concurrent insert retries on duplicate key
- existing windows use compare-and-set `UPDATE ... WHERE request_count = observedCount`
- over quota keeps existing HTTP 429 semantics
- coordination-storage failure is fail-closed rather than silently bypassing the limit
- key rotate/disable/delete clears shared windows
- old minute-window cleanup moved off the invocation hot path into bounded maintenance

### 2. Monotonic cache generation and cross-node correctness

Adds persisted `runtime_generation` to `yak_ops_data_service_api`.

Every Data Service mutation that changes online behavior advances the generation. Cache namespace now includes:

- API identity
- Source Revision
- persisted runtime generation
- maxRows / pagination shape
- cache policy shape
- compiled SQL / bindings / pagination identity

This replaces timestamp-only generation and prevents another node from reusing an older cache entry even if it never received an explicit local invalidate. Runtime-affecting settings are also included as a concurrency fallback when two admin writes observed the same previous generation.

Result cache itself intentionally remains Caffeine/node-local; Stage 3 provides **version-safe local cache**, not a pretend shared cache.

### 3. Cluster invocation metrics + explicit local resilience scope

Adds `DataServiceRuntimeMetricsRepository` over durable invocation evidence:

- cluster total/success/failure calls
- cluster success rate
- cluster average duration
- last success/failure
- bounded recent P95 sample (latest raw durations, not claimed as exact all-history histogram)

Runtime status now combines:

```text
Cluster invocation evidence
  +
Current-node cache/circuit evidence
```

and exposes:

```text
metricsScope = CLUSTER_INVOCATION_LOCAL_RESILIENCE
```

`cacheEntries/cacheHits/cacheHitRate/circuitState/circuitRejected` remain explicitly node-local.

### 4. Invocation audit sanitization

Adds `DataServiceAuditSanitizer` and applies it **before JSON serialization/persistence**.

Default rules:

- password/passwd/pwd -> `[REDACTED]`
- secret/token/authorization/apiKey/accessKey/credential -> `[REDACTED]`
- mobile/phone/tel -> first 3 + `****` + last 4
- idCard/identity/身份证 -> first 6 + mask + last 4
- email/mail -> first character + masked local part + domain
- ordinary parameters remain available for troubleshooting subject to the existing 4000-char bound

Stage 1 audit failure-isolation semantics remain unchanged: logging failure cannot change an already determined invocation result.

### 5. Raw audit retention + hourly rollup

Adds `yak_ops_data_service_call_log_hourly` and bounded maintenance.

Defaults:

```text
raw invocation logs: 30 days
hourly rollup:        365 days
max buckets/run:      168
maintenance cron:     0 20 3 * * *
```

Each expired complete hour is handled in **one DB transaction**:

```text
INSERT ... SELECT raw hour -> hourly rollup
DELETE same raw hour
COMMIT
```

Failure rolls both operations back, preventing double-counting or evidence loss.

The raw cutoff is truncated to a complete hour before rollup, so the boundary hour of a 30-day Overview is not deleted early. Existing 24h/7d/30d Overview therefore keeps exact raw evidence within its supported horizon.

### 6. V13 persistence

`V13__harden_data_service_cluster_runtime.sql` adds:

- `yak_ops_data_service_api.runtime_generation`
- `yak_ops_data_service_rate_window`
- `yak_ops_data_service_call_log_hourly`
- indexes for minute-window cleanup and project/API hourly rollup reads

Existing Flyway history is untouched.

### 7. Tests / guards

Added/updated coverage:

- `DataServiceRateLimiterTest`
  - shared repository admission
  - cluster quota rejection
  - global key-window invalidation
- `DataServiceAuditSanitizerTest`
  - secret redaction
  - phone / identity / email masking
- `DataServiceRuntimePolicyManagerTest`
  - cluster invocation metrics override local call totals
  - local cache/circuit evidence remains local
- `DataServiceObservabilityMaintenanceTest`
  - bounded hourly processing
  - complete-hour raw retention boundary
  - rollup/rate-window expiry
- `DataServiceInvokerTest`
  - monotonic runtime generation changes cache namespace
- `DataServiceClusterRuntimeContractTest`
  - rate limit cannot regress to per-JVM map
  - cache remains local but version-safe
  - audit must sanitize before persistence
  - rollup/delete share a transaction boundary
  - cluster invocation vs local resilience remains explicit

### 8. Documentation

Added/updated:

- `CLUSTER_RUNTIME.md`
- `REQUIREMENTS.md`
- `DOMAIN.md`
- `ARCHITECTURE.md`
- `DEPENDENCIES.md`
- `README.md`
- `RUNTIME_RELIABILITY.md`

## Validation status

The branch is synchronized with current `main` (`behind=0`).

I attempted to clone the branch into the execution environment for a real build, but the environment cannot resolve `github.com` (`Could not resolve host: github.com`). Therefore Maven/npm/MySQL integration tests were **not actually executed here**. Added tests/guards are not a passing-build claim.

Recommended minimum local verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-data-service -am test

cd yak-ops-ui
npm run tsc
npm run biome:lint -- src/services/data-service src/pages/data-service
```

Database:

- run Flyway V13 on a representative Stage-2 database
- confirm existing APIs receive `runtime_generation=1`
- confirm new rate-window/hourly tables and indexes exist
- exercise one maintenance rollup hour and verify raw + rollup never coexist after commit for the same completed hour

Recommended two-instance smoke matrix:

1. Configure one API Key at 10 RPM; alternate requests between two Yak Ops instances and verify total admitted requests are 10, not 20.
2. Republish/change Runtime settings through instance A while instance B has a warm cache; verify B cannot return a result from the old runtime namespace after reading the new Definition.
3. Call through both instances; runtime status from either management instance should show the same cluster invocation totals while cache/circuit values may differ by node.
4. Send `password`, `token`, `mobile`, `idCard`, and `email` parameters; verify raw secret/PII values are absent from `yak_ops_data_service_call_log.params_json`.
5. Put raw logs just inside and just outside the 30-day boundary; verify only fully expired hours are rolled/deleted.
6. Simulate rollup transaction failure and verify raw evidence remains available for retry.

## Non-goals

This PR does not introduce:

- Redis/shared result cache
- distributed circuit-breaker state
- API Gateway
- exact all-history P95 histogram
- async/durable audit queue

Those can be added later behind the new repository/runtime boundaries without changing Publication, Project Governance, or Public Invocation contracts.