### PR TITLE
style(workflow): refine editor accent and inspector behavior

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowCanvasTools.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowCanvasTools.tsx
@@ -45,7 +45,7 @@ interface CandidatePointer {
 const iconButtonClass = (active = false) => [
   'flex h-8 w-8 items-center justify-center rounded-md border-0 transition-colors',
   active
-    ? 'bg-[rgba(254,44,85,.08)] text-[#fe2c55]'
+    ? 'bg-[rgba(97,114,243,.10)] text-[#6172f3]'
     : 'bg-transparent text-[#667085] hover:bg-[#f2f4f7] hover:text-[#344054]',
 ].join(' ');
 
@@ -261,7 +261,6 @@ const WorkflowCanvasTools = <T,>({
       <style>{`
         .react-flow__controls { display: none !important; }
         .react-flow__minimap { right: 12px !important; bottom: 12px !important; transition: right 180ms ease; }
-        div:has(> aside) > .react-flow .react-flow__minimap { right: 424px !important; }
       `}</style>
 
       {candidateTask && candidatePointer ? (

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspector.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { Node } from 'reactflow';
 import type { WorkflowCanvasTaskOption, WorkflowNodeData } from './types';
+import useWorkflowInspectorBehavior from './useWorkflowInspectorBehavior';
 import WorkflowNodeIcon from './node/icons/WorkflowNodeIcon';
 import WorkflowNodeInspectorLastRun from './WorkflowNodeInspectorLastRun';
 import WorkflowNodeInspectorSettings from './WorkflowNodeInspectorSettings';
@@ -63,6 +64,7 @@ const WorkflowNodeInspector = ({
   onAppend,
 }: WorkflowNodeInspectorProps) => {
   const [activeTab, setActiveTab] = useState<InspectorTab>('settings');
+  const { panelWidth, resizing, handleResizePointerDown } = useWorkflowInspectorBehavior();
 
   useEffect(() => {
     setActiveTab('settings');
@@ -87,7 +89,26 @@ const WorkflowNodeInspector = ({
   ], [locked, onDelete, onDuplicate]);
 
   return (
-    <aside className="absolute bottom-0 right-0 top-0 z-20 flex w-[340px] flex-col overflow-hidden border-l border-[#e8eaee] bg-white">
+    <aside
+      className="absolute bottom-0 right-0 top-0 z-20 flex w-[340px] flex-col overflow-hidden border-l border-[#e8eaee] bg-white"
+      style={{ width: panelWidth }}
+    >
+      <div
+        role="separator"
+        aria-label="调整节点面板宽度"
+        aria-orientation="vertical"
+        aria-valuenow={Math.round(panelWidth)}
+        className="group/resize absolute left-0 top-0 z-30 flex h-full w-2 cursor-col-resize touch-none items-center justify-start"
+        onPointerDown={handleResizePointerDown}
+      >
+        <span
+          className={[
+            'h-full w-0.5 transition-colors duration-150',
+            resizing ? 'bg-[#6172f3]' : 'bg-transparent group-hover/resize:bg-[#6172f3]',
+          ].join(' ')}
+        />
+      </div>
+
       <header className="shrink-0 bg-white">
         <div className="flex h-12 items-center gap-2 border-b border-[#eef0f2] px-4">
           <WorkflowNodeIcon taskType={node.data.taskType} size="sm" />

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/edge/WorkflowEdge.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/edge/WorkflowEdge.tsx
@@ -22,7 +22,7 @@ const runtimeStroke = (status?: string) => {
       return '#f79009';
     case 'RUNNING':
     case 'RESUMING':
-      return '#fe2c55';
+      return '#6172f3';
     case 'SUCCESS':
       return '#12b76a';
     case 'FAILED':
@@ -70,7 +70,7 @@ const WorkflowEdge = ({
   const executionStroke = runtimeStroke(data?.runtimeStatus);
   const stroke = executionStroke
     || (highlighted
-      ? '#fe2c55'
+      ? '#6172f3'
       : hovered || insertOpen
         ? '#8a8f99'
         : '#cfd2d7');

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/edge/WorkflowEdgeInsert.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/edge/WorkflowEdgeInsert.tsx
@@ -31,7 +31,7 @@ const WorkflowEdgeInsert = ({
         'nodrag nopan flex h-6 w-6 items-center justify-center rounded-full',
         'border border-[#dfe1e5] bg-white text-[#667085]',
         'shadow-[0_1px_4px_rgba(22,24,35,.12)] transition-all duration-150',
-        'hover:scale-125 hover:border-[#fe2c55] hover:text-[#fe2c55]',
+        'hover:scale-125 hover:border-[#6172f3] hover:text-[#6172f3]',
         visible || open ? 'scale-100 opacity-100' : 'scale-90 opacity-0',
       ].join(' ')}
     >

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNode.tsx
@@ -45,8 +45,8 @@ const runtimeVisual = (status?: string): RuntimeVisual | undefined => {
     case 'RUNNING':
     case 'RESUMING':
       return {
-        borderClassName: 'border-[#fe2c55] shadow-[0_0_0_3px_rgba(254,44,85,.08)]',
-        badgeClassName: 'bg-[#fff1f3] text-[#d92d50]',
+        borderClassName: 'border-[#6172f3] shadow-[0_0_0_3px_rgba(97,114,243,.10)]',
+        badgeClassName: 'bg-[#eef0ff] text-[#4754c8]',
         icon: <LoaderCircle size={11} className="animate-spin" />,
       };
     case 'PAUSING':
@@ -124,9 +124,9 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
           runtimeActive ? '' : 'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
           visual?.borderClassName
             || (selected
-              ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.06)]'
+              ? 'border-[#6172f3] shadow-[0_0_0_2px_rgba(97,114,243,.10)]'
               : 'border-[#e8e9ec] group-hover:border-[#d7d9de]'),
-          selected && visual ? 'ring-1 ring-[rgba(254,44,85,.18)]' : '',
+          selected && visual ? 'ring-1 ring-[rgba(97,114,243,.22)]' : '',
         ].join(' ')}
       >
         <div className="flex min-h-9 items-center gap-2.5">

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeAppend.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeAppend.tsx
@@ -30,13 +30,13 @@ const WorkflowNodeAppend = ({
       aria-hidden
       className={[
         'nodrag nopan pointer-events-none absolute inset-0 z-20',
-        'flex h-4 w-4 items-center justify-center rounded-full border border-[#d0d5dd]',
-        'bg-white text-[#667085] shadow-[0_1px_3px_rgba(22,24,35,.10)]',
+        'flex h-4 w-4 items-center justify-center rounded-full',
+        'bg-[#6172f3] text-white shadow-[0_1px_3px_rgba(97,114,243,.28)]',
         'transition-opacity duration-150',
         selected || open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
       ].join(' ')}
     >
-      <Plus size={10} strokeWidth={2.2} />
+      <Plus size={10} strokeWidth={2.4} />
     </span>
   </WorkflowTaskPicker>
 );

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeHandle.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeHandle.tsx
@@ -60,9 +60,9 @@ const WorkflowNodeHandle = ({
         "after:absolute after:top-1 after:h-2 after:w-0.5 after:rounded-full after:content-['']",
         isTarget ? 'after:left-[7px]' : 'after:right-[7px]',
         selected || appendOpen
-          ? 'after:bg-[#667085]'
-          : 'after:bg-[#c7c9ce] group-hover:after:bg-[#667085]',
-        'transition-all duration-150 hover:scale-125 hover:after:bg-[#475467]',
+          ? 'after:bg-[#6172f3]'
+          : 'after:bg-[#c7c9ce] group-hover:after:bg-[#6172f3]',
+        'transition-all duration-150 hover:scale-125 hover:after:bg-[#4754c8]',
       ].join(' ')}
     >
       {canAppend ? (

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -47,7 +47,8 @@ const WorkflowNodeIcon = ({ taskType, size = 'md' }: WorkflowNodeIconProps) => {
   return (
     <span
       className={[
-        'flex shrink-0 items-center justify-center border border-[#eceef1] bg-[#fafafa] text-[#667085]',
+        'flex shrink-0 items-center justify-center bg-[#6172f3] text-white',
+        'shadow-[0_1px_2px_rgba(97,114,243,.22)]',
         tiny
           ? 'h-6 w-6 rounded-[7px]'
           : compact

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartInspector.tsx
@@ -6,6 +6,7 @@ import { GitBranch, Plus, RefreshCw, Trash2, Variable, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import WorkflowNextStep from '../WorkflowNextStep';
 import type { WorkflowCanvasTaskOption } from '../types';
+import useWorkflowInspectorBehavior from '../useWorkflowInspectorBehavior';
 import type {
   WorkflowStartConfig,
   WorkflowStartInputField,
@@ -119,6 +120,7 @@ const WorkflowStartInspector = ({
   const [draft, setDraft] = useState<EditorDraft>(newDraft());
   const [lastRunLoading, setLastRunLoading] = useState(false);
   const [lastRun, setLastRun] = useState<Awaited<ReturnType<typeof getWorkflowInstances>>[number]>();
+  const { panelWidth, resizing, handleResizePointerDown } = useWorkflowInspectorBehavior();
 
   const loadLastRun = useCallback(async () => {
     setLastRunLoading(true);
@@ -249,17 +251,36 @@ const WorkflowStartInspector = ({
         : 'bg-[#98a2b3]';
 
   const startStepIcon = (
-    <span className="flex h-6 w-6 items-center justify-center rounded-[6px] border border-[#eceef1] bg-[#fafafa] text-[#667085]">
-      <GitBranch size={14} strokeWidth={2} />
+    <span className="flex h-6 w-6 items-center justify-center rounded-[6px] bg-[#6172f3] text-white shadow-[0_1px_2px_rgba(97,114,243,.22)]">
+      <GitBranch size={14} strokeWidth={2.1} />
     </span>
   );
 
   return (
-    <aside className="absolute bottom-3 right-3 top-3 z-20 flex w-[400px] flex-col overflow-hidden rounded-2xl border border-[#e2e5e9] bg-white shadow-[0_12px_36px_rgba(22,24,35,.12)]">
+    <aside
+      className="absolute bottom-3 right-3 top-3 z-20 flex w-[400px] flex-col overflow-hidden rounded-2xl border border-[#e2e5e9] bg-white shadow-[0_12px_36px_rgba(22,24,35,.12)]"
+      style={{ width: panelWidth }}
+    >
+      <div
+        role="separator"
+        aria-label="调整开始节点面板宽度"
+        aria-orientation="vertical"
+        aria-valuenow={Math.round(panelWidth)}
+        className="group/resize absolute left-0 top-0 z-30 flex h-full w-2 cursor-col-resize touch-none items-center justify-start"
+        onPointerDown={handleResizePointerDown}
+      >
+        <span
+          className={[
+            'h-full w-0.5 transition-colors duration-150',
+            resizing ? 'bg-[#6172f3]' : 'bg-transparent group-hover/resize:bg-[#6172f3]',
+          ].join(' ')}
+        />
+      </div>
+
       <header className="shrink-0 bg-white">
         <div className="flex items-center gap-2 px-4 pb-2 pt-4">
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-[#eceef1] bg-[#fafafa] text-[#667085]">
-            <GitBranch size={15} strokeWidth={2} />
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[#6172f3] text-white shadow-[0_1px_2px_rgba(97,114,243,.22)]">
+            <GitBranch size={15} strokeWidth={2.1} />
           </span>
           <div className="min-w-0 flex-1 text-[14px] font-semibold text-[#161823]">开始</div>
           <button
@@ -308,7 +329,7 @@ const WorkflowStartInspector = ({
                     key={field.id}
                     className="group flex items-center gap-2 rounded-xl border border-[#e7e9ed] bg-white px-2.5 py-2 hover:bg-[#fafafa]"
                   >
-                    <Variable size={14} className="shrink-0 text-[#667085]" />
+                    <Variable size={14} className="shrink-0 text-[#6172f3]" />
                     <button
                       type="button"
                       disabled={locked}
@@ -360,7 +381,7 @@ const WorkflowStartInspector = ({
               <div className="space-y-1.5">
                 {config.variables.map((variable) => (
                   <div key={variable.id} className="flex items-center gap-2 rounded-xl border border-[#e7e9ed] px-2.5 py-2">
-                    <Variable size={14} className="shrink-0 text-[#667085]" />
+                    <Variable size={14} className="shrink-0 text-[#6172f3]" />
                     <button
                       type="button"
                       disabled={locked}

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/start/WorkflowStartNode.tsx
@@ -25,23 +25,23 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
           'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
           'transition-[border-color,box-shadow] duration-200',
           running
-            ? 'border-[#fe2c55] shadow-[0_0_0_3px_rgba(254,44,85,.08)]'
+            ? 'border-[#6172f3] shadow-[0_0_0_3px_rgba(97,114,243,.10)]'
             : succeeded
               ? 'border-[#12b76a] shadow-[0_0_0_2px_rgba(18,183,106,.07)]'
               : selected
-                ? 'border-[#fe2c55] shadow-[0_0_0_2px_rgba(254,44,85,.08)]'
+                ? 'border-[#6172f3] shadow-[0_0_0_2px_rgba(97,114,243,.10)]'
                 : 'border-[#e8e9ec] group-hover:border-[#d7d9de] group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
         ].join(' ')}
       >
         <div className="flex min-h-9 items-center gap-2.5 px-3 py-3">
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border border-[#eceef1] bg-[#fafafa] text-[#667085]">
-            <GitBranch size={18} strokeWidth={2} />
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#6172f3] text-white shadow-[0_1px_2px_rgba(97,114,243,.22)]">
+            <GitBranch size={18} strokeWidth={2.1} />
           </span>
           <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">
             开始
           </div>
           {running ? (
-            <span className="inline-flex h-6 items-center gap-1 rounded-md bg-[#fff1f3] px-1.5 text-[10px] font-medium text-[#d92d50]">
+            <span className="inline-flex h-6 items-center gap-1 rounded-md bg-[#eef0ff] px-1.5 text-[10px] font-medium text-[#4754c8]">
               <LoaderCircle size={11} className="animate-spin" />
               运行中
             </span>
@@ -61,7 +61,7 @@ const WorkflowStartNode = ({ id, data, selected }: NodeProps<WorkflowStartNodeDa
                   key={field.id}
                   className="flex h-6 items-center gap-1.5 rounded-md bg-[#f5f6f7] px-1.5 text-[10px]"
                 >
-                  <Variable size={12} className="shrink-0 text-[#667085]" />
+                  <Variable size={12} className="shrink-0 text-[#6172f3]" />
                   <span className="min-w-0 flex-1 truncate text-[#475467]">{field.name}</span>
                   {field.required ? (
                     <span className="shrink-0 text-[9px] font-medium text-[#98a2b3]">必填</span>

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
@@ -1,0 +1,91 @@
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DEFAULT_PANEL_WIDTH = 380;
+const MIN_PANEL_WIDTH = 320;
+const MAX_PANEL_WIDTH = 640;
+const MIN_CANVAS_WIDTH = 360;
+const PANEL_WIDTH_STORAGE_KEY = 'yak.workflow.inspector.width';
+
+const readStoredPanelWidth = (fallback: number) => {
+  if (typeof window === 'undefined') return fallback;
+  const value = Number(window.localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, value));
+};
+
+const useWorkflowInspectorBehavior = (defaultWidth = DEFAULT_PANEL_WIDTH) => {
+  const [panelWidth, setPanelWidth] = useState(() => readStoredPanelWidth(defaultWidth));
+  const [resizing, setResizing] = useState(false);
+  const cleanupResizeRef = useRef<() => void>();
+
+  useEffect(() => {
+    const keepInspectorOpen = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element) || !target.closest('.react-flow__pane')) return;
+
+      // React Flow clears node selection when the pane receives a click. The workflow
+      // inspector intentionally behaves like Dify: clicking empty canvas keeps the
+      // current inspector open, and only its explicit close button dismisses it.
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    };
+
+    document.addEventListener('click', keepInspectorOpen, true);
+    return () => document.removeEventListener('click', keepInspectorOpen, true);
+  }, []);
+
+  useEffect(() => () => cleanupResizeRef.current?.(), []);
+
+  const handleResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    cleanupResizeRef.current?.();
+
+    const startX = event.clientX;
+    const startWidth = panelWidth;
+    const flowBounds = document.querySelector('.react-flow')?.getBoundingClientRect();
+    const maxWidth = flowBounds
+      ? Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, flowBounds.width - MIN_CANVAS_WIDTH))
+      : MAX_PANEL_WIDTH;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const nextWidth = startWidth + startX - moveEvent.clientX;
+      setPanelWidth(Math.min(maxWidth, Math.max(MIN_PANEL_WIDTH, nextWidth)));
+    };
+
+    const cleanup = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', cleanup);
+      window.removeEventListener('pointercancel', cleanup);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      setResizing(false);
+      cleanupResizeRef.current = undefined;
+      window.localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(Math.round(panelWidth)));
+    };
+
+    cleanupResizeRef.current = cleanup;
+    setResizing(true);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', cleanup);
+    window.addEventListener('pointercancel', cleanup);
+  }, [panelWidth]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(Math.round(panelWidth)));
+  }, [panelWidth]);
+
+  return {
+    panelWidth,
+    resizing,
+    handleResizePointerDown,
+  };
+};
+
+export default useWorkflowInspectorBehavior;

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
@@ -9,7 +9,9 @@ const PANEL_WIDTH_STORAGE_KEY = 'yak.workflow.inspector.width';
 
 const readStoredPanelWidth = (fallback: number) => {
   if (typeof window === 'undefined') return fallback;
-  const value = Number(window.localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
+  const stored = window.localStorage.getItem(PANEL_WIDTH_STORAGE_KEY);
+  if (!stored) return fallback;
+  const value = Number(stored);
   if (!Number.isFinite(value)) return fallback;
   return Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, value));
 };

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
@@ -17,7 +17,7 @@ const readStoredPanelWidth = (fallback: number) => {
 const useWorkflowInspectorBehavior = (defaultWidth = DEFAULT_PANEL_WIDTH) => {
   const [panelWidth, setPanelWidth] = useState(() => readStoredPanelWidth(defaultWidth));
   const [resizing, setResizing] = useState(false);
-  const cleanupResizeRef = useRef<() => void>();
+  const cleanupResizeRef = useRef<(() => void) | undefined>(undefined);
 
   useEffect(() => {
     const keepInspectorOpen = (event: MouseEvent) => {
@@ -36,6 +36,14 @@ const useWorkflowInspectorBehavior = (defaultWidth = DEFAULT_PANEL_WIDTH) => {
   }, []);
 
   useEffect(() => () => cleanupResizeRef.current?.(), []);
+
+  useEffect(() => {
+    const miniMap = document.querySelector('.react-flow__minimap');
+    if (!(miniMap instanceof HTMLElement)) return undefined;
+
+    miniMap.style.setProperty('right', `${Math.round(panelWidth) + 24}px`, 'important');
+    return () => miniMap.style.removeProperty('right');
+  }, [panelWidth]);
 
   const handleResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -64,7 +72,6 @@ const useWorkflowInspectorBehavior = (defaultWidth = DEFAULT_PANEL_WIDTH) => {
       document.body.style.userSelect = previousUserSelect;
       setResizing(false);
       cleanupResizeRef.current = undefined;
-      window.localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(Math.round(panelWidth)));
     };
 
     cleanupResizeRef.current = cleanup;
@@ -77,7 +84,6 @@ const useWorkflowInspectorBehavior = (defaultWidth = DEFAULT_PANEL_WIDTH) => {
   }, [panelWidth]);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
     window.localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(Math.round(panelWidth)));
   }, [panelWidth]);
 


### PR DESCRIPTION
## What changed

- Bring a controlled Dify-like accent back into the workflow editor: node/start icons now use one indigo surface with white glyphs, and selected/running nodes, handles, append controls, edges, and active canvas tools share the same accent family.
- Keep the inspector open when clicking empty canvas. React Flow's pane-selection reset is intercepted while an inspector is mounted, so the panel is dismissed only through its explicit close button (clicking another configurable node still switches the inspector target normally).
- Make both task-node and start-node inspectors horizontally resizable from their left edge, with a 320–640 px range, a minimum usable canvas width, persisted panel width, and MiniMap offset that follows the resized panel.

## Scope

Frontend-only workflow editor polish. Workflow execution, persistence, node contracts, and backend behavior are unchanged.

## Verification

- Branch is based on the latest `main` after PR #959 and is not behind it.
- Reviewed the compare diff: changes are isolated to workflow-editor canvas/inspector UI plus one shared inspector behavior hook.
- The current execution environment cannot resolve `github.com` for a local repository clone, so the full frontend build was not run locally. GitHub CI should be treated as the build/type-check source of truth for this draft.