### PR TITLE
feat(dataset): contract Project ownership (Stage 6.1)

### DIFF
--- a/yak-ops-business/yak-ops-business-dataset/STAGE6_1_PROJECT_CONTRACT.md
+++ b/yak-ops-business/yak-ops-business-dataset/STAGE6_1_PROJECT_CONTRACT.md
@@ -1,0 +1,133 @@
+# Stage 6.1 — Dataset Project Physical Contract
+
+Stage 6 completed the Dataset runtime Project Space boundary and historical compatibility backfill. Stage 6.1 is the physical database Contract step: project ownership that is already required by runtime is now also required by MySQL.
+
+## Scope
+
+Only Dataset-owned Project columns are contracted:
+
+```text
+yak_dataset.project_id                    PROJECT_ROOT        -> NOT NULL
+yak_dataset_query_performance.project_id  project runtime fact -> NOT NULL
+```
+
+`yak_dataset_version` and `yak_dataset_field` remain `INHERITED` through their parent Dataset and do not receive duplicate `project_id` columns.
+
+## Migration sequence
+
+```text
+V3  Dataset project expand (nullable)
+        ↓
+V4  Query performance project column (nullable)
+        ↓
+Stage 6 ApplicationReady compatibility backfill
+        ↓
+Project A/B runtime verification
+        ↓
+V5  Stage 6.1 physical contract (NOT NULL)
+```
+
+`V5__contract_project_scope.sql` performs no ownership inference and no compatibility update. If NULL ownership remains, the Flyway migration is expected to fail fast.
+
+## Deployment prerequisite
+
+Flyway runs before `ApplicationReadyEvent`. Therefore an historical database must have successfully started with the Stage 6 runtime/backfill version before this Contract is deployed.
+
+A database that jumps directly from a pre-Stage-6 schema to a release containing V5 is not a supported one-start upgrade path: V5 can run before `DatasetProjectCompatibilityBackfill`, so remaining legacy NULL rows will make the migration fail. Do not work around this by adding a magic Project ID or an UPDATE to the Contract migration.
+
+Before deploying Stage 6.1, both checks must return `0`:
+
+```sql
+SELECT COUNT(*)
+FROM yak_dataset
+WHERE project_id IS NULL;
+
+SELECT COUNT(*)
+FROM yak_dataset_query_performance
+WHERE project_id IS NULL;
+```
+
+The Stage 6 source-truth invariants should also remain clean:
+
+```sql
+-- Dataset Node ownership
+SELECT COUNT(*)
+FROM yak_dataset d
+JOIN yak_dev_node n ON n.id = d.development_node_id
+WHERE n.project_id IS NOT NULL
+  AND d.project_id <> n.project_id;
+
+-- TaskAsset ownership
+SELECT COUNT(*)
+FROM yak_dataset d
+JOIN yak_dataset_version v
+  ON v.dataset_id = d.id
+ AND v.source_task_asset_id > 0
+JOIN yak_task_asset a ON a.id = v.source_task_asset_id
+WHERE a.project_id IS NOT NULL
+  AND d.project_id <> a.project_id;
+
+-- DataSource ownership for numeric SQL_QUERY datasource identities
+SELECT COUNT(*)
+FROM yak_dataset d
+JOIN yak_dataset_version v
+  ON v.dataset_id = d.id
+ AND v.data_source_id REGEXP '^[0-9]+$'
+JOIN yak_ops_data_source s
+  ON s.id = CAST(v.data_source_id AS UNSIGNED)
+WHERE s.project_id IS NOT NULL
+  AND d.project_id <> s.project_id;
+
+-- Query diagnostics inherit Dataset ownership
+SELECT COUNT(*)
+FROM yak_dataset_query_performance q
+JOIN yak_dataset d ON d.id = q.dataset_id
+WHERE q.project_id <> d.project_id;
+```
+
+All four invariant checks should return `0`.
+
+## Contract rules
+
+The Stage 6.1 migration must remain a pure Contract migration:
+
+- no `UPDATE yak_dataset`;
+- no `UPDATE yak_dataset_query_performance`;
+- no hard-coded `project_id = 1`;
+- no `project_id = 0` fallback;
+- no Project inference from TaskAsset, DevelopmentNode, or DataSource;
+- no duplicate Project column on DatasetVersion or DatasetField.
+
+Historical ownership inference belongs to the Stage 6 compatibility backfill, not to Flyway Contract SQL.
+
+## Compatibility code
+
+This stage does not remove the existing Dataset compatibility backfill. The current rollout still has historical deployment concerns across adjacent Project Space stages, and removing compatibility infrastructure piecemeal would make that upgrade path harder to reason about.
+
+The backfill remains idempotent, but it is **not** a substitute for the deployment prerequisite above because it executes after Flyway. Compatibility cleanup should happen only after the supported Project Space upgrade path is explicitly hardened and verified.
+
+## Verification
+
+Recommended module test:
+
+```bash
+mvn -pl yak-ops-business/yak-ops-business-dataset -am test
+```
+
+Recommended database verification:
+
+1. start a representative historical database on the Stage 6 runtime/backfill release;
+2. confirm the NULL and ownership-mismatch preflight queries all return `0`;
+3. deploy Stage 6.1 and confirm V5 succeeds;
+4. verify `information_schema.columns` reports both contracted `project_id` columns as `IS_NULLABLE = 'NO'`;
+5. rerun Project A/B Dataset isolation smoke tests.
+
+## Non-goals
+
+- Stage 7 Offline Sync Project Space;
+- Stage 7 Realtime Sync Project Space;
+- changing Dataset runtime APIs or repository behavior;
+- changing Task Catalog / Lineage Project propagation;
+- adding Project columns to DatasetVersion / DatasetField;
+- solving the global multi-stage direct-upgrade problem in this PR;
+- removing all Project Space compatibility corridors.

--- a/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V5__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-dataset/src/main/resources/db/migration/yak-dataset/V5__contract_project_scope.sql
@@ -1,0 +1,8 @@
+-- Stage 6.1 Project Space contract for Dataset-owned project columns.
+-- Historical rows must have completed the Stage 6 ApplicationReady compatibility backfill first.
+-- This migration performs no implicit backfill and intentionally fails fast if NULL ownership remains.
+ALTER TABLE yak_dataset
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';
+
+ALTER TABLE yak_dataset_query_performance
+    MODIFY COLUMN project_id BIGINT NOT NULL;

--- a/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetFlywayContractTest.java
+++ b/yak-ops-business/yak-ops-business-dataset/src/test/java/io/yak/ops/business/dataset/architecture/DatasetFlywayContractTest.java
@@ -1,0 +1,81 @@
+package io.yak.ops.business.dataset.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Locks Dataset Expand -> Backfill -> Contract migration boundaries. */
+class DatasetFlywayContractTest {
+
+  @Test
+  void datasetNamespaceContainsProjectExpandAndContractMigrations() throws IOException {
+    assertThat(sqlFiles(migrationRoot()))
+        .containsExactly(
+            "V1__baseline_dataset.sql",
+            "V2__add_dataset_overview_indexes.sql",
+            "V3__expand_project_scope.sql",
+            "V4__persist_dataset_query_performance.sql",
+            "V5__contract_project_scope.sql");
+
+    String projectScopeExpand =
+        Files.readString(migrationRoot().resolve("V3__expand_project_scope.sql"));
+    assertThat(projectScopeExpand)
+        .contains("ALTER TABLE yak_dataset")
+        .contains("ADD COLUMN project_id BIGINT NULL")
+        .contains("idx_yak_dataset_project_status_update")
+        .contains("idx_yak_dataset_project_development_node");
+
+    String queryPerformanceExpand =
+        Files.readString(migrationRoot().resolve("V4__persist_dataset_query_performance.sql"));
+    assertThat(queryPerformanceExpand)
+        .contains("CREATE TABLE IF NOT EXISTS yak_dataset_query_performance")
+        .contains("project_id BIGINT NULL")
+        .contains("idx_yak_dataset_query_performance_project_time");
+
+    String projectScopeContract =
+        Files.readString(migrationRoot().resolve("V5__contract_project_scope.sql"));
+    assertThat(projectScopeContract)
+        .contains(
+            "ALTER TABLE yak_dataset\n"
+                + "    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID'")
+        .contains(
+            "ALTER TABLE yak_dataset_query_performance\n"
+                + "    MODIFY COLUMN project_id BIGINT NOT NULL")
+        .contains("performs no implicit backfill")
+        .doesNotContain("UPDATE yak_dataset")
+        .doesNotContain("UPDATE yak_dataset_query_performance")
+        .doesNotContain("project_id = 1")
+        .doesNotContain("project_id = 0")
+        .doesNotContain("yak_dataset_version")
+        .doesNotContain("yak_dataset_field");
+  }
+
+  private List<String> sqlFiles(Path root) throws IOException {
+    try (var paths = Files.list(root)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .map(path -> path.getFileName().toString())
+          .filter(name -> name.endsWith(".sql"))
+          .sorted()
+          .toList();
+    }
+  }
+
+  private Path migrationRoot() {
+    Path local = Path.of("src/main/resources/db/migration/yak-dataset");
+    if (Files.isDirectory(local)) return local;
+    return Path.of(
+        "yak-ops-business",
+        "yak-ops-business-dataset",
+        "src",
+        "main",
+        "resources",
+        "db",
+        "migration",
+        "yak-dataset");
+  }
+}


### PR DESCRIPTION
## 背景

Stage 6（#877）已经把 Dataset 业务面切换到 `PROJECT_REQUIRED`，完成 Repository fail-closed、Source Truth 校验、Lineage Project 传播以及历史 Dataset / query diagnostics 的 ApplicationReady compatibility backfill。Stage 5B（#878）随后关闭了 Data Development × Dataset 的 Project integration seam。

Stage 6.1 只做 **Dataset Physical Contract**：把运行时已经要求必填的 Project ownership 收紧成数据库 `NOT NULL`，不提前进入 Stage 7。

## 本 PR 做了什么

### 1. 新增 V5 Contract migration

新增：

```text
V5__contract_project_scope.sql
```

物理收紧：

```text
yak_dataset.project_id                    -> NOT NULL
yak_dataset_query_performance.project_id  -> NOT NULL
```

其中：

- `yak_dataset` 是 `PROJECT_ROOT`；
- `yak_dataset_query_performance` 是 Project-scoped runtime / observability fact；
- `yak_dataset_version` / `yak_dataset_field` 继续通过父 Dataset `INHERITED`，不增加冗余 `project_id`。

V5 是纯 Contract migration：

- 不做历史 `UPDATE`；
- 不猜 Project；
- 不硬编码 `project_id = 1`；
- 不使用 `project_id = 0` fallback；
- legacy NULL 未清理时按预期 fail-fast。

### 2. 新增 Dataset Flyway Contract Test

新增 `DatasetFlywayContractTest`，锁定：

```text
V1 baseline
 ↓
V2 overview indexes
 ↓
V3 Dataset Project Expand(nullable)
 ↓
V4 Query Performance Project Expand(nullable)
 ↓
Stage 6 ApplicationReady Backfill
 ↓
V5 Stage 6.1 Contract(NOT NULL)
```

测试同时保证：

- V3 / V4 继续保持 nullable Expand 语义；
- V5 同时收紧 Dataset Root 与 query diagnostics；
- V5 不包含隐式 Backfill；
- V5 不触碰 DatasetVersion / DatasetField。

### 3. 新增 Stage 6.1 部署说明

新增 `STAGE6_1_PROJECT_CONTRACT.md`，明确：

- Flyway 早于 `ApplicationReadyEvent`；
- 历史数据库必须先成功运行过 Stage 6 runtime/backfill 版本；
- 不能依赖同一次启动中的 `DatasetProjectCompatibilityBackfill` 去抢救 V5 前的 NULL；
- 给出 NULL preflight 与 Dataset / DevelopmentNode / TaskAsset / DataSource / diagnostics ownership mismatch 检查 SQL；
- 当前 PR 不顺手删除兼容 Backfill，避免扩大跨 Stage 升级风险。

## 重要部署前置条件

Stage 6 Backfill 完成后，下面两条必须都返回 `0`：

```sql
SELECT COUNT(*)
FROM yak_dataset
WHERE project_id IS NULL;

SELECT COUNT(*)
FROM yak_dataset_query_performance
WHERE project_id IS NULL;
```

并建议同时确认 Stage 6 Source Truth mismatch 检查均为 `0`。

如果历史库从 pre-Stage-6 版本直接跳到包含 V5 的版本，Flyway 可能在 ApplicationReady Backfill 之前执行 V5 并失败；这是当前阶段刻意的 fail-fast 行为，不在 Contract SQL 中加入默认 Project 或隐式 UPDATE 掩盖升级顺序问题。

## 建议验证

```bash
mvn -pl yak-ops-business/yak-ops-business-dataset -am test
```

数据库最小验证：

1. 代表性历史库先运行 Stage 6 runtime/backfill；
2. NULL / ownership mismatch preflight 全部为 0；
3. 部署本 PR，确认 V5 Flyway 成功；
4. `information_schema.columns` 中两列 `IS_NULLABLE = 'NO'`；
5. Project A / B Dataset detail/query/version/field/overview/query-performance 隔离回归正常。

## 当前验证状态

已完成 connector 侧 branch vs main 静态范围审查：

```text
behind = 0
ahead = 3
changed files = 3
```

当前环境没有执行本地 Maven / MySQL Flyway 集成测试，因此保持 Draft，不宣称测试已经通过。

## Non-goals

- Stage 7 Offline Sync；
- Stage 7 Realtime Sync；
- Dataset Runtime API / Repository 改造；
- Task Catalog / Lineage 改造；
- 给 DatasetVersion / DatasetField 增加 Project 列；
- 全局多阶段直接升级方案；
- 删除所有 Project Space compatibility corridor。

## Review 重点

- `yak_dataset_query_performance` 是否应与 Dataset Root 一起在 6.1 收紧；
- V5 是否保持纯 Contract、没有 ownership inference；
- Version / Field `INHERITED` 边界是否继续保持；
- 历史库部署 prerequisite 是否足够明确；
- 是否需要在进入 Stage 7 前单独做 Project Space migration / upgrade hardening。