### PR TITLE
feat(project-space): add Lineage and Task Catalog projection substrate (Stage 4)

### DIFF
--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/LineageController.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/controller/v1/LineageController.java
@@ -15,6 +15,8 @@ import io.yak.ops.business.lineage.domain.LineageAssetType;
 import io.yak.ops.business.lineage.domain.LineageDirection;
 import io.yak.ops.business.lineage.query.LineageQueryService;
 import io.yak.ops.business.lineage.registration.LineageRegistrationService;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -36,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/lineage")
+@ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
 public class LineageController {
 
   private final LineageQueryService queryService;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/LineageDao.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/LineageDao.java
@@ -29,6 +29,8 @@ public interface LineageDao {
 
   LineageAssetPO selectAssetByKey(String assetKey);
 
+  LineageAssetPO selectAssetByKey(String assetKey, Long projectId);
+
   List<LineageAssetPO> selectAssets(AssetSearch query);
 
   long countAssets(String assetType);

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
@@ -9,13 +9,17 @@ import io.yak.ops.business.lineage.dao.mapper.LineageRelationMapper;
 import io.yak.ops.business.lineage.dao.mapper.LineageWriteMapper;
 import io.yak.ops.business.lineage.dao.model.LineageAssetPO;
 import io.yak.ops.business.lineage.dao.model.LineageRelationPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -24,13 +28,36 @@ import org.springframework.util.StringUtils;
 @Repository
 @DependsOn("yakLineageFlyway")
 @ConditionalOnLineagePersistence
-@RequiredArgsConstructor
 public class LineageDaoImpl implements LineageDao {
 
   private final LineageAssetMapper assetMapper;
   private final LineageRelationMapper relationMapper;
   private final LineageWriteMapper writeMapper;
   private final LineageQueryMapper queryMapper;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public LineageDaoImpl(
+      LineageAssetMapper assetMapper,
+      LineageRelationMapper relationMapper,
+      LineageWriteMapper writeMapper,
+      LineageQueryMapper queryMapper,
+      CurrentProject currentProject) {
+    this.assetMapper = assetMapper;
+    this.relationMapper = relationMapper;
+    this.writeMapper = writeMapper;
+    this.queryMapper = queryMapper;
+    this.currentProject = currentProject;
+  }
+
+  /** Compatibility constructor for focused DAO tests. */
+  public LineageDaoImpl(
+      LineageAssetMapper assetMapper,
+      LineageRelationMapper relationMapper,
+      LineageWriteMapper writeMapper,
+      LineageQueryMapper queryMapper) {
+    this(assetMapper, relationMapper, writeMapper, queryMapper, Optional::<ProjectContext>empty);
+  }
 
   @Override
   public int upsertAsset(LineageAssetPO asset) {
@@ -45,13 +72,16 @@ public class LineageDaoImpl implements LineageDao {
   @Override
   public List<LineageAssetPO> upsertAssets(List<LineageAssetPO> assets, int batchSize) {
     if (assets == null || assets.isEmpty()) return List.of();
+    Long batchProjectId = commonProjectId(assets);
     Map<String, LineageAssetPO> result = new LinkedHashMap<>();
     for (int start = 0; start < assets.size(); start += batchSize) {
       List<LineageAssetPO> batch = assets.subList(start, Math.min(start + batchSize, assets.size()));
       writeMapper.upsertAssets(batch);
       List<String> keys = batch.stream().map(LineageAssetPO::getAssetKey).toList();
       assetMapper.selectList(
-          Wrappers.<LineageAssetPO>lambdaQuery().in(LineageAssetPO::getAssetKey, keys))
+          Wrappers.<LineageAssetPO>lambdaQuery()
+              .in(LineageAssetPO::getAssetKey, keys)
+              .eq(batchProjectId != null, LineageAssetPO::getProjectId, batchProjectId))
           .forEach(row -> result.put(row.getAssetKey(), row));
     }
     return new ArrayList<>(result.values());
@@ -69,45 +99,59 @@ public class LineageDaoImpl implements LineageDao {
 
   @Override
   public int deleteRelationsByEvidence(String sourceType, String sourceId) {
+    Long projectId = currentProjectId();
     return relationMapper.delete(
         Wrappers.<LineageRelationPO>lambdaQuery()
+            .eq(projectId != null, LineageRelationPO::getProjectId, projectId)
             .eq(LineageRelationPO::getSourceType, sourceType)
             .eq(LineageRelationPO::getSourceId, sourceId));
   }
 
   @Override
   public Set<Long> selectAssetIdsByEvidence(String sourceType, String sourceId) {
-    List<Long> ids = queryMapper.selectAssetIdsByEvidence(sourceType, sourceId);
+    List<Long> ids = queryMapper.selectAssetIdsByEvidence(sourceType, sourceId, currentProjectId());
     return ids == null || ids.isEmpty() ? Set.of() : Set.copyOf(ids);
   }
 
   @Override
   public int deleteUnreferencedOwnedAssets(Set<Long> assetIds, String ownerType, String ownerId) {
     if (assetIds == null || assetIds.isEmpty()) return 0;
-    return writeMapper.deleteUnreferencedOwnedAssets(assetIds, ownerType, ownerId);
+    return writeMapper.deleteUnreferencedOwnedAssets(
+        assetIds, ownerType, ownerId, currentProjectId());
   }
 
   @Override
   public LineageAssetPO selectAssetForUpdate(String assetKey) {
-    return writeMapper.selectAssetForUpdate(assetKey);
+    return writeMapper.selectAssetForUpdate(assetKey, currentProjectId());
   }
 
   @Override
   public LineageAssetPO selectAsset(long assetId) {
-    return assetMapper.selectById(assetId);
+    Long projectId = currentProjectId();
+    return assetMapper.selectOne(
+        Wrappers.<LineageAssetPO>lambdaQuery()
+            .eq(LineageAssetPO::getId, assetId)
+            .eq(projectId != null, LineageAssetPO::getProjectId, projectId)
+            .last("LIMIT 1"));
   }
 
   @Override
   public LineageAssetPO selectAssetByKey(String assetKey) {
+    Long projectId = currentProjectId();
     return assetMapper.selectOne(
-        Wrappers.<LineageAssetPO>lambdaQuery().eq(LineageAssetPO::getAssetKey, assetKey));
+        Wrappers.<LineageAssetPO>lambdaQuery()
+            .eq(LineageAssetPO::getAssetKey, assetKey)
+            .eq(projectId != null, LineageAssetPO::getProjectId, projectId)
+            .last("LIMIT 1"));
   }
 
   @Override
   public List<LineageAssetPO> selectAssets(AssetSearch query) {
     AssetSearch condition = query == null ? new AssetSearch(null, null, 30) : query;
+    Long projectId = currentProjectId();
     return assetMapper.selectList(
         Wrappers.<LineageAssetPO>lambdaQuery()
+            .eq(projectId != null, LineageAssetPO::getProjectId, projectId)
             .and(
                 StringUtils.hasText(condition.keyword()),
                 nested ->
@@ -130,28 +174,37 @@ public class LineageDaoImpl implements LineageDao {
 
   @Override
   public long countAssets(String assetType) {
+    Long projectId = currentProjectId();
     return assetMapper.selectCount(
         Wrappers.<LineageAssetPO>lambdaQuery()
+            .eq(projectId != null, LineageAssetPO::getProjectId, projectId)
             .eq(StringUtils.hasText(assetType), LineageAssetPO::getAssetType, assetType));
   }
 
   @Override
   public long countAssetsUpdatedBetween(Timestamp start, Timestamp end) {
+    Long projectId = currentProjectId();
     return assetMapper.selectCount(
         Wrappers.<LineageAssetPO>lambdaQuery()
+            .eq(projectId != null, LineageAssetPO::getProjectId, projectId)
             .ge(LineageAssetPO::getUpdateTime, start)
             .lt(LineageAssetPO::getUpdateTime, end));
   }
 
   @Override
   public long countRelations() {
-    return relationMapper.selectCount(null);
+    Long projectId = currentProjectId();
+    return relationMapper.selectCount(
+        Wrappers.<LineageRelationPO>lambdaQuery()
+            .eq(projectId != null, LineageRelationPO::getProjectId, projectId));
   }
 
   @Override
   public List<LineageRelationPO> selectRecentRelations(int limit) {
+    Long projectId = currentProjectId();
     return relationMapper.selectList(
         Wrappers.<LineageRelationPO>lambdaQuery()
+            .eq(projectId != null, LineageRelationPO::getProjectId, projectId)
             .orderByDesc(LineageRelationPO::getUpdateTime)
             .orderByDesc(LineageRelationPO::getObservedAt)
             .orderByDesc(LineageRelationPO::getId)
@@ -161,16 +214,20 @@ public class LineageDaoImpl implements LineageDao {
   @Override
   public List<LineageAssetPO> selectAssetsByIds(Set<Long> assetIds) {
     if (assetIds == null || assetIds.isEmpty()) return List.of();
+    Long projectId = currentProjectId();
     return assetMapper.selectList(
         Wrappers.<LineageAssetPO>lambdaQuery()
             .in(LineageAssetPO::getId, assetIds)
+            .eq(projectId != null, LineageAssetPO::getProjectId, projectId)
             .orderByAsc(LineageAssetPO::getId));
   }
 
   @Override
   public LineageRelationPO selectRelationByIdentity(LineageRelationPO identity) {
+    Long projectId = identity.getProjectId() == null ? currentProjectId() : identity.getProjectId();
     return relationMapper.selectOne(
         Wrappers.<LineageRelationPO>lambdaQuery()
+            .eq(projectId != null, LineageRelationPO::getProjectId, projectId)
             .eq(LineageRelationPO::getSourceAssetId, identity.getSourceAssetId())
             .eq(LineageRelationPO::getTargetAssetId, identity.getTargetAssetId())
             .eq(LineageRelationPO::getRelationType, identity.getRelationType())
@@ -182,18 +239,36 @@ public class LineageDaoImpl implements LineageDao {
   @Override
   public List<LineageRelationPO> selectOutgoingRelations(Set<Long> sourceAssetIds) {
     if (sourceAssetIds == null || sourceAssetIds.isEmpty()) return List.of();
+    Long projectId = currentProjectId();
     return relationMapper.selectList(
         Wrappers.<LineageRelationPO>lambdaQuery()
             .in(LineageRelationPO::getSourceAssetId, sourceAssetIds)
+            .eq(projectId != null, LineageRelationPO::getProjectId, projectId)
             .orderByAsc(LineageRelationPO::getId));
   }
 
   @Override
   public List<LineageRelationPO> selectIncomingRelations(Set<Long> targetAssetIds) {
     if (targetAssetIds == null || targetAssetIds.isEmpty()) return List.of();
+    Long projectId = currentProjectId();
     return relationMapper.selectList(
         Wrappers.<LineageRelationPO>lambdaQuery()
             .in(LineageRelationPO::getTargetAssetId, targetAssetIds)
+            .eq(projectId != null, LineageRelationPO::getProjectId, projectId)
             .orderByAsc(LineageRelationPO::getId));
+  }
+
+  private Long currentProjectId() {
+    return currentProject.current().map(ProjectContext::projectId).orElse(null);
+  }
+
+  private Long commonProjectId(List<LineageAssetPO> assets) {
+    Long projectId = assets.get(0).getProjectId();
+    for (LineageAssetPO asset : assets) {
+      if (!Objects.equals(projectId, asset.getProjectId())) {
+        throw new IllegalArgumentException("批量血缘资产必须属于同一 Project");
+      }
+    }
+    return projectId;
   }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/impl/LineageDaoImpl.java
@@ -61,6 +61,7 @@ public class LineageDaoImpl implements LineageDao {
 
   @Override
   public int upsertAsset(LineageAssetPO asset) {
+    claimLegacyAsset(asset);
     return writeMapper.upsertAsset(asset);
   }
 
@@ -76,6 +77,7 @@ public class LineageDaoImpl implements LineageDao {
     Map<String, LineageAssetPO> result = new LinkedHashMap<>();
     for (int start = 0; start < assets.size(); start += batchSize) {
       List<LineageAssetPO> batch = assets.subList(start, Math.min(start + batchSize, assets.size()));
+      batch.forEach(this::claimLegacyAsset);
       writeMapper.upsertAssets(batch);
       List<String> keys = batch.stream().map(LineageAssetPO::getAssetKey).toList();
       assetMapper.selectList(
@@ -137,11 +139,16 @@ public class LineageDaoImpl implements LineageDao {
 
   @Override
   public LineageAssetPO selectAssetByKey(String assetKey) {
-    Long projectId = currentProjectId();
+    return selectAssetByKey(assetKey, null);
+  }
+
+  @Override
+  public LineageAssetPO selectAssetByKey(String assetKey, Long projectId) {
+    Long effectiveProjectId = projectId == null ? currentProjectId() : projectId;
     return assetMapper.selectOne(
         Wrappers.<LineageAssetPO>lambdaQuery()
             .eq(LineageAssetPO::getAssetKey, assetKey)
-            .eq(projectId != null, LineageAssetPO::getProjectId, projectId)
+            .eq(effectiveProjectId != null, LineageAssetPO::getProjectId, effectiveProjectId)
             .last("LIMIT 1"));
   }
 
@@ -256,6 +263,12 @@ public class LineageDaoImpl implements LineageDao {
             .in(LineageRelationPO::getTargetAssetId, targetAssetIds)
             .eq(projectId != null, LineageRelationPO::getProjectId, projectId)
             .orderByAsc(LineageRelationPO::getId));
+  }
+
+  private void claimLegacyAsset(LineageAssetPO asset) {
+    if (asset != null && asset.getProjectId() != null) {
+      writeMapper.claimLegacyAssetProject(asset.getAssetKey(), asset.getProjectId());
+    }
   }
 
   private Long currentProjectId() {

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/mapper/LineageQueryMapper.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/mapper/LineageQueryMapper.java
@@ -10,5 +10,6 @@ public interface LineageQueryMapper {
 
   List<Long> selectAssetIdsByEvidence(
       @Param("sourceType") String sourceType,
-      @Param("sourceId") String sourceId);
+      @Param("sourceId") String sourceId,
+      @Param("projectId") Long projectId);
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/mapper/LineageWriteMapper.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/mapper/LineageWriteMapper.java
@@ -19,10 +19,13 @@ public interface LineageWriteMapper {
 
   int upsertRelations(@Param("rows") List<LineageRelationPO> rows);
 
-  LineageAssetPO selectAssetForUpdate(@Param("assetKey") String assetKey);
+  LineageAssetPO selectAssetForUpdate(
+      @Param("assetKey") String assetKey,
+      @Param("projectId") Long projectId);
 
   int deleteUnreferencedOwnedAssets(
       @Param("assetIds") Set<Long> assetIds,
       @Param("ownerType") String ownerType,
-      @Param("ownerId") String ownerId);
+      @Param("ownerId") String ownerId,
+      @Param("projectId") Long projectId);
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/mapper/LineageWriteMapper.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/mapper/LineageWriteMapper.java
@@ -11,6 +11,10 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface LineageWriteMapper {
 
+  int claimLegacyAssetProject(
+      @Param("assetKey") String assetKey,
+      @Param("projectId") Long projectId);
+
   int upsertAsset(@Param("row") LineageAssetPO row);
 
   int upsertRelation(@Param("row") LineageRelationPO row);

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/model/LineageAssetPO.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/model/LineageAssetPO.java
@@ -13,6 +13,7 @@ public class LineageAssetPO {
 
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private String assetKey;
   private String assetType;
   private String name;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/model/LineageRelationPO.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/dao/model/LineageRelationPO.java
@@ -14,6 +14,7 @@ public class LineageRelationPO {
 
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private Long sourceAssetId;
   private Long targetAssetId;
   private String relationType;

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAsset.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAsset.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 /** Stable identity for an object participating in the Yak Ops metadata graph. */
 public record LineageAsset(
     long id,
+    Long projectId,
     String assetKey,
     LineageAssetType assetType,
     String name,
@@ -20,4 +21,40 @@ public record LineageAsset(
     JsonNode properties,
     Instant createTime,
     Instant updateTime) {
+
+  /** Compatibility constructor for callers compiled against the pre-Project projection model. */
+  public LineageAsset(
+      long id,
+      String assetKey,
+      LineageAssetType assetType,
+      String name,
+      String sourceType,
+      String sourceId,
+      Long parentAssetId,
+      String dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String columnName,
+      JsonNode properties,
+      Instant createTime,
+      Instant updateTime) {
+    this(
+        id,
+        null,
+        assetKey,
+        assetType,
+        name,
+        sourceType,
+        sourceId,
+        parentAssetId,
+        dataSourceId,
+        databaseName,
+        schemaName,
+        tableName,
+        columnName,
+        properties,
+        createTime,
+        updateTime);
+  }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAssetDraft.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageAssetDraft.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 /** Validated domain write model for registering a metadata asset. */
 public record LineageAssetDraft(
+    Long projectId,
     String assetKey,
     LineageAssetType assetType,
     String name,
@@ -16,4 +17,33 @@ public record LineageAssetDraft(
     String tableName,
     String columnName,
     JsonNode properties) {
+
+  public LineageAssetDraft(
+      String assetKey,
+      LineageAssetType assetType,
+      String name,
+      String sourceType,
+      String sourceId,
+      Long parentAssetId,
+      String dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName,
+      String columnName,
+      JsonNode properties) {
+    this(
+        null,
+        assetKey,
+        assetType,
+        name,
+        sourceType,
+        sourceId,
+        parentAssetId,
+        dataSourceId,
+        databaseName,
+        schemaName,
+        tableName,
+        columnName,
+        properties);
+  }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelation.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelation.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 /** Directed upstream-to-downstream edge with optional provenance evidence. */
 public record LineageRelation(
     long id,
+    Long projectId,
     long sourceAssetId,
     long targetAssetId,
     LineageRelationType relationType,
@@ -19,4 +20,35 @@ public record LineageRelation(
     JsonNode properties,
     Instant createTime,
     Instant updateTime) {
+
+  public LineageRelation(
+      long id,
+      long sourceAssetId,
+      long targetAssetId,
+      LineageRelationType relationType,
+      String sourceType,
+      String sourceId,
+      String expression,
+      BigDecimal confidence,
+      String version,
+      Instant observedAt,
+      JsonNode properties,
+      Instant createTime,
+      Instant updateTime) {
+    this(
+        id,
+        null,
+        sourceAssetId,
+        targetAssetId,
+        relationType,
+        sourceType,
+        sourceId,
+        expression,
+        confidence,
+        version,
+        observedAt,
+        properties,
+        createTime,
+        updateTime);
+  }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelationDraft.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/domain/LineageRelationDraft.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 
 /** Validated domain write model for registering a lineage relation. */
 public record LineageRelationDraft(
+    Long projectId,
     long sourceAssetId,
     long targetAssetId,
     LineageRelationType relationType,
@@ -16,4 +17,29 @@ public record LineageRelationDraft(
     String version,
     Instant observedAt,
     JsonNode properties) {
+
+  public LineageRelationDraft(
+      long sourceAssetId,
+      long targetAssetId,
+      LineageRelationType relationType,
+      String sourceType,
+      String sourceId,
+      String expression,
+      BigDecimal confidence,
+      String version,
+      Instant observedAt,
+      JsonNode properties) {
+    this(
+        null,
+        sourceAssetId,
+        targetAssetId,
+        relationType,
+        sourceType,
+        sourceId,
+        expression,
+        confidence,
+        version,
+        observedAt,
+        properties);
+  }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageAssetRegistrar.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageAssetRegistrar.java
@@ -32,7 +32,7 @@ public class LineageAssetRegistrar {
     if (commands == null || commands.isEmpty()) return Map.of();
     Map<String, LineageAssetDraft> drafts = new LinkedHashMap<>();
     for (RegisterAssetCommand command : commands) {
-      LineageAssetDraft draft = draftFactory.asset(command, false);
+      LineageAssetDraft draft = draftFactory.asset(command, true);
       drafts.putIfAbsent(draft.assetKey(), draft);
     }
     return repository.upsertAssets(List.copyOf(drafts.values()), batchSize);

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageRegistrationDraftFactory.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageRegistrationDraftFactory.java
@@ -8,9 +8,15 @@ import io.yak.ops.business.lineage.domain.LineageRelationType;
 import io.yak.ops.business.lineage.registration.LineageRegistrationService.RegisterAssetCommand;
 import io.yak.ops.business.lineage.registration.LineageRegistrationService.RegisterRelationCommand;
 import io.yak.ops.business.lineage.repository.LineageRepository;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Validates application commands and converts them into persistence-neutral domain drafts. */
@@ -18,9 +24,18 @@ import org.springframework.stereotype.Component;
 public class LineageRegistrationDraftFactory {
 
   private final LineageRepository repository;
+  private final CurrentProject currentProject;
 
-  public LineageRegistrationDraftFactory(LineageRepository repository) {
+  @Autowired
+  public LineageRegistrationDraftFactory(
+      LineageRepository repository, CurrentProject currentProject) {
     this.repository = repository;
+    this.currentProject = currentProject;
+  }
+
+  /** Compatibility constructor for focused unit tests. */
+  public LineageRegistrationDraftFactory(LineageRepository repository) {
+    this(repository, Optional::<ProjectContext>empty);
   }
 
   public LineageAssetDraft asset(RegisterAssetCommand command, boolean validateParent) {
@@ -29,12 +44,17 @@ public class LineageRegistrationDraftFactory {
     LineageAssetType assetType = Objects.requireNonNull(command.assetType(), "assetType");
     String name = optional(command.name(), 200);
     if (name == null) name = assetKey;
+    Long projectId = resolveSourceProject(command.sourceProjectId());
     Long parentAssetId = command.parentAssetId();
     if (parentAssetId != null) {
       requirePositive(parentAssetId, "parentAssetId");
-      if (validateParent) requireAsset(parentAssetId);
+      if (validateParent) {
+        LineageAsset parent = requireAsset(parentAssetId);
+        projectId = reconcileProject(projectId, parent.projectId());
+      }
     }
     return new LineageAssetDraft(
+        projectId,
         assetKey,
         assetType,
         name,
@@ -57,9 +77,12 @@ public class LineageRegistrationDraftFactory {
     if (command.sourceAssetId() == command.targetAssetId()) {
       throw new IllegalArgumentException("血缘关系不能指向资产自身");
     }
+    Long projectId = resolveSourceProject(command.sourceProjectId());
     if (validateAssets) {
-      requireAsset(command.sourceAssetId());
-      requireAsset(command.targetAssetId());
+      LineageAsset source = requireAsset(command.sourceAssetId());
+      LineageAsset target = requireAsset(command.targetAssetId());
+      projectId = reconcileProject(projectId, source.projectId());
+      projectId = reconcileProject(projectId, target.projectId());
     }
     LineageRelationType type =
         Objects.requireNonNull(command.relationType(), "relationType");
@@ -70,6 +93,7 @@ public class LineageRegistrationDraftFactory {
       throw new IllegalArgumentException("confidence 必须在 0 到 1 之间");
     }
     return new LineageRelationDraft(
+        projectId,
         command.sourceAssetId(),
         command.targetAssetId(),
         type,
@@ -80,6 +104,33 @@ public class LineageRegistrationDraftFactory {
         valueOrEmpty(command.version(), 128),
         command.observedAt() == null ? Instant.now() : command.observedAt(),
         command.properties());
+  }
+
+  private Long resolveSourceProject(Long sourceProjectId) {
+    Long normalized = normalizeProjectId(sourceProjectId);
+    return currentProject.current()
+        .map(
+            context -> {
+              if (normalized != null && !Objects.equals(context.projectId(), normalized)) {
+                throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+              }
+              return context.projectId();
+            })
+        .orElse(normalized);
+  }
+
+  private Long reconcileProject(Long expected, Long actual) {
+    Long normalizedActual = normalizeProjectId(actual);
+    if (expected == null) return normalizedActual;
+    if (normalizedActual == null) return expected;
+    if (!Objects.equals(expected, normalizedActual)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+    return expected;
+  }
+
+  private Long normalizeProjectId(Long value) {
+    return value == null || value <= 0L ? null : value;
   }
 
   private LineageAsset requireAsset(long assetId) {

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageRegistrationService.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageRegistrationService.java
@@ -59,7 +59,38 @@ public class LineageRegistrationService {
       String schemaName,
       String tableName,
       String columnName,
-      JsonNode properties) {
+      JsonNode properties,
+      Long sourceProjectId) {
+
+    /** Compatibility constructor; HTTP and pre-Stage-4 producers do not provide project identity. */
+    public RegisterAssetCommand(
+        String assetKey,
+        LineageAssetType assetType,
+        String name,
+        String sourceType,
+        String sourceId,
+        Long parentAssetId,
+        String dataSourceId,
+        String databaseName,
+        String schemaName,
+        String tableName,
+        String columnName,
+        JsonNode properties) {
+      this(
+          assetKey,
+          assetType,
+          name,
+          sourceType,
+          sourceId,
+          parentAssetId,
+          dataSourceId,
+          databaseName,
+          schemaName,
+          tableName,
+          columnName,
+          properties,
+          null);
+    }
   }
 
   public record RegisterRelationCommand(
@@ -72,6 +103,33 @@ public class LineageRegistrationService {
       BigDecimal confidence,
       String version,
       Instant observedAt,
-      JsonNode properties) {
+      JsonNode properties,
+      Long sourceProjectId) {
+
+    /** Compatibility constructor for existing producers; project will be derived from endpoints/context. */
+    public RegisterRelationCommand(
+        long sourceAssetId,
+        long targetAssetId,
+        LineageRelationType relationType,
+        String sourceType,
+        String sourceId,
+        String expression,
+        BigDecimal confidence,
+        String version,
+        Instant observedAt,
+        JsonNode properties) {
+      this(
+          sourceAssetId,
+          targetAssetId,
+          relationType,
+          sourceType,
+          sourceId,
+          expression,
+          confidence,
+          version,
+          observedAt,
+          properties,
+          null);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageRelationRegistrar.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/registration/LineageRelationRegistrar.java
@@ -31,7 +31,7 @@ public class LineageRelationRegistrar {
     if (commands == null || commands.isEmpty()) return;
     Map<String, LineageRelationDraft> drafts = new LinkedHashMap<>();
     for (RegisterRelationCommand command : commands) {
-      LineageRelationDraft draft = draftFactory.relation(command, false);
+      LineageRelationDraft draft = draftFactory.relation(command, true);
       String identity =
           draft.sourceAssetId()
               + "\u0000"

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
@@ -141,6 +141,7 @@ public class LineageRepositoryAdapter
 
   private LineageAssetPO toAssetPO(LineageAssetDraft draft) {
     LineageAssetPO row = new LineageAssetPO();
+    row.setProjectId(draft.projectId());
     row.setAssetKey(draft.assetKey());
     row.setAssetType(draft.assetType().name());
     row.setName(draft.name());
@@ -158,6 +159,7 @@ public class LineageRepositoryAdapter
 
   private LineageRelationPO toRelationPO(LineageRelationDraft draft) {
     LineageRelationPO row = new LineageRelationPO();
+    row.setProjectId(draft.projectId());
     row.setSourceAssetId(draft.sourceAssetId());
     row.setTargetAssetId(draft.targetAssetId());
     row.setRelationType(draft.relationType().name());
@@ -174,6 +176,7 @@ public class LineageRepositoryAdapter
   private LineageAsset toAsset(LineageAssetPO row) {
     return new LineageAsset(
         row.getId(),
+        row.getProjectId(),
         row.getAssetKey(),
         LineageAssetType.valueOf(row.getAssetType()),
         row.getName(),
@@ -193,6 +196,7 @@ public class LineageRepositoryAdapter
   private LineageRelation toRelation(LineageRelationPO row) {
     return new LineageRelation(
         row.getId(),
+        row.getProjectId(),
         row.getSourceAssetId(),
         row.getTargetAssetId(),
         LineageRelationType.valueOf(row.getRelationType()),

--- a/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/java/io/yak/ops/business/lineage/repository/LineageRepositoryAdapter.java
@@ -33,7 +33,7 @@ public class LineageRepositoryAdapter
   public LineageAsset upsertAsset(LineageAssetDraft draft) {
     LineageAssetPO row = toAssetPO(draft);
     lineageDao.upsertAsset(row);
-    return Optional.ofNullable(lineageDao.selectAssetByKey(draft.assetKey()))
+    return Optional.ofNullable(lineageDao.selectAssetByKey(draft.assetKey(), draft.projectId()))
         .map(this::toAsset)
         .orElseThrow(() -> new IllegalStateException("保存血缘资产后无法读取资产"));
   }

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V2__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V2__expand_project_scope.sql
@@ -1,0 +1,16 @@
+-- Project Space Stage 4 expand migration for Lineage projections.
+-- Project ownership is propagated from producer/source truth, so columns remain nullable until
+-- Data Development / Dataset / Sync / Workflow producers have completed their own migration.
+
+ALTER TABLE yak_metadata_asset
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID from source truth' AFTER id,
+    DROP INDEX uk_yak_metadata_asset_key,
+    ADD UNIQUE KEY uk_yak_metadata_asset_project_key (project_id, asset_key),
+    ADD KEY idx_yak_metadata_asset_project_type (project_id, asset_type, update_time),
+    ADD KEY idx_yak_metadata_asset_project_source (project_id, source_type, source_id);
+
+ALTER TABLE yak_metadata_relation
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Project ID shared by source/target assets' AFTER id,
+    ADD KEY idx_yak_metadata_relation_project_source (project_id, source_asset_id, relation_type),
+    ADD KEY idx_yak_metadata_relation_project_target (project_id, target_asset_id, relation_type),
+    ADD KEY idx_yak_metadata_relation_project_evidence (project_id, source_type, source_id);

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V2__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/db/migration/yak-lineage/V2__expand_project_scope.sql
@@ -1,11 +1,16 @@
 -- Project Space Stage 4 expand migration for Lineage projections.
--- Project ownership is propagated from producer/source truth, so columns remain nullable until
+-- Project ownership is propagated from producer/source truth, so project_id remains nullable until
 -- Data Development / Dataset / Sync / Workflow producers have completed their own migration.
+-- project_scope_id is a transitional database-only key: NULL project rows share scope 0, preserving
+-- the old global asset identity while project-aware rows can reuse the same asset_key per Project.
 
 ALTER TABLE yak_metadata_asset
     ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID from source truth' AFTER id,
+    ADD COLUMN project_scope_id BIGINT
+        GENERATED ALWAYS AS (COALESCE(project_id, 0)) STORED
+        COMMENT 'Transitional project identity key for nullable Project migration' AFTER project_id,
     DROP INDEX uk_yak_metadata_asset_key,
-    ADD UNIQUE KEY uk_yak_metadata_asset_project_key (project_id, asset_key),
+    ADD UNIQUE KEY uk_yak_metadata_asset_project_key (project_scope_id, asset_key),
     ADD KEY idx_yak_metadata_asset_project_type (project_id, asset_type, update_time),
     ADD KEY idx_yak_metadata_asset_project_source (project_id, source_type, source_id);
 

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageQueryMapper.xml
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageQueryMapper.xml
@@ -6,9 +6,15 @@
         SELECT source_asset_id AS asset_id
         FROM yak_metadata_relation
         WHERE source_type = #{sourceType} AND source_id = #{sourceId}
+        <if test="projectId != null">
+            AND project_id = #{projectId}
+        </if>
         UNION
         SELECT target_asset_id AS asset_id
         FROM yak_metadata_relation
         WHERE source_type = #{sourceType} AND source_id = #{sourceId}
+        <if test="projectId != null">
+            AND project_id = #{projectId}
+        </if>
     </select>
 </mapper>

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageWriteMapper.xml
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageWriteMapper.xml
@@ -75,6 +75,9 @@
                create_time, update_time
         FROM yak_metadata_asset
         WHERE asset_key = #{assetKey}
+        <if test="projectId != null">
+            AND project_id = #{projectId}
+        </if>
         LIMIT 1
         FOR UPDATE
     </select>
@@ -91,6 +94,9 @@
         </foreach>
           AND asset.source_type = #{ownerType}
           AND asset.source_id = #{ownerId}
+        <if test="projectId != null">
+          AND asset.project_id = #{projectId}
+        </if>
           AND outgoing.id IS NULL
           AND incoming.id IS NULL
           AND child.id IS NULL

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageWriteMapper.xml
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageWriteMapper.xml
@@ -4,71 +4,73 @@
 
     <insert id="upsertAsset">
         INSERT INTO yak_metadata_asset
-            (asset_key, asset_type, name, source_type, source_id, parent_asset_id,
+            (project_id, asset_key, asset_type, name, source_type, source_id, parent_asset_id,
              data_source_id, database_name, schema_name, table_name, column_name, properties,
              create_time, update_time)
         VALUES
-            (#{row.assetKey}, #{row.assetType}, #{row.name}, #{row.sourceType}, #{row.sourceId},
+            (#{row.projectId}, #{row.assetKey}, #{row.assetType}, #{row.name}, #{row.sourceType}, #{row.sourceId},
              #{row.parentAssetId}, #{row.dataSourceId}, #{row.databaseName}, #{row.schemaName},
              #{row.tableName}, #{row.columnName}, #{row.properties}, NOW(6), NOW(6))
         ON DUPLICATE KEY UPDATE
-            asset_type = VALUES(asset_type), name = VALUES(name), source_type = VALUES(source_type),
-            source_id = VALUES(source_id), parent_asset_id = VALUES(parent_asset_id),
-            data_source_id = VALUES(data_source_id), database_name = VALUES(database_name),
-            schema_name = VALUES(schema_name), table_name = VALUES(table_name),
-            column_name = VALUES(column_name), properties = VALUES(properties), update_time = NOW(6)
+            project_id = VALUES(project_id), asset_type = VALUES(asset_type), name = VALUES(name),
+            source_type = VALUES(source_type), source_id = VALUES(source_id),
+            parent_asset_id = VALUES(parent_asset_id), data_source_id = VALUES(data_source_id),
+            database_name = VALUES(database_name), schema_name = VALUES(schema_name),
+            table_name = VALUES(table_name), column_name = VALUES(column_name),
+            properties = VALUES(properties), update_time = NOW(6)
     </insert>
 
     <insert id="upsertRelation">
         INSERT INTO yak_metadata_relation
-            (source_asset_id, target_asset_id, relation_type, source_type, source_id,
+            (project_id, source_asset_id, target_asset_id, relation_type, source_type, source_id,
              expression, confidence, version, observed_at, properties, create_time, update_time)
         VALUES
-            (#{row.sourceAssetId}, #{row.targetAssetId}, #{row.relationType}, #{row.sourceType},
+            (#{row.projectId}, #{row.sourceAssetId}, #{row.targetAssetId}, #{row.relationType}, #{row.sourceType},
              #{row.sourceId}, #{row.expression}, #{row.confidence}, #{row.version},
              #{row.observedAt}, #{row.properties}, NOW(6), NOW(6))
         ON DUPLICATE KEY UPDATE
-            expression = VALUES(expression), confidence = VALUES(confidence),
+            project_id = VALUES(project_id), expression = VALUES(expression), confidence = VALUES(confidence),
             observed_at = VALUES(observed_at), properties = VALUES(properties), update_time = NOW(6)
     </insert>
 
     <insert id="upsertAssets">
         INSERT INTO yak_metadata_asset
-            (asset_key, asset_type, name, source_type, source_id, parent_asset_id,
+            (project_id, asset_key, asset_type, name, source_type, source_id, parent_asset_id,
              data_source_id, database_name, schema_name, table_name, column_name, properties,
              create_time, update_time)
         VALUES
         <foreach collection="rows" item="row" separator=",">
-            (#{row.assetKey}, #{row.assetType}, #{row.name}, #{row.sourceType}, #{row.sourceId},
+            (#{row.projectId}, #{row.assetKey}, #{row.assetType}, #{row.name}, #{row.sourceType}, #{row.sourceId},
              #{row.parentAssetId}, #{row.dataSourceId}, #{row.databaseName}, #{row.schemaName},
              #{row.tableName}, #{row.columnName}, #{row.properties}, NOW(6), NOW(6))
         </foreach>
         ON DUPLICATE KEY UPDATE
-            asset_type = VALUES(asset_type), name = VALUES(name), source_type = VALUES(source_type),
-            source_id = VALUES(source_id), parent_asset_id = VALUES(parent_asset_id),
-            data_source_id = VALUES(data_source_id), database_name = VALUES(database_name),
-            schema_name = VALUES(schema_name), table_name = VALUES(table_name),
-            column_name = VALUES(column_name), properties = VALUES(properties), update_time = NOW(6)
+            project_id = VALUES(project_id), asset_type = VALUES(asset_type), name = VALUES(name),
+            source_type = VALUES(source_type), source_id = VALUES(source_id),
+            parent_asset_id = VALUES(parent_asset_id), data_source_id = VALUES(data_source_id),
+            database_name = VALUES(database_name), schema_name = VALUES(schema_name),
+            table_name = VALUES(table_name), column_name = VALUES(column_name),
+            properties = VALUES(properties), update_time = NOW(6)
     </insert>
 
     <insert id="upsertRelations">
         INSERT INTO yak_metadata_relation
-            (source_asset_id, target_asset_id, relation_type, source_type, source_id,
+            (project_id, source_asset_id, target_asset_id, relation_type, source_type, source_id,
              expression, confidence, version, observed_at, properties, create_time, update_time)
         VALUES
         <foreach collection="rows" item="row" separator=",">
-            (#{row.sourceAssetId}, #{row.targetAssetId}, #{row.relationType}, #{row.sourceType},
+            (#{row.projectId}, #{row.sourceAssetId}, #{row.targetAssetId}, #{row.relationType}, #{row.sourceType},
              #{row.sourceId}, #{row.expression}, #{row.confidence}, #{row.version},
              #{row.observedAt}, #{row.properties}, NOW(6), NOW(6))
         </foreach>
         ON DUPLICATE KEY UPDATE
-            expression = VALUES(expression), confidence = VALUES(confidence),
+            project_id = VALUES(project_id), expression = VALUES(expression), confidence = VALUES(confidence),
             observed_at = VALUES(observed_at), properties = VALUES(properties), update_time = NOW(6)
     </insert>
 
     <select id="selectAssetForUpdate"
             resultType="io.yak.ops.business.lineage.dao.model.LineageAssetPO">
-        SELECT id, asset_key, asset_type, name, source_type, source_id, parent_asset_id,
+        SELECT id, project_id, asset_key, asset_type, name, source_type, source_id, parent_asset_id,
                data_source_id, database_name, schema_name, table_name, column_name, properties,
                create_time, update_time
         FROM yak_metadata_asset

--- a/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageWriteMapper.xml
+++ b/yak-ops-business/yak-ops-business-lineage/src/main/resources/mapper/lineage/LineageWriteMapper.xml
@@ -2,6 +2,17 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.yak.ops.business.lineage.dao.mapper.LineageWriteMapper">
 
+    <update id="claimLegacyAssetProject">
+        UPDATE yak_metadata_asset legacy
+        LEFT JOIN yak_metadata_asset scoped
+          ON scoped.asset_key = legacy.asset_key
+         AND scoped.project_id = #{projectId}
+        SET legacy.project_id = #{projectId}, legacy.update_time = NOW(6)
+        WHERE legacy.asset_key = #{assetKey}
+          AND legacy.project_id IS NULL
+          AND scoped.id IS NULL
+    </update>
+
     <insert id="upsertAsset">
         INSERT INTO yak_metadata_asset
             (project_id, asset_key, asset_type, name, source_type, source_id, parent_asset_id,

--- a/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/registration/LineageProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-lineage/src/test/java/io/yak/ops/business/lineage/registration/LineageProjectScopeTest.java
@@ -1,0 +1,106 @@
+package io.yak.ops.business.lineage.registration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.lineage.domain.LineageAsset;
+import io.yak.ops.business.lineage.domain.LineageAssetDraft;
+import io.yak.ops.business.lineage.domain.LineageAssetType;
+import io.yak.ops.business.lineage.domain.LineageRelationType;
+import io.yak.ops.business.lineage.registration.LineageRegistrationService.RegisterAssetCommand;
+import io.yak.ops.business.lineage.registration.LineageRegistrationService.RegisterRelationCommand;
+import io.yak.ops.business.lineage.repository.LineageRepository;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class LineageProjectScopeTest {
+
+  @Test
+  void sourceProjectCannotOverrideCurrentProject() {
+    LineageRepository repository = mock(LineageRepository.class);
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    LineageRegistrationDraftFactory factory =
+        new LineageRegistrationDraftFactory(repository, currentProject);
+
+    RegisterAssetCommand command = assetCommand(8L);
+
+    assertThrows(ProjectContextException.class, () -> factory.asset(command, true));
+  }
+
+  @Test
+  void sourceProjectPropagatesWithoutHttpContext() {
+    LineageRepository repository = mock(LineageRepository.class);
+    LineageRegistrationDraftFactory factory = new LineageRegistrationDraftFactory(repository);
+
+    LineageAssetDraft draft = factory.asset(assetCommand(7L), true);
+
+    assertEquals(7L, draft.projectId());
+  }
+
+  @Test
+  void relationRejectsAssetsFromDifferentProjects() {
+    LineageRepository repository = mock(LineageRepository.class);
+    when(repository.findAsset(1L)).thenReturn(Optional.of(asset(1L, 7L)));
+    when(repository.findAsset(2L)).thenReturn(Optional.of(asset(2L, 8L)));
+    LineageRegistrationDraftFactory factory = new LineageRegistrationDraftFactory(repository);
+
+    RegisterRelationCommand command = new RegisterRelationCommand(
+        1L,
+        2L,
+        LineageRelationType.DERIVES_FROM,
+        "TEST",
+        "relation-1",
+        null,
+        null,
+        "v1",
+        Instant.parse("2026-08-29T00:00:00Z"),
+        null,
+        null);
+
+    assertThrows(ProjectContextException.class, () -> factory.relation(command, true));
+  }
+
+  private RegisterAssetCommand assetCommand(Long sourceProjectId) {
+    return new RegisterAssetCommand(
+        "table:orders",
+        LineageAssetType.TABLE,
+        "orders",
+        "TEST",
+        "orders",
+        null,
+        "9",
+        "demo",
+        null,
+        "orders",
+        null,
+        null,
+        sourceProjectId);
+  }
+
+  private LineageAsset asset(long id, Long projectId) {
+    Instant now = Instant.parse("2026-08-29T00:00:00Z");
+    return new LineageAsset(
+        id,
+        projectId,
+        "asset:" + id,
+        LineageAssetType.TABLE,
+        "asset-" + id,
+        "TEST",
+        String.valueOf(id),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        now,
+        now);
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/repository/JdbcTaskAssetRepository.java
@@ -57,6 +57,7 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
       long revisionId,
       int revisionNo) {
     Long effectiveProjectId = effectiveProjectId(projectId);
+    claimLegacyProject(source, sourceRef, effectiveProjectId);
     jdbcTemplate.update(
         """
         INSERT INTO yak_task_asset (
@@ -79,7 +80,7 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
         taskType,
         revisionId,
         revisionNo);
-    return findBySource(source, sourceRef)
+    return findBySourceInProject(source, sourceRef, effectiveProjectId)
         .orElseThrow(() -> new IllegalStateException("任务资产发布后无法重新读取：" + source + "/" + sourceRef));
   }
 
@@ -96,13 +97,7 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
   @Override
   public Optional<TaskAsset> findBySource(TaskAssetSource source, String sourceRef) {
     Long projectId = currentProjectId();
-    String sql = SELECT_COLUMNS + " WHERE source = ? AND source_ref = ?"
-        + (projectId == null ? "" : " AND project_id = ?")
-        + " LIMIT 1";
-    Object[] args = projectId == null
-        ? new Object[] {source.name(), sourceRef}
-        : new Object[] {source.name(), sourceRef, projectId};
-    return jdbcTemplate.query(sql, JdbcTaskAssetRepository::mapRow, args).stream().findFirst();
+    return findBySourceInProject(source, sourceRef, projectId);
   }
 
   @Override
@@ -143,17 +138,17 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
       String name,
       String taskType) {
     Long effectiveProjectId = effectiveProjectId(projectId);
-    Long currentProjectId = currentProjectId();
+    claimLegacyProject(source, sourceRef, effectiveProjectId);
     String sql = "UPDATE yak_task_asset SET project_id = ?, name = ?, task_type = ?, update_time = NOW(6) "
         + "WHERE source = ? AND source_ref = ?"
-        + (currentProjectId == null ? "" : " AND (project_id = ? OR project_id IS NULL)");
+        + (effectiveProjectId == null ? " AND project_id IS NULL" : " AND project_id = ?");
     List<Object> args = new ArrayList<>();
     args.add(effectiveProjectId);
     args.add(name);
     args.add(taskType);
     args.add(source.name());
     args.add(sourceRef);
-    if (currentProjectId != null) args.add(currentProjectId);
+    if (effectiveProjectId != null) args.add(effectiveProjectId);
     return jdbcTemplate.update(sql, args.toArray()) > 0;
   }
 
@@ -164,11 +159,44 @@ public class JdbcTaskAssetRepository implements TaskAssetRepository {
       TaskAssetStatus status) {
     Long projectId = currentProjectId();
     String sql = "UPDATE yak_task_asset SET status = ?, update_time = NOW(6) WHERE source = ? AND source_ref = ?"
-        + (projectId == null ? "" : " AND project_id = ?");
+        + (projectId == null ? " AND project_id IS NULL" : " AND project_id = ?");
     Object[] args = projectId == null
         ? new Object[] {status.name(), source.name(), sourceRef}
         : new Object[] {status.name(), source.name(), sourceRef, projectId};
     return jdbcTemplate.update(sql, args) > 0;
+  }
+
+  private Optional<TaskAsset> findBySourceInProject(
+      TaskAssetSource source, String sourceRef, Long projectId) {
+    String sql = SELECT_COLUMNS + " WHERE source = ? AND source_ref = ?"
+        + (projectId == null ? " AND project_id IS NULL" : " AND project_id = ?")
+        + " LIMIT 1";
+    Object[] args = projectId == null
+        ? new Object[] {source.name(), sourceRef}
+        : new Object[] {source.name(), sourceRef, projectId};
+    return jdbcTemplate.query(sql, JdbcTaskAssetRepository::mapRow, args).stream().findFirst();
+  }
+
+  private void claimLegacyProject(
+      TaskAssetSource source, String sourceRef, Long projectId) {
+    if (projectId == null) return;
+    jdbcTemplate.update(
+        """
+        UPDATE yak_task_asset legacy
+        LEFT JOIN yak_task_asset scoped
+          ON scoped.source = legacy.source
+         AND scoped.source_ref = legacy.source_ref
+         AND scoped.project_id = ?
+        SET legacy.project_id = ?, legacy.update_time = NOW(6)
+        WHERE legacy.source = ?
+          AND legacy.source_ref = ?
+          AND legacy.project_id IS NULL
+          AND scoped.id IS NULL
+        """,
+        projectId,
+        projectId,
+        source.name(),
+        sourceRef);
   }
 
   private Long currentProjectId() {

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/service/TaskCatalogService.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +59,7 @@ public class TaskCatalogService {
   public TaskAsset publish(
       TaskAssetSource source,
       String sourceRef,
-      Long projectId,
+      Long sourceProjectId,
       String name,
       String taskType,
       long revisionId,
@@ -71,7 +72,7 @@ public class TaskCatalogService {
     return repository.upsertPublished(
         source,
         normalizeSourceRef(sourceRef),
-        normalizeProjectId(projectId),
+        normalizeProjectId(sourceProjectId),
         normalizeName(name),
         normalizedTaskType,
         revisionId,
@@ -106,6 +107,13 @@ public class TaskCatalogService {
           "任务资产类型与版本类型不一致：asset=" + asset.taskType()
               + "，revision=" + revision.definition().taskType());
     }
+    if (asset.projectId() != null
+        && revision.sourceProjectId() != null
+        && !Objects.equals(asset.projectId(), revision.sourceProjectId())) {
+      throw new IllegalStateException(
+          "任务资产 Project 与来源版本 Project 不一致：assetProject=" + asset.projectId()
+              + "，sourceProject=" + revision.sourceProjectId());
+    }
     return new TaskAssetRevision(asset, revision);
   }
 
@@ -118,14 +126,14 @@ public class TaskCatalogService {
   public void updateSourceMetadata(
       TaskAssetSource source,
       String sourceRef,
-      Long projectId,
+      Long sourceProjectId,
       String name,
       String taskType) {
     if (source == null) throw new IllegalArgumentException("任务资产来源不能为空");
     repository.updateSourceMetadata(
         source,
         normalizeSourceRef(sourceRef),
-        normalizeProjectId(projectId),
+        normalizeProjectId(sourceProjectId),
         normalizeName(name),
         normalizeTaskType(taskType));
   }

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskSourceRevision.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskSourceRevision.java
@@ -8,11 +8,24 @@ public record TaskSourceRevision(
     long revisionId,
     int revisionNo,
     TaskDefinition definition,
-    String checksum) {
+    String checksum,
+    Long sourceProjectId) {
 
   public TaskSourceRevision {
     if (revisionId <= 0L) throw new IllegalArgumentException("revisionId must be positive");
     if (revisionNo <= 0) throw new IllegalArgumentException("revisionNo must be positive");
     definition = Objects.requireNonNull(definition, "definition");
+    if (sourceProjectId != null && sourceProjectId <= 0L) {
+      throw new IllegalArgumentException("sourceProjectId must be positive when present");
+    }
+  }
+
+  /** Compatibility constructor for producers that have not reached their Project Space stage yet. */
+  public TaskSourceRevision(
+      long revisionId,
+      int revisionNo,
+      TaskDefinition definition,
+      String checksum) {
+    this(revisionId, revisionNo, definition, checksum, null);
   }
 }

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V4__strengthen_project_source_identity.sql
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/resources/db/migration/yak-task-catalog/V4__strengthen_project_source_identity.sql
@@ -1,0 +1,11 @@
+-- Project Space Stage 4: TaskAsset is a projection whose ownership comes from its source domain.
+-- project_id remains nullable until all Task producers are migrated. project_scope_id keeps legacy
+-- NULL projections globally unique while allowing the same source/source_ref identity per Project.
+
+ALTER TABLE yak_task_asset
+    ADD COLUMN project_scope_id BIGINT
+        GENERATED ALWAYS AS (COALESCE(project_id, 0)) STORED
+        COMMENT 'Transitional project identity key for nullable Project migration' AFTER project_id,
+    DROP INDEX uk_yak_task_asset_source_ref,
+    ADD UNIQUE KEY uk_yak_task_asset_project_source_ref
+        (project_scope_id, source, source_ref);

--- a/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/service/TaskCatalogServiceTest.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/service/TaskCatalogServiceTest.java
@@ -9,11 +9,15 @@ import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
 import io.yak.ops.business.taskcatalog.repository.TaskAssetRepository;
+import io.yak.ops.business.taskcatalog.spi.TaskAssetRevisionProvider;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
 import io.yak.ops.spi.task.model.TaskRevisionRef;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class TaskCatalogServiceTest {
@@ -83,6 +87,34 @@ class TaskCatalogServiceTest {
         TaskAssetSource.DATA_DEVELOPMENT,
         TaskAssetStatus.ONLINE,
         "统计");
+  }
+
+  @Test
+  void revisionProjectMustMatchPublishedAssetProject() {
+    TaskAssetRepository repository = mock(TaskAssetRepository.class);
+    TaskAssetRevisionProvider provider = new TaskAssetRevisionProvider() {
+      @Override
+      public TaskAssetSource source() {
+        return TaskAssetSource.DATA_DEVELOPMENT;
+      }
+
+      @Override
+      public Optional<TaskSourceRevision> resolve(String sourceRef, long revisionId) {
+        return Optional.of(new TaskSourceRevision(
+            101L,
+            2,
+            new TaskDefinition("SQL", 1, "select 1", "{}"),
+            "checksum",
+            8L));
+      }
+    };
+    TaskCatalogService service = new TaskCatalogService(repository, List.of(provider));
+    when(repository.findById(9L)).thenReturn(Optional.of(asset(9L, 101L, 2)));
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> service.resolveRevision(9L, 101L));
+
+    assertTrue(exception.getMessage().contains("Project"));
   }
 
   private TaskAsset asset(long id, long revisionId, int revisionNo) {


### PR DESCRIPTION
## 背景

Stage 4 在已合并的 DataSource / Resource / Data Service Project Space 基础上，为 **Task Catalog + Lineage** 建立 Project 传播底座。

这两个模块都属于投影层，因此本阶段遵循一个核心原则：

> Projection 的 Project 必须来自 Source Truth，不能由 Task Catalog / Lineage 自己猜，也不能信任前端任意传入的 projectId。

本 PR 只做 **Expand + Runtime substrate**，不会提前做最终 `NOT NULL` Contract；最终 Contract 要等 Data Development / Dataset / Sync / Workflow 等主要 Producer 完成 Project 化后再收口。

## Task Catalog

- `TaskSourceRevision` 增加 nullable `sourceProjectId`，并保留旧构造器兼容尚未迁移的 Producer
- `TaskCatalogService` 将发布参数语义收口为 `sourceProjectId`
- 解析 immutable revision 时校验 `TaskAsset.projectId` 与来源 revision 的 `sourceProjectId`，发现漂移直接拒绝
- 新增 V4 migration：将 `(source, source_ref)` identity 过渡为 Project-scoped identity
- 使用数据库内部 generated `project_scope_id = COALESCE(project_id, 0)`：
  - 历史 NULL 投影仍保持旧的全局唯一语义
  - 已 Project 化的 Producer 可在不同 Project 中拥有同一个 `source/source_ref`
- 发布/metadata 更新会用 Source Truth 主动 claim 历史 NULL 投影，避免同一个逻辑 TaskAsset 留下 legacy + project 两份记录
- 无 ProjectContext 时，按 source identity 的更新/下线不再猜测某个 Project-scoped 投影

## Lineage

- `yak_metadata_asset` 新增 nullable `project_id`
- `yak_metadata_relation` 新增 nullable `project_id`
- `asset_key` identity 过渡为 Project-scoped identity，同样用 generated `project_scope_id` 保护迁移期 NULL 语义
- Lineage HTTP API 增加 `@ProjectScope(PROJECT_OPTIONAL)`，当前阶段保留兼容窗口
- Asset / Relation / Draft / PO 全链路携带 Project ownership
- `RegisterAssetCommand` / `RegisterRelationCommand` 增加内部 `sourceProjectId` 传播入口，同时保留旧构造器
- HTTP DTO **不增加 projectId**：浏览器只能通过受信任 CurrentProject 进入上下文，不能覆盖 Source Truth
- `LineageRegistrationDraftFactory`：
  - CurrentProject 与 `sourceProjectId` 不一致时 fail-closed
  - 子资产与父资产必须属于同一 Project
  - Relation source / target asset 必须属于同一 Project
- 单条和批量注册都执行同 Project 校验
- DAO 查询、图遍历、overview/maintenance 相关读写在 CurrentProject 存在时追加 project 条件
- 后台 Producer 只有 `sourceProjectId`、没有 HTTP CurrentProject 时，写后回读仍按显式 Project 定位，避免同名 assetKey 串项目
- Project-aware upsert 会 claim 对应 legacy NULL asset，逐步为后续 Backfill / Contract 减少历史空值

## 数据迁移策略

本 PR **不做**：

- `project_id NOT NULL`
- 将 Lineage / Task Catalog 切换到 `PROJECT_REQUIRED`
- 猜测历史 NULL 数据属于哪个 Project
- 提前修改 Data Development / Dataset / Offline Sync / Realtime Sync / Workflow 的 Project Root / Runtime 模型

历史 NULL 投影只能由其真实 Producer / Source Truth 在后续阶段逐步认领和回填。等主要 Producer 全部迁移完成后，再执行最终 Contract 并删除 `project_scope_id` 过渡列和无 Project 兼容路径。

## 验证

新增/更新测试覆盖：

- CurrentProject 不允许被 `sourceProjectId` 覆盖
- 后台无 HTTP Context 时 `sourceProjectId` 可以正确传播到 Lineage projection
- Relation 两端属于不同 Project 时拒绝注册
- TaskAsset 与来源 revision Project 不一致时拒绝解析

## 重点 Review

- Source Truth → TaskAsset → MetadataAsset/Relation 的 Project 传播方向是否正确
- nullable migration + generated scope key 的过渡语义
- legacy NULL projection claim 是否符合渐进迁移预期
- `PROJECT_OPTIONAL` 兼容窗口是否足够支撑 Stage 5/6/7 Producer 逐步接入
- 批量 lineage 注册当前优先保证同 Project 正确性，后续如出现大批量性能压力可改成批量预取 endpoint project

> Draft：当前环境无法执行完整本地 Maven / MySQL 集成测试，待 GitHub CI 与本地历史库升级验证后再转 Ready。