### PR TITLE
fix(ui): reserve workspace management for root

### DIFF
--- a/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
+++ b/yak-ops-ui/src/components/security/SecurityProjectSwitcher/index.tsx
@@ -18,7 +18,7 @@ import {
 
 type SupportedLocale = 'zh-CN' | 'en-US';
 
-const PROJECT_MANAGEMENT_PERMISSION = 'security:project:read';
+const WORKSPACE_MANAGEMENT_PERMISSION = 'security:root';
 
 const getSupportedLocale = (): SupportedLocale =>
   getLocale().toLowerCase().startsWith('zh') ? 'zh-CN' : 'en-US';
@@ -78,7 +78,7 @@ function ProjectSwitcher() {
   const permissionCodes = initialState?.currentUser?.permissionCodes ?? [];
   const canManage = hasPermission(
     permissionCodes,
-    PROJECT_MANAGEMENT_PERMISSION,
+    WORKSPACE_MANAGEMENT_PERMISSION,
   );
 
   const items: MenuProps['items'] = [


### PR DESCRIPTION
## Summary

Aligns the workspace switcher with the system-level root authorization model.

- the right-top workspace switcher continues to consume `currentUser.projectList` from `/account/current`;
- the `管理工作空间` entry is now reserved for `security:root` instead of any identity with `security:project:read`;
- workspace switching remains available to any user whose authenticated identity contains accessible projects.

## Dependency

This frontend change is designed to land with `weifuwan/yak-framework#110`, which completes `/account/current.projectList` and makes root users see all enabled workspaces while ordinary users only see assigned enabled workspaces.

## Scope

Intentionally small: the existing project context, persisted selection, refresh flow, and root-gated management page already implement the desired behavior once the backend identity contract is fixed.