### PR TITLE
refactor(home): polish data center latest task card

### DIFF
--- a/yak-ops-ui/src/pages/home/components/DataCenter/LatestTaskCard.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/LatestTaskCard.tsx
@@ -4,7 +4,7 @@ import { history } from '@umijs/max';
 import {
   ArrowRightLeft,
   ChevronRight,
-  Clock3,
+  Clock,
   Database,
   ShieldCheck,
   Workflow,
@@ -98,7 +98,9 @@ function LatestTaskContent({ task }: { task: HomeLatestTask }) {
       />
 
       <div className="relative flex items-start justify-between gap-2">
-        <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] ${theme.iconBox} ${theme.icon}`}>
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] ${theme.iconBox} ${theme.icon}`}
+        >
           <TaskTypeIcon taskType={task.taskType} />
         </div>
         <span
@@ -110,7 +112,9 @@ function LatestTaskContent({ task }: { task: HomeLatestTask }) {
       </div>
 
       <div className="relative mt-3 min-w-0">
-        <span className={`inline-flex rounded-[6px] px-2 py-1 text-[10px] font-medium leading-none ${theme.tag}`}>
+        <span
+          className={`inline-flex rounded-[6px] px-2 py-1 text-[10px] font-medium leading-none ${theme.tag}`}
+        >
           {taskTypeLabel(task.taskType)}
         </span>
         <div className="mt-2 truncate text-[14px] font-semibold leading-5 text-[#2b2e37]">
@@ -126,7 +130,9 @@ function LatestTaskContent({ task }: { task: HomeLatestTask }) {
           <div className="text-[10px] leading-4 text-[#92969f]">运行次数</div>
           <div className="mt-0.5 text-[17px] font-semibold leading-6 text-[#31343c]">
             {task.runCount}
-            <span className="ml-0.5 text-[10px] font-normal text-[#a0a4ac]">次</span>
+            <span className="ml-0.5 text-[10px] font-normal text-[#a0a4ac]">
+              次
+            </span>
           </div>
         </div>
         <div className="rounded-[10px] bg-[#f7f8fa] px-3 py-2.5">
@@ -137,14 +143,16 @@ function LatestTaskContent({ task }: { task: HomeLatestTask }) {
             }`}
           >
             {task.exceptionCount}
-            <span className="ml-0.5 text-[10px] font-normal text-[#a0a4ac]">次</span>
+            <span className="ml-0.5 text-[10px] font-normal text-[#a0a4ac]">
+              次
+            </span>
           </div>
         </div>
       </div>
 
       <div className="relative mt-2.5 flex items-center justify-between rounded-[10px] border border-[#eef0f3] bg-[#fbfbfc] px-3 py-2">
         <span className="flex items-center gap-1.5 text-[10px] text-[#858a93]">
-          <Clock3 size={12} strokeWidth={1.8} />
+          <Clock size={12} strokeWidth={1.8} />
           本次耗时
         </span>
         <strong className="text-[11px] font-semibold text-[#4c5059]">
@@ -175,7 +183,9 @@ export function LatestTaskCard({
         <span className="text-[13px] font-semibold leading-5 text-[#353842]">
           最新任务
         </span>
-        <span className="text-[10px] font-normal text-[#a1a5ad]">最近一次执行</span>
+        <span className="text-[10px] font-normal text-[#a1a5ad]">
+          最近一次执行
+        </span>
       </div>
 
       {task ? (

--- a/yak-ops-ui/src/pages/home/components/DataCenter/LatestTaskCard.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/LatestTaskCard.tsx
@@ -1,10 +1,18 @@
 import YakOpsEmpty from '@/components/YakOpsEmpty';
 import type { HomeLatestTask } from '@/services/home';
 import { history } from '@umijs/max';
-import { Copy, Database } from 'lucide-react';
+import {
+  ArrowRightLeft,
+  ChevronRight,
+  Clock3,
+  Database,
+  ShieldCheck,
+  Workflow,
+} from 'lucide-react';
 
 import {
-  formatCardDuration,
+  formatDuration,
+  statusLabel,
   taskTypeLabel,
 } from '../../utils/homeDataCenter';
 
@@ -14,85 +22,173 @@ interface LatestTaskCardProps {
   failed: boolean;
 }
 
+type TaskTheme = {
+  accent: string;
+  iconBox: string;
+  icon: string;
+  tag: string;
+};
+
+const TASK_THEMES: Record<HomeLatestTask['taskType'], TaskTheme> = {
+  OFFLINE_SYNC: {
+    accent: 'bg-[linear-gradient(90deg,#6675f5_0%,#94a8ff_100%)]',
+    iconBox: 'bg-[#eef1ff]',
+    icon: 'text-[#6572ed]',
+    tag: 'bg-[#f1f3ff] text-[#5d68dc]',
+  },
+  WORKFLOW: {
+    accent: 'bg-[linear-gradient(90deg,#ffb900_0%,#ffd85a_100%)]',
+    iconBox: 'bg-[#fff7dc]',
+    icon: 'text-[#d49600]',
+    tag: 'bg-[#fff8e2] text-[#aa7600]',
+  },
+  DATA_QUALITY: {
+    accent: 'bg-[linear-gradient(90deg,#23a66b_0%,#66ce9b_100%)]',
+    iconBox: 'bg-[#eaf8f1]',
+    icon: 'text-[#259767]',
+    tag: 'bg-[#edf9f3] text-[#23855b]',
+  },
+};
+
+function TaskTypeIcon({ taskType }: { taskType: HomeLatestTask['taskType'] }) {
+  if (taskType === 'OFFLINE_SYNC') {
+    return <ArrowRightLeft size={20} strokeWidth={1.9} />;
+  }
+  if (taskType === 'WORKFLOW') {
+    return <Workflow size={20} strokeWidth={1.9} />;
+  }
+  if (taskType === 'DATA_QUALITY') {
+    return <ShieldCheck size={20} strokeWidth={1.9} />;
+  }
+  return <Database size={20} strokeWidth={1.9} />;
+}
+
+function statusBadgeClassName(status?: string) {
+  const label = statusLabel(status);
+  if (label === '成功') return 'bg-[#ebf8f1] text-[#218557]';
+  if (label === '失败') return 'bg-[#fff0f1] text-[#dc4250]';
+  if (label === '运行中') return 'bg-[#eef4ff] text-[#4775d1]';
+  if (label === '已取消') return 'bg-[#f2f3f5] text-[#747983]';
+  return 'bg-[#f4f5f7] text-[#747983]';
+}
+
+function LatestTaskContent({ task }: { task: HomeLatestTask }) {
+  const theme = TASK_THEMES[task.taskType];
+  const status = statusLabel(task.status);
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (task.detailPath) history.push(task.detailPath);
+      }}
+      className="group relative flex h-[280px] w-full flex-col overflow-hidden rounded-[16px] border border-[#e8ebef] bg-white p-4 text-left shadow-[0_4px_14px_rgba(31,35,41,0.045),0_1px_2px_rgba(31,35,41,0.025)] transition-[border-color,box-shadow,transform] duration-[240ms] ease-out hover:-translate-y-px hover:border-[#dde2e8] hover:shadow-[0_9px_22px_rgba(31,35,41,0.07),0_1px_2px_rgba(31,35,41,0.025)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-200/70"
+    >
+      <span
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-x-0 top-0 h-[3px] ${theme.accent}`}
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-8 -top-10 h-32 w-32 rounded-full border border-[#eef0f4]"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-3 -top-5 h-24 w-24 rounded-full border border-[#f1f2f5]"
+      />
+
+      <div className="relative flex items-start justify-between gap-2">
+        <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] ${theme.iconBox} ${theme.icon}`}>
+          <TaskTypeIcon taskType={task.taskType} />
+        </div>
+        <span
+          className={`inline-flex max-w-[92px] items-center gap-1 rounded-full px-2 py-1 text-[10px] font-medium leading-none ${statusBadgeClassName(task.status)}`}
+        >
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-80" />
+          <span className="truncate">{status}</span>
+        </span>
+      </div>
+
+      <div className="relative mt-3 min-w-0">
+        <span className={`inline-flex rounded-[6px] px-2 py-1 text-[10px] font-medium leading-none ${theme.tag}`}>
+          {taskTypeLabel(task.taskType)}
+        </span>
+        <div className="mt-2 truncate text-[14px] font-semibold leading-5 text-[#2b2e37]">
+          {task.taskName}
+        </div>
+        <div className="mt-1 truncate text-[10px] leading-4 text-[#9a9ea7]">
+          任务 ID · {task.taskId}
+        </div>
+      </div>
+
+      <div className="relative mt-3 grid grid-cols-2 gap-2">
+        <div className="rounded-[10px] bg-[#f7f8fa] px-3 py-2.5">
+          <div className="text-[10px] leading-4 text-[#92969f]">运行次数</div>
+          <div className="mt-0.5 text-[17px] font-semibold leading-6 text-[#31343c]">
+            {task.runCount}
+            <span className="ml-0.5 text-[10px] font-normal text-[#a0a4ac]">次</span>
+          </div>
+        </div>
+        <div className="rounded-[10px] bg-[#f7f8fa] px-3 py-2.5">
+          <div className="text-[10px] leading-4 text-[#92969f]">异常</div>
+          <div
+            className={`mt-0.5 text-[17px] font-semibold leading-6 ${
+              task.exceptionCount > 0 ? 'text-[#df4b58]' : 'text-[#31343c]'
+            }`}
+          >
+            {task.exceptionCount}
+            <span className="ml-0.5 text-[10px] font-normal text-[#a0a4ac]">次</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="relative mt-2.5 flex items-center justify-between rounded-[10px] border border-[#eef0f3] bg-[#fbfbfc] px-3 py-2">
+        <span className="flex items-center gap-1.5 text-[10px] text-[#858a93]">
+          <Clock3 size={12} strokeWidth={1.8} />
+          本次耗时
+        </span>
+        <strong className="text-[11px] font-semibold text-[#4c5059]">
+          {formatDuration(task.durationMs)}
+        </strong>
+      </div>
+
+      <div className="relative mt-auto flex items-center justify-between border-t border-[#eef0f3] pt-3 text-[11px] font-medium text-[#666b75] transition-colors group-hover:text-[#2f333b]">
+        <span>查看任务详情</span>
+        <ChevronRight
+          size={14}
+          strokeWidth={1.8}
+          className="transition-transform duration-200 group-hover:translate-x-0.5"
+        />
+      </div>
+    </button>
+  );
+}
+
 export function LatestTaskCard({
   task,
   loading,
   failed,
 }: LatestTaskCardProps) {
   return (
-    <aside className="w-full shrink-0 lg:w-[220px] lg:border-r lg:border-[#edf0f3] lg:pr-5">
-      <div className="mb-2 text-[13px] font-semibold leading-5 text-[#353842]">
-        最新任务
+    <aside className="w-full shrink-0 self-start lg:h-[310px] lg:w-[238px] lg:border-r lg:border-[#edf0f3] lg:pr-6">
+      <div className="mb-2 flex h-5 items-center justify-between gap-2">
+        <span className="text-[13px] font-semibold leading-5 text-[#353842]">
+          最新任务
+        </span>
+        <span className="text-[10px] font-normal text-[#a1a5ad]">最近一次执行</span>
       </div>
 
       {task ? (
-        <button
-          type="button"
-          onClick={() => {
-            if (task.detailPath) history.push(task.detailPath);
-          }}
-          className="group relative h-[266px] w-full overflow-hidden rounded-[10px] border border-[#e8ebef] bg-[linear-gradient(150deg,#6c737d_0%,#9197a0_48%,#c0c4ca_100%)] text-left text-white transition-[border-color,transform] duration-200 hover:-translate-y-px hover:border-[#dfe3e8] lg:w-[198px]"
-        >
-          <div className="pointer-events-none absolute inset-0 opacity-[0.18] [background-image:linear-gradient(rgba(255,255,255,.28)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.22)_1px,transparent_1px)] [background-size:22px_22px]" />
-          <div className="pointer-events-none absolute -right-9 top-10 h-32 w-32 rounded-full border border-white/20" />
-          <div className="pointer-events-none absolute -right-2 top-16 h-24 w-24 rounded-full border border-white/20" />
-
-          <div className="absolute left-4 top-3 z-10">
-            <div className="text-[12px] font-semibold text-white/95">
-              {taskTypeLabel(task.taskType)}
-            </div>
-            <div className="mt-0.5 text-[11px] text-white/80">
-              {formatCardDuration(task.durationMs)}
-            </div>
-          </div>
-
-          <Copy
-            size={14}
-            strokeWidth={1.8}
-            className="absolute right-3 top-3 z-10 text-white/90"
-          />
-
-          <div className="absolute inset-x-0 top-[50px] z-10 flex justify-center">
-            <div className="relative flex h-[122px] w-[122px] items-center justify-center">
-              <span className="absolute h-[112px] w-[112px] rounded-full border border-white/25" />
-              <span className="absolute h-[82px] w-[82px] rounded-full border border-white/18" />
-              <span className="absolute h-[52px] w-[52px] rounded-full bg-white/12 backdrop-blur-[2px]" />
-              <Database
-                size={52}
-                strokeWidth={1.15}
-                className="relative text-white/95"
-              />
-            </div>
-          </div>
-
-          <div className="absolute inset-x-0 bottom-[70px] z-10 px-4">
-            <div className="truncate text-[12px] font-medium text-white/95">
-              {task.taskName}
-            </div>
-          </div>
-
-          <div className="absolute inset-x-0 bottom-0 z-10 h-[70px] bg-black/20 px-4 backdrop-blur-[12px]">
-            <div className="flex h-1/2 items-center justify-between border-b border-white/12">
-              <span className="text-[11px] text-white/78">运行次数</span>
-              <strong className="text-[12px] font-semibold">{task.runCount}</strong>
-            </div>
-            <div className="flex h-1/2 items-center justify-between">
-              <span className="text-[11px] text-white/78">异常</span>
-              <strong className="text-[12px] font-semibold">
-                {task.exceptionCount}
-              </strong>
-            </div>
-          </div>
-        </button>
+        <LatestTaskContent task={task} />
       ) : loading || failed ? (
-        <div className="flex h-[266px] w-full items-center justify-center rounded-[10px] border border-[#e8ebef] bg-[#fafbfc] text-[11px] text-[#9da1a8] lg:w-[198px]">
+        <div className="flex h-[280px] w-full items-center justify-center rounded-[16px] border border-[#e8ebef] bg-[#fafbfc] text-[11px] text-[#9da1a8]">
           {loading ? '任务数据加载中...' : '任务数据加载失败'}
         </div>
       ) : (
-        <div className="flex h-[266px] w-full items-center justify-center rounded-[10px] border border-[#e8ebef] bg-[#fafbfc] lg:w-[198px]">
+        <div className="flex h-[280px] w-full items-center justify-center rounded-[16px] border border-[#e8ebef] bg-[#fafbfc]">
           <YakOpsEmpty
-            width={150}
-            height={100}
+            width={144}
+            height={96}
             title="暂无运行任务"
             showCaption
           />


### PR DESCRIPTION
## Motivation

首页「数据中心」左侧最新任务区域目前有两个明显的视觉问题：

1. 左右分隔线使用 `aside` 自然拉伸高度，右侧运行总览 / 近期任务 / 调度数据内容高度变化时，分隔线也跟着变长或变短；
2. 最新任务卡片使用大面积灰色渐变 + 大图标，信息密度低，任务类型、状态和执行摘要不够清晰。

## Changes

- 把左侧区域设为 `self-start`，并在桌面端固定为 `310px` 高度，分隔线不再受右侧 Tab 内容高度影响；
- 将最新任务卡从深灰大图风格重构为轻量白色信息卡，与首页现有 Quick Create 的卡片语言保持一致；
- 根据离线同步 / 工作流 / 数据质量使用不同的轻量任务类型强调色和图标；
- 增加任务状态、任务 ID、运行次数、异常次数、本次耗时和「查看任务详情」入口；
- 保留现有 `detailPath` 跳转、loading / failed / empty 状态；
- 不改后端接口、不改 Home API contract，也不新增前端请求。

## Compatibility

- `/api/v1/home/**` 无任何变化；
- `HomeLatestTask` 数据结构无变化；
- 右侧运行总览 / 近期任务 / 调度数据逻辑无变化；
- 移动端继续保持单列布局，桌面端才显示固定高度分隔线。

## Validation

- branch 基于当前 `main`（已包含 Home business module 拆分）；
- diff 仅修改 `LatestTaskCard.tsx`；
- 建议本地重点回归 1080p / 2K 下三组 Tab 切换，确认分隔线高度固定，并检查最新任务、空状态、加载失败状态的布局。

完整 `npm run lint / npm test / 浏览器回归` 留给 CI 或本地验证后再转 Ready。