### PR TITLE
fix(data-service): 修复限流器多构造器导致的启动失败

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiter.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.dataservice.domain.access.DataServiceApiKey;
 import io.yak.ops.business.dataservice.repository.DataServiceRateLimitRepository;
 import java.time.Clock;
 import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -19,6 +20,7 @@ public class DataServiceRateLimiter {
   private final DataServiceRateLimitRepository repository;
   private final Clock clock;
 
+  @Autowired
   public DataServiceRateLimiter(DataServiceRateLimitRepository repository) {
     this(repository, Clock.systemUTC());
   }

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiterTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceRateLimiterTest.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.dataservice.access;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -12,10 +13,24 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 class DataServiceRateLimiterTest {
 
   private static final Instant NOW = Instant.parse("2026-08-28T04:50:00Z");
+
+  @Test
+  void springCanCreateRateLimiterWithRepositoryConstructor() {
+    DataServiceRateLimitRepository repository = mock(DataServiceRateLimitRepository.class);
+
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+      context.registerBean(DataServiceRateLimitRepository.class, () -> repository);
+      context.register(DataServiceRateLimiter.class);
+      context.refresh();
+
+      assertThat(context.getBean(DataServiceRateLimiter.class)).isNotNull();
+    }
+  }
 
   @Test
   void delegatesAdmissionToSharedRepositoryWindow() {


### PR DESCRIPTION
## 问题

启动 `yak-ops-boot` 时，Spring 创建 `DataServiceRateLimiter` Bean 失败：

- `DataServiceRateLimiter` 同时存在生产构造器 `DataServiceRateLimiter(DataServiceRateLimitRepository)` 与测试用构造器 `DataServiceRateLimiter(DataServiceRateLimitRepository, Clock)`；
- 多构造器场景下未显式标记注入构造器，Spring 无法确定应使用哪个构造器，最终回退尝试无参构造；
- 类没有无参构造器，因此抛出 `NoSuchMethodException: DataServiceRateLimiter.<init>()`，进而导致 `DataServiceApiKeyManager` 依赖注入失败，ApplicationContext 启动中止。

## 修复

- 在生产构造器上显式添加 `@Autowired`，保留 `Clock` 构造器作为包内测试注入点；
- 新增最小 Spring ApplicationContext 回归测试，直接验证 `DataServiceRateLimiter` 能通过 Spring 完成构造注入；
- 不改限流算法、Repository 协议和 API Key 业务逻辑。

## 影响范围

仅 `yak-ops-business-data-service` 模块，属于启动回归修复，改动 2 个文件。

## 验证建议

- `mvn -pl yak-ops-business/yak-ops-business-data-service -am test`
- 启动 `yak-ops-boot`，确认 `DataServiceRateLimiter` / `DataServiceApiKeyManager` Bean 正常创建

> 当前通过 GitHub 连接器完成代码修复与回归测试补充，未在本地完整环境执行 Maven 与真实数据库启动回归，因此保持 Draft。