### PR TITLE
fix(ui): align message center with security contract

### DIFF
--- a/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
@@ -1,5 +1,7 @@
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
 import {
   pageMessages,
+  safeMessageActionPath,
   type SecurityMessage,
 } from '@/services/security/messages';
 import { history } from '@umijs/max';
@@ -15,20 +17,22 @@ interface NotificationState {
   failed: boolean;
 }
 
-const formatMessageDate = (value?: string) => {
-  if (!value) return '--';
+const formatMessageDate = (value?: string | number) => {
+  if (value === undefined || value === null || value === '') return '--';
   const date = new Date(value);
-  if (!Number.isFinite(date.getTime())) return value;
+  if (!Number.isFinite(date.getTime())) return String(value);
   return `${String(date.getMonth() + 1).padStart(2, '0')}-${String(
     date.getDate(),
   ).padStart(2, '0')}`;
 };
 
 function NotificationRow({ item }: { item: SecurityMessage }) {
+  const actionPath = safeMessageActionPath(item.actionPath);
+
   return (
     <button
       type="button"
-      onClick={() => history.push('/system/messages')}
+      onClick={() => history.push(actionPath || '/system/messages')}
       className="group flex w-full items-start gap-2 border-0 bg-transparent py-3 text-left"
     >
       <span
@@ -60,6 +64,7 @@ function NotificationRow({ item }: { item: SecurityMessage }) {
 }
 
 export default function NotificationCenter() {
+  const { projects, currentProject } = useSecurityProject();
   const [state, setState] = useState<NotificationState>({
     items: [],
     total: 0,
@@ -70,7 +75,22 @@ export default function NotificationCenter() {
   useEffect(() => {
     let active = true;
 
-    pageMessages({ pageNum: 1, pageSize: 3 })
+    // SecurityProjectProvider resolves the persisted/default workspace in a layout
+    // effect. Avoid issuing an unscoped request while that selection is pending.
+    if (projects.length > 0 && !currentProject) {
+      setState({ items: [], total: 0, loading: true, failed: false });
+      return () => {
+        active = false;
+      };
+    }
+
+    setState({ items: [], total: 0, loading: true, failed: false });
+
+    pageMessages({
+      pageNum: 1,
+      pageSize: 3,
+      projectId: currentProject?.id,
+    })
       .then((result) => {
         if (!active) return;
         setState({
@@ -88,7 +108,7 @@ export default function NotificationCenter() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [currentProject?.id, projects.length]);
 
   return (
     <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-5">

--- a/yak-ops-ui/src/pages/system/messages/MessageList.tsx
+++ b/yak-ops-ui/src/pages/system/messages/MessageList.tsx
@@ -1,32 +1,79 @@
-import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { history, useModel } from '@umijs/max';
-import { Alert, Button, Drawer, message, Space, Tag, Typography } from 'antd';
-import dayjs from 'dayjs';
-import { useRef, useState } from 'react';
 import { SecurityQueryTable } from '@/components/security';
 import {
   batchReadMessages,
   getMessageDetail,
   type MessageDetail,
+  type MessageLevel,
   type MessageStatus,
   markMessageRead,
   pageMessages,
+  safeMessageActionPath,
   type SecurityMessage,
 } from '@/services/security/messages';
 import { satisfiesPermissionRequirement } from '@/utils/security/permission';
+import type { ActionType, ProColumns } from '@ant-design/pro-components';
+import { history, useModel } from '@umijs/max';
+import { Alert, Button, Drawer, message, Space, Tag, Typography } from 'antd';
+import dayjs from 'dayjs';
+import { useRef, useState } from 'react';
 
 export const MESSAGE_COUNT_CHANGED_EVENT = 'yak-message-count-changed';
-const notifyCountChanged = () => window.dispatchEvent(new Event(MESSAGE_COUNT_CHANGED_EVENT));
+
+const MESSAGE_TYPE_LABELS: Record<string, string> = {
+  SYSTEM: '系统',
+  SECURITY: '安全',
+  TASK: '任务',
+  QUALITY: '质量',
+};
+
+const MESSAGE_LEVEL_LABELS: Record<MessageLevel, string> = {
+  INFO: '信息',
+  SUCCESS: '成功',
+  WARNING: '警告',
+  ERROR: '错误',
+};
+
+const MESSAGE_LEVEL_COLORS: Record<MessageLevel, string> = {
+  INFO: 'blue',
+  SUCCESS: 'green',
+  WARNING: 'orange',
+  ERROR: 'red',
+};
+
+const notifyCountChanged = () =>
+  window.dispatchEvent(new Event(MESSAGE_COUNT_CHANGED_EVENT));
+
+const messageTypeLabel = (value?: string) =>
+  (value && MESSAGE_TYPE_LABELS[value]) || value || '消息';
+
+const formatMessageTime = (value?: string | number | null) => {
+  if (value === undefined || value === null || value === '') return '-';
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : String(value);
+};
+
+const toTimestamp = (value?: string) => {
+  if (!value) return undefined;
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.valueOf() : undefined;
+};
+
+const operationLogIdOf = (item?: SecurityMessage) =>
+  item?.operationLogId ?? item?.oplogId;
 
 export default function MessageList({ compact = false }: { compact?: boolean }) {
   const actionRef = useRef<ActionType>();
   const { initialState } = useModel('@@initialState');
-  const canReadLogs = satisfiesPermissionRequirement(initialState?.currentUser?.permissionCodes, {
-    mode: 'one',
-    permission: 'security:operation-log:read',
-  });
+  const canReadLogs = satisfiesPermissionRequirement(
+    initialState?.currentUser?.permissionCodes,
+    {
+      mode: 'one',
+      permission: 'security:operation-log:read',
+    },
+  );
   const [selected, setSelected] = useState<Array<number | string>>([]);
   const [detail, setDetail] = useState<MessageDetail>();
+
   const read = async (row: SecurityMessage) => {
     if (row.status === 'UNREAD') {
       await markMessageRead(row.id);
@@ -35,60 +82,95 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
     }
     setDetail(await getMessageDetail(row.id));
   };
+
   const columns: ProColumns<SecurityMessage>[] = [
     {
       title: '标题',
       dataIndex: 'title',
       search: false,
       render: (_, row) => (
-        <Button type="link" className={row.status === 'UNREAD' ? 'font-semibold' : ''} onClick={() => read(row)}>
+        <Button
+          type="link"
+          className={row.status === 'UNREAD' ? 'font-semibold' : ''}
+          onClick={() => read(row)}
+        >
           {row.title}
         </Button>
       ),
     },
     { title: '摘要', dataIndex: 'summary', search: false, ellipsis: true },
-    { title: '类型', dataIndex: 'type', valueType: 'select' },
+    {
+      title: '类型',
+      dataIndex: 'type',
+      valueType: 'select',
+      valueEnum: {
+        SYSTEM: { text: '系统' },
+        SECURITY: { text: '安全' },
+        TASK: { text: '任务' },
+        QUALITY: { text: '质量' },
+      },
+      render: (_, row) => messageTypeLabel(row.type),
+    },
     {
       title: '状态',
       dataIndex: 'status',
       valueType: 'select',
-      valueEnum: { UNREAD: { text: '未读', status: 'Processing' }, READ: { text: '已读', status: 'Default' } },
+      valueEnum: {
+        UNREAD: { text: '未读', status: 'Processing' },
+        READ: { text: '已读', status: 'Default' },
+      },
     },
     {
       title: '创建时间',
       dataIndex: 'createTime',
       valueType: 'dateTimeRange',
-      render: (_, row) => row.createTime ?? '-',
+      render: (_, row) => formatMessageTime(row.createTime),
     },
     {
       title: '关联日志',
       search: false,
-      render: (_, row) =>
-        row.operationLogId ? (
-          canReadLogs ? (
-            <Button
-              type="link"
-              onClick={() => history.push(`/system/oplogs?messageLogId=${encodeURIComponent(row.operationLogId!)}`)}
-            >
-              查看日志
-            </Button>
-          ) : (
-            <Typography.Text type="secondary">不可访问</Typography.Text>
-          )
-        ) : (
-          '-'
-        ),
+      render: (_, row) => {
+        const operationLogId = operationLogIdOf(row);
+        if (!operationLogId) return '-';
+        if (!canReadLogs) {
+          return <Typography.Text type="secondary">不可访问</Typography.Text>;
+        }
+        return (
+          <Button
+            type="link"
+            onClick={() =>
+              history.push(
+                `/system/oplogs?messageLogId=${encodeURIComponent(operationLogId)}`,
+              )
+            }
+          >
+            查看日志
+          </Button>
+        );
+      },
     },
   ];
+
+  const detailActionPath = safeMessageActionPath(detail?.actionPath);
+  const detailOperationLogId = operationLogIdOf(detail);
+
   return (
     <>
       <SecurityQueryTable<SecurityMessage>
         actionRef={actionRef}
         columns={
-          compact ? columns.filter((column) => column.dataIndex !== 'summary' && column.dataIndex !== 'type') : columns
+          compact
+            ? columns.filter(
+                (column) =>
+                  column.dataIndex !== 'summary' && column.dataIndex !== 'type',
+              )
+            : columns
         }
         search={compact ? false : undefined}
-        pagination={{ defaultPageSize: compact ? 5 : 10, showSizeChanger: !compact }}
+        pagination={{
+          defaultPageSize: compact ? 5 : 10,
+          showSizeChanger: !compact,
+        }}
         rowSelection={{
           selectedRowKeys: selected,
           onChange: (keys) => setSelected(keys as Array<number | string>),
@@ -101,10 +183,14 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
             pageSize: params.pageSize ?? (compact ? 5 : 10),
             status: params.status as MessageStatus,
             type: params.type as string,
-            startTime: range?.[0] ? dayjs(range[0]).format() : undefined,
-            endTime: range?.[1] ? dayjs(range[1]).format() : undefined,
+            startTime: toTimestamp(range?.[0]),
+            endTime: toTimestamp(range?.[1]),
           });
-          return { data: result.records, total: result.total, success: true };
+          return {
+            data: result.records,
+            total: result.total,
+            success: true,
+          };
         }}
         tableAlertRender={() => `已选择 ${selected.length} 条未读消息`}
         tableAlertOptionRender={() => (
@@ -122,6 +208,7 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
           </Button>
         )}
       />
+
       <Drawer
         title={detail?.title ?? '消息详情'}
         width={560}
@@ -131,18 +218,45 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
       >
         {detail && (
           <Space direction="vertical" size="middle" className="w-full">
-            <Space>
-              <Tag>{detail.type ?? '消息'}</Tag>
-              <Typography.Text type="secondary">{detail.createTime}</Typography.Text>
+            <Space wrap>
+              <Tag>{messageTypeLabel(detail.type)}</Tag>
+              {detail.level ? (
+                <Tag color={MESSAGE_LEVEL_COLORS[detail.level]}>
+                  {MESSAGE_LEVEL_LABELS[detail.level]}
+                </Tag>
+              ) : null}
+              {detail.scope ? (
+                <Tag>
+                  {detail.scope === 'PROJECT'
+                    ? `项目${detail.projectId ? ` #${detail.projectId}` : ''}`
+                    : '系统'}
+                </Tag>
+              ) : null}
+              <Typography.Text type="secondary">
+                {formatMessageTime(detail.createTime)}
+              </Typography.Text>
             </Space>
+
             <Typography.Paragraph className="whitespace-pre-wrap break-words">
               {detail.content ?? detail.summary ?? '-'}
             </Typography.Paragraph>
-            {detail.operationLogId &&
+
+            {detailActionPath ? (
+              <Button
+                type="primary"
+                onClick={() => history.push(detailActionPath)}
+              >
+                前往处理
+              </Button>
+            ) : null}
+
+            {detailOperationLogId &&
               (canReadLogs ? (
                 <Button
                   onClick={() =>
-                    history.push(`/system/oplogs?messageLogId=${encodeURIComponent(detail.operationLogId!)}`)
+                    history.push(
+                      `/system/oplogs?messageLogId=${encodeURIComponent(detailOperationLogId)}`,
+                    )
                   }
                 >
                   查看关联操作日志

--- a/yak-ops-ui/src/services/security/messages.test.ts
+++ b/yak-ops-ui/src/services/security/messages.test.ts
@@ -1,0 +1,43 @@
+import { buildMessageQuery, safeMessageActionPath } from './messages';
+
+describe('message center contract', () => {
+  it('serializes project scope and epoch time filters', () => {
+    const params = new URLSearchParams(
+      buildMessageQuery({
+        pageNum: 2,
+        pageSize: 20,
+        status: 'UNREAD',
+        type: 'TASK',
+        projectId: 7,
+        startTime: 1788163200000,
+        endTime: 1788249599999,
+      }),
+    );
+
+    expect(params.get('pageNum')).toBe('2');
+    expect(params.get('pageSize')).toBe('20');
+    expect(params.get('status')).toBe('UNREAD');
+    expect(params.get('type')).toBe('TASK');
+    expect(params.get('projectId')).toBe('7');
+    expect(params.get('startTime')).toBe('1788163200000');
+    expect(params.get('endTime')).toBe('1788249599999');
+  });
+
+  it('omits optional filters that are not supplied', () => {
+    const params = new URLSearchParams(
+      buildMessageQuery({ pageNum: 1, pageSize: 3 }),
+    );
+
+    expect(params.has('projectId')).toBe(false);
+    expect(params.has('status')).toBe(false);
+    expect(params.has('startTime')).toBe(false);
+  });
+
+  it('only accepts internal action paths', () => {
+    expect(safeMessageActionPath('/data-quality/overview')).toBe(
+      '/data-quality/overview',
+    );
+    expect(safeMessageActionPath('https://example.com')).toBeUndefined();
+    expect(safeMessageActionPath('//example.com/path')).toBeUndefined();
+  });
+});

--- a/yak-ops-ui/src/services/security/messages.ts
+++ b/yak-ops-ui/src/services/security/messages.ts
@@ -1,35 +1,81 @@
 import { securityGetData, securityPostData } from './client';
 
 const MESSAGE_API = '/api/v1/message';
+
 export type MessageStatus = 'UNREAD' | 'READ';
+export type MessageLevel = 'INFO' | 'SUCCESS' | 'WARNING' | 'ERROR';
+export type MessageScope = 'SYSTEM' | 'PROJECT';
+export type MessageTimestamp = string | number;
+
 export interface SecurityMessage {
   id: number | string;
   title: string;
   summary?: string;
   type?: string;
+  level?: MessageLevel;
+  scope?: MessageScope;
+  projectId?: number | string | null;
+  sourceType?: string;
+  sourceId?: string;
+  actionPath?: string;
   status: MessageStatus;
-  createTime?: string;
+  readTag?: boolean;
+  readTime?: number | null;
+  createTime?: MessageTimestamp;
+  oplogId?: number | string | null;
   operationLogId?: number | string | null;
 }
-export interface MessageDetail extends SecurityMessage { content?: string }
-export interface MessagePage { records: SecurityMessage[]; total: number }
-export interface MessageQuery {
-  pageNum: number; pageSize: number; status?: MessageStatus; type?: string;
-  startTime?: string; endTime?: string;
+
+export interface MessageDetail extends SecurityMessage {
+  content?: string;
 }
-const query = (values: object) => {
+
+export interface MessagePage {
+  records: SecurityMessage[];
+  total: number;
+}
+
+export interface MessageQuery {
+  pageNum: number;
+  pageSize: number;
+  status?: MessageStatus;
+  type?: string;
+  projectId?: number | string;
+  startTime?: number;
+  endTime?: number;
+}
+
+export const buildMessageQuery = (values: MessageQuery) => {
   const params = new URLSearchParams();
   Object.entries(values as Record<string, unknown>).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== '') params.set(key, String(value));
+    if (value !== undefined && value !== null && value !== '') {
+      params.set(key, String(value));
+    }
   });
   return params.toString();
 };
+
+/** Message actions are limited to internal application routes. */
+export const safeMessageActionPath = (value?: string) => {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) {
+    return undefined;
+  }
+  return value;
+};
+
 export const pageMessages = (params: MessageQuery) =>
-  securityGetData<MessagePage>(`${MESSAGE_API}/page?${query(params)}`);
-export const getUnreadMessageCount = () => securityGetData<number>(`${MESSAGE_API}/unread-count`);
+  securityGetData<MessagePage>(`${MESSAGE_API}/page?${buildMessageQuery(params)}`);
+
+export const getUnreadMessageCount = () =>
+  securityGetData<number>(`${MESSAGE_API}/unread-count`);
+
 export const markMessageRead = (id: number | string) =>
   securityPostData<void>(`${MESSAGE_API}/mark-read`, { id });
+
 export const batchReadMessages = (ids: Array<number | string>) =>
   securityPostData<void>(`${MESSAGE_API}/batch-read`, { ids });
+
 export const getMessageDetail = (id: number | string) =>
-  securityGetData<MessageDetail>(`${MESSAGE_API}/detail?id=${encodeURIComponent(id)}`);
+  securityGetData<MessageDetail>(
+    `${MESSAGE_API}/detail?id=${encodeURIComponent(id)}`,
+  );


### PR DESCRIPTION
## Summary

Align the Yak Ops message UI with the evolved `yak-security` Message Center contract introduced by `weifuwan/yak-framework#112`.

### Homepage notifications

- send the active workspace `projectId` to `/yak-security/api/v1/message/page`
- reload and clear stale notification rows when the workspace changes
- avoid an unscoped request while `SecurityProjectProvider` is still resolving the persisted/default workspace
- use backend `actionPath` for direct navigation when it is a safe internal route
- accept epoch-millisecond `createTime` values returned by the new backend contract

Homepage semantics are intentionally: **SYSTEM notifications + active PROJECT notifications**.

### Message center

- align frontend message types with the new fields: `level`, `scope`, `projectId`, `sourceType`, `sourceId`, `actionPath`, `readTime`, `oplogId`
- preserve `operationLogId` compatibility alias
- convert date-time range filters to epoch milliseconds before calling `/page`; the backend contract accepts `Long startTime/endTime`
- render epoch timestamps as readable date-time text
- show message type/level/scope in the detail drawer
- expose a `前往处理` action for safe internal `actionPath` values
- fall back across `operationLogId` and `oplogId` for operation-log navigation

The full system message center intentionally remains the user's complete inbox and does not inject the active project filter.

### Contract safety

- add `buildMessageQuery` to make query serialization explicit and testable
- add `safeMessageActionPath` so message payloads cannot navigate to external/protocol-relative URLs through `history.push`
- add service tests covering project scope, epoch time filters, omitted optional filters, and internal action-path validation

## Dependency

This PR depends on the backend contract in:

- https://github.com/weifuwan/yak-framework/pull/112

Until that framework change is merged/published into the `1.0.0-SNAPSHOT` consumed by Yak Ops, `/message/page` will still return 404 against the old backend.

## Validation

- compared `main...fix/security-message-center-client`: 4 frontend files only, branch is ahead-only
- reviewed the frontend request parameters against the controller DTO/VO in framework PR #112
- local `yarn`/TypeScript execution was not available because this execution environment cannot resolve `github.com` to clone the repository; CI/local developer validation should be treated as the runtime build gate
