### PR TITLE
feat(offline-sync): add emoji icon picker to create drawer

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineEditorMetaCodec.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineEditorMetaCodec.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobEditorMetaDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobIconDTO;
+import java.util.Locale;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -77,7 +78,7 @@ public class OfflineEditorMetaCodec {
 
     OfflineJobIconDTO icon = new OfflineJobIconDTO();
     icon.setEmoji(emoji);
-    icon.setBackground(background.toUpperCase());
+    icon.setBackground(background.toUpperCase(Locale.ROOT));
     normalized.setIcon(icon);
     return normalized;
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineEditorMetaCodec.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineEditorMetaCodec.java
@@ -1,0 +1,88 @@
+package io.yak.ops.business.sync.offline.definition;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobEditorMetaDTO;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobIconDTO;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Encodes UI-only metadata without coupling it to the executable Offline Sync JobSpec. */
+@Component
+@ConditionalOnOfflineSyncEnabled
+public class OfflineEditorMetaCodec {
+
+  private static final int MAX_EMOJI_LENGTH = 32;
+  private static final String HEX_COLOR_PATTERN = "#[0-9a-fA-F]{6}";
+
+  private final ObjectMapper objectMapper;
+
+  public OfflineEditorMetaCodec(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public String encode(OfflineJobEditorMetaDTO value) {
+    if (value == null) return null;
+    try {
+      return objectMapper.writeValueAsString(normalize(value));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化离线同步编辑器元数据失败", exception);
+    }
+  }
+
+  public JsonNode applyToEditDetail(JsonNode detail, String json) {
+    if (detail == null || !detail.isObject()) {
+      throw new IllegalArgumentException("离线同步编辑详情必须是 JSON 对象");
+    }
+    ObjectNode result = ((ObjectNode) detail).deepCopy();
+    if (!StringUtils.hasText(json)) {
+      result.remove("editorMeta");
+      return result;
+    }
+    try {
+      OfflineJobEditorMetaDTO normalized =
+          normalize(objectMapper.readValue(json, OfflineJobEditorMetaDTO.class));
+      result.set("editorMeta", objectMapper.valueToTree(normalized));
+      return result;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("离线同步编辑器元数据 JSON 已损坏", exception);
+    }
+  }
+
+  OfflineJobEditorMetaDTO normalize(OfflineJobEditorMetaDTO value) {
+    if (value == null) {
+      throw new IllegalArgumentException("编辑器元数据不能为空");
+    }
+    OfflineJobEditorMetaDTO normalized = new OfflineJobEditorMetaDTO();
+    if (value.getIcon() == null) {
+      return normalized;
+    }
+
+    String emoji = trim(value.getIcon().getEmoji());
+    String background = trim(value.getIcon().getBackground());
+    if (!StringUtils.hasText(emoji) || !StringUtils.hasText(background)) {
+      throw new IllegalArgumentException("任务图标必须同时包含 emoji 和 background");
+    }
+    if (emoji.length() > MAX_EMOJI_LENGTH) {
+      throw new IllegalArgumentException("任务图标 emoji 长度不能超过 32 个字符");
+    }
+    if (!background.matches(HEX_COLOR_PATTERN)) {
+      throw new IllegalArgumentException("任务图标 background 必须是 #RRGGBB 颜色");
+    }
+
+    OfflineJobIconDTO icon = new OfflineJobIconDTO();
+    icon.setEmoji(emoji);
+    icon.setBackground(background.toUpperCase());
+    normalized.setIcon(icon);
+    return normalized;
+  }
+
+  private String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionService.java
@@ -36,6 +36,7 @@ public class OfflineJobDefinitionService {
   private final OfflineScheduleRepository scheduleRepository;
   private final OfflineDefinitionSupport support;
   private final OfflineNotificationPolicyCodec notificationPolicyCodec;
+  private final OfflineEditorMetaCodec editorMetaCodec;
   private final OfflineScheduleSupport scheduleSupport;
   private final OfflineScheduleLifecycle scheduleLifecycle;
   private final OfflineSyncViewMapper viewMapper;
@@ -59,11 +60,13 @@ public class OfflineJobDefinitionService {
 
     DraftDefinition draft = support.prepareDraft(dto);
     String notificationConfigJson = resolveNotificationConfig(dto, existing);
+    String editorMetaJson = resolveEditorMeta(dto, existing);
     ensureUniqueName(draft.getJobName(), id);
 
     OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
     applyDraft(definition, existing, id, draft);
     definition.setNotificationConfigJson(notificationConfigJson);
+    definition.setEditorMetaJson(editorMetaJson);
     persist(existing, definition);
     saveScheduleAndSync(id, draft.getRequest().get("schedule"));
     return id;
@@ -77,11 +80,13 @@ public class OfflineJobDefinitionService {
 
     PreparedDefinition prepared = support.prepare(dto);
     String notificationConfigJson = resolveNotificationConfig(dto, existing);
+    String editorMetaJson = resolveEditorMeta(dto, existing);
     ensureUniqueName(prepared.getJobName(), id);
 
     OfflineJobDefinition definition = existing == null ? new OfflineJobDefinition() : existing;
     applyPrepared(definition, existing, id, prepared);
     definition.setNotificationConfigJson(notificationConfigJson);
+    definition.setEditorMetaJson(editorMetaJson);
     persist(existing, definition);
     saveScheduleAndSync(id, prepared.getRequest().get("schedule"));
     return id;
@@ -119,8 +124,9 @@ public class OfflineJobDefinitionService {
 
   public JsonNode getEditDetail(Long id) {
     OfflineJobDefinition definition = require(id);
-    return notificationPolicyCodec.applyToEditDetail(
+    JsonNode detail = notificationPolicyCodec.applyToEditDetail(
         support.editDetail(definition), definition.getNotificationConfigJson());
+    return editorMetaCodec.applyToEditDetail(detail, definition.getEditorMetaJson());
   }
 
   public PageData<OfflineJobDefinition> pageDomain(OfflineDefinitionQuery query) {
@@ -213,6 +219,17 @@ public class OfflineJobDefinitionService {
       return existing.getNotificationConfigJson();
     }
     return notificationPolicyCodec.encode(dto.getNotification());
+  }
+
+  private String resolveEditorMeta(
+      OfflineJobDefinitionDTO dto,
+      OfflineJobDefinition existing) {
+    if (dto.getEditorMeta() == null && existing != null) {
+      // Editor metadata is optional for older clients. Keep the selected icon when they save other
+      // task settings so UI-only preferences never get erased accidentally.
+      return existing.getEditorMetaJson();
+    }
+    return editorMetaCodec.encode(dto.getEditorMeta());
   }
 
   private void ensureCanSaveDraft(OfflineJobDefinition existing) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobDefinition.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineJobDefinition.java
@@ -35,6 +35,7 @@ public class OfflineJobDefinition {
   private Integer retryMaxAttempts;
   private Integer retryBackoffSeconds;
   private String notificationConfigJson;
+  private String editorMetaJson;
   private LocalDateTime scheduleLastFireTime;
   private LocalDateTime scheduleNextFireTime;
   private Integer version;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -77,9 +77,10 @@ public final class OfflineDefinitionModelAdapter {
       return definition;
     }
     ObjectNode adapted = (ObjectNode) definition.deepCopy();
-    // Notification is a Yak Ops control-plane concern. It must never alter engine JobSpec,
-    // execution snapshots or config digests when only delivery preferences change.
+    // Notification and editor metadata are Yak Ops control-plane concerns. They must never alter
+    // engine JobSpec, execution snapshots or config digests when only UI preferences change.
     adapted.remove("notification");
+    adapted.remove("editorMeta");
     String mode = text(adapted.path("basic"), "mode", "GUIDE_SINGLE");
     adaptEndpoint(adapted, "source", mode, objectMapper);
     adaptEndpoint(adapted, "sink", mode, objectMapper);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__add_offline_editor_meta.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V3__add_offline_editor_meta.sql
@@ -1,0 +1,2 @@
+ALTER TABLE yak_offline_job_definition
+    ADD COLUMN editor_meta_json TEXT NULL COMMENT 'UI-only editor metadata such as the task emoji icon';

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineEditorMetaCodecTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineEditorMetaCodecTest.java
@@ -1,0 +1,57 @@
+package io.yak.ops.business.sync.offline.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobEditorMetaDTO;
+import io.yak.ops.common.bean.dto.sync.offline.OfflineJobIconDTO;
+import org.junit.jupiter.api.Test;
+
+class OfflineEditorMetaCodecTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final OfflineEditorMetaCodec codec = new OfflineEditorMetaCodec(objectMapper);
+
+  @Test
+  void dedicatedEditorMetaOverridesStaleEmbeddedValue() throws Exception {
+    OfflineJobIconDTO icon = new OfflineJobIconDTO();
+    icon.setEmoji("🚀");
+    icon.setBackground("#dceeff");
+    OfflineJobEditorMetaDTO meta = new OfflineJobEditorMetaDTO();
+    meta.setIcon(icon);
+
+    JsonNode detail = objectMapper.readTree(
+        "{\"id\":10,\"editorMeta\":{\"icon\":{\"emoji\":\"🤖\",\"background\":\"#FFFFFF\"}}}");
+    JsonNode result = codec.applyToEditDetail(detail, codec.encode(meta));
+
+    assertThat(result.path("editorMeta").path("icon").path("emoji").asText())
+        .isEqualTo("🚀");
+    assertThat(result.path("editorMeta").path("icon").path("background").asText())
+        .isEqualTo("#DCEEFF");
+  }
+
+  @Test
+  void legacyNullColumnRemovesPotentialEmbeddedEditorMeta() throws Exception {
+    JsonNode detail = objectMapper.readTree(
+        "{\"id\":10,\"editorMeta\":{\"icon\":{\"emoji\":\"🤖\",\"background\":\"#FFE7D6\"}}}");
+
+    JsonNode result = codec.applyToEditDetail(detail, null);
+
+    assertThat(result.has("editorMeta")).isFalse();
+  }
+
+  @Test
+  void invalidIconBackgroundIsRejected() {
+    OfflineJobIconDTO icon = new OfflineJobIconDTO();
+    icon.setEmoji("🤖");
+    icon.setBackground("red");
+    OfflineJobEditorMetaDTO meta = new OfflineJobEditorMetaDTO();
+    meta.setIcon(icon);
+
+    assertThatThrownBy(() -> codec.encode(meta))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("#RRGGBB");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceNotificationCompatibilityTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceNotificationCompatibilityTest.java
@@ -22,12 +22,13 @@ import org.junit.jupiter.api.Test;
 class OfflineJobDefinitionServiceNotificationCompatibilityTest {
 
   @Test
-  void olderClientOmittingNotificationPreservesConfiguredPolicy() {
+  void olderClientOmittingControlPlaneMetadataPreservesConfiguredValues() {
     OfflineJobDefinitionRepository definitions = mock(OfflineJobDefinitionRepository.class);
     OfflineBatchExecutionRepository batches = mock(OfflineBatchExecutionRepository.class);
     OfflineScheduleRepository schedules = mock(OfflineScheduleRepository.class);
     OfflineDefinitionSupport support = mock(OfflineDefinitionSupport.class);
     OfflineNotificationPolicyCodec codec = mock(OfflineNotificationPolicyCodec.class);
+    OfflineEditorMetaCodec editorMetaCodec = mock(OfflineEditorMetaCodec.class);
     OfflineScheduleSupport scheduleSupport = mock(OfflineScheduleSupport.class);
     OfflineScheduleLifecycle lifecycle = mock(OfflineScheduleLifecycle.class);
     OfflineSyncViewMapper viewMapper = mock(OfflineSyncViewMapper.class);
@@ -36,6 +37,8 @@ class OfflineJobDefinitionServiceNotificationCompatibilityTest {
     existing.setId(10L);
     existing.setReleaseState("OFFLINE");
     existing.setNotificationConfigJson("{\"enabled\":false}");
+    existing.setEditorMetaJson(
+        "{\"icon\":{\"emoji\":\"🚀\",\"background\":\"#DCEEFF\"}}");
     when(definitions.findById(10L)).thenReturn(Optional.of(existing));
     when(definitions.existsByName("订单同步", 10L)).thenReturn(false);
 
@@ -57,15 +60,18 @@ class OfflineJobDefinitionServiceNotificationCompatibilityTest {
         schedules,
         support,
         codec,
+        editorMetaCodec,
         scheduleSupport,
         lifecycle,
         viewMapper);
 
     OfflineJobDefinitionDTO dto = new OfflineJobDefinitionDTO();
     dto.setId(10L);
-    // Deliberately leave dto.notification null to simulate an older client.
+    // Deliberately leave dto.notification and dto.editorMeta null to simulate an older client.
     service.saveDraft(dto);
 
     assertThat(existing.getNotificationConfigJson()).isEqualTo("{\"enabled\":false}");
+    assertThat(existing.getEditorMetaJson())
+        .isEqualTo("{\"icon\":{\"emoji\":\"🚀\",\"background\":\"#DCEEFF\"}}");
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceRuntimeTruthTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/definition/OfflineJobDefinitionServiceRuntimeTruthTest.java
@@ -73,6 +73,7 @@ class OfflineJobDefinitionServiceRuntimeTruthTest {
         schedules,
         mock(OfflineDefinitionSupport.class),
         mock(OfflineNotificationPolicyCodec.class),
+        mock(OfflineEditorMetaCodec.class),
         mock(OfflineScheduleSupport.class),
         lifecycle,
         mock(OfflineSyncViewMapper.class));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineEditorMetaJobSpecIsolationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineEditorMetaJobSpecIsolationTest.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class OfflineEditorMetaJobSpecIsolationTest {
+
+  @Test
+  void editorMetaNeverEntersEngineJobSpecModel() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode definition = objectMapper.readTree("""
+        {
+          "basic": {"mode": "GUIDE_SINGLE"},
+          "source": {"dbType": "MYSQL", "config": {}},
+          "sink": {"dbType": "MYSQL", "config": {}},
+          "channel": {"parallelism": 1},
+          "editorMeta": {
+            "icon": {"emoji": "🚀", "background": "#DCEEFF"}
+          }
+        }
+        """);
+
+    JsonNode jobSpecInput =
+        OfflineDefinitionModelAdapter.forJobSpec(definition, objectMapper);
+
+    assertThat(jobSpecInput.has("editorMeta")).isFalse();
+    assertThat(definition.has("editorMeta")).isTrue();
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
@@ -31,4 +31,7 @@ public class OfflineJobDefinitionDTO {
 
   /** 任务级通知策略；缺省/null 保留历史 Project OWNER + IN_APP 默认行为。 */
   private OfflineJobNotificationDTO notification;
+
+  /** UI-only metadata such as the selected EmojiIconPicker icon. */
+  private OfflineJobEditorMetaDTO editorMeta;
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobEditorMetaDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobEditorMetaDTO.java
@@ -1,0 +1,14 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+/** UI-only metadata for an Offline Sync task definition. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class OfflineJobEditorMetaDTO {
+
+  private OfflineJobIconDTO icon;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobIconDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobIconDTO.java
@@ -1,0 +1,15 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+/** Emoji icon selected for an Offline Sync task in the editor. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class OfflineJobIconDTO {
+
+  private String emoji;
+  private String background;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineJobDefinitionPO.java
@@ -35,6 +35,7 @@ public class OfflineJobDefinitionPO {
   private Integer retryMaxAttempts;
   private Integer retryBackoffSeconds;
   @ToString.Exclude @TableField(updateStrategy = FieldStrategy.ALWAYS) private String notificationConfigJson;
+  @ToString.Exclude @TableField(updateStrategy = FieldStrategy.ALWAYS) private String editorMetaJson;
   @TableField(updateStrategy = FieldStrategy.ALWAYS) private LocalDateTime scheduleLastFireTime;
   @TableField(updateStrategy = FieldStrategy.ALWAYS) private LocalDateTime scheduleNextFireTime;
   private Integer version;

--- a/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/components/CreateSyncTaskDrawer.tsx
@@ -1,3 +1,7 @@
+import EmojiIconPicker, {
+  DEFAULT_EMOJI_ICON,
+  type EmojiIconValue,
+} from '@/components/EmojiIconPicker';
 import { YakButton } from '@/components/ui';
 import {
   createOfflineSyncDraft,
@@ -113,6 +117,7 @@ export default function CreateSyncTaskDrawer({
 }: CreateSyncTaskDrawerProps) {
   const [form] = Form.useForm<CreateSyncTaskFormValues>();
   const [submitting, setSubmitting] = useState(false);
+  const [icon, setIcon] = useState<EmojiIconValue>(DEFAULT_EMOJI_ICON);
   const autoJobNameRef = useRef('');
 
   const connectorOptions = useMemo(
@@ -133,6 +138,7 @@ export default function CreateSyncTaskDrawer({
     const defaultJobName = buildDefaultJobName(defaultDbType, defaultDbType);
 
     autoJobNameRef.current = defaultJobName;
+    setIcon(DEFAULT_EMOJI_ICON);
     form.setFieldsValue({
       sourceDbType: defaultDbType,
       targetDbType: defaultDbType,
@@ -163,6 +169,7 @@ export default function CreateSyncTaskDrawer({
     if (submitting) return;
 
     form.resetFields();
+    setIcon(DEFAULT_EMOJI_ICON);
     autoJobNameRef.current = '';
     onCancel();
   };
@@ -180,12 +187,15 @@ export default function CreateSyncTaskDrawer({
 
       setSubmitting(true);
       const taskId = String(await getOfflineSyncUniqueId());
-      const payload = buildCreatePayload(
-        taskId,
-        normalizedValues,
-        source,
-        sink,
-      );
+      const payload = {
+        ...buildCreatePayload(
+          taskId,
+          normalizedValues,
+          source,
+          sink,
+        ),
+        editorMeta: { icon },
+      };
       const savedId = await createOfflineSyncDraft(payload);
       const createdId = String(savedId ?? taskId);
       const path =
@@ -194,6 +204,7 @@ export default function CreateSyncTaskDrawer({
           : `/sync/batch-link-up/${createdId}/config/single?scene=edit`;
 
       form.resetFields();
+      setIcon(DEFAULT_EMOJI_ICON);
       autoJobNameRef.current = '';
       message.success('任务草稿已创建，请继续配置数据源和同步表');
       onCreated(createdId, normalizedValues.mode);
@@ -314,21 +325,32 @@ export default function CreateSyncTaskDrawer({
             </div>
           </div>
 
-          <Form.Item
-            name="jobName"
-            label="任务名称"
-            rules={[
-              { required: true, message: '请输入任务名称' },
-              { max: 64, message: '任务名称不能超过 64 个字符' },
-            ]}
-          >
-            <Input
-              autoFocus
-              maxLength={64}
-              showCount
-              variant="filled"
-              placeholder="例如：订单数据每日同步"
-            />
+          <Form.Item label="任务名称" required className="!mb-6">
+            <div className="flex items-start gap-2.5">
+              <EmojiIconPicker
+                value={icon}
+                disabled={submitting}
+                onChange={setIcon}
+                className="mt-px"
+              />
+              <Form.Item
+                name="jobName"
+                noStyle
+                rules={[
+                  { required: true, message: '请输入任务名称' },
+                  { max: 64, message: '任务名称不能超过 64 个字符' },
+                ]}
+              >
+                <Input
+                  autoFocus
+                  maxLength={64}
+                  showCount
+                  variant="filled"
+                  placeholder="例如：订单数据每日同步"
+                  className="!h-[44px] !rounded-[10px]"
+                />
+              </Form.Item>
+            </div>
           </Form.Item>
 
           <Form.Item
@@ -350,7 +372,7 @@ export default function CreateSyncTaskDrawer({
             label="同步类型"
             rules={[{ required: true, message: '请选择同步类型' }]}
           >
-            <Radio.Group className="grid w-full grid-cols-2 gap-3">
+            <Radio.Group className="grid w-full grid-cols-2 gap-2.5">
               {modeOptions.map((option) => (
                 <Radio.Button
                   key={option.value}
@@ -360,20 +382,22 @@ export default function CreateSyncTaskDrawer({
                     '!rounded-lg',
                     '!border',
                     '!border-[#e4e7ec]',
-                    '!px-4',
-                    '!py-4',
+                    '!bg-white',
+                    '!px-3',
+                    '!py-3',
                     '!shadow-none',
                     'hover:!border-[var(--yak-brand-color-border)]',
-                    'hover:!bg-[var(--yak-brand-color-soft-hover)]',
+                    'hover:!bg-[#fbfcfe]',
                     '[&.ant-radio-button-wrapper-checked]:!border-[var(--yak-brand-color)]',
-                    '[&.ant-radio-button-wrapper-checked]:!bg-[var(--yak-brand-color-soft)]',
+                    '[&.ant-radio-button-wrapper-checked]:!bg-white',
                     '[&.ant-radio-button-wrapper-checked]:!text-inherit',
+                    '[&.ant-radio-button-wrapper-checked]:!shadow-[0_0_0_2px_rgba(201,40,72,0.08)]',
                     'before:!hidden',
                   ].join(' ')}
                 >
-                  <div className="flex items-start gap-3 whitespace-normal">
+                  <div className="flex items-start gap-2.5 whitespace-normal">
                     <div
-                      className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[17px]"
+                      className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[15px]"
                       style={{
                         color: BRAND_COLOR,
                         backgroundColor: BRAND_COLOR_SOFT_HOVER,
@@ -383,11 +407,11 @@ export default function CreateSyncTaskDrawer({
                     </div>
 
                     <div className="min-w-0 text-left">
-                      <div className="font-medium text-[#182230]">
+                      <div className="text-[13px] font-medium leading-5 text-[#182230]">
                         {option.title}
                       </div>
 
-                      <div className="mt-1 text-xs leading-5 text-[#667085]">
+                      <div className="mt-0.5 text-[11px] leading-[18px] text-[#667085]">
                         {option.description}
                       </div>
                     </div>


### PR DESCRIPTION
## 变更内容

- 在“新建离线同步任务”的任务名称旁复用 `EmojiIconPicker`，交互与工作流创建页保持一致。
- 调整“同步类型”卡片：缩小尺寸、降低选中态大面积品牌色填充，改为白底 + 品牌边框 + 轻量 focus ring，降低视觉饱和度。
- 新增 Offline Sync 的 `editorMeta.icon` 协议，后端使用独立 `editor_meta_json` 字段保存 UI-only 元数据，结构与 Workflow 的 `editorMeta.icon` 对齐。
- 旧客户端保存其他任务配置时，如果未携带 `editorMeta`，保留已有图标，避免被覆盖为空。
- `editorMeta` 在生成引擎 JobSpec 前剥离，不影响执行配置、版本摘要或运行时行为。

## 后端

- 新增 `OfflineJobEditorMetaDTO` / `OfflineJobIconDTO`。
- 新增 `OfflineEditorMetaCodec`，负责图标元数据校验、序列化与 edit-detail 投影。
- 新增 Flyway `V3__add_offline_editor_meta.sql`。
- Domain / PO 增加 `editorMetaJson`。

## 测试覆盖

- `OfflineEditorMetaCodecTest`：独立列覆盖旧嵌入值、legacy NULL 清理、非法背景色校验。
- `OfflineEditorMetaJobSpecIsolationTest`：确保 `editorMeta` 不进入引擎 JobSpec。
- `OfflineJobDefinitionServiceNotificationCompatibilityTest`：补充旧客户端不携带 `editorMeta` 时保留已有图标配置的兼容性断言。
- 同步调整 `OfflineJobDefinitionServiceRuntimeTruthTest` 的 Service 构造依赖。

## 设计说明

图标属于编辑器展示元数据，不应该成为 Offline Sync 的执行配置。使用独立 `editor_meta_json` 后，既可以保持 API 侧 `editorMeta.icon` 的统一结构，也能避免后续新增 UI 元数据时继续扩表。