### PR TITLE
feat(notification): route external alerts through Alert plugins (Stage 4.3)

### DIFF
--- a/docs/architecture/NOTIFICATION_ALERT_SINK.md
+++ b/docs/architecture/NOTIFICATION_ALERT_SINK.md
@@ -1,0 +1,210 @@
+# Notification Alert Sink (Stage 4.3)
+
+## Scope
+
+Stage 4.3 connects the Notification Router to the existing Yak Ops Alert plugin system.
+
+Business modules still publish only durable notification intent and policy. They do not depend on `AlertService`, plugin classes, webhook addresses, or channel credentials.
+
+```text
+Offline Sync final failure
+        ↓
+NotificationIntent
+        ↓
+NotificationPolicyResolver
+        ↓
+NotificationPolicy
+  destinations = IN_APP / ALERT
+  alertChannelIds = [...]
+        ↓
+DefaultNotificationRouter
+        ├─ IN_APP -> Yak Security Message Center
+        └─ ALERT  -> AlertNotificationSink
+                         ↓
+                    AlertService.notify
+                         ↓
+                   AlertPluginRegistry
+                         ↓
+                  registered plugin
+```
+
+## Alert Channel ownership
+
+`AlertChannel` remains a GLOBAL capability.
+
+Stage 4.3 does **not** add `project_id` to `yak_ops_alert_channel` and does not create a Project-specific copy of channel secrets.
+
+A Project-owned business task expresses its external delivery choice by storing references to global channel primary keys:
+
+```text
+task notification policy
+  alertChannelIds = [7, 8]
+        ↓
+yak_ops_alert_channel.id
+```
+
+Project ownership therefore belongs to the task / notification intent, while the reusable delivery endpoint remains global.
+
+## Stable channel identity
+
+The Router policy references the persisted database primary key, not `channelType` text.
+
+```text
+NotificationPolicy.alertChannelIds
+        ↓
+AlertChannelRepository.findById(id)
+        ↓
+AlertChannelDefinition.channelType
+        ↓
+AlertService.notify
+```
+
+`AlertChannelVO.id` is exposed so task editors can persist the stable key.
+
+Plugins that are registered but have never been configured do not have a persistent id and cannot be selected by a task.
+
+## Secret boundary
+
+`AlertNotificationSink` never reads or assembles channel credentials.
+
+It only resolves:
+
+```text
+channelId -> channelType
+```
+
+The existing `DefaultAlertService.notify()` remains responsible for:
+
+1. resolving the plugin from `AlertPluginRegistry`;
+2. loading persisted channel configuration;
+3. checking whether the channel is enabled;
+4. merging runtime non-address parameters;
+5. sending the final message through the plugin.
+
+Webhook URLs, tokens and other sensitive channel configuration therefore stay inside the Alert module.
+
+## Failure semantics
+
+External delivery is a secondary side effect.
+
+The Router already isolates destinations, and the ALERT sink additionally isolates every selected channel:
+
+```text
+channel 7 missing / disabled / failed
+        ↓
+log failure
+        ↓
+continue channel 8
+```
+
+A broken external channel must not:
+
+- fail the originating Offline Sync execution;
+- suppress Message Center delivery;
+- suppress another selected external channel.
+
+## Severity mapping
+
+Notification and Alert use slightly different level vocabularies:
+
+```text
+Notification INFO     -> Alert INFO
+Notification SUCCESS  -> Alert INFO
+Notification WARNING  -> Alert WARN
+Notification ERROR    -> Alert ERROR
+```
+
+Stage 4.3 does not invent a success-specific Alert severity.
+
+## Offline Sync policy
+
+The existing `notification_config_json` gains optional external delivery fields:
+
+```json
+{
+  "enabled": true,
+  "triggers": ["FINAL_FAILURE"],
+  "recipientType": "PROJECT_OWNER",
+  "recipientUserIds": [],
+  "inAppEnabled": true,
+  "alertEnabled": true,
+  "alertChannelIds": [7]
+}
+```
+
+Compatibility defaults are intentionally unchanged:
+
+```text
+legacy NULL policy
+  -> IN_APP enabled
+  -> Project OWNER
+  -> ALERT disabled
+```
+
+Existing Stage 4.2 JSON that has no `alertEnabled` or `alertChannelIds` also normalizes to ALERT disabled.
+
+External alert delivery is therefore opt-in and cannot start unexpectedly after upgrade.
+
+## Policy validation
+
+An enabled ALERT destination requires at least one valid positive channel id.
+
+```text
+alertEnabled = true
+alertChannelIds = []
+        ↓
+reject policy
+```
+
+`IN_APP` recipients are validated only when the IN_APP destination is enabled. An alert-only policy does not require a Project OWNER lookup or explicit in-app recipients.
+
+## UI
+
+The shared Offline Sync editor supports destination composition:
+
+```text
+通知方式
+  [x] 站内消息
+  [x] 外部告警渠道
+
+外部告警渠道
+  [DingTalk ...]
+```
+
+The channel selector uses `/api/v1/alert/channels` and only presents channels with persisted IDs.
+
+Disabled channels remain visible for historical selections but cannot be newly selected. Missing historical channel ids remain visible as stale references so the editor does not silently rewrite task configuration.
+
+## Current plugin availability
+
+At Stage 4.3 the repository contains a DingTalk Alert plugin.
+
+The sink is intentionally plugin-agnostic. Future Email, Webhook or other Alert plugins should be added behind `AlertPluginRegistry`; the Notification Router and business modules should not require another integration change.
+
+## Persistence
+
+Stage 4.3 adds no new table and no Flyway migration.
+
+It reuses:
+
+```text
+yak_ops_alert_channel.id
+```
+
+and the Stage 4.2 task-level:
+
+```text
+yak_offline_job_definition.notification_config_json
+```
+
+## Non-goals
+
+Stage 4.3 does not add:
+
+- Project ownership to Alert Channel;
+- Email or generic Webhook plugin implementations that do not already exist;
+- success notifications;
+- retry-attempt notification spam;
+- MQ / WebSocket / SSE;
+- synchronous coupling from Offline Sync to `AlertService`;
+- a second alert-channel configuration table.

--- a/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/dao/AlertChannelDao.java
+++ b/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/dao/AlertChannelDao.java
@@ -11,6 +11,8 @@ public interface AlertChannelDao {
 
   int update(AlertChannelPO po);
 
+  AlertChannelPO selectById(long id);
+
   AlertChannelPO selectByChannelType(String channelType);
 
   List<AlertChannelPO> selectAll();

--- a/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/dao/impl/AlertChannelDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/dao/impl/AlertChannelDaoImpl.java
@@ -27,6 +27,11 @@ public class AlertChannelDaoImpl implements AlertChannelDao {
   }
 
   @Override
+  public AlertChannelPO selectById(long id) {
+    return alertChannelMapper.selectById(id);
+  }
+
+  @Override
   public AlertChannelPO selectByChannelType(String channelType) {
     return alertChannelMapper.selectOne(
         Wrappers.<AlertChannelPO>lambdaQuery()

--- a/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/notification/AlertNotificationSink.java
+++ b/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/notification/AlertNotificationSink.java
@@ -1,0 +1,105 @@
+package io.yak.ops.business.alert.notification;
+
+import io.yak.ops.business.alert.domain.AlertChannelDefinition;
+import io.yak.ops.business.alert.repository.AlertChannelRepository;
+import io.yak.ops.business.alert.service.AlertService;
+import io.yak.ops.common.bean.dto.alert.AlertNotifyDTO;
+import io.yak.ops.core.notification.NotificationIntent;
+import io.yak.ops.core.notification.NotificationPolicy;
+import io.yak.ops.core.notification.NotificationSink;
+import io.yak.ops.plugin.alert.api.AlertResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/** Routes Notification Router ALERT destinations through the configured Alert plugin system. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlertNotificationSink implements NotificationSink {
+
+  private final AlertChannelRepository channelRepository;
+  private final AlertService alertService;
+
+  @Override
+  public NotificationPolicy.Destination destination() {
+    return NotificationPolicy.Destination.ALERT;
+  }
+
+  @Override
+  public void deliver(NotificationIntent intent, NotificationPolicy policy) {
+    for (Long channelId : policy.alertChannelIds()) {
+      deliverChannel(intent, channelId);
+    }
+  }
+
+  private void deliverChannel(NotificationIntent intent, Long channelId) {
+    try {
+      AlertChannelDefinition channel = channelRepository.findById(channelId).orElse(null);
+      if (channel == null) {
+        log.warn(
+            "Notification ALERT channel no longer exists: channelId={}, projectId={}, sourceType={}, sourceId={}",
+            channelId,
+            intent.projectId(),
+            intent.sourceType(),
+            intent.sourceId());
+        return;
+      }
+
+      AlertNotifyDTO dto = new AlertNotifyDTO();
+      dto.setChannelType(channel.getChannelType());
+      dto.setTitle(intent.title());
+      dto.setContent(content(intent));
+      dto.setLevel(level(intent.level()));
+
+      AlertResult result = alertService.notify(dto);
+      if (result == null || !result.success()) {
+        log.warn(
+            "Notification ALERT delivery failed: channelId={}, channelType={}, projectId={}, sourceType={}, sourceId={}, error={}",
+            channelId,
+            channel.getChannelType(),
+            intent.projectId(),
+            intent.sourceType(),
+            intent.sourceId(),
+            result == null ? "null result" : result.errorMessage());
+      }
+    } catch (RuntimeException exception) {
+      // One broken external channel must not suppress the remaining selected channels.
+      log.error(
+          "Notification ALERT delivery raised an exception: channelId={}, projectId={}, sourceType={}, sourceId={}",
+          channelId,
+          intent.projectId(),
+          intent.sourceType(),
+          intent.sourceId(),
+          exception);
+    }
+  }
+
+  private String content(NotificationIntent intent) {
+    String summary = intent.summary();
+    String detail = intent.content();
+    String body;
+    if (summary != null && detail != null && !summary.equals(detail)) {
+      body = summary + "\n\n" + detail;
+    } else if (detail != null) {
+      body = detail;
+    } else if (summary != null) {
+      body = summary;
+    } else {
+      body = intent.title();
+    }
+
+    if (intent.actionPath() != null) {
+      return body + "\n\n查看详情：" + intent.actionPath();
+    }
+    return body;
+  }
+
+  private String level(NotificationIntent.Level level) {
+    return switch (level) {
+      case WARNING -> "WARN";
+      case ERROR -> "ERROR";
+      case INFO, SUCCESS -> "INFO";
+    };
+  }
+}

--- a/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/repository/AlertChannelRepository.java
+++ b/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/repository/AlertChannelRepository.java
@@ -1,12 +1,14 @@
 package io.yak.ops.business.alert.repository;
 
-import io.yak.ops.common.enums.alert.AlertChannelStatus;
 import io.yak.ops.business.alert.domain.AlertChannelDefinition;
+import io.yak.ops.common.enums.alert.AlertChannelStatus;
 import java.util.List;
 import java.util.Optional;
 
 /** 告警渠道领域仓储。 */
 public interface AlertChannelRepository {
+  Optional<AlertChannelDefinition> findById(long id);
+
   Optional<AlertChannelDefinition> findByChannelType(String channelType);
 
   List<AlertChannelDefinition> findAll();

--- a/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/repository/AlertChannelRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/repository/AlertChannelRepositoryAdapter.java
@@ -18,6 +18,11 @@ public class AlertChannelRepositoryAdapter implements AlertChannelRepository {
   private final AlertChannelDao dao;
 
   @Override
+  public Optional<AlertChannelDefinition> findById(long id) {
+    return Optional.ofNullable(toDomain(dao.selectById(id)));
+  }
+
+  @Override
   public Optional<AlertChannelDefinition> findByChannelType(String channelType) {
     return Optional.ofNullable(toDomain(dao.selectByChannelType(channelType)));
   }

--- a/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/service/impl/DefaultAlertService.java
+++ b/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/service/impl/DefaultAlertService.java
@@ -117,7 +117,7 @@ public class DefaultAlertService implements AlertService {
         .map(AlertChannelVO::from)
         .toList();
 
-    // 数据库持久化配置 → 合并 id/enabled/connStatus/configJson
+    // 数据库持久化配置 → 合并安全的列表字段；敏感 configJson 仅由详情接口返回。
     Map<String, AlertChannelDefinition> persisted = repository.findAll().stream()
         .collect(Collectors.toMap(AlertChannelDefinition::getChannelType, Function.identity()));
 
@@ -127,7 +127,6 @@ public class DefaultAlertService implements AlertService {
         vo.setId(def.getId());
         vo.setEnabled(def.getEnabled());
         vo.setConnStatus(def.getConnStatus() != null ? def.getConnStatus().name() : "UNKNOWN");
-        vo.setConfigJson(def.getConfigJson());
       }
     }
     return channels;

--- a/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/service/impl/DefaultAlertService.java
+++ b/yak-ops-business/yak-ops-business-alert/src/main/java/io/yak/ops/business/alert/service/impl/DefaultAlertService.java
@@ -117,13 +117,14 @@ public class DefaultAlertService implements AlertService {
         .map(AlertChannelVO::from)
         .toList();
 
-    // 数据库持久化配置 → 合并 enabled/connStatus/configJson
+    // 数据库持久化配置 → 合并 id/enabled/connStatus/configJson
     Map<String, AlertChannelDefinition> persisted = repository.findAll().stream()
         .collect(Collectors.toMap(AlertChannelDefinition::getChannelType, Function.identity()));
 
     for (AlertChannelVO vo : channels) {
       AlertChannelDefinition def = persisted.get(vo.getType());
       if (def != null) {
+        vo.setId(def.getId());
         vo.setEnabled(def.getEnabled());
         vo.setConnStatus(def.getConnStatus() != null ? def.getConnStatus().name() : "UNKNOWN");
         vo.setConfigJson(def.getConfigJson());
@@ -147,6 +148,7 @@ public class DefaultAlertService implements AlertService {
     // 合并持久化配置
     AlertChannelDefinition def = repository.findByChannelType(channelType).orElse(null);
     if (def != null) {
+      vo.setId(def.getId());
       vo.setEnabled(def.getEnabled());
       vo.setConnStatus(def.getConnStatus() != null ? def.getConnStatus().name() : "UNKNOWN");
       vo.setConfigJson(def.getConfigJson());

--- a/yak-ops-business/yak-ops-business-alert/src/test/java/io/yak/ops/business/alert/notification/AlertNotificationSinkTest.java
+++ b/yak-ops-business/yak-ops-business-alert/src/test/java/io/yak/ops/business/alert/notification/AlertNotificationSinkTest.java
@@ -14,6 +14,7 @@ import io.yak.ops.common.bean.dto.alert.AlertNotifyDTO;
 import io.yak.ops.core.notification.NotificationIntent;
 import io.yak.ops.core.notification.NotificationPolicy;
 import io.yak.ops.plugin.alert.api.AlertResult;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -45,7 +46,7 @@ class AlertNotificationSinkTest {
     assertThat(captor.getAllValues())
         .extracting(AlertNotifyDTO::getTitle)
         .containsOnly("离线同步任务执行失败");
-    assertThat(captor.getAllValues().getFirst().getContent())
+    assertThat(captor.getAllValues().get(0).getContent())
         .contains("orders -> ods_orders")
         .contains("连接目标库超时")
         .contains("/sync/batch-link-up/10/detail");
@@ -87,7 +88,7 @@ class AlertNotificationSinkTest {
         NotificationPolicy.RecipientStrategy.PROJECT_OWNER,
         List.of(),
         Set.of(NotificationPolicy.Destination.ALERT),
-        List.of(ids));
+        Arrays.asList(ids));
   }
 
   private NotificationIntent intent(NotificationIntent.Level level) {

--- a/yak-ops-business/yak-ops-business-alert/src/test/java/io/yak/ops/business/alert/notification/AlertNotificationSinkTest.java
+++ b/yak-ops-business/yak-ops-business-alert/src/test/java/io/yak/ops/business/alert/notification/AlertNotificationSinkTest.java
@@ -1,0 +1,113 @@
+package io.yak.ops.business.alert.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.alert.domain.AlertChannelDefinition;
+import io.yak.ops.business.alert.repository.AlertChannelRepository;
+import io.yak.ops.business.alert.service.AlertService;
+import io.yak.ops.common.bean.dto.alert.AlertNotifyDTO;
+import io.yak.ops.core.notification.NotificationIntent;
+import io.yak.ops.core.notification.NotificationPolicy;
+import io.yak.ops.plugin.alert.api.AlertResult;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AlertNotificationSinkTest {
+
+  @Test
+  void sendsEachSelectedChannelThroughAlertService() {
+    AlertChannelRepository repository = mock(AlertChannelRepository.class);
+    AlertService alertService = mock(AlertService.class);
+    when(repository.findById(7L)).thenReturn(Optional.of(channel(7L, "DINGTALK")));
+    when(repository.findById(8L)).thenReturn(Optional.of(channel(8L, "CUSTOM")));
+    when(alertService.notify(any(AlertNotifyDTO.class))).thenReturn(AlertResult.ok());
+
+    AlertNotificationSink sink = new AlertNotificationSink(repository, alertService);
+    sink.deliver(intent(NotificationIntent.Level.WARNING), alertPolicy(7L, 8L));
+
+    ArgumentCaptor<AlertNotifyDTO> captor = ArgumentCaptor.forClass(AlertNotifyDTO.class);
+    verify(alertService, times(2)).notify(captor.capture());
+
+    assertThat(captor.getAllValues())
+        .extracting(AlertNotifyDTO::getChannelType)
+        .containsExactly("DINGTALK", "CUSTOM");
+    assertThat(captor.getAllValues())
+        .extracting(AlertNotifyDTO::getLevel)
+        .containsOnly("WARN");
+    assertThat(captor.getAllValues())
+        .extracting(AlertNotifyDTO::getTitle)
+        .containsOnly("离线同步任务执行失败");
+    assertThat(captor.getAllValues().getFirst().getContent())
+        .contains("orders -> ods_orders")
+        .contains("连接目标库超时")
+        .contains("/sync/batch-link-up/10/detail");
+  }
+
+  @Test
+  void missingChannelDoesNotSuppressRemainingChannels() {
+    AlertChannelRepository repository = mock(AlertChannelRepository.class);
+    AlertService alertService = mock(AlertService.class);
+    when(repository.findById(7L)).thenReturn(Optional.empty());
+    when(repository.findById(8L)).thenReturn(Optional.of(channel(8L, "DINGTALK")));
+    when(alertService.notify(any(AlertNotifyDTO.class))).thenReturn(AlertResult.ok());
+
+    new AlertNotificationSink(repository, alertService)
+        .deliver(intent(NotificationIntent.Level.ERROR), alertPolicy(7L, 8L));
+
+    verify(alertService, times(1)).notify(any(AlertNotifyDTO.class));
+  }
+
+  @Test
+  void failedChannelResultDoesNotThrowOrStopNextChannel() {
+    AlertChannelRepository repository = mock(AlertChannelRepository.class);
+    AlertService alertService = mock(AlertService.class);
+    when(repository.findById(7L)).thenReturn(Optional.of(channel(7L, "DINGTALK")));
+    when(repository.findById(8L)).thenReturn(Optional.of(channel(8L, "CUSTOM")));
+    when(alertService.notify(any(AlertNotifyDTO.class)))
+        .thenReturn(AlertResult.fail("network error"))
+        .thenReturn(AlertResult.ok());
+
+    new AlertNotificationSink(repository, alertService)
+        .deliver(intent(NotificationIntent.Level.ERROR), alertPolicy(7L, 8L));
+
+    verify(alertService, times(2)).notify(any(AlertNotifyDTO.class));
+  }
+
+  private NotificationPolicy alertPolicy(Long... ids) {
+    return new NotificationPolicy(
+        true,
+        NotificationPolicy.RecipientStrategy.PROJECT_OWNER,
+        List.of(),
+        Set.of(NotificationPolicy.Destination.ALERT),
+        List.of(ids));
+  }
+
+  private NotificationIntent intent(NotificationIntent.Level level) {
+    return new NotificationIntent(
+        3L,
+        NotificationIntent.Type.TASK,
+        level,
+        "离线同步任务执行失败",
+        "orders -> ods_orders",
+        "连接目标库超时",
+        "OFFLINE_SYNC_EXECUTION",
+        "1001",
+        "/sync/batch-link-up/10/detail");
+  }
+
+  private AlertChannelDefinition channel(long id, String type) {
+    AlertChannelDefinition channel = new AlertChannelDefinition();
+    channel.setId(id);
+    channel.setChannelType(type);
+    channel.setEnabled(true);
+    return channel;
+  }
+}

--- a/yak-ops-business/yak-ops-business-alert/src/test/java/io/yak/ops/business/alert/service/DefaultAlertServiceTest.java
+++ b/yak-ops-business/yak-ops-business-alert/src/test/java/io/yak/ops/business/alert/service/DefaultAlertServiceTest.java
@@ -100,6 +100,26 @@ class DefaultAlertServiceTest {
     assertEquals("1.0.0", vo.getVersion());
     assertFalse(vo.getEnabled()); // 未配置时默认 disabled
     assertEquals("UNKNOWN", vo.getConnStatus());
+    assertNull(vo.getId());
+    assertNull(vo.getConfigJson());
+  }
+
+  @Test
+  void listChannels_exposesStableIdButNotSensitiveConfig() {
+    AlertChannelSaveDTO dto = new AlertChannelSaveDTO();
+    dto.setChannelType(DINGTALK);
+    dto.setConfigJson("{\"webhookUrl\":\"https://example.com\",\"secret\":\"SEC123\"}");
+    dto.setEnabled(true);
+    assertTrue(alertService.saveChannel(dto));
+
+    AlertChannelVO listItem = alertService.listChannels().get(0);
+    assertEquals(41L, listItem.getId());
+    assertTrue(listItem.getEnabled());
+    assertNull(listItem.getConfigJson());
+
+    AlertChannelVO detail = alertService.getChannel(DINGTALK);
+    assertEquals(41L, detail.getId());
+    assertEquals(dto.getConfigJson(), detail.getConfigJson());
   }
 
   @Test
@@ -313,6 +333,13 @@ class DefaultAlertServiceTest {
     private AlertChannelDefinition stored;
 
     @Override
+    public Optional<AlertChannelDefinition> findById(long id) {
+      return stored != null && stored.getId() != null && stored.getId() == id
+          ? Optional.of(clone(stored))
+          : Optional.empty();
+    }
+
+    @Override
     public Optional<AlertChannelDefinition> findByChannelType(String channelType) {
       return stored != null && stored.getChannelType().equals(channelType)
           ? Optional.of(clone(stored))
@@ -327,6 +354,9 @@ class DefaultAlertServiceTest {
     @Override
     public boolean insert(AlertChannelDefinition definition) {
       stored = clone(definition);
+      if (stored.getId() == null) {
+        stored.setId(41L);
+      }
       return true;
     }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodec.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodec.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobNotificationDTO;
 import io.yak.ops.core.notification.NotificationPolicy;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -75,19 +76,40 @@ public class OfflineNotificationPolicyCodec {
       OfflineJobNotificationDTO config =
           normalize(objectMapper.readValue(json, OfflineJobNotificationDTO.class));
       if (!Boolean.TRUE.equals(config.getEnabled())
-          || !Boolean.TRUE.equals(config.getInAppEnabled())
           || !config.getTriggers().contains(FINAL_FAILURE)) {
         return NotificationPolicy.disabled();
       }
-      if (EXPLICIT_USERS.equals(config.getRecipientType())) {
-        return new NotificationPolicy(
-            true,
-            NotificationPolicy.RecipientStrategy.EXPLICIT_USERS,
-            config.getRecipientUserIds(),
-            Set.of(NotificationPolicy.Destination.IN_APP),
-            List.of());
+
+      Set<NotificationPolicy.Destination> destinations =
+          EnumSet.noneOf(NotificationPolicy.Destination.class);
+      if (Boolean.TRUE.equals(config.getInAppEnabled())) {
+        destinations.add(NotificationPolicy.Destination.IN_APP);
       }
-      return NotificationPolicy.projectOwnersInApp();
+      if (Boolean.TRUE.equals(config.getAlertEnabled())) {
+        destinations.add(NotificationPolicy.Destination.ALERT);
+      }
+      if (destinations.isEmpty()) {
+        return NotificationPolicy.disabled();
+      }
+
+      NotificationPolicy.RecipientStrategy recipientStrategy =
+          EXPLICIT_USERS.equals(config.getRecipientType())
+              ? NotificationPolicy.RecipientStrategy.EXPLICIT_USERS
+              : NotificationPolicy.RecipientStrategy.PROJECT_OWNER;
+      List<Long> recipientUserIds =
+          recipientStrategy == NotificationPolicy.RecipientStrategy.EXPLICIT_USERS
+              ? config.getRecipientUserIds()
+              : List.of();
+      List<Long> alertChannelIds = Boolean.TRUE.equals(config.getAlertEnabled())
+          ? config.getAlertChannelIds()
+          : List.of();
+
+      return new NotificationPolicy(
+          true,
+          recipientStrategy,
+          recipientUserIds,
+          destinations,
+          alertChannelIds);
     } catch (JsonProcessingException exception) {
       throw new IllegalStateException("离线同步通知策略 JSON 已损坏", exception);
     }
@@ -101,6 +123,7 @@ public class OfflineNotificationPolicyCodec {
     normalized.setEnabled(value.getEnabled() == null ? Boolean.TRUE : value.getEnabled());
     normalized.setInAppEnabled(
         value.getInAppEnabled() == null ? Boolean.TRUE : value.getInAppEnabled());
+    normalized.setAlertEnabled(Boolean.TRUE.equals(value.getAlertEnabled()));
 
     List<String> triggers = value.getTriggers() == null || value.getTriggers().isEmpty()
         ? List.of(FINAL_FAILURE)
@@ -123,13 +146,7 @@ public class OfflineNotificationPolicyCodec {
     }
     normalized.setRecipientType(recipientType);
 
-    List<Long> userIds = value.getRecipientUserIds() == null
-        ? List.of()
-        : value.getRecipientUserIds().stream()
-            .filter(Objects::nonNull)
-            .filter(id -> id > 0L)
-            .distinct()
-            .toList();
+    List<Long> userIds = normalizeIds(value.getRecipientUserIds());
     if (EXPLICIT_USERS.equals(recipientType)
         && Boolean.TRUE.equals(normalized.getEnabled())
         && Boolean.TRUE.equals(normalized.getInAppEnabled())
@@ -137,6 +154,25 @@ public class OfflineNotificationPolicyCodec {
       throw new IllegalArgumentException("指定用户通知至少需要选择一个用户");
     }
     normalized.setRecipientUserIds(EXPLICIT_USERS.equals(recipientType) ? userIds : List.of());
+
+    List<Long> alertChannelIds = normalizeIds(value.getAlertChannelIds());
+    if (Boolean.TRUE.equals(normalized.getEnabled())
+        && Boolean.TRUE.equals(normalized.getAlertEnabled())
+        && alertChannelIds.isEmpty()) {
+      throw new IllegalArgumentException("外部告警通知至少需要选择一个告警渠道");
+    }
+    normalized.setAlertChannelIds(
+        Boolean.TRUE.equals(normalized.getAlertEnabled()) ? alertChannelIds : List.of());
     return normalized;
+  }
+
+  private List<Long> normalizeIds(List<Long> ids) {
+    return ids == null
+        ? List.of()
+        : ids.stream()
+            .filter(Objects::nonNull)
+            .filter(id -> id > 0L)
+            .distinct()
+            .toList();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodecTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/notification/OfflineNotificationPolicyCodecTest.java
@@ -25,6 +25,7 @@ class OfflineNotificationPolicyCodecTest {
     assertThat(policy.recipientStrategy())
         .isEqualTo(NotificationPolicy.RecipientStrategy.PROJECT_OWNER);
     assertThat(policy.routesTo(NotificationPolicy.Destination.IN_APP)).isTrue();
+    assertThat(policy.routesTo(NotificationPolicy.Destination.ALERT)).isFalse();
   }
 
   @Test
@@ -44,6 +45,35 @@ class OfflineNotificationPolicyCodecTest {
   }
 
   @Test
+  void inAppAndAlertDestinationsCanBeCombined() {
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setAlertEnabled(true);
+    config.setAlertChannelIds(Arrays.asList(7L, null, -1L, 7L, 8L));
+
+    NotificationPolicy policy = codec.decodePolicy(codec.encode(config));
+
+    assertThat(policy.routesTo(NotificationPolicy.Destination.IN_APP)).isTrue();
+    assertThat(policy.routesTo(NotificationPolicy.Destination.ALERT)).isTrue();
+    assertThat(policy.alertChannelIds()).containsExactly(7L, 8L);
+  }
+
+  @Test
+  void alertOnlyPolicyDoesNotRequireInAppRecipients() {
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setInAppEnabled(false);
+    config.setRecipientType("EXPLICIT_USERS");
+    config.setAlertEnabled(true);
+    config.setAlertChannelIds(List.of(7L));
+
+    NotificationPolicy policy = codec.decodePolicy(codec.encode(config));
+
+    assertThat(policy.enabled()).isTrue();
+    assertThat(policy.routesTo(NotificationPolicy.Destination.IN_APP)).isFalse();
+    assertThat(policy.routesTo(NotificationPolicy.Destination.ALERT)).isTrue();
+    assertThat(policy.recipientUserIds()).isEmpty();
+  }
+
+  @Test
   void disabledTaskNotificationProducesDisabledPolicy() {
     OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
     config.setEnabled(false);
@@ -59,6 +89,8 @@ class OfflineNotificationPolicyCodecTest {
     OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
     config.setRecipientType("EXPLICIT_USERS");
     config.setRecipientUserIds(List.of(21L));
+    config.setAlertEnabled(true);
+    config.setAlertChannelIds(List.of(9L));
 
     JsonNode detail = objectMapper.readTree(
         "{\"id\":10,\"notification\":{\"recipientType\":\"PROJECT_OWNER\"}}");
@@ -68,6 +100,9 @@ class OfflineNotificationPolicyCodecTest {
         .isEqualTo("EXPLICIT_USERS");
     assertThat(result.path("notification").path("recipientUserIds").get(0).asLong())
         .isEqualTo(21L);
+    assertThat(result.path("notification").path("alertEnabled").asBoolean()).isTrue();
+    assertThat(result.path("notification").path("alertChannelIds").get(0).asLong())
+        .isEqualTo(9L);
   }
 
   @Test
@@ -88,5 +123,15 @@ class OfflineNotificationPolicyCodecTest {
     assertThatThrownBy(() -> codec.encode(config))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("至少选择一个用户");
+  }
+
+  @Test
+  void activeAlertPolicyRequiresAtLeastOneChannel() {
+    OfflineJobNotificationDTO config = new OfflineJobNotificationDTO();
+    config.setAlertEnabled(true);
+
+    assertThatThrownBy(() -> codec.encode(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("至少需要选择一个告警渠道");
   }
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobNotificationDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobNotificationDTO.java
@@ -14,15 +14,21 @@ public class OfflineJobNotificationDTO {
   /** Master switch. Null inside an explicit policy is normalized to true. */
   private Boolean enabled;
 
-  /** Supported trigger in Stage 4.2: FINAL_FAILURE. */
+  /** Supported trigger: FINAL_FAILURE. */
   private List<String> triggers;
 
-  /** PROJECT_OWNER or EXPLICIT_USERS. */
+  /** PROJECT_OWNER or EXPLICIT_USERS for the in-app destination. */
   private String recipientType;
 
   /** Durable numeric recipients when recipientType is EXPLICIT_USERS. */
   private List<Long> recipientUserIds;
 
-  /** Stage 4.2 supports the in-app Message Center destination only. */
+  /** Deliver to the in-app Message Center. */
   private Boolean inAppEnabled;
+
+  /** Deliver through the global Alert plugin system. */
+  private Boolean alertEnabled;
+
+  /** Stable yak_ops_alert_channel primary keys selected for external delivery. */
+  private List<Long> alertChannelIds;
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/alert/AlertChannelVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/alert/AlertChannelVO.java
@@ -7,6 +7,9 @@ import lombok.Data;
 @Data
 public class AlertChannelVO {
 
+  /** 持久化渠道主键；尚未保存配置的插件描述为 null。 */
+  private Long id;
+
   /** 渠道类型标识 */
   private String type;
 

--- a/yak-ops-core/src/main/java/io/yak/ops/core/notification/NotificationPolicy.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/notification/NotificationPolicy.java
@@ -36,6 +36,11 @@ public record NotificationPolicy(
         && recipientUserIds.isEmpty()) {
       throw new IllegalArgumentException("EXPLICIT_USERS in-app policy requires recipient user ids");
     }
+    if (enabled
+        && destinations.contains(Destination.ALERT)
+        && alertChannelIds.isEmpty()) {
+      throw new IllegalArgumentException("ALERT notification policy requires alert channel ids");
+    }
   }
 
   /** Current backward-compatible default inherited from the original Message Center integration. */

--- a/yak-ops-core/src/test/java/io/yak/ops/core/notification/NotificationPolicyTest.java
+++ b/yak-ops-core/src/test/java/io/yak/ops/core/notification/NotificationPolicyTest.java
@@ -58,4 +58,16 @@ class NotificationPolicyTest {
         List.of()))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  void alertPolicyRequiresConfiguredChannelIds() {
+    assertThatThrownBy(() -> new NotificationPolicy(
+        true,
+        NotificationPolicy.RecipientStrategy.PROJECT_OWNER,
+        List.of(),
+        Set.of(NotificationPolicy.Destination.ALERT),
+        List.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("alert channel ids");
+  }
 }

--- a/yak-ops-ui/src/pages/batch-link-up/detail/alertChannels.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/alertChannels.test.ts
@@ -1,0 +1,59 @@
+jest.mock('@/utils/HttpUtils', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+import HttpUtils from '@/utils/HttpUtils';
+
+import { fetchNotificationAlertChannels } from './alertChannels';
+
+const mockedGet = HttpUtils.get as jest.MockedFunction<
+  typeof HttpUtils.get
+>;
+
+describe('notification alert channels', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it('keeps only persisted channels with stable positive ids', async () => {
+    mockedGet.mockResolvedValue({
+      code: 0,
+      data: [
+        {
+          id: 7,
+          type: 'DINGTALK',
+          name: '钉钉告警',
+          enabled: true,
+          connStatus: 'CONNECTED',
+        },
+        {
+          id: null,
+          type: 'EMAIL',
+          name: '邮件',
+          enabled: false,
+        },
+        {
+          id: -1,
+          type: 'INVALID',
+          name: 'Invalid',
+          enabled: true,
+        },
+      ],
+    } as any);
+
+    await expect(fetchNotificationAlertChannels()).resolves.toEqual([
+      {
+        id: 7,
+        type: 'DINGTALK',
+        name: '钉钉告警',
+        enabled: true,
+        connStatus: 'CONNECTED',
+      },
+    ]);
+
+    expect(mockedGet).toHaveBeenCalledWith('/api/v1/alert/channels');
+  });
+});

--- a/yak-ops-ui/src/pages/batch-link-up/detail/alertChannels.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/alertChannels.ts
@@ -1,0 +1,56 @@
+import HttpUtils from '@/utils/HttpUtils';
+
+export interface NotificationAlertChannel {
+  id: number;
+  type: string;
+  name: string;
+  enabled: boolean;
+  connStatus: string;
+}
+
+interface AlertChannelResponse {
+  id?: number | string | null;
+  type?: string | null;
+  name?: string | null;
+  enabled?: boolean | null;
+  connStatus?: string | null;
+}
+
+/**
+ * 读取全局 Alert 渠道配置。
+ *
+ * 只有已经持久化的渠道才具有稳定 id，才能被任务通知策略引用。
+ * 插件已注册但尚未保存配置的渠道不会作为任务通知选项返回。
+ */
+export async function fetchNotificationAlertChannels(): Promise<
+  NotificationAlertChannel[]
+> {
+  const response = await HttpUtils.get<AlertChannelResponse[]>(
+    '/api/v1/alert/channels',
+  );
+  const list = Array.isArray(response?.data) ? response.data : [];
+
+  return list
+    .map((item) => {
+      const id = Number(item?.id);
+      const type = String(item?.type || '').trim();
+      const name = String(item?.name || type).trim();
+
+      if (!Number.isSafeInteger(id) || id <= 0 || !type) {
+        return null;
+      }
+
+      return {
+        id,
+        type,
+        name: name || type,
+        enabled: item?.enabled === true,
+        connStatus: String(item?.connStatus || 'UNKNOWN'),
+      } satisfies NotificationAlertChannel;
+    })
+    .filter(
+      (
+        item,
+      ): item is NotificationAlertChannel => item !== null,
+    );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/NotificationConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/NotificationConfigSection.tsx
@@ -7,6 +7,10 @@ import {
   type SecurityProjectUser,
 } from '@/services/security/projects';
 
+import {
+  fetchNotificationAlertChannels,
+  type NotificationAlertChannel,
+} from '../alertChannels';
 import type { SyncEditorState } from '../model';
 import EditorSection from './EditorSection';
 
@@ -34,6 +38,10 @@ export default function NotificationConfigSection({
   const { currentProject } = useSecurityProject();
   const [projectUsers, setProjectUsers] = useState<SecurityProjectUser[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(false);
+  const [alertChannels, setAlertChannels] = useState<
+    NotificationAlertChannel[]
+  >([]);
+  const [loadingAlertChannels, setLoadingAlertChannels] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -66,6 +74,25 @@ export default function NotificationConfigSection({
     };
   }, [currentProject?.id]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingAlertChannels(true);
+    fetchNotificationAlertChannels()
+      .then((channels) => {
+        if (!cancelled) setAlertChannels(channels);
+      })
+      .catch(() => {
+        if (!cancelled) setAlertChannels([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingAlertChannels(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const updateNotification = (
     patch: Partial<SyncEditorState['notification']>,
   ) => {
@@ -97,9 +124,35 @@ export default function NotificationConfigSection({
     return options;
   }, [editor.notification.recipientUserIds, projectUsers]);
 
+  const alertOptions = useMemo(() => {
+    const selected = new Set(editor.notification.alertChannelIds);
+    const options = alertChannels.map((channel) => ({
+      value: channel.id,
+      label: `${channel.name} (${channel.type})${
+        channel.enabled ? '' : ' · 已停用'
+      }`,
+      disabled: !channel.enabled && !selected.has(channel.id),
+    }));
+    const known = new Set(options.map((item) => item.value));
+    editor.notification.alertChannelIds.forEach((id) => {
+      if (!known.has(id)) {
+        options.push({
+          value: id,
+          label: `告警渠道 #${id}（已不存在）`,
+          disabled: false,
+        });
+      }
+    });
+    return options;
+  }, [alertChannels, editor.notification.alertChannelIds]);
+
   const active = editor.notification.enabled;
   const explicit =
     editor.notification.recipientType === 'EXPLICIT_USERS';
+  const missingAlertChannel =
+    active &&
+    editor.notification.alertEnabled &&
+    editor.notification.alertChannelIds.length === 0;
 
   return (
     <EditorSection title="通知设置">
@@ -110,7 +163,7 @@ export default function NotificationConfigSection({
               开启任务通知
             </div>
             <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
-              当前仅在重试策略耗尽或不可重试的最终失败时触发，不会为每次失败重试重复发送。
+              仅在重试策略耗尽或不可重试的最终失败时触发，不会为每次失败重试重复发送。
             </div>
           </div>
           <Switch
@@ -128,7 +181,7 @@ export default function NotificationConfigSection({
               <Tag color="error">最终执行失败</Tag>
             </div>
             <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
-              Stage 4.2 只开放高价值失败通知，成功通知暂不启用。
+              当前只开放高价值失败通知，成功通知暂不启用。
             </div>
           </div>
 
@@ -136,25 +189,71 @@ export default function NotificationConfigSection({
             <div className="mb-2 text-[12px] font-medium text-[#475467]">
               通知方式
             </div>
-            <div className="flex h-8 items-center gap-3">
-              <Switch
-                disabled={!active}
-                checked={editor.notification.inAppEnabled}
-                onChange={(inAppEnabled) =>
-                  updateNotification({ inAppEnabled })
-                }
-              />
-              <span className="text-[12px] text-[#344054]">站内消息</span>
+            <div className="space-y-2">
+              <div className="flex h-8 items-center gap-3">
+                <Switch
+                  disabled={!active}
+                  checked={editor.notification.inAppEnabled}
+                  onChange={(inAppEnabled) =>
+                    updateNotification({ inAppEnabled })
+                  }
+                />
+                <span className="text-[12px] text-[#344054]">站内消息</span>
+              </div>
+              <div className="flex h-8 items-center gap-3">
+                <Switch
+                  disabled={!active}
+                  checked={editor.notification.alertEnabled}
+                  onChange={(alertEnabled) =>
+                    updateNotification({ alertEnabled })
+                  }
+                />
+                <span className="text-[12px] text-[#344054]">外部告警渠道</span>
+              </div>
             </div>
             <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
-              钉钉、邮件和 Webhook 等外部渠道将在 Alert 集成阶段接入。
+              外部通知由全局 Alert 渠道和插件统一发送；任务只保存渠道 ID，不保存 Webhook 等敏感配置。
             </div>
           </div>
         </div>
 
+        {editor.notification.alertEnabled ? (
+          <div>
+            <div className="mb-2 text-[12px] font-medium text-[#475467]">
+              外部告警渠道
+            </div>
+            <div className="max-w-[640px]">
+              <Select
+                mode="multiple"
+                allowClear
+                showSearch
+                optionFilterProp="label"
+                loading={loadingAlertChannels}
+                disabled={!active}
+                value={editor.notification.alertChannelIds}
+                options={alertOptions}
+                placeholder="选择已配置的告警渠道"
+                className="w-full"
+                status={missingAlertChannel ? 'error' : undefined}
+                onChange={(alertChannelIds) =>
+                  updateNotification({ alertChannelIds })
+                }
+              />
+              <Typography.Text
+                type={missingAlertChannel ? 'danger' : 'secondary'}
+                className="mt-1.5 block !text-[11px]"
+              >
+                {missingAlertChannel
+                  ? '开启外部告警后至少选择一个已配置渠道'
+                  : '仅可选择已经在告警中心保存过配置的渠道；停用渠道不会实际发送。'}
+              </Typography.Text>
+            </div>
+          </div>
+        ) : null}
+
         <div>
           <div className="mb-2 text-[12px] font-medium text-[#475467]">
-            接收人
+            站内消息接收人
           </div>
           <Radio.Group
             disabled={!active || !editor.notification.inAppEnabled}
@@ -220,7 +319,7 @@ export default function NotificationConfigSection({
             </div>
           ) : (
             <div className="mt-2 text-[11px] leading-5 text-[#98a2b3]">
-              最终失败时通知当前 Project 的 OWNER 用户，保持历史默认行为。
+              站内消息会发送给当前 Project 的 OWNER 用户，保持历史默认行为。
             </div>
           )}
         </div>

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -52,6 +52,8 @@ export interface SyncNotification {
   recipientType: SyncNotificationRecipientType;
   recipientUserIds: number[];
   inAppEnabled: boolean;
+  alertEnabled: boolean;
+  alertChannelIds: number[];
 }
 
 export interface SyncEditorState {
@@ -103,6 +105,8 @@ export const DEFAULT_NOTIFICATION_CONFIG: SyncNotification = {
   recipientType: 'PROJECT_OWNER',
   recipientUserIds: [],
   inAppEnabled: true,
+  alertEnabled: false,
+  alertChannelIds: [],
 };
 
 export const isApiSuccess = (response: any): boolean =>
@@ -215,7 +219,7 @@ const serializeSchedule = (
   retryOnFailure: Boolean(schedule?.retryOnFailure),
 });
 
-const normalizeNotificationUserIds = (value: unknown): number[] => {
+const normalizeNotificationIds = (value: unknown): number[] => {
   if (!Array.isArray(value)) return [];
   return Array.from(
     new Set(
@@ -245,13 +249,20 @@ const normalizeNotification = (raw: any): SyncNotification => {
       recipientType === 'EXPLICIT_USERS'
         ? 'EXPLICIT_USERS'
         : 'PROJECT_OWNER',
-    recipientUserIds: normalizeNotificationUserIds(
+    recipientUserIds: normalizeNotificationIds(
       notification.recipientUserIds,
     ),
     inAppEnabled:
       notification.inAppEnabled === undefined
         ? DEFAULT_NOTIFICATION_CONFIG.inAppEnabled
         : Boolean(notification.inAppEnabled),
+    alertEnabled:
+      notification.alertEnabled === undefined
+        ? DEFAULT_NOTIFICATION_CONFIG.alertEnabled
+        : Boolean(notification.alertEnabled),
+    alertChannelIds: normalizeNotificationIds(
+      notification.alertChannelIds,
+    ),
   };
 };
 
@@ -262,6 +273,7 @@ const serializeNotification = (
     notification?.recipientType === 'EXPLICIT_USERS'
       ? 'EXPLICIT_USERS'
       : 'PROJECT_OWNER';
+  const alertEnabled = notification?.alertEnabled === true;
 
   return {
     enabled: notification?.enabled !== false,
@@ -269,11 +281,15 @@ const serializeNotification = (
     recipientType,
     recipientUserIds:
       recipientType === 'EXPLICIT_USERS'
-        ? normalizeNotificationUserIds(
+        ? normalizeNotificationIds(
             notification?.recipientUserIds,
           )
         : [],
     inAppEnabled: notification?.inAppEnabled !== false,
+    alertEnabled,
+    alertChannelIds: alertEnabled
+      ? normalizeNotificationIds(notification?.alertChannelIds)
+      : [],
   };
 };
 
@@ -482,7 +498,7 @@ const directConfig = (
     config.fetchSize = Number(options.fetch_size);
   }
   if (!config.batchSize && options.batch_size) {
-    config.batchSize = Number(options.batch_size);
+    config.batchSize = Number(options.batchSize);
   }
 
   return {

--- a/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/model.ts
@@ -498,7 +498,7 @@ const directConfig = (
     config.fetchSize = Number(options.fetch_size);
   }
   if (!config.batchSize && options.batch_size) {
-    config.batchSize = Number(options.batchSize);
+    config.batchSize = Number(options.batch_size);
   }
 
   return {

--- a/yak-ops-ui/src/pages/batch-link-up/detail/notificationPolicy.test.ts
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/notificationPolicy.test.ts
@@ -27,6 +27,8 @@ describe('offline sync notification policy', () => {
       recipientType: 'PROJECT_OWNER',
       recipientUserIds: [],
       inAppEnabled: true,
+      alertEnabled: false,
+      alertChannelIds: [],
     });
   });
 
@@ -61,6 +63,35 @@ describe('offline sync notification policy', () => {
       recipientType: 'EXPLICIT_USERS',
       recipientUserIds: [11, 12],
       inAppEnabled: true,
+      alertEnabled: false,
+      alertChannelIds: [],
     });
+  });
+
+  it('normalizes and serializes stable alert channel ids', () => {
+    const editor = normalizeEditDetail(
+      {
+        id: 10,
+        basic: {
+          jobName: '订单同步',
+          jobDesc: '',
+          mode: 'GUIDE_SINGLE',
+        },
+        source: {},
+        sink: {},
+        channel: {},
+        schedule: {},
+        notification: {
+          alertEnabled: true,
+          alertChannelIds: [7, '8', 7, -1, null],
+        },
+      },
+      '10',
+    );
+
+    const payload = buildSavePayload(editor);
+
+    expect(payload.notification.alertEnabled).toBe(true);
+    expect(payload.notification.alertChannelIds).toEqual([7, 8]);
   });
 });


### PR DESCRIPTION
## Summary

Implement Stage 4.3 on top of the merged Notification Router + Offline policy work (#908 / #909): connect `NotificationPolicy.Destination.ALERT` to the existing Yak Ops Alert plugin system and let Offline Sync tasks opt into configured external Alert channels.

The business boundary stays unchanged:

```text
business module
    ↓
NotificationIntent
    ↓
NotificationPolicy
    ↓
DefaultNotificationRouter
    ├─ IN_APP -> Message Center
    └─ ALERT  -> AlertNotificationSink
                     ↓
                AlertService.notify
                     ↓
              AlertPluginRegistry
                     ↓
              registered plugin
```

Business modules do not call `AlertService` directly and never handle channel credentials.

## Alert Channel ownership

`AlertChannel` remains a **GLOBAL** capability.

This PR deliberately does **not** add `project_id` to `yak_ops_alert_channel` and does not create Project-specific copies of webhook/token configuration.

A Project-owned task stores only references to reusable global channels:

```text
task.notification.alertChannelIds
        ↓
yak_ops_alert_channel.id
```

Project ownership stays on the task / NotificationIntent; reusable delivery endpoints remain global.

## Stable channel identity

`NotificationPolicy.alertChannelIds` now has a real persistence contract:

```text
alertChannelId
    ↓
AlertChannelRepository.findById
    ↓
channelType
    ↓
AlertService.notify
```

Added channel primary-key lookup through DAO + Repository and exposed the persisted `AlertChannelVO.id` for task editors.

The policy uses database IDs rather than `channelType`, so deleting/recreating a channel does not silently rebind an old task to a different persisted channel record.

## Core policy hardening

An enabled ALERT destination must contain at least one valid channel id:

```text
Destination.ALERT + []
    -> reject policy
```

This removes the previous half-configured state where a policy could request external delivery without identifying a destination channel.

## ALERT Sink

Added:

```text
AlertNotificationSink
```

Behavior:

- consumes only `NotificationPolicy.Destination.ALERT`;
- resolves each selected `alertChannelId` to a persisted channel;
- maps Notification severity to Alert severity;
- builds external notification copy from title / summary / content / internal action path;
- delegates actual sending to `AlertService.notify()`;
- never reads or assembles webhook/token credentials;
- isolates failures per selected channel.

Failure isolation:

```text
channel 7 missing / disabled / failed / throws
        ↓
log
        ↓
continue channel 8
```

A broken external channel cannot fail the originating business execution, suppress Message Center delivery, or suppress another selected external channel.

## Severity mapping

```text
Notification INFO     -> Alert INFO
Notification SUCCESS  -> Alert INFO
Notification WARNING  -> Alert WARN
Notification ERROR    -> Alert ERROR
```

## Secret boundary hardening

The existing `AlertChannelVO` contract already says `configJson` is detail-only, but `listChannels()` was also returning it.

Stage 4.3 fixes that mismatch:

```text
GET /api/v1/alert/channels
  -> id / type / name / status
  -> no configJson

GET /api/v1/alert/channels/{type}
  -> detail
  -> configJson retained for channel editing
```

This matters because the Offline task editor now queries the channel list. It should never need to receive webhook URLs, secrets or tokens just to select a channel id.

## Offline Sync task policy

The existing task-level `notification_config_json` now accepts:

```json
{
  "enabled": true,
  "triggers": ["FINAL_FAILURE"],
  "recipientType": "PROJECT_OWNER",
  "recipientUserIds": [],
  "inAppEnabled": true,
  "alertEnabled": true,
  "alertChannelIds": [7]
}
```

Destinations are composable:

```text
IN_APP only
ALERT only
IN_APP + ALERT
```

An alert-only policy does not require in-app user recipients.

Compatibility remains intentionally conservative:

```text
legacy NULL policy
  -> Project OWNER + IN_APP
  -> ALERT disabled

existing Stage 4.2 JSON without alert fields
  -> ALERT disabled
```

So upgrading cannot unexpectedly start sending DingTalk/external alerts.

## Frontend

The shared Offline editor now exposes:

```text
通知方式
  [ ] 站内消息
  [ ] 外部告警渠道

外部告警渠道
  [ configured channel(s) ]
```

Channel options come from the real backend endpoint:

```text
/api/v1/alert/channels
```

Only persisted channels with stable positive IDs are selectable.

- enabled channels can be selected;
- disabled channels are visible but cannot be newly selected;
- an already-selected disabled channel remains visible so it can be removed;
- a deleted historical channel id remains visible as a stale reference instead of silently rewriting task policy;
- task policy stores only channel IDs, never channel config.

## Existing plugin availability

The repository currently includes the DingTalk Alert plugin.

This PR does **not** invent placeholder Email/Webhook plugins. The Sink is plugin-agnostic: future plugins only need to register through `AlertPluginRegistry`; Notification Router and business modules do not need another integration layer.

## Persistence / Flyway

No schema change.

No Flyway migration.

Stage 4.3 reuses:

```text
yak_ops_alert_channel.id
yak_offline_job_definition.notification_config_json
```

## Tests

Added/updated coverage for:

- ALERT policy requires channel IDs;
- Alert Sink routes each selected channel through `AlertService.notify`;
- Notification WARNING -> Alert WARN mapping;
- missing channel does not suppress remaining channels;
- failed external result does not suppress remaining channels;
- Alert list exposes stable id but not sensitive config;
- Alert detail still returns config for editing;
- Offline IN_APP + ALERT combined policy;
- alert-only Offline policy;
- alert channel id normalization / dedupe;
- active external delivery requires at least one channel;
- legacy Offline task keeps ALERT disabled;
- frontend legacy policy remains in-app only;
- frontend external channel ID normalization;
- frontend Alert channel loader ignores unpersisted/invalid channel records.

Existing `DefaultNotificationRouterTest` already locks policy-based ALERT sink selection, after-commit routing and sink failure isolation.

## Documentation

Added:

```text
docs/architecture/NOTIFICATION_ALERT_SINK.md
```

## Non-goals

No:

- Project ownership on Alert Channel;
- new Alert channel table;
- Email/Webhook plugin placeholders;
- direct `AlertService` calls from Offline / Workflow / Quality;
- success notifications;
- per-retry failure spam;
- MQ / WebSocket / SSE.

## Suggested backend validation

```bash
mvn \
  -pl yak-ops-core,\
yak-ops-business/yak-ops-business-alert,\
yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline,\
yak-ops-boot \
  -am \
  -Dtest=NotificationPolicyTest,AlertNotificationSinkTest,DefaultAlertServiceTest,OfflineNotificationPolicyCodecTest,OfflineSyncNotificationPolicyResolverTest,DefaultNotificationRouterTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

## Suggested frontend validation

```bash
cd yak-ops-ui
yarn tsc
yarn jest \
  src/pages/batch-link-up/detail/notificationPolicy.test.ts \
  src/pages/batch-link-up/detail/alertChannels.test.ts
```

## Manual regression

1. Existing legacy Offline task -> final failure still creates Message Center item only; no external alert.
2. Existing Stage 4.2 task -> same behavior until external alert is explicitly enabled.
3. Configure DingTalk globally and enable it -> channel list returns a stable id without configJson.
4. Enable external alert on one Offline task and select DingTalk -> final failure sends through AlertService/plugin.
5. Enable both in-app and external -> both destinations receive the same business failure independently.
6. Disable DingTalk globally -> task remains configured but external send fails safely; Message Center still works.
7. Delete/recreate a channel -> old task's previous id is treated as stale rather than silently rebinding.
8. Intermediate retry failure -> no in-app or external notification.

## Validation status

- branch is based on current `main` containing merged Stage 4.2 (#909);
- compare is ahead-only / behind 0;
- no Flyway files changed;
- local Maven/Yarn execution is unavailable in this runtime, so this PR remains Draft until CI or developer-local targeted validation runs.