### PR TITLE
fix(datasource): update architecture test converter imports

### DIFF
--- a/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-datasource/src/test/java/io/yak/ops/business/datasource/architecture/DataSourceGatewayArchitectureTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
 import io.yak.ops.business.datasource.connection.DataSourceConnectionResolver;
 import io.yak.ops.business.datasource.connection.DataSourceConnectionTester;
-import io.yak.ops.business.datasource.controller.v1.mapper.DataSourcePluginViewMapper;
-import io.yak.ops.business.datasource.controller.v1.mapper.DataSourceViewMapper;
+import io.yak.ops.business.datasource.controller.v1.converter.DataSourcePluginViewConverter;
+import io.yak.ops.business.datasource.controller.v1.converter.DataSourceViewConverter;
 import io.yak.ops.business.datasource.domain.plugin.DataSourcePluginDescriptor;
 import io.yak.ops.business.datasource.execution.DefaultSqlExecutionRuntime;
 import io.yak.ops.business.datasource.execution.domain.SqlExecutionAggregate;
@@ -62,8 +62,8 @@ class DataSourceGatewayArchitectureTest {
             DataSourceConnectionTester.class,
             DataSourceCatalogReader.class,
             DataSourcePluginReader.class,
-            DataSourceViewMapper.class,
-            DataSourcePluginViewMapper.class,
+            DataSourceViewConverter.class,
+            DataSourcePluginViewConverter.class,
             DefaultSqlExecutionRuntime.class)) {
       for (Field field : type.getDeclaredFields()) {
         String fieldType = field.getGenericType().getTypeName();


### PR DESCRIPTION
## Summary

Fix `DataSourceGatewayArchitectureTest` after the datasource controller projection layer was renamed from `mapper` to `converter`.

The architecture test still imported the deleted classes:

- `DataSourceViewMapper`
- `DataSourcePluginViewMapper`

Production code now uses:

- `DataSourceViewConverter`
- `DataSourcePluginViewConverter`

This updates both imports and the guarded application-role class list so the architecture contract continues checking the current production components rather than stale types.

## Root cause

The controller mapper-to-converter refactor removed the old mapper classes, but `DataSourceGatewayArchitectureTest` retained those references. That leaves the test source with unresolved imports/symbols and prevents the datasource test sources from compiling.

## Scope

- one test file only
- no production behavior changes
- no REST / DB / Plugin SPI changes
- preserves the existing gateway architecture assertions

## Validation

- confirmed both replacement converter classes exist on current `main`
- branch diff is limited to 4 additions / 4 deletions in `DataSourceGatewayArchitectureTest`
- Maven was not executed through the GitHub connector environment
