### PR TITLE
feat(project-space): 完成 Stage 2 数据源工作空间隔离

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/DataSourceProjectCompatibilityBackfill.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/DataSourceProjectCompatibilityBackfill.java
@@ -1,0 +1,88 @@
+package io.yak.ops.boot.project;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Completes the DataSource Project Space cutover after Flyway has expanded the schema.
+ *
+ * <p>The real default Project ID must come from Yak Security rather than a migration constant, so
+ * legacy rows are backfilled at application readiness. Runtime repositories are already
+ * fail-closed; startup is rejected if any datasource or SQL execution audit remains unscoped.
+ */
+@Component
+@DependsOn("opsDataSourceFlyway")
+@ConditionalOnDataSourceEnabled
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class DataSourceProjectCompatibilityBackfill {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DataSourceProjectCompatibilityBackfill.class);
+
+  private final ProjectCompatibilityCoordinator projectCoordinator;
+  private final JdbcTemplate jdbcTemplate;
+
+  public DataSourceProjectCompatibilityBackfill(
+      ProjectCompatibilityCoordinator projectCoordinator,
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.projectCoordinator = projectCoordinator;
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void backfillLegacyRows() {
+    long defaultProjectId = projectCoordinator.ensureRequiredDefaultProject();
+
+    int dataSources =
+        jdbcTemplate.update(
+            "UPDATE yak_ops_data_source SET project_id = ? WHERE project_id IS NULL",
+            defaultProjectId);
+
+    int inferredAudits =
+        jdbcTemplate.update(
+            "UPDATE yak_ops_sql_execution e "
+                + "JOIN yak_ops_data_source d "
+                + "  ON e.data_source_id REGEXP '^[0-9]+$' "
+                + " AND d.id = CAST(e.data_source_id AS UNSIGNED) "
+                + "SET e.project_id = d.project_id "
+                + "WHERE e.project_id IS NULL AND d.project_id IS NOT NULL");
+
+    int defaultAudits =
+        jdbcTemplate.update(
+            "UPDATE yak_ops_sql_execution SET project_id = ? WHERE project_id IS NULL",
+            defaultProjectId);
+
+    assertNoUnscopedRows("yak_ops_data_source");
+    assertNoUnscopedRows("yak_ops_sql_execution");
+
+    LOGGER.info(
+        "DataSource Project Space backfill complete: defaultProjectId={}, dataSources={}, inferredAudits={}, defaultAudits={}",
+        defaultProjectId,
+        dataSources,
+        inferredAudits,
+        defaultAudits);
+  }
+
+  private void assertNoUnscopedRows(String table) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(1) FROM " + table + " WHERE project_id IS NULL", Long.class);
+    if (count != null && count > 0L) {
+      throw new IllegalStateException(
+          "DataSource Project Space cutover left " + count + " unscoped rows in " + table);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceCatalogController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceCatalogController.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping(DataSourceConstants.API_PREFIX + "/catalog")
 @RequiresPermission(DataSourcePermissionCode.READ)
-@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
+@ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)
 public class DataSourceCatalogController {
   private final DataSourceCatalogReader catalogReader;
   private final CatalogRequestConverter requestConverter;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/DataSourceController.java
@@ -41,7 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping(DataSourceConstants.API_PREFIX)
 @RequiresPermission(DataSourcePermissionCode.READ)
-@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
+@ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)
 public class DataSourceController {
   private final DataSourceManager manager;
   private final DataSourceReader reader;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/SqlExecutionAuditController.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/controller/v1/SqlExecutionAuditController.java
@@ -13,6 +13,8 @@ import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditDetailVO;
 import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditSummaryVO;
 import io.yak.ops.common.bean.vo.observability.SqlExecutionAuditVO;
 import io.yak.ops.common.constant.observability.SqlExecutionAuditConstants;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping(SqlExecutionAuditConstants.API_PREFIX)
 @RequiresPermission(SqlExecutionAuditConstants.READ_PERMISSION)
+@ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)
 public class SqlExecutionAuditController {
   private final SqlExecutionAuditReader auditReader;
   private final SqlExecutionAuditConverter auditConverter;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/SqlExecutionAuditDao.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/SqlExecutionAuditDao.java
@@ -17,9 +17,9 @@ public interface SqlExecutionAuditDao {
 
   IPage<SqlExecutionAuditPO> selectPage(SqlExecutionAuditQuery query);
 
-  SqlExecutionAuditPO selectByExecutionId(String executionId);
+  SqlExecutionAuditPO selectByExecutionId(Long projectId, String executionId);
 
-  List<SqlStatementExecutionAuditPO> selectStatements(String executionId);
+  List<SqlStatementExecutionAuditPO> selectStatements(Long projectId, String executionId);
 
   SqlExecutionAuditSummaryRow selectSummary(SqlExecutionAuditQuery query);
 

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/DataSourceDaoImpl.java
@@ -20,7 +20,14 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-/** 基于 MyBatis-Plus 的数据源数据访问实现。 */
+/**
+ * 基于 MyBatis-Plus 的数据源数据访问实现。
+ *
+ * <p>DataSource 对外业务面统一通过 project-required Repository 访问。这里暂保留“无 CurrentProject
+ * 时按显式 ID 解析”的底层兼容通道，供尚处迁移期的 Offline/Realtime 后台任务恢复已持久化的数据源引用；
+ * 一旦存在 CurrentProject，则所有查询和写入都严格按该项目过滤。后续这些后台模块完成 project context
+ * 恢复后，应删除这条 legacy corridor。
+ */
 @Repository
 @ConditionalOnDataSourceEnabled
 public class DataSourceDaoImpl implements DataSourceDao {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/SqlExecutionAuditDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/impl/SqlExecutionAuditDaoImpl.java
@@ -16,7 +16,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-/** MyBatis-Plus implementation of the SQL execution audit DAO. */
+/** MyBatis-Plus implementation of the project-scoped SQL execution audit DAO. */
 @Repository
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
@@ -27,6 +27,9 @@ public class SqlExecutionAuditDaoImpl implements SqlExecutionAuditDao {
 
   @Override
   public void insertExecution(SqlExecutionAuditPO execution) {
+    if (execution == null || execution.getProjectId() == null || execution.getProjectId() <= 0L) {
+      throw new IllegalArgumentException("SQL execution audit requires projectId");
+    }
     executionMapper.insert(execution);
   }
 
@@ -44,17 +47,20 @@ public class SqlExecutionAuditDaoImpl implements SqlExecutionAuditDao {
   }
 
   @Override
-  public SqlExecutionAuditPO selectByExecutionId(String executionId) {
+  public SqlExecutionAuditPO selectByExecutionId(Long projectId, String executionId) {
     if (executionId == null || executionId.isBlank()) return null;
+    long scopedProjectId = requireProjectId(projectId);
     return executionMapper.selectOne(
         Wrappers.<SqlExecutionAuditPO>lambdaQuery()
+            .eq(SqlExecutionAuditPO::getProjectId, scopedProjectId)
             .eq(SqlExecutionAuditPO::getExecutionId, executionId.trim())
             .last("LIMIT 1"));
   }
 
   @Override
-  public List<SqlStatementExecutionAuditPO> selectStatements(String executionId) {
+  public List<SqlStatementExecutionAuditPO> selectStatements(Long projectId, String executionId) {
     if (executionId == null || executionId.isBlank()) return List.of();
+    if (selectByExecutionId(projectId, executionId) == null) return List.of();
     return statementMapper.selectList(
         Wrappers.<SqlStatementExecutionAuditPO>lambdaQuery()
             .eq(SqlStatementExecutionAuditPO::getExecutionId, executionId.trim())
@@ -82,9 +88,16 @@ public class SqlExecutionAuditDaoImpl implements SqlExecutionAuditDao {
   }
 
   private static SqlExecutionAuditQuery requireQuery(SqlExecutionAuditQuery query) {
-    return query == null
-        ? new SqlExecutionAuditQuery(
-            1, 20, null, null, null, null, null, null, null, null, null, null, null, null)
-        : query;
+    if (query == null || query.getProjectId() == null || query.getProjectId() <= 0L) {
+      throw new IllegalArgumentException("SQL execution audit query requires projectId");
+    }
+    return query;
+  }
+
+  private static long requireProjectId(Long projectId) {
+    if (projectId == null || projectId <= 0L) {
+      throw new IllegalArgumentException("projectId must be positive");
+    }
+    return projectId;
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditPO.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditPO.java
@@ -17,6 +17,7 @@ public class SqlExecutionAuditPO {
   @TableId(type = IdType.AUTO)
   private Long id;
 
+  private Long projectId;
   private String executionId;
   private String dataSourceId;
   private SqlExecutionCaller caller;

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditQuery.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/dao/model/SqlExecutionAuditQuery.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 public final class SqlExecutionAuditQuery {
 
+  private final Long projectId;
   private final int pageNo;
   private final int pageSize;
   private final String executionId;
@@ -41,6 +42,41 @@ public final class SqlExecutionAuditQuery {
       Long minDurationMs,
       LocalDateTime startedFrom,
       LocalDateTime startedTo) {
+    this(
+        null,
+        pageNo,
+        pageSize,
+        executionId,
+        dataSourceId,
+        caller,
+        callerReference,
+        operatorName,
+        status,
+        transactionMode,
+        statementType,
+        sqlFingerprint,
+        minDurationMs,
+        startedFrom,
+        startedTo);
+  }
+
+  private SqlExecutionAuditQuery(
+      Long projectId,
+      int pageNo,
+      int pageSize,
+      String executionId,
+      String dataSourceId,
+      SqlExecutionCaller caller,
+      String callerReference,
+      String operatorName,
+      SqlExecutionStatus status,
+      SqlTransactionMode transactionMode,
+      SqlStatementType statementType,
+      String sqlFingerprint,
+      Long minDurationMs,
+      LocalDateTime startedFrom,
+      LocalDateTime startedTo) {
+    this.projectId = projectId;
     this.pageNo = Math.max(1, pageNo);
     this.pageSize = Math.min(200, Math.max(1, pageSize));
     this.executionId = normalize(executionId);
@@ -55,6 +91,28 @@ public final class SqlExecutionAuditQuery {
     this.minDurationMs = minDurationMs == null ? null : Math.max(0L, minDurationMs);
     this.startedFrom = startedFrom;
     this.startedTo = startedTo;
+  }
+
+  public SqlExecutionAuditQuery scopedTo(Long projectId) {
+    if (projectId == null || projectId <= 0L) {
+      throw new IllegalArgumentException("projectId must be positive");
+    }
+    return new SqlExecutionAuditQuery(
+        projectId,
+        pageNo,
+        pageSize,
+        executionId,
+        dataSourceId,
+        caller,
+        callerReference,
+        operatorName,
+        status,
+        transactionMode,
+        statementType,
+        sqlFingerprint,
+        minDurationMs,
+        startedFrom,
+        startedTo);
   }
 
   private static String normalize(String value) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntime.java
@@ -20,6 +20,9 @@ import io.yak.ops.core.execution.sql.SqlStatementClassification;
 import io.yak.ops.core.execution.sql.SqlStatementClassifier;
 import io.yak.ops.core.execution.sql.SqlStatementRequest;
 import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import jakarta.annotation.PreDestroy;
 import java.sql.SQLTimeoutException;
 import java.util.ArrayList;
@@ -47,6 +50,8 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
   private final SqlExecutionGateway executionGateway;
   private final SqlStatementClassifier statementClassifier;
   private final SqlExecutionPolicy executionPolicy;
+  private final CurrentProject currentProject;
+  private final ProjectContextScope projectContextScope;
   private final ExecutorService lifecycleExecutor;
   private final ConcurrentMap<String, RuntimeExecution> executions = new ConcurrentHashMap<>();
   private final ConcurrentLinkedDeque<String> completedOrder = new ConcurrentLinkedDeque<>();
@@ -55,17 +60,47 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
   @Autowired
   public DefaultSqlExecutionRuntime(
       SqlExecutionGateway executionGateway,
+      SqlExecutionPolicy executionPolicy,
+      CurrentProject currentProject,
+      ProjectContextScope projectContextScope) {
+    this(
+        executionGateway,
+        new LexicalSqlStatementClassifier(),
+        executionPolicy,
+        currentProject,
+        projectContextScope);
+  }
+
+  /** Compatibility entry point for direct unit construction; Spring always uses the annotated one. */
+  public DefaultSqlExecutionRuntime(
+      SqlExecutionGateway executionGateway,
       SqlExecutionPolicy executionPolicy) {
-    this(executionGateway, new LexicalSqlStatementClassifier(), executionPolicy);
+    this(
+        executionGateway,
+        new LexicalSqlStatementClassifier(),
+        executionPolicy,
+        null,
+        null);
   }
 
   DefaultSqlExecutionRuntime(
       SqlExecutionGateway executionGateway,
       SqlStatementClassifier statementClassifier,
       SqlExecutionPolicy executionPolicy) {
+    this(executionGateway, statementClassifier, executionPolicy, null, null);
+  }
+
+  private DefaultSqlExecutionRuntime(
+      SqlExecutionGateway executionGateway,
+      SqlStatementClassifier statementClassifier,
+      SqlExecutionPolicy executionPolicy,
+      CurrentProject currentProject,
+      ProjectContextScope projectContextScope) {
     this.executionGateway = Objects.requireNonNull(executionGateway, "executionGateway");
     this.statementClassifier = Objects.requireNonNull(statementClassifier, "statementClassifier");
     this.executionPolicy = Objects.requireNonNull(executionPolicy, "executionPolicy");
+    this.currentProject = currentProject;
+    this.projectContextScope = projectContextScope;
     this.lifecycleExecutor = Executors.newVirtualThreadPerTaskExecutor();
   }
 
@@ -84,13 +119,19 @@ public final class DefaultSqlExecutionRuntime implements SqlExecutionRuntime {
       classifications.add(classifyAndValidate(plan.context(), statement.sql()));
     }
 
+    ProjectContext projectContext = currentProject == null ? null : currentProject.require();
     String executionId = "sql-" + UUID.randomUUID();
     SqlExecutionAggregate aggregate =
         new SqlExecutionAggregate(executionId, plan, classifications);
     RuntimeExecution execution = new RuntimeExecution(aggregate);
     executions.put(executionId, execution);
     try {
-      lifecycleExecutor.submit(() -> run(execution));
+      Runnable action = () -> run(execution);
+      if (projectContext != null && projectContextScope != null) {
+        lifecycleExecutor.submit(() -> projectContextScope.run(projectContext, action));
+      } else {
+        lifecycleExecutor.submit(action);
+      }
     } catch (RuntimeException exception) {
       execution.failBeforeStart(exception);
       retainCompleted(executionId);

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntime.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/ObservableSqlExecutionRuntime.java
@@ -14,6 +14,9 @@ import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
 import io.yak.ops.core.execution.sql.SqlStatementStatus;
 import io.yak.ops.core.execution.sql.SqlStatementType;
 import io.yak.ops.core.execution.sql.SqlTransactionMode;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import jakarta.annotation.PreDestroy;
 import java.sql.SQLTimeoutException;
 import java.time.Instant;
@@ -43,21 +46,39 @@ public final class ObservableSqlExecutionRuntime implements SqlExecutionRuntime 
 
   private final DefaultSqlExecutionRuntime delegate;
   private final List<SqlExecutionObserver> observers;
+  private final CurrentProject currentProject;
+  private final ProjectContextScope projectContextScope;
   private final LexicalSqlStatementClassifier classifier = new LexicalSqlStatementClassifier();
   private final ExecutorService tracker = Executors.newVirtualThreadPerTaskExecutor();
 
   @Autowired
   public ObservableSqlExecutionRuntime(
       DefaultSqlExecutionRuntime delegate,
-      ObjectProvider<SqlExecutionObserver> observers) {
-    this(delegate, observers.orderedStream().toList());
+      ObjectProvider<SqlExecutionObserver> observers,
+      CurrentProject currentProject,
+      ProjectContextScope projectContextScope) {
+    this(
+        delegate,
+        observers.orderedStream().toList(),
+        currentProject,
+        projectContextScope);
   }
 
   ObservableSqlExecutionRuntime(
       DefaultSqlExecutionRuntime delegate,
       List<SqlExecutionObserver> observers) {
+    this(delegate, observers, null, null);
+  }
+
+  private ObservableSqlExecutionRuntime(
+      DefaultSqlExecutionRuntime delegate,
+      List<SqlExecutionObserver> observers,
+      CurrentProject currentProject,
+      ProjectContextScope projectContextScope) {
     this.delegate = Objects.requireNonNull(delegate, "delegate");
     this.observers = observers == null ? List.of() : List.copyOf(observers);
+    this.currentProject = currentProject;
+    this.projectContextScope = projectContextScope;
   }
 
   @Override
@@ -126,13 +147,19 @@ public final class ObservableSqlExecutionRuntime implements SqlExecutionRuntime 
 
   @Override
   public SqlExecutionSnapshot start(SqlExecutionPlan plan) {
+    ProjectContext projectContext = currentProject == null ? null : currentProject.require();
     SqlExecutionSnapshot started = delegate.start(plan);
     if (started.terminal()) {
       notifyObservers(started);
       return started;
     }
     try {
-      tracker.submit(() -> notifyObservers(delegate.await(started.executionId())));
+      Runnable action = () -> notifyObservers(delegate.await(started.executionId()));
+      if (projectContext != null && projectContextScope != null) {
+        tracker.submit(() -> projectContextScope.run(projectContext, action));
+      } else {
+        tracker.submit(action);
+      }
     } catch (RuntimeException exception) {
       // Observability scheduling must not change the underlying execution lifecycle.
       log.warn(

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserver.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserver.java
@@ -9,6 +9,7 @@ import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
 import io.yak.ops.core.execution.sql.SqlFingerprint;
 import io.yak.ops.core.execution.sql.SqlStatementSnapshot;
 import io.yak.ops.core.execution.sql.SqlStatementStatus;
+import io.yak.ops.core.project.CurrentProject;
 import jakarta.annotation.PreDestroy;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -26,8 +27,9 @@ import org.springframework.stereotype.Component;
 /**
  * Persists completed SQL execution metadata without retaining result rows or bind parameters.
  *
- * <p>The bounded queue deliberately decouples audit I/O from user SQL latency. Saturation drops the
- * audit item and emits a warning rather than changing the SQL execution outcome.
+ * <p>The bounded queue deliberately decouples audit I/O from user SQL latency. Project ownership is
+ * captured before the audit batch crosses the async queue so ThreadLocal request context is never
+ * consulted by the background writer.
  */
 @Component
 @ConditionalOnDataSourceEnabled
@@ -38,10 +40,12 @@ public final class PersistentSqlExecutionObserver implements SqlExecutionObserve
   private static final int SQL_PREVIEW_LIMIT = 2048;
 
   private final SqlExecutionAuditStore store;
+  private final CurrentProject currentProject;
   private final ThreadPoolExecutor executor;
 
-  public PersistentSqlExecutionObserver(SqlExecutionAuditStore store) {
+  public PersistentSqlExecutionObserver(SqlExecutionAuditStore store, CurrentProject currentProject) {
     this.store = store;
+    this.currentProject = currentProject;
     this.executor = new ThreadPoolExecutor(
         2,
         2,
@@ -55,7 +59,20 @@ public final class PersistentSqlExecutionObserver implements SqlExecutionObserve
   @Override
   public void onExecutionCompleted(SqlExecutionSnapshot snapshot) {
     if (snapshot == null || !snapshot.terminal()) return;
-    AuditBatch batch = map(snapshot);
+
+    Long projectId = currentProject.current().map(context -> context.projectId()).orElse(null);
+    if (projectId == null || projectId <= 0L) {
+      // A successful datasource SQL execution should already have resolved a project-scoped
+      // DataSource. Persisting a global audit row would reopen the isolation boundary, so fail
+      // closed for observability and keep the SQL outcome untouched.
+      log.warn(
+          "SQL execution completed without Project Space; dropping audit: executionId={}, dataSourceId={}",
+          snapshot.executionId(),
+          snapshot.dataSourceId());
+      return;
+    }
+
+    AuditBatch batch = map(snapshot, projectId);
     try {
       executor.execute(() -> persist(batch));
     } catch (RejectedExecutionException exception) {
@@ -88,7 +105,12 @@ public final class PersistentSqlExecutionObserver implements SqlExecutionObserve
   }
 
   static AuditBatch map(SqlExecutionSnapshot snapshot) {
+    return map(snapshot, null);
+  }
+
+  static AuditBatch map(SqlExecutionSnapshot snapshot, Long projectId) {
     SqlExecutionAuditPO execution = new SqlExecutionAuditPO();
+    execution.setProjectId(projectId);
     execution.setExecutionId(snapshot.executionId());
     execution.setDataSourceId(snapshot.dataSourceId());
     execution.setCaller(snapshot.context().caller());

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/SqlExecutionAuditReader.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/execution/audit/SqlExecutionAuditReader.java
@@ -8,18 +8,21 @@ import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
 import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditQuery;
 import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditSummaryRow;
 import io.yak.ops.business.datasource.dao.model.SqlStatementExecutionAuditPO;
+import io.yak.ops.core.project.CurrentProject;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-/** SQL execution observability read-side role returning business projections. */
+/** SQL execution observability read-side role returning project-scoped business projections. */
 @Component
 @ConditionalOnDataSourceEnabled
 public class SqlExecutionAuditReader {
 
   private final SqlExecutionAuditDao auditDao;
+  private final CurrentProject currentProject;
 
-  public SqlExecutionAuditReader(SqlExecutionAuditDao auditDao) {
+  public SqlExecutionAuditReader(SqlExecutionAuditDao auditDao, CurrentProject currentProject) {
     this.auditDao = auditDao;
+    this.currentProject = currentProject;
   }
 
   public PageData<SqlExecutionAuditRecord> page(SqlExecutionAuditCriteria criteria) {
@@ -37,13 +40,17 @@ public class SqlExecutionAuditReader {
     if (executionId == null || executionId.isBlank()) {
       throw new IllegalArgumentException("executionId must not be blank");
     }
+    long projectId = currentProject.requireProjectId();
     String normalizedId = executionId.trim();
-    SqlExecutionAuditPO execution = auditDao.selectByExecutionId(normalizedId);
+    SqlExecutionAuditPO execution = auditDao.selectByExecutionId(projectId, normalizedId);
     if (execution == null) {
+      // Cross-project IDs deliberately look identical to an unknown ID.
       throw new IllegalArgumentException("SQL execution audit not found: " + normalizedId);
     }
     List<SqlStatementAuditRecord> statements =
-        auditDao.selectStatements(normalizedId).stream().map(this::statementRecord).toList();
+        auditDao.selectStatements(projectId, normalizedId).stream()
+            .map(this::statementRecord)
+            .toList();
     return new SqlExecutionAuditDetail(executionRecord(execution), statements);
   }
 
@@ -95,7 +102,8 @@ public class SqlExecutionAuditReader {
         value.sqlFingerprint(),
         value.minDurationMs(),
         value.startedFrom(),
-        value.startedTo());
+        value.startedTo())
+        .scopedTo(currentProject.requireProjectId());
   }
 
   private SqlExecutionAuditRecord executionRecord(SqlExecutionAuditPO row) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapter.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-/** MyBatis persistence adapter; persistence rehydration is explicit and cannot mutate aggregates via setters. */
+/** MyBatis persistence adapter; every business operation is scoped to the trusted CurrentProject. */
 @Repository
 @ConditionalOnDataSourceEnabled
 public class DataSourceRepositoryAdapter implements DataSourceRepository {
@@ -35,20 +35,23 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
     this.currentProject = currentProject;
   }
 
+  /** Test-only compatibility constructor. Calls still fail closed until a CurrentProject is supplied. */
   public DataSourceRepositoryAdapter(DataSourceDao dao) {
     this(dao, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
   public Optional<DataSourceDefinition> findById(Long id) {
-    Long projectId = currentProjectId();
-    DataSourcePO row = projectId == null ? dao.selectById(id) : dao.selectById(projectId, id);
-    return Optional.ofNullable(toDomain(row));
+    return Optional.ofNullable(toDomain(dao.selectById(currentProjectId(), id)));
   }
 
   @Override
   public boolean insert(DataSourceDefinition definition) {
-    currentProject.current().ifPresent(context -> definition.assignProject(context.projectId()));
+    long projectId = currentProjectId();
+    if (definition.getProjectId() != null && !Objects.equals(projectId, definition.getProjectId())) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+    definition.assignProject(projectId);
     return dao.addDataSource(toPO(definition)) > 0;
   }
 
@@ -60,16 +63,12 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
 
   @Override
   public boolean delete(Long id) {
-    Long projectId = currentProjectId();
-    return projectId == null ? dao.deleteById(id) : dao.deleteById(projectId, id);
+    return dao.deleteById(currentProjectId(), id);
   }
 
   @Override
   public boolean existsByName(String name, Long excludeId) {
-    Long projectId = currentProjectId();
-    return projectId == null
-        ? dao.existsByName(name, excludeId)
-        : dao.existsByName(projectId, name, excludeId);
+    return dao.existsByName(currentProjectId(), name, excludeId);
   }
 
   @Override
@@ -98,17 +97,12 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
 
   @Override
   public List<DataSourceDefinition> findAll(DataSourceDbType dbType) {
-    Long projectId = currentProjectId();
-    List<DataSourcePO> rows =
-        projectId == null ? dao.selectAll(dbType) : dao.selectAll(projectId, dbType);
-    return rows.stream().map(this::toDomain).toList();
+    return dao.selectAll(currentProjectId(), dbType).stream().map(this::toDomain).toList();
   }
 
   @Override
   public DataSourceSummary summary() {
-    Long projectId = currentProjectId();
-    DataSourceSummaryRow row =
-        projectId == null ? dao.selectSummary() : dao.selectSummary(projectId);
+    DataSourceSummaryRow row = dao.selectSummary(currentProjectId());
     return row == null
         ? DataSourceSummary.empty()
         : new DataSourceSummary(
@@ -121,23 +115,18 @@ public class DataSourceRepositoryAdapter implements DataSourceRepository {
 
   @Override
   public boolean updateConnectionStatus(Long id, DataSourceConnStatus status) {
-    Long projectId = currentProjectId();
-    return projectId == null
-        ? dao.updateConnectionStatus(id, status)
-        : dao.updateConnectionStatus(projectId, id, status);
+    return dao.updateConnectionStatus(currentProjectId(), id, status);
   }
 
-  private Long currentProjectId() {
-    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  private long currentProjectId() {
+    return currentProject.requireProjectId();
   }
 
   private void ensureCurrentProject(Long ownerProjectId) {
-    currentProject.current().ifPresent(
-        context -> {
-          if (!Objects.equals(context.projectId(), ownerProjectId)) {
-            throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
-          }
-        });
+    long projectId = currentProjectId();
+    if (ownerProjectId == null || !Objects.equals(projectId, ownerProjectId)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
   }
 
   private DataSourceDefinition toDomain(DataSourcePO po) {

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V2__add_project_scope_to_sql_execution.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V2__add_project_scope_to_sql_execution.sql
@@ -1,0 +1,7 @@
+-- Project Space Stage 2 expand migration.
+-- Existing rows are backfilled after Yak Security resolves the real default Project ID.
+
+ALTER TABLE yak_ops_sql_execution
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id,
+    ADD KEY idx_yak_ops_sql_execution_project_started (project_id, started_at),
+    ADD KEY idx_yak_ops_sql_execution_project_status_started (project_id, status, started_at);

--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/SqlExecutionAuditMapper.xml
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/mapper/datasource/SqlExecutionAuditMapper.xml
@@ -5,6 +5,7 @@
 <mapper namespace="io.yak.ops.business.datasource.dao.mapper.SqlExecutionAuditMapper">
 
     <sql id="ExecutionBaseFilters">
+        AND e.project_id = #{query.projectId}
         <if test="query.executionId != null">
             AND e.execution_id = #{query.executionId}
         </if>

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceFlywayContractTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceFlywayContractTest.java
@@ -21,17 +21,28 @@ class DataSourceFlywayContractTest {
   }
 
   @Test
-  void datasourceNamespaceContainsOnlyFirstReleaseBaseline() throws IOException {
+  void datasourceNamespaceContainsBaselineAndProjectScopeExpandMigration() throws IOException {
     assertThat(sqlFiles(migrationRoot()))
-        .containsExactly("V1__baseline_datasource.sql");
+        .containsExactly(
+            "V1__baseline_datasource.sql",
+            "V2__add_project_scope_to_sql_execution.sql");
 
-    String migration = Files.readString(migrationRoot().resolve("V1__baseline_datasource.sql"));
-    assertThat(migration)
+    String baseline = Files.readString(migrationRoot().resolve("V1__baseline_datasource.sql"));
+    assertThat(baseline)
         .contains("CREATE TABLE IF NOT EXISTS yak_ops_data_source")
         .contains("CREATE TABLE IF NOT EXISTS yak_ops_sql_execution")
         .contains("CREATE TABLE IF NOT EXISTS yak_ops_sql_statement_execution")
         .contains("project_id")
         .doesNotContain("ALTER TABLE");
+
+    String projectScope =
+        Files.readString(
+            migrationRoot().resolve("V2__add_project_scope_to_sql_execution.sql"));
+    assertThat(projectScope)
+        .contains("ALTER TABLE yak_ops_sql_execution")
+        .contains("ADD COLUMN project_id BIGINT NULL")
+        .contains("idx_yak_ops_sql_execution_project_started")
+        .contains("idx_yak_ops_sql_execution_project_status_started");
   }
 
   private List<String> sqlFiles(Path root) throws IOException {

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/controller/v1/DataSourceControllerPermissionTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/controller/v1/DataSourceControllerPermissionTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.common.constant.datasource.DataSourcePermissionCode;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +16,16 @@ class DataSourceControllerPermissionTest {
     assertPermission(DataSourceController.class, DataSourcePermissionCode.READ);
     assertPermission(DataSourceCatalogController.class, DataSourcePermissionCode.READ);
     assertPermission(DataSourcePluginConfigController.class, DataSourcePermissionCode.READ);
+  }
+
+  @Test
+  void shouldRequireProjectForDatasourceBusinessControllers() {
+    assertProjectMode(DataSourceController.class, ProjectMigrationMode.PROJECT_REQUIRED);
+    assertProjectMode(DataSourceCatalogController.class, ProjectMigrationMode.PROJECT_REQUIRED);
+    assertProjectMode(SqlExecutionAuditController.class, ProjectMigrationMode.PROJECT_REQUIRED);
+
+    // Connector/plugin definitions are platform capabilities rather than project-owned data.
+    assertThat(DataSourcePluginConfigController.class.getAnnotation(ProjectScope.class)).isNull();
   }
 
   @Test
@@ -43,5 +55,11 @@ class DataSourceControllerPermissionTest {
     RequiresPermission permission = method.getAnnotation(RequiresPermission.class);
     assertThat(permission).isNotNull();
     assertThat(permission.value()).isEqualTo(expected);
+  }
+
+  private void assertProjectMode(Class<?> controllerType, ProjectMigrationMode expected) {
+    ProjectScope projectScope = controllerType.getAnnotation(ProjectScope.class);
+    assertThat(projectScope).isNotNull();
+    assertThat(projectScope.value()).isEqualTo(expected);
   }
 }

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeProjectContextTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/DefaultSqlExecutionRuntimeProjectContextTest.java
@@ -1,0 +1,84 @@
+package io.yak.ops.business.datasource.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.yak.ops.business.datasource.gateway.adapter.SpiSqlExecutionGateway;
+import io.yak.ops.core.execution.sql.SqlExecutionCaller;
+import io.yak.ops.core.execution.sql.SqlExecutionContext;
+import io.yak.ops.core.execution.sql.SqlExecutionPlan;
+import io.yak.ops.core.execution.sql.SqlExecutionSnapshot;
+import io.yak.ops.core.execution.sql.SqlExecutionStatus;
+import io.yak.ops.core.execution.sql.SqlStatementRequest;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
+import io.yak.ops.spi.datasource.execution.DataSourceExecutionProvider;
+import io.yak.ops.spi.datasource.execution.DataSourceSqlResult;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class DefaultSqlExecutionRuntimeProjectContextTest {
+
+  @Test
+  void restoresCapturedProjectInsideAsyncExecutionThread() {
+    TestProjectRuntime projectRuntime = new TestProjectRuntime();
+    projectRuntime.bind(new ProjectContext(7L, "Project A"));
+
+    DataSourceExecutionProvider provider =
+        dataSourceId -> {
+          assertEquals(7L, projectRuntime.requireProjectId());
+          return request -> DataSourceSqlResult.resultSet(List.of(), List.of(), false);
+        };
+
+    DefaultSqlExecutionRuntime runtime =
+        new DefaultSqlExecutionRuntime(
+            new SpiSqlExecutionGateway(provider),
+            new DefaultSqlExecutionPolicy(),
+            projectRuntime,
+            projectRuntime);
+
+    SqlExecutionSnapshot started =
+        runtime.start(
+            new SqlExecutionPlan(
+                "42",
+                List.of(new SqlStatementRequest("select 1", 10, 30)),
+                SqlExecutionContext.of(SqlExecutionCaller.SQL_TASK, "task-project")));
+
+    projectRuntime.clear();
+    SqlExecutionSnapshot completed = runtime.await(started.executionId());
+    runtime.shutdown();
+
+    assertEquals(SqlExecutionStatus.SUCCEEDED, completed.status());
+  }
+
+  private static final class TestProjectRuntime implements CurrentProject, ProjectContextScope {
+    private final ThreadLocal<ProjectContext> holder = new ThreadLocal<>();
+
+    @Override
+    public Optional<ProjectContext> current() {
+      return Optional.ofNullable(holder.get());
+    }
+
+    @Override
+    public <T> T call(ProjectContext context, Supplier<T> action) {
+      ProjectContext previous = holder.get();
+      holder.set(context);
+      try {
+        return action.get();
+      } finally {
+        if (previous == null) holder.remove();
+        else holder.set(previous);
+      }
+    }
+
+    void bind(ProjectContext context) {
+      holder.set(context);
+    }
+
+    void clear() {
+      holder.remove();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserverTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/PersistentSqlExecutionObserverTest.java
@@ -52,8 +52,10 @@ class PersistentSqlExecutionObserverTest {
         finished,
         null);
 
-    PersistentSqlExecutionObserver.AuditBatch batch = PersistentSqlExecutionObserver.map(snapshot);
+    PersistentSqlExecutionObserver.AuditBatch batch =
+        PersistentSqlExecutionObserver.map(snapshot, 7L);
 
+    assertEquals(7L, batch.execution().getProjectId());
     assertEquals("bruce", batch.execution().getOperatorName());
     assertEquals(1L, batch.execution().getReturnedRows());
     assertEquals(1, batch.execution().getSucceededStatementCount());

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/SqlExecutionAuditReaderProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/execution/audit/SqlExecutionAuditReaderProjectScopeTest.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.datasource.execution.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import io.yak.ops.business.datasource.dao.SqlExecutionAuditDao;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditPO;
+import io.yak.ops.business.datasource.dao.model.SqlExecutionAuditQuery;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SqlExecutionAuditReaderProjectScopeTest {
+
+  @Mock private SqlExecutionAuditDao auditDao;
+
+  @Test
+  void injectsCurrentProjectIntoAuditPageQuery() {
+    Page<SqlExecutionAuditPO> page = Page.of(1, 20);
+    page.setRecords(List.of());
+    page.setTotal(0L);
+    when(auditDao.selectPage(any(SqlExecutionAuditQuery.class))).thenReturn(page);
+
+    SqlExecutionAuditReader reader = new SqlExecutionAuditReader(auditDao, project(7L));
+    reader.page(null);
+
+    ArgumentCaptor<SqlExecutionAuditQuery> queryCaptor =
+        ArgumentCaptor.forClass(SqlExecutionAuditQuery.class);
+    verify(auditDao).selectPage(queryCaptor.capture());
+    assertThat(queryCaptor.getValue().getProjectId()).isEqualTo(7L);
+  }
+
+  @Test
+  void rejectsAuditReadsWithoutCurrentProject() {
+    CurrentProject missingProject = Optional::empty;
+    SqlExecutionAuditReader reader = new SqlExecutionAuditReader(auditDao, missingProject);
+
+    assertThatThrownBy(() -> reader.page(null))
+        .isInstanceOf(ProjectContextException.class);
+  }
+
+  private static CurrentProject project(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "Project " + projectId));
+  }
+}

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/repository/DataSourceRepositoryAdapterTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.datasource.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -14,6 +15,7 @@ import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import io.yak.ops.common.enums.datasource.DataSourceEnvironment;
 import io.yak.ops.core.project.CurrentProject;
 import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,17 +31,21 @@ class DataSourceRepositoryAdapterTest {
   void mapsPersistenceRowToDomainIncludingRuntimeConnectionData() {
     DataSourcePO po = new DataSourcePO();
     po.setId(42L);
+    po.setProjectId(7L);
     po.setName("orders-db");
     po.setDbType(DataSourceDbType.MYSQL);
     po.setEnvironment(DataSourceEnvironment.PROD);
     po.setConnStatus(DataSourceConnStatus.CONNECTED);
     po.setConnectionParams("{\"host\":\"127.0.0.1\"}");
     po.setOriginalJson("{\"host\":\"127.0.0.1\"}");
-    when(dao.selectById(42L)).thenReturn(po);
+    CurrentProject currentProject = project(7L);
+    when(dao.selectById(7L, 42L)).thenReturn(po);
 
-    DataSourceDefinition result = new DataSourceRepositoryAdapter(dao).findById(42L).orElseThrow();
+    DataSourceDefinition result =
+        new DataSourceRepositoryAdapter(dao, currentProject).findById(42L).orElseThrow();
 
     assertThat(result.getId()).isEqualTo(42L);
+    assertThat(result.getProjectId()).isEqualTo(7L);
     assertThat(result.getDbType()).isEqualTo(DataSourceDbType.MYSQL);
     assertThat(result.getEnvironment()).isEqualTo(DataSourceEnvironment.PROD);
     assertThat(result.getConnStatus()).isEqualTo(DataSourceConnStatus.CONNECTED);
@@ -52,7 +58,7 @@ class DataSourceRepositoryAdapterTest {
     po.setId(42L);
     po.setProjectId(7L);
     po.setName("orders-db");
-    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    CurrentProject currentProject = project(7L);
     when(dao.selectById(7L, 42L)).thenReturn(po);
 
     DataSourceDefinition result =
@@ -63,21 +69,32 @@ class DataSourceRepositoryAdapterTest {
   }
 
   @Test
-  void mapsDaoSummaryProjectionToDomain() {
+  void mapsProjectQualifiedSummaryProjectionToDomain() {
     DataSourceSummaryRow row = new DataSourceSummaryRow();
     row.setTotal(8L);
     row.setConnected(5L);
     row.setDisconnected(2L);
     row.setUnknown(1L);
     row.setEnvironmentCount(3L);
-    when(dao.selectSummary()).thenReturn(row);
+    when(dao.selectSummary(7L)).thenReturn(row);
 
-    DataSourceSummary result = new DataSourceRepositoryAdapter(dao).summary();
+    DataSourceSummary result = new DataSourceRepositoryAdapter(dao, project(7L)).summary();
 
     assertThat(result.total()).isEqualTo(8L);
     assertThat(result.connected()).isEqualTo(5L);
     assertThat(result.disconnected()).isEqualTo(2L);
     assertThat(result.unknown()).isEqualTo(1L);
     assertThat(result.environmentCount()).isEqualTo(3L);
+    verify(dao).selectSummary(7L);
+  }
+
+  @Test
+  void rejectsBusinessReadsWithoutCurrentProject() {
+    assertThatThrownBy(() -> new DataSourceRepositoryAdapter(dao).findById(42L))
+        .isInstanceOf(ProjectContextException.class);
+  }
+
+  private static CurrentProject project(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "Project " + projectId));
   }
 }

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -16,8 +16,11 @@ const rules: ProjectRequestRule[] = [
 describe('Project Space request context', () => {
   afterEach(() => clearStoredProjectId());
 
-  it('keeps transitional routes optional while strong management planes require a project', () => {
-    expect(resolveProjectRequestMode('/api/v1/data-source')).toBe('PROJECT_OPTIONAL');
+  it('requires a project for datasource and other completed project planes', () => {
+    expect(resolveProjectRequestMode('/api/v1/data-source')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/data-source/1')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/data-source/catalog/1/tables')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/sql-executions/page')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/resources/tree')).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/datasets/1')).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/home/cockpit')).toBe('PROJECT_REQUIRED');
@@ -33,7 +36,9 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/workflows/definitions')).toBe('PROJECT_OPTIONAL');
   });
 
-  it('keeps public data service invocation outside the project management plane', () => {
+  it('keeps datasource plugin metadata and public data service runtime global', () => {
+    expect(resolveProjectRequestMode('/api/v1/data-source/plugin/config?pluginType=MYSQL')).toBe('LEGACY_GLOBAL');
+    expect(resolveProjectRequestMode('/api/v1/data-source/plugin/config/install')).toBe('LEGACY_GLOBAL');
     expect(resolveProjectRequestMode('/api/v1/data-service/runtime/orders')).toBe('LEGACY_GLOBAL');
     expect(resolveProjectRequestMode('/api/v1/data-service/runtime/orders/by-id')).toBe('LEGACY_GLOBAL');
   });
@@ -51,6 +56,8 @@ describe('Project Space request context', () => {
   it('never attaches a project header to a legacy-global route', () => {
     const headers = applyCurrentProjectHeader('/api/v1/compute-environments', {}, '7');
     expect(headers).toEqual({});
+    const pluginHeaders = applyCurrentProjectHeader('/api/v1/data-source/plugin/config', {}, '7');
+    expect(pluginHeaders).toEqual({});
     const runtimeHeaders = applyCurrentProjectHeader('/api/v1/data-service/runtime/orders', {}, '7');
     expect(runtimeHeaders).toEqual({});
   });
@@ -59,6 +66,12 @@ describe('Project Space request context', () => {
     storeProjectId(7);
     expect(readStoredProjectId()).toBe('7');
 
+    expect(applyCurrentProjectHeader('/api/v1/data-source/42', {})).toEqual({
+      [PROJECT_ID_HEADER]: '7',
+    });
+    expect(applyCurrentProjectHeader('/api/v1/sql-executions/page', {})).toEqual({
+      [PROJECT_ID_HEADER]: '7',
+    });
     expect(applyCurrentProjectHeader('/api/v1/home/cockpit', {})).toEqual({
       [PROJECT_ID_HEADER]: '7',
     });

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -13,7 +13,10 @@ export type ProjectRequestRule = {
 
 /** Project-aware API rollout table kept in lockstep with backend @ProjectScope adoption. */
 export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
-  { prefix: '/api/v1/data-source', mode: 'PROJECT_OPTIONAL' },
+  // Connector/plugin definitions are platform capabilities shared by every workspace.
+  { prefix: '/api/v1/data-source/plugin/config', mode: 'LEGACY_GLOBAL' },
+  { prefix: '/api/v1/data-source', mode: 'PROJECT_REQUIRED' },
+  { prefix: '/api/v1/sql-executions', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/resources', mode: 'PROJECT_OPTIONAL' },
   { prefix: '/api/v1/datasets', mode: 'PROJECT_OPTIONAL' },
   { prefix: '/api/v1/home', mode: 'PROJECT_REQUIRED' },


### PR DESCRIPTION
## 背景

Stage 1（#869）已经完成工作空间产品入口、Header 切换和工作空间管理闭环。Stage 2 只选择 DataSource 做第一条完整的 Project Space 数据隔离样板链路，不横向扩到 Dataset / Resource / Offline / Realtime。

目标是把 DataSource 从迁移态 `PROJECT_OPTIONAL` 推进到业务面的 `PROJECT_REQUIRED`，并同时覆盖 Catalog、已保存连接测试、SQL 执行及 SQL Execution Audit，避免只隔离列表却留下详情、执行或审计旁路。

## 本 PR 做了什么

### 1. DataSource 业务面切换到 PROJECT_REQUIRED

- `DataSourceController` -> `PROJECT_REQUIRED`
- `DataSourceCatalogController` -> `PROJECT_REQUIRED`
- `SqlExecutionAuditController` -> `PROJECT_REQUIRED`
- 前端 `/api/v1/data-source/**` 和 `/api/v1/sql-executions/**` 统一注入 `X-YAK-SECURITY-PROJECT-ID`
- DataSource Plugin/Connector 配置继续保持 `GLOBAL`，通过更具体的 `/api/v1/data-source/plugin/config` 规则排除 Project Header

这样缺少工作空间的 DataSource 管理请求直接返回 `PROJECT_REQUIRED`，而插件定义仍是平台级能力。

### 2. DataSource Repository 改为 fail-closed

`DataSourceRepositoryAdapter` 不再接受“没有 CurrentProject 时退回全局查询”的正常业务路径：

- 创建：`project_id` 只来自可信 `CurrentProject`
- 列表 / 分页 / summary / option：按当前 Project 查询
- 详情：`project_id + id` 双条件
- 编辑 / 删除 /连接状态更新：`project_id + id` 双条件
- 名称唯一：按当前 Project 判断
- 请求体或领域对象携带其他 Project ID 时拒绝

因此在 Project A 手工替换成 Project B 的 datasourceId，对外只表现为“当前工作空间下不存在该数据源”。

### 3. 历史 DataSource 回填默认工作空间

新增 `DataSourceProjectCompatibilityBackfill`：

- 等待 Datasource Flyway 完成后执行
- 通过 `ProjectCompatibilityCoordinator.ensureRequiredDefaultProject()` 获取真实默认 Project ID
- 历史 `yak_ops_data_source.project_id IS NULL` 全部回填默认工作空间
- 不在 SQL 中硬编码 `project_id = 1`
- ApplicationReady 阶段校验不存在未归属 DataSource

### 4. SQL Execution Audit 纳入工作空间隔离

SQL 执行历史会包含 datasourceId、operator、SQL fingerprint / redacted preview 等业务信息，因此也属于 Project 数据边界。

本 PR：

- `yak_ops_sql_execution` 增加 nullable `project_id` expand migration
- 新 SQL Audit 在执行完成时持久化当前 Project ID
- page / summary / P95 / statement type 统计全部强制 `project_id`
- execution detail 先校验 execution 属于当前 Project，再读取 statement 明细
- 跨 Project executionId 与不存在的 executionId 使用相同不可见语义
- 历史 Audit 优先按关联 DataSource 推导 Project；无法推导的旧记录回填默认工作空间

### 5. 修复异步 SQL 执行丢失 Project Context

`DefaultSqlExecutionRuntime.start()` 和 `ObservableSqlExecutionRuntime.start()` 会进入虚拟线程，而 Project Context 当前基于普通 ThreadLocal，不能依赖线程继承。

本 PR 在提交异步任务前捕获 `ProjectContext`，并通过现有 `ProjectContextScope` 在虚拟线程中显式恢复：

```text
HTTP CurrentProject
      ↓ capture
virtual thread
      ↓ ProjectContextScope.run(...)
DataSource resolve / SQL execute / audit
```

没有改成 `InheritableThreadLocal`，避免上下文在线程复用场景中泄漏。

### 6. 暂留 DataSourceDao 的 legacy 后台兼容通道

这里是本 PR 一个刻意保留的迁移边界，不是遗漏。

当前 Offline Sync 的后台调度会在没有 HTTP Project Context 的情况下，通过 `LinkUpJobSpecFactory -> DataSourceDao.selectById(id)` 恢复已经持久化的数据源引用。Realtime 也仍处在 Project 迁移阶段。

因此 Stage 2 的边界是：

```text
对外 Controller / Repository
    -> 100% Project REQUIRED / fail-closed

底层 DataSourceDao
    -> 有 CurrentProject：严格按 Project 过滤
    -> 无 CurrentProject：暂保留 legacy 后台按显式 ID 解析
```

这条 DAO corridor 不能被新的业务 API 使用。等 Offline / Realtime 后续完成 project_id 持久化和后台 `ProjectContextScope` 恢复后，再删除这条兼容通道。

如果本 PR 直接把 DAO 也完全 fail-closed，会让现有定时离线同步在后台执行时直接触发 `PROJECT_REQUIRED`，属于迁移顺序错误。

### 7. 为什么本 PR 没有立刻把数据库列改成 NOT NULL

这是 Expand -> Backfill -> Contract 的部署顺序要求。

Flyway 执行时还无法安全获得 Yak Security 的真实默认 Project ID，因此不能在同一个 SQL migration 中完成：

```text
ADD project_id NOT NULL
+ 历史数据回填真实默认 Project
```

本 PR 采用：

1. Flyway Expand：列允许 NULL
2. ApplicationReady：通过 Project Service 获取真实 defaultProjectId
3. Backfill
4. 启动校验：DataSource / SQL Audit 均不允许残留 NULL
5. Runtime / API：已经按 REQUIRED 运行
6. 后续 Contract migration：在已经运行过 backfill 的数据库上物理收紧 `NOT NULL`

这样避免硬编码默认 Project ID，也避免升级数据库因历史 NULL 行直接启动失败。

## 测试补充

新增/增强测试覆盖：

- DataSource / Catalog / SQL Audit Controller 的 `PROJECT_REQUIRED` 契约
- Plugin Config 保持 GLOBAL
- 前端 DataSource / SQL Audit Project Header 路由
- DataSource Repository 无 Project 时 fail-closed
- Repository project-qualified detail / summary
- SQL Audit Query 自动注入当前 Project
- SQL Audit 缺 Project 拒绝查询
- SQL Audit 持久化 projectId
- SQL redacted preview 仍保持脱敏
- 虚拟线程异步 SQL 显式恢复 Project Context
- Datasource Flyway V2 project-scope migration 契约

## 建议本地验证

```bash
mvn -pl yak-ops-business/yak-ops-business-datasource -am test
mvn -pl yak-ops-boot -am test

cd yak-ops-ui
npm test -- src/utils/security/projectContext.test.ts
npm run lint
```

当前通过 GitHub connector 无法执行本地 Maven / npm，因此本 PR 保持 Draft；当前 head 也没有检测到 GitHub Actions workflow run / commit status。

## 最小手工回归

1. Project A / Project B 分别创建同名数据源，均成功
2. A 列表看不到 B 的数据源
3. 在 A 中手改 URL 使用 B datasourceId：详情 / 编辑 / 删除 / connect-test / Catalog 均失败
4. 不带 Project Header 请求 DataSource API：返回 `PROJECT_REQUIRED`
5. Header 切换 A -> B 后，数据源列表同步切换
6. SQL 执行历史只能看到当前工作空间的记录
7. A 使用 B 的 executionId 查询 SQL Audit：表现为当前工作空间下不存在
8. 异步 SQL execution 在调用线程退出/清理 Context 后仍能在虚拟线程恢复正确 Project
9. DataSource plugin config 在无 Project Header 时仍正常工作
10. 使用有历史数据的数据库升级，确认启动日志出现 DataSource Project Space backfill complete，且不存在未归属行
11. 现有 Offline Sync 定时任务仍能解析已持久化 datasourceId，不因 Stage 2 直接触发 `PROJECT_REQUIRED`

## 明确不在 Stage 2 范围

- Dataset / File Resource 项目化
- Offline / Realtime 全链路 `PROJECT_REQUIRED`
- Workflow / Quality / Dashboard 项目化
- Project 内角色覆盖 / 资源级授权
- DataSource/SQL Audit 数据库物理 `NOT NULL` Contract migration（待 backfill 版本实际运行后收紧）
- 删除 DataSourceDao legacy background corridor（待 Offline / Realtime 后台上下文恢复后删除）
