### PR TITLE
feat(project-space): 完成 Stage 2.1 数据源 Project Contract

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V3__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-datasource/src/main/resources/db/migration/yak-datasource/V3__contract_project_scope.sql
@@ -1,0 +1,11 @@
+-- Project Space Stage 2.1 contract migration.
+--
+-- Deployment precondition: the Stage 2 application backfill must have completed successfully.
+-- This migration intentionally performs no implicit backfill and never guesses a default Project ID.
+-- If legacy NULL rows still exist, MySQL rejects the NOT NULL ALTER and the deployment stops.
+
+ALTER TABLE yak_ops_data_source
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';
+
+ALTER TABLE yak_ops_sql_execution
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';

--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceFlywayContractTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceFlywayContractTest.java
@@ -21,11 +21,12 @@ class DataSourceFlywayContractTest {
   }
 
   @Test
-  void datasourceNamespaceContainsBaselineAndProjectScopeExpandMigration() throws IOException {
+  void datasourceNamespaceContainsExpandAndContractProjectScopeMigrations() throws IOException {
     assertThat(sqlFiles(migrationRoot()))
         .containsExactly(
             "V1__baseline_datasource.sql",
-            "V2__add_project_scope_to_sql_execution.sql");
+            "V2__add_project_scope_to_sql_execution.sql",
+            "V3__contract_project_scope.sql");
 
     String baseline = Files.readString(migrationRoot().resolve("V1__baseline_datasource.sql"));
     assertThat(baseline)
@@ -35,14 +36,24 @@ class DataSourceFlywayContractTest {
         .contains("project_id")
         .doesNotContain("ALTER TABLE");
 
-    String projectScope =
+    String projectScopeExpand =
         Files.readString(
             migrationRoot().resolve("V2__add_project_scope_to_sql_execution.sql"));
-    assertThat(projectScope)
+    assertThat(projectScopeExpand)
         .contains("ALTER TABLE yak_ops_sql_execution")
         .contains("ADD COLUMN project_id BIGINT NULL")
         .contains("idx_yak_ops_sql_execution_project_started")
         .contains("idx_yak_ops_sql_execution_project_status_started");
+
+    String projectScopeContract =
+        Files.readString(migrationRoot().resolve("V3__contract_project_scope.sql"));
+    assertThat(projectScopeContract)
+        .contains("ALTER TABLE yak_ops_data_source")
+        .contains("ALTER TABLE yak_ops_sql_execution")
+        .contains("MODIFY COLUMN project_id BIGINT NOT NULL")
+        .contains("performs no implicit backfill")
+        .doesNotContain("UPDATE yak_ops_data_source")
+        .doesNotContain("UPDATE yak_ops_sql_execution");
   }
 
   private List<String> sqlFiles(Path root) throws IOException {


### PR DESCRIPTION
## 背景

Stage 2（#870）已经把 DataSource 业务面切换到 `PROJECT_REQUIRED`，并在 ApplicationReady 阶段完成历史 DataSource / SQL Execution Audit 的 Project backfill。

Stage 2.1 只做一件事：在 Stage 2 backfill 已经实际运行并验证干净之后，把数据库层的 `project_id` 从逻辑必填收紧为物理 `NOT NULL`。

本 PR 不新增业务能力，不修改 Controller / Repository / Backfill / 前端，也不处理 Offline / Realtime。

## 改动范围

仅 2 个文件：

1. 新增 `V3__contract_project_scope.sql`
2. 更新 `DataSourceFlywayContractTest`

### Contract migration

```sql
ALTER TABLE yak_ops_data_source
    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';

ALTER TABLE yak_ops_sql_execution
    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';
```

收紧对象只有：

- `yak_ops_data_source.project_id`
- `yak_ops_sql_execution.project_id`

`yak_ops_sql_statement_execution` 仍通过 execution 继承项目归属，不新增重复 `project_id`。

## 重要：部署前置条件

**本 PR 不允许替代 Stage 2 backfill。**

Flyway 在 ApplicationReady 之前执行，因此如果一个历史数据库从 Stage 1 直接跳过 Stage 2 运行态版本进入本 migration，历史 NULL 行会导致 `ALTER ... NOT NULL` 失败。

这是刻意的 fail-fast 行为，不做以下任何兜底：

- 不硬编码 `project_id = 1`
- 不猜测默认 Project
- 不在 migration 中偷偷 UPDATE 历史数据
- 不把 NULL 转成 0

合并/部署 Stage 2.1 前，应至少让 #870 对一个已有历史数据的数据库成功启动过一次，并确认：

```sql
SELECT COUNT(*) FROM yak_ops_data_source WHERE project_id IS NULL;
SELECT COUNT(*) FROM yak_ops_sql_execution WHERE project_id IS NULL;
```

两者都必须为 `0`。

如果仍有 NULL，本 V3 应该失败，而不是掩盖迁移顺序问题。

## 为什么保持这么小

Stage 2.1 是 Expand -> Backfill -> Contract 的 Contract 阶段，不再改运行时逻辑：

```text
Stage 2
  Expand(nullable)
      ↓
  ApplicationReady Backfill
      ↓
  Runtime PROJECT_REQUIRED

Stage 2.1
      ↓
  DB NOT NULL Contract
```

DataSourceDao 的 legacy background corridor 仍保留，等 Offline / Realtime 后续完成后台 Project Context 恢复后再单独删除，不在本 PR 顺手扩大范围。

## 测试

`DataSourceFlywayContractTest` 增加以下契约：

- migration 顺序固定为 V1 -> V2 -> V3
- V2 仍是 nullable Expand
- V3 同时收紧 DataSource / SQL Execution
- V3 必须包含 `BIGINT NOT NULL`
- V3 不允许出现对两张业务表的历史 UPDATE backfill

建议本地执行：

```bash
mvn -pl yak-ops-business/yak-ops-business-datasource -am test
```

并在一个已经运行过 #870 的历史数据库上启动验证 Flyway V3。

当前 connector 未检测到 GitHub Actions workflow run / commit status，因此保持 Draft。

## 合并门槛

- [ ] #870 已在至少一个历史数据库成功启动
- [ ] `yak_ops_data_source.project_id IS NULL` 数量为 0
- [ ] `yak_ops_sql_execution.project_id IS NULL` 数量为 0
- [ ] Datasource Maven tests 通过
- [ ] V3 在该历史数据库成功执行
