### PR TITLE
feat(project-space): 完成 Stage 1 工作空间 UI 闭环

### DIFF
--- a/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
+++ b/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
@@ -1,13 +1,27 @@
-import { productFeatures } from "@/config/productFeatures";
-import { useSecurityProject } from "@/contexts/SecurityProjectContext";
-import { getLocale, setLocale } from "@umijs/max";
-import { Dropdown } from "antd";
-import { ChevronDown, Languages } from "lucide-react";
+import { productFeatures } from '@/config/productFeatures';
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
+import { hasPermission } from '@/utils/security/permission';
+import {
+  getLocale,
+  history,
+  setLocale,
+  useModel,
+} from '@umijs/max';
+import { Dropdown, type MenuProps } from 'antd';
+import {
+  Check,
+  ChevronDown,
+  FolderKanban,
+  Languages,
+  Settings,
+} from 'lucide-react';
 
-type SupportedLocale = "zh-CN" | "en-US";
+type SupportedLocale = 'zh-CN' | 'en-US';
+
+const PROJECT_MANAGEMENT_PERMISSION = 'security:project:read';
 
 const getSupportedLocale = (): SupportedLocale =>
-  getLocale().toLowerCase().startsWith("zh") ? "zh-CN" : "en-US";
+  getLocale().toLowerCase().startsWith('zh') ? 'zh-CN' : 'en-US';
 
 function LanguageSwitcher() {
   const currentLocale = getSupportedLocale();
@@ -23,20 +37,20 @@ function LanguageSwitcher() {
   return (
     <Dropdown
       placement="bottomRight"
-      trigger={["click"]}
+      trigger={['click']}
       menu={{
         selectable: true,
         selectedKeys: [currentLocale],
         items: [
           {
-            key: "zh-CN",
-            label: "中文",
-            onClick: () => switchLocale("zh-CN"),
+            key: 'zh-CN',
+            label: '中文',
+            onClick: () => switchLocale('zh-CN'),
           },
           {
-            key: "en-US",
-            label: "English",
-            onClick: () => switchLocale("en-US"),
+            key: 'en-US',
+            label: 'English',
+            onClick: () => switchLocale('en-US'),
           },
         ],
       }}
@@ -51,7 +65,7 @@ function LanguageSwitcher() {
           <Languages className="h-[17px] w-[17px]" strokeWidth={1.8} />
         </span>
         <span className="mt-0.5 whitespace-nowrap text-[10px] leading-3">
-          {currentLocale === "zh-CN" ? "中文" : "EN"}
+          {currentLocale === 'zh-CN' ? '中文' : 'EN'}
         </span>
       </button>
     </Dropdown>
@@ -59,30 +73,95 @@ function LanguageSwitcher() {
 }
 
 function ProjectSwitcher() {
+  const { initialState } = useModel('@@initialState');
   const { projects, currentProject, selectProject } = useSecurityProject();
+  const permissionCodes = initialState?.currentUser?.permissionCodes ?? [];
+  const canManage = hasPermission(
+    permissionCodes,
+    PROJECT_MANAGEMENT_PERMISSION,
+  );
 
-  if (!projects.length) {
-    return <span className="whitespace-nowrap px-2 text-sm">暂无可用项目</span>;
+  const items: MenuProps['items'] = [
+    ...projects.map((project) => ({
+      key: `project:${project.id}`,
+      label: (
+        <div className="flex min-w-[188px] items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="truncate text-[13px] font-medium text-[#1c1f23]">
+              {project.projectName}
+            </div>
+            {project.projectCode ? (
+              <div className="mt-0.5 truncate text-[11px] text-slate-400">
+                {project.projectCode}
+              </div>
+            ) : null}
+          </div>
+          {currentProject?.id === project.id ? (
+            <Check className="h-4 w-4 shrink-0 text-[#fe2c55]" />
+          ) : null}
+        </div>
+      ),
+    })),
+    ...(canManage
+      ? [
+          { type: 'divider' as const },
+          {
+            key: 'manage',
+            icon: <Settings className="h-4 w-4" strokeWidth={1.8} />,
+            label: '管理工作空间',
+          },
+        ]
+      : []),
+  ];
+
+  const handleMenuClick: MenuProps['onClick'] = ({ key }) => {
+    if (key === 'manage') {
+      history.push('/system/projects');
+      return;
+    }
+
+    if (!key.startsWith('project:')) return;
+    const id = Number(key.slice('project:'.length));
+    const project = projects.find((item) => item.id === id);
+    if (!project || project.id === currentProject?.id) return;
+
+    selectProject(project);
+
+    // Project-scoped pages own local query state. Reload after persisting the
+    // selected project so every mounted module re-enters with one consistent
+    // X-YAK-SECURITY-PROJECT-ID instead of showing mixed old/new workspace data.
+    window.location.reload();
+  };
+
+  if (!projects.length && !canManage) {
+    return (
+      <div className="mx-1 flex h-8 items-center gap-2 rounded-lg px-2 text-[12px] text-slate-400">
+        <FolderKanban className="h-4 w-4" strokeWidth={1.8} />
+        <span>暂无工作空间</span>
+      </div>
+    );
   }
 
   return (
     <Dropdown
-      menu={{
-        selectable: true,
-        selectedKeys: currentProject ? [String(currentProject.id)] : [],
-        items: projects.map((project) => ({
-          key: String(project.id),
-          label: project.projectName,
-          onClick: () => selectProject(project),
-        })),
-      }}
+      placement="bottomRight"
+      trigger={['click']}
+      menu={{ items, onClick: handleMenuClick }}
     >
       <button
         type="button"
-        className="flex items-center gap-1 border-0 bg-transparent px-2 text-sm"
+        aria-label="切换工作空间"
+        title="切换工作空间"
+        className="mx-1 flex h-8 max-w-[220px] items-center gap-2 rounded-lg border border-[rgba(28,31,35,0.08)] bg-white px-2.5 text-[13px] text-[#1c1f23] transition-colors hover:bg-[#f7f7f8]"
       >
-        <span>{currentProject?.projectName}</span>
-        <ChevronDown className="h-3 w-3" />
+        <FolderKanban
+          className="h-4 w-4 shrink-0 text-[rgba(22,24,35,0.55)]"
+          strokeWidth={1.8}
+        />
+        <span className="min-w-0 flex-1 truncate text-left">
+          {currentProject?.projectName ?? '暂无工作空间'}
+        </span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[rgba(22,24,35,0.4)]" />
       </button>
     </Dropdown>
   );

--- a/yak-ops-ui/src/config/productFeatures.ts
+++ b/yak-ops-ui/src/config/productFeatures.ts
@@ -6,7 +6,7 @@
  * while removing unfinished entry points from the default navigation.
  */
 export const productFeatures = {
-  projectSpace: false,
+  projectSpace: true,
   resourceAuthorization: false,
   systemConfig: false,
 } as const;

--- a/yak-ops-ui/src/pages/system/security-projects/index.tsx
+++ b/yak-ops-ui/src/pages/system/security-projects/index.tsx
@@ -1,7 +1,9 @@
-import type {
-  ActionType,
-  ProColumns,
-} from '@ant-design/pro-components';
+import {
+  ApartmentOutlined,
+  PlusOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
+import { useModel } from '@umijs/max';
 import {
   Alert,
   Button,
@@ -10,20 +12,27 @@ import {
   Form,
   Input,
   Modal,
+  Select,
   Space,
   Switch,
   Tag,
+  TreeSelect,
   Typography,
   message,
+  type TableColumnsType,
 } from 'antd';
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import YakButton from '@/components/YakButton';
 import {
   AssignmentDrawer,
-  PermissionGuard,
   SecurityQueryTable,
 } from '@/components/security';
 import { useSecurityProject } from '@/contexts/SecurityProjectContext';
+import {
+  getDepartmentTree,
+  type DepartmentVO,
+} from '@/services/security/departments';
 import {
   assignSecurityProjectMembers,
   assignSecurityProjectOwner,
@@ -41,79 +50,190 @@ import {
   updateSecurityProject,
   updateSecurityProjectStatus,
 } from '@/services/security/projects';
+import { hasPermission } from '@/utils/security/permission';
 
-const permission = (action: string) =>
-  `system:project:${action}`;
+import SystemManagementPage from '../components/SystemManagementPage';
+import {
+  formatSystemDateTime,
+  getSystemErrorMessage,
+} from '../utils';
+import {
+  buildWorkspaceCreateInput,
+  filterWorkspaceAssignmentCandidates,
+  normalizeWorkspaceInput,
+  toWorkspaceDepartmentTreeData,
+  type WorkspaceAssignmentMode,
+} from './workspace';
 
-const errorText = (
-  error: unknown,
-  fallback: string,
-): string =>
-  error instanceof Error && error.message
-    ? error.message
-    : fallback;
+const ROOT_PERMISSION = 'security:root';
+const DEFAULT_PAGE_SIZE = 10;
 
-const userDisplayName = (
-  user?: SecurityProjectUser,
-): string =>
-  user?.realName || user?.nickName || user?.userName || '-';
+interface WorkspaceFilters {
+  projectCode?: string;
+  projectName?: string;
+  ownerName?: string;
+  status?: SecurityProjectStatus;
+}
 
 interface AssignmentState {
   project: SecurityProjectSummary;
-  mode: 'single' | 'multiple';
+  mode: WorkspaceAssignmentMode;
   value: number[];
 }
 
+const userDisplayName = (user?: SecurityProjectUser): string =>
+  user?.realName || user?.nickName || user?.userName || '-';
+
+const cleanFilter = (value?: string): string | undefined => {
+  const normalized = value?.trim();
+  return normalized || undefined;
+};
+
 export default function SecurityProjectsPage() {
-  const actionRef = useRef<ActionType>();
-  const [form] = Form.useForm<SecurityProjectInput>();
-  const { currentProject, refreshProjects } =
-    useSecurityProject();
-  const [editing, setEditing] =
-    useState<SecurityProjectSummary>();
-  const [formOpen, setFormOpen] = useState(false);
+  const { initialState } = useModel('@@initialState');
+  const { currentProject, refreshProjects } = useSecurityProject();
+  const permissionCodes = initialState?.currentUser?.permissionCodes ?? [];
+  const canManage = hasPermission(permissionCodes, ROOT_PERMISSION);
+  const currentUserId = Number(initialState?.currentUser?.id ?? 0);
+
+  const [filterForm] = Form.useForm<WorkspaceFilters>();
+  const [editorForm] = Form.useForm<SecurityProjectInput>();
+  const [filters, setFilters] = useState<WorkspaceFilters>({});
+  const [rows, setRows] = useState<SecurityProjectSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [pageNum, setPageNum] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [total, setTotal] = useState(0);
+
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<SecurityProjectSummary>();
   const [saving, setSaving] = useState(false);
-  const [detail, setDetail] =
-    useState<SecurityProjectDetail>();
-  const [detailLoading, setDetailLoading] =
-    useState(false);
-  const [assigning, setAssigning] =
-    useState<AssignmentState>();
-  const [candidates, setCandidates] =
-    useState<SecurityProjectUser[]>([]);
-  const [candidateLoading, setCandidateLoading] =
-    useState(false);
+  const [departmentRoot, setDepartmentRoot] = useState<DepartmentVO>();
+  const [departmentLoading, setDepartmentLoading] = useState(false);
 
-  const reload = () => actionRef.current?.reload();
+  const [detail, setDetail] = useState<SecurityProjectDetail>();
+  const [detailLoading, setDetailLoading] = useState(false);
 
-  const resetForm = () => {
-    setFormOpen(false);
+  const [assigning, setAssigning] = useState<AssignmentState>();
+  const [candidates, setCandidates] = useState<SecurityProjectUser[]>([]);
+  const [candidateLoading, setCandidateLoading] = useState(false);
+
+  const loadProjects = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await pageSecurityProjects({
+        pageNum,
+        pageSize,
+        projectCode: cleanFilter(filters.projectCode),
+        projectName: cleanFilter(filters.projectName),
+        ownerName: cleanFilter(filters.ownerName),
+        status: filters.status,
+      });
+      setRows(result.records);
+      setTotal(result.total);
+    } catch (error) {
+      setRows([]);
+      setTotal(0);
+      message.error(
+        getSystemErrorMessage(error, '工作空间列表加载失败'),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [filters, pageNum, pageSize]);
+
+  useEffect(() => {
+    void loadProjects();
+  }, [loadProjects]);
+
+  const loadDepartments = useCallback(async () => {
+    if (departmentRoot) return departmentRoot;
+
+    setDepartmentLoading(true);
+    try {
+      const root = await getDepartmentTree();
+      setDepartmentRoot(root);
+      return root;
+    } catch (error) {
+      message.error(
+        getSystemErrorMessage(error, '部门列表加载失败'),
+      );
+      return undefined;
+    } finally {
+      setDepartmentLoading(false);
+    }
+  }, [departmentRoot]);
+
+  const departmentTreeData = useMemo(
+    () => toWorkspaceDepartmentTreeData(departmentRoot),
+    [departmentRoot],
+  );
+
+  const closeEditor = () => {
+    if (saving) return;
+    setEditorOpen(false);
     setEditing(undefined);
-    form.resetFields();
+    editorForm.resetFields();
   };
 
-  const closeForm = () => {
-    if (!saving) resetForm();
-  };
+  const openEditor = async (project?: SecurityProjectSummary) => {
+    if (!canManage) return;
 
-  const openForm = (project?: SecurityProjectSummary) => {
     setEditing(project);
-    setFormOpen(true);
-    form.setFieldsValue({
+    setEditorOpen(true);
+    editorForm.resetFields();
+    editorForm.setFieldsValue({
       projectName: project?.projectName ?? '',
       description: project?.description ?? '',
       deptId: project?.deptId ?? undefined,
     });
+    await loadDepartments();
   };
 
-  const showDetail = async (
-    project: SecurityProjectSummary,
-  ) => {
+  const saveWorkspace = async (values: SecurityProjectInput) => {
+    if (saving) return;
+
+    setSaving(true);
+    try {
+      if (editing) {
+        await updateSecurityProject(
+          editing.id,
+          normalizeWorkspaceInput(values),
+        );
+        message.success('工作空间已更新');
+      } else {
+        if (!currentUserId) {
+          throw new Error('无法识别当前用户，不能创建工作空间');
+        }
+        await createSecurityProject(
+          buildWorkspaceCreateInput(values, currentUserId),
+        );
+        message.success('工作空间已创建，你已成为负责人');
+      }
+
+      closeEditor();
+      await refreshProjects();
+      await loadProjects();
+    } catch (error) {
+      message.error(
+        getSystemErrorMessage(
+          error,
+          editing ? '工作空间更新失败' : '工作空间创建失败',
+        ),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const showDetail = async (project: SecurityProjectSummary) => {
     setDetailLoading(true);
     try {
       setDetail(await getSecurityProject(project.id));
     } catch (error) {
-      
+      message.error(
+        getSystemErrorMessage(error, '工作空间详情加载失败'),
+      );
     } finally {
       setDetailLoading(false);
     }
@@ -121,34 +241,69 @@ export default function SecurityProjectsPage() {
 
   const openAssignment = async (
     project: SecurityProjectSummary,
-    mode: 'single' | 'multiple',
+    mode: WorkspaceAssignmentMode,
   ) => {
+    if (!canManage) return;
+
     setCandidateLoading(true);
     try {
-      const [projectDetail, userCandidates] =
-        await Promise.all([
-          getSecurityProject(project.id),
-          getSecurityProjectMemberCandidates(project.id),
-        ]);
+      const [projectDetail, allCandidates] = await Promise.all([
+        getSecurityProject(project.id),
+        getSecurityProjectMemberCandidates(project.id),
+      ]);
+      const visibleCandidates = filterWorkspaceAssignmentCandidates(
+        mode,
+        projectDetail,
+        allCandidates,
+      );
 
-      setCandidates(userCandidates);
+      setCandidates(visibleCandidates);
       setAssigning({
         project,
         mode,
         value:
-          mode === 'single'
-            ? projectDetail.owners
-                .slice(0, 1)
-                .map((user) => user.id)
-            : projectDetail.members.map(
-                (user) => user.id,
-              ),
+          mode === 'owner'
+            ? projectDetail.owners.slice(0, 1).map((user) => user.id)
+            : projectDetail.members.map((user) => user.id),
       });
     } catch (error) {
       setCandidates([]);
-      
+      message.error(
+        getSystemErrorMessage(error, '可分配用户加载失败'),
+      );
     } finally {
       setCandidateLoading(false);
+    }
+  };
+
+  const submitAssignment = async (ids: number[]) => {
+    if (!assigning) return;
+
+    try {
+      if (assigning.mode === 'owner') {
+        if (!ids.length) {
+          throw new Error('工作空间至少需要一名负责人');
+        }
+        await assignSecurityProjectOwner(
+          assigning.project.id,
+          ids.slice(0, 1),
+        );
+      } else {
+        await assignSecurityProjectMembers(assigning.project.id, ids);
+      }
+
+      message.success(
+        assigning.mode === 'owner' ? '负责人已更新' : '成员已更新',
+      );
+      setAssigning(undefined);
+      setCandidates([]);
+      await refreshProjects();
+      await loadProjects();
+    } catch (error) {
+      message.error(
+        getSystemErrorMessage(error, '成员关系更新失败'),
+      );
+      throw error;
     }
   };
 
@@ -156,45 +311,41 @@ export default function SecurityProjectsPage() {
     project: SecurityProjectSummary,
     checked: boolean,
   ) => {
+    if (!canManage) return;
+
     const status: SecurityProjectStatus = checked
       ? 'ENABLED'
       : 'DISABLED';
 
     Modal.confirm({
-      title: `确认${checked ? '启用' : '停用'}项目“${project.projectName}”？`,
+      title: `确认${checked ? '启用' : '停用'}工作空间“${project.projectName}”？`,
       content: !checked
-        ? '停用后该项目将不可再从项目切换器选择。'
+        ? '停用后，该工作空间将从成员的工作空间切换列表中移除。'
         : undefined,
       onOk: async () => {
         try {
-          await updateSecurityProjectStatus(
-            project.id,
-            status,
-          );
-
-          if (currentProject?.id === project.id) {
-            await refreshProjects();
-          }
-
-          message.success('状态已更新');
-          reload();
+          await updateSecurityProjectStatus(project.id, status);
+          await refreshProjects();
+          await loadProjects();
+          message.success('工作空间状态已更新');
         } catch (error) {
-          
+          message.error(
+            getSystemErrorMessage(error, '工作空间状态更新失败'),
+          );
           throw error;
         }
       },
     });
   };
 
-  const remove = async (
-    project: SecurityProjectSummary,
-  ) => {
-    try {
-      const check =
-        await checkSecurityProjectDeletion(project.id);
+  const removeWorkspace = async (project: SecurityProjectSummary) => {
+    if (!canManage) return;
 
+    try {
+      const check = await checkSecurityProjectDeletion(project.id);
       Modal.confirm({
-        title: `删除项目“${project.projectName}”？`,
+        title: `删除工作空间“${project.projectName}”？`,
+        okText: '删除',
         okButtonProps: {
           danger: true,
           disabled: !check.deletable,
@@ -203,7 +354,7 @@ export default function SecurityProjectsPage() {
           <Alert
             showIcon
             type="warning"
-            message="检查通过，删除后无法恢复。"
+            message="检查通过。删除后无法恢复，请确认该工作空间确实不再使用。"
           />
         ) : (
           <div className="space-y-3">
@@ -211,8 +362,7 @@ export default function SecurityProjectsPage() {
               showIcon
               type="error"
               message={
-                check.reason ??
-                '项目仍有关联资源，无法删除。'
+                check.reason ?? '工作空间仍有关联资源，无法删除。'
               }
             />
             <Space size={[4, 6]} wrap>
@@ -225,353 +375,381 @@ export default function SecurityProjectsPage() {
         onOk: async () => {
           try {
             await deleteSecurityProject(project.id);
-
-            if (currentProject?.id === project.id) {
-              await refreshProjects();
-            }
-
-            message.success('项目已删除');
-            reload();
+            await refreshProjects();
+            await loadProjects();
+            message.success('工作空间已删除');
           } catch (error) {
-            
+            message.error(
+              getSystemErrorMessage(error, '工作空间删除失败'),
+            );
             throw error;
           }
         },
       });
     } catch (error) {
-      
+      message.error(
+        getSystemErrorMessage(error, '删除前检查失败'),
+      );
     }
   };
 
-  const columns: ProColumns<SecurityProjectSummary>[] = [
-    {
-      title: '项目编码',
-      dataIndex: 'projectCode',
-    },
-    {
-      title: '项目名称',
-      dataIndex: 'projectName',
-    },
-    {
-      title: '负责人',
-      dataIndex: 'ownerName',
-      fieldProps: { placeholder: '用户名或姓名' },
-      render: (_, row) =>
-        row.owners.length > 0 ? (
-          <Space size={[4, 4]} wrap>
-            {row.owners.map((owner) => (
-              <Tag key={owner.id}>
-                {userDisplayName(owner)}
-              </Tag>
-            ))}
-          </Space>
-        ) : (
-          '-'
+  const columns = useMemo<TableColumnsType<SecurityProjectSummary>>(
+    () => [
+      {
+        title: '工作空间',
+        dataIndex: 'projectName',
+        width: 240,
+        render: (_, row) => (
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate font-medium text-slate-800">
+                {row.projectName}
+              </span>
+              {currentProject?.id === row.id ? (
+                <Tag color="processing">当前</Tag>
+              ) : null}
+            </div>
+            <div className="mt-1 text-xs text-slate-400">
+              {row.projectCode || '-'}
+            </div>
+          </div>
         ),
-    },
-    {
-      title: '成员数',
-      dataIndex: 'memberCount',
-      search: false,
-    },
-    {
-      title: '状态',
-      dataIndex: 'status',
-      valueType: 'select',
-      valueEnum: {
-        ENABLED: {
-          text: '运行中',
-          status: 'Success',
-        },
-        DISABLED: {
-          text: '已停用',
-          status: 'Default',
-        },
       },
-      render: (_, row) => (
-        <PermissionGuard
-          mode="one"
-          permission={permission('status')}
-          behavior="disable"
-        >
-          <Switch
-            checked={row.status === 'ENABLED'}
-            checkedChildren="运行"
-            unCheckedChildren="停用"
-            onChange={(checked) =>
-              changeStatus(row, checked)
-            }
-          />
-        </PermissionGuard>
-      ),
-    },
-    {
-      title: '创建时间',
-      dataIndex: 'createTime',
-      valueType: 'dateTime',
-      search: false,
-    },
-    {
-      title: '更新时间',
-      dataIndex: 'updateTime',
-      valueType: 'dateTime',
-      search: false,
-    },
-    {
-      title: '操作',
-      valueType: 'option',
-      render: (_, row) => (
-        <Space wrap>
-          <Button
-            type="link"
-            onClick={() => void showDetail(row)}
-          >
-            详情
-          </Button>
-          <PermissionGuard
-            mode="one"
-            permission={permission('update')}
-          >
-            <Button
-              type="link"
-              onClick={() => openForm(row)}
-            >
-              编辑
+      {
+        title: '所属部门',
+        dataIndex: 'deptPath',
+        width: 220,
+        render: (_, row) => row.deptPath?.join(' / ') || '-',
+      },
+      {
+        title: '负责人',
+        dataIndex: 'owners',
+        width: 180,
+        render: (_, row) =>
+          row.owners.length > 0 ? (
+            <Space size={[4, 4]} wrap>
+              {row.owners.map((owner) => (
+                <Tag key={owner.id}>{userDisplayName(owner)}</Tag>
+              ))}
+            </Space>
+          ) : (
+            <span className="text-amber-600">未分配</span>
+          ),
+      },
+      {
+        title: '普通成员',
+        dataIndex: 'memberCount',
+        width: 100,
+        align: 'center',
+        render: (value) => Number(value ?? 0),
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 110,
+        render: (_, row) =>
+          canManage ? (
+            <Switch
+              size="small"
+              checked={row.status === 'ENABLED'}
+              checkedChildren="启用"
+              unCheckedChildren="停用"
+              onChange={(checked) => changeStatus(row, checked)}
+            />
+          ) : (
+            <Tag color={row.status === 'ENABLED' ? 'success' : 'default'}>
+              {row.status === 'ENABLED' ? '启用' : '停用'}
+            </Tag>
+          ),
+      },
+      {
+        title: '创建时间',
+        dataIndex: 'createTime',
+        width: 168,
+        render: (value) => formatSystemDateTime(value as string | undefined),
+      },
+      {
+        title: '操作',
+        key: 'action',
+        fixed: 'right',
+        width: canManage ? 300 : 80,
+        render: (_, row) => (
+          <Space size={4} wrap>
+            <Button type="link" onClick={() => void showDetail(row)}>
+              详情
             </Button>
-          </PermissionGuard>
-          <PermissionGuard
-            mode="one"
-            permission={permission('assign')}
-          >
-            <Button
-              type="link"
-              onClick={() =>
-                void openAssignment(row, 'single')
-              }
-            >
-              负责人
-            </Button>
-            <Button
-              type="link"
-              onClick={() =>
-                void openAssignment(row, 'multiple')
-              }
-            >
-              成员
-            </Button>
-          </PermissionGuard>
-          <PermissionGuard
-            mode="one"
-            permission={permission('delete')}
-          >
-            <Button
-              danger
-              type="link"
-              onClick={() => void remove(row)}
-            >
-              删除
-            </Button>
-          </PermissionGuard>
-        </Space>
-      ),
-    },
-  ];
+            {canManage ? (
+              <>
+                <Button type="link" onClick={() => void openEditor(row)}>
+                  编辑
+                </Button>
+                <Button
+                  type="link"
+                  onClick={() => void openAssignment(row, 'owner')}
+                >
+                  负责人
+                </Button>
+                <Button
+                  type="link"
+                  onClick={() => void openAssignment(row, 'member')}
+                >
+                  成员
+                </Button>
+                <Button
+                  danger
+                  type="link"
+                  onClick={() => void removeWorkspace(row)}
+                >
+                  删除
+                </Button>
+              </>
+            ) : null}
+          </Space>
+        ),
+      },
+    ],
+    [canManage, currentProject?.id],
+  );
 
   return (
-    <section className="m-4 rounded-xl bg-white p-6">
-      <Typography.Title level={4}>
-        Security 授权项目1
-      </Typography.Title>
-
-      <SecurityQueryTable<SecurityProjectSummary>
-        actionRef={actionRef}
-        columns={columns}
-        request={async (params) => {
-          try {
-            const result = await pageSecurityProjects({
-              pageNum: params.current ?? 1,
-              pageSize: params.pageSize ?? 10,
-              projectCode:
-                params.projectCode as string,
-              projectName:
-                params.projectName as string,
-              ownerName: params.ownerName as string,
-              status:
-                params.status as SecurityProjectStatus,
-            });
-
-            return {
-              data: result.records,
-              total: result.total,
-              success: true,
-            };
-          } catch (error) {
-           
-
-            return {
-              data: [],
-              total: 0,
-              success: false,
-            };
-          }
-        }}
-        toolBarRender={() => [
-          <PermissionGuard
-            key="create"
-            mode="one"
-            permission={permission('create')}
-          >
-            <Button
-              type="primary"
-              onClick={() => openForm()}
-            >
-              新增项目
-            </Button>
-          </PermissionGuard>,
-        ]}
+    <SystemManagementPage
+      title="工作空间"
+      titleId="system-workspaces-title"
+      icon={<ApartmentOutlined className="text-slate-500" />}
+      className="min-h-full"
+    >
+      <Alert
+        showIcon
+        type="info"
+        className="mb-4"
+        message="工作空间是 Yak Ops 的业务数据隔离边界"
+        description="角色与功能权限决定用户能做什么；工作空间成员关系决定用户能进入哪里；数据源等业务数据通过 project_id 归属当前工作空间。Stage 1 暂不启用资源级授权。"
       />
 
-      <Modal
-        open={formOpen}
-        title={
-          editing
-            ? '编辑 Security 授权项目'
-            : '新增 Security 授权项目'
-        }
-        confirmLoading={saving}
+      <div className="mb-4 rounded-xl border border-slate-200 bg-white p-4">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <Form<WorkspaceFilters>
+            form={filterForm}
+            layout="inline"
+            onFinish={(values) => {
+              setPageNum(1);
+              setFilters(values);
+            }}
+          >
+            <Form.Item name="projectName" label="名称">
+              <Input allowClear placeholder="工作空间名称" />
+            </Form.Item>
+            <Form.Item name="projectCode" label="编码">
+              <Input allowClear placeholder="工作空间编码" />
+            </Form.Item>
+            <Form.Item name="ownerName" label="负责人">
+              <Input allowClear placeholder="用户名或姓名" />
+            </Form.Item>
+            <Form.Item name="status" label="状态">
+              <Select
+                allowClear
+                className="w-28"
+                placeholder="全部"
+                options={[
+                  { label: '启用', value: 'ENABLED' },
+                  { label: '停用', value: 'DISABLED' },
+                ]}
+              />
+            </Form.Item>
+            <Form.Item>
+              <Space>
+                <YakButton type="primary" htmlType="submit">
+                  查询
+                </YakButton>
+                <YakButton
+                  onClick={() => {
+                    filterForm.resetFields();
+                    setPageNum(1);
+                    setFilters({});
+                  }}
+                >
+                  重置
+                </YakButton>
+              </Space>
+            </Form.Item>
+          </Form>
+
+          <Space>
+            <YakButton
+              icon={<ReloadOutlined />}
+              loading={loading}
+              onClick={() => void loadProjects()}
+            >
+              刷新
+            </YakButton>
+            {canManage ? (
+              <YakButton
+                type="primary"
+                icon={<PlusOutlined />}
+                onClick={() => void openEditor()}
+              >
+                新增工作空间
+              </YakButton>
+            ) : null}
+          </Space>
+        </div>
+      </div>
+
+      <SecurityQueryTable<SecurityProjectSummary>
+        dataSource={rows}
+        columns={columns}
+        loading={loading}
+        scroll={{ x: 1280 }}
+        pagination={{
+          current: pageNum,
+          pageSize,
+          total,
+          showSizeChanger: true,
+          showTotal: (value) => `共 ${value} 个工作空间`,
+          onChange: (nextPage, nextPageSize) => {
+            setPageNum(nextPageSize === pageSize ? nextPage : 1);
+            setPageSize(nextPageSize);
+          },
+        }}
+      />
+
+      <Drawer
+        open={editorOpen}
+        title={editing ? '编辑工作空间' : '新增工作空间'}
+        width={520}
+        forceRender
         maskClosable={!saving}
+        keyboard={!saving}
         closable={!saving}
-        destroyOnClose
-        onCancel={closeForm}
-        onOk={() => form.submit()}
+        onClose={closeEditor}
+        extra={
+          <Space>
+            <YakButton disabled={saving} onClick={closeEditor}>
+              取消
+            </YakButton>
+            <YakButton
+              type="primary"
+              loading={saving}
+              onClick={() => editorForm.submit()}
+            >
+              {editing ? '更新' : '创建'}
+            </YakButton>
+          </Space>
+        }
       >
+        <Alert
+          showIcon
+          type="info"
+          className="mb-5"
+          message={
+            editing
+              ? '修改名称或所属部门不会改变已有负责人和成员关系。'
+              : '创建后当前用户会自动成为负责人，工作空间会立即出现在 Header 切换列表中。'
+          }
+        />
+
+        {departmentTreeData.length === 0 && !departmentLoading ? (
+          <Alert
+            showIcon
+            type="warning"
+            className="mb-4"
+            message="暂无可用部门"
+            description="工作空间必须归属真实部门，请先在“系统管理 > 部门管理”创建部门。"
+          />
+        ) : null}
+
         <Form<SecurityProjectInput>
-          form={form}
+          form={editorForm}
           layout="vertical"
           preserve={false}
           disabled={saving}
-          onFinish={async (values) => {
-            setSaving(true);
-            try {
-              if (editing) {
-                await updateSecurityProject(
-                  editing.id,
-                  values,
-                );
-              } else {
-                await createSecurityProject(values);
-              }
-
-              message.success('保存成功');
-              resetForm();
-              reload();
-            } catch (error) {
-              
-            } finally {
-              setSaving(false);
-            }
-          }}
+          onFinish={(values) => void saveWorkspace(values)}
         >
-          <Form.Item label="项目编码">
-            <Input
-              disabled
-              value={
-                editing?.projectCode ||
-                '保存后由后端自动生成'
-              }
-            />
-          </Form.Item>
+          {editing ? (
+            <Form.Item label="工作空间编码">
+              <Input disabled value={editing.projectCode || '-'} />
+            </Form.Item>
+          ) : null}
+
           <Form.Item
             name="projectName"
-            label="项目名称"
+            label="工作空间名称"
             rules={[
               {
                 required: true,
                 whitespace: true,
-                message: '请输入项目名称',
+                message: '请输入工作空间名称',
               },
             ]}
           >
             <Input
               maxLength={128}
               showCount
-              placeholder="请输入项目名称"
+              placeholder="例如：成都一院"
             />
           </Form.Item>
+
           <Form.Item
-            name="description"
-            label="项目描述"
+            name="deptId"
+            label="所属部门"
+            rules={[{ required: true, message: '请选择所属部门' }]}
           >
+            <TreeSelect
+              treeData={departmentTreeData}
+              treeDefaultExpandAll
+              showSearch
+              allowClear={false}
+              loading={departmentLoading}
+              placeholder="请选择所属部门"
+              filterTreeNode={(input, node) =>
+                String(node.title ?? '')
+                  .toLocaleLowerCase()
+                  .includes(input.trim().toLocaleLowerCase())
+              }
+            />
+          </Form.Item>
+
+          <Form.Item name="description" label="工作空间描述">
             <Input.TextArea
               maxLength={500}
               showCount
-              autoSize={{ minRows: 3, maxRows: 6 }}
-              placeholder="请输入项目用途或授权范围"
+              autoSize={{ minRows: 4, maxRows: 8 }}
+              placeholder="说明这个工作空间对应的医院、团队或业务范围"
             />
           </Form.Item>
         </Form>
-      </Modal>
+      </Drawer>
 
       <AssignmentDrawer
         open={Boolean(assigning)}
-        title={
-          assigning?.mode === 'single'
-            ? '分配负责人'
-            : '分配成员'
-        }
-        mode={assigning?.mode ?? 'single'}
+        title={assigning?.mode === 'owner' ? '分配负责人' : '分配普通成员'}
+        mode={assigning?.mode === 'owner' ? 'single' : 'multiple'}
         options={candidates.map((user) => ({
           id: user.id,
           label: userDisplayName(user),
           description:
-            user.realName &&
-            user.realName !== user.userName
+            user.realName && user.realName !== user.userName
               ? user.userName
               : undefined,
         }))}
         value={assigning?.value ?? []}
         loading={candidateLoading}
-        allowEmpty
+        allowEmpty={assigning?.mode === 'member'}
         onClose={() => {
           setAssigning(undefined);
           setCandidates([]);
         }}
-        onSubmit={async (ids) => {
-          if (!assigning) return;
-
-          try {
-            if (assigning.mode === 'single') {
-              await assignSecurityProjectOwner(
-                assigning.project.id,
-                ids.slice(0, 1),
-              );
-            } else {
-              await assignSecurityProjectMembers(
-                assigning.project.id,
-                ids,
-              );
-            }
-
-            await refreshProjects();
-            message.success('分配成功');
-            setAssigning(undefined);
-            setCandidates([]);
-            reload();
-          } catch (error) {
-            
-            throw error;
-          }
-        }}
+        onSubmit={submitAssignment}
       />
 
       <Drawer
         open={Boolean(detail) || detailLoading}
-        title="Security 授权项目详情"
+        title="工作空间详情"
         width={600}
         loading={detailLoading}
         onClose={() => setDetail(undefined)}
       >
-        {detail && (
+        {detail ? (
           <div className="space-y-6">
             <Descriptions
               column={1}
@@ -590,8 +768,7 @@ export default function SecurityProjectsPage() {
                 {
                   key: 'dept',
                   label: '所属部门',
-                  children:
-                    detail.deptPath?.join(' / ') || '-',
+                  children: detail.deptPath?.join(' / ') || '-',
                 },
                 {
                   key: 'description',
@@ -602,62 +779,47 @@ export default function SecurityProjectsPage() {
                   key: 'status',
                   label: '状态',
                   children: (
-                    <Tag
-                      color={
-                        detail.status === 'ENABLED'
-                          ? 'success'
-                          : 'default'
-                      }
-                    >
-                      {detail.status === 'ENABLED'
-                        ? '运行中'
-                        : '已停用'}
+                    <Tag color={detail.status === 'ENABLED' ? 'success' : 'default'}>
+                      {detail.status === 'ENABLED' ? '启用' : '停用'}
                     </Tag>
                   ),
+                },
+                {
+                  key: 'created',
+                  label: '创建时间',
+                  children: formatSystemDateTime(detail.createTime),
                 },
               ]}
             />
 
             <div>
-              <Typography.Title level={5}>
-                负责人
-              </Typography.Title>
+              <Typography.Title level={5}>负责人</Typography.Title>
               <Space wrap>
                 {detail.owners.length > 0 ? (
                   detail.owners.map((owner) => (
-                    <Tag key={owner.id}>
-                      {userDisplayName(owner)}
-                    </Tag>
+                    <Tag key={owner.id}>{userDisplayName(owner)}</Tag>
                   ))
                 ) : (
-                  <Typography.Text type="secondary">
-                    暂未分配负责人
-                  </Typography.Text>
+                  <Typography.Text type="secondary">暂未分配负责人</Typography.Text>
                 )}
               </Space>
             </div>
 
             <div>
-              <Typography.Title level={5}>
-                成员
-              </Typography.Title>
+              <Typography.Title level={5}>普通成员</Typography.Title>
               <Space wrap>
                 {detail.members.length > 0 ? (
                   detail.members.map((member) => (
-                    <Tag key={member.id}>
-                      {userDisplayName(member)}
-                    </Tag>
+                    <Tag key={member.id}>{userDisplayName(member)}</Tag>
                   ))
                 ) : (
-                  <Typography.Text type="secondary">
-                    暂未分配成员
-                  </Typography.Text>
+                  <Typography.Text type="secondary">暂无普通成员</Typography.Text>
                 )}
               </Space>
             </div>
           </div>
-        )}
+        ) : null}
       </Drawer>
-    </section>
+    </SystemManagementPage>
   );
 }

--- a/yak-ops-ui/src/pages/system/security-projects/workspace.test.ts
+++ b/yak-ops-ui/src/pages/system/security-projects/workspace.test.ts
@@ -1,0 +1,76 @@
+import {
+  buildWorkspaceCreateInput,
+  filterWorkspaceAssignmentCandidates,
+  toWorkspaceDepartmentTreeData,
+} from './workspace';
+
+const user = (id: number, userName: string) => ({ id, userName });
+
+describe('workspace helpers', () => {
+  it('hides the virtual department root and preserves hierarchy', () => {
+    expect(
+      toWorkspaceDepartmentTreeData({
+        id: 0,
+        childList: [
+          {
+            id: 10,
+            deptName: '数据中心',
+            childList: [{ id: 11, deptName: '开发组' }],
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        value: 10,
+        title: '数据中心',
+        children: [{ value: 11, title: '开发组' }],
+      },
+    ]);
+  });
+
+  it('makes the workspace creator the initial owner', () => {
+    expect(
+      buildWorkspaceCreateInput(
+        {
+          projectName: '  成都一院  ',
+          description: ' 数据项目 ',
+          deptId: 10,
+        },
+        7,
+      ),
+    ).toEqual({
+      projectName: '成都一院',
+      description: '数据项目',
+      deptId: 10,
+      ownerIdList: [7],
+    });
+  });
+
+  it('keeps owner and normal-member assignment mutually exclusive', () => {
+    const owner = user(1, 'owner');
+    const member = user(2, 'member');
+    const free = user(3, 'free');
+    const detail = {
+      id: 9,
+      projectCode: 'p9',
+      projectName: '工作空间',
+      owners: [owner],
+      members: [member],
+      owner,
+      memberCount: 1,
+      status: 'ENABLED' as const,
+    };
+    const candidates = [owner, member, free];
+
+    expect(
+      filterWorkspaceAssignmentCandidates('owner', detail, candidates).map(
+        (item) => item.id,
+      ),
+    ).toEqual([1, 3]);
+    expect(
+      filterWorkspaceAssignmentCandidates('member', detail, candidates).map(
+        (item) => item.id,
+      ),
+    ).toEqual([2, 3]);
+  });
+});

--- a/yak-ops-ui/src/pages/system/security-projects/workspace.ts
+++ b/yak-ops-ui/src/pages/system/security-projects/workspace.ts
@@ -1,0 +1,89 @@
+import type { DepartmentVO } from '@/services/security/departments';
+import type {
+  SecurityProjectCreateInput,
+  SecurityProjectDetail,
+  SecurityProjectInput,
+  SecurityProjectUser,
+} from '@/services/security/projects';
+
+export type WorkspaceAssignmentMode = 'owner' | 'member';
+
+export interface WorkspaceDepartmentTreeNode {
+  value: number;
+  title: string;
+  children?: WorkspaceDepartmentTreeNode[];
+}
+
+const safeChildren = (department?: DepartmentVO): DepartmentVO[] =>
+  Array.isArray(department?.childList) ? department.childList : [];
+
+const departmentForest = (root?: DepartmentVO): DepartmentVO[] => {
+  if (!root) return [];
+  const virtualRoot = Number(root.id) === 0 && !root.deptName;
+  return virtualRoot ? safeChildren(root) : [root];
+};
+
+const departmentLabel = (department: DepartmentVO): string =>
+  department.deptName?.trim() || `部门 ${department.id}`;
+
+const toDepartmentNodes = (
+  departments: DepartmentVO[],
+  visited = new Set<string>(),
+): WorkspaceDepartmentTreeNode[] =>
+  departments.flatMap((department) => {
+    const key = String(department.id);
+    if (visited.has(key)) return [];
+
+    const nextVisited = new Set(visited);
+    nextVisited.add(key);
+    const children = toDepartmentNodes(
+      safeChildren(department),
+      nextVisited,
+    );
+
+    return [
+      {
+        value: Number(department.id),
+        title: departmentLabel(department),
+        ...(children.length > 0 ? { children } : {}),
+      },
+    ];
+  });
+
+export const toWorkspaceDepartmentTreeData = (
+  root?: DepartmentVO,
+): WorkspaceDepartmentTreeNode[] =>
+  toDepartmentNodes(departmentForest(root));
+
+export const normalizeWorkspaceInput = (
+  values: SecurityProjectInput,
+): SecurityProjectInput => ({
+  projectName: values.projectName.trim(),
+  description: values.description?.trim() ?? '',
+  deptId: Number(values.deptId),
+});
+
+export const buildWorkspaceCreateInput = (
+  values: SecurityProjectInput,
+  creatorUserId?: number,
+): SecurityProjectCreateInput => ({
+  ...normalizeWorkspaceInput(values),
+  ...(creatorUserId && creatorUserId > 0
+    ? { ownerIdList: [creatorUserId] }
+    : {}),
+});
+
+export const filterWorkspaceAssignmentCandidates = (
+  mode: WorkspaceAssignmentMode,
+  detail: SecurityProjectDetail,
+  candidates: SecurityProjectUser[],
+): SecurityProjectUser[] => {
+  const ownerIds = new Set(detail.owners.map((user) => user.id));
+  const memberIds = new Set(detail.members.map((user) => user.id));
+
+  return candidates.filter((user) =>
+    mode === 'owner'
+      ? !memberIds.has(user.id) || ownerIds.has(user.id)
+      : !ownerIds.has(user.id) || memberIds.has(user.id),
+  );
+};

--- a/yak-ops-ui/src/services/security/projects.test.ts
+++ b/yak-ops-ui/src/services/security/projects.test.ts
@@ -2,8 +2,16 @@ import { toSecurityProjectBrief } from './projects';
 
 describe('toSecurityProjectBrief', () => {
   it('isolates the selectable identity from management fields', () => {
-    expect(toSecurityProjectBrief({
-      id: 7, projectCode: 'SEC', projectName: 'Security', memberCount: 2, status: 'ENABLED',
-    })).toEqual({ id: 7, projectCode: 'SEC', projectName: 'Security' });
+    expect(
+      toSecurityProjectBrief({
+        id: 7,
+        projectCode: 'SEC',
+        projectName: 'Security',
+        owners: [],
+        members: [],
+        memberCount: 2,
+        status: 'ENABLED',
+      }),
+    ).toEqual({ id: 7, projectCode: 'SEC', projectName: 'Security' });
   });
 });

--- a/yak-ops-ui/src/services/security/projects.ts
+++ b/yak-ops-ui/src/services/security/projects.ts
@@ -52,7 +52,12 @@ export interface SecurityProjectPage {
 export interface SecurityProjectInput {
   projectName: string;
   description?: string;
-  deptId?: number;
+  deptId: number;
+}
+
+export interface SecurityProjectCreateInput extends SecurityProjectInput {
+  ownerIdList?: number[];
+  userIdList?: number[];
 }
 
 export interface SecurityProjectDeleteCheck {
@@ -193,7 +198,7 @@ export const getSecurityProject = async (
   );
 
 export const createSecurityProject = async (
-  body: SecurityProjectInput,
+  body: SecurityProjectCreateInput,
 ): Promise<SecurityProjectSummary> =>
   toProject(
     await securityPostData<BackendProjectVO>(
@@ -281,7 +286,7 @@ export const checkSecurityProjectDeletion = async (
     resourceNameList,
     reason: deletable
       ? undefined
-      : `项目仍关联 ${resourceNameList.length} 个资源，不能删除。`,
+      : `工作空间仍关联 ${resourceNameList.length} 个资源，不能删除。`,
     references: {
       resources: resourceNameList.length,
     },


### PR DESCRIPTION
## 背景

Yak Ops 的 Project Space 底层能力已经具备，但当前产品入口被 `productFeatures.projectSpace=false` 隐藏，Header 切换器和 `/system/projects` 管理页也还处于未产品化状态。Stage 1 先把“工作空间”产品闭环真正打开，为后续 DataSource `PROJECT_REQUIRED` MVP 提供稳定入口。

## 本 PR 做了什么

### 1. 正式开放工作空间入口
- `productFeatures.projectSpace = true`
- `resourceAuthorization`、`systemConfig` 继续保持关闭
- 不提前引入资源级授权或 Project 内角色覆盖

### 2. 完成 Header 工作空间切换器
- Header 展示当前工作空间
- 下拉展示当前用户可访问的工作空间，并标识当前项
- 提供“管理工作空间”入口
- 没有可用工作空间时展示明确空状态
- 切换工作空间后持久化 Project ID 并刷新页面，避免已挂载模块出现旧/新 Project 数据混杂

### 3. 重构 `/system/projects` 为真正可用的工作空间管理页
- 使用受控 AntD Table，不再向普通 Table 传递无效的 ProTable `request/toolBarRender` props
- 支持名称、编码、负责人、状态筛选和分页
- 支持详情、创建、编辑、启停、删除、负责人和成员分配
- 当前工作空间在列表中明确标记
- 页面产品文案统一按“工作空间”表达

### 4. 补齐创建工作空间的必要契约
- 新增/编辑工作空间必须选择真实 `deptId`
- 复用现有部门树作为所属部门 TreeSelect
- 无可用部门时明确提示先创建部门
- 新建工作空间时当前创建人自动成为初始负责人，创建完成后立即刷新当前用户的工作空间列表

### 5. 收紧负责人 / 普通成员关系
- 负责人和普通成员候选互斥，避免同一用户在同一 Project 中重复占用关系
- 负责人至少保留一人
- 普通成员允许清空
- 分配完成后刷新 Header 的可用工作空间列表

### 6. Stage 1 权限边界
- 工作空间管理页面继续使用 `security:project:read` 作为可见入口
- 由于 yak-framework 当前稳定 Project 权限编码只有 READ，Stage 1 的创建/编辑/启停/成员分配/删除按钮仅对 `security:root` 展示
- 本 PR 不发明 Project 级 RBAC，也不开放 `resourceAuthorization`

## 测试

新增 workspace helper 测试，覆盖：
- 部门树虚拟根节点过滤与层级保持
- 创建人自动成为初始负责人
- OWNER / NORMAL 成员候选互斥
- 补齐已有 project service fixture 类型契约

仓库现有前端验证命令：
```bash
cd yak-ops-ui
npm test -- src/pages/system/security-projects/workspace.test.ts src/services/security/projects.test.ts
npm run lint
```

当前通过 GitHub connector 未执行本地 Node/npm，因此 PR 保持 Draft；当前 head 暂未检测到 GitHub Actions workflow run。

## 建议手工回归

1. root 登录后 Header 显示默认工作空间
2. 进入 系统管理 > 项目空间，确认工作空间列表正常加载
3. 创建工作空间：选择部门，保存后 root 自动成为负责人
4. 新工作空间立即出现在 Header 切换列表
5. 添加普通成员并用该用户登录，确认只能看到其加入的工作空间
6. 在 Header 切换工作空间，确认页面刷新且后续请求使用新的 `X-YAK-SECURITY-PROJECT-ID`
7. 停用当前工作空间，确认刷新后不再作为可选工作空间
8. 验证负责人不能直接重复分配成普通成员，普通成员也不能直接重复分配成负责人

## 明确不在 Stage 1 范围
- DataSource 从 `PROJECT_OPTIONAL` 切换到 `PROJECT_REQUIRED`（Stage 2）
- Project 内不同角色/权限覆盖
- 资源级授权
- 跨 Project 资源共享
- yak-framework Project 管理接口的更细粒度权限编码扩展
