### PR TITLE
fix(workflow): prevent SQL nodes from remaining submitted

### DIFF
--- a/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/AbstractTaskExecutorAdapter.java
+++ b/yak-ops-business/yak-ops-business-job/src/main/java/io/yak/ops/business/job/runtime/AbstractTaskExecutorAdapter.java
@@ -22,10 +22,13 @@ import io.yak.ops.spi.task.model.TaskExecutionTrigger;
 import jakarta.annotation.PreDestroy;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +46,8 @@ public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
   private final ExecutorService workerExecutor;
   private final ConcurrentMap<String, ExecutionHandle> executions = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, String> idempotencyIndex = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, CompletableFuture<String>> idempotencyStarts =
+      new ConcurrentHashMap<>();
 
   protected AbstractTaskExecutorAdapter(
       TaskPluginRegistry pluginRegistry,
@@ -111,7 +116,7 @@ public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
   }
 
   @Override
-  public synchronized TaskExecution start(
+  public TaskExecution start(
       TaskVersionSnapshot snapshot,
       TaskExecutionTrigger trigger,
       String idempotencyKey,
@@ -121,41 +126,39 @@ public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     TaskExecutionTrigger safeTrigger =
         trigger == null ? TaskExecutionTrigger.WORKFLOW : trigger;
     String safeKey = normalizeKey(idempotencyKey);
-    if (safeKey != null) {
-      String existing = idempotencyIndex.get(safeKey);
-      if (existing != null) return status(existing);
+    if (safeKey == null) {
+      return startNewExecution(snapshot, safeTrigger, null, input);
     }
 
-    TaskDefinition definition = extractDefinition(snapshot);
-    TaskPlugin plugin = requireExecutablePlugin();
-    validateDefinition(plugin, definition);
+    String existing = idempotencyIndex.get(safeKey);
+    if (existing != null) return status(existing);
 
-    TaskExecutionContext context = contextFactory.create(
-        safeTrigger,
-        input,
-        builder -> configureContext(builder, snapshot.definitionSnapshotJson()));
-    io.yak.ops.plugin.task.api.TaskExecutor pluginExecutor =
-        plugin.createExecutor(definition, context);
-
-    String executionId = executionIdPrefix() + "-" + UUID.randomUUID();
-    TaskExecution initial = new TaskExecution(executionId, "RUNNING", null, Map.of());
-    ExecutionHandle handle = new ExecutionHandle(pluginExecutor, new AtomicReference<>(initial));
-    executions.put(executionId, handle);
-    if (safeKey != null) idempotencyIndex.put(safeKey, executionId);
+    CompletableFuture<String> owner = new CompletableFuture<>();
+    CompletableFuture<String> inFlight = idempotencyStarts.putIfAbsent(safeKey, owner);
+    if (inFlight != null) {
+      log.debug(
+          "{} task startup waiting for idempotent owner task={} idempotencyKey={}",
+          displayName(),
+          snapshot.taskId(),
+          safeKey);
+      return status(awaitExecutionId(inFlight));
+    }
 
     try {
-      workerExecutor.submit(
-          contextFactory.captureProjectContext(() -> runExecution(executionId, handle)));
-    } catch (RuntimeException exception) {
-      TaskExecution failed = new TaskExecution(
-          executionId,
-          "FAILED",
-          executionFailureMessage(exception),
-          Map.of());
-      handle.snapshot().set(failed);
-      return failed;
+      existing = idempotencyIndex.get(safeKey);
+      if (existing != null) {
+        owner.complete(existing);
+        return status(existing);
+      }
+      TaskExecution started = startNewExecution(snapshot, safeTrigger, safeKey, input);
+      owner.complete(started.executionId());
+      return started;
+    } catch (RuntimeException | Error failure) {
+      owner.completeExceptionally(failure);
+      throw failure;
+    } finally {
+      idempotencyStarts.remove(safeKey, owner);
     }
-    return initial;
   }
 
   @Override
@@ -188,6 +191,65 @@ public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     return resourceResolverProvider == null ? null : resourceResolverProvider.getIfAvailable();
   }
 
+  private TaskExecution startNewExecution(
+      TaskVersionSnapshot snapshot,
+      TaskExecutionTrigger trigger,
+      String idempotencyKey,
+      Map<String, Object> input) {
+    long startedAtNanos = System.nanoTime();
+    try {
+      logStartupStage("definition", snapshot, idempotencyKey, startedAtNanos);
+      TaskDefinition definition = extractDefinition(snapshot);
+      TaskPlugin plugin = requireExecutablePlugin();
+      validateDefinition(plugin, definition);
+
+      logStartupStage("context", snapshot, idempotencyKey, startedAtNanos);
+      TaskExecutionContext context = contextFactory.create(
+          trigger,
+          input,
+          builder -> configureContext(builder, snapshot.definitionSnapshotJson()));
+
+      logStartupStage("executor", snapshot, idempotencyKey, startedAtNanos);
+      io.yak.ops.plugin.task.api.TaskExecutor pluginExecutor =
+          plugin.createExecutor(definition, context);
+
+      String executionId = executionIdPrefix() + "-" + UUID.randomUUID();
+      TaskExecution initial = new TaskExecution(executionId, "RUNNING", null, Map.of());
+      ExecutionHandle handle = new ExecutionHandle(pluginExecutor, new AtomicReference<>(initial));
+      executions.put(executionId, handle);
+      if (idempotencyKey != null) idempotencyIndex.put(idempotencyKey, executionId);
+
+      logStartupStage("worker-submit", snapshot, idempotencyKey, startedAtNanos);
+      try {
+        workerExecutor.submit(
+            contextFactory.captureProjectContext(() -> runExecution(executionId, handle)));
+      } catch (VirtualMachineError | ThreadDeath fatal) {
+        throw fatal;
+      } catch (Throwable throwable) {
+        TaskExecution failed = new TaskExecution(
+            executionId,
+            "FAILED",
+            executionFailureMessage(throwable),
+            Map.of());
+        handle.snapshot().set(failed);
+        log.error(
+            "{} task worker submission failed [{}]",
+            displayName(),
+            executionId,
+            throwable);
+        return failed;
+      }
+      logStartupStage("started", snapshot, idempotencyKey, startedAtNanos);
+      return initial;
+    } catch (VirtualMachineError | ThreadDeath fatal) {
+      throw fatal;
+    } catch (RuntimeException exception) {
+      throw exception;
+    } catch (Throwable throwable) {
+      throw new IllegalStateException(executionFailureMessage(throwable), throwable);
+    }
+  }
+
   private void runExecution(String executionId, ExecutionHandle handle) {
     try {
       TaskExecutionResult result = handle.executor().execute();
@@ -201,15 +263,20 @@ public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
             completed.status(),
             completed.errorMessage());
       } else {
-        log.info("{} task execution completed [{}] status={}",
-            displayName(), executionId, completed.status());
+        log.info(
+            "{} task execution completed [{}] status={}",
+            displayName(),
+            executionId,
+            completed.status());
       }
-    } catch (Exception exception) {
-      log.error("{} task execution exception [{}]", displayName(), executionId, exception);
+    } catch (VirtualMachineError | ThreadDeath fatal) {
+      throw fatal;
+    } catch (Throwable throwable) {
+      log.error("{} task execution exception [{}]", displayName(), executionId, throwable);
       TaskExecution failed = new TaskExecution(
           executionId,
           "FAILED",
-          executionFailureMessage(exception),
+          executionFailureMessage(throwable),
           Map.of());
       handle.snapshot().updateAndGet(current -> current.terminal() ? current : failed);
     }
@@ -273,6 +340,33 @@ public abstract class AbstractTaskExecutorAdapter implements TaskExecutor {
     ExecutionHandle handle = executions.get(executionId);
     if (handle == null) throw new IllegalArgumentException(executionNotFoundMessage(executionId));
     return handle;
+  }
+
+  private String awaitExecutionId(CompletableFuture<String> inFlight) {
+    try {
+      return inFlight.join();
+    } catch (CompletionException exception) {
+      Throwable cause = exception.getCause();
+      if (cause instanceof RuntimeException runtimeException) throw runtimeException;
+      if (cause instanceof Error error) throw error;
+      throw new IllegalStateException(cause == null ? exception : cause);
+    }
+  }
+
+  private void logStartupStage(
+      String stage,
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey,
+      long startedAtNanos) {
+    if (!log.isDebugEnabled()) return;
+    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos);
+    log.debug(
+        "{} task startup stage={} task={} idempotencyKey={} elapsedMs={}",
+        displayName(),
+        stage,
+        snapshot.taskId(),
+        idempotencyKey,
+        elapsedMillis);
   }
 
   private static String normalizeKey(String key) {

--- a/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-job/src/test/java/io/yak/ops/business/job/adapter/plugin/SqlTaskExecutorAdapterTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.job.adapter.plugin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +30,14 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -214,6 +222,140 @@ class SqlTaskExecutorAdapterTest {
     assertSame(plugin.definition.get(), plugin.definition.get());
   }
 
+  @Test
+  void doesNotSerializeDifferentWorkflowAttemptsDuringExecutorCreation() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    CountDownLatch blockingCreateEntered = new CountDownLatch(1);
+    CountDownLatch releaseBlockingCreate = new CountDownLatch(1);
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(
+        () -> TaskExecutionResult.success(Map.of("ok", true)),
+        definition -> {
+          if (!definition.content().contains("blocking")) return;
+          blockingCreateEntered.countDown();
+          awaitLatch(releaseBlockingCreate, "blocking SQL executor creation was not released");
+        });
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper,
+        stubContextFactory());
+    TaskVersionSnapshot blocking = snapshot(
+        objectMapper, "task-asset:blocking", "select 'blocking'");
+    TaskVersionSnapshot independent = snapshot(
+        objectMapper, "task-asset:independent", "select 'independent'");
+    ExecutorService callers = Executors.newFixedThreadPool(2);
+
+    try {
+      Future<TaskExecution> blockingStart = callers.submit(
+          () -> adapter.start(blocking, "attempt-blocking", Map.of()));
+      assertTrue(
+          blockingCreateEntered.await(1, TimeUnit.SECONDS),
+          "the first task should reach executor creation");
+
+      Future<TaskExecution> independentStart = callers.submit(
+          () -> adapter.start(independent, "attempt-independent", Map.of()));
+      TaskExecution independentExecution;
+      try {
+        independentExecution = independentStart.get(2, TimeUnit.SECONDS);
+      } finally {
+        releaseBlockingCreate.countDown();
+      }
+      TaskExecution blockingExecution = blockingStart.get(2, TimeUnit.SECONDS);
+
+      assertNotEquals(blockingExecution.executionId(), independentExecution.executionId());
+      assertTrue(awaitTerminal(blockingExecution.executionId()).successful());
+      assertTrue(awaitTerminal(independentExecution.executionId()).successful());
+    } finally {
+      releaseBlockingCreate.countDown();
+      callers.shutdownNow();
+    }
+  }
+
+  @Test
+  void preservesIdempotencyForConcurrentCallsWithTheSameAttempt() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    CountDownLatch createEntered = new CountDownLatch(1);
+    CountDownLatch releaseCreate = new CountDownLatch(1);
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(
+        () -> TaskExecutionResult.success(Map.of("ok", true)),
+        definition -> {
+          createEntered.countDown();
+          awaitLatch(releaseCreate, "SQL executor creation was not released");
+        });
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper,
+        stubContextFactory());
+    TaskVersionSnapshot snapshot = snapshot(
+        objectMapper, "task-asset:idempotent", "select 1");
+    ExecutorService callers = Executors.newFixedThreadPool(2);
+
+    try {
+      Future<TaskExecution> firstStart = callers.submit(
+          () -> adapter.start(snapshot, "same-concurrent-attempt", Map.of()));
+      assertTrue(createEntered.await(1, TimeUnit.SECONDS));
+      Future<TaskExecution> secondStart = callers.submit(
+          () -> adapter.start(snapshot, "same-concurrent-attempt", Map.of()));
+
+      releaseCreate.countDown();
+      TaskExecution first = firstStart.get(2, TimeUnit.SECONDS);
+      TaskExecution second = secondStart.get(2, TimeUnit.SECONDS);
+
+      assertEquals(first.executionId(), second.executionId());
+      assertEquals(1, plugin.createCount.get());
+    } finally {
+      releaseCreate.countDown();
+      callers.shutdownNow();
+    }
+  }
+
+  @Test
+  void convertsNonFatalPluginStartupErrorsToRuntimeFailures() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(
+        () -> TaskExecutionResult.success(Map.of()),
+        definition -> {
+          throw new NoClassDefFoundError("missing-sql-driver");
+        });
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper,
+        stubContextFactory());
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> adapter.start(
+            snapshot(objectMapper, "task-asset:broken-start", "select 1"),
+            "broken-start-attempt",
+            Map.of()));
+
+    assertTrue(exception.getMessage().contains("missing-sql-driver"));
+  }
+
+  @Test
+  void marksNonFatalExecutionErrorsAsFailed() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    RecordingSqlPlugin plugin = new RecordingSqlPlugin(() -> {
+      throw new NoClassDefFoundError("broken-sql-runtime");
+    });
+    adapter = new SqlTaskExecutorAdapter(
+        TaskPluginRegistry.from(List.of(plugin)),
+        emptyDataSourceProvider(),
+        objectMapper,
+        stubContextFactory());
+
+    TaskExecution started = adapter.start(
+        snapshot(objectMapper, "task-asset:broken-runtime", "select 1"),
+        "broken-runtime-attempt",
+        Map.of());
+    TaskExecution failed = awaitTerminal(started.executionId());
+
+    assertEquals("FAILED", failed.status());
+    assertTrue(failed.errorMessage().contains("broken-sql-runtime"));
+  }
+
   private TaskExecution awaitTerminal(String executionId) throws InterruptedException {
     Instant deadline = Instant.now().plus(Duration.ofSeconds(2));
     TaskExecution current = adapter.status(executionId);
@@ -223,6 +365,32 @@ class SqlTaskExecutorAdapterTest {
     }
     assertTrue(current.terminal(), "SQL execution should become terminal");
     return current;
+  }
+
+  private TaskVersionSnapshot snapshot(
+      ObjectMapper objectMapper,
+      String taskId,
+      String sql) throws Exception {
+    TaskDefinition definition = new TaskDefinition("SQL", 1, sql, "{}");
+    return new TaskVersionSnapshot(
+        taskId,
+        taskId,
+        "SQL",
+        1L,
+        "checksum-" + taskId,
+        objectMapper.writeValueAsString(definition),
+        definition.configJson());
+  }
+
+  private static void awaitLatch(CountDownLatch latch, String timeoutMessage) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException(timeoutMessage);
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted while waiting for SQL startup", exception);
+    }
   }
 
   @SuppressWarnings("unchecked")
@@ -248,15 +416,24 @@ class SqlTaskExecutorAdapterTest {
 
   private static final class RecordingSqlPlugin implements TaskPlugin {
     private final Supplier<TaskExecutionResult> resultSupplier;
+    private final Consumer<TaskDefinition> beforeCreate;
     private final AtomicReference<TaskDefinition> definition = new AtomicReference<>();
     private final AtomicReference<TaskExecutionContext> context = new AtomicReference<>();
+    private final AtomicInteger createCount = new AtomicInteger();
 
     private RecordingSqlPlugin(TaskExecutionResult result) {
       this(() -> result);
     }
 
     private RecordingSqlPlugin(Supplier<TaskExecutionResult> resultSupplier) {
+      this(resultSupplier, ignored -> {});
+    }
+
+    private RecordingSqlPlugin(
+        Supplier<TaskExecutionResult> resultSupplier,
+        Consumer<TaskDefinition> beforeCreate) {
       this.resultSupplier = resultSupplier;
+      this.beforeCreate = beforeCreate;
     }
 
     @Override
@@ -274,6 +451,8 @@ class SqlTaskExecutorAdapterTest {
     public io.yak.ops.plugin.task.api.TaskExecutor createExecutor(
         TaskDefinition definition,
         TaskExecutionContext context) {
+      createCount.incrementAndGet();
+      beforeCreate.accept(definition);
       this.definition.set(definition);
       this.context.set(context);
       return new io.yak.ops.plugin.task.api.TaskExecutor() {


### PR DESCRIPTION
## 背景

修复 #931 中工作流测试运行时，首个 SQL 节点可能长期停留在 `SUBMITTED / 提交中`，并导致暂停操作一直处于处理中状态的问题。

当前 `AbstractTaskExecutorAdapter.start(...)` 使用实例级 `synchronized`。任意一次 SQL 任务在环境解析、插件校验或 Executor 创建阶段阻塞，都会持有整个 SQL Adapter 的全局锁，后续工作流节点只能等待，无法进入 `RUNNING`。

另外，插件启动或执行阶段若抛出 `NoClassDefFoundError`、`LinkageError` 等非 `Exception` 异常，原逻辑无法将执行状态收口为失败，也可能表现为长期运行或提交中。

## 修改内容

- 移除 Task Plugin Adapter 的全方法全局锁。
- 使用按 `idempotencyKey` 隔离的 in-flight 协调：
  - 不同工作流 Attempt 可以并发完成任务启动；
  - 相同 Attempt 仍只创建一个任务执行实例，保留原有幂等语义。
- 对插件启动阶段的非致命 `Throwable` 转换为可被工作流运行时处理的运行时异常。
- 对异步执行阶段的非致命 `Throwable` 统一回写为 `FAILED`，避免任务状态永久停留在 `RUNNING`。
- 保留 `VirtualMachineError`、`ThreadDeath` 的直接抛出，不吞掉 JVM 致命错误。
- 增加 `definition / context / executor / worker-submit / started` 分段 DEBUG 日志，便于定位环境解析、插件创建或线程提交的具体阻塞点。

## 回归测试

补充 SQL Task Adapter 测试，覆盖：

- 一个 SQL Executor 创建阻塞时，另一个不同 Attempt 仍能独立启动；
- 相同 Attempt 并发调用仍复用同一 executionId；
- 插件启动阶段出现 `NoClassDefFoundError` 时转换为工作流可处理的失败；
- 插件异步执行阶段出现非 `Exception` 错误时，任务正确收口为 `FAILED`。

Closes #931