### PR TITLE
feat(workflow): reuse Cron Mega Editor for schedule config

### DIFF
--- a/yak-ops-ui/src/pages/workflow/schedules/components/ScheduleEditorDrawer.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/components/ScheduleEditorDrawer.tsx
@@ -1,4 +1,4 @@
-import CronSchedulerEditor from '@/components/CronSchedulerEditor';
+import CronSchedulerInput from '@/components/CronSchedulerEditor/CronSchedulerInput';
 import YakButton from '@/components/YakButton';
 import type { WorkflowDefinition } from '@/services/workflow/definitions';
 import {
@@ -133,53 +133,31 @@ const ScheduleEditorDrawer = ({
           <Input variant="filled" placeholder="例如：每日凌晨订单同步" />
         </Form.Item>
 
-        <Form.Item name="timezone" label="时区" rules={[{ required: true }]}>
-          <Select
-            options={[
-              { value: 'Asia/Shanghai', label: 'Asia/Shanghai' },
-              { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
-              { value: 'UTC', label: 'UTC' },
-            ]}
-          />
-        </Form.Item>
-
         <Form.Item
           name="cronExpression"
-          hidden
+          label="Cron 表达式"
+          extra="点击输入框可使用可视化 Cron 调度配置；也可以直接手动输入 Quartz Cron。"
           rules={[{ required: true, message: '请配置 Cron 表达式' }]}
         >
-          <Input />
-        </Form.Item>
-        <Form.Item name="effectiveRange" hidden>
-          <DatePicker.RangePicker showTime />
+          <CronSchedulerInput />
         </Form.Item>
 
-        <div className="mb-6 rounded-xl border border-[#eef0f3] bg-[#fbfbfc] px-4 py-4">
-          <Form.Item
-            noStyle
-            shouldUpdate={(previous, current) =>
-              previous.cronExpression !== current.cronExpression ||
-              previous.timezone !== current.timezone ||
-              previous.effectiveRange !== current.effectiveRange
-            }
-          >
-            {() => (
-              <CronSchedulerEditor
-                value={form.getFieldValue('cronExpression')}
-                timezone={form.getFieldValue('timezone') || 'Asia/Shanghai'}
-                effectiveRange={form.getFieldValue('effectiveRange')}
-                onChange={(cronExpression) =>
-                  form.setFieldValue('cronExpression', cronExpression)
-                }
-                onEffectiveRangeChange={(effectiveRange) =>
-                  form.setFieldValue('effectiveRange', effectiveRange)
-                }
-              />
-            )}
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <Form.Item name="timezone" label="时区" rules={[{ required: true }]}>
+            <Select
+              options={[
+                { value: 'Asia/Shanghai', label: 'Asia/Shanghai' },
+                { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
+                { value: 'UTC', label: 'UTC' },
+              ]}
+            />
+          </Form.Item>
+          <Form.Item name="effectiveRange" label="生效区间（可选）">
+            <DatePicker.RangePicker showTime className="w-full" />
           </Form.Item>
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
           <Form.Item
             name="executionStrategy"
             label="实例并发策略"

--- a/yak-ops-ui/src/pages/workflow/schedules/components/WorkflowScheduleConfig.tsx
+++ b/yak-ops-ui/src/pages/workflow/schedules/components/WorkflowScheduleConfig.tsx
@@ -1,3 +1,5 @@
+import CronSchedulerInput from '@/components/CronSchedulerEditor/CronSchedulerInput';
+import YakButton from '@/components/YakButton';
 import { getWorkflowDefinition, type WorkflowDefinition } from '@/services/workflow/definitions';
 import {
   createWorkflowSchedule,
@@ -43,7 +45,6 @@ import {
 import BackfillDrawer from './BackfillDrawer';
 import BackfillHistoryDrawer from './BackfillHistoryDrawer';
 import TriggerLedgerDrawer from './TriggerLedgerDrawer';
-import YakButton from '@/components/YakButton';
 
 interface FormValues {
   name: string;
@@ -478,7 +479,7 @@ export default function WorkflowScheduleConfigPage() {
                         label="Cron 表达式"
                         rules={[{ required: true, message: '请输入 Cron 表达式' }]}
                       >
-                        <Input variant="filled" placeholder="0 0 2 * * ?" className="font-mono" />
+                        <CronSchedulerInput disabled={!canEdit} />
                       </Form.Item>
 
                       <div className="-mt-3 mb-5 flex flex-wrap items-center gap-1.5">
@@ -488,6 +489,7 @@ export default function WorkflowScheduleConfigPage() {
                             key={preset.value}
                             size="small"
                             type="text"
+                            disabled={!canEdit}
                             className="!h-7 !bg-[#f7f8fa] !px-2.5 !text-[11px] !text-[#667085] hover:!bg-[#eef0f3]"
                             onClick={() => form.setFieldValue('cronExpression', preset.value)}
                           >


### PR DESCRIPTION
## What changed

- reuse the existing `CronSchedulerInput` Mega Panel interaction in the dedicated workflow schedule configuration page
- replace the plain Cron input in `WorkflowScheduleConfig` with the same visual Cron editor used by offline sync
- keep the existing quick Cron presets and disable them together with the page when an online workflow is read-only
- replace the always-expanded `CronSchedulerEditor` in `ScheduleEditorDrawer` with the same Cron Input -> Mega Panel interaction
- keep `timezone` and optional effective range as normal workflow form fields instead of hiding them inside a second editor layout

## Consistency

Workflow scheduling now uses the same interaction already validated in offline sync:

- click/focus Cron input to open the Mega Panel
- minute / hour / day / week / month / year visual configuration
- real-time Cron expression feedback
- Confirm / Cancel and Escape behavior
- outside-click close behavior
- Mega Nav transition matching `yak-ops-website`
- Ant Design popup layering fix from #950
- compact `small + filled` controls inside the visual editor

## Compatibility

No backend or schedule contract changes. The workflow forms still save the existing fields:

- `cronExpression`
- `timezone`
- `startTime` / `endTime`
- `executionStrategy`
- `misfireStrategy`
- `input`

## Scope

Only two workflow frontend files are changed. The reusable Cron Mega Editor itself is not duplicated or forked.

## Verification

- branch starts from current `main`, including merged #950
- diff limited to `WorkflowScheduleConfig.tsx` and `ScheduleEditorDrawer.tsx`
- dedicated config page read-only state explicitly disables the custom Cron input and quick presets
- no new dependency and no Cron parser/generator changes

Draft for visual review of both workflow schedule editing entry points.