### PR TITLE
fix(home): bind dashboard reads to current workspace

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeAssetOverviewController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeAssetOverviewController.java
@@ -2,6 +2,7 @@ package io.yak.ops.boot.home;
 
 import io.yak.framework.common.Result;
 import io.yak.ops.boot.home.HomeAssetOverviewService.OverviewResponse;
+import io.yak.ops.core.project.ProjectScope;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 首页数据资产与血缘总览接口。 */
 @RestController
 @RequestMapping("/api/v1/home/assets")
+@ProjectScope
 public class HomeAssetOverviewController {
 
   private final HomeAssetOverviewService service;

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeCockpitController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeCockpitController.java
@@ -2,6 +2,7 @@ package io.yak.ops.boot.home;
 
 import io.yak.framework.common.Result;
 import io.yak.ops.boot.home.HomeCockpitService.CockpitResponse;
+import io.yak.ops.core.project.ProjectScope;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 首页头部摘要接口。 */
 @RestController
 @RequestMapping("/api/v1/home/cockpit")
+@ProjectScope
 public class HomeCockpitController {
 
   private final HomeCockpitService service;

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeDataCenterController.java
@@ -4,6 +4,7 @@ import io.yak.framework.common.Result;
 import io.yak.ops.boot.home.HomeDataCenterService.OverviewResponse;
 import io.yak.ops.boot.home.HomeDataCenterService.RecentResponse;
 import io.yak.ops.boot.home.HomeDataCenterService.ScheduleResponse;
+import io.yak.ops.core.project.ProjectScope;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 首页数据中心接口。 */
 @RestController
 @RequestMapping("/api/v1/home/data-center")
+@ProjectScope
 @RequiredArgsConstructor
 public class HomeDataCenterController {
 

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeQualityOverviewController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeQualityOverviewController.java
@@ -4,6 +4,7 @@ import io.yak.framework.common.Result;
 import io.yak.framework.security.web.RequiresPermission;
 import io.yak.ops.boot.home.HomeQualityOverviewService.OverviewResponse;
 import io.yak.ops.business.quality.QualityPermissionCode;
+import io.yak.ops.core.project.ProjectScope;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 首页数据质量总览接口。 */
 @RestController
 @RequestMapping("/api/v1/home/quality")
+@ProjectScope
 @RequiresPermission(QualityPermissionCode.EXECUTION_READ)
 public class HomeQualityOverviewController {
 

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/home/HomeScheduleCenterController.java
@@ -2,6 +2,7 @@ package io.yak.ops.boot.home;
 
 import io.yak.framework.common.Result;
 import io.yak.ops.boot.home.HomeScheduleCenterService.CalendarResponse;
+import io.yak.ops.core.project.ProjectScope;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 首页调度中心接口。 */
 @RestController
 @RequestMapping("/api/v1/home/schedule-center")
+@ProjectScope
 @RequiredArgsConstructor
 public class HomeScheduleCenterController {
 

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeProjectScopeContractTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/home/HomeProjectScopeContractTest.java
@@ -1,0 +1,30 @@
+package io.yak.ops.boot.home;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HomeProjectScopeContractTest {
+
+  @Test
+  void shouldKeepEveryHomeEndpointProjectRequired() {
+    for (Class<?> controller : List.of(
+        HomeCockpitController.class,
+        HomeDataCenterController.class,
+        HomeAssetOverviewController.class,
+        HomeQualityOverviewController.class,
+        HomeScheduleCenterController.class)) {
+      ProjectScope scope = controller.getAnnotation(ProjectScope.class);
+
+      assertThat(scope)
+          .as("%s must participate in Project Space", controller.getSimpleName())
+          .isNotNull();
+      assertThat(scope.value())
+          .as("%s must require the current Project", controller.getSimpleName())
+          .isEqualTo(ProjectMigrationMode.PROJECT_REQUIRED);
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

A datasource created inside a non-default workspace is visible on the datasource management page, but the Home header still reports `数据源 0`.

The frontend already treats `/api/v1/home/**` as `PROJECT_REQUIRED` and sends `X-YAK-SECURITY-PROJECT-ID`. However, the Home controllers were not annotated with `@ProjectScope`, so `ProjectScopeInterceptor` treated them as `LEGACY_GLOBAL` and never bound `CurrentProject`.

`HomeCockpitService` then calls `DataSourceReader.summary()`. The datasource repository is intentionally fail-closed and requires `CurrentProject`, so the missing context raises a Project Context exception; the Home aggregation catches that read failure and degrades the datasource count to `0`. This makes a real workspace datasource look absent.

## Changes

- mark all `/api/v1/home/**` controller groups as `@ProjectScope` (`PROJECT_REQUIRED` by default);
- keep Home cockpit, data center, assets, quality and schedule-center on one workspace boundary instead of fixing only the datasource counter;
- add `HomeProjectScopeContractTest` so future Home endpoints cannot silently drift back to global mode.

## Expected behavior

With workspace A selected, Home aggregation binds workspace A before invoking project-scoped readers. Datasources and other Home summaries therefore reflect only workspace A. Switching to workspace B resolves the same endpoints against workspace B and does not leak counts across workspaces.

## Validation

The branch is one commit ahead of current `main` and only changes the Home controller Project Scope contract plus its regression test. Full Maven/CI execution is left to the repository workflow/local verification before merge.