### PR TITLE
fix(ui): redirect unauthenticated requests to login

### DIFF
--- a/yak-ops-ui/src/services/http/response.test.ts
+++ b/yak-ops-ui/src/services/http/response.test.ts
@@ -68,6 +68,7 @@ describe('API response protocols', () => {
   it('recognizes authentication failures without treating forbidden as anonymous', () => {
     expect(isUnauthenticatedResponse({ code: 401 }, 'yak-ops')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 401 }, 'security')).toBe(true);
+    expect(isUnauthenticatedResponse({ code: 2001 }, 'yak-ops')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 2001 }, 'security')).toBe(true);
     expect(isUnauthenticatedResponse({ code: 403 }, 'security')).toBe(false);
     expect(

--- a/yak-ops-ui/src/services/http/response.ts
+++ b/yak-ops-ui/src/services/http/response.ts
@@ -15,7 +15,10 @@ const protocolRules: Record<
 > = {
   'yak-ops': {
     success: [API_SUCCESS_CODE],
-    unauthenticated: [401],
+    // Yak Security protects application endpoints too, so /api/v1/** may return
+    // the framework USER_NOT_LOGIN business code even though the URL is not under
+    // /yak-security/**.
+    unauthenticated: [401, 2001],
   },
   security: {
     success: [API_SUCCESS_CODE],


### PR DESCRIPTION
## Motivation

When a protected application API returns Yak Security's unauthenticated response, the UI currently shows a generic `操作失败 / 用户未登录` notification and stays on the business page instead of entering the existing authentication-failure flow.

Yak Security protects `/api/v1/**` endpoints as well as `/yak-security/**`. For an unauthenticated request it returns HTTP 401 with the framework business code `USER_NOT_LOGIN = 2001`. The frontend classifies `/api/v1/**` as the `yak-ops` protocol, but that protocol only recognized business code `401` as unauthenticated. Because the JSON response interceptor evaluates the envelope first, code `2001` was treated as an ordinary business error before the HTTP 401 fallback could redirect.

## Changes

- recognize framework `USER_NOT_LOGIN (2001)` for protected Yak Ops API responses too;
- reuse the existing global authentication-failure path, which shows `登录状态失效` and redirects to `/login` while preserving `returnTo`;
- add a regression assertion covering `code: 2001` on the `yak-ops` protocol;
- keep `403` as a permission failure rather than treating it as anonymous.

## Expected behavior

If the session is missing or expires while the user is on a business page, the first protected API response enters the single authentication-failure handler, shows the login-state warning, and navigates to `/login?returnTo=...`. After login the user can return to the original page.

## Validation

The change is limited to the shared API response protocol and its unit test. Full UI test/CI execution is left to the repository workflow/local verification before merge.