### PR TITLE
feat(quality): restore workflow quality task integration

### DIFF
--- a/yak-ops-business/yak-ops-business-quality/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-quality/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Data Quality Architecture
 
-本文件描述 Data Quality **当前长期架构**。它只记录现在有效的 package、角色、truth ownership 和调用边界，不记录 Stage / Wave 迁移过程。
+本文件描述 Data Quality **当前长期架构**。它只记录现在有效的 package、角色、truth ownership 和调用边界，不记录迁移过程。
 
 需求看 `REQUIREMENTS.md`，领域规则看 `DOMAIN.md`，依赖矩阵看 `DEPENDENCIES.md`，统一工程规范看仓库根目录 [`../../CODE_STYLE.md`](../../CODE_STYLE.md)。
 
@@ -10,10 +10,12 @@
 2. **角色名表达职责。** Manager / Reader / Policy / Factory / Dispatcher / Worker / Recorder / Gateway / Adapter 不互相冒充。
 3. **Command 与 Read Side 分开。** Reader/Projector 不修改 Monitor/Execution 生命周期。
 4. **执行快照冻结。** Worker 消费 enqueue-time `QualityExecutionPlan`，不回读 current Monitor 改写本次执行。
-5. **外部能力停在 Gateway。** Datasource typed Catalog 通过 Quality-owned Gateway 进入。
-6. **Persistence 走 Repository port。** Application role 不直接依赖 DAO/PO/MyBatis。
-7. **Schedule 是投影。** MonitorSettings 是业务配置 truth，Yak Schedule 只负责触发。
-8. **架构规则可执行。** dependency/corridor/code-style tests 与文档共同维护。
+5. **编排版本冻结。** Workflow 固定的是 Quality-owned immutable revision，不直接引用可变 Monitor 当前状态。
+6. **外部能力停在 Gateway。** Datasource typed Catalog 通过 Quality-owned Gateway 进入。
+7. **Persistence 走 Repository port。** Application role 不直接依赖 DAO/PO/MyBatis。
+8. **Schedule 是投影。** MonitorSettings 是业务配置 truth，Yak Schedule 只负责触发。
+9. **Task Catalog 是投影。** Quality Monitor revision 是内容 truth，Catalog 只保存发现元数据与 current revision pointer。
+10. **架构规则可执行。** dependency/corridor/code-style tests 与文档共同维护。
 
 ## 2. Package Map
 
@@ -23,6 +25,7 @@ io.yak.ops.business.quality
 │   └── v1/mapper          # HTTP inbound / DTO-VO mapping
 ├── asset                  # table registration + candidate/read policy
 ├── monitor                # monitor/rule/settings lifecycle
+├── task                   # Workflow publication / revision resolution / executor adapter
 ├── execution              # admission / plan / dispatch / worker
 ├── alert                  # alert evidence recorder
 ├── schedule               # schedule lifecycle / framework bridge / callback
@@ -33,7 +36,7 @@ io.yak.ops.business.quality
 ├── repository             # narrow persistence ports + adapters
 ├── dao                    # MyBatis persistence primitives
 ├── domain
-│   └── execution          # immutable execution snapshot
+│   └── execution          # immutable execution snapshot/definition
 └── config                 # properties / condition / wiring
 ```
 
@@ -71,7 +74,7 @@ QualityExecutionWorkspaceController
     -> QualityExecutionLogProjector
 ```
 
-这不是“没有 Application 层”，而是 Application role 已经通过 Manager/Reader 等明确命名表达，不需要再包装一层无业务价值的 Service。
+Workflow 不直接进入 Quality Controller，而是通过 Task Catalog + generic Job TaskExecutor 进入 `task` subsystem。
 
 ## 4. Asset Subsystem
 
@@ -84,14 +87,6 @@ Controller
         `-> QualityDataCatalogGateway
 ```
 
-角色：
-
-- `QualityTableAssetManager`：注册/取消注册生命周期；
-- `QualityTableAssetReader`：已注册资产 read model；
-- `QualityTableCandidateReader`：Datasource 物理表候选列表；
-- `QualityTableTargetPolicy`：database/schema/table identity 与字符串标准化规则；
-- `QualityDataCatalogGateway`：Quality 所需的 Datasource 最小能力。
-
 Manager 不把 Reader 当 Helper，Reader 也不拥有注册状态变化。
 
 ## 5. Monitor Subsystem
@@ -103,21 +98,62 @@ QualityMonitorManager
     ├── QualityMonitorSettingsPolicy
     ├── QualityMonitorRepository
     ├── QualityExecutionRepository   # active-execution safety
-    `── QualityScheduleLifecycle
+    ├── QualityScheduleLifecycle
+    `── QualityTaskPublisher
 
 QualityMonitorReader
     `── QualityMonitorRepository
 ```
 
-Manager 拥有 Monitor/Rule/Settings 的事务性生命周期；Policy 只做 deterministic validate/normalize；Reader 只查询。
+Manager 拥有 Monitor/Rule/Settings 的事务性生命周期。创建/更新可执行 Monitor 时同步 Quality task revision；停用、无可执行规则或删除时下线新的 Task Catalog discovery，但不删除历史 revision。
 
-## 6. Execution Subsystem
+## 6. Workflow Task Subsystem
+
+```text
+current Monitor + Rules + Settings
+    -> QualityTaskPublisher
+    -> QualityExecutionPlanFactory.freeze
+    -> immutable QualityExecutionDefinition
+    -> QualityTaskRevisionRepository
+    -> TaskCatalogService.publish(DATA_QUALITY, QUALITY)
+
+Task Catalog revision lookup
+    -> QualityTaskRevisionProvider
+    -> Quality-owned immutable revision
+
+Workflow runtime
+    -> generic TaskExecutionGateway
+    -> QualityTaskExecutor
+    -> QualityExecutionManager.runWorkflowSnapshot
+    -> existing Quality Execution subsystem
+```
+
+角色：
+
+- `QualityTaskPublisher`：冻结 current Monitor 成 immutable revision，并维护 Catalog projection；
+- `QualityTaskRevisionProvider`：把 Quality revision 暴露为 source-neutral `TaskSourceRevision`；
+- `QualityTaskExecutor`：把 generic TaskExecutor start/status/cancel 映射到 Quality execution；
+- `QualityTaskCatalogReconciler`：当前 Project 首次 discovery 时幂等修复旧 Monitor 的 Catalog projection；
+- `QualityWorkflowExecutionRepository`：只承载 Workflow 特有的 snapshot admission、幂等键与取消状态，不扩大已有 execution repository contract。
+
+Workflow 质量门禁语义：
+
+```text
+PASSED       -> SUCCEEDED
+NOT_PASSED   -> FAILED
+ERROR        -> FAILED
+CANCELED     -> CANCELED
+```
+
+Task Catalog 不保存 `QualityExecutionDefinition` 内容，只保存 source/sourceRef/current revision pointer。历史 Workflow 因而继续解析自己固定的 revision，即使 current Monitor 后续被编辑或停用。
+
+## 7. Execution Subsystem
 
 高风险主路径保持显式：
 
 ```text
 QualityExecutionManager
-    -> lock/validate admission
+    -> admission
     -> insert WAITING Execution
     -> QualityExecutionPlanFactory
     -> immutable QualityExecutionPlan
@@ -133,17 +169,11 @@ QualityExecutionManager
               -> QualityAlertRecorder
 ```
 
-角色：
+Manual/Schedule 从 current Monitor 构造计划；Workflow 从 pinned `QualityExecutionDefinition` 构造计划。两条路径从 Plan 以后完全复用同一执行引擎。
 
-- `Manager`：受理 manual/scheduled execution；
-- `PlanFactory`：冻结本次执行需要的 Monitor/Rule/Settings 快照；
-- `Dispatcher`：事务提交后分发，不拥有最终结果；
-- `Worker`：执行规则并提交 execution evidence；
-- `Compiler` / `Evaluator`：规则 SQL 和 metric 判断；
-- `Reader`：查询 Execution；
-- `Receipt`：受理结果值对象。
+Worker 对 Workflow cancel 做 best-effort 响应：未开始时取消阻止进入 RUNNING；运行中在规则边界检查取消状态，不伪造后续完成/告警结果。
 
-## 7. Schedule Subsystem
+## 8. Schedule Subsystem
 
 ```text
 Monitor Manager
@@ -158,11 +188,9 @@ Yak Schedule callback
           -> refresh runtime projection
 ```
 
-`QualityMonitorSettingsPolicy` 可以使用 `QualityScheduleCalculator` 计算/验证 cron 表达，但 schedule package 不反向调用 Monitor Manager。
-
 `QualityScheduleReconciler` 负责从业务配置恢复 framework projection；它不拥有 Monitor 配置 truth。
 
-## 8. Alert Subsystem
+## 9. Alert Subsystem
 
 ```text
 QualityExecutionWorker
@@ -172,7 +200,7 @@ QualityExecutionWorker
 
 Recorder 是 best-effort notification evidence boundary。Alert 写入失败只记录日志，不改写已经确认的 Execution result。
 
-## 9. Template Subsystem
+## 10. Template Subsystem
 
 ```text
 QualityTemplateReader
@@ -183,7 +211,7 @@ TemplateFolderManager / Reader
 
 Template Policy 负责自定义 SQL 和参数 schema 的 validate/normalize；Template Manager/Folder Manager 负责生命周期；Reader 不写状态。
 
-## 10. Workspace Read Side
+## 11. Workspace Read Side
 
 ```text
 QualityWorkspaceReader
@@ -199,64 +227,66 @@ QualityExecutionLogProjector
 
 Workspace 只做查询与 projection，不能出现 Monitor save/delete、Execution run 或 Schedule sync。
 
-## 11. Datasource Boundary
+## 12. Datasource Boundary
 
 Quality 与 Datasource 的唯一实现级连接点：
 
 ```text
-QualityDataCatalogGateway               # Quality-owned port
+QualityDataCatalogGateway
         ^
         |
-DataSourceQualityCatalogAdapter         # only external adapter
+DataSourceQualityCatalogAdapter
         |
         v
 Datasource DataSourceCatalogReader
 ```
 
-只有该 Adapter 可以 import `io.yak.ops.business.datasource.*`。
-
 Asset / Execution 不允许为了方便直接调用 Datasource Reader、Repository、DAO、Plugin 或 Controller。
 
-## 12. Persistence Boundary
+## 13. Persistence Boundary
 
 ```text
 Application role
     -> Quality*Repository interface
     -> Repository Adapter
-    -> Quality*Dao
+    -> Quality*Dao / Mapper
     -> PO / Mapper XML / MyBatis
 ```
 
 Repository port 不暴露 DTO/VO/PO/MyBatis。
 
-目前较大的 `QualityRepositoryAdapter` 仍是 persistence adapter，不是 Application Service；它实现多个窄 port 是当前持久化实现选择。若未来需要拆分，应按 persistence responsibility 独立重构，不改变 port contract。
+`yak_quality_monitor_revision` 保存 Workflow 可固定的 immutable execution definition；`yak_quality_execution.idempotency_key` 只用于外部编排重复提交去重。
 
-## 13. Truth Ownership
+## 14. Truth Ownership
 
 ```text
-TableAsset                 = registered physical quality target
-Monitor + Rules + Settings = current monitor definition truth
-QualityExecutionPlan       = immutable enqueue-time execution truth
-Execution                  = execution lifecycle/result evidence
-RuleExecution              = per-rule evidence
-Monitor last-*             = execution projection
-AlertEvent                 = notification evidence
-Yak Schedule               = trigger projection
-Datasource Catalog         = physical metadata evidence
+TableAsset                    = registered physical quality target
+Monitor + Rules + Settings    = current monitor definition truth
+QualityExecutionDefinition    = immutable Workflow revision content truth
+QualityTaskRevision           = Workflow revision identity/checksum truth
+Task Catalog                  = discovery/current-revision projection
+QualityExecutionPlan          = immutable one-run execution truth
+Execution                     = execution lifecycle/result evidence
+RuleExecution                 = per-rule evidence
+Monitor last-*                = execution projection
+AlertEvent                    = notification evidence
+Yak Schedule                  = trigger projection
+Datasource Catalog            = physical metadata evidence
 ```
 
 出现两个角色同时“决定”同一个 truth 时，先修 ownership，不要通过事件、静态工具或新的 Context 掩盖冲突。
 
-## 14. Change Rule
+## 15. Change Rule
 
 新增或移动代码前依次回答：
 
 1. 属于哪个 Quality subsystem？
-2. 角色是什么？Manager/Reader/Policy/Worker/Gateway 是否准确？
+2. 角色是什么？Manager/Reader/Policy/Worker/Gateway/Task Adapter 是否准确？
 3. 它拥有哪个 truth，还是只读取/投影？
 4. 新 import 是否符合 `DEPENDENCIES.md`？
 5. 是否跨 Datasource？如果是，为什么 QualityDataCatalogGateway 不够？
 6. 是否让 Worker 回读 current Monitor 改写 frozen plan？
-7. 哪个 behavior test 与 architecture test 会保护这次改动？
+7. 是否让 Workflow 直接绑定 mutable Monitor，而不是 revision？
+8. 哪个 behavior test 与 architecture test 会保护这次改动？
 
 答不清楚时不要创建新的 Helper/Common/ServiceImpl。

--- a/yak-ops-business/yak-ops-business-quality/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-quality/DEPENDENCIES.md
@@ -12,7 +12,8 @@ Quality production 内部允许的 top-level 依赖：
 | --- | --- |
 | `controller` | `asset`, `config`, `domain`, `execution`, `monitor`, `template`, `workspace` |
 | `workspace` | `config`, `domain`, `monitor`, `repository` |
-| `monitor` | `config`, `domain`, `repository`, `schedule` |
+| `monitor` | `config`, `domain`, `repository`, `schedule`, `task` |
+| `task` | `config`, `domain`, `execution`, `repository` |
 | `schedule` | `config`, `domain`, `execution`, `repository` |
 | `execution` | `alert`, `config`, `domain`, `gateway`, `repository` |
 | `alert` | `config`, `domain`, `repository` |
@@ -24,9 +25,7 @@ Quality production 内部允许的 top-level 依赖：
 | `domain` | none |
 | `config` | none |
 
-同一 top-level package 内部可以互相协作，但不会因此自动成为其他 package 的公共 API。
-
-声明图和实际源码图都必须无环。
+同一 top-level package 内部可以互相协作，但不会因此自动成为其他 package 的公共 API。声明图和实际源码图都必须无环。
 
 ## 2. Controller Corridors
 
@@ -44,7 +43,7 @@ template   -> Manager / Reader
 
 Controller transport mapper 只负责 DTO/VO 与 Quality command/domain/read values 的边界转换。
 
-## 3. Monitor -> Schedule
+## 3. Monitor -> Schedule / Task
 
 Monitor 跨入 Schedule 只允许：
 
@@ -56,9 +55,34 @@ QualityMonitorSettingsPolicy
     -> QualityScheduleCalculator
 ```
 
-Monitor 不直接依赖 ScheduleHandler、EngineBridge 或 Reconciler。
+Monitor 发布工作流任务只允许：
 
-## 4. Schedule -> Execution
+```text
+QualityMonitorManager
+    -> QualityTaskPublisher
+```
+
+`QualityTaskPublisher` 负责把当前可执行 Monitor 冻结成 Quality-owned immutable revision，再更新 Task Catalog projection。Monitor 不直接操作 Task Catalog、revision repository 或 Workflow runtime。
+
+## 4. Task -> Execution
+
+Quality Workflow task adapter 进入 Execution 只允许：
+
+```text
+QualityTaskPublisher
+    -> QualityExecutionPlanFactory
+
+QualityTaskExecutor
+    -> QualityExecutionManager
+    -> QualityExecutionReader
+    -> QualityExecutionReceipt
+```
+
+Task package 不复制质量规则执行逻辑，不直接调用 Datasource。真正执行仍由既有 Execution subsystem 完成。
+
+`QualityTaskRevisionProvider` 只把 Quality-owned revision 解析成 Task Catalog 的稳定 `TaskSourceRevision`；不可变内容仍由 Quality 持有。
+
+## 5. Schedule -> Execution
 
 Schedule callback 进入 Execution 只允许：
 
@@ -74,7 +98,7 @@ Schedule 不能直接：
 - 调用 Dispatcher；
 - 自己复制 execution admission 规则。
 
-## 5. Workspace -> Monitor
+## 6. Workspace -> Monitor
 
 Workspace 读取 Monitor 当前定义只允许：
 
@@ -85,7 +109,7 @@ QualityWorkspaceReader
 
 其他 workspace projection 优先直接依赖自己的 read Repository；Workspace 不进入 Monitor Manager。
 
-## 6. Execution -> Alert
+## 7. Execution -> Alert
 
 Execution 触发告警只允许：
 
@@ -96,7 +120,7 @@ QualityExecutionWorker
 
 Execution 不直接写 Alert DAO/PO；Alert 也不反向调用 Execution Manager/Worker。
 
-## 7. Quality-owned Datasource Gateway
+## 8. Quality-owned Datasource Gateway
 
 Asset / Execution 使用 Datasource 能力时只依赖：
 
@@ -137,7 +161,23 @@ gateway/datasource/DataSourceQualityCatalogAdapter
 
 不得扩大为 Quality business package 直接依赖 Datasource implementation。
 
-## 8. Persistence Boundary
+## 9. Cross-module Task Corridors
+
+Quality 只通过稳定任务边界接入编排：
+
+```text
+quality.task
+    -> yak-ops-business-task-catalog
+       # publish / revision-provider / reconcile SPI
+    -> yak-ops-business-job
+       # TaskExecutor runtime contract
+    -> yak-ops-spi
+       # TaskAssetSource / shared task models
+```
+
+禁止 Quality 直接依赖 `yak-ops-business-workflow`。Workflow 只能经 Task Catalog + generic Job execution contract 消费 Quality。
+
+## 10. Persistence Boundary
 
 ```text
 Manager / Reader / Worker / Policy owner
@@ -163,7 +203,9 @@ Repository contract 不暴露：
 
 分页 Repository 继续使用 shared `io.yak.framework.common.PageData<T>`。
 
-## 9. Config Boundary
+Workflow 专用 execution admission/cancel 由 `QualityWorkflowExecutionRepository` 隔离，不扩大已有 `QualityExecutionRepository` 公共 contract。
+
+## 11. Config Boundary
 
 `config` 只负责：
 
@@ -179,13 +221,13 @@ Repository contract 不暴露：
 因此禁止重新建立：
 
 ```text
-config -> execution/monitor/asset/template/workspace
+config -> execution/monitor/asset/template/workspace/task
          -> config
 ```
 
 内部专业角色应使用正常 constructor injection + `@Component`。
 
-## 10. No Cycles
+## 12. No Cycles
 
 不允许通过以下方式掩盖 package cycle：
 
@@ -197,7 +239,7 @@ config -> execution/monitor/asset/template/workspace
 
 发现环时先明确能力 owner，再建立窄 Gateway / Reader / Lifecycle corridor。
 
-## 11. Adding a New Dependency
+## 13. Adding a New Dependency
 
 新增一个 import 不在允许矩阵时按顺序判断：
 

--- a/yak-ops-business/yak-ops-business-quality/pom.xml
+++ b/yak-ops-business/yak-ops-business-quality/pom.xml
@@ -23,11 +23,23 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-task-catalog</artifactId>
         </dependency>
         <dependency>
             <groupId>io.yak.framework</groupId>

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityTaskRevisionMapper.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/dao/mapper/QualityTaskRevisionMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.quality.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.common.bean.po.quality.QualityTaskRevisionPO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface QualityTaskRevisionMapper extends BaseMapper<QualityTaskRevisionPO> {}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/QualityTaskRevision.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/QualityTaskRevision.java
@@ -1,0 +1,31 @@
+package io.yak.ops.business.quality.domain;
+
+import java.time.LocalDateTime;
+
+/** Immutable workflow-facing revision owned by the Data Quality domain. */
+public record QualityTaskRevision(
+    long id,
+    long projectId,
+    long monitorId,
+    int revisionNo,
+    String monitorName,
+    String definitionJson,
+    String checksum,
+    LocalDateTime createdAt) {
+
+  public QualityTaskRevision {
+    if (id <= 0L) throw new IllegalArgumentException("质量任务 revision ID 不合法");
+    if (projectId <= 0L) throw new IllegalArgumentException("质量任务 Project ID 不合法");
+    if (monitorId <= 0L) throw new IllegalArgumentException("质量监控 ID 不合法");
+    if (revisionNo <= 0) throw new IllegalArgumentException("质量任务 revisionNo 不合法");
+    if (monitorName == null || monitorName.isBlank()) {
+      throw new IllegalArgumentException("质量任务名称不能为空");
+    }
+    if (definitionJson == null || definitionJson.isBlank()) {
+      throw new IllegalArgumentException("质量任务执行定义不能为空");
+    }
+    if (checksum == null || checksum.isBlank()) {
+      throw new IllegalArgumentException("质量任务 checksum 不能为空");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/execution/QualityExecutionDefinition.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/domain/execution/QualityExecutionDefinition.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.quality.domain.execution;
+
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.RuleSnapshot;
+import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
+import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
+import java.util.List;
+
+/** Immutable quality definition that can be pinned by an external orchestrator. */
+public record QualityExecutionDefinition(
+    long projectId,
+    MonitorSnapshot monitor,
+    List<RuleSnapshot> rules,
+    RuleFailureAction ruleFailureAction,
+    boolean notifyEnabled,
+    NotifyChannel notifyChannel,
+    String notifyTarget,
+    AlertLevel alertLevel) {
+
+  public QualityExecutionDefinition {
+    if (projectId <= 0L) throw new IllegalArgumentException("质量执行定义 Project ID 不合法");
+    if (monitor == null) throw new IllegalArgumentException("质量执行定义监控快照不能为空");
+    rules = rules == null ? List.of() : List.copyOf(rules);
+    ruleFailureAction =
+        ruleFailureAction == null ? RuleFailureAction.CONTINUE : ruleFailureAction;
+    notifyChannel = notifyChannel == null ? NotifyChannel.MESSAGE : notifyChannel;
+    alertLevel = alertLevel == null ? AlertLevel.WARNING : alertLevel;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionManager.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionManager.java
@@ -1,20 +1,24 @@
 package io.yak.ops.business.quality.execution;
 
 import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.domain.QualityDomain.Execution;
 import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionDefinition;
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan;
 import io.yak.ops.business.quality.repository.QualityExecutionRepository;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.business.quality.repository.QualityWorkflowExecutionRepository;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
 import io.yak.ops.common.enums.quality.QualityEnums.ExecutionStatus;
 import io.yak.ops.common.enums.quality.QualityEnums.TriggerType;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Command-side owner for accepting manual and scheduled quality executions. */
+/** Command-side owner for accepting manual, scheduled and Workflow quality executions. */
 @Component
 @ConditionalOnQualityEnabled
 public class QualityExecutionManager {
@@ -23,16 +27,19 @@ public class QualityExecutionManager {
 
   private final QualityMonitorRepository monitorRepository;
   private final QualityExecutionRepository executionRepository;
+  private final QualityWorkflowExecutionRepository workflowExecutionRepository;
   private final QualityExecutionPlanFactory planFactory;
   private final QualityExecutionDispatcher dispatcher;
 
   public QualityExecutionManager(
       QualityMonitorRepository monitorRepository,
       QualityExecutionRepository executionRepository,
+      QualityWorkflowExecutionRepository workflowExecutionRepository,
       QualityExecutionPlanFactory planFactory,
       QualityExecutionDispatcher dispatcher) {
     this.monitorRepository = monitorRepository;
     this.executionRepository = executionRepository;
+    this.workflowExecutionRepository = workflowExecutionRepository;
     this.planFactory = planFactory;
     this.dispatcher = dispatcher;
   }
@@ -45,6 +52,50 @@ public class QualityExecutionManager {
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public QualityExecutionReceipt runScheduled(long monitorId) {
     return enqueue(monitorId, "quality-scheduler", TriggerType.SCHEDULE);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public QualityExecutionReceipt runWorkflowSnapshot(
+      QualityExecutionDefinition definition,
+      String operator,
+      String idempotencyKey) {
+    String existingNo = workflowExecutionRepository
+        .findExecutionNoByIdempotencyKey(idempotencyKey)
+        .orElse(null);
+    if (existingNo != null) return receipt(existingNo);
+    if (definition.rules().isEmpty()) {
+      throw new IllegalStateException("质量任务快照没有可执行规则");
+    }
+    if (executionRepository.hasActiveExecution(definition.monitor().id())) {
+      throw new IllegalStateException("该质量监控已有运行中的检查任务");
+    }
+
+    LocalDateTime queuedAt = LocalDateTime.now();
+    String executionNo = executionNo(queuedAt);
+    long executionId;
+    try {
+      executionId = workflowExecutionRepository.insert(
+          executionNo,
+          definition,
+          normalizeOperator(operator),
+          TriggerType.WORKFLOW,
+          queuedAt,
+          idempotencyKey);
+    } catch (DuplicateKeyException exception) {
+      String racedExecutionNo = workflowExecutionRepository
+          .findExecutionNoByIdempotencyKey(idempotencyKey)
+          .orElseThrow(() -> exception);
+      return receipt(racedExecutionNo);
+    }
+    QualityExecutionPlan plan = planFactory.create(definition, executionId, executionNo);
+    dispatcher.dispatchAfterCommit(plan);
+    return new QualityExecutionReceipt(
+        executionNo, ExecutionStatus.WAITING, CheckResult.RUNNING);
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void cancelWorkflowExecution(String executionNo) {
+    workflowExecutionRepository.cancel(executionNo, LocalDateTime.now());
   }
 
   private QualityExecutionReceipt enqueue(
@@ -71,6 +122,13 @@ public class QualityExecutionManager {
     dispatcher.dispatchAfterCommit(plan);
     return new QualityExecutionReceipt(
         executionNo, ExecutionStatus.WAITING, CheckResult.RUNNING);
+  }
+
+  private QualityExecutionReceipt receipt(String executionNo) {
+    Execution execution = executionRepository.findExecution(executionNo)
+        .orElseThrow(() -> new IllegalStateException("质量执行不存在：" + executionNo));
+    return new QualityExecutionReceipt(
+        execution.executionNo(), execution.executionStatus(), execution.checkResult());
   }
 
   private static String executionNo(LocalDateTime queuedAt) {

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionPlanFactory.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionPlanFactory.java
@@ -4,16 +4,19 @@ import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
 import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
 import io.yak.ops.business.quality.domain.QualityDomain.MonitorSettings;
 import io.yak.ops.business.quality.domain.QualityDomain.Rule;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionDefinition;
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan;
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
 import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.RuleSnapshot;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
 import io.yak.ops.common.enums.quality.QualityEnums.ComparisonOperator;
 import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-/** Freezes the Project identity, monitor definition and enabled rules into an immutable plan. */
+/** Freezes mutable monitor state into reusable immutable execution definitions and run plans. */
 @Component
 @ConditionalOnQualityEnabled
 public class QualityExecutionPlanFactory {
@@ -27,47 +30,38 @@ public class QualityExecutionPlanFactory {
     this.currentProject = currentProject;
   }
 
-  public QualityExecutionPlan create(
-      Monitor monitor,
-      long executionId,
-      String executionNo) {
+  public QualityExecutionDefinition freeze(Monitor monitor) {
     long projectId = currentProject.requireProjectId();
     MonitorSettings settings = monitorRepository.findMonitorSettings(monitor.id());
-    MonitorSnapshot monitorSnapshot =
-        new MonitorSnapshot(
-            monitor.id(),
-            monitor.name(),
-            monitor.dataSourceId(),
-            monitor.dataSourceName(),
-            monitor.databaseName(),
-            monitor.schemaName(),
-            monitor.tableName(),
-            monitor.whereClause(),
-            monitor.owner());
-    List<RuleSnapshot> rules =
-        monitor.rules().stream()
-            .filter(Rule::enabled)
-            .map(
-                rule ->
-                    new RuleSnapshot(
-                        rule.id(),
-                        rule.templateId(),
-                        rule.templateCode(),
-                        rule.name(),
-                        rule.ruleType(),
-                        rule.scope(),
-                        rule.dimension(),
-                        rule.columnName(),
-                        ComparisonOperator.fromValue(rule.operator()),
-                        rule.threshold(),
-                        rule.thresholdEnd(),
-                        rule.enumValues(),
-                        rule.customSql()))
-            .toList();
-    return new QualityExecutionPlan(
+    MonitorSnapshot monitorSnapshot = new MonitorSnapshot(
+        monitor.id(),
+        monitor.name(),
+        monitor.dataSourceId(),
+        monitor.dataSourceName(),
+        monitor.databaseName(),
+        monitor.schemaName(),
+        monitor.tableName(),
+        monitor.whereClause(),
+        monitor.owner());
+    List<RuleSnapshot> rules = monitor.rules().stream()
+        .filter(Rule::enabled)
+        .map(rule -> new RuleSnapshot(
+            rule.id(),
+            rule.templateId(),
+            rule.templateCode(),
+            rule.name(),
+            rule.ruleType(),
+            rule.scope(),
+            rule.dimension(),
+            rule.columnName(),
+            ComparisonOperator.fromValue(rule.operator()),
+            rule.threshold(),
+            rule.thresholdEnd(),
+            rule.enumValues(),
+            rule.customSql()))
+        .toList();
+    return new QualityExecutionDefinition(
         projectId,
-        executionId,
-        executionNo,
         monitorSnapshot,
         rules,
         settings.ruleFailureAction(),
@@ -75,5 +69,36 @@ public class QualityExecutionPlanFactory {
         settings.notifyChannel(),
         settings.notifyTarget(),
         settings.alertLevel());
+  }
+
+  public QualityExecutionPlan create(
+      Monitor monitor,
+      long executionId,
+      String executionNo) {
+    return create(freeze(monitor), executionId, executionNo);
+  }
+
+  public QualityExecutionPlan create(
+      QualityExecutionDefinition definition,
+      long executionId,
+      String executionNo) {
+    requireCurrentProject(definition.projectId());
+    return new QualityExecutionPlan(
+        definition.projectId(),
+        executionId,
+        executionNo,
+        definition.monitor(),
+        definition.rules(),
+        definition.ruleFailureAction(),
+        definition.notifyEnabled(),
+        definition.notifyChannel(),
+        definition.notifyTarget(),
+        definition.alertLevel());
+  }
+
+  private void requireCurrentProject(long projectId) {
+    if (currentProject.requireProjectId() != projectId) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionWorker.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/execution/QualityExecutionWorker.java
@@ -10,6 +10,7 @@ import io.yak.ops.business.quality.execution.QualitySqlCompiler.CompiledRule;
 import io.yak.ops.business.quality.gateway.datasource.QualityDataCatalogGateway;
 import io.yak.ops.business.quality.repository.QualityExecutionRepository;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.business.quality.repository.QualityWorkflowExecutionRepository;
 import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
 import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
 import java.time.Duration;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class QualityExecutionWorker {
   private final QualityExecutionRepository executionRepository;
+  private final QualityWorkflowExecutionRepository workflowExecutionRepository;
   private final QualityMonitorRepository monitorRepository;
   private final QualitySqlCompiler compiler;
   private final QualityMetricEvaluator evaluator;
@@ -28,12 +30,14 @@ public class QualityExecutionWorker {
 
   public QualityExecutionWorker(
       QualityExecutionRepository executionRepository,
+      QualityWorkflowExecutionRepository workflowExecutionRepository,
       QualityMonitorRepository monitorRepository,
       QualitySqlCompiler compiler,
       QualityMetricEvaluator evaluator,
       QualityDataCatalogGateway catalogGateway,
       QualityAlertRecorder alertRecorder) {
     this.executionRepository = executionRepository;
+    this.workflowExecutionRepository = workflowExecutionRepository;
     this.monitorRepository = monitorRepository;
     this.compiler = compiler;
     this.evaluator = evaluator;
@@ -49,6 +53,7 @@ public class QualityExecutionWorker {
     int errors = 0;
     try {
       for (int index = 0; index < plan.rules().size(); index++) {
+        if (workflowExecutionRepository.isCanceled(plan.executionId())) return;
         RuleSnapshot rule = plan.rules().get(index);
         RuleOutcome outcome = executeRule(plan, rule);
         switch (outcome.result()) {
@@ -57,12 +62,14 @@ public class QualityExecutionWorker {
           case ERROR -> errors++;
           default -> throw new IllegalStateException("不支持的规则执行结果：" + outcome.result());
         }
+        if (workflowExecutionRepository.isCanceled(plan.executionId())) return;
         if (plan.ruleFailureAction() == RuleFailureAction.STOP
             && outcome.result() != CheckResult.PASSED) {
           markRemainingRulesNotRun(plan, index + 1);
           break;
         }
       }
+      if (workflowExecutionRepository.isCanceled(plan.executionId())) return;
       LocalDateTime finishedAt = LocalDateTime.now();
       CheckResult finalResult = errors > 0
           ? CheckResult.ERROR
@@ -74,6 +81,7 @@ public class QualityExecutionWorker {
           plan.monitor().id(), plan.executionNo(), finalResult, finishedAt);
       alertRecorder.recordIfNecessary(plan, finalResult, passed, failed, errors);
     } catch (RuntimeException exception) {
+      if (workflowExecutionRepository.isCanceled(plan.executionId())) return;
       LocalDateTime finishedAt = LocalDateTime.now();
       executionRepository.failExecution(
           plan.executionId(), message(exception), finishedAt,

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/monitor/QualityMonitorManager.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/monitor/QualityMonitorManager.java
@@ -9,6 +9,7 @@ import io.yak.ops.business.quality.domain.QualityDomain.RuleSpec;
 import io.yak.ops.business.quality.repository.QualityExecutionRepository;
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
 import io.yak.ops.business.quality.schedule.QualityScheduleLifecycle;
+import io.yak.ops.business.quality.task.QualityTaskPublisher;
 import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ public class QualityMonitorManager {
   private final QualityRulePolicy rulePolicy;
   private final QualityMonitorSettingsPolicy settingsPolicy;
   private final QualityScheduleLifecycle scheduleLifecycle;
+  private final QualityTaskPublisher taskPublisher;
 
   public QualityMonitorManager(
       QualityMonitorRepository monitorRepository,
@@ -30,13 +32,15 @@ public class QualityMonitorManager {
       QualityMonitorPolicy monitorPolicy,
       QualityRulePolicy rulePolicy,
       QualityMonitorSettingsPolicy settingsPolicy,
-      QualityScheduleLifecycle scheduleLifecycle) {
+      QualityScheduleLifecycle scheduleLifecycle,
+      QualityTaskPublisher taskPublisher) {
     this.monitorRepository = monitorRepository;
     this.executionRepository = executionRepository;
     this.monitorPolicy = monitorPolicy;
     this.rulePolicy = rulePolicy;
     this.settingsPolicy = settingsPolicy;
     this.scheduleLifecycle = scheduleLifecycle;
+    this.taskPublisher = taskPublisher;
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager")
@@ -48,12 +52,15 @@ public class QualityMonitorManager {
     monitorRepository.upsertMonitorSettings(id, settings);
     monitorRepository.replaceRules(id, rules);
     scheduleLifecycle.sync(id);
-    return require(id);
+    Monitor saved = require(id);
+    taskPublisher.sync(saved);
+    return saved;
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager")
   public Monitor update(long id, QualityMonitorCommand.Save command) {
     Monitor existing = require(id);
+    monitorRepository.lockMonitor(id);
     monitorPolicy.validateTarget(id, command);
     List<RuleSpec> rules = rulePolicy.normalize(command.rules());
     MonitorSettings currentSettings = monitorRepository.findMonitorSettings(existing.id());
@@ -64,7 +71,9 @@ public class QualityMonitorManager {
     monitorRepository.upsertMonitorSettings(id, settings);
     monitorRepository.replaceRules(id, rules);
     scheduleLifecycle.sync(id);
-    return require(id);
+    Monitor saved = require(id);
+    taskPublisher.sync(saved);
+    return saved;
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager")
@@ -77,6 +86,7 @@ public class QualityMonitorManager {
       throw new IllegalArgumentException("质量监控不存在：" + id);
     }
     scheduleLifecycle.remove(id);
+    taskPublisher.offline(id);
     return true;
   }
 

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTaskRevisionRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTaskRevisionRepository.java
@@ -1,0 +1,16 @@
+package io.yak.ops.business.quality.repository;
+
+import io.yak.ops.business.quality.domain.QualityTaskRevision;
+import java.util.Optional;
+
+/** Persistence boundary for immutable workflow-facing quality revisions. */
+public interface QualityTaskRevisionRepository {
+  Optional<QualityTaskRevision> findLatest(long monitorId);
+  Optional<QualityTaskRevision> find(long monitorId, long revisionId);
+  QualityTaskRevision insert(
+      long monitorId,
+      int revisionNo,
+      String monitorName,
+      String definitionJson,
+      String checksum);
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTaskRevisionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityTaskRevisionRepositoryAdapter.java
@@ -1,0 +1,85 @@
+package io.yak.ops.business.quality.repository;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.dao.mapper.QualityTaskRevisionMapper;
+import io.yak.ops.business.quality.domain.QualityTaskRevision;
+import io.yak.ops.common.bean.po.quality.QualityTaskRevisionPO;
+import io.yak.ops.core.project.CurrentProject;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+
+/** MyBatis adapter for immutable Data Quality workflow revisions. */
+@Repository
+@ConditionalOnQualityEnabled
+@DependsOn("qualityFlyway")
+public class QualityTaskRevisionRepositoryAdapter implements QualityTaskRevisionRepository {
+  private final QualityTaskRevisionMapper mapper;
+  private final CurrentProject currentProject;
+
+  public QualityTaskRevisionRepositoryAdapter(
+      QualityTaskRevisionMapper mapper,
+      CurrentProject currentProject) {
+    this.mapper = mapper;
+    this.currentProject = currentProject;
+  }
+
+  @Override
+  public Optional<QualityTaskRevision> findLatest(long monitorId) {
+    long projectId = currentProject.requireProjectId();
+    QualityTaskRevisionPO po = mapper.selectOne(
+        Wrappers.<QualityTaskRevisionPO>lambdaQuery()
+            .eq(QualityTaskRevisionPO::getProjectId, projectId)
+            .eq(QualityTaskRevisionPO::getMonitorId, monitorId)
+            .orderByDesc(QualityTaskRevisionPO::getRevisionNo)
+            .last("LIMIT 1"));
+    return Optional.ofNullable(po).map(this::revision);
+  }
+
+  @Override
+  public Optional<QualityTaskRevision> find(long monitorId, long revisionId) {
+    long projectId = currentProject.requireProjectId();
+    QualityTaskRevisionPO po = mapper.selectOne(
+        Wrappers.<QualityTaskRevisionPO>lambdaQuery()
+            .eq(QualityTaskRevisionPO::getProjectId, projectId)
+            .eq(QualityTaskRevisionPO::getMonitorId, monitorId)
+            .eq(QualityTaskRevisionPO::getId, revisionId));
+    return Optional.ofNullable(po).map(this::revision);
+  }
+
+  @Override
+  public QualityTaskRevision insert(
+      long monitorId,
+      int revisionNo,
+      String monitorName,
+      String definitionJson,
+      String checksum) {
+    QualityTaskRevisionPO po = new QualityTaskRevisionPO();
+    po.setProjectId(currentProject.requireProjectId());
+    po.setMonitorId(monitorId);
+    po.setRevisionNo(revisionNo);
+    po.setMonitorName(monitorName);
+    po.setDefinitionJson(definitionJson);
+    po.setChecksum(checksum);
+    po.setCreatedAt(LocalDateTime.now());
+    mapper.insert(po);
+    if (po.getId() == null) {
+      throw new IllegalStateException("质量任务 revision 已创建，但未返回 ID");
+    }
+    return revision(po);
+  }
+
+  private QualityTaskRevision revision(QualityTaskRevisionPO po) {
+    return new QualityTaskRevision(
+        po.getId(),
+        po.getProjectId(),
+        po.getMonitorId(),
+        po.getRevisionNo(),
+        po.getMonitorName(),
+        po.getDefinitionJson(),
+        po.getChecksum(),
+        po.getCreatedAt());
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityWorkflowExecutionRepository.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/repository/QualityWorkflowExecutionRepository.java
@@ -1,0 +1,131 @@
+package io.yak.ops.business.quality.repository;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.dao.mapper.QualityExecutionMapper;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionDefinition;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
+import io.yak.ops.common.bean.po.quality.QualityExecutionPO;
+import io.yak.ops.common.enums.quality.QualityEnums.TriggerType;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+
+/** Persistence adapter for Workflow-specific quality execution admission and cancellation. */
+@Repository
+@ConditionalOnQualityEnabled
+@DependsOn("qualityFlyway")
+public class QualityWorkflowExecutionRepository {
+  private final QualityExecutionMapper executionMapper;
+  private final CurrentProject currentProject;
+
+  public QualityWorkflowExecutionRepository(
+      QualityExecutionMapper executionMapper,
+      CurrentProject currentProject) {
+    this.executionMapper = executionMapper;
+    this.currentProject = currentProject;
+  }
+
+  public Optional<String> findExecutionNoByIdempotencyKey(String idempotencyKey) {
+    String normalized = normalizeIdempotencyKey(idempotencyKey);
+    if (normalized == null) return Optional.empty();
+    QualityExecutionPO po = executionMapper.selectOne(
+        Wrappers.<QualityExecutionPO>lambdaQuery()
+            .eq(QualityExecutionPO::getProjectId, currentProject.requireProjectId())
+            .eq(QualityExecutionPO::getIdempotencyKey, normalized));
+    return Optional.ofNullable(po).map(QualityExecutionPO::getExecutionNo);
+  }
+
+  public long insert(
+      String executionNo,
+      QualityExecutionDefinition definition,
+      String operator,
+      TriggerType triggerType,
+      LocalDateTime queuedAt,
+      String idempotencyKey) {
+    requireProject(definition.projectId());
+    MonitorSnapshot monitor = definition.monitor();
+    QualityExecutionPO po = new QualityExecutionPO();
+    po.setProjectId(definition.projectId());
+    po.setExecutionNo(executionNo);
+    po.setIdempotencyKey(normalizeIdempotencyKey(idempotencyKey));
+    po.setMonitorId(monitor.id());
+    po.setMonitorName(monitor.name());
+    po.setDataSourceId(monitor.dataSourceId());
+    po.setDataSourceName(monitor.dataSourceName());
+    po.setDatabaseName(monitor.databaseName());
+    po.setSchemaName(monitor.schemaName());
+    po.setTableName(monitor.tableName());
+    po.setObjectName(objectName(monitor));
+    po.setTriggerType(triggerType.name());
+    po.setExecutionStatus("WAITING");
+    po.setCheckResult("RUNNING");
+    po.setTotalRules(definition.rules().size());
+    po.setPassedRules(0);
+    po.setFailedRules(0);
+    po.setErrorRules(0);
+    po.setOperatorName(operator);
+    po.setQueuedAt(queuedAt);
+    executionMapper.insert(po);
+    if (po.getId() == null) {
+      throw new IllegalStateException("Workflow 质量检查已创建，但未返回执行 ID");
+    }
+    return po.getId();
+  }
+
+  public boolean cancel(String executionNo, LocalDateTime finishedAt) {
+    return executionMapper.update(
+            null,
+            Wrappers.<QualityExecutionPO>lambdaUpdate()
+                .eq(QualityExecutionPO::getProjectId, currentProject.requireProjectId())
+                .eq(QualityExecutionPO::getExecutionNo, executionNo)
+                .in(QualityExecutionPO::getExecutionStatus, List.of("WAITING", "RUNNING"))
+                .set(QualityExecutionPO::getExecutionStatus, "CANCELED")
+                .set(QualityExecutionPO::getCheckResult, "NOT_RUN")
+                .set(QualityExecutionPO::getFinishedAt, finishedAt)
+                .set(QualityExecutionPO::getErrorMessage, "执行已取消"))
+        > 0;
+  }
+
+  public boolean isCanceled(long executionId) {
+    return executionMapper.selectCount(
+            Wrappers.<QualityExecutionPO>lambdaQuery()
+                .eq(QualityExecutionPO::getProjectId, currentProject.requireProjectId())
+                .eq(QualityExecutionPO::getId, executionId)
+                .eq(QualityExecutionPO::getExecutionStatus, "CANCELED"))
+        > 0;
+  }
+
+  private String normalizeIdempotencyKey(String value) {
+    if (value == null || value.isBlank()) return null;
+    String normalized = value.trim();
+    if (normalized.length() > 255) {
+      throw new IllegalArgumentException("质量任务幂等键不能超过 255 个字符");
+    }
+    return normalized;
+  }
+
+  private String objectName(MonitorSnapshot monitor) {
+    List<String> parts = new ArrayList<>();
+    addPart(parts, monitor.databaseName());
+    addPart(parts, monitor.schemaName());
+    addPart(parts, monitor.tableName());
+    return String.join(".", parts);
+  }
+
+  private void addPart(List<String> parts, String value) {
+    if (value != null && !value.isBlank()) parts.add(value.trim());
+  }
+
+  private void requireProject(long projectId) {
+    if (currentProject.requireProjectId() != projectId) {
+      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskCatalogReconciler.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskCatalogReconciler.java
@@ -1,0 +1,97 @@
+package io.yak.ops.business.quality.task;
+
+import io.yak.framework.common.PageData;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
+import io.yak.ops.business.quality.domain.QualityQuery;
+import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.business.taskcatalog.spi.TaskAssetCatalogReconciler;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** Repairs the current Project's Quality Task Catalog projection for pre-existing monitors. */
+@Component
+@ConditionalOnQualityEnabled
+public class QualityTaskCatalogReconciler implements TaskAssetCatalogReconciler {
+  private static final Logger LOG = LoggerFactory.getLogger(QualityTaskCatalogReconciler.class);
+  private static final int PAGE_SIZE = 200;
+  private static final long RECONCILE_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(30);
+
+  private final QualityMonitorRepository monitorRepository;
+  private final QualityTaskPublisher taskPublisher;
+  private final CurrentProject currentProject;
+  private final ConcurrentMap<Long, Long> lastReconciled = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Long, Object> projectLocks = new ConcurrentHashMap<>();
+
+  public QualityTaskCatalogReconciler(
+      QualityMonitorRepository monitorRepository,
+      QualityTaskPublisher taskPublisher,
+      CurrentProject currentProject) {
+    this.monitorRepository = monitorRepository;
+    this.taskPublisher = taskPublisher;
+    this.currentProject = currentProject;
+  }
+
+  @Override
+  public TaskAssetSource source() {
+    return TaskAssetSource.DATA_QUALITY;
+  }
+
+  @Override
+  public void reconcile() {
+    if (!currentProject.isPresent()) return;
+    long projectId = currentProject.requireProjectId();
+    Object lock = projectLocks.computeIfAbsent(projectId, ignored -> new Object());
+    synchronized (lock) {
+      long now = System.nanoTime();
+      Long previous = lastReconciled.get(projectId);
+      if (previous != null && now - previous < RECONCILE_INTERVAL_NANOS) return;
+      reconcileCurrentProject();
+      lastReconciled.put(projectId, now);
+    }
+  }
+
+  private void reconcileCurrentProject() {
+    int pageNo = 1;
+    while (true) {
+      PageData<Monitor> page = monitorRepository.pageMonitors(query(pageNo));
+      for (Monitor summary : page.records()) {
+        monitorRepository.findMonitor(summary.id()).ifPresent(this::syncSafely);
+      }
+      if (pageNo >= page.pages()) break;
+      pageNo++;
+    }
+  }
+
+  private QualityQuery.Monitor query(int pageNo) {
+    return new QualityQuery.Monitor(
+        pageNo,
+        PAGE_SIZE,
+        null,
+        null,
+        null,
+        false,
+        null,
+        false,
+        null,
+        null,
+        null);
+  }
+
+  private void syncSafely(Monitor monitor) {
+    try {
+      taskPublisher.sync(monitor);
+    } catch (RuntimeException exception) {
+      LOG.warn(
+          "Unable to reconcile Quality monitor {} into Task Catalog: {}",
+          monitor.id(),
+          exception.getMessage());
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskExecutor.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskExecutor.java
@@ -1,0 +1,132 @@
+package io.yak.ops.business.quality.task;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskExecutor;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.domain.QualityDomain.Execution;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionDefinition;
+import io.yak.ops.business.quality.execution.QualityExecutionManager;
+import io.yak.ops.business.quality.execution.QualityExecutionReader;
+import io.yak.ops.business.quality.execution.QualityExecutionReceipt;
+import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
+import io.yak.ops.common.enums.quality.QualityEnums.ExecutionStatus;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Adapts immutable Data Quality revisions to the generic Workflow task runtime. */
+@Component
+@ConditionalOnQualityEnabled
+public class QualityTaskExecutor implements TaskExecutor {
+  private final QualityExecutionManager executionManager;
+  private final QualityExecutionReader executionReader;
+  private final ObjectMapper objectMapper;
+
+  public QualityTaskExecutor(
+      QualityExecutionManager executionManager,
+      QualityExecutionReader executionReader,
+      ObjectMapper objectMapper) {
+    this.executionManager = executionManager;
+    this.executionReader = executionReader;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public String taskType() {
+    return QualityTaskPublisher.TASK_TYPE;
+  }
+
+  @Override
+  public TaskExecution start(
+      TaskVersionSnapshot snapshot,
+      String idempotencyKey,
+      Map<String, Object> input) {
+    requireQualitySnapshot(snapshot);
+    QualityExecutionDefinition definition = read(snapshot.executionConfigSnapshotJson());
+    QualityExecutionReceipt receipt = executionManager.runWorkflowSnapshot(
+        definition,
+        "workflow",
+        idempotencyKey);
+    return toExecution(executionReader.requireSummary(receipt.executionNo()));
+  }
+
+  @Override
+  public TaskExecution status(String executionId) {
+    return toExecution(executionReader.requireSummary(requireExecutionNo(executionId)));
+  }
+
+  @Override
+  public void cancel(String executionId) {
+    executionManager.cancelWorkflowExecution(requireExecutionNo(executionId));
+  }
+
+  private TaskExecution toExecution(Execution execution) {
+    String status = taskStatus(execution);
+    Map<String, Object> output = new LinkedHashMap<>();
+    put(output, "executionNo", execution.executionNo());
+    put(output, "monitorId", execution.monitorId());
+    put(output, "checkResult", execution.checkResult());
+    put(output, "totalRules", execution.totalRules());
+    put(output, "passedRules", execution.passedRules());
+    put(output, "failedRules", execution.failedRules());
+    put(output, "errorRules", execution.errorRules());
+    put(output, "durationMillis", execution.durationMs());
+    return new TaskExecution(
+        execution.executionNo(),
+        status,
+        errorMessage(execution, status),
+        output);
+  }
+
+  private String taskStatus(Execution execution) {
+    return switch (execution.executionStatus()) {
+      case WAITING -> "SUBMITTED";
+      case RUNNING -> "RUNNING";
+      case FAILED -> "FAILED";
+      case CANCELED -> "CANCELED";
+      case SUCCESS -> execution.checkResult() == CheckResult.PASSED ? "SUCCEEDED" : "FAILED";
+    };
+  }
+
+  private String errorMessage(Execution execution, String taskStatus) {
+    if (execution.errorMessage() != null && !execution.errorMessage().isBlank()) {
+      return execution.errorMessage().trim();
+    }
+    if (!"FAILED".equals(taskStatus)) return null;
+    return execution.checkResult() == CheckResult.NOT_PASSED
+        ? "数据质量检查未通过"
+        : "数据质量检查执行异常";
+  }
+
+  private QualityExecutionDefinition read(String json) {
+    if (json == null || json.isBlank()) {
+      throw new IllegalArgumentException("质量任务执行快照不能为空");
+    }
+    try {
+      return objectMapper.readValue(json, QualityExecutionDefinition.class);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("质量任务执行快照无法解析", exception);
+    }
+  }
+
+  private void requireQualitySnapshot(TaskVersionSnapshot snapshot) {
+    if (snapshot == null) throw new IllegalArgumentException("任务版本快照不能为空");
+    if (!QualityTaskPublisher.TASK_TYPE.equalsIgnoreCase(snapshot.type())) {
+      throw new IllegalArgumentException("仅支持 QUALITY 任务版本快照：" + snapshot.taskId());
+    }
+  }
+
+  private String requireExecutionNo(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("质量任务 executionId 不能为空");
+    }
+    return value.trim();
+  }
+
+  private void put(Map<String, Object> target, String key, Object value) {
+    if (value != null) target.put(key, value);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskPublisher.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskPublisher.java
@@ -1,0 +1,101 @@
+package io.yak.ops.business.quality.task;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
+import io.yak.ops.business.quality.domain.QualityDomain.Rule;
+import io.yak.ops.business.quality.domain.QualityTaskRevision;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionDefinition;
+import io.yak.ops.business.quality.execution.QualityExecutionPlanFactory;
+import io.yak.ops.business.quality.repository.QualityTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Publishes enabled quality monitors as versioned workflow task assets. */
+@Component
+@ConditionalOnQualityEnabled
+public class QualityTaskPublisher {
+  static final String TASK_TYPE = "QUALITY";
+
+  private final QualityTaskRevisionRepository revisionRepository;
+  private final QualityExecutionPlanFactory planFactory;
+  private final TaskCatalogService taskCatalogService;
+  private final ObjectMapper objectMapper;
+
+  public QualityTaskPublisher(
+      QualityTaskRevisionRepository revisionRepository,
+      QualityExecutionPlanFactory planFactory,
+      TaskCatalogService taskCatalogService,
+      ObjectMapper objectMapper) {
+    this.revisionRepository = revisionRepository;
+    this.planFactory = planFactory;
+    this.taskCatalogService = taskCatalogService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void sync(Monitor monitor) {
+    if (!eligible(monitor)) {
+      offline(monitor.id());
+      return;
+    }
+
+    QualityExecutionDefinition definition = planFactory.freeze(monitor);
+    String definitionJson = write(definition);
+    String checksum = checksum(definitionJson);
+    QualityTaskRevision latest = revisionRepository.findLatest(monitor.id()).orElse(null);
+    QualityTaskRevision revision = latest != null && checksum.equals(latest.checksum())
+        ? latest
+        : revisionRepository.insert(
+            monitor.id(),
+            latest == null ? 1 : latest.revisionNo() + 1,
+            monitor.name(),
+            definitionJson,
+            checksum);
+
+    taskCatalogService.publish(
+        TaskAssetSource.DATA_QUALITY,
+        String.valueOf(monitor.id()),
+        definition.projectId(),
+        monitor.name(),
+        TASK_TYPE,
+        revision.id(),
+        revision.revisionNo());
+  }
+
+  @Transactional(transactionManager = "yakBusinessTransactionManager")
+  public void offline(long monitorId) {
+    taskCatalogService.offlineSource(TaskAssetSource.DATA_QUALITY, String.valueOf(monitorId));
+  }
+
+  static boolean eligible(Monitor monitor) {
+    return monitor != null
+        && monitor.enabled()
+        && monitor.rules().stream().anyMatch(Rule::enabled);
+  }
+
+  private String write(QualityExecutionDefinition definition) {
+    try {
+      return objectMapper.writeValueAsString(definition);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("质量任务执行定义序列化失败", exception);
+    }
+  }
+
+  private String checksum(String value) {
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256")
+          .digest(value.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest);
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("当前 JVM 不支持 SHA-256", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskRevisionProvider.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/task/QualityTaskRevisionProvider.java
@@ -1,0 +1,60 @@
+package io.yak.ops.business.quality.task;
+
+import io.yak.ops.business.quality.config.ConditionalOnQualityEnabled;
+import io.yak.ops.business.quality.domain.QualityTaskRevision;
+import io.yak.ops.business.quality.repository.QualityTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.spi.TaskAssetRevisionProvider;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** Resolves immutable Data Quality monitor revisions for Task Catalog consumers. */
+@Component
+@ConditionalOnQualityEnabled
+public class QualityTaskRevisionProvider implements TaskAssetRevisionProvider {
+  private final QualityTaskRevisionRepository revisionRepository;
+
+  public QualityTaskRevisionProvider(QualityTaskRevisionRepository revisionRepository) {
+    this.revisionRepository = revisionRepository;
+  }
+
+  @Override
+  public TaskAssetSource source() {
+    return TaskAssetSource.DATA_QUALITY;
+  }
+
+  @Override
+  public Optional<TaskSourceRevision> resolve(String sourceRef, long revisionId) {
+    long monitorId = parseMonitorId(sourceRef);
+    return revisionRepository.find(monitorId, revisionId).map(this::sourceRevision);
+  }
+
+  private TaskSourceRevision sourceRevision(QualityTaskRevision revision) {
+    TaskDefinition definition = new TaskDefinition(
+        QualityTaskPublisher.TASK_TYPE,
+        1,
+        revision.monitorName(),
+        revision.definitionJson());
+    return new TaskSourceRevision(
+        revision.id(),
+        revision.revisionNo(),
+        definition,
+        revision.checksum(),
+        revision.projectId());
+  }
+
+  private long parseMonitorId(String sourceRef) {
+    if (sourceRef == null || sourceRef.isBlank()) {
+      throw new IllegalArgumentException("Data Quality sourceRef 不能为空");
+    }
+    try {
+      long value = Long.parseLong(sourceRef.trim());
+      if (value <= 0L) throw new NumberFormatException("not positive");
+      return value;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("非法 Data Quality sourceRef：" + sourceRef, exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V2__add_quality_workflow_task_contract.sql
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/db/migration/yak-quality/V2__add_quality_workflow_task_contract.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS yak_quality_monitor_revision (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'Workflow 可固定的质量监控 revision ID',
+    project_id BIGINT NOT NULL COMMENT 'Yak Security Project ID',
+    monitor_id BIGINT NOT NULL COMMENT '来源质量监控 ID',
+    revision_no INT NOT NULL COMMENT '监控任务 revision 号',
+    monitor_name VARCHAR(100) NOT NULL COMMENT '监控名称快照',
+    definition_json MEDIUMTEXT NOT NULL COMMENT '不可变质量执行定义 JSON',
+    checksum VARCHAR(64) NOT NULL COMMENT '执行定义 SHA-256',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_quality_monitor_revision_no
+      (project_id, monitor_id, revision_no),
+    KEY idx_yak_quality_monitor_revision_latest
+      (project_id, monitor_id, revision_no),
+    KEY idx_yak_quality_monitor_revision_checksum
+      (project_id, monitor_id, checksum)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='数据质量 Workflow 不可变监控版本';
+
+ALTER TABLE yak_quality_execution
+    ADD COLUMN idempotency_key VARCHAR(255) NULL
+      COMMENT '外部编排提交幂等键' AFTER execution_no,
+    ADD UNIQUE KEY uk_yak_quality_execution_idempotency
+      (project_id, idempotency_key);

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityDependencyBoundaryTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityDependencyBoundaryTest.java
@@ -37,7 +37,8 @@ class QualityDependencyBoundaryTest {
               "controller",
               Set.of("asset", "config", "domain", "execution", "monitor", "template", "workspace")),
           Map.entry("workspace", Set.of("config", "domain", "monitor", "repository")),
-          Map.entry("monitor", Set.of("config", "domain", "repository", "schedule")),
+          Map.entry("monitor", Set.of("config", "domain", "repository", "schedule", "task")),
+          Map.entry("task", Set.of("config", "domain", "execution", "repository")),
           Map.entry("schedule", Set.of("config", "domain", "execution", "repository")),
           Map.entry("execution", Set.of("alert", "config", "domain", "gateway", "repository")),
           Map.entry("alert", Set.of("config", "domain", "repository")),
@@ -84,6 +85,18 @@ class QualityDependencyBoundaryTest {
         Set.of(
             BASE + ".schedule.QualityScheduleLifecycle",
             BASE + ".schedule.QualityScheduleCalculator"));
+    assertExactCorridor(
+        "monitor",
+        "task",
+        Set.of(BASE + ".task.QualityTaskPublisher"));
+    assertExactCorridor(
+        "task",
+        "execution",
+        Set.of(
+            BASE + ".execution.QualityExecutionManager",
+            BASE + ".execution.QualityExecutionPlanFactory",
+            BASE + ".execution.QualityExecutionReader",
+            BASE + ".execution.QualityExecutionReceipt"));
     assertExactCorridor(
         "schedule",
         "execution",

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityLayeringConventionTest.java
@@ -17,6 +17,7 @@ import io.yak.ops.business.quality.repository.QualityExecutionWorkspaceRepositor
 import io.yak.ops.business.quality.repository.QualityMonitorRepository;
 import io.yak.ops.business.quality.repository.QualityOverviewRepository;
 import io.yak.ops.business.quality.repository.QualityTableAssetRepository;
+import io.yak.ops.business.quality.repository.QualityTaskRevisionRepository;
 import io.yak.ops.business.quality.repository.QualityTemplateRepository;
 import io.yak.ops.business.quality.repository.QualityWorkspaceRepository;
 import io.yak.ops.common.bean.po.quality.QualityAlertEventPO;
@@ -27,6 +28,7 @@ import io.yak.ops.common.bean.po.quality.QualityRuleExecutionPO;
 import io.yak.ops.common.bean.po.quality.QualityRulePO;
 import io.yak.ops.common.bean.po.quality.QualityRuleTemplatePO;
 import io.yak.ops.common.bean.po.quality.QualityTableAssetPO;
+import io.yak.ops.common.bean.po.quality.QualityTaskRevisionPO;
 import io.yak.ops.common.bean.po.quality.QualityTemplateFolderPO;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -43,6 +45,7 @@ class QualityLayeringConventionTest {
         QualityTableAssetRepository.class,
         QualityMonitorRepository.class,
         QualityExecutionRepository.class,
+        QualityTaskRevisionRepository.class,
         QualityAlertRepository.class,
         CustomTemplateRepository.class,
         QualityWorkspaceRepository.class,
@@ -103,6 +106,7 @@ class QualityLayeringConventionTest {
     assertTable(QualityMonitorSettingPO.class, "yak_quality_monitor_setting");
     assertTable(QualityAlertEventPO.class, "yak_quality_alert_event");
     assertTable(QualityTemplateFolderPO.class, "yak_quality_template_folder");
+    assertTable(QualityTaskRevisionPO.class, "yak_quality_monitor_revision");
   }
 
   private void assertCleanBoundaries(List<Class<?>> types) {

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityRoleConventionTest.java
@@ -25,6 +25,10 @@ import io.yak.ops.business.quality.schedule.QualityScheduleEngineBridge;
 import io.yak.ops.business.quality.schedule.QualityScheduleHandler;
 import io.yak.ops.business.quality.schedule.QualityScheduleLifecycle;
 import io.yak.ops.business.quality.schedule.QualityScheduleReconciler;
+import io.yak.ops.business.quality.task.QualityTaskCatalogReconciler;
+import io.yak.ops.business.quality.task.QualityTaskExecutor;
+import io.yak.ops.business.quality.task.QualityTaskPublisher;
+import io.yak.ops.business.quality.task.QualityTaskRevisionProvider;
 import io.yak.ops.business.quality.template.CustomTemplateManager;
 import io.yak.ops.business.quality.template.CustomTemplatePolicy;
 import io.yak.ops.business.quality.template.CustomTemplateReader;
@@ -67,6 +71,10 @@ class QualityRoleConventionTest {
             QualityScheduleHandler.class,
             QualityScheduleLifecycle.class,
             QualityScheduleReconciler.class,
+            QualityTaskPublisher.class,
+            QualityTaskCatalogReconciler.class,
+            QualityTaskRevisionProvider.class,
+            QualityTaskExecutor.class,
             CustomTemplateManager.class,
             CustomTemplateReader.class,
             CustomTemplatePolicy.class,

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityWorkflowTaskMigrationTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/architecture/QualityWorkflowTaskMigrationTest.java
@@ -1,0 +1,41 @@
+package io.yak.ops.business.quality.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class QualityWorkflowTaskMigrationTest {
+
+  @Test
+  void workflowTaskMigrationAddsImmutableRevisionAndIdempotencyContracts() throws IOException {
+    String sql = Files.readString(migration());
+
+    assertThat(sql)
+        .contains("CREATE TABLE IF NOT EXISTS yak_quality_monitor_revision")
+        .contains("UNIQUE KEY uk_yak_quality_monitor_revision_no")
+        .contains("ADD COLUMN idempotency_key VARCHAR(255) NULL")
+        .contains("UNIQUE KEY uk_yak_quality_execution_idempotency")
+        .doesNotContain("UPDATE yak_quality_monitor");
+  }
+
+  private Path migration() {
+    Path local = Path.of(
+        "src/main/resources/db/migration/yak-quality/V2__add_quality_workflow_task_contract.sql");
+    if (Files.isRegularFile(local)) return local;
+    Path repository = Path.of(
+        "yak-ops-business",
+        "yak-ops-business-quality",
+        "src",
+        "main",
+        "resources",
+        "db",
+        "migration",
+        "yak-quality",
+        "V2__add_quality_workflow_task_contract.sql");
+    assertThat(Files.isRegularFile(repository)).isTrue();
+    return repository;
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskCatalogReconcilerTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskCatalogReconcilerTest.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.quality.task;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.common.PageData;
+import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
+import io.yak.ops.business.quality.repository.QualityMonitorRepository;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class QualityTaskCatalogReconcilerTest {
+
+  @Test
+  void currentProjectDiscoveryRepairsPreExistingMonitorProjection() {
+    QualityMonitorRepository monitors = Mockito.mock(QualityMonitorRepository.class);
+    QualityTaskPublisher publisher = Mockito.mock(QualityTaskPublisher.class);
+    CurrentProject currentProject = Mockito.mock(CurrentProject.class);
+    @SuppressWarnings("unchecked")
+    PageData<Monitor> page = Mockito.mock(PageData.class);
+    Monitor monitor = Mockito.mock(Monitor.class);
+    when(monitor.id()).thenReturn(42L);
+    when(currentProject.isPresent()).thenReturn(true);
+    when(currentProject.requireProjectId()).thenReturn(7L);
+    when(page.records()).thenReturn(List.of(monitor));
+    when(page.pages()).thenReturn(1L);
+    when(monitors.pageMonitors(Mockito.any())).thenReturn(page);
+    when(monitors.findMonitor(42L)).thenReturn(Optional.of(monitor));
+    QualityTaskCatalogReconciler reconciler = new QualityTaskCatalogReconciler(
+        monitors, publisher, currentProject);
+
+    reconciler.reconcile();
+
+    verify(publisher).sync(monitor);
+    org.assertj.core.api.Assertions.assertThat(reconciler.source())
+        .isEqualTo(TaskAssetSource.DATA_QUALITY);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskCatalogReconcilerTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskCatalogReconcilerTest.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.quality.task;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.yak.framework.common.PageData;
@@ -38,5 +39,19 @@ class QualityTaskCatalogReconcilerTest {
     verify(publisher).sync(monitor);
     org.assertj.core.api.Assertions.assertThat(reconciler.source())
         .isEqualTo(TaskAssetSource.DATA_QUALITY);
+  }
+
+  @Test
+  void discoveryWithoutProjectDoesNotReadOrRepairQualityData() {
+    QualityMonitorRepository monitors = Mockito.mock(QualityMonitorRepository.class);
+    QualityTaskPublisher publisher = Mockito.mock(QualityTaskPublisher.class);
+    CurrentProject currentProject = Mockito.mock(CurrentProject.class);
+    when(currentProject.isPresent()).thenReturn(false);
+    QualityTaskCatalogReconciler reconciler = new QualityTaskCatalogReconciler(
+        monitors, publisher, currentProject);
+
+    reconciler.reconcile();
+
+    verifyNoInteractions(monitors, publisher);
   }
 }

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskExecutorTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskExecutorTest.java
@@ -1,0 +1,140 @@
+package io.yak.ops.business.quality.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.job.task.TaskExecution;
+import io.yak.ops.business.job.task.TaskVersionSnapshot;
+import io.yak.ops.business.quality.domain.QualityDomain.Execution;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionDefinition;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
+import io.yak.ops.business.quality.execution.QualityExecutionManager;
+import io.yak.ops.business.quality.execution.QualityExecutionReader;
+import io.yak.ops.business.quality.execution.QualityExecutionReceipt;
+import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
+import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
+import io.yak.ops.common.enums.quality.QualityEnums.ExecutionStatus;
+import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
+import io.yak.ops.common.enums.quality.QualityEnums.TriggerType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class QualityTaskExecutorTest {
+
+  @Test
+  void workflowStartUsesPinnedExecutionDefinition() throws Exception {
+    QualityExecutionManager manager = Mockito.mock(QualityExecutionManager.class);
+    QualityExecutionReader reader = Mockito.mock(QualityExecutionReader.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    QualityTaskExecutor executor = new QualityTaskExecutor(manager, reader, objectMapper);
+    QualityExecutionDefinition definition = definition();
+    String json = objectMapper.writeValueAsString(definition);
+    when(manager.runWorkflowSnapshot(eq(definition), eq("workflow"), eq("attempt-1")))
+        .thenReturn(new QualityExecutionReceipt(
+            "QM-1", ExecutionStatus.WAITING, CheckResult.RUNNING));
+    when(reader.requireSummary("QM-1")).thenReturn(execution(
+        ExecutionStatus.WAITING, CheckResult.RUNNING, 0, 0, 0));
+
+    TaskExecution started = executor.start(
+        new TaskVersionSnapshot("asset-1", "quality", "QUALITY", 2L, "digest", null, json),
+        "attempt-1",
+        Map.of());
+
+    assertThat(started.executionId()).isEqualTo("QM-1");
+    assertThat(started.status()).isEqualTo("SUBMITTED");
+    verify(manager).runWorkflowSnapshot(definition, "workflow", "attempt-1");
+  }
+
+  @Test
+  void qualityGateFailureFailsWorkflowTaskEvenWhenExecutionCompleted() {
+    QualityExecutionManager manager = Mockito.mock(QualityExecutionManager.class);
+    QualityExecutionReader reader = Mockito.mock(QualityExecutionReader.class);
+    QualityTaskExecutor executor = new QualityTaskExecutor(manager, reader, new ObjectMapper());
+    when(reader.requireSummary("QM-2")).thenReturn(execution(
+        ExecutionStatus.SUCCESS, CheckResult.NOT_PASSED, 1, 1, 0));
+
+    TaskExecution result = executor.status("QM-2");
+
+    assertThat(result.status()).isEqualTo("FAILED");
+    assertThat(result.errorMessage()).isEqualTo("数据质量检查未通过");
+    assertThat(result.output())
+        .containsEntry("checkResult", CheckResult.NOT_PASSED)
+        .containsEntry("failedRules", 1);
+  }
+
+  @Test
+  void passedQualityGateSucceedsAndCancelDelegates() {
+    QualityExecutionManager manager = Mockito.mock(QualityExecutionManager.class);
+    QualityExecutionReader reader = Mockito.mock(QualityExecutionReader.class);
+    QualityTaskExecutor executor = new QualityTaskExecutor(manager, reader, new ObjectMapper());
+    when(reader.requireSummary("QM-3")).thenReturn(execution(
+        ExecutionStatus.SUCCESS, CheckResult.PASSED, 1, 0, 0));
+
+    assertThat(executor.status("QM-3").status()).isEqualTo("SUCCEEDED");
+    executor.cancel("QM-3");
+
+    verify(manager).cancelWorkflowExecution("QM-3");
+  }
+
+  private QualityExecutionDefinition definition() {
+    return new QualityExecutionDefinition(
+        7L,
+        new MonitorSnapshot(
+            42L,
+            "customers-quality",
+            9L,
+            "mysql",
+            "sales",
+            null,
+            "customers",
+            null,
+            "owner"),
+        List.of(),
+        RuleFailureAction.CONTINUE,
+        false,
+        NotifyChannel.MESSAGE,
+        null,
+        AlertLevel.WARNING);
+  }
+
+  private Execution execution(
+      ExecutionStatus status,
+      CheckResult result,
+      int passed,
+      int failed,
+      int errors) {
+    LocalDateTime now = LocalDateTime.now();
+    return new Execution(
+        1L,
+        status == ExecutionStatus.WAITING ? "QM-1" : status == ExecutionStatus.SUCCESS && failed > 0 ? "QM-2" : "QM-3",
+        42L,
+        "customers-quality",
+        9L,
+        "mysql",
+        "sales",
+        null,
+        "customers",
+        "sales.customers",
+        TriggerType.WORKFLOW,
+        status,
+        result,
+        1,
+        passed,
+        failed,
+        errors,
+        "workflow",
+        now,
+        status == ExecutionStatus.WAITING ? null : now,
+        status == ExecutionStatus.WAITING ? null : now,
+        status == ExecutionStatus.WAITING ? null : 10L,
+        null,
+        List.of());
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskPublisherTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskPublisherTest.java
@@ -1,0 +1,138 @@
+package io.yak.ops.business.quality.task;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.quality.domain.QualityDomain.Monitor;
+import io.yak.ops.business.quality.domain.QualityDomain.Rule;
+import io.yak.ops.business.quality.domain.QualityTaskRevision;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionDefinition;
+import io.yak.ops.business.quality.domain.execution.QualityExecutionPlan.MonitorSnapshot;
+import io.yak.ops.business.quality.execution.QualityExecutionPlanFactory;
+import io.yak.ops.business.quality.repository.QualityTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.common.enums.quality.QualityEnums.AlertLevel;
+import io.yak.ops.common.enums.quality.QualityEnums.CheckResult;
+import io.yak.ops.common.enums.quality.QualityEnums.NotifyChannel;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleFailureAction;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleScope;
+import io.yak.ops.common.enums.quality.QualityEnums.RuleType;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class QualityTaskPublisherTest {
+
+  @Test
+  void publishesEnabledMonitorAsQualityTaskAsset() {
+    QualityTaskRevisionRepository revisions = Mockito.mock(QualityTaskRevisionRepository.class);
+    QualityExecutionPlanFactory plans = Mockito.mock(QualityExecutionPlanFactory.class);
+    TaskCatalogService catalog = Mockito.mock(TaskCatalogService.class);
+    QualityTaskPublisher publisher = new QualityTaskPublisher(
+        revisions, plans, catalog, new ObjectMapper());
+    Monitor monitor = monitor(true);
+    QualityExecutionDefinition definition = definition();
+    when(plans.freeze(monitor)).thenReturn(definition);
+    when(revisions.findLatest(42L)).thenReturn(Optional.empty());
+    when(revisions.insert(
+        org.mockito.ArgumentMatchers.eq(42L),
+        org.mockito.ArgumentMatchers.eq(1),
+        org.mockito.ArgumentMatchers.eq("customers-quality"),
+        anyString(),
+        anyString()))
+        .thenReturn(new QualityTaskRevision(
+            101L, 7L, 42L, 1, "customers-quality", "{}", "digest", LocalDateTime.now()));
+
+    publisher.sync(monitor);
+
+    verify(catalog).publish(
+        TaskAssetSource.DATA_QUALITY,
+        "42",
+        7L,
+        "customers-quality",
+        "QUALITY",
+        101L,
+        1);
+  }
+
+  @Test
+  void disabledMonitorIsRemovedFromNewWorkflowDiscovery() {
+    QualityTaskRevisionRepository revisions = Mockito.mock(QualityTaskRevisionRepository.class);
+    QualityExecutionPlanFactory plans = Mockito.mock(QualityExecutionPlanFactory.class);
+    TaskCatalogService catalog = Mockito.mock(TaskCatalogService.class);
+    QualityTaskPublisher publisher = new QualityTaskPublisher(
+        revisions, plans, catalog, new ObjectMapper());
+
+    publisher.sync(monitor(false));
+
+    verify(catalog).offlineSource(TaskAssetSource.DATA_QUALITY, "42");
+    verify(plans, never()).freeze(org.mockito.ArgumentMatchers.any());
+  }
+
+  private Monitor monitor(boolean enabled) {
+    Rule rule = new Rule(
+        11L,
+        42L,
+        1L,
+        "COLUMN_NOT_NULL",
+        "id not null",
+        RuleType.COLUMN_NOT_NULL,
+        RuleScope.COLUMN,
+        "完整性",
+        "id",
+        "GTE",
+        BigDecimal.valueOf(99),
+        null,
+        List.of(),
+        null,
+        true,
+        10);
+    return new Monitor(
+        42L,
+        "customers-quality",
+        null,
+        9L,
+        "mysql",
+        "sales",
+        null,
+        "customers",
+        null,
+        "owner",
+        enabled,
+        CheckResult.NOT_RUN,
+        null,
+        null,
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        1,
+        List.of(rule));
+  }
+
+  private QualityExecutionDefinition definition() {
+    return new QualityExecutionDefinition(
+        7L,
+        new MonitorSnapshot(
+            42L,
+            "customers-quality",
+            9L,
+            "mysql",
+            "sales",
+            null,
+            "customers",
+            null,
+            "owner"),
+        List.of(),
+        RuleFailureAction.CONTINUE,
+        false,
+        NotifyChannel.MESSAGE,
+        null,
+        AlertLevel.WARNING);
+  }
+}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskRevisionProviderTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/task/QualityTaskRevisionProviderTest.java
@@ -1,0 +1,53 @@
+package io.yak.ops.business.quality.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.quality.domain.QualityTaskRevision;
+import io.yak.ops.business.quality.repository.QualityTaskRevisionRepository;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class QualityTaskRevisionProviderTest {
+
+  @Test
+  void resolvesPinnedQualityRevisionWithoutReadingCurrentMonitor() {
+    QualityTaskRevisionRepository repository = Mockito.mock(QualityTaskRevisionRepository.class);
+    QualityTaskRevision revision = new QualityTaskRevision(
+        101L,
+        7L,
+        42L,
+        3,
+        "customers-quality",
+        "{\"projectId\":7}",
+        "digest",
+        LocalDateTime.now());
+    when(repository.find(42L, 101L)).thenReturn(Optional.of(revision));
+    QualityTaskRevisionProvider provider = new QualityTaskRevisionProvider(repository);
+
+    TaskSourceRevision resolved = provider.resolve("42", 101L).orElseThrow();
+
+    assertThat(provider.source()).isEqualTo(TaskAssetSource.DATA_QUALITY);
+    assertThat(resolved.revisionId()).isEqualTo(101L);
+    assertThat(resolved.revisionNo()).isEqualTo(3);
+    assertThat(resolved.sourceProjectId()).isEqualTo(7L);
+    assertThat(resolved.checksum()).isEqualTo("digest");
+    assertThat(resolved.definition().taskType()).isEqualTo("QUALITY");
+    assertThat(resolved.definition().configJson()).isEqualTo("{\"projectId\":7}");
+  }
+
+  @Test
+  void rejectsMalformedQualitySourceReference() {
+    QualityTaskRevisionProvider provider = new QualityTaskRevisionProvider(
+        Mockito.mock(QualityTaskRevisionRepository.class));
+
+    assertThatThrownBy(() -> provider.resolve("monitor-42", 101L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sourceRef");
+  }
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogController.java
@@ -6,9 +6,11 @@ import io.yak.framework.common.Result;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.business.taskcatalog.domain.TaskAsset;
 import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskAssetCatalogReconciler;
 import io.yak.ops.core.project.ProjectMigrationMode;
 import io.yak.ops.core.project.ProjectScope;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,9 +26,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class TaskCatalogController {
 
   private final TaskCatalogService service;
+  private final List<TaskAssetCatalogReconciler> reconcilers;
 
-  public TaskCatalogController(TaskCatalogService service) {
+  @Autowired
+  public TaskCatalogController(
+      TaskCatalogService service,
+      List<TaskAssetCatalogReconciler> reconcilers) {
     this.service = service;
+    this.reconcilers = List.copyOf(reconcilers);
+  }
+
+  /** Compatibility constructor for focused controller tests. */
+  public TaskCatalogController(TaskCatalogService service) {
+    this(service, List.of());
   }
 
   @Operation(summary = "查询已发布任务资产")
@@ -35,6 +47,7 @@ public class TaskCatalogController {
       @RequestParam(value = "source", required = false) String source,
       @RequestParam(value = "status", required = false, defaultValue = "ONLINE") String status,
       @RequestParam(value = "keyword", required = false) String keyword) {
+    reconcile(source);
     return Result.success(service.list(source, status, keyword));
   }
 
@@ -42,5 +55,14 @@ public class TaskCatalogController {
   @GetMapping("/{assetId}")
   public Result<TaskAsset> detail(@PathVariable("assetId") long assetId) {
     return Result.success(service.get(assetId));
+  }
+
+  private void reconcile(String source) {
+    String normalized = source == null ? "" : source.trim();
+    for (TaskAssetCatalogReconciler reconciler : reconcilers) {
+      if (normalized.isEmpty() || reconciler.source().name().equalsIgnoreCase(normalized)) {
+        reconciler.reconcile();
+      }
+    }
   }
 }

--- a/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskAssetCatalogReconciler.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/main/java/io/yak/ops/business/taskcatalog/spi/TaskAssetCatalogReconciler.java
@@ -1,0 +1,9 @@
+package io.yak.ops.business.taskcatalog.spi;
+
+import io.yak.ops.spi.task.model.TaskAssetSource;
+
+/** Allows one source domain to repair its Task Catalog projection before discovery. */
+public interface TaskAssetCatalogReconciler {
+  TaskAssetSource source();
+  void reconcile();
+}

--- a/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogControllerReconcilerTest.java
+++ b/yak-ops-business/yak-ops-business-task-catalog/src/test/java/io/yak/ops/business/taskcatalog/controller/v1/TaskCatalogControllerReconcilerTest.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.taskcatalog.controller.v1;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskAssetCatalogReconciler;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TaskCatalogControllerReconcilerTest {
+
+  @Test
+  void sourceSpecificDiscoveryReconcilesOnlyMatchingProjection() {
+    TaskCatalogService service = Mockito.mock(TaskCatalogService.class);
+    TaskAssetCatalogReconciler quality = Mockito.mock(TaskAssetCatalogReconciler.class);
+    TaskAssetCatalogReconciler integration = Mockito.mock(TaskAssetCatalogReconciler.class);
+    when(quality.source()).thenReturn(TaskAssetSource.DATA_QUALITY);
+    when(integration.source()).thenReturn(TaskAssetSource.DATA_INTEGRATION);
+    when(service.list("DATA_QUALITY", "ONLINE", null)).thenReturn(List.of());
+    TaskCatalogController controller = new TaskCatalogController(
+        service, List.of(quality, integration));
+
+    controller.list("DATA_QUALITY", "ONLINE", null);
+
+    verify(quality).reconcile();
+    verify(integration, never()).reconcile();
+  }
+
+  @Test
+  void unfilteredDiscoveryReconcilesAllSourceProjections() {
+    TaskCatalogService service = Mockito.mock(TaskCatalogService.class);
+    TaskAssetCatalogReconciler quality = Mockito.mock(TaskAssetCatalogReconciler.class);
+    TaskAssetCatalogReconciler integration = Mockito.mock(TaskAssetCatalogReconciler.class);
+    when(service.list(null, "ONLINE", null)).thenReturn(List.of());
+    TaskCatalogController controller = new TaskCatalogController(
+        service, List.of(quality, integration));
+
+    controller.list(null, "ONLINE", null);
+
+    verify(quality).reconcile();
+    verify(integration).reconcile();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowQualityTaskAssetBindingTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowQualityTaskAssetBindingTest.java
@@ -1,0 +1,100 @@
+package io.yak.ops.business.workflow.definition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.taskcatalog.domain.TaskAsset;
+import io.yak.ops.business.taskcatalog.domain.TaskAssetRevision;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.taskcatalog.spi.TaskSourceRevision;
+import io.yak.ops.business.workflow.repository.NoopWorkflowDefinitionRepository;
+import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.spi.task.model.TaskAssetSource;
+import io.yak.ops.spi.task.model.TaskAssetStatus;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import io.yak.ops.spi.task.model.TaskRevisionRef;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class WorkflowQualityTaskAssetBindingTest {
+
+  @Test
+  void dataQualityAssetCanBePinnedAndPublished() {
+    WorkflowRuntime runtime = mock(WorkflowRuntime.class);
+    TaskRegistry registry = mock(TaskRegistry.class);
+    TaskCatalogService catalog = mock(TaskCatalogService.class);
+    TaskAsset asset = new TaskAsset(
+        12L,
+        TaskAssetSource.DATA_QUALITY,
+        "42",
+        7L,
+        "customers-quality",
+        "QUALITY",
+        TaskAssetStatus.ONLINE,
+        new TaskRevisionRef(12L, 101L, 1),
+        Instant.parse("2026-09-01T00:00:00Z"),
+        Instant.parse("2026-09-01T00:00:00Z"));
+    TaskDefinition qualityDefinition = new TaskDefinition(
+        "QUALITY",
+        1,
+        "customers-quality",
+        "{\"projectId\":7}");
+    when(catalog.get(12L)).thenReturn(asset);
+    when(catalog.resolveRevision(12L, 101L)).thenReturn(new TaskAssetRevision(
+        asset,
+        new TaskSourceRevision(101L, 1, qualityDefinition, "checksum", 7L)));
+    CurrentProject currentProject = () -> Optional.of(new ProjectContext(7L, "Project 7"));
+    WorkflowDefinitionManager manager = new WorkflowDefinitionManager(
+        runtime,
+        registry,
+        catalog,
+        NoopWorkflowDefinitionRepository.INSTANCE,
+        currentProject);
+
+    WorkflowDefinitionVO created = manager.create(
+        new WorkflowDefinitionCreateDTO("质量门禁工作流", "固定 Data Quality revision"));
+    manager.update(created.id(), updateRequest());
+    WorkflowDefinitionVO online = manager.online(created.id());
+
+    assertEquals(1, online.activeVersionNo());
+    assertEquals("QUALITY", online.nodes().getFirst().taskType());
+    assertEquals(1, online.nodes().getFirst().taskRevisionNo());
+  }
+
+  private static WorkflowDefinitionUpdateDTO updateRequest() {
+    WorkflowDefinitionUpdateDTO.NodeDTO node = new WorkflowDefinitionUpdateDTO.NodeDTO(
+        "quality-node-1",
+        "task-asset:12",
+        12L,
+        101L,
+        1,
+        160D,
+        120D,
+        1,
+        0L,
+        0L,
+        0L,
+        Map.of(),
+        "ALL_SUCCESS",
+        "FAIL_WORKFLOW");
+    return new WorkflowDefinitionUpdateDTO(
+        "质量门禁工作流",
+        "固定 Data Quality revision",
+        List.of(node),
+        List.of(),
+        Map.of(),
+        Map.of(),
+        0L,
+        "CONTINUE_INDEPENDENT_BRANCHES");
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityExecutionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityExecutionPO.java
@@ -13,6 +13,7 @@ public class QualityExecutionPO {
   private Long id;
   private Long projectId;
   private String executionNo;
+  private String idempotencyKey;
   private Long monitorId;
   private String monitorName;
   private Long dataSourceId;

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityTaskRevisionPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/quality/QualityTaskRevisionPO.java
@@ -1,0 +1,21 @@
+package io.yak.ops.common.bean.po.quality;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@TableName("yak_quality_monitor_revision")
+public class QualityTaskRevisionPO {
+  @TableId(type = IdType.AUTO)
+  private Long id;
+  private Long projectId;
+  private Long monitorId;
+  private Integer revisionNo;
+  private String monitorName;
+  private String definitionJson;
+  private String checksum;
+  private LocalDateTime createdAt;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/quality/QualityEnums.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/quality/QualityEnums.java
@@ -55,9 +55,9 @@ public final class QualityEnums {
     }
   }
 
-  public enum ExecutionStatus { WAITING, RUNNING, SUCCESS, FAILED }
+  public enum ExecutionStatus { WAITING, RUNNING, SUCCESS, FAILED, CANCELED }
   public enum CheckResult { PASSED, NOT_PASSED, ERROR, RUNNING, NOT_RUN }
-  public enum TriggerType { MANUAL, SCHEDULE }
+  public enum TriggerType { MANUAL, WORKFLOW, SCHEDULE }
   public enum RunMode { MANUAL, SCHEDULE }
   public enum ScheduleFrequency { DAILY, WEEKLY, CRON }
   public enum ScheduleWeekday { MON, TUE, WED, THU, FRI, SAT, SUN }

--- a/yak-ops-ui/src/services/workflow/instances.ts
+++ b/yak-ops-ui/src/services/workflow/instances.ts
@@ -1,5 +1,8 @@
 import type { ApiResponse } from '@/services/http/response';
-import { listTaskCatalogAssets } from '@/services/taskCatalog';
+import {
+  listTaskCatalogAssets,
+  type TaskCatalogAsset,
+} from '@/services/taskCatalog';
 import { request } from '@umijs/max';
 import type {
   WorkflowBackfill,
@@ -172,6 +175,17 @@ const TERMINAL_STATUSES = new Set([
   'TIMED_OUT',
 ]);
 
+const WORKFLOW_DATA_DEVELOPMENT_TYPES = new Set(['SQL', 'SHELL', 'HTTP', 'PYTHON']);
+
+const isWorkflowCatalogAsset = (asset: TaskCatalogAsset) => {
+  const source = (asset.source || '').trim().toUpperCase();
+  const taskType = (asset.taskType || '').trim().toUpperCase();
+  if (source === 'DATA_DEVELOPMENT') return WORKFLOW_DATA_DEVELOPMENT_TYPES.has(taskType);
+  if (source === 'DATA_INTEGRATION') return taskType === 'SYNC';
+  if (source === 'DATA_QUALITY') return taskType === 'QUALITY';
+  return false;
+};
+
 const workflowEventSubscriptions = new Map<string, WorkflowEventSubscription>();
 
 export const isWorkflowTerminal = (status?: string) =>
@@ -180,11 +194,11 @@ export const isWorkflowTerminal = (status?: string) =>
 export const getWorkflowTasks = async () => {
   const [response, assets] = await Promise.all([
     request<ApiResponse<WorkflowTaskDefinition[]>>('/api/v1/tasks'),
-    listTaskCatalogAssets({ source: 'DATA_DEVELOPMENT', status: 'ONLINE' }).catch(() => []),
+    listTaskCatalogAssets({ status: 'ONLINE' }).catch(() => []),
   ]);
   const merged = new Map<string, WorkflowTaskDefinition>();
   (response.data || []).forEach((task) => merged.set(task.id, task));
-  assets.forEach((asset) => merged.set(`task-asset:${asset.id}`, {
+  assets.filter(isWorkflowCatalogAsset).forEach((asset) => merged.set(`task-asset:${asset.id}`, {
     id: `task-asset:${asset.id}`,
     name: asset.name,
     type: asset.taskType,


### PR DESCRIPTION
## Summary

Reintroduce the Data Quality -> Workflow integration from #925 on top of the current `main` instead of merging the old stacked branch.

- publish enabled Quality monitors as `DATA_QUALITY / QUALITY` Task Catalog assets
- freeze Monitor + enabled Rules + runtime Settings into immutable Quality-owned revisions
- resolve pinned Quality revisions when a Workflow definition is published
- execute pinned Quality snapshots through `QualityTaskExecutor -> QualityExecutionManager -> Dispatcher -> Worker`
- expose `DATA_QUALITY / QUALITY` assets in the Workflow task picker

## Existing data / read repair

Adds a source-neutral `TaskAssetCatalogReconciler` SPI and a Project-scoped Quality reconciler. When Task Catalog discovery happens inside a Project, existing Quality monitors are reconciled into Task Catalog so monitors created before this feature become visible without requiring a manual re-save.

The reconciler is deliberately a no-op without `CurrentProject`, so `PROJECT_OPTIONAL` Task Catalog access cannot trigger cross-Project backfill.

## Project Scope

- Quality Monitor APIs remain `PROJECT_REQUIRED`
- immutable Quality revisions require `CurrentProject`
- Workflow Quality admission/idempotency/cancel operations are filtered by current Project
- Task Catalog repository reads/writes continue to enforce the bound Project when one is present
- Workflow `/api/v1/tasks` remains Project-required from #924
- Task Catalog stays `PROJECT_OPTIONAL` by design; the frontend still attaches the selected Project header in optional mode, while Quality reconciliation does nothing if no Project is bound
- adds an explicit regression test proving no Quality read/repair occurs without Project context

## Workflow runtime

Quality execution reuses the existing runtime chain and carries the persisted Project context into the async worker.

Status mapping:

- `WAITING -> SUBMITTED`
- `RUNNING -> RUNNING`
- `SUCCESS + PASSED -> SUCCEEDED`
- `SUCCESS + NOT_PASSED/ERROR -> FAILED`
- `FAILED -> FAILED`
- `CANCELED -> CANCELED`

Workflow submissions use a Project-scoped idempotency key and support best-effort cancellation.

## Persistence

Adds `V2__add_quality_workflow_task_contract.sql`:

- `yak_quality_monitor_revision`
- nullable `yak_quality_execution.idempotency_key`
- Project-scoped uniqueness for immutable revisions and Workflow idempotency

No existing Monitor/Rule data is rewritten by migration; historical publication is handled by Project-scoped read repair.

## Tests / validation

Restores/introduces coverage for:

- monitor publication/offline behavior
- immutable revision resolution
- historical Task Catalog reconciliation
- no-Project reconciliation fail-closed behavior
- Quality Workflow execution/status/cancel mapping
- Workflow binding to pinned `DATA_QUALITY` revisions
- Task Catalog reconciler dispatch
- migration and architecture boundaries

Static compatibility was checked against the current `TaskExecutor` / `TaskVersionSnapshot` contract, Workflow Task Catalog Project guards, Task Catalog Project-aware repository, frontend Project header rules, and the Quality async dispatcher Project restoration.

The repository currently has no generic Maven/frontend PR CI workflow (only targeted repository workflows). The execution container also cannot resolve `github.com`, so a fresh-clone Maven/Jest run could not be started here. This is an environment limitation rather than a reported test failure; the PR remains Draft for review/runtime verification.

## Context

#925 was merged into the stacked branch `fix/916-workflow-sync-task-discovery`, not into `main`. This PR restores that capability directly on the latest `main` and preserves subsequent Workflow/Data Quality changes, including #952 and #953.

Refs #916
Supersedes #925 for `main` integration.