### PR TITLE
fix(ui): harden message center interactions

### DIFF
--- a/yak-ops-ui/src/pages/home/components/NotificationCenter.test.tsx
+++ b/yak-ops-ui/src/pages/home/components/NotificationCenter.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import {
+  markMessageRead,
+  notifyMessageCountChanged,
+  pageMessages,
+} from '@/services/security/messages';
+
+import NotificationCenter from './NotificationCenter';
+
+let mockProjects: Array<{ id: number; projectName: string }> = [
+  { id: 7, projectName: 'Project A' },
+];
+let mockCurrentProject: { id: number; projectName: string } | undefined =
+  mockProjects[0];
+
+const push = jest.fn();
+
+jest.mock('@/contexts/SecurityProjectContext', () => ({
+  useSecurityProject: () => ({
+    projects: mockProjects,
+    currentProject: mockCurrentProject,
+  }),
+}));
+
+jest.mock('@/services/security/messages', () => ({
+  pageMessages: jest.fn(),
+  markMessageRead: jest.fn(),
+  notifyMessageCountChanged: jest.fn(),
+  safeMessageActionPath: jest.fn((value?: string) =>
+    value && value.startsWith('/') && !value.startsWith('//') ? value : undefined,
+  ),
+}));
+
+jest.mock('@umijs/max', () => ({
+  history: { push },
+}));
+
+describe('home NotificationCenter', () => {
+  const mockPageMessages = jest.mocked(pageMessages);
+  const mockMarkMessageRead = jest.mocked(markMessageRead);
+  const mockNotifyMessageCountChanged = jest.mocked(notifyMessageCountChanged);
+
+  beforeEach(() => {
+    mockProjects = [{ id: 7, projectName: 'Project A' }];
+    mockCurrentProject = mockProjects[0];
+    push.mockReset();
+    mockPageMessages.mockReset();
+    mockMarkMessageRead.mockReset();
+    mockNotifyMessageCountChanged.mockReset();
+    mockMarkMessageRead.mockResolvedValue(undefined);
+  });
+
+  it('loads only unread messages for the active workspace and marks them read before navigation', async () => {
+    mockPageMessages.mockResolvedValue({
+      records: [
+        {
+          id: 11,
+          title: '离线同步失败',
+          summary: 'ODS 用户表 → DWD 用户表',
+          status: 'UNREAD',
+          actionPath: '/batch-link-up',
+        },
+      ],
+      total: 4,
+    });
+
+    render(<NotificationCenter />);
+
+    await waitFor(() =>
+      expect(mockPageMessages).toHaveBeenCalledWith({
+        pageNum: 1,
+        pageSize: 3,
+        status: 'UNREAD',
+        projectId: 7,
+      }),
+    );
+
+    expect(await screen.findByText('离线同步失败')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('离线同步失败'));
+
+    await waitFor(() => expect(mockMarkMessageRead).toHaveBeenCalledWith(11));
+    expect(mockNotifyMessageCountChanged).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith('/batch-link-up');
+  });
+
+  it('uses the hardened backend system-only inbox when the user has no workspace', async () => {
+    mockProjects = [];
+    mockCurrentProject = undefined;
+    mockPageMessages.mockResolvedValue({ records: [], total: 0 });
+
+    render(<NotificationCenter />);
+
+    await waitFor(() =>
+      expect(mockPageMessages).toHaveBeenCalledWith({
+        pageNum: 1,
+        pageSize: 3,
+        status: 'UNREAD',
+        projectId: undefined,
+      }),
+    );
+  });
+
+  it('waits for project selection instead of issuing a transient unscoped request', async () => {
+    mockProjects = [{ id: 7, projectName: 'Project A' }];
+    mockCurrentProject = undefined;
+
+    render(<NotificationCenter />);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockPageMessages).not.toHaveBeenCalled();
+  });
+});

--- a/yak-ops-ui/src/pages/home/components/NotificationCenter.test.tsx
+++ b/yak-ops-ui/src/pages/home/components/NotificationCenter.test.tsx
@@ -14,7 +14,7 @@ let mockProjects: Array<{ id: number; projectName: string }> = [
 let mockCurrentProject: { id: number; projectName: string } | undefined =
   mockProjects[0];
 
-const push = jest.fn();
+const mockHistoryPush = jest.fn();
 
 jest.mock('@/contexts/SecurityProjectContext', () => ({
   useSecurityProject: () => ({
@@ -33,7 +33,7 @@ jest.mock('@/services/security/messages', () => ({
 }));
 
 jest.mock('@umijs/max', () => ({
-  history: { push },
+  history: { push: mockHistoryPush },
 }));
 
 describe('home NotificationCenter', () => {
@@ -44,7 +44,7 @@ describe('home NotificationCenter', () => {
   beforeEach(() => {
     mockProjects = [{ id: 7, projectName: 'Project A' }];
     mockCurrentProject = mockProjects[0];
-    push.mockReset();
+    mockHistoryPush.mockReset();
     mockPageMessages.mockReset();
     mockMarkMessageRead.mockReset();
     mockNotifyMessageCountChanged.mockReset();
@@ -76,14 +76,14 @@ describe('home NotificationCenter', () => {
       }),
     );
 
-    expect(await screen.findByText('离线同步失败')).toBeInTheDocument();
-    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(await screen.findByText('离线同步失败')).toBeTruthy();
+    expect(screen.getByText('4')).toBeTruthy();
 
     fireEvent.click(screen.getByText('离线同步失败'));
 
     await waitFor(() => expect(mockMarkMessageRead).toHaveBeenCalledWith(11));
     expect(mockNotifyMessageCountChanged).toHaveBeenCalledTimes(1);
-    expect(push).toHaveBeenCalledWith('/batch-link-up');
+    expect(mockHistoryPush).toHaveBeenCalledWith('/batch-link-up');
   });
 
   it('uses the hardened backend system-only inbox when the user has no workspace', async () => {

--- a/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/NotificationCenter.tsx
@@ -1,5 +1,7 @@
 import { useSecurityProject } from '@/contexts/SecurityProjectContext';
 import {
+  markMessageRead,
+  notifyMessageCountChanged,
   pageMessages,
   safeMessageActionPath,
   type SecurityMessage,
@@ -12,7 +14,7 @@ import { HomeEmptyState } from './HomeEmptyState';
 
 interface NotificationState {
   items: SecurityMessage[];
-  total: number;
+  unreadTotal: number;
   loading: boolean;
   failed: boolean;
 }
@@ -26,28 +28,22 @@ const formatMessageDate = (value?: string | number) => {
   ).padStart(2, '0')}`;
 };
 
-function NotificationRow({ item }: { item: SecurityMessage }) {
-  const actionPath = safeMessageActionPath(item.actionPath);
-
+function NotificationRow({
+  item,
+  onOpen,
+}: {
+  item: SecurityMessage;
+  onOpen: (item: SecurityMessage) => void;
+}) {
   return (
     <button
       type="button"
-      onClick={() => history.push(actionPath || '/system/messages')}
+      onClick={() => onOpen(item)}
       className="group flex w-full items-start gap-2 border-0 bg-transparent py-3 text-left"
     >
-      <span
-        className={`mt-[7px] h-1 w-1 shrink-0 rounded-full ${
-          item.status === 'UNREAD' ? 'bg-[#ff3657]' : 'bg-[#d7d9de]'
-        }`}
-      />
+      <span className="mt-[7px] h-1 w-1 shrink-0 rounded-full bg-[#ff3657]" />
       <span className="min-w-0 flex-1">
-        <strong
-          className={`line-clamp-2 block text-[12px] leading-5 transition-colors group-hover:text-[#20232b] ${
-            item.status === 'UNREAD'
-              ? 'font-semibold text-[#353943]'
-              : 'font-normal text-[#555a64]'
-          }`}
-        >
+        <strong className="line-clamp-2 block text-[12px] font-semibold leading-5 text-[#353943] transition-colors group-hover:text-[#20232b]">
           {item.title}
         </strong>
         {item.summary ? (
@@ -67,7 +63,7 @@ export default function NotificationCenter() {
   const { projects, currentProject } = useSecurityProject();
   const [state, setState] = useState<NotificationState>({
     items: [],
-    total: 0,
+    unreadTotal: 0,
     loading: true,
     failed: false,
   });
@@ -78,37 +74,55 @@ export default function NotificationCenter() {
     // SecurityProjectProvider resolves the persisted/default workspace in a layout
     // effect. Avoid issuing an unscoped request while that selection is pending.
     if (projects.length > 0 && !currentProject) {
-      setState({ items: [], total: 0, loading: true, failed: false });
+      setState({ items: [], unreadTotal: 0, loading: true, failed: false });
       return () => {
         active = false;
       };
     }
 
-    setState({ items: [], total: 0, loading: true, failed: false });
+    setState({ items: [], unreadTotal: 0, loading: true, failed: false });
 
+    // Homepage notifications are attention-oriented: only unread messages are shown.
+    // With yak-framework #113, omitting projectId for a user without workspaces is
+    // fail-closed to SYSTEM messages; with an active workspace the backend returns
+    // SYSTEM + that PROJECT.
     pageMessages({
       pageNum: 1,
       pageSize: 3,
+      status: 'UNREAD',
       projectId: currentProject?.id,
     })
       .then((result) => {
         if (!active) return;
         setState({
           items: result.records || [],
-          total: result.total || 0,
+          unreadTotal: result.total || 0,
           loading: false,
           failed: false,
         });
       })
       .catch(() => {
         if (!active) return;
-        setState({ items: [], total: 0, loading: false, failed: true });
+        setState({ items: [], unreadTotal: 0, loading: false, failed: true });
       });
 
     return () => {
       active = false;
     };
   }, [currentProject?.id, projects.length]);
+
+  const openNotification = async (item: SecurityMessage) => {
+    const actionPath = safeMessageActionPath(item.actionPath) || '/system/messages';
+
+    try {
+      await markMessageRead(item.id);
+      notifyMessageCountChanged();
+    } catch {
+      // Reading a notification must never block the user from opening its target.
+    } finally {
+      history.push(actionPath);
+    }
+  };
 
   return (
     <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-5">
@@ -117,9 +131,9 @@ export default function NotificationCenter() {
           <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
             通知
           </h2>
-          {state.total > 0 ? (
-            <span className="rounded-full bg-[#f4f5f7] px-2 py-0.5 text-[10px] text-[#8e939c]">
-              {state.total}
+          {state.unreadTotal > 0 ? (
+            <span className="rounded-full bg-[#fff0f2] px-2 py-0.5 text-[10px] font-medium text-[#e33f5c]">
+              {state.unreadTotal}
             </span>
           ) : null}
         </div>
@@ -138,7 +152,7 @@ export default function NotificationCenter() {
         {state.items.length > 0 ? (
           <div className="divide-y divide-[#f0f1f3]">
             {state.items.map((item) => (
-              <NotificationRow key={item.id} item={item} />
+              <NotificationRow key={item.id} item={item} onOpen={openNotification} />
             ))}
           </div>
         ) : state.loading || state.failed ? (
@@ -148,7 +162,7 @@ export default function NotificationCenter() {
         ) : (
           <HomeEmptyState
             icon={Bell}
-            title="暂无通知"
+            title="暂无未读通知"
             size="small"
             className="min-h-[126px]"
           />

--- a/yak-ops-ui/src/pages/system/messages/MessageList.tsx
+++ b/yak-ops-ui/src/pages/system/messages/MessageList.tsx
@@ -1,4 +1,5 @@
 import { SecurityQueryTable } from '@/components/security';
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
 import {
   batchReadMessages,
   getMessageDetail,
@@ -6,6 +7,7 @@ import {
   type MessageLevel,
   type MessageStatus,
   markMessageRead,
+  notifyMessageCountChanged,
   pageMessages,
   safeMessageActionPath,
   type SecurityMessage,
@@ -15,9 +17,7 @@ import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { history, useModel } from '@umijs/max';
 import { Alert, Button, Drawer, message, Space, Tag, Typography } from 'antd';
 import dayjs from 'dayjs';
-import { useRef, useState } from 'react';
-
-export const MESSAGE_COUNT_CHANGED_EVENT = 'yak-message-count-changed';
+import { useMemo, useRef, useState } from 'react';
 
 const MESSAGE_TYPE_LABELS: Record<string, string> = {
   SYSTEM: '系统',
@@ -40,9 +40,6 @@ const MESSAGE_LEVEL_COLORS: Record<MessageLevel, string> = {
   ERROR: 'red',
 };
 
-const notifyCountChanged = () =>
-  window.dispatchEvent(new Event(MESSAGE_COUNT_CHANGED_EVENT));
-
 const messageTypeLabel = (value?: string) =>
   (value && MESSAGE_TYPE_LABELS[value]) || value || '消息';
 
@@ -64,6 +61,7 @@ const operationLogIdOf = (item?: SecurityMessage) =>
 export default function MessageList({ compact = false }: { compact?: boolean }) {
   const actionRef = useRef<ActionType>();
   const { initialState } = useModel('@@initialState');
+  const { projects } = useSecurityProject();
   const canReadLogs = satisfiesPermissionRequirement(
     initialState?.currentUser?.permissionCodes,
     {
@@ -74,10 +72,26 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
   const [selected, setSelected] = useState<Array<number | string>>([]);
   const [detail, setDetail] = useState<MessageDetail>();
 
+  const projectNameById = useMemo(
+    () =>
+      new Map(
+        projects.map((project) => [String(project.id), project.projectName]),
+      ),
+    [projects],
+  );
+
+  // Project ownership follows projectId, matching the hardened backend security
+  // boundary. scope remains presentation metadata and is not trusted for ownership.
+  const ownershipLabel = (item?: SecurityMessage) => {
+    if (item?.projectId === undefined || item.projectId === null) return '系统';
+    const projectName = projectNameById.get(String(item.projectId));
+    return projectName ? `项目 · ${projectName}` : `项目 #${item.projectId}`;
+  };
+
   const read = async (row: SecurityMessage) => {
     if (row.status === 'UNREAD') {
       await markMessageRead(row.id);
-      notifyCountChanged();
+      notifyMessageCountChanged();
       actionRef.current?.reload();
     }
     setDetail(await getMessageDetail(row.id));
@@ -110,6 +124,12 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
         QUALITY: { text: '质量' },
       },
       render: (_, row) => messageTypeLabel(row.type),
+    },
+    {
+      title: '范围',
+      dataIndex: 'scope',
+      search: false,
+      render: (_, row) => <Tag>{ownershipLabel(row)}</Tag>,
     },
     {
       title: '状态',
@@ -162,7 +182,9 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
           compact
             ? columns.filter(
                 (column) =>
-                  column.dataIndex !== 'summary' && column.dataIndex !== 'type',
+                  column.dataIndex !== 'summary' &&
+                  column.dataIndex !== 'type' &&
+                  column.dataIndex !== 'scope',
               )
             : columns
         }
@@ -200,7 +222,7 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
               await batchReadMessages(selected);
               setSelected([]);
               message.success('已标记为已读');
-              notifyCountChanged();
+              notifyMessageCountChanged();
               actionRef.current?.reload();
             }}
           >
@@ -225,13 +247,7 @@ export default function MessageList({ compact = false }: { compact?: boolean }) 
                   {MESSAGE_LEVEL_LABELS[detail.level]}
                 </Tag>
               ) : null}
-              {detail.scope ? (
-                <Tag>
-                  {detail.scope === 'PROJECT'
-                    ? `项目${detail.projectId ? ` #${detail.projectId}` : ''}`
-                    : '系统'}
-                </Tag>
-              ) : null}
+              <Tag>{ownershipLabel(detail)}</Tag>
               <Typography.Text type="secondary">
                 {formatMessageTime(detail.createTime)}
               </Typography.Text>

--- a/yak-ops-ui/src/pages/system/messages/MessageList.tsx
+++ b/yak-ops-ui/src/pages/system/messages/MessageList.tsx
@@ -19,6 +19,8 @@ import { Alert, Button, Drawer, message, Space, Tag, Typography } from 'antd';
 import dayjs from 'dayjs';
 import { useMemo, useRef, useState } from 'react';
 
+export { MESSAGE_COUNT_CHANGED_EVENT } from '@/services/security/messages';
+
 const MESSAGE_TYPE_LABELS: Record<string, string> = {
   SYSTEM: '系统',
   SECURITY: '安全',

--- a/yak-ops-ui/src/services/security/messages.test.ts
+++ b/yak-ops-ui/src/services/security/messages.test.ts
@@ -1,4 +1,9 @@
-import { buildMessageQuery, safeMessageActionPath } from './messages';
+import {
+  buildMessageQuery,
+  MESSAGE_COUNT_CHANGED_EVENT,
+  notifyMessageCountChanged,
+  safeMessageActionPath,
+} from './messages';
 
 describe('message center contract', () => {
   it('serializes project scope and epoch time filters', () => {
@@ -39,5 +44,15 @@ describe('message center contract', () => {
     );
     expect(safeMessageActionPath('https://example.com')).toBeUndefined();
     expect(safeMessageActionPath('//example.com/path')).toBeUndefined();
+  });
+
+  it('emits a shared unread-count refresh event', () => {
+    const listener = jest.fn();
+    window.addEventListener(MESSAGE_COUNT_CHANGED_EVENT, listener);
+
+    notifyMessageCountChanged();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(MESSAGE_COUNT_CHANGED_EVENT, listener);
   });
 });

--- a/yak-ops-ui/src/services/security/messages.ts
+++ b/yak-ops-ui/src/services/security/messages.ts
@@ -2,6 +2,8 @@ import { securityGetData, securityPostData } from './client';
 
 const MESSAGE_API = '/api/v1/message';
 
+export const MESSAGE_COUNT_CHANGED_EVENT = 'yak-message-count-changed';
+
 export type MessageStatus = 'UNREAD' | 'READ';
 export type MessageLevel = 'INFO' | 'SUCCESS' | 'WARNING' | 'ERROR';
 export type MessageScope = 'SYSTEM' | 'PROJECT';
@@ -41,7 +43,9 @@ export interface MessageQuery {
   status?: MessageStatus;
   type?: string;
   projectId?: number | string;
+  /** Unix epoch milliseconds; aligned with yak-framework message-center contract. */
   startTime?: number;
+  /** Unix epoch milliseconds; aligned with yak-framework message-center contract. */
   endTime?: number;
 }
 
@@ -61,6 +65,12 @@ export const safeMessageActionPath = (value?: string) => {
     return undefined;
   }
   return value;
+};
+
+/** Notify mounted message counters that read state has changed. */
+export const notifyMessageCountChanged = () => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(MESSAGE_COUNT_CHANGED_EVENT));
 };
 
 export const pageMessages = (params: MessageQuery) =>


### PR DESCRIPTION
## Summary

Follow-up client hardening for the Message Center integration introduced by #903.

This PR keeps the existing UI architecture and aligns Yak Ops with the hardened Project/message contract in `weifuwan/yak-framework#113` before real business notifications are published.

## Changes

### 1. Homepage becomes an unread attention inbox

The homepage notification card now queries:

```text
/page?pageNum=1&pageSize=3&status=UNREAD&projectId=<activeProject>
```

Semantics:

- active workspace: `SYSTEM + active PROJECT` unread messages
- no workspace: relies on framework #113 fail-closed inbox semantics, which reduce ordinary users to SYSTEM messages
- while `SecurityProjectProvider` is still resolving a persisted/default workspace, no transient unscoped request is issued

The badge next to `通知` is now the unread total returned by this filtered page, instead of lifetime message history count.

The empty state is correspondingly `暂无未读通知`.

### 2. Opening a homepage notification marks it read

Clicking a homepage row now:

1. calls `/mark-read`
2. broadcasts the shared message-count-changed event so the header bell refreshes
3. navigates to the safe internal `actionPath`, or `/system/messages` when no safe action is present

A mark-read failure never blocks navigation to the business target.

### 3. Message center shows workspace names

The full message center now resolves Project-owned notifications against `SecurityProjectContext.projectList`.

Instead of only showing:

```text
项目 #123
```

it prefers:

```text
项目 · 成都一院
```

and falls back to the numeric Project ID only when the workspace is no longer present in the current visible project list.

A `范围` column is added to the full message table. The compact header drawer keeps its previous density and hides this extra column.

Ownership presentation follows `projectId`, matching framework #113 where `project_id` is the security boundary; the legacy `scope` label is not trusted to determine ownership.

### 4. Keep epoch-millisecond contract explicit

`MessageQuery.startTime/endTime` remain numbers and are now documented explicitly as Unix epoch milliseconds, matching framework #113.

### 5. Centralize unread-count refresh events

`MESSAGE_COUNT_CHANGED_EVENT` and `notifyMessageCountChanged()` now live in the shared message service contract so homepage/message-list interactions use one refresh path.

The existing `MessageList` export is retained as a compatibility re-export for `SiteLayout`.

## Tests

- `NotificationCenter.test.tsx`
  - active Project query contains `status=UNREAD`
  - unread total drives the homepage badge
  - click marks read, refreshes counters, then navigates
  - zero-workspace request uses the hardened backend fallback
  - pending workspace resolution does not issue an unscoped request
- `messages.test.ts`
  - epoch-millisecond query serialization remains locked
  - shared unread-count event emission is covered

## Dependency

This PR depends on the hardened backend semantics in:

- `weifuwan/yak-framework#113`

In particular, the zero-workspace behavior assumes #113's rule that an ordinary user's unscoped inbox contains only SYSTEM messages plus currently authorized Projects; with no authorized Projects, only SYSTEM remains.

## Scope

Frontend only.

No backend API additions.
No business notification events.
No MQ/WebSocket changes.

## Validation status

- branch is based on current Yak Ops `main`
- compare is ahead-only / behind 0
- changes are limited to 5 message-center/home frontend files
- local Jest/TypeScript/browser execution is not available in this connector environment, so CI/local developer verification remains the build gate for this Draft PR
