### PR TITLE
feat(project-space): 完成 Stage 3.1.1 Resource Project Contract

### DIFF
--- a/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V3__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-resource/src/main/resources/db/migration/yak-resource/V3__contract_project_scope.sql
@@ -1,0 +1,6 @@
+-- Project Space Stage 3.1.1 contract migration.
+-- Stage 3.1 ApplicationReady backfill must have completed before this migration reaches a legacy database.
+-- This migration intentionally performs no implicit backfill: remaining NULL rows must fail fast.
+
+ALTER TABLE yak_ops_resource
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';

--- a/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceFlywayContractTest.java
+++ b/yak-ops-business/yak-ops-business-resource/src/test/java/io/yak/ops/business/resource/architecture/ResourceFlywayContractTest.java
@@ -1,0 +1,55 @@
+package io.yak.ops.business.resource.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ResourceFlywayContractTest {
+
+  @Test
+  void resourceNamespaceContainsExpandAndContractProjectScopeMigrations() throws IOException {
+    assertThat(sqlFiles(migrationRoot()))
+        .containsExactly(
+            "V1__init_resource_management.sql",
+            "V2__expand_project_scope.sql",
+            "V3__contract_project_scope.sql");
+
+    String expand = Files.readString(migrationRoot().resolve("V2__expand_project_scope.sql"));
+    assertThat(expand)
+        .contains("ADD COLUMN project_id BIGINT NULL")
+        .contains("uk_yak_resource_project_parent_name")
+        .contains("idx_yak_resource_project_path")
+        .contains("idx_yak_resource_project_parent_type");
+
+    String contract = Files.readString(migrationRoot().resolve("V3__contract_project_scope.sql"));
+    assertThat(contract)
+        .contains("ALTER TABLE yak_ops_resource")
+        .contains("MODIFY COLUMN project_id BIGINT NOT NULL")
+        .contains("performs no implicit backfill")
+        .doesNotContain("UPDATE yak_ops_resource")
+        .doesNotContain("project_id = 1");
+  }
+
+  private List<String> sqlFiles(Path root) throws IOException {
+    try (var paths = Files.list(root)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .map(path -> path.getFileName().toString())
+          .filter(name -> name.endsWith(".sql"))
+          .sorted()
+          .toList();
+    }
+  }
+
+  private Path migrationRoot() {
+    Path local = Path.of("src/main/resources/db/migration/yak-resource");
+    if (Files.isDirectory(local)) return local;
+    return Path.of(
+        "yak-ops-business", "yak-ops-business-resource", "src", "main", "resources", "db",
+        "migration", "yak-resource");
+  }
+}


### PR DESCRIPTION
## 背景

Stage 3.1（#872）已经把 Resource 业务面切换到 `PROJECT_REQUIRED`，并在 ApplicationReady 阶段完成历史 `yak_ops_resource.project_id` 回填和父子 Project 一致性校验。

Stage 3.1.1 只做 Contract：把 Resource 的逻辑必填收紧成数据库物理 `NOT NULL`。

本 PR 不修改 Controller / Repository / Backfill / ResourceResolver / 前端，也不删除 Task Runtime 的只读兼容走廊。

## 改动范围

仅 2 个文件：

1. 新增 `V3__contract_project_scope.sql`
2. 新增 `ResourceFlywayContractTest`

### Contract migration

```sql
ALTER TABLE yak_ops_resource
    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';
```

没有新增索引、没有改唯一约束、没有修改 storage path，也没有引入任何运行时逻辑。

## 部署前置条件

**本 PR 不替代 Stage 3.1 backfill。**

Flyway 在 ApplicationReady 之前执行，因此历史数据库必须至少成功运行过一次 #872，让 Resource backfill 先完成。

合并/部署前确认：

```sql
SELECT COUNT(*)
FROM yak_ops_resource
WHERE project_id IS NULL;
```

结果必须为 `0`。

如果仍有 NULL，V3 的 `ALTER ... NOT NULL` 应直接失败。这是刻意的 fail-fast 行为，不做任何隐式兜底：

- 不硬编码 `project_id = 1`
- 不在 migration 中 UPDATE 历史 Resource
- 不猜测默认 Project
- 不把 NULL 转成 0

## Migration 契约测试

新增 `ResourceFlywayContractTest`，固定：

```text
V1  baseline
 ↓
V2  Expand(project_id nullable)
 ↓
Stage 3.1 ApplicationReady Backfill
 ↓
V3  Contract(project_id NOT NULL)
```

测试同时保证：

- V2 继续保持 `BIGINT NULL`
- V2 的 Project 维度唯一索引/查询索引仍存在
- V3 使用 `BIGINT NOT NULL`
- V3 不允许 `UPDATE yak_ops_resource`
- V3 不允许硬编码 `project_id = 1`

## 明确不在本 PR 范围

- Resource 业务逻辑调整
- Resource 前端调整
- ResourceResolver / Task Runtime ProjectContext 改造
- 删除 legacy read-only runtime corridor
- Storage Plugin 项目化
- Data Service / Dataset 等后续模块

## 建议本地验证

```bash
mvn -pl yak-ops-business/yak-ops-business-resource -am test
```

并使用一个已经成功运行过 #872 的历史数据库启动一次，确认 V3 正常执行。

当前 connector 未检测到 GitHub Actions workflow run / commit status，因此保持 Draft。

## 合并门槛

- [ ] #872 已在历史数据库成功启动
- [ ] `yak_ops_resource.project_id IS NULL` 数量为 0
- [ ] Resource Maven tests 通过
- [ ] V3 在该历史数据库成功执行
