### PR TITLE
fix(data-service): unify pagination request documentation contract

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/DataServiceDocumentationManager.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/DataServiceDocumentationManager.java
@@ -4,7 +4,6 @@ import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
 import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation;
 import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation.ParameterDoc;
 import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation.ResponseFieldDoc;
-import io.yak.ops.business.dataservice.execution.DataServiceSqlCompiler;
 import io.yak.ops.business.dataservice.query.DataServiceReader;
 import io.yak.ops.business.dataservice.repository.DataServiceDocumentationRepository;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
@@ -24,44 +23,71 @@ import org.springframework.util.StringUtils;
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataServiceDocumentationManager {
-  private static final Set<String> PARAMETER_TYPES = Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME");
-  private static final Set<String> RESPONSE_TYPES = Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME", "OBJECT");
+  private static final Set<String> PARAMETER_TYPES =
+      Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME");
+  private static final Set<String> RESPONSE_TYPES =
+      Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME", "OBJECT");
   private final DataServiceReader dataServiceReader;
   private final DataServiceDocumentationRepository repository;
   private final DataServiceDocumentationReader reader;
-  private final DataServiceSqlCompiler sqlCompiler;
+  private final DataServiceRequestParameterContract requestParameterContract;
   private final DocumentationFingerprint fingerprint;
 
   @Transactional
   public ApiDocumentation save(Long apiId, DocumentationInput input) {
     if (input == null) throw new IllegalArgumentException("API 文档配置不能为空");
     DataServiceDefinition definition = dataServiceReader.require(apiId);
-    List<String> currentNames = sqlCompiler.parameterNames(definition.runtimeSnapshot().sql());
-    List<ParameterDoc> parameters = normalizeParameters(currentNames, input.parameters());
+    List<ParameterDoc> currentParameters = requestParameterContract.resolve(definition);
+    List<ParameterDoc> parameters = normalizeParameters(currentParameters, input.parameters());
     List<ResponseFieldDoc> responseFields = normalizeResponseFields(input.responseFields());
     repository.save(new DataServiceDocumentation(
-        apiId, fingerprint.sqlHash(definition.runtimeSnapshot().sql()), parameters, responseFields, LocalDateTime.now()));
+        apiId,
+        fingerprint.sqlHash(definition.runtimeSnapshot().sql()),
+        parameters,
+        responseFields,
+        LocalDateTime.now()));
     return reader.get(apiId);
   }
 
   @Transactional
-  public void deleteForApi(Long apiId) { repository.delete(apiId); }
+  public void deleteForApi(Long apiId) {
+    repository.delete(apiId);
+  }
 
-  private List<ParameterDoc> normalizeParameters(List<String> currentNames, List<ParameterDoc> input) {
+  private List<ParameterDoc> normalizeParameters(
+      List<ParameterDoc> currentParameters, List<ParameterDoc> input) {
     List<ParameterDoc> supplied = input == null ? List.of() : input;
-    Set<String> current = new LinkedHashSet<>(currentNames == null ? List.of() : currentNames);
+    Map<String, ParameterDoc> current = new LinkedHashMap<>();
+    for (ParameterDoc parameter : currentParameters == null ? List.<ParameterDoc>of() : currentParameters) {
+      current.put(parameter.name(), parameter);
+    }
+
     Set<String> seen = new LinkedHashSet<>();
     Map<String, ParameterDoc> byName = new LinkedHashMap<>();
     for (ParameterDoc parameter : supplied) {
-      if (parameter == null || !StringUtils.hasText(parameter.name())) throw new IllegalArgumentException("参数名称不能为空");
+      if (parameter == null || !StringUtils.hasText(parameter.name())) {
+        throw new IllegalArgumentException("参数名称不能为空");
+      }
       String name = parameter.name().trim();
-      if (!current.contains(name)) throw new IllegalArgumentException("SQL 中不存在参数：" + name);
+      ParameterDoc canonical = current.get(name);
+      if (canonical == null) throw new IllegalArgumentException("SQL 中不存在参数：" + name);
       if (!seen.add(name)) throw new IllegalArgumentException("参数文档重复：" + name);
-      byName.put(name, new ParameterDoc(name, normalizeType(parameter.type(), PARAMETER_TYPES), true,
-          trim(parameter.description(), 500), trim(parameter.example(), 500)));
+
+      String type = requestParameterContract.isRuntimeManaged(name)
+          ? canonical.type()
+          : normalizeType(parameter.type(), PARAMETER_TYPES);
+      byName.put(name, new ParameterDoc(
+          name,
+          type,
+          canonical.required(),
+          firstText(trim(parameter.description(), 500), canonical.description()),
+          firstText(trim(parameter.example(), 500), canonical.example())));
     }
+
     List<ParameterDoc> result = new ArrayList<>();
-    for (String name : current) result.add(byName.getOrDefault(name, new ParameterDoc(name, "STRING", true, null, null)));
+    for (ParameterDoc canonical : current.values()) {
+      result.add(byName.getOrDefault(canonical.name(), canonical));
+    }
     return result;
   }
 
@@ -71,23 +97,36 @@ public class DataServiceDocumentationManager {
     Set<String> seen = new LinkedHashSet<>();
     List<ResponseFieldDoc> result = new ArrayList<>();
     for (ResponseFieldDoc field : supplied) {
-      if (field == null || !StringUtils.hasText(field.name())) throw new IllegalArgumentException("响应字段名称不能为空");
+      if (field == null || !StringUtils.hasText(field.name())) {
+        throw new IllegalArgumentException("响应字段名称不能为空");
+      }
       String name = field.name().trim();
       if (!seen.add(name)) throw new IllegalArgumentException("响应字段重复：" + name);
-      result.add(new ResponseFieldDoc(name, normalizeType(field.type(), RESPONSE_TYPES), field.nullable(),
-          trim(field.description(), 500), trim(field.example(), 500)));
+      result.add(new ResponseFieldDoc(
+          name,
+          normalizeType(field.type(), RESPONSE_TYPES),
+          field.nullable(),
+          trim(field.description(), 500),
+          trim(field.example(), 500)));
     }
     return result;
   }
 
   private String normalizeType(String type, Set<String> allowed) {
     String normalized = StringUtils.hasText(type) ? type.trim().toUpperCase() : "STRING";
-    if (!allowed.contains(normalized)) throw new IllegalArgumentException("不支持的 Schema 类型：" + normalized);
+    if (!allowed.contains(normalized)) {
+      throw new IllegalArgumentException("不支持的 Schema 类型：" + normalized);
+    }
     return normalized;
+  }
+
+  private String firstText(String preferred, String fallback) {
+    return StringUtils.hasText(preferred) ? preferred : fallback;
   }
 
   private String trim(String value, int max) {
     if (!StringUtils.hasText(value)) return null;
-    String result = value.trim(); return result.length() <= max ? result : result.substring(0, max);
+    String result = value.trim();
+    return result.length() <= max ? result : result.substring(0, max);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/DataServiceDocumentationReader.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/DataServiceDocumentationReader.java
@@ -3,7 +3,6 @@ package io.yak.ops.business.dataservice.documentation;
 import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
 import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation;
 import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation.ParameterDoc;
-import io.yak.ops.business.dataservice.execution.DataServiceSqlCompiler;
 import io.yak.ops.business.dataservice.query.DataServiceReader;
 import io.yak.ops.business.dataservice.repository.DataServiceDocumentationRepository;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
@@ -22,36 +21,65 @@ import org.springframework.util.StringUtils;
 @ConditionalOnDataSourceEnabled
 @RequiredArgsConstructor
 public class DataServiceDocumentationReader {
-  private static final Set<String> PARAMETER_TYPES = Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME");
+  private static final Set<String> PARAMETER_TYPES =
+      Set.of("STRING", "INTEGER", "NUMBER", "BOOLEAN", "DATE", "DATETIME");
   private final DataServiceReader dataServiceReader;
   private final DataServiceDocumentationRepository repository;
-  private final DataServiceSqlCompiler sqlCompiler;
+  private final DataServiceRequestParameterContract requestParameterContract;
   private final DocumentationFingerprint fingerprint;
 
   public ApiDocumentation get(Long apiId) {
     DataServiceDefinition definition = dataServiceReader.require(apiId);
     DataServiceDocumentation stored = repository.findByApiId(apiId).orElse(null);
-    List<String> currentNames = sqlCompiler.parameterNames(definition.runtimeSnapshot().sql());
-    List<ParameterDoc> parameters = mergeCurrentParameters(currentNames, stored == null ? List.of() : stored.parameters());
+    List<ParameterDoc> currentParameters = requestParameterContract.resolve(definition);
+    List<ParameterDoc> parameters = mergeCurrentParameters(
+        currentParameters, stored == null ? List.of() : stored.parameters());
     boolean documented = stored != null;
-    boolean stale = documented && StringUtils.hasText(stored.sqlHash())
+    boolean stale = documented
+        && StringUtils.hasText(stored.sqlHash())
         && !stored.sqlHash().equals(fingerprint.sqlHash(definition.runtimeSnapshot().sql()));
     return new ApiDocumentation(
-        definition.id(), definition.settings().name(), "/api/v1/data-service/runtime" + definition.settings().path(),
-        definition.authMode().name(), definition.settings().description(), documented, stale, parameters,
-        stored == null ? List.of() : stored.responseFields(), stored == null ? null : stored.updateTime());
+        definition.id(),
+        definition.settings().name(),
+        "/api/v1/data-service/runtime" + definition.settings().path(),
+        definition.authMode().name(),
+        definition.settings().description(),
+        documented,
+        stale,
+        parameters,
+        stored == null ? List.of() : stored.responseFields(),
+        stored == null ? null : stored.updateTime());
   }
 
-  private List<ParameterDoc> mergeCurrentParameters(List<String> names, List<ParameterDoc> saved) {
-    Map<String, ParameterDoc> savedByName = (saved == null ? List.<ParameterDoc>of() : saved).stream()
+  private List<ParameterDoc> mergeCurrentParameters(
+      List<ParameterDoc> currentParameters, List<ParameterDoc> saved) {
+    Map<String, ParameterDoc> savedByName = (saved == null ? List.<ParameterDoc>of() : saved)
+        .stream()
         .filter(item -> item != null && StringUtils.hasText(item.name()))
-        .collect(Collectors.toMap(item -> item.name().trim(), Function.identity(), (first, ignored) -> first, LinkedHashMap::new));
+        .collect(Collectors.toMap(
+            item -> item.name().trim(),
+            Function.identity(),
+            (first, ignored) -> first,
+            LinkedHashMap::new));
+
     List<ParameterDoc> result = new ArrayList<>();
-    for (String name : names == null ? List.<String>of() : names) {
-      ParameterDoc item = savedByName.get(name);
-      result.add(item == null
-          ? new ParameterDoc(name, "STRING", true, null, null)
-          : new ParameterDoc(name, normalizeType(item.type()), true, trim(item.description(), 500), trim(item.example(), 500)));
+    for (ParameterDoc canonical : currentParameters == null
+        ? List.<ParameterDoc>of()
+        : currentParameters) {
+      ParameterDoc item = savedByName.get(canonical.name());
+      if (item == null) {
+        result.add(canonical);
+        continue;
+      }
+      String type = requestParameterContract.isRuntimeManaged(canonical.name())
+          ? canonical.type()
+          : normalizeType(item.type());
+      result.add(new ParameterDoc(
+          canonical.name(),
+          type,
+          canonical.required(),
+          firstText(trim(item.description(), 500), canonical.description()),
+          firstText(trim(item.example(), 500), canonical.example())));
     }
     return result;
   }
@@ -64,8 +92,13 @@ public class DataServiceDocumentationReader {
     return normalized;
   }
 
+  private String firstText(String preferred, String fallback) {
+    return StringUtils.hasText(preferred) ? preferred : fallback;
+  }
+
   private String trim(String value, int max) {
     if (!StringUtils.hasText(value)) return null;
-    String result = value.trim(); return result.length() <= max ? result : result.substring(0, max);
+    String result = value.trim();
+    return result.length() <= max ? result : result.substring(0, max);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/DataServiceRequestParameterContract.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/DataServiceRequestParameterContract.java
@@ -1,0 +1,62 @@
+package io.yak.ops.business.dataservice.documentation;
+
+import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
+import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation.ParameterDoc;
+import io.yak.ops.business.dataservice.query.DataServiceParameterNameReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Resolves the complete HTTP request parameter contract exposed by one Data Service. */
+@Component
+@RequiredArgsConstructor
+public class DataServiceRequestParameterContract {
+
+  private static final Map<String, ParameterDoc> PAGINATION_PARAMETERS = paginationParameters();
+
+  private final DataServiceParameterNameReader parameterNameReader;
+
+  public List<ParameterDoc> resolve(DataServiceDefinition definition) {
+    if (definition == null) throw new IllegalArgumentException("数据服务定义不能为空");
+
+    List<String> sqlNames = parameterNameReader.parameterNames(definition.runtimeSnapshot().sql());
+    if (definition.settings().paginationEnabled()) {
+      for (String name : sqlNames) {
+        if (isRuntimeManaged(name)) {
+          throw new IllegalArgumentException("开启分页时 SQL 参数不能使用系统分页参数名：" + name);
+        }
+      }
+    }
+
+    List<ParameterDoc> result = new ArrayList<>();
+    for (String name : sqlNames) {
+      result.add(new ParameterDoc(name, "STRING", true, null, null));
+    }
+    if (definition.settings().paginationEnabled()) result.addAll(PAGINATION_PARAMETERS.values());
+    return List.copyOf(result);
+  }
+
+  boolean isRuntimeManaged(String name) {
+    return name != null && PAGINATION_PARAMETERS.containsKey(name);
+  }
+
+  private static Map<String, ParameterDoc> paginationParameters() {
+    Map<String, ParameterDoc> result = new LinkedHashMap<>();
+    result.put(
+        "returnTotalNum",
+        new ParameterDoc(
+            "returnTotalNum", "BOOLEAN", false, "是否返回分页总数，默认 true", "true"));
+    result.put(
+        "pageNum",
+        new ParameterDoc("pageNum", "INTEGER", false, "页码，从 1 开始，默认 1", "1"));
+    result.put(
+        "pageSize",
+        new ParameterDoc(
+            "pageSize", "INTEGER", false, "每页条数，默认 20，不超过服务最大行数", "20"));
+    return Collections.unmodifiableMap(result);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/OpenApiRenderer.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/documentation/OpenApiRenderer.java
@@ -25,7 +25,7 @@ public class OpenApiRenderer {
       Map<String, Object> item = new LinkedHashMap<>();
       item.put("name", parameter.name());
       item.put("in", "query");
-      item.put("required", true);
+      item.put("required", parameter.required());
       if (hasText(parameter.description())) item.put("description", parameter.description());
       item.put("schema", schema(parameter.type(), false));
       if (hasText(parameter.example())) item.put("example", parameter.example());
@@ -38,12 +38,14 @@ public class OpenApiRenderer {
     operation.put("x-yak-schema-stale", doc.schemaStale());
     if (hasText(doc.description())) operation.put("description", doc.description());
     operation.put("parameters", parameters);
-    if ("API_KEY".equals(doc.authMode())) operation.put("security", List.of(Map.of("ApiKeyAuth", List.of())));
+    if ("API_KEY".equals(doc.authMode())) {
+      operation.put("security", List.of(Map.of("ApiKeyAuth", List.of())));
+    }
     operation.put("responses", responses(doc.schemaStale() ? List.of() : doc.responseFields()));
     root.put("paths", Map.of(doc.runtimePath(), Map.of("get", operation)));
     if ("API_KEY".equals(doc.authMode())) {
-      root.put("components", Map.of("securitySchemes", Map.of("ApiKeyAuth",
-          map("type", "apiKey", "in", "header", "name", "X-API-Key"))));
+      root.put("components", Map.of("securitySchemes", Map.of(
+          "ApiKeyAuth", map("type", "apiKey", "in", "header", "name", "X-API-Key"))));
     }
     return root;
   }
@@ -58,17 +60,21 @@ public class OpenApiRenderer {
     }
     Map<String, Object> dataProperties = new LinkedHashMap<>();
     dataProperties.put("columns", map("type", "array", "items", Map.of("type", "string")));
-    dataProperties.put("rows", map("type", "array", "items",
+    dataProperties.put("rows", map(
+        "type", "array", "items",
         map("type", "object", "properties", rowProperties, "additionalProperties", true)));
     dataProperties.put("truncated", Map.of("type", "boolean"));
     dataProperties.put("rowCount", map("type", "integer", "format", "int32"));
     dataProperties.put("durationMs", map("type", "integer", "format", "int64"));
-    Map<String, Object> envelope = map("type", "object", "properties", map(
-        "code", map("type", "integer", "format", "int32"),
-        "data", map("type", "object", "properties", dataProperties),
-        "msg", Map.of("type", "string"), "message", Map.of("type", "string")));
+    Map<String, Object> envelope = map(
+        "type", "object", "properties", map(
+            "code", map("type", "integer", "format", "int32"),
+            "data", map("type", "object", "properties", dataProperties),
+            "msg", Map.of("type", "string"),
+            "message", Map.of("type", "string")));
     Map<String, Object> responses = new LinkedHashMap<>();
-    responses.put("200", map("description", "Success", "content",
+    responses.put("200", map(
+        "description", "Success", "content",
         Map.of("application/json", Map.of("schema", envelope))));
     responses.put("401", Map.of("description", "Missing or invalid API Key"));
     responses.put("429", Map.of("description", "Rate limit exceeded"));
@@ -80,23 +86,42 @@ public class OpenApiRenderer {
     String normalized = type == null ? "STRING" : type.trim().toUpperCase();
     Map<String, Object> schema = new LinkedHashMap<>();
     switch (normalized) {
-      case "INTEGER" -> { schema.put("type", "integer"); schema.put("format", "int64"); }
-      case "NUMBER" -> { schema.put("type", "number"); schema.put("format", "double"); }
+      case "INTEGER" -> {
+        schema.put("type", "integer");
+        schema.put("format", "int64");
+      }
+      case "NUMBER" -> {
+        schema.put("type", "number");
+        schema.put("format", "double");
+      }
       case "BOOLEAN" -> schema.put("type", "boolean");
-      case "DATE" -> { schema.put("type", "string"); schema.put("format", "date"); }
-      case "DATETIME" -> { schema.put("type", "string"); schema.put("format", "date-time"); }
-      case "OBJECT" -> { schema.put("type", "object"); schema.put("additionalProperties", true); }
+      case "DATE" -> {
+        schema.put("type", "string");
+        schema.put("format", "date");
+      }
+      case "DATETIME" -> {
+        schema.put("type", "string");
+        schema.put("format", "date-time");
+      }
+      case "OBJECT" -> {
+        schema.put("type", "object");
+        schema.put("additionalProperties", true);
+      }
       default -> schema.put("type", "string");
     }
     if (nullable) schema.put("nullable", true);
     return schema;
   }
 
-  private boolean hasText(String value) { return value != null && !value.isBlank(); }
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
 
   private Map<String, Object> map(Object... values) {
     Map<String, Object> result = new LinkedHashMap<>();
-    for (int index = 0; index + 1 < values.length; index += 2) result.put(String.valueOf(values[index]), values[index + 1]);
+    for (int index = 0; index + 1 < values.length; index += 2) {
+      result.put(String.valueOf(values[index]), values[index + 1]);
+    }
     return result;
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/documentation/DataServiceDocumentationManagerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/documentation/DataServiceDocumentationManagerTest.java
@@ -25,11 +25,13 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class DataServiceDocumentationManagerTest {
 
   private DataServiceReader dataServiceReader;
   private DataServiceDocumentationRepository repository;
+  private DataServiceDocumentationReader reader;
   private DataServiceDocumentationManager manager;
 
   @BeforeEach
@@ -37,17 +39,19 @@ class DataServiceDocumentationManagerTest {
     dataServiceReader = mock(DataServiceReader.class);
     repository = mock(DataServiceDocumentationRepository.class);
     DataServiceSqlCompiler compiler = new DataServiceSqlCompiler();
+    DataServiceRequestParameterContract requestParameterContract =
+        new DataServiceRequestParameterContract(compiler);
     DocumentationFingerprint fingerprint = new DocumentationFingerprint();
-    DataServiceDocumentationReader reader =
-        new DataServiceDocumentationReader(dataServiceReader, repository, compiler, fingerprint);
+    reader = new DataServiceDocumentationReader(
+        dataServiceReader, repository, requestParameterContract, fingerprint);
     manager = new DataServiceDocumentationManager(
-        dataServiceReader, repository, reader, compiler, fingerprint);
+        dataServiceReader, repository, reader, requestParameterContract, fingerprint);
   }
 
   @Test
   void currentSqlParametersRemainSourceOfTruth() {
     DataServiceDefinition definition = definition(
-        "select * from orders where status = :status and tenant_id = :tenantId");
+        "select * from orders where status = :status and tenant_id = :tenantId", false);
     when(dataServiceReader.require(7L)).thenReturn(definition);
     when(repository.findByApiId(7L)).thenReturn(Optional.of(new DataServiceDocumentation(
         7L,
@@ -58,8 +62,6 @@ class DataServiceDocumentationManagerTest {
         List.of(),
         null)));
 
-    DataServiceDocumentationReader reader = new DataServiceDocumentationReader(
-        dataServiceReader, repository, new DataServiceSqlCompiler(), new DocumentationFingerprint());
     ApiDocumentation result = reader.get(7L);
 
     assertThat(result.parameters()).extracting(ParameterDoc::name)
@@ -69,9 +71,75 @@ class DataServiceDocumentationManagerTest {
   }
 
   @Test
-  void rejectsParameterThatDoesNotExistInSql() {
+  void paginationRuntimeParametersDoNotNeedSqlPlaceholders() {
+    DataServiceDefinition definition =
+        definition("select * from orders where status = :status", true);
+    when(dataServiceReader.require(7L)).thenReturn(definition);
+    when(repository.findByApiId(7L)).thenReturn(Optional.empty());
+
+    ApiDocumentation result = manager.save(
+        7L,
+        new DocumentationInput(
+            List.of(
+                new ParameterDoc("status", "STRING", true, "订单状态", "PAID"),
+                new ParameterDoc("returnTotalNum", "BOOLEAN", false, null, null),
+                new ParameterDoc("pageNum", "INTEGER", false, null, null),
+                new ParameterDoc("pageSize", "INTEGER", false, null, null)),
+            List.<ResponseFieldDoc>of()));
+
+    ArgumentCaptor<DataServiceDocumentation> saved =
+        ArgumentCaptor.forClass(DataServiceDocumentation.class);
+    verify(repository).save(saved.capture());
+    assertThat(saved.getValue().parameters()).extracting(ParameterDoc::name)
+        .containsExactly("status", "returnTotalNum", "pageNum", "pageSize");
+    assertThat(saved.getValue().parameters().get(0).required()).isTrue();
+    assertThat(saved.getValue().parameters().subList(1, 4))
+        .allSatisfy(parameter -> assertThat(parameter.required()).isFalse());
+    assertThat(saved.getValue().parameters().get(1).type()).isEqualTo("BOOLEAN");
+    assertThat(saved.getValue().parameters().get(2).type()).isEqualTo("INTEGER");
+    assertThat(saved.getValue().parameters().get(3).type()).isEqualTo("INTEGER");
+    assertThat(result.parameters()).extracting(ParameterDoc::name)
+        .containsExactly("status", "returnTotalNum", "pageNum", "pageSize");
+  }
+
+  @Test
+  void readerRestoresOptionalPaginationParametersFromCurrentRuntimeContract() {
+    DataServiceDefinition definition =
+        definition("select * from orders where status = :status", true);
+    when(dataServiceReader.require(7L)).thenReturn(definition);
+    when(repository.findByApiId(7L)).thenReturn(Optional.of(new DataServiceDocumentation(
+        7L,
+        new DocumentationFingerprint().sqlHash(definition.runtimeSnapshot().sql()),
+        List.of(new ParameterDoc("status", "STRING", true, "订单状态", "PAID")),
+        List.of(),
+        null)));
+
+    ApiDocumentation result = reader.get(7L);
+
+    assertThat(result.parameters()).extracting(ParameterDoc::name)
+        .containsExactly("status", "returnTotalNum", "pageNum", "pageSize");
+    assertThat(result.parameters().get(0).required()).isTrue();
+    assertThat(result.parameters().subList(1, 4))
+        .allSatisfy(parameter -> assertThat(parameter.required()).isFalse());
+    assertThat(result.parameters().get(1).description()).contains("分页总数");
+    assertThat(result.parameters().get(2).example()).isEqualTo("1");
+    assertThat(result.parameters().get(3).example()).isEqualTo("20");
+  }
+
+  @Test
+  void paginationRuntimeNamesAreReservedFromSqlParameters() {
     when(dataServiceReader.require(7L)).thenReturn(
-        definition("select * from orders where status = :status"));
+        definition("select * from orders where id = :pageNum", true));
+
+    assertThatThrownBy(() -> reader.get(7L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("系统分页参数名：pageNum");
+  }
+
+  @Test
+  void rejectsParameterThatDoesNotExistInSqlOrRuntimeContract() {
+    when(dataServiceReader.require(7L)).thenReturn(
+        definition("select * from orders where status = :status", false));
 
     assertThatThrownBy(() -> manager.save(
         7L,
@@ -84,11 +152,12 @@ class DataServiceDocumentationManagerTest {
     verify(repository, never()).save(any());
   }
 
-  private DataServiceDefinition definition(String sql) {
+  private DataServiceDefinition definition(String sql, boolean paginationEnabled) {
     LocalDateTime now = LocalDateTime.of(2026, 8, 24, 10, 0);
     return DataServiceDefinition.restore(
         7L,
-        new DataServiceSettings("订单查询", "/orders", 1000, 30, true, "供订单系统查询", false),
+        new DataServiceSettings(
+            "订单查询", "/orders", 1000, 30, true, "供订单系统查询", paginationEnabled),
         new PublishedRuntimeSnapshot(42L, sql),
         new SourceReference("DATA_DEVELOPMENT_RELEASE", "88", 102L, 2),
         RuntimePolicy.defaults(false),

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/documentation/OpenApiRendererTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/documentation/OpenApiRendererTest.java
@@ -1,0 +1,45 @@
+package io.yak.ops.business.dataservice.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation.ParameterDoc;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenApiRendererTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void rendersPaginationRuntimeParametersAsOptional() {
+    ApiDocumentation documentation = new ApiDocumentation(
+        7L,
+        "订单查询",
+        "/api/v1/data-service/runtime/orders",
+        "NONE",
+        null,
+        true,
+        false,
+        List.of(
+            new ParameterDoc("status", "STRING", true, "订单状态", "PAID"),
+            new ParameterDoc("returnTotalNum", "BOOLEAN", false, "是否返回分页总数", "true"),
+            new ParameterDoc("pageNum", "INTEGER", false, "页码", "1"),
+            new ParameterDoc("pageSize", "INTEGER", false, "每页条数", "20")),
+        List.of(),
+        null);
+
+    Map<String, Object> rendered = new OpenApiRenderer().render(documentation);
+    Map<String, Object> paths = (Map<String, Object>) rendered.get("paths");
+    Map<String, Object> path =
+        (Map<String, Object>) paths.get("/api/v1/data-service/runtime/orders");
+    Map<String, Object> operation = (Map<String, Object>) path.get("get");
+    List<Map<String, Object>> parameters =
+        (List<Map<String, Object>>) operation.get("parameters");
+
+    assertThat(parameters).extracting(item -> item.get("name"))
+        .containsExactly("status", "returnTotalNum", "pageNum", "pageSize");
+    assertThat(parameters.get(0).get("required")).isEqualTo(true);
+    assertThat(parameters.subList(1, 4))
+        .allSatisfy(item -> assertThat(item.get("required")).isEqualTo(false));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/publication/DataServicePublisherTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/publication/DataServicePublisherTest.java
@@ -9,12 +9,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.dataservice.documentation.DataServiceDocumentationManager;
+import io.yak.ops.business.dataservice.documentation.DataServiceDocumentationReader;
+import io.yak.ops.business.dataservice.documentation.DataServiceRequestParameterContract;
+import io.yak.ops.business.dataservice.documentation.DocumentationFingerprint;
 import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
 import io.yak.ops.business.dataservice.domain.DataServiceSettings;
 import io.yak.ops.business.dataservice.domain.PublishedRuntimeSnapshot;
 import io.yak.ops.business.dataservice.domain.RuntimePolicy;
 import io.yak.ops.business.dataservice.domain.SourceReference;
 import io.yak.ops.business.dataservice.domain.access.AuthMode;
+import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation;
+import io.yak.ops.business.dataservice.domain.documentation.DataServiceDocumentation.ParameterDoc;
 import io.yak.ops.business.dataservice.execution.DataServiceSqlCompiler;
 import io.yak.ops.business.dataservice.management.DataServiceManager;
 import io.yak.ops.business.dataservice.publication.source.DataServiceSourceProvider;
@@ -26,6 +31,7 @@ import io.yak.ops.business.dataservice.publication.source.DataServiceSourceProvi
 import io.yak.ops.business.dataservice.query.DataServiceReader;
 import io.yak.ops.business.dataservice.query.DataServiceView;
 import io.yak.ops.business.dataservice.query.DataServiceViewFactory;
+import io.yak.ops.business.dataservice.repository.DataServiceDocumentationRepository;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -42,6 +48,8 @@ class DataServicePublisherTest {
   private DataServiceManager manager;
   private DataServiceViewFactory viewFactory;
   private DataServiceDocumentationManager documentationManager;
+  private DataServiceSourceRegistry registry;
+  private DataServicePublicationReader publicationReader;
   private DataServicePublisher publisher;
 
   @BeforeEach
@@ -49,13 +57,12 @@ class DataServicePublisherTest {
     provider = mock(DataServiceSourceProvider.class);
     when(provider.sourceType()).thenReturn(SOURCE_TYPE);
     when(provider.managesServiceDefinition()).thenReturn(true);
-    DataServiceSourceRegistry registry = new DataServiceSourceRegistry(List.of(provider));
+    registry = new DataServiceSourceRegistry(List.of(provider));
     dataServiceReader = mock(DataServiceReader.class);
     manager = mock(DataServiceManager.class);
     viewFactory = mock(DataServiceViewFactory.class);
     documentationManager = mock(DataServiceDocumentationManager.class);
-    DataServicePublicationReader publicationReader =
-        new DataServicePublicationReader(registry, dataServiceReader, viewFactory);
+    publicationReader = new DataServicePublicationReader(registry, dataServiceReader, viewFactory);
     publisher = new DataServicePublisher(
         publicationReader,
         registry,
@@ -68,9 +75,9 @@ class DataServicePublisherTest {
 
   @Test
   void sourceManagedPublishUsesRevisionOwnedDefinitionAndRuntime() {
-    when(provider.resolve("100")).thenReturn(resolved("ONLINE"));
+    when(provider.resolve("100")).thenReturn(resolved("ONLINE", false));
     when(dataServiceReader.findBySource(SOURCE_TYPE, "100")).thenReturn(Optional.empty());
-    DataServiceDefinition saved = definition(9L, false);
+    DataServiceDefinition saved = definition(9L, false, false);
     when(manager.savePublished(any(), any(), any(), any())).thenReturn(saved);
     DataServiceView view = mock(DataServiceView.class);
     when(viewFactory.view(saved)).thenReturn(view);
@@ -80,7 +87,8 @@ class DataServicePublisherTest {
         .isSameAs(view);
 
     ArgumentCaptor<DataServiceSettings> settings = ArgumentCaptor.forClass(DataServiceSettings.class);
-    ArgumentCaptor<PublishedRuntimeSnapshot> runtime = ArgumentCaptor.forClass(PublishedRuntimeSnapshot.class);
+    ArgumentCaptor<PublishedRuntimeSnapshot> runtime =
+        ArgumentCaptor.forClass(PublishedRuntimeSnapshot.class);
     ArgumentCaptor<SourceReference> source = ArgumentCaptor.forClass(SourceReference.class);
     verify(manager).savePublished(any(), settings.capture(), runtime.capture(), source.capture());
     assertThat(settings.getValue().name()).isEqualTo("订单查询 API");
@@ -96,8 +104,57 @@ class DataServicePublisherTest {
   }
 
   @Test
+  void paginatedSourcePublishesAndSynchronizesRuntimeParameters() {
+    when(provider.resolve("100")).thenReturn(resolved("ONLINE", true));
+    when(dataServiceReader.findBySource(SOURCE_TYPE, "100")).thenReturn(Optional.empty());
+    DataServiceDefinition saved = definition(9L, true, true);
+    when(manager.savePublished(any(), any(), any(), any())).thenReturn(saved);
+    when(dataServiceReader.require(9L)).thenReturn(saved);
+    DataServiceView view = mock(DataServiceView.class);
+    when(viewFactory.view(saved)).thenReturn(view);
+
+    DataServiceDocumentationRepository documentationRepository =
+        mock(DataServiceDocumentationRepository.class);
+    when(documentationRepository.findByApiId(9L)).thenReturn(Optional.empty());
+    DataServiceSqlCompiler compiler = new DataServiceSqlCompiler();
+    DataServiceRequestParameterContract requestParameterContract =
+        new DataServiceRequestParameterContract(compiler);
+    DocumentationFingerprint fingerprint = new DocumentationFingerprint();
+    DataServiceDocumentationReader documentationReader = new DataServiceDocumentationReader(
+        dataServiceReader, documentationRepository, requestParameterContract, fingerprint);
+    DataServiceDocumentationManager realDocumentationManager =
+        new DataServiceDocumentationManager(
+            dataServiceReader,
+            documentationRepository,
+            documentationReader,
+            requestParameterContract,
+            fingerprint);
+    DataServicePublisher paginatedPublisher = new DataServicePublisher(
+        publicationReader,
+        registry,
+        dataServiceReader,
+        manager,
+        viewFactory,
+        realDocumentationManager,
+        compiler);
+
+    assertThat(paginatedPublisher.publish(new PublishRequest(
+        SOURCE_TYPE, "100", null, null, null, null, true, null)))
+        .isSameAs(view);
+
+    ArgumentCaptor<DataServiceDocumentation> documentation =
+        ArgumentCaptor.forClass(DataServiceDocumentation.class);
+    verify(documentationRepository).save(documentation.capture());
+    assertThat(documentation.getValue().parameters()).extracting(ParameterDoc::name)
+        .containsExactly("status", "returnTotalNum", "pageNum", "pageSize");
+    assertThat(documentation.getValue().parameters().get(0).required()).isTrue();
+    assertThat(documentation.getValue().parameters().subList(1, 4))
+        .allSatisfy(parameter -> assertThat(parameter.required()).isFalse());
+  }
+
+  @Test
   void rejectsSourceThatIsNotOnlineBeforePersisting() {
-    when(provider.resolve("100")).thenReturn(resolved("OFFLINE"));
+    when(provider.resolve("100")).thenReturn(resolved("OFFLINE", false));
 
     assertThatThrownBy(() -> publisher.publish(
         new PublishRequest(SOURCE_TYPE, "100", null, null, null, null, null, null)))
@@ -108,7 +165,7 @@ class DataServicePublisherTest {
     verify(documentationManager, never()).save(any(), any());
   }
 
-  private ResolvedSource resolved(String status) {
+  private ResolvedSource resolved(String status, boolean paginationEnabled) {
     SourceDescriptor descriptor = new SourceDescriptor(
         SOURCE_TYPE,
         "100",
@@ -123,20 +180,37 @@ class DataServicePublisherTest {
         "/orders-v2",
         "Revision 定义",
         Instant.parse("2026-08-16T01:00:00Z"),
-        false);
+        paginationEnabled);
+    List<ParameterContract> parameters = paginationEnabled
+        ? List.of(
+            new ParameterContract("status", "STRING", true, "订单状态", "PAID"),
+            new ParameterContract(
+                "returnTotalNum", "BOOLEAN", false, "是否返回分页总数，默认 true", "true"),
+            new ParameterContract("pageNum", "INTEGER", false, "页码，从 1 开始，默认 1", "1"),
+            new ParameterContract(
+                "pageSize", "INTEGER", false, "每页条数，默认 20，不超过服务最大行数", "20"))
+        : List.of(new ParameterContract("status", "STRING", true, "订单状态", "PAID"));
     return new ResolvedSource(
         descriptor,
         "select id from orders where status = :status",
         new SourceContract(
-            List.of(new ParameterContract("status", "STRING", true, "订单状态", "PAID")),
+            parameters,
             List.of(new ResponseFieldContract("id", "INTEGER", false, "订单 ID", "1"))));
   }
 
-  private DataServiceDefinition definition(Long id, boolean enabled) {
+  private DataServiceDefinition definition(
+      Long id, boolean enabled, boolean paginationEnabled) {
     LocalDateTime now = LocalDateTime.of(2026, 8, 24, 10, 0);
     return DataServiceDefinition.restore(
         id,
-        new DataServiceSettings("订单查询 API", "/orders-v2", 500, 20, enabled, "Revision 定义", false),
+        new DataServiceSettings(
+            "订单查询 API",
+            "/orders-v2",
+            500,
+            20,
+            enabled,
+            "Revision 定义",
+            paginationEnabled),
         new PublishedRuntimeSnapshot(42L, "select id from orders where status = :status"),
         new SourceReference(SOURCE_TYPE, "100", 900L, 2),
         RuntimePolicy.defaults(true),


### PR DESCRIPTION
## Summary

Fixes #918, where bringing a paginated Data Service online failed with:

```text
SQL 中不存在参数：returnTotalNum
```

The failure was caused by treating the complete HTTP request contract as if every request parameter had to be a named SQL placeholder.

This PR fixes the contract once across **Manager → Reader → OpenAPI** instead of adding one-off pagination whitelists.

## Root cause

A paginated Data Service exposes two parameter categories:

```text
SQL parameters
  - status
  - tenantId
  - ...

Runtime pagination parameters
  - returnTotalNum
  - pageNum
  - pageSize
```

`DataServiceInvoker` already consumes the pagination parameters separately and removes them before SQL compilation. They are intentionally not SQL placeholders.

However `DataServiceDocumentationManager` validated every source contract parameter against `DataServiceSqlCompiler.parameterNames(sql)`. Publication therefore failed as soon as `returnTotalNum` reached documentation synchronization.

The read side had the same assumption and would drop pagination parameters, while `OpenApiRenderer` hard-coded every query parameter as `required=true`.

## Changes

### 1. Unified request parameter contract

Adds `DataServiceRequestParameterContract` as the single source of truth for the HTTP request contract.

It combines:

- SQL named parameters as required request parameters
- Runtime pagination parameters when pagination is enabled
  - `returnTotalNum`: BOOLEAN, optional
  - `pageNum`: INTEGER, optional
  - `pageSize`: INTEGER, optional

The pagination type/default/required semantics are defined in one place instead of repeated in Manager/Reader/OpenAPI.

### 2. Documentation Manager

`DataServiceDocumentationManager` now validates documentation input against the effective HTTP request contract rather than SQL parameter names alone.

- pagination runtime parameters no longer require SQL placeholders
- SQL parameter type documentation remains editable
- Runtime pagination parameter type/required semantics remain canonical
- missing pagination docs are filled from the Runtime contract
- truly unknown parameters are still rejected; the existing invalid-parameter protection is not weakened

### 3. Documentation Reader

`DataServiceDocumentationReader` now rebuilds documentation from the same effective request contract.

This prevents `returnTotalNum/pageNum/pageSize` from disappearing after publication/readback and preserves their optional semantics even when older stored documentation only contains SQL parameters.

### 4. OpenAPI

`OpenApiRenderer` now renders:

```java
parameter.required()
```

instead of hard-coding every query parameter as required.

Therefore pagination parameters remain optional in generated OpenAPI while SQL parameters remain required.

## Regression coverage

Added/updated tests for:

- paginated Runtime parameters can be saved without SQL placeholders
- pagination parameters are persisted with canonical BOOLEAN/INTEGER types and `required=false`
- Reader restores pagination parameters from the current Runtime contract
- unknown non-SQL/non-Runtime parameters are still rejected
- OpenAPI preserves `required=false` for pagination parameters
- `DataServicePublisherTest` now runs a paginated publication through a **real `DataServiceDocumentationManager`**, covering the #918 `publish → syncSourceContract → documentation.save` failure path rather than mocking that boundary

## Scope

No frontend changes.

No Flyway/database changes.

No Project Scope changes.

No Runtime pagination execution behavior changes.

This PR only corrects the HTTP/documentation contract around the already-existing Runtime pagination behavior.

Fixes #918

## Validation

Branch is based on current `main` and only changes Data Service documentation/publication contract code and focused tests.

The connector environment does not provide a runnable repository checkout, so Maven is not claimed as executed here. Recommended local/CI verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-data-service -am test
```
