### PR TITLE
fix(ui): avoid Mako resolving public font assets

### DIFF
--- a/yak-ops-ui/config/config.ts
+++ b/yak-ops-ui/config/config.ts
@@ -69,7 +69,7 @@ export default defineConfig({
    * @description 可以让你的本地服务器代理到你的服务器上，这样你就可以访问服务器的数据了
    * @see 要注意以下 代理只能在本地开发时使用，build 之后就无法使用了。
    * @doc 代理介绍 https://umijs.org/docs/guides/proxy
-   * @doc https://umijs.org/docs/api/config#proxy
+   * @doc 代理配置 https://umijs.org/docs/api/config#proxy
    */
   proxy: proxy[REACT_APP_ENV as keyof typeof proxy],
   /**

--- a/yak-ops-ui/config/config.ts
+++ b/yak-ops-ui/config/config.ts
@@ -29,6 +29,12 @@ export default defineConfig({
   hash: true,
 
   publicPath: PUBLIC_PATH,
+  links: [
+    {
+      href: `${PUBLIC_PATH}fonts/harmonyos-sans-sc/font-face.css`,
+      rel: "stylesheet",
+    },
+  ],
 
   /**
    * @name 兼容性设置
@@ -63,7 +69,7 @@ export default defineConfig({
    * @description 可以让你的本地服务器代理到你的服务器上，这样你就可以访问服务器的数据了
    * @see 要注意以下 代理只能在本地开发时使用，build 之后就无法使用了。
    * @doc 代理介绍 https://umijs.org/docs/guides/proxy
-   * @doc 代理配置 https://umijs.org/docs/api/config#proxy
+   * @doc https://umijs.org/docs/api/config#proxy
    */
   proxy: proxy[REACT_APP_ENV as keyof typeof proxy],
   /**

--- a/yak-ops-ui/public/fonts/harmonyos-sans-sc/font-face.css
+++ b/yak-ops-ui/public/fonts/harmonyos-sans-sc/font-face.css
@@ -1,0 +1,42 @@
+/*
+ * Static HarmonyOS Sans SC declarations.
+ *
+ * This stylesheet intentionally lives in public/ so Mako does not try to
+ * resolve these public font assets during Less compilation. Relative URLs also
+ * keep working if Yak Ops is deployed under a non-root publicPath.
+ */
+@font-face {
+  font-family: 'HarmonyOS Sans SC';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('HarmonyOS Sans SC Regular'), local('HarmonyOS Sans SC'),
+    url('./HarmonyOS_SansSC_Regular.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'HarmonyOS Sans SC';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: local('HarmonyOS Sans SC Medium'),
+    url('./HarmonyOS_SansSC_Medium.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'HarmonyOS Sans SC';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local('HarmonyOS Sans SC Semibold'),
+    url('./HarmonyOS_SansSC_Semibold.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'HarmonyOS Sans SC';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local('HarmonyOS Sans SC Bold'),
+    url('./HarmonyOS_SansSC_Bold.ttf') format('truetype');
+}

--- a/yak-ops-ui/src/styles/fonts.less
+++ b/yak-ops-ui/src/styles/fonts.less
@@ -1,38 +1,6 @@
-@font-face {
-  font-family: 'HarmonyOS Sans SC';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: local('HarmonyOS Sans SC Regular'), local('HarmonyOS Sans SC'),
-    url('/fonts/harmonyos-sans-sc/HarmonyOS_SansSC_Regular.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'HarmonyOS Sans SC';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: local('HarmonyOS Sans SC Medium'),
-    url('/fonts/harmonyos-sans-sc/HarmonyOS_SansSC_Medium.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'HarmonyOS Sans SC';
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: local('HarmonyOS Sans SC Semibold'),
-    url('/fonts/harmonyos-sans-sc/HarmonyOS_SansSC_Semibold.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'HarmonyOS Sans SC';
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
-  src: local('HarmonyOS Sans SC Bold'),
-    url('/fonts/harmonyos-sans-sc/HarmonyOS_SansSC_Bold.ttf') format('truetype');
-}
+// HarmonyOS Sans SC font-face declarations live under public/fonts and are
+// loaded as a static stylesheet from Umi config. Keeping asset URLs out of the
+// compiled Less prevents Mako from resolving public resources as source files.
 
 // Keep YakOps' existing Latin font for English, and switch the complete
 // Chinese UI (including Ant Design via --yak-font-family) to HarmonyOS Sans SC.


### PR DESCRIPTION
## Summary

Fix the frontend startup warnings where Mako reports that HarmonyOS Sans SC font files under `public/fonts` cannot be resolved from `src/styles/fonts.less`.

## Root cause

The font files already exist under `yak-ops-ui/public/fonts/harmonyos-sans-sc/`, but `@font-face` declarations lived in compiled Less and referenced them with `/fonts/...` URLs. During Less/CSS compilation, Mako attempted to resolve those URLs as source-module assets and printed `failed to resolve` warnings, even though Umi serves the files correctly from `public/` at runtime.

## Changes

- Add `public/fonts/harmonyos-sans-sc/font-face.css` containing the HarmonyOS Sans SC `@font-face` declarations.
- Use relative URLs inside that static CSS so the font files resolve next to the stylesheet and remain compatible with non-root `publicPath` deployments.
- Load the static stylesheet through Umi `links` configuration.
- Remove the font asset URLs from `src/styles/fonts.less`; it now only owns the locale-specific font-family variables.
- Keep all existing `.ttf` files unchanged.

## Expected result

`yarn start` should no longer print warnings like:

```text
failed to resolve `/fonts/harmonyos-sans-sc/HarmonyOS_SansSC_Regular.ttf`
```

while Chinese UI typography continues to use HarmonyOS Sans SC.

## Verification

Recommended local check:

```bash
cd yak-ops-ui
yarn start
```

Verify:

- Mako compiles without the four HarmonyOS font resolve warnings.
- `/fonts/harmonyos-sans-sc/font-face.css` returns 200.
- `/fonts/harmonyos-sans-sc/HarmonyOS_SansSC_Regular.ttf` returns 200.
- Chinese UI still renders with HarmonyOS Sans SC.

This PR intentionally does not convert or replace the existing font binaries.