### PR TITLE
fix(workflow): propagate workspace project context

### DIFF
--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -8,6 +8,7 @@ import { useEffect } from "react";
 
 import defaultSettings from "../config/defaultSettings";
 import { GlobalSearch, Knowledge } from "./components/RightContent";
+import SidebarMenuLink from "./components/SidebarMenuLink";
 import { getCurrentUser } from "./services/security/account";
 import { toCurrentUser } from "./services/security/currentIdentity";
 import { AUTHENTICATION_INVALIDATED_EVENT } from "./utils/security/authentication";

--- a/yak-ops-ui/src/app.tsx
+++ b/yak-ops-ui/src/app.tsx
@@ -2,16 +2,16 @@ import { AvatarDropdown, AvatarName, Footer } from "@/components";
 import type { Settings as LayoutSettings } from "@ant-design/pro-components";
 import { SettingDrawer } from "@ant-design/pro-components";
 import "@ant-design/v5-patch-for-react-19";
-import type { RunTimeLayoutConfig } from "@umijs/max";
+import type { RequestConfig, RunTimeLayoutConfig } from "@umijs/max";
 import { getLocale, history, useModel } from "@umijs/max";
 import { useEffect } from "react";
 
 import defaultSettings from "../config/defaultSettings";
 import { GlobalSearch, Knowledge } from "./components/RightContent";
-import SidebarMenuLink from "./components/SidebarMenuLink";
 import { getCurrentUser } from "./services/security/account";
 import { toCurrentUser } from "./services/security/currentIdentity";
 import { AUTHENTICATION_INVALIDATED_EVENT } from "./utils/security/authentication";
+import { applyCurrentProjectHeader } from "./utils/security/projectContext";
 import {
   getCurrentReturnTo,
   getSafeReturnTo,
@@ -27,6 +27,25 @@ const syncDocumentLocale = () => {
 
   document.documentElement.dataset.yakLocale = locale;
   document.documentElement.lang = locale;
+};
+
+/**
+ * Keep @umijs/max requests on the same Project Space contract as the shared
+ * umi-request client in utils/request.tsx. Some feature services (including
+ * Workflow) still use the Max request client, so without this interceptor a
+ * selected workspace would be visible in the header but absent from the HTTP
+ * request sent to PROJECT_REQUIRED endpoints.
+ */
+export const request: RequestConfig = {
+  requestInterceptors: [
+    (config) => ({
+      ...config,
+      headers: applyCurrentProjectHeader(
+        config?.url ?? "",
+        config?.headers as HeadersInit | undefined,
+      ) as typeof config.headers,
+    }),
+  ],
 };
 
 const redirectAnonymousUser = () => {

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -42,6 +42,9 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/realtime-sync/11')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/realtime-sync/11/events')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/workflows/definitions')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/workflows/instances')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/workflows/schedules')).toBe('PROJECT_REQUIRED');
+    expect(resolveProjectRequestMode('/api/v1/workflows/instances/run-1/events')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-quality/table-asset/page')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-quality/monitor/42')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-quality/execution/page')).toBe('PROJECT_REQUIRED');
@@ -102,6 +105,9 @@ describe('Project Space request context', () => {
       '/api/v1/realtime-sync/42',
       '/api/v1/realtime-sync/42/observability',
       '/api/v1/workflows/definitions',
+      '/api/v1/workflows/instances',
+      '/api/v1/workflows/schedules',
+      '/api/v1/workflows/instances/run-1/events',
       '/api/v1/data-quality/table-asset/page',
       '/api/v1/data-quality/monitor/42',
       '/api/v1/data-quality/execution/page',


### PR DESCRIPTION
## Motivation

The Workflow Definition and Workflow Instance pages are already classified as `PROJECT_REQUIRED`, but their services use the `@umijs/max` request client while Project Space headers were only injected by the separate shared `umi-request` client.

As a result, the UI could show a selected workspace in the header while `/api/v1/workflows/definitions` and `/api/v1/workflows/instances` were sent without `X-YAK-SECURITY-PROJECT-ID`, causing backend responses such as `PROJECT_REQUIRED: 当前操作需要选择项目空间`.

## Changes

- add a Umi Max runtime request interceptor in `app.tsx`;
- reuse the existing `applyCurrentProjectHeader()` policy instead of introducing a Workflow-specific fallback;
- keep both frontend request stacks on the same Project Space contract;
- extend Project Space regression coverage for workflow definitions, instances, schedules and nested workflow routes.

## Why this approach

The issue is not limited to one Workflow API call. Workflow services currently use `@umijs/max` request, while other modules use the shared `utils/request.tsx` client. Fixing the runtime request boundary prevents the two clients from drifting and avoids adding project-header code independently to every Workflow service method.

The existing rollout table remains the source of truth: `/api/v1/workflows` is `PROJECT_REQUIRED`, so only project-aware routes receive the workspace header; platform-global routes remain unchanged.

## Validation

Focused regression coverage was updated in `projectContext.test.ts`. Full frontend typecheck/lint/browser regression is left to CI/local verification before merge.