### PR TITLE
fix(home): 修复登录后首页缺失项目空间上下文

### DIFF
--- a/yak-ops-ui/src/contexts/SecurityProjectContext.tsx
+++ b/yak-ops-ui/src/contexts/SecurityProjectContext.tsx
@@ -1,6 +1,6 @@
 import { useModel } from '@umijs/max';
 import type { ReactNode } from 'react';
-import { createContext, useContext, useEffect, useMemo } from 'react';
+import { createContext, useContext, useEffect, useLayoutEffect, useMemo } from 'react';
 import { getCurrentUser } from '@/services/security/account';
 import { toCurrentUser } from '@/services/security/currentIdentity';
 import {
@@ -56,7 +56,8 @@ export function SecurityProjectProvider({ children }: { children: ReactNode }) {
     }));
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    // Persist the selected project before descendant passive effects issue project-scoped requests.
     const selected = chooseSecurityProject(projects, readStoredProjectId());
     if (selected) {
       if (selected.id !== currentProject?.id) selectProject(selected);

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -20,6 +20,8 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/data-source')).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/resources/tree')).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/datasets/1')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/home/cockpit')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/home/data-center/overview?period=7d')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-development/nodes')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-service')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-service/7')).toBe('PROJECT_REQUIRED');
@@ -57,6 +59,9 @@ describe('Project Space request context', () => {
     storeProjectId(7);
     expect(readStoredProjectId()).toBe('7');
 
+    expect(applyCurrentProjectHeader('/api/v1/home/cockpit', {})).toEqual({
+      [PROJECT_ID_HEADER]: '7',
+    });
     expect(applyCurrentProjectHeader('/api/v1/data-development/nodes', {})).toEqual({
       [PROJECT_ID_HEADER]: '7',
     });

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -16,6 +16,7 @@ export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
   { prefix: '/api/v1/data-source', mode: 'PROJECT_OPTIONAL' },
   { prefix: '/api/v1/resources', mode: 'PROJECT_OPTIONAL' },
   { prefix: '/api/v1/datasets', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/home', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/data-development', mode: 'PROJECT_REQUIRED' },
   // Data Service management is project-scoped, but the external runtime URL is intentionally
   // global and protected by the published NONE/API_KEY contract rather than Yak console headers.


### PR DESCRIPTION
## 问题

root 用户登录进入首页后，可能出现：

`PROJECT_REQUIRED: 当前操作需要选择项目空间`

原因有两层：

- `/api/v1/home/**` 未纳入前端 Project Space 请求规则，默认会按 `LEGACY_GLOBAL` 处理，因此不会自动携带 `X-YAK-SECURITY-PROJECT-ID`。
- 默认项目原本在 `SecurityProjectProvider` 的 passive effect 中初始化，而首页各数据组件也会在 passive effect 中立即发起请求，首次登录/本地无项目缓存时存在首屏请求与项目初始化的竞态。

## 修复

- 将 `/api/v1/home` 标记为 `PROJECT_REQUIRED`，覆盖 cockpit、data-center、assets、quality、schedule-center 等首页聚合接口。
- 将默认项目同步从 `useEffect` 调整为 `useLayoutEffect`，确保在子组件 passive effect 发起项目级请求前，当前 Project ID 已写入本地项目上下文。
- 增加 `projectContext` 回归测试，覆盖首页路由模式与 `X-YAK-SECURITY-PROJECT-ID` Header 注入。

## 设计说明

本次没有对 root 用户做特殊放行，也没有降低后端 `PROJECT_REQUIRED` 的隔离要求。root 的系统权限和 Project Space 数据上下文仍保持独立，修复点只收口在前端项目上下文初始化与请求注入。

## 影响范围

仅修改前端 3 个文件，不调整后端接口、权限模型或数据库。

## 建议验证

```bash
cd yak-ops-ui
npm test -- src/utils/security/projectContext.test.ts
npm run tsc
```

浏览器回归：

- root 清空 `yak-security.current-project-id` 后重新登录，进入首页不再出现 `PROJECT_REQUIRED`。
- 首页 `/api/v1/home/**` 请求携带当前 `X-YAK-SECURITY-PROJECT-ID`。
- 切换项目空间后，首页继续使用新的 Project ID 请求数据。

> 当前通过 GitHub Connector 完成代码修改，未在本地浏览器环境执行上述命令，因此保持 Draft。