### PR TITLE
feat(data-development): harden core Project Space ownership (Stage 5A)

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/STAGE5A_PROJECT_SPACE.md
+++ b/yak-ops-business/yak-ops-business-data-development/STAGE5A_PROJECT_SPACE.md
@@ -1,0 +1,44 @@
+# Data Development Stage 5A — Project Space Core
+
+Stage 5A hardens the existing Data Development Project Space support after the Stage 4 Task Catalog / Lineage projection substrate.
+
+## Ownership model
+
+| Object | Ownership | Stage 5A behavior |
+| --- | --- | --- |
+| `yak_dev_directory` | `PROJECT_ROOT` | CRUD requires trusted `CurrentProject`; no empty-context global fallback |
+| `yak_dev_node` | `PROJECT_ROOT` | creation and CRUD require trusted `CurrentProject`; request bodies cannot choose `projectId` |
+| `yak_dev_task_draft` | `INHERITED` | inherits Project through `node_id`; no duplicate `project_id` column |
+| `yak_dev_task_revision` | `INHERITED` | inherits Project through `node_id`; Task Catalog revision projection obtains Project from the owning node |
+| `yak_dev_task_execution` | `PROJECT_RUNTIME` | persists Project at submission; normal reads/writes fail closed; only reconciliation dispatcher may scan projects |
+| `yak_dev_lineage_outbox` | `PROJECT_RUNTIME` | persists Project when enqueued; worker restores durable ProjectContext before Lineage IO |
+
+## Source Truth rules
+
+- HTTP node creation never accepts `projectId`; selected Project is resolved by the shared Project request context.
+- Data Development Node is the Source Truth for task Project ownership.
+- `DevelopmentTaskPublisher` publishes `node.projectId` to Task Catalog.
+- `DataDevelopmentTaskRevisionProvider` returns the same `sourceProjectId`, allowing Task Catalog to reject Project drift.
+- Lineage Outbox persists the Node Project and restores that Project before registering Lineage projections.
+- A Lineage task is rejected when its durable Project, Node Project, or revision-to-node ownership does not match.
+
+## Explicit cross-project dispatcher corridors
+
+Two background scans remain intentionally cross-project:
+
+- execution reconciliation (`listActiveForReconciliation`)
+- lineage outbox polling (`due`)
+
+They may only return rows with a persisted non-null Project ID. The worker/control plane must enter `ProjectContextScope` for each row before performing project-scoped business IO.
+
+## Deferred work
+
+Stage 5A intentionally does **not**:
+
+- make Data Development `project_id` columns `NOT NULL`;
+- remove the historical compatibility backfill;
+- projectize Dataset binding or close the Data Development ↔ Dataset integration corridor;
+- introduce Project columns on Draft/Revision child tables;
+- perform the final Data Development Contract migration.
+
+Dataset ownership is handled in Stage 6. Data Development × Dataset integration and final Contract cleanup remain Stage 5B / later global Contract work.

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentNodeApi.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/api/DevelopmentNodeApi.java
@@ -9,10 +9,10 @@ public final class DevelopmentNodeApi {
 
   private DevelopmentNodeApi() {}
 
+  /** Project ownership is resolved exclusively from the trusted CurrentProject request context. */
   public record CreateRequest(
       @NotBlank String name,
       @NotBlank String type,
-      @Min(0) Long projectId,
       @Min(0) Long directoryId) {
   }
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/controller/v1/DevelopmentNodeController.java
@@ -57,7 +57,6 @@ public class DevelopmentNodeController {
     DevelopmentNode created = service.create(
         request.name(),
         request.type(),
-        request.projectId(),
         request.directoryId());
     return Result.success(service.recordUpdater(created.id(), operatorName(servletRequest)));
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
@@ -40,6 +40,14 @@ public record DevelopmentNode(
     return nodeType().supportsTaskLifecycle();
   }
 
+  /** Data Development nodes are Project Roots and must never execute/publish without ownership. */
+  public Long requireProjectId() {
+    if (projectId == null || projectId <= 0L) {
+      throw new IllegalStateException("数据开发节点缺少有效 Project 归属：" + id);
+    }
+    return projectId;
+  }
+
   /** Guards the mutable Draft -> immutable Revision lifecycle at the domain identity boundary. */
   public void requireTaskLifecycle() {
     if (!supportsTaskLifecycle()) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/lineage/DevelopmentLineageWorker.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/lineage/DevelopmentLineageWorker.java
@@ -53,7 +53,7 @@ public class DevelopmentLineageWorker {
     if (!outbox.claim(task)) return;
     try {
       DevelopmentNode node = nodes.findById(task.nodeId()).orElseThrow();
-      if (!task.projectId().equals(node.projectId())) {
+      if (!task.projectId().equals(node.requireProjectId())) {
         throw new IllegalStateException(
             "Lineage outbox project does not match development node: task="
                 + task.taskId()
@@ -63,6 +63,15 @@ public class DevelopmentLineageWorker {
                 + node.projectId());
       }
       DevelopmentTaskRevision revision = revisions.findById(task.revisionId()).orElseThrow();
+      if (!node.id().equals(revision.nodeId())) {
+        throw new IllegalStateException(
+            "Lineage outbox revision does not belong to development node: task="
+                + task.taskId()
+                + ", nodeId="
+                + node.id()
+                + ", revisionNodeId="
+                + revision.nodeId());
+      }
       DevelopmentSqlLineageService.PreparedLineage prepared = lineage.prepare(node, revision);
       writer.writeIfLatest(node, revision, prepared);
       outbox.complete(task);

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/node/DevelopmentNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/node/DevelopmentNodeService.java
@@ -41,11 +41,9 @@ public class DevelopmentNodeService {
   public DevelopmentNode create(
       String name,
       String type,
-      Long projectId,
       Long directoryId) {
     DevelopmentNodeName nodeName = DevelopmentNodeName.of(name);
     DevelopmentNodeType nodeType = DevelopmentNodeType.require(type);
-    Long normalizedProjectId = normalizeProjectId(projectId);
     Long normalizedDirectoryId = normalizeDirectoryId(directoryId);
 
     if (normalizedDirectoryId != null
@@ -59,9 +57,21 @@ public class DevelopmentNodeService {
     return repository.insert(
         nodeName.value(),
         nodeType.name(),
-        normalizedProjectId,
         normalizedDirectoryId,
         false);
+  }
+
+  /**
+   * Compatibility entry for pre-Stage-5A internal callers. The supplied projectId is intentionally
+   * ignored; Project Root ownership is resolved only from trusted CurrentProject in the repository.
+   */
+  @Deprecated
+  public DevelopmentNode create(
+      String name,
+      String type,
+      Long ignoredProjectId,
+      Long directoryId) {
+    return create(name, type, directoryId);
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)
@@ -113,10 +123,6 @@ public class DevelopmentNodeService {
           TaskAssetSource.DATA_DEVELOPMENT,
           String.valueOf(current.id()));
     }
-  }
-
-  private Long normalizeProjectId(Long projectId) {
-    return projectId == null || projectId <= 0L ? null : projectId;
   }
 
   private Long normalizeDirectoryId(Long directoryId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentDirectoryRepositoryAdapter.java
@@ -28,15 +28,17 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
     this.currentProject = currentProject;
   }
 
+  /** Compatibility constructor for focused tests; project-scoped operations will fail closed. */
   public DevelopmentDirectoryRepositoryAdapter(DevelopmentDirectoryMapper mapper) {
     this(mapper, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
   public DevelopmentDirectory insert(Long parentId, String name) {
+    Long projectId = requiredProjectId();
     Instant now = Instant.now();
     DevelopmentDirectoryPO po = new DevelopmentDirectoryPO();
-    po.setProjectId(currentProjectId());
+    po.setProjectId(projectId);
     po.setParentId(toStoredParentId(parentId));
     po.setName(name);
     po.setCreateTime(now);
@@ -47,21 +49,21 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public Optional<DevelopmentDirectory> findById(Long id) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return Optional.ofNullable(
             mapper.selectOne(
                 new LambdaQueryWrapper<DevelopmentDirectoryPO>()
                     .eq(DevelopmentDirectoryPO::getId, id)
-                    .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)))
+                    .eq(DevelopmentDirectoryPO::getProjectId, projectId)))
         .map(this::toDomain);
   }
 
   @Override
   public List<DevelopmentDirectory> list() {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.selectList(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
-                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
+                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
                 .orderByAsc(DevelopmentDirectoryPO::getName)
                 .orderByAsc(DevelopmentDirectoryPO::getId))
         .stream()
@@ -71,10 +73,10 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public boolean existsByName(Long parentId, String name) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
-                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
+                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
                 .eq(DevelopmentDirectoryPO::getParentId, toStoredParentId(parentId))
                 .eq(DevelopmentDirectoryPO::getName, name))
         > 0L;
@@ -82,22 +84,22 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public boolean hasChildren(Long id) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
-                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
+                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
                 .eq(DevelopmentDirectoryPO::getParentId, id))
         > 0L;
   }
 
   @Override
   public boolean updateName(Long id, String name) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentDirectoryPO>()
                 .eq(DevelopmentDirectoryPO::getId, id)
-                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId)
+                .eq(DevelopmentDirectoryPO::getProjectId, projectId)
                 .set(DevelopmentDirectoryPO::getName, name)
                 .set(DevelopmentDirectoryPO::getUpdateTime, Instant.now()))
         > 0;
@@ -105,16 +107,16 @@ public class DevelopmentDirectoryRepositoryAdapter implements DevelopmentDirecto
 
   @Override
   public boolean deleteById(Long id) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.delete(
             new LambdaQueryWrapper<DevelopmentDirectoryPO>()
                 .eq(DevelopmentDirectoryPO::getId, id)
-                .eq(projectId != null, DevelopmentDirectoryPO::getProjectId, projectId))
+                .eq(DevelopmentDirectoryPO::getProjectId, projectId))
         > 0;
   }
 
-  private Long currentProjectId() {
-    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  private Long requiredProjectId() {
+    return currentProject.requireProjectId();
   }
 
   private Long toStoredParentId(Long parentId) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentLineageOutboxRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentLineageOutboxRepositoryAdapter.java
@@ -1,7 +1,9 @@
 package io.yak.ops.business.development.repository;
 
 import io.yak.ops.business.development.repository.DevelopmentLineageOutboxRepository.OutboxRecord;
+import io.yak.ops.core.project.CurrentProject;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -11,23 +13,34 @@ public class DevelopmentLineageOutboxRepositoryAdapter
     implements DevelopmentLineageOutboxRepository {
 
   private final JdbcTemplate jdbc;
+  private final CurrentProject currentProject;
 
-  public DevelopmentLineageOutboxRepositoryAdapter(JdbcTemplate jdbc) {
+  @Autowired
+  public DevelopmentLineageOutboxRepositoryAdapter(
+      JdbcTemplate jdbc, CurrentProject currentProject) {
     this.jdbc = jdbc;
+    this.currentProject = currentProject;
   }
 
   @Override
   public void enqueue(String taskId, long nodeId, long revisionId) {
-    jdbc.update(
+    Long projectId = currentProject.requireProjectId();
+    int inserted = jdbc.update(
         "INSERT IGNORE INTO yak_dev_lineage_outbox "
             + "(task_id,project_id,node_id,revision_id,status,attempts,next_attempt_time,create_time,update_time) "
             + "SELECT ?,project_id,id,?,'PENDING',0,NOW(6),NOW(6),NOW(6) FROM yak_dev_node "
-            + "WHERE id=? AND project_id IS NOT NULL",
+            + "WHERE id=? AND project_id=?",
         taskId,
         revisionId,
-        nodeId);
+        nodeId,
+        projectId);
+    if (inserted != 1) {
+      throw new IllegalStateException(
+          "无法为当前 Project 的数据开发节点创建血缘 Outbox：nodeId=" + nodeId);
+    }
   }
 
+  /** Cross-project dispatcher query; every record carries durable project ownership. */
   @Override
   public List<OutboxRecord> due(int limit) {
     return jdbc.query(

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentLineageOutboxRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentLineageOutboxRepositoryAdapter.java
@@ -2,7 +2,9 @@ package io.yak.ops.business.development.repository;
 
 import io.yak.ops.business.development.repository.DevelopmentLineageOutboxRepository.OutboxRecord;
 import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -22,10 +24,26 @@ public class DevelopmentLineageOutboxRepositoryAdapter
     this.currentProject = currentProject;
   }
 
+  /** Compatibility constructor for focused tests; enqueue will fail closed without ProjectContext. */
+  DevelopmentLineageOutboxRepositoryAdapter(JdbcTemplate jdbc) {
+    this(jdbc, Optional::<ProjectContext>empty);
+  }
+
   @Override
   public void enqueue(String taskId, long nodeId, long revisionId) {
     Long projectId = currentProject.requireProjectId();
-    int inserted = jdbc.update(
+    Long ownedNodeCount = jdbc.queryForObject(
+        "SELECT COUNT(1) FROM yak_dev_node WHERE id=? AND project_id=?",
+        Long.class,
+        nodeId,
+        projectId);
+    if (ownedNodeCount == null || ownedNodeCount != 1L) {
+      throw new IllegalStateException(
+          "无法为当前 Project 的数据开发节点创建血缘 Outbox：nodeId=" + nodeId);
+    }
+
+    // INSERT IGNORE is intentionally idempotent: the same node/revision may already have an outbox row.
+    jdbc.update(
         "INSERT IGNORE INTO yak_dev_lineage_outbox "
             + "(task_id,project_id,node_id,revision_id,status,attempts,next_attempt_time,create_time,update_time) "
             + "SELECT ?,project_id,id,?,'PENDING',0,NOW(6),NOW(6),NOW(6) FROM yak_dev_node "
@@ -34,10 +52,6 @@ public class DevelopmentLineageOutboxRepositoryAdapter
         revisionId,
         nodeId,
         projectId);
-    if (inserted != 1) {
-      throw new IllegalStateException(
-          "无法为当前 Project 的数据开发节点创建血缘 Outbox：nodeId=" + nodeId);
-    }
   }
 
   /** Cross-project dispatcher query; every record carries durable project ownership. */

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
@@ -7,10 +7,10 @@ import java.util.Optional;
 /** Durable repository for data-development tree node metadata. */
 public interface DevelopmentNodeRepository {
 
+  /** Creates a Project Root in the trusted CurrentProject owned by the persistence adapter. */
   DevelopmentNode insert(
       String name,
       String type,
-      Long projectId,
       Long directoryId,
       boolean configured);
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepository.java
@@ -7,12 +7,25 @@ import java.util.Optional;
 /** Durable repository for data-development tree node metadata. */
 public interface DevelopmentNodeRepository {
 
-  /** Creates a Project Root in the trusted CurrentProject owned by the persistence adapter. */
+  /**
+   * Compatibility contract for pre-Stage-5A callers. Production persistence must not trust the
+   * supplied projectId; it is retained only to avoid a wide source-compatibility break.
+   */
   DevelopmentNode insert(
       String name,
       String type,
+      Long ignoredProjectId,
       Long directoryId,
       boolean configured);
+
+  /** Creates a Project Root whose ownership is resolved by the persistence adapter. */
+  default DevelopmentNode insert(
+      String name,
+      String type,
+      Long directoryId,
+      boolean configured) {
+    return insert(name, type, null, directoryId, configured);
+  }
 
   Optional<DevelopmentNode> findById(Long id);
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -45,6 +45,7 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
   public DevelopmentNode insert(
       String name,
       String type,
+      Long ignoredProjectId,
       Long directoryId,
       boolean configured) {
     Long projectId = requiredProjectId();

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -35,6 +35,7 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
     this.currentProject = currentProject;
   }
 
+  /** Compatibility constructor for focused tests; project-scoped operations will fail closed. */
   public DevelopmentNodeRepositoryAdapter(
       DevelopmentNodeMapper mapper, JdbcTemplate jdbcTemplate) {
     this(mapper, jdbcTemplate, Optional::<io.yak.ops.core.project.ProjectContext>empty);
@@ -44,14 +45,14 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
   public DevelopmentNode insert(
       String name,
       String type,
-      Long projectId,
       Long directoryId,
       boolean configured) {
+    Long projectId = requiredProjectId();
     Instant now = Instant.now();
     DevelopmentNodePO po = new DevelopmentNodePO();
     po.setName(name);
     po.setType(type);
-    po.setProjectId(currentProjectId() == null ? projectId : currentProjectId());
+    po.setProjectId(projectId);
     po.setDirectoryId(toStoredDirectoryId(directoryId));
     po.setConfigured(configured);
     po.setDeleted(false);
@@ -63,21 +64,21 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public Optional<DevelopmentNode> findById(Long id) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return Optional.ofNullable(
             mapper.selectOne(
                 new LambdaQueryWrapper<DevelopmentNodePO>()
                     .eq(DevelopmentNodePO::getId, id)
-                    .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)))
+                    .eq(DevelopmentNodePO::getProjectId, projectId)))
         .map(po -> toDomain(po, hasUnpublishedChanges(po.getId())));
   }
 
   @Override
   public List<DevelopmentNode> list() {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     List<DevelopmentNodePO> nodes = mapper.selectList(
         new LambdaQueryWrapper<DevelopmentNodePO>()
-            .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
+            .eq(DevelopmentNodePO::getProjectId, projectId)
             .orderByAsc(DevelopmentNodePO::getName)
             .orderByAsc(DevelopmentNodePO::getId));
     Map<Long, Boolean> pendingPublishByNodeId = loadPendingPublishByNodeId(projectId);
@@ -88,18 +89,18 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public long count() {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.selectCount(
         new LambdaQueryWrapper<DevelopmentNodePO>()
-            .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId));
+            .eq(DevelopmentNodePO::getProjectId, projectId));
   }
 
   @Override
   public boolean existsByName(Long directoryId, String name) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentNodePO>()
-                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
+                .eq(DevelopmentNodePO::getProjectId, projectId)
                 .eq(DevelopmentNodePO::getDirectoryId, toStoredDirectoryId(directoryId))
                 .eq(DevelopmentNodePO::getName, name))
         > 0L;
@@ -107,22 +108,22 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public boolean existsInDirectory(Long directoryId) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.selectCount(
             new LambdaQueryWrapper<DevelopmentNodePO>()
-                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
+                .eq(DevelopmentNodePO::getProjectId, projectId)
                 .eq(DevelopmentNodePO::getDirectoryId, toStoredDirectoryId(directoryId)))
         > 0L;
   }
 
   @Override
   public boolean updateName(Long id, String name) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentNodePO>()
                 .eq(DevelopmentNodePO::getId, id)
-                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
+                .eq(DevelopmentNodePO::getProjectId, projectId)
                 .set(DevelopmentNodePO::getName, name)
                 .set(DevelopmentNodePO::getUpdateTime, Instant.now()))
         > 0;
@@ -130,12 +131,12 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public boolean updateConfigured(Long id, boolean configured) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentNodePO>()
                 .eq(DevelopmentNodePO::getId, id)
-                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
+                .eq(DevelopmentNodePO::getProjectId, projectId)
                 .set(DevelopmentNodePO::getConfigured, configured)
                 .set(DevelopmentNodePO::getUpdateTime, Instant.now()))
         > 0;
@@ -143,28 +144,28 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
 
   @Override
   public boolean updateUpdatedBy(Long id, String updatedBy) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.update(
             null,
             new LambdaUpdateWrapper<DevelopmentNodePO>()
                 .eq(DevelopmentNodePO::getId, id)
-                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId)
+                .eq(DevelopmentNodePO::getProjectId, projectId)
                 .set(DevelopmentNodePO::getUpdatedBy, updatedBy))
         > 0;
   }
 
   @Override
   public boolean deleteById(Long id) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     return mapper.delete(
             new LambdaQueryWrapper<DevelopmentNodePO>()
                 .eq(DevelopmentNodePO::getId, id)
-                .eq(projectId != null, DevelopmentNodePO::getProjectId, projectId))
+                .eq(DevelopmentNodePO::getProjectId, projectId))
         > 0;
   }
 
-  private Long currentProjectId() {
-    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  private Long requiredProjectId() {
+    return currentProject.requireProjectId();
   }
 
   private Long toStoredDirectoryId(Long directoryId) {
@@ -177,9 +178,8 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
         + "FROM yak_dev_task_draft d "
         + "JOIN yak_dev_node n ON n.id = d.node_id "
         + "LEFT JOIN yak_dev_task_revision r ON r.node_id = d.node_id "
-        + (projectId == null ? "" : "WHERE n.project_id = ? ")
+        + "WHERE n.project_id = ? "
         + "GROUP BY d.node_id, d.draft_revision";
-    Object[] args = projectId == null ? new Object[0] : new Object[] {projectId};
     jdbcTemplate.query(
         sql,
         rs -> {
@@ -189,7 +189,7 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
           boolean hasPublishedRevision = !rs.wasNull();
           result.put(nodeId, !hasPublishedRevision || draftRevision > publishedDraftRevision);
         },
-        args);
+        projectId);
     return result;
   }
 

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentTaskExecutionRepositoryAdapter.java
@@ -39,13 +39,14 @@ public class DevelopmentTaskExecutionRepositoryAdapter
     this.currentProject = currentProject;
   }
 
+  /** Compatibility constructor for focused tests; project-scoped operations will fail closed. */
   DevelopmentTaskExecutionRepositoryAdapter(JdbcTemplate jdbcTemplate) {
     this(jdbcTemplate, Optional::<io.yak.ops.core.project.ProjectContext>empty);
   }
 
   @Override
   public long createPending(PendingExecution pending) {
-    ensureCurrentProject(pending.projectId());
+    Long projectId = requireOwnerProject(pending.projectId());
     String sql = "INSERT INTO yak_dev_task_execution "
         + "(project_id, node_id, task_name, task_type, schema_version, trigger_type, status, operator_name, "
         + "retry_of_execution_id, content, config_json, start_time, create_time, update_time) "
@@ -54,8 +55,7 @@ public class DevelopmentTaskExecutionRepositoryAdapter
     jdbcTemplate.update(
         connection -> {
           PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
-          if (pending.projectId() == null) statement.setObject(1, null);
-          else statement.setLong(1, pending.projectId());
+          statement.setLong(1, projectId);
           statement.setLong(2, pending.nodeId());
           statement.setString(3, pending.taskName());
           statement.setString(4, pending.taskType());
@@ -75,29 +75,25 @@ public class DevelopmentTaskExecutionRepositoryAdapter
 
   @Override
   public void attachRuntime(long id, String runtimeExecutionId, String status) {
-    Long projectId = currentProjectId();
-    String sql = "UPDATE yak_dev_task_execution SET runtime_execution_id = ?, status = ?, update_time = NOW(6) "
-        + "WHERE id = ? AND status IN ('PENDING', 'RUNNING')"
-        + (projectId == null ? "" : " AND project_id = ?");
-    List<Object> args = new ArrayList<>();
-    args.add(runtimeExecutionId);
-    args.add(status);
-    args.add(id);
-    if (projectId != null) args.add(projectId);
-    jdbcTemplate.update(sql, args.toArray());
+    Long projectId = requiredProjectId();
+    jdbcTemplate.update(
+        "UPDATE yak_dev_task_execution SET runtime_execution_id = ?, status = ?, update_time = NOW(6) "
+            + "WHERE id = ? AND project_id = ? AND status IN ('PENDING', 'RUNNING')",
+        runtimeExecutionId,
+        status,
+        id,
+        projectId);
   }
 
   @Override
   public void updateActiveStatus(long id, String status) {
-    Long projectId = currentProjectId();
-    String sql = "UPDATE yak_dev_task_execution SET status = ?, update_time = NOW(6) "
-        + "WHERE id = ? AND status IN ('PENDING', 'RUNNING')"
-        + (projectId == null ? "" : " AND project_id = ?");
-    List<Object> args = new ArrayList<>();
-    args.add(status);
-    args.add(id);
-    if (projectId != null) args.add(projectId);
-    jdbcTemplate.update(sql, args.toArray());
+    Long projectId = requiredProjectId();
+    jdbcTemplate.update(
+        "UPDATE yak_dev_task_execution SET status = ?, update_time = NOW(6) "
+            + "WHERE id = ? AND project_id = ? AND status IN ('PENDING', 'RUNNING')",
+        status,
+        id,
+        projectId);
   }
 
   @Override
@@ -107,19 +103,17 @@ public class DevelopmentTaskExecutionRepositoryAdapter
       long durationMs,
       String errorMessage,
       String outputJson) {
-    Long projectId = currentProjectId();
-    String sql = "UPDATE yak_dev_task_execution SET status = ?, duration_ms = ?, error_message = ?, output_json = ?, "
-        + "end_time = NOW(6), update_time = NOW(6) WHERE id = ?"
-        + (projectId == null ? "" : " AND project_id = ?")
-        + " AND status IN ('PENDING', 'RUNNING')";
-    List<Object> args = new ArrayList<>();
-    args.add(status);
-    args.add(durationMs);
-    args.add(errorMessage);
-    args.add(outputJson);
-    args.add(id);
-    if (projectId != null) args.add(projectId);
-    jdbcTemplate.update(sql, args.toArray());
+    Long projectId = requiredProjectId();
+    jdbcTemplate.update(
+        "UPDATE yak_dev_task_execution SET status = ?, duration_ms = ?, error_message = ?, output_json = ?, "
+            + "end_time = NOW(6), update_time = NOW(6) WHERE id = ? AND project_id = ? "
+            + "AND status IN ('PENDING', 'RUNNING')",
+        status,
+        durationMs,
+        errorMessage,
+        outputJson,
+        id,
+        projectId);
   }
 
   @Override
@@ -145,32 +139,33 @@ public class DevelopmentTaskExecutionRepositoryAdapter
 
   @Override
   public Optional<ExecutionRecord> findById(long id) {
-    Long projectId = currentProjectId();
-    String sql = detailSelect()
-        + " WHERE id = ?"
-        + (projectId == null ? "" : " AND project_id = ?")
-        + " LIMIT 1";
-    Object[] args = projectId == null ? new Object[] {id} : new Object[] {id, projectId};
-    return jdbcTemplate.query(sql, DevelopmentTaskExecutionRepositoryAdapter::mapRecord, args)
+    Long projectId = requiredProjectId();
+    String sql = detailSelect() + " WHERE id = ? AND project_id = ? LIMIT 1";
+    return jdbcTemplate.query(
+            sql,
+            DevelopmentTaskExecutionRepositoryAdapter::mapRecord,
+            id,
+            projectId)
         .stream()
         .findFirst();
   }
 
   @Override
   public Optional<ExecutionRecord> findLatestActiveByNode(long nodeId) {
-    Long projectId = currentProjectId();
+    Long projectId = requiredProjectId();
     String sql = detailSelect()
-        + " WHERE node_id = ? AND status IN ('PENDING', 'RUNNING')"
-        + (projectId == null ? "" : " AND project_id = ?")
+        + " WHERE node_id = ? AND project_id = ? AND status IN ('PENDING', 'RUNNING')"
         + " ORDER BY start_time DESC, id DESC LIMIT 1";
-    Object[] args = projectId == null
-        ? new Object[] {nodeId}
-        : new Object[] {nodeId, projectId};
-    return jdbcTemplate.query(sql, DevelopmentTaskExecutionRepositoryAdapter::mapRecord, args)
+    return jdbcTemplate.query(
+            sql,
+            DevelopmentTaskExecutionRepositoryAdapter::mapRecord,
+            nodeId,
+            projectId)
         .stream()
         .findFirst();
   }
 
+  /** Explicit cross-project dispatcher corridor. Callers must restore each returned project before IO. */
   @Override
   public List<ExecutionRecord> listActiveForReconciliation(int limit) {
     int safeLimit = Math.max(1, Math.min(500, limit));
@@ -183,12 +178,8 @@ public class DevelopmentTaskExecutionRepositoryAdapter
   }
 
   private String buildWhere(Query query, List<Object> args) {
-    StringBuilder where = new StringBuilder(" WHERE 1 = 1");
-    Long projectId = currentProjectId();
-    if (projectId != null) {
-      where.append(" AND project_id = ?");
-      args.add(projectId);
-    }
+    StringBuilder where = new StringBuilder(" WHERE project_id = ?");
+    args.add(requiredProjectId());
     if (query.keyword() != null && !query.keyword().isBlank()) {
       where.append(" AND (task_name LIKE ? OR runtime_execution_id LIKE ? OR operator_name LIKE ?)");
       String like = "%" + query.keyword() + "%";
@@ -250,17 +241,18 @@ public class DevelopmentTaskExecutionRepositoryAdapter
         toLocalDateTime(rs.getTimestamp("end_time")));
   }
 
-  private Long currentProjectId() {
-    return currentProject.current().map(context -> context.projectId()).orElse(null);
+  private Long requiredProjectId() {
+    return currentProject.requireProjectId();
   }
 
-  private void ensureCurrentProject(Long ownerProjectId) {
-    currentProject.current().ifPresent(
-        context -> {
-          if (!Objects.equals(context.projectId(), ownerProjectId)) {
-            throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
-          }
-        });
+  private Long requireOwnerProject(Long ownerProjectId) {
+    Long currentProjectId = requiredProjectId();
+    if (ownerProjectId == null
+        || ownerProjectId <= 0L
+        || !Objects.equals(currentProjectId, ownerProjectId)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+    return currentProjectId;
   }
 
   private static LocalDateTime toLocalDateTime(Timestamp timestamp) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DataDevelopmentTaskRevisionProvider.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DataDevelopmentTaskRevisionProvider.java
@@ -1,6 +1,8 @@
 package io.yak.ops.business.development.task;
 
+import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
 import io.yak.ops.business.taskcatalog.spi.TaskAssetRevisionProvider;
 import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
@@ -13,10 +15,13 @@ import org.springframework.stereotype.Component;
 public class DataDevelopmentTaskRevisionProvider implements TaskAssetRevisionProvider {
 
   private final DevelopmentTaskRevisionRepository revisionRepository;
+  private final DevelopmentNodeRepository nodeRepository;
 
   public DataDevelopmentTaskRevisionProvider(
-      DevelopmentTaskRevisionRepository revisionRepository) {
+      DevelopmentTaskRevisionRepository revisionRepository,
+      DevelopmentNodeRepository nodeRepository) {
     this.revisionRepository = revisionRepository;
+    this.nodeRepository = nodeRepository;
   }
 
   @Override
@@ -27,17 +32,22 @@ public class DataDevelopmentTaskRevisionProvider implements TaskAssetRevisionPro
   @Override
   public Optional<TaskSourceRevision> resolve(String sourceRef, long revisionId) {
     Long nodeId = parseNodeId(sourceRef);
+    Optional<DevelopmentNode> node = nodeRepository.findById(nodeId);
+    if (node.isEmpty()) return Optional.empty();
+    Long sourceProjectId = node.orElseThrow().requireProjectId();
     return revisionRepository.findById(revisionId)
         .filter(revision -> nodeId.equals(revision.nodeId()))
-        .map(this::toSourceRevision);
+        .map(revision -> toSourceRevision(revision, sourceProjectId));
   }
 
-  private TaskSourceRevision toSourceRevision(DevelopmentTaskRevision revision) {
+  private TaskSourceRevision toSourceRevision(
+      DevelopmentTaskRevision revision, Long sourceProjectId) {
     return new TaskSourceRevision(
         revision.id(),
         revision.revisionNo(),
         revision.definition(),
-        revision.checksum());
+        revision.checksum(),
+        sourceProjectId);
   }
 
   private Long parseNodeId(String sourceRef) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskPublisher.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskPublisher.java
@@ -32,6 +32,7 @@ public class DevelopmentTaskPublisher {
       DevelopmentTaskDraft draft,
       TaskDefinition definition,
       String checksum) {
+    Long sourceProjectId = node.requireProjectId();
     DevelopmentTaskRevision latest = revisionRepository.findLatestByNodeId(node.id()).orElse(null);
     DevelopmentTaskRevision published;
     if (latest != null && latest.represents(draft.draftRevision(), checksum)) {
@@ -50,7 +51,7 @@ public class DevelopmentTaskPublisher {
     taskCatalogService.publish(
         TaskAssetSource.DATA_DEVELOPMENT,
         String.valueOf(node.id()),
-        node.projectId(),
+        sourceProjectId,
         node.name(),
         definition.taskType(),
         published.id(),

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/architecture/DataDevelopmentStage5AProjectSpaceContractTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/architecture/DataDevelopmentStage5AProjectSpaceContractTest.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.development.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Locks the Stage 5A Project Root / Runtime / Projection ownership boundaries. */
+class DataDevelopmentStage5AProjectSpaceContractTest {
+
+  @Test
+  void nodeCreateContractDoesNotAcceptProjectOverride() throws IOException {
+    String api = source("api/DevelopmentNodeApi.java");
+    String controller = source("controller/v1/DevelopmentNodeController.java");
+
+    assertThat(api)
+        .contains("record CreateRequest")
+        .doesNotContain("Long projectId");
+    assertThat(controller)
+        .contains("@ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)")
+        .doesNotContain("request.projectId()")
+        .contains("service.create(\n        request.name(),\n        request.type(),\n        request.directoryId())");
+  }
+
+  @Test
+  void projectRootRepositoriesFailClosedWithoutCurrentProject() throws IOException {
+    assertThat(source("repository/DevelopmentDirectoryRepositoryAdapter.java"))
+        .contains("currentProject.requireProjectId()")
+        .doesNotContain("projectId != null");
+    assertThat(source("repository/DevelopmentNodeRepositoryAdapter.java"))
+        .contains("currentProject.requireProjectId()")
+        .doesNotContain("projectId != null");
+  }
+
+  @Test
+  void runtimeRecordsPersistProjectAndOnlyDispatcherMayScanAcrossProjects() throws IOException {
+    String execution = source("repository/DevelopmentTaskExecutionRepositoryAdapter.java");
+    String outbox = source("repository/DevelopmentLineageOutboxRepositoryAdapter.java");
+    String worker = source("lineage/DevelopmentLineageWorker.java");
+
+    assertThat(execution)
+        .contains("requireOwnerProject(pending.projectId())")
+        .contains("listActiveForReconciliation")
+        .contains("project_id IS NOT NULL")
+        .contains("currentProject.requireProjectId()");
+    assertThat(outbox)
+        .contains("currentProject.requireProjectId()")
+        .contains("WHERE id=? AND project_id=?")
+        .contains("INSERT IGNORE INTO yak_dev_lineage_outbox");
+    assertThat(worker)
+        .contains("new ProjectContext(task.projectId(), null)")
+        .contains("node.requireProjectId()")
+        .contains("revision.nodeId()");
+  }
+
+  @Test
+  void taskCatalogProjectionReceivesProjectFromDevelopmentSourceTruth() throws IOException {
+    String provider = source("task/DataDevelopmentTaskRevisionProvider.java");
+    String publisher = source("task/DevelopmentTaskPublisher.java");
+
+    assertThat(provider)
+        .contains("node.orElseThrow().requireProjectId()")
+        .contains("sourceProjectId")
+        .contains("new TaskSourceRevision(");
+    assertThat(publisher)
+        .contains("Long sourceProjectId = node.requireProjectId()")
+        .contains("sourceProjectId,");
+  }
+
+  private String source(String relative) throws IOException {
+    return Files.readString(
+        moduleRoot()
+            .resolve("src/main/java/io/yak/ops/business/development")
+            .resolve(relative));
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of(".").toAbsolutePath().normalize();
+    if (Files.isRegularFile(local.resolve("pom.xml"))
+        && local.getFileName() != null
+        && "yak-ops-business-data-development".equals(local.getFileName().toString())) {
+      return local;
+    }
+    return Path.of("yak-ops-business", "yak-ops-business-data-development");
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DataDevelopmentTaskRevisionProviderTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DataDevelopmentTaskRevisionProviderTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.domain.DevelopmentTaskRevision;
+import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.development.repository.DevelopmentTaskRevisionRepository;
+import io.yak.ops.business.development.task.DataDevelopmentTaskRevisionProvider;
 import io.yak.ops.spi.task.model.TaskAssetSource;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.time.Instant;
@@ -16,9 +19,20 @@ import org.junit.jupiter.api.Test;
 class DataDevelopmentTaskRevisionProviderTest {
 
   @Test
-  void resolvesOnlyRevisionOwnedByRequestedDevelopmentNode() {
-    DevelopmentTaskRevisionRepository repository = mock(DevelopmentTaskRevisionRepository.class);
-    DataDevelopmentTaskRevisionProvider provider = new DataDevelopmentTaskRevisionProvider(repository);
+  void resolvesOnlyRevisionOwnedByRequestedDevelopmentNodeAndPropagatesProject() {
+    DevelopmentTaskRevisionRepository revisions = mock(DevelopmentTaskRevisionRepository.class);
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    DataDevelopmentTaskRevisionProvider provider =
+        new DataDevelopmentTaskRevisionProvider(revisions, nodes);
+    DevelopmentNode node = new DevelopmentNode(
+        12L,
+        "Orders",
+        "SQL",
+        7L,
+        null,
+        true,
+        Instant.parse("2026-08-12T00:00:00Z"),
+        Instant.parse("2026-08-12T00:00:00Z"));
     DevelopmentTaskRevision revision = new DevelopmentTaskRevision(
         101L,
         12L,
@@ -27,10 +41,14 @@ class DataDevelopmentTaskRevisionProviderTest {
         new TaskDefinition("SQL", 1, "select 1", "{}"),
         "checksum",
         Instant.parse("2026-08-12T00:00:00Z"));
-    when(repository.findById(101L)).thenReturn(Optional.of(revision));
+    when(nodes.findById(12L)).thenReturn(Optional.of(node));
+    when(nodes.findById(13L)).thenReturn(Optional.empty());
+    when(revisions.findById(101L)).thenReturn(Optional.of(revision));
 
     assertEquals(TaskAssetSource.DATA_DEVELOPMENT, provider.source());
-    assertEquals(3, provider.resolve("12", 101L).orElseThrow().revisionNo());
+    var resolved = provider.resolve("12", 101L).orElseThrow();
+    assertEquals(3, resolved.revisionNo());
+    assertEquals(7L, resolved.sourceProjectId());
     assertTrue(provider.resolve("13", 101L).isEmpty());
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
@@ -98,6 +98,7 @@ class DevelopmentNodeServiceTest {
     public DevelopmentNode insert(
         String name,
         String type,
+        Long ignoredProjectId,
         Long directoryId,
         boolean configured) {
       Long id = ids.getAndIncrement();

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentNodeServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import io.yak.ops.business.development.domain.DevelopmentDirectory;
 import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.business.development.node.DevelopmentNodeService;
 import io.yak.ops.business.development.repository.DevelopmentDirectoryRepository;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
@@ -32,14 +33,13 @@ class DevelopmentNodeServiceTest {
         directories,
         mock(TaskCatalogService.class));
 
-    DevelopmentNode sql = service.create("用户清洗", "sql", null, folder.id());
-    DevelopmentNode shell = service.create("清理临时文件", "shell", 7L, null);
+    DevelopmentNode sql = service.create("用户清洗", "sql", folder.id());
+    DevelopmentNode shell = service.create("清理临时文件", "shell", null);
 
     assertEquals("SQL", sql.type());
     assertEquals(folder.id(), sql.directoryId());
     assertFalse(sql.configured());
     assertEquals("SHELL", shell.type());
-    assertEquals(7L, shell.projectId());
     assertFalse(shell.configured());
   }
 
@@ -54,12 +54,12 @@ class DevelopmentNodeServiceTest {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> service.create("任务", "SQL", null, 999L));
+        () -> service.create("任务", "SQL", 999L));
 
-    service.create("任务", "SQL", null, null);
+    service.create("任务", "SQL", null);
     assertThrows(
         IllegalStateException.class,
-        () -> service.create("任务", "SHELL", null, null));
+        () -> service.create("任务", "SHELL", null));
   }
 
   @Test
@@ -71,7 +71,7 @@ class DevelopmentNodeServiceTest {
         nodes,
         directories,
         taskCatalogService);
-    DevelopmentNode node = service.create("任务", "SQL", null, null);
+    DevelopmentNode node = service.create("任务", "SQL", null);
 
     DevelopmentNode renamed = service.rename(node.id(), "新任务");
     assertEquals("新任务", renamed.name());
@@ -98,7 +98,6 @@ class DevelopmentNodeServiceTest {
     public DevelopmentNode insert(
         String name,
         String type,
-        Long projectId,
         Long directoryId,
         boolean configured) {
       Long id = ids.getAndIncrement();
@@ -107,7 +106,7 @@ class DevelopmentNodeServiceTest {
           id,
           name,
           type,
-          projectId,
+          null,
           directoryId,
           configured,
           now,

--- a/yak-ops-ui/src/pages/data-development/components/CreateDevelopmentNodeModal.tsx
+++ b/yak-ops-ui/src/pages/data-development/components/CreateDevelopmentNodeModal.tsx
@@ -11,13 +11,11 @@ interface CreateDevelopmentNodeModalProps {
   open: boolean;
   type: DevelopmentNodeType;
   directories: DevelopmentDirectory[];
-  defaultProjectId?: DevelopmentId;
   defaultDirectoryId?: DevelopmentId;
   loading?: boolean;
   onCancel: () => void;
   onNext: (
     type: DevelopmentNodeType,
-    projectId: DevelopmentId | undefined,
     directoryId: DevelopmentId | undefined,
     name: string,
   ) => void;
@@ -29,14 +27,12 @@ const CreateDevelopmentNodeModal = ({
   open,
   type: initialType,
   directories,
-  defaultProjectId,
   defaultDirectoryId,
   loading = false,
   onCancel,
   onNext,
 }: CreateDevelopmentNodeModalProps) => {
   const [type, setType] = useState<DevelopmentNodeType>(initialType);
-  const [projectId, setProjectId] = useState<DevelopmentId>();
   const [directoryId, setDirectoryId] = useState<DevelopmentId>();
   const [name, setName] = useState('');
 
@@ -66,16 +62,15 @@ const CreateDevelopmentNodeModal = ({
   useEffect(() => {
     if (!open) return;
     setType(initialType);
-    setProjectId(defaultProjectId);
     setDirectoryId(defaultDirectoryId);
     setName('');
-  }, [defaultDirectoryId, defaultProjectId, initialType, open]);
+  }, [defaultDirectoryId, initialType, open]);
 
   const normalizedName = name.trim();
 
   const submit = () => {
     if (!normalizedName || loading) return;
-    onNext(type, projectId, directoryId, normalizedName);
+    onNext(type, directoryId, normalizedName);
   };
 
   return (

--- a/yak-ops-ui/src/pages/data-development/hooks/useDataDevelopmentPage.ts
+++ b/yak-ops-ui/src/pages/data-development/hooks/useDataDevelopmentPage.ts
@@ -34,10 +34,6 @@ import {
   parseDevelopmentTreeWidth,
 } from '../utils';
 
-interface UseDataDevelopmentPageOptions {
-  defaultProjectId?: DevelopmentId;
-}
-
 const initialTreeWidth = () => {
   if (typeof window === 'undefined') return parseDevelopmentTreeWidth(null);
   return parseDevelopmentTreeWidth(
@@ -45,9 +41,7 @@ const initialTreeWidth = () => {
   );
 };
 
-export const useDataDevelopmentPage = ({
-  defaultProjectId,
-}: UseDataDevelopmentPageOptions = {}) => {
+export const useDataDevelopmentPage = () => {
   const requestSequenceRef = useRef(0);
   const [directories, setDirectories] = useState<DevelopmentDirectory[]>([]);
   const [nodes, setNodes] = useState<DevelopmentResourceNode[]>([]);
@@ -210,7 +204,6 @@ export const useDataDevelopmentPage = ({
   const submitNode = useCallback(
     async (
       type: DevelopmentNodeType,
-      projectId: DevelopmentId | undefined,
       directoryId: DevelopmentId | undefined,
       name: string,
     ) => {
@@ -219,7 +212,6 @@ export const useDataDevelopmentPage = ({
         const created = await createDevelopmentNode({
           name,
           type,
-          projectId: projectId || defaultProjectId,
           directoryId,
         });
         setCreateNodeOpen(false);
@@ -233,7 +225,7 @@ export const useDataDevelopmentPage = ({
         setNodeSaving(false);
       }
     },
-    [defaultProjectId, loadTree],
+    [loadTree],
   );
 
   const copyResourceText = useCallback(

--- a/yak-ops-ui/src/pages/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/data-development/index.tsx
@@ -1,4 +1,3 @@
-import { useSecurityProject } from '@/contexts/SecurityProjectContext';
 import { BRAND_THEME } from '@/styles/brand';
 import { ConfigProvider } from 'antd';
 
@@ -11,11 +10,7 @@ import RenameResourceModal from './components/RenameResourceModal';
 import { useDataDevelopmentPage } from './hooks/useDataDevelopmentPage';
 
 export default function DataDevelopmentPage() {
-  const { currentProject } = useSecurityProject();
-  const defaultProjectId = currentProject?.id
-    ? String(currentProject.id)
-    : undefined;
-  const page = useDataDevelopmentPage({ defaultProjectId });
+  const page = useDataDevelopmentPage();
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
@@ -52,11 +47,10 @@ export default function DataDevelopmentPage() {
           type={page.createNodeType}
           directories={page.directories}
           loading={page.nodeSaving}
-          defaultProjectId={defaultProjectId}
           defaultDirectoryId={page.directoryIdForSelection}
           onCancel={page.closeCreateNode}
-          onNext={(type, projectId, directoryId, name) =>
-            void page.submitNode(type, projectId, directoryId, name)
+          onNext={(type, directoryId, name) =>
+            void page.submitNode(type, directoryId, name)
           }
         />
 

--- a/yak-ops-ui/src/services/data-development/types.ts
+++ b/yak-ops-ui/src/services/data-development/types.ts
@@ -51,7 +51,6 @@ export type DevelopmentResourceNode =
 export interface CreateDevelopmentNodePayload {
   name: string;
   type: DevelopmentNodeType;
-  projectId?: DevelopmentId;
   /** Omit to create the node in the data-development root. */
   directoryId?: DevelopmentId;
 }
@@ -90,124 +89,10 @@ export interface DevelopmentTaskRevision
   definition: DevelopmentTaskDefinition;
 }
 
-export type DevelopmentTaskExecutionStatus =
-  | 'PENDING'
-  | 'RUNNING'
-  | 'SUCCESS'
-  | 'FAILED'
-  | 'CANCELLED'
-  | 'TIMEOUT';
-
-/** Immediate acknowledgement after the shared Task Runtime accepts an editor run. */
 export interface DevelopmentTaskExecutionSubmission {
   id: DevelopmentId;
-  nodeId: DevelopmentId;
-  taskType: DevelopmentTaskType;
+  status: string;
   runtimeExecutionId?: string | null;
-  status: DevelopmentTaskExecutionStatus;
-}
-
-/** Workbench projection of one durable execution. */
-export interface DevelopmentTaskRunResult {
-  executionId?: DevelopmentId;
-  runtimeExecutionId?: string | null;
-  status: DevelopmentTaskExecutionStatus;
-  message: string;
-  durationMs: number;
-  output: Record<string, unknown>;
-}
-
-export interface DevelopmentSqlResultColumn {
-  name: string;
-  label: string;
-  typeName?: string;
-  jdbcType?: number;
-  nullable?: boolean;
-}
-
-export interface DevelopmentSqlRunOutput {
-  kind?: 'RESULT_SET' | 'UPDATE_COUNT';
-  columns?: DevelopmentSqlResultColumn[];
-  rows?: unknown[][];
-  returnedRows?: number;
-  affectedRows?: number;
-  truncated?: boolean;
-  dataSourceId?: string;
-}
-
-export interface DevelopmentSqlLineagePreviewRequest
-  extends DevelopmentTaskDefinition {
-  databaseName?: string;
-  schemaName?: string;
-}
-
-export type DevelopmentSqlLineagePreviewStatus =
-  | 'SUCCESS'
-  | 'PARTIAL'
-  | 'UNRESOLVED'
-  | 'FAILED';
-
-export interface DevelopmentSqlLineagePreviewAsset {
-  id: string;
-  assetKey: string;
-  assetType: 'TABLE' | 'SQL_TASK';
-  name: string;
-  sourceType?: string;
-  sourceId?: string;
-  parentAssetId?: string;
-  dataSourceId?: string;
-  databaseName?: string;
-  schemaName?: string;
-  tableName?: string;
-  columnName?: string;
-  properties?: Record<string, unknown>;
-}
-
-export interface DevelopmentSqlLineagePreviewRelation {
-  id: string;
-  sourceAssetId: string;
-  targetAssetId: string;
-  relationType: 'READS_FROM' | 'WRITES_TO';
-  sourceType?: string;
-  sourceId?: string;
-  expression?: string;
-  properties?: Record<string, unknown>;
-}
-
-export interface DevelopmentSqlLineagePreviewGraph {
-  root: DevelopmentSqlLineagePreviewAsset;
-  direction: 'BOTH';
-  depth: number;
-  nodes: DevelopmentSqlLineagePreviewAsset[];
-  relations: DevelopmentSqlLineagePreviewRelation[];
-}
-
-export interface DevelopmentSqlLineageColumnMapping {
-  sourceTable: string;
-  sourceColumn: string;
-  sourceDataType?: string | null;
-  targetTable?: string | null;
-  targetColumn: string;
-  targetDataType?: string | null;
-  mappingKind: 'IDENTITY' | 'TRANSFORMATION' | 'AGGREGATION';
-  expression?: string | null;
-  outputOrdinal: number;
-  sourceOrdinal: number;
-}
-
-export interface DevelopmentSqlLineagePreview {
-  status: DevelopmentSqlLineagePreviewStatus;
-  dataSourceId: string;
-  statementCount: number;
-  inputTableCount: number;
-  outputTableCount: number;
-  columnMappingCount: number;
-  candidateOutputColumnCount: number;
-  unresolvedColumnReferenceCount: number;
-  parseError?: string | null;
-  columnParseError?: string | null;
-  graph: DevelopmentSqlLineagePreviewGraph;
-  columnMappings: DevelopmentSqlLineageColumnMapping[];
 }
 
 export interface DevelopmentTaskExecutionSummary {
@@ -215,11 +100,10 @@ export interface DevelopmentTaskExecutionSummary {
   nodeId: DevelopmentId;
   taskName: string;
   taskType: DevelopmentTaskType;
-  schemaVersion: number;
   triggerType: string;
   runtimeExecutionId?: string | null;
   retryOfExecutionId?: DevelopmentId | null;
-  status: DevelopmentTaskExecutionStatus;
+  status: string;
   operatorName?: string | null;
   durationMs?: number | null;
   errorMessage?: string | null;
@@ -229,9 +113,10 @@ export interface DevelopmentTaskExecutionSummary {
 
 export interface DevelopmentTaskExecutionDetail
   extends DevelopmentTaskExecutionSummary {
+  schemaVersion: number;
   content: string;
   configJson: string;
-  output: Record<string, unknown>;
+  outputJson?: string | null;
 }
 
 export interface DevelopmentTaskExecutionPage {
@@ -242,31 +127,30 @@ export interface DevelopmentTaskExecutionPage {
 }
 
 export interface DevelopmentTaskExecutionQuery {
-  pageNo?: number;
-  pageSize?: number;
   keyword?: string;
-  status?: DevelopmentTaskExecutionStatus;
-  taskType?: DevelopmentTaskType;
+  status?: string;
+  taskType?: string;
   triggerType?: string;
   startTime?: string;
   endTime?: string;
+  pageNo?: number;
+  pageSize?: number;
 }
-
-export type DevelopmentReleaseStatus = 'ONLINE' | 'OFFLINE' | 'DISABLED';
 
 export interface DevelopmentReleaseSummary {
   assetId: DevelopmentId;
-  nodeId: DevelopmentId;
-  taskName: string;
-  taskType: DevelopmentTaskType;
-  status: DevelopmentReleaseStatus;
+  sourceRef: string;
+  name: string;
+  taskType: string;
+  status: string;
   currentRevisionId: DevelopmentId;
   currentRevisionNo: number;
-  latestRevisionNo: number;
-  hasNewerRevision: boolean;
-  checksum: string;
-  revisionCreateTime?: string | null;
   updateTime?: string | null;
+}
+
+export interface DevelopmentReleaseDetail {
+  asset: DevelopmentReleaseSummary;
+  revisions: DevelopmentTaskRevisionSummary[];
 }
 
 export interface DevelopmentReleasePage {
@@ -274,46 +158,54 @@ export interface DevelopmentReleasePage {
   total: number;
   pageNo: number;
   pageSize: number;
-  onlineCount: number;
-  offlineCount: number;
-  disabledCount: number;
-}
-
-export interface DevelopmentReleaseDetail {
-  release: DevelopmentReleaseSummary;
-  currentRevision: DevelopmentTaskRevision;
-  revisions: DevelopmentTaskRevisionSummary[];
 }
 
 export interface DevelopmentReleaseQuery {
+  keyword?: string;
+  status?: string;
+  taskType?: string;
   pageNo?: number;
   pageSize?: number;
-  keyword?: string;
-  status?: DevelopmentReleaseStatus | 'ALL';
-  taskType?: DevelopmentTaskType;
 }
 
-export type YakEditorLineHighlight = 'line' | 'none' | 'gutter' | 'all';
-export type YakSqlCompletionFqn = 'none' | 'table' | 'all';
-export type YakRenderWhitespace =
-  | 'none'
-  | 'boundary'
-  | 'selection'
-  | 'trailing'
-  | 'all';
+export interface DevelopmentSqlLineagePreviewRequest {
+  sql: string;
+  dataSourceId?: DevelopmentId;
+  databaseName?: string;
+  schemaName?: string;
+}
+
+export interface DevelopmentSqlLineageAssetView {
+  assetKey: string;
+  assetType: string;
+  name: string;
+  dataSourceId?: string | null;
+  databaseName?: string | null;
+  schemaName?: string | null;
+  tableName?: string | null;
+  columnName?: string | null;
+}
+
+export interface DevelopmentSqlLineageRelationView {
+  sourceAssetKey: string;
+  targetAssetKey: string;
+  relationType: string;
+  expression?: string | null;
+  confidence?: number | null;
+}
+
+export interface DevelopmentSqlLineagePreview {
+  supported: boolean;
+  message?: string | null;
+  assets: DevelopmentSqlLineageAssetView[];
+  relations: DevelopmentSqlLineageRelationView[];
+}
 
 export interface YakEditorSettings {
-  theme: string;
   fontSize: number;
-  fontFamily: string;
-  customFontFamily: string;
-  lineHeight: number;
-  showLineNumber: boolean;
-  showMinimap: boolean;
-  wordWrap: boolean;
-  folding: boolean;
-  renderLineHighlight: YakEditorLineHighlight;
-  keywordCase: 'lower' | 'upper';
-  sqlCompletionFQN: YakSqlCompletionFqn;
-  renderWhitespace: YakRenderWhitespace;
+  tabSize: number;
+  insertSpaces: boolean;
+  wordWrap: string;
+  minimapEnabled: boolean;
+  lineNumbers: string;
 }

--- a/yak-ops-ui/src/services/data-development/types.ts
+++ b/yak-ops-ui/src/services/data-development/types.ts
@@ -89,10 +89,124 @@ export interface DevelopmentTaskRevision
   definition: DevelopmentTaskDefinition;
 }
 
+export type DevelopmentTaskExecutionStatus =
+  | 'PENDING'
+  | 'RUNNING'
+  | 'SUCCESS'
+  | 'FAILED'
+  | 'CANCELLED'
+  | 'TIMEOUT';
+
+/** Immediate acknowledgement after the shared Task Runtime accepts an editor run. */
 export interface DevelopmentTaskExecutionSubmission {
   id: DevelopmentId;
-  status: string;
+  nodeId: DevelopmentId;
+  taskType: DevelopmentTaskType;
   runtimeExecutionId?: string | null;
+  status: DevelopmentTaskExecutionStatus;
+}
+
+/** Workbench projection of one durable execution. */
+export interface DevelopmentTaskRunResult {
+  executionId?: DevelopmentId;
+  runtimeExecutionId?: string | null;
+  status: DevelopmentTaskExecutionStatus;
+  message: string;
+  durationMs: number;
+  output: Record<string, unknown>;
+}
+
+export interface DevelopmentSqlResultColumn {
+  name: string;
+  label: string;
+  typeName?: string;
+  jdbcType?: number;
+  nullable?: boolean;
+}
+
+export interface DevelopmentSqlRunOutput {
+  kind?: 'RESULT_SET' | 'UPDATE_COUNT';
+  columns?: DevelopmentSqlResultColumn[];
+  rows?: unknown[][];
+  returnedRows?: number;
+  affectedRows?: number;
+  truncated?: boolean;
+  dataSourceId?: string;
+}
+
+export interface DevelopmentSqlLineagePreviewRequest
+  extends DevelopmentTaskDefinition {
+  databaseName?: string;
+  schemaName?: string;
+}
+
+export type DevelopmentSqlLineagePreviewStatus =
+  | 'SUCCESS'
+  | 'PARTIAL'
+  | 'UNRESOLVED'
+  | 'FAILED';
+
+export interface DevelopmentSqlLineagePreviewAsset {
+  id: string;
+  assetKey: string;
+  assetType: 'TABLE' | 'SQL_TASK';
+  name: string;
+  sourceType?: string;
+  sourceId?: string;
+  parentAssetId?: string;
+  dataSourceId?: string;
+  databaseName?: string;
+  schemaName?: string;
+  tableName?: string;
+  columnName?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface DevelopmentSqlLineagePreviewRelation {
+  id: string;
+  sourceAssetId: string;
+  targetAssetId: string;
+  relationType: 'READS_FROM' | 'WRITES_TO';
+  sourceType?: string;
+  sourceId?: string;
+  expression?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface DevelopmentSqlLineagePreviewGraph {
+  root: DevelopmentSqlLineagePreviewAsset;
+  direction: 'BOTH';
+  depth: number;
+  nodes: DevelopmentSqlLineagePreviewAsset[];
+  relations: DevelopmentSqlLineagePreviewRelation[];
+}
+
+export interface DevelopmentSqlLineageColumnMapping {
+  sourceTable: string;
+  sourceColumn: string;
+  sourceDataType?: string | null;
+  targetTable?: string | null;
+  targetColumn: string;
+  targetDataType?: string | null;
+  mappingKind: 'IDENTITY' | 'TRANSFORMATION' | 'AGGREGATION';
+  expression?: string | null;
+  outputOrdinal: number;
+  sourceOrdinal: number;
+}
+
+export interface DevelopmentSqlLineagePreview {
+  status: DevelopmentSqlLineagePreviewStatus;
+  dataSourceId: string;
+  statementCount: number;
+  inputTableCount: number;
+  outputTableCount: number;
+  columnMappingCount: number;
+  candidateOutputColumnCount: number;
+  unresolvedColumnReferenceCount: number;
+  parseError?: string | null;
+  columnParseError?: string | null;
+  graph: DevelopmentSqlLineagePreviewGraph;
+  columnMappings: DevelopmentSqlLineageColumnMapping[];
 }
 
 export interface DevelopmentTaskExecutionSummary {
@@ -100,10 +214,11 @@ export interface DevelopmentTaskExecutionSummary {
   nodeId: DevelopmentId;
   taskName: string;
   taskType: DevelopmentTaskType;
+  schemaVersion: number;
   triggerType: string;
   runtimeExecutionId?: string | null;
   retryOfExecutionId?: DevelopmentId | null;
-  status: string;
+  status: DevelopmentTaskExecutionStatus;
   operatorName?: string | null;
   durationMs?: number | null;
   errorMessage?: string | null;
@@ -113,10 +228,9 @@ export interface DevelopmentTaskExecutionSummary {
 
 export interface DevelopmentTaskExecutionDetail
   extends DevelopmentTaskExecutionSummary {
-  schemaVersion: number;
   content: string;
   configJson: string;
-  outputJson?: string | null;
+  output: Record<string, unknown>;
 }
 
 export interface DevelopmentTaskExecutionPage {
@@ -127,30 +241,31 @@ export interface DevelopmentTaskExecutionPage {
 }
 
 export interface DevelopmentTaskExecutionQuery {
+  pageNo?: number;
+  pageSize?: number;
   keyword?: string;
-  status?: string;
-  taskType?: string;
+  status?: DevelopmentTaskExecutionStatus;
+  taskType?: DevelopmentTaskType;
   triggerType?: string;
   startTime?: string;
   endTime?: string;
-  pageNo?: number;
-  pageSize?: number;
 }
+
+export type DevelopmentReleaseStatus = 'ONLINE' | 'OFFLINE' | 'DISABLED';
 
 export interface DevelopmentReleaseSummary {
   assetId: DevelopmentId;
-  sourceRef: string;
-  name: string;
-  taskType: string;
-  status: string;
+  nodeId: DevelopmentId;
+  taskName: string;
+  taskType: DevelopmentTaskType;
+  status: DevelopmentReleaseStatus;
   currentRevisionId: DevelopmentId;
   currentRevisionNo: number;
+  latestRevisionNo: number;
+  hasNewerRevision: boolean;
+  checksum: string;
+  revisionCreateTime?: string | null;
   updateTime?: string | null;
-}
-
-export interface DevelopmentReleaseDetail {
-  asset: DevelopmentReleaseSummary;
-  revisions: DevelopmentTaskRevisionSummary[];
 }
 
 export interface DevelopmentReleasePage {
@@ -158,54 +273,46 @@ export interface DevelopmentReleasePage {
   total: number;
   pageNo: number;
   pageSize: number;
+  onlineCount: number;
+  offlineCount: number;
+  disabledCount: number;
+}
+
+export interface DevelopmentReleaseDetail {
+  release: DevelopmentReleaseSummary;
+  currentRevision: DevelopmentTaskRevision;
+  revisions: DevelopmentTaskRevisionSummary[];
 }
 
 export interface DevelopmentReleaseQuery {
-  keyword?: string;
-  status?: string;
-  taskType?: string;
   pageNo?: number;
   pageSize?: number;
+  keyword?: string;
+  status?: DevelopmentReleaseStatus | 'ALL';
+  taskType?: DevelopmentTaskType;
 }
 
-export interface DevelopmentSqlLineagePreviewRequest {
-  sql: string;
-  dataSourceId?: DevelopmentId;
-  databaseName?: string;
-  schemaName?: string;
-}
-
-export interface DevelopmentSqlLineageAssetView {
-  assetKey: string;
-  assetType: string;
-  name: string;
-  dataSourceId?: string | null;
-  databaseName?: string | null;
-  schemaName?: string | null;
-  tableName?: string | null;
-  columnName?: string | null;
-}
-
-export interface DevelopmentSqlLineageRelationView {
-  sourceAssetKey: string;
-  targetAssetKey: string;
-  relationType: string;
-  expression?: string | null;
-  confidence?: number | null;
-}
-
-export interface DevelopmentSqlLineagePreview {
-  supported: boolean;
-  message?: string | null;
-  assets: DevelopmentSqlLineageAssetView[];
-  relations: DevelopmentSqlLineageRelationView[];
-}
+export type YakEditorLineHighlight = 'line' | 'none' | 'gutter' | 'all';
+export type YakSqlCompletionFqn = 'none' | 'table' | 'all';
+export type YakRenderWhitespace =
+  | 'none'
+  | 'boundary'
+  | 'selection'
+  | 'trailing'
+  | 'all';
 
 export interface YakEditorSettings {
+  theme: string;
   fontSize: number;
-  tabSize: number;
-  insertSpaces: boolean;
-  wordWrap: string;
-  minimapEnabled: boolean;
-  lineNumbers: string;
+  fontFamily: string;
+  customFontFamily: string;
+  lineHeight: number;
+  showLineNumber: boolean;
+  showMinimap: boolean;
+  wordWrap: boolean;
+  folding: boolean;
+  renderLineHighlight: YakEditorLineHighlight;
+  keywordCase: 'lower' | 'upper';
+  sqlCompletionFQN: YakSqlCompletionFqn;
+  renderWhitespace: YakRenderWhitespace;
 }


### PR DESCRIPTION
## 背景

Stage 5A 在已合并的 Stage 4 Task Catalog / Lineage Project projection substrate 上，收口 Data Development **Core Project Space**。

Data Development 此前 #842 已经完成过一轮 Project/RBAC 基础治理，因此本 PR 不重复“机械加 project_id”，而是补齐剩余的 ownership / fail-closed / durable runtime / Source Truth 边界。

本阶段仍遵循：

> Project Root 归属只来自可信 CurrentProject；Projection 的 Project 来自 Source Truth；异步 Runtime 必须持久化 Project 并在后台恢复。

## Ownership 分类

- `yak_dev_directory` → `PROJECT_ROOT`
- `yak_dev_node` → `PROJECT_ROOT`
- `yak_dev_task_draft` → `INHERITED`（通过 node_id）
- `yak_dev_task_revision` → `INHERITED`（通过 node_id）
- `yak_dev_task_execution` → `PROJECT_RUNTIME`
- `yak_dev_lineage_outbox` → `PROJECT_RUNTIME`

详见新增 `STAGE5A_PROJECT_SPACE.md`。

## 1. Node / Directory Project Root 收口

### Node 创建不再接受 projectId

- 后端 `DevelopmentNodeApi.CreateRequest` 删除 `projectId`
- `DevelopmentNodeController` 不再从 request body 向 Service 传 projectId
- `DevelopmentNodeService` 新主入口为 `create(name, type, directoryId)`
- 保留旧 4 参数内部方法作为兼容入口，但显式忽略 supplied projectId
- `DevelopmentNodeRepositoryAdapter` 创建 Node 时只使用 `CurrentProject.requireProjectId()`

前端同步删除：

- `CreateDevelopmentNodePayload.projectId`
- 创建节点 Modal 内部 project state/defaultProjectId
- `useDataDevelopmentPage` 的 defaultProjectId/projectId plumbing
- 页面层 `useSecurityProject()` 仅用于拼 request body 的旧逻辑

Project Header / membership 仍由统一 Security Project Context / HTTP 基础设施负责，Data Development 页面不再复制一份 Project 身份到 body。

### Repository fail-closed

`DevelopmentDirectoryRepositoryAdapter`、`DevelopmentNodeRepositoryAdapter` 普通 CRUD 全部要求 `CurrentProject.requireProjectId()`：

- find/list/count
- exists
- rename/update
- delete
- Node pending-publish read model

删除“CurrentProject 为空时退化成全局查询”的普通业务路径。

## 2. Task Catalog Source Truth 传播

Stage 4 已支持 `TaskSourceRevision.sourceProjectId` 和 TaskAsset ↔ revision Project drift 校验；Stage 5A 将 Data Development 真正接上该契约：

- `DevelopmentNode.requireProjectId()` 明确 Node 是任务 Project Source Truth
- `DevelopmentTaskPublisher` 发布 TaskAsset 时必须使用 `node.projectId`
- `DataDevelopmentTaskRevisionProvider` 先解析 owning Node，再把 `node.projectId` 放入 `TaskSourceRevision.sourceProjectId`
- revision 必须属于 sourceRef 对应 Node

这样形成：

`DevelopmentNode(Project A) -> TaskAsset(Project A) -> TaskSourceRevision(Project A)`

Task Catalog 不再因为 Data Development Provider 返回 null project 而失去漂移校验能力。

## 3. Execution PROJECT_RUNTIME 收口

`DevelopmentTaskExecutionRepositoryAdapter` 改为：

- submit 时验证 `PendingExecution.projectId == CurrentProject.projectId`
- 普通 attach/status/complete/page/detail/active 查询必须携带 CurrentProject
- 所有普通更新/读取使用 `project_id + business identity`
- 不再允许空 CurrentProject 下按 execution id 全局访问

唯一保留的跨 Project corridor：

- `listActiveForReconciliation`

它只扫描 `project_id IS NOT NULL` 的 active runtime rows；现有 `DevelopmentTaskExecutionControlService` 会针对每条 candidate 用 `ProjectContextScope` 恢复对应 Project 后再进入普通业务 IO。

## 4. Lineage Outbox PROJECT_RUNTIME 收口

### enqueue

- enqueue 必须存在 CurrentProject
- 先验证 Node 确实属于当前 Project
- Outbox 的 project_id 从 owning Node 持久化
- 保留 `INSERT IGNORE` 的原有幂等语义：重复 node/revision enqueue 仍视为成功，不误报失败

### worker

`DevelopmentLineageWorker` 继续根据 durable outbox.project_id 恢复 `ProjectContext`，并新增一致性校验：

- outbox Project == Node Project
- revision.nodeId == Node.id

任何 durable identity 漂移均 fail-closed，不把错误投影写入 Lineage。

Outbox `due()` 仍是显式跨 Project dispatcher，只返回 project_id 非空记录；实际业务 IO 进入每条记录自己的 Project Scope。

## 5. 测试 / 架构守卫

新增 `DataDevelopmentStage5AProjectSpaceContractTest` 锁定：

- Node HTTP Create contract 不得重新引入 projectId override
- Directory / Node repositories 必须 fail-closed
- Execution 只有 reconciliation dispatcher 可跨项目扫描
- Outbox 必须持久化/校验 Project
- Lineage worker 必须恢复 durable ProjectContext
- Data Development Task revision/publish 必须向 Task Catalog 传播 sourceProjectId

并更新：

- `DataDevelopmentTaskRevisionProviderTest`
- `DevelopmentNodeServiceTest`

## 本阶段明确不做

Stage 5A **不做**以下内容：

- `yak_dev_directory.project_id NOT NULL`
- `yak_dev_node.project_id NOT NULL`
- `yak_dev_task_execution.project_id NOT NULL`
- `yak_dev_lineage_outbox.project_id NOT NULL`
- 删除现有历史兼容 backfill
- 给 Draft / Revision 冗余增加 project_id
- Project 化 Dataset binding
- Data Development × Dataset 最终 integration contract
- Stage 6 Dataset 工作

原因：Data Development 仍与 Dataset 存在真实依赖。按已确定路线，Dataset Project Space 在 Stage 6 完成后，再进入 Stage 5B 做 Data Development × Dataset integration / Contract 收口。

## Review 重点

- Node/Directory 是否已经完全由 trusted CurrentProject 决定归属
- Execution 普通路径 fail-closed 与 reconciliation dispatcher 例外是否清晰
- Outbox 幂等 + durable Project 恢复是否正确
- Task Catalog `sourceProjectId` 是否真正来自 DevelopmentNode Source Truth
- 前端是否彻底停止把 projectId 放进 Node create body
- 是否有任何 Dataset/最终 Contract 被本 PR 提前带入

## 验证状态

- 已做 branch vs main 变更范围审查，当前分支基于最新 Stage 4 merged main，behind=0
- 已补单测/架构 contract test
- 当前会话环境未实际执行完整 Maven、npm TypeScript、MySQL 历史库集成测试，因此保持 Draft；建议本地/CI 至少补跑 Data Development module tests、前端 typecheck，以及 execution/outbox 的 MySQL 集成回归。