### PR TITLE
fix(quality): disambiguate QualityAlertRecorder constructors

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/alert/QualityAlertRecorder.java
@@ -28,19 +28,14 @@ public class QualityAlertRecorder {
   public QualityAlertRecorder(
       QualityAlertRepository repository,
       ObjectProvider<BusinessNotificationGateway> notificationGateways) {
-    this(repository, notificationGateways.getIfAvailable());
+    this.repository = repository;
+    this.notificationGateway = notificationGateways.getIfAvailable();
   }
 
   /** Focused tests retain the lightweight constructor. */
   public QualityAlertRecorder(QualityAlertRepository repository) {
-    this(repository, null);
-  }
-
-  private QualityAlertRecorder(
-      QualityAlertRepository repository,
-      BusinessNotificationGateway notificationGateway) {
     this.repository = repository;
-    this.notificationGateway = notificationGateway;
+    this.notificationGateway = null;
   }
 
   public void recordIfNecessary(

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/alert/QualityAlertRecorderNotificationTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/alert/QualityAlertRecorderNotificationTest.java
@@ -24,6 +24,21 @@ import org.springframework.beans.factory.ObjectProvider;
 class QualityAlertRecorderNotificationTest {
 
   @Test
+  void lightweightConstructorKeepsNotificationGatewayOptional() {
+    QualityAlertRepository repository = mock(QualityAlertRepository.class);
+
+    QualityAlertRecorder recorder = new QualityAlertRecorder(repository);
+    recorder.recordIfNecessary(
+        plan(false, NotifyChannel.EMAIL, AlertLevel.WARNING),
+        CheckResult.ERROR,
+        0,
+        0,
+        1);
+
+    verify(repository, never()).insertAlertEvent(any());
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   void messageChannelPublishesQualityWarningToProjectOwners() {
     QualityAlertRepository repository = mock(QualityAlertRepository.class);


### PR DESCRIPTION
## Background

`QualityAlertRecorder` currently has these constructor shapes:

- `(QualityAlertRepository, ObjectProvider<BusinessNotificationGateway>)`
- `(QualityAlertRepository)`
- private `(QualityAlertRepository, BusinessNotificationGateway)`

The repository-only constructor delegates with `this(repository, null)`. Because `null` is applicable to both `ObjectProvider<BusinessNotificationGateway>` and `BusinessNotificationGateway`, Java cannot resolve which two-argument constructor should be called and compilation fails with an ambiguous constructor error.

## Changes

- Remove the ambiguous constructor delegation path.
- Initialize `repository` and `notificationGateway` explicitly in the Spring constructor.
- Initialize the lightweight repository-only constructor explicitly with no notification gateway.
- Add a regression test covering the repository-only constructor and optional notification behavior.

## Scope

This PR does not change quality alert decision logic, notification routing, message-center contracts, or persistence behavior. It only fixes constructor initialization so the module compiles cleanly while preserving both Spring injection and lightweight test construction.

## Verification

- `QualityAlertRecorderNotificationTest` now covers the repository-only constructor path.
- Diff is limited to `QualityAlertRecorder` and its focused notification test.