### PR TITLE
fix(data-service): declare Yak Security compile dependency

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/pom.xml
+++ b/yak-ops-business/yak-ops-business-data-service/pom.xml
@@ -33,6 +33,10 @@
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.yak.framework</groupId>
+            <artifactId>yak-security-spring-boot-starter</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceGovernanceContractTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceGovernanceContractTest.java
@@ -37,6 +37,14 @@ class DataServiceGovernanceContractTest {
   }
 
   @Test
+  void managementRbacHasExplicitYakSecurityCompileDependency() throws IOException {
+    String pom = Files.readString(modulePom());
+    assertThat(pom)
+        .contains("<groupId>io.yak.framework</groupId>")
+        .contains("<artifactId>yak-security-spring-boot-starter</artifactId>");
+  }
+
+  @Test
   void permissionVocabularyIsExplicitAndStable() throws IOException {
     String source = Files.readString(permissionSource());
     assertThat(source)
@@ -61,6 +69,12 @@ class DataServiceGovernanceContractTest {
     assertThat(reader)
         .contains("repository.findByRuntimePath(path)")
         .contains("repository.count()");
+  }
+
+  private Path modulePom() {
+    Path local = Path.of("pom.xml");
+    if (Files.isRegularFile(local)) return local;
+    return Path.of("yak-ops-business", "yak-ops-business-data-service", "pom.xml");
   }
 
   private Path controllerRoot() {


### PR DESCRIPTION
## Summary

Fixes the Data Service compile/startup failure introduced when Stage 2 added `@RequiresPermission` to Data Service management controllers without declaring the Yak Security artifact on the Data Service module compile classpath.

### Root cause

The controller import is correct:

```java
import io.yak.framework.security.web.RequiresPermission;
```

`RequiresPermission` still exists in current `yak-framework/main` under `yak-security`. The problem is Maven module isolation: `yak-ops-business-data-service` used the annotation directly but did not depend on the artifact that owns it.

`yak-ops-business-data-development` already follows the correct pattern and explicitly depends on:

```xml
<dependency>
    <groupId>io.yak.framework</groupId>
    <artifactId>yak-security-spring-boot-starter</artifactId>
</dependency>
```

### Changes

- add the same explicit `yak-security-spring-boot-starter` dependency to `yak-ops-business-data-service`
- keep all existing `RequiresPermission` imports/annotations unchanged
- add a governance contract test that requires the module POM to retain the Yak Security compile dependency while Data Service owns RBAC-protected management controllers

### Scope

No REST, permission-code, Project Scope, Runtime, database, or frontend behavior changes.

## Validation

Branch is based on current `main` after #850 and is `behind=0`.

Recommended local verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-data-service -am clean compile
mvn -pl yak-ops-business/yak-ops-business-data-service -am test
```

Then reload Maven in IntelliJ and start `YakOpsApplication` again.

The immediate expected result is that both the unresolved import and unresolved `@RequiresPermission` symbol disappear from the Data Service controllers.