### PR TITLE
fix(ui): refine home data center overview

### DIFF
--- a/yak-ops-ui/src/pages/home/components/DataCenter/OverviewMetrics.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/OverviewMetrics.tsx
@@ -6,11 +6,11 @@ export function OverviewMetrics({
   metrics: HomeOverviewMetric[];
 }) {
   return (
-    <div className="mt-1 grid grid-cols-2 gap-x-2 gap-y-1 sm:grid-cols-3">
+    <div className="mt-1 grid grid-cols-2 gap-x-2 gap-y-1 sm:grid-cols-3 lg:grid-cols-6 lg:gap-x-1">
       {metrics.map((metric) => (
         <div
           key={metric.label}
-          className="group min-w-0 rounded-[6px] px-3 py-2 transition-colors duration-150 hover:bg-[#f7f8fa]"
+          className="group min-w-0 rounded-[6px] px-3 py-2 transition-colors duration-150 hover:bg-[#f7f8fa] lg:px-2 lg:py-1.5"
         >
           <div className="text-[12px] font-semibold leading-5 text-[#454951]">
             {metric.label}

--- a/yak-ops-ui/src/pages/home/components/DataCenter/OverviewPanel.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/OverviewPanel.tsx
@@ -28,35 +28,42 @@ export function OverviewPanel({
   );
   const trendLabels = overview?.trend?.labels || [];
   const trendValues = overview?.trend?.values || [];
-  const hasTrendData = trendValues.some((value) => value > 0);
+  const hasTrendData = trendLabels.length > 0 && trendValues.length > 0;
+
+  if (loading || failed) {
+    return (
+      <div className="flex h-[240px] items-center justify-center text-[12px] text-[#9da1a8]">
+        {loading ? '运行数据加载中...' : '运行数据加载失败'}
+      </div>
+    );
+  }
+
+  if (!hasTrendData) {
+    return (
+      <div className="flex h-[240px] items-center justify-center">
+        <YakOpsEmpty
+          width={120}
+          height={80}
+          title={`${periodLabel}暂无运行数据`}
+          showCaption
+        />
+      </div>
+    );
+  }
 
   return (
-    <div>
+    <div className="lg:h-[240px]">
       <div className="mt-2 flex items-center justify-end gap-1.5 text-[12px] text-[#7f848e]">
         <span className="h-2 w-2 rounded-full bg-[#5b8cff]" />
         运行次数
       </div>
-      {loading || failed ? (
-        <div className="flex h-[152px] items-center justify-center text-[12px] text-[#9da1a8]">
-          {loading ? '运行数据加载中...' : '运行数据加载失败'}
-        </div>
-      ) : hasTrendData ? (
-        <TrendChart
-          key={`trend-${periodKey}`}
-          values={trendValues}
-          labels={trendLabels}
-          name="运行次数"
-        />
-      ) : (
-        <div className="flex h-[152px] items-center justify-center">
-          <YakOpsEmpty
-            width={120}
-            height={80}
-            title={`${periodLabel}暂无运行数据`}
-            showCaption
-          />
-        </div>
-      )}
+      <TrendChart
+        key={`trend-${periodKey}`}
+        values={trendValues}
+        labels={trendLabels}
+        name="运行次数"
+        height={132}
+      />
       <OverviewMetrics metrics={overviewMetrics} />
     </div>
   );

--- a/yak-ops-ui/src/pages/home/components/DataCenter/TrendChart.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/TrendChart.tsx
@@ -6,9 +6,15 @@ interface TrendChartProps {
   values: number[];
   labels: string[];
   name: string;
+  height?: number;
 }
 
-export function TrendChart({ values, labels, name }: TrendChartProps) {
+export function TrendChart({
+  values,
+  labels,
+  name,
+  height = 152,
+}: TrendChartProps) {
   const option = useMemo<EChartsOption>(
     () => ({
       animation: true,
@@ -131,7 +137,7 @@ export function TrendChart({ values, labels, name }: TrendChartProps) {
       option={option}
       notMerge
       lazyUpdate
-      style={{ height: 152, width: '100%' }}
+      style={{ height, width: '100%' }}
     />
   );
 }


### PR DESCRIPTION
## Summary

- use the presence of trend series data to decide whether the overview has data, instead of treating all-zero run counts as an empty state
- render a centered `YakOpsEmpty` only when no trend data is returned, and hide the six overview metrics in that state
- keep loading and failure states inside the same fixed-height overview body
- compact the desktop overview by rendering the six metrics in one row and using a shorter trend chart
- make `TrendChart` height configurable without changing its default behavior

## Scope

Frontend-only change under `yak-ops-ui/src/pages/home/components/DataCenter`. No backend API or data contract changes.

## Validation

- reviewed the updated component state branches and prop types
- no local build/test run was available through the GitHub connector
