### PR TITLE
fix(workflow): use current node type accessor in runtime test

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowRuntimeGenericTaskTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowRuntimeGenericTaskTest.java
@@ -82,7 +82,7 @@ class WorkflowRuntimeGenericTaskTest {
     WorkflowInstanceVO completed = waitForTerminal(started.id());
     WorkflowInstanceVO.NodeInstanceVO node = completed.nodes().getFirst();
     assertThat(completed.status()).isEqualTo("SUCCESS");
-    assertThat(node.taskType()).isEqualTo("SQL");
+    assertThat(node.type()).isEqualTo("SQL");
     assertThat(node.output()).containsEntry("taskType", "SQL");
     assertThat(node.output()).containsEntry("taskExecutionId", "sql-execution-1");
   }


### PR DESCRIPTION
## Summary

Fix the stale node type assertion in `WorkflowRuntimeGenericTaskTest`.

`WorkflowInstanceVO.NodeInstanceVO` currently exposes the task type through the record accessor `type()`, while this test still calls the removed/non-existent `taskType()` accessor. That leaves the workflow test source unable to compile.

This changes only:

```java
node.taskType()
```

to:

```java
node.type()
```

The existing assertions on the runtime output (`taskType = SQL` and `taskExecutionId`) remain unchanged.

## Scope

- one test file only
- 1 addition / 1 deletion
- no production behavior changes
- no workflow runtime contract changes

## Validation

- confirmed `WorkflowInstanceVO.NodeInstanceVO` defines `String type` and therefore exposes `type()`
- confirmed `WorkflowRuntime` populates that field from the task metadata type
- branch is one commit ahead of current `main` and changes only `WorkflowRuntimeGenericTaskTest`
- Maven was not executed through the GitHub connector environment
