### PR TITLE
fix(ui): 修复 Dashboard Dataset service 启动引用

### DIFF
--- a/yak-ops-ui/src/pages/dashboard/service.ts
+++ b/yak-ops-ui/src/pages/dashboard/service.ts
@@ -1,4 +1,4 @@
 export {
   fetchAnalysisDatasets as fetchDashboardDatasets,
   queryAnalysisDataset as queryDashboardDataset,
-} from '@/components/analysis/dataset-service';
+} from '@/services/dataset';


### PR DESCRIPTION
## 问题

`yarn start` 在 Umi / Mako prepare 阶段失败：

```text
Can't resolve '@/components/analysis/dataset-service'
```

`yak-ops-ui/src/pages/dashboard/service.ts` 仍然引用了已删除的 Analysis 兼容层 `@/components/analysis/dataset-service`。

PR #860 已将 Dataset HTTP 操作收口到 `@/services/dataset`，并删除了该 deprecated shim；Dashboard 的这处 re-export 未同步迁移，因此留下了悬空 import。

## 修复

- Dashboard 继续保留 `fetchDashboardDatasets` / `queryDashboardDataset` 对外别名，避免影响现有调用方。
- 将底层 re-export 来源改为正式的 `@/services/dataset`。
- 不恢复已删除的兼容层，保持 Dataset domain service 的收口方向。

## 变更范围

仅修改：

- `yak-ops-ui/src/pages/dashboard/service.ts`

## 校验

- `@/services/dataset/index.ts` 通过 `export * from './api'` 暴露 Dataset API。
- `api.ts` 当前仍导出兼容别名 `fetchAnalysisDatasets` 与 `queryAnalysisDataset`。
- PR #860 删除的旧 shim 本身也明确标注应改从 `@/services/dataset` 导入。
- 当前分支相对创建时的 `main` 仅 1 个 commit，1 个文件，1 行增 / 1 行删。

> 本次通过仓库代码与提交差异完成静态校验；未在连接环境中执行本地 `yarn start` / 浏览器回归。