### PR TITLE
fix(boot): 修复默认空间初始化缺少部门导致的启动退出

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
@@ -1,9 +1,11 @@
 package io.yak.ops.boot.project;
 
+import io.yak.framework.security.common.dto.dept.DeptSaveDTO;
 import io.yak.framework.security.common.dto.project.ProjectSaveDTO;
 import io.yak.framework.security.common.vo.project.ProjectBriefVO;
 import io.yak.framework.security.common.vo.project.ProjectVO;
 import io.yak.framework.security.common.vo.user.UserBriefVO;
+import io.yak.framework.security.service.DeptService;
 import io.yak.framework.security.service.ProjectService;
 import io.yak.framework.security.service.UserService;
 import java.util.Collections;
@@ -28,18 +30,22 @@ public class ProjectCompatibilityCoordinator {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ProjectCompatibilityCoordinator.class);
+  private static final long ROOT_DEPARTMENT_ID = 0L;
 
   private final ProjectSpaceProperties properties;
   private final ProjectService projectService;
   private final UserService userService;
+  private final DeptService deptService;
 
   public ProjectCompatibilityCoordinator(
       ProjectSpaceProperties properties,
       ProjectService projectService,
-      UserService userService) {
+      UserService userService,
+      DeptService deptService) {
     this.properties = properties;
     this.projectService = projectService;
     this.userService = userService;
+    this.deptService = deptService;
   }
 
   /**
@@ -109,6 +115,7 @@ public class ProjectCompatibilityCoordinator {
     input.setProjectName(normalizedProjectName());
     input.setDescription("Yak Ops Project Space compatibility default project");
     input.setRunning(Boolean.TRUE);
+    input.setDeptId(resolveCompatibilityDepartmentId(owner));
     input.setOwnerIdList(Collections.singletonList(owner.getId()));
     input.setUserIdList(userIds);
 
@@ -125,10 +132,61 @@ public class ProjectCompatibilityCoordinator {
     }
   }
 
+  private long resolveCompatibilityDepartmentId(UserBriefVO owner) {
+    Long ownerDepartmentId = owner.getDeptId();
+    if (ownerDepartmentId != null && ownerDepartmentId > 0) {
+      return ownerDepartmentId;
+    }
+
+    String departmentName = normalizedDepartmentName();
+    OptionalLong existing = findRootDepartmentId(departmentName);
+    if (existing.isPresent()) {
+      return existing.getAsLong();
+    }
+
+    DeptSaveDTO input = new DeptSaveDTO();
+    input.setDeptName(departmentName);
+    input.setDescription("Yak Ops Project Space compatibility default department");
+    input.setParentId(ROOT_DEPARTMENT_ID);
+
+    try {
+      deptService.createDept(input);
+    } catch (RuntimeException exception) {
+      // Multi-instance startup can race on department creation as well.
+      OptionalLong concurrent = findRootDepartmentId(departmentName);
+      if (concurrent.isPresent()) {
+        return concurrent.getAsLong();
+      }
+      throw exception;
+    }
+
+    return findRootDepartmentId(departmentName)
+        .orElseThrow(
+            () -> new IllegalStateException(
+                "Compatibility department was created but cannot be resolved: " + departmentName));
+  }
+
+  private OptionalLong findRootDepartmentId(String departmentName) {
+    List<Long> ids =
+        deptService.getDeptIdListByParentIdAndDeptName(ROOT_DEPARTMENT_ID, departmentName);
+    return (ids == null ? Collections.<Long>emptyList() : ids).stream()
+        .filter(id -> id != null && id > 0)
+        .mapToLong(Long::longValue)
+        .findFirst();
+  }
+
   private String normalizedProjectName() {
     String name = properties.getCompatibility().getDefaultProjectName();
     if (!StringUtils.hasText(name)) {
       throw new IllegalStateException("Default Project Space name must not be blank");
+    }
+    return name.trim();
+  }
+
+  private String normalizedDepartmentName() {
+    String name = properties.getCompatibility().getDefaultDepartmentName();
+    if (!StringUtils.hasText(name)) {
+      throw new IllegalStateException("Default compatibility department name must not be blank");
     }
     return name.trim();
   }

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectSpaceProperties.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectSpaceProperties.java
@@ -19,6 +19,7 @@ public class ProjectSpaceProperties {
     private boolean bootstrapDefaultProject;
     private String defaultProjectName = "默认空间";
     private String defaultOwnerUsername = "root";
+    private String defaultDepartmentName = "默认部门";
 
     public boolean isBootstrapDefaultProject() {
       return bootstrapDefaultProject;
@@ -42,6 +43,14 @@ public class ProjectSpaceProperties {
 
     public void setDefaultOwnerUsername(String defaultOwnerUsername) {
       this.defaultOwnerUsername = defaultOwnerUsername;
+    }
+
+    public String getDefaultDepartmentName() {
+      return defaultDepartmentName;
+    }
+
+    public void setDefaultDepartmentName(String defaultDepartmentName) {
+      this.defaultDepartmentName = defaultDepartmentName;
     }
   }
 }

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinatorTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinatorTest.java
@@ -1,0 +1,62 @@
+package io.yak.ops.boot.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.security.common.dto.dept.DeptSaveDTO;
+import io.yak.framework.security.common.dto.project.ProjectSaveDTO;
+import io.yak.framework.security.common.vo.project.ProjectVO;
+import io.yak.framework.security.common.vo.user.UserBriefVO;
+import io.yak.framework.security.service.DeptService;
+import io.yak.framework.security.service.ProjectService;
+import io.yak.framework.security.service.UserService;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProjectCompatibilityCoordinatorTest {
+
+  @Test
+  void createsRootDepartmentBeforeFreshCompatibilityProject() {
+    ProjectSpaceProperties properties = new ProjectSpaceProperties();
+    ProjectService projectService = mock(ProjectService.class);
+    UserService userService = mock(UserService.class);
+    DeptService deptService = mock(DeptService.class);
+
+    UserBriefVO owner = new UserBriefVO();
+    owner.setId(1L);
+    owner.setUserName("root");
+    owner.setDeptId(null);
+
+    when(projectService.getProjectBriefList()).thenReturn(Collections.emptyList());
+    when(userService.getUserBriefByUsername("root")).thenReturn(owner);
+    when(userService.getAllUserBriefList()).thenReturn(List.of(owner));
+    when(deptService.getDeptIdListByParentIdAndDeptName(0L, "默认部门"))
+        .thenReturn(Collections.emptyList(), List.of(7L));
+
+    ProjectVO created = mock(ProjectVO.class);
+    when(created.getId()).thenReturn(11L);
+    when(projectService.createProject(any(ProjectSaveDTO.class), eq("root"))).thenReturn(created);
+
+    ProjectCompatibilityCoordinator coordinator =
+        new ProjectCompatibilityCoordinator(properties, projectService, userService, deptService);
+
+    assertThat(coordinator.ensureRequiredDefaultProject()).isEqualTo(11L);
+
+    ArgumentCaptor<DeptSaveDTO> departmentCaptor = ArgumentCaptor.forClass(DeptSaveDTO.class);
+    verify(deptService).createDept(departmentCaptor.capture());
+    assertThat(departmentCaptor.getValue().getDeptName()).isEqualTo("默认部门");
+    assertThat(departmentCaptor.getValue().getParentId()).isZero();
+
+    ArgumentCaptor<ProjectSaveDTO> projectCaptor = ArgumentCaptor.forClass(ProjectSaveDTO.class);
+    verify(projectService).createProject(projectCaptor.capture(), eq("root"));
+    assertThat(projectCaptor.getValue().getProjectName()).isEqualTo("默认空间");
+    assertThat(projectCaptor.getValue().getDeptId()).isEqualTo(7L);
+    assertThat(projectCaptor.getValue().getOwnerIdList()).containsExactly(1L);
+  }
+}


### PR DESCRIPTION
## 问题

在前一个 `DataServiceRateLimiter` 启动修复合并后，Spring Boot 已能正常完成容器启动，但 `ApplicationReadyEvent` 阶段的数据开发 Project 兼容回填仍会触发退出：

- `DataDevelopmentProjectCompatibilityBackfill` 强制调用 `ProjectCompatibilityCoordinator.ensureRequiredDefaultProject()`；
- fresh install 下 bootstrap 用户 `root` 没有关联部门；
- `ProjectCompatibilityCoordinator` 创建 `ProjectSaveDTO` 时没有设置 `deptId`；
- yak-security 的 `yak_security_project.dept_id` 是必填字段，因此最终 SQL 因 `Field 'dept_id' doesn't have a default value` 失败。

## 修复

- 为 Project Space 兼容配置增加 `defaultDepartmentName`，默认值为 `默认部门`；
- 创建兼容默认空间时：
  - owner 已有关联部门则直接复用；
  - owner 无部门时，优先复用根级同名兼容部门；
  - 不存在则通过 `DeptService` 创建根级兼容部门并重新解析真实 ID；
- 将解析出的真实 `deptId` 写入 `ProjectSaveDTO` 后再创建默认空间；
- 对部门创建保留多实例启动竞争下的二次读取兜底，不使用 `dept_id=0`，也不放宽数据库 NOT NULL 约束。

## 回归测试

新增 `ProjectCompatibilityCoordinatorTest`，覆盖 fresh install 的关键路径：

- 默认空间不存在；
- `root.deptId == null`；
- 默认部门不存在；
- 先创建根级默认部门，再使用解析到的部门 ID 创建默认空间。

## 验证建议

```bash
mvn -pl yak-ops-boot -am test
```

随后使用 fresh `yak_security` 库启动 `YakOpsApplication`，确认：

1. bootstrap root 创建成功；
2. 根级 `默认部门` 创建/复用成功；
3. `默认空间.dept_id` 为真实部门 ID；
4. `DataDevelopmentProjectCompatibilityBackfill` 执行完成后进程保持运行。

> 前一个 PR #863 已在本次处理过程中合并，因此本修复单独创建 Draft PR。当前通过仓库代码与用户启动日志完成定位和回归测试补充，未在本地真实 MySQL 环境执行完整 Maven/启动回归。