### PR TITLE
feat(notification): publish high-value business failures

### DIFF
--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/notification/YakSecurityBusinessNotificationGateway.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/notification/YakSecurityBusinessNotificationGateway.java
@@ -35,21 +35,24 @@ public class YakSecurityBusinessNotificationGateway implements BusinessNotificat
   @Override
   public void publishToProjectOwners(BusinessNotification notification) {
     Objects.requireNonNull(notification, "notification");
-    Runnable delivery = () -> publishNow(notification);
-
-    if (TransactionSynchronizationManager.isSynchronizationActive()
-        && TransactionSynchronizationManager.isActualTransactionActive()) {
-      TransactionSynchronizationManager.registerSynchronization(
-          new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-              delivery.run();
-            }
-          });
-      return;
+    try {
+      Runnable delivery = () -> publishNow(notification);
+      if (TransactionSynchronizationManager.isSynchronizationActive()
+          && TransactionSynchronizationManager.isActualTransactionActive()) {
+        TransactionSynchronizationManager.registerSynchronization(
+            new TransactionSynchronization() {
+              @Override
+              public void afterCommit() {
+                delivery.run();
+              }
+            });
+        return;
+      }
+      delivery.run();
+    } catch (RuntimeException exception) {
+      // Even transaction-synchronization failures are secondary notification failures.
+      logFailure(notification, exception);
     }
-
-    delivery.run();
   }
 
   private void publishNow(BusinessNotification notification) {
@@ -64,10 +67,12 @@ public class YakSecurityBusinessNotificationGateway implements BusinessNotificat
         return;
       }
 
-      List<Long> ownerIds =
-          userProjectService
-              .getUserIdListByProjectId(notification.projectId(), ProjectUserCode.OWNER)
-              .stream()
+      List<Long> resolvedOwnerIds =
+          userProjectService.getUserIdListByProjectId(
+              notification.projectId(), ProjectUserCode.OWNER);
+      List<Long> ownerIds = resolvedOwnerIds == null
+          ? List.of()
+          : resolvedOwnerIds.stream()
               .filter(Objects::nonNull)
               .filter(userId -> userId > 0L)
               .distinct()
@@ -86,13 +91,19 @@ public class YakSecurityBusinessNotificationGateway implements BusinessNotificat
     } catch (RuntimeException exception) {
       // Notification delivery is deliberately best-effort. It must never turn a successful
       // business state transition into a failed sync/workflow/quality execution.
-      LOGGER.error(
-          "Business notification delivery failed: projectId={}, sourceType={}, sourceId={}",
-          notification.projectId(),
-          notification.sourceType(),
-          notification.sourceId(),
-          exception);
+      logFailure(notification, exception);
     }
+  }
+
+  private void logFailure(
+      BusinessNotification notification,
+      RuntimeException exception) {
+    LOGGER.error(
+        "Business notification delivery failed: projectId={}, sourceType={}, sourceId={}",
+        notification.projectId(),
+        notification.sourceType(),
+        notification.sourceId(),
+        exception);
   }
 
   private MessageDTO toMessage(BusinessNotification notification, Long userId) {

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/notification/YakSecurityBusinessNotificationGateway.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/notification/YakSecurityBusinessNotificationGateway.java
@@ -1,0 +1,112 @@
+package io.yak.ops.boot.notification;
+
+import io.yak.framework.security.common.dto.message.MessageDTO;
+import io.yak.framework.security.common.enums.project.ProjectUserCode;
+import io.yak.framework.security.notification.NotificationPublisher;
+import io.yak.framework.security.service.UserProjectService;
+import io.yak.ops.core.notification.BusinessNotification;
+import io.yak.ops.core.notification.BusinessNotificationGateway;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/** Yak Ops business-notification adapter backed by Yak Security's Message Center. */
+@Component
+public class YakSecurityBusinessNotificationGateway implements BusinessNotificationGateway {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(YakSecurityBusinessNotificationGateway.class);
+
+  private final ObjectProvider<UserProjectService> userProjectServices;
+  private final ObjectProvider<NotificationPublisher> notificationPublishers;
+
+  public YakSecurityBusinessNotificationGateway(
+      ObjectProvider<UserProjectService> userProjectServices,
+      ObjectProvider<NotificationPublisher> notificationPublishers) {
+    this.userProjectServices = userProjectServices;
+    this.notificationPublishers = notificationPublishers;
+  }
+
+  @Override
+  public void publishToProjectOwners(BusinessNotification notification) {
+    Objects.requireNonNull(notification, "notification");
+    Runnable delivery = () -> publishNow(notification);
+
+    if (TransactionSynchronizationManager.isSynchronizationActive()
+        && TransactionSynchronizationManager.isActualTransactionActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              delivery.run();
+            }
+          });
+      return;
+    }
+
+    delivery.run();
+  }
+
+  private void publishNow(BusinessNotification notification) {
+    try {
+      UserProjectService userProjectService = userProjectServices.getIfAvailable();
+      NotificationPublisher notificationPublisher = notificationPublishers.getIfAvailable();
+      if (userProjectService == null || notificationPublisher == null) {
+        LOGGER.debug(
+            "Business notification skipped because Yak Security notification infrastructure is unavailable: sourceType={}, sourceId={}",
+            notification.sourceType(),
+            notification.sourceId());
+        return;
+      }
+
+      List<Long> ownerIds =
+          userProjectService
+              .getUserIdListByProjectId(notification.projectId(), ProjectUserCode.OWNER)
+              .stream()
+              .filter(Objects::nonNull)
+              .filter(userId -> userId > 0L)
+              .distinct()
+              .toList();
+      if (ownerIds.isEmpty()) {
+        LOGGER.debug(
+            "Business notification skipped because Project has no owner: projectId={}, sourceType={}, sourceId={}",
+            notification.projectId(),
+            notification.sourceType(),
+            notification.sourceId());
+        return;
+      }
+
+      notificationPublisher.publishAll(
+          ownerIds.stream().map(userId -> toMessage(notification, userId)).toList());
+    } catch (RuntimeException exception) {
+      // Notification delivery is deliberately best-effort. It must never turn a successful
+      // business state transition into a failed sync/workflow/quality execution.
+      LOGGER.error(
+          "Business notification delivery failed: projectId={}, sourceType={}, sourceId={}",
+          notification.projectId(),
+          notification.sourceType(),
+          notification.sourceId(),
+          exception);
+    }
+  }
+
+  private MessageDTO toMessage(BusinessNotification notification, Long userId) {
+    MessageDTO message = new MessageDTO();
+    message.setUserId(userId);
+    message.setProjectId(notification.projectId());
+    message.setType(notification.type().name());
+    message.setLevel(notification.level().name());
+    message.setTitle(notification.title());
+    message.setSummary(notification.summary());
+    message.setContent(notification.content());
+    message.setSourceType(notification.sourceType());
+    message.setSourceId(notification.sourceId());
+    message.setActionPath(notification.actionPath());
+    return message;
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/notification/YakSecurityBusinessNotificationGatewayTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/notification/YakSecurityBusinessNotificationGatewayTest.java
@@ -1,0 +1,127 @@
+package io.yak.ops.boot.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.security.common.dto.message.MessageDTO;
+import io.yak.framework.security.common.enums.project.ProjectUserCode;
+import io.yak.framework.security.notification.NotificationPublisher;
+import io.yak.framework.security.service.UserProjectService;
+import io.yak.ops.core.notification.BusinessNotification;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+class YakSecurityBusinessNotificationGatewayTest {
+
+  @AfterEach
+  void clearTransactionSynchronization() {
+    TransactionSynchronizationManager.setActualTransactionActive(false);
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void sendsOneProjectOwnedMessageToEachDistinctOwner() {
+    UserProjectService projects = mock(UserProjectService.class);
+    NotificationPublisher publisher = mock(NotificationPublisher.class);
+    ObjectProvider<UserProjectService> projectProvider = mock(ObjectProvider.class);
+    ObjectProvider<NotificationPublisher> publisherProvider = mock(ObjectProvider.class);
+    when(projectProvider.getIfAvailable()).thenReturn(projects);
+    when(publisherProvider.getIfAvailable()).thenReturn(publisher);
+    when(projects.getUserIdListByProjectId(7L, ProjectUserCode.OWNER))
+        .thenReturn(List.of(11L, 12L, 11L));
+
+    YakSecurityBusinessNotificationGateway gateway =
+        new YakSecurityBusinessNotificationGateway(projectProvider, publisherProvider);
+    gateway.publishToProjectOwners(notification());
+
+    ArgumentCaptor<List<MessageDTO>> captor = ArgumentCaptor.forClass(List.class);
+    verify(publisher).publishAll(captor.capture());
+    assertThat(captor.getValue()).hasSize(2);
+    assertThat(captor.getValue()).extracting(MessageDTO::getUserId)
+        .containsExactly(11L, 12L);
+    assertThat(captor.getValue()).allSatisfy(message -> {
+      assertThat(message.getProjectId()).isEqualTo(7L);
+      assertThat(message.getType()).isEqualTo("TASK");
+      assertThat(message.getLevel()).isEqualTo("ERROR");
+      assertThat(message.getSourceType()).isEqualTo("OFFLINE_SYNC_EXECUTION");
+      assertThat(message.getActionPath()).isEqualTo("/sync/batch-link-up/10/detail");
+    });
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void defersDeliveryUntilTheBusinessTransactionCommits() {
+    UserProjectService projects = mock(UserProjectService.class);
+    NotificationPublisher publisher = mock(NotificationPublisher.class);
+    ObjectProvider<UserProjectService> projectProvider = mock(ObjectProvider.class);
+    ObjectProvider<NotificationPublisher> publisherProvider = mock(ObjectProvider.class);
+    when(projectProvider.getIfAvailable()).thenReturn(projects);
+    when(publisherProvider.getIfAvailable()).thenReturn(publisher);
+    when(projects.getUserIdListByProjectId(7L, ProjectUserCode.OWNER))
+        .thenReturn(List.of(11L));
+
+    TransactionSynchronizationManager.initSynchronization();
+    TransactionSynchronizationManager.setActualTransactionActive(true);
+
+    YakSecurityBusinessNotificationGateway gateway =
+        new YakSecurityBusinessNotificationGateway(projectProvider, publisherProvider);
+    gateway.publishToProjectOwners(notification());
+
+    verify(publisher, never()).publishAll(anyList());
+    List<TransactionSynchronization> synchronizations =
+        TransactionSynchronizationManager.getSynchronizations();
+    assertThat(synchronizations).hasSize(1);
+
+    synchronizations.get(0).afterCommit();
+
+    verify(publisher).publishAll(anyList());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void deliveryFailureNeverEscapesIntoTheBusinessFlow() {
+    UserProjectService projects = mock(UserProjectService.class);
+    NotificationPublisher publisher = mock(NotificationPublisher.class);
+    ObjectProvider<UserProjectService> projectProvider = mock(ObjectProvider.class);
+    ObjectProvider<NotificationPublisher> publisherProvider = mock(ObjectProvider.class);
+    when(projectProvider.getIfAvailable()).thenReturn(projects);
+    when(publisherProvider.getIfAvailable()).thenReturn(publisher);
+    when(projects.getUserIdListByProjectId(7L, ProjectUserCode.OWNER))
+        .thenReturn(List.of(11L));
+    doThrow(new IllegalStateException("message store unavailable"))
+        .when(publisher).publishAll(anyList());
+
+    YakSecurityBusinessNotificationGateway gateway =
+        new YakSecurityBusinessNotificationGateway(projectProvider, publisherProvider);
+
+    assertThatCode(() -> gateway.publishToProjectOwners(notification()))
+        .doesNotThrowAnyException();
+  }
+
+  private BusinessNotification notification() {
+    return new BusinessNotification(
+        7L,
+        BusinessNotification.Type.TASK,
+        BusinessNotification.Level.ERROR,
+        "离线同步任务执行失败",
+        "订单同步",
+        "engine down",
+        "OFFLINE_SYNC_EXECUTION",
+        "99",
+        "/sync/batch-link-up/10/detail");
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
@@ -6,10 +6,14 @@ import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan;
 import io.yak.ops.business.quality.repository.QualityAlertRepository;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
 import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
+import io.yak.ops.core.notification.BusinessNotification;
+import io.yak.ops.core.notification.BusinessNotificationGateway;
 import java.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /** Records alert evidence when an execution result requires notification. */
 @Component
@@ -17,9 +21,25 @@ import org.springframework.stereotype.Component;
 public class QualityAlertRecorder {
   private static final Logger LOGGER = LoggerFactory.getLogger(QualityAlertRecorder.class);
   private final QualityAlertRepository repository;
+  private final BusinessNotificationGateway notificationGateway;
 
+  @org.springframework.beans.factory.annotation.Autowired
+  public QualityAlertRecorder(
+      QualityAlertRepository repository,
+      ObjectProvider<BusinessNotificationGateway> notificationGateways) {
+    this(repository, notificationGateways.getIfAvailable());
+  }
+
+  /** Focused tests retain the lightweight constructor. */
   public QualityAlertRecorder(QualityAlertRepository repository) {
+    this(repository, null);
+  }
+
+  private QualityAlertRecorder(
+      QualityAlertRepository repository,
+      BusinessNotificationGateway notificationGateway) {
     this.repository = repository;
+    this.notificationGateway = notificationGateway;
   }
 
   public void recordIfNecessary(
@@ -42,6 +62,9 @@ public class QualityAlertRecorder {
       repository.insertAlertEvent(new AlertEventSpec(
           plan.monitor().id(), plan.executionNo(), result, plan.alertLevel(), plan.notifyChannel(),
           target, status, message, null, LocalDateTime.now()));
+      if (plan.notifyChannel() == NotifyChannel.MESSAGE) {
+        publishMessageNotification(plan, result, message);
+      }
       LOGGER.warn(
           "Quality alert recorded: monitor={}, execution={}, result={}, channel={}, target={}",
           plan.monitor().id(), plan.executionNo(), result, plan.notifyChannel(), target);
@@ -49,6 +72,41 @@ public class QualityAlertRecorder {
       LOGGER.error(
           "Failed to record quality alert for monitor {} and execution {}",
           plan.monitor().id(), plan.executionNo(), exception);
+    }
+  }
+
+  private void publishMessageNotification(
+      QualityExecutionPlan plan,
+      CheckResult result,
+      String message) {
+    if (notificationGateway == null) return;
+    try {
+      boolean error = result == CheckResult.ERROR;
+      String monitorName = StringUtils.hasText(plan.monitor().name())
+          ? plan.monitor().name().trim()
+          : "质量监控 #" + plan.monitor().id();
+      String table = StringUtils.hasText(plan.monitor().tableName())
+          ? plan.monitor().tableName().trim()
+          : null;
+      String summary = table == null ? monitorName : monitorName + " · " + table;
+
+      notificationGateway.publishToProjectOwners(
+          new BusinessNotification(
+              plan.projectId(),
+              BusinessNotification.Type.QUALITY,
+              error ? BusinessNotification.Level.ERROR : BusinessNotification.Level.WARNING,
+              error ? "数据质量执行异常" : "数据质量检查发现问题",
+              summary,
+              message,
+              "DATA_QUALITY_EXECUTION",
+              plan.executionNo(),
+              "/data-quality/execution/" + plan.executionNo()));
+    } catch (RuntimeException exception) {
+      LOGGER.error(
+          "Failed to publish quality Message Center notification: monitor={}, execution={}",
+          plan.monitor().id(),
+          plan.executionNo(),
+          exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.domain.QualityDomain.AlertEventSpec;
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan;
 import io.yak.ops.business.quality.repository.QualityAlertRepository;
+import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
 import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
 import io.yak.ops.core.notification.BusinessNotification;
@@ -81,7 +82,7 @@ public class QualityAlertRecorder {
       String message) {
     if (notificationGateway == null) return;
     try {
-      boolean error = result == CheckResult.ERROR;
+      boolean error = result == CheckResult.ERROR || plan.alertLevel() == AlertLevel.CRITICAL;
       String monitorName = StringUtils.hasText(plan.monitor().name())
           ? plan.monitor().name().trim()
           : "质量监控 #" + plan.monitor().id();
@@ -89,13 +90,16 @@ public class QualityAlertRecorder {
           ? plan.monitor().tableName().trim()
           : null;
       String summary = table == null ? monitorName : monitorName + " · " + table;
+      String title = result == CheckResult.ERROR
+          ? "数据质量执行异常"
+          : error ? "数据质量检查发现严重问题" : "数据质量检查发现问题";
 
       notificationGateway.publishToProjectOwners(
           new BusinessNotification(
               plan.projectId(),
               BusinessNotification.Type.QUALITY,
               error ? BusinessNotification.Level.ERROR : BusinessNotification.Level.WARNING,
-              error ? "数据质量执行异常" : "数据质量检查发现问题",
+              title,
               summary,
               message,
               "DATA_QUALITY_EXECUTION",

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
@@ -49,23 +49,38 @@ public class QualityAlertRecorder {
       int passed,
       int failed,
       int errors) {
-    if (!plan.notifyEnabled()
-        || result == CheckResult.PASSED
+    if (result == CheckResult.PASSED
         || result == CheckResult.RUNNING
         || result == CheckResult.NOT_RUN) {
       return;
     }
+
+    boolean recordConfiguredAlert = plan.notifyEnabled();
+    boolean publishMessage = result == CheckResult.ERROR
+        || (plan.notifyEnabled() && plan.notifyChannel() == NotifyChannel.MESSAGE);
+    if (!recordConfiguredAlert && !publishMessage) return;
+
+    String message = "质量监控“" + plan.monitor().name() + "”执行结果为 " + result
+        + "，通过 " + passed + " 条，未通过 " + failed + " 条，异常 " + errors + " 条。";
+
+    if (recordConfiguredAlert) {
+      recordConfiguredAlert(plan, result, message);
+    }
+    if (publishMessage) {
+      publishMessageNotification(plan, result, message);
+    }
+  }
+
+  private void recordConfiguredAlert(
+      QualityExecutionPlan plan,
+      CheckResult result,
+      String message) {
     try {
       String target = normalizeTarget(plan);
       String status = plan.notifyChannel() == NotifyChannel.MESSAGE ? "RECORDED" : "PENDING";
-      String message = "质量监控“" + plan.monitor().name() + "”执行结果为 " + result
-          + "，通过 " + passed + " 条，未通过 " + failed + " 条，异常 " + errors + " 条。";
       repository.insertAlertEvent(new AlertEventSpec(
           plan.monitor().id(), plan.executionNo(), result, plan.alertLevel(), plan.notifyChannel(),
           target, status, message, null, LocalDateTime.now()));
-      if (plan.notifyChannel() == NotifyChannel.MESSAGE) {
-        publishMessageNotification(plan, result, message);
-      }
       LOGGER.warn(
           "Quality alert recorded: monitor={}, execution={}, result={}, channel={}, target={}",
           plan.monitor().id(), plan.executionNo(), result, plan.notifyChannel(), target);

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/alert/QualityAlertRecorderNotificationTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/alert/QualityAlertRecorderNotificationTest.java
@@ -32,7 +32,12 @@ class QualityAlertRecorderNotificationTest {
     when(provider.getIfAvailable()).thenReturn(gateway);
 
     QualityAlertRecorder recorder = new QualityAlertRecorder(repository, provider);
-    recorder.recordIfNecessary(plan(NotifyChannel.MESSAGE), CheckResult.NOT_PASSED, 8, 2, 0);
+    recorder.recordIfNecessary(
+        plan(true, NotifyChannel.MESSAGE, AlertLevel.WARNING),
+        CheckResult.NOT_PASSED,
+        8,
+        2,
+        0);
 
     verify(repository).insertAlertEvent(any());
     ArgumentCaptor<BusinessNotification> captor =
@@ -51,20 +56,75 @@ class QualityAlertRecorderNotificationTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  void nonMessageChannelKeepsAlertEvidenceWithoutMessageCenterDelivery() {
+  void configuredNonMessageProblemKeepsAlertEvidenceWithoutInboxDelivery() {
     QualityAlertRepository repository = mock(QualityAlertRepository.class);
     BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
     ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
     when(provider.getIfAvailable()).thenReturn(gateway);
 
     QualityAlertRecorder recorder = new QualityAlertRecorder(repository, provider);
-    recorder.recordIfNecessary(plan(NotifyChannel.EMAIL), CheckResult.ERROR, 0, 0, 1);
+    recorder.recordIfNecessary(
+        plan(true, NotifyChannel.EMAIL, AlertLevel.WARNING),
+        CheckResult.NOT_PASSED,
+        8,
+        2,
+        0);
 
     verify(repository).insertAlertEvent(any());
     verify(gateway, never()).publishToProjectOwners(any());
   }
 
-  private QualityExecutionPlan plan(NotifyChannel channel) {
+  @Test
+  @SuppressWarnings("unchecked")
+  void executionErrorAlwaysSurfacesInInboxEvenWhenConfiguredAlertsAreDisabled() {
+    QualityAlertRepository repository = mock(QualityAlertRepository.class);
+    BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
+    ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(gateway);
+
+    QualityAlertRecorder recorder = new QualityAlertRecorder(repository, provider);
+    recorder.recordIfNecessary(
+        plan(false, NotifyChannel.EMAIL, AlertLevel.WARNING),
+        CheckResult.ERROR,
+        0,
+        0,
+        1);
+
+    verify(repository, never()).insertAlertEvent(any());
+    ArgumentCaptor<BusinessNotification> captor =
+        ArgumentCaptor.forClass(BusinessNotification.class);
+    verify(gateway).publishToProjectOwners(captor.capture());
+    assertThat(captor.getValue().level()).isEqualTo(BusinessNotification.Level.ERROR);
+    assertThat(captor.getValue().title()).isEqualTo("数据质量执行异常");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void criticalQualityProblemUsesErrorSeverity() {
+    QualityAlertRepository repository = mock(QualityAlertRepository.class);
+    BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
+    ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(gateway);
+
+    QualityAlertRecorder recorder = new QualityAlertRecorder(repository, provider);
+    recorder.recordIfNecessary(
+        plan(true, NotifyChannel.MESSAGE, AlertLevel.CRITICAL),
+        CheckResult.NOT_PASSED,
+        5,
+        5,
+        0);
+
+    ArgumentCaptor<BusinessNotification> captor =
+        ArgumentCaptor.forClass(BusinessNotification.class);
+    verify(gateway).publishToProjectOwners(captor.capture());
+    assertThat(captor.getValue().level()).isEqualTo(BusinessNotification.Level.ERROR);
+    assertThat(captor.getValue().title()).isEqualTo("数据质量检查发现严重问题");
+  }
+
+  private QualityExecutionPlan plan(
+      boolean notifyEnabled,
+      NotifyChannel channel,
+      AlertLevel alertLevel) {
     return new QualityExecutionPlan(
         7L,
         101L,
@@ -81,9 +141,9 @@ class QualityAlertRecorderNotificationTest {
             "alice"),
         List.of(),
         RuleFailureAction.CONTINUE,
-        true,
+        notifyEnabled,
         channel,
         null,
-        AlertLevel.WARNING);
+        alertLevel);
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/alert/QualityAlertRecorderNotificationTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/alert/QualityAlertRecorderNotificationTest.java
@@ -1,0 +1,89 @@
+package io.yak.ops.business.quality.alert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
+import io.yak.ops.business.quality.repository.QualityAlertRepository;
+import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
+import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
+import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
+import io.yak.ops.core.notification.BusinessNotification;
+import io.yak.ops.core.notification.BusinessNotificationGateway;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+class QualityAlertRecorderNotificationTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void messageChannelPublishesQualityWarningToProjectOwners() {
+    QualityAlertRepository repository = mock(QualityAlertRepository.class);
+    BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
+    ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(gateway);
+
+    QualityAlertRecorder recorder = new QualityAlertRecorder(repository, provider);
+    recorder.recordIfNecessary(plan(NotifyChannel.MESSAGE), CheckResult.NOT_PASSED, 8, 2, 0);
+
+    verify(repository).insertAlertEvent(any());
+    ArgumentCaptor<BusinessNotification> captor =
+        ArgumentCaptor.forClass(BusinessNotification.class);
+    verify(gateway).publishToProjectOwners(captor.capture());
+    BusinessNotification notification = captor.getValue();
+    assertThat(notification.projectId()).isEqualTo(7L);
+    assertThat(notification.type()).isEqualTo(BusinessNotification.Type.QUALITY);
+    assertThat(notification.level()).isEqualTo(BusinessNotification.Level.WARNING);
+    assertThat(notification.title()).isEqualTo("数据质量检查发现问题");
+    assertThat(notification.sourceType()).isEqualTo("DATA_QUALITY_EXECUTION");
+    assertThat(notification.sourceId()).isEqualTo("Q-20260831-001");
+    assertThat(notification.actionPath())
+        .isEqualTo("/data-quality/execution/Q-20260831-001");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void nonMessageChannelKeepsAlertEvidenceWithoutMessageCenterDelivery() {
+    QualityAlertRepository repository = mock(QualityAlertRepository.class);
+    BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
+    ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(gateway);
+
+    QualityAlertRecorder recorder = new QualityAlertRecorder(repository, provider);
+    recorder.recordIfNecessary(plan(NotifyChannel.EMAIL), CheckResult.ERROR, 0, 0, 1);
+
+    verify(repository).insertAlertEvent(any());
+    verify(gateway, never()).publishToProjectOwners(any());
+  }
+
+  private QualityExecutionPlan plan(NotifyChannel channel) {
+    return new QualityExecutionPlan(
+        7L,
+        101L,
+        "Q-20260831-001",
+        new MonitorSnapshot(
+            21L,
+            "订单完整性检查",
+            31L,
+            "warehouse",
+            "dwd",
+            "public",
+            "dwd_order",
+            null,
+            "alice"),
+        List.of(),
+        RuleFailureAction.CONTINUE,
+        true,
+        channel,
+        null,
+        AlertLevel.WARNING);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionFinalFailureEvent.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineExecutionFinalFailureEvent.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.sync.offline.domain;
+
+/** Emitted after an Offline Sync attempt first enters FAILED with no retry scheduled. */
+public record OfflineExecutionFinalFailureEvent(
+    Long executionId,
+    Long jobDefinitionId,
+    String errorMessage) {
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFailureNotificationListener.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFailureNotificationListener.java
@@ -9,9 +9,8 @@ import io.yak.ops.core.notification.BusinessNotificationGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.util.StringUtils;
 
 /** Converts final Offline Sync failures into user-facing Project notifications. */
@@ -32,7 +31,7 @@ public class OfflineFailureNotificationListener {
     this.notificationGateways = notificationGateways;
   }
 
-  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  @EventListener
   public void onFinalFailure(OfflineExecutionFinalFailureEvent event) {
     BusinessNotificationGateway gateway = notificationGateways.getIfAvailable();
     if (gateway == null || event == null || event.jobDefinitionId() == null) return;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFailureNotificationListener.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFailureNotificationListener.java
@@ -1,0 +1,86 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionFinalFailureEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.core.notification.BusinessNotification;
+import io.yak.ops.core.notification.BusinessNotificationGateway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.util.StringUtils;
+
+/** Converts final Offline Sync failures into user-facing Project notifications. */
+@Component
+@ConditionalOnOfflineSyncEnabled
+public class OfflineFailureNotificationListener {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(OfflineFailureNotificationListener.class);
+
+  private final OfflineJobDefinitionRepository definitionRepository;
+  private final ObjectProvider<BusinessNotificationGateway> notificationGateways;
+
+  public OfflineFailureNotificationListener(
+      OfflineJobDefinitionRepository definitionRepository,
+      ObjectProvider<BusinessNotificationGateway> notificationGateways) {
+    this.definitionRepository = definitionRepository;
+    this.notificationGateways = notificationGateways;
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  public void onFinalFailure(OfflineExecutionFinalFailureEvent event) {
+    BusinessNotificationGateway gateway = notificationGateways.getIfAvailable();
+    if (gateway == null || event == null || event.jobDefinitionId() == null) return;
+
+    try {
+      OfflineJobDefinition definition =
+          definitionRepository.findById(event.jobDefinitionId()).orElse(null);
+      if (definition == null) return;
+
+      String taskName = StringUtils.hasText(definition.getJobName())
+          ? definition.getJobName().trim()
+          : "离线同步任务 #" + definition.getId();
+      String relation = relation(definition);
+      String summary = relation == null ? taskName : taskName + " · " + relation;
+      String content = StringUtils.hasText(event.errorMessage())
+          ? event.errorMessage().trim()
+          : "离线同步执行失败，且当前重试策略已没有后续重试，请查看任务详情。";
+
+      gateway.publishToProjectOwners(
+          new BusinessNotification(
+              definition.requireProjectId(),
+              BusinessNotification.Type.TASK,
+              BusinessNotification.Level.ERROR,
+              "离线同步任务执行失败",
+              summary,
+              content,
+              "OFFLINE_SYNC_EXECUTION",
+              String.valueOf(event.executionId()),
+              "/sync/batch-link-up/" + definition.getId() + "/detail"));
+    } catch (RuntimeException exception) {
+      LOGGER.error(
+          "Failed to publish Offline Sync failure notification: execution={}, definition={}",
+          event.executionId(),
+          event.jobDefinitionId(),
+          exception);
+    }
+  }
+
+  private String relation(OfflineJobDefinition definition) {
+    String source = StringUtils.hasText(definition.getSourceTable())
+        ? definition.getSourceTable().trim()
+        : null;
+    String sink = StringUtils.hasText(definition.getSinkTable())
+        ? definition.getSinkTable().trim()
+        : null;
+    if (source == null && sink == null) return null;
+    if (source == null) return sink;
+    if (sink == null) return source;
+    return source + " → " + sink;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapter.java
@@ -3,30 +3,50 @@ package io.yak.ops.business.sync.offline.repository;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionFinalFailureEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.common.bean.po.sync.offline.OfflineExecutionEventPO;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Repository;
 
 /** 执行事件 PO 与领域模型之间的持久化适配器；Project 从所属 Execution 继承。 */
 @ConditionalOnOfflineSyncEnabled
 @Repository
-@RequiredArgsConstructor
 public class OfflineExecutionEventRepositoryAdapter implements OfflineExecutionEventRepository {
   private final OfflineExecutionEventDao dao;
   private final OfflineJobExecutionRepository executionRepository;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public OfflineExecutionEventRepositoryAdapter(
+      OfflineExecutionEventDao dao,
+      OfflineJobExecutionRepository executionRepository,
+      ApplicationEventPublisher eventPublisher) {
+    this.dao = dao;
+    this.executionRepository = executionRepository;
+    this.eventPublisher = eventPublisher;
+  }
+
+  /** Focused repository tests can retain the pre-notification constructor. */
+  public OfflineExecutionEventRepositoryAdapter(
+      OfflineExecutionEventDao dao,
+      OfflineJobExecutionRepository executionRepository) {
+    this(dao, executionRepository, event -> {});
+  }
 
   @Override
   public void append(OfflineExecutionEvent event) {
     if (event == null || event.getExecutionId() == null) {
       throw new IllegalArgumentException("执行事件缺少 executionId");
     }
-    requireExecution(event.getExecutionId());
+    OfflineJobExecution execution = requireExecution(event.getExecutionId());
     OfflineExecutionEventPO po = new OfflineExecutionEventPO();
     BeanUtils.copyProperties(event, po);
     if (!dao.insert(po)) throw new IllegalStateException("记录离线同步执行事件失败");
     event.setId(po.getId());
+    publishFinalFailure(event, execution);
   }
 
   @Override
@@ -43,12 +63,27 @@ public class OfflineExecutionEventRepositoryAdapter implements OfflineExecutionE
     return dao.selectAfter(executionId, afterId, limit).stream().map(this::toDomain).toList();
   }
 
-  private void requireExecution(Long executionId) {
+  private OfflineJobExecution requireExecution(Long executionId) {
     if (executionId == null || executionId <= 0L) {
       throw new IllegalArgumentException("executionId 必须大于 0");
     }
-    executionRepository.findById(executionId)
+    return executionRepository.findById(executionId)
         .orElseThrow(() -> new IllegalArgumentException("离线同步执行实例不存在：" + executionId));
+  }
+
+  private void publishFinalFailure(
+      OfflineExecutionEvent event,
+      OfflineJobExecution execution) {
+    if (!"FAILED".equalsIgnoreCase(event.getToStatus())
+        || "FAILED".equalsIgnoreCase(event.getFromStatus())
+        || execution.getNextRetryTime() != null) {
+      return;
+    }
+    eventPublisher.publishEvent(
+        new OfflineExecutionFinalFailureEvent(
+            execution.getId(),
+            execution.getJobDefinitionId(),
+            execution.getErrorMessage()));
   }
 
   private OfflineExecutionEvent toDomain(OfflineExecutionEventPO po) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineFailureNotificationListenerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineFailureNotificationListenerTest.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionFinalFailureEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.core.notification.BusinessNotification;
+import io.yak.ops.core.notification.BusinessNotificationGateway;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+class OfflineFailureNotificationListenerTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void publishesActionableFailureToProjectOwners() {
+    OfflineJobDefinitionRepository definitions = mock(OfflineJobDefinitionRepository.class);
+    BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
+    ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(gateway);
+
+    OfflineJobDefinition definition = new OfflineJobDefinition();
+    definition.setId(10L);
+    definition.setProjectId(7L);
+    definition.setJobName("订单离线同步");
+    definition.setSourceTable("ods_order");
+    definition.setSinkTable("dwd_order");
+    when(definitions.findById(10L)).thenReturn(Optional.of(definition));
+
+    OfflineFailureNotificationListener listener =
+        new OfflineFailureNotificationListener(definitions, provider);
+    listener.onFinalFailure(new OfflineExecutionFinalFailureEvent(99L, 10L, "engine down"));
+
+    ArgumentCaptor<BusinessNotification> captor =
+        ArgumentCaptor.forClass(BusinessNotification.class);
+    verify(gateway).publishToProjectOwners(captor.capture());
+    BusinessNotification notification = captor.getValue();
+    assertThat(notification.projectId()).isEqualTo(7L);
+    assertThat(notification.type()).isEqualTo(BusinessNotification.Type.TASK);
+    assertThat(notification.level()).isEqualTo(BusinessNotification.Level.ERROR);
+    assertThat(notification.summary()).contains("订单离线同步", "ods_order", "dwd_order");
+    assertThat(notification.content()).isEqualTo("engine down");
+    assertThat(notification.sourceType()).isEqualTo("OFFLINE_SYNC_EXECUTION");
+    assertThat(notification.sourceId()).isEqualTo("99");
+    assertThat(notification.actionPath()).isEqualTo("/sync/batch-link-up/10/detail");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapterNotificationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapterNotificationTest.java
@@ -1,7 +1,7 @@
 package io.yak.ops.business.sync.offline.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -14,6 +14,7 @@ import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 
 class OfflineExecutionEventRepositoryAdapterNotificationTest {
@@ -32,11 +33,14 @@ class OfflineExecutionEventRepositoryAdapterNotificationTest {
         new OfflineExecutionEventRepositoryAdapter(dao, executions, publisher);
     repository.append(event("RUNNING", "FAILED"));
 
-    verify(publisher).publishEvent(argThat(value ->
-        value instanceof OfflineExecutionFinalFailureEvent failure
-            && failure.executionId().equals(99L)
-            && failure.jobDefinitionId().equals(10L)
-            && "engine down".equals(failure.errorMessage())));
+    ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+    verify(publisher).publishEvent(captor.capture());
+    assertThat(captor.getValue()).isInstanceOf(OfflineExecutionFinalFailureEvent.class);
+    OfflineExecutionFinalFailureEvent failure =
+        (OfflineExecutionFinalFailureEvent) captor.getValue();
+    assertThat(failure.executionId()).isEqualTo(99L);
+    assertThat(failure.jobDefinitionId()).isEqualTo(10L);
+    assertThat(failure.errorMessage()).isEqualTo("engine down");
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapterNotificationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineExecutionEventRepositoryAdapterNotificationTest.java
@@ -1,0 +1,93 @@
+package io.yak.ops.business.sync.offline.repository;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.sync.offline.dao.OfflineExecutionEventDao;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionFinalFailureEvent;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+class OfflineExecutionEventRepositoryAdapterNotificationTest {
+
+  @Test
+  void emitsFinalFailureOnlyWhenNoRetryIsScheduled() {
+    OfflineExecutionEventDao dao = mock(OfflineExecutionEventDao.class);
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+    when(dao.insert(any())).thenReturn(true);
+
+    OfflineJobExecution execution = execution();
+    when(executions.findById(99L)).thenReturn(Optional.of(execution));
+
+    OfflineExecutionEventRepositoryAdapter repository =
+        new OfflineExecutionEventRepositoryAdapter(dao, executions, publisher);
+    repository.append(event("RUNNING", "FAILED"));
+
+    verify(publisher).publishEvent(argThat(value ->
+        value instanceof OfflineExecutionFinalFailureEvent failure
+            && failure.executionId().equals(99L)
+            && failure.jobDefinitionId().equals(10L)
+            && "engine down".equals(failure.errorMessage())));
+  }
+
+  @Test
+  void retryableFailureDoesNotEmitUserNotificationSignal() {
+    OfflineExecutionEventDao dao = mock(OfflineExecutionEventDao.class);
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+    when(dao.insert(any())).thenReturn(true);
+
+    OfflineJobExecution execution = execution();
+    execution.setNextRetryTime(LocalDateTime.now().plusMinutes(1));
+    when(executions.findById(99L)).thenReturn(Optional.of(execution));
+
+    OfflineExecutionEventRepositoryAdapter repository =
+        new OfflineExecutionEventRepositoryAdapter(dao, executions, publisher);
+    repository.append(event("RUNNING", "FAILED"));
+
+    verify(publisher, never()).publishEvent(any(Object.class));
+  }
+
+  @Test
+  void repeatedFailedStateDoesNotEmitDuplicateSignal() {
+    OfflineExecutionEventDao dao = mock(OfflineExecutionEventDao.class);
+    OfflineJobExecutionRepository executions = mock(OfflineJobExecutionRepository.class);
+    ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+    when(dao.insert(any())).thenReturn(true);
+    when(executions.findById(99L)).thenReturn(Optional.of(execution()));
+
+    OfflineExecutionEventRepositoryAdapter repository =
+        new OfflineExecutionEventRepositoryAdapter(dao, executions, publisher);
+    repository.append(event("FAILED", "FAILED"));
+
+    verify(publisher, never()).publishEvent(any(Object.class));
+  }
+
+  private OfflineJobExecution execution() {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(99L);
+    execution.setJobDefinitionId(10L);
+    execution.setStatus("FAILED");
+    execution.setErrorMessage("engine down");
+    return execution;
+  }
+
+  private OfflineExecutionEvent event(String from, String to) {
+    return OfflineExecutionEvent.builder()
+        .executionId(99L)
+        .fromStatus(from)
+        .toStatus(to)
+        .eventType("FAILED")
+        .createTime(LocalDateTime.now())
+        .build();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionNotificationReader.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionNotificationReader.java
@@ -1,0 +1,17 @@
+package io.yak.ops.business.workflow.execution;
+
+import java.util.Optional;
+
+/** Read-only execution evidence required to build Workflow terminal notifications. */
+public interface WorkflowExecutionNotificationReader {
+
+  Optional<Snapshot> find(String executionId);
+
+  record Snapshot(
+      long projectId,
+      String executionId,
+      String workflowName,
+      String status,
+      String errorMessage) {
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListener.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListener.java
@@ -1,12 +1,9 @@
 package io.yak.ops.business.workflow.execution;
 
-import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
-import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
-import io.yak.ops.common.bean.po.workflow.WorkflowNodeExecutionPO;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionNotificationReader.Snapshot;
 import io.yak.ops.core.notification.BusinessNotification;
 import io.yak.ops.core.notification.BusinessNotificationGateway;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -21,13 +18,13 @@ public class WorkflowFailureNotificationListener {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(WorkflowFailureNotificationListener.class);
 
-  private final WorkflowExecutionDao executionDao;
+  private final WorkflowExecutionNotificationReader executionReader;
   private final ObjectProvider<BusinessNotificationGateway> notificationGateways;
 
   public WorkflowFailureNotificationListener(
-      WorkflowExecutionDao executionDao,
+      WorkflowExecutionNotificationReader executionReader,
       ObjectProvider<BusinessNotificationGateway> notificationGateways) {
-    this.executionDao = executionDao;
+    this.executionReader = executionReader;
     this.notificationGateways = notificationGateways;
   }
 
@@ -38,24 +35,23 @@ public class WorkflowFailureNotificationListener {
     if (gateway == null) return;
 
     try {
-      WorkflowExecutionPO execution = executionDao.selectExecution(event.executionId());
-      if (execution == null || execution.getProjectId() == null || execution.getProjectId() <= 0L) {
-        return;
-      }
+      Snapshot execution = executionReader.find(event.executionId()).orElse(null);
+      if (execution == null) return;
 
-      String workflowName = StringUtils.hasText(execution.getWorkflowName())
-          ? execution.getWorkflowName().trim()
-          : "工作流 " + execution.getDefinitionId();
-      String error = firstError(executionDao.selectNodeExecutions(event.executionId()));
+      String workflowName = StringUtils.hasText(execution.workflowName())
+          ? execution.workflowName().trim()
+          : "工作流 " + event.executionId();
       boolean timedOut = "TIMED_OUT".equalsIgnoreCase(event.executionStatus());
       String title = timedOut ? "工作流执行超时" : "工作流执行失败";
-      String content = error == null
-          ? (timedOut ? "工作流执行已超时，请查看实例详情。" : "工作流执行失败，请查看实例详情。")
-          : error;
+      String content = StringUtils.hasText(execution.errorMessage())
+          ? execution.errorMessage().trim()
+          : timedOut
+              ? "工作流执行已超时，请查看实例详情。"
+              : "工作流执行失败，请查看实例详情。";
 
       gateway.publishToProjectOwners(
           new BusinessNotification(
-              execution.getProjectId(),
+              execution.projectId(),
               BusinessNotification.Type.TASK,
               BusinessNotification.Level.ERROR,
               title,
@@ -75,15 +71,5 @@ public class WorkflowFailureNotificationListener {
 
   private boolean notifiable(String status) {
     return "FAILED".equalsIgnoreCase(status) || "TIMED_OUT".equalsIgnoreCase(status);
-  }
-
-  private String firstError(List<WorkflowNodeExecutionPO> nodes) {
-    if (nodes == null) return null;
-    return nodes.stream()
-        .map(WorkflowNodeExecutionPO::getErrorMessage)
-        .filter(StringUtils::hasText)
-        .map(String::trim)
-        .findFirst()
-        .orElse(null);
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListener.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListener.java
@@ -1,0 +1,89 @@
+package io.yak.ops.business.workflow.execution;
+
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowNodeExecutionPO;
+import io.yak.ops.core.notification.BusinessNotification;
+import io.yak.ops.core.notification.BusinessNotificationGateway;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Publishes actionable notifications for failed or timed-out Workflow executions. */
+@Component
+public class WorkflowFailureNotificationListener {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(WorkflowFailureNotificationListener.class);
+
+  private final WorkflowExecutionDao executionDao;
+  private final ObjectProvider<BusinessNotificationGateway> notificationGateways;
+
+  public WorkflowFailureNotificationListener(
+      WorkflowExecutionDao executionDao,
+      ObjectProvider<BusinessNotificationGateway> notificationGateways) {
+    this.executionDao = executionDao;
+    this.notificationGateways = notificationGateways;
+  }
+
+  @EventListener
+  public void onTerminal(WorkflowExecutionTerminalEvent event) {
+    if (event == null || !notifiable(event.executionStatus())) return;
+    BusinessNotificationGateway gateway = notificationGateways.getIfAvailable();
+    if (gateway == null) return;
+
+    try {
+      WorkflowExecutionPO execution = executionDao.selectExecution(event.executionId());
+      if (execution == null || execution.getProjectId() == null || execution.getProjectId() <= 0L) {
+        return;
+      }
+
+      String workflowName = StringUtils.hasText(execution.getWorkflowName())
+          ? execution.getWorkflowName().trim()
+          : "工作流 " + execution.getDefinitionId();
+      String error = firstError(executionDao.selectNodeExecutions(event.executionId()));
+      boolean timedOut = "TIMED_OUT".equalsIgnoreCase(event.executionStatus());
+      String title = timedOut ? "工作流执行超时" : "工作流执行失败";
+      String content = error == null
+          ? (timedOut ? "工作流执行已超时，请查看实例详情。" : "工作流执行失败，请查看实例详情。")
+          : error;
+
+      gateway.publishToProjectOwners(
+          new BusinessNotification(
+              execution.getProjectId(),
+              BusinessNotification.Type.TASK,
+              BusinessNotification.Level.ERROR,
+              title,
+              workflowName,
+              content,
+              "WORKFLOW_EXECUTION",
+              event.executionId(),
+              "/workflow/instances/" + event.executionId()));
+    } catch (RuntimeException exception) {
+      LOGGER.error(
+          "Failed to publish Workflow failure notification: execution={}, status={}",
+          event.executionId(),
+          event.executionStatus(),
+          exception);
+    }
+  }
+
+  private boolean notifiable(String status) {
+    return "FAILED".equalsIgnoreCase(status) || "TIMED_OUT".equalsIgnoreCase(status);
+  }
+
+  private String firstError(List<WorkflowNodeExecutionPO> nodes) {
+    if (nodes == null) return null;
+    return nodes.stream()
+        .map(WorkflowNodeExecutionPO::getErrorMessage)
+        .filter(StringUtils::hasText)
+        .map(String::trim)
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowExecutionNotificationReaderAdapter.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowExecutionNotificationReaderAdapter.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.workflow.repository;
+
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionNotificationReader;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowNodeExecutionPO;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/** Persistence adapter for the narrow Workflow notification read contract. */
+@Repository
+public class WorkflowExecutionNotificationReaderAdapter
+    implements WorkflowExecutionNotificationReader {
+
+  private final WorkflowExecutionDao executionDao;
+
+  public WorkflowExecutionNotificationReaderAdapter(WorkflowExecutionDao executionDao) {
+    this.executionDao = executionDao;
+  }
+
+  @Override
+  public Optional<Snapshot> find(String executionId) {
+    if (!StringUtils.hasText(executionId)) return Optional.empty();
+    WorkflowExecutionPO execution = executionDao.selectExecution(executionId.trim());
+    if (execution == null || execution.getProjectId() == null || execution.getProjectId() <= 0L) {
+      return Optional.empty();
+    }
+
+    String workflowName = StringUtils.hasText(execution.getWorkflowName())
+        ? execution.getWorkflowName().trim()
+        : execution.getDefinitionId();
+    String error = executionDao.selectNodeExecutions(execution.getId()).stream()
+        .map(WorkflowNodeExecutionPO::getErrorMessage)
+        .filter(StringUtils::hasText)
+        .map(String::trim)
+        .findFirst()
+        .orElse(null);
+
+    return Optional.of(new Snapshot(
+        execution.getProjectId(),
+        execution.getId(),
+        workflowName,
+        execution.getStatus(),
+        error));
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListenerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListenerTest.java
@@ -7,14 +7,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
-import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
-import io.yak.ops.common.bean.po.workflow.WorkflowNodeExecutionPO;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionNotificationReader.Snapshot;
 import io.yak.ops.core.notification.BusinessNotification;
 import io.yak.ops.core.notification.BusinessNotificationGateway;
 import java.time.Instant;
-import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.ObjectProvider;
@@ -24,21 +22,12 @@ class WorkflowFailureNotificationListenerTest {
   @Test
   @SuppressWarnings("unchecked")
   void failedExecutionPublishesProjectOwnedTaskNotification() {
-    WorkflowExecutionDao executions = mock(WorkflowExecutionDao.class);
+    WorkflowExecutionNotificationReader executions = mock(WorkflowExecutionNotificationReader.class);
     BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
     ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
     when(provider.getIfAvailable()).thenReturn(gateway);
-
-    WorkflowExecutionPO execution = new WorkflowExecutionPO();
-    execution.setId("exec-1");
-    execution.setProjectId(7L);
-    execution.setDefinitionId("workflow-1");
-    execution.setWorkflowName("每日订单加工");
-    when(executions.selectExecution("exec-1")).thenReturn(execution);
-
-    WorkflowNodeExecutionPO node = new WorkflowNodeExecutionPO();
-    node.setErrorMessage("SQL task failed");
-    when(executions.selectNodeExecutions("exec-1")).thenReturn(List.of(node));
+    when(executions.find("exec-1")).thenReturn(Optional.of(
+        new Snapshot(7L, "exec-1", "每日订单加工", "FAILED", "SQL task failed")));
 
     WorkflowFailureNotificationListener listener =
         new WorkflowFailureNotificationListener(executions, provider);
@@ -60,7 +49,7 @@ class WorkflowFailureNotificationListenerTest {
   @Test
   @SuppressWarnings("unchecked")
   void successfulExecutionDoesNotPublishNotification() {
-    WorkflowExecutionDao executions = mock(WorkflowExecutionDao.class);
+    WorkflowExecutionNotificationReader executions = mock(WorkflowExecutionNotificationReader.class);
     BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
     ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
     when(provider.getIfAvailable()).thenReturn(gateway);
@@ -69,7 +58,7 @@ class WorkflowFailureNotificationListenerTest {
         new WorkflowFailureNotificationListener(executions, provider);
     listener.onTerminal(new WorkflowExecutionTerminalEvent("exec-1", "SUCCESS", Instant.now()));
 
-    verify(executions, never()).selectExecution(any());
+    verify(executions, never()).find(any());
     verify(gateway, never()).publishToProjectOwners(any());
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListenerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowFailureNotificationListenerTest.java
@@ -1,0 +1,75 @@
+package io.yak.ops.business.workflow.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
+import io.yak.ops.common.bean.po.workflow.WorkflowExecutionPO;
+import io.yak.ops.common.bean.po.workflow.WorkflowNodeExecutionPO;
+import io.yak.ops.core.notification.BusinessNotification;
+import io.yak.ops.core.notification.BusinessNotificationGateway;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+class WorkflowFailureNotificationListenerTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void failedExecutionPublishesProjectOwnedTaskNotification() {
+    WorkflowExecutionDao executions = mock(WorkflowExecutionDao.class);
+    BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
+    ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(gateway);
+
+    WorkflowExecutionPO execution = new WorkflowExecutionPO();
+    execution.setId("exec-1");
+    execution.setProjectId(7L);
+    execution.setDefinitionId("workflow-1");
+    execution.setWorkflowName("每日订单加工");
+    when(executions.selectExecution("exec-1")).thenReturn(execution);
+
+    WorkflowNodeExecutionPO node = new WorkflowNodeExecutionPO();
+    node.setErrorMessage("SQL task failed");
+    when(executions.selectNodeExecutions("exec-1")).thenReturn(List.of(node));
+
+    WorkflowFailureNotificationListener listener =
+        new WorkflowFailureNotificationListener(executions, provider);
+    listener.onTerminal(new WorkflowExecutionTerminalEvent("exec-1", "FAILED", Instant.now()));
+
+    ArgumentCaptor<BusinessNotification> captor =
+        ArgumentCaptor.forClass(BusinessNotification.class);
+    verify(gateway).publishToProjectOwners(captor.capture());
+    BusinessNotification notification = captor.getValue();
+    assertThat(notification.projectId()).isEqualTo(7L);
+    assertThat(notification.type()).isEqualTo(BusinessNotification.Type.TASK);
+    assertThat(notification.level()).isEqualTo(BusinessNotification.Level.ERROR);
+    assertThat(notification.title()).isEqualTo("工作流执行失败");
+    assertThat(notification.summary()).isEqualTo("每日订单加工");
+    assertThat(notification.content()).isEqualTo("SQL task failed");
+    assertThat(notification.actionPath()).isEqualTo("/workflow/instances/exec-1");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void successfulExecutionDoesNotPublishNotification() {
+    WorkflowExecutionDao executions = mock(WorkflowExecutionDao.class);
+    BusinessNotificationGateway gateway = mock(BusinessNotificationGateway.class);
+    ObjectProvider<BusinessNotificationGateway> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(gateway);
+
+    WorkflowFailureNotificationListener listener =
+        new WorkflowFailureNotificationListener(executions, provider);
+    listener.onTerminal(new WorkflowExecutionTerminalEvent("exec-1", "SUCCESS", Instant.now()));
+
+    verify(executions, never()).selectExecution(any());
+    verify(gateway, never()).publishToProjectOwners(any());
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/notification/BusinessNotification.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/notification/BusinessNotification.java
@@ -1,0 +1,65 @@
+package io.yak.ops.core.notification;
+
+/**
+ * A user-facing business event worth surfacing in the Yak Ops notification inbox.
+ *
+ * <p>The owning business module supplies durable business identity and copy only. Recipient
+ * resolution and persistence belong to the application notification adapter.</p>
+ */
+public record BusinessNotification(
+    long projectId,
+    Type type,
+    Level level,
+    String title,
+    String summary,
+    String content,
+    String sourceType,
+    String sourceId,
+    String actionPath) {
+
+  public BusinessNotification {
+    if (projectId <= 0L) throw new IllegalArgumentException("notification projectId must be positive");
+    if (type == null) throw new IllegalArgumentException("notification type must not be null");
+    if (level == null) throw new IllegalArgumentException("notification level must not be null");
+    title = required(title, "notification title must not be blank");
+    sourceType = required(sourceType, "notification sourceType must not be blank");
+    sourceId = required(sourceId, "notification sourceId must not be blank");
+    summary = trimToNull(summary);
+    content = trimToNull(content);
+    actionPath = internalPath(actionPath);
+  }
+
+  public enum Type {
+    TASK,
+    QUALITY,
+    SYSTEM
+  }
+
+  public enum Level {
+    INFO,
+    SUCCESS,
+    WARNING,
+    ERROR
+  }
+
+  private static String required(String value, String message) {
+    String normalized = trimToNull(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  private static String internalPath(String value) {
+    String normalized = trimToNull(value);
+    if (normalized == null) return null;
+    if (!normalized.startsWith("/") || normalized.startsWith("//")) {
+      throw new IllegalArgumentException("notification actionPath must be an internal route");
+    }
+    return normalized;
+  }
+}

--- a/yak-ops-core/src/main/java/io/yak/ops/core/notification/BusinessNotificationGateway.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/notification/BusinessNotificationGateway.java
@@ -1,0 +1,13 @@
+package io.yak.ops.core.notification;
+
+/** Outbound port for delivering Project-owned business notifications to Project owners. */
+public interface BusinessNotificationGateway {
+
+  /**
+   * Deliver one business event to the current Project owners.
+   *
+   * <p>Implementations must treat notification delivery as a secondary side effect: delivery
+   * failures must not fail the originating business execution.</p>
+   */
+  void publishToProjectOwners(BusinessNotification notification);
+}

--- a/yak-ops-core/src/test/java/io/yak/ops/core/notification/BusinessNotificationTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/notification/BusinessNotificationTest.java
@@ -1,0 +1,56 @@
+package io.yak.ops.core.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class BusinessNotificationTest {
+
+  @Test
+  void normalizesCopyAndAcceptsOnlyInternalActions() {
+    BusinessNotification notification = new BusinessNotification(
+        7L,
+        BusinessNotification.Type.TASK,
+        BusinessNotification.Level.ERROR,
+        "  Task failed  ",
+        "  summary  ",
+        "  detail  ",
+        "  OFFLINE_SYNC_EXECUTION  ",
+        "  99  ",
+        "  /sync/batch-link-up/10/detail  ");
+
+    assertThat(notification.title()).isEqualTo("Task failed");
+    assertThat(notification.summary()).isEqualTo("summary");
+    assertThat(notification.sourceType()).isEqualTo("OFFLINE_SYNC_EXECUTION");
+    assertThat(notification.sourceId()).isEqualTo("99");
+    assertThat(notification.actionPath()).isEqualTo("/sync/batch-link-up/10/detail");
+  }
+
+  @Test
+  void rejectsInvalidProjectAndExternalActions() {
+    assertThatThrownBy(() -> new BusinessNotification(
+        0L,
+        BusinessNotification.Type.TASK,
+        BusinessNotification.Level.ERROR,
+        "failed",
+        null,
+        null,
+        "TASK",
+        "1",
+        "/tasks/1"))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() -> new BusinessNotification(
+        7L,
+        BusinessNotification.Type.TASK,
+        BusinessNotification.Level.ERROR,
+        "failed",
+        null,
+        null,
+        "TASK",
+        "1",
+        "https://example.com"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
## Summary

Connect the hardened Message Center foundation to the first real Yak Ops business events without coupling business modules directly to `yak-security`.

This PR intentionally keeps notifications selective: failures and actionable quality exceptions only. Successful executions do not create inbox noise.

## Architecture

Business modules publish a stable Yak Ops core contract:

```text
Offline Sync / Workflow / Quality
        ↓
BusinessNotificationGateway
        ↓
yak-ops-boot adapter
        ↓
resolve Project OWNER recipients
        ↓
framework NotificationPublisher
        ↓
yak_security_message
```

`yak-ops-core` owns only the outbound notification contract (`BusinessNotification` + `BusinessNotificationGateway`). Business modules do not import `MessageDTO`, `MessageService`, `NotificationPublisher`, or security DAO types.

`yak-ops-boot` is the only adapter that knows Yak Security.

## Recipient policy

The first version deliberately notifies **Project OWNER users only**.

```text
projectId
  ↓
UserProjectService.getUserIdListByProjectId(projectId, OWNER)
```

It does not broadcast every operational failure to all Project members.

## Delivery semantics

Notification persistence is a secondary side effect:

- when a business transaction is active, delivery is registered for `afterCommit`;
- a rolled-back business transaction therefore produces no notification;
- notification infrastructure unavailable / owner resolution failure / message persistence failure is logged and swallowed;
- notification failure must never turn a successful business state transition into a failed Offline Sync, Workflow, or Quality execution;
- no MQ, WebSocket, or new notification table is introduced.

## Business events

### 1. Offline Sync final failure

Publishes:

```text
type       = TASK
level      = ERROR
sourceType = OFFLINE_SYNC_EXECUTION
actionPath = /sync/batch-link-up/{definitionId}/detail
```

The existing Offline Attempt retry truth is reused.

A user notification is emitted only when an Attempt first enters `FAILED` **and no `nextRetryTime` is scheduled**.

Therefore a task with `maxAttempts=3` does not generate one notification per failed retry. Intermediate retryable failures remain execution evidence only; the user is notified when the retry policy is exhausted or the failure is non-retryable.

### 2. Workflow failure / timeout

Reuses the existing `WorkflowExecutionTerminalEvent`.

Only these terminal states notify:

```text
FAILED
TIMED_OUT
```

`SUCCESS`, `SUCCESS_WITH_WARNINGS`, and `CANCELED` do not notify.

Notification contract:

```text
type       = TASK
level      = ERROR
sourceType = WORKFLOW_EXECUTION
actionPath = /workflow/instances/{executionId}
```

The listener follows the repository architecture instead of reading DAO/PO directly:

```text
WorkflowFailureNotificationListener
  ↓
WorkflowExecutionNotificationReader
  ↓
WorkflowExecutionNotificationReaderAdapter
  ↓
WorkflowExecutionDao
```

### 3. Data Quality exceptions

Quality notification behavior distinguishes operational failure from rule findings.

#### Execution ERROR

A real quality execution error is always surfaced in the Message Center, even when the monitor's configured external/business alerting is disabled.

```text
type  = QUALITY
level = ERROR
```

#### NOT_PASSED

Rule findings respect the existing Quality notification contract:

```text
notifyEnabled = true
AND notifyChannel = MESSAGE
```

Severity mapping:

```text
AlertLevel.WARNING  -> WARNING
AlertLevel.CRITICAL -> ERROR
```

Non-MESSAGE channels continue to create their existing alert evidence without injecting an in-app notification.

Quality messages navigate to:

```text
/data-quality/execution/{executionNo}
```

## Message Center compatibility

This PR assumes the already-merged hardened contracts:

- `weifuwan/yak-framework#113`
- `weifuwan/yak-ops#905`

`projectId` is supplied for every business notification, so framework derives PROJECT scope and Project authorization remains enforced by the Message Center.

## Tests

Added regression coverage for:

- business notification value-object validation and safe internal action paths;
- Project OWNER recipient resolution and duplicate-owner removal;
- after-commit delivery;
- notification persistence failure isolation;
- Offline retryable failures not notifying;
- Offline repeated `FAILED -> FAILED` state not duplicating notification signal;
- final Offline failure payload / Project / action route;
- Workflow failure payload and success suppression;
- Quality MESSAGE findings;
- Quality non-MESSAGE findings not entering the inbox;
- Quality execution ERROR always entering the inbox;
- CRITICAL quality findings mapping to ERROR severity.

## Scope

Changed areas:

```text
yak-ops-core
yak-ops-boot
yak-ops-business-sync-offline
yak-ops-business-workflow
yak-ops-business-quality
```

No Flyway/schema changes.
No frontend changes.
No success notifications.
No MQ/WebSocket.
No broadcast to all Project members.

## Suggested validation

```bash
mvn \
  -pl yak-ops-core,\
yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline,\
yak-ops-business/yak-ops-business-workflow,\
yak-ops-business/yak-ops-business-quality,\
yak-ops-boot \
  -am \
  -Dtest=BusinessNotificationTest,YakSecurityBusinessNotificationGatewayTest,OfflineExecutionEventRepositoryAdapterNotificationTest,OfflineFailureNotificationListenerTest,WorkflowFailureNotificationListenerTest,QualityAlertRecorderNotificationTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

Manual minimum regression:

1. Project A has an OWNER and an Offline Sync task with retry enabled; fail an intermediate Attempt -> no notification; exhaust retries -> one Project A notification.
2. Switch to Project B -> the Project A notification is absent from the homepage Project inbox.
3. Fail a Workflow instance -> Project OWNER receives one TASK/ERROR notification linking to the instance.
4. Complete Workflow successfully -> no notification.
5. Trigger a Quality NOT_PASSED monitor configured with MESSAGE -> QUALITY notification appears.
6. Trigger a Quality NOT_PASSED monitor configured with EMAIL -> no Message Center notification.
7. Force a Quality execution ERROR with configured alerts disabled -> ERROR notification still appears.
8. Make notification persistence unavailable -> originating business execution state remains unchanged; only notification delivery logs an error.

## Validation status

- branch is based on current `main` (already includes #905)
- compare is ahead-only / behind 0
- framework main already contains #113
- local Maven execution could not be performed because this runtime cannot resolve `github.com`, so CI/local developer execution remains the build gate for this Draft PR
