### PR TITLE
refactor(dataset): 收口前端 Dataset 类型与依赖边界（PR 2）

### DIFF
--- a/yak-ops-ui/src/components/analysis/dataset-service.ts
+++ b/yak-ops-ui/src/components/analysis/dataset-service.ts
@@ -1,5 +1,0 @@
-/** @deprecated Import Dataset HTTP operations from `@/services/dataset` instead. */
-export {
-  fetchAnalysisDatasets,
-  queryAnalysisDataset,
-} from '@/services/dataset';

--- a/yak-ops-ui/src/components/analysis/model.ts
+++ b/yak-ops-ui/src/components/analysis/model.ts
@@ -1,28 +1,24 @@
-export type DatasetFieldRole = 'dimension' | 'metric';
-export type DatasetFieldType = 'string' | 'number' | 'date' | 'datetime' | 'boolean' | 'unknown';
-export type Scalar = string | number | boolean | null;
+import type {
+  Aggregation,
+  DatasetFieldRole,
+  Scalar,
+} from '@/services/dataset/model';
 
-export interface DatasetField {
-  key: string;
-  label: string;
-  physicalName: string;
-  dataType: DatasetFieldType;
-  role: DatasetFieldRole;
-  nullable: boolean;
-  description?: string;
-}
-
-export interface PublishedDataset {
-  id: string;
-  name: string;
-  description: string;
-  status: 'ONLINE' | 'OFFLINE';
-  sourceTaskId: string;
-  sourceTaskName: string;
-  currentVersionNo?: number;
-  updatedAt: string;
-  fields: DatasetField[];
-}
+export type {
+  Aggregation,
+  DatasetField,
+  DatasetFieldRole,
+  DatasetFieldType,
+  DatasetQueryColumn,
+  DatasetQueryColumnBinding,
+  DatasetQueryFilter,
+  DatasetQueryMetric,
+  DatasetQueryPayload,
+  DatasetQueryResult,
+  DatasetQuerySort,
+  PublishedDataset,
+  Scalar,
+} from '@/services/dataset/model';
 
 export type BasicChartType = 'metric' | 'bar' | 'line' | 'pie' | 'table';
 export type AdvancedChartType =
@@ -33,7 +29,6 @@ export type AdvancedChartType =
   | 'funnel'
   | 'treemap';
 export type ChartType = BasicChartType | AdvancedChartType;
-export type Aggregation = 'SUM' | 'AVG' | 'COUNT' | 'COUNT_DISTINCT' | 'MAX' | 'MIN';
 export type SortDirection = 'asc' | 'desc';
 export type FilterOperator = 'eq' | 'neq' | 'contains' | 'gt' | 'gte' | 'lt' | 'lte';
 
@@ -95,8 +90,8 @@ export type AnalysisTableDensity = 'compact' | 'comfortable' | 'relaxed';
 
 /**
  * Versioned visual appearance grammar. The original four booleans stay required for
- * backwards source compatibility; Phase 7 properties are optional so old persisted
- * Analysis / Dashboard snapshots continue to deserialize without migration.
+ * backwards source compatibility; optional properties let old persisted Analysis / Dashboard
+ * snapshots continue to deserialize without migration.
  */
 export interface AnalysisVisualConfig {
   version?: 1;
@@ -184,7 +179,7 @@ export interface AnalysisComputationConfig {
   version: 1;
   metrics?: Record<string, AnalysisMetricComputation>;
   topN?: AnalysisTopNConfig;
-  /** Optional Phase 9 chart-local calculated metrics. */
+  /** Optional chart-local calculated metrics. */
   calculatedFields?: AnalysisCalculatedField[];
 }
 
@@ -201,7 +196,7 @@ export interface AnalysisSpec {
   filters: AnalysisFilter[];
   sort?: AnalysisSort;
   style: AnalysisVisualConfig;
-  /** Optional Phase 8+ analysis semantics. Legacy snapshots resolve to raw metric values. */
+  /** Optional analysis semantics. Legacy snapshots resolve to raw metric values. */
   analysis?: AnalysisComputationConfig;
   limit?: number;
   timeoutSeconds?: number;
@@ -221,59 +216,4 @@ export interface AnalysisSelection {
   value: Scalar;
   label: string;
   rowIndex: number;
-}
-
-export interface DatasetQueryMetric {
-  fieldId: string;
-  aggregation: Aggregation;
-}
-
-export interface DatasetQueryFilter {
-  fieldId: string;
-  operator: 'EQ' | 'NE' | 'GT' | 'GTE' | 'LT' | 'LTE' | 'LIKE';
-  value: Scalar;
-}
-
-export interface DatasetQuerySort {
-  fieldId: string;
-  aggregation?: Aggregation;
-  direction: 'ASC' | 'DESC';
-}
-
-export interface DatasetQueryPayload {
-  dimensions: string[];
-  metrics: DatasetQueryMetric[];
-  filters: DatasetQueryFilter[];
-  sorts: DatasetQuerySort[];
-  limit: number;
-  timeoutSeconds: number;
-}
-
-export interface DatasetQueryColumnBinding {
-  key: string;
-  fieldId: string;
-  displayName: string;
-  dataType: string;
-  aggregation?: Aggregation | null;
-}
-
-export interface DatasetQueryColumn {
-  name: string;
-  label: string;
-  typeName: string;
-  jdbcType: number;
-  nullable: boolean;
-}
-
-export interface DatasetQueryResult {
-  queryId?: string;
-  datasetId: string;
-  datasetVersionId: string;
-  datasetVersionNo: number;
-  bindings: DatasetQueryColumnBinding[];
-  columns: DatasetQueryColumn[];
-  rows: Scalar[][];
-  returnedRows: number;
-  truncated: boolean;
-  elapsedMillis: number;
 }

--- a/yak-ops-ui/src/components/analysis/query-runtime.ts
+++ b/yak-ops-ui/src/components/analysis/query-runtime.ts
@@ -1,9 +1,9 @@
-import { queryAnalysisDataset } from './dataset-service';
+import { queryDataset } from '@/services/dataset';
 import type {
   DatasetQueryPayload,
   DatasetQueryResult,
   PublishedDataset,
-} from './model';
+} from '@/services/dataset';
 
 const QUERY_RESULT_TTL_MS = 1_500;
 const MAX_QUERY_ENTRIES = 64;
@@ -65,7 +65,7 @@ const rememberQueryId = (key: string, queryId?: string) => {
 export const queryAnalysisDatasetShared = (
   dataset: Pick<PublishedDataset, 'id' | 'currentVersionNo'>,
   payload: DatasetQueryPayload,
-  loader: AnalysisQueryLoader = queryAnalysisDataset,
+  loader: AnalysisQueryLoader = queryDataset,
 ): Promise<DatasetQueryResult> => {
   const now = Date.now();
   const key = analysisQueryCacheKey(dataset, payload);

--- a/yak-ops-ui/src/services/dataset/api.ts
+++ b/yak-ops-ui/src/services/dataset/api.ts
@@ -3,14 +3,16 @@ import { API_SUCCESS_CODE } from '@/services/http/response';
 import HttpUtils from '@/utils/HttpUtils';
 import { isQueryableDatasetSourceType } from './constants';
 import type {
-  DatasetCatalogWire,
   DatasetField,
   DatasetFieldType,
-  DatasetFieldWire,
   DatasetQueryPayload,
   DatasetQueryResult,
-  DatasetVersionWire,
   PublishedDataset,
+} from './model';
+import type {
+  DatasetCatalogWire,
+  DatasetFieldWire,
+  DatasetVersionWire,
 } from './types';
 
 const DATASET_API = '/api/v1/datasets';

--- a/yak-ops-ui/src/services/dataset/boundary.test.ts
+++ b/yak-ops-ui/src/services/dataset/boundary.test.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const serviceRoot = __dirname;
+const analysisRoot = join(serviceRoot, '..', '..', 'components', 'analysis');
+
+const productionSources = () => readdirSync(serviceRoot, { withFileTypes: true })
+  .filter((entry) => entry.isFile())
+  .map((entry) => entry.name)
+  .filter((name) => /\.(ts|tsx)$/.test(name) && !name.endsWith('.test.ts') && !name.endsWith('.test.tsx'));
+
+describe('Dataset frontend dependency boundary', () => {
+  it('keeps Dataset service code independent from UI component modules', () => {
+    productionSources().forEach((name) => {
+      const source = readFileSync(join(serviceRoot, name), 'utf8');
+      expect(source).not.toMatch(/from\s+['"]@\/components\//);
+      expect(source).not.toContain('@/components/analysis/model');
+    });
+  });
+
+  it('owns Dataset domain and query contracts outside Analysis', () => {
+    const datasetModel = readFileSync(join(serviceRoot, 'model.ts'), 'utf8');
+    const analysisModel = readFileSync(join(analysisRoot, 'model.ts'), 'utf8');
+
+    expect(datasetModel).toContain('export interface PublishedDataset');
+    expect(datasetModel).toContain('export interface DatasetQueryPayload');
+    expect(analysisModel).toContain("from '@/services/dataset/model'");
+    expect(analysisModel).not.toContain('export interface PublishedDataset');
+    expect(analysisModel).not.toContain('export interface DatasetQueryPayload');
+  });
+
+  it('does not keep the deprecated Analysis Dataset service shim', () => {
+    expect(existsSync(join(analysisRoot, 'dataset-service.ts'))).toBe(false);
+  });
+});

--- a/yak-ops-ui/src/services/dataset/index.ts
+++ b/yak-ops-ui/src/services/dataset/index.ts
@@ -1,3 +1,18 @@
 export * from './api';
 export * from './constants';
+export type {
+  Aggregation,
+  DatasetField,
+  DatasetFieldRole as DatasetFieldSemanticRole,
+  DatasetFieldType,
+  DatasetQueryColumn,
+  DatasetQueryColumnBinding,
+  DatasetQueryFilter,
+  DatasetQueryMetric,
+  DatasetQueryPayload,
+  DatasetQueryResult,
+  DatasetQuerySort,
+  PublishedDataset,
+  Scalar,
+} from './model';
 export type * from './types';

--- a/yak-ops-ui/src/services/dataset/model.ts
+++ b/yak-ops-ui/src/services/dataset/model.ts
@@ -1,0 +1,82 @@
+export type DatasetFieldRole = 'dimension' | 'metric';
+export type DatasetFieldType = 'string' | 'number' | 'date' | 'datetime' | 'boolean' | 'unknown';
+export type Scalar = string | number | boolean | null;
+
+export interface DatasetField {
+  key: string;
+  label: string;
+  physicalName: string;
+  dataType: DatasetFieldType;
+  role: DatasetFieldRole;
+  nullable: boolean;
+  description?: string;
+}
+
+export interface PublishedDataset {
+  id: string;
+  name: string;
+  description: string;
+  status: 'ONLINE' | 'OFFLINE';
+  sourceTaskId: string;
+  sourceTaskName: string;
+  currentVersionNo?: number;
+  updatedAt: string;
+  fields: DatasetField[];
+}
+
+export type Aggregation = 'SUM' | 'AVG' | 'COUNT' | 'COUNT_DISTINCT' | 'MAX' | 'MIN';
+
+export interface DatasetQueryMetric {
+  fieldId: string;
+  aggregation: Aggregation;
+}
+
+export interface DatasetQueryFilter {
+  fieldId: string;
+  operator: 'EQ' | 'NE' | 'GT' | 'GTE' | 'LT' | 'LTE' | 'LIKE';
+  value: Scalar;
+}
+
+export interface DatasetQuerySort {
+  fieldId: string;
+  aggregation?: Aggregation;
+  direction: 'ASC' | 'DESC';
+}
+
+export interface DatasetQueryPayload {
+  dimensions: string[];
+  metrics: DatasetQueryMetric[];
+  filters: DatasetQueryFilter[];
+  sorts: DatasetQuerySort[];
+  limit: number;
+  timeoutSeconds: number;
+}
+
+export interface DatasetQueryColumnBinding {
+  key: string;
+  fieldId: string;
+  displayName: string;
+  dataType: string;
+  aggregation?: Aggregation | null;
+}
+
+export interface DatasetQueryColumn {
+  name: string;
+  label: string;
+  typeName: string;
+  jdbcType: number;
+  nullable: boolean;
+}
+
+export interface DatasetQueryResult {
+  queryId?: string;
+  datasetId: string;
+  datasetVersionId: string;
+  datasetVersionNo: number;
+  bindings: DatasetQueryColumnBinding[];
+  columns: DatasetQueryColumn[];
+  rows: Scalar[][];
+  returnedRows: number;
+  truncated: boolean;
+  elapsedMillis: number;
+}

--- a/yak-ops-ui/src/services/dataset/types.ts
+++ b/yak-ops-ui/src/services/dataset/types.ts
@@ -72,13 +72,3 @@ export interface DatasetDetailWire {
   versions: DatasetVersionWire[];
   fields: DatasetFieldWire[];
 }
-
-export type {
-  Aggregation,
-  DatasetField,
-  DatasetFieldType,
-  DatasetQueryPayload,
-  DatasetQueryResult,
-  PublishedDataset,
-  Scalar,
-} from '@/components/analysis/model';


### PR DESCRIPTION
## 背景

Dataset 前端当前存在一条反向依赖：

```text
services/dataset/types.ts
  -> components/analysis/model.ts
```

这意味着 Service 层为了定义自己的返回值和查询契约，需要依赖 UI Component 模块，和 `FRONTEND_CODE_STYLE.md` 中“Service 负责后端通信、业务模块内聚”的方向相反；同时 `analysis/model.ts` 混放 Dataset domain/query contract 与 Analysis visualization contract，后续 Dataset 被 Dashboard、Digital Screen、Data Service 等模块复用时边界会越来越模糊。

本 PR 只做前端 Dataset 依赖边界治理，不新增 Dataset 管理页面，也不调整后端协议。

## 改动

### 1. Dataset Service 正式拥有前端 Domain / Query Model

新增：

```text
src/services/dataset/model.ts
```

统一承载：

- `PublishedDataset`
- `DatasetField`
- `DatasetFieldType`
- Dataset 语义字段角色
- `Aggregation`
- `Scalar`
- `DatasetQueryPayload`
- `DatasetQueryMetric / Filter / Sort`
- `DatasetQueryResult / Column / Binding`

`src/services/dataset/types.ts` 只保留 HTTP Wire contract：

- `DatasetSummaryWire`
- `DatasetVersionWire`
- `DatasetFieldWire`
- `DatasetCatalogWire`
- `DatasetDetailWire`
- 后端枚举/持久化字段类型

从而明确：

```text
HTTP Wire -> Dataset Service mapper -> Dataset frontend domain model
                                      -> Analysis / Dashboard / Digital Screen
```

### 2. 移除 `services/dataset -> components/analysis` 反向依赖

删除原来的：

```ts
export type { ... } from '@/components/analysis/model';
```

`dataset/api.ts` 改为直接依赖 Dataset 自己的 `model.ts` + `types.ts`。

### 3. Analysis 变成 Dataset contract 的消费者

`components/analysis/model.ts`：

- 不再自己声明 `PublishedDataset` / Dataset Query contract；
- 从 `@/services/dataset/model` 引入；
- 暂时保留兼容 type re-export，避免要求已有 Analysis / Dashboard 文件在同一个 PR 内大规模改 import。

依赖方向变为：

```text
services/dataset
      ↑
components/analysis
```

不再出现 Service 依赖 Component。

### 4. Query Runtime 直接依赖 Dataset Service

原来：

```text
query-runtime
 -> analysis/dataset-service (deprecated shim)
 -> services/dataset
```

现在：

```text
query-runtime
 -> services/dataset
```

并删除 `components/analysis/dataset-service.ts` 兼容中转文件。

Dataset Query Runtime 的 1.5s success cache、in-flight dedupe、Dataset version cache key 等行为保持不变。

### 5. 增加前端依赖边界守卫

新增 `src/services/dataset/boundary.test.ts`，用于防止后续重新出现：

```text
services/dataset -> @/components/*
```

同时检查：

- `PublishedDataset` / `DatasetQueryPayload` 由 Dataset model 持有；
- Analysis model 只兼容转出 Dataset contract；
- deprecated `analysis/dataset-service.ts` 不再回归。

## 兼容性

- 后端 API：无变化；
- Dataset Catalog / Query 请求：无变化；
- Dataset Query Runtime 行为：无变化；
- Analysis 已有 `from './model'` 类型引用继续可用，由 compatibility re-export 承接；
- `services/dataset` 原有 Wire types 继续保留。

## 验证说明

当前执行环境没有实际执行仓库 npm 依赖，因此不把静态自检写成“测试已通过”。合并前建议最小补跑：

```bash
cd yak-ops-ui
npm test -- --runInBand \
  src/services/dataset/boundary.test.ts \
  src/services/dataset/api.test.ts \
  src/services/dataset/constants.test.ts \
  src/components/analysis/query-runtime.test.ts
npm run tsc
npm run biome:lint -- src/services/dataset src/components/analysis/model.ts src/components/analysis/query-runtime.ts
```

## Scope

本 PR **不包含**：

- Dataset 管理列表/详情/版本历史 UI；
- TABLE / VIEW Query Runtime；
- Query Performance 生产化；
- DatasetVersion 并发发布治理；
- Analysis Service 自身 HTTP 层迁移（后续可独立治理）。
