### PR TITLE
feat(project): complete Data Development × Dataset contract (Stage 5B)

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/STAGE5B_PROJECT_SPACE.md
+++ b/yak-ops-business/yak-ops-business-data-development/STAGE5B_PROJECT_SPACE.md
@@ -1,0 +1,87 @@
+# Stage 5B — Data Development × Dataset Project Contract
+
+Stage 5A completed the Data Development core ownership/runtime boundary. Stage 6 then made Dataset a fail-closed `PROJECT_ROOT`. Stage 5B closes the integration seam between the two modules and contracts the Data Development project columns physically.
+
+## Ownership model
+
+```text
+yak_dev_directory        PROJECT_ROOT
+yak_dev_node             PROJECT_ROOT
+yak_dev_task_draft       INHERITED(node_id)
+yak_dev_task_revision    INHERITED(node_id)
+yak_dev_task_execution   PROJECT_RUNTIME
+yak_dev_lineage_outbox   PROJECT_RUNTIME
+
+Dataset                   PROJECT_ROOT
+DatasetVersion            INHERITED(dataset_id)
+DatasetField              INHERITED(version_id -> dataset_id)
+```
+
+Draft and Revision deliberately do not receive duplicate `project_id` columns.
+
+## Data Development × Dataset boundary
+
+The owning identities are independent source truths:
+
+```text
+DevelopmentNode.project_id
+          │
+          │ must equal
+          ▼
+Dataset.project_id
+```
+
+Data Development does not pass a caller-selected Project ID into Dataset. Instead:
+
+1. Data Development resolves the Dataset Node inside the current Project.
+2. Dataset executes through its Stage 6 fail-closed repository boundary.
+3. `DevelopmentDatasetFacade` exposes the persisted Dataset Project as part of the internal snapshot.
+4. Data Development compares that Project against `DevelopmentNode.requireProjectId()`.
+5. A mismatch fails closed before the node can be marked configured.
+
+Standalone Dataset SQL preview/query continues to rely on the trusted CurrentProject plus the already project-scoped Dataset/DataSource boundaries. Legacy TaskAsset flows retain the existing TaskAsset and source SQL node same-Project checks.
+
+## Physical contract
+
+`V2__contract_project_scope.sql` changes only the Project Root / Runtime columns to `NOT NULL`:
+
+```text
+yak_dev_directory.project_id
+yak_dev_node.project_id
+yak_dev_task_execution.project_id
+yak_dev_lineage_outbox.project_id
+```
+
+The migration performs no ownership inference, no default-project update, and no `0`/hard-coded Project fallback.
+
+## Deployment prerequisite
+
+Flyway runs before `ApplicationReadyEvent`, while the existing `DataDevelopmentProjectCompatibilityBackfill` runs at ApplicationReady. Therefore an historical database must have successfully run a pre-contract application version first.
+
+Before deploying this contract, all four checks must return `0`:
+
+```sql
+SELECT COUNT(*) FROM yak_dev_directory WHERE project_id IS NULL;
+SELECT COUNT(*) FROM yak_dev_node WHERE project_id IS NULL;
+SELECT COUNT(*) FROM yak_dev_task_execution WHERE project_id IS NULL;
+SELECT COUNT(*) FROM yak_dev_lineage_outbox WHERE project_id IS NULL;
+```
+
+The Data Development / Dataset relationship should also be clean:
+
+```sql
+SELECT COUNT(*)
+FROM yak_dataset d
+JOIN yak_dev_node n ON n.id = d.development_node_id
+WHERE d.project_id <> n.project_id;
+```
+
+If legacy NULL ownership remains, Flyway V2 is expected to fail. That is intentional fail-fast behavior.
+
+## Non-goals
+
+- Dataset `project_id NOT NULL` contract (Stage 6.1)
+- adding `project_id` to Development Draft/Revision
+- adding `project_id` to DatasetVersion/DatasetField
+- Stage 7 Offline/Realtime Sync
+- removing the compatibility backfills that Stage 6 still composes during historical cutover

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dataset/DevelopmentDatasetNodeService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/dataset/DevelopmentDatasetNodeService.java
@@ -37,7 +37,9 @@ public class DevelopmentDatasetNodeService {
 
   public DatasetNodeContext get(long nodeId) {
     DevelopmentNode datasetNode = requireDatasetNode(nodeId);
-    NodeDataset dataset = datasetFacade.findByDevelopmentNodeId(nodeId).orElse(null);
+    NodeDataset dataset = datasetFacade.findByDevelopmentNodeId(nodeId)
+        .map(candidate -> requireSameProject(datasetNode, candidate))
+        .orElse(null);
     return context(datasetNode, dataset, selectedSource(dataset));
   }
 
@@ -62,8 +64,10 @@ public class DevelopmentDatasetNodeService {
       String description,
       List<FieldDraft> fields) {
     DevelopmentNode datasetNode = requireDatasetNode(nodeId);
-    NodeDataset saved = datasetFacade.save(
-        nodeId, dataSourceId, sql, datasetNode.name(), description, fields);
+    NodeDataset saved = requireSameProject(
+        datasetNode,
+        datasetFacade.save(
+            nodeId, dataSourceId, sql, datasetNode.name(), description, fields));
     markConfigured(datasetNode);
     DevelopmentNode refreshed = nodeRepository.findById(nodeId).orElse(datasetNode);
     return context(refreshed, saved, null);
@@ -85,8 +89,10 @@ public class DevelopmentDatasetNodeService {
       List<FieldDraft> fields) {
     DevelopmentNode datasetNode = requireDatasetNode(nodeId);
     TaskAsset source = requireSelectableSqlAsset(datasetNode, sourceTaskAssetId);
-    NodeDataset saved = datasetFacade.save(
-        nodeId, source.id(), datasetNode.name(), description, fields);
+    NodeDataset saved = requireSameProject(
+        datasetNode,
+        datasetFacade.save(
+            nodeId, source.id(), datasetNode.name(), description, fields));
     markConfigured(datasetNode);
     DevelopmentNode refreshed = nodeRepository.findById(nodeId).orElse(datasetNode);
     return context(refreshed, saved, toSnapshot(source));
@@ -212,7 +218,24 @@ public class DevelopmentDatasetNodeService {
     if (type != DevelopmentNodeType.DATASET) {
       throw new IllegalArgumentException("当前节点不是 Dataset Node：" + nodeId);
     }
+    node.requireProjectId();
     return node;
+  }
+
+  private NodeDataset requireSameProject(DevelopmentNode datasetNode, NodeDataset dataset) {
+    long nodeProjectId = datasetNode.requireProjectId();
+    if (dataset.projectId() <= 0L || dataset.projectId() != nodeProjectId) {
+      throw new IllegalStateException(
+          "Dataset 与数据开发节点 Project 不一致：nodeId="
+              + datasetNode.id()
+              + ", nodeProjectId="
+              + nodeProjectId
+              + ", datasetId="
+              + dataset.datasetId()
+              + ", datasetProjectId="
+              + dataset.projectId());
+    }
+    return dataset;
   }
 
   private boolean sameProject(Long left, Long right) {

--- a/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/resources/db/migration/yak-data-development/V2__contract_project_scope.sql
@@ -1,0 +1,17 @@
+-- Stage 5B Project Space contract for Data Development.
+--
+-- Historical databases must have already completed the existing ApplicationReady compatibility
+-- backfill before this migration is deployed. This migration deliberately performs no ownership
+-- inference and must fail fast when legacy NULL project rows still exist.
+
+ALTER TABLE yak_dev_directory
+    MODIFY COLUMN project_id BIGINT NOT NULL;
+
+ALTER TABLE yak_dev_node
+    MODIFY COLUMN project_id BIGINT NOT NULL;
+
+ALTER TABLE yak_dev_task_execution
+    MODIFY COLUMN project_id BIGINT NOT NULL;
+
+ALTER TABLE yak_dev_lineage_outbox
+    MODIFY COLUMN project_id BIGINT NOT NULL;

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/architecture/DataDevelopmentStage5BProjectSpaceContractTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/architecture/DataDevelopmentStage5BProjectSpaceContractTest.java
@@ -1,0 +1,79 @@
+package io.yak.ops.business.development.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Locks the Stage 5B Data Development x Dataset integration and physical Project contract. */
+class DataDevelopmentStage5BProjectSpaceContractTest {
+
+  @Test
+  void datasetIntegrationValidatesBothProjectSourceTruths() throws IOException {
+    String service = developmentSource("dataset/DevelopmentDatasetNodeService.java");
+    String facade = datasetSource("DevelopmentDatasetFacade.java");
+
+    assertThat(service)
+        .contains("node.requireProjectId()")
+        .contains("requireSameProject(datasetNode, candidate)")
+        .contains("dataset.projectId()")
+        .contains("Dataset 与数据开发节点 Project 不一致");
+
+    assertThat(facade)
+        .contains("dataset.requireProjectId()")
+        .contains("long projectId,");
+  }
+
+  @Test
+  void contractMakesOnlyProjectRootsAndRuntimeRowsPhysicallyRequired() throws IOException {
+    String contract = Files.readString(
+        moduleRoot()
+            .resolve("src/main/resources/db/migration/yak-data-development")
+            .resolve("V2__contract_project_scope.sql"));
+
+    assertThat(contract)
+        .contains("ALTER TABLE yak_dev_directory")
+        .contains("ALTER TABLE yak_dev_node")
+        .contains("ALTER TABLE yak_dev_task_execution")
+        .contains("ALTER TABLE yak_dev_lineage_outbox")
+        .doesNotContain("yak_dev_task_draft")
+        .doesNotContain("yak_dev_task_revision");
+
+    assertThat(contract.split("MODIFY COLUMN project_id BIGINT NOT NULL", -1).length - 1)
+        .isEqualTo(4);
+    assertThat(contract.toUpperCase())
+        .doesNotContain("UPDATE YAK_DEV_")
+        .doesNotContain("PROJECT_ID = 1")
+        .doesNotContain("PROJECT_ID = 0");
+  }
+
+  private String developmentSource(String relative) throws IOException {
+    return Files.readString(
+        moduleRoot()
+            .resolve("src/main/java/io/yak/ops/business/development")
+            .resolve(relative));
+  }
+
+  private String datasetSource(String relative) throws IOException {
+    return Files.readString(
+        repositoryRoot()
+            .resolve("yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset")
+            .resolve(relative));
+  }
+
+  private Path repositoryRoot() {
+    return moduleRoot().getParent().getParent();
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of(".").toAbsolutePath().normalize();
+    if (Files.isRegularFile(local.resolve("pom.xml"))
+        && local.getFileName() != null
+        && "yak-ops-business-data-development".equals(local.getFileName().toString())) {
+      return local;
+    }
+    return Path.of("yak-ops-business", "yak-ops-business-data-development").toAbsolutePath().normalize();
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDatasetNodeServiceTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/DevelopmentDatasetNodeServiceTest.java
@@ -7,12 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade;
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade.FieldDraft;
 import io.yak.ops.business.dataset.DevelopmentDatasetFacade.NodeDataset;
+import io.yak.ops.business.development.dataset.DevelopmentDatasetNodeService;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.business.development.repository.DevelopmentNodeRepository;
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
@@ -87,7 +89,7 @@ class DevelopmentDatasetNodeServiceTest {
     when(catalog.list("DATA_DEVELOPMENT", "ONLINE", null)).thenReturn(List.of(asset));
     when(nodes.updateConfigured(501L, true)).thenReturn(true);
     NodeDataset saved = new NodeDataset(
-        "501", "21", "sales_dataset", "销售数据", "ONLINE", null,
+        "501", "21", 7L, "sales_dataset", "销售数据", "ONLINE", null,
         List.of(), List.of(), Instant.EPOCH, Instant.EPOCH);
     when(datasets.save(eq(501L), eq(11L), eq("sales_dataset"), eq("销售数据"), anyList()))
         .thenReturn(saved);
@@ -119,6 +121,49 @@ class DevelopmentDatasetNodeServiceTest {
         () -> service.preview(501L, 11L));
 
     assertEquals("Dataset 只能选择同项目的 SQL 来源", error.getMessage());
+  }
+
+  @Test
+  void getRejectsDatasetOwnedByAnotherProject() {
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DevelopmentDatasetFacade datasets = mock(DevelopmentDatasetFacade.class);
+    DevelopmentDatasetNodeService service = new DevelopmentDatasetNodeService(nodes, catalog, datasets);
+
+    when(nodes.findById(501L)).thenReturn(Optional.of(node(501L, "sales_dataset", "DATASET", true, 7L)));
+    when(datasets.findByDevelopmentNodeId(501L)).thenReturn(Optional.of(new NodeDataset(
+        "501", "21", 8L, "sales_dataset", "销售数据", "ONLINE", null,
+        List.of(), List.of(), Instant.EPOCH, Instant.EPOCH)));
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> service.get(501L));
+
+    assertTrue(error.getMessage().contains("Dataset 与数据开发节点 Project 不一致"));
+    assertTrue(error.getMessage().contains("nodeProjectId=7"));
+    assertTrue(error.getMessage().contains("datasetProjectId=8"));
+  }
+
+  @Test
+  void saveRejectsDatasetProjectDriftBeforeMarkingNodeConfigured() {
+    DevelopmentNodeRepository nodes = mock(DevelopmentNodeRepository.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    DevelopmentDatasetFacade datasets = mock(DevelopmentDatasetFacade.class);
+    DevelopmentDatasetNodeService service = new DevelopmentDatasetNodeService(nodes, catalog, datasets);
+
+    DevelopmentNode datasetNode = node(501L, "sales_dataset", "DATASET", false, 7L);
+    when(nodes.findById(501L)).thenReturn(Optional.of(datasetNode));
+    when(datasets.save(eq(501L), eq("10"), eq("select 1"), eq("sales_dataset"), eq("销售数据"), anyList()))
+        .thenReturn(new NodeDataset(
+            "501", "21", 8L, "sales_dataset", "销售数据", "DRAFT", null,
+            List.of(), List.of(), Instant.EPOCH, Instant.EPOCH));
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> service.save(501L, "10", "select 1", "销售数据", List.of()));
+
+    assertTrue(error.getMessage().contains("Dataset 与数据开发节点 Project 不一致"));
+    verify(nodes, never()).updateConfigured(501L, true);
   }
 
   private static DevelopmentNode node(

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
@@ -100,6 +100,7 @@ public class DevelopmentDatasetFacade {
     return new NodeDataset(
         String.valueOf(developmentNodeId),
         String.valueOf(dataset.id()),
+        dataset.requireProjectId(),
         dataset.name(),
         dataset.description(),
         dataset.status().name(),
@@ -185,6 +186,7 @@ public class DevelopmentDatasetFacade {
   public record NodeDataset(
       String developmentNodeId,
       String datasetId,
+      long projectId,
       String name,
       String description,
       String status,

--- a/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/java/io/yak/ops/business/dataset/DevelopmentDatasetFacade.java
@@ -194,7 +194,34 @@ public class DevelopmentDatasetFacade {
       List<VersionSnapshot> versions,
       List<FieldSnapshot> fields,
       Instant createTime,
-      Instant updateTime) {}
+      Instant updateTime) {
+
+    /** Compatibility constructor for callers that do not provide a Project-aware snapshot yet. */
+    public NodeDataset(
+        String developmentNodeId,
+        String datasetId,
+        String name,
+        String description,
+        String status,
+        VersionSnapshot currentVersion,
+        List<VersionSnapshot> versions,
+        List<FieldSnapshot> fields,
+        Instant createTime,
+        Instant updateTime) {
+      this(
+          developmentNodeId,
+          datasetId,
+          0L,
+          name,
+          description,
+          status,
+          currentVersion,
+          versions,
+          fields,
+          createTime,
+          updateTime);
+    }
+  }
 
   public record VersionSnapshot(
       String versionId,


### PR DESCRIPTION
## Summary

Complete **Stage 5B** after Stage 5A (#876) and Dataset Stage 6 (#877): close the Data Development × Dataset Project Space integration seam and physically contract Data Development Project ownership.

### Data Development × Dataset boundary

- expose the persisted `Dataset.project_id` through the internal `DevelopmentDatasetFacade.NodeDataset` snapshot
- keep the previous `NodeDataset` constructor source-compatible; compatibility snapshots use `projectId=0` and therefore cannot bypass the Stage 5B fail-closed check
- require the owning Dataset Development Node to have a valid Project
- validate `Dataset.projectId == DevelopmentNode.projectId` when loading or saving Dataset Node state
- reject Project drift **before** a Development Node can be marked `configured`
- retain existing same-Project checks for legacy TaskAsset / SQL-node sources

The caller does **not** pass an expected Project ID into Dataset. Both modules expose their own persisted source truth and Data Development compares them at the integration boundary.

### Data Development physical contract

Add `V2__contract_project_scope.sql` and make these columns `NOT NULL`:

- `yak_dev_directory.project_id` — PROJECT_ROOT
- `yak_dev_node.project_id` — PROJECT_ROOT
- `yak_dev_task_execution.project_id` — PROJECT_RUNTIME
- `yak_dev_lineage_outbox.project_id` — PROJECT_RUNTIME

Draft/Revision remain inherited through `node_id`; this PR does not add duplicate `project_id` columns to them.

The V2 migration contains **no backfill**, no hard-coded Project ID, and no `0` fallback.

## Rollout prerequisite

Flyway runs before `ApplicationReadyEvent`, while `DataDevelopmentProjectCompatibilityBackfill` runs at ApplicationReady. Historical databases must therefore have successfully run the pre-contract Stage 5A/6 application before deploying this PR.

These checks must all return `0` before rollout:

```sql
SELECT COUNT(*) FROM yak_dev_directory WHERE project_id IS NULL;
SELECT COUNT(*) FROM yak_dev_node WHERE project_id IS NULL;
SELECT COUNT(*) FROM yak_dev_task_execution WHERE project_id IS NULL;
SELECT COUNT(*) FROM yak_dev_lineage_outbox WHERE project_id IS NULL;
```

And the cross-module ownership check should return `0`:

```sql
SELECT COUNT(*)
FROM yak_dataset d
JOIN yak_dev_node n ON n.id = d.development_node_id
WHERE d.project_id <> n.project_id;
```

If legacy NULL ownership remains, Flyway V2 is expected to fail fast.

## Tests / guards

Added/updated contract coverage for:

- Dataset snapshot Project source truth
- Data Development fail-closed Dataset/Node Project comparison
- mismatch rejection on read
- mismatch rejection before `configured` mutation on save
- exactly four Data Development Project columns contracted to `NOT NULL`
- no physical Project duplication on Draft/Revision
- no implicit migration backfill / magic Project IDs

I could not run Maven locally in the connector-only environment, so this PR does **not** claim a successful local build/test run. Recommended minimum local verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-data-development,yak-ops-business/yak-ops-business-dataset -am test
```

Plus a Flyway upgrade test against a database that has already completed the Stage 5A/6 compatibility backfill.

## Non-goals

- Dataset physical `project_id NOT NULL` contract (Stage 6.1)
- Stage 7 Offline / Realtime Sync
- removing compatibility backfills still used by historical cutover
