### PR TITLE
feat(sync): configure Offline notification policy (Stage 4.2)

### DIFF
--- a/docs/architecture/OFFLINE_NOTIFICATION_POLICY.md
+++ b/docs/architecture/OFFLINE_NOTIFICATION_POLICY.md
@@ -1,0 +1,134 @@
+# Offline Sync Notification Policy (Stage 4.2)
+
+## Scope
+
+Stage 4.2 makes the Offline Sync final-failure notification introduced earlier configurable per task without coupling Offline Sync to Yak Security Message persistence or the Alert plugin system.
+
+The business event remains:
+
+```text
+Offline attempt first enters FAILED
++ no nextRetryTime is scheduled
+        ↓
+OfflineExecutionFinalFailureEvent
+        ↓
+NotificationIntent
+sourceType = OFFLINE_SYNC_EXECUTION
+sourceId   = executionId
+```
+
+Routing is decided later by the Stage 4.1 `NotificationRouter`.
+
+## Persistent model
+
+Task-level policy is stored on the owning definition:
+
+```text
+yak_offline_job_definition.notification_config_json
+```
+
+The column is nullable by design.
+
+```text
+NULL
+  = legacy compatibility policy
+  = final failure -> current Project OWNER -> IN_APP
+```
+
+The migration does not backfill old rows. This keeps existing tasks behavior-compatible while distinguishing an untouched legacy task from an explicitly configured policy.
+
+The dedicated column is the policy source of truth. `definition_json` may also contain the request field for round-trip compatibility, but edit responses always project the dedicated column back over it.
+
+## API contract
+
+`OfflineJobDefinitionDTO` accepts a top-level sibling configuration:
+
+```json
+{
+  "notification": {
+    "enabled": true,
+    "triggers": ["FINAL_FAILURE"],
+    "recipientType": "PROJECT_OWNER",
+    "recipientUserIds": [],
+    "inAppEnabled": true
+  }
+}
+```
+
+Stage 4.2 supports only:
+
+```text
+trigger:
+  FINAL_FAILURE
+
+recipientType:
+  PROJECT_OWNER
+  EXPLICIT_USERS
+
+destination:
+  IN_APP
+```
+
+External Alert channels are intentionally deferred to Stage 4.3.
+
+## Backward compatibility
+
+Older clients do not know the `notification` field.
+
+When an existing task is updated with `notification == null`, the service preserves the already persisted `notification_config_json` instead of resetting it. A new task that omits the field keeps `NULL` and therefore inherits the legacy compatibility policy.
+
+## Routing
+
+`OfflineSyncNotificationPolicyResolver` has order `100`, before the global fallback resolver.
+
+It resolves policy using explicit durable identity:
+
+```text
+(intent.projectId, intent.sourceId/executionId)
+        ↓
+yak_offline_job_execution
+        ↓
+job_definition_id
+        ↓
+yak_offline_job_definition.notification_config_json
+```
+
+The resolver does not parse `actionPath` and does not depend on a ThreadLocal current Project. This matters because `DefaultNotificationRouter` may execute after the originating business transaction commits.
+
+If execution/definition/policy data cannot be resolved, routing fails closed rather than silently falling back and potentially violating an explicit user opt-out.
+
+## JobSpec isolation
+
+Notification is a Yak Ops control-plane setting. `OfflineDefinitionModelAdapter.forJobSpec` explicitly removes the root `notification` field before engine JobSpec construction.
+
+Therefore changing only notification preferences must not change engine execution configuration or make the notification payload part of an engine snapshot/config digest.
+
+## UI
+
+The shared Offline editor exposes **通知设置** for both GUIDE_SINGLE and GUIDE_MULTI tasks.
+
+Stage 4.2 UI provides:
+
+```text
+开启任务通知
+触发条件: 最终执行失败
+通知方式: 站内消息
+接收人:
+  - 项目负责人
+  - 指定用户
+```
+
+Explicit-user candidates are loaded from the current Project detail and limited to its owners and members. Only stable numeric user IDs are persisted.
+
+## Non-goals
+
+Stage 4.2 does not add:
+
+- success notifications;
+- per-retry failure spam;
+- DingTalk/email/webhook delivery;
+- Project-scoped Alert channel configuration;
+- MQ/WebSocket/SSE;
+- a new shared notification-policy table.
+
+Stage 4.3 should implement external delivery as `NotificationPolicy.Destination.ALERT -> AlertNotificationSink`, not by calling `AlertService` from Offline Sync business code.

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
@@ -58,7 +58,7 @@ public class OfflineJobDefinitionService {
     ensureCanSaveDraft(existing);
 
     DraftDefinition draft = support.prepareDraft(dto);
-    String notificationConfigJson = notificationPolicyCodec.encode(dto.getNotification());
+    String notificationConfigJson = resolveNotificationConfig(dto, existing);
     ensureUniqueName(draft.getJobName(), id);
 
     OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
@@ -76,7 +76,7 @@ public class OfflineJobDefinitionService {
     ensureEditable(existing);
 
     PreparedDefinition prepared = support.prepare(dto);
-    String notificationConfigJson = notificationPolicyCodec.encode(dto.getNotification());
+    String notificationConfigJson = resolveNotificationConfig(dto, existing);
     ensureUniqueName(prepared.getJobName(), id);
 
     OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
@@ -118,7 +118,9 @@ public class OfflineJobDefinitionService {
   }
 
   public JsonNode getEditDetail(Long id) {
-    return support.editDetail(require(id));
+    OfflineJobDefinition definition = require(id);
+    return notificationPolicyCodec.applyToEditDetail(
+        support.editDetail(definition), definition.getNotificationConfigJson());
   }
 
   public PageData<OfflineJobDefinition> pageDomain(OfflineDefinitionQuery query) {
@@ -200,6 +202,17 @@ public class OfflineJobDefinitionService {
       dto.setId(id);
     }
     return id;
+  }
+
+  private String resolveNotificationConfig(
+      OfflineJobDefinitionDTO dto,
+      OfflineJobDefinition existing) {
+    if (dto.getNotification() == null && existing != null) {
+      // Backward compatibility: an older client does not know the notification field and must not
+      // erase an already-configured policy while editing another part of the task.
+      return existing.getNotificationConfigJson();
+    }
+    return notificationPolicyCodec.encode(dto.getNotification());
   }
 
   private void ensureCanSaveDraft(OfflineJobDefinition existing) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.sync.offline.definition.OfflineDefinitionSupport.Prep
 import io.yak.ops.business.sync.offline.domain.OfflineDefinitionQuery;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
+import io.yak.ops.business.sync.offline.notification.OfflineNotificationPolicyCodec;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
@@ -34,6 +35,7 @@ public class OfflineJobDefinitionService {
   private final OfflineBatchExecutionRepository batchRepository;
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineDefinitionSupport support;
+  private final OfflineNotificationPolicyCodec notificationPolicyCodec;
   private final OfflineScheduleSupport scheduleSupport;
   private final OfflineScheduleLifecycle scheduleLifecycle;
   private final OfflineSyncViewMapper viewMapper;
@@ -56,10 +58,12 @@ public class OfflineJobDefinitionService {
     ensureCanSaveDraft(existing);
 
     DraftDefinition draft = support.prepareDraft(dto);
+    String notificationConfigJson = notificationPolicyCodec.encode(dto.getNotification());
     ensureUniqueName(draft.getJobName(), id);
 
     OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
     applyDraft(definition, existing, id, draft);
+    definition.setNotificationConfigJson(notificationConfigJson);
     persist(existing, definition);
     saveScheduleAndSync(id, draft.getRequest().get("schedule"));
     return id;
@@ -72,10 +76,12 @@ public class OfflineJobDefinitionService {
     ensureEditable(existing);
 
     PreparedDefinition prepared = support.prepare(dto);
+    String notificationConfigJson = notificationPolicyCodec.encode(dto.getNotification());
     ensureUniqueName(prepared.getJobName(), id);
 
     OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
     applyPrepared(definition, existing, id, prepared);
+    definition.setNotificationConfigJson(notificationConfigJson);
     persist(existing, definition);
     saveScheduleAndSync(id, prepared.getRequest().get("schedule"));
     return id;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobDefinition.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobDefinition.java
@@ -34,6 +34,7 @@ public class OfflineJobDefinition {
   private String cronExpression;
   private Integer retryMaxAttempts;
   private Integer retryBackoffSeconds;
+  private String notificationConfigJson;
   private LocalDateTime scheduleLastFireTime;
   private LocalDateTime scheduleNextFireTime;
   private Integer version;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -77,6 +77,9 @@ public final class OfflineDefinitionModelAdapter {
       return definition;
     }
     ObjectNode adapted = (ObjectNode) definition.deepCopy();
+    // Notification is a Yak Ops control-plane concern. It must never alter engine JobSpec,
+    // execution snapshots or config digests when only delivery preferences change.
+    adapted.remove("notification");
     String mode = text(adapted.path("basic"), "mode", "GUIDE_SINGLE");
     adaptEndpoint(adapted, "source", mode, objectMapper);
     adaptEndpoint(adapted, "sink", mode, objectMapper);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodec.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodec.java
@@ -1,7 +1,9 @@
 package io.yak.ops.business.sync.offline.notification;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobNotificationDTO;
 import io.yak.ops.core.notification.NotificationPolicy;
@@ -36,6 +38,32 @@ public class OfflineNotificationPolicyCodec {
       return objectMapper.writeValueAsString(normalize(value));
     } catch (JsonProcessingException exception) {
       throw new IllegalStateException("序列化离线同步通知策略失败", exception);
+    }
+  }
+
+  /**
+   * The dedicated notification column is the source of truth for edit responses.
+   *
+   * <p>Old definition_json payloads may not contain notification at all, while older clients may
+   * keep stale embedded notification data. Always project the normalized dedicated column into the
+   * response and remove the embedded field for legacy NULL policies.</p>
+   */
+  public JsonNode applyToEditDetail(JsonNode detail, String json) {
+    if (detail == null || !detail.isObject()) {
+      throw new IllegalArgumentException("离线同步编辑详情必须是 JSON 对象");
+    }
+    ObjectNode result = ((ObjectNode) detail).deepCopy();
+    if (!StringUtils.hasText(json)) {
+      result.remove("notification");
+      return result;
+    }
+    try {
+      OfflineJobNotificationDTO normalized =
+          normalize(objectMapper.readValue(json, OfflineJobNotificationDTO.class));
+      result.set("notification", objectMapper.valueToTree(normalized));
+      return result;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("离线同步通知策略 JSON 已损坏", exception);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodec.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodec.java
@@ -1,0 +1,114 @@
+package io.yak.ops.business.sync.offline.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobNotificationDTO;
+import io.yak.ops.core.notification.NotificationPolicy;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Normalizes Offline Sync task notification configuration and maps it to Router policy. */
+@Component
+@ConditionalOnOfflineSyncEnabled
+public class OfflineNotificationPolicyCodec {
+
+  public static final String FINAL_FAILURE = "FINAL_FAILURE";
+  public static final String PROJECT_OWNER = "PROJECT_OWNER";
+  public static final String EXPLICIT_USERS = "EXPLICIT_USERS";
+
+  private final ObjectMapper objectMapper;
+
+  public OfflineNotificationPolicyCodec(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  /** Null means legacy task and intentionally keeps the Stage 4.1 compatibility policy. */
+  public String encode(OfflineJobNotificationDTO value) {
+    if (value == null) return null;
+    try {
+      return objectMapper.writeValueAsString(normalize(value));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化离线同步通知策略失败", exception);
+    }
+  }
+
+  public NotificationPolicy decodePolicy(String json) {
+    if (!StringUtils.hasText(json)) {
+      return NotificationPolicy.projectOwnersInApp();
+    }
+    try {
+      OfflineJobNotificationDTO config =
+          normalize(objectMapper.readValue(json, OfflineJobNotificationDTO.class));
+      if (!Boolean.TRUE.equals(config.getEnabled())
+          || !Boolean.TRUE.equals(config.getInAppEnabled())
+          || !config.getTriggers().contains(FINAL_FAILURE)) {
+        return NotificationPolicy.disabled();
+      }
+      if (EXPLICIT_USERS.equals(config.getRecipientType())) {
+        return new NotificationPolicy(
+            true,
+            NotificationPolicy.RecipientStrategy.EXPLICIT_USERS,
+            config.getRecipientUserIds(),
+            Set.of(NotificationPolicy.Destination.IN_APP),
+            List.of());
+      }
+      return NotificationPolicy.projectOwnersInApp();
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("离线同步通知策略 JSON 已损坏", exception);
+    }
+  }
+
+  public OfflineJobNotificationDTO normalize(OfflineJobNotificationDTO value) {
+    if (value == null) {
+      throw new IllegalArgumentException("通知策略不能为空");
+    }
+    OfflineJobNotificationDTO normalized = new OfflineJobNotificationDTO();
+    normalized.setEnabled(value.getEnabled() == null ? Boolean.TRUE : value.getEnabled());
+    normalized.setInAppEnabled(
+        value.getInAppEnabled() == null ? Boolean.TRUE : value.getInAppEnabled());
+
+    List<String> triggers = value.getTriggers() == null || value.getTriggers().isEmpty()
+        ? List.of(FINAL_FAILURE)
+        : value.getTriggers().stream()
+            .filter(Objects::nonNull)
+            .map(item -> item.trim().toUpperCase(Locale.ROOT))
+            .filter(StringUtils::hasText)
+            .distinct()
+            .toList();
+    if (triggers.isEmpty() || triggers.stream().anyMatch(item -> !FINAL_FAILURE.equals(item))) {
+      throw new IllegalArgumentException("离线同步通知触发条件仅支持 FINAL_FAILURE");
+    }
+    normalized.setTriggers(triggers);
+
+    String recipientType = StringUtils.hasText(value.getRecipientType())
+        ? value.getRecipientType().trim().toUpperCase(Locale.ROOT)
+        : PROJECT_OWNER;
+    if (!PROJECT_OWNER.equals(recipientType) && !EXPLICIT_USERS.equals(recipientType)) {
+      throw new IllegalArgumentException("通知接收人类型仅支持 PROJECT_OWNER 或 EXPLICIT_USERS");
+    }
+    normalized.setRecipientType(recipientType);
+
+    List<Long> userIds = value.getRecipientUserIds() == null
+        ? List.of()
+        : value.getRecipientUserIds().stream()
+            .filter(Objects::nonNull)
+            .filter(id -> id > 0L)
+            .distinct()
+            .toList();
+    if (EXPLICIT_USERS.equals(recipientType)
+        && Boolean.TRUE.equals(normalized.getEnabled())
+        && Boolean.TRUE.equals(normalized.getInAppEnabled())
+        && userIds.isEmpty()) {
+      throw new IllegalArgumentException("指定用户通知至少需要选择一个用户");
+    }
+    normalized.setRecipientUserIds(EXPLICIT_USERS.equals(recipientType) ? userIds : List.of());
+    return normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyReader.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyReader.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.sync.offline.notification;
+
+import java.util.Optional;
+
+/** Read-only port used by notification routing after the business transaction commits. */
+public interface OfflineNotificationPolicyReader {
+
+  Optional<Snapshot> find(long projectId, long executionId);
+
+  record Snapshot(long definitionId, String notificationConfigJson) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyReaderAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyReaderAdapter.java
@@ -1,0 +1,41 @@
+package io.yak.ops.business.sync.offline.notification;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobDefinitionMapper;
+import io.yak.ops.business.sync.offline.dao.mapper.OfflineJobExecutionMapper;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobDefinitionPO;
+import io.yak.ops.common.bean.po.sync.offline.OfflineJobExecutionPO;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/** Project-explicit adapter for resolving execution -> definition notification policy. */
+@Repository
+@ConditionalOnOfflineSyncEnabled
+@RequiredArgsConstructor
+public class OfflineNotificationPolicyReaderAdapter implements OfflineNotificationPolicyReader {
+
+  private final OfflineJobExecutionMapper executionMapper;
+  private final OfflineJobDefinitionMapper definitionMapper;
+
+  @Override
+  public Optional<Snapshot> find(long projectId, long executionId) {
+    OfflineJobExecutionPO execution = executionMapper.selectOne(
+        Wrappers.<OfflineJobExecutionPO>lambdaQuery()
+            .eq(OfflineJobExecutionPO::getId, executionId)
+            .eq(OfflineJobExecutionPO::getProjectId, projectId)
+            .last("LIMIT 1"));
+    if (execution == null || execution.getJobDefinitionId() == null) return Optional.empty();
+
+    OfflineJobDefinitionPO definition = definitionMapper.selectOne(
+        Wrappers.<OfflineJobDefinitionPO>lambdaQuery()
+            .eq(OfflineJobDefinitionPO::getId, execution.getJobDefinitionId())
+            .eq(OfflineJobDefinitionPO::getProjectId, projectId)
+            .last("LIMIT 1"));
+    if (definition == null) return Optional.empty();
+
+    return Optional.of(new Snapshot(
+        definition.getId(), definition.getNotificationConfigJson()));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineSyncNotificationPolicyResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineSyncNotificationPolicyResolver.java
@@ -1,0 +1,60 @@
+package io.yak.ops.business.sync.offline.notification;
+
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.core.notification.NotificationIntent;
+import io.yak.ops.core.notification.NotificationPolicy;
+import io.yak.ops.core.notification.NotificationPolicyResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Overrides the global notification fallback with the owning Offline Sync task policy. */
+@Component
+@ConditionalOnOfflineSyncEnabled
+public class OfflineSyncNotificationPolicyResolver implements NotificationPolicyResolver {
+
+  static final String SOURCE_TYPE = "OFFLINE_SYNC_EXECUTION";
+  static final int ORDER = 100;
+
+  private final OfflineNotificationPolicyReader reader;
+  private final OfflineNotificationPolicyCodec codec;
+
+  public OfflineSyncNotificationPolicyResolver(
+      OfflineNotificationPolicyReader reader,
+      OfflineNotificationPolicyCodec codec) {
+    this.reader = reader;
+    this.codec = codec;
+  }
+
+  @Override
+  public boolean supports(NotificationIntent intent) {
+    return intent != null && SOURCE_TYPE.equalsIgnoreCase(intent.sourceType());
+  }
+
+  @Override
+  public NotificationPolicy resolve(NotificationIntent intent) {
+    if (intent == null || !StringUtils.hasText(intent.sourceId())) {
+      throw new IllegalArgumentException("离线同步通知缺少 executionId");
+    }
+    long executionId;
+    try {
+      executionId = Long.parseLong(intent.sourceId().trim());
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("离线同步通知 executionId 不合法", exception);
+    }
+    if (executionId <= 0L) {
+      throw new IllegalArgumentException("离线同步通知 executionId 必须大于 0");
+    }
+
+    OfflineNotificationPolicyReader.Snapshot snapshot = reader
+        .find(intent.projectId(), executionId)
+        .orElseThrow(() -> new IllegalStateException(
+            "无法解析离线同步通知策略：projectId=" + intent.projectId()
+                + ", executionId=" + executionId));
+    return codec.decodePolicy(snapshot.notificationConfigJson());
+  }
+
+  @Override
+  public int order() {
+    return ORDER;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V2__add_offline_notification_config.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V2__add_offline_notification_config.sql
@@ -1,0 +1,2 @@
+ALTER TABLE yak_offline_job_definition
+    ADD COLUMN notification_config_json TEXT NULL COMMENT 'Task-level notification policy JSON; NULL keeps the legacy Project OWNER + IN_APP default';

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/OfflineSlimSchemaTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/OfflineSlimSchemaTest.java
@@ -11,6 +11,8 @@ class OfflineSlimSchemaTest {
 
   private static final String BASELINE =
       "/db/migration/yak-offline-sync/V1__baseline_offline_sync.sql";
+  private static final String NOTIFICATION_POLICY =
+      "/db/migration/yak-offline-sync/V2__add_offline_notification_config.sql";
 
   @Test
   void baselineCreatesOnlyCurrentOfflineSyncTables() throws Exception {
@@ -64,6 +66,17 @@ class OfflineSlimSchemaTest {
     assertFalse(sql.contains("UPDATE YAK_OFFLINE_"));
     assertFalse(sql.contains("SET STATUS = 'UNKNOWN'"));
     assertFalse(sql.contains("SET LAST_JOB_STATUS = 'UNKNOWN'"));
+  }
+
+  @Test
+  void notificationPolicyMigrationIsAdditiveAndDoesNotBackfillLegacyTasks() throws Exception {
+    String sql = read(NOTIFICATION_POLICY);
+    String upper = sql.toUpperCase();
+
+    assertTrue(sql.contains("ALTER TABLE yak_offline_job_definition"));
+    assertTrue(sql.contains("notification_config_json TEXT NULL"));
+    assertFalse(upper.contains("UPDATE YAK_OFFLINE_JOB_DEFINITION"));
+    assertFalse(upper.contains("NOT NULL"));
   }
 
   private String read(String path) throws Exception {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceNotificationCompatibilityTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceNotificationCompatibilityTest.java
@@ -1,0 +1,71 @@
+package io.yak.ops.business.sync.offline.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.definition.OfflineDefinitionSupport.DraftDefinition;
+import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
+import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
+import io.yak.ops.business.sync.offline.notification.OfflineNotificationPolicyCodec;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
+import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleLifecycle;
+import io.yak.ops.business.sync.offline.schedule.OfflineScheduleSupport;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OfflineJobDefinitionServiceNotificationCompatibilityTest {
+
+  @Test
+  void olderClientOmittingNotificationPreservesConfiguredPolicy() {
+    OfflineJobDefinitionRepository definitions = mock(OfflineJobDefinitionRepository.class);
+    OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
+    OfflineScheduleRepository schedules = mock(OfflineScheduleRepository.class);
+    OfflineDefinitionSupport support = mock(OfflineDefinitionSupport.class);
+    OfflineNotificationPolicyCodec codec = mock(OfflineNotificationPolicyCodec.class);
+    OfflineScheduleSupport scheduleSupport = mock(OfflineScheduleSupport.class);
+    OfflineScheduleLifecycle lifecycle = mock(OfflineScheduleLifecycle.class);
+    OfflineSyncViewMapper viewMapper = mock(OfflineSyncViewMapper.class);
+
+    OfflineJobDefinition existing = new OfflineJobDefinition();
+    existing.setId(10L);
+    existing.setReleaseState("OFFLINE");
+    existing.setNotificationConfigJson("{\"enabled\":false}");
+    when(definitions.findById(10L)).thenReturn(Optional.of(existing));
+    when(definitions.existsByName("订单同步", 10L)).thenReturn(false);
+
+    ObjectNode request = new ObjectMapper().createObjectNode();
+    request.set("schedule", new ObjectMapper().createObjectNode());
+    when(support.prepareDraft(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(new DraftDefinition(
+            request,
+            "订单同步",
+            null,
+            "GUIDE_SINGLE",
+            "{}",
+            "MYSQL",
+            "MYSQL"));
+
+    OfflineJobDefinitionService service = new OfflineJobDefinitionService(
+        definitions,
+        batches,
+        schedules,
+        support,
+        codec,
+        scheduleSupport,
+        lifecycle,
+        viewMapper);
+
+    OfflineJobDefinitionDTO dto = new OfflineJobDefinitionDTO();
+    dto.setId(10L);
+    // Deliberately leave dto.notification null to simulate an older client.
+    service.saveDraft(dto);
+
+    assertThat(existing.getNotificationConfigJson()).isEqualTo("{\"enabled\":false}");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceRuntimeTruthTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceRuntimeTruthTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
+import io.yak.ops.business.sync.offline.notification.OfflineNotificationPolicyCodec;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineScheduleRepository;
@@ -71,6 +72,7 @@ class OfflineJobDefinitionServiceRuntimeTruthTest {
         batches,
         schedules,
         mock(OfflineDefinitionSupport.class),
+        mock(OfflineNotificationPolicyCodec.class),
         mock(OfflineScheduleSupport.class),
         lifecycle,
         mock(OfflineSyncViewMapper.class));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineNotificationJobSpecIsolationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineNotificationJobSpecIsolationTest.java
@@ -1,0 +1,34 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class OfflineNotificationJobSpecIsolationTest {
+
+  @Test
+  void notificationPolicyNeverEntersEngineJobSpecModel() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode definition = objectMapper.readTree("""
+        {
+          "basic": {"mode": "GUIDE_SINGLE"},
+          "source": {"dbType": "MYSQL", "config": {}},
+          "sink": {"dbType": "MYSQL", "config": {}},
+          "channel": {"parallelism": 1},
+          "notification": {
+            "enabled": true,
+            "recipientType": "EXPLICIT_USERS",
+            "recipientUserIds": [11]
+          }
+        }
+        """);
+
+    JsonNode jobSpecInput =
+        OfflineDefinitionModelAdapter.forJobSpec(definition, objectMapper);
+
+    assertThat(jobSpecInput.has("notification")).isFalse();
+    assertThat(definition.has("notification")).isTrue();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodecTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodecTest.java
@@ -1,0 +1,92 @@
+package io.yak.ops.business.sync.offline.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobNotificationDTO;
+import io.yak.ops.core.notification.NotificationPolicy;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineNotificationPolicyCodecTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final OfflineNotificationPolicyCodec codec =
+      new OfflineNotificationPolicyCodec(objectMapper);
+
+  @Test
+  void legacyNullPolicyKeepsProjectOwnerInAppCompatibility() {
+    NotificationPolicy policy = codec.decodePolicy(null);
+
+    assertThat(policy.enabled()).isTrue();
+    assertThat(policy.recipientStrategy())
+        .isEqualTo(NotificationPolicy.RecipientStrategy.PROJECT_OWNER);
+    assertThat(policy.routesTo(NotificationPolicy.Destination.IN_APP)).isTrue();
+  }
+
+  @Test
+  void explicitUsersAreNormalizedAndMappedToRouterPolicy() {
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setRecipientType(" explicit_users ");
+    config.setRecipientUserIds(Arrays.asList(12L, null, -1L, 12L, 13L));
+
+    String json = codec.encode(config);
+    NotificationPolicy policy = codec.decodePolicy(json);
+
+    assertThat(policy.enabled()).isTrue();
+    assertThat(policy.recipientStrategy())
+        .isEqualTo(NotificationPolicy.RecipientStrategy.EXPLICIT_USERS);
+    assertThat(policy.recipientUserIds()).containsExactly(12L, 13L);
+    assertThat(policy.routesTo(NotificationPolicy.Destination.IN_APP)).isTrue();
+  }
+
+  @Test
+  void disabledTaskNotificationProducesDisabledPolicy() {
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setEnabled(false);
+    config.setRecipientType("EXPLICIT_USERS");
+
+    NotificationPolicy policy = codec.decodePolicy(codec.encode(config));
+
+    assertThat(policy.enabled()).isFalse();
+  }
+
+  @Test
+  void dedicatedColumnOverridesStaleEmbeddedEditDetail() throws Exception {
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setRecipientType("EXPLICIT_USERS");
+    config.setRecipientUserIds(List.of(21L));
+
+    JsonNode detail = objectMapper.readTree(
+        "{\"id\":10,\"notification\":{\"recipientType\":\"PROJECT_OWNER\"}}");
+    JsonNode result = codec.applyToEditDetail(detail, codec.encode(config));
+
+    assertThat(result.path("notification").path("recipientType").asText())
+        .isEqualTo("EXPLICIT_USERS");
+    assertThat(result.path("notification").path("recipientUserIds").get(0).asLong())
+        .isEqualTo(21L);
+  }
+
+  @Test
+  void legacyNullColumnRemovesPotentialEmbeddedNotification() throws Exception {
+    JsonNode detail = objectMapper.readTree(
+        "{\"id\":10,\"notification\":{\"enabled\":false}}");
+
+    JsonNode result = codec.applyToEditDetail(detail, null);
+
+    assertThat(result.has("notification")).isFalse();
+  }
+
+  @Test
+  void activeExplicitUserPolicyRequiresAtLeastOneRecipient() {
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setRecipientType("EXPLICIT_USERS");
+
+    assertThatThrownBy(() -> codec.encode(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("至少选择一个用户");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/notification/OfflineSyncNotificationPolicyResolverTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/notification/OfflineSyncNotificationPolicyResolverTest.java
@@ -1,0 +1,69 @@
+package io.yak.ops.business.sync.offline.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobNotificationDTO;
+import io.yak.ops.core.notification.NotificationIntent;
+import io.yak.ops.core.notification.NotificationPolicy;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncNotificationPolicyResolverTest {
+
+  @Test
+  void resolvesExecutionToConfiguredExplicitRecipients() {
+    OfflineNotificationPolicyReader reader = mock(OfflineNotificationPolicyReader.class);
+    OfflineNotificationPolicyCodec codec =
+        new OfflineNotificationPolicyCodec(new ObjectMapper());
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setRecipientType("EXPLICIT_USERS");
+    config.setRecipientUserIds(List.of(31L, 32L));
+    when(reader.find(7L, 99L)).thenReturn(Optional.of(
+        new OfflineNotificationPolicyReader.Snapshot(10L, codec.encode(config))));
+
+    OfflineSyncNotificationPolicyResolver resolver =
+        new OfflineSyncNotificationPolicyResolver(reader, codec);
+    NotificationPolicy policy = resolver.resolve(intent());
+
+    verify(reader).find(7L, 99L);
+    assertThat(resolver.supports(intent())).isTrue();
+    assertThat(resolver.order()).isEqualTo(100);
+    assertThat(policy.recipientStrategy())
+        .isEqualTo(NotificationPolicy.RecipientStrategy.EXPLICIT_USERS);
+    assertThat(policy.recipientUserIds()).containsExactly(31L, 32L);
+  }
+
+  @Test
+  void missingExecutionFailsClosedInsteadOfFallingBack() {
+    OfflineNotificationPolicyReader reader = mock(OfflineNotificationPolicyReader.class);
+    OfflineNotificationPolicyCodec codec =
+        new OfflineNotificationPolicyCodec(new ObjectMapper());
+    when(reader.find(7L, 99L)).thenReturn(Optional.empty());
+
+    OfflineSyncNotificationPolicyResolver resolver =
+        new OfflineSyncNotificationPolicyResolver(reader, codec);
+
+    assertThatThrownBy(() -> resolver.resolve(intent()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("无法解析离线同步通知策略");
+  }
+
+  private NotificationIntent intent() {
+    return new NotificationIntent(
+        7L,
+        NotificationIntent.Type.TASK,
+        NotificationIntent.Level.ERROR,
+        "离线同步任务执行失败",
+        "订单同步",
+        "engine down",
+        "OFFLINE_SYNC_EXECUTION",
+        "99",
+        "/sync/batch-link-up/10/detail");
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
@@ -7,7 +7,7 @@ import lombok.Data;
 /**
  * 离线同步任务定义入参。
  *
- * <p>离线同步是固定的 Source -> Channel -> Sink 链路。字段映射和调度配置作为
+ * <p>离线同步是固定的 Source -> Channel -> Sink 链路。字段映射、调度和通知策略作为
  * 任务级配置，与 basic、source、sink、channel 同级保存。</p>
  *
  * @author weifuwan
@@ -28,4 +28,7 @@ public class OfflineJobDefinitionDTO {
 
   /** 任务级 Cron、启停和失败重跑配置。 */
   private OfflineJobScheduleDTO schedule = new OfflineJobScheduleDTO();
+
+  /** 任务级通知策略；缺省/null 保留历史 Project OWNER + IN_APP 默认行为。 */
+  private OfflineJobNotificationDTO notification;
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobNotificationDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobNotificationDTO.java
@@ -1,0 +1,28 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Data;
+
+/** Offline Sync task-level notification policy input. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class OfflineJobNotificationDTO {
+
+  /** Master switch. Null inside an explicit policy is normalized to true. */
+  private Boolean enabled;
+
+  /** Supported trigger in Stage 4.2: FINAL_FAILURE. */
+  private List<String> triggers;
+
+  /** PROJECT_OWNER or EXPLICIT_USERS. */
+  private String recipientType;
+
+  /** Durable numeric recipients when recipientType is EXPLICIT_USERS. */
+  private List<Long> recipientUserIds;
+
+  /** Stage 4.2 supports the in-app Message Center destination only. */
+  private Boolean inAppEnabled;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
@@ -34,6 +34,7 @@ public class OfflineJobDefinitionPO {
   @TableField(updateStrategy = FieldStrategy.ALWAYS) private String cronExpression;
   private Integer retryMaxAttempts;
   private Integer retryBackoffSeconds;
+  @ToString.Exclude @TableField(updateStrategy = FieldStrategy.ALWAYS) private String notificationConfigJson;
   @TableField(updateStrategy = FieldStrategy.ALWAYS) private LocalDateTime scheduleLastFireTime;
   @TableField(updateStrategy = FieldStrategy.ALWAYS) private LocalDateTime scheduleNextFireTime;
   private Integer version;

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/NotificationConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/NotificationConfigSection.tsx
@@ -1,0 +1,230 @@
+import { Radio, Select, Switch, Tag, Typography } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+
+import { useSecurityProject } from '@/contexts/SecurityProjectContext';
+import {
+  getSecurityProject,
+  type SecurityProjectUser,
+} from '@/services/security/projects';
+
+import type { SyncEditorState } from '../model';
+import EditorSection from './EditorSection';
+
+interface NotificationConfigSectionProps {
+  editor: SyncEditorState;
+  onChange: (value: SyncEditorState) => void;
+}
+
+const uniqueUsers = (
+  users: SecurityProjectUser[],
+): SecurityProjectUser[] => {
+  const result = new Map<number, SecurityProjectUser>();
+  users.forEach((user) => {
+    if (Number.isSafeInteger(user.id) && user.id > 0) {
+      result.set(user.id, user);
+    }
+  });
+  return Array.from(result.values());
+};
+
+export default function NotificationConfigSection({
+  editor,
+  onChange,
+}: NotificationConfigSectionProps) {
+  const { currentProject } = useSecurityProject();
+  const [projectUsers, setProjectUsers] = useState<SecurityProjectUser[]>([]);
+  const [loadingUsers, setLoadingUsers] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const projectId = Number(currentProject?.id);
+    if (!Number.isSafeInteger(projectId) || projectId <= 0) {
+      setProjectUsers([]);
+      return undefined;
+    }
+
+    setLoadingUsers(true);
+    getSecurityProject(projectId)
+      .then((project) => {
+        if (cancelled) return;
+        setProjectUsers(
+          uniqueUsers([
+            ...(project.owners || []),
+            ...(project.members || []),
+          ]),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setProjectUsers([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingUsers(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentProject?.id]);
+
+  const updateNotification = (
+    patch: Partial<SyncEditorState['notification']>,
+  ) => {
+    onChange({
+      ...editor,
+      notification: {
+        ...editor.notification,
+        ...patch,
+      },
+    });
+  };
+
+  const userOptions = useMemo(() => {
+    const options = projectUsers.map((user) => ({
+      value: user.id,
+      label: user.realName?.trim()
+        ? `${user.realName.trim()} (${user.userName})`
+        : user.userName,
+    }));
+    const known = new Set(options.map((item) => item.value));
+    editor.notification.recipientUserIds.forEach((id) => {
+      if (!known.has(id)) {
+        options.push({
+          value: id,
+          label: `用户 #${id}（已不在当前项目）`,
+        });
+      }
+    });
+    return options;
+  }, [editor.notification.recipientUserIds, projectUsers]);
+
+  const active = editor.notification.enabled;
+  const explicit =
+    editor.notification.recipientType === 'EXPLICIT_USERS';
+
+  return (
+    <EditorSection title="通知设置">
+      <div className="space-y-5">
+        <div className="flex items-start justify-between gap-6 rounded-lg bg-[#f7f8fa] px-4 py-3">
+          <div>
+            <div className="text-[13px] font-medium text-[#344054]">
+              开启任务通知
+            </div>
+            <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+              当前仅在重试策略耗尽或不可重试的最终失败时触发，不会为每次失败重试重复发送。
+            </div>
+          </div>
+          <Switch
+            checked={active}
+            onChange={(enabled) => updateNotification({ enabled })}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-5 max-md:grid-cols-1">
+          <div>
+            <div className="mb-2 text-[12px] font-medium text-[#475467]">
+              触发条件
+            </div>
+            <div className="flex h-8 items-center">
+              <Tag color="error">最终执行失败</Tag>
+            </div>
+            <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+              Stage 4.2 只开放高价值失败通知，成功通知暂不启用。
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-2 text-[12px] font-medium text-[#475467]">
+              通知方式
+            </div>
+            <div className="flex h-8 items-center gap-3">
+              <Switch
+                disabled={!active}
+                checked={editor.notification.inAppEnabled}
+                onChange={(inAppEnabled) =>
+                  updateNotification({ inAppEnabled })
+                }
+              />
+              <span className="text-[12px] text-[#344054]">站内消息</span>
+            </div>
+            <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+              钉钉、邮件和 Webhook 等外部渠道将在 Alert 集成阶段接入。
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="mb-2 text-[12px] font-medium text-[#475467]">
+            接收人
+          </div>
+          <Radio.Group
+            disabled={!active || !editor.notification.inAppEnabled}
+            value={editor.notification.recipientType}
+            onChange={(event) =>
+              updateNotification({
+                recipientType: event.target.value,
+                recipientUserIds:
+                  event.target.value === 'PROJECT_OWNER'
+                    ? []
+                    : editor.notification.recipientUserIds,
+              })
+            }
+          >
+            <Radio value="PROJECT_OWNER">项目负责人</Radio>
+            <Radio value="EXPLICIT_USERS">指定用户</Radio>
+          </Radio.Group>
+
+          {explicit ? (
+            <div className="mt-3 max-w-[640px]">
+              <Select
+                mode="multiple"
+                allowClear
+                showSearch
+                optionFilterProp="label"
+                loading={loadingUsers}
+                disabled={!active || !editor.notification.inAppEnabled}
+                value={editor.notification.recipientUserIds}
+                options={userOptions}
+                placeholder={
+                  currentProject
+                    ? '选择当前项目中的接收用户'
+                    : '当前没有可用的项目空间'
+                }
+                className="w-full"
+                status={
+                  active &&
+                  editor.notification.inAppEnabled &&
+                  editor.notification.recipientUserIds.length === 0
+                    ? 'error'
+                    : undefined
+                }
+                onChange={(recipientUserIds) =>
+                  updateNotification({ recipientUserIds })
+                }
+              />
+              <Typography.Text
+                type={
+                  active &&
+                  editor.notification.inAppEnabled &&
+                  editor.notification.recipientUserIds.length === 0
+                    ? 'danger'
+                    : 'secondary'
+                }
+                className="mt-1.5 block !text-[11px]"
+              >
+                {active &&
+                editor.notification.inAppEnabled &&
+                editor.notification.recipientUserIds.length === 0
+                  ? '指定用户模式至少选择一个当前项目成员'
+                  : '仅展示当前 Project 的负责人和成员；保存时只记录稳定的用户 ID。'}
+              </Typography.Text>
+            </div>
+          ) : (
+            <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
+              最终失败时通知当前 Project 的 OWNER 用户，保持历史默认行为。
+            </div>
+          )}
+        </div>
+      </div>
+    </EditorSection>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -6,6 +6,7 @@ import { updateEndpointConfig, type SyncEditorState } from '../model';
 import ChannelConfigSection from './ChannelConfigSection';
 import FieldMappingSection, { type FieldMappingValue } from './FieldMappingSection';
 import MultiTableConfigSection from './MultiTableConfigSection';
+import NotificationConfigSection from './NotificationConfigSection';
 import ScheduleConfigSection from './ScheduleConfigSection';
 import SingleTableConfigSection from './SingleTableConfigSection';
 import TaskBasicSection from './TaskBasicSection';
@@ -142,6 +143,10 @@ export default function SyncTaskEditor({
 
       <div id="schedule-config" className="scroll-mt-6">
         <ScheduleConfigSection editor={editor} onChange={onChange} />
+      </div>
+
+      <div id="notification-config" className="scroll-mt-6">
+        <NotificationConfigSection editor={editor} onChange={onChange} />
       </div>
     </div>
   );

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -125,6 +125,14 @@ export default function SyncTaskEditor({
         />
       </div>
 
+      <div id="schedule-config" className="scroll-mt-6">
+        <ScheduleConfigSection editor={editor} onChange={onChange} />
+      </div>
+
+      <div id="notification-config" className="scroll-mt-6">
+        <NotificationConfigSection editor={editor} onChange={onChange} />
+      </div>
+
       {editor.mode === 'GUIDE_SINGLE' ? (
         <div id="field-mapping" className="scroll-mt-6">
           <FieldMappingSection
@@ -140,14 +148,6 @@ export default function SyncTaskEditor({
           />
         </div>
       ) : null}
-
-      <div id="schedule-config" className="scroll-mt-6">
-        <ScheduleConfigSection editor={editor} onChange={onChange} />
-      </div>
-
-      <div id="notification-config" className="scroll-mt-6">
-        <NotificationConfigSection editor={editor} onChange={onChange} />
-      </div>
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -5,6 +5,9 @@ import { connectorIdForDataSourceType } from './form-schema/valueAdapter';
 
 export type SyncMode = 'GUIDE_SINGLE' | 'GUIDE_MULTI';
 export type EndpointKind = 'source' | 'sink';
+export type SyncNotificationRecipientType =
+  | 'PROJECT_OWNER'
+  | 'EXPLICIT_USERS';
 
 export interface SyncTaskBasic {
   jobName: string;
@@ -43,6 +46,14 @@ export interface SyncSchedule {
   retryOnFailure: boolean;
 }
 
+export interface SyncNotification {
+  enabled: boolean;
+  triggers: string[];
+  recipientType: SyncNotificationRecipientType;
+  recipientUserIds: number[];
+  inAppEnabled: boolean;
+}
+
 export interface SyncEditorState {
   id: string;
   mode: SyncMode;
@@ -52,6 +63,7 @@ export interface SyncEditorState {
   channel: SyncChannel;
   mapping: SyncMapping;
   schedule: SyncSchedule;
+  notification: SyncNotification;
   state?: Record<string, any>;
 }
 
@@ -83,6 +95,14 @@ export const DEFAULT_SCHEDULE_CONFIG: SyncSchedule = {
   cron: '',
   enabled: false,
   retryOnFailure: false,
+};
+
+export const DEFAULT_NOTIFICATION_CONFIG: SyncNotification = {
+  enabled: true,
+  triggers: ['FINAL_FAILURE'],
+  recipientType: 'PROJECT_OWNER',
+  recipientUserIds: [],
+  inAppEnabled: true,
 };
 
 export const isApiSuccess = (response: any): boolean =>
@@ -195,6 +215,68 @@ const serializeSchedule = (
   retryOnFailure: Boolean(schedule?.retryOnFailure),
 });
 
+const normalizeNotificationUserIds = (value: unknown): number[] => {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(
+      value
+        .map((item) => Number(item))
+        .filter((id) => Number.isSafeInteger(id) && id > 0),
+    ),
+  );
+};
+
+const normalizeNotification = (raw: any): SyncNotification => {
+  const notification =
+    raw?.notification && typeof raw.notification === 'object'
+      ? raw.notification
+      : {};
+  const recipientType = String(
+    notification.recipientType || 'PROJECT_OWNER',
+  ).toUpperCase();
+
+  return {
+    enabled:
+      notification.enabled === undefined
+        ? DEFAULT_NOTIFICATION_CONFIG.enabled
+        : Boolean(notification.enabled),
+    triggers: ['FINAL_FAILURE'],
+    recipientType:
+      recipientType === 'EXPLICIT_USERS'
+        ? 'EXPLICIT_USERS'
+        : 'PROJECT_OWNER',
+    recipientUserIds: normalizeNotificationUserIds(
+      notification.recipientUserIds,
+    ),
+    inAppEnabled:
+      notification.inAppEnabled === undefined
+        ? DEFAULT_NOTIFICATION_CONFIG.inAppEnabled
+        : Boolean(notification.inAppEnabled),
+  };
+};
+
+const serializeNotification = (
+  notification?: SyncNotification,
+): SyncNotification => {
+  const recipientType =
+    notification?.recipientType === 'EXPLICIT_USERS'
+      ? 'EXPLICIT_USERS'
+      : 'PROJECT_OWNER';
+
+  return {
+    enabled: notification?.enabled !== false,
+    triggers: ['FINAL_FAILURE'],
+    recipientType,
+    recipientUserIds:
+      recipientType === 'EXPLICIT_USERS'
+        ? normalizeNotificationUserIds(
+            notification?.recipientUserIds,
+          )
+        : [],
+    inAppEnabled: notification?.inAppEnabled !== false,
+  };
+};
+
 const endpointFromType = (
   endpoint?: Partial<CreateSyncEndpoint> | null,
 ): SyncEndpoint => {
@@ -269,6 +351,7 @@ export const buildCreatePayload = (
       channel: serializeChannel(DEFAULT_CHANNEL_CONFIG),
       mapping: { ...DEFAULT_MAPPING_CONFIG },
       schedule: { ...DEFAULT_SCHEDULE_CONFIG },
+      notification: { ...DEFAULT_NOTIFICATION_CONFIG },
     };
   }
 
@@ -280,6 +363,7 @@ export const buildCreatePayload = (
     channel: DEFAULT_CHANNEL_CONFIG,
     mapping: { ...DEFAULT_MAPPING_CONFIG },
     schedule: { ...DEFAULT_SCHEDULE_CONFIG },
+    notification: { ...DEFAULT_NOTIFICATION_CONFIG },
   };
 };
 
@@ -469,6 +553,7 @@ export const normalizeEditDetail = (
     },
     mapping: normalizeMapping(raw),
     schedule: normalizeSchedule(raw),
+    notification: normalizeNotification(raw),
     state: raw?.state,
   };
 };
@@ -641,6 +726,7 @@ export const buildSavePayload = (
     ? serializeMapping(editor.mapping)
     : { ...DEFAULT_MAPPING_CONFIG };
   const schedule = serializeSchedule(editor.schedule);
+  const notification = serializeNotification(editor.notification);
 
   if (editor.mode === 'GUIDE_MULTI') {
     return {
@@ -651,6 +737,7 @@ export const buildSavePayload = (
       channel: serializeChannel(editor.channel),
       mapping,
       schedule,
+      notification,
     };
   }
 
@@ -662,5 +749,6 @@ export const buildSavePayload = (
     channel: editor.channel,
     mapping,
     schedule,
+    notification,
   };
 };

--- a/yak-ops-ui/src/pages/batch-link-up/detail/notificationPolicy.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/notificationPolicy.test.ts
@@ -1,0 +1,66 @@
+import {
+  buildSavePayload,
+  normalizeEditDetail,
+} from './model';
+
+describe('offline sync notification policy', () => {
+  it('maps legacy tasks without notification to the compatibility default', () => {
+    const editor = normalizeEditDetail(
+      {
+        id: 10,
+        basic: {
+          jobName: '订单同步',
+          jobDesc: '',
+          mode: 'GUIDE_SINGLE',
+        },
+        source: {},
+        sink: {},
+        channel: {},
+        schedule: {},
+      },
+      '10',
+    );
+
+    expect(editor.notification).toEqual({
+      enabled: true,
+      triggers: ['FINAL_FAILURE'],
+      recipientType: 'PROJECT_OWNER',
+      recipientUserIds: [],
+      inAppEnabled: true,
+    });
+  });
+
+  it('serializes explicit recipients as stable unique numeric user ids', () => {
+    const editor = normalizeEditDetail(
+      {
+        id: 10,
+        basic: {
+          jobName: '订单同步',
+          jobDesc: '',
+          mode: 'GUIDE_SINGLE',
+        },
+        source: {},
+        sink: {},
+        channel: {},
+        schedule: {},
+        notification: {
+          enabled: true,
+          recipientType: 'EXPLICIT_USERS',
+          recipientUserIds: [11, '12', 11, -1, null],
+          inAppEnabled: true,
+        },
+      },
+      '10',
+    );
+
+    const payload = buildSavePayload(editor);
+
+    expect(payload.notification).toEqual({
+      enabled: true,
+      triggers: ['FINAL_FAILURE'],
+      recipientType: 'EXPLICIT_USERS',
+      recipientUserIds: [11, 12],
+      inAppEnabled: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implement Stage 4.2 on top of the merged Notification Router foundation (#908): Offline Sync tasks can now configure their own final-failure in-app notification policy instead of always inheriting a hard-coded Project OWNER rule.

This PR deliberately stays inside the Stage 4.2 boundary: task policy + Message Center routing only. External Alert channels remain Stage 4.3.

## User experience

The shared Offline editor used by both `GUIDE_SINGLE` and `GUIDE_MULTI` now contains **通知设置**:

```text
开启任务通知
触发条件: 最终执行失败
通知方式: 站内消息
接收人:
  - 项目负责人
  - 指定用户
```

Explicit-user candidates come from the current Project's owners + members. The task stores stable numeric user IDs only.

No success notification is introduced and intermediate retry failures still do not create user notifications.

## Persistent contract

Added nullable task-level policy storage:

```text
yak_offline_job_definition.notification_config_json
```

Flyway:

```text
V2__add_offline_notification_config.sql
```

The migration is additive and performs **no backfill**.

`NULL` is intentional and means the legacy compatibility policy:

```text
final failure -> current Project OWNER -> IN_APP
```

So all existing Offline tasks keep the behavior introduced by #906/#908 without a data migration.

## API contract

`OfflineJobDefinitionDTO` now accepts:

```json
{
  "notification": {
    "enabled": true,
    "triggers": ["FINAL_FAILURE"],
    "recipientType": "PROJECT_OWNER",
    "recipientUserIds": [],
    "inAppEnabled": true
  }
}
```

Stage 4.2 accepts only:

```text
trigger:
  FINAL_FAILURE

recipientType:
  PROJECT_OWNER
  EXPLICIT_USERS

destination:
  IN_APP
```

The backend normalizes and validates the JSON before persistence.

## Backward compatibility

Older clients do not submit `notification`.

For an existing task:

```text
notification omitted by old client
        ↓
preserve existing notification_config_json
```

This prevents editing an unrelated field with an older UI/client from accidentally resetting a previously configured notification policy.

For edit detail, the dedicated `notification_config_json` column is authoritative and is projected back into the response. A stale embedded `definition_json.notification` cannot override it.

## Router integration

Added:

```text
OfflineSyncNotificationPolicyResolver
order = 100
supports sourceType = OFFLINE_SYNC_EXECUTION
```

Runtime resolution:

```text
NotificationIntent(projectId, sourceId=executionId)
        ↓
yak_offline_job_execution
        ↓
job_definition_id
        ↓
yak_offline_job_definition.notification_config_json
        ↓
NotificationPolicy
        ↓
IN_APP Sink / Message Center
```

The reader uses explicit `(projectId, executionId)` identity. It does not parse `actionPath` and does not depend on a ThreadLocal current Project, which is important because the Router can execute after the business transaction commits.

If execution/definition/policy state cannot be resolved, the Stage 4.1 Router semantics remain **fail closed** rather than silently falling back and violating an explicit opt-out.

## Policy mapping

```text
NULL policy
  -> PROJECT_OWNER + IN_APP

notification.enabled = false
  -> disabled

inAppEnabled = false
  -> disabled in Stage 4.2

PROJECT_OWNER
  -> PROJECT_OWNER + IN_APP

EXPLICIT_USERS
  -> EXPLICIT_USERS + recipientUserIds + IN_APP
```

## JobSpec isolation

Notification is a control-plane concern, not an engine concern.

`OfflineDefinitionModelAdapter.forJobSpec()` now explicitly removes the root `notification` field before JobSpec construction.

Therefore changing only notification preferences must not alter engine execution semantics or make notification delivery settings part of the engine JobSpec/config digest.

## Frontend

Updated the shared Offline editor model and UI:

- legacy tasks normalize to Project OWNER + IN_APP by default;
- new task payloads include the default notification policy;
- explicit user IDs are normalized to unique positive numeric IDs;
- the notification section is shared by single-table and multi-table editors;
- Project owners/members are loaded from the current Security Project detail;
- stale selected IDs are visibly identified as no longer belonging to the current Project;
- Alert channels are explicitly described as a later stage.

## Tests

Added/updated coverage for:

- legacy `NULL` policy compatibility;
- explicit recipient normalization and Router mapping;
- disabled notification mapping;
- dedicated-column edit-detail authority;
- active explicit-user policy requiring recipients;
- Offline resolver execution -> definition lookup semantics;
- resolver failure when the execution cannot be resolved;
- notification exclusion from engine JobSpec input;
- additive Flyway migration with no legacy backfill;
- existing `OfflineJobDefinitionService` constructor regression;
- frontend legacy/default normalization;
- frontend explicit user ID serialization.

## Documentation

Added:

```text
docs/architecture/OFFLINE_NOTIFICATION_POLICY.md
```

## Scope / non-goals

No:

- DingTalk/email/webhook delivery;
- Project-scoped Alert channel changes;
- `AlertService` calls from Offline business code;
- success notifications;
- per-retry notification spam;
- MQ/WebSocket/SSE;
- shared notification-policy database table.

## Suggested backend validation

```bash
mvn \
  -pl yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline \
  -am \
  -Dtest=OfflineNotificationPolicyCodecTest,OfflineSyncNotificationPolicyResolverTest,OfflineNotificationJobSpecIsolationTest,OfflineSlimSchemaTest,OfflineJobDefinitionServiceRuntimeTruthTest,OfflineFailureNotificationListenerTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

## Suggested frontend validation

```bash
cd yak-ops-ui
yarn tsc
yarn jest src/pages/batch-link-up/detail/notificationPolicy.test.ts
```

## Manual regression

1. Open an existing legacy task with no policy row value -> UI shows notification enabled, final failure, Project OWNER, in-app.
2. Final retry/non-retryable failure on that legacy task -> Project OWNER still gets one Message Center item.
3. Set notification disabled -> final failure produces no Message Center item.
4. Set explicit Project users -> only those user IDs are routed to IN_APP.
5. Intermediate retry failure -> no user notification.
6. Edit a configured task through a client that omits `notification` -> persisted policy is preserved.
7. Change only notification settings -> engine JobSpec must not gain a `notification` root field.
8. Switch Project -> user candidates come from the active Project and Message Center Project visibility remains isolated.

## Validation status

- branch is based on current `main` containing merged Stage 4.1 (#908);
- compare is ahead-only / behind 0;
- local Maven/Yarn execution is not available in this runtime, so the PR remains Draft until CI or developer-local validation runs the targeted suites.