### PR TITLE
fix(workflow): restore project-scoped sync task discovery

### DIFF
--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/controller/v1/TaskController.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/controller/v1/TaskController.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.job.controller.v1;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.job.task.TaskDefinition;
 import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.core.project.ProjectScope;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 工作流可引用任务查询接口。 */
 @RestController
 @RequestMapping("/api/v1/tasks")
+@ProjectScope
 public class TaskController {
 
   private final TaskRegistry taskRegistry;

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/controller/v1/TaskControllerProjectScopeTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/controller/v1/TaskControllerProjectScopeTest.java
@@ -1,0 +1,18 @@
+package io.yak.ops.business.job.controller.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import org.junit.jupiter.api.Test;
+
+class TaskControllerProjectScopeTest {
+
+  @Test
+  void taskDiscoveryRequiresProjectContext() {
+    ProjectScope scope = TaskController.class.getAnnotation(ProjectScope.class);
+
+    assertThat(scope).isNotNull();
+    assertThat(scope.value()).isEqualTo(ProjectMigrationMode.PROJECT_REQUIRED);
+  }
+}

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowTaskPicker.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowTaskPicker.tsx
@@ -1,14 +1,9 @@
-import { listTaskCatalogAssets } from '@/services/taskCatalog';
-import { Input, Popover, Spin } from 'antd';
+import { Input, Popover } from 'antd';
 import type { PopoverProps } from 'antd';
 import { Search } from 'lucide-react';
 import type { ReactElement } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
-import {
-  isWorkflowEligibleTaskCatalogAsset,
-  taskCatalogOption,
-} from './taskOptions';
 import type { WorkflowCanvasTaskOption } from './types';
 
 export type WorkflowTaskCategory = 'sync' | 'development' | 'quality';
@@ -75,8 +70,6 @@ const WorkflowTaskPicker = ({
   const [innerOpen, setInnerOpen] = useState(false);
   const [activeCategory, setActiveCategory] = useState<WorkflowTaskCategory>(defaultCategory);
   const [searchText, setSearchText] = useState(createSearchState);
-  const [catalogOptions, setCatalogOptions] = useState<WorkflowCanvasTaskOption[]>([]);
-  const [catalogLoading, setCatalogLoading] = useState(false);
   const open = controlledOpen ?? innerOpen;
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -85,43 +78,15 @@ const WorkflowTaskPicker = ({
     onOpenChange?.(nextOpen);
   };
 
-  useEffect(() => {
-    if (!open) return;
-    let active = true;
-    setCatalogLoading(true);
-    void listTaskCatalogAssets({ source: 'DATA_DEVELOPMENT', status: 'ONLINE' })
-      .then((assets) => {
-        if (active) {
-          setCatalogOptions(
-            assets.filter(isWorkflowEligibleTaskCatalogAsset).map(taskCatalogOption),
-          );
-        }
-      })
-      .catch(() => {
-        if (active) setCatalogOptions([]);
-      })
-      .finally(() => {
-        if (active) setCatalogLoading(false);
-      });
-    return () => { active = false; };
-  }, [open]);
-
-  const allOptions = useMemo(() => {
-    const merged = new Map<string, WorkflowCanvasTaskOption>();
-    options.forEach((option) => merged.set(option.id, option));
-    catalogOptions.forEach((option) => merged.set(option.id, option));
-    return Array.from(merged.values());
-  }, [catalogOptions, options]);
-
   const groupedOptions = useMemo(() => {
     const grouped: Record<WorkflowTaskCategory, WorkflowCanvasTaskOption[]> = {
       sync: [],
       development: [],
       quality: [],
     };
-    allOptions.forEach((option) => grouped[resolveTaskCategory(option)].push(option));
+    options.forEach((option) => grouped[resolveTaskCategory(option)].push(option));
     return grouped;
-  }, [allOptions]);
+  }, [options]);
 
   const activeMeta = CATEGORY_META.find((item) => item.key === activeCategory) ?? CATEGORY_META[0];
   const keyword = searchText[activeCategory].trim().toLowerCase();
@@ -175,9 +140,7 @@ const WorkflowTaskPicker = ({
 
       <div className="border-t border-[#f0f1f3]">
         <div className="max-h-[420px] overflow-y-auto p-1">
-          {catalogLoading && activeCategory === 'development' && !filteredOptions.length ? (
-            <div className="flex h-16 items-center justify-center"><Spin size="small" /></div>
-          ) : filteredOptions.length ? filteredOptions.map((option) => (
+          {filteredOptions.length ? filteredOptions.map((option) => (
             <button
               key={option.id}
               type="button"

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/taskOptions.test.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/taskOptions.test.ts
@@ -4,9 +4,12 @@ import {
   taskCatalogOption,
 } from './taskOptions';
 
-const asset = (taskType: string): TaskCatalogAsset => ({
+const asset = (
+  taskType: string,
+  source = 'DATA_DEVELOPMENT',
+): TaskCatalogAsset => ({
   id: '12',
-  source: 'DATA_DEVELOPMENT',
+  source,
   sourceRef: '10001',
   projectId: '7',
   name: '测试资产',
@@ -32,5 +35,11 @@ describe('workflow task catalog options', () => {
     expect(isWorkflowEligibleTaskCatalogAsset(asset('DATA_SERVICE'))).toBe(false);
     expect(() => taskCatalogOption(asset('DATASET'))).toThrow('不能进入工作流编排');
     expect(() => taskCatalogOption(asset('DATA_SERVICE'))).toThrow('不能进入工作流编排');
+  });
+
+  test('maps task asset sources to workflow task categories', () => {
+    expect(taskCatalogOption(asset('SYNC', 'DATA_INTEGRATION')).typeLabel).toBe('数据同步');
+    expect(taskCatalogOption(asset('SQL', 'DATA_DEVELOPMENT')).typeLabel).toBe('数据开发');
+    expect(taskCatalogOption(asset('QUALITY_CHECK', 'DATA_QUALITY')).typeLabel).toBe('数据质量');
   });
 });

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/taskOptions.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/taskOptions.ts
@@ -13,6 +13,17 @@ const WORKFLOW_ELIGIBLE_DATA_DEVELOPMENT_TASK_TYPES = new Set([
   'PYTHON',
 ]);
 
+const TASK_ASSET_SOURCE_LABELS: Record<string, string> = {
+  DATA_INTEGRATION: '数据同步',
+  DATA_DEVELOPMENT: '数据开发',
+  DATA_QUALITY: '数据质量',
+};
+
+const taskCatalogTypeLabel = (asset: TaskCatalogAsset) => {
+  const source = (asset.source || '').trim().toUpperCase();
+  return TASK_ASSET_SOURCE_LABELS[source] || asset.source || '任务';
+};
+
 export const isWorkflowEligibleTaskCatalogAsset = (asset: TaskCatalogAsset) => {
   const source = (asset.source || '').trim().toUpperCase();
   const taskType = (asset.taskType || '').trim().toUpperCase();
@@ -27,7 +38,7 @@ export const taskCatalogOption = (asset: TaskCatalogAsset): WorkflowCanvasTaskOp
   return {
     id: `${TASK_ASSET_ID_PREFIX}${asset.id}`,
     label: asset.name,
-    typeLabel: '数据开发',
+    typeLabel: taskCatalogTypeLabel(asset),
     taskType: asset.taskType,
     taskAssetId: asset.id,
     taskRevisionId: asset.currentRevision.taskRevisionId,
@@ -41,13 +52,21 @@ export const taskAssetIdFromTaskId = (taskId: string) =>
     ? taskId.slice(TASK_ASSET_ID_PREFIX.length).trim()
     : undefined;
 
+const hasPinnedCatalogBinding = (option: WorkflowCanvasTaskOption) => Boolean(
+  option.taskAssetId
+  && option.taskRevisionId
+  && option.taskRevisionNo,
+);
+
 export const resolveWorkflowTaskOption = async (
   taskId: string,
   knownOptions: WorkflowCanvasTaskOption[],
 ): Promise<WorkflowCanvasTaskOption | undefined> => {
   const known = knownOptions.find((option) => option.id === taskId);
-  if (known) return known;
+  if (known && hasPinnedCatalogBinding(known)) return known;
+
   const assetId = taskAssetIdFromTaskId(taskId);
-  if (!assetId) return undefined;
+  if (!assetId) return known;
+
   return taskCatalogOption(await getTaskCatalogAsset(assetId));
 };

--- a/yak-ops-ui/src/utils/security/projectContext.test.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.test.ts
@@ -34,6 +34,7 @@ describe('Project Space request context', () => {
     expect(resolveProjectRequestMode('/api/v1/data-service/7')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/data-service/overview')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/task-catalog/assets')).toBe('PROJECT_OPTIONAL');
+    expect(resolveProjectRequestMode('/api/v1/tasks')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/job/batch-definition/page')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/job/batch-execution/11/execute')).toBe('PROJECT_REQUIRED');
     expect(resolveProjectRequestMode('/api/v1/job/batch-instance/11')).toBe('PROJECT_REQUIRED');
@@ -100,6 +101,7 @@ describe('Project Space request context', () => {
       '/api/v1/home/cockpit',
       '/api/v1/data-development/nodes',
       '/api/v1/data-service/7',
+      '/api/v1/tasks',
       '/api/v1/job/batch-definition/page',
       '/api/v1/job/batch-instance/42',
       '/api/v1/realtime-sync/42',

--- a/yak-ops-ui/src/utils/security/projectContext.ts
+++ b/yak-ops-ui/src/utils/security/projectContext.ts
@@ -32,6 +32,8 @@ export const PROJECT_REQUEST_RULES: readonly ProjectRequestRule[] = [
   { prefix: '/api/v1/data-service/runtime', mode: 'LEGACY_GLOBAL' },
   { prefix: '/api/v1/data-service', mode: 'PROJECT_REQUIRED' },
   { prefix: '/api/v1/task-catalog', mode: 'PROJECT_OPTIONAL' },
+  // Generic workflow task discovery includes Project-owned providers such as Offline Sync.
+  { prefix: '/api/v1/tasks', mode: 'PROJECT_REQUIRED' },
   // Link-Up engine health is platform-global; Offline definitions and runtime facts are Project data.
   { prefix: '/api/v1/job/batch-execution/health', mode: 'LEGACY_GLOBAL' },
   { prefix: '/api/v1/executor/health', mode: 'LEGACY_GLOBAL' },


### PR DESCRIPTION
## Summary

- make `/api/v1/tasks` a Project-scoped task discovery endpoint
- send `X-YAK-SECURITY-PROJECT-ID` for workflow task discovery from the UI
- remove the Workflow picker’s duplicate `DATA_DEVELOPMENT` catalog request and consume the editor’s unified task list
- preserve immutable Task Catalog bindings when a catalog task is selected from the unified picker
- map Task Catalog sources to the correct Workflow categories (`DATA_INTEGRATION` / `DATA_DEVELOPMENT` / `DATA_QUALITY`)

## Root cause

Offline Sync already contributes workflow-eligible `SYNC` tasks through `OfflineSyncTaskProvider`, but the provider intentionally returns no registrations when `CurrentProject` is absent. `/api/v1/tasks` was not annotated with `@ProjectScope`, and the frontend Project request table also treated that route as global, so Offline Sync discovery always ran without a Project context and returned an empty list.

The Workflow picker also issued a second, hard-coded Task Catalog request for `DATA_DEVELOPMENT`, which made the three-tab UI diverge from the actual unified task discovery path.

## Scope

This is **PR 1 / phase 1** for #916. It restores the already-supported Offline Sync workflow tasks and normalizes the picker discovery path.

It intentionally does **not** add Data Quality or Realtime Sync as new workflow task capabilities. Data Quality still needs its own TaskAsset / revision / executor integration before it can be safely exposed as an executable workflow node.

Refs #916

## Tests

- add a backend contract test locking `/api/v1/tasks` to `PROJECT_REQUIRED`
- extend frontend Project request tests for `/api/v1/tasks`
- extend workflow task option tests for TaskAsset source-to-category mapping
