### PR TITLE
fix(job): propagate project context into async task runtime

### DIFF
--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/AbstractTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/AbstractTaskExecutorAdapter.java
@@ -144,7 +144,8 @@ public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     if (safeKey != null) idempotencyIndex.put(safeKey, executionId);
 
     try {
-      workerExecutor.submit(() -> runExecution(executionId, handle));
+      workerExecutor.submit(
+          contextFactory.captureProjectContext(() -> runExecution(executionId, handle)));
     } catch (RuntimeException exception) {
       TaskExecution failed = new TaskExecution(
           executionId,

--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/TaskExecutionContextFactory.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/TaskExecutionContextFactory.java
@@ -1,10 +1,15 @@
 package io.yak.ops.business.job.runtime;
 
 import io.yak.ops.business.job.environment.TaskEnvironmentResolver;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import io.yak.ops.plugin.task.api.DefaultTaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import java.util.Map;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Creates runtime contexts without depending on environment-management CRUD. */
@@ -12,9 +17,22 @@ import org.springframework.stereotype.Component;
 public class TaskExecutionContextFactory {
 
   private final TaskEnvironmentResolver environmentResolver;
+  private final CurrentProject currentProject;
+  private final ProjectContextScope projectScope;
 
+  /** Keeps focused tests and existing non-Spring callers source compatible. */
   public TaskExecutionContextFactory(TaskEnvironmentResolver environmentResolver) {
+    this(environmentResolver, null, null);
+  }
+
+  @Autowired
+  public TaskExecutionContextFactory(
+      TaskEnvironmentResolver environmentResolver,
+      CurrentProject currentProject,
+      ProjectContextScope projectScope) {
     this.environmentResolver = environmentResolver;
+    this.currentProject = currentProject;
+    this.projectScope = projectScope;
   }
 
   public TaskExecutionContext create(
@@ -39,5 +57,18 @@ public class TaskExecutionContextFactory {
       customiser.accept(builder);
     }
     return builder.build();
+  }
+
+  /**
+   * Captures the trusted Project Space on the submitting thread and restores it when the returned
+   * work runs on an asynchronous worker.
+   */
+  Runnable captureProjectContext(Runnable action) {
+    Objects.requireNonNull(action, "action must not be null");
+    if (currentProject == null || projectScope == null) return action;
+
+    ProjectContext captured = currentProject.current().orElse(null);
+    if (captured == null) return action;
+    return () -> projectScope.run(captured, action);
   }
 }

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapterTest.java
@@ -13,6 +13,9 @@ import io.yak.ops.business.job.runtime.TaskExecutionContextFactory;
 import io.yak.ops.business.job.task.TaskExecution;
 import io.yak.ops.business.job.task.TaskVersionSnapshot;
 import io.yak.ops.core.plugin.task.TaskPluginRegistry;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextScope;
 import io.yak.ops.plugin.task.api.TaskExecutionContext;
 import io.yak.ops.plugin.task.api.TaskExecutionResult;
 import io.yak.ops.plugin.task.api.TaskPlugin;
@@ -25,7 +28,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
@@ -107,6 +112,65 @@ class SqlTaskExecutorAdapterTest {
   }
 
   @Test
+  void restoresCapturedProjectContextOnAsyncWorker() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    ThreadLocal<ProjectContext> projectHolder = new ThreadLocal<>();
+    CurrentProject currentProject = () -> Optional.ofNullable(projectHolder.get());
+    ProjectContextScope projectScope = new ProjectContextScope() {
+      @Override
+      public <T> T call(ProjectContext context, Supplier<T> action) {
+        ProjectContext previous = projectHolder.get();
+        projectHolder.set(context);
+        try {
+          return action.get();
+        } finally {
+          if (previous == null) {
+            projectHolder.remove();
+          } else {
+            projectHolder.set(previous);
+          }
+        }
+      }
+    };
+    AtomicReference<Long> executedProjectId = new AtomicReference<>();
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(() -> {
+      executedProjectId.set(currentProject.requireProjectId());
+      return TaskExecutionResult.success(Map.of("ok", true));
+    });
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper,
+        contextFactory(currentProject, projectScope));
+    TaskDefinition definition = new TaskDefinition("SQL", 1, "select 1", "{}");
+    TaskVersionSnapshot snapshot = new TaskVersionSnapshot(
+        "development:42",
+        "项目上下文传播",
+        "SQL",
+        0L,
+        null,
+        objectMapper.writeValueAsString(definition),
+        definition.configJson());
+
+    projectHolder.set(new ProjectContext(42L, "Project A"));
+    TaskExecution started;
+    try {
+      started = adapter.start(
+          snapshot,
+          TaskExecutionTrigger.MANUAL,
+          null,
+          Map.of("nodeId", "42"));
+    } finally {
+      projectHolder.remove();
+    }
+    TaskExecution completed = awaitTerminal(started.executionId());
+
+    assertTrue(completed.successful());
+    assertEquals(42L, executedProjectId.get());
+    assertTrue(currentProject.current().isEmpty());
+  }
+
+  @Test
   void rejectsMissingImmutableSnapshotWithoutFallback() {
     adapter = new SqlTaskExecutorAdapter(
         TaskPluginRegistry.from(List.of(new RecordingSqlPlugin(TaskExecutionResult.success(Map.of())))),
@@ -174,13 +238,25 @@ class SqlTaskExecutorAdapterTest {
     return new TaskExecutionContextFactory(envVarService);
   }
 
+  private TaskExecutionContextFactory contextFactory(
+      CurrentProject currentProject,
+      ProjectContextScope projectScope) {
+    SystemEnvVarService envVarService = mock(SystemEnvVarService.class);
+    when(envVarService.resolveMergedEnv()).thenReturn(Map.of());
+    return new TaskExecutionContextFactory(envVarService, currentProject, projectScope);
+  }
+
   private static final class RecordingSqlPlugin implements TaskPlugin {
-    private final TaskExecutionResult result;
+    private final Supplier<TaskExecutionResult> resultSupplier;
     private final AtomicReference<TaskDefinition> definition = new AtomicReference<>();
     private final AtomicReference<TaskExecutionContext> context = new AtomicReference<>();
 
     private RecordingSqlPlugin(TaskExecutionResult result) {
-      this.result = result;
+      this(() -> result);
+    }
+
+    private RecordingSqlPlugin(Supplier<TaskExecutionResult> resultSupplier) {
+      this.resultSupplier = resultSupplier;
     }
 
     @Override
@@ -203,7 +279,7 @@ class SqlTaskExecutorAdapterTest {
       return new io.yak.ops.plugin.task.api.TaskExecutor() {
         @Override
         public TaskExecutionResult execute() {
-          return result;
+          return resultSupplier.get();
         }
       };
     }


### PR DESCRIPTION
## Summary

- capture the trusted Project Space before Task Runtime crosses the async boundary
- restore the captured `ProjectContext` inside the virtual-thread worker through `ProjectContextScope`
- keep non-project task execution unchanged when no Project context is present
- add a SQL Task Runtime regression test that reads `CurrentProject` from the actual async worker

## Root cause

Data Development manual SQL execution passes `PROJECT_REQUIRED` on the HTTP request thread, but the shared Task Runtime executes the plugin with `newVirtualThreadPerTaskExecutor()`. The worker thread did not restore the request's Project context, so datasource execution later failed with “没有获取到工作空间”.

This fixes the context propagation at the shared async runtime boundary instead of weakening Project governance or introducing a default-project fallback.

Fixes #911

## Testing

- added `SqlTaskExecutorAdapterTest.restoresCapturedProjectContextOnAsyncWorker`
- CI status will validate the module/build on this PR
