### PR TITLE
feat(ui): add visual CronSchedulerEditor

### DIFF
--- a/yak-ops-ui/src/components/CronSchedulerEditor/cron.test.ts
+++ b/yak-ops-ui/src/components/CronSchedulerEditor/cron.test.ts
@@ -1,0 +1,66 @@
+import { createDefaultCronScheduleConfig, generateCron, parseCron } from './cron';
+
+describe('CronSchedulerEditor cron codec', () => {
+  it('generates minute schedules', () => {
+    expect(
+      generateCron({
+        ...createDefaultCronScheduleConfig(),
+        period: 'minute',
+        minuteStartTime: '00:00',
+        minuteInterval: 5,
+        minuteEndTime: '23:59',
+      }).cron,
+    ).toBe('00 */5 00-23 * * ?');
+  });
+
+  it('generates weekly schedules', () => {
+    expect(
+      generateCron({
+        ...createDefaultCronScheduleConfig(),
+        period: 'week',
+        weekdays: [2, 4, 6],
+        weekTime: '09:30',
+      }).cron,
+    ).toBe('00 30 09 ? * 2,4,6');
+  });
+
+  it('generates month rules with last weekday', () => {
+    expect(
+      generateCron({
+        ...createDefaultCronScheduleConfig(),
+        period: 'month',
+        monthRules: [{ kind: 'lastWeekday', weekday: 3 }],
+        monthTime: '00:19',
+      }).cron,
+    ).toBe('00 19 00 ? * 3L');
+  });
+
+  it('generates yearly schedules', () => {
+    expect(
+      generateCron({
+        ...createDefaultCronScheduleConfig(),
+        period: 'year',
+        months: [1, 7],
+        yearRules: [{ kind: 'day', day: 1 }],
+        yearTime: '08:15',
+      }).cron,
+    ).toBe('00 15 08 1 1,7 ?');
+  });
+
+  it('parses existing Yak Ops presets', () => {
+    const daily = parseCron('0 0 2 * * ?');
+    const hourly = parseCron('0 0 * * * ?');
+    const tenMinutes = parseCron('0 0/10 * * * ?');
+
+    expect(daily?.period).toBe('day');
+    expect(daily?.dayTime).toBe('02:00');
+    expect(hourly?.period).toBe('hour');
+    expect(tenMinutes?.period).toBe('minute');
+    expect(tenMinutes?.minuteInterval).toBe(10);
+  });
+
+  it('keeps unsupported expressions out of visual parsing', () => {
+    expect(parseCron('0 0 2 LW * ?')).toBeUndefined();
+    expect(parseCron('0 0 2 * * ? 2028')).toBeUndefined();
+  });
+});

--- a/yak-ops-ui/src/components/CronSchedulerEditor/cron.ts
+++ b/yak-ops-ui/src/components/CronSchedulerEditor/cron.ts
@@ -1,0 +1,362 @@
+import type {
+  CronGenerationResult,
+  CronScheduleConfig,
+  MonthRule,
+  QuartzWeekday,
+} from './types';
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, Number.isFinite(value) ? value : min));
+
+const pad2 = (value: number) => String(value).padStart(2, '0');
+
+function parseTime(value: string) {
+  const [rawHour = '0', rawMinute = '0'] = value.split(':');
+  return {
+    hour: clamp(Number(rawHour), 0, 23),
+    minute: clamp(Number(rawMinute), 0, 59),
+  };
+}
+
+function uniqueSorted(values: number[]) {
+  return [...new Set(values)].sort((left, right) => left - right);
+}
+
+function createResult(
+  second: string,
+  minute: string,
+  hour: string,
+  dayOfMonth: string,
+  month: string,
+  dayOfWeek: string,
+): CronGenerationResult {
+  const fields = { second, minute, hour, dayOfMonth, month, dayOfWeek };
+  return {
+    fields,
+    cron: [second, minute, hour, dayOfMonth, month, dayOfWeek].join(' '),
+  };
+}
+
+function splitMonthRules(rules: MonthRule[]) {
+  const dayOfMonth: string[] = [];
+  const dayOfWeek: string[] = [];
+
+  rules.forEach((rule) => {
+    switch (rule.kind) {
+      case 'day':
+        dayOfMonth.push(String(clamp(rule.day, 1, 31)));
+        break;
+      case 'lastDay':
+        dayOfMonth.push('L');
+        break;
+      case 'nthWeekday':
+        dayOfWeek.push(`${rule.weekday}#${rule.nth}`);
+        break;
+      case 'lastWeekday':
+        dayOfWeek.push(`${rule.weekday}L`);
+        break;
+      default:
+        break;
+    }
+  });
+
+  return {
+    dayOfMonth: [...new Set(dayOfMonth)],
+    dayOfWeek: [...new Set(dayOfWeek)],
+  };
+}
+
+export function createDefaultCronScheduleConfig(): CronScheduleConfig {
+  return {
+    period: 'day',
+    minuteStartTime: '00:00',
+    minuteInterval: 5,
+    minuteEndTime: '23:59',
+    hourMode: 'range',
+    hourStartTime: '00:00',
+    hourInterval: 1,
+    hourEndTime: '23:59',
+    specifiedHours: [0],
+    specifiedHourMinute: 0,
+    dayTime: '02:00',
+    weekdays: [2],
+    weekTime: '02:00',
+    monthRules: [{ kind: 'day', day: 1 }],
+    monthTime: '02:00',
+    months: [1],
+    yearRules: [{ kind: 'day', day: 1 }],
+    yearTime: '02:00',
+  };
+}
+
+/** Generate six-field Cron: second minute hour day-of-month month day-of-week. */
+export function generateCron(config: CronScheduleConfig): CronGenerationResult {
+  switch (config.period) {
+    case 'minute': {
+      const start = parseTime(config.minuteStartTime);
+      const end = parseTime(config.minuteEndTime);
+      const interval = clamp(Math.round(config.minuteInterval), 1, 59);
+      const minute = start.minute === 0 ? `*/${interval}` : `${start.minute}/${interval}`;
+      const from = Math.min(start.hour, end.hour);
+      const to = Math.max(start.hour, end.hour);
+      const hour = from === to ? pad2(from) : `${pad2(from)}-${pad2(to)}`;
+      return createResult('00', minute, hour, '*', '*', '?');
+    }
+
+    case 'hour': {
+      if (config.hourMode === 'specified') {
+        const hours = uniqueSorted(config.specifiedHours.map((item) => clamp(item, 0, 23)));
+        return createResult(
+          '00',
+          pad2(clamp(config.specifiedHourMinute, 0, 59)),
+          hours.length ? hours.map(pad2).join(',') : '00',
+          '*',
+          '*',
+          '?',
+        );
+      }
+
+      const start = parseTime(config.hourStartTime);
+      const end = parseTime(config.hourEndTime);
+      const interval = clamp(Math.round(config.hourInterval), 1, 23);
+      const from = Math.min(start.hour, end.hour);
+      const to = Math.max(start.hour, end.hour);
+      const hour = from === to ? pad2(from) : `${pad2(from)}-${pad2(to)}/${interval}`;
+      return createResult('00', pad2(start.minute), hour, '*', '*', '?');
+    }
+
+    case 'day': {
+      const time = parseTime(config.dayTime);
+      return createResult('00', pad2(time.minute), pad2(time.hour), '*', '*', '?');
+    }
+
+    case 'week': {
+      const time = parseTime(config.weekTime);
+      const weekdays = uniqueSorted(config.weekdays).join(',') || '2';
+      return createResult('00', pad2(time.minute), pad2(time.hour), '?', '*', weekdays);
+    }
+
+    case 'month': {
+      const time = parseTime(config.monthTime);
+      const parsed = splitMonthRules(config.monthRules);
+      return createResult(
+        '00',
+        pad2(time.minute),
+        pad2(time.hour),
+        parsed.dayOfMonth.join(',') || '?',
+        '*',
+        parsed.dayOfWeek.join(',') || '?',
+      );
+    }
+
+    case 'year': {
+      const time = parseTime(config.yearTime);
+      const parsed = splitMonthRules(config.yearRules);
+      const month = uniqueSorted(config.months.map((item) => clamp(item, 1, 12))).join(',') || '1';
+      return createResult(
+        '00',
+        pad2(time.minute),
+        pad2(time.hour),
+        parsed.dayOfMonth.join(',') || '?',
+        month,
+        parsed.dayOfWeek.join(',') || '?',
+      );
+    }
+  }
+}
+
+function parseNumber(value: string, min: number, max: number): number | undefined {
+  if (!/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return parsed >= min && parsed <= max ? parsed : undefined;
+}
+
+function parseNumberList(value: string, min: number, max: number): number[] | undefined {
+  const parts = value.split(',');
+  const parsed = parts.map((item) => parseNumber(item, min, max));
+  if (parsed.some((item) => item === undefined)) return undefined;
+  return uniqueSorted(parsed as number[]);
+}
+
+function parseRuleFields(dayOfMonth: string, dayOfWeek: string): MonthRule[] | undefined {
+  const rules: MonthRule[] = [];
+
+  if (dayOfMonth !== '?') {
+    for (const token of dayOfMonth.split(',')) {
+      if (token === 'L') {
+        rules.push({ kind: 'lastDay' });
+        continue;
+      }
+      const day = parseNumber(token, 1, 31);
+      if (!day) return undefined;
+      rules.push({ kind: 'day', day });
+    }
+  }
+
+  if (dayOfWeek !== '?') {
+    for (const token of dayOfWeek.split(',')) {
+      const nthMatch = token.match(/^([1-7])#([1-4])$/);
+      if (nthMatch) {
+        rules.push({
+          kind: 'nthWeekday',
+          weekday: Number(nthMatch[1]) as QuartzWeekday,
+          nth: Number(nthMatch[2]) as 1 | 2 | 3 | 4,
+        });
+        continue;
+      }
+      const lastMatch = token.match(/^([1-7])L$/);
+      if (lastMatch) {
+        rules.push({ kind: 'lastWeekday', weekday: Number(lastMatch[1]) as QuartzWeekday });
+        continue;
+      }
+      return undefined;
+    }
+  }
+
+  return rules.length ? rules : undefined;
+}
+
+/**
+ * Parses the subset emitted by this editor plus the existing Yak Ops presets.
+ * Unsupported advanced expressions deliberately return undefined so callers can
+ * preserve them in manual mode instead of rewriting them incorrectly.
+ */
+export function parseCron(cron?: string): CronScheduleConfig | undefined {
+  const normalized = cron?.trim().replace(/\s+/g, ' ');
+  if (!normalized) return createDefaultCronScheduleConfig();
+
+  const fields = normalized.split(' ');
+  if (fields.length !== 6) return undefined;
+  const [second, minute, hour, dayOfMonth, month, dayOfWeek] = fields;
+  if (!['0', '00'].includes(second)) return undefined;
+
+  const base = createDefaultCronScheduleConfig();
+
+  if (dayOfMonth === '*' && month === '*' && dayOfWeek === '?') {
+    const minuteIntervalMatch = minute.match(/^(\*|\d{1,2})\/(\d{1,2})$/);
+    const plainHourRange = hour.match(/^(\d{1,2})-(\d{1,2})$/);
+    if (minuteIntervalMatch && (plainHourRange || /^\d{1,2}$/.test(hour) || hour === '*')) {
+      const interval = parseNumber(minuteIntervalMatch[2], 1, 59);
+      const startMinute = minuteIntervalMatch[1] === '*'
+        ? 0
+        : parseNumber(minuteIntervalMatch[1], 0, 59);
+      const fromHour = hour === '*'
+        ? 0
+        : plainHourRange
+          ? parseNumber(plainHourRange[1], 0, 23)
+          : parseNumber(hour, 0, 23);
+      const toHour = hour === '*'
+        ? 23
+        : plainHourRange
+          ? parseNumber(plainHourRange[2], 0, 23)
+          : parseNumber(hour, 0, 23);
+      if (interval && startMinute !== undefined && fromHour !== undefined && toHour !== undefined) {
+        return {
+          ...base,
+          period: 'minute',
+          minuteInterval: interval,
+          minuteStartTime: `${pad2(fromHour)}:${pad2(startMinute)}`,
+          minuteEndTime: `${pad2(toHour)}:59`,
+        };
+      }
+    }
+
+    if (hour === '*') {
+      const parsedMinute = parseNumber(minute, 0, 59);
+      if (parsedMinute !== undefined) {
+        return {
+          ...base,
+          period: 'hour',
+          hourMode: 'range',
+          hourStartTime: `00:${pad2(parsedMinute)}`,
+          hourEndTime: `23:${pad2(parsedMinute)}`,
+          hourInterval: 1,
+        };
+      }
+    }
+
+    const hourRangeMatch = hour.match(/^(\d{1,2})-(\d{1,2})\/(\d{1,2})$/);
+    if (hourRangeMatch) {
+      const parsedMinute = parseNumber(minute, 0, 59);
+      const fromHour = parseNumber(hourRangeMatch[1], 0, 23);
+      const toHour = parseNumber(hourRangeMatch[2], 0, 23);
+      const interval = parseNumber(hourRangeMatch[3], 1, 23);
+      if (parsedMinute !== undefined && fromHour !== undefined && toHour !== undefined && interval) {
+        return {
+          ...base,
+          period: 'hour',
+          hourMode: 'range',
+          hourStartTime: `${pad2(fromHour)}:${pad2(parsedMinute)}`,
+          hourEndTime: `${pad2(toHour)}:${pad2(parsedMinute)}`,
+          hourInterval: interval,
+        };
+      }
+    }
+
+    if (hour.includes(',')) {
+      const parsedMinute = parseNumber(minute, 0, 59);
+      const hours = parseNumberList(hour, 0, 23);
+      if (parsedMinute !== undefined && hours?.length) {
+        return {
+          ...base,
+          period: 'hour',
+          hourMode: 'specified',
+          specifiedHours: hours,
+          specifiedHourMinute: parsedMinute,
+        };
+      }
+    }
+
+    const parsedMinute = parseNumber(minute, 0, 59);
+    const parsedHour = parseNumber(hour, 0, 23);
+    if (parsedMinute !== undefined && parsedHour !== undefined) {
+      return {
+        ...base,
+        period: 'day',
+        dayTime: `${pad2(parsedHour)}:${pad2(parsedMinute)}`,
+      };
+    }
+    return undefined;
+  }
+
+  if (dayOfMonth === '?' && month === '*' && dayOfWeek !== '?') {
+    const parsedMinute = parseNumber(minute, 0, 59);
+    const parsedHour = parseNumber(hour, 0, 23);
+    const weekdays = parseNumberList(dayOfWeek, 1, 7) as QuartzWeekday[] | undefined;
+    if (parsedMinute !== undefined && parsedHour !== undefined && weekdays?.length) {
+      return {
+        ...base,
+        period: 'week',
+        weekdays,
+        weekTime: `${pad2(parsedHour)}:${pad2(parsedMinute)}`,
+      };
+    }
+    // Expressions such as `3L` and `3#2` are monthly rules, not weekly lists.
+  }
+
+  const parsedMinute = parseNumber(minute, 0, 59);
+  const parsedHour = parseNumber(hour, 0, 23);
+  if (parsedMinute === undefined || parsedHour === undefined) return undefined;
+
+  const rules = parseRuleFields(dayOfMonth, dayOfWeek);
+  if (!rules) return undefined;
+
+  if (month === '*') {
+    return {
+      ...base,
+      period: 'month',
+      monthRules: rules,
+      monthTime: `${pad2(parsedHour)}:${pad2(parsedMinute)}`,
+    };
+  }
+
+  const months = parseNumberList(month, 1, 12);
+  if (!months?.length) return undefined;
+  return {
+    ...base,
+    period: 'year',
+    months,
+    yearRules: rules,
+    yearTime: `${pad2(parsedHour)}:${pad2(parsedMinute)}`,
+  };
+}

--- a/yak-ops-ui/src/components/CronSchedulerEditor/index.tsx
+++ b/yak-ops-ui/src/components/CronSchedulerEditor/index.tsx
@@ -1,0 +1,582 @@
+import {
+  DatePicker,
+  Input,
+  InputNumber,
+  Radio,
+  Select,
+  TimePicker,
+  Tooltip,
+  message,
+} from 'antd';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+import { CircleHelp, Copy, Info } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { createDefaultCronScheduleConfig, generateCron, parseCron } from './cron';
+import type {
+  CronScheduleConfig,
+  MonthRule,
+  QuartzWeekday,
+  SchedulePeriod,
+} from './types';
+
+export type { CronScheduleConfig, MonthRule, SchedulePeriod } from './types';
+export { generateCron, parseCron } from './cron';
+
+const TIME_FORMAT = 'HH:mm';
+
+const PERIOD_OPTIONS: { label: string; value: SchedulePeriod }[] = [
+  { label: '分钟', value: 'minute' },
+  { label: '小时', value: 'hour' },
+  { label: '日', value: 'day' },
+  { label: '周', value: 'week' },
+  { label: '月', value: 'month' },
+  { label: '年', value: 'year' },
+];
+
+const WEEKDAY_OPTIONS: { label: string; value: QuartzWeekday }[] = [
+  { label: '星期一', value: 2 },
+  { label: '星期二', value: 3 },
+  { label: '星期三', value: 4 },
+  { label: '星期四', value: 5 },
+  { label: '星期五', value: 6 },
+  { label: '星期六', value: 7 },
+  { label: '星期日', value: 1 },
+];
+
+const MONTH_OPTIONS = [
+  '一月',
+  '二月',
+  '三月',
+  '四月',
+  '五月',
+  '六月',
+  '七月',
+  '八月',
+  '九月',
+  '十月',
+  '十一月',
+  '十二月',
+].map((label, index) => ({ label, value: index + 1 }));
+
+const ORDINAL = ['第一个', '第二个', '第三个', '第四个'];
+
+const MONTH_RULE_OPTIONS = [
+  ...Array.from({ length: 31 }, (_, index) => ({
+    label: `每月${index + 1}号`,
+    value: `day:${index + 1}`,
+    rule: { kind: 'day', day: index + 1 } as MonthRule,
+  })),
+  ...Array.from({ length: 4 }, (_, nthIndex) =>
+    WEEKDAY_OPTIONS.map(({ label, value }) => ({
+      label: `每月${ORDINAL[nthIndex]}${label}`,
+      value: `nth:${nthIndex + 1}:${value}`,
+      rule: {
+        kind: 'nthWeekday',
+        nth: (nthIndex + 1) as 1 | 2 | 3 | 4,
+        weekday: value,
+      } as MonthRule,
+    })),
+  ).flat(),
+  { label: '每月最后一天', value: 'last-day', rule: { kind: 'lastDay' } as MonthRule },
+  ...WEEKDAY_OPTIONS.map(({ label, value }) => ({
+    label: `每月最后一个${label}`,
+    value: `last-weekday:${value}`,
+    rule: { kind: 'lastWeekday', weekday: value } as MonthRule,
+  })),
+];
+
+function monthRuleToValue(rule: MonthRule): string {
+  switch (rule.kind) {
+    case 'day':
+      return `day:${rule.day}`;
+    case 'nthWeekday':
+      return `nth:${rule.nth}:${rule.weekday}`;
+    case 'lastDay':
+      return 'last-day';
+    case 'lastWeekday':
+      return `last-weekday:${rule.weekday}`;
+  }
+}
+
+function monthRuleFromValue(value: string): MonthRule | undefined {
+  return MONTH_RULE_OPTIONS.find((item) => item.value === value)?.rule;
+}
+
+function timeValue(value: string) {
+  const [hour = '0', minute = '0'] = value.split(':');
+  return dayjs().hour(Number(hour) || 0).minute(Number(minute) || 0).second(0).millisecond(0);
+}
+
+interface FieldRowProps {
+  label: string;
+  required?: boolean;
+  help?: string;
+  children: ReactNode;
+}
+
+function FieldRow({ label, required, help, children }: FieldRowProps) {
+  return (
+    <div className="grid min-h-9 grid-cols-1 items-start gap-1.5 py-1 md:grid-cols-[150px_minmax(0,1fr)] md:gap-5">
+      <div className="flex min-h-8 items-center text-[13px] text-[#4e5969] md:justify-end">
+        {required ? <span className="mr-1 text-[#f04438]">*</span> : null}
+        <span>{label}</span>
+        {help ? (
+          <Tooltip title={help}>
+            <CircleHelp size={13} className="ml-1 text-[#98a2b3]" />
+          </Tooltip>
+        ) : null}
+        <span>：</span>
+      </div>
+      <div className="flex min-h-8 min-w-0 items-start">{children}</div>
+    </div>
+  );
+}
+
+async function copyText(text: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+}
+
+export interface CronSchedulerEditorProps {
+  value?: string;
+  onChange?: (cronExpression: string) => void;
+  timezone?: string;
+  effectiveRange?: [Dayjs, Dayjs];
+  onEffectiveRangeChange?: (value?: [Dayjs, Dayjs]) => void;
+  disabled?: boolean;
+  className?: string;
+  showTimezoneTip?: boolean;
+  showEffectiveDate?: boolean;
+}
+
+export default function CronSchedulerEditor({
+  value,
+  onChange,
+  timezone = 'Asia/Shanghai',
+  effectiveRange,
+  onEffectiveRangeChange,
+  disabled = false,
+  className,
+  showTimezoneTip = true,
+  showEffectiveDate = true,
+}: CronSchedulerEditorProps) {
+  const initialValueRef = useRef(parseCron(value));
+  const [config, setConfig] = useState<CronScheduleConfig>(
+    initialValueRef.current || createDefaultCronScheduleConfig(),
+  );
+  const [manualMode, setManualMode] = useState(
+    Boolean(value?.trim() && !initialValueRef.current),
+  );
+  const previousExternalValue = useRef(value);
+
+  const generatedCron = useMemo(() => generateCron(config).cron, [config]);
+  const cronExpression = manualMode ? value?.trim() || '' : generatedCron;
+
+  useEffect(() => {
+    if (value === previousExternalValue.current) return;
+    previousExternalValue.current = value;
+    const parsed = parseCron(value);
+    if (parsed) {
+      setConfig(parsed);
+      setManualMode(false);
+    } else if (value?.trim()) {
+      setManualMode(true);
+    }
+  }, [value]);
+
+  const patch = (next: Partial<CronScheduleConfig>) => {
+    const nextConfig = { ...config, ...next };
+    const nextCron = generateCron(nextConfig).cron;
+    setConfig(nextConfig);
+    setManualMode(false);
+    previousExternalValue.current = nextCron;
+    onChange?.(nextCron);
+  };
+
+  const renderPeriodFields = () => {
+    switch (config.period) {
+      case 'minute':
+        return (
+          <>
+            <FieldRow label="开始时间" required help="从该时间开始按分钟间隔触发。">
+              <TimePicker
+                className="w-[228px] max-w-full"
+                value={timeValue(config.minuteStartTime)}
+                format={TIME_FORMAT}
+                allowClear={false}
+                disabled={disabled}
+                onChange={(next) => next && patch({ minuteStartTime: next.format(TIME_FORMAT) })}
+              />
+            </FieldRow>
+            <FieldRow label="时间间隔" required>
+              <div className="flex items-center gap-2">
+                <InputNumber
+                  className="w-[228px] max-w-full"
+                  min={1}
+                  max={59}
+                  precision={0}
+                  value={config.minuteInterval}
+                  disabled={disabled}
+                  onChange={(next) => patch({ minuteInterval: Number(next ?? 1) })}
+                />
+                <span className="text-[13px] text-[#4e5969]">分钟</span>
+              </div>
+            </FieldRow>
+            <FieldRow label="结束时间" required>
+              <TimePicker
+                className="w-[228px] max-w-full"
+                value={timeValue(config.minuteEndTime)}
+                format={TIME_FORMAT}
+                allowClear={false}
+                disabled={disabled}
+                onChange={(next) => next && patch({ minuteEndTime: next.format(TIME_FORMAT) })}
+              />
+            </FieldRow>
+          </>
+        );
+
+      case 'hour':
+        return (
+          <>
+            <FieldRow label="小时模式" required>
+              <Radio.Group
+                value={config.hourMode}
+                optionType="button"
+                buttonStyle="solid"
+                disabled={disabled}
+                onChange={(event) => patch({ hourMode: event.target.value })}
+              >
+                <Radio.Button value="range">小时区间</Radio.Button>
+                <Radio.Button value="specified">指定小时</Radio.Button>
+              </Radio.Group>
+            </FieldRow>
+            {config.hourMode === 'range' ? (
+              <>
+                <FieldRow label="开始时间" required>
+                  <TimePicker
+                    className="w-[228px] max-w-full"
+                    value={timeValue(config.hourStartTime)}
+                    format={TIME_FORMAT}
+                    allowClear={false}
+                    disabled={disabled}
+                    onChange={(next) => next && patch({ hourStartTime: next.format(TIME_FORMAT) })}
+                  />
+                </FieldRow>
+                <FieldRow label="时间间隔" required>
+                  <div className="flex items-center gap-2">
+                    <InputNumber
+                      className="w-[228px] max-w-full"
+                      min={1}
+                      max={23}
+                      precision={0}
+                      value={config.hourInterval}
+                      disabled={disabled}
+                      onChange={(next) => patch({ hourInterval: Number(next ?? 1) })}
+                    />
+                    <span className="text-[13px] text-[#4e5969]">小时</span>
+                  </div>
+                </FieldRow>
+                <FieldRow label="结束时间" required>
+                  <TimePicker
+                    className="w-[228px] max-w-full"
+                    value={timeValue(config.hourEndTime)}
+                    format={TIME_FORMAT}
+                    allowClear={false}
+                    disabled={disabled}
+                    onChange={(next) => next && patch({ hourEndTime: next.format(TIME_FORMAT) })}
+                  />
+                </FieldRow>
+              </>
+            ) : (
+              <>
+                <FieldRow label="指定小时" required>
+                  <Select
+                    mode="multiple"
+                    className="w-full max-w-[456px]"
+                    value={config.specifiedHours}
+                    maxTagCount="responsive"
+                    disabled={disabled}
+                    placeholder="请选择执行小时"
+                    options={Array.from({ length: 24 }, (_, hour) => ({
+                      label: `${String(hour).padStart(2, '0')}时`,
+                      value: hour,
+                    }))}
+                    onChange={(next) => patch({ specifiedHours: next })}
+                  />
+                </FieldRow>
+                <FieldRow label="执行分钟" required>
+                  <div className="flex items-center gap-2">
+                    <InputNumber
+                      className="w-[228px] max-w-full"
+                      min={0}
+                      max={59}
+                      precision={0}
+                      value={config.specifiedHourMinute}
+                      disabled={disabled}
+                      onChange={(next) => patch({ specifiedHourMinute: Number(next ?? 0) })}
+                    />
+                    <span className="text-[13px] text-[#4e5969]">分</span>
+                  </div>
+                </FieldRow>
+              </>
+            )}
+          </>
+        );
+
+      case 'day':
+        return (
+          <FieldRow label="调度时间" required>
+            <TimePicker
+              className="w-[228px] max-w-full"
+              value={timeValue(config.dayTime)}
+              format={TIME_FORMAT}
+              allowClear={false}
+              disabled={disabled}
+              onChange={(next) => next && patch({ dayTime: next.format(TIME_FORMAT) })}
+            />
+          </FieldRow>
+        );
+
+      case 'week':
+        return (
+          <>
+            <FieldRow label="指定星期" required>
+              <Select
+                mode="multiple"
+                className="w-full max-w-[456px]"
+                value={config.weekdays}
+                maxTagCount="responsive"
+                disabled={disabled}
+                options={WEEKDAY_OPTIONS}
+                onChange={(next) => patch({ weekdays: next })}
+              />
+            </FieldRow>
+            <FieldRow label="调度时间" required>
+              <TimePicker
+                className="w-[228px] max-w-full"
+                value={timeValue(config.weekTime)}
+                format={TIME_FORMAT}
+                allowClear={false}
+                disabled={disabled}
+                onChange={(next) => next && patch({ weekTime: next.format(TIME_FORMAT) })}
+              />
+            </FieldRow>
+          </>
+        );
+
+      case 'month':
+        return (
+          <>
+            <FieldRow label="指定时间" required>
+              <Select
+                mode="multiple"
+                showSearch
+                className="w-full max-w-[456px]"
+                value={config.monthRules.map(monthRuleToValue)}
+                maxTagCount="responsive"
+                disabled={disabled}
+                optionFilterProp="label"
+                options={MONTH_RULE_OPTIONS.map(({ label, value: optionValue }) => ({
+                  label,
+                  value: optionValue,
+                }))}
+                onChange={(values) =>
+                  patch({
+                    monthRules: values
+                      .map(monthRuleFromValue)
+                      .filter((item): item is MonthRule => Boolean(item)),
+                  })
+                }
+              />
+            </FieldRow>
+            <FieldRow label="调度时间" required>
+              <TimePicker
+                className="w-[228px] max-w-full"
+                value={timeValue(config.monthTime)}
+                format={TIME_FORMAT}
+                allowClear={false}
+                disabled={disabled}
+                onChange={(next) => next && patch({ monthTime: next.format(TIME_FORMAT) })}
+              />
+            </FieldRow>
+          </>
+        );
+
+      case 'year':
+        return (
+          <>
+            <FieldRow label="指定月份" required>
+              <Select
+                mode="multiple"
+                className="w-full max-w-[456px]"
+                value={config.months}
+                maxTagCount="responsive"
+                disabled={disabled}
+                options={MONTH_OPTIONS}
+                onChange={(next) => patch({ months: next })}
+              />
+            </FieldRow>
+            <FieldRow label="指定时间" required>
+              <Select
+                mode="multiple"
+                showSearch
+                className="w-full max-w-[456px]"
+                value={config.yearRules.map(monthRuleToValue)}
+                maxTagCount="responsive"
+                disabled={disabled}
+                optionFilterProp="label"
+                options={MONTH_RULE_OPTIONS.map(({ label, value: optionValue }) => ({
+                  label,
+                  value: optionValue,
+                }))}
+                onChange={(values) =>
+                  patch({
+                    yearRules: values
+                      .map(monthRuleFromValue)
+                      .filter((item): item is MonthRule => Boolean(item)),
+                  })
+                }
+              />
+            </FieldRow>
+            <FieldRow label="调度时间" required>
+              <TimePicker
+                className="w-[228px] max-w-full"
+                value={timeValue(config.yearTime)}
+                format={TIME_FORMAT}
+                allowClear={false}
+                disabled={disabled}
+                onChange={(next) => next && patch({ yearTime: next.format(TIME_FORMAT) })}
+              />
+            </FieldRow>
+          </>
+        );
+    }
+  };
+
+  const effectiveType = effectiveRange?.length === 2 ? 'range' : 'forever';
+
+  return (
+    <div className={['w-full text-[#161823]', className || ''].join(' ')}>
+      {showTimezoneTip ? (
+        <div className="mb-4 flex min-h-9 items-center gap-2 rounded-md bg-[#f2f5ff] px-3 py-2 text-[12px] text-[#52637a]">
+          <Info size={14} className="shrink-0 text-[#6074d9]" />
+          <span>
+            调度时区为 <span className="font-medium text-[#465bb8]">{timezone}</span>
+          </span>
+        </div>
+      ) : null}
+
+      <FieldRow label="调度周期" required>
+        <Select
+          className="w-[228px] max-w-full"
+          value={config.period}
+          disabled={disabled}
+          options={PERIOD_OPTIONS}
+          onChange={(period) => patch({ period })}
+        />
+      </FieldRow>
+
+      {renderPeriodFields()}
+
+      {showEffectiveDate ? (
+        <FieldRow
+          label="生效日期"
+          required
+          help="生效区间由调度服务控制，不写入 Cron 表达式。"
+        >
+          <div className="flex min-w-0 flex-col gap-2.5">
+            <Radio.Group
+              value={effectiveType}
+              disabled={disabled}
+              onChange={(event) => {
+                if (event.target.value === 'forever') {
+                  onEffectiveRangeChange?.(undefined);
+                  return;
+                }
+                onEffectiveRangeChange?.([
+                  dayjs().startOf('day'),
+                  dayjs().add(1, 'year').endOf('day'),
+                ]);
+              }}
+            >
+              <Radio value="forever">永久生效</Radio>
+              <Radio value="range">指定时间</Radio>
+            </Radio.Group>
+            {effectiveType === 'range' ? (
+              <DatePicker.RangePicker
+                showTime
+                className="w-full max-w-[456px]"
+                value={effectiveRange}
+                disabled={disabled}
+                onChange={(next) =>
+                  onEffectiveRangeChange?.(
+                    next?.[0] && next?.[1] ? [next[0], next[1]] : undefined,
+                  )
+                }
+              />
+            ) : null}
+          </div>
+        </FieldRow>
+      ) : null}
+
+      <FieldRow label="Cron表达式" help="六段式：秒 分 时 日 月 周。">
+        <div className="min-w-0 max-w-full">
+          {manualMode ? (
+            <div className="w-full max-w-[456px]">
+              <Input
+                value={value}
+                disabled={disabled}
+                className="font-mono text-[12px]"
+                placeholder="0 0 2 * * ?"
+                onChange={(event) => {
+                  previousExternalValue.current = event.target.value;
+                  onChange?.(event.target.value);
+                }}
+              />
+              <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+                当前表达式包含可视化编辑器尚未覆盖的高级语法；将原样保留。修改上方周期配置后会切换为可视化生成。
+              </div>
+            </div>
+          ) : (
+            <div className="flex min-h-8 items-center gap-1.5">
+              <code className="break-all font-mono text-[12px] text-[#344054]">
+                {cronExpression}
+              </code>
+              <Tooltip title="复制 Cron 表达式">
+                <button
+                  type="button"
+                  aria-label="复制 Cron 表达式"
+                  disabled={disabled}
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border-0 bg-transparent text-[#6676d8] transition-colors hover:bg-[#f2f4ff] disabled:cursor-not-allowed disabled:text-[#c8ccd4]"
+                  onClick={async () => {
+                    try {
+                      await copyText(cronExpression);
+                      message.success('Cron 表达式已复制');
+                    } catch {
+                      message.error('复制失败，请手动复制');
+                    }
+                  }}
+                >
+                  <Copy size={14} />
+                </button>
+              </Tooltip>
+            </div>
+          )}
+        </div>
+      </FieldRow>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/components/CronSchedulerEditor/types.ts
+++ b/yak-ops-ui/src/components/CronSchedulerEditor/types.ts
@@ -1,0 +1,50 @@
+export type SchedulePeriod = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+export type HourMode = 'range' | 'specified';
+
+/** Quartz-style day-of-week: Sunday=1, Monday=2 ... Saturday=7. */
+export type QuartzWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type MonthRule =
+  | { kind: 'day'; day: number }
+  | { kind: 'nthWeekday'; nth: 1 | 2 | 3 | 4; weekday: QuartzWeekday }
+  | { kind: 'lastDay' }
+  | { kind: 'lastWeekday'; weekday: QuartzWeekday };
+
+export interface CronScheduleConfig {
+  period: SchedulePeriod;
+
+  minuteStartTime: string;
+  minuteInterval: number;
+  minuteEndTime: string;
+
+  hourMode: HourMode;
+  hourStartTime: string;
+  hourInterval: number;
+  hourEndTime: string;
+  specifiedHours: number[];
+  specifiedHourMinute: number;
+
+  dayTime: string;
+
+  weekdays: QuartzWeekday[];
+  weekTime: string;
+
+  monthRules: MonthRule[];
+  monthTime: string;
+
+  months: number[];
+  yearRules: MonthRule[];
+  yearTime: string;
+}
+
+export interface CronGenerationResult {
+  cron: string;
+  fields: {
+    second: string;
+    minute: string;
+    hour: string;
+    dayOfMonth: string;
+    month: string;
+    dayOfWeek: string;
+  };
+}

--- a/yak-ops-ui/src/pages/workflow/schedules/components/ScheduleEditorDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/components/ScheduleEditorDrawer.tsx
@@ -1,3 +1,4 @@
+import CronSchedulerEditor from '@/components/CronSchedulerEditor';
 import YakButton from '@/components/YakButton';
 import type { WorkflowDefinition } from '@/services/workflow/definitions';
 import {
@@ -7,7 +8,7 @@ import {
   type WorkflowScheduleExecutionStrategy,
   type WorkflowScheduleMisfireStrategy,
 } from '@/services/workflow/schedules';
-import { Button, DatePicker, Drawer, Form, Input, Select, message } from 'antd';
+import { DatePicker, Drawer, Form, Input, Select, message } from 'antd';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
@@ -101,7 +102,7 @@ const ScheduleEditorDrawer = ({
   return (
     <Drawer
       open={open}
-      width={620}
+      width={760}
       destroyOnClose
       title={schedule ? '编辑调度' : '新建调度'}
       onClose={onClose}
@@ -132,27 +133,49 @@ const ScheduleEditorDrawer = ({
           <Input variant="filled" placeholder="例如：每日凌晨订单同步" />
         </Form.Item>
 
-        <Form.Item
-          name="cronExpression"
-          label="Cron 表达式"
-          extra="调度启用后由 Yak Schedule / Quartz 按 Cron 与时区触发；每次计划时间都会进入 Trigger Ledger。"
-          rules={[{ required: true, message: '请输入 Cron 表达式' }]}
-        >
-          <Input variant="filled" placeholder="0 0 2 * * ?" />
+        <Form.Item name="timezone" label="时区" rules={[{ required: true }]}>
+          <Select
+            options={[
+              { value: 'Asia/Shanghai', label: 'Asia/Shanghai' },
+              { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
+              { value: 'UTC', label: 'UTC' },
+            ]}
+          />
         </Form.Item>
 
-        <div className="grid grid-cols-2 gap-4">
-          <Form.Item name="timezone" label="时区" rules={[{ required: true }]}>
-            <Select
-              options={[
-                { value: 'Asia/Shanghai', label: 'Asia/Shanghai' },
-                { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
-                { value: 'UTC', label: 'UTC' },
-              ]}
-            />
-          </Form.Item>
-          <Form.Item name="effectiveRange" label="生效区间">
-            <DatePicker.RangePicker showTime className="w-full" />
+        <Form.Item
+          name="cronExpression"
+          hidden
+          rules={[{ required: true, message: '请配置 Cron 表达式' }]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item name="effectiveRange" hidden>
+          <DatePicker.RangePicker showTime />
+        </Form.Item>
+
+        <div className="mb-6 rounded-xl border border-[#eef0f3] bg-[#fbfbfc] px-4 py-4">
+          <Form.Item
+            noStyle
+            shouldUpdate={(previous, current) =>
+              previous.cronExpression !== current.cronExpression ||
+              previous.timezone !== current.timezone ||
+              previous.effectiveRange !== current.effectiveRange
+            }
+          >
+            {() => (
+              <CronSchedulerEditor
+                value={form.getFieldValue('cronExpression')}
+                timezone={form.getFieldValue('timezone') || 'Asia/Shanghai'}
+                effectiveRange={form.getFieldValue('effectiveRange')}
+                onChange={(cronExpression) =>
+                  form.setFieldValue('cronExpression', cronExpression)
+                }
+                onEffectiveRangeChange={(effectiveRange) =>
+                  form.setFieldValue('effectiveRange', effectiveRange)
+                }
+              />
+            )}
           </Form.Item>
         </div>
 


### PR DESCRIPTION
## What changed

- add reusable `CronSchedulerEditor` under `yak-ops-ui/src/components`
- visually configure minute / hour / day / week / month / year schedules
- support hour ranges, specified hours, weekday selection, day-of-month, nth weekday, last day and last weekday rules
- generate six-field Cron expressions in real time and provide one-click copy
- show schedule timezone and manage permanent / bounded effective dates
- parse the existing Yak Ops presets (`daily 02:00`, hourly, every 10 minutes) back into the visual editor
- preserve unsupported advanced Cron expressions in manual mode instead of rewriting historical schedules
- wire the editor into `workflow/schedules/components/ScheduleEditorDrawer`
- widen the schedule drawer so the video-style horizontal editor layout remains usable

## Compatibility

The backend payload is unchanged: the editor still submits the existing `cronExpression`, `timezone`, `startTime`, and `endTime` fields. No new frontend dependency is introduced.

## Verification

- strict TypeScript check for the pure Cron codec (`types.ts` + `cron.ts`)
- TS/TSX syntax transpile check for the editor and schedule drawer integration
- smoke-tested generation/parsing for minute, hourly, daily, weekly, monthly last-weekday, yearly, and the existing Yak Ops Cron presets
- added `cron.test.ts` coverage for generator/parser behavior

## Notes

This is intentionally opened as a Draft PR so the visual details can be reviewed against the reference video before merge.