### PR TITLE
refactor(ui): refine home empty-state hierarchy

### DIFF
--- a/yak-ops-ui/src/pages/home/components/DataCenter/RecentTasksPanel.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/RecentTasksPanel.tsx
@@ -1,4 +1,3 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import type { HomeRecentTask } from '@/services/home';
 import { history } from '@umijs/max';
 import { Clock3, Database } from 'lucide-react';
@@ -9,6 +8,7 @@ import {
   statusClassName,
   statusLabel,
 } from '../../utils/homeDataCenter';
+import { HomeEmptyState } from '../HomeEmptyState';
 
 interface RecentTasksPanelProps {
   items: HomeRecentTask[];
@@ -31,14 +31,12 @@ export function RecentTasksPanel({
 
   if (items.length === 0) {
     return (
-      <div className="flex min-h-[263px] items-center justify-center">
-        <YakOpsEmpty
-          width={160}
-          height={108}
-          title="暂无近期任务"
-          showCaption
-        />
-      </div>
+      <HomeEmptyState
+        icon={Database}
+        title="暂无近期任务"
+        size="medium"
+        className="min-h-[263px]"
+      />
     );
   }
 

--- a/yak-ops-ui/src/pages/home/components/DataCenter/SchedulePanel.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/SchedulePanel.tsx
@@ -1,4 +1,3 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import type { HomeScheduleItem } from '@/services/home';
 import { history } from '@umijs/max';
 import { Clock3, RadioTower } from 'lucide-react';
@@ -9,17 +8,16 @@ import {
   statusLabel,
   taskTypeLabel,
 } from '../../utils/homeDataCenter';
+import { HomeEmptyState } from '../HomeEmptyState';
 
 function EmptySchedulePanel({ periodLabel }: { periodLabel: string }) {
   return (
-    <div className="flex min-h-[263px] items-center justify-center">
-      <YakOpsEmpty
-        width={160}
-        height={108}
-        title={`${periodLabel}暂无调度数据`}
-        showCaption
-      />
-    </div>
+    <HomeEmptyState
+      icon={RadioTower}
+      title={`${periodLabel}暂无调度数据`}
+      size="medium"
+      className="min-h-[263px]"
+    />
   );
 }
 

--- a/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
@@ -1,4 +1,3 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import {
   getDataServiceOverview,
   type DataServiceOverview,
@@ -6,8 +5,10 @@ import {
 import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
 import ReactECharts from 'echarts-for-react';
+import { Activity } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
+import { HomeEmptyState } from './HomeEmptyState';
 import { SectionHeader } from './homeAssetOverviewShared';
 
 interface DataServiceOverviewState {
@@ -133,14 +134,12 @@ function TrendEmpty({ state }: { state: DataServiceOverviewState }) {
   }
 
   return (
-    <div className="flex h-[126px] items-center justify-center">
-      <YakOpsEmpty
-        width={116}
-        height={78}
-        title="近 7 日暂无 API 调用"
-        showCaption
-      />
-    </div>
+    <HomeEmptyState
+      icon={Activity}
+      title="近 7 日暂无 API 调用"
+      size="small"
+      className="h-[126px]"
+    />
   );
 }
 

--- a/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
@@ -139,6 +139,7 @@ function RecentDatasetColumn({ state }: { state: HomeAssetOverviewState }) {
           failed={state.failed}
           unavailable={state.data?.dataset?.datasetCount == null}
           text="暂无数据集"
+          icon={Table2}
         />
       )}
     </div>
@@ -195,6 +196,7 @@ function OnlineDatasetColumn({ state }: { state: HomeAssetOverviewState }) {
           failed={state.failed}
           unavailable={state.data?.dataset?.datasetCount == null}
           text="暂无上线数据集"
+          icon={Database}
         />
       )}
 

--- a/yak-ops-ui/src/pages/home/components/HomeEmptyState.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeEmptyState.tsx
@@ -1,0 +1,65 @@
+import type { LucideIcon } from 'lucide-react';
+
+interface HomeEmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  size?: 'small' | 'medium';
+  className?: string;
+}
+
+const SIZE_STYLES = {
+  small: {
+    iconBox: 'h-8 w-8 rounded-[9px]',
+    iconSize: 15,
+    title: 'text-[10px] leading-4',
+    description: 'text-[9px] leading-4',
+    gap: 'gap-2',
+  },
+  medium: {
+    iconBox: 'h-9 w-9 rounded-[10px]',
+    iconSize: 17,
+    title: 'text-[11px] leading-5',
+    description: 'text-[10px] leading-4',
+    gap: 'gap-2.5',
+  },
+} as const;
+
+/**
+ * 首页轻量空状态。
+ *
+ * 小型列表、图表和侧栏区域使用图标 + 文案，避免同一屏重复出现
+ * YakOpsEmpty 品牌插画。大型主画布仍保留 YakOpsEmpty。
+ */
+export function HomeEmptyState({
+  icon: Icon,
+  title,
+  description,
+  size = 'medium',
+  className = '',
+}: HomeEmptyStateProps) {
+  const styles = SIZE_STYLES[size];
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center text-center ${styles.gap} ${className}`}
+    >
+      <span
+        className={`flex shrink-0 items-center justify-center bg-[#f4f5f7] text-[#a4a9b2] ${styles.iconBox}`}
+      >
+        <Icon size={styles.iconSize} strokeWidth={1.7} />
+      </span>
+
+      <div>
+        <div className={`font-medium text-[#858b95] ${styles.title}`}>
+          {title}
+        </div>
+        {description ? (
+          <div className={`mt-0.5 text-[#a7abb3] ${styles.description}`}>
+            {description}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
@@ -5,6 +5,7 @@ import ReactECharts from 'echarts-for-react';
 import { Activity } from 'lucide-react';
 import { useMemo } from 'react';
 
+import { HomeEmptyState } from './HomeEmptyState';
 import {
   assetTypeColor,
   compactName,
@@ -202,14 +203,12 @@ export function DataLineageOverview({
                     : '数据暂不可用'}
               </div>
             ) : (
-              <div className="flex min-h-[118px] items-center justify-center">
-                <YakOpsEmpty
-                  width={100}
-                  height={66}
-                  title="暂无最近关系"
-                  showCaption
-                />
-              </div>
+              <HomeEmptyState
+                icon={Activity}
+                title="暂无最近关系"
+                size="small"
+                className="min-h-[118px]"
+              />
             )}
           </div>
         </div>

--- a/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
@@ -1,4 +1,3 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import {
   homeQualityOverviewApi,
   type HomeQualityDimension,
@@ -9,9 +8,15 @@ import { BRAND_COLOR } from '@/styles/brand';
 import { history } from '@umijs/max';
 import type { EChartsOption } from 'echarts';
 import ReactECharts from 'echarts-for-react';
-import { AlertTriangle, CheckCircle2, ChevronRight } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  ShieldCheck,
+} from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
+import { HomeEmptyState } from './HomeEmptyState';
 import { relativeTime, SectionHeader } from './homeAssetOverviewShared';
 
 interface QualitySidebarState {
@@ -298,14 +303,12 @@ export default function HomeQualitySidebarOverview() {
               {state.loading ? '质量数据加载中...' : '质量数据加载失败'}
             </div>
           ) : (
-            <div className="flex h-full items-center justify-center">
-              <YakOpsEmpty
-                width={108}
-                height={72}
-                title="暂无质量执行数据"
-                showCaption
-              />
-            </div>
+            <HomeEmptyState
+              icon={ShieldCheck}
+              title="暂无质量执行数据"
+              size="medium"
+              className="h-full"
+            />
           )}
         </div>
 
@@ -347,14 +350,12 @@ export default function HomeQualitySidebarOverview() {
                 : '问题数据暂不可用'}
           </div>
         ) : (
-          <div className="flex min-h-[92px] items-center justify-center">
-            <YakOpsEmpty
-              width={100}
-              height={66}
-              title="近 7 日暂无质量问题"
-              showCaption
-            />
-          </div>
+          <HomeEmptyState
+            icon={CheckCircle2}
+            title="近 7 日暂无质量问题"
+            size="small"
+            className="min-h-[92px]"
+          />
         )}
       </div>
     </section>

--- a/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
@@ -1,4 +1,3 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { listDigitalScreens, type DigitalScreenInstance } from '@/services/digital-screen';
 import {
   fetchDashboardOverview,
@@ -9,6 +8,7 @@ import { history } from '@umijs/max';
 import { Clock3, LayoutDashboard, Monitor } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
+import { HomeEmptyState } from './HomeEmptyState';
 import {
   formatMetric,
   relativeTime,
@@ -292,14 +292,12 @@ export default function HomeVisualizationOverview() {
           {loading ? '可视化数据加载中...' : '可视化数据加载失败'}
         </div>
       ) : (
-        <div className="flex min-h-[176px] items-center justify-center">
-          <YakOpsEmpty
-            width={150}
-            height={100}
-            title="暂无仪表盘或数字大屏"
-            showCaption
-          />
-        </div>
+        <HomeEmptyState
+          icon={LayoutDashboard}
+          title="暂无仪表盘或数字大屏"
+          size="medium"
+          className="min-h-[176px]"
+        />
       )}
     </section>
   );

--- a/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
@@ -1,11 +1,12 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import {
   pageMessages,
   type SecurityMessage,
 } from '@/services/security/messages';
 import { history } from '@umijs/max';
-import { ChevronRight } from 'lucide-react';
+import { Bell, ChevronRight } from 'lucide-react';
 import { useEffect, useState } from 'react';
+
+import { HomeEmptyState } from './HomeEmptyState';
 
 interface NotificationState {
   items: SecurityMessage[];
@@ -125,14 +126,12 @@ export default function NotificationCenter() {
             {state.loading ? '通知加载中...' : '通知加载失败'}
           </div>
         ) : (
-          <div className="flex min-h-[126px] items-center justify-center">
-            <YakOpsEmpty
-              width={112}
-              height={74}
-              title="暂无通知"
-              showCaption
-            />
-          </div>
+          <HomeEmptyState
+            icon={Bell}
+            title="暂无通知"
+            size="small"
+            className="min-h-[126px]"
+          />
         )}
       </div>
     </section>

--- a/yak-ops-ui/src/pages/home/components/ScheduleCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/ScheduleCenter.tsx
@@ -1,12 +1,13 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import {
   homeScheduleCenterApi,
   type HomeScheduleCalendar,
   type HomeScheduleDay,
 } from '@/services/home';
 import { history } from '@umijs/max';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Clock3 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+
+import { HomeEmptyState } from './HomeEmptyState';
 
 const pad2 = (value: number) => String(value).padStart(2, '0');
 
@@ -268,14 +269,12 @@ export default function ScheduleCenter() {
           ))}
 
           {calendar && calendar.overview.length === 0 && (
-            <div className="flex min-h-[126px] items-center justify-center">
-              <YakOpsEmpty
-                width={116}
-                height={78}
-                title="本月暂无调度配置"
-                showCaption
-              />
-            </div>
+            <HomeEmptyState
+              icon={Clock3}
+              title="本月暂无调度配置"
+              size="medium"
+              className="min-h-[126px]"
+            />
           )}
         </div>
       </div>

--- a/yak-ops-ui/src/pages/home/components/homeAssetOverviewShared.tsx
+++ b/yak-ops-ui/src/pages/home/components/homeAssetOverviewShared.tsx
@@ -1,7 +1,7 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
+import type { LucideIcon } from 'lucide-react';
 import { ChevronRight } from 'lucide-react';
 
-import type { HomeAssetOverview } from './service';
+import { HomeEmptyState } from './HomeEmptyState';
 
 export interface HomeAssetOverviewState {
   data?: HomeAssetOverview;
@@ -102,11 +102,13 @@ export function EmptyList({
   failed,
   unavailable,
   text,
+  icon,
 }: {
   loading: boolean;
   failed: boolean;
   unavailable: boolean;
   text: string;
+  icon: LucideIcon;
 }) {
   if (loading || failed || unavailable) {
     return (
@@ -117,8 +119,11 @@ export function EmptyList({
   }
 
   return (
-    <div className="flex min-h-[214px] items-center justify-center">
-      <YakOpsEmpty width={150} height={100} title={text} showCaption />
-    </div>
+    <HomeEmptyState
+      icon={icon}
+      title={text}
+      size="medium"
+      className="min-h-[214px]"
+    />
   );
 }


### PR DESCRIPTION
## Summary

- add a reusable `HomeEmptyState` for lightweight homepage empty states using neutral Lucide icons and concise copy
- replace repeated `YakOpsEmpty` illustrations in small/list/chart/sidebar areas across datasets, notifications, schedules, quality, visualization, data service, and DataCenter secondary tabs
- keep `YakOpsEmpty` for large branded/focal scenes such as the lineage canvas and primary DataCenter/latest-task experiences
- preserve existing loading and failure states; this change only adjusts the successful-but-empty presentation

## Design intent

The homepage previously repeated the same yak illustration many times in one viewport, making empty states visually dominant. This introduces a hierarchy:

- large focal canvas -> branded `YakOpsEmpty`
- small list/chart/sidebar empty state -> lightweight `HomeEmptyState`

## Scope

Frontend-only changes under `yak-ops-ui/src/pages/home/components`. No backend API or data contract changes.

## Validation

- compared `main...refactor/home-empty-state`; branch is ahead only and touches 11 homepage component files
- reviewed all changed imports and `HomeEmptyState` call sites
- no local yarn build/test was available through the GitHub connector
