### PR TITLE
feat(audit): explain project authorization decisions

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectAuthorizationAuditBridge.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectAuthorizationAuditBridge.java
@@ -1,0 +1,89 @@
+package io.yak.ops.boot.project;
+
+import io.yak.ops.business.audit.AuditAuthorizationDecision;
+import io.yak.ops.business.audit.BusinessAuditService;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/** Adapts Project Space access facts to the shared, fail-open authorization audit contract. */
+@Component
+public class ProjectAuthorizationAuditBridge {
+
+  static final String PERMISSION = "PROJECT_ACCESS";
+  static final String RESOURCE_TYPE = "PROJECT";
+
+  private static final Logger log = LoggerFactory.getLogger(ProjectAuthorizationAuditBridge.class);
+
+  private final ObjectProvider<BusinessAuditService> auditServiceProvider;
+
+  public ProjectAuthorizationAuditBridge(ObjectProvider<BusinessAuditService> auditServiceProvider) {
+    this.auditServiceProvider = auditServiceProvider;
+  }
+
+  public void beginRequest() {
+    BusinessAuditService auditService = auditService();
+    if (auditService == null) return;
+    safe(auditService::clearAuthorizationDecisions);
+  }
+
+  public void allowed(Long projectId, String projectName, String reasonCode) {
+    BusinessAuditService auditService = auditService();
+    if (auditService == null) return;
+    safe(
+        () ->
+            auditService.authorizationDecision(
+                AuditAuthorizationDecision.allow(
+                    PERMISSION,
+                    reasonCode,
+                    RESOURCE_TYPE,
+                    resourceId(projectId),
+                    projectName,
+                    Map.of("scope", "PROJECT_SPACE"))));
+  }
+
+  public void denied(Long projectId, String reasonCode) {
+    BusinessAuditService auditService = auditService();
+    if (auditService == null) return;
+    safe(
+        () ->
+            auditService.authorizationDecision(
+                AuditAuthorizationDecision.deny(
+                    PERMISSION,
+                    reasonCode,
+                    RESOURCE_TYPE,
+                    resourceId(projectId),
+                    null,
+                    Map.of("scope", "PROJECT_SPACE"))));
+  }
+
+  /** Drops an ALLOW decision if no business AuditOperation claimed it during this request. */
+  public void endRequest() {
+    BusinessAuditService auditService = auditService();
+    if (auditService == null) return;
+    safe(auditService::clearAuthorizationDecisions);
+  }
+
+  private BusinessAuditService auditService() {
+    try {
+      return auditServiceProvider.getIfAvailable();
+    } catch (RuntimeException exception) {
+      log.warn("Unable to resolve audit runtime; Project access semantics are unchanged", exception);
+      return null;
+    }
+  }
+
+  private String resourceId(Long projectId) {
+    return projectId == null || projectId <= 0L ? null : String.valueOf(projectId);
+  }
+
+  private void safe(Runnable action) {
+    try {
+      action.run();
+    } catch (RuntimeException exception) {
+      log.warn("Project authorization audit failed; Project access semantics are unchanged", exception);
+    }
+  }
+}

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectScopeInterceptor.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/ProjectScopeInterceptor.java
@@ -2,6 +2,7 @@ package io.yak.ops.boot.project;
 
 import io.yak.framework.security.extend.CurrentUserProvider;
 import io.yak.ops.core.project.ProjectAccessGuard;
+import io.yak.ops.core.project.ProjectAuthorizationReason;
 import io.yak.ops.core.project.ProjectContext;
 import io.yak.ops.core.project.ProjectContextError;
 import io.yak.ops.core.project.ProjectContextException;
@@ -23,18 +24,22 @@ public class ProjectScopeInterceptor implements HandlerInterceptor {
   private final ProjectContextRuntime currentProject;
   private final ProjectAccessGuard accessGuard;
   private final CurrentUserProvider currentUserProvider;
+  private final ProjectAuthorizationAuditBridge authorizationAudit;
 
   public ProjectScopeInterceptor(
       ProjectContextRuntime currentProject,
       ProjectAccessGuard accessGuard,
-      CurrentUserProvider currentUserProvider) {
+      CurrentUserProvider currentUserProvider,
+      ProjectAuthorizationAuditBridge authorizationAudit) {
     this.currentProject = currentProject;
     this.accessGuard = accessGuard;
     this.currentUserProvider = currentUserProvider;
+    this.authorizationAudit = authorizationAudit;
   }
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    authorizationAudit.beginRequest();
     currentProject.clear();
     if (!(handler instanceof HandlerMethod handlerMethod)) {
       return true;
@@ -74,7 +79,11 @@ public class ProjectScopeInterceptor implements HandlerInterceptor {
       HttpServletResponse response,
       Object handler,
       Exception exception) {
-    currentProject.clear();
+    try {
+      authorizationAudit.endRequest();
+    } finally {
+      currentProject.clear();
+    }
   }
 
   ProjectMigrationMode resolveMode(HandlerMethod handlerMethod) {
@@ -92,6 +101,7 @@ public class ProjectScopeInterceptor implements HandlerInterceptor {
   private Long parseProjectId(String rawProjectId, ProjectMigrationMode mode) {
     if (!StringUtils.hasText(rawProjectId)) {
       if (mode == ProjectMigrationMode.PROJECT_REQUIRED) {
+        authorizationAudit.denied(null, ProjectAuthorizationReason.PROJECT_REQUIRED.name());
         throw new ProjectContextException(ProjectContextError.PROJECT_REQUIRED);
       }
       return null;
@@ -104,6 +114,7 @@ public class ProjectScopeInterceptor implements HandlerInterceptor {
       }
       return projectId;
     } catch (NumberFormatException exception) {
+      authorizationAudit.denied(null, ProjectAuthorizationReason.PROJECT_ID_INVALID.name());
       throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND, exception);
     }
   }

--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/project/YakSecurityProjectAccessGuard.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/project/YakSecurityProjectAccessGuard.java
@@ -5,6 +5,7 @@ import io.yak.framework.security.common.vo.user.UserBriefVO;
 import io.yak.framework.security.service.ProjectService;
 import io.yak.framework.security.service.UserService;
 import io.yak.ops.core.project.ProjectAccessGuard;
+import io.yak.ops.core.project.ProjectAuthorizationReason;
 import io.yak.ops.core.project.ProjectContext;
 import io.yak.ops.core.project.ProjectContextError;
 import io.yak.ops.core.project.ProjectContextException;
@@ -20,47 +21,83 @@ public class YakSecurityProjectAccessGuard implements ProjectAccessGuard {
 
   private final ProjectService projectService;
   private final UserService userService;
+  private final ProjectAuthorizationAuditBridge authorizationAudit;
 
-  public YakSecurityProjectAccessGuard(ProjectService projectService, UserService userService) {
+  public YakSecurityProjectAccessGuard(
+      ProjectService projectService,
+      UserService userService,
+      ProjectAuthorizationAuditBridge authorizationAudit) {
     this.projectService = projectService;
     this.userService = userService;
+    this.authorizationAudit = authorizationAudit;
   }
 
   @Override
   public ProjectContext requireAccessible(Long projectId, String username) {
     if (projectId == null || projectId <= 0 || !StringUtils.hasText(username)) {
-      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      authorizationAudit.denied(
+          projectId, ProjectAuthorizationReason.PROJECT_ACCESS_INPUT_INVALID.name());
+      throw hiddenNotFound();
     }
 
     if (!projectService.checkProjectExist(projectId)) {
-      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      authorizationAudit.denied(projectId, ProjectAuthorizationReason.PROJECT_NOT_FOUND.name());
+      throw hiddenNotFound();
     }
 
     UserBriefVO user = userService.getUserBriefByUsername(username);
     if (user == null || user.getId() == null) {
-      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+      authorizationAudit.denied(projectId, ProjectAuthorizationReason.PROJECT_ACTOR_NOT_FOUND.name());
+      throw hiddenNotFound();
     }
 
     ProjectVO project = projectService.getProjectDetailByProjectId(projectId);
-    if (!isMember(project, user.getId())) {
-      // Deliberately return the same outward error as a missing project to avoid project-ID enumeration.
-      throw new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+    if (project == null || project.getId() == null) {
+      authorizationAudit.denied(projectId, ProjectAuthorizationReason.PROJECT_NOT_FOUND.name());
+      throw hiddenNotFound();
+    }
+
+    AccessPath accessPath = accessPath(project, user.getId());
+    if (accessPath == null) {
+      authorizationAudit.denied(
+          projectId, ProjectAuthorizationReason.PROJECT_MEMBERSHIP_REQUIRED.name());
+      // Keep the outward error identical to a missing project to prevent Project ID enumeration.
+      throw hiddenNotFound();
     }
 
     if (!Boolean.TRUE.equals(project.getRunning())) {
+      authorizationAudit.denied(projectId, ProjectAuthorizationReason.PROJECT_UNAVAILABLE.name());
       throw new ProjectContextException(ProjectContextError.PROJECT_UNAVAILABLE);
     }
 
+    authorizationAudit.allowed(
+        projectId,
+        project.getProjectName(),
+        (accessPath == AccessPath.OWNER
+                ? ProjectAuthorizationReason.PROJECT_OWNER_ACCESS_ALLOWED
+                : ProjectAuthorizationReason.PROJECT_MEMBER_ACCESS_ALLOWED)
+            .name());
     return new ProjectContext(project.getId(), project.getProjectName());
   }
 
-  private boolean isMember(ProjectVO project, Long userId) {
-    return containsUser(project == null ? null : project.getOwnerList(), userId)
-        || containsUser(project == null ? null : project.getUserList(), userId);
+  private ProjectContextException hiddenNotFound() {
+    return new ProjectContextException(ProjectContextError.PROJECT_NOT_FOUND);
+  }
+
+  private AccessPath accessPath(ProjectVO project, Long userId) {
+    if (containsUser(project.getOwnerList(), userId)) {
+      return AccessPath.OWNER;
+    }
+    return containsUser(project.getUserList(), userId) ? AccessPath.MEMBER : null;
   }
 
   private boolean containsUser(List<UserBriefVO> users, Long userId) {
     List<UserBriefVO> safeUsers = users == null ? Collections.emptyList() : users;
     return safeUsers.stream().anyMatch(user -> Objects.equals(userId, user.getId()));
+  }
+
+  private enum AccessPath {
+    OWNER,
+    MEMBER
   }
 }

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectAuthorizationAuditBridgeTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectAuthorizationAuditBridgeTest.java
@@ -1,0 +1,77 @@
+package io.yak.ops.boot.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.audit.AuditAuthorizationDecision;
+import io.yak.ops.business.audit.BusinessAuditService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+
+class ProjectAuthorizationAuditBridgeTest {
+
+  @Test
+  void translatesProjectAllowAndDenyWithoutPuttingUsernameIntoPayload() {
+    BusinessAuditService auditService = mock(BusinessAuditService.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<BusinessAuditService> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(auditService);
+    ProjectAuthorizationAuditBridge bridge = new ProjectAuthorizationAuditBridge(provider);
+
+    bridge.allowed(7L, "Project A", "PROJECT_OWNER_ACCESS_ALLOWED");
+    bridge.denied(8L, "PROJECT_MEMBERSHIP_REQUIRED");
+
+    ArgumentCaptor<AuditAuthorizationDecision> captor =
+        ArgumentCaptor.forClass(AuditAuthorizationDecision.class);
+    verify(auditService, times(2)).authorizationDecision(captor.capture());
+
+    AuditAuthorizationDecision allow = captor.getAllValues().get(0);
+    assertThat(allow.permission()).isEqualTo(ProjectAuthorizationAuditBridge.PERMISSION);
+    assertThat(allow.allowed()).isTrue();
+    assertThat(allow.resourceType()).isEqualTo(ProjectAuthorizationAuditBridge.RESOURCE_TYPE);
+    assertThat(allow.resourceId()).isEqualTo("7");
+    assertThat(allow.resourceName()).isEqualTo("Project A");
+    assertThat(allow.attributes().get("scope")).isEqualTo("PROJECT_SPACE");
+
+    AuditAuthorizationDecision deny = captor.getAllValues().get(1);
+    assertThat(deny.allowed()).isFalse();
+    assertThat(deny.resourceId()).isEqualTo("8");
+    assertThat(deny.reasonCode()).isEqualTo("PROJECT_MEMBERSHIP_REQUIRED");
+  }
+
+  @Test
+  void requestLifecycleClearsDeferredAuthorizationStateAtBothBoundaries() {
+    BusinessAuditService auditService = mock(BusinessAuditService.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<BusinessAuditService> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(auditService);
+    ProjectAuthorizationAuditBridge bridge = new ProjectAuthorizationAuditBridge(provider);
+
+    bridge.beginRequest();
+    bridge.endRequest();
+
+    verify(auditService, times(2)).clearAuthorizationDecisions();
+  }
+
+  @Test
+  void missingAuditRuntimeNeverBreaksProjectAccess() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<BusinessAuditService> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(null);
+    ProjectAuthorizationAuditBridge bridge = new ProjectAuthorizationAuditBridge(provider);
+
+    assertThatCode(
+            () -> {
+              bridge.beginRequest();
+              bridge.allowed(7L, "Project A", "PROJECT_MEMBER_ACCESS_ALLOWED");
+              bridge.denied(7L, "PROJECT_MEMBERSHIP_REQUIRED");
+              bridge.endRequest();
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectScopeInterceptorTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/ProjectScopeInterceptorTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.yak.framework.security.extend.CurrentUserProvider;
 import io.yak.ops.core.project.ProjectAccessGuard;
+import io.yak.ops.core.project.ProjectAuthorizationReason;
 import io.yak.ops.core.project.ProjectContext;
 import io.yak.ops.core.project.ProjectContextError;
 import io.yak.ops.core.project.ProjectContextException;
@@ -27,6 +29,7 @@ class ProjectScopeInterceptorTest {
   private ProjectContextRuntime currentProject;
   private ProjectAccessGuard accessGuard;
   private CurrentUserProvider currentUserProvider;
+  private ProjectAuthorizationAuditBridge authorizationAudit;
   private ProjectScopeInterceptor interceptor;
 
   @BeforeEach
@@ -34,7 +37,10 @@ class ProjectScopeInterceptorTest {
     currentProject = new ProjectContextRuntime();
     accessGuard = mock(ProjectAccessGuard.class);
     currentUserProvider = mock(CurrentUserProvider.class);
-    interceptor = new ProjectScopeInterceptor(currentProject, accessGuard, currentUserProvider);
+    authorizationAudit = mock(ProjectAuthorizationAuditBridge.class);
+    interceptor =
+        new ProjectScopeInterceptor(
+            currentProject, accessGuard, currentUserProvider, authorizationAudit);
   }
 
   @Test
@@ -45,6 +51,7 @@ class ProjectScopeInterceptorTest {
 
     assertFalse(currentProject.isPresent());
     verifyNoInteractions(accessGuard, currentUserProvider);
+    verify(authorizationAudit).beginRequest();
   }
 
   @Test
@@ -64,12 +71,31 @@ class ProjectScopeInterceptorTest {
     ProjectContextException error =
         assertThrows(
             ProjectContextException.class,
-            () -> interceptor.preHandle(
-                request,
-                new MockHttpServletResponse(),
-                handler("required")));
+            () ->
+                interceptor.preHandle(
+                    request, new MockHttpServletResponse(), handler("required")));
 
     assertEquals(ProjectContextError.PROJECT_REQUIRED, error.getError());
+    verify(authorizationAudit)
+        .denied(null, ProjectAuthorizationReason.PROJECT_REQUIRED.name());
+    verifyNoInteractions(accessGuard);
+  }
+
+  @Test
+  void invalidProjectHeaderIsAuditedWithoutPersistingRawInput() throws Exception {
+    MockHttpServletRequest request = requestWithProject("not-a-project-id");
+    when(currentUserProvider.getCurrentUser(request)).thenReturn("alice");
+
+    ProjectContextException error =
+        assertThrows(
+            ProjectContextException.class,
+            () ->
+                interceptor.preHandle(
+                    request, new MockHttpServletResponse(), handler("required")));
+
+    assertEquals(ProjectContextError.PROJECT_NOT_FOUND, error.getError());
+    verify(authorizationAudit)
+        .denied(null, ProjectAuthorizationReason.PROJECT_ID_INVALID.name());
     verifyNoInteractions(accessGuard);
   }
 
@@ -84,7 +110,7 @@ class ProjectScopeInterceptorTest {
   }
 
   @Test
-  void bindsAuthorizedProjectAndClearsItAfterRequest() throws Exception {
+  void bindsAuthorizedProjectAndClearsRequestContextsAfterCompletion() throws Exception {
     MockHttpServletRequest request = requestWithProject("7");
     when(currentUserProvider.getCurrentUser(request)).thenReturn("alice");
     when(accessGuard.requireAccessible(7L, "alice"))
@@ -95,6 +121,8 @@ class ProjectScopeInterceptorTest {
 
     interceptor.afterCompletion(
         request, new MockHttpServletResponse(), handler("required"), null);
+
+    verify(authorizationAudit).endRequest();
     assertFalse(currentProject.isPresent());
   }
 
@@ -111,15 +139,12 @@ class ProjectScopeInterceptorTest {
 
   private static class TestController {
 
-    void legacy() {
-    }
+    void legacy() {}
 
     @ProjectScope(ProjectMigrationMode.PROJECT_OPTIONAL)
-    void optional() {
-    }
+    void optional() {}
 
     @ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)
-    void required() {
-    }
+    void required() {}
   }
 }

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/project/YakSecurityProjectAccessGuardTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/project/YakSecurityProjectAccessGuardTest.java
@@ -1,0 +1,140 @@
+package io.yak.ops.boot.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.framework.security.common.vo.project.ProjectVO;
+import io.yak.framework.security.common.vo.user.UserBriefVO;
+import io.yak.framework.security.service.ProjectService;
+import io.yak.framework.security.service.UserService;
+import io.yak.ops.core.project.ProjectAuthorizationReason;
+import io.yak.ops.core.project.ProjectContext;
+import io.yak.ops.core.project.ProjectContextError;
+import io.yak.ops.core.project.ProjectContextException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class YakSecurityProjectAccessGuardTest {
+
+  private ProjectService projectService;
+  private UserService userService;
+  private ProjectAuthorizationAuditBridge authorizationAudit;
+  private YakSecurityProjectAccessGuard guard;
+
+  @BeforeEach
+  void setUp() {
+    projectService = mock(ProjectService.class);
+    userService = mock(UserService.class);
+    authorizationAudit = mock(ProjectAuthorizationAuditBridge.class);
+    guard = new YakSecurityProjectAccessGuard(projectService, userService, authorizationAudit);
+  }
+
+  @Test
+  void ownerAccessIsAllowedWithStableReasonCode() {
+    UserBriefVO user = user(11L);
+    ProjectVO project = project(7L, "Project A", true, List.of(user), List.of());
+    stubExistingProject(user, project);
+
+    ProjectContext context = guard.requireAccessible(7L, "alice");
+
+    assertThat(context.projectId()).isEqualTo(7L);
+    assertThat(context.projectName()).isEqualTo("Project A");
+    verify(authorizationAudit)
+        .allowed(
+            7L,
+            "Project A",
+            ProjectAuthorizationReason.PROJECT_OWNER_ACCESS_ALLOWED.name());
+  }
+
+  @Test
+  void memberAccessIsAllowedWithDifferentStableReasonCode() {
+    UserBriefVO user = user(11L);
+    ProjectVO project = project(7L, "Project A", true, List.of(), List.of(user));
+    stubExistingProject(user, project);
+
+    guard.requireAccessible(7L, "alice");
+
+    verify(authorizationAudit)
+        .allowed(
+            7L,
+            "Project A",
+            ProjectAuthorizationReason.PROJECT_MEMBER_ACCESS_ALLOWED.name());
+  }
+
+  @Test
+  void membershipDenialKeepsOutwardNotFoundButAuditsRealReason() {
+    UserBriefVO user = user(11L);
+    ProjectVO project = project(7L, "Project A", true, List.of(), List.of());
+    stubExistingProject(user, project);
+
+    assertThatThrownBy(() -> guard.requireAccessible(7L, "alice"))
+        .isInstanceOfSatisfying(
+            ProjectContextException.class,
+            exception ->
+                assertThat(exception.getError()).isEqualTo(ProjectContextError.PROJECT_NOT_FOUND));
+
+    verify(authorizationAudit)
+        .denied(7L, ProjectAuthorizationReason.PROJECT_MEMBERSHIP_REQUIRED.name());
+  }
+
+  @Test
+  void missingProjectKeepsOutwardNotFoundAndAuditsMissingReason() {
+    when(projectService.checkProjectExist(7L)).thenReturn(false);
+
+    assertThatThrownBy(() -> guard.requireAccessible(7L, "alice"))
+        .isInstanceOfSatisfying(
+            ProjectContextException.class,
+            exception ->
+                assertThat(exception.getError()).isEqualTo(ProjectContextError.PROJECT_NOT_FOUND));
+
+    verify(authorizationAudit)
+        .denied(7L, ProjectAuthorizationReason.PROJECT_NOT_FOUND.name());
+  }
+
+  @Test
+  void unavailableProjectPreservesExistingOutwardErrorAndAuditsReason() {
+    UserBriefVO user = user(11L);
+    ProjectVO project = project(7L, "Project A", false, List.of(user), List.of());
+    stubExistingProject(user, project);
+
+    assertThatThrownBy(() -> guard.requireAccessible(7L, "alice"))
+        .isInstanceOfSatisfying(
+            ProjectContextException.class,
+            exception ->
+                assertThat(exception.getError()).isEqualTo(ProjectContextError.PROJECT_UNAVAILABLE));
+
+    verify(authorizationAudit)
+        .denied(7L, ProjectAuthorizationReason.PROJECT_UNAVAILABLE.name());
+  }
+
+  private void stubExistingProject(UserBriefVO user, ProjectVO project) {
+    when(projectService.checkProjectExist(7L)).thenReturn(true);
+    when(userService.getUserBriefByUsername("alice")).thenReturn(user);
+    when(projectService.getProjectDetailByProjectId(7L)).thenReturn(project);
+  }
+
+  private UserBriefVO user(long id) {
+    UserBriefVO user = mock(UserBriefVO.class);
+    when(user.getId()).thenReturn(id);
+    return user;
+  }
+
+  private ProjectVO project(
+      long id,
+      String name,
+      boolean running,
+      List<UserBriefVO> owners,
+      List<UserBriefVO> members) {
+    ProjectVO project = mock(ProjectVO.class);
+    when(project.getId()).thenReturn(id);
+    when(project.getProjectName()).thenReturn(name);
+    when(project.getRunning()).thenReturn(running);
+    when(project.getOwnerList()).thenReturn(owners);
+    when(project.getUserList()).thenReturn(members);
+    return project;
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditAuthorizationDecision.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditAuthorizationDecision.java
@@ -1,0 +1,72 @@
+package io.yak.ops.business.audit;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Technology-agnostic authorization decision that can be attached to a business operation. */
+public record AuditAuthorizationDecision(
+    String permission,
+    Decision decision,
+    String reasonCode,
+    String resourceType,
+    String resourceId,
+    String resourceName,
+    Map<String, ?> attributes) {
+
+  public enum Decision {
+    ALLOW,
+    DENY
+  }
+
+  public AuditAuthorizationDecision {
+    permission = requireText(permission, "permission");
+    if (decision == null) throw new IllegalArgumentException("decision must not be null");
+    reasonCode = requireText(reasonCode, "reasonCode");
+    resourceType = normalize(resourceType);
+    resourceId = normalize(resourceId);
+    resourceName = normalize(resourceName);
+    attributes =
+        attributes == null || attributes.isEmpty()
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(attributes));
+  }
+
+  public static AuditAuthorizationDecision allow(
+      String permission,
+      String reasonCode,
+      String resourceType,
+      String resourceId,
+      String resourceName,
+      Map<String, ?> attributes) {
+    return new AuditAuthorizationDecision(
+        permission, Decision.ALLOW, reasonCode, resourceType, resourceId, resourceName, attributes);
+  }
+
+  public static AuditAuthorizationDecision deny(
+      String permission,
+      String reasonCode,
+      String resourceType,
+      String resourceId,
+      String resourceName,
+      Map<String, ?> attributes) {
+    return new AuditAuthorizationDecision(
+        permission, Decision.DENY, reasonCode, resourceType, resourceId, resourceName, attributes);
+  }
+
+  public boolean allowed() {
+    return decision == Decision.ALLOW;
+  }
+
+  private static String requireText(String value, String field) {
+    String normalized = normalize(value);
+    if (normalized == null) throw new IllegalArgumentException(field + " must not be blank");
+    return normalized;
+  }
+
+  private static String normalize(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditAuthorizationDecisionContext.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditAuthorizationDecisionContext.java
@@ -1,0 +1,32 @@
+package io.yak.ops.business.audit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Request-thread buffer for ALLOW decisions that should follow the next business AuditOperation. */
+final class AuditAuthorizationDecisionContext {
+
+  private static final ThreadLocal<List<AuditAuthorizationDecision>> DECISIONS = new ThreadLocal<>();
+
+  private AuditAuthorizationDecisionContext() {}
+
+  static void defer(AuditAuthorizationDecision decision) {
+    if (decision == null) return;
+    List<AuditAuthorizationDecision> decisions = DECISIONS.get();
+    if (decisions == null) {
+      decisions = new ArrayList<>();
+      DECISIONS.set(decisions);
+    }
+    decisions.add(decision);
+  }
+
+  static List<AuditAuthorizationDecision> drain() {
+    List<AuditAuthorizationDecision> decisions = DECISIONS.get();
+    DECISIONS.remove();
+    return decisions == null || decisions.isEmpty() ? List.of() : List.copyOf(decisions);
+  }
+
+  static void clear() {
+    DECISIONS.remove();
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventCategory.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventCategory.java
@@ -1,0 +1,7 @@
+package io.yak.ops.business.audit;
+
+/** Stable audit event categories used by storage and the future Audit Center. */
+public enum AuditEventCategory {
+  BUSINESS,
+  AUTHORIZATION
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventRequest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventRequest.java
@@ -4,10 +4,14 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Structured event command with an optional idempotency key for async redelivery/retry. */
+/** Structured event command with optional idempotency and event-level classification overrides. */
 public record AuditEventRequest(
     AuditEventType type,
+    AuditEventCategory category,
+    AuditEventStatus status,
     String eventKey,
+    String resourceType,
+    String resourceId,
     String message,
     String reasonCode,
     Map<String, ?> payload) {
@@ -15,6 +19,8 @@ public record AuditEventRequest(
   public AuditEventRequest {
     if (type == null) throw new IllegalArgumentException("type must not be null");
     eventKey = normalize(eventKey);
+    resourceType = normalize(resourceType);
+    resourceId = normalize(resourceId);
     message = normalize(message);
     reasonCode = normalize(reasonCode);
     payload =
@@ -23,9 +29,38 @@ public record AuditEventRequest(
             : Collections.unmodifiableMap(new LinkedHashMap<>(payload));
   }
 
+  /** Backward-compatible business event constructor used by existing callers. */
+  public AuditEventRequest(
+      AuditEventType type,
+      String eventKey,
+      String message,
+      String reasonCode,
+      Map<String, ?> payload) {
+    this(type, null, null, eventKey, null, null, message, reasonCode, payload);
+  }
+
   public static AuditEventRequest of(
       AuditEventType type, String eventKey, String message, Map<String, ?> payload) {
     return new AuditEventRequest(type, eventKey, message, null, payload);
+  }
+
+  public static AuditEventRequest authorization(
+      AuditAuthorizationDecision decision, String eventKey) {
+    if (decision == null) throw new IllegalArgumentException("decision must not be null");
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.putAll(decision.attributes());
+    payload.put("permission", decision.permission());
+    payload.put("decision", decision.decision().name());
+    return new AuditEventRequest(
+        AuditEventType.AUTHORIZATION_DECISION,
+        AuditEventCategory.AUTHORIZATION,
+        decision.allowed() ? AuditEventStatus.SUCCESS : AuditEventStatus.FAILURE,
+        eventKey,
+        decision.resourceType(),
+        decision.resourceId(),
+        decision.allowed() ? "Authorization allowed" : "Authorization denied",
+        decision.reasonCode(),
+        payload);
   }
 
   private static String normalize(String value) {

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventStatus.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventStatus.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.audit;
+
+/** Normalized event outcome for filtering and timeline rendering. */
+public enum AuditEventStatus {
+  INFO,
+  SUCCESS,
+  FAILURE
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventType.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventType.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.audit;
 /** Stable business-level events. Keep this vocabulary intentionally small and technology agnostic. */
 public enum AuditEventType {
   OPERATION_STARTED,
+  AUTHORIZATION_DECISION,
   RESOURCE_CREATED,
   RESOURCE_UPDATED,
   RESOURCE_DELETED,

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/BusinessAuditService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/BusinessAuditService.java
@@ -7,4 +7,10 @@ public interface BusinessAuditService {
   default AuditOperationHandle resume(AuditCarrier carrier) {
     return AuditOperationHandle.noop(carrier);
   }
+
+  /** Records or defers one authorization decision without making audit a business dependency. */
+  default void authorizationDecision(AuditAuthorizationDecision decision) {}
+
+  /** Clears request-scoped authorization state defensively at request boundaries. */
+  default void clearAuthorizationDecisions() {}
 }

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcBusinessAuditService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcBusinessAuditService.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.core.project.CurrentProject;
 import io.yak.ops.core.project.ProjectContext;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import javax.sql.DataSource;
@@ -21,6 +24,7 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
 
   private static final Logger log = LoggerFactory.getLogger(JdbcBusinessAuditService.class);
   private static final int SCHEMA_VERSION = 1;
+  private static final int MAX_EVENT_KEY_LENGTH = 160;
 
   private final JdbcTemplate jdbcTemplate;
   private final TransactionTemplate transactionTemplate;
@@ -57,6 +61,45 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
 
   @Override
   public AuditOperationHandle start(AuditOperationRequest request) {
+    return startInternal(request, true);
+  }
+
+  @Override
+  public AuditOperationHandle resume(AuditCarrier carrier) {
+    if (carrier == null) return AuditOperationHandle.noop(null);
+    AuditCarrier persisted = loadCarrier(carrier.operationId());
+    return persisted == null
+        ? AuditOperationHandle.noop(null)
+        : new JdbcAuditOperationHandle(persisted, true);
+  }
+
+  @Override
+  public void authorizationDecision(AuditAuthorizationDecision decision) {
+    if (decision == null) return;
+
+    AuditCarrier activeCarrier = AuditContext.current().orElse(null);
+    if (activeCarrier != null) {
+      resume(activeCarrier).event(authorizationEvent(decision));
+      return;
+    }
+
+    if (decision.allowed()) {
+      AuditAuthorizationDecisionContext.defer(decision);
+      return;
+    }
+
+    writeStandaloneAuthorizationDecision(decision);
+  }
+
+  @Override
+  public void clearAuthorizationDecisions() {
+    AuditAuthorizationDecisionContext.clear();
+  }
+
+  private AuditOperationHandle startInternal(
+      AuditOperationRequest request, boolean attachDeferredAuthorization) {
+    List<AuditAuthorizationDecision> deferredAuthorization =
+        attachDeferredAuthorization ? AuditAuthorizationDecisionContext.drain() : List.of();
     String operationId = "AUD-" + UUID.randomUUID();
     AuditActor actor = safeActor();
     ProjectContext project = currentProject.current().orElse(null);
@@ -103,11 +146,17 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
                   SCHEMA_VERSION,
                   now,
                   now);
+              for (AuditAuthorizationDecision decision : deferredAuthorization) {
+                insertAuthorizationEvent(carrier, decision);
+              }
               insertEvent(
                   carrier,
                   AuditEventType.OPERATION_STARTED,
-                  "INFO",
+                  AuditEventCategory.BUSINESS,
+                  AuditEventStatus.INFO,
                   "operation:started",
+                  null,
+                  null,
                   "Operation started",
                   null,
                   Map.of());
@@ -115,13 +164,67 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
     return new JdbcAuditOperationHandle(carrier, persisted);
   }
 
-  @Override
-  public AuditOperationHandle resume(AuditCarrier carrier) {
-    if (carrier == null) return AuditOperationHandle.noop(null);
-    AuditCarrier persisted = loadCarrier(carrier.operationId());
-    return persisted == null
-        ? AuditOperationHandle.noop(null)
-        : new JdbcAuditOperationHandle(persisted, true);
+  private void writeStandaloneAuthorizationDecision(AuditAuthorizationDecision decision) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("permission", decision.permission());
+    metadata.put("decision", decision.decision().name());
+    AuditOperationHandle handle =
+        startInternal(
+            new AuditOperationRequest(
+                "AUTHORIZATION_CHECK",
+                "Authorize " + decision.permission(),
+                decision.resourceType(),
+                decision.resourceId(),
+                decision.resourceName(),
+                "WEB",
+                metadata),
+            false);
+    handle.event(authorizationEvent(decision));
+    if (decision.allowed()) {
+      handle.success("Authorization allowed");
+    } else {
+      handle.failure(decision.reasonCode(), null);
+    }
+  }
+
+  private void insertAuthorizationEvent(
+      AuditCarrier carrier, AuditAuthorizationDecision decision) {
+    AuditEventRequest request = authorizationEvent(decision);
+    insertEvent(
+        carrier,
+        request.type(),
+        request.category(),
+        request.status(),
+        request.eventKey(),
+        request.resourceType(),
+        request.resourceId(),
+        request.message(),
+        request.reasonCode(),
+        request.payload());
+  }
+
+  private AuditEventRequest authorizationEvent(AuditAuthorizationDecision decision) {
+    return AuditEventRequest.authorization(decision, authorizationEventKey(decision));
+  }
+
+  private String authorizationEventKey(AuditAuthorizationDecision decision) {
+    String key =
+        "authorization:"
+            + keyToken(decision.permission())
+            + ":"
+            + keyToken(decision.resourceType())
+            + ":"
+            + keyToken(decision.resourceId())
+            + ":"
+            + decision.decision().name().toLowerCase(Locale.ROOT)
+            + ":"
+            + keyToken(decision.reasonCode());
+    return key.length() <= MAX_EVENT_KEY_LENGTH ? key : key.substring(0, MAX_EVENT_KEY_LENGTH);
+  }
+
+  private String keyToken(String value) {
+    if (value == null || value.isBlank()) return "none";
+    return value.trim().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9._-]", "-");
   }
 
   private final class JdbcAuditOperationHandle implements AuditOperationHandle {
@@ -170,13 +273,20 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
     @Override
     public void event(AuditEventRequest request) {
       if (!persisted || request == null) return;
+      AuditEventCategory category =
+          request.category() == null ? AuditEventCategory.BUSINESS : request.category();
+      AuditEventStatus status =
+          request.status() == null ? eventStatus(request.type()) : request.status();
       safeWrite(
           () ->
               insertEvent(
                   carrier(),
                   request.type(),
-                  eventStatus(request.type()),
+                  category,
+                  status,
                   request.eventKey(),
+                  request.resourceType(),
+                  request.resourceId(),
                   request.message(),
                   request.reasonCode(),
                   request.payload()));
@@ -203,8 +313,11 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
               insertEvent(
                   carrier(),
                   AuditEventType.OPERATION_SUCCEEDED,
-                  "SUCCESS",
+                  AuditEventCategory.BUSINESS,
+                  AuditEventStatus.SUCCESS,
                   "operation:succeeded",
+                  null,
+                  null,
                   summary == null ? "Operation succeeded" : summary,
                   null,
                   Map.of());
@@ -236,8 +349,11 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
               insertEvent(
                   carrier(),
                   AuditEventType.OPERATION_FAILED,
-                  "FAILURE",
+                  AuditEventCategory.BUSINESS,
+                  AuditEventStatus.FAILURE,
                   "operation:failed",
+                  null,
+                  null,
                   summary,
                   reasonCode,
                   cause == null ? Map.of() : Map.of("exceptionType", cause.getClass().getName()));
@@ -249,8 +365,11 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
   private void insertEvent(
       AuditCarrier carrier,
       AuditEventType type,
-      String eventStatus,
+      AuditEventCategory category,
+      AuditEventStatus eventStatus,
       String eventKey,
+      String eventResourceType,
+      String eventResourceId,
       String message,
       String reasonCode,
       Map<String, ?> payload) {
@@ -261,7 +380,7 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
           operation_id, event_type, event_category, event_status, occurred_at,
           actor_id, resource_type, resource_id, trace_id, span_id,
           reason_code, event_key, message, payload_json, schema_version, created_at
-        ) VALUES (?, ?, 'BUSINESS', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """;
     if (eventKey != null) {
       sql += " ON DUPLICATE KEY UPDATE id = id";
@@ -270,11 +389,12 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
         sql,
         carrier.operationId(),
         type.name(),
-        eventStatus,
+        category.name(),
+        eventStatus.name(),
         now,
         carrier.actorId(),
-        carrier.resourceType(),
-        carrier.resourceId(),
+        eventResourceType == null ? carrier.resourceType() : eventResourceType,
+        eventResourceId == null ? carrier.resourceId() : eventResourceId,
         MDC.get("traceId"),
         MDC.get("spanId"),
         reasonCode,
@@ -350,15 +470,19 @@ final class JdbcBusinessAuditService implements BusinessAuditService {
     }
   }
 
-  private static String eventStatus(AuditEventType type) {
+  private static AuditEventStatus eventStatus(AuditEventType type) {
     return switch (type) {
       case RESOURCE_CREATED,
           RESOURCE_UPDATED,
           RESOURCE_DELETED,
           TASK_SUCCEEDED,
-          OPERATION_SUCCEEDED -> "SUCCESS";
-      case TASK_FAILED, TASK_CANCELED, OPERATION_FAILED -> "FAILURE";
-      case OPERATION_STARTED, TASK_SUBMITTED, TASK_QUEUED, WORKER_STARTED -> "INFO";
+          OPERATION_SUCCEEDED -> AuditEventStatus.SUCCESS;
+      case TASK_FAILED, TASK_CANCELED, OPERATION_FAILED -> AuditEventStatus.FAILURE;
+      case OPERATION_STARTED,
+          AUTHORIZATION_DECISION,
+          TASK_SUBMITTED,
+          TASK_QUEUED,
+          WORKER_STARTED -> AuditEventStatus.INFO;
     };
   }
 }

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditAuthorizationDecisionContextTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditAuthorizationDecisionContextTest.java
@@ -1,0 +1,55 @@
+package io.yak.ops.business.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class AuditAuthorizationDecisionContextTest {
+
+  @AfterEach
+  void clear() {
+    AuditAuthorizationDecisionContext.clear();
+  }
+
+  @Test
+  void drainReturnsDeferredDecisionsAndClearsThreadLocal() {
+    AuditAuthorizationDecision decision =
+        AuditAuthorizationDecision.allow(
+            "PROJECT_ACCESS",
+            "PROJECT_MEMBER_ACCESS_ALLOWED",
+            "PROJECT",
+            "7",
+            "Project A",
+            Map.of("scope", "PROJECT_SPACE"));
+
+    AuditAuthorizationDecisionContext.defer(decision);
+
+    assertThat(AuditAuthorizationDecisionContext.drain()).containsExactly(decision);
+    assertThat(AuditAuthorizationDecisionContext.drain()).isEmpty();
+  }
+
+  @Test
+  void authorizationFactoryKeepsCategoryStatusReasonAndProjectResource() {
+    AuditAuthorizationDecision decision =
+        AuditAuthorizationDecision.deny(
+            "PROJECT_ACCESS",
+            "PROJECT_MEMBERSHIP_REQUIRED",
+            "PROJECT",
+            "7",
+            null,
+            Map.of());
+
+    AuditEventRequest event = AuditEventRequest.authorization(decision, "authorization:test");
+
+    assertThat(event.type()).isEqualTo(AuditEventType.AUTHORIZATION_DECISION);
+    assertThat(event.category()).isEqualTo(AuditEventCategory.AUTHORIZATION);
+    assertThat(event.status()).isEqualTo(AuditEventStatus.FAILURE);
+    assertThat(event.reasonCode()).isEqualTo("PROJECT_MEMBERSHIP_REQUIRED");
+    assertThat(event.resourceType()).isEqualTo("PROJECT");
+    assertThat(event.resourceId()).isEqualTo("7");
+    assertThat(event.payload().get("permission")).isEqualTo("PROJECT_ACCESS");
+    assertThat(event.payload().get("decision")).isEqualTo("DENY");
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/JdbcBusinessAuditServiceTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/JdbcBusinessAuditServiceTest.java
@@ -11,23 +11,21 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.Optional;
 import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 
 class JdbcBusinessAuditServiceTest {
 
+  @AfterEach
+  void clearAuthorizationContext() {
+    AuditAuthorizationDecisionContext.clear();
+  }
+
   @Test
   void unavailableAuditStoreNeverBreaksBusinessCallerAndOperationIdIsNotTraceId() throws Exception {
-    DataSource dataSource = mock(DataSource.class);
-    when(dataSource.getConnection()).thenThrow(new SQLException("audit database unavailable"));
-    CurrentProject currentProject = Optional::empty;
-    JdbcBusinessAuditService service =
-        new JdbcBusinessAuditService(
-            dataSource,
-            new DataSourceTransactionManager(dataSource),
-            currentProject,
-            new ObjectMapper());
+    JdbcBusinessAuditService service = unavailableService();
 
     MDC.put("traceId", "trace-123");
     try {
@@ -53,5 +51,55 @@ class JdbcBusinessAuditServiceTest {
     } finally {
       MDC.remove("traceId");
     }
+  }
+
+  @Test
+  void authorizationDecisionsRemainFailOpenAndDeferredAllowDoesNotLeak() throws Exception {
+    JdbcBusinessAuditService service = unavailableService();
+    AuditAuthorizationDecision allow =
+        AuditAuthorizationDecision.allow(
+            "PROJECT_ACCESS",
+            "PROJECT_MEMBER_ACCESS_ALLOWED",
+            "PROJECT",
+            "7",
+            "Project A",
+            Map.of());
+    AuditAuthorizationDecision deny =
+        AuditAuthorizationDecision.deny(
+            "PROJECT_ACCESS",
+            "PROJECT_MEMBERSHIP_REQUIRED",
+            "PROJECT",
+            "7",
+            null,
+            Map.of());
+
+    assertThatCode(() -> service.authorizationDecision(allow)).doesNotThrowAnyException();
+    assertThatCode(
+            () ->
+                service.start(
+                    new AuditOperationRequest(
+                        "TEST_OPERATION",
+                        "Test operation",
+                        "TEST_RESOURCE",
+                        "42",
+                        "resource",
+                        "TEST",
+                        Map.of())))
+        .doesNotThrowAnyException();
+    assertThat(AuditAuthorizationDecisionContext.drain()).isEmpty();
+
+    assertThatCode(() -> service.authorizationDecision(deny)).doesNotThrowAnyException();
+    assertThatCode(service::clearAuthorizationDecisions).doesNotThrowAnyException();
+  }
+
+  private JdbcBusinessAuditService unavailableService() throws Exception {
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenThrow(new SQLException("audit database unavailable"));
+    CurrentProject currentProject = Optional::empty;
+    return new JdbcBusinessAuditService(
+        dataSource,
+        new DataSourceTransactionManager(dataSource),
+        currentProject,
+        new ObjectMapper());
   }
 }

--- a/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectAuthorizationReason.java
+++ b/yak-ops-core/src/main/java/io/yak/ops/core/project/ProjectAuthorizationReason.java
@@ -1,0 +1,14 @@
+package io.yak.ops.core.project;
+
+/** Stable internal reason codes for Project Space authorization decisions. */
+public enum ProjectAuthorizationReason {
+  PROJECT_REQUIRED,
+  PROJECT_ID_INVALID,
+  PROJECT_ACCESS_INPUT_INVALID,
+  PROJECT_NOT_FOUND,
+  PROJECT_ACTOR_NOT_FOUND,
+  PROJECT_MEMBERSHIP_REQUIRED,
+  PROJECT_UNAVAILABLE,
+  PROJECT_OWNER_ACCESS_ALLOWED,
+  PROJECT_MEMBER_ACCESS_ALLOWED
+}


### PR DESCRIPTION
## Summary

Implements **PR 2.2** for #921: explainable Project authorization decisions inside the end-to-end business audit model introduced by PR 2.1 / #962.

This PR deliberately stays on the authorization boundary. The administrator-facing Audit Center / Timeline remains PR 3.

## 1. Stable authorization event contract

Adds a first-class authorization event instead of encoding permission facts as generic business text:

```text
AuditEventType.AUTHORIZATION_DECISION
AuditEventCategory.AUTHORIZATION
AuditEventStatus.SUCCESS | FAILURE
```

`AuditEventRequest` now supports event-level category/status/resource overrides while preserving the existing five-argument constructor used by Offline Sync.

Authorization payloads are structured:

```text
permission = PROJECT_ACCESS
decision   = ALLOW | DENY
reasonCode = stable ProjectAuthorizationReason
resource   = PROJECT / projectId
```

No UI prose is stored as the historical reason.

## 2. Stable Project authorization reasons

Adds the Audit-independent Core vocabulary:

```text
PROJECT_REQUIRED
PROJECT_ID_INVALID
PROJECT_ACCESS_INPUT_INVALID
PROJECT_NOT_FOUND
PROJECT_ACTOR_NOT_FOUND
PROJECT_MEMBERSHIP_REQUIRED
PROJECT_UNAVAILABLE
PROJECT_OWNER_ACCESS_ALLOWED
PROJECT_MEMBER_ACCESS_ALLOWED
```

`yak-ops-core` still has no dependency on business-audit. It only owns Project authorization semantics; the Boot adapter translates those facts into Audit events.

## 3. Preserve anti-enumeration behavior

The outward Project security contract is unchanged.

For example, both of these still return the same outward error:

```text
Project does not exist  -> PROJECT_NOT_FOUND
User is not a member    -> PROJECT_NOT_FOUND
```

Internally, Audit keeps the actual historical decision:

```text
PROJECT_NOT_FOUND
PROJECT_MEMBERSHIP_REQUIRED
```

This improves explainability without exposing whether an inaccessible Project ID exists.

The same pattern covers:

- invalid/missing Project input;
- missing Yak Security actor;
- disabled Project;
- Owner access;
- ordinary Project member access.

## 4. Same-operation ALLOW correlation

A successful Project authorization happens before the business Application Service creates its AuditOperation.

PR 2.2 therefore defers the ALLOW decision in an ordinary request-thread `ThreadLocal` and lets the next business `BusinessAuditService.start(...)` claim it.

For the Offline Sync vertical slice the timeline becomes:

```text
AUTHORIZATION_DECISION
  decision = ALLOW
  reason   = PROJECT_OWNER_ACCESS_ALLOWED / PROJECT_MEMBER_ACCESS_ALLOWED
  resource = PROJECT:{projectId}
        ↓
OPERATION_STARTED
        ↓
TASK_SUBMITTED
        ↓
WORKER_STARTED / Retry / Reconcile ...
        ↓
OPERATION_SUCCEEDED | OPERATION_FAILED
```

The ALLOW event is inserted after the AuditOperation row exists but **before** `OPERATION_STARTED`, in the same `REQUIRES_NEW` audit transaction. This keeps the human timeline in authorization-before-execution order while sharing the same `operationId`.

If no audited business operation is created during the request, the temporary ALLOW is discarded at request completion. This avoids turning ordinary Project-scoped read traffic into authorization-heartbeat noise.

## 5. DENY remains visible even when business code never runs

A denied Project request cannot reach the business layer, so there is no business operation available to attach to.

DENY is therefore persisted immediately as a standalone:

```text
operation_type = AUTHORIZATION_CHECK
resource_type  = PROJECT
resource_id    = requested projectId when valid
status         = FAILED
```

with an `AUTHORIZATION_DECISION / AUTHORIZATION / FAILURE` event carrying the stable reasonCode.

Malformed raw Project headers are intentionally **not** persisted; they produce `PROJECT_ID_INVALID` with no fabricated resource ID.

## 6. Deterministic authorization event keys

Authorization events use bounded deterministic keys derived from:

```text
permission + resourceType + resourceId + decision + reasonCode
```

Example:

```text
authorization:project_access:project:7:allow:project_member_access_allowed
```

They reuse the existing Audit V1 uniqueness contract:

```text
UNIQUE(operation_id, event_key)
```

No new Audit schema migration is required.

## 7. Fail-open remains a hard invariant

Project authorization behavior must never depend on Audit availability.

`ProjectAuthorizationAuditBridge` therefore treats all Audit integration as optional/fail-open, including:

- missing `BusinessAuditService` runtime;
- `ObjectProvider` bean-resolution failures;
- Audit database failures;
- serialization/event persistence failures.

Any Audit failure can lose an audit record, but it cannot change an ALLOW/DENY result or turn valid Project access into a 500.

## 8. Sensitive-data boundary

Authorization events do **not** copy:

- request bodies;
- raw malformed Project headers;
- credentials/tokens;
- role/user object snapshots;
- arbitrary exception text.

Actor identity continues to come from PR 2.1's stable Audit actor snapshot (`userId + username`) rather than duplicating usernames into authorization payloads.

## Tests / validation

Added/updated coverage for:

- Owner ALLOW reason;
- Member ALLOW reason;
- non-member DENY with outward anti-enumeration still preserved;
- missing Project DENY;
- unavailable Project DENY;
- required Project header missing;
- invalid Project header without persisting raw input;
- request-bound authorization context cleanup;
- authorization category/status/resource/reason structure;
- fail-open behavior when Audit runtime/store is unavailable;
- compatibility of existing Audit event callers.

Static validation performed from the final branch:

- branch is based directly on current `main` (`behind_by=0`);
- branch is squashed to one commit;
- no Flyway migration is introduced;
- pure-JDK authorization contracts compile successfully with `javac --release 21`.

A full Maven reactor build is **not claimed** from this environment because the execution container cannot materialize the repository/dependency toolchain from GitHub. Run the normal local/CI build before marking this Draft ready.

Recommended verification:

```bash
mvn -pl yak-ops-core,yak-ops-business/yak-ops-business-audit,yak-ops-boot -am test
```

Suggested smoke flow:

1. Log in as a Project Owner and execute one Offline Sync task.
2. Verify its single AuditOperation begins with `AUTHORIZATION_DECISION` reason `PROJECT_OWNER_ACCESS_ALLOWED`, followed by `OPERATION_STARTED` and the PR 2.1 async events.
3. Repeat as a normal Project member and verify `PROJECT_MEMBER_ACCESS_ALLOWED`.
4. Call the same Project-scoped endpoint as a non-member.
5. Verify the API still returns outward `PROJECT_NOT_FOUND`, while Audit records a standalone failed `AUTHORIZATION_CHECK` with `PROJECT_MEMBERSHIP_REQUIRED`.
6. Stop/disable the Project and verify outward `PROJECT_UNAVAILABLE` plus internal `PROJECT_UNAVAILABLE` authorization history.

## Non-goals

- Audit Center / Timeline UI (PR 3)
- global RBAC/action-level permission redesign
- menu/button authorization auditing
- retroactive reinterpretation of historical decisions using today's roles
- changing current Project outward error semantics
- adding audit records for every successful read-only Project request

Refs #921