### PR TITLE
fix(dataset): align frontend source contracts (Stage 1)

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetSourceTypeContractTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/DatasetSourceTypeContractTest.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.dataset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DatasetSourceTypeContractTest {
+
+  @Test
+  void persistedSourceTypeValuesStayStable() {
+    assertThat(DatasetSourceType.values())
+        .containsExactlyInAnyOrder(
+            DatasetSourceType.QUERY_REVISION,
+            DatasetSourceType.SQL_QUERY,
+            DatasetSourceType.TABLE,
+            DatasetSourceType.VIEW);
+  }
+}

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/components/CatalogDatasetDetail.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/components/CatalogDatasetDetail.tsx
@@ -5,7 +5,8 @@ import type {
   CatalogDatasetFieldRole,
   CatalogDatasetSourceType,
 } from '@/services/data-analysis';
-import { Popconfirm, Table, Tag } from 'antd';
+import { isQueryableDatasetSourceType } from '@/services/dataset';
+import { Popconfirm, Table, Tag, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { BarChart3, GitBranch, Rows3, Sigma, TableProperties } from 'lucide-react';
 import {
@@ -14,7 +15,11 @@ import {
   SOURCE_TYPE_LABELS,
 } from '../constants';
 import type { CatalogDetailTab } from '../types';
-import { formatDateTime, getSchemaSummary } from '../utils';
+import {
+  formatDateTime,
+  getDatasetVersionSourceSummary,
+  getSchemaSummary,
+} from '../utils';
 import DatasetLineageTab from './DatasetLineageTab';
 
 interface CatalogDatasetDetailProps {
@@ -108,17 +113,16 @@ export function CatalogDatasetDetail({
       ),
     },
     {
-      title: '来源任务',
-      render: (_, record) => (
-        <div>
-          <div className="text-[14px] text-[#344054]">
-            {dataset.sourceTaskName || `TaskAsset #${record.sourceTaskAssetId}`}
+      title: '来源',
+      render: (_, record) => {
+        const source = getDatasetVersionSourceSummary(record, dataset.sourceTaskName);
+        return (
+          <div>
+            <div className="text-[14px] text-[#344054]">{source.title}</div>
+            <div className="mt-0.5 text-[12px] text-[#8a8f99]">{source.detail}</div>
           </div>
-          <div className="mt-0.5 text-[12px] text-[#8a8f99]">
-            SQL V{record.sourceTaskRevisionNo}
-          </div>
-        </div>
-      ),
+        );
+      },
     },
     {
       title: '发布时间',
@@ -141,11 +145,35 @@ export function CatalogDatasetDetail({
     },
   ];
 
-  const datasetType = dataset.currentVersion
-    ? dataset.currentVersion.sourceType === 'QUERY_REVISION'
-      ? 'SQL 数据集'
-      : `${SOURCE_TYPE_LABELS[dataset.currentVersion.sourceType]}数据集`
-    : '-';
+  const datasetType = (() => {
+    switch (dataset.currentVersion?.sourceType) {
+      case 'QUERY_REVISION':
+        return 'SQL 任务数据集';
+      case 'SQL_QUERY':
+        return 'Standalone SQL 数据集';
+      case 'TABLE':
+        return '数据表 Dataset（未接入查询运行时）';
+      case 'VIEW':
+        return '视图 Dataset（未接入查询运行时）';
+      default:
+        return '-';
+    }
+  })();
+  const currentSource = dataset.currentVersion
+    ? getDatasetVersionSourceSummary(dataset.currentVersion, dataset.sourceTaskName)
+    : undefined;
+  const hasQueryableVersion = Boolean(
+    dataset.currentVersion
+    && isQueryableDatasetSourceType(dataset.currentVersion.sourceType),
+  );
+  const canCreateAnalysis = dataset.status === 'ONLINE' && hasQueryableVersion;
+  const createAnalysisTip = !dataset.currentVersion
+    ? 'Dataset 尚无当前版本'
+    : !hasQueryableVersion
+      ? `${SOURCE_TYPE_LABELS[dataset.currentVersion.sourceType]}尚未接入 Dataset Query Runtime`
+      : dataset.status === 'ONLINE'
+        ? '使用当前 Dataset 创建分析'
+        : 'Dataset 上线后才能创建 Analysis';
 
   const detailItems = [
     { label: '类型', value: datasetType },
@@ -153,7 +181,7 @@ export function CatalogDatasetDetail({
       label: '所属目录',
       value: dataset.directoryPath || (dataset.sourceNodeId ? '根目录' : '未分组'),
     },
-    { label: '来源任务', value: dataset.sourceTaskName || '-' },
+    { label: '来源', value: currentSource?.title || '-' },
     { label: '数据描述', value: dataset.description || '无' },
     { label: '更新时间', value: formatDateTime(dataset.updateTime || dataset.createTime) },
     { label: '创建时间', value: formatDateTime(dataset.createTime) },
@@ -197,18 +225,22 @@ export function CatalogDatasetDetail({
               {dataset.status === 'ONLINE' ? '下线' : '上线'}
             </YakButton>
           </Popconfirm>
-          <YakButton
-            type="primary"
-            icon={<BarChart3 size={13} />}
-            disabled={dataset.status !== 'ONLINE' || !dataset.currentVersion}
-            href={
-              dataset.status === 'ONLINE' && dataset.currentVersion
-                ? `/data-analysis/chart-analysis?datasetId=${encodeURIComponent(dataset.id)}`
-                : undefined
-            }
-          >
-            创建分析
-          </YakButton>
+          <Tooltip title={createAnalysisTip}>
+            <span>
+              <YakButton
+                type="primary"
+                icon={<BarChart3 size={13} />}
+                disabled={!canCreateAnalysis}
+                href={
+                  canCreateAnalysis
+                    ? `/data-analysis/chart-analysis?datasetId=${encodeURIComponent(dataset.id)}`
+                    : undefined
+                }
+              >
+                创建分析
+              </YakButton>
+            </span>
+          </Tooltip>
         </div>
       </div>
 

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/components/CatalogDatasetTable.tsx
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/components/CatalogDatasetTable.tsx
@@ -4,12 +4,20 @@ import type {
   CatalogDataset,
   CatalogDatasetStatus,
 } from '@/services/data-analysis';
+import { isQueryableDatasetSourceType } from '@/services/dataset';
 import { Input, Pagination, Popconfirm, Select, Table, Tag, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { BarChart3, Clock3, Search, TableProperties } from 'lucide-react';
-import { SOURCE_TYPE_LABELS } from '../constants';
+import {
+  QUERYABLE_SOURCE_TYPE_OPTIONS,
+  SOURCE_TYPE_LABELS,
+} from '../constants';
 import type { CatalogSourceTypeFilter, CatalogStatusFilter } from '../types';
-import { formatDateTime, getSchemaSummary } from '../utils';
+import {
+  formatDateTime,
+  getDatasetVersionSourceSummary,
+  getSchemaSummary,
+} from '../utils';
 
 interface CatalogDatasetTableProps {
   scopeTitle: string;
@@ -104,19 +112,25 @@ export function CatalogDatasetTable({
     {
       title: '来源',
       width: 210,
-      render: (_, record) => record.currentVersion ? (
-        <div className="min-w-0">
-          <div className="truncate text-[14px] text-[#344054]">
-            {record.sourceTaskName || `TaskAsset #${record.currentVersion.sourceTaskAssetId}`}
+      render: (_, record) => {
+        if (!record.currentVersion) {
+          return <span className="text-[12px] text-[#8a8f99]">尚无当前版本</span>;
+        }
+        const source = getDatasetVersionSourceSummary(
+          record.currentVersion,
+          record.sourceTaskName,
+        );
+        return (
+          <div className="min-w-0">
+            <div className="truncate text-[14px] text-[#344054]">
+              {source.title}
+            </div>
+            <div className="mt-0.5 text-[12px] text-[#8a8f99]">
+              {SOURCE_TYPE_LABELS[record.currentVersion.sourceType]} · {source.detail}
+            </div>
           </div>
-          <div className="mt-0.5 text-[12px] text-[#8a8f99]">
-            {SOURCE_TYPE_LABELS[record.currentVersion.sourceType]} · SQL V
-            {record.currentVersion.sourceTaskRevisionNo}
-          </div>
-        </div>
-      ) : (
-        <span className="text-[12px] text-[#8a8f99]">尚无当前版本</span>
-      ),
+        );
+      },
     },
     {
       title: 'Schema',
@@ -170,51 +184,59 @@ export function CatalogDatasetTable({
       title: '操作',
       fixed: 'right',
       width: 170,
-      render: (_, record) => (
-        <div className="flex items-center gap-1">
-          <Tooltip
-            title={
-              record.status === 'ONLINE'
-                ? '使用当前 Dataset 创建分析'
-                : 'Dataset 上线后才能创建 Analysis'
-            }
-          >
-            <YakButton
-              type="link"
-              size="small"
-              disabled={record.status !== 'ONLINE' || !record.currentVersion}
-              href={
-                record.status === 'ONLINE' && record.currentVersion
-                  ? `/data-analysis/chart-analysis?datasetId=${encodeURIComponent(record.id)}`
-                  : undefined
+      render: (_, record) => {
+        const hasQueryableVersion = Boolean(
+          record.currentVersion
+          && isQueryableDatasetSourceType(record.currentVersion.sourceType),
+        );
+        const canCreateAnalysis = record.status === 'ONLINE' && hasQueryableVersion;
+        const createAnalysisTip = !record.currentVersion
+          ? 'Dataset 尚无当前版本'
+          : !hasQueryableVersion
+            ? `${SOURCE_TYPE_LABELS[record.currentVersion.sourceType]}尚未接入 Dataset Query Runtime`
+            : record.status === 'ONLINE'
+              ? '使用当前 Dataset 创建分析'
+              : 'Dataset 上线后才能创建 Analysis';
+        return (
+          <div className="flex items-center gap-1">
+            <Tooltip title={createAnalysisTip}>
+              <YakButton
+                type="link"
+                size="small"
+                disabled={!canCreateAnalysis}
+                href={
+                  canCreateAnalysis
+                    ? `/data-analysis/chart-analysis?datasetId=${encodeURIComponent(record.id)}`
+                    : undefined
+                }
+                onClick={(event) => event.stopPropagation()}
+              >
+                创建分析
+              </YakButton>
+            </Tooltip>
+            <Popconfirm
+              title={record.status === 'ONLINE' ? '确认下线这个 Dataset？' : '确认上线这个 Dataset？'}
+              description={
+                record.status === 'ONLINE'
+                  ? '下线后现有 Analysis 将无法继续查询。'
+                  : '上线后可继续用于图表分析和仪表盘。'
               }
-              onClick={(event) => event.stopPropagation()}
+              okText="确认"
+              cancelText="取消"
+              onConfirm={() => onToggleStatus(record)}
             >
-              创建分析
-            </YakButton>
-          </Tooltip>
-          <Popconfirm
-            title={record.status === 'ONLINE' ? '确认下线这个 Dataset？' : '确认上线这个 Dataset？'}
-            description={
-              record.status === 'ONLINE'
-                ? '下线后现有 Analysis 将无法继续查询。'
-                : '上线后可继续用于图表分析和仪表盘。'
-            }
-            okText="确认"
-            cancelText="取消"
-            onConfirm={() => onToggleStatus(record)}
-          >
-            <YakButton
-              type="text"
-              size="small"
-              loading={statusUpdatingId === record.id}
-              onClick={(event) => event.stopPropagation()}
-            >
-              {record.status === 'ONLINE' ? '下线' : '上线'}
-            </YakButton>
-          </Popconfirm>
-        </div>
-      ),
+              <YakButton
+                type="text"
+                size="small"
+                loading={statusUpdatingId === record.id}
+                onClick={(event) => event.stopPropagation()}
+              >
+                {record.status === 'ONLINE' ? '下线' : '上线'}
+              </YakButton>
+            </Popconfirm>
+          </div>
+        );
+      },
     },
   ];
 
@@ -253,13 +275,11 @@ export function CatalogDatasetTable({
             <Select
               variant="filled"
               value={sourceType}
-              className="w-[116px]"
+              className="w-[142px]"
               onChange={onSourceTypeChange}
               options={[
                 { label: '全部来源', value: 'ALL' },
-                { label: 'SQL 查询', value: 'QUERY_REVISION' },
-                { label: '数据表', value: 'TABLE' },
-                { label: '视图', value: 'VIEW' },
+                ...QUERYABLE_SOURCE_TYPE_OPTIONS,
               ]}
             />
             <YakButton onClick={onReset}>重置</YakButton>

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/constants.ts
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/constants.ts
@@ -2,6 +2,7 @@ import type {
   CatalogDatasetFieldRole,
   CatalogDatasetSourceType,
 } from '@/services/data-analysis';
+import type { QueryableDatasetSourceType } from '@/services/dataset';
 
 export const DEFAULT_LEFT_WIDTH = 286;
 export const MIN_LEFT_WIDTH = 220;
@@ -11,10 +12,19 @@ export const ROOT_KEY = 'catalog:root';
 export const UNGROUPED_KEY = 'catalog:ungrouped';
 
 export const SOURCE_TYPE_LABELS: Record<CatalogDatasetSourceType, string> = {
-  QUERY_REVISION: 'SQL 查询',
-  TABLE: '数据表',
-  VIEW: '视图',
+  QUERY_REVISION: 'SQL 任务',
+  SQL_QUERY: 'Standalone SQL',
+  TABLE: '数据表（未接入）',
+  VIEW: '视图（未接入）',
 };
+
+export const QUERYABLE_SOURCE_TYPE_OPTIONS: Array<{
+  label: string;
+  value: QueryableDatasetSourceType;
+}> = [
+  { label: 'SQL 任务', value: 'QUERY_REVISION' },
+  { label: 'Standalone SQL', value: 'SQL_QUERY' },
+];
 
 export const FIELD_ROLE_LABELS: Record<CatalogDatasetFieldRole, string> = {
   DIMENSION: '维度',

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/types.ts
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/types.ts
@@ -1,9 +1,10 @@
-import type { CatalogDatasetSourceType, CatalogDatasetStatus } from '@/services/data-analysis';
+import type { CatalogDatasetStatus } from '@/services/data-analysis';
+import type { QueryableDatasetSourceType } from '@/services/dataset';
 import type { DataNode } from 'antd/es/tree';
 
 export type CatalogTreeNodeKind = 'root' | 'directory' | 'dataset' | 'ungrouped';
 export type CatalogStatusFilter = 'ALL' | CatalogDatasetStatus;
-export type CatalogSourceTypeFilter = 'ALL' | CatalogDatasetSourceType;
+export type CatalogSourceTypeFilter = 'ALL' | QueryableDatasetSourceType;
 export type CatalogDetailTab = 'fields' | 'versions' | 'overview' | 'lineage';
 
 export interface CatalogTreeNode extends DataNode {

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/utils.test.ts
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/utils.test.ts
@@ -1,0 +1,34 @@
+import type { CatalogDatasetVersion } from '@/services/data-analysis';
+import { getDatasetVersionSourceSummary } from './utils';
+
+describe('Dataset catalog source summary', () => {
+  it('renders standalone SQL from its datasource snapshot instead of TaskAsset zero values', () => {
+    const version: CatalogDatasetVersion = {
+      id: '20',
+      versionNo: 2,
+      sourceType: 'SQL_QUERY',
+      dataSourceId: 'mysql-prod',
+    };
+
+    expect(getDatasetVersionSourceSummary(version)).toEqual({
+      title: '数据源 mysql-prod',
+      detail: 'Standalone SQL · DV2',
+    });
+  });
+
+  it('keeps immutable TaskRevision wording for QUERY_REVISION datasets', () => {
+    const version: CatalogDatasetVersion = {
+      id: '30',
+      versionNo: 4,
+      sourceType: 'QUERY_REVISION',
+      sourceTaskAssetId: '10',
+      sourceTaskRevisionId: '40',
+      sourceTaskRevisionNo: 7,
+    };
+
+    expect(getDatasetVersionSourceSummary(version, '订单明细')).toEqual({
+      title: '订单明细',
+      detail: 'SQL V7',
+    });
+  });
+});

--- a/yak-ops-ui/src/pages/data-analysis/data-catalog/utils.ts
+++ b/yak-ops-ui/src/pages/data-analysis/data-catalog/utils.ts
@@ -1,5 +1,6 @@
 import type {
   CatalogDataset,
+  CatalogDatasetVersion,
   CatalogDirectory,
 } from '@/services/data-analysis';
 import {
@@ -47,6 +48,40 @@ export const getSchemaSummary = (dataset: CatalogDataset) => {
     (field) => field.defaultRole === 'MEASURE',
   ).length;
   return { fields: dataset.fields.length, dimensions, metrics };
+};
+
+export const getDatasetVersionSourceSummary = (
+  version: CatalogDatasetVersion,
+  sourceTaskName?: string,
+) => {
+  switch (version.sourceType) {
+    case 'QUERY_REVISION':
+      return {
+        title:
+          sourceTaskName
+          || (version.sourceTaskAssetId
+            ? `TaskAsset #${version.sourceTaskAssetId}`
+            : 'SQL TaskAsset'),
+        detail: version.sourceTaskRevisionNo
+          ? `SQL V${version.sourceTaskRevisionNo}`
+          : `Dataset DV${version.versionNo}`,
+      };
+    case 'SQL_QUERY':
+      return {
+        title: version.dataSourceId ? `数据源 ${version.dataSourceId}` : 'Standalone SQL',
+        detail: `Standalone SQL · DV${version.versionNo}`,
+      };
+    case 'TABLE':
+      return {
+        title: '数据表来源',
+        detail: '查询运行时尚未接入',
+      };
+    case 'VIEW':
+      return {
+        title: '视图来源',
+        detail: '查询运行时尚未接入',
+      };
+  }
 };
 
 const getDirectoryAncestors = (

--- a/yak-ops-ui/src/services/data-analysis/catalog.ts
+++ b/yak-ops-ui/src/services/data-analysis/catalog.ts
@@ -8,16 +8,18 @@ import {
   type DevelopmentNode,
   type DevelopmentReleaseSummary,
 } from '@/services/data-development';
+import type {
+  DatasetDetailWire,
+  DatasetFieldWire,
+  DatasetSummaryWire,
+  DatasetVersionWire,
+} from '@/services/dataset';
 import type { ApiResponse } from '@/services/http/response';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 import type {
   CatalogDataset,
   CatalogDatasetField,
-  CatalogDatasetFieldRole,
-  CatalogDatasetFieldType,
-  CatalogDatasetSourceType,
-  CatalogDatasetStatus,
   CatalogDatasetVersion,
   CatalogDirectory,
   CatalogWorkspace,
@@ -25,49 +27,6 @@ import type {
 
 const DATASET_API = '/api/v1/datasets';
 const RELEASE_PAGE_SIZE = 100;
-
-type WireId = string | number;
-
-interface DatasetSummaryWire {
-  id: WireId;
-  name: string;
-  description?: string | null;
-  status: CatalogDatasetStatus;
-  currentVersionId?: WireId | null;
-  createTime?: string;
-  updateTime?: string;
-}
-
-interface DatasetVersionWire {
-  id: WireId;
-  datasetId: WireId;
-  versionNo: number;
-  sourceType: CatalogDatasetSourceType;
-  sourceTaskAssetId: WireId;
-  sourceTaskRevisionId: WireId;
-  sourceTaskRevisionNo: number;
-  schemaSnapshot?: string | null;
-  createTime?: string;
-}
-
-interface DatasetFieldWire {
-  fieldId: string;
-  versionId: WireId;
-  physicalName: string;
-  displayName: string;
-  dataType: CatalogDatasetFieldType;
-  nullable: boolean;
-  description?: string | null;
-  defaultRole: CatalogDatasetFieldRole;
-  sortOrder: number;
-}
-
-interface DatasetDetailWire {
-  dataset: DatasetSummaryWire;
-  currentVersion?: DatasetVersionWire | null;
-  versions?: DatasetVersionWire[];
-  fields?: DatasetFieldWire[];
-}
 
 interface DevelopmentTopology {
   directories: DevelopmentDirectory[];
@@ -82,15 +41,29 @@ const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   return response.data;
 };
 
-const toVersion = (value: DatasetVersionWire): CatalogDatasetVersion => ({
-  id: String(value.id),
-  versionNo: value.versionNo,
-  sourceType: value.sourceType,
-  sourceTaskAssetId: String(value.sourceTaskAssetId),
-  sourceTaskRevisionId: String(value.sourceTaskRevisionId),
-  sourceTaskRevisionNo: value.sourceTaskRevisionNo,
-  createTime: value.createTime,
-});
+const toVersion = (value: DatasetVersionWire): CatalogDatasetVersion => {
+  const taskBacked = value.sourceType === 'QUERY_REVISION';
+  return {
+    id: String(value.id),
+    versionNo: value.versionNo,
+    sourceType: value.sourceType,
+    sourceTaskAssetId:
+      taskBacked && value.sourceTaskAssetId !== '0'
+        ? String(value.sourceTaskAssetId)
+        : undefined,
+    sourceTaskRevisionId:
+      taskBacked && value.sourceTaskRevisionId !== '0'
+        ? String(value.sourceTaskRevisionId)
+        : undefined,
+    sourceTaskRevisionNo:
+      taskBacked && value.sourceTaskRevisionNo > 0
+        ? value.sourceTaskRevisionNo
+        : undefined,
+    dataSourceId: value.dataSourceId?.trim() || undefined,
+    sql: value.sql?.trim() || undefined,
+    createTime: value.createTime,
+  };
+};
 
 const toField = (value: DatasetFieldWire): CatalogDatasetField => ({
   fieldId: value.fieldId,
@@ -170,7 +143,9 @@ const toDataset = (
   topology?: DevelopmentTopology,
 ): CatalogDataset => {
   const currentVersion = detail.currentVersion ? toVersion(detail.currentVersion) : undefined;
-  const assetId = currentVersion?.sourceTaskAssetId;
+  const assetId = currentVersion?.sourceType === 'QUERY_REVISION'
+    ? currentVersion.sourceTaskAssetId
+    : undefined;
   const release = assetId
     ? topology?.releases.find((item) => String(item.assetId) === assetId)
     : undefined;
@@ -181,6 +156,11 @@ const toDataset = (
   const directory = directoryId
     ? topology?.directories.find((item) => String(item.id) === directoryId)
     : undefined;
+  const sourceDisplayName = currentVersion?.sourceType === 'SQL_QUERY'
+    ? currentVersion.dataSourceId
+      ? `Standalone SQL · 数据源 ${currentVersion.dataSourceId}`
+      : 'Standalone SQL'
+    : release?.taskName;
 
   return {
     id: String(detail.dataset.id),
@@ -196,7 +176,7 @@ const toDataset = (
     createTime: detail.dataset.createTime,
     updateTime: detail.dataset.updateTime,
     analysisCount: counts.get(String(detail.dataset.id)) || 0,
-    sourceTaskName: release?.taskName,
+    sourceTaskName: sourceDisplayName,
     sourceNodeId: release ? String(release.nodeId) : undefined,
     directoryId,
     directoryPath: directory?.path,

--- a/yak-ops-ui/src/services/data-analysis/types.ts
+++ b/yak-ops-ui/src/services/data-analysis/types.ts
@@ -1,13 +1,14 @@
-export type CatalogDatasetStatus = 'ONLINE' | 'OFFLINE';
-export type CatalogDatasetSourceType = 'QUERY_REVISION' | 'TABLE' | 'VIEW';
-export type CatalogDatasetFieldRole = 'DIMENSION' | 'MEASURE';
-export type CatalogDatasetFieldType =
-  | 'STRING'
-  | 'NUMBER'
-  | 'DATE'
-  | 'DATETIME'
-  | 'BOOLEAN'
-  | 'UNKNOWN';
+import type {
+  DatasetFieldDataType,
+  DatasetFieldRole,
+  DatasetSourceType,
+  DatasetStatus,
+} from '@/services/dataset';
+
+export type CatalogDatasetStatus = DatasetStatus;
+export type CatalogDatasetSourceType = DatasetSourceType;
+export type CatalogDatasetFieldRole = DatasetFieldRole;
+export type CatalogDatasetFieldType = DatasetFieldDataType;
 
 export interface CatalogDirectory {
   id: string;
@@ -20,9 +21,11 @@ export interface CatalogDatasetVersion {
   id: string;
   versionNo: number;
   sourceType: CatalogDatasetSourceType;
-  sourceTaskAssetId: string;
-  sourceTaskRevisionId: string;
-  sourceTaskRevisionNo: number;
+  sourceTaskAssetId?: string;
+  sourceTaskRevisionId?: string;
+  sourceTaskRevisionNo?: number;
+  dataSourceId?: string;
+  sql?: string;
   createTime?: string;
 }
 
@@ -49,6 +52,7 @@ export interface CatalogDataset {
   createTime?: string;
   updateTime?: string;
   analysisCount: number;
+  /** Current source display label. Historical property name retained for compatibility. */
   sourceTaskName?: string;
   sourceNodeId?: string;
   directoryId?: string;

--- a/yak-ops-ui/src/services/dataset/api.ts
+++ b/yak-ops-ui/src/services/dataset/api.ts
@@ -1,56 +1,20 @@
 import type { ApiResponse } from '@/services/http/response';
 import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
+import { isQueryableDatasetSourceType } from './constants';
 import type {
+  DatasetDetailWire,
   DatasetField,
   DatasetFieldType,
+  DatasetFieldWire,
   DatasetQueryPayload,
   DatasetQueryResult,
+  DatasetSummaryWire,
+  DatasetVersionWire,
   PublishedDataset,
 } from './types';
 
 const DATASET_API = '/api/v1/datasets';
-
-interface DatasetSummaryWire {
-  id: string;
-  name: string;
-  description?: string | null;
-  status: 'ONLINE' | 'OFFLINE';
-  currentVersionId?: string | null;
-  createTime?: string;
-  updateTime?: string;
-}
-
-interface DatasetVersionWire {
-  id: string;
-  datasetId: string;
-  versionNo: number;
-  sourceType: 'QUERY_REVISION' | 'TABLE' | 'VIEW';
-  sourceTaskAssetId: string;
-  sourceTaskRevisionId: string;
-  sourceTaskRevisionNo: number;
-  schemaSnapshot?: string;
-  createTime?: string;
-}
-
-interface DatasetFieldWire {
-  fieldId: string;
-  versionId: string;
-  physicalName: string;
-  displayName: string;
-  dataType: 'STRING' | 'NUMBER' | 'DATE' | 'DATETIME' | 'BOOLEAN' | 'UNKNOWN';
-  nullable: boolean;
-  description?: string | null;
-  defaultRole: 'DIMENSION' | 'MEASURE';
-  sortOrder: number;
-}
-
-interface DatasetDetailWire {
-  dataset: DatasetSummaryWire;
-  currentVersion?: DatasetVersionWire | null;
-  versions: DatasetVersionWire[];
-  fields: DatasetFieldWire[];
-}
 
 export interface DatasetRequestOptions {
   /** Allows callers to cancel stale Dataset requests without changing the backend contract. */
@@ -96,17 +60,40 @@ const toField = (field: DatasetFieldWire): DatasetField => ({
   description: field.description || undefined,
 });
 
+const datasetVersionSource = (version?: DatasetVersionWire | null) => {
+  if (!version) {
+    return { id: '', name: '尚未绑定版本' };
+  }
+  switch (version.sourceType) {
+    case 'QUERY_REVISION':
+      return {
+        id: String(version.sourceTaskAssetId),
+        name: `SQL TaskAsset #${version.sourceTaskAssetId} · V${version.sourceTaskRevisionNo}`,
+      };
+    case 'SQL_QUERY': {
+      const dataSourceId = version.dataSourceId?.trim() || '';
+      return {
+        id: '',
+        name: dataSourceId ? `Standalone SQL · 数据源 ${dataSourceId}` : 'Standalone SQL',
+      };
+    }
+    case 'TABLE':
+      return { id: '', name: '数据表 Dataset（查询运行时尚未接入）' };
+    case 'VIEW':
+      return { id: '', name: '视图 Dataset（查询运行时尚未接入）' };
+  }
+};
+
 const toDataset = (detail: DatasetDetailWire): PublishedDataset => {
   const version = detail.currentVersion;
+  const source = datasetVersionSource(version);
   return {
     id: String(detail.dataset.id),
     name: detail.dataset.name,
     description: detail.dataset.description || '',
     status: detail.dataset.status,
-    sourceTaskId: version ? String(version.sourceTaskAssetId) : '',
-    sourceTaskName: version
-      ? `SQL TaskAsset #${version.sourceTaskAssetId} · V${version.sourceTaskRevisionNo}`
-      : '尚未绑定版本',
+    sourceTaskId: source.id,
+    sourceTaskName: source.name,
     currentVersionNo: version?.versionNo,
     updatedAt: detail.dataset.updateTime || detail.dataset.createTime || '',
     fields: (detail.fields || []).map(toField),
@@ -130,8 +117,11 @@ export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => {
     await HttpUtils.get<DatasetSummaryWire[]>(DATASET_API),
     '查询 Dataset 列表失败',
   );
-  const online = (list || []).filter((dataset) => dataset.status === 'ONLINE' && dataset.currentVersionId);
+  const online = (list || []).filter(
+    (dataset) => dataset.status === 'ONLINE' && dataset.currentVersionId,
+  );
   if (!online.length) return [];
+
   const details = await Promise.allSettled(
     online.map((dataset) => fetchDatasetDetail(
       String(dataset.id),
@@ -139,11 +129,26 @@ export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => {
     )),
   );
   const available = details
-    .filter((item): item is PromiseFulfilledResult<DatasetDetailWire> => item.status === 'fulfilled')
-    .map((item) => toDataset(item.value));
+    .filter(
+      (item): item is PromiseFulfilledResult<DatasetDetailWire> => item.status === 'fulfilled',
+    )
+    .map((item) => item.value)
+    .filter(
+      (detail) => Boolean(
+        detail.currentVersion
+        && isQueryableDatasetSourceType(detail.currentVersion.sourceType),
+      ),
+    )
+    .map(toDataset);
   if (!available.length) {
-    const rejected = details.find((item): item is PromiseRejectedResult => item.status === 'rejected');
-    throw rejected?.reason instanceof Error ? rejected.reason : new Error('读取 Dataset 详情失败');
+    const rejected = details.find(
+      (item): item is PromiseRejectedResult => item.status === 'rejected',
+    );
+    if (rejected) {
+      throw rejected.reason instanceof Error
+        ? rejected.reason
+        : new Error('读取 Dataset 详情失败');
+    }
   }
   return available;
 };
@@ -153,9 +158,18 @@ export const getPublishedDataset = async (
   datasetId: string,
   options?: DatasetRequestOptions,
 ): Promise<PublishedDataset> => {
-  const detail = await fetchDatasetDetail(datasetId, `查询 Dataset ${datasetId} 详情失败`, options);
+  const detail = await fetchDatasetDetail(
+    datasetId,
+    `查询 Dataset ${datasetId} 详情失败`,
+    options,
+  );
   if (detail.dataset.status !== 'ONLINE' || !detail.currentVersion) {
     throw new Error(`Dataset ${datasetId} 当前未发布`);
+  }
+  if (!isQueryableDatasetSourceType(detail.currentVersion.sourceType)) {
+    throw new Error(
+      `Dataset ${datasetId} 来源类型 ${detail.currentVersion.sourceType} 尚未接入查询运行时`,
+    );
   }
   return toDataset(detail);
 };

--- a/yak-ops-ui/src/services/dataset/constants.test.ts
+++ b/yak-ops-ui/src/services/dataset/constants.test.ts
@@ -1,0 +1,27 @@
+import {
+  DATASET_SOURCE_TYPES,
+  isQueryableDatasetSourceType,
+  QUERYABLE_DATASET_SOURCE_TYPES,
+} from './constants';
+
+describe('Dataset source contract', () => {
+  it('keeps persisted source types aligned with the backend contract', () => {
+    expect(DATASET_SOURCE_TYPES).toEqual([
+      'QUERY_REVISION',
+      'SQL_QUERY',
+      'TABLE',
+      'VIEW',
+    ]);
+  });
+
+  it('only exposes source types backed by the current Query Runtime', () => {
+    expect(QUERYABLE_DATASET_SOURCE_TYPES).toEqual([
+      'QUERY_REVISION',
+      'SQL_QUERY',
+    ]);
+    expect(isQueryableDatasetSourceType('QUERY_REVISION')).toBe(true);
+    expect(isQueryableDatasetSourceType('SQL_QUERY')).toBe(true);
+    expect(isQueryableDatasetSourceType('TABLE')).toBe(false);
+    expect(isQueryableDatasetSourceType('VIEW')).toBe(false);
+  });
+});

--- a/yak-ops-ui/src/services/dataset/constants.ts
+++ b/yak-ops-ui/src/services/dataset/constants.ts
@@ -1,0 +1,23 @@
+import type {
+  DatasetSourceType,
+  QueryableDatasetSourceType,
+} from './types';
+
+/** Persisted backend sourceType values; TABLE/VIEW remain reserved contract values. */
+export const DATASET_SOURCE_TYPES = [
+  'QUERY_REVISION',
+  'SQL_QUERY',
+  'TABLE',
+  'VIEW',
+] as const satisfies readonly DatasetSourceType[];
+
+/** Source types with an executable DatasetSourceQueryAdapter today. */
+export const QUERYABLE_DATASET_SOURCE_TYPES = [
+  'QUERY_REVISION',
+  'SQL_QUERY',
+] as const satisfies readonly QueryableDatasetSourceType[];
+
+export const isQueryableDatasetSourceType = (
+  sourceType: DatasetSourceType,
+): sourceType is QueryableDatasetSourceType =>
+  QUERYABLE_DATASET_SOURCE_TYPES.some((value) => value === sourceType);

--- a/yak-ops-ui/src/services/dataset/index.ts
+++ b/yak-ops-ui/src/services/dataset/index.ts
@@ -1,2 +1,3 @@
 export * from './api';
+export * from './constants';
 export type * from './types';

--- a/yak-ops-ui/src/services/dataset/types.ts
+++ b/yak-ops-ui/src/services/dataset/types.ts
@@ -1,3 +1,71 @@
+export type DatasetStatus = 'ONLINE' | 'OFFLINE';
+
+/** Persisted Dataset source types. Keep this union aligned with backend DatasetSourceType. */
+export type DatasetSourceType = 'QUERY_REVISION' | 'SQL_QUERY' | 'TABLE' | 'VIEW';
+
+/** Source types that currently have a Dataset Query Runtime adapter. */
+export type QueryableDatasetSourceType = Extract<
+  DatasetSourceType,
+  'QUERY_REVISION' | 'SQL_QUERY'
+>;
+
+export type DatasetFieldDataType =
+  | 'STRING'
+  | 'NUMBER'
+  | 'DATE'
+  | 'DATETIME'
+  | 'BOOLEAN'
+  | 'UNKNOWN';
+
+export type DatasetFieldRole = 'DIMENSION' | 'MEASURE';
+
+/** HTTP contract for GET /api/v1/datasets. */
+export interface DatasetSummaryWire {
+  id: string;
+  name: string;
+  description?: string | null;
+  status: DatasetStatus;
+  currentVersionId?: string | null;
+  createTime?: string;
+  updateTime?: string;
+}
+
+/** HTTP contract for DatasetVersionVO. */
+export interface DatasetVersionWire {
+  id: string;
+  datasetId: string;
+  versionNo: number;
+  sourceType: DatasetSourceType;
+  sourceTaskAssetId: string;
+  sourceTaskRevisionId: string;
+  sourceTaskRevisionNo: number;
+  dataSourceId?: string | null;
+  sql?: string | null;
+  schemaSnapshot?: string | null;
+  createTime?: string;
+}
+
+/** HTTP contract for DatasetFieldVO. */
+export interface DatasetFieldWire {
+  fieldId: string;
+  versionId: string;
+  physicalName: string;
+  displayName: string;
+  dataType: DatasetFieldDataType;
+  nullable: boolean;
+  description?: string | null;
+  defaultRole: DatasetFieldRole;
+  sortOrder: number;
+}
+
+/** HTTP contract for DatasetDetailVO. */
+export interface DatasetDetailWire {
+  dataset: DatasetSummaryWire;
+  currentVersion?: DatasetVersionWire | null;
+  versions: DatasetVersionWire[];
+  fields: DatasetFieldWire[];
+}
+
 export type {
   Aggregation,
   DatasetField,


### PR DESCRIPTION
## 背景

Dataset 后端当前持久化 `DatasetSourceType` 包含 `QUERY_REVISION / SQL_QUERY / TABLE / VIEW`，但实际 Query Runtime 只接入 `QUERY_REVISION / SQL_QUERY`。前端此前遗漏了已经真实可用的 `SQL_QUERY`，同时又把尚未接入 Runtime 的 `TABLE / VIEW` 暴露成可选产品能力，导致前后端 contract 漂移。

## 本 PR 做什么

- 将 Dataset HTTP Wire contract 统一收口到 `src/services/dataset`：
  - `DatasetSummaryWire`
  - `DatasetVersionWire`
  - `DatasetFieldWire`
  - `DatasetDetailWire`
  - 补齐 `dataSourceId / sql`
- 明确区分：
  - 持久化 sourceType：`QUERY_REVISION / SQL_QUERY / TABLE / VIEW`
  - 当前可查询 sourceType：`QUERY_REVISION / SQL_QUERY`
- Analysis / Dashboard Dataset 消费入口只接受当前有 Query Runtime Adapter 的 sourceType。
- Data Catalog：
  - 增加 `SQL_QUERY` 筛选和展示；
  - standalone SQL 使用 `dataSourceId` 展示来源，不再出现 `TaskAsset #0 / SQL V0`；
  - `TABLE / VIEW` 仍可作为历史/保留 contract 正常展示，但不再作为可用筛选入口；
  - 对未接入 Runtime 的来源禁用“创建分析”，并给出明确提示。
- `data-analysis` 不再重复声明 Dataset Wire DTO，直接消费 Dataset-owned contract。
- 增加前后端 contract 回归测试，保护 persisted sourceType 和当前 Query Runtime capability 集合。

## 明确不做

本 PR 只执行 Dataset Stage 1 契约收口，不包含：

- Data Catalog 服务端分页 / N+1 治理；
- Dataset version history 分页；
- Repository 查询性能优化；
- TABLE / VIEW Publication / Query Runtime 实现；
- SQL dialect / 参数化 compiler；
- Query observability 扩展。

这些留给后续 Stage 2+ 独立处理。

## 验证

新增聚焦回归：

- `yak-ops-ui/src/services/dataset/constants.test.ts`
- `yak-ops-ui/src/pages/data-analysis/data-catalog/utils.test.ts`
- `DatasetSourceTypeContractTest`

分支已同步到创建 PR 前最新 `main`（`e360256a`），且与这期间合入的 data-quality 改动无文件重叠。

由于当前执行环境通过 GitHub connector 直接修改仓库，没有完整本地 checkout / node_modules / Maven 依赖环境，因此未声称本地跑通完整 `npm run lint`、前端 Jest、Maven module test 或浏览器回归；PR 保持 Draft，等待仓库 CI 与本地最小验证。