### PR TITLE
feat(quality): complete Stage 8.2 Project Space isolation

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/PROJECT_SPACE.md
+++ b/yak-ops-business/yak-ops-business-quality/PROJECT_SPACE.md
@@ -1,0 +1,108 @@
+# Data Quality Project Space
+
+本文件定义 Data Quality 当前有效的 Project Space 数据边界。全局产品语义以仓库级 [`docs/architecture/PROJECT_SCOPE.md`](../../docs/architecture/PROJECT_SCOPE.md) 为准；本文件只收敛 Quality 自身的归属、查询和后台恢复契约。
+
+## 1. Ownership
+
+| Quality fact | Project ownership | Rule |
+| --- | --- | --- |
+| 内置规则模板 | `GLOBAL` | 平台级只读能力，不随 Project 切换 |
+| 自定义模板与模板目录 | `GLOBAL` | 当前版本仍是平台共享模板库 |
+| `TableAsset` | `PROJECT_ROOT` | 归属必须来自当前 Project 内的 Datasource |
+| `Monitor` | `PROJECT_ROOT` | 目标 TableAsset 与 Datasource 必须属于同一 Project |
+| `Rules` / `MonitorSettings` | `INHERITED` | 通过 Monitor 继承，不独立接受 Project 参数 |
+| `Execution` | `PROJECT_RUNTIME` | 直接持久化 `project_id`，支持独立查询和后台恢复 |
+| `RuleExecution` / `AlertEvent` | `INHERITED` | 通过 Execution / Monitor 证明归属 |
+| Yak Schedule definition | runtime projection | payload 与 metadata 必须携带持久化 Project ID |
+
+Quality 不支持跨 Project TableAsset、Monitor、Execution 引用，也不提供全局管理旁路。
+
+## 2. HTTP Boundary
+
+以下接口要求 trusted `CurrentProject`：
+
+```text
+/api/v1/data-quality/table-asset/**
+/api/v1/data-quality/monitor/**
+/api/v1/data-quality/execution/**
+/api/v1/data-quality/overview/**
+```
+
+模板接口保持显式全局：
+
+```text
+/api/v1/data-quality/template/**
+```
+
+请求头只负责选择 Project。业务归属由服务端完成身份、成员与状态校验后建立的 `CurrentProject` 决定；DTO、Path 或 Query 中的 ID 不能覆盖该上下文。
+
+## 3. Persistence Boundary
+
+项目级根事实直接保存 `project_id`：
+
+```text
+yak_quality_table_asset.project_id
+yak_quality_monitor.project_id
+yak_quality_execution.project_id
+```
+
+普通 DAO / Repository 访问必须 fail closed：
+
+- 列表、详情、更新、删除、执行和报表都带当前 `project_id`；
+- 创建时忽略外部归属，统一写入 `CurrentProject.requireProjectId()`；
+- 预填的其他 Project ID 被视为不可见资源；
+- Rule、Settings、RuleExecution、Alert 写入前先证明父 Monitor / Execution 属于当前 Project；
+- 跨 Project ID 对业务层表现为当前 Project 下不存在，避免资源枚举。
+
+全局模板查询不注入 Project 条件；模板使用量等统计仍表达平台级模板库事实。
+
+## 4. Datasource Consistency
+
+TableAsset 注册只能通过 `QualityDataCatalogGateway` 进入 Datasource typed Catalog。Datasource 自身已经按 `CurrentProject` 隔离，因此：
+
+```text
+CurrentProject
+  == Datasource.project_id
+  == TableAsset.project_id
+  == Monitor.project_id
+```
+
+数据库迁移从 Datasource 根事实确定性回填 TableAsset / Monitor，再由 Monitor 回填 Execution。迁移不猜测默认 Project ID；存在孤立数据时由 `NOT NULL` contract 阻止部署继续。
+
+## 5. Async Execution
+
+`QualityExecutionPlan` 在受理时冻结 `projectId`。事务提交后的线程池任务不能依赖 HTTP ThreadLocal，而必须显式恢复：
+
+```text
+QualityExecutionPlan.projectId
+  -> ProjectContextScope
+  -> QualityExecutionWorker
+  -> project-scoped Repository / Datasource Catalog
+```
+
+队列拒绝后的 Execution/Monitor 补偿写入也必须在相同 Project Context 中执行。
+
+## 6. Schedule and Recovery
+
+Schedule definition 的 payload 和 metadata 同时保存 `projectId` 与 `monitorId`。回调处理顺序固定为：
+
+```text
+read persisted projectId
+  -> ProjectContextScope
+  -> load current Monitor / Settings
+  -> QualityExecutionManager.runScheduled
+```
+
+启动恢复使用一个显式、只返回 `(projectId, monitorId)` 的系统级扫描端口。扫描结果不能直接执行业务操作；每个候选必须先恢复对应 Project，再进入普通 Repository 和 Lifecycle。
+
+## 7. Review Checklist
+
+变更 Quality 项目数据时至少验证：
+
+- Project A / B 的列表、详情、修改、删除和运行互不可见；
+- A 不能注册或监控 B 的 Datasource / TableAsset；
+- 执行记录、规则执行工作台、质量报告与总览不聚合其他 Project；
+- 手动执行、线程池 Worker、队列拒绝补偿都保留受理时 Project；
+- Schedule callback、misfire 与启动恢复都能恢复持久化 Project；
+- 模板接口继续全局，且前端不会向其附加 Project Header；
+- 迁移不存在硬编码 `project_id = 1` 或其他猜测默认空间的逻辑。

--- a/yak-ops-business/yak-ops-business-quality/README.md
+++ b/yak-ops-business/yak-ops-business-quality/README.md
@@ -5,10 +5,10 @@ Data Quality 是 Yak Ops 的数据质量控制面，负责数据表资产注册�
 当前核心执行关系：
 
 ```text
-Table Asset
-    -> Monitor + Rules + Settings
-    -> enqueue immutable QualityExecutionPlan
-    -> Execution + RuleExecution evidence
+Project-scoped Table Asset
+    -> Project-scoped Monitor + Rules + Settings
+    -> enqueue immutable QualityExecutionPlan(projectId)
+    -> Project-scoped Execution + RuleExecution evidence
 ```
 
 ## Read First
@@ -21,6 +21,7 @@ Table Asset
 | --- | --- |
 | [`REQUIREMENTS.md`](./REQUIREMENTS.md) | 模块必须提供哪些行为 |
 | [`DOMAIN.md`](./DOMAIN.md) | 哪些业务事实和生命周期不能违反 |
+| [`PROJECT_SPACE.md`](./PROJECT_SPACE.md) | 哪些事实属于 Project、后台如何恢复上下文 |
 | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | 代码放哪里、各角色如何协作 |
 | [`DEPENDENCIES.md`](./DEPENDENCIES.md) | package 可以依赖谁、跨边界走哪里 |
 | [`../../CODE_STYLE.md`](../../CODE_STYLE.md) | Yak Ops 统一工程与角色规范 |
@@ -50,18 +51,32 @@ production 不再维护 `quality/service/**`。Quality 当前也不引入一个�
 ## Truth Ownership
 
 ```text
-TableAsset                  = 已注册的数据质量物理表事实
-Monitor + Rules + Settings  = 当前质量监控定义事实
-QualityExecutionPlan        = enqueue 时冻结的不可变执行快照
-Execution                   = 一次质量检查的持久化执行事实
-RuleExecution               = 单条规则的执行证据
-Yak Schedule                = 时间触发投影，不是 Monitor 配置真相
-AlertEvent                  = 告警/通知证据，不是 Execution 状态真相
+CurrentProject               = 当前请求可信的工作空间边界
+TableAsset                   = 当前 Project 已注册的数据质量物理表事实
+Monitor + Rules + Settings   = 当前 Project 的质量监控定义事实
+QualityExecutionPlan         = enqueue 时冻结的 Project + 规则执行快照
+Execution                    = 当前 Project 的一次质量检查持久化事实
+RuleExecution                = 单条规则的执行证据，通过 Execution 继承 Project
+Yak Schedule                 = 携带 Project 的时间触发投影，不是 Monitor 配置真相
+AlertEvent                   = 告警/通知证据，通过 Monitor/Execution 继承 Project
+Rule Template / Folder       = 平台级全局模板能力
 ```
 
-已入队或运行中的执行不得通过回读当前 Monitor / Rule / Settings 改写自己的执行快照。
+已入队或运行中的执行不得通过回读当前 Monitor / Rule / Settings 改写自己的执行快照，也不得在异步线程中依赖原 HTTP 上下文。
 
 ## Main Boundaries
+
+Project Space：
+
+```text
+HTTP @ProjectScope
+    -> trusted CurrentProject
+    -> project-scoped Repository / DAO
+
+Background payload.projectId
+    -> ProjectContextScope
+    -> normal Quality application roles
+```
 
 Datasource：
 
@@ -87,9 +102,9 @@ Execution：
 QualityExecutionManager
     -> QualityExecutionPlanFactory
     -> immutable QualityExecutionPlan
-    -> QualityExecutionDispatcher (afterCommit)
+    -> QualityExecutionDispatcher (afterCommit + ProjectContextScope)
     -> QualityExecutionWorker
     -> QualityAlertRecorder
 ```
 
-完整依赖矩阵和窄 corridor 见 `DEPENDENCIES.md`。
+完整 Project 归属见 `PROJECT_SPACE.md`，依赖矩阵和窄 corridor 见 `DEPENDENCIES.md`。

--- a/yak-ops-business/yak-ops-business-quality/pom.xml
+++ b/yak-ops-business/yak-ops-business-quality/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/config/QualityConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -22,6 +23,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class QualityConfiguration {
 
   @Bean(initMethod = "migrate")
+  @DependsOn("opsDataSourceFlyway")
   public Flyway qualityFlyway(
       @Qualifier("yakBusinessDataSource") DataSource dataSource) {
     return Flyway.configure()

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/CustomTemplateController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/CustomTemplateController.java
@@ -13,6 +13,8 @@ import io.yak.ops.business.quality.template.TemplateFolderManager;
 import io.yak.ops.business.quality.template.TemplateFolderReader;
 import io.yak.ops.common.bean.dto.quality.CustomQualityTemplateDTO;
 import io.yak.ops.common.bean.vo.quality.CustomQualityTemplateVO;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/data-quality/template")
 @RequiresPermission(QualityPermissionCode.TEMPLATE_READ)
+@ProjectScope(ProjectMigrationMode.LEGACY_GLOBAL)
 public class CustomTemplateController {
   private final CustomTemplateReader reader;
   private final CustomTemplateManager manager;
@@ -46,7 +49,9 @@ public class CustomTemplateController {
       @RequestParam(value = "keyword", required = false) String keyword,
       @RequestParam(value = "dimension", required = false) String dimension,
       @RequestParam(value = "folderId", required = false) Long folderId) {
-    return Result.success(converter.customList(reader.list(converter.customQuery(keyword, dimension, folderId))));
+    return Result.success(
+        converter.customList(
+            reader.list(converter.customQuery(keyword, dimension, folderId))));
   }
 
   @Operation(summary = "查询自定义规则模板详情")
@@ -67,7 +72,11 @@ public class CustomTemplateController {
   public Result<CustomQualityTemplateVO.Folder> createFolder(
       @Valid @RequestBody CustomQualityTemplateDTO.SaveFolderRequest request,
       Principal principal) {
-    return Result.success(converter.folder(folderManager.create(converter.folderCommand(request), operator(principal))));
+    return Result.success(
+        converter.folder(
+            folderManager.create(
+                converter.folderCommand(request),
+                operator(principal))));
   }
 
   @Operation(summary = "更新自定义模板目录")
@@ -77,14 +86,22 @@ public class CustomTemplateController {
       @PathVariable long id,
       @Valid @RequestBody CustomQualityTemplateDTO.SaveFolderRequest request,
       Principal principal) {
-    return Result.success(converter.folder(folderManager.update(id, converter.folderCommand(request), operator(principal))));
+    return Result.success(
+        converter.folder(
+            folderManager.update(
+                id,
+                converter.folderCommand(request),
+                operator(principal))));
   }
 
   @Operation(summary = "删除自定义模板目录")
   @DeleteMapping("/folder/{id}")
   @RequiresPermission(QualityPermissionCode.TEMPLATE_DELETE)
-  public Result<Boolean> deleteFolder(@PathVariable long id, Principal principal) {
-    return Result.success(folderManager.delete(id, operator(principal)));
+  public Result<Boolean> deleteFolder(
+      @PathVariable long id,
+      Principal principal) {
+    return Result.success(
+        folderManager.delete(id, operator(principal)));
   }
 
   @Operation(summary = "创建自定义规则模板")
@@ -93,7 +110,11 @@ public class CustomTemplateController {
   public Result<CustomQualityTemplateVO.Template> create(
       @Valid @RequestBody CustomQualityTemplateDTO.SaveTemplateRequest request,
       Principal principal) {
-    return Result.success(converter.customTemplate(manager.create(converter.customCommand(request), operator(principal))));
+    return Result.success(
+        converter.customTemplate(
+            manager.create(
+                converter.customCommand(request),
+                operator(principal))));
   }
 
   @Operation(summary = "更新自定义规则模板")
@@ -103,7 +124,12 @@ public class CustomTemplateController {
       @PathVariable long id,
       @Valid @RequestBody CustomQualityTemplateDTO.SaveTemplateRequest request,
       Principal principal) {
-    return Result.success(converter.customTemplate(manager.update(id, converter.customCommand(request), operator(principal))));
+    return Result.success(
+        converter.customTemplate(
+            manager.update(
+                id,
+                converter.customCommand(request),
+                operator(principal))));
   }
 
   @Operation(summary = "复制自定义规则模板")
@@ -113,7 +139,12 @@ public class CustomTemplateController {
       @PathVariable long id,
       @Valid @RequestBody CustomQualityTemplateDTO.CopyTemplateRequest request,
       Principal principal) {
-    return Result.success(converter.customTemplate(manager.copy(id, converter.copyCommand(request), operator(principal))));
+    return Result.success(
+        converter.customTemplate(
+            manager.copy(
+                id,
+                converter.copyCommand(request),
+                operator(principal))));
   }
 
   @Operation(summary = "删除自定义规则模板")
@@ -124,7 +155,10 @@ public class CustomTemplateController {
   }
 
   private static String operator(Principal principal) {
-    return principal == null || principal.getName() == null || principal.getName().isBlank()
-        ? "system" : principal.getName();
+    return principal == null
+            || principal.getName() == null
+            || principal.getName().isBlank()
+        ? "system"
+        : principal.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExecutionController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExecutionController.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.quality.controller.v1.converter.QualityExecutionConve
 import io.yak.ops.business.quality.execution.QualityExecutionReader;
 import io.yak.ops.common.bean.dto.quality.QualityExecutionDTO;
 import io.yak.ops.common.bean.vo.quality.QualityExecutionVO;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ConditionalOnQualityEnabled
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/data-quality/execution")
+@ProjectScope
 public class QualityExecutionController {
   private final QualityExecutionReader reader;
   private final QualityExecutionConverter converter;
@@ -40,14 +42,17 @@ public class QualityExecutionController {
   @Operation(summary = "查询执行状态")
   @GetMapping("/{executionNo}/status")
   @RequiresPermission(QualityPermissionCode.MONITOR_RUN)
-  public Result<QualityExecutionVO.Status> status(@PathVariable String executionNo) {
-    return Result.success(converter.status(reader.requireSummary(executionNo)));
+  public Result<QualityExecutionVO.Status> status(
+      @PathVariable String executionNo) {
+    return Result.success(
+        converter.status(reader.requireSummary(executionNo)));
   }
 
   @Operation(summary = "查询执行详情")
   @GetMapping("/{executionNo}")
   @RequiresPermission(QualityPermissionCode.EXECUTION_READ)
-  public Result<QualityExecutionVO.Detail> detail(@PathVariable String executionNo) {
+  public Result<QualityExecutionVO.Detail> detail(
+      @PathVariable String executionNo) {
     return Result.success(converter.detail(reader.require(executionNo)));
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExecutionWorkspaceController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityExecutionWorkspaceController.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.quality.execution.QualityExecutionReader;
 import io.yak.ops.business.quality.workspace.QualityExecutionLogProjector;
 import io.yak.ops.common.bean.dto.quality.QualityExecutionWorkspaceDTO;
 import io.yak.ops.common.bean.vo.quality.QualityExecutionWorkspaceVO;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ConditionalOnQualityEnabled
 @RequestMapping("/api/v1/data-quality/execution/workspace")
 @RequiresPermission(QualityPermissionCode.EXECUTION_READ)
+@ProjectScope
 public class QualityExecutionWorkspaceController {
   private final QualityExecutionReader reader;
   private final QualityExecutionLogProjector logProjector;
@@ -41,7 +43,8 @@ public class QualityExecutionWorkspaceController {
   @Operation(summary = "分页查询监控执行记录")
   @PostMapping("/page")
   public Result<QualityExecutionWorkspaceVO.ExecutionPage> page(
-      @Valid @RequestBody(required = false) QualityExecutionWorkspaceDTO.PageRequest request) {
+      @Valid @RequestBody(required = false)
+          QualityExecutionWorkspaceDTO.PageRequest request) {
     var query = converter.query(request);
     return Result.success(converter.page(reader.page(query), query));
   }
@@ -49,20 +52,24 @@ public class QualityExecutionWorkspaceController {
   @Operation(summary = "分页查询规则执行记录")
   @PostMapping("/rule/page")
   public Result<QualityExecutionWorkspaceVO.RuleExecutionPage> pageRules(
-      @Valid @RequestBody(required = false) QualityExecutionWorkspaceDTO.PageRequest request) {
+      @Valid @RequestBody(required = false)
+          QualityExecutionWorkspaceDTO.PageRequest request) {
     var query = converter.query(request);
     return Result.success(converter.pageRules(reader.pageRules(query), query));
   }
 
   @Operation(summary = "查询执行工作台详情")
   @GetMapping("/{executionNo}")
-  public Result<QualityExecutionWorkspaceVO.ExecutionDetail> detail(@PathVariable String executionNo) {
+  public Result<QualityExecutionWorkspaceVO.ExecutionDetail> detail(
+      @PathVariable String executionNo) {
     return Result.success(converter.detail(reader.require(executionNo)));
   }
 
   @Operation(summary = "查询执行结构化日志")
   @GetMapping("/{executionNo}/logs")
-  public Result<QualityExecutionWorkspaceVO.LogView> logs(@PathVariable String executionNo) {
-    return Result.success(converter.logs(logProjector.project(reader.require(executionNo))));
+  public Result<QualityExecutionWorkspaceVO.LogView> logs(
+      @PathVariable String executionNo) {
+    return Result.success(
+        converter.logs(logProjector.project(reader.require(executionNo))));
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityMonitorController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityMonitorController.java
@@ -12,6 +12,7 @@ import io.yak.ops.business.quality.monitor.QualityMonitorManager;
 import io.yak.ops.business.quality.monitor.QualityMonitorReader;
 import io.yak.ops.common.bean.dto.quality.QualityMonitorDTO;
 import io.yak.ops.common.bean.vo.quality.QualityMonitorVO;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/data-quality/monitor")
 @RequiresPermission(QualityPermissionCode.MONITOR_READ)
+@ProjectScope
 public class QualityMonitorController {
   private final QualityMonitorReader reader;
   private final QualityMonitorManager manager;
@@ -52,7 +54,9 @@ public class QualityMonitorController {
       @RequestParam long dataSourceId,
       @RequestParam(value = "databaseName", required = false) String databaseName,
       @RequestParam(value = "schemaName", required = false) String schemaName) {
-    return Result.success(converter.tableSummaries(reader.tableSummaries(dataSourceId, databaseName, schemaName)));
+    return Result.success(
+        converter.tableSummaries(
+            reader.tableSummaries(dataSourceId, databaseName, schemaName)));
   }
 
   @Operation(summary = "查询质量监控详情")
@@ -72,7 +76,8 @@ public class QualityMonitorController {
   @RequiresPermission(QualityPermissionCode.MONITOR_CREATE)
   public Result<QualityMonitorVO.Detail> create(
       @Valid @RequestBody QualityMonitorDTO.SaveRequest request) {
-    return Result.success(converter.detail(manager.create(converter.command(request))));
+    return Result.success(
+        converter.detail(manager.create(converter.command(request))));
   }
 
   @Operation(summary = "更新质量监控")
@@ -81,7 +86,8 @@ public class QualityMonitorController {
   public Result<QualityMonitorVO.Detail> update(
       @PathVariable long id,
       @Valid @RequestBody QualityMonitorDTO.SaveRequest request) {
-    return Result.success(converter.detail(manager.update(id, converter.command(request))));
+    return Result.success(
+        converter.detail(manager.update(id, converter.command(request))));
   }
 
   @Operation(summary = "删除质量监控")
@@ -94,12 +100,18 @@ public class QualityMonitorController {
   @Operation(summary = "手动运行质量监控")
   @PostMapping("/{id}/run")
   @RequiresPermission(QualityPermissionCode.MONITOR_RUN)
-  public Result<QualityMonitorVO.Run> run(@PathVariable long id, Principal principal) {
-    return Result.success(converter.run(executionManager.run(id, operator(principal))));
+  public Result<QualityMonitorVO.Run> run(
+      @PathVariable long id,
+      Principal principal) {
+    return Result.success(
+        converter.run(executionManager.run(id, operator(principal))));
   }
 
   private static String operator(Principal principal) {
-    return principal == null || principal.getName() == null || principal.getName().isBlank()
-        ? "system" : principal.getName();
+    return principal == null
+            || principal.getName() == null
+            || principal.getName().isBlank()
+        ? "system"
+        : principal.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityOverviewController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityOverviewController.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.controller.v1.converter.QualityOverviewConverter;
 import io.yak.ops.business.quality.workspace.QualityOverviewReader;
 import io.yak.ops.common.bean.vo.quality.QualityOverviewVO;
+import io.yak.ops.core.project.ProjectScope;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ConditionalOnQualityEnabled
 @RequestMapping("/api/v1/data-quality/overview")
 @RequiresPermission(QualityPermissionCode.EXECUTION_READ)
+@ProjectScope
 public class QualityOverviewController {
 
   private final QualityOverviewReader reader;
@@ -37,11 +39,12 @@ public class QualityOverviewController {
   @GetMapping
   public Result<QualityOverviewVO.Overview> overview(
       @RequestParam(required = false)
-      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-      LocalDate startDate,
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startDate,
       @RequestParam(required = false)
-      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-      LocalDate endDate) {
-    return Result.success(converter.overview(reader.analytics(startDate, endDate)));
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate endDate) {
+    return Result.success(
+        converter.overview(reader.analytics(startDate, endDate)));
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityTableAssetController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityTableAssetController.java
@@ -12,6 +12,7 @@ import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.controller.v1.converter.QualityTableAssetConverter;
 import io.yak.ops.common.bean.dto.quality.QualityTableAssetDTO;
 import io.yak.ops.common.bean.vo.quality.QualityTableAssetVO;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/data-quality/table-asset")
 @RequiresPermission(QualityPermissionCode.MONITOR_READ)
+@ProjectScope
 public class QualityTableAssetController {
   private final QualityTableAssetReader reader;
   private final QualityTableCandidateReader candidateReader;
@@ -42,7 +44,8 @@ public class QualityTableAssetController {
 
   @Operation(summary = "分页查询已注册数据表")
   @PostMapping("/page")
-  public Result<QualityTableAssetVO.Page> page(@Valid @RequestBody QualityTableAssetDTO.PageRequest request) {
+  public Result<QualityTableAssetVO.Page> page(
+      @Valid @RequestBody QualityTableAssetDTO.PageRequest request) {
     var query = converter.query(request);
     return Result.success(converter.page(reader.page(query), query));
   }
@@ -56,8 +59,15 @@ public class QualityTableAssetController {
       @RequestParam(value = "keyword", required = false) String keyword,
       @RequestParam(defaultValue = "1") @Min(1) int current,
       @RequestParam(defaultValue = "20") @Min(1) @Max(100) int pageSize) {
-    return Result.success(converter.candidates(candidateReader.candidates(
-        dataSourceId, databaseName, schemaName, keyword, current, pageSize)));
+    return Result.success(
+        converter.candidates(
+            candidateReader.candidates(
+                dataSourceId,
+                databaseName,
+                schemaName,
+                keyword,
+                current,
+                pageSize)));
   }
 
   @Operation(summary = "批量注册数据表")
@@ -66,7 +76,11 @@ public class QualityTableAssetController {
   public Result<QualityTableAssetVO.RegisterResult> register(
       @Valid @RequestBody QualityTableAssetDTO.RegisterRequest request,
       Principal principal) {
-    return Result.success(converter.register(manager.register(converter.command(request), operator(principal))));
+    return Result.success(
+        converter.register(
+            manager.register(
+                converter.command(request),
+                operator(principal))));
   }
 
   @Operation(summary = "取消注册数据表")
@@ -77,7 +91,10 @@ public class QualityTableAssetController {
   }
 
   private static String operator(Principal principal) {
-    return principal == null || principal.getName() == null || principal.getName().isBlank()
-        ? "system" : principal.getName();
+    return principal == null
+            || principal.getName() == null
+            || principal.getName().isBlank()
+        ? "system"
+        : principal.getName();
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityTemplateController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityTemplateController.java
@@ -10,6 +10,8 @@ import io.yak.ops.business.quality.controller.v1.converter.QualityTemplateConver
 import io.yak.ops.business.quality.template.QualityTemplateReader;
 import io.yak.ops.common.bean.vo.quality.QualityTemplateVO;
 import io.yak.ops.common.enums.quality.QualityEnums.RuleScope;
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/data-quality/template")
 @RequiresPermission(QualityPermissionCode.TEMPLATE_READ)
+@ProjectScope(ProjectMigrationMode.LEGACY_GLOBAL)
 public class QualityTemplateController {
   private final QualityTemplateReader reader;
   private final QualityTemplateConverter converter;
@@ -33,7 +36,10 @@ public class QualityTemplateController {
       @RequestParam(value = "keyword", required = false) String keyword,
       @RequestParam(value = "dimension", required = false) String dimension,
       @RequestParam(value = "scope", required = false) RuleScope scope) {
-    return Result.success(converter.templateList(reader.list(converter.templateQuery(keyword, dimension, scope))));
+    return Result.success(
+        converter.templateList(
+            reader.list(
+                converter.templateQuery(keyword, dimension, scope))));
   }
 
   @Operation(summary = "查询规则模板目录统计")

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityWorkspaceController.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/controller/v1/QualityWorkspaceController.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.controller.v1.converter.QualityWorkspaceConverter;
 import io.yak.ops.business.quality.workspace.QualityWorkspaceReader;
 import io.yak.ops.common.bean.vo.quality.QualityWorkspaceVO;
+import io.yak.ops.core.project.ProjectScope;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,18 +23,22 @@ import org.springframework.web.bind.annotation.RestController;
 @ConditionalOnQualityEnabled
 @RequestMapping("/api/v1/data-quality/monitor")
 @RequiresPermission(QualityPermissionCode.MONITOR_READ)
+@ProjectScope
 public class QualityWorkspaceController {
   private final QualityWorkspaceReader reader;
   private final QualityWorkspaceConverter converter;
 
-  public QualityWorkspaceController(QualityWorkspaceReader reader, QualityWorkspaceConverter converter) {
+  public QualityWorkspaceController(
+      QualityWorkspaceReader reader,
+      QualityWorkspaceConverter converter) {
     this.reader = reader;
     this.converter = converter;
   }
 
   @Operation(summary = "查询质量监控工作台")
   @GetMapping("/{id}/workspace")
-  public Result<QualityWorkspaceVO.MonitorWorkspace> workspace(@PathVariable long id) {
+  public Result<QualityWorkspaceVO.MonitorWorkspace> workspace(
+      @PathVariable long id) {
     return Result.success(converter.workspace(reader.workspace(id)));
   }
 
@@ -42,7 +47,8 @@ public class QualityWorkspaceController {
   public Result<QualityWorkspaceVO.MonitorReport> report(
       @PathVariable long id,
       @RequestParam(value = "date", required = false)
-      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate date) {
     return Result.success(converter.report(reader.report(id, date)));
   }
 
@@ -52,6 +58,7 @@ public class QualityWorkspaceController {
       @PathVariable long id,
       @RequestParam(value = "current", required = false) Integer current,
       @RequestParam(value = "pageSize", required = false) Integer pageSize) {
-    return Result.success(converter.operationLogs(reader.operationLogs(id, current, pageSize)));
+    return Result.success(
+        converter.operationLogs(reader.operationLogs(id, current, pageSize)));
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/QualityMonitorDao.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/QualityMonitorDao.java
@@ -17,6 +17,7 @@ public interface QualityMonitorDao {
   long countMonitors(Map<String, Object> params);
   List<MonitorRow> selectMonitors(Map<String, Object> params);
   MonitorRow selectMonitor(long id);
+  List<ProjectMonitorRef> selectScheduledMonitorsForRecovery();
   List<TableMonitorSummaryRow> selectTableSummaries(Map<String, Object> params);
   long insertMonitor(QualityMonitorPO monitor);
   boolean updateMonitor(QualityMonitorPO monitor);
@@ -39,4 +40,12 @@ public interface QualityMonitorDao {
   int upsertTableAssets(List<QualityTableAssetPO> assets);
   int countMonitorsForAsset(long assetId);
   boolean softDeleteTableAsset(long assetId);
+
+  /** Explicit cross-Project startup dispatch reference; ordinary CRUD remains CurrentProject-bound. */
+  record ProjectMonitorRef(long projectId, long monitorId) {
+    public ProjectMonitorRef {
+      if (projectId <= 0L) throw new IllegalArgumentException("projectId must be positive");
+      if (monitorId <= 0L) throw new IllegalArgumentException("monitorId must be positive");
+    }
+  }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityAnalyticsDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityAnalyticsDaoImpl.java
@@ -15,6 +15,8 @@ import io.yak.ops.common.bean.po.quality.QualityQueryPO.OperationLogRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.ReportOverviewRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.TrendPointRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.WorkspaceStatsRow;
+import io.yak.ops.core.project.CurrentProject;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -28,18 +30,76 @@ import org.springframework.stereotype.Repository;
 public class QualityAnalyticsDaoImpl implements QualityAnalyticsDao {
   private final QualityQueryMapper queryMapper;
   private final QualityOverviewMapper overviewMapper;
+  private final CurrentProject currentProject;
 
-  @Override public WorkspaceStatsRow selectStats(long monitorId) { return queryMapper.selectWorkspaceStats(monitorId); }
-  @Override public ReportOverviewRow selectOverview(Map<String, Object> params) { return queryMapper.selectReportOverview(params); }
-  @Override public List<DimensionReportRow> selectDimensions(Map<String, Object> params) { return queryMapper.selectDimensionReport(params); }
-  @Override public List<TrendPointRow> selectTrend(Map<String, Object> params) { return queryMapper.selectTrend(params); }
-  @Override public List<ColumnReportRow> selectColumns(Map<String, Object> params) { return queryMapper.selectColumnReport(params); }
-  @Override public long countOperationLogs(long monitorId) { return queryMapper.countOperationLogs(monitorId); }
-  @Override public List<OperationLogRow> selectOperationLogs(Map<String, Object> params) { return queryMapper.selectOperationLogs(params); }
+  @Override
+  public WorkspaceStatsRow selectStats(long monitorId) {
+    return queryMapper.selectWorkspaceStats(currentProjectId(), monitorId);
+  }
 
-  @Override public StatsRow selectHomeOverviewStats(Map<String, Object> params) { return overviewMapper.selectStats(params); }
-  @Override public AnalyticsStatsRow selectOverviewAnalyticsStats(Map<String, Object> params) { return overviewMapper.selectAnalyticsStats(params); }
-  @Override public List<DimensionRow> selectHomeOverviewDimensions(Map<String, Object> params) { return overviewMapper.selectDimensions(params); }
-  @Override public List<TrendRow> selectOverviewAnalyticsTrend(Map<String, Object> params) { return overviewMapper.selectAnalyticsTrend(params); }
-  @Override public List<IssueRow> selectHomeOverviewIssues(Map<String, Object> params) { return overviewMapper.selectRecentIssues(params); }
+  @Override
+  public ReportOverviewRow selectOverview(Map<String, Object> params) {
+    return queryMapper.selectReportOverview(scoped(params));
+  }
+
+  @Override
+  public List<DimensionReportRow> selectDimensions(Map<String, Object> params) {
+    return queryMapper.selectDimensionReport(scoped(params));
+  }
+
+  @Override
+  public List<TrendPointRow> selectTrend(Map<String, Object> params) {
+    return queryMapper.selectTrend(scoped(params));
+  }
+
+  @Override
+  public List<ColumnReportRow> selectColumns(Map<String, Object> params) {
+    return queryMapper.selectColumnReport(scoped(params));
+  }
+
+  @Override
+  public long countOperationLogs(long monitorId) {
+    return queryMapper.countOperationLogs(currentProjectId(), monitorId);
+  }
+
+  @Override
+  public List<OperationLogRow> selectOperationLogs(Map<String, Object> params) {
+    return queryMapper.selectOperationLogs(scoped(params));
+  }
+
+  @Override
+  public StatsRow selectHomeOverviewStats(Map<String, Object> params) {
+    return overviewMapper.selectStats(scoped(params));
+  }
+
+  @Override
+  public AnalyticsStatsRow selectOverviewAnalyticsStats(Map<String, Object> params) {
+    return overviewMapper.selectAnalyticsStats(scoped(params));
+  }
+
+  @Override
+  public List<DimensionRow> selectHomeOverviewDimensions(Map<String, Object> params) {
+    return overviewMapper.selectDimensions(scoped(params));
+  }
+
+  @Override
+  public List<TrendRow> selectOverviewAnalyticsTrend(Map<String, Object> params) {
+    return overviewMapper.selectAnalyticsTrend(scoped(params));
+  }
+
+  @Override
+  public List<IssueRow> selectHomeOverviewIssues(Map<String, Object> params) {
+    return overviewMapper.selectRecentIssues(scoped(params));
+  }
+
+  private Map<String, Object> scoped(Map<String, Object> params) {
+    Map<String, Object> scoped = new LinkedHashMap<>();
+    if (params != null) scoped.putAll(params);
+    scoped.put("projectId", currentProjectId());
+    return scoped;
+  }
+
+  private long currentProjectId() {
+    return currentProject.requireProjectId();
+  }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityExecutionDaoImpl.java
@@ -9,9 +9,14 @@ import io.yak.ops.business.quality.dao.mapper.QualityRuleExecutionMapper;
 import io.yak.ops.common.bean.po.quality.QualityExecutionPO;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.RuleExecutionWorkspaceRow;
 import io.yak.ops.common.bean.po.quality.QualityRuleExecutionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
@@ -24,88 +29,184 @@ public class QualityExecutionDaoImpl implements QualityExecutionDao {
   private final QualityExecutionMapper executionMapper;
   private final QualityRuleExecutionMapper ruleExecutionMapper;
   private final QualityQueryMapper queryMapper;
+  private final CurrentProject currentProject;
 
   @Override
   public boolean hasActive(long monitorId) {
+    long projectId = currentProjectId();
     return executionMapper.selectCount(
-        Wrappers.<QualityExecutionPO>lambdaQuery()
-            .eq(QualityExecutionPO::getMonitorId, monitorId)
-            .in(QualityExecutionPO::getExecutionStatus, List.of("WAITING", "RUNNING"))) > 0;
+            Wrappers.<QualityExecutionPO>lambdaQuery()
+                .eq(QualityExecutionPO::getProjectId, projectId)
+                .eq(QualityExecutionPO::getMonitorId, monitorId)
+                .in(
+                    QualityExecutionPO::getExecutionStatus,
+                    List.of("WAITING", "RUNNING")))
+        > 0;
   }
 
   @Override
   public long insertExecution(QualityExecutionPO execution) {
+    long projectId = currentProjectId();
+    bindProject(execution, projectId);
     executionMapper.insert(execution);
-    if (execution.getId() == null) throw new IllegalStateException("质量检查已创建，但未返回执行编号");
+    if (execution.getId() == null) {
+      throw new IllegalStateException("质量检查已创建，但未返回执行编号");
+    }
     return execution.getId();
   }
 
   @Override
   public boolean markRunning(long id, LocalDateTime startedAt) {
+    long projectId = currentProjectId();
     return executionMapper.update(
-        null,
-        Wrappers.<QualityExecutionPO>lambdaUpdate()
-            .eq(QualityExecutionPO::getId, id)
-            .eq(QualityExecutionPO::getExecutionStatus, "WAITING")
-            .set(QualityExecutionPO::getExecutionStatus, "RUNNING")
-            .set(QualityExecutionPO::getCheckResult, "RUNNING")
-            .set(QualityExecutionPO::getStartedAt, startedAt)
-            .set(QualityExecutionPO::getErrorMessage, null)) > 0;
-  }
-
-  @Override public void insertRuleExecution(QualityRuleExecutionPO ruleExecution) { ruleExecutionMapper.insert(ruleExecution); }
-
-  @Override
-  public boolean complete(long id, String result, int passed, int failed, int errors, LocalDateTime finishedAt, long durationMs) {
-    return executionMapper.update(
-        null,
-        Wrappers.<QualityExecutionPO>lambdaUpdate()
-            .eq(QualityExecutionPO::getId, id)
-            .eq(QualityExecutionPO::getExecutionStatus, "RUNNING")
-            .set(QualityExecutionPO::getExecutionStatus, "SUCCESS")
-            .set(QualityExecutionPO::getCheckResult, result)
-            .set(QualityExecutionPO::getPassedRules, passed)
-            .set(QualityExecutionPO::getFailedRules, failed)
-            .set(QualityExecutionPO::getErrorRules, errors)
-            .set(QualityExecutionPO::getFinishedAt, finishedAt)
-            .set(QualityExecutionPO::getDurationMs, durationMs)
-            .set(QualityExecutionPO::getErrorMessage, null)) > 0;
+            null,
+            Wrappers.<QualityExecutionPO>lambdaUpdate()
+                .eq(QualityExecutionPO::getProjectId, projectId)
+                .eq(QualityExecutionPO::getId, id)
+                .eq(QualityExecutionPO::getExecutionStatus, "WAITING")
+                .set(QualityExecutionPO::getExecutionStatus, "RUNNING")
+                .set(QualityExecutionPO::getCheckResult, "RUNNING")
+                .set(QualityExecutionPO::getStartedAt, startedAt)
+                .set(QualityExecutionPO::getErrorMessage, null))
+        > 0;
   }
 
   @Override
-  public boolean fail(long id, String errorMessage, LocalDateTime finishedAt, long durationMs) {
-    return executionMapper.update(
-        null,
-        Wrappers.<QualityExecutionPO>lambdaUpdate()
-            .eq(QualityExecutionPO::getId, id)
-            .in(QualityExecutionPO::getExecutionStatus, List.of("WAITING", "RUNNING"))
-            .set(QualityExecutionPO::getExecutionStatus, "FAILED")
-            .set(QualityExecutionPO::getCheckResult, "ERROR")
-            .set(QualityExecutionPO::getErrorMessage, errorMessage)
-            .set(QualityExecutionPO::getFinishedAt, finishedAt)
-            .set(QualityExecutionPO::getDurationMs, durationMs)) > 0;
+  public void insertRuleExecution(QualityRuleExecutionPO ruleExecution) {
+    requireOwnedExecution(ruleExecution.getExecutionId());
+    ruleExecutionMapper.insert(ruleExecution);
   }
 
-  @Override public long countExecutions(Map<String, Object> params) { return queryMapper.countExecutions(params); }
-  @Override public List<QualityExecutionPO> selectExecutions(Map<String, Object> params) { return queryMapper.selectExecutions(params); }
+  @Override
+  public boolean complete(
+      long id,
+      String result,
+      int passed,
+      int failed,
+      int errors,
+      LocalDateTime finishedAt,
+      long durationMs) {
+    long projectId = currentProjectId();
+    return executionMapper.update(
+            null,
+            Wrappers.<QualityExecutionPO>lambdaUpdate()
+                .eq(QualityExecutionPO::getProjectId, projectId)
+                .eq(QualityExecutionPO::getId, id)
+                .eq(QualityExecutionPO::getExecutionStatus, "RUNNING")
+                .set(QualityExecutionPO::getExecutionStatus, "SUCCESS")
+                .set(QualityExecutionPO::getCheckResult, result)
+                .set(QualityExecutionPO::getPassedRules, passed)
+                .set(QualityExecutionPO::getFailedRules, failed)
+                .set(QualityExecutionPO::getErrorRules, errors)
+                .set(QualityExecutionPO::getFinishedAt, finishedAt)
+                .set(QualityExecutionPO::getDurationMs, durationMs)
+                .set(QualityExecutionPO::getErrorMessage, null))
+        > 0;
+  }
+
+  @Override
+  public boolean fail(
+      long id,
+      String errorMessage,
+      LocalDateTime finishedAt,
+      long durationMs) {
+    long projectId = currentProjectId();
+    return executionMapper.update(
+            null,
+            Wrappers.<QualityExecutionPO>lambdaUpdate()
+                .eq(QualityExecutionPO::getProjectId, projectId)
+                .eq(QualityExecutionPO::getId, id)
+                .in(
+                    QualityExecutionPO::getExecutionStatus,
+                    List.of("WAITING", "RUNNING"))
+                .set(QualityExecutionPO::getExecutionStatus, "FAILED")
+                .set(QualityExecutionPO::getCheckResult, "ERROR")
+                .set(QualityExecutionPO::getErrorMessage, errorMessage)
+                .set(QualityExecutionPO::getFinishedAt, finishedAt)
+                .set(QualityExecutionPO::getDurationMs, durationMs))
+        > 0;
+  }
+
+  @Override
+  public long countExecutions(Map<String, Object> params) {
+    return queryMapper.countExecutions(scoped(params));
+  }
+
+  @Override
+  public List<QualityExecutionPO> selectExecutions(Map<String, Object> params) {
+    return queryMapper.selectExecutions(scoped(params));
+  }
 
   @Override
   public QualityExecutionPO selectByExecutionNo(String executionNo) {
+    long projectId = currentProjectId();
     return executionMapper.selectOne(
         Wrappers.<QualityExecutionPO>lambdaQuery()
+            .eq(QualityExecutionPO::getProjectId, projectId)
             .eq(QualityExecutionPO::getExecutionNo, executionNo));
   }
 
   @Override
   public List<QualityRuleExecutionPO> selectRuleExecutions(long executionId) {
+    requireOwnedExecution(executionId);
     return ruleExecutionMapper.selectList(
         Wrappers.<QualityRuleExecutionPO>lambdaQuery()
             .eq(QualityRuleExecutionPO::getExecutionId, executionId)
             .orderByAsc(QualityRuleExecutionPO::getId));
   }
 
-  @Override public long countExecutionWorkspace(Map<String, Object> params) { return queryMapper.countExecutionWorkspace(params); }
-  @Override public List<QualityExecutionPO> selectExecutionWorkspace(Map<String, Object> params) { return queryMapper.selectExecutionWorkspace(params); }
-  @Override public long countRuleExecutionWorkspace(Map<String, Object> params) { return queryMapper.countRuleExecutionWorkspace(params); }
-  @Override public List<RuleExecutionWorkspaceRow> selectRuleExecutionWorkspace(Map<String, Object> params) { return queryMapper.selectRuleExecutionWorkspace(params); }
+  @Override
+  public long countExecutionWorkspace(Map<String, Object> params) {
+    return queryMapper.countExecutionWorkspace(scoped(params));
+  }
+
+  @Override
+  public List<QualityExecutionPO> selectExecutionWorkspace(Map<String, Object> params) {
+    return queryMapper.selectExecutionWorkspace(scoped(params));
+  }
+
+  @Override
+  public long countRuleExecutionWorkspace(Map<String, Object> params) {
+    return queryMapper.countRuleExecutionWorkspace(scoped(params));
+  }
+
+  @Override
+  public List<RuleExecutionWorkspaceRow> selectRuleExecutionWorkspace(
+      Map<String, Object> params) {
+    return queryMapper.selectRuleExecutionWorkspace(scoped(params));
+  }
+
+  private Map<String, Object> scoped(Map<String, Object> params) {
+    Map<String, Object> scoped = new LinkedHashMap<>();
+    if (params != null) scoped.putAll(params);
+    scoped.put("projectId", currentProjectId());
+    return scoped;
+  }
+
+  private void requireOwnedExecution(Long executionId) {
+    if (executionId == null || executionId <= 0L) throw projectNotFound();
+    long projectId = currentProjectId();
+    Long count =
+        executionMapper.selectCount(
+            Wrappers.<QualityExecutionPO>lambdaQuery()
+                .eq(QualityExecutionPO::getProjectId, projectId)
+                .eq(QualityExecutionPO::getId, executionId));
+    if (count == null || count == 0L) throw projectNotFound();
+  }
+
+  private void bindProject(QualityExecutionPO execution, long projectId) {
+    if (execution.getProjectId() != null
+        && !Objects.equals(execution.getProjectId(), projectId)) {
+      throw projectNotFound();
+    }
+    execution.setProjectId(projectId);
+  }
+
+  private long currentProjectId() {
+    return currentProject.requireProjectId();
+  }
+
+  private static ProjectContextException projectNotFound() {
+    return new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+  }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityMonitorDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/impl/QualityMonitorDaoImpl.java
@@ -18,9 +18,14 @@ import io.yak.ops.common.bean.po.quality.QualityQueryPO.TableAssetRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.TableMonitorSummaryRow;
 import io.yak.ops.common.bean.po.quality.QualityRulePO;
 import io.yak.ops.common.bean.po.quality.QualityTableAssetPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
@@ -37,37 +42,74 @@ public class QualityMonitorDaoImpl implements QualityMonitorDao {
   private final QualityMonitorSettingMapper settingMapper;
   private final QualityTableAssetMapper tableAssetMapper;
   private final QualityAlertEventMapper alertEventMapper;
+  private final CurrentProject currentProject;
 
-  @Override public long countMonitors(Map<String, Object> params) { return queryMapper.countMonitors(params); }
-  @Override public List<MonitorRow> selectMonitors(Map<String, Object> params) { return queryMapper.selectMonitors(params); }
-  @Override public MonitorRow selectMonitor(long id) { return queryMapper.selectMonitor(id); }
-  @Override public List<TableMonitorSummaryRow> selectTableSummaries(Map<String, Object> params) { return queryMapper.selectTableSummaries(params); }
+  @Override
+  public long countMonitors(Map<String, Object> params) {
+    return queryMapper.countMonitors(scoped(params));
+  }
+
+  @Override
+  public List<MonitorRow> selectMonitors(Map<String, Object> params) {
+    return queryMapper.selectMonitors(scoped(params));
+  }
+
+  @Override
+  public MonitorRow selectMonitor(long id) {
+    return queryMapper.selectMonitor(currentProjectId(), id);
+  }
+
+  @Override
+  public List<ProjectMonitorRef> selectScheduledMonitorsForRecovery() {
+    return queryMapper.selectScheduledMonitorsForRecovery().stream()
+        .map(
+            row ->
+                new ProjectMonitorRef(
+                    requirePositive(row.getProjectId(), "质量监控缺少 Project 归属"),
+                    requirePositive(row.getId(), "质量监控恢复引用缺少监控编号")))
+        .toList();
+  }
+
+  @Override
+  public List<TableMonitorSummaryRow> selectTableSummaries(Map<String, Object> params) {
+    return queryMapper.selectTableSummaries(scoped(params));
+  }
 
   @Override
   public long insertMonitor(QualityMonitorPO monitor) {
+    long projectId = currentProjectId();
+    bindProject(monitor, projectId);
     monitorMapper.insert(monitor);
-    if (monitor.getId() == null) throw new IllegalStateException("质量监控创建成功，但未返回监控编号");
+    if (monitor.getId() == null) {
+      throw new IllegalStateException("质量监控创建成功，但未返回监控编号");
+    }
     return monitor.getId();
   }
 
   @Override
   public boolean updateMonitor(QualityMonitorPO monitor) {
+    long projectId = currentProjectId();
+    bindProject(monitor, projectId);
     return monitorMapper.update(
         monitor,
         Wrappers.<QualityMonitorPO>lambdaUpdate()
+            .eq(QualityMonitorPO::getProjectId, projectId)
             .eq(QualityMonitorPO::getId, monitor.getId())
             .eq(QualityMonitorPO::getDeleted, false)) > 0;
   }
 
   @Override
   public boolean softDeleteMonitor(long id) {
-    int affected = monitorMapper.update(
-        null,
-        Wrappers.<QualityMonitorPO>lambdaUpdate()
-            .eq(QualityMonitorPO::getId, id)
-            .eq(QualityMonitorPO::getDeleted, false)
-            .set(QualityMonitorPO::getDeleted, true)
-            .set(QualityMonitorPO::getEnabled, false));
+    long projectId = currentProjectId();
+    int affected =
+        monitorMapper.update(
+            null,
+            Wrappers.<QualityMonitorPO>lambdaUpdate()
+                .eq(QualityMonitorPO::getProjectId, projectId)
+                .eq(QualityMonitorPO::getId, id)
+                .eq(QualityMonitorPO::getDeleted, false)
+                .set(QualityMonitorPO::getDeleted, true)
+                .set(QualityMonitorPO::getEnabled, false));
     if (affected > 0) {
       ruleMapper.update(
           null,
@@ -82,11 +124,18 @@ public class QualityMonitorDaoImpl implements QualityMonitorDao {
 
   @Override
   public boolean existsMonitorTarget(
-      Long excludeId, long dataSourceId, String databaseName, String schemaName, String tableName) {
-    var query = Wrappers.<QualityMonitorPO>lambdaQuery()
-        .eq(QualityMonitorPO::getDeleted, false)
-        .eq(QualityMonitorPO::getDataSourceId, dataSourceId)
-        .eq(QualityMonitorPO::getTableName, tableName);
+      Long excludeId,
+      long dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName) {
+    long projectId = currentProjectId();
+    var query =
+        Wrappers.<QualityMonitorPO>lambdaQuery()
+            .eq(QualityMonitorPO::getProjectId, projectId)
+            .eq(QualityMonitorPO::getDeleted, false)
+            .eq(QualityMonitorPO::getDataSourceId, dataSourceId)
+            .eq(QualityMonitorPO::getTableName, tableName);
     if (databaseName == null) query.isNull(QualityMonitorPO::getDatabaseName);
     else query.eq(QualityMonitorPO::getDatabaseName, databaseName);
     if (schemaName == null) query.isNull(QualityMonitorPO::getSchemaName);
@@ -95,13 +144,22 @@ public class QualityMonitorDaoImpl implements QualityMonitorDao {
     return monitorMapper.selectCount(query) > 0;
   }
 
-  @Override public void lockMonitor(long monitorId) { writeMapper.lockMonitor(monitorId); }
+  @Override
+  public void lockMonitor(long monitorId) {
+    writeMapper.lockMonitor(currentProjectId(), monitorId);
+  }
 
   @Override
-  public boolean updateMonitorResult(long monitorId, String executionNo, String result, LocalDateTime runTime) {
+  public boolean updateMonitorResult(
+      long monitorId,
+      String executionNo,
+      String result,
+      LocalDateTime runTime) {
+    long projectId = currentProjectId();
     return monitorMapper.update(
         null,
         Wrappers.<QualityMonitorPO>lambdaUpdate()
+            .eq(QualityMonitorPO::getProjectId, projectId)
             .eq(QualityMonitorPO::getId, monitorId)
             .eq(QualityMonitorPO::getDeleted, false)
             .set(QualityMonitorPO::getLastExecutionNo, executionNo)
@@ -111,6 +169,7 @@ public class QualityMonitorDaoImpl implements QualityMonitorDao {
 
   @Override
   public List<QualityRulePO> selectRules(long monitorId) {
+    requireActiveMonitor(monitorId);
     return ruleMapper.selectList(
         Wrappers.<QualityRulePO>lambdaQuery()
             .eq(QualityRulePO::getMonitorId, monitorId)
@@ -121,6 +180,7 @@ public class QualityMonitorDaoImpl implements QualityMonitorDao {
 
   @Override
   public void replaceRules(long monitorId, List<QualityRulePO> rules) {
+    requireActiveMonitor(monitorId);
     ruleMapper.update(
         null,
         Wrappers.<QualityRulePO>lambdaUpdate()
@@ -131,49 +191,157 @@ public class QualityMonitorDaoImpl implements QualityMonitorDao {
     for (QualityRulePO rule : rules) ruleMapper.insert(rule);
   }
 
-  @Override public QualityMonitorSettingPO selectSetting(long monitorId) { return settingMapper.selectById(monitorId); }
-  @Override public void upsertSetting(QualityMonitorSettingPO setting) { writeMapper.upsertMonitorSetting(setting); }
-  @Override public void insertAlert(QualityAlertEventPO alert) { alertEventMapper.insert(alert); }
-
-  @Override public long countTableAssets(Map<String, Object> params) { return queryMapper.countTableAssets(params); }
-  @Override public List<TableAssetRow> selectTableAssets(Map<String, Object> params) { return queryMapper.selectTableAssets(params); }
+  @Override
+  public QualityMonitorSettingPO selectSetting(long monitorId) {
+    requireOwnedMonitor(monitorId);
+    return settingMapper.selectById(monitorId);
+  }
 
   @Override
-  public List<QualityTableAssetPO> selectTableAssetTargets(long dataSourceId, String databaseName) {
-    var query = Wrappers.<QualityTableAssetPO>lambdaQuery()
-        .eq(QualityTableAssetPO::getDeleted, false)
-        .eq(QualityTableAssetPO::getDataSourceId, dataSourceId);
-    if (databaseName != null) query.eq(QualityTableAssetPO::getDatabaseName, databaseName);
+  public void upsertSetting(QualityMonitorSettingPO setting) {
+    requireOwnedMonitor(setting.getMonitorId());
+    writeMapper.upsertMonitorSetting(setting);
+  }
+
+  @Override
+  public void insertAlert(QualityAlertEventPO alert) {
+    requireOwnedMonitor(alert.getMonitorId());
+    alertEventMapper.insert(alert);
+  }
+
+  @Override
+  public long countTableAssets(Map<String, Object> params) {
+    return queryMapper.countTableAssets(scoped(params));
+  }
+
+  @Override
+  public List<TableAssetRow> selectTableAssets(Map<String, Object> params) {
+    return queryMapper.selectTableAssets(scoped(params));
+  }
+
+  @Override
+  public List<QualityTableAssetPO> selectTableAssetTargets(
+      long dataSourceId,
+      String databaseName) {
+    long projectId = currentProjectId();
+    var query =
+        Wrappers.<QualityTableAssetPO>lambdaQuery()
+            .eq(QualityTableAssetPO::getProjectId, projectId)
+            .eq(QualityTableAssetPO::getDeleted, false)
+            .eq(QualityTableAssetPO::getDataSourceId, dataSourceId);
+    if (databaseName != null) {
+      query.eq(QualityTableAssetPO::getDatabaseName, databaseName);
+    }
     return tableAssetMapper.selectList(query);
   }
 
   @Override
-  public boolean existsTableAssetTarget(long dataSourceId, String databaseName, String schemaName, String tableName) {
+  public boolean existsTableAssetTarget(
+      long dataSourceId,
+      String databaseName,
+      String schemaName,
+      String tableName) {
+    long projectId = currentProjectId();
     return tableAssetMapper.selectCount(
-        Wrappers.<QualityTableAssetPO>lambdaQuery()
-            .eq(QualityTableAssetPO::getDeleted, false)
-            .eq(QualityTableAssetPO::getDataSourceId, dataSourceId)
-            .eq(QualityTableAssetPO::getDatabaseName, databaseName == null ? "" : databaseName)
-            .eq(QualityTableAssetPO::getSchemaName, schemaName == null ? "" : schemaName)
-            .eq(QualityTableAssetPO::getTableName, tableName)) > 0;
+            Wrappers.<QualityTableAssetPO>lambdaQuery()
+                .eq(QualityTableAssetPO::getProjectId, projectId)
+                .eq(QualityTableAssetPO::getDeleted, false)
+                .eq(QualityTableAssetPO::getDataSourceId, dataSourceId)
+                .eq(
+                    QualityTableAssetPO::getDatabaseName,
+                    databaseName == null ? "" : databaseName)
+                .eq(
+                    QualityTableAssetPO::getSchemaName,
+                    schemaName == null ? "" : schemaName)
+                .eq(QualityTableAssetPO::getTableName, tableName))
+        > 0;
   }
 
   @Override
   public int upsertTableAssets(List<QualityTableAssetPO> assets) {
-    for (QualityTableAssetPO asset : assets) writeMapper.upsertTableAsset(asset);
+    if (assets == null || assets.isEmpty()) return 0;
+    long projectId = currentProjectId();
+    for (QualityTableAssetPO asset : assets) {
+      bindProject(asset, projectId);
+      writeMapper.upsertTableAsset(asset);
+    }
     return assets.size();
   }
 
-  @Override public int countMonitorsForAsset(long assetId) { return queryMapper.countMonitorsForAsset(assetId); }
+  @Override
+  public int countMonitorsForAsset(long assetId) {
+    return queryMapper.countMonitorsForAsset(currentProjectId(), assetId);
+  }
 
   @Override
   public boolean softDeleteTableAsset(long assetId) {
+    long projectId = currentProjectId();
     return tableAssetMapper.update(
-        null,
-        Wrappers.<QualityTableAssetPO>lambdaUpdate()
-            .eq(QualityTableAssetPO::getId, assetId)
-            .eq(QualityTableAssetPO::getDeleted, false)
-            .set(QualityTableAssetPO::getDeleted, true)
-            .set(QualityTableAssetPO::getUpdatedAt, LocalDateTime.now())) > 0;
+            null,
+            Wrappers.<QualityTableAssetPO>lambdaUpdate()
+                .eq(QualityTableAssetPO::getProjectId, projectId)
+                .eq(QualityTableAssetPO::getId, assetId)
+                .eq(QualityTableAssetPO::getDeleted, false)
+                .set(QualityTableAssetPO::getDeleted, true)
+                .set(QualityTableAssetPO::getUpdatedAt, LocalDateTime.now()))
+        > 0;
+  }
+
+  private Map<String, Object> scoped(Map<String, Object> params) {
+    Map<String, Object> scoped = new LinkedHashMap<>();
+    if (params != null) scoped.putAll(params);
+    scoped.put("projectId", currentProjectId());
+    return scoped;
+  }
+
+  private void requireActiveMonitor(long monitorId) {
+    long projectId = currentProjectId();
+    Long count =
+        monitorMapper.selectCount(
+            Wrappers.<QualityMonitorPO>lambdaQuery()
+                .eq(QualityMonitorPO::getProjectId, projectId)
+                .eq(QualityMonitorPO::getId, monitorId)
+                .eq(QualityMonitorPO::getDeleted, false));
+    if (count == null || count == 0L) throw projectNotFound();
+  }
+
+  private void requireOwnedMonitor(Long monitorId) {
+    if (monitorId == null || monitorId <= 0L) throw projectNotFound();
+    long projectId = currentProjectId();
+    Long count =
+        monitorMapper.selectCount(
+            Wrappers.<QualityMonitorPO>lambdaQuery()
+                .eq(QualityMonitorPO::getProjectId, projectId)
+                .eq(QualityMonitorPO::getId, monitorId));
+    if (count == null || count == 0L) throw projectNotFound();
+  }
+
+  private void bindProject(QualityMonitorPO monitor, long projectId) {
+    requireCompatibleProject(monitor.getProjectId(), projectId);
+    monitor.setProjectId(projectId);
+  }
+
+  private void bindProject(QualityTableAssetPO asset, long projectId) {
+    requireCompatibleProject(asset.getProjectId(), projectId);
+    asset.setProjectId(projectId);
+  }
+
+  private void requireCompatibleProject(Long requestedProjectId, long currentProjectId) {
+    if (requestedProjectId != null && !Objects.equals(requestedProjectId, currentProjectId)) {
+      throw projectNotFound();
+    }
+  }
+
+  private long currentProjectId() {
+    return currentProject.requireProjectId();
+  }
+
+  private static long requirePositive(Long value, String message) {
+    if (value == null || value <= 0L) throw new IllegalStateException(message);
+    return value;
+  }
+
+  private static ProjectContextException projectNotFound() {
+    return new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityQueryMapper.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityQueryMapper.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.quality.dao.mapper;
 
 import io.yak.ops.common.bean.po.quality.QualityExecutionPO;
+import io.yak.ops.common.bean.po.quality.QualityMonitorPO;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.ColumnReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.DimensionReportRow;
 import io.yak.ops.common.bean.po.quality.QualityQueryPO.FolderRow;
@@ -28,12 +29,15 @@ public interface QualityQueryMapper {
 
   long countMonitors(Map<String, Object> params);
   List<MonitorRow> selectMonitors(Map<String, Object> params);
-  MonitorRow selectMonitor(@Param("id") long id);
+  MonitorRow selectMonitor(@Param("projectId") long projectId, @Param("id") long id);
+  List<QualityMonitorPO> selectScheduledMonitorsForRecovery();
   List<TableMonitorSummaryRow> selectTableSummaries(Map<String, Object> params);
 
   long countTableAssets(Map<String, Object> params);
   List<TableAssetRow> selectTableAssets(Map<String, Object> params);
-  int countMonitorsForAsset(@Param("assetId") long assetId);
+  int countMonitorsForAsset(
+      @Param("projectId") long projectId,
+      @Param("assetId") long assetId);
 
   long countExecutions(Map<String, Object> params);
   List<QualityExecutionPO> selectExecutions(Map<String, Object> params);
@@ -42,11 +46,15 @@ public interface QualityQueryMapper {
   long countRuleExecutionWorkspace(Map<String, Object> params);
   List<RuleExecutionWorkspaceRow> selectRuleExecutionWorkspace(Map<String, Object> params);
 
-  WorkspaceStatsRow selectWorkspaceStats(@Param("monitorId") long monitorId);
+  WorkspaceStatsRow selectWorkspaceStats(
+      @Param("projectId") long projectId,
+      @Param("monitorId") long monitorId);
   ReportOverviewRow selectReportOverview(Map<String, Object> params);
   List<DimensionReportRow> selectDimensionReport(Map<String, Object> params);
   List<TrendPointRow> selectTrend(Map<String, Object> params);
   List<ColumnReportRow> selectColumnReport(Map<String, Object> params);
-  long countOperationLogs(@Param("monitorId") long monitorId);
+  long countOperationLogs(
+      @Param("projectId") long projectId,
+      @Param("monitorId") long monitorId);
   List<OperationLogRow> selectOperationLogs(Map<String, Object> params);
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityWriteMapper.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityWriteMapper.java
@@ -8,7 +8,9 @@ import org.apache.ibatis.annotations.Param;
 /** 需要数据库原子语义而不适合拆成多次 BaseMapper CRUD 的写操作。 */
 @Mapper
 public interface QualityWriteMapper {
-  Long lockMonitor(@Param("monitorId") long monitorId);
+  Long lockMonitor(
+      @Param("projectId") long projectId,
+      @Param("monitorId") long monitorId);
 
   int upsertTableAsset(QualityTableAssetPO asset);
 

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/execution/QualityExecutionPlan.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/execution/QualityExecutionPlan.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 /** Immutable execution snapshot captured when a quality check is enqueued. */
 public record QualityExecutionPlan(
+    long projectId,
     long executionId,
     String executionNo,
     MonitorSnapshot monitor,
@@ -22,11 +23,15 @@ public record QualityExecutionPlan(
     AlertLevel alertLevel) {
 
   public QualityExecutionPlan {
+    if (projectId <= 0L) throw new IllegalArgumentException("质量执行 Project ID 不合法");
     if (executionId <= 0L) throw new IllegalArgumentException("质量执行 ID 不合法");
-    if (executionNo == null || executionNo.isBlank()) throw new IllegalArgumentException("质量执行编号不能为空");
+    if (executionNo == null || executionNo.isBlank()) {
+      throw new IllegalArgumentException("质量执行编号不能为空");
+    }
     if (monitor == null) throw new IllegalArgumentException("质量监控快照不能为空");
     rules = rules == null ? List.of() : List.copyOf(rules);
-    ruleFailureAction = ruleFailureAction == null ? RuleFailureAction.CONTINUE : ruleFailureAction;
+    ruleFailureAction =
+        ruleFailureAction == null ? RuleFailureAction.CONTINUE : ruleFailureAction;
     notifyChannel = notifyChannel == null ? NotifyChannel.MESSAGE : notifyChannel;
     alertLevel = alertLevel == null ? AlertLevel.WARNING : alertLevel;
   }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionDispatcher.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionDispatcher.java
@@ -5,6 +5,8 @@ import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan;
 import io.yak.ops.business.quality.repository.QualityExecutionRepository;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskRejectedException;
@@ -13,7 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-/** Dispatches an accepted execution only after its surrounding transaction commits. */
+/** Dispatches an accepted execution after commit and restores its persisted Project context. */
 @Component
 @ConditionalOnQualityEnabled
 public class QualityExecutionDispatcher {
@@ -21,16 +23,19 @@ public class QualityExecutionDispatcher {
   private final QualityExecutionRepository executionRepository;
   private final QualityMonitorRepository monitorRepository;
   private final ThreadPoolTaskExecutor taskExecutor;
+  private final ProjectContextScope projectScope;
 
   public QualityExecutionDispatcher(
       QualityExecutionWorker worker,
       QualityExecutionRepository executionRepository,
       QualityMonitorRepository monitorRepository,
-      @Qualifier("qualityExecutionTaskExecutor") ThreadPoolTaskExecutor taskExecutor) {
+      @Qualifier("qualityExecutionTaskExecutor") ThreadPoolTaskExecutor taskExecutor,
+      ProjectContextScope projectScope) {
     this.worker = worker;
     this.executionRepository = executionRepository;
     this.monitorRepository = monitorRepository;
     this.taskExecutor = taskExecutor;
+    this.projectScope = projectScope;
   }
 
   public void dispatchAfterCommit(QualityExecutionPlan plan) {
@@ -39,22 +44,36 @@ public class QualityExecutionDispatcher {
       dispatch.run();
       return;
     }
-    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-      @Override
-      public void afterCommit() {
-        dispatch.run();
-      }
-    });
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            dispatch.run();
+          }
+        });
   }
 
   private void dispatch(QualityExecutionPlan plan) {
+    ProjectContext project = new ProjectContext(plan.projectId(), null);
     try {
-      taskExecutor.execute(() -> worker.execute(plan));
+      taskExecutor.execute(
+          () -> projectScope.run(project, () -> worker.execute(plan)));
     } catch (TaskRejectedException exception) {
-      LocalDateTime now = LocalDateTime.now();
-      executionRepository.failExecution(plan.executionId(), "质量执行队列已满", now, 0L);
-      monitorRepository.updateMonitorResult(
-          plan.monitor().id(), plan.executionNo(), CheckResult.ERROR, now);
+      projectScope.run(project, () -> recordQueueRejection(plan));
     }
+  }
+
+  private void recordQueueRejection(QualityExecutionPlan plan) {
+    LocalDateTime now = LocalDateTime.now();
+    executionRepository.failExecution(
+        plan.executionId(),
+        "质量执行队列已满",
+        now,
+        0L);
+    monitorRepository.updateMonitorResult(
+        plan.monitor().id(),
+        plan.executionNo(),
+        CheckResult.ERROR,
+        now);
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionPlanFactory.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionPlanFactory.java
@@ -9,34 +9,71 @@ import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.Monitor
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.RuleSnapshot;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
 import io.yak.ops.common.enums.quality.QualityEnums.ComparisonOperator;
+import io.yak.ops.core.project.CurrentProject;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-/** Freezes the monitor definition and enabled rules into an immutable execution plan. */
+/** Freezes the Project identity, monitor definition and enabled rules into an immutable plan. */
 @Component
 @ConditionalOnQualityEnabled
 public class QualityExecutionPlanFactory {
   private final QualityMonitorRepository monitorRepository;
+  private final CurrentProject currentProject;
 
-  public QualityExecutionPlanFactory(QualityMonitorRepository monitorRepository) {
+  public QualityExecutionPlanFactory(
+      QualityMonitorRepository monitorRepository,
+      CurrentProject currentProject) {
     this.monitorRepository = monitorRepository;
+    this.currentProject = currentProject;
   }
 
-  public QualityExecutionPlan create(Monitor monitor, long executionId, String executionNo) {
+  public QualityExecutionPlan create(
+      Monitor monitor,
+      long executionId,
+      String executionNo) {
+    long projectId = currentProject.requireProjectId();
     MonitorSettings settings = monitorRepository.findMonitorSettings(monitor.id());
-    MonitorSnapshot monitorSnapshot = new MonitorSnapshot(
-        monitor.id(), monitor.name(), monitor.dataSourceId(), monitor.dataSourceName(),
-        monitor.databaseName(), monitor.schemaName(), monitor.tableName(), monitor.whereClause(), monitor.owner());
-    List<RuleSnapshot> rules = monitor.rules().stream()
-        .filter(Rule::enabled)
-        .map(rule -> new RuleSnapshot(
-            rule.id(), rule.templateId(), rule.templateCode(), rule.name(), rule.ruleType(), rule.scope(),
-            rule.dimension(), rule.columnName(), ComparisonOperator.fromValue(rule.operator()),
-            rule.threshold(), rule.thresholdEnd(), rule.enumValues(), rule.customSql()))
-        .toList();
+    MonitorSnapshot monitorSnapshot =
+        new MonitorSnapshot(
+            monitor.id(),
+            monitor.name(),
+            monitor.dataSourceId(),
+            monitor.dataSourceName(),
+            monitor.databaseName(),
+            monitor.schemaName(),
+            monitor.tableName(),
+            monitor.whereClause(),
+            monitor.owner());
+    List<RuleSnapshot> rules =
+        monitor.rules().stream()
+            .filter(Rule::enabled)
+            .map(
+                rule ->
+                    new RuleSnapshot(
+                        rule.id(),
+                        rule.templateId(),
+                        rule.templateCode(),
+                        rule.name(),
+                        rule.ruleType(),
+                        rule.scope(),
+                        rule.dimension(),
+                        rule.columnName(),
+                        ComparisonOperator.fromValue(rule.operator()),
+                        rule.threshold(),
+                        rule.thresholdEnd(),
+                        rule.enumValues(),
+                        rule.customSql()))
+            .toList();
     return new QualityExecutionPlan(
-        executionId, executionNo, monitorSnapshot, rules,
-        settings.ruleFailureAction(), settings.notifyEnabled(), settings.notifyChannel(),
-        settings.notifyTarget(), settings.alertLevel());
+        projectId,
+        executionId,
+        executionNo,
+        monitorSnapshot,
+        rules,
+        settings.ruleFailureAction(),
+        settings.notifyEnabled(),
+        settings.notifyChannel(),
+        settings.notifyTarget(),
+        settings.alertLevel());
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityExecutionOverviewRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.quality.repository;
 
 import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.core.project.CurrentProject;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -12,12 +13,14 @@ import java.util.List;
 import java.util.Locale;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-/** MySQL-backed data-quality execution overview projection. */
+/** MySQL-backed, Project-scoped data-quality execution overview projection. */
 @Repository
 @ConditionalOnQualityEnabled
+@DependsOn("qualityFlyway")
 public class QualityExecutionOverviewRepositoryAdapter
     implements QualityExecutionOverviewRepository {
 
@@ -26,37 +29,37 @@ public class QualityExecutionOverviewRepositoryAdapter
   private static final String RUNNING_STATUSES = "'QUEUED','RUNNING'";
 
   private final JdbcTemplate jdbc;
+  private final CurrentProject currentProject;
 
   public QualityExecutionOverviewRepositoryAdapter(
-      @Qualifier("yakBusinessDataSource") DataSource dataSource) {
+      @Qualifier("yakBusinessDataSource") DataSource dataSource,
+      CurrentProject currentProject) {
     this.jdbc = new JdbcTemplate(dataSource);
+    this.currentProject = currentProject;
   }
 
   @Override
-  public Overview overview(LocalDateTime start, LocalDateTime end, boolean hourlyTrend) {
-    return new Overview(metrics(start, end), trend(start, end, hourlyTrend), latest(start, end));
+  public Overview overview(
+      LocalDateTime start,
+      LocalDateTime end,
+      boolean hourlyTrend) {
+    long projectId = currentProjectId();
+    return new Overview(
+        metrics(projectId, start, end),
+        trend(projectId, start, end, hourlyTrend),
+        latest(projectId, start, end));
   }
 
   @Override
   public Execution latest(LocalDateTime start, LocalDateTime end) {
-    String sql = """
-        SELECT CAST(e.monitor_id AS CHAR) AS task_id,
-               e.monitor_name AS task_name,
-               e.execution_status AS status,
-               COALESCE(e.started_at, e.queued_at, e.created_at) AS occurred_at,
-               COALESCE(e.duration_ms, 0) AS duration_ms,
-               e.execution_no AS execution_id
-          FROM yak_quality_execution e
-         WHERE e.queued_at >= ? AND e.queued_at < ?
-         ORDER BY COALESCE(e.started_at, e.queued_at, e.created_at) DESC, e.id DESC
-         LIMIT 1
-        """;
-    List<Execution> rows = jdbc.query(sql, this::execution, start, end);
-    return rows.isEmpty() ? null : rows.get(0);
+    return latest(currentProjectId(), start, end);
   }
 
   @Override
-  public TaskSummary taskSummary(String taskId, LocalDateTime start, LocalDateTime end) {
+  public TaskSummary taskSummary(
+      String taskId,
+      LocalDateTime start,
+      LocalDateTime end) {
     if (taskId == null || taskId.isBlank()) return null;
     long id;
     try {
@@ -64,6 +67,7 @@ public class QualityExecutionOverviewRepositoryAdapter
     } catch (NumberFormatException ignored) {
       return null;
     }
+    long projectId = currentProjectId();
     String sql = """
         SELECT e.monitor_id AS task_id,
                MAX(e.monitor_name) AS task_name,
@@ -72,17 +76,25 @@ public class QualityExecutionOverviewRepositoryAdapter
                SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
                MAX(COALESCE(e.started_at, e.queued_at, e.created_at)) AS last_run_time
           FROM yak_quality_execution e
-         WHERE e.queued_at >= ? AND e.queued_at < ?
+         WHERE e.project_id = ?
+           AND e.queued_at >= ? AND e.queued_at < ?
            AND e.monitor_id = ?
          GROUP BY e.monitor_id
         """.formatted(SUCCESS_STATUSES, FAILED_STATUSES);
-    List<TaskAggregate> aggregates = jdbc.query(sql, this::taskAggregate, start, end, id);
+    List<TaskAggregate> aggregates =
+        jdbc.query(sql, this::taskAggregate, projectId, start, end, id);
     if (aggregates.isEmpty()) return null;
-    return summary(aggregates.get(0), latestForTask(id, start, end));
+    return summary(
+        aggregates.get(0),
+        latestForTask(projectId, id, start, end));
   }
 
   @Override
-  public List<TaskSummary> recentTasks(LocalDateTime start, LocalDateTime end, int limit) {
+  public List<TaskSummary> recentTasks(
+      LocalDateTime start,
+      LocalDateTime end,
+      int limit) {
+    long projectId = currentProjectId();
     int boundedLimit = Math.max(1, Math.min(limit, 20));
     String sql = """
         SELECT e.monitor_id AS task_id,
@@ -92,21 +104,59 @@ public class QualityExecutionOverviewRepositoryAdapter
                SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END) AS failed_count,
                MAX(COALESCE(e.started_at, e.queued_at, e.created_at)) AS last_run_time
           FROM yak_quality_execution e
-         WHERE e.queued_at >= ? AND e.queued_at < ?
+         WHERE e.project_id = ?
+           AND e.queued_at >= ? AND e.queued_at < ?
          GROUP BY e.monitor_id
          ORDER BY last_run_time DESC
          LIMIT %d
         """.formatted(SUCCESS_STATUSES, FAILED_STATUSES, boundedLimit);
-    List<TaskAggregate> aggregates = jdbc.query(sql, this::taskAggregate, start, end);
+    List<TaskAggregate> aggregates =
+        jdbc.query(sql, this::taskAggregate, projectId, start, end);
     List<TaskSummary> result = new ArrayList<>(aggregates.size());
     for (TaskAggregate aggregate : aggregates) {
-      result.add(summary(aggregate, latestForTask(aggregate.taskId(), start, end)));
+      result.add(
+          summary(
+              aggregate,
+              latestForTask(
+                  projectId,
+                  aggregate.taskId(),
+                  start,
+                  end)));
     }
     return List.copyOf(result);
   }
 
   @Override
   public Metrics metrics(LocalDateTime start, LocalDateTime end) {
+    return metrics(currentProjectId(), start, end);
+  }
+
+  private Execution latest(
+      long projectId,
+      LocalDateTime start,
+      LocalDateTime end) {
+    String sql = """
+        SELECT CAST(e.monitor_id AS CHAR) AS task_id,
+               e.monitor_name AS task_name,
+               e.execution_status AS status,
+               COALESCE(e.started_at, e.queued_at, e.created_at) AS occurred_at,
+               COALESCE(e.duration_ms, 0) AS duration_ms,
+               e.execution_no AS execution_id
+          FROM yak_quality_execution e
+         WHERE e.project_id = ?
+           AND e.queued_at >= ? AND e.queued_at < ?
+         ORDER BY COALESCE(e.started_at, e.queued_at, e.created_at) DESC, e.id DESC
+         LIMIT 1
+        """;
+    List<Execution> rows =
+        jdbc.query(sql, this::execution, projectId, start, end);
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  private Metrics metrics(
+      long projectId,
+      LocalDateTime start,
+      LocalDateTime end) {
     String sql = """
         SELECT COALESCE(SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END), 0) AS success_count,
                COALESCE(SUM(CASE WHEN UPPER(e.execution_status) IN (%s) THEN 1 ELSE 0 END), 0) AS failed_count,
@@ -116,53 +166,77 @@ public class QualityExecutionOverviewRepositoryAdapter
                COALESCE(SUM(CASE WHEN UPPER(e.execution_status) NOT IN (%s)
                                   AND COALESCE(e.duration_ms, 0) > 0 THEN 1 ELSE 0 END), 0) AS duration_sample_count
           FROM yak_quality_execution e
-         WHERE e.queued_at >= ? AND e.queued_at < ?
+         WHERE e.project_id = ?
+           AND e.queued_at >= ? AND e.queued_at < ?
         """.formatted(
-            SUCCESS_STATUSES, FAILED_STATUSES, RUNNING_STATUSES, RUNNING_STATUSES);
-    Metrics aggregate = jdbc.queryForObject(
-        sql,
-        (rs, rowNum) -> new Metrics(
-            rs.getLong("success_count"),
-            0L,
-            rs.getLong("failed_count"),
-            rs.getLong("schedule_count"),
-            0L,
-            rs.getLong("duration_total_ms"),
-            rs.getLong("duration_sample_count")),
-        start,
-        end);
-    return (aggregate == null ? Metrics.empty() : aggregate).withRunning(runningAt(end));
+            SUCCESS_STATUSES,
+            FAILED_STATUSES,
+            RUNNING_STATUSES,
+            RUNNING_STATUSES);
+    Metrics aggregate =
+        jdbc.queryForObject(
+            sql,
+            (rs, rowNum) ->
+                new Metrics(
+                    rs.getLong("success_count"),
+                    0L,
+                    rs.getLong("failed_count"),
+                    rs.getLong("schedule_count"),
+                    0L,
+                    rs.getLong("duration_total_ms"),
+                    rs.getLong("duration_sample_count")),
+            projectId,
+            start,
+            end);
+    return (aggregate == null ? Metrics.empty() : aggregate)
+        .withRunning(runningAt(projectId, end));
   }
 
-  private long runningAt(LocalDateTime point) {
+  private long runningAt(long projectId, LocalDateTime point) {
     String sql = """
         SELECT COUNT(*)
           FROM yak_quality_execution e
-         WHERE e.queued_at <= ?
+         WHERE e.project_id = ?
+           AND e.queued_at <= ?
            AND (e.finished_at IS NULL OR e.finished_at > ?)
         """;
-    Long value = jdbc.queryForObject(sql, Long.class, point, point);
+    Long value = jdbc.queryForObject(sql, Long.class, projectId, point, point);
     return value == null ? 0L : value;
   }
 
-  private List<TrendPoint> trend(LocalDateTime start, LocalDateTime end, boolean hourly) {
+  private List<TrendPoint> trend(
+      long projectId,
+      LocalDateTime start,
+      LocalDateTime end,
+      boolean hourly) {
     String occurredAt = "COALESCE(e.started_at, e.queued_at, e.created_at)";
-    String bucketHour = hourly ? "FLOOR(HOUR(" + occurredAt + ") / 4) * 4" : "0";
-    String sql = "SELECT DATE(" + occurredAt + ") AS bucket_date, "
-        + bucketHour + " AS bucket_hour, COUNT(*) AS total "
-        + "FROM yak_quality_execution e "
-        + "WHERE e.queued_at >= ? AND e.queued_at < ? "
-        + "GROUP BY bucket_date, bucket_hour ORDER BY bucket_date, bucket_hour";
+    String bucketHour =
+        hourly ? "FLOOR(HOUR(" + occurredAt + ") / 4) * 4" : "0";
+    String sql =
+        "SELECT DATE("
+            + occurredAt
+            + ") AS bucket_date, "
+            + bucketHour
+            + " AS bucket_hour, COUNT(*) AS total "
+            + "FROM yak_quality_execution e "
+            + "WHERE e.project_id = ? AND e.queued_at >= ? AND e.queued_at < ? "
+            + "GROUP BY bucket_date, bucket_hour ORDER BY bucket_date, bucket_hour";
     return jdbc.query(
         sql,
-        (rs, rowNum) -> new TrendPoint(
-            date(rs, "bucket_date").atTime(rs.getInt("bucket_hour"), 0),
-            rs.getLong("total")),
+        (rs, rowNum) ->
+            new TrendPoint(
+                date(rs, "bucket_date").atTime(rs.getInt("bucket_hour"), 0),
+                rs.getLong("total")),
+        projectId,
         start,
         end);
   }
 
-  private Execution latestForTask(long taskId, LocalDateTime start, LocalDateTime end) {
+  private Execution latestForTask(
+      long projectId,
+      long taskId,
+      LocalDateTime start,
+      LocalDateTime end) {
     String sql = """
         SELECT CAST(e.monitor_id AS CHAR) AS task_id,
                e.monitor_name AS task_name,
@@ -171,12 +245,20 @@ public class QualityExecutionOverviewRepositoryAdapter
                COALESCE(e.duration_ms, 0) AS duration_ms,
                e.execution_no AS execution_id
           FROM yak_quality_execution e
-         WHERE e.queued_at >= ? AND e.queued_at < ?
+         WHERE e.project_id = ?
+           AND e.queued_at >= ? AND e.queued_at < ?
            AND e.monitor_id = ?
          ORDER BY COALESCE(e.started_at, e.queued_at, e.created_at) DESC, e.id DESC
          LIMIT 1
         """;
-    List<Execution> rows = jdbc.query(sql, this::execution, start, end, taskId);
+    List<Execution> rows =
+        jdbc.query(
+            sql,
+            this::execution,
+            projectId,
+            start,
+            end,
+            taskId);
     return rows.isEmpty() ? null : rows.get(0);
   }
 
@@ -191,7 +273,8 @@ public class QualityExecutionOverviewRepositoryAdapter
         rs.getString("execution_id"));
   }
 
-  private TaskAggregate taskAggregate(ResultSet rs, int rowNum) throws SQLException {
+  private TaskAggregate taskAggregate(ResultSet rs, int rowNum)
+      throws SQLException {
     return new TaskAggregate(
         rs.getLong("task_id"),
         rs.getString("task_name"),
@@ -215,12 +298,18 @@ public class QualityExecutionOverviewRepositoryAdapter
         last == null ? null : last.executionId());
   }
 
-  private static LocalDate date(ResultSet rs, String column) throws SQLException {
+  private long currentProjectId() {
+    return currentProject.requireProjectId();
+  }
+
+  private static LocalDate date(ResultSet rs, String column)
+      throws SQLException {
     Date value = rs.getDate(column);
     return value == null ? LocalDate.of(1970, 1, 1) : value.toLocalDate();
   }
 
-  private static LocalDateTime localDateTime(ResultSet rs, String column) throws SQLException {
+  private static LocalDateTime localDateTime(ResultSet rs, String column)
+      throws SQLException {
     Timestamp value = rs.getTimestamp(column);
     return value == null ? null : value.toLocalDateTime();
   }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityScheduleRecoveryRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityScheduleRecoveryRepository.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.quality.repository;
+
+import java.util.List;
+
+/** Explicit system-level scan used only to restore scheduled monitors by persisted Project. */
+public interface QualityScheduleRecoveryRepository {
+  List<ProjectMonitorRef> listScheduledMonitors();
+
+  record ProjectMonitorRef(long projectId, long monitorId) {
+    public ProjectMonitorRef {
+      if (projectId <= 0L) throw new IllegalArgumentException("projectId must be positive");
+      if (monitorId <= 0L) throw new IllegalArgumentException("monitorId must be positive");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityScheduleRecoveryRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityScheduleRecoveryRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.dao.QualityMonitorDao;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@ConditionalOnQualityEnabled
+@DependsOn("qualityFlyway")
+public class QualityScheduleRecoveryRepositoryAdapter
+    implements QualityScheduleRecoveryRepository {
+  private final QualityMonitorDao monitorDao;
+
+  @Override
+  public List<ProjectMonitorRef> listScheduledMonitors() {
+    return monitorDao.selectScheduledMonitorsForRecovery().stream()
+        .map(value -> new ProjectMonitorRef(value.projectId(), value.monitorId()))
+        .toList();
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridge.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridge.java
@@ -12,6 +12,7 @@ import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
 import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
 import io.yak.ops.common.schedule.YakScheduleGateway;
 import io.yak.ops.common.schedule.YakScheduleNamespaces;
+import io.yak.ops.core.project.CurrentProject;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,12 +29,15 @@ public class QualityScheduleEngineBridge {
 
   private final YakScheduleGateway gateway;
   private final QualityScheduleCalculator calculator;
+  private final CurrentProject currentProject;
 
   public QualityScheduleEngineBridge(
       ObjectProvider<ScheduleManager> scheduleManagers,
-      QualityScheduleCalculator calculator) {
+      QualityScheduleCalculator calculator,
+      CurrentProject currentProject) {
     this.gateway = new YakScheduleGateway(scheduleManagers::getIfAvailable, NAMESPACE);
     this.calculator = calculator;
+    this.currentProject = currentProject;
   }
 
   public boolean available() {
@@ -72,17 +76,21 @@ public class QualityScheduleEngineBridge {
       throw new IllegalArgumentException("质量监控未配置调度触发");
     }
 
-    String cron = calculator.cronExpression(
-        settings.scheduleFrequency(),
-        settings.scheduleTime(),
-        settings.scheduleWeekday(),
-        settings.cronExpression());
+    long projectId = currentProject.requireProjectId();
+    String cron =
+        calculator.cronExpression(
+            settings.scheduleFrequency(),
+            settings.scheduleTime(),
+            settings.scheduleWeekday(),
+            settings.cronExpression());
 
     Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("projectId", projectId);
     payload.put("monitorId", monitor.id());
 
     Map<String, String> metadata = new LinkedHashMap<>();
     metadata.put("source", "yak-ops");
+    metadata.put("projectId", String.valueOf(projectId));
     metadata.put("monitorId", String.valueOf(monitor.id()));
     metadata.put("dataSourceId", String.valueOf(monitor.dataSourceId()));
     metadata.put("tableName", monitor.tableName());

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleHandler.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleHandler.java
@@ -9,9 +9,11 @@ import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
 import io.yak.ops.business.quality.execution.QualityExecutionManager;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
 import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import org.springframework.stereotype.Component;
 
-/** Yak Schedule handler that delegates every accepted trigger to QualityExecutionManager. */
+/** Yak Schedule handler that restores Project context before entering Quality execution. */
 @ConditionalOnQualityEnabled
 @Component(QualityScheduleEngineBridge.HANDLER)
 public class QualityScheduleHandler implements ScheduleHandler {
@@ -19,37 +21,52 @@ public class QualityScheduleHandler implements ScheduleHandler {
   private final QualityExecutionManager executionManager;
   private final QualityScheduleEngineBridge engine;
   private final QualityScheduleLifecycle lifecycle;
+  private final ProjectContextScope projectScope;
 
   public QualityScheduleHandler(
       QualityMonitorRepository repository,
       QualityExecutionManager executionManager,
       QualityScheduleEngineBridge engine,
-      QualityScheduleLifecycle lifecycle) {
+      QualityScheduleLifecycle lifecycle,
+      ProjectContextScope projectScope) {
     this.repository = repository;
     this.executionManager = executionManager;
     this.engine = engine;
     this.lifecycle = lifecycle;
+    this.projectScope = projectScope;
   }
 
   @Override
   public ScheduleExecutionResult execute(ScheduleExecutionContext context) {
+    long projectId = context.requiredLong("projectId");
     long monitorId = context.requiredLong("monitorId");
+    return projectScope.call(
+        new ProjectContext(projectId, null),
+        () -> executeInProject(monitorId));
+  }
+
+  private ScheduleExecutionResult executeInProject(long monitorId) {
     Monitor monitor = repository.findMonitor(monitorId).orElse(null);
     if (monitor == null) {
-      engine.deleteIfPresent(monitorId);
-      return ScheduleExecutionResult.accepted(null, "质量监控已删除，清理残留调度计划");
+      return ScheduleExecutionResult.accepted(
+          null,
+          "质量监控在当前 Project 不可用，本次触发忽略");
     }
 
     MonitorSettings settings = repository.findMonitorSettings(monitorId);
     if (!monitor.enabled() || settings.runMode() != RunMode.SCHEDULE) {
       engine.pauseIfPresent(monitorId);
       lifecycle.refreshRuntimeState(monitorId);
-      return ScheduleExecutionResult.accepted(null, "质量监控未启用调度，本次触发忽略");
+      return ScheduleExecutionResult.accepted(
+          null,
+          "质量监控未启用调度，本次触发忽略");
     }
 
     try {
       var receipt = executionManager.runScheduled(monitorId);
-      return ScheduleExecutionResult.accepted(receipt.executionNo(), "质量检查已提交执行");
+      return ScheduleExecutionResult.accepted(
+          receipt.executionNo(),
+          "质量检查已提交执行");
     } finally {
       lifecycle.refreshRuntimeState(monitorId);
     }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleReconciler.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleReconciler.java
@@ -3,12 +3,16 @@ package io.yak.ops.business.quality.schedule;
 import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
-import io.yak.ops.business.quality.domain.QualityQuery;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.business.quality.repository.QualityScheduleRecoveryRepository;
+import io.yak.ops.business.quality.repository.QualityScheduleRecoveryRepository.ProjectMonitorRef;
 import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -16,99 +20,121 @@ import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-/** 应用启动后以质量监控业务表为事实来源恢复 Yak Schedule 计划。 */
+/** 应用启动后按持久化 Project 恢复数据质量调度计划。 */
 @ConditionalOnQualityEnabled
 @Component
 public class QualityScheduleReconciler {
-  private static final Logger LOGGER = LoggerFactory.getLogger(QualityScheduleReconciler.class);
-  private static final int PAGE_SIZE = 100;
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(QualityScheduleReconciler.class);
 
   private final QualityMonitorRepository repository;
+  private final QualityScheduleRecoveryRepository recoveryRepository;
   private final QualityScheduleEngineBridge engine;
   private final QualityScheduleLifecycle lifecycle;
+  private final ProjectContextScope projectScope;
 
   public QualityScheduleReconciler(
       QualityMonitorRepository repository,
+      QualityScheduleRecoveryRepository recoveryRepository,
       QualityScheduleEngineBridge engine,
-      QualityScheduleLifecycle lifecycle) {
+      QualityScheduleLifecycle lifecycle,
+      ProjectContextScope projectScope) {
     this.repository = repository;
+    this.recoveryRepository = recoveryRepository;
     this.engine = engine;
     this.lifecycle = lifecycle;
+    this.projectScope = projectScope;
   }
 
   @Order(30)
   @EventListener(ApplicationReadyEvent.class)
   public void reconcile() {
     if (!engine.available()) {
-      LOGGER.warn("[quality-schedule] Yak ScheduleManager unavailable, skip startup reconcile");
+      LOGGER.warn(
+          "[quality-schedule] Yak ScheduleManager unavailable, skip startup reconcile");
       return;
     }
 
-    Map<Long, Monitor> monitors = loadMonitors();
-    Map<Long, MonitorSettings> scheduled = new LinkedHashMap<>();
-    for (Monitor monitor : monitors.values()) {
-      MonitorSettings settings = repository.findMonitorSettings(monitor.id());
-      if (monitor.enabled() && settings.runMode() == RunMode.SCHEDULE) {
-        scheduled.put(monitor.id(), settings);
-      }
-    }
-
-    engine.list().forEach(snapshot -> {
-      long monitorId;
-      try {
-        monitorId = Long.parseLong(snapshot.definition().key().name());
-      } catch (NumberFormatException exception) {
-        return;
-      }
-      if (!scheduled.containsKey(monitorId)) {
-        try {
-          engine.deleteIfPresent(monitorId);
-        } catch (RuntimeException exception) {
-          LOGGER.warn(
-              "[quality-schedule] stale schedule cleanup failed monitor={}, message={}",
-              monitorId, exception.getMessage());
-        }
-      }
-    });
+    List<ProjectMonitorRef> candidates = recoveryRepository.listScheduledMonitors();
+    cleanupStaleSchedules(candidates);
 
     LocalDateTime now = LocalDateTime.now();
-    scheduled.forEach((monitorId, settings) -> {
-      LocalDateTime persistedNextRunTime = settings.nextRunTime();
+    for (ProjectMonitorRef candidate : candidates) {
       try {
-        lifecycle.sync(monitorId);
-        LOGGER.info("[quality-schedule] reconciled monitor={}", monitorId);
+        projectScope.run(
+            new ProjectContext(candidate.projectId(), null),
+            () -> reconcileInProject(candidate, now));
       } catch (RuntimeException exception) {
         LOGGER.error(
-            "[quality-schedule] reconcile failed monitor={}, message={}",
-            monitorId, exception.getMessage(), exception);
-        return;
+            "[quality-schedule] reconcile failed projectId={}, monitor={}, message={}",
+            candidate.projectId(),
+            candidate.monitorId(),
+            exception.getMessage(),
+            exception);
       }
-
-      if (persistedNextRunTime != null && !persistedNextRunTime.isAfter(now)) {
-        try {
-          engine.runNowIfPresent(monitorId);
-          LOGGER.info(
-              "[quality-schedule] recovered missed trigger monitor={}, planned={}",
-              monitorId, persistedNextRunTime);
-        } catch (RuntimeException exception) {
-          LOGGER.warn(
-              "[quality-schedule] missed trigger recovery skipped monitor={}, planned={}, message={}",
-              monitorId, persistedNextRunTime, exception.getMessage());
-        }
-      }
-    });
+    }
   }
 
-  private Map<Long, Monitor> loadMonitors() {
-    Map<Long, Monitor> result = new LinkedHashMap<>();
-    int current = 1;
-    while (true) {
-      var page = repository.pageMonitors(new QualityQuery.Monitor(
-          current, PAGE_SIZE, null, null, null, false, null, false, null, null, null));
-      page.records().forEach(monitor -> result.put(monitor.id(), monitor));
-      if (page.records().size() < PAGE_SIZE) break;
-      current++;
+  private void cleanupStaleSchedules(List<ProjectMonitorRef> candidates) {
+    Set<Long> expectedMonitorIds = new HashSet<>();
+    candidates.forEach(candidate -> expectedMonitorIds.add(candidate.monitorId()));
+    engine.list().forEach(
+        snapshot -> {
+          long monitorId;
+          try {
+            monitorId = Long.parseLong(snapshot.definition().key().name());
+          } catch (NumberFormatException exception) {
+            return;
+          }
+          if (expectedMonitorIds.contains(monitorId)) return;
+          try {
+            engine.deleteIfPresent(monitorId);
+          } catch (RuntimeException exception) {
+            LOGGER.warn(
+                "[quality-schedule] stale schedule cleanup failed monitor={}, message={}",
+                monitorId,
+                exception.getMessage());
+          }
+        });
+  }
+
+  private void reconcileInProject(
+      ProjectMonitorRef candidate,
+      LocalDateTime now) {
+    Monitor monitor = repository.findMonitor(candidate.monitorId()).orElse(null);
+    if (monitor == null) {
+      engine.deleteIfPresent(candidate.monitorId());
+      return;
     }
-    return result;
+
+    MonitorSettings settings =
+        repository.findMonitorSettings(candidate.monitorId());
+    LocalDateTime persistedNextRunTime = settings.nextRunTime();
+    lifecycle.sync(candidate.monitorId());
+    LOGGER.info(
+        "[quality-schedule] reconciled projectId={}, monitor={}",
+        candidate.projectId(),
+        candidate.monitorId());
+
+    if (monitor.enabled()
+        && settings.runMode() == RunMode.SCHEDULE
+        && persistedNextRunTime != null
+        && !persistedNextRunTime.isAfter(now)) {
+      try {
+        engine.runNowIfPresent(candidate.monitorId());
+        LOGGER.info(
+            "[quality-schedule] recovered missed trigger projectId={}, monitor={}, planned={}",
+            candidate.projectId(),
+            candidate.monitorId(),
+            persistedNextRunTime);
+      } catch (RuntimeException exception) {
+        LOGGER.warn(
+            "[quality-schedule] missed trigger recovery skipped projectId={}, monitor={}, planned={}, message={}",
+            candidate.projectId(),
+            candidate.monitorId(),
+            persistedNextRunTime,
+            exception.getMessage());
+      }
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V6__add_quality_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V6__add_quality_project_scope.sql
@@ -1,0 +1,65 @@
+-- Data Quality Project Space contract migration.
+--
+-- Project identity is derived from the already project-scoped Datasource root. The migration never
+-- guesses a default Project ID. Any orphaned Quality root remains NULL and makes the NOT NULL
+-- contract fail, stopping deployment instead of silently assigning data to the wrong workspace.
+
+ALTER TABLE yak_quality_table_asset
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id;
+
+ALTER TABLE yak_quality_monitor
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id;
+
+ALTER TABLE yak_quality_execution
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id;
+
+UPDATE yak_quality_table_asset asset
+INNER JOIN yak_ops_data_source datasource ON datasource.id = asset.data_source_id
+SET asset.project_id = datasource.project_id
+WHERE asset.project_id IS NULL;
+
+UPDATE yak_quality_monitor monitor
+INNER JOIN yak_ops_data_source datasource ON datasource.id = monitor.data_source_id
+SET monitor.project_id = datasource.project_id
+WHERE monitor.project_id IS NULL;
+
+UPDATE yak_quality_execution execution_row
+INNER JOIN yak_quality_monitor monitor ON monitor.id = execution_row.monitor_id
+SET execution_row.project_id = monitor.project_id
+WHERE execution_row.project_id IS NULL;
+
+ALTER TABLE yak_quality_table_asset
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID',
+    DROP INDEX uk_yak_quality_table_asset_target,
+    DROP INDEX idx_yak_quality_table_asset_query,
+    ADD UNIQUE KEY uk_yak_quality_table_asset_target
+      (project_id, data_source_id, database_name, schema_name, table_name),
+    ADD KEY idx_yak_quality_table_asset_query
+      (project_id, data_source_id, database_name, deleted, table_name);
+
+ALTER TABLE yak_quality_monitor
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID',
+    DROP INDEX idx_yak_quality_monitor_target,
+    DROP INDEX idx_yak_quality_monitor_result,
+    DROP INDEX idx_yak_quality_monitor_updated,
+    ADD KEY idx_yak_quality_monitor_target
+      (project_id, data_source_id, database_name, schema_name, table_name, deleted),
+    ADD KEY idx_yak_quality_monitor_result
+      (project_id, last_result, deleted),
+    ADD KEY idx_yak_quality_monitor_updated
+      (project_id, updated_at, id);
+
+ALTER TABLE yak_quality_execution
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID',
+    DROP INDEX idx_yak_quality_execution_monitor,
+    DROP INDEX idx_yak_quality_execution_status,
+    DROP INDEX idx_yak_quality_execution_result,
+    DROP INDEX idx_yak_quality_execution_queued,
+    ADD KEY idx_yak_quality_execution_monitor
+      (project_id, monitor_id, created_at),
+    ADD KEY idx_yak_quality_execution_status
+      (project_id, execution_status, created_at),
+    ADD KEY idx_yak_quality_execution_result
+      (project_id, check_result, created_at),
+    ADD KEY idx_yak_quality_execution_queued
+      (project_id, queued_at, id);

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
@@ -22,33 +22,40 @@
           m.data_source_id, '|', COALESCE(m.database_name, ''), '|',
           COALESCE(m.schema_name, ''), '|', m.table_name))
        FROM yak_quality_monitor m
-       WHERE m.deleted = 0 AND m.enabled = 1) AS monitored_table_count,
+       WHERE m.project_id = #{projectId}
+         AND m.deleted = 0 AND m.enabled = 1) AS monitored_table_count,
       (SELECT COUNT(*)
        FROM yak_quality_rule r
        INNER JOIN yak_quality_monitor m ON m.id = r.monitor_id
-       WHERE r.deleted = 0 AND r.enabled = 1
+       WHERE m.project_id = #{projectId}
+         AND r.deleted = 0 AND r.enabled = 1
          AND m.deleted = 0 AND m.enabled = 1) AS enabled_rule_count,
       (SELECT COUNT(*)
        FROM yak_quality_execution e
-       WHERE e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}) AS today_execution_count,
+       WHERE e.project_id = #{projectId}
+         AND e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}) AS today_execution_count,
       (SELECT COUNT(DISTINCT e.monitor_id)
        FROM yak_quality_execution e
-       WHERE e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}
+       WHERE e.project_id = #{projectId}
+         AND e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}
          AND e.check_result IN ('NOT_PASSED', 'ERROR')) AS today_issue_table_count,
       (SELECT COUNT(*)
        FROM yak_quality_rule_execution re
        INNER JOIN yak_quality_execution e ON e.id = re.execution_id
-       WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+       WHERE e.project_id = #{projectId}
+         AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
          AND re.check_result IN ('PASSED', 'NOT_PASSED', 'ERROR')) AS recent_executed_rule_count,
       (SELECT COUNT(*)
        FROM yak_quality_rule_execution re
        INNER JOIN yak_quality_execution e ON e.id = re.execution_id
-       WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+       WHERE e.project_id = #{projectId}
+         AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
          AND re.check_result = 'PASSED') AS recent_passed_rule_count,
       (SELECT COUNT(*)
        FROM yak_quality_rule_execution re
        INNER JOIN yak_quality_execution e ON e.id = re.execution_id
-       WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+       WHERE e.project_id = #{projectId}
+         AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
          AND re.check_result IN ('NOT_PASSED', 'ERROR')) AS recent_issue_rule_count
   </select>
 
@@ -77,7 +84,8 @@
         AVG(e.duration_ms) AS average_duration_ms,
         MAX(e.queued_at) AS latest_execution_at
       FROM yak_quality_execution e
-      WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+      WHERE e.project_id = #{projectId}
+        AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
     ) execution_stats
     CROSS JOIN (
       SELECT
@@ -102,7 +110,8 @@
           END) AS affected_column_count
       FROM yak_quality_rule_execution re
       INNER JOIN yak_quality_execution e ON e.id = re.execution_id
-      WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+      WHERE e.project_id = #{projectId}
+        AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
         AND re.check_result IN ('PASSED', 'NOT_PASSED', 'ERROR')
     ) rule_stats
   </select>
@@ -122,7 +131,8 @@
       FROM yak_quality_rule_execution re
       INNER JOIN yak_quality_execution e ON e.id = re.execution_id
       LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
-      WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+      WHERE e.project_id = #{projectId}
+        AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
         AND re.check_result IN ('PASSED', 'NOT_PASSED', 'ERROR')
       GROUP BY <include refid="DimensionExpression"/>
     ) dimension_stats
@@ -154,7 +164,8 @@
           THEN 1 ELSE 0 END) AS issue_execution_count,
       AVG(e.duration_ms) AS average_duration_ms
     FROM yak_quality_execution e
-    WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+    WHERE e.project_id = #{projectId}
+      AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
     GROUP BY DATE(e.queued_at)
     ORDER BY stat_date ASC
   </select>
@@ -175,7 +186,8 @@
     FROM yak_quality_rule_execution re
     INNER JOIN yak_quality_execution e ON e.id = re.execution_id
     LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
-    WHERE e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
+    WHERE e.project_id = #{projectId}
+      AND e.queued_at &gt;= #{rangeStart} AND e.queued_at &lt; #{rangeEnd}
       AND re.check_result IN ('NOT_PASSED', 'ERROR')
     ORDER BY e.queued_at DESC, e.id DESC, re.id ASC
     LIMIT #{limit}

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityQueryMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityQueryMapper.xml
@@ -81,7 +81,7 @@
   </select>
 
   <sql id="MonitorWhere">
-    WHERE m.deleted = 0
+    WHERE m.project_id = #{projectId} AND m.deleted = 0
     <if test="keyword != null and keyword != ''">
       AND (LOWER(m.monitor_name) LIKE #{keyword}
         OR LOWER(COALESCE(m.description, '')) LIKE #{keyword}
@@ -124,7 +124,19 @@
       m.created_at, m.updated_at,
       (SELECT COUNT(*) FROM yak_quality_rule r WHERE r.monitor_id = m.id AND r.deleted = 0) AS rule_count
     FROM yak_quality_monitor m
-    WHERE m.id = #{id} AND m.deleted = 0
+    WHERE m.project_id = #{projectId} AND m.id = #{id} AND m.deleted = 0
+  </select>
+
+  <select id="selectScheduledMonitorsForRecovery"
+      resultType="io.yak.ops.common.bean.po.quality.QualityMonitorPO">
+    SELECT m.id, m.project_id
+    FROM yak_quality_monitor m
+    INNER JOIN yak_quality_monitor_setting setting ON setting.monitor_id = m.id
+    WHERE m.project_id IS NOT NULL
+      AND m.deleted = 0
+      AND m.enabled = 1
+      AND setting.run_mode = 'SCHEDULE'
+    ORDER BY m.project_id ASC, m.id ASC
   </select>
 
   <select id="selectTableSummaries" resultType="io.yak.ops.common.bean.po.quality.QualityQueryPO$TableMonitorSummaryRow">
@@ -137,14 +149,15 @@
       MAX(m.last_run_time) AS last_run_time
     FROM yak_quality_monitor m
     LEFT JOIN yak_quality_rule r ON r.monitor_id = m.id AND r.deleted = 0
-    WHERE m.deleted = 0 AND m.data_source_id = #{dataSourceId}
+    WHERE m.project_id = #{projectId} AND m.deleted = 0 AND m.data_source_id = #{dataSourceId}
     <if test="databaseFilter != null and databaseFilter">AND COALESCE(m.database_name, '') = #{databaseName}</if>
     <if test="schemaFilter != null and schemaFilter">AND COALESCE(m.schema_name, '') = #{schemaName}</if>
     GROUP BY m.table_name ORDER BY m.table_name ASC
   </select>
 
   <sql id="TableAssetWhere">
-    WHERE asset.deleted = 0 AND asset.data_source_id = #{dataSourceId}
+    WHERE asset.project_id = #{projectId}
+      AND asset.deleted = 0 AND asset.data_source_id = #{dataSourceId}
     <if test="databaseFilter != null and databaseFilter">AND asset.database_name = #{databaseName}</if>
     <if test="schemaFilter != null and schemaFilter">AND asset.schema_name = #{schemaName}</if>
     <if test="keyword != null and keyword != ''">
@@ -167,7 +180,8 @@
       MAX(monitor.last_run_time) AS last_run_time
     FROM yak_quality_table_asset asset
     LEFT JOIN yak_quality_monitor monitor
-      ON monitor.data_source_id = asset.data_source_id
+      ON monitor.project_id = asset.project_id
+      AND monitor.data_source_id = asset.data_source_id
       AND COALESCE(monitor.database_name, '') = asset.database_name
       AND COALESCE(monitor.schema_name, '') = asset.schema_name
       AND monitor.table_name = asset.table_name AND monitor.deleted = 0
@@ -184,15 +198,17 @@
     SELECT COUNT(*)
     FROM yak_quality_table_asset asset
     JOIN yak_quality_monitor monitor
-      ON monitor.data_source_id = asset.data_source_id
+      ON monitor.project_id = asset.project_id
+      AND monitor.data_source_id = asset.data_source_id
       AND COALESCE(monitor.database_name, '') = asset.database_name
       AND COALESCE(monitor.schema_name, '') = asset.schema_name
       AND monitor.table_name = asset.table_name AND monitor.deleted = 0
-    WHERE asset.id = #{assetId} AND asset.deleted = 0
+    WHERE asset.project_id = #{projectId}
+      AND asset.id = #{assetId} AND asset.deleted = 0
   </select>
 
   <sql id="ExecutionColumns">
-    e.id, e.execution_no, e.monitor_id, e.monitor_name, e.data_source_id,
+    e.id, e.project_id, e.execution_no, e.monitor_id, e.monitor_name, e.data_source_id,
     e.data_source_name, e.database_name, e.schema_name, e.table_name, e.object_name,
     e.trigger_type, e.execution_status, e.check_result, e.total_rules, e.passed_rules,
     e.failed_rules, e.error_rules, e.operator_name, e.queued_at, e.started_at,
@@ -200,7 +216,7 @@
   </sql>
 
   <sql id="SimpleExecutionWhere">
-    WHERE 1 = 1
+    WHERE e.project_id = #{projectId}
     <if test="keyword != null and keyword != ''">
       AND (LOWER(e.execution_no) LIKE #{keyword} OR LOWER(e.monitor_name) LIKE #{keyword}
         OR LOWER(e.data_source_name) LIKE #{keyword} OR LOWER(e.object_name) LIKE #{keyword})
@@ -221,7 +237,7 @@
   </select>
 
   <sql id="WorkspaceExecutionWhere">
-    WHERE 1 = 1
+    WHERE e.project_id = #{projectId}
     <if test="keyword != null and keyword != ''">
       AND (LOWER(e.execution_no) LIKE #{keyword} OR LOWER(e.monitor_name) LIKE #{keyword})
     </if>
@@ -261,7 +277,7 @@
   </select>
 
   <sql id="RuleWorkspaceWhere">
-    WHERE 1 = 1
+    WHERE e.project_id = #{projectId}
     <if test="keyword != null and keyword != ''">
       AND (LOWER(e.execution_no) LIKE #{keyword} OR LOWER(e.monitor_name) LIKE #{keyword}
         OR LOWER(r.rule_name) LIKE #{keyword} OR LOWER(r.template_code) LIKE #{keyword})
@@ -314,24 +330,41 @@
 
   <select id="selectWorkspaceStats" resultType="io.yak.ops.common.bean.po.quality.QualityQueryPO$WorkspaceStatsRow">
     SELECT
-      (SELECT COUNT(*) FROM yak_quality_rule r WHERE r.monitor_id = #{monitorId} AND r.deleted = 0) AS rule_count,
-      (SELECT COUNT(*) FROM yak_quality_rule r WHERE r.monitor_id = #{monitorId} AND r.deleted = 0 AND r.enabled = 1) AS enabled_rule_count,
-      (SELECT COUNT(*) FROM yak_quality_execution e WHERE e.monitor_id = #{monitorId}) AS execution_count,
-      (SELECT COUNT(*) FROM yak_quality_execution e WHERE e.monitor_id = #{monitorId} AND e.check_result IN ('NOT_PASSED', 'ERROR')) AS issue_execution_count,
-      (SELECT MAX(e.queued_at) FROM yak_quality_execution e WHERE e.monitor_id = #{monitorId}) AS latest_execution_time
+      (SELECT COUNT(*) FROM yak_quality_rule r
+        INNER JOIN yak_quality_monitor m ON m.id = r.monitor_id
+        WHERE r.monitor_id = #{monitorId} AND r.deleted = 0
+          AND m.project_id = #{projectId}) AS rule_count,
+      (SELECT COUNT(*) FROM yak_quality_rule r
+        INNER JOIN yak_quality_monitor m ON m.id = r.monitor_id
+        WHERE r.monitor_id = #{monitorId} AND r.deleted = 0 AND r.enabled = 1
+          AND m.project_id = #{projectId}) AS enabled_rule_count,
+      (SELECT COUNT(*) FROM yak_quality_execution e
+        WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}) AS execution_count,
+      (SELECT COUNT(*) FROM yak_quality_execution e
+        WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}
+          AND e.check_result IN ('NOT_PASSED', 'ERROR')) AS issue_execution_count,
+      (SELECT MAX(e.queued_at) FROM yak_quality_execution e
+        WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}) AS latest_execution_time
   </select>
 
   <select id="selectReportOverview" resultType="io.yak.ops.common.bean.po.quality.QualityQueryPO$ReportOverviewRow">
     SELECT
-      (SELECT COUNT(*) FROM yak_quality_rule r WHERE r.monitor_id = #{monitorId} AND r.deleted = 0) AS total_rules,
-      (SELECT COUNT(*) FROM yak_quality_rule r WHERE r.monitor_id = #{monitorId} AND r.deleted = 0 AND r.enabled = 1) AS enabled_rules,
+      (SELECT COUNT(*) FROM yak_quality_rule r
+        INNER JOIN yak_quality_monitor m ON m.id = r.monitor_id
+        WHERE r.monitor_id = #{monitorId} AND r.deleted = 0
+          AND m.project_id = #{projectId}) AS total_rules,
+      (SELECT COUNT(*) FROM yak_quality_rule r
+        INNER JOIN yak_quality_monitor m ON m.id = r.monitor_id
+        WHERE r.monitor_id = #{monitorId} AND r.deleted = 0 AND r.enabled = 1
+          AND m.project_id = #{projectId}) AS enabled_rules,
       COALESCE(SUM(CASE WHEN re.check_result &lt;&gt; 'NOT_RUN' THEN 1 ELSE 0 END), 0) AS executed_rules,
       COALESCE(SUM(CASE WHEN re.check_result = 'NOT_PASSED' THEN 1 ELSE 0 END), 0) AS issue_rules,
       COALESCE(SUM(CASE WHEN re.check_result = 'ERROR' THEN 1 ELSE 0 END), 0) AS error_rules,
       COALESCE(SUM(CASE WHEN re.check_result = 'PASSED' THEN 1 ELSE 0 END), 0) AS passed_rules
     FROM yak_quality_execution e
     LEFT JOIN yak_quality_rule_execution re ON re.execution_id = e.id
-    WHERE e.monitor_id = #{monitorId} AND e.queued_at &gt;= #{reportStart} AND e.queued_at &lt; #{reportEnd}
+    WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}
+      AND e.queued_at &gt;= #{reportStart} AND e.queued_at &lt; #{reportEnd}
   </select>
 
   <select id="selectDimensionReport" resultType="io.yak.ops.common.bean.po.quality.QualityQueryPO$DimensionReportRow">
@@ -339,8 +372,11 @@
       COALESCE(a.passed_count, 0) AS passed_count,
       COALESCE(a.not_passed_count, 0) AS not_passed_count,
       COALESCE(a.error_count, 0) AS error_count
-    FROM (SELECT DISTINCT COALESCE(NULLIF(quality_dimension, ''), '其他') AS dimension
-      FROM yak_quality_rule WHERE monitor_id = #{monitorId} AND deleted = 0) d
+    FROM (SELECT DISTINCT COALESCE(NULLIF(r.quality_dimension, ''), '其他') AS dimension
+      FROM yak_quality_rule r
+      INNER JOIN yak_quality_monitor m ON m.id = r.monitor_id
+      WHERE r.monitor_id = #{monitorId} AND r.deleted = 0
+        AND m.project_id = #{projectId}) d
     LEFT JOIN (
       SELECT COALESCE(NULLIF(r.quality_dimension, ''), '其他') AS dimension,
         SUM(CASE WHEN re.check_result &lt;&gt; 'NOT_RUN' THEN 1 ELSE 0 END) AS total_count,
@@ -350,7 +386,8 @@
       FROM yak_quality_rule_execution re
       JOIN yak_quality_execution e ON e.id = re.execution_id
       LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
-      WHERE e.monitor_id = #{monitorId} AND e.queued_at &gt;= #{reportStart} AND e.queued_at &lt; #{reportEnd}
+      WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}
+      AND e.queued_at &gt;= #{reportStart} AND e.queued_at &lt; #{reportEnd}
       GROUP BY COALESCE(NULLIF(r.quality_dimension, ''), '其他')) a ON a.dimension = d.dimension
     ORDER BY FIELD(d.dimension, '完整性', '准确性', '一致性', '唯一性', '时效性', '有效性'), d.dimension
   </select>
@@ -364,7 +401,8 @@
     FROM yak_quality_rule_execution re
     JOIN yak_quality_execution e ON e.id = re.execution_id
     LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
-    WHERE e.monitor_id = #{monitorId} AND e.queued_at &gt;= #{trendStart} AND e.queued_at &lt; #{reportEnd}
+    WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}
+      AND e.queued_at &gt;= #{trendStart} AND e.queued_at &lt; #{reportEnd}
     GROUP BY DATE(e.queued_at), COALESCE(NULLIF(r.quality_dimension, ''), '其他')
     ORDER BY report_date ASC, dimension ASC
   </select>
@@ -378,7 +416,8 @@
     FROM yak_quality_rule_execution re
     JOIN yak_quality_execution e ON e.id = re.execution_id
     LEFT JOIN yak_quality_rule r ON r.id = re.rule_id
-    WHERE e.monitor_id = #{monitorId} AND e.queued_at &gt;= #{reportStart} AND e.queued_at &lt; #{reportEnd}
+    WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}
+      AND e.queued_at &gt;= #{reportStart} AND e.queued_at &lt; #{reportEnd}
     GROUP BY COALESCE(NULLIF(re.column_name, ''), '表级'), COALESCE(NULLIF(r.quality_dimension, ''), '其他')
     ORDER BY issue_count DESC, column_name ASC
   </select>
@@ -387,8 +426,10 @@
     SELECT 1
       + CASE WHEN m.updated_at &gt; DATE_ADD(m.created_at, INTERVAL 1 SECOND) THEN 1 ELSE 0 END
       + (SELECT COUNT(*) FROM yak_quality_rule r WHERE r.monitor_id = m.id)
-      + (SELECT COUNT(*) FROM yak_quality_execution e WHERE e.monitor_id = m.id)
-    FROM yak_quality_monitor m WHERE m.id = #{monitorId} AND m.deleted = 0
+      + (SELECT COUNT(*) FROM yak_quality_execution e
+          WHERE e.project_id = #{projectId} AND e.monitor_id = m.id)
+    FROM yak_quality_monitor m
+    WHERE m.project_id = #{projectId} AND m.id = #{monitorId} AND m.deleted = 0
   </select>
 
   <select id="selectOperationLogs" resultType="io.yak.ops.common.bean.po.quality.QualityQueryPO$OperationLogRow">
@@ -401,11 +442,13 @@
           COALESCE(NULLIF(m.schema_name, ''), ''),
           CASE WHEN m.schema_name IS NULL OR m.schema_name = '' THEN '' ELSE '.' END,
           m.table_name) AS action_content
-      FROM yak_quality_monitor m WHERE m.id = #{monitorId} AND m.deleted = 0
+      FROM yak_quality_monitor m
+      WHERE m.project_id = #{projectId} AND m.id = #{monitorId} AND m.deleted = 0
       UNION ALL
       SELECT CONCAT('monitor-update-', m.id), m.owner, m.updated_at, 'UPDATE_MONITOR',
         CONCAT('更新质量监控「', m.monitor_name, '」的基础配置、运行设置或问题处理策略')
-      FROM yak_quality_monitor m WHERE m.id = #{monitorId} AND m.deleted = 0
+      FROM yak_quality_monitor m
+      WHERE m.project_id = #{projectId} AND m.id = #{monitorId} AND m.deleted = 0
         AND m.updated_at &gt; DATE_ADD(m.created_at, INTERVAL 1 SECOND)
       UNION ALL
       SELECT CONCAT('rule-', r.id), m.owner, r.created_at, 'SAVE_RULE',
@@ -413,12 +456,13 @@
           '，关联范围：', CASE WHEN r.rule_scope = 'TABLE' THEN '表级' ELSE '字段级' END,
           CASE WHEN r.column_name IS NULL OR r.column_name = '' THEN '' ELSE CONCAT('，字段：', r.column_name) END)
       FROM yak_quality_rule r JOIN yak_quality_monitor m ON m.id = r.monitor_id
-      WHERE r.monitor_id = #{monitorId}
+      WHERE m.project_id = #{projectId} AND r.monitor_id = #{monitorId}
       UNION ALL
       SELECT CONCAT('execution-', e.id), e.operator_name, e.queued_at, 'RUN_MONITOR',
         CONCAT('触发质量检查，执行编号：', e.execution_no,
           '，触发方式：', e.trigger_type, '，检查结果：', e.check_result)
-      FROM yak_quality_execution e WHERE e.monitor_id = #{monitorId}
+      FROM yak_quality_execution e
+      WHERE e.project_id = #{projectId} AND e.monitor_id = #{monitorId}
     ) logs
     ORDER BY operation_time DESC, log_id DESC LIMIT #{limit} OFFSET #{offset}
   </select>

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityWriteMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityWriteMapper.xml
@@ -4,16 +4,16 @@
 
   <select id="lockMonitor" resultType="long">
     SELECT id FROM yak_quality_monitor
-    WHERE id = #{monitorId} AND deleted = 0
+    WHERE project_id = #{projectId} AND id = #{monitorId} AND deleted = 0
     FOR UPDATE
   </select>
 
   <insert id="upsertTableAsset">
     INSERT INTO yak_quality_table_asset (
-      data_source_id, data_source_name, database_name, schema_name, table_name,
+      project_id, data_source_id, data_source_name, database_name, schema_name, table_name,
       table_type, remarks, registered_by, registered_at, deleted
     ) VALUES (
-      #{dataSourceId}, #{dataSourceName}, #{databaseName}, #{schemaName}, #{tableName},
+      #{projectId}, #{dataSourceId}, #{dataSourceName}, #{databaseName}, #{schemaName}, #{tableName},
       #{tableType}, #{remarks}, #{registeredBy}, CURRENT_TIMESTAMP(3), 0
     )
     ON DUPLICATE KEY UPDATE

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityProjectScopeContractTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityProjectScopeContractTest.java
@@ -1,0 +1,91 @@
+package io.yak.ops.business.quality.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Source-level guard for Quality Project Space persistence and background context propagation. */
+class QualityProjectScopeContractTest {
+
+  @Test
+  void migrationDerivesProjectWithoutGuessingDefaultId() throws IOException {
+    String migration = read(
+        "src/main/resources/db/migration/yak-quality/V6__add_quality_project_scope.sql");
+
+    assertThat(migration)
+        .contains(
+            "ADD COLUMN project_id BIGINT NULL",
+            "INNER JOIN yak_ops_data_source",
+            "MODIFY COLUMN project_id BIGINT NOT NULL",
+            "(project_id, data_source_id, database_name, schema_name, table_name)")
+        .doesNotContain("project_id = 1", "DEFAULT 1", "VALUES (1");
+  }
+
+  @Test
+  void projectOwnedQueriesCarryProjectPredicates() throws IOException {
+    String qualityQueries =
+        read("src/main/resources/mapper/quality/QualityQueryMapper.xml");
+    String overviewQueries =
+        read("src/main/resources/mapper/quality/QualityOverviewMapper.xml");
+
+    assertThat(qualityQueries)
+        .contains(
+            "m.project_id = #{projectId}",
+            "asset.project_id = #{projectId}",
+            "e.project_id = #{projectId}");
+    assertThat(overviewQueries)
+        .contains(
+            "m.project_id = #{projectId}",
+            "e.project_id = #{projectId}");
+  }
+
+  @Test
+  void executionAndScheduleRestorePersistedProject() throws IOException {
+    String plan = read(
+        "src/main/java/io/yak/ops/business/quality/domain/execution/QualityExecutionPlan.java");
+    String dispatcher = read(
+        "src/main/java/io/yak/ops/business/quality/execution/QualityExecutionDispatcher.java");
+    String schedule = read(
+        "src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridge.java");
+    String handler = read(
+        "src/main/java/io/yak/ops/business/quality/schedule/QualityScheduleHandler.java");
+
+    assertThat(plan).contains("long projectId");
+    assertThat(dispatcher)
+        .contains(
+            "new ProjectContext(plan.projectId(), null)",
+            "projectScope.run(project");
+    assertThat(schedule)
+        .contains(
+            "payload.put(\"projectId\", projectId)",
+            "metadata.put(\"projectId\", String.valueOf(projectId))");
+    assertThat(handler)
+        .contains(
+            "context.requiredLong(\"projectId\")",
+            "projectScope.call(");
+  }
+
+  private String read(String relative) throws IOException {
+    Path module = moduleRoot();
+    return Files.readString(module.resolve(relative), StandardCharsets.UTF_8);
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java/io/yak/ops/business/quality"))) {
+      return local;
+    }
+    Path repositoryRelative =
+        Path.of("yak-ops-business", "yak-ops-business-quality")
+            .toAbsolutePath()
+            .normalize();
+    assertThat(Files.isDirectory(repositoryRelative))
+        .as("Unable to locate Data Quality module root from %s", local)
+        .isTrue();
+    return repositoryRelative;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/controller/v1/QualityControllerProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/controller/v1/QualityControllerProjectScopeTest.java
@@ -1,0 +1,52 @@
+package io.yak.ops.business.quality.controller.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class QualityControllerProjectScopeTest {
+
+  @Test
+  void projectOwnedControllersRequireTrustedProjectContext() {
+    for (Class<?> controller : projectControllers()) {
+      ProjectScope scope = controller.getAnnotation(ProjectScope.class);
+      assertThat(scope)
+          .as("%s must declare ProjectScope", controller.getSimpleName())
+          .isNotNull();
+      assertThat(scope.value())
+          .as("%s must reject requests without Project context", controller.getSimpleName())
+          .isEqualTo(ProjectMigrationMode.PROJECT_REQUIRED);
+    }
+  }
+
+  @Test
+  void platformTemplateControllersRemainGlobal() {
+    for (Class<?> controller : globalControllers()) {
+      ProjectScope scope = controller.getAnnotation(ProjectScope.class);
+      assertThat(scope)
+          .as("%s must explicitly declare its global contract", controller.getSimpleName())
+          .isNotNull();
+      assertThat(scope.value())
+          .isEqualTo(ProjectMigrationMode.LEGACY_GLOBAL);
+    }
+  }
+
+  private List<Class<?>> projectControllers() {
+    return List.of(
+        QualityTableAssetController.class,
+        QualityMonitorController.class,
+        QualityExecutionController.class,
+        QualityExecutionWorkspaceController.class,
+        QualityOverviewController.class,
+        QualityWorkspaceController.class);
+  }
+
+  private List<Class<?>> globalControllers() {
+    return List.of(
+        QualityTemplateController.class,
+        CustomTemplateController.class);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/dao/impl/QualityExecutionDaoProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/dao/impl/QualityExecutionDaoProjectScopeTest.java
@@ -1,0 +1,101 @@
+package io.yak.ops.business.quality.dao.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.dao.mapper.QualityExecutionMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityQueryMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityRuleExecutionMapper;
+import io.yak.ops.common.bean.po.quality.QualityExecutionPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class QualityExecutionDaoProjectScopeTest {
+
+  @Test
+  void executionQueriesReceiveTrustedProjectId() {
+    Fixture fixture = fixture(7L);
+    when(fixture.queryMapper.countExecutions(any())).thenReturn(2L);
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put("monitorId", 42L);
+
+    assertThat(fixture.dao.countExecutions(params)).isEqualTo(2L);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+    verify(fixture.queryMapper).countExecutions(captor.capture());
+    assertThat(captor.getValue())
+        .containsEntry("projectId", 7L)
+        .containsEntry("monitorId", 42L);
+    assertThat(params).doesNotContainKey("projectId");
+  }
+
+  @Test
+  void executionInsertAlwaysUsesTrustedProject() {
+    Fixture fixture = fixture(7L);
+    doAnswer(
+            invocation -> {
+              QualityExecutionPO row = invocation.getArgument(0);
+              row.setId(11L);
+              return 1;
+            })
+        .when(fixture.executionMapper)
+        .insert(any(QualityExecutionPO.class));
+    QualityExecutionPO execution = new QualityExecutionPO();
+
+    assertThat(fixture.dao.insertExecution(execution)).isEqualTo(11L);
+    assertThat(execution.getProjectId()).isEqualTo(7L);
+  }
+
+  @Test
+  void callerCannotOverrideExecutionProject() {
+    Fixture fixture = fixture(7L);
+    QualityExecutionPO execution = new QualityExecutionPO();
+    execution.setProjectId(8L);
+
+    assertThatThrownBy(() -> fixture.dao.insertExecution(execution))
+        .isInstanceOf(ProjectContextException.class);
+  }
+
+  @Test
+  void executionDetailUsesProjectAndBusinessKeyTogether() {
+    Fixture fixture = fixture(7L);
+
+    fixture.dao.selectByExecutionNo("QM-TEST");
+
+    verify(fixture.executionMapper).selectOne(any());
+  }
+
+  private Fixture fixture(long projectId) {
+    QualityExecutionMapper executionMapper = mock(QualityExecutionMapper.class);
+    QualityRuleExecutionMapper ruleExecutionMapper =
+        mock(QualityRuleExecutionMapper.class);
+    QualityQueryMapper queryMapper = mock(QualityQueryMapper.class);
+    CurrentProject currentProject =
+        () -> Optional.of(new ProjectContext(projectId, "test-project"));
+    return new Fixture(
+        new QualityExecutionDaoImpl(
+            executionMapper,
+            ruleExecutionMapper,
+            queryMapper,
+            currentProject),
+        executionMapper,
+        queryMapper);
+  }
+
+  private record Fixture(
+      QualityExecutionDaoImpl dao,
+      QualityExecutionMapper executionMapper,
+      QualityQueryMapper queryMapper) {}
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/dao/impl/QualityMonitorDaoProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/dao/impl/QualityMonitorDaoProjectScopeTest.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.quality.dao.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.dao.mapper.QualityAlertEventMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityMonitorMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityMonitorSettingMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityQueryMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityRuleMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityTableAssetMapper;
+import io.yak.ops.business.quality.dao.mapper.QualityWriteMapper;
+import io.yak.ops.common.bean.po.quality.QualityMonitorPO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class QualityMonitorDaoProjectScopeTest {
+
+  @Test
+  void complexQueriesReceiveTrustedProjectId() {
+    Fixture fixture = fixture(7L);
+    when(fixture.queryMapper.countMonitors(any())).thenReturn(3L);
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put("keyword", "%orders%");
+
+    assertThat(fixture.dao.countMonitors(params)).isEqualTo(3L);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+    verify(fixture.queryMapper).countMonitors(captor.capture());
+    assertThat(captor.getValue())
+        .containsEntry("projectId", 7L)
+        .containsEntry("keyword", "%orders%");
+    assertThat(params).doesNotContainKey("projectId");
+  }
+
+  @Test
+  void monitorInsertAlwaysUsesTrustedProject() {
+    Fixture fixture = fixture(7L);
+    doAnswer(
+            invocation -> {
+              QualityMonitorPO row = invocation.getArgument(0);
+              row.setId(42L);
+              return 1;
+            })
+        .when(fixture.monitorMapper)
+        .insert(any(QualityMonitorPO.class));
+    QualityMonitorPO monitor = new QualityMonitorPO();
+
+    assertThat(fixture.dao.insertMonitor(monitor)).isEqualTo(42L);
+    assertThat(monitor.getProjectId()).isEqualTo(7L);
+  }
+
+  @Test
+  void callerCannotOverrideMonitorProject() {
+    Fixture fixture = fixture(7L);
+    QualityMonitorPO monitor = new QualityMonitorPO();
+    monitor.setProjectId(8L);
+
+    assertThatThrownBy(() -> fixture.dao.insertMonitor(monitor))
+        .isInstanceOf(ProjectContextException.class);
+  }
+
+  @Test
+  void monitorDetailUsesProjectAndIdTogether() {
+    Fixture fixture = fixture(7L);
+
+    fixture.dao.selectMonitor(42L);
+
+    verify(fixture.queryMapper).selectMonitor(7L, 42L);
+  }
+
+  private Fixture fixture(long projectId) {
+    QualityQueryMapper queryMapper = mock(QualityQueryMapper.class);
+    QualityWriteMapper writeMapper = mock(QualityWriteMapper.class);
+    QualityMonitorMapper monitorMapper = mock(QualityMonitorMapper.class);
+    QualityRuleMapper ruleMapper = mock(QualityRuleMapper.class);
+    QualityMonitorSettingMapper settingMapper = mock(QualityMonitorSettingMapper.class);
+    QualityTableAssetMapper tableAssetMapper = mock(QualityTableAssetMapper.class);
+    QualityAlertEventMapper alertMapper = mock(QualityAlertEventMapper.class);
+    CurrentProject currentProject =
+        () -> Optional.of(new ProjectContext(projectId, "test-project"));
+    return new Fixture(
+        new QualityMonitorDaoImpl(
+            queryMapper,
+            writeMapper,
+            monitorMapper,
+            ruleMapper,
+            settingMapper,
+            tableAssetMapper,
+            alertMapper,
+            currentProject),
+        queryMapper,
+        monitorMapper);
+  }
+
+  private record Fixture(
+      QualityMonitorDaoImpl dao,
+      QualityQueryMapper queryMapper,
+      QualityMonitorMapper monitorMapper) {}
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/execution/QualityExecutionDispatcherProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/execution/QualityExecutionDispatcherProjectScopeTest.java
@@ -1,0 +1,135 @@
+package io.yak.ops.business.quality.execution;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
+import io.yak.ops.business.quality.repository.QualityExecutionRepository;
+import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
+import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
+import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+class QualityExecutionDispatcherProjectScopeTest {
+
+  @Test
+  void workerRunsInsidePersistedProjectContext() {
+    QualityExecutionWorker worker = mock(QualityExecutionWorker.class);
+    QualityExecutionRepository executionRepository =
+        mock(QualityExecutionRepository.class);
+    QualityMonitorRepository monitorRepository =
+        mock(QualityMonitorRepository.class);
+    ThreadPoolTaskExecutor executor = mock(ThreadPoolTaskExecutor.class);
+    RecordingProjectScope projectScope = new RecordingProjectScope();
+    doAnswer(
+            invocation -> {
+              invocation.<Runnable>getArgument(0).run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class));
+
+    QualityExecutionPlan plan = plan(7L);
+    QualityExecutionDispatcher dispatcher =
+        new QualityExecutionDispatcher(
+            worker,
+            executionRepository,
+            monitorRepository,
+            executor,
+            projectScope);
+
+    dispatcher.dispatchAfterCommit(plan);
+
+    verify(worker).execute(plan);
+    org.assertj.core.api.Assertions.assertThat(projectScope.context.get().projectId())
+        .isEqualTo(7L);
+  }
+
+  @Test
+  void queueRejectionIsRecordedInsidePersistedProjectContext() {
+    QualityExecutionWorker worker = mock(QualityExecutionWorker.class);
+    QualityExecutionRepository executionRepository =
+        mock(QualityExecutionRepository.class);
+    QualityMonitorRepository monitorRepository =
+        mock(QualityMonitorRepository.class);
+    ThreadPoolTaskExecutor executor = mock(ThreadPoolTaskExecutor.class);
+    RecordingProjectScope projectScope = new RecordingProjectScope();
+    doThrow(new TaskRejectedException("full"))
+        .when(executor)
+        .execute(any(Runnable.class));
+
+    QualityExecutionPlan plan = plan(9L);
+    QualityExecutionDispatcher dispatcher =
+        new QualityExecutionDispatcher(
+            worker,
+            executionRepository,
+            monitorRepository,
+            executor,
+            projectScope);
+
+    dispatcher.dispatchAfterCommit(plan);
+
+    verify(executionRepository)
+        .failExecution(
+            org.mockito.ArgumentMatchers.eq(11L),
+            org.mockito.ArgumentMatchers.eq("质量执行队列已满"),
+            any(java.time.LocalDateTime.class),
+            org.mockito.ArgumentMatchers.eq(0L));
+    verify(monitorRepository)
+        .updateMonitorResult(
+            org.mockito.ArgumentMatchers.eq(42L),
+            org.mockito.ArgumentMatchers.eq("QM-TEST"),
+            org.mockito.ArgumentMatchers.eq(CheckResult.ERROR),
+            any(java.time.LocalDateTime.class));
+    org.assertj.core.api.Assertions.assertThat(projectScope.context.get().projectId())
+        .isEqualTo(9L);
+  }
+
+  private QualityExecutionPlan plan(long projectId) {
+    return new QualityExecutionPlan(
+        projectId,
+        11L,
+        "QM-TEST",
+        new MonitorSnapshot(
+            42L,
+            "orders-quality",
+            3L,
+            "mysql",
+            "demo",
+            null,
+            "orders",
+            null,
+            "owner"),
+        List.of(),
+        RuleFailureAction.CONTINUE,
+        false,
+        NotifyChannel.MESSAGE,
+        null,
+        AlertLevel.WARNING);
+  }
+
+  private static final class RecordingProjectScope
+      implements ProjectContextScope {
+    private final AtomicReference<ProjectContext> context =
+        new AtomicReference<>();
+
+    @Override
+    public <T> T call(ProjectContext project, Supplier<T> action) {
+      context.set(project);
+      return action.get();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridgeTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/schedule/QualityScheduleEngineBridgeTest.java
@@ -15,8 +15,11 @@ import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
 import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
 import io.yak.ops.common.enums.quality.QualityEnums.ScheduleFrequency;
 import io.yak.ops.common.enums.quality.QualityEnums.ScheduleWeekday;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 
@@ -27,20 +30,31 @@ class QualityScheduleEngineBridgeTest {
     @SuppressWarnings("unchecked")
     ObjectProvider<ScheduleManager> provider = mock(ObjectProvider.class);
     QualityScheduleEngineBridge bridge =
-        new QualityScheduleEngineBridge(provider, new QualityScheduleCalculator());
+        new QualityScheduleEngineBridge(
+            provider,
+            new QualityScheduleCalculator(),
+            currentProject(7L));
 
-    ScheduleDefinition definition = bridge.toDefinition(
-        monitor(true),
-        settings(ScheduleFrequency.DAILY, "09:05", null, null));
+    ScheduleDefinition definition =
+        bridge.toDefinition(
+            monitor(true),
+            settings(ScheduleFrequency.DAILY, "09:05", null, null));
 
     assertThat(definition.key().namespace()).isEqualTo("yak-ops-quality");
     assertThat(definition.key().name()).isEqualTo("42");
     assertThat(definition.trigger().expression()).isEqualTo("0 5 9 * * ?");
     assertThat(definition.trigger().zoneId()).isEqualTo(ZoneId.systemDefault());
     assertThat(definition.target().handler()).isEqualTo("qualityScheduleHandler");
-    assertThat(definition.target().payload()).containsEntry("monitorId", 42L);
-    assertThat(definition.policy().concurrencyPolicy()).isEqualTo(ConcurrencyPolicy.FORBID);
-    assertThat(definition.policy().misfirePolicy()).isEqualTo(MisfirePolicy.FIRE_ONCE_NOW);
+    assertThat(definition.target().payload())
+        .containsEntry("projectId", 7L)
+        .containsEntry("monitorId", 42L);
+    assertThat(definition.metadata())
+        .containsEntry("projectId", "7")
+        .containsEntry("monitorId", "42");
+    assertThat(definition.policy().concurrencyPolicy())
+        .isEqualTo(ConcurrencyPolicy.FORBID);
+    assertThat(definition.policy().misfirePolicy())
+        .isEqualTo(MisfirePolicy.FIRE_ONCE_NOW);
     assertThat(definition.policy().triggerRetries()).isZero();
     assertThat(definition.enabled()).isTrue();
   }
@@ -50,14 +64,26 @@ class QualityScheduleEngineBridgeTest {
     @SuppressWarnings("unchecked")
     ObjectProvider<ScheduleManager> provider = mock(ObjectProvider.class);
     QualityScheduleEngineBridge bridge =
-        new QualityScheduleEngineBridge(provider, new QualityScheduleCalculator());
+        new QualityScheduleEngineBridge(
+            provider,
+            new QualityScheduleCalculator(),
+            currentProject(7L));
 
-    ScheduleDefinition definition = bridge.toDefinition(
-        monitor(false),
-        settings(ScheduleFrequency.WEEKLY, "18:30", ScheduleWeekday.FRI, null));
+    ScheduleDefinition definition =
+        bridge.toDefinition(
+            monitor(false),
+            settings(
+                ScheduleFrequency.WEEKLY,
+                "18:30",
+                ScheduleWeekday.FRI,
+                null));
 
     assertThat(definition.trigger().expression()).isEqualTo("0 30 18 ? * FRI");
     assertThat(definition.enabled()).isFalse();
+  }
+
+  private CurrentProject currentProject(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "test-project"));
   }
 
   private Monitor monitor(boolean enabled) {

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/schedule/QualityScheduleHandlerProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/schedule/QualityScheduleHandlerProjectScopeTest.java
@@ -1,0 +1,154 @@
+package io.yak.ops.business.quality.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.schedule.api.ScheduleExecutionContext;
+import io.yak.framework.schedule.api.ScheduleExecutionResult;
+import io.yak.framework.schedule.api.ScheduleKey;
+import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
+import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
+import io.yak.ops.business.quality.execution.QualityExecutionManager;
+import io.yak.ops.business.quality.execution.QualityExecutionReceipt;
+import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
+import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
+import io.yak.ops.common.enums.quality.QualityEnums.ExecutionStatus;
+import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
+import io.yak.ops.common.enums.quality.QualityEnums.RunMode;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class QualityScheduleHandlerProjectScopeTest {
+
+  @Test
+  void schedulePayloadRestoresProjectBeforeReadingAndRunningMonitor() {
+    QualityMonitorRepository repository = mock(QualityMonitorRepository.class);
+    QualityExecutionManager executionManager = mock(QualityExecutionManager.class);
+    QualityScheduleEngineBridge engine = mock(QualityScheduleEngineBridge.class);
+    QualityScheduleLifecycle lifecycle = mock(QualityScheduleLifecycle.class);
+    RecordingProjectScope projectScope = new RecordingProjectScope();
+    when(repository.findMonitor(42L)).thenReturn(Optional.of(monitor()));
+    when(repository.findMonitorSettings(42L)).thenReturn(settings());
+    when(executionManager.runScheduled(42L))
+        .thenReturn(
+            new QualityExecutionReceipt(
+                "QM-TEST",
+                ExecutionStatus.WAITING,
+                CheckResult.RUNNING));
+    QualityScheduleHandler handler =
+        new QualityScheduleHandler(
+            repository,
+            executionManager,
+            engine,
+            lifecycle,
+            projectScope);
+
+    ScheduleExecutionResult result = handler.execute(context(7L, 42L));
+
+    assertThat(result.accepted()).isTrue();
+    assertThat(result.businessExecutionId()).isEqualTo("QM-TEST");
+    assertThat(projectScope.context.get().projectId()).isEqualTo(7L);
+    verify(repository).findMonitor(42L);
+    verify(executionManager).runScheduled(42L);
+    verify(lifecycle).refreshRuntimeState(42L);
+  }
+
+  @Test
+  void invisibleMonitorDoesNotDeleteAnotherProjectsSchedule() {
+    QualityMonitorRepository repository = mock(QualityMonitorRepository.class);
+    QualityExecutionManager executionManager = mock(QualityExecutionManager.class);
+    QualityScheduleEngineBridge engine = mock(QualityScheduleEngineBridge.class);
+    QualityScheduleLifecycle lifecycle = mock(QualityScheduleLifecycle.class);
+    RecordingProjectScope projectScope = new RecordingProjectScope();
+    when(repository.findMonitor(42L)).thenReturn(Optional.empty());
+    QualityScheduleHandler handler =
+        new QualityScheduleHandler(
+            repository,
+            executionManager,
+            engine,
+            lifecycle,
+            projectScope);
+
+    ScheduleExecutionResult result = handler.execute(context(8L, 42L));
+
+    assertThat(result.accepted()).isTrue();
+    assertThat(projectScope.context.get().projectId()).isEqualTo(8L);
+    verify(engine, never()).deleteIfPresent(42L);
+    verify(executionManager, never()).runScheduled(42L);
+  }
+
+  private ScheduleExecutionContext context(long projectId, long monitorId) {
+    Instant now = Instant.now();
+    return new ScheduleExecutionContext(
+        "trigger-test",
+        new ScheduleKey("yak-ops-quality", String.valueOf(monitorId)),
+        "test",
+        QualityScheduleEngineBridge.HANDLER,
+        Map.of("projectId", projectId, "monitorId", monitorId),
+        now,
+        now,
+        false,
+        1);
+  }
+
+  private Monitor monitor() {
+    return new Monitor(
+        42L,
+        "orders-quality",
+        null,
+        3L,
+        "mysql",
+        "demo",
+        null,
+        "orders",
+        null,
+        "owner",
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        List.of());
+  }
+
+  private MonitorSettings settings() {
+    return new MonitorSettings(
+        RunMode.SCHEDULE,
+        null,
+        null,
+        null,
+        "0 0 0 * * ?",
+        null,
+        RuleFailureAction.CONTINUE,
+        false,
+        NotifyChannel.MESSAGE,
+        null,
+        AlertLevel.WARNING);
+  }
+
+  private static final class RecordingProjectScope
+      implements ProjectContextScope {
+    private final AtomicReference<ProjectContext> context =
+        new AtomicReference<>();
+
+    @Override
+    public <T> T call(ProjectContext project, Supplier<T> action) {
+      context.set(project);
+      return action.get();
+    }
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityExecutionPO.java
@@ -11,6 +11,7 @@ import lombok.Data;
 public class QualityExecutionPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private String executionNo;
   private Long monitorId;
   private String monitorName;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityMonitorPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityMonitorPO.java
@@ -11,6 +11,7 @@ import lombok.Data;
 public class QualityMonitorPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private String monitorName;
   private String description;
   private Long dataSourceId;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityTableAssetPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityTableAssetPO.java
@@ -11,6 +11,7 @@ import lombok.Data;
 public class QualityTableAssetPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private Long dataSourceId;
   private String dataSourceName;
   private String databaseName;

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -39,6 +39,10 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/realtime-sync/11')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/realtime-sync/11/events')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/workflows/definitions')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/table-asset/page')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/monitor/42')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/execution/page')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/overview')).toBe('PROJECT_REQUIRED');
   });
 
   it('keeps platform capabilities, public runtimes and engine health global', () => {
@@ -50,6 +54,10 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/job/batch-execution/health')).toBe('LEGACY_GLOBAL');
     expect(resolveProjectRequestMode('/api/v1/executor/health')).toBe('LEGACY_GLOBAL');
     expect(resolveProjectRequestMode('/api/v1/compute-environments')).toBe('LEGACY_GLOBAL');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/template')).toBe('LEGACY_GLOBAL');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/template/42')).toBe('LEGACY_GLOBAL');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/template/custom')).toBe('LEGACY_GLOBAL');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/template/folder')).toBe('LEGACY_GLOBAL');
   });
 
   it('keeps unrelated global capabilities outside the rollout table', () => {
@@ -59,6 +67,7 @@ describe('Project Space request context', () => {
   it('uses the most specific project-aware route rule', () => {
     expect(resolveProjectRequestMode('/api/v1/data-source/1', rules)).toBe('PROJECT_OPTIONAL');
     expect(resolveProjectRequestMode('/api/v1/data-source/admin/1', rules)).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/data-quality/template/1')).toBe('LEGACY_GLOBAL');
   });
 
   it('never attaches a project header to a legacy-global route', () => {
@@ -67,6 +76,7 @@ describe('Project Space request context', () => {
     expect(applyCurrentProjectHeader('/api/v1/resources/storage-plugins', {}, '7')).toEqual({});
     expect(applyCurrentProjectHeader('/api/v1/data-service/runtime/orders', {}, '7')).toEqual({});
     expect(applyCurrentProjectHeader('/api/v1/job/batch-execution/health', {}, '7')).toEqual({});
+    expect(applyCurrentProjectHeader('/api/v1/data-quality/template/custom', {}, '7')).toEqual({});
   });
 
   it('attaches the stored project to required management routes', () => {
@@ -86,12 +96,16 @@ describe('Project Space request context', () => {
       '/api/v1/realtime-sync/42',
       '/api/v1/realtime-sync/42/observability',
       '/api/v1/workflows/definitions',
+      '/api/v1/data-quality/table-asset/page',
+      '/api/v1/data-quality/monitor/42',
+      '/api/v1/data-quality/execution/page',
+      '/api/v1/data-quality/overview',
     ]) {
       expect(applyCurrentProjectHeader(url, {})).toEqual({ [PROJECT_ID_HEADER]: '7' });
     }
   });
 
-  it('still attaches the stored project to optional Task Catalog routes', () => {
+  it('still attaches the stored project to optional migrated routes', () => {
     storeProjectId(7);
     expect(applyCurrentProjectHeader('/api/v1/task-catalog/assets', {})).toEqual({
       [PROJECT_ID_HEADER]: '7',

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -40,6 +40,9 @@ export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
   { prefix: '/api/v1/compute-environments', mode: 'LEGACY_GLOBAL' },
   { prefix: '/api/v1/realtime-sync', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/workflows', mode: 'PROJECT_REQUIRED' },
+  // Rule templates remain platform-global; monitor, execution and reports are Project-owned.
+  { prefix: '/api/v1/data-quality/template', mode: 'LEGACY_GLOBAL' },
+  { prefix: '/api/v1/data-quality', mode: 'PROJECT_REQUIRED' },
 ];
 
 const normalizePath = (url: string): string => {


### PR DESCRIPTION
## 背景

完成 Stage 8.2，将 Data Quality 纳入 Project Space 强隔离。TableAsset、Monitor、Execution 成为显式 Project 事实；Rule、Settings、RuleExecution、Alert 通过父事实继承归属；内置/自定义模板库继续保持平台全局能力。

## 完成内容

- 为 `yak_quality_table_asset`、`yak_quality_monitor`、`yak_quality_execution` 增加并收紧 `project_id`
- 从已项目化 Datasource 确定性回填 TableAsset/Monitor，再从 Monitor 回填 Execution；不猜测默认 Project ID
- Monitor、Execution、Workspace、Overview、复杂 MyBatis 查询全部使用 trusted `CurrentProject` fail closed
- 子事实写入前重新证明所属 Monitor/Execution 属于当前 Project
- `QualityExecutionPlan` 冻结 `projectId`，after-commit Worker 与 queue rejection 补偿通过 `ProjectContextScope` 恢复上下文
- Schedule payload/metadata 持久化 `projectId`，callback 和 startup recovery 按 Project 恢复普通 Quality 调用链
- Quality 项目数据 Controller 切换为 `@ProjectScope`；模板 Controller 显式保持 `LEGACY_GLOBAL`
- 前端 `/api/v1/data-quality/template` 保持全局，其余 `/api/v1/data-quality/**` 切换为 `PROJECT_REQUIRED`
- 增加 DAO 隔离、异步上下文、Schedule、Controller 契约和迁移/SQL source-level guard，并补充 `PROJECT_SPACE.md`

## 迁移策略

采用 Expand → deterministic Backfill → Contract：

1. nullable 增加 `project_id`
2. 按 Datasource / Monitor 真实归属回填
3. 将 `project_id` 收紧为 `NOT NULL`
4. 唯一索引与核心查询索引增加 Project 前缀

迁移不包含 `project_id = 1` 或其他默认空间猜测。存在孤立 Quality 数据时，`NOT NULL` contract 会阻止部署继续。

## 验证

- [x] 三个 MyBatis XML 与 Quality POM 可解析
- [x] `projectContext.ts` / `projectContext.test.ts` 通过 TypeScript strict compile
- [x] 43 个待提交文件的本地 Git blob SHA 与 GitHub blob SHA 全量一致
- [x] 迁移、Project predicate、异步/Schedule 上下文与 Quality code-style 静态检查通过
- [x] 分支已重新叠到最新 `main`，当前 ahead 1 / behind 0
- [ ] Maven/JUnit 全量测试待 CI 执行（当前执行环境没有完整仓库 checkout，且外网不可用）

## Review Focus

- V6 orphan data 的 fail-fast 策略是否符合上线准备
- startup recovery 的系统级 `(projectId, monitorId)` 扫描 corridor
- Rule/Settings/RuleExecution/Alert 的父归属证明与查询成本
- 全局模板库与其余 Quality API 的 rollout 分界
