### PR TITLE
fix(ui): polish Cron Mega Editor controls and popup layering

### DIFF
--- a/yak-ops-ui/src/components/CronSchedulerEditor/CronSchedulerInput.tsx
+++ b/yak-ops-ui/src/components/CronSchedulerEditor/CronSchedulerInput.tsx
@@ -1,5 +1,5 @@
 import YakButton from '@/components/YakButton';
-import { Input } from 'antd';
+import { ConfigProvider, Input } from 'antd';
 import { ChevronDown } from 'lucide-react';
 import {
   useCallback,
@@ -15,6 +15,11 @@ const MEGA_NAV_ANIMATION_MS = 750;
 const VIEWPORT_GAP = 16;
 const PANEL_GAP = 8;
 const DEFAULT_PANEL_WIDTH = 760;
+/**
+ * Ant Design 的 Select / TimePicker 等浮层默认 z-index 为 1050。
+ * Mega Panel 必须略低于它，否则这些挂到 body 的 popup 会被面板本身遮住。
+ */
+const MEGA_PANEL_Z_INDEX = 1040;
 
 interface PanelPosition {
   top: number;
@@ -245,7 +250,7 @@ export default function CronSchedulerInput({
             top: panelPosition.top,
             left: panelPosition.left,
             width: panelPosition.width,
-            zIndex: 2100,
+            zIndex: MEGA_PANEL_Z_INDEX,
             pointerEvents: expanded ? 'auto' : 'none',
           }}
         >
@@ -276,12 +281,14 @@ export default function CronSchedulerInput({
                 </div>
 
                 <div className="px-6 py-5">
-                  <CronSchedulerEditor
-                    value={draftCron}
-                    onChange={updateDraftCron}
-                    showTimezoneTip={false}
-                    showEffectiveDate={false}
-                  />
+                  <ConfigProvider componentSize="small" variant="filled">
+                    <CronSchedulerEditor
+                      value={draftCron}
+                      onChange={updateDraftCron}
+                      showTimezoneTip={false}
+                      showEffectiveDate={false}
+                    />
+                  </ConfigProvider>
                 </div>
 
                 <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-[#f0f1f3] bg-white/95 px-6 py-3 backdrop-blur">


### PR DESCRIPTION
## What changed

- fix the offline-sync Cron Mega Panel layering issue where Ant Design Select / TimePicker popups could render behind the panel
- keep the Mega Panel just below Ant Design's default popup layer so dropdowns remain visible while the panel still stays above normal page content
- wrap the embedded `CronSchedulerEditor` with `ConfigProvider componentSize="small" variant="filled"`
- make Select / TimePicker / InputNumber / Input / DatePicker controls inside the Mega Panel consistently compact and filled without changing Cron generation logic

## Why

The Mega Panel was rendered at `z-index: 2100`, while Ant Design popup layers are normally around `1050`. Since Select / TimePicker popups are portaled to `body`, the panel itself covered them. Keeping the panel below Ant Design popup layers fixes the stacking order without moving popup DOM back into the scrollable panel, which would reintroduce overflow clipping.

## Scope

- frontend only
- one reusable component changed: `CronSchedulerInput.tsx`
- no backend or saved schedule model changes
- no new dependency
- no Cron parser/generator behavior changes

## Verification

- branch starts from current `main` after merged #948
- diff limited to the Cron Mega Editor wrapper
- Ant Design 5.25.x supports global `ConfigProvider` `componentSize` and `variant`, so all nested data-entry controls inherit `small + filled`

Draft for visual review on the offline-sync schedule configuration page.