### PR TITLE
refactor(ui): align dataset list and detail experience

### DIFF
--- a/yak-ops-ui/src/pages/dataset/components/DatasetFilterBar.tsx
+++ b/yak-ops-ui/src/pages/dataset/components/DatasetFilterBar.tsx
@@ -1,0 +1,139 @@
+import {
+  CloudUploadOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
+import { Input, Select, Tooltip } from 'antd';
+import { useState } from 'react';
+
+import { YakButton } from '@/components/ui';
+import type {
+  DatasetSourceType,
+  DatasetStatus,
+} from '@/services/dataset';
+
+export interface DatasetListFilters {
+  keyword: string;
+  status: 'ALL' | DatasetStatus;
+  sourceType: 'ALL' | DatasetSourceType;
+}
+
+const SOURCE_TYPE_OPTIONS: Array<{
+  label: string;
+  value: 'ALL' | DatasetSourceType;
+}> = [
+  { value: 'ALL', label: '全部来源' },
+  { value: 'QUERY_REVISION', label: 'SQL 任务' },
+  { value: 'SQL_QUERY', label: 'Standalone SQL' },
+  { value: 'TABLE', label: '数据表' },
+  { value: 'VIEW', label: '视图' },
+];
+
+interface DatasetFilterBarProps {
+  total: number;
+  loading?: boolean;
+  onSearch: (filters: DatasetListFilters) => void;
+  onRefresh: () => void;
+  onOpenReleaseCenter: () => void;
+}
+
+export default function DatasetFilterBar({
+  total,
+  loading = false,
+  onSearch,
+  onRefresh,
+  onOpenReleaseCenter,
+}: DatasetFilterBarProps) {
+  const [keyword, setKeyword] = useState('');
+  const [status, setStatus] = useState<'ALL' | DatasetStatus>('ALL');
+  const [sourceType, setSourceType] =
+    useState<'ALL' | DatasetSourceType>('ALL');
+
+  const submit = (
+    nextKeyword = keyword,
+    nextStatus = status,
+    nextSourceType = sourceType,
+  ) => {
+    onSearch({
+      keyword: nextKeyword.trim(),
+      status: nextStatus,
+      sourceType: nextSourceType,
+    });
+  };
+
+  return (
+    <div className="mb-4 flex min-w-0 flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div className="inline-flex h-8 w-fit items-center rounded-[8px] bg-[#f2f3f5] px-3.5 text-[13px] font-semibold text-[#242731]">
+        全部数据集
+        <span className="ml-1.5 text-xs font-medium text-[#98a2b3]">
+          {total}
+        </span>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <Input
+          allowClear
+          value={keyword}
+          variant="filled"
+          placeholder="搜索 Dataset、字段、来源"
+          suffix={
+            <SearchOutlined
+              className="cursor-pointer text-slate-400 transition-colors hover:text-slate-700"
+              onClick={() => submit()}
+            />
+          }
+          className="w-[260px]"
+          onChange={(event) => {
+            const value = event.target.value;
+            setKeyword(value);
+            if (!value) submit('', status, sourceType);
+          }}
+          onPressEnter={() => submit()}
+        />
+
+        <Select<'ALL' | DatasetStatus>
+          value={status}
+          variant="filled"
+          className="w-[116px]"
+          options={[
+            { value: 'ALL', label: '全部状态' },
+            { value: 'ONLINE', label: '已上线' },
+            { value: 'OFFLINE', label: '已下线' },
+          ]}
+          onChange={(nextStatus) => {
+            setStatus(nextStatus);
+            submit(keyword, nextStatus, sourceType);
+          }}
+        />
+
+        <Select<'ALL' | DatasetSourceType>
+          value={sourceType}
+          variant="filled"
+          className="w-[156px]"
+          options={SOURCE_TYPE_OPTIONS}
+          onChange={(nextSourceType) => {
+            setSourceType(nextSourceType);
+            submit(keyword, status, nextSourceType);
+          }}
+        />
+
+        <Tooltip title="刷新列表">
+          <YakButton
+            iconOnly
+            icon={<ReloadOutlined />}
+            loading={loading}
+            onClick={onRefresh}
+          />
+        </Tooltip>
+
+        <YakButton
+          type="primary"
+          icon={<CloudUploadOutlined />}
+          onClick={onOpenReleaseCenter}
+        >
+          发布中心
+        </YakButton>
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dataset/components/DatasetRowActions.tsx
+++ b/yak-ops-ui/src/pages/dataset/components/DatasetRowActions.tsx
@@ -1,0 +1,61 @@
+import {
+  CloudUploadOutlined,
+  EyeOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
+import { Popconfirm, Space } from 'antd';
+
+import { YakButton } from '@/components/ui';
+import type { DatasetManagementItem } from '@/services/dataset';
+
+interface DatasetRowActionsProps {
+  dataset: DatasetManagementItem;
+  loading?: boolean;
+  onDetail: (dataset: DatasetManagementItem) => void;
+  onToggleStatus: (dataset: DatasetManagementItem) => void;
+}
+
+export default function DatasetRowActions({
+  dataset,
+  loading = false,
+  onDetail,
+  onToggleStatus,
+}: DatasetRowActionsProps) {
+  const online = dataset.status === 'ONLINE';
+
+  return (
+    <Space size={2} onClick={(event) => event.stopPropagation()}>
+      <YakButton
+        type="text"
+        size="small"
+        icon={<EyeOutlined />}
+        className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+        onClick={() => onDetail(dataset)}
+      >
+        详情
+      </YakButton>
+
+      <Popconfirm
+        title={online ? '确认下线这个 Dataset？' : '确认上线这个 Dataset？'}
+        description={
+          online
+            ? '下线后 Analysis、仪表盘和大屏将无法继续查询。'
+            : '上线后可重新用于下游消费。'
+        }
+        okText="确认"
+        cancelText="取消"
+        onConfirm={() => onToggleStatus(dataset)}
+      >
+        <YakButton
+          type="text"
+          size="small"
+          loading={loading}
+          icon={online ? <StopOutlined /> : <CloudUploadOutlined />}
+          className="!px-1.5 !text-slate-600 hover:!text-slate-900"
+        >
+          {online ? '下线' : '上线'}
+        </YakButton>
+      </Popconfirm>
+    </Space>
+  );
+}

--- a/yak-ops-ui/src/pages/dataset/detail/DatasetQueryDiagnostics.tsx
+++ b/yak-ops-ui/src/pages/dataset/detail/DatasetQueryDiagnostics.tsx
@@ -1,3 +1,4 @@
+import { ReloadOutlined } from '@ant-design/icons';
 import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { YakButton } from '@/components/ui';
 import {
@@ -5,10 +6,18 @@ import {
   type DatasetQueryPerformance,
   type DatasetQueryStatus,
 } from '@/services/dataset';
-import { Alert, InputNumber, Select, Table, Tag, Tooltip } from 'antd';
+import {
+  Alert,
+  InputNumber,
+  Select,
+  Table,
+  Tag,
+  Tooltip,
+} from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { DETAIL_TABLE_CLASS } from './components/DatasetDetailPrimitives';
 
 interface DatasetQueryDiagnosticsProps {
   datasetId: string;
@@ -29,9 +38,12 @@ const formatDateTime = (value?: string) => {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 };
 
-const shortHash = (value?: string | null) => value ? value.slice(0, 12) : '-';
+const shortHash = (value?: string | null) =>
+  value ? value.slice(0, 12) : '-';
 
-export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagnosticsProps) {
+export default function DatasetQueryDiagnostics({
+  datasetId,
+}: DatasetQueryDiagnosticsProps) {
   const [status, setStatus] = useState<StatusFilter>('ALL');
   const [minTotalMillis, setMinTotalMillis] = useState(0);
   const [limit, setLimit] = useState(100);
@@ -43,15 +55,21 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
     setLoading(true);
     setError('');
     try {
-      setRecords(await listDatasetQueryPerformance({
-        datasetIds: [datasetId],
-        statuses: status === 'ALL' ? undefined : [status],
-        minTotalMillis: minTotalMillis > 0 ? minTotalMillis : undefined,
-        limit,
-      }));
+      setRecords(
+        await listDatasetQueryPerformance({
+          datasetIds: [datasetId],
+          statuses: status === 'ALL' ? undefined : [status],
+          minTotalMillis: minTotalMillis > 0 ? minTotalMillis : undefined,
+          limit,
+        }),
+      );
     } catch (loadError) {
       setRecords([]);
-      setError(loadError instanceof Error ? loadError.message : '加载 Dataset 运行诊断失败');
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : '加载 Dataset 运行诊断失败',
+      );
     } finally {
       setLoading(false);
     }
@@ -62,9 +80,15 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
   }, [load]);
 
   const summary = useMemo(() => {
-    const failures = records.filter((record) => record.status === 'FAILED').length;
-    const timeouts = records.filter((record) => record.status === 'TIMEOUT').length;
-    const rejected = records.filter((record) => record.status === 'REJECTED').length;
+    const failures = records.filter(
+      (record) => record.status === 'FAILED',
+    ).length;
+    const timeouts = records.filter(
+      (record) => record.status === 'TIMEOUT',
+    ).length;
+    const rejected = records.filter(
+      (record) => record.status === 'REJECTED',
+    ).length;
     const slow = records.filter((record) => record.totalMillis >= 3_000).length;
     return { failures, timeouts, rejected, slow };
   }, [records]);
@@ -75,7 +99,9 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
       dataIndex: 'startedAt',
       width: 175,
       render: (value?: string) => (
-        <span className="text-[12px] text-[#667085]">{formatDateTime(value)}</span>
+        <span className="text-[12px] text-[#667085]">
+          {formatDateTime(value)}
+        </span>
       ),
     },
     {
@@ -95,7 +121,9 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
       ellipsis: true,
       render: (value: string) => (
         <Tooltip title={value}>
-          <span className="font-mono text-[12px] text-[#344054]">{value}</span>
+          <span className="font-mono text-[12px] text-[#344054]">
+            {value}
+          </span>
         </Tooltip>
       ),
     },
@@ -103,7 +131,7 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
       title: '版本',
       dataIndex: 'datasetVersionNo',
       width: 84,
-      render: (value?: number | null) => value ? `DV${value}` : '-',
+      render: (value?: number | null) => (value ? `DV${value}` : '-'),
     },
     {
       title: '总耗时',
@@ -111,7 +139,13 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
       width: 100,
       sorter: (left, right) => left.totalMillis - right.totalMillis,
       render: (value: number) => (
-        <span className={value >= 3_000 ? 'font-medium text-[#d92d20]' : 'text-[#344054]'}>
+        <span
+          className={
+            value >= 3_000
+              ? 'font-medium text-[#d92d20]'
+              : 'text-[#344054]'
+          }
+        >
           {value} ms
         </span>
       ),
@@ -124,7 +158,8 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
           title={`prepare ${record.prepareMillis} / wait ${record.waitMillis} / execute ${record.executeMillis} / transfer ${record.transferMillis} ms`}
         >
           <span className="text-[12px] text-[#667085]">
-            P {record.prepareMillis} · W {record.waitMillis} · E {record.executeMillis} · T {record.transferMillis}
+            P {record.prepareMillis} · W {record.waitMillis} · E{' '}
+            {record.executeMillis} · T {record.transferMillis}
           </span>
         </Tooltip>
       ),
@@ -132,27 +167,36 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
     {
       title: '结果',
       width: 105,
-      render: (_, record) => record.status === 'SUCCESS'
-        ? `${record.returnedRows} 行${record.truncated ? ' · 截断' : ''}`
-        : '-',
+      render: (_, record) =>
+        record.status === 'SUCCESS'
+          ? `${record.returnedRows} 行${record.truncated ? ' · 截断' : ''}`
+          : '-',
     },
     {
       title: '失败阶段 / 原因',
       width: 270,
-      render: (_, record) => record.status === 'SUCCESS' ? (
-        <span className="text-[#98a2b3]">-</span>
-      ) : (
-        <Tooltip title={record.errorMessage || record.errorType || record.failureStage || '-'}>
-          <div className="max-w-[250px]">
-            <div className="truncate text-[12px] font-medium text-[#344054]">
-              {record.failureStage || 'UNKNOWN'}
+      render: (_, record) =>
+        record.status === 'SUCCESS' ? (
+          <span className="text-[#98a2b3]">-</span>
+        ) : (
+          <Tooltip
+            title={
+              record.errorMessage ||
+              record.errorType ||
+              record.failureStage ||
+              '-'
+            }
+          >
+            <div className="max-w-[250px]">
+              <div className="truncate text-[12px] font-medium text-[#344054]">
+                {record.failureStage || 'UNKNOWN'}
+              </div>
+              <div className="mt-0.5 truncate text-[12px] text-[#667085]">
+                {record.errorMessage || record.errorType || '-'}
+              </div>
             </div>
-            <div className="mt-0.5 truncate text-[12px] text-[#667085]">
-              {record.errorMessage || record.errorType || '-'}
-            </div>
-          </div>
-        </Tooltip>
-      ),
+          </Tooltip>
+        ),
     },
     {
       title: 'SQL 指纹',
@@ -160,7 +204,9 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
       width: 120,
       render: (value?: string | null) => (
         <Tooltip title={value || '暂无 SQL 指纹'}>
-          <span className="font-mono text-[12px] text-[#667085]">{shortHash(value)}</span>
+          <span className="font-mono text-[12px] text-[#667085]">
+            {shortHash(value)}
+          </span>
         </Tooltip>
       ),
     },
@@ -169,11 +215,22 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
       dataIndex: 'sql',
       width: 280,
       ellipsis: true,
-      render: (value?: string | null) => value ? (
-        <Tooltip title={<pre className="m-0 max-w-[680px] whitespace-pre-wrap text-[12px]">{value}</pre>}>
-          <span className="font-mono text-[12px] text-[#667085]">{value}</span>
-        </Tooltip>
-      ) : '-',
+      render: (value?: string | null) =>
+        value ? (
+          <Tooltip
+            title={
+              <pre className="m-0 max-w-[680px] whitespace-pre-wrap text-[12px]">
+                {value}
+              </pre>
+            }
+          >
+            <span className="font-mono text-[12px] text-[#667085]">
+              {value}
+            </span>
+          </Tooltip>
+        ) : (
+          '-'
+        ),
     },
   ];
 
@@ -185,11 +242,12 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
         message="诊断记录跨实例持久化；SQL 预览由后端移除字面量和注释后再保存，仅用于查询结构定位。"
       />
 
-      <div className="flex flex-wrap items-end gap-3 border border-[#e4e7ec] bg-[#fafbfc] p-4">
+      <div className="flex flex-wrap items-end gap-3 rounded-md bg-[#f7f7f8] p-4">
         <div>
           <div className="mb-1.5 text-[12px] text-[#667085]">终态</div>
           <Select<StatusFilter>
             value={status}
+            variant="filled"
             className="w-[140px]"
             options={[
               { value: 'ALL', label: '全部状态' },
@@ -201,10 +259,14 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
             onChange={setStatus}
           />
         </div>
+
         <div>
-          <div className="mb-1.5 text-[12px] text-[#667085]">最小总耗时</div>
+          <div className="mb-1.5 text-[12px] text-[#667085]">
+            最小总耗时
+          </div>
           <Select
             value={minTotalMillis}
+            variant="filled"
             className="w-[150px]"
             options={[
               { value: 0, label: '不限' },
@@ -217,19 +279,30 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
             onChange={setMinTotalMillis}
           />
         </div>
+
         <div>
-          <div className="mb-1.5 text-[12px] text-[#667085]">最近记录数</div>
+          <div className="mb-1.5 text-[12px] text-[#667085]">
+            最近记录数
+          </div>
           <InputNumber
             min={1}
             max={200}
             value={limit}
+            variant="filled"
             className="w-[120px]"
             onChange={(value) => setLimit(value || 100)}
           />
         </div>
-        <YakButton icon={<RefreshCw size={13} />} loading={loading} onClick={() => void load()}>
-          刷新诊断
-        </YakButton>
+
+        <Tooltip title="刷新诊断">
+          <YakButton
+            iconOnly
+            icon={<ReloadOutlined />}
+            loading={loading}
+            onClick={() => void load()}
+          />
+        </Tooltip>
+
         <div className="ml-auto flex flex-wrap gap-4 text-[12px] text-[#667085]">
           <span>失败 {summary.failures}</span>
           <span>超时 {summary.timeouts}</span>
@@ -238,17 +311,24 @@ export default function DatasetQueryDiagnostics({ datasetId }: DatasetQueryDiagn
         </div>
       </div>
 
-      {error && <Alert type="error" showIcon message="运行诊断加载失败" description={error} />}
+      {error ? (
+        <Alert
+          type="error"
+          showIcon
+          message="运行诊断加载失败"
+          description={error}
+        />
+      ) : null}
 
       <Table<DatasetQueryPerformance>
         rowKey="queryId"
-        bordered
         size="small"
         loading={loading}
         pagination={false}
         columns={columns}
         dataSource={records}
         scroll={{ x: 1680, y: 520 }}
+        className={DETAIL_TABLE_CLASS}
         locale={{
           emptyText: (
             <div className="flex min-h-[260px] items-center justify-center">

--- a/yak-ops-ui/src/pages/dataset/detail/components/DatasetDetailPrimitives.tsx
+++ b/yak-ops-ui/src/pages/dataset/detail/components/DatasetDetailPrimitives.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+
+export const DETAIL_TABLE_CLASS = [
+  '[&_.ant-table-container]:!overflow-hidden',
+  '[&_.ant-table-container]:!rounded-md',
+  '[&_.ant-table-container]:!border',
+  '[&_.ant-table-container]:!border-solid',
+  '[&_.ant-table-container]:!border-[#eceef1]',
+  '[&_.ant-table-thead>tr>th]:!h-10',
+  '[&_.ant-table-thead>tr>th]:!bg-[#f7f7f8]',
+  '[&_.ant-table-thead>tr>th]:!px-4',
+  '[&_.ant-table-thead>tr>th]:!py-0',
+  '[&_.ant-table-thead>tr>th]:!text-[12px]',
+  '[&_.ant-table-thead>tr>th]:!font-medium',
+  '[&_.ant-table-tbody>tr>td]:!px-4',
+  '[&_.ant-table-tbody>tr>td]:!py-3',
+  '[&_.ant-table-tbody>tr>td]:!text-[12px]',
+].join(' ');
+
+export function MetricTile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: ReactNode;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-md bg-[#f7f7f8] px-4 py-4">
+      <div className="text-[12px] leading-4 text-[#7c828c]">{label}</div>
+      <div className="mt-2 text-[20px] font-semibold leading-7 tracking-[-0.02em] text-[#161823]">
+        {value}
+      </div>
+      {hint ? (
+        <div className="mt-1 text-[11px] text-[#9aa0aa]">{hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+export function SectionCard({
+  title,
+  extra,
+  children,
+  className = '',
+}: {
+  title: ReactNode;
+  extra?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={`min-w-0 rounded-lg bg-white ${className}`}>
+      <div className="flex min-h-[52px] items-center justify-between gap-4 px-5">
+        <div className="text-[15px] font-semibold text-[#161823]">
+          {title}
+        </div>
+        {extra}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function DetailItem({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[12px] leading-4 text-[#8a8f98]">{label}</div>
+      <div className="mt-2 break-words text-[13px] leading-5 text-[#30343b]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/dataset/detail/index.tsx
+++ b/yak-ops-ui/src/pages/dataset/detail/index.tsx
@@ -1,3 +1,12 @@
+import {
+  ArrowLeftOutlined,
+  BarChartOutlined,
+  CloudUploadOutlined,
+  DatabaseOutlined,
+  LinkOutlined,
+  PlayCircleOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
 import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { YakButton, YakTab } from '@/components/ui';
 import {
@@ -17,8 +26,8 @@ import { BRAND_THEME } from '@/styles/brand';
 import { history, useParams } from '@umijs/max';
 import {
   Alert,
+  Button,
   ConfigProvider,
-  Descriptions,
   InputNumber,
   Popconfirm,
   Select,
@@ -29,19 +38,15 @@ import {
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import {
-  ArrowLeft,
-  BarChart3,
-  Database,
-  GitBranch,
-  Play,
-  RefreshCw,
-  Rows3,
-  Sigma,
-  Workflow,
-} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+
 import DatasetQueryDiagnostics from './DatasetQueryDiagnostics';
+import {
+  DETAIL_TABLE_CLASS,
+  DetailItem,
+  MetricTile,
+  SectionCard,
+} from './components/DatasetDetailPrimitives';
 
 const SOURCE_TYPE_LABELS: Record<DatasetSourceType, string> = {
   QUERY_REVISION: 'SQL 任务版本',
@@ -73,16 +78,31 @@ const sourceSummary = (version?: DatasetManagementVersion) => {
       : 'SQL TaskAsset';
   }
   if (version.sourceType === 'SQL_QUERY') {
-    return version.dataSourceId ? `Standalone SQL · 数据源 ${version.dataSourceId}` : 'Standalone SQL';
+    return version.dataSourceId
+      ? `Standalone SQL · 数据源 ${version.dataSourceId}`
+      : 'Standalone SQL';
   }
   return SOURCE_TYPE_LABELS[version.sourceType];
 };
 
-type DetailTab = 'overview' | 'schema' | 'versions' | 'query' | 'diagnostics' | 'source';
+type DetailTab =
+  | 'overview'
+  | 'schema'
+  | 'versions'
+  | 'query'
+  | 'diagnostics'
+  | 'source';
 
-function DatasetQueryPlayground({ dataset }: { dataset: DatasetManagementDetail }) {
+function DatasetQueryPlayground({
+  dataset,
+}: {
+  dataset: DatasetManagementDetail;
+}) {
   const sortedVersions = useMemo(
-    () => [...dataset.versions].sort((left, right) => right.versionNo - left.versionNo),
+    () =>
+      [...dataset.versions].sort(
+        (left, right) => right.versionNo - left.versionNo,
+      ),
     [dataset.versions],
   );
   const [versionNo, setVersionNo] = useState<number | undefined>(
@@ -99,139 +119,170 @@ function DatasetQueryPlayground({ dataset }: { dataset: DatasetManagementDetail 
     setError('');
   }, [dataset.currentVersion?.versionNo, dataset.id]);
 
-  const selectedVersion = sortedVersions.find((version) => version.versionNo === versionNo);
+  const selectedVersion = sortedVersions.find(
+    (version) => version.versionNo === versionNo,
+  );
   const queryable = Boolean(
     selectedVersion && isQueryableDatasetSourceType(selectedVersion.sourceType),
   );
-  const disabledReason = dataset.status !== 'ONLINE'
-    ? 'Dataset 当前已下线，Query Runtime 不接受查询。'
-    : !selectedVersion
-      ? '请选择一个 Dataset 版本。'
-      : !queryable
-        ? `${SOURCE_TYPE_LABELS[selectedVersion.sourceType]}尚未接入 Dataset Query Runtime。`
-        : '';
+  const disabledReason =
+    dataset.status !== 'ONLINE'
+      ? 'Dataset 当前已下线，Query Runtime 不接受查询。'
+      : !selectedVersion
+        ? '请选择一个 Dataset 版本。'
+        : !queryable
+          ? `${SOURCE_TYPE_LABELS[selectedVersion.sourceType]}尚未接入 Dataset Query Runtime。`
+          : '';
 
   const runQuery = async () => {
     if (!versionNo || disabledReason) return;
     setRunning(true);
     setError('');
     try {
-      setResult(await queryDataset(dataset.id, {
-        versionNo,
-        dimensions: [],
-        metrics: [],
-        filters: [],
-        sorts: [],
-        limit,
-        timeoutSeconds: 30,
-      }));
+      setResult(
+        await queryDataset(dataset.id, {
+          versionNo,
+          dimensions: [],
+          metrics: [],
+          filters: [],
+          sorts: [],
+          limit,
+          timeoutSeconds: 30,
+        }),
+      );
     } catch (queryError) {
       setResult(undefined);
-      setError(queryError instanceof Error ? queryError.message : 'Dataset 查询失败');
+      setError(
+        queryError instanceof Error ? queryError.message : 'Dataset 查询失败',
+      );
     } finally {
       setRunning(false);
     }
   };
 
-  const previewColumns = useMemo<ColumnsType<Record<string, unknown>>>(() => (
-    result?.columns || []
-  ).map((column, index) => ({
-    title: result?.bindings[index]?.displayName || column.label || column.name,
-    dataIndex: `c${index}`,
-    key: `c${index}`,
-    width: 180,
-    ellipsis: true,
-    render: (value: unknown) => value == null ? '-' : String(value),
-  })), [result]);
+  const previewColumns = useMemo<ColumnsType<Record<string, unknown>>>(
+    () =>
+      (result?.columns || []).map((column, index) => ({
+        title:
+          result?.bindings[index]?.displayName || column.label || column.name,
+        dataIndex: `c${index}`,
+        key: `c${index}`,
+        width: 180,
+        ellipsis: true,
+        render: (value: unknown) => (value == null ? '-' : String(value)),
+      })),
+    [result],
+  );
 
-  const previewRows = useMemo(() => (result?.rows || []).map((row, rowIndex) => {
-    const record: Record<string, unknown> = { key: rowIndex };
-    row.forEach((value, columnIndex) => {
-      record[`c${columnIndex}`] = value;
-    });
-    return record;
-  }), [result]);
+  const previewRows = useMemo(
+    () =>
+      (result?.rows || []).map((row, rowIndex) => {
+        const record: Record<string, unknown> = { key: rowIndex };
+        row.forEach((value, columnIndex) => {
+          record[`c${columnIndex}`] = value;
+        });
+        return record;
+      }),
+    [result],
+  );
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-end gap-3 border border-[#e4e7ec] bg-[#fafbfc] p-4">
-        <div>
-          <div className="mb-1.5 text-[12px] text-[#667085]">Dataset 版本</div>
-          <Select
-            value={versionNo}
-            className="w-[220px]"
-            placeholder="请选择版本"
-            options={sortedVersions.map((version) => ({
-              value: version.versionNo,
-              label: `DV${version.versionNo} · ${SOURCE_TYPE_LABELS[version.sourceType]}`,
-            }))}
-            onChange={setVersionNo}
-          />
-        </div>
-        <div>
-          <div className="mb-1.5 text-[12px] text-[#667085]">最大返回行数</div>
-          <InputNumber
-            min={1}
-            max={1000}
-            value={limit}
-            className="w-[150px]"
-            onChange={(value) => setLimit(value || 50)}
-          />
-        </div>
-        <Tooltip title={disabledReason}>
-          <span>
-            <YakButton
-              type="primary"
-              icon={<Play size={13} />}
-              loading={running}
-              disabled={Boolean(disabledReason)}
-              onClick={() => void runQuery()}
-            >
-              执行查询
-            </YakButton>
-          </span>
-        </Tooltip>
-        <div className="ml-auto text-[12px] text-[#8a8f99]">
+    <SectionCard
+      title="Query Playground"
+      extra={
+        <span className="text-[12px] font-normal text-[#9aa0aa]">
           原始数据预览，不修改 Dataset 版本语义
-        </div>
-      </div>
-
-      {disabledReason && (
-        <Alert type="info" showIcon message={disabledReason} />
-      )}
-      {error && <Alert type="error" showIcon message="查询失败" description={error} />}
-
-      {result ? (
-        <div className="border border-[#e4e7ec]">
-          <div className="flex flex-wrap items-center gap-4 border-b border-[#e4e7ec] bg-[#fafbfc] px-4 py-2 text-[12px] text-[#667085]">
-            <span>版本：DV{result.datasetVersionNo}</span>
-            <span>返回：{result.returnedRows} 行</span>
-            <span>耗时：{result.elapsedMillis} ms</span>
-            {result.queryId && <span>Query ID：{result.queryId}</span>}
-            {result.truncated && <Tag color="warning">结果已截断</Tag>}
+        </span>
+      }
+    >
+      <div className="space-y-4 p-5 pt-1">
+        <div className="flex flex-wrap items-end gap-3 rounded-md bg-[#f7f7f8] p-4">
+          <div>
+            <div className="mb-1.5 text-[12px] text-[#667085]">
+              Dataset 版本
+            </div>
+            <Select
+              value={versionNo}
+              variant="filled"
+              className="w-[220px]"
+              placeholder="请选择版本"
+              options={sortedVersions.map((version) => ({
+                value: version.versionNo,
+                label: `DV${version.versionNo} · ${SOURCE_TYPE_LABELS[version.sourceType]}`,
+              }))}
+              onChange={setVersionNo}
+            />
           </div>
-          <Table<Record<string, unknown>>
-            rowKey="key"
-            size="small"
-            pagination={false}
-            columns={previewColumns}
-            dataSource={previewRows}
-            scroll={{ x: 'max-content', y: 420 }}
-            locale={{ emptyText: '查询成功，但没有返回数据' }}
-          />
+
+          <div>
+            <div className="mb-1.5 text-[12px] text-[#667085]">
+              最大返回行数
+            </div>
+            <InputNumber
+              min={1}
+              max={1000}
+              value={limit}
+              variant="filled"
+              className="w-[150px]"
+              onChange={(value) => setLimit(value || 50)}
+            />
+          </div>
+
+          <Tooltip title={disabledReason}>
+            <span>
+              <YakButton
+                type="primary"
+                icon={<PlayCircleOutlined />}
+                loading={running}
+                disabled={Boolean(disabledReason)}
+                onClick={() => void runQuery()}
+              >
+                执行查询
+              </YakButton>
+            </span>
+          </Tooltip>
         </div>
-      ) : !error ? (
-        <div className="flex min-h-[300px] items-center justify-center border border-[#e4e7ec]">
-          <YakOpsEmpty
-            width={170}
-            height={112}
-            title="等待执行查询"
-            description="选择不可变 Dataset 版本后，可直接预览该版本数据。"
-            showCaption
-          />
-        </div>
-      ) : null}
-    </div>
+
+        {disabledReason ? (
+          <Alert type="info" showIcon message={disabledReason} />
+        ) : null}
+        {error ? (
+          <Alert type="error" showIcon message="查询失败" description={error} />
+        ) : null}
+
+        {result ? (
+          <div className="overflow-hidden rounded-md border border-solid border-[#eceef1]">
+            <div className="flex flex-wrap items-center gap-4 bg-[#f7f7f8] px-4 py-2 text-[12px] text-[#667085]">
+              <span>版本：DV{result.datasetVersionNo}</span>
+              <span>返回：{result.returnedRows} 行</span>
+              <span>耗时：{result.elapsedMillis} ms</span>
+              {result.queryId ? <span>Query ID：{result.queryId}</span> : null}
+              {result.truncated ? <Tag color="warning">结果已截断</Tag> : null}
+            </div>
+            <Table<Record<string, unknown>>
+              rowKey="key"
+              size="small"
+              pagination={false}
+              columns={previewColumns}
+              dataSource={previewRows}
+              scroll={{ x: 'max-content', y: 420 }}
+              locale={{ emptyText: '查询成功，但没有返回数据' }}
+              className={DETAIL_TABLE_CLASS}
+            />
+          </div>
+        ) : !error ? (
+          <div className="flex min-h-[300px] items-center justify-center rounded-md bg-[#f7f7f8]">
+            <YakOpsEmpty
+              width={170}
+              height={112}
+              title="等待执行查询"
+              description="选择不可变 Dataset 版本后，可直接预览该版本数据。"
+              showCaption
+            />
+          </div>
+        ) : null}
+      </div>
+    </SectionCard>
   );
 }
 
@@ -252,7 +303,9 @@ export default function DatasetDetailPage() {
       setDataset(await getDatasetForManagement(id));
     } catch (error) {
       setDataset(undefined);
-      setLoadError(error instanceof Error ? error.message : '加载 Dataset 详情失败');
+      setLoadError(
+        error instanceof Error ? error.message : '加载 Dataset 详情失败',
+      );
     } finally {
       setLoading(false);
     }
@@ -266,13 +319,18 @@ export default function DatasetDetailPage() {
     if (!dataset) return;
     setStatusUpdating(true);
     try {
-      const next = dataset.status === 'ONLINE'
-        ? await offlineDataset(dataset.id)
-        : await onlineDataset(dataset.id);
+      const next =
+        dataset.status === 'ONLINE'
+          ? await offlineDataset(dataset.id)
+          : await onlineDataset(dataset.id);
       setDataset(next);
-      message.success(dataset.status === 'ONLINE' ? 'Dataset 已下线' : 'Dataset 已上线');
+      message.success(
+        dataset.status === 'ONLINE' ? 'Dataset 已下线' : 'Dataset 已上线',
+      );
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '更新 Dataset 状态失败');
+      message.error(
+        error instanceof Error ? error.message : '更新 Dataset 状态失败',
+      );
     } finally {
       setStatusUpdating(false);
     }
@@ -285,7 +343,9 @@ export default function DatasetDetailPage() {
       setDataset(await createDatasetVersion(dataset.id));
       message.success('Dataset 新版本已发布');
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '发布 Dataset 新版本失败');
+      message.error(
+        error instanceof Error ? error.message : '发布 Dataset 新版本失败',
+      );
     } finally {
       setVersionCreating(false);
     }
@@ -293,7 +353,7 @@ export default function DatasetDetailPage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-white">
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f7f8]">
         <Spin size="large" />
       </div>
     );
@@ -301,7 +361,7 @@ export default function DatasetDetailPage() {
 
   if (!dataset) {
     return (
-      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-white">
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-[#f7f7f8]">
         <YakOpsEmpty
           width={190}
           height={126}
@@ -319,8 +379,13 @@ export default function DatasetDetailPage() {
   );
   const canCreateAnalysis = dataset.status === 'ONLINE' && queryable;
   const canCreateVersion = currentVersion?.sourceType === 'QUERY_REVISION';
-  const dimensions = dataset.fields.filter((field) => field.defaultRole === 'DIMENSION').length;
-  const measures = dataset.fields.filter((field) => field.defaultRole === 'MEASURE').length;
+  const dimensions = dataset.fields.filter(
+    (field) => field.defaultRole === 'DIMENSION',
+  ).length;
+  const measures = dataset.fields.filter(
+    (field) => field.defaultRole === 'MEASURE',
+  ).length;
+  const online = dataset.status === 'ONLINE';
 
   const fieldColumns: ColumnsType<DatasetManagementField> = [
     {
@@ -329,8 +394,10 @@ export default function DatasetDetailPage() {
       width: 220,
       render: (value: string, record) => (
         <div>
-          <div className="font-medium text-[#161823]">{value}</div>
-          <div className="mt-0.5 text-[12px] text-[#8a8f99]">{record.physicalName}</div>
+          <div className="font-medium text-[#30343b]">{value}</div>
+          <div className="mt-0.5 text-[11px] text-[#9aa0aa]">
+            {record.physicalName}
+          </div>
         </div>
       ),
     },
@@ -345,21 +412,21 @@ export default function DatasetDetailPage() {
       dataIndex: 'defaultRole',
       width: 110,
       render: (value: DatasetManagementField['defaultRole']) => (
-        <span className="inline-flex items-center gap-1.5">
-          {value === 'MEASURE' ? <Sigma size={13} /> : <Rows3 size={13} />}
+        <Tag bordered={false} color={value === 'MEASURE' ? 'processing' : 'default'}>
           {value === 'MEASURE' ? '指标' : '维度'}
-        </span>
+        </Tag>
       ),
     },
     {
       title: '可空',
       dataIndex: 'nullable',
       width: 80,
-      render: (value: boolean) => value ? '是' : '否',
+      render: (value: boolean) => (value ? '是' : '否'),
     },
     {
       title: '描述',
       dataIndex: 'description',
+      minWidth: 240,
       render: (value?: string) => value || '-',
     },
   ];
@@ -371,10 +438,10 @@ export default function DatasetDetailPage() {
       width: 100,
       render: (value: number, record) => (
         <div className="flex items-center gap-2">
-          <span className="font-medium">DV{value}</span>
-          {record.id === dataset.currentVersionId && (
+          <span className="font-medium text-[#30343b]">DV{value}</span>
+          {record.id === dataset.currentVersionId ? (
             <Tag bordered={false}>当前</Tag>
-          )}
+          ) : null}
         </div>
       ),
     },
@@ -386,6 +453,7 @@ export default function DatasetDetailPage() {
     },
     {
       title: '来源快照',
+      minWidth: 300,
       render: (_, record) => sourceSummary(record),
     },
     {
@@ -396,202 +464,353 @@ export default function DatasetDetailPage() {
     },
   ];
 
-  return (
-    <ConfigProvider theme={BRAND_THEME}>
-      <div className="min-h-[calc(100vh-64px)] bg-white text-[#161823]">
-        <header className="border-b border-[#e4e7ec] px-6 py-4">
-          <div className="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              aria-label="返回 Dataset 列表"
-              className="flex h-9 w-9 items-center justify-center rounded-[6px] border border-[#e4e7ec] bg-white text-[#667085] hover:text-[#161823]"
-              onClick={() => history.push('/dataset')}
-            >
-              <ArrowLeft size={16} />
-            </button>
-            <div className="flex h-10 w-10 items-center justify-center rounded-[8px] bg-[#f4f5f7] text-[#667085]">
-              <Database size={18} />
+  const tabItems = [
+    {
+      key: 'overview' as const,
+      label: '基本信息',
+      children: (
+        <div className="space-y-3">
+          <SectionCard title="数据集概览">
+            <div className="grid grid-cols-2 gap-3 p-5 pt-1 lg:grid-cols-4">
+              <MetricTile
+                label="字段"
+                value={dataset.fields.length}
+                hint="当前版本字段合同"
+              />
+              <MetricTile
+                label="维度"
+                value={dimensions}
+                hint="默认维度字段"
+              />
+              <MetricTile
+                label="指标"
+                value={measures}
+                hint="默认度量字段"
+              />
+              <MetricTile
+                label="版本"
+                value={dataset.versions.length}
+                hint="不可变 DatasetVersion"
+              />
             </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <h1 className="m-0 truncate text-[20px] font-semibold">{dataset.name}</h1>
-                <Tag bordered={false} color={dataset.status === 'ONLINE' ? 'success' : 'default'}>
-                  {dataset.status === 'ONLINE' ? '已上线' : '已下线'}
-                </Tag>
-                {currentVersion && <Tag bordered={false}>DV{currentVersion.versionNo}</Tag>}
-              </div>
-              <div className="mt-1 text-[12px] text-[#667085]">
-                {dataset.description || '暂无描述'}
-              </div>
-            </div>
-            <YakButton icon={<RefreshCw size={13} />} onClick={() => void loadDataset()}>
-              刷新
-            </YakButton>
-            <YakButton
-              icon={<Workflow size={13} />}
-              href={`/data-analysis/lineage?datasetId=${encodeURIComponent(dataset.id)}`}
-            >
-              查看血缘
-            </YakButton>
-            <Tooltip title={canCreateVersion ? '从来源 TaskAsset 当前版本生成新的不可变 DatasetVersion' : '仅 SQL TaskAsset 来源支持此操作'}>
-              <span>
-                <Popconfirm
-                  title="确认发布新的 DatasetVersion？"
-                  description="新版本会冻结来源 TaskAsset 当前 Revision，不会修改历史版本。"
-                  okText="发布"
-                  cancelText="取消"
-                  disabled={!canCreateVersion}
-                  onConfirm={() => void publishNextVersion()}
-                >
-                  <YakButton
-                    icon={<GitBranch size={13} />}
-                    disabled={!canCreateVersion}
-                    loading={versionCreating}
-                  >
-                    发布新版本
-                  </YakButton>
-                </Popconfirm>
-              </span>
-            </Tooltip>
-            <Popconfirm
-              title={dataset.status === 'ONLINE' ? '确认下线这个 Dataset？' : '确认上线这个 Dataset？'}
-              description={dataset.status === 'ONLINE'
-                ? '下线后下游 Analysis、仪表盘和大屏将无法继续查询。'
-                : '上线后可重新被下游消费。'}
-              okText="确认"
-              cancelText="取消"
-              onConfirm={() => void toggleStatus()}
-            >
-              <YakButton loading={statusUpdating}>
-                {dataset.status === 'ONLINE' ? '下线' : '上线'}
-              </YakButton>
-            </Popconfirm>
-            <Tooltip title={canCreateAnalysis ? '使用当前 Dataset 创建分析' : 'Dataset 需在线且来源类型已接入 Query Runtime'}>
-              <span>
-                <YakButton
-                  type="primary"
-                  icon={<BarChart3 size={13} />}
-                  disabled={!canCreateAnalysis}
-                  href={canCreateAnalysis
-                    ? `/data-analysis/chart-analysis?datasetId=${encodeURIComponent(dataset.id)}`
-                    : undefined}
-                >
-                  创建分析
-                </YakButton>
-              </span>
-            </Tooltip>
-          </div>
-        </header>
+          </SectionCard>
 
-        <div className="border-b border-[#e4e7ec] px-5">
-          <YakTab
-            activeKey={activeTab}
-            items={[
-              { key: 'overview', label: '基本信息' },
-              { key: 'schema', label: `字段 Schema ${dataset.fields.length}` },
-              { key: 'versions', label: `版本历史 ${dataset.versions.length}` },
-              { key: 'query', label: 'Query Playground' },
-              { key: 'diagnostics', label: '运行诊断' },
-              { key: 'source', label: '来源信息' },
-            ]}
-            onChange={(key) => setActiveTab(key as DetailTab)}
-          />
+          <SectionCard title="基础信息">
+            <div className="grid gap-x-10 gap-y-6 p-5 pt-1 sm:grid-cols-2 xl:grid-cols-3">
+              <DetailItem label="Dataset ID">{dataset.id}</DetailItem>
+              <DetailItem label="状态">
+                {online ? '已上线' : '已下线'}
+              </DetailItem>
+              <DetailItem label="当前版本">
+                {currentVersion ? `DV${currentVersion.versionNo}` : '-'}
+              </DetailItem>
+              <DetailItem label="当前来源">
+                {sourceSummary(currentVersion)}
+              </DetailItem>
+              <DetailItem label="创建时间">
+                {formatDateTime(dataset.createTime)}
+              </DetailItem>
+              <DetailItem label="更新时间">
+                {formatDateTime(dataset.updateTime || dataset.createTime)}
+              </DetailItem>
+            </div>
+          </SectionCard>
         </div>
-
-        <main className="p-6">
-          {activeTab === 'overview' && (
-            <div className="space-y-4">
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
-                {[
-                  { label: '字段', value: dataset.fields.length },
-                  { label: '维度', value: dimensions },
-                  { label: '指标', value: measures },
-                  { label: '版本', value: dataset.versions.length },
-                ].map((item) => (
-                  <div key={item.label} className="border border-[#e4e7ec] p-4">
-                    <div className="text-[12px] text-[#667085]">{item.label}</div>
-                    <div className="mt-2 text-[24px] font-semibold">{item.value}</div>
-                  </div>
-                ))}
-              </div>
-              <div className="border border-[#e4e7ec] p-5">
-                <Descriptions
-                  column={{ xs: 1, sm: 2, lg: 3 }}
-                  items={[
-                    { key: 'id', label: 'Dataset ID', children: dataset.id },
-                    { key: 'status', label: '状态', children: dataset.status === 'ONLINE' ? '已上线' : '已下线' },
-                    { key: 'version', label: '当前版本', children: currentVersion ? `DV${currentVersion.versionNo}` : '-' },
-                    { key: 'source', label: '当前来源', children: sourceSummary(currentVersion) },
-                    { key: 'created', label: '创建时间', children: formatDateTime(dataset.createTime) },
-                    { key: 'updated', label: '更新时间', children: formatDateTime(dataset.updateTime || dataset.createTime) },
-                  ]}
-                />
-              </div>
-            </div>
-          )}
-
-          {activeTab === 'schema' && (
-            <Table
+      ),
+    },
+    {
+      key: 'schema' as const,
+      label: `字段 Schema ${dataset.fields.length}`,
+      children: (
+        <SectionCard
+          title="字段 Schema"
+          extra={
+            <span className="text-[12px] font-normal text-[#9aa0aa]">
+              共 {dataset.fields.length} 个字段
+            </span>
+          }
+        >
+          <div className="p-5 pt-1">
+            <Table<DatasetManagementField>
               rowKey="fieldId"
-              bordered
               pagination={false}
               columns={fieldColumns}
-              dataSource={[...dataset.fields].sort((left, right) => left.sortOrder - right.sortOrder)}
-              scroll={{ x: 850 }}
+              dataSource={[...dataset.fields].sort(
+                (left, right) => left.sortOrder - right.sortOrder,
+              )}
+              scroll={{ x: 880 }}
               locale={{ emptyText: '当前版本暂无字段定义' }}
+              className={DETAIL_TABLE_CLASS}
             />
-          )}
-
-          {activeTab === 'versions' && (
-            <Table
+          </div>
+        </SectionCard>
+      ),
+    },
+    {
+      key: 'versions' as const,
+      label: `版本历史 ${dataset.versions.length}`,
+      children: (
+        <SectionCard
+          title="版本历史"
+          extra={
+            <span className="text-[12px] font-normal text-[#9aa0aa]">
+              当前 {currentVersion ? `DV${currentVersion.versionNo}` : '-'}
+            </span>
+          }
+        >
+          <div className="p-5 pt-1">
+            <Table<DatasetManagementVersion>
               rowKey="id"
-              bordered
               pagination={false}
               columns={versionColumns}
-              dataSource={[...dataset.versions].sort((left, right) => right.versionNo - left.versionNo)}
-              scroll={{ x: 860 }}
+              dataSource={[...dataset.versions].sort(
+                (left, right) => right.versionNo - left.versionNo,
+              )}
+              scroll={{ x: 900 }}
               locale={{ emptyText: '暂无 Dataset 版本' }}
+              className={DETAIL_TABLE_CLASS}
             />
-          )}
-
-          {activeTab === 'query' && <DatasetQueryPlayground dataset={dataset} />}
-          {activeTab === 'diagnostics' && <DatasetQueryDiagnostics datasetId={dataset.id} />}
-
-          {activeTab === 'source' && (
-            <div className="space-y-4">
-              <div className="border border-[#e4e7ec] p-5">
-                <Descriptions
-                  column={{ xs: 1, sm: 2 }}
-                  items={[
-                    { key: 'type', label: '来源类型', children: currentVersion ? SOURCE_TYPE_LABELS[currentVersion.sourceType] : '-' },
-                    { key: 'summary', label: '来源快照', children: sourceSummary(currentVersion) },
-                    { key: 'asset', label: 'TaskAsset ID', children: currentVersion?.sourceTaskAssetId || '-' },
-                    { key: 'revision', label: 'TaskRevision ID', children: currentVersion?.sourceTaskRevisionId || '-' },
-                    { key: 'revisionNo', label: 'TaskRevision No.', children: currentVersion?.sourceTaskRevisionNo || '-' },
-                    { key: 'datasource', label: '数据源 ID', children: currentVersion?.dataSourceId || '-' },
-                  ]}
-                />
-              </div>
-              {currentVersion?.sql && (
-                <div className="border border-[#e4e7ec]">
-                  <div className="border-b border-[#e4e7ec] bg-[#fafbfc] px-4 py-2 text-[13px] font-medium">
-                    冻结 SQL
-                  </div>
-                  <pre className="m-0 max-h-[440px] overflow-auto whitespace-pre-wrap break-words p-4 text-[12px] leading-6 text-[#344054]">
-                    {currentVersion.sql}
-                  </pre>
-                </div>
-              )}
-              {currentVersion && !isQueryableDatasetSourceType(currentVersion.sourceType) && (
-                <Alert
-                  type="warning"
-                  showIcon
-                  message={`${SOURCE_TYPE_LABELS[currentVersion.sourceType]}当前仅保留 Dataset 合同值，尚未接入 Query Runtime。`}
-                />
-              )}
+          </div>
+        </SectionCard>
+      ),
+    },
+    {
+      key: 'query' as const,
+      label: 'Query Playground',
+      children: <DatasetQueryPlayground dataset={dataset} />,
+    },
+    {
+      key: 'diagnostics' as const,
+      label: '运行诊断',
+      children: (
+        <SectionCard title="运行诊断">
+          <div className="p-5 pt-1">
+            <DatasetQueryDiagnostics datasetId={dataset.id} />
+          </div>
+        </SectionCard>
+      ),
+    },
+    {
+      key: 'source' as const,
+      label: '来源信息',
+      children: (
+        <div className="space-y-3">
+          <SectionCard title="来源信息">
+            <div className="grid gap-x-10 gap-y-6 p-5 pt-1 sm:grid-cols-2 xl:grid-cols-3">
+              <DetailItem label="来源类型">
+                {currentVersion
+                  ? SOURCE_TYPE_LABELS[currentVersion.sourceType]
+                  : '-'}
+              </DetailItem>
+              <DetailItem label="来源快照">
+                {sourceSummary(currentVersion)}
+              </DetailItem>
+              <DetailItem label="TaskAsset ID">
+                {currentVersion?.sourceTaskAssetId || '-'}
+              </DetailItem>
+              <DetailItem label="TaskRevision ID">
+                {currentVersion?.sourceTaskRevisionId || '-'}
+              </DetailItem>
+              <DetailItem label="TaskRevision No.">
+                {currentVersion?.sourceTaskRevisionNo || '-'}
+              </DetailItem>
+              <DetailItem label="数据源 ID">
+                {currentVersion?.dataSourceId || '-'}
+              </DetailItem>
             </div>
-          )}
-        </main>
+          </SectionCard>
+
+          {currentVersion?.sql ? (
+            <SectionCard title="冻结 SQL">
+              <div className="p-5 pt-1">
+                <pre className="m-0 max-h-[520px] overflow-auto whitespace-pre-wrap break-words rounded-md bg-[#181a1f] p-4 font-mono text-[12px] leading-5 text-[#d6d9df]">
+                  {currentVersion.sql}
+                </pre>
+              </div>
+            </SectionCard>
+          ) : null}
+
+          {currentVersion &&
+          !isQueryableDatasetSourceType(currentVersion.sourceType) ? (
+            <Alert
+              type="warning"
+              showIcon
+              message={`${SOURCE_TYPE_LABELS[currentVersion.sourceType]}当前仅保留 Dataset 合同值，尚未接入 Query Runtime。`}
+            />
+          ) : null}
+        </div>
+      ),
+    },
+  ];
+
+  const currentSourceLabel = currentVersion
+    ? SOURCE_TYPE_LABELS[currentVersion.sourceType]
+    : '暂无来源';
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="min-h-[calc(100vh-64px)] bg-[#f7f7f8] text-[#161823]">
+        <div className="mx-auto w-full max-w-[1800px] px-4 pb-8 pt-0 lg:px-5">
+          <div className="mb-2 flex h-10 items-center">
+            <Button
+              type="text"
+              icon={<ArrowLeftOutlined />}
+              className="!h-9 !px-1 !text-[14px] !font-semibold !text-[#30343b]"
+              onClick={() => history.push('/dataset')}
+            >
+              返回数据集列表
+            </Button>
+          </div>
+
+          <section className="rounded-lg bg-white">
+            <div className="grid min-h-[176px] gap-6 px-5 py-6 lg:px-6 xl:grid-cols-[116px_minmax(0,1fr)_430px] xl:items-center">
+              <div className="relative flex h-[116px] w-[116px] shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#f7f7f8]">
+                <div className="absolute h-[78px] w-[78px] rounded-full bg-white shadow-[0_8px_22px_rgba(22,24,35,0.05)]" />
+                <DatabaseOutlined className="relative z-10 text-[38px] text-[#5d6470]" />
+                <span className="absolute bottom-3 z-10 rounded-md bg-white px-2 py-1 text-[10px] font-medium text-[#667085] shadow-sm">
+                  {currentVersion ? `DV${currentVersion.versionNo}` : 'Dataset'}
+                </span>
+              </div>
+
+              <div className="min-w-0">
+                <div className="max-w-[620px] truncate text-[16px] font-semibold leading-6 text-[#161823]">
+                  {dataset.name}
+                </div>
+                <div className="mt-1 max-w-[720px] line-clamp-2 text-[12px] leading-5 text-[#8a8f98]">
+                  {dataset.description || '暂无描述'}
+                </div>
+
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] leading-4 text-[#667085]">
+                  <span
+                    className={`inline-block h-[10px] w-[10px] rounded-full ${
+                      online ? 'bg-[#20c77a]' : 'bg-[#98a2b3]'
+                    }`}
+                  />
+                  <span>{online ? '已上线' : '已下线'}</span>
+                  <span className="text-[#d0d3d8]">·</span>
+                  <span>
+                    {currentVersion
+                      ? `当前版本 DV${currentVersion.versionNo}`
+                      : '尚无版本'}
+                  </span>
+                </div>
+
+                <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1.5 text-[11px] leading-4 text-[#8a8f98]">
+                  <span className="max-w-[220px] truncate">
+                    {currentSourceLabel}
+                  </span>
+                  <span className="text-[10px] text-[#b0b5bd]">→</span>
+                  <span className="max-w-[420px] truncate">
+                    {sourceSummary(currentVersion)}
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex min-w-0 flex-wrap items-center justify-start gap-2 xl:justify-end">
+                <Tooltip title="刷新 Dataset 详情">
+                  <YakButton
+                    iconOnly
+                    icon={<ReloadOutlined />}
+                    onClick={() => void loadDataset()}
+                  />
+                </Tooltip>
+
+                <YakButton
+                  icon={<LinkOutlined />}
+                  href={`/data-analysis/lineage?datasetId=${encodeURIComponent(
+                    dataset.id,
+                  )}`}
+                >
+                  查看血缘
+                </YakButton>
+
+                <Tooltip
+                  title={
+                    canCreateVersion
+                      ? '从来源 TaskAsset 当前版本生成新的不可变 DatasetVersion'
+                      : '仅 SQL TaskAsset 来源支持此操作'
+                  }
+                >
+                  <span>
+                    <Popconfirm
+                      title="确认发布新的 DatasetVersion？"
+                      description="新版本会冻结来源 TaskAsset 当前 Revision，不会修改历史版本。"
+                      okText="发布"
+                      cancelText="取消"
+                      disabled={!canCreateVersion}
+                      onConfirm={() => void publishNextVersion()}
+                    >
+                      <YakButton
+                        icon={<CloudUploadOutlined />}
+                        disabled={!canCreateVersion}
+                        loading={versionCreating}
+                      >
+                        发布新版本
+                      </YakButton>
+                    </Popconfirm>
+                  </span>
+                </Tooltip>
+
+                <Popconfirm
+                  title={
+                    online
+                      ? '确认下线这个 Dataset？'
+                      : '确认上线这个 Dataset？'
+                  }
+                  description={
+                    online
+                      ? '下线后下游 Analysis、仪表盘和大屏将无法继续查询。'
+                      : '上线后可重新被下游消费。'
+                  }
+                  okText="确认"
+                  cancelText="取消"
+                  onConfirm={() => void toggleStatus()}
+                >
+                  <YakButton loading={statusUpdating}>
+                    {online ? '下线' : '上线'}
+                  </YakButton>
+                </Popconfirm>
+
+                <Tooltip
+                  title={
+                    canCreateAnalysis
+                      ? '使用当前 Dataset 创建分析'
+                      : 'Dataset 需在线且来源类型已接入 Query Runtime'
+                  }
+                >
+                  <span>
+                    <YakButton
+                      type="primary"
+                      icon={<BarChartOutlined />}
+                      disabled={!canCreateAnalysis}
+                      href={
+                        canCreateAnalysis
+                          ? `/data-analysis/chart-analysis?datasetId=${encodeURIComponent(
+                              dataset.id,
+                            )}`
+                          : undefined
+                      }
+                    >
+                      创建分析
+                    </YakButton>
+                  </span>
+                </Tooltip>
+              </div>
+            </div>
+          </section>
+
+          <div className="px-5 lg:px-6">
+            <YakTab
+              activeKey={activeTab}
+              items={tabItems.map(({ key, label }) => ({ key, label }))}
+              onChange={(key) => setActiveTab(key as DetailTab)}
+            />
+          </div>
+
+          <div className="mt-3">
+            {tabItems.find((item) => item.key === activeTab)?.children}
+          </div>
+        </div>
       </div>
     </ConfigProvider>
   );

--- a/yak-ops-ui/src/pages/dataset/index.tsx
+++ b/yak-ops-ui/src/pages/dataset/index.tsx
@@ -1,5 +1,8 @@
 import YakOpsEmpty from '@/components/YakOpsEmpty';
-import { YakButton } from '@/components/ui';
+import {
+  SecurityPagination,
+  SecurityQueryTable,
+} from '@/components/security';
 import {
   listDatasetsForManagement,
   offlineDataset,
@@ -10,16 +13,28 @@ import {
 } from '@/services/dataset';
 import { BRAND_THEME } from '@/styles/brand';
 import { history } from '@umijs/max';
-import { ConfigProvider, Input, Popconfirm, Select, Table, Tag, message } from 'antd';
+import { ConfigProvider, Tag, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { Database, GitBranch, RefreshCw, Search } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import DatasetFilterBar, {
+  type DatasetListFilters,
+} from './components/DatasetFilterBar';
+import DatasetRowActions from './components/DatasetRowActions';
+
+const DEFAULT_PAGE_SIZE = 20;
 
 const SOURCE_TYPE_LABELS: Record<DatasetSourceType, string> = {
   QUERY_REVISION: 'SQL 任务',
   SQL_QUERY: 'Standalone SQL',
   TABLE: '数据表',
   VIEW: '视图',
+};
+
+const DEFAULT_FILTERS: DatasetListFilters = {
+  keyword: '',
+  status: 'ALL',
+  sourceType: 'ALL',
 };
 
 const formatDateTime = (value?: string) => {
@@ -32,9 +47,9 @@ export default function DatasetManagementPage() {
   const [datasets, setDatasets] = useState<DatasetManagementItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState('');
-  const [keyword, setKeyword] = useState('');
-  const [status, setStatus] = useState<'ALL' | DatasetStatus>('ALL');
-  const [sourceType, setSourceType] = useState<'ALL' | DatasetSourceType>('ALL');
+  const [filters, setFilters] = useState<DatasetListFilters>(DEFAULT_FILTERS);
+  const [pageNum, setPageNum] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [statusUpdatingId, setStatusUpdatingId] = useState('');
 
   const loadDatasets = useCallback(async () => {
@@ -55,11 +70,19 @@ export default function DatasetManagementPage() {
   }, [loadDatasets]);
 
   const filteredDatasets = useMemo(() => {
-    const normalized = keyword.trim().toLowerCase();
+    const normalized = filters.keyword.trim().toLowerCase();
     return datasets.filter((dataset) => {
-      if (status !== 'ALL' && dataset.status !== status) return false;
-      if (sourceType !== 'ALL' && dataset.currentVersion?.sourceType !== sourceType) return false;
+      if (filters.status !== 'ALL' && dataset.status !== filters.status) {
+        return false;
+      }
+      if (
+        filters.sourceType !== 'ALL' &&
+        dataset.currentVersion?.sourceType !== filters.sourceType
+      ) {
+        return false;
+      }
       if (!normalized) return true;
+
       return [
         dataset.name,
         dataset.description,
@@ -72,210 +95,184 @@ export default function DatasetManagementPage() {
         ]),
       ].some((value) => value.toLowerCase().includes(normalized));
     });
-  }, [datasets, keyword, sourceType, status]);
+  }, [datasets, filters]);
 
-  const toggleStatus = useCallback(async (dataset: DatasetManagementItem) => {
-    setStatusUpdatingId(dataset.id);
-    try {
-      if (dataset.status === 'ONLINE') {
-        await offlineDataset(dataset.id);
-        message.success(`Dataset「${dataset.name}」已下线`);
-      } else {
-        await onlineDataset(dataset.id);
-        message.success(`Dataset「${dataset.name}」已上线`);
+  useEffect(() => {
+    const maxPage = Math.max(1, Math.ceil(filteredDatasets.length / pageSize));
+    if (pageNum > maxPage) setPageNum(maxPage);
+  }, [filteredDatasets.length, pageNum, pageSize]);
+
+  const visibleDatasets = useMemo(() => {
+    const start = (pageNum - 1) * pageSize;
+    return filteredDatasets.slice(start, start + pageSize);
+  }, [filteredDatasets, pageNum, pageSize]);
+
+  const toggleStatus = useCallback(
+    async (dataset: DatasetManagementItem) => {
+      setStatusUpdatingId(dataset.id);
+      try {
+        if (dataset.status === 'ONLINE') {
+          await offlineDataset(dataset.id);
+          message.success(`Dataset「${dataset.name}」已下线`);
+        } else {
+          await onlineDataset(dataset.id);
+          message.success(`Dataset「${dataset.name}」已上线`);
+        }
+        await loadDatasets();
+      } catch (error) {
+        message.error(
+          error instanceof Error ? error.message : '更新 Dataset 状态失败',
+        );
+      } finally {
+        setStatusUpdatingId('');
       }
-      await loadDatasets();
-    } catch (error) {
-      message.error(error instanceof Error ? error.message : '更新 Dataset 状态失败');
-    } finally {
-      setStatusUpdatingId('');
-    }
-  }, [loadDatasets]);
+    },
+    [loadDatasets],
+  );
 
-  const columns = useMemo<ColumnsType<DatasetManagementItem>>(() => [
-    {
-      title: 'Dataset',
-      dataIndex: 'name',
-      minWidth: 260,
-      render: (_value, record) => (
-        <div className="min-w-0">
-          <button
-            type="button"
-            className="max-w-full truncate bg-transparent p-0 text-left text-[14px] font-medium text-[#161823] hover:text-[#fe2c55]"
-            onClick={(event) => {
-              event.stopPropagation();
-              history.push(`/dataset/${record.id}`);
-            }}
-          >
-            {record.name}
-          </button>
-          <div className="mt-1 line-clamp-1 text-[12px] text-[#8a8f99]">
-            {record.description || '暂无描述'}
+  const columns = useMemo<ColumnsType<DatasetManagementItem>>(
+    () => [
+      {
+        title: 'Dataset',
+        dataIndex: 'name',
+        minWidth: 280,
+        render: (_value, record) => (
+          <div className="min-w-0">
+            <button
+              type="button"
+              className="max-w-full truncate border-0 bg-transparent p-0 text-left text-[14px] font-medium text-[#242731] transition-colors hover:text-[#fe2c55]"
+              onClick={() => history.push(`/dataset/${record.id}`)}
+            >
+              {record.name}
+            </button>
+            <div className="mt-1 line-clamp-1 text-[12px] text-slate-400">
+              {record.description || '暂无描述'}
+            </div>
           </div>
-        </div>
-      ),
-    },
-    {
-      title: '状态',
-      dataIndex: 'status',
-      width: 100,
-      render: (value: DatasetStatus) => (
-        <Tag bordered={false} color={value === 'ONLINE' ? 'success' : 'default'}>
-          {value === 'ONLINE' ? '已上线' : '已下线'}
-        </Tag>
-      ),
-    },
-    {
-      title: '来源类型',
-      width: 150,
-      render: (_, record) => record.currentVersion
-        ? SOURCE_TYPE_LABELS[record.currentVersion.sourceType]
-        : '-',
-    },
-    {
-      title: '当前版本',
-      width: 110,
-      render: (_, record) => record.currentVersion
-        ? `DV${record.currentVersion.versionNo}`
-        : '-',
-    },
-    {
-      title: '字段数',
-      dataIndex: 'fields',
-      width: 90,
-      render: (fields: DatasetManagementItem['fields']) => fields.length,
-    },
-    {
-      title: '更新时间',
-      dataIndex: 'updateTime',
-      width: 180,
-      render: (value?: string, record) => formatDateTime(value || record.createTime),
-    },
-    {
-      title: '操作',
-      width: 190,
-      fixed: 'right',
-      render: (_, record) => (
-        <div className="flex items-center gap-2" onClick={(event) => event.stopPropagation()}>
-          <YakButton onClick={() => history.push(`/dataset/${record.id}`)}>
-            详情
-          </YakButton>
-          <Popconfirm
-            title={record.status === 'ONLINE' ? '确认下线这个 Dataset？' : '确认上线这个 Dataset？'}
-            description={record.status === 'ONLINE'
-              ? '下线后 Analysis、仪表盘和大屏将无法继续查询。'
-              : '上线后可重新用于下游消费。'}
-            okText="确认"
-            cancelText="取消"
-            onConfirm={() => void toggleStatus(record)}
+        ),
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 100,
+        render: (value: DatasetStatus) => (
+          <Tag
+            bordered={false}
+            color={value === 'ONLINE' ? 'success' : 'default'}
           >
-            <YakButton loading={statusUpdatingId === record.id}>
-              {record.status === 'ONLINE' ? '下线' : '上线'}
-            </YakButton>
-          </Popconfirm>
-        </div>
-      ),
-    },
-  ], [statusUpdatingId, toggleStatus]);
+            {value === 'ONLINE' ? '已上线' : '已下线'}
+          </Tag>
+        ),
+      },
+      {
+        title: '来源类型',
+        width: 160,
+        render: (_, record) =>
+          record.currentVersion
+            ? SOURCE_TYPE_LABELS[record.currentVersion.sourceType]
+            : '-',
+      },
+      {
+        title: '当前版本',
+        width: 110,
+        render: (_, record) =>
+          record.currentVersion
+            ? `DV${record.currentVersion.versionNo}`
+            : '-',
+      },
+      {
+        title: '字段数',
+        dataIndex: 'fields',
+        width: 90,
+        render: (fields: DatasetManagementItem['fields']) => fields.length,
+      },
+      {
+        title: '更新时间',
+        dataIndex: 'updateTime',
+        width: 180,
+        render: (value?: string, record) =>
+          formatDateTime(value || record.createTime),
+      },
+      {
+        title: '操作',
+        key: 'action',
+        fixed: 'right',
+        width: 156,
+        render: (_, record) => (
+          <DatasetRowActions
+            dataset={record}
+            loading={statusUpdatingId === record.id}
+            onDetail={(dataset) => history.push(`/dataset/${dataset.id}`)}
+            onToggleStatus={(dataset) => void toggleStatus(dataset)}
+          />
+        ),
+      },
+    ],
+    [statusUpdatingId, toggleStatus],
+  );
 
   return (
     <ConfigProvider theme={BRAND_THEME}>
-      <div className="min-h-[calc(100vh-64px)] bg-white text-[#161823]">
-        <header className="border-b border-[#e4e7ec] px-6 py-4">
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="flex min-w-0 flex-1 items-center gap-3">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[8px] bg-[#f4f5f7] text-[#667085]">
-                <Database size={18} />
-              </div>
-              <div className="min-w-0">
-                <h1 className="m-0 text-[22px] font-semibold leading-8">数据集</h1>
-                <p className="m-0 mt-0.5 text-[13px] text-[#667085]">
-                  统一管理可被 Analysis、仪表盘、数字化大屏和数据服务消费的稳定数据契约。
-                </p>
-              </div>
-            </div>
-            <YakButton icon={<RefreshCw size={14} />} onClick={() => void loadDatasets()}>
-              刷新
-            </YakButton>
-            <YakButton type="primary" icon={<GitBranch size={14} />} href="/data-development/releases">
-              发布中心
-            </YakButton>
-          </div>
-        </header>
+      <section className="box-border flex min-h-[calc(100vh-64px)] flex-col overflow-hidden bg-slate-50/50 p-6 text-[#161823]">
+        <div className="mb-4 flex shrink-0 items-center gap-2">
+          <h1 className="m-0 text-[18px] font-semibold text-[#282828]">
+            数据集
+          </h1>
+        </div>
 
-        <main className="p-6">
-          <div className="mb-4 flex flex-wrap items-center gap-3 border border-[#e4e7ec] bg-[#fafbfc] p-3">
-            <Input
-              allowClear
-              value={keyword}
-              prefix={<Search size={14} />}
-              placeholder="搜索 Dataset、字段、来源"
-              className="w-[320px]"
-              onChange={(event) => setKeyword(event.target.value)}
-            />
-            <Select
-              value={status}
-              className="w-[130px]"
-              options={[
-                { value: 'ALL', label: '全部状态' },
-                { value: 'ONLINE', label: '已上线' },
-                { value: 'OFFLINE', label: '已下线' },
-              ]}
-              onChange={setStatus}
-            />
-            <Select
-              value={sourceType}
-              className="w-[170px]"
-              options={[
-                { value: 'ALL', label: '全部来源' },
-                ...Object.entries(SOURCE_TYPE_LABELS).map(([value, label]) => ({ value, label })),
-              ]}
-              onChange={setSourceType}
-            />
-            <div className="ml-auto text-[12px] text-[#667085]">
-              共 {filteredDatasets.length} 个 Dataset
-            </div>
-          </div>
+        <div className="shrink-0">
+          <DatasetFilterBar
+            total={filteredDatasets.length}
+            loading={loading}
+            onSearch={(nextFilters) => {
+              setPageNum(1);
+              setFilters(nextFilters);
+            }}
+            onRefresh={() => void loadDatasets()}
+            onOpenReleaseCenter={() =>
+              history.push('/data-development/releases')
+            }
+          />
 
-          {loadError && !loading ? (
-            <div className="flex min-h-[420px] items-center justify-center border border-[#e4e7ec]">
-              <YakOpsEmpty
-                width={180}
-                height={120}
-                title="Dataset 加载失败"
-                description={loadError}
-                showCaption
-              />
-            </div>
-          ) : (
-            <Table
-              rowKey="id"
-              loading={loading}
-              columns={columns}
-              dataSource={filteredDatasets}
-              scroll={{ x: 1120 }}
-              pagination={{ pageSize: 20, showSizeChanger: true }}
-              onRow={(record) => ({
-                onClick: () => history.push(`/dataset/${record.id}`),
-                className: 'cursor-pointer',
-              })}
-              locale={{
-                emptyText: (
-                  <div className="flex min-h-[360px] items-center justify-center">
-                    <YakOpsEmpty
-                      width={180}
-                      height={120}
-                      title="暂无 Dataset"
-                      description="请先从数据开发发布中心发布可消费的数据集。"
-                      showCaption
-                    />
-                  </div>
-                ),
-              }}
-            />
-          )}
-        </main>
-      </div>
+          <SecurityQueryTable<DatasetManagementItem>
+            rowKey="id"
+            loading={loading}
+            columns={columns}
+            dataSource={visibleDatasets}
+            pagination={false}
+            bordered
+            scroll={{ x: 'max-content' }}
+            locale={{
+              emptyText: (
+                <div className="flex min-h-[300px] items-center justify-center">
+                  <YakOpsEmpty
+                    width={180}
+                    height={120}
+                    title={loadError ? 'Dataset 加载失败' : '暂无 Dataset'}
+                    description={
+                      loadError || '请先从数据开发发布中心发布可消费的数据集。'
+                    }
+                    showCaption
+                  />
+                </div>
+              ),
+            }}
+          />
+        </div>
+
+        <div className="min-h-6 flex-1" />
+
+        <SecurityPagination
+          current={pageNum}
+          pageSize={pageSize}
+          total={filteredDatasets.length}
+          disabled={loading}
+          onChange={(nextPage, nextPageSize) => {
+            setPageNum(nextPageSize === pageSize ? nextPage : 1);
+            setPageSize(nextPageSize);
+          }}
+        />
+      </section>
     </ConfigProvider>
   );
 }


### PR DESCRIPTION
## 背景

当前 Dataset 管理页与最近统一后的「角色与权限 / 工作空间」页面仍有明显视觉差异：列表页保留大标题说明区、独立描边筛选卡片和普通 Table；Dataset 详情页虽然功能已经比较完整，但整体仍是传统后台详情结构，与离线同步最新任务详情的视觉层级不一致。

本 PR 只重构 Dataset 前端展示与交互层，不修改 Dataset API、后端逻辑、Project Space、版本语义和 Query Runtime 行为。

## 1. Dataset 列表对齐统一管理页标准

列表页按「角色与权限 / 工作空间」现有标准重构：

```text
页面标题
  ↓
轻量筛选 / 操作栏
  ↓
SecurityQueryTable
  ↓
页面底部 SecurityPagination
```

具体调整：

- 去掉原来的大图标 + 描述型 Header；
- 左侧使用 `全部数据集 + 数量` 轻量标签；
- 搜索、状态、来源类型统一使用 Ant Design `variant="filled"`；
- 刷新使用 icon-only 按钮；
- 保留「发布中心」主操作；
- Table 切换为共享 `SecurityQueryTable`，统一表头、圆角、loading 与 empty state；
- 分页切换为共享 `SecurityPagination`，数据较少时仍稳定落在页面底部；
- 原有 Dataset / 字段 / 来源搜索、状态筛选、来源筛选能力保持；
- Dataset 名称和「详情」都可以进入详情页。

操作区也改为和统一管理页相同的轻量 text action：

```text
详情 | 上线/下线
```

上线 / 下线仍保留原确认提示和业务调用。

## 2. Dataset 详情参考离线同步任务详情重构

详情页布局直接参考当前 Offline Sync redesigned detail 的页面结构：

```text
返回数据集列表
  ↓
白色 Hero 摘要区
  ├─ Dataset 视觉标识 / 当前版本
  ├─ 名称 / 描述 / 状态 / 来源
  └─ 刷新 / 血缘 / 发布版本 / 上下线 / 创建分析
  ↓
YakTab
  ↓
SectionCard 内容区
```

Hero 区不再把所有信息堆在传统页面 Header 中，而是突出：

- Dataset 名称与描述；
- ONLINE / OFFLINE 状态；
- 当前 DatasetVersion；
- 当前来源类型和来源快照；
- 核心管理动作。

页面背景、最大内容宽度、返回区、Hero 高度、Tab 位置、内容卡片和表格密度均向离线同步任务详情靠齐。

## 3. 各 Tab 统一详情视觉

### 基本信息

使用 Offline detail 同类 `MetricTile + SectionCard`：

- 字段数；
- 维度数；
- 指标数；
- 版本数；
- Dataset ID / 状态 / 当前版本 / 当前来源 / 创建时间 / 更新时间。

### 字段 Schema / 版本历史

- 改为紧凑圆角表格；
- 灰色表头；
- 统一 padding / 字号；
- 保留原字段角色、可空、描述和不可变版本信息。

### Query Playground

- 收进统一 SectionCard；
- Dataset 版本 Select 与返回行数 InputNumber 使用 `filled`；
- 查询结果表使用详情页统一表格视觉；
- 原 Query Runtime 请求、版本选择和错误语义不变。

### 运行诊断

- 保留持久化 Query diagnostics 的全部字段和过滤能力；
- 状态 / 慢查询 / 最近记录数过滤器统一改为 Filled；
- 刷新改为 icon-only；
- 诊断表对齐详情页紧凑表格样式。

### 来源信息

- 来源事实改为 SectionCard 信息网格；
- 冻结 SQL 使用与离线同步运行配置 / 结构 SQL 类似的深色代码区；
- 非 Queryable Source 的原 warning 语义保持不变。

## 行为保持不变

本 PR 不改变：

- `GET /api/v1/datasets/**` 等 Dataset API；
- Dataset Project Space 隔离；
- ONLINE / OFFLINE 状态机；
- DatasetVersion 不可变语义；
- QUERY_REVISION 才允许发布下一版本的规则；
- ONLINE + Queryable 才允许创建 Analysis 的规则；
- Query Playground 请求结构；
- Query Performance / diagnostics 行为；
- Lineage 跳转；
- 数据源 / TaskAsset / Revision Source Truth。

## 变更范围

仅 Dataset UI：

```text
yak-ops-ui/src/pages/dataset/
```

新增：

- `components/DatasetFilterBar.tsx`
- `components/DatasetRowActions.tsx`
- `detail/components/DatasetDetailPrimitives.tsx`

并重构：

- `dataset/index.tsx`
- `dataset/detail/index.tsx`
- `dataset/detail/DatasetQueryDiagnostics.tsx`

## 建议本地验证

```bash
cd yak-ops-ui

npm test -- --runInBand \
  src/services/dataset/management.test.ts \
  src/services/dataset/observability.test.ts \
  src/services/dataset/api.test.ts

npm run tsc
npm run biome:lint
```

浏览器最小回归：

1. `/dataset` 列表布局与角色 / 工作空间管理页保持同一视觉体系；
2. Dataset 搜索、状态、来源类型过滤正常，Input / Select 为 Filled；
3. 列表分页、刷新、发布中心、详情、上线/下线正常；
4. 点击 Dataset 名称或详情进入 `/dataset/:id`；
5. 详情页整体层级与 Offline Sync 任务详情一致：返回区 + Hero + Tabs + Cards；
6. 基本信息 / Schema / 版本历史正常展示；
7. QUERY_REVISION Dataset 可以继续发布新版本，其他来源保持禁用；
8. ONLINE + Queryable Dataset 可以继续创建 Analysis；
9. Query Playground 成功 / 错误 / 空结果正常；
10. 运行诊断筛选、刷新和表格正常；
11. 来源信息 / 冻结 SQL / 血缘跳转正常；
12. 1080p / 2K 下 Hero 操作区、Tab 和长表格无明显挤压或溢出。

## 当前验证状态

- branch 已重新叠到创建 PR 时最新 `main`；
- connector compare：ahead 1 / behind 0；
- 最终 diff 仅 6 个 Dataset 前端文件；
- 当前连接环境未实际执行 Jest / TypeScript / Biome / 浏览器回归，因此保持 Draft，不宣称测试已通过。
