### PR TITLE
refactor(home): rebalance homepage dashboard columns

### DIFF
--- a/yak-ops-ui/src/pages/home/HomePage.tsx
+++ b/yak-ops-ui/src/pages/home/HomePage.tsx
@@ -1,7 +1,10 @@
 import DataCenter from './components/DataCenter';
 import { HomeBackground } from './components/HomeBackground';
 import { HomeHeader } from './components/HomeHeader';
-import HomeWorkbench from './components/HomeWorkbench';
+import {
+  HomeWorkbenchMain,
+  HomeWorkbenchSidebar,
+} from './components/HomeWorkbench';
 import NotificationCenter from './components/NotificationCenter';
 import { QuickCreatePanel } from './components/QuickCreatePanel';
 import ScheduleCenter from './components/ScheduleCenter';
@@ -18,47 +21,20 @@ export default function HomePage() {
         <HomeHeader stats={cockpit.data?.header} />
 
         <main className="px-4 pb-4">
-          {/* 快速创建：全宽 */}
           <div className="mt-4">
             <QuickCreatePanel />
           </div>
 
-          {/* 
-            主体采用抖音创作者中心式双列布局。
-
-            左：
-            - 数据中心
-            - HomeWorkbench
-
-            右：
-            - 通知
-            - 调度中心
-
-            两列高度完全独立，不再互相绑定。
-          */}
-          <div
-            className="
-              mt-4
-              grid
-              grid-cols-1
-              items-start
-              gap-4
-              xl:grid-cols-[minmax(0,1fr)_380px]
-              2xl:grid-cols-[minmax(0,1fr)_410px]
-            "
-          >
-            {/* 左侧主内容 */}
+          <div className="mt-4 grid grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1fr)_380px] 2xl:grid-cols-[minmax(0,1fr)_410px]">
             <div className="min-w-0 space-y-4">
               <DataCenter />
-
-              <HomeWorkbench />
+              <HomeWorkbenchMain />
             </div>
 
-            {/* 右侧辅助区域 */}
             <aside className="min-w-0 space-y-4">
               <NotificationCenter />
-
               <ScheduleCenter />
+              <HomeWorkbenchSidebar />
             </aside>
           </div>
         </main>

--- a/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
@@ -1,0 +1,362 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import {
+  homeQualityOverviewApi,
+  type HomeQualityDimension,
+  type HomeQualityIssue,
+  type HomeQualityOverview,
+} from '@/services/home';
+import { BRAND_COLOR } from '@/styles/brand';
+import { history } from '@umijs/max';
+import type { EChartsOption } from 'echarts';
+import ReactECharts from 'echarts-for-react';
+import { AlertTriangle, CheckCircle2, ChevronRight } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { relativeTime, SectionHeader } from './homeAssetOverviewShared';
+
+interface QualitySidebarState {
+  data?: HomeQualityOverview;
+  loading: boolean;
+  failed: boolean;
+}
+
+interface RadarDimensionDefinition {
+  label: string;
+  aliases: string[];
+}
+
+const COUNT_FORMATTER = new Intl.NumberFormat('zh-CN');
+const RADAR_DIMENSIONS: RadarDimensionDefinition[] = [
+  { label: '完整性', aliases: ['完整性'] },
+  { label: '唯一性', aliases: ['唯一性'] },
+  { label: '有效性', aliases: ['有效性'] },
+  { label: '准确性', aliases: ['准确性'] },
+  { label: '时效性', aliases: ['时效性', '及时性'] },
+];
+
+const formatMetric = (value?: number | null) =>
+  value == null ? '--' : COUNT_FORMATTER.format(value);
+
+const formatRate = (value?: number | null) =>
+  value == null ? '--' : value.toFixed(1);
+
+const normalizeRadarDimensions = (
+  dimensions: HomeQualityDimension[],
+): HomeQualityDimension[] =>
+  RADAR_DIMENSIONS.map((definition) => {
+    const matched = dimensions.find((item) =>
+      definition.aliases.includes(item.dimension),
+    );
+
+    return {
+      dimension: definition.label,
+      total: matched?.total ?? 0,
+      issues: matched?.issues ?? 0,
+      passRate: matched?.passRate ?? null,
+    };
+  });
+
+const healthState = (passRate?: number | null) => {
+  if (passRate == null) {
+    return {
+      label: '暂无质量执行数据',
+      className: 'text-[#858b94]',
+      icon: null,
+    };
+  }
+
+  if (passRate >= 95) {
+    return {
+      label: '整体质量健康',
+      className: 'text-[#31865a]',
+      icon: <CheckCircle2 size={13} strokeWidth={2} />,
+    };
+  }
+
+  return {
+    label: passRate >= 80 ? '质量表现需关注' : '质量问题较多',
+    className: passRate >= 80 ? 'text-[#b87520]' : 'text-[#d94d59]',
+    icon: <AlertTriangle size={13} strokeWidth={1.9} />,
+  };
+};
+
+function useQualitySidebarOverview(): QualitySidebarState {
+  const [state, setState] = useState<QualitySidebarState>({
+    loading: true,
+    failed: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    homeQualityOverviewApi
+      .overview()
+      .then((response) => {
+        if (!active) return;
+        if (!response.data) {
+          setState({ loading: false, failed: true });
+          return;
+        }
+        setState({ data: response.data, loading: false, failed: false });
+      })
+      .catch(() => {
+        if (active) setState({ loading: false, failed: true });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}
+
+function buildRadarOption(dimensions: HomeQualityDimension[]): EChartsOption {
+  const hasCompleteRadar = dimensions.every((item) => item.passRate != null);
+
+  return {
+    animation: hasCompleteRadar,
+    animationDuration: 520,
+    tooltip: hasCompleteRadar
+      ? {
+          trigger: 'item',
+          formatter: () =>
+            dimensions
+              .map(
+                (item) =>
+                  `${item.dimension}：${formatRate(item.passRate)}%`,
+              )
+              .join('<br/>'),
+        }
+      : { show: false },
+    radar: {
+      center: ['50%', '51%'],
+      radius: '62%',
+      splitNumber: 4,
+      indicator: dimensions.map((item) => ({
+        name: item.dimension,
+        max: 100,
+      })),
+      axisName: {
+        color: '#666d78',
+        fontSize: 10,
+        fontWeight: 500,
+      },
+      axisLine: {
+        lineStyle: { color: '#dde1e7' },
+      },
+      splitLine: {
+        lineStyle: { color: '#e2e5ea' },
+      },
+      splitArea: {
+        areaStyle: { color: ['#ffffff', '#f8f9fb'] },
+      },
+    },
+    series: hasCompleteRadar
+      ? [
+          {
+            type: 'radar',
+            symbol: 'circle',
+            symbolSize: 4,
+            data: [
+              {
+                value: dimensions.map((item) => item.passRate ?? 0),
+                lineStyle: { width: 2, color: BRAND_COLOR },
+                itemStyle: { color: BRAND_COLOR },
+                areaStyle: { color: 'rgba(254,44,85,0.09)' },
+              },
+            ],
+          },
+        ]
+      : [],
+  };
+}
+
+function QualityMetric({
+  label,
+  value,
+  warning = false,
+}: {
+  label: string;
+  value?: number | null;
+  warning?: boolean;
+}) {
+  return (
+    <div className="min-w-0 text-center">
+      <div className="truncate text-[10px] leading-4 text-[#92969f]">
+        {label}
+      </div>
+      <strong
+        className={`mt-1 block text-[17px] font-semibold leading-6 ${
+          warning && (value ?? 0) > 0 ? 'text-[#d94d59]' : 'text-[#343943]'
+        }`}
+      >
+        {formatMetric(value)}
+      </strong>
+    </div>
+  );
+}
+
+const objectLabel = (issue: HomeQualityIssue) =>
+  issue.objectName || issue.tableName || issue.monitorName;
+
+function RecentIssueRow({ issue }: { issue: HomeQualityIssue }) {
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        history.push(
+          `/data-quality/execution/${encodeURIComponent(issue.executionNo)}`,
+        )
+      }
+      className="group flex w-full items-center gap-2.5 border-0 bg-transparent py-2.5 text-left"
+    >
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[#fff2f3] text-[#e35d69]">
+        <AlertTriangle size={13} strokeWidth={1.9} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <strong className="truncate text-[11px] font-medium text-[#42464f]">
+            {issue.ruleName}
+          </strong>
+          <span className="shrink-0 rounded-full bg-[#f0f1f4] px-1.5 py-0.5 text-[9px] text-[#747a84]">
+            {issue.dimension}
+          </span>
+        </span>
+        <span className="mt-0.5 block truncate text-[9px] text-[#999ea7]">
+          {objectLabel(issue)}
+          {issue.columnName ? ` · ${issue.columnName}` : ''}
+        </span>
+      </span>
+      <span className="shrink-0 text-[9px] text-[#a0a4ac]">
+        {relativeTime(issue.queuedAt)}
+      </span>
+      <ChevronRight
+        size={12}
+        strokeWidth={1.8}
+        className="shrink-0 text-[#b0b4bb] transition-transform group-hover:translate-x-0.5"
+      />
+    </button>
+  );
+}
+
+export default function HomeQualitySidebarOverview() {
+  const state = useQualitySidebarOverview();
+  const data = state.data;
+  const health = healthState(data?.passRate);
+  const dimensions = useMemo(
+    () => normalizeRadarDimensions(data?.dimensions ?? []),
+    [data?.dimensions],
+  );
+  const radarOption = useMemo(() => buildRadarOption(dimensions), [dimensions]);
+  const issues = data?.recentIssues?.slice(0, 3) ?? [];
+  const showRadar = !state.loading && !state.failed && data?.passRate != null;
+
+  return (
+    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-5 pb-5 pt-5">
+      <SectionHeader
+        title="数据质量"
+        description="质量健康与最近问题"
+        onMore={() => history.push('/data-quality/overview')}
+      />
+
+      <div className="mt-4 rounded-[14px] border border-[#eef0f3] bg-[#fafbfc] px-4 pb-3.5 pt-3.5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <span className="text-[10px] text-[#92969f]">整体通过率</span>
+            <div className="mt-0.5 flex items-end gap-1">
+              <strong className="text-[28px] font-semibold leading-8 tracking-[-0.7px] text-[#2d313a]">
+                {formatRate(data?.passRate)}
+              </strong>
+              {data?.passRate != null ? (
+                <span className="mb-0.5 text-[10px] text-[#7e848e]">%</span>
+              ) : null}
+            </div>
+          </div>
+
+          <span
+            className={`mt-1 flex items-center gap-1 text-[10px] font-medium ${health.className}`}
+          >
+            {health.icon}
+            {state.loading
+              ? '加载中...'
+              : state.failed
+                ? '加载失败'
+                : health.label}
+          </span>
+        </div>
+
+        <div className="mt-1 h-[176px]">
+          {showRadar ? (
+            <ReactECharts
+              option={radarOption}
+              notMerge
+              style={{ width: '100%', height: '176px' }}
+            />
+          ) : state.loading || state.failed ? (
+            <div className="flex h-full items-center justify-center text-[10px] text-[#9da1a8]">
+              {state.loading ? '质量数据加载中...' : '质量数据加载失败'}
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <YakOpsEmpty
+                width={108}
+                height={72}
+                title="暂无质量执行数据"
+                showCaption
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-4 gap-2 border-t border-[#e6e9ee] pt-3">
+          <QualityMetric label="监控表" value={data?.monitoredTableCount} />
+          <QualityMetric label="今日检测" value={data?.todayExecutionCount} />
+          <QualityMetric
+            label="问题表"
+            value={data?.todayIssueTableCount}
+            warning
+          />
+          <QualityMetric label="启用规则" value={data?.enabledRuleCount} />
+        </div>
+      </div>
+
+      <div className="mt-4 border-t border-[#eef0f3] pt-3.5">
+        <div className="flex items-center justify-between gap-3">
+          <strong className="text-[12px] font-semibold text-[#454a53]">
+            最近问题
+          </strong>
+          <span className="flex items-center gap-1 text-[10px] text-[#8f949d]">
+            <AlertTriangle size={11} strokeWidth={1.8} className="text-[#e35d69]" />
+            {formatMetric(data?.recentIssueCount)} 项
+          </span>
+        </div>
+
+        {issues.length > 0 ? (
+          <div className="mt-1 divide-y divide-[#f0f1f3]">
+            {issues.map((issue) => (
+              <RecentIssueRow key={issue.id} issue={issue} />
+            ))}
+          </div>
+        ) : state.loading || state.failed || data?.recentIssueCount == null ? (
+          <div className="flex min-h-[92px] items-center justify-center text-[10px] text-[#9da1a8]">
+            {state.loading
+              ? '问题数据加载中...'
+              : state.failed
+                ? '问题数据加载失败'
+                : '问题数据暂不可用'}
+          </div>
+        ) : (
+          <div className="flex min-h-[92px] items-center justify-center">
+            <YakOpsEmpty
+              width={100}
+              height={66}
+              title="近 7 日暂无质量问题"
+              showCaption
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/components/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeWorkbench.tsx
@@ -1,35 +1,51 @@
-import { Sparkles } from 'lucide-react';
-
 import {
   DataLineageOverview,
   DatasetOverview,
   useHomeAssetOverview,
 } from './HomeAssetOverview';
 import HomeDataServiceOverview from './HomeDataServiceOverview';
-import QualityOverview from './HomeQualityOverview';
+import HomeQualitySidebarOverview from './HomeQualitySidebarOverview';
 import HomeVisualizationOverview from './HomeVisualizationOverview';
 
 /**
- * 首页业务总览。
+ * 首页主内容流。
  *
- * 数据集、血缘、数据质量、数据服务与可视化均接入当前真实数据源。
+ * 宽内容保留在主列，避免数据集、血缘和可视化在窄侧栏中失去信息密度。
  */
-export default function HomeWorkbench() {
+export function HomeWorkbenchMain() {
   const assetOverviewState = useHomeAssetOverview();
 
   return (
-    <div className="mt-4 space-y-4">
+    <div className="min-w-0 space-y-4">
       <DatasetOverview state={assetOverviewState} />
-
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.32fr)_minmax(400px,0.68fr)]">
-        <QualityOverview />
-        <HomeDataServiceOverview />
-      </div>
-
       <DataLineageOverview state={assetOverviewState} />
-
       <HomeVisualizationOverview />
+    </div>
+  );
+}
 
+/**
+ * 首页辅助内容流。
+ *
+ * 数据质量使用侧栏专用紧凑视图，数据服务本身即适配约 400px 宽度。
+ */
+export function HomeWorkbenchSidebar() {
+  return (
+    <div className="min-w-0 space-y-4">
+      <HomeQualitySidebarOverview />
+      <HomeDataServiceOverview />
+    </div>
+  );
+}
+
+/**
+ * 保留独立使用 HomeWorkbench 时的兼容入口。
+ */
+export default function HomeWorkbench() {
+  return (
+    <div className="mt-4 grid grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1fr)_380px] 2xl:grid-cols-[minmax(0,1fr)_410px]">
+      <HomeWorkbenchMain />
+      <HomeWorkbenchSidebar />
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
@@ -1,0 +1,140 @@
+import YakOpsEmpty from '@/components/YakOpsEmpty';
+import {
+  pageMessages,
+  type SecurityMessage,
+} from '@/services/security/messages';
+import { history } from '@umijs/max';
+import { ChevronRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface NotificationState {
+  items: SecurityMessage[];
+  total: number;
+  loading: boolean;
+  failed: boolean;
+}
+
+const formatMessageDate = (value?: string) => {
+  if (!value) return '--';
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return value;
+  return `${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+    date.getDate(),
+  ).padStart(2, '0')}`;
+};
+
+function NotificationRow({ item }: { item: SecurityMessage }) {
+  return (
+    <button
+      type="button"
+      onClick={() => history.push('/system/messages')}
+      className="group flex w-full items-start gap-2 border-0 bg-transparent py-3 text-left"
+    >
+      <span
+        className={`mt-[7px] h-1 w-1 shrink-0 rounded-full ${
+          item.status === 'UNREAD' ? 'bg-[#ff3657]' : 'bg-[#d7d9de]'
+        }`}
+      />
+      <span className="min-w-0 flex-1">
+        <strong
+          className={`line-clamp-2 block text-[12px] leading-5 transition-colors group-hover:text-[#20232b] ${
+            item.status === 'UNREAD'
+              ? 'font-semibold text-[#353943]'
+              : 'font-normal text-[#555a64]'
+          }`}
+        >
+          {item.title}
+        </strong>
+        {item.summary ? (
+          <span className="mt-0.5 block truncate text-[10px] leading-4 text-[#9a9ea6]">
+            {item.summary}
+          </span>
+        ) : null}
+      </span>
+      <span className="shrink-0 pt-0.5 text-[10px] leading-5 text-[#a0a4ac]">
+        {formatMessageDate(item.createTime)}
+      </span>
+    </button>
+  );
+}
+
+export default function NotificationCenter() {
+  const [state, setState] = useState<NotificationState>({
+    items: [],
+    total: 0,
+    loading: true,
+    failed: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    pageMessages({ pageNum: 1, pageSize: 3 })
+      .then((result) => {
+        if (!active) return;
+        setState({
+          items: result.records || [],
+          total: result.total || 0,
+          loading: false,
+          failed: false,
+        });
+      })
+      .catch(() => {
+        if (!active) return;
+        setState({ items: [], total: 0, loading: false, failed: true });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-5">
+      <header className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+            通知
+          </h2>
+          {state.total > 0 ? (
+            <span className="rounded-full bg-[#f4f5f7] px-2 py-0.5 text-[10px] text-[#8e939c]">
+              {state.total}
+            </span>
+          ) : null}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => history.push('/system/messages')}
+          className="flex shrink-0 items-center gap-0.5 border-0 bg-transparent p-0 text-[12px] text-[#666b75] transition-colors hover:text-[#252832]"
+        >
+          查看更多
+          <ChevronRight size={14} strokeWidth={1.8} />
+        </button>
+      </header>
+
+      <div className="mt-3 min-h-[126px]">
+        {state.items.length > 0 ? (
+          <div className="divide-y divide-[#f0f1f3]">
+            {state.items.map((item) => (
+              <NotificationRow key={item.id} item={item} />
+            ))}
+          </div>
+        ) : state.loading || state.failed ? (
+          <div className="flex min-h-[126px] items-center justify-center text-[11px] text-[#9da1a8]">
+            {state.loading ? '通知加载中...' : '通知加载失败'}
+          </div>
+        ) : (
+          <div className="flex min-h-[126px] items-center justify-center">
+            <YakOpsEmpty
+              width={112}
+              height={74}
+              title="暂无通知"
+              showCaption
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 背景

当前首页已经把数据中心与右侧调度区域拆成双列，但 `HomeWorkbench` 仍把数据集、数据质量、数据服务、数据血缘、可视化全部塞在左侧内容流里。结果是调度中心结束后右侧出现大块空白，和抖音创作者中心这种“左右两条独立内容流”的排版差异很明显。

另外，当前 `HomePage.tsx` 已经引用 `NotificationCenter`，但 main 上缺少对应组件文件，本 PR 一并补齐。

## 调整方案

- 首页主区域改成真正独立的两条纵向内容流：
  - 左侧主列：数据中心 → 数据集 → 数据血缘 → 可视化
  - 右侧辅助列：通知 → 调度中心 → 数据质量 → 数据服务
- `xl` 侧栏宽度固定为 380px，`2xl` 扩展到 410px；两列使用 `items-start`，高度互不绑定。
- 拆分 `HomeWorkbenchMain` / `HomeWorkbenchSidebar`，避免 HomeWorkbench 继续作为一个不可拆的大块占据左列。
- 新增侧栏专用数据质量组件，在约 400px 宽度下保留：
  - 整体通过率
  - 质量雷达
  - 4 个核心指标
  - 最近 3 条质量问题
- 新增通知卡片，直接复用现有消息中心真实接口 `/api/v1/message/page`，最多展示 3 条，查看更多跳转 `/system/messages`，不引入假数据。
- 保留 `HomeWorkbench` 默认导出作为兼容入口。

## 设计目标

- 消除右侧调度中心以下的大块空白。
- 宽内容继续留在主列，避免数据集、血缘图、可视化内容被压进窄侧栏。
- 将本来就适合约 400px 展示的数据服务与新的紧凑质量总览放到右侧，形成类似抖音创作者中心的连续辅助信息流。
- 不再通过固定高度让左右卡片强行对齐，卡片由内容自然决定高度。

## 影响范围

仅调整首页前端布局与组件组合，不修改后端接口和数据口径。

## 验证

- [ ] `npm run tsc`
- [ ] `npm run biome:lint`
- [ ] 1080p 首页布局回归
- [ ] 2K 首页布局回归
- [ ] 消息为空 / 有消息状态
- [ ] 数据质量为空 / 有数据状态

当前通过 GitHub 连接器提交，无法在本地拉取依赖执行完整前端命令，CI 结果以 PR checks 为准。