### PR TITLE
feat(sync): add Cron Mega Editor to offline sync

### DIFF
--- a/yak-ops-ui/src/components/CronSchedulerEditor/CronSchedulerInput.tsx
+++ b/yak-ops-ui/src/components/CronSchedulerEditor/CronSchedulerInput.tsx
@@ -71,7 +71,6 @@ export default function CronSchedulerInput({
   const openRef = useRef(false);
   const originCronRef = useRef(value);
   const draftCronRef = useRef(value);
-  const committedCronRef = useRef(value);
 
   const [displayCron, setDisplayCron] = useState(value);
   const [draftCron, setDraftCron] = useState(value);
@@ -89,7 +88,7 @@ export default function CronSchedulerInput({
     if (!trigger || typeof window === 'undefined') return;
 
     const rect = trigger.getBoundingClientRect();
-    const availableWidth = Math.max(320, window.innerWidth - VIEWPORT_GAP * 2);
+    const availableWidth = Math.max(0, window.innerWidth - VIEWPORT_GAP * 2);
     const width = Math.min(panelWidth, availableWidth);
     const left = Math.max(
       VIEWPORT_GAP,
@@ -121,7 +120,6 @@ export default function CronSchedulerInput({
     const nextCron = draftCronRef.current.trim();
 
     draftCronRef.current = nextCron;
-    committedCronRef.current = nextCron;
     setDraftCron(nextCron);
     setDisplayCron(nextCron);
     onChange?.(nextCron);
@@ -134,8 +132,9 @@ export default function CronSchedulerInput({
     draftCronRef.current = originalCron;
     setDraftCron(originalCron);
     setDisplayCron(originalCron);
+    onChange?.(originalCron);
     startCloseAnimation();
-  }, [startCloseAnimation]);
+  }, [onChange, startCloseAnimation]);
 
   const openPanel = useCallback(() => {
     if (disabled || openRef.current) return;
@@ -161,15 +160,17 @@ export default function CronSchedulerInput({
     });
   }, [disabled, displayCron, updatePanelPosition]);
 
-  const updateDraftCron = useCallback((nextCron: string) => {
-    draftCronRef.current = nextCron;
-    setDraftCron(nextCron);
-    setDisplayCron(nextCron);
-  }, []);
+  const updateDraftCron = useCallback(
+    (nextCron: string) => {
+      draftCronRef.current = nextCron;
+      setDraftCron(nextCron);
+      setDisplayCron(nextCron);
+      onChange?.(nextCron);
+    },
+    [onChange],
+  );
 
   useEffect(() => {
-    committedCronRef.current = value;
-
     if (!openRef.current) {
       draftCronRef.current = value;
       setDraftCron(value);
@@ -204,7 +205,7 @@ export default function CronSchedulerInput({
         return;
       }
 
-      commitAndClose();
+      startCloseAnimation();
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -221,7 +222,7 @@ export default function CronSchedulerInput({
       document.removeEventListener('pointerdown', handlePointerDown, true);
       document.removeEventListener('keydown', handleKeyDown, true);
     };
-  }, [cancelAndClose, commitAndClose, expanded]);
+  }, [cancelAndClose, expanded, startCloseAnimation]);
 
   useEffect(
     () => () => {
@@ -285,7 +286,7 @@ export default function CronSchedulerInput({
 
                 <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-[#f0f1f3] bg-white/95 px-6 py-3 backdrop-blur">
                   <span className="text-[11px] text-[#98a2b3]">
-                    点击页面其它区域会自动应用当前配置
+                    点击页面其它区域会保留当前配置并关闭
                   </span>
                   <div className="flex shrink-0 items-center gap-2">
                     <YakButton onClick={cancelAndClose}>取消</YakButton>

--- a/yak-ops-ui/src/components/CronSchedulerEditor/CronSchedulerInput.tsx
+++ b/yak-ops-ui/src/components/CronSchedulerEditor/CronSchedulerInput.tsx
@@ -1,0 +1,338 @@
+import YakButton from '@/components/YakButton';
+import { Input } from 'antd';
+import { ChevronDown } from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+import CronSchedulerEditor from './index';
+
+const MEGA_NAV_ANIMATION_MS = 750;
+const VIEWPORT_GAP = 16;
+const PANEL_GAP = 8;
+const DEFAULT_PANEL_WIDTH = 760;
+
+interface PanelPosition {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
+}
+
+export interface CronSchedulerInputProps {
+  value?: string;
+  onChange?: (cronExpression: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  status?: 'error' | 'warning';
+  className?: string;
+  panelWidth?: number;
+}
+
+function isAntdFloatingLayer(target: EventTarget | null) {
+  if (!(target instanceof Element)) return false;
+
+  return Boolean(
+    target.closest(
+      [
+        '.ant-select-dropdown',
+        '.ant-picker-dropdown',
+        '.ant-dropdown',
+        '.ant-popover',
+        '.ant-tooltip',
+      ].join(', '),
+    ),
+  );
+}
+
+/**
+ * 用 Input 触发 CronSchedulerEditor 的大尺寸浮层。
+ *
+ * 浮层通过 Portal 挂到 body，避免被 EditorSection 的 overflow-hidden 裁剪；
+ * 展开动画沿用 yak-ops-website Mega Nav 的 0fr -> 1fr 方案。
+ */
+export default function CronSchedulerInput({
+  value = '',
+  onChange,
+  disabled = false,
+  placeholder = '0 0 2 * * ?',
+  status,
+  className,
+  panelWidth = DEFAULT_PANEL_WIDTH,
+}: CronSchedulerInputProps) {
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<number>();
+  const animationFrameRef = useRef<number>();
+  const openRef = useRef(false);
+  const originCronRef = useRef(value);
+  const draftCronRef = useRef(value);
+  const committedCronRef = useRef(value);
+
+  const [displayCron, setDisplayCron] = useState(value);
+  const [draftCron, setDraftCron] = useState(value);
+  const [mounted, setMounted] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [panelPosition, setPanelPosition] = useState<PanelPosition>({
+    top: 0,
+    left: 0,
+    width: panelWidth,
+    maxHeight: 560,
+  });
+
+  const updatePanelPosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger || typeof window === 'undefined') return;
+
+    const rect = trigger.getBoundingClientRect();
+    const availableWidth = Math.max(320, window.innerWidth - VIEWPORT_GAP * 2);
+    const width = Math.min(panelWidth, availableWidth);
+    const left = Math.max(
+      VIEWPORT_GAP,
+      Math.min(rect.left, window.innerWidth - width - VIEWPORT_GAP),
+    );
+    const top = rect.bottom + PANEL_GAP;
+    const maxHeight = Math.max(
+      220,
+      Math.min(620, window.innerHeight - top - VIEWPORT_GAP),
+    );
+
+    setPanelPosition({ top, left, width, maxHeight });
+  }, [panelWidth]);
+
+  const startCloseAnimation = useCallback(() => {
+    openRef.current = false;
+    setExpanded(false);
+
+    if (closeTimerRef.current) {
+      window.clearTimeout(closeTimerRef.current);
+    }
+
+    closeTimerRef.current = window.setTimeout(() => {
+      setMounted(false);
+    }, MEGA_NAV_ANIMATION_MS);
+  }, []);
+
+  const commitAndClose = useCallback(() => {
+    const nextCron = draftCronRef.current.trim();
+
+    draftCronRef.current = nextCron;
+    committedCronRef.current = nextCron;
+    setDraftCron(nextCron);
+    setDisplayCron(nextCron);
+    onChange?.(nextCron);
+    startCloseAnimation();
+  }, [onChange, startCloseAnimation]);
+
+  const cancelAndClose = useCallback(() => {
+    const originalCron = originCronRef.current;
+
+    draftCronRef.current = originalCron;
+    setDraftCron(originalCron);
+    setDisplayCron(originalCron);
+    startCloseAnimation();
+  }, [startCloseAnimation]);
+
+  const openPanel = useCallback(() => {
+    if (disabled || openRef.current) return;
+
+    if (closeTimerRef.current) {
+      window.clearTimeout(closeTimerRef.current);
+    }
+    if (animationFrameRef.current) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+    }
+
+    const currentCron = displayCron;
+    originCronRef.current = currentCron;
+    draftCronRef.current = currentCron;
+    setDraftCron(currentCron);
+    openRef.current = true;
+    setMounted(true);
+    updatePanelPosition();
+
+    animationFrameRef.current = window.requestAnimationFrame(() => {
+      updatePanelPosition();
+      setExpanded(true);
+    });
+  }, [disabled, displayCron, updatePanelPosition]);
+
+  const updateDraftCron = useCallback((nextCron: string) => {
+    draftCronRef.current = nextCron;
+    setDraftCron(nextCron);
+    setDisplayCron(nextCron);
+  }, []);
+
+  useEffect(() => {
+    committedCronRef.current = value;
+
+    if (!openRef.current) {
+      draftCronRef.current = value;
+      setDraftCron(value);
+      setDisplayCron(value);
+    }
+  }, [value]);
+
+  useEffect(() => {
+    if (!mounted) return undefined;
+
+    const handleViewportChange = () => updatePanelPosition();
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
+
+    return () => {
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
+    };
+  }, [mounted, updatePanelPosition]);
+
+  useEffect(() => {
+    if (!expanded) return undefined;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+
+      if (
+        (target && triggerRef.current?.contains(target)) ||
+        (target && panelRef.current?.contains(target)) ||
+        isAntdFloatingLayer(event.target)
+      ) {
+        return;
+      }
+
+      commitAndClose();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelAndClose();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [cancelAndClose, commitAndClose, expanded]);
+
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+      if (animationFrameRef.current) {
+        window.cancelAnimationFrame(animationFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  const panel = mounted && typeof document !== 'undefined'
+    ? createPortal(
+        <div
+          aria-hidden={!expanded}
+          style={{
+            position: 'fixed',
+            top: panelPosition.top,
+            left: panelPosition.left,
+            width: panelPosition.width,
+            zIndex: 2100,
+            pointerEvents: expanded ? 'auto' : 'none',
+          }}
+        >
+          <div
+            className={[
+              'grid origin-top transition-[grid-template-rows,opacity,transform]',
+              'duration-[750ms] ease-[cubic-bezier(0.16,1,0.3,1)]',
+              expanded
+                ? 'grid-rows-[1fr] translate-y-0 opacity-100'
+                : 'grid-rows-[0fr] -translate-y-1 opacity-0',
+            ].join(' ')}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <div
+                ref={panelRef}
+                role="dialog"
+                aria-label="Cron 调度配置"
+                className="overflow-y-auto rounded-[12.5px] border border-[#eaecf0] bg-white text-[#161823] shadow-[0_12px_36px_rgba(16,24,40,0.14)]"
+                style={{ maxHeight: panelPosition.maxHeight }}
+              >
+                <div className="border-b border-[#f0f1f3] px-6 py-4">
+                  <div className="text-[14px] font-semibold text-[#161823]">
+                    Cron 调度配置
+                  </div>
+                  <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+                    选择周期与执行时间，Cron 表达式会实时回显到输入框。
+                  </div>
+                </div>
+
+                <div className="px-6 py-5">
+                  <CronSchedulerEditor
+                    value={draftCron}
+                    onChange={updateDraftCron}
+                    showTimezoneTip={false}
+                    showEffectiveDate={false}
+                  />
+                </div>
+
+                <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-[#f0f1f3] bg-white/95 px-6 py-3 backdrop-blur">
+                  <span className="text-[11px] text-[#98a2b3]">
+                    点击页面其它区域会自动应用当前配置
+                  </span>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <YakButton onClick={cancelAndClose}>取消</YakButton>
+                    <YakButton type="primary" onClick={commitAndClose}>
+                      确认
+                    </YakButton>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
+
+  return (
+    <>
+      <div ref={triggerRef} className={['relative', className || ''].join(' ')}>
+        <Input
+          allowClear
+          variant="filled"
+          value={displayCron}
+          disabled={disabled}
+          placeholder={placeholder}
+          status={status}
+          aria-haspopup="dialog"
+          aria-expanded={expanded}
+          suffix={
+            <ChevronDown
+              size={14}
+              className={[
+                'text-[#98a2b3] transition-transform duration-[750ms]',
+                'ease-[cubic-bezier(0.16,1,0.3,1)]',
+                expanded ? 'rotate-180' : 'rotate-0',
+              ].join(' ')}
+            />
+          }
+          onFocus={openPanel}
+          onClick={openPanel}
+          onChange={(event) => updateDraftCron(event.target.value)}
+          onPressEnter={() => {
+            if (openRef.current) commitAndClose();
+          }}
+        />
+      </div>
+      {panel}
+    </>
+  );
+}

--- a/yak-ops-ui/src/pages/batch-link-up/detail/components/ScheduleConfigSection.tsx
+++ b/yak-ops-ui/src/pages/batch-link-up/detail/components/ScheduleConfigSection.tsx
@@ -1,4 +1,5 @@
-import { Input, Switch } from 'antd';
+import CronSchedulerInput from '@/components/CronSchedulerEditor/CronSchedulerInput';
+import { Switch } from 'antd';
 import type { ReactNode } from 'react';
 
 import type { SyncEditorState } from '../model';
@@ -54,11 +55,9 @@ export default function ScheduleConfigSection({
       <div className="grid grid-cols-[minmax(0,1.8fr)_minmax(180px,.6fr)_minmax(180px,.6fr)] gap-4 max-lg:grid-cols-2 max-sm:grid-cols-1">
         <Field
           label="Cron 表达式"
-          hint="采用 Quartz Cron，例如每天凌晨 2 点：0 0 2 * * ?"
+          hint="采用 Quartz Cron，例如每天凌晨 2 点：0 0 2 * * ?；点击输入框可打开可视化调度配置。"
         >
-          <Input
-            allowClear
-            variant="filled"
+          <CronSchedulerInput
             value={editor.schedule.cron}
             placeholder="0 0 2 * * ?"
             status={
@@ -66,9 +65,7 @@ export default function ScheduleConfigSection({
                 ? 'error'
                 : undefined
             }
-            onChange={(event) =>
-              updateSchedule({ cron: event.target.value })
-            }
+            onChange={(cron) => updateSchedule({ cron })}
           />
         </Field>
 


### PR DESCRIPTION
## What changed

- add a reusable `CronSchedulerInput` wrapper for the existing `CronSchedulerEditor`
- replace the plain Cron input in offline sync `ScheduleConfigSection` with the new visual trigger
- click/focus the Cron input to expand a large Mega Nav style scheduler panel directly below the field
- reuse the Mega Nav motion from `yak-ops-website`: `grid-template-rows: 0fr -> 1fr`, opacity/translate transition, 750ms `cubic-bezier(0.16, 1, 0.3, 1)` easing
- render the panel through `createPortal(document.body)` so it is not clipped by `EditorSection`'s `overflow-hidden`
- keep the Cron expression synchronized with the input while selecting schedule options
- add explicit Confirm / Cancel actions
- clicking outside keeps the current selection and closes the panel; Escape or Cancel restores the Cron value from when the panel was opened
- ignore Ant Design select/time-picker floating layers in outside-click detection so choosing an option does not close the Mega Panel
- reposition the panel on nested page scroll and viewport resize

## Scope

This PR only changes the offline sync frontend interaction. It reuses the `CronSchedulerEditor` already merged in #947 and does not change the offline-sync backend contract or saved schedule model.

## UX notes

The existing Cron input remains manually editable. Clicking it opens the visual editor; generated Cron values are reflected back into the same input immediately. The panel is deliberately wider than the input so minute/hour/day/week/month/year configuration remains readable.

## Verification

- branch starts from the current `main` containing merged PR #947
- no new npm dependency
- existing `schedule.cron` field and save payload remain unchanged
- diff is limited to the reusable trigger component and offline sync schedule section

Draft for visual review against the offline-sync configuration page and the `yak-ops-website` Mega Nav interaction.