### PR TITLE
fix(offline-sync): harden Project Space task isolation

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapter.java
@@ -42,15 +42,18 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
 
   @Override
   public Optional<OfflineJobDefinition> findById(Long id) {
-    requireProject();
-    return Optional.ofNullable(toDomain(dao.selectById(id), Map.of()));
+    long projectId = requireProject();
+    OfflineJobDefinitionPO po = dao.selectById(id);
+    requireCurrentProject(po, projectId);
+    return Optional.ofNullable(toDomain(po, Map.of()));
   }
 
   @Override
   public Optional<OfflineJobDefinition> findForViewById(Long id) {
-    requireProject();
+    long projectId = requireProject();
     OfflineJobDefinitionPO po = dao.selectById(id);
     if (po == null) return Optional.empty();
+    requireCurrentProject(po, projectId);
     return Optional.of(toDomain(po, dataSourceNames(List.of(po))));
   }
 
@@ -104,6 +107,7 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
   private PageData<OfflineJobDefinition> page(
       OfflineDefinitionQuery query,
       boolean includeDisplayNames) {
+    long projectId = requireProject();
     OfflineDefinitionQuery q = query == null
         ? new OfflineDefinitionQuery(1, 10, null, null, null, null, null, null, null, null, null)
         : query;
@@ -113,6 +117,7 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
             q.sourceType(), q.sinkType(), q.sourceTable(), q.sinkTable(),
             q.createTimeStart(), q.createTimeEnd()));
     List<OfflineJobDefinitionPO> pageRecords = page.getRecords();
+    requireCurrentProject(pageRecords, projectId);
     Map<Long, String> dataSourceNames =
         includeDisplayNames ? dataSourceNames(pageRecords) : Map.of();
     List<OfflineJobDefinition> records = pageRecords.stream()
@@ -162,6 +167,20 @@ public class OfflineJobDefinitionRepositoryAdapter implements OfflineJobDefiniti
       }
     }
     return names;
+  }
+
+  private void requireCurrentProject(List<OfflineJobDefinitionPO> definitions, long projectId) {
+    if (definitions == null || definitions.isEmpty()) return;
+    for (OfflineJobDefinitionPO definition : definitions) {
+      requireCurrentProject(definition, projectId);
+    }
+  }
+
+  private void requireCurrentProject(OfflineJobDefinitionPO definition, long projectId) {
+    if (definition == null) return;
+    if (!Objects.equals(definition.getProjectId(), projectId)) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
   }
 
   private long requireProject() {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/dao/impl/OfflineJobDefinitionDaoProjectScopeTest.java
@@ -2,8 +2,11 @@ package io.yak.ops.business.sync.offline.dao.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineExecutionEventMapper;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
 import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
@@ -41,7 +44,24 @@ class OfflineJobDefinitionDaoProjectScopeTest {
 
     ArgumentCaptor<OfflineJobDefinitionPO> captor =
         ArgumentCaptor.forClass(OfflineJobDefinitionPO.class);
-    org.mockito.Mockito.verify(mapper).insert(captor.capture());
+    verify(mapper).insert(captor.capture());
     assertThat(captor.getValue().getProjectId()).isEqualTo(7L);
+  }
+
+  @Test
+  void pageAlwaysUsesCurrentProjectPredicate() {
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project A"));
+    OfflineJobDefinitionDaoImpl dao =
+        new OfflineJobDefinitionDaoImpl(
+            mapper, executionMapper, eventMapper, writeMapper, currentProject);
+
+    dao.selectPage(null);
+
+    verify(mapper).selectPage(
+        any(Page.class),
+        argThat(
+            wrapper ->
+                wrapper.getSqlSegment().contains("project_id")
+                    && wrapper.getParamNameValuePairs().containsValue(7L)));
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineJobDefinitionRepositoryAdapterTest.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.sync.offline.repository;
 import static io.yak.ops.business.sync.offline.OfflineProjectTestContext.PROJECT_ID;
 import static io.yak.ops.business.sync.offline.OfflineProjectTestContext.currentProject;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -14,6 +15,7 @@ import io.yak.ops.business.sync.offline.dao.OfflineJobDefinitionDao;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,6 +78,21 @@ class OfflineJobDefinitionRepositoryAdapterTest {
     repository().pageForView(null);
 
     verify(dataSourceDao).selectByIds(List.of(1L, 2L, 3L));
+  }
+
+  @Test
+  void displayPageRejectsForeignProjectRowsBeforeDatasourceEnrichment() {
+    OfflineJobDefinitionPO foreign = definition();
+    foreign.setProjectId(PROJECT_ID + 1L);
+
+    Page<OfflineJobDefinitionPO> page = Page.of(1, 10);
+    page.setRecords(List.of(foreign));
+    page.setTotal(1L);
+    when(dao.selectPage(any())).thenReturn(page);
+
+    assertThatThrownBy(() -> repository().pageForView(null))
+        .isInstanceOf(ProjectContextException.class);
+    verifyNoInteractions(dataSourceDao);
   }
 
   private OfflineJobDefinitionRepositoryAdapter repository() {

--- a/yak-ops-ui/src/pages/batch-link-up/hooks/useOfflineSyncTasks.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/hooks/useOfflineSyncTasks.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { listOfflineSyncTasks } from '@/services/batch-link-up';
+
+import { useOfflineSyncTasks } from './useOfflineSyncTasks';
+
+let mockCurrentProjectId = 7;
+
+jest.mock('@/contexts/SecurityProjectContext', () => ({
+  useSecurityProject: () => ({
+    currentProject: { id: mockCurrentProjectId, name: `Project ${mockCurrentProjectId}` },
+  }),
+}));
+
+jest.mock('@/services/batch-link-up', () => ({
+  listOfflineSyncTasks: jest.fn(),
+}));
+
+jest.mock('@umijs/max', () => ({
+  history: { replace: jest.fn() },
+}));
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
+
+const page = (id: number, jobName: string) =>
+  ({
+    bizData: [{ id, jobName }],
+    pagination: { current: 1, pageSize: 10, total: 1 },
+  }) as any;
+
+describe('useOfflineSyncTasks Project Space isolation', () => {
+  const mockListOfflineSyncTasks = jest.mocked(listOfflineSyncTasks);
+
+  beforeEach(() => {
+    mockCurrentProjectId = 7;
+    mockListOfflineSyncTasks.mockReset();
+    window.history.replaceState({}, '', '/batch-link-up');
+  });
+
+  it('drops stale rows and stale responses after the workspace changes', async () => {
+    const projectA = deferred<any>();
+    const projectB = deferred<any>();
+    mockListOfflineSyncTasks
+      .mockImplementationOnce(() => projectA.promise)
+      .mockImplementationOnce(() => projectB.promise);
+
+    const { result, rerender } = renderHook(() => useOfflineSyncTasks());
+    await waitFor(() => expect(mockListOfflineSyncTasks).toHaveBeenCalledTimes(1));
+
+    mockCurrentProjectId = 8;
+    rerender();
+
+    await waitFor(() => expect(mockListOfflineSyncTasks).toHaveBeenCalledTimes(2));
+    expect(result.current.records).toEqual([]);
+
+    await act(async () => {
+      projectA.resolve(page(101, 'Project A task'));
+      await projectA.promise;
+    });
+    expect(result.current.records).toEqual([]);
+
+    await act(async () => {
+      projectB.resolve(page(202, 'Project B task'));
+      await projectB.promise;
+    });
+    await waitFor(() => expect(result.current.records).toEqual(page(202, 'Project B task').bizData));
+  });
+});

--- a/yak-ops-ui/src/pages/batch-link-up/hooks/useOfflineSyncTasks.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/hooks/useOfflineSyncTasks.ts
@@ -1,3 +1,4 @@
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
 import { listOfflineSyncTasks, type OfflineJobDefinitionVO } from '@/services/batch-link-up';
 import { history } from '@umijs/max';
 import { message } from 'antd';
@@ -22,7 +23,13 @@ const currentLocationSearch = () =>
   typeof window === 'undefined' ? '' : window.location.search;
 
 export const useOfflineSyncTasks = () => {
+  const { currentProject } = useSecurityProject();
+  const currentProjectId = currentProject?.id;
   const requestSequenceRef = useRef(0);
+  const activeProjectIdRef = useRef(currentProjectId);
+  const previousProjectIdRef = useRef(currentProjectId);
+  activeProjectIdRef.current = currentProjectId;
+
   const initialSearchState = useMemo(
     () => parseOfflineSyncSearchFromUrl(currentLocationSearch()),
     [],
@@ -46,15 +53,31 @@ export const useOfflineSyncTasks = () => {
   }, []);
 
   const loadTasks = useCallback(async () => {
+    const requestProjectId = currentProjectId;
     const requestSequence = requestSequenceRef.current + 1;
     requestSequenceRef.current = requestSequence;
+
+    if (!requestProjectId) {
+      setRecords([]);
+      setPagination((current) =>
+        current.total === 0 ? current : { ...current, total: 0 },
+      );
+      setLoading(false);
+      return;
+    }
+
     setLoading(true);
 
     try {
       const result = await listOfflineSyncTasks(
         buildOfflineSyncPageQuery(search, pagination),
       );
-      if (requestSequence !== requestSequenceRef.current) return;
+      if (
+        requestSequence !== requestSequenceRef.current ||
+        requestProjectId !== activeProjectIdRef.current
+      ) {
+        return;
+      }
 
       setRecords(result?.bizData || []);
       setPagination((current) => ({
@@ -62,17 +85,35 @@ export const useOfflineSyncTasks = () => {
         total: result?.pagination?.total || 0,
       }));
     } catch (error) {
-      if (requestSequence === requestSequenceRef.current) {
+      if (
+        requestSequence === requestSequenceRef.current &&
+        requestProjectId === activeProjectIdRef.current
+      ) {
         message.error(
           error instanceof Error ? error.message : '查询离线同步任务失败',
         );
       }
     } finally {
-      if (requestSequence === requestSequenceRef.current) {
+      if (
+        requestSequence === requestSequenceRef.current &&
+        requestProjectId === activeProjectIdRef.current
+      ) {
         setLoading(false);
       }
     }
-  }, [pagination.current, pagination.pageSize, refreshVersion, search]);
+  }, [currentProjectId, pagination.current, pagination.pageSize, refreshVersion, search]);
+
+  useEffect(() => {
+    if (previousProjectIdRef.current === currentProjectId) return;
+    previousProjectIdRef.current = currentProjectId;
+    requestSequenceRef.current += 1;
+    setRecords([]);
+    setSelectedRowKeys([]);
+    setPagination((current) => {
+      if (current.current === 1 && current.total === 0) return current;
+      return { ...current, current: 1, total: 0 };
+    });
+  }, [currentProjectId]);
 
   useEffect(() => {
     const query = buildOfflineSyncQueryString(search, pagination);


### PR DESCRIPTION
## 背景

复现反馈：在 Project A 中创建 DataSource 和 Offline Sync task，任务执行成功后切换到另一个工作空间，DataSource 列表已经正确隔离，但离线同步页面仍可能显示 Project A 的任务。

## 排查结论

当前 `main` 的后端 Definition 主查询本身已经有 Project 条件：

- `/api/v1/job/batch-definition/**` 是 `PROJECT_REQUIRED`；
- 前端共享 request policy 会为该路由注入 `X-YAK-SECURITY-PROJECT-ID`；
- `OfflineJobDefinitionDaoImpl.selectPage()` 使用 trusted `CurrentProject.requireProjectId()`，并追加 `project_id = currentProject`；
- `yak_offline_job_definition.project_id` 在首发 baseline 中为 `NOT NULL`。

因此这次不是简单补一个遗漏的 `WHERE project_id = ?`。

当前仍存在两个可确认的隔离缺口：

1. **Offline Sync 页面状态没有绑定 Project identity**。`useOfflineSyncTasks` 只按搜索条件/分页刷新，records 本身不属于某个 Project generation。只要 Project context 发生软切换，或者旧 Project 请求在切换后晚返回，旧 rows 就仍有机会写回页面；新 Project 请求失败时也会继续保留旧 rows。
2. **Repository 对 DAO page result 只有 `projectId != null` 校验，没有二次验证 `row.projectId == CurrentProject`**。正常情况下 DAO 会正确过滤，但一旦查询层发生回归，Repository 会直接把 foreign row 转成 VO，缺少 fail-closed 的第二道 ownership guard。现有 DAO Project test 也只覆盖 insert，没有锁定 page predicate。

## 修改

### Frontend

`useOfflineSyncTasks` 现在显式消费 `SecurityProjectContext`：

- Project 切换时立即失效旧 request generation；
- 清空旧 tasks / selected rows，并把分页回到第一页；
- request capture 当前 `projectId`，响应落地前同时验证 request sequence 和 Project identity；
- Project A 的慢响应即使在切到 Project B 后才返回，也不能重新写回 records；
- 无有效 Project 时 fail closed 为 empty state，不发 Project-owned task 查询。

### Backend

`OfflineJobDefinitionRepositoryAdapter` 增加 ownership guard：

- detail / display detail 在 DAO 返回 row 后重新验证 `row.projectId == CurrentProject`；
- page 在做 DataSource display-name enrichment **之前**验证整页 rows；
- 一旦出现 foreign row，直接抛 `PROJECT_NOT_FOUND`，不把跨空间数据继续向上层返回。

DAO 仍然是第一道 Project predicate，Repository guard 是 defense-in-depth，不允许把前端过滤当作权限边界。

## Regression tests

新增/补强：

- `OfflineJobDefinitionDaoProjectScopeTest`
  - 锁定 page query 必须包含 `project_id` predicate，并且参数来自 CurrentProject；
- `OfflineJobDefinitionRepositoryAdapterTest`
  - 模拟 DAO 错误返回其他 Project row，Repository 必须在 DataSource enrichment 前 fail closed；
- `useOfflineSyncTasks.test.ts`
  - 模拟 A 请求未完成时切到 B，A 的迟到响应不得重新出现在 B 的页面。

## 数据库

无 Flyway / schema 变化。

当前 baseline 已经是：

```sql
yak_offline_job_definition.project_id BIGINT NOT NULL
```

## 建议本地验证

Backend：

```bash
mvn -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline -am \
  -Dtest=OfflineJobDefinitionDaoProjectScopeTest,OfflineJobDefinitionRepositoryAdapterTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

Frontend：

```bash
cd yak-ops-ui
npm test -- --runInBand src/pages/batch-link-up/hooks/useOfflineSyncTasks.test.ts
npm run tsc
```

最小 A/B 手工回归：

1. Project A 新建 DataSource + Offline Sync task 并运行成功；
2. 切到 Project B，确认 DataSource 和 Offline task 都为空/只展示 B 自己的数据；
3. 快速 A -> B -> A 切换，确认慢请求不会把上一空间 rows 写回；
4. B 使用 A 的 definitionId 调 detail / edit / execute，均应表现为当前空间不可见；
5. 浏览器 Network 确认 `/api/v1/job/batch-definition/page` 的 `X-YAK-SECURITY-PROJECT-ID` 随工作空间切换；
6. 如历史/本地库仍能复现，直接核对对应 `yak_offline_job_definition.id` 的 `project_id`，排除运行中的旧后端或未重建的 pre-v1 开发数据库。

## 当前验证状态

- branch 基于当前 `main`；
- connector 静态 compare：ahead 1 / behind 0；
- 变更限定在 Offline Definition Repository + Project scope tests + Offline page hook；
- 当前 connector 环境没有实际执行 Maven / Jest / TypeScript / MySQL 集成测试，因此保持 Draft，不宣称测试已经通过。
