### PR TITLE
feat(project-space): 完成 Stage 3.1 Resource 工作空间隔离

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ResourceProjectCompatibilityBackfill.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ResourceProjectCompatibilityBackfill.java
@@ -1,0 +1,98 @@
+package io.yak.ops.boot.project;
+
+import io.yak.ops.business.resource.config.ConditionalOnResourceEnabled;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/** Completes the Resource Project Space cutover after the existing V2 expand migration. */
+@Component
+@DependsOn("opsResourceFlyway")
+@ConditionalOnResourceEnabled
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class ResourceProjectCompatibilityBackfill {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ResourceProjectCompatibilityBackfill.class);
+
+  private final ProjectCompatibilityCoordinator projectCoordinator;
+  private final JdbcTemplate jdbcTemplate;
+
+  public ResourceProjectCompatibilityBackfill(
+      ProjectCompatibilityCoordinator projectCoordinator,
+      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+    this.projectCoordinator = projectCoordinator;
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void backfillLegacyRows() {
+    long defaultProjectId = projectCoordinator.ensureRequiredDefaultProject();
+
+    int inheritedRows = inheritProjectFromParents();
+    int defaultRows =
+        jdbcTemplate.update(
+            "UPDATE yak_ops_resource SET project_id = ? WHERE project_id IS NULL",
+            defaultProjectId);
+
+    assertNoUnscopedRows();
+    assertNoCrossProjectParentLinks();
+
+    LOGGER.info(
+        "Resource Project Space backfill complete: defaultProjectId={}, inheritedRows={}, defaultRows={}",
+        defaultProjectId,
+        inheritedRows,
+        defaultRows);
+  }
+
+  private int inheritProjectFromParents() {
+    int total = 0;
+    int updated;
+    do {
+      updated =
+          jdbcTemplate.update(
+              "UPDATE yak_ops_resource child "
+                  + "JOIN yak_ops_resource parent ON child.parent_id = parent.id "
+                  + "SET child.project_id = parent.project_id "
+                  + "WHERE child.project_id IS NULL AND parent.project_id IS NOT NULL");
+      total += updated;
+    } while (updated > 0);
+    return total;
+  }
+
+  private void assertNoUnscopedRows() {
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(1) FROM yak_ops_resource WHERE project_id IS NULL", Long.class);
+    if (count != null && count > 0L) {
+      throw new IllegalStateException(
+          "Resource Project Space cutover left " + count + " unscoped resource rows");
+    }
+  }
+
+  private void assertNoCrossProjectParentLinks() {
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(1) FROM yak_ops_resource child "
+                + "JOIN yak_ops_resource parent ON child.parent_id = parent.id "
+                + "WHERE child.parent_id <> 0 AND child.project_id <> parent.project_id",
+            Long.class);
+    if (count != null && count > 0L) {
+      throw new IllegalStateException(
+          "Resource Project Space cutover found "
+              + count
+              + " cross-project parent-child resource links");
+    }
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ResourceProjectCompatibilityBackfillContractTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ResourceProjectCompatibilityBackfillContractTest.java
@@ -1,0 +1,31 @@
+package io.yak.ops.boot.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ResourceProjectCompatibilityBackfillContractTest {
+
+  @Test
+  void legacyResourcesInheritParentProjectBeforeDefaultFallback() throws Exception {
+    String source = Files.readString(source());
+    assertThat(source)
+        .contains("JOIN yak_ops_resource parent ON child.parent_id = parent.id")
+        .contains("SET child.project_id = parent.project_id")
+        .contains("WHERE child.project_id IS NULL AND parent.project_id IS NOT NULL")
+        .contains("UPDATE yak_ops_resource SET project_id = ? WHERE project_id IS NULL")
+        .contains("SELECT COUNT(1) FROM yak_ops_resource WHERE project_id IS NULL")
+        .contains("child.project_id <> parent.project_id")
+        .contains("ensureRequiredDefaultProject()");
+  }
+
+  private Path source() {
+    Path local = Path.of(
+        "src/main/java/io/yak/ops/boot/project/ResourceProjectCompatibilityBackfill.java");
+    if (Files.isRegularFile(local)) return local;
+    return Path.of(
+        "yak-ops-boot/src/main/java/io/yak/ops/boot/project/ResourceProjectCompatibilityBackfill.java");
+  }
+}

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/controller/v1/ResourcesController.java
@@ -59,7 +59,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/resources")
 @RequiresPermission(ResourcePermissionCode.READ)
-@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
+@ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)
 public class ResourcesController {
 
   private final ResourceNamespaceManager namespaceManager;
@@ -184,6 +184,7 @@ public class ResourcesController {
 
   @Operation(summary = "查询已安装存储插件")
   @GetMapping("/storage-plugins")
+  @ProjectScope(ProjectMigrationMode.LEGACY_GLOBAL)
   public Result<List<ResourceStoragePluginVO>> storagePlugins() {
     return Result.success(storageReader.list().stream().map(viewConverter::storagePlugin).toList());
   }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/ResourceDao.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/ResourceDao.java
@@ -12,6 +12,8 @@ public interface ResourceDao {
 
   boolean update(ResourcePO resourcePO);
 
+  boolean update(Long projectId, ResourcePO resourcePO);
+
   ResourcePO selectById(Long id);
 
   ResourcePO selectById(Long projectId, Long id);
@@ -40,6 +42,8 @@ public interface ResourceDao {
   IPage<ResourcePO> selectPage(PageQuery query);
 
   boolean updateBatch(List<ResourcePO> resources);
+
+  boolean updateBatch(Long projectId, List<ResourcePO> resources);
 
   boolean deleteBatch(List<Long> ids);
 

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/dao/impl/ResourceDaoImpl.java
@@ -10,17 +10,19 @@ import io.yak.ops.business.resource.dao.mapper.ResourceMapper;
 import io.yak.ops.common.bean.po.resource.ResourcePO;
 import java.util.Collections;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 /** 基于 MyBatis-Plus 的资源数据访问实现。 */
 @Repository
 @ConditionalOnResourceEnabled
-@RequiredArgsConstructor
 public class ResourceDaoImpl implements ResourceDao {
 
   private final ResourceMapper resourceMapper;
+
+  public ResourceDaoImpl(ResourceMapper resourceMapper) {
+    this.resourceMapper = resourceMapper;
+  }
 
   @Override
   public int insert(ResourcePO resourcePO) {
@@ -30,6 +32,18 @@ public class ResourceDaoImpl implements ResourceDao {
   @Override
   public boolean update(ResourcePO resourcePO) {
     return resourcePO != null && resourceMapper.updateById(resourcePO) > 0;
+  }
+
+  @Override
+  public boolean update(Long projectId, ResourcePO resourcePO) {
+    if (projectId == null || resourcePO == null || resourcePO.getId() == null) return false;
+    resourcePO.setProjectId(projectId);
+    return resourceMapper.update(
+            resourcePO,
+            Wrappers.<ResourcePO>lambdaUpdate()
+                .eq(ResourcePO::getProjectId, projectId)
+                .eq(ResourcePO::getId, resourcePO.getId()))
+        > 0;
   }
 
   @Override
@@ -160,6 +174,16 @@ public class ResourceDaoImpl implements ResourceDao {
     if (resources == null || resources.isEmpty()) return true;
     for (ResourcePO resource : resources) {
       if (resourceMapper.updateById(resource) <= 0) return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean updateBatch(Long projectId, List<ResourcePO> resources) {
+    if (resources == null || resources.isEmpty()) return true;
+    if (projectId == null) return false;
+    for (ResourcePO resource : resources) {
+      if (!update(projectId, resource)) return false;
     }
     return true;
   }

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceParentResolver.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/namespace/ResourceParentResolver.java
@@ -39,7 +39,7 @@ public class ResourceParentResolver {
   public Parent resolve(Long parentId) {
     long normalized = normalize(parentId);
     if (normalized == 0L) {
-      Long projectId = currentProject.current().map(context -> context.projectId()).orElse(null);
+      Long projectId = currentProject.requireProjectId();
       return new Parent(0L, "/", storage.defaultType(), projectId);
     }
     ResourceNode parent =
@@ -47,6 +47,10 @@ public class ResourceParentResolver {
             .orElseThrow(() -> new ResourceException(ResourceErrorCode.PARENT_NOT_FOUND));
     if (parent.getNodeType() != ResourceNodeType.DIRECTORY) {
       throw new ResourceException(ResourceErrorCode.PARENT_NOT_DIRECTORY);
+    }
+    Long projectId = currentProject.requireProjectId();
+    if (!projectId.equals(parent.getProjectId())) {
+      throw new ResourceException(ResourceErrorCode.PARENT_NOT_FOUND);
     }
     return new Parent(
         parent.getId(), parent.getFullPath(), parent.getStorageType(), parent.getProjectId());

--- a/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-resource/src/main/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapter.java
@@ -38,6 +38,10 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
   @Override
   public Optional<ResourceNode> findById(Long id) {
     Long projectId = currentProjectId();
+    // Temporary read-only runtime corridor: ResourceResolver can still be entered by legacy task
+    // runtimes that have not restored ProjectContext yet. HTTP Resource APIs are PROJECT_REQUIRED,
+    // and every broad query/mutation below is fail-closed. Remove this fallback after task runtime
+    // project restoration is complete.
     ResourcePO row =
         projectId == null ? resourceDao.selectById(id) : resourceDao.selectById(projectId, id);
     return Optional.ofNullable(row).map(this::toDomain);
@@ -45,30 +49,21 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
 
   @Override
   public Optional<ResourceNode> findByFullPath(String fullPath) {
-    Long projectId = currentProjectId();
-    ResourcePO row =
-        projectId == null
-            ? resourceDao.selectByFullPath(fullPath)
-            : resourceDao.selectByFullPath(projectId, fullPath);
-    return Optional.ofNullable(row).map(this::toDomain);
+    long projectId = requireProjectId();
+    return Optional.ofNullable(resourceDao.selectByFullPath(projectId, fullPath)).map(this::toDomain);
   }
 
   @Override
   public boolean existsByParentAndName(Long parentId, String name, Long excludeId) {
-    Long projectId = currentProjectId();
-    return projectId == null
-        ? resourceDao.existsByParentAndName(parentId, name, excludeId)
-        : resourceDao.existsByParentAndName(projectId, parentId, name, excludeId);
+    return resourceDao.existsByParentAndName(requireProjectId(), parentId, name, excludeId);
   }
 
   @Override
   public boolean insert(ResourceNode resource) {
     if (resource == null) return false;
-    currentProject.current().ifPresent(
-        context -> {
-          ensureCurrentProject(resource.getProjectId());
-          resource.setProjectId(context.projectId());
-        });
+    long projectId = requireProjectId();
+    ensureCurrentProject(resource.getProjectId(), projectId);
+    resource.setProjectId(projectId);
     ResourcePO po = toPersistence(resource);
     boolean inserted = resourceDao.insert(po) > 0;
     if (inserted) resource.setId(po.getId());
@@ -78,66 +73,62 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
   @Override
   public boolean update(ResourceNode resource) {
     if (resource == null) return false;
-    ensureCurrentProject(resource.getProjectId());
-    return resourceDao.update(toPersistence(resource));
+    long projectId = requireProjectId();
+    ensureCurrentProject(resource.getProjectId(), projectId);
+    resource.setProjectId(projectId);
+    return resourceDao.update(projectId, toPersistence(resource));
   }
 
   @Override
   public boolean updateBatch(List<ResourceNode> resources) {
     if (resources == null || resources.isEmpty()) return true;
-    resources.forEach(resource -> ensureCurrentProject(resource.getProjectId()));
-    return resourceDao.updateBatch(resources.stream().map(this::toPersistence).toList());
+    long projectId = requireProjectId();
+    resources.forEach(
+        resource -> {
+          ensureCurrentProject(resource.getProjectId(), projectId);
+          resource.setProjectId(projectId);
+        });
+    return resourceDao.updateBatch(
+        projectId, resources.stream().map(this::toPersistence).toList());
   }
 
   @Override
   public boolean deleteBatch(List<Long> ids) {
-    Long projectId = currentProjectId();
-    return projectId == null
-        ? resourceDao.deleteBatch(ids)
-        : resourceDao.deleteBatch(projectId, ids);
+    return resourceDao.deleteBatch(requireProjectId(), ids);
   }
 
   @Override
   public List<ResourceNode> findChildren(Long parentId, String keyword) {
-    Long projectId = currentProjectId();
-    List<ResourcePO> rows =
-        projectId == null
-            ? resourceDao.selectChildren(parentId, keyword)
-            : resourceDao.selectChildren(projectId, parentId, keyword);
-    return rows.stream().map(this::toDomain).toList();
+    return resourceDao.selectChildren(requireProjectId(), parentId, keyword).stream()
+        .map(this::toDomain)
+        .toList();
   }
 
   @Override
   public List<ResourceNode> findAll() {
-    Long projectId = currentProjectId();
-    List<ResourcePO> rows =
-        projectId == null ? resourceDao.selectAll() : resourceDao.selectAll(projectId);
-    return rows.stream().map(this::toDomain).toList();
+    return resourceDao.selectAll(requireProjectId()).stream().map(this::toDomain).toList();
   }
 
   @Override
   public List<ResourceNode> findDescendants(String fullPath) {
-    Long projectId = currentProjectId();
-    List<ResourcePO> rows =
-        projectId == null
-            ? resourceDao.selectDescendants(fullPath)
-            : resourceDao.selectDescendants(projectId, fullPath);
-    return rows.stream().map(this::toDomain).toList();
+    return resourceDao.selectDescendants(requireProjectId(), fullPath).stream()
+        .map(this::toDomain)
+        .toList();
   }
 
   @Override
   public PageData<ResourceNode> page(ResourceQuery query) {
-    ResourceQuery condition = query == null
-        ? new ResourceQuery(1, 20, null, null, null)
-        : query;
-    IPage<ResourcePO> page = resourceDao.selectPage(
-        new PageQuery(
-            currentProjectId(),
-            condition.pageNo(),
-            condition.pageSize(),
-            condition.parentId(),
-            condition.keyword(),
-            condition.nodeType()));
+    ResourceQuery condition =
+        query == null ? new ResourceQuery(1, 20, null, null, null) : query;
+    IPage<ResourcePO> page =
+        resourceDao.selectPage(
+            new PageQuery(
+                requireProjectId(),
+                condition.pageNo(),
+                condition.pageSize(),
+                condition.parentId(),
+                condition.keyword(),
+                condition.nodeType()));
     return new PageData<>(
         page.getRecords().stream().map(this::toDomain).toList(),
         page.getTotal(),
@@ -150,13 +141,14 @@ public class ResourceRepositoryAdapter implements ResourceRepository {
     return currentProject.current().map(context -> context.projectId()).orElse(null);
   }
 
-  private void ensureCurrentProject(Long ownerProjectId) {
-    currentProject.current().ifPresent(
-        context -> {
-          if (ownerProjectId != null && !Objects.equals(context.projectId(), ownerProjectId)) {
-            throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
-          }
-        });
+  private long requireProjectId() {
+    return currentProject.requireProjectId();
+  }
+
+  private void ensureCurrentProject(Long ownerProjectId, long currentProjectId) {
+    if (ownerProjectId != null && !Objects.equals(currentProjectId, ownerProjectId)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
   }
 
   ResourceNode toDomain(ResourcePO po) {

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/controller/v1/ResourcesControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/controller/v1/ResourcesControllerContractTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.common.constant.resource.ResourcePermissionCode;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,15 +17,19 @@ class ResourcesControllerContractTest {
   void exposesVersionedResourceApiAndExistingPermissionContract() throws Exception {
     RequestMapping mapping = ResourcesController.class.getAnnotation(RequestMapping.class);
     RequiresPermission read = ResourcesController.class.getAnnotation(RequiresPermission.class);
+    ProjectScope resourceScope = ResourcesController.class.getAnnotation(ProjectScope.class);
     Method download = ResourcesController.class.getMethod(
         "download", Long.class, jakarta.servlet.http.HttpServletResponse.class);
     RequiresPermission downloadPermission = download.getAnnotation(RequiresPermission.class);
     Method storagePlugins = ResourcesController.class.getMethod("storagePlugins");
     GetMapping storagePluginsMapping = storagePlugins.getAnnotation(GetMapping.class);
+    ProjectScope storagePluginScope = storagePlugins.getAnnotation(ProjectScope.class);
 
     assertThat(mapping.value()).containsExactly("/api/v1/resources");
     assertThat(read.value()).isEqualTo(ResourcePermissionCode.READ);
+    assertThat(resourceScope.value()).isEqualTo(ProjectMigrationMode.PROJECT_REQUIRED);
     assertThat(downloadPermission.value()).isEqualTo(ResourcePermissionCode.DOWNLOAD);
     assertThat(storagePluginsMapping.value()).containsExactly("/storage-plugins");
+    assertThat(storagePluginScope.value()).isEqualTo(ProjectMigrationMode.LEGACY_GLOBAL);
   }
 }

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/repository/ResourceRepositoryAdapterTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.resource.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
@@ -17,6 +18,7 @@ import io.yak.ops.common.enums.resource.ResourceNodeType;
 import io.yak.ops.common.enums.resource.ResourceStorageType;
 import io.yak.ops.core.project.CurrentProject;
 import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,8 +32,8 @@ class ResourceRepositoryAdapterTest {
   @Mock private ResourceDao resourceDao;
 
   @Test
-  void insertPropagatesGeneratedIdBackToDomain() {
-    ResourceRepositoryAdapter adapter = new ResourceRepositoryAdapter(resourceDao);
+  void insertPropagatesTrustedProjectAndGeneratedIdBackToDomain() {
+    ResourceRepositoryAdapter adapter = new ResourceRepositoryAdapter(resourceDao, project(7L));
     ResourceNode node = new ResourceNode();
     node.setName("README.md");
     node.setFullPath("/README.md");
@@ -49,9 +51,11 @@ class ResourceRepositoryAdapterTest {
 
     assertThat(adapter.insert(node)).isTrue();
     assertThat(node.getId()).isEqualTo(42L);
+    assertThat(node.getProjectId()).isEqualTo(7L);
 
     ArgumentCaptor<ResourcePO> captor = ArgumentCaptor.forClass(ResourcePO.class);
     verify(resourceDao).insert(captor.capture());
+    assertThat(captor.getValue().getProjectId()).isEqualTo(7L);
     assertThat(captor.getValue().getFullPath()).isEqualTo("/README.md");
     assertThat(captor.getValue().getNodeType()).isEqualTo(ResourceNodeType.FILE);
   }
@@ -61,21 +65,55 @@ class ResourceRepositoryAdapterTest {
     ResourcePO po = new ResourcePO();
     po.setId(9L);
     po.setProjectId(7L);
-    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
     when(resourceDao.selectById(7L, 9L)).thenReturn(po);
 
     ResourceNode result =
-        new ResourceRepositoryAdapter(resourceDao, currentProject).findById(9L).orElseThrow();
+        new ResourceRepositoryAdapter(resourceDao, project(7L)).findById(9L).orElseThrow();
 
     assertThat(result.getProjectId()).isEqualTo(7L);
     verify(resourceDao).selectById(7L, 9L);
   }
 
   @Test
-  void pageMapsDomainQueryToDaoQueryAndBack() {
+  void legacyRuntimeLookupCanStillResolveByIdWithoutProject() {
+    ResourcePO po = new ResourcePO();
+    po.setId(9L);
+    when(resourceDao.selectById(9L)).thenReturn(po);
+
+    assertThat(new ResourceRepositoryAdapter(resourceDao).findById(9L)).isPresent();
+
+    verify(resourceDao).selectById(9L);
+  }
+
+  @Test
+  void updateUsesProjectQualifiedMutation() {
+    ResourceNode node = new ResourceNode();
+    node.setId(9L);
+    node.setProjectId(7L);
+    node.setName("job.sql");
+    when(resourceDao.update(org.mockito.ArgumentMatchers.eq(7L), any(ResourcePO.class)))
+        .thenReturn(true);
+
+    assertThat(new ResourceRepositoryAdapter(resourceDao, project(7L)).update(node)).isTrue();
+
+    verify(resourceDao).update(org.mockito.ArgumentMatchers.eq(7L), any(ResourcePO.class));
+  }
+
+  @Test
+  void broadQueriesFailClosedWithoutProject() {
     ResourceRepositoryAdapter adapter = new ResourceRepositoryAdapter(resourceDao);
+
+    assertThatThrownBy(() -> adapter.page(new ResourceQuery(1, 20, null, null, null)))
+        .isInstanceOf(ProjectContextException.class);
+    assertThatThrownBy(adapter::findAll).isInstanceOf(ProjectContextException.class);
+  }
+
+  @Test
+  void pageMapsTrustedProjectAndDomainQueryToDaoQueryAndBack() {
+    ResourceRepositoryAdapter adapter = new ResourceRepositoryAdapter(resourceDao, project(7L));
     ResourcePO po = new ResourcePO();
     po.setId(7L);
+    po.setProjectId(7L);
     po.setName("job.sql");
     po.setNodeType(ResourceNodeType.FILE);
     po.setStorageType(ResourceStorageType.LOCAL);
@@ -95,8 +133,13 @@ class ResourceRepositoryAdapterTest {
 
     ArgumentCaptor<PageQuery> captor = ArgumentCaptor.forClass(PageQuery.class);
     verify(resourceDao).selectPage(captor.capture());
+    assertThat(captor.getValue().projectId()).isEqualTo(7L);
     assertThat(captor.getValue().parentId()).isEqualTo(3L);
     assertThat(captor.getValue().keyword()).isEqualTo("job");
     assertThat(captor.getValue().nodeType()).isEqualTo(ResourceNodeType.FILE);
+  }
+
+  private CurrentProject project(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "Project " + projectId));
   }
 }

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -21,7 +21,8 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/data-source/1')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-source/catalog/1/tables')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/sql-executions/page')).toBe('PROJECT_REQUIRED');
-    expect(resolveProjectRequestMode('/api/v1/resources/tree')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/resources/tree')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/resources/42/download')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/datasets/1')).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/home/cockpit')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/home/data-center/overview?period=7d')).toBe('PROJECT_REQUIRED');
@@ -36,9 +37,10 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/workflows/definitions')).toBe('PROJECT_OPTIONAL');
   });
 
-  it('keeps datasource plugin metadata and public data service runtime global', () => {
+  it('keeps datasource and storage plugin metadata plus public data service runtime global', () => {
     expect(resolveProjectRequestMode('/api/v1/data-source/plugin/config?pluginType=MYSQL')).toBe('LEGACY_GLOBAL');
     expect(resolveProjectRequestMode('/api/v1/data-source/plugin/config/install')).toBe('LEGACY_GLOBAL');
+    expect(resolveProjectRequestMode('/api/v1/resources/storage-plugins')).toBe('LEGACY_GLOBAL');
     expect(resolveProjectRequestMode('/api/v1/data-service/runtime/orders')).toBe('LEGACY_GLOBAL');
     expect(resolveProjectRequestMode('/api/v1/data-service/runtime/orders/by-id')).toBe('LEGACY_GLOBAL');
   });
@@ -58,6 +60,8 @@ describe('Project Space request context', () => {
     expect(headers).toEqual({});
     const pluginHeaders = applyCurrentProjectHeader('/api/v1/data-source/plugin/config', {}, '7');
     expect(pluginHeaders).toEqual({});
+    const storagePluginHeaders = applyCurrentProjectHeader('/api/v1/resources/storage-plugins', {}, '7');
+    expect(storagePluginHeaders).toEqual({});
     const runtimeHeaders = applyCurrentProjectHeader('/api/v1/data-service/runtime/orders', {}, '7');
     expect(runtimeHeaders).toEqual({});
   });
@@ -70,6 +74,9 @@ describe('Project Space request context', () => {
       [PROJECT_ID_HEADER]: '7',
     });
     expect(applyCurrentProjectHeader('/api/v1/sql-executions/page', {})).toEqual({
+      [PROJECT_ID_HEADER]: '7',
+    });
+    expect(applyCurrentProjectHeader('/api/v1/resources/42/download', {})).toEqual({
       [PROJECT_ID_HEADER]: '7',
     });
     expect(applyCurrentProjectHeader('/api/v1/home/cockpit', {})).toEqual({

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -17,7 +17,9 @@ export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
   { prefix: '/api/v1/data-source/plugin/config', mode: 'LEGACY_GLOBAL' },
   { prefix: '/api/v1/data-source', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/sql-executions', mode: 'PROJECT_REQUIRED' },
-  { prefix: '/api/v1/resources', mode: 'PROJECT_OPTIONAL' },
+  // Storage plugin metadata is platform-global; resource namespace/content is workspace-owned.
+  { prefix: '/api/v1/resources/storage-plugins', mode: 'LEGACY_GLOBAL' },
+  { prefix: '/api/v1/resources', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/datasets', mode: 'PROJECT_OPTIONAL' },
   { prefix: '/api/v1/home', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/data-development', mode: 'PROJECT_REQUIRED' },


### PR DESCRIPTION
## 背景

DataSource 已完成 Stage 2 / Stage 2.1。Resource 之前在 PR #774 / #777 已经做过 Project Space Expand：`yak_ops_resource` 已有 nullable `project_id`、项目内名称唯一约束、Project-aware storage path，但业务面仍处于 `PROJECT_OPTIONAL`，Repository 在缺少 CurrentProject 时也会退回全局查询。

Stage 3.1 不重复改表结构，只把 File Resource 从“部分项目化”收口到真正可用的工作空间业务面。

## 本 PR 做了什么

### 1. Resource HTTP 业务面切换到 PROJECT_REQUIRED

`/api/v1/resources/**` 由：

```text
PROJECT_OPTIONAL
```

切换为：

```text
PROJECT_REQUIRED
```

覆盖：

- 目录创建
- 文件上传 / 在线创建
- 列表 / 分页 / 资源树
- 详情
- 重命名 / 移动
- 文件替换 / 内容编辑
- 删除
- 内容读取
- 下载

因此正常控制台请求必须带 `X-YAK-SECURITY-PROJECT-ID`。

### 2. Storage Plugin 继续保持 GLOBAL

`/api/v1/resources/storage-plugins` 是平台级 Storage Plugin 元数据，不属于某个工作空间。

因此：

- Controller method 显式 `LEGACY_GLOBAL`
- 前端使用更具体的 global route rule
- 不附加 Project Header

没有把 Local / MinIO / HDFS Storage Plugin 配置错误地项目化。

### 3. Resource Repository 业务路径 fail-closed

正常 Resource 业务操作全部要求可信 CurrentProject：

- `findByFullPath`
- `existsByParentAndName`
- `insert`
- `update`
- `updateBatch`
- `deleteBatch`
- `findChildren`
- `findAll`
- `findDescendants`
- `page`

创建时 `project_id` 只来自 CurrentProject；调用方不能通过 Domain/DTO 覆盖归属。

更新和批量更新新增 DAO 的 project-qualified mutation，最终使用：

```text
project_id + id
```

双条件写入，避免只靠前置查询后再 `updateById(id)` 留下跨 Project mutation 窗口。

### 4. 根目录 / 父子目录强制同 Project

Resource 的每一行都是 `PROJECT_ROOT` 数据。

创建根节点时必须有 CurrentProject；创建/移动到非根父目录时，父目录必须属于当前 Project。

现有 move 逻辑中对子节点项目归属的校验继续保留，因此不能把 Project A 的文件移动到 Project B 目录。

### 5. 历史 Resource 回填默认工作空间

复用已有 `V2__expand_project_scope.sql`，本 PR不新增重复 Expand migration。

新增 `ResourceProjectCompatibilityBackfill`，在 Resource Flyway 完成后：

1. 从 `ProjectCompatibilityCoordinator` 获取真实默认 Project ID；
2. 对已有部分项目化目录树，优先让 NULL 子节点继承父节点 project；
3. 剩余 legacy NULL 资源回填默认工作空间；
4. 校验不存在 `project_id IS NULL`；
5. 校验不存在父子节点跨 Project。

不会硬编码 `project_id = 1`，也不会改写已有资源的物理 `storage_path`。历史物理文件保持原位置；后续新建/移动仍继续使用现有 `projects/{projectId}/...` 存储命名空间。

### 6. 暂留 ResourceResolver 的只读 Runtime 兼容走廊

这是刻意保留的迁移边界，不是遗漏。

当前 Java/Shell/Python 等 Task Runtime 会通过：

```text
ResourceResolver
  -> ResourceDownloadProvider
  -> ResourceRepository.findById(resourceId)
```

解析已持久化的 resourceId。Data Development / Workflow 的后台 Project Context 恢复将在后续生产链阶段继续收口。

因此 Stage 3.1 仅保留：

```text
findById(id)
无 CurrentProject -> legacy read-only runtime fallback
```

其余目录查询、分页、名称判断和所有写操作全部 fail-closed。

这条兼容路径不允许新增业务 API 使用；待 Task Runtime 全链路完成 ProjectContext 恢复后删除。

## 测试补充

- Controller contract：Resource = `PROJECT_REQUIRED`
- Storage Plugin method = `LEGACY_GLOBAL`
- Repository：CurrentProject-qualified lookup
- Repository：创建强制写入可信 projectId
- Repository：更新走 `project_id + id`
- Repository：无 Project 的 broad query fail-closed
- Repository：保留 legacy runtime `findById` read-only corridor
- 前端 Resource API route = `PROJECT_REQUIRED`
- Storage Plugin route = `LEGACY_GLOBAL`
- Resource backfill source contract：父项目继承 -> 默认空间 fallback -> NULL / cross-project 校验

## 建议本地验证

```bash
mvn -pl yak-ops-business/yak-ops-business-resource -am test
mvn -pl yak-ops-boot -am test

cd yak-ops-ui
npm test -- src/utils/security/projectContext.test.ts
npm run lint
```

当前 connector 无法执行本地 Maven / npm，且 head 未检测到 GitHub Actions workflow run / commit status，所以保持 Draft。

## 最小手工回归

1. Project A / B 根目录下可以创建同名文件/目录
2. A 的 list / page / tree 看不到 B
3. A 使用 B 的 resourceId：detail / content / download / update / move / delete 均不可见或失败
4. A 不能把资源移动到 B 的父目录
5. 不带 Project Header 调用 `/api/v1/resources/**` 返回 `PROJECT_REQUIRED`
6. `/api/v1/resources/storage-plugins` 不带 Project Header 仍可正常读取
7. 新资源 `project_id` 等于当前 Project，storage path 使用现有 `projects/{projectId}/...`
8. 历史数据库启动后日志出现 `Resource Project Space backfill complete`
9. 回填后 `SELECT COUNT(*) FROM yak_ops_resource WHERE project_id IS NULL` 为 0
10. 历史目录树不存在父子节点跨 Project
11. 现有引用 Resource 的 Java/Shell/Python 手工运行仍能解析已持久化 resourceId

## 明确不在 Stage 3.1 范围

- `yak_ops_resource.project_id NOT NULL` 物理 Contract（后续 Stage 3.1.1，小 PR）
- Data Service
- Dataset / Lineage / Task Catalog
- Data Development / Workflow Task Runtime ProjectContext 全链路改造
- 删除 ResourceResolver legacy read-only corridor
- Storage Plugin 项目化
