### PR TITLE
style(workflow): unify editor icon and inspector visuals

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspector.tsx
@@ -1,3 +1,4 @@
+import YakTab from '@/components/YakTab';
 import { Dropdown } from 'antd';
 import type { MenuProps } from 'antd';
 import { Copy, Ellipsis, Trash2, X } from 'lucide-react';
@@ -24,6 +25,11 @@ interface WorkflowNodeInspectorProps {
   onDelete: () => void;
   onAppend: (taskId: string) => void;
 }
+
+const INSPECTOR_TABS = [
+  { key: 'settings', label: '属性' },
+  { key: 'lastRun', label: '上次运行' },
+];
 
 const ActionButton = ({
   label,
@@ -82,8 +88,8 @@ const WorkflowNodeInspector = ({
 
   return (
     <aside className="absolute bottom-0 right-0 top-0 z-20 flex w-[340px] flex-col overflow-hidden border-l border-[#e8eaee] bg-white">
-      <header className="shrink-0 border-b border-[#eef0f2] bg-white">
-        <div className="flex h-12 items-center gap-2 px-4">
+      <header className="shrink-0 bg-white">
+        <div className="flex h-12 items-center gap-2 border-b border-[#eef0f2] px-4">
           <WorkflowNodeIcon taskType={node.data.taskType} size="sm" />
           <div className="min-w-0 flex-1">
             <div className="truncate text-[13px] font-semibold text-[#161823]">
@@ -111,30 +117,13 @@ const WorkflowNodeInspector = ({
           </div>
         </div>
 
-        <nav className="flex h-9 items-end gap-5 px-4" aria-label="节点配置页签">
-          <button
-            type="button"
-            className={[
-              'relative h-9 border-0 bg-transparent px-0 text-[11px] font-medium transition-colors',
-              activeTab === 'settings' ? 'text-[#161823]' : 'text-[#98a2b3] hover:text-[#475467]',
-            ].join(' ')}
-            onClick={() => setActiveTab('settings')}
-          >
-            属性
-            {activeTab === 'settings' ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
-          </button>
-          <button
-            type="button"
-            className={[
-              'relative h-9 border-0 bg-transparent px-0 text-[11px] font-medium transition-colors',
-              activeTab === 'lastRun' ? 'text-[#161823]' : 'text-[#98a2b3] hover:text-[#475467]',
-            ].join(' ')}
-            onClick={() => setActiveTab('lastRun')}
-          >
-            上次运行
-            {activeTab === 'lastRun' ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
-          </button>
-        </nav>
+        <div className="px-4">
+          <YakTab
+            activeKey={activeTab}
+            items={INSPECTOR_TABS}
+            onChange={(key) => setActiveTab(key as InspectorTab)}
+          />
+        </div>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto bg-white">

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspectorLastRun.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspectorLastRun.tsx
@@ -6,7 +6,7 @@ import {
 import { getWorkflowDefinition } from '@/services/workflow/definitions';
 import { Spin } from 'antd';
 import dayjs from 'dayjs';
-import { RefreshCw } from 'lucide-react';
+import { CircleAlert, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 interface WorkflowNodeInspectorLastRunProps {
@@ -14,36 +14,36 @@ interface WorkflowNodeInspectorLastRunProps {
   nodeId: string;
 }
 
-const STATUS_META: Record<string, { label: string; className: string; dotClassName: string }> = {
+const STATUS_META: Record<string, { label: string; textClassName: string; dotClassName: string }> = {
   SUCCESS: {
     label: 'SUCCESS',
-    className: 'border-[#86d9a8] bg-[linear-gradient(110deg,#effcf4,#e7fbf2)] text-[#138a4b]',
-    dotClassName: 'bg-[#22c55e]',
+    textClassName: 'text-[#067647]',
+    dotClassName: 'bg-[#12b76a]',
   },
   SUCCESS_WITH_WARNINGS: {
     label: 'SUCCESS WITH WARNINGS',
-    className: 'border-[#f4d68f] bg-[#fffaf0] text-[#b7791f]',
-    dotClassName: 'bg-[#f59e0b]',
+    textClassName: 'text-[#b54708]',
+    dotClassName: 'bg-[#f79009]',
   },
   RUNNING: {
     label: 'RUNNING',
-    className: 'border-[#a9c7ff] bg-[#f2f7ff] text-[#2563eb]',
-    dotClassName: 'bg-[#3b82f6]',
+    textClassName: 'text-[#175cd3]',
+    dotClassName: 'bg-[#2e90fa]',
   },
   FAILED: {
     label: 'FAILED',
-    className: 'border-[#ffc1ce] bg-[#fff4f6] text-[#d92d4a]',
-    dotClassName: 'bg-[#fe2c55]',
+    textClassName: 'text-[#b42318]',
+    dotClassName: 'bg-[#f04438]',
   },
   CANCELED: {
     label: 'CANCELED',
-    className: 'border-[#dadde3] bg-[#f7f7f8] text-[#667085]',
+    textClassName: 'text-[#667085]',
     dotClassName: 'bg-[#98a2b3]',
   },
   TIMED_OUT: {
     label: 'TIMED OUT',
-    className: 'border-[#ffc1ce] bg-[#fff4f6] text-[#d92d4a]',
-    dotClassName: 'bg-[#fe2c55]',
+    textClassName: 'text-[#b42318]',
+    dotClassName: 'bg-[#f04438]',
   },
 };
 
@@ -122,7 +122,7 @@ const WorkflowNodeInspectorLastRun = ({
     const status = nodeRun?.status || '';
     return STATUS_META[status] || {
       label: status || '--',
-      className: 'border-[#e4e7ec] bg-[#f7f7f8] text-[#667085]',
+      textClassName: 'text-[#667085]',
       dotClassName: 'bg-[#98a2b3]',
     };
   }, [nodeRun?.status]);
@@ -172,21 +172,21 @@ const WorkflowNodeInspectorLastRun = ({
         </button>
       </div>
 
-      <div className={`grid grid-cols-3 overflow-hidden rounded-xl border ${statusMeta.className}`}>
+      <div className="grid grid-cols-3 overflow-hidden rounded-xl border border-[#e4e7ec] bg-[#fafafa]">
         <div className="px-3 py-2.5">
-          <div className="text-[9px] text-current opacity-60">状态</div>
-          <div className="mt-1 flex items-center gap-1.5 text-[11px] font-semibold">
+          <div className="text-[9px] text-[#98a2b3]">状态</div>
+          <div className={`mt-1 flex items-center gap-1.5 text-[11px] font-semibold ${statusMeta.textClassName}`}>
             <span className={`h-1.5 w-1.5 rounded-full ${statusMeta.dotClassName}`} />
             {statusMeta.label}
           </div>
         </div>
-        <div className="border-l border-current/10 px-3 py-2.5">
-          <div className="text-[9px] text-current opacity-60">运行时间</div>
-          <div className="mt-1 text-[11px] font-semibold">{formatElapsed(nodeRun)}</div>
+        <div className="border-l border-[#e4e7ec] px-3 py-2.5">
+          <div className="text-[9px] text-[#98a2b3]">运行时间</div>
+          <div className="mt-1 text-[11px] font-semibold text-[#475467]">{formatElapsed(nodeRun)}</div>
         </div>
-        <div className="border-l border-current/10 px-3 py-2.5">
-          <div className="text-[9px] text-current opacity-60">Attempt</div>
-          <div className="mt-1 text-[11px] font-semibold">{nodeRun.attemptCount || nodeRun.attempts?.length || 0}</div>
+        <div className="border-l border-[#e4e7ec] px-3 py-2.5">
+          <div className="text-[9px] text-[#98a2b3]">Attempt</div>
+          <div className="mt-1 text-[11px] font-semibold text-[#475467]">{nodeRun.attemptCount || nodeRun.attempts?.length || 0}</div>
         </div>
       </div>
 
@@ -196,8 +196,9 @@ const WorkflowNodeInspectorLastRun = ({
       {(nodeRun.errorMessage || nodeRun.failureReason) ? (
         <section>
           <div className="mb-2 text-[12px] font-semibold text-[#344054]">错误信息</div>
-          <div className="rounded-xl border border-[#ffc7d2] bg-[#fff5f7] px-3 py-2.5 text-[11px] leading-5 text-[#b4233f]">
-            {nodeRun.errorMessage || nodeRun.failureReason}
+          <div className="flex items-start gap-2 rounded-xl border border-[#e4e7ec] bg-[#fafafa] px-3 py-2.5 text-[11px] leading-5 text-[#475467]">
+            <CircleAlert size={14} className="mt-0.5 shrink-0 text-[#d92d50]" />
+            <span className="min-w-0 break-words">{nodeRun.errorMessage || nodeRun.failureReason}</span>
           </div>
         </section>
       ) : null}

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeAppend.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeAppend.tsx
@@ -30,13 +30,13 @@ const WorkflowNodeAppend = ({
       aria-hidden
       className={[
         'nodrag nopan pointer-events-none absolute inset-0 z-20',
-        'flex h-4 w-4 items-center justify-center rounded-full',
-        'bg-[#fe2c55] text-white shadow-[0_1px_3px_rgba(254,44,85,.22)]',
+        'flex h-4 w-4 items-center justify-center rounded-full border border-[#d0d5dd]',
+        'bg-white text-[#667085] shadow-[0_1px_3px_rgba(22,24,35,.10)]',
         'transition-opacity duration-150',
         selected || open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
       ].join(' ')}
     >
-      <Plus size={10} strokeWidth={2.4} />
+      <Plus size={10} strokeWidth={2.2} />
     </span>
   </WorkflowTaskPicker>
 );

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeHandle.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeHandle.tsx
@@ -60,9 +60,9 @@ const WorkflowNodeHandle = ({
         "after:absolute after:top-1 after:h-2 after:w-0.5 after:rounded-full after:content-['']",
         isTarget ? 'after:left-[7px]' : 'after:right-[7px]',
         selected || appendOpen
-          ? 'after:bg-[#fe2c55]'
-          : 'after:bg-[#c7c9ce] group-hover:after:bg-[#fe2c55]',
-        'transition-all duration-150 hover:scale-125 hover:after:bg-[#fe2c55]',
+          ? 'after:bg-[#667085]'
+          : 'after:bg-[#c7c9ce] group-hover:after:bg-[#667085]',
+        'transition-all duration-150 hover:scale-125 hover:after:bg-[#475467]',
       ].join(' ')}
     >
       {canAppend ? (

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -9,7 +9,6 @@ interface WorkflowNodeIconProps {
 
 interface NodeIconMeta {
   icon: ComponentType<SVGProps<SVGSVGElement>>;
-  className: string;
 }
 
 const DefaultNodeIcon = (props: SVGProps<SVGSVGElement>) => (
@@ -28,17 +27,14 @@ const DefaultNodeIcon = (props: SVGProps<SVGSVGElement>) => (
 
 const DEFAULT_ICON_META: NodeIconMeta = {
   icon: DefaultNodeIcon,
-  className: 'bg-[#f4f4f5] text-[#52525b]',
 };
 
 const NODE_ICON_META: Record<string, NodeIconMeta> = {
   SYNC: {
     icon: SyncNodeIcon,
-    className: 'bg-[rgba(254,44,85,.08)] text-[#fe2c55]',
   },
   SQL: {
     icon: SqlNodeIcon,
-    className: 'bg-[#f4f4f5] text-[#344054]',
   },
 };
 
@@ -51,13 +47,12 @@ const WorkflowNodeIcon = ({ taskType, size = 'md' }: WorkflowNodeIconProps) => {
   return (
     <span
       className={[
-        'flex shrink-0 items-center justify-center',
+        'flex shrink-0 items-center justify-center border border-[#eceef1] bg-[#fafafa] text-[#667085]',
         tiny
           ? 'h-6 w-6 rounded-[7px]'
           : compact
             ? 'h-7 w-7 rounded-[8px]'
             : 'h-9 w-9 rounded-[10px]',
-        meta.className,
       ].join(' ')}
     >
       <Icon

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartInspector.tsx
@@ -1,3 +1,4 @@
+import YakTab from '@/components/YakTab';
 import { getWorkflowInstances } from '@/services/workflow';
 import { Input, Modal, Select, Switch, message } from 'antd';
 import dayjs from 'dayjs';
@@ -49,6 +50,11 @@ const INPUT_TYPE_OPTIONS = [
   { value: 'BOOLEAN', label: 'Boolean' },
   { value: 'FILE', label: 'File' },
   { value: 'ARRAY_STRING', label: 'Array[String]' },
+];
+
+const START_INSPECTOR_TABS = [
+  { key: 'settings', label: '属性' },
+  { key: 'lastRun', label: '上次运行' },
 ];
 
 const VARIABLE_TYPE_OPTIONS = INPUT_TYPE_OPTIONS.filter((item) => item.value !== 'FILE');
@@ -226,18 +232,34 @@ const WorkflowStartInspector = ({
     { name: 'sys.workflowName', value: workflowName || '--' },
   ], [definitionId, workflowName]);
 
+  const lastRunStatus = lastRun?.status || '';
+  const lastRunStatusClassName = lastRunStatus === 'SUCCESS'
+    ? 'text-[#067647]'
+    : lastRunStatus === 'FAILED' || lastRunStatus === 'TIMED_OUT'
+      ? 'text-[#b42318]'
+      : lastRunStatus === 'RUNNING'
+        ? 'text-[#175cd3]'
+        : 'text-[#667085]';
+  const lastRunStatusDotClassName = lastRunStatus === 'SUCCESS'
+    ? 'bg-[#12b76a]'
+    : lastRunStatus === 'FAILED' || lastRunStatus === 'TIMED_OUT'
+      ? 'bg-[#f04438]'
+      : lastRunStatus === 'RUNNING'
+        ? 'bg-[#2e90fa]'
+        : 'bg-[#98a2b3]';
+
   const startStepIcon = (
-    <span className="flex h-6 w-6 items-center justify-center rounded-[6px] bg-[#155eef] text-white shadow-[0_1px_2px_rgba(21,94,239,.18)]">
-      <GitBranch size={14} strokeWidth={2.2} />
+    <span className="flex h-6 w-6 items-center justify-center rounded-[6px] border border-[#eceef1] bg-[#fafafa] text-[#667085]">
+      <GitBranch size={14} strokeWidth={2} />
     </span>
   );
 
   return (
     <aside className="absolute bottom-3 right-3 top-3 z-20 flex w-[400px] flex-col overflow-hidden rounded-2xl border border-[#e2e5e9] bg-white shadow-[0_12px_36px_rgba(22,24,35,.12)]">
-      <header className="shrink-0 border-b border-[#eceef1] bg-white">
+      <header className="shrink-0 bg-white">
         <div className="flex items-center gap-2 px-4 pb-2 pt-4">
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[#eaf2ff] text-[#155eef]">
-            <GitBranch size={15} strokeWidth={2.2} />
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-[#eceef1] bg-[#fafafa] text-[#667085]">
+            <GitBranch size={15} strokeWidth={2} />
           </span>
           <div className="min-w-0 flex-1 text-[14px] font-semibold text-[#161823]">开始</div>
           <button
@@ -252,22 +274,13 @@ const WorkflowStartInspector = ({
         <div className="px-4 pb-2 text-[11px] leading-5 text-[rgba(22,24,35,.36)]">
           定义工作流输入和可供后续所有节点引用的上下文变量。
         </div>
-        <nav className="flex h-10 items-end gap-5 px-4">
-          {(['settings', 'lastRun'] as TabKey[]).map((key) => (
-            <button
-              key={key}
-              type="button"
-              className={[
-                'relative h-10 border-0 bg-transparent px-0 text-[12px] font-semibold',
-                tab === key ? 'text-[#344054]' : 'text-[#667085] hover:text-[#344054]',
-              ].join(' ')}
-              onClick={() => setTab(key)}
-            >
-              {key === 'settings' ? '设置' : '上次运行'}
-              {tab === key ? <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-[#fe2c55]" /> : null}
-            </button>
-          ))}
-        </nav>
+        <div className="px-4">
+          <YakTab
+            activeKey={tab}
+            items={START_INSPECTOR_TABS}
+            onChange={(key) => setTab(key as TabKey)}
+          />
+        </div>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -295,7 +308,7 @@ const WorkflowStartInspector = ({
                     key={field.id}
                     className="group flex items-center gap-2 rounded-xl border border-[#e7e9ed] bg-white px-2.5 py-2 hover:bg-[#fafafa]"
                   >
-                    <Variable size={14} className="shrink-0 text-[#155eef]" />
+                    <Variable size={14} className="shrink-0 text-[#667085]" />
                     <button
                       type="button"
                       disabled={locked}
@@ -347,7 +360,7 @@ const WorkflowStartInspector = ({
               <div className="space-y-1.5">
                 {config.variables.map((variable) => (
                   <div key={variable.id} className="flex items-center gap-2 rounded-xl border border-[#e7e9ed] px-2.5 py-2">
-                    <Variable size={14} className="shrink-0 text-[#7f56d9]" />
+                    <Variable size={14} className="shrink-0 text-[#667085]" />
                     <button
                       type="button"
                       disabled={locked}
@@ -420,14 +433,17 @@ const WorkflowStartInspector = ({
             </div>
             {lastRun ? (
               <div className="space-y-4">
-                <div className="grid grid-cols-2 rounded-xl border border-[#f5c2cc] bg-[#fff6f8]">
+                <div className="grid grid-cols-2 rounded-xl border border-[#e4e7ec] bg-[#fafafa]">
                   <div className="px-3 py-2.5">
-                    <div className="text-[9px] text-[#667085]">状态</div>
-                    <div className="mt-1 text-[11px] font-semibold text-[#fe2c55]">{lastRun.status}</div>
+                    <div className="text-[9px] text-[#98a2b3]">状态</div>
+                    <div className={`mt-1 flex items-center gap-1.5 text-[11px] font-semibold ${lastRunStatusClassName}`}>
+                      <span className={`h-1.5 w-1.5 rounded-full ${lastRunStatusDotClassName}`} />
+                      {lastRun.status}
+                    </div>
                   </div>
-                  <div className="border-l border-[#f5c2cc] px-3 py-2.5">
-                    <div className="text-[9px] text-[#667085]">开始时间</div>
-                    <div className="mt-1 text-[11px] font-semibold text-[#344054]">{dayjs(lastRun.startedAt).format('YYYY-MM-DD HH:mm:ss')}</div>
+                  <div className="border-l border-[#e4e7ec] px-3 py-2.5">
+                    <div className="text-[9px] text-[#98a2b3]">开始时间</div>
+                    <div className="mt-1 text-[11px] font-semibold text-[#475467]">{dayjs(lastRun.startedAt).format('YYYY-MM-DD HH:mm:ss')}</div>
                   </div>
                 </div>
                 <div>

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartNode.tsx
@@ -34,8 +34,8 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
         ].join(' ')}
       >
         <div className="flex min-h-9 items-center gap-2.5 px-3 py-3">
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#eaf2ff] text-[#155eef]">
-            <GitBranch size={18} strokeWidth={2.2} />
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border border-[#eceef1] bg-[#fafafa] text-[#667085]">
+            <GitBranch size={18} strokeWidth={2} />
           </span>
           <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
             开始
@@ -61,7 +61,7 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
                   key={field.id}
                   className="flex h-6 items-center gap-1.5 rounded-md bg-[#f5f6f7] px-1.5 text-[10px]"
                 >
-                  <Variable size={12} className="shrink-0 text-[#155eef]" />
+                  <Variable size={12} className="shrink-0 text-[#667085]" />
                   <span className="min-w-0 flex-1 truncate text-[#475467]">{field.name}</span>
                   {field.required ? (
                     <span className="shrink-0 text-[9px] font-medium text-[#98a2b3]">必填</span>


### PR DESCRIPTION
## What changed

- Unify workflow task/start-node icon surfaces with a low-emphasis neutral treatment while preserving task-type glyphs.
- Replace the custom `属性 / 上次运行` tab switches in both task-node and start-node inspectors with the shared `YakTab` component.
- Tone down the last-run panel: status summaries now use neutral containers and keep semantic color only on the status text/dot.
- Tone down error presentation to a neutral container with a small error icon accent instead of a full red/pink surface.
- Neutralize node append/handle controls and start-node variable icons so selection/runtime state remains the main visual emphasis.

## Scope

UI-only workflow editor polish. Workflow execution, persistence, node configuration, and runtime behavior are unchanged.

## Verification

- Reviewed the branch diff against `main`; only the seven workflow-editor UI components are changed.
- The current execution environment cannot clone `github.com` due DNS/network restrictions, so a local frontend build was not run here. GitHub CI should be treated as the build/type-check source of truth for this draft.