### PR TITLE
fix(boot): 避免默认空间负责人重复绑定为普通成员

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinator.java
@@ -104,10 +104,12 @@ public class ProjectCompatibilityCoordinator {
               + ". Configure yak.project-space.compatibility.default-owner-username if needed.");
     }
 
+    Long ownerId = owner.getId();
     List<UserBriefVO> users = userService.getAllUserBriefList();
     List<Long> userIds = (users == null ? Collections.<UserBriefVO>emptyList() : users).stream()
         .map(UserBriefVO::getId)
         .filter(id -> id != null && id > 0)
+        .filter(id -> !ownerId.equals(id))
         .distinct()
         .toList();
 
@@ -116,7 +118,7 @@ public class ProjectCompatibilityCoordinator {
     input.setDescription("Yak Ops Project Space compatibility default project");
     input.setRunning(Boolean.TRUE);
     input.setDeptId(resolveCompatibilityDepartmentId(owner));
-    input.setOwnerIdList(Collections.singletonList(owner.getId()));
+    input.setOwnerIdList(Collections.singletonList(ownerId));
     input.setUserIdList(userIds);
 
     try {

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinatorTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectCompatibilityCoordinatorTest.java
@@ -22,7 +22,7 @@ import org.mockito.ArgumentCaptor;
 class ProjectCompatibilityCoordinatorTest {
 
   @Test
-  void createsRootDepartmentBeforeFreshCompatibilityProject() {
+  void createsRootDepartmentAndKeepsOwnerOutOfNormalMembers() {
     ProjectSpaceProperties properties = new ProjectSpaceProperties();
     ProjectService projectService = mock(ProjectService.class);
     UserService userService = mock(UserService.class);
@@ -33,9 +33,13 @@ class ProjectCompatibilityCoordinatorTest {
     owner.setUserName("root");
     owner.setDeptId(null);
 
+    UserBriefVO member = new UserBriefVO();
+    member.setId(2L);
+    member.setUserName("member");
+
     when(projectService.getProjectBriefList()).thenReturn(Collections.emptyList());
     when(userService.getUserBriefByUsername("root")).thenReturn(owner);
-    when(userService.getAllUserBriefList()).thenReturn(List.of(owner));
+    when(userService.getAllUserBriefList()).thenReturn(List.of(owner, member, owner));
     when(deptService.getDeptIdListByParentIdAndDeptName(0L, "默认部门"))
         .thenReturn(Collections.emptyList(), List.of(7L));
 
@@ -58,5 +62,6 @@ class ProjectCompatibilityCoordinatorTest {
     assertThat(projectCaptor.getValue().getProjectName()).isEqualTo("默认空间");
     assertThat(projectCaptor.getValue().getDeptId()).isEqualTo(7L);
     assertThat(projectCaptor.getValue().getOwnerIdList()).containsExactly(1L);
+    assertThat(projectCaptor.getValue().getUserIdList()).containsExactly(2L);
   }
 }


### PR DESCRIPTION
## 问题

fresh install 启动时，前序默认部门 / 默认空间初始化已经成功，但 `ApplicationReadyEvent` 阶段仍会因为用户项目关系重复插入而退出：

- 兼容默认空间 owner 为 `root`；
- `ProjectCompatibilityCoordinator` 同时把 `root` 放入 `ownerIdList` 和 `userIdList`；
- `ProjectServiceImpl.createProject()` 先保存负责人关系，再保存普通成员关系；
- `yak_security_user_project.uk_user_project_active` 对同一 `app_name + user_id + project_id` 只允许一条有效关系，因此第二次写入触发 `DuplicateKeyException`。

## 修复

- 解析兼容默认空间成员列表时，显式排除 owner ID；
- owner 只进入 `ownerIdList`；
- 其他普通用户仍保留在 `userIdList`；
- 不修改 `yak_security_user_project` 唯一约束，也不改变 yak-security 通用 Project API。

## 回归测试

更新 `ProjectCompatibilityCoordinatorTest`：

- root(owner) 无部门；
- 创建/复用根级默认部门；
- 用户列表同时包含 owner、普通 member，并故意重复出现 owner；
- 验证最终 `ownerIdList == [1]`；
- 验证最终 `userIdList == [2]`，owner 不会再次作为普通成员提交。

## 验证建议

```bash
mvn -pl yak-ops-boot -am test
```

随后使用 fresh `yak_security` 库启动 `YakOpsApplication`，确认：

1. 默认部门创建/复用成功；
2. 默认空间创建成功；
3. root 只产生一条默认空间关系；
4. `DataDevelopmentProjectCompatibilityBackfill` 执行完成；
5. ApplicationReadyEvent 后进程保持运行。

> 当前通过用户 fresh-install 启动日志完成定位，并补充了针对性回归测试；未在本地真实 MySQL 环境执行完整 Maven/启动回归，因此保持 Draft。