### PR TITLE
feat(bi): complete Stage 8.3 Project Space isolation

### DIFF
--- a/docs/architecture/STAGE8_3_ANALYSIS_DASHBOARD_DIGITAL_SCREEN_PROJECT_SPACE.md
+++ b/docs/architecture/STAGE8_3_ANALYSIS_DASHBOARD_DIGITAL_SCREEN_PROJECT_SPACE.md
@@ -1,0 +1,82 @@
+# Stage 8.3: Analysis / Dashboard / Digital Screen Project Space
+
+## Scope
+
+This stage moves the three BI definition planes to `PROJECT_REQUIRED` management semantics:
+
+- `yak_analysis` is a `PROJECT_ROOT`; its Dataset reference must resolve in the current Project.
+- `yak_dashboard` is a `PROJECT_ROOT`; DashboardVersion, Widget, Filter, Binding and Interaction
+  inherit ownership through `dashboard_id`.
+- `yak_digital_screen` is a `PROJECT_ROOT`; immutable publication versions inherit ownership
+  through `screen_id`.
+
+The server derives ownership only from trusted `CurrentProject`. Request DTOs do not own or
+override `projectId`, and cross-Project IDs fail closed as not found in the current workspace.
+
+## Migration rules
+
+All migrations follow Expand -> deterministic Backfill -> Contract and never use Project `0`,
+Project `1`, the first Project, or another guessed default.
+
+### Analysis
+
+`yak_analysis.project_id` is deterministically copied from its referenced, already-contracted
+`yak_dataset.project_id`. Orphan Analysis rows stay `NULL`, so the subsequent `NOT NULL` contract
+blocks the upgrade.
+
+### Dashboard
+
+Historical Dashboard ownership is accepted only when every explicit reference resolves and all
+references agree on one Project. Evidence includes:
+
+- `yak_dashboard_version.active_dataset_id`;
+- reusable `yak_dashboard_widget.analysis_id`;
+- `inline_analysis_json.datasetId` when present.
+
+Dashboards with no evidence, unresolved references or mixed-Project evidence remain `NULL` and
+block the contract migration. This is deliberate: an empty Dashboard has no trustworthy historic
+owner that can be inferred from the current schema.
+
+### Digital Screen
+
+Template bindings are opaque JSON and do not provide one stable ownership contract. The expand
+migration therefore performs no automatic backfill. Existing installations must explicitly assign
+historical rows after inspecting business ownership; the `NOT NULL` migration intentionally fails
+until that work is complete.
+
+Useful preflight queries:
+
+```sql
+SELECT id, dataset_id FROM yak_analysis WHERE project_id IS NULL;
+SELECT id, name FROM yak_dashboard WHERE project_id IS NULL;
+SELECT id, name, template_id FROM yak_digital_screen WHERE project_id IS NULL;
+```
+
+No migration in this stage updates those rows to a hard-coded Project.
+
+## Runtime isolation
+
+- Analysis CRUD always includes `project_id` and its Dataset gateway uses Dataset's scoped reader.
+- Dashboard root CRUD, overview aggregation and Analysis-reference guards include `project_id`.
+- Dashboard child reads and writes first prove that the parent Dashboard belongs to the current
+  Project.
+- Active Dataset, reusable Analysis and inline Analysis Dataset references are validated through
+  owner-defined gateways in the current Project.
+- Digital Screen root CRUD includes `project_id`; version reads prove the owning Screen before
+  returning inherited rows.
+
+Analysis and Dashboard after-commit lineage events freeze `projectId` in the event payload and use
+`ProjectContextScope` before reading source state or updating derived lineage. They never depend on
+an HTTP ThreadLocal surviving beyond the request boundary.
+
+## HTTP rollout
+
+The following management prefixes are `PROJECT_REQUIRED` and receive
+`X-YAK-SECURITY-PROJECT-ID` from the shared console request interceptor:
+
+- `/api/v1/analyses`
+- `/api/v1/dashboards`
+- `/api/v1/digital-screens`
+
+This stage does not introduce a new anonymous Digital Screen runtime route. The existing published
+snapshot endpoints remain part of the authenticated, project-owned management API.

--- a/yak-ops-business/yak-ops-business-analysis/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-analysis/ARCHITECTURE.md
@@ -1,12 +1,10 @@
 # Analysis Architecture
 
-## 1. Purpose
+## Purpose
 
-Analysis 是 reusable analytical definition control plane，不是 query execution runtime。
+Analysis is a Project-owned reusable analytical-definition control plane, not a query execution runtime. Definition, query semantics, visualization, Dataset binding, references, Lineage projection and persistence retain explicit roles.
 
-架构目标：让 Definition、Query Semantics、Visualization、Dataset Binding、Reference、Lineage Projection 和 Persistence 各自拥有明确角色。
-
-## 2. Package Map
+## Package map
 
 ```text
 io.yak.ops.business.analysis
@@ -16,7 +14,7 @@ io.yak.ops.business.analysis
 ├── controller/v1
 │   ├── dto
 │   ├── vo
-│   └── mapper
+│   └── converter
 ├── definition
 ├── domain
 ├── query
@@ -32,153 +30,67 @@ io.yak.ops.business.analysis
 └── config
 ```
 
-根 package 的三个 public type 是稳定兼容边界。新的实现角色必须进入明确 subsystem。
+The root public types remain compatibility boundaries. New implementation roles belong to a named subsystem.
 
-## 3. Stable Facades
+## Stable facades
 
-### AnalysisService
+`AnalysisService` delegates use cases to `AnalysisManager` and `AnalysisReader`. `AnalysisReferenceService` exposes only narrow existence validation for downstream modules. `AnalysisDeletionGuard` is the stable extension point used by owners such as Dashboard.
 
-保留给 HTTP 与已有 application caller：
-
-```text
-AnalysisService
-    -> AnalysisManager
-    -> AnalysisReader
-```
-
-它不拥有另一套 lifecycle，不直接依赖 Repository/DAO/Dataset/Lineage。
-
-### AnalysisReferenceService
-
-提供下游模块最小引用能力：
+## Definition flow
 
 ```text
-requireExists(analysisId)
+HTTP @ProjectScope
+ -> AnalysisService
+ -> AnalysisManager
+ -> AnalysisDefinitionNormalizer
+ -> AnalysisDatasetGateway
+ -> persist with trusted CurrentProject.projectId
+ -> publish AnalysisChangedEvent(projectId, analysisId)
 ```
 
-Dashboard 不需要通过完整 AnalysisService 获取内部定义来做引用校验。
+Create/update normalize query and visual semantics and validate the Dataset through the owner-defined gateway. Delete runs every guard before removing metadata. No request field owns Project identity.
 
-### AnalysisDeletionGuard
-
-稳定 cross-domain extension point。Dashboard 等 owner 可以阻止删除仍被引用的 Analysis。
-
-## 4. Definition
-
-`definition` 拥有当前 Analysis command/read lifecycle：
-
-```text
-AnalysisManager
-AnalysisReader
-AnalysisDefinitionNormalizer
-AnalysisSaveCommand
-AnalysisChangedEvent
-```
-
-Create/update 流程：
-
-```text
-validate command
-    -> normalize query
-    -> normalize visual config
-    -> validate Dataset binding
-    -> persist current definition
-    -> publish AnalysisChangedEvent
-```
-
-Delete 流程：
-
-```text
-require current Analysis
-    -> deletion guards
-    -> delete metadata
-    -> publish deleted fact
-```
-
-## 5. Query And Visualization
-
-`query` 只表达 declarative analysis semantics 和标准化角色。
-
-```text
-AnalysisQueryNormalizer
-    -> AnalysisChartBindingPolicy
-```
-
-`visualization` 拥有 chart type、chart binding constraint 和 chart-local visual defaults。
-
-没有 Analysis Runtime/Engine package；真正查询 Dataset 的能力不在本模块。
-
-## 6. Dataset Boundary
-
-Analysis-owned Port：
+## Dataset boundary
 
 ```text
 AnalysisDatasetGateway
+ -> DatasetAnalysisAdapter
+ -> DatasetBindingPolicy
 ```
 
-Adapter：
+Only the adapter knows Dataset implementation APIs. Because Dataset binding is Project-scoped, the reference must belong to the current Project in addition to satisfying Dataset's ONLINE/current-schema contract.
 
-```text
-DatasetAnalysisAdapter
-    -> DatasetBindingPolicy
-```
-
-只有 adapter 可以理解 Dataset 模块的具体 API。Definition 只依赖自己的 Gateway。
-
-## 7. Reference Boundary
-
-```text
-AnalysisReferenceService
-    -> AnalysisReferenceReader
-    -> AnalysisReader
-```
-
-Reference 是窄 read-side，不产生 mutation。
-
-## 8. Lineage Projection
-
-```text
-AnalysisChangedEvent
-    -> AnalysisLineageRefreshListener   (AFTER_COMMIT)
-    -> AnalysisLineageSynchronizer      (REQUIRES_NEW)
-    -> AnalysisLineageGraphGateway
-    -> LineageAnalysisAdapter
-    -> shared Lineage module
-```
-
-`AnalysisFieldUsageExtractor` 负责把 QuerySpec 转成稳定 usage evidence。
-
-Synchronizer 只依赖 Analysis-owned gateway，不依赖 LineageService、LineageMaintenanceService、LineageAsset 或 ObjectMapper。
-
-## 9. Persistence
+## Persistence
 
 ```text
 Definition / Reader
-    -> AnalysisRepository
-    -> AnalysisRepositoryAdapter
-    -> AnalysisDao
-    -> AnalysisMapper / AnalysisPO
-    -> MySQL
+ -> AnalysisRepository
+ -> AnalysisRepositoryAdapter
+ -> AnalysisDao
+ -> AnalysisMapper / AnalysisPO
 ```
 
-`AnalysisJsonCodec` 位于 `repository/codec`，负责 JSON column representation。
+`yak_analysis` is a Project root. DAO insert stores `CurrentProject.requireProjectId()` and all reads/updates/deletes include the same trusted predicate. `AnalysisJsonCodec` alone owns JSON-column representation.
 
-Application/Domain 不读取或写入 `query_spec_json` / `visual_config_json` 字符串。
+## Lineage projection
 
-## 10. Infrastructure Dependency
+```text
+AnalysisChangedEvent(projectId, analysisId)
+ -> AFTER_COMMIT listener
+ -> ProjectContextScope
+ -> AnalysisLineageSynchronizer (REQUIRES_NEW)
+ -> AnalysisLineageGraphGateway
+ -> LineageAnalysisAdapter
+```
 
-Analysis 复用业务 DataSource 与 `ConditionalOnDataSourceEnabled` 等基础设施 wiring；这不表示 Analysis 拥有 Datasource 业务领域。
+The listener restores the frozen Project before reading Analysis state or updating derived graph evidence. Projection failure is logged and cannot roll back committed Analysis truth.
 
-`AnalysisPersistenceConfiguration` 当前仍依赖 Dataset Flyway 初始化顺序，这是部署/初始化约束，不是 Dataset truth ownership。
+## Dependency and stereotype rules
 
-## 11. Stereotypes
+Controller enters only through stable facades. Definition reaches Dataset and Lineage only through Analysis-owned ports. Domain/query/visualization values do not depend on Spring, HTTP, MyBatis or external business implementations.
 
-- `@Service`：仅稳定 `AnalysisService` / `AnalysisReferenceService`；
-- `@Component`：Manager、Reader、Normalizer、Policy、Collector、Extractor、Synchronizer、Gateway Adapter、Codec、HTTP Mapper；
-- `@Repository`：Repository/DAO persistence adapter；
-- Domain/value object：不使用 Spring stereotype。
+`@Service` is reserved for stable facades; explicit internal roles use `@Component`; persistence adapters use `@Repository`.
 
-## 12. Compatibility Rule
+## Compatibility
 
-架构重构默认保持 REST、DB、Dataset binding、Dashboard reference、Lineage evidence 和 query semantic 行为。
-
-如果要新增 Analysis Version、Execution 或 Runtime，必须作为独立领域设计，而不是扩张现有 Manager/Normalizer。
+REST paths, request/response fields, Dataset binding semantics, Dashboard reference guards, Lineage evidence and query semantics remain stable. Analysis Version, execution, result cache and runtime remain explicit non-goals until separately designed.

--- a/yak-ops-business/yak-ops-business-analysis/pom.xml
+++ b/yak-ops-business/yak-ops-business-analysis/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/controller/v1/AnalysisController.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/controller/v1/AnalysisController.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.analysis.controller.v1.converter.AnalysisRequestConve
 import io.yak.ops.business.analysis.controller.v1.converter.AnalysisViewConverter;
 import io.yak.ops.business.analysis.controller.v1.dto.AnalysisRequests.SaveAnalysisRequest;
 import io.yak.ops.business.analysis.controller.v1.vo.AnalysisViews;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "BI 图表分析接口")
 @Validated
 @RestController
+@ProjectScope
 @RequestMapping("/api/v1/analyses")
 public class AnalysisController {
 

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/dao/impl/AnalysisDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/dao/impl/AnalysisDaoImpl.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.analysis.dao.AnalysisDao;
 import io.yak.ops.business.analysis.dao.mapper.AnalysisMapper;
 import io.yak.ops.business.analysis.dao.model.AnalysisPO;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.project.CurrentProject;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
@@ -18,14 +19,17 @@ import org.springframework.stereotype.Repository;
 public class AnalysisDaoImpl implements AnalysisDao {
 
   private final AnalysisMapper mapper;
+  private final CurrentProject currentProject;
 
-  public AnalysisDaoImpl(AnalysisMapper mapper) {
+  public AnalysisDaoImpl(AnalysisMapper mapper, CurrentProject currentProject) {
     this.mapper = mapper;
+    this.currentProject = currentProject;
   }
 
   @Override
   public long insert(AnalysisPO value) {
     Timestamp now = Timestamp.from(Instant.now());
+    value.setProjectId(projectId());
     value.setCreateTime(now);
     value.setUpdateTime(now);
     if (mapper.insert(value) != 1 || value.getId() == null) {
@@ -36,34 +40,53 @@ public class AnalysisDaoImpl implements AnalysisDao {
 
   @Override
   public void update(long analysisId, AnalysisPO value) {
-    int updated = mapper.update(null, Wrappers.<AnalysisPO>lambdaUpdate()
-        .set(AnalysisPO::getName, value.getName())
-        .set(AnalysisPO::getDescription, value.getDescription())
-        .set(AnalysisPO::getDatasetId, value.getDatasetId())
-        .set(AnalysisPO::getChartType, value.getChartType())
-        .set(AnalysisPO::getQuerySpecJson, value.getQuerySpecJson())
-        .set(AnalysisPO::getVisualConfigJson, value.getVisualConfigJson())
-        .set(AnalysisPO::getUpdateTime, Timestamp.from(Instant.now()))
-        .eq(AnalysisPO::getId, analysisId));
-    if (updated != 1) throw new IllegalArgumentException("Analysis 不存在：" + analysisId);
+    int updated = mapper.update(
+        null,
+        Wrappers.<AnalysisPO>lambdaUpdate()
+            .eq(AnalysisPO::getProjectId, projectId())
+            .eq(AnalysisPO::getId, analysisId)
+            .set(AnalysisPO::getName, value.getName())
+            .set(AnalysisPO::getDescription, value.getDescription())
+            .set(AnalysisPO::getDatasetId, value.getDatasetId())
+            .set(AnalysisPO::getChartType, value.getChartType())
+            .set(AnalysisPO::getQuerySpecJson, value.getQuerySpecJson())
+            .set(AnalysisPO::getVisualConfigJson, value.getVisualConfigJson())
+            .set(AnalysisPO::getUpdateTime, Timestamp.from(Instant.now())));
+    if (updated != 1) throw notFound(analysisId);
   }
 
   @Override
   public Optional<AnalysisPO> findById(long analysisId) {
-    return Optional.ofNullable(mapper.selectById(analysisId));
+    return Optional.ofNullable(
+        mapper.selectOne(
+            Wrappers.<AnalysisPO>lambdaQuery()
+                .eq(AnalysisPO::getProjectId, projectId())
+                .eq(AnalysisPO::getId, analysisId)));
   }
 
   @Override
   public List<AnalysisPO> list() {
-    return mapper.selectList(Wrappers.<AnalysisPO>lambdaQuery()
-        .orderByDesc(AnalysisPO::getUpdateTime)
-        .orderByDesc(AnalysisPO::getId));
+    return mapper.selectList(
+        Wrappers.<AnalysisPO>lambdaQuery()
+            .eq(AnalysisPO::getProjectId, projectId())
+            .orderByDesc(AnalysisPO::getUpdateTime)
+            .orderByDesc(AnalysisPO::getId));
   }
 
   @Override
   public void delete(long analysisId) {
-    if (mapper.deleteById(analysisId) != 1) {
-      throw new IllegalArgumentException("Analysis 不存在：" + analysisId);
-    }
+    int deleted = mapper.delete(
+        Wrappers.<AnalysisPO>lambdaQuery()
+            .eq(AnalysisPO::getProjectId, projectId())
+            .eq(AnalysisPO::getId, analysisId));
+    if (deleted != 1) throw notFound(analysisId);
+  }
+
+  private long projectId() {
+    return currentProject.requireProjectId();
+  }
+
+  private IllegalArgumentException notFound(long analysisId) {
+    return new IllegalArgumentException("Analysis 不存在：" + analysisId);
   }
 }

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/dao/model/AnalysisPO.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/dao/model/AnalysisPO.java
@@ -12,6 +12,7 @@ public class AnalysisPO {
 
   @TableId(value = "id", type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private String name;
   private String description;
   private Long datasetId;

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/definition/AnalysisChangedEvent.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/definition/AnalysisChangedEvent.java
@@ -1,17 +1,18 @@
 package io.yak.ops.business.analysis.definition;
 
 /** Committed Analysis mutation fact consumed by derived projections such as lineage. */
-public record AnalysisChangedEvent(long analysisId, boolean deleted) {
+public record AnalysisChangedEvent(long projectId, long analysisId, boolean deleted) {
 
   public AnalysisChangedEvent {
+    if (projectId <= 0L) throw new IllegalArgumentException("projectId 必须大于 0");
     if (analysisId <= 0L) throw new IllegalArgumentException("analysisId 必须大于 0");
   }
 
-  public static AnalysisChangedEvent refreshed(long analysisId) {
-    return new AnalysisChangedEvent(analysisId, false);
+  public static AnalysisChangedEvent refreshed(long projectId, long analysisId) {
+    return new AnalysisChangedEvent(projectId, analysisId, false);
   }
 
-  public static AnalysisChangedEvent deleted(long analysisId) {
-    return new AnalysisChangedEvent(analysisId, true);
+  public static AnalysisChangedEvent deleted(long projectId, long analysisId) {
+    return new AnalysisChangedEvent(projectId, analysisId, true);
   }
 }

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/definition/AnalysisManager.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/definition/AnalysisManager.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.analysis.AnalysisDeletionGuard;
 import io.yak.ops.business.analysis.domain.AnalysisAsset;
 import io.yak.ops.business.analysis.domain.AnalysisDefinition;
 import io.yak.ops.business.analysis.repository.AnalysisRepository;
+import io.yak.ops.core.project.CurrentProject;
 import java.util.List;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ public class AnalysisManager {
   private final AnalysisRepository repository;
   private final AnalysisDefinitionNormalizer normalizer;
   private final AnalysisReader reader;
+  private final CurrentProject currentProject;
   private final ApplicationEventPublisher events;
   private final List<AnalysisDeletionGuard> deletionGuards;
 
@@ -23,39 +25,44 @@ public class AnalysisManager {
       AnalysisRepository repository,
       AnalysisDefinitionNormalizer normalizer,
       AnalysisReader reader,
+      CurrentProject currentProject,
       ApplicationEventPublisher events,
       List<AnalysisDeletionGuard> deletionGuards) {
     this.repository = repository;
     this.normalizer = normalizer;
     this.reader = reader;
+    this.currentProject = currentProject;
     this.events = events;
     this.deletionGuards = deletionGuards == null ? List.of() : List.copyOf(deletionGuards);
   }
 
   @Transactional("yakBusinessTransactionManager")
   public AnalysisAsset create(AnalysisSaveCommand command) {
+    long projectId = currentProject.requireProjectId();
     AnalysisDefinition definition = normalizer.normalize(command);
     long analysisId = repository.insert(definition);
-    events.publishEvent(AnalysisChangedEvent.refreshed(analysisId));
+    events.publishEvent(AnalysisChangedEvent.refreshed(projectId, analysisId));
     return reader.require(analysisId);
   }
 
   @Transactional("yakBusinessTransactionManager")
   public AnalysisAsset update(long analysisId, AnalysisSaveCommand command) {
+    long projectId = currentProject.requireProjectId();
     AnalysisReader.requireAnalysisId(analysisId);
     reader.require(analysisId);
     AnalysisDefinition definition = normalizer.normalize(command);
     repository.update(analysisId, definition);
-    events.publishEvent(AnalysisChangedEvent.refreshed(analysisId));
+    events.publishEvent(AnalysisChangedEvent.refreshed(projectId, analysisId));
     return reader.require(analysisId);
   }
 
   @Transactional("yakBusinessTransactionManager")
   public void delete(long analysisId) {
+    long projectId = currentProject.requireProjectId();
     AnalysisReader.requireAnalysisId(analysisId);
     reader.require(analysisId);
     deletionGuards.forEach(guard -> guard.requireDeletable(analysisId));
     repository.delete(analysisId);
-    events.publishEvent(AnalysisChangedEvent.deleted(analysisId));
+    events.publishEvent(AnalysisChangedEvent.deleted(projectId, analysisId));
   }
 }

--- a/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/lineage/AnalysisLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/java/io/yak/ops/business/analysis/lineage/AnalysisLineageRefreshListener.java
@@ -2,6 +2,8 @@ package io.yak.ops.business.analysis.lineage;
 
 import io.yak.ops.business.analysis.definition.AnalysisChangedEvent;
 import io.yak.ops.business.analysis.definition.AnalysisReader;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -16,26 +18,36 @@ public class AnalysisLineageRefreshListener {
 
   private final AnalysisReader reader;
   private final AnalysisLineageSynchronizer lineage;
+  private final ProjectContextScope projectContextScope;
 
   public AnalysisLineageRefreshListener(
       AnalysisReader reader,
-      AnalysisLineageSynchronizer lineage) {
+      AnalysisLineageSynchronizer lineage,
+      ProjectContextScope projectContextScope) {
     this.reader = reader;
     this.lineage = lineage;
+    this.projectContextScope = projectContextScope;
   }
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
   public void refresh(AnalysisChangedEvent event) {
-    if (event == null || event.analysisId() <= 0L) return;
+    if (event == null || event.projectId() <= 0L || event.analysisId() <= 0L) return;
     try {
-      if (event.deleted()) lineage.clear(event.analysisId());
-      else lineage.syncCurrent(reader.require(event.analysisId()));
+      projectContextScope.run(
+          new ProjectContext(event.projectId(), null),
+          () -> refreshWithinProject(event));
     } catch (RuntimeException exception) {
       LOGGER.warn(
-          "Analysis lineage refresh failed after commit for analysis {}: {}",
+          "Analysis lineage refresh failed after commit for project {} analysis {}: {}",
+          event.projectId(),
           event.analysisId(),
           exception.getMessage(),
           exception);
     }
+  }
+
+  private void refreshWithinProject(AnalysisChangedEvent event) {
+    if (event.deleted()) lineage.clear(event.analysisId());
+    else lineage.syncCurrent(reader.require(event.analysisId()));
   }
 }

--- a/yak-ops-business/yak-ops-business-analysis/src/main/resources/db/migration/yak-analysis/V2__expand_and_backfill_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/resources/db/migration/yak-analysis/V2__expand_and_backfill_project_scope.sql
@@ -1,0 +1,11 @@
+-- Project Space expand and deterministic backfill for Analysis roots.
+-- Ownership is inherited only from the already-projectized Dataset source of truth.
+ALTER TABLE yak_analysis
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id,
+    ADD KEY idx_yak_analysis_project_update (project_id, update_time, id),
+    ADD KEY idx_yak_analysis_project_dataset (project_id, dataset_id);
+
+UPDATE yak_analysis a
+JOIN yak_dataset d ON d.id = a.dataset_id
+SET a.project_id = d.project_id
+WHERE a.project_id IS NULL;

--- a/yak-ops-business/yak-ops-business-analysis/src/main/resources/db/migration/yak-analysis/V3__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-analysis/src/main/resources/db/migration/yak-analysis/V3__contract_project_scope.sql
@@ -1,0 +1,3 @@
+-- Contract phase: unresolved/orphan Analysis rows must block deployment rather than guess a Project.
+ALTER TABLE yak_analysis
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisProjectSpaceContractTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisProjectSpaceContractTest.java
@@ -1,0 +1,66 @@
+package io.yak.ops.business.analysis.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class AnalysisProjectSpaceContractTest {
+
+  @Test
+  void persistenceIsFailClosedOnTrustedCurrentProject() throws IOException {
+    String dao = read("src/main/java/io/yak/ops/business/analysis/dao/impl/AnalysisDaoImpl.java");
+    String po = read("src/main/java/io/yak/ops/business/analysis/dao/model/AnalysisPO.java");
+
+    assertThat(po).contains("private Long projectId;");
+    assertThat(dao)
+        .contains("CurrentProject")
+        .contains("currentProject.requireProjectId()")
+        .contains("AnalysisPO::getProjectId")
+        .doesNotContain("selectById(analysisId)")
+        .doesNotContain("deleteById(analysisId)");
+  }
+
+  @Test
+  void migrationBackfillsOnlyFromDatasetAndThenContracts() throws IOException {
+    String expand = read(
+        "src/main/resources/db/migration/yak-analysis/V2__expand_and_backfill_project_scope.sql");
+    String contract = read(
+        "src/main/resources/db/migration/yak-analysis/V3__contract_project_scope.sql");
+
+    assertThat(expand)
+        .contains("ADD COLUMN project_id BIGINT NULL")
+        .contains("JOIN yak_dataset")
+        .contains("d.project_id")
+        .doesNotContain("project_id = 1")
+        .doesNotContain("DEFAULT 0");
+    assertThat(contract)
+        .contains("project_id BIGINT NOT NULL")
+        .doesNotContainIgnoringCase("UPDATE");
+  }
+
+  @Test
+  void afterCommitProjectionRestoresFrozenProjectContext() throws IOException {
+    String event = read(
+        "src/main/java/io/yak/ops/business/analysis/definition/AnalysisChangedEvent.java");
+    String listener = read(
+        "src/main/java/io/yak/ops/business/analysis/lineage/AnalysisLineageRefreshListener.java");
+
+    assertThat(event).contains("long projectId");
+    assertThat(listener)
+        .contains("ProjectContextScope")
+        .contains("new ProjectContext(event.projectId(), null)");
+  }
+
+  private String read(String relative) throws IOException {
+    return Files.readString(moduleRoot().resolve(relative));
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/analysis");
+    if (Files.isDirectory(local)) return Path.of(".");
+    return Path.of("yak-ops-business", "yak-ops-business-analysis");
+  }
+}

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/architecture/AnalysisRoleConventionTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.yak.ops.business.analysis.AnalysisReferenceService;
 import io.yak.ops.business.analysis.AnalysisService;
-import io.yak.ops.business.analysis.controller.v1.mapper.AnalysisRequestMapper;
-import io.yak.ops.business.analysis.controller.v1.mapper.AnalysisViewMapper;
+import io.yak.ops.business.analysis.controller.v1.converter.AnalysisRequestConverter;
+import io.yak.ops.business.analysis.controller.v1.converter.AnalysisViewConverter;
 import io.yak.ops.business.analysis.definition.AnalysisDefinitionNormalizer;
 import io.yak.ops.business.analysis.definition.AnalysisManager;
 import io.yak.ops.business.analysis.definition.AnalysisReader;
@@ -55,8 +55,8 @@ class AnalysisRoleConventionTest {
         DatasetAnalysisAdapter.class,
         LineageAnalysisAdapter.class,
         AnalysisJsonCodec.class,
-        AnalysisRequestMapper.class,
-        AnalysisViewMapper.class)) {
+        AnalysisRequestConverter.class,
+        AnalysisViewConverter.class)) {
       assertThat(role.getAnnotation(Component.class))
           .as("%s must remain an explicit internal component role", role.getSimpleName())
           .isNotNull();

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/controller/v1/AnalysisControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/controller/v1/AnalysisControllerContractTest.java
@@ -1,8 +1,10 @@
 package io.yak.ops.business.analysis.controller.v1;
 
+import static io.yak.ops.core.project.ProjectMigrationMode.PROJECT_REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.yak.ops.business.analysis.controller.v1.dto.AnalysisRequests.SaveAnalysisRequest;
+import io.yak.ops.core.project.ProjectScope;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,8 +16,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 class AnalysisControllerContractTest {
 
   @Test
-  void keepsExistingVersionedCrudContract() throws Exception {
+  void keepsExistingVersionedCrudContractInsideRequiredProjectScope() throws Exception {
     RequestMapping root = AnalysisController.class.getAnnotation(RequestMapping.class);
+    ProjectScope projectScope = AnalysisController.class.getAnnotation(ProjectScope.class);
     Method list = AnalysisController.class.getMethod("list");
     Method get = AnalysisController.class.getMethod("get", long.class);
     Method create = AnalysisController.class.getMethod("create", SaveAnalysisRequest.class);
@@ -24,6 +27,8 @@ class AnalysisControllerContractTest {
     Method delete = AnalysisController.class.getMethod("delete", long.class);
 
     assertThat(root.value()).containsExactly("/api/v1/analyses");
+    assertThat(projectScope).isNotNull();
+    assertThat(projectScope.value()).isEqualTo(PROJECT_REQUIRED);
     assertThat(list.getAnnotation(GetMapping.class)).isNotNull();
     assertThat(get.getAnnotation(GetMapping.class).value()).containsExactly("/{analysisId}");
     assertThat(create.getAnnotation(PostMapping.class)).isNotNull();

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/definition/AnalysisManagerTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/definition/AnalysisManagerTest.java
@@ -17,21 +17,24 @@ import io.yak.ops.business.analysis.query.AnalysisQuerySpec;
 import io.yak.ops.business.analysis.repository.AnalysisRepository;
 import io.yak.ops.business.analysis.visualization.AnalysisChartType;
 import io.yak.ops.business.analysis.visualization.AnalysisVisualConfig;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 
 class AnalysisManagerTest {
 
   @Test
-  void createPersistsNormalizedDefinitionAndPublishesProjectionFact() {
+  void createPersistsNormalizedDefinitionAndPublishesProjectScopedProjectionFact() {
     AnalysisRepository repository = mock(AnalysisRepository.class);
     AnalysisDefinitionNormalizer normalizer = mock(AnalysisDefinitionNormalizer.class);
     AnalysisReader reader = mock(AnalysisReader.class);
     ApplicationEventPublisher events = mock(ApplicationEventPublisher.class);
     AnalysisManager manager = new AnalysisManager(
-        repository, normalizer, reader, events, List.of());
+        repository, normalizer, reader, currentProject(23L), events, List.of());
     AnalysisSaveCommand command = command();
     AnalysisDefinition definition = definition();
     AnalysisAsset stored = asset(11L);
@@ -43,7 +46,7 @@ class AnalysisManagerTest {
     AnalysisAsset created = manager.create(command);
 
     assertThat(created.id()).isEqualTo(11L);
-    verify(events).publishEvent(AnalysisChangedEvent.refreshed(11L));
+    verify(events).publishEvent(AnalysisChangedEvent.refreshed(23L, 11L));
   }
 
   @Test
@@ -54,7 +57,7 @@ class AnalysisManagerTest {
     ApplicationEventPublisher events = mock(ApplicationEventPublisher.class);
     AnalysisDeletionGuard guard = mock(AnalysisDeletionGuard.class);
     AnalysisManager manager = new AnalysisManager(
-        repository, normalizer, reader, events, List.of(guard));
+        repository, normalizer, reader, currentProject(23L), events, List.of(guard));
     when(reader.require(7L)).thenReturn(asset(7L));
     doThrow(new IllegalStateException("still referenced"))
         .when(guard)
@@ -63,6 +66,10 @@ class AnalysisManagerTest {
     assertThatThrownBy(() -> manager.delete(7L))
         .isInstanceOf(IllegalStateException.class);
     verify(repository, never()).delete(7L);
+  }
+
+  private static CurrentProject currentProject(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "P" + projectId));
   }
 
   private static AnalysisSaveCommand command() {

--- a/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/lineage/AnalysisLineageRefreshListenerTest.java
+++ b/yak-ops-business/yak-ops-business-analysis/src/test/java/io/yak/ops/business/analysis/lineage/AnalysisLineageRefreshListenerTest.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.analysis.lineage;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -13,22 +14,28 @@ import io.yak.ops.business.analysis.query.AnalysisMetricBinding;
 import io.yak.ops.business.analysis.query.AnalysisQuerySpec;
 import io.yak.ops.business.analysis.visualization.AnalysisChartType;
 import io.yak.ops.business.analysis.visualization.AnalysisVisualConfig;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import java.time.Instant;
 import java.util.List;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 class AnalysisLineageRefreshListenerTest {
 
   @Test
-  void refreshReadsCommittedAnalysisSnapshot() {
+  void refreshRestoresProjectAndReadsCommittedAnalysisSnapshot() {
     AnalysisReader reader = mock(AnalysisReader.class);
     AnalysisLineageSynchronizer lineage = mock(AnalysisLineageSynchronizer.class);
-    AnalysisLineageRefreshListener listener = new AnalysisLineageRefreshListener(reader, lineage);
+    RecordingProjectContextScope scope = new RecordingProjectContextScope();
+    AnalysisLineageRefreshListener listener =
+        new AnalysisLineageRefreshListener(reader, lineage, scope);
     AnalysisAsset asset = asset();
     when(reader.require(5L)).thenReturn(asset);
 
-    listener.refresh(AnalysisChangedEvent.refreshed(5L));
+    listener.refresh(AnalysisChangedEvent.refreshed(23L, 5L));
 
+    assertThat(scope.context.projectId()).isEqualTo(23L);
     verify(lineage).syncCurrent(asset);
   }
 
@@ -36,21 +43,25 @@ class AnalysisLineageRefreshListenerTest {
   void projectionFailureDoesNotEscapeCommittedBusinessCall() {
     AnalysisReader reader = mock(AnalysisReader.class);
     AnalysisLineageSynchronizer lineage = mock(AnalysisLineageSynchronizer.class);
-    AnalysisLineageRefreshListener listener = new AnalysisLineageRefreshListener(reader, lineage);
+    AnalysisLineageRefreshListener listener =
+        new AnalysisLineageRefreshListener(reader, lineage, new RecordingProjectContextScope());
     when(reader.require(5L)).thenThrow(new IllegalStateException("lineage unavailable"));
 
-    assertThatCode(() -> listener.refresh(AnalysisChangedEvent.refreshed(5L)))
+    assertThatCode(() -> listener.refresh(AnalysisChangedEvent.refreshed(23L, 5L)))
         .doesNotThrowAnyException();
   }
 
   @Test
-  void deleteClearsEvidenceWithoutReadingDeletedAnalysis() {
+  void deleteClearsEvidenceInsideOwningProjectWithoutReadingDeletedAnalysis() {
     AnalysisReader reader = mock(AnalysisReader.class);
     AnalysisLineageSynchronizer lineage = mock(AnalysisLineageSynchronizer.class);
-    AnalysisLineageRefreshListener listener = new AnalysisLineageRefreshListener(reader, lineage);
+    RecordingProjectContextScope scope = new RecordingProjectContextScope();
+    AnalysisLineageRefreshListener listener =
+        new AnalysisLineageRefreshListener(reader, lineage, scope);
 
-    listener.refresh(AnalysisChangedEvent.deleted(5L));
+    listener.refresh(AnalysisChangedEvent.deleted(23L, 5L));
 
+    assertThat(scope.context.projectId()).isEqualTo(23L);
     verify(lineage).clear(5L);
   }
 
@@ -71,5 +82,15 @@ class AnalysisLineageRefreshListenerTest {
         new AnalysisVisualConfig(false, false, false, false),
         Instant.EPOCH,
         Instant.EPOCH);
+  }
+
+  private static final class RecordingProjectContextScope implements ProjectContextScope {
+    private ProjectContext context;
+
+    @Override
+    public <T> T call(ProjectContext context, Supplier<T> action) {
+      this.context = context;
+      return action.get();
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-dashboard/ARCHITECTURE.md
@@ -2,256 +2,141 @@
 
 ## Architecture principle
 
-Package names describe business capability and role. Dashboard uses explicit boundaries rather than a generic Service/Support layer.
+Dashboard is a Project-owned, versioned composition control plane. Package names describe business capability and role; cross-module access uses owner-defined gateways instead of a generic Service/Support layer.
 
 ```text
-HTTP
-  -> DashboardService facade
+HTTP @ProjectScope
+  -> DashboardService
       -> Definition / Version / Publication
           -> shared Read side
           -> Composition
-          -> Dashboard-owned gateways
+              -> Analysis gateway
+              -> Dataset gateway
           -> Repositories
-              -> DAO
+              -> DAO + trusted CurrentProject
 
-Committed Dashboard change
-  -> Change fact
-  -> after-commit Lineage listener
-      -> effective snapshot reader
-      -> Lineage synchronizer
-          -> DashboardLineageGraphGateway
-              -> Lineage adapter
+Committed Dashboard change(projectId, dashboardId)
+  -> AFTER_COMMIT listener
+  -> ProjectContextScope
+  -> effective snapshot reader
+  -> Lineage gateway
 ```
 
 ## Package roles
 
 ### Root facade
 
-`DashboardService` is the stable application/HTTP compatibility facade. It delegates to explicit internal roles and should not absorb their implementation logic.
+`DashboardService` is the stable application and HTTP compatibility facade. It delegates to explicit internal roles and does not absorb their implementation logic.
 
 ### `definition`
 
-Owns stable Dashboard identity mutation use cases.
-
-- `DashboardManager`: create/delete identity lifecycle.
-
-Definition uses the shared `read` role for identity/current reads and the neutral `change` fact for derived projection notification. It may delegate version append during initial V1 creation without making Version depend back on Definition.
+`DashboardManager` owns stable Dashboard identity create/delete. The root identity is persisted with `project_id` from `CurrentProject`; callers never choose ownership through request data.
 
 ### `read`
 
-`DashboardReader` is the shared read-side entry for Dashboard identity and current detail.
-
-It depends only on Domain and Repository ports, so Definition, Version, Publication and the stable facade can reuse it without creating package cycles.
+`DashboardReader` is the shared read-side entry for Dashboard identity and current detail. Repository reads fail closed when the requested Dashboard is outside the current Project.
 
 ### `change`
 
-`DashboardChangedEvent` is the committed mutation fact consumed by derived projections. It is a tiny framework-free value and does not depend on Definition, Version, Publication or Lineage.
+`DashboardChangedEvent` is a framework-free committed fact containing `projectId`, `dashboardId` and deletion semantics. The frozen Project is required because after-commit projection cannot depend on the original request ThreadLocal.
 
 ### `version`
 
-Owns immutable version lifecycle.
-
-- `DashboardVersionAppender`: append snapshot then move current pointer.
-- `DashboardVersionManager`: save and restore use cases.
-- `DashboardVersionReader`: version history and immutable snapshot reads.
-
-This package may use shared `read` and `change` roles. It must not implement publication semantics.
+`DashboardVersionAppender`, `DashboardVersionManager` and `DashboardVersionReader` own append-only version history. Every child operation first proves its owning Dashboard in the current Project. Version code does not publish.
 
 ### `publication`
 
-Owns the published pointer and effective-snapshot selection.
-
-- `DashboardPublisher`: move published pointer to current.
-- `DashboardEffectiveSnapshotReader`: choose published when present, otherwise current for downstream effective projection.
-
-Publication uses shared `read`, Repository ports and the neutral change fact. It must not mutate immutable versions.
+`DashboardPublisher` moves the published pointer to the current immutable version. `DashboardEffectiveSnapshotReader` selects published when present and current otherwise. Publication does not append or rewrite historical versions.
 
 ### `composition`
 
-Owns normalization of candidate Dashboard composition.
+`DashboardCompositionNormalizer` coordinates candidate validation. Widget, layout, filter, interaction and JSON policies keep their focused rules.
 
-- `DashboardCompositionNormalizer`: orchestration only.
-- `DashboardWidgetPolicy`: widget identity/content-mode rules.
-- `DashboardLayoutPolicy`: grid constraints.
-- `DashboardFilterPolicy`: global-filter/binding rules.
-- `DashboardInteractionPolicy`: interaction graph rules.
-- `DashboardJsonPolicy`: dynamic JSON shape/size boundary.
+Composition enters external truth only through:
 
-Composition may enter Analysis only through `DashboardAnalysisGateway`.
+```text
+DashboardAnalysisGateway
+DashboardDatasetGateway
+```
+
+A reusable Analysis, `activeDatasetId`, and an explicit inline `datasetId` must resolve inside the current Project. This is an ownership check, not Dataset ONLINE/schema/query validation.
 
 ### `gateway/analysis`
 
-Dashboard-owned port for validating reusable Analysis references.
-
 ```text
-Dashboard composition
-  -> DashboardAnalysisGateway
+DashboardAnalysisGateway
   -> AnalysisDashboardAdapter
   -> AnalysisReferenceService
 ```
 
-Only the adapter knows the Analysis module API.
+### `gateway/dataset`
+
+```text
+DashboardDatasetGateway
+  -> DatasetDashboardAdapter
+  -> DatasetReader
+```
 
 ### `reference`
 
-Hosts Dashboard's implementation of the Analysis deletion guard. It asks `DashboardReferenceRepository` about historical references rather than reaching into DAO directly.
+Dashboard implements Analysis deletion safety through `DashboardReferenceRepository`. Historical widget references remain relevant and the SQL join is constrained by Dashboard Project ownership.
 
 ### `lineage`
 
-Owns derived lineage projection, not Dashboard command truth.
+`DashboardLineageRefreshListener` restores the event's Project with `ProjectContextScope`, then reads the effective snapshot. `DashboardLineageSynchronizer` owns deterministic projection and `DashboardInlineLineageExtractor` owns best-effort inline evidence parsing. Shared graph access goes only through `DashboardLineageGraphGateway`.
 
-- `DashboardLineageRefreshListener`: after-commit trigger and failure isolation.
-- `DashboardLineageSynchronizer`: independent-transaction projection convergence.
-- `DashboardInlineLineageExtractor`: best-effort inline payload interpretation.
+### `repository` and `dao`
 
-The listener consumes the neutral `change` fact and effective publication read-side. Lineage enters the shared graph only through `DashboardLineageGraphGateway`.
-
-### `gateway/lineage`
-
-Dashboard-owned graph contract and adapter.
-
-Only `LineageDashboardAdapter` may translate to Lineage module types and ObjectMapper/JsonNode infrastructure required by that external contract.
-
-### `repository`
-
-Business persistence ports are split by role:
-
-- `DashboardRepository`: identity and current/published pointers;
-- `DashboardVersionRepository`: immutable version snapshots;
-- `DashboardReferenceRepository`: historical Analysis reference query.
-
-Adapters translate to DAO/PO and may use the persistence codec.
-
-### `repository/codec`
-
-`DashboardJsonCodec` owns persistence serialization for Dashboard JSON columns. JSON persistence details do not leak into application/domain APIs.
-
-### `dao`
-
-Database-facing persistence implementation. DAO may expose PO/MyBatis details internally but not upward through repository contracts.
+Repository ports expose domain/JDK values. Adapters translate persistence representations. DAO owns MyBatis details and applies `project_id` to root CRUD, overview aggregation and cross-domain reference joins. Child tables inherit through their parent and are never returned by a globally trusted child ID alone.
 
 ### `domain`
 
-Framework-free Dashboard semantic values and snapshots.
-
-Domain does not depend on Spring, HTTP, MyBatis, DAO, Repository adapters, Analysis implementation APIs or Lineage implementation APIs.
+Domain values are framework-free and do not import Analysis, Dataset or Lineage implementation APIs.
 
 ### `controller/v1`
 
-HTTP transport boundary. DTO/VO/mappers remain here. Controller enters the application through `DashboardService` and never through repositories, DAOs or gateway adapters.
+Controllers are `PROJECT_REQUIRED`, enter through `DashboardService`, and preserve existing REST/JSON compatibility.
 
-### `config`
-
-Infrastructure wiring only.
-
-## Save flow
+## Create and save flow
 
 ```text
-HTTP request
- -> DashboardService.saveVersion
- -> DashboardVersionManager
- -> DashboardReader
- -> DashboardCompositionNormalizer
- -> policies / Analysis gateway
- -> DashboardVersionAppender
- -> DashboardVersionRepository.appendVersion
- -> DashboardRepository.updateCurrentVersion
- -> publish DashboardChangedEvent
+request
+ -> trusted Project context
+ -> normalize candidate
+ -> prove Analysis/Dataset references
+ -> create or require Project-owned Dashboard
+ -> append immutable version
+ -> move current pointer
+ -> publish DashboardChangedEvent(projectId, dashboardId)
  -> commit
- -> after-commit lineage projection
-```
-
-## Create flow
-
-```text
-normalize candidate
- -> create Dashboard identity
- -> append V1
- -> move current pointer to V1
- -> publish change fact
- -> commit
+ -> restore Project for lineage projection
 ```
 
 ## Restore flow
 
 ```text
-read historical immutable snapshot Vn
- -> convert snapshot to candidate DashboardDraft
- -> normalize
- -> append next version Vm
+read Project-owned historical Vn
+ -> copy snapshot to candidate
+ -> normalize and prove current references
+ -> append next Vm
  -> current = Vm
  -> published unchanged
 ```
 
-No historical version row is reactivated or mutated.
+Restore is copy-forward; no old version row is reactivated or mutated.
 
 ## Publish flow
 
-```text
-require Dashboard through shared read side
- -> require current version
- -> if current == published: no-op
- -> update published pointer to current
- -> publish change fact
- -> commit
-```
+Publishing proves the Dashboard and target version share the current Project, then moves only the published pointer. Re-publishing the same current version is a business no-op.
 
-## Lineage flow
+## Persistence and migration
 
-```text
-DashboardChangedEvent AFTER_COMMIT
- -> deleted? clear evidence
- -> otherwise DashboardEffectiveSnapshotReader
-      published if present
-      else current
- -> DashboardLineageSynchronizer (REQUIRES_NEW)
- -> DashboardLineageGraphGateway
- -> LineageDashboardAdapter
- -> shared Lineage graph
-```
+`yak_dashboard` is `PROJECT_ROOT`. `yak_dashboard_version` and all component rows are inherited facts.
 
-Failure after the Dashboard commit is logged and isolated.
+Historical ownership is backfilled only when all explicit Dataset/Analysis evidence resolves and agrees on one Project. Empty, orphaned or mixed-Project Dashboards remain unresolved and the subsequent `NOT NULL` contract blocks deployment rather than guessing.
 
-## Persistence flow
+## Compatibility and known gap
 
-```text
-Application role
- -> Repository port
- -> Repository adapter
- -> DAO
- -> MyBatis / Dashboard tables
-```
+The REST paths, request/response fields, long-ID serialization, append-only history, current/published divergence and deprecated activate alias remain stable.
 
-Repository adapters own persistence mapping. Application roles do not know PO/Mapper/JdbcTemplate.
-
-## Acyclic application graph
-
-The shared `read` and `change` packages are intentionally lower-level than Definition/Version/Publication:
-
-```text
-definition -> read / change / version-appender
-version    -> read / change
-publication-> read / change
-read       -> repository / domain
-change     -> JDK only
-```
-
-Version does not depend on Definition, which closes the Stage 1 `definition <-> version` package cycle.
-
-## Architecture exclusions
-
-Do not introduce top-level production buckets such as:
-
-```text
-service/
-common/
-helper/
-helpers/
-utils/
-util/
-base/
-persistence/
-support/
-```
-
-A new class must state the Dashboard capability and role it belongs to.
+The known version allocation concurrency boundary remains: the unique `(dashboard_id, version_no)` key protects durable uniqueness, while richer retry/CAS allocation is future work.

--- a/yak-ops-business/yak-ops-business-dashboard/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-dashboard/DEPENDENCIES.md
@@ -2,63 +2,61 @@
 
 ## Direction
 
-Dependencies point from transport/application orchestration toward explicit business/persistence ports. Cross-module dependencies pass through Dashboard-owned gateways.
+Dependencies point from transport/application orchestration toward explicit business and persistence ports. Cross-module dependencies pass only through Dashboard-owned gateways.
 
 ## Package matrix
 
 | Source | Allowed direct Dashboard dependencies |
 | --- | --- |
 | root `DashboardService` | `definition`, `read`, `version`, `publication`, `domain` |
-| `controller` | root stable facade, controller DTO/VO/mapper, domain types needed by transport mappers |
+| `controller` | root stable facade, controller DTO/VO/converter, domain values needed by transport conversion |
 | `definition` | `read`, `change`, `domain`, `composition`, version appender, `repository` ports |
 | `read` | `domain`, `repository` ports |
 | `change` | JDK only |
 | `version` | `read`, `change`, `domain`, `composition`, `repository` ports |
 | `publication` | `read`, `change`, `domain`, `repository` ports |
-| `composition` | `domain`, `gateway.analysis` port |
+| `composition` | `domain`, `gateway.analysis`, `gateway.dataset` ports |
 | `reference` | `repository` reference port plus external Analysis deletion extension contract |
-| `lineage` | `change`, `domain`, `publication` effective read-side, `gateway.lineage` port |
-| `gateway.analysis` | Dashboard-owned port; adapter may call Analysis stable reference facade |
+| `lineage` | `change`, `domain`, `publication`, `gateway.lineage` port |
+| `gateway.analysis` | Dashboard-owned port; adapter may call the Analysis stable reference facade |
+| `gateway.dataset` | Dashboard-owned port; adapter may call the Dataset stable scoped reader |
 | `gateway.lineage` | Dashboard-owned port; adapter may call Lineage module APIs |
 | `repository` | `domain`, `dao`, `repository.codec`, infrastructure annotations |
 | `repository.codec` | Jackson persistence infrastructure only |
-| `dao` | DAO/PO/Mapper/MyBatis + datasource infrastructure |
+| `dao` | DAO/PO/Mapper/MyBatis, `CurrentProject`, datasource infrastructure |
 | `domain` | JDK only |
 | `config` | wiring/infrastructure only |
 
-The matrix describes permitted direction, not permission for every class to depend on every package in its row. Keep dependencies narrower when possible.
+The matrix describes permitted direction, not permission for every class to depend on every package in its row. Keep dependencies narrower when possible, and keep the actual graph acyclic.
 
 ## Stable facade corridor
 
-HTTP and compatibility callers enter through:
+HTTP callers enter through:
 
 ```text
-DashboardController
+DashboardController / DashboardOverviewController
     -> DashboardService
 ```
 
-Controller must not inject repositories, DAOs, cross-module gateways or lineage internals.
+Both controllers are `PROJECT_REQUIRED`. They must not inject repositories, DAOs, cross-module adapters or lineage internals.
 
-## Shared read and change roles
+## Project context corridor
 
-`DashboardReader` lives in `read` rather than Definition because Version and Publication also need Dashboard identity/current reads. `DashboardChangedEvent` lives in neutral `change` for the same reason.
-
-This deliberately prevents:
+`yak_dashboard` is a Project root. `DashboardVersion`, Widget, Filter, Binding and Interaction inherit ownership through their owning Dashboard.
 
 ```text
-definition -> version
-version    -> definition
+HTTP @ProjectScope
+    -> trusted CurrentProject
+    -> root DAO predicate: project_id = currentProject.requireProjectId()
 ```
 
-from becoming a package cycle.
+Child reads and writes must prove the parent Dashboard before returning or mutating inherited rows. A request ID from another workspace is treated as absent in the current workspace.
 
-`read` depends only on Repository/Domain. `change` is framework-free and depends only on JDK types.
+After-commit work freezes `projectId` in `DashboardChangedEvent` and restores it through `ProjectContextScope`. It must not assume the request ThreadLocal survives commit callbacks.
 
 ## Analysis corridor
 
 Composition cannot import the Analysis module directly.
-
-The only Dashboard business corridor is:
 
 ```text
 composition
@@ -67,15 +65,26 @@ composition
  -> AnalysisReferenceService
 ```
 
-Only `gateway/analysis/AnalysisDashboardAdapter` may import Analysis application/reference implementation types for reusable widget validation.
+Only `gateway/analysis/AnalysisDashboardAdapter` may import Analysis application/reference types. Because Analysis reads are Project-scoped, this corridor also proves that reusable widget references belong to the current Project.
 
-Dashboard's Analysis deletion guard is the inverse extension mechanism already defined by Analysis. The guard implementation may implement `AnalysisDeletionGuard`, but it must query Dashboard history through `DashboardReferenceRepository`, not DAO.
+Dashboard's Analysis deletion guard is the inverse extension mechanism defined by Analysis. It queries historical references through `DashboardReferenceRepository`, whose implementation constrains the reference join by the current Project.
+
+## Dataset corridor
+
+`activeDatasetId` and an explicit `inlineAnalysis.datasetId` are Project references. Dashboard validates only identity and same-Project ownership here; Dataset ONLINE state, schema compatibility and query execution remain Dataset-owned concerns.
+
+```text
+composition
+ -> DashboardDatasetGateway
+ -> DatasetDashboardAdapter
+ -> DatasetReader
+```
+
+Only `gateway/dataset/DatasetDashboardAdapter` may import Dataset implementation APIs. No controller, composition policy, repository or DAO may bypass this port.
 
 ## Lineage corridor
 
-Dashboard lineage business code cannot import `LineageService`, `LineageMaintenanceService`, Lineage PO/model types or ObjectMapper for graph translation.
-
-The only graph corridor is:
+Dashboard lineage business code cannot import Lineage implementation types.
 
 ```text
 lineage
@@ -84,7 +93,7 @@ lineage
  -> Lineage module
 ```
 
-Only `gateway/lineage/LineageDashboardAdapter` may know the Lineage module API and graph JSON translation infrastructure.
+Only `gateway/lineage/LineageDashboardAdapter` may know the Lineage API and graph translation infrastructure.
 
 ## Repository corridor
 
@@ -97,88 +106,32 @@ application role
  -> DashboardDao
 ```
 
-Repository interfaces must not expose:
-
-- `DashboardPO` or other DAO models;
-- MyBatis Mapper types;
-- `JdbcTemplate`;
-- controller DTO/VO;
-- serialized JSON strings as the business representation of version composition.
+Repository interfaces must not expose PO/MyBatis types, controller DTO/VO or serialized JSON strings as business contracts.
 
 ## Domain purity
 
-`domain` must not import:
-
-- Spring;
-- Jackson transport/persistence infrastructure;
-- MyBatis;
-- Dashboard DAO/repository adapters;
-- controller DTO/VO;
-- Analysis module APIs;
-- Lineage module APIs.
-
-Domain types remain plain Java records/enums/value objects.
+`domain` must not import Spring, Jackson, MyBatis, DAO/repository adapters, controller types, Analysis APIs, Dataset APIs or Lineage APIs. Domain values remain plain Java records, enums and value objects.
 
 ## Version and publication separation
 
-`version` owns append/read/restore. It must not update the published pointer.
+`version` owns append/read/restore and must not update the published pointer. `publication` owns the published-pointer transition and must not append or mutate historical versions. This protects `current != published` as a first-class invariant.
 
-`publication` owns published-pointer transition and effective-snapshot selection. It must not append or mutate historical version rows.
+## Infrastructure dependencies
 
-This separation protects:
+Dashboard directly depends on:
 
-```text
-current != published
-```
+- `yak-ops-core` for trusted Project context;
+- `yak-ops-business-datasource` for business DataSource/Flyway/MyBatis infrastructure;
+- `yak-ops-business-analysis` through the Analysis gateway adapter;
+- `yak-ops-business-dataset` through the Dataset gateway adapter;
+- `yak-ops-business-lineage` through the Lineage gateway adapter.
 
-as a first-class Dashboard invariant.
-
-## Effective projection corridor
-
-Derived consumers that need the effective Dashboard snapshot should use `DashboardEffectiveSnapshotReader` rather than reproducing:
-
-```text
-published if present else current
-```
-
-in multiple places.
-
-Lineage currently uses this read-side policy.
-
-## Datasource dependency
-
-Dashboard retains a direct Maven dependency on `yak-ops-business-datasource` because persistence/configuration reuses:
-
-- conditional datasource enablement;
-- business DataSource wiring;
-- Flyway/MyBatis infrastructure.
-
-This is an infrastructure dependency. It must not leak into Dashboard domain/composition/version/publication business semantics beyond configuration/conditional annotations already required for module activation.
-
-## Dataset dependency
-
-Dashboard does not currently require a direct Dataset business dependency. `activeDatasetId` remains optional metadata and inline lineage parsing is projection-only evidence.
-
-Do not add Dataset validation as a side effect of architecture refactoring.
+A Maven dependency does not grant arbitrary package access. Owner-defined gateways remain mandatory.
 
 ## Forbidden broad buckets
 
-Do not reintroduce top-level production packages named:
+Do not reintroduce top-level production packages named `service`, `common`, `helper`, `helpers`, `utils`, `util`, `base`, `persistence` or `support`.
 
-```text
-service
-common
-helper
-helpers
-utils
-util
-base
-persistence
-support
-```
+## Change rule
 
-Use the role vocabulary from repository `CODE_STYLE.md` and the Dashboard architecture instead.
-
-## Acyclic rule
-
-The Dashboard package graph must remain acyclic. A new import that creates a cycle is an architecture defect even when compilation succeeds.
+A dependency-graph change requires the truth owner, this contract and executable architecture tests to change together. Do not delete or weaken a guard merely to make a new import compile.

--- a/yak-ops-business/yak-ops-business-dashboard/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-dashboard/DOMAIN.md
@@ -2,7 +2,7 @@
 
 ## Aggregate truth
 
-Dashboard is a versioned composition aggregate with two levels of truth:
+Dashboard is a Project-owned, versioned composition aggregate with two levels of truth:
 
 ```text
 DashboardAsset
@@ -15,84 +15,17 @@ DashboardVersionSnapshot
     = immutable composition truth for one version
 ```
 
-`DashboardAsset.name` and `description` follow the current-version projection for list/read convenience. They do not replace the name/description snapshot stored on historical DashboardVersion rows.
+`yak_dashboard.project_id` is durable root ownership derived from trusted `CurrentProject`. It is not accepted from a request DTO. DashboardVersion, Widget, Filter, Binding and Interaction inherit that ownership through `dashboard_id` and `dashboard_version_id`.
 
-## DashboardAsset
+`DashboardAsset.name` and `description` follow the current-version projection for list/read convenience. They do not replace historical snapshots.
 
-`DashboardAsset` owns:
+## Version lifecycle
 
-- Dashboard ID;
-- current version ID/no;
-- published version ID/no;
-- published time;
-- current projected name/description;
-- create/update timestamps.
+DashboardVersion is append-only. Saving a candidate appends the next immutable snapshot and moves `currentVersionId`; it never mutates the current row in place.
 
-It does not own mutable widget/filter/interaction collections.
+`publishedVersionId` identifies the externally effective published snapshot. Current and published may diverge for any number of edits.
 
-## DashboardVersion
-
-`DashboardVersion` is immutable after append.
-
-It owns version metadata:
-
-- version identity;
-- Dashboard identity;
-- monotonically selected version number under the current repository strategy;
-- name/description snapshot;
-- optional active Dataset ID metadata;
-- create time.
-
-`DashboardVersionSnapshot` completes that truth with:
-
-- theme;
-- widget snapshots;
-- global-filter snapshots;
-- interaction snapshots.
-
-### Append-only invariant
-
-For a live Dashboard:
-
-```text
-save candidate
-    != mutate current row
-
-save candidate
-    = append next immutable version
-```
-
-Historical rows may only disappear when their owning Dashboard is deleted according to existing persistence semantics.
-
-## DashboardDraft
-
-`DashboardDraft` is a candidate composition used to create the next immutable DashboardVersion.
-
-Unlike the former Analysis `Draft` terminology, Dashboard Draft has a real relationship to version creation: it is normalized input before append. It is not itself persistent lifecycle state and there is no `DRAFT` database status row.
-
-## Current pointer
-
-`currentVersionId` identifies the current editable Dashboard snapshot.
-
-Moving current does not make that version published.
-
-## Published pointer
-
-`publishedVersionId` identifies the externally effective published snapshot.
-
-Publishing changes the pointer only:
-
-```text
-publishedVersionId = currentVersionId
-```
-
-It does not mutate the version snapshot.
-
-Current and published may diverge for an arbitrary number of new draft versions.
-
-## Restore invariant
-
-Restore is copy-forward, not pointer rewind.
+Restore is copy-forward:
 
 ```text
 V1 -> V2 -> V3(current)
@@ -102,15 +35,11 @@ append V4(copy of V1 composition)
 current -> V4
 ```
 
-If published is V2, restore must leave published at V2 until an explicit publish occurs.
-
-The deprecated `activateVersion` name is compatibility vocabulary only; its domain meaning is restore-as-new-version.
+The published pointer remains unchanged until an explicit publish. The deprecated activate name is only a compatibility alias.
 
 ## Composition
 
-### Widget
-
-A widget contains layout plus exactly one content binding:
+A widget freezes exactly one content binding:
 
 ```text
 reusable Analysis reference
@@ -118,81 +47,37 @@ OR
 inline Analysis payload
 ```
 
-A linked widget freezes the Analysis ID reference in the DashboardVersion. It does **not** freeze the referenced Analysis definition.
+Analysis owns reusable analytical definitions. Dashboard owns only the frozen Analysis ID reference or inline payload in a DashboardVersion.
 
-An inline widget freezes its inline payload directly in the DashboardVersion.
+A reusable Analysis reference must exist in the current Project. An inline payload may declare `datasetId`; when it does, that Dataset must exist in the current Project. The optional `activeDatasetId` follows the same ownership rule.
 
-### Layout
+Those checks do not prove that a Dataset is ONLINE, has a current version, or that every field binding matches its schema. Dataset lifecycle, schema and query truth remain Dataset-owned.
 
-Layout belongs to the DashboardVersion. The current contract uses a 24-column grid and the existing dimension/min-size constraints.
+Layout, theme, global filters, bindings and interactions belong to the immutable DashboardVersion snapshot.
 
-### Global filters
+## Historical reference safety
 
-Global filters, filter keys, default values and widget-field bindings belong to the DashboardVersion snapshot.
+Any historical DashboardVersion that references Analysis X prevents Analysis X from being deleted. The reference query is constrained by the current Project, so one workspace cannot observe or control another workspace's references.
 
-A filter binding references a widget key and a field ID. Dashboard owns the binding relation, not the field's Dataset schema truth.
+## Change fact and lineage
 
-### Interactions
+`DashboardChangedEvent` contains the owning `projectId` because the listener runs after commit. `ProjectContextScope` restores that context before any Dashboard read or Lineage projection.
 
-Interactions belong to the version snapshot and connect an existing source widget/field to an existing target filter.
+Lineage owns graph truth. Dashboard owns only deterministic/best-effort projection input and convergence logic. Projection failure cannot roll back committed Dashboard truth.
 
-## activeDatasetId
-
-`activeDatasetId` is currently optional version metadata.
-
-It is not proof that a Dataset is ONLINE, that a Dataset version exists, or that every field binding belongs to that Dataset. No such new invariant is introduced by this refactor.
-
-## Analysis ownership
-
-Analysis owns reusable analytical definitions.
-
-Dashboard owns:
-
-- an Analysis ID reference frozen into a DashboardVersion; or
-- an inline payload frozen into a DashboardVersion.
-
-Dashboard does not become a second Analysis-definition owner.
-
-### Historical deletion restriction
-
-Dashboard's historical version truth means an old Analysis reference remains meaningful even when the current Dashboard version no longer uses it.
-
-Therefore the existing deletion invariant remains:
-
-```text
-any historical DashboardVersion references Analysis X
-    => Analysis X is not deletable
-```
-
-## Lineage ownership
-
-Lineage owns graph truth.
-
-Dashboard Lineage owns only the deterministic/best-effort projection logic from committed Dashboard state.
-
-The effective lineage snapshot rule is:
+The effective lineage rule remains:
 
 ```text
 published exists -> project published
 otherwise         -> project current
 ```
 
-Projection happens after commit and in an independent transaction. Projection failure does not roll back already committed Dashboard truth.
-
-## Inline lineage parsing
-
-Inline Analysis JSON is not promoted into a second Dashboard analysis domain model.
-
-`DashboardInlineLineageExtractor` may interpret known fields for derived lineage evidence. Parse status such as success/partial/unresolved describes projection evidence, not Dashboard lifecycle state.
-
 ## Persistence truth
 
-Database rows own durable Dashboard identity, pointers and immutable version snapshots.
+Database rows own Dashboard identity, Project ownership, pointers and immutable snapshots. Repository adapters translate persistence rows/JSON columns; PO/Mapper/MyBatis types are not domain contracts.
 
-Repository adapters translate between persistence rows/JSON columns and Dashboard domain values. PO/Mapper/MyBatis types are not domain contracts.
+Cross-Project IDs fail closed as absent in the current workspace. Child rows are never considered independently accessible merely because their numeric ID exists.
 
 ## Known domain gap: version allocation concurrency
 
-The current flow obtains `nextVersionNo` and then appends. The unique `(dashboard_id, version_no)` database key protects duplicate durable numbers, but the application does not yet define a richer retry/CAS allocator contract.
-
-This is intentionally documented as a future domain/concurrency concern. Architecture governance must not pretend the gap is solved.
+The current flow obtains `nextVersionNo` and then appends. The unique `(dashboard_id, version_no)` database key protects duplicate durable numbers, but the application does not yet define a richer retry/CAS allocator contract. This remains a future domain/concurrency concern.

--- a/yak-ops-business/yak-ops-business-dashboard/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-dashboard/REQUIREMENTS.md
@@ -2,161 +2,63 @@
 
 ## Purpose
 
-Dashboard provides persistent, versioned BI composition. It composes reusable Analysis references and optional inline analysis payloads into layouts, filters and interactions while keeping editing and published state independent.
+Dashboard provides persistent, versioned BI composition inside a Project Space. It composes reusable Analysis references and optional inline analysis payloads into layouts, filters and interactions while keeping editing and published state independent.
 
 ## Supported use cases
 
-The module supports:
+The module supports listing, reading, creating, versioning, publishing, restoring and deleting Dashboards; reading immutable history; blocking deletion of historically referenced Analysis assets; and projecting the effective snapshot into Lineage after commit.
 
-- list Dashboard identities;
-- read the current Dashboard detail;
-- create a Dashboard and append version V1;
-- append a new Dashboard version;
-- list version history;
-- read an immutable version snapshot;
-- publish the current version;
-- read the published snapshot;
-- restore a historical snapshot as a new version;
-- delete a Dashboard and its owned version history;
-- reject Analysis deletion while any historical DashboardVersion still references it;
-- project the effective Dashboard snapshot into Lineage after commit.
+The deprecated `activateVersion` API remains a compatibility alias for restore and never reactivates an old row.
 
-The existing deprecated `activateVersion` API remains a compatibility alias for restore. It must not reactivate an old version row.
+## Project Space requirements
+
+- `yak_dashboard` is a `PROJECT_ROOT` and stores trusted `CurrentProject.projectId`.
+- Controllers are `PROJECT_REQUIRED`.
+- List, detail, update, publish, restore, delete, overview and reference-check paths fail closed outside the current Project.
+- DashboardVersion, Widget, Filter, Binding and Interaction inherit ownership from the parent Dashboard; every independent child read/write proves that parent.
+- Request DTOs cannot choose or override `projectId`.
+- `DashboardChangedEvent` freezes `projectId`; after-commit projection restores it with `ProjectContextScope`.
 
 ## Composition contract
 
-A Dashboard version may contain:
+A Dashboard version contains a name/description snapshot, optional `activeDatasetId`, optional theme object, widgets, global filters/bindings and interactions.
 
-- name and description snapshot;
-- optional `activeDatasetId` metadata;
-- optional theme JSON object;
-- widgets;
-- global filters and widget-field bindings;
-- interactions.
-
-### Widget binding
-
-Every widget must choose exactly one content mode:
+Every widget chooses exactly one mode:
 
 ```text
 analysisId XOR inlineAnalysis
 ```
 
-A reusable `analysisId` must reference an existing Analysis. An inline payload is stored as part of the immutable DashboardVersion snapshot.
+A reusable `analysisId` must resolve through `DashboardAnalysisGateway` in the current Project. `activeDatasetId` and an explicit `inlineAnalysis.datasetId` must resolve through `DashboardDatasetGateway` in the current Project.
 
-### Existing validation limits
+These are identity and ownership checks only. Dashboard does not take ownership of Dataset ONLINE state, current version, schema compatibility or query execution.
 
-Stage 1 behavior remains the contract:
+Existing limits remain: at most 200 widgets, a 24-column grid, at most 20 global filters, 200 bindings and 100 interactions, plus the existing JSON shape and serialized-size limits.
 
-- at most 200 widgets;
-- 24-column layout grid;
-- `x` in 0..23;
-- positive width/height within existing limits;
-- widget must not overflow the 24-column grid;
-- at most 20 global filters;
-- at most 200 filter bindings;
-- at most 100 interactions;
-- existing JSON object/scalar and serialized-size validation remains unchanged.
+## Version and publication requirements
 
-## Version requirements
+DashboardVersion is append-only. Save normalizes a candidate, allocates the next number using the current repository strategy, appends an immutable snapshot and moves the current pointer.
 
-DashboardVersion is append-only for the lifetime of a Dashboard.
+Restoring V2 while current is V7 produces V8. It does not move current back to the old V2 row.
 
-Saving composition must:
+`currentVersionId` and `publishedVersionId` may intentionally differ. Publishing moves only the published pointer to the current immutable version and is a business no-op when both already match.
 
-```text
-normalize candidate composition
- -> allocate next version number using current repository strategy
- -> append immutable version snapshot
- -> move currentVersion pointer
-```
+## Reference and lineage requirements
 
-Existing historical version rows must not be mutated by save or restore.
+Reusable Analysis definitions remain owned by Analysis. Any historical DashboardVersion reference continues to block deletion, scoped to the current Project.
 
-### Restore
+After commit, Lineage uses the published snapshot when present and current otherwise, runs in an independent transaction, and isolates projection failure from committed Dashboard truth. Inline parsing remains best effort.
 
-Restoring historical V2 while current is V7 must produce V8. It must not point `currentVersionId` back to the old V2 row.
+## Persistence and migration requirements
 
-### Current and published pointers
+The existing six Dashboard tables remain authoritative. Only `yak_dashboard` stores `project_id`; descendants inherit ownership.
 
-`currentVersionId` represents the latest editable snapshot.
-
-`publishedVersionId` represents the externally effective published snapshot.
-
-They may intentionally differ, for example:
-
-```text
-current   = V8
-published = V5
-```
-
-Saving V9 must not change `publishedVersionId`.
-
-## Publication requirements
-
-Publishing must move the published pointer to the current immutable version. It must not copy, rewrite or renumber that version.
-
-Publishing when current and published already point to the same version remains idempotent from the Dashboard business perspective.
-
-## Analysis reference requirements
-
-Reusable Analysis definitions remain owned by `yak-ops-business-analysis`.
-
-Dashboard owns only the reference embedded in each version snapshot. A DashboardVersion that stores `analysisId = 10` does not freeze the current Analysis definition as a Dashboard-owned copy.
-
-Historical references matter for deletion safety: if any historical DashboardVersion references Analysis 10, Dashboard's `AnalysisDeletionGuard` integration must continue to block deletion of Analysis 10.
-
-## Inline analysis requirements
-
-Inline Analysis is a Dashboard-owned opaque JSON payload frozen inside the version snapshot.
-
-Dashboard validation checks its configured JSON shape/size but does not introduce Dataset lifecycle/schema ownership.
-
-Lineage may perform best-effort parsing of known inline fields (`datasetId`, dimensions, metrics, filters, sorts). Failure to understand an inline payload must not corrupt Dashboard truth.
-
-## Lineage requirements
-
-Lineage is a derived projection of committed Dashboard state.
-
-After Dashboard mutation commits:
-
-- use the published snapshot when a published version exists;
-- otherwise use the current draft snapshot;
-- synchronize in an independent transaction;
-- isolate projection failure from the already committed Dashboard business operation;
-- preserve `DASHBOARD_BINDING` evidence semantics and existing asset/relation keys.
-
-Lineage never becomes Dashboard command truth.
-
-## Persistence requirements
-
-The existing six Dashboard tables and Flyway baseline remain authoritative persistence for this stage:
-
-- `yak_dashboard`;
-- `yak_dashboard_version`;
-- `yak_dashboard_widget`;
-- `yak_dashboard_filter`;
-- `yak_dashboard_filter_binding`;
-- `yak_dashboard_interaction`.
-
-Repository contracts expose Dashboard domain/JDK values. DAO/PO/MyBatis details stay below repository adapters.
+Historical Project ownership may be backfilled only from complete, resolvable Dataset/Analysis evidence that agrees on one Project. Empty, orphaned or mixed-Project history must remain unresolved and block the `NOT NULL` contract. No default Project, Project `0`, first Project or request-supplied fallback is allowed.
 
 ## HTTP compatibility
 
-Stage 2 does not change `/api/v1/dashboards/**`, request/response JSON fields, long-ID serialization, or the deprecated activate route.
+`/api/v1/dashboards/**`, request/response fields, long-ID serialization and the deprecated activate route remain stable. The only transport change is the required trusted Project context already defined by the shared Project Space contract.
 
 ## Explicit non-goals
 
-This architecture governance does **not** add:
-
-- a Dashboard execution engine;
-- Dataset query execution;
-- automatic Dataset ONLINE/schema validation for `activeDatasetId`;
-- an Analysis definition copy/version inside Dashboard;
-- in-place historical version editing;
-- publish-time version copying;
-- a new Dashboard status state machine;
-- stronger version-number concurrency/CAS semantics;
-- synchronous Lineage truth.
-
-The current `nextVersionNo -> appendVersion` strategy is a known concurrency boundary. Stronger allocation/retry/CAS behavior is a separate domain change and must not be smuggled into an architecture-only refactor.
+This stage does not add a Dashboard execution engine, Dataset query execution, Dataset ONLINE/schema validation, an Analysis definition copy inside Dashboard, in-place history editing, publish-time copying, a new status machine, stronger version-number CAS/retry semantics or synchronous Lineage truth.

--- a/yak-ops-business/yak-ops-business-dashboard/pom.xml
+++ b/yak-ops-business/yak-ops-business-dashboard/pom.xml
@@ -22,7 +22,16 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-dataset</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/change/DashboardChangedEvent.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/change/DashboardChangedEvent.java
@@ -1,19 +1,22 @@
 package io.yak.ops.business.dashboard.change;
 
 /** Committed Dashboard mutation fact consumed by derived projections. */
-public record DashboardChangedEvent(long dashboardId, boolean deleted) {
+public record DashboardChangedEvent(long projectId, long dashboardId, boolean deleted) {
 
   public DashboardChangedEvent {
+    if (projectId <= 0L) {
+      throw new IllegalArgumentException("projectId 必须大于 0");
+    }
     if (dashboardId <= 0L) {
       throw new IllegalArgumentException("dashboardId 必须大于 0");
     }
   }
 
-  public static DashboardChangedEvent refreshed(long dashboardId) {
-    return new DashboardChangedEvent(dashboardId, false);
+  public static DashboardChangedEvent refreshed(long projectId, long dashboardId) {
+    return new DashboardChangedEvent(projectId, dashboardId, false);
   }
 
-  public static DashboardChangedEvent deleted(long dashboardId) {
-    return new DashboardChangedEvent(dashboardId, true);
+  public static DashboardChangedEvent deleted(long projectId, long dashboardId) {
+    return new DashboardChangedEvent(projectId, dashboardId, true);
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardCompositionNormalizer.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardCompositionNormalizer.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.dashboard.composition;
 
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
+import io.yak.ops.business.dashboard.gateway.dataset.DashboardDatasetGateway;
 import java.util.Objects;
 import org.springframework.stereotype.Component;
 
@@ -12,16 +13,19 @@ public class DashboardCompositionNormalizer {
   private final DashboardWidgetPolicy widgets;
   private final DashboardFilterPolicy filters;
   private final DashboardInteractionPolicy interactions;
+  private final DashboardDatasetGateway datasets;
 
   public DashboardCompositionNormalizer(
       DashboardJsonPolicy json,
       DashboardWidgetPolicy widgets,
       DashboardFilterPolicy filters,
-      DashboardInteractionPolicy interactions) {
+      DashboardInteractionPolicy interactions,
+      DashboardDatasetGateway datasets) {
     this.json = json;
     this.widgets = widgets;
     this.filters = filters;
     this.interactions = interactions;
+    this.datasets = datasets;
   }
 
   public DashboardDraft normalize(DashboardDraft draft) {
@@ -31,6 +35,9 @@ public class DashboardCompositionNormalizer {
     Long activeDatasetId = draft.activeDatasetId();
     if (activeDatasetId != null && activeDatasetId <= 0L) {
       activeDatasetId = null;
+    }
+    if (activeDatasetId != null) {
+      datasets.requireExists(activeDatasetId);
     }
 
     Object theme = json.requireObject(draft.theme(), "Dashboard Theme", 16000);

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardJsonPolicy.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardJsonPolicy.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 
-/** Validates opaque Dashboard JSON values at the composition boundary. */
+/** Validates and reads opaque Dashboard JSON values at the composition boundary. */
 @Component
 public class DashboardJsonPolicy {
 
@@ -33,6 +33,33 @@ public class DashboardJsonPolicy {
     }
     ensureLength(value, label, maxLength);
     return value;
+  }
+
+  public Long optionalPositiveLongField(Object value, String fieldName, String label) {
+    if (value == null) return null;
+    JsonNode root = objectMapper.valueToTree(value);
+    if (!root.isObject()) {
+      throw new IllegalArgumentException(label + " 必须是 JSON 对象");
+    }
+    JsonNode field = root.get(fieldName);
+    if (field == null || field.isNull()) return null;
+
+    long parsed;
+    try {
+      if (field.isIntegralNumber()) {
+        parsed = field.longValue();
+      } else if (field.isTextual()) {
+        parsed = Long.parseLong(field.asText().trim());
+      } else {
+        throw new NumberFormatException("not an integer");
+      }
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException(label + "." + fieldName + " 非法", exception);
+    }
+    if (parsed <= 0L) {
+      throw new IllegalArgumentException(label + "." + fieldName + " 必须大于 0");
+    }
+    return parsed;
   }
 
   private void ensureLength(Object value, String label, int maxLength) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardWidgetPolicy.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardWidgetPolicy.java
@@ -1,7 +1,10 @@
 package io.yak.ops.business.dashboard.composition;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.dashboard.domain.WidgetSpec;
 import io.yak.ops.business.dashboard.gateway.analysis.DashboardAnalysisGateway;
+import io.yak.ops.business.dashboard.gateway.dataset.DashboardDatasetGateway;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -16,16 +19,22 @@ public class DashboardWidgetPolicy {
   private static final int MAX_INLINE_JSON = 65535;
 
   private final DashboardAnalysisGateway analyses;
+  private final DashboardDatasetGateway datasets;
   private final DashboardLayoutPolicy layout;
   private final DashboardJsonPolicy json;
+  private final ObjectMapper objectMapper;
 
   public DashboardWidgetPolicy(
       DashboardAnalysisGateway analyses,
+      DashboardDatasetGateway datasets,
       DashboardLayoutPolicy layout,
-      DashboardJsonPolicy json) {
+      DashboardJsonPolicy json,
+      ObjectMapper objectMapper) {
     this.analyses = analyses;
+    this.datasets = datasets;
     this.layout = layout;
     this.json = json;
+    this.objectMapper = objectMapper;
   }
 
   public Result normalize(List<WidgetSpec> values) {
@@ -51,17 +60,20 @@ public class DashboardWidgetPolicy {
         throw new IllegalArgumentException(
             "Widget 必须且只能选择 analysisId 或 inlineAnalysis：" + widgetKey);
       }
+
+      Object inlineAnalysis = inline
+          ? json.requireObject(value.inlineAnalysis(), "inlineAnalysis：" + widgetKey, MAX_INLINE_JSON)
+          : null;
       if (linked) {
         if (value.analysisId() <= 0L) {
           throw new IllegalArgumentException("analysisId 必须大于 0");
         }
         analyses.requireExists(value.analysisId());
+      } else {
+        requireInlineDataset(inlineAnalysis, widgetKey);
       }
 
       layout.validate(value, widgetKey);
-      Object inlineAnalysis = inline
-          ? json.requireObject(value.inlineAnalysis(), "inlineAnalysis：" + widgetKey, MAX_INLINE_JSON)
-          : null;
       normalized.add(new WidgetSpec(
           widgetKey,
           value.analysisId(),
@@ -75,6 +87,30 @@ public class DashboardWidgetPolicy {
           value.minH()));
     }
     return new Result(List.copyOf(normalized), Set.copyOf(widgetKeys));
+  }
+
+  private void requireInlineDataset(Object inlineAnalysis, String widgetKey) {
+    JsonNode root = objectMapper.valueToTree(inlineAnalysis);
+    JsonNode value = root == null ? null : root.get("datasetId");
+    if (value == null || value.isNull()) return;
+
+    long datasetId;
+    try {
+      if (value.isIntegralNumber()) {
+        datasetId = value.longValue();
+      } else if (value.isTextual()) {
+        datasetId = Long.parseLong(value.asText().trim());
+      } else {
+        throw new NumberFormatException("not an integer");
+      }
+    } catch (RuntimeException exception) {
+      throw new IllegalArgumentException(
+          "inlineAnalysis.datasetId 非法：" + widgetKey, exception);
+    }
+    if (datasetId <= 0L) {
+      throw new IllegalArgumentException("inlineAnalysis.datasetId 必须大于 0：" + widgetKey);
+    }
+    datasets.requireExists(datasetId);
   }
 
   private String required(String value, String label, int maxLength) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardWidgetPolicy.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/composition/DashboardWidgetPolicy.java
@@ -1,7 +1,5 @@
 package io.yak.ops.business.dashboard.composition;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.dashboard.domain.WidgetSpec;
 import io.yak.ops.business.dashboard.gateway.analysis.DashboardAnalysisGateway;
 import io.yak.ops.business.dashboard.gateway.dataset.DashboardDatasetGateway;
@@ -22,19 +20,16 @@ public class DashboardWidgetPolicy {
   private final DashboardDatasetGateway datasets;
   private final DashboardLayoutPolicy layout;
   private final DashboardJsonPolicy json;
-  private final ObjectMapper objectMapper;
 
   public DashboardWidgetPolicy(
       DashboardAnalysisGateway analyses,
       DashboardDatasetGateway datasets,
       DashboardLayoutPolicy layout,
-      DashboardJsonPolicy json,
-      ObjectMapper objectMapper) {
+      DashboardJsonPolicy json) {
     this.analyses = analyses;
     this.datasets = datasets;
     this.layout = layout;
     this.json = json;
-    this.objectMapper = objectMapper;
   }
 
   public Result normalize(List<WidgetSpec> values) {
@@ -90,27 +85,13 @@ public class DashboardWidgetPolicy {
   }
 
   private void requireInlineDataset(Object inlineAnalysis, String widgetKey) {
-    JsonNode root = objectMapper.valueToTree(inlineAnalysis);
-    JsonNode value = root == null ? null : root.get("datasetId");
-    if (value == null || value.isNull()) return;
-
-    long datasetId;
-    try {
-      if (value.isIntegralNumber()) {
-        datasetId = value.longValue();
-      } else if (value.isTextual()) {
-        datasetId = Long.parseLong(value.asText().trim());
-      } else {
-        throw new NumberFormatException("not an integer");
-      }
-    } catch (RuntimeException exception) {
-      throw new IllegalArgumentException(
-          "inlineAnalysis.datasetId 非法：" + widgetKey, exception);
+    Long datasetId = json.optionalPositiveLongField(
+        inlineAnalysis,
+        "datasetId",
+        "inlineAnalysis：" + widgetKey);
+    if (datasetId != null) {
+      datasets.requireExists(datasetId);
     }
-    if (datasetId <= 0L) {
-      throw new IllegalArgumentException("inlineAnalysis.datasetId 必须大于 0：" + widgetKey);
-    }
-    datasets.requireExists(datasetId);
   }
 
   private String required(String value, String label, int maxLength) {

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/controller/v1/DashboardController.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/controller/v1/DashboardController.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.dashboard.controller.v1.converter.DashboardViewConver
 import io.yak.ops.business.dashboard.controller.v1.dto.SaveDashboardRequest;
 import io.yak.ops.business.dashboard.controller.v1.vo.DashboardViews;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "BI 仪表盘接口")
 @RestController
 @Validated
+@ProjectScope
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/dashboards")

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/controller/v1/DashboardOverviewController.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/controller/v1/DashboardOverviewController.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.dashboard.DashboardService;
 import io.yak.ops.business.dashboard.controller.v1.converter.DashboardOverviewViewConverter;
 import io.yak.ops.business.dashboard.controller.v1.vo.DashboardOverviewView;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.project.ProjectScope;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** Bounded Dashboard overview HTTP adapter. */
 @Tag(name = "BI 仪表盘接口")
 @RestController
+@ProjectScope
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/dashboards")

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/impl/DashboardDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/impl/DashboardDaoImpl.java
@@ -15,6 +15,7 @@ import io.yak.ops.business.dashboard.dao.model.DashboardPO;
 import io.yak.ops.business.dashboard.dao.model.DashboardVersionPO;
 import io.yak.ops.business.dashboard.dao.model.DashboardWidgetPO;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.project.CurrentProject;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
@@ -22,208 +23,263 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
-/** 基于 MyBatis-Plus 的 Dashboard DAO 实现。 */
+/** 基于 MyBatis-Plus 的 Project-scoped Dashboard DAO 实现。 */
 @Repository
 @DependsOn("yakDashboardFlyway")
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DashboardDaoImpl implements DashboardDao {
 
-    private final DashboardMapper dashboardMapper;
-    private final DashboardVersionMapper versionMapper;
-    private final DashboardWidgetMapper widgetMapper;
-    private final DashboardFilterMapper filterMapper;
-    private final DashboardFilterBindingMapper filterBindingMapper;
-    private final DashboardInteractionMapper interactionMapper;
+  private final DashboardMapper dashboardMapper;
+  private final DashboardVersionMapper versionMapper;
+  private final DashboardWidgetMapper widgetMapper;
+  private final DashboardFilterMapper filterMapper;
+  private final DashboardFilterBindingMapper filterBindingMapper;
+  private final DashboardInteractionMapper interactionMapper;
+  private final CurrentProject currentProject;
 
-    @Override
-    public int insertDashboard(DashboardPO dashboard) {
-        dashboard.setCreateTime(Timestamp.from(Instant.now()));
-        dashboard.setUpdateTime(dashboard.getCreateTime());
-        dashboard.setCurrentVersionNo(0);
-        dashboard.setPublishedVersionNo(0);
-        return dashboardMapper.insert(dashboard);
+  @Override
+  public int insertDashboard(DashboardPO dashboard) {
+    dashboard.setProjectId(projectId());
+    dashboard.setCreateTime(Timestamp.from(Instant.now()));
+    dashboard.setUpdateTime(dashboard.getCreateTime());
+    dashboard.setCurrentVersionNo(0);
+    dashboard.setPublishedVersionNo(0);
+    return dashboardMapper.insert(dashboard);
+  }
+
+  @Override
+  public int insertVersion(DashboardVersionPO version) {
+    requireDashboard(version.getDashboardId());
+    version.setCreateTime(Timestamp.from(Instant.now()));
+    return versionMapper.insert(version);
+  }
+
+  @Override
+  public int insertWidget(DashboardWidgetPO widget) {
+    requireVersion(widget.getDashboardVersionId());
+    return widgetMapper.insert(widget);
+  }
+
+  @Override
+  public int insertFilter(DashboardFilterPO filter) {
+    requireVersion(filter.getDashboardVersionId());
+    return filterMapper.insert(filter);
+  }
+
+  @Override
+  public int insertFilterBinding(DashboardFilterBindingPO binding) {
+    requireVersion(binding.getDashboardVersionId());
+    return filterBindingMapper.insert(binding);
+  }
+
+  @Override
+  public int insertInteraction(DashboardInteractionPO interaction) {
+    requireVersion(interaction.getDashboardVersionId());
+    return interactionMapper.insert(interaction);
+  }
+
+  @Override
+  public int updateCurrentVersion(
+      long dashboardId,
+      long versionId,
+      int versionNo,
+      String name,
+      String description) {
+    requireOwnedVersion(dashboardId, versionId);
+    return dashboardMapper.update(
+        null,
+        Wrappers.<DashboardPO>lambdaUpdate()
+            .eq(DashboardPO::getProjectId, projectId())
+            .eq(DashboardPO::getId, dashboardId)
+            .set(DashboardPO::getCurrentVersionId, versionId)
+            .set(DashboardPO::getCurrentVersionNo, versionNo)
+            .set(DashboardPO::getName, name)
+            .set(DashboardPO::getDescription, description)
+            .set(DashboardPO::getUpdateTime, Timestamp.from(Instant.now())));
+  }
+
+  @Override
+  public int updatePublishedVersion(long dashboardId, long versionId, int versionNo) {
+    requireOwnedVersion(dashboardId, versionId);
+    Timestamp now = Timestamp.from(Instant.now());
+    return dashboardMapper.update(
+        null,
+        Wrappers.<DashboardPO>lambdaUpdate()
+            .eq(DashboardPO::getProjectId, projectId())
+            .eq(DashboardPO::getId, dashboardId)
+            .set(DashboardPO::getPublishedVersionId, versionId)
+            .set(DashboardPO::getPublishedVersionNo, versionNo)
+            .set(DashboardPO::getPublishedTime, now)
+            .set(DashboardPO::getUpdateTime, now));
+  }
+
+  @Override
+  public DashboardPO selectDashboard(long dashboardId) {
+    return dashboardMapper.selectOne(
+        Wrappers.<DashboardPO>lambdaQuery()
+            .eq(DashboardPO::getProjectId, projectId())
+            .eq(DashboardPO::getId, dashboardId));
+  }
+
+  @Override
+  public List<DashboardPO> selectDashboards() {
+    return dashboardMapper.selectList(
+        Wrappers.<DashboardPO>lambdaQuery()
+            .eq(DashboardPO::getProjectId, projectId())
+            .orderByDesc(DashboardPO::getUpdateTime)
+            .orderByDesc(DashboardPO::getId));
+  }
+
+  @Override
+  public DashboardVersionPO selectVersion(long versionId) {
+    DashboardVersionPO version = versionMapper.selectById(versionId);
+    if (version == null || selectDashboard(version.getDashboardId()) == null) return null;
+    return version;
+  }
+
+  @Override
+  public DashboardVersionPO selectVersionByNo(long dashboardId, int versionNo) {
+    if (selectDashboard(dashboardId) == null) return null;
+    return versionMapper.selectOne(
+        Wrappers.<DashboardVersionPO>lambdaQuery()
+            .eq(DashboardVersionPO::getDashboardId, dashboardId)
+            .eq(DashboardVersionPO::getVersionNo, versionNo));
+  }
+
+  @Override
+  public List<DashboardVersionPO> selectVersions(long dashboardId) {
+    if (selectDashboard(dashboardId) == null) return List.of();
+    return versionMapper.selectList(
+        Wrappers.<DashboardVersionPO>lambdaQuery()
+            .eq(DashboardVersionPO::getDashboardId, dashboardId)
+            .orderByDesc(DashboardVersionPO::getVersionNo));
+  }
+
+  @Override
+  public List<DashboardWidgetPO> selectWidgets(long versionId) {
+    if (selectVersion(versionId) == null) return List.of();
+    return widgetMapper.selectList(
+        Wrappers.<DashboardWidgetPO>lambdaQuery()
+            .eq(DashboardWidgetPO::getDashboardVersionId, versionId)
+            .orderByAsc(DashboardWidgetPO::getSortOrder)
+            .orderByAsc(DashboardWidgetPO::getId));
+  }
+
+  @Override
+  public List<DashboardFilterPO> selectFilters(long versionId) {
+    if (selectVersion(versionId) == null) return List.of();
+    return filterMapper.selectList(
+        Wrappers.<DashboardFilterPO>lambdaQuery()
+            .eq(DashboardFilterPO::getDashboardVersionId, versionId)
+            .orderByAsc(DashboardFilterPO::getSortOrder)
+            .orderByAsc(DashboardFilterPO::getId));
+  }
+
+  @Override
+  public List<DashboardFilterBindingPO> selectFilterBindings(long versionId) {
+    if (selectVersion(versionId) == null) return List.of();
+    return filterBindingMapper.selectList(
+        Wrappers.<DashboardFilterBindingPO>lambdaQuery()
+            .eq(DashboardFilterBindingPO::getDashboardVersionId, versionId)
+            .orderByAsc(DashboardFilterBindingPO::getFilterKey)
+            .orderByAsc(DashboardFilterBindingPO::getSortOrder)
+            .orderByAsc(DashboardFilterBindingPO::getWidgetKey));
+  }
+
+  @Override
+  public List<DashboardInteractionPO> selectInteractions(long versionId) {
+    if (selectVersion(versionId) == null) return List.of();
+    return interactionMapper.selectList(
+        Wrappers.<DashboardInteractionPO>lambdaQuery()
+            .eq(DashboardInteractionPO::getDashboardVersionId, versionId)
+            .orderByAsc(DashboardInteractionPO::getSortOrder)
+            .orderByAsc(DashboardInteractionPO::getId));
+  }
+
+  @Override
+  public boolean existsWidgetByAnalysisId(long analysisId) {
+    return dashboardMapper.countAnalysisReferences(projectId(), analysisId) > 0L;
+  }
+
+  @Override
+  public int selectNextVersionNo(long dashboardId) {
+    requireDashboard(dashboardId);
+    List<Object> values = versionMapper.selectObjs(
+        Wrappers.<DashboardVersionPO>query()
+            .select("COALESCE(MAX(version_no), 0) + 1")
+            .eq("dashboard_id", dashboardId));
+    if (values == null || values.isEmpty() || values.get(0) == null) {
+      return 1;
+    }
+    return ((Number) values.get(0)).intValue();
+  }
+
+  @Override
+  public int deleteDashboard(long dashboardId) {
+    if (selectDashboard(dashboardId) == null) return 0;
+    List<Long> versionIds = versionMapper.selectObjs(
+            Wrappers.<DashboardVersionPO>query()
+                .select("id")
+                .eq("dashboard_id", dashboardId))
+        .stream()
+        .filter(Number.class::isInstance)
+        .map(Number.class::cast)
+        .map(Number::longValue)
+        .toList();
+
+    int deleted = dashboardMapper.delete(
+        Wrappers.<DashboardPO>lambdaQuery()
+            .eq(DashboardPO::getProjectId, projectId())
+            .eq(DashboardPO::getId, dashboardId));
+    if (deleted != 1 || versionIds.isEmpty()) {
+      return deleted;
     }
 
-    @Override
-    public int insertVersion(DashboardVersionPO version) {
-        version.setCreateTime(Timestamp.from(Instant.now()));
-        return versionMapper.insert(version);
+    interactionMapper.delete(
+        Wrappers.<DashboardInteractionPO>lambdaQuery()
+            .in(DashboardInteractionPO::getDashboardVersionId, versionIds));
+    filterBindingMapper.delete(
+        Wrappers.<DashboardFilterBindingPO>lambdaQuery()
+            .in(DashboardFilterBindingPO::getDashboardVersionId, versionIds));
+    filterMapper.delete(
+        Wrappers.<DashboardFilterPO>lambdaQuery()
+            .in(DashboardFilterPO::getDashboardVersionId, versionIds));
+    widgetMapper.delete(
+        Wrappers.<DashboardWidgetPO>lambdaQuery()
+            .in(DashboardWidgetPO::getDashboardVersionId, versionIds));
+    versionMapper.delete(
+        Wrappers.<DashboardVersionPO>lambdaQuery()
+            .in(DashboardVersionPO::getId, versionIds));
+    return deleted;
+  }
+
+  private DashboardPO requireDashboard(long dashboardId) {
+    DashboardPO dashboard = selectDashboard(dashboardId);
+    if (dashboard == null) {
+      throw new IllegalArgumentException("Dashboard 不存在：" + dashboardId);
     }
+    return dashboard;
+  }
 
-    @Override
-    public int insertWidget(DashboardWidgetPO widget) {
-        return widgetMapper.insert(widget);
+  private DashboardVersionPO requireVersion(long versionId) {
+    DashboardVersionPO version = selectVersion(versionId);
+    if (version == null) {
+      throw new IllegalArgumentException("DashboardVersion 不存在：" + versionId);
     }
+    return version;
+  }
 
-    @Override
-    public int insertFilter(DashboardFilterPO filter) {
-        return filterMapper.insert(filter);
+  private void requireOwnedVersion(long dashboardId, long versionId) {
+    requireDashboard(dashboardId);
+    DashboardVersionPO version = requireVersion(versionId);
+    if (!Long.valueOf(dashboardId).equals(version.getDashboardId())) {
+      throw new IllegalArgumentException(
+          "DashboardVersion 不属于 Dashboard：" + versionId + " / " + dashboardId);
     }
+  }
 
-    @Override
-    public int insertFilterBinding(DashboardFilterBindingPO binding) {
-        return filterBindingMapper.insert(binding);
-    }
-
-    @Override
-    public int insertInteraction(DashboardInteractionPO interaction) {
-        return interactionMapper.insert(interaction);
-    }
-
-    @Override
-    public int updateCurrentVersion(
-            long dashboardId,
-            long versionId,
-            int versionNo,
-            String name,
-            String description) {
-        return dashboardMapper.update(
-                null,
-                Wrappers.<DashboardPO>lambdaUpdate()
-                        .eq(DashboardPO::getId, dashboardId)
-                        .set(DashboardPO::getCurrentVersionId, versionId)
-                        .set(DashboardPO::getCurrentVersionNo, versionNo)
-                        .set(DashboardPO::getName, name)
-                        .set(DashboardPO::getDescription, description)
-                        .set(DashboardPO::getUpdateTime, Timestamp.from(Instant.now())));
-    }
-
-    @Override
-    public int updatePublishedVersion(long dashboardId, long versionId, int versionNo) {
-        Timestamp now = Timestamp.from(Instant.now());
-        return dashboardMapper.update(
-                null,
-                Wrappers.<DashboardPO>lambdaUpdate()
-                        .eq(DashboardPO::getId, dashboardId)
-                        .set(DashboardPO::getPublishedVersionId, versionId)
-                        .set(DashboardPO::getPublishedVersionNo, versionNo)
-                        .set(DashboardPO::getPublishedTime, now)
-                        .set(DashboardPO::getUpdateTime, now));
-    }
-
-    @Override
-    public DashboardPO selectDashboard(long dashboardId) {
-        return dashboardMapper.selectById(dashboardId);
-    }
-
-    @Override
-    public List<DashboardPO> selectDashboards() {
-        return dashboardMapper.selectList(
-                Wrappers.<DashboardPO>lambdaQuery()
-                        .orderByDesc(DashboardPO::getUpdateTime)
-                        .orderByDesc(DashboardPO::getId));
-    }
-
-    @Override
-    public DashboardVersionPO selectVersion(long versionId) {
-        return versionMapper.selectById(versionId);
-    }
-
-    @Override
-    public DashboardVersionPO selectVersionByNo(long dashboardId, int versionNo) {
-        return versionMapper.selectOne(
-                Wrappers.<DashboardVersionPO>lambdaQuery()
-                        .eq(DashboardVersionPO::getDashboardId, dashboardId)
-                        .eq(DashboardVersionPO::getVersionNo, versionNo));
-    }
-
-    @Override
-    public List<DashboardVersionPO> selectVersions(long dashboardId) {
-        return versionMapper.selectList(
-                Wrappers.<DashboardVersionPO>lambdaQuery()
-                        .eq(DashboardVersionPO::getDashboardId, dashboardId)
-                        .orderByDesc(DashboardVersionPO::getVersionNo));
-    }
-
-    @Override
-    public List<DashboardWidgetPO> selectWidgets(long versionId) {
-        return widgetMapper.selectList(
-                Wrappers.<DashboardWidgetPO>lambdaQuery()
-                        .eq(DashboardWidgetPO::getDashboardVersionId, versionId)
-                        .orderByAsc(DashboardWidgetPO::getSortOrder)
-                        .orderByAsc(DashboardWidgetPO::getId));
-    }
-
-    @Override
-    public List<DashboardFilterPO> selectFilters(long versionId) {
-        return filterMapper.selectList(
-                Wrappers.<DashboardFilterPO>lambdaQuery()
-                        .eq(DashboardFilterPO::getDashboardVersionId, versionId)
-                        .orderByAsc(DashboardFilterPO::getSortOrder)
-                        .orderByAsc(DashboardFilterPO::getId));
-    }
-
-    @Override
-    public List<DashboardFilterBindingPO> selectFilterBindings(long versionId) {
-        return filterBindingMapper.selectList(
-                Wrappers.<DashboardFilterBindingPO>lambdaQuery()
-                        .eq(DashboardFilterBindingPO::getDashboardVersionId, versionId)
-                        .orderByAsc(DashboardFilterBindingPO::getFilterKey)
-                        .orderByAsc(DashboardFilterBindingPO::getSortOrder)
-                        .orderByAsc(DashboardFilterBindingPO::getWidgetKey));
-    }
-
-    @Override
-    public List<DashboardInteractionPO> selectInteractions(long versionId) {
-        return interactionMapper.selectList(
-                Wrappers.<DashboardInteractionPO>lambdaQuery()
-                        .eq(DashboardInteractionPO::getDashboardVersionId, versionId)
-                        .orderByAsc(DashboardInteractionPO::getSortOrder)
-                        .orderByAsc(DashboardInteractionPO::getId));
-    }
-
-    @Override
-    public boolean existsWidgetByAnalysisId(long analysisId) {
-        return widgetMapper.selectCount(
-                Wrappers.<DashboardWidgetPO>lambdaQuery()
-                        .eq(DashboardWidgetPO::getAnalysisId, analysisId)) > 0L;
-    }
-
-    @Override
-    public int selectNextVersionNo(long dashboardId) {
-        List<Object> values = versionMapper.selectObjs(
-                Wrappers.<DashboardVersionPO>query()
-                        .select("COALESCE(MAX(version_no), 0) + 1")
-                        .eq("dashboard_id", dashboardId));
-        if (values == null || values.isEmpty() || values.get(0) == null) {
-            return 1;
-        }
-        return ((Number) values.get(0)).intValue();
-    }
-
-    @Override
-    public int deleteDashboard(long dashboardId) {
-        List<Long> versionIds = versionMapper.selectObjs(
-                        Wrappers.<DashboardVersionPO>query()
-                                .select("id")
-                                .eq("dashboard_id", dashboardId))
-                .stream()
-                .filter(Number.class::isInstance)
-                .map(Number.class::cast)
-                .map(Number::longValue)
-                .toList();
-
-        int deleted = dashboardMapper.deleteById(dashboardId);
-        if (deleted != 1 || versionIds.isEmpty()) {
-            return deleted;
-        }
-
-        interactionMapper.delete(
-                Wrappers.<DashboardInteractionPO>lambdaQuery()
-                        .in(DashboardInteractionPO::getDashboardVersionId, versionIds));
-        filterBindingMapper.delete(
-                Wrappers.<DashboardFilterBindingPO>lambdaQuery()
-                        .in(DashboardFilterBindingPO::getDashboardVersionId, versionIds));
-        filterMapper.delete(
-                Wrappers.<DashboardFilterPO>lambdaQuery()
-                        .in(DashboardFilterPO::getDashboardVersionId, versionIds));
-        widgetMapper.delete(
-                Wrappers.<DashboardWidgetPO>lambdaQuery()
-                        .in(DashboardWidgetPO::getDashboardVersionId, versionIds));
-        versionMapper.delete(
-                Wrappers.<DashboardVersionPO>lambdaQuery()
-                        .in(DashboardVersionPO::getId, versionIds));
-        return deleted;
-    }
+  private long projectId() {
+    return currentProject.requireProjectId();
+  }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/mapper/DashboardMapper.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/mapper/DashboardMapper.java
@@ -3,7 +3,21 @@ package io.yak.ops.business.dashboard.dao.mapper;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import io.yak.ops.business.dashboard.dao.model.DashboardPO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface DashboardMapper extends BaseMapper<DashboardPO> {
+
+  @Select("""
+      SELECT COUNT(*)
+      FROM yak_dashboard_widget w
+      JOIN yak_dashboard_version v ON v.id = w.dashboard_version_id
+      JOIN yak_dashboard d ON d.id = v.dashboard_id
+      WHERE d.project_id = #{projectId}
+        AND w.analysis_id = #{analysisId}
+      """)
+  long countAnalysisReferences(
+      @Param("projectId") long projectId,
+      @Param("analysisId") long analysisId);
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/mapper/DashboardOverviewMapper.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/mapper/DashboardOverviewMapper.java
@@ -19,8 +19,9 @@ public interface DashboardOverviewMapper {
               ELSE 0
           END), 0) AS publishedDashboardCount
       FROM yak_dashboard
+      WHERE project_id = #{projectId}
       """)
-  DashboardOverviewSummaryPO selectSummary();
+  DashboardOverviewSummaryPO selectSummary(@Param("projectId") long projectId);
 
   @Select("""
       SELECT
@@ -35,8 +36,11 @@ public interface DashboardOverviewMapper {
           create_time AS createTime,
           update_time AS updateTime
       FROM yak_dashboard
+      WHERE project_id = #{projectId}
       ORDER BY update_time DESC, id DESC
       LIMIT #{limit}
       """)
-  List<DashboardPO> selectRecent(@Param("limit") int limit);
+  List<DashboardPO> selectRecent(
+      @Param("projectId") long projectId,
+      @Param("limit") int limit);
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/model/DashboardPO.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/dao/model/DashboardPO.java
@@ -11,6 +11,7 @@ import lombok.Data;
 public class DashboardPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private String name;
   private String description;
   private Long currentVersionId;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/definition/DashboardManager.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/definition/DashboardManager.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.dashboard.domain.DashboardDraft;
 import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.version.DashboardVersionAppender;
+import io.yak.ops.core.project.CurrentProject;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ public class DashboardManager {
   private final DashboardCompositionNormalizer composition;
   private final DashboardVersionAppender versions;
   private final DashboardReader reader;
+  private final CurrentProject currentProject;
   private final ApplicationEventPublisher events;
 
   public DashboardManager(
@@ -26,27 +28,31 @@ public class DashboardManager {
       DashboardCompositionNormalizer composition,
       DashboardVersionAppender versions,
       DashboardReader reader,
+      CurrentProject currentProject,
       ApplicationEventPublisher events) {
     this.dashboards = dashboards;
     this.composition = composition;
     this.versions = versions;
     this.reader = reader;
+    this.currentProject = currentProject;
     this.events = events;
   }
 
   @Transactional("yakBusinessTransactionManager")
   public DashboardDetail create(DashboardDraft draft) {
+    long projectId = currentProject.requireProjectId();
     DashboardDraft normalized = composition.normalize(draft);
     long dashboardId = dashboards.insertDashboard(normalized.name(), normalized.description());
     versions.append(dashboardId, 1, normalized);
-    events.publishEvent(DashboardChangedEvent.refreshed(dashboardId));
+    events.publishEvent(DashboardChangedEvent.refreshed(projectId, dashboardId));
     return reader.get(dashboardId);
   }
 
   @Transactional("yakBusinessTransactionManager")
   public void delete(long dashboardId) {
+    long projectId = currentProject.requireProjectId();
     reader.require(dashboardId);
     dashboards.deleteDashboard(dashboardId);
-    events.publishEvent(DashboardChangedEvent.deleted(dashboardId));
+    events.publishEvent(DashboardChangedEvent.deleted(projectId, dashboardId));
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/gateway/dataset/DashboardDatasetGateway.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/gateway/dataset/DashboardDatasetGateway.java
@@ -1,0 +1,7 @@
+package io.yak.ops.business.dashboard.gateway.dataset;
+
+/** Dashboard-owned port for proving Dataset references inside the current Project. */
+public interface DashboardDatasetGateway {
+
+  void requireExists(long datasetId);
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/gateway/dataset/DatasetDashboardAdapter.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/gateway/dataset/DatasetDashboardAdapter.java
@@ -1,0 +1,20 @@
+package io.yak.ops.business.dashboard.gateway.dataset;
+
+import io.yak.ops.business.dataset.definition.DatasetReader;
+import org.springframework.stereotype.Component;
+
+/** Adapts Dataset's project-scoped read contract to Dashboard. */
+@Component
+public class DatasetDashboardAdapter implements DashboardDatasetGateway {
+
+  private final DatasetReader reader;
+
+  public DatasetDashboardAdapter(DatasetReader reader) {
+    this.reader = reader;
+  }
+
+  @Override
+  public void requireExists(long datasetId) {
+    reader.require(datasetId);
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListener.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListener.java
@@ -4,6 +4,8 @@ import io.yak.ops.business.dashboard.change.DashboardChangedEvent;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
 import io.yak.ops.business.dashboard.publication.DashboardEffectiveSnapshotReader;
 import io.yak.ops.business.dashboard.publication.DashboardEffectiveSnapshotReader.EffectiveSnapshot;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,35 +21,45 @@ public class DashboardLineageRefreshListener {
 
   private final DashboardEffectiveSnapshotReader snapshots;
   private final DashboardLineageSynchronizer lineage;
+  private final ProjectContextScope projectContextScope;
 
   public DashboardLineageRefreshListener(
       DashboardEffectiveSnapshotReader snapshots,
-      DashboardLineageSynchronizer lineage) {
+      DashboardLineageSynchronizer lineage,
+      ProjectContextScope projectContextScope) {
     this.snapshots = snapshots;
     this.lineage = lineage;
+    this.projectContextScope = projectContextScope;
   }
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
   public void refresh(DashboardChangedEvent event) {
-    if (event == null || event.dashboardId() <= 0L) return;
+    if (event == null || event.projectId() <= 0L || event.dashboardId() <= 0L) return;
     try {
-      if (event.deleted()) {
-        lineage.clear(event.dashboardId());
-        return;
-      }
-      EffectiveSnapshot effective = snapshots.read(event.dashboardId());
-      DashboardVersionSnapshot snapshot = effective.snapshot();
-      lineage.syncVersion(
-          effective.dashboard(),
-          snapshot == null ? null : snapshot.version(),
-          snapshot == null ? List.of() : snapshot.widgets(),
-          effective.published());
+      projectContextScope.run(
+          new ProjectContext(event.projectId(), null),
+          () -> refreshWithinProject(event));
     } catch (RuntimeException exception) {
       LOGGER.warn(
-          "Dashboard lineage refresh failed after commit for dashboard {}: {}",
+          "Dashboard lineage refresh failed after commit for project {} dashboard {}: {}",
+          event.projectId(),
           event.dashboardId(),
           exception.getMessage(),
           exception);
     }
+  }
+
+  private void refreshWithinProject(DashboardChangedEvent event) {
+    if (event.deleted()) {
+      lineage.clear(event.dashboardId());
+      return;
+    }
+    EffectiveSnapshot effective = snapshots.read(event.dashboardId());
+    DashboardVersionSnapshot snapshot = effective.snapshot();
+    lineage.syncVersion(
+        effective.dashboard(),
+        snapshot == null ? null : snapshot.version(),
+        snapshot == null ? List.of() : snapshot.widgets(),
+        effective.published());
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/publication/DashboardPublisher.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/publication/DashboardPublisher.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
 import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.repository.DashboardVersionRepository;
+import io.yak.ops.core.project.CurrentProject;
 import java.util.Objects;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -19,21 +20,25 @@ public class DashboardPublisher {
   private final DashboardReader reader;
   private final DashboardRepository dashboards;
   private final DashboardVersionRepository versions;
+  private final CurrentProject currentProject;
   private final ApplicationEventPublisher events;
 
   public DashboardPublisher(
       DashboardReader reader,
       DashboardRepository dashboards,
       DashboardVersionRepository versions,
+      CurrentProject currentProject,
       ApplicationEventPublisher events) {
     this.reader = reader;
     this.dashboards = dashboards;
     this.versions = versions;
+    this.currentProject = currentProject;
     this.events = events;
   }
 
   @Transactional("yakBusinessTransactionManager")
   public DashboardDetail publish(long dashboardId) {
+    long projectId = currentProject.requireProjectId();
     DashboardAsset dashboard = reader.require(dashboardId);
     if (dashboard.currentVersionId() == null || dashboard.currentVersionNo() <= 0) {
       throw new IllegalStateException("Dashboard 没有可发布的草稿：" + dashboardId);
@@ -49,7 +54,7 @@ public class DashboardPublisher {
         dashboardId,
         current.version().id(),
         current.version().versionNo());
-    events.publishEvent(DashboardChangedEvent.refreshed(dashboardId));
+    events.publishEvent(DashboardChangedEvent.refreshed(projectId, dashboardId));
     return reader.get(dashboardId);
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/repository/DashboardOverviewRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/repository/DashboardOverviewRepositoryAdapter.java
@@ -5,6 +5,7 @@ import io.yak.ops.business.dashboard.dao.model.DashboardOverviewSummaryPO;
 import io.yak.ops.business.dashboard.dao.model.DashboardPO;
 import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import io.yak.ops.core.project.CurrentProject;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
@@ -18,17 +19,20 @@ import org.springframework.stereotype.Repository;
 public class DashboardOverviewRepositoryAdapter implements DashboardOverviewRepository {
 
   private final DashboardOverviewMapper mapper;
+  private final CurrentProject currentProject;
 
   @Override
   public Summary summarize() {
-    DashboardOverviewSummaryPO value = mapper.selectSummary();
+    DashboardOverviewSummaryPO value = mapper.selectSummary(projectId());
     if (value == null) return new Summary(0L, 0L);
     return new Summary(number(value.getDashboardCount()), number(value.getPublishedDashboardCount()));
   }
 
   @Override
   public List<DashboardAsset> listRecent(int limit) {
-    return mapper.selectRecent(normalizeLimit(limit)).stream().map(this::toDomain).toList();
+    return mapper.selectRecent(projectId(), normalizeLimit(limit)).stream()
+        .map(this::toDomain)
+        .toList();
   }
 
   private DashboardAsset toDomain(DashboardPO value) {
@@ -59,5 +63,9 @@ public class DashboardOverviewRepositoryAdapter implements DashboardOverviewRepo
 
   private Instant instant(Timestamp value) {
     return value == null ? null : value.toInstant();
+  }
+
+  private long projectId() {
+    return currentProject.requireProjectId();
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/version/DashboardVersionManager.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/java/io/yak/ops/business/dashboard/version/DashboardVersionManager.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.dashboard.domain.GlobalFilterSpec;
 import io.yak.ops.business.dashboard.domain.InteractionSpec;
 import io.yak.ops.business.dashboard.domain.WidgetSpec;
 import io.yak.ops.business.dashboard.read.DashboardReader;
+import io.yak.ops.core.project.CurrentProject;
 import java.util.List;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,7 @@ public class DashboardVersionManager {
   private final DashboardVersionReader versions;
   private final DashboardCompositionNormalizer composition;
   private final DashboardVersionAppender appender;
+  private final CurrentProject currentProject;
   private final ApplicationEventPublisher events;
 
   public DashboardVersionManager(
@@ -30,20 +32,23 @@ public class DashboardVersionManager {
       DashboardVersionReader versions,
       DashboardCompositionNormalizer composition,
       DashboardVersionAppender appender,
+      CurrentProject currentProject,
       ApplicationEventPublisher events) {
     this.dashboards = dashboards;
     this.versions = versions;
     this.composition = composition;
     this.appender = appender;
+    this.currentProject = currentProject;
     this.events = events;
   }
 
   @Transactional("yakBusinessTransactionManager")
   public DashboardDetail saveVersion(long dashboardId, DashboardDraft draft) {
+    long projectId = currentProject.requireProjectId();
     dashboards.require(dashboardId);
     DashboardDraft normalized = composition.normalize(draft);
     appender.appendNext(dashboardId, normalized);
-    events.publishEvent(DashboardChangedEvent.refreshed(dashboardId));
+    events.publishEvent(DashboardChangedEvent.refreshed(projectId, dashboardId));
     return dashboards.get(dashboardId);
   }
 

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V2__expand_and_backfill_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V2__expand_and_backfill_project_scope.sql
@@ -1,0 +1,52 @@
+-- Project Space expand and deterministic ownership proof for Dashboard roots.
+-- DashboardVersion and all composition rows continue to inherit through dashboard_id.
+ALTER TABLE yak_dashboard
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id,
+    ADD KEY idx_yak_dashboard_project_update (project_id, update_time, id);
+
+-- One evidence row is recorded for every explicit Dataset/Analysis reference.
+-- A Dashboard is backfilled only when every reference resolves and all references agree.
+CREATE TEMPORARY TABLE tmp_yak_dashboard_project_evidence (
+    dashboard_id BIGINT NOT NULL,
+    project_id BIGINT NULL
+);
+
+INSERT INTO tmp_yak_dashboard_project_evidence (dashboard_id, project_id)
+SELECT v.dashboard_id, d.project_id
+FROM yak_dashboard_version v
+LEFT JOIN yak_dataset d ON d.id = v.active_dataset_id
+WHERE v.active_dataset_id IS NOT NULL;
+
+INSERT INTO tmp_yak_dashboard_project_evidence (dashboard_id, project_id)
+SELECT v.dashboard_id, a.project_id
+FROM yak_dashboard_version v
+JOIN yak_dashboard_widget w ON w.dashboard_version_id = v.id
+LEFT JOIN yak_analysis a ON a.id = w.analysis_id
+WHERE w.analysis_id IS NOT NULL;
+
+INSERT INTO tmp_yak_dashboard_project_evidence (dashboard_id, project_id)
+SELECT v.dashboard_id, d.project_id
+FROM yak_dashboard_version v
+JOIN yak_dashboard_widget w ON w.dashboard_version_id = v.id
+LEFT JOIN yak_dataset d
+  ON d.id = CASE
+      WHEN JSON_UNQUOTE(JSON_EXTRACT(w.inline_analysis_json, '$.datasetId'))
+          REGEXP '^[1-9][0-9]*$'
+      THEN CAST(JSON_UNQUOTE(JSON_EXTRACT(w.inline_analysis_json, '$.datasetId')) AS UNSIGNED)
+      ELSE NULL
+  END
+WHERE w.inline_analysis_json IS NOT NULL
+  AND JSON_EXTRACT(w.inline_analysis_json, '$.datasetId') IS NOT NULL;
+
+UPDATE yak_dashboard dashboard
+JOIN (
+    SELECT dashboard_id, MIN(project_id) AS project_id
+    FROM tmp_yak_dashboard_project_evidence
+    GROUP BY dashboard_id
+    HAVING COUNT(*) = COUNT(project_id)
+       AND MIN(project_id) = MAX(project_id)
+) owner ON owner.dashboard_id = dashboard.id
+SET dashboard.project_id = owner.project_id
+WHERE dashboard.project_id IS NULL;
+
+DROP TEMPORARY TABLE tmp_yak_dashboard_project_evidence;

--- a/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V3__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-dashboard/src/main/resources/db/migration/yak-dashboard/V3__contract_project_scope.sql
@@ -1,0 +1,3 @@
+-- Contract phase: empty, unresolved or mixed-project historical Dashboards must block deployment.
+ALTER TABLE yak_dashboard
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardArchitectureDocumentationTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardArchitectureDocumentationTest.java
@@ -43,19 +43,24 @@ class DashboardArchitectureDocumentationTest {
         .contains("Restore is copy-forward")
         .contains("Analysis owns reusable analytical definitions")
         .contains("Lineage owns graph truth")
+        .contains("ProjectContextScope")
         .contains("version allocation concurrency");
   }
 
   @Test
-  void dependencyContractNamesTheTwoCrossModuleGateways() throws IOException {
+  void dependencyContractNamesAllCrossModuleGatewaysAndProjectCorridors() throws IOException {
     String dependencies = Files.readString(moduleRoot().resolve("DEPENDENCIES.md"));
 
     assertThat(dependencies)
         .contains("DashboardAnalysisGateway")
         .contains("AnalysisDashboardAdapter")
+        .contains("DashboardDatasetGateway")
+        .contains("DatasetDashboardAdapter")
         .contains("DashboardLineageGraphGateway")
         .contains("LineageDashboardAdapter")
         .contains("DashboardReferenceRepository")
+        .contains("CurrentProject")
+        .contains("ProjectContextScope")
         .contains("acyclic");
   }
 

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardDependencyBoundaryTest.java
@@ -56,6 +56,19 @@ class DashboardDependencyBoundaryTest {
   }
 
   @Test
+  void compositionEntersDatasetOnlyThroughDashboardOwnedGateway() throws IOException {
+    assertPackageDoesNotImport("composition", "io.yak.ops.business.dataset");
+
+    for (Path source : productionJavaFiles()) {
+      String relative = relative(source);
+      String text = Files.readString(source);
+      if (text.contains("import io.yak.ops.business.dataset.")) {
+        assertThat(relative).isEqualTo("gateway/dataset/DatasetDashboardAdapter.java");
+      }
+    }
+  }
+
+  @Test
   void lineageEntersSharedGraphOnlyThroughDashboardOwnedGateway() throws IOException {
     assertPackageDoesNotImport("lineage", "io.yak.ops.business.lineage");
 

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardProjectSpaceContractTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardProjectSpaceContractTest.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.dashboard.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class DashboardProjectSpaceContractTest {
+
+  @Test
+  void rootCrudOverviewAndReferenceChecksAreProjectScoped() throws IOException {
+    String dao = read("src/main/java/io/yak/ops/business/dashboard/dao/impl/DashboardDaoImpl.java");
+    String mapper = read("src/main/java/io/yak/ops/business/dashboard/dao/mapper/DashboardMapper.java");
+    String overview = read(
+        "src/main/java/io/yak/ops/business/dashboard/dao/mapper/DashboardOverviewMapper.java");
+    String po = read("src/main/java/io/yak/ops/business/dashboard/dao/model/DashboardPO.java");
+
+    assertThat(po).contains("private Long projectId;");
+    assertThat(dao)
+        .contains("CurrentProject")
+        .contains("currentProject.requireProjectId()")
+        .contains("DashboardPO::getProjectId")
+        .doesNotContain("dashboardMapper.selectById(dashboardId)")
+        .doesNotContain("dashboardMapper.deleteById(dashboardId)");
+    assertThat(mapper).contains("d.project_id = #{projectId}");
+    assertThat(overview).contains("WHERE project_id = #{projectId}");
+  }
+
+  @Test
+  void datasetAndAnalysisReferencesAreProvedInsideCurrentProject() throws IOException {
+    String composition = read(
+        "src/main/java/io/yak/ops/business/dashboard/composition/DashboardCompositionNormalizer.java");
+    String widgets = read(
+        "src/main/java/io/yak/ops/business/dashboard/composition/DashboardWidgetPolicy.java");
+
+    assertThat(composition).contains("datasets.requireExists(activeDatasetId)");
+    assertThat(widgets)
+        .contains("analyses.requireExists(value.analysisId())")
+        .contains("datasets.requireExists(datasetId)");
+  }
+
+  @Test
+  void migrationRequiresCompleteSingleProjectEvidenceThenContracts() throws IOException {
+    String expand = read(
+        "src/main/resources/db/migration/yak-dashboard/V2__expand_and_backfill_project_scope.sql");
+    String contract = read(
+        "src/main/resources/db/migration/yak-dashboard/V3__contract_project_scope.sql");
+
+    assertThat(expand)
+        .contains("ADD COLUMN project_id BIGINT NULL")
+        .contains("tmp_yak_dashboard_project_evidence")
+        .contains("COUNT(*) = COUNT(project_id)")
+        .contains("MIN(project_id) = MAX(project_id)")
+        .doesNotContain("project_id = 1")
+        .doesNotContain("DEFAULT 0");
+    assertThat(contract)
+        .contains("project_id BIGINT NOT NULL")
+        .doesNotContainIgnoringCase("UPDATE");
+  }
+
+  @Test
+  void afterCommitLineageRestoresFrozenProjectContext() throws IOException {
+    String event = read(
+        "src/main/java/io/yak/ops/business/dashboard/change/DashboardChangedEvent.java");
+    String listener = read(
+        "src/main/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListener.java");
+
+    assertThat(event).contains("long projectId");
+    assertThat(listener)
+        .contains("ProjectContextScope")
+        .contains("new ProjectContext(event.projectId(), null)");
+  }
+
+  private String read(String relative) throws IOException {
+    return Files.readString(moduleRoot().resolve(relative));
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/dashboard");
+    if (Files.isDirectory(local)) return Path.of(".");
+    return Path.of("yak-ops-business", "yak-ops-business-dashboard");
+  }
+}

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/architecture/DashboardRoleConventionTest.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.dashboard.composition.DashboardLayoutPolicy;
 import io.yak.ops.business.dashboard.composition.DashboardWidgetPolicy;
 import io.yak.ops.business.dashboard.definition.DashboardManager;
 import io.yak.ops.business.dashboard.gateway.analysis.AnalysisDashboardAdapter;
+import io.yak.ops.business.dashboard.gateway.dataset.DatasetDashboardAdapter;
 import io.yak.ops.business.dashboard.gateway.lineage.LineageDashboardAdapter;
 import io.yak.ops.business.dashboard.lineage.DashboardInlineLineageExtractor;
 import io.yak.ops.business.dashboard.lineage.DashboardLineageRefreshListener;
@@ -80,6 +81,7 @@ class DashboardRoleConventionTest {
         DashboardInteractionPolicy.class,
         DashboardJsonPolicy.class,
         AnalysisDashboardAdapter.class,
+        DatasetDashboardAdapter.class,
         LineageDashboardAdapter.class,
         DashboardLineageRefreshListener.class,
         DashboardLineageSynchronizer.class,

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/composition/DashboardCompositionNormalizerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/composition/DashboardCompositionNormalizerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
 import io.yak.ops.business.dashboard.domain.WidgetSpec;
 import io.yak.ops.business.dashboard.gateway.analysis.DashboardAnalysisGateway;
+import io.yak.ops.business.dashboard.gateway.dataset.DashboardDatasetGateway;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -16,9 +17,10 @@ import org.junit.jupiter.api.Test;
 class DashboardCompositionNormalizerTest {
 
   @Test
-  void linkedWidgetUsesAnalysisGatewayAndPreservesLayout() {
+  void linkedWidgetAndActiveDatasetUseProjectScopedGateways() {
     DashboardAnalysisGateway analyses = mock(DashboardAnalysisGateway.class);
-    DashboardCompositionNormalizer normalizer = normalizer(analyses);
+    DashboardDatasetGateway datasets = mock(DashboardDatasetGateway.class);
+    DashboardCompositionNormalizer normalizer = normalizer(analyses, datasets);
     DashboardDraft draft = new DashboardDraft(
         "  销售驾驶舱  ",
         null,
@@ -33,12 +35,35 @@ class DashboardCompositionNormalizerTest {
     assertThat(normalized.name()).isEqualTo("销售驾驶舱");
     assertThat(normalized.widgets()).hasSize(1);
     assertThat(normalized.widgets().get(0).w()).isEqualTo(10);
+    verify(datasets).requireExists(12L);
     verify(analyses).requireExists(99L);
   }
 
   @Test
+  void inlineAnalysisDatasetUsesProjectScopedDatasetGateway() {
+    DashboardDatasetGateway datasets = mock(DashboardDatasetGateway.class);
+    DashboardCompositionNormalizer normalizer =
+        normalizer(mock(DashboardAnalysisGateway.class), datasets);
+    DashboardDraft draft = new DashboardDraft(
+        "D",
+        null,
+        null,
+        null,
+        List.of(new WidgetSpec(
+            "w1", null, null, Map.of("datasetId", 44L), 0, 0, 6, 4, null, null)),
+        List.of(),
+        List.of());
+
+    normalizer.normalize(draft);
+
+    verify(datasets).requireExists(44L);
+  }
+
+  @Test
   void widgetCannotLinkReusableAndInlineAnalysisAtTheSameTime() {
-    DashboardCompositionNormalizer normalizer = normalizer(mock(DashboardAnalysisGateway.class));
+    DashboardCompositionNormalizer normalizer = normalizer(
+        mock(DashboardAnalysisGateway.class),
+        mock(DashboardDatasetGateway.class));
     DashboardDraft draft = new DashboardDraft(
         "D",
         null,
@@ -54,14 +79,22 @@ class DashboardCompositionNormalizerTest {
         .hasMessageContaining("必须且只能选择");
   }
 
-  private DashboardCompositionNormalizer normalizer(DashboardAnalysisGateway analyses) {
-    DashboardJsonPolicy json = new DashboardJsonPolicy(new ObjectMapper());
-    DashboardWidgetPolicy widgets =
-        new DashboardWidgetPolicy(analyses, new DashboardLayoutPolicy(), json);
+  private DashboardCompositionNormalizer normalizer(
+      DashboardAnalysisGateway analyses,
+      DashboardDatasetGateway datasets) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    DashboardJsonPolicy json = new DashboardJsonPolicy(objectMapper);
+    DashboardWidgetPolicy widgets = new DashboardWidgetPolicy(
+        analyses,
+        datasets,
+        new DashboardLayoutPolicy(),
+        json,
+        objectMapper);
     return new DashboardCompositionNormalizer(
         json,
         widgets,
         new DashboardFilterPolicy(json),
-        new DashboardInteractionPolicy());
+        new DashboardInteractionPolicy(),
+        datasets);
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/composition/DashboardCompositionNormalizerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/composition/DashboardCompositionNormalizerTest.java
@@ -82,14 +82,9 @@ class DashboardCompositionNormalizerTest {
   private DashboardCompositionNormalizer normalizer(
       DashboardAnalysisGateway analyses,
       DashboardDatasetGateway datasets) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    DashboardJsonPolicy json = new DashboardJsonPolicy(objectMapper);
-    DashboardWidgetPolicy widgets = new DashboardWidgetPolicy(
-        analyses,
-        datasets,
-        new DashboardLayoutPolicy(),
-        json,
-        objectMapper);
+    DashboardJsonPolicy json = new DashboardJsonPolicy(new ObjectMapper());
+    DashboardWidgetPolicy widgets =
+        new DashboardWidgetPolicy(analyses, datasets, new DashboardLayoutPolicy(), json);
     return new DashboardCompositionNormalizer(
         json,
         widgets,

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/controller/v1/DashboardControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/controller/v1/DashboardControllerContractTest.java
@@ -1,7 +1,9 @@
 package io.yak.ops.business.dashboard.controller.v1;
 
+import static io.yak.ops.core.project.ProjectMigrationMode.PROJECT_REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.core.project.ProjectScope;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,10 +12,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 class DashboardControllerContractTest {
 
   @Test
-  void baseRestPathRemainsStable() {
+  void baseRestPathRemainsStableInsideRequiredProjectScope() {
     RequestMapping mapping = DashboardController.class.getAnnotation(RequestMapping.class);
+    ProjectScope controllerScope = DashboardController.class.getAnnotation(ProjectScope.class);
+    ProjectScope overviewScope = DashboardOverviewController.class.getAnnotation(ProjectScope.class);
+
     assertThat(mapping).isNotNull();
     assertThat(mapping.value()).containsExactly("/api/v1/dashboards");
+    assertThat(controllerScope).isNotNull();
+    assertThat(controllerScope.value()).isEqualTo(PROJECT_REQUIRED);
+    assertThat(overviewScope).isNotNull();
+    assertThat(overviewScope.value()).isEqualTo(PROJECT_REQUIRED);
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/definition/DashboardManagerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/definition/DashboardManagerTest.java
@@ -13,21 +13,24 @@ import io.yak.ops.business.dashboard.domain.DashboardDraft;
 import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.version.DashboardVersionAppender;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 
 class DashboardManagerTest {
 
   @Test
-  void createAppendsV1AndPublishesCommittedChangeFact() {
+  void createAppendsV1AndPublishesProjectScopedChangeFact() {
     DashboardRepository repository = mock(DashboardRepository.class);
     DashboardCompositionNormalizer composition = mock(DashboardCompositionNormalizer.class);
     DashboardVersionAppender versions = mock(DashboardVersionAppender.class);
     DashboardReader reader = mock(DashboardReader.class);
     ApplicationEventPublisher events = mock(ApplicationEventPublisher.class);
     DashboardManager manager = new DashboardManager(
-        repository, composition, versions, reader, events);
+        repository, composition, versions, reader, currentProject(23L), events);
     DashboardDraft draft = new DashboardDraft("D", null, null, null, List.of(), List.of(), List.of());
     DashboardDetail detail = new DashboardDetail(
         mock(DashboardAsset.class), null, null, List.of(), List.of(), List.of(), List.of());
@@ -40,6 +43,10 @@ class DashboardManagerTest {
 
     assertThat(created).isSameAs(detail);
     verify(versions).append(7L, 1, draft);
-    verify(events).publishEvent(DashboardChangedEvent.refreshed(7L));
+    verify(events).publishEvent(DashboardChangedEvent.refreshed(23L, 7L));
+  }
+
+  private CurrentProject currentProject(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "P" + projectId));
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListenerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/lineage/DashboardLineageRefreshListenerTest.java
@@ -1,5 +1,6 @@
 package io.yak.ops.business.dashboard.lineage;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -12,25 +13,31 @@ import io.yak.ops.business.dashboard.domain.DashboardVersion;
 import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
 import io.yak.ops.business.dashboard.publication.DashboardEffectiveSnapshotReader;
 import io.yak.ops.business.dashboard.publication.DashboardEffectiveSnapshotReader.EffectiveSnapshot;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import java.time.Instant;
 import java.util.List;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 class DashboardLineageRefreshListenerTest {
 
   @Test
-  void refreshUsesEffectiveSnapshotChosenByPublicationReadSide() {
+  void refreshRestoresProjectAndUsesEffectiveSnapshot() {
     DashboardEffectiveSnapshotReader snapshots = mock(DashboardEffectiveSnapshotReader.class);
     DashboardLineageSynchronizer lineage = mock(DashboardLineageSynchronizer.class);
-    DashboardLineageRefreshListener listener = new DashboardLineageRefreshListener(snapshots, lineage);
+    RecordingProjectContextScope scope = new RecordingProjectContextScope();
+    DashboardLineageRefreshListener listener =
+        new DashboardLineageRefreshListener(snapshots, lineage, scope);
     DashboardAsset dashboard = dashboard();
     DashboardVersion version = new DashboardVersion(12L, 7L, 3, "D", null, null, Instant.EPOCH);
     DashboardVersionSnapshot snapshot =
         new DashboardVersionSnapshot(version, null, List.of(), List.of(), List.of());
     when(snapshots.read(7L)).thenReturn(new EffectiveSnapshot(dashboard, snapshot, true));
 
-    listener.refresh(DashboardChangedEvent.refreshed(7L));
+    listener.refresh(DashboardChangedEvent.refreshed(23L, 7L));
 
+    assertThat(scope.context.projectId()).isEqualTo(23L);
     verify(lineage).syncVersion(dashboard, version, List.of(), true);
   }
 
@@ -38,26 +45,40 @@ class DashboardLineageRefreshListenerTest {
   void projectionFailureDoesNotEscapeCommittedBusinessMutation() {
     DashboardEffectiveSnapshotReader snapshots = mock(DashboardEffectiveSnapshotReader.class);
     DashboardLineageSynchronizer lineage = mock(DashboardLineageSynchronizer.class);
-    DashboardLineageRefreshListener listener = new DashboardLineageRefreshListener(snapshots, lineage);
+    DashboardLineageRefreshListener listener = new DashboardLineageRefreshListener(
+        snapshots, lineage, new RecordingProjectContextScope());
     doThrow(new IllegalStateException("lineage unavailable")).when(snapshots).read(7L);
 
-    assertThatCode(() -> listener.refresh(DashboardChangedEvent.refreshed(7L)))
+    assertThatCode(() -> listener.refresh(DashboardChangedEvent.refreshed(23L, 7L)))
         .doesNotThrowAnyException();
   }
 
   @Test
-  void deleteOnlyClearsDashboardScopedEvidence() {
+  void deleteOnlyClearsDashboardEvidenceInsideOwningProject() {
     DashboardEffectiveSnapshotReader snapshots = mock(DashboardEffectiveSnapshotReader.class);
     DashboardLineageSynchronizer lineage = mock(DashboardLineageSynchronizer.class);
-    DashboardLineageRefreshListener listener = new DashboardLineageRefreshListener(snapshots, lineage);
+    RecordingProjectContextScope scope = new RecordingProjectContextScope();
+    DashboardLineageRefreshListener listener =
+        new DashboardLineageRefreshListener(snapshots, lineage, scope);
 
-    listener.refresh(DashboardChangedEvent.deleted(7L));
+    listener.refresh(DashboardChangedEvent.deleted(23L, 7L));
 
+    assertThat(scope.context.projectId()).isEqualTo(23L);
     verify(lineage).clear(7L);
   }
 
   private DashboardAsset dashboard() {
     return new DashboardAsset(
         7L, "D", null, 12L, 3, 12L, 3, Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
+  }
+
+  private static final class RecordingProjectContextScope implements ProjectContextScope {
+    private ProjectContext context;
+
+    @Override
+    public <T> T call(ProjectContext context, Supplier<T> action) {
+      this.context = context;
+      return action.get();
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/publication/DashboardPublisherTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/publication/DashboardPublisherTest.java
@@ -13,6 +13,8 @@ import io.yak.ops.business.dashboard.domain.DashboardVersionSnapshot;
 import io.yak.ops.business.dashboard.read.DashboardReader;
 import io.yak.ops.business.dashboard.repository.DashboardRepository;
 import io.yak.ops.business.dashboard.repository.DashboardVersionRepository;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -22,12 +24,13 @@ import org.springframework.context.ApplicationEventPublisher;
 class DashboardPublisherTest {
 
   @Test
-  void publishMovesOnlyPublishedPointerToCurrentVersion() {
+  void publishMovesPointerAndPublishesProjectScopedChangeFact() {
     DashboardReader reader = mock(DashboardReader.class);
     DashboardRepository dashboards = mock(DashboardRepository.class);
     DashboardVersionRepository versions = mock(DashboardVersionRepository.class);
     ApplicationEventPublisher events = mock(ApplicationEventPublisher.class);
-    DashboardPublisher publisher = new DashboardPublisher(reader, dashboards, versions, events);
+    DashboardPublisher publisher = new DashboardPublisher(
+        reader, dashboards, versions, currentProject(23L), events);
     DashboardAsset dashboard = new DashboardAsset(
         7L, "D", null, 12L, 3, 10L, 2, Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
     DashboardVersion version = new DashboardVersion(12L, 7L, 3, "D", null, null, Instant.EPOCH);
@@ -44,6 +47,10 @@ class DashboardPublisherTest {
 
     assertThat(published).isSameAs(detail);
     verify(dashboards).updatePublishedVersion(7L, 12L, 3);
-    verify(events).publishEvent(DashboardChangedEvent.refreshed(7L));
+    verify(events).publishEvent(DashboardChangedEvent.refreshed(23L, 7L));
+  }
+
+  private CurrentProject currentProject(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "P" + projectId));
   }
 }

--- a/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/version/DashboardVersionManagerTest.java
+++ b/yak-ops-business/yak-ops-business-dashboard/src/test/java/io/yak/ops/business/dashboard/version/DashboardVersionManagerTest.java
@@ -11,21 +11,24 @@ import io.yak.ops.business.dashboard.domain.DashboardAsset;
 import io.yak.ops.business.dashboard.domain.DashboardDetail;
 import io.yak.ops.business.dashboard.domain.DashboardDraft;
 import io.yak.ops.business.dashboard.read.DashboardReader;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 
 class DashboardVersionManagerTest {
 
   @Test
-  void saveCreatesANewImmutableVersionAndMovesCurrentPointerThroughAppender() {
+  void saveCreatesVersionAndPublishesProjectScopedChangeFact() {
     DashboardReader dashboards = mock(DashboardReader.class);
     DashboardVersionReader versionReader = mock(DashboardVersionReader.class);
     DashboardCompositionNormalizer composition = mock(DashboardCompositionNormalizer.class);
     DashboardVersionAppender appender = mock(DashboardVersionAppender.class);
     ApplicationEventPublisher events = mock(ApplicationEventPublisher.class);
     DashboardVersionManager manager = new DashboardVersionManager(
-        dashboards, versionReader, composition, appender, events);
+        dashboards, versionReader, composition, appender, currentProject(23L), events);
     DashboardDraft draft = new DashboardDraft("V", null, null, null, List.of(), List.of(), List.of());
     DashboardDetail detail = new DashboardDetail(
         mock(DashboardAsset.class), null, null, List.of(), List.of(), List.of(), List.of());
@@ -38,6 +41,10 @@ class DashboardVersionManagerTest {
 
     assertThat(saved).isSameAs(detail);
     verify(appender).appendNext(3L, draft);
-    verify(events).publishEvent(DashboardChangedEvent.refreshed(3L));
+    verify(events).publishEvent(DashboardChangedEvent.refreshed(23L, 3L));
+  }
+
+  private CurrentProject currentProject(long projectId) {
+    return () -> Optional.of(new ProjectContext(projectId, "P" + projectId));
   }
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/README.md
+++ b/yak-ops-business/yak-ops-business-digital-screen/README.md
@@ -1,16 +1,34 @@
 # Yak Ops Digital Screen
 
-Digital Screen owns the persisted screen definition and its lightweight lifecycle. It does not execute Dataset queries; runtime data continues to flow through the Dataset module.
+Digital Screen owns Project-scoped persisted screen definitions, mutable Draft state and append-only published snapshots. It does not execute Dataset queries; runtime data continues to flow through the owning data capabilities.
 
-PR 1 intentionally persists one mutable screen definition with `DRAFT` / `PUBLISHED` status. Immutable published snapshots, version history and rollback belong to PR 2.
+`yak_digital_screen` is a `PROJECT_ROOT`. Published versions inherit ownership through `screen_id`. The management controller is `PROJECT_REQUIRED`, root CRUD always uses trusted `CurrentProject`, and version reads prove the owning Screen before returning an inherited row.
+
+Historical bindings are template-defined opaque JSON, so the Project migration never guesses ownership. Existing rows must be assigned explicitly after business review; unresolved rows intentionally block the `NOT NULL` contract.
+
+## Lifecycle
+
+```text
+create Draft
+ -> update Draft (revision increases)
+ -> publish immutable version
+ -> optionally offline
+ -> rollback by copying an old version into a new published version
+```
+
+Duplicate creates a new Project-owned Draft and does not copy publication history.
 
 ## API
 
 - `GET /api/v1/digital-screens`
 - `GET /api/v1/digital-screens/{id}`
+- `GET /api/v1/digital-screens/{id}/published`
+- `GET /api/v1/digital-screens/{id}/versions`
+- `GET /api/v1/digital-screens/{id}/versions/{versionNo}`
 - `POST /api/v1/digital-screens`
 - `PUT /api/v1/digital-screens/{id}`
 - `POST /api/v1/digital-screens/{id}/publish`
 - `POST /api/v1/digital-screens/{id}/offline`
+- `POST /api/v1/digital-screens/{id}/versions/{versionNo}/rollback`
 - `POST /api/v1/digital-screens/{id}/duplicate`
 - `DELETE /api/v1/digital-screens/{id}`

--- a/yak-ops-business/yak-ops-business-digital-screen/pom.xml
+++ b/yak-ops-business/yak-ops-business-digital-screen/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
 

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenController.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenController.java
@@ -12,6 +12,7 @@ import io.yak.ops.business.digitalscreen.controller.v1.dto.DigitalScreenRequests
 import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVO;
 import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVersionSummaryVO;
 import io.yak.ops.business.digitalscreen.controller.v1.vo.DigitalScreenViews.DigitalScreenVersionVO;
+import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +26,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Digital Screen HTTP adapter. Viewer endpoints expose immutable published snapshots. */
+/** Digital Screen management HTTP adapter. Viewer routes expose immutable project-owned snapshots. */
 @Tag(name = "数字化大屏接口")
 @RestController
 @Validated
+@ProjectScope
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/digital-screens")

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/dao/model/DigitalScreenPO.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/dao/model/DigitalScreenPO.java
@@ -11,6 +11,7 @@ import lombok.Data;
 public class DigitalScreenPO {
   @TableId(type = IdType.AUTO)
   private Long id;
+  private Long projectId;
   private String name;
   private String description;
   private String templateId;

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenRepositoryAdapter.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.digitalscreen.dao.model.DigitalScreenPO;
 import io.yak.ops.business.digitalscreen.domain.DigitalScreen;
 import io.yak.ops.business.digitalscreen.domain.DigitalScreenStatus;
 import io.yak.ops.business.digitalscreen.repository.codec.DigitalScreenBindingsCodec;
+import io.yak.ops.core.project.CurrentProject;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
@@ -16,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
-/** MyBatis-Plus adapter for the mutable Digital Screen draft and publication pointer. */
+/** MyBatis-Plus adapter for project-owned Digital Screen drafts and publication pointers. */
 @Repository
 @DependsOn("yakDigitalScreenFlyway")
 @ConditionalOnDataSourceEnabled
@@ -25,11 +26,13 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
 
   private final DigitalScreenMapper mapper;
   private final DigitalScreenBindingsCodec bindingsCodec;
+  private final CurrentProject currentProject;
 
   @Override
   public List<DigitalScreen> list() {
     return mapper.selectList(
             Wrappers.<DigitalScreenPO>lambdaQuery()
+                .eq(DigitalScreenPO::getProjectId, projectId())
                 .orderByDesc(DigitalScreenPO::getUpdateTime)
                 .orderByDesc(DigitalScreenPO::getId))
         .stream()
@@ -39,19 +42,26 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
 
   @Override
   public long count() {
-    Long count = mapper.selectCount(Wrappers.<DigitalScreenPO>lambdaQuery());
+    Long count = mapper.selectCount(
+        Wrappers.<DigitalScreenPO>lambdaQuery()
+            .eq(DigitalScreenPO::getProjectId, projectId()));
     return count == null ? 0L : count;
   }
 
   @Override
   public Optional<DigitalScreen> findById(long id) {
-    return Optional.ofNullable(mapper.selectById(id)).map(this::toDomain);
+    return Optional.ofNullable(mapper.selectOne(
+            Wrappers.<DigitalScreenPO>lambdaQuery()
+                .eq(DigitalScreenPO::getProjectId, projectId())
+                .eq(DigitalScreenPO::getId, id)))
+        .map(this::toDomain);
   }
 
   @Override
   public DigitalScreen lockById(long id) {
     DigitalScreenPO row = mapper.selectOne(
         Wrappers.<DigitalScreenPO>lambdaQuery()
+            .eq(DigitalScreenPO::getProjectId, projectId())
             .eq(DigitalScreenPO::getId, id)
             .last("FOR UPDATE"));
     if (row == null) throw notFound(id);
@@ -67,6 +77,7 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
       Map<String, Object> bindings) {
     Instant now = Instant.now();
     DigitalScreenPO row = new DigitalScreenPO();
+    row.setProjectId(projectId());
     row.setName(name);
     row.setDescription(description);
     row.setTemplateId(templateId);
@@ -92,6 +103,7 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
     int updated = mapper.update(
         null,
         Wrappers.<DigitalScreenPO>lambdaUpdate()
+            .eq(DigitalScreenPO::getProjectId, projectId())
             .eq(DigitalScreenPO::getId, id)
             .set(DigitalScreenPO::getName, name)
             .set(DigitalScreenPO::getDescription, description)
@@ -113,6 +125,7 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
     int updated = mapper.update(
         null,
         Wrappers.<DigitalScreenPO>lambdaUpdate()
+            .eq(DigitalScreenPO::getProjectId, projectId())
             .eq(DigitalScreenPO::getId, id)
             .set(DigitalScreenPO::getName, name)
             .set(DigitalScreenPO::getDescription, description)
@@ -136,6 +149,7 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
     int updated = mapper.update(
         null,
         Wrappers.<DigitalScreenPO>lambdaUpdate()
+            .eq(DigitalScreenPO::getProjectId, projectId())
             .eq(DigitalScreenPO::getId, id)
             .set(DigitalScreenPO::getStatus, DigitalScreenStatus.PUBLISHED.name())
             .set(DigitalScreenPO::getPublishedVersionId, versionId)
@@ -152,6 +166,7 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
     int updated = mapper.update(
         null,
         Wrappers.<DigitalScreenPO>lambdaUpdate()
+            .eq(DigitalScreenPO::getProjectId, projectId())
             .eq(DigitalScreenPO::getId, id)
             .set(DigitalScreenPO::getStatus, DigitalScreenStatus.DRAFT.name())
             .set(DigitalScreenPO::getPublishedVersionId, null)
@@ -165,7 +180,10 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
 
   @Override
   public boolean deleteById(long id) {
-    return mapper.deleteById(id) == 1;
+    return mapper.delete(
+        Wrappers.<DigitalScreenPO>lambdaQuery()
+            .eq(DigitalScreenPO::getProjectId, projectId())
+            .eq(DigitalScreenPO::getId, id)) == 1;
   }
 
   private DigitalScreen required(long id) {
@@ -204,5 +222,9 @@ public class DigitalScreenRepositoryAdapter implements DigitalScreenRepository {
 
   private Instant instant(Timestamp value) {
     return value == null ? null : value.toInstant();
+  }
+
+  private long projectId() {
+    return currentProject.requireProjectId();
   }
 }

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenVersionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenVersionRepositoryAdapter.java
@@ -10,12 +10,13 @@ import io.yak.ops.business.digitalscreen.repository.codec.DigitalScreenBindingsC
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Repository;
 
-/** MyBatis-Plus adapter for append-only Digital Screen published snapshots. */
+/** MyBatis-Plus adapter for inherited, append-only Digital Screen published snapshots. */
 @Repository
 @DependsOn("yakDigitalScreenFlyway")
 @ConditionalOnDataSourceEnabled
@@ -23,10 +24,12 @@ import org.springframework.stereotype.Repository;
 public class DigitalScreenVersionRepositoryAdapter implements DigitalScreenVersionRepository {
 
   private final DigitalScreenVersionMapper mapper;
+  private final DigitalScreenRepository screens;
   private final DigitalScreenBindingsCodec bindingsCodec;
 
   @Override
   public List<DigitalScreenVersion> list(long screenId) {
+    requireOwnedScreen(screenId);
     return mapper.selectList(
             Wrappers.<DigitalScreenVersionPO>lambdaQuery()
                 .eq(DigitalScreenVersionPO::getScreenId, screenId)
@@ -38,11 +41,16 @@ public class DigitalScreenVersionRepositoryAdapter implements DigitalScreenVersi
 
   @Override
   public Optional<DigitalScreenVersion> findById(long versionId) {
-    return Optional.ofNullable(mapper.selectById(versionId)).map(this::toDomain);
+    DigitalScreenVersionPO row = mapper.selectById(versionId);
+    if (row == null || screens.findById(row.getScreenId()).isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(toDomain(row));
   }
 
   @Override
   public Optional<DigitalScreenVersion> findByVersionNo(long screenId, int versionNo) {
+    requireOwnedScreen(screenId);
     return Optional.ofNullable(mapper.selectOne(
             Wrappers.<DigitalScreenVersionPO>lambdaQuery()
                 .eq(DigitalScreenVersionPO::getScreenId, screenId)
@@ -52,6 +60,7 @@ public class DigitalScreenVersionRepositoryAdapter implements DigitalScreenVersi
 
   @Override
   public int nextVersionNo(long screenId) {
+    requireOwnedScreen(screenId);
     DigitalScreenVersionPO latest = mapper.selectOne(
         Wrappers.<DigitalScreenVersionPO>lambdaQuery()
             .eq(DigitalScreenVersionPO::getScreenId, screenId)
@@ -62,6 +71,8 @@ public class DigitalScreenVersionRepositoryAdapter implements DigitalScreenVersi
 
   @Override
   public DigitalScreenVersion insert(DigitalScreen draft, int versionNo, Instant publishedTime) {
+    Objects.requireNonNull(draft, "draft");
+    requireOwnedScreen(draft.id());
     DigitalScreenVersionPO row = new DigitalScreenVersionPO();
     row.setScreenId(draft.id());
     row.setVersionNo(versionNo);
@@ -81,8 +92,14 @@ public class DigitalScreenVersionRepositoryAdapter implements DigitalScreenVersi
 
   @Override
   public void deleteByScreenId(long screenId) {
+    requireOwnedScreen(screenId);
     mapper.delete(Wrappers.<DigitalScreenVersionPO>lambdaQuery()
         .eq(DigitalScreenVersionPO::getScreenId, screenId));
+  }
+
+  private void requireOwnedScreen(long screenId) {
+    screens.findById(screenId).orElseThrow(() -> new IllegalArgumentException(
+        "数字化大屏不存在或已被删除：" + screenId));
   }
 
   private DigitalScreenVersion toDomain(DigitalScreenVersionPO row) {

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V3__expand_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V3__expand_project_scope.sql
@@ -1,0 +1,10 @@
+-- Project Space expand migration for Digital Screen aggregate roots.
+-- Published versions continue to inherit ownership through screen_id.
+ALTER TABLE yak_digital_screen
+    ADD COLUMN project_id BIGINT NULL COMMENT 'Yak Security Project ID' AFTER id,
+    ADD KEY idx_yak_digital_screen_project_status_update (
+        project_id, status, update_time, id
+    );
+
+-- Historical Digital Screen bindings are template-defined opaque JSON and do not provide a
+-- trustworthy, universal owner. This migration intentionally performs no guessed backfill.

--- a/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V4__contract_project_scope.sql
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/main/resources/db/migration/yak-digital-screen/V4__contract_project_scope.sql
@@ -1,0 +1,4 @@
+-- Contract phase: operators must explicitly assign any historical Digital Screen rows.
+-- Existing unowned rows intentionally make this migration fail instead of falling back globally.
+ALTER TABLE yak_digital_screen
+    MODIFY COLUMN project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID';

--- a/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenControllerContractTest.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/controller/v1/DigitalScreenControllerContractTest.java
@@ -1,7 +1,9 @@
 package io.yak.ops.business.digitalscreen.controller.v1;
 
+import static io.yak.ops.core.project.ProjectMigrationMode.PROJECT_REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.core.project.ProjectScope;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,10 +13,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 class DigitalScreenControllerContractTest {
 
   @Test
-  void baseRestPathRemainsStable() {
+  void baseRestPathRemainsStableInsideRequiredProjectScope() {
     RequestMapping mapping = DigitalScreenController.class.getAnnotation(RequestMapping.class);
+    ProjectScope projectScope = DigitalScreenController.class.getAnnotation(ProjectScope.class);
+
     assertThat(mapping).isNotNull();
     assertThat(mapping.value()).containsExactly("/api/v1/digital-screens");
+    assertThat(projectScope).isNotNull();
+    assertThat(projectScope.value()).isEqualTo(PROJECT_REQUIRED);
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenProjectSpaceContractTest.java
+++ b/yak-ops-business/yak-ops-business-digital-screen/src/test/java/io/yak/ops/business/digitalscreen/repository/DigitalScreenProjectSpaceContractTest.java
@@ -1,0 +1,67 @@
+package io.yak.ops.business.digitalscreen.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class DigitalScreenProjectSpaceContractTest {
+
+  @Test
+  void rootCrudIsFailClosedOnTrustedCurrentProject() throws IOException {
+    String adapter = read(
+        "src/main/java/io/yak/ops/business/digitalscreen/repository/"
+            + "DigitalScreenRepositoryAdapter.java");
+    String po = read(
+        "src/main/java/io/yak/ops/business/digitalscreen/dao/model/DigitalScreenPO.java");
+
+    assertThat(po).contains("private Long projectId;");
+    assertThat(adapter)
+        .contains("CurrentProject")
+        .contains("currentProject.requireProjectId()")
+        .contains("DigitalScreenPO::getProjectId")
+        .doesNotContain("mapper.deleteById(id)")
+        .doesNotContain("mapper.selectById(id)");
+  }
+
+  @Test
+  void inheritedPublishedVersionsProveOwningScreenBeforeAccess() throws IOException {
+    String adapter = read(
+        "src/main/java/io/yak/ops/business/digitalscreen/repository/"
+            + "DigitalScreenVersionRepositoryAdapter.java");
+
+    assertThat(adapter)
+        .contains("DigitalScreenRepository screens")
+        .contains("screens.findById(row.getScreenId()).isEmpty()")
+        .contains("requireOwnedScreen(screenId)");
+  }
+
+  @Test
+  void migrationNeverGuessesHistoricalOwnershipAndThenContracts() throws IOException {
+    String expand = read(
+        "src/main/resources/db/migration/yak-digital-screen/V3__expand_project_scope.sql");
+    String contract = read(
+        "src/main/resources/db/migration/yak-digital-screen/V4__contract_project_scope.sql");
+
+    assertThat(expand)
+        .contains("ADD COLUMN project_id BIGINT NULL")
+        .doesNotContainIgnoringCase("UPDATE")
+        .doesNotContain("project_id = 1")
+        .doesNotContain("DEFAULT 0");
+    assertThat(contract)
+        .contains("project_id BIGINT NOT NULL")
+        .doesNotContainIgnoringCase("UPDATE");
+  }
+
+  private String read(String relative) throws IOException {
+    return Files.readString(moduleRoot().resolve(relative));
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("src/main/java/io/yak/ops/business/digitalscreen");
+    if (Files.isDirectory(local)) return Path.of(".");
+    return Path.of("yak-ops-business", "yak-ops-business-digital-screen");
+  }
+}

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -24,6 +24,9 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/resources/tree')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/resources/42/download')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/datasets/1')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/analyses/1')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/dashboards/1/versions')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/digital-screens/1/published')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/home/cockpit')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/home/data-center/overview?period=7d')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-development/nodes')).toBe('PROJECT_REQUIRED');
@@ -88,6 +91,9 @@ describe('Project Space request context', () => {
       '/api/v1/sql-executions/page',
       '/api/v1/resources/42/download',
       '/api/v1/datasets/42',
+      '/api/v1/analyses/42',
+      '/api/v1/dashboards/42/publish',
+      '/api/v1/digital-screens/42/versions',
       '/api/v1/home/cockpit',
       '/api/v1/data-development/nodes',
       '/api/v1/data-service/7',

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -21,6 +21,10 @@ export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
   { prefix: '/api/v1/resources/storage-plugins', mode: 'LEGACY_GLOBAL' },
   { prefix: '/api/v1/resources', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/datasets', mode: 'PROJECT_REQUIRED' },
+  // BI definition planes are Project-owned; published snapshots remain authenticated management APIs.
+  { prefix: '/api/v1/analyses', mode: 'PROJECT_REQUIRED' },
+  { prefix: '/api/v1/dashboards', mode: 'PROJECT_REQUIRED' },
+  { prefix: '/api/v1/digital-screens', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/home', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/data-development', mode: 'PROJECT_REQUIRED' },
   // Data Service management is project-scoped, but the external runtime URL is intentionally


### PR DESCRIPTION
## 背景

完成 Stage 8.3，将 Analysis、Dashboard、Digital Screen 三个 BI 后端模块纳入 Project Space 强隔离。

本次遵循统一边界：

- `yak_analysis`、`yak_dashboard`、`yak_digital_screen` 是 `PROJECT_ROOT`
- DashboardVersion / Widget / Filter / Binding / Interaction 通过 Dashboard 继承归属
- DigitalScreenVersion 通过 Digital Screen 继承归属
- `project_id` 只来自服务端 trusted `CurrentProject`
- 跨 Project ID 统一 fail closed，不返回其他空间的资源归属信息

## Analysis

- `yak_analysis` 增加并收紧 `project_id`
- List / Detail / Create / Update / Delete 全部增加当前 Project 条件
- Dataset binding 继续通过 `AnalysisDatasetGateway`，复用 Dataset 已项目化的绑定契约
- `AnalysisChangedEvent` 冻结 `projectId`
- after-commit Lineage listener 通过 `ProjectContextScope` 恢复 Project 上下文
- Controller 切换为 `@ProjectScope(PROJECT_REQUIRED)`

## Dashboard

- `yak_dashboard` 增加并收紧 `project_id`
- Dashboard 根 CRUD、Overview 聚合、历史 Analysis 引用检查增加 Project 条件
- Version / Widget / Filter / Binding / Interaction 独立访问前重新证明父 Dashboard 属于当前 Project
- current / published pointer 更新前证明目标 Version 属于同一 Dashboard
- 新增 `DashboardDatasetGateway`：
  - 校验 `activeDatasetId`
  - 校验显式 `inlineAnalysis.datasetId`
- 可复用 Analysis 继续通过 `DashboardAnalysisGateway` 校验，并自然继承当前 Project 边界
- `DashboardChangedEvent` 冻结 `projectId`，after-commit Lineage 恢复上下文
- Dashboard / Overview Controller 切换为 `PROJECT_REQUIRED`

## Digital Screen

- `yak_digital_screen` 增加并收紧 `project_id`
- List / Count / Detail / Lock / Update / Publish / Offline / Duplicate / Delete 全链路增加 Project 条件
- 发布版本读取、追加、回滚和删除前证明所属 Screen 属于当前 Project
- 管理 Controller 切换为 `PROJECT_REQUIRED`
- 当前仓库不存在独立匿名大屏 Runtime 路由，因此现有 published/version 路由继续作为认证后的 Project 管理 API

## 迁移策略

继续采用 Expand → deterministic Backfill → Contract，不使用 Project `0`、Project `1`、第一条 Project 或其他默认值猜测。

### Analysis

从已项目化 Dataset 确定性回填：

```sql
yak_analysis.dataset_id -> yak_dataset.project_id
```

孤立 Analysis 保持 `NULL`，由后续 `NOT NULL` Contract 阻止部署。

### Dashboard

只在所有显式证据均可解析、且全部指向同一 Project 时回填。证据包括：

- `active_dataset_id`
- Widget `analysis_id`
- `inline_analysis_json.datasetId`

空 Dashboard、孤立引用或混合 Project 引用不会被猜测归属，会在 Contract 阶段阻止升级。

### Digital Screen

历史 bindings 是模板定义的 opaque JSON，当前没有稳定、统一的归属来源，因此 Expand migration 不执行自动回填。历史库必须在 Contract 前人工确认并赋值；未处理行会让 `NOT NULL` migration 主动失败。

详细升级说明：

- `docs/architecture/STAGE8_3_ANALYSIS_DASHBOARD_DIGITAL_SCREEN_PROJECT_SPACE.md`

## 前端请求上下文

共享 Project request rule 增加：

- `/api/v1/analyses`
- `/api/v1/dashboards`
- `/api/v1/digital-screens`

三类管理请求都会携带 `X-YAK-SECURITY-PROJECT-ID`。

## 架构契约

- Dashboard 新增 Dataset owner-defined gateway，不允许 Composition 直接依赖 Dataset 实现
- Jackson 字段读取继续收口在 `DashboardJsonPolicy`
- Dashboard 模块 ARCHITECTURE / DOMAIN / REQUIREMENTS / DEPENDENCIES 与 executable architecture tests 同步更新
- 修正 Analysis 架构文档及角色测试中的旧 `mapper` 目录名，统一为实际 `converter`

## 提交

1. `feat(analysis): enforce Project Space isolation`
2. `feat(dashboard): enforce Project Space ownership`
3. `feat(digital-screen): enforce Project Space ownership`
4. `docs(bi): align Project Space architecture contracts`

## 验证

- [x] 分支基于当前 `main` `d03aa5d44c62`
- [x] 当前分支 ahead 4 / behind 0
- [x] GitHub 判定 PR 当前可合并，且保持 Draft
- [x] 完成变更文件、构造器调用面与 PR Patch 危险模式静态核对
- [x] 增加 Controller、迁移、DAO 隔离、父归属证明、异步 Project 恢复和前端路由契约测试
- [ ] 当前仓库没有为该 head 触发可见 GitHub Actions workflow；Maven/JUnit 全量测试需在完整本地仓库执行
- [ ] 前端 Jest/TypeScript 完整回归需在完整本地仓库执行
- [ ] 历史库升级必须先执行文档中的 orphan / ownership preflight

## Review Focus

- Dashboard 历史数据的“完整且单一 Project 证据”回填规则
- Digital Screen 历史数据不自动猜测归属的 fail-fast 策略
- Dashboard 子事实访问前的父归属证明与查询成本
- after-commit Lineage 的 ProjectContext 恢复
- 现有 published/version 路由作为 Project 管理 API，而非匿名 Runtime 的边界
