### PR TITLE
feat(workflow): add reusable emoji icon picker

### DIFF
--- a/yak-ops-ui/src/components/EmojiIconPicker/index.tsx
+++ b/yak-ops-ui/src/components/EmojiIconPicker/index.tsx
@@ -1,0 +1,332 @@
+import { Input, Popover } from 'antd';
+import { Check, Search } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+export interface EmojiIconValue {
+  emoji: string;
+  background: string;
+}
+
+export const DEFAULT_EMOJI_ICON: EmojiIconValue = {
+  emoji: '🤖',
+  background: '#FFE7D6',
+};
+
+interface EmojiEntry {
+  emoji: string;
+  keywords: string;
+}
+
+interface EmojiGroup {
+  label: string;
+  items: EmojiEntry[];
+}
+
+const EMOJI_GROUPS: EmojiGroup[] = [
+  {
+    label: '常用',
+    items: [
+      { emoji: '👍', keywords: '赞 like good thumbs up' },
+      { emoji: '😀', keywords: '开心 smile happy face' },
+      { emoji: '😘', keywords: '亲吻 kiss love' },
+      { emoji: '😍', keywords: '喜欢 love heart eyes' },
+      { emoji: '😆', keywords: '大笑 laugh happy' },
+      { emoji: '😜', keywords: '调皮 wink playful' },
+      { emoji: '😅', keywords: '汗 smile sweat' },
+      { emoji: '😂', keywords: '笑哭 joy tears' },
+      { emoji: '😱', keywords: '惊讶 shock surprise' },
+      { emoji: '🤖', keywords: '机器人 robot ai workflow' },
+      { emoji: '✨', keywords: '闪光 sparkle magic' },
+      { emoji: '🚀', keywords: '火箭 rocket launch' },
+      { emoji: '⚡', keywords: '闪电 lightning fast' },
+      { emoji: '🔥', keywords: '火 fire hot' },
+      { emoji: '✅', keywords: '完成 check done success' },
+      { emoji: '🎯', keywords: '目标 target goal' },
+    ],
+  },
+  {
+    label: '人物',
+    items: [
+      { emoji: '🙂', keywords: '微笑 smile person' },
+      { emoji: '😎', keywords: '酷 cool sunglasses' },
+      { emoji: '🤓', keywords: '程序员 nerd developer' },
+      { emoji: '🧐', keywords: '观察 inspect monocle' },
+      { emoji: '🤔', keywords: '思考 think' },
+      { emoji: '🥳', keywords: '庆祝 party celebrate' },
+      { emoji: '🙋', keywords: '举手 hand person' },
+      { emoji: '👨‍💻', keywords: '开发 developer programmer code' },
+      { emoji: '👩‍💻', keywords: '开发 developer programmer code' },
+      { emoji: '🧑‍🔧', keywords: '工具 engineer worker' },
+      { emoji: '🧑‍🚀', keywords: '宇航员 astronaut' },
+      { emoji: '🕵️', keywords: '检查 inspect detective' },
+    ],
+  },
+  {
+    label: '对象',
+    items: [
+      { emoji: '🔀', keywords: '工作流 workflow shuffle flow' },
+      { emoji: '🔁', keywords: '同步 sync repeat' },
+      { emoji: '🗄️', keywords: '数据库 database storage' },
+      { emoji: '📦', keywords: '包 package box' },
+      { emoji: '📊', keywords: '数据 chart analytics' },
+      { emoji: '🧩', keywords: '组件 component puzzle' },
+      { emoji: '🔗', keywords: '连接 link connect' },
+      { emoji: '🛠️', keywords: '工具 tools build' },
+      { emoji: '📌', keywords: '固定 pin' },
+      { emoji: '🧠', keywords: '智能 ai brain' },
+      { emoji: '💡', keywords: '想法 idea light' },
+      { emoji: '🛡️', keywords: '安全 security shield' },
+      { emoji: '🔍', keywords: '搜索 search inspect' },
+      { emoji: '📡', keywords: '实时 realtime signal' },
+      { emoji: '⏱️', keywords: '定时 timer schedule' },
+      { emoji: '🧪', keywords: '测试 test experiment' },
+    ],
+  },
+];
+
+const ICON_BACKGROUNDS = [
+  '#FFE7D6',
+  '#FDECC8',
+  '#E8F7D9',
+  '#DDF4EE',
+  '#DCEEFF',
+  '#E5E7FF',
+  '#F0E3FF',
+  '#FBE2EF',
+  '#FFF1CC',
+  '#EAF6D5',
+  '#D9F2F4',
+  '#D8EBFF',
+  '#E3E1FF',
+  '#EEE0F8',
+  '#F7DFE6',
+  '#FFE1D7',
+];
+
+const isEmojiIconValue = (value: unknown): value is EmojiIconValue => {
+  if (!value || Array.isArray(value) || typeof value !== 'object') return false;
+  const candidate = value as Partial<EmojiIconValue>;
+  return Boolean(candidate.emoji?.trim() && candidate.background?.trim());
+};
+
+export const normalizeEmojiIconValue = (
+  value: unknown,
+  fallback: EmojiIconValue = DEFAULT_EMOJI_ICON,
+): EmojiIconValue => (isEmojiIconValue(value) ? value : fallback);
+
+interface EmojiIconProps {
+  value?: EmojiIconValue;
+  size?: number;
+  className?: string;
+  title?: string;
+}
+
+export const EmojiIcon = ({
+  value,
+  size = 40,
+  className,
+  title,
+}: EmojiIconProps) => {
+  const resolved = normalizeEmojiIconValue(value);
+
+  return (
+    <span
+      aria-label={title || resolved.emoji}
+      title={title}
+      className={[
+        'inline-flex shrink-0 select-none items-center justify-center overflow-hidden',
+        className || '',
+      ].join(' ')}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: Math.max(10, Math.round(size * 0.27)),
+        background: resolved.background,
+        fontSize: Math.max(18, Math.round(size * 0.5)),
+        lineHeight: 1,
+      }}
+    >
+      {resolved.emoji}
+    </span>
+  );
+};
+
+interface EmojiIconPickerProps {
+  value?: EmojiIconValue;
+  onChange?: (value: EmojiIconValue) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const EmojiIconPicker = ({
+  value,
+  onChange,
+  disabled,
+  className,
+}: EmojiIconPickerProps) => {
+  const resolvedValue = normalizeEmojiIconValue(value);
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<EmojiIconValue>(resolvedValue);
+  const [keyword, setKeyword] = useState('');
+
+  useEffect(() => {
+    if (!open) setDraft(normalizeEmojiIconValue(value));
+  }, [open, value]);
+
+  const groups = useMemo(() => {
+    const normalized = keyword.trim().toLowerCase();
+    if (!normalized) return EMOJI_GROUPS;
+
+    return EMOJI_GROUPS.map((group) => ({
+      ...group,
+      items: group.items.filter((item) =>
+        `${item.emoji} ${item.keywords}`.toLowerCase().includes(normalized),
+      ),
+    })).filter((group) => group.items.length > 0);
+  }, [keyword]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (disabled) return;
+    if (nextOpen) {
+      setDraft(normalizeEmojiIconValue(value));
+      setKeyword('');
+    }
+    setOpen(nextOpen);
+  };
+
+  const content = (
+    <div className="w-[360px] overflow-hidden rounded-[14px] bg-white">
+      <div className="px-3 pb-2 pt-3">
+        <Input
+          value={keyword}
+          allowClear
+          variant="filled"
+          prefix={<Search size={14} className="text-[#98a2b3]" />}
+          placeholder="搜索表情..."
+          onChange={(event) => setKeyword(event.target.value)}
+          className="!rounded-[9px]"
+        />
+      </div>
+
+      <div className="max-h-[250px] overflow-y-auto border-y border-[#f0f1f3] px-3 py-2.5">
+        {groups.length ? (
+          groups.map((group) => (
+            <section key={group.label} className="mb-3 last:mb-0">
+              <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.04em] text-[#667085]">
+                {group.label}
+              </div>
+              <div className="grid grid-cols-8 gap-1">
+                {group.items.map((item) => {
+                  const selected = draft.emoji === item.emoji;
+                  return (
+                    <button
+                      key={`${group.label}-${item.emoji}`}
+                      type="button"
+                      title={item.keywords.split(' ')[0]}
+                      className={[
+                        'flex h-9 w-9 items-center justify-center rounded-[8px] border text-[21px] transition-all',
+                        selected
+                          ? 'border-[#6d7fe8] bg-[#f2f4ff] shadow-[0_0_0_2px_rgba(84,104,223,.09)]'
+                          : 'border-transparent bg-transparent hover:bg-[#f5f6f8]',
+                      ].join(' ')}
+                      onClick={() => setDraft((current) => ({ ...current, emoji: item.emoji }))}
+                    >
+                      {item.emoji}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          ))
+        ) : (
+          <div className="flex h-24 items-center justify-center text-[12px] text-[#98a2b3]">
+            没有找到匹配的表情
+          </div>
+        )}
+      </div>
+
+      <div className="px-3 py-3">
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.04em] text-[#667085]">
+          选择样式
+        </div>
+        <div className="grid grid-cols-8 gap-1.5">
+          {ICON_BACKGROUNDS.map((background) => {
+            const selected = draft.background === background;
+            return (
+              <button
+                key={background}
+                type="button"
+                aria-label={`背景 ${background}`}
+                className={[
+                  'relative flex h-9 items-center justify-center rounded-[8px] border transition-all',
+                  selected
+                    ? 'border-[#6d7fe8] shadow-[0_0_0_2px_rgba(84,104,223,.1)]'
+                    : 'border-transparent hover:border-[#d9dce3]',
+                ].join(' ')}
+                style={{ background }}
+                onClick={() => setDraft((current) => ({ ...current, background }))}
+              >
+                <span className="text-[17px] leading-none">{draft.emoji}</span>
+                {selected ? (
+                  <span className="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[#5367dc] text-white shadow-sm">
+                    <Check size={9} strokeWidth={2.4} />
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex gap-2 border-t border-[#f0f1f3] px-3 py-3">
+        <button
+          type="button"
+          className="h-9 flex-1 rounded-[9px] border border-[#e3e5e9] bg-white text-[13px] font-medium text-[#4b5565] transition-colors hover:bg-[#f7f8fa]"
+          onClick={() => {
+            setDraft(normalizeEmojiIconValue(value));
+            setOpen(false);
+          }}
+        >
+          取消
+        </button>
+        <button
+          type="button"
+          className="h-9 flex-1 rounded-[9px] border border-[#1f2937] bg-[#1f2937] text-[13px] font-semibold text-white transition-colors hover:bg-[#111827]"
+          onClick={() => {
+            onChange?.(draft);
+            setOpen(false);
+          }}
+        >
+          确认
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover
+      open={open}
+      trigger="click"
+      placement="bottomLeft"
+      arrow={false}
+      content={content}
+      overlayInnerStyle={{ padding: 0, borderRadius: 14 }}
+      onOpenChange={handleOpenChange}
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label="选择图标"
+        className={[
+          'group/icon relative inline-flex shrink-0 rounded-[12px] border border-[#e4e7ec] bg-white p-0 shadow-[0_1px_2px_rgba(16,24,40,.03)] transition-all hover:border-[#cbd2dc] hover:shadow-[0_4px_12px_rgba(16,24,40,.08)] disabled:cursor-not-allowed disabled:opacity-50',
+          className || '',
+        ].join(' ')}
+        onClick={() => !disabled && setOpen(true)}
+      >
+        <EmojiIcon value={resolvedValue} size={42} />
+      </button>
+    </Popover>
+  );
+};
+
+export default EmojiIconPicker;

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/context.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/context.ts
@@ -43,6 +43,14 @@ const readStartMeta = (
   return isRecord(legacy) ? legacy as StartMeta : undefined;
 };
 
+const readEditorMetaExtras = (
+  editorMeta?: Record<string, unknown>,
+): Record<string, unknown> => Object.fromEntries(
+  Object.entries(editorMeta || {}).filter(
+    ([key]) => key !== WORKFLOW_START_META_KEY && key !== WORKFLOW_EDITOR_META_KEY,
+  ),
+);
+
 export const hydrateWorkflowStartConfig = (
   runtimeInput?: Record<string, unknown>,
   editorMeta?: Record<string, unknown>,
@@ -105,6 +113,7 @@ export const hydrateWorkflowStartConfig = (
     inputs,
     variables,
     nextNodeIds,
+    editorMetaExtras: readEditorMetaExtras(editorMeta),
   };
 };
 
@@ -147,6 +156,7 @@ export const serializeWorkflowStartContext = (
 export const serializeWorkflowStartEditorMeta = (
   config: WorkflowStartConfig,
 ): Record<string, unknown> => ({
+  ...(config.editorMetaExtras || {}),
   [WORKFLOW_START_META_KEY]: {
     version: 2,
     position: config.position,

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/types.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/types.ts
@@ -28,6 +28,10 @@ export interface WorkflowStartConfig {
   variables: WorkflowStartVariable[];
   /** Start 的显式后继节点，是编辑器历史状态的一部分。 */
   nextNodeIds: string[];
+  /**
+   * 编辑器不识别的顶层元数据需要原样透传，避免保存画布时误删图标等公共 UI 元数据。
+   */
+  editorMetaExtras?: Record<string, unknown>;
 }
 
 export interface WorkflowStartNodeData {

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowCreateDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowCreateDrawer.tsx
@@ -1,10 +1,16 @@
+import EmojiIconPicker, {
+  DEFAULT_EMOJI_ICON,
+  type EmojiIconValue,
+} from '@/components/EmojiIconPicker';
 import { YakButton } from '@/components/ui';
 import { Drawer, Form, Input } from 'antd';
 import { GitBranch } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 export interface WorkflowCreateValues {
   name: string;
   description?: string;
+  icon: EmojiIconValue;
 }
 
 interface WorkflowCreateDrawerProps {
@@ -20,19 +26,28 @@ const WorkflowCreateDrawer = ({
   onClose,
   onSubmit,
 }: WorkflowCreateDrawerProps) => {
-  const [form] = Form.useForm<WorkflowCreateValues>();
+  const [form] = Form.useForm<Omit<WorkflowCreateValues, 'icon'>>();
+  const [icon, setIcon] = useState<EmojiIconValue>(DEFAULT_EMOJI_ICON);
+
+  useEffect(() => {
+    if (!open) return;
+    form.resetFields();
+    setIcon(DEFAULT_EMOJI_ICON);
+  }, [form, open]);
 
   const handleClose = () => {
     if (creating) return;
     form.resetFields();
+    setIcon(DEFAULT_EMOJI_ICON);
     onClose();
   };
 
   const handleSubmit = async () => {
     try {
       const values = await form.validateFields();
-      await onSubmit(values);
+      await onSubmit({ ...values, icon });
       form.resetFields();
+      setIcon(DEFAULT_EMOJI_ICON);
     } catch {
       // Form owns validation feedback; request failures are surfaced by the page action.
     }
@@ -86,15 +101,29 @@ const WorkflowCreateDrawer = ({
       }}
     >
       <Form form={form} layout="vertical" requiredMark="optional">
-        <Form.Item
-          name="name"
-          label="工作流名称"
-          rules={[
-            { required: true, message: '请输入工作流名称' },
-            { max: 100, message: '名称不能超过 100 个字符' },
-          ]}
-        >
-          <Input variant="filled" placeholder="例如：每日订单同步工作流" />
+        <Form.Item label="工作流名称" required className="!mb-6">
+          <div className="flex items-start gap-2.5">
+            <EmojiIconPicker
+              value={icon}
+              disabled={creating}
+              onChange={setIcon}
+              className="mt-px"
+            />
+            <Form.Item
+              name="name"
+              noStyle
+              rules={[
+                { required: true, message: '请输入工作流名称' },
+                { max: 100, message: '名称不能超过 100 个字符' },
+              ]}
+            >
+              <Input
+                variant="filled"
+                placeholder="例如：每日订单同步工作流"
+                className="!h-[44px] !rounded-[10px]"
+              />
+            </Form.Item>
+          </div>
         </Form.Item>
 
         <Form.Item

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionCard.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionCard.tsx
@@ -1,10 +1,13 @@
+import {
+  EmojiIcon,
+  normalizeEmojiIconValue,
+} from '@/components/EmojiIconPicker';
 import { YakButton } from '@/components/ui';
 import type { WorkflowDefinition } from '@/services/workflow/definitions';
 import { motion } from 'framer-motion';
 import {
   CalendarClock,
   Clock3,
-  GitBranch,
   LoaderCircle,
   Pause,
   Pencil,
@@ -62,6 +65,7 @@ const WorkflowDefinitionCard = ({
   const definitionMeta = DEFINITION_STATUS_META[record.status];
   const runtimeMeta = runtimeStatusMeta(record.latestExecutionStatus);
   const activeRuntime = isActiveRuntime(record.latestExecutionStatus);
+  const definitionIcon = normalizeEmojiIconValue(record.editorMeta?.icon);
   const isListView = viewMode === 'list';
   const canDelete = record.status !== 'ONLINE' && !activeRuntime;
   const canRun =
@@ -173,9 +177,12 @@ const WorkflowDefinitionCard = ({
 
       <div className="relative z-[1] flex min-h-[108px] items-start gap-3 px-4 pb-4 pt-4">
         <div className="flex min-w-0 flex-1 items-start gap-3">
-          <div className="flex h-[46px] w-[46px] shrink-0 items-center justify-center rounded-[13px] border border-[rgba(31,35,41,0.07)] bg-[linear-gradient(145deg,#ffffff_0%,#f5f7fa_100%)] text-[#566071] shadow-[0_5px_14px_rgba(31,35,41,0.055)] transition-transform duration-[260ms] group-hover:scale-[1.025]">
-            <GitBranch size={24} strokeWidth={1.75} />
-          </div>
+          <EmojiIcon
+            value={definitionIcon}
+            size={46}
+            title={`${record.name || '工作流'}图标`}
+            className="border border-[rgba(31,35,41,0.07)] shadow-[0_5px_14px_rgba(31,35,41,0.055)] transition-transform duration-[260ms] group-hover:scale-[1.025]"
+          />
 
           <div className="min-w-0 flex-1 pt-0.5">
             <div className="flex min-w-0 flex-wrap items-center gap-1.5">

--- a/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionList.tsx
+++ b/yak-ops-ui/src/pages/workflow/management/components/WorkflowDefinitionList.tsx
@@ -7,6 +7,7 @@ import {
   pauseWorkflowDefinition,
   resumeWorkflowDefinition,
   runWorkflowDefinition,
+  updateWorkflowDefinition,
   type WorkflowDefinition,
 } from '@/services/workflow/definitions';
 import { history } from '@umijs/max';
@@ -154,10 +155,23 @@ const WorkflowDefinitionList = () => {
         name: values.name.trim(),
         description: values.description?.trim() || undefined,
       });
+      const configured = await updateWorkflowDefinition(created.id, {
+        name: created.name,
+        description: created.description,
+        nodes: created.nodes,
+        edges: created.edges,
+        input: created.input,
+        editorMeta: {
+          ...created.editorMeta,
+          icon: values.icon,
+        },
+        workflowTimeoutSeconds: created.workflowTimeoutSeconds,
+        failureStrategy: created.failureStrategy,
+      });
 
       message.success('工作流草稿已创建，请继续配置任务节点');
       setCreateOpen(false);
-      history.push(`/workflow/definition/${created.id}?scene=create`);
+      history.push(`/workflow/definition/${configured.id}?scene=create`);
     } catch (error) {
       message.error(
         error instanceof Error ? error.message : '创建工作流失败',


### PR DESCRIPTION
## Summary

- add a reusable `EmojiIconPicker` / `EmojiIcon` component with a Dify-inspired emoji + background-style selection experience
- add the icon selector before the workflow name in the create drawer
- persist the selected icon in the existing workflow `editorMeta` and render it on workflow definition cards
- preserve unknown top-level `editorMeta` values across workflow editor saves so UI metadata such as the icon is not accidentally dropped
- keep legacy workflows backward compatible with a default emoji icon

## Persistence decision

No database column is added in this change. Workflow already persists `editorMeta` as part of the editable draft, and the emoji/background are presentation-only metadata rather than execution semantics. Reusing that boundary keeps the runtime/version model clean and lets the common picker be reused later by offline-sync and realtime-sync creation flows with their own persistence models.

## Scope

This PR intentionally wires the reusable component into Workflow first. Offline sync / realtime sync can adopt the same common component in follow-up changes.

## Validation

- branch diff reviewed against `main`
- GitHub Actions / frontend typecheck pending after PR creation
