### PR TITLE
refactor(ui): align workspace management with role layout

### DIFF
--- a/yak-ops-ui/src/pages/system/security-projects/components/WorkspaceEditorDrawer.tsx
+++ b/yak-ops-ui/src/pages/system/security-projects/components/WorkspaceEditorDrawer.tsx
@@ -1,0 +1,158 @@
+import { Alert, Drawer, Form, Input, TreeSelect } from 'antd';
+import { useEffect } from 'react';
+
+import { YakButton } from '@/components/ui';
+import type {
+  SecurityProjectInput,
+  SecurityProjectSummary,
+} from '@/services/security/projects';
+
+import type { WorkspaceDepartmentTreeNode } from '../workspace';
+
+interface WorkspaceEditorDrawerProps {
+  open: boolean;
+  editing?: SecurityProjectSummary;
+  saving: boolean;
+  departmentLoading: boolean;
+  departmentTreeData: WorkspaceDepartmentTreeNode[];
+  onClose: () => void;
+  onSave: (values: SecurityProjectInput) => void;
+}
+
+export default function WorkspaceEditorDrawer({
+  open,
+  editing,
+  saving,
+  departmentLoading,
+  departmentTreeData,
+  onClose,
+  onSave,
+}: WorkspaceEditorDrawerProps) {
+  const [form] = Form.useForm<SecurityProjectInput>();
+
+  useEffect(() => {
+    if (!open) return;
+    form.resetFields();
+    form.setFieldsValue({
+      projectName: editing?.projectName ?? '',
+      description: editing?.description ?? '',
+      deptId: editing?.deptId ?? undefined,
+    });
+  }, [editing, form, open]);
+
+  return (
+    <Drawer
+      open={open}
+      title={editing ? '编辑工作空间' : '新增工作空间'}
+      width={560}
+      forceRender
+      maskClosable={!saving}
+      keyboard={!saving}
+      closable={!saving}
+      onClose={onClose}
+      extra={
+        <div className="flex items-center gap-2">
+          <YakButton disabled={saving} onClick={onClose}>
+            取消
+          </YakButton>
+          <YakButton
+            type="primary"
+            loading={saving}
+            onClick={() => form.submit()}
+          >
+            {editing ? '更新' : '创建'}
+          </YakButton>
+        </div>
+      }
+    >
+      <Alert
+        showIcon
+        type="info"
+        className="mb-5"
+        message={
+          editing
+            ? '修改名称或所属部门不会改变已有负责人和成员关系。'
+            : '创建后当前用户会自动成为负责人，工作空间会立即出现在 Header 切换列表中。'
+        }
+      />
+
+      {departmentTreeData.length === 0 && !departmentLoading ? (
+        <Alert
+          showIcon
+          type="warning"
+          className="mb-4"
+          message="暂无可用部门"
+          description="工作空间必须归属真实部门，请先在“系统管理 > 部门管理”创建部门。"
+        />
+      ) : null}
+
+      <Form<SecurityProjectInput>
+        form={form}
+        layout="vertical"
+        preserve={false}
+        disabled={saving}
+        onFinish={onSave}
+      >
+        {editing ? (
+          <Form.Item label="工作空间编码">
+            <Input
+              disabled
+              variant="filled"
+              value={editing.projectCode || '-'}
+            />
+          </Form.Item>
+        ) : null}
+
+        <Form.Item
+          name="projectName"
+          label="工作空间名称"
+          rules={[
+            {
+              required: true,
+              whitespace: true,
+              message: '请输入工作空间名称',
+            },
+          ]}
+        >
+          <Input
+            variant="filled"
+            maxLength={128}
+            showCount
+            placeholder="例如：成都一院"
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="deptId"
+          label="所属部门"
+          rules={[{ required: true, message: '请选择所属部门' }]}
+        >
+          <TreeSelect
+            variant="filled"
+            treeData={departmentTreeData}
+            treeDefaultExpandAll
+            showSearch
+            allowClear={false}
+            loading={departmentLoading}
+            placeholder="请选择所属部门"
+            filterTreeNode={(input, node) =>
+              String(node.title ?? '')
+                .toLocaleLowerCase()
+                .includes(input.trim().toLocaleLowerCase())
+            }
+          />
+        </Form.Item>
+
+        <Form.Item name="description" label="工作空间描述">
+          <Input.TextArea
+            variant="filled"
+            maxLength={500}
+            showCount
+            autoSize={{ minRows: 4, maxRows: 8 }}
+            placeholder="说明这个工作空间对应的医院、团队或业务范围"
+          />
+        </Form.Item>
+      </Form>
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/pages/system/security-projects/components/WorkspaceFilterBar.tsx
+++ b/yak-ops-ui/src/pages/system/security-projects/components/WorkspaceFilterBar.tsx
@@ -1,0 +1,153 @@
+import {
+  PlusOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import { Input, Select, Tooltip } from 'antd';
+import { useState } from 'react';
+
+import { YakButton } from '@/components/ui';
+import type { SecurityProjectStatus } from '@/services/security/projects';
+
+export interface WorkspaceFilters {
+  projectCode?: string;
+  projectName?: string;
+  ownerName?: string;
+  status?: SecurityProjectStatus;
+}
+
+type WorkspaceSearchField = 'projectName' | 'projectCode' | 'ownerName';
+
+const SEARCH_FIELD_OPTIONS: Array<{
+  label: string;
+  value: WorkspaceSearchField;
+}> = [
+  { label: '工作空间名称', value: 'projectName' },
+  { label: '工作空间编码', value: 'projectCode' },
+  { label: '负责人', value: 'ownerName' },
+];
+
+const SEARCH_PLACEHOLDERS: Record<WorkspaceSearchField, string> = {
+  projectName: '请输入工作空间名称',
+  projectCode: '请输入工作空间编码',
+  ownerName: '请输入负责人名称',
+};
+
+const buildFilters = (
+  keyword: string,
+  searchField: WorkspaceSearchField,
+  status?: SecurityProjectStatus,
+): WorkspaceFilters => {
+  const filters: WorkspaceFilters = status ? { status } : {};
+  const normalized = keyword.trim();
+  if (normalized) filters[searchField] = normalized;
+  return filters;
+};
+
+interface WorkspaceFilterBarProps {
+  total: number;
+  loading?: boolean;
+  canManage: boolean;
+  onSearch: (filters: WorkspaceFilters) => void;
+  onRefresh: () => void;
+  onCreate: () => void;
+}
+
+export default function WorkspaceFilterBar({
+  total,
+  loading = false,
+  canManage,
+  onSearch,
+  onRefresh,
+  onCreate,
+}: WorkspaceFilterBarProps) {
+  const [searchField, setSearchField] =
+    useState<WorkspaceSearchField>('projectName');
+  const [keyword, setKeyword] = useState('');
+  const [status, setStatus] = useState<SecurityProjectStatus>();
+
+  const submit = () => {
+    onSearch(buildFilters(keyword, searchField, status));
+  };
+
+  return (
+    <div className="mb-4 flex min-w-0 flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div className="inline-flex h-8 w-fit items-center rounded-[8px] bg-[#f2f3f5] px-3.5 text-[13px] font-semibold text-[#242731]">
+        全部工作空间
+        <span className="ml-1.5 text-xs font-medium text-[#98a2b3]">
+          {total}
+        </span>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <Select<WorkspaceSearchField>
+          value={searchField}
+          options={SEARCH_FIELD_OPTIONS}
+          variant="filled"
+          popupMatchSelectWidth={140}
+          className="w-[132px]"
+          onChange={(nextField) => {
+            setSearchField(nextField);
+            setKeyword('');
+            onSearch(status ? { status } : {});
+          }}
+        />
+
+        <Input
+          allowClear
+          value={keyword}
+          variant="filled"
+          placeholder={SEARCH_PLACEHOLDERS[searchField]}
+          suffix={
+            <SearchOutlined
+              className="cursor-pointer text-slate-400 transition-colors hover:text-slate-700"
+              onClick={submit}
+            />
+          }
+          className="w-[240px]"
+          onChange={(event) => {
+            const value = event.target.value;
+            setKeyword(value);
+            if (!value) onSearch(status ? { status } : {});
+          }}
+          onPressEnter={submit}
+        />
+
+        <Select<SecurityProjectStatus>
+          allowClear
+          value={status}
+          variant="filled"
+          placeholder="状态"
+          className="w-[108px]"
+          options={[
+            { label: '启用', value: 'ENABLED' },
+            { label: '停用', value: 'DISABLED' },
+          ]}
+          onChange={(nextStatus) => {
+            setStatus(nextStatus);
+            onSearch(buildFilters(keyword, searchField, nextStatus));
+          }}
+        />
+
+        <Tooltip title="刷新列表">
+          <YakButton
+            iconOnly
+            icon={<ReloadOutlined />}
+            loading={loading}
+            onClick={onRefresh}
+          />
+        </Tooltip>
+
+        {canManage && (
+          <YakButton
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={onCreate}
+          >
+            新增工作空间
+          </YakButton>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/security-projects/components/WorkspaceRowActions.tsx
+++ b/yak-ops-ui/src/pages/system/security-projects/components/WorkspaceRowActions.tsx
@@ -1,0 +1,104 @@
+import {
+  DeleteOutlined,
+  DownOutlined,
+  EditOutlined,
+  EyeOutlined,
+  TeamOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
+import { Dropdown, Space, type MenuProps } from 'antd';
+
+import { YakButton } from '@/components/ui';
+import type { SecurityProjectSummary } from '@/services/security/projects';
+
+interface WorkspaceRowActionsProps {
+  project: SecurityProjectSummary;
+  canManage: boolean;
+  onDetail: (project: SecurityProjectSummary) => void;
+  onEdit: (project: SecurityProjectSummary) => void;
+  onAssignOwner: (project: SecurityProjectSummary) => void;
+  onAssignMembers: (project: SecurityProjectSummary) => void;
+  onDelete: (project: SecurityProjectSummary) => void;
+}
+
+export default function WorkspaceRowActions({
+  project,
+  canManage,
+  onDetail,
+  onEdit,
+  onAssignOwner,
+  onAssignMembers,
+  onDelete,
+}: WorkspaceRowActionsProps) {
+  const items: MenuProps['items'] = canManage
+    ? [
+        {
+          key: 'owner',
+          icon: <UserOutlined />,
+          label: '分配负责人',
+        },
+        {
+          key: 'members',
+          icon: <TeamOutlined />,
+          label: '分配成员',
+        },
+        { type: 'divider' },
+        {
+          key: 'delete',
+          icon: <DeleteOutlined />,
+          label: '删除工作空间',
+          danger: true,
+        },
+      ]
+    : [];
+
+  return (
+    <Space size={2}>
+      <YakButton
+        type="text"
+        size="small"
+        icon={<EyeOutlined />}
+        className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+        onClick={() => onDetail(project)}
+      >
+        详情
+      </YakButton>
+
+      {canManage && (
+        <YakButton
+          type="text"
+          size="small"
+          icon={<EditOutlined />}
+          className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+          onClick={() => onEdit(project)}
+        >
+          编辑
+        </YakButton>
+      )}
+
+      {canManage && (
+        <Dropdown
+          trigger={['click']}
+          placement="bottomRight"
+          menu={{
+            items,
+            onClick: ({ key }) => {
+              if (key === 'owner') onAssignOwner(project);
+              if (key === 'members') onAssignMembers(project);
+              if (key === 'delete') onDelete(project);
+            },
+          }}
+        >
+          <YakButton
+            type="text"
+            size="small"
+            className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+          >
+            更多
+            <DownOutlined className="ml-1 text-[10px]" />
+          </YakButton>
+        </Dropdown>
+      )}
+    </Space>
+  );
+}

--- a/yak-ops-ui/src/pages/system/security-projects/index.tsx
+++ b/yak-ops-ui/src/pages/system/security-projects/index.tsx
@@ -1,31 +1,21 @@
-import {
-  ApartmentOutlined,
-  PlusOutlined,
-  ReloadOutlined,
-} from '@ant-design/icons';
 import { useModel } from '@umijs/max';
 import {
   Alert,
-  Button,
   Descriptions,
   Drawer,
-  Form,
-  Input,
   Modal,
-  Select,
   Space,
   Switch,
   Tag,
-  TreeSelect,
   Typography,
   message,
   type TableColumnsType,
 } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import YakButton from '@/components/YakButton';
 import {
   AssignmentDrawer,
+  SecurityPagination,
   SecurityQueryTable,
 } from '@/components/security';
 import { useSecurityProject } from '@/contexts/SecurityProjectContext';
@@ -57,6 +47,11 @@ import {
   formatSystemDateTime,
   getSystemErrorMessage,
 } from '../utils';
+import WorkspaceEditorDrawer from './components/WorkspaceEditorDrawer';
+import WorkspaceFilterBar, {
+  type WorkspaceFilters,
+} from './components/WorkspaceFilterBar';
+import WorkspaceRowActions from './components/WorkspaceRowActions';
 import {
   buildWorkspaceCreateInput,
   filterWorkspaceAssignmentCandidates,
@@ -67,13 +62,6 @@ import {
 
 const ROOT_PERMISSION = 'security:root';
 const DEFAULT_PAGE_SIZE = 10;
-
-interface WorkspaceFilters {
-  projectCode?: string;
-  projectName?: string;
-  ownerName?: string;
-  status?: SecurityProjectStatus;
-}
 
 interface AssignmentState {
   project: SecurityProjectSummary;
@@ -96,8 +84,6 @@ export default function SecurityProjectsPage() {
   const canManage = hasPermission(permissionCodes, ROOT_PERMISSION);
   const currentUserId = Number(initialState?.currentUser?.id ?? 0);
 
-  const [filterForm] = Form.useForm<WorkspaceFilters>();
-  const [editorForm] = Form.useForm<SecurityProjectInput>();
   const [filters, setFilters] = useState<WorkspaceFilters>({});
   const [rows, setRows] = useState<SecurityProjectSummary[]>([]);
   const [loading, setLoading] = useState(false);
@@ -173,7 +159,6 @@ export default function SecurityProjectsPage() {
     if (saving) return;
     setEditorOpen(false);
     setEditing(undefined);
-    editorForm.resetFields();
   };
 
   const openEditor = async (project?: SecurityProjectSummary) => {
@@ -181,12 +166,6 @@ export default function SecurityProjectsPage() {
 
     setEditing(project);
     setEditorOpen(true);
-    editorForm.resetFields();
-    editorForm.setFieldsValue({
-      projectName: project?.projectName ?? '',
-      description: project?.description ?? '',
-      deptId: project?.deptId ?? undefined,
-    });
     await loadDepartments();
   };
 
@@ -211,7 +190,8 @@ export default function SecurityProjectsPage() {
         message.success('工作空间已创建，你已成为负责人');
       }
 
-      closeEditor();
+      setEditorOpen(false);
+      setEditing(undefined);
       await refreshProjects();
       await loadProjects();
     } catch (error) {
@@ -466,45 +446,28 @@ export default function SecurityProjectsPage() {
         title: '创建时间',
         dataIndex: 'createTime',
         width: 168,
-        render: (value) => formatSystemDateTime(value as string | undefined),
+        render: (value) =>
+          formatSystemDateTime(value as string | undefined),
       },
       {
         title: '操作',
         key: 'action',
         fixed: 'right',
-        width: canManage ? 300 : 80,
+        width: canManage ? 190 : 88,
         render: (_, row) => (
-          <Space size={4} wrap>
-            <Button type="link" onClick={() => void showDetail(row)}>
-              详情
-            </Button>
-            {canManage ? (
-              <>
-                <Button type="link" onClick={() => void openEditor(row)}>
-                  编辑
-                </Button>
-                <Button
-                  type="link"
-                  onClick={() => void openAssignment(row, 'owner')}
-                >
-                  负责人
-                </Button>
-                <Button
-                  type="link"
-                  onClick={() => void openAssignment(row, 'member')}
-                >
-                  成员
-                </Button>
-                <Button
-                  danger
-                  type="link"
-                  onClick={() => void removeWorkspace(row)}
-                >
-                  删除
-                </Button>
-              </>
-            ) : null}
-          </Space>
+          <WorkspaceRowActions
+            project={row}
+            canManage={canManage}
+            onDetail={(project) => void showDetail(project)}
+            onEdit={(project) => void openEditor(project)}
+            onAssignOwner={(project) =>
+              void openAssignment(project, 'owner')
+            }
+            onAssignMembers={(project) =>
+              void openAssignment(project, 'member')
+            }
+            onDelete={(project) => void removeWorkspace(project)}
+          />
         ),
       },
     ],
@@ -515,214 +478,60 @@ export default function SecurityProjectsPage() {
     <SystemManagementPage
       title="工作空间"
       titleId="system-workspaces-title"
-      icon={<ApartmentOutlined className="text-slate-500" />}
-      className="min-h-full"
+      className="min-h-[calc(100vh-64px)] overflow-hidden"
     >
-      <Alert
-        showIcon
-        type="info"
-        className="mb-4"
-        message="工作空间是 Yak Ops 的业务数据隔离边界"
-        description="角色与功能权限决定用户能做什么；工作空间成员关系决定用户能进入哪里；数据源等业务数据通过 project_id 归属当前工作空间。Stage 1 暂不启用资源级授权。"
-      />
+      <div className="shrink-0">
+        <WorkspaceFilterBar
+          total={total}
+          loading={loading}
+          canManage={canManage}
+          onSearch={(nextFilters) => {
+            setPageNum(1);
+            setFilters(nextFilters);
+          }}
+          onRefresh={() => void loadProjects()}
+          onCreate={() => void openEditor()}
+        />
 
-      <div className="mb-4 rounded-xl border border-slate-200 bg-white p-4">
-        <div className="flex flex-wrap items-end justify-between gap-3">
-          <Form<WorkspaceFilters>
-            form={filterForm}
-            layout="inline"
-            onFinish={(values) => {
-              setPageNum(1);
-              setFilters(values);
-            }}
-          >
-            <Form.Item name="projectName" label="名称">
-              <Input allowClear placeholder="工作空间名称" />
-            </Form.Item>
-            <Form.Item name="projectCode" label="编码">
-              <Input allowClear placeholder="工作空间编码" />
-            </Form.Item>
-            <Form.Item name="ownerName" label="负责人">
-              <Input allowClear placeholder="用户名或姓名" />
-            </Form.Item>
-            <Form.Item name="status" label="状态">
-              <Select
-                allowClear
-                className="w-28"
-                placeholder="全部"
-                options={[
-                  { label: '启用', value: 'ENABLED' },
-                  { label: '停用', value: 'DISABLED' },
-                ]}
-              />
-            </Form.Item>
-            <Form.Item>
-              <Space>
-                <YakButton type="primary" htmlType="submit">
-                  查询
-                </YakButton>
-                <YakButton
-                  onClick={() => {
-                    filterForm.resetFields();
-                    setPageNum(1);
-                    setFilters({});
-                  }}
-                >
-                  重置
-                </YakButton>
-              </Space>
-            </Form.Item>
-          </Form>
-
-          <Space>
-            <YakButton
-              icon={<ReloadOutlined />}
-              loading={loading}
-              onClick={() => void loadProjects()}
-            >
-              刷新
-            </YakButton>
-            {canManage ? (
-              <YakButton
-                type="primary"
-                icon={<PlusOutlined />}
-                onClick={() => void openEditor()}
-              >
-                新增工作空间
-              </YakButton>
-            ) : null}
-          </Space>
-        </div>
+        <SecurityQueryTable<SecurityProjectSummary>
+          rowKey="id"
+          dataSource={rows}
+          columns={columns}
+          loading={loading}
+          pagination={false}
+          bordered
+          scroll={{ x: 'max-content' }}
+        />
       </div>
 
-      <SecurityQueryTable<SecurityProjectSummary>
-        dataSource={rows}
-        columns={columns}
-        loading={loading}
-        scroll={{ x: 1280 }}
-        pagination={{
-          current: pageNum,
-          pageSize,
-          total,
-          showSizeChanger: true,
-          showTotal: (value) => `共 ${value} 个工作空间`,
-          onChange: (nextPage, nextPageSize) => {
-            setPageNum(nextPageSize === pageSize ? nextPage : 1);
-            setPageSize(nextPageSize);
-          },
+      <div className="min-h-6 flex-1" />
+
+      <SecurityPagination
+        current={pageNum}
+        pageSize={pageSize}
+        total={total}
+        disabled={loading}
+        onChange={(nextPage, nextPageSize) => {
+          setPageNum(nextPageSize === pageSize ? nextPage : 1);
+          setPageSize(nextPageSize);
         }}
       />
 
-      <Drawer
+      <WorkspaceEditorDrawer
         open={editorOpen}
-        title={editing ? '编辑工作空间' : '新增工作空间'}
-        width={520}
-        forceRender
-        maskClosable={!saving}
-        keyboard={!saving}
-        closable={!saving}
+        editing={editing}
+        saving={saving}
+        departmentLoading={departmentLoading}
+        departmentTreeData={departmentTreeData}
         onClose={closeEditor}
-        extra={
-          <Space>
-            <YakButton disabled={saving} onClick={closeEditor}>
-              取消
-            </YakButton>
-            <YakButton
-              type="primary"
-              loading={saving}
-              onClick={() => editorForm.submit()}
-            >
-              {editing ? '更新' : '创建'}
-            </YakButton>
-          </Space>
-        }
-      >
-        <Alert
-          showIcon
-          type="info"
-          className="mb-5"
-          message={
-            editing
-              ? '修改名称或所属部门不会改变已有负责人和成员关系。'
-              : '创建后当前用户会自动成为负责人，工作空间会立即出现在 Header 切换列表中。'
-          }
-        />
-
-        {departmentTreeData.length === 0 && !departmentLoading ? (
-          <Alert
-            showIcon
-            type="warning"
-            className="mb-4"
-            message="暂无可用部门"
-            description="工作空间必须归属真实部门，请先在“系统管理 > 部门管理”创建部门。"
-          />
-        ) : null}
-
-        <Form<SecurityProjectInput>
-          form={editorForm}
-          layout="vertical"
-          preserve={false}
-          disabled={saving}
-          onFinish={(values) => void saveWorkspace(values)}
-        >
-          {editing ? (
-            <Form.Item label="工作空间编码">
-              <Input disabled value={editing.projectCode || '-'} />
-            </Form.Item>
-          ) : null}
-
-          <Form.Item
-            name="projectName"
-            label="工作空间名称"
-            rules={[
-              {
-                required: true,
-                whitespace: true,
-                message: '请输入工作空间名称',
-              },
-            ]}
-          >
-            <Input
-              maxLength={128}
-              showCount
-              placeholder="例如：成都一院"
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="deptId"
-            label="所属部门"
-            rules={[{ required: true, message: '请选择所属部门' }]}
-          >
-            <TreeSelect
-              treeData={departmentTreeData}
-              treeDefaultExpandAll
-              showSearch
-              allowClear={false}
-              loading={departmentLoading}
-              placeholder="请选择所属部门"
-              filterTreeNode={(input, node) =>
-                String(node.title ?? '')
-                  .toLocaleLowerCase()
-                  .includes(input.trim().toLocaleLowerCase())
-              }
-            />
-          </Form.Item>
-
-          <Form.Item name="description" label="工作空间描述">
-            <Input.TextArea
-              maxLength={500}
-              showCount
-              autoSize={{ minRows: 4, maxRows: 8 }}
-              placeholder="说明这个工作空间对应的医院、团队或业务范围"
-            />
-          </Form.Item>
-        </Form>
-      </Drawer>
+        onSave={(values) => void saveWorkspace(values)}
+      />
 
       <AssignmentDrawer
         open={Boolean(assigning)}
-        title={assigning?.mode === 'owner' ? '分配负责人' : '分配普通成员'}
+        title={
+          assigning?.mode === 'owner' ? '分配负责人' : '分配普通成员'
+        }
         mode={assigning?.mode === 'owner' ? 'single' : 'multiple'}
         options={candidates.map((user) => ({
           id: user.id,
@@ -779,7 +588,11 @@ export default function SecurityProjectsPage() {
                   key: 'status',
                   label: '状态',
                   children: (
-                    <Tag color={detail.status === 'ENABLED' ? 'success' : 'default'}>
+                    <Tag
+                      color={
+                        detail.status === 'ENABLED' ? 'success' : 'default'
+                      }
+                    >
                       {detail.status === 'ENABLED' ? '启用' : '停用'}
                     </Tag>
                   ),
@@ -800,7 +613,9 @@ export default function SecurityProjectsPage() {
                     <Tag key={owner.id}>{userDisplayName(owner)}</Tag>
                   ))
                 ) : (
-                  <Typography.Text type="secondary">暂未分配负责人</Typography.Text>
+                  <Typography.Text type="secondary">
+                    暂未分配负责人
+                  </Typography.Text>
                 )}
               </Space>
             </div>
@@ -813,7 +628,9 @@ export default function SecurityProjectsPage() {
                     <Tag key={member.id}>{userDisplayName(member)}</Tag>
                   ))
                 ) : (
-                  <Typography.Text type="secondary">暂无普通成员</Typography.Text>
+                  <Typography.Text type="secondary">
+                    暂无普通成员
+                  </Typography.Text>
                 )}
               </Space>
             </div>


### PR DESCRIPTION
## 背景

当前「工作空间」页面和「角色与权限」页面已经属于同一套系统管理视觉体系，但工作空间页仍保留了一套较重的旧布局：

- 页面顶部有一整块业务边界说明 Alert，占用较多首屏空间；
- 筛选区使用独立白色卡片 + 多个描边表单项，与角色页的轻量工具栏不一致；
- 操作列把详情、编辑、负责人、成员、删除全部平铺，信息密度偏高；
- 新增/编辑抽屉中的 Input / TreeSelect / TextArea 仍是默认描边形态。

本 PR 按现有「角色与权限」页面作为参照，统一工作空间管理页的布局和交互语言，不修改后端接口和权限模型。

## 修改

### 1. 页面布局对齐角色与权限

- 删除页面顶部「工作空间是 Yak Ops 的业务数据隔离边界」大块 Alert；
- 页面结构改为与角色页一致的：
  - 标题；
  - 顶部轻量筛选/操作栏；
  - bordered `SecurityQueryTable`；
  - 页面底部独立 `SecurityPagination`；
- 使用和角色页一致的 viewport 高度与 flex 布局，列表较少时分页仍稳定落在页面底部。

### 2. 筛选区改成轻量 Filled 风格

新增 `WorkspaceFilterBar`：

- 左侧展示 `全部工作空间 + 总数`；
- 右侧采用「搜索字段 + 关键词 + 状态 + 刷新 + 新增」布局；
- 搜索字段支持：
  - 工作空间名称；
  - 工作空间编码；
  - 负责人；
- Input / Select 全部使用 Ant Design `variant="filled"`；
- 刷新改为和角色页一致的 icon-only 按钮；
- 保留原有名称、编码、负责人、状态过滤能力，只是收口到更紧凑的交互中。

### 3. 操作列对齐角色页

新增 `WorkspaceRowActions`，操作结构改为：

```text
详情 | 编辑 | 更多 v
```

`更多` 下拉内收口：

```text
分配负责人
分配成员
────────
删除工作空间
```

删除继续使用 danger 样式，原有删除前资源检查逻辑不变。

非 root 用户仍只看到「详情」，不会因为视觉调整扩大管理权限。

### 4. 新增/编辑抽屉使用 Filled 表单

抽出 `WorkspaceEditorDrawer`：

- 工作空间编码 Input：`filled`；
- 工作空间名称 Input：`filled`；
- 所属部门 TreeSelect：`filled`；
- 工作空间描述 TextArea：`filled`；
- 保留原有创建人自动成为负责人、部门必选、编辑不改变成员关系等业务规则和提示。

## 行为保持不变

- Project CRUD API 无变化；
- Header 工作空间刷新逻辑无变化；
- root-only 创建/编辑/启停/负责人/成员/删除权限边界无变化；
- 当前工作空间标识无变化；
- 启用/停用确认逻辑无变化；
- 删除前资源检查无变化；
- 负责人/普通成员互斥与 AssignmentDrawer 行为无变化。

## 变更范围

仅前端工作空间页面：

```text
yak-ops-ui/src/pages/system/security-projects/
```

新增 3 个展示组件并收口原本 800+ 行的页面 JSX：

- `components/WorkspaceFilterBar.tsx`
- `components/WorkspaceRowActions.tsx`
- `components/WorkspaceEditorDrawer.tsx`

## 建议本地验证

```bash
cd yak-ops-ui
npm test -- --runInBand src/pages/system/security-projects/workspace.test.ts
npm run tsc
npm run biome:lint
```

浏览器最小回归：

1. `/system/projects` 顶部大块说明 Alert 已移除；
2. 页面整体布局与 `/system/roles` 基本一致；
3. 名称 / 编码 / 负责人搜索和状态过滤正常；
4. 筛选 Input / Select 均为 Filled 视觉；
5. 操作列只展示「详情 / 编辑 / 更多」，负责人、成员、删除位于下拉菜单；
6. 新增和编辑工作空间时 Input / TreeSelect / TextArea 均为 Filled；
7. 新增、编辑、启停、负责人分配、成员分配、删除流程正常；
8. 非 root 用户仍只具备已有的只读能力；
9. 1080p / 2K 下列表和底部分页布局与角色页一致。

## 当前验证状态

- branch 基于创建 PR 时的最新 `main`；
- connector compare：ahead 1 / behind 0；
- 当前连接环境未实际执行 npm / Jest / TypeScript / 浏览器回归，因此保持 Draft，不宣称测试已通过。
