### PR TITLE
test(security): enforce navigation menu catalog consistency

### DIFF
--- a/.github/workflows/navigation-menu-contract.yml
+++ b/.github/workflows/navigation-menu-contract.yml
@@ -1,0 +1,44 @@
+name: Navigation Menu Contract
+
+on:
+  pull_request:
+    paths:
+      - 'yak-ops-ui/src/config/navigation.ts'
+      - 'yak-ops-ui/src/config/navigationMenuContract.test.ts'
+      - 'yak-ops-ui/src/constants/securityMenuCodes.ts'
+      - 'yak-ops-boot/src/main/resources/yak-security/db/migration/V2006__reconcile_menu_permission_catalog.sql'
+      - '.github/workflows/navigation-menu-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Navigation ↔ menu catalog
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: yak-ops-ui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: yarn
+          cache-dependency-path: yak-ops-ui/yarn.lock
+
+      - name: Activate Yarn 1
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Install frontend dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Verify Navigation ↔ menu catalog contract
+        run: yarn jest src/config/navigationMenuContract.test.ts --runInBand

--- a/yak-ops-ui/docs/navigation-menu-contract.md
+++ b/yak-ops-ui/docs/navigation-menu-contract.md
@@ -4,11 +4,11 @@ Yak Ops navigation and Yak Security menu authorization are separate models that 
 
 ## Contract
 
-- `route.id`, `path`, `title`, `component`, icon and grouping are frontend UI metadata. They may change without changing RBAC.
+- `route.id`, `path`, `title`, `component`, icon and grouping are frontend UI metadata. They may change without changing RBAC identity.
 - `menuCode` is the stable database-backed authorization identifier. Do not derive it from `route.id` or URL shape.
-- Yak Ops business menu codes are declared in `src/constants/securityMenuCodes.ts` and correspond to the Yak Ops security catalog (currently reconciled by `V2006__reconcile_menu_permission_catalog.sql`).
+- Yak Ops business menu codes are declared in `src/constants/securityMenuCodes.ts` and correspond to the Yak Ops security catalog reconciled by `V2006__reconcile_menu_permission_catalog.sql`.
 - System-management menu codes in the same constants file are framework-owned and correspond to the Yak Security menu catalog. Yak Ops must not duplicate those rows in its own Flyway migrations.
-- Every protected route that represents a menu page declares a `menuCode` explicitly.
+- Every visible route declares a stable `menuCode`.
 - Hidden detail/editor routes normally omit `menuCode` and inherit the nearest parent route's stable menu code.
 - Hidden utility/public routes that are not database-backed menus may omit `menuCode`.
 
@@ -28,4 +28,27 @@ Compatibility rules:
 
 This contract intentionally does not make TypeScript generate backend menu rows and does not make the frontend navigation tree database-driven. Each side keeps the metadata it owns while sharing stable menu codes.
 
-A follow-up consistency check can mechanically compare protected visible navigation resources with the backend catalog and fail CI on missing, duplicate or invalid mappings. That enforcement is intentionally outside this PR.
+Yak Ops owns the business-menu rows in `V2006__reconcile_menu_permission_catalog.sql`. Yak Security owns `system-*` menu rows. The frontend may reference both namespaces but the Yak Ops Flyway catalog must contain only the Yak Ops-owned namespace.
+
+## Consistency enforcement
+
+`src/config/navigationMenuContract.test.ts` reads the real final Yak Ops menu section from `V2006__reconcile_menu_permission_catalog.sql` and compares it with `navigationGroups` and `appRoutes`.
+
+The contract test fails on:
+
+- missing or duplicate stable menu codes;
+- frontend menu codes missing from the backend catalog;
+- orphan backend menu rows with no frontend resource;
+- parent, route-path or menu-type drift;
+- protected routes whose backend required permission is not declared by the frontend route;
+- visible routes without a stable menu code;
+- hidden protected routes without a menu owner;
+- framework-owned `system-*` rows accidentally duplicated in the Yak Ops migration.
+
+Run it locally from `yak-ops-ui` with:
+
+```bash
+yarn jest src/config/navigationMenuContract.test.ts --runInBand
+```
+
+`.github/workflows/navigation-menu-contract.yml` runs the same targeted test for pull requests that modify the navigation contract or the final business-menu catalog.

--- a/yak-ops-ui/src/config/navigationMenuContract.test.ts
+++ b/yak-ops-ui/src/config/navigationMenuContract.test.ts
@@ -1,0 +1,241 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  YAK_OPS_MENU_CODES,
+  YAK_SECURITY_MENU_CODES,
+} from '../constants/securityMenuCodes';
+import {
+  appRoutes,
+  navigationGroups,
+  resolveNavigationMenuCode,
+  type NavigationRoute,
+} from './navigation';
+
+type MenuCatalogRow = {
+  menuCode: string;
+  parentCode: string | null;
+  routePath: string | null;
+  menuType: number;
+  visible: boolean;
+  active: boolean;
+  requiredPermissionCode: string | null;
+};
+
+const FINAL_CATALOG_MIGRATION = path.resolve(
+  __dirname,
+  '../../../yak-ops-boot/src/main/resources/yak-security/db/migration/V2006__reconcile_menu_permission_catalog.sql',
+);
+
+const sqlValue = (token: string): string | null =>
+  token === 'NULL' ? null : token.slice(1, -1);
+
+const parseFinalYakOpsMenuCatalog = (): MenuCatalogRow[] => {
+  const sql = readFileSync(FINAL_CATALOG_MIGRATION, 'utf8');
+  const sectionStart = sql.indexOf(
+    '-- 3. Upsert the complete set of current visible Yak Ops menus.',
+  );
+  const sectionEnd = sql.indexOf('ON DUPLICATE KEY UPDATE', sectionStart);
+
+  if (sectionStart < 0 || sectionEnd < 0) {
+    throw new Error(
+      'Cannot locate the final Yak Ops menu catalog in V2006__reconcile_menu_permission_catalog.sql',
+    );
+  }
+
+  const section = sql.slice(sectionStart, sectionEnd);
+  const rowPattern = /\(\s*'([^']+)'\s*,\s*'[^']*'\s*,\s*(NULL|'[^']*')\s*,\s*(NULL|'[^']*')\s*,\s*'[^']*'\s*,\s*(\d+)\s*,\s*\d+\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(NULL|'[^']*')\s*,\s*'[^']*'\s*,\s*'\$\{appName\}'\s*\)/g;
+
+  const rows = [...section.matchAll(rowPattern)].map((match) => ({
+    menuCode: match[1],
+    parentCode: sqlValue(match[2]),
+    routePath: sqlValue(match[3]),
+    menuType: Number(match[4]),
+    visible: match[5] === '1',
+    active: match[6] === '1',
+    requiredPermissionCode: sqlValue(match[7]),
+  }));
+
+  if (rows.length === 0) {
+    throw new Error('Parsed zero rows from the final Yak Ops menu catalog');
+  }
+
+  return rows;
+};
+
+const duplicateValues = (values: readonly string[]) =>
+  values.filter((value, index) => values.indexOf(value) !== index);
+
+const routePermissionCodes = (route: NavigationRoute): readonly string[] => {
+  if (!route.mode || route.mode === 'public') return [];
+  if (route.mode === 'one') return [route.permission];
+  return route.permissions;
+};
+
+const finalCatalog = parseFinalYakOpsMenuCatalog();
+const catalogByCode = new Map(finalCatalog.map((row) => [row.menuCode, row]));
+const yakOpsMenuCodes = Object.values(YAK_OPS_MENU_CODES);
+const frameworkMenuCodes = Object.values(YAK_SECURITY_MENU_CODES);
+const yakOpsCodeSet = new Set<string>(yakOpsMenuCodes);
+const frameworkCodeSet = new Set<string>(frameworkMenuCodes);
+const navigationGroupById = new Map(
+  navigationGroups.map((group) => [group.id, group]),
+);
+
+describe('Navigation ↔ Yak Security menu catalog contract', () => {
+  it('keeps stable menu-code namespaces unique and disjoint', () => {
+    expect(duplicateValues(yakOpsMenuCodes)).toEqual([]);
+    expect(duplicateValues(frameworkMenuCodes)).toEqual([]);
+    expect(
+      yakOpsMenuCodes.filter((code) => frameworkCodeSet.has(code)),
+    ).toEqual([]);
+  });
+
+  it('requires visible routes to declare stable menu codes and hidden protected routes to inherit one', () => {
+    const errors: string[] = [];
+
+    for (const route of appRoutes) {
+      if (!route.hidden && !route.menuCode) {
+        errors.push(`Missing menuCode: ${route.id} (${route.path})`);
+      }
+
+      if (
+        route.hidden &&
+        route.mode !== 'public' &&
+        !route.menuCode &&
+        !route.parentId
+      ) {
+        errors.push(`Protected hidden route has no menu owner: ${route.id} (${route.path})`);
+      }
+
+      if (route.hidden && route.parentId && !route.menuCode) {
+        const parent = appRoutes.find((candidate) => candidate.id === route.parentId);
+        if (!parent) {
+          errors.push(`Unknown parent route: ${route.id} -> ${route.parentId}`);
+        } else if (resolveNavigationMenuCode(route) !== resolveNavigationMenuCode(parent)) {
+          errors.push(
+            `Hidden route menu inheritance drift: ${route.id} -> ${route.parentId}`,
+          );
+        }
+      }
+    }
+
+    expect(errors).toEqual([]);
+  });
+
+  it('keeps the frontend Yak Ops menu-code set exactly aligned with the final Flyway catalog', () => {
+    const frontendEntries = [
+      ...navigationGroups
+        .filter((group) => yakOpsCodeSet.has(group.menuCode))
+        .map((group) => ({ code: group.menuCode, owner: `group:${group.id}` })),
+      ...appRoutes
+        .filter(
+          (route): route is NavigationRoute & { menuCode: string } =>
+            Boolean(route.menuCode && yakOpsCodeSet.has(route.menuCode)),
+        )
+        .map((route) => ({ code: route.menuCode, owner: `route:${route.id}` })),
+    ];
+
+    const duplicateFrontendCodes = duplicateValues(
+      frontendEntries.map((entry) => entry.code),
+    );
+    const frontendCodes = new Set(frontendEntries.map((entry) => entry.code));
+    const backendCodes = new Set(finalCatalog.map((row) => row.menuCode));
+    const errors = [
+      ...duplicateFrontendCodes.map((code) => `Duplicate frontend menuCode: ${code}`),
+      ...[...frontendCodes]
+        .filter((code) => !backendCodes.has(code))
+        .map((code) => `Missing backend menu: ${code}`),
+      ...[...backendCodes]
+        .filter((code) => !frontendCodes.has(code))
+        .map((code) => `Orphan backend menu: ${code}`),
+      ...yakOpsMenuCodes
+        .filter((code) => !frontendCodes.has(code))
+        .map((code) => `Unused Yak Ops menu constant: ${code}`),
+    ];
+
+    expect(errors).toEqual([]);
+  });
+
+  it('keeps parent, type, path and required-permission metadata aligned', () => {
+    const errors: string[] = [];
+
+    for (const group of navigationGroups) {
+      if (!yakOpsCodeSet.has(group.menuCode)) continue;
+      const backend = catalogByCode.get(group.menuCode);
+      if (!backend) continue;
+
+      if (backend.parentCode !== null) {
+        errors.push(`Menu group must be root: ${group.menuCode}`);
+      }
+      if (backend.routePath !== null) {
+        errors.push(`Menu group must not own a route path: ${group.menuCode}`);
+      }
+      if (backend.menuType !== 1) {
+        errors.push(`Menu group type mismatch: ${group.menuCode} expected=1 actual=${backend.menuType}`);
+      }
+      if (!backend.visible || !backend.active) {
+        errors.push(`Menu group must be visible and active: ${group.menuCode}`);
+      }
+    }
+
+    for (const route of appRoutes) {
+      if (!route.menuCode || !yakOpsCodeSet.has(route.menuCode)) continue;
+      const backend = catalogByCode.get(route.menuCode);
+      if (!backend) continue;
+
+      const parentCode = route.menuGroup
+        ? navigationGroupById.get(route.menuGroup)?.menuCode ?? null
+        : null;
+      if (backend.parentCode !== parentCode) {
+        errors.push(
+          `Parent mismatch: ${route.menuCode} frontend=${parentCode ?? 'ROOT'} backend=${backend.parentCode ?? 'ROOT'}`,
+        );
+      }
+      if (backend.routePath !== route.path) {
+        errors.push(
+          `Route path mismatch: ${route.menuCode} frontend=${route.path} backend=${backend.routePath ?? 'NULL'}`,
+        );
+      }
+      if (backend.menuType !== 2) {
+        errors.push(`Menu page type mismatch: ${route.menuCode} expected=2 actual=${backend.menuType}`);
+      }
+      if (!backend.visible || !backend.active) {
+        errors.push(`Menu page must be visible and active: ${route.menuCode}`);
+      }
+
+      const declaredPermissions = routePermissionCodes(route);
+      if (
+        backend.requiredPermissionCode &&
+        !declaredPermissions.includes(backend.requiredPermissionCode)
+      ) {
+        errors.push(
+          `Required permission mismatch: ${route.menuCode} backend=${backend.requiredPermissionCode} frontend=${declaredPermissions.join(',') || 'PUBLIC'}`,
+        );
+      }
+      if (
+        route.mode !== 'public' &&
+        !backend.requiredPermissionCode
+      ) {
+        errors.push(`Protected menu has no backend required permission: ${route.menuCode}`);
+      }
+    }
+
+    expect(errors).toEqual([]);
+  });
+
+  it('keeps framework-owned system menus out of the Yak Ops Flyway catalog', () => {
+    const duplicatedFrameworkMenus = finalCatalog
+      .map((row) => row.menuCode)
+      .filter((code) => frameworkCodeSet.has(code));
+    const unknownSystemCodes = [
+      ...navigationGroups.map((group) => group.menuCode),
+      ...appRoutes.flatMap((route) => (route.menuCode ? [route.menuCode] : [])),
+    ].filter(
+      (code) => code.startsWith('system') && !frameworkCodeSet.has(code),
+    );
+
+    expect(duplicatedFrameworkMenus).toEqual([]);
+    expect(unknownSystemCodes).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to merged #927 and #930. This PR turns the Navigation ↔ Yak Security menu contract into an executable consistency gate.

- add `navigationMenuContract.test.ts` that reads the real final Yak Ops business-menu section from `V2006__reconcile_menu_permission_catalog.sql`
- compare backend catalog rows directly with `navigationGroups` and `appRoutes`; no third JSON/YAML catalog is introduced
- fail on missing/duplicate menu codes, backend/frontend missing or orphan entries, parent/type/path drift, and incompatible required-permission declarations
- require every visible route to declare a stable menu code and hidden protected routes to have a menu owner/inheritance path
- keep framework-owned `system-*` menu codes outside the Yak Ops Flyway catalog and validate that namespace boundary
- add a targeted GitHub Actions workflow that runs only when the navigation/menu contract or V2006 catalog changes
- update the contract documentation with the enforced rules and local test command

## Contract source

Yak Ops business menu rows in `V2006__reconcile_menu_permission_catalog.sql` remain the backend source of truth. The test parses the migration section beginning with `-- 3. Upsert the complete set of current visible Yak Ops menus.` and compares those real rows with the frontend stable `menuCode` declarations introduced by #930.

System-management rows remain owned by `yak-framework/yak-security`; this PR intentionally does not copy the framework catalog into Yak Ops.

## CI

New workflow: `.github/workflows/navigation-menu-contract.yml`

It runs a targeted Jest command on pull requests that change:

- `yak-ops-ui/src/config/navigation.ts`
- `yak-ops-ui/src/config/navigationMenuContract.test.ts`
- `yak-ops-ui/src/constants/securityMenuCodes.ts`
- `yak-ops-boot/.../V2006__reconcile_menu_permission_catalog.sql`
- the workflow itself

The workflow uses Node 20 + Yarn 1 and runs:

```bash
yarn jest src/config/navigationMenuContract.test.ts --runInBand
```

## Out of scope

- no runtime authorization changes
- no menu/permission data migration changes
- no role grant changes
- no attempt to make navigation database-driven or generate Flyway SQL from TypeScript
