### PR TITLE
feat(data-service): enforce project-scoped public invocation (Stage 3.2)

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
@@ -11,6 +11,8 @@ import io.yak.ops.business.dataservice.domain.access.AccessContext;
 import io.yak.ops.business.dataservice.query.DataServiceReader;
 import io.yak.ops.business.dataservice.runtime.LocalDataServiceRuntime;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,6 +35,7 @@ public class DataServiceInvoker {
   private final DataServiceQueryExecutor queryExecutor;
   private final LocalDataServiceRuntime runtime;
   private final DataServiceInvocationRecorder recorder;
+  private final ProjectContextScope projectContextScope;
 
   public DataServiceQueryResponse test(Long id, Map<String, String> parameters) {
     return execute(reader.require(id), parameters, AccessContext.console(), false);
@@ -40,6 +43,14 @@ public class DataServiceInvoker {
 
   public DataServiceQueryResponse invoke(String servicePath, Map<String, String> parameters, String rawApiKey) {
     DataServiceDefinition definition = reader.requireByPath(normalizePath(servicePath));
+    ProjectContext projectContext = requireProjectContext(definition);
+    return projectContextScope.call(
+        projectContext,
+        () -> invokeInProject(definition, parameters, rawApiKey));
+  }
+
+  private DataServiceQueryResponse invokeInProject(
+      DataServiceDefinition definition, Map<String, String> parameters, String rawApiKey) {
     if (!definition.settings().enabled()) throw new IllegalStateException("数据服务未启用：" + definition.settings().path());
     AccessContext access;
     try {
@@ -49,6 +60,15 @@ public class DataServiceInvoker {
       throw exception;
     }
     return execute(definition, parameters, access, true);
+  }
+
+  private ProjectContext requireProjectContext(DataServiceDefinition definition) {
+    Long projectId = definition == null ? null : definition.projectId();
+    if (projectId == null || projectId <= 0L) {
+      throw new IllegalStateException("数据服务缺少有效的 Project Space 归属：apiId="
+          + (definition == null ? null : definition.id()));
+    }
+    return new ProjectContext(projectId, null);
   }
 
   private DataServiceQueryResponse execute(

--- a/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-data-service/V2__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-data-service/V2__contract_project_scope.sql
@@ -1,0 +1,9 @@
+-- Project Space Stage 3.2 contract migration.
+-- Stage 3.2 backfill must have completed before this migration reaches a legacy database.
+-- This migration intentionally performs no implicit backfill: remaining NULL rows must fail fast.
+
+ALTER TABLE yak_ops_data_service_api
+    MODIFY COLUMN project_id BIGINT UNSIGNED NOT NULL COMMENT 'Yak Security Project Space ID';
+
+ALTER TABLE yak_ops_data_service_call_log
+    MODIFY COLUMN project_id BIGINT UNSIGNED NOT NULL COMMENT '调用发生时的数据服务 Project Space ID';

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceFlywayContractTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceFlywayContractTest.java
@@ -22,13 +22,15 @@ class DataServiceFlywayContractTest {
   }
 
   @Test
-  void dedicatedNamespaceContainsOnlyFirstReleaseBaseline() throws IOException {
+  void dedicatedNamespaceContainsBaselineAndProjectContract() throws IOException {
     assertThat(sqlFiles(dedicatedMigrationRoot()))
-        .containsExactly("V1__baseline_data_service.sql");
+        .containsExactly(
+            "V1__baseline_data_service.sql",
+            "V2__contract_project_scope.sql");
 
-    String migration = Files.readString(
+    String baseline = Files.readString(
         dedicatedMigrationRoot().resolve("V1__baseline_data_service.sql"));
-    assertThat(migration)
+    assertThat(baseline)
         .contains("CREATE TABLE IF NOT EXISTS yak_ops_data_service_api")
         .contains("CREATE TABLE IF NOT EXISTS yak_ops_data_service_api_key")
         .contains("CREATE TABLE IF NOT EXISTS yak_ops_data_service_documentation")
@@ -38,6 +40,14 @@ class DataServiceFlywayContractTest {
         .contains("project_id")
         .contains("runtime_generation")
         .doesNotContain("ALTER TABLE");
+
+    String contract = Files.readString(
+        dedicatedMigrationRoot().resolve("V2__contract_project_scope.sql"));
+    assertThat(contract)
+        .contains("ALTER TABLE yak_ops_data_service_api")
+        .contains("ALTER TABLE yak_ops_data_service_call_log")
+        .contains("project_id BIGINT UNSIGNED NOT NULL")
+        .doesNotContain("UPDATE yak_ops_data_service");
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
@@ -23,9 +23,12 @@ import io.yak.ops.business.dataservice.domain.access.AccessContext;
 import io.yak.ops.business.dataservice.domain.access.AuthMode;
 import io.yak.ops.business.dataservice.query.DataServiceReader;
 import io.yak.ops.business.dataservice.runtime.LocalDataServiceRuntime;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +38,7 @@ class DataServiceInvokerTest {
   private DataServiceAuthorizer authorizer;
   private DataServiceQueryExecutor executor;
   private DataServiceInvocationRecorder recorder;
+  private ProjectContextScope projectContextScope;
   private DataServiceInvoker invoker;
   private DataServiceDefinition definition;
 
@@ -44,16 +48,33 @@ class DataServiceInvokerTest {
     authorizer = mock(DataServiceAuthorizer.class);
     executor = mock(DataServiceQueryExecutor.class);
     recorder = mock(DataServiceInvocationRecorder.class);
+    projectContextScope = mock(ProjectContextScope.class);
+    when(projectContextScope.call(any(), any())).thenAnswer(invocation -> {
+      Supplier<?> action = invocation.getArgument(1);
+      return action.get();
+    });
     invoker = new DataServiceInvoker(
         reader,
         authorizer,
         new DataServiceSqlCompiler(),
         executor,
         new LocalDataServiceRuntime(),
-        recorder);
+        recorder,
+        projectContextScope);
     definition = definition();
     when(reader.requireByPath("/orders")).thenReturn(definition);
     when(authorizer.authorize(definition, null)).thenReturn(AccessContext.publicAccess());
+  }
+
+  @Test
+  void publicInvocationRestoresResolvedApiProjectContext() {
+    DataServiceQueryResponse response = new DataServiceQueryResponse(
+        List.of("id"), List.of(Map.of("id", 1L)), false, 1, 8L);
+    when(executor.execute(eq(definition), any(), isNull())).thenReturn(response);
+
+    invoker.invoke("orders", Map.of("id", "1"), null);
+
+    verify(projectContextScope).call(eq(new ProjectContext(3L, null)), any());
   }
 
   @Test


### PR DESCRIPTION
## 背景

Stage 3.2 继续收口 Data Service 的 Project Space 隔离。公开调用入口无法依赖管理端 HTTP Project Header，因此需要以已发布 API 自身持久化的 `projectId` 作为可信归属，在进入鉴权、限流、SQL 执行和调用审计前恢复 ProjectContext。

## 本次改动

- 公共 Data Service 调用按 `DataServiceDefinition.projectId` 恢复 `ProjectContext`
- 鉴权、限流、SQL 执行、调用审计统一运行在 API 所属 Project Scope 内
- 当历史数据缺失有效 `projectId` 时 fail-closed，避免在空 ProjectContext 下继续执行
- 复用现有 `ProjectContext` / `ProjectContextScope`，不新增第二套 ThreadLocal 或 SQL Runtime 上下文协议
- 新增 `V2__contract_project_scope.sql`
  - `yak_ops_data_service_api.project_id` 收口为 `NOT NULL`
  - `yak_ops_data_service_call_log.project_id` 收口为 `NOT NULL`
  - 不做隐式回填，遗留 NULL 由迁移直接失败暴露
- 更新 `DataServiceInvokerTest`
- 更新 `DataServiceFlywayContractTest`

## 设计说明

这次不修改 `SqlExecutionContext`。DataSource SQL Runtime 已经依赖 `CurrentProject` 做 Project-aware 数据源解析，并且已有 ProjectContext 恢复机制；因此 Data Service 在入口处恢复已有 ProjectContext 即可让后续共享执行链自然获得正确项目归属。

公开调用只有“根据 service path 解析 Data Service 定义”这一步位于 Project Scope 之外。定义解析完成后，后续业务链全部进入该 API 自身 Project Scope。

## 数据迁移约束

V2 为 Contract migration，不猜测历史数据归属，也不写默认 Project。升级旧库前应确保 `yak_ops_data_service_api.project_id` 与 `yak_ops_data_service_call_log.project_id` 已无 NULL；否则迁移应 fail-fast，而不是静默产生错误租户归属。

## 验证重点

- PUBLIC / API_KEY 调用能够在 API 所属 Project 下访问数据源
- API Key 拒绝、限流失败和 SQL 失败日志仍归属于 API Project
- 缺失 `projectId` 的历史定义不能继续公开执行
- V2 Contract 在存在 NULL 历史数据时按预期失败
- Data Service 单测与 Flyway contract test

> Draft：暂未宣称已完成完整 Maven、数据库集成测试及浏览器/端到端回归。