### PR TITLE
perf(dataset): 收口 Dataset 查询入口与批量元数据读取（PR 1）

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetCatalogEntry.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetCatalogEntry.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.dataset;
+
+import java.util.List;
+
+/** Lightweight consumer catalog projection for one Dataset and its current schema. */
+public record DatasetCatalogEntry(
+    Dataset dataset, DatasetVersion currentVersion, List<DatasetField> fields) {
+
+  public DatasetCatalogEntry {
+    fields = fields == null ? List.of() : List.copyOf(fields);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
@@ -70,6 +70,10 @@ public class DatasetService {
     return reader.catalog(datasetIds);
   }
 
+  public List<DatasetCatalogEntry> catalog(Collection<Long> datasetIds, boolean onlineOnly) {
+    return reader.catalog(datasetIds, onlineOnly);
+  }
+
   public DatasetOverviewSnapshot overview(Instant from, Instant to, int listLimit) {
     return overviewReader.overview(from, to, listLimit);
   }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DatasetService.java
@@ -66,6 +66,10 @@ public class DatasetService {
     return reader.list();
   }
 
+  public List<DatasetCatalogEntry> catalog(Collection<Long> datasetIds) {
+    return reader.catalog(datasetIds);
+  }
+
   public DatasetOverviewSnapshot overview(Instant from, Instant to, int listLimit) {
     return overviewReader.overview(from, to, listLimit);
   }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/DatasetController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/DatasetController.java
@@ -52,8 +52,10 @@ public class DatasetController {
   @Operation(summary = "批量查询 Dataset 当前版本与字段目录")
   @GetMapping("/catalog")
   public Result<List<DatasetCatalogVO>> catalog(
-      @RequestParam(value = "datasetIds", required = false) List<Long> datasetIds) {
-    return Result.success(datasetService.catalog(datasetIds).stream().map(viewConverter::catalog).toList());
+      @RequestParam(value = "datasetIds", required = false) List<Long> datasetIds,
+      @RequestParam(value = "onlineOnly", defaultValue = "false") boolean onlineOnly) {
+    return Result.success(
+        datasetService.catalog(datasetIds, onlineOnly).stream().map(viewConverter::catalog).toList());
   }
 
   @Operation(summary = "查询最近的 Dataset SQL 性能诊断记录")

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/DatasetController.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/DatasetController.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.dataset.controller.v1.converter.DatasetViewConverter;
 import io.yak.ops.business.dataset.controller.v1.dto.DatasetRequests.CreateDatasetVersionRequest;
 import io.yak.ops.business.dataset.controller.v1.dto.DatasetRequests.PublishDatasetRequest;
 import io.yak.ops.business.dataset.controller.v1.dto.DatasetRequests.QueryDatasetRequest;
+import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetCatalogVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetDetailVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetQueryPerformanceVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetQueryResultVO;
@@ -46,6 +47,13 @@ public class DatasetController {
   @GetMapping
   public Result<List<DatasetVO>> list() {
     return Result.success(datasetService.list().stream().map(viewConverter::dataset).toList());
+  }
+
+  @Operation(summary = "批量查询 Dataset 当前版本与字段目录")
+  @GetMapping("/catalog")
+  public Result<List<DatasetCatalogVO>> catalog(
+      @RequestParam(value = "datasetIds", required = false) List<Long> datasetIds) {
+    return Result.success(datasetService.catalog(datasetIds).stream().map(viewConverter::catalog).toList());
   }
 
   @Operation(summary = "查询最近的 Dataset SQL 性能诊断记录")

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/converter/DatasetViewConverter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/converter/DatasetViewConverter.java
@@ -1,11 +1,13 @@
 package io.yak.ops.business.dataset.controller.v1.converter;
 
 import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.DatasetCatalogEntry;
 import io.yak.ops.business.dataset.DatasetDetail;
 import io.yak.ops.business.dataset.DatasetField;
 import io.yak.ops.business.dataset.DatasetQueryPerformance;
 import io.yak.ops.business.dataset.DatasetQueryResult;
 import io.yak.ops.business.dataset.DatasetVersion;
+import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetCatalogVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetDetailVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetFieldVO;
 import io.yak.ops.business.dataset.controller.v1.vo.DatasetViews.DatasetQueryBindingVO;
@@ -39,6 +41,13 @@ public class DatasetViewConverter {
     return new DatasetFieldVO(value.fieldId(), value.versionId(), value.physicalName(),
         value.displayName(), value.dataType().name(), value.nullable(), value.description(),
         value.defaultRole().name(), value.sortOrder());
+  }
+
+  public DatasetCatalogVO catalog(DatasetCatalogEntry value) {
+    return new DatasetCatalogVO(
+        dataset(value.dataset()),
+        version(value.currentVersion()),
+        value.fields().stream().map(this::field).toList());
   }
 
   public DatasetDetailVO detail(DatasetDetail value) {

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/vo/DatasetViews.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/controller/v1/vo/DatasetViews.java
@@ -47,6 +47,10 @@ public final class DatasetViews {
       int sortOrder) {
   }
 
+  public record DatasetCatalogVO(
+      DatasetVO dataset, DatasetVersionVO currentVersion, List<DatasetFieldVO> fields) {
+  }
+
   public record DatasetDetailVO(
       DatasetVO dataset,
       DatasetVersionVO currentVersion,

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/DatasetDao.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/DatasetDao.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.dataset.dao;
 import io.yak.ops.business.dataset.dao.model.DatasetFieldPO;
 import io.yak.ops.business.dataset.dao.model.DatasetPO;
 import io.yak.ops.business.dataset.dao.model.DatasetVersionPO;
+import java.util.Collection;
 import java.util.List;
 
 /** Database access boundary. MyBatis/PO types stay below the Repository adapter. */
@@ -13,6 +14,8 @@ public interface DatasetDao {
   int insertVersion(DatasetVersionPO version);
 
   int insertField(DatasetFieldPO field);
+
+  int insertFields(List<DatasetFieldPO> fields);
 
   int updateCurrentVersion(long datasetId, long versionId);
 
@@ -42,11 +45,19 @@ public interface DatasetDao {
 
   List<DatasetPO> selectDatasets(Long projectId);
 
+  List<DatasetPO> selectDatasetsByIds(Long projectId, Collection<Long> datasetIds);
+
   DatasetVersionPO selectVersion(long versionId);
+
+  DatasetVersionPO selectVersion(long datasetId, int versionNo);
 
   List<DatasetVersionPO> selectVersions(long datasetId);
 
+  List<DatasetVersionPO> selectVersionsByIds(Collection<Long> versionIds);
+
   List<DatasetFieldPO> selectFields(long versionId);
+
+  List<DatasetFieldPO> selectFieldsByVersionIds(Collection<Long> versionIds);
 
   int selectNextVersionNo(long datasetId);
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/impl/DatasetDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/impl/DatasetDaoImpl.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.dataset.dao.model.DatasetVersionPO;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.DependsOn;
@@ -22,6 +23,8 @@ import org.springframework.stereotype.Repository;
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DatasetDaoImpl implements DatasetDao {
+
+  private static final int FIELD_INSERT_BATCH_SIZE = 200;
 
   private final DatasetMapper datasetMapper;
   private final DatasetVersionMapper versionMapper;
@@ -44,6 +47,19 @@ public class DatasetDaoImpl implements DatasetDao {
   @Override
   public int insertField(DatasetFieldPO field) {
     return fieldMapper.insert(field);
+  }
+
+  @Override
+  public int insertFields(List<DatasetFieldPO> fields) {
+    if (fields == null || fields.isEmpty()) {
+      return 0;
+    }
+    int affectedRows = 0;
+    for (int start = 0; start < fields.size(); start += FIELD_INSERT_BATCH_SIZE) {
+      int end = Math.min(start + FIELD_INSERT_BATCH_SIZE, fields.size());
+      affectedRows += fieldMapper.insertBatch(fields.subList(start, end));
+    }
+    return affectedRows;
   }
 
   @Override
@@ -168,8 +184,29 @@ public class DatasetDaoImpl implements DatasetDao {
   }
 
   @Override
+  public List<DatasetPO> selectDatasetsByIds(Long projectId, Collection<Long> datasetIds) {
+    if (datasetIds == null || datasetIds.isEmpty()) {
+      return List.of();
+    }
+    return datasetMapper.selectList(
+        Wrappers.<DatasetPO>lambdaQuery()
+            .eq(projectId != null, DatasetPO::getProjectId, projectId)
+            .in(DatasetPO::getId, datasetIds)
+            .orderByDesc(DatasetPO::getUpdateTime)
+            .orderByDesc(DatasetPO::getId));
+  }
+
+  @Override
   public DatasetVersionPO selectVersion(long versionId) {
     return versionMapper.selectById(versionId);
+  }
+
+  @Override
+  public DatasetVersionPO selectVersion(long datasetId, int versionNo) {
+    return versionMapper.selectOne(
+        Wrappers.<DatasetVersionPO>lambdaQuery()
+            .eq(DatasetVersionPO::getDatasetId, datasetId)
+            .eq(DatasetVersionPO::getVersionNo, versionNo));
   }
 
   @Override
@@ -181,10 +218,33 @@ public class DatasetDaoImpl implements DatasetDao {
   }
 
   @Override
+  public List<DatasetVersionPO> selectVersionsByIds(Collection<Long> versionIds) {
+    if (versionIds == null || versionIds.isEmpty()) {
+      return List.of();
+    }
+    return versionMapper.selectList(
+        Wrappers.<DatasetVersionPO>lambdaQuery()
+            .in(DatasetVersionPO::getId, versionIds));
+  }
+
+  @Override
   public List<DatasetFieldPO> selectFields(long versionId) {
     return fieldMapper.selectList(
         Wrappers.<DatasetFieldPO>lambdaQuery()
             .eq(DatasetFieldPO::getVersionId, versionId)
+            .orderByAsc(DatasetFieldPO::getSortOrder)
+            .orderByAsc(DatasetFieldPO::getPhysicalName));
+  }
+
+  @Override
+  public List<DatasetFieldPO> selectFieldsByVersionIds(Collection<Long> versionIds) {
+    if (versionIds == null || versionIds.isEmpty()) {
+      return List.of();
+    }
+    return fieldMapper.selectList(
+        Wrappers.<DatasetFieldPO>lambdaQuery()
+            .in(DatasetFieldPO::getVersionId, versionIds)
+            .orderByAsc(DatasetFieldPO::getVersionId)
             .orderByAsc(DatasetFieldPO::getSortOrder)
             .orderByAsc(DatasetFieldPO::getPhysicalName));
   }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/mapper/DatasetFieldMapper.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/dao/mapper/DatasetFieldMapper.java
@@ -2,8 +2,23 @@ package io.yak.ops.business.dataset.dao.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import io.yak.ops.business.dataset.dao.model.DatasetFieldPO;
+import java.util.List;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface DatasetFieldMapper extends BaseMapper<DatasetFieldPO> {
+
+  @Insert({
+      "<script>",
+      "INSERT INTO yak_dataset_field ",
+      "(field_id, version_id, physical_name, display_name, data_type, `nullable`, description, default_role, sort_order) VALUES ",
+      "<foreach collection='fields' item='field' separator=','>",
+      "(#{field.fieldId}, #{field.versionId}, #{field.physicalName}, #{field.displayName}, ",
+      "#{field.dataType}, #{field.nullable}, #{field.description}, #{field.defaultRole}, #{field.sortOrder})",
+      "</foreach>",
+      "</script>"
+  })
+  int insertBatch(@Param("fields") List<DatasetFieldPO> fields);
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/definition/DatasetReader.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/definition/DatasetReader.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.dataset.Dataset;
 import io.yak.ops.business.dataset.DatasetCatalogEntry;
 import io.yak.ops.business.dataset.DatasetDetail;
 import io.yak.ops.business.dataset.DatasetField;
+import io.yak.ops.business.dataset.DatasetStatus;
 import io.yak.ops.business.dataset.DatasetVersion;
 import io.yak.ops.business.dataset.repository.DatasetRepository;
 import java.util.Collection;
@@ -36,10 +37,20 @@ public class DatasetReader {
 
   @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
   public List<DatasetCatalogEntry> catalog(Collection<Long> datasetIds) {
+    return catalog(datasetIds, false);
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public List<DatasetCatalogEntry> catalog(Collection<Long> datasetIds, boolean onlineOnly) {
     List<Long> requestedIds = normalizeCatalogDatasetIds(datasetIds);
     List<Dataset> datasets = requestedIds.isEmpty()
         ? repository.listDatasets()
         : repository.listDatasetsByIds(requestedIds);
+    if (onlineOnly) {
+      datasets = datasets.stream()
+          .filter(dataset -> dataset.status() == DatasetStatus.ONLINE)
+          .toList();
+    }
     if (datasets.isEmpty()) {
       return List.of();
     }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/definition/DatasetReader.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/definition/DatasetReader.java
@@ -1,18 +1,27 @@
 package io.yak.ops.business.dataset.definition;
 
 import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.DatasetCatalogEntry;
 import io.yak.ops.business.dataset.DatasetDetail;
 import io.yak.ops.business.dataset.DatasetField;
 import io.yak.ops.business.dataset.DatasetVersion;
 import io.yak.ops.business.dataset.repository.DatasetRepository;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Read-side access to Dataset identity, immutable versions and current schema. */
 @Component
 public class DatasetReader {
+
+  private static final int MAX_CATALOG_DATASET_IDS = 500;
 
   private final DatasetRepository repository;
 
@@ -23,6 +32,41 @@ public class DatasetReader {
   @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
   public List<Dataset> list() {
     return repository.listDatasets();
+  }
+
+  @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
+  public List<DatasetCatalogEntry> catalog(Collection<Long> datasetIds) {
+    List<Long> requestedIds = normalizeCatalogDatasetIds(datasetIds);
+    List<Dataset> datasets = requestedIds.isEmpty()
+        ? repository.listDatasets()
+        : repository.listDatasetsByIds(requestedIds);
+    if (datasets.isEmpty()) {
+      return List.of();
+    }
+
+    List<Long> currentVersionIds = datasets.stream()
+        .map(Dataset::currentVersionId)
+        .filter(value -> value != null)
+        .distinct()
+        .toList();
+    if (currentVersionIds.isEmpty()) {
+      return datasets.stream()
+          .map(dataset -> new DatasetCatalogEntry(dataset, null, List.of()))
+          .toList();
+    }
+
+    Map<Long, DatasetVersion> versionsById = repository.listVersionsByIds(currentVersionIds).stream()
+        .collect(Collectors.toMap(DatasetVersion::id, Function.identity()));
+    Map<Long, List<DatasetField>> fieldsByVersionId =
+        repository.listFieldsByVersionIds(currentVersionIds).stream()
+            .collect(Collectors.groupingBy(
+                DatasetField::versionId,
+                LinkedHashMap::new,
+                Collectors.toList()));
+
+    return datasets.stream()
+        .map(dataset -> catalogEntry(dataset, versionsById, fieldsByVersionId))
+        .toList();
   }
 
   @Transactional(readOnly = true, transactionManager = "yakBusinessTransactionManager")
@@ -67,5 +111,41 @@ public class DatasetReader {
       throw new IllegalArgumentException("developmentNodeId 必须大于 0");
     }
     return repository.findDatasetByDevelopmentNodeId(developmentNodeId).map(value -> require(value.id()));
+  }
+
+  private DatasetCatalogEntry catalogEntry(
+      Dataset dataset,
+      Map<Long, DatasetVersion> versionsById,
+      Map<Long, List<DatasetField>> fieldsByVersionId) {
+    Long versionId = dataset.currentVersionId();
+    if (versionId == null) {
+      return new DatasetCatalogEntry(dataset, null, List.of());
+    }
+    DatasetVersion version = versionsById.get(versionId);
+    if (version == null) {
+      throw new IllegalStateException(
+          "Dataset 当前版本不存在：datasetId=" + dataset.id() + ", versionId=" + versionId);
+    }
+    return new DatasetCatalogEntry(
+        dataset,
+        version,
+        fieldsByVersionId.getOrDefault(versionId, List.of()));
+  }
+
+  private List<Long> normalizeCatalogDatasetIds(Collection<Long> datasetIds) {
+    if (datasetIds == null || datasetIds.isEmpty()) {
+      return List.of();
+    }
+    LinkedHashSet<Long> normalized = new LinkedHashSet<>();
+    for (Long datasetId : datasetIds) {
+      if (datasetId == null || datasetId <= 0L) {
+        throw new IllegalArgumentException("datasetIds 必须全部大于 0");
+      }
+      normalized.add(datasetId);
+      if (normalized.size() > MAX_CATALOG_DATASET_IDS) {
+        throw new IllegalArgumentException("datasetIds 最多支持 500 个");
+      }
+    }
+    return List.copyOf(normalized);
   }
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/query/DatasetQueryCoordinator.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/query/DatasetQueryCoordinator.java
@@ -91,9 +91,8 @@ public class DatasetQueryCoordinator {
     if (versionNo <= 0) {
       throw new IllegalArgumentException("versionNo 必须大于 0");
     }
-    return repository.listVersions(dataset.id()).stream()
-        .filter(version -> version.versionNo() == versionNo)
-        .findFirst()
+    return repository
+        .findVersion(dataset.id(), versionNo)
         .orElseThrow(
             () ->
                 new IllegalArgumentException(

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepository.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepository.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.dataset.DatasetField;
 import io.yak.ops.business.dataset.DatasetStatus;
 import io.yak.ops.business.dataset.DatasetVersion;
 import io.yak.ops.business.dataset.DatasetVersionDraft;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,11 +33,19 @@ public interface DatasetRepository {
 
   List<Dataset> listDatasets();
 
+  List<Dataset> listDatasetsByIds(Collection<Long> datasetIds);
+
   Optional<DatasetVersion> findVersion(long versionId);
+
+  Optional<DatasetVersion> findVersion(long datasetId, int versionNo);
 
   List<DatasetVersion> listVersions(long datasetId);
 
+  List<DatasetVersion> listVersionsByIds(Collection<Long> versionIds);
+
   List<DatasetField> listFields(long versionId);
+
+  List<DatasetField> listFieldsByVersionIds(Collection<Long> versionIds);
 
   int nextVersionNo(long datasetId);
 }

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapter.java
@@ -19,6 +19,8 @@ import io.yak.ops.core.project.ProjectContextError;
 import io.yak.ops.core.project.ProjectContextException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,6 +92,7 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
     }
 
     long versionId = version.getId();
+    List<DatasetFieldPO> rows = new ArrayList<>(draft.fields().size());
     for (int index = 0; index < draft.fields().size(); index++) {
       DatasetFieldDefinition field = draft.fields().get(index);
       DatasetFieldPO po = new DatasetFieldPO();
@@ -102,8 +105,13 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
       po.setDescription(field.description());
       po.setDefaultRole(field.defaultRole().name());
       po.setSortOrder(index + 1);
-      if (datasetDao.insertField(po) != 1) {
-        throw new IllegalStateException("保存 Dataset 字段失败：" + field.fieldId());
+      rows.add(po);
+    }
+    if (!rows.isEmpty()) {
+      int affectedRows = datasetDao.insertFields(rows);
+      if (affectedRows != rows.size()) {
+        throw new IllegalStateException(
+            "保存 Dataset 字段失败：expected=" + rows.size() + ", actual=" + affectedRows);
       }
     }
     return versionId;
@@ -178,8 +186,21 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
   }
 
   @Override
+  public List<Dataset> listDatasetsByIds(Collection<Long> datasetIds) {
+    Long projectId = currentProjectId();
+    return datasetDao.selectDatasetsByIds(projectId, datasetIds).stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
   public Optional<DatasetVersion> findVersion(long versionId) {
     return Optional.ofNullable(datasetDao.selectVersion(versionId)).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<DatasetVersion> findVersion(long datasetId, int versionNo) {
+    return Optional.ofNullable(datasetDao.selectVersion(datasetId, versionNo)).map(this::toDomain);
   }
 
   @Override
@@ -188,8 +209,18 @@ public class DatasetRepositoryAdapter implements DatasetRepository {
   }
 
   @Override
+  public List<DatasetVersion> listVersionsByIds(Collection<Long> versionIds) {
+    return datasetDao.selectVersionsByIds(versionIds).stream().map(this::toDomain).toList();
+  }
+
+  @Override
   public List<DatasetField> listFields(long versionId) {
     return datasetDao.selectFields(versionId).stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public List<DatasetField> listFieldsByVersionIds(Collection<Long> versionIds) {
+    return datasetDao.selectFieldsByVersionIds(versionIds).stream().map(this::toDomain).toList();
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/definition/DatasetReaderTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/definition/DatasetReaderTest.java
@@ -26,16 +26,17 @@ class DatasetReaderTest {
   void catalogLoadsCurrentMetadataWithBulkRepositoryReads() {
     DatasetRepository repository = mock(DatasetRepository.class);
     DatasetReader reader = new DatasetReader(repository);
-    Dataset versioned = dataset(21L, 31L);
-    Dataset empty = dataset(22L, null);
+    Dataset versioned = dataset(21L, 31L, DatasetStatus.ONLINE);
+    Dataset empty = dataset(22L, null, DatasetStatus.ONLINE);
+    Dataset offline = dataset(23L, 32L, DatasetStatus.OFFLINE);
     DatasetVersion version = version(31L, 21L, 2);
     DatasetField field = field("amount", 31L);
 
-    when(repository.listDatasets()).thenReturn(List.of(versioned, empty));
+    when(repository.listDatasets()).thenReturn(List.of(versioned, empty, offline));
     when(repository.listVersionsByIds(List.of(31L))).thenReturn(List.of(version));
     when(repository.listFieldsByVersionIds(List.of(31L))).thenReturn(List.of(field));
 
-    List<DatasetCatalogEntry> result = reader.catalog(null);
+    List<DatasetCatalogEntry> result = reader.catalog(null, true);
 
     assertThat(result).hasSize(2);
     assertThat(result.get(0).dataset()).isEqualTo(versioned);
@@ -54,7 +55,7 @@ class DatasetReaderTest {
   void catalogUsesRequestedIdsWithoutLoadingTheWholeDatasetList() {
     DatasetRepository repository = mock(DatasetRepository.class);
     DatasetReader reader = new DatasetReader(repository);
-    Dataset dataset = dataset(21L, null);
+    Dataset dataset = dataset(21L, null, DatasetStatus.ONLINE);
     when(repository.listDatasetsByIds(List.of(21L, 22L))).thenReturn(List.of(dataset));
 
     List<DatasetCatalogEntry> result = reader.catalog(List.of(21L, 22L, 21L));
@@ -64,12 +65,12 @@ class DatasetReaderTest {
     verify(repository, never()).listDatasets();
   }
 
-  private Dataset dataset(long datasetId, Long currentVersionId) {
+  private Dataset dataset(long datasetId, Long currentVersionId, DatasetStatus status) {
     return new Dataset(
         datasetId,
         "dataset-" + datasetId,
         null,
-        DatasetStatus.ONLINE,
+        status,
         currentVersionId,
         Instant.EPOCH,
         Instant.EPOCH);

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/definition/DatasetReaderTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/definition/DatasetReaderTest.java
@@ -1,0 +1,105 @@
+package io.yak.ops.business.dataset.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataset.Dataset;
+import io.yak.ops.business.dataset.DatasetCatalogEntry;
+import io.yak.ops.business.dataset.DatasetField;
+import io.yak.ops.business.dataset.DatasetFieldDataType;
+import io.yak.ops.business.dataset.DatasetFieldRole;
+import io.yak.ops.business.dataset.DatasetSourceType;
+import io.yak.ops.business.dataset.DatasetStatus;
+import io.yak.ops.business.dataset.DatasetVersion;
+import io.yak.ops.business.dataset.repository.DatasetRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DatasetReaderTest {
+
+  @Test
+  void catalogLoadsCurrentMetadataWithBulkRepositoryReads() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    DatasetReader reader = new DatasetReader(repository);
+    Dataset versioned = dataset(21L, 31L);
+    Dataset empty = dataset(22L, null);
+    DatasetVersion version = version(31L, 21L, 2);
+    DatasetField field = field("amount", 31L);
+
+    when(repository.listDatasets()).thenReturn(List.of(versioned, empty));
+    when(repository.listVersionsByIds(List.of(31L))).thenReturn(List.of(version));
+    when(repository.listFieldsByVersionIds(List.of(31L))).thenReturn(List.of(field));
+
+    List<DatasetCatalogEntry> result = reader.catalog(null);
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).dataset()).isEqualTo(versioned);
+    assertThat(result.get(0).currentVersion()).isEqualTo(version);
+    assertThat(result.get(0).fields()).containsExactly(field);
+    assertThat(result.get(1).dataset()).isEqualTo(empty);
+    assertThat(result.get(1).currentVersion()).isNull();
+    assertThat(result.get(1).fields()).isEmpty();
+    verify(repository).listVersionsByIds(List.of(31L));
+    verify(repository).listFieldsByVersionIds(List.of(31L));
+    verify(repository, never()).findVersion(anyLong());
+    verify(repository, never()).listFields(anyLong());
+  }
+
+  @Test
+  void catalogUsesRequestedIdsWithoutLoadingTheWholeDatasetList() {
+    DatasetRepository repository = mock(DatasetRepository.class);
+    DatasetReader reader = new DatasetReader(repository);
+    Dataset dataset = dataset(21L, null);
+    when(repository.listDatasetsByIds(List.of(21L, 22L))).thenReturn(List.of(dataset));
+
+    List<DatasetCatalogEntry> result = reader.catalog(List.of(21L, 22L, 21L));
+
+    assertThat(result).extracting(entry -> entry.dataset().id()).containsExactly(21L);
+    verify(repository).listDatasetsByIds(List.of(21L, 22L));
+    verify(repository, never()).listDatasets();
+  }
+
+  private Dataset dataset(long datasetId, Long currentVersionId) {
+    return new Dataset(
+        datasetId,
+        "dataset-" + datasetId,
+        null,
+        DatasetStatus.ONLINE,
+        currentVersionId,
+        Instant.EPOCH,
+        Instant.EPOCH);
+  }
+
+  private DatasetVersion version(long versionId, long datasetId, int versionNo) {
+    return new DatasetVersion(
+        versionId,
+        datasetId,
+        versionNo,
+        DatasetSourceType.SQL_QUERY,
+        0L,
+        0L,
+        0,
+        "ds-1",
+        "select 1",
+        "[]",
+        Instant.EPOCH);
+  }
+
+  private DatasetField field(String fieldId, long versionId) {
+    return new DatasetField(
+        fieldId,
+        versionId,
+        fieldId,
+        fieldId,
+        DatasetFieldDataType.NUMBER,
+        true,
+        null,
+        DatasetFieldRole.MEASURE,
+        1);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/query/DatasetQueryCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/query/DatasetQueryCoordinatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -70,11 +71,10 @@ class DatasetQueryCoordinatorTest {
 
     Dataset dataset = dataset(21L, 32L);
     DatasetVersion v1 = version(31L, 21L, 1, DatasetSourceType.QUERY_REVISION);
-    DatasetVersion v2 = version(32L, 21L, 2, DatasetSourceType.SQL_QUERY);
     DatasetQueryRequest request =
         new DatasetQueryRequest(1, List.of(), List.of(), List.of(), List.of(), 10, null);
     when(repository.findDataset(21L)).thenReturn(Optional.of(dataset));
-    when(repository.listVersions(21L)).thenReturn(List.of(v2, v1));
+    when(repository.findVersion(21L, 1)).thenReturn(Optional.of(v1));
     when(repository.listFields(31L)).thenReturn(List.of());
     when(registry.require(DatasetSourceType.QUERY_REVISION)).thenReturn(adapter);
     when(adapter.execute(any(), any(), any(), any()))
@@ -92,6 +92,8 @@ class DatasetQueryCoordinatorTest {
     DatasetQueryResult result = coordinator.query(21L, request);
 
     assertEquals(31L, result.datasetVersionId());
+    verify(repository).findVersion(21L, 1);
+    verify(repository, never()).listVersions(21L);
     verify(registry).require(DatasetSourceType.QUERY_REVISION);
     verify(adapter).execute(dataset, v1, List.of(), request);
   }

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapterBatchTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/repository/DatasetRepositoryAdapterBatchTest.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.dataset.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataset.DatasetFieldDataType;
+import io.yak.ops.business.dataset.DatasetFieldDefinition;
+import io.yak.ops.business.dataset.DatasetFieldRole;
+import io.yak.ops.business.dataset.DatasetVersionDraft;
+import io.yak.ops.business.dataset.dao.DatasetDao;
+import io.yak.ops.business.dataset.dao.model.DatasetFieldPO;
+import io.yak.ops.business.dataset.dao.model.DatasetVersionPO;
+import io.yak.ops.business.dataset.repository.support.DatasetJsonCodec;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DatasetRepositoryAdapterBatchTest {
+
+  @Test
+  void appendVersionWritesFieldContractInOneBatchBoundary() {
+    DatasetDao datasetDao = mock(DatasetDao.class);
+    DatasetJsonCodec jsonCodec = mock(DatasetJsonCodec.class);
+    DatasetRepositoryAdapter repository = new DatasetRepositoryAdapter(datasetDao, jsonCodec);
+    List<DatasetFieldDefinition> fields = List.of(
+        field("order_id", DatasetFieldRole.DIMENSION),
+        field("amount", DatasetFieldRole.MEASURE));
+    DatasetVersionDraft draft =
+        DatasetVersionDraft.sqlQuery(7L, 3, "ds-1", "select 1", fields);
+
+    when(jsonCodec.schemaSnapshot(fields)).thenReturn("[]");
+    when(datasetDao.insertVersion(any(DatasetVersionPO.class)))
+        .thenAnswer(invocation -> {
+          DatasetVersionPO value = invocation.getArgument(0);
+          value.setId(31L);
+          return 1;
+        });
+    when(datasetDao.insertFields(anyList())).thenReturn(2);
+
+    long versionId = repository.appendVersion(draft);
+
+    assertThat(versionId).isEqualTo(31L);
+    ArgumentCaptor<List<DatasetFieldPO>> rows = ArgumentCaptor.forClass(List.class);
+    verify(datasetDao).insertFields(rows.capture());
+    assertThat(rows.getValue()).hasSize(2);
+    assertThat(rows.getValue()).extracting(DatasetFieldPO::getVersionId).containsOnly(31L);
+    assertThat(rows.getValue()).extracting(DatasetFieldPO::getSortOrder).containsExactly(1, 2);
+  }
+
+  private DatasetFieldDefinition field(String name, DatasetFieldRole role) {
+    return new DatasetFieldDefinition(
+        name,
+        name,
+        name,
+        role == DatasetFieldRole.MEASURE
+            ? DatasetFieldDataType.NUMBER
+            : DatasetFieldDataType.STRING,
+        true,
+        null,
+        role);
+  }
+}

--- a/yak-ops-ui/src/services/dataset/api.test.ts
+++ b/yak-ops-ui/src/services/dataset/api.test.ts
@@ -1,5 +1,6 @@
 import HttpUtils from '@/utils/HttpUtils';
 import {
+  getPublishedDataset,
   listPublishedDatasets,
   resolvePublishedDatasetsByIds,
 } from './api';
@@ -49,16 +50,29 @@ describe('Dataset catalog API', () => {
   it('loads the published Dataset catalog with one HTTP request', async () => {
     const get = jest.spyOn(HttpUtils, 'get').mockResolvedValue({
       code: 200,
-      data: [catalogEntry('1'), catalogEntry('2', 'OFFLINE')],
+      data: [catalogEntry('1')],
     } as any);
 
     const result = await listPublishedDatasets();
 
     expect(get).toHaveBeenCalledTimes(1);
-    expect(get.mock.calls[0][0]).toBe('/api/v1/datasets/catalog');
+    expect(get.mock.calls[0][0]).toBe('/api/v1/datasets/catalog?onlineOnly=true');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('1');
     expect(result[0].fields).toHaveLength(1);
+  });
+
+  it('loads one Dataset through the catalog without requesting version history', async () => {
+    const get = jest.spyOn(HttpUtils, 'get').mockResolvedValue({
+      code: 200,
+      data: [catalogEntry('7')],
+    } as any);
+
+    const result = await getPublishedDataset('7');
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0]).toBe('/api/v1/datasets/catalog?datasetIds=7');
+    expect(result.id).toBe('7');
   });
 
   it('resolves requested ids in one batch and preserves per-id availability errors', async () => {

--- a/yak-ops-ui/src/services/dataset/api.test.ts
+++ b/yak-ops-ui/src/services/dataset/api.test.ts
@@ -1,0 +1,83 @@
+import HttpUtils from '@/utils/HttpUtils';
+import {
+  listPublishedDatasets,
+  resolvePublishedDatasetsByIds,
+} from './api';
+import type { DatasetCatalogWire, DatasetSourceType } from './types';
+
+const catalogEntry = (
+  id: string,
+  status: 'ONLINE' | 'OFFLINE' = 'ONLINE',
+  sourceType: DatasetSourceType = 'SQL_QUERY',
+): DatasetCatalogWire => ({
+  dataset: {
+    id,
+    name: `dataset-${id}`,
+    status,
+    currentVersionId: `${id}01`,
+    updateTime: '2026-08-28T00:00:00Z',
+  },
+  currentVersion: {
+    id: `${id}01`,
+    datasetId: id,
+    versionNo: 1,
+    sourceType,
+    sourceTaskAssetId: '0',
+    sourceTaskRevisionId: '0',
+    sourceTaskRevisionNo: 0,
+    dataSourceId: 'ds-1',
+  },
+  fields: [
+    {
+      fieldId: `field-${id}`,
+      versionId: `${id}01`,
+      physicalName: 'amount',
+      displayName: 'amount',
+      dataType: 'NUMBER',
+      nullable: true,
+      defaultRole: 'MEASURE',
+      sortOrder: 1,
+    },
+  ],
+});
+
+describe('Dataset catalog API', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('loads the published Dataset catalog with one HTTP request', async () => {
+    const get = jest.spyOn(HttpUtils, 'get').mockResolvedValue({
+      code: 200,
+      data: [catalogEntry('1'), catalogEntry('2', 'OFFLINE')],
+    } as any);
+
+    const result = await listPublishedDatasets();
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0]).toBe('/api/v1/datasets/catalog');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+    expect(result[0].fields).toHaveLength(1);
+  });
+
+  it('resolves requested ids in one batch and preserves per-id availability errors', async () => {
+    const get = jest.spyOn(HttpUtils, 'get').mockResolvedValue({
+      code: 200,
+      data: [
+        catalogEntry('1'),
+        catalogEntry('2', 'OFFLINE'),
+        catalogEntry('3', 'ONLINE', 'TABLE'),
+      ],
+    } as any);
+
+    const result = await resolvePublishedDatasetsByIds(['1', '2', '3', '4', '1']);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0]).toBe('/api/v1/datasets/catalog?datasetIds=1,2,3,4');
+    expect(result.datasets.map((dataset) => dataset.id)).toEqual(['1']);
+    expect(result.errors['2']).toContain('当前未发布');
+    expect(result.errors['3']).toContain('尚未接入查询运行时');
+    expect(result.errors['4']).toContain('不存在或当前项目不可见');
+  });
+});

--- a/yak-ops-ui/src/services/dataset/api.ts
+++ b/yak-ops-ui/src/services/dataset/api.ts
@@ -4,13 +4,11 @@ import HttpUtils from '@/utils/HttpUtils';
 import { isQueryableDatasetSourceType } from './constants';
 import type {
   DatasetCatalogWire,
-  DatasetDetailWire,
   DatasetField,
   DatasetFieldType,
   DatasetFieldWire,
   DatasetQueryPayload,
   DatasetQueryResult,
-  DatasetSummaryWire,
   DatasetVersionWire,
   PublishedDataset,
 } from './types';
@@ -31,7 +29,7 @@ export interface PublishedDatasetBatchResult {
 }
 
 type DatasetMetadataWire = Pick<
-  DatasetDetailWire,
+  DatasetCatalogWire,
   'dataset' | 'currentVersion' | 'fields'
 >;
 
@@ -107,29 +105,24 @@ const toDataset = (detail: DatasetMetadataWire): PublishedDataset => {
   };
 };
 
-const fetchDatasetDetail = async (
-  datasetId: string,
-  fallback: string,
-  options?: DatasetRequestOptions,
-) => unwrap(
-  await HttpUtils.get<DatasetDetailWire>(
-    `${DATASET_API}/${datasetId}`,
-    requestOptions(options),
-  ),
-  fallback,
-);
-
-const catalogUrl = (datasetIds?: string[]) => {
-  if (!datasetIds?.length) return DATASET_CATALOG_API;
-  return `${DATASET_CATALOG_API}?datasetIds=${datasetIds.map(encodeURIComponent).join(',')}`;
+const catalogUrl = (datasetIds?: string[], onlineOnly = false) => {
+  const params: string[] = [];
+  if (datasetIds?.length) {
+    params.push(`datasetIds=${datasetIds.map(encodeURIComponent).join(',')}`);
+  }
+  if (onlineOnly) {
+    params.push('onlineOnly=true');
+  }
+  return params.length ? `${DATASET_CATALOG_API}?${params.join('&')}` : DATASET_CATALOG_API;
 };
 
 const fetchDatasetCatalog = async (
   datasetIds?: string[],
   options?: DatasetRequestOptions,
+  onlineOnly = false,
 ): Promise<DatasetCatalogWire[]> => unwrap(
   await HttpUtils.get<DatasetCatalogWire[]>(
-    catalogUrl(datasetIds),
+    catalogUrl(datasetIds, onlineOnly),
     requestOptions(options),
   ),
   '查询 Dataset Catalog 失败',
@@ -153,30 +146,23 @@ const catalogEntryError = (datasetId: string, entry?: DatasetCatalogWire) => {
 };
 
 export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => (
-  await fetchDatasetCatalog()
+  await fetchDatasetCatalog(undefined, undefined, true)
 )
   .filter(isPublishedQueryableCatalogEntry)
   .map(toDataset);
 
-/** Fetches one currently published Dataset without first loading the entire Dataset catalog. */
+/** Fetches one currently published Dataset without loading its version history. */
 export const getPublishedDataset = async (
   datasetId: string,
   options?: DatasetRequestOptions,
 ): Promise<PublishedDataset> => {
-  const detail = await fetchDatasetDetail(
-    datasetId,
-    `查询 Dataset ${datasetId} 详情失败`,
-    options,
-  );
-  if (detail.dataset.status !== 'ONLINE' || !detail.currentVersion) {
-    throw new Error(`Dataset ${datasetId} 当前未发布`);
+  const catalog = await fetchDatasetCatalog([datasetId], options);
+  const entry = catalog.find((candidate) => String(candidate.dataset.id) === datasetId);
+  const error = catalogEntryError(datasetId, entry);
+  if (error) {
+    throw new Error(error);
   }
-  if (!isQueryableDatasetSourceType(detail.currentVersion.sourceType)) {
-    throw new Error(
-      `Dataset ${datasetId} 来源类型 ${detail.currentVersion.sourceType} 尚未接入查询运行时`,
-    );
-  }
-  return toDataset(detail);
+  return toDataset(entry!);
 };
 
 /**

--- a/yak-ops-ui/src/services/dataset/api.ts
+++ b/yak-ops-ui/src/services/dataset/api.ts
@@ -3,6 +3,7 @@ import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 import { isQueryableDatasetSourceType } from './constants';
 import type {
+  DatasetCatalogWire,
   DatasetDetailWire,
   DatasetField,
   DatasetFieldType,
@@ -15,6 +16,7 @@ import type {
 } from './types';
 
 const DATASET_API = '/api/v1/datasets';
+const DATASET_CATALOG_API = `${DATASET_API}/catalog`;
 
 export interface DatasetRequestOptions {
   /** Allows callers to cancel stale Dataset requests without changing the backend contract. */
@@ -27,6 +29,11 @@ export interface PublishedDatasetBatchResult {
   datasets: PublishedDataset[];
   errors: Record<string, string>;
 }
+
+type DatasetMetadataWire = Pick<
+  DatasetDetailWire,
+  'dataset' | 'currentVersion' | 'fields'
+>;
 
 const unwrap = <T,>(response: ApiResponse<T>, fallback: string): T => {
   if (response?.code !== API_SUCCESS_CODE || response.data === undefined) {
@@ -84,7 +91,7 @@ const datasetVersionSource = (version?: DatasetVersionWire | null) => {
   }
 };
 
-const toDataset = (detail: DatasetDetailWire): PublishedDataset => {
+const toDataset = (detail: DatasetMetadataWire): PublishedDataset => {
   const version = detail.currentVersion;
   const source = datasetVersionSource(version);
   return {
@@ -112,46 +119,44 @@ const fetchDatasetDetail = async (
   fallback,
 );
 
-export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => {
-  const list = unwrap(
-    await HttpUtils.get<DatasetSummaryWire[]>(DATASET_API),
-    '查询 Dataset 列表失败',
-  );
-  const online = (list || []).filter(
-    (dataset) => dataset.status === 'ONLINE' && dataset.currentVersionId,
-  );
-  if (!online.length) return [];
-
-  const details = await Promise.allSettled(
-    online.map((dataset) => fetchDatasetDetail(
-      String(dataset.id),
-      `查询 Dataset ${dataset.name} 详情失败`,
-    )),
-  );
-  const available = details
-    .filter(
-      (item): item is PromiseFulfilledResult<DatasetDetailWire> => item.status === 'fulfilled',
-    )
-    .map((item) => item.value)
-    .filter(
-      (detail) => Boolean(
-        detail.currentVersion
-        && isQueryableDatasetSourceType(detail.currentVersion.sourceType),
-      ),
-    )
-    .map(toDataset);
-  if (!available.length) {
-    const rejected = details.find(
-      (item): item is PromiseRejectedResult => item.status === 'rejected',
-    );
-    if (rejected) {
-      throw rejected.reason instanceof Error
-        ? rejected.reason
-        : new Error('读取 Dataset 详情失败');
-    }
-  }
-  return available;
+const catalogUrl = (datasetIds?: string[]) => {
+  if (!datasetIds?.length) return DATASET_CATALOG_API;
+  return `${DATASET_CATALOG_API}?datasetIds=${datasetIds.map(encodeURIComponent).join(',')}`;
 };
+
+const fetchDatasetCatalog = async (
+  datasetIds?: string[],
+  options?: DatasetRequestOptions,
+): Promise<DatasetCatalogWire[]> => unwrap(
+  await HttpUtils.get<DatasetCatalogWire[]>(
+    catalogUrl(datasetIds),
+    requestOptions(options),
+  ),
+  '查询 Dataset Catalog 失败',
+) || [];
+
+const isPublishedQueryableCatalogEntry = (entry: DatasetCatalogWire) => Boolean(
+  entry.dataset.status === 'ONLINE'
+  && entry.currentVersion
+  && isQueryableDatasetSourceType(entry.currentVersion.sourceType),
+);
+
+const catalogEntryError = (datasetId: string, entry?: DatasetCatalogWire) => {
+  if (!entry) return `Dataset ${datasetId} 不存在或当前项目不可见`;
+  if (entry.dataset.status !== 'ONLINE' || !entry.currentVersion) {
+    return `Dataset ${datasetId} 当前未发布`;
+  }
+  if (!isQueryableDatasetSourceType(entry.currentVersion.sourceType)) {
+    return `Dataset ${datasetId} 来源类型 ${entry.currentVersion.sourceType} 尚未接入查询运行时`;
+  }
+  return '';
+};
+
+export const listPublishedDatasets = async (): Promise<PublishedDataset[]> => (
+  await fetchDatasetCatalog()
+)
+  .filter(isPublishedQueryableCatalogEntry)
+  .map(toDataset);
 
 /** Fetches one currently published Dataset without first loading the entire Dataset catalog. */
 export const getPublishedDataset = async (
@@ -175,8 +180,8 @@ export const getPublishedDataset = async (
 };
 
 /**
- * Viewer-oriented tolerant lookup: keep healthy Dataset metadata available while surfacing
- * failures for the specific ids that could not be resolved.
+ * Viewer-oriented tolerant lookup: resolve all requested Dataset metadata in one catalog request,
+ * while preserving per-id availability errors for callers that can render partial content.
  */
 export const resolvePublishedDatasetsByIds = async (
   datasetIds: string[],
@@ -185,21 +190,19 @@ export const resolvePublishedDatasetsByIds = async (
   const uniqueIds = [...new Set(datasetIds.filter(Boolean))];
   if (!uniqueIds.length) return { datasets: [], errors: {} };
 
-  const details = await Promise.allSettled(
-    uniqueIds.map((datasetId) => getPublishedDataset(datasetId, options)),
-  );
+  const catalog = await fetchDatasetCatalog(uniqueIds, options);
+  const entries = new Map(catalog.map((entry) => [String(entry.dataset.id), entry]));
   const datasets: PublishedDataset[] = [];
   const errors: Record<string, string> = {};
 
-  details.forEach((result, index) => {
-    const datasetId = uniqueIds[index];
-    if (result.status === 'fulfilled') {
-      datasets.push(result.value);
+  uniqueIds.forEach((datasetId) => {
+    const entry = entries.get(datasetId);
+    const error = catalogEntryError(datasetId, entry);
+    if (error) {
+      errors[datasetId] = error;
       return;
     }
-    errors[datasetId] = result.reason instanceof Error
-      ? result.reason.message
-      : `Dataset ${datasetId} 元数据加载失败`;
+    datasets.push(toDataset(entry!));
   });
 
   return { datasets, errors };

--- a/yak-ops-ui/src/services/dataset/types.ts
+++ b/yak-ops-ui/src/services/dataset/types.ts
@@ -58,6 +58,13 @@ export interface DatasetFieldWire {
   sortOrder: number;
 }
 
+/** HTTP contract for GET /api/v1/datasets/catalog. */
+export interface DatasetCatalogWire {
+  dataset: DatasetSummaryWire;
+  currentVersion?: DatasetVersionWire | null;
+  fields: DatasetFieldWire[];
+}
+
 /** HTTP contract for DatasetDetailVO. */
 export interface DatasetDetailWire {
   dataset: DatasetSummaryWire;


### PR DESCRIPTION
## 背景

Dataset 消费侧当前存在三个明显的规模化问题：

1. 前端 `listPublishedDatasets()` 先查列表，再对每个 ONLINE Dataset 请求详情，形成 `1 + N` HTTP 扇出；
2. 指定历史 `versionNo` 查询会读取该 Dataset 的全部版本后在 JVM 内过滤；
3. 发布 DatasetVersion 时字段 contract 逐字段 INSERT，宽表会产生大量数据库 round-trip。

本 PR 只处理查询入口与持久化性能，不改 Dataset 产品页面，也不包含并发版本发布治理。

## 改动

### 1. 新增 Dataset Catalog 批量读接口

新增：

```text
GET /api/v1/datasets/catalog
GET /api/v1/datasets/catalog?datasetIds=1,2,3
GET /api/v1/datasets/catalog?onlineOnly=true
```

Catalog 只返回消费侧需要的：

- Dataset identity/status；
- current DatasetVersion；
- current version fields。

不返回版本历史。

后端读取路径固定为批量查询：

```text
Dataset list / requested ids
  -> current version ids batch read
  -> current fields batch read
```

Dataset 数量增加时不再按 Dataset 循环执行详情查询。

### 2. 前端移除 Dataset `1 + N`

`src/services/dataset/api.ts`：

- `listPublishedDatasets()` 改为一次 `catalog?onlineOnly=true`；
- `resolvePublishedDatasetsByIds()` 改为一次按 ID Catalog 批量请求；
- `getPublishedDataset()` 也改走单 ID Catalog，不再为了当前元数据读取完整 version history；
- 保留 `AbortSignal` 取消能力；
- 保留 ONLINE / Query Runtime sourceType 校验和按 ID 的可用性错误。

### 3. 历史 DatasetVersion 精确查询

把：

```text
listVersions(datasetId)
 -> stream filter versionNo
```

改为：

```text
findVersion(datasetId, versionNo)
```

直接利用现有 `(dataset_id, version_no)` 唯一键做精确读取，避免版本历史增长后每次把全部版本搬入 JVM。

### 4. DatasetField 批量写入

- Repository 先构造完整 field rows；
- DAO 使用 MyBatis multi-values batch INSERT；
- 每批最多 200 个字段，避免超大 SQL；
- 保持 DatasetVersion + fields 仍位于原调用事务内。

## 测试

新增/调整：

- `DatasetReaderTest`：验证 Catalog 使用 bulk Repository read，并验证 `onlineOnly` 不继续加载 OFFLINE version/fields；
- `DatasetQueryCoordinatorTest`：验证历史版本走 `(datasetId, versionNo)` 精确读取，不再 `listVersions`；
- `DatasetRepositoryAdapterBatchTest`：验证字段 contract 进入 batch DAO boundary；
- `yak-ops-ui/src/services/dataset/api.test.ts`：验证列表、单 Dataset、按 ID 批量解析都只发一次 Catalog HTTP 请求。

## 验证说明

当前执行环境无法拉取仓库依赖并实际运行 Maven/npm，因此未声称本地测试已通过。建议合并前最小补跑：

```bash
./mvnw -pl yak-ops-business/yak-ops-business-dataset -am test

cd yak-ops-ui
npm test -- --runInBand src/services/dataset/api.test.ts src/services/dataset/constants.test.ts
npm run typecheck
```

并建议用 50~100 个 ONLINE Dataset 做一次浏览器 Network 回归，确认 Dataset 目录加载从 `1 + N` 收敛为单个 `/catalog?onlineOnly=true` 请求。

## Scope

本 PR **不包含**：

- DatasetVersion 并发发布 / `MAX(version_no)+1` 竞态治理；
- Query Performance 持久化；
- TABLE / VIEW Query Runtime；
- Dataset 管理产品页面。
