### PR TITLE
fix(ui): silence anonymous bootstrap auth probe

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -82,15 +82,16 @@ export async function getInitialState(): Promise<{
   const fetchUserInfo = async () => toCurrentUser(await getCurrentUser());
   const onLoginPage = isLoginPath(window.location.pathname);
 
-  // Probe cookie-backed authentication state on every route. The login page uses
-  // a silent probe so an expired session or an unavailable backend does not show
-  // an unrelated current-user notification before the user submits the form.
+  // Application bootstrap only probes cookie-backed authentication state. An
+  // anonymous first visit is expected, so keep this probe silent on every route
+  // and redirect to login without showing a misleading session-expired notice.
+  // Post-login refreshes still use fetchUserInfo and normal error handling.
   let currentUser: API.CurrentUser | undefined;
   let currentUserLoadError = false;
   try {
-    currentUser = onLoginPage
-      ? toCurrentUser(await getCurrentUser({ skipErrorHandler: true }))
-      : await fetchUserInfo();
+    currentUser = toCurrentUser(
+      await getCurrentUser({ skipErrorHandler: true }),
+    );
   } catch (error) {
     currentUserLoadError = true;
 


### PR DESCRIPTION
## 背景

首次匿名打开 Yak Ops（例如直接访问 `/`）时，应用初始化会先请求当前用户接口。由于此时浏览器还没有登录 Cookie，后端正常返回未认证，但前端把这次启动探测按普通认证失败处理，导致在登录页右上角出现“登录状态失效 / 用户未登录 / 即将跳转登录页”的误导提示。

## 根因

`getInitialState()` 只有当前路由已经是 `/login` 时才给 `getCurrentUser()` 传入 `skipErrorHandler: true`。

从 `/`、`/home` 等受保护路由首次进入时，初始化请求走的是普通 `fetchUserInfo()`，因此匿名 401 会进入全局认证失效处理并弹通知，再跳转到登录页。

## 修改

- 应用启动阶段的 current-user 探测在所有路由上统一使用 `skipErrorHandler: true`
- 匿名首次访问仍会正常跳转到 `/login`，但不再弹“登录状态失效”提示
- 保留 `fetchUserInfo()` 的正常错误处理：登录成功后的用户刷新以及系统运行期间真正的认证异常仍按原逻辑处理
- 不修改后端认证协议，也不关闭全局 401 处理

## 预期行为

| 场景 | 修改后 |
| --- | --- |
| 第一次匿名访问 `/` | 静默探测 → 跳转 `/login`，不弹认证失效提示 |
| 直接访问 `/login` | 静默探测，不弹提示 |
| 已登录访问系统 | 正常加载当前用户 |
| 系统运行期间登录态失效 | 普通业务请求仍触发全局“登录状态失效”处理 |
| 登录成功后刷新当前用户失败 | `fetchUserInfo()` 仍按正常错误处理链路展示异常 |

## 验证

- 已确认改动只涉及 `yak-ops-ui/src/app.tsx`
- 分支基于最新 `main` 创建
- 已检查初始化探测与登录后 `fetchUserInfo()` 两条链路仍然分离

建议本地补跑：

1. 清除站点 Cookie / 使用无痕窗口，直接打开 `/`，确认跳转登录页且右上角无“登录状态失效”提示。
2. 正常登录，确认可进入系统。
3. 登录后让 Cookie/会话失效，再触发业务请求，确认仍会出现“登录状态失效”提示并跳转登录页。
4. `cd yak-ops-ui && npm run tsc`。