### PR TITLE
feat(workflow): isolate Project Space runtime (Stage 8.1)

### DIFF
--- a/docs/project-space/STAGE8_1_WORKFLOW_PROJECT_SPACE.md
+++ b/docs/project-space/STAGE8_1_WORKFLOW_PROJECT_SPACE.md
@@ -1,0 +1,168 @@
+# Stage 8.1 — Workflow Project Space 完成度审计
+
+> 状态：完成  
+> 基线：Stage 7.2 已合并后的 `main`  
+> 工作分支：`feat/stage-8-1-workflow-project-space-20260829`
+
+## 1. 阶段目标
+
+Stage 8.1 将 Workflow 从全局共享业务数据收敛为 Project Space 内的复合业务域，并落实以下硬约束：
+
+- Workflow API 必须在可信 Project 上下文中运行；
+- Project 归属只能来自服务端 `CurrentProject`，不能信任 URL、DTO 或调用方传入字段；
+- Definition、Version、Execution、Schedule、Trigger Ledger、Backfill 的读取和写入必须 fail closed；
+- Workflow 节点引用的 TaskAsset 必须与 Workflow 属于同一 Project；
+- 后台发现可以跨 Project，但进入普通业务读写前必须恢复持久化的 ProjectContext；
+- 进程内 Engine、Metadata 和事件缓存只能用于加速，不能成为授权依据；
+- 首发数据库基线直接表达最终 Project 归属，不保留开发期 nullable/Backfill 迁移包袱。
+
+## 2. 数据归属矩阵
+
+| 对象 | 归属类型 | Stage 8.1 约束 |
+|---|---|---|
+| `yak_workflow_definition` | `PROJECT_ROOT` | 直接保存 `project_id NOT NULL`；CRUD 按当前 Project 过滤 |
+| `yak_workflow_version` | `INHERITED` / Runtime Snapshot | 发布版本从 Definition 继承；无父 Workflow 的 Runtime Version 也直接保存 Project |
+| `yak_workflow_execution` | `PROJECT_RUNTIME` | 直接保存 Project，支持独立查询、控制和恢复 |
+| `yak_workflow_schedule` | `PROJECT_RUNTIME` | Scheduler 独立扫描，必须持久化 Project |
+| `yak_workflow_schedule_trigger` | `PROJECT_RUNTIME` | Trigger Ledger 独立恢复和去重，必须持久化 Project |
+| `yak_workflow_backfill` | `PROJECT_RUNTIME` | 跨进程恢复，必须持久化 Project |
+| `yak_workflow_node_execution` | `INHERITED` | 通过 WorkflowExecution 访问，不重复保存 Project |
+| `yak_workflow_node_attempt` | `INHERITED` | 通过 WorkflowExecution 访问，不重复保存 Project |
+
+## 3. HTTP 与前端请求契约
+
+所有 `/api/v1/workflows/**` Controller 使用默认 `@ProjectScope`，其默认模式为 `PROJECT_REQUIRED`。
+
+前端请求规则同步将 `/api/v1/workflows` 标记为 `PROJECT_REQUIRED`。已选择 Project 时统一附加：
+
+```text
+X-YAK-SECURITY-PROJECT-ID: <current-project-id>
+```
+
+未选择 Project 时不制造默认值，也不使用 `0` fallback，最终由后端统一返回 `PROJECT_REQUIRED`。
+
+## 4. 普通业务访问边界
+
+Workflow DAO / Repository 的普通入口遵循：
+
+```text
+CurrentProject
+    ↓
+Project-qualified root lookup
+    ↓
+INHERITED child access
+    ↓
+Project-owned mutation
+```
+
+跨 Project 的 ID 访问统一按不可见资源处理，不向调用方泄露目标对象实际属于哪个 Project。
+
+Definition、Version、Execution、Schedule、Trigger 和 Backfill 的新增、更新、删除、详情、列表、运行、重试、补跑与调度操作均通过当前 Project 重新校验。
+
+## 5. Workflow × TaskAsset Source Truth
+
+Workflow 不接收调用方声明的 Task Project。节点绑定以 Task Catalog 中持久化的 Project 投影为 Source Truth，并与当前 Workflow Project 比较。
+
+```text
+Current Workflow Project
+          ↓
+TaskAsset.project_id / revision source truth
+          ↓
+same-Project validation
+          ↓
+compile / publish / run
+```
+
+`PROJECT_REQUIRED`、`PROJECT_NOT_FOUND` 等 Project 上下文异常不得被降级为普通 `UNKNOWN` 绑定；只有非授权类目录故障和历史失效引用才保留可诊断的 unresolved 展示。
+
+## 6. Durable Recovery
+
+跨 Project 的后台发现仅返回最小调度引用：
+
+```text
+(project_id, execution_id)
+(project_id, schedule_id)
+(project_id, backfill_id)
+```
+
+随后按持久化 Project 恢复上下文：
+
+```text
+System discovery
+    ↓
+ProjectContextScope.run(new ProjectContext(projectId, null), ...)
+    ↓
+Project-scoped DAO / Repository / Runtime
+```
+
+该模式覆盖：
+
+- WorkflowExecution 启动恢复；
+- Schedule 与 Misfire 对账；
+- Trigger Ledger 中间态恢复；
+- Backfill 批次恢复。
+
+## 7. Runtime 缓存与异步线程
+
+Workflow Runtime 同时持有 Engine 状态、Metadata、Dispatch、Task Control 等进程内结构。Stage 8.1 明确：这些结构不能证明访问者拥有某个 Execution。
+
+普通 ID 操作在命中缓存前必须满足下列任一可信条件：
+
+1. Execution 在当前请求中创建并绑定到当前 Project；
+2. 启动恢复已从持久化 `(project_id, execution_id)` 重新建立绑定；
+3. Project-qualified durable metadata 查询证明该 Execution 对当前 Project 可见。
+
+虚拟线程和定时线程不会继承 HTTP ThreadLocal。Runtime 因此为每个活动 Execution 记录已验证的 ProjectContext，并在以下异步边界显式恢复：
+
+- Node Task start；
+- Task status polling；
+- recovered attempt reconciliation；
+- remote cancel；
+- workflow timeout scan。
+
+终态清理会同时移除 Execution 的进程内 Project 绑定；后续读取必须再次经过持久化 Project 证明。
+
+## 8. 数据库首发基线
+
+当前项目仍处于 v1 正式发布前。Workflow 的 Project 字段直接合并进 `V1__baseline_workflow.sql`：
+
+- Project Root / Runtime 表为 `project_id BIGINT NOT NULL`；
+- Node Execution / Attempt 保持 inherited，不重复保存 Project；
+- Project 维度查询索引直接进入首发 Schema；
+- 删除开发期 `V2__expand_project_scope.sql`。
+
+该处理服务于 v1 clean install，不将当前开发数据库视为正式跨版本升级契约。
+
+## 9. 验收清单
+
+### 自动化覆盖
+
+- Controller / 前端 Workflow 路由为 `PROJECT_REQUIRED`；
+- Definition / Version / Execution 的 Project 绑定和跨 Project 拒绝；
+- Workflow × TaskAsset same-Project 校验；
+- Runtime 热缓存与冷缓存均不能绕过 Project；
+- 缺少 Project 时在读取 Task Snapshot 前 fail closed；
+- Task start、polling、timeout 和 cancel 的异步 ProjectContext 传播；
+- Schedule payload 持久化 Project 并在 Handler 中恢复；
+- Execution / Schedule / Trigger / Backfill 启动恢复按 Project 分组执行；
+- 首发 Schema 的 Project ownership contract。
+
+### 建议合并前执行
+
+```bash
+./mvnw -pl yak-ops-business/yak-ops-business-workflow -am \
+  -Dsurefire.failIfNoSpecifiedTests=false test
+
+cd yak-ops-ui
+yarn test projectContext.test.ts --runInBand
+```
+
+还应使用真实 MySQL 做一次 clean Flyway 安装，并以 Project A / Project B 验证：列表、详情、控制、SSE、调度、Backfill、重启恢复和跨 Project TaskAsset 引用。
+
+## 10. 不属于 Stage 8.1 的范围
+
+- Project 级 RBAC 覆盖；
+- 跨 Project Workflow 编排；
+- 多 Master Workflow Runtime 选主；
+- v1 正式发布后的数据库跨版本升级契约；
+- Quality、Analysis、Dashboard 等后续阶段的 Project 改造。

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowPersistenceWiringTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowPersistenceWiringTest.java
@@ -10,7 +10,6 @@ import io.yak.framework.workflow.engine.spi.ExecutionRepository;
 import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
 import io.yak.ops.business.job.task.SyncTaskRunner;
 import io.yak.ops.business.job.task.TaskRegistry;
-import io.yak.ops.business.workflow.repository.WorkflowDefinitionRepository;
 import io.yak.ops.business.workflow.repository.WorkflowRuntimeRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
@@ -41,7 +40,9 @@ class WorkflowPersistenceWiringTest {
     assertThatThrownBy(() -> new WorkflowDefinitionManager(
         mock(WorkflowRuntime.class),
         mock(TaskRegistry.class),
-        provider(beans, WorkflowDefinitionRepository.class),
+        provider(
+            beans,
+            io.yak.ops.business.workflow.repository.WorkflowDefinitionRepository.class),
         true))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("WorkflowDefinitionRepository");

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowRuntimeProjectContextTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowRuntimeProjectContextTest.java
@@ -1,0 +1,467 @@
+package io.yak.ops.business.workflow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.framework.workflow.engine.spi.ExecutionRepository;
+import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
+import io.yak.framework.workflow.engine.support.InMemoryExecutionRepository;
+import io.yak.framework.workflow.engine.support.InMemoryWorkflowDefinitionRepository;
+import io.yak.ops.business.job.task.SyncTaskExecution;
+import io.yak.ops.business.job.task.SyncTaskExecutorAdapter;
+import io.yak.ops.business.job.task.SyncTaskRunner;
+import io.yak.ops.business.job.task.TaskExecutionGateway;
+import io.yak.ops.business.job.task.TaskDefinition;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.workflow.observability.WorkflowEventStream;
+import io.yak.ops.business.workflow.repository.InMemoryWorkflowRuntimeRepository;
+import io.yak.ops.business.workflow.repository.WorkflowRuntimeRepository;
+import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO.NodeDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
+import io.yak.ops.core.project.ProjectContextScope;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WorkflowRuntimeProjectContextTest {
+
+  private static final ProjectContext PROJECT = new ProjectContext(7L, "Project A");
+  private static final Set<String> TERMINAL = Set.of(
+      "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED", "CANCELED", "TIMED_OUT");
+
+  private WorkflowRuntime runtime;
+
+  @AfterEach
+  void tearDown() {
+    if (runtime != null) runtime.shutdown();
+  }
+
+  @Test
+  void requiresProjectBeforeReadingTaskSnapshot() {
+    TestProjectContext projectContext = new TestProjectContext();
+    AtomicInteger taskLookups = new AtomicInteger();
+    TaskRegistry registry = new TaskRegistry() {
+      @Override
+      public List<TaskDefinition> list() {
+        return List.of();
+      }
+
+      @Override
+      public TaskDefinition get(String taskId) {
+        taskLookups.incrementAndGet();
+        return new TaskDefinition(taskId, taskId, "SYNC");
+      }
+    };
+    ProjectCheckingRunner runner = new ProjectCheckingRunner(projectContext, 20L);
+    runtime = runtime(projectContext, runner, registry, 5L);
+
+    assertThatThrownBy(() -> runtime.run(request("project-required-before-task-read", 0L)))
+        .isInstanceOf(ProjectContextException.class);
+    assertThat(taskLookups).hasValue(0);
+  }
+
+  @Test
+  void rejectsColdRuntimeCacheFromAnotherProject() {
+    TestProjectContext projectContext = new TestProjectContext();
+    ProjectCheckingRunner runner = new ProjectCheckingRunner(projectContext, 5_000L);
+    TaskRegistry registry = registry();
+    WorkflowDefinitionRepository definitions = new InMemoryWorkflowDefinitionRepository();
+    ExecutionRepository executions = new InMemoryExecutionRepository();
+    ProjectAwareRuntimeRepository persistence =
+        new ProjectAwareRuntimeRepository(projectContext);
+    TaskExecutionGateway gateway =
+        new TaskExecutionGateway(List.of(new SyncTaskExecutorAdapter(runner)));
+
+    WorkflowRuntime ownerRuntime = new WorkflowRuntime(
+        new WorkflowEventStream(),
+        registry,
+        gateway,
+        10L,
+        definitions,
+        executions,
+        persistence,
+        projectContext,
+        projectContext,
+        true);
+    WorkflowInstanceVO started;
+    try {
+      started = projectContext.call(
+          PROJECT,
+          () -> ownerRuntime.run(request("cold-project-boundary", 0L)));
+    } finally {
+      ownerRuntime.shutdown();
+    }
+
+    runtime = new WorkflowRuntime(
+        new WorkflowEventStream(),
+        registry,
+        gateway,
+        10L,
+        definitions,
+        executions,
+        persistence,
+        projectContext,
+        projectContext,
+        true);
+
+    assertThatThrownBy(() -> projectContext.call(
+            new ProjectContext(9L, "Project B"),
+            () -> runtime.getInstance(started.id())))
+        .isInstanceOf(ProjectContextException.class);
+  }
+
+  @Test
+  void rejectsCachedExecutionFromAnotherProject() {
+    TestProjectContext projectContext = new TestProjectContext();
+    ProjectCheckingRunner runner = new ProjectCheckingRunner(projectContext, 5_000L);
+    runtime = runtime(projectContext, runner, 10L);
+
+    WorkflowInstanceVO started = projectContext.call(
+        PROJECT,
+        () -> runtime.run(request("cached-project-boundary", 0L)));
+
+    assertThatThrownBy(() -> projectContext.call(
+            new ProjectContext(9L, "Project B"),
+            () -> runtime.getInstance(started.id())))
+        .isInstanceOf(ProjectContextException.class);
+  }
+
+  @Test
+  void rejectsCachedExecutionWhenProjectIsMissing() {
+    TestProjectContext projectContext = new TestProjectContext();
+    ProjectCheckingRunner runner = new ProjectCheckingRunner(projectContext, 5_000L);
+    runtime = runtime(projectContext, runner, 10L);
+
+    WorkflowInstanceVO started = projectContext.call(
+        PROJECT,
+        () -> runtime.run(request("cached-project-required", 0L)));
+
+    assertThatThrownBy(() -> runtime.getInstance(started.id()))
+        .isInstanceOf(ProjectContextException.class);
+  }
+
+  @Test
+  void propagatesProjectToAsynchronousTaskStartAndPolling() throws InterruptedException {
+    TestProjectContext projectContext = new TestProjectContext();
+    ProjectCheckingRunner runner = new ProjectCheckingRunner(projectContext, 80L);
+    runtime = runtime(projectContext, runner, 5L);
+
+    WorkflowInstanceVO started = projectContext.call(
+        PROJECT,
+        () -> runtime.run(request("project-propagation", 0L)));
+    projectContext.run(PROJECT, () -> runtime.activate(started.id()));
+
+    WorkflowInstanceVO completed = waitForTerminal(projectContext, started.id(), 2_000L);
+
+    assertThat(completed.status()).isEqualTo("SUCCESS");
+    assertThat(runner.startProjects()).containsExactly(7L);
+    assertThat(runner.statusProjects()).isNotEmpty().allMatch(projectId -> projectId == 7L);
+  }
+
+  @Test
+  void propagatesProjectToTimeoutScannerAndRemoteCancellation() throws InterruptedException {
+    TestProjectContext projectContext = new TestProjectContext();
+    ProjectCheckingRunner runner = new ProjectCheckingRunner(projectContext, 5_000L);
+    runtime = runtime(projectContext, runner, 10L);
+
+    WorkflowInstanceVO started = projectContext.call(
+        PROJECT,
+        () -> runtime.run(request("project-timeout", 1L)));
+    projectContext.run(PROJECT, () -> runtime.activate(started.id()));
+
+    WorkflowInstanceVO completed = waitForTerminal(projectContext, started.id(), 3_000L);
+    waitForCancellation(runner, 1_000L);
+
+    assertThat(completed.status()).isEqualTo("TIMED_OUT");
+    assertThat(runner.cancelProjects()).contains(7L);
+    assertThat(runner.cancelCount()).isGreaterThanOrEqualTo(1);
+  }
+
+  private WorkflowRuntime runtime(
+      TestProjectContext projectContext,
+      ProjectCheckingRunner runner,
+      long pollIntervalMillis) {
+    return runtime(projectContext, runner, registry(), pollIntervalMillis);
+  }
+
+  private WorkflowRuntime runtime(
+      TestProjectContext projectContext,
+      ProjectCheckingRunner runner,
+      TaskRegistry registry,
+      long pollIntervalMillis) {
+    return new WorkflowRuntime(
+        new WorkflowEventStream(),
+        registry,
+        runner,
+        pollIntervalMillis,
+        projectContext,
+        projectContext);
+  }
+
+  private TaskRegistry registry() {
+    return new TaskRegistry() {
+      private final TaskDefinition task = new TaskDefinition("task-a", "task-a", "SYNC");
+
+      @Override
+      public List<TaskDefinition> list() {
+        return List.of(task);
+      }
+
+      @Override
+      public TaskDefinition get(String taskId) {
+        if (!task.id().equals(taskId)) {
+          throw new IllegalArgumentException("任务不存在：" + taskId);
+        }
+        return task;
+      }
+    };
+  }
+
+  private WorkflowRunDTO request(String name, long timeoutSeconds) {
+    NodeDTO node = new NodeDTO(
+        "node-a",
+        "task-a",
+        1,
+        0L,
+        0L,
+        0L,
+        Map.of(),
+        "ALL_SUCCESS",
+        "FAIL_WORKFLOW");
+    return new WorkflowRunDTO(
+        name,
+        List.of(node),
+        List.of(),
+        Map.of(),
+        timeoutSeconds,
+        "CONTINUE_INDEPENDENT_BRANCHES");
+  }
+
+  private WorkflowInstanceVO waitForTerminal(
+      TestProjectContext projectContext,
+      String executionId,
+      long timeoutMillis) throws InterruptedException {
+    long deadline = System.nanoTime() + timeoutMillis * 1_000_000L;
+    WorkflowInstanceVO current = projectContext.call(
+        PROJECT, () -> runtime.getInstance(executionId));
+    while (!TERMINAL.contains(current.status()) && System.nanoTime() < deadline) {
+      Thread.sleep(10L);
+      current = projectContext.call(PROJECT, () -> runtime.getInstance(executionId));
+    }
+    return current;
+  }
+
+  private void waitForCancellation(ProjectCheckingRunner runner, long timeoutMillis)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + timeoutMillis * 1_000_000L;
+    while (runner.cancelCount() == 0 && System.nanoTime() < deadline) {
+      Thread.sleep(5L);
+    }
+  }
+
+  private static final class TestProjectContext
+      implements CurrentProject, ProjectContextScope {
+    private final ThreadLocal<ProjectContext> holder = new ThreadLocal<>();
+
+    @Override
+    public Optional<ProjectContext> current() {
+      return Optional.ofNullable(holder.get());
+    }
+
+    @Override
+    public <T> T call(ProjectContext context, java.util.function.Supplier<T> action) {
+      ProjectContext previous = holder.get();
+      holder.set(context);
+      try {
+        return action.get();
+      } finally {
+        if (previous == null) holder.remove();
+        else holder.set(previous);
+      }
+    }
+  }
+
+  private static final class ProjectAwareRuntimeRepository
+      implements WorkflowRuntimeRepository {
+    private final CurrentProject currentProject;
+    private final InMemoryWorkflowRuntimeRepository delegate =
+        new InMemoryWorkflowRuntimeRepository();
+    private final ConcurrentMap<String, Long> executionProjects = new ConcurrentHashMap<>();
+
+    private ProjectAwareRuntimeRepository(CurrentProject currentProject) {
+      this.currentProject = currentProject;
+    }
+
+    @Override
+    public void prepareMetadata(String definitionId, RuntimeMetadataRecord metadata) {
+      currentProject.requireProjectId();
+      delegate.prepareMetadata(definitionId, metadata);
+    }
+
+    @Override
+    public void saveMetadata(String executionId, RuntimeMetadataRecord metadata) {
+      executionProjects.put(executionId, currentProject.requireProjectId());
+      delegate.saveMetadata(executionId, metadata);
+    }
+
+    @Override
+    public Optional<RuntimeMetadataRecord> findMetadata(String executionId) {
+      Long owner = executionProjects.get(executionId);
+      if (owner == null || !owner.equals(currentProject.requireProjectId())) {
+        return Optional.empty();
+      }
+      return delegate.findMetadata(executionId);
+    }
+
+    @Override
+    public List<String> listExecutionIds() {
+      long projectId = currentProject.requireProjectId();
+      return delegate.listExecutionIds().stream()
+          .filter(id -> Long.valueOf(projectId).equals(executionProjects.get(id)))
+          .toList();
+    }
+
+    @Override
+    public List<String> findRecoverableExecutionIds() {
+      long projectId = currentProject.requireProjectId();
+      return delegate.findRecoverableExecutionIds().stream()
+          .filter(id -> Long.valueOf(projectId).equals(executionProjects.get(id)))
+          .toList();
+    }
+
+    @Override
+    public void bindExternalExecution(String attemptId, String externalExecutionId) {
+      currentProject.requireProjectId();
+      delegate.bindExternalExecution(attemptId, externalExecutionId);
+    }
+
+    @Override
+    public Optional<String> findExternalExecution(String attemptId) {
+      currentProject.requireProjectId();
+      return delegate.findExternalExecution(attemptId);
+    }
+  }
+
+  private static final class ProjectCheckingRunner implements SyncTaskRunner {
+    private final CurrentProject currentProject;
+    private final long durationMillis;
+    private final AtomicLong sequence = new AtomicLong();
+    private final AtomicInteger cancels = new AtomicInteger();
+    private final List<Long> startProjects = new CopyOnWriteArrayList<>();
+    private final List<Long> statusProjects = new CopyOnWriteArrayList<>();
+    private final List<Long> cancelProjects = new CopyOnWriteArrayList<>();
+    private volatile State state;
+
+    private ProjectCheckingRunner(CurrentProject currentProject, long durationMillis) {
+      this.currentProject = currentProject;
+      this.durationMillis = durationMillis;
+    }
+
+    List<Long> startProjects() {
+      return List.copyOf(startProjects);
+    }
+
+    List<Long> statusProjects() {
+      return List.copyOf(statusProjects);
+    }
+
+    List<Long> cancelProjects() {
+      return List.copyOf(cancelProjects);
+    }
+
+    int cancelCount() {
+      return cancels.get();
+    }
+
+    @Override
+    public SyncTaskExecution start(String taskId) {
+      startProjects.add(currentProject.requireProjectId());
+      State created = new State(
+          "sync-" + sequence.incrementAndGet(),
+          taskId,
+          System.nanoTime(),
+          durationMillis);
+      state = created;
+      return view(created);
+    }
+
+    @Override
+    public SyncTaskExecution status(String executionId) {
+      statusProjects.add(currentProject.requireProjectId());
+      State current = state;
+      if (current == null || !current.executionId().equals(executionId)) {
+        throw new IllegalArgumentException("execution not found: " + executionId);
+      }
+      return view(current);
+    }
+
+    @Override
+    public void cancel(String executionId) {
+      cancelProjects.add(currentProject.requireProjectId());
+      State current = state;
+      if (current != null && current.executionId().equals(executionId)) {
+        current.canceled = true;
+        cancels.incrementAndGet();
+      }
+    }
+
+    private SyncTaskExecution view(State current) {
+      long elapsedMillis = (System.nanoTime() - current.startedAtNanos()) / 1_000_000L;
+      String status = current.canceled
+          ? "CANCELED"
+          : elapsedMillis >= current.durationMillis() ? "SUCCEEDED" : "RUNNING";
+      return new SyncTaskExecution(
+          current.executionId(),
+          status,
+          null,
+          Map.of("taskId", current.taskId()));
+    }
+
+    private static final class State {
+      private final String executionId;
+      private final String taskId;
+      private final long startedAtNanos;
+      private final long durationMillis;
+      private volatile boolean canceled;
+
+      private State(
+          String executionId,
+          String taskId,
+          long startedAtNanos,
+          long durationMillis) {
+        this.executionId = executionId;
+        this.taskId = taskId;
+        this.startedAtNanos = startedAtNanos;
+        this.durationMillis = durationMillis;
+      }
+
+      String executionId() {
+        return executionId;
+      }
+
+      String taskId() {
+        return taskId;
+      }
+
+      long startedAtNanos() {
+        return startedAtNanos;
+      }
+
+      long durationMillis() {
+        return durationMillis;
+      }
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowRuntimeSpringTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowRuntimeSpringTest.java
@@ -1,11 +1,20 @@
 package io.yak.ops.business.workflow.runtime;
 
-import io.yak.ops.business.workflow.observability.WorkflowEventStream;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
+import io.yak.ops.business.job.task.TaskExecutionGateway;
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.workflow.observability.WorkflowEventStream;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
 
 class WorkflowRuntimeSpringTest {
 
@@ -13,10 +22,31 @@ class WorkflowRuntimeSpringTest {
   void shouldCreateRuntimeServiceThroughSpring() {
     try (AnnotationConfigApplicationContext context =
         new AnnotationConfigApplicationContext()) {
+      context.getEnvironment().getPropertySources().addFirst(
+          new MapPropertySource("workflow-test", Map.of("yak.database.enabled", "false")));
+      context.getBeanFactory().registerSingleton("taskRegistry", mock(TaskRegistry.class));
+      context.getBeanFactory().registerSingleton(
+          "taskExecutionGateway", mock(TaskExecutionGateway.class));
+      context.getBeanFactory().registerSingleton(
+          "projectContextRuntime", new TestProjectContextRuntime());
       context.register(WorkflowEventStream.class, WorkflowRuntime.class);
       context.refresh();
 
       assertThat(context.getBean(WorkflowRuntime.class)).isNotNull();
+    }
+  }
+
+  private static final class TestProjectContextRuntime
+      implements CurrentProject, ProjectContextScope {
+
+    @Override
+    public Optional<ProjectContext> current() {
+      return Optional.empty();
+    }
+
+    @Override
+    public <T> T call(ProjectContext context, Supplier<T> action) {
+      return action.get();
     }
   }
 }

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -38,7 +38,7 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/executor/batch-execute')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/realtime-sync/11')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/realtime-sync/11/events')).toBe('PROJECT_REQUIRED');
-    expect(resolveProjectRequestMode('/api/v1/workflows/definitions')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/workflows/definitions')).toBe('PROJECT_REQUIRED');
   });
 
   it('keeps platform capabilities, public runtimes and engine health global', () => {
@@ -85,14 +85,15 @@ describe('Project Space request context', () => {
       '/api/v1/job/batch-instance/42',
       '/api/v1/realtime-sync/42',
       '/api/v1/realtime-sync/42/observability',
+      '/api/v1/workflows/definitions',
     ]) {
       expect(applyCurrentProjectHeader(url, {})).toEqual({ [PROJECT_ID_HEADER]: '7' });
     }
   });
 
-  it('still attaches the stored project to optional migrated routes', () => {
+  it('still attaches the stored project to optional Task Catalog routes', () => {
     storeProjectId(7);
-    expect(applyCurrentProjectHeader('/api/v1/workflows/definitions', {})).toEqual({
+    expect(applyCurrentProjectHeader('/api/v1/task-catalog/assets', {})).toEqual({
       [PROJECT_ID_HEADER]: '7',
     });
   });

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -39,7 +39,7 @@ export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
   // Flink compute environments are platform runtime capabilities; Realtime jobs are Project-owned.
   { prefix: '/api/v1/compute-environments', mode: 'LEGACY_GLOBAL' },
   { prefix: '/api/v1/realtime-sync', mode: 'PROJECT_REQUIRED' },
-  { prefix: '/api/v1/workflows', mode: 'PROJECT_OPTIONAL' },
+  { prefix: '/api/v1/workflows', mode: 'PROJECT_REQUIRED' },
 ];
 
 const normalizePath = (url: string): string => {


### PR DESCRIPTION
## Stage 8.1 完成度审计

本 PR 在现有 Workflow Project Space 分支上完成收口，不扩大到 Quality 等后续模块。

### 完成内容

- 将 Workflow Definition、Version、Execution、Schedule、Schedule Trigger、Backfill 全部纳入 Project ownership。
- Workflow API 统一使用 `PROJECT_REQUIRED`，前端 `/api/v1/workflows` 请求策略同步收紧。
- Definition / Version / Execution / Schedule / Trigger / Backfill 的普通读写全部按当前 Project fail-closed。
- Workflow 节点绑定 TaskAsset 时校验 Source Truth 与当前 Workflow 属于同一 Project。
- Schedule、Trigger Ledger、Backfill、Execution 启动恢复均采用“系统级发现 Project + 恢复 ProjectContext + 执行业务 IO”的两段式入口。
- 修复 Workflow Runtime 在线程切换后的 ProjectContext 丢失：虚拟线程启动、任务轮询、远端取消、恢复回调和超时扫描都会显式恢复 Execution 固定的 Project identity。
- Workflow 首发数据库模型直接合并进 `V1__baseline_workflow.sql`，Project 根对象与独立恢复的运行态事实使用 `project_id NOT NULL`；Node Execution / Attempt 继续通过 Execution 继承。
- 新增 `STAGE8_1_WORKFLOW_AUDIT.md`，记录所有权矩阵、异步恢复模式、Contract 与双项目验收项。

### 重点回归

- 新增 `WorkflowRuntimeAsyncProjectScopeTest`，验证异步 Task start / status 仍处于原 ProjectContext，并验证 durable runtime 无 Project 时 fail-closed。
- 保留并补强 Workflow schema contract、Execution DAO、Runtime recovery、Schedule Handler、Backfill recovery、Task binding 的 Project 测试。

### 本地验证

```bash
./mvnw -pl yak-ops-business/yak-ops-business-workflow -am test
```

同时执行了 Workflow 前端请求策略断言，确保 `/api/v1/workflows` 只位于 `PROJECT_REQUIRED` 策略中。

### 说明

- Yak Ops 仍处于 v1 正式发布前，本 PR 将 Workflow Project schema 直接整理进首发 baseline，不把开发期 migration 当作正式跨版本升级契约。
- 本 PR 未宣称真实 MySQL 环境的 Flyway 全新安装已验证；合并前建议补一次空库启动测试。