### PR TITLE
refactor(workflow-ui): align workflow list with datasource experience

### DIFF
--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowCreateDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowCreateDrawer.tsx
@@ -1,0 +1,127 @@
+import { YakButton } from '@/components/ui';
+import { Drawer, Form, Input } from 'antd';
+import { GitBranch } from 'lucide-react';
+
+export interface WorkflowCreateValues {
+  name: string;
+  description?: string;
+}
+
+interface WorkflowCreateDrawerProps {
+  open: boolean;
+  creating: boolean;
+  onClose: () => void;
+  onSubmit: (values: WorkflowCreateValues) => Promise<void>;
+}
+
+const WorkflowCreateDrawer = ({
+  open,
+  creating,
+  onClose,
+  onSubmit,
+}: WorkflowCreateDrawerProps) => {
+  const [form] = Form.useForm<WorkflowCreateValues>();
+
+  const handleClose = () => {
+    if (creating) return;
+    form.resetFields();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    const values = await form.validateFields();
+    await onSubmit(values);
+    form.resetFields();
+  };
+
+  return (
+    <Drawer
+      open={open}
+      width={560}
+      placement="right"
+      closable={false}
+      destroyOnClose
+      maskClosable={!creating}
+      keyboard={!creating}
+      onClose={handleClose}
+      title={
+        <div>
+          <div className="text-[18px] font-semibold leading-7 text-[#101828]">
+            新建工作流
+          </div>
+          <div className="mt-1 text-[11px] font-normal text-[rgba(22,24,35,.42)]">
+            第一步创建基础信息，下一步进入画布完成任务编排
+          </div>
+        </div>
+      }
+      extra={
+        <div className="flex items-center gap-2">
+          <YakButton
+            disabled={creating}
+            onClick={handleClose}
+            className="!h-9 !rounded-lg !px-4"
+          >
+            取消
+          </YakButton>
+          <YakButton
+            type="primary"
+            loading={creating}
+            onClick={() => void handleSubmit()}
+            className="!h-9 !rounded-lg !px-5 !text-white"
+          >
+            创建并配置
+          </YakButton>
+        </div>
+      }
+      styles={{
+        header: {
+          padding: '18px 24px',
+          borderBottom: '1px solid #eaecf0',
+        },
+        body: { padding: 24 },
+      }}
+    >
+      <Form form={form} layout="vertical" requiredMark="optional">
+        <Form.Item
+          name="name"
+          label="工作流名称"
+          rules={[
+            { required: true, message: '请输入工作流名称' },
+            { max: 100, message: '名称不能超过 100 个字符' },
+          ]}
+        >
+          <Input variant="filled" placeholder="例如：每日订单同步工作流" />
+        </Form.Item>
+
+        <Form.Item
+          name="description"
+          label="工作流描述"
+          rules={[{ max: 500, message: '描述不能超过 500 个字符' }]}
+        >
+          <Input.TextArea
+            variant="filled"
+            rows={4}
+            placeholder="简单说明这个工作流负责什么"
+          />
+        </Form.Item>
+
+        <div className="mt-2 rounded-[9px] border border-[rgba(22,24,35,.055)] bg-[#f8f9fa] p-4">
+          <div className="flex items-center gap-2 text-[12px] font-semibold text-[#161823]">
+            <GitBranch
+              size={15}
+              strokeWidth={1.9}
+              className="text-[#667085]"
+            />
+            创建后进入工作流配置
+          </div>
+          <div className="mt-2 text-[11px] leading-5 text-[rgba(22,24,35,.48)]">
+            在下一步从左侧拖入已经配置好的任务，完成 DAG
+            连线，并设置节点重试、超时、触发规则和失败策略。
+          </div>
+        </div>
+      </Form>
+    </Drawer>
+  );
+};
+
+export default WorkflowCreateDrawer;

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowCreateDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowCreateDrawer.tsx
@@ -29,9 +29,13 @@ const WorkflowCreateDrawer = ({
   };
 
   const handleSubmit = async () => {
-    const values = await form.validateFields();
-    await onSubmit(values);
-    form.resetFields();
+    try {
+      const values = await form.validateFields();
+      await onSubmit(values);
+      form.resetFields();
+    } catch {
+      // Form owns validation feedback; request failures are surfaced by the page action.
+    }
   };
 
   return (

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionCard.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionCard.tsx
@@ -1,0 +1,344 @@
+import { YakButton } from '@/components/ui';
+import type { WorkflowDefinition } from '@/services/workflow/definitions';
+import { motion } from 'framer-motion';
+import {
+  CalendarClock,
+  Clock3,
+  GitBranch,
+  LoaderCircle,
+  Pause,
+  Pencil,
+  Play,
+  Power,
+  Rocket,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
+
+import {
+  DEFINITION_STATUS_META,
+  WORKFLOW_PAGE_ANIMATION,
+  failureStrategyLabel,
+  formatWorkflowDuration,
+  formatWorkflowTime,
+  getPublishActionLabel,
+  getRuntimeHint,
+  isActiveRuntime,
+  isRunningRuntime,
+  runtimeStatusMeta,
+  type WorkflowViewMode,
+} from '../model';
+
+interface WorkflowDefinitionCardProps {
+  record: WorkflowDefinition;
+  viewMode: WorkflowViewMode;
+  busy: boolean;
+  blocked: boolean;
+  onEdit: (record: WorkflowDefinition) => void;
+  onSchedule: (record: WorkflowDefinition) => void;
+  onDelete: (record: WorkflowDefinition) => void;
+  onPublish: (record: WorkflowDefinition) => void;
+  onOffline: (record: WorkflowDefinition) => void;
+  onRun: (record: WorkflowDefinition) => void;
+  onPause: (record: WorkflowDefinition) => void;
+  onResume: (record: WorkflowDefinition) => void;
+}
+
+const actionButtonClassName =
+  '!h-[30px] !w-[30px] !rounded-[8px] !border !border-[#e9ebef] !bg-white/90 !p-0 !text-[#7e838d] !shadow-[0_1px_3px_rgba(31,35,41,0.035)] hover:!text-[#4058c8]';
+
+const WorkflowDefinitionCard = ({
+  record,
+  viewMode,
+  busy,
+  blocked,
+  onEdit,
+  onSchedule,
+  onDelete,
+  onPublish,
+  onOffline,
+  onRun,
+  onPause,
+  onResume,
+}: WorkflowDefinitionCardProps) => {
+  const definitionMeta = DEFINITION_STATUS_META[record.status];
+  const runtimeMeta = runtimeStatusMeta(record.latestExecutionStatus);
+  const activeRuntime = isActiveRuntime(record.latestExecutionStatus);
+  const isListView = viewMode === 'list';
+  const canDelete = record.status !== 'ONLINE' && !activeRuntime;
+  const canRun =
+    record.status === 'ONLINE' &&
+    record.nodeCount > 0 &&
+    Boolean(record.activeVersionNo) &&
+    !activeRuntime;
+
+  const renderRuntimeAction = () => {
+    const status = record.latestExecutionStatus;
+
+    if (status === 'PAUSING' || status === 'RESUMING') {
+      return (
+        <YakButton
+          type="text"
+          size="small"
+          iconOnly
+          disabled
+          title={status === 'PAUSING' ? '最近执行暂停中' : '最近执行恢复中'}
+          className={actionButtonClassName}
+          icon={<LoaderCircle size={14} strokeWidth={1.9} className="animate-spin" />}
+        />
+      );
+    }
+
+    if (status === 'PAUSED') {
+      return (
+        <YakButton
+          type="text"
+          size="small"
+          iconOnly
+          title="恢复最近执行"
+          loading={busy}
+          disabled={blocked}
+          className={actionButtonClassName}
+          icon={<RotateCcw size={14} strokeWidth={1.9} />}
+          onClick={() => onResume(record)}
+        />
+      );
+    }
+
+    if (isRunningRuntime(status)) {
+      return (
+        <YakButton
+          type="text"
+          size="small"
+          iconOnly
+          title="暂停最近执行"
+          loading={busy}
+          disabled={blocked}
+          className={actionButtonClassName}
+          icon={<Pause size={14} strokeWidth={1.9} />}
+          onClick={() => onPause(record)}
+        />
+      );
+    }
+
+    if (record.status === 'ONLINE') {
+      return (
+        <YakButton
+          type="text"
+          size="small"
+          iconOnly
+          title={
+            canRun
+              ? `运行已上线 v${record.activeVersionNo}`
+              : !record.activeVersionNo
+                ? '当前没有生效版本'
+                : record.nodeCount <= 0
+                  ? '请先完成节点编排'
+                  : '当前已有活动执行'
+          }
+          loading={busy}
+          disabled={!canRun || blocked}
+          className={actionButtonClassName}
+          icon={<Play size={14} strokeWidth={1.9} />}
+          onClick={() => onRun(record)}
+        />
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <motion.article
+      variants={WORKFLOW_PAGE_ANIMATION.fadeUp}
+      className={[
+        'group relative min-w-0 overflow-hidden rounded-[16px] border border-[rgba(31,35,41,0.075)] bg-white/[0.98]',
+        'shadow-[0_3px_10px_rgba(31,35,41,0.035),0_1px_2px_rgba(31,35,41,0.02)]',
+        'transition-[transform,border-color,box-shadow] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)]',
+        'hover:-translate-y-px hover:border-[rgba(31,35,41,0.11)] hover:shadow-[0_10px_24px_rgba(31,35,41,0.065),0_1px_2px_rgba(31,35,41,0.02)]',
+        isListView
+          ? 'grid grid-cols-[minmax(430px,1.5fr)_minmax(430px,1fr)] max-xl:grid-cols-1'
+          : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 [background-image:radial-gradient(circle,rgba(94,117,163,0.14)_0.7px,transparent_0.8px)] [background-size:8px_8px] [mask-image:linear-gradient(115deg,#000_0%,rgba(0,0,0,0.18)_40%,transparent_72%)]"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-16 -top-20 z-0 h-48 w-48 rounded-full bg-[#dce7ff]/35 blur-3xl transition-transform duration-300 group-hover:scale-110"
+      />
+
+      <div className="relative z-[1] flex min-h-[116px] items-start justify-between gap-4 px-[18px] pb-[17px] pt-[18px]">
+        <div className="flex min-w-0 items-start gap-[13px]">
+          <div className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-[14px] border border-[rgba(31,35,41,0.07)] bg-[linear-gradient(145deg,#ffffff_0%,#f5f7fa_100%)] text-[#566071] shadow-[0_5px_14px_rgba(31,35,41,0.055)] transition-transform duration-[260ms] group-hover:scale-[1.025]">
+            <GitBranch size={27} strokeWidth={1.75} />
+          </div>
+
+          <div className="min-w-0 pt-0.5">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <button
+                type="button"
+                title={record.name}
+                className="m-0 max-w-[280px] cursor-pointer truncate border-0 bg-transparent p-0 text-left text-[15px] font-semibold leading-[22px] text-[#292c35] transition-colors hover:text-[#4058c8]"
+                onClick={() => onEdit(record)}
+              >
+                {record.name || '未命名工作流'}
+              </button>
+
+              <span
+                className={[
+                  'inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-full px-[7px] text-[10px] font-semibold',
+                  definitionMeta.textClassName,
+                  definitionMeta.backgroundClassName,
+                ].join(' ')}
+              >
+                {definitionMeta.label}
+              </span>
+
+              {record.draftChanged ? (
+                <span className="inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-full bg-[#fff7e9] px-[7px] text-[10px] font-semibold text-[#b77a22]">
+                  有草稿修改
+                </span>
+              ) : null}
+            </div>
+
+            <p
+              title={record.description || ''}
+              className="mb-0 mt-2 max-w-[500px] truncate rounded-[7px] bg-[#f7f8fa]/90 px-2 py-1 text-[11px] leading-[18px] text-[#858a94]"
+            >
+              {record.description || '暂无工作流描述'}
+            </p>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] leading-4 text-[#9a9fa8]">
+              <span>{record.nodeCount} 个节点 · {record.edgeCount} 条依赖</span>
+              <span>超时 {formatWorkflowDuration(record.workflowTimeoutSeconds)}</span>
+              <span>{failureStrategyLabel(record.failureStrategy)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 -translate-y-1 gap-1 opacity-0 transition-all duration-150 group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:translate-y-0 group-focus-within:opacity-100">
+          {renderRuntimeAction()}
+
+          <YakButton
+            type="text"
+            size="small"
+            iconOnly
+            title="编辑工作流"
+            disabled={blocked}
+            className={actionButtonClassName}
+            icon={<Pencil size={14} strokeWidth={1.9} />}
+            onClick={() => onEdit(record)}
+          />
+
+          <YakButton
+            type="text"
+            size="small"
+            iconOnly
+            title="调度配置"
+            disabled={blocked}
+            className={actionButtonClassName}
+            icon={<CalendarClock size={14} strokeWidth={1.9} />}
+            onClick={() => onSchedule(record)}
+          />
+
+          <YakButton
+            type="text"
+            size="small"
+            iconOnly
+            title={getPublishActionLabel(record)}
+            loading={busy}
+            disabled={blocked}
+            className={actionButtonClassName}
+            icon={
+              record.status === 'ONLINE' ? (
+                <Power size={14} strokeWidth={1.9} />
+              ) : (
+                <Rocket size={14} strokeWidth={1.9} />
+              )
+            }
+            onClick={() =>
+              record.status === 'ONLINE' ? onOffline(record) : onPublish(record)
+            }
+          />
+
+          {canDelete ? (
+            <YakButton
+              type="text"
+              size="small"
+              danger
+              iconOnly
+              title="删除工作流"
+              disabled={blocked}
+              className="!h-[30px] !w-[30px] !rounded-[8px] !border !border-[#e9ebef] !bg-white/90 !p-0 !shadow-[0_1px_3px_rgba(31,35,41,0.035)]"
+              icon={<Trash2 size={14} strokeWidth={1.9} />}
+              onClick={() => onDelete(record)}
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <div
+        className={[
+          'relative z-[1] grid grid-cols-[1fr_1.1fr_1.15fr] border-t border-[#eef0f3] bg-white/75 px-[18px] py-[14px]',
+          isListView
+            ? 'items-center border-l border-t-0 max-xl:border-l-0 max-xl:border-t'
+            : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <div className="flex min-w-0 flex-col gap-1.5 pr-3">
+          <span className="text-[10px] leading-4 text-[#a0a4ad]">发布状态</span>
+          <strong className="truncate text-[11px] font-semibold leading-[18px] text-[#5c616b]">
+            {record.activeVersionNo
+              ? `生效 v${record.activeVersionNo}${
+                  record.latestVersionNo > record.activeVersionNo
+                    ? ` · 最新 v${record.latestVersionNo}`
+                    : ''
+                }`
+              : record.latestVersionNo > 0
+                ? `最新 v${record.latestVersionNo}`
+                : '尚未发布版本'}
+          </strong>
+        </div>
+
+        <div className="flex min-w-0 flex-col gap-1.5 border-l border-[#eff0f2] px-3">
+          <span className="text-[10px] leading-4 text-[#a0a4ad]">最近执行</span>
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              className={[
+                'inline-flex h-5 shrink-0 items-center gap-1.5 rounded-full px-[7px] text-[10px] font-semibold',
+                runtimeMeta.textClassName,
+                runtimeMeta.backgroundClassName,
+              ].join(' ')}
+            >
+              <span className={['h-1.5 w-1.5 rounded-full', runtimeMeta.dotClassName].join(' ')} />
+              {runtimeMeta.label}
+            </span>
+            <span
+              title={getRuntimeHint(record.latestExecutionStatus, record.status)}
+              className="min-w-0 truncate text-[10px] text-[#989da7]"
+            >
+              {getRuntimeHint(record.latestExecutionStatus, record.status)}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex min-w-0 flex-col gap-1.5 border-l border-[#eff0f2] pl-3">
+          <span className="text-[10px] leading-4 text-[#a0a4ad]">最近更新</span>
+          <strong className="flex min-w-0 items-center gap-1.5 truncate text-[11px] font-medium leading-[18px] text-[#737882]">
+            <Clock3 size={11} strokeWidth={1.8} className="shrink-0 text-[#9ca0a9]" />
+            <span className="truncate">{formatWorkflowTime(record.updateTime)}</span>
+          </strong>
+        </div>
+      </div>
+    </motion.article>
+  );
+};
+
+export default WorkflowDefinitionCard;

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionList.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionList.tsx
@@ -1,4 +1,3 @@
-import YakButton from '@/components/YakButton';
 import {
   createWorkflowDefinition,
   deleteWorkflowDefinition,
@@ -9,235 +8,40 @@ import {
   resumeWorkflowDefinition,
   runWorkflowDefinition,
   type WorkflowDefinition,
-  type WorkflowDefinitionStatus,
 } from '@/services/workflow/definitions';
-import {
-  CalendarOutlined,
-  CloudDownloadOutlined,
-  CloudUploadOutlined,
-  DeleteOutlined,
-  DownOutlined,
-  EditOutlined,
-  PauseCircleOutlined,
-  PlayCircleOutlined,
-  ReloadOutlined,
-  SearchOutlined,
-} from '@ant-design/icons';
 import { history } from '@umijs/max';
-import {
-  ConfigProvider,
-  Divider,
-  Drawer,
-  Dropdown,
-  Empty,
-  Form,
-  Input,
-  Modal,
-  Popconfirm,
-  Table,
-  Tooltip,
-  message,
-} from 'antd';
-import type { MenuProps } from 'antd';
-import { GitBranch } from 'lucide-react';
+import { Modal, Pagination, Spin, message } from 'antd';
+import { motion } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-type FilterKey = 'ALL' | WorkflowDefinitionStatus;
+import {
+  WORKFLOW_PAGE_ANIMATION,
+  WORKFLOW_PAGE_SIZE_OPTIONS,
+  buildWorkflowSummary,
+  isActiveRuntime,
+  type WorkflowFilterKey,
+  type WorkflowViewMode,
+} from '../model';
+import WorkflowCreateDrawer, {
+  type WorkflowCreateValues,
+} from './WorkflowCreateDrawer';
+import WorkflowDefinitionCard from './WorkflowDefinitionCard';
+import WorkflowEmptyState from './WorkflowEmptyState';
+import WorkflowPageHeader from './WorkflowPageHeader';
+import WorkflowSummaryCards from './WorkflowSummaryCards';
+import WorkflowToolbar from './WorkflowToolbar';
 
-interface StatusMeta {
-  label: string;
-  className: string;
-  dotClassName: string;
-}
-
-const DEFINITION_STATUS: Record<WorkflowDefinitionStatus, StatusMeta> = {
-  DRAFT: {
-    label: '草稿',
-    className: 'border-[#e4e7ec] bg-[#f7f7f8] text-[#667085]',
-    dotClassName: 'bg-[#98a2b3]',
-  },
-  ONLINE: {
-    label: '已上线',
-    className: 'border-[#ffd8e0] bg-[#fff4f6] text-[#e5254e]',
-    dotClassName: 'bg-[#fe2c55]',
-  },
-  OFFLINE: {
-    label: '已下线',
-    className: 'border-[#e4e7ec] bg-[#f5f5f6] text-[#667085]',
-    dotClassName: 'bg-[#98a2b3]',
-  },
-};
-
-const RUNTIME_LABEL: Record<string, string> = {
-  CREATED: '已创建',
-  WAITING: '等待中',
-  READY: '就绪',
-  SUBMITTED: '待执行',
-  RUNNING: '运行中',
-  PAUSING: '暂停中',
-  PAUSED: '已暂停',
-  RESUMING: '恢复中',
-  SUCCESS: '成功',
-  SUCCESS_WITH_WARNINGS: '完成（有告警）',
-  FAILED: '失败',
-  WARNING: '告警',
-  CANCELED: '已取消',
-  TIMED_OUT: '已超时',
-};
-
-const FAILURE_STRATEGY_LABEL: Record<string, string> = {
-  FAIL_FAST: '快速失败',
-  CONTINUE_INDEPENDENT_BRANCHES: '继续独立分支',
-  TERMINATE_ALL: '终止全部',
-};
-
-const ACTIVE_RUNTIME_STATUSES = new Set([
-  'CREATED',
-  'WAITING',
-  'READY',
-  'SUBMITTED',
-  'RUNNING',
-  'PAUSING',
-  'PAUSED',
-  'RESUMING',
-]);
-
-const RUNNING_RUNTIME_STATUSES = new Set([
-  'CREATED',
-  'WAITING',
-  'READY',
-  'SUBMITTED',
-  'RUNNING',
-]);
-
-const isActiveRuntime = (status?: string) =>
-  Boolean(status && ACTIVE_RUNTIME_STATUSES.has(status));
-
-const isRunningRuntime = (status?: string) =>
-  Boolean(status && RUNNING_RUNTIME_STATUSES.has(status));
-
-const formatTime = (value?: string) => {
-  if (!value) return '-';
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-
-  return date.toLocaleString();
-};
-
-const formatDuration = (seconds?: number) => {
-  if (!seconds || seconds <= 0) return '未设置';
-  if (seconds < 60) return `${seconds} 秒`;
-  if (seconds % 3600 === 0) return `${seconds / 3600} 小时`;
-  if (seconds % 60 === 0) return `${seconds / 60} 分钟`;
-  return `${seconds} 秒`;
-};
-
-const runtimeTone = (status?: string) => {
-  if (!status) {
-    return {
-      className: 'border-[#e4e7ec] bg-[#f7f7f8] text-[#667085]',
-      dotClassName: 'bg-[#98a2b3]',
-    };
-  }
-
-  if (status === 'FAILED' || status === 'TIMED_OUT') {
-    return {
-      className: 'border-[#fecdca] bg-[#fef3f2] text-[#b42318]',
-      dotClassName: 'bg-[#f04438]',
-    };
-  }
-
-  if (status === 'WARNING' || status === 'SUCCESS_WITH_WARNINGS') {
-    return {
-      className: 'border-[#fedf89] bg-[#fffaeb] text-[#b54708]',
-      dotClassName: 'bg-[#f79009]',
-    };
-  }
-
-  if (isActiveRuntime(status)) {
-    return {
-      className: 'border-[#ffd8e0] bg-[#fff4f6] text-[#e5254e]',
-      dotClassName: 'bg-[#fe2c55]',
-    };
-  }
-
-  if (status === 'SUCCESS') {
-    return {
-      className: 'border-[#d0d5dd] bg-[#f8f9fb] text-[#344054]',
-      dotClassName: 'bg-[#667085]',
-    };
-  }
-
-  return {
-    className: 'border-[#e4e7ec] bg-[#f7f7f8] text-[#667085]',
-    dotClassName: 'bg-[#98a2b3]',
-  };
-};
-
-const getRuntimeHint = (
-  runtimeStatus: string | undefined,
-  definitionStatus: WorkflowDefinitionStatus,
-) => {
-  if (!runtimeStatus) {
-    return definitionStatus === 'ONLINE'
-      ? '已上线，可运行当前生效版本'
-      : '发布并上线后可正式运行';
-  }
-
-  switch (runtimeStatus) {
-    case 'RUNNING':
-      return '当前存在运行中的执行实例';
-    case 'PAUSING':
-      return '正在暂停当前执行';
-    case 'PAUSED':
-      return '执行已暂停，可恢复后继续';
-    case 'RESUMING':
-      return '正在恢复当前执行';
-    case 'CREATED':
-    case 'WAITING':
-    case 'READY':
-    case 'SUBMITTED':
-      return '执行已提交，等待运行';
-    case 'SUCCESS':
-      return '最近一次执行已成功完成';
-    case 'SUCCESS_WITH_WARNINGS':
-    case 'WARNING':
-      return '最近一次执行完成，但存在告警';
-    case 'FAILED':
-      return '最近一次执行失败';
-    case 'TIMED_OUT':
-      return '最近一次执行超时';
-    case 'CANCELED':
-      return '最近一次执行已取消';
-    default:
-      return '查看运行记录获取更多信息';
-  }
-};
-
-const getPublishActionLabel = (record: WorkflowDefinition) => {
-  if (record.status === 'ONLINE') return '下线工作流';
-  if (record.status === 'OFFLINE' && record.activeVersionNo && !record.draftChanged) {
-    return '重新上线';
-  }
-  if (record.activeVersionNo && record.draftChanged) return '发布更新并上线';
-  return '发布并上线';
-};
-
-export default function WorkflowDefinitionList() {
+const WorkflowDefinitionList = () => {
   const [definitions, setDefinitions] = useState<WorkflowDefinition[]>([]);
   const [loading, setLoading] = useState(false);
   const [actionId, setActionId] = useState<string>();
-  const [filter, setFilter] = useState<FilterKey>('ALL');
-  const [keywordDraft, setKeywordDraft] = useState('');
+  const [filter, setFilter] = useState<WorkflowFilterKey>('ALL');
   const [keyword, setKeyword] = useState('');
+  const [viewMode, setViewMode] = useState<WorkflowViewMode>('grid');
+  const [pageNo, setPageNo] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
   const [createOpen, setCreateOpen] = useState(false);
   const [creating, setCreating] = useState(false);
-
-  const [form] = Form.useForm<{
-    name: string;
-    description?: string;
-  }>();
 
   const loadDefinitions = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
@@ -261,7 +65,11 @@ export default function WorkflowDefinitionList() {
   }, [loadDefinitions]);
 
   useEffect(() => {
-    if (!definitions.some((item) => isActiveRuntime(item.latestExecutionStatus))) {
+    if (
+      !definitions.some((item) =>
+        isActiveRuntime(item.latestExecutionStatus),
+      )
+    ) {
       return;
     }
 
@@ -271,13 +79,6 @@ export default function WorkflowDefinitionList() {
 
     return () => window.clearInterval(timer);
   }, [definitions, loadDefinitions]);
-
-  const filterTabs: Array<{ key: FilterKey; label: string }> = [
-    { key: 'ALL', label: '全部工作流' },
-    { key: 'ONLINE', label: '已上线' },
-    { key: 'DRAFT', label: '草稿' },
-    { key: 'OFFLINE', label: '已下线' },
-  ];
 
   const filteredDefinitions = useMemo(() => {
     const normalizedKeyword = keyword.trim().toLowerCase();
@@ -292,6 +93,30 @@ export default function WorkflowDefinitionList() {
       );
     });
   }, [definitions, filter, keyword]);
+
+  const summary = useMemo(
+    () => buildWorkflowSummary(definitions),
+    [definitions],
+  );
+
+  const hasActiveFilters = filter !== 'ALL' || Boolean(keyword.trim());
+
+  useEffect(() => {
+    setPageNo(1);
+  }, [filter, keyword]);
+
+  useEffect(() => {
+    const maxPage = Math.max(
+      1,
+      Math.ceil(filteredDefinitions.length / pageSize),
+    );
+    if (pageNo > maxPage) setPageNo(maxPage);
+  }, [filteredDefinitions.length, pageNo, pageSize]);
+
+  const pageRecords = useMemo(() => {
+    const start = (pageNo - 1) * pageSize;
+    return filteredDefinitions.slice(start, start + pageSize);
+  }, [filteredDefinitions, pageNo, pageSize]);
 
   const executeAction = async (
     id: string,
@@ -312,40 +137,6 @@ export default function WorkflowDefinitionList() {
     }
   };
 
-  const handleSearch = () => {
-    setKeyword(keywordDraft.trim());
-  };
-
-  const handleCreate = async () => {
-    try {
-      const values = await form.validateFields();
-      setCreating(true);
-
-      const created = await createWorkflowDefinition({
-        name: values.name.trim(),
-        description: values.description?.trim() || undefined,
-      });
-
-      message.success('工作流草稿已创建，请继续配置任务节点');
-      setCreateOpen(false);
-      form.resetFields();
-      history.push(`/workflow/definition/${created.id}?scene=create`);
-    } catch (error: any) {
-      if (error?.errorFields) return;
-      message.error(
-        error instanceof Error ? error.message : '创建工作流失败',
-      );
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleCreateClose = () => {
-    if (creating) return;
-    setCreateOpen(false);
-    form.resetFields();
-  };
-
   const goToDefinition = (record: WorkflowDefinition) => {
     history.push(`/workflow/definition/${record.id}?scene=edit`);
   };
@@ -356,27 +147,49 @@ export default function WorkflowDefinitionList() {
     );
   };
 
+  const handleCreate = async (values: WorkflowCreateValues) => {
+    setCreating(true);
+    try {
+      const created = await createWorkflowDefinition({
+        name: values.name.trim(),
+        description: values.description?.trim() || undefined,
+      });
+
+      message.success('工作流草稿已创建，请继续配置任务节点');
+      setCreateOpen(false);
+      history.push(`/workflow/definition/${created.id}?scene=create`);
+    } catch (error) {
+      message.error(
+        error instanceof Error ? error.message : '创建工作流失败',
+      );
+      throw error;
+    } finally {
+      setCreating(false);
+    }
+  };
+
   const handleDelete = (record: WorkflowDefinition) => {
     Modal.confirm({
       centered: true,
-      title: '确认删除工作流吗？',
+      title: '确认删除该工作流吗？',
       content: (
-        <div className="text-[13px] leading-6 text-[rgba(22,24,35,.58)]">
+        <span>
           即将删除工作流
-          <span className="mx-1 font-semibold text-[#fe2c55]">
-            [{record.name}]
-          </span>
+          <span className="font-semibold text-[#fe2c55]"> [{record.name}]</span>
           。
           <br />
           删除后无法恢复，请谨慎操作。
-        </div>
+        </span>
       ),
       okText: '删除',
       cancelText: '取消',
-      okYakButtonProps: { danger: true, size: 'small' },
-      cancelYakButtonProps: { size: 'small' },
+      okType: 'primary',
+      okButtonProps: { size: 'small', danger: true },
+      cancelButtonProps: { size: 'small' },
       maskClosable: true,
       async onOk() {
+        if (actionId) return;
+        setActionId(record.id);
         try {
           await deleteWorkflowDefinition(record.id);
           message.success('工作流已删除');
@@ -385,50 +198,14 @@ export default function WorkflowDefinitionList() {
           message.error(
             error instanceof Error ? error.message : '删除工作流失败',
           );
+        } finally {
+          setActionId(undefined);
         }
       },
     });
   };
 
-  const renderDefinitionStatus = (status: WorkflowDefinitionStatus) => {
-    const meta = DEFINITION_STATUS[status];
-
-    return (
-      <span
-        className={[
-          'inline-flex h-6 items-center gap-1.5 rounded-full border px-2.5',
-          'text-[11px] font-medium',
-          meta.className,
-        ].join(' ')}
-      >
-        <span
-          className={['h-1.5 w-1.5 rounded-full', meta.dotClassName].join(' ')}
-        />
-        {meta.label}
-      </span>
-    );
-  };
-
-  const renderRuntimeStatus = (status?: string) => {
-    const tone = runtimeTone(status);
-
-    return (
-      <span
-        className={[
-          'inline-flex h-6 items-center gap-1.5 rounded-md border px-2',
-          'text-[11px] font-medium',
-          tone.className,
-        ].join(' ')}
-      >
-        <span
-          className={['h-1.5 w-1.5 rounded-full', tone.dotClassName].join(' ')}
-        />
-        {status ? RUNTIME_LABEL[status] || status : '尚未运行'}
-      </span>
-    );
-  };
-
-  const confirmOnline = (record: WorkflowDefinition) => {
+  const handlePublish = (record: WorkflowDefinition) => {
     if (record.nodeCount <= 0) {
       message.warning('请先编辑工作流并添加至少一个任务节点');
       return;
@@ -438,47 +215,42 @@ export default function WorkflowDefinitionList() {
       record.status === 'OFFLINE' &&
       Boolean(record.activeVersionNo) &&
       !record.draftChanged;
-    const publishingUpdate = Boolean(record.activeVersionNo) && record.draftChanged;
+    const publishingUpdate =
+      Boolean(record.activeVersionNo) && record.draftChanged;
     const targetVersionNo = reenable
       ? record.activeVersionNo
       : (record.latestVersionNo || 0) + 1;
-    const title = reenable
-      ? `重新上线工作流 v${targetVersionNo}？`
-      : publishingUpdate
-        ? `发布更新 v${targetVersionNo} 并上线？`
-        : `发布并上线工作流 v${targetVersionNo}？`;
-    const content = reenable
-      ? `将重新启用已发布的 v${targetVersionNo}，不会创建新版本，已保存调度将恢复触发。`
-      : publishingUpdate
-        ? `当前草稿将形成不可变的 v${targetVersionNo} 并成为正式运行版本；已有运行实例不会受到影响。`
-        : `当前草稿将形成不可变的 v${targetVersionNo} 并开启正式运行入口；后续草稿修改不会影响该版本。`;
-    const success = reenable
-      ? '工作流已重新上线'
-      : publishingUpdate
-        ? `工作流 v${targetVersionNo} 已发布并上线`
-        : `工作流 v${targetVersionNo} 已发布并上线`;
 
     Modal.confirm({
       centered: true,
-      title,
-      content,
+      title: reenable
+        ? `重新上线工作流 v${targetVersionNo}？`
+        : publishingUpdate
+          ? `发布更新 v${targetVersionNo} 并上线？`
+          : `发布并上线工作流 v${targetVersionNo}？`,
+      content: reenable
+        ? `将重新启用已发布的 v${targetVersionNo}，不会创建新版本，已保存调度将恢复触发。`
+        : publishingUpdate
+          ? `当前草稿将形成不可变的 v${targetVersionNo} 并成为正式运行版本；已有运行实例不会受到影响。`
+          : `当前草稿将形成不可变的 v${targetVersionNo} 并开启正式运行入口；后续草稿修改不会影响该版本。`,
       okText: reenable
         ? '重新上线'
         : publishingUpdate
           ? '发布更新并上线'
           : '发布并上线',
       cancelText: '取消',
-      async onOk() {
-        await executeAction(
+      onOk: () =>
+        executeAction(
           record.id,
           () => onlineWorkflowDefinition(record.id),
-          success,
-        );
-      },
+          reenable
+            ? '工作流已重新上线'
+            : `工作流 v${targetVersionNo} 已发布并上线`,
+        ),
     });
   };
 
-  const confirmOffline = (record: WorkflowDefinition) => {
+  const handleOffline = (record: WorkflowDefinition) => {
     Modal.confirm({
       centered: true,
       title: '下线工作流',
@@ -486,679 +258,181 @@ export default function WorkflowDefinitionList() {
         '下线后将关闭新的正式运行和调度触发；已经启动的实例继续执行，草稿仍可继续编辑和测试。确认下线吗？',
       okText: '下线',
       cancelText: '取消',
-      async onOk() {
-        await executeAction(
+      okButtonProps: { danger: true },
+      onOk: () =>
+        executeAction(
           record.id,
           () => offlineWorkflowDefinition(record.id),
           '工作流已下线',
-        );
-      },
+        ),
     });
   };
 
-  const handleMoreAction = (key: string, record: WorkflowDefinition) => {
-    switch (key) {
-      case 'edit':
-        goToDefinition(record);
-        break;
-      case 'schedule':
-        goToSchedules(record);
-        break;
-      case 'online':
-        confirmOnline(record);
-        break;
-      case 'offline':
-        confirmOffline(record);
-        break;
-      case 'pause':
-        void executeAction(
+  const handleRun = (record: WorkflowDefinition) => {
+    if (
+      record.status !== 'ONLINE' ||
+      !record.activeVersionNo ||
+      record.nodeCount <= 0 ||
+      isActiveRuntime(record.latestExecutionStatus)
+    ) {
+      return;
+    }
+
+    Modal.confirm({
+      centered: true,
+      title: `运行已上线 v${record.activeVersionNo}？`,
+      content: record.draftChanged
+        ? `当前存在未发布草稿，本次仍运行已上线的 v${record.activeVersionNo}。`
+        : '本次运行当前生效的正式版本。',
+      okText: '运行',
+      cancelText: '取消',
+      onOk: () =>
+        executeAction(
+          record.id,
+          () => runWorkflowDefinition(record.id),
+          `工作流 v${record.activeVersionNo} 已启动`,
+        ),
+    });
+  };
+
+  const handlePause = (record: WorkflowDefinition) => {
+    Modal.confirm({
+      centered: true,
+      title: '暂停最近执行？',
+      content: '暂停只影响当前执行实例，不影响工作流草稿和已发布版本。',
+      okText: '暂停',
+      cancelText: '取消',
+      onOk: () =>
+        executeAction(
           record.id,
           () => pauseWorkflowDefinition(record.id),
-          '已请求暂停最近执行',
-        );
-        break;
-      case 'resume':
-        void executeAction(
-          record.id,
-          () => resumeWorkflowDefinition(record.id),
-          '最近执行已恢复',
-        );
-        break;
-      case 'delete':
-        handleDelete(record);
-        break;
-      default:
-        break;
-    }
+          '已请求暂停工作流',
+        ),
+    });
   };
 
-  const getMoreMenuItems = (record: WorkflowDefinition): MenuProps['items'] => {
-    const active = isActiveRuntime(record.latestExecutionStatus);
-    const canDelete = record.status !== 'ONLINE' && !active;
-    const items: NonNullable<MenuProps['items']> = [
-      {
-        key: 'edit',
-        icon: <EditOutlined />,
-        label: '编辑工作流',
-      },
-      {
-        key: 'schedule',
-        icon: <CalendarOutlined />,
-        label: '调度配置',
-      },
-    ];
-
-    // 草稿编辑与运行实例是两条独立生命周期；非 ONLINE 状态下仍保留最近执行的控制入口。
-    if (record.status !== 'ONLINE') {
-      if (isRunningRuntime(record.latestExecutionStatus)) {
-        items.push({
-          key: 'pause',
-          icon: <PauseCircleOutlined />,
-          label: '暂停最近执行',
-        });
-      } else if (record.latestExecutionStatus === 'PAUSED') {
-        items.push({
-          key: 'resume',
-          icon: <PlayCircleOutlined />,
-          label: '恢复最近执行',
-        });
-      } else if (
-        record.latestExecutionStatus === 'PAUSING' ||
-        record.latestExecutionStatus === 'RESUMING'
-      ) {
-        items.push({
-          key: 'runtime-transition',
-          icon:
-            record.latestExecutionStatus === 'PAUSING' ? (
-              <PauseCircleOutlined />
-            ) : (
-              <PlayCircleOutlined />
-            ),
-          label:
-            record.latestExecutionStatus === 'PAUSING'
-              ? '最近执行暂停中'
-              : '最近执行恢复中',
-          disabled: true,
-        });
-      }
-    }
-
-    items.push(
-      { type: 'divider' },
-      {
-        key: record.status === 'ONLINE' ? 'offline' : 'online',
-        icon:
-          record.status === 'ONLINE' ? (
-            <CloudDownloadOutlined />
-          ) : (
-            <CloudUploadOutlined />
-          ),
-        label: getPublishActionLabel(record),
-      },
-      { type: 'divider' },
-      {
-        key: 'delete',
-        icon: <DeleteOutlined />,
-        label: '删除工作流',
-        danger: true,
-        disabled: !canDelete,
-      },
-    );
-
-    return items;
-  };
-
-  const getRunDisabledReason = (record: WorkflowDefinition) => {
-    if (actionId && actionId !== record.id) return '正在处理其他工作流，请稍候';
-    if (record.status !== 'ONLINE') return '请先发布并上线工作流';
-    if (record.nodeCount <= 0) return '请先完成节点编排';
-    if (!record.activeVersionNo) return '当前没有生效版本，请重新发布并上线';
-    if (isActiveRuntime(record.latestExecutionStatus)) return '当前已有活动执行';
-    return undefined;
-  };
-
-  const renderPrimaryAction = (record: WorkflowDefinition) => {
-    const busy = actionId === record.id;
-    const runtimeStatus = record.latestExecutionStatus;
-
-    // 草稿/下线状态的主任务是继续编辑，而不是让最近一次执行状态抢占入口。
-    if (record.status !== 'ONLINE') {
-      return (
-        <YakButton
-          size="small"
-          color="default"
-          variant="filled"
-          disabled={Boolean(actionId)}
-          icon={<EditOutlined />}
-          className="!h-7 !rounded-md !px-2.5 !text-xs"
-          onClick={() => goToDefinition(record)}
-        >
-          编辑
-        </YakButton>
-      );
-    }
-
-    if (runtimeStatus === 'PAUSING') {
-      return (
-        <YakButton
-          size="small"
-          color="danger"
-          variant="filled"
-          disabled
-          icon={<PauseCircleOutlined />}
-          className="!h-7 !rounded-md !px-2.5 !text-xs"
-        >
-          暂停中
-        </YakButton>
-      );
-    }
-
-    if (runtimeStatus === 'RESUMING') {
-      return (
-        <YakButton
-          size="small"
-          color="primary"
-          variant="filled"
-          disabled
-          icon={<PlayCircleOutlined />}
-          className="!h-7 !rounded-md !px-2.5 !text-xs"
-        >
-          恢复中
-        </YakButton>
-      );
-    }
-
-    if (runtimeStatus === 'PAUSED') {
-      return (
-        <YakButton
-          size="small"
-          color="primary"
-          variant="filled"
-          loading={busy}
-          disabled={Boolean(actionId && !busy)}
-          icon={<PlayCircleOutlined />}
-          className="!h-7 !rounded-md !px-2.5 !text-xs"
-          onClick={() =>
-            void executeAction(
-              record.id,
-              () => resumeWorkflowDefinition(record.id),
-              '工作流已恢复',
-            )
-          }
-        >
-          恢复
-        </YakButton>
-      );
-    }
-
-    if (isRunningRuntime(runtimeStatus)) {
-      return (
-        <Popconfirm
-          title="暂停工作流"
-          description="确认暂停当前工作流执行吗？"
-          okText="确认"
-          cancelText="取消"
-          disabled={Boolean(actionId && !busy)}
-          onConfirm={() =>
-            executeAction(
-              record.id,
-              () => pauseWorkflowDefinition(record.id),
-              '已请求暂停工作流',
-            )
-          }
-        >
-          <YakButton
-            size="small"
-            color="danger"
-            variant="filled"
-            loading={busy}
-            disabled={Boolean(actionId && !busy)}
-            icon={<PauseCircleOutlined />}
-            className="!h-7 !rounded-md !px-2.5 !text-xs"
-          >
-            暂停
-          </YakButton>
-        </Popconfirm>
-      );
-    }
-
-    const disabledReason = getRunDisabledReason(record);
-    const canRun = !disabledReason;
-
-    return (
-      <Tooltip title={disabledReason}>
-        <span className="inline-flex">
-          <Popconfirm
-            title="运行已上线版本"
-            description={
-              record.draftChanged
-                ? `当前存在未发布草稿，本次仍运行已上线的 v${record.activeVersionNo}。确认运行吗？`
-                : `确认运行当前已上线的 v${record.activeVersionNo} 吗？`
-            }
-            okText="确认"
-            cancelText="取消"
-            disabled={!canRun}
-            onConfirm={() =>
-              executeAction(
-                record.id,
-                () => runWorkflowDefinition(record.id),
-                `工作流 v${record.activeVersionNo} 已启动`,
-              )
-            }
-          >
-            <YakButton
-              size="small"
-              color={canRun ? 'primary' : 'default'}
-              variant="filled"
-              loading={busy}
-              disabled={!canRun}
-              icon={<PlayCircleOutlined />}
-              className={[
-                '!h-7 !rounded-md !px-2.5 !text-xs',
-                !canRun ? '!cursor-not-allowed !text-[#98a2b3]' : '',
-              ].join(' ')}
-            >
-              运行
-            </YakButton>
-          </Popconfirm>
-        </span>
-      </Tooltip>
+  const handleResume = (record: WorkflowDefinition) => {
+    void executeAction(
+      record.id,
+      () => resumeWorkflowDefinition(record.id),
+      '最近执行已恢复',
     );
   };
 
-  const columns = [
-    {
-      title: '工作流',
-      dataIndex: 'name',
-      width: 310,
-      render: (_value: string, record: WorkflowDefinition) => (
-        <div className="min-w-0 py-0.5">
-          <YakButton
-            type="YakButton"
-            title={record.name}
-            onClick={() => goToDefinition(record)}
-            className={[
-              'block max-w-full truncate border-0 bg-transparent p-0 text-left',
-              'text-[13px] font-medium leading-5 text-[#344054]',
-              'transition-colors hover:text-[#fe2c55]',
-            ].join(' ')}
-          >
-            {record.name || '未命名工作流'}
-          </YakButton>
-          <div
-            title={record.description || ''}
-            className="mt-0.5 truncate text-[11px] leading-5 text-[#98a2b3]"
-          >
-            {record.description || '暂无描述'}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '编排信息',
-      dataIndex: 'topology',
-      width: 300,
-      render: (_value: unknown, record: WorkflowDefinition) => (
-        <div className="py-0.5 text-[12px] leading-5 text-[#667085]">
-          <div className="flex items-center gap-2 text-[#475467]">
-            <span>
-              {record.nodeCount > 0 ? `${record.nodeCount} 个节点` : '尚未配置节点'}
-            </span>
-            <span className="text-[#d0d5dd]">·</span>
-            <span>{record.edgeCount} 条依赖</span>
-          </div>
-          <div className="mt-1 text-[11px] text-[#98a2b3]">
-            超时：{formatDuration(record.workflowTimeoutSeconds)}
-            <span className="mx-1.5 text-[#d0d5dd]">·</span>
-            失败：{FAILURE_STRATEGY_LABEL[record.failureStrategy] || record.failureStrategy}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '发布信息',
-      dataIndex: 'status',
-      width: 230,
-      render: (_value: WorkflowDefinitionStatus, record: WorkflowDefinition) => (
-        <div className="py-0.5">
-          <div className="flex flex-wrap items-center gap-1.5">
-            {renderDefinitionStatus(record.status)}
-            {record.draftChanged && (
-              <span className="inline-flex h-6 items-center rounded-md bg-[#fff7e6] px-2 text-[11px] font-medium text-[#b54708]">
-                有草稿修改
-              </span>
-            )}
-          </div>
-          <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
-            {record.latestVersionNo > 0 ? (
-              <>
-                <span>最新 V{record.latestVersionNo}</span>
-                <span className="mx-1.5 text-[#d0d5dd]">·</span>
-                <span>
-                  {record.activeVersionNo
-                    ? `生效 V${record.activeVersionNo}`
-                    : '暂无生效版本'}
-                </span>
-              </>
-            ) : (
-              <span>尚未发布版本</span>
-            )}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '执行状态',
-      dataIndex: 'latestExecutionStatus',
-      width: 245,
-      render: (_value: string | undefined, record: WorkflowDefinition) => (
-        <div className="py-0.5">
-          {renderRuntimeStatus(record.latestExecutionStatus)}
-          <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
-            {getRuntimeHint(record.latestExecutionStatus, record.status)}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '时间',
-      dataIndex: 'updateTime',
-      width: 200,
-      render: (_value: string, record: WorkflowDefinition) => (
-        <div className="text-[12px] leading-5 text-[#667085]">
-          <div className="whitespace-nowrap">更新：{formatTime(record.updateTime)}</div>
-          <div className="whitespace-nowrap text-[11px] text-[#98a2b3]">
-            创建：{formatTime(record.createTime)}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: '操作',
-      dataIndex: 'operate',
-      width: 190,
-      fixed: 'right' as const,
-      render: (_value: unknown, record: WorkflowDefinition) => (
-        <div className="flex min-h-7 items-center gap-1 whitespace-nowrap">
-          {renderPrimaryAction(record)}
-          <Dropdown
-            trigger={['click']}
-            placement="bottomRight"
-            menu={{
-              items: getMoreMenuItems(record),
-              onClick: ({ key, domEvent }) => {
-                domEvent.stopPropagation();
-                handleMoreAction(key, record);
-              },
-            }}
-          >
-            <YakButton
-              size="small"
-              color="default"
-              variant="text"
-              disabled={Boolean(actionId)}
-              className="!h-7 !rounded-md !px-2 !text-xs !text-[#667085]"
-              onClick={(event) => event.stopPropagation()}
-            >
-              更多
-              <DownOutlined className="text-[9px]" />
-            </YakButton>
-          </Dropdown>
-        </div>
-      ),
-    },
-  ];
+  const resetFilters = () => {
+    setFilter('ALL');
+    setKeyword('');
+    setPageNo(1);
+  };
 
   return (
-    <ConfigProvider
-      theme={{
-        token: {
-          borderRadius: 10,
-          colorBorder: '#f0f0f0',
-          colorBgContainer: '#ffffff',
-        },
-        components: {
-          YakButton: { borderRadius: 8 },
-          Input: { activeShadow: 'none' },
-        },
-      }}
-    >
-      <div className="flex min-h-[calc(100vh-64px)] flex-col bg-white px-5 pt-4 text-[#161823]">
-        <h1 className="m-0 text-[17px] font-semibold leading-8 text-[#161823]">
-          工作流定义
-        </h1>
-
-        <div className="mx-auto flex w-full max-w-full flex-1 flex-col">
-          <div className="mb-3">
-            <div className="border-b border-[#f0f0f0]">
-              <div className="flex min-h-[54px] items-center justify-between gap-4 py-2">
-                <div className="flex shrink-0 items-center gap-1 rounded-lg bg-[#f5f5f6] p-1">
-                  {filterTabs.map((item) => {
-                    const active = filter === item.key;
-
-                    return (
-                      <YakButton
-                        key={item.key}
-                        type="YakButton"
-                        onClick={() => setFilter(item.key)}
-                        className={[
-                          'h-8 rounded-md px-3.5 text-[13px] font-medium transition-all',
-                          active
-                            ? 'bg-white text-[#fe2c55] shadow-[0_1px_4px_rgba(16,24,40,0.08)]'
-                            : 'text-[#667085] hover:bg-white/70 hover:text-[#344054]',
-                        ].join(' ')}
-                      >
-                        {item.label}
-                      </YakButton>
-                    );
-                  })}
-                </div>
-
-                <div className="flex min-w-0 flex-1 items-center justify-end gap-2 overflow-x-auto">
-                  <Input
-                    allowClear
-                    variant="filled"
-                    value={keywordDraft}
-                    prefix={<SearchOutlined className="text-[#98a2b3]" />}
-                    placeholder="搜索工作流名称或描述"
-                    className="!h-9 !w-[300px] !min-w-[220px]"
-                    onChange={(event) => setKeywordDraft(event.target.value)}
-                    onPressEnter={handleSearch}
-                  />
-
-                  <YakButton
-                    size="small"
-                    className="!h-9 !px-4"
-                    onClick={handleSearch}
-                  >
-                    查询
-                  </YakButton>
-
-                  <Tooltip title="刷新">
-                    <YakButton
-                      size="small"
-                      icon={<ReloadOutlined spin={loading} />}
-                      className="!h-9 !w-9 !px-0"
-                      disabled={loading}
-                      onClick={() => void loadDefinitions()}
-                    />
-                  </Tooltip>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex min-h-[48px] items-center justify-end">
-              <YakButton
-                danger
-                type="primary"
-                size="small"
-                className="!h-7"
-                onClick={() => setCreateOpen(true)}
-              >
-                <span className="text-[13px]">新建工作流</span>
-              </YakButton>
-            </div>
-
-            <div className="flex min-h-9 items-center rounded-sm bg-[#fff7e6] px-3 text-[12px] text-[#475467]">
-              <span className="mr-2 text-[14px] text-[#faad14]">▲</span>
-              <span className="font-medium text-[#344054]">【提示】</span>
-              <span>
-                草稿可随时编辑和测试；发布后生成正式版本。调度仅对已上线版本生效，下线不会中断已经启动的实例。
-              </span>
-            </div>
-          </div>
-
-          <Divider style={{ marginTop: 4, marginBottom: 16 }} />
-
-          <div className="flex-1">
-            <Table
-              columns={columns as any}
-              dataSource={filteredDefinitions}
-              rowKey="id"
-              bordered
-              size="small"
-              loading={loading}
-              pagination={{
-                pageSize: 10,
-                showSizeChanger: true,
-                pageSizeOptions: [10, 20, 50],
-                showTotal: (total) => `共 ${total} 条`,
-                position: ['bottomRight'],
-              }}
-              scroll={{ x: 'max-content' }}
-              className={[
-                'compact-workflow-definition-table',
-                '[&_.ant-table]:!text-[13px]',
-                '[&_.ant-table-container]:!border-[#eaecf0]',
-                '[&_.ant-table-cell]:!align-middle',
-                '[&_.ant-table-thead>tr>th]:!h-10',
-                '[&_.ant-table-thead>tr>th]:!bg-[#f8f9fb]',
-                '[&_.ant-table-thead>tr>th]:!px-4',
-                '[&_.ant-table-thead>tr>th]:!py-2',
-                '[&_.ant-table-thead>tr>th]:!text-[12px]',
-                '[&_.ant-table-thead>tr>th]:!font-medium',
-                '[&_.ant-table-thead>tr>th]:!text-[#667085]',
-                '[&_.ant-table-thead>tr>th]:!border-[#eaecf0]',
-                '[&_.ant-table-tbody>tr>td]:!px-4',
-                '[&_.ant-table-tbody>tr>td]:!py-2.5',
-                '[&_.ant-table-tbody>tr>td]:!border-[#f0f2f5]',
-                '[&_.ant-table-tbody>tr>td]:!text-[#667085]',
-                '[&_.ant-table-tbody>tr:hover>td]:!bg-[#fafbfc]',
-                '[&_.ant-table-cell-fix-right]:!bg-white',
-                '[&_.ant-table-tbody>tr:hover_.ant-table-cell-fix-right]:!bg-[#fafbfc]',
-                '[&_.ant-table-placeholder>td]:!h-[240px]',
-                '[&_.ant-pagination]:!my-4',
-              ].join(' ')}
-              locale={{
-                emptyText: (
-                  <Empty
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    description={
-                      <span className="text-[12px] text-[#98a2b3]">
-                        {keyword || filter !== 'ALL'
-                          ? '暂无符合条件的工作流'
-                          : '暂无工作流定义'}
-                      </span>
-                    }
-                  />
-                ),
-              }}
-            />
-          </div>
-        </div>
-
-        <Drawer
-          open={createOpen}
-          width={560}
-          placement="right"
-          closable={false}
-          destroyOnClose
-          maskClosable={!creating}
-          keyboard={!creating}
-          onClose={handleCreateClose}
-          title={
-            <div>
-              <div className="text-[18px] font-semibold leading-7 text-[#101828]">
-                新建工作流
-              </div>
-              <div className="mt-1 text-[11px] font-normal text-[rgba(22,24,35,.42)]">
-                第一步创建基础信息，下一步进入画布完成任务编排
-              </div>
-            </div>
-          }
-          extra={
-            <div className="flex items-center gap-2">
-              <YakButton
-                disabled={creating}
-                onClick={handleCreateClose}
-                className="!h-9 !rounded-lg !px-4"
-              >
-                取消
-              </YakButton>
-              <YakButton
-                type="primary"
-                loading={creating}
-                onClick={() => void handleCreate()}
-                className="!h-9 !rounded-lg !px-5 !text-white"
-              >
-                创建并配置
-              </YakButton>
-            </div>
-          }
-          styles={{
-            header: {
-              padding: '18px 24px',
-              borderBottom: '1px solid #eaecf0',
-            },
-            body: { padding: 24 },
-          }}
+    <>
+      <div className="min-h-[calc(100dvh-56px)] bg-[#f7f8fa] text-[#242731]">
+        <motion.main
+          initial="hidden"
+          animate="visible"
+          variants={WORKFLOW_PAGE_ANIMATION.sectionStagger}
+          className="px-4 pb-4 pt-4"
         >
-          <Form form={form} layout="vertical" requiredMark="optional">
-            <Form.Item
-              name="name"
-              label="工作流名称"
-              rules={[
-                { required: true, message: '请输入工作流名称' },
-                { max: 100, message: '名称不能超过 100 个字符' },
-              ]}
-            >
-              <Input
-                variant="filled"
-                placeholder="例如：每日订单同步工作流"
-              />
-            </Form.Item>
+          <motion.section
+            variants={WORKFLOW_PAGE_ANIMATION.fadeUp}
+            className="flex min-h-[calc(100dvh-88px)] flex-col rounded-[20px] bg-white px-6 pb-4 pt-5 shadow-[0_2px_10px_rgba(31,35,41,0.025)] max-md:px-4"
+          >
+            <div className="space-y-5">
+              <WorkflowPageHeader onCreate={() => setCreateOpen(true)} />
 
-            <Form.Item
-              name="description"
-              label="工作流描述"
-              rules={[
-                { max: 500, message: '描述不能超过 500 个字符' },
-              ]}
-            >
-              <Input.TextArea
-                variant="filled"
-                rows={4}
-                placeholder="简单说明这个工作流负责什么"
-              />
-            </Form.Item>
+              <WorkflowSummaryCards summary={summary} />
 
-            <div className="mt-2 rounded-[9px] border border-[rgba(22,24,35,.055)] bg-[#f8f9fa] p-4">
-              <div className="flex items-center gap-2 text-[12px] font-semibold text-[#161823]">
-                <GitBranch
-                  size={15}
-                  strokeWidth={1.9}
-                  className="text-[#667085]"
-                />
-                创建后进入工作流配置
-              </div>
-              <div className="mt-2 text-[11px] leading-5 text-[rgba(22,24,35,.48)]">
-                在下一步从左侧拖入已经配置好的任务，完成 DAG
-                连线，并设置节点重试、超时、触发规则和失败策略。
-              </div>
+              <WorkflowToolbar
+                filter={filter}
+                keyword={keyword}
+                viewMode={viewMode}
+                hasActiveFilters={hasActiveFilters}
+                onFilterChange={setFilter}
+                onKeywordChange={setKeyword}
+                onViewModeChange={setViewMode}
+                onReset={resetFilters}
+              />
             </div>
-          </Form>
-        </Drawer>
+
+            <div className="mt-5 flex flex-1 flex-col">
+              <Spin spinning={loading}>
+                <motion.section
+                  variants={WORKFLOW_PAGE_ANIMATION.cardStagger}
+                  initial="hidden"
+                  animate="visible"
+                  className={
+                    viewMode === 'list'
+                      ? 'grid grid-cols-1 gap-[14px]'
+                      : 'grid grid-cols-1 gap-[14px] md:grid-cols-2 2xl:grid-cols-3'
+                  }
+                >
+                  {pageRecords.map((record) => (
+                    <WorkflowDefinitionCard
+                      key={record.id}
+                      record={record}
+                      viewMode={viewMode}
+                      busy={actionId === record.id}
+                      blocked={Boolean(actionId && actionId !== record.id)}
+                      onEdit={goToDefinition}
+                      onSchedule={goToSchedules}
+                      onDelete={handleDelete}
+                      onPublish={handlePublish}
+                      onOffline={handleOffline}
+                      onRun={handleRun}
+                      onPause={handlePause}
+                      onResume={handleResume}
+                    />
+                  ))}
+                </motion.section>
+
+                {!loading && filteredDefinitions.length === 0 ? (
+                  <div className="mt-6">
+                    <WorkflowEmptyState
+                      filtered={hasActiveFilters}
+                      onReset={resetFilters}
+                      onCreate={() => setCreateOpen(true)}
+                    />
+                  </div>
+                ) : null}
+              </Spin>
+
+              {filteredDefinitions.length > 0 ? (
+                <motion.footer
+                  variants={WORKFLOW_PAGE_ANIMATION.fadeUp}
+                  className="mt-auto flex shrink-0 justify-end pt-6"
+                >
+                  <Pagination
+                    current={pageNo}
+                    pageSize={pageSize}
+                    total={filteredDefinitions.length}
+                    showSizeChanger
+                    showQuickJumper
+                    pageSizeOptions={WORKFLOW_PAGE_SIZE_OPTIONS}
+                    disabled={loading}
+                    showTotal={(total, range) =>
+                      `第 ${range[0]}-${range[1]} 条，共 ${total} 条`
+                    }
+                    onChange={(nextPage, nextPageSize) => {
+                      setPageNo(nextPageSize !== pageSize ? 1 : nextPage);
+                      setPageSize(nextPageSize);
+                    }}
+                  />
+                </motion.footer>
+              ) : null}
+            </div>
+          </motion.section>
+        </motion.main>
       </div>
-    </ConfigProvider>
+
+      <WorkflowCreateDrawer
+        open={createOpen}
+        creating={creating}
+        onClose={() => setCreateOpen(false)}
+        onSubmit={handleCreate}
+      />
+    </>
   );
-}
+};
+
+export default WorkflowDefinitionList;

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowEmptyState.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowEmptyState.tsx
@@ -1,0 +1,84 @@
+import { YakButton } from '@/components/ui';
+
+const WorkflowEmptyIllustration = () => (
+  <svg
+    width="220"
+    height="158"
+    viewBox="0 0 220 158"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <circle cx="67" cy="27" r="18" fill="#ffe9ee" />
+    <path
+      d="M67 19V35M59 27H75"
+      stroke="#fe2c55"
+      strokeWidth="3.5"
+      strokeLinecap="round"
+    />
+    <ellipse cx="112" cy="145" rx="78" ry="5" fill="#161823" opacity="0.045" />
+
+    <rect x="91" y="35" width="96" height="79" rx="7" fill="#fff" stroke="#515151" strokeWidth="1.5" />
+    <path d="M91 51H187" stroke="#515151" strokeWidth="1.5" />
+    <circle cx="101" cy="43" r="2" fill="#c6cacd" />
+    <circle cx="108" cy="43" r="2" fill="#c6cacd" />
+    <circle cx="115" cy="43" r="2" fill="#c6cacd" />
+
+    <rect x="105" y="66" width="24" height="14" rx="5" fill="#f6f7f9" stroke="#515151" strokeWidth="1.5" />
+    <rect x="151" y="60" width="24" height="14" rx="5" fill="#f6f7f9" stroke="#515151" strokeWidth="1.5" />
+    <rect x="151" y="91" width="24" height="14" rx="5" fill="#f6f7f9" stroke="#515151" strokeWidth="1.5" />
+    <path d="M129 73H140C146 73 147 67 151 67" stroke="#8f959d" strokeWidth="1.7" strokeLinecap="round" />
+    <path d="M129 73H140C146 73 147 98 151 98" stroke="#8f959d" strokeWidth="1.7" strokeLinecap="round" />
+    <circle cx="117" cy="73" r="3" fill="#fe2c55" />
+    <circle cx="163" cy="67" r="3" fill="#5868d8" />
+    <circle cx="163" cy="98" r="3" fill="#2ea35d" />
+
+    <circle cx="57" cy="90" r="10" fill="#fff" stroke="#515151" strokeWidth="1.5" />
+    <path d="M45 121C45 106 49 100 57 100C65 100 70 107 70 121V135H43L45 121Z" fill="#515151" />
+    <path d="M65 106C76 104 82 98 94 89" stroke="#515151" strokeWidth="2" strokeLinecap="round" />
+    <circle cx="95" cy="88" r="3" fill="#fff" stroke="#515151" strokeWidth="1.5" />
+
+    <path d="M179 121C183 116 190 113 197 114" stroke="#c6cacd" strokeWidth="1.5" strokeLinecap="round" strokeDasharray="3 4" />
+    <circle cx="189" cy="40" r="2.5" fill="#ffd8e1" />
+    <circle cx="196" cy="34" r="1.5" fill="#c6cacd" />
+  </svg>
+);
+
+interface WorkflowEmptyStateProps {
+  filtered: boolean;
+  onReset: () => void;
+  onCreate: () => void;
+}
+
+const WorkflowEmptyState = ({
+  filtered,
+  onReset,
+  onCreate,
+}: WorkflowEmptyStateProps) => (
+  <div className="mt-1 flex min-h-[360px] items-center justify-center rounded-[10px] bg-[#fafafa]">
+    <div className="flex w-[360px] -translate-y-1 flex-col items-center">
+      <WorkflowEmptyIllustration />
+      <h3 className="mt-0.5 text-[14px] font-semibold leading-[22px] text-[#1c1f23]">
+        {filtered ? '没有找到符合条件的工作流' : '还没有创建工作流'}
+      </h3>
+      <p className="mb-0 mt-1 text-center text-[11px] leading-5 text-[#969ba5]">
+        {filtered
+          ? '调整状态或搜索条件后再试试'
+          : '创建草稿后即可编排节点、测试运行并发布正式版本'}
+      </p>
+      <div className="mt-3.5">
+        {filtered ? (
+          <YakButton size="small" onClick={onReset}>
+            重置筛选
+          </YakButton>
+        ) : (
+          <YakButton type="primary" size="small" onClick={onCreate}>
+            新建工作流
+          </YakButton>
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+export default WorkflowEmptyState;

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowPageHeader.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowPageHeader.tsx
@@ -1,0 +1,30 @@
+import { YakButton } from '@/components/ui';
+import { GitBranch, Plus } from 'lucide-react';
+
+interface WorkflowPageHeaderProps {
+  onCreate: () => void;
+}
+
+const WorkflowPageHeader = ({ onCreate }: WorkflowPageHeaderProps) => (
+  <header className="flex items-center justify-between gap-6">
+    <div className="flex min-w-0 items-center gap-3">
+      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] border border-[rgba(31,35,41,0.07)] bg-[#f7f8fa] text-[#4f5968]">
+        <GitBranch size={19} strokeWidth={1.85} />
+      </span>
+      <h1 className="m-0 text-xl font-semibold leading-7 tracking-[-0.35px] text-[#252832]">
+        工作流定义
+      </h1>
+    </div>
+
+    <YakButton
+      type="primary"
+      icon={<Plus size={16} strokeWidth={2.1} />}
+      className="!h-9 !shrink-0 !rounded-[10px] !px-4 !text-[13px]"
+      onClick={onCreate}
+    >
+      新建工作流
+    </YakButton>
+  </header>
+);
+
+export default WorkflowPageHeader;

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowSummaryCards.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowSummaryCards.tsx
@@ -1,0 +1,79 @@
+import { motion } from 'framer-motion';
+import { Activity, FilePenLine, GitBranch, Rocket } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import type { WorkflowSummary } from '../model';
+import { WORKFLOW_PAGE_ANIMATION } from '../model';
+
+interface SummaryItem {
+  key: keyof WorkflowSummary;
+  label: string;
+  icon: ReactNode;
+  iconClassName: string;
+}
+
+const SUMMARY_ITEMS: SummaryItem[] = [
+  {
+    key: 'total',
+    label: '全部工作流',
+    icon: <GitBranch size={17} strokeWidth={1.9} />,
+    iconClassName: 'bg-[#eef2ff] text-[#5868d8]',
+  },
+  {
+    key: 'online',
+    label: '已上线',
+    icon: <Rocket size={17} strokeWidth={1.9} />,
+    iconClassName: 'bg-[#edf8f1] text-[#2ea35d]',
+  },
+  {
+    key: 'draftChanged',
+    label: '待发布草稿',
+    icon: <FilePenLine size={17} strokeWidth={1.9} />,
+    iconClassName: 'bg-[#fff7e9] text-[#c98628]',
+  },
+  {
+    key: 'activeExecutions',
+    label: '活动执行',
+    icon: <Activity size={17} strokeWidth={1.9} />,
+    iconClassName: 'bg-[#fff1f4] text-[#e34f6d]',
+  },
+];
+
+interface WorkflowSummaryCardsProps {
+  summary: WorkflowSummary;
+}
+
+const WorkflowSummaryCards = ({ summary }: WorkflowSummaryCardsProps) => (
+  <motion.section
+    variants={WORKFLOW_PAGE_ANIMATION.fadeUp}
+    className="flex flex-wrap gap-3"
+  >
+    {SUMMARY_ITEMS.map((item) => (
+      <div
+        key={item.key}
+        className="flex min-w-[180px] flex-1 items-center gap-3 rounded-[14px] bg-[#fafbfc] px-4 py-3"
+      >
+        <span
+          className={[
+            'flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px]',
+            item.iconClassName,
+          ].join(' ')}
+        >
+          {item.icon}
+        </span>
+
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-medium text-[#606571]">
+            {item.label}
+          </div>
+        </div>
+
+        <strong className="ml-auto shrink-0 text-[28px] font-semibold leading-none tracking-[-0.6px] text-[#242731]">
+          {summary[item.key]}
+        </strong>
+      </div>
+    ))}
+  </motion.section>
+);
+
+export default WorkflowSummaryCards;

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowToolbar.tsx
@@ -1,0 +1,128 @@
+import { YakButton, YakTab } from '@/components/ui';
+import { Input } from 'antd';
+import { motion } from 'framer-motion';
+import { Grid2X2, LayoutList, Search } from 'lucide-react';
+
+import {
+  WORKFLOW_PAGE_ANIMATION,
+  WORKFLOW_STATUS_TABS,
+  type WorkflowFilterKey,
+  type WorkflowViewMode,
+} from '../model';
+
+interface WorkflowToolbarProps {
+  filter: WorkflowFilterKey;
+  keyword: string;
+  viewMode: WorkflowViewMode;
+  hasActiveFilters: boolean;
+  onFilterChange: (value: WorkflowFilterKey) => void;
+  onKeywordChange: (value: string) => void;
+  onViewModeChange: (value: WorkflowViewMode) => void;
+  onReset: () => void;
+}
+
+const WorkflowToolbar = ({
+  filter,
+  keyword,
+  viewMode,
+  hasActiveFilters,
+  onFilterChange,
+  onKeywordChange,
+  onViewModeChange,
+  onReset,
+}: WorkflowToolbarProps) => (
+  <motion.section
+    variants={WORKFLOW_PAGE_ANIMATION.fadeUp}
+    className="flex min-h-9 items-end justify-between gap-6 border-b border-solid border-[#eceef2] max-xl:flex-col max-xl:items-stretch max-xl:gap-3"
+  >
+    <div className="flex items-end">
+      <YakTab
+        size="small"
+        activeKey={filter}
+        className={[
+          '[&_.ant-tabs-nav]:!mb-0',
+          '[&_.ant-tabs-nav::before]:!hidden',
+          '[&_.ant-tabs-tab]:!px-0',
+          '[&_.ant-tabs-tab]:!pb-[10px]',
+          '[&_.ant-tabs-tab+.ant-tabs-tab]:!ml-8',
+          '[&_.ant-tabs-tab]:!text-[13px]',
+          '[&_.ant-tabs-tab]:!text-[#8c919b]',
+          '[&_.ant-tabs-tab.ant-tabs-tab-active_.ant-tabs-tab-btn]:!font-semibold',
+          '[&_.ant-tabs-tab.ant-tabs-tab-active_.ant-tabs-tab-btn]:!text-[#292c35]',
+          '[&_.ant-tabs-tab::after]:!bottom-[-1px]',
+          '[&_.ant-tabs-tab::after]:!h-0.5',
+          '[&_.ant-tabs-tab::after]:!bg-[#252832]',
+        ].join(' ')}
+        items={WORKFLOW_STATUS_TABS.map((item) => ({
+          key: item.key,
+          label: item.label,
+        }))}
+        onChange={(key) => onFilterChange(key as WorkflowFilterKey)}
+      />
+    </div>
+
+    <div className="flex flex-wrap items-center justify-end gap-2 pb-[5px] max-xl:justify-start">
+      <Input
+        allowClear
+        variant="filled"
+        value={keyword}
+        prefix={
+          <Search size={15} strokeWidth={1.8} className="text-[#8f949e]" />
+        }
+        className={[
+          '!w-[292px] max-md:!w-[220px]',
+          '[&.ant-input-affix-wrapper]:!h-9',
+          '[&.ant-input-affix-wrapper]:!rounded-[10px]',
+          '[&.ant-input-affix-wrapper]:!border-0',
+          '[&.ant-input-affix-wrapper]:!bg-[#f6f7f9]',
+          '[&_.ant-input]:!text-[12px]',
+        ].join(' ')}
+        placeholder="搜索工作流名称或描述"
+        onChange={(event) => onKeywordChange(event.target.value)}
+      />
+
+      {hasActiveFilters ? (
+        <YakButton
+          type="text"
+          size="small"
+          className="!h-9 !rounded-[9px] !px-2.5 !text-[12px] !text-[#777c86]"
+          onClick={onReset}
+        >
+          重置
+        </YakButton>
+      ) : null}
+
+      <div className="flex h-9 items-center gap-0.5 rounded-[10px] bg-[#f4f5f7] p-[3px]">
+        <YakButton
+          type="text"
+          iconOnly
+          title="卡片视图"
+          className={[
+            '!h-[30px] !w-[30px] !rounded-[7px] !border-0 !p-0',
+            viewMode === 'grid'
+              ? '!bg-white !text-[#2d313a] !shadow-[0_1px_4px_rgba(31,35,41,0.10)]'
+              : '!bg-transparent !text-[#92969f] hover:!text-[#555b66]',
+          ].join(' ')}
+          icon={<Grid2X2 size={15} strokeWidth={1.8} />}
+          onClick={() => onViewModeChange('grid')}
+        />
+
+        <YakButton
+          type="text"
+          iconOnly
+          title="列表视图"
+          className={[
+            '!h-[30px] !w-[30px] !rounded-[7px] !border-0 !p-0',
+            viewMode === 'list'
+              ? '!bg-white !text-[#2d313a] !shadow-[0_1px_4px_rgba(31,35,41,0.10)]'
+              : '!bg-transparent !text-[#92969f] hover:!text-[#555b66]',
+          ].join(' ')}
+          icon={<LayoutList size={16} strokeWidth={1.8} />}
+          onClick={() => onViewModeChange('list')}
+        />
+      </div>
+    </div>
+  </motion.section>
+);
+
+export default WorkflowToolbar;

--- a/yak-ops-ui/src/pages/workflow/management/model.ts
+++ b/yak-ops-ui/src/pages/workflow/management/model.ts
@@ -1,0 +1,264 @@
+import type {
+  WorkflowDefinition,
+  WorkflowDefinitionStatus,
+} from '@/services/workflow/definitions';
+
+export type WorkflowFilterKey = 'ALL' | WorkflowDefinitionStatus;
+export type WorkflowViewMode = 'grid' | 'list';
+
+export interface WorkflowSummary {
+  total: number;
+  online: number;
+  draftChanged: number;
+  activeExecutions: number;
+}
+
+export const WORKFLOW_PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+
+export const WORKFLOW_STATUS_TABS: Array<{
+  key: WorkflowFilterKey;
+  label: string;
+}> = [
+  { key: 'ALL', label: '全部' },
+  { key: 'ONLINE', label: '已上线' },
+  { key: 'DRAFT', label: '草稿' },
+  { key: 'OFFLINE', label: '已下线' },
+];
+
+const ACTIVE_RUNTIME_STATUSES = new Set([
+  'CREATED',
+  'WAITING',
+  'READY',
+  'SUBMITTED',
+  'RUNNING',
+  'PAUSING',
+  'PAUSED',
+  'RESUMING',
+]);
+
+const RUNNING_RUNTIME_STATUSES = new Set([
+  'CREATED',
+  'WAITING',
+  'READY',
+  'SUBMITTED',
+  'RUNNING',
+]);
+
+const RUNTIME_LABELS: Record<string, string> = {
+  CREATED: '已创建',
+  WAITING: '等待中',
+  READY: '就绪',
+  SUBMITTED: '待执行',
+  RUNNING: '运行中',
+  PAUSING: '暂停中',
+  PAUSED: '已暂停',
+  RESUMING: '恢复中',
+  SUCCESS: '成功',
+  SUCCESS_WITH_WARNINGS: '完成（有告警）',
+  FAILED: '失败',
+  WARNING: '告警',
+  CANCELED: '已取消',
+  TIMED_OUT: '已超时',
+};
+
+const FAILURE_STRATEGY_LABELS: Record<string, string> = {
+  FAIL_FAST: '快速失败',
+  CONTINUE_INDEPENDENT_BRANCHES: '继续独立分支',
+  TERMINATE_ALL: '终止全部',
+};
+
+export const DEFINITION_STATUS_META: Record<
+  WorkflowDefinitionStatus,
+  { label: string; textClassName: string; backgroundClassName: string }
+> = {
+  DRAFT: {
+    label: '草稿',
+    textClassName: 'text-[#667085]',
+    backgroundClassName: 'bg-[#f1f3f5]',
+  },
+  ONLINE: {
+    label: '已上线',
+    textClassName: 'text-[#e5254e]',
+    backgroundClassName: 'bg-[#fff1f4]',
+  },
+  OFFLINE: {
+    label: '已下线',
+    textClassName: 'text-[#667085]',
+    backgroundClassName: 'bg-[#f1f3f5]',
+  },
+};
+
+export const isActiveRuntime = (status?: string) =>
+  Boolean(status && ACTIVE_RUNTIME_STATUSES.has(status));
+
+export const isRunningRuntime = (status?: string) =>
+  Boolean(status && RUNNING_RUNTIME_STATUSES.has(status));
+
+export const runtimeStatusMeta = (status?: string) => {
+  if (!status) {
+    return {
+      label: '尚未运行',
+      dotClassName: 'bg-[#a6abb4]',
+      textClassName: 'text-[#777d88]',
+      backgroundClassName: 'bg-[#f3f4f6]',
+    };
+  }
+
+  if (status === 'FAILED' || status === 'TIMED_OUT') {
+    return {
+      label: RUNTIME_LABELS[status] || status,
+      dotClassName: 'bg-[#e45863]',
+      textClassName: 'text-[#c74350]',
+      backgroundClassName: 'bg-[#fff1f2]',
+    };
+  }
+
+  if (status === 'WARNING' || status === 'SUCCESS_WITH_WARNINGS') {
+    return {
+      label: RUNTIME_LABELS[status] || status,
+      dotClassName: 'bg-[#e39b35]',
+      textClassName: 'text-[#b77a22]',
+      backgroundClassName: 'bg-[#fff7e9]',
+    };
+  }
+
+  if (isActiveRuntime(status)) {
+    return {
+      label: RUNTIME_LABELS[status] || status,
+      dotClassName: 'bg-[#fe2c55]',
+      textClassName: 'text-[#e5254e]',
+      backgroundClassName: 'bg-[#fff1f4]',
+    };
+  }
+
+  if (status === 'SUCCESS') {
+    return {
+      label: '成功',
+      dotClassName: 'bg-[#38a169]',
+      textClassName: 'text-[#36845d]',
+      backgroundClassName: 'bg-[#edf8f1]',
+    };
+  }
+
+  return {
+    label: RUNTIME_LABELS[status] || status,
+    dotClassName: 'bg-[#8f96a3]',
+    textClassName: 'text-[#667085]',
+    backgroundClassName: 'bg-[#f3f4f6]',
+  };
+};
+
+export const getRuntimeHint = (
+  runtimeStatus: string | undefined,
+  definitionStatus: WorkflowDefinitionStatus,
+) => {
+  if (!runtimeStatus) {
+    return definitionStatus === 'ONLINE'
+      ? '可运行当前生效版本'
+      : '发布并上线后可正式运行';
+  }
+
+  switch (runtimeStatus) {
+    case 'RUNNING':
+      return '当前存在运行中的执行实例';
+    case 'PAUSING':
+      return '正在暂停当前执行';
+    case 'PAUSED':
+      return '执行已暂停，可恢复后继续';
+    case 'RESUMING':
+      return '正在恢复当前执行';
+    case 'CREATED':
+    case 'WAITING':
+    case 'READY':
+    case 'SUBMITTED':
+      return '执行已提交，等待运行';
+    case 'SUCCESS':
+      return '最近一次执行已成功完成';
+    case 'SUCCESS_WITH_WARNINGS':
+    case 'WARNING':
+      return '最近一次执行完成，但存在告警';
+    case 'FAILED':
+      return '最近一次执行失败';
+    case 'TIMED_OUT':
+      return '最近一次执行超时';
+    case 'CANCELED':
+      return '最近一次执行已取消';
+    default:
+      return '可前往执行实例查看详细状态';
+  }
+};
+
+export const getPublishActionLabel = (record: WorkflowDefinition) => {
+  if (record.status === 'ONLINE') return '下线工作流';
+  if (
+    record.status === 'OFFLINE' &&
+    record.activeVersionNo &&
+    !record.draftChanged
+  ) {
+    return '重新上线';
+  }
+  if (record.activeVersionNo && record.draftChanged) {
+    return '发布更新并上线';
+  }
+  return '发布并上线';
+};
+
+export const formatWorkflowTime = (value?: string) => {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+};
+
+export const formatWorkflowDuration = (seconds?: number) => {
+  if (!seconds || seconds <= 0) return '未设置';
+  if (seconds < 60) return `${seconds} 秒`;
+  if (seconds % 3600 === 0) return `${seconds / 3600} 小时`;
+  if (seconds % 60 === 0) return `${seconds / 60} 分钟`;
+  return `${seconds} 秒`;
+};
+
+export const failureStrategyLabel = (value: string) =>
+  FAILURE_STRATEGY_LABELS[value] || value;
+
+export const buildWorkflowSummary = (
+  definitions: WorkflowDefinition[],
+): WorkflowSummary => ({
+  total: definitions.length,
+  online: definitions.filter((item) => item.status === 'ONLINE').length,
+  draftChanged: definitions.filter((item) => item.draftChanged).length,
+  activeExecutions: definitions.filter((item) =>
+    isActiveRuntime(item.latestExecutionStatus),
+  ).length,
+});
+
+export const WORKFLOW_PAGE_ANIMATION = {
+  fadeUp: {
+    hidden: { opacity: 0, y: 18 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.45,
+        ease: [0.22, 1, 0.36, 1],
+      },
+    },
+  },
+  sectionStagger: {
+    hidden: {},
+    visible: {
+      transition: {
+        staggerChildren: 0.08,
+        delayChildren: 0.06,
+      },
+    },
+  },
+  cardStagger: {
+    hidden: {},
+    visible: {
+      transition: {
+        staggerChildren: 0.06,
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Rebuild the Workflow Definition list using the current Data Source management page as the visual and interaction reference, while preserving Workflow-specific lifecycle behavior.

## Data Source parity

- use the same light-gray page canvas and rounded white content shell
- use the same icon-tile + page title + primary create-action header
- add the same four-tile summary area
- use underline tabs, filled search, conditional reset, and grid/list view switching
- replace the dense table with animated card/list views following the Data Source card language
- reuse the same card rhythm: rounded border, soft shadow, hover lift, subtle pattern/glow, hover actions, and bottom metadata strip
- add a dedicated workflow empty state matching the Data Source empty-state presentation
- move pagination to the page footer with size changer, quick jumper, and range/total text

## Workflow-specific mapping

The Data Source presentation is copied, but Workflow business semantics remain Workflow-owned:

- summary cards show **全部工作流 / 已上线 / 待发布草稿 / 活动执行**
- cards preserve workflow name, lifecycle status, draft-change state, description, node/edge counts, timeout, failure strategy, published version, latest execution, and update time
- card actions preserve the lifecycle model from merged #939:
  - edit draft
  - schedule configuration
  - run active published version
  - pause/resume the latest execution
  - publish and online / publish update / re-online
  - offline
  - delete when allowed
- active execution polling remains in place so card runtime state continues to refresh
- grid and list modes present the same business information at different densities

## Refactor

The previous `WorkflowDefinitionList.tsx` mixed fetching, filtering, lifecycle actions, table rendering, create form, status presentation, and layout in one large component.

This PR splits the page into focused presentation units:

- `model.ts`
- `WorkflowPageHeader.tsx`
- `WorkflowSummaryCards.tsx`
- `WorkflowToolbar.tsx`
- `WorkflowDefinitionCard.tsx`
- `WorkflowEmptyState.tsx`
- `WorkflowCreateDrawer.tsx`
- a smaller orchestration-focused `WorkflowDefinitionList.tsx`

## Scope

Frontend only.

No Workflow backend API, persistence model, Project Space contract, version semantics, runtime semantics, or route contract is changed.

## Validation status

- branch is based on current `main`, which already contains the lifecycle cleanup from #939
- compare is ahead-only / behind 0
- changes are limited to the Workflow management list UI
- this connector environment does not provide a runnable browser/TypeScript checkout, so local `tsc`, Jest, and browser regression are not claimed as executed; keep this PR Draft until CI or developer-local verification runs

Suggested local validation:

```bash
cd yak-ops-ui
yarn tsc
```

Suggested browser regression:

1. Open Workflow Definition list and compare page shell/header/summary/toolbar/card density with Data Source management.
2. Verify status tabs, live search, reset, grid/list switching, and pagination.
3. Create a workflow and confirm the create drawer still enters the editor after creation.
4. DRAFT/OFFLINE workflow remains editable even if the latest test/recent execution is active or paused.
5. ONLINE workflow runs the active published version; unpublished draft changes do not change that execution target.
6. Pause/resume active executions from the card action area.
7. Publish first version, publish an updated draft, re-online an unchanged offline version, and offline an online version.
8. Verify delete remains unavailable for ONLINE or active-runtime workflows.
9. Verify empty and filtered-empty states behave correctly.
10. Check 1080p/2K and grid/list layouts for overflow or action clipping.